### PR TITLE
Scope parent dashboard RSVP to selected child

### DIFF
--- a/docs/pr-notes/runs/issue-110-fixer-20260301T142502Z/architecture.md
+++ b/docs/pr-notes/runs/issue-110-fixer-20260301T142502Z/architecture.md
@@ -1,0 +1,19 @@
+# Architecture Role (manual fallback)
+
+Required allplays orchestration skills/subagent tooling were requested but are unavailable in this runtime, so this is a manual role synthesis artifact.
+
+## Current state
+`submitGameRsvpFromButton` forwards `childId/childIds` from button dataset.
+Resolver trusts explicit `childIds` when provided.
+
+## Proposed state
+Pass currently selected player-filter value as explicit `selectedChildId` context and prioritize it during RSVP playerId resolution.
+
+## Why minimal and safe
+- Touches only parent-dashboard RSVP context wiring + resolver precedence.
+- Keeps existing allowed-scope sanitization against teamId+gameId.
+- No Firestore schema or backend contract changes.
+
+## Controls and blast radius
+- Limits writes to least-privileged child scope when filter is present.
+- Reduces over-scoped write blast radius for multi-child parents.

--- a/docs/pr-notes/runs/issue-110-fixer-20260301T142502Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-110-fixer-20260301T142502Z/code-plan.md
@@ -1,0 +1,10 @@
+# Code Role (manual fallback)
+
+Required allplays orchestration skills/subagent tooling were requested but are unavailable in this runtime, so this is a manual role synthesis artifact.
+
+## Plan
+1. Add failing unit test asserting selected filter child (`selectedChildId`) overrides broad button `childIds`.
+2. Update `resolveRsvpPlayerIdsForSubmission` to prioritize `selectedChildId` before other explicit child contexts.
+3. Update `submitGameRsvpFromButton` to include selected filter child in child context.
+4. Run targeted RSVP unit tests.
+5. Commit test + fix referencing issue #110.

--- a/docs/pr-notes/runs/issue-110-fixer-20260301T142502Z/qa.md
+++ b/docs/pr-notes/runs/issue-110-fixer-20260301T142502Z/qa.md
@@ -1,0 +1,19 @@
+# QA Role (manual fallback)
+
+Required allplays orchestration skills/subagent tooling were requested but are unavailable in this runtime, so this is a manual role synthesis artifact.
+
+## Test strategy
+- Add failing-first unit test in `tests/unit/parent-dashboard-rsvp.test.js`:
+  - Given broad `childIds` payload containing multiple children
+  - And selected child filter context
+  - Expect output to include only selected child.
+
+## Regression checks
+- Existing RSVP scope tests still pass:
+  - explicit childId
+  - explicit childIds sanitization
+  - reject out-of-scope childId
+  - game-scope fallback
+
+## Manual sanity checks (optional)
+- Parent dashboard list and calendar/day modal RSVP buttons under selected player filter.

--- a/docs/pr-notes/runs/issue-110-fixer-20260301T142502Z/requirements.md
+++ b/docs/pr-notes/runs/issue-110-fixer-20260301T142502Z/requirements.md
@@ -1,0 +1,18 @@
+# Requirements Role (manual fallback)
+
+Required allplays orchestration skills/subagent tooling were requested but are unavailable in this runtime, so this is a manual role synthesis artifact.
+
+## Objective
+Ensure parent-dashboard RSVP writes are scoped to the selected child/event context for multi-child families.
+
+## User-facing requirement
+When a parent has selected one child in the filter and submits RSVP from schedule/day modal, only that child's playerId must be persisted.
+
+## Acceptance criteria
+- RSVP payload never includes sibling playerIds when child filter context exists.
+- Existing behavior for no selected-child context remains unchanged.
+- Regression test covers selected-child precedence over broad childIds payload.
+
+## Risk surface
+- Parent-dashboard availability submission path only.
+- Potential blast radius is RSVP payload composition for games/practices.

--- a/js/parent-dashboard-rsvp.js
+++ b/js/parent-dashboard-rsvp.js
@@ -22,6 +22,9 @@ export function resolveRsvpPlayerIdsForSubmission(allScheduleEvents, teamId, gam
     const allowedSet = new Set(allowedPlayerIds);
     const sanitizeToAllowedScope = (ids) => ids.filter((id) => allowedSet.has(id));
 
+    const selectedChildId = String(childContext?.selectedChildId || '').trim();
+    if (selectedChildId) return sanitizeToAllowedScope([selectedChildId]);
+
     const explicitChildId = String(childContext?.childId || '').trim();
     if (explicitChildId) return sanitizeToAllowedScope([explicitChildId]);
 

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -190,7 +190,7 @@
         import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence } from './js/utils.js?v=8';
         import { requireAuth, checkAuth } from './js/auth.js?v=9';
         import { resolvePracticePacketSessionIdForEvent as resolvePracticePacketSessionIdForEventBase, resolvePracticePacketContextForEvent as resolvePracticePacketContextForEventBase } from './js/parent-dashboard-packets.js?v=2';
-        import { resolveRsvpPlayerIdsForSubmission } from './js/parent-dashboard-rsvp.js?v=2';
+        import { resolveRsvpPlayerIdsForSubmission } from './js/parent-dashboard-rsvp.js?v=3';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -255,7 +255,9 @@
             const teamId = btn?.dataset?.teamId || '';
             const gameId = btn?.dataset?.gameId || '';
             if (!teamId || !gameId) return;
+            const selectedChildId = document.getElementById('player-filter')?.value || '';
             window.submitGameRsvp(teamId, gameId, response, {
+                selectedChildId,
                 childId: btn?.dataset?.childId || '',
                 childIds: btn?.dataset?.childIds || ''
             });

--- a/tests/unit/parent-dashboard-rsvp.test.js
+++ b/tests/unit/parent-dashboard-rsvp.test.js
@@ -25,6 +25,15 @@ describe('parent dashboard RSVP player scope', () => {
     expect(result).toEqual(['child-a']);
   });
 
+  it('prioritizes selected child filter over broad childIds payload', () => {
+    const result = resolveRsvpPlayerIdsForSubmission(allScheduleEvents, 'team-1', 'game-1', {
+      selectedChildId: 'child-a',
+      childIds: 'child-a,child-b'
+    });
+
+    expect(result).toEqual(['child-a']);
+  });
+
   it('rejects explicit childId values outside the selected game scope', () => {
     const result = resolveRsvpPlayerIdsForSubmission(allScheduleEvents, 'team-1', 'game-1', {
       childId: 'child-z'


### PR DESCRIPTION
Closes #110

## What changed
- Added regression coverage for parent RSVP player-ID resolution to prove selected child filter context must take precedence over broad `childIds` payloads.
- Updated `resolveRsvpPlayerIdsForSubmission` to prioritize `selectedChildId` before `childId`/`childIds`, while still sanitizing to the selected team/game scope.
- Updated `submitGameRsvpFromButton` to pass the currently selected player filter as `selectedChildId` and bumped the RSVP helper import cache-bust version.
- Added required run artifacts in `docs/pr-notes/runs/issue-110-fixer-20260301T142502Z/`.

## Why
The parent day-modal/button path could still over-scope RSVP submissions if a button payload contained multiple child IDs. This change enforces child-scoped submissions when a child is selected, preventing sibling RSVP contamination and distorted summary counts.