### PR TITLE
Honor weekly recurrence intervals in series expansion

### DIFF
--- a/docs/pr-notes/runs/95-remediator-20260301T144559Z/architecture.md
+++ b/docs/pr-notes/runs/95-remediator-20260301T144559Z/architecture.md
@@ -1,0 +1,15 @@
+# Architecture Role Notes
+
+## Current state
+`expandRecurrence` iterates dates via local `setDate/getDate` but still used UTC-derived fields (`getUTCDay`, ISO date from `toISOString`) for recurrence matching and instance keys.
+
+## Proposed state
+Use one coherent local-time basis for recurrence iteration and matching:
+- day number via `getTime()/MS_PER_DAY`
+- day-of-week via `getDay()`
+- week anchor via local day-of-week subtraction
+- `instanceDate` key via local YYYY-MM-DD formatter
+
+## Risk and blast radius
+- Scope is confined to `expandRecurrence` in `js/utils.js`.
+- Main behavior shift affects edge cases around timezone offsets/DST boundaries and week-interval gating.

--- a/docs/pr-notes/runs/95-remediator-20260301T144559Z/code-plan.md
+++ b/docs/pr-notes/runs/95-remediator-20260301T144559Z/code-plan.md
@@ -1,0 +1,10 @@
+# Code Role Plan
+
+## Plan
+1. Patch `js/utils.js` recurrence block to remove UTC/local mixing.
+2. Keep weekly interval math anchored to week boundaries using consistent local day-of-week values.
+3. Preserve existing recurrence behavior outside the reviewed logic.
+4. Run recurrence unit test to validate no regression in interval handling.
+
+## Fallback
+If tests are unavailable in this workspace, provide exact command attempted and failure output in run notes.

--- a/docs/pr-notes/runs/95-remediator-20260301T144559Z/qa.md
+++ b/docs/pr-notes/runs/95-remediator-20260301T144559Z/qa.md
@@ -1,0 +1,13 @@
+# QA Role Notes
+
+## Test focus
+- Weekly recurrence with `interval > 1` and multi-day `byDays`.
+- Off-cadence week exclusion for days before/after anchor weekday.
+- Date key consistency for exclusions/overrides (`instanceDate` string).
+
+## Validation plan
+- Run existing recurrence unit test: `tests/unit/recurrence-interval.test.js`.
+- Confirm expected dates include cadence weeks only and exclude off-cadence Mondays.
+
+## Residual risk
+- Repo has limited automated coverage for timezone-specific environments; manual follow-up in browser remains useful if needed.

--- a/docs/pr-notes/runs/95-remediator-20260301T144559Z/requirements.md
+++ b/docs/pr-notes/runs/95-remediator-20260301T144559Z/requirements.md
@@ -1,0 +1,17 @@
+# Requirements Role Notes
+
+## Objective
+Resolve unresolved PR #95 review feedback in `js/utils.js` recurrence expansion logic.
+
+## Required outcomes
+- Eliminate UTC/local timezone inconsistency in day-number calculations.
+- Ensure weekly interval gating is aligned to calendar week boundaries, not start-date 7-day buckets.
+- Keep change scoped to recurrence logic only.
+
+## Assumptions
+- Existing recurrence semantics define week buckets by local calendar weeks (Sunday-based via `DAY_CODES`).
+- `instanceDate` keys should map to the same local day used by recurrence matching.
+
+## Acceptance
+- Biweekly multi-day recurrence starting midweek skips off-cadence days in alternating weeks.
+- No `Date.UTC(...)`-style day-number mixing with local date iteration remains in this path.

--- a/docs/pr-notes/runs/95-review-3870447483-20260228T133434Z/architecture.md
+++ b/docs/pr-notes/runs/95-review-3870447483-20260228T133434Z/architecture.md
@@ -1,0 +1,15 @@
+# Architecture Role Summary
+
+## Risk Surface
+`expandRecurrence` drives generated practice instances; incorrect cadence affects scheduling, RSVPs, and calendar exports.
+
+## Design Decision
+Replace day-delta week computation with week-start day-number computation:
+- `weekStartDayNumber = dayNumber - getDay()`
+- `weeksSinceSeriesStart = (currentWeekStart - seriesStartWeekStart) / 7`
+
+## Control Equivalence
+Keeps DST-safe calendar arithmetic via `Date.UTC(y, m, d)` day numbers; narrows blast radius to weekly interval gating only.
+
+## Rollback
+Single-function revert in `js/utils.js` plus test revert in `tests/unit/recurrence-interval.test.js`.

--- a/docs/pr-notes/runs/95-review-3870447483-20260228T133434Z/code-plan.md
+++ b/docs/pr-notes/runs/95-review-3870447483-20260228T133434Z/code-plan.md
@@ -1,0 +1,10 @@
+# Code Role Plan
+
+## Minimal Patch
+1. In `expandRecurrence`, compute series week-start day number and current week-start day number.
+2. Use week-start delta to derive interval gate.
+3. Add a regression test for a mid-week start plus multi-day `byDays`.
+
+## Non-Goals
+- No changes to recurrence UI or storage schema.
+- No changes to daily recurrence logic.

--- a/docs/pr-notes/runs/95-review-3870447483-20260228T133434Z/qa.md
+++ b/docs/pr-notes/runs/95-review-3870447483-20260228T133434Z/qa.md
@@ -1,0 +1,12 @@
+# QA Role Summary
+
+## Regression Focus
+- Weekly `interval > 1` with `byDays` spanning multiple weekdays.
+- Mid-week series start alignment.
+
+## Added Coverage
+- Biweekly Monday+Wednesday series starting Wednesday validates skip/include behavior across week boundaries.
+
+## Manual Validation Targets
+- Baseline: Monday biweekly remains `03-02, 03-16, 03-30, 04-13`.
+- Edge: Wednesday start with Monday+Wednesday excludes `03-09`, includes `03-16` and `03-18`.

--- a/docs/pr-notes/runs/95-review-3870447483-20260228T133434Z/requirements.md
+++ b/docs/pr-notes/runs/95-review-3870447483-20260228T133434Z/requirements.md
@@ -1,0 +1,15 @@
+# Requirements Role Summary
+
+## Objective
+Ensure weekly recurrence `interval` semantics honor calendar-week cadence for multi-day `byDays` patterns.
+
+## Current State
+Weekly interval gating uses 7-day buckets anchored to the series start date, which can include off-cadence days when the series starts mid-week.
+
+## Proposed State
+Gate weekly occurrences by week-start boundaries (Sunday-based, consistent with `getDay()` and existing day-code mapping), then apply `interval` on week offsets.
+
+## Acceptance Criteria
+- Biweekly series starting on Wednesday with `byDays=['MO','WE']` excludes the immediate next Monday.
+- Included weeks produce only in-cadence weekdays.
+- Existing weekly interval behavior for aligned starts remains unchanged.

--- a/docs/pr-notes/runs/95-review-comment-2867475544-20260228T133734Z/architecture.md
+++ b/docs/pr-notes/runs/95-review-comment-2867475544-20260228T133734Z/architecture.md
@@ -1,0 +1,18 @@
+# Architecture Role (Fallback Synthesis)
+
+## Tooling status
+Requested skill `allplays-architecture-expert` and `sessions_spawn` are not available in this runtime; this file records equivalent architecture analysis.
+
+## Current state
+`expandRecurrence()` iterates `current` using local `Date` operations (`setDate/getDay`) but derived day numbers via `Date.UTC(year, month, date)`.
+
+## Proposed state
+Derive both `seriesStartDayNumber` and `currentDayNumber` using epoch time from the same `Date` objects (`Math.floor(date.getTime() / MS_PER_DAY)`), keeping arithmetic basis consistent.
+
+## Risk surface and blast radius
+- Affects only `js/utils.js` recurrence expansion logic.
+- Potential impact confined to weekly interval matching.
+- No schema, API, or Firestore/security changes.
+
+## Rollback
+Revert the two updated lines in `expandRecurrence()` if regression appears.

--- a/docs/pr-notes/runs/95-review-comment-2867475544-20260228T133734Z/code-plan.md
+++ b/docs/pr-notes/runs/95-review-comment-2867475544-20260228T133734Z/code-plan.md
@@ -1,0 +1,13 @@
+# Code Role (Fallback Synthesis)
+
+## Tooling status
+Requested skills `allplays-orchestrator-playbook` / `allplays-code-expert` and `sessions_spawn` are not available in this runtime; this file records equivalent code plan.
+
+## Plan
+1. Patch `js/utils.js` day-number calculations in `expandRecurrence()` to use `getTime()`.
+2. Run focused checks (grep + small Node harness) for weekly interval behavior around DST.
+3. Commit and push on PR head branch.
+
+## Conflict resolution across roles
+- All roles align on a minimal two-line fix.
+- No competing proposals required reconciliation.

--- a/docs/pr-notes/runs/95-review-comment-2867475544-20260228T133734Z/qa.md
+++ b/docs/pr-notes/runs/95-review-comment-2867475544-20260228T133734Z/qa.md
@@ -1,0 +1,17 @@
+# QA Role (Fallback Synthesis)
+
+## Tooling status
+Requested skill `allplays-qa-expert` and `sessions_spawn` are not available in this runtime; this file records equivalent QA analysis.
+
+## Regression targets
+- Weekly recurrence with `interval > 1` and explicit `byDays`.
+- Weekly recurrence with no `byDays` (series-start weekday fallback).
+- DST-adjacent dates where UTC/local midnight boundaries diverge.
+
+## Quick validation strategy
+- Static verification that both day-number lines now use `getTime()`.
+- Sanity execution of recurrence expansion in Node across a DST-boundary fixture.
+
+## Guardrails
+- Confirm unchanged loop control and match conditions except day-number derivation.
+- Confirm no impact to exDates/overrides handling.

--- a/docs/pr-notes/runs/95-review-comment-2867475544-20260228T133734Z/requirements.md
+++ b/docs/pr-notes/runs/95-review-comment-2867475544-20260228T133734Z/requirements.md
@@ -1,0 +1,20 @@
+# Requirements Role (Fallback Synthesis)
+
+## Tooling status
+Requested skill `allplays-requirements-expert` and `sessions_spawn` are not available in this runtime; this file records equivalent requirements analysis.
+
+## Objective
+Fix timezone inconsistency in recurrence week-offset calculations so weekly interval matching is deterministic across local timezone/DST boundaries.
+
+## Decision
+Use a single time basis for series and current day-number math by switching both calculations from `Date.UTC(...)` to `date.getTime() / MS_PER_DAY`.
+
+## Constraints and controls
+- Keep behavior unchanged for daily recurrence and `byDays` matching.
+- Limit blast radius to recurrence expansion internals.
+- Preserve existing API and object shape.
+
+## Acceptance criteria
+- `expandRecurrence()` computes `weeksSinceSeriesStart` from consistent day-number derivation for both dates.
+- No additional timezone conversion logic is introduced.
+- Existing recurrence paths continue functioning.

--- a/docs/pr-notes/runs/95-review-comment-2867475814-20260228T134148Z/architecture.md
+++ b/docs/pr-notes/runs/95-review-comment-2867475814-20260228T134148Z/architecture.md
@@ -1,0 +1,18 @@
+# Architecture Role Notes
+
+## Decision
+Normalize recurrence interval calculations to a single temporal frame (UTC) to remove mixed-frame math.
+
+## Why
+- Existing logic used UTC day numbers with local weekday boundaries, creating edge-case cadence drift.
+- UTC alignment matches existing `isoDate` generation via `toISOString()` and recurrence comparisons.
+
+## Control Equivalence
+- No reduction in access control, data segregation, or auditability.
+- Pure deterministic logic correction in client-side expansion.
+
+## Rollback
+- Revert commit touching `js/utils.js` recurrence block if any downstream cadence regressions appear.
+
+## Instrumentation
+- Validate with deterministic node checks across default timezone and `TZ=America/Chicago`.

--- a/docs/pr-notes/runs/95-review-comment-2867475814-20260228T134148Z/code-plan.md
+++ b/docs/pr-notes/runs/95-review-comment-2867475814-20260228T134148Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Role Notes
+
+## Minimal Patch
+- File: `js/utils.js`
+- Replace local weekday calls in weekly interval gating with UTC weekday calls:
+  - `seriesStart.getDay()` -> `seriesStart.getUTCDay()`
+  - `current.getDay()` -> `current.getUTCDay()`
+- Reuse computed UTC day-of-week for both `byDays` mapping and same-day weekly matching.
+
+## Rationale
+This preserves existing algorithm shape while removing mixed local/UTC boundary calculations that can include off-cadence dates.

--- a/docs/pr-notes/runs/95-review-comment-2867475814-20260228T134148Z/qa.md
+++ b/docs/pr-notes/runs/95-review-comment-2867475814-20260228T134148Z/qa.md
@@ -1,0 +1,14 @@
+# QA Role Notes
+
+## Regression Targets
+- Weekly recurrence with `interval > 1` and multiple `byDays` values.
+- Weekly recurrence with empty `byDays` (same weekday as series start).
+- Timezone-sensitive date parsing (`YYYY-MM-DD` string start dates).
+
+## Executed Checks
+- Biweekly case: start `2026-03-04`, `byDays=['MO','WE']` excludes `2026-03-09`.
+- Same recurrence under `TZ=America/Chicago` yields identical cadence dates.
+- Weekly/no-`byDays` cadence remains aligned to interval week boundaries.
+
+## Residual Risk
+- No browser-manual recurrence page test executed in this run; validation is function-level via Node.

--- a/docs/pr-notes/runs/95-review-comment-2867475814-20260228T134148Z/requirements.md
+++ b/docs/pr-notes/runs/95-review-comment-2867475814-20260228T134148Z/requirements.md
@@ -1,0 +1,21 @@
+# Requirements Role Notes
+
+## Objective
+Prevent off-cadence weekly recurrence instances by aligning interval gating to a consistent calendar week boundary.
+
+## Current vs Proposed
+- Current: Weekly interval uses UTC day-number buckets but local weekday extraction (`getDay`), which can drift at timezone edges.
+- Proposed: Use UTC weekday extraction (`getUTCDay`) everywhere recurrence week bucketing/day matching is computed.
+
+## Risk Surface / Blast Radius
+- Affects recurring practice expansion logic in `js/utils.js` only.
+- No schema or API changes.
+- Potential regression risk: existing weekly recurrences near timezone boundaries.
+
+## Assumptions
+- Recurrence dates are represented/compared in ISO UTC day form (`YYYY-MM-DD`).
+- Week cadence should be deterministic regardless of client locale/timezone.
+
+## Success Criteria
+- Biweekly schedule starting `2026-03-04` with `byDays=['MO','WE']` excludes `2026-03-09`.
+- Weekly interval outputs remain stable under different `TZ` values.

--- a/docs/pr-notes/runs/issue-94-fixer-20260228T132922Z/architecture.md
+++ b/docs/pr-notes/runs/issue-94-fixer-20260228T132922Z/architecture.md
@@ -1,0 +1,16 @@
+# Architecture role synthesis (fallback)
+
+Current state:
+- `expandRecurrence` iterates day-by-day and matches weekly occurrences solely by weekday membership.
+- Weekly interval is stored but never used for match gating.
+
+Proposed state:
+- Keep day-by-day iteration to avoid broad refactor.
+- Add weekly interval gate based on elapsed whole weeks from `seriesStart`.
+- A candidate weekly date matches only if:
+  - Day-of-week matches current weekly rules, and
+  - `weeksSinceSeriesStart % interval === 0`.
+
+Risk and blast radius:
+- Scope limited to `js/utils.js` recurrence expansion used by schedule, calendar, parent dashboard.
+- Main risk is off-by-one around week boundaries; mitigate with targeted unit tests.

--- a/docs/pr-notes/runs/issue-94-fixer-20260228T132922Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-94-fixer-20260228T132922Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code role synthesis (fallback)
+
+Plan:
+1. Add a new unit test file for recurrence interval behavior in `tests/unit`.
+2. Reproduce bug with weekly `interval=2` expecting biweekly dates.
+3. Patch `expandRecurrence` to apply weekly interval gating by week offset from series start.
+4. Run targeted tests.
+5. Commit docs + tests + fix with issue reference.
+
+Constraints:
+- Minimal patch only; no unrelated refactors.
+- Preserve existing recurrence end-condition behavior (`count`, `until`, `exDates`, overrides).

--- a/docs/pr-notes/runs/issue-94-fixer-20260228T132922Z/qa.md
+++ b/docs/pr-notes/runs/issue-94-fixer-20260228T132922Z/qa.md
@@ -1,0 +1,11 @@
+# QA role synthesis (fallback)
+
+Regression targets:
+- Weekly recurrence with `interval = 2` and one `byDays` value should skip alternating weeks.
+- Weekly recurrence with multiple `byDays` values should include all selected days only in valid interval weeks.
+- Daily recurrence should remain unaffected.
+
+Validation plan:
+- Add unit tests against `expandRecurrence` in `tests/unit`.
+- Use fixed system time to keep windowing deterministic.
+- Run targeted vitest file for fast feedback.

--- a/docs/pr-notes/runs/issue-94-fixer-20260228T132922Z/requirements.md
+++ b/docs/pr-notes/runs/issue-94-fixer-20260228T132922Z/requirements.md
@@ -1,0 +1,13 @@
+# Requirements role synthesis (fallback)
+
+Objective: Ensure weekly recurring practices honor `recurrence.interval` so `interval = N` generates every N weeks, not every week.
+
+User impact:
+- Coaches creating biweekly or multi-week recurring practices currently get extra events.
+- Parents and team dashboards inherit these incorrect occurrences.
+
+Acceptance criteria:
+- Weekly series with `byDays` and `interval > 1` only produces occurrences on weeks aligned to the master start week cadence.
+- Weekly series without `byDays` still defaults to the master day-of-week, respecting interval.
+- Existing daily recurrence behavior remains unchanged.
+- `count` and `until` still cap occurrences.

--- a/js/utils.js
+++ b/js/utils.js
@@ -553,7 +553,7 @@ export function expandRecurrence(master, windowDays = 180) {
 
   // Start from series creation date
   const seriesStart = master.date?.toDate ? master.date.toDate() : new Date(master.date || master.createdAt?.toDate?.() || now);
-  const seriesStartDayNumber = Math.floor(Date.UTC(seriesStart.getFullYear(), seriesStart.getMonth(), seriesStart.getDate()) / MS_PER_DAY);
+  const seriesStartDayNumber = Math.floor(seriesStart.getTime() / MS_PER_DAY);
   const seriesStartWeekStartDayNumber = seriesStartDayNumber - seriesStart.getDay();
   let current = new Date(seriesStart);
   let generated = 0;
@@ -574,7 +574,7 @@ export function expandRecurrence(master, windowDays = 180) {
 
     const isoDate = current.toISOString().split('T')[0];
     const dayCode = DAY_CODES[current.getDay()];
-    const currentDayNumber = Math.floor(Date.UTC(current.getFullYear(), current.getMonth(), current.getDate()) / MS_PER_DAY);
+    const currentDayNumber = Math.floor(current.getTime() / MS_PER_DAY);
     const currentWeekStartDayNumber = currentDayNumber - current.getDay();
     const weeksSinceSeriesStart = Math.floor((currentWeekStartDayNumber - seriesStartWeekStartDayNumber) / 7);
     const weeklyIntervalMatch = interval <= 1 || (weeksSinceSeriesStart >= 0 && weeksSinceSeriesStart % interval === 0);

--- a/js/utils.js
+++ b/js/utils.js
@@ -554,7 +554,8 @@ export function expandRecurrence(master, windowDays = 180) {
   // Start from series creation date
   const seriesStart = master.date?.toDate ? master.date.toDate() : new Date(master.date || master.createdAt?.toDate?.() || now);
   const seriesStartDayNumber = Math.floor(seriesStart.getTime() / MS_PER_DAY);
-  const seriesStartWeekStartDayNumber = seriesStartDayNumber - seriesStart.getDay();
+  const seriesStartUtcDayOfWeek = seriesStart.getUTCDay();
+  const seriesStartWeekStartDayNumber = seriesStartDayNumber - seriesStartUtcDayOfWeek;
   let current = new Date(seriesStart);
   let generated = 0;
 
@@ -573,9 +574,10 @@ export function expandRecurrence(master, windowDays = 180) {
     if (count && generated >= count) break;
 
     const isoDate = current.toISOString().split('T')[0];
-    const dayCode = DAY_CODES[current.getDay()];
+    const currentUtcDayOfWeek = current.getUTCDay();
+    const dayCode = DAY_CODES[currentUtcDayOfWeek];
     const currentDayNumber = Math.floor(current.getTime() / MS_PER_DAY);
-    const currentWeekStartDayNumber = currentDayNumber - current.getDay();
+    const currentWeekStartDayNumber = currentDayNumber - currentUtcDayOfWeek;
     const weeksSinceSeriesStart = Math.floor((currentWeekStartDayNumber - seriesStartWeekStartDayNumber) / 7);
     const weeklyIntervalMatch = interval <= 1 || (weeksSinceSeriesStart >= 0 && weeksSinceSeriesStart % interval === 0);
 
@@ -587,7 +589,7 @@ export function expandRecurrence(master, windowDays = 180) {
       matches = true;
     } else if (freq === 'weekly' && byDays.length === 0) {
       // If no specific days, match the same day as series start
-      matches = current.getDay() === seriesStart.getDay() && weeklyIntervalMatch;
+      matches = currentUtcDayOfWeek === seriesStartUtcDayOfWeek && weeklyIntervalMatch;
     }
 
     // Only process if within visible window and matches pattern

--- a/js/utils.js
+++ b/js/utils.js
@@ -554,6 +554,7 @@ export function expandRecurrence(master, windowDays = 180) {
   // Start from series creation date
   const seriesStart = master.date?.toDate ? master.date.toDate() : new Date(master.date || master.createdAt?.toDate?.() || now);
   const seriesStartDayNumber = Math.floor(Date.UTC(seriesStart.getFullYear(), seriesStart.getMonth(), seriesStart.getDate()) / MS_PER_DAY);
+  const seriesStartWeekStartDayNumber = seriesStartDayNumber - seriesStart.getDay();
   let current = new Date(seriesStart);
   let generated = 0;
 
@@ -574,7 +575,8 @@ export function expandRecurrence(master, windowDays = 180) {
     const isoDate = current.toISOString().split('T')[0];
     const dayCode = DAY_CODES[current.getDay()];
     const currentDayNumber = Math.floor(Date.UTC(current.getFullYear(), current.getMonth(), current.getDate()) / MS_PER_DAY);
-    const weeksSinceSeriesStart = Math.floor((currentDayNumber - seriesStartDayNumber) / 7);
+    const currentWeekStartDayNumber = currentDayNumber - current.getDay();
+    const weeksSinceSeriesStart = Math.floor((currentWeekStartDayNumber - seriesStartWeekStartDayNumber) / 7);
     const weeklyIntervalMatch = interval <= 1 || (weeksSinceSeriesStart >= 0 && weeksSinceSeriesStart % interval === 0);
 
     // Check if this day matches the recurrence pattern

--- a/js/utils.js
+++ b/js/utils.js
@@ -529,6 +529,13 @@ export function generateSeriesId() {
 const DAY_CODES = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
+function toLocalDateKey(date) {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
 /**
  * Expand a recurring practice master into individual occurrences
  * @param {Object} master - The series master document
@@ -554,8 +561,8 @@ export function expandRecurrence(master, windowDays = 180) {
   // Start from series creation date
   const seriesStart = master.date?.toDate ? master.date.toDate() : new Date(master.date || master.createdAt?.toDate?.() || now);
   const seriesStartDayNumber = Math.floor(seriesStart.getTime() / MS_PER_DAY);
-  const seriesStartUtcDayOfWeek = seriesStart.getUTCDay();
-  const seriesStartWeekStartDayNumber = seriesStartDayNumber - seriesStartUtcDayOfWeek;
+  const seriesStartDayOfWeek = seriesStart.getDay();
+  const seriesStartWeekStartDayNumber = seriesStartDayNumber - seriesStartDayOfWeek;
   let current = new Date(seriesStart);
   let generated = 0;
 
@@ -573,11 +580,11 @@ export function expandRecurrence(master, windowDays = 180) {
     }
     if (count && generated >= count) break;
 
-    const isoDate = current.toISOString().split('T')[0];
-    const currentUtcDayOfWeek = current.getUTCDay();
-    const dayCode = DAY_CODES[currentUtcDayOfWeek];
+    const isoDate = toLocalDateKey(current);
+    const currentDayOfWeek = current.getDay();
+    const dayCode = DAY_CODES[currentDayOfWeek];
     const currentDayNumber = Math.floor(current.getTime() / MS_PER_DAY);
-    const currentWeekStartDayNumber = currentDayNumber - currentUtcDayOfWeek;
+    const currentWeekStartDayNumber = currentDayNumber - currentDayOfWeek;
     const weeksSinceSeriesStart = Math.floor((currentWeekStartDayNumber - seriesStartWeekStartDayNumber) / 7);
     const weeklyIntervalMatch = interval <= 1 || (weeksSinceSeriesStart >= 0 && weeksSinceSeriesStart % interval === 0);
 
@@ -589,7 +596,7 @@ export function expandRecurrence(master, windowDays = 180) {
       matches = true;
     } else if (freq === 'weekly' && byDays.length === 0) {
       // If no specific days, match the same day as series start
-      matches = currentUtcDayOfWeek === seriesStartUtcDayOfWeek && weeklyIntervalMatch;
+      matches = currentDayOfWeek === seriesStartDayOfWeek && weeklyIntervalMatch;
     }
 
     // Only process if within visible window and matches pattern

--- a/tests/unit/recurrence-interval.test.js
+++ b/tests/unit/recurrence-interval.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { expandRecurrence } from '../../js/utils.js';
+
+afterEach(() => {
+    vi.useRealTimers();
+});
+
+describe('expandRecurrence weekly interval handling', () => {
+    it('expands weekly recurrences every N weeks when byDays is set', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-03-01T12:00:00Z'));
+
+        const master = {
+            id: 'practice-1',
+            isSeriesMaster: true,
+            date: new Date('2026-03-02T17:00:00Z'),
+            recurrence: {
+                freq: 'weekly',
+                interval: 2,
+                byDays: ['MO']
+            }
+        };
+
+        const dates = expandRecurrence(master, 50).map((occ) => occ.instanceDate);
+
+        expect(dates.slice(0, 4)).toEqual([
+            '2026-03-02',
+            '2026-03-16',
+            '2026-03-30',
+            '2026-04-13'
+        ]);
+        expect(dates).not.toContain('2026-03-09');
+    });
+});

--- a/tests/unit/recurrence-interval.test.js
+++ b/tests/unit/recurrence-interval.test.js
@@ -31,4 +31,32 @@ describe('expandRecurrence weekly interval handling', () => {
         ]);
         expect(dates).not.toContain('2026-03-09');
     });
+
+    it('anchors weekly intervals to calendar weeks for multi-day patterns', () => {
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-03-01T12:00:00Z'));
+
+        const master = {
+            id: 'practice-2',
+            isSeriesMaster: true,
+            date: new Date('2026-03-04T17:00:00Z'),
+            recurrence: {
+                freq: 'weekly',
+                interval: 2,
+                byDays: ['MO', 'WE']
+            }
+        };
+
+        const dates = expandRecurrence(master, 50).map((occ) => occ.instanceDate);
+
+        expect(dates.slice(0, 5)).toEqual([
+            '2026-03-04',
+            '2026-03-16',
+            '2026-03-18',
+            '2026-03-30',
+            '2026-04-01'
+        ]);
+        expect(dates).not.toContain('2026-03-09');
+        expect(dates).not.toContain('2026-03-23');
+    });
 });


### PR DESCRIPTION
Closes #94

## What changed
- Fixed `expandRecurrence` in `js/utils.js` so weekly recurrence now applies `interval` gating by week offset from the series start date.
- Kept existing daily recurrence behavior unchanged.
- Added `tests/unit/recurrence-interval.test.js` to reproduce and guard against the weekly interval bug (`interval=2` now yields biweekly dates).
- Added run artifacts under `docs/pr-notes/runs/issue-94-fixer-20260228T132922Z/` for requirements, architecture, QA, and code-plan synthesis.

## Why
Weekly recurring practices were being expanded every week even when `interval > 1`, creating extra unintended events across schedule, calendar, and parent dashboard views. This patch enforces expected weekly spacing while preserving existing recurrence constraints (`until`, `count`, exclusions, overrides).