### PR TITLE
Team chat: add voice-to-text and image attachments

### DIFF
--- a/js/db.js
+++ b/js/db.js
@@ -97,6 +97,23 @@ export async function uploadUserPhoto(file) {
     return downloadURL;
 }
 
+export async function uploadChatImage(teamId, file) {
+    await requireImageAuth();
+
+    const path = `chat-images/${teamId}/${Date.now()}_${file.name}`;
+    const storageRef = ref(imageStorage, path);
+    const snapshot = await uploadBytes(storageRef, file);
+    const url = await getDownloadURL(snapshot.ref);
+
+    return {
+        url,
+        path,
+        name: file.name || null,
+        type: file.type || null,
+        size: Number.isFinite(file.size) ? file.size : null
+    };
+}
+
 export async function uploadStatSheetPhoto(file) {
     console.log('Starting stat sheet upload...', {
         fileName: file.name,
@@ -1180,7 +1197,22 @@ export function subscribeToChatMessages(teamId, { limit = 50 } = {}, onMessages)
 /**
  * Post a new chat message.
  */
-export async function postChatMessage(teamId, { text, senderId, senderName, senderEmail, senderPhotoUrl, ai = false, aiName = null, aiQuestion = null, aiMeta = null }) {
+export async function postChatMessage(teamId, {
+    text,
+    senderId,
+    senderName,
+    senderEmail,
+    senderPhotoUrl,
+    imageUrl = null,
+    imagePath = null,
+    imageName = null,
+    imageType = null,
+    imageSize = null,
+    ai = false,
+    aiName = null,
+    aiQuestion = null,
+    aiMeta = null
+}) {
     const messagesRef = collection(db, 'teams', teamId, 'chatMessages');
     return await addDoc(messagesRef, {
         text,
@@ -1188,6 +1220,11 @@ export async function postChatMessage(teamId, { text, senderId, senderName, send
         senderName: senderName || null,
         senderEmail: senderEmail || null,
         senderPhotoUrl: senderPhotoUrl || null,
+        imageUrl: imageUrl || null,
+        imagePath: imagePath || null,
+        imageName: imageName || null,
+        imageType: imageType || null,
+        imageSize: Number.isFinite(imageSize) ? imageSize : null,
         createdAt: Timestamp.now(),
         editedAt: null,
         deleted: false,

--- a/team-chat.html
+++ b/team-chat.html
@@ -88,7 +88,17 @@
 
             <!-- Composer -->
             <div class="p-4 border-t border-gray-200 bg-gray-50">
-                <div class="flex gap-2">
+                <div class="flex gap-2 items-start">
+                    <button id="voice-btn" type="button"
+                        class="shrink-0 px-3 py-2.5 border border-gray-300 rounded-lg text-gray-600 hover:text-primary-600 hover:border-primary-300 bg-white transition"
+                        title="Voice to text">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 1a3 3 0 00-3 3v8a3 3 0 006 0V4a3 3 0 00-3-3z"></path>
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 10v2a7 7 0 01-14 0v-2"></path>
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 19v4"></path>
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 23h8"></path>
+                        </svg>
+                    </button>
                     <div class="relative flex-1">
                         <input type="text" id="message-input"
                             placeholder="Type a message..."
@@ -103,10 +113,35 @@
                             </button>
                         </div>
                     </div>
+                    <input id="chat-image-input" type="file" accept="image/*" class="hidden">
+                    <button id="image-btn" type="button"
+                        class="shrink-0 px-3 py-2.5 border border-gray-300 rounded-lg text-gray-600 hover:text-primary-600 hover:border-primary-300 bg-white transition"
+                        title="Attach image">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7a2 2 0 012-2h14a2 2 0 012 2v10a2 2 0 01-2 2H5a2 2 0 01-2-2V7z"></path>
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.5 11.5a1.5 1.5 0 100-3 1.5 1.5 0 000 3z"></path>
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 15l-4-4L6 22"></path>
+                        </svg>
+                    </button>
                     <button id="send-btn"
                         class="px-5 py-2.5 bg-primary-600 text-white rounded-lg font-medium hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary-500 disabled:opacity-50 disabled:cursor-not-allowed transition">
                         Send
                     </button>
+                </div>
+                <div id="voice-hint" class="hidden mt-2 text-xs text-primary-700 bg-primary-50 border border-primary-100 rounded-lg px-3 py-2">
+                    Listening... tap mic again to stop.
+                </div>
+                <div id="chat-image-preview" class="hidden mt-2 p-2 border border-gray-200 rounded-lg bg-white">
+                    <div class="flex items-center gap-3">
+                        <img id="chat-image-preview-img" alt="Image preview" class="w-14 h-14 rounded-md object-cover border border-gray-200">
+                        <div class="min-w-0 flex-1">
+                            <p id="chat-image-preview-name" class="text-sm font-medium text-gray-800 truncate"></p>
+                            <p id="chat-image-preview-size" class="text-xs text-gray-500"></p>
+                        </div>
+                        <button id="chat-image-remove-btn" type="button" class="text-sm text-red-600 hover:text-red-700 font-medium">
+                            Remove
+                        </button>
+                    </div>
                 </div>
                 <div id="ai-thinking" class="hidden mt-2 text-sm text-indigo-600 flex items-center gap-2">
                     <div class="animate-spin rounded-full h-4 w-4 border-b-2 border-indigo-600"></div>
@@ -145,7 +180,7 @@
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
-        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages } from './js/db.js?v=14';
+        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, uploadChatImage } from './js/db.js?v=15';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { getAI, getGenerativeModel, GoogleAIBackend } from './js/vendor/firebase-ai.js';
         import { getApp } from './js/vendor/firebase-app.js';
@@ -280,7 +315,11 @@
         const AI_GAMES_CONTEXT_LIMIT = 20;
         const AI_EVENTS_GAMES_LIMIT = 3;
         const AI_EVENTS_PER_GAME_LIMIT = 25;
+        const MAX_CHAT_IMAGE_SIZE = 5 * 1024 * 1024;
         let aiModelCache = null;
+        let activeVoiceRecognition = null;
+        let voiceListening = false;
+        let pendingImageFile = null;
 
         // Get teamId from URL
         function getTeamIdFromUrl() {
@@ -536,8 +575,15 @@
                          <span class="text-xs font-bold text-gray-600">${escapeHtml(displayName.charAt(0).toUpperCase())}</span>
                        </div>`;
 
-            const canEdit = isOwn;
+            const canEdit = isOwn && !!msg.text;
             const canDelete = !isAi && (isOwn || canModerate);
+            const hasImage = msg.imageUrl && isSafeUrl(msg.imageUrl);
+            const messageImage = hasImage ? `
+                <a href="${escapeHtml(msg.imageUrl)}" target="_blank" rel="noopener noreferrer" class="block mb-2">
+                    <img src="${escapeHtml(msg.imageUrl)}" alt="${escapeHtml(msg.imageName || 'Chat image')}" class="max-w-full max-h-72 rounded-lg border border-gray-200 object-cover">
+                </a>
+            ` : '';
+            const messageText = msg.text ? `<p class="text-sm whitespace-pre-wrap break-words">${formatMessageText(msg.text)}</p>` : '';
 
             const actions = [];
             if (canEdit) {
@@ -561,7 +607,7 @@
                                 ${msg.editedAt ? '<span class="italic">(edited)</span> ' : ''}${timestamp}
                             </div>
                             <div class="${bubbleClass} rounded-lg px-4 py-2 rounded-br-sm">
-                                <p class="text-sm whitespace-pre-wrap break-words">${formatMessageText(msg.text)}</p>
+                                ${messageImage}${messageText}
                             </div>
                             ${actions.length > 0 ? `
                                 <div class="flex justify-end gap-2 mt-1">
@@ -583,7 +629,7 @@
                                 <span class="ml-1">${timestamp}</span>
                             </div>
                             <div class="${bubbleClass} rounded-lg px-4 py-2 rounded-bl-sm">
-                                <p class="text-sm whitespace-pre-wrap break-words">${formatMessageText(msg.text)}</p>
+                                ${messageImage}${messageText}
                             </div>
                             ${actions.length > 0 ? `
                                 <div class="flex gap-2 mt-1">
@@ -657,6 +703,141 @@
                 await new Promise(resolve => setTimeout(resolve, minMs - elapsed));
             }
             showAiThinking(false);
+        }
+
+        function formatBytes(bytes) {
+            if (!Number.isFinite(bytes) || bytes <= 0) return '';
+            if (bytes < 1024) return `${bytes} B`;
+            if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+            return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+        }
+
+        function updateComposerState() {
+            const input = document.getElementById('message-input');
+            const sendBtn = document.getElementById('send-btn');
+            sendBtn.disabled = !input.value.trim() && !pendingImageFile;
+        }
+
+        function setVoiceButtonState(isListening) {
+            const voiceBtn = document.getElementById('voice-btn');
+            const hint = document.getElementById('voice-hint');
+            voiceBtn.classList.toggle('text-red-600', isListening);
+            voiceBtn.classList.toggle('border-red-300', isListening);
+            voiceBtn.classList.toggle('bg-red-50', isListening);
+            hint.classList.toggle('hidden', !isListening);
+        }
+
+        function stopVoiceCapture() {
+            if (activeVoiceRecognition && voiceListening) {
+                try {
+                    activeVoiceRecognition.stop();
+                } catch (_) {}
+            }
+            voiceListening = false;
+            activeVoiceRecognition = null;
+            setVoiceButtonState(false);
+        }
+
+        function appendTranscriptToInput(transcript) {
+            const input = document.getElementById('message-input');
+            const clean = String(transcript || '').trim();
+            if (!clean) return;
+            const spacer = input.value.trim().length > 0 ? ' ' : '';
+            input.value = `${input.value}${spacer}${clean}`.trimStart();
+            input.focus();
+            updateComposerState();
+        }
+
+        function toggleVoiceCapture() {
+            if (!('webkitSpeechRecognition' in window) && !('SpeechRecognition' in window)) {
+                showError('Voice input is not supported in this browser.');
+                return;
+            }
+
+            if (voiceListening && activeVoiceRecognition) {
+                stopVoiceCapture();
+                return;
+            }
+
+            const SR = window.SpeechRecognition || window.webkitSpeechRecognition;
+            const recognition = new SR();
+            recognition.lang = 'en-US';
+            recognition.interimResults = false;
+            recognition.continuous = false;
+
+            activeVoiceRecognition = recognition;
+            voiceListening = true;
+            setVoiceButtonState(true);
+
+            recognition.onresult = (e) => {
+                const transcript = e.results?.[0]?.[0]?.transcript || '';
+                appendTranscriptToInput(transcript);
+            };
+            recognition.onerror = (event) => {
+                if (event?.error !== 'no-speech' && event?.error !== 'aborted') {
+                    showError('Voice recognition failed. Try again.');
+                }
+            };
+            recognition.onend = () => {
+                voiceListening = false;
+                activeVoiceRecognition = null;
+                setVoiceButtonState(false);
+            };
+
+            recognition.start();
+        }
+
+        function clearSelectedImage() {
+            pendingImageFile = null;
+            const input = document.getElementById('chat-image-input');
+            const preview = document.getElementById('chat-image-preview');
+            const previewImg = document.getElementById('chat-image-preview-img');
+            const previewName = document.getElementById('chat-image-preview-name');
+            const previewSize = document.getElementById('chat-image-preview-size');
+            input.value = '';
+            previewImg.src = '';
+            previewName.textContent = '';
+            previewSize.textContent = '';
+            preview.classList.add('hidden');
+            updateComposerState();
+        }
+
+        function setSelectedImage(file) {
+            pendingImageFile = file;
+            const preview = document.getElementById('chat-image-preview');
+            const previewImg = document.getElementById('chat-image-preview-img');
+            const previewName = document.getElementById('chat-image-preview-name');
+            const previewSize = document.getElementById('chat-image-preview-size');
+
+            previewName.textContent = file.name;
+            previewSize.textContent = formatBytes(file.size);
+
+            const reader = new FileReader();
+            reader.onload = (e) => {
+                previewImg.src = e.target?.result || '';
+            };
+            reader.readAsDataURL(file);
+            preview.classList.remove('hidden');
+            updateComposerState();
+        }
+
+        function handleImageSelection(event) {
+            const file = event.target.files?.[0];
+            if (!file) {
+                clearSelectedImage();
+                return;
+            }
+            if (!file.type.startsWith('image/')) {
+                showError('Please select an image file.');
+                clearSelectedImage();
+                return;
+            }
+            if (file.size > MAX_CHAT_IMAGE_SIZE) {
+                showError('Image must be 5MB or smaller.');
+                clearSelectedImage();
+                return;
+            }
+            setSelectedImage(file);
         }
 
         function hideMentionMenu() {
@@ -999,6 +1180,12 @@
         function setupEventListeners() {
             // Send button
             document.getElementById('send-btn').addEventListener('click', triggerSend);
+            document.getElementById('voice-btn').addEventListener('click', toggleVoiceCapture);
+            document.getElementById('image-btn').addEventListener('click', () => {
+                document.getElementById('chat-image-input').click();
+            });
+            document.getElementById('chat-image-input').addEventListener('change', handleImageSelection);
+            document.getElementById('chat-image-remove-btn').addEventListener('click', clearSelectedImage);
 
             // Enter key to send
             document.getElementById('message-input').addEventListener('keypress', (e) => {
@@ -1069,7 +1256,7 @@
             const input = document.getElementById('message-input');
             const sendBtn = document.getElementById('send-btn');
             input.addEventListener('input', () => {
-                sendBtn.disabled = !input.value.trim();
+                updateComposerState();
                 updateMentionMenu();
             });
             input.addEventListener('keydown', (e) => {
@@ -1096,7 +1283,9 @@
                     hideMentionMenu();
                 }
             });
+            window.addEventListener('beforeunload', stopVoiceCapture);
             sendBtn.disabled = true;
+            updateComposerState();
         }
 
         function triggerSend() {
@@ -1114,25 +1303,41 @@
         async function sendMessage() {
             const input = document.getElementById('message-input');
             const sendBtn = document.getElementById('send-btn');
+            const voiceBtn = document.getElementById('voice-btn');
+            const imageBtn = document.getElementById('image-btn');
             const text = input.value.trim();
+            const imageFile = pendingImageFile;
             const wantsAi = /@all\s*plays/i.test(text);
 
-            if (!text) return;
+            if (!text && !imageFile) return;
 
             sendBtn.disabled = true;
-            sendBtn.textContent = 'Sending...';
+            sendBtn.textContent = imageFile ? 'Uploading...' : 'Sending...';
+            voiceBtn.disabled = true;
+            imageBtn.disabled = true;
+            stopVoiceCapture();
 
             try {
+                let imagePayload = null;
+                if (imageFile) {
+                    imagePayload = await uploadChatImage(teamId, imageFile);
+                }
                 pendingScrollToBottom = true;
                 await postChatMessage(teamId, {
                     text,
                     senderId: currentUser.uid,
                     senderName: currentUserProfile?.fullName || null,
                     senderEmail: currentUser.email,
-                    senderPhotoUrl: currentUserProfile?.photoUrl || null
+                    senderPhotoUrl: currentUserProfile?.photoUrl || null,
+                    imageUrl: imagePayload?.url || null,
+                    imagePath: imagePayload?.path || null,
+                    imageName: imagePayload?.name || null,
+                    imageType: imagePayload?.type || null,
+                    imageSize: imagePayload?.size || null
                 });
 
                 input.value = '';
+                clearSelectedImage();
                 document.getElementById('send-error').classList.add('hidden');
                 scrollToBottom();
                 hideMentionMenu();
@@ -1146,8 +1351,10 @@
                 showError('Failed to send message. Please try again.');
                 pendingScrollToBottom = false;
             } finally {
-                sendBtn.disabled = !input.value.trim();
+                voiceBtn.disabled = false;
+                imageBtn.disabled = false;
                 sendBtn.textContent = 'Send';
+                updateComposerState();
             }
         }
 
@@ -1156,7 +1363,7 @@
 
         window.editMessage = function(messageId) {
             const msg = messages.find(m => m.id === messageId);
-            if (!msg || msg.deleted) return;
+            if (!msg || msg.deleted || !msg.text) return;
 
             editingMessageId = messageId;
             document.getElementById('edit-textarea').value = msg.text;


### PR DESCRIPTION
## Summary
- add voice-to-text in `team-chat.html` using the same Web Speech API pattern as drills (toggle mic, append transcript, stop on unload/send)
- add image attachment UX to team chat composer (attach button, preview, remove, 5MB validation)
- support image messages in chat rendering with safe URL checks and click-to-open full image
- add `uploadChatImage(teamId, file)` in `js/db.js` using existing `imageStorage` + `requireImageAuth` path
- extend `postChatMessage` to store optional image metadata (`imageUrl`, `imagePath`, `imageName`, `imageType`, `imageSize`)
- bump team-chat db import cache key to `./js/db.js?v=15`

## Testing
- `node --check js/db.js`
- `awk '/<script type="module">/{flag=1; next} /<\/script>/{if(flag){flag=0; exit}} flag' team-chat.html > /tmp/team-chat-module.js && node --check /tmp/team-chat-module.js`

## Notes
- no project-wide automated browser test harness exists in this repo, so validation here is syntax-level + implementation consistency with existing patterns.
