### PR TITLE
Use team notification email for game summary send

### DIFF
--- a/docs/pr-notes/runs/issue-108-fixer-20260301T172515Z/architecture.md
+++ b/docs/pr-notes/runs/issue-108-fixer-20260301T172515Z/architecture.md
@@ -1,0 +1,18 @@
+# Architecture role synthesis
+
+## Decision
+Extract recipient-selection logic into a tiny pure module used by `js/live-tracker.js`.
+
+## Why
+- Improves testability without introducing framework/runtime changes.
+- Keeps patch minimal and avoids heavy integration harness around DOM + Firebase page script.
+
+## Design
+- New module: `js/live-tracker-email.js`
+- Export `resolveSummaryRecipient({ teamNotificationEmail, userEmail })`
+- Normalize inputs by trimming; return team email first, else user email, else empty string.
+- Import in `live-tracker.js` and use in `finishAndSave()` `mailto` construction.
+
+## Controls / rollback
+- One call-site swap; rollback is single-commit revert.
+- No schema/API contract changes.

--- a/docs/pr-notes/runs/issue-108-fixer-20260301T172515Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-108-fixer-20260301T172515Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code role plan
+
+## Smallest viable change
+1. Add `resolveSummaryRecipient` helper module.
+2. Add failing unit tests covering team-priority recipient behavior.
+3. Update `finishAndSave()` to use resolver.
+4. Run unit tests for new file and nearby live-tracker helper tests.
+5. Commit with issue reference.
+
+## Tradeoffs
+- Chosen over direct inline conditional to keep behavior testable and explicit.
+- Avoids broader refactor of live-tracker page script.

--- a/docs/pr-notes/runs/issue-108-fixer-20260301T172515Z/qa.md
+++ b/docs/pr-notes/runs/issue-108-fixer-20260301T172515Z/qa.md
@@ -1,0 +1,17 @@
+# QA role synthesis
+
+## Bug reproduction assertion
+When both emails are present and different, send flow should choose team `notificationEmail`.
+
+## Test strategy
+- Add focused unit tests for recipient resolver:
+  - prefers team notification email
+  - falls back to current user email when team email missing/blank
+  - trims whitespace and handles null/undefined safely
+
+## Regression guardrails
+- Keep existing `mailto` composition unchanged except recipient source.
+- Run targeted unit test file and full unit suite (if feasible) to avoid collateral regressions.
+
+## Manual spot-check
+- In UI, set team Notification Email distinct from login email, complete game with send-on-save checked, verify mailto recipient.

--- a/docs/pr-notes/runs/issue-108-fixer-20260301T172515Z/requirements.md
+++ b/docs/pr-notes/runs/issue-108-fixer-20260301T172515Z/requirements.md
@@ -1,0 +1,25 @@
+# Requirements role synthesis
+
+## Objective
+Ensure live tracker "Send game summary email on save" targets the team's configured `notificationEmail`, with sensible fallback.
+
+## Current state
+`finishAndSave()` composes `mailto:` with `currentUser.email` only.
+
+## Proposed state
+Recipient priority is:
+1. `currentTeam.notificationEmail` (trimmed, if non-empty)
+2. `currentUser.email` (trimmed, if non-empty)
+3. empty recipient (existing behavior if neither exists)
+
+## Risk surface / blast radius
+- Blast radius is limited to game-completion email compose path in live tracker.
+- No Firestore write path changes.
+- No auth or access-control behavior changes.
+
+## Assumptions
+- `notificationEmail` is already persisted on team document by team settings.
+- Existing flow intentionally uses `mailto:` client-side compose and should remain so.
+
+## Recommendation
+Implement a small pure helper for recipient selection and unit test priority/fallback behavior.

--- a/js/live-tracker-email.js
+++ b/js/live-tracker-email.js
@@ -1,0 +1,8 @@
+export function resolveSummaryRecipient({ teamNotificationEmail, userEmail }) {
+  const teamRecipient = (teamNotificationEmail || '').trim();
+  if (teamRecipient) {
+    return teamRecipient;
+  }
+
+  return (userEmail || '').trim();
+}

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -9,6 +9,7 @@ import { getApp } from './vendor/firebase-app.js';
 import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './live-tracker-notes.js?v=1';
 import { canApplySubstitution, applySubstitution, canTrustScoreLogForFinalization, reconcileFinalScoreFromLog, acquireSingleFlightLock, releaseSingleFlightLock } from './live-tracker-integrity.js?v=1';
 import { hydrateOpponentStats } from './live-tracker-opponent-stats.js?v=1';
+import { resolveSummaryRecipient } from './live-tracker-email.js?v=1';
 
 let currentTeamId = null;
 let currentGameId = null;
@@ -1475,8 +1476,11 @@ async function saveAndComplete() {
     if (sendEmail) {
       const subject = `${currentTeam.name} vs ${currentGame.opponent || 'Unknown Opponent'} - Game Summary`;
       const body = generateEmailBody(finalHome, finalAway, summary);
-      const userEmail = currentUser.email || '';
-      const mailto = `mailto:${userEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+      const recipientEmail = resolveSummaryRecipient({
+        teamNotificationEmail: currentTeam?.notificationEmail,
+        userEmail: currentUser?.email
+      });
+      const mailto = `mailto:${recipientEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
       window.location.href = mailto;
       setTimeout(() => {
         window.location.href = `game.html#teamId=${currentTeamId}&gameId=${currentGameId}`;

--- a/tests/unit/live-tracker-email.test.js
+++ b/tests/unit/live-tracker-email.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolveSummaryRecipient } from '../../js/live-tracker-email.js';
+
+describe('live tracker summary email recipient', () => {
+  it('prefers team notification email over signed-in user email', () => {
+    expect(resolveSummaryRecipient({
+      teamNotificationEmail: 'team-notify@example.com',
+      userEmail: 'coach-login@example.com'
+    })).toBe('team-notify@example.com');
+  });
+
+  it('falls back to signed-in user email when team notification email is missing', () => {
+    expect(resolveSummaryRecipient({
+      teamNotificationEmail: '   ',
+      userEmail: 'coach-login@example.com'
+    })).toBe('coach-login@example.com');
+  });
+
+  it('returns empty string when neither email is available', () => {
+    expect(resolveSummaryRecipient({
+      teamNotificationEmail: undefined,
+      userEmail: null
+    })).toBe('');
+  });
+
+  it('wires recipient resolution into live tracker finish flow', () => {
+    const source = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8');
+    expect(source).toContain('resolveSummaryRecipient');
+    expect(source).toContain('teamNotificationEmail: currentTeam?.notificationEmail');
+  });
+});


### PR DESCRIPTION
Closes #108

## What changed
- Added a new helper module `js/live-tracker-email.js` with `resolveSummaryRecipient()` to centralize recipient selection.
- Updated `js/live-tracker.js` finish/save email flow to use team `notificationEmail` first, then fall back to signed-in user email.
- Added `tests/unit/live-tracker-email.test.js` to cover recipient priority, fallback behavior, empty-input handling, and live-tracker wiring.
- Added required run artifacts under `docs/pr-notes/runs/issue-108-fixer-20260301T172515Z/` (`requirements.md`, `architecture.md`, `qa.md`, `code-plan.md`).

## Why
The previous flow always used `currentUser.email`, which ignored the team-level Notification Email configured for game summaries. This patch aligns send-on-save behavior with team settings while preserving a safe fallback path.

## Validation
- Ran full unit suite with vitest:
  - `/home/paul-bot1/.openclaw/workspace/allplays/node_modules/.bin/vitest run tests/unit`
  - Result: 17 test files passed, 73 tests passed.