### PR TITLE
Add practice availability, 4 RSVP statuses, and player deactivation

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -149,6 +149,7 @@
         let currentTeamFilter = '';
         let calendarMonth = new Date().getMonth();
         let calendarYear = new Date().getFullYear();
+        let playerIdsByTeam = new Map();
         const teamColors = {};
         const colorPalette = ['#6366f1', '#ec4899', '#f59e0b', '#10b981', '#ef4444', '#8b5cf6', '#06b6d4', '#f97316'];
 
@@ -172,22 +173,25 @@
                 .replace(/>/g, '&gt;');
         }
 
+        function formatRsvpSummary(summary) {
+            if (!summary) return 'No RSVPs yet.';
+            return `${summary.going || 0} going · ${summary.maybe || 0} maybe · ${summary.notGoing || 0} can't go · ${summary.notResponded || 0} no response`;
+        }
+
         function renderRsvpBlock(ev, compact = false) {
-            if (ev.type !== 'game' || ev.status === 'cancelled') return '';
-            const summary = ev.rsvpSummary
-                ? `${ev.rsvpSummary.going || 0} going · ${ev.rsvpSummary.maybe || 0} maybe · ${ev.rsvpSummary.notGoing || 0} can't go`
-                : 'No RSVPs yet.';
+            if ((ev.type !== 'game' && ev.type !== 'practice') || ev.status === 'cancelled') return '';
+            const summary = formatRsvpSummary(ev.rsvpSummary);
             if (ev.source !== 'db') {
                 return compact
-                    ? `<span class="text-[10px] text-gray-400">RSVP after tracking game</span>`
-                    : `<div class="mt-1 text-xs text-gray-400">RSVP opens after this event is tracked as a game.</div><div class="mt-1 text-xs text-gray-400">${summary}</div>`;
+                    ? `<span class="text-[10px] text-gray-400">Availability after tracking</span>`
+                    : `<div class="mt-1 text-xs text-gray-400">Availability opens after this event is tracked in the schedule.</div><div class="mt-1 text-xs text-gray-400">${summary}</div>`;
             }
             if (compact) {
                 return `<span class="text-[10px] text-gray-500">${summary}</span>`;
             }
             return `
                 <div class="mt-3 border-t border-gray-100 pt-3">
-                    <div class="text-[11px] font-bold uppercase tracking-wide text-gray-500 mb-2">RSVP</div>
+                    <div class="text-[11px] font-bold uppercase tracking-wide text-gray-500 mb-2">Availability</div>
                     <div class="flex gap-2">
                         <button data-team-id="${escapeAttr(ev.teamId)}" data-game-id="${escapeAttr(ev.id)}" onclick="submitCalendarRsvpFromButton(this, 'going')" class="rsvp-btn rsvp-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'going' ? 'bg-green-600 text-white border-green-600' : 'bg-white text-green-700 border-green-300 hover:bg-green-50'}">Going</button>
                         <button data-team-id="${escapeAttr(ev.teamId)}" data-game-id="${escapeAttr(ev.id)}" onclick="submitCalendarRsvpFromButton(this, 'maybe')" class="rsvp-btn rsvp-maybe flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'maybe' ? 'bg-yellow-500 text-white border-yellow-500' : 'bg-white text-yellow-700 border-yellow-300 hover:bg-yellow-50'}">Maybe</button>
@@ -214,6 +218,15 @@
 
                 const profile = await getUserProfile(user.uid);
                 const email = user.email || profile?.email;
+                const parentOf = Array.isArray(profile?.parentOf) ? profile.parentOf : [];
+                playerIdsByTeam = parentOf.reduce((acc, link) => {
+                    const teamId = link?.teamId;
+                    const playerId = link?.playerId;
+                    if (!teamId || !playerId) return acc;
+                    if (!acc.has(teamId)) acc.set(teamId, new Set());
+                    acc.get(teamId).add(playerId);
+                    return acc;
+                }, new Map());
 
                 // Load all teams the user has access to (coach + parent)
                 const [coachTeams, parentTeams] = await Promise.all([
@@ -306,9 +319,9 @@
                 const results = await Promise.all(loadPromises);
                 allEvents = results.flat().sort((a, b) => a.date - b.date);
 
-                // Fetch current user's RSVP for DB games.
-                const dbGames = allEvents.filter(ev => ev.source === 'db' && ev.type === 'game' && ev.status !== 'cancelled');
-                const uniqueGameKeys = [...new Set(dbGames.map(ev => `${ev.teamId}::${ev.id}`))];
+                // Fetch current user's RSVP for DB schedule events (games + practices).
+                const dbEvents = allEvents.filter(ev => ev.source === 'db' && (ev.type === 'game' || ev.type === 'practice') && ev.status !== 'cancelled');
+                const uniqueGameKeys = [...new Set(dbEvents.map(ev => `${ev.teamId}::${ev.id}`))];
                 await Promise.all(uniqueGameKeys.map(async (key) => {
                     const [teamId, gameId] = key.split('::');
                     try {
@@ -566,9 +579,12 @@
 
         async function submitCalendarRsvp(teamId, gameId, response) {
             try {
+                const playerIds = playerIdsByTeam.has(teamId)
+                    ? Array.from(playerIdsByTeam.get(teamId))
+                    : [];
                 const summary = await submitRsvp(teamId, gameId, currentUserId, {
                     displayName: currentUser?.displayName || currentUser?.email || null,
-                    playerIds: [],
+                    playerIds,
                     response
                 });
                 allEvents.forEach(ev => {

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -343,7 +343,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getPlayers, addPlayer, deletePlayer, getGames, uploadPlayerPhoto, updatePlayer, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount } from './js/db.js?v=14';
+        import { getTeam, getPlayers, addPlayer, deactivatePlayer, reactivatePlayer, getGames, uploadPlayerPhoto, updatePlayer, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount } from './js/db.js?v=14';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth, sendInviteEmail } from './js/auth.js?v=9';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
@@ -406,7 +406,7 @@
 
         async function loadRoster() {
             const [players, games, allUsers] = await Promise.all([
-                getPlayers(currentTeamId),
+                getPlayers(currentTeamId, { includeInactive: true }),
                 getGames(currentTeamId),
                 getAllUsers()
             ]);
@@ -460,7 +460,7 @@
                             ` : '';
 
                 return `
-                <tr class="hover:bg-gray-50">
+                <tr class="hover:bg-gray-50 ${p.active === false ? 'bg-gray-50/60' : ''}">
                     <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 font-mono align-middle">
                         <a class="text-gray-600 hover:text-indigo-700" href="${latestGameId ? `player.html#teamId=${currentTeamId}&gameId=${latestGameId}&playerId=${p.id}` : `player.html#teamId=${currentTeamId}&playerId=${p.id}`}">${p.number || '-'}</a>
                     </td>
@@ -474,24 +474,37 @@
                                 `}
                                 </span>
                                 <span>${p.name}</span>
+                                ${p.active === false ? '<span class="inline-flex ml-2 text-[10px] bg-gray-200 text-gray-700 px-2 py-0.5 rounded-full font-semibold uppercase tracking-wide">Inactive</span>' : ''}
                             </a>
                             ${parentChips}
                         </td>
                     <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                         <div class="flex items-center gap-3 justify-end">
-                            <button data-id="${p.id}" class="text-green-600 hover:text-green-800 invite-btn text-xs uppercase font-bold tracking-wide border border-green-200 bg-green-50 px-2 py-1 rounded">Invite Parent</button>
+                            <button data-id="${p.id}" class="text-green-600 hover:text-green-800 invite-btn text-xs uppercase font-bold tracking-wide border border-green-200 bg-green-50 px-2 py-1 rounded ${p.active === false ? 'opacity-50 cursor-not-allowed' : ''}" ${p.active === false ? 'disabled' : ''}>Invite Parent</button>
                             <button data-id="${p.id}" class="text-indigo-600 hover:text-indigo-800 edit-btn">Edit</button>
-                            <button data-id="${p.id}" class="text-red-600 hover:text-red-900 delete-btn">Delete</button>
+                            ${p.active === false
+                                ? `<button data-id="${p.id}" class="text-emerald-700 hover:text-emerald-900 reactivate-btn">Reactivate</button>`
+                                : `<button data-id="${p.id}" class="text-amber-700 hover:text-amber-900 deactivate-btn">Deactivate</button>`
+                            }
                         </div>
                     </td>
                 </tr>
             `;
             }).join('');
 
-            document.querySelectorAll('.delete-btn').forEach(btn => {
+            document.querySelectorAll('.deactivate-btn').forEach(btn => {
                 btn.addEventListener('click', async (e) => {
-                    if (confirm('Are you sure you want to remove this player?')) {
-                        await deletePlayer(currentTeamId, e.target.dataset.id);
+                    if (confirm('Deactivate this player? This keeps all historical stats and reports.')) {
+                        await deactivatePlayer(currentTeamId, e.target.dataset.id);
+                        loadRoster();
+                    }
+                });
+            });
+
+            document.querySelectorAll('.reactivate-btn').forEach(btn => {
+                btn.addEventListener('click', async (e) => {
+                    if (confirm('Reactivate this player on the roster?')) {
+                        await reactivatePlayer(currentTeamId, e.target.dataset.id);
                         loadRoster();
                     }
                 });
@@ -995,10 +1008,10 @@ EXAMPLES:
                         <div class="border border-red-300 bg-red-50 rounded-lg p-3" data-index="${index}">
                             <div class="flex justify-between items-start gap-2">
                                 <div class="flex-1">
-                                    <div class="text-xs font-bold text-red-700 uppercase mb-1">🗑️ Delete</div>
+                                    <div class="text-xs font-bold text-red-700 uppercase mb-1">⏸️ Deactivate</div>
                                     <div class="text-sm">
                                         Player ID: ${op.playerId}<br>
-                                        <span class="text-xs text-gray-600">${op.reason || 'Removed from roster'}</span>
+                                        <span class="text-xs text-gray-600">${op.reason || 'Deactivate from active roster (preserve history)'}</span>
                                     </div>
                                 </div>
                                 <button onclick="removePlayerOperation(${index})"
@@ -1061,7 +1074,13 @@ EXAMPLES:
                             await updatePlayer(currentTeamId, op.playerId, op.changes);
                             successCount++;
                         } else if (op.action === 'delete') {
-                            await deletePlayer(currentTeamId, op.playerId);
+                            await deactivatePlayer(currentTeamId, op.playerId);
+                            successCount++;
+                        } else if (op.action === 'deactivate') {
+                            await deactivatePlayer(currentTeamId, op.playerId);
+                            successCount++;
+                        } else if (op.action === 'reactivate') {
+                            await reactivatePlayer(currentTeamId, op.playerId);
                             successCount++;
                         }
                     } catch (error) {

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -562,7 +562,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getTeams, getGames, getEvents, addGame, updateGame, deleteGame, addPractice, updateEvent, deleteEvent, getConfigs, addCalendarToTeam, removeCalendarFromTeam, getTrackedCalendarEventUids, cancelOccurrence, updateOccurrence, restoreOccurrence, clearOccurrenceOverride, updateSeries, deleteSeries, getUnreadChatCount, getPracticeSessions, cancelGame, getLatestGameAssignments, postChatMessage, getRsvps } from './js/db.js?v=20';
+        import { getTeam, getTeams, getGames, getEvents, addGame, updateGame, deleteGame, addPractice, updateEvent, deleteEvent, getConfigs, addCalendarToTeam, removeCalendarFromTeam, getTrackedCalendarEventUids, cancelOccurrence, updateOccurrence, restoreOccurrence, clearOccurrenceOverride, updateSeries, deleteSeries, getUnreadChatCount, getPracticeSessions, cancelGame, getLatestGameAssignments, postChatMessage, getRsvpBreakdownByPlayer } from './js/db.js?v=20';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, formatTimeRange, getDefaultEndTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, generateSeriesId, expandRecurrence, formatRecurrence, shareOrCopy, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
@@ -1046,40 +1046,34 @@
                     content.innerHTML = '<div class="text-center py-8"><div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600 mx-auto"></div></div>';
                     modal.classList.remove('hidden');
                     try {
-                        const rsvps = await getRsvps(currentTeamId, gameId);
-                        if (rsvps.length === 0) {
-                            content.innerHTML = '<p class="text-gray-500 text-center py-8">No RSVPs yet.</p>';
-                            return;
-                        }
-                        const grouped = { going: [], maybe: [], not_going: [] };
-                        rsvps.forEach(r => {
-                            if (grouped[r.response]) grouped[r.response].push(r);
-                        });
+                        const breakdown = await getRsvpBreakdownByPlayer(currentTeamId, gameId);
+                        const grouped = breakdown.grouped;
+                        const counts = breakdown.counts;
+                        const renderRows = (rows) => rows.length
+                            ? rows.map((row) => {
+                                const name = escapeHtml(row.playerName || 'Unknown Player');
+                                const jersey = row.playerNumber ? ` <span class="text-gray-400 text-xs">#${escapeHtml(row.playerNumber)}</span>` : '';
+                                const note = row.note ? ` <span class="text-gray-400 text-xs">- ${escapeHtml(row.note)}</span>` : '';
+                                return `<div class="text-sm py-1">${name}${jersey}${note}</div>`;
+                            }).join('')
+                            : '<p class="text-xs text-gray-400">None</p>';
                         content.innerHTML = `
                             <div class="space-y-4">
                                 <div>
-                                    <h4 class="text-sm font-bold text-green-700 mb-2">Going (${grouped.going.length})</h4>
-                                    ${grouped.going.length ? grouped.going.map((r) => {
-                                        const name = escapeHtml(r.displayName || r.userId || 'Unknown');
-                                        const note = r.note ? ` <span class="text-gray-400 text-xs">- ${escapeHtml(r.note)}</span>` : '';
-                                        return `<div class="text-sm py-1">${name}${note}</div>`;
-                                    }).join('') : '<p class="text-xs text-gray-400">None</p>'}
+                                    <h4 class="text-sm font-bold text-green-700 mb-2">Going (${counts.going})</h4>
+                                    ${renderRows(grouped.going)}
                                 </div>
                                 <div>
-                                    <h4 class="text-sm font-bold text-yellow-700 mb-2">Maybe (${grouped.maybe.length})</h4>
-                                    ${grouped.maybe.length ? grouped.maybe.map((r) => {
-                                        const name = escapeHtml(r.displayName || r.userId || 'Unknown');
-                                        const note = r.note ? ` <span class="text-gray-400 text-xs">- ${escapeHtml(r.note)}</span>` : '';
-                                        return `<div class="text-sm py-1">${name}${note}</div>`;
-                                    }).join('') : '<p class="text-xs text-gray-400">None</p>'}
+                                    <h4 class="text-sm font-bold text-yellow-700 mb-2">Maybe (${counts.maybe})</h4>
+                                    ${renderRows(grouped.maybe)}
                                 </div>
                                 <div>
-                                    <h4 class="text-sm font-bold text-red-700 mb-2">Can't Go (${grouped.not_going.length})</h4>
-                                    ${grouped.not_going.length ? grouped.not_going.map((r) => {
-                                        const name = escapeHtml(r.displayName || r.userId || 'Unknown');
-                                        const note = r.note ? ` <span class="text-gray-400 text-xs">- ${escapeHtml(r.note)}</span>` : '';
-                                        return `<div class="text-sm py-1">${name}${note}</div>`;
-                                    }).join('') : '<p class="text-xs text-gray-400">None</p>'}
+                                    <h4 class="text-sm font-bold text-red-700 mb-2">Can't Go (${counts.notGoing})</h4>
+                                    ${renderRows(grouped.not_going)}
+                                </div>
+                                <div>
+                                    <h4 class="text-sm font-bold text-gray-700 mb-2">Not Responded (${counts.notResponded})</h4>
+                                    ${renderRows(grouped.not_responded)}
                                 </div>
                             </div>
                         `;
@@ -1123,6 +1117,7 @@
                 actions = `
                     <a href="${planHref}"
                         class="px-3 py-1 bg-indigo-100 text-indigo-700 rounded text-sm hover:bg-indigo-200">Plan Practice</a>
+                    <button data-game-id="${practice.masterId}" class="view-rsvps-btn px-3 py-1 bg-green-100 text-green-700 rounded text-sm hover:bg-green-200">Availability</button>
                     <button onclick="editOccurrence('${practice.masterId}', '${practice.instanceDate}')"
                         class="px-3 py-1 bg-blue-100 text-blue-700 rounded text-sm hover:bg-blue-200">Manage</button>
                 `;
@@ -1131,6 +1126,7 @@
                 actions = `
                     <a href="${planHref}"
                         class="px-3 py-1 bg-indigo-100 text-indigo-700 rounded text-sm hover:bg-indigo-200">Plan Practice</a>
+                    <button data-game-id="${practice.eventId}" class="view-rsvps-btn px-3 py-1 bg-green-100 text-green-700 rounded text-sm hover:bg-green-200">Availability</button>
                     <button onclick="editPractice('${practice.eventId}')"
                         class="px-3 py-1 bg-blue-100 text-blue-700 rounded text-sm hover:bg-blue-200">Edit</button>
                     <button onclick="deletePractice('${practice.eventId}')"
@@ -1315,7 +1311,7 @@
                         ${game.assignments && game.assignments.length > 0 ? `<div class="mt-1 text-xs text-gray-600">${game.assignments.map(a => `<span class="inline-block bg-gray-100 rounded px-1.5 py-0.5 mr-1 mb-1"><b>${escapeHtml(a.role)}:</b> ${escapeHtml(a.value || 'TBD')}</span>`).join('')}</div>` : ''}
                         ${isCompleted ? `<span class="inline-block bg-green-100 text-green-800 text-xs px-2 py-1 rounded-full font-semibold mt-2">Final: ${game.homeScore}-${game.awayScore}</span>` : ''}
                         ${game.status === 'cancelled' ? '<div class="mt-1"><span class="inline-block bg-red-100 text-red-800 text-xs px-2 py-1 rounded-full font-semibold">CANCELLED</span></div>' : ''}
-                        ${game.rsvpSummary ? `<div class="text-xs text-gray-500 mt-1">${game.rsvpSummary.going || 0} going · ${game.rsvpSummary.maybe || 0} maybe · ${game.rsvpSummary.notGoing || 0} can't go</div>` : ''}
+                        ${game.rsvpSummary ? `<div class="text-xs text-gray-500 mt-1">${game.rsvpSummary.going || 0} going · ${game.rsvpSummary.maybe || 0} maybe · ${game.rsvpSummary.notGoing || 0} can't go · ${game.rsvpSummary.notResponded || 0} no response</div>` : ''}
                     </div>
                     <div class="flex flex-wrap gap-2">
                         <button data-game-id="${game.id}" class="edit-game-btn px-3 py-1 bg-blue-100 text-blue-700 rounded text-sm hover:bg-blue-200">Edit</button>

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -222,6 +222,11 @@
                 .replace(/>/g, '&gt;');
         }
 
+        function formatRsvpSummary(summary) {
+            if (!summary) return 'No RSVPs yet.';
+            return `${summary.going || 0} going · ${summary.maybe || 0} maybe · ${summary.notGoing || 0} can't go · ${summary.notResponded || 0} no response`;
+        }
+
         window.submitGameRsvp = async function(teamId, gameId, response) {
             try {
                 const playerIds = allScheduleEvents
@@ -238,7 +243,7 @@
                 if (game) {
                     game.myRsvp = response;
                     if (summary) game.rsvpSummary = summary;
-                    else if (!game.rsvpSummary) game.rsvpSummary = { going: 0, maybe: 0, notGoing: 0, total: 0 };
+                    else if (!game.rsvpSummary) game.rsvpSummary = { going: 0, maybe: 0, notGoing: 0, notResponded: 0, total: 0 };
                 }
                 renderScheduleFromControls();
             } catch (err) {
@@ -294,10 +299,10 @@
                 const combinedSchedule = await buildCombinedSchedule(data.children);
                 allScheduleEvents = combinedSchedule;
 
-                // Fetch my RSVPs for game events (deduped by team/game).
+                // Fetch my RSVPs for tracked DB events (games + practices).
                 const uniqueGameKeys = [...new Set(
                     allScheduleEvents
-                        .filter((event) => event.type === 'game' && !event.isCancelled && event.teamId && event.id)
+                        .filter((event) => event.isDbGame && !event.isCancelled && event.teamId && event.id)
                         .map((event) => `${event.teamId}::${event.id}`)
                 )];
                 await Promise.all(uniqueGameKeys.map(async (key) => {
@@ -691,7 +696,7 @@
                                 ${dayEvents.slice(0, 3).map((ev) => `
                                     <div class="text-[10px] px-1 py-0.5 rounded truncate ${ev.type === 'practice' ? 'bg-amber-100 text-amber-800' : 'bg-primary-100 text-primary-800'}">
                                         ${escapeHtml(ev.type === 'practice' ? (ev.title || 'Practice') : `vs. ${ev.opponent || 'TBD'}`)}
-                                        ${ev.type === 'game' ? `<span class="ml-1 text-[9px] opacity-70">(${ev.rsvpSummary?.going || 0}/${ev.rsvpSummary?.maybe || 0}/${ev.rsvpSummary?.notGoing || 0})</span>` : ''}
+                                        ${ev.type === 'game' ? `<span class="ml-1 text-[9px] opacity-70">(${ev.rsvpSummary?.going || 0}/${ev.rsvpSummary?.maybe || 0}/${ev.rsvpSummary?.notGoing || 0}/${ev.rsvpSummary?.notResponded || 0})</span>` : ''}
                                     </div>
                                 `).join('')}
                                 ${dayEvents.length > 3 ? `<div class="text-[10px] text-gray-400">+${dayEvents.length - 3} more</div>` : ''}
@@ -735,19 +740,19 @@
                             ${ev.arrivalTime ? `<div class="text-xs text-amber-700 mt-1">Arrive: ${(() => { const at = ev.arrivalTime?.toDate ? ev.arrivalTime.toDate() : new Date(ev.arrivalTime); return at.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }); })()}</div>` : ''}
                             ${ev.notes ? `<div class="text-xs text-gray-500 mt-1 italic">${escapeHtml(ev.notes)}</div>` : ''}
                             ${ev.assignments && ev.assignments.length > 0 ? `<div class="mt-1 text-xs text-gray-600">${ev.assignments.map(a => `<span class="inline-block bg-gray-100 rounded px-1.5 py-0.5 mr-1 mb-1"><b>${escapeHtml(a.role)}:</b> ${escapeHtml(a.value || 'TBD')}</span>`).join('')}</div>` : ''}
-                            ${ev.rsvpSummary ? `<div class="text-xs text-gray-500 mt-1">${ev.rsvpSummary.going || 0} going · ${ev.rsvpSummary.maybe || 0} maybe · ${ev.rsvpSummary.notGoing || 0} can't go</div>` : ''}
+                            ${ev.rsvpSummary ? `<div class="text-xs text-gray-500 mt-1">${formatRsvpSummary(ev.rsvpSummary)}</div>` : ''}
                             ${ev.childNames?.length ? `<div class="text-xs text-gray-500 mt-1">For ${escapeHtml(ev.childNames.join(', '))}</div>` : ''}
-                            ${!ev.isCancelled && ev.type === 'game' ? `
+                            ${!ev.isCancelled && (ev.type === 'game' || ev.type === 'practice') ? `
                                 <div class="mt-3 border-t border-gray-100 pt-3">
-                                    <div class="text-[11px] font-bold uppercase tracking-wide text-gray-500 mb-2">RSVP</div>
+                                    <div class="text-[11px] font-bold uppercase tracking-wide text-gray-500 mb-2">Availability</div>
                                     ${ev.isDbGame ? `
                                         <div class="flex gap-2">
                                             <button data-team-id="${escapeAttr(ev.teamId)}" data-game-id="${escapeAttr(ev.id)}" onclick="submitGameRsvpFromButton(this, 'going')" class="rsvp-btn rsvp-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'going' ? 'bg-green-600 text-white border-green-600' : 'bg-white text-green-700 border-green-300 hover:bg-green-50'}">Going</button>
                                             <button data-team-id="${escapeAttr(ev.teamId)}" data-game-id="${escapeAttr(ev.id)}" onclick="submitGameRsvpFromButton(this, 'maybe')" class="rsvp-btn rsvp-maybe flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'maybe' ? 'bg-yellow-500 text-white border-yellow-500' : 'bg-white text-yellow-700 border-yellow-300 hover:bg-yellow-50'}">Maybe</button>
                                             <button data-team-id="${escapeAttr(ev.teamId)}" data-game-id="${escapeAttr(ev.id)}" onclick="submitGameRsvpFromButton(this, 'not_going')" class="rsvp-btn rsvp-not-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${ev.myRsvp === 'not_going' ? 'bg-red-500 text-white border-red-500' : 'bg-white text-red-700 border-red-300 hover:bg-red-50'}">Can't Go</button>
                                         </div>
-                                    ` : `<div class="text-xs text-gray-500">RSVP opens after coach tracks this event as a game.</div>`}
-                                    ${ev.rsvpSummary ? `<div class="text-xs text-gray-500 mt-1">${ev.rsvpSummary.going || 0} going · ${ev.rsvpSummary.maybe || 0} maybe · ${ev.rsvpSummary.notGoing || 0} can't go</div>` : '<div class="text-xs text-gray-400 mt-1">No RSVPs yet.</div>'}
+                                    ` : `<div class="text-xs text-gray-500">Availability opens after this event is tracked in the schedule.</div>`}
+                                    <div class="text-xs text-gray-500 mt-1">${formatRsvpSummary(ev.rsvpSummary)}</div>
                                 </div>
                             ` : ''}
                             ${ev.isCancelled ? '<div class="text-xs text-red-700 mt-1 font-semibold">Cancelled</div>' : ''}
@@ -1185,17 +1190,17 @@
                             </div>
                         ` : ''}
                     </div>
-                    ${!isCancelled && game.type === 'game' ? `
+                    ${!isCancelled && (game.type === 'game' || game.type === 'practice') ? `
                         <div class="mt-3 border-t border-gray-100 pt-3">
-                            <div class="text-[11px] font-bold uppercase tracking-wide text-gray-500 mb-2">RSVP</div>
+                            <div class="text-[11px] font-bold uppercase tracking-wide text-gray-500 mb-2">Availability</div>
                             ${game.isDbGame ? `
                                 <div class="flex gap-2">
                                     <button data-team-id="${escapeAttr(game.teamId)}" data-game-id="${escapeAttr(game.id)}" onclick="submitGameRsvpFromButton(this, 'going')" class="rsvp-btn rsvp-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${game.myRsvp === 'going' ? 'bg-green-600 text-white border-green-600' : 'bg-white text-green-700 border-green-300 hover:bg-green-50'}">Going</button>
                                     <button data-team-id="${escapeAttr(game.teamId)}" data-game-id="${escapeAttr(game.id)}" onclick="submitGameRsvpFromButton(this, 'maybe')" class="rsvp-btn rsvp-maybe flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${game.myRsvp === 'maybe' ? 'bg-yellow-500 text-white border-yellow-500' : 'bg-white text-yellow-700 border-yellow-300 hover:bg-yellow-50'}">Maybe</button>
                                     <button data-team-id="${escapeAttr(game.teamId)}" data-game-id="${escapeAttr(game.id)}" onclick="submitGameRsvpFromButton(this, 'not_going')" class="rsvp-btn rsvp-not-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${game.myRsvp === 'not_going' ? 'bg-red-500 text-white border-red-500' : 'bg-white text-red-700 border-red-300 hover:bg-red-50'}">Can't Go</button>
                                 </div>
-                            ` : `<div class="text-xs text-gray-500">RSVP opens after coach tracks this event as a game.</div>`}
-                            ${game.rsvpSummary ? `<div class="text-[10px] text-gray-400 mt-1">${game.rsvpSummary.going || 0} going · ${game.rsvpSummary.maybe || 0} maybe · ${game.rsvpSummary.notGoing || 0} can't go</div>` : '<div class="text-[10px] text-gray-400 mt-1">No RSVPs yet.</div>'}
+                            ` : `<div class="text-xs text-gray-500">Availability opens after this event is tracked in the schedule.</div>`}
+                            <div class="text-[10px] text-gray-400 mt-1">${formatRsvpSummary(game.rsvpSummary)}</div>
                         </div>
                     ` : ''}
                     ${!isCancelled && game.isDbGame ? `


### PR DESCRIPTION
## Summary
- add availability (RSVP) support for practices where schedule availability is shown
- switch coach RSVP detail modal to player-based breakdown (name/number) instead of parent email
- add a fourth RSVP bucket: **Not Responded** so active roster players are always represented in one of four statuses
- switch roster removal flow to **Deactivate/Reactivate** and keep player records (soft-delete)

## Implementation notes
- `deletePlayer` is now a soft-delete (`active: false`) to preserve historical data
- `getPlayers` now excludes inactive players by default with an option to include them
- availability summaries include `notResponded` for game/practice UI surfaces
- calendar/parent availability submission now supports tracked practices as well as games
