### PR TITLE
fix: keep live game clock in sync from tracker

### DIFF
--- a/js/live-game.js
+++ b/js/live-game.js
@@ -276,7 +276,7 @@ function renderPlayByPlay(event, isNew = false) {
   const card = document.createElement('div');
 
   // System events (clock, period changes) don't have a side
-  const isSystemEvent = ['clock_pause', 'clock_start', 'period_change', 'undo', 'log_remove'].includes(event.type);
+  const isSystemEvent = ['clock_pause', 'clock_start', 'period_change', 'undo', 'log_remove', 'clock_sync'].includes(event.type);
   const sideClass = isSystemEvent ? 'border-slate' : (event.isOpponent ? 'event-away' : 'event-home');
   card.className = `bg-slate/50 rounded-lg p-3 border-l-4 ${sideClass} ${isNew ? 'event-slide' : ''}`;
   const opponentLabel = [
@@ -724,6 +724,18 @@ function processNewEvents(events) {
     if (event.type === 'lineup') {
       return;
     }
+
+    // Tracker emits heartbeat events to keep late-joining viewers on an accurate clock.
+    // Apply score/period/clock updates but don't add feed noise.
+    if (event.type === 'clock_sync') {
+      if (event.homeScore !== undefined) state.homeScore = event.homeScore;
+      if (event.awayScore !== undefined) state.awayScore = event.awayScore;
+      if (event.period) state.period = event.period;
+      if (event.gameClockMs !== undefined) state.gameClockMs = event.gameClockMs;
+      renderScoreboard();
+      return;
+    }
+
     state.events.push(event);
 
     if (event.homeScore !== undefined) state.homeScore = event.homeScore;

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -66,8 +66,11 @@ let liveState = {
   lastChatSentAt: 0,
   scoreSyncTimeout: null,
   lastSyncedHome: null,
-  lastSyncedAway: null
+  lastSyncedAway: null,
+  lastClockSyncAt: 0
 };
+
+const LIVE_CLOCK_SYNC_INTERVAL_MS = 5000;
 
 let liveSync = {
   playerTimeouts: new Map(),
@@ -1051,6 +1054,7 @@ function initViewerCount() {
 async function startLiveBroadcast() {
   if (liveState.isLive) return;
   liveState.isLive = true;
+  liveState.lastClockSyncAt = 0;
   try {
     await setGameLiveStatus(currentTeamId, currentGameId, 'live');
   } catch (error) {
@@ -1071,6 +1075,7 @@ async function endLiveBroadcast() {
 
   if (liveState.isLive) {
     liveState.isLive = false;
+    liveState.lastClockSyncAt = 0;
     if (liveState.unsubscribeChat) liveState.unsubscribeChat();
     if (liveState.unsubscribeViewers) liveState.unsubscribeViewers();
   }
@@ -1433,6 +1438,20 @@ function tick() {
   updateClockUI();
   updatePlayerTimes();
   renderFairness();
+
+  const wallNow = Date.now();
+  if (
+    liveState.isLive &&
+    currentTeamId &&
+    currentGameId &&
+    (wallNow - liveState.lastClockSyncAt >= LIVE_CLOCK_SYNC_INTERVAL_MS)
+  ) {
+    liveState.lastClockSyncAt = wallNow;
+    broadcastEvent(baseLiveEvent({
+      type: 'clock_sync',
+      description: 'Clock sync'
+    }));
+  }
 }
 
 function updatePlayerTimes() {


### PR DESCRIPTION
## Objective
Fix the live game tracker/viewer clock drift so spectators joining mid-game see an accurate clock without waiting for the next stat event.

## Current state
- `live-tracker` only broadcasts clock values when a stat or system event happens.
- `live-game` updates clock from incoming events.
- Result: if no stats are logged for a while, viewer clock can be stale.

## Proposed state
- `live-tracker` emits a lightweight `clock_sync` heartbeat every 5 seconds while game is running/live.
- `live-game` consumes `clock_sync` to update scoreboard clock/period/score, but does **not** add it to play-by-play feed.

## Risk surface / blast radius
- Scope is limited to `js/live-tracker.js` and `js/live-game.js`.
- New event type is additive and ignored by older clients that don’t special-case it.
- Firestore write volume increase is bounded (1 event / 5s during active live tracking).

## Files changed
- `js/live-tracker.js`
  - add `LIVE_CLOCK_SYNC_INTERVAL_MS = 5000`
  - add `liveState.lastClockSyncAt`
  - emit `clock_sync` in `tick()` at interval while live
  - reset sync timer on live start/end
- `js/live-game.js`
  - treat `clock_sync` as a system event
  - handle `clock_sync` in `processNewEvents()` by updating scoreboard state only

## Validation
- Reviewed event flow end-to-end between tracker and viewer code paths.
- Could not run browser E2E in this environment due missing system lib: `libatk-1.0.so.0`.
