### PR TITLE
Add compact voice notes to live game tracker

### DIFF
--- a/js/live-tracker-notes.js
+++ b/js/live-tracker-notes.js
@@ -1,0 +1,21 @@
+export function isVoiceRecognitionSupported(win = globalThis) {
+  if (!win) return false;
+  return !!(win.SpeechRecognition || win.webkitSpeechRecognition);
+}
+
+export function normalizeGameNoteText(text) {
+  return (text || '').trim();
+}
+
+export function appendGameSummaryLine(existingSummary, noteText) {
+  const summary = normalizeGameNoteText(existingSummary);
+  const note = normalizeGameNoteText(noteText);
+  if (!note) return summary;
+  return summary ? `${summary}\n${note}` : note;
+}
+
+export function buildGameNoteLogText(noteText, type = 'text') {
+  const note = normalizeGameNoteText(noteText);
+  if (!note) return '';
+  return type === 'voice' ? `Voice note: ${note}` : `Note: ${note}`;
+}

--- a/live-tracker.html
+++ b/live-tracker.html
@@ -133,6 +133,17 @@
       <div id="live-players" class="grid grid-cols-2 gap-2"></div>
       <button id="toggle-bench-mobile" class="w-full text-xs font-semibold pill px-3 py-2 bg-white border border-slate/10">Bench / Add starters</button>
       <div id="bench-mobile" class="grid grid-cols-2 gap-2"></div>
+      <div class="rounded-xl border border-slate/10 bg-sand/60 p-2 space-y-2">
+        <div class="flex items-center justify-between gap-2">
+          <p class="text-[11px] uppercase tracking-[0.18em] text-slate/60 font-semibold">Live Notes</p>
+          <button id="voice-note-btn" class="pill px-2 py-1 bg-white border border-slate/20 text-[11px] font-semibold text-slate-700">Start voice note</button>
+        </div>
+        <p id="voice-note-hint" class="text-[11px] text-slate-500">Tap Start voice note, speak, then tap Stop voice note.</p>
+        <div class="flex gap-2">
+          <input id="live-note-input" class="flex-1 px-3 py-2 rounded-lg border border-slate/10 text-xs" placeholder="Quick note for this game...">
+          <button id="live-note-add" class="pill px-3 py-2 bg-slate text-white text-[11px] font-semibold">Add</button>
+        </div>
+      </div>
     </section>
 
     <!-- Opponents -->

--- a/tests/unit/live-tracker-notes.test.js
+++ b/tests/unit/live-tracker-notes.test.js
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isVoiceRecognitionSupported,
+  normalizeGameNoteText,
+  appendGameSummaryLine,
+  buildGameNoteLogText
+} from '../../js/live-tracker-notes.js';
+
+describe('live tracker note helpers', () => {
+  it('detects support when SpeechRecognition exists', () => {
+    expect(isVoiceRecognitionSupported({ SpeechRecognition: function Mock() {} })).toBe(true);
+  });
+
+  it('detects support when webkitSpeechRecognition exists', () => {
+    expect(isVoiceRecognitionSupported({ webkitSpeechRecognition: function Mock() {} })).toBe(true);
+  });
+
+  it('returns false when no recognition API exists', () => {
+    expect(isVoiceRecognitionSupported({})).toBe(false);
+  });
+
+  it('normalizes note text by trimming whitespace', () => {
+    expect(normalizeGameNoteText('  pushed pace in Q2  ')).toBe('pushed pace in Q2');
+  });
+
+  it('appends note lines to existing summary', () => {
+    expect(appendGameSummaryLine('First note', 'Second note')).toBe('First note\nSecond note');
+  });
+
+  it('does not append empty note lines', () => {
+    expect(appendGameSummaryLine('First note', '   ')).toBe('First note');
+  });
+
+  it('formats text note log entries', () => {
+    expect(buildGameNoteLogText('Subbed in energy unit', 'text')).toBe('Note: Subbed in energy unit');
+  });
+
+  it('formats voice note log entries', () => {
+    expect(buildGameNoteLogText('Great closeout by 12', 'voice')).toBe('Voice note: Great closeout by 12');
+  });
+});


### PR DESCRIPTION
## Summary
- add compact Live Notes controls in live-tracker.html (voice toggle + quick note input)
- reuse the drills-style speech recognition flow for start/stop voice capture in js/live-tracker.js
- append notes to game summary (#notes-final) and game log in real time
- add shared note helpers and unit tests for normalization/log formatting

## Testing
- ./node_modules/.bin/vitest run
