### PR TITLE
Rebase replay clock when changing playback speed

### DIFF
--- a/docs/pr-notes/runs/issue-106-fixer-20260301T082635Z/architecture.md
+++ b/docs/pr-notes/runs/issue-106-fixer-20260301T082635Z/architecture.md
@@ -1,0 +1,19 @@
+# Architecture Role Output (manual fallback)
+
+## Root cause
+- `elapsed = (Date.now() - replayStartTime) * replaySpeed` applies *new* speed retroactively to all prior wall-clock replay duration.
+- Speed button handler mutates `replaySpeed` but does not rebase `replayStartTime` while playing.
+
+## Proposed design
+- Introduce small replay timing helper utilities:
+  - elapsed calculation from `(now - start) * speed`
+  - start-time rebasing from current replay clock and new speed: `start = now - (clock / speed)`
+- On speed click while replay is playing:
+  - capture current elapsed under old speed
+  - set new speed
+  - rebase start time to preserve continuity
+
+## Risk/blast radius
+- Localized to replay timing in `live-game` page.
+- No Firestore, auth, or rules impact.
+- Low regression risk if helper functions are unit tested.

--- a/docs/pr-notes/runs/issue-106-fixer-20260301T082635Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-106-fixer-20260301T082635Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Role Output (manual fallback)
+
+## Planned edits
+1. Add `js/live-game-replay.js` with pure timing helpers for elapsed and start-time rebasing.
+2. Update `js/live-game.js`:
+   - use helper for elapsed in replay tick
+   - on speed change while playing, preserve current replay clock via start-time rebasing
+3. Add unit test `tests/unit/live-game-replay-speed.test.js` covering continuity across speed change.
+
+## Validation
+- `node ./node_modules/vitest/vitest.mjs run tests/unit/live-game-replay-speed.test.js`

--- a/docs/pr-notes/runs/issue-106-fixer-20260301T082635Z/qa.md
+++ b/docs/pr-notes/runs/issue-106-fixer-20260301T082635Z/qa.md
@@ -1,0 +1,16 @@
+# QA Role Output (manual fallback)
+
+## Regression target
+- Replay speed change continuity under active playback.
+
+## Test strategy
+- Unit-test timing helper behavior:
+  - pre-fix baseline demonstrates retroactive jump with unchanged start time.
+  - post-fix path rebases start time at speed change and keeps elapsed continuous.
+  - verify continued progression at new rate after change.
+- Run targeted tests for replay helper file.
+
+## Manual smoke (recommended)
+1. Start completed-game replay at 1x.
+2. After a few seconds, switch to 10x/20x.
+3. Confirm replay clock does not jump immediately and feed continues from current moment.

--- a/docs/pr-notes/runs/issue-106-fixer-20260301T082635Z/requirements.md
+++ b/docs/pr-notes/runs/issue-106-fixer-20260301T082635Z/requirements.md
@@ -1,0 +1,21 @@
+# Requirements Role Output (manual fallback)
+
+## Context
+- Requested skill `allplays-orchestrator-playbook` and role skills were not available in-session.
+- Produced equivalent role analysis manually before implementation.
+
+## User-visible problem
+- While replay is actively playing, changing speed (1x -> 10x/20x) jumps timeline forward and skips events.
+
+## Functional requirement
+- Speed changes during active replay must only affect future progression rate from the current replay position.
+- No immediate jump in replay clock/progress/feed when speed is changed mid-play.
+
+## Acceptance criteria
+- Replay clock remains continuous across speed change (no discontinuous jump at click time).
+- Event consumption remains ordered and no immediate bulk skip caused by speed toggle alone.
+- Existing pause/resume and scrub behavior remains unchanged.
+
+## Constraints
+- Minimal targeted patch in `live-game` replay flow only.
+- Add regression tests covering speed-change continuity.

--- a/js/live-game-replay.js
+++ b/js/live-game-replay.js
@@ -1,0 +1,13 @@
+export function getReplayElapsedMs(nowMs, replayStartTimeMs, replaySpeed) {
+  if (!Number.isFinite(nowMs) || !Number.isFinite(replayStartTimeMs) || !Number.isFinite(replaySpeed) || replaySpeed <= 0) {
+    return 0;
+  }
+  return Math.max(0, (nowMs - replayStartTimeMs) * replaySpeed);
+}
+
+export function rebaseReplayStartTimeMs(nowMs, currentElapsedMs, nextReplaySpeed) {
+  if (!Number.isFinite(nowMs) || !Number.isFinite(currentElapsedMs) || !Number.isFinite(nextReplaySpeed) || nextReplaySpeed <= 0) {
+    return nowMs;
+  }
+  return nowMs - (Math.max(0, currentElapsedMs) / nextReplaySpeed);
+}

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -17,6 +17,7 @@ import {
 import { getUrlParams, escapeHtml, renderHeader, renderFooter, formatShortDate, formatTime, shareOrCopy } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=9';
 import { isViewerChatEnabled } from './live-game-chat.js?v=1';
+import { getReplayElapsedMs, rebaseReplayStartTimeMs } from './live-game-replay.js?v=1';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
 
@@ -958,7 +959,7 @@ function playReplay() {
 
 function replayTick() {
   if (!state.replayPlaying) return;
-  const elapsed = (Date.now() - state.replayStartTime) * state.replaySpeed;
+  const elapsed = getReplayElapsedMs(Date.now(), state.replayStartTime, state.replaySpeed);
 
   while (
     state.replayIndex < state.replayEvents.length &&
@@ -1093,6 +1094,12 @@ function initReplayControls() {
   document.querySelectorAll('[data-speed]').forEach(btn => {
     btn.addEventListener('click', () => {
       const speed = Number(btn.dataset.speed);
+      if (!Number.isFinite(speed) || speed <= 0) return;
+      if (state.replayPlaying && Number.isFinite(state.replayStartTime)) {
+        const nowMs = Date.now();
+        const elapsedMs = getReplayElapsedMs(nowMs, state.replayStartTime, state.replaySpeed);
+        state.replayStartTime = rebaseReplayStartTimeMs(nowMs, elapsedMs, speed);
+      }
       state.replaySpeed = speed;
       document.querySelectorAll('.speed-btn').forEach(b => b.classList.remove('bg-teal', 'text-ink'));
       btn.classList.add('bg-teal', 'text-ink');

--- a/tests/unit/live-game-replay-speed.test.js
+++ b/tests/unit/live-game-replay-speed.test.js
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { getReplayElapsedMs, rebaseReplayStartTimeMs } from '../../js/live-game-replay.js';
+
+describe('live game replay speed timing', () => {
+  it('keeps replay elapsed continuous when speed changes during playback', () => {
+    const startTimeMs = 1_000;
+    const speedBefore = 1;
+    const speedAfter = 20;
+    const speedChangeAtMs = 6_000;
+    const nextFrameMs = 6_016;
+
+    const elapsedBeforeChange = getReplayElapsedMs(speedChangeAtMs, startTimeMs, speedBefore);
+    expect(elapsedBeforeChange).toBe(5_000);
+
+    // Old behavior: start time not rebased, so changing speed retroactively multiplies past playback.
+    const jumpedElapsed = getReplayElapsedMs(nextFrameMs, startTimeMs, speedAfter);
+    expect(jumpedElapsed).toBe(100_320);
+
+    const rebasedStartTimeMs = rebaseReplayStartTimeMs(speedChangeAtMs, elapsedBeforeChange, speedAfter);
+    const elapsedAfterChange = getReplayElapsedMs(nextFrameMs, rebasedStartTimeMs, speedAfter);
+
+    expect(elapsedAfterChange).toBe(5_320);
+  });
+
+  it('advances future playback at the new speed after rebasing', () => {
+    const rebasedStartTimeMs = rebaseReplayStartTimeMs(20_000, 8_000, 10);
+
+    expect(getReplayElapsedMs(20_100, rebasedStartTimeMs, 10)).toBe(9_000);
+    expect(getReplayElapsedMs(20_250, rebasedStartTimeMs, 10)).toBe(10_500);
+  });
+});


### PR DESCRIPTION
Closes #106

## What changed
- Added replay timing helpers in `js/live-game-replay.js` to centralize elapsed-time math and replay start-time rebasing.
- Updated `js/live-game.js` replay tick to use helper elapsed calculation.
- Updated replay speed button handling so when speed changes during active playback, the current replay elapsed time is preserved by rebasing `replayStartTime` before applying the new speed.
- Added run artifacts under `docs/pr-notes/runs/issue-106-fixer-20260301T082635Z/` for requirements, architecture, QA, and code plan synthesis.
- Added regression tests in `tests/unit/live-game-replay-speed.test.js` covering the pre-fix jump behavior and post-fix continuity.

## Why
The replay jump happened because the new speed multiplier was being applied retroactively to all elapsed wall-clock time since replay start. Rebasing start time at the moment of speed change keeps timeline position continuous and only changes future playback rate.

## Validation
- `node /home/paul-bot1/.openclaw/workspace/allplays/node_modules/vitest/vitest.mjs run tests/unit/live-game-replay-speed.test.js tests/unit/live-game-chat.test.js`