### PR TITLE
Preserve opponent fouls when resuming live tracker

### DIFF
--- a/docs/pr-notes/runs/issue-67-fixer-20260227T072526Z/architecture.md
+++ b/docs/pr-notes/runs/issue-67-fixer-20260227T072526Z/architecture.md
@@ -1,0 +1,20 @@
+# Architecture Role Analysis (manual fallback)
+
+## Current state
+Resume path initializes opponent `stats` with `statDefaults(currentConfig.columns)` and copies only configured columns from `game.opponentStats`, omitting `fouls`.
+
+## Proposed state
+Centralize opponent stat hydration in a pure helper:
+- Start from defaults (`time: 0`, `fouls: 0`, configured columns).
+- Copy configured columns from persisted data when defined.
+- Copy persisted `fouls` when defined.
+
+Use helper in resume flow to avoid drift and make behavior unit-testable.
+
+## Controls equivalence
+- Data shape remains identical.
+- Existing defaulting behavior preserved.
+- Only additive copy of an already persisted field (`fouls`).
+
+## Rollback plan
+Revert helper usage and restore prior inline mapping if regression appears.

--- a/docs/pr-notes/runs/issue-67-fixer-20260227T072526Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-67-fixer-20260227T072526Z/code-plan.md
@@ -1,0 +1,15 @@
+# Code Role Plan (manual fallback)
+
+## Minimal patch plan
+1. Add helper module `js/live-tracker-opponent-stats.js` with:
+   - `buildOpponentStatDefaults(columns)`
+   - `hydrateOpponentStats(data, columns)`
+2. Add unit tests `tests/unit/live-tracker-opponent-stats.test.js` reproducing missing-fouls regression.
+3. Update `js/live-tracker.js` resume mapping to use `hydrateOpponentStats`.
+4. Run Vitest targeted and full unit suite.
+5. Commit only issue-relevant files.
+
+## Conflict resolution
+- Requirements/QA want explicit foul preservation.
+- Architecture wants low-blast-radius and testability.
+- Chosen approach is tiny helper extraction + single call-site change, balancing safety and regression coverage.

--- a/docs/pr-notes/runs/issue-67-fixer-20260227T072526Z/qa.md
+++ b/docs/pr-notes/runs/issue-67-fixer-20260227T072526Z/qa.md
@@ -1,0 +1,16 @@
+# QA Role Analysis (manual fallback)
+
+## Failure mode under test
+Resuming with existing `game.opponentStats` drops `fouls` into default `0` and save path persists corrupted values.
+
+## Test strategy
+- Add focused unit test around new pure hydration helper.
+- First test asserts configured columns copy correctly and persisted `fouls` is preserved.
+- Second test asserts missing `fouls` defaults to `0` (backward compatibility).
+
+## Regression guardrails
+- Run targeted new test file.
+- Run full `tests/unit` suite to catch side effects in neighboring tracker helpers.
+
+## Manual spot-check (optional)
+- Resume a game with known opponent fouls > 0 in `live-tracker.html` and verify opponents panel + post-finish report.

--- a/docs/pr-notes/runs/issue-67-fixer-20260227T072526Z/requirements.md
+++ b/docs/pr-notes/runs/issue-67-fixer-20260227T072526Z/requirements.md
@@ -1,0 +1,20 @@
+# Requirements Role Analysis (manual fallback)
+
+Requested orchestration skills (`allplays-orchestrator-playbook` and role skills) are not installed in this runtime, so this artifact captures equivalent analysis.
+
+## Objective
+Prevent opponent foul totals from being reset during live-tracker resume and persisted as zero on finish/save.
+
+## User-visible requirement
+- If a game already has `game.opponentStats[*].fouls`, resuming tracked data must preserve those values in tracker state.
+- Finishing/saving after resume must persist the same foul totals unless explicitly edited.
+
+## Acceptance criteria
+- Resume hydration copies configured columns and `fouls` from persisted `game.opponentStats`.
+- Existing behavior for missing `fouls` remains safe (`0` fallback).
+- Regression test proves hydrated opponent stats include non-zero fouls when present.
+
+## Risk and blast radius
+- Scope limited to opponent resume mapping in `live-tracker.js`.
+- No schema changes, no Firestore rule changes, no UI changes.
+- Primary risk is unintended side effects in opponent stat initialization.

--- a/js/live-tracker-opponent-stats.js
+++ b/js/live-tracker-opponent-stats.js
@@ -1,0 +1,17 @@
+export function buildOpponentStatDefaults(columns = []) {
+  const stats = { time: 0, fouls: 0 };
+  columns.forEach(col => {
+    stats[String(col).toLowerCase()] = 0;
+  });
+  return stats;
+}
+
+export function hydrateOpponentStats(data = {}, columns = []) {
+  const stats = buildOpponentStatDefaults(columns);
+  columns.forEach(col => {
+    const key = String(col).toLowerCase();
+    if (data[key] !== undefined) stats[key] = data[key];
+  });
+  if (data.fouls !== undefined) stats.fouls = data.fouls;
+  return stats;
+}

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -8,6 +8,7 @@ import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai
 import { getApp } from './vendor/firebase-app.js';
 import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './live-tracker-notes.js?v=1';
 import { canApplySubstitution, applySubstitution, canTrustScoreLogForFinalization, reconcileFinalScoreFromLog, acquireSingleFlightLock, releaseSingleFlightLock } from './live-tracker-integrity.js?v=1';
+import { hydrateOpponentStats } from './live-tracker-opponent-stats.js?v=1';
 
 let currentTeamId = null;
 let currentGameId = null;
@@ -2486,11 +2487,7 @@ async function init() {
     // Initialize opponents from game or fresh
     if (shouldResume && hasOpponentStats) {
       state.opp = Object.entries(game.opponentStats).map(([id, data]) => {
-        const stats = statDefaults(currentConfig.columns);
-        (currentConfig.columns || []).forEach(col => {
-          const key = col.toLowerCase();
-          if (data[key] !== undefined) stats[key] = data[key];
-        });
+        const stats = hydrateOpponentStats(data, currentConfig.columns || []);
         return {
           id,
           playerId: data.playerId || null,

--- a/tests/unit/live-tracker-opponent-stats.test.js
+++ b/tests/unit/live-tracker-opponent-stats.test.js
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest';
+import { hydrateOpponentStats } from '../../js/live-tracker-opponent-stats.js';
+
+describe('live tracker opponent stats hydration', () => {
+  it('preserves persisted fouls when resuming opponent stats', () => {
+    const hydrated = hydrateOpponentStats({ pts: 8, ast: 2, fouls: 3 }, ['PTS', 'AST']);
+    expect(hydrated.pts).toBe(8);
+    expect(hydrated.ast).toBe(2);
+    expect(hydrated.fouls).toBe(3);
+  });
+
+  it('defaults fouls to zero when persisted fouls are missing', () => {
+    const hydrated = hydrateOpponentStats({ pts: 4 }, ['PTS']);
+    expect(hydrated.pts).toBe(4);
+    expect(hydrated.fouls).toBe(0);
+  });
+});


### PR DESCRIPTION
Closes #67

## What changed
- Added a focused opponent-stats hydration helper in `js/live-tracker-opponent-stats.js`.
- Updated the live tracker resume path in `js/live-tracker.js` to use that helper when rebuilding `state.opp` from `game.opponentStats`.
- Added regression coverage in `tests/unit/live-tracker-opponent-stats.test.js` to verify persisted opponent `fouls` are preserved on resume and still default to `0` when missing.
- Added required run artifacts under `docs/pr-notes/runs/issue-67-fixer-20260227T072526Z/`.

## Why
The resume flow copied configured stat columns but omitted `fouls`, causing opponent fouls to reset to zero and then be saved back as incorrect data. This patch makes foul hydration explicit and covered by unit tests to prevent recurrence.

## Validation
- `pnpm dlx vitest run tests/unit/live-tracker-opponent-stats.test.js`
- `pnpm dlx vitest run tests/unit`
- Result: all tests passed (11 files, 58 tests).