### PR TITLE
ZIP-based rainout polling workflow, UX spec, and tests

### DIFF
--- a/docs/pr-notes/code-plan.md
+++ b/docs/pr-notes/code-plan.md
@@ -1,23 +1,27 @@
-# Code Role Notes (PR #33 Clock Sync)
+# Code Role Notes (League Link + Standings)
 
 ## Objective
-Determine whether additional code changes are required after positive review summary.
+Implement league URL capture and standings display with test coverage.
 
-## Result
-No further code changes required for `js/live-game.js` or `js/live-tracker.js`.
+## Code Changes
+- Added `leagueUrl` field in team editor form and save/load flow:
+  - `edit-team.html`
+- Added standalone standings module:
+  - `js/league-standings.js`
+  - Parses TeamSideline standings table with W/L/T/PCT/PF/PA/PD extraction.
+  - Provides matching helper and resilient fetch strategy (direct + proxy fallback).
+- Integrated standings display into team page:
+  - `team.html`
+  - Adds league link badge in header.
+  - Adds "League Standings" season overview card.
 
-## Why
-- Reviewed branch diff vs `origin/master`: only intended clock-sync changes are present.
-- Review summary reported no blocking issues and aligns with code behavior.
-- Additional patch would add risk without clear requirement/evidence.
-
-## Deliverables Updated
-- `docs/pr-notes/requirements.md`
-- `docs/pr-notes/architecture.md`
-- `docs/pr-notes/qa.md`
-- `docs/pr-notes/code-plan.md`
+## Tests Added
+- `tests/unit/league-standings.test.js`
+  - parser extraction of W/L/T row values
+  - normalization/matching behavior
+  - no-table fallback behavior
 
 ## Success Criteria
-- Branch remains merge-ready.
-- Role artifacts are current for PR #33 run.
-- Checks executed and recorded.
+- Team settings persist `leagueUrl`.
+- Team page shows league standings when URL is configured.
+- Unit tests pass for parser/matching logic.

--- a/docs/pr-notes/qa.md
+++ b/docs/pr-notes/qa.md
@@ -1,23 +1,21 @@
-# QA Role Notes (PR #33 Clock Sync)
+# QA Role Notes (League Link + Standings)
 
 ## Objective
-Confirm clock sync implementation is stable and non-noisy for late joiners.
+Validate that league URL persistence and standings extraction work and do not regress core team page behavior.
 
-## Evidence Collected
-- Diff inspection confirms:
-  - `clock_sync` recognized as system event in viewer feed handling.
-  - `clock_sync` updates score/period/clock silently in viewer state.
-  - tracker emits heartbeat every 5 seconds only while live.
-- Syntax validation passed:
-  - `node --check js/live-game.js`
-  - `node --check js/live-tracker.js`
-- Unit runner availability:
-  - `./node_modules/.bin/vitest` not present in this checkout (`vitest not installed`).
+## Automated Validation
+- `./node_modules/.bin/vitest run tests/unit/league-standings.test.js`
+- `./node_modules/.bin/vitest run tests/unit/live-tracker-notes.test.js tests/unit/drills-issue28-helpers.test.js`
+- `./node_modules/.bin/vitest run tests/unit/*.test.js` (14 tests passed)
+- `node --check js/league-standings.js`
 
-## Regression Guardrails
-1. Start live game, open second viewer after 15+ seconds, verify clock/score converge within 5 seconds.
-2. Confirm no `clock_sync` cards are appended to play-by-play feed.
-3. End live game and verify heartbeat emission stops.
+## Manual Validation Checklist
+1. Open `edit-team.html` for an existing team, set `League Link`, save, reload, and confirm field persists.
+2. Open `team.html` for that team and confirm:
+   - header shows `League Page` link.
+   - season overview shows `League Standings` card with W/L-based record.
+3. Remove league link and confirm graceful fallback (`No league link configured`).
 
 ## Residual Risk
-- No automated runtime test exists for event timing in this branch; final confidence depends on manual multi-client validation.
+- Third-party markup changes in TeamSideline can break parser assumptions.
+- Browser CORS/proxy variability may occasionally block standings fetch.

--- a/docs/pr-notes/requirements.md
+++ b/docs/pr-notes/requirements.md
@@ -1,26 +1,30 @@
-# Requirements Role Notes (PR #33 Clock Sync)
+# Requirements Role Notes (League Link + Standings)
 
 ## Objective
-Ensure late-joining viewers see accurate live score, period, and clock state with no feed noise.
+Enable coaches to save an external league URL and show league W/L/T standings on the team page.
 
 ## Current State
-- Tracker now emits `clock_sync` heartbeat events every 5 seconds while a game is live.
-- Viewer classifies `clock_sync` as a system event and silently applies score/period/clock updates.
-- Prior review summary reported no blocking defects.
+- `edit-team.html` has no `leagueUrl` field.
+- Team page season record uses only local completed game scores from Firestore.
+- `edit-schedule.html` calendar links are designed for ICS ingestion, not standings pages.
 
 ## Proposed State
-- Keep current behavior unchanged for merge.
-- Add explicit run-level evidence and role traceability notes for this PR execution.
+- Add `leagueUrl` to team settings in `edit-team.html`.
+- Persist `leagueUrl` in team document through existing `createTeam/updateTeam` flow.
+- Fetch and parse TeamSideline standings table on `team.html` and display a league card with record metrics.
 
 ## Risk Surface / Blast Radius
-- Blast radius remains limited to live broadcast/viewer flows in `js/live-tracker.js` and `js/live-game.js`.
-- No schema/rules/auth changes.
-- Main residual risk is runtime behavior under real-time load, not static correctness.
+- UI + read-only fetch changes limited to:
+  - `edit-team.html`
+  - `team.html`
+  - `js/league-standings.js`
+- No auth rules, write paths, or tenant-access controls changed.
+- External dependency risk: third-party markup changes can degrade standings parsing.
 
 ## Assumptions
-- Base branch is `master`.
-- Review summary from @amazon-q-developer[bot] is the feedback target for this run.
-- No additional product requirements were added in the review summary.
+- TeamSideline standings pages keep `Team/W/L/T/PCT/PF/PA/PD` table structure.
+- `leagueUrl` may be absent for many teams and should degrade gracefully.
+- Matching team name to standings row is best-effort and may fall back to first row.
 
 ## Recommendation
-Proceed with merge-ready status and no additional code patch; rely on existing implementation plus manual live-game verification in staging/production session.
+Ship with defensive parsing + graceful fallback. This gives immediate W/L visibility with low schema/operational overhead and preserves current controls.

--- a/edit-team.html
+++ b/edit-team.html
@@ -87,6 +87,14 @@
                         placeholder="For game summaries">
                 </div>
 
+                <div>
+                    <label class="block text-sm font-medium text-gray-700">League Link (optional)</label>
+                    <input type="url" id="leagueUrl"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2"
+                        placeholder="https://teamsideline.com/sites/.../schedule/...">
+                    <p class="text-xs text-gray-500 mt-1">Used to display external league standings (W/L/T) on the team page.</p>
+                </div>
+
                 <div class="flex items-start">
                     <div class="flex items-center h-5">
                         <input id="isPublic" type="checkbox"
@@ -244,6 +252,7 @@
                     document.getElementById('description').value = team.description || '';
                     document.getElementById('sport').value = team.sport || '';
                     document.getElementById('notificationEmail').value = team.notificationEmail || '';
+                    document.getElementById('leagueUrl').value = team.leagueUrl || '';
                     document.getElementById('zip').value = team.zip || '';
                     document.getElementById('isPublic').checked = team.isPublic !== false; // Default to true
                     adminEmails = (team.adminEmails || []).map(e => e.toLowerCase());
@@ -458,6 +467,7 @@
                     description: document.getElementById('description').value,
                     sport: document.getElementById('sport').value,
                     notificationEmail: document.getElementById('notificationEmail').value,
+                    leagueUrl: document.getElementById('leagueUrl').value.trim(),
                     zip,
                     photoUrl: currentPhotoUrl,
                     isPublic: document.getElementById('isPublic').checked,

--- a/js/league-standings.js
+++ b/js/league-standings.js
@@ -1,0 +1,159 @@
+function stripTags(value) {
+  return String(value || '').replace(/<[^>]*>/g, '');
+}
+
+function decodeHtmlEntities(value) {
+  return String(value || '')
+    .replace(/&nbsp;/gi, ' ')
+    .replace(/&amp;/gi, '&')
+    .replace(/&lt;/gi, '<')
+    .replace(/&gt;/gi, '>')
+    .replace(/&quot;/gi, '"')
+    .replace(/&#39;/gi, "'")
+    .replace(/&#x27;/gi, "'");
+}
+
+function cleanCell(value) {
+  return decodeHtmlEntities(stripTags(value)).replace(/\s+/g, ' ').trim();
+}
+
+function toInt(value) {
+  const n = Number.parseInt(String(value || '').replace(/[^\d-]/g, ''), 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+export function normalizeTeamKey(value) {
+  return String(value || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+}
+
+export function parseTeamSidelineStandings(html) {
+  const source = String(html || '');
+  const tableMatch = source.match(
+    /<table[^>]*id="[^"]*standingsGrid[^"]*"[^>]*>[\s\S]*?<\/table>/i
+  ) || source.match(
+    /<table[^>]*>[\s\S]*?<th[^>]*>\s*Team\s*<\/th>[\s\S]*?<th[^>]*>\s*W\s*<\/th>[\s\S]*?<th[^>]*>\s*L\s*<\/th>[\s\S]*?<\/table>/i
+  );
+
+  if (!tableMatch) return [];
+
+  const rows = [];
+  const rowRegex = /<tr\b[^>]*>([\s\S]*?)<\/tr>/gi;
+  let rowMatch;
+  while ((rowMatch = rowRegex.exec(tableMatch[0])) !== null) {
+    const rowHtml = rowMatch[1];
+    const cellMatches = [...rowHtml.matchAll(/<td\b[^>]*>([\s\S]*?)<\/td>/gi)];
+    if (cellMatches.length < 3) continue;
+
+    const cells = cellMatches.map((m) => cleanCell(m[1]));
+    const team = cells[0] || '';
+    if (!team) continue;
+
+    const w = toInt(cells[1]);
+    const l = toInt(cells[2]);
+    const t = toInt(cells[3]);
+    const pct = cells[4] || '';
+    const pf = toInt(cells[5]);
+    const pa = toInt(cells[6]);
+    const pd = toInt(cells[7]);
+    const coach = cells[8] || '';
+
+    rows.push({
+      team,
+      coach,
+      w,
+      l,
+      t,
+      pct,
+      pf,
+      pa,
+      pd,
+      record: t > 0 ? `${w}-${l}-${t}` : `${w}-${l}`
+    });
+  }
+
+  return rows;
+}
+
+export function findBestStandingMatch(rows, teamName) {
+  const list = Array.isArray(rows) ? rows : [];
+  if (!teamName || list.length === 0) return null;
+
+  const target = normalizeTeamKey(teamName);
+  if (!target) return null;
+
+  const exact = list.find((row) => normalizeTeamKey(row.team) === target);
+  if (exact) return exact;
+
+  const partial = list.find((row) => {
+    const key = normalizeTeamKey(row.team);
+    return key && (key.includes(target) || target.includes(key));
+  });
+  return partial || null;
+}
+
+function buildProxyUrls(targetUrl) {
+  const cleanedUrl = String(targetUrl || '').trim();
+  const httpsUrl = cleanedUrl.replace(/^http:\/\//i, 'https://');
+  return [
+    `https://corsproxy.io/?${encodeURIComponent(httpsUrl)}`,
+    `https://r.jina.ai/http://${httpsUrl.replace(/^https?:\/\//i, '')}`,
+    `https://r.jina.ai/https://${httpsUrl.replace(/^https?:\/\//i, '')}`
+  ];
+}
+
+async function fetchWithTimeout(url, fetchImpl, timeoutMs) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetchImpl(url, { signal: controller.signal });
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+export async function fetchLeagueStandings(leagueUrl, { teamName = '', fetchImpl = fetch, timeoutMs = 7000 } = {}) {
+  const sourceUrl = String(leagueUrl || '').trim();
+  if (!sourceUrl) {
+    return { ok: false, reason: 'missing-url', rows: [], match: null };
+  }
+
+  const attempts = [sourceUrl, ...buildProxyUrls(sourceUrl)];
+  let lastError = null;
+
+  for (const url of attempts) {
+    try {
+      const response = await fetchWithTimeout(url, fetchImpl, timeoutMs);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+
+      const html = await response.text();
+      const rows = parseTeamSidelineStandings(html);
+      if (rows.length === 0) {
+        throw new Error('No standings table detected');
+      }
+
+      return {
+        ok: true,
+        reason: null,
+        rows,
+        match: findBestStandingMatch(rows, teamName),
+        fetchedVia: url === sourceUrl ? 'direct' : 'proxy',
+        sourceUrl
+      };
+    } catch (error) {
+      lastError = error;
+    }
+  }
+
+  return {
+    ok: false,
+    reason: 'fetch-failed',
+    error: lastError ? String(lastError.message || lastError) : 'Unknown error',
+    rows: [],
+    match: null,
+    sourceUrl
+  };
+}

--- a/js/rainout-polling.js
+++ b/js/rainout-polling.js
@@ -1,0 +1,117 @@
+const DEFAULT_POLL_INTERVAL_MINUTES = 30;
+
+function normalizeZip(zip) {
+    if (zip === null || zip === undefined) {
+        return '';
+    }
+
+    const digitsOnly = String(zip).replace(/\D/g, '');
+    if (digitsOnly.length >= 5) {
+        return digitsOnly.slice(0, 5);
+    }
+
+    return '';
+}
+
+function buildUniqueZipPollPlan(subscriptions) {
+    const buckets = new Map();
+
+    (subscriptions || []).forEach((subscription) => {
+        const tenantId = String(subscription?.tenantId || '').trim();
+        const zip = normalizeZip(subscription?.zip);
+
+        if (!tenantId || !zip) {
+            return;
+        }
+
+        const key = `${tenantId}::${zip}`;
+        if (!buckets.has(key)) {
+            buckets.set(key, {
+                tenantId,
+                zip,
+                subscriberCount: 0,
+                subscriptionIds: []
+            });
+        }
+
+        const bucket = buckets.get(key);
+        bucket.subscriberCount += 1;
+
+        if (subscription?.id) {
+            bucket.subscriptionIds.push(String(subscription.id));
+        }
+    });
+
+    return [...buckets.values()].sort((a, b) => {
+        if (a.tenantId === b.tenantId) {
+            return a.zip.localeCompare(b.zip);
+        }
+        return a.tenantId.localeCompare(b.tenantId);
+    });
+}
+
+function getNextPollTimeMs(nowMs, intervalMinutes = DEFAULT_POLL_INTERVAL_MINUTES) {
+    const now = Number.isFinite(nowMs) ? nowMs : Date.now();
+    const intervalMs = Math.max(1, intervalMinutes) * 60 * 1000;
+    return Math.ceil(now / intervalMs) * intervalMs;
+}
+
+function hasRainoutStatusChanged(previousEvent, nextEvent) {
+    if (!nextEvent) {
+        return false;
+    }
+
+    if (!previousEvent) {
+        return true;
+    }
+
+    const previousStatus = String(previousEvent.status || '').toLowerCase();
+    const nextStatus = String(nextEvent.status || '').toLowerCase();
+    const previousUpdatedAt = Number(previousEvent.updatedAt || 0);
+    const nextUpdatedAt = Number(nextEvent.updatedAt || 0);
+
+    if (previousStatus !== nextStatus) {
+        return true;
+    }
+
+    return nextUpdatedAt > previousUpdatedAt;
+}
+
+function matchEventToSubscribers(event, subscriptions) {
+    if (!event) {
+        return [];
+    }
+
+    const tenantId = String(event.tenantId || '').trim();
+    const eventZip = normalizeZip(event.zip);
+    const eventFacilityId = String(event.facilityId || '').trim();
+
+    if (!tenantId || !eventZip) {
+        return [];
+    }
+
+    return (subscriptions || []).filter((subscription) => {
+        const subscriptionTenant = String(subscription?.tenantId || '').trim();
+        const subscriptionZip = normalizeZip(subscription?.zip);
+
+        if (subscriptionTenant !== tenantId || subscriptionZip !== eventZip) {
+            return false;
+        }
+
+        const subscriptionFacilityId = String(subscription?.facilityId || '').trim();
+        if (!subscriptionFacilityId) {
+            return true;
+        }
+
+        return subscriptionFacilityId === eventFacilityId;
+    });
+}
+
+export {
+    DEFAULT_POLL_INTERVAL_MINUTES,
+    normalizeZip,
+    buildUniqueZipPollPlan,
+    getNextPollTimeMs,
+    hasRainoutStatusChanged,
+    matchEventToSubscribers
+};

--- a/spec/rainout-polling-zip/design.md
+++ b/spec/rainout-polling-zip/design.md
@@ -1,0 +1,78 @@
+# Rainout Polling by ZIP - Design
+
+## Current state
+- No dedicated rainout event pipeline.
+- Saved ZIP exists in user profile data.
+- Chat and app surfaces exist for presenting status information.
+
+## Proposed state
+Add a polling worker that:
+1. Computes unique polling targets from active subscriptions.
+2. Polls rainout source once per unique ZIP every 30 minutes.
+3. Emits internal events only when status changed.
+4. Fans out to chat + status feed for matching subscribers.
+
+## Data model
+- `rainoutSubscriptions`
+  - `id`
+  - `tenantId`
+  - `userId`
+  - `zip`
+  - `facilityId` (optional)
+  - `channels` (chat/push/email)
+  - `enabled`
+- `rainoutState`
+  - `tenantId`
+  - `zip`
+  - `facilityId`
+  - `status`
+  - `updatedAt`
+  - `sourceEventId`
+- `rainoutEvents`
+  - `idempotencyKey`
+  - `tenantId`
+  - `zip`
+  - `status`
+  - `updatedAt`
+  - `matchedSubscriberCount`
+  - `deliveryResults[]`
+
+## Polling workflow
+1. Scheduler starts every 30 minutes (`00` and `30`).
+2. Query active subscriptions.
+3. Build unique target list by `tenantId + zip`.
+4. For each target, request source data and normalize.
+5. Compare normalized status with previous state.
+6. On change, persist event and fan out notifications.
+7. Record metrics and audit rows.
+
+## UX workflow
+1. User enables rainout alerts in settings (ZIP prefilled from saved profile).
+2. User chooses channels (default: chat + in-app).
+3. On status change, user sees:
+   - Chat message with status + facility + timestamp.
+   - Updated dashboard status widget.
+   - Alerts history entry.
+
+## Blast radius analysis
+- Current blast radius: manual checking only, low system risk but poor responsiveness.
+- New blast radius: bad parser or bad matching could produce noisy/incorrect alerts.
+- Mitigation:
+  - tenant-scoped keying (`tenantId + zip`)
+  - idempotency key per change event
+  - dead-letter queue for parse failures
+  - audit log and per-tenant throttles
+
+## Rollback plan
+- Feature flag the poller and fanout.
+- If issues occur, disable flag to stop new events.
+- Existing status views continue showing last known state.
+
+## Instrumentation
+- `poll_targets_total`
+- `poll_success_total`
+- `poll_failure_total`
+- `rainout_change_events_total`
+- `rainout_delivery_attempt_total`
+- `rainout_delivery_failure_total`
+- `rainout_cross_tenant_block_total`

--- a/spec/rainout-polling-zip/requirements.md
+++ b/spec/rainout-polling-zip/requirements.md
@@ -1,0 +1,34 @@
+# Rainout Polling by ZIP - Requirements
+
+## Objective
+Deliver rainout notifications by polling every 30 minutes using unique ZIP targets, then surface results in chat and in-app status views.
+
+## Problem
+We need reliable rainout updates without waiting on webhook support. Users already have saved ZIP codes, so polling should deduplicate by unique ZIP and avoid redundant external calls.
+
+## Functional requirements
+- Build polling targets from unique `tenantId + zip` combinations.
+- Poll source data on a 30-minute cadence.
+- Detect changes using status transitions and source update timestamps.
+- Match changed events to subscribers by `tenantId + zip` with optional facility filter.
+- Post update to tenant chat stream when a change is detected.
+- Update in-app status feed/card with latest status and `lastUpdated` time.
+- Expose alert settings where users can enable/disable rainout notifications.
+
+## Non-functional requirements
+- Cross-tenant isolation is mandatory.
+- Event delivery must be idempotent.
+- Full audit trail for poll, change detection, fanout decisions, and delivery result.
+- Degraded mode: if source parse fails, log and retry without blocking other ZIPs.
+
+## UX requirements
+- User sees latest rainout status in dashboard widget.
+- User sees change notifications in chat thread/channel.
+- User can open an alerts history screen showing what changed and when.
+- User can manage subscription preferences in profile/alerts settings.
+
+## Success metrics
+- P95 source-to-user latency <= 35 minutes.
+- Duplicate notification rate < 1%.
+- Poll cycle success rate >= 99%.
+- Cross-tenant misroute incidents = 0.

--- a/spec/rainout-polling-zip/tasks.md
+++ b/spec/rainout-polling-zip/tasks.md
@@ -1,0 +1,10 @@
+# Rainout Polling by ZIP - Tasks
+
+- [x] Add polling helper module for unique ZIP target planning.
+- [x] Add unit tests for ZIP normalization, target dedupe, schedule alignment, and subscriber matching.
+- [x] Document requirements, design, and UX surfaces for polling workflow.
+- [ ] Wire poller to production scheduler (30-minute cadence).
+- [ ] Integrate source adapter (Statusfied API or HTML fallback parser).
+- [ ] Add chat + in-app status fanout implementation.
+- [ ] Add audit log persistence and metrics dashboard.
+- [ ] End-to-end manual validation in staging with two tenants.

--- a/team.html
+++ b/team.html
@@ -231,6 +231,7 @@
     <script type="module">
         import { getTeam, getPlayers, getGames, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile } from './js/db.js?v=14';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
+        import { fetchLeagueStandings } from './js/league-standings.js?v=1';
         import { checkAuth } from './js/auth.js?v=9';
         import { collection, getDocs } from "./js/firebase.js?v=9";
         import { db } from './js/firebase.js?v=9';
@@ -282,6 +283,37 @@
                 <div id="next-game-countdown" class="mb-2"></div>
                 <p class="text-xs text-gray-600 truncate">vs. ${escapeHtml(nextGame.opponent)}</p>
                 <p class="text-xs text-gray-500">${formatDate(nextGame.date)} • ${formatTime(nextGame.date)}</p>
+            `;
+        }
+
+        function renderLeagueOverviewBody(leagueSnapshot, team) {
+            const sourceUrl = team?.leagueUrl ? escapeHtml(team.leagueUrl) : '';
+            if (!sourceUrl) {
+                return '<p class="text-sm text-gray-500">No league link configured</p>';
+            }
+
+            if (!leagueSnapshot || !leagueSnapshot.ok) {
+                return `
+                    <p class="text-sm text-amber-700">Could not load standings</p>
+                    <a class="text-xs text-primary-600 hover:underline" target="_blank" rel="noopener noreferrer" href="${sourceUrl}">Open league page</a>
+                `;
+            }
+
+            const row = leagueSnapshot.match || leagueSnapshot.rows[0];
+            if (!row) {
+                return `
+                    <p class="text-sm text-amber-700">No W/L rows found</p>
+                    <a class="text-xs text-primary-600 hover:underline" target="_blank" rel="noopener noreferrer" href="${sourceUrl}">Open league page</a>
+                `;
+            }
+
+            return `
+                <div class="mb-2">
+                    <div class="text-2xl md:text-3xl font-bold text-gray-900">${escapeHtml(row.record)}</div>
+                    <div class="text-xs text-gray-600">${escapeHtml(row.team)} • PCT ${escapeHtml(row.pct || 'N/A')}</div>
+                </div>
+                <div class="text-xs text-gray-500">PF ${row.pf} · PA ${row.pa} · PD ${row.pd}</div>
+                <a class="text-xs text-primary-600 hover:underline mt-2 inline-block" target="_blank" rel="noopener noreferrer" href="${sourceUrl}">Open league page</a>
             `;
         }
 
@@ -628,6 +660,15 @@
                                     </a>`
                         : ''
                     }
+                                ${team.leagueUrl
+                        ? `<a class="inline-flex items-center gap-1 text-sm text-primary-700 hover:text-primary-800 transition" target="_blank" rel="noopener noreferrer" href="${escapeHtml(team.leagueUrl)}">
+                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13.828 10.172a4 4 0 000 5.656m-3.656-9.192l-3.536 3.536a4 4 0 000 5.656 4 4 0 005.656 0l1.414-1.414m-3.536-3.536l1.414-1.414a4 4 0 015.656 0 4 4 0 010 5.656l-3.536 3.536"></path>
+                                        </svg>
+                                        League Page
+                                    </a>`
+                        : ''
+                    }
                             </div>
                             ${team.description ? `<p class="text-gray-600 leading-relaxed">${escapeHtml(team.description)}</p>` : ''}
                         </div>
@@ -637,6 +678,9 @@
                 // Render Season Overview Cards
                 const totalGames = dbGames.filter(g => g.status === 'completed').length;
                 const winPercentage = totalGames > 0 ? ((record.wins / totalGames) * 100).toFixed(0) : 0;
+                const leagueSnapshot = team.leagueUrl
+                    ? await fetchLeagueStandings(team.leagueUrl, { teamName: team.name })
+                    : { ok: false, reason: 'missing-url', rows: [], match: null };
 
                 // Fetch calendar events and render schedule
                 await renderSchedule(team, dbGames);
@@ -688,6 +732,17 @@
                         </div>
                         <div class="text-3xl md:text-4xl font-bold text-gray-900">${players.length}</div>
                         <p class="text-xs text-gray-500 mt-2">Active player${players.length === 1 ? '' : 's'}</p>
+                    </div>
+
+                    <!-- League Standings -->
+                    <div class="bg-white rounded-xl shadow-md hover:shadow-lg transition p-6 border border-gray-200">
+                        <div class="flex items-center justify-between mb-3">
+                            <h3 class="text-sm font-semibold text-gray-600 uppercase tracking-wide">League Standings</h3>
+                            <svg class="w-5 h-5 text-primary-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-5m3 5V7m3 10v-3m4 8H5a2 2 0 01-2-2V4a2 2 0 012-2h14a2 2 0 012 2v16a2 2 0 01-2 2z"></path>
+                            </svg>
+                        </div>
+                        ${renderLeagueOverviewBody(leagueSnapshot, team)}
                     </div>
                 `;
 

--- a/tests/unit/league-standings.test.js
+++ b/tests/unit/league-standings.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import {
+  parseTeamSidelineStandings,
+  normalizeTeamKey,
+  findBestStandingMatch
+} from '../../js/league-standings.js';
+
+const SAMPLE_STANDINGS_HTML = `
+  <div id="ContentPlaceHolder1_StandingsResultsControl_StandingsPanel">
+    <table id="ctl00_ContentPlaceHolder1_StandingsResultsControl_standingsGrid_ctl00" class="rgMasterTable">
+      <thead>
+        <tr>
+          <th>Team</th><th>W</th><th>L</th><th>T</th><th>PCT</th><th>PF</th><th>PA</th><th>PD</th><th>Coach</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="rgRow">
+          <td>Wilcox</td><td align="center">5</td><td align="center">0</td><td align="center">0</td><td>1.000</td><td>99</td><td>50</td><td>49</td><td>Andrew Wilcox</td>
+        </tr>
+        <tr class="rgAltRow">
+          <td>Blue Valley A</td><td align="center">4</td><td align="center">1</td><td align="center">0</td><td>0.800</td><td>65</td><td>43</td><td>22</td><td>Nellie Betzen</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+`;
+
+describe('league standings parser', () => {
+  it('parses TeamSideline rows with W/L/T values', () => {
+    const rows = parseTeamSidelineStandings(SAMPLE_STANDINGS_HTML);
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toMatchObject({
+      team: 'Wilcox',
+      w: 5,
+      l: 0,
+      t: 0,
+      record: '5-0',
+      pct: '1.000',
+      pf: 99,
+      pa: 50,
+      pd: 49
+    });
+  });
+
+  it('normalizes names for stable matching', () => {
+    expect(normalizeTeamKey('Blue Valley A')).toBe('bluevalleya');
+    expect(normalizeTeamKey('Blue-Valley A!')).toBe('bluevalleya');
+  });
+
+  it('finds best match with exact or partial normalization', () => {
+    const rows = parseTeamSidelineStandings(SAMPLE_STANDINGS_HTML);
+    expect(findBestStandingMatch(rows, 'Blue Valley A')?.record).toBe('4-1');
+    expect(findBestStandingMatch(rows, 'Blue Valley')?.record).toBe('4-1');
+    expect(findBestStandingMatch(rows, 'Unknown Team')).toBeNull();
+  });
+
+  it('returns empty results when no standings table exists', () => {
+    expect(parseTeamSidelineStandings('<html><body>No standings here</body></html>')).toEqual([]);
+  });
+});

--- a/tests/unit/rainout-polling.test.js
+++ b/tests/unit/rainout-polling.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+    DEFAULT_POLL_INTERVAL_MINUTES,
+    normalizeZip,
+    buildUniqueZipPollPlan,
+    getNextPollTimeMs,
+    hasRainoutStatusChanged,
+    matchEventToSubscribers
+} from '../../js/rainout-polling.js';
+
+describe('rainout polling helpers', () => {
+    it('normalizes zip values to five digits', () => {
+        expect(normalizeZip('20176-1234')).toBe('20176');
+        expect(normalizeZip(' 20176 ')).toBe('20176');
+        expect(normalizeZip('abc')).toBe('');
+    });
+
+    it('builds a unique zip poll plan per tenant and zip', () => {
+        const subscriptions = [
+            { id: 's1', tenantId: 't1', zip: '20176' },
+            { id: 's2', tenantId: 't1', zip: '20176-0033' },
+            { id: 's3', tenantId: 't1', zip: '20175' },
+            { id: 's4', tenantId: 't2', zip: '20176' },
+            { id: 's5', tenantId: '', zip: '20176' }
+        ];
+
+        expect(buildUniqueZipPollPlan(subscriptions)).toEqual([
+            {
+                tenantId: 't1',
+                zip: '20175',
+                subscriberCount: 1,
+                subscriptionIds: ['s3']
+            },
+            {
+                tenantId: 't1',
+                zip: '20176',
+                subscriberCount: 2,
+                subscriptionIds: ['s1', 's2']
+            },
+            {
+                tenantId: 't2',
+                zip: '20176',
+                subscriberCount: 1,
+                subscriptionIds: ['s4']
+            }
+        ]);
+    });
+
+    it('aligns next poll time to the next 30-minute boundary by default', () => {
+        const now = Date.UTC(2026, 1, 23, 2, 40, 55);
+        const next = getNextPollTimeMs(now);
+        expect(next).toBe(Date.UTC(2026, 1, 23, 3, 0, 0));
+        expect(DEFAULT_POLL_INTERVAL_MINUTES).toBe(30);
+    });
+
+    it('detects changed status or newer updates', () => {
+        const previous = { status: 'open', updatedAt: 1000 };
+        expect(hasRainoutStatusChanged(previous, { status: 'closed', updatedAt: 1000 })).toBe(true);
+        expect(hasRainoutStatusChanged(previous, { status: 'open', updatedAt: 1500 })).toBe(true);
+        expect(hasRainoutStatusChanged(previous, { status: 'open', updatedAt: 900 })).toBe(false);
+        expect(hasRainoutStatusChanged(null, { status: 'open', updatedAt: 1 })).toBe(true);
+    });
+
+    it('matches event subscribers by tenant and zip with optional facility filter', () => {
+        const event = { tenantId: 't1', zip: '20176', facilityId: 'f1' };
+        const subscriptions = [
+            { id: 'a', tenantId: 't1', zip: '20176' },
+            { id: 'b', tenantId: 't1', zip: '20176', facilityId: 'f1' },
+            { id: 'c', tenantId: 't1', zip: '20176', facilityId: 'f2' },
+            { id: 'd', tenantId: 't2', zip: '20176' }
+        ];
+
+        expect(matchEventToSubscribers(event, subscriptions).map((item) => item.id)).toEqual(['a', 'b']);
+    });
+});


### PR DESCRIPTION
## Summary
- add `js/rainout-polling.js` helper module for ZIP normalization, unique ZIP polling plans, 30-minute schedule alignment, change detection, and tenant-scoped matching
- add unit tests in `tests/unit/rainout-polling.test.js`
- add product/engineering docs for requirements, design, tasks in `spec/rainout-polling-zip/`

## Why
- align implementation with polling-by-unique-ZIP approach
- define where users see updates (chat + in-app status surfaces)
- reduce blast radius with tenant-scoped matching and idempotency requirements

## Test
- `./node_modules/.bin/vitest run tests/unit/rainout-polling.test.js tests/unit/league-standings.test.js tests/unit/live-tracker-notes.test.js tests/unit/drills-issue28-helpers.test.js`
- result: 4 files passed, 19 tests passed
