### PR TITLE
Fix ICS practice typing in Calendar sync

### DIFF
--- a/docs/pr-notes/runs/issue-84-fixer-20260227T222800Z/architecture.md
+++ b/docs/pr-notes/runs/issue-84-fixer-20260227T222800Z/architecture.md
@@ -1,0 +1,20 @@
+# Architecture Role Output
+
+## Root Cause
+`calendar.html` maps ICS type using `ev.isPractice`, but `parseICS()` in `js/utils.js` never sets `isPractice`.
+
+## Minimal Fix
+Set `currentEvent.isPractice = isPracticeEvent(value)` when parsing `SUMMARY` in `parseICS()`.
+
+## Why This Layer
+- Keeps classification where ICS event objects are constructed.
+- Avoids duplicating summary parsing at multiple calendar consumers.
+- Preserves existing filter/render behavior without broad refactor.
+
+## Controls and Blast Radius
+- No changes to auth, Firestore, or tenant boundaries.
+- No persistence model changes.
+- Behavioral delta constrained to ICS-derived event type inference.
+
+## Rollback
+Revert parser assignment line and corresponding test if regression appears.

--- a/docs/pr-notes/runs/issue-84-fixer-20260227T222800Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-84-fixer-20260227T222800Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Role Output
+
+## Plan
+1. Add failing unit test file under `tests/unit/` for `parseICS` practice classification.
+2. Update `parseICS` summary handling in `js/utils.js` to set `isPractice` via existing helper.
+3. Run targeted test then broader unit suite command.
+4. Commit test + fix together with issue reference.
+
+## Non-Goals
+- No calendar rendering refactor.
+- No ICS schema expansion beyond required classification.

--- a/docs/pr-notes/runs/issue-84-fixer-20260227T222800Z/qa.md
+++ b/docs/pr-notes/runs/issue-84-fixer-20260227T222800Z/qa.md
@@ -1,0 +1,14 @@
+# QA Role Output
+
+## Test Strategy
+- Add unit test coverage for ICS parsing classification:
+  - summary includes `Practice` => `isPractice === true`
+  - summary includes `Training` => `isPractice === true`
+  - typical game summary => `isPractice === false`
+
+## Regression Guardrails
+- Verify parser still returns existing fields (`dtstart`, `summary`, `uid`) for same fixture.
+- Keep fixture minimal and deterministic.
+
+## Manual Spot Check
+- In `calendar.html` ingestion, `type` assignment remains `ev.isPractice ? 'practice' : 'game'`; parser now supplies expected flag.

--- a/docs/pr-notes/runs/issue-84-fixer-20260227T222800Z/requirements.md
+++ b/docs/pr-notes/runs/issue-84-fixer-20260227T222800Z/requirements.md
@@ -1,0 +1,22 @@
+# Requirements Role Output
+
+## Objective
+Ensure synced ICS events representing practices are classified as `practice` so Calendar filters and badges behave correctly.
+
+## Current vs Proposed
+- Current: ICS events default to game unless `ev.isPractice` is already set.
+- Proposed: ICS parser marks practice-like summaries (`practice`, `training`, `skills club`) with `isPractice: true`.
+
+## User Impact
+- Coaches/parents can reliably filter to Practices and see synced practice events.
+- Badges and labels match expected event type.
+
+## Acceptance Criteria
+- ICS event summary containing `Practice` is typed `practice` in calendar ingestion path.
+- ICS event summary containing `Training` is typed `practice` in calendar ingestion path.
+- Non-practice summaries remain non-practice.
+- Regression test proves classification at parse level.
+
+## Risk Surface
+- Parser-level change affects ICS consumers globally.
+- Blast radius limited to event typing metadata; date parsing and fetch logic unchanged.

--- a/js/utils.js
+++ b/js/utils.js
@@ -370,6 +370,7 @@ export function parseICS(icsText) {
             break;
           case 'SUMMARY':
             currentEvent.summary = value;
+            currentEvent.isPractice = isPracticeEvent(value);
             break;
           case 'DESCRIPTION':
             currentEvent.description = value;

--- a/tests/unit/utils-ics-practice-classification.test.js
+++ b/tests/unit/utils-ics-practice-classification.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { parseICS } from '../../js/utils.js';
+
+describe('parseICS practice classification', () => {
+    it('sets isPractice for practice and training summaries', () => {
+        const ics = [
+            'BEGIN:VCALENDAR',
+            'BEGIN:VEVENT',
+            'UID:practice-1',
+            'DTSTART:20260227T180000Z',
+            'SUMMARY:Evening Practice',
+            'END:VEVENT',
+            'BEGIN:VEVENT',
+            'UID:training-1',
+            'DTSTART:20260228T180000Z',
+            'SUMMARY:Speed Training Session',
+            'END:VEVENT',
+            'BEGIN:VEVENT',
+            'UID:game-1',
+            'DTSTART:20260301T180000Z',
+            'SUMMARY:Tigers vs Lions',
+            'END:VEVENT',
+            'END:VCALENDAR'
+        ].join('\n');
+
+        const events = parseICS(ics);
+        expect(events).toHaveLength(3);
+        expect(events[0].isPractice).toBe(true);
+        expect(events[1].isPractice).toBe(true);
+        expect(events[2].isPractice).toBe(false);
+    });
+});


### PR DESCRIPTION
Closes #84

## What changed
- Added a regression unit test to verify `parseICS` marks practice-like events correctly from ICS summaries.
- Updated `js/utils.js` `parseICS()` so when `SUMMARY` is parsed it also sets `isPractice` using the existing `isPracticeEvent()` helper.
- Added run artifacts for requirements, architecture, QA, and code-plan under `docs/pr-notes/runs/issue-84-fixer-20260227T222800Z/`.

## Why
`calendar.html` already maps synced ICS events to `practice` vs `game` using `ev.isPractice`, but the parser never populated that field. This caused practice/training events to be labeled as games and filtered out of the Practices view.

## Validation
- `pnpm dlx vitest run tests/unit/utils-ics-practice-classification.test.js`
- `pnpm dlx vitest run tests/unit`