### PR TITLE
Fix beta tracker: improve quarter tracking and add X buttons for event removal

### DIFF
--- a/beta/js/track-basketball-mock.js
+++ b/beta/js/track-basketball-mock.js
@@ -309,13 +309,13 @@ function renderLog() {
     }
     els.gameLog.innerHTML = gameState.log.map((ev, idx) => `
         <div class="p-2 rounded-lg border border-court-100 bg-white flex justify-between items-center">
-            <div>
+            <div class="flex-1">
                 <p class="font-semibold text-court-900">${ev.text}</p>
                 <p class="text-xs text-court-500">${ev.period} • ${ev.clock}</p>
             </div>
             <div class="flex items-center gap-2">
-                <button class="text-xs px-2 py-1 rounded bg-court-900 text-white" data-remove-log="${idx}">Remove</button>
                 <span class="text-xs text-court-500">${new Date(ev.ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}</span>
+                <button class="w-6 h-6 flex items-center justify-center rounded-full hover:bg-court-100 text-court-500 hover:text-court-900 transition" data-remove-log="${idx}" title="Remove event">✕</button>
             </div>
         </div>
     `).join('');
@@ -749,16 +749,28 @@ function init() {
 }
 
 function setActivePeriod(period) {
+    const previousPeriod = gameState.period;
     gameState.period = period;
     els.periodLabel.textContent = period;
     document.querySelectorAll('.period-btn').forEach(b => {
-        b.classList.remove('bg-court-100', 'text-court-900');
+        b.classList.remove('bg-court-900', 'text-white', 'font-bold');
         b.classList.add('bg-white', 'text-court-700');
         if (b.dataset.period === period) {
-            b.classList.add('bg-court-100', 'text-court-900');
+            b.classList.add('bg-court-900', 'text-white', 'font-bold');
             b.classList.remove('bg-white', 'text-court-700');
         }
     });
+
+    // Log period changes during live game
+    if (phaseIsLive() && previousPeriod !== period) {
+        addEvent({
+            type: 'period-change',
+            period: period,
+            clock: formatClock(gameState.clockMs),
+            ts: Date.now(),
+            text: `Period changed: ${previousPeriod} → ${period}`
+        });
+    }
 }
 
 function renderLiveReport() {

--- a/beta/track-basketball-mock.html
+++ b/beta/track-basketball-mock.html
@@ -115,11 +115,11 @@
                 </div>
                 <div class="flex items-center gap-3 text-sm">
                     <div class="flex gap-2">
-                        <button data-period="Q1" class="period-btn px-3 py-1 rounded-lg font-semibold border border-court-200">Q1</button>
-                        <button data-period="Q2" class="period-btn px-3 py-1 rounded-lg font-semibold border border-court-200">Q2</button>
-                        <button data-period="Q3" class="period-btn px-3 py-1 rounded-lg font-semibold border border-court-200">Q3</button>
-                        <button data-period="Q4" class="period-btn px-3 py-1 rounded-lg font-semibold border border-court-200">Q4</button>
-                        <button data-period="OT" class="period-btn px-3 py-1 rounded-lg font-semibold border border-court-200">OT</button>
+                        <button data-period="Q1" class="period-btn px-3 py-1 rounded-lg font-semibold bg-court-900 text-white transition hover:bg-court-700">Q1</button>
+                        <button data-period="Q2" class="period-btn px-3 py-1 rounded-lg font-semibold bg-white text-court-700 transition hover:bg-court-50">Q2</button>
+                        <button data-period="Q3" class="period-btn px-3 py-1 rounded-lg font-semibold bg-white text-court-700 transition hover:bg-court-50">Q3</button>
+                        <button data-period="Q4" class="period-btn px-3 py-1 rounded-lg font-semibold bg-white text-court-700 transition hover:bg-court-50">Q4</button>
+                        <button data-period="OT" class="period-btn px-3 py-1 rounded-lg font-semibold bg-white text-court-700 transition hover:bg-court-50">OT</button>
                     </div>
                     <div class="flex gap-2 ml-auto">
                         <button id="undo-btn" class="px-3 py-1 rounded-lg border border-court-200 text-court-800 font-semibold bg-white hover:bg-court-50">↶ Undo</button>


### PR DESCRIPTION
This commit addresses two key UX issues in the beta basketball tracker:

1. Quarter tracking improvements:
   - Enhanced visual feedback for active period with darker background (bg-court-900)
   - Made active quarter button bold and white text for better contrast
   - Added automatic logging of period changes during live games
   - Period changes now appear in the game log with "Period changed: Q1 → Q2" format

2. Event removal UX enhancement:
   - Replaced "Remove" text button with a clean "✕" icon button
   - Styled as a circular button with hover effects
   - Added title attribute for accessibility
   - More compact and visually consistent with modern UI patterns

Both features were technically working but lacked proper visual feedback and UX polish.