### PR TITLE
Enforce soft-delete policy for historical player lookups

### DIFF
--- a/docs/pr-notes/runs/93-remediator-20260301T151808Z/architecture.md
+++ b/docs/pr-notes/runs/93-remediator-20260301T151808Z/architecture.md
@@ -1,0 +1,12 @@
+# Architecture Role Notes
+
+## Current State
+`init()` in `js/live-game.js` requests players during initial `Promise.all` load. Prior implementation passed an options object on every call.
+
+## Proposed State
+Build a conditional players promise:
+- Replay: `getPlayers(state.teamId, { includeInactive: true })`
+- Live/active: `getPlayers(state.teamId)`
+
+## Blast Radius
+Low. One call-site in `live-game.js`; no data model or API changes. Behavior aligns with existing `getPlayers` semantics and keeps active workflows filtered.

--- a/docs/pr-notes/runs/93-remediator-20260301T151808Z/code-plan.md
+++ b/docs/pr-notes/runs/93-remediator-20260301T151808Z/code-plan.md
@@ -1,0 +1,10 @@
+# Code Role Notes
+
+## Implementation Plan
+1. Edit `js/live-game.js` `init()` to compute `playersPromise` conditionally by `state.isReplay`.
+2. Keep all other data-loading and render flows unchanged.
+3. Update `tests/unit/player-soft-delete-policy.test.js` assertions for the new conditional query pattern.
+4. Run targeted test file and commit only scoped files.
+
+## Orchestration Fallback
+Requested `allplays-orchestrator-playbook`/role subagent spawning is unavailable in this session, so analysis was completed inline and persisted here.

--- a/docs/pr-notes/runs/93-remediator-20260301T151808Z/qa.md
+++ b/docs/pr-notes/runs/93-remediator-20260301T151808Z/qa.md
@@ -1,0 +1,9 @@
+# QA Role Notes
+
+## Test Plan
+- Update unit guard in `tests/unit/player-soft-delete-policy.test.js` to enforce replay-only includeInactive usage in `js/live-game.js`.
+- Run targeted vitest file:
+  - `tests/unit/player-soft-delete-policy.test.js`
+
+## Expected
+- Test passes and confirms replay-only includeInactive query shape.

--- a/docs/pr-notes/runs/93-remediator-20260301T151808Z/requirements.md
+++ b/docs/pr-notes/runs/93-remediator-20260301T151808Z/requirements.md
@@ -1,0 +1,13 @@
+# Requirements Role Notes
+
+## Objective
+Address unresolved PR thread `PRRT_kwDOQe-T585xUbvI` by ensuring inactive players are included in live-game roster loading only for historical replay sessions.
+
+## Evidence
+- Review feedback points to `js/live-game.js` roster query regression where inactive players can appear in active workflows.
+- `live-game.html` is used for both live and replay contexts.
+
+## Requirement
+- Replay mode (`replay=true`) must include inactive players.
+- Non-replay live mode must use active roster only.
+- Keep change minimal and scoped to this thread.

--- a/docs/pr-notes/runs/93-review-3870357319-20260228T103520Z/architecture.md
+++ b/docs/pr-notes/runs/93-review-3870357319-20260228T103520Z/architecture.md
@@ -1,0 +1,16 @@
+# Architecture Role Notes
+
+## Decision
+Apply mode-aware query option at call site in `live-game.js` instead of changing `db.js` defaults.
+
+## Why
+- Preserves existing API behavior and avoids cross-page regressions.
+- Keeps control local to one consumer with clear business intent.
+- Aligns with least-change principle for PR feedback remediation.
+
+## Control Equivalence
+- Data access remains read-only and team-scoped.
+- No security model changes; only filtering behavior by UI mode.
+
+## Rollback
+Revert the single conditional argument in `live-game.js` if unintended historical impact appears.

--- a/docs/pr-notes/runs/93-review-3870357319-20260228T103520Z/code-plan.md
+++ b/docs/pr-notes/runs/93-review-3870357319-20260228T103520Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code Role Notes
+
+## Minimal Patch
+Change `getPlayers(state.teamId, { includeInactive: true })` to `getPlayers(state.teamId, { includeInactive: state.isReplay })` in `init()`.
+
+## Rationale
+`state.isReplay` is set from URL params before data fetch. This cleanly gates inactive player inclusion to replay sessions.
+
+## Validation
+- `rg` confirmation of updated query option.
+- `node --check js/live-game.js` syntax check.
+- `git diff --stat` to confirm single-target code change plus run artifacts.

--- a/docs/pr-notes/runs/93-review-3870357319-20260228T103520Z/qa.md
+++ b/docs/pr-notes/runs/93-review-3870357319-20260228T103520Z/qa.md
@@ -1,0 +1,17 @@
+# QA Role Notes
+
+## Test Strategy
+- Verify query argument wiring for both replay and non-replay modes.
+- Run lightweight static validation for syntax safety.
+
+## Regression Checks
+- Non-replay: inactive players should remain hidden in lineup/stat contexts.
+- Replay: inactive players available for historical rendering.
+
+## Manual Verification Matrix
+1. Open `live-game.html?teamId=<id>&gameId=<id>` and confirm only active players appear.
+2. Open `live-game.html?teamId=<id>&gameId=<id>&replay=true` and confirm inactive players are present for historical stats.
+3. Confirm no load errors in console during initialization.
+
+## Residual Risk
+If completed-game workflows rely on inactive players without `replay=true`, those sessions may still hide inactive records. Current scope follows review feedback precisely.

--- a/docs/pr-notes/runs/93-review-3870357319-20260228T103520Z/requirements.md
+++ b/docs/pr-notes/runs/93-review-3870357319-20260228T103520Z/requirements.md
@@ -1,0 +1,25 @@
+# Requirements Role Notes
+
+## Objective
+Keep inactive players visible for historical replay identity resolution, while preventing them from appearing in active live-game roster contexts.
+
+## Current State
+`live-game.js` always calls `getPlayers(teamId, { includeInactive: true })`, regardless of mode.
+
+## Proposed State
+Only include inactive players when the page is explicitly in replay mode (`replay=true`).
+
+## Risk Surface / Blast Radius
+- Low blast radius: isolated to player query options on `live-game.html` init.
+- Primary risk: historical non-replay flows could exclude inactive players.
+- Mitigation: scope requirement strictly to replay mode as requested by review feedback.
+
+## Assumptions
+- Replay links include `replay=true` in URL.
+- Active live-game sessions should not show inactive roster members.
+- Historical identity resolution requirement is satisfied in replay mode.
+
+## Acceptance Criteria
+- `live-game.html?teamId=...&gameId=...` excludes inactive players.
+- `live-game.html?teamId=...&gameId=...&replay=true` includes inactive players.
+- No regression to game loading or lineup/stat rendering.

--- a/docs/pr-notes/runs/issue-64-fixer-20260228T102852Z/architecture.md
+++ b/docs/pr-notes/runs/issue-64-fixer-20260228T102852Z/architecture.md
@@ -1,0 +1,20 @@
+# Architecture Role Notes (fallback, no allplays-orchestrator-playbook skill available)
+
+## Current State
+- `getPlayers` already supports `{ includeInactive }`.
+- `deletePlayer` currently hard-deletes player doc via Firestore `deleteDoc`.
+- Historical views currently use active-only roster lookup.
+
+## Proposed Minimal Change
+1. Convert `deletePlayer` to soft-delete update (`active=false`, `deactivatedAt`, `updatedAt`).
+2. Update historical callsites only:
+   - `game.html`
+   - `player.html`
+   - `js/live-game.js`
+   - `team-chat.html`
+3. Keep active roster callsites unchanged.
+4. Add explicit roster-management copy clarifying delete semantics.
+
+## Blast Radius
+- Low schema risk (no migration).
+- Moderate UI behavior impact on historical rendering only.

--- a/docs/pr-notes/runs/issue-64-fixer-20260228T102852Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-64-fixer-20260228T102852Z/code-plan.md
@@ -1,0 +1,8 @@
+# Code Role Plan (fallback)
+
+1. Add source-level regression tests in `tests/unit/player-soft-delete-policy.test.js`.
+2. Run the new test to confirm failure before code change.
+3. Patch `js/db.js` `deletePlayer` to soft-delete update semantics.
+4. Patch historical pages to request `includeInactive: true`.
+5. Add roster UI copy in `edit-roster.html` explaining delete/deactivate semantics.
+6. Run unit tests and commit all changes with issue reference.

--- a/docs/pr-notes/runs/issue-64-fixer-20260228T102852Z/qa.md
+++ b/docs/pr-notes/runs/issue-64-fixer-20260228T102852Z/qa.md
@@ -1,0 +1,14 @@
+# QA Role Notes (fallback)
+
+## Regression Risks
+- Reintroducing hard-delete in `deletePlayer`.
+- Historical pages dropping player names for deactivated users.
+- Accidentally exposing inactive players in active roster workflows.
+
+## Test Strategy
+- Add unit regression test asserting `deletePlayer` implementation uses soft-delete update fields and does not call `deleteDoc` in function body.
+- Add unit test assertions that historical pages use `includeInactive: true` in `getPlayers` calls.
+- Run full `tests/unit` suite.
+
+## Manual Spot Checks
+- Deactivate player from roster UI and verify old game report + player deep link still load.

--- a/docs/pr-notes/runs/issue-64-fixer-20260228T102852Z/requirements.md
+++ b/docs/pr-notes/runs/issue-64-fixer-20260228T102852Z/requirements.md
@@ -1,0 +1,16 @@
+# Requirements Role Notes (fallback, no sessions_spawn available)
+
+## Objective
+Enforce soft-delete policy so inactive players are excluded from active workflows but remain visible in historical/reporting views.
+
+## Decisions
+- Keep active-only default for `getPlayers(teamId)` and active workflows.
+- Historical/reporting pages must call `getPlayers(teamId, { includeInactive: true })`.
+- `deletePlayer` must be soft-delete only (same semantics as deactivate).
+- Roster management copy must explicitly clarify delete semantics.
+
+## Success Criteria
+- Deactivated player is absent from active roster flows.
+- Historical pages still resolve deactivated player identities.
+- Deep-link `player.html` for inactive player resolves.
+- No hard-delete call in `deletePlayer` path.

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -180,6 +180,9 @@
                         <h2 class="text-xl font-bold">Current Roster</h2>
                         <span id="team-name-display" class="text-gray-500"></span>
                     </div>
+                    <div class="px-6 py-3 bg-amber-50 border-b border-amber-100 text-sm text-amber-900">
+                        Delete = deactivate from active roster, history preserved.
+                    </div>
                     <table class="w-full">
                         <thead class="bg-gray-50">
                             <tr>

--- a/game.html
+++ b/game.html
@@ -608,7 +608,7 @@ Write the match report now:`;
                 const [team, game, players] = await Promise.all([
                     getTeam(teamId),
                     getGame(teamId, gameId),
-                    getPlayers(teamId)
+                    getPlayers(teamId, { includeInactive: true })
                 ]);
 
                 if (!game) {

--- a/js/db.js
+++ b/js/db.js
@@ -362,7 +362,11 @@ export async function updatePlayer(teamId, playerId, playerData) {
 }
 
 export async function deletePlayer(teamId, playerId) {
-    await deleteDoc(doc(db, `teams/${teamId}/players`, playerId));
+    await updateDoc(doc(db, `teams/${teamId}/players`, playerId), {
+        active: false,
+        deactivatedAt: Timestamp.now(),
+        updatedAt: Timestamp.now()
+    });
 }
 
 export async function deactivatePlayer(teamId, playerId) {

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -1323,7 +1323,7 @@ async function init() {
     [team, game, players, configs] = await Promise.all([
       getTeam(state.teamId),
       getGame(state.teamId, state.gameId),
-      getPlayers(state.teamId, { includeInactive: true }),
+      getPlayers(state.teamId, { includeInactive: state.isReplay }),
       getConfigs(state.teamId)
     ]);
   } catch (error) {

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -1323,7 +1323,7 @@ async function init() {
     [team, game, players, configs] = await Promise.all([
       getTeam(state.teamId),
       getGame(state.teamId, state.gameId),
-      getPlayers(state.teamId),
+      getPlayers(state.teamId, { includeInactive: true }),
       getConfigs(state.teamId)
     ]);
   } catch (error) {

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -1320,10 +1320,13 @@ async function init() {
 
   let team, game, players, configs;
   try {
+    const playersPromise = state.isReplay
+      ? getPlayers(state.teamId, { includeInactive: true })
+      : getPlayers(state.teamId);
     [team, game, players, configs] = await Promise.all([
       getTeam(state.teamId),
       getGame(state.teamId, state.gameId),
-      getPlayers(state.teamId, { includeInactive: state.isReplay }),
+      playersPromise,
       getConfigs(state.teamId)
     ]);
   } catch (error) {

--- a/player.html
+++ b/player.html
@@ -263,7 +263,7 @@
                 currentTeamId = teamId; // Store global
                 const [team, players, games] = await Promise.all([
                     getTeam(teamId),
-                    getPlayers(teamId),
+                    getPlayers(teamId, { includeInactive: true }),
                     getGames(teamId)
                 ]);
 

--- a/team-chat.html
+++ b/team-chat.html
@@ -1103,7 +1103,7 @@
 
         async function buildAiContext(question, { fetchStats, fetchEvents }) {
             const [players, games] = await Promise.all([
-                getPlayers(teamId),
+                getPlayers(teamId, { includeInactive: true }),
                 getGames(teamId)
             ]);
             const playersById = new Map(players.map(p => [p.id, p]));

--- a/tests/unit/player-soft-delete-policy.test.js
+++ b/tests/unit/player-soft-delete-policy.test.js
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+
+function readFile(relPath) {
+    return fs.readFileSync(path.join(repoRoot, relPath), 'utf8');
+}
+
+function getFunctionBody(source, functionName) {
+    const signature = `export async function ${functionName}(`;
+    const start = source.indexOf(signature);
+    if (start === -1) return null;
+
+    const braceStart = source.indexOf('{', start);
+    if (braceStart === -1) return null;
+
+    let depth = 1;
+    for (let i = braceStart + 1; i < source.length; i += 1) {
+        const ch = source[i];
+        if (ch === '{') depth += 1;
+        if (ch === '}') depth -= 1;
+        if (depth === 0) return source.slice(braceStart + 1, i);
+    }
+
+    return null;
+}
+
+describe('player soft-delete policy', () => {
+    it('implements deletePlayer as a soft-delete update (never hard delete)', () => {
+        const source = readFile('js/db.js');
+        const body = getFunctionBody(source, 'deletePlayer');
+
+        expect(body).toBeTruthy();
+        expect(body).toContain('updateDoc(');
+        expect(body).toContain('active: false');
+        expect(body).toContain('deactivatedAt: Timestamp.now()');
+        expect(body).toContain('updatedAt: Timestamp.now()');
+        expect(body).not.toContain('deleteDoc(');
+    });
+
+    it('loads historical game report roster with inactive players included', () => {
+        const source = readFile('game.html');
+        expect(source).toContain('getPlayers(teamId, { includeInactive: true })');
+    });
+
+    it('loads inactive players for historical identity resolution views', () => {
+        const playerPage = readFile('player.html');
+        const liveGame = readFile('js/live-game.js');
+        const teamChat = readFile('team-chat.html');
+
+        expect(playerPage).toContain('getPlayers(teamId, { includeInactive: true })');
+        expect(liveGame).toContain('getPlayers(state.teamId, { includeInactive: true })');
+        expect(teamChat).toContain('getPlayers(teamId, { includeInactive: true })');
+    });
+});

--- a/tests/unit/player-soft-delete-policy.test.js
+++ b/tests/unit/player-soft-delete-policy.test.js
@@ -53,7 +53,8 @@ describe('player soft-delete policy', () => {
         const teamChat = readFile('team-chat.html');
 
         expect(playerPage).toContain('getPlayers(teamId, { includeInactive: true })');
-        expect(liveGame).toContain('getPlayers(state.teamId, { includeInactive: true })');
+        expect(liveGame).toContain('? getPlayers(state.teamId, { includeInactive: true })');
+        expect(liveGame).toContain(': getPlayers(state.teamId);');
         expect(teamChat).toContain('getPlayers(teamId, { includeInactive: true })');
     });
 });


### PR DESCRIPTION
Closes #64

## What changed
- Converted `deletePlayer()` in `js/db.js` from hard-delete to soft-delete by updating the player document with:
  - `active: false`
  - `deactivatedAt: Timestamp.now()`
  - `updatedAt: Timestamp.now()`
- Updated historical/reporting player lookups to explicitly include inactive players:
  - `game.html`
  - `player.html`
  - `js/live-game.js`
  - `team-chat.html`
- Added roster management UI copy in `edit-roster.html`:
  - `Delete = deactivate from active roster, history preserved.`
- Added regression coverage in `tests/unit/player-soft-delete-policy.test.js` to enforce:
  - `deletePlayer` remains soft-delete (and does not call `deleteDoc`)
  - historical views use `getPlayers(..., { includeInactive: true })`

## Why
The app was inconsistently applying active-only roster filtering in historical contexts, causing inactive players to disappear from game reports, deep links, and historical AI context mapping. This change makes retrieval intent explicit by keeping active-only defaults for active workflows while preserving historical correctness for past games/events/stats.