### PR TITLE
fix: parse HTML-escaped URL params in hash/search

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -1,11 +1,24 @@
 export function getUrlParams() {
-  // Combine params from both search (?) and hash (#)
-  const searchParams = new URLSearchParams(window.location.search);
-  const hashParams = new URLSearchParams(window.location.hash.substring(1));
+  // Combine params from both search (?) and hash (#).
+  // Some shared links arrive HTML-escaped (e.g. "&amp;"), so normalize first.
+  const normalizeParamString = (value) => {
+    if (!value) return '';
+    return value.replace(/^\?/, '').replace(/^#/, '').replace(/&amp;/gi, '&');
+  };
+
+  const searchParams = new URLSearchParams(normalizeParamString(window.location.search));
+  const hashParams = new URLSearchParams(normalizeParamString(window.location.hash));
 
   const params = {};
-  for (const [key, value] of searchParams) params[key] = value;
-  for (const [key, value] of hashParams) params[key] = value;
+  const collect = (entries) => {
+    for (const [rawKey, value] of entries) {
+      const key = rawKey.startsWith('amp;') ? rawKey.slice(4) : rawKey;
+      if (key) params[key] = value;
+    }
+  };
+
+  collect(searchParams);
+  collect(hashParams);
 
   return params;
 }

--- a/tests/smoke/url-params-escaped-amp.spec.js
+++ b/tests/smoke/url-params-escaped-amp.spec.js
@@ -1,0 +1,12 @@
+const { test, expect } = require('@playwright/test');
+
+// @smoke
+test.describe('URL param parsing @smoke', () => {
+  test('game page accepts HTML-escaped hash delimiters', async ({ page }) => {
+    await page.goto('/game.html#teamId=demoTeam&amp;gameId=demoGame');
+    await page.waitForTimeout(1200);
+
+    // If parsing fails, game.html redirects to index.html.
+    await expect(page).toHaveURL(/\/game\.html#/);
+  });
+});


### PR DESCRIPTION
## Summary
- fix `getUrlParams()` to normalize HTML-escaped delimiters (`&amp;`) in both search and hash strings
- add defensive key normalization so malformed keys like `amp;gameId` are treated as `gameId`
- add a smoke test covering `game.html#teamId=...&amp;gameId=...` to prevent regression

## Repro
1. Open `game.html#teamId=X8Tmh8wkp5U2tNWiHQ2I&amp;gameId=3qyJxjo6zs`
2. Before this change, parser produced `amp;gameId`, so `gameId` was missing and the page redirected to `index.html`

## Validation
- parser logic check (Node): normalized output now includes both `teamId` and `gameId`
- Playwright test added: `tests/smoke/url-params-escaped-amp.spec.js`
- Could not execute Playwright in this environment due missing system lib: `libatk-1.0.so.0`
