### PR TITLE
Implement team soft-delete and inactive team filtering

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -181,8 +181,14 @@
             <div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
                 <div class="p-4 border-b border-gray-200 flex justify-between items-center">
                     <h2 class="text-lg font-semibold text-gray-900">All Teams</h2>
-                    <input type="text" id="search-teams" placeholder="Search teams..."
-                        class="px-3 py-1 border border-gray-300 rounded-md text-sm">
+                    <div class="flex items-center gap-3">
+                        <label for="filter-inactive-teams" class="flex items-center gap-2 text-sm text-gray-600">
+                            <input id="filter-inactive-teams" type="checkbox" class="rounded border-gray-300">
+                            Show inactive
+                        </label>
+                        <input type="text" id="search-teams" placeholder="Search teams..."
+                            class="px-3 py-1 border border-gray-300 rounded-md text-sm">
+                    </div>
                 </div>
                 <div class="overflow-x-auto">
                     <table class="min-w-full divide-y divide-gray-200">

--- a/dashboard.html
+++ b/dashboard.html
@@ -267,11 +267,11 @@
                         const buttonEl = e.currentTarget;
                         const teamId = buttonEl.dataset.teamId;
                         const teamName = buttonEl.dataset.teamName;
-                        if (!confirm(`Delete team "${teamName}"? This will remove its schedule, roster, and stats.`)) return;
+                        if (!confirm(`Deactivate team "${teamName}"? Team data will be retained for history.`)) return;
                         const card = buttonEl.closest('[data-team-card]');
                         const originalText = buttonEl.textContent;
                         buttonEl.disabled = true;
-                        buttonEl.textContent = 'Deleting...';
+                        buttonEl.textContent = 'Deactivating...';
                         try {
                             await deleteTeam(teamId);
                             if (card) card.remove();
@@ -293,8 +293,8 @@
                                 `;
                             }
                         } catch (err) {
-                            console.error('Delete team failed', err);
-                            alert('Error deleting team. ' + (err?.message || 'Please try again.'));
+                            console.error('Deactivate team failed', err);
+                            alert('Error deactivating team. ' + (err?.message || 'Please try again.'));
                             buttonEl.disabled = false;
                             buttonEl.textContent = originalText;
                         }

--- a/docs/pr-notes/runs/74-remediator-20260301T145733Z/architecture.md
+++ b/docs/pr-notes/runs/74-remediator-20260301T145733Z/architecture.md
@@ -1,0 +1,13 @@
+# Architecture Role Notes
+
+Current state:
+- `getTeam(teamId, options)` defaults to filtering out inactive teams.
+- Some replay/history surfaces already opt into inactive inclusion, but `js/live-tracker.js` still uses default active-only lookups.
+
+Proposed state:
+- Keep `getTeam` default behavior unchanged.
+- Update replay/history-oriented lookups in `js/live-tracker.js` to pass `{ includeInactive: true }`.
+
+Risk/blast radius:
+- Low; only affects metadata fetches for game viewing/tracking flows.
+- No schema or permission changes.

--- a/docs/pr-notes/runs/74-remediator-20260301T145733Z/code-plan.md
+++ b/docs/pr-notes/runs/74-remediator-20260301T145733Z/code-plan.md
@@ -1,0 +1,7 @@
+# Code Role Notes
+
+Plan:
+1. Update `js/live-tracker.js` primary team fetch in `init()` to include inactive teams.
+2. Update linked opponent-team lookup in same file to include inactive teams.
+3. Keep changes limited to review feedback scope.
+4. Stage, commit, and report JSON output.

--- a/docs/pr-notes/runs/74-remediator-20260301T145733Z/qa.md
+++ b/docs/pr-notes/runs/74-remediator-20260301T145733Z/qa.md
@@ -1,0 +1,11 @@
+# QA Role Notes
+
+Validation focus:
+- Load a completed game for an inactive team in live tracker/report path.
+- Confirm page no longer fails due to null team metadata.
+- Confirm active-team flow still works unchanged.
+
+Manual checks:
+1. Open a game URL for an inactive team and verify header/team UI renders.
+2. If linked opponent team is inactive, verify linked-team metadata still resolves.
+3. Spot-check an active team game to ensure no regression.

--- a/docs/pr-notes/runs/74-remediator-20260301T145733Z/requirements.md
+++ b/docs/pr-notes/runs/74-remediator-20260301T145733Z/requirements.md
@@ -1,0 +1,12 @@
+# Requirements Role Notes
+
+Objective: Resolve PR thread PRRT_kwDOQe-T585xFFv5 by preventing inactive-team historical/replay views from failing when team metadata is fetched.
+
+Required behavior:
+- Historical/replay flows must be able to load inactive teams.
+- Active-only filtering should remain default for normal team-management flows.
+- Change scope must be minimal and targeted to the review concern.
+
+Acceptance evidence:
+- History/replay page team fetches use `getTeam(..., { includeInactive: true })` where needed.
+- No broad behavior change to all `getTeam` calls.

--- a/docs/pr-notes/runs/74-review-comment-2862082344-20260227T015314Z/architecture.md
+++ b/docs/pr-notes/runs/74-review-comment-2862082344-20260227T015314Z/architecture.md
@@ -1,0 +1,16 @@
+# Architecture Role Summary
+
+## Current State
+`getTeam(teamId)` defaults to active-only and returns `null` for inactive docs.
+
+## Proposed State
+Apply explicit `includeInactive` at history/replay route boundaries rather than changing the global default.
+
+## Rationale
+- Minimizes blast radius.
+- Preserves active workflow filtering introduced for issue #65.
+- Restores historical/report/replay read paths that rely on direct team lookup.
+
+## Risk Surface
+- Low risk: two call-site option changes.
+- No security rule changes.

--- a/docs/pr-notes/runs/74-review-comment-2862082344-20260227T015314Z/code-plan.md
+++ b/docs/pr-notes/runs/74-review-comment-2862082344-20260227T015314Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code Role Summary
+
+## Thinking Level
+medium - small cross-route regression fix with policy guardrails.
+
+## Patch Plan
+1. Update `game.html` loader to call `getTeam(teamId, { includeInactive: true })`.
+2. Update `js/live-game.js` loader to call `getTeam(state.teamId, { includeInactive: true })`.
+3. Keep `js/db.js` default behavior unchanged.
+
+## Conflict Resolution
+Requested 4-role subagent orchestration could not run because required skills/tools are unavailable in this environment (`allplays-orchestrator-playbook`, role skills, `sessions_spawn`). Applied equivalent single-lane synthesis and persisted per-role artifacts in this run directory.

--- a/docs/pr-notes/runs/74-review-comment-2862082344-20260227T015314Z/qa.md
+++ b/docs/pr-notes/runs/74-review-comment-2862082344-20260227T015314Z/qa.md
@@ -1,0 +1,11 @@
+# QA Role Summary
+
+## Regression Focus
+- Report page (`game.html`) no longer errors when team is inactive.
+- Replay page (`live-game.html`) can render metadata for inactive teams.
+- No regression to active-only filtering in list/discovery flows.
+
+## Validation Plan
+1. Run unit tests for team visibility policy helper.
+2. Run related live-game unit tests for replay page behavior baseline.
+3. Verify diff scope is limited to route-level includeInactive opt-in.

--- a/docs/pr-notes/runs/74-review-comment-2862082344-20260227T015314Z/requirements.md
+++ b/docs/pr-notes/runs/74-review-comment-2862082344-20260227T015314Z/requirements.md
@@ -1,0 +1,16 @@
+# Requirements Role Summary
+
+## Objective
+Preserve historical and replay access for soft-deleted teams while keeping active workflows filtered.
+
+## User Impact
+- Parents/coaches can open old game reports even after team deactivation.
+- Replay cards that intentionally include inactive teams keep working end-to-end.
+
+## Acceptance Criteria
+- `game.html` loads team header/details for inactive team documents.
+- `live-game.html?replay=true` loads team metadata for inactive teams.
+- Active discovery/list helpers remain unchanged (inactive excluded by default).
+
+## Assumptions
+- Team documents are soft-deleted (`active=false`) and not hard-deleted.

--- a/docs/pr-notes/runs/issue-65-fixer-20260227T012951Z/architecture.md
+++ b/docs/pr-notes/runs/issue-65-fixer-20260227T012951Z/architecture.md
@@ -1,0 +1,20 @@
+# Architecture Role Synthesis
+
+## Current State
+`deleteTeam` performs hard delete of team doc and subcollections. Team reads return all docs with no active filter.
+
+## Proposed State
+- Add team active contract in db helpers:
+  - reads treat `active !== false` as active (backfill-safe)
+  - write path for delete becomes update-only soft delete
+- Query helpers accept options object with `includeInactive` (default false).
+- Discovery helpers for live/upcoming exclude inactive team docs.
+- Replay helper keeps completed games for inactive teams (explicit policy choice).
+
+## Risk / Blast Radius
+- Low data-loss risk (removes destructive behavior).
+- Moderate behavior change risk on pages that rely on unfiltered team lists.
+- Historical access preserved by keeping replay discovery inclusive.
+
+## Conflict Resolution
+- Issue suggests `getTeam(..., { includeInactive=false })`; to preserve historical views, explicit includeInactive usage is applied in replay contexts while default filtering is used for active workflows.

--- a/docs/pr-notes/runs/issue-65-fixer-20260227T012951Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-65-fixer-20260227T012951Z/code-plan.md
@@ -1,0 +1,18 @@
+# Code Role Plan
+
+## Files to update
+- `js/db.js`
+- `js/admin.js`
+- `admin.html`
+- `firestore.rules`
+- `tests/unit/team-visibility.test.js` (new)
+
+## Minimal patch outline
+1. Add reusable `isTeamActive` predicate and db helper options (`includeInactive=false`).
+2. Convert `deleteTeam` to update-only soft delete fields (`active`, `deactivatedAt`, `deactivatedBy`, `updatedAt`).
+3. Ensure `createTeam` defaults active metadata.
+4. Filter parent dashboard future flows by active team.
+5. Exclude inactive teams from live/upcoming discovery; keep replays inclusive.
+6. Admin page: active-only default with explicit include-inactive toggle.
+7. Firestore rules: disallow client team document delete.
+8. Add Vitest coverage for active filtering and replay policy helper behavior.

--- a/docs/pr-notes/runs/issue-65-fixer-20260227T012951Z/qa.md
+++ b/docs/pr-notes/runs/issue-65-fixer-20260227T012951Z/qa.md
@@ -1,0 +1,16 @@
+# QA Role Synthesis
+
+## Test Strategy
+- Add unit tests for team visibility helpers and soft-delete payload generation semantics.
+- Add at least one UI-surface-oriented test by validating search/discovery filtering helper behavior.
+- Run targeted Vitest suites covering new behavior and nearby regressions.
+
+## Critical Regressions to Guard
+- `deleteTeam` must not delete subcollections.
+- Inactive teams must be excluded from browse/search/opponent linking via default list helpers.
+- Parent future workflow helper output should skip inactive teams.
+- Replay list should still include inactive-team completed games.
+
+## Manual Spot Checks (post-unit)
+- Dashboard team cards no longer show deactivated teams.
+- Teams browse page excludes deactivated teams.

--- a/docs/pr-notes/runs/issue-65-fixer-20260227T012951Z/requirements.md
+++ b/docs/pr-notes/runs/issue-65-fixer-20260227T012951Z/requirements.md
@@ -1,0 +1,14 @@
+# Requirements Role Synthesis
+
+## Objective
+Implement team soft-delete so inactive teams are hidden from active workflows and discovery while preserving historical game/replay access.
+
+## Decisions
+- Team delete UX becomes archive semantics: set `active=false` without deleting team subcollections.
+- Active workflows and discovery default to active-only teams.
+- Historical replays remain visible on home replay cards even when team is inactive.
+
+## UX Notes
+- Owner/admin delete actions should remain available but represent deactivation.
+- Active schedule and management entry points should not list inactive teams through team list/access helpers.
+- Parent future schedule views should exclude inactive teams.

--- a/firestore.rules
+++ b/firestore.rules
@@ -168,7 +168,8 @@ service cloud.firestore {
     match /teams/{teamId} {
       allow read: if true;  // Public teams for browsing
       allow create: if isSignedIn() && request.resource.data.ownerId == request.auth.uid;
-      allow update, delete: if isTeamOwnerOrAdmin(teamId);
+      allow update: if isTeamOwnerOrAdmin(teamId);
+      allow delete: if isGlobalAdmin();
 
 	      // Players subcollection
 	      match /players/{playerId} {

--- a/game.html
+++ b/game.html
@@ -606,7 +606,8 @@ Write the match report now:`;
 
             try {
                 const [team, game, players] = await Promise.all([
-                    getTeam(teamId),
+                    // Reports are historical and must resolve soft-deleted teams.
+                    getTeam(teamId, { includeInactive: true }),
                     getGame(teamId, gameId),
                     getPlayers(teamId, { includeInactive: true })
                 ]);

--- a/js/db.js
+++ b/js/db.js
@@ -33,6 +33,12 @@ import { imageStorage, ensureImageAuth, requireImageAuth } from './firebase-imag
 import { buildDrillDiagramUploadPaths } from './drill-upload-paths.js?v=1';
 import { isAccessCodeExpired } from './access-code-utils.js?v=1';
 import { buildCoachOverrideRsvpDocId } from './rsvp-doc-ids.js';
+import {
+    isTeamActive,
+    filterTeamsByActive,
+    shouldIncludeTeamInLiveOrUpcoming,
+    shouldIncludeTeamInReplay
+} from './team-visibility.js?v=1';
 import { getApp } from './vendor/firebase-app.js';
 // import { getAI, getGenerativeModel, GoogleAIBackend } from 'https://www.gstatic.com/firebasejs/12.6.0/firebase-vertexai.js';
 export { collection, getDocs, deleteDoc, query };
@@ -179,30 +185,38 @@ export async function uploadStatSheetPhoto(file) {
 }
 
 // Teams
-export async function getTeams() {
+export async function getTeams(options = {}) {
+    const includeInactive = !!options.includeInactive;
     const q = query(collection(db, "teams"), orderBy("name"));
     const snapshot = await getDocs(q);
-    return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    const teams = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    return filterTeamsByActive(teams, includeInactive);
 }
 
-export async function getTeam(teamId) {
+export async function getTeam(teamId, options = {}) {
+    const includeInactive = !!options.includeInactive;
     const docRef = doc(db, "teams", teamId);
     const docSnap = await getDoc(docRef);
     if (docSnap.exists()) {
-        return { id: docSnap.id, ...docSnap.data() };
+        const team = { id: docSnap.id, ...docSnap.data() };
+        if (!includeInactive && !isTeamActive(team)) return null;
+        return team;
     } else {
         return null;
     }
 }
 
-export async function getUserTeams(userId) {
+export async function getUserTeams(userId, options = {}) {
+    const includeInactive = !!options.includeInactive;
     const q = query(collection(db, "teams"), where("ownerId", "==", userId));
     const snapshot = await getDocs(q);
     // Sort in memory instead of query to avoid composite index requirement
-    return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() })).sort((a, b) => a.name.localeCompare(b.name));
+    const teams = snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() })).sort((a, b) => a.name.localeCompare(b.name));
+    return filterTeamsByActive(teams, includeInactive);
 }
 
-export async function getUserTeamsWithAccess(userId, email) {
+export async function getUserTeamsWithAccess(userId, email, options = {}) {
+    const includeInactive = !!options.includeInactive;
     const [ownedSnap, adminSnap] = await Promise.all([
         getDocs(query(collection(db, "teams"), where("ownerId", "==", userId))),
         email ? getDocs(query(collection(db, "teams"), where("adminEmails", "array-contains", email.toLowerCase()))) : Promise.resolve({ docs: [] })
@@ -212,14 +226,16 @@ export async function getUserTeamsWithAccess(userId, email) {
     ownedSnap.docs.forEach(d => map.set(d.id, { id: d.id, ...d.data() }));
     adminSnap.docs.forEach(d => map.set(d.id, { id: d.id, ...d.data() }));
 
-    return Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+    const teams = Array.from(map.values()).sort((a, b) => a.name.localeCompare(b.name));
+    return filterTeamsByActive(teams, includeInactive);
 }
 
 /**
  * Get teams where the user is connected as a parent (via parentOf)
  * This is used to power the "My Teams" view for parents, in a read-only way.
  */
-export async function getParentTeams(userId) {
+export async function getParentTeams(userId, options = {}) {
+    const includeInactive = !!options.includeInactive;
     const profile = await getUserProfile(userId);
     if (!profile || !Array.isArray(profile.parentOf) || profile.parentOf.length === 0) {
         return [];
@@ -230,7 +246,7 @@ export async function getParentTeams(userId) {
 
     const teams = [];
     for (const teamId of teamIds) {
-        const team = await getTeam(teamId);
+        const team = await getTeam(teamId, { includeInactive });
         if (team) {
             teams.push(team);
         }
@@ -269,6 +285,15 @@ export async function getUserByEmail(email) {
 export async function createTeam(teamData) {
     teamData.createdAt = Timestamp.now();
     teamData.updatedAt = Timestamp.now();
+    if (!Object.prototype.hasOwnProperty.call(teamData, 'active')) {
+        teamData.active = true;
+    }
+    if (!Object.prototype.hasOwnProperty.call(teamData, 'deactivatedAt')) {
+        teamData.deactivatedAt = null;
+    }
+    if (!Object.prototype.hasOwnProperty.call(teamData, 'deactivatedBy')) {
+        teamData.deactivatedBy = null;
+    }
     const docRef = await addDoc(collection(db, "teams"), teamData);
     return docRef.id;
 }
@@ -280,29 +305,13 @@ export async function updateTeam(teamId, teamData) {
 }
 
 export async function deleteTeam(teamId) {
-    // Delete games and their subcollections
-    const gamesSnapshot = await getDocs(collection(db, `teams/${teamId}/games`));
-    for (const gameDoc of gamesSnapshot.docs) {
-        const gameId = gameDoc.id;
-        // Remove events
-        const eventsSnap = await getDocs(collection(db, `teams/${teamId}/games/${gameId}/events`));
-        await Promise.all(eventsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
-        // Remove aggregated stats
-        const statsSnap = await getDocs(collection(db, `teams/${teamId}/games/${gameId}/aggregatedStats`));
-        await Promise.all(statsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
-        await deleteDoc(gameDoc.ref);
-    }
-
-    // Delete players
-    const playersSnapshot = await getDocs(collection(db, `teams/${teamId}/players`));
-    await Promise.all(playersSnapshot.docs.map(docItem => deleteDoc(docItem.ref)));
-
-    // Delete configs
-    const configsSnapshot = await getDocs(collection(db, `teams/${teamId}/statTrackerConfigs`));
-    await Promise.all(configsSnapshot.docs.map(docItem => deleteDoc(docItem.ref)));
-
-    // Finally delete team document
-    await deleteDoc(doc(db, "teams", teamId));
+    const userId = auth.currentUser?.uid || null;
+    await updateDoc(doc(db, "teams", teamId), {
+        active: false,
+        deactivatedAt: Timestamp.now(),
+        deactivatedBy: userId,
+        updatedAt: Timestamp.now()
+    });
 }
 
 // Players
@@ -1094,6 +1103,7 @@ export async function getParentDashboardData(userId) {
     // parents[] entry, because production rules may block that
     // write even when the profile is updated successfully.
     const children = userProfile.parentOf;
+    const activeChildren = [];
     const upcomingGames = [];
 
     // Cache events per team to avoid duplicate reads when a parent
@@ -1106,6 +1116,9 @@ export async function getParentDashboardData(userId) {
 
     for (const child of children) {
         if (!child.teamId) continue;
+        const team = await getTeam(child.teamId);
+        if (!team) continue;
+        activeChildren.push(child);
 
         let events = eventsByTeam.get(child.teamId);
         if (!events) {
@@ -1135,7 +1148,7 @@ export async function getParentDashboardData(userId) {
         return dA - dB;
     });
 
-    return { upcomingGames, children };
+    return { upcomingGames, children: activeChildren };
 }
 
 export async function updatePlayerProfile(teamId, playerId, data) {
@@ -1628,6 +1641,11 @@ export async function getUpcomingLiveGames(limitCount = 10) {
         if (teamSnap.exists()) {
             gameData.team = { id: teamSnap.id, ...teamSnap.data() };
             gameData.teamId = teamSnap.id;
+            if (!shouldIncludeTeamInLiveOrUpcoming(gameData.team)) {
+                continue;
+            }
+        } else {
+            continue;
         }
         games.push(gameData);
     }
@@ -2086,6 +2104,11 @@ export async function getLiveGamesNow() {
         if (teamSnap.exists()) {
             gameData.team = { id: teamSnap.id, ...teamSnap.data() };
             gameData.teamId = teamSnap.id;
+            if (!shouldIncludeTeamInLiveOrUpcoming(gameData.team)) {
+                continue;
+            }
+        } else {
+            continue;
         }
         games.push(gameData);
     }
@@ -2119,6 +2142,11 @@ export async function getRecentLiveTrackedGames(limitCount = 6) {
         if (teamSnap.exists()) {
             gameData.team = { id: teamSnap.id, ...teamSnap.data() };
             gameData.teamId = teamSnap.id;
+            if (!shouldIncludeTeamInReplay(gameData.team)) {
+                continue;
+            }
+        } else {
+            continue;
         }
         games.push(gameData);
     }

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -1331,7 +1331,8 @@ async function init() {
       ? getPlayers(state.teamId, { includeInactive: true })
       : getPlayers(state.teamId);
     [team, game, players, configs] = await Promise.all([
-      getTeam(state.teamId),
+      // Replay/live links should still load team metadata for inactive teams.
+      getTeam(state.teamId, { includeInactive: true }),
       getGame(state.teamId, state.gameId),
       playersPromise,
       getConfigs(state.teamId)

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -2262,7 +2262,7 @@ async function init() {
 
   try {
     const [team, game, playersList] = await Promise.all([
-      getTeam(teamId),
+      getTeam(teamId, { includeInactive: true }),
       getGame(teamId, gameId),
       getPlayers(teamId)
     ]);
@@ -2290,7 +2290,7 @@ async function init() {
 
     if (game.opponentTeamId) {
       try {
-        const linkedTeam = await getTeam(game.opponentTeamId);
+        const linkedTeam = await getTeam(game.opponentTeamId, { includeInactive: true });
         opponentTeam = linkedTeam || {
           id: game.opponentTeamId,
           name: game.opponentTeamName || game.opponent || 'Opponent',

--- a/js/team-visibility.js
+++ b/js/team-visibility.js
@@ -1,0 +1,18 @@
+export function isTeamActive(team) {
+    return team?.active !== false;
+}
+
+export function filterTeamsByActive(teams, includeInactive = false) {
+    const safeTeams = Array.isArray(teams) ? teams : [];
+    if (includeInactive) return safeTeams;
+    return safeTeams.filter(isTeamActive);
+}
+
+export function shouldIncludeTeamInLiveOrUpcoming(team) {
+    return isTeamActive(team);
+}
+
+// Policy choice: keep completed replay history visible even if a team is inactive.
+export function shouldIncludeTeamInReplay(_team) {
+    return true;
+}

--- a/tests/unit/team-visibility.test.js
+++ b/tests/unit/team-visibility.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import {
+    isTeamActive,
+    filterTeamsByActive,
+    shouldIncludeTeamInLiveOrUpcoming,
+    shouldIncludeTeamInReplay
+} from '../../js/team-visibility.js';
+
+describe('team visibility helpers', () => {
+    it('treats missing active flag as active', () => {
+        expect(isTeamActive({ id: 't1', name: 'No Active Field' })).toBe(true);
+    });
+
+    it('treats active false as inactive', () => {
+        expect(isTeamActive({ id: 't1', active: false })).toBe(false);
+    });
+
+    it('filters inactive teams by default', () => {
+        const teams = [
+            { id: 'a', active: true },
+            { id: 'b', active: false },
+            { id: 'c' }
+        ];
+        expect(filterTeamsByActive(teams)).toEqual([
+            { id: 'a', active: true },
+            { id: 'c' }
+        ]);
+    });
+
+    it('returns all teams when includeInactive=true', () => {
+        const teams = [{ id: 'a', active: true }, { id: 'b', active: false }];
+        expect(filterTeamsByActive(teams, true)).toEqual(teams);
+    });
+
+    it('excludes inactive teams from upcoming/live cards', () => {
+        expect(shouldIncludeTeamInLiveOrUpcoming({ id: 'a', active: true })).toBe(true);
+        expect(shouldIncludeTeamInLiveOrUpcoming({ id: 'b', active: false })).toBe(false);
+    });
+
+    it('keeps replay cards for inactive teams to preserve historical context', () => {
+        expect(shouldIncludeTeamInReplay({ id: 'a', active: false })).toBe(true);
+    });
+});


### PR DESCRIPTION
Closes #65

## What changed
- Converted `deleteTeam(teamId)` in `js/db.js` from hard delete to soft-delete by updating team fields: `active=false`, `deactivatedAt`, `deactivatedBy`, and `updatedAt`.
- Added team visibility helpers in `js/team-visibility.js` and applied them in `js/db.js` so team list/access helpers now default to active-only (`active !== false` treated as active for backfill safety).
- Updated team creation to default `active=true` and null deactivation metadata.
- Updated parent dashboard data assembly to exclude inactive teams from future/upcoming parent flows.
- Updated live/upcoming home discovery queries to exclude inactive teams; replay discovery intentionally remains inclusive for completed historical games.
- Updated admin teams UX (`admin.html`, `js/admin.js`) to load all teams but default display to active-only, with an explicit "Show inactive" toggle.
- Updated owner/admin delete UX copy in `dashboard.html`/`js/admin.js` to deactivation language.
- Updated `firestore.rules` to disallow normal team doc deletes (`allow delete: if isGlobalAdmin()`), aligning client behavior to update-based soft delete.
- Added run-scoped role artifacts under `docs/pr-notes/runs/issue-65-fixer-20260227T012951Z/`.

## Why
This removes destructive team deletion from normal product workflows, hides inactive teams from active management/discovery paths, and preserves historical replay access as required.

## Validation
- `pnpm dlx vitest run tests/unit/team-visibility.test.js tests/unit/team-access.test.js`
- `pnpm dlx vitest run tests/unit`
- `node --check js/admin.js && node --check js/team-visibility.js && node --check tests/unit/team-visibility.test.js && node --check js/db.js`