### PR TITLE
Fix live game playback: hide LIVE badge by default, add error handling, fix replay

### DIFF
--- a/js/live-game.js
+++ b/js/live-game.js
@@ -800,22 +800,22 @@ function startEngagements() {
 function startLiveEvents() {
   if (state.liveEventsActive) return;
   state.liveEventsActive = true;
-  let firstLoad = true;
+  state.liveEventsFirstLoad = true;
   const unsubEvents = subscribeLiveEvents(state.teamId, state.gameId, (events) => {
     setConnectionBanner(false);
-    if (firstLoad && events.length === 0) {
+    if (state.liveEventsFirstLoad && events.length === 0) {
       // Show a message while waiting for first events
-      const placeholder = els.playsFeed?.querySelector('[data-placeholder="plays"]');
+      const placeholder = els.playsFeed?.querySelector?.('[data-placeholder="plays"]');
       if (placeholder) placeholder.textContent = 'Connected. Waiting for plays...';
     }
-    firstLoad = false;
+    state.liveEventsFirstLoad = false;
     processNewEvents(events);
   }, (error) => {
     console.warn('Live events subscription failed:', error);
     setConnectionBanner(true, formatFirestoreError(error));
     // Also show error in plays feed if no events have loaded yet
     if (state.events.length === 0 && els.playsFeed) {
-      const placeholder = els.playsFeed.querySelector('[data-placeholder="plays"]');
+      const placeholder = els.playsFeed?.querySelector?.('[data-placeholder="plays"]');
       if (placeholder) placeholder.textContent = 'Unable to connect to live data. Try refreshing.';
     }
   });

--- a/live-game.html
+++ b/live-game.html
@@ -191,9 +191,9 @@
         <div class="text-center">
           <div id="period" class="text-teal font-medium">Q1</div>
           <div id="clock" class="text-sand/70 text-sm">0:00</div>
-          <div id="live-badge" class="inline-flex items-center gap-1 mt-1">
-            <span class="w-2 h-2 bg-red-500 rounded-full animate-pulse"></span>
-            <span class="text-red-400 text-xs font-medium">LIVE</span>
+          <div id="live-badge" class="hidden inline-flex items-center gap-1 mt-1">
+            <span id="live-badge-dot" class="w-2 h-2 bg-red-500 rounded-full animate-pulse"></span>
+            <span id="live-badge-text" class="text-red-400 text-xs font-medium">LIVE</span>
           </div>
         </div>
         <span id="away-score" class="text-5xl font-display font-bold away-color">0</span>


### PR DESCRIPTION
- Hide LIVE badge by default in HTML (was showing even when JS failed to load)
- Show REPLAY badge (teal) instead of LIVE badge during replay mode
- Add try/catch around init data fetch so page shows error instead of blank screen
- Add try/catch around replay data fetch with loading/error states
- Handle empty liveEvents gracefully (show "No play-by-play data" message)
- Show connection errors in plays feed when live subscription fails
- Show "Connected. Waiting for plays..." when live but no events yet
- Fix game subscription error to show connection banner
- Allow replay mode regardless of liveStatus (was restricted to 'completed' only)
- Use game doc scores as authoritative in ended overlay

https://claude.ai/code/session_019xziipoTgFowfhs7mWxNqo