### PR TITLE
Reject expired parent invite codes on redemption

### DIFF
--- a/docs/pr-notes/runs/102-remediator-20260301T144220Z/architecture.md
+++ b/docs/pr-notes/runs/102-remediator-20260301T144220Z/architecture.md
@@ -1,0 +1,17 @@
+# Architecture Role Notes
+
+Current state:
+- `isAccessCodeExpired(expiresAt, nowMs)` normalizes Timestamp-like, Date, and numeric inputs.
+- Expiration comparison is inclusive (`nowMs >= expiresAtMs`).
+- Null/undefined expirations are treated as non-expiring.
+
+Risk surface:
+- Incorrect boundary comparison can allow redemption at expiration instant.
+- Falsy numeric handling (0) can bypass expiration if guarded incorrectly.
+
+Proposed state:
+- Preserve inclusive boundary behavior in helper.
+- Confirm behavior contract via explicit unit tests across all supported input types.
+
+Blast radius:
+- Low; helper-level change validation only. No API changes.

--- a/docs/pr-notes/runs/102-remediator-20260301T144220Z/code-plan.md
+++ b/docs/pr-notes/runs/102-remediator-20260301T144220Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Role Notes
+
+Implementation plan:
+1. Inspect helper and tests for unresolved thread deltas.
+2. Add minimal tests for Date and numeric exact-expiration boundaries.
+3. Run focused unit test file.
+4. Stage and commit only thread-related changes plus required run artifacts.
+
+Non-goals:
+- No refactor of helper internals.
+- No unrelated flow or UI changes.

--- a/docs/pr-notes/runs/102-remediator-20260301T144220Z/qa.md
+++ b/docs/pr-notes/runs/102-remediator-20260301T144220Z/qa.md
@@ -1,0 +1,14 @@
+# QA Role Notes
+
+Test focus:
+- Timestamp-like past/future and exact boundary.
+- Date input boundary coverage.
+- Numeric timestamp boundary coverage.
+- Zero-millis value coverage.
+
+Validation command:
+- `node ./node_modules/vitest/vitest.mjs run tests/unit/access-code-utils.test.js`
+
+Pass criteria:
+- All tests pass.
+- Boundary assertions confirm inclusive expiration semantics.

--- a/docs/pr-notes/runs/102-remediator-20260301T144220Z/requirements.md
+++ b/docs/pr-notes/runs/102-remediator-20260301T144220Z/requirements.md
@@ -1,0 +1,16 @@
+# Requirements Role Notes
+
+Objective: Resolve unresolved PR #102 review threads for access-code expiration behavior.
+
+Constraints and scope:
+- Limit edits to `js/access-code-utils.js` and `tests/unit/access-code-utils.test.js` unless required for run notes.
+- Ensure expiration at exact timestamp is treated as expired.
+- Ensure Date and numeric timestamp input formats are covered by tests, including boundary behavior.
+- Ensure falsy numeric timestamps (e.g., `0`) are handled as valid expirations.
+
+Decision:
+- Keep helper semantics fail-open only for null/invalid values.
+- Add missing boundary tests for Date and numeric timestamp input forms.
+
+Fallback note:
+- Requested orchestration skills/subagent spawning unavailable in-session; performed inline role synthesis.

--- a/docs/pr-notes/runs/102-review-3870770986-20260228T202438Z/architecture.md
+++ b/docs/pr-notes/runs/102-review-3870770986-20260228T202438Z/architecture.md
@@ -1,0 +1,19 @@
+# Architecture Role - PR #102 Review 3870770986
+
+## Current state
+`isAccessCodeExpired` normalized `expiresAt` to milliseconds but used strict `>` comparison.
+
+## Proposed state
+Use `>=` comparison to enforce expiration at the exact configured instant.
+
+## Risk surface and blast radius
+- Blast radius is low and localized to expiration boundary handling.
+- Affected flows are only those consuming `isAccessCodeExpired` (parent invite redemption checks).
+- No schema, API, or dependency changes.
+
+## Controls
+- Fail-closed at boundary time.
+- Existing normalization logic remains intact for Timestamp-like, Date, and numeric input.
+
+## Rollback
+- Revert the comparison operator and associated tests if product intent changes.

--- a/docs/pr-notes/runs/102-review-3870770986-20260228T202438Z/code-plan.md
+++ b/docs/pr-notes/runs/102-review-3870770986-20260228T202438Z/code-plan.md
@@ -1,0 +1,16 @@
+# Code Role - PR #102 Review 3870770986
+
+## Planned patch
+1. Update `js/access-code-utils.js` comparison from `>` to `>=`.
+2. Extend `tests/unit/access-code-utils.test.js` with:
+   - equality boundary case
+   - Date input case
+   - numeric timestamp case
+
+## Conflict resolution
+- All roles converged on inclusive expiration boundary semantics.
+- No role conflicts detected.
+
+## Expected outcome
+- Invite codes expire exactly at configured timestamp.
+- Broader input-shape test coverage for expiration helper.

--- a/docs/pr-notes/runs/102-review-3870770986-20260228T202438Z/qa.md
+++ b/docs/pr-notes/runs/102-review-3870770986-20260228T202438Z/qa.md
@@ -1,0 +1,17 @@
+# QA Role - PR #102 Review 3870770986
+
+## Test strategy
+Prioritize deterministic unit tests around time boundary and input type normalization.
+
+## Coverage executed
+- Boundary equality (`nowMs === expiresAt`) => expired.
+- Timestamp-like values in past/future.
+- Missing expiration => not expired.
+- Date instance support.
+- Numeric epoch millisecond support.
+
+## Regression risk
+- Low. Change is a single-operator boundary correction validated by focused tests.
+
+## Additional guardrail
+- Keep tests pinning UTC constants to avoid timezone-dependent flakiness.

--- a/docs/pr-notes/runs/102-review-3870770986-20260228T202438Z/requirements.md
+++ b/docs/pr-notes/runs/102-review-3870770986-20260228T202438Z/requirements.md
@@ -1,0 +1,18 @@
+# Requirements Role - PR #102 Review 3870770986
+
+## Objective
+Close the expiration boundary bug for parent invite redemption and ensure coverage for supported expiration value shapes.
+
+## User impact
+- Parents should be blocked from redeeming an invite at or after the configured expiration instant.
+- Behavior must stay deterministic regardless of whether expiration arrives as Firestore Timestamp-like object, Date, or numeric epoch milliseconds.
+
+## Acceptance criteria
+1. `isAccessCodeExpired` returns `true` when `nowMs === expiresAt`.
+2. Existing Timestamp-like past/future behavior remains unchanged.
+3. Unit tests include Date input, numeric timestamp input, and boundary equality case.
+4. No regression in missing-expiration behavior.
+
+## Assumptions
+- Product intent treats expiration as inclusive boundary (`>=`).
+- Utility is the single source for this comparison in invite redemption.

--- a/docs/pr-notes/runs/102-review-3870771866-20260228T203034Z/architecture.md
+++ b/docs/pr-notes/runs/102-review-3870771866-20260228T203034Z/architecture.md
@@ -1,0 +1,14 @@
+# Architecture Role Summary
+
+## Decision
+Implement a minimal helper-level fix: replace falsy guard with explicit nullish guard.
+
+## Why
+- Centralized in `isAccessCodeExpired`; no call-site sprawl.
+- Preserves existing coercion logic (`toMillis`, `Date`, numeric).
+- Avoids behavior change for non-numeric invalid values (still returns non-expired).
+
+## Controls
+- No schema changes.
+- No additional permissions or Firestore rule changes.
+- Regression constrained to helper logic and unit tests.

--- a/docs/pr-notes/runs/102-review-3870771866-20260228T203034Z/code-plan.md
+++ b/docs/pr-notes/runs/102-review-3870771866-20260228T203034Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code Role Plan and Result
+
+## Planned Patch
+1. Update helper guard from falsy to nullish check.
+2. Add regression test asserting `expiresAt: 0` is expired.
+
+## Implemented
+- `js/access-code-utils.js`: `if (expiresAt == null) return false;`
+- `tests/unit/access-code-utils.test.js`: added `treats zero-millis timestamps as valid expirations` test.
+
+## Out of Scope
+- Broader refactor of other expiration call sites.

--- a/docs/pr-notes/runs/102-review-3870771866-20260228T203034Z/qa.md
+++ b/docs/pr-notes/runs/102-review-3870771866-20260228T203034Z/qa.md
@@ -1,0 +1,15 @@
+# QA Role Summary
+
+## Primary Regression Guardrail
+Add explicit unit test for zero-millis expiration boundary.
+
+## Test Matrix
+1. Exact boundary (`nowMs === expiresAt`) -> expired.
+2. Past/future timestamp-like objects.
+3. `Date` objects.
+4. Numeric timestamps.
+5. Missing expiration (`null`) -> non-expired.
+6. Zero-millis (`0`) -> expired.
+
+## Residual Risk
+Repository has limited runnable automated test harness in current checkout; validation uses direct Node import assertion for changed helper logic and static test file inspection.

--- a/docs/pr-notes/runs/102-review-3870771866-20260228T203034Z/requirements.md
+++ b/docs/pr-notes/runs/102-review-3870771866-20260228T203034Z/requirements.md
@@ -1,0 +1,17 @@
+# Requirements Role Summary
+
+## Objective
+Close PR #102 review feedback by ensuring expiration logic handles zero-millis timestamps correctly.
+
+## Current vs Proposed
+- Current: `isAccessCodeExpired` treats falsy values as missing, so `0` bypasses expiry checks.
+- Proposed: treat only `null`/`undefined` as missing; numeric `0` is a valid timestamp and must expire.
+
+## Risk Surface / Blast Radius
+- Scope: access code expiration helper used in parent invite redemption.
+- Blast radius: low; only expiration eligibility evaluation changes for malformed/legacy records with numeric `0`.
+
+## Acceptance Criteria
+1. `expiresAt: 0` returns expired at `nowMs >= 0`.
+2. Existing behavior for `null`/`undefined` remains non-expired.
+3. Existing timestamp/date cases keep passing.

--- a/docs/pr-notes/runs/102-review-comment-2867852307-20260228T202701Z/architecture.md
+++ b/docs/pr-notes/runs/102-review-comment-2867852307-20260228T202701Z/architecture.md
@@ -1,0 +1,22 @@
+# Architecture Role Output
+
+## Current-State Read
+`validateAccessCode` in `js/db.js` performs inline expiration comparison using `Date.now() > expiresAtMs`, which permits redemption at exact boundary time.
+
+## Proposed Design
+Change boundary comparison to `Date.now() >= expiresAtMs` in `validateAccessCode` to align with expiration-at-timestamp semantics.
+
+## Files And Modules Touched
+- `js/db.js` (access code validation boundary condition)
+
+## Data/State Impacts
+- No schema or persistence changes
+- Runtime validation outcome changes only at exact boundary millisecond
+
+## Security/Permissions Impacts
+- Tightens access-code enforcement by closing a boundary acceptance gap
+- No auth/rules permission changes
+
+## Failure Modes And Mitigations
+- Risk: accidental behavior change for active codes
+- Mitigation: boundary-focused regression test execution for expiration helper and validation smoke checks

--- a/docs/pr-notes/runs/102-review-comment-2867852307-20260228T202701Z/code-plan.md
+++ b/docs/pr-notes/runs/102-review-comment-2867852307-20260228T202701Z/code-plan.md
@@ -1,0 +1,18 @@
+# Code Role Output
+
+## Patch Plan
+1. Update expiration comparison in `js/db.js` from `>` to `>=`.
+2. Run targeted tests covering expiration boundary semantics.
+3. Commit and push to PR branch.
+
+## Code Changes Applied
+- Updated `validateAccessCode` expiration condition to expire at exact timestamp boundary.
+
+## Validation Run
+- `node node_modules/vitest/vitest.mjs run tests/unit/access-code-utils.test.js`
+
+## Residual Risks
+- `validateAccessCode` path has limited direct unit coverage; helper has strong boundary checks, but end-to-end Firestore path remains mostly manual.
+
+## Commit Message Draft
+Fix access code expiration boundary in validateAccessCode

--- a/docs/pr-notes/runs/102-review-comment-2867852307-20260228T202701Z/qa.md
+++ b/docs/pr-notes/runs/102-review-comment-2867852307-20260228T202701Z/qa.md
@@ -1,0 +1,28 @@
+# QA Role Output
+
+## Risk Matrix
+- High: incorrect boundary comparison allows redemption at exact expiration timestamp
+- Medium: regression in code validity window interpretation
+- Low: unrelated auth or tracker flows
+
+## Automated Tests To Add/Update
+- Existing boundary helper tests already cover equality-expired behavior (`tests/unit/access-code-utils.test.js`).
+- No new test added in this patch because change is single-line in `db.js`; validate via targeted unit test and code inspection.
+
+## Manual Test Plan
+- Validate a code just before expiration: valid
+- Validate exactly at expiration timestamp: expired
+- Validate after expiration: expired
+
+## Negative Tests
+- Invalid code remains invalid
+- Used code remains blocked
+- Missing `expiresAt` behavior unchanged
+
+## Release Gates
+- Targeted unit tests pass
+- Diff limited to boundary condition in access-code validation
+
+## Post-Deploy Checks
+- Monitor support feedback for invite redemption near expiration boundaries
+- Spot-check one production-like code at boundary timestamp in staging/manual environment

--- a/docs/pr-notes/runs/102-review-comment-2867852307-20260228T202701Z/requirements.md
+++ b/docs/pr-notes/runs/102-review-comment-2867852307-20260228T202701Z/requirements.md
@@ -1,0 +1,27 @@
+# Requirements Role Output
+
+## Problem Statement
+Access codes must become invalid at the exact expiration timestamp to prevent boundary-time redemption.
+
+## User Segments Impacted
+- Coach/admin generating and validating invites/codes
+- Parents redeeming invite codes near expiration
+- Team admins relying on predictable expiration behavior
+
+## Acceptance Criteria
+1. Access code validation returns expired when `nowMs` equals `expiresAtMs`.
+2. Access code validation continues to return valid when `nowMs` is before `expiresAtMs`.
+3. Access code validation continues to return expired when `nowMs` is after `expiresAtMs`.
+4. Behavior remains unchanged for used and invalid codes.
+
+## Non-Goals
+- Changing code generation behavior or expiration duration logic
+- Refactoring access-code validation architecture
+
+## Edge Cases
+- Firestore `Timestamp` values converted via `toMillis()`
+- Numeric millisecond expiration values
+- Missing `expiresAt` stays non-expired by current design
+
+## Open Questions
+- None for this review-comment scope.

--- a/docs/pr-notes/runs/102-review-comment-2867853676-20260228T203233Z/architecture.md
+++ b/docs/pr-notes/runs/102-review-comment-2867853676-20260228T203233Z/architecture.md
@@ -1,0 +1,12 @@
+# Architecture Role Summary
+
+## Current state
+- Expiration decisions were partially centralized in `isAccessCodeExpired`.
+- `validateAccessCode` still had inline falsy-gated logic (`if (data.expiresAt)`) that can skip numeric `0`.
+
+## Proposed state
+- Route `validateAccessCode` through `isAccessCodeExpired` to enforce one canonical expiration policy.
+
+## Risk and blast radius
+- Low blast radius: single conditional path in invite/access-code validation.
+- Reduced regression risk by eliminating duplicate expiration logic.

--- a/docs/pr-notes/runs/102-review-comment-2867853676-20260228T203233Z/code-plan.md
+++ b/docs/pr-notes/runs/102-review-comment-2867853676-20260228T203233Z/code-plan.md
@@ -1,0 +1,9 @@
+# Code Role Summary
+
+## Patch plan
+- Replace inline expiration logic in `validateAccessCode` with `isAccessCodeExpired(data.expiresAt)`.
+- Keep error contract unchanged (`{ valid: false, message: \"Code has expired\" }`).
+
+## Conflict resolution
+- Requirements and QA both require explicit support for `expiresAt: 0`.
+- Architecture preference for single source of truth resolves potential drift between invite flows.

--- a/docs/pr-notes/runs/102-review-comment-2867853676-20260228T203233Z/qa.md
+++ b/docs/pr-notes/runs/102-review-comment-2867853676-20260228T203233Z/qa.md
@@ -1,0 +1,10 @@
+# QA Role Summary
+
+## Regression focus
+- Boundary timestamp equality (`nowMs === expiresAt`) should expire.
+- Zero timestamp (`expiresAt: 0`) should expire.
+- Missing timestamp should remain valid unless other checks fail.
+
+## Evidence strategy
+- Run `tests/unit/access-code-utils.test.js` which includes zero-millis and boundary assertions.
+- Verify no test regressions in helper behavior after caller refactor.

--- a/docs/pr-notes/runs/102-review-comment-2867853676-20260228T203233Z/requirements.md
+++ b/docs/pr-notes/runs/102-review-comment-2867853676-20260228T203233Z/requirements.md
@@ -1,0 +1,13 @@
+# Requirements Role Summary
+
+## Objective
+Ensure access-code expiration treats numeric zero (`expiresAt: 0`) as a valid timestamp and blocks redemption/validation as expired.
+
+## User impact
+- Coaches/admins: expired invites cannot be reused.
+- Parents: receive correct "Code has expired" outcome for invalid invite links.
+
+## Acceptance criteria
+- `expiresAt` null/undefined remains non-expiring.
+- Numeric timestamps, including `0`, are evaluated as real expiration values.
+- `validateAccessCode` and `redeemParentInvite` produce consistent expiration decisions.

--- a/docs/pr-notes/runs/issue-92-fixer-20260228T202032Z/architecture.md
+++ b/docs/pr-notes/runs/issue-92-fixer-20260228T202032Z/architecture.md
@@ -1,0 +1,14 @@
+# Architecture role output (manual fallback)
+
+Chosen approach:
+- Introduce `js/access-code-utils.js` with a small pure helper to evaluate `expiresAt` values from Firestore `Timestamp`, number, or `Date`.
+- Reuse helper inside `redeemParentInvite` in `js/db.js` and fail closed before mutation steps.
+
+Why this path:
+- Minimal patch footprint.
+- Improves consistency with existing expiration semantics already present in `validateAccessCode`.
+- Keeps logic testable without Firebase runtime dependencies.
+
+Control and rollback:
+- No data migration and no rules change.
+- Rollback is single-file logic revert in `db.js` (and helper if needed).

--- a/docs/pr-notes/runs/issue-92-fixer-20260228T202032Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-92-fixer-20260228T202032Z/code-plan.md
@@ -1,0 +1,7 @@
+# Code role output (manual fallback)
+
+Implementation plan:
+1. Add `isAccessCodeExpired(expiresAt, nowMs = Date.now())` in `js/access-code-utils.js`.
+2. Add `tests/unit/access-code-utils.test.js` covering expired/non-expired/no-expiration cases.
+3. Import helper in `js/db.js` and enforce in `redeemParentInvite` immediately after loading code data.
+4. Keep error text aligned with existing patterns: `Code has expired`.

--- a/docs/pr-notes/runs/issue-92-fixer-20260228T202032Z/qa.md
+++ b/docs/pr-notes/runs/issue-92-fixer-20260228T202032Z/qa.md
@@ -1,0 +1,16 @@
+# QA role output (manual fallback)
+
+Test strategy:
+- Unit-test helper behavior for expiration handling inputs:
+  - `Timestamp`-like (`toMillis`) value in past => expired.
+  - Future timestamp => not expired.
+  - Missing/invalid expiration => not expired (preserve existing optional behavior).
+
+Regression guardrails:
+- Run new targeted unit test file.
+- Run existing invite helper tests to ensure no unrelated invite path regressions.
+
+Manual sanity checks (recommended for PR):
+1. Redeem an expired parent invite in `parent-dashboard.html` and confirm expiration error.
+2. Redeem a valid invite and confirm parent linkage succeeds.
+3. Confirm used-code behavior remains unchanged.

--- a/docs/pr-notes/runs/issue-92-fixer-20260228T202032Z/requirements.md
+++ b/docs/pr-notes/runs/issue-92-fixer-20260228T202032Z/requirements.md
@@ -1,0 +1,27 @@
+# Requirements role output (manual fallback)
+
+Objective: prevent expired parent invite codes from being redeemable in Parent Dashboard.
+
+Current state:
+- Parent dashboard redemption path calls `redeemParentInvite`.
+- `redeemParentInvite` checks `code` + `used=false` but not `expiresAt`.
+
+Proposed state:
+- Expired `parent_invite` access codes are rejected before any profile or player mutation.
+- User receives a clear expiration error (`Code has expired`).
+
+Risk surface and blast radius:
+- High if unchanged: expired invitation links can still grant parent linkage and downstream data access.
+- Low for fix: targeted redemption path logic only; no schema/rules changes.
+
+Assumptions:
+- Parent invite codes use `expiresAt` when created.
+- Existing UX already surfaces thrown error message from redemption call.
+
+Recommendation:
+- Add explicit expiration guard in redemption path with shared expiration utility.
+- Add unit coverage for expiration helper used by redemption logic.
+
+Success criteria:
+- Expired parent invite redemption throws and does not proceed to profile/player writes.
+- Non-expired codes still redeem.

--- a/js/access-code-utils.js
+++ b/js/access-code-utils.js
@@ -1,0 +1,15 @@
+export function isAccessCodeExpired(expiresAt, nowMs = Date.now()) {
+    if (!expiresAt) return false;
+
+    let expiresAtMs;
+    if (typeof expiresAt?.toMillis === 'function') {
+        expiresAtMs = expiresAt.toMillis();
+    } else if (expiresAt instanceof Date) {
+        expiresAtMs = expiresAt.getTime();
+    } else {
+        expiresAtMs = Number(expiresAt);
+    }
+
+    if (!Number.isFinite(expiresAtMs)) return false;
+    return nowMs > expiresAtMs;
+}

--- a/js/access-code-utils.js
+++ b/js/access-code-utils.js
@@ -1,5 +1,5 @@
 export function isAccessCodeExpired(expiresAt, nowMs = Date.now()) {
-    if (!expiresAt) return false;
+    if (expiresAt == null) return false;
 
     let expiresAtMs;
     if (typeof expiresAt?.toMillis === 'function') {

--- a/js/access-code-utils.js
+++ b/js/access-code-utils.js
@@ -11,5 +11,5 @@ export function isAccessCodeExpired(expiresAt, nowMs = Date.now()) {
     }
 
     if (!Number.isFinite(expiresAtMs)) return false;
-    return nowMs > expiresAtMs;
+    return nowMs >= expiresAtMs;
 }

--- a/js/db.js
+++ b/js/db.js
@@ -30,6 +30,7 @@ import {
 } from './firebase.js?v=9';
 import { imageStorage, ensureImageAuth, requireImageAuth } from './firebase-images.js?v=2';
 import { buildDrillDiagramUploadPaths } from './drill-upload-paths.js?v=1';
+import { isAccessCodeExpired } from './access-code-utils.js?v=1';
 import { getApp } from './vendor/firebase-app.js';
 // import { getAI, getGenerativeModel, GoogleAIBackend } from 'https://www.gstatic.com/firebasejs/12.6.0/firebase-vertexai.js';
 export { collection, getDocs, deleteDoc, query };
@@ -971,8 +972,9 @@ export async function redeemParentInvite(userId, code) {
         playerId: codeData.playerId,
         generatedBy: codeData.generatedBy
     });
-    
+
     if (codeData.type !== 'parent_invite') throw new Error("Not a parent invite code");
+    if (isAccessCodeExpired(codeData.expiresAt)) throw new Error("Code has expired");
 
     // 2. Get Team & Player details for caching
     console.log('[redeemParentInvite] fetching team & player', {

--- a/js/db.js
+++ b/js/db.js
@@ -830,7 +830,7 @@ export async function validateAccessCode(code) {
     // Check expiration for codes that have expiresAt
     if (data.expiresAt) {
         const expiresAtMs = data.expiresAt.toMillis ? data.expiresAt.toMillis() : data.expiresAt;
-        if (Date.now() > expiresAtMs) {
+        if (Date.now() >= expiresAtMs) {
             return { valid: false, message: "Code has expired" };
         }
     }

--- a/js/db.js
+++ b/js/db.js
@@ -827,12 +827,8 @@ export async function validateAccessCode(code) {
         return { valid: false, message: "Code already used" };
     }
 
-    // Check expiration for codes that have expiresAt
-    if (data.expiresAt) {
-        const expiresAtMs = data.expiresAt.toMillis ? data.expiresAt.toMillis() : data.expiresAt;
-        if (Date.now() >= expiresAtMs) {
-            return { valid: false, message: "Code has expired" };
-        }
+    if (isAccessCodeExpired(data.expiresAt)) {
+        return { valid: false, message: "Code has expired" };
     }
 
     // Code exists, not used, and not expired

--- a/tests/unit/access-code-utils.test.js
+++ b/tests/unit/access-code-utils.test.js
@@ -2,6 +2,12 @@ import { describe, it, expect } from 'vitest';
 import { isAccessCodeExpired } from '../../js/access-code-utils.js';
 
 describe('access code expiration helper', () => {
+    it('returns true when nowMs exactly equals expiresAt', () => {
+        const nowMs = Date.UTC(2026, 1, 28, 20, 20, 0);
+        const boundary = { toMillis: () => nowMs };
+        expect(isAccessCodeExpired(boundary, nowMs)).toBe(true);
+    });
+
     it('returns true when expiresAt is in the past (Timestamp-like)', () => {
         const nowMs = Date.UTC(2026, 1, 28, 20, 20, 0);
         const expired = { toMillis: () => nowMs - 1000 };
@@ -16,5 +22,17 @@ describe('access code expiration helper', () => {
 
     it('returns false when expiresAt is missing', () => {
         expect(isAccessCodeExpired(null, Date.UTC(2026, 1, 28, 20, 20, 0))).toBe(false);
+    });
+
+    it('accepts Date instances', () => {
+        const nowMs = Date.UTC(2026, 1, 28, 20, 20, 0);
+        const expiresAt = new Date(nowMs + 5000);
+        expect(isAccessCodeExpired(expiresAt, nowMs)).toBe(false);
+    });
+
+    it('accepts numeric timestamps', () => {
+        const nowMs = Date.UTC(2026, 1, 28, 20, 20, 0);
+        const expiresAtMs = nowMs - 5000;
+        expect(isAccessCodeExpired(expiresAtMs, nowMs)).toBe(true);
     });
 });

--- a/tests/unit/access-code-utils.test.js
+++ b/tests/unit/access-code-utils.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { isAccessCodeExpired } from '../../js/access-code-utils.js';
+
+describe('access code expiration helper', () => {
+    it('returns true when expiresAt is in the past (Timestamp-like)', () => {
+        const nowMs = Date.UTC(2026, 1, 28, 20, 20, 0);
+        const expired = { toMillis: () => nowMs - 1000 };
+        expect(isAccessCodeExpired(expired, nowMs)).toBe(true);
+    });
+
+    it('returns false when expiresAt is in the future (Timestamp-like)', () => {
+        const nowMs = Date.UTC(2026, 1, 28, 20, 20, 0);
+        const active = { toMillis: () => nowMs + 1000 };
+        expect(isAccessCodeExpired(active, nowMs)).toBe(false);
+    });
+
+    it('returns false when expiresAt is missing', () => {
+        expect(isAccessCodeExpired(null, Date.UTC(2026, 1, 28, 20, 20, 0))).toBe(false);
+    });
+});

--- a/tests/unit/access-code-utils.test.js
+++ b/tests/unit/access-code-utils.test.js
@@ -35,4 +35,9 @@ describe('access code expiration helper', () => {
         const expiresAtMs = nowMs - 5000;
         expect(isAccessCodeExpired(expiresAtMs, nowMs)).toBe(true);
     });
+
+    it('treats zero-millis timestamps as valid expirations', () => {
+        expect(isAccessCodeExpired(0, 0)).toBe(true);
+        expect(isAccessCodeExpired(0, 1)).toBe(true);
+    });
 });

--- a/tests/unit/access-code-utils.test.js
+++ b/tests/unit/access-code-utils.test.js
@@ -30,10 +30,21 @@ describe('access code expiration helper', () => {
         expect(isAccessCodeExpired(expiresAt, nowMs)).toBe(false);
     });
 
+    it('treats Date expiration exactly at nowMs as expired', () => {
+        const nowMs = Date.UTC(2026, 1, 28, 20, 20, 0);
+        const expiresAt = new Date(nowMs);
+        expect(isAccessCodeExpired(expiresAt, nowMs)).toBe(true);
+    });
+
     it('accepts numeric timestamps', () => {
         const nowMs = Date.UTC(2026, 1, 28, 20, 20, 0);
         const expiresAtMs = nowMs - 5000;
         expect(isAccessCodeExpired(expiresAtMs, nowMs)).toBe(true);
+    });
+
+    it('treats numeric expiration exactly at nowMs as expired', () => {
+        const nowMs = Date.UTC(2026, 1, 28, 20, 20, 0);
+        expect(isAccessCodeExpired(nowMs, nowMs)).toBe(true);
     });
 
     it('treats zero-millis timestamps as valid expirations', () => {


### PR DESCRIPTION
Closes #92

## What changed
- Added a new shared helper at `js/access-code-utils.js` to consistently evaluate whether an access code is expired from `expiresAt` values (Firestore Timestamp-like, Date, or numeric millis).
- Updated `redeemParentInvite` in `js/db.js` to reject expired parent invite codes with `Code has expired` before any user/player mutation steps.
- Added unit coverage in `tests/unit/access-code-utils.test.js` for expired, active, and missing-expiration cases.
- Added run-scoped role artifacts under `docs/pr-notes/runs/issue-92-fixer-20260228T202032Z/` (requirements, architecture, QA, code plan).

## Why
The parent dashboard redemption path accepted expired parent invite codes because it only filtered by `code` and `used=false`. This patch enforces the expected invite lifecycle so expired codes cannot be redeemed.

## Validation
- Fail-first: `node /home/paul-bot1/.openclaw/workspace/allplays/node_modules/vitest/vitest.mjs run tests/unit/access-code-utils.test.js` (failed before fix)
- Pass: `node /home/paul-bot1/.openclaw/workspace/allplays/node_modules/vitest/vitest.mjs run tests/unit/access-code-utils.test.js tests/unit/invite-redirect.test.js`