### PR TITLE
Allow coaches and admins to access Game Day planning

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -566,6 +566,7 @@
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, formatTimeRange, getDefaultEndTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, generateSeriesId, expandRecurrence, formatRecurrence, shareOrCopy, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
+        import { getTeamAccessInfo } from './js/team-access.js';
         import { Timestamp } from "./js/firebase.js?v=9";
         import { getApp } from './js/vendor/firebase-app.js';
         import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
@@ -664,10 +665,8 @@
         let currentTeam = null;
         function hasAccess(team, user) {
             if (!team || !user) return false;
-            if (team.ownerId === user.uid) return true;
-            if (user.isAdmin) return true;
-            const email = (user.email || '').toLowerCase();
-            return (team.adminEmails || []).map(e => e.toLowerCase()).includes(email);
+            const accessInfo = getTeamAccessInfo(user, { ...team, id: team.id || currentTeamId });
+            return accessInfo.hasAccess && accessInfo.accessLevel === 'full';
         }
 
         async function init() {

--- a/game-day.html
+++ b/game-day.html
@@ -650,7 +650,7 @@
                 // Access check — full access only
                 const accessInfo = getTeamAccessInfo(state.user, { ...team, id: teamId });
                 if (!accessInfo.hasAccess || accessInfo.accessLevel !== 'full') {
-                    window.location.href = `team.html#teamId=${teamId}&message=Game+Day+is+for+coaches+only`;
+                    window.location.href = `team.html#teamId=${teamId}&message=Game+Day+is+for+coaches+and+admins+only`;
                     return;
                 }
 

--- a/js/team-access.js
+++ b/js/team-access.js
@@ -1,0 +1,37 @@
+/**
+ * Check whether a user has full team management access.
+ * Full access means owner, team admin email, platform admin, or coach assignment.
+ */
+export function hasFullTeamAccess(user, team) {
+  if (!user || !team) return false;
+
+  const isOwner = team.ownerId === user.uid;
+  const normalizedEmail = (user.email || '').toLowerCase();
+  const adminEmails = (team.adminEmails || []).map((email) => String(email || '').toLowerCase());
+  const isTeamAdmin = adminEmails.includes(normalizedEmail);
+  const isPlatformAdmin = user.isAdmin === true;
+  const isCoach = (user.coachOf || []).includes(team.id);
+
+  return isOwner || isTeamAdmin || isPlatformAdmin || isCoach;
+}
+
+/**
+ * Determine user's access level for a team.
+ * @returns {{ hasAccess: boolean, accessLevel: 'full'|'parent'|null, exitUrl: string }}
+ */
+export function getTeamAccessInfo(user, team) {
+  if (!user || !team) {
+    return { hasAccess: false, accessLevel: null, exitUrl: 'index.html' };
+  }
+
+  if (hasFullTeamAccess(user, team)) {
+    return { hasAccess: true, accessLevel: 'full', exitUrl: 'dashboard.html' };
+  }
+
+  const isParent = (user.parentOf || []).some((p) => p.teamId === team.id);
+  if (isParent) {
+    return { hasAccess: true, accessLevel: 'parent', exitUrl: 'parent-dashboard.html' };
+  }
+
+  return { hasAccess: false, accessLevel: null, exitUrl: 'index.html' };
+}

--- a/js/team-admin-banner.js
+++ b/js/team-admin-banner.js
@@ -1,36 +1,7 @@
 import { escapeHtml } from './utils.js?v=8';
+import { getTeamAccessInfo } from './team-access.js';
 
-/**
- * Determine user's access level for a team
- * @param {Object} user - Firebase user object with enriched profile (coachOf, parentOf, isAdmin)
- * @param {Object} team - Team object with ownerId, adminEmails
- * @returns {{ hasAccess: boolean, accessLevel: 'full'|'parent'|null, exitUrl: string }}
- */
-export function getTeamAccessInfo(user, team) {
-  if (!user || !team) {
-    return { hasAccess: false, accessLevel: null, exitUrl: 'index.html' };
-  }
-
-  // Check for full access: owner, admin, coach, or platform admin
-  const isOwner = team.ownerId === user.uid;
-  const normalizedEmail = (user.email || '').toLowerCase();
-  const adminEmails = (team.adminEmails || []).map(email => String(email || '').toLowerCase());
-  const isTeamAdmin = adminEmails.includes(normalizedEmail);
-  const isPlatformAdmin = user.isAdmin === true;
-  const isCoach = (user.coachOf || []).includes(team.id);
-
-  if (isOwner || isTeamAdmin || isPlatformAdmin || isCoach) {
-    return { hasAccess: true, accessLevel: 'full', exitUrl: 'dashboard.html' };
-  }
-
-  // Check for parent access
-  const isParent = (user.parentOf || []).some(p => p.teamId === team.id);
-  if (isParent) {
-    return { hasAccess: true, accessLevel: 'parent', exitUrl: 'parent-dashboard.html' };
-  }
-
-  return { hasAccess: false, accessLevel: null, exitUrl: 'index.html' };
-}
+export { getTeamAccessInfo } from './team-access.js';
 
 function icon(name) {
   if (name === 'view') {

--- a/tests/unit/team-access.test.js
+++ b/tests/unit/team-access.test.js
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { hasFullTeamAccess, getTeamAccessInfo } from '../../js/team-access.js';
+
+const TEAM = {
+  id: 'team-1',
+  ownerId: 'owner-1',
+  adminEmails: ['admin@example.com']
+};
+
+describe('team access helpers', () => {
+  it('grants full access to team owner', () => {
+    expect(hasFullTeamAccess({ uid: 'owner-1' }, TEAM)).toBe(true);
+  });
+
+  it('grants full access to team admin email (case-insensitive)', () => {
+    expect(hasFullTeamAccess({ uid: 'u1', email: 'ADMIN@EXAMPLE.COM' }, TEAM)).toBe(true);
+  });
+
+  it('grants full access to platform admin', () => {
+    expect(hasFullTeamAccess({ uid: 'u2', isAdmin: true }, TEAM)).toBe(true);
+  });
+
+  it('grants full access to assigned coach', () => {
+    expect(hasFullTeamAccess({ uid: 'u3', coachOf: ['team-1'] }, TEAM)).toBe(true);
+  });
+
+  it('returns parent access level for parent-linked users', () => {
+    expect(getTeamAccessInfo({ uid: 'u4', parentOf: [{ teamId: 'team-1', playerId: 'p1' }] }, TEAM)).toEqual({
+      hasAccess: true,
+      accessLevel: 'parent',
+      exitUrl: 'parent-dashboard.html'
+    });
+  });
+
+  it('returns no access for unrelated users', () => {
+    expect(getTeamAccessInfo({ uid: 'u5', email: 'random@example.com' }, TEAM)).toEqual({
+      hasAccess: false,
+      accessLevel: null,
+      exitUrl: 'index.html'
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add shared team access helper for consistent full-access checks (owner, team admin, global admin, coach)
- update edit-schedule.html access gate to use shared helper so coaches can access schedule/Game Day entry points
- keep getTeamAccessInfo export stable via team-admin-banner.js re-export
- clarify Game Day redirect message to mention coaches and admins
- add unit tests for team access matrix

## Testing
- ./node_modules/.bin/vitest run tests/unit
