### PR TITLE
Fail closed when parent invite signup linkage fails

### DIFF
--- a/docs/pr-notes/runs/109-review-3871384239-20260301T053006Z/architecture.md
+++ b/docs/pr-notes/runs/109-review-3871384239-20260301T053006Z/architecture.md
@@ -1,0 +1,16 @@
+# Architecture Role Notes
+
+## Current State
+`signup()` creates Firebase Auth user first. Parent-invite linkage failures currently rethrow but leave Auth account alive.
+
+## Proposed State
+Mirror Google new-user cleanup semantics in email/password parent-invite branch:
+- best-effort `userCredential.user.delete()`
+- `signOut(auth)` in both success and delete-failure paths
+- rethrow original parent-invite error
+
+## Control Equivalence
+Improves control parity with existing Google flow and reduces identity-store/Firestore divergence.
+
+## Rollback
+Single-hunk revert in `js/auth.js` parent-invite catch block.

--- a/docs/pr-notes/runs/109-review-3871384239-20260301T053006Z/code-plan.md
+++ b/docs/pr-notes/runs/109-review-3871384239-20260301T053006Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code Role Plan
+
+## Minimal Patch
+1. Add Auth cleanup in `signup()` parent-invite catch:
+   - delete created auth user
+   - sign out auth session
+   - log cleanup failure and still sign out
+   - rethrow original error
+2. Update `tests/unit/auth-signup-parent-invite.test.js` to assert cleanup statements exist.
+
+## Why This Path
+Smallest safe delta that addresses review blocker and aligns with existing Google cleanup pattern.

--- a/docs/pr-notes/runs/109-review-3871384239-20260301T053006Z/qa.md
+++ b/docs/pr-notes/runs/109-review-3871384239-20260301T053006Z/qa.md
@@ -1,0 +1,12 @@
+# QA Role Notes
+
+## Regression Focus
+- Parent-invite signup error path should include cleanup before throw.
+- Non-parent signup and successful parent-invite paths unaffected.
+
+## Checks
+- Structural unit assertion for cleanup statements in parent-invite catch block.
+- Existing parent-invite fail-closed assertion retained.
+
+## Residual Risk
+- Runtime delete failure handling is best-effort and depends on Firebase client state; sign-out fallback mitigates lingering session risk.

--- a/docs/pr-notes/runs/109-review-3871384239-20260301T053006Z/requirements.md
+++ b/docs/pr-notes/runs/109-review-3871384239-20260301T053006Z/requirements.md
@@ -1,0 +1,17 @@
+# Requirements Role Notes
+
+## Objective
+Prevent orphaned Firebase Auth accounts when parent-invite signup fails after email/password account creation.
+
+## User/UX Constraint
+Parent signup must fail closed: no success redirect and no partially created identity.
+
+## Acceptance Criteria
+- If `redeemParentInvite` or parent-invite profile write fails, the newly created Auth user is deleted.
+- User session is signed out after cleanup attempt.
+- Original error is rethrown so caller sees failure.
+- Existing non-parent signup behavior remains unchanged.
+
+## Risk/Blast Radius
+- Touches only parent-invite branch in `signup` flow.
+- No data model or routing changes.

--- a/docs/pr-notes/runs/109-review-comment-2868454044-20260301T053729Z/architecture.md
+++ b/docs/pr-notes/runs/109-review-comment-2868454044-20260301T053729Z/architecture.md
@@ -1,0 +1,18 @@
+# Architecture Role Summary
+
+## Decision
+Keep fail-closed cleanup local to `signup` parent-invite catch block with two isolated cleanup attempts.
+
+## Why
+- Minimal blast radius and no cross-flow behavior drift.
+- Preserves control equivalence: account deletion intent plus explicit auth session termination.
+- Prevents cleanup exceptions from shadowing the true business failure.
+
+## Controls
+- Auditability: explicit logging for delete and sign-out cleanup failures.
+- Access/session control: explicit `signOut(auth)` attempted regardless of delete result.
+- Segregation: no changes to Firestore rule paths or unrelated auth flows.
+
+## Assumptions
+- `createUserWithEmailAndPassword` completes before parent invite finalization.
+- Caller already handles thrown errors and user-facing messaging.

--- a/docs/pr-notes/runs/109-review-comment-2868454044-20260301T053729Z/code-plan.md
+++ b/docs/pr-notes/runs/109-review-comment-2868454044-20260301T053729Z/code-plan.md
@@ -1,0 +1,14 @@
+# Code Role Plan
+
+## Patch Scope
+- File: `js/auth.js`
+  - Refactor parent-invite `signup` catch cleanup to:
+    - isolate delete attempt and logging
+    - isolate sign-out attempt and logging
+    - rethrow original caught error
+- File: `tests/unit/auth-signup-parent-invite.test.js`
+  - Add assertions for independent sign-out catch and non-coupled cleanup shape.
+
+## Out of Scope
+- No functional changes to Google signup flow.
+- No Firestore rules/data-model changes.

--- a/docs/pr-notes/runs/109-review-comment-2868454044-20260301T053729Z/qa.md
+++ b/docs/pr-notes/runs/109-review-comment-2868454044-20260301T053729Z/qa.md
@@ -1,0 +1,12 @@
+# QA Role Summary
+
+## Regression Risks Targeted
+- user remains authenticated after parent-invite signup failure
+- cleanup exception masks original parent-invite failure
+
+## Validation Strategy
+- Run focused unit test covering parent-invite signup cleanup structure.
+- Confirm assertions include: delete attempt, independent sign-out attempt, and original error rethrow contract.
+
+## Expected Outcome
+- Targeted test passes with explicit guardrails against coupled cleanup paths.

--- a/docs/pr-notes/runs/109-review-comment-2868454044-20260301T053729Z/requirements.md
+++ b/docs/pr-notes/runs/109-review-comment-2868454044-20260301T053729Z/requirements.md
@@ -1,0 +1,23 @@
+# Requirements Role Summary
+
+## Objective
+Ensure email/password signup fails closed for parent-invite finalization failures so users are not left authenticated after reported failure.
+
+## Current State
+`signup` creates Firebase Auth user first, then performs parent invite redeem/profile writes. Failure handling attempted cleanup, but sign-out was coupled to delete flow and could mask the original failure path.
+
+## Proposed State
+On parent-invite finalization error:
+- attempt `userCredential.user.delete()` best-effort
+- independently attempt `signOut(auth)` regardless of delete outcome
+- always rethrow the original parent-invite error to preserve caller semantics
+
+## Risk Surface and Blast Radius
+- Scope limited to parent-invite branch in `signup`.
+- No change to coach/admin signup branch.
+- Reduced auth/session residue risk and retry-blocking (`email-already-in-use`) risk after failed parent linking.
+
+## Acceptance Criteria
+- Parent-invite finalization errors still throw to caller.
+- Cleanup path contains both delete and sign-out attempts.
+- Sign-out failure does not replace the original parent-invite error.

--- a/docs/pr-notes/runs/issue-90-fixer-20260301T052502Z/architecture.md
+++ b/docs/pr-notes/runs/issue-90-fixer-20260301T052502Z/architecture.md
@@ -1,0 +1,15 @@
+# Architecture Role (manual fallback)
+
+## Current state
+`signup()` creates auth user, attempts `redeemParentInvite`, catches parent-link failures, logs, and returns success object. Caller unconditionally redirects to `verify-pending.html` on resolved promise.
+
+## Proposed state
+Maintain existing flow but change parent-invite catch in `signup()` to fail closed by rethrowing, preserving existing error UI path in `login.html`.
+
+## Controls / equivalence
+- Stronger control: success signal now means parent invite finalization succeeded.
+- Reduced blast radius: no redirect into broken verification flow when invite linkage fails.
+
+## Tradeoffs
+- Parent sees immediate signup error instead of silent partial account creation flow.
+- Potentially exposes backend failure text; acceptable for now because existing UI already displays error.message.

--- a/docs/pr-notes/runs/issue-90-fixer-20260301T052502Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-90-fixer-20260301T052502Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code Role Plan (manual fallback)
+
+## Plan
+1. Add failing regression test for `signup()` parent invite catch block in `js/auth.js`.
+2. Patch `js/auth.js` parent invite catch to rethrow after logging.
+3. Run targeted vitest for new test.
+4. Stage docs + test + code, commit with `#90` reference.
+
+## Conflict resolution
+- Requirements and QA both require fail-closed behavior and visible error.
+- Architecture recommends minimal scoped patch in `signup()` only.
+- Final synthesis: implement only email/password parent invite fail-closed change plus regression test, no broader auth refactor.

--- a/docs/pr-notes/runs/issue-90-fixer-20260301T052502Z/qa.md
+++ b/docs/pr-notes/runs/issue-90-fixer-20260301T052502Z/qa.md
@@ -1,0 +1,16 @@
+# QA Role (manual fallback)
+
+## Regression target
+`js/auth.js` parent invite signup catch block must not suppress invite redemption errors.
+
+## Test strategy
+- Add unit regression test that inspects `signup()` parent invite catch block in source and enforces throw behavior.
+- Run targeted vitest command for new test file.
+
+## Manual checks
+1. Open `login.html?code=<parent_code>`.
+2. Force parent invite redemption failure (invalid/redeemed/deleted target).
+3. Confirm error shown on login page and no redirect to `verify-pending.html`.
+
+## Residual risk
+- Google new-user parent invite path has similar suppression pattern; out of scope unless explicitly requested.

--- a/docs/pr-notes/runs/issue-90-fixer-20260301T052502Z/requirements.md
+++ b/docs/pr-notes/runs/issue-90-fixer-20260301T052502Z/requirements.md
@@ -1,0 +1,17 @@
+# Requirements Role (manual fallback)
+
+## Objective
+Prevent false-success parent invite signup outcomes. If parent invite finalization fails, the signup must fail visibly and keep the user on login with an actionable error.
+
+## User impact
+- Parent should never be redirected to `verify-pending.html` unless invite linking completed.
+- Error must be surfaced from `signup()` so existing `login.html` catch block displays it.
+
+## Acceptance criteria
+1. `signup(email, password, activationCode)` throws on parent invite finalization failure.
+2. `login.html` signup path does not redirect when `signup` throws.
+3. Regression test covers fail-closed behavior.
+
+## Risk / blast radius
+- Limited to parent invite signup path in `js/auth.js`.
+- No behavior change for coach/admin activation code flow.

--- a/tests/unit/auth-signup-parent-invite.test.js
+++ b/tests/unit/auth-signup-parent-invite.test.js
@@ -1,4 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 const firebaseMocks = vi.hoisted(() => {
     const auth = { currentUser: null };
@@ -36,7 +38,7 @@ vi.mock('../../js/db.js?v=14', () => dbMocks);
 
 import { signup } from '../../js/auth.js';
 
-describe('auth signup parent invite handling', () => {
+describe('auth signup parent invite failure handling', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         firebaseMocks.auth.currentUser = null;
@@ -48,6 +50,20 @@ describe('auth signup parent invite handling', () => {
         dbMocks.redeemParentInvite.mockResolvedValue({ success: true });
         dbMocks.updateUserProfile.mockResolvedValue(undefined);
         firebaseMocks.sendEmailVerification.mockResolvedValue(undefined);
+    });
+
+    it('fails closed by rethrowing parent invite finalization errors', () => {
+        const authSource = readFileSync(resolve(process.cwd(), 'js/auth.js'), 'utf8');
+        const signupSection = authSource.split('export async function signup')[1]?.split('export async function loginWithGoogle')[0];
+
+        expect(signupSection).toBeTruthy();
+
+        const parentInviteCatchBlock = signupSection.match(/if \(validation\.type === 'parent_invite'\)[\s\S]*?catch \(e\) \{([\s\S]*?)\n\s*\}/);
+        expect(parentInviteCatchBlock).toBeTruthy();
+
+        const catchBody = parentInviteCatchBlock[1];
+        expect(catchBody).toMatch(/throw\s+(e|new Error\()/);
+        expect(catchBody).not.toContain("Don't fail the whole signup");
     });
 
     it('rejects signup when parent invite profile finalization fails', async () => {

--- a/tests/unit/auth-signup-parent-invite.test.js
+++ b/tests/unit/auth-signup-parent-invite.test.js
@@ -52,18 +52,20 @@ describe('auth signup parent invite failure handling', () => {
         firebaseMocks.sendEmailVerification.mockResolvedValue(undefined);
     });
 
-    it('fails closed by rethrowing parent invite finalization errors', () => {
+    it('fails closed by cleaning up auth user and rethrowing parent invite finalization errors', () => {
         const authSource = readFileSync(resolve(process.cwd(), 'js/auth.js'), 'utf8');
         const signupSection = authSource.split('export async function signup')[1]?.split('export async function loginWithGoogle')[0];
 
         expect(signupSection).toBeTruthy();
 
-        const parentInviteCatchBlock = signupSection.match(/if \(validation\.type === 'parent_invite'\)[\s\S]*?catch \(e\) \{([\s\S]*?)\n\s*\}/);
-        expect(parentInviteCatchBlock).toBeTruthy();
+        const parentInviteBranch = signupSection.match(/if \(validation\.type === 'parent_invite'\) \{([\s\S]*?)\n\s*\} else \{/);
+        expect(parentInviteBranch).toBeTruthy();
 
-        const catchBody = parentInviteCatchBlock[1];
-        expect(catchBody).toMatch(/throw\s+(e|new Error\()/);
-        expect(catchBody).not.toContain("Don't fail the whole signup");
+        const branchBody = parentInviteBranch[1];
+        expect(branchBody).toContain('userCredential.user.delete();');
+        expect(branchBody).toContain('await signOut(auth);');
+        expect(branchBody).toMatch(/catch \(e\) \{[\s\S]*throw\s+(e|new Error\()/);
+        expect(branchBody).not.toContain("Don't fail the whole signup");
     });
 
     it('rejects signup when parent invite profile finalization fails', async () => {

--- a/tests/unit/auth-signup-parent-invite.test.js
+++ b/tests/unit/auth-signup-parent-invite.test.js
@@ -64,6 +64,10 @@ describe('auth signup parent invite failure handling', () => {
         const branchBody = parentInviteBranch[1];
         expect(branchBody).toContain('userCredential.user.delete();');
         expect(branchBody).toContain('await signOut(auth);');
+        expect(branchBody).toContain('Error cleaning up failed parent invite signup');
+        expect(branchBody).toContain('Error signing out after failed parent invite signup');
+        expect(branchBody).toMatch(/await userCredential\.user\.delete\(\);[\s\S]*catch \(deleteError\)/);
+        expect(branchBody).toMatch(/try \{[\s\S]*await signOut\(auth\);[\s\S]*catch \(signOutError\)/);
         expect(branchBody).toMatch(/catch \(e\) \{[\s\S]*throw\s+(e|new Error\()/);
         expect(branchBody).not.toContain("Don't fail the whole signup");
     });


### PR DESCRIPTION
Closes #90

## What changed
- Updated `js/auth.js` so parent-invite signup no longer suppresses invite-linking failures.
- In the parent-invite branch of `signup(...)`, errors from invite redemption/finalization are now rethrown after logging.
- Added regression coverage in `tests/unit/auth-signup-parent-invite.test.js` to enforce fail-closed behavior in the signup parent-invite catch block.
- Added required run-role artifacts under `docs/pr-notes/runs/issue-90-fixer-20260301T052502Z/`.

## Why
Previously, parent-invite failures were caught and ignored, so signup still resolved and `login.html` redirected users to `verify-pending.html` even when invite linking failed. Rethrowing makes signup fail visibly, preventing false-success redirects for broken parent-invite outcomes.

## Validation
- `node /home/paul-bot1/.openclaw/workspace/allplays/node_modules/vitest/vitest.mjs run tests/unit/auth-signup-parent-invite.test.js tests/unit/invite-redirect.test.js`