### PR TITLE
Add coach RSVP overrides and season-aware game records

### DIFF
--- a/PR-TESTING-GUIDE.md
+++ b/PR-TESTING-GUIDE.md
@@ -61,6 +61,49 @@ Pass criteria: filter behavior is correct and packet completion writes successfu
 
 Pass criteria: coach sees accurate completion rollup for the same session.
 
+## Addendum: Coach RSVP Overrides + Season Record Controls (2026-03-01)
+
+### A. Coach RSVP Override from Game Day
+
+1. Open `game-day.html?teamId=...&gameId=...` as a coach/admin.
+2. In the `RSVPs` panel, click `Going`, `Maybe`, and `Out` for a specific player.
+3. Verify the player moves between sections and counts update immediately.
+4. Refresh the page and confirm the overridden status persists.
+
+Pass criteria: coach can set per-player availability and values persist.
+
+### B. Parent/Coach Overwrite Behavior
+
+1. As a parent, submit RSVP for a child (`Going`).
+2. As coach/admin, override that same player to `Out` in Game Day.
+3. Return as parent and submit RSVP again (`Going` or `Maybe`).
+4. Open schedule RSVP modal or Game Day panel and verify the latest write wins.
+
+Pass criteria: parent and coach can overwrite each other; latest response is reflected.
+
+### C. Schedule Save: Home/Away + Kit Color
+
+1. Open `edit-schedule.html#teamId=...`.
+2. Edit a DB game and set `Home/Away` and `Kit Color`.
+3. Save, then verify badges appear in the game row.
+4. Re-open edit for the same game and verify values are still populated.
+
+Pass criteria: values persist and are not dropped on reload.
+
+### D. Season/Tournament Record Controls
+
+1. In `edit-schedule.html`, edit or create games with:
+   - `Season Label` (example: `2026` and `2025`)
+   - `Competition Type` (league/tournament/etc.)
+   - `Count this game toward season record` unchecked for tournament games.
+2. Mark games completed with final scores.
+3. Open `team.html#teamId=...`.
+4. Use the `Season Record` season dropdown and verify:
+   - Only selected season is counted.
+   - Games with `Count toward season record = false` are excluded.
+
+Pass criteria: season filter and record-exclusion behavior are correct.
+
 ## 🎯 Critical Test Areas
 
 ### 1. Basketball Tracker Selection Modal

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -132,6 +132,28 @@
                                 class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2">
                         </div>
                         <div>
+                            <label class="block text-sm font-medium text-gray-700">Season Label</label>
+                            <input type="text" id="seasonLabel" placeholder="e.g. 2026 Spring"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2">
+                            <p class="text-xs text-gray-500 mt-1">Used to separate records by season.</p>
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700">Competition Type</label>
+                            <select id="competitionType"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2">
+                                <option value="league">League</option>
+                                <option value="tournament">Tournament</option>
+                                <option value="scrimmage">Scrimmage</option>
+                                <option value="other">Other</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label class="inline-flex items-center gap-2 text-sm font-medium text-gray-700">
+                                <input type="checkbox" id="countsTowardSeasonRecord" checked class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+                                Count this game toward season record
+                            </label>
+                        </div>
+                        <div>
                             <label class="block text-sm font-medium text-gray-700">Arrival Time</label>
                             <input type="datetime-local" id="arrivalTime"
                                 class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2">
@@ -907,14 +929,22 @@
                         title: event.title,
                         location: event.location || 'TBD',
                         notes: event.notes,
+                        isHome: event.isHome ?? null,
+                        kitColor: event.kitColor || null,
+                        seasonLabel: event.seasonLabel || null,
+                        competitionType: event.competitionType || 'league',
+                        countsTowardSeasonRecord: event.countsTowardSeasonRecord !== false,
+                        arrivalTime: event.arrivalTime || null,
+                        assignments: Array.isArray(event.assignments) ? event.assignments : [],
+                        rsvpSummary: event.rsvpSummary || null,
                         status: event.status,
                         homeScore: event.homeScore,
                         awayScore: event.awayScore,
-                            id: event.id,
-                            eventId: event.id,
-                            isPractice: eventType === 'practice',
-                            isRecurring: false
-                        });
+                        id: event.id,
+                        eventId: event.id,
+                        isPractice: eventType === 'practice',
+                        isRecurring: false
+                    });
                 }
             });
 
@@ -1305,6 +1335,9 @@
                             ${game.isHome === true ? '<span class="inline-block bg-blue-100 text-blue-800 text-xs px-2 py-0.5 rounded-full font-semibold">HOME</span>' : ''}
                             ${game.isHome === false ? '<span class="inline-block bg-gray-100 text-gray-700 text-xs px-2 py-0.5 rounded-full font-semibold">AWAY</span>' : ''}
                             ${game.kitColor ? `<span class="inline-block bg-purple-100 text-purple-800 text-xs px-2 py-0.5 rounded-full font-semibold">${escapeHtml(game.kitColor)}</span>` : ''}
+                            ${game.seasonLabel ? `<span class="inline-block bg-slate-100 text-slate-700 text-xs px-2 py-0.5 rounded-full font-semibold">Season: ${escapeHtml(game.seasonLabel)}</span>` : ''}
+                            ${game.competitionType ? `<span class="inline-block bg-indigo-100 text-indigo-800 text-xs px-2 py-0.5 rounded-full font-semibold">${escapeHtml(String(game.competitionType).replace(/_/g, ' '))}</span>` : ''}
+                            ${game.countsTowardSeasonRecord === false ? '<span class="inline-block bg-amber-100 text-amber-800 text-xs px-2 py-0.5 rounded-full font-semibold">No record impact</span>' : ''}
                         </div>
                         ${game.arrivalTime ? `<div class="text-xs text-amber-700 mt-1">Arrive: ${formatTime(game.arrivalTime)}</div>` : ''}
                         ${game.notes ? `<div class="text-xs text-gray-500 mt-1 italic">${escapeHtml(game.notes)}</div>` : ''}
@@ -1361,6 +1394,9 @@
             // Populate new fields
             setHomeAway(game.isHome === true ? 'home' : (game.isHome === false ? 'away' : null));
             document.getElementById('kitColor').value = game.kitColor || '';
+            document.getElementById('seasonLabel').value = game.seasonLabel || inferSeasonLabel(date);
+            document.getElementById('competitionType').value = game.competitionType || 'league';
+            document.getElementById('countsTowardSeasonRecord').checked = game.countsTowardSeasonRecord !== false;
             if (game.arrivalTime) {
                 const at = game.arrivalTime.toDate ? game.arrivalTime.toDate() : new Date(game.arrivalTime);
                 const atStr = new Date(at.getTime() - at.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
@@ -1385,6 +1421,14 @@
             document.getElementById('homeAwayHome').className = `flex-1 px-3 py-2 border rounded-md text-sm font-medium focus:outline-none transition ${val === 'home' ? 'border-indigo-600 bg-indigo-600 text-white' : 'border-gray-300 text-gray-700 hover:bg-indigo-50'}`;
             document.getElementById('homeAwayAway').className = `flex-1 px-3 py-2 border rounded-md text-sm font-medium focus:outline-none transition ${val === 'away' ? 'border-indigo-600 bg-indigo-600 text-white' : 'border-gray-300 text-gray-700 hover:bg-indigo-50'}`;
         };
+
+        function inferSeasonLabel(dateLike) {
+            const d = dateLike instanceof Date
+                ? dateLike
+                : (dateLike?.toDate ? dateLike.toDate() : new Date(dateLike || Date.now()));
+            if (Number.isNaN(d.getTime())) return String(new Date().getFullYear());
+            return String(d.getFullYear());
+        }
 
         // ===== ASSIGNMENT ROWS =====
         function addAssignmentRow(role = '', value = '') {
@@ -1428,6 +1472,9 @@
             clearLinkedOpponent();
             setHomeAway(null);
             document.getElementById('kitColor').value = '';
+            document.getElementById('seasonLabel').value = inferSeasonLabel(new Date());
+            document.getElementById('competitionType').value = 'league';
+            document.getElementById('countsTowardSeasonRecord').checked = true;
             document.getElementById('arrivalTime').value = '';
             document.getElementById('gameNotes').value = '';
             document.getElementById('assignment-rows').innerHTML = '';
@@ -1447,6 +1494,7 @@
         }
 
         document.getElementById('cancel-edit-game-btn').addEventListener('click', resetGameForm);
+        resetGameForm();
 
         document.getElementById('add-game-form').addEventListener('submit', async (e) => {
             e.preventDefault();
@@ -1460,9 +1508,10 @@
             try {
                 const isHomeVal = document.getElementById('isHome').value;
                 const arrivalVal = document.getElementById('arrivalTime').value;
+                const parsedGameDate = new Date(dateVal);
                 const gameData = {
                     type: 'game',
-                    date: Timestamp.fromDate(new Date(dateVal)),
+                    date: Timestamp.fromDate(parsedGameDate),
                     opponent,
                     location,
                     statTrackerConfigId: configId || null,
@@ -1471,6 +1520,9 @@
                     opponentTeamPhoto: selectedOpponentTeam ? selectedOpponentTeam.photoUrl || null : null,
                     isHome: isHomeVal === 'home' ? true : (isHomeVal === 'away' ? false : null),
                     kitColor: document.getElementById('kitColor').value.trim() || null,
+                    seasonLabel: document.getElementById('seasonLabel').value.trim() || inferSeasonLabel(parsedGameDate),
+                    competitionType: document.getElementById('competitionType').value || 'league',
+                    countsTowardSeasonRecord: document.getElementById('countsTowardSeasonRecord').checked,
                     arrivalTime: arrivalVal ? Timestamp.fromDate(new Date(arrivalVal)) : null,
                     notes: document.getElementById('gameNotes').value.trim() || null,
                     assignments: getAssignmentsFromForm()
@@ -1903,6 +1955,9 @@
                     status: 'scheduled',
                     homeScore: 0,
                     awayScore: 0,
+                    seasonLabel: inferSeasonLabel(eventDate),
+                    competitionType: 'league',
+                    countsTowardSeasonRecord: true,
                     calendarEventUid: calendarEvent.uid
                 });
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -226,11 +226,18 @@ service cloud.firestore {
         // RSVP subcollection - game attendance responses
         match /rsvps/{rsvpId} {
           allow read: if isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId);
+          // Supports two doc ID patterns for writes by the authenticated user:
+          // 1) request.auth.uid (standard parent RSVP)
+          // 2) request.auth.uid__{playerId} (coach/player-specific override RSVP)
+          function isOwnRsvpDoc() {
+            return rsvpId == request.auth.uid ||
+                   rsvpId.matches('^' + request.auth.uid + '__[A-Za-z0-9_-]+$');
+          }
           allow create, update: if (isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId)) &&
-                                   isSignedIn() && rsvpId == request.auth.uid &&
+                                   isSignedIn() && isOwnRsvpDoc() &&
                                    request.resource.data.userId == request.auth.uid;
           allow delete: if (isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId)) &&
-                           isSignedIn() && rsvpId == request.auth.uid;
+                           isSignedIn() && isOwnRsvpDoc();
         }
       }
 

--- a/game-day.html
+++ b/game-day.html
@@ -478,11 +478,12 @@
             getRsvpBreakdownByPlayer, getGames, getAggregatedStatsForGames,
             getConfigs, updateGame, logStatEvent, updatePlayerStats,
             broadcastLiveEvent, subscribeLiveEvents, subscribeAggregatedStats,
-            setGameLiveStatus
-        } from './js/db.js?v=14';
+            setGameLiveStatus, submitRsvpForPlayer
+        } from './js/db.js?v=15';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js?v=3';
+        import { buildRotationPlanFromGamePlan } from './js/game-plan-interop.js';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -1177,7 +1178,7 @@
         async function loadRsvps() {
             try {
                 const breakdown = await getRsvpBreakdownByPlayer(state.teamId, state.gameId);
-                state.rsvpBreakdown = breakdown;
+                state.rsvpBreakdown = breakdown?.grouped || breakdown || null;
                 markAiChatContextDirty();
                 renderRsvpPanel();
             } catch (err) {
@@ -1197,13 +1198,34 @@
             const notGoing = Array.isArray(breakdown.not_going) ? breakdown.not_going : [];
             const noResponse = Array.isArray(breakdown.not_responded) ? breakdown.not_responded : [];
 
-            const chip = (p) => `<span class="inline-flex items-center gap-1 px-2 py-0.5 bg-gray-100 rounded-full text-xs font-medium">${p.playerNumber ? `#${p.playerNumber} ` : ''}${escapeHtml(p.playerName)}</span>`;
+            const rowActions = (p, currentResponse) => {
+                const mkBtn = (label, response, activeClass, idleClass) => `
+                    <button
+                        onclick="setCoachPlayerRsvp(decodeURIComponent('${encodeURIComponent(p.playerId || '')}'),'${response}')"
+                        class="px-1.5 py-0.5 rounded border text-[10px] font-semibold ${currentResponse === response ? activeClass : idleClass}">
+                        ${label}
+                    </button>`;
+                return `
+                    <span class="ml-1 inline-flex items-center gap-1">
+                        ${mkBtn('Going', 'going', 'bg-green-600 text-white border-green-600', 'bg-white text-green-700 border-green-300 hover:bg-green-50')}
+                        ${mkBtn('Maybe', 'maybe', 'bg-amber-500 text-white border-amber-500', 'bg-white text-amber-700 border-amber-300 hover:bg-amber-50')}
+                        ${mkBtn('Out', 'not_going', 'bg-red-500 text-white border-red-500', 'bg-white text-red-700 border-red-300 hover:bg-red-50')}
+                    </span>
+                `;
+            };
+
+            const chip = (p, responseKey) => `
+                <span class="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 rounded-full text-xs font-medium">
+                    ${p.playerNumber ? `#${p.playerNumber} ` : ''}${escapeHtml(p.playerName)}
+                    ${rowActions(p, responseKey)}
+                </span>
+            `;
 
             const section = (label, color, players) => {
                 if (!players.length) return '';
                 return `<div class="mb-2">
                     <div class="text-xs font-semibold ${color} mb-1">${label} (${players.length})</div>
-                    <div class="flex flex-wrap gap-1">${players.map(chip).join('')}</div>
+                    <div class="flex flex-wrap gap-1">${players.map((p) => chip(p, p.response)).join('')}</div>
                 </div>`;
             };
 
@@ -1211,8 +1233,31 @@
                 section('Going', 'text-green-600', going) +
                 section('Maybe', 'text-amber-600', maybe) +
                 section('Not Going', 'text-red-500', notGoing) +
-                section('No Response', 'text-gray-400', noResponse);
+                section('No Response', 'text-gray-400', noResponse) +
+                '<div id="coach-rsvp-status" class="text-[11px] text-gray-400 mt-2"></div>';
         }
+
+        window.setCoachPlayerRsvp = async function(playerId, response) {
+            const statusEl = document.getElementById('coach-rsvp-status');
+            if (!playerId || !response) return;
+            try {
+                if (statusEl) statusEl.textContent = 'Saving availability…';
+                await submitRsvpForPlayer(state.teamId, state.gameId, state.user?.uid, {
+                    displayName: state.user?.displayName || state.user?.email || null,
+                    playerId,
+                    response
+                });
+                await loadRsvps();
+                if (statusEl) statusEl.textContent = 'Saved';
+                setTimeout(() => {
+                    const nextStatusEl = document.getElementById('coach-rsvp-status');
+                    if (nextStatusEl) nextStatusEl.textContent = '';
+                }, 1800);
+            } catch (err) {
+                console.error('setCoachPlayerRsvp error', err);
+                if (statusEl) statusEl.textContent = 'Save failed';
+            }
+        };
 
         function renderScoutingNotes() {
             const ta = document.getElementById('scouting-notes');
@@ -1861,18 +1906,7 @@ Respond ONLY with valid JSON.`;
         }
 
         function buildRotationFromGamePlan(gamePlan) {
-            if (!gamePlan?.lineups) return {};
-            const plan = {};
-            Object.entries(gamePlan.lineups).forEach(([key, playerId]) => {
-                // key format: "H1-positionId" or "Q1-positionId"
-                const dashIdx = key.indexOf('-');
-                if (dashIdx === -1) return;
-                const period = key.substring(0, dashIdx);
-                const posId = key.substring(dashIdx + 1);
-                if (!plan[period]) plan[period] = {};
-                plan[period][posId] = playerId;
-            });
-            return plan;
+            return buildRotationPlanFromGamePlan(gamePlan);
         }
 
         // ==================== GAME DAY ====================

--- a/js/db.js
+++ b/js/db.js
@@ -30,6 +30,7 @@ import {
 } from './firebase.js?v=9';
 import { imageStorage, ensureImageAuth, requireImageAuth } from './firebase-images.js?v=2';
 import { buildDrillDiagramUploadPaths } from './drill-upload-paths.js?v=1';
+import { buildCoachOverrideRsvpDocId } from './rsvp-doc-ids.js';
 import { getApp } from './vendor/firebase-app.js';
 // import { getAI, getGenerativeModel, GoogleAIBackend } from 'https://www.gstatic.com/firebasejs/12.6.0/firebase-vertexai.js';
 export { collection, getDocs, deleteDoc, query };
@@ -2215,6 +2216,7 @@ function resolveRsvpPlayerIds(rsvp, fallbackByUser) {
     const uid = rsvp?.userId || rsvp?.id;
     return uid ? uniqueNonEmptyIds(fallbackByUser.get(uid) || []) : [];
 }
+export { buildCoachOverrideRsvpDocId };
 
 export async function submitRsvp(teamId, gameId, userId, { displayName, playerIds, response, note }) {
     const authUid = auth.currentUser?.uid || null;
@@ -2271,6 +2273,73 @@ export async function submitRsvp(teamId, gameId, userId, { displayName, playerId
     // Best effort: write denormalized summary if caller is allowed to update game doc.
     // For recurring-occurrence IDs (masterId__instanceDate) the virtual game doc may not
     // exist, so we also suppress 'not-found' rather than crashing the submission.
+    if (summary) {
+        try {
+            await updateDoc(doc(db, `teams/${teamId}/games`, gameId), { rsvpSummary: summary });
+        } catch (err) {
+            if (err?.code !== 'permission-denied' && err?.code !== 'not-found') throw err;
+        }
+    }
+
+    return summary;
+}
+
+export async function submitRsvpForPlayer(teamId, gameId, userId, { displayName, playerId, response, note }) {
+    const authUid = auth.currentUser?.uid || null;
+    if (userId && authUid && userId !== authUid) {
+        throw new Error('RSVP user mismatch. Please refresh and try again.');
+    }
+    const effectiveUserId = userId || authUid || null;
+    if (!effectiveUserId) {
+        throw new Error('You must be signed in to submit RSVP');
+    }
+
+    const normalizedPlayerId = String(playerId || '').trim();
+    if (!normalizedPlayerId) {
+        throw new Error('Missing player for RSVP override');
+    }
+
+    const docId = buildCoachOverrideRsvpDocId(effectiveUserId, normalizedPlayerId);
+    const rsvpRef = doc(db, `teams/${teamId}/games/${gameId}/rsvps`, docId);
+    await setDoc(rsvpRef, {
+        userId: effectiveUserId,
+        displayName: displayName || null,
+        playerIds: [normalizedPlayerId],
+        response, // 'going' | 'maybe' | 'not_going'
+        respondedAt: Timestamp.now(),
+        note: note || null
+    });
+
+    // Keep denormalized summary consistent with submitRsvp behavior.
+    let summary = null;
+    try {
+        const [rsvps, roster] = await Promise.all([
+            getRsvps(teamId, gameId),
+            getPlayers(teamId)
+        ]);
+        const fallbackByUser = await buildFallbackPlayerIdsByUser(teamId, rsvps);
+        const activeRosterIds = new Set(roster.map((player) => player.id));
+        summary = { going: 0, maybe: 0, notGoing: 0, notResponded: 0, total: 0 };
+        rsvps.forEach((rsvp) => {
+            const responseKey = normalizeRsvpResponse(rsvp.response);
+            if (responseKey === 'not_responded') return;
+
+            const playerCount = resolveRsvpPlayerIds(rsvp, fallbackByUser)
+                .filter((id) => activeRosterIds.has(id))
+                .length;
+            if (playerCount === 0) return;
+
+            if (responseKey === 'going') summary.going += playerCount;
+            else if (responseKey === 'maybe') summary.maybe += playerCount;
+            else if (responseKey === 'not_going') summary.notGoing += playerCount;
+        });
+        summary.total = summary.going + summary.maybe + summary.notGoing;
+        summary.notResponded = Math.max(0, roster.length - summary.total);
+        summary.total = roster.length;
+    } catch (err) {
+        if (err?.code !== 'permission-denied') throw err;
+    }
+
     if (summary) {
         try {
             await updateDoc(doc(db, `teams/${teamId}/games`, gameId), { rsvpSummary: summary });

--- a/js/game-plan-interop.js
+++ b/js/game-plan-interop.js
@@ -1,0 +1,46 @@
+export function buildRotationPlanFromGamePlan(gamePlan) {
+  if (!gamePlan?.lineups || typeof gamePlan.lineups !== 'object') return {};
+  const plan = {};
+  const legacyByPeriodPos = {};
+  const numPeriods = Number.parseInt(gamePlan?.numPeriods, 10) || 2;
+  const periodPrefix = numPeriods === 4 ? 'Q' : 'H';
+
+  Object.entries(gamePlan.lineups).forEach(([key, playerId]) => {
+    const currentMatch = /^([HQ]\d+)-(.+)$/.exec(key);
+    if (currentMatch) {
+      const period = currentMatch[1];
+      const posId = currentMatch[2];
+      if (!plan[period]) plan[period] = {};
+      plan[period][posId] = playerId;
+      return;
+    }
+
+    const legacyMatch = /^(\d+)-(\d+)-(.+)$/.exec(key);
+    if (!legacyMatch) return;
+    const periodNum = Number.parseInt(legacyMatch[1], 10);
+    const timeNum = Number.parseInt(legacyMatch[2], 10);
+    const posId = legacyMatch[3];
+    if (!Number.isFinite(periodNum)) return;
+
+    const period = `${periodPrefix}${periodNum}`;
+    const legacyKey = `${period}::${posId}`;
+    const existing = legacyByPeriodPos[legacyKey];
+    if (!existing || (Number.isFinite(timeNum) && timeNum < existing.time)) {
+      legacyByPeriodPos[legacyKey] = {
+        period,
+        posId,
+        time: Number.isFinite(timeNum) ? timeNum : 999,
+        playerId
+      };
+    }
+  });
+
+  Object.values(legacyByPeriodPos).forEach((row) => {
+    if (!plan[row.period]) plan[row.period] = {};
+    if (!plan[row.period][row.posId]) {
+      plan[row.period][row.posId] = row.playerId;
+    }
+  });
+
+  return plan;
+}

--- a/js/rsvp-doc-ids.js
+++ b/js/rsvp-doc-ids.js
@@ -1,0 +1,6 @@
+export function buildCoachOverrideRsvpDocId(userId, playerId) {
+  const uid = String(userId || '').trim();
+  const pid = String(playerId || '').trim();
+  if (!uid || !pid) return '';
+  return `${uid}__${pid}`;
+}

--- a/js/season-record.js
+++ b/js/season-record.js
@@ -1,0 +1,50 @@
+export function inferSeasonLabelFromGame(game) {
+  if (typeof game?.seasonLabel === 'string' && game.seasonLabel.trim()) {
+    return game.seasonLabel.trim();
+  }
+  const rawDate = game?.date;
+  const d = rawDate?.toDate ? rawDate.toDate() : new Date(rawDate || Date.now());
+  if (Number.isNaN(d.getTime())) return String(new Date().getFullYear());
+  return String(d.getFullYear());
+}
+
+export function gameCountsTowardSeasonRecord(game) {
+  return game?.countsTowardSeasonRecord !== false;
+}
+
+export function isCompletedGame(game) {
+  if (!game || game.type === 'practice') return false;
+  const status = String(game.status || '').toLowerCase();
+  const liveStatus = String(game.liveStatus || '').toLowerCase();
+  if (status !== 'completed' && liveStatus !== 'completed') return false;
+  return typeof game.homeScore === 'number' && typeof game.awayScore === 'number';
+}
+
+export function calculateSeasonRecord(games, { seasonLabel } = {}) {
+  let wins = 0;
+  let losses = 0;
+  let ties = 0;
+
+  (Array.isArray(games) ? games : []).forEach((game) => {
+    if (!isCompletedGame(game)) return;
+    if (!gameCountsTowardSeasonRecord(game)) return;
+    if (seasonLabel && inferSeasonLabelFromGame(game) !== seasonLabel) return;
+
+    if (game.homeScore > game.awayScore) wins += 1;
+    else if (game.homeScore < game.awayScore) losses += 1;
+    else ties += 1;
+  });
+
+  return { wins, losses, ties };
+}
+
+export function listSeasonLabels(games) {
+  const labels = new Set();
+  (Array.isArray(games) ? games : []).forEach((game) => {
+    if (game?.type === 'practice') return;
+    labels.add(inferSeasonLabelFromGame(game));
+  });
+  return Array.from(labels)
+    .filter(Boolean)
+    .sort((a, b) => b.localeCompare(a, undefined, { numeric: true, sensitivity: 'base' }));
+}

--- a/team.html
+++ b/team.html
@@ -232,6 +232,7 @@
         import { getTeam, getPlayers, getGames, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile } from './js/db.js?v=14';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';
+        import { calculateSeasonRecord, listSeasonLabels } from './js/season-record.js';
         import { checkAuth } from './js/auth.js?v=9';
         import { collection, getDocs } from "./js/firebase.js?v=9";
         import { db } from './js/firebase.js?v=9';
@@ -270,6 +271,7 @@
         let scheduleViewMode = 'list';
         let scheduleCalendarMonth = new Date().getMonth();
         let scheduleCalendarYear = new Date().getFullYear();
+        let seasonFilterLabel = String(new Date().getFullYear());
 
         window.setScheduleFilter = setScheduleFilter;
         window.setScheduleView = setScheduleView;
@@ -344,24 +346,27 @@
             return Number.isNaN(d?.getTime?.()) ? null : d;
         }
 
-        function calculateSeasonRecord(games) {
-            let wins = 0;
-            let losses = 0;
-            let ties = 0;
+        function getSeasonRecordMeta(games, selectedSeason) {
+            const record = calculateSeasonRecord(games, { seasonLabel: selectedSeason });
+            const totalGames = record.wins + record.losses + record.ties;
+            const winPercentage = totalGames > 0 ? ((record.wins / totalGames) * 100).toFixed(0) : 0;
+            return { record, totalGames, winPercentage };
+        }
 
-            games.forEach(game => {
-                if (game.status === 'completed' && game.homeScore !== undefined && game.awayScore !== undefined) {
-                    if (game.homeScore > game.awayScore) {
-                        wins++;
-                    } else if (game.homeScore < game.awayScore) {
-                        losses++;
-                    } else {
-                        ties++;
-                    }
-                }
-            });
+        function updateSeasonRecordCard(games, selectedSeason) {
+            const titleEl = document.getElementById('season-record-title');
+            const valueEl = document.getElementById('season-record-value');
+            const pctEl = document.getElementById('season-record-pct');
+            const playedEl = document.getElementById('season-record-played');
+            if (!titleEl || !valueEl || !pctEl || !playedEl) return;
 
-            return { wins, losses, ties };
+            const { record, totalGames, winPercentage } = getSeasonRecordMeta(games, selectedSeason);
+            titleEl.textContent = `Season Record (${selectedSeason})`;
+            valueEl.textContent = `${record.wins}-${record.losses}${record.ties > 0 ? `-${record.ties}` : ''}`;
+            pctEl.textContent = totalGames > 0 ? `(${winPercentage}%)` : '';
+            playedEl.textContent = totalGames === 0
+                ? 'No countable games completed yet'
+                : `${totalGames} game${totalGames === 1 ? '' : 's'} played`;
         }
 
         function formatMMSS(ms) {
@@ -633,8 +638,15 @@
                     }
                 }
 
-                // Calculate season record
-                const record = calculateSeasonRecord(dbGames);
+                const seasonLabels = listSeasonLabels(dbGames);
+                if (!seasonLabels.length) {
+                    seasonLabels.push(String(new Date().getFullYear()));
+                }
+                if (!seasonLabels.includes(seasonFilterLabel)) {
+                    const currentYearLabel = String(new Date().getFullYear());
+                    seasonFilterLabel = seasonLabels.includes(currentYearLabel) ? currentYearLabel : seasonLabels[0];
+                }
+                const seasonMeta = getSeasonRecordMeta(dbGames, seasonFilterLabel);
 
                 // Render Header
                 document.getElementById('team-header').innerHTML = `
@@ -677,8 +689,9 @@
                 `;
 
                 // Render Season Overview Cards
-                const totalGames = dbGames.filter(g => g.status === 'completed').length;
-                const winPercentage = totalGames > 0 ? ((record.wins / totalGames) * 100).toFixed(0) : 0;
+                const totalGames = seasonMeta.totalGames;
+                const winPercentage = seasonMeta.winPercentage;
+                const record = seasonMeta.record;
                 const leagueSnapshot = team.leagueUrl
                     ? await fetchLeagueStandings(team.leagueUrl, { teamName: team.name })
                     : { ok: false, reason: 'missing-url', rows: [], match: null };
@@ -694,21 +707,26 @@
                     <!-- Season Record -->
                     <div class="bg-white rounded-xl shadow-md hover:shadow-lg transition p-6 border border-gray-200">
                         <div class="flex items-center justify-between mb-3">
-                            <h3 class="text-sm font-semibold text-gray-600 uppercase tracking-wide">Season Record</h3>
+                            <div class="flex flex-col gap-1">
+                                <h3 id="season-record-title" class="text-sm font-semibold text-gray-600 uppercase tracking-wide">Season Record (${seasonFilterLabel})</h3>
+                                <select id="season-record-filter" class="text-xs border border-gray-200 rounded px-2 py-0.5 text-gray-700">
+                                    ${seasonLabels.map((label) => `<option value="${escapeHtml(label)}" ${label === seasonFilterLabel ? 'selected' : ''}>${escapeHtml(label)}</option>`).join('')}
+                                </select>
+                            </div>
                             <svg class="w-5 h-5 text-primary-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
                             </svg>
                         </div>
                         <div class="flex items-baseline gap-2">
-                            <span class="text-3xl md:text-4xl font-bold text-gray-900">${record.wins}-${record.losses}${record.ties > 0 ? `-${record.ties}` : ''}</span>
+                            <span id="season-record-value" class="text-3xl md:text-4xl font-bold text-gray-900">${record.wins}-${record.losses}${record.ties > 0 ? `-${record.ties}` : ''}</span>
                             ${totalGames > 0
-                            ? `<span class="text-sm text-gray-500">(${winPercentage}%)</span>`
-                            : ''
+                            ? `<span id="season-record-pct" class="text-sm text-gray-500">(${winPercentage}%)</span>`
+                            : '<span id="season-record-pct" class="text-sm text-gray-500"></span>'
                         }
                         </div>
                         ${totalGames === 0
-                            ? `<p class="text-xs text-gray-500 mt-2">No games completed yet</p>`
-                            : `<p class="text-xs text-gray-500 mt-2">${totalGames} game${totalGames === 1 ? '' : 's'} played</p>`
+                            ? `<p id="season-record-played" class="text-xs text-gray-500 mt-2">No countable games completed yet</p>`
+                            : `<p id="season-record-played" class="text-xs text-gray-500 mt-2">${totalGames} game${totalGames === 1 ? '' : 's'} played</p>`
                         }
                     </div>
 
@@ -746,6 +764,14 @@
                         ${renderLeagueOverviewBody(leagueSnapshot, team)}
                     </div>
                 `;
+
+                const seasonFilterEl = document.getElementById('season-record-filter');
+                if (seasonFilterEl) {
+                    seasonFilterEl.addEventListener('change', () => {
+                        seasonFilterLabel = seasonFilterEl.value;
+                        updateSeasonRecordCard(dbGames, seasonFilterLabel);
+                    });
+                }
 
                 // Start countdown updates
                 if (nextGame) {

--- a/tests/unit/game-plan-interop.test.js
+++ b/tests/unit/game-plan-interop.test.js
@@ -1,0 +1,50 @@
+import { describe, it, expect } from 'vitest';
+import { buildRotationPlanFromGamePlan } from '../../js/game-plan-interop.js';
+
+describe('game plan interop helpers', () => {
+  it('reads current game-day lineups shape', () => {
+    const plan = buildRotationPlanFromGamePlan({
+      lineups: {
+        'H1-keeper': 'p1',
+        'H1-striker': 'p2',
+        'H2-keeper': 'p3'
+      }
+    });
+
+    expect(plan).toEqual({
+      H1: { keeper: 'p1', striker: 'p2' },
+      H2: { keeper: 'p3' }
+    });
+  });
+
+  it('maps legacy game-plan period-time-position shape to period-position', () => {
+    const plan = buildRotationPlanFromGamePlan({
+      numPeriods: 2,
+      lineups: {
+        '1-7-keeper': 'p1',
+        '1-14-keeper': 'p2',
+        '2-7-striker': 'p3'
+      }
+    });
+
+    expect(plan).toEqual({
+      H1: { keeper: 'p1' },
+      H2: { striker: 'p3' }
+    });
+  });
+
+  it('uses quarter prefixes for 4-period legacy plans', () => {
+    const plan = buildRotationPlanFromGamePlan({
+      numPeriods: 4,
+      lineups: {
+        '1-4-pg': 'p1',
+        '2-4-pg': 'p2'
+      }
+    });
+
+    expect(plan).toEqual({
+      Q1: { pg: 'p1' },
+      Q2: { pg: 'p2' }
+    });
+  });
+});

--- a/tests/unit/rsvp-doc-ids.test.js
+++ b/tests/unit/rsvp-doc-ids.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { buildCoachOverrideRsvpDocId } from '../../js/rsvp-doc-ids.js';
+
+describe('rsvp doc id helpers', () => {
+  it('builds player-specific override doc ids', () => {
+    expect(buildCoachOverrideRsvpDocId('coach123', 'player456')).toBe('coach123__player456');
+  });
+
+  it('returns empty string when user or player id is missing', () => {
+    expect(buildCoachOverrideRsvpDocId('', 'player456')).toBe('');
+    expect(buildCoachOverrideRsvpDocId('coach123', '')).toBe('');
+  });
+});

--- a/tests/unit/season-record.test.js
+++ b/tests/unit/season-record.test.js
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import {
+  inferSeasonLabelFromGame,
+  gameCountsTowardSeasonRecord,
+  isCompletedGame,
+  calculateSeasonRecord,
+  listSeasonLabels
+} from '../../js/season-record.js';
+
+describe('season record helpers', () => {
+  it('infers season label from explicit seasonLabel first', () => {
+    expect(inferSeasonLabelFromGame({ seasonLabel: '2026 Spring', date: '2024-01-01T00:00:00Z' })).toBe('2026 Spring');
+  });
+
+  it('falls back to year from date when season label is missing', () => {
+    expect(inferSeasonLabelFromGame({ date: '2025-09-01T00:00:00Z' })).toBe('2025');
+  });
+
+  it('respects countsTowardSeasonRecord false', () => {
+    expect(gameCountsTowardSeasonRecord({ countsTowardSeasonRecord: false })).toBe(false);
+    expect(gameCountsTowardSeasonRecord({})).toBe(true);
+  });
+
+  it('recognizes completed games only when scores are present', () => {
+    expect(isCompletedGame({ type: 'game', status: 'completed', homeScore: 2, awayScore: 1 })).toBe(true);
+    expect(isCompletedGame({ type: 'game', status: 'completed' })).toBe(false);
+    expect(isCompletedGame({ type: 'practice', status: 'completed', homeScore: 2, awayScore: 1 })).toBe(false);
+  });
+
+  it('calculates record by selected season and excludes no-record games', () => {
+    const games = [
+      { type: 'game', status: 'completed', seasonLabel: '2026', homeScore: 2, awayScore: 1 },
+      { type: 'game', status: 'completed', seasonLabel: '2026', homeScore: 1, awayScore: 3 },
+      { type: 'game', status: 'completed', seasonLabel: '2026', homeScore: 0, awayScore: 0 },
+      { type: 'game', status: 'completed', seasonLabel: '2026', homeScore: 3, awayScore: 1, countsTowardSeasonRecord: false },
+      { type: 'game', status: 'completed', seasonLabel: '2025', homeScore: 4, awayScore: 2 }
+    ];
+
+    expect(calculateSeasonRecord(games, { seasonLabel: '2026' })).toEqual({ wins: 1, losses: 1, ties: 1 });
+    expect(calculateSeasonRecord(games, { seasonLabel: '2025' })).toEqual({ wins: 1, losses: 0, ties: 0 });
+  });
+
+  it('lists unique season labels in descending order', () => {
+    const games = [
+      { type: 'game', seasonLabel: '2024' },
+      { type: 'game', seasonLabel: '2026' },
+      { type: 'game', seasonLabel: '2025' },
+      { type: 'practice', seasonLabel: '2027' }
+    ];
+
+    expect(listSeasonLabels(games)).toEqual(['2026', '2025', '2024']);
+  });
+});


### PR DESCRIPTION
## Summary
- add coach/player-specific RSVP overrides in Game Day (Going/Maybe/Out per player)
- allow parent and coach RSVP overwrites; latest write wins
- add game detail fields in schedule: seasonLabel, competitionType, countsTowardSeasonRecord
- update Team page Season Record to filter by season and exclude games that do not count toward record
- fix Game Day RSVP panel data-shape issue so RSVP data renders correctly
- fix Game Plan/Game Day lineup interoperability by supporting legacy and current saved lineup key formats
- fix schedule persistence/display for Home/Away and Kit Color (and related mapped fields)
- update PR testing guide with new manual validation steps

## Firebase
- deployed Firestore rules to game-flow-c6311 to support RSVP doc IDs:
  - uid (parent RSVP)
  - uid__playerId (coach per-player override)

## Tests
- added unit tests:
  - tests/unit/rsvp-doc-ids.test.js
  - tests/unit/season-record.test.js
  - tests/unit/game-plan-interop.test.js
- ran:
  - npx -y vitest@latest run tests/unit/parent-dashboard-rsvp.test.js tests/unit/rsvp-doc-ids.test.js tests/unit/season-record.test.js tests/unit/game-plan-interop.test.js
- result: 4 files passed, 15 tests passed

## Smoke Validation
- verified in browser on local server:
  - schedule field persistence for Home/Away, Kit Color, season/competition fields
  - Game Day coach RSVP override writes and persistence after reload
  - Season Record UI wiring and season selector rendering
