### PR TITLE
feat(game-day): Game Day Command Center

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -1321,6 +1321,7 @@
                         ${isCompleted ? `<a href="game.html#teamId=${currentTeamId}&gameId=${game.id}" class="px-3 py-1 bg-green-100 text-green-700 rounded text-sm hover:bg-green-200">Report</a>` : ''}
                         ${game.liveStatus === 'completed' ? `<a href="live-game.html?teamId=${currentTeamId}&gameId=${game.id}&replay=true" class="px-3 py-1 bg-teal-100 text-teal-700 rounded text-sm hover:bg-teal-200">Watch Replay</a>` : ''}
                         <a href="game-plan.html#teamId=${currentTeamId}&gameId=${game.id}" class="px-3 py-1 bg-primary-100 text-primary-700 rounded text-sm hover:bg-primary-200">Game Plan</a>
+                        ${game.status !== 'cancelled' ? `<a href="game-day.html?teamId=${currentTeamId}&gameId=${game.id}" class="px-3 py-1 bg-orange-100 text-orange-700 rounded text-sm hover:bg-orange-200">Command Center</a>` : ''}
                         <button data-game-id="${game.id}" class="view-rsvps-btn px-3 py-1 bg-green-100 text-green-700 rounded text-sm hover:bg-green-200">RSVPs</button>
                         ${game.status !== 'cancelled' ? `<button data-game-id="${game.id}" class="cancel-game-btn px-3 py-1 border border-orange-300 text-orange-600 rounded text-sm hover:bg-orange-50">Cancel</button>` : '<span class="px-3 py-1 bg-red-100 text-red-700 rounded text-sm font-semibold">Cancelled</span>'}
                         <button data-id="${game.id}" class="px-3 py-1 border border-red-300 text-red-600 rounded text-sm hover:bg-red-50 delete-btn">Delete</button>

--- a/game-day.html
+++ b/game-day.html
@@ -1,0 +1,1912 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Game Day Command Center — ALL PLAYS</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        primary: {
+                            50: '#eef2ff', 100: '#e0e7ff', 200: '#c7d2fe',
+                            300: '#a5b4fc', 400: '#818cf8', 500: '#6366f1',
+                            600: '#4f46e5', 700: '#4338ca', 800: '#3730a3', 900: '#312e81'
+                        }
+                    }
+                }
+            }
+        };
+    </script>
+    <style>
+        .player-chip {
+            cursor: grab;
+            user-select: none;
+        }
+        .player-chip:active { cursor: grabbing; }
+        .rotation-cell {
+            min-height: 36px;
+            transition: background 0.15s;
+        }
+        .rotation-cell.drag-over { background: #e0e7ff; }
+        .pulse-dot {
+            width: 10px; height: 10px;
+            background: #ef4444;
+            border-radius: 50%;
+            animation: pulse 1.5s infinite;
+        }
+        @keyframes pulse {
+            0%, 100% { opacity: 1; transform: scale(1); }
+            50% { opacity: 0.5; transform: scale(1.3); }
+        }
+        .ai-bubble-user { background: #4f46e5; color: white; border-radius: 18px 18px 4px 18px; }
+        .ai-bubble-ai { background: #f3f4f6; color: #111827; border-radius: 18px 18px 18px 4px; }
+        .stat-btn { min-width: 52px; min-height: 44px; font-size: 0.875rem; font-weight: 600; }
+        /* Player color system */
+        .color-swatch { width: 10px; height: 10px; border-radius: 50%; flex-shrink: 0; border: 1px solid rgba(0,0,0,0.15); }
+        /* Field diagram */
+        .field-diagram { position: relative; background: #3a7d44; border-radius: 8px; overflow: hidden; }
+        .field-diagram::before { /* center line */
+            content: ''; position: absolute; left: 8%; right: 8%; top: 50%; height: 1px; background: rgba(255,255,255,0.3);
+        }
+        .field-diagram::after { /* center circle */
+            content: ''; position: absolute; left: 50%; top: 50%; width: 50px; height: 50px;
+            margin-left: -25px; margin-top: -25px; border: 1px solid rgba(255,255,255,0.3); border-radius: 50%;
+        }
+        .field-line { position: absolute; background: rgba(255,255,255,0.3); }
+        .field-player { position: absolute; transform: translate(-50%, -50%);
+            border-radius: 6px; padding: 3px 6px; font-size: 11px; font-weight: 700;
+            white-space: nowrap; cursor: default; border: 1px solid rgba(0,0,0,0.2);
+            box-shadow: 0 1px 3px rgba(0,0,0,0.3); max-width: 72px; text-align: center;
+            line-height: 1.2; transition: transform 0.2s; }
+        .field-player:hover { transform: translate(-50%, -50%) scale(1.08); z-index: 10; }
+        .field-pos-label { font-size: 9px; opacity: 0.7; display: block; }
+        .basketball-court { background: #c68642; }
+        .basketball-court::before { background: rgba(255,255,255,0.2); }
+        .basketball-court::after { border-color: rgba(255,255,255,0.2); }
+    </style>
+</head>
+<body class="bg-gray-50 min-h-screen">
+
+    <div id="header-container"></div>
+
+    <div class="max-w-7xl mx-auto px-4 pt-4 pb-2">
+        <div id="banner-container"></div>
+    </div>
+
+    <!-- Game Sub-Banner -->
+    <div id="game-subbanner" class="bg-white border-b border-gray-200 shadow-sm sticky top-0 z-30 hidden">
+        <div class="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between gap-4">
+            <div id="subbanner-game-info" class="flex items-center gap-3 min-w-0">
+                <div class="text-sm font-semibold text-gray-900 truncate" id="subbanner-title">Loading...</div>
+                <div class="text-xs text-gray-500" id="subbanner-date"></div>
+            </div>
+            <div class="flex items-center gap-2 flex-shrink-0">
+                <!-- Mode switcher pill -->
+                <div class="flex bg-gray-100 rounded-full p-1 gap-1" id="mode-switcher">
+                    <button id="mode-btn-pregame" onclick="setMode('pregame')"
+                        class="px-3 py-1 rounded-full text-xs font-semibold transition">Pre-Game</button>
+                    <button id="mode-btn-gameday" onclick="setMode('gameday')"
+                        class="px-3 py-1 rounded-full text-xs font-semibold transition">Game Day</button>
+                    <button id="mode-btn-wrapup" onclick="setMode('wrapup')"
+                        class="px-3 py-1 rounded-full text-xs font-semibold transition">Wrap-Up</button>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- PRE-GAME VIEW                                                -->
+    <!-- ============================================================ -->
+    <div id="pre-game-view" class="hidden max-w-7xl mx-auto px-4 py-6">
+        <div class="flex gap-6" style="align-items:flex-start">
+
+            <!-- LEFT RAIL (~280px) -->
+            <div class="flex-shrink-0 flex flex-col gap-4" style="width:280px">
+
+                <!-- Game info card -->
+                <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
+                    <div class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">Game Info</div>
+                    <div id="game-info-card" class="text-sm text-gray-700 space-y-1">
+                        <div class="text-lg font-bold text-gray-900" id="gi-opponent">Loading…</div>
+                        <div id="gi-date" class="text-gray-500"></div>
+                        <div id="gi-location" class="text-gray-500 text-xs"></div>
+                        <div id="gi-badges" class="flex flex-wrap gap-1 mt-1"></div>
+                    </div>
+                    <a id="gi-edit-link" href="#" class="mt-3 inline-block text-xs text-primary-600 hover:underline">Edit game details →</a>
+                </div>
+
+                <!-- From Last Game -->
+                <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
+                    <div class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">From Last Game</div>
+                    <div id="last-game-section" class="text-sm text-gray-500 italic">Loading…</div>
+                </div>
+
+                <!-- RSVP Panel -->
+                <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
+                    <div class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">RSVPs</div>
+                    <div id="rsvp-panel" class="text-sm text-gray-500">Loading…</div>
+                </div>
+
+                <!-- Scouting Notes -->
+                <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
+                    <div class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">Scouting Notes</div>
+                    <textarea id="scouting-notes" rows="4"
+                        class="w-full text-sm border border-gray-200 rounded-lg p-2 resize-none focus:outline-none focus:ring-2 focus:ring-primary-300"
+                        placeholder="Opponent tendencies, key players, set pieces…"></textarea>
+                    <div id="scouting-save-status" class="text-xs text-gray-400 mt-1 text-right"></div>
+                </div>
+
+                <!-- AI Coach Focus -->
+                <div class="bg-gradient-to-br from-primary-50 to-indigo-50 rounded-xl border border-primary-200 p-4">
+                    <div class="flex items-center justify-between mb-2">
+                        <div class="text-xs font-semibold text-primary-700 uppercase tracking-wider">AI Coach Focus</div>
+                        <button id="refresh-focus-btn" onclick="generateCoachFocus()"
+                            class="text-xs text-primary-600 hover:text-primary-800 font-semibold">↺ Refresh</button>
+                    </div>
+                    <div id="ai-focus-text" class="text-sm text-primary-900 italic">Generating…</div>
+                </div>
+
+            </div>
+
+            <!-- CENTER PANEL (AI Chat) -->
+            <div class="flex-1 flex flex-col gap-4 min-w-0">
+
+                <!-- Chat mode toggle -->
+                <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4 flex flex-col" style="min-height:480px">
+                    <div class="flex items-center gap-2 mb-3">
+                        <div class="flex bg-gray-100 rounded-full p-1 gap-1">
+                            <button id="chat-mode-ask" onclick="setChatMode('ask')"
+                                class="px-4 py-1.5 rounded-full text-sm font-semibold transition bg-white text-primary-700 shadow-sm">Ask</button>
+                            <button id="chat-mode-lineup" onclick="setChatMode('lineup')"
+                                class="px-4 py-1.5 rounded-full text-sm font-semibold transition text-gray-500">Lineup</button>
+                        </div>
+                        <div class="text-xs text-gray-400 ml-2" id="chat-mode-hint">Ask anything about your game</div>
+                    </div>
+
+                    <!-- Starter chips -->
+                    <div id="chat-starter-chips" class="flex flex-wrap gap-2 mb-3"></div>
+
+                    <!-- Chat bubble list -->
+                    <div id="chat-bubble-list" class="flex-1 overflow-y-auto flex flex-col gap-3 mb-3" style="max-height:320px">
+                        <div class="text-xs text-center text-gray-400 py-4">Start a conversation with your AI coach</div>
+                    </div>
+
+                    <!-- Input area -->
+                    <div class="flex gap-2">
+                        <input type="text" id="chat-input"
+                            class="flex-1 border border-gray-200 rounded-full px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-300"
+                            placeholder="Message your AI coach…"
+                            onkeydown="if(event.key==='Enter')sendChatMessage()">
+                        <button onclick="sendChatMessage()"
+                            class="px-4 py-2 bg-primary-600 text-white rounded-full text-sm font-semibold hover:bg-primary-700">Send</button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- RIGHT PANEL (Rotation Canvas ~360px) -->
+            <div class="flex-shrink-0 flex flex-col gap-4" style="width:360px">
+
+                <!-- Formation picker -->
+                <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
+                    <div class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">Formation</div>
+                    <select id="formation-picker" onchange="onFormationChange(this.value)"
+                        class="w-full border border-gray-200 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary-300">
+                        <option value="">— Select formation —</option>
+                        <option value="soccer-9v9">Soccer 9v9</option>
+                        <option value="basketball-5v5">Basketball 5v5</option>
+                    </select>
+                </div>
+
+                <!-- Period tabs + rotation canvas -->
+                <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
+                    <div class="flex items-center justify-between mb-3">
+                        <div class="flex bg-gray-100 rounded-full p-1 gap-1" id="period-tabs"></div>
+                        <div class="flex gap-2">
+                            <button onclick="balancePlayingTime()"
+                                class="text-xs text-gray-500 hover:text-primary-600 font-semibold px-2 py-1 rounded border border-gray-200 hover:border-primary-300">Balance</button>
+                            <button onclick="aiOptimizeLineup()"
+                                class="text-xs text-primary-600 hover:text-primary-800 font-semibold px-2 py-1 rounded border border-primary-200 hover:bg-primary-50">AI Optimize</button>
+                        </div>
+                    </div>
+
+                    <!-- Canvas: positions as rows -->
+                    <div id="rotation-canvas" class="space-y-1 mb-4">
+                        <div class="text-xs text-gray-400 text-center py-4">Select a formation to build your lineup</div>
+                    </div>
+
+                    <!-- Playing time bars -->
+                    <div id="playing-time-bars" class="hidden">
+                        <div class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">Playing Time Balance</div>
+                        <div id="pt-bars-list" class="space-y-1.5"></div>
+                    </div>
+
+                    <!-- Save lineup button -->
+                    <button onclick="saveGamePlan()"
+                        class="w-full mt-3 py-2 bg-primary-600 text-white rounded-lg text-sm font-semibold hover:bg-primary-700">
+                        Save Lineup
+                    </button>
+                </div>
+
+                <!-- Bench Pool -->
+                <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
+                    <div class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-2">Player Pool</div>
+                    <div id="bench-pool" class="flex flex-wrap gap-2">
+                        <div class="text-xs text-gray-400">Select a formation to see available players</div>
+                    </div>
+                </div>
+
+            </div>
+        </div>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- GAME DAY VIEW                                                -->
+    <!-- ============================================================ -->
+    <div id="game-day-view" class="hidden">
+
+        <!-- Dark top bar -->
+        <div class="bg-gray-900 text-white px-4 py-3 flex items-center justify-between gap-4">
+            <div class="flex items-center gap-3">
+                <div class="pulse-dot" id="live-pulse"></div>
+                <div class="flex items-center gap-2 text-2xl font-bold">
+                    <span id="gd-home-score">0</span>
+                    <span class="text-gray-400">:</span>
+                    <span id="gd-away-score">0</span>
+                </div>
+                <span id="gd-period-chip" class="px-2 py-0.5 bg-gray-700 rounded text-xs font-semibold">H1</span>
+            </div>
+            <div class="flex-1 text-center">
+                <div class="text-sm font-semibold" id="gd-matchup">Team vs Opponent</div>
+            </div>
+            <div class="flex bg-gray-800 rounded-full p-1 gap-1">
+                <button id="gd-coach-btn" onclick="setGameViewTab('coach')"
+                    class="px-3 py-1 rounded-full text-xs font-semibold transition bg-white text-gray-900">Coach</button>
+                <button id="gd-stats-btn" onclick="setGameViewTab('stats')"
+                    class="px-3 py-1 rounded-full text-xs font-semibold transition text-gray-400">Stats</button>
+            </div>
+        </div>
+
+        <div class="max-w-7xl mx-auto px-4 py-6">
+            <div class="flex gap-6" style="align-items:flex-start">
+
+                <!-- COACH VIEW -->
+                <div id="gd-coach-view" class="flex-1 flex flex-col gap-4">
+
+                    <!-- On Field -->
+                    <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
+                        <div class="flex items-center justify-between mb-3">
+                            <div class="text-xs font-semibold text-gray-400 uppercase tracking-wider">On Field</div>
+                            <div class="flex gap-2">
+                                <button onclick="setActivePeriod('H1')" id="gd-h1-btn"
+                                    class="px-2 py-0.5 rounded text-xs font-semibold bg-primary-100 text-primary-700">H1</button>
+                                <button onclick="setActivePeriod('H2')" id="gd-h2-btn"
+                                    class="px-2 py-0.5 rounded text-xs font-semibold text-gray-500 hover:bg-gray-100">H2</button>
+                            </div>
+                        </div>
+                        <div id="field-diagram-container">
+                            <div class="text-xs text-gray-400">No players assigned for this period</div>
+                        </div>
+                    </div>
+
+                    <!-- Substitution -->
+                    <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
+                        <div class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Make Substitution</div>
+                        <div class="flex gap-2 mb-2">
+                            <div class="flex-1">
+                                <label class="text-xs text-gray-500 block mb-1">OUT</label>
+                                <select id="sub-out-select" class="w-full border border-gray-200 rounded-lg px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-300">
+                                    <option value="">— Select player —</option>
+                                </select>
+                            </div>
+                            <div class="flex-1">
+                                <label class="text-xs text-gray-500 block mb-1">IN</label>
+                                <select id="sub-in-select" class="w-full border border-gray-200 rounded-lg px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-300">
+                                    <option value="">— Select player —</option>
+                                </select>
+                            </div>
+                        </div>
+                        <button onclick="applySub()"
+                            class="w-full py-2 bg-orange-500 text-white rounded-lg text-sm font-semibold hover:bg-orange-600">Apply Sub</button>
+                    </div>
+
+                    <!-- Score update -->
+                    <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
+                        <div class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Update Score</div>
+                        <div class="flex gap-3 items-end">
+                            <div class="flex-1 text-center">
+                                <label class="text-xs text-gray-500 block mb-1">Our Score</label>
+                                <div class="flex items-center gap-2 justify-center">
+                                    <button onclick="adjustScore('home',-1)" class="w-8 h-8 rounded-full bg-gray-100 text-gray-700 font-bold hover:bg-gray-200">−</button>
+                                    <span id="score-home-display" class="text-2xl font-bold text-gray-900 w-8 text-center">0</span>
+                                    <button onclick="adjustScore('home',1)" class="w-8 h-8 rounded-full bg-primary-100 text-primary-700 font-bold hover:bg-primary-200">+</button>
+                                </div>
+                            </div>
+                            <div class="text-gray-400 font-bold pb-2">:</div>
+                            <div class="flex-1 text-center">
+                                <label class="text-xs text-gray-500 block mb-1">Their Score</label>
+                                <div class="flex items-center gap-2 justify-center">
+                                    <button onclick="adjustScore('away',-1)" class="w-8 h-8 rounded-full bg-gray-100 text-gray-700 font-bold hover:bg-gray-200">−</button>
+                                    <span id="score-away-display" class="text-2xl font-bold text-gray-900 w-8 text-center">0</span>
+                                    <button onclick="adjustScore('away',1)" class="w-8 h-8 rounded-full bg-red-100 text-red-600 font-bold hover:bg-red-200">+</button>
+                                </div>
+                            </div>
+                        </div>
+                        <button onclick="saveScore()"
+                            class="w-full mt-3 py-1.5 border border-gray-200 rounded-lg text-sm text-gray-600 hover:bg-gray-50">Save Score</button>
+                    </div>
+
+                    <!-- Coaching Log -->
+                    <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
+                        <div class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Coaching Log</div>
+                        <div class="flex flex-wrap gap-2 mb-3">
+                            <button onclick="logCoachEvent('Timeout','Timeout')" class="px-3 py-1.5 bg-amber-100 text-amber-700 rounded-lg text-xs font-semibold hover:bg-amber-200">Timeout</button>
+                            <button onclick="logCoachEvent('Formation Change','Formation Change')" class="px-3 py-1.5 bg-blue-100 text-blue-700 rounded-lg text-xs font-semibold hover:bg-blue-200">Formation Change</button>
+                            <button onclick="logCoachEvent('Injury','Injury')" class="px-3 py-1.5 bg-red-100 text-red-700 rounded-lg text-xs font-semibold hover:bg-red-200">Injury</button>
+                        </div>
+                        <div class="flex gap-2 mb-3">
+                            <input type="text" id="coaching-note-input"
+                                class="flex-1 border border-gray-200 rounded-lg px-3 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-primary-300"
+                                placeholder="Free text note…"
+                                onkeydown="if(event.key==='Enter')logCoachEvent()">
+                            <button onclick="logCoachEvent()"
+                                class="px-3 py-1.5 bg-gray-700 text-white rounded-lg text-xs font-semibold hover:bg-gray-800">Log</button>
+                        </div>
+                        <div id="coaching-log-list" class="space-y-1.5 max-h-40 overflow-y-auto">
+                            <div class="text-xs text-gray-400">No notes yet</div>
+                        </div>
+                    </div>
+
+                </div>
+
+                <!-- STATS VIEW -->
+                <div id="gd-stats-view" class="flex-1 hidden flex-col gap-4">
+
+                    <!-- Live event log -->
+                    <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
+                        <div class="flex items-center justify-between mb-2">
+                            <div class="text-xs font-semibold text-gray-400 uppercase tracking-wider">Recent Events</div>
+                            <button onclick="undoLastStat()"
+                                class="text-xs text-red-500 hover:text-red-700 font-semibold border border-red-200 rounded px-2 py-0.5 hover:bg-red-50">Undo Last</button>
+                        </div>
+                        <div id="live-event-log" class="space-y-1 max-h-28 overflow-y-auto text-xs text-gray-600">
+                            <div class="text-gray-400 italic">No events yet</div>
+                        </div>
+                    </div>
+
+                    <!-- Player stat table -->
+                    <div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+                        <div class="text-xs font-semibold text-gray-400 uppercase tracking-wider px-4 pt-4 pb-2">Tap to Record Stats</div>
+                        <div id="stats-player-table" class="divide-y divide-gray-100">
+                            <div class="px-4 py-3 text-sm text-gray-400 italic">Loading players…</div>
+                        </div>
+                    </div>
+
+                </div>
+
+            </div>
+        </div>
+    </div>
+
+    <!-- ============================================================ -->
+    <!-- WRAP-UP PANEL (modal overlay)                               -->
+    <!-- ============================================================ -->
+    <div id="wrapup-panel" class="hidden fixed inset-0 bg-black bg-opacity-50 z-50 flex items-center justify-center p-4">
+        <div class="bg-white rounded-2xl shadow-xl w-full max-w-2xl max-h-screen overflow-y-auto">
+            <div class="p-6">
+                <div class="flex items-center justify-between mb-6">
+                    <div>
+                        <div class="text-xl font-bold text-gray-900">Post-Game Wrap-Up</div>
+                        <div class="text-sm text-gray-500">Complete the match report</div>
+                    </div>
+                    <button onclick="closeWrapup()" class="text-gray-400 hover:text-gray-600 text-2xl leading-none">×</button>
+                </div>
+
+                <!-- Final Score -->
+                <div class="mb-6">
+                    <div class="text-sm font-semibold text-gray-700 mb-3">Final Score</div>
+                    <div class="flex gap-4 items-center">
+                        <div class="flex-1">
+                            <label class="text-xs text-gray-500 block mb-1">Our Team</label>
+                            <input type="number" id="wrapup-home-score" min="0"
+                                class="w-full border border-gray-200 rounded-lg px-3 py-2 text-lg font-bold text-center focus:outline-none focus:ring-2 focus:ring-primary-300">
+                        </div>
+                        <div class="text-2xl font-bold text-gray-400">:</div>
+                        <div class="flex-1">
+                            <label class="text-xs text-gray-500 block mb-1">Opponent</label>
+                            <input type="number" id="wrapup-away-score" min="0"
+                                class="w-full border border-gray-200 rounded-lg px-3 py-2 text-lg font-bold text-center focus:outline-none focus:ring-2 focus:ring-primary-300">
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Post-game notes -->
+                <div class="mb-6">
+                    <div class="text-sm font-semibold text-gray-700 mb-2">Post-Game Notes</div>
+                    <textarea id="post-game-notes" rows="4"
+                        class="w-full border border-gray-200 rounded-lg p-3 text-sm focus:outline-none focus:ring-2 focus:ring-primary-300 resize-none"
+                        placeholder="What went well? What to improve? Key moments…"></textarea>
+                </div>
+
+                <!-- AI Actions -->
+                <div class="flex flex-col gap-3 mb-6">
+                    <button onclick="analyzeGame()"
+                        class="w-full py-3 bg-indigo-600 text-white rounded-xl font-semibold hover:bg-indigo-700 flex items-center justify-center gap-2">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.347.347a3.75 3.75 0 01-5.303-5.303 3.75 3.75 0 015.303 0l.347.347a5 5 0 01-7.072 7.072z"/>
+                        </svg>
+                        Analyze Game → Generate Practice Feed
+                    </button>
+                    <button onclick="generateSummary()"
+                        class="w-full py-3 bg-white border border-primary-300 text-primary-700 rounded-xl font-semibold hover:bg-primary-50 flex items-center justify-center gap-2">
+                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"/>
+                        </svg>
+                        Generate Game Summary
+                    </button>
+                </div>
+
+                <!-- AI status -->
+                <div id="wrapup-ai-status" class="hidden mb-4 p-3 bg-indigo-50 rounded-lg text-sm text-indigo-700"></div>
+
+                <!-- Done button -->
+                <button id="wrapup-done-btn" onclick="finishGame()"
+                    class="w-full py-3 bg-green-600 text-white rounded-xl font-bold hover:bg-green-700">
+                    Done — See Match Report →
+                </button>
+            </div>
+        </div>
+    </div>
+
+    <!-- Loading overlay -->
+    <div id="loading-overlay" class="fixed inset-0 bg-white bg-opacity-80 flex items-center justify-center z-40">
+        <div class="text-center">
+            <div class="w-8 h-8 border-4 border-primary-500 border-t-transparent rounded-full animate-spin mx-auto mb-3"></div>
+            <div class="text-sm text-gray-500">Loading Game Day…</div>
+        </div>
+    </div>
+
+    <div id="footer-container" class="mt-16"></div>
+
+    <script type="module">
+        import { getApp } from './js/vendor/firebase-app.js';
+        import { getAI, getGenerativeModel, GoogleAIBackend } from './js/vendor/firebase-ai.js';
+        import {
+            getTeam, getGame, subscribeGame, getPlayers,
+            getRsvpBreakdownByPlayer, getGames, getAggregatedStatsForGames,
+            getConfigs, updateGame, logStatEvent, updatePlayerStats,
+            broadcastLiveEvent, subscribeLiveEvents, subscribeAggregatedStats,
+            setGameLiveStatus
+        } from './js/db.js?v=14';
+        import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime } from './js/utils.js?v=8';
+        import { checkAuth } from './js/auth.js?v=9';
+        import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js?v=3';
+
+        renderFooter(document.getElementById('footer-container'));
+
+        // ==================== FORMATIONS ====================
+        const FORMATIONS = {
+            'soccer-9v9': {
+                name: 'Soccer 9v9',
+                numPeriods: 2,
+                positions: [
+                    { id: 'keeper', name: 'Keeper' },
+                    { id: 'right-defense', name: 'Right Defense' },
+                    { id: 'sweeper', name: 'Sweeper' },
+                    { id: 'left-defense', name: 'Left Defense' },
+                    { id: 'left-mid', name: 'Left Mid' },
+                    { id: 'center-mid-1', name: 'Center Mid' },
+                    { id: 'center-mid-2', name: 'Center Mid' },
+                    { id: 'right-mid', name: 'Right Mid' },
+                    { id: 'striker', name: 'Striker' }
+                ]
+            },
+            'basketball-5v5': {
+                name: 'Basketball 5v5',
+                numPeriods: 4,
+                positions: [
+                    { id: 'pg', name: 'Point Guard' },
+                    { id: 'sg', name: 'Shooting Guard' },
+                    { id: 'sf', name: 'Small Forward' },
+                    { id: 'pf', name: 'Power Forward' },
+                    { id: 'c', name: 'Center' }
+                ]
+            }
+        };
+
+        // ==================== PLAYER COLORS ====================
+        // 8 color options coaches can assign per player to group by play style
+        const PLAYER_COLORS = [
+            { bg: '#dbeafe', text: '#1e40af', border: '#93c5fd', name: 'Blue' },
+            { bg: '#dcfce7', text: '#166534', border: '#86efac', name: 'Green' },
+            { bg: '#fef9c3', text: '#854d0e', border: '#fde047', name: 'Yellow' },
+            { bg: '#fce7f3', text: '#9d174d', border: '#f9a8d4', name: 'Pink' },
+            { bg: '#ede9fe', text: '#4c1d95', border: '#c4b5fd', name: 'Purple' },
+            { bg: '#ffedd5', text: '#9a3412', border: '#fdba74', name: 'Orange' },
+            { bg: '#ccfbf1', text: '#115e59', border: '#5eead4', name: 'Teal' },
+            { bg: '#f1f5f9', text: '#334155', border: '#cbd5e1', name: 'Gray' },
+        ];
+
+        // Spatial positions on the field diagram (left%, top% from top-left)
+        // Soccer: portrait orientation, our goal at bottom; Basketball: half-court
+        const FIELD_POSITIONS = {
+            'soccer-9v9': {
+                'keeper':        { left: 50, top: 84 },
+                'right-defense': { left: 79, top: 67 },
+                'sweeper':       { left: 50, top: 67 },
+                'left-defense':  { left: 21, top: 67 },
+                'right-mid':     { left: 83, top: 46 },
+                'center-mid-1':  { left: 37, top: 46 },
+                'center-mid-2':  { left: 63, top: 46 },
+                'left-mid':      { left: 17, top: 46 },
+                'striker':       { left: 50, top: 20 },
+            },
+            'basketball-5v5': {
+                'pg': { left: 50, top: 20 },
+                'sg': { left: 22, top: 42 },
+                'sf': { left: 78, top: 42 },
+                'pf': { left: 28, top: 67 },
+                'c':  { left: 72, top: 67 },
+            }
+        };
+
+        // ==================== STATE ====================
+        const state = {
+            teamId: null, gameId: null,
+            team: null, game: null, players: [], user: null,
+            mode: 'pregame',
+            rsvpBreakdown: null,
+            configs: [], statConfig: null,
+            recentGames: [],
+            playerColors: {}, // { playerId: colorIndex (0-7) }
+            // AI chat
+            chatHistory: [], chatMode: 'ask',
+            // Rotation
+            formationId: null,
+            activePeriod: 'H1',
+            rotationPlan: {},  // { H1: { positionId: playerId }, H2: {...} }
+            gamePlan: null,
+            // Game day
+            gameViewTab: 'coach',
+            score: { home: 0, away: 0 },
+            activePeriodGD: 'H1',
+            rotationActual: {},
+            coachingNotes: [],
+            aggregatedStats: [],
+            liveEvents: [],
+            lastStatEvent: null,
+            // AI model
+            aiModel: null,
+            aiChatSession: null,
+            // Unsubs
+            unsubscribers: []
+        };
+
+        // ==================== PLAYER COLOR UTILITIES ====================
+        function loadPlayerColors() {
+            try {
+                const saved = localStorage.getItem(`playerColors-${state.teamId}`);
+                if (saved) state.playerColors = JSON.parse(saved);
+            } catch (e) {}
+        }
+
+        function savePlayerColors() {
+            try {
+                localStorage.setItem(`playerColors-${state.teamId}`, JSON.stringify(state.playerColors));
+            } catch (e) {}
+        }
+
+        function getPlayerColor(playerId) {
+            const idx = state.playerColors[playerId];
+            return (idx !== undefined) ? PLAYER_COLORS[idx % PLAYER_COLORS.length] : null;
+        }
+
+        window.cyclePlayerColor = function(playerId, event) {
+            if (event) { event.preventDefault(); event.stopPropagation(); }
+            const current = state.playerColors[playerId];
+            state.playerColors[playerId] = (current === undefined) ? 0 : (current + 1) % PLAYER_COLORS.length;
+            savePlayerColors();
+            renderBenchPool();
+            renderRotationCanvas();
+            if (state.mode === 'gameday') renderFieldDiagram();
+        };
+
+        // ==================== AUTH ====================
+        checkAuth(async (user) => {
+            if (!user) {
+                window.location.href = 'login.html';
+                return;
+            }
+            state.user = user;
+            renderHeader(document.getElementById('header-container'), user);
+            await initPage();
+        });
+
+        async function initPage() {
+            const { teamId, gameId } = getUrlParams();
+            if (!teamId || !gameId) {
+                showError('Missing teamId or gameId in URL.');
+                return;
+            }
+            state.teamId = teamId;
+            state.gameId = gameId;
+
+            try {
+                const [team, game, players, configs] = await Promise.all([
+                    getTeam(teamId),
+                    getGame(teamId, gameId),
+                    getPlayers(teamId),
+                    getConfigs(teamId)
+                ]);
+
+                state.team = team;
+                state.game = game;
+                state.players = players;
+                state.configs = configs;
+                loadPlayerColors();
+
+                // Access check — full access only
+                const accessInfo = getTeamAccessInfo(state.user, { ...team, id: teamId });
+                if (!accessInfo.hasAccess || accessInfo.accessLevel !== 'full') {
+                    window.location.href = `team.html#teamId=${teamId}&message=Game+Day+is+for+coaches+only`;
+                    return;
+                }
+
+                // Render banner
+                renderTeamAdminBanner(document.getElementById('banner-container'), {
+                    team, teamId, active: 'gameday',
+                    accessLevel: accessInfo.accessLevel,
+                    exitUrl: accessInfo.exitUrl
+                });
+
+                // Resolve stat config
+                if (game.statTrackerConfigId && configs.length) {
+                    state.statConfig = configs.find(c => c.id === game.statTrackerConfigId) || null;
+                }
+
+                // Determine initial mode
+                const liveStatus = game.liveStatus || game.status;
+                if (liveStatus === 'live') {
+                    state.mode = 'gameday';
+                } else if (liveStatus === 'completed' || game.status === 'completed') {
+                    state.mode = 'wrapup';
+                } else {
+                    state.mode = 'pregame';
+                }
+
+                // Load game plan from saved data
+                if (game.gamePlan) {
+                    state.gamePlan = game.gamePlan;
+                    state.rotationPlan = buildRotationFromGamePlan(game.gamePlan);
+                    if (game.gamePlan.formationId) {
+                        state.formationId = game.gamePlan.formationId;
+                    }
+                }
+
+                state.score = {
+                    home: game.homeScore || 0,
+                    away: game.awayScore || 0
+                };
+
+                if (game.coachingNotes) state.coachingNotes = game.coachingNotes;
+                if (game.rotationActual) state.rotationActual = game.rotationActual;
+
+                // Render sub-banner
+                renderSubbanner();
+
+                // Load async data
+                loadRsvps();
+                loadLastGame();
+
+                // Set up real-time subscriptions
+                const unsubGame = subscribeGame(teamId, gameId, (updatedGame) => {
+                    const prevLiveStatus = state.game?.liveStatus;
+                    state.game = updatedGame;
+                    state.score = { home: updatedGame.homeScore || 0, away: updatedGame.awayScore || 0 };
+                    updateScoreDisplay();
+                    // Detect transitions
+                    if (updatedGame.liveStatus === 'live' && prevLiveStatus !== 'live' && state.mode !== 'gameday') {
+                        if (confirm('The game is now live! Switch to Game Day mode?')) setMode('gameday');
+                    } else if (updatedGame.liveStatus === 'completed' && prevLiveStatus !== 'completed' && state.mode !== 'wrapup') {
+                        if (confirm('Game marked as completed. Open Wrap-Up?')) setMode('wrapup');
+                    }
+                }, (err) => console.error('subscribeGame error', err));
+                state.unsubscribers.push(unsubGame);
+
+                if (state.mode === 'gameday' || state.mode === 'wrapup') {
+                    subscribeGameDayData();
+                }
+
+                // Render the right view
+                renderCurrentMode();
+                hideLoading();
+
+                // Auto-generate AI focus for pre-game
+                if (state.mode === 'pregame') {
+                    setTimeout(() => generateCoachFocus(), 800);
+                }
+
+            } catch (err) {
+                console.error('initPage error', err);
+                showError('Failed to load game data: ' + err.message);
+            }
+        }
+
+        function subscribeGameDayData() {
+            const { teamId, gameId } = state;
+            const unsubStats = subscribeAggregatedStats(teamId, gameId, (stats) => {
+                state.aggregatedStats = stats;
+                if (state.mode === 'gameday' && state.gameViewTab === 'stats') renderStatsView();
+            }, (err) => console.error('subscribeAggregatedStats error', err));
+            state.unsubscribers.push(unsubStats);
+
+            const unsubLive = subscribeLiveEvents(teamId, gameId, (events) => {
+                state.liveEvents = events;
+                if (state.mode === 'gameday') renderLiveEventLog();
+            }, (err) => console.error('subscribeLiveEvents error', err));
+            state.unsubscribers.push(unsubLive);
+        }
+
+        // ==================== SUBBANNER ====================
+        function renderSubbanner() {
+            const game = state.game;
+            document.getElementById('subbanner-title').textContent =
+                `vs. ${game?.opponent || 'Opponent'}`;
+            document.getElementById('subbanner-date').textContent =
+                game?.date ? formatDate(game.date) : '';
+            document.getElementById('game-subbanner').classList.remove('hidden');
+            updateModeSwitcherUI();
+        }
+
+        function updateModeSwitcherUI() {
+            const modes = ['pregame', 'gameday', 'wrapup'];
+            modes.forEach(m => {
+                const btn = document.getElementById(`mode-btn-${m}`);
+                if (!btn) return;
+                if (m === state.mode) {
+                    btn.className = 'px-3 py-1 rounded-full text-xs font-semibold transition bg-white text-primary-700 shadow-sm';
+                } else {
+                    btn.className = 'px-3 py-1 rounded-full text-xs font-semibold transition text-gray-500 hover:text-gray-700';
+                }
+            });
+        }
+
+        // ==================== MODE SWITCHING ====================
+        window.setMode = function(mode) {
+            state.mode = mode;
+            updateModeSwitcherUI();
+            renderCurrentMode();
+            if (mode === 'gameday' && state.unsubscribers.length <= 1) {
+                subscribeGameDayData();
+            }
+        };
+
+        function renderCurrentMode() {
+            document.getElementById('pre-game-view').classList.add('hidden');
+            document.getElementById('game-day-view').classList.add('hidden');
+            document.getElementById('wrapup-panel').classList.add('hidden');
+
+            if (state.mode === 'pregame') {
+                document.getElementById('pre-game-view').classList.remove('hidden');
+                renderPreGame();
+            } else if (state.mode === 'gameday') {
+                document.getElementById('game-day-view').classList.remove('hidden');
+                renderGameDay();
+            } else if (state.mode === 'wrapup') {
+                document.getElementById('pre-game-view').classList.remove('hidden');
+                renderPreGame();
+                document.getElementById('wrapup-panel').classList.remove('hidden');
+                renderWrapup();
+            }
+        }
+
+        // ==================== PRE-GAME ====================
+        function renderPreGame() {
+            renderGameInfoCard();
+            renderScoutingNotes();
+            renderFormationPicker();
+            renderChatStarters();
+            if (state.formationId) {
+                renderPeriodTabs();
+                renderRotationCanvas();
+                renderBenchPool();
+                renderPlayingTimeBars();
+            }
+        }
+
+        function renderGameInfoCard() {
+            const game = state.game;
+            if (!game) return;
+            document.getElementById('gi-opponent').textContent = `vs. ${game.opponent || 'TBD'}`;
+            document.getElementById('gi-date').textContent =
+                game.date ? `${formatDate(game.date)} at ${formatTime(game.date)}` : '';
+            document.getElementById('gi-location').textContent = game.location || '';
+
+            const badges = document.getElementById('gi-badges');
+            const badgeParts = [];
+            if (game.isHome === true) badgeParts.push('<span class="px-2 py-0.5 bg-blue-100 text-blue-700 rounded-full text-xs font-semibold">HOME</span>');
+            if (game.isHome === false) badgeParts.push('<span class="px-2 py-0.5 bg-gray-100 text-gray-700 rounded-full text-xs font-semibold">AWAY</span>');
+            if (game.kitColor) badgeParts.push(`<span class="px-2 py-0.5 bg-purple-100 text-purple-700 rounded-full text-xs font-semibold">${escapeHtml(game.kitColor)}</span>`);
+            badges.innerHTML = badgeParts.join('');
+
+            const { teamId, gameId } = state;
+            document.getElementById('gi-edit-link').href = `edit-schedule.html#teamId=${teamId}`;
+        }
+
+        async function loadRsvps() {
+            try {
+                const breakdown = await getRsvpBreakdownByPlayer(state.teamId, state.gameId);
+                state.rsvpBreakdown = breakdown;
+                renderRsvpPanel();
+            } catch (err) {
+                console.error('loadRsvps error', err);
+                document.getElementById('rsvp-panel').innerHTML = '<span class="text-xs text-red-400">Failed to load RSVPs</span>';
+            }
+        }
+
+        function renderRsvpPanel() {
+            const breakdown = state.rsvpBreakdown;
+            if (!breakdown) return;
+            const el = document.getElementById('rsvp-panel');
+
+            const chip = (p) => `<span class="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100 rounded-full text-xs font-medium">${p.playerNumber ? `#${p.playerNumber} ` : ''}${escapeHtml(p.playerName)}</span>`;
+
+            const section = (label, color, players) => {
+                if (!players.length) return '';
+                return `<div class="mb-2">
+                    <div class="text-xs font-semibold ${color} mb-1">${label} (${players.length})</div>
+                    <div class="flex flex-wrap gap-1">${players.map(chip).join('')}</div>
+                </div>`;
+            };
+
+            el.innerHTML =
+                section('Going', 'text-green-600', breakdown.going) +
+                section('Maybe', 'text-amber-600', breakdown.maybe) +
+                section('Not Going', 'text-red-500', breakdown.not_going) +
+                section('No Response', 'text-gray-400', breakdown.not_responded);
+        }
+
+        function renderScoutingNotes() {
+            const ta = document.getElementById('scouting-notes');
+            ta.value = state.game?.scoutingNotes || '';
+            ta.onblur = async () => {
+                const text = ta.value.trim();
+                const status = document.getElementById('scouting-save-status');
+                try {
+                    status.textContent = 'Saving…';
+                    await updateGame(state.teamId, state.gameId, { scoutingNotes: text });
+                    state.game = { ...state.game, scoutingNotes: text };
+                    status.textContent = 'Saved';
+                    setTimeout(() => { status.textContent = ''; }, 2000);
+                } catch (err) {
+                    status.textContent = 'Save failed';
+                }
+            };
+        }
+
+        async function loadLastGame() {
+            const el = document.getElementById('last-game-section');
+            try {
+                const games = await getGames(state.teamId);
+                const completed = games.filter(g =>
+                    g.id !== state.gameId &&
+                    (g.status === 'completed' || g.liveStatus === 'completed')
+                );
+                if (!completed.length) {
+                    el.innerHTML = '<span class="text-xs text-gray-400">No previous games</span>';
+                    return;
+                }
+                state.recentGames = completed.slice(0, 3);
+                const lastGame = completed[0];
+                const stats = await getAggregatedStatsForGames(state.teamId, [lastGame.id]);
+
+                let html = `<div class="text-xs font-semibold text-gray-700 mb-1">Last: vs ${escapeHtml(lastGame.opponent || 'Opponent')} (${formatDate(lastGame.date)})</div>`;
+                if (lastGame.homeScore !== undefined) {
+                    html += `<div class="text-xs text-gray-500 mb-2">Score: ${lastGame.homeScore}–${lastGame.awayScore}</div>`;
+                }
+
+                if (state.game?.practiceFeedItems?.length) {
+                    html += `<div class="text-xs font-semibold text-orange-600 mb-1">Areas to Address:</div>`;
+                    state.game.practiceFeedItems.slice(0, 3).forEach(item => {
+                        html += `<div class="flex items-center justify-between mb-1.5">
+                            <span class="text-xs text-gray-700">${escapeHtml(item.weakness)}</span>
+                            <a href="drills.html#teamId=${state.teamId}&weakness=${encodeURIComponent(item.weakness)}&drillCategory=${encodeURIComponent(item.drillCategory || '')}"
+                               class="text-xs text-primary-600 hover:underline font-semibold">Plan →</a>
+                        </div>`;
+                    });
+                } else {
+                    html += '<div class="text-xs text-gray-400">Run Wrap-Up analysis to build a practice feed.</div>';
+                }
+                el.innerHTML = html;
+            } catch (err) {
+                console.error('loadLastGame error', err);
+                el.innerHTML = '<span class="text-xs text-red-400">Could not load last game</span>';
+            }
+        }
+
+        // ==================== AI COACH FOCUS ====================
+        window.generateCoachFocus = async function() {
+            const el = document.getElementById('ai-focus-text');
+            el.textContent = 'Generating…';
+            try {
+                const model = getAIModel();
+                const goingList = state.rsvpBreakdown?.going?.map(p => p.playerName).join(', ') || 'Unknown';
+                const scoutingNotes = document.getElementById('scouting-notes')?.value || '';
+                const recentResults = state.recentGames.slice(0, 3).map(g =>
+                    `vs ${g.opponent}: ${g.homeScore ?? '?'}-${g.awayScore ?? '?'}`
+                ).join('; ');
+
+                const prompt = `You are a soccer coach assistant. Generate a 2-3 sentence pre-game focus directive.
+Team: ${escapeHtml(state.team?.name || 'Team')}, Sport: ${state.team?.sport || 'Soccer'}
+Going players: ${goingList}
+Scouting notes: ${scoutingNotes || 'None'}
+Last 3 game results: ${recentResults || 'None'}
+Respond with ONLY the directive text, no markdown.`;
+
+                const result = await model.generateContent(prompt);
+                el.textContent = result.response.text().trim();
+            } catch (err) {
+                console.error('generateCoachFocus error', err);
+                el.textContent = 'Could not generate focus. Check your connection.';
+            }
+        };
+
+        // ==================== AI CHAT ====================
+        window.setChatMode = function(mode) {
+            state.chatMode = mode;
+            document.getElementById('chat-mode-ask').className =
+                mode === 'ask'
+                    ? 'px-4 py-1.5 rounded-full text-sm font-semibold transition bg-white text-primary-700 shadow-sm'
+                    : 'px-4 py-1.5 rounded-full text-sm font-semibold transition text-gray-500';
+            document.getElementById('chat-mode-lineup').className =
+                mode === 'lineup'
+                    ? 'px-4 py-1.5 rounded-full text-sm font-semibold transition bg-white text-primary-700 shadow-sm'
+                    : 'px-4 py-1.5 rounded-full text-sm font-semibold transition text-gray-500';
+            const hint = document.getElementById('chat-mode-hint');
+            hint.textContent = mode === 'ask' ? 'Ask anything about your game' : 'Get AI lineup suggestions';
+            renderChatStarters();
+        };
+
+        function renderChatStarters() {
+            const chips = document.getElementById('chat-starter-chips');
+            const starters = state.chatMode === 'ask' ? [
+                'What's our team strength today?',
+                'How should we start the game?',
+                'Who should play keeper?'
+            ] : [
+                'Generate H1 lineup for going players',
+                'Balance playing time evenly',
+                'Suggest an optimal formation'
+            ];
+            chips.innerHTML = starters.map(s =>
+                `<button onclick="sendChatMessage('${escapeHtml(s).replace(/'/g, "\\'")}')"
+                    class="px-3 py-1.5 bg-gray-100 text-gray-700 rounded-full text-xs font-semibold hover:bg-primary-100 hover:text-primary-700 transition">${escapeHtml(s)}</button>`
+            ).join('');
+        }
+
+        window.sendChatMessage = async function(text) {
+            const input = document.getElementById('chat-input');
+            const msg = text || input.value.trim();
+            if (!msg) return;
+            input.value = '';
+
+            appendChatBubble(msg, 'user');
+
+            try {
+                const model = getAIModel();
+                if (!state.aiChatSession) {
+                    const systemPrompt = buildChatSystemPrompt();
+                    state.aiChatSession = model.startChat({ systemInstruction: systemPrompt });
+                }
+
+                const thinkingEl = appendChatBubble('…', 'ai');
+                const response = await state.aiChatSession.sendMessage(msg);
+                const aiText = response.response.text().trim();
+                thinkingEl.textContent = '';
+
+                // Check if response is a lineup JSON
+                if (state.chatMode === 'lineup' && aiText.includes('"H1"')) {
+                    try {
+                        const jsonMatch = aiText.match(/\{[\s\S]*\}/);
+                        if (jsonMatch) {
+                            const parsed = JSON.parse(jsonMatch[0]);
+                            const aiMsg = document.createElement('div');
+                            aiMsg.className = 'ai-bubble-ai px-3 py-2 text-sm self-start max-w-xs';
+                            aiMsg.textContent = 'Here's a suggested lineup:';
+                            thinkingEl.appendChild(aiMsg);
+
+                            const acceptBtn = document.createElement('button');
+                            acceptBtn.className = 'mt-2 px-3 py-1.5 bg-primary-600 text-white rounded-lg text-xs font-semibold hover:bg-primary-700';
+                            acceptBtn.textContent = '✓ Accept to Canvas';
+                            acceptBtn.onclick = () => acceptLineupProposal(parsed);
+                            thinkingEl.appendChild(acceptBtn);
+                            return;
+                        }
+                    } catch (e) { /* not JSON, show as text */ }
+                }
+
+                thinkingEl.textContent = aiText;
+            } catch (err) {
+                console.error('sendChatMessage error', err);
+                appendChatBubble('Sorry, could not reach AI. Try again.', 'ai');
+            }
+        };
+
+        function appendChatBubble(text, role) {
+            const list = document.getElementById('chat-bubble-list');
+            if (list.querySelector('.text-center')) list.innerHTML = '';
+            const el = document.createElement('div');
+            el.className = role === 'user'
+                ? 'ai-bubble-user px-3 py-2 text-sm self-end max-w-xs ml-auto'
+                : 'ai-bubble-ai px-3 py-2 text-sm self-start max-w-xs';
+            el.textContent = text;
+            list.appendChild(el);
+            list.scrollTop = list.scrollHeight;
+            return el;
+        }
+
+        function buildChatSystemPrompt() {
+            const goingList = state.rsvpBreakdown?.going?.map(p => `${p.playerName}${p.playerNumber ? ' (#' + p.playerNumber + ')' : ''}`).join(', ') || 'Unknown';
+            const formation = state.formationId ? FORMATIONS[state.formationId] : null;
+            const positions = formation ? formation.positions.map(p => p.name).join(', ') : 'Not selected';
+            return `You are an expert soccer coach assistant for ${state.team?.name || 'this team'}.
+Game: vs ${state.game?.opponent || 'Opponent'} on ${state.game?.date ? formatDate(state.game.date) : 'today'}.
+Going players: ${goingList}.
+Formation: ${state.formationId || 'Not selected'} — Positions: ${positions}.
+When asked for a lineup, return ONLY valid JSON: { "H1": { "positionId": "PlayerName", ... }, "H2": { ... } }.
+Otherwise answer concisely in 2-4 sentences.`;
+        }
+
+        function acceptLineupProposal(proposal) {
+            // Map proposal player names to player IDs
+            const nameToId = {};
+            state.players.forEach(p => { nameToId[p.name] = p.id; });
+
+            const newPlan = { H1: {}, H2: {} };
+            ['H1', 'H2'].forEach(period => {
+                if (!proposal[period]) return;
+                Object.entries(proposal[period]).forEach(([posId, playerName]) => {
+                    const playerId = nameToId[playerName];
+                    if (playerId) newPlan[period][posId] = playerId;
+                });
+            });
+
+            state.rotationPlan = newPlan;
+            appendChatBubble('Lineup applied to canvas! Review and save.', 'ai');
+            renderRotationCanvas();
+            renderBenchPool();
+            renderPlayingTimeBars();
+        }
+
+        // ==================== ROTATION CANVAS ====================
+        function renderFormationPicker() {
+            const picker = document.getElementById('formation-picker');
+            picker.value = state.formationId || '';
+        }
+
+        window.onFormationChange = function(formationId) {
+            state.formationId = formationId || null;
+            if (formationId) {
+                const f = FORMATIONS[formationId];
+                // Init empty plan for each period
+                const periods = getPeriods(formationId);
+                state.rotationPlan = {};
+                periods.forEach(p => { state.rotationPlan[p] = {}; });
+                renderPeriodTabs();
+                renderRotationCanvas();
+                renderBenchPool();
+                renderPlayingTimeBars();
+            } else {
+                document.getElementById('rotation-canvas').innerHTML = '<div class="text-xs text-gray-400 text-center py-4">Select a formation to build your lineup</div>';
+                document.getElementById('bench-pool').innerHTML = '<div class="text-xs text-gray-400">Select a formation to see available players</div>';
+                document.getElementById('playing-time-bars').classList.add('hidden');
+            }
+        };
+
+        function getPeriods(formationId) {
+            const f = FORMATIONS[formationId];
+            if (!f) return ['H1', 'H2'];
+            const n = f.numPeriods || 2;
+            if (n === 4) return ['Q1', 'Q2', 'Q3', 'Q4'];
+            return ['H1', 'H2'];
+        }
+
+        function renderPeriodTabs() {
+            if (!state.formationId) return;
+            const periods = getPeriods(state.formationId);
+            state.activePeriod = periods[0];
+            const tabs = document.getElementById('period-tabs');
+            tabs.innerHTML = periods.map(p =>
+                `<button id="period-tab-${p}" onclick="switchPeriodTab('${p}')"
+                    class="px-3 py-1 rounded-full text-xs font-semibold transition ${p === state.activePeriod ? 'bg-white text-primary-700 shadow-sm' : 'text-gray-500'}">${p}</button>`
+            ).join('');
+        }
+
+        window.switchPeriodTab = function(period) {
+            state.activePeriod = period;
+            const periods = getPeriods(state.formationId);
+            periods.forEach(p => {
+                const btn = document.getElementById(`period-tab-${p}`);
+                if (btn) {
+                    btn.className = `px-3 py-1 rounded-full text-xs font-semibold transition ${p === period ? 'bg-white text-primary-700 shadow-sm' : 'text-gray-500'}`;
+                }
+            });
+            renderRotationCanvas();
+            renderBenchPool();
+        };
+
+        function renderRotationCanvas() {
+            if (!state.formationId) return;
+            const formation = FORMATIONS[state.formationId];
+            const period = state.activePeriod;
+            const assignments = state.rotationPlan[period] || {};
+            const canvas = document.getElementById('rotation-canvas');
+
+            canvas.innerHTML = formation.positions.map(pos => {
+                const playerId = assignments[pos.id];
+                const player = playerId ? state.players.find(p => p.id === playerId) : null;
+                const color = player ? getPlayerColor(player.id) : null;
+                const cellBorder = color ? `border-left: 4px solid ${color.border}` : '';
+                const chipStyle = color
+                    ? `background:${color.bg};color:${color.text};border:1px solid ${color.border};border-radius:9999px;padding:1px 8px;`
+                    : '';
+                const playerLabel = player
+                    ? `<span style="${chipStyle}" class="text-xs font-semibold">${player.number ? `#${player.number} ` : ''}${escapeHtml(player.name)}</span>`
+                    : `<span class="text-xs text-gray-300 italic">drag player here</span>`;
+                return `<div class="flex items-center gap-2 p-2 rounded-lg border border-gray-100 hover:border-primary-200 rotation-cell"
+                    style="${cellBorder}"
+                    data-pos="${pos.id}"
+                    ondragover="event.preventDefault();this.classList.add('drag-over')"
+                    ondragleave="this.classList.remove('drag-over')"
+                    ondrop="dropOnPosition(event,'${pos.id}')">
+                    <div class="text-xs text-gray-500 font-semibold w-24 flex-shrink-0">${escapeHtml(pos.name)}</div>
+                    <div class="flex-1 min-w-0 truncate" id="canvas-cell-${period}-${pos.id}">${playerLabel}</div>
+                    ${player ? `<button onclick="clearPosition('${pos.id}')" class="text-gray-300 hover:text-red-400 text-xs ml-1 flex-shrink-0">×</button>` : ''}
+                </div>`;
+            }).join('');
+        }
+
+        function renderBenchPool() {
+            if (!state.formationId) return;
+            const period = state.activePeriod;
+            const assignments = state.rotationPlan[period] || {};
+            const assignedIds = new Set(Object.values(assignments));
+
+            const going = state.rsvpBreakdown?.going?.map(r => r.playerId) || [];
+            const availablePlayers = state.players.filter(p =>
+                !assignedIds.has(p.id) && (going.length === 0 || going.includes(p.id))
+            );
+
+            const pool = document.getElementById('bench-pool');
+            if (!availablePlayers.length) {
+                pool.innerHTML = '<div class="text-xs text-gray-400 italic">All going players assigned</div>';
+                return;
+            }
+            pool.innerHTML = availablePlayers.map(p => {
+                const color = getPlayerColor(p.id);
+                const chipStyle = color
+                    ? `background:${color.bg};color:${color.text};border:1.5px solid ${color.border}`
+                    : 'background:#e0e7ff;color:#3730a3;border:1.5px solid #a5b4fc';
+                const dotStyle = color ? `background:${color.bg};border-color:${color.border}` : 'background:#c7d2fe;border-color:#a5b4fc';
+                return `<div class="player-chip flex items-center gap-1 px-2 py-1 rounded-full text-xs font-semibold cursor-grab select-none"
+                    style="${chipStyle}"
+                    draggable="true"
+                    data-player-id="${p.id}"
+                    ondragstart="startDragPlayer(event,'${p.id}')"
+                    title="Drag to assign • Click dot to change color">
+                    <span class="color-swatch" style="${dotStyle}" onclick="cyclePlayerColor('${p.id}',event)" title="Click to change color"></span>
+                    ${p.number ? `#${p.number} ` : ''}${escapeHtml(p.name)}
+                </div>`;
+            }).join('');
+        }
+
+        window.startDragPlayer = function(event, playerId) {
+            event.dataTransfer.setData('playerId', playerId);
+        };
+
+        window.dropOnPosition = function(event, posId) {
+            event.preventDefault();
+            event.currentTarget.classList.remove('drag-over');
+            const playerId = event.dataTransfer.getData('playerId');
+            if (!playerId) return;
+            const period = state.activePeriod;
+            if (!state.rotationPlan[period]) state.rotationPlan[period] = {};
+            state.rotationPlan[period][posId] = playerId;
+            renderRotationCanvas();
+            renderBenchPool();
+            renderPlayingTimeBars();
+        };
+
+        window.clearPosition = function(posId) {
+            const period = state.activePeriod;
+            if (state.rotationPlan[period]) {
+                delete state.rotationPlan[period][posId];
+                renderRotationCanvas();
+                renderBenchPool();
+                renderPlayingTimeBars();
+            }
+        };
+
+        function renderPlayingTimeBars() {
+            if (!state.formationId) return;
+            const formation = FORMATIONS[state.formationId];
+            const periods = getPeriods(state.formationId);
+            const numPositions = formation.positions.length;
+
+            // Count how many periods each player appears in
+            const periodCount = {};
+            state.players.forEach(p => { periodCount[p.id] = 0; });
+            periods.forEach(period => {
+                const assignments = state.rotationPlan[period] || {};
+                Object.values(assignments).forEach(playerId => {
+                    periodCount[playerId] = (periodCount[playerId] || 0) + 1;
+                });
+            });
+
+            const totalPeriods = periods.length;
+            const el = document.getElementById('pt-bars-list');
+            const barsContainer = document.getElementById('playing-time-bars');
+
+            const going = state.rsvpBreakdown?.going || [];
+            const goingIds = going.length ? going.map(r => r.playerId) : state.players.map(p => p.id);
+
+            const rows = state.players
+                .filter(p => goingIds.includes(p.id))
+                .map(p => ({
+                    player: p,
+                    count: periodCount[p.id] || 0,
+                    pct: ((periodCount[p.id] || 0) / totalPeriods) * 100
+                }))
+                .sort((a, b) => b.count - a.count);
+
+            if (!rows.length) { barsContainer.classList.add('hidden'); return; }
+            barsContainer.classList.remove('hidden');
+
+            el.innerHTML = rows.map(row => {
+                const color = row.pct >= 80 ? 'bg-green-400' : row.pct >= 40 ? 'bg-amber-400' : 'bg-red-300';
+                return `<div>
+                    <div class="flex items-center justify-between mb-0.5">
+                        <span class="text-xs text-gray-700">${row.player.number ? `#${row.player.number} ` : ''}${escapeHtml(row.player.name)}</span>
+                        <span class="text-xs text-gray-400">${row.count}/${totalPeriods}</span>
+                    </div>
+                    <div class="w-full h-2 bg-gray-100 rounded-full overflow-hidden">
+                        <div class="${color} h-2 rounded-full transition-all" style="width:${row.pct}%"></div>
+                    </div>
+                </div>`;
+            }).join('');
+        }
+
+        window.balancePlayingTime = function() {
+            if (!state.formationId) return;
+            const formation = FORMATIONS[state.formationId];
+            const periods = getPeriods(state.formationId);
+            const going = state.rsvpBreakdown?.going || [];
+            const goingIds = going.length ? going.map(r => r.playerId) : state.players.map(p => p.id);
+            const goingPlayers = state.players.filter(p => goingIds.includes(p.id));
+
+            if (!goingPlayers.length) { alert('No going players to balance.'); return; }
+
+            const numPositions = formation.positions.length;
+            // Simple round-robin distribution
+            const newPlan = {};
+            periods.forEach(period => { newPlan[period] = {}; });
+
+            // Build a flat rotation list cycling through going players
+            let playerIdx = 0;
+            periods.forEach(period => {
+                formation.positions.forEach(pos => {
+                    if (goingPlayers.length) {
+                        newPlan[period][pos.id] = goingPlayers[playerIdx % goingPlayers.length].id;
+                        playerIdx++;
+                    }
+                });
+            });
+
+            state.rotationPlan = newPlan;
+            renderRotationCanvas();
+            renderBenchPool();
+            renderPlayingTimeBars();
+        };
+
+        window.aiOptimizeLineup = async function() {
+            if (!state.formationId) { alert('Select a formation first.'); return; }
+            const formation = FORMATIONS[state.formationId];
+            const going = state.rsvpBreakdown?.going || [];
+            const goingList = going.map(p => p.playerName).join(', ') || 'Unknown';
+            const positions = formation.positions.map(p => p.name).join(', ');
+
+            appendChatBubble('Optimize my lineup for equal playing time', 'user');
+
+            try {
+                const model = getAIModel();
+                const prompt = `Return a JSON rotation plan: { "H1": { "positionId": "PlayerName", ... }, "H2": { ... } }
+Going players: ${goingList}
+Formation: ${state.formationId} — Positions (use these exact IDs as keys): ${formation.positions.map(p => p.id + ':' + p.name).join(', ')}
+Goal: balance playing time. Equal minutes for all going players.
+Respond ONLY with valid JSON.`;
+                const result = await model.generateContent(prompt);
+                const text = result.response.text().trim();
+                const jsonMatch = text.match(/\{[\s\S]*\}/);
+                if (jsonMatch) {
+                    const parsed = JSON.parse(jsonMatch[0]);
+                    acceptLineupProposal(parsed);
+                    appendChatBubble('Optimized lineup applied to canvas!', 'ai');
+                } else {
+                    appendChatBubble('Could not parse lineup. Try asking in chat.', 'ai');
+                }
+            } catch (err) {
+                console.error('aiOptimizeLineup error', err);
+                appendChatBubble('AI error. Try again.', 'ai');
+            }
+            setChatMode('lineup');
+            document.getElementById('pre-game-view').scrollIntoView({ behavior: 'smooth' });
+        };
+
+        // ==================== SAVE GAME PLAN ====================
+        window.saveGamePlan = async function() {
+            if (!state.formationId) { alert('Select a formation first.'); return; }
+            const btn = document.querySelector('[onclick="saveGamePlan()"]');
+            const orig = btn.textContent;
+            btn.textContent = 'Saving…';
+            btn.disabled = true;
+            try {
+                const gamePlan = {
+                    formationId: state.formationId,
+                    numPeriods: FORMATIONS[state.formationId].numPeriods || 2,
+                    lineups: flattenRotationPlan(state.rotationPlan)
+                };
+                await updateGame(state.teamId, state.gameId, { gamePlan });
+                state.gamePlan = gamePlan;
+                btn.textContent = 'Saved!';
+                setTimeout(() => { btn.textContent = orig; btn.disabled = false; }, 2000);
+            } catch (err) {
+                console.error('saveGamePlan error', err);
+                btn.textContent = 'Error saving';
+                btn.disabled = false;
+            }
+        };
+
+        function flattenRotationPlan(plan) {
+            const lineups = {};
+            Object.entries(plan).forEach(([period, positions]) => {
+                Object.entries(positions).forEach(([posId, playerId]) => {
+                    lineups[`${period}-${posId}`] = playerId;
+                });
+            });
+            return lineups;
+        }
+
+        function buildRotationFromGamePlan(gamePlan) {
+            if (!gamePlan?.lineups) return {};
+            const plan = {};
+            Object.entries(gamePlan.lineups).forEach(([key, playerId]) => {
+                // key format: "H1-positionId" or "Q1-positionId"
+                const dashIdx = key.indexOf('-');
+                if (dashIdx === -1) return;
+                const period = key.substring(0, dashIdx);
+                const posId = key.substring(dashIdx + 1);
+                if (!plan[period]) plan[period] = {};
+                plan[period][posId] = playerId;
+            });
+            return plan;
+        }
+
+        // ==================== GAME DAY ====================
+        function renderGameDay() {
+            const game = state.game;
+            document.getElementById('gd-matchup').textContent =
+                `${state.team?.name || 'Team'} vs ${game?.opponent || 'Opponent'}`;
+            updateScoreDisplay();
+            renderGDPeriodTabs();
+            setGameViewTab(state.gameViewTab);
+            populateSubDropdowns();
+        }
+
+        function updateScoreDisplay() {
+            document.getElementById('gd-home-score').textContent = state.score.home;
+            document.getElementById('gd-away-score').textContent = state.score.away;
+            document.getElementById('score-home-display').textContent = state.score.home;
+            document.getElementById('score-away-display').textContent = state.score.away;
+            if (document.getElementById('wrapup-home-score')) {
+                document.getElementById('wrapup-home-score').value = state.score.home;
+                document.getElementById('wrapup-away-score').value = state.score.away;
+            }
+        }
+
+        function renderGDPeriodTabs() {
+            const periods = state.formationId ? getPeriods(state.formationId) : ['H1', 'H2'];
+            document.getElementById('gd-h1-btn').textContent = periods[0];
+            document.getElementById('gd-h2-btn').textContent = periods[1] || 'H2';
+        }
+
+        window.setActivePeriod = function(period) {
+            state.activePeriodGD = period;
+            const periods = state.formationId ? getPeriods(state.formationId) : ['H1', 'H2'];
+            document.getElementById('gd-h1-btn').className =
+                period === periods[0]
+                    ? 'px-2 py-0.5 rounded text-xs font-semibold bg-primary-100 text-primary-700'
+                    : 'px-2 py-0.5 rounded text-xs font-semibold text-gray-500 hover:bg-gray-100';
+            document.getElementById('gd-h2-btn').className =
+                period === periods[1]
+                    ? 'px-2 py-0.5 rounded text-xs font-semibold bg-primary-100 text-primary-700'
+                    : 'px-2 py-0.5 rounded text-xs font-semibold text-gray-500 hover:bg-gray-100';
+            renderOnFieldList();
+        };
+
+        window.setGameViewTab = function(tab) {
+            state.gameViewTab = tab;
+            const coachView = document.getElementById('gd-coach-view');
+            const statsView = document.getElementById('gd-stats-view');
+            const coachBtn = document.getElementById('gd-coach-btn');
+            const statsBtn = document.getElementById('gd-stats-btn');
+
+            if (tab === 'coach') {
+                coachView.classList.remove('hidden');
+                statsView.classList.add('hidden');
+                coachBtn.className = 'px-3 py-1 rounded-full text-xs font-semibold transition bg-white text-gray-900';
+                statsBtn.className = 'px-3 py-1 rounded-full text-xs font-semibold transition text-gray-400';
+                renderOnFieldList();
+                renderCoachingLog();
+            } else {
+                coachView.classList.add('hidden');
+                statsView.classList.remove('hidden');
+                coachBtn.className = 'px-3 py-1 rounded-full text-xs font-semibold transition text-gray-400';
+                statsBtn.className = 'px-3 py-1 rounded-full text-xs font-semibold transition bg-white text-gray-900';
+                renderStatsView();
+                renderLiveEventLog();
+            }
+        };
+
+        // Build the current on-field map { posId: playerId } for a given period,
+        // merging planned lineup with any actual subs applied
+        function buildOnFieldMap(period) {
+            const actual = state.rotationActual?.[period] || {};
+            const plan = state.rotationPlan?.[period] || {};
+            const onField = { ...plan };
+            Object.values(actual).flat().forEach(sub => {
+                if (sub && sub.position && sub.in) {
+                    const player = state.players.find(p => p.name === sub.in);
+                    if (player) onField[sub.position] = player.id;
+                }
+            });
+            return onField;
+        }
+
+        function renderOnFieldList() {
+            renderFieldDiagram();
+        }
+
+        function renderFieldDiagram() {
+            const period = state.activePeriodGD;
+            const container = document.getElementById('field-diagram-container');
+            const formation = state.formationId ? FORMATIONS[state.formationId] : null;
+            const fieldPositions = state.formationId ? FIELD_POSITIONS[state.formationId] : null;
+            const onField = buildOnFieldMap(period);
+
+            if (!formation || !fieldPositions) {
+                // Fallback: simple text list
+                if (!Object.keys(onField).length) {
+                    container.innerHTML = '<div class="text-xs text-gray-400">Select a formation in Pre-Game mode to see on-field players.</div>';
+                    return;
+                }
+                container.innerHTML = Object.entries(onField).map(([posId, playerId]) => {
+                    const player = state.players.find(p => p.id === playerId);
+                    return `<div class="flex items-center justify-between py-1 border-b border-gray-50">
+                        <span class="text-xs text-gray-500">${escapeHtml(posId)}</span>
+                        <span class="text-xs font-medium">${player ? escapeHtml(player.name) : '—'}</span>
+                    </div>`;
+                }).join('');
+                return;
+            }
+
+            const isSoccer = state.formationId.startsWith('soccer');
+            const isBasketball = state.formationId.startsWith('basketball');
+
+            // Field background class
+            const fieldClass = isBasketball ? 'basketball-court' : '';
+
+            // Build player blocks HTML
+            const playerBlocks = formation.positions.map(pos => {
+                const coords = fieldPositions[pos.id];
+                if (!coords) return '';
+                const playerId = onField[pos.id];
+                const player = playerId ? state.players.find(p => p.id === playerId) : null;
+                const color = player ? getPlayerColor(player.id) : null;
+
+                const blockBg = color ? color.bg : 'rgba(255,255,255,0.85)';
+                const blockText = color ? color.text : '#1f2937';
+                const blockBorder = color ? color.border : 'rgba(255,255,255,0.6)';
+
+                const label = player
+                    ? `${player.number ? '#' + player.number : ''}${player.number && player.name ? ' ' : ''}${escapeHtml(player.name.split(' ')[0])}`
+                    : '—';
+                const posLabel = pos.name.replace('Center Mid', 'CM').replace('- Defense', 'Def').replace('- ', '');
+
+                return `<div class="field-player"
+                    style="left:${coords.left}%;top:${coords.top}%;background:${blockBg};color:${blockText};border-color:${blockBorder}"
+                    title="${escapeHtml(pos.name)}: ${player ? escapeHtml(player.name) : 'Empty'}">
+                    <span class="field-pos-label">${escapeHtml(posLabel)}</span>
+                    ${label}
+                </div>`;
+            }).join('');
+
+            // Field markings (white lines)
+            const soccerMarkings = isSoccer ? `
+                <!-- penalty areas -->
+                <div class="field-line" style="left:25%;right:25%;top:8%;height:1px"></div>
+                <div class="field-line" style="left:25%;top:8%;width:1px;height:12%"></div>
+                <div class="field-line" style="right:25%;top:8%;width:1px;height:12%"></div>
+                <div class="field-line" style="left:25%;right:25%;bottom:8%;height:1px"></div>
+                <div class="field-line" style="left:25%;bottom:8%;width:1px;height:12%"></div>
+                <div class="field-line" style="right:25%;bottom:8%;width:1px;height:12%"></div>
+            ` : '';
+
+            const basketballMarkings = isBasketball ? `
+                <!-- three-point arc (simplified) -->
+                <div class="field-line" style="left:10%;right:10%;top:5%;height:1px"></div>
+                <div class="field-line" style="left:35%;right:35%;top:78%;height:1px"></div>
+            ` : '';
+
+            container.innerHTML = `
+                <div class="field-diagram ${fieldClass}" style="height:260px">
+                    ${soccerMarkings}${basketballMarkings}
+                    ${playerBlocks}
+                    <!-- bench players -->
+                </div>
+                <div class="mt-2 flex flex-wrap gap-1" id="bench-on-field">
+                    ${renderBenchOnField(onField)}
+                </div>
+            `;
+        }
+
+        function renderBenchOnField(onField) {
+            // Show players NOT on field as "bench" chips below diagram
+            const onFieldIds = new Set(Object.values(onField).filter(Boolean));
+            const going = state.rsvpBreakdown?.going?.map(r => r.playerId) || [];
+            const bench = state.players.filter(p =>
+                !onFieldIds.has(p.id) && (going.length === 0 || going.includes(p.id))
+            );
+            if (!bench.length) return '<span class="text-xs text-gray-400 italic">No bench players</span>';
+            return bench.map(p => {
+                const color = getPlayerColor(p.id);
+                const style = color
+                    ? `background:${color.bg};color:${color.text};border:1px solid ${color.border}`
+                    : 'background:#f1f5f9;color:#475569;border:1px solid #cbd5e1';
+                return `<span class="px-2 py-0.5 rounded-full text-xs font-semibold" style="${style}">
+                    ${p.number ? `#${p.number} ` : ''}${escapeHtml(p.name)}
+                </span>`;
+            }).join('');
+        }
+
+        function populateSubDropdowns() {
+            const outSel = document.getElementById('sub-out-select');
+            const inSel = document.getElementById('sub-in-select');
+            const period = state.activePeriodGD;
+            const planForPeriod = state.rotationPlan?.[period] || {};
+            const onFieldIds = new Set(Object.values(planForPeriod).filter(Boolean));
+            const offFieldPlayers = state.players.filter(p => !onFieldIds.has(p.id));
+            const onFieldPlayers = state.players.filter(p => onFieldIds.has(p.id));
+
+            const toOption = p => `<option value="${p.id}">${p.number ? '#' + p.number + ' ' : ''}${escapeHtml(p.name)}</option>`;
+            outSel.innerHTML = '<option value="">— Select player —</option>' + onFieldPlayers.map(toOption).join('');
+            inSel.innerHTML = '<option value="">— Select player —</option>' + offFieldPlayers.map(toOption).join('');
+        }
+
+        window.applySub = async function() {
+            const outId = document.getElementById('sub-out-select').value;
+            const inId = document.getElementById('sub-in-select').value;
+            if (!outId || !inId) { alert('Select both OUT and IN players.'); return; }
+
+            const period = state.activePeriodGD;
+            const outPlayer = state.players.find(p => p.id === outId);
+            const inPlayer = state.players.find(p => p.id === inId);
+            if (!outPlayer || !inPlayer) return;
+
+            // Find position of outPlayer
+            const planForPeriod = state.rotationPlan?.[period] || {};
+            const position = Object.entries(planForPeriod).find(([_, pid]) => pid === outId)?.[0] || 'unknown';
+
+            // Update rotationPlan
+            if (!state.rotationPlan[period]) state.rotationPlan[period] = {};
+            state.rotationPlan[period][position] = inId;
+
+            // Log to rotationActual
+            if (!state.rotationActual[period]) state.rotationActual[period] = {};
+            const subKey = `sub-${Date.now()}`;
+            if (!state.rotationActual[period][subKey]) state.rotationActual[period][subKey] = [];
+            state.rotationActual[period][subKey].push({
+                position, out: outPlayer.name, in: inPlayer.name, appliedAt: new Date().toISOString()
+            });
+
+            try {
+                await updateGame(state.teamId, state.gameId, { rotationActual: state.rotationActual });
+                await logCoachEvent(`Sub: ${outPlayer.name} → ${inPlayer.name}`, 'substitution');
+            } catch (err) {
+                console.error('applySub error', err);
+            }
+            renderFieldDiagram();
+            populateSubDropdowns();
+        };
+
+        window.adjustScore = function(side, delta) {
+            if (side === 'home') {
+                state.score.home = Math.max(0, state.score.home + delta);
+            } else {
+                state.score.away = Math.max(0, state.score.away + delta);
+            }
+            updateScoreDisplay();
+        };
+
+        window.saveScore = async function() {
+            try {
+                await updateGame(state.teamId, state.gameId, {
+                    homeScore: state.score.home,
+                    awayScore: state.score.away
+                });
+            } catch (err) {
+                console.error('saveScore error', err);
+            }
+        };
+
+        window.logCoachEvent = async function(text, type = 'note') {
+            const input = document.getElementById('coaching-note-input');
+            const eventText = text || input?.value?.trim();
+            if (!eventText) return;
+            if (input && !text) input.value = '';
+
+            const note = {
+                text: eventText,
+                type,
+                period: state.activePeriodGD,
+                createdAt: new Date().toISOString()
+            };
+
+            state.coachingNotes.push(note);
+            renderCoachingLog();
+
+            try {
+                // Use direct updateGame with arrayUnion equivalent — append to notes
+                await updateGame(state.teamId, state.gameId, {
+                    coachingNotes: state.coachingNotes
+                });
+            } catch (err) {
+                console.error('logCoachEvent error', err);
+            }
+        };
+
+        function renderCoachingLog() {
+            const el = document.getElementById('coaching-log-list');
+            if (!state.coachingNotes.length) {
+                el.innerHTML = '<div class="text-xs text-gray-400">No notes yet</div>';
+                return;
+            }
+            el.innerHTML = [...state.coachingNotes].reverse().slice(0, 20).map(note => {
+                const typeColors = {
+                    substitution: 'text-orange-600', Timeout: 'text-amber-600',
+                    'Formation Change': 'text-blue-600', Injury: 'text-red-600', note: 'text-gray-700'
+                };
+                const color = typeColors[note.type] || 'text-gray-700';
+                return `<div class="flex items-start gap-1.5 py-1 border-b border-gray-50">
+                    <span class="text-xs ${color} font-medium">${escapeHtml(note.period || '')}:</span>
+                    <span class="text-xs text-gray-700 flex-1">${escapeHtml(note.text)}</span>
+                </div>`;
+            }).join('');
+        }
+
+        // ==================== STATS VIEW ====================
+        function renderStatsView() {
+            const el = document.getElementById('stats-player-table');
+            const columns = state.statConfig?.columns || ['Goals', 'Assists'];
+            const going = state.rsvpBreakdown?.going?.map(r => r.playerId) || [];
+
+            const displayPlayers = state.players.filter(p =>
+                going.length === 0 || going.includes(p.id)
+            ).sort((a, b) => (parseInt(a.number) || 999) - (parseInt(b.number) || 999));
+
+            // Header
+            el.innerHTML = `
+                <div class="flex items-center px-4 py-2 bg-gray-50 text-xs text-gray-500 font-semibold gap-2">
+                    <div class="flex-1">Player</div>
+                    ${columns.map(col => `<div class="text-center" style="min-width:52px">${escapeHtml(col)}</div>`).join('')}
+                </div>
+            ` + displayPlayers.map(player => {
+                const playerStats = state.aggregatedStats.find(s => s.id === player.id)?.stats || {};
+                return `<div class="flex items-center px-4 py-3 gap-2 border-b border-gray-50 hover:bg-gray-50">
+                    <div class="flex-1 min-w-0">
+                        <div class="text-sm font-semibold text-gray-900 truncate">${player.number ? `#${player.number} ` : ''}${escapeHtml(player.name)}</div>
+                    </div>
+                    ${columns.map(col => {
+                        const statKey = col.toLowerCase().replace(/\s+/g, '_');
+                        const val = playerStats[statKey] || playerStats[col] || 0;
+                        return `<div class="text-center" style="min-width:52px">
+                            <button class="stat-btn w-12 h-11 rounded-xl bg-gray-100 text-gray-800 hover:bg-primary-100 hover:text-primary-700 active:scale-95 transition-all font-bold"
+                                onclick="recordStat('${player.id}','${escapeHtml(col)}','${escapeHtml(player.name)}','${player.number || ''}')">
+                                ${val}
+                            </button>
+                        </div>`;
+                    }).join('')}
+                </div>`;
+            }).join('');
+        }
+
+        window.recordStat = async function(playerId, statCol, playerName, playerNumber) {
+            const statKey = statCol.toLowerCase().replace(/\s+/g, '_');
+            try {
+                await updatePlayerStats(state.teamId, state.gameId, playerId, statKey, 1, playerName, playerNumber);
+                const event = {
+                    type: 'stat',
+                    playerId, playerName,
+                    stat: statCol, value: 1,
+                    period: state.activePeriodGD
+                };
+                state.lastStatEvent = { playerId, statKey, playerName, playerNumber };
+                await broadcastLiveEvent(state.teamId, state.gameId, event);
+            } catch (err) {
+                console.error('recordStat error', err);
+            }
+        };
+
+        window.undoLastStat = async function() {
+            if (!state.lastStatEvent) { alert('No recent stat to undo.'); return; }
+            const { playerId, statKey, playerName, playerNumber } = state.lastStatEvent;
+            try {
+                await updatePlayerStats(state.teamId, state.gameId, playerId, statKey, -1, playerName, playerNumber);
+                state.lastStatEvent = null;
+            } catch (err) {
+                console.error('undoLastStat error', err);
+            }
+        };
+
+        function renderLiveEventLog() {
+            const el = document.getElementById('live-event-log');
+            const recent = [...state.liveEvents].reverse().slice(0, 10);
+            if (!recent.length) {
+                el.innerHTML = '<div class="text-gray-400 italic">No events yet</div>';
+                return;
+            }
+            el.innerHTML = recent.map(ev => {
+                const time = ev.createdAt?.toDate ? ev.createdAt.toDate().toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '';
+                return `<div class="flex items-center gap-2 py-0.5 border-b border-gray-50">
+                    <span class="text-gray-400 text-xs flex-shrink-0">${time}</span>
+                    <span class="font-medium text-gray-700">${escapeHtml(ev.playerName || '')}</span>
+                    <span class="text-gray-500">${escapeHtml(ev.stat || ev.type || '')}</span>
+                </div>`;
+            }).join('');
+        }
+
+        // ==================== WRAP-UP ====================
+        function renderWrapup() {
+            document.getElementById('wrapup-home-score').value = state.score.home;
+            document.getElementById('wrapup-away-score').value = state.score.away;
+            document.getElementById('post-game-notes').value = state.game?.postGameNotes || '';
+        }
+
+        window.closeWrapup = function() {
+            document.getElementById('wrapup-panel').classList.add('hidden');
+        };
+
+        window.analyzeGame = async function() {
+            const status = document.getElementById('wrapup-ai-status');
+            status.classList.remove('hidden');
+            status.textContent = 'Analyzing game… this may take a moment.';
+            try {
+                const model = getAIModel();
+                const stats = state.aggregatedStats;
+                const events = state.liveEvents.slice(-30);
+                const notes = document.getElementById('post-game-notes').value;
+
+                const prompt = `Analyze this soccer game and return JSON: { "practiceFeedItems": [ { "weakness": "...", "evidence": "...", "drillCategory": "...", "urgency": "high|medium|low" } ] }
+Game: ${state.team?.name || 'Team'} vs ${state.game?.opponent || 'Opponent'}
+Score: ${state.score.home}-${state.score.away}
+Coaching notes: ${state.coachingNotes.map(n => n.text).join(', ') || 'None'}
+Post-game notes: ${notes || 'None'}
+Key events: ${events.map(e => `${e.playerName || ''} ${e.stat || e.type || ''}`).join(', ') || 'None'}
+Identify 2-4 specific areas to improve. Respond ONLY with valid JSON.`;
+
+                const result = await model.generateContent(prompt);
+                const text = result.response.text().trim();
+                const jsonMatch = text.match(/\{[\s\S]*\}/);
+                if (jsonMatch) {
+                    const parsed = JSON.parse(jsonMatch[0]);
+                    const items = (parsed.practiceFeedItems || []).map(item => ({
+                        ...item, addedAt: new Date().toISOString()
+                    }));
+                    await updateGame(state.teamId, state.gameId, { practiceFeedItems: items });
+                    state.game = { ...state.game, practiceFeedItems: items };
+                    status.textContent = `Practice feed generated: ${items.length} focus area(s) saved.`;
+                } else {
+                    status.textContent = 'Could not parse AI response. Try again.';
+                }
+            } catch (err) {
+                console.error('analyzeGame error', err);
+                status.textContent = 'AI error: ' + err.message;
+            }
+        };
+
+        window.generateSummary = async function() {
+            const status = document.getElementById('wrapup-ai-status');
+            status.classList.remove('hidden');
+            status.textContent = 'Generating game summary…';
+            try {
+                const model = getAIModel();
+                const notes = document.getElementById('post-game-notes').value;
+                const prompt = `Write a 3-5 sentence game summary for a youth soccer team.
+Team: ${state.team?.name || 'Team'} vs ${state.game?.opponent || 'Opponent'}
+Final score: ${state.score.home}-${state.score.away}
+Coach notes: ${notes || 'None'}
+Key highlights: ${state.coachingNotes.map(n => n.text).join(', ') || 'None'}
+Be encouraging and specific. No markdown.`;
+                const result = await model.generateContent(prompt);
+                const summary = result.response.text().trim();
+                await updateGame(state.teamId, state.gameId, { summary });
+                state.game = { ...state.game, summary };
+                status.textContent = 'Summary saved! Visible on the match report.';
+            } catch (err) {
+                console.error('generateSummary error', err);
+                status.textContent = 'AI error: ' + err.message;
+            }
+        };
+
+        window.finishGame = async function() {
+            const homeScore = parseInt(document.getElementById('wrapup-home-score').value) || 0;
+            const awayScore = parseInt(document.getElementById('wrapup-away-score').value) || 0;
+            const postGameNotes = document.getElementById('post-game-notes').value.trim();
+
+            try {
+                await updateGame(state.teamId, state.gameId, {
+                    homeScore, awayScore, postGameNotes,
+                    status: 'completed', liveStatus: 'completed'
+                });
+                window.location.href = `game.html#teamId=${state.teamId}&gameId=${state.gameId}`;
+            } catch (err) {
+                console.error('finishGame error', err);
+                alert('Error saving: ' + err.message);
+            }
+        };
+
+        // ==================== AI MODEL ====================
+        function getAIModel() {
+            if (!state.aiModel) {
+                const app = getApp();
+                const ai = getAI(app, { backend: new GoogleAIBackend() });
+                state.aiModel = getGenerativeModel(ai, { model: 'gemini-2.5-flash' });
+            }
+            return state.aiModel;
+        }
+
+        // ==================== HELPERS ====================
+        function escapeHtml(str) {
+            if (!str) return '';
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+        }
+
+        function hideLoading() {
+            const overlay = document.getElementById('loading-overlay');
+            if (overlay) overlay.style.display = 'none';
+        }
+
+        function showError(msg) {
+            hideLoading();
+            document.body.innerHTML = `<div class="flex items-center justify-center min-h-screen">
+                <div class="text-center p-8">
+                    <div class="text-red-500 text-lg font-bold mb-2">Error</div>
+                    <div class="text-gray-600">${escapeHtml(msg)}</div>
+                    <a href="dashboard.html" class="mt-4 inline-block text-primary-600 hover:underline">← Back to Dashboard</a>
+                </div>
+            </div>`;
+        }
+
+        // Cleanup on page unload
+        window.addEventListener('beforeunload', () => {
+            state.unsubscribers.forEach(fn => { try { fn(); } catch (e) {} });
+        });
+    </script>
+</body>
+</html>

--- a/js/db.js
+++ b/js/db.js
@@ -1438,6 +1438,17 @@ export async function getLiveEvents(teamId, gameId) {
 }
 
 /**
+ * Subscribe to aggregated stats (real-time) for Game Day Command Center
+ */
+export function subscribeAggregatedStats(teamId, gameId, callback, onError) {
+    const ref = collection(db, 'teams', teamId, 'games', gameId, 'aggregatedStats');
+    return onSnapshot(ref, snap => {
+        const stats = snap.docs.map(d => ({ id: d.id, ...d.data() }));
+        callback(stats);
+    }, onError);
+}
+
+/**
  * Update game live status
  */
 export async function setGameLiveStatus(teamId, gameId, status) {

--- a/js/team-admin-banner.js
+++ b/js/team-admin-banner.js
@@ -75,6 +75,11 @@ function icon(name) {
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"></path>
     </svg>`;
   }
+  if (name === 'gameday') {
+    return `<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9"></path>
+    </svg>`;
+  }
   if (name === 'exit') {
     return `<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v8a2 2 0 002 2h4"></path>
@@ -145,6 +150,7 @@ export function renderTeamAdminBanner(container, { team, teamId, active = '', un
     stats: `edit-config.html#teamId=${teamId}`,
     chat: `team-chat.html#teamId=${teamId}`,
     drills: `drills.html#teamId=${teamId}`,
+    gameday: `game-day.html#teamId=${teamId}`,
     exit: exitUrl
   };
 
@@ -161,6 +167,7 @@ export function renderTeamAdminBanner(container, { team, teamId, active = '', un
       ${actionCard({ href: hrefs.stats, label: 'Stats', iconName: 'stats', active: active === 'stats' })}
       ${actionCard({ href: hrefs.chat, label: 'Chat', iconName: 'chat', active: active === 'chat', unreadCount })}
       ${actionCard({ href: hrefs.drills, label: 'Drills', iconName: 'drills', active: active === 'drills' })}
+      ${actionCard({ href: hrefs.gameday, label: 'Game Day', iconName: 'gameday', active: active === 'gameday' })}
     `;
   } else {
     // Parent: View, Chat only
@@ -172,7 +179,7 @@ export function renderTeamAdminBanner(container, { team, teamId, active = '', un
 
   // Determine grid columns based on number of items
   const gridCols = isFullAccess
-    ? 'grid-cols-2 sm:grid-cols-4 lg:grid-cols-8'
+    ? 'grid-cols-2 sm:grid-cols-5 lg:grid-cols-9'
     : 'grid-cols-2';
 
   container.innerHTML = `

--- a/test-game-day.html
+++ b/test-game-day.html
@@ -1,0 +1,686 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Suite — Game Day Command Center</title>
+    <style>
+        body { font-family: monospace; padding: 20px; background: #f5f5f5; }
+        .test-section { background: white; margin: 20px 0; padding: 20px; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+        .test-case { margin: 10px 0; padding: 10px; border-left: 4px solid #ccc; }
+        .pass { border-left-color: #22c55e; background: #f0fdf4; }
+        .fail { border-left-color: #ef4444; background: #fef2f2; }
+        .test-name { font-weight: bold; margin-bottom: 5px; }
+        .test-result { font-size: 0.9em; color: #666; white-space: pre-wrap; }
+        h2 { color: #4338ca; }
+        .summary-pass { color: #16a34a; font-weight: bold; }
+        .summary-fail { color: #dc2626; font-weight: bold; }
+    </style>
+</head>
+<body>
+    <h1>🧪 Test Suite — Game Day Command Center</h1>
+    <p>Covers: <code>game-day.html</code>, <code>js/db.js</code> (subscribeAggregatedStats), <code>js/team-admin-banner.js</code>, <code>edit-schedule.html</code></p>
+
+    <div id="test-results"></div>
+
+    <script>
+        // ==================== TEST HARNESS ====================
+        const results = [];
+
+        function test(name, fn) {
+            try {
+                fn();
+                results.push({ name, pass: true, error: null });
+            } catch (e) {
+                results.push({ name, pass: false, error: e.message });
+            }
+        }
+
+        function assertEquals(actual, expected, message) {
+            if (actual !== expected) {
+                throw new Error(`${message || 'assertEquals failed'}\n  Expected: ${JSON.stringify(expected)}\n  Actual:   ${JSON.stringify(actual)}`);
+            }
+        }
+
+        function assertDeepEquals(actual, expected, message) {
+            const a = JSON.stringify(actual);
+            const e = JSON.stringify(expected);
+            if (a !== e) {
+                throw new Error(`${message || 'assertDeepEquals failed'}\n  Expected: ${e}\n  Actual:   ${a}`);
+            }
+        }
+
+        function assertTrue(value, message) {
+            if (!value) throw new Error(message || 'Expected truthy but got falsy');
+        }
+
+        function assertFalse(value, message) {
+            if (value) throw new Error(message || 'Expected falsy but got truthy');
+        }
+
+        function assertNull(value, message) {
+            if (value !== null && value !== undefined) {
+                throw new Error(`${message || 'Expected null/undefined'}\n  Actual: ${JSON.stringify(value)}`);
+            }
+        }
+
+        function assertNotNull(value, message) {
+            if (value === null || value === undefined) {
+                throw new Error(message || 'Expected non-null value but got null/undefined');
+            }
+        }
+
+        // ==================== REPLICATED LOGIC FROM game-day.html ====================
+        // These are pure-function extractions for unit testing
+
+        const FORMATIONS = {
+            'soccer-9v9': {
+                name: 'Soccer 9v9', numPeriods: 2,
+                positions: [
+                    { id: 'keeper', name: 'Keeper' },
+                    { id: 'right-defense', name: 'Right Defense' },
+                    { id: 'sweeper', name: 'Sweeper' },
+                    { id: 'left-defense', name: 'Left Defense' },
+                    { id: 'left-mid', name: 'Left Mid' },
+                    { id: 'center-mid-1', name: 'Center Mid' },
+                    { id: 'center-mid-2', name: 'Center Mid' },
+                    { id: 'right-mid', name: 'Right Mid' },
+                    { id: 'striker', name: 'Striker' }
+                ]
+            },
+            'basketball-5v5': {
+                name: 'Basketball 5v5', numPeriods: 4,
+                positions: [
+                    { id: 'pg', name: 'Point Guard' },
+                    { id: 'sg', name: 'Shooting Guard' },
+                    { id: 'sf', name: 'Small Forward' },
+                    { id: 'pf', name: 'Power Forward' },
+                    { id: 'c', name: 'Center' }
+                ]
+            }
+        };
+
+        const PLAYER_COLORS = [
+            { bg: '#dbeafe', text: '#1e40af', border: '#93c5fd', name: 'Blue' },
+            { bg: '#dcfce7', text: '#166534', border: '#86efac', name: 'Green' },
+            { bg: '#fef9c3', text: '#854d0e', border: '#fde047', name: 'Yellow' },
+            { bg: '#fce7f3', text: '#9d174d', border: '#f9a8d4', name: 'Pink' },
+            { bg: '#ede9fe', text: '#4c1d95', border: '#c4b5fd', name: 'Purple' },
+            { bg: '#ffedd5', text: '#9a3412', border: '#fdba74', name: 'Orange' },
+            { bg: '#ccfbf1', text: '#115e59', border: '#5eead4', name: 'Teal' },
+            { bg: '#f1f5f9', text: '#334155', border: '#cbd5e1', name: 'Gray' },
+        ];
+
+        function getPeriods(formationId) {
+            const f = FORMATIONS[formationId];
+            if (!f) return ['H1', 'H2'];
+            const n = f.numPeriods || 2;
+            if (n === 4) return ['Q1', 'Q2', 'Q3', 'Q4'];
+            return ['H1', 'H2'];
+        }
+
+        function flattenRotationPlan(plan) {
+            const lineups = {};
+            Object.entries(plan).forEach(([period, positions]) => {
+                Object.entries(positions).forEach(([posId, playerId]) => {
+                    lineups[`${period}-${posId}`] = playerId;
+                });
+            });
+            return lineups;
+        }
+
+        function buildRotationFromGamePlan(gamePlan) {
+            if (!gamePlan?.lineups) return {};
+            const plan = {};
+            Object.entries(gamePlan.lineups).forEach(([key, playerId]) => {
+                const dashIdx = key.indexOf('-');
+                if (dashIdx === -1) return;
+                const period = key.substring(0, dashIdx);
+                const posId = key.substring(dashIdx + 1);
+                if (!plan[period]) plan[period] = {};
+                plan[period][posId] = playerId;
+            });
+            return plan;
+        }
+
+        function getPlayerColor(playerColors, playerId) {
+            const idx = playerColors[playerId];
+            return (idx !== undefined) ? PLAYER_COLORS[idx % PLAYER_COLORS.length] : null;
+        }
+
+        function cyclePlayerColor(playerColors, playerId) {
+            const current = playerColors[playerId];
+            playerColors[playerId] = (current === undefined) ? 0 : (current + 1) % PLAYER_COLORS.length;
+            return playerColors[playerId];
+        }
+
+        function buildOnFieldMap(rotationPlan, rotationActual, players, period) {
+            const actual = rotationActual?.[period] || {};
+            const plan = rotationPlan?.[period] || {};
+            const onField = { ...plan };
+            Object.values(actual).flat().forEach(sub => {
+                if (sub && sub.position && sub.in) {
+                    const player = players.find(p => p.name === sub.in);
+                    if (player) onField[sub.position] = player.id;
+                }
+            });
+            return onField;
+        }
+
+        function determineInitialMode(liveStatus, status) {
+            if (liveStatus === 'live') return 'gameday';
+            if (liveStatus === 'completed' || status === 'completed') return 'wrapup';
+            return 'pregame';
+        }
+
+        function balancePlayingTime(formationId, goingPlayers) {
+            const formation = FORMATIONS[formationId];
+            if (!formation || !goingPlayers.length) return {};
+            const periods = getPeriods(formationId);
+            const newPlan = {};
+            periods.forEach(period => { newPlan[period] = {}; });
+            let playerIdx = 0;
+            periods.forEach(period => {
+                formation.positions.forEach(pos => {
+                    newPlan[period][pos.id] = goingPlayers[playerIdx % goingPlayers.length].id;
+                    playerIdx++;
+                });
+            });
+            return newPlan;
+        }
+
+        function escapeHtml(str) {
+            if (!str) return '';
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+        }
+
+        // ============================================================
+        // SUITE 1: Formation & Period Logic
+        // ============================================================
+
+        test('Soccer 9v9 has 9 positions', () => {
+            assertEquals(FORMATIONS['soccer-9v9'].positions.length, 9, 'Soccer should have 9 positions');
+        });
+
+        test('Basketball 5v5 has 5 positions', () => {
+            assertEquals(FORMATIONS['basketball-5v5'].positions.length, 5, 'Basketball should have 5 positions');
+        });
+
+        test('Soccer returns H1/H2 periods', () => {
+            assertDeepEquals(getPeriods('soccer-9v9'), ['H1', 'H2'], 'Soccer should have 2 halves');
+        });
+
+        test('Basketball returns Q1/Q2/Q3/Q4 periods', () => {
+            assertDeepEquals(getPeriods('basketball-5v5'), ['Q1', 'Q2', 'Q3', 'Q4'], 'Basketball should have 4 quarters');
+        });
+
+        test('Unknown formation defaults to H1/H2', () => {
+            assertDeepEquals(getPeriods('unknown-sport'), ['H1', 'H2'], 'Unknown formation should default to 2 halves');
+        });
+
+        test('Null formation defaults to H1/H2', () => {
+            assertDeepEquals(getPeriods(null), ['H1', 'H2'], 'Null formation should default to 2 halves');
+        });
+
+        test('All soccer position IDs are unique', () => {
+            const ids = FORMATIONS['soccer-9v9'].positions.map(p => p.id);
+            const unique = new Set(ids);
+            assertEquals(unique.size, ids.length, 'All soccer position IDs must be unique');
+        });
+
+        test('All basketball position IDs are unique', () => {
+            const ids = FORMATIONS['basketball-5v5'].positions.map(p => p.id);
+            const unique = new Set(ids);
+            assertEquals(unique.size, ids.length, 'All basketball position IDs must be unique');
+        });
+
+        // ============================================================
+        // SUITE 2: Rotation Plan — Flatten & Rebuild
+        // ============================================================
+
+        const mockRotationPlan = {
+            H1: { keeper: 'player1', striker: 'player2', sweeper: 'player3' },
+            H2: { keeper: 'player4', striker: 'player1', sweeper: 'player5' }
+        };
+
+        test('flattenRotationPlan produces correct keys', () => {
+            const flat = flattenRotationPlan(mockRotationPlan);
+            assertEquals(flat['H1-keeper'], 'player1', 'H1-keeper should map to player1');
+            assertEquals(flat['H1-striker'], 'player2', 'H1-striker should map to player2');
+            assertEquals(flat['H2-keeper'], 'player4', 'H2-keeper should map to player4');
+        });
+
+        test('flattenRotationPlan handles all entries', () => {
+            const flat = flattenRotationPlan(mockRotationPlan);
+            assertEquals(Object.keys(flat).length, 6, 'Should produce 6 flat entries (3 per period × 2 periods)');
+        });
+
+        test('buildRotationFromGamePlan reconstructs correct structure', () => {
+            const flat = flattenRotationPlan(mockRotationPlan);
+            const rebuilt = buildRotationFromGamePlan({ lineups: flat });
+            assertEquals(rebuilt['H1']['keeper'], 'player1', 'Should rebuild H1 keeper');
+            assertEquals(rebuilt['H2']['striker'], 'player1', 'Should rebuild H2 striker');
+        });
+
+        test('flattenRotationPlan → buildRotationFromGamePlan round-trip is lossless', () => {
+            const flat = flattenRotationPlan(mockRotationPlan);
+            const rebuilt = buildRotationFromGamePlan({ lineups: flat });
+            assertDeepEquals(rebuilt, mockRotationPlan, 'Round-trip should be lossless');
+        });
+
+        test('buildRotationFromGamePlan handles hyphenated position IDs (center-mid-1)', () => {
+            const plan = { H1: { 'center-mid-1': 'player7', 'left-defense': 'player8' } };
+            const flat = flattenRotationPlan(plan);
+            const rebuilt = buildRotationFromGamePlan({ lineups: flat });
+            assertEquals(rebuilt['H1']['center-mid-1'], 'player7', 'Should handle center-mid-1 correctly');
+            assertEquals(rebuilt['H1']['left-defense'], 'player8', 'Should handle left-defense correctly');
+        });
+
+        test('buildRotationFromGamePlan returns empty object for null gamePlan', () => {
+            assertDeepEquals(buildRotationFromGamePlan(null), {}, 'Null gamePlan should return empty object');
+        });
+
+        test('buildRotationFromGamePlan returns empty object for missing lineups', () => {
+            assertDeepEquals(buildRotationFromGamePlan({}), {}, 'Missing lineups should return empty object');
+        });
+
+        // ============================================================
+        // SUITE 3: Mode State Machine
+        // ============================================================
+
+        test('liveStatus=live → gameday mode', () => {
+            assertEquals(determineInitialMode('live', 'scheduled'), 'gameday', 'Live game should be gameday mode');
+        });
+
+        test('liveStatus=completed → wrapup mode', () => {
+            assertEquals(determineInitialMode('completed', 'scheduled'), 'wrapup', 'Completed liveStatus should be wrapup');
+        });
+
+        test('status=completed → wrapup mode (no liveStatus)', () => {
+            assertEquals(determineInitialMode(undefined, 'completed'), 'wrapup', 'Completed status without liveStatus should be wrapup');
+        });
+
+        test('scheduled status → pregame mode', () => {
+            assertEquals(determineInitialMode('scheduled', 'scheduled'), 'pregame', 'Scheduled game should be pregame');
+        });
+
+        test('null liveStatus with non-completed status → pregame mode', () => {
+            assertEquals(determineInitialMode(null, 'scheduled'), 'pregame', 'No liveStatus, not completed → pregame');
+        });
+
+        test('liveStatus takes precedence over status for live detection', () => {
+            assertEquals(determineInitialMode('live', 'completed'), 'gameday', 'liveStatus=live should beat status=completed');
+        });
+
+        // ============================================================
+        // SUITE 4: Player Color System
+        // ============================================================
+
+        test('getPlayerColor returns null for unassigned player', () => {
+            assertNull(getPlayerColor({}, 'player1'), 'Unassigned player should return null color');
+        });
+
+        test('cyclePlayerColor assigns color index 0 on first cycle', () => {
+            const colors = {};
+            const idx = cyclePlayerColor(colors, 'player1');
+            assertEquals(idx, 0, 'First cycle should assign index 0 (Blue)');
+        });
+
+        test('cyclePlayerColor increments on subsequent cycles', () => {
+            const colors = {};
+            cyclePlayerColor(colors, 'player1'); // 0
+            cyclePlayerColor(colors, 'player1'); // 1
+            const idx = cyclePlayerColor(colors, 'player1'); // 2
+            assertEquals(idx, 2, 'Third cycle should be index 2 (Yellow)');
+        });
+
+        test('cyclePlayerColor wraps around after 8 colors', () => {
+            const colors = { 'player1': 7 }; // last color (Gray)
+            const idx = cyclePlayerColor(colors, 'player1');
+            assertEquals(idx, 0, 'Should wrap back to index 0 after 8th color');
+        });
+
+        test('getPlayerColor returns correct color object after assignment', () => {
+            const colors = { 'player1': 1 }; // Green
+            const color = getPlayerColor(colors, 'player1');
+            assertNotNull(color, 'Should return a color object');
+            assertEquals(color.name, 'Green', 'Index 1 should be Green');
+        });
+
+        test('Player colors are independent per player', () => {
+            const colors = {};
+            cyclePlayerColor(colors, 'player1');
+            cyclePlayerColor(colors, 'player1');
+            // player2 is still unassigned
+            assertNull(getPlayerColor(colors, 'player2'), 'player2 color should be independent of player1');
+        });
+
+        test('PLAYER_COLORS has exactly 8 entries', () => {
+            assertEquals(PLAYER_COLORS.length, 8, 'Should have exactly 8 color options');
+        });
+
+        test('Every color entry has bg, text, border, and name', () => {
+            PLAYER_COLORS.forEach((c, i) => {
+                assertTrue(c.bg, `Color ${i} missing bg`);
+                assertTrue(c.text, `Color ${i} missing text`);
+                assertTrue(c.border, `Color ${i} missing border`);
+                assertTrue(c.name, `Color ${i} missing name`);
+            });
+        });
+
+        // ============================================================
+        // SUITE 5: On-Field Map / Sub Logic
+        // ============================================================
+
+        const mockPlayers = [
+            { id: 'p1', name: 'Alice', number: '7' },
+            { id: 'p2', name: 'Bob', number: '9' },
+            { id: 'p3', name: 'Carol', number: '3' },
+            { id: 'p4', name: 'Dave', number: '11' },
+        ];
+
+        test('buildOnFieldMap returns planned lineup when no actual subs', () => {
+            const plan = { H1: { keeper: 'p1', striker: 'p2' } };
+            const map = buildOnFieldMap(plan, {}, mockPlayers, 'H1');
+            assertEquals(map['keeper'], 'p1', 'Keeper should be p1 from plan');
+            assertEquals(map['striker'], 'p2', 'Striker should be p2 from plan');
+        });
+
+        test('buildOnFieldMap applies actual sub over planned lineup', () => {
+            const plan = { H1: { keeper: 'p1', striker: 'p2' } };
+            const actual = {
+                H1: { 'sub-1': [{ position: 'striker', out: 'Bob', in: 'Carol', appliedAt: '2024-01-01' }] }
+            };
+            const map = buildOnFieldMap(plan, actual, mockPlayers, 'H1');
+            assertEquals(map['keeper'], 'p1', 'Keeper unchanged by sub');
+            assertEquals(map['striker'], 'p3', 'Striker should be updated to Carol (p3) after sub');
+        });
+
+        test('buildOnFieldMap ignores subs for unknown player names', () => {
+            const plan = { H1: { keeper: 'p1' } };
+            const actual = {
+                H1: { 'sub-1': [{ position: 'keeper', out: 'p1', in: 'NoSuchPlayer', appliedAt: '2024-01-01' }] }
+            };
+            const map = buildOnFieldMap(plan, actual, mockPlayers, 'H1');
+            assertEquals(map['keeper'], 'p1', 'Should keep original if sub player not found');
+        });
+
+        test('buildOnFieldMap handles empty rotation actual', () => {
+            const plan = { H1: { keeper: 'p1' } };
+            const map = buildOnFieldMap(plan, {}, mockPlayers, 'H1');
+            assertEquals(map['keeper'], 'p1', 'Should use plan when actual is empty');
+        });
+
+        test('buildOnFieldMap returns empty map for unknown period', () => {
+            const plan = { H1: { keeper: 'p1' } };
+            const map = buildOnFieldMap(plan, {}, mockPlayers, 'H2');
+            assertEquals(Object.keys(map).length, 0, 'H2 with no plan should return empty map');
+        });
+
+        // ============================================================
+        // SUITE 6: Balance Playing Time
+        // ============================================================
+
+        const twoPlayers = [{ id: 'p1' }, { id: 'p2' }];
+        const ninePlayers = Array.from({ length: 9 }, (_, i) => ({ id: `p${i + 1}` }));
+
+        test('balancePlayingTime returns a plan for all periods', () => {
+            const plan = balancePlayingTime('soccer-9v9', ninePlayers);
+            assertTrue('H1' in plan, 'Plan should have H1');
+            assertTrue('H2' in plan, 'Plan should have H2');
+        });
+
+        test('balancePlayingTime fills all positions', () => {
+            const plan = balancePlayingTime('soccer-9v9', ninePlayers);
+            assertEquals(Object.keys(plan['H1']).length, 9, 'H1 should have 9 position assignments');
+        });
+
+        test('balancePlayingTime cycles players when fewer than positions', () => {
+            const plan = balancePlayingTime('soccer-9v9', twoPlayers);
+            const assigned = new Set(Object.values(plan['H1']));
+            assertTrue(assigned.size <= 2, 'Should only use the 2 available players');
+        });
+
+        test('balancePlayingTime returns empty when no going players', () => {
+            const plan = balancePlayingTime('soccer-9v9', []);
+            assertDeepEquals(plan, {}, 'No going players should return empty plan');
+        });
+
+        test('balancePlayingTime works for basketball quarters', () => {
+            const plan = balancePlayingTime('basketball-5v5', [{ id: 'p1' }, { id: 'p2' }, { id: 'p3' }, { id: 'p4' }, { id: 'p5' }]);
+            assertTrue('Q1' in plan && 'Q2' in plan && 'Q3' in plan && 'Q4' in plan, 'Basketball should have all 4 quarters');
+        });
+
+        // ============================================================
+        // SUITE 7: escapeHtml / XSS Prevention
+        // ============================================================
+
+        test('escapeHtml escapes < and >', () => {
+            assertEquals(escapeHtml('<script>'), '&lt;script&gt;', 'Should escape angle brackets');
+        });
+
+        test('escapeHtml escapes ampersand', () => {
+            assertEquals(escapeHtml('A & B'), 'A &amp; B', 'Should escape ampersand');
+        });
+
+        test('escapeHtml escapes double quotes', () => {
+            assertEquals(escapeHtml('"hello"'), '&quot;hello&quot;', 'Should escape double quotes');
+        });
+
+        test('escapeHtml escapes single quotes', () => {
+            assertEquals(escapeHtml("O'Brien"), 'O&#039;Brien', 'Should escape single quotes');
+        });
+
+        test('escapeHtml returns empty string for null', () => {
+            assertEquals(escapeHtml(null), '', 'Null should return empty string');
+        });
+
+        test('escapeHtml returns empty string for undefined', () => {
+            assertEquals(escapeHtml(undefined), '', 'Undefined should return empty string');
+        });
+
+        test('escapeHtml passes through safe strings unchanged', () => {
+            assertEquals(escapeHtml('Alice #7'), 'Alice #7', 'Safe string should be unchanged');
+        });
+
+        test('escapeHtml handles XSS payload in player name', () => {
+            const xss = '<img src=x onerror=alert(1)>';
+            const result = escapeHtml(xss);
+            assertFalse(result.includes('<img'), 'XSS payload should be escaped');
+            assertTrue(result.includes('&lt;img'), 'Should contain escaped version');
+        });
+
+        // ============================================================
+        // SUITE 8: Access Control Logic
+        // ============================================================
+
+        function hasFullAccess(team, user) {
+            if (!team || !user) return false;
+            if (team.ownerId === user.uid) return true;
+            const email = (user.email || '').toLowerCase();
+            return (team.adminEmails || []).map(e => e.toLowerCase()).includes(email);
+        }
+
+        const mockTeam = {
+            ownerId: 'uid-owner',
+            adminEmails: ['coach@school.com', 'admin@school.com']
+        };
+
+        test('Team owner has full access', () => {
+            assertTrue(hasFullAccess(mockTeam, { uid: 'uid-owner', email: 'owner@test.com' }),
+                'Owner should have access');
+        });
+
+        test('Listed admin email has full access', () => {
+            assertTrue(hasFullAccess(mockTeam, { uid: 'uid-other', email: 'coach@school.com' }),
+                'Admin email should have access');
+        });
+
+        test('Admin email check is case-insensitive', () => {
+            assertTrue(hasFullAccess(mockTeam, { uid: 'uid-other', email: 'COACH@SCHOOL.COM' }),
+                'Uppercase admin email should still have access');
+        });
+
+        test('Non-admin, non-owner has no full access', () => {
+            assertFalse(hasFullAccess(mockTeam, { uid: 'uid-parent', email: 'parent@test.com' }),
+                'Parent should not have full access');
+        });
+
+        test('hasFullAccess returns false for null user', () => {
+            assertFalse(hasFullAccess(mockTeam, null), 'Null user should return false');
+        });
+
+        test('hasFullAccess returns false for null team', () => {
+            assertFalse(hasFullAccess(null, { uid: 'uid-owner' }), 'Null team should return false');
+        });
+
+        test('hasFullAccess returns false for empty adminEmails', () => {
+            const teamNoAdmins = { ownerId: 'uid-owner', adminEmails: [] };
+            assertFalse(hasFullAccess(teamNoAdmins, { uid: 'uid-other', email: 'rando@test.com' }),
+                'Non-owner with no admins should not have access');
+        });
+
+        // ============================================================
+        // SUITE 9: Coaching Note Types
+        // ============================================================
+
+        const COACHING_TYPE_COLORS = {
+            substitution: 'text-orange-600',
+            Timeout: 'text-amber-600',
+            'Formation Change': 'text-blue-600',
+            Injury: 'text-red-600',
+            note: 'text-gray-700'
+        };
+
+        function getCoachingNoteColor(type) {
+            return COACHING_TYPE_COLORS[type] || 'text-gray-700';
+        }
+
+        test('Timeout type renders amber color', () => {
+            assertEquals(getCoachingNoteColor('Timeout'), 'text-amber-600', 'Timeout should be amber');
+        });
+
+        test('Formation Change type renders blue color', () => {
+            assertEquals(getCoachingNoteColor('Formation Change'), 'text-blue-600', 'Formation Change should be blue');
+        });
+
+        test('Injury type renders red color', () => {
+            assertEquals(getCoachingNoteColor('Injury'), 'text-red-600', 'Injury should be red');
+        });
+
+        test('Substitution type renders orange color', () => {
+            assertEquals(getCoachingNoteColor('substitution'), 'text-orange-600', 'Substitution should be orange');
+        });
+
+        test('Unknown type defaults to gray', () => {
+            assertEquals(getCoachingNoteColor('random'), 'text-gray-700', 'Unknown type should default to gray');
+        });
+
+        test('Note type renders gray', () => {
+            assertEquals(getCoachingNoteColor('note'), 'text-gray-700', 'Note type should be gray');
+        });
+
+        // ============================================================
+        // SUITE 10: localStorage Player Color Persistence
+        // ============================================================
+
+        test('Player colors can be stored and retrieved from localStorage', () => {
+            const testKey = 'playerColors-test-team-999';
+            const testColors = { 'player1': 3, 'player2': 5 };
+            localStorage.setItem(testKey, JSON.stringify(testColors));
+            const retrieved = JSON.parse(localStorage.getItem(testKey));
+            assertEquals(retrieved['player1'], 3, 'player1 color index should be 3');
+            assertEquals(retrieved['player2'], 5, 'player2 color index should be 5');
+            localStorage.removeItem(testKey);
+        });
+
+        test('Missing localStorage key returns null', () => {
+            localStorage.removeItem('playerColors-nonexistent');
+            assertNull(localStorage.getItem('playerColors-nonexistent'), 'Missing key should return null');
+        });
+
+        test('Player colors persist across simulated page reload', () => {
+            const testKey = 'playerColors-reload-test';
+            const original = { 'alice': 2, 'bob': 6 };
+            localStorage.setItem(testKey, JSON.stringify(original));
+            // Simulate reload: retrieve and parse
+            const loaded = JSON.parse(localStorage.getItem(testKey) || '{}');
+            assertEquals(loaded['alice'], 2, 'alice color should persist');
+            assertEquals(loaded['bob'], 6, 'bob color should persist');
+            localStorage.removeItem(testKey);
+        });
+
+        test('Corrupted localStorage color data is handled gracefully', () => {
+            const testKey = 'playerColors-corrupt-test';
+            localStorage.setItem(testKey, 'NOT VALID JSON {{{{');
+            let colors = {};
+            try {
+                const saved = localStorage.getItem(testKey);
+                if (saved) colors = JSON.parse(saved);
+            } catch (e) {
+                // Gracefully ignored — colors remains {}
+            }
+            assertDeepEquals(colors, {}, 'Corrupted data should fall back to empty colors');
+            localStorage.removeItem(testKey);
+        });
+
+        // ============================================================
+        // DISPLAY RESULTS
+        // ============================================================
+
+        const passCount = results.filter(r => r.pass).length;
+        const failCount = results.filter(r => !r.pass).length;
+
+        const suites = [
+            { name: 'Suite 1: Formation & Period Logic', count: 8 },
+            { name: 'Suite 2: Rotation Plan — Flatten & Rebuild', count: 7 },
+            { name: 'Suite 3: Mode State Machine', count: 6 },
+            { name: 'Suite 4: Player Color System', count: 8 },
+            { name: 'Suite 5: On-Field Map / Sub Logic', count: 5 },
+            { name: 'Suite 6: Balance Playing Time', count: 5 },
+            { name: 'Suite 7: escapeHtml / XSS Prevention', count: 8 },
+            { name: 'Suite 8: Access Control Logic', count: 7 },
+            { name: 'Suite 9: Coaching Note Types', count: 6 },
+            { name: 'Suite 10: localStorage Color Persistence', count: 4 },
+        ];
+
+        const container = document.getElementById('test-results');
+
+        let summaryClass = failCount === 0 ? 'summary-pass' : 'summary-fail';
+        let html = `
+            <div class="test-section">
+                <h2>Summary</h2>
+                <p class="${summaryClass}">✅ Passed: ${passCount} &nbsp;|&nbsp; ❌ Failed: ${failCount} &nbsp;|&nbsp; Total: ${results.length}</p>
+                ${failCount > 0 ? '<p style="color:#dc2626">⚠️ Some tests failed — see details below.</p>' : '<p style="color:#16a34a">All tests passed!</p>'}
+            </div>
+        `;
+
+        let resultIdx = 0;
+        suites.forEach(suite => {
+            html += `<div class="test-section"><h2>${suite.name}</h2>`;
+            const suiteResults = results.slice(resultIdx, resultIdx + suite.count);
+            resultIdx += suite.count;
+            suiteResults.forEach(result => {
+                const cls = result.pass ? 'pass' : 'fail';
+                const icon = result.pass ? '✅' : '❌';
+                html += `
+                    <div class="test-case ${cls}">
+                        <div class="test-name">${icon} ${result.name}</div>
+                        ${result.error ? `<div class="test-result">Error: ${result.error}</div>` : ''}
+                    </div>
+                `;
+            });
+            const suitePass = suiteResults.filter(r => r.pass).length;
+            html += `<p style="font-size:0.85em;color:#666;margin-top:8px">${suitePass}/${suiteResults.length} passed</p>`;
+            html += '</div>';
+        });
+
+        container.innerHTML = html;
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `game-day.html` — unified coaching surface for the full game lifecycle (pre-game → live → wrap-up)
- Add `subscribeAggregatedStats()` to `js/db.js` for real-time stat listeners during live games
- Add **Game Day** nav card to `team-admin-banner.js` (flag icon, 9-column grid)
- Add **Command Center** button to each non-cancelled game row in `edit-schedule.html`
- Add `test-game-day.html` — 64 test cases across 10 suites

## Feature Details

### Pre-Game Mode (3-column layout)
- **Left rail:** game info card, "From Last Game" weakness feed, RSVP breakdown by bucket (Going / Maybe / Not Going / No Response), scouting notes (auto-save on blur), AI Coach Focus directive
- **Center:** AI Coach chat with Ask / Lineup mode toggle; lineup JSON proposals render with Accept-to-Canvas button
- **Right:** Formation picker (soccer-9v9 / basketball-5v5), H1/H2 period tabs, drag-and-drop rotation canvas with **color-coded player chips** (8 colors, click dot to cycle, persisted to localStorage), playing time balance bars, Save Lineup

### Game Day Mode
- Dark top bar with live pulse dot, score (±1 buttons), period chip, Coach / Stats toggle
- **Coach View:** Visual **field diagram** (top-down green pitch / basketball court) with player blocks spatially positioned at their formation coordinates — updates live on subs. Bench row shown below diagram.
- **Stats View:** Player table from `statTrackerConfig.columns`, large tap targets, Undo Last Stat
- Coaching log: Timeout / Formation Change / Injury quick-buttons + free text, saved to `game.coachingNotes[]`

### Wrap-Up Panel (modal)
- Editable final score, post-game notes
- AI Analyze → saves `practiceFeedItems[]` to game doc (feeds "From Last Game" in next pre-game)
- AI Summary → saves `game.summary`
- Done → navigates to `game.html` match report

### Addresses Issue #29
- Color-coded player blocks in rotation canvas (coaches group players by play style/tendency)
- Visual whiteboard-style field diagram in game day Coach View (spatial top-down layout, updates on every sub — mirrors the physical whiteboard workflow described in the issue)

## Bug Fixes (caught in code review)
- `user` variable was out of scope in `initPage()` → changed to `state.user`
- `renderPreGame()` didn't call `renderPeriodTabs()` for saved game plans → period tabs now render on load
- `switchPeriodTab()` didn't refresh bench pool → players now update when switching H1 ↔ H2
- Coaching log quick-buttons didn't pass `type` arg → Timeout/Injury/Formation Change now color correctly

## Test Plan
- [ ] `python3 -m http.server 8000` → open `http://localhost:8000/test-game-day.html` → all 64 tests pass
- [ ] Navigate to `edit-schedule.html?teamId=<id>` → verify orange "Command Center" button appears on game rows, absent on cancelled games
- [ ] Open `game-day.html?teamId=<id>&gameId=<id>` as team owner → loads Pre-Game mode
- [ ] Select soccer-9v9 formation → period tabs, rotation canvas, bench pool all appear
- [ ] Click color dot on a player chip → chip cycles through 8 colors; reload page → color persists
- [ ] Drag a player to a position → canvas cell shows colored left-border + colored pill
- [ ] Switch H1 → H2 → bench pool updates to reflect different assignments
- [ ] Save Lineup → confirm `game.gamePlan` updated in Firestore
- [ ] Set game `liveStatus=live` in Firebase console → mode-switch prompt appears
- [ ] In Game Day / Coach View → verify field diagram shows correct formation layout with player names
- [ ] Apply Sub → field diagram updates immediately (player moves to new position)
- [ ] Stats View → tap stat button → `aggregatedStats` doc increments in Firestore
- [ ] Wrap-Up → enter score, click Analyze Game → `practiceFeedItems` saved; click Done → redirects to match report
- [ ] Sign in as parent → redirected away (Game Day is coach/admin only)
- [ ] Verify "Game Day" nav card visible in team admin banner on all team pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)