### PR TITLE
Honor weekly interval in recurrence expansion

### DIFF
--- a/docs/pr-notes/runs/89-remediator-20260301T145012Z/architecture.md
+++ b/docs/pr-notes/runs/89-remediator-20260301T145012Z/architecture.md
@@ -1,0 +1,13 @@
+# Architecture Role Notes
+
+## Current state
+`expandRecurrence` iterates day-by-day and determines inclusion by frequency-specific matching.
+
+## Decision
+Keep day-by-day iteration; enforce interval behavior entirely in match predicates:
+- Daily: `daysSinceSeriesStart % interval === 0`.
+- Weekly: compute week bucket from calendar week start (not start-date / 7 bucketing).
+
+## Risk surface
+- Recurrence generation only (`js/utils.js`).
+- Blast radius: schedule expansion and any UI using occurrence instances.

--- a/docs/pr-notes/runs/89-remediator-20260301T145012Z/code-plan.md
+++ b/docs/pr-notes/runs/89-remediator-20260301T145012Z/code-plan.md
@@ -1,0 +1,8 @@
+# Code Role Notes
+
+## Plan
+1. Inspect `js/utils.js` recurrence matching and increment logic.
+2. Apply minimal targeted adjustment for start-date gating clarity where needed.
+3. Add/adjust unit assertion if needed to lock daily interval semantics.
+4. Run targeted recurrence tests.
+5. Commit scoped changes.

--- a/docs/pr-notes/runs/89-remediator-20260301T145012Z/qa.md
+++ b/docs/pr-notes/runs/89-remediator-20260301T145012Z/qa.md
@@ -1,0 +1,13 @@
+# QA Role Notes
+
+## Validation scope
+Run recurrence unit coverage for daily and weekly interval behavior.
+
+## Cases to verify
+- Daily interval 2 and 3 produce expected spacing.
+- Daily interval 1 unchanged.
+- Weekly interval 2 with one day-of-week spaced biweekly.
+- Weekly interval 2 with multiple byDays uses calendar week boundaries.
+
+## Expected
+No regressions in existing recurrence expansion tests.

--- a/docs/pr-notes/runs/89-remediator-20260301T145012Z/requirements.md
+++ b/docs/pr-notes/runs/89-remediator-20260301T145012Z/requirements.md
@@ -1,0 +1,10 @@
+# Requirements Role Notes
+
+## Objective
+Resolve unresolved PR #89 review feedback on recurrence expansion logic in `js/utils.js`.
+
+## Required outcomes
+- Daily recurrence honors `interval` via modulo gate instead of unconditional match.
+- Daily loop advancement does not double-apply interval jumps.
+- Weekly `interval > 1` uses calendar week boundaries so multi-day `byDays` schedules in the same active week are included.
+- Changes remain minimal and scoped to recurrence expansion.

--- a/docs/pr-notes/runs/89-review-3870063472-20260228T043134Z/architecture.md
+++ b/docs/pr-notes/runs/89-review-3870063472-20260228T043134Z/architecture.md
@@ -1,0 +1,17 @@
+# Architecture Role Summary
+
+## Decision
+Unify interval semantics across frequencies by evaluating match eligibility from series anchor date, not loop increment side-effects.
+
+## Rationale
+- Weekly path already uses elapsed time modulo interval.
+- Daily path should follow the same deterministic rule to prevent accidental over-generation.
+- Keeping loop skip logic is acceptable for efficiency but not correctness-critical after match guard.
+
+## Control Equivalence
+- No new data flows.
+- No auth/rules changes.
+- Blast radius confined to pure recurrence computation.
+
+## Rollback
+Revert the single condition in `expandRecurrence` if unexpected regressions appear.

--- a/docs/pr-notes/runs/89-review-3870063472-20260228T043134Z/code-plan.md
+++ b/docs/pr-notes/runs/89-review-3870063472-20260228T043134Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Role Plan
+
+## Minimal Patch
+1. In `expandRecurrence`, replace daily `matches = true` with modulo-day interval check.
+2. Add daily recurrence fixtures and assertions in `tests/unit/recurrence-expand.test.js`.
+3. Run focused tests and ship.
+
+## Why This Patch
+- Solves reported bug directly.
+- Keeps behavior backward compatible for default interval.
+- Adds regression guardrails to prevent recurrence.

--- a/docs/pr-notes/runs/89-review-3870063472-20260228T043134Z/qa.md
+++ b/docs/pr-notes/runs/89-review-3870063472-20260228T043134Z/qa.md
@@ -1,0 +1,16 @@
+# QA Role Summary
+
+## Regression Focus
+- Daily recurrences with `interval > 1` should not include in-between days.
+- Daily `interval=1` and existing weekly interval behavior must remain stable.
+
+## Test Additions
+- `honors every-2-days interval for daily recurrences`
+- `keeps daily interval 1 behavior unchanged`
+
+## Validation Plan
+Run targeted unit suite:
+- `npx vitest run tests/unit/recurrence-expand.test.js`
+
+## Residual Risk
+- Timezone edge cases around local midnight are unchanged from existing behavior and should be covered separately if needed.

--- a/docs/pr-notes/runs/89-review-3870063472-20260228T043134Z/requirements.md
+++ b/docs/pr-notes/runs/89-review-3870063472-20260228T043134Z/requirements.md
@@ -1,0 +1,21 @@
+# Requirements Role Summary
+
+## Objective
+Fix recurring daily schedules so `interval > 1` produces occurrences every N days instead of every day.
+
+## Current State
+- Weekly interval matching already computes elapsed weeks from series start.
+- Daily matching currently accepts all days and relies on pointer skipping, which can over-include dates.
+
+## Proposed State
+- Daily matching uses elapsed day math from series start (`daysSinceSeriesStart % interval === 0`).
+- Regression tests cover daily `interval=2` and preserve `interval=1` behavior.
+
+## Risk Surface / Blast Radius
+- Scope limited to recurrence expansion logic in `js/utils.js` and unit tests.
+- No schema/API changes.
+
+## Acceptance Criteria
+1. `freq=daily, interval=2` yields alternating-day dates.
+2. `freq=daily, interval=1` remains daily.
+3. Existing weekly interval tests continue passing.

--- a/docs/pr-notes/runs/89-review-comment-2867043766-20260228T043335Z/architecture.md
+++ b/docs/pr-notes/runs/89-review-comment-2867043766-20260228T043335Z/architecture.md
@@ -1,0 +1,12 @@
+# Architecture Role Summary
+
+## Current state
+Daily matching is computed from `daysSinceSeriesStart % normalizedInterval === 0`, but the iterator also performs a second interval-based date jump.
+
+## Proposed state
+Single-step date iteration for all recurrence frequencies, with interval control centralized in the match predicate only.
+
+## Risk surface and blast radius
+- Scope: `expandRecurringPractice` in `js/utils.js` only.
+- Blast radius: recurrence generation for practice series.
+- Risk reduction: removes duplicate interval application for daily schedules while preserving weekly interval calculations.

--- a/docs/pr-notes/runs/89-review-comment-2867043766-20260228T043335Z/code-plan.md
+++ b/docs/pr-notes/runs/89-review-comment-2867043766-20260228T043335Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Role Summary
+
+## Minimal patch
+- Remove redundant daily post-increment in recurrence loop.
+- Keep existing modulo-based interval matching as source of truth.
+- Clarify loop comment to prevent reintroduction.
+
+## Why this is safe
+- The loop already advances one day each iteration.
+- Daily interval application in both matching and advancement double-counts spacing.
+- Removing secondary advancement aligns generated dates to configured interval.

--- a/docs/pr-notes/runs/89-review-comment-2867043766-20260228T043335Z/qa.md
+++ b/docs/pr-notes/runs/89-review-comment-2867043766-20260228T043335Z/qa.md
@@ -1,0 +1,14 @@
+# QA Role Summary
+
+## Regression targets
+- Daily interval spacing with `interval > 1`
+- Daily interval spacing with `interval = 1`
+- Weekly recurrences with and without `byDays`
+- Ex-date suppression and overrides
+
+## Focused verification
+- Static code inspection confirms the only change removes extra daily date advancement.
+- Targeted runtime check validates interval=3 produces 3-day spacing.
+
+## Remaining risk
+- No full browser manual pass in this run; recommend spot-check on practice series UI if this PR also changes adjacent recurrence logic.

--- a/docs/pr-notes/runs/89-review-comment-2867043766-20260228T043335Z/requirements.md
+++ b/docs/pr-notes/runs/89-review-comment-2867043766-20260228T043335Z/requirements.md
@@ -1,0 +1,14 @@
+# Requirements Role Summary
+
+## Objective
+Fix the daily recurrence interval bug so generated practice occurrences match user-entered day spacing.
+
+## User-visible expectation
+- A series with `freq: daily` and `interval: N` appears every N days.
+- No hidden acceleration in schedule generation.
+
+## Acceptance criteria
+- Interval 1 yields daily occurrences.
+- Interval 3 yields dates separated by exactly 3 calendar days.
+- Weekly logic remains unchanged.
+- Ex-date and override behavior remains unchanged.

--- a/docs/pr-notes/runs/89-review-comment-2867044630-20260228T043809Z/architecture.md
+++ b/docs/pr-notes/runs/89-review-comment-2867044630-20260228T043809Z/architecture.md
@@ -1,0 +1,19 @@
+# Architecture Role Summary
+
+## Current State
+Weekly interval gate in `expandRecurrence` used:
+- `daysSinceSeriesStart`
+- `Math.floor(daysSinceSeriesStart / 7)`
+This anchors buckets to the exact series start day and can misclassify weekdays in the same calendar biweekly block.
+
+## Proposed State
+Compute interval buckets from week starts:
+- Derive UTC day for `seriesStart` and `current` dates.
+- Derive week-start UTC day via `date - getDay() * MS_PER_DAY`.
+- Compute `weeksSinceSeriesWeekStart` from week-start delta.
+- Keep `daysSinceSeriesStart >= 0` guard to avoid pre-series generation.
+
+## Control Equivalence
+- Same recurrence API, same data model.
+- Same exDates/overrides logic.
+- Change isolated to interval match predicate.

--- a/docs/pr-notes/runs/89-review-comment-2867044630-20260228T043809Z/code-plan.md
+++ b/docs/pr-notes/runs/89-review-comment-2867044630-20260228T043809Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code Role Plan
+
+## Minimal Patch
+1. Add reusable `MS_PER_DAY` constant in `js/utils.js`.
+2. Precompute series UTC day and series week start UTC day.
+3. Replace `Math.floor(daysSinceSeriesStart / 7)` weekly gate with week-start delta gate.
+4. Add a unit regression in `tests/unit/recurrence-expand.test.js` for `byDays: ['MO','WE']`, `interval: 2`, start on Wednesday.
+
+## Safety
+- No API surface changes.
+- No persistence or network changes.
+- Existing tests around recurrence remain as guardrails.

--- a/docs/pr-notes/runs/89-review-comment-2867044630-20260228T043809Z/qa.md
+++ b/docs/pr-notes/runs/89-review-comment-2867044630-20260228T043809Z/qa.md
@@ -1,0 +1,14 @@
+# QA Role Summary
+
+## Regression Focus
+- Weekly + `interval: 2` + multi-day `byDays` with midweek series start.
+- Ensure previously covered weekly and daily interval tests still pass.
+
+## Test Cases
+1. Existing: biweekly single-day weekly recurrence.
+2. Existing: weekly interval 1 unchanged.
+3. New: multi-day biweekly recurrence aligned by calendar week boundaries.
+4. Existing: daily interval behaviors unchanged.
+
+## Pass Criteria
+- Targeted unit suite `tests/unit/recurrence-expand.test.js` passes without failures.

--- a/docs/pr-notes/runs/89-review-comment-2867044630-20260228T043809Z/requirements.md
+++ b/docs/pr-notes/runs/89-review-comment-2867044630-20260228T043809Z/requirements.md
@@ -1,0 +1,18 @@
+# Requirements Role Summary
+
+## Objective
+Fix weekly recurrence interval bucketing so multi-day weekly schedules with `interval > 1` honor calendar week groupings, not start-date-offset 7-day chunks.
+
+## User/UX Impact
+- Coaches scheduling biweekly practices on multiple weekdays should see expected dates.
+- Parents/players should not miss valid sessions due to hidden scheduling gaps.
+
+## Acceptance Criteria
+1. For weekly recurrences with `byDays` and `interval > 1`, active/inactive week gates are computed from calendar week boundaries containing series start.
+2. Existing weekly interval behavior for single-day schedules remains correct.
+3. Daily recurrence interval behavior remains unchanged.
+4. Regression test covers a series starting midweek (`WE`) with `byDays: ['MO', 'WE']`, `interval: 2`, and includes Monday/Wednesday in active biweekly blocks.
+
+## Risks / Blast Radius
+- Scope limited to recurrence expansion logic in `js/utils.js` and unit tests.
+- No Firestore schema, auth, or data write path changes.

--- a/docs/pr-notes/runs/issue-88-fixer-20260228T042809Z/architecture.md
+++ b/docs/pr-notes/runs/issue-88-fixer-20260228T042809Z/architecture.md
@@ -1,0 +1,12 @@
+# Architecture Role (manual fallback)
+
+## Root cause
+`expandRecurrence` matches weekly days by weekday only and then increments one day at a time. No weekly interval gate exists, so all matching weekdays are emitted every week.
+
+## Minimal safe design
+Compute elapsed days from series start to current candidate date, convert to elapsed weeks via `Math.floor(days / 7)`, and only match weekly dates when `elapsedWeeks % interval === 0`.
+
+## Why this is safe
+- Targets only weekly matching branch.
+- Leaves daily skip logic intact.
+- Preserves by-day behavior and no-byDays fallback.

--- a/docs/pr-notes/runs/issue-88-fixer-20260228T042809Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-88-fixer-20260228T042809Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Role (manual fallback)
+
+## Patch plan
+1. Add failing unit tests for weekly interval handling in recurrence expansion.
+2. Update weekly recurrence matching in `js/utils.js` to enforce interval.
+3. Re-run targeted and full unit tests.
+4. Commit with issue reference.
+
+## Non-goals
+- No refactor of recurrence model.
+- No UI changes in `edit-schedule.html`.

--- a/docs/pr-notes/runs/issue-88-fixer-20260228T042809Z/qa.md
+++ b/docs/pr-notes/runs/issue-88-fixer-20260228T042809Z/qa.md
@@ -1,0 +1,13 @@
+# QA Role (manual fallback)
+
+## Test strategy
+- Add unit tests around `expandRecurrence` weekly interval behavior.
+- Freeze system time to keep visibility window deterministic.
+
+## Cases
+- Regression case: weekly interval 2 + Monday should skip alternating weeks.
+- Control case: weekly interval 1 + Monday should remain weekly.
+
+## Validation commands
+- `./node_modules/.bin/vitest run tests/unit/recurrence-expand.test.js`
+- `./node_modules/.bin/vitest run tests/unit`

--- a/docs/pr-notes/runs/issue-88-fixer-20260228T042809Z/requirements.md
+++ b/docs/pr-notes/runs/issue-88-fixer-20260228T042809Z/requirements.md
@@ -1,0 +1,16 @@
+# Requirements Role (manual fallback)
+
+## Objective
+Fix issue #88 so weekly recurrences honor `interval` in `expandRecurrence`.
+
+## User-facing requirement
+When a coach selects recurring weekly practices with `Every: 2 week(s)`, generated occurrences must appear every other week on selected weekdays.
+
+## Acceptance criteria
+- Weekly recurrence with `interval: 2` and `byDays: ['MO']` expands as `2026-03-02, 2026-03-16, 2026-03-30...`.
+- Weekly recurrence with `interval: 1` behavior remains unchanged.
+- Existing daily interval behavior remains unchanged.
+
+## Risk and blast radius
+- Risk surface: `js/utils.js` recurrence expansion used by schedule views.
+- Blast radius: schedule occurrence generation/display and any flows consuming recurrence expansion.

--- a/js/utils.js
+++ b/js/utils.js
@@ -635,13 +635,8 @@ export function expandRecurrence(master, windowDays = 180) {
       generated++;
     }
 
-    // Advance to next day
+    // Advance by one day; interval matching is handled by daysSinceSeriesStart modulo checks
     current.setDate(current.getDate() + 1);
-
-    // For daily with interval > 1, skip days
-    if (freq === 'daily' && normalizedInterval > 1) {
-      current.setDate(current.getDate() + normalizedInterval - 1);
-    }
   }
 
   return occurrences;

--- a/js/utils.js
+++ b/js/utils.js
@@ -587,7 +587,7 @@ export function expandRecurrence(master, windowDays = 180) {
     if (freq === 'weekly' && byDays.length > 0) {
       matches = byDays.includes(dayCode) && matchesWeeklyInterval;
     } else if (freq === 'daily') {
-      matches = true;
+      matches = daysSinceSeriesStart >= 0 && (daysSinceSeriesStart % normalizedInterval === 0);
     } else if (freq === 'weekly' && byDays.length === 0) {
       // If no specific days, match the same day as series start
       matches = current.getDay() === seriesStart.getDay() && matchesWeeklyInterval;

--- a/js/utils.js
+++ b/js/utils.js
@@ -585,14 +585,15 @@ export function expandRecurrence(master, windowDays = 180) {
       ) / MS_PER_DAY
     );
     const currentUtc = Date.UTC(current.getFullYear(), current.getMonth(), current.getDate());
+    const hasStarted = currentUtc >= seriesStartUtc;
     const currentWeekStartUtc = currentUtc - (current.getDay() * MS_PER_DAY);
     const weeksSinceSeriesWeekStart = Math.floor((currentWeekStartUtc - seriesWeekStartUtc) / (7 * MS_PER_DAY));
-    const matchesWeeklyInterval = daysSinceSeriesStart >= 0 && (weeksSinceSeriesWeekStart % normalizedInterval === 0);
+    const matchesWeeklyInterval = hasStarted && weeksSinceSeriesWeekStart >= 0 && (weeksSinceSeriesWeekStart % normalizedInterval === 0);
 
     if (freq === 'weekly' && byDays.length > 0) {
       matches = byDays.includes(dayCode) && matchesWeeklyInterval;
     } else if (freq === 'daily') {
-      matches = daysSinceSeriesStart >= 0 && (daysSinceSeriesStart % normalizedInterval === 0);
+      matches = hasStarted && (daysSinceSeriesStart % normalizedInterval === 0);
     } else if (freq === 'weekly' && byDays.length === 0) {
       // If no specific days, match the same day as series start
       matches = current.getDay() === seriesStart.getDay() && matchesWeeklyInterval;

--- a/tests/unit/recurrence-expand.test.js
+++ b/tests/unit/recurrence-expand.test.js
@@ -34,6 +34,23 @@ function buildDailyMaster(interval = 2) {
     };
 }
 
+function buildMultiDayWeeklyMaster(interval = 2) {
+    return {
+        id: 'w2',
+        isSeriesMaster: true,
+        date: new Date('2026-03-04T18:00:00Z'),
+        startTime: '18:00',
+        endTime: '19:00',
+        recurrence: {
+            freq: 'weekly',
+            interval,
+            byDays: ['MO', 'WE']
+        },
+        exDates: [],
+        overrides: {}
+    };
+}
+
 describe('expandRecurrence weekly interval behavior', () => {
     beforeEach(() => {
         vi.useFakeTimers();
@@ -64,6 +81,19 @@ describe('expandRecurrence weekly interval behavior', () => {
             '2026-03-09',
             '2026-03-16',
             '2026-03-23'
+        ]);
+    });
+
+    it('uses calendar week boundaries for multi-day biweekly recurrences', () => {
+        const occurrences = expandRecurrence(buildMultiDayWeeklyMaster(2), 40);
+        const firstFive = occurrences.slice(0, 5).map((item) => item.instanceDate);
+
+        expect(firstFive).toEqual([
+            '2026-03-04',
+            '2026-03-16',
+            '2026-03-18',
+            '2026-03-30',
+            '2026-04-01'
         ]);
     });
 });

--- a/tests/unit/recurrence-expand.test.js
+++ b/tests/unit/recurrence-expand.test.js
@@ -18,6 +18,22 @@ function buildMaster(interval = 2) {
     };
 }
 
+function buildDailyMaster(interval = 2) {
+    return {
+        id: 'd1',
+        isSeriesMaster: true,
+        date: new Date('2026-03-02T18:00:00Z'),
+        startTime: '18:00',
+        endTime: '19:00',
+        recurrence: {
+            freq: 'daily',
+            interval
+        },
+        exDates: [],
+        overrides: {}
+    };
+}
+
 describe('expandRecurrence weekly interval behavior', () => {
     beforeEach(() => {
         vi.useFakeTimers();
@@ -48,6 +64,42 @@ describe('expandRecurrence weekly interval behavior', () => {
             '2026-03-09',
             '2026-03-16',
             '2026-03-23'
+        ]);
+    });
+});
+
+describe('expandRecurrence daily interval behavior', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-03-01T00:00:00Z'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('honors every-2-days interval for daily recurrences', () => {
+        const occurrences = expandRecurrence(buildDailyMaster(2), 8);
+        const firstFive = occurrences.slice(0, 5).map((item) => item.instanceDate);
+
+        expect(firstFive).toEqual([
+            '2026-03-02',
+            '2026-03-04',
+            '2026-03-06',
+            '2026-03-08'
+        ]);
+    });
+
+    it('keeps daily interval 1 behavior unchanged', () => {
+        const occurrences = expandRecurrence(buildDailyMaster(1), 5);
+        const firstFive = occurrences.slice(0, 5).map((item) => item.instanceDate);
+
+        expect(firstFive).toEqual([
+            '2026-03-02',
+            '2026-03-03',
+            '2026-03-04',
+            '2026-03-05',
+            '2026-03-06'
         ]);
     });
 });

--- a/tests/unit/recurrence-expand.test.js
+++ b/tests/unit/recurrence-expand.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { expandRecurrence } from '../../js/utils.js';
+
+function buildMaster(interval = 2) {
+    return {
+        id: 'm1',
+        isSeriesMaster: true,
+        date: new Date('2026-03-02T18:00:00Z'),
+        startTime: '18:00',
+        endTime: '19:00',
+        recurrence: {
+            freq: 'weekly',
+            interval,
+            byDays: ['MO']
+        },
+        exDates: [],
+        overrides: {}
+    };
+}
+
+describe('expandRecurrence weekly interval behavior', () => {
+    beforeEach(() => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-03-01T00:00:00Z'));
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    it('honors biweekly interval for weekly recurrences', () => {
+        const occurrences = expandRecurrence(buildMaster(2), 40);
+        const firstFive = occurrences.slice(0, 5).map((item) => item.instanceDate);
+
+        expect(firstFive).toEqual([
+            '2026-03-02',
+            '2026-03-16',
+            '2026-03-30'
+        ]);
+    });
+
+    it('keeps weekly interval 1 behavior unchanged', () => {
+        const occurrences = expandRecurrence(buildMaster(1), 28);
+        const firstFour = occurrences.slice(0, 4).map((item) => item.instanceDate);
+
+        expect(firstFour).toEqual([
+            '2026-03-02',
+            '2026-03-09',
+            '2026-03-16',
+            '2026-03-23'
+        ]);
+    });
+});

--- a/tests/unit/recurrence-expand.test.js
+++ b/tests/unit/recurrence-expand.test.js
@@ -120,6 +120,18 @@ describe('expandRecurrence daily interval behavior', () => {
         ]);
     });
 
+    it('honors every-3-days interval for daily recurrences', () => {
+        const occurrences = expandRecurrence(buildDailyMaster(3), 12);
+        const firstFive = occurrences.slice(0, 5).map((item) => item.instanceDate);
+
+        expect(firstFive).toEqual([
+            '2026-03-02',
+            '2026-03-05',
+            '2026-03-08',
+            '2026-03-11'
+        ]);
+    });
+
     it('keeps daily interval 1 behavior unchanged', () => {
         const occurrences = expandRecurrence(buildDailyMaster(1), 5);
         const firstFive = occurrences.slice(0, 5).map((item) => item.instanceDate);


### PR DESCRIPTION
Closes #88

## What changed
- Added a new unit test file `tests/unit/recurrence-expand.test.js` to reproduce and guard weekly recurrence interval behavior.
- Updated `expandRecurrence` in `js/utils.js` to enforce weekly interval matching by elapsed weeks from the series start date.
- Kept daily interval behavior intact while normalizing interval handling.
- Added required role-analysis artifacts under `docs/pr-notes/runs/issue-88-fixer-20260228T042809Z/`.

## Why
Weekly recurrence expansion previously matched only weekday and ignored `interval` for `freq: 'weekly'`, causing biweekly series to expand weekly.

## Validation
- `vitest run tests/unit/recurrence-expand.test.js`
- `vitest run tests/unit`
- Reproduction command now outputs biweekly dates: `2026-03-02,2026-03-16,2026-03-30`.