### PR TITLE
Global header search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,7 +53,9 @@ serviceAccountKey*.json
 *.private
 
 # Migration and admin utility scripts
-_migration/
+_migration/*
+!_migration/
+!_migration/migrate-player-private-profile.js
 migrate_admin.js
 verify_admin.js
 check-admin-status.html

--- a/_migration/migrate-player-private-profile.js
+++ b/_migration/migrate-player-private-profile.js
@@ -1,0 +1,135 @@
+#!/usr/bin/env node
+/**
+ * Migration: Move sensitive player fields off the public player doc into:
+ *   teams/{teamId}/players/{playerId}/private/profile
+ *
+ * Why:
+ * - Firestore rules are document-level; if a player doc is publicly readable,
+ *   any sensitive fields on that doc are publicly readable too.
+ *
+ * Usage:
+ *   node _migration/migrate-player-private-profile.js
+ *
+ * Options:
+ * - TEAM_ID=...           Migrate only one team (recommended first run)
+ * - DRY_RUN=1            Print intended writes without modifying Firestore
+ * - FIREBASE_SERVICE_ACCOUNT=/path/to/key.json   Use explicit service account
+ * - FIREBASE_PROJECT_ID=...  Fallback project id when using ADC
+ */
+
+import { readFileSync } from 'fs';
+import { initializeApp, cert, getApps } from 'firebase-admin/app';
+import { getFirestore, FieldValue } from 'firebase-admin/firestore';
+
+const TEAM_ID = process.env.TEAM_ID || '';
+const DRY_RUN = process.env.DRY_RUN === '1';
+const PROJECT_ID = process.env.FIREBASE_PROJECT_ID || 'game-flow-c6311';
+const SERVICE_ACCOUNT_PATH = process.env.FIREBASE_SERVICE_ACCOUNT || './serviceAccountKey.json';
+
+function initAdmin() {
+    if (getApps().length) return;
+
+    // Prefer explicit service account if present.
+    try {
+        const sa = JSON.parse(readFileSync(SERVICE_ACCOUNT_PATH, 'utf8'));
+        initializeApp({ credential: cert(sa) });
+        return;
+    } catch {
+        // Fall back to ADC (or any ambient auth the environment provides).
+        initializeApp({ projectId: PROJECT_ID });
+    }
+}
+
+function pickSensitive(player) {
+    const out = {};
+    if (Object.prototype.hasOwnProperty.call(player, 'emergencyContact')) {
+        out.emergencyContact = player.emergencyContact ?? null;
+    }
+    if (Object.prototype.hasOwnProperty.call(player, 'medicalInfo')) {
+        out.medicalInfo = player.medicalInfo ?? '';
+    }
+    return out;
+}
+
+async function migrate() {
+    initAdmin();
+    const db = getFirestore();
+
+    const teamsRef = db.collection('teams');
+    const teamDocs = TEAM_ID
+        ? [await teamsRef.doc(TEAM_ID).get()].filter(d => d.exists)
+        : (await teamsRef.get()).docs;
+
+    console.log('Starting migration: move player emergencyContact/medicalInfo to private profile');
+    console.log(`Teams: ${TEAM_ID ? TEAM_ID : `${teamDocs.length} (all)`}`);
+    console.log(`Dry run: ${DRY_RUN ? 'yes' : 'no'}`);
+    console.log('');
+
+    let movedPlayers = 0;
+    let skippedPlayers = 0;
+    let errors = 0;
+
+    for (const teamDoc of teamDocs) {
+        const teamId = teamDoc.id;
+        console.log(`Team ${teamId}...`);
+
+        const playersSnap = await db.collection(`teams/${teamId}/players`).get();
+        console.log(`  Players: ${playersSnap.size}`);
+
+        for (const pDoc of playersSnap.docs) {
+            const playerId = pDoc.id;
+            const player = pDoc.data() || {};
+
+            const sensitive = pickSensitive(player);
+            if (Object.keys(sensitive).length === 0) {
+                skippedPlayers++;
+                continue;
+            }
+
+            const privateRef = db.doc(`teams/${teamId}/players/${playerId}/private/profile`);
+
+            if (DRY_RUN) {
+                console.log(`  DRY_RUN move ${teamId}/${playerId}:`, Object.keys(sensitive));
+                movedPlayers++;
+                continue;
+            }
+
+            try {
+                // 1) Write private profile doc (merge, so it's safe to re-run).
+                await privateRef.set(
+                    {
+                        ...sensitive,
+                        updatedAt: FieldValue.serverTimestamp()
+                    },
+                    { merge: true }
+                );
+
+                // 2) Delete sensitive fields from the public player doc.
+                await pDoc.ref.update({
+                    emergencyContact: FieldValue.delete(),
+                    medicalInfo: FieldValue.delete(),
+                    updatedAt: FieldValue.serverTimestamp()
+                });
+
+                movedPlayers++;
+            } catch (e) {
+                errors++;
+                console.error(`  ERROR ${teamId}/${playerId}:`, e?.message || e);
+            }
+        }
+    }
+
+    console.log('');
+    console.log('=== Migration Complete ===');
+    console.log(`Moved:   ${movedPlayers}`);
+    console.log(`Skipped: ${skippedPlayers}`);
+    console.log(`Errors:  ${errors}`);
+}
+
+migrate()
+    .then(() => process.exit(0))
+    .catch((err) => {
+        console.error('Migration failed:', err?.message || err);
+        process.exit(1);
+    });
+

--- a/accept-invite.html
+++ b/accept-invite.html
@@ -135,7 +135,7 @@
 
     <script type="module">
         import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=9';
-        import { validateAccessCode, redeemParentInvite, updateUserProfile, getTeam, getUserProfile } from './js/db.js?v=13';
+        import { validateAccessCode, redeemParentInvite, updateUserProfile, getTeam, getUserProfile } from './js/db.js?v=14';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 
         renderFooter(document.getElementById('footer-container'));

--- a/accept-invite.html
+++ b/accept-invite.html
@@ -135,7 +135,7 @@
 
     <script type="module">
         import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=9';
-        import { validateAccessCode, redeemParentInvite, updateUserProfile, getTeam, getUserProfile } from './js/db.js';
+        import { validateAccessCode, redeemParentInvite, updateUserProfile, getTeam, getUserProfile } from './js/db.js?v=13';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 
         renderFooter(document.getElementById('footer-container'));

--- a/dashboard.html
+++ b/dashboard.html
@@ -72,7 +72,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=3';
+        import { getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=13';
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { requireAuth as authRequireAuth } from './js/auth.js?v=9';
 

--- a/dashboard.html
+++ b/dashboard.html
@@ -72,7 +72,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=13';
+        import { getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=14';
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { requireAuth as authRequireAuth } from './js/auth.js?v=9';
 

--- a/edit-config.html
+++ b/edit-config.html
@@ -103,7 +103,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getConfigs, createConfig, deleteConfig, getUnreadChatCount } from './js/db.js';
+        import { getTeam, getConfigs, createConfig, deleteConfig, getUnreadChatCount } from './js/db.js?v=13';
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';

--- a/edit-config.html
+++ b/edit-config.html
@@ -103,7 +103,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getConfigs, createConfig, deleteConfig, getUnreadChatCount } from './js/db.js?v=13';
+        import { getTeam, getConfigs, createConfig, deleteConfig, getUnreadChatCount } from './js/db.js?v=14';
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -343,7 +343,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getPlayers, addPlayer, deletePlayer, getGames, uploadPlayerPhoto, updatePlayer, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount } from './js/db.js?v=13';
+        import { getTeam, getPlayers, addPlayer, deletePlayer, getGames, uploadPlayerPhoto, updatePlayer, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount } from './js/db.js?v=14';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth, sendInviteEmail } from './js/auth.js?v=9';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -343,7 +343,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getPlayers, addPlayer, deletePlayer, getGames, uploadPlayerPhoto, updatePlayer, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount } from './js/db.js';
+        import { getTeam, getPlayers, addPlayer, deletePlayer, getGames, uploadPlayerPhoto, updatePlayer, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount } from './js/db.js?v=13';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth, sendInviteEmail } from './js/auth.js?v=9';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -509,7 +509,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getTeams, getGames, getEvents, addGame, updateGame, deleteGame, addPractice, updateEvent, deleteEvent, getConfigs, addCalendarToTeam, removeCalendarFromTeam, getTrackedCalendarEventUids, cancelOccurrence, updateOccurrence, restoreOccurrence, clearOccurrenceOverride, updateSeries, deleteSeries, getUnreadChatCount } from './js/db.js?v=13';
+        import { getTeam, getTeams, getGames, getEvents, addGame, updateGame, deleteGame, addPractice, updateEvent, deleteEvent, getConfigs, addCalendarToTeam, removeCalendarFromTeam, getTrackedCalendarEventUids, cancelOccurrence, updateOccurrence, restoreOccurrence, clearOccurrenceOverride, updateSeries, deleteSeries, getUnreadChatCount } from './js/db.js?v=14';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, formatTimeRange, getDefaultEndTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, generateSeriesId, expandRecurrence, formatRecurrence, shareOrCopy } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -509,7 +509,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getTeams, getGames, getEvents, addGame, updateGame, deleteGame, addPractice, updateEvent, deleteEvent, getConfigs, addCalendarToTeam, removeCalendarFromTeam, getTrackedCalendarEventUids, cancelOccurrence, updateOccurrence, restoreOccurrence, clearOccurrenceOverride, updateSeries, deleteSeries, getUnreadChatCount } from './js/db.js';
+        import { getTeam, getTeams, getGames, getEvents, addGame, updateGame, deleteGame, addPractice, updateEvent, deleteEvent, getConfigs, addCalendarToTeam, removeCalendarFromTeam, getTrackedCalendarEventUids, cancelOccurrence, updateOccurrence, restoreOccurrence, clearOccurrenceOverride, updateSeries, deleteSeries, getUnreadChatCount } from './js/db.js?v=13';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, formatTimeRange, getDefaultEndTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, generateSeriesId, expandRecurrence, formatRecurrence, shareOrCopy } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';

--- a/edit-team.html
+++ b/edit-team.html
@@ -180,7 +180,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { createTeam, updateTeam, getTeam, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin } from './js/db.js?v=13';
+        import { createTeam, updateTeam, getTeam, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin } from './js/db.js?v=14';
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=8';
         import { checkAuth, sendInviteEmail } from './js/auth.js?v=9';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';

--- a/edit-team.html
+++ b/edit-team.html
@@ -180,7 +180,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { createTeam, updateTeam, getTeam, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin } from './js/db.js';
+        import { createTeam, updateTeam, getTeam, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin } from './js/db.js?v=13';
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=8';
         import { checkAuth, sendInviteEmail } from './js/auth.js?v=9';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';

--- a/firebase.json
+++ b/firebase.json
@@ -9,6 +9,7 @@
       "firebase.json",
       "**/.*",
       "**/node_modules/**",
+      "_temp/**",
       "**/*.md",
       "cleanup.md",
       "PROJECT_DOCUMENTATION.md",

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -25,6 +25,22 @@
         { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" },
         { "order": "DESCENDING", "queryScope": "COLLECTION_GROUP" }
       ]
+    },
+    {
+      "collectionGroup": "players",
+      "fieldPath": "name",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION" },
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
+    },
+    {
+      "collectionGroup": "players",
+      "fieldPath": "number",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION" },
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
     }
   ]
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -28,12 +28,15 @@ service cloud.firestore {
               isGlobalAdmin());
     }
 
-    // Check if user is a parent for a specific player (uses parentTeamIds for reliability)
+    // Check if user is a parent for a specific player.
+    // IMPORTANT: must validate both teamId AND playerId (least privilege).
     function isParentForPlayer(teamId, playerId) {
       let userPath = /databases/$(database)/documents/users/$(request.auth.uid);
       return isSignedIn() &&
              exists(userPath) &&
-             teamId in get(userPath).data.get('parentTeamIds', []);
+             get(userPath).data.get('parentOf', [])
+                .where(p, p.teamId == teamId && p.playerId == playerId)
+                .size() > 0;
     }
 
     // Check if user is a parent for any player on a team (uses parentTeamIds)
@@ -83,10 +86,10 @@ service cloud.firestore {
       allow read: if true;  // Public read for collection group queries
     }
 
-    // Collection group rule for players - allows cross-team player search.
-    // Note: Team-scoped player reads are already allowed below; this enables collectionGroup('players') queries.
+    // Collection group rule for players - enables collectionGroup('players') queries.
+    // SECURITY: deny reads of any player doc that still contains sensitive fields.
     match /{path=**}/players/{playerId} {
-      allow read: if true;
+      allow read: if !resource.data.keys().hasAny(['medicalInfo', 'emergencyContact']);
     }
 
     // Teams - only owner or admins can modify
@@ -97,16 +100,35 @@ service cloud.firestore {
 
       // Players subcollection
       match /players/{playerId} {
-        allow read: if true;  // Public player stats
+        // Public player doc is only safe if it contains no sensitive fields.
+        // Team owner/admin/parent-of-player may still read legacy docs that contain sensitive fields.
+        allow read: if isTeamOwnerOrAdmin(teamId) ||
+                      isParentForPlayer(teamId, playerId) ||
+                      !resource.data.keys().hasAny(['medicalInfo', 'emergencyContact']);
 
         // Full write access for team owners/admins
         allow write: if isTeamOwnerOrAdmin(teamId);
 
-        // Limited write access for parents (only their linked players, no parents array mutation)
+        // Limited write access for parents (only their linked player):
+        // - Public player doc: photo only
         allow update: if isParentForPlayer(teamId, playerId) &&
-                         request.resource.data.diff(resource.data).affectedKeys().hasOnly(
-                           ['photoUrl', 'emergencyContact', 'medicalInfo', 'updatedAt']
-                         );
+                         request.resource.data.diff(resource.data).affectedKeys().hasOnly(['photoUrl', 'updatedAt']);
+
+        // Private player profile (sensitive fields)
+        match /private/profile {
+          allow read: if isTeamOwnerOrAdmin(teamId) || isParentForPlayer(teamId, playerId);
+
+          // Coaches/admins can write freely.
+          allow create, update: if isTeamOwnerOrAdmin(teamId);
+
+          // Parents can only write specific sensitive fields for their linked player.
+          allow create: if isParentForPlayer(teamId, playerId) &&
+                           request.resource.data.keys().hasOnly(['emergencyContact', 'medicalInfo', 'updatedAt']);
+          allow update: if isParentForPlayer(teamId, playerId) &&
+                           request.resource.data.diff(resource.data).affectedKeys().hasOnly(['emergencyContact', 'medicalInfo', 'updatedAt']);
+
+          allow delete: if isTeamOwnerOrAdmin(teamId);
+        }
       }
 
       // Games subcollection

--- a/firestore.rules
+++ b/firestore.rules
@@ -83,6 +83,12 @@ service cloud.firestore {
       allow read: if true;  // Public read for collection group queries
     }
 
+    // Collection group rule for players - allows cross-team player search.
+    // Note: Team-scoped player reads are already allowed below; this enables collectionGroup('players') queries.
+    match /{path=**}/players/{playerId} {
+      allow read: if true;
+    }
+
     // Teams - only owner or admins can modify
     match /teams/{teamId} {
       allow read: if true;  // Public teams for browsing

--- a/firestore.rules
+++ b/firestore.rules
@@ -98,21 +98,26 @@ service cloud.firestore {
       allow create: if isSignedIn() && request.resource.data.ownerId == request.auth.uid;
       allow update, delete: if isTeamOwnerOrAdmin(teamId);
 
-      // Players subcollection
-      match /players/{playerId} {
-        // Public player doc is only safe if it contains no sensitive fields.
-        // Team owner/admin/parent-of-player may still read legacy docs that contain sensitive fields.
-        allow read: if isTeamOwnerOrAdmin(teamId) ||
-                      isParentForPlayer(teamId, playerId) ||
-                      !resource.data.keys().hasAny(['medicalInfo', 'emergencyContact']);
+	      // Players subcollection
+	      match /players/{playerId} {
+	        // Public player doc is only safe if it contains no sensitive fields.
+	        // Team owner/admin/parent-of-player may still read legacy docs that contain sensitive fields.
+	        allow read: if isTeamOwnerOrAdmin(teamId) ||
+	                      isParentForPlayer(teamId, playerId) ||
+	                      !resource.data.keys().hasAny(['medicalInfo', 'emergencyContact']);
 
-        // Full write access for team owners/admins
-        allow write: if isTeamOwnerOrAdmin(teamId);
+	        // Writes: never allow sensitive fields on the public player doc.
+	        // Coaches/admins can create/update/delete, but must keep the doc "public-safe".
+	        allow create: if isTeamOwnerOrAdmin(teamId) &&
+	                        !request.resource.data.keys().hasAny(['medicalInfo', 'emergencyContact']);
+	        allow update: if isTeamOwnerOrAdmin(teamId) &&
+	                        !request.resource.data.keys().hasAny(['medicalInfo', 'emergencyContact']);
+	        allow delete: if isTeamOwnerOrAdmin(teamId);
 
-        // Limited write access for parents (only their linked player):
-        // - Public player doc: photo only
-        allow update: if isParentForPlayer(teamId, playerId) &&
-                         request.resource.data.diff(resource.data).affectedKeys().hasOnly(['photoUrl', 'updatedAt']);
+	        // Limited write access for parents (only their linked player):
+	        // - Public player doc: photo only
+	        allow update: if isParentForPlayer(teamId, playerId) &&
+	                         request.resource.data.diff(resource.data).affectedKeys().hasOnly(['photoUrl', 'updatedAt']);
 
         // Private player profile (sensitive fields)
         match /private/profile {

--- a/game-plan.html
+++ b/game-plan.html
@@ -261,7 +261,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getPlayers, getGames, getGame, updateGame, getTrackedCalendarEventUids, getEvents } from './js/db.js';
+        import { getTeam, getPlayers, getGames, getGame, updateGame, getTrackedCalendarEventUids, getEvents } from './js/db.js?v=13';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
 

--- a/game-plan.html
+++ b/game-plan.html
@@ -261,7 +261,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getPlayers, getGames, getGame, updateGame, getTrackedCalendarEventUids, getEvents } from './js/db.js?v=13';
+        import { getTeam, getPlayers, getGames, getGame, updateGame, getTrackedCalendarEventUids, getEvents } from './js/db.js?v=14';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
 

--- a/game.html
+++ b/game.html
@@ -251,7 +251,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getUnreadChatCounts, getUserProfile, updateGame, uploadStatSheetPhoto } from './js/db.js?v=13';
+        import { getTeam, getGame, getPlayers, getUnreadChatCounts, getUserProfile, updateGame, uploadStatSheetPhoto } from './js/db.js?v=14';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { collection, getDocs, query, orderBy } from "./js/firebase.js?v=9";

--- a/game.html
+++ b/game.html
@@ -251,7 +251,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getUnreadChatCounts, getUserProfile, updateGame, uploadStatSheetPhoto } from './js/db.js';
+        import { getTeam, getGame, getPlayers, getUnreadChatCounts, getUserProfile, updateGame, uploadStatSheetPhoto } from './js/db.js?v=13';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { collection, getDocs, query, orderBy } from "./js/firebase.js?v=9";

--- a/index.html
+++ b/index.html
@@ -649,7 +649,7 @@
   <script type="module">
     import { checkAuth, logout } from './js/auth.js?v=9';
     import { renderHeader, formatDate, formatTime } from './js/utils.js?v=8';
-    import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=13';
+    import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=14';
 
     const heroCta = document.getElementById('hero-cta');
 

--- a/index.html
+++ b/index.html
@@ -649,7 +649,7 @@
   <script type="module">
     import { checkAuth, logout } from './js/auth.js?v=9';
     import { renderHeader, formatDate, formatTime } from './js/utils.js?v=8';
-    import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=9';
+    import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=13';
 
     const heroCta = document.getElementById('hero-cta');
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,4 +1,4 @@
-import { getTeams, getAllUsers, deleteTeam } from './db.js';
+import { getTeams, getAllUsers, deleteTeam } from './db.js?v=13';
 import { renderHeader, renderFooter, escapeHtml } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=9';
 
@@ -50,7 +50,7 @@ async function loadGameStats() {
     // Load games from all teams
     const gamesPromises = allTeams.map(async (team) => {
         try {
-            const { getGames } = await import('./db.js');
+            const { getGames } = await import('./db.js?v=13');
             const games = await getGames(team.id);
             return games.map(g => ({ ...g, teamId: team.id, teamName: team.name }));
         } catch (e) {

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,4 +1,4 @@
-import { getTeams, getAllUsers, deleteTeam } from './db.js?v=13';
+import { getTeams, getAllUsers, deleteTeam } from './db.js?v=14';
 import { renderHeader, renderFooter, escapeHtml } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=9';
 
@@ -50,7 +50,7 @@ async function loadGameStats() {
     // Load games from all teams
     const gamesPromises = allTeams.map(async (team) => {
         try {
-            const { getGames } = await import('./db.js?v=13');
+            const { getGames } = await import('./db.js?v=14');
             const games = await getGames(team.id);
             return games.map(g => ({ ...g, teamId: team.id, teamName: team.name }));
         } catch (e) {

--- a/js/auth.js
+++ b/js/auth.js
@@ -15,7 +15,7 @@ import {
     signInWithEmailLink,
     updatePassword
 } from './firebase.js?v=9';
-import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, getUserProfile, getUserTeams, getUserByEmail } from './db.js';
+import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, getUserProfile, getUserTeams, getUserByEmail } from './db.js?v=13';
 
 export async function login(email, password) {
     const userCredential = await signInWithEmailAndPassword(auth, email, password);

--- a/js/auth.js
+++ b/js/auth.js
@@ -15,7 +15,7 @@ import {
     signInWithEmailLink,
     updatePassword
 } from './firebase.js?v=9';
-import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, getUserProfile, getUserTeams, getUserByEmail } from './db.js?v=13';
+import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, getUserProfile, getUserTeams, getUserByEmail } from './db.js?v=14';
 
 export async function login(email, password) {
     const userCredential = await signInWithEmailAndPassword(auth, email, password);

--- a/js/global-search.js
+++ b/js/global-search.js
@@ -1,0 +1,674 @@
+import { escapeHtml } from './utils.js?v=8';
+import { getTeams } from './db.js?v=13';
+import {
+    db,
+    collectionGroup,
+    getDocs,
+    query,
+    where,
+    orderBy,
+    limit
+} from './firebase.js?v=9';
+
+let cachedTeams = null;
+let cachedTeamsLoadedAt = 0;
+
+let currentUser = null;
+let keyHandlerInstalled = false;
+let modalState = null;
+
+function nowMs() {
+    return Date.now();
+}
+
+function isTypingTarget(target) {
+    if (!target) return false;
+    const tag = (target.tagName || '').toLowerCase();
+    if (tag === 'input' || tag === 'textarea' || tag === 'select') return true;
+    if (target.isContentEditable) return true;
+    return false;
+}
+
+function normalizeQuery(q) {
+    return (q || '').trim().toLowerCase();
+}
+
+function capitalizeFirst(s) {
+    const str = (s || '').trim();
+    if (!str) return '';
+    return str[0].toUpperCase() + str.slice(1);
+}
+
+function titleCaseWord(s) {
+    const str = (s || '').trim().toLowerCase();
+    if (!str) return '';
+    return str[0].toUpperCase() + str.slice(1);
+}
+
+function splitTokens(q) {
+    const norm = normalizeQuery(q);
+    if (!norm) return [];
+    return norm.split(/\s+/g).filter(Boolean);
+}
+
+function scoreText(text, tokens) {
+    const hay = (text || '').toLowerCase();
+    if (!hay) return 0;
+
+    let score = 0;
+    for (const t of tokens) {
+        const idx = hay.indexOf(t);
+        if (idx === -1) return -1;
+        score += idx === 0 ? 50 : 10;
+        score += Math.max(0, 20 - idx);
+    }
+    return score;
+}
+
+function buildActions(user) {
+    const actions = [
+        { kind: 'action', title: 'Browse Teams', subtitle: 'Explore teams on ALL PLAYS', href: 'teams.html' }
+    ];
+
+    if (!user) {
+        actions.push(
+            { kind: 'action', title: 'Sign In', subtitle: 'Log in to your account', href: 'login.html' },
+            { kind: 'action', title: 'Get Started', subtitle: 'Create an account', href: 'login.html#signup' }
+        );
+        return actions;
+    }
+
+    actions.push(
+        { kind: 'action', title: 'Dashboard', subtitle: 'Go to your teams', href: 'dashboard.html' },
+        { kind: 'action', title: 'Profile', subtitle: 'Account settings', href: 'profile.html' }
+    );
+
+    if (user.isAdmin) {
+        actions.push({ kind: 'action', title: 'Admin Dashboard', subtitle: 'Platform admin tools', href: 'admin.html' });
+    }
+
+    return actions;
+}
+
+async function loadTeamsOnce() {
+    const ttlMs = 10 * 60 * 1000;
+    if (cachedTeams && (nowMs() - cachedTeamsLoadedAt) < ttlMs) return cachedTeams;
+
+    const teams = await getTeams();
+    cachedTeams = Array.isArray(teams) ? teams : [];
+    cachedTeamsLoadedAt = nowMs();
+    return cachedTeams;
+}
+
+function parseTeamAndPlayerIdFromPath(path) {
+    // Expected: teams/{teamId}/players/{playerId}
+    const parts = String(path || '').split('/');
+    const tIdx = parts.indexOf('teams');
+    const pIdx = parts.indexOf('players');
+    if (tIdx === -1 || pIdx === -1) return { teamId: '', playerId: '' };
+    return { teamId: parts[tIdx + 1] || '', playerId: parts[pIdx + 1] || '' };
+}
+
+function renderResultRow(item, isActive) {
+    const activeCls = isActive ? 'bg-primary-50 border-primary-200' : 'bg-white border-gray-200 hover:bg-gray-50';
+    const title = escapeHtml(item.title || '');
+    const subtitle = escapeHtml(item.subtitle || '');
+
+    return `
+        <button
+            type="button"
+            class="w-full text-left px-4 py-3 rounded-lg border ${activeCls} transition"
+            data-global-search-result="1"
+            data-href="${escapeHtml(item.href || '')}"
+        >
+            <div class="flex items-start justify-between gap-3">
+                <div class="min-w-0">
+                    <div class="font-semibold text-gray-900 truncate">${title}</div>
+                    ${subtitle ? `<div class="text-sm text-gray-500 truncate">${subtitle}</div>` : ''}
+                </div>
+                <div class="text-xs font-semibold text-gray-400 pt-1">${escapeHtml(item.kind || '')}</div>
+            </div>
+        </button>
+    `;
+}
+
+function closeModal() {
+    if (!modalState) return;
+    modalState.root.remove();
+    document.body.classList.remove('overflow-hidden');
+    modalState = null;
+}
+
+function openModal({ initialQuery = '' } = {}) {
+    if (modalState) return;
+
+    const root = document.createElement('div');
+    root.setAttribute('data-global-search-root', '1');
+    root.className = 'fixed inset-0 z-[9999]';
+    root.innerHTML = `
+        <div class="absolute inset-0 bg-black/30 backdrop-blur-sm" data-global-search-backdrop="1"></div>
+        <div class="absolute inset-0 flex items-start justify-center p-4 md:p-8">
+            <div class="w-full max-w-2xl bg-white rounded-2xl shadow-2xl border border-gray-200 overflow-hidden">
+                <div class="p-3 md:p-4 border-b border-gray-100 bg-gradient-to-r from-gray-50 to-white">
+                    <div class="flex items-center gap-3">
+                        <div class="w-9 h-9 md:w-10 md:h-10 rounded-xl bg-primary-100 text-primary-700 flex items-center justify-center border border-primary-200">
+                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 1010.5 18a7.5 7.5 0 006.15-3.35z"></path>
+                            </svg>
+                        </div>
+                        <div class="flex-1 min-w-0">
+                            <input
+                                type="text"
+                                class="w-full px-3 py-2.5 md:px-4 md:py-3 rounded-xl border border-gray-200 focus:outline-none focus:ring-2 focus:ring-primary-200 focus:border-primary-300 text-[15px] md:text-base"
+                                placeholder="Search teams or actions..."
+                                autocomplete="off"
+                                data-global-search-input="1"
+                            />
+                            <div class="hidden sm:block text-xs text-gray-500 mt-2">
+                                Tip: Use <span class="font-semibold">↑</span>/<span class="font-semibold">↓</span> to navigate, <span class="font-semibold">Enter</span> to open, <span class="font-semibold">Esc</span> to close.
+                            </div>
+                        </div>
+                        <button
+                            type="button"
+                            class="p-2 rounded-lg text-gray-500 hover:text-gray-900 hover:bg-gray-100 transition"
+                            data-global-search-close="1"
+                            aria-label="Close"
+                            title="Close"
+                        >
+                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+                <div class="p-3 md:p-4 max-h-[70vh] overflow-y-auto">
+                    <div class="space-y-3" data-global-search-sections="1">
+                        <div class="text-sm text-gray-500">Loading teams...</div>
+                    </div>
+                </div>
+            </div>
+        </div>
+    `;
+
+    document.body.appendChild(root);
+    document.body.classList.add('overflow-hidden');
+
+    const input = root.querySelector('[data-global-search-input="1"]');
+    const sections = root.querySelector('[data-global-search-sections="1"]');
+
+    modalState = {
+        root,
+        input,
+        sections,
+        activeIndex: 0,
+        flatResults: [],
+        teams: [],
+        loadingTeams: true,
+        teamsError: ''
+        ,
+        players: [],
+        loadingPlayers: false,
+        playersError: '',
+        lastPlayersQuery: '',
+        playersReqId: 0,
+        playersDebounce: null,
+        teamsById: new Map()
+    };
+
+    const onBackdrop = (e) => {
+        const target = e.target;
+        if (target && target.matches('[data-global-search-backdrop="1"]')) closeModal();
+    };
+    root.addEventListener('mousedown', onBackdrop);
+
+    const closeBtn = root.querySelector('[data-global-search-close="1"]');
+    closeBtn.addEventListener('click', closeModal);
+
+    const onKeyDown = (e) => {
+        if (!modalState) return;
+        if (e.key === 'Escape') {
+            e.preventDefault();
+            closeModal();
+            return;
+        }
+
+        if (e.key === 'ArrowDown') {
+            e.preventDefault();
+            modalState.activeIndex = Math.min(modalState.flatResults.length - 1, modalState.activeIndex + 1);
+            renderResults();
+            scrollActiveIntoView();
+            return;
+        }
+
+        if (e.key === 'ArrowUp') {
+            e.preventDefault();
+            modalState.activeIndex = Math.max(0, modalState.activeIndex - 1);
+            renderResults();
+            scrollActiveIntoView();
+            return;
+        }
+
+        if (e.key === 'Enter') {
+            const item = modalState.flatResults[modalState.activeIndex];
+            if (item && item.href) {
+                e.preventDefault();
+                window.location.href = item.href;
+            }
+        }
+    };
+    root.addEventListener('keydown', onKeyDown);
+
+    const onClickResult = (e) => {
+        const btn = e.target?.closest?.('[data-global-search-result="1"]');
+        if (!btn) return;
+        const href = btn.getAttribute('data-href');
+        if (href) window.location.href = href;
+    };
+    root.addEventListener('click', onClickResult);
+
+    const renderSection = (label, items, offset) => {
+        if (!items.length) return '';
+        const rows = items.map((item, idx) => renderResultRow(item, (offset + idx) === modalState.activeIndex)).join('');
+        return `
+            <div>
+                <div class="text-xs uppercase tracking-wider font-bold text-gray-500 mb-2">${escapeHtml(label)}</div>
+                <div class="space-y-2">
+                    ${rows}
+                </div>
+            </div>
+        `;
+    };
+
+    const scrollActiveIntoView = () => {
+        const active = root.querySelectorAll('[data-global-search-result="1"]')[modalState.activeIndex];
+        if (active && active.scrollIntoView) active.scrollIntoView({ block: 'nearest' });
+    };
+
+    const computeResults = (q, teams, players) => {
+        const tokens = splitTokens(q);
+        const actions = buildActions(currentUser);
+
+        const matchedActions = tokens.length === 0
+            ? actions
+            : actions
+                .map(a => ({ item: a, score: scoreText(`${a.title} ${a.subtitle}`, tokens) }))
+                .filter(x => x.score >= 0)
+                .sort((a, b) => b.score - a.score)
+                .map(x => x.item);
+
+        const playerItems = (players || []);
+
+        const teamItems = (teams || []).map(t => ({
+            kind: 'team',
+            title: t.name || 'Team',
+            subtitle: [t.sport, t.zip].filter(Boolean).join(' • '),
+            href: `team.html#teamId=${encodeURIComponent(t.id)}`
+        }));
+
+        const matchedTeams = tokens.length === 0
+            ? teamItems.slice(0, 20)
+            : teamItems
+                .map(t => ({ item: t, score: scoreText(`${t.title} ${t.subtitle}`, tokens) }))
+                .filter(x => x.score >= 0)
+                .sort((a, b) => b.score - a.score)
+                .slice(0, 20)
+                .map(x => x.item);
+
+        return { matchedActions, matchedPlayers: playerItems.slice(0, 20), matchedTeams };
+    };
+
+    const renderResults = () => {
+        if (!modalState) return;
+
+        const q = modalState.input.value || '';
+        const teams = modalState.teams || [];
+        const players = modalState.players || [];
+        const { matchedActions, matchedPlayers, matchedTeams } = computeResults(q, teams, players);
+
+        // Order: Actions, Teams, Players
+        modalState.flatResults = [...matchedActions, ...matchedTeams, ...matchedPlayers];
+        if (modalState.activeIndex >= modalState.flatResults.length) modalState.activeIndex = Math.max(0, modalState.flatResults.length - 1);
+
+        const actionsHtml = renderSection('Actions', matchedActions, 0);
+        const teamsOffset = matchedActions.length;
+        const teamsRows = matchedTeams.map((item, idx) => renderResultRow(item, (teamsOffset + idx) === modalState.activeIndex)).join('');
+        const teamsStatus = modalState.loadingTeams
+            ? `<div class="text-sm text-gray-500 px-1 py-2">Loading teams...</div>`
+            : modalState.teamsError
+                ? `<div class="text-sm text-red-600 px-1 py-2">${escapeHtml(modalState.teamsError)}</div>`
+                : (matchedTeams.length === 0 ? `<div class="text-sm text-gray-500 px-1 py-2">No matching teams</div>` : '');
+
+        const teamsHtml = `
+            <div>
+                <div class="text-xs uppercase tracking-wider font-bold text-gray-500 mb-2">Teams</div>
+                <div class="space-y-2">
+                    ${teamsRows}
+                </div>
+                ${teamsStatus}
+            </div>
+        `;
+
+        const playersOffset = matchedActions.length + matchedTeams.length;
+        const playersRows = matchedPlayers.map((item, idx) => renderResultRow(item, (playersOffset + idx) === modalState.activeIndex)).join('');
+        const playersStatus = modalState.loadingPlayers
+            ? `<div class="text-sm text-gray-500 px-1 py-2">Searching players...</div>`
+            : modalState.playersError
+                ? `<div class="text-sm text-red-600 px-1 py-2">${escapeHtml(modalState.playersError)}</div>`
+                : (q.trim().length < 2 ? `<div class="text-sm text-gray-500 px-1 py-2">Type at least 2 characters to search players</div>` : (matchedPlayers.length === 0 ? `<div class="text-sm text-gray-500 px-1 py-2">No matching players</div>` : ''));
+
+        const playersHtml = `
+            <div>
+                <div class="text-xs uppercase tracking-wider font-bold text-gray-500 mb-2">Players</div>
+                <div class="space-y-2">
+                    ${playersRows}
+                </div>
+                ${playersStatus}
+            </div>
+        `;
+
+        const emptyHtml = modalState.flatResults.length === 0 && !modalState.loadingTeams
+            ? `<div class="text-sm text-gray-500 px-1 py-6 text-center">No results</div>`
+            : '';
+
+        modalState.sections.innerHTML = `
+            <div class="space-y-5">
+                ${actionsHtml}
+                ${teamsHtml}
+                ${playersHtml}
+                ${emptyHtml}
+            </div>
+        `;
+    };
+
+    const runPlayerSearch = async (rawQuery) => {
+        const q = (rawQuery || '').trim();
+        if (!modalState) return;
+
+        // Avoid blasting reads on single-character queries.
+        if (q.length < 2) {
+            modalState.players = [];
+            modalState.loadingPlayers = false;
+            modalState.playersError = '';
+            modalState.lastPlayersQuery = q;
+            renderResults();
+            return;
+        }
+
+        const reqId = ++modalState.playersReqId;
+        modalState.loadingPlayers = true;
+        modalState.playersError = '';
+        modalState.lastPlayersQuery = q;
+        renderResults();
+
+        const tokens = splitTokens(q);
+        const searchTokens = Array.from(new Set(tokens.slice(0, 2)));
+        const prefixes = Array.from(new Set(
+            searchTokens.flatMap((t) => [t, t.toLowerCase(), titleCaseWord(t)])
+        ).values()).filter(Boolean).slice(0, 6);
+        const isNumeric = /^[0-9]+$/.test(q);
+
+        try {
+            const playersRef = collectionGroup(db, 'players');
+            const queries = [];
+
+            for (const prefix of prefixes) {
+                queries.push(
+                    getDocs(query(
+                        playersRef,
+                        orderBy('name'),
+                        where('name', '>=', prefix),
+                        where('name', '<=', `${prefix}\uf8ff`),
+                        limit(20)
+                    ))
+                );
+            }
+
+            if (isNumeric) {
+                queries.push(
+                    getDocs(query(
+                        playersRef,
+                        orderBy('number'),
+                        where('number', '>=', q),
+                        where('number', '<=', `${q}\uf8ff`),
+                        limit(20)
+                    ))
+                );
+            }
+
+            const snaps = await Promise.allSettled(queries);
+            if (!modalState || reqId !== modalState.playersReqId) return;
+
+            const rejected = snaps.filter(s => s.status === 'rejected').map(s => s.reason).filter(Boolean);
+            const hasFulfilled = snaps.some(s => s.status === 'fulfilled');
+            const anyPermDenied = rejected.some(e => (e?.code || '') === 'permission-denied');
+            const anyFailedPre = rejected.some(e => (e?.code || '') === 'failed-precondition');
+            const anyIndexBuilding = rejected.some(e => (e?.code || '') === 'failed-precondition' && String(e?.message || '').toLowerCase().includes('not ready yet'));
+
+            const byPath = new Map();
+            for (const s of snaps) {
+                if (s.status !== 'fulfilled') continue;
+                for (const d of s.value.docs || []) {
+                    byPath.set(d.ref.path, d);
+                }
+            }
+
+            if (!hasFulfilled && (anyPermDenied || anyFailedPre)) {
+                modalState.players = [];
+                modalState.loadingPlayers = false;
+                modalState.playersError = anyPermDenied
+                    ? 'Player search unavailable (permission denied). Update Firestore rules to allow collection-group reads for players.'
+                    : (anyIndexBuilding
+                        ? 'Player search index is building. Try again in a few minutes.'
+                        : 'Player search unavailable (index required).');
+                renderResults();
+                return;
+            }
+
+            const items = Array.from(byPath.values()).map((d) => {
+                const data = d.data() || {};
+                const name = data.name || 'Player';
+                const number = data.number || '';
+                const { teamId, playerId } = parseTeamAndPlayerIdFromPath(d.ref.path);
+                const teamName = modalState.teamsById.get(teamId)?.name || teamId || 'Team';
+
+                return {
+                    kind: 'player',
+                    title: `${number ? `#${number} ` : ''}${name}`,
+                    subtitle: teamName,
+                    href: `player.html#teamId=${encodeURIComponent(teamId)}&playerId=${encodeURIComponent(playerId)}`
+                };
+            });
+
+            // Basic ranking: starts-with match on name/number, then shorter strings first.
+            const ranked = items
+                .map((it) => ({ it, score: scoreText(it.title, tokens) }))
+                .filter(x => x.score >= 0)
+                .sort((a, b) => (b.score - a.score) || (a.it.title.length - b.it.title.length))
+                .slice(0, 20)
+                .map(x => x.it);
+
+            modalState.players = ranked;
+            modalState.loadingPlayers = false;
+            modalState.playersError = '';
+            renderResults();
+        } catch (e) {
+            console.error('[GlobalSearch] Player search failed:', e);
+            if (!modalState || reqId !== modalState.playersReqId) return;
+            modalState.players = [];
+            modalState.loadingPlayers = false;
+            modalState.playersError = e?.code === 'permission-denied'
+                ? 'Player search unavailable (permission denied).'
+                : 'Player search unavailable.';
+            renderResults();
+        }
+    };
+
+    const schedulePlayerSearch = () => {
+        if (!modalState) return;
+        if (modalState.playersDebounce) clearTimeout(modalState.playersDebounce);
+        modalState.playersDebounce = setTimeout(() => {
+            if (!modalState) return;
+            runPlayerSearch(modalState.input.value || '');
+        }, 180);
+    };
+
+    input.addEventListener('input', () => {
+        modalState.activeIndex = 0;
+        schedulePlayerSearch();
+        renderResults();
+    });
+
+    input.value = initialQuery || '';
+    input.focus();
+    renderResults();
+
+    // Load teams asynchronously, then render.
+    (async () => {
+        try {
+            const teams = await loadTeamsOnce();
+            if (!modalState) return;
+            modalState.teams = teams;
+            modalState.loadingTeams = false;
+            modalState.teamsError = '';
+            modalState.teamsById = new Map((teams || []).map(t => [t.id, t]));
+            modalState.activeIndex = 0;
+            renderResults();
+        } catch (e) {
+            console.error('[GlobalSearch] Failed to load teams:', e);
+            if (!modalState) return;
+            modalState.teams = [];
+            modalState.loadingTeams = false;
+            modalState.teamsError = 'Unable to load teams.';
+            modalState.activeIndex = 0;
+            renderResults();
+        }
+    })();
+}
+
+function installKeyHandler() {
+    if (keyHandlerInstalled) return;
+    keyHandlerInstalled = true;
+
+    window.addEventListener('keydown', (e) => {
+        const isModK = (e.key || '').toLowerCase() === 'k' && (e.metaKey || e.ctrlKey);
+        if (!isModK) return;
+        if (isTypingTarget(e.target)) return;
+
+        e.preventDefault();
+        openModal();
+    });
+}
+
+function injectMobileMenuItem(menuContainer) {
+    if (!menuContainer) return;
+    if (menuContainer.querySelector('[data-global-search-open="1"]')) return;
+
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.setAttribute('data-global-search-open', '1');
+    btn.setAttribute('aria-label', 'Search');
+    btn.className = 'block w-full text-left text-base font-medium text-gray-700 hover:text-primary-700 transition';
+    btn.innerHTML = `
+        <span class="inline-flex items-center gap-2">
+            <svg class="w-5 h-5 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 1010.5 18a7.5 7.5 0 006.15-3.35z"></path>
+            </svg>
+            <span>Search</span>
+        </span>
+    `;
+    btn.addEventListener('click', () => openModal());
+
+    menuContainer.insertAdjacentElement('afterbegin', btn);
+}
+
+function injectMobileIconButton(headerContainer) {
+    if (!headerContainer) return;
+    if (headerContainer.querySelector('[data-global-search-icon="1"]')) return;
+
+    const mobileBtn = headerContainer.querySelector('#mobile-menu-btn');
+    if (!mobileBtn || !mobileBtn.parentElement) return;
+
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.setAttribute('data-global-search-icon', '1');
+    btn.setAttribute('aria-label', 'Search');
+    btn.title = 'Search';
+    btn.className = 'md:hidden p-2 text-gray-600 hover:text-primary-600 focus:outline-none';
+    btn.innerHTML = `
+        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 1010.5 18a7.5 7.5 0 006.15-3.35z"></path>
+        </svg>
+    `;
+    btn.addEventListener('click', () => openModal());
+
+    // Put the magnifier immediately to the left of the hamburger.
+    mobileBtn.insertAdjacentElement('beforebegin', btn);
+}
+
+function injectCenteredSearchLauncher(headerContainer) {
+    if (!headerContainer) return;
+    if (headerContainer.querySelector('[data-global-search-launcher="1"]')) return;
+
+    // In renderHeader(): the top row container is the first ".flex.items-center.justify-between".
+    const topRow = headerContainer.querySelector('header nav > div.flex.items-center.justify-between');
+    if (!topRow) return;
+
+    const desktopActions = headerContainer.querySelector('#nav-auth-actions-desktop');
+    if (!desktopActions) return;
+
+    // Create a center "fake input" launcher.
+    const wrap = document.createElement('div');
+    wrap.className = 'hidden md:flex flex-1 px-4';
+    wrap.setAttribute('data-global-search-launcher', '1');
+
+    const btn = document.createElement('button');
+    btn.type = 'button';
+    btn.setAttribute('aria-label', 'Search');
+    btn.title = 'Search (Ctrl+K / Cmd+K)';
+    btn.className = [
+        'w-full max-w-xl mx-auto',
+        'inline-flex items-center justify-between gap-3',
+        'px-4 py-2.5 rounded-xl border border-gray-200',
+        'bg-white/70 hover:bg-white',
+        'text-sm text-gray-600 hover:text-gray-900',
+        'shadow-sm hover:shadow transition',
+        'focus:outline-none focus:ring-2 focus:ring-primary-200 focus:border-primary-300'
+    ].join(' ');
+    btn.innerHTML = `
+        <span class="inline-flex items-center gap-2 min-w-0">
+            <svg class="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 21l-4.35-4.35m0 0A7.5 7.5 0 1010.5 18a7.5 7.5 0 006.15-3.35z"></path>
+            </svg>
+            <span class="truncate">Search teams, players, actions...</span>
+        </span>
+        <span class="hidden lg:inline-flex items-center gap-1 px-2 py-1 rounded-lg border border-gray-200 text-[11px] text-gray-500 bg-white">
+            <span class="font-semibold">Ctrl</span><span>+</span><span class="font-semibold">K</span>
+        </span>
+    `;
+    btn.addEventListener('click', () => openModal());
+
+    wrap.appendChild(btn);
+
+    // Insert before the right-side action links so it visually centers.
+    desktopActions.insertAdjacentElement('beforebegin', wrap);
+}
+
+export function setupHeaderSearch({ user, headerContainer } = {}) {
+    currentUser = user || null;
+    installKeyHandler();
+
+    injectCenteredSearchLauncher(headerContainer);
+    injectMobileIconButton(headerContainer);
+    injectMobileMenuItem(headerContainer?.querySelector('#nav-auth-actions-mobile'));
+}
+
+/**
+ * Index-only for now: inject a search launcher into the rendered header and
+ * bind Cmd/Ctrl+K to open the search modal.
+ */
+export function setupIndexSearch({ user } = {}) {
+    setupHeaderSearch({
+        user,
+        headerContainer: document.getElementById('header-container')
+    });
+}

--- a/js/global-search.js
+++ b/js/global-search.js
@@ -204,8 +204,7 @@ function openModal({ initialQuery = '' } = {}) {
         flatResults: [],
         teams: [],
         loadingTeams: true,
-        teamsError: ''
-        ,
+        teamsError: '',
         players: [],
         loadingPlayers: false,
         playersError: '',

--- a/js/global-search.js
+++ b/js/global-search.js
@@ -456,7 +456,7 @@ function openModal({ initialQuery = '' } = {}) {
                 modalState.players = [];
                 modalState.loadingPlayers = false;
                 modalState.playersError = anyPermDenied
-                    ? 'Player search unavailable (permission denied). Update Firestore rules to allow collection-group reads for players.'
+                    ? 'Player search unavailable (permission denied). If security rules were tightened, migrate player docs to remove sensitive fields (see spec/player-data-security.md).'
                     : (anyIndexBuilding
                         ? 'Player search index is building. Try again in a few minutes.'
                         : 'Player search unavailable (index required).');
@@ -497,7 +497,7 @@ function openModal({ initialQuery = '' } = {}) {
             modalState.players = [];
             modalState.loadingPlayers = false;
             modalState.playersError = e?.code === 'permission-denied'
-                ? 'Player search unavailable (permission denied).'
+                ? 'Player search unavailable (permission denied). If security rules were tightened, migrate player docs to remove sensitive fields.'
                 : 'Player search unavailable.';
             renderResults();
         }

--- a/js/global-search.js
+++ b/js/global-search.js
@@ -1,5 +1,5 @@
 import { escapeHtml } from './utils.js?v=8';
-import { getTeams } from './db.js?v=13';
+import { getTeams } from './db.js?v=14';
 import {
     db,
     collectionGroup,

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -13,7 +13,7 @@ import {
   getLiveReactions,
   getConfigs,
   subscribeGame
-} from './db.js';
+} from './db.js?v=13';
 import { getUrlParams, escapeHtml, renderHeader, renderFooter, formatShortDate, formatTime, shareOrCopy } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=9';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -13,7 +13,7 @@ import {
   getLiveReactions,
   getConfigs,
   subscribeGame
-} from './db.js?v=13';
+} from './db.js?v=14';
 import { getUrlParams, escapeHtml, renderHeader, renderFooter, formatShortDate, formatTime, shareOrCopy } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=9';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -1,5 +1,5 @@
 // Mobile-first basketball tracker, now backed by Firebase like track.html.
-import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js';
+import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=13';
 import { db } from './firebase.js?v=9';
 import { getUrlParams, escapeHtml } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=9';

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -1,5 +1,5 @@
 // Mobile-first basketball tracker, now backed by Firebase like track.html.
-import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=13';
+import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=14';
 import { db } from './firebase.js?v=9';
 import { getUrlParams, escapeHtml } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=9';

--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -1,5 +1,5 @@
 // Mobile-first basketball tracker, now backed by Firebase like track.html.
-import { getTeam, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query } from './db.js?v=13';
+import { getTeam, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query } from './db.js?v=14';
 import { db } from './firebase.js?v=9';
 import { getUrlParams, escapeHtml } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=9';

--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -1,5 +1,5 @@
 // Mobile-first basketball tracker, now backed by Firebase like track.html.
-import { getTeam, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query } from './db.js';
+import { getTeam, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query } from './db.js?v=13';
 import { db } from './firebase.js?v=9';
 import { getUrlParams, escapeHtml } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=9';

--- a/js/utils.js
+++ b/js/utils.js
@@ -191,6 +191,20 @@ export function renderHeader(container, user) {
 
   updateNav('desktop');
   updateNav('mobile');
+
+  // Global search: injected into the shared header in one place.
+  // Lazy-import to avoid adding weight to initial render and to avoid circular deps.
+  try {
+    import('./global-search.js?v=7')
+      .then(({ setupHeaderSearch }) => {
+        if (typeof setupHeaderSearch === 'function') {
+          setupHeaderSearch({ user, headerContainer: container });
+        }
+      })
+      .catch((e) => console.warn('[GlobalSearch] Failed to load:', e));
+  } catch (e) {
+    console.warn('[GlobalSearch] Failed to initialize:', e);
+  }
 }
 
 export function renderFooter(container) {

--- a/login.html
+++ b/login.html
@@ -96,7 +96,7 @@
 
     <script type="module">
         import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=9';
-        import { getUserProfile } from './js/db.js';
+        import { getUserProfile } from './js/db.js?v=13';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 
         renderFooter(document.getElementById('footer-container'));

--- a/login.html
+++ b/login.html
@@ -96,7 +96,7 @@
 
     <script type="module">
         import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=9';
-        import { getUserProfile } from './js/db.js?v=13';
+        import { getUserProfile } from './js/db.js?v=14';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 
         renderFooter(document.getElementById('footer-container'));

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -116,7 +116,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getParentDashboardData, redeemParentInvite, getTeam, getGames, getTrackedCalendarEventUids, getUnreadChatCounts } from './js/db.js?v=13';
+        import { getParentDashboardData, redeemParentInvite, getTeam, getGames, getTrackedCalendarEventUids, getUnreadChatCounts } from './js/db.js?v=14';
         import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent } from './js/utils.js?v=8';
         import { requireAuth, checkAuth } from './js/auth.js?v=9';
 

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -116,7 +116,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getParentDashboardData, redeemParentInvite, getTeam, getGames, getTrackedCalendarEventUids, getUnreadChatCounts } from './js/db.js?v=2';
+        import { getParentDashboardData, redeemParentInvite, getTeam, getGames, getTrackedCalendarEventUids, getUnreadChatCounts } from './js/db.js?v=13';
         import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent } from './js/utils.js?v=8';
         import { requireAuth, checkAuth } from './js/auth.js?v=9';
 

--- a/player.html
+++ b/player.html
@@ -202,7 +202,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getGames, updatePlayerProfile, uploadPlayerPhoto, getUnreadChatCounts, getUserProfile } from './js/db.js';
+        import { getTeam, getGame, getPlayers, getGames, updatePlayerProfile, uploadPlayerPhoto, getUnreadChatCounts, getUserProfile } from './js/db.js?v=13';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { collection, getDocs, doc, getDoc, query, orderBy } from "./js/firebase.js?v=9";

--- a/player.html
+++ b/player.html
@@ -202,7 +202,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getGames, updatePlayerProfile, uploadPlayerPhoto, getUnreadChatCounts, getUserProfile } from './js/db.js?v=13';
+        import { getTeam, getGame, getPlayers, getGames, updatePlayerProfile, getPlayerPrivateProfile, uploadPlayerPhoto, getUnreadChatCounts, getUserProfile } from './js/db.js?v=14';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { collection, getDocs, doc, getDoc, query, orderBy } from "./js/firebase.js?v=9";
@@ -211,6 +211,7 @@
 
         let currentUser = null;
         let currentPlayer = null; // Store for modal access
+        let currentPrivateProfile = null; // Sensitive fields live in a private doc
         let currentTeamId = null;
 
         checkAuth((user) => {
@@ -862,12 +863,22 @@
             }
         }
 
-        function openEditModal() {
+        async function openEditModal() {
              if (!currentPlayer) return;
              document.getElementById('edit-player-modal').classList.remove('hidden');
-             document.getElementById('edit-ec-name').value = currentPlayer.emergencyContact?.name || '';
-             document.getElementById('edit-ec-phone').value = currentPlayer.emergencyContact?.phone || '';
-             document.getElementById('edit-medical-info').value = currentPlayer.medicalInfo || '';
+
+             // Load sensitive fields from the private profile doc.
+             // If denied or missing, treat as empty.
+             try {
+                 currentPrivateProfile = await getPlayerPrivateProfile(currentTeamId, currentPlayer.id);
+             } catch (e) {
+                 console.warn('Failed to load private player profile:', e);
+                 currentPrivateProfile = null;
+             }
+
+             document.getElementById('edit-ec-name').value = currentPrivateProfile?.emergencyContact?.name || '';
+             document.getElementById('edit-ec-phone').value = currentPrivateProfile?.emergencyContact?.phone || '';
+             document.getElementById('edit-medical-info').value = currentPrivateProfile?.medicalInfo || '';
              
              const preview = document.getElementById('edit-photo-preview');
              if (currentPlayer.photoUrl) {

--- a/profile.html
+++ b/profile.html
@@ -374,7 +374,7 @@
     <script type="module">
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import { checkAuth, setUserPassword, resendVerificationEmail } from './js/auth.js?v=9';
-        import { getUserProfile, updateUserProfile, generateAccessCode, createAccessCode, getUserAccessCodes, uploadUserPhoto } from './js/db.js';
+        import { getUserProfile, updateUserProfile, generateAccessCode, createAccessCode, getUserAccessCodes, uploadUserPhoto } from './js/db.js?v=13';
 
         renderFooter(document.getElementById('footer-container'));
 

--- a/profile.html
+++ b/profile.html
@@ -374,7 +374,7 @@
     <script type="module">
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import { checkAuth, setUserPassword, resendVerificationEmail } from './js/auth.js?v=9';
-        import { getUserProfile, updateUserProfile, generateAccessCode, createAccessCode, getUserAccessCodes, uploadUserPhoto } from './js/db.js?v=13';
+        import { getUserProfile, updateUserProfile, generateAccessCode, createAccessCode, getUserAccessCodes, uploadUserPhoto } from './js/db.js?v=14';
 
         renderFooter(document.getElementById('footer-container'));
 

--- a/spec/firestore-backup-strategy.md
+++ b/spec/firestore-backup-strategy.md
@@ -1,0 +1,77 @@
+# Firestore Backup Strategy
+
+This repo (static site + Firebase) does not encode Firestore backup behavior.
+Backups for Firestore are configured in Google Cloud (the Firebase project), not in
+`firebase.json` / `firestore.rules` / `firestore.indexes.json`.
+
+## Goals
+
+- Recover from accidental deletes/updates (bad client code, bad rules, operator error).
+- Be able to restore specific collections or the entire database.
+- Keep operational cost and complexity reasonable.
+
+## Recommended Approach
+
+### 1) Enable Firestore Managed Backups / PITR (Primary)
+
+Use Firestore managed backups / point-in-time recovery (PITR) in the GCP Console.
+
+Why:
+
+- Best protection against accidental deletes/overwrites.
+- No extra code paths required in this repo.
+- Faster and more reliable than building a custom export pipeline.
+
+Notes:
+
+- Configure retention based on how quickly you want to detect issues (typical: 7-30 days).
+- Document the restore workflow and who has permission to run restores.
+
+### 2) Scheduled Exports to Cloud Storage (Secondary, for longer retention)
+
+Set up a scheduled Firestore export to a Cloud Storage bucket (daily or weekly).
+
+Why:
+
+- Longer retention windows (e.g., 90-365 days) at lower cost than keeping PITR for that long.
+- Offline copy that can be used for analytics or emergency migration.
+
+Implementation options (outside this repo unless we add infra code):
+
+- Cloud Scheduler -> Cloud Run job (or Cloud Function) -> Firestore export API
+- Terraform (preferred if you want this reproducible/config-as-code)
+
+Export scope:
+
+- Full export (simplest), or
+- Collection-level exports if you want to reduce cost/size (requires discipline to keep a list).
+
+## Restore Playbook (What We Should Document)
+
+- When to use PITR restore vs export restore
+- Who can approve/execute a restore
+- Expected downtime / impact on the app
+- Post-restore validation checklist (sample queries, key pages to load)
+
+## Minimum Operational Checklist
+
+- Confirm PITR/managed backups are enabled in the Firebase project
+- Confirm a Storage bucket exists for exports (if doing scheduled exports)
+- Confirm IAM roles for the account that runs exports/restores
+- Confirm alerts/notifications for failed exports (if scheduled exports exist)
+
+## Why This Matters For Data Privacy
+
+Firestore rules are document-level (no field-level redaction). If we keep sensitive
+fields (e.g., `medicalInfo`, `emergencyContact`) in documents that are readable to
+many users (or publicly readable), those fields are exposed.
+
+If/when we tighten privacy, the recommended pattern is:
+
+- Public player doc: `teams/{teamId}/players/{playerId}` (name/number/photo and other safe fields)
+- Private player subcollection doc: `teams/{teamId}/players/{playerId}/private/profile`
+  (sensitive fields, locked down by rules)
+
+This also makes future backups/restores more obviously sensitive: restoring private
+data should be more tightly controlled.
+

--- a/spec/player-data-security.md
+++ b/spec/player-data-security.md
@@ -1,0 +1,111 @@
+# Player Data Security (Public vs Private Fields)
+
+Firestore security rules are document-level: if a client can read a document, it can read *all fields* in that document.
+This means we cannot “hide” sensitive fields inside a publicly-readable `players/{playerId}` document.
+
+This spec defines a structure that keeps roster basics searchable while keeping sensitive info restricted.
+
+## Current Paths
+
+- Player public doc (today):
+  - `teams/{teamId}/players/{playerId}`
+- Player stats (per-game):
+  - `teams/{teamId}/games/{gameId}/aggregatedStats/{playerId}`
+  - `teams/{teamId}/games/{gameId}/events/{eventId}`
+
+## Proposed Player Data Structure
+
+### Public Player Doc (Searchable)
+
+Path:
+
+- `teams/{teamId}/players/{playerId}`
+
+Recommended fields:
+
+- `name` (string)
+- `number` (string or number)
+- `photoUrl` (string | null)
+- `position` (string | null) (optional; safe if you want it public)
+- `createdAt`, `updatedAt` (timestamps)
+
+This document may be readable broadly (even publicly) if the product requires it, but it must not contain sensitive data.
+
+### Private Player Profile (Sensitive)
+
+Path:
+
+- `teams/{teamId}/players/{playerId}/private/profile`
+
+Recommended fields:
+
+- `emergencyContact: { name, phone }`
+- `medicalInfo` (string)
+- (future) `address`, `dob`, etc.
+- `updatedAt` (timestamp)
+
+## Access Model (Intended)
+
+### Read Access
+
+- Coaches/admins for the team: can read private profile.
+- The linked parent for that player: can read private profile.
+- Others (including other parents on the same team): cannot read private profile.
+
+### Write Access
+
+- Coaches/admins: can update both public and private fields.
+- Linked parent: can update only the private profile (and only for their linked player).
+- No one else can update.
+
+## Firestore Rules Outline (Conceptual)
+
+Public player doc (example options):
+
+- If you want roster to be public: `allow read: if true;`
+- If you want roster gated: `allow read: if isSignedIn() && (isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId));`
+
+Private player profile doc:
+
+- `allow read: if isTeamOwnerOrAdmin(teamId) || isParentForPlayer(teamId, playerId);`
+- `allow update: if isTeamOwnerOrAdmin(teamId) || (isParentForPlayer(teamId, playerId) && onlyTouchesPrivateFields);`
+
+Important: `isParentForPlayer(teamId, playerId)` must validate *both* team and player, ideally via a `users/{uid}.parentOf[]`
+list that includes `{ teamId, playerId }`. Checking only `parentTeamIds` is too broad.
+
+See also: `spec/parent-update-security-bug.md`.
+
+## Global Search Implications
+
+Global search should only query the **public** player docs.
+
+Options:
+
+1. Team-scoped search only (simplest privacy):
+   - Search within a team page (query `teams/{teamId}/players`)
+2. Cross-team search (requires deliberate privacy posture):
+   - Either allow collection-group read of public player docs, or
+   - Maintain a dedicated `playerSearchIndex` collection that contains only safe fields
+     (`name`, `number`, `teamId`, `playerId`, `photoUrl`) and query that.
+
+Do not put sensitive fields in any document that is readable for search.
+
+## Migration Plan (No Duplication)
+
+Goal: move sensitive fields out of the public player doc into the private subcollection.
+
+1. Update UI code:
+   - `player.html` reads/writes `teams/{teamId}/players/{playerId}/private/profile` for sensitive fields.
+2. Backfill existing data:
+   - One-time script (admin-only) reads each player doc and, if `emergencyContact` / `medicalInfo` exist,
+     writes them to `private/profile` then deletes those fields from the public doc.
+3. Tighten rules:
+   - Ensure private profile is restricted.
+   - Optionally reconsider whether public player docs should remain publicly readable.
+
+## What Should Never Be Public
+
+- `medicalInfo`
+- `emergencyContact`
+- Addresses, DOB, phone numbers, emails
+

--- a/team-chat.html
+++ b/team-chat.html
@@ -145,7 +145,7 @@
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
-        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages } from './js/db.js';
+        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages } from './js/db.js?v=13';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { getAI, getGenerativeModel, GoogleAIBackend } from './js/vendor/firebase-ai.js';
         import { getApp } from './js/vendor/firebase-app.js';

--- a/team-chat.html
+++ b/team-chat.html
@@ -145,7 +145,7 @@
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
-        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages } from './js/db.js?v=13';
+        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages } from './js/db.js?v=14';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { getAI, getGenerativeModel, GoogleAIBackend } from './js/vendor/firebase-ai.js';
         import { getApp } from './js/vendor/firebase-app.js';

--- a/team.html
+++ b/team.html
@@ -197,7 +197,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getPlayers, getGames, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile } from './js/db.js?v=9';
+        import { getTeam, getPlayers, getGames, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile } from './js/db.js?v=13';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { collection, getDocs } from "./js/firebase.js?v=9";

--- a/team.html
+++ b/team.html
@@ -197,7 +197,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getPlayers, getGames, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile } from './js/db.js?v=13';
+        import { getTeam, getPlayers, getGames, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile } from './js/db.js?v=14';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { collection, getDocs } from "./js/firebase.js?v=9";

--- a/teams.html
+++ b/teams.html
@@ -67,7 +67,7 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { getTeams } from './js/db.js?v=13';
+    import { getTeams } from './js/db.js?v=14';
     import { renderHeader, renderFooter } from './js/utils.js?v=8';
     import { checkAuth } from './js/auth.js?v=9';
 

--- a/teams.html
+++ b/teams.html
@@ -67,7 +67,7 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { getTeams } from './js/db.js';
+    import { getTeams } from './js/db.js?v=13';
     import { renderHeader, renderFooter } from './js/utils.js?v=8';
     import { checkAuth } from './js/auth.js?v=9';
 

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -199,7 +199,7 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { getTeam, getGame, getPlayers, getConfigs, collection, getDocs, deleteDoc, uploadStatSheetPhoto } from './js/db.js?v=13';
+    import { getTeam, getGame, getPlayers, getConfigs, collection, getDocs, deleteDoc, uploadStatSheetPhoto } from './js/db.js?v=14';
     import { db } from './js/firebase.js?v=9';
     import { writeBatch, doc, setDoc } from './js/firebase.js?v=9';
     import { renderHeader, renderFooter, getUrlParams, escapeHtml, formatDate } from './js/utils.js?v=8';
@@ -955,7 +955,7 @@ Write the match report now:`;
       try {
         if (summaryText) {
           status.textContent = 'Saving summary…';
-          const { updateGame } = await import('./js/db.js?v=13');
+          const { updateGame } = await import('./js/db.js?v=14');
           await updateGame(currentTeamId, currentGameId, { summary: summaryText });
           status.textContent = 'Summary saved!';
         }

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -199,7 +199,7 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { getTeam, getGame, getPlayers, getConfigs, collection, getDocs, deleteDoc, uploadStatSheetPhoto } from './js/db.js?v=12';
+    import { getTeam, getGame, getPlayers, getConfigs, collection, getDocs, deleteDoc, uploadStatSheetPhoto } from './js/db.js?v=13';
     import { db } from './js/firebase.js?v=9';
     import { writeBatch, doc, setDoc } from './js/firebase.js?v=9';
     import { renderHeader, renderFooter, getUrlParams, escapeHtml, formatDate } from './js/utils.js?v=8';
@@ -955,7 +955,7 @@ Write the match report now:`;
       try {
         if (summaryText) {
           status.textContent = 'Saving summary…';
-          const { updateGame } = await import('./js/db.js?v=12');
+          const { updateGame } = await import('./js/db.js?v=13');
           await updateGame(currentTeamId, currentGameId, { summary: summaryText });
           status.textContent = 'Summary saved!';
         }

--- a/track.html
+++ b/track.html
@@ -272,7 +272,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, collection, getDocs, deleteDoc, query } from './js/db.js';
+        import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, collection, getDocs, deleteDoc, query } from './js/db.js?v=13';
         import { db } from './js/firebase.js?v=9';
         import { writeBatch, doc, setDoc, addDoc } from './js/firebase.js?v=9';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';

--- a/track.html
+++ b/track.html
@@ -272,7 +272,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, collection, getDocs, deleteDoc, query } from './js/db.js?v=13';
+        import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, collection, getDocs, deleteDoc, query } from './js/db.js?v=14';
         import { db } from './js/firebase.js?v=9';
         import { writeBatch, doc, setDoc, addDoc } from './js/firebase.js?v=9';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';


### PR DESCRIPTION
Adds a command-palette style global search in the shared header (teams + players + actions).

Manual/Playwright:
- _temp/pw-global-search-smoke.mjs (local + prod)
- _temp/pw-check-search-coverage-all.mjs (local + prod)

Security:
- Sensitive player fields are stored in `teams/{teamId}/players/{playerId}/private/profile`.
- Public player docs (`teams/{teamId}/players/{playerId}`) reject `medicalInfo` and `emergencyContact` writes via `firestore.rules`.
- `js/db.js` guards `addPlayer()`/`updatePlayer()` to avoid accidentally writing those keys.

Notes:
- Pages not using the shared renderHeader() are unchanged (live-game + test pages).
