### PR TITLE
Parent dashboard rideshare offers/requests (Closes #53)

### DIFF
--- a/docs/pr-notes/architecture.md
+++ b/docs/pr-notes/architecture.md
@@ -1,28 +1,31 @@
-# Architecture Role Notes (Parent Take-Home Packet Visibility)
+# Architecture Role Notes (Issue #53 Rideshare)
 
-## Decision
-Add a packet-context resolver that returns both `sessionId` and `homePacket` for a schedule event.
+## Objective
+Introduce rideshare coordination without changing existing game/practice scheduling and RSVP architecture.
 
-## Design
-- Module: `js/parent-dashboard-packets.js`
-- Existing path (unchanged): resolve by explicit IDs (`practiceSessionId`, direct `eventId`, recurring `masterId__date`).
-- New fallback path:
-  - constrain candidates to same `teamId`
-  - constrain candidates to same calendar day as event date
-  - choose nearest-time candidate (title tie-breaker)
-- Output: `{ sessionId, homePacket }`
+## Current Architecture
+- Parent dashboard composes per-child event rows from team `games` docs.
+- RSVP data lives under `games/{gameId}/rsvps`.
+- Security model uses team owner/admin/parent relationships from `users` and `teams` docs.
 
-## Integration Points
-- `parent-dashboard.html` schedule list rendering
-- `parent-dashboard.html` calendar day modal rendering
-- Both now use packet-context fallback when `event.practiceHomePacket` is absent.
+## Proposed Architecture
+- Add rideshare subcollection:
+  - `teams/{teamId}/games/{gameId}/rideOffers/{offerId}`
+  - `teams/{teamId}/games/{gameId}/rideOffers/{offerId}/requests/{requestId}`
+- Keep all writes client-side through `js/db.js` helpers, enforcing seat count correctness with `runTransaction`.
+- Parent dashboard reads rideshare offers per event and renders event-local blocks in list and day-modal views.
 
-## Blast Radius
-- UI/read-only composition changes only.
-- No write-path changes.
-- No schema migration.
-- No auth/rules changes required.
+## Control Equivalence
+- Access remains tenant-scoped by team ID.
+- Parent request creation is constrained by linked child validation (`isParentForPlayer`).
+- Request decision authority limited to driver or team owner/admin.
+- No broadening of top-level document access.
 
-## Controls
-- Team-scoped fallback prevents cross-team packet lookup.
-- Existing session-ID mapping remains primary source to minimize false matches.
+## Blast Radius Comparison
+- Before: RSVP only, no rideshare operations.
+- After: additional reads/writes under event subcollections; no change to unrelated pages or data paths.
+
+## Rollback Plan
+- Revert rideshare UI blocks in `parent-dashboard.html`.
+- Remove rideshare helpers in `js/db.js` and `js/rideshare-helpers.js`.
+- Remove `rideOffers` rules section from `firestore.rules`.

--- a/docs/pr-notes/code-plan.md
+++ b/docs/pr-notes/code-plan.md
@@ -1,21 +1,30 @@
-# Code Role Notes (Parent Take-Home Packet Visibility)
+# Code Role Notes (Issue #53 Rideshare)
+
+## Objective
+Implement issue #53 end-to-end with DB helpers, rules, parent dashboard UX, and tests.
 
 ## Implementation Summary
-- Enhanced resolver module to provide packet context fallback:
-  - `resolvePracticePacketContextForEvent(event, sessions)` in `js/parent-dashboard-packets.js`
-- Updated parent dashboard rendering to use packet context fallback in:
-  - schedule list cards
-  - calendar day modal
-- Bumped module import cache key to ensure clients pull updated resolver:
-  - `parent-dashboard.html` imports `parent-dashboard-packets.js?v=2`
+- Added Firestore transaction export plumbing:
+  - `js/firebase.js`
+- Added rideshare DB operations:
+  - `createRideOffer`
+  - `listRideOffersForEvent`
+  - `requestRideSpot`
+  - `updateRideRequestStatus` (transaction seat guard)
+  - `closeRideOffer`
+  - `cancelRideRequest`
+  - in `js/db.js`
+- Added rideshare helper module for deterministic UI state rendering:
+  - `js/rideshare-helpers.js`
+- Added unit coverage for rideshare helper logic:
+  - `tests/unit/rideshare-helpers.test.js`
+- Integrated rideshare UI/actions into parent dashboard schedule list + day modal:
+  - `parent-dashboard.html`
+- Added Firestore rules for `rideOffers` and nested `requests`:
+  - `firestore.rules`
 
-## Tests Updated
-- `tests/unit/parent-dashboard-packets.test.js`
-  - added fallback-by-team/date case
-  - added cross-team safety case
-
-## Firebase / Rules
-- Verified `firestore.rules` already permits required reads/writes for parent packet flows:
-  - `practiceSessions`
-  - `practiceSessions/{sessionId}/packetCompletions`
-- No rules changes required for this feature fix.
+## Success Criteria
+- Offer/request/decision flows work in-page without full page navigation.
+- Seat count cannot exceed capacity under concurrent confirmation attempts.
+- Parent can only request for linked child (rules constrained).
+- Driver/admin decision flow updates status and seat counts consistently.

--- a/docs/pr-notes/qa.md
+++ b/docs/pr-notes/qa.md
@@ -1,26 +1,22 @@
-# QA Role Notes (Parent Take-Home Packet Visibility)
+# QA Role Notes (Issue #53 Rideshare)
 
-## Test Objective
-Validate that packet CTA visibility is robust across schedule render paths and safe in fallback mode.
+## Objective
+Validate rideshare helper logic and parent dashboard integration safety for the MVP flow.
 
 ## Automated Validation
-- `./node_modules/.bin/vitest run tests/unit/parent-dashboard-packets.test.js`
-- `./node_modules/.bin/vitest run tests/unit`
-- `node --check js/parent-dashboard-packets.js`
-- `node --check` on extracted module from `parent-dashboard.html`
+- `./node_modules/.bin/vitest run tests/unit/rideshare-helpers.test.js`
+- `./node_modules/.bin/vitest run tests/unit/*.test.js`
+- `node --check js/rideshare-helpers.js`
 
-## Added Coverage
-- fallback resolves packet context by same-team + same-day nearest session
-- fallback does not cross team boundaries
-- existing direct and recurring resolution behaviors remain covered
-
-## Manual Verification Checklist
-1. Parent Dashboard -> Schedule list: practice with packet shows `Open Packet`.
-2. Parent Dashboard -> Calendar -> day modal: same practice shows `Open Packet`.
-3. Click `Open Packet`: side modal loads expected packet blocks.
-4. Practice without packet: no packet CTA appears.
-5. Multi-team parent account: packet CTA never leaks across teams.
+## Manual Validation Checklist
+1. Parent opens `parent-dashboard.html` with a DB-backed upcoming game or practice.
+2. Create an offer with seat count/direction/note and confirm offer appears with seat chips.
+3. As another parent on same team, request a spot for a linked child and verify status appears as pending.
+4. As offer driver, confirm request and verify seat counts decrement/increment correctly.
+5. Attempt to confirm over-capacity request and verify UI error (offer remains bounded).
+6. Verify rideshare UI appears in both list card and day-modal views for the event.
 
 ## Residual Risk
-- If multiple same-team practices occur on the same day at similar times with missing linkage, nearest-time fallback may pick the wrong session.
-- This is bounded and still safer than current hidden-CTA behavior.
+- Per-event reads can increase dashboard load time for families with many upcoming events.
+- UI deduplication complexity in calendar/day modal remains moderate; future refactor could centralize event card rendering.
+- Rules should be emulator-tested in a future pass for edge-case field diffs.

--- a/docs/pr-notes/runs/56-remediator-20260301T150406Z/architecture.md
+++ b/docs/pr-notes/runs/56-remediator-20260301T150406Z/architecture.md
@@ -1,0 +1,14 @@
+# Architecture role (fallback inline)
+
+Current state:
+- Seat accounting relies on client transaction helpers plus rules that validate offer/request coupling.
+- Offer status lifecycle exists (`open|closed|cancelled`) but must be enforced on server-side request creation.
+- Parent modal includes child picker, but eligibility rendering is tied to default child on first pass.
+
+Proposed minimal state:
+- Keep existing helper structure in `firestore.rules`; tighten predicates only.
+- Keep parent-dashboard rendering flow; introduce per-offer selected child resolution helper and use it for `myRequest`/`canRequest` and child name derivation.
+
+Blast radius:
+- Firestore rules on rideshare paths only.
+- Parent dashboard rideshare component only.

--- a/docs/pr-notes/runs/56-remediator-20260301T150406Z/code-plan.md
+++ b/docs/pr-notes/runs/56-remediator-20260301T150406Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code role plan (fallback inline)
+
+1. Update `firestore.rules`:
+   - add `seatCountConfirmed` delta cap in `rideOffers/{offerId}` update (if absent).
+   - ensure `requests` create requires open offer status.
+   - restrict request-owner update branch to non-status metadata edits while pending only.
+2. Update `parent-dashboard.html`:
+   - derive selected child from picker state via helper.
+   - compute `myRequest` and `canRequest` from selected child for modal path.
+3. Validate via syntax/read checks and targeted grep.
+4. Commit scoped changes.

--- a/docs/pr-notes/runs/56-remediator-20260301T150406Z/qa.md
+++ b/docs/pr-notes/runs/56-remediator-20260301T150406Z/qa.md
@@ -1,0 +1,11 @@
+# QA role (fallback inline)
+
+Risk-focused checks:
+1. Parent creates request on open offer: allowed.
+2. Parent attempts create request on closed/cancelled offer via direct write: denied.
+3. Parent attempts update `status` from confirmed to pending: denied.
+4. Driver/admin status decision path still works for confirmed/waitlisted/declined with seat counter invariant.
+5. Modal child picker: switching child updates visible Request/Cancel controls and status text.
+
+Execution constraints:
+- Repo has no automated tests for rules/UI; perform targeted static validation and note manual verification steps.

--- a/docs/pr-notes/runs/56-remediator-20260301T150406Z/requirements.md
+++ b/docs/pr-notes/runs/56-remediator-20260301T150406Z/requirements.md
@@ -1,0 +1,14 @@
+# Requirements role (fallback inline)
+
+Objective: remediate unresolved PR #56 review threads with minimal scoped changes.
+
+Required fixes:
+1. Firestore rule hardening for ride offers: limit `seatCountConfirmed` mutation per offer update to at most +/-1.
+2. Firestore request create rule must only allow new requests when referenced offer status is `open`.
+3. Firestore request owner updates must not allow status resets (especially `confirmed -> pending`) that bypass transactional seat accounting.
+4. Parent dashboard modal rideshare UI must compute request/can-request from the selected child in picker flow.
+
+Acceptance:
+- Rules reject direct writes that bypass lifecycle constraints.
+- Modal request/cancel controls reflect currently selected child.
+- No unrelated refactors.

--- a/docs/pr-notes/runs/56-review-3851931064-20260225T052049Z/architecture.md
+++ b/docs/pr-notes/runs/56-review-3851931064-20260225T052049Z/architecture.md
@@ -1,0 +1,21 @@
+# Architecture Role Summary
+
+## Decision
+Use Firestore rules-level invariants for rideshare seat counters via parent-offer `get(...)` + `getAfter(...)` comparisons.
+
+## Design
+- Added helper `rideshareOfferPath(teamId, gameId, offerId)`.
+- Added helper `isRideshareSeatCountUpdateValid(...)` to validate:
+  - Offer exists before and after write.
+  - Offer remains `open` and immutable core fields (`driverUserId`, `seatCapacity`, `status`) are unchanged.
+  - Post-write `seatCountConfirmed` equals expected transition delta from request status change.
+  - Seat count remains within `[0, seatCapacity]`.
+
+## Why this over alternatives
+- Enforces the same seat-capacity guarantees at the database boundary.
+- Preserves existing client transaction model without schema migration.
+- Limits blast radius to rideshare request/offer paths.
+
+## Tradeoffs
+- Requires status decision/deletion writes to include offer updates in the same atomic operation.
+- Adds stricter field-diff checks that may reject previously permissive manual writes.

--- a/docs/pr-notes/runs/56-review-3851931064-20260225T052049Z/code-plan.md
+++ b/docs/pr-notes/runs/56-review-3851931064-20260225T052049Z/code-plan.md
@@ -1,0 +1,15 @@
+# Code Role Summary
+
+## Patch Scope
+- File: `firestore.rules` only.
+
+## Implemented Changes
+- Added rideshare offer path helper and seat-update validation helper.
+- Hardened `rideOffers/{offerId}/requests/{requestId}` update rule:
+  - Driver/admin decisions now require strict field diff and seat-count invariant validation.
+  - Parent path constrained to pending-only metadata edits.
+- Hardened delete rule to require seat-count invariant validation (prevents delete-induced drift).
+
+## Non-Goals
+- No app-layer API or UI changes.
+- No schema/index changes.

--- a/docs/pr-notes/runs/56-review-3851931064-20260225T052049Z/qa.md
+++ b/docs/pr-notes/runs/56-review-3851931064-20260225T052049Z/qa.md
@@ -1,0 +1,18 @@
+# QA Role Summary
+
+## Focus Areas
+- Regression guardrail: request decision writes must fail without synchronized offer seat update.
+- Data-integrity guardrail: request deletes must maintain seat-count correctness.
+- Authorization guardrail: parent edits restricted to pending metadata updates.
+
+## Test Strategy
+1. Rules parse/deploy check (`firebase deploy --only firestore:rules --project game-flow-c6311`).
+2. Targeted rideshare unit test regression (`npx vitest run tests/unit/rideshare-helpers.test.js`).
+
+## Manual Emulator Scenarios (follow-up)
+- Attempt direct request `pending -> confirmed` update without offer update: expect deny.
+- Attempt delete confirmed request without decrementing offer seats: expect deny.
+- Execute app transaction path for status update/delete: expect allow.
+
+## Residual Risks
+- No dedicated Firestore emulator rules test harness currently in repo; coverage relies on deploy validation + app/unit behavior.

--- a/docs/pr-notes/runs/56-review-3851931064-20260225T052049Z/requirements.md
+++ b/docs/pr-notes/runs/56-review-3851931064-20260225T052049Z/requirements.md
@@ -1,0 +1,25 @@
+# Requirements Role Summary
+
+## Objective
+Close the Firestore-rule integrity gap where rideshare confirmations can be written without synchronized seat-capacity enforcement at rule-evaluation time.
+
+## Current State
+- App code uses `runTransaction` for `seatCountConfirmed` updates.
+- Rules allow request status changes (`confirmed`, `waitlisted`, `declined`) without requiring a matching parent-offer seat update in the same atomic write.
+
+## Proposed State
+- Any request decision or deletion must satisfy seat-count transition math against the parent offer document using `getAfter(...)`.
+- Parent-owned request edits remain limited to pending-state metadata updates.
+
+## Risk / Blast Radius
+- Scope: `firestore.rules` rideshare request update/delete logic.
+- Impacted users: ride drivers, team staff, and parents in rideshare workflows.
+- Reduced risk: prevents oversubscription and seat-count drift caused by out-of-band request writes.
+
+## Assumptions
+- Request status lifecycle is `pending -> confirmed|waitlisted|declined` for driver/admin decisions.
+- Parent cancellation path is delete-based and already transaction-coupled in app code.
+
+## Success Criteria
+- Rules deny request confirmation when the same commit does not provide a consistent parent-offer `seatCountConfirmed` update.
+- Rules continue to allow valid transaction-based status updates and cancellation deletes.

--- a/docs/pr-notes/runs/56-review-3851946305-20260225T052642Z/architecture.md
+++ b/docs/pr-notes/runs/56-review-3851946305-20260225T052642Z/architecture.md
@@ -1,0 +1,15 @@
+# Architecture Role Summary
+
+## Decision
+Apply minimal, control-preserving patch at rules and presentation layers.
+
+## Design Notes
+- Rules: add parent-offer status guard on `requests` `allow create` via `get(...rideOffers/{offerId}).data.status == 'open'`.
+- UI: track selected child per offer row with `selectedRideChildBySelector` map and rerender modal on selection change.
+
+## Control Equivalence
+- New rules check strengthens DB-level control without reducing existing access checks.
+- UI change aligns action visibility with real eligibility and existing helper logic (`canRequestRide`, `findRequestForChild`).
+
+## Rollback
+- Revert single guard line in `firestore.rules` and selected-child state block in `parent-dashboard.html`.

--- a/docs/pr-notes/runs/56-review-3851946305-20260225T052642Z/code-plan.md
+++ b/docs/pr-notes/runs/56-review-3851946305-20260225T052642Z/code-plan.md
@@ -1,0 +1,16 @@
+# Code Role Summary
+
+## Implemented Patch Set
+1. Firestore rules hardening
+- File: `firestore.rules`
+- Added open-offer precondition to `rideOffers/{offerId}/requests` create rule.
+
+2. Parent dashboard rideshare child selection correctness
+- File: `parent-dashboard.html`
+- Added `selectedRideChildBySelector` map and `setRideChildSelection` handler.
+- Recomputed `myRequest`, `canRequest`, and selected child labels from active selection.
+- Wired child `<select>` `onchange` to rerender modal and refresh controls.
+
+## Why this minimal patch
+- Preserves existing helper APIs and transactional seat-count semantics.
+- Avoids broader UI refactor while directly closing reported failure modes.

--- a/docs/pr-notes/runs/56-review-3851946305-20260225T052642Z/qa.md
+++ b/docs/pr-notes/runs/56-review-3851946305-20260225T052642Z/qa.md
@@ -1,0 +1,16 @@
+# QA Role Summary
+
+## Targeted Regressions
+- Request create should be denied when offer status is `closed` or `cancelled`.
+- Modal rideshare action visibility should follow selected child for multi-child parent accounts.
+
+## Validation Strategy
+- Run existing unit suite for rideshare helper safety (`tests/unit/rideshare-helpers.test.js`).
+- Run Firestore rules syntax compile check (`firebase firestore:rules:test --help`) and inspect modified rule path.
+- Manual verification workflow:
+  1. Parent with two children opens day modal.
+  2. Toggle child in selector for same offer.
+  3. Observe Request/Cancel controls and request status text update on each selection.
+
+## Residual Risks
+- No emulator scenario test was run for rule behavior against live-style request documents in this pass.

--- a/docs/pr-notes/runs/56-review-3851946305-20260225T052642Z/requirements.md
+++ b/docs/pr-notes/runs/56-review-3851946305-20260225T052642Z/requirements.md
@@ -1,0 +1,24 @@
+# Requirements Role Summary
+
+## Objective
+Close PR #56 review gaps while preserving parent usability and rideshare lifecycle integrity.
+
+## Current State
+- Parents can create ride requests without rules-level check that the offer is still `open`.
+- In modal rideshare UI for multi-child parents, request/cancel controls are computed from default child, not selected child.
+
+## Proposed State
+- Rules require offer status `open` on request creation.
+- Modal controls recompute from selected child so availability/action state matches user intent.
+
+## Risk Surface and Blast Radius
+- Firestore rules change affects only `teams/{teamId}/games/{gameId}/rideOffers/{offerId}/requests` create path.
+- UI state change affects rideshare rendering in `parent-dashboard.html` modal context only.
+
+## Assumptions
+- Offer lifecycle should block new demand after `closed`/`cancelled`.
+- Parent can still cancel their existing request through transactional API flow.
+
+## Success Criteria
+- Direct writes to create requests fail when offer is not `open`.
+- In day modal, selecting different child updates Request/Cancel controls immediately.

--- a/docs/pr-notes/runs/56-review-comment-2850906291-20260225T052428Z/architecture.md
+++ b/docs/pr-notes/runs/56-review-comment-2850906291-20260225T052428Z/architecture.md
@@ -1,0 +1,16 @@
+# Architecture Role Summary
+
+## Decision
+Apply a defense-in-depth invariant at the document rule boundary for ride offers.
+
+## Control Equivalence
+- Existing control: transaction logic in `js/db.js` computes seat deltas from request status transitions.
+- New control: Firestore rule blocks direct document writes from mutating `seatCountConfirmed` by arbitrary amounts.
+- Combined effect: client helper integrity + backend rule-level invariant.
+
+## Blast Radius Comparison
+- Before: driver/admin direct `updateDoc` could move seat count multiple seats in one write.
+- After: max movement is 1 per write; bulk tampering requires repeated writes and is rate-limited by rules checks per operation.
+
+## Rollback Plan
+Remove the one-line delta predicate from `rideOffers` `allow update` if regression discovered.

--- a/docs/pr-notes/runs/56-review-comment-2850906291-20260225T052428Z/code-plan.md
+++ b/docs/pr-notes/runs/56-review-comment-2850906291-20260225T052428Z/code-plan.md
@@ -1,0 +1,13 @@
+# Code Role Plan
+
+## Minimal Safe Patch
+- File: `firestore.rules`
+- Scope: `match /rideOffers/{offerId}` `allow update` predicate
+- Change: add absolute-delta guard for `seatCountConfirmed` against existing value
+
+## Why This Patch
+Implements reviewer-requested mitigation with one localized rule condition and no JS behavior changes.
+
+## Acceptance Criteria
+- Rules compile with `math.abs(...)` expression.
+- Branch includes only targeted rule change plus required run-note artifacts.

--- a/docs/pr-notes/runs/56-review-comment-2850906291-20260225T052428Z/qa.md
+++ b/docs/pr-notes/runs/56-review-comment-2850906291-20260225T052428Z/qa.md
@@ -1,0 +1,13 @@
+# QA Role Summary
+
+## Regression Guardrails
+1. Confirm direct rules update with `seatCountConfirmed` delta `+2` fails.
+2. Confirm direct rules update with delta `+1` passes when within capacity.
+3. Confirm transactional request status update path still passes.
+
+## Manual Validation Focus
+- Ride offer document updates from driver/admin clients.
+- Request status transitions (`pending -> confirmed`, `confirmed -> declined`).
+
+## Risks Remaining
+- Rule does not guarantee perfect serialization under high concurrency; it narrows exploitability by preventing large jumps per write.

--- a/docs/pr-notes/runs/56-review-comment-2850906291-20260225T052428Z/requirements.md
+++ b/docs/pr-notes/runs/56-review-comment-2850906291-20260225T052428Z/requirements.md
@@ -1,0 +1,26 @@
+# Requirements Role Summary
+
+## Objective
+Prevent direct ride-offer updates from increasing or decreasing `seatCountConfirmed` by more than one seat per write.
+
+## Current State
+`rideOffers` update rules enforce numeric bounds (`>= 0` and `<= seatCapacity`) but permit multi-seat jumps in a single write.
+
+## Proposed State
+A single write can only change `seatCountConfirmed` by at most 1, reducing abuse window if a client bypasses transactional helpers.
+
+## Risk Surface and Blast Radius
+- Affects only `/teams/{teamId}/games/{gameId}/rideOffers/{offerId}` updates.
+- Does not alter request-level transactional flow; blocks only oversized seat jumps.
+- Parent/driver/admin UX impact: sequential seat adjustments required for manual corrections larger than one.
+
+## Assumptions
+- Legitimate seat-count changes occur through request status updates.
+- Direct ride-offer updates to seat counters are exceptional and should be constrained.
+
+## Recommendation
+Add `math.abs(request.resource.data.seatCountConfirmed - resource.data.seatCountConfirmed) <= 1` to `rideOffers` update guard.
+
+## Success Criteria
+- Direct update attempts with seat count delta > 1 are denied by rules.
+- Existing transaction-driven confirm/decline operations remain allowed.

--- a/docs/pr-notes/runs/56-review-comment-2850919448-20260225T052931Z/architecture.md
+++ b/docs/pr-notes/runs/56-review-comment-2850919448-20260225T052931Z/architecture.md
@@ -1,0 +1,22 @@
+# Architecture Role
+
+## Objective
+Make lifecycle enforcement explicit in Firestore rules with minimal change.
+
+## Current vs Proposed
+- Current state: inline `get(...).data.status == 'open'` in request create rule.
+- Proposed state: `isRideshareOfferOpen(teamId, gameId, offerId)` helper (`exists + status`) used by request create rule.
+
+## Risk Surface / Blast Radius
+- Security boundary: Firestore rules only.
+- Blast radius: one helper + one call-site replacement, no schema change.
+
+## Assumptions
+- Rules evaluation cost remains acceptable for one additional helper call.
+- Existing write paths already provide required fields.
+
+## Recommendation
+Adopt helper-based guard for consistency with existing rideshare helper pattern (`rideshareOfferPath`, seat-count validator). Tradeoff: negligible complexity for clearer policy semantics.
+
+## Rollback
+Revert helper and call-site if regression appears; no data migration required.

--- a/docs/pr-notes/runs/56-review-comment-2850919448-20260225T052931Z/code-plan.md
+++ b/docs/pr-notes/runs/56-review-comment-2850919448-20260225T052931Z/code-plan.md
@@ -1,0 +1,15 @@
+# Code Role
+
+## Objective
+Patch rules minimally to satisfy review finding with explicit evidence.
+
+## Plan
+1. Add `isRideshareOfferOpen(teamId, gameId, offerId)` helper in `firestore.rules`.
+2. Replace inline offer status check in `requests` create rule with helper call.
+3. Run lightweight validation command for rules syntax/deployability.
+4. Commit and push to `feat/issue-53-rideshare`.
+
+## Why This Patch
+- Smallest safe change.
+- Keeps lifecycle authority in rules (not UI-only).
+- Improves readability and future reuse.

--- a/docs/pr-notes/runs/56-review-comment-2850919448-20260225T052931Z/qa.md
+++ b/docs/pr-notes/runs/56-review-comment-2850919448-20260225T052931Z/qa.md
@@ -1,0 +1,23 @@
+# QA Role
+
+## Objective
+Validate that closed/cancelled offers reject new request creation.
+
+## Coverage
+- Rule parsing sanity via Firebase deploy dry-run command.
+- Targeted rule inspection for create path.
+
+## Regression Guardrails
+- Confirm request create still requires:
+  - signed-in parent
+  - parent-child link
+  - pending request status
+  - open offer state
+
+## Acceptance Criteria
+1. Request create denied when offer status is `closed`.
+2. Request create denied when offer status is `cancelled`.
+3. Request create allowed when offer status is `open` and other constraints pass.
+
+## Residual Gaps
+- No emulator-backed automated rule tests currently in repo; manual/CI rule tests should be added in a follow-up.

--- a/docs/pr-notes/runs/56-review-comment-2850919448-20260225T052931Z/requirements.md
+++ b/docs/pr-notes/runs/56-review-comment-2850919448-20260225T052931Z/requirements.md
@@ -1,0 +1,23 @@
+# Requirements Role
+
+## Objective
+Prevent parents from creating new ride requests once an offer is no longer open.
+
+## Current vs Proposed
+- Current state: Request create authorization depended on identity/link checks and an inline offer status read.
+- Proposed state: Request create authorization uses an explicit helper that requires offer existence and `open` status.
+
+## Risk Surface / Blast Radius
+- Risk addressed: direct Firestore writes bypassing UI guard and reopening demand on closed/cancelled offers.
+- Blast radius: limited to `rideOffers/{offerId}/requests` creation; no user-flow expansion.
+
+## Assumptions
+- Offer lifecycle is authoritative in Firestore (`open`, `closed`, `cancelled`).
+- Parent UX should block new demand unless offer is open.
+
+## Recommendation
+Ship explicit server-side offer-open gate for request creation. Tradeoff: one extra helper indirection, but stronger lifecycle clarity and reviewability.
+
+## Success Metrics
+- New request writes fail when offer status is `closed` or `cancelled`.
+- Existing pending/decision flows remain unchanged.

--- a/docs/pr-notes/runs/56-review-comment-2850919452-20260225T053430Z/architecture.md
+++ b/docs/pr-notes/runs/56-review-comment-2850919452-20260225T053430Z/architecture.md
@@ -1,0 +1,15 @@
+# Architecture Role Notes
+
+## Current State
+Selection state is keyed by UI selector IDs, which are render-coupled.
+
+## Proposed State
+Store picker selection by stable domain key: `teamId::eventId::offerId`.
+
+## Blast Radius
+- Scoped to rideshare modal/list rendering in `parent-dashboard.html`.
+- No Firestore schema or API changes.
+
+## Control Equivalence
+- Preserves existing request/cancel APIs.
+- Improves determinism by decoupling selection state from ephemeral DOM IDs.

--- a/docs/pr-notes/runs/56-review-comment-2850919452-20260225T053430Z/code-plan.md
+++ b/docs/pr-notes/runs/56-review-comment-2850919452-20260225T053430Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Role Notes
+
+## Minimal Safe Patch
+- Replace `selectedRideChildBySelector` with `selectedRideChildByOffer` map.
+- Add `getRideOfferSelectionKey(teamId, eventId, offerId)` helper.
+- Update `setRideChildSelection` to accept team/event/offer IDs and persist by stable key.
+- Compute modal `selectedChildId` from stable key before `findRequestForChild` / `canRequestRide`.
+- Update picker `onchange` to pass stable identifiers.
+
+## Why This Fix
+The eligibility and request-state computation now uses selection state bound to actual offer identity, so changing picker child updates controls for that offer reliably.

--- a/docs/pr-notes/runs/56-review-comment-2850919452-20260225T053430Z/qa.md
+++ b/docs/pr-notes/runs/56-review-comment-2850919452-20260225T053430Z/qa.md
@@ -1,0 +1,14 @@
+# QA Role Notes
+
+## Regression Risks
+- Dropdown change handler signature changed; verify all call sites.
+- Ensure non-modal rendering (`includeChildPicker=false`) remains unchanged.
+
+## Manual Checks
+1. Multi-child parent in modal: switch child, verify Request/Cancel and status text update.
+2. Submit request for selected child, refresh, verify persisted request shown for same child.
+3. Single-child parent path still shows correct controls.
+
+## Acceptance Criteria
+- Eligibility state follows selected child across rerenders.
+- No console errors from `setRideChildSelection` invocation.

--- a/docs/pr-notes/runs/56-review-comment-2850919452-20260225T053430Z/requirements.md
+++ b/docs/pr-notes/runs/56-review-comment-2850919452-20260225T053430Z/requirements.md
@@ -1,0 +1,13 @@
+# Requirements Role Notes
+
+## Objective
+Ensure rideshare Request/Cancel controls in day-modal context reflect the child currently selected in the picker, not only the default child.
+
+## UX Decision
+- Child picker selection is the source of truth for eligibility and current request state.
+- Selection persistence must survive modal rerenders triggered by data refreshes.
+
+## Success Criteria
+- Changing child in dropdown immediately changes Request/Cancel visibility for that offer.
+- Existing request status text references the selected child.
+- No behavior change for single-child parents or non-modal rideshare rendering.

--- a/docs/pr-notes/runs/95-remediator-20260301T002002Z/architecture.md
+++ b/docs/pr-notes/runs/95-remediator-20260301T002002Z/architecture.md
@@ -1,0 +1,24 @@
+# Architecture Role Analysis (manual fallback)
+
+## Current State
+`expandRecurrence` iterates day-by-day and applies recurrence gates. Prior review concerns were:
+- timezone-misaligned day-number derivation,
+- weekly interval bucket alignment using start-anchored 7-day blocks.
+
+## Proposed State
+- Use epoch-based day numbers via `Math.floor(date.getTime() / MS_PER_DAY)` consistently for `seriesStart` and `current`.
+- Derive week buckets from week-start day numbers:
+  - `seriesWeekStartDayNumber = seriesStartDayNumber - seriesStart.getDay()`
+  - `currentWeekStartDayNumber = currentDayNumber - current.getDay()`
+  - `weeksSinceSeriesStart = floor((currentWeekStartDayNumber - seriesWeekStartDayNumber) / 7)`
+
+## Blast Radius
+Low. Changes are isolated to recurrence matching math in `js/utils.js`.
+No schema, auth, network, or storage changes.
+
+## Controls
+- Unit tests for daily and weekly interval guardrails.
+- Regression assertion for biweekly Wednesday/Monday scenario from review thread.
+
+## Rollback
+Revert `js/utils.js` recurrence math and related test additions in one commit if regression is detected.

--- a/docs/pr-notes/runs/95-remediator-20260301T002002Z/code-plan.md
+++ b/docs/pr-notes/runs/95-remediator-20260301T002002Z/code-plan.md
@@ -1,0 +1,17 @@
+# Code Role Plan (manual fallback)
+
+## Implementation Plan
+1. Update recurrence day-number math in `js/utils.js` to use `getTime()` day numbers consistently.
+2. Ensure weekly interval uses week-start aligned bucket math.
+3. Add/verify recurrence tests covering review scenario and prior interval regression.
+4. Run focused vitest suite.
+
+## Conflict Resolution Across Roles
+- Requirements requested strict minimal scope.
+- Architecture requested week-boundary math instead of 7-day start anchoring.
+- QA requested explicit regression case (`2026-03-09` exclusion).
+
+Resolution: implement only recurrence-matching math and matching tests, avoid unrelated refactors.
+
+## Tooling Note
+Requested `allplays-orchestrator-playbook` and role skills were unavailable in this session environment, and `sessions_spawn` is not an available tool. This run uses a manual four-role synthesis with persisted artifacts to preserve traceability.

--- a/docs/pr-notes/runs/95-remediator-20260301T002002Z/qa.md
+++ b/docs/pr-notes/runs/95-remediator-20260301T002002Z/qa.md
@@ -1,0 +1,18 @@
+# QA Role Analysis (manual fallback)
+
+## Risk Surface
+- Incorrect occurrence generation cadence (over/under generation).
+- Date-boundary regressions around interval checks.
+
+## Test Strategy
+- Focused unit tests in `tests/unit/recurrence-expand.test.js`:
+  - Daily interval every 3 days remains correct.
+  - Weekly interval for multi-day schedules aligns to week boundaries.
+  - Biweekly series starting Wednesday with `['MO','WE']` must exclude Monday of immediate next week (`2026-03-09`).
+
+## Validation Command
+- `node ./node_modules/vitest/vitest.mjs run tests/unit/recurrence-expand.test.js`
+
+## Exit Criteria
+- All recurrence interval guardrail tests pass.
+- Expected date sequences match review-thread examples.

--- a/docs/pr-notes/runs/95-remediator-20260301T002002Z/requirements.md
+++ b/docs/pr-notes/runs/95-remediator-20260301T002002Z/requirements.md
@@ -1,0 +1,24 @@
+# Requirements Role Analysis (manual fallback)
+
+## Objective
+Resolve unresolved PR #95 review feedback for recurrence expansion with minimal blast radius and regression-safe behavior.
+
+## Constraints
+- Scope limited to unresolved review comments in `js/utils.js` recurrence interval logic.
+- Preserve existing recurrence behaviors outside the interval/date-bucket defects.
+- Add/maintain tests for impacted recurrence workflows.
+
+## Evidence
+- Review comment `r2867475544`: day-number calculation should not use `Date.UTC(...)` with local date iteration.
+- Review comment `r2867475547`: same issue for `currentDayNumber`.
+- Review comment `r2867475814`: weekly interval must align to calendar week boundaries, not rolling 7-day buckets anchored to series start.
+
+## Acceptance Criteria
+1. Day-number calculations use `getTime() / MS_PER_DAY` for both series start and current date.
+2. Weekly interval gating computes from week-start boundaries so biweekly multi-day series skips off-cadence next-week dates.
+3. Existing daily interval behavior remains correct.
+4. Focused tests pass.
+
+## Assumptions
+- Week boundary convention is Sunday-based (`Date#getDay()`), consistent with existing code path and day-code mapping.
+- No product requirement currently mandates locale-specific week start customization.

--- a/firestore.rules
+++ b/firestore.rules
@@ -60,6 +60,33 @@ service cloud.firestore {
       return isSignedIn() && (isOwnerOrAdmin || isParentForTeam(teamId));
     }
 
+    function rideshareOfferPath(teamId, gameId, offerId) {
+      return /databases/$(database)/documents/teams/$(teamId)/games/$(gameId)/rideOffers/$(offerId);
+    }
+
+    // Require request status decisions/deletes to keep parent offer seat counters consistent.
+    function isRideshareSeatCountUpdateValid(teamId, gameId, offerId, previousStatus, nextStatus) {
+      let offerPath = rideshareOfferPath(teamId, gameId, offerId);
+      let offerBefore = get(offerPath).data;
+      let offerAfter = getAfter(offerPath).data;
+      let seatCountBefore = offerBefore.seatCountConfirmed is int ? offerBefore.seatCountConfirmed : 0;
+      let seatDelta = (nextStatus == 'confirmed' ? 1 : 0) - (previousStatus == 'confirmed' ? 1 : 0);
+      let expectedSeatCount = seatCountBefore + seatDelta;
+
+      return exists(offerPath) &&
+             existsAfter(offerPath) &&
+             offerBefore.status == 'open' &&
+             offerAfter.status == offerBefore.status &&
+             offerAfter.driverUserId == offerBefore.driverUserId &&
+             offerAfter.seatCapacity == offerBefore.seatCapacity &&
+             offerAfter.seatCapacity is int &&
+             offerAfter.seatCapacity > 0 &&
+             offerAfter.seatCountConfirmed is int &&
+             offerAfter.seatCountConfirmed == expectedSeatCount &&
+             offerAfter.seatCountConfirmed >= 0 &&
+             offerAfter.seatCountConfirmed <= offerAfter.seatCapacity;
+    }
+
     // Users collection - users should only write their own profile
     match /users/{userId} {
       allow read: if true;  // Public profiles
@@ -270,20 +297,27 @@ service cloud.firestore {
                                  (isTeamOwnerOrAdmin(teamId) || get(/databases/$(database)/documents/teams/$(teamId)/games/$(gameId)/rideOffers/$(offerId)).data.driverUserId == request.auth.uid) &&
                                  request.resource.data.parentUserId == resource.data.parentUserId &&
                                  request.resource.data.childId == resource.data.childId &&
-                                 request.resource.data.status in ['confirmed', 'waitlisted', 'declined']
+                                 request.resource.data.requestedAt == resource.data.requestedAt &&
+                                 request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status', 'respondedAt', 'updatedAt']) &&
+                                 request.resource.data.status in ['confirmed', 'waitlisted', 'declined'] &&
+                                 isRideshareSeatCountUpdateValid(teamId, gameId, offerId, resource.data.status, request.resource.data.status)
                                ) ||
-                               // Request owner can reset to pending or update childName only.
+                               // Request owner can edit childName while request is still pending.
                                (
                                  resource.data.parentUserId == request.auth.uid &&
                                  request.resource.data.parentUserId == resource.data.parentUserId &&
                                  request.resource.data.childId == resource.data.childId &&
-                                 request.resource.data.status == 'pending'
+                                 request.resource.data.requestedAt == resource.data.requestedAt &&
+                                 resource.data.status == 'pending' &&
+                                 request.resource.data.status == 'pending' &&
+                                 request.resource.data.diff(resource.data).affectedKeys().hasOnly(['childName', 'updatedAt'])
                                )
                              );
             allow delete: if isSignedIn() &&
                              (isTeamOwnerOrAdmin(teamId) ||
                               resource.data.parentUserId == request.auth.uid ||
-                              get(/databases/$(database)/documents/teams/$(teamId)/games/$(gameId)/rideOffers/$(offerId)).data.driverUserId == request.auth.uid);
+                              get(/databases/$(database)/documents/teams/$(teamId)/games/$(gameId)/rideOffers/$(offerId)).data.driverUserId == request.auth.uid) &&
+                             isRideshareSeatCountUpdateValid(teamId, gameId, offerId, resource.data.status, 'declined');
           }
         }
       }

--- a/firestore.rules
+++ b/firestore.rules
@@ -64,6 +64,11 @@ service cloud.firestore {
       return /databases/$(database)/documents/teams/$(teamId)/games/$(gameId)/rideOffers/$(offerId);
     }
 
+    function isRideshareOfferOpen(teamId, gameId, offerId) {
+      let offerPath = rideshareOfferPath(teamId, gameId, offerId);
+      return exists(offerPath) && get(offerPath).data.status == 'open';
+    }
+
     // Require request status decisions/deletes to keep parent offer seat counters consistent.
     function isRideshareSeatCountUpdateValid(teamId, gameId, offerId, previousStatus, nextStatus) {
       let offerPath = rideshareOfferPath(teamId, gameId, offerId);
@@ -289,7 +294,7 @@ service cloud.firestore {
                              requestId == request.auth.uid + "__" + request.resource.data.childId &&
                              request.resource.data.parentUserId == request.auth.uid &&
                              isParentForPlayer(teamId, request.resource.data.childId) &&
-                             get(/databases/$(database)/documents/teams/$(teamId)/games/$(gameId)/rideOffers/$(offerId)).data.status == 'open' &&
+                             isRideshareOfferOpen(teamId, gameId, offerId) &&
                              request.resource.data.status == 'pending';
 
             allow update: if isSignedIn() &&

--- a/firestore.rules
+++ b/firestore.rules
@@ -232,6 +232,60 @@ service cloud.firestore {
           allow delete: if (isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId)) &&
                            isSignedIn() && rsvpId == request.auth.uid;
         }
+
+        // Rideshare offers for games/practices.
+        match /rideOffers/{offerId} {
+          allow read: if isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId);
+          allow create: if isSignedIn() &&
+                           (isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId)) &&
+                           request.resource.data.driverUserId == request.auth.uid &&
+                           request.resource.data.seatCapacity is int &&
+                           request.resource.data.seatCapacity > 0 &&
+                           request.resource.data.seatCountConfirmed == 0 &&
+                           request.resource.data.status == 'open' &&
+                           request.resource.data.direction in ['to', 'from', 'round-trip'];
+          allow update: if isSignedIn() &&
+                           (isTeamOwnerOrAdmin(teamId) || resource.data.driverUserId == request.auth.uid) &&
+                           request.resource.data.driverUserId == resource.data.driverUserId &&
+                           request.resource.data.createdAt == resource.data.createdAt &&
+                           request.resource.data.seatCountConfirmed is int &&
+                           request.resource.data.seatCountConfirmed >= 0 &&
+                           request.resource.data.seatCountConfirmed <= request.resource.data.seatCapacity &&
+                           request.resource.data.status in ['open', 'closed', 'cancelled'];
+          allow delete: if isSignedIn() && (isTeamOwnerOrAdmin(teamId) || resource.data.driverUserId == request.auth.uid);
+
+          match /requests/{requestId} {
+            allow read: if isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId);
+
+            allow create: if isSignedIn() &&
+                             requestId == request.auth.uid + "__" + request.resource.data.childId &&
+                             request.resource.data.parentUserId == request.auth.uid &&
+                             isParentForPlayer(teamId, request.resource.data.childId) &&
+                             request.resource.data.status == 'pending';
+
+            allow update: if isSignedIn() &&
+                             (
+                               // Driver/coach/admin can decide status.
+                               (
+                                 (isTeamOwnerOrAdmin(teamId) || get(/databases/$(database)/documents/teams/$(teamId)/games/$(gameId)/rideOffers/$(offerId)).data.driverUserId == request.auth.uid) &&
+                                 request.resource.data.parentUserId == resource.data.parentUserId &&
+                                 request.resource.data.childId == resource.data.childId &&
+                                 request.resource.data.status in ['confirmed', 'waitlisted', 'declined']
+                               ) ||
+                               // Request owner can reset to pending or update childName only.
+                               (
+                                 resource.data.parentUserId == request.auth.uid &&
+                                 request.resource.data.parentUserId == resource.data.parentUserId &&
+                                 request.resource.data.childId == resource.data.childId &&
+                                 request.resource.data.status == 'pending'
+                               )
+                             );
+            allow delete: if isSignedIn() &&
+                             (isTeamOwnerOrAdmin(teamId) ||
+                              resource.data.parentUserId == request.auth.uid ||
+                              get(/databases/$(database)/documents/teams/$(teamId)/games/$(gameId)/rideOffers/$(offerId)).data.driverUserId == request.auth.uid);
+          }
+        }
       }
 
       // Stat tracker configs subcollection

--- a/firestore.rules
+++ b/firestore.rules
@@ -278,6 +278,7 @@ service cloud.firestore {
                            request.resource.data.seatCountConfirmed is int &&
                            request.resource.data.seatCountConfirmed >= 0 &&
                            request.resource.data.seatCountConfirmed <= request.resource.data.seatCapacity &&
+                           math.abs(request.resource.data.seatCountConfirmed - resource.data.seatCountConfirmed) <= 1 &&
                            request.resource.data.status in ['open', 'closed', 'cancelled'];
           allow delete: if isSignedIn() && (isTeamOwnerOrAdmin(teamId) || resource.data.driverUserId == request.auth.uid);
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -289,6 +289,7 @@ service cloud.firestore {
                              requestId == request.auth.uid + "__" + request.resource.data.childId &&
                              request.resource.data.parentUserId == request.auth.uid &&
                              isParentForPlayer(teamId, request.resource.data.childId) &&
+                             get(/databases/$(database)/documents/teams/$(teamId)/games/$(gameId)/rideOffers/$(offerId)).data.status == 'open' &&
                              request.resource.data.status == 'pending';
 
             allow update: if isSignedIn() &&

--- a/firestore.rules
+++ b/firestore.rules
@@ -295,6 +295,7 @@ service cloud.firestore {
                              request.resource.data.parentUserId == request.auth.uid &&
                              isParentForPlayer(teamId, request.resource.data.childId) &&
                              isRideshareOfferOpen(teamId, gameId, offerId) &&
+                             get(rideshareOfferPath(teamId, gameId, offerId)).data.status == 'open' &&
                              request.resource.data.status == 'pending';
 
             allow update: if isSignedIn() &&
@@ -316,6 +317,7 @@ service cloud.firestore {
                                  request.resource.data.childId == resource.data.childId &&
                                  request.resource.data.requestedAt == resource.data.requestedAt &&
                                  resource.data.status == 'pending' &&
+                                 request.resource.data.status == resource.data.status &&
                                  request.resource.data.status == 'pending' &&
                                  request.resource.data.diff(resource.data).affectedKeys().hasOnly(['childName', 'updatedAt'])
                                )

--- a/js/firebase.js
+++ b/js/firebase.js
@@ -43,7 +43,8 @@ import {
     onSnapshot,
     serverTimestamp,
     collectionGroup,
-    writeBatch
+    writeBatch,
+    runTransaction
 } from "./vendor/firebase-firestore.js";
 import { getStorage, ref, uploadBytes, getDownloadURL } from "./vendor/firebase-storage.js";
 
@@ -92,7 +93,8 @@ export {
     onSnapshot,
     serverTimestamp,
     collectionGroup,
-    writeBatch
+    writeBatch,
+    runTransaction
 };
 
 export {

--- a/js/rideshare-helpers.js
+++ b/js/rideshare-helpers.js
@@ -1,0 +1,86 @@
+const OFFER_STATUS_OPEN = 'open';
+const REQUEST_STATUS_PENDING = 'pending';
+const REQUEST_STATUS_CONFIRMED = 'confirmed';
+
+export function normalizeOffer(offer = {}) {
+    const statusRaw = (offer.status || '').toString().toLowerCase();
+    const status = statusRaw === 'closed' || statusRaw === 'cancelled' ? statusRaw : OFFER_STATUS_OPEN;
+    const seatCapacity = Number.isFinite(Number(offer.seatCapacity)) ? Math.max(0, Number.parseInt(offer.seatCapacity, 10)) : 0;
+    const seatCountConfirmed = Number.isFinite(Number(offer.seatCountConfirmed))
+        ? Math.max(0, Number.parseInt(offer.seatCountConfirmed, 10))
+        : 0;
+    const requests = Array.isArray(offer.requests) ? offer.requests : [];
+    return {
+        ...offer,
+        status,
+        seatCapacity,
+        seatCountConfirmed,
+        requests
+    };
+}
+
+export function getOfferSeatInfo(offer = {}) {
+    const normalized = normalizeOffer(offer);
+    const seatsLeft = Math.max(0, normalized.seatCapacity - normalized.seatCountConfirmed);
+    const isFull = normalized.status !== OFFER_STATUS_OPEN || seatsLeft === 0;
+    return {
+        seatCapacity: normalized.seatCapacity,
+        seatCountConfirmed: normalized.seatCountConfirmed,
+        seatsLeft,
+        isFull
+    };
+}
+
+export function getRequestStatusCounts(offer = {}) {
+    const normalized = normalizeOffer(offer);
+    return normalized.requests.reduce((acc, request) => {
+        const status = (request?.status || '').toString().toLowerCase();
+        if (status === REQUEST_STATUS_CONFIRMED) acc.confirmed += 1;
+        else if (status === 'waitlisted') acc.waitlisted += 1;
+        else if (status === 'declined') acc.declined += 1;
+        else acc.pending += 1;
+        return acc;
+    }, { pending: 0, confirmed: 0, waitlisted: 0, declined: 0 });
+}
+
+export function getEventRideshareSummary(offers = []) {
+    const normalizedOffers = Array.isArray(offers) ? offers.map(normalizeOffer) : [];
+    const openOffers = normalizedOffers.filter((offer) => offer.status === OFFER_STATUS_OPEN);
+    const totals = openOffers.reduce((acc, offer) => {
+        const seatInfo = getOfferSeatInfo(offer);
+        const requestCounts = getRequestStatusCounts(offer);
+        acc.seatsLeft += seatInfo.seatsLeft;
+        acc.requests += offer.requests.length;
+        acc.pending += requestCounts.pending;
+        acc.confirmed += requestCounts.confirmed;
+        return acc;
+    }, { seatsLeft: 0, requests: 0, pending: 0, confirmed: 0 });
+
+    return {
+        offerCount: openOffers.length,
+        seatsLeft: totals.seatsLeft,
+        requests: totals.requests,
+        pending: totals.pending,
+        confirmed: totals.confirmed,
+        isFull: openOffers.length > 0 && totals.seatsLeft === 0
+    };
+}
+
+export function findRequestForChild(offer = {}, parentUserId, childId) {
+    const normalized = normalizeOffer(offer);
+    if (!parentUserId || !childId) return null;
+    return normalized.requests.find((request) =>
+        request?.parentUserId === parentUserId && request?.childId === childId
+    ) || null;
+}
+
+export function canRequestRide(offer = {}, parentUserId, childId) {
+    const normalized = normalizeOffer(offer);
+    if (normalized.status !== OFFER_STATUS_OPEN) return false;
+    if (!parentUserId || !childId) return false;
+    if (normalized.driverUserId === parentUserId) return false;
+    const seatInfo = getOfferSeatInfo(normalized);
+    const existing = findRequestForChild(normalized, parentUserId, childId);
+    if (existing?.status === REQUEST_STATUS_PENDING || existing?.status === REQUEST_STATUS_CONFIRMED) return false;
+    return seatInfo.seatsLeft > 0;
+}

--- a/js/utils.js
+++ b/js/utils.js
@@ -548,6 +548,7 @@ export function expandRecurrence(master, windowDays = 180) {
   const windowEnd = new Date(now.getTime() + windowDays * 24 * 60 * 60 * 1000);
 
   const { freq, interval = 1, byDays = [], until, count } = master.recurrence;
+  const normalizedInterval = Math.max(1, Number(interval) || 1);
   const exDates = master.exDates || [];
   const overrides = master.overrides || {};
   let untilBoundary = null;
@@ -588,6 +589,9 @@ export function expandRecurrence(master, windowDays = 180) {
   const seriesStart = master.date?.toDate ? master.date.toDate() : new Date(master.date || master.createdAt?.toDate?.() || now);
   let current = new Date(seriesStart);
   let generated = 0;
+  const MS_PER_DAY = 24 * 60 * 60 * 1000;
+  const seriesStartDayNumber = Math.floor(seriesStart.getTime() / MS_PER_DAY);
+  const seriesWeekStartDayNumber = seriesStartDayNumber - seriesStart.getDay();
 
   // For weekly recurrence, we need to check each day
   const maxIterations = windowDays * 2; // Safety limit
@@ -604,16 +608,30 @@ export function expandRecurrence(master, windowDays = 180) {
 
     const isoDate = current.toISOString().split('T')[0];
     const dayCode = DAY_CODES[current.getDay()];
+    const currentDayNumber = Math.floor(current.getTime() / MS_PER_DAY);
+    const daysSinceSeriesStart = currentDayNumber - seriesStartDayNumber;
+    const currentWeekStartDayNumber = currentDayNumber - current.getDay();
+    const weeksSinceSeriesStart = Math.floor((currentWeekStartDayNumber - seriesWeekStartDayNumber) / 7);
 
     // Check if this day matches the recurrence pattern
     let matches = false;
     if (freq === 'weekly' && byDays.length > 0) {
-      matches = byDays.includes(dayCode);
+      matches = (
+        weeksSinceSeriesStart >= 0 &&
+        (weeksSinceSeriesStart % normalizedInterval === 0) &&
+        byDays.includes(dayCode) &&
+        daysSinceSeriesStart >= 0
+      );
     } else if (freq === 'daily') {
-      matches = true;
+      matches = daysSinceSeriesStart >= 0 && (daysSinceSeriesStart % normalizedInterval === 0);
     } else if (freq === 'weekly' && byDays.length === 0) {
       // If no specific days, match the same day as series start
-      matches = current.getDay() === seriesStart.getDay();
+      matches = (
+        weeksSinceSeriesStart >= 0 &&
+        (weeksSinceSeriesStart % normalizedInterval === 0) &&
+        current.getDay() === seriesStart.getDay() &&
+        daysSinceSeriesStart >= 0
+      );
     }
 
     // Only process if within visible window and matches pattern
@@ -660,11 +678,6 @@ export function expandRecurrence(master, windowDays = 180) {
 
     // Advance to next day
     current.setDate(current.getDate() + 1);
-
-    // For daily with interval > 1, skip days
-    if (freq === 'daily' && interval > 1) {
-      current.setDate(current.getDate() + interval - 1);
-    }
   }
 
   return occurrences;

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -228,7 +228,7 @@
         const practicePacketSessionMap = new Map();
         const rideshareOffersByEvent = new Map();
         const teamChildrenByTeamId = new Map();
-        const selectedRideChildBySelector = new Map();
+        const selectedRideChildByOffer = new Map();
         window.setPracticePacketFilter = setPracticePacketFilter;
         window.setScheduleFilter = setScheduleFilter;
         window.setScheduleView = setScheduleView;
@@ -279,10 +279,15 @@
             }));
         }
 
-        function setRideChildSelection(selectorId, childId) {
-            if (!selectorId) return;
-            if (!childId) selectedRideChildBySelector.delete(selectorId);
-            else selectedRideChildBySelector.set(selectorId, childId);
+        function getRideOfferSelectionKey(teamId, eventId, offerId) {
+            return `${teamId || ''}::${eventId || ''}::${offerId || ''}`;
+        }
+
+        function setRideChildSelection(teamId, eventId, offerId, childId) {
+            const selectionKey = getRideOfferSelectionKey(teamId, eventId, offerId);
+            if (!selectionKey) return;
+            if (!childId) selectedRideChildByOffer.delete(selectionKey);
+            else selectedRideChildByOffer.set(selectionKey, childId);
             rerenderActiveDayModal();
         }
 
@@ -327,8 +332,9 @@
                             const seatInfo = getOfferSeatInfo(offer);
                             const canManageOffer = offer.driverUserId === currentUserId;
                             const childSelectorId = `ride-child-${renderKey}-${offer.id}`.replace(/[^a-zA-Z0-9_-]/g, '_');
+                            const selectionKey = getRideOfferSelectionKey(event.teamId, event.id, offer.id);
                             const selectedChildId = includeChildPicker
-                                ? (selectedRideChildBySelector.get(childSelectorId) || defaultChildId)
+                                ? (selectedRideChildByOffer.get(selectionKey) || defaultChildId)
                                 : defaultChildId;
                             const selectedChild = childChoices.find((child) => child.childId === selectedChildId);
                             const selectedChildName = selectedChild?.childName || defaultChildName;
@@ -345,7 +351,7 @@
                                         </div>
                                         <div class="flex items-center gap-2">
                                             ${includeChildPicker && childChoices.length > 0 ? `
-                                                <select id="${escapeAttr(childSelectorId)}" onchange="setRideChildSelection('${escapeAttr(childSelectorId)}', this.value)" class="px-2 py-1 text-xs border border-gray-300 rounded">
+                                                <select id="${escapeAttr(childSelectorId)}" onchange="setRideChildSelection('${escapeAttr(event.teamId)}','${escapeAttr(event.id)}','${escapeAttr(offer.id)}', this.value)" class="px-2 py-1 text-xs border border-gray-300 rounded">
                                                     ${childChoices.map((child) => `<option value="${escapeAttr(child.childId)}" ${child.childId === selectedChildId ? 'selected' : ''}>${escapeHtml(child.childName)}</option>`).join('')}
                                                 </select>
                                             ` : ''}

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -291,6 +291,14 @@
             rerenderActiveDayModal();
         }
 
+        function getSelectedRideChildId(teamId, eventId, offerId, defaultChildId, childChoices, includeChildPicker) {
+            if (!includeChildPicker) return defaultChildId;
+            const selectionKey = getRideOfferSelectionKey(teamId, eventId, offerId);
+            const selectedChildId = selectedRideChildByOffer.get(selectionKey) || defaultChildId;
+            if (childChoices.some((child) => child.childId === selectedChildId)) return selectedChildId;
+            return childChoices[0]?.childId || '';
+        }
+
         function renderEventRideshare(event, { includeChildPicker = false } = {}) {
             if (!event?.isDbGame || event?.isCancelled || !event?.teamId || !event?.id) return '';
             const offers = getEventRideOffers(event.teamId, event.id);
@@ -332,10 +340,14 @@
                             const seatInfo = getOfferSeatInfo(offer);
                             const canManageOffer = offer.driverUserId === currentUserId;
                             const childSelectorId = `ride-child-${renderKey}-${offer.id}`.replace(/[^a-zA-Z0-9_-]/g, '_');
-                            const selectionKey = getRideOfferSelectionKey(event.teamId, event.id, offer.id);
-                            const selectedChildId = includeChildPicker
-                                ? (selectedRideChildByOffer.get(selectionKey) || defaultChildId)
-                                : defaultChildId;
+                            const selectedChildId = getSelectedRideChildId(
+                                event.teamId,
+                                event.id,
+                                offer.id,
+                                defaultChildId,
+                                childChoices,
+                                includeChildPicker
+                            );
                             const selectedChild = childChoices.find((child) => child.childId === selectedChildId);
                             const selectedChildName = selectedChild?.childName || defaultChildName;
                             const myRequest = findRequestForChild(offer, currentUserId, selectedChildId);

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -228,6 +228,7 @@
         const practicePacketSessionMap = new Map();
         const rideshareOffersByEvent = new Map();
         const teamChildrenByTeamId = new Map();
+        const selectedRideChildBySelector = new Map();
         window.setPracticePacketFilter = setPracticePacketFilter;
         window.setScheduleFilter = setScheduleFilter;
         window.setScheduleView = setScheduleView;
@@ -244,6 +245,7 @@
         window.updateRideRequestDecision = updateRideRequestDecision;
         window.toggleRideOfferClosed = toggleRideOfferClosed;
         window.cancelMyRideRequest = cancelMyRideRequest;
+        window.setRideChildSelection = setRideChildSelection;
 
         function escapeAttr(value) {
             return String(value ?? '')
@@ -275,6 +277,13 @@
                 childId: child.playerId,
                 childName: child.playerName || 'Player'
             }));
+        }
+
+        function setRideChildSelection(selectorId, childId) {
+            if (!selectorId) return;
+            if (!childId) selectedRideChildBySelector.delete(selectorId);
+            else selectedRideChildBySelector.set(selectorId, childId);
+            rerenderActiveDayModal();
         }
 
         function renderEventRideshare(event, { includeChildPicker = false } = {}) {
@@ -316,11 +325,16 @@
                         ? '<div class="text-xs text-gray-500 mt-2">No ride offers yet for this event.</div>'
                         : `<div class="mt-2 space-y-2">${offers.map((offer) => {
                             const seatInfo = getOfferSeatInfo(offer);
-                            const myRequest = findRequestForChild(offer, currentUserId, defaultChildId);
-                            const canRequest = canRequestRide(offer, currentUserId, defaultChildId);
                             const canManageOffer = offer.driverUserId === currentUserId;
-                            const requestableChildName = myRequest?.childName || defaultChildName;
                             const childSelectorId = `ride-child-${renderKey}-${offer.id}`.replace(/[^a-zA-Z0-9_-]/g, '_');
+                            const selectedChildId = includeChildPicker
+                                ? (selectedRideChildBySelector.get(childSelectorId) || defaultChildId)
+                                : defaultChildId;
+                            const selectedChild = childChoices.find((child) => child.childId === selectedChildId);
+                            const selectedChildName = selectedChild?.childName || defaultChildName;
+                            const myRequest = findRequestForChild(offer, currentUserId, selectedChildId);
+                            const canRequest = canRequestRide(offer, currentUserId, selectedChildId);
+                            const requestableChildName = myRequest?.childName || selectedChildName;
                             return `
                                 <div class="rounded-lg border border-gray-200 bg-white p-2">
                                     <div class="flex items-center justify-between gap-2">
@@ -331,12 +345,12 @@
                                         </div>
                                         <div class="flex items-center gap-2">
                                             ${includeChildPicker && childChoices.length > 0 ? `
-                                                <select id="${escapeAttr(childSelectorId)}" class="px-2 py-1 text-xs border border-gray-300 rounded">
-                                                    ${childChoices.map((child) => `<option value="${escapeAttr(child.childId)}" ${child.childId === defaultChildId ? 'selected' : ''}>${escapeHtml(child.childName)}</option>`).join('')}
+                                                <select id="${escapeAttr(childSelectorId)}" onchange="setRideChildSelection('${escapeAttr(childSelectorId)}', this.value)" class="px-2 py-1 text-xs border border-gray-300 rounded">
+                                                    ${childChoices.map((child) => `<option value="${escapeAttr(child.childId)}" ${child.childId === selectedChildId ? 'selected' : ''}>${escapeHtml(child.childName)}</option>`).join('')}
                                                 </select>
                                             ` : ''}
                                             ${canRequest ? `
-                                                <button onclick="requestRideSpotForChild('${escapeAttr(event.teamId)}','${escapeAttr(event.id)}','${escapeAttr(offer.id)}','${escapeAttr(defaultChildId)}','${escapeAttr(defaultChildName)}','${escapeAttr(childSelectorId)}')" class="px-2 py-1 text-xs rounded border border-emerald-300 bg-emerald-50 text-emerald-700 font-semibold hover:bg-emerald-100">Request Spot</button>
+                                                <button onclick="requestRideSpotForChild('${escapeAttr(event.teamId)}','${escapeAttr(event.id)}','${escapeAttr(offer.id)}','${escapeAttr(selectedChildId)}','${escapeAttr(selectedChildName)}','${escapeAttr(childSelectorId)}')" class="px-2 py-1 text-xs rounded border border-emerald-300 bg-emerald-50 text-emerald-700 font-semibold hover:bg-emerald-100">Request Spot</button>
                                             ` : ''}
                                             ${myRequest ? `
                                                 <button onclick="cancelMyRideRequest('${escapeAttr(event.teamId)}','${escapeAttr(event.id)}','${escapeAttr(offer.id)}','${escapeAttr(myRequest.id)}')" class="px-2 py-1 text-xs rounded border border-gray-300 bg-white text-gray-600 font-semibold hover:bg-gray-50">Cancel</button>

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -186,11 +186,32 @@
     </div>
 
     <script type="module">
-        import { getParentDashboardData, redeemParentInvite, getTeam, getGames, getTrackedCalendarEventUids, getUnreadChatCounts, getPracticeSessions, getPracticePacketCompletions, upsertPracticePacketCompletion, updateUserProfile, getUserProfile, submitRsvp, getMyRsvp } from './js/db.js?v=22';
+        import {
+            getParentDashboardData,
+            redeemParentInvite,
+            getTeam,
+            getGames,
+            getTrackedCalendarEventUids,
+            getUnreadChatCounts,
+            getPracticeSessions,
+            getPracticePacketCompletions,
+            upsertPracticePacketCompletion,
+            updateUserProfile,
+            getUserProfile,
+            submitRsvp,
+            getMyRsvp,
+            createRideOffer,
+            listRideOffersForEvent,
+            requestRideSpot,
+            updateRideRequestStatus,
+            closeRideOffer,
+            cancelRideRequest
+        } from './js/db.js?v=22';
         import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence } from './js/utils.js?v=8';
         import { requireAuth, checkAuth } from './js/auth.js?v=9';
         import { resolvePracticePacketSessionIdForEvent as resolvePracticePacketSessionIdForEventBase, resolvePracticePacketContextForEvent as resolvePracticePacketContextForEventBase } from './js/parent-dashboard-packets.js?v=2';
         import { resolveRsvpPlayerIdsForSubmission } from './js/parent-dashboard-rsvp.js?v=2';
+        import { getEventRideshareSummary, getOfferSeatInfo, canRequestRide, findRequestForChild } from './js/rideshare-helpers.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -203,7 +224,10 @@
         let scheduleViewMode = 'list';
         let scheduleCalendarMonth = new Date().getMonth();
         let scheduleCalendarYear = new Date().getFullYear();
+        let activeDayModal = null;
         const practicePacketSessionMap = new Map();
+        const rideshareOffersByEvent = new Map();
+        const teamChildrenByTeamId = new Map();
         window.setPracticePacketFilter = setPracticePacketFilter;
         window.setScheduleFilter = setScheduleFilter;
         window.setScheduleView = setScheduleView;
@@ -214,6 +238,12 @@
         window.closePracticePacketPreview = closePracticePacketPreview;
         window.markPracticePacketComplete = markPracticePacketComplete;
         window.submitGameRsvpFromButton = submitGameRsvpFromButton;
+        window.toggleRideOfferForm = toggleRideOfferForm;
+        window.submitRideOfferFromForm = submitRideOfferFromForm;
+        window.requestRideSpotForChild = requestRideSpotForChild;
+        window.updateRideRequestDecision = updateRideRequestDecision;
+        window.toggleRideOfferClosed = toggleRideOfferClosed;
+        window.cancelMyRideRequest = cancelMyRideRequest;
 
         function escapeAttr(value) {
             return String(value ?? '')
@@ -227,6 +257,231 @@
         function formatRsvpSummary(summary) {
             if (!summary) return 'No RSVPs yet.';
             return `${summary.going || 0} going · ${summary.maybe || 0} maybe · ${summary.notGoing || 0} can't go · ${summary.notResponded || 0} no response`;
+        }
+
+        window.submitGameRsvp = async function(teamId, gameId, response, childContext = {}) {
+        function getEventRideKey(teamId, eventId) {
+            return `${teamId || ''}::${eventId || ''}`;
+        }
+
+        function getEventRideOffers(teamId, eventId) {
+            const key = getEventRideKey(teamId, eventId);
+            return rideshareOffersByEvent.get(key) || [];
+        }
+
+        function resolveChildChoices(teamId) {
+            const children = teamChildrenByTeamId.get(teamId) || [];
+            return children.filter((child) => child?.playerId).map((child) => ({
+                childId: child.playerId,
+                childName: child.playerName || 'Player'
+            }));
+        }
+
+        function renderEventRideshare(event, { includeChildPicker = false } = {}) {
+            if (!event?.isDbGame || event?.isCancelled || !event?.teamId || !event?.id) return '';
+            const offers = getEventRideOffers(event.teamId, event.id);
+            const summary = getEventRideshareSummary(offers);
+            const eventKey = getEventRideKey(event.teamId, event.id);
+            const renderKey = `${eventKey}::${includeChildPicker ? 'modal' : (event.childId || 'row')}`.replace(/[^a-zA-Z0-9_-]/g, '_');
+            const childChoices = resolveChildChoices(event.teamId);
+            const defaultChildId = event?.childId || childChoices[0]?.childId || '';
+            const defaultChildName = event?.childName || childChoices[0]?.childName || 'Player';
+
+            return `
+                <div class="mt-3 border-t border-gray-100 pt-3">
+                    <div class="flex items-center justify-between gap-2">
+                        <div class="text-[11px] font-bold uppercase tracking-wide text-gray-500">Rideshare</div>
+                        <div class="flex items-center gap-1 text-[10px]">
+                            <span class="px-2 py-0.5 rounded-full border border-blue-200 bg-blue-50 text-blue-700 font-semibold">${summary.seatsLeft} seats left</span>
+                            <span class="px-2 py-0.5 rounded-full border border-gray-200 bg-gray-50 text-gray-600 font-semibold">${summary.requests} requests</span>
+                            ${summary.isFull ? '<span class="px-2 py-0.5 rounded-full border border-red-200 bg-red-50 text-red-700 font-semibold">Full</span>' : ''}
+                        </div>
+                    </div>
+                    <div class="mt-2 flex items-center gap-2">
+                        <button onclick="toggleRideOfferForm('${escapeAttr(renderKey)}')" class="text-xs font-semibold text-primary-700 bg-primary-50 border border-primary-200 px-2 py-1 rounded hover:bg-primary-100">Offer Ride</button>
+                    </div>
+                    <div id="ride-offer-form-${escapeAttr(renderKey)}" class="hidden mt-2 rounded-lg border border-primary-100 bg-primary-50 p-2">
+                        <div class="grid grid-cols-3 gap-2">
+                            <input id="ride-seats-${escapeAttr(renderKey)}" type="number" min="1" max="12" value="3" class="col-span-1 px-2 py-1 text-xs border border-gray-300 rounded" placeholder="Seats">
+                            <select id="ride-direction-${escapeAttr(renderKey)}" class="col-span-1 px-2 py-1 text-xs border border-gray-300 rounded">
+                                <option value="to">To Event</option>
+                                <option value="from">From Event</option>
+                                <option value="round-trip">Round Trip</option>
+                            </select>
+                            <button onclick="submitRideOfferFromForm('${escapeAttr(event.teamId)}','${escapeAttr(event.id)}','${escapeAttr(renderKey)}')" class="col-span-1 px-2 py-1 text-xs rounded bg-primary-600 text-white font-semibold hover:bg-primary-700">Save</button>
+                        </div>
+                        <input id="ride-note-${escapeAttr(renderKey)}" type="text" maxlength="160" class="mt-2 w-full px-2 py-1 text-xs border border-gray-300 rounded" placeholder="Optional note">
+                    </div>
+                    ${offers.length === 0
+                        ? '<div class="text-xs text-gray-500 mt-2">No ride offers yet for this event.</div>'
+                        : `<div class="mt-2 space-y-2">${offers.map((offer) => {
+                            const seatInfo = getOfferSeatInfo(offer);
+                            const myRequest = findRequestForChild(offer, currentUserId, defaultChildId);
+                            const canRequest = canRequestRide(offer, currentUserId, defaultChildId);
+                            const canManageOffer = offer.driverUserId === currentUserId;
+                            const requestableChildName = myRequest?.childName || defaultChildName;
+                            const childSelectorId = `ride-child-${renderKey}-${offer.id}`.replace(/[^a-zA-Z0-9_-]/g, '_');
+                            return `
+                                <div class="rounded-lg border border-gray-200 bg-white p-2">
+                                    <div class="flex items-center justify-between gap-2">
+                                        <div>
+                                            <div class="text-xs font-semibold text-gray-900">${escapeHtml(offer.driverName || 'Driver')} · ${escapeHtml(offer.direction || 'to')}</div>
+                                            <div class="text-[11px] text-gray-500">${seatInfo.seatCountConfirmed}/${seatInfo.seatCapacity} confirmed · ${seatInfo.seatsLeft} left</div>
+                                            ${offer.note ? `<div class="text-[11px] text-gray-500 italic mt-0.5">${escapeHtml(offer.note)}</div>` : ''}
+                                        </div>
+                                        <div class="flex items-center gap-2">
+                                            ${includeChildPicker && childChoices.length > 0 ? `
+                                                <select id="${escapeAttr(childSelectorId)}" class="px-2 py-1 text-xs border border-gray-300 rounded">
+                                                    ${childChoices.map((child) => `<option value="${escapeAttr(child.childId)}" ${child.childId === defaultChildId ? 'selected' : ''}>${escapeHtml(child.childName)}</option>`).join('')}
+                                                </select>
+                                            ` : ''}
+                                            ${canRequest ? `
+                                                <button onclick="requestRideSpotForChild('${escapeAttr(event.teamId)}','${escapeAttr(event.id)}','${escapeAttr(offer.id)}','${escapeAttr(defaultChildId)}','${escapeAttr(defaultChildName)}','${escapeAttr(childSelectorId)}')" class="px-2 py-1 text-xs rounded border border-emerald-300 bg-emerald-50 text-emerald-700 font-semibold hover:bg-emerald-100">Request Spot</button>
+                                            ` : ''}
+                                            ${myRequest ? `
+                                                <button onclick="cancelMyRideRequest('${escapeAttr(event.teamId)}','${escapeAttr(event.id)}','${escapeAttr(offer.id)}','${escapeAttr(myRequest.id)}')" class="px-2 py-1 text-xs rounded border border-gray-300 bg-white text-gray-600 font-semibold hover:bg-gray-50">Cancel</button>
+                                            ` : ''}
+                                            ${canManageOffer ? `
+                                                <button onclick="toggleRideOfferClosed('${escapeAttr(event.teamId)}','${escapeAttr(event.id)}','${escapeAttr(offer.id)}','${escapeAttr(offer.status)}')" class="px-2 py-1 text-xs rounded border border-orange-300 bg-orange-50 text-orange-700 font-semibold hover:bg-orange-100">${offer.status === 'open' ? 'Close' : 'Reopen'}</button>
+                                            ` : ''}
+                                        </div>
+                                    </div>
+                                    ${myRequest ? `<div class="text-[11px] mt-1 font-semibold ${myRequest.status === 'confirmed' ? 'text-emerald-700' : myRequest.status === 'waitlisted' ? 'text-amber-700' : myRequest.status === 'declined' ? 'text-red-700' : 'text-gray-600'}">Your request for ${escapeHtml(requestableChildName)}: ${escapeHtml(myRequest.status || 'pending')}</div>` : ''}
+                                    ${canManageOffer && offer.requests?.length
+                                        ? `<div class="mt-2 pt-2 border-t border-gray-100 space-y-1">
+                                            ${offer.requests.map((request) => `
+                                                <div class="flex items-center justify-between gap-2 text-[11px]">
+                                                    <span class="text-gray-700">${escapeHtml(request.childName || 'Player')} · ${escapeHtml(request.status || 'pending')}</span>
+                                                    <div class="flex items-center gap-1">
+                                                        <button onclick="updateRideRequestDecision('${escapeAttr(event.teamId)}','${escapeAttr(event.id)}','${escapeAttr(offer.id)}','${escapeAttr(request.id)}','confirmed')" class="px-1.5 py-0.5 rounded border border-emerald-300 text-emerald-700 bg-emerald-50">Confirm</button>
+                                                        <button onclick="updateRideRequestDecision('${escapeAttr(event.teamId)}','${escapeAttr(event.id)}','${escapeAttr(offer.id)}','${escapeAttr(request.id)}','waitlisted')" class="px-1.5 py-0.5 rounded border border-amber-300 text-amber-700 bg-amber-50">Waitlist</button>
+                                                        <button onclick="updateRideRequestDecision('${escapeAttr(event.teamId)}','${escapeAttr(event.id)}','${escapeAttr(offer.id)}','${escapeAttr(request.id)}','declined')" class="px-1.5 py-0.5 rounded border border-red-300 text-red-700 bg-red-50">Decline</button>
+                                                    </div>
+                                                </div>
+                                            `).join('')}
+                                        </div>`
+                                        : ''
+                                    }
+                                </div>
+                            `;
+                        }).join('')}</div>`
+                    }
+                </div>
+            `;
+        }
+
+        function rerenderActiveDayModal() {
+            if (!activeDayModal) return;
+            openScheduleDayModal(activeDayModal.year, activeDayModal.month, activeDayModal.day);
+        }
+
+        async function refreshRideshareForEvent(teamId, gameId) {
+            const key = getEventRideKey(teamId, gameId);
+            try {
+                const offers = await listRideOffersForEvent(teamId, gameId);
+                rideshareOffersByEvent.set(key, offers);
+            } catch (err) {
+                console.warn('Unable to load rideshare offers for event:', teamId, gameId, err);
+                rideshareOffersByEvent.set(key, []);
+            }
+        }
+
+        async function hydrateRideshareOffersForSchedule(events = []) {
+            const uniqueDbEvents = [...new Set(
+                (events || [])
+                    .filter((ev) => ev?.isDbGame && ev?.teamId && ev?.id)
+                    .map((ev) => getEventRideKey(ev.teamId, ev.id))
+            )];
+            await Promise.all(uniqueDbEvents.map(async (key) => {
+                const [teamId, gameId] = key.split('::');
+                await refreshRideshareForEvent(teamId, gameId);
+            }));
+        }
+
+        function toggleRideOfferForm(eventKey) {
+            const panel = document.getElementById(`ride-offer-form-${eventKey}`);
+            if (!panel) return;
+            panel.classList.toggle('hidden');
+        }
+
+        async function submitRideOfferFromForm(teamId, gameId, eventKey) {
+            try {
+                const seatsEl = document.getElementById(`ride-seats-${eventKey}`);
+                const directionEl = document.getElementById(`ride-direction-${eventKey}`);
+                const noteEl = document.getElementById(`ride-note-${eventKey}`);
+                const seatCapacity = Number.parseInt(seatsEl?.value || '0', 10);
+                await createRideOffer(teamId, gameId, {
+                    seatCapacity,
+                    direction: directionEl?.value || 'to',
+                    note: noteEl?.value || '',
+                    driverName: currentUser?.displayName || currentUser?.email || 'Parent Driver'
+                });
+                await refreshRideshareForEvent(teamId, gameId);
+                renderScheduleFromControls();
+                rerenderActiveDayModal();
+                toggleRideOfferForm(eventKey);
+            } catch (err) {
+                console.error('Failed to create ride offer:', err);
+                alert(`Could not create ride offer: ${err?.message || err}`);
+            }
+        }
+
+        async function requestRideSpotForChild(teamId, gameId, offerId, defaultChildId, defaultChildName, selectorId = '') {
+            try {
+                let childId = defaultChildId;
+                let childName = defaultChildName;
+                const selector = selectorId ? document.getElementById(selectorId) : null;
+                if (selector) {
+                    childId = selector.value || childId;
+                    const selected = resolveChildChoices(teamId).find((child) => child.childId === childId);
+                    childName = selected?.childName || childName;
+                }
+                if (!childId) throw new Error('Select a child first.');
+                await requestRideSpot(teamId, gameId, offerId, { childId, childName });
+                await refreshRideshareForEvent(teamId, gameId);
+                renderScheduleFromControls();
+                rerenderActiveDayModal();
+            } catch (err) {
+                console.error('Failed to request spot:', err);
+                alert(`Could not request spot: ${err?.message || err}`);
+            }
+        }
+
+        async function updateRideRequestDecision(teamId, gameId, offerId, requestId, status) {
+            try {
+                await updateRideRequestStatus(teamId, gameId, offerId, requestId, status);
+                await refreshRideshareForEvent(teamId, gameId);
+                renderScheduleFromControls();
+                rerenderActiveDayModal();
+            } catch (err) {
+                console.error('Failed to update request decision:', err);
+                alert(`Could not update request: ${err?.message || err}`);
+            }
+        }
+
+        async function toggleRideOfferClosed(teamId, gameId, offerId, currentStatus) {
+            try {
+                const nextStatus = currentStatus === 'open' ? 'closed' : 'open';
+                await closeRideOffer(teamId, gameId, offerId, nextStatus);
+                await refreshRideshareForEvent(teamId, gameId);
+                renderScheduleFromControls();
+                rerenderActiveDayModal();
+            } catch (err) {
+                console.error('Failed to update offer status:', err);
+                alert(`Could not update offer: ${err?.message || err}`);
+            }
+        }
+
+        async function cancelMyRideRequest(teamId, gameId, offerId, requestId) {
+            try {
+                await cancelRideRequest(teamId, gameId, offerId, requestId);
+                await refreshRideshareForEvent(teamId, gameId);
+                renderScheduleFromControls();
+                rerenderActiveDayModal();
+            } catch (err) {
+                console.error('Failed to cancel request:', err);
+                alert(`Could not cancel request: ${err?.message || err}`);
+            }
         }
 
         window.submitGameRsvp = async function(teamId, gameId, response, childContext = {}) {
@@ -300,6 +555,12 @@
 
                 const data = await getParentDashboardData(user.uid);
                 renderPlayers(data.children);
+                teamChildrenByTeamId.clear();
+                (data.children || []).forEach((child) => {
+                    if (!child?.teamId) return;
+                    if (!teamChildrenByTeamId.has(child.teamId)) teamChildrenByTeamId.set(child.teamId, []);
+                    teamChildrenByTeamId.get(child.teamId).push(child);
+                });
 
                 // Get unique team IDs and fetch unread counts
                 const teamIds = [...new Set(data.children.map(c => c.teamId).filter(Boolean))];
@@ -308,6 +569,7 @@
                 renderTeamChats(data.children, unreadCounts);
                 const combinedSchedule = await buildCombinedSchedule(data.children);
                 allScheduleEvents = combinedSchedule;
+                await hydrateRideshareOffersForSchedule(allScheduleEvents);
 
                 // Fetch my RSVPs for tracked DB events (games + practices).
                 const uniqueGameKeys = [...new Set(
@@ -763,6 +1025,7 @@
             const contentEl = document.getElementById('schedule-day-modal-content');
             const modalEl = document.getElementById('schedule-day-modal');
             if (!titleEl || !contentEl || !modalEl) return;
+            activeDayModal = { year, month, day };
 
             const dayStart = new Date(year, month, day);
             const dayEnd = new Date(year, month, day, 23, 59, 59);
@@ -822,6 +1085,7 @@
                                     <div class="text-xs text-gray-500 mt-1">${formatRsvpSummary(ev.rsvpSummary)}</div>
                                 </div>
                             ` : ''}
+                            ${renderEventRideshare(ev, { includeChildPicker: true })}
                             ${ev.isCancelled ? '<div class="text-xs text-red-700 mt-1 font-semibold">Cancelled</div>' : ''}
                         </div>
                     `;
@@ -831,6 +1095,7 @@
         }
 
         function closeScheduleDayModal() {
+            activeDayModal = null;
             document.getElementById('schedule-day-modal')?.classList.add('hidden');
         }
 
@@ -1284,6 +1549,7 @@
                             <div class="text-[10px] text-gray-400 mt-1">${formatRsvpSummary(game.rsvpSummary)}</div>
                         </div>
                     ` : ''}
+                    ${renderEventRideshare(game)}
                     ${!isCancelled && game.isDbGame ? `
                     <div class="flex-shrink-0 text-right">
                          <a href="game.html?teamId=${game.teamId}&gameId=${game.id}"

--- a/tests/unit/recurrence-expand.test.js
+++ b/tests/unit/recurrence-expand.test.js
@@ -1,0 +1,84 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { expandRecurrence } from '../../js/utils.js';
+
+describe('expandRecurrence interval guardrails', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('honors daily interval in matching and does not double-advance', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-10T12:00:00Z'));
+
+    const master = {
+      id: 'series-daily-3',
+      isSeriesMaster: true,
+      date: new Date('2026-01-01T12:00:00Z'),
+      recurrence: {
+        freq: 'daily',
+        interval: 3
+      }
+    };
+
+    const dates = expandRecurrence(master, 20).map((occ) => occ.instanceDate);
+    expect(dates.slice(0, 6)).toEqual([
+      '2026-01-01',
+      '2026-01-04',
+      '2026-01-07',
+      '2026-01-10',
+      '2026-01-13',
+      '2026-01-16'
+    ]);
+  });
+
+  it('computes weekly interval from calendar week boundaries for multi-day schedules', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-10T12:00:00Z'));
+
+    const master = {
+      id: 'series-weekly-2',
+      isSeriesMaster: true,
+      date: new Date('2026-01-07T12:00:00Z'),
+      recurrence: {
+        freq: 'weekly',
+        interval: 2,
+        byDays: ['MO', 'WE']
+      }
+    };
+
+    const dates = expandRecurrence(master, 35).map((occ) => occ.instanceDate);
+    expect(dates.slice(0, 5)).toEqual([
+      '2026-01-07',
+      '2026-01-19',
+      '2026-01-21',
+      '2026-02-02',
+      '2026-02-04'
+    ]);
+  });
+
+  it('skips off-cadence weekdays in the immediate next week for biweekly multi-day rules', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-05T12:00:00Z'));
+
+    const master = {
+      id: 'series-weekly-2-wed-mo',
+      isSeriesMaster: true,
+      date: new Date('2026-03-04T12:00:00Z'),
+      recurrence: {
+        freq: 'weekly',
+        interval: 2,
+        byDays: ['MO', 'WE']
+      }
+    };
+
+    const dates = expandRecurrence(master, 35).map((occ) => occ.instanceDate);
+    expect(dates.slice(0, 5)).toEqual([
+      '2026-03-04',
+      '2026-03-16',
+      '2026-03-18',
+      '2026-03-30',
+      '2026-04-01'
+    ]);
+    expect(dates).not.toContain('2026-03-09');
+  });
+});

--- a/tests/unit/rideshare-helpers.test.js
+++ b/tests/unit/rideshare-helpers.test.js
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import {
+  canRequestRide,
+  findRequestForChild,
+  getEventRideshareSummary,
+  getOfferSeatInfo,
+  getRequestStatusCounts,
+  normalizeOffer
+} from '../../js/rideshare-helpers.js';
+
+describe('rideshare helpers', () => {
+  it('normalizes seat counts and status', () => {
+    const normalized = normalizeOffer({
+      status: 'OPEN',
+      seatCapacity: '3',
+      seatCountConfirmed: '1',
+      requests: null
+    });
+    expect(normalized.status).toBe('open');
+    expect(normalized.seatCapacity).toBe(3);
+    expect(normalized.seatCountConfirmed).toBe(1);
+    expect(normalized.requests).toEqual([]);
+  });
+
+  it('computes seat info and full state', () => {
+    expect(getOfferSeatInfo({ seatCapacity: 4, seatCountConfirmed: 2, status: 'open' })).toEqual({
+      seatCapacity: 4,
+      seatCountConfirmed: 2,
+      seatsLeft: 2,
+      isFull: false
+    });
+
+    expect(getOfferSeatInfo({ seatCapacity: 2, seatCountConfirmed: 2, status: 'open' }).isFull).toBe(true);
+  });
+
+  it('counts request statuses', () => {
+    const counts = getRequestStatusCounts({
+      requests: [
+        { status: 'pending' },
+        { status: 'confirmed' },
+        { status: 'waitlisted' },
+        { status: 'declined' },
+        { status: 'anything' }
+      ]
+    });
+    expect(counts).toEqual({
+      pending: 2,
+      confirmed: 1,
+      waitlisted: 1,
+      declined: 1
+    });
+  });
+
+  it('aggregates event-level rideshare summary from open offers', () => {
+    const summary = getEventRideshareSummary([
+      {
+        status: 'open',
+        seatCapacity: 3,
+        seatCountConfirmed: 1,
+        requests: [{ status: 'pending' }, { status: 'confirmed' }]
+      },
+      {
+        status: 'closed',
+        seatCapacity: 4,
+        seatCountConfirmed: 0,
+        requests: [{ status: 'pending' }]
+      }
+    ]);
+
+    expect(summary.offerCount).toBe(1);
+    expect(summary.seatsLeft).toBe(2);
+    expect(summary.requests).toBe(2);
+    expect(summary.pending).toBe(1);
+    expect(summary.confirmed).toBe(1);
+  });
+
+  it('finds request for a specific parent + child', () => {
+    const offer = {
+      requests: [
+        { parentUserId: 'u1', childId: 'c1', status: 'pending' },
+        { parentUserId: 'u2', childId: 'c2', status: 'confirmed' }
+      ]
+    };
+    expect(findRequestForChild(offer, 'u2', 'c2')?.status).toBe('confirmed');
+    expect(findRequestForChild(offer, 'u3', 'c9')).toBeNull();
+  });
+
+  it('allows request only when rider is not driver and seat is available', () => {
+    const offer = {
+      status: 'open',
+      driverUserId: 'driver-1',
+      seatCapacity: 2,
+      seatCountConfirmed: 1,
+      requests: [{ parentUserId: 'parent-2', childId: 'child-2', status: 'confirmed' }]
+    };
+    expect(canRequestRide(offer, 'parent-3', 'child-3')).toBe(true);
+    expect(canRequestRide(offer, 'driver-1', 'child-4')).toBe(false);
+    expect(canRequestRide(offer, 'parent-2', 'child-2')).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- add rideshare offer/request data helpers with transactional seat-count protection
- add parent-dashboard rideshare UI in schedule list cards and calendar day modal
- add Firestore rules for `rideOffers` and nested `requests` with parent-child and driver/admin constraints
- add rideshare helper module + unit tests for event summaries, seat logic, and request eligibility

## Validation
- `./node_modules/.bin/vitest run tests/unit/*.test.js` (53 tests passed)
- `node --check js/db.js`
- `node --check js/rideshare-helpers.js`
- extracted module syntax check for `parent-dashboard.html`

## Role Summaries
- Requirements: `docs/pr-notes/requirements.md`
- Architecture: `docs/pr-notes/architecture.md`
- QA: `docs/pr-notes/qa.md`
- Code Plan: `docs/pr-notes/code-plan.md`

Closes #53
