### PR TITLE
Route login invite links through invite redemption flow

### DIFF
--- a/accept-invite.html
+++ b/accept-invite.html
@@ -366,7 +366,7 @@
             checkAuth(async (user) => {
                 if (!user) {
                     // Not logged in - redirect to login with the code
-                    window.location.href = `login.html?code=${code}`;
+                    window.location.href = `login.html?code=${code}&type=${encodeURIComponent(inviteType)}`;
                     return;
                 }
 

--- a/docs/pr-notes/runs/issue-43-fixer-20260225T190937Z/architecture.md
+++ b/docs/pr-notes/runs/issue-43-fixer-20260225T190937Z/architecture.md
@@ -1,0 +1,23 @@
+# Architecture role output
+
+## Root cause
+`login.html` consumes `code` only to toggle signup UI. Post-auth redirects always call `getRedirectUrl(user)` and never invoke invite redemption.
+
+## Minimal design
+- Introduce a tiny pure helper module for redirect resolution.
+- Helper chooses `accept-invite.html?code=...` only when:
+  - caller indicates invite redemption is required, and
+  - code is valid 8-char token.
+- Update `login.html` post-auth redirects to call helper in login paths.
+
+## Blast radius
+- Low; only login-page redirect decisions and one new pure helper module.
+- No Firestore schema/rules changes.
+
+## Control equivalence
+- Invite processing still centralized in `accept-invite.html`.
+- No elevated data access added.
+- Audit trail remains via existing access code usage updates during redemption.
+
+## Rollback
+- Revert helper import and redirect calls in `login.html`.

--- a/docs/pr-notes/runs/issue-43-fixer-20260225T190937Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-43-fixer-20260225T190937Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code role output
+
+## Plan
+1. Add `js/invite-redirect.js` pure helper with invite-code normalization and redirect selection.
+2. Add `tests/unit/invite-redirect.test.js` with expected failing case for invite redemption redirect.
+3. Wire `login.html` auth-success branches to use helper when processing login with invite code.
+4. Run targeted test then full `tests/unit`.
+5. Commit with issue reference.
+
+## Conflict resolution synthesis
+- Requirements and architecture align on routing to `accept-invite` rather than duplicating redemption logic in login.
+- QA requests unit coverage; we satisfy with pure helper tests to avoid brittle DOM tests.

--- a/docs/pr-notes/runs/issue-43-fixer-20260225T190937Z/qa.md
+++ b/docs/pr-notes/runs/issue-43-fixer-20260225T190937Z/qa.md
@@ -1,0 +1,17 @@
+# QA role output
+
+## Test strategy
+- Add unit tests for redirect helper:
+  - invite code + redemption path => `accept-invite.html?code=...`
+  - no code => default redirect
+  - malformed code => default redirect
+  - redemption flag off => default redirect
+- Run targeted test file first to show failure before fix.
+- Run full unit suite after fix.
+
+## Regression guardrails
+- Verify signup flow still uses activation code behavior.
+- Verify standard login without invite still routes by role.
+
+## Residual risk
+- Google redirect mode differences may require future focused e2e if invite link is used with social login.

--- a/docs/pr-notes/runs/issue-43-fixer-20260225T190937Z/requirements.md
+++ b/docs/pr-notes/runs/issue-43-fixer-20260225T190937Z/requirements.md
@@ -1,0 +1,18 @@
+# Requirements role output
+
+## Objective
+Fix existing-user invite acceptance so invite links with `code` redeem after authentication.
+
+## Current vs proposed
+- Current: Existing-user link points to `login.html?code=...`; login path ignores code and redirects to dashboard.
+- Proposed: After successful auth in login flow, if a valid invite code is present and user is in login redemption path, route to `accept-invite.html?code=...` so invite redemption logic runs.
+
+## Constraints
+- Keep signup activation flow unchanged for new users.
+- Keep patch minimal and low-risk.
+- Add automated unit coverage for redirect decision logic.
+
+## Success criteria
+- Existing user opening an invite link and logging in lands on invite redemption path.
+- No regression for normal login (no invite code).
+- Tests cover redirect behavior for invite and non-invite cases.

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -652,7 +652,7 @@
         function setupCopyLinkButton(buttonId, codeId) {
             document.getElementById(buttonId).addEventListener('click', async () => {
                 const code = document.getElementById(codeId).textContent;
-                const signupUrl = `${window.location.origin}/login.html?code=${code}`;
+                const signupUrl = `${window.location.origin}/login.html?code=${code}&type=parent`;
                 try {
                     await navigator.clipboard.writeText(signupUrl);
                     const btn = document.getElementById(buttonId);

--- a/edit-team.html
+++ b/edit-team.html
@@ -423,7 +423,7 @@
         // Copy admin signup link button
         document.getElementById('copy-admin-link-btn').addEventListener('click', async () => {
             const code = document.getElementById('admin-code-text').textContent;
-            const signupUrl = `${window.location.origin}/login.html?code=${code}`;
+            const signupUrl = `${window.location.origin}/login.html?code=${code}&type=admin`;
             try {
                 await navigator.clipboard.writeText(signupUrl);
                 const btn = document.getElementById('copy-admin-link-btn');

--- a/js/invite-redirect.js
+++ b/js/invite-redirect.js
@@ -1,0 +1,12 @@
+export function normalizeInviteCode(inviteCode) {
+    const normalized = typeof inviteCode === 'string' ? inviteCode.trim().toUpperCase() : '';
+    return normalized.length === 8 ? normalized : null;
+}
+
+export function getPostAuthRedirectUrl(defaultRedirectUrl, inviteCode, shouldRedeemInvite = false) {
+    const normalizedCode = normalizeInviteCode(inviteCode);
+    if (shouldRedeemInvite && normalizedCode) {
+        return `accept-invite.html?code=${encodeURIComponent(normalizedCode)}`;
+    }
+    return defaultRedirectUrl;
+}

--- a/login.html
+++ b/login.html
@@ -98,11 +98,23 @@
         import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=9';
         import { getUserProfile } from './js/db.js?v=14';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
+        import { getPostAuthRedirectUrl } from './js/invite-redirect.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
 
         let isLogin = true;
         let isProcessingAuth = false; // Flag to prevent auto-redirect during login/signup
+
+        // Read invite-related URL params once for redirect decisions.
+        const urlParams = new URLSearchParams(window.location.search);
+        const urlCodeParam = urlParams.get('code');
+        const urlInviteType = urlParams.get('type');
+        const shouldRedeemInviteFromLogin = urlInviteType === 'parent' || urlInviteType === 'admin';
+
+        function getPostAuthRedirect(userWithRoles, shouldRedeemInvite = false) {
+            const defaultRedirect = getRedirectUrl(userWithRoles);
+            return getPostAuthRedirectUrl(defaultRedirect, urlCodeParam, shouldRedeemInvite);
+        }
 
         // Handle Google redirect result on page load
         (async () => {
@@ -121,7 +133,10 @@
                     const profile = await getUserProfile(result.user.uid);
                     console.log('[Login Page] Profile fetched:', profile);
                     const userWithRoles = { ...result.user, ...profile };
-                    const redirectUrl = getRedirectUrl(userWithRoles);
+                    const googleAuthMode = window.sessionStorage.getItem('postGoogleAuthMode');
+                    window.sessionStorage.removeItem('postGoogleAuthMode');
+                    const shouldRedeemInvite = shouldRedeemInviteFromLogin && googleAuthMode === 'login';
+                    const redirectUrl = getPostAuthRedirect(userWithRoles, shouldRedeemInvite);
                     console.log('[Login Page] Redirecting to:', redirectUrl);
                     window.location.href = redirectUrl;
                     return; // Prevent further initialization
@@ -142,7 +157,6 @@
         })();
 
         // Auto-fill activation code from URL parameter
-        const urlCodeParam = new URLSearchParams(window.location.search).get('code');
         if (urlCodeParam && urlCodeParam.length === 8) {
             // Switch to signup mode
             isLogin = false;
@@ -184,7 +198,7 @@
         checkAuth((user) => {
             // Only auto-redirect if not currently processing login/signup
             if (user && !isProcessingAuth) {
-                window.location.href = getRedirectUrl(user);
+                window.location.href = getPostAuthRedirect(user, shouldRedeemInviteFromLogin);
             }
             renderHeader(document.getElementById('header-container'), user);
         });
@@ -237,7 +251,7 @@
                     // Fetch profile to determine redirect
                     const profile = await getUserProfile(userCredential.user.uid);
                     const userWithRoles = { ...userCredential.user, ...profile };
-                    window.location.href = getRedirectUrl(userWithRoles);
+                    window.location.href = getPostAuthRedirect(userWithRoles, shouldRedeemInviteFromLogin);
                 } else {
                     // Signup mode - validate password confirmation
                     const confirmPassword = document.getElementById('confirm-password').value;
@@ -267,6 +281,7 @@
             errorDiv.classList.add('hidden');
 
             try {
+                window.sessionStorage.setItem('postGoogleAuthMode', isLogin ? 'login' : 'signup');
                 // If in signup mode, validate activation code before starting auth
                 let activationCode = null;
                 if (!isLogin) {
@@ -284,10 +299,12 @@
                     console.log('[Login Page] Popup succeeded, redirecting...');
                     const profile = await getUserProfile(result.user.uid);
                     const userWithRoles = { ...result.user, ...profile };
-                    window.location.href = getRedirectUrl(userWithRoles);
+                    const shouldRedeemInvite = shouldRedeemInviteFromLogin && isLogin;
+                    window.location.href = getPostAuthRedirect(userWithRoles, shouldRedeemInvite);
                 }
                 // If result is null, redirect flow was triggered - page will reload
             } catch (error) {
+                window.sessionStorage.removeItem('postGoogleAuthMode');
                 errorDiv.textContent = error.message;
                 errorDiv.classList.remove('hidden');
                 console.error(error);

--- a/tests/unit/invite-redirect.test.js
+++ b/tests/unit/invite-redirect.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeInviteCode, getPostAuthRedirectUrl } from '../../js/invite-redirect.js';
+
+describe('invite redirect helper', () => {
+    it('normalizes valid invite codes', () => {
+        expect(normalizeInviteCode(' abcd1234 ')).toBe('ABCD1234');
+    });
+
+    it('returns null for malformed invite codes', () => {
+        expect(normalizeInviteCode('short')).toBe(null);
+    });
+
+    it('routes login to invite acceptance when redemption is requested', () => {
+        expect(getPostAuthRedirectUrl('dashboard.html', 'abcd1234', true)).toBe('accept-invite.html?code=ABCD1234');
+    });
+
+    it('uses default redirect when no valid code exists', () => {
+        expect(getPostAuthRedirectUrl('dashboard.html', '', true)).toBe('dashboard.html');
+    });
+
+    it('uses default redirect when redemption is not requested', () => {
+        expect(getPostAuthRedirectUrl('dashboard.html', 'abcd1234', false)).toBe('dashboard.html');
+    });
+});


### PR DESCRIPTION
Closes #43

## What changed
- Added a dedicated redirect helper (`js/invite-redirect.js`) to route authenticated login flows with invite links to `accept-invite.html` instead of immediately sending users to their dashboard.
- Updated `login.html` post-auth redirect paths (email/password, Google popup/redirect, and already-authenticated page load) to use that helper when invite context is present.
- Updated existing-user invite link generation to include invite type metadata:
  - parent invites from `edit-roster.html` now copy `login.html?code=...&type=parent`
  - admin invites from `edit-team.html` now copy `login.html?code=...&type=admin`
- Updated `accept-invite.html` fallback login redirect to preserve `type` when sending unauthenticated users to login.
- Added unit coverage in `tests/unit/invite-redirect.test.js` for invite and non-invite redirect behavior.
- Persisted required role artifacts under `docs/pr-notes/runs/issue-43-fixer-20260225T190937Z/`.

## Why
Existing users opening shared invite links were authenticated successfully but never sent through invite redemption logic, so parent/admin linkage silently failed. This change keeps login behavior normal by default while explicitly routing invite login contexts to the existing redemption page.