### PR TITLE
Fix duplicate live practice note entries

### DIFF
--- a/docs/pr-notes/runs/issue-63-fixer-20260227T012501Z/architecture.md
+++ b/docs/pr-notes/runs/issue-63-fixer-20260227T012501Z/architecture.md
@@ -1,0 +1,17 @@
+# Architecture Role Synthesis (fallback; subagent infra unavailable)
+
+## Root Cause
+`appendPracticeNote` mutates overlapping fields:
+- canonical event stream: `block.notesLog.push(...)`
+- static summary text: `block.notes = ... + clean`
+
+`renderPracticeDrill` emits both `notesLog` and `notes`, yielding duplicate visual output for a single live note.
+
+## Minimal Safe Change
+- Remove `block.notes` mutation in `appendPracticeNote`.
+- Keep persistence as-is (`state.canvasBlocks` persisted), so `notesLog` remains source of truth for live notes.
+- Keep rendering logic unchanged to preserve display of pre-authored `notes`.
+
+## Blast Radius
+- Localized to practice note write path in `drills.html`.
+- No auth, tenancy, or Firestore permission behavior changes.

--- a/docs/pr-notes/runs/issue-63-fixer-20260227T012501Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-63-fixer-20260227T012501Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code Role Synthesis (fallback; subagent infra unavailable)
+
+## Plan
+1. Add helper module for live practice note append behavior so it is unit-testable.
+2. Add failing unit test to enforce: append to `notesLog` only, preserve existing `notes`.
+3. Wire `drills.html` `appendPracticeNote` to helper.
+4. Run targeted unit test and ensure pass.
+5. Stage and commit docs + test + fix with issue reference.
+
+## Non-goals
+- No render-layer dedupe logic.
+- No historical data migration.

--- a/docs/pr-notes/runs/issue-63-fixer-20260227T012501Z/qa.md
+++ b/docs/pr-notes/runs/issue-63-fixer-20260227T012501Z/qa.md
@@ -1,0 +1,14 @@
+# QA Role Synthesis (fallback; subagent infra unavailable)
+
+## Test Strategy
+- Add a targeted unit test that guards the write-path contract:
+  - Live append updates `notesLog`.
+  - Live append does **not** update `notes`.
+- Verify test fails against pre-fix behavior, then passes with fix.
+
+## Regression Checks
+- Existing static/planned notes continue rendering via `notes`.
+- Text-note and voice-note flows both call same append path; contract covers both types.
+
+## Commands
+- `./node_modules/.bin/vitest run tests/unit/drills-live-practice-notes.test.js`

--- a/docs/pr-notes/runs/issue-63-fixer-20260227T012501Z/requirements.md
+++ b/docs/pr-notes/runs/issue-63-fixer-20260227T012501Z/requirements.md
@@ -1,0 +1,16 @@
+# Requirements Role Synthesis (fallback; subagent infra unavailable)
+
+## Objective
+Ensure one live practice voice note creates exactly one visible note entry in drill notes.
+
+## Current vs Proposed
+- Current: Live note appends to both `notesLog` and `notes`, while UI renders both.
+- Proposed: Live note appends only to `notesLog`; `notes` remains static/planned drill context.
+
+## Acceptance Criteria
+- One voice transcript event adds one entry to `notesLog`.
+- `notes` field is not mutated by live note append path.
+- Practice notes render still includes planned/static notes (`notes`) and live log entries (`notesLog`) without duplication from a single append.
+
+## Risks
+- Legacy data may already contain duplicated values in both fields; this fix prevents new duplicates but does not auto-migrate old records.

--- a/drills.html
+++ b/drills.html
@@ -618,6 +618,7 @@
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js?v=3';
         import { DRILL_TYPES, DRILL_LEVELS, DRILL_TYPE_COLORS, getAllSkillTags } from './js/drill-constants.js?v=1';
         import { mergeUniqueDrills, linkifySafeText, parseMarkdown } from './js/drills-issue28-helpers.js?v=3';
+        import { appendLivePracticeNote } from './js/drills-live-practice-notes.js?v=1';
         import { getAI, getGenerativeModel, GoogleAIBackend } from './js/vendor/firebase-ai.js';
         import { getApp } from './js/vendor/firebase-app.js';
 
@@ -4714,16 +4715,8 @@ ${userPrompt}
 
         function appendPracticeNote(text, type = 'text') {
             const block = getPracticePlaybackBlocks()[state.practiceIndex]?._source;
-            if (!block) return false;
-            const clean = (text || '').trim();
-            if (!clean) return false;
-            if (!Array.isArray(block.notesLog)) block.notesLog = [];
-            block.notesLog.push({
-                type,
-                text: clean,
-                createdAt: new Date().toISOString()
-            });
-            block.notes = `${(block.notes || '').trim()}${block.notes ? '\n' : ''}${clean}`.trim();
+            const appended = appendLivePracticeNote(block, text, type);
+            if (!appended) return false;
             renderPracticeDrill();
             persistActiveBlockNotes().catch(err => console.warn('Failed to persist note:', err));
             return true;

--- a/js/drills-live-practice-notes.js
+++ b/js/drills-live-practice-notes.js
@@ -1,0 +1,16 @@
+export function appendLivePracticeNote(block, text, type = 'text', nowIso = null) {
+    if (!block) return false;
+    const clean = (text || '').trim();
+    if (!clean) return false;
+
+    if (!Array.isArray(block.notesLog)) {
+        block.notesLog = [];
+    }
+
+    block.notesLog.push({
+        type,
+        text: clean,
+        createdAt: nowIso || new Date().toISOString()
+    });
+    return true;
+}

--- a/tests/unit/drills-live-practice-notes.test.js
+++ b/tests/unit/drills-live-practice-notes.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { appendLivePracticeNote } from '../../js/drills-live-practice-notes.js';
+
+describe('live practice notes append helper', () => {
+    it('appends live note to notesLog only and preserves authored notes', () => {
+        const block = {
+            notes: 'Coach setup reminder',
+            notesLog: []
+        };
+
+        const appended = appendLivePracticeNote(block, 'Press quickly after loss', 'voice', '2026-02-27T01:25:00.000Z');
+
+        expect(appended).toBe(true);
+        expect(block.notesLog).toEqual([
+            {
+                type: 'voice',
+                text: 'Press quickly after loss',
+                createdAt: '2026-02-27T01:25:00.000Z'
+            }
+        ]);
+        expect(block.notes).toBe('Coach setup reminder');
+    });
+
+    it('ignores empty text', () => {
+        const block = { notes: 'x', notesLog: [] };
+        const appended = appendLivePracticeNote(block, '   ', 'text');
+        expect(appended).toBe(false);
+        expect(block.notesLog).toEqual([]);
+        expect(block.notes).toBe('x');
+    });
+});


### PR DESCRIPTION
Closes #63

## What changed
- Added a dedicated helper at `js/drills-live-practice-notes.js` for live practice note append behavior.
- Updated `appendPracticeNote` in `drills.html` to use that helper.
- Fixed live note writes so they append only to `notesLog` (canonical live stream) and do not mutate `notes`.
- Added `tests/unit/drills-live-practice-notes.test.js` to lock the contract that live notes preserve authored/static `notes`.
- Added required run artifacts under `docs/pr-notes/runs/issue-63-fixer-20260227T012501Z/`.

## Why
The duplication happened because one live voice note was written into both `notesLog` and `notes`, while the UI renders both fields. This change keeps live entries in `notesLog` only, preventing duplicate timeline entries from a single voice note.

## Validation
- `pnpm dlx vitest run tests/unit/drills-live-practice-notes.test.js`
- `pnpm dlx vitest run tests/unit/drills-issue28-helpers.test.js`