### PR TITLE
Prevent admin invite code reuse after accept

### DIFF
--- a/accept-invite.html
+++ b/accept-invite.html
@@ -135,8 +135,8 @@
 
     <script type="module">
         import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=9';
-        import { validateAccessCode, redeemParentInvite, updateUserProfile, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=14';
-        import { createInviteProcessor } from './js/accept-invite-flow.js?v=1';
+        import { validateAccessCode, redeemParentInvite, updateUserProfile, getTeam, getUserProfile, updateTeam, markAccessCodeAsUsed } from './js/db.js?v=14';
+        import { createInviteProcessor } from './js/accept-invite-flow.js?v=2';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 
         renderFooter(document.getElementById('footer-container'));
@@ -177,6 +177,7 @@
             updateUserProfile,
             getTeam,
             getUserProfile,
+            updateTeam,
             markAccessCodeAsUsed
         });
 

--- a/accept-invite.html
+++ b/accept-invite.html
@@ -135,7 +135,8 @@
 
     <script type="module">
         import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=9';
-        import { validateAccessCode, redeemParentInvite, updateUserProfile, getTeam, getUserProfile } from './js/db.js?v=14';
+        import { validateAccessCode, redeemParentInvite, updateUserProfile, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=14';
+        import { createInviteProcessor } from './js/accept-invite-flow.js?v=1';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 
         renderFooter(document.getElementById('footer-container'));
@@ -170,59 +171,14 @@
             }, 2000);
         }
 
-        async function processInvite(userId, code) {
-            // Validate the invite code
-            const validation = await validateAccessCode(code);
-            if (!validation.valid) {
-                throw new Error(validation.message || 'Invalid or expired invite code');
-            }
-
-            if (validation.type === 'parent_invite') {
-                // Process parent invite
-                await redeemParentInvite(userId, code);
-                const team = await getTeam(validation.data.teamId);
-                return {
-                    success: true,
-                    message: `You've been added to follow ${validation.data.playerNum ? '#' + validation.data.playerNum : 'a player'} on ${team?.name || 'the team'}!`,
-                    redirectUrl: 'parent-dashboard.html'
-                };
-            } else if (validation.type === 'admin_invite') {
-                // Process admin invite - add email to team's adminEmails
-                const team = await getTeam(validation.data.teamId);
-                if (!team) {
-                    throw new Error('Team not found');
-                }
-
-                // Get current user's email
-                const profile = await getUserProfile(userId);
-                const userEmail = profile?.email;
-
-                if (userEmail) {
-                    const adminEmails = team.adminEmails || [];
-                    if (!adminEmails.map(e => e.toLowerCase()).includes(userEmail.toLowerCase())) {
-                        adminEmails.push(userEmail.toLowerCase());
-                        // Note: We need to update the team, but we should use db.js
-                        // For now, we'll update user profile with coach role
-                    }
-                }
-
-                // Update user profile to add coachOf
-                await updateUserProfile(userId, {
-                    coachOf: [validation.data.teamId],
-                    roles: ['coach']
-                });
-
-                // Mark code as used is handled by validateAccessCode flow
-
-                return {
-                    success: true,
-                    message: `You've been added as an admin of ${team?.name || 'the team'}!`,
-                    redirectUrl: 'dashboard.html'
-                };
-            } else {
-                throw new Error('Unknown invite type');
-            }
-        }
+        const processInvite = createInviteProcessor({
+            validateAccessCode,
+            redeemParentInvite,
+            updateUserProfile,
+            getTeam,
+            getUserProfile,
+            markAccessCodeAsUsed
+        });
 
         async function init() {
             renderHeader(document.getElementById('header-container'), null);

--- a/docs/pr-notes/runs/70-remediator-20260301T150046Z/architecture.md
+++ b/docs/pr-notes/runs/70-remediator-20260301T150046Z/architecture.md
@@ -1,0 +1,12 @@
+# Architecture role notes
+
+Current state:
+- Admin invite flow mutates team-level admin access (`teams/{teamId}.adminEmails`) and user-level coach access (`users/{userId}.coachOf`, `roles`).
+
+Proposed state:
+- Keep two-write sequence explicit: team update first (when needed), then user profile update.
+- Preserve existing `coachOf` memberships by append+dedupe.
+
+Risk surface:
+- Team/user write ordering and role escalation logic.
+- Blast radius limited to `js/accept-invite-flow.js` admin invite branch.

--- a/docs/pr-notes/runs/70-remediator-20260301T150046Z/code-plan.md
+++ b/docs/pr-notes/runs/70-remediator-20260301T150046Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code role plan
+
+1. Patch `js/accept-invite-flow.js` admin invite branch to make append/persist logic explicit and defensive.
+2. Keep changes scoped; no refactor outside invite flow.
+3. Run targeted unit tests for accept invite flow.
+4. Commit with review-remediation message.

--- a/docs/pr-notes/runs/70-remediator-20260301T150046Z/qa.md
+++ b/docs/pr-notes/runs/70-remediator-20260301T150046Z/qa.md
@@ -1,0 +1,9 @@
+# QA role notes
+
+Validation target:
+- `tests/unit/accept-invite-flow.test.js`
+
+Expected assertions relevant to feedback:
+- Team update invoked with appended `adminEmails` before profile update path.
+- `coachOf` merged with prior teams (no overwrite).
+- Existing admin email path avoids redundant team write.

--- a/docs/pr-notes/runs/70-remediator-20260301T150046Z/requirements.md
+++ b/docs/pr-notes/runs/70-remediator-20260301T150046Z/requirements.md
@@ -1,0 +1,7 @@
+# Requirements role notes
+
+- Requested skills/subagent orchestration (`allplays-orchestrator-playbook`, role sessions) are not available in this runtime; using inline role analysis fallback.
+- PR feedback to satisfy:
+  - Persist `adminEmails` updates to team doc in admin invite flow.
+  - Avoid overwriting `coachOf` when accepting additional admin invites.
+- Constraint: minimal targeted changes only in review-affected flow.

--- a/docs/pr-notes/runs/70-review-3863129743-20260226T193124Z/architecture.md
+++ b/docs/pr-notes/runs/70-review-3863129743-20260226T193124Z/architecture.md
@@ -1,0 +1,30 @@
+# Architecture Role (allplays-architecture-expert)
+
+## Objective
+Apply the smallest safe patch to the invite redemption module that restores control equivalence for team admin access and coach team membership.
+
+## Current vs Proposed Architecture
+- Current flow (`createInviteProcessor`):
+  1. Validate code
+  2. Load team/user
+  3. Mutate local `adminEmails` only
+  4. Overwrite `coachOf` with single team
+  5. Mark code as used
+- Proposed flow:
+  1. Validate code
+  2. Load team/user
+  3. Persist `adminEmails` via `updateTeam` only when invited email not present
+  4. Merge `coachOf` (set union) and append `coach` role without dropping existing roles
+  5. Mark code as used
+
+## Controls Equivalence/Improvement
+- Improved: team admin authorization materialized in source of truth (`teams/{teamId}.adminEmails`).
+- Improved: coach access blast radius reduced by eliminating destructive overwrite of `coachOf`.
+- Preserved: single-use invite control (`markAccessCodeAsUsed`) remains required and unchanged.
+
+## Blast Radius
+- Files: `js/accept-invite-flow.js`, `accept-invite.html`, unit tests.
+- No Firestore rules changes, no schema migration, no backend service changes.
+
+## Rollback Plan
+Revert this patch commit on PR branch to restore prior behavior if unexpected regressions appear.

--- a/docs/pr-notes/runs/70-review-3863129743-20260226T193124Z/code-plan.md
+++ b/docs/pr-notes/runs/70-review-3863129743-20260226T193124Z/code-plan.md
@@ -1,0 +1,17 @@
+# Code Role (allplays-code-expert)
+
+## Objective
+Implement a minimal safe patch for PR #70 review blockers without broad refactors.
+
+## Implementation Plan
+1. Inject `updateTeam` dependency into invite processor wiring in `accept-invite.html`.
+2. In `js/accept-invite-flow.js` admin invite branch:
+   - persist missing admin email via `updateTeam`
+   - merge `coachOf` values instead of overwrite
+   - preserve existing roles and add `coach` if missing
+3. Extend `tests/unit/accept-invite-flow.test.js` with regression assertions for both review findings.
+4. Run targeted unit tests and ship commit.
+
+## Tradeoffs
+- Keeps writes non-transactional to avoid scope expansion; acceptable for current single-user invite acceptance path.
+- Uses additive merges to preserve backward compatibility with mixed-role profiles.

--- a/docs/pr-notes/runs/70-review-3863129743-20260226T193124Z/qa.md
+++ b/docs/pr-notes/runs/70-review-3863129743-20260226T193124Z/qa.md
@@ -1,0 +1,18 @@
+# QA Role (allplays-qa-expert)
+
+## Objective
+Prove the two blocking regressions are fixed and guard against reintroduction.
+
+## Risk-Based Coverage
+- Regression 1: invited admin email is persisted to team doc write path.
+- Regression 2: accepting an additional admin invite does not remove existing `coachOf` team memberships.
+- Security invariant: admin invite still marks access code as used after successful redemption.
+
+## Validation Commands
+- `cd /home/paul-bot1/.openclaw/workspace/repos/pauljsnider/allplays`
+- `./node_modules/.bin/vitest run tests/unit/accept-invite-flow.test.js`
+
+## Acceptance Criteria
+- Unit suite passes with explicit assertions for `updateTeam` persistence.
+- Unit suite passes with explicit assertions for additive `coachOf` merge behavior.
+- Existing validation-fail path still does not mark access code as used.

--- a/docs/pr-notes/runs/70-review-3863129743-20260226T193124Z/requirements.md
+++ b/docs/pr-notes/runs/70-review-3863129743-20260226T193124Z/requirements.md
@@ -1,0 +1,26 @@
+# Requirements Role (allplays-requirements-expert)
+
+## Objective
+Fix admin invite acceptance so invited coaches reliably retain access across multiple teams and team admin identity is persisted for authorization checks.
+
+## Current vs Proposed
+- Current: Admin invite flow lowercases and appends email in-memory but never writes `teams/{teamId}.adminEmails`.
+- Current: Admin invite flow writes `coachOf: [teamId]`, replacing any existing teams.
+- Proposed: Persist `adminEmails` to team when missing and merge `coachOf` with existing user teams.
+
+## Risk Surface and Blast Radius
+- Surface: `accept-invite.html` admin invite redemption path and `users/` + `teams/` writes.
+- Current blast radius: coach loses prior team access; team-level admin checks may fail due to missing `adminEmails` persistence.
+- Proposed blast radius: limited to invite redemption transaction; no auth-rule or schema changes.
+
+## Assumptions
+- `updateTeam(teamId, { adminEmails })` is the canonical write path for team doc updates.
+- Existing role semantics allow additive role merge (`coach` added without removing existing roles).
+
+## Recommendation
+Ship minimal additive fix: persist team admin email when newly invited, merge coach team memberships, preserve existing roles, and keep access code single-use marking unchanged.
+
+## Success Criteria
+- Admin invite persists user email into `teams/{teamId}.adminEmails` when absent.
+- Existing `users/{uid}.coachOf` entries remain after accepting another admin invite.
+- Access code is still marked used exactly once after success.

--- a/docs/pr-notes/runs/issue-49-fixer-20260226T192631Z/architecture.md
+++ b/docs/pr-notes/runs/issue-49-fixer-20260226T192631Z/architecture.md
@@ -1,0 +1,20 @@
+# Architecture Role Notes (Fallback)
+
+Objective: Close privilege-escalation gap from reusable admin invite codes.
+
+Current -> proposed control equivalence:
+- Current: Validation-only check in accept flow (read path only).
+- Proposed: Preserve validation check and add post-success write to `accessCodes/{codeId}` (`used=true`, `usedBy`, `usedAt`).
+
+Why this is minimal and safe:
+- Reuses existing `markAccessCodeAsUsed` helper in `js/db.js`.
+- No refactor of auth/link flow.
+- No changes to code generation or expiration logic.
+
+Blast radius comparison:
+- Current blast radius: unlimited admin-level team joins from one leaked code.
+- Proposed blast radius: single-account use per code; subsequent attempts blocked by existing validator.
+
+Instrumentation and rollback:
+- Evidence of redemption stored in `usedBy`/`usedAt` fields.
+- Rollback is single-line call removal (not expected to be needed).

--- a/docs/pr-notes/runs/issue-49-fixer-20260226T192631Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-49-fixer-20260226T192631Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code Role Plan (Fallback)
+
+Planned files:
+- `js/accept-invite-flow.js` (new): extract testable invite processing logic from inline page module.
+- `accept-invite.html`: import extracted helper and wire existing dependencies.
+- `tests/unit/accept-invite-flow.test.js` (new): reproduce bug and verify fix.
+
+Implementation steps:
+1. Extract `processInvite` into dedicated module with dependency injection.
+2. Add failing test asserting admin flow calls usage marker.
+3. Patch admin flow to call `markAccessCodeAsUsed(validation.codeId, userId)`.
+4. Run unit tests for changed area, then full unit suite.

--- a/docs/pr-notes/runs/issue-49-fixer-20260226T192631Z/qa.md
+++ b/docs/pr-notes/runs/issue-49-fixer-20260226T192631Z/qa.md
@@ -1,0 +1,17 @@
+# QA Role Notes (Fallback)
+
+Test strategy:
+1. Unit test for admin invite acceptance helper path:
+   - Valid admin invite -> updates profile and marks code as used.
+   - Assert call order: validation before mutation.
+   - Assert code usage marker invoked exactly once with expected `codeId` and `userId`.
+2. Regression guard:
+   - Parent invite path not changed; smoke run existing unit suite.
+
+Manual verification checklist:
+- Invite admin user A, accept invite, observe success.
+- Retry same code as user B via manual entry.
+- Confirm UI shows rejection (`Code already used`) and no new coach/admin grant.
+
+Pass/fail gate:
+- New unit test passes and existing unit tests pass.

--- a/docs/pr-notes/runs/issue-49-fixer-20260226T192631Z/requirements.md
+++ b/docs/pr-notes/runs/issue-49-fixer-20260226T192631Z/requirements.md
@@ -1,0 +1,29 @@
+# Requirements Role Notes (Fallback)
+
+Objective: Enforce one-time redemption for admin invite codes in `accept-invite` so a second redemption fails with `Code already used`.
+
+Current state:
+- Accept flow validates admin invite code with `validateAccessCode(code)`.
+- Admin branch updates user profile but does not mutate access code state.
+- Same code can be redeemed by multiple accounts.
+
+Proposed state:
+- On successful admin invite redemption, mark the exact code record as used and store `usedBy` and `usedAt`.
+- Keep existing success UX and redirect behavior unchanged.
+
+Risk surface and blast radius:
+- Scope limited to admin invite redemption path in `accept-invite.html`.
+- No schema changes.
+- Parent invite behavior should remain unchanged.
+
+Assumptions:
+- Invite lifecycle is single-use for both parent and admin invite types.
+- Existing Firestore rules permit invited user to call the same path used by parent invite redemption helper.
+
+Recommendation:
+- Minimal fix: call `markAccessCodeAsUsed(validation.codeId, userId)` after successful admin profile/team updates.
+- Add a unit test covering sequencing and ensuring the usage mark happens once per successful admin flow.
+
+Success criteria:
+- A second `validateAccessCode` call for the same admin code returns invalid due to `used: true`.
+- New test fails before the patch and passes after.

--- a/js/accept-invite-flow.js
+++ b/js/accept-invite-flow.js
@@ -1,0 +1,62 @@
+export function createInviteProcessor(deps) {
+    const {
+        validateAccessCode,
+        redeemParentInvite,
+        updateUserProfile,
+        getTeam,
+        getUserProfile,
+        markAccessCodeAsUsed
+    } = deps;
+
+    return async function processInvite(userId, code) {
+        const validation = await validateAccessCode(code);
+        if (!validation.valid) {
+            throw new Error(validation.message || 'Invalid or expired invite code');
+        }
+
+        if (validation.type === 'parent_invite') {
+            await redeemParentInvite(userId, code);
+            const team = await getTeam(validation.data.teamId);
+            return {
+                success: true,
+                message: `You've been added to follow ${validation.data.playerNum ? '#' + validation.data.playerNum : 'a player'} on ${team?.name || 'the team'}!`,
+                redirectUrl: 'parent-dashboard.html'
+            };
+        }
+
+        if (validation.type === 'admin_invite') {
+            const team = await getTeam(validation.data.teamId);
+            if (!team) {
+                throw new Error('Team not found');
+            }
+
+            const profile = await getUserProfile(userId);
+            const userEmail = profile?.email;
+
+            if (userEmail) {
+                const adminEmails = team.adminEmails || [];
+                if (!adminEmails.map(e => e.toLowerCase()).includes(userEmail.toLowerCase())) {
+                    adminEmails.push(userEmail.toLowerCase());
+                }
+            }
+
+            await updateUserProfile(userId, {
+                coachOf: [validation.data.teamId],
+                roles: ['coach']
+            });
+
+            if (!validation.codeId) {
+                throw new Error('Invite code record not found');
+            }
+            await markAccessCodeAsUsed(validation.codeId, userId);
+
+            return {
+                success: true,
+                message: `You've been added as an admin of ${team?.name || 'the team'}!`,
+                redirectUrl: 'dashboard.html'
+            };
+        }
+
+        throw new Error('Unknown invite type');
+    };
+}

--- a/js/accept-invite-flow.js
+++ b/js/accept-invite-flow.js
@@ -33,16 +33,18 @@ export function createInviteProcessor(deps) {
 
             const profile = await getUserProfile(userId);
             const userEmail = profile?.email;
-            const adminEmails = team.adminEmails || [];
+            const adminEmails = Array.isArray(team.adminEmails) ? [...team.adminEmails] : [];
             const normalizedEmail = userEmail ? userEmail.toLowerCase() : null;
+            const normalizedAdminEmails = adminEmails.map((email) => String(email || '').toLowerCase());
 
-            if (normalizedEmail && !adminEmails.map((email) => email.toLowerCase()).includes(normalizedEmail)) {
+            if (normalizedEmail && !normalizedAdminEmails.includes(normalizedEmail)) {
+                adminEmails.push(normalizedEmail);
                 await updateTeam(validation.data.teamId, {
-                    adminEmails: [...adminEmails, normalizedEmail]
+                    adminEmails
                 });
             }
 
-            const existingCoachOf = Array.isArray(profile?.coachOf) ? profile.coachOf : [];
+            const existingCoachOf = Array.isArray(profile?.coachOf) ? [...profile.coachOf] : [];
             const mergedCoachOf = Array.from(new Set([...existingCoachOf, validation.data.teamId]));
             const existingRoles = Array.isArray(profile?.roles) ? profile.roles : [];
             const mergedRoles = existingRoles.includes('coach') ? existingRoles : [...existingRoles, 'coach'];

--- a/tests/unit/accept-invite-flow.test.js
+++ b/tests/unit/accept-invite-flow.test.js
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createInviteProcessor } from '../../js/accept-invite-flow.js';
+
+describe('accept invite flow', () => {
+    it('marks admin invite code as used after successful redemption', async () => {
+        const calls = [];
+        const deps = {
+            validateAccessCode: vi.fn(async () => {
+                calls.push('validate');
+                return {
+                    valid: true,
+                    codeId: 'code-123',
+                    type: 'admin_invite',
+                    data: { teamId: 'team-1' }
+                };
+            }),
+            redeemParentInvite: vi.fn(),
+            updateUserProfile: vi.fn(async () => {
+                calls.push('profile');
+            }),
+            getTeam: vi.fn(async () => ({ id: 'team-1', name: 'Tigers', adminEmails: [] })),
+            getUserProfile: vi.fn(async () => ({ email: 'coach@example.com' })),
+            markAccessCodeAsUsed: vi.fn(async () => {
+                calls.push('mark');
+            })
+        };
+
+        const processInvite = createInviteProcessor(deps);
+        const result = await processInvite('user-1', 'ABCD1234');
+
+        expect(result.success).toBe(true);
+        expect(result.redirectUrl).toBe('dashboard.html');
+        expect(deps.markAccessCodeAsUsed).toHaveBeenCalledWith('code-123', 'user-1');
+        expect(calls).toEqual(['validate', 'profile', 'mark']);
+    });
+
+    it('does not mark code when validation fails', async () => {
+        const deps = {
+            validateAccessCode: vi.fn(async () => ({ valid: false, message: 'Code already used' })),
+            redeemParentInvite: vi.fn(),
+            updateUserProfile: vi.fn(),
+            getTeam: vi.fn(),
+            getUserProfile: vi.fn(),
+            markAccessCodeAsUsed: vi.fn()
+        };
+
+        const processInvite = createInviteProcessor(deps);
+
+        await expect(processInvite('user-2', 'ABCD1234')).rejects.toThrow('Code already used');
+        expect(deps.markAccessCodeAsUsed).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Closes #49

## What changed
- Extracted invite redemption logic from `accept-invite.html` into a testable module: `js/accept-invite-flow.js`.
- Updated `accept-invite.html` to use the new processor and pass required db dependencies.
- Fixed the admin invite branch to explicitly mark redeemed codes used via `markAccessCodeAsUsed(validation.codeId, userId)`.
- Added unit tests in `tests/unit/accept-invite-flow.test.js` covering:
  - successful admin redemption marks the code as used
  - failed validation does not mark code usage
- Added required per-run role artifacts under `docs/pr-notes/runs/issue-49-fixer-20260226T192631Z/`.

## Why
Admin invite codes were validated but never mutated to `used`, allowing repeated redemptions and unauthorized elevated team access. This patch enforces one-time redemption semantics for admin invites using the existing access-code mutation helper.

## Validation
- Fail-first proof: `pnpm dlx vitest run tests/unit/accept-invite-flow.test.js` (failed before fix)
- Post-fix regression run: `pnpm dlx vitest run tests/unit/accept-invite-flow.test.js tests/unit/*.test.js`
- Result: 10 test files passed, 53 tests passed.