### PR TITLE
Feature: game schedule enhancements, RSVP flows, and calendar views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,8 @@ See `PR-TESTING-GUIDE.md` for critical flow testing and `FOUL-TRACKING-TEST-GUID
 - `track-basketball.js` - Mobile basketball tracker (primary tracker)
 - `live-tracker.js` - Live game monitoring
 - `live-game.js` - Live game viewer and replay player
+- `drill-constants.js` - Practice drill library data (categories, skill levels)
+- `global-search.js` - Cross-entity search functionality
 - `vendor/` - Firebase SDK bundles (ES Module format): app, auth, firestore, storage, ai
 
 ### Two Firebase Projects
@@ -77,6 +79,7 @@ Non-basketball games always route to `track.html`.
 /users/{userId}
 /teams/{teamId}
   /players/{playerId}
+    /private/profile         # Sensitive fields (medical, contacts) - restricted access
   /games/{gameId}
     /events/{eventId}        # Raw stat events
     /aggregatedStats/{statId}
@@ -85,6 +88,12 @@ Non-basketball games always route to `track.html`.
     /liveReactions/{reactionId}
   /statTrackerConfigs/{configId}
   /chatMessages/{messageId}  # Team-level chat
+  /practiceSessions/{sessionId}
+    /attendance/{playerId}
+    /packets/{packetId}
+      /completions/{odp}     # Parent-submitted drill completions
+  /drills/{drillId}          # Custom team drills
+/drills/{drillId}            # Community drill library
 /accessCodes/{codeId}        # Signup activation codes
 ```
 
@@ -107,15 +116,19 @@ Linked opponent fields on `games/{gameId}` (Phase 1):
 
 ## Migration Scripts
 
-The `_migration/` directory contains one-off Node.js scripts for data fixes and migrations (e.g., `migrate-parent-team-ids.js`, `fix-summary-field.js`, `delete-game.js`). These run against Firestore using a service account key. See `_migration/MIGRATION-README.md`.
+The `_migration/` directory contains one-off Node.js scripts for data fixes and migrations (e.g., `migrate-parent-team-ids.js`, `fix-summary-field.js`, `delete-game.js`). These run against Firestore using a service account key (`firebase-admin` SDK). Requires Node.js 18+. See `_migration/MIGRATION-README.md`.
 
 ## Spec-Driven Development
 
 Feature specs live in `/spec/{feature_name}/` with `requirements.md`, `design.md`, and `tasks.md`.
 
-Existing specs: `linked-opponent-teams`, `live-game-tracker`, `team-chat`, `parent-teams-dashboard-single-button`.
+Existing specs: `linked-opponent-teams`, `live-game-tracker`, `team-chat`, `parent-teams-dashboard-single-button`, `practice-drills`.
 
 Use custom commands: `/spec-init`, `/spec-execute-task`, `/spec-update`
+
+## Commit and PR Guidelines
+
+See `AGENTS.md` for commit message style (short, imperative, sentence-case) and PR requirements (bullet summary, manual test steps, screenshots for UI changes).
 
 ## Coding Conventions
 

--- a/calendar.html
+++ b/calendar.html
@@ -254,14 +254,16 @@
                     }
 
                     // Load ICS calendar events
-                    if (team.calendars && team.calendars.length > 0) {
+                    const calendarUrls = Array.isArray(team.calendarUrls) ? team.calendarUrls : [];
+                    if (calendarUrls.length > 0) {
                         const trackedUids = await getTrackedCalendarEventUids(team.id);
-                        for (const calUrl of team.calendars) {
+                        for (const calUrl of calendarUrls) {
                             try {
                                 const icsEvents = await fetchAndParseCalendar(calUrl);
                                 for (const ev of icsEvents) {
-                                    if (trackedUids.has(ev.uid)) continue;
-                                    const evDate = ev.start instanceof Date ? ev.start : new Date(ev.start);
+                                    if (trackedUids.includes(ev.uid)) continue;
+                                    const evDate = ev.dtstart instanceof Date ? ev.dtstart : new Date(ev.dtstart);
+                                    if (Number.isNaN(evDate.getTime())) continue;
                                     events.push({
                                         id: ev.uid || `ics-${evDate.getTime()}`,
                                         teamId: team.id,

--- a/calendar.html
+++ b/calendar.html
@@ -1,0 +1,653 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-3J13LHWFT3"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-3J13LHWFT3');
+  </script>
+
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Calendar - ALL PLAYS</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        primary: {
+                            50: '#eef2ff',
+                            100: '#e0e7ff',
+                            500: '#6366f1',
+                            600: '#4f46e5',
+                            700: '#4338ca',
+                            800: '#3730a3',
+                            900: '#312e81'
+                        }
+                    }
+                }
+            }
+        }
+    </script>
+    <style>
+        .cal-grid { display: grid; grid-template-columns: repeat(7, 1fr); }
+        .cal-cell { min-height: 90px; border: 1px solid #e5e7eb; padding: 4px; position: relative; }
+        .cal-cell.other-month { background: #f9fafb; color: #9ca3af; }
+        .cal-cell.today { background: #eef2ff; }
+        .cal-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin: 1px; cursor: pointer; }
+        .cal-cell:hover { background: #f3f4f6; cursor: pointer; }
+    </style>
+</head>
+
+<body class="bg-gradient-to-br from-gray-50 to-gray-100 text-gray-900">
+    <div id="header-container"></div>
+
+    <main class="container mx-auto px-4 py-8 md:py-12">
+        <!-- Page Header -->
+        <div class="mb-8">
+            <h1 class="text-3xl md:text-4xl font-bold mb-2 bg-gradient-to-r from-primary-600 to-primary-800 bg-clip-text text-transparent">Calendar</h1>
+            <p class="text-gray-600 text-sm">All your games and practices across every team.</p>
+        </div>
+
+        <!-- Filter Bar -->
+        <div class="bg-white rounded-xl shadow-md border border-gray-200 p-4 mb-6">
+            <div class="flex flex-wrap items-center gap-3">
+                <!-- View Toggle -->
+                <div class="flex rounded-lg border border-gray-200 overflow-hidden">
+                    <button id="view-detailed" onclick="setView('detailed')" class="px-3 py-1.5 text-xs font-semibold bg-primary-600 text-white">Detailed</button>
+                    <button id="view-compact" onclick="setView('compact')" class="px-3 py-1.5 text-xs font-semibold bg-white text-gray-600 hover:bg-gray-50">Compact</button>
+                    <button id="view-calendar" onclick="setView('calendar')" class="px-3 py-1.5 text-xs font-semibold bg-white text-gray-600 hover:bg-gray-50">Calendar</button>
+                </div>
+
+                <div class="w-px h-6 bg-gray-200 hidden sm:block"></div>
+
+                <!-- Time Range -->
+                <div class="flex rounded-lg border border-gray-200 overflow-hidden">
+                    <button onclick="setTimeRange('week')" class="time-range-btn px-3 py-1.5 text-xs font-semibold bg-white text-gray-600 hover:bg-gray-50">Week</button>
+                    <button onclick="setTimeRange('month')" class="time-range-btn px-3 py-1.5 text-xs font-semibold bg-primary-600 text-white">Month</button>
+                    <button onclick="setTimeRange('quarter')" class="time-range-btn px-3 py-1.5 text-xs font-semibold bg-white text-gray-600 hover:bg-gray-50">Quarter</button>
+                    <button onclick="setTimeRange('all')" class="time-range-btn px-3 py-1.5 text-xs font-semibold bg-white text-gray-600 hover:bg-gray-50">All</button>
+                </div>
+
+                <div class="w-px h-6 bg-gray-200 hidden sm:block"></div>
+
+                <!-- Event Type -->
+                <div class="flex rounded-lg border border-gray-200 overflow-hidden">
+                    <button onclick="setTypeFilter('all')" class="type-filter-btn px-3 py-1.5 text-xs font-semibold bg-primary-600 text-white">All</button>
+                    <button onclick="setTypeFilter('game')" class="type-filter-btn px-3 py-1.5 text-xs font-semibold bg-white text-gray-600 hover:bg-gray-50">Games</button>
+                    <button onclick="setTypeFilter('practice')" class="type-filter-btn px-3 py-1.5 text-xs font-semibold bg-white text-gray-600 hover:bg-gray-50">Practices</button>
+                </div>
+
+                <div class="w-px h-6 bg-gray-200 hidden sm:block"></div>
+
+                <!-- Team Filter -->
+                <select id="team-filter" onchange="applyFilters()" class="text-xs font-medium bg-white px-3 py-1.5 rounded-lg border border-gray-200 text-gray-600 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                    <option value="">All Teams</option>
+                </select>
+
+                <!-- Export -->
+                <button id="export-ics-btn" onclick="exportIcs()" class="ml-auto inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-primary-600 bg-primary-50 rounded-lg hover:bg-primary-100 transition border border-primary-200">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"></path></svg>
+                    .ics Export
+                </button>
+            </div>
+        </div>
+
+        <!-- Calendar Month Nav (only visible in calendar view) -->
+        <div id="month-nav" class="hidden mb-4 flex items-center justify-center gap-4">
+            <button onclick="navMonth(-1)" class="px-3 py-1.5 rounded-lg bg-white border border-gray-200 text-gray-600 hover:bg-gray-50 text-sm font-medium">&larr; Prev</button>
+            <span id="month-label" class="text-lg font-bold text-gray-900"></span>
+            <button onclick="navMonth(1)" class="px-3 py-1.5 rounded-lg bg-white border border-gray-200 text-gray-600 hover:bg-gray-50 text-sm font-medium">Next &rarr;</button>
+        </div>
+
+        <!-- Content Area -->
+        <div id="calendar-content" class="bg-white rounded-xl shadow-md border border-gray-200 overflow-hidden min-h-[400px]">
+            <div class="text-center py-12">
+                <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mx-auto mb-2"></div>
+                <p class="text-sm text-gray-500">Loading calendar...</p>
+            </div>
+        </div>
+    </main>
+
+    <!-- Day Detail Modal -->
+    <div id="day-modal" class="hidden fixed inset-0 z-50">
+        <div class="absolute inset-0 bg-black/50" onclick="closeDayModal()"></div>
+        <div class="absolute inset-y-0 right-0 w-full max-w-lg bg-white shadow-2xl overflow-y-auto">
+            <div class="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between z-10">
+                <h3 id="day-modal-title" class="text-lg font-bold text-gray-900"></h3>
+                <button onclick="closeDayModal()" class="text-gray-400 hover:text-gray-700">
+                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+                </button>
+            </div>
+            <div id="day-modal-content" class="px-6 py-5"></div>
+        </div>
+    </div>
+
+    <div id="footer-container"></div>
+
+    <script type="module">
+        import { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, getMyRsvp } from './js/db.js?v=20';
+        import { renderHeader, renderFooter, escapeHtml, formatDate, formatTime, fetchAndParseCalendar } from './js/utils.js?v=8';
+        import { requireAuth, checkAuth } from './js/auth.js?v=9';
+
+        renderFooter(document.getElementById('footer-container'));
+
+        let allEvents = [];
+        let filteredEvents = [];
+        let currentUser = null;
+        let currentUserId = null;
+        let currentView = 'detailed';
+        let currentTimeRange = 'month';
+        let currentTypeFilter = 'all';
+        let currentTeamFilter = '';
+        let calendarMonth = new Date().getMonth();
+        let calendarYear = new Date().getFullYear();
+        const teamColors = {};
+        const colorPalette = ['#6366f1', '#ec4899', '#f59e0b', '#10b981', '#ef4444', '#8b5cf6', '#06b6d4', '#f97316'];
+
+        window.setView = setView;
+        window.setTimeRange = setTimeRange;
+        window.setTypeFilter = setTypeFilter;
+        window.applyFilters = applyFilters;
+        window.navMonth = navMonth;
+        window.exportIcs = exportIcs;
+        window.openDayDetail = openDayDetail;
+        window.closeDayModal = closeDayModal;
+        window.submitCalendarRsvp = submitCalendarRsvp;
+
+        function renderRsvpBlock(ev, compact = false) {
+            if (ev.type !== 'game' || ev.status === 'cancelled') return '';
+            const summary = ev.rsvpSummary
+                ? `${ev.rsvpSummary.going || 0} going · ${ev.rsvpSummary.maybe || 0} maybe · ${ev.rsvpSummary.notGoing || 0} can't go`
+                : 'No RSVPs yet.';
+            if (ev.source !== 'db') {
+                return compact
+                    ? `<span class="text-[10px] text-gray-400">RSVP after tracking game</span>`
+                    : `<div class="mt-1 text-xs text-gray-400">RSVP opens after this event is tracked as a game.</div><div class="mt-1 text-xs text-gray-400">${summary}</div>`;
+            }
+            if (compact) {
+                return `<span class="text-[10px] text-gray-500">${summary}</span>`;
+            }
+            return `
+                <div class="mt-3 border-t border-gray-100 pt-3">
+                    <div class="text-[11px] font-bold uppercase tracking-wide text-gray-500 mb-2">RSVP</div>
+                    <div class="flex gap-2">
+                        <button onclick="submitCalendarRsvp('${ev.teamId}', '${ev.id}', 'going')" class="rsvp-btn rsvp-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'going' ? 'bg-green-600 text-white border-green-600' : 'bg-white text-green-700 border-green-300 hover:bg-green-50'}">Going</button>
+                        <button onclick="submitCalendarRsvp('${ev.teamId}', '${ev.id}', 'maybe')" class="rsvp-btn rsvp-maybe flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'maybe' ? 'bg-yellow-500 text-white border-yellow-500' : 'bg-white text-yellow-700 border-yellow-300 hover:bg-yellow-50'}">Maybe</button>
+                        <button onclick="submitCalendarRsvp('${ev.teamId}', '${ev.id}', 'not_going')" class="rsvp-btn rsvp-not-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'not_going' ? 'bg-red-500 text-white border-red-500' : 'bg-white text-red-700 border-red-300 hover:bg-red-50'}">Can't Go</button>
+                    </div>
+                    <div class="mt-1 text-xs text-gray-500">${summary}</div>
+                </div>
+            `;
+        }
+
+        async function init() {
+            try {
+                const user = await requireAuth();
+                currentUser = user;
+                currentUserId = user.uid;
+                checkAuth((u) => renderHeader(document.getElementById('header-container'), u));
+
+                const profile = await getUserProfile(user.uid);
+                const email = user.email || profile?.email;
+
+                // Load all teams the user has access to (coach + parent)
+                const [coachTeams, parentTeams] = await Promise.all([
+                    getUserTeamsWithAccess(user.uid, email),
+                    getParentTeams(user.uid)
+                ]);
+
+                const teamsMap = new Map();
+                [...coachTeams, ...parentTeams].forEach(t => teamsMap.set(t.id, t));
+                const teams = Array.from(teamsMap.values());
+
+                // Assign colors to teams
+                teams.forEach((team, i) => {
+                    teamColors[team.id] = colorPalette[i % colorPalette.length];
+                });
+
+                // Populate team filter
+                const teamFilter = document.getElementById('team-filter');
+                teams.forEach(team => {
+                    const opt = document.createElement('option');
+                    opt.value = team.id;
+                    opt.textContent = team.name;
+                    teamFilter.appendChild(opt);
+                });
+
+                // Load events from all teams
+                const loadPromises = teams.map(async (team) => {
+                    const games = await getGames(team.id);
+                    const events = [];
+
+                    for (const game of games) {
+                        const date = game.date?.toDate ? game.date.toDate() : new Date(game.date);
+                        events.push({
+                            id: game.id,
+                            teamId: team.id,
+                            teamName: team.name,
+                            teamColor: teamColors[team.id],
+                            type: game.type || 'game',
+                            title: game.type === 'practice' ? (game.title || 'Practice') : `vs. ${game.opponent || 'TBD'}`,
+                            date,
+                            location: game.location || 'TBD',
+                            status: game.status,
+                            isHome: game.isHome,
+                            kitColor: game.kitColor,
+                            arrivalTime: game.arrivalTime,
+                            notes: game.notes,
+                            assignments: game.assignments,
+                            rsvpSummary: game.rsvpSummary,
+                            homeScore: game.homeScore,
+                            awayScore: game.awayScore,
+                            liveStatus: game.liveStatus,
+                            myRsvp: null,
+                            source: 'db'
+                        });
+                    }
+
+                    // Load ICS calendar events
+                    if (team.calendars && team.calendars.length > 0) {
+                        const trackedUids = await getTrackedCalendarEventUids(team.id);
+                        for (const calUrl of team.calendars) {
+                            try {
+                                const icsEvents = await fetchAndParseCalendar(calUrl);
+                                for (const ev of icsEvents) {
+                                    if (trackedUids.has(ev.uid)) continue;
+                                    const evDate = ev.start instanceof Date ? ev.start : new Date(ev.start);
+                                    events.push({
+                                        id: ev.uid || `ics-${evDate.getTime()}`,
+                                        teamId: team.id,
+                                        teamName: team.name,
+                                        teamColor: teamColors[team.id],
+                                        type: ev.isPractice ? 'practice' : 'game',
+                                        title: ev.summary || 'Event',
+                                        date: evDate,
+                                        location: ev.location || 'TBD',
+                                        status: 'scheduled',
+                                        source: 'ics'
+                                    });
+                                }
+                            } catch (e) {
+                                console.warn('Failed to load ICS calendar:', e);
+                            }
+                        }
+                    }
+
+                    return events;
+                });
+
+                const results = await Promise.all(loadPromises);
+                allEvents = results.flat().sort((a, b) => a.date - b.date);
+
+                // Fetch current user's RSVP for DB games.
+                const dbGames = allEvents.filter(ev => ev.source === 'db' && ev.type === 'game' && ev.status !== 'cancelled');
+                const uniqueGameKeys = [...new Set(dbGames.map(ev => `${ev.teamId}::${ev.id}`))];
+                await Promise.all(uniqueGameKeys.map(async (key) => {
+                    const [teamId, gameId] = key.split('::');
+                    try {
+                        const myRsvp = await getMyRsvp(teamId, gameId, currentUserId);
+                        if (myRsvp?.response) {
+                            allEvents.forEach(ev => {
+                                if (ev.teamId === teamId && ev.id === gameId) ev.myRsvp = myRsvp.response;
+                            });
+                        }
+                    } catch (_) {}
+                }));
+
+                applyFilters();
+            } catch (error) {
+                console.error('Calendar init error:', error);
+                document.getElementById('calendar-content').innerHTML = `<div class="text-center py-12 text-red-600">Error loading calendar: ${error.message}</div>`;
+            }
+        }
+
+        function applyFilters() {
+            const now = new Date();
+            let rangeStart, rangeEnd;
+
+            if (currentTimeRange === 'week') {
+                rangeStart = new Date(now);
+                rangeStart.setDate(rangeStart.getDate() - rangeStart.getDay());
+                rangeEnd = new Date(rangeStart);
+                rangeEnd.setDate(rangeEnd.getDate() + 7);
+            } else if (currentTimeRange === 'month') {
+                rangeStart = new Date(now.getFullYear(), now.getMonth(), 1);
+                rangeEnd = new Date(now.getFullYear(), now.getMonth() + 1, 0, 23, 59, 59);
+            } else if (currentTimeRange === 'quarter') {
+                rangeStart = new Date(now);
+                rangeStart.setDate(rangeStart.getDate() - 30);
+                rangeEnd = new Date(now);
+                rangeEnd.setDate(rangeEnd.getDate() + 90);
+            } else {
+                rangeStart = new Date(0);
+                rangeEnd = new Date(9999, 11, 31);
+            }
+
+            currentTeamFilter = document.getElementById('team-filter').value;
+
+            filteredEvents = allEvents.filter(ev => {
+                if (currentTimeRange !== 'all' && currentView !== 'calendar') {
+                    if (ev.date < rangeStart || ev.date > rangeEnd) return false;
+                }
+                if (currentTypeFilter !== 'all' && ev.type !== currentTypeFilter) return false;
+                if (currentTeamFilter && ev.teamId !== currentTeamFilter) return false;
+                return true;
+            });
+
+            render();
+        }
+
+        function render() {
+            if (currentView === 'detailed') renderDetailed();
+            else if (currentView === 'compact') renderCompact();
+            else if (currentView === 'calendar') renderCalendarGrid();
+
+            document.getElementById('month-nav').classList.toggle('hidden', currentView !== 'calendar');
+        }
+
+        // ===== DETAILED LIST VIEW =====
+        function renderDetailed() {
+            const container = document.getElementById('calendar-content');
+            if (filteredEvents.length === 0) {
+                container.innerHTML = '<div class="text-center py-12 text-gray-500">No events found for this filter.</div>';
+                return;
+            }
+
+            container.innerHTML = '<div class="divide-y divide-gray-100">' + filteredEvents.map(ev => {
+                const isCancelled = ev.status === 'cancelled';
+                const dateStr = ev.date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+                const timeStr = ev.date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+                const typeColor = ev.type === 'practice' ? 'bg-amber-100 text-amber-800' : 'bg-primary-100 text-primary-800';
+
+                return `
+                <div class="p-5 hover:bg-gray-50 transition ${isCancelled ? 'opacity-60' : ''}">
+                    <div class="flex flex-col sm:flex-row gap-4 sm:items-start">
+                        <div class="flex-shrink-0 w-24">
+                            <div class="text-sm font-bold text-gray-900 ${isCancelled ? 'line-through' : ''}">${dateStr}</div>
+                            <div class="text-xs text-gray-500 ${isCancelled ? 'line-through' : ''}">${timeStr}</div>
+                        </div>
+                        <div class="flex-grow">
+                            <div class="flex items-center gap-2 mb-1">
+                                <span class="inline-block px-2 py-0.5 rounded text-xs font-bold uppercase tracking-wide ${typeColor}">${ev.type === 'practice' ? 'Practice' : 'Game'}</span>
+                                <span class="text-xs font-medium px-2 py-0.5 rounded-full" style="background: ${ev.teamColor}20; color: ${ev.teamColor}">${escapeHtml(ev.teamName)}</span>
+                                ${isCancelled ? '<span class="px-2 py-0.5 rounded text-xs font-bold bg-red-100 text-red-800">CANCELLED</span>' : ''}
+                                ${ev.isHome === true ? '<span class="text-xs bg-blue-100 text-blue-800 px-2 py-0.5 rounded-full font-semibold">HOME</span>' : ''}
+                                ${ev.isHome === false ? '<span class="text-xs bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full font-semibold">AWAY</span>' : ''}
+                                ${ev.kitColor ? `<span class="text-xs bg-purple-100 text-purple-800 px-2 py-0.5 rounded-full font-semibold">${escapeHtml(ev.kitColor)}</span>` : ''}
+                            </div>
+                            <div class="font-bold text-gray-900 text-lg ${isCancelled ? 'line-through' : ''}">${escapeHtml(ev.title)}</div>
+                            <div class="text-sm text-gray-500 mt-1">
+                                <svg class="w-4 h-4 inline mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"></path><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"></path></svg>
+                                ${escapeHtml(ev.location)}
+                            </div>
+                            ${ev.arrivalTime ? `<div class="text-xs text-amber-700 mt-1">Arrive: ${(() => { const at = ev.arrivalTime?.toDate ? ev.arrivalTime.toDate() : new Date(ev.arrivalTime); return at.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }); })()}</div>` : ''}
+                            ${ev.notes ? `<div class="text-xs text-gray-500 mt-1 italic">${escapeHtml(ev.notes)}</div>` : ''}
+                            ${ev.assignments && ev.assignments.length > 0 ? `<div class="mt-1 flex flex-wrap gap-1">${ev.assignments.map(a => `<span class="text-xs bg-gray-100 rounded px-2 py-0.5"><b>${escapeHtml(a.role)}:</b> ${escapeHtml(a.value || 'TBD')}</span>`).join('')}</div>` : ''}
+                            ${renderRsvpBlock(ev)}
+                        </div>
+                    </div>
+                </div>`;
+            }).join('') + '</div>';
+        }
+
+        // ===== COMPACT LIST VIEW =====
+        function renderCompact() {
+            const container = document.getElementById('calendar-content');
+            if (filteredEvents.length === 0) {
+                container.innerHTML = '<div class="text-center py-12 text-gray-500">No events found.</div>';
+                return;
+            }
+
+            container.innerHTML = '<div class="divide-y divide-gray-100">' + filteredEvents.map(ev => {
+                const isCancelled = ev.status === 'cancelled';
+                const dateStr = ev.date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+                const timeStr = ev.date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+                return `
+                <div class="px-5 py-3 flex items-center gap-3 hover:bg-gray-50 ${isCancelled ? 'opacity-50' : ''}">
+                    <div class="w-3 h-3 rounded-full flex-shrink-0" style="background: ${ev.teamColor}"></div>
+                    <div class="text-xs text-gray-500 w-28 flex-shrink-0 font-medium">${dateStr} ${timeStr}</div>
+                    <span class="text-xs font-bold uppercase ${ev.type === 'practice' ? 'text-amber-700' : 'text-primary-700'} w-16 flex-shrink-0">${ev.type === 'practice' ? 'Prac' : 'Game'}</span>
+                    <div class="text-sm font-medium text-gray-900 truncate flex-grow ${isCancelled ? 'line-through' : ''}">${escapeHtml(ev.title)}</div>
+                    <div class="text-xs text-gray-500 truncate max-w-[150px] hidden sm:block">${escapeHtml(ev.teamName)}</div>
+                    ${renderRsvpBlock(ev, true)}
+                    ${ev.isHome === true ? '<span class="text-[10px] bg-blue-100 text-blue-800 px-1.5 py-0.5 rounded font-bold">H</span>' : ''}
+                    ${ev.isHome === false ? '<span class="text-[10px] bg-gray-100 text-gray-600 px-1.5 py-0.5 rounded font-bold">A</span>' : ''}
+                </div>`;
+            }).join('') + '</div>';
+        }
+
+        // ===== CALENDAR GRID VIEW =====
+        function renderCalendarGrid() {
+            const container = document.getElementById('calendar-content');
+            const label = document.getElementById('month-label');
+            const monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+            label.textContent = `${monthNames[calendarMonth]} ${calendarYear}`;
+
+            const firstDay = new Date(calendarYear, calendarMonth, 1);
+            const lastDay = new Date(calendarYear, calendarMonth + 1, 0);
+            const startDow = firstDay.getDay();
+            const daysInMonth = lastDay.getDate();
+
+            // Get events for this month
+            const monthStart = new Date(calendarYear, calendarMonth, 1);
+            const monthEnd = new Date(calendarYear, calendarMonth + 1, 0, 23, 59, 59);
+            const monthEvents = allEvents.filter(ev => {
+                if (currentTypeFilter !== 'all' && ev.type !== currentTypeFilter) return false;
+                if (currentTeamFilter && ev.teamId !== currentTeamFilter) return false;
+                return ev.date >= monthStart && ev.date <= monthEnd;
+            });
+
+            // Group events by day
+            const eventsByDay = {};
+            monthEvents.forEach(ev => {
+                const day = ev.date.getDate();
+                if (!eventsByDay[day]) eventsByDay[day] = [];
+                eventsByDay[day].push(ev);
+            });
+
+            const today = new Date();
+            const isCurrentMonth = today.getMonth() === calendarMonth && today.getFullYear() === calendarYear;
+
+            // Day headers
+            let html = '<div class="cal-grid bg-gray-50 border-b border-gray-200">';
+            ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].forEach(d => {
+                html += `<div class="text-center text-xs font-bold text-gray-500 py-2">${d}</div>`;
+            });
+            html += '</div>';
+
+            // Calendar cells
+            html += '<div class="cal-grid">';
+            const totalCells = Math.ceil((startDow + daysInMonth) / 7) * 7;
+
+            for (let i = 0; i < totalCells; i++) {
+                const dayNum = i - startDow + 1;
+                const inMonth = dayNum >= 1 && dayNum <= daysInMonth;
+                const isToday = isCurrentMonth && inMonth && dayNum === today.getDate();
+                const dayEvents = inMonth ? (eventsByDay[dayNum] || []) : [];
+
+                html += `<div class="cal-cell ${inMonth ? '' : 'other-month'} ${isToday ? 'today' : ''}" ${inMonth && dayEvents.length > 0 ? `onclick="openDayDetail(${calendarYear}, ${calendarMonth}, ${dayNum})"` : ''}>`;
+                if (inMonth) {
+                    html += `<div class="text-xs font-medium ${isToday ? 'text-primary-700 font-bold' : 'text-gray-700'} mb-1">${dayNum}</div>`;
+                    html += '<div class="flex flex-wrap">';
+                    dayEvents.slice(0, 6).forEach(ev => {
+                        html += `<span class="cal-dot" style="background: ${ev.teamColor}" title="${escapeHtml(ev.title)}"></span>`;
+                    });
+                    if (dayEvents.length > 6) {
+                        html += `<span class="text-[9px] text-gray-400">+${dayEvents.length - 6}</span>`;
+                    }
+                    html += '</div>';
+                    // Show first event title on larger screens
+                    if (dayEvents.length > 0) {
+                        html += `<div class="hidden md:block text-[10px] text-gray-600 truncate mt-0.5">${escapeHtml(dayEvents[0].title)}</div>`;
+                    }
+                }
+                html += '</div>';
+            }
+            html += '</div>';
+
+            container.innerHTML = html;
+        }
+
+        function openDayDetail(year, month, day) {
+            const dayStart = new Date(year, month, day);
+            const dayEnd = new Date(year, month, day, 23, 59, 59);
+            const dayEvents = allEvents.filter(ev => {
+                if (currentTypeFilter !== 'all' && ev.type !== currentTypeFilter) return false;
+                if (currentTeamFilter && ev.teamId !== currentTeamFilter) return false;
+                return ev.date >= dayStart && ev.date <= dayEnd;
+            });
+
+            const modal = document.getElementById('day-modal');
+            const title = document.getElementById('day-modal-title');
+            const content = document.getElementById('day-modal-content');
+
+            title.textContent = dayStart.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
+
+            if (dayEvents.length === 0) {
+                content.innerHTML = '<p class="text-gray-500 text-center py-8">No events on this day.</p>';
+            } else {
+                content.innerHTML = dayEvents.map(ev => {
+                    const timeStr = ev.date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+                    const isCancelled = ev.status === 'cancelled';
+                    return `
+                    <div class="mb-4 p-4 rounded-lg border border-gray-200 ${isCancelled ? 'opacity-60' : ''}">
+                        <div class="flex items-center gap-2 mb-2">
+                            <div class="w-3 h-3 rounded-full" style="background: ${ev.teamColor}"></div>
+                            <span class="text-xs font-semibold text-gray-500">${escapeHtml(ev.teamName)}</span>
+                            <span class="text-xs font-bold uppercase ${ev.type === 'practice' ? 'text-amber-700' : 'text-primary-700'}">${ev.type}</span>
+                            ${isCancelled ? '<span class="text-xs font-bold text-red-700 bg-red-100 px-2 py-0.5 rounded">CANCELLED</span>' : ''}
+                        </div>
+                        <div class="font-bold text-gray-900 ${isCancelled ? 'line-through' : ''}">${escapeHtml(ev.title)}</div>
+                        <div class="text-sm text-gray-600 mt-1">${timeStr} · ${escapeHtml(ev.location)}</div>
+                        ${ev.isHome === true ? '<span class="text-xs bg-blue-100 text-blue-800 px-2 py-0.5 rounded-full font-semibold mr-1">HOME</span>' : ''}
+                        ${ev.isHome === false ? '<span class="text-xs bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full font-semibold mr-1">AWAY</span>' : ''}
+                        ${ev.kitColor ? `<span class="text-xs bg-purple-100 text-purple-800 px-2 py-0.5 rounded-full font-semibold">${escapeHtml(ev.kitColor)}</span>` : ''}
+                        ${ev.arrivalTime ? `<div class="text-xs text-amber-700 mt-1">Arrive: ${(() => { const at = ev.arrivalTime?.toDate ? ev.arrivalTime.toDate() : new Date(ev.arrivalTime); return at.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }); })()}</div>` : ''}
+                        ${ev.notes ? `<div class="text-xs text-gray-500 mt-1 italic">${escapeHtml(ev.notes)}</div>` : ''}
+                        ${ev.assignments && ev.assignments.length > 0 ? `<div class="mt-1 flex flex-wrap gap-1">${ev.assignments.map(a => `<span class="text-xs bg-gray-100 rounded px-2 py-0.5"><b>${escapeHtml(a.role)}:</b> ${escapeHtml(a.value || 'TBD')}</span>`).join('')}</div>` : ''}
+                        ${renderRsvpBlock(ev)}
+                    </div>`;
+                }).join('');
+            }
+
+            modal.classList.remove('hidden');
+        }
+
+        function closeDayModal() {
+            document.getElementById('day-modal').classList.add('hidden');
+        }
+
+        async function submitCalendarRsvp(teamId, gameId, response) {
+            try {
+                const summary = await submitRsvp(teamId, gameId, currentUserId, {
+                    displayName: currentUser?.displayName || currentUser?.email || null,
+                    playerIds: [],
+                    response
+                });
+                allEvents.forEach(ev => {
+                    if (ev.teamId === teamId && ev.id === gameId) {
+                        ev.myRsvp = response;
+                        if (summary) ev.rsvpSummary = summary;
+                    }
+                });
+                applyFilters();
+                if (currentView === 'calendar') {
+                    // Keep day modal content fresh for current selection
+                    const title = document.getElementById('day-modal-title')?.textContent;
+                    if (title && !document.getElementById('day-modal')?.classList.contains('hidden')) {
+                        // No-op: user can click date again; avoid parsing locale title.
+                    }
+                }
+            } catch (err) {
+                alert('Failed to submit RSVP: ' + (err?.message || err));
+            }
+        }
+
+        // ===== FILTER HELPERS =====
+        function setView(view) {
+            currentView = view;
+            document.querySelectorAll('#view-detailed, #view-compact, #view-calendar').forEach(btn => {
+                btn.className = btn.id === `view-${view}`
+                    ? 'px-3 py-1.5 text-xs font-semibold bg-primary-600 text-white'
+                    : 'px-3 py-1.5 text-xs font-semibold bg-white text-gray-600 hover:bg-gray-50';
+            });
+            applyFilters();
+        }
+
+        function setTimeRange(range) {
+            currentTimeRange = range;
+            document.querySelectorAll('.time-range-btn').forEach(btn => {
+                const isActive = btn.textContent.trim().toLowerCase() === range;
+                btn.className = `time-range-btn px-3 py-1.5 text-xs font-semibold ${isActive ? 'bg-primary-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`;
+            });
+            applyFilters();
+        }
+
+        function setTypeFilter(type) {
+            currentTypeFilter = type;
+            document.querySelectorAll('.type-filter-btn').forEach(btn => {
+                const label = btn.textContent.trim().toLowerCase();
+                const btnType = label === 'games' ? 'game' : (label === 'practices' ? 'practice' : 'all');
+                btn.className = `type-filter-btn px-3 py-1.5 text-xs font-semibold ${btnType === type ? 'bg-primary-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-50'}`;
+            });
+            applyFilters();
+        }
+
+        function navMonth(delta) {
+            calendarMonth += delta;
+            if (calendarMonth > 11) { calendarMonth = 0; calendarYear++; }
+            if (calendarMonth < 0) { calendarMonth = 11; calendarYear--; }
+            render();
+        }
+
+        // ===== ICS EXPORT =====
+        function exportIcs() {
+            if (filteredEvents.length === 0) {
+                alert('No events to export.');
+                return;
+            }
+
+            const lines = ['BEGIN:VCALENDAR', 'VERSION:2.0', 'PRODID:-//ALL PLAYS//EN'];
+            const pad = (n) => String(n).padStart(2, '0');
+            const fmtDate = (d) => `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}T${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}Z`;
+
+            const seen = new Set();
+            filteredEvents.forEach(ev => {
+                const dedupeKey = `${ev.teamId || ''}::${ev.id || ''}::${ev.date?.getTime?.() || ''}::${ev.type || ''}`;
+                if (seen.has(dedupeKey)) return;
+                seen.add(dedupeKey);
+                const start = fmtDate(ev.date);
+                const end = fmtDate(new Date(ev.date.getTime() + 60 * 60 * 1000));
+                lines.push(
+                    'BEGIN:VEVENT',
+                    `UID:${dedupeKey}@allplays`,
+                    `DTSTAMP:${fmtDate(new Date())}`,
+                    `DTSTART:${start}`,
+                    `DTEND:${end}`,
+                    `SUMMARY:${ev.teamName} - ${ev.title}`,
+                    `LOCATION:${(ev.location || '').replace(/,/g, '\\,')}`,
+                    'END:VEVENT'
+                );
+            });
+            lines.push('END:VCALENDAR');
+
+            const blob = new Blob([lines.join('\r\n')], { type: 'text/calendar' });
+            const a = document.createElement('a');
+            a.href = URL.createObjectURL(blob);
+            a.download = 'allplays-calendar.ics';
+            a.click();
+            URL.revokeObjectURL(a.href);
+        }
+
+        init();
+    </script>
+</body>
+</html>

--- a/calendar.html
+++ b/calendar.html
@@ -161,6 +161,16 @@
         window.openDayDetail = openDayDetail;
         window.closeDayModal = closeDayModal;
         window.submitCalendarRsvp = submitCalendarRsvp;
+        window.submitCalendarRsvpFromButton = submitCalendarRsvpFromButton;
+
+        function escapeAttr(value) {
+            return String(value ?? '')
+                .replace(/&/g, '&amp;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;');
+        }
 
         function renderRsvpBlock(ev, compact = false) {
             if (ev.type !== 'game' || ev.status === 'cancelled') return '';
@@ -179,13 +189,20 @@
                 <div class="mt-3 border-t border-gray-100 pt-3">
                     <div class="text-[11px] font-bold uppercase tracking-wide text-gray-500 mb-2">RSVP</div>
                     <div class="flex gap-2">
-                        <button onclick="submitCalendarRsvp('${ev.teamId}', '${ev.id}', 'going')" class="rsvp-btn rsvp-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'going' ? 'bg-green-600 text-white border-green-600' : 'bg-white text-green-700 border-green-300 hover:bg-green-50'}">Going</button>
-                        <button onclick="submitCalendarRsvp('${ev.teamId}', '${ev.id}', 'maybe')" class="rsvp-btn rsvp-maybe flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'maybe' ? 'bg-yellow-500 text-white border-yellow-500' : 'bg-white text-yellow-700 border-yellow-300 hover:bg-yellow-50'}">Maybe</button>
-                        <button onclick="submitCalendarRsvp('${ev.teamId}', '${ev.id}', 'not_going')" class="rsvp-btn rsvp-not-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'not_going' ? 'bg-red-500 text-white border-red-500' : 'bg-white text-red-700 border-red-300 hover:bg-red-50'}">Can't Go</button>
+                        <button data-team-id="${escapeAttr(ev.teamId)}" data-game-id="${escapeAttr(ev.id)}" onclick="submitCalendarRsvpFromButton(this, 'going')" class="rsvp-btn rsvp-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'going' ? 'bg-green-600 text-white border-green-600' : 'bg-white text-green-700 border-green-300 hover:bg-green-50'}">Going</button>
+                        <button data-team-id="${escapeAttr(ev.teamId)}" data-game-id="${escapeAttr(ev.id)}" onclick="submitCalendarRsvpFromButton(this, 'maybe')" class="rsvp-btn rsvp-maybe flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'maybe' ? 'bg-yellow-500 text-white border-yellow-500' : 'bg-white text-yellow-700 border-yellow-300 hover:bg-yellow-50'}">Maybe</button>
+                        <button data-team-id="${escapeAttr(ev.teamId)}" data-game-id="${escapeAttr(ev.id)}" onclick="submitCalendarRsvpFromButton(this, 'not_going')" class="rsvp-btn rsvp-not-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'not_going' ? 'bg-red-500 text-white border-red-500' : 'bg-white text-red-700 border-red-300 hover:bg-red-50'}">Can't Go</button>
                     </div>
                     <div class="mt-1 text-xs text-gray-500">${summary}</div>
                 </div>
             `;
+        }
+
+        function submitCalendarRsvpFromButton(btn, response) {
+            const teamId = btn?.dataset?.teamId || '';
+            const gameId = btn?.dataset?.gameId || '';
+            if (!teamId || !gameId) return;
+            submitCalendarRsvp(teamId, gameId, response);
         }
 
         async function init() {
@@ -620,6 +637,11 @@
             const lines = ['BEGIN:VCALENDAR', 'VERSION:2.0', 'PRODID:-//ALL PLAYS//EN'];
             const pad = (n) => String(n).padStart(2, '0');
             const fmtDate = (d) => `${d.getUTCFullYear()}${pad(d.getUTCMonth() + 1)}${pad(d.getUTCDate())}T${pad(d.getUTCHours())}${pad(d.getUTCMinutes())}${pad(d.getUTCSeconds())}Z`;
+            const escapeIcsText = (value) => String(value || '')
+                .replace(/\\/g, '\\\\')
+                .replace(/;/g, '\\;')
+                .replace(/,/g, '\\,')
+                .replace(/\r?\n/g, '\\n');
 
             const seen = new Set();
             filteredEvents.forEach(ev => {
@@ -634,8 +656,8 @@
                     `DTSTAMP:${fmtDate(new Date())}`,
                     `DTSTART:${start}`,
                     `DTEND:${end}`,
-                    `SUMMARY:${ev.teamName} - ${ev.title}`,
-                    `LOCATION:${(ev.location || '').replace(/,/g, '\\,')}`,
+                    `SUMMARY:${escapeIcsText(`${ev.teamName} - ${ev.title}`)}`,
+                    `LOCATION:${escapeIcsText(ev.location || '')}`,
                     'END:VEVENT'
                 );
             });

--- a/dashboard.html
+++ b/dashboard.html
@@ -50,6 +50,12 @@
                     <h1 class="text-3xl md:text-4xl lg:text-5xl font-bold mb-2 bg-gradient-to-r from-primary-600 to-primary-800 bg-clip-text text-transparent">My Teams</h1>
                     <p class="text-gray-600 text-sm md:text-base">Manage your teams, rosters, schedules, and stats all in one place.</p>
                 </div>
+                <div class="flex gap-3">
+                    <a href="calendar.html"
+                        class="inline-flex items-center gap-2 bg-white text-primary-600 px-4 py-3 rounded-xl border border-primary-200 hover:bg-primary-50 transition font-semibold text-sm">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+                        Calendar
+                    </a>
                 <a href="edit-team.html"
                     class="w-full sm:w-auto inline-flex items-center justify-center gap-2 bg-gradient-to-r from-primary-600 to-primary-700 text-white px-6 py-3 rounded-xl hover:from-primary-700 hover:to-primary-800 transition shadow-lg hover:shadow-xl font-semibold">
                     <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -57,6 +63,7 @@
                     </svg>
                     Create New Team
                 </a>
+                </div>
             </div>
         </div>
 

--- a/drills.html
+++ b/drills.html
@@ -2239,18 +2239,19 @@ ${JSON.stringify({
 
         function removeChildBlock(structureIndex, childIndex) {
             const structure = state.canvasBlocks[structureIndex];
-            if (!structure || !structure.children) return;
-            const [child] = structure.children.splice(childIndex, 1);
-            // Move child back to top level right after the structure
-            state.canvasBlocks.splice(structureIndex + 1, 0, child);
+            if (!structure || structure.blockType !== 'structure') return;
+            const children = getStructureChildren(structure);
+            const [child] = children.splice(childIndex, 1);
+            if (!child) return;
             renderCanvas();
-            showToast(`Moved "${child.drillTitle}" out of structure block`);
+            showToast(`Removed "${child.drillTitle}" from structure block`);
         }
 
         function updateStructureChildDuration(structureIndex, childIndex, value) {
             const structure = state.canvasBlocks[structureIndex];
-            if (!structure || !Array.isArray(structure.children)) return;
-            const child = structure.children[childIndex];
+            if (!structure || structure.blockType !== 'structure') return;
+            const children = getStructureChildren(structure);
+            const child = children[childIndex];
             if (!child) return;
             const next = Math.max(1, parseInt(value, 10) || 1);
             child.duration = next;
@@ -2259,8 +2260,9 @@ ${JSON.stringify({
 
         function updateStructureChildNote(structureIndex, childIndex, value) {
             const structure = state.canvasBlocks[structureIndex];
-            if (!structure || !Array.isArray(structure.children)) return;
-            const child = structure.children[childIndex];
+            if (!structure || structure.blockType !== 'structure') return;
+            const children = getStructureChildren(structure);
+            const child = children[childIndex];
             if (!child) return;
             child.notes = (value || '').trim();
             renderCanvas();

--- a/drills.html
+++ b/drills.html
@@ -62,6 +62,34 @@
         .attendance-btn.active-present { background: #14532d; border-color: #22c55e; color: #bbf7d0; }
         .attendance-btn.active-late { background: #78350f; border-color: #f59e0b; color: #fde68a; }
         .attendance-btn.active-absent { background: #7f1d1d; border-color: #ef4444; color: #fecaca; }
+        /* Structure block styles */
+        .structure-warmup { border-color: #86efac; background: #f0fdf4; }
+        .structure-stations { border-color: #93c5fd; background: #eff6ff; }
+        .structure-scrimmage { border-color: #fca5a5; background: #fef2f2; }
+        .structure-cooldown { border-color: #c4b5fd; background: #f5f3ff; }
+        .structure-custom { border-color: #fde68a; background: #fffbeb; }
+        .structure-bar-warmup { background: #22c55e; }
+        .structure-bar-stations { background: #3b82f6; }
+        .structure-bar-scrimmage { background: #ef4444; }
+        .structure-bar-cooldown { background: #8b5cf6; }
+        .structure-bar-custom { background: #f59e0b; }
+        .canvas-edit-panel { max-height: 0; overflow: hidden; transition: max-height 0.3s ease; }
+        .canvas-edit-panel.open { max-height: 400px; }
+        .structure-children { min-height: 40px; border: 2px dashed #d1d5db; border-radius: 8px; padding: 8px; }
+        .structure-children.drag-over { border-color: #6366f1; background: rgba(99,102,241,0.05); }
+        .drag-handle { cursor: grab; }
+        .drag-handle:active { cursor: grabbing; }
+        .timeline-drop-zone {
+            height: 14px;
+            border-radius: 9999px;
+            margin: 2px 6px;
+            transition: all 120ms ease;
+        }
+        .timeline-drop-zone.active {
+            height: 14px;
+            background: rgba(59, 130, 246, 0.15);
+            box-shadow: inset 0 0 0 2px rgba(59, 130, 246, 0.45);
+        }
     </style>
 </head>
 
@@ -188,6 +216,30 @@
                                 Home Packet
                             </button>
                         </div>
+                    </div>
+                    <!-- Canvas action buttons -->
+                    <div class="flex items-center gap-2 mb-3 flex-wrap">
+                        <div class="relative">
+                            <button onclick="toggleStructurePicker()" class="px-2.5 py-1.5 text-xs font-medium rounded-lg bg-indigo-50 text-indigo-700 border border-indigo-200 hover:bg-indigo-100 flex items-center gap-1">
+                                <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"/></svg>
+                                Structure Block
+                            </button>
+                            <div id="structure-picker" class="hidden absolute left-0 top-full mt-1 z-20 bg-white border border-gray-200 rounded-lg shadow-lg py-1 min-w-[160px]">
+                                <button onclick="addStructureBlock('warmup')" class="w-full text-left px-3 py-2 text-xs hover:bg-green-50 flex items-center gap-2"><span class="w-2 h-2 rounded-full bg-green-500"></span> Warm-up</button>
+                                <button onclick="addStructureBlock('stations')" class="w-full text-left px-3 py-2 text-xs hover:bg-blue-50 flex items-center gap-2"><span class="w-2 h-2 rounded-full bg-blue-500"></span> Stations</button>
+                                <button onclick="addStructureBlock('scrimmage')" class="w-full text-left px-3 py-2 text-xs hover:bg-red-50 flex items-center gap-2"><span class="w-2 h-2 rounded-full bg-red-500"></span> Scrimmage</button>
+                                <button onclick="addStructureBlock('cooldown')" class="w-full text-left px-3 py-2 text-xs hover:bg-purple-50 flex items-center gap-2"><span class="w-2 h-2 rounded-full bg-purple-500"></span> Cool-down</button>
+                                <button onclick="addStructureBlock('custom')" class="w-full text-left px-3 py-2 text-xs hover:bg-amber-50 flex items-center gap-2"><span class="w-2 h-2 rounded-full bg-amber-500"></span> Custom</button>
+                            </div>
+                        </div>
+                        <button onclick="saveAsTemplate()" class="px-2.5 py-1.5 text-xs font-medium rounded-lg bg-white text-gray-600 border border-gray-200 hover:bg-gray-50 flex items-center gap-1">
+                            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7H5a2 2 0 00-2 2v9a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2h-3m-1 4l-3 3m0 0l-3-3m3 3V4"/></svg>
+                            Save Template
+                        </button>
+                        <button onclick="openTemplateLoader()" class="px-2.5 py-1.5 text-xs font-medium rounded-lg bg-white text-gray-600 border border-gray-200 hover:bg-gray-50 flex items-center gap-1">
+                            <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-8l-4-4m0 0L8 8m4-4v12"/></svg>
+                            Load Template
+                        </button>
                     </div>
                     <div id="canvas-blocks" class="space-y-3">
                         <p id="canvas-empty" class="text-sm text-gray-400 text-center py-8">No drills added yet. Browse the library or ask the AI Coach to build a plan.</p>
@@ -436,6 +488,20 @@
                             <label class="block text-sm font-medium text-gray-700 mb-1">Instructions</label>
                             <textarea id="form-drill-instructions" rows="6" placeholder="Setup, exercise, progressions, coaching points..." class="w-full px-3 py-2 border border-gray-200 rounded-lg text-sm"></textarea>
                         </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700">YouTube Video URL</label>
+                            <input type="url" id="drillYoutubeUrl" placeholder="https://youtube.com/watch?v=..."
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm">
+                            <p class="text-xs text-gray-500 mt-1">Optional: Link a video demonstration</p>
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700">Diagrams / Images</label>
+                            <div id="drill-diagram-previews" class="flex gap-2 mt-1 flex-wrap"></div>
+                            <input type="file" id="drillDiagramFiles" accept="image/*" multiple
+                                class="mt-1 block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100">
+                            <p class="text-xs text-gray-500 mt-1">Up to 5 images (plays, formations, etc.)</p>
+                            <div id="drill-existing-diagrams" class="flex gap-2 mt-2 flex-wrap"></div>
+                        </div>
                         <label class="flex items-center gap-2">
                             <input type="checkbox" id="form-publish-community" class="rounded text-primary-600">
                             <span class="text-sm text-gray-700">Publish to Community Library</span>
@@ -485,6 +551,44 @@
             </div>
 
             <!-- Toast -->
+            <!-- Template Loader Modal -->
+            <div id="template-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+                <div class="bg-white rounded-xl shadow-2xl w-full max-w-md mx-4 overflow-hidden">
+                    <div class="flex items-center justify-between px-5 py-4 border-b border-gray-100">
+                        <h3 class="text-sm font-bold text-gray-800">Load Practice Template</h3>
+                        <button onclick="closeTemplateModal()" class="text-gray-400 hover:text-gray-600">
+                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+                        </button>
+                    </div>
+                    <div id="template-list" class="px-5 py-4 max-h-72 overflow-y-auto space-y-2">
+                        <p class="text-sm text-gray-400 text-center py-4">Loading templates...</p>
+                    </div>
+                    <div class="px-5 py-3 border-t border-gray-100 bg-gray-50 flex justify-end">
+                        <button onclick="closeTemplateModal()" class="px-3 py-1.5 text-xs font-medium rounded-lg bg-gray-200 text-gray-700 hover:bg-gray-300">Cancel</button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Save Template Modal -->
+            <div id="save-template-modal" class="hidden fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+                <div class="bg-white rounded-xl shadow-2xl w-full max-w-sm mx-4 overflow-hidden">
+                    <div class="flex items-center justify-between px-5 py-4 border-b border-gray-100">
+                        <h3 class="text-sm font-bold text-gray-800">Save as Template</h3>
+                        <button onclick="closeSaveTemplateModal()" class="text-gray-400 hover:text-gray-600">
+                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+                        </button>
+                    </div>
+                    <div class="px-5 py-4">
+                        <label class="block text-xs font-medium text-gray-700 mb-1">Template Name</label>
+                        <input type="text" id="template-name-input" placeholder="e.g. Game Day Prep" class="w-full px-3 py-2 text-sm border border-gray-200 rounded-lg focus:ring-2 focus:ring-primary-500 focus:border-primary-500">
+                    </div>
+                    <div class="px-5 py-3 border-t border-gray-100 bg-gray-50 flex justify-end gap-2">
+                        <button onclick="closeSaveTemplateModal()" class="px-3 py-1.5 text-xs font-medium rounded-lg bg-gray-200 text-gray-700 hover:bg-gray-300">Cancel</button>
+                        <button onclick="confirmSaveTemplate()" class="px-3 py-1.5 text-xs font-medium rounded-lg bg-primary-600 text-white hover:bg-primary-700">Save</button>
+                    </div>
+                </div>
+            </div>
+
             <div id="toast" class="hidden fixed bottom-6 right-6 z-50 px-4 py-3 rounded-xl shadow-lg text-sm font-medium transition-all"></div>
         </div>
     </main>
@@ -495,11 +599,12 @@
         import {
             getTeam, getGames, getPlayers, getUserProfile,
             getGameEvents, getAggregatedStatsForGames,
-            getDrills, getTeamDrills, getDrill, createDrill, updateDrill, deleteDrill,
+            getDrills, getTeamDrills, getDrill, createDrill, updateDrill, deleteDrill, uploadDrillDiagram,
             getDrillFavorites, addDrillFavorite, removeDrillFavorite,
             createPracticeSession, updatePracticeSession,
-            getPracticeSessionByEvent, upsertPracticeSessionForEvent, updatePracticeAttendance, getPracticeSessions, getPracticePacketCompletions
-        } from './js/db.js?v=19';
+            getPracticeSessionByEvent, upsertPracticeSessionForEvent, updatePracticeAttendance, getPracticeSessions, getPracticePacketCompletions,
+            savePracticeTemplate, getPracticeTemplates, deletePracticeTemplate
+        } from './js/db.js?v=20';
         import { renderHeader, renderFooter, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
         import { requireAuth } from './js/auth.js?v=9';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js?v=3';
@@ -585,6 +690,12 @@
         window.startDragBlock = startDragBlock;
         window.allowDropBlock = allowDropBlock;
         window.dropBlock = dropBlock;
+        window.moveCanvasBlock = moveCanvasBlock;
+        window.activateDropZone = activateDropZone;
+        window.deactivateDropZone = deactivateDropZone;
+        window.updateStructureChildDuration = updateStructureChildDuration;
+        window.updateStructureChildNote = updateStructureChildNote;
+        window.endDragBlock = endDragBlock;
         window.acceptAiProposal = acceptAiProposal;
         window.dismissAiProposal = dismissAiProposal;
         window.toggleProposalBlock = toggleProposalBlock;
@@ -596,6 +707,24 @@
         window.addFreeTextNote = addFreeTextNote;
         window.completePractice = completePractice;
         window.setChatIntentMode = setChatIntentMode;
+        window.toggleStructurePicker = toggleStructurePicker;
+        window.addStructureBlock = addStructureBlock;
+        window.toggleCanvasBlockEdit = toggleCanvasBlockEdit;
+        window.saveCanvasBlockEdit = saveCanvasBlockEdit;
+        window.openCanvasBlockDetail = openCanvasBlockDetail;
+        window.openStructureChildDetail = openStructureChildDetail;
+        window.moveBlockIntoStructure = moveBlockIntoStructure;
+        window.removeChildBlock = removeChildBlock;
+        window.saveAsTemplate = saveAsTemplate;
+        window.openTemplateLoader = openTemplateLoader;
+        window.closeTemplateModal = closeTemplateModal;
+        window.loadTemplate = loadTemplate;
+        window.deleteTemplateConfirm = deleteTemplateConfirm;
+        window.closeSaveTemplateModal = closeSaveTemplateModal;
+        window.confirmSaveTemplate = confirmSaveTemplate;
+        window.allowDropStructure = allowDropStructure;
+        window.dropIntoStructure = dropIntoStructure;
+        window.updateStructureField = updateStructureField;
 
         function parseHashParams() {
             const raw = window.location.hash.startsWith('#') ? window.location.hash.slice(1) : '';
@@ -883,10 +1012,12 @@
                 const d = session.date.toDate ? session.date.toDate() : new Date(session.date);
                 if (!isNaN(d.getTime())) document.getElementById('session-date').value = d.toISOString().split('T')[0];
             }
-            if (state.eventId && state.eventMeta?.duration && Number.isFinite(state.eventMeta.duration)) {
+            // Always prefer saved draft/session duration when present.
+            // The hash eventDuration is only a fallback for brand-new sessions.
+            if (session.duration) {
+                document.getElementById('session-duration').value = String(Math.max(15, parseInt(session.duration, 10) || 60));
+            } else if (state.eventId && state.eventMeta?.duration && Number.isFinite(state.eventMeta.duration)) {
                 document.getElementById('session-duration').value = String(Math.max(15, state.eventMeta.duration));
-            } else if (session.duration) {
-                document.getElementById('session-duration').value = session.duration;
             }
             if (session.attendance) {
                 state.attendance = {
@@ -1608,6 +1739,21 @@ ${JSON.stringify({
                     </div>
                     <p class="text-sm text-blue-700">${escapeHtml(drill.homeVariant)}</p>
                 </div>` : ''}
+                ${(() => {
+                    const embedUrl = getYoutubeEmbedUrl(drill.youtubeUrl);
+                    return embedUrl ? `<div class="mb-6">
+                        <h3 class="text-sm font-semibold text-gray-700 mb-3">Video Demonstration</h3>
+                        <div class="relative w-full" style="padding-bottom:56.25%;">
+                            <iframe class="absolute inset-0 w-full h-full rounded-xl" src="${embedUrl}" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                        </div>
+                    </div>` : '';
+                })()}
+                ${(drill.diagramUrls && drill.diagramUrls.length) ? `<div class="mb-6">
+                    <h3 class="text-sm font-semibold text-gray-700 mb-3">Diagrams</h3>
+                    <div class="flex gap-3 overflow-x-auto pb-2">
+                        ${drill.diagramUrls.map((url, i) => `<img src="${escapeHtml(url)}" alt="Diagram ${i+1}" class="h-40 rounded-lg border border-gray-200 cursor-pointer flex-shrink-0 hover:shadow-lg transition-shadow" onclick="openDiagramLightbox('${escapeHtml(url)}')">`).join('')}
+                    </div>
+                </div>` : ''}
                 ${attribution}`;
 
                 document.getElementById('drill-detail-modal').classList.remove('hidden');
@@ -1615,6 +1761,28 @@ ${JSON.stringify({
                 console.error('Open drill error:', err);
                 showToast('Failed to open drill details', 'error');
             }
+        };
+
+        function getYoutubeEmbedUrl(url) {
+            if (!url) return null;
+            let videoId = null;
+            try {
+                const u = new URL(url);
+                if (u.hostname.includes('youtube.com')) {
+                    videoId = u.searchParams.get('v');
+                } else if (u.hostname.includes('youtu.be')) {
+                    videoId = u.pathname.slice(1);
+                }
+            } catch(e) {}
+            return videoId ? `https://www.youtube.com/embed/${videoId}` : null;
+        }
+
+        window.openDiagramLightbox = function(url) {
+            const overlay = document.createElement('div');
+            overlay.className = 'fixed inset-0 z-[60] bg-black/80 flex items-center justify-center p-4 cursor-pointer';
+            overlay.onclick = () => overlay.remove();
+            overlay.innerHTML = `<img src="${escapeHtml(url)}" class="max-w-full max-h-full rounded-xl shadow-2xl">`;
+            document.body.appendChild(overlay);
         };
 
         function closeDrillDetail() {
@@ -1666,11 +1834,13 @@ ${JSON.stringify({
             if (!state.currentDetailDrill) return;
             const d = state.currentDetailDrill;
             state.canvasBlocks.push({
+                blockType: 'drill',
                 drillId: d.id,
                 drillTitle: d.title,
                 type: d.type || 'Technical',
                 duration: d.setup?.duration || 15,
                 notes: '',
+                customInstructions: '',
                 description: d.description || ''
             });
             renderCanvas();
@@ -1679,14 +1849,264 @@ ${JSON.stringify({
             showToast(`Added "${d.title}" to canvas`);
         }
 
+        async function openCanvasBlockDetail(index) {
+            const block = state.canvasBlocks[index];
+            if (!block || block.blockType === 'structure') return;
+            if (!block.drillId) {
+                showToast('No linked drill details for this timeline item');
+                return;
+            }
+            await window._openDrill(block.drillId);
+        }
+
+        async function openStructureChildDetail(structureIndex, childIndex) {
+            const structure = state.canvasBlocks[structureIndex];
+            if (!structure || structure.blockType !== 'structure') return;
+            const children = getStructureChildren(structure);
+            const child = children[childIndex];
+            if (!child) return;
+            if (!child.drillId) {
+                showToast('No linked drill details for this timeline item');
+                return;
+            }
+            await window._openDrill(child.drillId);
+        }
+
         function removeCanvasBlock(index) {
             state.canvasBlocks.splice(index, 1);
             renderCanvas();
         }
 
+        function getStructureChildren(block) {
+            if (!block || block.blockType !== 'structure') return [];
+            if (Array.isArray(block.children)) return block.children;
+            // Backward compatibility for legacy structure payloads.
+            if (Array.isArray(block.blocks)) {
+                block.children = block.blocks;
+                return block.children;
+            }
+            if (Array.isArray(block.drills)) {
+                block.children = block.drills;
+                return block.children;
+            }
+            block.children = [];
+            return block.children;
+        }
+
+        function getBlockDurationMinutes(block) {
+            if (!block) return 0;
+            if (block.blockType === 'structure') {
+                const children = getStructureChildren(block);
+                return children.reduce((sum, child) => sum + getBlockDurationMinutes(child), 0);
+            }
+            const parsed = parseInt(block.duration, 10);
+            return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+        }
+
+        function syncStructureDurations() {
+            state.canvasBlocks.forEach((block) => {
+                if (block?.blockType !== 'structure') return;
+                const children = getStructureChildren(block);
+                block.duration = block.children.reduce((sum, child) => sum + getBlockDurationMinutes(child), 0);
+            });
+        }
+
+        function getCanvasTotalMinutes() {
+            syncStructureDurations();
+            return state.canvasBlocks.reduce((sum, block) => sum + getBlockDurationMinutes(block), 0);
+        }
+
+        function getStructureBarClass(structureType) {
+            const map = { warmup: 'structure-bar-warmup', stations: 'structure-bar-stations', scrimmage: 'structure-bar-scrimmage', cooldown: 'structure-bar-cooldown', custom: 'structure-bar-custom' };
+            return map[structureType] || 'structure-bar-custom';
+        }
+
+        function getStructureClass(structureType) {
+            const map = { warmup: 'structure-warmup', stations: 'structure-stations', scrimmage: 'structure-scrimmage', cooldown: 'structure-cooldown', custom: 'structure-custom' };
+            return map[structureType] || 'structure-custom';
+        }
+
+        function getStructureLabel(structureType) {
+            const map = { warmup: 'Warm-up', stations: 'Stations', scrimmage: 'Scrimmage', cooldown: 'Cool-down', custom: 'Custom' };
+            return map[structureType] || structureType;
+        }
+
+        function getStructureIcon(structureType) {
+            const icons = {
+                warmup: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 18.657A8 8 0 016.343 7.343S7 9 9 10c0-2 .5-5 2.986-7C14 5 16.09 5.777 17.656 7.343A7.975 7.975 0 0120 13a7.975 7.975 0 01-2.343 5.657z"/>',
+                stations: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2V6zM14 6a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2V6zM4 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2H6a2 2 0 01-2-2v-2zM14 16a2 2 0 012-2h2a2 2 0 012 2v2a2 2 0 01-2 2h-2a2 2 0 01-2-2v-2z"/>',
+                scrimmage: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 10V3L4 14h7v7l9-11h-7z"/>',
+                cooldown: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"/>',
+                custom: '<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6V4m0 2a2 2 0 100 4m0-4a2 2 0 110 4m-6 8a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4m6 6v10m6-2a2 2 0 100-4m0 4a2 2 0 110-4m0 4v2m0-6V4"/>'
+            };
+            return `<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">${icons[structureType] || icons.custom}</svg>`;
+        }
+
+        function renderDrillBlock(b, i) {
+            const barClass = getBarClass(b.type);
+            const tc = getTypeClass(b.type);
+            const editOpen = b._editing ? 'open' : '';
+            return `<div class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden"
+                    data-block-index="${i}"
+                    ondragover="allowDropBlock(event)"
+                    ondrop="dropBlock(event, ${i})">
+                <div class="flex items-stretch">
+                    <div class="w-1.5 ${barClass} flex-shrink-0"></div>
+                    <div class="flex-1 p-3 min-w-0 cursor-pointer" onclick="openCanvasBlockDetail(${i})">
+                        <div class="flex flex-wrap sm:flex-nowrap items-start sm:items-center justify-between gap-2 mb-1">
+                            <div class="flex items-center gap-2 min-w-0 flex-1">
+                                <button type="button" class="drag-handle text-gray-300 hover:text-gray-500 hover:bg-gray-100 rounded p-1 -ml-1" draggable="true" ondragstart="startDragBlock(event, ${i})" ondragend="endDragBlock()" onclick="event.stopPropagation()" title="Drag to reorder">
+                                    <svg class="w-4 h-4 pointer-events-none" fill="currentColor" viewBox="0 0 20 20"><path d="M7 2a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM7 8a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM7 14a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM13 2a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM13 8a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM13 14a2 2 0 1 0 0 4 2 2 0 0 0 0-4z"/></svg>
+                                </button>
+                                <span class="text-sm font-semibold text-gray-800 truncate">${escapeHtml(b.drillTitle)}</span>
+                                <span class="${tc} text-[10px] font-bold px-2 py-0.5 rounded-full uppercase">${escapeHtml(b.type)}</span>
+                            </div>
+                            <div class="flex items-center gap-1 sm:gap-2 shrink-0 ml-auto" onclick="event.stopPropagation()">
+                                <button onclick="moveCanvasBlock(${i}, -1)" ${i === 0 ? 'disabled' : ''} class="text-gray-300 hover:text-gray-500 disabled:opacity-30 disabled:cursor-not-allowed" title="Move up">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"/></svg>
+                                </button>
+                                <button onclick="moveCanvasBlock(${i}, 1)" ${i >= state.canvasBlocks.length - 1 ? 'disabled' : ''} class="text-gray-300 hover:text-gray-500 disabled:opacity-30 disabled:cursor-not-allowed" title="Move down">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                                </button>
+                                <input type="number" value="${b.duration}" min="1" max="60" class="w-10 text-center text-sm font-bold text-gray-500 border-none bg-transparent focus:bg-primary-50 focus:outline-none rounded" onchange="window._updateBlockDur(${i}, this.value)">
+                                <span class="text-xs text-gray-400">min</span>
+                                <button onclick="toggleCanvasBlockEdit(${i})" class="text-gray-300 hover:text-primary-500" title="Edit">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"/></svg>
+                                </button>
+                                <button onclick="removeCanvasBlock(${i})" class="text-gray-300 hover:text-red-400 ml-1">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+                                </button>
+                            </div>
+                        </div>
+                        <p class="text-xs text-gray-500 ml-6">${escapeHtml(b.description || '')}</p>
+                        ${b.customInstructions ? `<p class="text-xs text-indigo-600 ml-6 mt-1 italic">${escapeHtml(b.customInstructions)}</p>` : ''}
+                        ${b.notes ? `<p class="text-xs text-gray-400 ml-6 mt-1">${escapeHtml(b.notes)}</p>` : ''}
+                        <!-- Edit panel -->
+                        <div class="canvas-edit-panel ${editOpen} ml-6 mt-2" onclick="event.stopPropagation()">
+                            <div class="bg-gray-50 rounded-lg p-3 space-y-2 border border-gray-100">
+                                <div>
+                                    <label class="block text-[10px] font-semibold text-gray-500 mb-0.5">Custom Instructions</label>
+                                    <textarea id="block-instructions-${i}" rows="2" class="w-full text-xs px-2 py-1.5 border border-gray-200 rounded-lg focus:ring-1 focus:ring-primary-400" placeholder="Special instructions for this drill...">${escapeHtml(b.customInstructions || '')}</textarea>
+                                </div>
+                                <div>
+                                    <label class="block text-[10px] font-semibold text-gray-500 mb-0.5">Duration Override (min)</label>
+                                    <input type="number" id="block-duration-${i}" value="${b.duration}" min="1" max="60" class="w-20 text-xs px-2 py-1.5 border border-gray-200 rounded-lg focus:ring-1 focus:ring-primary-400">
+                                </div>
+                                <div>
+                                    <label class="block text-[10px] font-semibold text-gray-500 mb-0.5">Notes</label>
+                                    <textarea id="block-notes-${i}" rows="2" class="w-full text-xs px-2 py-1.5 border border-gray-200 rounded-lg focus:ring-1 focus:ring-primary-400" placeholder="Coach notes...">${escapeHtml(b.notes || '')}</textarea>
+                                </div>
+                                <div class="flex justify-end">
+                                    <button onclick="saveCanvasBlockEdit(${i})" class="px-3 py-1 text-xs font-medium rounded-lg bg-primary-600 text-white hover:bg-primary-700">Save</button>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>`;
+        }
+
+        function renderStructureBlock(b, i) {
+            const sc = getStructureClass(b.structureType);
+            const barClass = getStructureBarClass(b.structureType);
+            const label = getStructureLabel(b.structureType);
+            const icon = getStructureIcon(b.structureType);
+            const children = b.children || [];
+            const childrenHtml = children.length > 0
+                ? children.map((c, ci) => {
+                    const cBar = getBarClass(c.type);
+                    const cTc = getTypeClass(c.type);
+                    return `<div class="bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden cursor-pointer" onclick="openStructureChildDetail(${i}, ${ci})">
+                        <div class="flex items-stretch">
+                            <div class="w-1 ${cBar} flex-shrink-0"></div>
+                            <div class="flex-1 p-2">
+                                <div class="flex items-center justify-between gap-2">
+                                    <div class="flex items-center gap-1.5 min-w-0">
+                                        <span class="text-xs font-semibold text-gray-700 truncate">${escapeHtml(c.drillTitle)}</span>
+                                        <span class="${cTc} text-[9px] font-bold px-1.5 py-0.5 rounded-full uppercase">${escapeHtml(c.type)}</span>
+                                    </div>
+                                    <div class="flex items-center gap-1 shrink-0">
+                                        <input type="number"
+                                            value="${Math.max(1, parseInt(c.duration, 10) || 1)}"
+                                            min="1"
+                                            max="120"
+                                            class="w-12 text-center text-[11px] text-gray-600 border border-gray-200 rounded px-1 py-0.5 bg-white"
+                                            onclick="event.stopPropagation()"
+                                            onchange="updateStructureChildDuration(${i}, ${ci}, this.value)">
+                                        <span class="text-[10px] text-gray-400">m</span>
+                                        <button onclick="event.stopPropagation(); removeChildBlock(${i}, ${ci})" class="text-gray-300 hover:text-red-400">
+                                            <svg class="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+                                        </button>
+                                    </div>
+                                </div>
+                                <input type="text"
+                                    value="${escapeHtml(c.notes || '')}"
+                                    class="mt-1 w-full text-[10px] text-gray-600 border border-gray-200 rounded px-2 py-1 bg-white"
+                                    placeholder="Child drill notes"
+                                    onclick="event.stopPropagation()"
+                                    onchange="updateStructureChildNote(${i}, ${ci}, this.value)">
+                            </div>
+                        </div>
+                    </div>`;
+                }).join('')
+                : `<p class="text-[10px] text-gray-400 text-center py-2">Drag drills here</p>`;
+
+            const stationsFields = b.structureType === 'stations' ? `
+                <div class="flex flex-wrap items-center gap-3 mt-2 ml-0 sm:ml-7">
+                    <div class="flex items-center gap-1">
+                        <label class="text-[10px] text-gray-500">Groups:</label>
+                        <input type="number" value="${b.groupCount || 2}" min="1" max="10" class="w-10 text-center text-xs border border-gray-200 rounded px-1 py-0.5" onchange="updateStructureField(${i}, 'groupCount', parseInt(this.value))">
+                    </div>
+                    <div class="flex items-center gap-1">
+                        <label class="text-[10px] text-gray-500">Rotation:</label>
+                        <input type="number" value="${b.rotationTime || 5}" min="1" max="30" class="w-10 text-center text-xs border border-gray-200 rounded px-1 py-0.5" onchange="updateStructureField(${i}, 'rotationTime', parseInt(this.value))">
+                        <span class="text-[10px] text-gray-400">min</span>
+                    </div>
+                </div>` : '';
+
+            return `<div class="rounded-xl border-2 ${sc} shadow-sm overflow-hidden"
+                    data-block-index="${i}"
+                    ondragover="allowDropBlock(event)"
+                    ondrop="dropBlock(event, ${i})">
+                <div class="flex items-stretch">
+                    <div class="w-2 ${barClass} flex-shrink-0"></div>
+                    <div class="flex-1 p-3 min-w-0">
+                        <div class="flex flex-wrap sm:flex-nowrap items-start sm:items-center justify-between gap-2 mb-1">
+                            <div class="flex items-center gap-2 min-w-0 flex-1">
+                                <button type="button" class="drag-handle text-gray-400 hover:text-gray-600 hover:bg-white/80 rounded p-1 -ml-1" draggable="true" ondragstart="startDragBlock(event, ${i})" ondragend="endDragBlock()" title="Drag to reorder">${icon}</button>
+                                <input type="text" value="${escapeHtml(b.title)}" class="text-sm font-bold bg-transparent border-none focus:bg-white focus:outline-none focus:ring-1 focus:ring-primary-300 rounded px-1 min-w-0 w-full sm:w-44 max-w-full" onchange="updateStructureField(${i}, 'title', this.value)">
+                                <span class="text-[10px] font-bold px-2 py-0.5 rounded-full uppercase bg-white/60 text-gray-600 shrink-0">${escapeHtml(label)}</span>
+                            </div>
+                            <div class="flex items-center gap-1 sm:gap-2 shrink-0">
+                                <button onclick="moveCanvasBlock(${i}, -1)" ${i === 0 ? 'disabled' : ''} class="text-gray-300 hover:text-gray-500 disabled:opacity-30 disabled:cursor-not-allowed" title="Move up">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"/></svg>
+                                </button>
+                                <button onclick="moveCanvasBlock(${i}, 1)" ${i >= state.canvasBlocks.length - 1 ? 'disabled' : ''} class="text-gray-300 hover:text-gray-500 disabled:opacity-30 disabled:cursor-not-allowed" title="Move down">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"/></svg>
+                                </button>
+                                <span class="w-12 text-center text-sm font-bold text-gray-600">${b.duration || 0}</span>
+                                <span class="text-xs text-gray-400">min (auto)</span>
+                                <button onclick="removeCanvasBlock(${i})" class="text-gray-400 hover:text-red-400 ml-1">
+                                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
+                                </button>
+                            </div>
+                        </div>
+                        ${stationsFields}
+                        ${b.notes ? `<p class="text-xs text-gray-500 ml-0 sm:ml-7 mt-1 italic">${escapeHtml(b.notes)}</p>` : ''}
+                        <div class="structure-children mt-2 ml-0 sm:ml-5 space-y-1.5"
+                             ondragover="allowDropStructure(event)"
+                             ondrop="dropIntoStructure(event, ${i})">
+                            ${childrenHtml}
+                        </div>
+                    </div>
+                </div>
+            </div>`;
+        }
+
         function renderCanvas() {
             const container = document.getElementById('canvas-blocks');
             const empty = document.getElementById('canvas-empty');
+            syncStructureDurations();
             if (state.canvasBlocks.length === 0) {
                 container.innerHTML = '';
                 if (empty) container.appendChild(empty);
@@ -1695,56 +2115,266 @@ ${JSON.stringify({
                 return;
             }
             if (empty) empty.remove();
-            const total = state.canvasBlocks.reduce((s, b) => s + (b.duration || 0), 0);
+            const total = getCanvasTotalMinutes();
             document.getElementById('canvas-total').textContent = `Total: ${total} min`;
             updateTimelineAllocation(total);
 
-            container.innerHTML = state.canvasBlocks.map((b, i) => {
-                const barClass = getBarClass(b.type);
-                const tc = getTypeClass(b.type);
-                return `<div class="bg-white rounded-xl border border-gray-200 shadow-sm overflow-hidden"
-                        draggable="true"
-                        data-block-index="${i}"
-                        ondragstart="startDragBlock(event, ${i})"
-                        ondragover="allowDropBlock(event)"
-                        ondrop="dropBlock(event, ${i})">
-                    <div class="flex items-stretch">
-                        <div class="w-1.5 ${barClass} flex-shrink-0"></div>
-                        <div class="flex-1 p-3">
-                            <div class="flex items-center justify-between mb-1">
-                                <div class="flex items-center gap-2">
-                                    <span class="drag-handle text-gray-300">
-                                        <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 20 20"><path d="M7 2a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM7 8a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM7 14a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM13 2a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM13 8a2 2 0 1 0 0 4 2 2 0 0 0 0-4zM13 14a2 2 0 1 0 0 4 2 2 0 0 0 0-4z"/></svg>
-                                    </span>
-                                    <span class="text-sm font-semibold text-gray-800">${escapeHtml(b.drillTitle)}</span>
-                                    <span class="${tc} text-[10px] font-bold px-2 py-0.5 rounded-full uppercase">${escapeHtml(b.type)}</span>
-                                </div>
-                                <div class="flex items-center gap-2">
-                                    <input type="number" value="${b.duration}" min="1" max="60" class="w-10 text-center text-sm font-bold text-gray-500 border-none bg-transparent focus:bg-primary-50 focus:outline-none rounded" onchange="window._updateBlockDur(${i}, this.value)">
-                                    <span class="text-xs text-gray-400">min</span>
-                                    <button onclick="removeCanvasBlock(${i})" class="text-gray-300 hover:text-red-400 ml-1">
-                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"/></svg>
-                                    </button>
-                                </div>
-                            </div>
-                            <p class="text-xs text-gray-500 ml-6">${escapeHtml(b.description)}</p>
-                        </div>
-                    </div>
-                </div>`;
+            const dropZone = (i) => `<div class="timeline-drop-zone" data-drop-index="${i}" ondragenter="activateDropZone(event)" ondragleave="deactivateDropZone(event)" ondragover="allowDropBlock(event)" ondrop="dropBlock(event, ${i})"></div>`;
+            let html = dropZone(0);
+            html += state.canvasBlocks.map((b, i) => {
+                if (b.blockType === 'structure') {
+                    return `${renderStructureBlock(b, i)}${dropZone(i + 1)}`;
+                }
+                return `${renderDrillBlock(b, i)}${dropZone(i + 1)}`;
             }).join('');
+            container.innerHTML = html;
         }
 
         window._updateBlockDur = function(index, val) {
-            state.canvasBlocks[index].duration = parseInt(val) || 1;
-            const total = state.canvasBlocks.reduce((s, b) => s + (b.duration || 0), 0);
+            const block = state.canvasBlocks[index];
+            if (!block || block.blockType === 'structure') return;
+            block.duration = parseInt(val, 10) || 1;
+            const total = getCanvasTotalMinutes();
             document.getElementById('canvas-total').textContent = `Total: ${total} min`;
             updateTimelineAllocation(total);
         };
 
+        // ==================== EDIT DRILL ON CANVAS ====================
+        function toggleCanvasBlockEdit(index) {
+            const b = state.canvasBlocks[index];
+            b._editing = !b._editing;
+            renderCanvas();
+        }
+
+        function saveCanvasBlockEdit(index) {
+            const b = state.canvasBlocks[index];
+            const instrEl = document.getElementById(`block-instructions-${index}`);
+            const durEl = document.getElementById(`block-duration-${index}`);
+            const notesEl = document.getElementById(`block-notes-${index}`);
+            if (instrEl) b.customInstructions = instrEl.value.trim();
+            if (durEl && b.blockType !== 'structure') b.duration = parseInt(durEl.value, 10) || b.duration;
+            if (notesEl) b.notes = notesEl.value.trim();
+            b._editing = false;
+            renderCanvas();
+            showToast('Block updated');
+        }
+
+        // ==================== STRUCTURE BLOCKS ====================
+        function toggleStructurePicker() {
+            const picker = document.getElementById('structure-picker');
+            picker.classList.toggle('hidden');
+            // Close on outside click
+            if (!picker.classList.contains('hidden')) {
+                setTimeout(() => {
+                    const close = (e) => {
+                        if (!picker.contains(e.target)) {
+                            picker.classList.add('hidden');
+                            document.removeEventListener('click', close);
+                        }
+                    };
+                    document.addEventListener('click', close);
+                }, 10);
+            }
+        }
+
+        function addStructureBlock(structureType) {
+            document.getElementById('structure-picker').classList.add('hidden');
+            const label = getStructureLabel(structureType);
+            state.canvasBlocks.push({
+                blockType: 'structure',
+                structureType,
+                title: label,
+                duration: 0,
+                groupCount: structureType === 'stations' ? 3 : null,
+                rotationTime: structureType === 'stations' ? 5 : null,
+                grouping: null,
+                notes: null,
+                children: []
+            });
+            renderCanvas();
+            showToast(`Added ${label} structure block`);
+        }
+
+        function updateStructureField(index, field, value) {
+            state.canvasBlocks[index][field] = value;
+        }
+
+        function allowDropStructure(event) {
+            event.preventDefault();
+            event.stopPropagation();
+            event.dataTransfer.dropEffect = 'move';
+            event.currentTarget.classList.add('drag-over');
+            updateDragAutoScrollFromPointer(event.clientY);
+        }
+
+        function dropIntoStructure(event, structureIndex) {
+            event.preventDefault();
+            event.stopPropagation();
+            event.currentTarget.classList.remove('drag-over');
+            const sourceIndexRaw = event.dataTransfer.getData('text/plain');
+            const sourceIndex = sourceIndexRaw !== '' ? parseInt(sourceIndexRaw, 10) : draggedBlockIndex;
+            if (Number.isNaN(sourceIndex) || sourceIndex === null || sourceIndex === structureIndex) return;
+            const block = state.canvasBlocks[sourceIndex];
+            if (!block || block.blockType === 'structure') return; // Don't nest structures
+            // Remove from top level and add to structure children
+            state.canvasBlocks.splice(sourceIndex, 1);
+            // Adjust structure index if source was before it
+            const adjustedIndex = sourceIndex < structureIndex ? structureIndex - 1 : structureIndex;
+            if (!state.canvasBlocks[adjustedIndex].children) state.canvasBlocks[adjustedIndex].children = [];
+            state.canvasBlocks[adjustedIndex].children.push(block);
+            endDragBlock();
+            renderCanvas();
+            showToast(`Moved "${block.drillTitle}" into structure block`);
+        }
+
+        function moveBlockIntoStructure(blockIndex, structureIndex) {
+            const block = state.canvasBlocks[blockIndex];
+            if (!block || block.blockType === 'structure') return;
+            state.canvasBlocks.splice(blockIndex, 1);
+            const adjustedIndex = blockIndex < structureIndex ? structureIndex - 1 : structureIndex;
+            if (!state.canvasBlocks[adjustedIndex].children) state.canvasBlocks[adjustedIndex].children = [];
+            state.canvasBlocks[adjustedIndex].children.push(block);
+            renderCanvas();
+        }
+
+        function removeChildBlock(structureIndex, childIndex) {
+            const structure = state.canvasBlocks[structureIndex];
+            if (!structure || !structure.children) return;
+            const [child] = structure.children.splice(childIndex, 1);
+            // Move child back to top level right after the structure
+            state.canvasBlocks.splice(structureIndex + 1, 0, child);
+            renderCanvas();
+            showToast(`Moved "${child.drillTitle}" out of structure block`);
+        }
+
+        function updateStructureChildDuration(structureIndex, childIndex, value) {
+            const structure = state.canvasBlocks[structureIndex];
+            if (!structure || !Array.isArray(structure.children)) return;
+            const child = structure.children[childIndex];
+            if (!child) return;
+            const next = Math.max(1, parseInt(value, 10) || 1);
+            child.duration = next;
+            renderCanvas();
+        }
+
+        function updateStructureChildNote(structureIndex, childIndex, value) {
+            const structure = state.canvasBlocks[structureIndex];
+            if (!structure || !Array.isArray(structure.children)) return;
+            const child = structure.children[childIndex];
+            if (!child) return;
+            child.notes = (value || '').trim();
+            renderCanvas();
+        }
+
+        // ==================== TEMPLATES ====================
+        function saveAsTemplate() {
+            if (state.canvasBlocks.length === 0) {
+                showToast('Add drills to canvas first', 'error');
+                return;
+            }
+            document.getElementById('save-template-modal').classList.remove('hidden');
+            document.getElementById('template-name-input').value = '';
+            document.getElementById('template-name-input').focus();
+        }
+
+        function closeSaveTemplateModal() {
+            document.getElementById('save-template-modal').classList.add('hidden');
+        }
+
+        async function confirmSaveTemplate() {
+            const name = document.getElementById('template-name-input').value.trim();
+            if (!name) {
+                showToast('Enter a template name', 'error');
+                return;
+            }
+            try {
+                const total = getCanvasTotalMinutes();
+                // Strip transient fields like _editing before saving
+                const cleanBlocks = state.canvasBlocks.map((b, i) => {
+                    const { _editing, ...clean } = b;
+                    return { ...clean, order: i };
+                });
+                await savePracticeTemplate(state.teamId, {
+                    name,
+                    blocks: cleanBlocks,
+                    totalMinutes: total,
+                    createdBy: state.user?.uid || null
+                });
+                closeSaveTemplateModal();
+                showToast(`Template "${name}" saved`);
+            } catch (err) {
+                showToast('Failed to save template: ' + err.message, 'error');
+            }
+        }
+
+        async function openTemplateLoader() {
+            document.getElementById('template-modal').classList.remove('hidden');
+            const listEl = document.getElementById('template-list');
+            listEl.innerHTML = '<p class="text-sm text-gray-400 text-center py-4">Loading templates...</p>';
+            try {
+                const templates = await getPracticeTemplates(state.teamId);
+                if (templates.length === 0) {
+                    listEl.innerHTML = '<p class="text-sm text-gray-400 text-center py-4">No templates saved yet.</p>';
+                    return;
+                }
+                listEl.innerHTML = templates.map(t => `
+                    <div class="flex items-center justify-between p-3 rounded-lg border border-gray-100 hover:bg-gray-50">
+                        <div class="flex-1 cursor-pointer" onclick="loadTemplate('${t.id}')">
+                            <p class="text-sm font-semibold text-gray-800">${escapeHtml(t.name)}</p>
+                            <p class="text-[10px] text-gray-400">${(t.blocks || []).length} blocks &middot; ${t.totalMinutes || 0} min</p>
+                        </div>
+                        <button onclick="deleteTemplateConfirm('${t.id}', '${escapeHtml(t.name)}')" class="text-gray-300 hover:text-red-400 ml-2" title="Delete">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
+                        </button>
+                    </div>
+                `).join('');
+            } catch (err) {
+                listEl.innerHTML = `<p class="text-sm text-red-500 text-center py-4">Error loading templates</p>`;
+            }
+        }
+
+        function closeTemplateModal() {
+            document.getElementById('template-modal').classList.add('hidden');
+        }
+
+        async function loadTemplate(templateId) {
+            try {
+                const templates = await getPracticeTemplates(state.teamId);
+                const t = templates.find(tp => tp.id === templateId);
+                if (!t || !t.blocks) {
+                    showToast('Template not found', 'error');
+                    return;
+                }
+                if (state.canvasBlocks.length > 0) {
+                    if (!confirm('Replace current canvas with template? (Existing blocks will be replaced)')) return;
+                }
+                state.canvasBlocks = t.blocks.map(b => {
+                    const { order, ...rest } = b;
+                    return { ...rest };
+                });
+                renderCanvas();
+                closeTemplateModal();
+                showToast(`Loaded template "${t.name}"`);
+            } catch (err) {
+                showToast('Failed to load template: ' + err.message, 'error');
+            }
+        }
+
+        async function deleteTemplateConfirm(templateId, name) {
+            if (!confirm(`Delete template "${name}"?`)) return;
+            try {
+                await deletePracticeTemplate(state.teamId, templateId);
+                showToast('Template deleted');
+                openTemplateLoader(); // Refresh list
+            } catch (err) {
+                showToast('Failed to delete: ' + err.message, 'error');
+            }
+        }
+
         function updateTimelineAllocation(explicitTotal = null) {
             const total = explicitTotal !== null
                 ? explicitTotal
-                : state.canvasBlocks.reduce((s, b) => s + (b.duration || 0), 0);
+                : getCanvasTotalMinutes();
             const durationInput = document.getElementById('session-duration');
             const sessionDuration = parseInt(durationInput?.value, 10) || 60;
             const gapEl = document.getElementById('canvas-gap');
@@ -1780,27 +2410,93 @@ ${JSON.stringify({
         }
 
         let draggedBlockIndex = null;
+        let dragAutoScrollVelocity = 0;
+        let dragAutoScrollRaf = null;
+
+        function startDragAutoScrollLoop() {
+            if (dragAutoScrollRaf) return;
+            const tick = () => {
+                if (draggedBlockIndex === null) {
+                    dragAutoScrollRaf = null;
+                    return;
+                }
+                if (dragAutoScrollVelocity !== 0) {
+                    window.scrollBy(0, dragAutoScrollVelocity);
+                }
+                dragAutoScrollRaf = requestAnimationFrame(tick);
+            };
+            dragAutoScrollRaf = requestAnimationFrame(tick);
+        }
+
+        function updateDragAutoScrollFromPointer(clientY) {
+            const edgeThreshold = 96;
+            const maxSpeed = 20;
+            if (!Number.isFinite(clientY)) {
+                dragAutoScrollVelocity = 0;
+                return;
+            }
+            if (clientY < edgeThreshold) {
+                const ratio = (edgeThreshold - clientY) / edgeThreshold;
+                dragAutoScrollVelocity = -Math.max(2, Math.round(maxSpeed * ratio));
+            } else if (clientY > window.innerHeight - edgeThreshold) {
+                const ratio = (clientY - (window.innerHeight - edgeThreshold)) / edgeThreshold;
+                dragAutoScrollVelocity = Math.max(2, Math.round(maxSpeed * ratio));
+            } else {
+                dragAutoScrollVelocity = 0;
+            }
+        }
+
         function startDragBlock(event, index) {
             draggedBlockIndex = index;
             event.dataTransfer.effectAllowed = 'move';
             event.dataTransfer.setData('text/plain', String(index));
+            startDragAutoScrollLoop();
+        }
+
+        function endDragBlock() {
+            draggedBlockIndex = null;
+            dragAutoScrollVelocity = 0;
+            if (dragAutoScrollRaf) {
+                cancelAnimationFrame(dragAutoScrollRaf);
+                dragAutoScrollRaf = null;
+            }
+            document.querySelectorAll('.timeline-drop-zone.active').forEach(z => z.classList.remove('active'));
+            document.querySelectorAll('.structure-children.drag-over').forEach(z => z.classList.remove('drag-over'));
         }
 
         function allowDropBlock(event) {
             event.preventDefault();
             event.dataTransfer.dropEffect = 'move';
+            updateDragAutoScrollFromPointer(event.clientY);
+        }
+
+        function activateDropZone(event) {
+            const zone = event.currentTarget;
+            if (zone && zone.classList.contains('timeline-drop-zone')) {
+                zone.classList.add('active');
+            }
+        }
+
+        function deactivateDropZone(event) {
+            const zone = event.currentTarget;
+            if (zone && zone.classList.contains('timeline-drop-zone')) {
+                zone.classList.remove('active');
+            }
         }
 
         async function dropBlock(event, targetIndex) {
             event.preventDefault();
+            document.querySelectorAll('.timeline-drop-zone.active').forEach(z => z.classList.remove('active'));
             const sourceIndexRaw = event.dataTransfer.getData('text/plain');
             const sourceIndex = sourceIndexRaw ? parseInt(sourceIndexRaw, 10) : draggedBlockIndex;
             if (Number.isNaN(sourceIndex) || sourceIndex === null || sourceIndex === targetIndex) return;
             if (sourceIndex < 0 || sourceIndex >= state.canvasBlocks.length) return;
-            if (targetIndex < 0 || targetIndex >= state.canvasBlocks.length) return;
+            if (targetIndex < 0 || targetIndex > state.canvasBlocks.length) return;
 
             const [moved] = state.canvasBlocks.splice(sourceIndex, 1);
-            state.canvasBlocks.splice(targetIndex, 0, moved);
+            const insertionIndex = sourceIndex < targetIndex ? targetIndex - 1 : targetIndex;
+            state.canvasBlocks.splice(Math.max(0, insertionIndex), 0, moved);
+            endDragBlock();
             renderCanvas();
 
             if (state.sessionId) {
@@ -1812,6 +2508,23 @@ ${JSON.stringify({
                     console.warn('Failed to persist reordered blocks:', err);
                     showToast('Failed to save order', 'error');
                 }
+            }
+        }
+
+        async function moveCanvasBlock(index, direction) {
+            const targetIndex = index + direction;
+            if (index < 0 || index >= state.canvasBlocks.length) return;
+            if (targetIndex < 0 || targetIndex >= state.canvasBlocks.length) return;
+            const [moved] = state.canvasBlocks.splice(index, 1);
+            state.canvasBlocks.splice(targetIndex, 0, moved);
+            renderCanvas();
+            if (!state.sessionId) return;
+            try {
+                await updatePracticeSession(state.teamId, state.sessionId, {
+                    blocks: state.canvasBlocks.map((b, i) => ({ ...b, order: i }))
+                });
+            } catch (err) {
+                console.warn('Failed to persist reordered blocks:', err);
             }
         }
 
@@ -1829,6 +2542,16 @@ ${JSON.stringify({
             document.getElementById('form-drill-desc').value = drill?.description || '';
             document.getElementById('form-drill-instructions').value = drill?.instructions || '';
             document.getElementById('form-publish-community').checked = !!drill?.publishedToCommunity;
+
+            // YouTube URL
+            document.getElementById('drillYoutubeUrl').value = drill?.youtubeUrl || '';
+
+            // Diagram files - reset file input and previews
+            document.getElementById('drillDiagramFiles').value = '';
+            document.getElementById('drill-diagram-previews').innerHTML = '';
+            state.formDiagramUrls = drill?.diagramUrls ? [...drill.diagramUrls] : [];
+            renderExistingDiagrams();
+
             state.formAiHistory = [{
                 role: 'assistant',
                 content: 'Tell me the drill concept and I will fill the card fields for you.'
@@ -1837,10 +2560,55 @@ ${JSON.stringify({
             document.getElementById('drill-form-modal').classList.remove('hidden');
         }
 
+        function renderExistingDiagrams() {
+            const container = document.getElementById('drill-existing-diagrams');
+            if (!container) return;
+            if (!state.formDiagramUrls || state.formDiagramUrls.length === 0) {
+                container.innerHTML = '';
+                return;
+            }
+            container.innerHTML = state.formDiagramUrls.map((url, i) => `
+                <div class="relative group">
+                    <img src="${escapeHtml(url)}" alt="Diagram ${i+1}" class="h-20 w-20 object-cover rounded-lg border border-gray-200">
+                    <button type="button" onclick="removeDiagram(${i})" class="absolute -top-2 -right-2 bg-red-500 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs font-bold shadow hover:bg-red-600">&times;</button>
+                </div>
+            `).join('');
+        }
+
+        window.removeDiagram = function(index) {
+            if (!state.formDiagramUrls) return;
+            state.formDiagramUrls.splice(index, 1);
+            renderExistingDiagrams();
+        };
+
         function closeDrillForm() {
             document.getElementById('drill-form-modal').classList.add('hidden');
             state.formAiHistory = [];
+            state.formDiagramUrls = [];
         }
+
+        // Preview selected diagram files before upload
+        document.getElementById('drillDiagramFiles')?.addEventListener('change', function() {
+            const container = document.getElementById('drill-diagram-previews');
+            container.innerHTML = '';
+            const files = Array.from(this.files || []);
+            const existingCount = (state.formDiagramUrls || []).length;
+            const maxNew = 5 - existingCount;
+            files.slice(0, maxNew).forEach(file => {
+                const reader = new FileReader();
+                reader.onload = (e) => {
+                    const img = document.createElement('img');
+                    img.src = e.target.result;
+                    img.className = 'h-20 w-20 object-cover rounded-lg border border-gray-200';
+                    img.alt = file.name;
+                    container.appendChild(img);
+                };
+                reader.readAsDataURL(file);
+            });
+            if (files.length > maxNew) {
+                showToast(`Only ${maxNew} more diagram(s) allowed (max 5 total)`, 'error');
+            }
+        });
 
         function renderFormAiMessages() {
             const box = document.getElementById('form-ai-messages');
@@ -1953,6 +2721,7 @@ ${text}
         async function submitDrillForm(e) {
             e.preventDefault();
             const id = document.getElementById('form-drill-id').value;
+            const youtubeUrl = document.getElementById('drillYoutubeUrl').value.trim();
             const data = {
                 title: document.getElementById('form-drill-title').value.trim(),
                 sport: state.team?.sport || 'Soccer',
@@ -1962,6 +2731,7 @@ ${text}
                 description: document.getElementById('form-drill-desc').value.trim(),
                 instructions: document.getElementById('form-drill-instructions').value.trim(),
                 publishedToCommunity: !!document.getElementById('form-publish-community').checked,
+                youtubeUrl: youtubeUrl || null,
                 setup: {
                     duration: parseInt(document.getElementById('form-drill-duration').value) || 15,
                     players: document.getElementById('form-drill-players').value.trim(),
@@ -1972,8 +2742,38 @@ ${text}
                 if (data.publishedToCommunity && !state.user?.isAdmin) {
                     showToast('Published drills are shared from your team. Save to publish.', 'success');
                 }
-                if (id) { await updateDrill(id, data); showToast('Drill updated'); }
-                else { await createDrill(state.teamId, data); showToast('Drill created'); }
+
+                // Determine the drill ID (create first if new)
+                let drillId = id;
+                if (drillId) {
+                    await updateDrill(drillId, data);
+                } else {
+                    drillId = await createDrill(state.teamId, data);
+                }
+
+                // Upload new diagram files if selected
+                const fileInput = document.getElementById('drillDiagramFiles');
+                const files = Array.from(fileInput.files || []);
+                const existingUrls = state.formDiagramUrls || [];
+                if (files.length > 0) {
+                    const maxNew = 5 - existingUrls.length;
+                    const toUpload = files.slice(0, Math.max(0, maxNew));
+                    if (toUpload.length > 0) {
+                        showToast('Uploading diagrams...', 'success');
+                        const uploaded = [];
+                        for (const file of toUpload) {
+                            const url = await uploadDrillDiagram(drillId, file);
+                            uploaded.push(url);
+                        }
+                        const allUrls = [...existingUrls, ...uploaded];
+                        await updateDrill(drillId, { diagramUrls: allUrls });
+                    }
+                } else if (existingUrls !== undefined) {
+                    // Persist existing diagram URLs (may have had removals)
+                    await updateDrill(drillId, { diagramUrls: existingUrls });
+                }
+
+                showToast(id ? 'Drill updated' : 'Drill created');
                 invalidateAiDrillUniverse();
                 closeDrillForm();
                 closeDrillDetail();
@@ -2300,14 +3100,41 @@ ${text}
         }
 
         function normalizeProposalBlocks(blocks) {
-            return (Array.isArray(blocks) ? blocks : []).map((b, i) => ({
-                drillId: b.drillId || null,
-                drillTitle: b.drillTitle || b.title || `Block ${i + 1}`,
-                type: normalizeDrillType(b.type || 'Technical'),
-                duration: parseInt(b.duration, 10) || 10,
-                notes: b.notes || '',
-                description: b.description || ''
-            }));
+            return (Array.isArray(blocks) ? blocks : []).map((b, i) => {
+                // Support structure blocks proposed by AI
+                if (b.blockType === 'structure') {
+                    return {
+                        blockType: 'structure',
+                        structureType: b.structureType || 'custom',
+                        title: b.title || b.drillTitle || `Block ${i + 1}`,
+                        duration: parseInt(b.duration, 10) || 10,
+                        groupCount: b.groupCount || null,
+                        rotationTime: b.rotationTime || null,
+                        grouping: b.grouping || null,
+                        notes: b.notes || null,
+                        children: Array.isArray(b.children) ? b.children.map(c => ({
+                            blockType: 'drill',
+                            drillId: c.drillId || null,
+                            drillTitle: c.drillTitle || c.title || 'Drill',
+                            type: normalizeDrillType(c.type || 'Technical'),
+                            duration: parseInt(c.duration, 10) || 10,
+                            notes: c.notes || '',
+                            customInstructions: c.customInstructions || '',
+                            description: c.description || ''
+                        })) : []
+                    };
+                }
+                return {
+                    blockType: 'drill',
+                    drillId: b.drillId || null,
+                    drillTitle: b.drillTitle || b.title || `Block ${i + 1}`,
+                    type: normalizeDrillType(b.type || 'Technical'),
+                    duration: parseInt(b.duration, 10) || 10,
+                    notes: b.notes || '',
+                    customInstructions: b.customInstructions || '',
+                    description: b.description || ''
+                };
+            });
         }
 
         function getProposalSelectedIndices(proposal) {
@@ -2454,21 +3281,22 @@ ${text}
                     aiText = await generateAiAnswer(text, attendanceSummary);
                 }
             } catch (err) {
+                const aiErrorSummary = formatAiErrorSummary(err);
                 if (effectiveIntent === 'plan') {
-                    console.warn('Gemini planning failed, using fallback:', err);
+                    console.warn('Gemini planning failed, using fallback:', aiErrorSummary, err);
                     const suggestedBlocks = normalizeProposalBlocks(buildAttendanceAwarePlan(attendanceSummary, text, targetMinutes, planScope));
-                    aiText = `ALL PLAYS AI is temporarily unavailable (${err?.message || 'unknown error'}). I prepared an attendance-aware fallback suggestion for ${attendanceSummary.checkedIn} checked-in players (${attendanceSummary.late} late, ${attendanceSummary.absent} absent). Target planning time: ${targetMinutes} min (${planScope === 'gap-fill' ? 'fill timeline gap' : 'full session'}). Review the suggested drills below, choose drills or use all, then move them to the timeline.`;
+                    aiText = `ALL PLAYS AI is temporarily unavailable (${aiErrorSummary}). I prepared an attendance-aware fallback suggestion for ${attendanceSummary.checkedIn} checked-in players (${attendanceSummary.late} late, ${attendanceSummary.absent} absent). Target planning time: ${targetMinutes} min (${planScope === 'gap-fill' ? 'fill timeline gap' : 'full session'}). Review the suggested drills below, choose drills or use all, then move them to the timeline.`;
                     aiProposal = {
                         status: 'pending',
                         blocks: suggestedBlocks,
                         targetMinutes,
                         planScope
                     };
-                    showToast(`AI unavailable (${err?.message || 'unknown error'}). Used fallback plan.`, 'error');
+                    showToast(`AI unavailable (${aiErrorSummary}). Used fallback plan.`, 'error');
                 } else {
-                    console.warn('Gemini Q&A failed:', err);
-                    aiText = `ALL PLAYS AI is temporarily unavailable (${err?.message || 'unknown error'}). Try again in a moment.`;
-                    showToast(`AI unavailable (${err?.message || 'unknown error'})`, 'error');
+                    console.warn('Gemini Q&A failed:', aiErrorSummary, err);
+                    aiText = `ALL PLAYS AI is temporarily unavailable (${aiErrorSummary}). Try again in a moment.`;
+                    showToast(`AI unavailable (${aiErrorSummary})`, 'error');
                 }
             } finally {
                 input.disabled = false;
@@ -2533,7 +3361,7 @@ ${text}
 
         function getTimelineDurationSummary() {
             const sessionDuration = parseInt(document.getElementById('session-duration').value, 10) || 60;
-            const allocated = state.canvasBlocks.reduce((sum, b) => sum + (parseInt(b.duration, 10) || 0), 0);
+            const allocated = getCanvasTotalMinutes();
             const gap = sessionDuration - allocated;
             return {
                 sessionDuration,
@@ -2543,8 +3371,30 @@ ${text}
             };
         }
 
+        function formatAiErrorSummary(err) {
+            if (!err) return 'unknown error';
+            const details = err?.customErrorData?.errorDetails;
+            const errorInfo = Array.isArray(details)
+                ? details.find(d => d && typeof d === 'object' && d.reason)
+                : null;
+            const reason = errorInfo?.reason || '';
+            const status = err?.customErrorData?.status ? `HTTP ${err.customErrorData.status}` : '';
+            const code = typeof err?.code === 'string' ? err.code : '';
+            const parts = [reason, status, code].filter(Boolean);
+            if (parts.length > 0) return parts.join(' | ');
+
+            const raw = typeof err?.message === 'string' ? err.message : 'unknown error';
+            return raw.replace(/\s+/g, ' ').trim().slice(0, 160);
+        }
+
         async function generateAiPlan(userPrompt, attendanceSummary, targetMinutes, planScope = 'full-session') {
-            const context = await buildAiPromptContext(attendanceSummary, userPrompt, targetMinutes, planScope);
+            let context;
+            try {
+                context = await buildAiPromptContext(attendanceSummary, userPrompt, targetMinutes, planScope);
+            } catch (err) {
+                console.warn('AI plan context build failed, using minimal context:', err);
+                context = buildMinimalAiPromptContext(attendanceSummary, userPrompt, targetMinutes, planScope);
+            }
             const app = getApp();
             const ai = getAI(app, { backend: new GoogleAIBackend() });
             const model = getGenerativeModel(ai, { model: 'gemini-2.5-flash' });
@@ -2561,11 +3411,17 @@ Hard constraints:
 - If plan scope is "full-session", include warm-up and cool-down considerations.
 - Prefer drills that match recent negative trends from recent games.
 
+You may optionally wrap drill blocks in structure containers (warmup, stations, scrimmage, cooldown, custom).
+Structure blocks group drills into logical practice phases. Use them when building full-session plans.
+
 Return ONLY valid JSON in this shape:
 {
   "assistantMessage": "short coaching rationale",
   "coreBlocks": [
-    { "title": "string", "type": "Technical|Tactical|Physical|Game|Warm-up", "duration": 12, "description": "string", "notes": "string" }
+    { "title": "string", "type": "Technical|Tactical|Physical|Game|Warm-up", "duration": 12, "description": "string", "notes": "string" },
+    { "blockType": "structure", "structureType": "warmup|stations|scrimmage|cooldown|custom", "title": "string", "duration": 15, "notes": "string", "groupCount": null, "rotationTime": null, "children": [
+      { "title": "string", "type": "Technical", "duration": 5, "description": "string" }
+    ]}
   ]
 }
 
@@ -2586,12 +3442,18 @@ ${userPrompt}
 
         async function generateAiAnswer(userPrompt, attendanceSummary) {
             const timelineSummary = getTimelineDurationSummary();
-            const context = await buildAiPromptContext(
-                attendanceSummary,
-                userPrompt,
-                timelineSummary.sessionDuration,
-                'qa'
-            );
+            let context;
+            try {
+                context = await buildAiPromptContext(
+                    attendanceSummary,
+                    userPrompt,
+                    timelineSummary.sessionDuration,
+                    'qa'
+                );
+            } catch (err) {
+                console.warn('AI Q&A context build failed, using minimal context:', err);
+                context = buildMinimalAiPromptContext(attendanceSummary, userPrompt, timelineSummary.sessionDuration, 'qa');
+            }
             const app = getApp();
             const ai = getAI(app, { backend: new GoogleAIBackend() });
             const model = getGenerativeModel(ai, { model: 'gemini-2.5-flash' });
@@ -2620,24 +3482,66 @@ ${userPrompt}
             return parsed.assistantMessage || 'I could not find enough context to answer that clearly yet.';
         }
 
+        function buildMinimalAiPromptContext(attendanceSummary, userPrompt = '', targetMinutes = null, planScope = 'full-session') {
+            const sessionDuration = parseInt(document.getElementById('session-duration').value, 10) || 60;
+            const sessionDate = document.getElementById('session-date').value || new Date().toISOString().split('T')[0];
+            return {
+                team: {
+                    id: state.teamId,
+                    name: state.team?.name || '',
+                    sport: state.team?.sport || 'Soccer'
+                },
+                eventContext: {
+                    eventId: state.eventId || null,
+                    sourcePage: state.sourcePage || 'drills',
+                    eventDate: state.eventMeta?.date || null,
+                    eventDuration: state.eventMeta?.duration || null,
+                    eventLocation: state.eventMeta?.location || null
+                },
+                sessionDuration,
+                targetPlanMinutes: targetMinutes || sessionDuration,
+                planScope,
+                sessionDate,
+                attendance: attendanceSummary,
+                coachPrompt: userPrompt || '',
+                note: 'Using minimal context because full Firestore context is unavailable.'
+            };
+        }
+
         async function buildAiPromptContext(attendanceSummary, userPrompt = '', targetMinutes = null, planScope = 'full-session') {
             const sport = state.team?.sport || 'Soccer';
             const sessionDuration = parseInt(document.getElementById('session-duration').value, 10) || 60;
             const sessionDate = document.getElementById('session-date').value || new Date().toISOString().split('T')[0];
 
             if (!state.aiDrillContext?.community || state.aiDrillContext.community.length === 0) {
-                const communityResult = await getDrills({ sport, limitCount: 12 });
-                state.aiDrillContext = {
-                    ...(state.aiDrillContext || {}),
-                    community: communityResult.drills || []
-                };
+                try {
+                    const communityResult = await getDrills({ sport, limitCount: 12 });
+                    state.aiDrillContext = {
+                        ...(state.aiDrillContext || {}),
+                        community: communityResult.drills || []
+                    };
+                } catch (err) {
+                    console.warn('AI context: unable to load community drills:', err);
+                    state.aiDrillContext = {
+                        ...(state.aiDrillContext || {}),
+                        community: []
+                    };
+                }
             }
             if (!state.aiDrillContext?.myDrills && state.accessLevel === 'full') {
-                const myDrills = await getTeamDrills(state.teamId);
-                state.aiDrillContext = {
-                    ...(state.aiDrillContext || {}),
-                    myDrills: myDrills.slice(0, 12)
-                };
+                try {
+                    const myDrills = await getTeamDrills(state.teamId);
+                    state.aiDrillContext = {
+                        ...(state.aiDrillContext || {}),
+                        myDrills: myDrills.slice(0, 12)
+                    };
+                } catch (err) {
+                    console.warn('AI context: unable to load team drills, continuing with community drills only:', err);
+                    state.aiDrillContext = {
+                        ...(state.aiDrillContext || {}),
+                        myDrills: []
+                    };
+                }
             }
 
             const libraryShortlist = [...(state.aiDrillContext?.myDrills || []), ...(state.aiDrillContext?.community || [])]
@@ -2660,8 +3564,23 @@ ${userPrompt}
             const recentGamesRaw = (state.recentGames || []).map(g => normalizeForAiPayload(g, 0));
             const recentWindowRaw = (state.allGames || []).slice(-10).reverse().map(g => normalizeForAiPayload(g, 0));
             const scoringLeaders = deriveScoringLeaders(recentWindowRaw);
-            const rawGameContext = await ensureRawGameContext();
-            const drillUniverse = await ensureAiDrillUniverse();
+            let rawGameContext = {
+                recentGameIds: [],
+                aggregatedStatsByPlayer: {},
+                recentEventsByGame: {}
+            };
+            try {
+                rawGameContext = await ensureRawGameContext();
+            } catch (err) {
+                console.warn('AI context: unable to load raw game context:', err);
+            }
+
+            let drillUniverse = [];
+            try {
+                drillUniverse = await ensureAiDrillUniverse();
+            } catch (err) {
+                console.warn('AI context: unable to load drill universe:', err);
+            }
             const drillTopMatches = getRelevantDrillMatches(drillUniverse, userPrompt, attendanceSummary, 40);
             const drillCatalog = drillUniverse.slice(0, 500).map(d => ({
                 id: d.id,
@@ -2703,9 +3622,11 @@ ${userPrompt}
                 attendance: attendanceSummary,
                 currentCanvas: state.canvasBlocks.map((b, idx) => ({
                     order: idx,
-                    title: b.drillTitle,
-                    type: b.type,
-                    duration: b.duration
+                    blockType: b.blockType || 'drill',
+                    title: b.drillTitle || b.title,
+                    type: b.type || b.structureType,
+                    duration: b.duration,
+                    ...(b.blockType === 'structure' ? { structureType: b.structureType, children: (b.children || []).map(c => c.drillTitle || c.title) } : {})
                 })),
                 recentGames: recentGameContext,
                 recentGamesRaw,
@@ -2828,6 +3749,11 @@ ${userPrompt}
             const includeBuffers = options.includeBuffers !== false;
             const warmupDuration = includeBuffers ? (totalDuration === 60 ? 10 : Math.max(8, Math.round(totalDuration * 0.15))) : 0;
             const cooldownDuration = includeBuffers ? (totalDuration === 60 ? 5 : Math.max(5, Math.round(totalDuration * 0.1))) : 0;
+            // Check if the AI returned structure blocks; if so, pass them through directly
+            const hasStructureBlocks = Array.isArray(coreBlocks) && coreBlocks.some(b => b.blockType === 'structure');
+            if (hasStructureBlocks) {
+                return coreBlocks; // normalizeProposalBlocks will handle them downstream
+            }
             const usableCore = Array.isArray(coreBlocks) ? coreBlocks.slice(0, 3) : [];
             const rawCoreTotal = usableCore.reduce((sum, b) => sum + (parseInt(b.duration, 10) || 0), 0);
             const remainingCoreTarget = Math.max(10, totalDuration - warmupDuration - cooldownDuration);
@@ -3368,6 +4294,50 @@ ${userPrompt}
             renderPracticeDrill();
         }
 
+        function getPracticePlaybackBlocks() {
+            const blocks = [];
+            (state.canvasBlocks || []).forEach((b) => {
+                if (b?.blockType === 'structure') {
+                    const children = Array.isArray(b.children) ? b.children : [];
+                    if (children.length === 0) {
+                        blocks.push({
+                            drillTitle: b.title || getStructureLabel(b.structureType),
+                            type: getStructureLabel(b.structureType),
+                            duration: Math.max(1, parseInt(b.duration, 10) || 1),
+                            description: b.notes || '',
+                            notes: b.notes || '',
+                            notesLog: Array.isArray(b.notesLog) ? b.notesLog : [],
+                            _source: b
+                        });
+                        return;
+                    }
+                    children.forEach((child, idx) => {
+                        blocks.push({
+                            drillTitle: child.drillTitle || child.title || `${b.title || getStructureLabel(b.structureType)} ${idx + 1}`,
+                            type: child.type || 'Technical',
+                            duration: Math.max(1, parseInt(child.duration, 10) || 1),
+                            description: child.description || child.notes || '',
+                            notes: child.notes || '',
+                            notesLog: Array.isArray(child.notesLog) ? child.notesLog : [],
+                            _source: child
+                        });
+                    });
+                    return;
+                }
+
+                blocks.push({
+                    drillTitle: b.drillTitle || b.title || 'Drill',
+                    type: b.type || 'Technical',
+                    duration: Math.max(1, parseInt(b.duration, 10) || 1),
+                    description: b.description || '',
+                    notes: b.notes || '',
+                    notesLog: Array.isArray(b.notesLog) ? b.notesLog : [],
+                    _source: b
+                });
+            });
+            return blocks;
+        }
+
         function stopActiveVoiceRecognition() {
             if (state.activeVoiceRecognition && state.voiceListening) {
                 try { state.activeVoiceRecognition.stop(); } catch (_) {}
@@ -3390,7 +4360,7 @@ ${userPrompt}
         }
 
         function renderPracticeDrill() {
-            const blocks = state.canvasBlocks;
+            const blocks = getPracticePlaybackBlocks();
             const idx = state.practiceIndex;
             const counter = document.getElementById('practice-drill-counter');
             counter.textContent = blocks.length ? `Drill ${idx + 1} of ${blocks.length}` : 'No drills';
@@ -3405,10 +4375,13 @@ ${userPrompt}
             }
 
             const b = blocks[idx];
-            document.getElementById('practice-type-badge').className = `${getTypeClass(b.type)} text-xs font-bold px-3 py-1 rounded-full uppercase`;
-            document.getElementById('practice-type-badge').textContent = b.type;
-            document.getElementById('practice-drill-title').textContent = b.drillTitle;
-            document.getElementById('practice-drill-desc').textContent = b.description || '';
+            const displayType = b.type || 'Technical';
+            const displayTitle = b.drillTitle || 'Drill';
+            const displayDesc = b.description || '';
+            document.getElementById('practice-type-badge').className = `${getTypeClass(displayType)} text-xs font-bold px-3 py-1 rounded-full uppercase`;
+            document.getElementById('practice-type-badge').textContent = displayType;
+            document.getElementById('practice-drill-title').textContent = displayTitle;
+            document.getElementById('practice-drill-desc').textContent = displayDesc;
 
             state.practiceSecondsLeft = (b.duration || 1) * 60;
             updateTimerDisplay();
@@ -3431,8 +4404,8 @@ ${userPrompt}
             if (idx < blocks.length - 1) {
                 const next = blocks[idx + 1];
                 document.getElementById('practice-next-btn').classList.remove('hidden');
-                document.getElementById('practice-next-title').textContent = next.drillTitle;
-                document.getElementById('practice-next-meta').textContent = `${next.duration} min \u00b7 ${next.type}`;
+                document.getElementById('practice-next-title').textContent = next.drillTitle || 'Next drill';
+                document.getElementById('practice-next-meta').textContent = `${next.duration} min \u00b7 ${next.type || 'Technical'}`;
             } else {
                 document.getElementById('practice-next-btn').classList.add('hidden');
             }
@@ -3445,7 +4418,7 @@ ${userPrompt}
         }
 
         function practiceToggle() {
-            if (state.canvasBlocks.length === 0) return;
+            if (getPracticePlaybackBlocks().length === 0) return;
             state.practiceRunning = !state.practiceRunning;
             const icon = document.getElementById('practice-play-icon');
             if (state.practiceRunning) {
@@ -3471,7 +4444,7 @@ ${userPrompt}
         }
 
         function practiceNext() {
-            if (state.practiceIndex < state.canvasBlocks.length - 1) {
+            if (state.practiceIndex < getPracticePlaybackBlocks().length - 1) {
                 stopActiveVoiceRecognition();
                 state.practiceIndex++;
                 state.practiceRunning = false;
@@ -3493,7 +4466,7 @@ ${userPrompt}
         }
 
         function appendPracticeNote(text, type = 'text') {
-            const block = state.canvasBlocks[state.practiceIndex];
+            const block = getPracticePlaybackBlocks()[state.practiceIndex]?._source;
             if (!block) return false;
             const clean = (text || '').trim();
             if (!clean) return false;

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -2028,12 +2028,19 @@
 
         function normalizeAssignments(value) {
             if (!Array.isArray(value)) return [];
-            return value
+            const normalized = value
                 .map((a) => ({
                     role: String(a?.role || '').trim(),
                     value: String(a?.value || '').trim()
                 }))
                 .filter((a) => a.role);
+            if (value.length > normalized.length) {
+                console.warn('Bulk AI assignments: dropped malformed entries', {
+                    provided: value.length,
+                    kept: normalized.length
+                });
+            }
+            return normalized;
         }
 
         function formatAssignmentsForInput(assignments) {

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -118,6 +118,37 @@
                                 class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2">
                         </div>
                         <div>
+                            <label class="block text-sm font-medium text-gray-700">Home / Away</label>
+                            <div class="mt-1 flex gap-2">
+                                <button type="button" id="homeAwayHome" class="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-indigo-50 focus:outline-none transition" onclick="setHomeAway('home')">Home</button>
+                                <button type="button" id="homeAwayAway" class="flex-1 px-3 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-indigo-50 focus:outline-none transition" onclick="setHomeAway('away')">Away</button>
+                                <button type="button" id="homeAwayClear" class="px-3 py-2 border border-gray-300 rounded-md text-sm text-gray-400 hover:bg-gray-50 focus:outline-none transition" onclick="setHomeAway(null)">Clear</button>
+                            </div>
+                            <input type="hidden" id="isHome" value="">
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700">Kit Color</label>
+                            <input type="text" id="kitColor" placeholder="e.g. White home kit"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2">
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700">Arrival Time</label>
+                            <input type="datetime-local" id="arrivalTime"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2">
+                            <p class="text-xs text-gray-500 mt-1">When players should arrive (if different from game time)</p>
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700">Notes</label>
+                            <textarea id="gameNotes" rows="2" placeholder="Optional game notes..."
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2"></textarea>
+                        </div>
+                        <!-- Assignments Section -->
+                        <div id="assignments-section">
+                            <label class="block text-sm font-medium text-gray-700 mb-1">Assignments</label>
+                            <div id="assignment-rows" class="space-y-2"></div>
+                            <button type="button" id="add-assignment-btn" class="mt-2 text-sm text-indigo-600 hover:text-indigo-800 font-medium">+ Add Assignment</button>
+                        </div>
+                        <div>
                             <label class="block text-sm font-medium text-gray-700">Stat Config</label>
                             <select id="statConfig"
                                 class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2">
@@ -369,6 +400,20 @@
         </div>
     </main>
 
+    <!-- RSVP Detail Modal -->
+    <div id="rsvp-modal" class="hidden fixed inset-0 z-50">
+        <div class="absolute inset-0 bg-black/50" onclick="document.getElementById('rsvp-modal').classList.add('hidden')"></div>
+        <div class="absolute inset-y-0 right-0 w-full max-w-md bg-white shadow-2xl overflow-y-auto">
+            <div class="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between z-10">
+                <h3 class="text-lg font-bold text-gray-900">RSVPs</h3>
+                <button onclick="document.getElementById('rsvp-modal').classList.add('hidden')" class="text-gray-400 hover:text-gray-700">
+                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+                </button>
+            </div>
+            <div id="rsvp-modal-content" class="px-6 py-5"></div>
+        </div>
+    </div>
+
     <div id="footer-container"></div>
 
     <!-- Track Calendar Event Modal -->
@@ -517,8 +562,8 @@
     </div>
 
     <script type="module">
-        import { getTeam, getTeams, getGames, getEvents, addGame, updateGame, deleteGame, addPractice, updateEvent, deleteEvent, getConfigs, addCalendarToTeam, removeCalendarFromTeam, getTrackedCalendarEventUids, cancelOccurrence, updateOccurrence, restoreOccurrence, clearOccurrenceOverride, updateSeries, deleteSeries, getUnreadChatCount, getPracticeSessions } from './js/db.js?v=18';
-        import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, formatTimeRange, getDefaultEndTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, generateSeriesId, expandRecurrence, formatRecurrence, shareOrCopy } from './js/utils.js?v=8';
+        import { getTeam, getTeams, getGames, getEvents, addGame, updateGame, deleteGame, addPractice, updateEvent, deleteEvent, getConfigs, addCalendarToTeam, removeCalendarFromTeam, getTrackedCalendarEventUids, cancelOccurrence, updateOccurrence, restoreOccurrence, clearOccurrenceOverride, updateSeries, deleteSeries, getUnreadChatCount, getPracticeSessions, cancelGame, getLatestGameAssignments, postChatMessage, getRsvps } from './js/db.js?v=20';
+        import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, formatTimeRange, getDefaultEndTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, generateSeriesId, expandRecurrence, formatRecurrence, shareOrCopy, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { Timestamp } from "./js/firebase.js?v=9";
@@ -965,6 +1010,84 @@
                     handleTrackClick(gameId);
                 });
             });
+
+            // Attach cancel game button handlers
+            document.querySelectorAll('.cancel-game-btn').forEach(btn => {
+                btn.addEventListener('click', async (e) => {
+                    const gameId = e.target.dataset.gameId;
+                    const game = gamesCache[gameId];
+                    if (!game) return;
+                    if (!confirm(`Cancel the game vs. ${game.opponent}? This will notify the team via chat.`)) return;
+                    try {
+                        await cancelGame(currentTeamId, gameId, currentUser.uid);
+                        // Post cancellation to team chat
+                        const gameDate = game.date?.toDate ? game.date.toDate() : new Date(game.date);
+                        const dateStr = gameDate.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+                        await postChatMessage(currentTeamId, {
+                            text: `⚠️ Game cancelled: vs. ${game.opponent} on ${dateStr}`,
+                            senderId: currentUser.uid,
+                            senderName: currentUser.displayName || currentUser.email,
+                            senderEmail: currentUser.email
+                        });
+                        loadSchedule();
+                    } catch (err) {
+                        console.error('Failed to cancel game:', err);
+                        alert('Error cancelling game: ' + err.message);
+                    }
+                });
+            });
+
+            // Attach RSVP view button handlers
+            document.querySelectorAll('.view-rsvps-btn').forEach(btn => {
+                btn.addEventListener('click', async (e) => {
+                    const gameId = e.target.dataset.gameId;
+                    const modal = document.getElementById('rsvp-modal');
+                    const content = document.getElementById('rsvp-modal-content');
+                    content.innerHTML = '<div class="text-center py-8"><div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600 mx-auto"></div></div>';
+                    modal.classList.remove('hidden');
+                    try {
+                        const rsvps = await getRsvps(currentTeamId, gameId);
+                        if (rsvps.length === 0) {
+                            content.innerHTML = '<p class="text-gray-500 text-center py-8">No RSVPs yet.</p>';
+                            return;
+                        }
+                        const grouped = { going: [], maybe: [], not_going: [] };
+                        rsvps.forEach(r => {
+                            if (grouped[r.response]) grouped[r.response].push(r);
+                        });
+                        content.innerHTML = `
+                            <div class="space-y-4">
+                                <div>
+                                    <h4 class="text-sm font-bold text-green-700 mb-2">Going (${grouped.going.length})</h4>
+                                    ${grouped.going.length ? grouped.going.map((r) => {
+                                        const name = escapeHtml(r.displayName || r.userId || 'Unknown');
+                                        const note = r.note ? ` <span class="text-gray-400 text-xs">- ${escapeHtml(r.note)}</span>` : '';
+                                        return `<div class="text-sm py-1">${name}${note}</div>`;
+                                    }).join('') : '<p class="text-xs text-gray-400">None</p>'}
+                                </div>
+                                <div>
+                                    <h4 class="text-sm font-bold text-yellow-700 mb-2">Maybe (${grouped.maybe.length})</h4>
+                                    ${grouped.maybe.length ? grouped.maybe.map((r) => {
+                                        const name = escapeHtml(r.displayName || r.userId || 'Unknown');
+                                        const note = r.note ? ` <span class="text-gray-400 text-xs">- ${escapeHtml(r.note)}</span>` : '';
+                                        return `<div class="text-sm py-1">${name}${note}</div>`;
+                                    }).join('') : '<p class="text-xs text-gray-400">None</p>'}
+                                </div>
+                                <div>
+                                    <h4 class="text-sm font-bold text-red-700 mb-2">Can't Go (${grouped.not_going.length})</h4>
+                                    ${grouped.not_going.length ? grouped.not_going.map((r) => {
+                                        const name = escapeHtml(r.displayName || r.userId || 'Unknown');
+                                        const note = r.note ? ` <span class="text-gray-400 text-xs">- ${escapeHtml(r.note)}</span>` : '';
+                                        return `<div class="text-sm py-1">${name}${note}</div>`;
+                                    }).join('') : '<p class="text-xs text-gray-400">None</p>'}
+                                </div>
+                            </div>
+                        `;
+                    } catch (err) {
+                        content.innerHTML = `<p class="text-red-600 text-center py-8">Error loading RSVPs: ${err.message}</p>`;
+                    }
+                });
+            });
         }
 
         // Render practice events (single or recurring instance)
@@ -1178,11 +1301,21 @@
                 <div class="p-6 hover:bg-gray-50 flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
                     <div>
                         <div class="text-sm text-gray-500 font-semibold uppercase tracking-wide mb-1">${formatDate(game.date)} • ${formatTime(game.date)}</div>
-                        <div class="text-lg font-bold text-gray-900">vs. ${game.opponent}</div>
+                        <div class="text-lg font-bold text-gray-900">vs. ${escapeHtml(game.opponent || 'TBD')}</div>
                         <div class="text-sm text-gray-600">
-                            ${mapLink(game.location) ? `<a class="text-indigo-600 hover:underline" target="_blank" rel="noopener noreferrer" href="${mapLink(game.location)}">${game.location || 'TBD'}</a>` : (game.location || 'TBD')}
+                            ${mapLink(game.location) ? `<a class="text-indigo-600 hover:underline" target="_blank" rel="noopener noreferrer" href="${mapLink(game.location)}">${escapeHtml(game.location || 'TBD')}</a>` : escapeHtml(game.location || 'TBD')}
                         </div>
+                        <div class="flex flex-wrap gap-1 mt-1">
+                            ${game.isHome === true ? '<span class="inline-block bg-blue-100 text-blue-800 text-xs px-2 py-0.5 rounded-full font-semibold">HOME</span>' : ''}
+                            ${game.isHome === false ? '<span class="inline-block bg-gray-100 text-gray-700 text-xs px-2 py-0.5 rounded-full font-semibold">AWAY</span>' : ''}
+                            ${game.kitColor ? `<span class="inline-block bg-purple-100 text-purple-800 text-xs px-2 py-0.5 rounded-full font-semibold">${escapeHtml(game.kitColor)}</span>` : ''}
+                        </div>
+                        ${game.arrivalTime ? `<div class="text-xs text-amber-700 mt-1">Arrive: ${formatTime(game.arrivalTime)}</div>` : ''}
+                        ${game.notes ? `<div class="text-xs text-gray-500 mt-1 italic">${escapeHtml(game.notes)}</div>` : ''}
+                        ${game.assignments && game.assignments.length > 0 ? `<div class="mt-1 text-xs text-gray-600">${game.assignments.map(a => `<span class="inline-block bg-gray-100 rounded px-1.5 py-0.5 mr-1 mb-1"><b>${escapeHtml(a.role)}:</b> ${escapeHtml(a.value || 'TBD')}</span>`).join('')}</div>` : ''}
                         ${isCompleted ? `<span class="inline-block bg-green-100 text-green-800 text-xs px-2 py-1 rounded-full font-semibold mt-2">Final: ${game.homeScore}-${game.awayScore}</span>` : ''}
+                        ${game.status === 'cancelled' ? '<div class="mt-1"><span class="inline-block bg-red-100 text-red-800 text-xs px-2 py-1 rounded-full font-semibold">CANCELLED</span></div>' : ''}
+                        ${game.rsvpSummary ? `<div class="text-xs text-gray-500 mt-1">${game.rsvpSummary.going || 0} going · ${game.rsvpSummary.maybe || 0} maybe · ${game.rsvpSummary.notGoing || 0} can't go</div>` : ''}
                     </div>
                     <div class="flex flex-wrap gap-2">
                         <button data-game-id="${game.id}" class="edit-game-btn px-3 py-1 bg-blue-100 text-blue-700 rounded text-sm hover:bg-blue-200">Edit</button>
@@ -1192,6 +1325,8 @@
                         ${isCompleted ? `<a href="game.html#teamId=${currentTeamId}&gameId=${game.id}" class="px-3 py-1 bg-green-100 text-green-700 rounded text-sm hover:bg-green-200">Report</a>` : ''}
                         ${game.liveStatus === 'completed' ? `<a href="live-game.html?teamId=${currentTeamId}&gameId=${game.id}&replay=true" class="px-3 py-1 bg-teal-100 text-teal-700 rounded text-sm hover:bg-teal-200">Watch Replay</a>` : ''}
                         <a href="game-plan.html#teamId=${currentTeamId}&gameId=${game.id}" class="px-3 py-1 bg-primary-100 text-primary-700 rounded text-sm hover:bg-primary-200">Game Plan</a>
+                        <button data-game-id="${game.id}" class="view-rsvps-btn px-3 py-1 bg-green-100 text-green-700 rounded text-sm hover:bg-green-200">RSVPs</button>
+                        ${game.status !== 'cancelled' ? `<button data-game-id="${game.id}" class="cancel-game-btn px-3 py-1 border border-orange-300 text-orange-600 rounded text-sm hover:bg-orange-50">Cancel</button>` : '<span class="px-3 py-1 bg-red-100 text-red-700 rounded text-sm font-semibold">Cancelled</span>'}
                         <button data-id="${game.id}" class="px-3 py-1 border border-red-300 text-red-600 rounded text-sm hover:bg-red-50 delete-btn">Delete</button>
                     </div>
                 </div>
@@ -1226,6 +1361,19 @@
                 clearLinkedOpponent();
             }
 
+            // Populate new fields
+            setHomeAway(game.isHome === true ? 'home' : (game.isHome === false ? 'away' : null));
+            document.getElementById('kitColor').value = game.kitColor || '';
+            if (game.arrivalTime) {
+                const at = game.arrivalTime.toDate ? game.arrivalTime.toDate() : new Date(game.arrivalTime);
+                const atStr = new Date(at.getTime() - at.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
+                document.getElementById('arrivalTime').value = atStr;
+            } else {
+                document.getElementById('arrivalTime').value = '';
+            }
+            document.getElementById('gameNotes').value = game.notes || '';
+            populateAssignments(game.assignments || []);
+
             // Update UI
             document.getElementById('submit-game-btn').textContent = 'Update Game';
             document.getElementById('cancel-edit-game-btn').classList.remove('hidden');
@@ -1234,12 +1382,71 @@
             document.getElementById('add-game-form').scrollIntoView({ behavior: 'smooth' });
         };
 
+        // ===== HOME/AWAY TOGGLE =====
+        window.setHomeAway = function(val) {
+            document.getElementById('isHome').value = val === null ? '' : val;
+            document.getElementById('homeAwayHome').className = `flex-1 px-3 py-2 border rounded-md text-sm font-medium focus:outline-none transition ${val === 'home' ? 'border-indigo-600 bg-indigo-600 text-white' : 'border-gray-300 text-gray-700 hover:bg-indigo-50'}`;
+            document.getElementById('homeAwayAway').className = `flex-1 px-3 py-2 border rounded-md text-sm font-medium focus:outline-none transition ${val === 'away' ? 'border-indigo-600 bg-indigo-600 text-white' : 'border-gray-300 text-gray-700 hover:bg-indigo-50'}`;
+        };
+
+        // ===== ASSIGNMENT ROWS =====
+        function addAssignmentRow(role = '', value = '') {
+            const container = document.getElementById('assignment-rows');
+            const row = document.createElement('div');
+            row.className = 'flex gap-2 items-center';
+            row.innerHTML = `
+                <input type="text" placeholder="Role (e.g. Snack)" value="${role}" class="assignment-role flex-1 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm">
+                <input type="text" placeholder="Assigned to" value="${value}" class="assignment-value flex-1 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm">
+                <button type="button" class="text-red-400 hover:text-red-600 text-lg font-bold" onclick="this.parentElement.remove()">&times;</button>
+            `;
+            container.appendChild(row);
+        }
+
+        document.getElementById('add-assignment-btn').addEventListener('click', () => addAssignmentRow());
+
+        function getAssignmentsFromForm() {
+            const rows = document.querySelectorAll('#assignment-rows .flex');
+            const assignments = [];
+            rows.forEach(row => {
+                const role = row.querySelector('.assignment-role').value.trim();
+                const value = row.querySelector('.assignment-value').value.trim();
+                if (role) assignments.push({ role, value });
+            });
+            return assignments;
+        }
+
+        function populateAssignments(assignments) {
+            const container = document.getElementById('assignment-rows');
+            container.innerHTML = '';
+            if (assignments && assignments.length > 0) {
+                assignments.forEach(a => addAssignmentRow(a.role, a.value));
+            }
+        }
+
         function resetGameForm() {
             editingGameId = null;
             document.getElementById('add-game-form').reset();
             document.getElementById('submit-game-btn').textContent = 'Add Game';
             document.getElementById('cancel-edit-game-btn').classList.add('hidden');
             clearLinkedOpponent();
+            setHomeAway(null);
+            document.getElementById('kitColor').value = '';
+            document.getElementById('arrivalTime').value = '';
+            document.getElementById('gameNotes').value = '';
+            document.getElementById('assignment-rows').innerHTML = '';
+        }
+
+        // Pre-populate assignments for new games from the latest game
+        async function prefillAssignments() {
+            if (editingGameId) return; // Don't prefill when editing
+            try {
+                const latest = await getLatestGameAssignments(currentTeamId);
+                if (latest && latest.length > 0) {
+                    populateAssignments(latest.map(a => ({ role: a.role, value: '' })));
+                }
+            } catch (e) {
+                console.log('Could not prefill assignments:', e);
+            }
         }
 
         document.getElementById('cancel-edit-game-btn').addEventListener('click', resetGameForm);
@@ -1254,6 +1461,8 @@
             if (!dateVal) return;
 
             try {
+                const isHomeVal = document.getElementById('isHome').value;
+                const arrivalVal = document.getElementById('arrivalTime').value;
                 const gameData = {
                     type: 'game',
                     date: Timestamp.fromDate(new Date(dateVal)),
@@ -1262,7 +1471,12 @@
                     statTrackerConfigId: configId || null,
                     opponentTeamId: selectedOpponentTeam ? selectedOpponentTeam.id : null,
                     opponentTeamName: selectedOpponentTeam ? selectedOpponentTeam.name || opponent : null,
-                    opponentTeamPhoto: selectedOpponentTeam ? selectedOpponentTeam.photoUrl || null : null
+                    opponentTeamPhoto: selectedOpponentTeam ? selectedOpponentTeam.photoUrl || null : null,
+                    isHome: isHomeVal === 'home' ? true : (isHomeVal === 'away' ? false : null),
+                    kitColor: document.getElementById('kitColor').value.trim() || null,
+                    arrivalTime: arrivalVal ? Timestamp.fromDate(new Date(arrivalVal)) : null,
+                    notes: document.getElementById('gameNotes').value.trim() || null,
+                    assignments: getAssignmentsFromForm()
                 };
 
                 if (editingGameId) {
@@ -1733,7 +1947,10 @@
             });
         }
 
-        document.getElementById('tab-add-game').addEventListener('click', () => switchTab('tab-add-game'));
+        document.getElementById('tab-add-game').addEventListener('click', () => {
+            switchTab('tab-add-game');
+            if (!editingGameId) prefillAssignments();
+        });
         document.getElementById('tab-add-practice').addEventListener('click', () => switchTab('tab-add-practice'));
         document.getElementById('tab-bulk-ai').addEventListener('click', () => switchTab('tab-bulk-ai'));
 
@@ -1791,6 +2008,66 @@
             };
         }
 
+        function normalizeIsHome(value) {
+            if (value === true || value === false || value === null) return value;
+            if (typeof value === 'string') {
+                const v = value.trim().toLowerCase();
+                if (v === 'home') return true;
+                if (v === 'away') return false;
+                if (v === '' || v === 'unknown' || v === 'null') return null;
+            }
+            return null;
+        }
+
+        function formatIsoForInput(value) {
+            if (!value) return '';
+            const d = value?.toDate ? value.toDate() : new Date(value);
+            if (Number.isNaN(d.getTime())) return '';
+            return new Date(d.getTime() - d.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
+        }
+
+        function normalizeAssignments(value) {
+            if (!Array.isArray(value)) return [];
+            return value
+                .map((a) => ({
+                    role: String(a?.role || '').trim(),
+                    value: String(a?.value || '').trim()
+                }))
+                .filter((a) => a.role);
+        }
+
+        function formatAssignmentsForInput(assignments) {
+            const normalized = normalizeAssignments(assignments);
+            return normalized.map((a) => `${a.role}:${a.value || ''}`).join('; ');
+        }
+
+        function parseAssignmentsInput(text) {
+            if (!text || !text.trim()) return [];
+            return text
+                .split(';')
+                .map((chunk) => {
+                    const [rolePart, ...valueParts] = chunk.split(':');
+                    return {
+                        role: (rolePart || '').trim(),
+                        value: valueParts.join(':').trim()
+                    };
+                })
+                .filter((a) => a.role);
+        }
+
+        function normalizeBulkGameForAdd(game) {
+            const normalizedIsHome = normalizeIsHome(game?.isHome);
+            const rawKitColor = typeof game?.kitColor === 'string' ? game.kitColor.trim() : '';
+            const kitColor = rawKitColor || (normalizedIsHome === true ? 'Home kit' : (normalizedIsHome === false ? 'Away kit' : 'TBD kit'));
+            return {
+                ...game,
+                isHome: normalizedIsHome,
+                kitColor,
+                notes: game?.notes ? String(game.notes).trim() : null,
+                assignments: normalizeAssignments(game?.assignments || [])
+            };
+        }
+
         // Process with AI
         document.getElementById('process-ai-btn').addEventListener('click', async () => {
             const textInput = document.getElementById('bulk-text-input').value.trim();
@@ -1843,20 +2120,44 @@
                                             date: Schema.string(),
                                             opponent: Schema.string(),
                                             location: Schema.string(),
+                                            isHome: Schema.boolean(),
+                                            kitColor: Schema.string(),
+                                            arrivalTime: Schema.string(),
+                                            notes: Schema.string(),
+                                            assignments: Schema.array({
+                                                items: Schema.object({
+                                                    properties: {
+                                                        role: Schema.string(),
+                                                        value: Schema.string()
+                                                    }
+                                                })
+                                            }),
                                             status: Schema.string(),
                                             homeScore: Schema.number(),
                                             awayScore: Schema.number()
                                         },
-                                        optionalProperties: ["status", "homeScore", "awayScore"]
+                                        optionalProperties: ["isHome", "kitColor", "arrivalTime", "notes", "assignments", "status", "homeScore", "awayScore"]
                                     }),
                                     gameId: Schema.string(),
                                     changes: Schema.object({
                                         properties: {
                                             date: Schema.string(),
                                             opponent: Schema.string(),
-                                            location: Schema.string()
+                                            location: Schema.string(),
+                                            isHome: Schema.boolean(),
+                                            kitColor: Schema.string(),
+                                            arrivalTime: Schema.string(),
+                                            notes: Schema.string(),
+                                            assignments: Schema.array({
+                                                items: Schema.object({
+                                                    properties: {
+                                                        role: Schema.string(),
+                                                        value: Schema.string()
+                                                    }
+                                                })
+                                            })
                                         },
-                                        optionalProperties: ["date", "opponent", "location"]
+                                        optionalProperties: ["date", "opponent", "location", "isHome", "kitColor", "arrivalTime", "notes", "assignments"]
                                     }),
                                     reason: Schema.string()
                                 },
@@ -1887,7 +2188,13 @@ PARSING RULES:
    - "11/15" = November 15, "Sat 11/22" = November 22
    - Use year ${currentYear} for future dates, ${currentYear + 1} for past dates
 6. Time: "8:30 AM" = 08:30:00, "2:20 PM" = 14:20:00, "12:00 PM" = 12:00:00
-7. For each game, create an operation with action="add" and game object with date, opponent, location, status="scheduled", homeScore=0, awayScore=0`;
+7. Extract extra fields when available:
+   - Home/Away -> isHome (true for home, false for away)
+   - Kit/Uniform color -> kitColor
+   - Arrival/check-in time -> arrivalTime (ISO 8601 datetime)
+   - Notes/comments -> notes
+   - Assignments (snack, carpool, etc.) -> assignments array: [{ role, value }]
+8. For each game, create an operation with action="add" and game object with date, opponent, location, status="scheduled", homeScore=0, awayScore=0`;
 
                 // Call Firebase AI with structured output
                 const firebaseApp = getApp();
@@ -1918,7 +2225,12 @@ PARSING RULES:
                 }
 
                 // Store operations and render preview
-                proposedOperations = aiResponse.operations;
+                proposedOperations = aiResponse.operations.map((op) => {
+                    if (op.action === 'add' && op.game) {
+                        return { ...op, game: normalizeBulkGameForAdd(op.game) };
+                    }
+                    return op;
+                });
 
                 if (proposedOperations.length === 0) {
                     alert('AI did not find any games to add/update/delete in the text. Please try being more specific with dates and opponents.');
@@ -1988,6 +2300,24 @@ PARSING RULES:
                                         <input type="text" value="${game.location || ''}" placeholder="Location"
                                             onchange="updateOperation(${index}, 'location', this.value)"
                                             class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full">
+                                        <select onchange="updateOperation(${index}, 'isHome', this.value)"
+                                            class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mt-1">
+                                            <option value="" ${game.isHome === null || game.isHome === undefined ? 'selected' : ''}>Home/Away Unknown</option>
+                                            <option value="home" ${game.isHome === true ? 'selected' : ''}>Home</option>
+                                            <option value="away" ${game.isHome === false ? 'selected' : ''}>Away</option>
+                                        </select>
+                                        <input type="text" value="${game.kitColor || ''}" placeholder="Kit color"
+                                            onchange="updateOperation(${index}, 'kitColor', this.value)"
+                                            class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mt-1">
+                                        <input type="datetime-local" value="${formatIsoForInput(game.arrivalTime)}"
+                                            onchange="updateOperation(${index}, 'arrivalTime', this.value)"
+                                            class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mt-1">
+                                        <textarea rows="2" placeholder="Notes"
+                                            onchange="updateOperation(${index}, 'notes', this.value)"
+                                            class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mt-1">${game.notes || ''}</textarea>
+                                        <input type="text" value="${formatAssignmentsForInput(game.assignments)}" placeholder="Assignments: Role:Value; Role2:Value2"
+                                            onchange="updateOperation(${index}, 'assignments', this.value)"
+                                            class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mt-1">
                                     </div>
                                     ${hasConflict ? `<div class="text-xs text-yellow-700 mt-1">⚠️ Similar game exists within 24 hours</div>` : ''}
                                 </div>
@@ -2058,6 +2388,12 @@ PARSING RULES:
             if (proposedOperations[index].action === 'add') {
                 if (field === 'date') {
                     proposedOperations[index].game[field] = new Date(value).toISOString();
+                } else if (field === 'arrivalTime') {
+                    proposedOperations[index].game[field] = value ? new Date(value).toISOString() : null;
+                } else if (field === 'isHome') {
+                    proposedOperations[index].game[field] = normalizeIsHome(value);
+                } else if (field === 'assignments') {
+                    proposedOperations[index].game[field] = parseAssignmentsInput(value);
                 } else {
                     proposedOperations[index].game[field] = value;
                 }
@@ -2098,13 +2434,19 @@ PARSING RULES:
                 for (const op of proposedOperations) {
                     try {
                         if (op.action === 'add') {
+                            const normalizedGame = normalizeBulkGameForAdd(op.game);
                             const gameData = {
-                                ...op.game,
+                                ...normalizedGame,
                                 type: 'game',
-                                date: Timestamp.fromDate(new Date(op.game.date)),
-                                status: op.game.status || 'scheduled',
-                                homeScore: op.game.homeScore || 0,
-                                awayScore: op.game.awayScore || 0
+                                date: Timestamp.fromDate(new Date(normalizedGame.date)),
+                                isHome: normalizedGame.isHome,
+                                kitColor: normalizedGame.kitColor,
+                                arrivalTime: normalizedGame.arrivalTime ? Timestamp.fromDate(new Date(normalizedGame.arrivalTime)) : null,
+                                notes: normalizedGame.notes,
+                                assignments: normalizedGame.assignments,
+                                status: normalizedGame.status || 'scheduled',
+                                homeScore: normalizedGame.homeScore || 0,
+                                awayScore: normalizedGame.awayScore || 0
                             };
                             await addGame(currentTeamId, gameData);
                             successCount++;
@@ -2112,6 +2454,21 @@ PARSING RULES:
                             const changes = { ...op.changes };
                             if (changes.date) {
                                 changes.date = Timestamp.fromDate(new Date(changes.date));
+                            }
+                            if ('arrivalTime' in changes) {
+                                changes.arrivalTime = changes.arrivalTime ? Timestamp.fromDate(new Date(changes.arrivalTime)) : null;
+                            }
+                            if ('isHome' in changes) {
+                                changes.isHome = normalizeIsHome(changes.isHome);
+                            }
+                            if ('kitColor' in changes) {
+                                changes.kitColor = changes.kitColor ? String(changes.kitColor).trim() : null;
+                            }
+                            if ('notes' in changes) {
+                                changes.notes = changes.notes ? String(changes.notes).trim() : null;
+                            }
+                            if ('assignments' in changes) {
+                                changes.assignments = normalizeAssignments(changes.assignments);
                             }
                             await updateGame(currentTeamId, op.gameId, changes);
                             successCount++;

--- a/firestore.rules
+++ b/firestore.rules
@@ -20,11 +20,19 @@ service cloud.firestore {
       return isSignedIn() && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.isAdmin == true;
     }
 
+    function isCoachForTeam(teamId) {
+      let userPath = /databases/$(database)/documents/users/$(request.auth.uid);
+      return isSignedIn() &&
+             exists(userPath) &&
+             teamId in get(userPath).data.get('coachOf', []);
+    }
+
     function isTeamOwnerOrAdmin(teamId) {
       return isSignedIn() &&
              (get(/databases/$(database)/documents/teams/$(teamId)).data.ownerId == request.auth.uid ||
               (request.auth.token.email != null &&
                request.auth.token.email.lower() in get(/databases/$(database)/documents/teams/$(teamId)).data.get('adminEmails', [])) ||
+              isCoachForTeam(teamId) ||
               isGlobalAdmin());
     }
 
@@ -55,6 +63,7 @@ service cloud.firestore {
       let isOwnerOrAdmin = team.ownerId == request.auth.uid ||
         (request.auth.token.email != null &&
          request.auth.token.email.lower() in team.get('adminEmails', [])) ||
+        isCoachForTeam(teamId) ||
         isGlobalAdmin();
 
       return isSignedIn() && (isOwnerOrAdmin || isParentForTeam(teamId));
@@ -222,6 +231,16 @@ service cloud.firestore {
           allow create: if true;  // Anyone can react
           allow update, delete: if false;  // Reactions are immutable
         }
+
+        // RSVP subcollection - game attendance responses
+        match /rsvps/{rsvpId} {
+          allow read: if isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId);
+          allow create, update: if (isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId)) &&
+                                   isSignedIn() && rsvpId == request.auth.uid &&
+                                   request.resource.data.userId == request.auth.uid;
+          allow delete: if (isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId)) &&
+                           isSignedIn() && rsvpId == request.auth.uid;
+        }
       }
 
       // Stat tracker configs subcollection
@@ -264,6 +283,12 @@ service cloud.firestore {
                             completionId == request.auth.uid + "__" + resource.data.childId &&
                             isParentForPlayer(teamId, resource.data.childId));
         }
+      }
+
+      // Practice Templates subcollection
+      match /practiceTemplates/{templateId} {
+        allow read: if isTeamOwnerOrAdmin(teamId);
+        allow create, update, delete: if isTeamOwnerOrAdmin(teamId);
       }
 
       // Chat messages subcollection

--- a/js/db.js
+++ b/js/db.js
@@ -1985,7 +1985,10 @@ export async function getLatestGameAssignments(teamId) {
 
 export async function submitRsvp(teamId, gameId, userId, { displayName, playerIds, response, note }) {
     const authUid = auth.currentUser?.uid || null;
-    const effectiveUserId = authUid || userId || null;
+    if (userId && authUid && userId !== authUid) {
+        throw new Error('RSVP user mismatch. Please refresh and try again.');
+    }
+    const effectiveUserId = userId || authUid || null;
     if (!effectiveUserId) {
         throw new Error('You must be signed in to submit RSVP');
     }

--- a/js/db.js
+++ b/js/db.js
@@ -230,7 +230,7 @@ export async function updateTeam(teamId, teamData) {
 
 export async function deleteTeam(teamId) {
     // Delete games and their subcollections
-    const gamesSnapshot = await getDocs(collection(db, `teams / ${teamId}/games`));
+    const gamesSnapshot = await getDocs(collection(db, `teams/${teamId}/games`));
     for (const gameDoc of gamesSnapshot.docs) {
         const gameId = gameDoc.id;
         // Remove events

--- a/js/team-admin-banner.js
+++ b/js/team-admin-banner.js
@@ -13,7 +13,9 @@ export function getTeamAccessInfo(user, team) {
 
   // Check for full access: owner, admin, coach, or platform admin
   const isOwner = team.ownerId === user.uid;
-  const isTeamAdmin = (team.adminEmails || []).includes(user.email);
+  const normalizedEmail = (user.email || '').toLowerCase();
+  const adminEmails = (team.adminEmails || []).map(email => String(email || '').toLowerCase());
+  const isTeamAdmin = adminEmails.includes(normalizedEmail);
   const isPlatformAdmin = user.isAdmin === true;
   const isCoach = (user.coachOf || []).includes(team.id);
 
@@ -202,4 +204,3 @@ export function renderTeamAdminBanner(container, { team, teamId, active = '', un
     </div>
   `;
 }
-

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -211,6 +211,16 @@
         window.openPracticePacketPreview = openPracticePacketPreview;
         window.closePracticePacketPreview = closePracticePacketPreview;
         window.markPracticePacketComplete = markPracticePacketComplete;
+        window.submitGameRsvpFromButton = submitGameRsvpFromButton;
+
+        function escapeAttr(value) {
+            return String(value ?? '')
+                .replace(/&/g, '&amp;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;');
+        }
 
         window.submitGameRsvp = async function(teamId, gameId, response) {
             try {
@@ -236,6 +246,13 @@
                 alert('Failed to submit RSVP: ' + err.message);
             }
         };
+
+        function submitGameRsvpFromButton(btn, response) {
+            const teamId = btn?.dataset?.teamId || '';
+            const gameId = btn?.dataset?.gameId || '';
+            if (!teamId || !gameId) return;
+            window.submitGameRsvp(teamId, gameId, response);
+        }
 
         function hasRecordedAttendance(attendance) {
             if (!attendance || !Array.isArray(attendance.players) || attendance.players.length === 0) return false;
@@ -725,9 +742,9 @@
                                     <div class="text-[11px] font-bold uppercase tracking-wide text-gray-500 mb-2">RSVP</div>
                                     ${ev.isDbGame ? `
                                         <div class="flex gap-2">
-                                            <button onclick="submitGameRsvp('${ev.teamId}', '${ev.id}', 'going')" class="rsvp-btn rsvp-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'going' ? 'bg-green-600 text-white border-green-600' : 'bg-white text-green-700 border-green-300 hover:bg-green-50'}">Going</button>
-                                            <button onclick="submitGameRsvp('${ev.teamId}', '${ev.id}', 'maybe')" class="rsvp-btn rsvp-maybe flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'maybe' ? 'bg-yellow-500 text-white border-yellow-500' : 'bg-white text-yellow-700 border-yellow-300 hover:bg-yellow-50'}">Maybe</button>
-                                            <button onclick="submitGameRsvp('${ev.teamId}', '${ev.id}', 'not_going')" class="rsvp-btn rsvp-not-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'not_going' ? 'bg-red-500 text-white border-red-500' : 'bg-white text-red-700 border-red-300 hover:bg-red-50'}">Can't Go</button>
+                                            <button data-team-id="${escapeAttr(ev.teamId)}" data-game-id="${escapeAttr(ev.id)}" onclick="submitGameRsvpFromButton(this, 'going')" class="rsvp-btn rsvp-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'going' ? 'bg-green-600 text-white border-green-600' : 'bg-white text-green-700 border-green-300 hover:bg-green-50'}">Going</button>
+                                            <button data-team-id="${escapeAttr(ev.teamId)}" data-game-id="${escapeAttr(ev.id)}" onclick="submitGameRsvpFromButton(this, 'maybe')" class="rsvp-btn rsvp-maybe flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'maybe' ? 'bg-yellow-500 text-white border-yellow-500' : 'bg-white text-yellow-700 border-yellow-300 hover:bg-yellow-50'}">Maybe</button>
+                                            <button data-team-id="${escapeAttr(ev.teamId)}" data-game-id="${escapeAttr(ev.id)}" onclick="submitGameRsvpFromButton(this, 'not_going')" class="rsvp-btn rsvp-not-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'not_going' ? 'bg-red-500 text-white border-red-500' : 'bg-white text-red-700 border-red-300 hover:bg-red-50'}">Can't Go</button>
                                         </div>
                                     ` : `<div class="text-xs text-gray-500">RSVP opens after coach tracks this event as a game.</div>`}
                                     ${ev.rsvpSummary ? `<div class="text-xs text-gray-500 mt-1">${ev.rsvpSummary.going || 0} going · ${ev.rsvpSummary.maybe || 0} maybe · ${ev.rsvpSummary.notGoing || 0} can't go</div>` : '<div class="text-xs text-gray-400 mt-1">No RSVPs yet.</div>'}
@@ -1172,10 +1189,10 @@
                         <div class="mt-3 border-t border-gray-100 pt-3">
                             <div class="text-[11px] font-bold uppercase tracking-wide text-gray-500 mb-2">RSVP</div>
                             ${game.isDbGame ? `
-                                <div class="flex gap-2" id="rsvp-buttons-${game.teamId}-${game.id}">
-                                    <button onclick="submitGameRsvp('${game.teamId}', '${game.id}', 'going')" class="rsvp-btn rsvp-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${game.myRsvp === 'going' ? 'bg-green-600 text-white border-green-600' : 'bg-white text-green-700 border-green-300 hover:bg-green-50'}">Going</button>
-                                    <button onclick="submitGameRsvp('${game.teamId}', '${game.id}', 'maybe')" class="rsvp-btn rsvp-maybe flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${game.myRsvp === 'maybe' ? 'bg-yellow-500 text-white border-yellow-500' : 'bg-white text-yellow-700 border-yellow-300 hover:bg-yellow-50'}">Maybe</button>
-                                    <button onclick="submitGameRsvp('${game.teamId}', '${game.id}', 'not_going')" class="rsvp-btn rsvp-not-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${game.myRsvp === 'not_going' ? 'bg-red-500 text-white border-red-500' : 'bg-white text-red-700 border-red-300 hover:bg-red-50'}">Can't Go</button>
+                                <div class="flex gap-2">
+                                    <button data-team-id="${escapeAttr(game.teamId)}" data-game-id="${escapeAttr(game.id)}" onclick="submitGameRsvpFromButton(this, 'going')" class="rsvp-btn rsvp-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${game.myRsvp === 'going' ? 'bg-green-600 text-white border-green-600' : 'bg-white text-green-700 border-green-300 hover:bg-green-50'}">Going</button>
+                                    <button data-team-id="${escapeAttr(game.teamId)}" data-game-id="${escapeAttr(game.id)}" onclick="submitGameRsvpFromButton(this, 'maybe')" class="rsvp-btn rsvp-maybe flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${game.myRsvp === 'maybe' ? 'bg-yellow-500 text-white border-yellow-500' : 'bg-white text-yellow-700 border-yellow-300 hover:bg-yellow-50'}">Maybe</button>
+                                    <button data-team-id="${escapeAttr(game.teamId)}" data-game-id="${escapeAttr(game.id)}" onclick="submitGameRsvpFromButton(this, 'not_going')" class="rsvp-btn rsvp-not-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${game.myRsvp === 'not_going' ? 'bg-red-500 text-white border-red-500' : 'bg-white text-red-700 border-red-300 hover:bg-red-50'}">Can't Go</button>
                                 </div>
                             ` : `<div class="text-xs text-gray-500">RSVP opens after coach tracks this event as a game.</div>`}
                             ${game.rsvpSummary ? `<div class="text-[10px] text-gray-400 mt-1">${game.rsvpSummary.going || 0} going · ${game.rsvpSummary.maybe || 0} maybe · ${game.rsvpSummary.notGoing || 0} can't go</div>` : '<div class="text-[10px] text-gray-400 mt-1">No RSVPs yet.</div>'}
@@ -1204,6 +1221,11 @@
 
         function buildIcs(events) {
             const lines = ['BEGIN:VCALENDAR', 'VERSION:2.0', 'PRODID:-//ALL PLAYS//EN'];
+            const escapeIcsText = (value) => String(value || '')
+                .replace(/\\/g, '\\\\')
+                .replace(/;/g, '\\;')
+                .replace(/,/g, '\\,')
+                .replace(/\r?\n/g, '\\n');
 
             // Dedupe events by id to avoid duplicates for multiple kids on same team
             const seen = new Set();
@@ -1226,9 +1248,9 @@
                     `DTSTAMP:${formatIcsDate(new Date())}`,
                     `DTSTART:${start}`,
                     `DTEND:${end}`,
-                    `SUMMARY:${summary}`,
-                    `LOCATION:${(event.location || 'TBD').replace(/,/g, '\\,')}`,
-                    `DESCRIPTION:For ${event.childName}`,
+                    `SUMMARY:${escapeIcsText(summary)}`,
+                    `LOCATION:${escapeIcsText(event.location || 'TBD')}`,
+                    `DESCRIPTION:${escapeIcsText(`For ${event.childName}`)}`,
                     'END:VEVENT'
                 );
             });

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -45,8 +45,17 @@
     <main class="container mx-auto px-4 py-8 md:py-12">
         <!-- Page Header -->
         <div class="mb-8 md:mb-12">
-            <h1 class="text-3xl md:text-4xl lg:text-5xl font-bold mb-2 bg-gradient-to-r from-primary-600 to-primary-800 bg-clip-text text-transparent">Parent Dashboard</h1>
-            <p class="text-gray-600 text-sm md:text-base">Track your athletes' schedules and stats.</p>
+            <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+                <div>
+                    <h1 class="text-3xl md:text-4xl lg:text-5xl font-bold mb-2 bg-gradient-to-r from-primary-600 to-primary-800 bg-clip-text text-transparent">Parent Dashboard</h1>
+                    <p class="text-gray-600 text-sm md:text-base">Track your athletes' schedules and stats.</p>
+                </div>
+                <a href="calendar.html"
+                    class="inline-flex items-center gap-2 bg-white text-primary-600 px-4 py-3 rounded-xl border border-primary-200 hover:bg-primary-50 transition font-semibold text-sm">
+                    <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path></svg>
+                    Calendar
+                </a>
+            </div>
         </div>
 
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
@@ -91,6 +100,10 @@
                     <div class="p-6 border-b border-gray-100 bg-gray-50 flex justify-between items-center gap-3">
                         <h2 class="text-xl font-bold text-gray-900">Schedule</h2>
                         <div class="flex items-center gap-2">
+                            <div class="flex rounded-lg border border-gray-200 overflow-hidden">
+                                <button id="schedule-view-list" onclick="setScheduleView('list')" class="px-2.5 py-1 text-xs font-semibold bg-primary-600 text-white">List</button>
+                                <button id="schedule-view-calendar" onclick="setScheduleView('calendar')" class="px-2.5 py-1 text-xs font-semibold bg-white text-gray-600 hover:bg-gray-100">Calendar</button>
+                            </div>
                             <select id="player-filter" class="text-xs font-medium bg-white px-2 py-1 rounded border border-gray-200 text-gray-600 focus:outline-none focus:ring-1 focus:ring-primary-500 focus:border-primary-500">
                                 <option value="">All Players</option>
                             </select>
@@ -110,12 +123,18 @@
                             <button id="schedule-filter-past-all" onclick="setScheduleFilter('past-all')" class="px-2.5 py-1 text-xs font-semibold rounded-full border border-gray-200 bg-white text-gray-600 hover:bg-gray-100">Past Events</button>
                         </div>
                     </div>
+                    <div id="schedule-calendar-nav" class="hidden px-6 py-3 border-b border-gray-100 bg-white flex items-center justify-center gap-4">
+                        <button onclick="navScheduleMonth(-1)" class="px-3 py-1.5 rounded-lg bg-white border border-gray-200 text-gray-600 hover:bg-gray-50 text-sm font-medium">&larr; Prev</button>
+                        <span id="schedule-calendar-month-label" class="text-base font-bold text-gray-900"></span>
+                        <button onclick="navScheduleMonth(1)" class="px-3 py-1.5 rounded-lg bg-white border border-gray-200 text-gray-600 hover:bg-gray-50 text-sm font-medium">Next &rarr;</button>
+                    </div>
                     <div id="schedule-list" class="divide-y divide-gray-100">
                         <div class="text-center py-12">
                             <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mx-auto mb-2"></div>
                             <p class="text-sm text-gray-500">Loading schedule...</p>
                         </div>
                     </div>
+                    <div id="schedule-calendar-grid" class="hidden"></div>
                 </div>
                 <div id="practice-packets-card" class="bg-white rounded-2xl shadow-md border border-gray-200 overflow-hidden mt-6">
                     <div class="p-6 border-b border-gray-100 bg-gray-50">
@@ -151,9 +170,23 @@
             <div id="packet-preview-content" class="px-6 py-5"></div>
         </div>
     </div>
+    <div id="schedule-day-modal" class="hidden fixed inset-0 z-50">
+        <div class="absolute inset-0 bg-black/50" onclick="closeScheduleDayModal()"></div>
+        <div class="absolute inset-y-0 right-0 w-full max-w-lg bg-white shadow-2xl overflow-y-auto">
+            <div class="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between z-10">
+                <h3 id="schedule-day-modal-title" class="text-lg font-bold text-gray-900"></h3>
+                <button onclick="closeScheduleDayModal()" class="text-gray-400 hover:text-gray-700">
+                    <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+                    </svg>
+                </button>
+            </div>
+            <div id="schedule-day-modal-content" class="px-6 py-5"></div>
+        </div>
+    </div>
 
     <script type="module">
-        import { getParentDashboardData, redeemParentInvite, getTeam, getGames, getTrackedCalendarEventUids, getUnreadChatCounts, getPracticeSessions, getPracticePacketCompletions, upsertPracticePacketCompletion, updateUserProfile, getUserProfile } from './js/db.js?v=19';
+        import { getParentDashboardData, redeemParentInvite, getTeam, getGames, getTrackedCalendarEventUids, getUnreadChatCounts, getPracticeSessions, getPracticePacketCompletions, upsertPracticePacketCompletion, updateUserProfile, getUserProfile, submitRsvp, getMyRsvp } from './js/db.js?v=20';
         import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent } from './js/utils.js?v=8';
         import { requireAuth, checkAuth } from './js/auth.js?v=9';
 
@@ -165,12 +198,44 @@
         let allPracticePacketSessions = [];
         let practicePacketFilter = 'recent_upcoming';
         let scheduleViewFilter = 'upcoming-all';
+        let scheduleViewMode = 'list';
+        let scheduleCalendarMonth = new Date().getMonth();
+        let scheduleCalendarYear = new Date().getFullYear();
         const practicePacketSessionMap = new Map();
         window.setPracticePacketFilter = setPracticePacketFilter;
         window.setScheduleFilter = setScheduleFilter;
+        window.setScheduleView = setScheduleView;
+        window.navScheduleMonth = navScheduleMonth;
+        window.openScheduleDayModal = openScheduleDayModal;
+        window.closeScheduleDayModal = closeScheduleDayModal;
         window.openPracticePacketPreview = openPracticePacketPreview;
         window.closePracticePacketPreview = closePracticePacketPreview;
         window.markPracticePacketComplete = markPracticePacketComplete;
+
+        window.submitGameRsvp = async function(teamId, gameId, response) {
+            try {
+                const playerIds = allScheduleEvents
+                    .filter(e => e.teamId === teamId)
+                    .map(e => e.childId || e.playerId)
+                    .filter(Boolean);
+                const summary = await submitRsvp(teamId, gameId, currentUserId, {
+                    displayName: currentUser?.displayName || currentUser?.email,
+                    playerIds: [...new Set(playerIds)],
+                    response
+                });
+                // Update local state and re-render
+                const game = allScheduleEvents.find(e => e.teamId === teamId && e.id === gameId);
+                if (game) {
+                    game.myRsvp = response;
+                    if (summary) game.rsvpSummary = summary;
+                    else if (!game.rsvpSummary) game.rsvpSummary = { going: 0, maybe: 0, notGoing: 0, total: 0 };
+                }
+                renderScheduleFromControls();
+            } catch (err) {
+                console.error('RSVP error:', err);
+                alert('Failed to submit RSVP: ' + err.message);
+            }
+        };
 
         function hasRecordedAttendance(attendance) {
             if (!attendance || !Array.isArray(attendance.players) || attendance.players.length === 0) return false;
@@ -211,6 +276,27 @@
                 renderTeamChats(data.children, unreadCounts);
                 const combinedSchedule = await buildCombinedSchedule(data.children);
                 allScheduleEvents = combinedSchedule;
+
+                // Fetch my RSVPs for game events (deduped by team/game).
+                const uniqueGameKeys = [...new Set(
+                    allScheduleEvents
+                        .filter((event) => event.type === 'game' && !event.isCancelled && event.teamId && event.id)
+                        .map((event) => `${event.teamId}::${event.id}`)
+                )];
+                await Promise.all(uniqueGameKeys.map(async (key) => {
+                    const [teamId, gameId] = key.split('::');
+                    try {
+                        const myRsvp = await getMyRsvp(teamId, gameId, currentUserId);
+                        allScheduleEvents.forEach((event) => {
+                            if (event.teamId === teamId && event.id === gameId) {
+                                event.myRsvp = myRsvp ? myRsvp.response : null;
+                            }
+                        });
+                    } catch (e) {
+                        // Ignore per-game RSVP read failures.
+                    }
+                }));
+
                 allPracticePacketSessions = await buildPracticePacketSessions(data.children);
                 initPlayerFilter(data.children);
                 setScheduleFilter('upcoming-all');
@@ -342,6 +428,7 @@
                     const location = game.location || 'TBD';
                     const opponent = game.opponent || 'TBD';
                     const id = game.id || game.gameId;
+                    const isCancelled = game.status === 'cancelled';
                     const session = isPractice ? resolvePracticeSession(game, date) : null;
 
                     for (const child of teamChildren) {
@@ -352,8 +439,18 @@
                             opponent,
                             teamId,
                             id,
+                            isDbGame: true,
                             childId: child.playerId,
                             childName: child.playerName,
+                            title: game.title || null,
+                            status: game.status || 'scheduled',
+                            isCancelled,
+                            isHome: game.isHome ?? null,
+                            kitColor: game.kitColor || null,
+                            arrivalTime: game.arrivalTime || null,
+                            notes: game.notes || null,
+                            assignments: Array.isArray(game.assignments) ? game.assignments : [],
+                            rsvpSummary: game.rsvpSummary || null,
                             practiceAttendance: isPractice && hasRecordedAttendance(session?.attendance) ? session.attendance : null,
                             practiceHomePacket: isPractice && hasHomePacket(session) ? session.homePacketContent : null
                         });
@@ -402,6 +499,7 @@
                                         opponent,
                                         teamId,
                                         id: event.uid || null,
+                                        isDbGame: false,
                                         childId: child.playerId,
                                         childName: child.playerName,
                                         isCancelled,
@@ -433,6 +531,7 @@
                                 opponent: null,
                                 teamId,
                                 id: session.eventId || session.id,
+                                isDbGame: false,
                                 childId: child.playerId,
                                 childName: child.playerName,
                                 title: session.title || 'Practice',
@@ -489,7 +588,198 @@
 
         function renderScheduleFromControls(selectedPlayerId = '') {
             const playerId = selectedPlayerId || (document.getElementById('player-filter')?.value || '');
-            renderSchedule(getFilteredScheduleEvents(playerId));
+            const events = getFilteredScheduleEvents(playerId);
+            const listEl = document.getElementById('schedule-list');
+            const calEl = document.getElementById('schedule-calendar-grid');
+            const navEl = document.getElementById('schedule-calendar-nav');
+            if (!listEl || !calEl || !navEl) {
+                renderSchedule(events);
+                return;
+            }
+            if (scheduleViewMode === 'calendar') {
+                listEl.classList.add('hidden');
+                calEl.classList.remove('hidden');
+                navEl.classList.remove('hidden');
+                renderScheduleCalendar(events);
+            } else {
+                calEl.classList.add('hidden');
+                navEl.classList.add('hidden');
+                listEl.classList.remove('hidden');
+                renderSchedule(events);
+            }
+        }
+
+        function getCalendarEntries(events) {
+            const byKey = new Map();
+            (events || []).forEach((event) => {
+                const d = event.date?.toDate ? event.date.toDate() : new Date(event.date);
+                if (!d || Number.isNaN(d.getTime())) return;
+                const key = `${event.teamId || ''}::${event.id || ''}::${d.toISOString()}::${event.type || ''}`;
+                if (!byKey.has(key)) {
+                    byKey.set(key, { ...event, date: d, childNames: [] });
+                }
+                const item = byKey.get(key);
+                if (event.childName) item.childNames.push(event.childName);
+            });
+            return Array.from(byKey.values()).map((item) => ({
+                ...item,
+                childNames: [...new Set(item.childNames)]
+            }));
+        }
+
+        function renderScheduleCalendar(events) {
+            const container = document.getElementById('schedule-calendar-grid');
+            const label = document.getElementById('schedule-calendar-month-label');
+            if (!container || !label) return;
+
+            const monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+            label.textContent = `${monthNames[scheduleCalendarMonth]} ${scheduleCalendarYear}`;
+
+            const monthStart = new Date(scheduleCalendarYear, scheduleCalendarMonth, 1);
+            const monthEnd = new Date(scheduleCalendarYear, scheduleCalendarMonth + 1, 0, 23, 59, 59);
+            const firstDay = new Date(scheduleCalendarYear, scheduleCalendarMonth, 1);
+            const startDow = firstDay.getDay();
+            const daysInMonth = monthEnd.getDate();
+
+            const calendarEvents = getCalendarEntries(events).filter((ev) => ev.date >= monthStart && ev.date <= monthEnd);
+            const eventsByDay = {};
+            calendarEvents.forEach((ev) => {
+                const day = ev.date.getDate();
+                if (!eventsByDay[day]) eventsByDay[day] = [];
+                eventsByDay[day].push(ev);
+            });
+
+            const totalCells = Math.ceil((startDow + daysInMonth) / 7) * 7;
+            const today = new Date();
+            const isCurrentMonth = today.getMonth() === scheduleCalendarMonth && today.getFullYear() === scheduleCalendarYear;
+
+            let html = `
+                <div class="grid grid-cols-7 border-b border-gray-200 bg-gray-50">
+                    ${['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map((d) => `<div class="text-center text-xs font-bold text-gray-500 py-2">${d}</div>`).join('')}
+                </div>
+                <div class="grid grid-cols-7">
+            `;
+
+            for (let i = 0; i < totalCells; i++) {
+                const dayNum = i - startDow + 1;
+                const inMonth = dayNum >= 1 && dayNum <= daysInMonth;
+                const dayEvents = inMonth ? (eventsByDay[dayNum] || []) : [];
+                const isToday = isCurrentMonth && inMonth && dayNum === today.getDate();
+                html += `
+                    <div class="min-h-[96px] border border-gray-100 p-1.5 ${inMonth ? 'bg-white' : 'bg-gray-50 text-gray-300'} ${isToday ? 'ring-1 ring-primary-300' : ''} ${inMonth && dayEvents.length ? 'cursor-pointer hover:bg-gray-50' : ''}"
+                        ${inMonth && dayEvents.length ? `onclick="openScheduleDayModal(${scheduleCalendarYear}, ${scheduleCalendarMonth}, ${dayNum})"` : ''}>
+                        ${inMonth ? `<div class="text-xs font-semibold ${isToday ? 'text-primary-700' : 'text-gray-700'}">${dayNum}</div>` : ''}
+                        ${inMonth && dayEvents.length ? `
+                            <div class="mt-1 space-y-1">
+                                ${dayEvents.slice(0, 3).map((ev) => `
+                                    <div class="text-[10px] px-1 py-0.5 rounded truncate ${ev.type === 'practice' ? 'bg-amber-100 text-amber-800' : 'bg-primary-100 text-primary-800'}">
+                                        ${escapeHtml(ev.type === 'practice' ? (ev.title || 'Practice') : `vs. ${ev.opponent || 'TBD'}`)}
+                                        ${ev.type === 'game' ? `<span class="ml-1 text-[9px] opacity-70">(${ev.rsvpSummary?.going || 0}/${ev.rsvpSummary?.maybe || 0}/${ev.rsvpSummary?.notGoing || 0})</span>` : ''}
+                                    </div>
+                                `).join('')}
+                                ${dayEvents.length > 3 ? `<div class="text-[10px] text-gray-400">+${dayEvents.length - 3} more</div>` : ''}
+                            </div>
+                        ` : ''}
+                    </div>
+                `;
+            }
+            html += '</div>';
+            container.innerHTML = html;
+        }
+
+        function openScheduleDayModal(year, month, day) {
+            const titleEl = document.getElementById('schedule-day-modal-title');
+            const contentEl = document.getElementById('schedule-day-modal-content');
+            const modalEl = document.getElementById('schedule-day-modal');
+            if (!titleEl || !contentEl || !modalEl) return;
+
+            const dayStart = new Date(year, month, day);
+            const dayEnd = new Date(year, month, day, 23, 59, 59);
+            const playerId = document.getElementById('player-filter')?.value || '';
+            const events = getCalendarEntries(getFilteredScheduleEvents(playerId))
+                .filter((ev) => ev.date >= dayStart && ev.date <= dayEnd)
+                .sort((a, b) => a.date - b.date);
+
+            titleEl.textContent = dayStart.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
+            if (!events.length) {
+                contentEl.innerHTML = '<p class="text-gray-500 text-center py-8">No events on this day.</p>';
+            } else {
+                contentEl.innerHTML = events.map((ev) => {
+                    const timeStr = ev.date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+                    const title = ev.type === 'practice' ? (ev.title || 'Practice') : `vs. ${ev.opponent || 'TBD'}`;
+                    return `
+                        <div class="mb-4 p-4 rounded-lg border border-gray-200 ${ev.isCancelled ? 'opacity-60' : ''}">
+                            <div class="text-xs font-semibold uppercase ${ev.type === 'practice' ? 'text-amber-700' : 'text-primary-700'}">${ev.type}</div>
+                            <div class="font-bold text-gray-900 ${ev.isCancelled ? 'line-through' : ''}">${escapeHtml(title)}</div>
+                            <div class="text-sm text-gray-600 mt-1">${timeStr} · ${escapeHtml(ev.location || 'TBD')}</div>
+                            ${ev.type === 'game' && ev.isHome === true ? '<span class="inline-block text-xs bg-blue-100 text-blue-800 px-2 py-0.5 rounded-full font-semibold mt-1 mr-1">HOME</span>' : ''}
+                            ${ev.type === 'game' && ev.isHome === false ? '<span class="inline-block text-xs bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full font-semibold mt-1 mr-1">AWAY</span>' : ''}
+                            ${ev.kitColor ? `<div class="text-xs text-purple-700 mt-1">Kit: ${escapeHtml(ev.kitColor)}</div>` : ''}
+                            ${ev.arrivalTime ? `<div class="text-xs text-amber-700 mt-1">Arrive: ${(() => { const at = ev.arrivalTime?.toDate ? ev.arrivalTime.toDate() : new Date(ev.arrivalTime); return at.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }); })()}</div>` : ''}
+                            ${ev.notes ? `<div class="text-xs text-gray-500 mt-1 italic">${escapeHtml(ev.notes)}</div>` : ''}
+                            ${ev.assignments && ev.assignments.length > 0 ? `<div class="mt-1 text-xs text-gray-600">${ev.assignments.map(a => `<span class="inline-block bg-gray-100 rounded px-1.5 py-0.5 mr-1 mb-1"><b>${escapeHtml(a.role)}:</b> ${escapeHtml(a.value || 'TBD')}</span>`).join('')}</div>` : ''}
+                            ${ev.rsvpSummary ? `<div class="text-xs text-gray-500 mt-1">${ev.rsvpSummary.going || 0} going · ${ev.rsvpSummary.maybe || 0} maybe · ${ev.rsvpSummary.notGoing || 0} can't go</div>` : ''}
+                            ${ev.childNames?.length ? `<div class="text-xs text-gray-500 mt-1">For ${escapeHtml(ev.childNames.join(', '))}</div>` : ''}
+                            ${!ev.isCancelled && ev.type === 'game' ? `
+                                <div class="mt-3 border-t border-gray-100 pt-3">
+                                    <div class="text-[11px] font-bold uppercase tracking-wide text-gray-500 mb-2">RSVP</div>
+                                    ${ev.isDbGame ? `
+                                        <div class="flex gap-2">
+                                            <button onclick="submitGameRsvp('${ev.teamId}', '${ev.id}', 'going')" class="rsvp-btn rsvp-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'going' ? 'bg-green-600 text-white border-green-600' : 'bg-white text-green-700 border-green-300 hover:bg-green-50'}">Going</button>
+                                            <button onclick="submitGameRsvp('${ev.teamId}', '${ev.id}', 'maybe')" class="rsvp-btn rsvp-maybe flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'maybe' ? 'bg-yellow-500 text-white border-yellow-500' : 'bg-white text-yellow-700 border-yellow-300 hover:bg-yellow-50'}">Maybe</button>
+                                            <button onclick="submitGameRsvp('${ev.teamId}', '${ev.id}', 'not_going')" class="rsvp-btn rsvp-not-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'not_going' ? 'bg-red-500 text-white border-red-500' : 'bg-white text-red-700 border-red-300 hover:bg-red-50'}">Can't Go</button>
+                                        </div>
+                                    ` : `<div class="text-xs text-gray-500">RSVP opens after coach tracks this event as a game.</div>`}
+                                    ${ev.rsvpSummary ? `<div class="text-xs text-gray-500 mt-1">${ev.rsvpSummary.going || 0} going · ${ev.rsvpSummary.maybe || 0} maybe · ${ev.rsvpSummary.notGoing || 0} can't go</div>` : '<div class="text-xs text-gray-400 mt-1">No RSVPs yet.</div>'}
+                                </div>
+                            ` : ''}
+                            ${ev.isCancelled ? '<div class="text-xs text-red-700 mt-1 font-semibold">Cancelled</div>' : ''}
+                        </div>
+                    `;
+                }).join('');
+            }
+            modalEl.classList.remove('hidden');
+        }
+
+        function closeScheduleDayModal() {
+            document.getElementById('schedule-day-modal')?.classList.add('hidden');
+        }
+
+        function setScheduleView(mode) {
+            scheduleViewMode = mode === 'calendar' ? 'calendar' : 'list';
+            const listBtn = document.getElementById('schedule-view-list');
+            const calBtn = document.getElementById('schedule-view-calendar');
+            if (scheduleViewMode === 'calendar') {
+                const playerId = document.getElementById('player-filter')?.value || '';
+                const events = getCalendarEntries(getFilteredScheduleEvents(playerId));
+                if (events.length > 0) {
+                    const hasCurrentMonthEvents = events.some((ev) =>
+                        ev.date.getMonth() === scheduleCalendarMonth && ev.date.getFullYear() === scheduleCalendarYear
+                    );
+                    if (!hasCurrentMonthEvents) {
+                        scheduleCalendarMonth = events[0].date.getMonth();
+                        scheduleCalendarYear = events[0].date.getFullYear();
+                    }
+                }
+            }
+            if (listBtn && calBtn) {
+                const listActive = scheduleViewMode === 'list';
+                listBtn.className = `px-2.5 py-1 text-xs font-semibold ${listActive ? 'bg-primary-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-100'}`;
+                calBtn.className = `px-2.5 py-1 text-xs font-semibold ${!listActive ? 'bg-primary-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-100'}`;
+            }
+            renderScheduleFromControls();
+        }
+
+        function navScheduleMonth(delta) {
+            scheduleCalendarMonth += delta;
+            if (scheduleCalendarMonth > 11) {
+                scheduleCalendarMonth = 0;
+                scheduleCalendarYear += 1;
+            } else if (scheduleCalendarMonth < 0) {
+                scheduleCalendarMonth = 11;
+                scheduleCalendarYear -= 1;
+            }
+            if (scheduleViewMode === 'calendar') renderScheduleFromControls();
         }
 
         function setScheduleFilter(next) {
@@ -854,6 +1144,12 @@
                             </svg>
                             ${escapeHtml(game.location || 'TBD')}
                         </div>
+                        ${game.type !== 'practice' && game.isHome === true ? '<span class="inline-block text-xs bg-blue-100 text-blue-800 px-2 py-0.5 rounded-full font-semibold mt-1 mr-1">HOME</span>' : ''}
+                        ${game.type !== 'practice' && game.isHome === false ? '<span class="inline-block text-xs bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full font-semibold mt-1 mr-1">AWAY</span>' : ''}
+                        ${game.kitColor ? `<div class="text-xs text-purple-700 mt-1">Kit: ${escapeHtml(game.kitColor)}</div>` : ''}
+                        ${game.arrivalTime ? `<div class="text-xs text-amber-700 mt-1">Arrive: ${(() => { const at = game.arrivalTime?.toDate ? game.arrivalTime.toDate() : new Date(game.arrivalTime); return at.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }); })()}</div>` : ''}
+                        ${game.notes ? `<div class="text-xs text-gray-500 mt-1 italic">${escapeHtml(game.notes)}</div>` : ''}
+                        ${game.assignments && game.assignments.length > 0 ? `<div class="mt-1 text-xs text-gray-600">${game.assignments.map(a => `<span class="inline-block bg-gray-100 rounded px-1.5 py-0.5 mr-1 mb-1"><b>${escapeHtml(a.role)}:</b> ${escapeHtml(a.value || 'TBD')}</span>`).join('')}</div>` : ''}
                         ${attendanceRecorded ? `
                             <div class="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2">
                                 <div class="text-[11px] font-bold uppercase tracking-wide text-amber-800">Practice Attendance</div>
@@ -872,7 +1168,20 @@
                             </div>
                         ` : ''}
                     </div>
-                    ${!isCancelled ? `
+                    ${!isCancelled && game.type === 'game' ? `
+                        <div class="mt-3 border-t border-gray-100 pt-3">
+                            <div class="text-[11px] font-bold uppercase tracking-wide text-gray-500 mb-2">RSVP</div>
+                            ${game.isDbGame ? `
+                                <div class="flex gap-2" id="rsvp-buttons-${game.teamId}-${game.id}">
+                                    <button onclick="submitGameRsvp('${game.teamId}', '${game.id}', 'going')" class="rsvp-btn rsvp-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${game.myRsvp === 'going' ? 'bg-green-600 text-white border-green-600' : 'bg-white text-green-700 border-green-300 hover:bg-green-50'}">Going</button>
+                                    <button onclick="submitGameRsvp('${game.teamId}', '${game.id}', 'maybe')" class="rsvp-btn rsvp-maybe flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${game.myRsvp === 'maybe' ? 'bg-yellow-500 text-white border-yellow-500' : 'bg-white text-yellow-700 border-yellow-300 hover:bg-yellow-50'}">Maybe</button>
+                                    <button onclick="submitGameRsvp('${game.teamId}', '${game.id}', 'not_going')" class="rsvp-btn rsvp-not-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${game.myRsvp === 'not_going' ? 'bg-red-500 text-white border-red-500' : 'bg-white text-red-700 border-red-300 hover:bg-red-50'}">Can't Go</button>
+                                </div>
+                            ` : `<div class="text-xs text-gray-500">RSVP opens after coach tracks this event as a game.</div>`}
+                            ${game.rsvpSummary ? `<div class="text-[10px] text-gray-400 mt-1">${game.rsvpSummary.going || 0} going · ${game.rsvpSummary.maybe || 0} maybe · ${game.rsvpSummary.notGoing || 0} can't go</div>` : '<div class="text-[10px] text-gray-400 mt-1">No RSVPs yet.</div>'}
+                        </div>
+                    ` : ''}
+                    ${!isCancelled && game.isDbGame ? `
                     <div class="flex-shrink-0 text-right">
                          <a href="game.html?teamId=${game.teamId}&gameId=${game.id}"
                             class="inline-flex items-center gap-1 text-sm font-medium text-primary-600 hover:text-primary-700">

--- a/spec/feature-requests/tasks.md
+++ b/spec/feature-requests/tasks.md
@@ -1,0 +1,180 @@
+# Feature Requests Implementation Plan
+
+## Context
+
+The user has requested enhancements across four areas: game schedule fields, practice planner improvements, drill enhancements, and a new global calendar page. All work will be done on a new feature branch. The app is static HTML + vanilla JS + Firebase with no build step.
+
+---
+
+## Phase 1: Game Schedule Field Extensions
+
+**Files:** `edit-schedule.html`, `team.html`, `parent-dashboard.html`, `js/db.js`
+
+**New fields on game documents** (`/teams/{teamId}/games/{gameId}`):
+- `isHome` (Boolean|null) — Home/Away toggle
+- `kitColor` (String|null) — Free text, e.g. "White home kit"
+- `arrivalTime` (Timestamp|null) — Separate from game time
+- `notes` (String|null) — Free text
+- `cancelledAt`, `cancelledBy` — Set when `status` is changed to `'cancelled'`
+
+**Steps:**
+1. Add form fields (Home/Away toggle, Kit Color input, Arrival Time picker, Notes textarea) to the game form in `edit-schedule.html` (~line 92-136)
+2. Update `startEditGame()` (~line 1201) to populate new fields when editing
+3. Update form submit handler (~line 1247) to include new fields in `gameData`
+4. Add "Cancel Game" button to game cards in `edit-schedule.html`. On click: set `status: 'cancelled'` and auto-post cancellation message to team chat (using existing `postChatMessage()` pattern)
+5. Update `renderDbGame()` in `team.html` (~line 981) to display: HOME/AWAY badge, kit color, arrival time, notes, and cancelled state (strikethrough + red badge)
+6. Update `parent-dashboard.html` event rendering to show new fields
+7. Add `cancelGame(teamId, gameId, userId)` helper to `db.js`
+
+---
+
+## Phase 2: Game Assignments with Carry-Forward
+
+**Files:** `edit-schedule.html`, `team.html`, `parent-dashboard.html`, `js/db.js`
+
+**New field on game documents:**
+- `assignments` — Array of `{ role: String, value: String }` (e.g. `{ role: "Snack", value: "John's family" }`)
+
+**Steps:**
+1. Add dynamic "Assignments" section to game form — rows with role + value text inputs, "Add Row" button
+2. Add `getLatestGameAssignments(teamId)` to `db.js` — queries most recent game with assignments to carry forward role names and optionally values
+3. On new game creation, pre-populate assignment roles from the latest game
+4. Display assignments on game cards in `team.html` and `parent-dashboard.html`
+
+**Depends on:** Phase 1
+
+---
+
+## Phase 3: Availability / RSVP
+
+**Files:** `parent-dashboard.html`, `team.html`, `edit-schedule.html`, `js/db.js`, `firestore.rules`
+
+**New subcollection:** `/teams/{teamId}/games/{gameId}/rsvps/{userId}`
+```
+{ userId, displayName, playerIds[], response: "going"|"maybe"|"not_going", respondedAt, note }
+```
+
+**Denormalized summary on game doc:** `rsvpSummary: { going, maybe, notGoing, total }`
+
+**Steps:**
+1. Add Firestore security rules for RSVP subcollection (user writes own RSVP, coach reads all)
+2. Add `submitRsvp()`, `getRsvps()`, `getMyRsvp()` to `db.js`
+3. Add RSVP buttons (Going / Maybe / Not Going) to event cards in `parent-dashboard.html`
+4. Show RSVP summary counts on game cards in `team.html`
+5. Add RSVP detail view for coaches (modal in `edit-schedule.html`)
+
+**Depends on:** Phase 1
+
+---
+
+## Phase 4: Drill Enhancements (YouTube + Diagrams)
+
+**Files:** `drills.html`, `js/db.js`
+
+**New fields on drill documents:**
+- `youtubeUrl` (String|null)
+- `diagramUrls` (String[] — up to 5 image URLs)
+
+Images upload to `game-flow-img` Firebase Storage at `drill-diagrams/{drillId}/{timestamp}_{filename}`
+
+**Steps:**
+1. Add YouTube URL text input to drill create/edit form in `drills.html`
+2. Add YouTube embed rendering in drill detail modal (parse video ID, render iframe)
+3. Add multi-file upload UI with preview thumbnails for diagram images (using existing `firebase-images.js` pattern)
+4. Add `uploadDrillDiagram(drillId, file)` to `db.js`
+5. Add image gallery in drill detail modal (horizontal scroll, click to enlarge)
+6. Update `createDrill()` and `updateDrill()` in `db.js` to include new fields
+
+**No dependencies — can run in parallel with Phases 1-3**
+
+---
+
+## Phase 5: Practice Planner Enhancements
+
+**Files:** `drills.html`, `js/db.js`
+
+### 5A: Edit Drill on Canvas
+- Add "Edit" button to each canvas block (~line 1722)
+- Open inline expansion with: custom instructions textarea, duration override, notes
+- Save to `state.canvasBlocks[index].customInstructions` / `customSetup`
+
+### 5B: Practice Structure Blocks
+New block type in `practiceSession.blocks[]`:
+```
+{
+    blockType: "structure",
+    structureType: "warmup"|"stations"|"scrimmage"|"cooldown"|"custom",
+    title: String, duration: Number,
+    groupCount: Number|null, rotationTime: Number|null,
+    grouping: String|null,  // e.g. "3 rotating stations, 4-5 players per coach"
+    notes: String|null,
+    children: [ /* nested drill blocks */ ]
+}
+```
+
+**Steps:**
+1. Add "Add Structure Block" button above canvas with picker (Warm-up, Stations, Scrimmage, Cooldown, Custom)
+2. Update `renderCanvas()` to render structure blocks as container cards with nested drill areas
+3. Extend drag-and-drop to support dropping drills into structure block children
+4. For "Stations" type: show group count, rotation time, and multiple concurrent drill slots
+
+### 5C: AI Structure Proposals + Templates
+- Extend AI chat to propose a structure when starting a new session
+- Add "Save as Template" / "Load Template" UI
+- Add `savePracticeTemplate()`, `getPracticeTemplates()`, `deletePracticeTemplate()` to `db.js`
+- Templates stored at `/teams/{teamId}/practiceTemplates/{templateId}`
+
+**Depends on:** Phase 4
+
+---
+
+## Phase 6: Global Calendar Page
+
+**Files:** NEW `calendar.html`, `dashboard.html`, `js/db.js`
+
+Design modeled after `/Users/paulsnider/paulsnidernet/family/events.html`:
+
+**Three views:** Detailed list, Compact list, Calendar grid (month view)
+
+**Filters:** Time range (Week/Month/Quarter/All), Event type (Games/Practices/All), Team filter
+
+**Steps:**
+1. Create `calendar.html` with Tailwind-styled layout matching app chrome
+2. Load data: iterate user's teams, fetch games + ICS calendars, merge and deduplicate
+3. Build filter bar with toggle buttons (time, type, team)
+4. Build detailed list view (full event cards with all fields from Phases 1-3)
+5. Build compact list view (one-line per event)
+6. Build calendar grid: CSS Grid 7 columns / 42 cells, month nav (prev/next), color-coded event dots by team
+7. Build day-click popup modal with full event details
+8. Build .ics export
+9. Add "Calendar" nav link to `dashboard.html` and `parent-dashboard.html`
+
+**Depends on:** Phases 1, 3
+
+---
+
+## Phase Dependency Graph
+
+```
+Phase 1 (Game Fields) ───┬──> Phase 2 (Assignments)
+                         ├──> Phase 3 (RSVP) ──────┐
+                         │                          │
+Phase 4 (Drills) ────────┴──> Phase 5 (Practice) ──┤
+                                                    v
+                                              Phase 6 (Calendar)
+```
+
+Phases 1 and 4 can begin in parallel.
+
+---
+
+## Verification
+
+- Serve locally: `python3 -m http.server 8000`
+- Test game creation with new fields at `edit-schedule.html`
+- Test cancel flow and verify team chat message appears
+- Test RSVP from parent-dashboard, verify summary on team.html
+- Test drill creation with YouTube URL + diagram uploads
+- Test practice planner: add structure blocks, edit drill on canvas, save/load templates
+- Test calendar.html: all three views, filters, day popup, .ics export
+- Verify Firestore rules with `firebase deploy --only firestore:rules`

--- a/team.html
+++ b/team.html
@@ -1021,6 +1021,16 @@
                     : `<span class="truncate">${escapeHtml(game.location)}</span>`
                 }
                                 </div>
+                                <div class="flex flex-wrap gap-1 mt-2">
+                                    ${game.isHome === true ? '<span class="text-xs bg-blue-100 text-blue-800 px-2 py-0.5 rounded-full font-semibold">HOME</span>' : ''}
+                                    ${game.isHome === false ? '<span class="text-xs bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full font-semibold">AWAY</span>' : ''}
+                                    ${game.kitColor ? `<span class="text-xs bg-purple-100 text-purple-800 px-2 py-0.5 rounded-full font-semibold">${escapeHtml(game.kitColor)}</span>` : ''}
+                                    ${game.status === 'cancelled' ? '<span class="text-xs bg-red-100 text-red-800 px-2 py-0.5 rounded-full font-semibold">CANCELLED</span>' : ''}
+                                </div>
+                                ${game.arrivalTime ? `<div class="text-xs text-amber-600 mt-1">Arrive by ${formatTime(game.arrivalTime)}</div>` : ''}
+                                ${game.notes ? `<div class="text-xs text-gray-500 mt-1 italic">${escapeHtml(game.notes)}</div>` : ''}
+                                ${game.assignments && game.assignments.length > 0 ? `<div class="mt-2 flex flex-wrap gap-1">${game.assignments.map(a => `<span class="text-xs bg-gray-100 rounded px-2 py-0.5"><b>${escapeHtml(a.role)}:</b> ${escapeHtml(a.value || 'TBD')}</span>`).join('')}</div>` : ''}
+                                ${game.rsvpSummary ? `<div class="mt-2 flex items-center gap-3 text-xs"><span class="text-green-600 font-semibold">${game.rsvpSummary.going || 0} going</span><span class="text-yellow-600">${game.rsvpSummary.maybe || 0} maybe</span><span class="text-red-600">${game.rsvpSummary.notGoing || 0} can't go</span></div>` : ''}
                             </div>
                             <div class="flex flex-col items-end gap-2">
                                 ${(isLive || isUpcoming) ? `


### PR DESCRIPTION
## Summary
- Add game schedule enhancements (home/away, kit color, arrival time, notes, assignments) across schedule/team/parent/calendar views
- Add RSVP flows for parents plus coach RSVP detail surfaces and summary displays
- Add calendar experiences for dashboard/parent dashboards and new `calendar.html` multi-view page
- Harden drills planner workflows (structure blocks, timeline interactions, edit/detail behavior, drag improvements)
- Add practice template persistence helpers and related UI integration
- Tighten Firestore RSVP rules and fix XSS/output escaping paths in schedule RSVP UIs

## Manual/Smoke Testing
- Ran Playwright smoke checks on `calendar.html`, `parent-dashboard.html`, and `edit-schedule.html` (authenticated + non-auth pageerror checks)
- Verified auth smoke login and page loads for calendar/parent/schedule routes
- Deployed Firestore rules successfully:
  - `firebase deploy --only firestore:rules`

## Notes
- Includes repository planning note at `spec/feature-requests/tasks.md`
