### PR TITLE
ZIP-based rainout polling workflow, UX spec, and tests

### DIFF
--- a/js/rainout-polling.js
+++ b/js/rainout-polling.js
@@ -1,0 +1,117 @@
+const DEFAULT_POLL_INTERVAL_MINUTES = 30;
+
+function normalizeZip(zip) {
+    if (zip === null || zip === undefined) {
+        return '';
+    }
+
+    const digitsOnly = String(zip).replace(/\D/g, '');
+    if (digitsOnly.length >= 5) {
+        return digitsOnly.slice(0, 5);
+    }
+
+    return '';
+}
+
+function buildUniqueZipPollPlan(subscriptions) {
+    const buckets = new Map();
+
+    (subscriptions || []).forEach((subscription) => {
+        const tenantId = String(subscription?.tenantId || '').trim();
+        const zip = normalizeZip(subscription?.zip);
+
+        if (!tenantId || !zip) {
+            return;
+        }
+
+        const key = `${tenantId}::${zip}`;
+        if (!buckets.has(key)) {
+            buckets.set(key, {
+                tenantId,
+                zip,
+                subscriberCount: 0,
+                subscriptionIds: []
+            });
+        }
+
+        const bucket = buckets.get(key);
+        bucket.subscriberCount += 1;
+
+        if (subscription?.id) {
+            bucket.subscriptionIds.push(String(subscription.id));
+        }
+    });
+
+    return [...buckets.values()].sort((a, b) => {
+        if (a.tenantId === b.tenantId) {
+            return a.zip.localeCompare(b.zip);
+        }
+        return a.tenantId.localeCompare(b.tenantId);
+    });
+}
+
+function getNextPollTimeMs(nowMs, intervalMinutes = DEFAULT_POLL_INTERVAL_MINUTES) {
+    const now = Number.isFinite(nowMs) ? nowMs : Date.now();
+    const intervalMs = Math.max(1, intervalMinutes) * 60 * 1000;
+    return Math.ceil(now / intervalMs) * intervalMs;
+}
+
+function hasRainoutStatusChanged(previousEvent, nextEvent) {
+    if (!nextEvent) {
+        return false;
+    }
+
+    if (!previousEvent) {
+        return true;
+    }
+
+    const previousStatus = String(previousEvent.status || '').toLowerCase();
+    const nextStatus = String(nextEvent.status || '').toLowerCase();
+    const previousUpdatedAt = Number(previousEvent.updatedAt || 0);
+    const nextUpdatedAt = Number(nextEvent.updatedAt || 0);
+
+    if (previousStatus !== nextStatus) {
+        return true;
+    }
+
+    return nextUpdatedAt > previousUpdatedAt;
+}
+
+function matchEventToSubscribers(event, subscriptions) {
+    if (!event) {
+        return [];
+    }
+
+    const tenantId = String(event.tenantId || '').trim();
+    const eventZip = normalizeZip(event.zip);
+    const eventFacilityId = String(event.facilityId || '').trim();
+
+    if (!tenantId || !eventZip) {
+        return [];
+    }
+
+    return (subscriptions || []).filter((subscription) => {
+        const subscriptionTenant = String(subscription?.tenantId || '').trim();
+        const subscriptionZip = normalizeZip(subscription?.zip);
+
+        if (subscriptionTenant !== tenantId || subscriptionZip !== eventZip) {
+            return false;
+        }
+
+        const subscriptionFacilityId = String(subscription?.facilityId || '').trim();
+        if (!subscriptionFacilityId) {
+            return true;
+        }
+
+        return subscriptionFacilityId === eventFacilityId;
+    });
+}
+
+export {
+    DEFAULT_POLL_INTERVAL_MINUTES,
+    normalizeZip,
+    buildUniqueZipPollPlan,
+    getNextPollTimeMs,
+    hasRainoutStatusChanged,
+    matchEventToSubscribers
+};

--- a/spec/rainout-polling-zip/design.md
+++ b/spec/rainout-polling-zip/design.md
@@ -1,0 +1,78 @@
+# Rainout Polling by ZIP - Design
+
+## Current state
+- No dedicated rainout event pipeline.
+- Saved ZIP exists in user profile data.
+- Chat and app surfaces exist for presenting status information.
+
+## Proposed state
+Add a polling worker that:
+1. Computes unique polling targets from active subscriptions.
+2. Polls rainout source once per unique ZIP every 30 minutes.
+3. Emits internal events only when status changed.
+4. Fans out to chat + status feed for matching subscribers.
+
+## Data model
+- `rainoutSubscriptions`
+  - `id`
+  - `tenantId`
+  - `userId`
+  - `zip`
+  - `facilityId` (optional)
+  - `channels` (chat/push/email)
+  - `enabled`
+- `rainoutState`
+  - `tenantId`
+  - `zip`
+  - `facilityId`
+  - `status`
+  - `updatedAt`
+  - `sourceEventId`
+- `rainoutEvents`
+  - `idempotencyKey`
+  - `tenantId`
+  - `zip`
+  - `status`
+  - `updatedAt`
+  - `matchedSubscriberCount`
+  - `deliveryResults[]`
+
+## Polling workflow
+1. Scheduler starts every 30 minutes (`00` and `30`).
+2. Query active subscriptions.
+3. Build unique target list by `tenantId + zip`.
+4. For each target, request source data and normalize.
+5. Compare normalized status with previous state.
+6. On change, persist event and fan out notifications.
+7. Record metrics and audit rows.
+
+## UX workflow
+1. User enables rainout alerts in settings (ZIP prefilled from saved profile).
+2. User chooses channels (default: chat + in-app).
+3. On status change, user sees:
+   - Chat message with status + facility + timestamp.
+   - Updated dashboard status widget.
+   - Alerts history entry.
+
+## Blast radius analysis
+- Current blast radius: manual checking only, low system risk but poor responsiveness.
+- New blast radius: bad parser or bad matching could produce noisy/incorrect alerts.
+- Mitigation:
+  - tenant-scoped keying (`tenantId + zip`)
+  - idempotency key per change event
+  - dead-letter queue for parse failures
+  - audit log and per-tenant throttles
+
+## Rollback plan
+- Feature flag the poller and fanout.
+- If issues occur, disable flag to stop new events.
+- Existing status views continue showing last known state.
+
+## Instrumentation
+- `poll_targets_total`
+- `poll_success_total`
+- `poll_failure_total`
+- `rainout_change_events_total`
+- `rainout_delivery_attempt_total`
+- `rainout_delivery_failure_total`
+- `rainout_cross_tenant_block_total`

--- a/spec/rainout-polling-zip/requirements.md
+++ b/spec/rainout-polling-zip/requirements.md
@@ -1,0 +1,34 @@
+# Rainout Polling by ZIP - Requirements
+
+## Objective
+Deliver rainout notifications by polling every 30 minutes using unique ZIP targets, then surface results in chat and in-app status views.
+
+## Problem
+We need reliable rainout updates without waiting on webhook support. Users already have saved ZIP codes, so polling should deduplicate by unique ZIP and avoid redundant external calls.
+
+## Functional requirements
+- Build polling targets from unique `tenantId + zip` combinations.
+- Poll source data on a 30-minute cadence.
+- Detect changes using status transitions and source update timestamps.
+- Match changed events to subscribers by `tenantId + zip` with optional facility filter.
+- Post update to tenant chat stream when a change is detected.
+- Update in-app status feed/card with latest status and `lastUpdated` time.
+- Expose alert settings where users can enable/disable rainout notifications.
+
+## Non-functional requirements
+- Cross-tenant isolation is mandatory.
+- Event delivery must be idempotent.
+- Full audit trail for poll, change detection, fanout decisions, and delivery result.
+- Degraded mode: if source parse fails, log and retry without blocking other ZIPs.
+
+## UX requirements
+- User sees latest rainout status in dashboard widget.
+- User sees change notifications in chat thread/channel.
+- User can open an alerts history screen showing what changed and when.
+- User can manage subscription preferences in profile/alerts settings.
+
+## Success metrics
+- P95 source-to-user latency <= 35 minutes.
+- Duplicate notification rate < 1%.
+- Poll cycle success rate >= 99%.
+- Cross-tenant misroute incidents = 0.

--- a/spec/rainout-polling-zip/tasks.md
+++ b/spec/rainout-polling-zip/tasks.md
@@ -1,0 +1,10 @@
+# Rainout Polling by ZIP - Tasks
+
+- [x] Add polling helper module for unique ZIP target planning.
+- [x] Add unit tests for ZIP normalization, target dedupe, schedule alignment, and subscriber matching.
+- [x] Document requirements, design, and UX surfaces for polling workflow.
+- [ ] Wire poller to production scheduler (30-minute cadence).
+- [ ] Integrate source adapter (Statusfied API or HTML fallback parser).
+- [ ] Add chat + in-app status fanout implementation.
+- [ ] Add audit log persistence and metrics dashboard.
+- [ ] End-to-end manual validation in staging with two tenants.

--- a/tests/unit/rainout-polling.test.js
+++ b/tests/unit/rainout-polling.test.js
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import {
+    DEFAULT_POLL_INTERVAL_MINUTES,
+    normalizeZip,
+    buildUniqueZipPollPlan,
+    getNextPollTimeMs,
+    hasRainoutStatusChanged,
+    matchEventToSubscribers
+} from '../../js/rainout-polling.js';
+
+describe('rainout polling helpers', () => {
+    it('normalizes zip values to five digits', () => {
+        expect(normalizeZip('20176-1234')).toBe('20176');
+        expect(normalizeZip(' 20176 ')).toBe('20176');
+        expect(normalizeZip('abc')).toBe('');
+    });
+
+    it('builds a unique zip poll plan per tenant and zip', () => {
+        const subscriptions = [
+            { id: 's1', tenantId: 't1', zip: '20176' },
+            { id: 's2', tenantId: 't1', zip: '20176-0033' },
+            { id: 's3', tenantId: 't1', zip: '20175' },
+            { id: 's4', tenantId: 't2', zip: '20176' },
+            { id: 's5', tenantId: '', zip: '20176' }
+        ];
+
+        expect(buildUniqueZipPollPlan(subscriptions)).toEqual([
+            {
+                tenantId: 't1',
+                zip: '20175',
+                subscriberCount: 1,
+                subscriptionIds: ['s3']
+            },
+            {
+                tenantId: 't1',
+                zip: '20176',
+                subscriberCount: 2,
+                subscriptionIds: ['s1', 's2']
+            },
+            {
+                tenantId: 't2',
+                zip: '20176',
+                subscriberCount: 1,
+                subscriptionIds: ['s4']
+            }
+        ]);
+    });
+
+    it('aligns next poll time to the next 30-minute boundary by default', () => {
+        const now = Date.UTC(2026, 1, 23, 2, 40, 55);
+        const next = getNextPollTimeMs(now);
+        expect(next).toBe(Date.UTC(2026, 1, 23, 3, 0, 0));
+        expect(DEFAULT_POLL_INTERVAL_MINUTES).toBe(30);
+    });
+
+    it('detects changed status or newer updates', () => {
+        const previous = { status: 'open', updatedAt: 1000 };
+        expect(hasRainoutStatusChanged(previous, { status: 'closed', updatedAt: 1000 })).toBe(true);
+        expect(hasRainoutStatusChanged(previous, { status: 'open', updatedAt: 1500 })).toBe(true);
+        expect(hasRainoutStatusChanged(previous, { status: 'open', updatedAt: 900 })).toBe(false);
+        expect(hasRainoutStatusChanged(null, { status: 'open', updatedAt: 1 })).toBe(true);
+    });
+
+    it('matches event subscribers by tenant and zip with optional facility filter', () => {
+        const event = { tenantId: 't1', zip: '20176', facilityId: 'f1' };
+        const subscriptions = [
+            { id: 'a', tenantId: 't1', zip: '20176' },
+            { id: 'b', tenantId: 't1', zip: '20176', facilityId: 'f1' },
+            { id: 'c', tenantId: 't1', zip: '20176', facilityId: 'f2' },
+            { id: 'd', tenantId: 't2', zip: '20176' }
+        ];
+
+        expect(matchEventToSubscribers(event, subscriptions).map((item) => item.id)).toEqual(['a', 'b']);
+    });
+});


### PR DESCRIPTION
## Summary
- add `js/rainout-polling.js` helper module for ZIP normalization, unique ZIP polling plans, 30-minute schedule alignment, change detection, and tenant-scoped matching
- add unit tests in `tests/unit/rainout-polling.test.js`
- add product/engineering docs for requirements, design, tasks in `spec/rainout-polling-zip/`

## Why
- align implementation with polling-by-unique-ZIP approach
- define where users see updates (chat + in-app status surfaces)
- reduce blast radius with tenant-scoped matching and idempotency requirements

## Test
- `./node_modules/.bin/vitest run tests/unit/rainout-polling.test.js tests/unit/league-standings.test.js tests/unit/live-tracker-notes.test.js tests/unit/drills-issue28-helpers.test.js`
- result: 4 files passed, 19 tests passed
