### PR TITLE
Enable viewer chat whenever liveStatus is live

### DIFF
--- a/js/live-game-chat.js
+++ b/js/live-game-chat.js
@@ -1,0 +1,20 @@
+function toDate(value) {
+  if (!value) return null;
+  if (typeof value?.toDate === 'function') return value.toDate();
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function isSameDay(left, right) {
+  if (!left || !right) return false;
+  return left.getFullYear() === right.getFullYear() &&
+    left.getMonth() === right.getMonth() &&
+    left.getDate() === right.getDate();
+}
+
+export function isViewerChatEnabled(game, { isReplay = false, now = new Date() } = {}) {
+  if (isReplay) return false;
+  if (game?.liveStatus === 'live') return true;
+  const gameDate = toDate(game?.date);
+  return isSameDay(gameDate, now);
+}

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -16,6 +16,7 @@ import {
 } from './db.js?v=14';
 import { getUrlParams, escapeHtml, renderHeader, renderFooter, formatShortDate, formatTime, shareOrCopy } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=9';
+import { isViewerChatEnabled } from './live-game-chat.js?v=1';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
 
@@ -1288,18 +1289,7 @@ function handleGameUpdate(gameDoc) {
 }
 
 function updateChatAvailability() {
-  if (state.isReplay) {
-    state.chatEnabled = false;
-  } else {
-    const gameDate = state.game?.date?.toDate ? state.game.date.toDate() : (state.game?.date ? new Date(state.game.date) : null);
-    const today = new Date();
-    const isSameDay = gameDate
-      ? gameDate.getFullYear() === today.getFullYear() &&
-        gameDate.getMonth() === today.getMonth() &&
-        gameDate.getDate() === today.getDate()
-      : false;
-    state.chatEnabled = isSameDay;
-  }
+  state.chatEnabled = isViewerChatEnabled(state.game, { isReplay: state.isReplay });
 
   if (els.chatInput) {
     if (state.chatEnabled) {

--- a/tests/unit/live-game-chat.test.js
+++ b/tests/unit/live-game-chat.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { isViewerChatEnabled } from '../../js/live-game-chat.js';
+
+describe('live game chat availability', () => {
+  it('enables chat when the game is scheduled for today', () => {
+    const now = new Date('2026-02-24T18:00:00.000Z');
+    const game = { date: '2026-02-24T01:00:00.000Z', liveStatus: 'scheduled' };
+    expect(isViewerChatEnabled(game, { now })).toBe(true);
+  });
+
+  it('disables chat in replay mode', () => {
+    const now = new Date('2026-02-24T18:00:00.000Z');
+    const game = { date: '2026-02-24T01:00:00.000Z', liveStatus: 'live' };
+    expect(isViewerChatEnabled(game, { isReplay: true, now })).toBe(false);
+  });
+
+  it('keeps chat enabled for live games even if the scheduled date is not today', () => {
+    const now = new Date('2026-02-24T18:00:00.000Z');
+    const game = { date: '2026-02-23T23:30:00.000Z', liveStatus: 'live' };
+    expect(isViewerChatEnabled(game, { now })).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #36

## What changed
- Added `js/live-game-chat.js` with a focused `isViewerChatEnabled` helper for live-game chat eligibility.
- Added `tests/unit/live-game-chat.test.js` to reproduce and guard the regression where chat was disabled for active live games whose scheduled date is not the current day.
- Updated `js/live-game.js` to use the helper inside `updateChatAvailability`.

## Why
The previous logic only enabled chat when the scheduled game date matched the viewer's current local day. That incorrectly disabled chat for legitimate active live games that crossed midnight, were rescheduled, or had timezone/date drift.

## Validation
- `pnpm dlx vitest run tests/unit/live-game-chat.test.js tests/unit/live-tracker-notes.test.js tests/unit/team-access.test.js`