### PR TITLE
Restore live tracker period and clock on resume

### DIFF
--- a/docs/pr-notes/runs/97-remediator-20260301T151553Z/architecture.md
+++ b/docs/pr-notes/runs/97-remediator-20260301T151553Z/architecture.md
@@ -1,0 +1,13 @@
+# Architecture Role Notes
+
+## Decision
+Simplify mixed timestamp handling: pick the highest `order` candidate when both timestamped and untimestamped events exist.
+
+## Rationale
+- `order` reflects snapshot/list order from Firestore query and is the only reliable signal when `serverTimestamp()` is unresolved.
+- Avoids stale restore from older timestamped event when a later untimestamped event exists.
+- Keeps all-timestamped branch unchanged for deterministic server-time ordering.
+
+## Blast Radius
+- Limited to `js/live-tracker-resume.js` logic path for mixed datasets.
+- No schema or API changes.

--- a/docs/pr-notes/runs/97-remediator-20260301T151553Z/code-plan.md
+++ b/docs/pr-notes/runs/97-remediator-20260301T151553Z/code-plan.md
@@ -1,0 +1,10 @@
+# Code Role Plan
+
+## Thinking Level
+medium - single-module behavioral fix with regression-test confirmation.
+
+## Plan
+1. Update mixed timestamp branch in `deriveResumeClockState` to include untimestamped recency by event order.
+2. Add/update unit test to lock behavior where latest event is untimestamped and should be restored.
+3. Run targeted Vitest file.
+4. Commit scoped changes.

--- a/docs/pr-notes/runs/97-remediator-20260301T151553Z/qa.md
+++ b/docs/pr-notes/runs/97-remediator-20260301T151553Z/qa.md
@@ -1,0 +1,12 @@
+# QA Role Notes
+
+## Test Focus
+- Unit tests for `deriveResumeClockState` mixed timestamp behavior.
+- Regression: latest untimestamped event should win over older timestamped event.
+
+## Validation Plan
+1. Run `tests/unit/live-tracker-resume.test.js` via Vitest.
+2. Confirm no regressions in existing timestamped and untimestamped-only tests.
+
+## Risks
+- Assumes event array order corresponds to event recency in listener payload.

--- a/docs/pr-notes/runs/97-remediator-20260301T151553Z/requirements.md
+++ b/docs/pr-notes/runs/97-remediator-20260301T151553Z/requirements.md
@@ -1,0 +1,18 @@
+# Requirements Role Notes
+
+## Objective
+Address PR thread `PRRT_kwDOQe-T585xVPRU` by ensuring resume state derivation handles mixed timestamped/untimestamped `liveEvents` without restoring stale context.
+
+## Current State
+`deriveResumeClockState` uses timestamp ordering when all events have timestamps, and progression heuristics otherwise. The review indicates a mixed-data case where latest event can be untimestamped (`createdAt: null`) and should not be ignored.
+
+## Proposed State
+When dataset is mixed, include untimestamped events as valid candidates for recency/progression so the most recent context is restored even while server timestamps are pending.
+
+## Constraints
+- Keep change minimal and scoped to resume derivation.
+- Preserve existing behavior for all-timestamped and all-untimestamped datasets.
+
+## Success Criteria
+- Mixed dataset with latest untimestamped event restores that latest event.
+- Existing unit tests pass; add/adjust regression coverage for mixed case.

--- a/docs/pr-notes/runs/97-review-3870546083-20260228T161008Z/architecture.md
+++ b/docs/pr-notes/runs/97-review-3870546083-20260228T161008Z/architecture.md
@@ -1,0 +1,17 @@
+# Architecture Role Summary
+
+## Decision
+Use a deterministic dual-strategy chooser:
+- `latestByTimestamp`: newest record among timestamped candidates.
+- `mostAdvanced`: furthest game progression among all valid candidates.
+
+Select the later state by progression comparator (period order, then clock, then source order).
+
+## Why
+Pending server timestamps are common in Firestore local/offline scenarios. Treating missing timestamps as ineligible can restore stale state. Comparing both candidates keeps correctness in mixed datasets while preserving timestamp authority when it still reflects the latest state.
+
+## Controls Equivalence
+- No persistence-layer change.
+- No auth/rules impact.
+- No additional network calls.
+- Blast radius limited to pure function behavior.

--- a/docs/pr-notes/runs/97-review-3870546083-20260228T161008Z/code-plan.md
+++ b/docs/pr-notes/runs/97-review-3870546083-20260228T161008Z/code-plan.md
@@ -1,0 +1,10 @@
+# Code Role Plan
+
+## Smallest Safe Patch
+1. Introduce comparator helpers in `js/live-tracker-resume.js` for progression ranking and candidate selection.
+2. Evaluate both `latestByTimestamp` and `mostAdvanced` in mixed datasets.
+3. Return the more advanced candidate to avoid stale restore.
+4. Add one focused unit test for mixed timestamp state.
+
+## Rollback
+Single-commit rollback restores previous behavior.

--- a/docs/pr-notes/runs/97-review-3870546083-20260228T161008Z/qa.md
+++ b/docs/pr-notes/runs/97-review-3870546083-20260228T161008Z/qa.md
@@ -1,0 +1,14 @@
+# QA Role Summary
+
+## Regression Targets
+1. Pure timestamp ordering still picks latest `createdAt`.
+2. No valid candidates still returns defaults with `restored: false`.
+3. Timestamp-missing datasets still use progression heuristic.
+4. Mixed timestamped/untimestamped datasets do not regress to stale timestamped state.
+
+## Test Additions
+Add unit test covering mixed dataset where untimestamped event is more advanced than latest timestamped event.
+
+## Validation Scope
+Run targeted Vitest file:
+- `tests/unit/live-tracker-resume.test.js`

--- a/docs/pr-notes/runs/97-review-3870546083-20260228T161008Z/requirements.md
+++ b/docs/pr-notes/runs/97-review-3870546083-20260228T161008Z/requirements.md
@@ -1,0 +1,20 @@
+# Requirements Role Summary
+
+## Objective
+Prevent stale period/clock restore when live event documents include pending `serverTimestamp()` values (`createdAt: null`) during resume.
+
+## Current State
+Resume logic trusts latest `createdAt` whenever at least one timestamped event exists, ignoring untimestamped events.
+
+## Proposed State
+Resume logic must include untimestamped valid events in mixed datasets and avoid regressing to an older game position.
+
+## Risk Surface and Blast Radius
+- Scope: resume initialization path only (`deriveResumeClockState`).
+- User impact: incorrect period/clock on resume can mislead coaches/parents and create stat/log drift.
+- Data risk: no schema/rules changes, read-only derivation logic.
+
+## Acceptance Criteria
+1. Mixed timestamped + untimestamped events restore to latest plausible game position.
+2. Existing behavior for fully timestamped datasets remains unchanged.
+3. Existing fallback behavior for no valid events remains unchanged.

--- a/docs/pr-notes/runs/97-review-comment-2867602409-20260228T161255Z/architecture.md
+++ b/docs/pr-notes/runs/97-review-comment-2867602409-20260228T161255Z/architecture.md
@@ -1,0 +1,15 @@
+# Architecture Role Notes
+
+## Current State
+`deriveResumeClockState()` resolves mixed datasets by comparing latest timestamped against furthest untimestamped progression.
+
+## Proposed State
+For mixed datasets:
+- Compute latest timestamped candidate.
+- If untimestamped candidates appear after it in observed event order, choose the latest such untimestamped candidate.
+- Otherwise keep existing progression comparison fallback.
+
+## Risk and Blast Radius
+- Scope limited to tracker resume helper and import cache-bust version.
+- No Firestore schema/rules changes.
+- Minimal runtime risk due isolated pure-function update and added unit coverage.

--- a/docs/pr-notes/runs/97-review-comment-2867602409-20260228T161255Z/code-plan.md
+++ b/docs/pr-notes/runs/97-review-comment-2867602409-20260228T161255Z/code-plan.md
@@ -1,0 +1,7 @@
+# Code Role Notes
+
+## Minimal Patch Plan
+1. Update mixed-dataset logic in `js/live-tracker-resume.js` to include untimestamped events that appear after latest timestamped event.
+2. Add unit test proving newest untimestamped event wins in mixed datasets.
+3. Bump `live-tracker-resume` import cache version in `js/live-tracker.js`.
+4. Run targeted unit tests and commit/push.

--- a/docs/pr-notes/runs/97-review-comment-2867602409-20260228T161255Z/qa.md
+++ b/docs/pr-notes/runs/97-review-comment-2867602409-20260228T161255Z/qa.md
@@ -1,0 +1,13 @@
+# QA Role Notes
+
+## Regression Target
+Mixed `liveEvents` where newest event has `createdAt: null` must not restore stale period/clock.
+
+## Test Strategy
+- Unit test helper behavior directly in `tests/unit/live-tracker-resume.test.js`.
+- Keep existing tests for timestamped-only, untimestamped-only, and mixed progression.
+- Add explicit mixed-recency test where latest untimestamped event has lower clock than stale timestamped event.
+
+## Pass Criteria
+- Targeted unit test file passes in Vitest.
+- No regressions in existing helper tests.

--- a/docs/pr-notes/runs/97-review-comment-2867602409-20260228T161255Z/requirements.md
+++ b/docs/pr-notes/runs/97-review-comment-2867602409-20260228T161255Z/requirements.md
@@ -1,0 +1,13 @@
+# Requirements Role Notes
+
+## Objective
+Fix resume-state restoration so mixed `liveEvents` datasets do not ignore newest untimestamped events.
+
+## User Impact
+- Prevents resuming to stale period/clock after reload/offline transitions while `serverTimestamp()` is pending.
+- Preserves continuity for coaches/parents/managers rejoining active games.
+
+## Acceptance Criteria
+1. In mixed timestamped + untimestamped `liveEvents`, untimestamped events that occur after the latest timestamped event can drive restored period/clock.
+2. Existing behavior remains for all-timestamped and all-untimestamped datasets.
+3. Unit tests cover mixed-dataset recency behavior and pass.

--- a/docs/pr-notes/runs/issue-96-fixer-20260228T160043Z/architecture.md
+++ b/docs/pr-notes/runs/issue-96-fixer-20260228T160043Z/architecture.md
@@ -1,0 +1,19 @@
+# Architecture role synthesis (fallback; requested skill unavailable)
+
+## Current state
+- `init()` resets `state.period='Q1'` and `state.clock=0`.
+- Resume reconstruction reads `liveEvents` only for some score/opponent backfill logic.
+- UI init unconditionally calls `setPeriod('Q1')`, overriding any restored state.
+
+## Proposed state
+- Add a small pure helper for resume-state derivation from persisted live events.
+- In resume path, always fetch `liveEvents`, derive latest valid period/clock, and apply to `state`.
+- Replace `setPeriod('Q1')` with `setPeriod(state.period)`.
+
+## Blast radius
+- Limited to live tracker resume flow (`js/live-tracker.js`) + new helper module + unit tests.
+- No Firestore schema/rules changes.
+
+## Control equivalence
+- Does not increase data access surface; uses already-read game-scoped events.
+- No change to auth/tenant boundaries.

--- a/docs/pr-notes/runs/issue-96-fixer-20260228T160043Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-96-fixer-20260228T160043Z/code-plan.md
@@ -1,0 +1,10 @@
+# Code role synthesis (fallback; requested skill unavailable)
+
+## Minimal patch
+1. Add `js/live-tracker-resume.js` with pure resume derivation helper.
+2. Add `tests/unit/live-tracker-resume.test.js` covering latest-event restore + fallback logic.
+3. Wire helper into `js/live-tracker.js` resume path and apply `setPeriod(state.period)` during init.
+
+## Non-goals
+- No refactor of broader live tracker state machine.
+- No changes to scoring aggregation logic beyond necessary `liveEvents` availability.

--- a/docs/pr-notes/runs/issue-96-fixer-20260228T160043Z/qa.md
+++ b/docs/pr-notes/runs/issue-96-fixer-20260228T160043Z/qa.md
@@ -1,0 +1,13 @@
+# QA role synthesis (fallback; requested skill unavailable)
+
+## Primary regression to guard
+Resume path must not reset to Q1 00:00 when persisted events indicate later period/clock.
+
+## Unit test plan
+- New helper test: choose latest valid event by `createdAt`; restore `period` + `gameClockMs`.
+- Fallback test: when no valid period/clock exists, return defaults Q1/0.
+- Robustness test: still restore using progression fallback when timestamps unavailable.
+
+## Manual sanity checks
+- Reproduce issue flow in browser: track into Q3 with running clock, reload, choose resume, verify period/clock retained.
+- Start-over path still wipes events and starts at Q1 00:00.

--- a/docs/pr-notes/runs/issue-96-fixer-20260228T160043Z/requirements.md
+++ b/docs/pr-notes/runs/issue-96-fixer-20260228T160043Z/requirements.md
@@ -1,0 +1,17 @@
+# Requirements role synthesis (fallback; requested skill unavailable)
+
+## Objective
+When a stat-keeper chooses “Continue where you left off”, the tracker must resume at the last persisted game period and clock, not reset to Q1 00:00.
+
+## User-facing acceptance criteria
+- Resume path preserves in-game context (period + elapsed clock ms) from persisted live events.
+- If no valid persisted period/clock exists, fallback remains Q1 00:00.
+- Starting-over path (Cancel) still clears persisted events/stats and starts at Q1 00:00.
+- Existing score/stat/opponent resume behavior remains unchanged.
+
+## Risk surface
+- Incorrect ordering of live events could pick wrong resume point.
+- Non-standard/legacy event payloads may lack usable period/clock.
+
+## Recommendation
+Use persisted `liveEvents` as source of truth for period/clock restoration and apply restored period during init rendering.

--- a/js/live-tracker-resume.js
+++ b/js/live-tracker-resume.js
@@ -1,0 +1,74 @@
+function toMillis(value) {
+    if (value == null) return null;
+    if (typeof value === 'number' && Number.isFinite(value)) return value;
+    if (typeof value?.toMillis === 'function') {
+        const ms = value.toMillis();
+        return Number.isFinite(ms) ? ms : null;
+    }
+    if (typeof value === 'object' && Number.isFinite(value.seconds)) {
+        const nanos = Number.isFinite(value.nanoseconds) ? value.nanoseconds : 0;
+        return (value.seconds * 1000) + Math.floor(nanos / 1000000);
+    }
+    return null;
+}
+
+function periodOrder(period) {
+    const value = String(period || '').trim().toUpperCase();
+    const quarterMatch = value.match(/^Q(\d+)$/);
+    if (quarterMatch) return Number(quarterMatch[1]);
+
+    const otMatch = value.match(/^OT(?:\s*|[-]?)(\d+)?$/);
+    if (otMatch) return 100 + Number(otMatch[1] || 1);
+
+    return 0;
+}
+
+export function deriveResumeClockState(liveEvents, defaults = { period: 'Q1', clock: 0 }) {
+    const fallbackPeriod = defaults?.period || 'Q1';
+    const fallbackClock = Number.isFinite(defaults?.clock) ? defaults.clock : 0;
+
+    if (!Array.isArray(liveEvents) || liveEvents.length === 0) {
+        return { period: fallbackPeriod, clock: fallbackClock, restored: false };
+    }
+
+    const candidates = liveEvents
+        .map((event, index) => {
+            const period = typeof event?.period === 'string' ? event.period : null;
+            const clock = Number(event?.gameClockMs);
+            if (!period || !Number.isFinite(clock) || clock < 0) return null;
+
+            return {
+                period,
+                clock,
+                createdAtMs: toMillis(event.createdAt),
+                order: index
+            };
+        })
+        .filter(Boolean);
+
+    if (!candidates.length) {
+        return { period: fallbackPeriod, clock: fallbackClock, restored: false };
+    }
+
+    const withTimestamp = candidates.filter(item => Number.isFinite(item.createdAtMs));
+    if (withTimestamp.length) {
+        const latest = withTimestamp.reduce((best, item) => {
+            if (!best) return item;
+            if (item.createdAtMs > best.createdAtMs) return item;
+            if (item.createdAtMs === best.createdAtMs && item.order > best.order) return item;
+            return best;
+        }, null);
+        return { period: latest.period, clock: latest.clock, restored: true };
+    }
+
+    const furthest = candidates.reduce((best, item) => {
+        if (!best) return item;
+        const bestPeriod = periodOrder(best.period);
+        const itemPeriod = periodOrder(item.period);
+        if (itemPeriod > bestPeriod) return item;
+        if (itemPeriod === bestPeriod && item.clock > best.clock) return item;
+        return best;
+    }, null);
+
+    return { period: furthest.period, clock: furthest.clock, restored: true };
+}

--- a/js/live-tracker-resume.js
+++ b/js/live-tracker-resume.js
@@ -93,10 +93,19 @@ export function deriveResumeClockState(liveEvents, defaults = { period: 'Q1', cl
         if (item.createdAtMs === best.createdAtMs && item.order > best.order) return item;
         return best;
     }, null);
+    const untimestampedAfterLatestTimestamp = withoutTimestamp.filter(
+        item => item.order > latestTimestamped.order
+    );
+    if (untimestampedAfterLatestTimestamp.length) {
+        const latestUntimestamped = untimestampedAfterLatestTimestamp.reduce(
+            (best, item) => (item.order > best.order ? item : best),
+            untimestampedAfterLatestTimestamp[0]
+        );
+        return { period: latestUntimestamped.period, clock: latestUntimestamped.clock, restored: true };
+    }
+
     const furthestUntimestamped = pickMostAdvanced(withoutTimestamp);
-    const chosen = compareProgress(furthestUntimestamped, latestTimestamped) > 0
-        ? furthestUntimestamped
-        : latestTimestamped;
+    const chosen = compareProgress(furthestUntimestamped, latestTimestamped) > 0 ? furthestUntimestamped : latestTimestamped;
 
     return { period: chosen.period, clock: chosen.clock, restored: true };
 }

--- a/js/live-tracker-resume.js
+++ b/js/live-tracker-resume.js
@@ -86,26 +86,11 @@ export function deriveResumeClockState(liveEvents, defaults = { period: 'Q1', cl
         return { period: furthest.period, clock: furthest.clock, restored: true };
     }
 
-    const withoutTimestamp = candidates.filter(item => !Number.isFinite(item.createdAtMs));
-    const latestTimestamped = withTimestamp.reduce((best, item) => {
-        if (!best) return item;
-        if (item.createdAtMs > best.createdAtMs) return item;
-        if (item.createdAtMs === best.createdAtMs && item.order > best.order) return item;
-        return best;
-    }, null);
-    const untimestampedAfterLatestTimestamp = withoutTimestamp.filter(
-        item => item.order > latestTimestamped.order
+    // Mixed datasets can include pending serverTimestamp() writes (createdAt: null).
+    // In this case, preserve recency from snapshot order instead of ignoring untimestamped events.
+    const latestByOrder = candidates.reduce(
+        (best, item) => (item.order > best.order ? item : best),
+        candidates[0]
     );
-    if (untimestampedAfterLatestTimestamp.length) {
-        const latestUntimestamped = untimestampedAfterLatestTimestamp.reduce(
-            (best, item) => (item.order > best.order ? item : best),
-            untimestampedAfterLatestTimestamp[0]
-        );
-        return { period: latestUntimestamped.period, clock: latestUntimestamped.clock, restored: true };
-    }
-
-    const furthestUntimestamped = pickMostAdvanced(withoutTimestamp);
-    const chosen = compareProgress(furthestUntimestamped, latestTimestamped) > 0 ? furthestUntimestamped : latestTimestamped;
-
-    return { period: chosen.period, clock: chosen.clock, restored: true };
+    return { period: latestByOrder.period, clock: latestByOrder.clock, restored: true };
 }

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -9,6 +9,7 @@ import { getApp } from './vendor/firebase-app.js';
 import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './live-tracker-notes.js?v=1';
 import { canApplySubstitution, applySubstitution, canTrustScoreLogForFinalization, reconcileFinalScoreFromLog, acquireSingleFlightLock, releaseSingleFlightLock } from './live-tracker-integrity.js?v=1';
 import { hydrateOpponentStats } from './live-tracker-opponent-stats.js?v=1';
+import { deriveResumeClockState } from './live-tracker-resume.js?v=1';
 
 let currentTeamId = null;
 let currentGameId = null;
@@ -2406,14 +2407,15 @@ async function init() {
       if (shouldResume) {
         const statsSnapshot = await safeGetDocs(collection(db, `teams/${teamId}/games/${gameId}/aggregatedStats`), 'aggregatedStats');
         const hasAggregatedStats = statsSnapshot.size > 0;
-        let liveEvents = [];
-
-        if (!hasAggregatedStats || !hasOpponentStats) {
-          const liveEventsSnapshot = await safeGetDocs(collection(db, `teams/${teamId}/games/${gameId}/liveEvents`), 'liveEvents');
-          liveEvents = liveEventsSnapshot.docs.map(d => d.data());
-        }
+        const liveEventsSnapshot = await safeGetDocs(collection(db, `teams/${teamId}/games/${gameId}/liveEvents`), 'liveEvents');
+        const liveEvents = liveEventsSnapshot.docs.map(d => d.data());
         const resumedFromPersistedData = hasScores || hasLiveFlag || hasOpponentStats || hasAggregatedStats || liveEvents.length > 0;
         state.scoreLogIsComplete = !resumedFromPersistedData;
+        const resumeClockState = deriveResumeClockState(liveEvents, { period: state.period, clock: state.clock });
+        if (resumeClockState.restored) {
+          state.period = resumeClockState.period;
+          state.clock = resumeClockState.clock;
+        }
 
         // Load existing aggregated stats
         statsSnapshot.forEach(d => {
@@ -2517,7 +2519,7 @@ async function init() {
     updateSubtitle();
 
     setTab('live');
-    setPeriod('Q1');
+    setPeriod(state.period);
     renderAll();
     renderQueue();
     attachEvents();

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -9,7 +9,7 @@ import { getApp } from './vendor/firebase-app.js';
 import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './live-tracker-notes.js?v=1';
 import { canApplySubstitution, applySubstitution, canTrustScoreLogForFinalization, reconcileFinalScoreFromLog, acquireSingleFlightLock, releaseSingleFlightLock } from './live-tracker-integrity.js?v=1';
 import { hydrateOpponentStats } from './live-tracker-opponent-stats.js?v=1';
-import { deriveResumeClockState } from './live-tracker-resume.js?v=1';
+import { deriveResumeClockState } from './live-tracker-resume.js?v=2';
 
 let currentTeamId = null;
 let currentGameId = null;

--- a/tests/unit/live-tracker-resume.test.js
+++ b/tests/unit/live-tracker-resume.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { deriveResumeClockState } from '../../js/live-tracker-resume.js';
+
+describe('live tracker resume clock state', () => {
+  it('restores period and clock from latest persisted live event by createdAt', () => {
+    const result = deriveResumeClockState([
+      { period: 'Q3', gameClockMs: 120000, createdAt: { toMillis: () => 1000 } },
+      { period: 'Q2', gameClockMs: 45000, createdAt: { toMillis: () => 900 } },
+      { period: 'Q3', gameClockMs: 150000, createdAt: { toMillis: () => 1100 } }
+    ]);
+
+    expect(result.restored).toBe(true);
+    expect(result.period).toBe('Q3');
+    expect(result.clock).toBe(150000);
+  });
+
+  it('falls back to defaults when no valid period/clock exists', () => {
+    const result = deriveResumeClockState([
+      { type: 'chat', message: 'hello' },
+      { period: null, gameClockMs: undefined }
+    ]);
+
+    expect(result.restored).toBe(false);
+    expect(result.period).toBe('Q1');
+    expect(result.clock).toBe(0);
+  });
+
+  it('restores using period/clock progression when timestamps are unavailable', () => {
+    const result = deriveResumeClockState([
+      { period: 'Q1', gameClockMs: 30000 },
+      { period: 'Q2', gameClockMs: 10000 },
+      { period: 'Q1', gameClockMs: 45000 }
+    ]);
+
+    expect(result.restored).toBe(true);
+    expect(result.period).toBe('Q2');
+    expect(result.clock).toBe(10000);
+  });
+});

--- a/tests/unit/live-tracker-resume.test.js
+++ b/tests/unit/live-tracker-resume.test.js
@@ -36,4 +36,16 @@ describe('live tracker resume clock state', () => {
     expect(result.period).toBe('Q2');
     expect(result.clock).toBe(10000);
   });
+
+  it('prefers untimestamped progress over stale timestamped state in mixed datasets', () => {
+    const result = deriveResumeClockState([
+      { period: 'Q2', gameClockMs: 20000, createdAt: { toMillis: () => 1000 } },
+      { period: 'Q2', gameClockMs: 25000, createdAt: { toMillis: () => 1100 } },
+      { period: 'Q3', gameClockMs: 5000, createdAt: null }
+    ]);
+
+    expect(result.restored).toBe(true);
+    expect(result.period).toBe('Q3');
+    expect(result.clock).toBe(5000);
+  });
 });

--- a/tests/unit/live-tracker-resume.test.js
+++ b/tests/unit/live-tracker-resume.test.js
@@ -48,4 +48,16 @@ describe('live tracker resume clock state', () => {
     expect(result.period).toBe('Q3');
     expect(result.clock).toBe(5000);
   });
+
+  it('prefers newer untimestamped events that follow the latest timestamped event', () => {
+    const result = deriveResumeClockState([
+      { period: 'Q2', gameClockMs: 20000, createdAt: { toMillis: () => 1000 } },
+      { period: 'Q2', gameClockMs: 25000, createdAt: { toMillis: () => 1100 } },
+      { period: 'Q2', gameClockMs: 24000, createdAt: null }
+    ]);
+
+    expect(result.restored).toBe(true);
+    expect(result.period).toBe('Q2');
+    expect(result.clock).toBe(24000);
+  });
 });

--- a/tests/unit/live-tracker-resume.test.js
+++ b/tests/unit/live-tracker-resume.test.js
@@ -60,4 +60,16 @@ describe('live tracker resume clock state', () => {
     expect(result.period).toBe('Q2');
     expect(result.clock).toBe(24000);
   });
+
+  it('uses latest event order for mixed timestamp datasets', () => {
+    const result = deriveResumeClockState([
+      { period: 'Q3', gameClockMs: 150000, createdAt: { toMillis: () => 2000 } },
+      { period: 'Q3', gameClockMs: 160000, createdAt: null },
+      { period: 'Q4', gameClockMs: 10000, createdAt: null }
+    ]);
+
+    expect(result.restored).toBe(true);
+    expect(result.period).toBe('Q4');
+    expect(result.clock).toBe(10000);
+  });
 });


### PR DESCRIPTION
Closes #96

## What changed
- Added a new resume helper in `js/live-tracker-resume.js` to derive the latest valid `period` and `gameClockMs` from persisted `liveEvents`.
- Updated `js/live-tracker.js` resume flow to always read `liveEvents`, restore `state.period`/`state.clock` when resuming, and initialize UI period with `setPeriod(state.period)` instead of forcing `Q1`.
- Added `tests/unit/live-tracker-resume.test.js` to cover timestamp-based restore, fallback defaults, and no-timestamp progression behavior.
- Added required role-analysis run artifacts under `docs/pr-notes/runs/issue-96-fixer-20260228T160043Z/`.

## Why
The resume path previously reconstructed scores/stats but ignored persisted clock/period and then unconditionally reset period to Q1 during init. This patch restores actual in-game context for resumed sessions so subsequent live events keep correct period/clock metadata.