### PR TITLE
Fix persistent reaction failures from stale client/rules mismatch

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -316,7 +316,9 @@ service cloud.firestore {
 
         // Update for reactions: any team member can add/remove reactions only
         allow update: if canAccessTeamChat(teamId) &&
-                         request.resource.data.diff(resource.data).affectedKeys()
+                         (
+                           // Current client writes nested reaction keys.
+                           request.resource.data.diff(resource.data).affectedKeys()
                              .hasOnly([
                                'reactions.thumbs_up',
                                'reactions.heart',
@@ -324,7 +326,20 @@ service cloud.firestore {
                                'reactions.wow',
                                'reactions.sad',
                                'reactions.clap'
-                             ]);
+                             ]) ||
+                           // Backward compatibility for stale cached clients that write the full map.
+                           (
+                             request.resource.data.diff(resource.data).affectedKeys().hasOnly(['reactions']) &&
+                             request.resource.data.get('reactions', {}).keys().hasOnly([
+                               'thumbs_up',
+                               'heart',
+                               'joy',
+                               'wow',
+                               'sad',
+                               'clap'
+                             ])
+                           )
+                         );
       }
     }
 

--- a/team-chat.html
+++ b/team-chat.html
@@ -182,7 +182,7 @@
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
-        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, uploadChatImage, toggleChatReaction } from './js/db.js?v=18';
+        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, uploadChatImage, toggleChatReaction } from './js/db.js?v=19';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { getAI, getGenerativeModel, GoogleAIBackend } from './js/vendor/firebase-ai.js';
         import { getApp } from './js/vendor/firebase-app.js';


### PR DESCRIPTION
## Objective
Fix persistent "Failed to update reaction" errors after previous reaction rule/client changes.

## What was happening
There were two client write shapes in the wild:
1. New client: nested writes (`reactions.<key>`)
2. Stale cached client: full map write (`reactions`)

Rules were hardened to nested-only, which blocked stale clients still using full-map writes.

## Fix in this PR
1. `firestore.rules`
- Keep nested-key reaction updates allowed:
  - `reactions.thumbs_up`, `reactions.heart`, `reactions.joy`, `reactions.wow`, `reactions.sad`, `reactions.clap`
- Add backward-compat allowance for full-map writes **only** when:
  - affected key is exactly `reactions`
  - map keys are restricted to the same approved 6 reaction keys

2. `team-chat.html`
- Bump db import cache key from `v=18` to `v=19` to force clients to fetch latest reaction logic.

## Blast radius
- Limited to team chat reaction updates.
- No change to chat create/edit/delete rules.

## Validation
- `node --check js/db.js`
- `node --check` on extracted module from `team-chat.html`
- Firestore rules compiled and deployed successfully to `game-flow-c6311`.
