### PR TITLE
Keep chat unread badges accurate during active sessions

### DIFF
--- a/docs/pr-notes/runs/91-remediator-20260301T144743Z/architecture.md
+++ b/docs/pr-notes/runs/91-remediator-20260301T144743Z/architecture.md
@@ -1,0 +1,14 @@
+# Architecture role notes
+
+Current state:
+- Last-read update happens from realtime snapshot callback in `team-chat.html`.
+- Guard logic is centralized in `js/team-chat-last-read.js` via `shouldUpdateChatLastRead`.
+
+Proposed state:
+- Keep centralized guard function.
+- Ensure call site passes visibility + focus signals.
+- Keep function contract explicit and tested for required gating inputs only.
+
+Risk/blast radius:
+- Limited to team chat read-receipt behavior and tests.
+- No schema/API changes.

--- a/docs/pr-notes/runs/91-remediator-20260301T144743Z/code-plan.md
+++ b/docs/pr-notes/runs/91-remediator-20260301T144743Z/code-plan.md
@@ -1,0 +1,8 @@
+# Code role notes
+
+Plan:
+1. Inspect `tests/unit/team-chat-last-read.test.js` and `js/team-chat-last-read.js` contract alignment.
+2. Inspect `team-chat.html` call site guard before `updateChatLastRead`.
+3. Apply minimal updates to make both review concerns explicit and verifiable.
+4. Run targeted unit tests.
+5. Commit only scoped files.

--- a/docs/pr-notes/runs/91-remediator-20260301T144743Z/qa.md
+++ b/docs/pr-notes/runs/91-remediator-20260301T144743Z/qa.md
@@ -1,0 +1,9 @@
+# QA role notes
+
+Test focus:
+- `shouldUpdateChatLastRead` returns true only when user+team context and active-view conditions are true.
+- Returns false when page hidden or window unfocused.
+- Verify suite passes in affected unit file.
+
+Regression concern:
+- Prevent clearing unread state while user is away from visible/focused chat page.

--- a/docs/pr-notes/runs/91-remediator-20260301T144743Z/requirements.md
+++ b/docs/pr-notes/runs/91-remediator-20260301T144743Z/requirements.md
@@ -1,0 +1,12 @@
+# Requirements role notes
+
+Objective: Resolve PR #91 unresolved review threads with minimal scoped changes.
+
+Feedback to satisfy:
+1. Ensure tests and `shouldUpdateChatLastRead` signature align. No phantom `initialSnapshotLoaded` parameter should be required.
+2. Ensure `updateChatLastRead` is gated so last-read only advances while chat is actively viewed (tab visible and focused).
+
+Acceptance criteria:
+- Unit tests reflect actual function inputs and behavior.
+- Production call site only updates last-read when active-view guard passes.
+- No unrelated refactors.

--- a/docs/pr-notes/runs/91-review-3870192866-20260228T073202Z/architecture.md
+++ b/docs/pr-notes/runs/91-review-3870192866-20260228T073202Z/architecture.md
@@ -1,0 +1,15 @@
+# Architecture Role Summary
+
+## Decision
+Do not add `initialSnapshotLoaded` to `shouldUpdateChatLastRead`.
+
+## Rationale
+- The implementation contract is intentionally minimal: update iff `hasCurrentUser && hasTeamId`.
+- Introducing snapshot phase state into this utility would increase coupling to listener lifecycle state that is already represented by call timing.
+
+## Blast Radius
+- Limited to `team-chat-last-read` helper tests and inline documentation.
+- No runtime behavioral change in chat listener execution path.
+
+## Conflict Resolution
+- Reviewer suggested two options; selected option is removing `initialSnapshotLoaded` from tests because it preserves current behavior and avoids unnecessary API surface growth.

--- a/docs/pr-notes/runs/91-review-3870192866-20260228T073202Z/code-plan.md
+++ b/docs/pr-notes/runs/91-review-3870192866-20260228T073202Z/code-plan.md
@@ -1,0 +1,9 @@
+# Code Role Summary
+
+## Minimal Safe Patch
+1. Remove unsupported `initialSnapshotLoaded` from `tests/unit/team-chat-last-read.test.js` inputs.
+2. Clarify policy in `js/team-chat-last-read.js` doc comment: update on every realtime snapshot when context exists.
+3. Run targeted test file.
+
+## Notes
+- `allplays-orchestrator-playbook` and `sessions_spawn` are not available in this runtime, so role outputs were captured as traceable artifacts in this run directory.

--- a/docs/pr-notes/runs/91-review-3870192866-20260228T073202Z/qa.md
+++ b/docs/pr-notes/runs/91-review-3870192866-20260228T073202Z/qa.md
@@ -1,0 +1,13 @@
+# QA Role Summary
+
+## Regression Focus
+- Unread badge update trigger on initial snapshot.
+- Unread badge update trigger on subsequent realtime snapshots.
+- Guardrails when required context is missing.
+
+## Validation Plan
+- Execute targeted unit test file for `team-chat-last-read`.
+- Confirm all assertions pass with only supported parameters.
+
+## Residual Risk
+- No end-to-end UI run in this patch; policy correctness depends on listener wiring unchanged by this PR.

--- a/docs/pr-notes/runs/91-review-3870192866-20260228T073202Z/requirements.md
+++ b/docs/pr-notes/runs/91-review-3870192866-20260228T073202Z/requirements.md
@@ -1,0 +1,17 @@
+# Requirements Role Summary
+
+## Objective
+Restore test reliability for team chat unread badge behavior by aligning tests with implemented snapshot policy.
+
+## Current vs Proposed
+- Current: Tests pass an `initialSnapshotLoaded` parameter that the implementation does not consume.
+- Proposed: Tests only assert user/team context gates and keep update behavior active on both initial and subsequent snapshots.
+
+## Risks and Controls
+- Risk: Policy ambiguity between "initial only" and "all snapshots".
+- Control: Keep behavior explicit in function doc comment and test names covering both initial and subsequent snapshots.
+
+## Acceptance Criteria
+- `shouldUpdateChatLastRead` tests do not pass undeclared parameters.
+- Tests explicitly validate updates on initial and subsequent snapshots.
+- Missing user/team context still blocks updates.

--- a/docs/pr-notes/runs/91-review-comment-2867184871-20260228T073647Z/architecture.md
+++ b/docs/pr-notes/runs/91-review-comment-2867184871-20260228T073647Z/architecture.md
@@ -1,0 +1,14 @@
+# Architecture Role Notes
+
+## Current state
+Realtime snapshot callback updates `chatLastRead` whenever user/team context exists.
+
+## Proposed state
+Extend policy helper input with `isPageVisible` and `isWindowFocused`; guard last-read updates through helper to keep logic centralized and testable.
+
+## Blast radius
+Low. Change is scoped to Team Chat read receipt behavior and unit tests for helper logic.
+
+## Controls
+- Keep decision logic in `js/team-chat-last-read.js`.
+- Avoid ad hoc checks at multiple call sites.

--- a/docs/pr-notes/runs/91-review-comment-2867184871-20260228T073647Z/code-plan.md
+++ b/docs/pr-notes/runs/91-review-comment-2867184871-20260228T073647Z/code-plan.md
@@ -1,0 +1,9 @@
+# Code Role Plan
+
+1. Update `shouldUpdateChatLastRead` to require `hasCurrentUser`, `hasTeamId`, `isPageVisible`, and `isWindowFocused`.
+2. Pass `document.visibilityState === 'visible'` and `document.hasFocus()` from Team Chat snapshot callback.
+3. Update/add unit tests for both positive and negative focus/visibility scenarios.
+4. Run targeted tests and commit minimal patch.
+
+## Conflict resolution
+No role conflicts. All roles align on adding visibility + focus gating as the minimal safe patch.

--- a/docs/pr-notes/runs/91-review-comment-2867184871-20260228T073647Z/qa.md
+++ b/docs/pr-notes/runs/91-review-comment-2867184871-20260228T073647Z/qa.md
@@ -1,0 +1,13 @@
+# QA Role Notes
+
+## Regression focus
+- Last-read should not update while tab hidden.
+- Last-read should not update when browser window lacks focus.
+- Last-read should still update during normal active viewing.
+
+## Validation plan
+- Unit tests for helper with visibility/focus permutations.
+- Quick targeted test run for `team-chat-last-read` spec.
+
+## Residual risk
+- Browser-specific focus semantics can vary slightly; policy still errs safe by requiring both visible and focused.

--- a/docs/pr-notes/runs/91-review-comment-2867184871-20260228T073647Z/requirements.md
+++ b/docs/pr-notes/runs/91-review-comment-2867184871-20260228T073647Z/requirements.md
@@ -1,0 +1,20 @@
+# Requirements Role Notes
+
+## Objective
+Prevent `chatLastRead` from advancing unless the user is actively viewing Team Chat.
+
+## User-facing risk
+Unread indicators can be cleared while the tab is backgrounded, causing missed messages and trust loss in notification state.
+
+## Acceptance criteria
+- `updateChatLastRead` is only called when all are true:
+  - authenticated user exists
+  - `teamId` exists
+  - document visibility is `visible`
+  - browser window is focused
+- Existing behavior remains unchanged when user is actively reading chat.
+- Unit coverage includes non-visible and non-focused states.
+
+## Assumptions
+- Team chat page is the only path impacted by this regression.
+- `document.visibilityState` and `document.hasFocus()` are available in supported browsers.

--- a/docs/pr-notes/runs/issue-69-fixer-20260228T072840Z/architecture.md
+++ b/docs/pr-notes/runs/issue-69-fixer-20260228T072840Z/architecture.md
@@ -1,0 +1,16 @@
+# Architecture Role Output (manual fallback)
+
+## Current state
+`team-chat.html` advances `chatLastRead` only inside `if (!initialSnapshotLoaded)` in the real-time listener.
+
+## Proposed state
+Advance `chatLastRead` on every applied snapshot while user/team context is valid (not just initial snapshot).
+
+## Blast radius
+- Read path unchanged.
+- Write path: more frequent `users/{uid}.chatLastRead.{teamId}` updates during active chat view.
+- No schema/rules/query changes.
+
+## Risk and mitigations
+- Risk: increased write frequency.
+- Mitigation: only write when there is a valid `currentUser.uid` and current `teamId`; triggered only on message snapshot updates.

--- a/docs/pr-notes/runs/issue-69-fixer-20260228T072840Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-69-fixer-20260228T072840Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Role Output (manual fallback)
+
+## Minimal patch plan
+1. Add `js/team-chat-last-read.js` helper exporting `shouldUpdateChatLastRead`.
+2. Add unit test file `tests/unit/team-chat-last-read.test.js` capturing bug expectation (subsequent snapshots should update).
+3. Wire helper into `team-chat.html` realtime callback and call `updateChatLastRead` whenever helper returns true.
+4. Run targeted unit tests, then full unit suite if feasible.
+
+## Conflict resolution synthesis
+- Requirements/QA demand correctness of unread counts over session lifetime.
+- Architecture cautions write volume; resolved by a single boolean guard helper and no broader refactor.

--- a/docs/pr-notes/runs/issue-69-fixer-20260228T072840Z/qa.md
+++ b/docs/pr-notes/runs/issue-69-fixer-20260228T072840Z/qa.md
@@ -1,0 +1,13 @@
+# QA Role Output (manual fallback)
+
+## Failure reproduction target
+Second/subsequent realtime snapshots in active chat session should still trigger last-read advancement.
+
+## Test strategy
+- Add a focused unit test for a pure helper that decides if last-read should update on a snapshot.
+- Cover both initial and subsequent snapshot states.
+- Cover guard case when no authenticated user is present.
+
+## Regression checks
+- Existing unit suite remains green.
+- Manual sanity: open team chat, receive new message, navigate to dashboard, unread badge remains accurate.

--- a/docs/pr-notes/runs/issue-69-fixer-20260228T072840Z/requirements.md
+++ b/docs/pr-notes/runs/issue-69-fixer-20260228T072840Z/requirements.md
@@ -1,0 +1,17 @@
+# Requirements Role Output (manual fallback)
+
+## Objective
+Ensure unread badges do not count messages a user already saw while actively viewing team chat.
+
+## User-visible defect
+During an active team chat session, new incoming messages are visible in real time but still counted as unread on dashboard/team pages.
+
+## Constraints
+- Keep behavior aligned with current notification model (`createdAt > chatLastRead[teamId]`).
+- Do not change badge rendering pages unless needed.
+- Keep changes minimal and low-risk.
+
+## Acceptance criteria
+1. While user has team chat page open and receives new messages, chat last-read is advanced in-session.
+2. Leaving chat and opening dashboard does not show false unread count for messages already seen in active session.
+3. No regression to first-load behavior.

--- a/js/team-chat-last-read.js
+++ b/js/team-chat-last-read.js
@@ -1,5 +1,6 @@
 /**
  * Decide whether chat last-read should be advanced for the current snapshot.
+ * Policy: advance on every realtime snapshot while required context exists.
  * @param {Object} params
  * @param {boolean} params.hasCurrentUser
  * @param {boolean} params.hasTeamId

--- a/js/team-chat-last-read.js
+++ b/js/team-chat-last-read.js
@@ -1,11 +1,18 @@
 /**
  * Decide whether chat last-read should be advanced for the current snapshot.
- * Policy: advance on every realtime snapshot while required context exists.
+ * Policy: advance on realtime snapshot only while the user is actively viewing chat.
  * @param {Object} params
  * @param {boolean} params.hasCurrentUser
  * @param {boolean} params.hasTeamId
+ * @param {boolean} params.isPageVisible
+ * @param {boolean} params.isWindowFocused
  * @returns {boolean}
  */
-export function shouldUpdateChatLastRead({ hasCurrentUser, hasTeamId }) {
-    return Boolean(hasCurrentUser && hasTeamId);
+export function shouldUpdateChatLastRead({
+    hasCurrentUser,
+    hasTeamId,
+    isPageVisible,
+    isWindowFocused
+}) {
+    return Boolean(hasCurrentUser && hasTeamId && isPageVisible && isWindowFocused);
 }

--- a/js/team-chat-last-read.js
+++ b/js/team-chat-last-read.js
@@ -1,0 +1,10 @@
+/**
+ * Decide whether chat last-read should be advanced for the current snapshot.
+ * @param {Object} params
+ * @param {boolean} params.hasCurrentUser
+ * @param {boolean} params.hasTeamId
+ * @returns {boolean}
+ */
+export function shouldUpdateChatLastRead({ hasCurrentUser, hasTeamId }) {
+    return Boolean(hasCurrentUser && hasTeamId);
+}

--- a/js/team-chat-last-read.js
+++ b/js/team-chat-last-read.js
@@ -1,6 +1,8 @@
 /**
  * Decide whether chat last-read should be advanced for the current snapshot.
  * Policy: advance on realtime snapshot only while the user is actively viewing chat.
+ * Snapshot lifecycle flags (for example `initialSnapshotLoaded`) are intentionally
+ * handled by the caller and are not part of this predicate.
  * @param {Object} params
  * @param {boolean} params.hasCurrentUser
  * @param {boolean} params.hasTeamId

--- a/team-chat.html
+++ b/team-chat.html
@@ -183,6 +183,7 @@
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, uploadChatImage, toggleChatReaction } from './js/db.js?v=20';
+        import { shouldUpdateChatLastRead } from './js/team-chat-last-read.js?v=1';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { getAI, getGenerativeModel, GoogleAIBackend } from './js/vendor/firebase-ai.js';
         import { getApp } from './js/vendor/firebase-app.js';
@@ -490,13 +491,17 @@
                 if (!initialSnapshotLoaded) {
                     initialSnapshotLoaded = true;
                     scrollToBottom();
-                    if (currentUser?.uid) {
-                        updateChatLastRead(currentUser.uid, teamId).catch(err =>
-                            console.warn('Failed to update last read:', err)
-                        );
-                    }
                 } else if (pendingScrollToBottom || wasNearBottom) {
                     scrollToBottom();
+                }
+
+                if (shouldUpdateChatLastRead({
+                    hasCurrentUser: Boolean(currentUser?.uid),
+                    hasTeamId: Boolean(teamId)
+                })) {
+                    updateChatLastRead(currentUser.uid, teamId).catch(err =>
+                        console.warn('Failed to update last read:', err)
+                    );
                 }
                 pendingScrollToBottom = false;
             });

--- a/team-chat.html
+++ b/team-chat.html
@@ -497,7 +497,9 @@
 
                 if (shouldUpdateChatLastRead({
                     hasCurrentUser: Boolean(currentUser?.uid),
-                    hasTeamId: Boolean(teamId)
+                    hasTeamId: Boolean(teamId),
+                    isPageVisible: document.visibilityState === 'visible',
+                    isWindowFocused: document.hasFocus()
                 })) {
                     updateChatLastRead(currentUser.uid, teamId).catch(err =>
                         console.warn('Failed to update last read:', err)

--- a/team-chat.html
+++ b/team-chat.html
@@ -495,11 +495,14 @@
                     scrollToBottom();
                 }
 
+                const isPageVisible = document.visibilityState === 'visible' && !document.hidden;
+                const isWindowFocused = document.hasFocus();
+
                 if (shouldUpdateChatLastRead({
                     hasCurrentUser: Boolean(currentUser?.uid),
                     hasTeamId: Boolean(teamId),
-                    isPageVisible: document.visibilityState === 'visible',
-                    isWindowFocused: document.hasFocus()
+                    isPageVisible,
+                    isWindowFocused
                 })) {
                     updateChatLastRead(currentUser.uid, teamId).catch(err =>
                         console.warn('Failed to update last read:', err)

--- a/tests/unit/team-chat-last-read.test.js
+++ b/tests/unit/team-chat-last-read.test.js
@@ -5,32 +5,28 @@ describe('team chat last-read snapshot policy', () => {
     it('updates last-read on initial realtime snapshot when user and team are present', () => {
         expect(shouldUpdateChatLastRead({
             hasCurrentUser: true,
-            hasTeamId: true,
-            initialSnapshotLoaded: false
+            hasTeamId: true
         })).toBe(true);
     });
 
     it('updates last-read on subsequent realtime snapshots during active session', () => {
         expect(shouldUpdateChatLastRead({
             hasCurrentUser: true,
-            hasTeamId: true,
-            initialSnapshotLoaded: true
+            hasTeamId: true
         })).toBe(true);
     });
 
     it('does not update when user context is missing', () => {
         expect(shouldUpdateChatLastRead({
             hasCurrentUser: false,
-            hasTeamId: true,
-            initialSnapshotLoaded: true
+            hasTeamId: true
         })).toBe(false);
     });
 
     it('does not update when team context is missing', () => {
         expect(shouldUpdateChatLastRead({
             hasCurrentUser: true,
-            hasTeamId: false,
-            initialSnapshotLoaded: true
+            hasTeamId: false
         })).toBe(false);
     });
 });

--- a/tests/unit/team-chat-last-read.test.js
+++ b/tests/unit/team-chat-last-read.test.js
@@ -2,31 +2,48 @@ import { describe, it, expect } from 'vitest';
 import { shouldUpdateChatLastRead } from '../../js/team-chat-last-read.js';
 
 describe('team chat last-read snapshot policy', () => {
-    it('updates last-read on initial realtime snapshot when user and team are present', () => {
+    it('updates last-read when user/team context exists and chat is actively visible/focused', () => {
         expect(shouldUpdateChatLastRead({
             hasCurrentUser: true,
-            hasTeamId: true
+            hasTeamId: true,
+            isPageVisible: true,
+            isWindowFocused: true
         })).toBe(true);
     });
 
-    it('updates last-read on subsequent realtime snapshots during active session', () => {
+    it('does not update when page is not visible', () => {
         expect(shouldUpdateChatLastRead({
             hasCurrentUser: true,
-            hasTeamId: true
-        })).toBe(true);
+            hasTeamId: true,
+            isPageVisible: false,
+            isWindowFocused: true
+        })).toBe(false);
+    });
+
+    it('does not update when window is not focused', () => {
+        expect(shouldUpdateChatLastRead({
+            hasCurrentUser: true,
+            hasTeamId: true,
+            isPageVisible: true,
+            isWindowFocused: false
+        })).toBe(false);
     });
 
     it('does not update when user context is missing', () => {
         expect(shouldUpdateChatLastRead({
             hasCurrentUser: false,
-            hasTeamId: true
+            hasTeamId: true,
+            isPageVisible: true,
+            isWindowFocused: true
         })).toBe(false);
     });
 
     it('does not update when team context is missing', () => {
         expect(shouldUpdateChatLastRead({
             hasCurrentUser: true,
-            hasTeamId: false
+            hasTeamId: false,
+            isPageVisible: true,
+            isWindowFocused: true
         })).toBe(false);
     });
 });

--- a/tests/unit/team-chat-last-read.test.js
+++ b/tests/unit/team-chat-last-read.test.js
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { shouldUpdateChatLastRead } from '../../js/team-chat-last-read.js';
+
+describe('team chat last-read snapshot policy', () => {
+    it('updates last-read on initial realtime snapshot when user and team are present', () => {
+        expect(shouldUpdateChatLastRead({
+            hasCurrentUser: true,
+            hasTeamId: true,
+            initialSnapshotLoaded: false
+        })).toBe(true);
+    });
+
+    it('updates last-read on subsequent realtime snapshots during active session', () => {
+        expect(shouldUpdateChatLastRead({
+            hasCurrentUser: true,
+            hasTeamId: true,
+            initialSnapshotLoaded: true
+        })).toBe(true);
+    });
+
+    it('does not update when user context is missing', () => {
+        expect(shouldUpdateChatLastRead({
+            hasCurrentUser: false,
+            hasTeamId: true,
+            initialSnapshotLoaded: true
+        })).toBe(false);
+    });
+
+    it('does not update when team context is missing', () => {
+        expect(shouldUpdateChatLastRead({
+            hasCurrentUser: true,
+            hasTeamId: false,
+            initialSnapshotLoaded: true
+        })).toBe(false);
+    });
+});

--- a/tests/unit/team-chat-last-read.test.js
+++ b/tests/unit/team-chat-last-read.test.js
@@ -46,4 +46,11 @@ describe('team chat last-read snapshot policy', () => {
             isWindowFocused: true
         })).toBe(false);
     });
+
+    it('does not update when active-view gates are omitted', () => {
+        expect(shouldUpdateChatLastRead({
+            hasCurrentUser: true,
+            hasTeamId: true
+        })).toBe(false);
+    });
 });


### PR DESCRIPTION
Closes #69

## What changed
- Added a new helper `js/team-chat-last-read.js` with `shouldUpdateChatLastRead(...)` to centralize when chat last-read should advance.
- Updated `team-chat.html` realtime snapshot handling to call `updateChatLastRead` on every valid snapshot (not only the initial snapshot), while preserving existing initial scroll behavior.
- Added unit coverage in `tests/unit/team-chat-last-read.test.js` for initial snapshot, subsequent snapshot, and missing-context guard cases.
- Added run artifacts under `docs/pr-notes/runs/issue-69-fixer-20260228T072840Z/` for requirements, architecture, QA, and code-plan synthesis.

## Why
Unread counts are computed from messages with `createdAt > lastRead`. Previously, `lastRead` only advanced once on initial snapshot load, so messages seen live later in the same session were still counted as unread on dashboard/team pages.

## Validation
- `pnpm dlx vitest run tests/unit/team-chat-last-read.test.js`
- `pnpm dlx vitest run tests/unit`