### PR TITLE
Fix parent dashboard take-home packet visibility in schedule

### DIFF
--- a/docs/pr-notes/architecture.md
+++ b/docs/pr-notes/architecture.md
@@ -1,27 +1,28 @@
-# Architecture Role Notes (League Link + Standings)
-
-## Objective
-Add external league standings visibility without changing existing schedule ingestion or local scoring system behavior.
-
-## Current Architecture
-- Team metadata is managed in `edit-team.html` and persisted by existing Firestore team write paths.
-- Team page computes season record from local game data only.
-- External schedule ingestion uses ICS parsing (`fetchAndParseCalendar`) and does not parse standings.
+# Architecture Role Notes (Parent Take-Home Packet Visibility)
 
 ## Decision
-Introduce a separate league standings module (`js/league-standings.js`) and keep it orthogonal to ICS schedule ingestion.
+Add a packet-context resolver that returns both `sessionId` and `homePacket` for a schedule event.
 
-## Controls and Blast Radius
-- Current blast radius: local record visibility only.
-- New blast radius: read-only outbound fetch to league URL + proxy fallback attempts for standings parsing.
-- Control equivalence: no broadened team data access, no new write permissions, no schema migration requirement.
+## Design
+- Module: `js/parent-dashboard-packets.js`
+- Existing path (unchanged): resolve by explicit IDs (`practiceSessionId`, direct `eventId`, recurring `masterId__date`).
+- New fallback path:
+  - constrain candidates to same `teamId`
+  - constrain candidates to same calendar day as event date
+  - choose nearest-time candidate (title tie-breaker)
+- Output: `{ sessionId, homePacket }`
 
-## Tradeoffs
-1. Parse TeamSideline HTML directly (selected): immediate value with no backend service.
-2. Build server-side adapter: more stable parsing but adds infra/toil.
-3. Manual standings entry: low technical risk but high coach toil and stale data risk.
+## Integration Points
+- `parent-dashboard.html` schedule list rendering
+- `parent-dashboard.html` calendar day modal rendering
+- Both now use packet-context fallback when `event.practiceHomePacket` is absent.
 
-## Rollback Plan
-- Remove standings card render in `team.html`.
-- Remove `leagueUrl` field usage in `edit-team.html`.
-- Revert `js/league-standings.js` and associated tests.
+## Blast Radius
+- UI/read-only composition changes only.
+- No write-path changes.
+- No schema migration.
+- No auth/rules changes required.
+
+## Controls
+- Team-scoped fallback prevents cross-team packet lookup.
+- Existing session-ID mapping remains primary source to minimize false matches.

--- a/docs/pr-notes/code-plan.md
+++ b/docs/pr-notes/code-plan.md
@@ -1,27 +1,21 @@
-# Code Role Notes (League Link + Standings)
+# Code Role Notes (Parent Take-Home Packet Visibility)
 
-## Objective
-Implement league URL capture and standings display with test coverage.
+## Implementation Summary
+- Enhanced resolver module to provide packet context fallback:
+  - `resolvePracticePacketContextForEvent(event, sessions)` in `js/parent-dashboard-packets.js`
+- Updated parent dashboard rendering to use packet context fallback in:
+  - schedule list cards
+  - calendar day modal
+- Bumped module import cache key to ensure clients pull updated resolver:
+  - `parent-dashboard.html` imports `parent-dashboard-packets.js?v=2`
 
-## Code Changes
-- Added `leagueUrl` field in team editor form and save/load flow:
-  - `edit-team.html`
-- Added standalone standings module:
-  - `js/league-standings.js`
-  - Parses TeamSideline standings table with W/L/T/PCT/PF/PA/PD extraction.
-  - Provides matching helper and resilient fetch strategy (direct + proxy fallback).
-- Integrated standings display into team page:
-  - `team.html`
-  - Adds league link badge in header.
-  - Adds "League Standings" season overview card.
+## Tests Updated
+- `tests/unit/parent-dashboard-packets.test.js`
+  - added fallback-by-team/date case
+  - added cross-team safety case
 
-## Tests Added
-- `tests/unit/league-standings.test.js`
-  - parser extraction of W/L/T row values
-  - normalization/matching behavior
-  - no-table fallback behavior
-
-## Success Criteria
-- Team settings persist `leagueUrl`.
-- Team page shows league standings when URL is configured.
-- Unit tests pass for parser/matching logic.
+## Firebase / Rules
+- Verified `firestore.rules` already permits required reads/writes for parent packet flows:
+  - `practiceSessions`
+  - `practiceSessions/{sessionId}/packetCompletions`
+- No rules changes required for this feature fix.

--- a/docs/pr-notes/qa.md
+++ b/docs/pr-notes/qa.md
@@ -1,21 +1,26 @@
-# QA Role Notes (League Link + Standings)
+# QA Role Notes (Parent Take-Home Packet Visibility)
 
-## Objective
-Validate that league URL persistence and standings extraction work and do not regress core team page behavior.
+## Test Objective
+Validate that packet CTA visibility is robust across schedule render paths and safe in fallback mode.
 
 ## Automated Validation
-- `./node_modules/.bin/vitest run tests/unit/league-standings.test.js`
-- `./node_modules/.bin/vitest run tests/unit/live-tracker-notes.test.js tests/unit/drills-issue28-helpers.test.js`
-- `./node_modules/.bin/vitest run tests/unit/*.test.js` (14 tests passed)
-- `node --check js/league-standings.js`
+- `./node_modules/.bin/vitest run tests/unit/parent-dashboard-packets.test.js`
+- `./node_modules/.bin/vitest run tests/unit`
+- `node --check js/parent-dashboard-packets.js`
+- `node --check` on extracted module from `parent-dashboard.html`
 
-## Manual Validation Checklist
-1. Open `edit-team.html` for an existing team, set `League Link`, save, reload, and confirm field persists.
-2. Open `team.html` for that team and confirm:
-   - header shows `League Page` link.
-   - season overview shows `League Standings` card with W/L-based record.
-3. Remove league link and confirm graceful fallback (`No league link configured`).
+## Added Coverage
+- fallback resolves packet context by same-team + same-day nearest session
+- fallback does not cross team boundaries
+- existing direct and recurring resolution behaviors remain covered
+
+## Manual Verification Checklist
+1. Parent Dashboard -> Schedule list: practice with packet shows `Open Packet`.
+2. Parent Dashboard -> Calendar -> day modal: same practice shows `Open Packet`.
+3. Click `Open Packet`: side modal loads expected packet blocks.
+4. Practice without packet: no packet CTA appears.
+5. Multi-team parent account: packet CTA never leaks across teams.
 
 ## Residual Risk
-- Third-party markup changes in TeamSideline can break parser assumptions.
-- Browser CORS/proxy variability may occasionally block standings fetch.
+- If multiple same-team practices occur on the same day at similar times with missing linkage, nearest-time fallback may pick the wrong session.
+- This is bounded and still safer than current hidden-CTA behavior.

--- a/docs/pr-notes/requirements.md
+++ b/docs/pr-notes/requirements.md
@@ -1,30 +1,24 @@
-# Requirements Role Notes (League Link + Standings)
+# Requirements Role Notes (Parent Take-Home Packet Visibility)
 
 ## Objective
-Enable coaches to save an external league URL and show league W/L/T standings on the team page.
+Ensure parents can reliably open a generated take-home packet from the parent dashboard schedule experience.
 
 ## Current State
-- `edit-team.html` has no `leagueUrl` field.
-- Team page season record uses only local completed game scores from Firestore.
-- `edit-schedule.html` calendar links are designed for ICS ingestion, not standings pages.
+- `Open Packet` in schedule list/calendar only appears when `practiceHomePacket` is attached directly to the rendered event.
+- Event->session linkage can miss in some recurring/calendar cases even when a valid practice session packet exists.
+- Result: packet exists in session data, but no `Open Packet` CTA appears in schedule.
 
 ## Proposed State
-- Add `leagueUrl` to team settings in `edit-team.html`.
-- Persist `leagueUrl` in team document through existing `createTeam/updateTeam` flow.
-- Fetch and parse TeamSideline standings table on `team.html` and display a league card with record metrics.
+- Keep existing direct linkage path.
+- Add a safe fallback lookup so schedule views can resolve packet context from known practice sessions when direct event linkage is missing.
+- Preserve tenant/team boundaries and avoid cross-team packet exposure.
 
-## Risk Surface / Blast Radius
-- UI + read-only fetch changes limited to:
-  - `edit-team.html`
-  - `team.html`
-  - `js/league-standings.js`
-- No auth rules, write paths, or tenant-access controls changed.
-- External dependency risk: third-party markup changes can degrade standings parsing.
+## User-Facing Acceptance Criteria
+1. Parent sees `Open Packet` on practice schedule cards when a packet exists for the matched session.
+2. Parent sees `Open Packet` in calendar day modal under the same conditions.
+3. If no packet exists, no CTA is shown (existing behavior).
+4. Fallback never maps to another team’s session.
 
 ## Assumptions
-- TeamSideline standings pages keep `Team/W/L/T/PCT/PF/PA/PD` table structure.
-- `leagueUrl` may be absent for many teams and should degrade gracefully.
-- Matching team name to standings row is best-effort and may fall back to first row.
-
-## Recommendation
-Ship with defensive parsing + graceful fallback. This gives immediate W/L visibility with low schema/operational overhead and preserves current controls.
+- Practice session docs remain the source of truth for packet content.
+- Team/date proximity is a valid fallback key when event IDs are absent or mismatched.

--- a/js/parent-dashboard-packets.js
+++ b/js/parent-dashboard-packets.js
@@ -4,6 +4,10 @@ function toDateSafe(value) {
   return Number.isNaN(d?.getTime?.()) ? null : d;
 }
 
+function normalizeTitle(value) {
+  return String(value || '').trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
 export function resolvePracticePacketSessionIdForEvent(event, allPracticePacketSessions = []) {
   if (event?.practiceSessionId) return event.practiceSessionId;
   const sessions = Array.isArray(allPracticePacketSessions) ? allPracticePacketSessions : [];
@@ -28,4 +32,63 @@ export function resolvePracticePacketSessionIdForEvent(event, allPracticePacketS
     return Math.abs(at - eventDate.getTime()) - Math.abs(bt - eventDate.getTime());
   });
   return recurringCandidates[0]?.sessionId || null;
+}
+
+export function resolvePracticePacketContextForEvent(event, allPracticePacketSessions = []) {
+  const sessions = Array.isArray(allPracticePacketSessions) ? allPracticePacketSessions : [];
+  if (!event || !sessions.length) {
+    return { sessionId: null, homePacket: null };
+  }
+
+  const directSessionId = resolvePracticePacketSessionIdForEvent(event, sessions);
+  if (directSessionId) {
+    const direct = sessions.find((row) => row?.sessionId === directSessionId) || null;
+    return { sessionId: directSessionId, homePacket: direct?.homePacket || null };
+  }
+
+  const teamId = String(event?.teamId || '').trim();
+  const eventDate = toDateSafe(event?.date);
+  if (!teamId || !eventDate) {
+    return { sessionId: null, homePacket: null };
+  }
+
+  // Fallback when eventId/session linkage is missing: use nearest same-team session on the same day.
+  const eventStart = new Date(eventDate);
+  eventStart.setHours(0, 0, 0, 0);
+  const eventEnd = new Date(eventStart);
+  eventEnd.setDate(eventEnd.getDate() + 1);
+  const eventTitle = normalizeTitle(event?.title || '');
+
+  const sameTeamDay = sessions.filter((row) => {
+    if (String(row?.teamId || '').trim() !== teamId) return false;
+    const rowDate = toDateSafe(row?.date);
+    if (!rowDate) return false;
+    return rowDate >= eventStart && rowDate < eventEnd;
+  });
+
+  if (!sameTeamDay.length) {
+    return { sessionId: null, homePacket: null };
+  }
+
+  sameTeamDay.sort((a, b) => {
+    const at = toDateSafe(a?.date)?.getTime?.() || 0;
+    const bt = toDateSafe(b?.date)?.getTime?.() || 0;
+    const aDiff = Math.abs(at - eventDate.getTime());
+    const bDiff = Math.abs(bt - eventDate.getTime());
+    if (aDiff !== bDiff) return aDiff - bDiff;
+
+    const aTitle = normalizeTitle(a?.title || '');
+    const bTitle = normalizeTitle(b?.title || '');
+    const aTitleMatch = eventTitle && aTitle && aTitle === eventTitle ? 0 : 1;
+    const bTitleMatch = eventTitle && bTitle && bTitle === eventTitle ? 0 : 1;
+    if (aTitleMatch !== bTitleMatch) return aTitleMatch - bTitleMatch;
+
+    return at - bt;
+  });
+
+  const chosen = sameTeamDay[0] || null;
+  return {
+    sessionId: chosen?.sessionId || null,
+    homePacket: chosen?.homePacket || null
+  };
 }

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -189,7 +189,7 @@
         import { getParentDashboardData, redeemParentInvite, getTeam, getGames, getTrackedCalendarEventUids, getUnreadChatCounts, getPracticeSessions, getPracticePacketCompletions, upsertPracticePacketCompletion, updateUserProfile, getUserProfile, submitRsvp, getMyRsvp } from './js/db.js?v=22';
         import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence } from './js/utils.js?v=8';
         import { requireAuth, checkAuth } from './js/auth.js?v=9';
-        import { resolvePracticePacketSessionIdForEvent as resolvePracticePacketSessionIdForEventBase } from './js/parent-dashboard-packets.js?v=1';
+        import { resolvePracticePacketSessionIdForEvent as resolvePracticePacketSessionIdForEventBase, resolvePracticePacketContextForEvent as resolvePracticePacketContextForEventBase } from './js/parent-dashboard-packets.js?v=2';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -280,6 +280,10 @@
 
         function resolvePracticePacketSessionIdForEvent(event) {
             return resolvePracticePacketSessionIdForEventBase(event, allPracticePacketSessions);
+        }
+
+        function resolvePracticePacketContextForEvent(event) {
+            return resolvePracticePacketContextForEventBase(event, allPracticePacketSessions);
         }
 
         async function init() {
@@ -771,11 +775,14 @@
                 contentEl.innerHTML = events.map((ev) => {
                     const timeStr = ev.date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
                     const title = ev.type === 'practice' ? (ev.title || 'Practice') : `vs. ${ev.opponent || 'TBD'}`;
-                    const homePacket = ev.practiceHomePacket || null;
+                    const packetContext = ev.type === 'practice'
+                        ? resolvePracticePacketContextForEvent(ev)
+                        : { sessionId: null, homePacket: null };
+                    const homePacket = ev.practiceHomePacket || packetContext.homePacket || null;
                     const homePacketBlocks = Array.isArray(homePacket?.blocks) ? homePacket.blocks : [];
                     const homePacketReady = ev.type === 'practice' && homePacketBlocks.length > 0;
                     const homePacketMinutes = homePacket?.totalMinutes || homePacketBlocks.reduce((sum, b) => sum + (parseInt(b?.duration, 10) || 0), 0);
-                    const packetSessionId = homePacketReady ? resolvePracticePacketSessionIdForEvent(ev) : null;
+                    const packetSessionId = homePacketReady ? (packetContext.sessionId || resolvePracticePacketSessionIdForEvent(ev)) : null;
                     return `
                         <div class="mb-4 p-4 rounded-lg border border-gray-200 ${ev.isCancelled ? 'opacity-60' : ''}">
                             <div class="text-xs font-semibold uppercase ${ev.type === 'practice' ? 'text-amber-700' : 'text-primary-700'}">${ev.type}</div>
@@ -1187,12 +1194,15 @@
                 const isCancelled = game.isCancelled;
                 const attendance = game.practiceAttendance || null;
                 const attendanceRecorded = game.type === 'practice' && hasRecordedAttendance(attendance);
-                const homePacket = game.practiceHomePacket || null;
+                const packetContext = game.type === 'practice'
+                    ? resolvePracticePacketContextForEvent(game)
+                    : { sessionId: null, homePacket: null };
+                const homePacket = game.practiceHomePacket || packetContext.homePacket || null;
                 const homePacketBlocks = Array.isArray(homePacket?.blocks) ? homePacket.blocks : [];
                 const homePacketReady = game.type === 'practice' && homePacketBlocks.length > 0;
                 const homePacketMinutes = homePacket?.totalMinutes || homePacketBlocks.reduce((sum, b) => sum + (parseInt(b?.duration, 10) || 0), 0);
                 const homePacketPreview = homePacketBlocks.slice(0, 2).map(b => b?.drillTitle || b?.title).filter(Boolean);
-                const packetSessionId = homePacketReady ? resolvePracticePacketSessionIdForEvent(game) : null;
+                const packetSessionId = homePacketReady ? (packetContext.sessionId || resolvePracticePacketSessionIdForEvent(game)) : null;
                 const presentCount = attendanceRecorded
                     ? attendance.players.filter(p => p.status === 'present' || p.status === 'late').length
                     : 0;


### PR DESCRIPTION
## Summary
- add packet-context resolver fallback in `js/parent-dashboard-packets.js` so schedule rendering can find a session packet even when direct event linkage is missing
- wire fallback into both schedule list cards and calendar day modal in `parent-dashboard.html`
- preserve safety by constraining fallback to same `teamId` and same-day nearest session
- add/expand unit tests in `tests/unit/parent-dashboard-packets.test.js` for fallback behavior and cross-team isolation
- refresh role artifacts for requirements/architecture/qa/code in `docs/pr-notes/*`

## Why
Parents could have a generated take-home packet in practice sessions but still not see `Open Packet` in schedule because rendering relied on `event.practiceHomePacket` only.

## Validation
- `./node_modules/.bin/vitest run tests/unit/parent-dashboard-packets.test.js`
- `./node_modules/.bin/vitest run tests/unit`
- `node --check js/parent-dashboard-packets.js`
- `awk '/<script type="module">/{flag=1;next}/<\/script>/{if(flag){flag=0;exit}}flag' parent-dashboard.html > /tmp/parent-dashboard-module.js && node --check /tmp/parent-dashboard-module.js`

## Firebase Rules Check
- Reviewed `firestore.rules` paths for `practiceSessions` and `packetCompletions`; existing access controls already support this flow.
- No rules change required for this fix.

## Role Summaries
- Requirements: `docs/pr-notes/requirements.md`
- Architecture: `docs/pr-notes/architecture.md`
- QA: `docs/pr-notes/qa.md`
- Code Plan: `docs/pr-notes/code-plan.md`
