### PR TITLE
Add YouTube + Twitch live stream embed with Watch Live links

### DIFF
--- a/docs/pr-notes/runs/122-review-3873728050-20260302T014729Z/architecture.md
+++ b/docs/pr-notes/runs/122-review-3873728050-20260302T014729Z/architecture.md
@@ -1,0 +1,17 @@
+# Architecture Role (manual fallback)
+
+- Thinking level: medium (cross-file behavior consistency).
+
+## Current state
+- Stream normalization logic was embedded in `edit-team.html` and discarded embed query state.
+- Visibility logic in `js/live-game.js` had two competing controllers (`setupVideoPanel` and `updateTabs`) with no shared source of truth for stream presence.
+
+## Proposed state
+1. Introduce `js/live-stream-utils.js` as shared pure utility layer:
+   - `normalizeYouTubeEmbedUrl(url)` preserves query params and enforces `autoplay=1&mute=1`.
+   - `computePanelVisibility(...)` centralizes panel/tab visibility decisions.
+2. Use the shared utility in both `edit-team.html` and `js/live-game.js`.
+3. Store `state.hasVideoStream` in live-game runtime and drive tab/layout from it.
+
+## Blast radius
+- Scoped to stream parsing and live-game panel visibility; no Firestore schema or auth/rules changes.

--- a/docs/pr-notes/runs/122-review-3873728050-20260302T014729Z/code-plan.md
+++ b/docs/pr-notes/runs/122-review-3873728050-20260302T014729Z/code-plan.md
@@ -1,0 +1,16 @@
+# Code Role (manual fallback)
+
+- Thinking level: medium (minimal safe patch).
+
+## Plan executed
+1. Add `js/live-stream-utils.js` with pure helpers for embed normalization and tab/panel visibility.
+2. Update `edit-team.html` to normalize embed URLs without dropping query params.
+3. Update `js/live-game.js` to track `hasVideoStream` and honor it in desktop/mobile visibility logic.
+4. Update `test-youtube-stream.html` for parity with new embed normalization expectations.
+5. Add regression tests in `tests/unit/live-stream-utils.test.js`.
+
+## Conflict resolution across roles
+- Requirements favored preserving all useful query params.
+- Architecture favored centralization to avoid repeated logic drift.
+- QA required executable guardrails, so utility extraction enabled direct unit tests.
+- Final patch prioritized smallest cross-file change that satisfies all three.

--- a/docs/pr-notes/runs/122-review-3873728050-20260302T014729Z/qa.md
+++ b/docs/pr-notes/runs/122-review-3873728050-20260302T014729Z/qa.md
@@ -1,0 +1,16 @@
+# QA Role (manual fallback)
+
+- Thinking level: medium (regression guardrails for two P-level comments).
+
+## Risks targeted
+1. Silent corruption of channel-based embeds during save.
+2. Empty desktop video column shown for teams without streams.
+
+## Coverage plan
+1. Add unit tests for URL normalization preserving required query params.
+2. Add unit tests for panel visibility decisions when `hasVideoStream=false`.
+3. Re-run adjacent live-game chat test file to ensure no module regression from new import path.
+
+## Validation outcome
+- Passed: `tests/unit/live-stream-utils.test.js`
+- Passed: `tests/unit/live-game-chat.test.js`

--- a/docs/pr-notes/runs/122-review-3873728050-20260302T014729Z/requirements.md
+++ b/docs/pr-notes/runs/122-review-3873728050-20260302T014729Z/requirements.md
@@ -1,0 +1,14 @@
+# Requirements Role (manual fallback)
+
+- Thinking level: medium (targeted regression fixes with user-visible impact).
+- Constraint: preserve existing valid live-stream configs during unrelated team edits.
+
+## Problem framing
+1. `parseStreamUrl()` was stripping all query params from existing YouTube embed URLs.
+2. Live game desktop tabs were re-showing `#video-panel` even when no stream exists.
+
+## Acceptance criteria
+1. Saving a team that already has `streamEmbedUrl` using `/embed/live_stream?channel=UC...` must keep `channel` after normalization.
+2. Desktop live-game layout must hide `#video-panel` when no stream is configured.
+3. Mobile tab behavior must not allow a dead `video` tab when no stream exists.
+4. Add automated checks for both regressions.

--- a/edit-team.html
+++ b/edit-team.html
@@ -95,6 +95,30 @@
                     <p class="text-xs text-gray-500 mt-1">Used to display external league standings (W/L/T) on the team page.</p>
                 </div>
 
+                <div>
+                    <label class="block text-sm font-medium text-gray-700">
+                        Live Stream <span class="font-normal text-gray-400">(optional)</span>
+                    </label>
+                    <input type="text" id="streamUrl"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2"
+                        placeholder="youtube.com/live/... or twitch.tv/yourchannel">
+                    <div id="stream-detect" class="hidden mt-1 text-xs font-medium"></div>
+                    <details class="mt-2 group">
+                        <summary class="text-xs text-indigo-500 cursor-pointer hover:text-indigo-700 select-none">
+                            What can I paste? ▸
+                        </summary>
+                        <ul class="mt-2 text-xs text-gray-500 space-y-1 pl-1 border-l-2 border-indigo-100 ml-1">
+                            <li class="pl-2"><span class="text-purple-600 font-semibold">Twitch</span> — twitch.tv/yourchannel</li>
+                            <li class="pl-2"><span class="text-red-500 font-semibold">YouTube</span> — youtube.com/live/VIDEO_ID</li>
+                            <li class="pl-2"><span class="text-red-500 font-semibold">YouTube</span> — youtube.com/watch?v=VIDEO_ID</li>
+                            <li class="pl-2"><span class="text-red-500 font-semibold">YouTube</span> — youtu.be/VIDEO_ID</li>
+                            <li class="pl-2"><span class="text-red-500 font-semibold">YouTube</span> — Channel ID: UCa9ghvbup6VQmnDOdqwYpqQ</li>
+                            <li class="pl-2"><span class="text-red-500 font-semibold">YouTube</span> — paste the entire &lt;iframe&gt; embed code</li>
+                        </ul>
+                        <p class="mt-2 text-xs text-gray-400 pl-1">Shown to fans during live games. For a permanent YouTube channel stream, use your Channel ID from YouTube Studio → Settings → Channel → Advanced.</p>
+                    </details>
+                </div>
+
                 <div class="flex items-start">
                     <div class="flex items-center h-5">
                         <input id="isPublic" type="checkbox"
@@ -253,6 +277,14 @@
                     document.getElementById('leagueUrl').value = team.leagueUrl || '';
                     document.getElementById('zip').value = team.zip || '';
                     document.getElementById('isPublic').checked = team.isPublic !== false; // Default to true
+                    // Populate Live Stream field from twitchChannel, streamEmbedUrl, or legacy youtubeEmbedUrl
+                    const streamInput = document.getElementById('streamUrl');
+                    if (team.twitchChannel) {
+                        streamInput.value = `twitch.tv/${team.twitchChannel}`;
+                    } else if (team.streamEmbedUrl || team.youtubeEmbedUrl) {
+                        streamInput.value = team.streamEmbedUrl || team.youtubeEmbedUrl;
+                    }
+                    streamInput.dispatchEvent(new Event('input')); // trigger detection badge
                     adminEmails = (team.adminEmails || []).map(e => e.toLowerCase());
                     renderAdminList();
 
@@ -433,6 +465,66 @@
             }
         });
 
+        // Parses any YouTube or Twitch URL and returns { platform, twitchChannel?, streamEmbedUrl? }
+        function parseStreamUrl(input) {
+            if (!input) return null;
+            const str = input.trim();
+
+            // Extract src from a pasted <iframe> embed code
+            const iframeSrc = str.match(/src="([^"]+)"/);
+            const url = iframeSrc ? iframeSrc[1] : str;
+
+            // ── TWITCH ──────────────────────────────────────────────────────────
+            // Matches: twitch.tv/channel  or  player.twitch.tv/?channel=name
+            const twitchMatch = url.match(/(?:(?:www\.)?twitch\.tv\/|player\.twitch\.tv\/\?.*channel=)([a-zA-Z0-9_]{1,25})/);
+            if (twitchMatch) {
+                return { platform: 'twitch', twitchChannel: twitchMatch[1].toLowerCase() };
+            }
+
+            // ── YOUTUBE ─────────────────────────────────────────────────────────
+            // Already a YouTube embed URL — normalize params
+            if (url.includes('youtube.com/embed/')) {
+                return { platform: 'youtube', streamEmbedUrl: url.split('?')[0] + '?autoplay=1&mute=1' };
+            }
+            // Raw channel ID (UC + 22 chars)
+            if (/^UC[a-zA-Z0-9_-]{22}$/.test(url)) {
+                return { platform: 'youtube', streamEmbedUrl: `https://www.youtube.com/embed/live_stream?channel=${url}&autoplay=1&mute=1` };
+            }
+            // youtube.com/channel/UCxxxxxxxxxx
+            const channelMatch = url.match(/youtube\.com\/channel\/(UC[a-zA-Z0-9_-]{22})/);
+            if (channelMatch) {
+                return { platform: 'youtube', streamEmbedUrl: `https://www.youtube.com/embed/live_stream?channel=${channelMatch[1]}&autoplay=1&mute=1` };
+            }
+            // Path-based video ID: /live/ID, /embed/ID, youtu.be/ID
+            const pathMatch = url.match(/(?:youtube\.com\/(?:live|embed)\/|youtu\.be\/)([a-zA-Z0-9_-]{11})/);
+            // Query-based video ID: ?v=ID or &v=ID
+            const queryMatch = url.match(/[?&]v=([a-zA-Z0-9_-]{11})/);
+            const videoId = (pathMatch && pathMatch[1]) || (queryMatch && queryMatch[1]);
+            if (videoId) {
+                return { platform: 'youtube', streamEmbedUrl: `https://www.youtube.com/embed/${videoId}?autoplay=1&mute=1` };
+            }
+
+            return null;
+        }
+
+        // Live detection badge as the user types / pastes
+        document.getElementById('streamUrl').addEventListener('input', function () {
+            const detect = document.getElementById('stream-detect');
+            const result = parseStreamUrl(this.value);
+            if (!this.value.trim()) {
+                detect.className = 'hidden mt-1 text-xs font-medium';
+            } else if (result?.platform === 'twitch') {
+                detect.textContent = `✅ Twitch channel detected: ${result.twitchChannel}`;
+                detect.className = 'mt-1 text-xs font-medium text-purple-600';
+            } else if (result?.platform === 'youtube') {
+                detect.textContent = '✅ YouTube stream detected';
+                detect.className = 'mt-1 text-xs font-medium text-red-600';
+            } else {
+                detect.textContent = '⚠️ Link not recognized — try a full URL (e.g. twitch.tv/channel)';
+                detect.className = 'mt-1 text-xs font-medium text-amber-600';
+            }
+        });
+
         document.getElementById('team-form').addEventListener('submit', async (e) => {
             e.preventDefault();
             const btn = document.getElementById('save-btn');
@@ -469,7 +561,15 @@
                     zip,
                     photoUrl: currentPhotoUrl,
                     isPublic: document.getElementById('isPublic').checked,
-                    adminEmails
+                    adminEmails,
+                    ...((() => {
+                        const sr = parseStreamUrl(document.getElementById('streamUrl').value);
+                        return {
+                            twitchChannel: sr?.platform === 'twitch' ? sr.twitchChannel : null,
+                            streamEmbedUrl: sr?.platform === 'youtube' ? sr.streamEmbedUrl : null,
+                            youtubeEmbedUrl: null, // clear legacy field on every save
+                        };
+                    })())
                 };
 
                 if (!currentTeamId) {

--- a/edit-team.html
+++ b/edit-team.html
@@ -216,6 +216,7 @@
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=8';
         import { checkAuth, sendInviteEmail } from './js/auth.js?v=9';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
+        import { normalizeYouTubeEmbedUrl } from './js/live-stream-utils.js?v=1';
         import { hasFullTeamAccess } from './js/team-access.js';
 
         renderFooter(document.getElementById('footer-container'));
@@ -484,7 +485,8 @@
             // ── YOUTUBE ─────────────────────────────────────────────────────────
             // Already a YouTube embed URL — normalize params
             if (url.includes('youtube.com/embed/')) {
-                return { platform: 'youtube', streamEmbedUrl: url.split('?')[0] + '?autoplay=1&mute=1' };
+                const normalized = normalizeYouTubeEmbedUrl(url);
+                return normalized ? { platform: 'youtube', streamEmbedUrl: normalized } : null;
             }
             // Raw channel ID (UC + 22 chars)
             if (/^UC[a-zA-Z0-9_-]{22}$/.test(url)) {

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -127,6 +127,7 @@ const els = {
   gameStartTime: q('#game-start-time'),
 
   mobileTabs: document.querySelectorAll('#mobile-tabs [data-tab]'),
+  videoPanel: q('#video-panel'),
   playsPanel: q('#plays-panel'),
   statsPanel: q('#stats-panel'),
   chatPanelMobile: q('#chat-panel')
@@ -198,6 +199,7 @@ function updateTabs() {
   const isMobile = window.matchMedia('(max-width: 767px)').matches;
 
   if (!isMobile) {
+    els.videoPanel?.classList.remove('hidden');
     els.playsPanel?.classList.remove('hidden');
     els.statsPanel?.classList.remove('hidden');
     els.chatPanel?.classList.remove('hidden');
@@ -212,18 +214,37 @@ function updateTabs() {
     tab.classList.toggle('border-transparent', !active);
   });
 
-  if (state.activeTab === 'plays') {
-    els.playsPanel?.classList.remove('hidden');
-    els.statsPanel?.classList.add('hidden');
-    els.chatPanel?.classList.add('hidden');
-  } else if (state.activeTab === 'stats') {
-    els.playsPanel?.classList.add('hidden');
-    els.statsPanel?.classList.remove('hidden');
-    els.chatPanel?.classList.add('hidden');
+  const tab = state.activeTab;
+  els.videoPanel?.classList.toggle('hidden', tab !== 'video');
+  els.playsPanel?.classList.toggle('hidden', tab !== 'plays');
+  els.statsPanel?.classList.toggle('hidden', tab !== 'stats');
+  els.chatPanel?.classList.toggle('hidden', tab !== 'chat');
+}
+
+function setupVideoPanel() {
+  // Build embed URL: Twitch takes priority, then streamEmbedUrl, then legacy YouTube fields
+  let embedUrl = null;
+  if (state.team?.twitchChannel) {
+    const host = window.location.hostname;
+    embedUrl = `https://player.twitch.tv/?channel=${state.team.twitchChannel}&parent=${host}&autoplay=true&muted=true`;
   } else {
-    els.playsPanel?.classList.add('hidden');
-    els.statsPanel?.classList.add('hidden');
-    els.chatPanel?.classList.remove('hidden');
+    embedUrl = state.team?.streamEmbedUrl ||
+      state.team?.youtubeEmbedUrl ||
+      (state.team?.youtubeVideoId
+        ? `https://www.youtube.com/embed/${state.team.youtubeVideoId}?autoplay=1&mute=1`
+        : null);
+  }
+
+  const videoTab = document.querySelector('#mobile-tabs [data-tab="video"]');
+
+  if (embedUrl) {
+    const iframe = document.getElementById('youtube-stream-iframe');
+    if (iframe) iframe.src = embedUrl;
+    if (videoTab) videoTab.classList.remove('hidden');
+  } else {
+    els.videoPanel?.classList.add('hidden');
+    if (videoTab) videoTab.classList.add('hidden');
+    if (state.activeTab === 'video') state.activeTab = 'plays';
   }
 }
 
@@ -1361,6 +1382,7 @@ async function init() {
   state.awayScore = game.awayScore || 0;
   state.period = game.period || 'Q1';
 
+  setupVideoPanel();
   renderGameInfo();
   renderScoreboard();
   renderLineup();

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -224,23 +224,43 @@ function updateTabs() {
 function setupVideoPanel() {
   // Build embed URL: Twitch takes priority, then streamEmbedUrl, then legacy YouTube fields
   let embedUrl = null;
+  let publicUrl = null;
+  let publicLabel = null;
+
   if (state.team?.twitchChannel) {
     const host = window.location.hostname;
     embedUrl = `https://player.twitch.tv/?channel=${state.team.twitchChannel}&parent=${host}&autoplay=true&muted=true`;
+    publicUrl = `https://twitch.tv/${state.team.twitchChannel}`;
+    publicLabel = 'Watch on Twitch ↗';
   } else {
-    embedUrl = state.team?.streamEmbedUrl ||
+    const src = state.team?.streamEmbedUrl ||
       state.team?.youtubeEmbedUrl ||
       (state.team?.youtubeVideoId
         ? `https://www.youtube.com/embed/${state.team.youtubeVideoId}?autoplay=1&mute=1`
         : null);
+    if (src) {
+      embedUrl = src;
+      const channelMatch = src.match(/channel=(UC[a-zA-Z0-9_-]{22})/);
+      const videoMatch = src.match(/\/embed\/([a-zA-Z0-9_-]{11})/);
+      publicUrl = channelMatch
+        ? `https://www.youtube.com/channel/${channelMatch[1]}`
+        : videoMatch ? `https://www.youtube.com/watch?v=${videoMatch[1]}` : null;
+      publicLabel = 'Watch on YouTube ↗';
+    }
   }
 
   const videoTab = document.querySelector('#mobile-tabs [data-tab="video"]');
+  const extLink = document.getElementById('stream-external-link');
 
   if (embedUrl) {
     const iframe = document.getElementById('youtube-stream-iframe');
     if (iframe) iframe.src = embedUrl;
     if (videoTab) videoTab.classList.remove('hidden');
+    if (extLink && publicUrl) {
+      extLink.href = publicUrl;
+      extLink.textContent = publicLabel;
+      extLink.classList.remove('hidden');
+    }
   } else {
     els.videoPanel?.classList.add('hidden');
     if (videoTab) videoTab.classList.add('hidden');

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -15,6 +15,7 @@ import {
   subscribeGame
 } from './db.js?v=14';
 import { getUrlParams, escapeHtml, renderHeader, renderFooter, formatShortDate, formatTime, shareOrCopy } from './utils.js?v=8';
+import { computePanelVisibility } from './live-stream-utils.js?v=1';
 import { checkAuth } from './auth.js?v=9';
 import { isViewerChatEnabled } from './live-game-chat.js?v=1';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
@@ -69,7 +70,8 @@ const state = {
 
   lastStatChange: null,
   scoringRun: { team: null, points: 0 },
-  lastRunAnnounced: 0
+  lastRunAnnounced: 0,
+  hasVideoStream: false
 };
 
 const els = {
@@ -197,14 +199,19 @@ function initTabs() {
 
 function updateTabs() {
   const isMobile = window.matchMedia('(max-width: 767px)').matches;
+  const visibility = computePanelVisibility({
+    isMobile,
+    activeTab: state.activeTab,
+    hasVideoStream: state.hasVideoStream
+  });
+  state.activeTab = visibility.activeTab;
 
-  if (!isMobile) {
-    els.videoPanel?.classList.remove('hidden');
-    els.playsPanel?.classList.remove('hidden');
-    els.statsPanel?.classList.remove('hidden');
-    els.chatPanel?.classList.remove('hidden');
-    return;
-  }
+  els.videoPanel?.classList.toggle('hidden', visibility.videoHidden);
+  els.playsPanel?.classList.toggle('hidden', visibility.playsHidden);
+  els.statsPanel?.classList.toggle('hidden', visibility.statsHidden);
+  els.chatPanel?.classList.toggle('hidden', visibility.chatHidden);
+
+  if (!isMobile) return;
 
   els.mobileTabs.forEach(tab => {
     const active = tab.dataset.tab === state.activeTab;
@@ -213,12 +220,6 @@ function updateTabs() {
     tab.classList.toggle('text-sand/50', !active);
     tab.classList.toggle('border-transparent', !active);
   });
-
-  const tab = state.activeTab;
-  els.videoPanel?.classList.toggle('hidden', tab !== 'video');
-  els.playsPanel?.classList.toggle('hidden', tab !== 'plays');
-  els.statsPanel?.classList.toggle('hidden', tab !== 'stats');
-  els.chatPanel?.classList.toggle('hidden', tab !== 'chat');
 }
 
 function setupVideoPanel() {
@@ -251,6 +252,7 @@ function setupVideoPanel() {
 
   const videoTab = document.querySelector('#mobile-tabs [data-tab="video"]');
   const extLink = document.getElementById('stream-external-link');
+  state.hasVideoStream = Boolean(embedUrl);
 
   if (embedUrl) {
     const iframe = document.getElementById('youtube-stream-iframe');
@@ -264,6 +266,10 @@ function setupVideoPanel() {
   } else {
     els.videoPanel?.classList.add('hidden');
     if (videoTab) videoTab.classList.add('hidden');
+    if (extLink) {
+      extLink.classList.add('hidden');
+      extLink.removeAttribute('href');
+    }
     if (state.activeTab === 'video') state.activeTab = 'plays';
   }
 }

--- a/js/live-stream-utils.js
+++ b/js/live-stream-utils.js
@@ -1,0 +1,43 @@
+export function normalizeYouTubeEmbedUrl(url) {
+    if (!url || typeof url !== 'string') return null;
+    const raw = url.trim();
+    if (!raw) return null;
+
+    try {
+        const parsed = new URL(raw);
+        parsed.searchParams.set('autoplay', '1');
+        parsed.searchParams.set('mute', '1');
+        return parsed.toString();
+    } catch {
+        const [beforeHash, hash = ''] = raw.split('#');
+        const queryIndex = beforeHash.indexOf('?');
+        const base = queryIndex >= 0 ? beforeHash.slice(0, queryIndex) : beforeHash;
+        const query = queryIndex >= 0 ? beforeHash.slice(queryIndex + 1) : '';
+        const params = new URLSearchParams(query);
+        params.set('autoplay', '1');
+        params.set('mute', '1');
+        const normalized = `${base}?${params.toString()}`;
+        return hash ? `${normalized}#${hash}` : normalized;
+    }
+}
+
+export function computePanelVisibility({ isMobile, activeTab, hasVideoStream }) {
+    if (!isMobile) {
+        return {
+            activeTab,
+            videoHidden: !hasVideoStream,
+            playsHidden: false,
+            statsHidden: false,
+            chatHidden: false
+        };
+    }
+
+    const safeActiveTab = activeTab === 'video' && !hasVideoStream ? 'plays' : activeTab;
+    return {
+        activeTab: safeActiveTab,
+        videoHidden: safeActiveTab !== 'video' || !hasVideoStream,
+        playsHidden: safeActiveTab !== 'plays',
+        statsHidden: safeActiveTab !== 'stats',
+        chatHidden: safeActiveTab !== 'chat'
+    };
+}

--- a/live-game.html
+++ b/live-game.html
@@ -257,12 +257,15 @@
           id="youtube-stream-iframe"
           class="w-full aspect-video md:aspect-auto md:flex-1 rounded-xl"
           src=""
-          title="YouTube Live Stream"
+          title="Live Stream"
           frameborder="0"
           allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
           referrerpolicy="strict-origin-when-cross-origin"
           allowfullscreen
         ></iframe>
+        <a id="stream-external-link" href="#" target="_blank" rel="noopener noreferrer"
+          class="hidden mt-1 text-xs text-center text-sand/50 hover:text-sand/80 transition">
+        </a>
       </section>
 
       <!-- STATS (right sidebar) -->

--- a/live-game.html
+++ b/live-game.html
@@ -220,6 +220,7 @@
   <!-- MOBILE TABS -->
   <nav id="mobile-tabs" class="bg-ink border-b border-teal/20 md:hidden">
     <div class="flex">
+      <button data-tab="video" class="hidden flex-1 py-3 text-sm font-medium text-sand/50 border-b-2 border-transparent">&#127909; Video</button>
       <button data-tab="plays" class="flex-1 py-3 text-sm font-medium text-teal border-b-2 border-teal">Plays</button>
       <button data-tab="stats" class="flex-1 py-3 text-sm font-medium text-sand/50 border-b-2 border-transparent">Stats</button>
       <button data-tab="chat" class="flex-1 py-3 text-sm font-medium text-sand/50 border-b-2 border-transparent relative">
@@ -231,82 +232,108 @@
 
   <!-- MAIN CONTENT -->
   <main class="max-w-6xl mx-auto px-4 py-4 pb-24">
-    <div class="md:grid md:grid-cols-3 md:gap-6">
-      <!-- PLAY-BY-PLAY -->
-      <section id="plays-panel" class="md:col-span-2">
-        <h2 class="text-teal font-medium mb-3 flex items-center gap-2">
-          <span class="text-lg">&#9654;</span>
+
+    <!--
+      DESKTOP: 3-col layout [Plays | Video | Stats] in a fixed-height row.
+      Grid uses 4 columns so video (col-span-2) gets twice the width of each sidebar.
+      MOBILE: each section is a tab-controlled panel.
+    -->
+    <div class="md:grid md:grid-cols-4 md:gap-4 md:h-[52vh] mb-6">
+
+      <!-- PLAY-BY-PLAY (left sidebar) -->
+      <section id="plays-panel" class="md:col-span-1 md:flex md:flex-col md:overflow-hidden">
+        <h2 class="text-teal font-medium mb-2 flex items-center gap-2 shrink-0">
+          <span>&#9654;</span>
           Play-by-Play
         </h2>
-        <div id="plays-feed" class="space-y-2 max-h-[60vh] overflow-y-auto">
+        <div id="plays-feed" class="space-y-2 overflow-y-auto flex-1 pr-1">
           <div data-placeholder="plays" class="text-center text-sand/40 py-8">Waiting for game to start...</div>
         </div>
       </section>
 
-      <!-- STATS PANEL -->
-      <section id="stats-panel" class="hidden md:block">
-        <h2 class="text-teal font-medium mb-3 flex items-center gap-2">
-          <span class="text-lg">&#9205;</span>
+      <!-- VIDEO (center, double-wide) -->
+      <section id="video-panel" class="hidden md:flex md:col-span-2 md:flex-col md:overflow-hidden">
+        <iframe
+          id="youtube-stream-iframe"
+          class="w-full aspect-video md:aspect-auto md:flex-1 rounded-xl"
+          src=""
+          title="YouTube Live Stream"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          referrerpolicy="strict-origin-when-cross-origin"
+          allowfullscreen
+        ></iframe>
+      </section>
+
+      <!-- STATS (right sidebar) -->
+      <section id="stats-panel" class="hidden md:flex md:col-span-1 md:flex-col md:overflow-hidden">
+        <h2 class="text-teal font-medium mb-2 flex items-center gap-2 shrink-0">
+          <span>&#9205;</span>
           Player Stats
         </h2>
-        <div class="mb-4">
-          <div class="text-teal/70 text-xs uppercase tracking-[0.2em]">Lineup</div>
-          <div class="mt-2">
-            <div class="text-sand/60 text-xs mb-2">On Court</div>
+        <div class="overflow-y-auto flex-1 pr-1 space-y-4">
+          <div>
+            <div class="text-teal/70 text-xs uppercase tracking-[0.2em] mb-2">Lineup</div>
+            <div class="text-sand/60 text-xs mb-1">On Court</div>
             <div id="lineup-oncourt" class="grid grid-cols-1 gap-2"></div>
-          </div>
-          <div class="mt-3">
-            <div class="text-sand/60 text-xs mb-2">Bench</div>
+            <div class="text-sand/60 text-xs mt-3 mb-1">Bench</div>
             <div id="lineup-bench" class="grid grid-cols-1 gap-2"></div>
           </div>
-        </div>
-        <div id="stats-list" class="hidden"></div>
-        <div class="mt-4">
-          <div class="text-teal/70 text-sm mb-2">Opponent Stats</div>
-          <div id="opponent-stats" class="space-y-2"></div>
+          <div id="stats-list" class="hidden"></div>
+          <div>
+            <div class="text-teal/70 text-sm mb-2">Opponent Stats</div>
+            <div id="opponent-stats" class="space-y-2"></div>
+          </div>
         </div>
       </section>
 
-      <!-- CHAT PANEL -->
-      <section id="chat-panel" class="hidden md:block md:col-span-3 lg:col-span-1">
-        <h2 class="text-teal font-medium mb-3 flex items-center gap-2">
-          <span class="text-lg">&#128172;</span>
-          Live Chat
-        </h2>
-        <div id="chat-container" class="bg-slate/50 rounded-lg border border-teal/20">
-          <div id="chat-messages" class="h-64 overflow-y-auto p-3 space-y-2"></div>
-          <form id="chat-form" class="p-3 border-t border-teal/20">
-            <div class="flex gap-2">
-              <div class="relative flex-1">
-                <input type="text" id="chat-input" placeholder="Send a message..." class="w-full bg-ink border border-teal/30 rounded-lg px-3 py-2 text-sand text-sm">
-                <div id="mention-menu" class="hidden absolute bottom-full left-0 mb-2 w-48 bg-slate border border-teal/30 rounded-lg shadow-lg overflow-hidden">
-                  <button type="button" id="mention-allplays" class="w-full text-left px-3 py-2 hover:bg-ink/70 flex items-center gap-2">
-                    <span class="inline-flex items-center justify-center w-7 h-7 rounded-full bg-teal/20 text-teal font-bold text-xs">AP</span>
-                    <span class="text-sm font-medium text-sand">@ALL PLAYS</span>
-                  </button>
-                </div>
-              </div>
-              <button type="submit" class="bg-teal text-ink px-4 py-2 rounded-lg font-medium text-sm">Send</button>
-            </div>
-            <p id="chat-anon-notice" class="hidden text-sand/40 text-xs mt-2 flex items-center gap-2">
-              Chatting as <span id="anon-name">Fan1234</span>
-              <button id="anon-change-btn" type="button" class="text-teal/80 hover:text-teal text-xs underline">Change name</button>
-            </p>
-            <div id="anon-edit" class="hidden mt-2 flex gap-2">
-              <input type="text" id="anon-input" class="flex-1 bg-ink border border-teal/30 rounded-lg px-3 py-2 text-sand text-xs" placeholder="Enter a display name" maxlength="20">
-              <button id="anon-save" type="button" class="bg-teal text-ink px-3 py-2 rounded-lg text-xs font-medium">Save</button>
-              <button id="anon-cancel" type="button" class="bg-slate text-sand px-3 py-2 rounded-lg text-xs font-medium">Cancel</button>
-            </div>
-            <div id="ai-thinking" class="hidden mt-2 text-xs text-teal/80 flex items-center gap-2">
-              <div class="animate-spin rounded-full h-3 w-3 border-b-2 border-teal"></div>
-              <span>ALL PLAYS is thinking...</span>
-            </div>
-            <p class="mt-2 text-sand/40 text-[11px]">Tip: tag <span class="text-teal font-semibold">@ALL PLAYS</span> to ask the live assistant.</p>
-            <p id="chat-locked-notice" class="hidden mt-2 text-xs text-coral">Chat is disabled until game time.</p>
-          </form>
-        </div>
-      </section>
     </div>
+
+    <!-- CHAT PANEL — full width, normal top-messages / bottom-input layout -->
+    <section id="chat-panel" class="hidden md:block">
+      <h2 class="text-teal font-medium mb-3 flex items-center gap-2">
+        <span class="text-lg">&#128172;</span>
+        Live Chat
+      </h2>
+      <div id="chat-container" class="bg-slate/50 rounded-lg border border-teal/20 flex flex-col">
+
+        <!-- Messages on top -->
+        <div id="chat-messages" class="h-36 overflow-y-auto p-3 space-y-2"></div>
+
+        <!-- Input on bottom -->
+        <form id="chat-form" class="p-3 border-t border-teal/20">
+          <div class="flex gap-2">
+            <div class="relative flex-1">
+              <input type="text" id="chat-input" placeholder="Send a message..." class="w-full bg-ink border border-teal/30 rounded-lg px-3 py-2 text-sand text-sm">
+              <div id="mention-menu" class="hidden absolute bottom-full left-0 mb-2 w-48 bg-slate border border-teal/30 rounded-lg shadow-lg overflow-hidden">
+                <button type="button" id="mention-allplays" class="w-full text-left px-3 py-2 hover:bg-ink/70 flex items-center gap-2">
+                  <span class="inline-flex items-center justify-center w-7 h-7 rounded-full bg-teal/20 text-teal font-bold text-xs">AP</span>
+                  <span class="text-sm font-medium text-sand">@ALL PLAYS</span>
+                </button>
+              </div>
+            </div>
+            <button type="submit" class="bg-teal text-ink px-4 py-2 rounded-lg font-medium text-sm">Send</button>
+          </div>
+          <p id="chat-anon-notice" class="hidden text-sand/40 text-xs mt-2 flex items-center gap-2">
+            Chatting as <span id="anon-name">Fan1234</span>
+            <button id="anon-change-btn" type="button" class="text-teal/80 hover:text-teal text-xs underline">Change name</button>
+          </p>
+          <div id="anon-edit" class="hidden mt-2 flex gap-2">
+            <input type="text" id="anon-input" class="flex-1 bg-ink border border-teal/30 rounded-lg px-3 py-2 text-sand text-xs" placeholder="Enter a display name" maxlength="20">
+            <button id="anon-save" type="button" class="bg-teal text-ink px-3 py-2 rounded-lg text-xs font-medium">Save</button>
+            <button id="anon-cancel" type="button" class="bg-slate text-sand px-3 py-2 rounded-lg text-xs font-medium">Cancel</button>
+          </div>
+          <div id="ai-thinking" class="hidden mt-2 text-xs text-teal/80 flex items-center gap-2">
+            <div class="animate-spin rounded-full h-3 w-3 border-b-2 border-teal"></div>
+            <span>ALL PLAYS is thinking...</span>
+          </div>
+          <p class="mt-2 text-sand/40 text-[11px]">Tip: tag <span class="text-teal font-semibold">@ALL PLAYS</span> to ask the live assistant.</p>
+          <p id="chat-locked-notice" class="hidden mt-2 text-xs text-coral">Chat is disabled until game time.</p>
+        </form>
+
+      </div>
+    </section>
+
   </main>
 
   <!-- REACTIONS BAR -->

--- a/spec/live-streaming/notes.md
+++ b/spec/live-streaming/notes.md
@@ -1,0 +1,150 @@
+# Live Streaming — Research Notes
+
+**Status:** Research complete. Next step: implement Twitch as Phase 1.
+**Last updated:** 2026-03-01
+
+---
+
+## The Problem
+
+Browsers cannot speak RTMP (the protocol streaming platforms require). This means going live from the ALL PLAYS web app always needs either:
+- A server in the middle (browser → WebSocket → server → RTMP → platform), OR
+- Handing off to a native app (YouTube app, OBS, Streamlabs, etc.)
+
+ALL PLAYS is a static GitHub Pages app (`allplays.ai`). No backend today.
+
+---
+
+## Platform Comparison
+
+### Social Platforms
+
+| Platform | Go Live Requirement | RTMP Support | Embeddable | Notes |
+|---|---|---|---|---|
+| **Twitch** | **None** | ✅ | ✅ (`parent` param) | Best option — zero barrier |
+| **YouTube** | 50 subs (mobile only) | ✅ bypasses it | ✅ iframe | Already built for viewer side |
+| **Facebook Live** | **None** | ✅ | ✅ (login sometimes required) | Parents likely have accounts |
+| Instagram Live | 1,000 followers | ❌ | ❌ | Not viable |
+| TikTok Live | 1,000 followers | ❌ | ❌ | Not viable |
+
+### Managed / Infrastructure Services
+
+| Service | Cost | Follower Req | Latency | Notes |
+|---|---|---|---|---|
+| **AWS IVS** | ~$0.002/min streamed | None | <3s | Twitch-built tech, lowest latency, best long-term |
+| **Mux** | ~$0.006/min | None | ~5–10s | Best developer SDK, WebRTC built-in |
+| **Cloudflare Stream** | $1/1,000 min delivered | None | ~10s | Simple pricing, already in Cloudflare ecosystem |
+| Dacast / BoxCast | $25–100/mo flat | None | ~10s | Sports-focused, white-label |
+
+---
+
+## Why Twitch Wins for Phase 1 (Free / No Requirements)
+
+- **Zero follower/subscriber requirement** — anyone can stream immediately
+- **Free** — no cost to stream or embed
+- **RTMP support** — bypasses any mobile restrictions, no platform subscriber checks
+- **Embeddable via iframe** — confirmed via Twitch Developer docs
+- **`parent` domain requirement** — must match host domain. Ours is `allplays.ai`. ✅
+- **HTTPS required** — GitHub Pages + custom domain = HTTPS. ✅
+- **Localhost works** — `parent=localhost` accepted for dev/testing. ✅
+
+### Twitch Embed Format
+```html
+<iframe
+  src="https://player.twitch.tv/?channel=CHANNEL_NAME&parent=allplays.ai"
+  frameborder="0"
+  allowfullscreen
+  width="100%"
+  height="100%">
+</iframe>
+```
+
+The `channel` value = the Twitch username the team sets up. Stored on the team doc same as `youtubeEmbedUrl`.
+
+### Known Twitch Limitations
+- Stream is public — anyone on Twitch can find it
+- Branding is Twitch (purple, Twitch logo in player)
+- Coach needs a Twitch account and stream key
+- No private/unlisted streams on free tier
+
+---
+
+## Going Live — What the Coach Does Today (Before We Build Anything)
+
+1. Create a free Twitch account at twitch.tv
+2. Get stream key: Twitch Dashboard → Settings → Stream → Primary Stream Key
+3. Download a free RTMP app: **Streamlabs** (mobile) or **OBS** (desktop)
+4. Paste stream key into the app, go live
+5. Paste their Twitch channel URL into ALL PLAYS team settings
+6. ALL PLAYS embeds the stream for fans automatically during live games
+
+No server needed. No follower count. No cost.
+
+---
+
+## Long-Term Path (When We Want "Go Live" Button in the App)
+
+Going live from the browser requires a server for WebRTC → RTMP transcoding.
+
+### Recommended Architecture
+```
+Phone Camera
+  ↓
+Browser (getUserMedia + MediaRecorder)
+  ↓  WebSocket chunks
+Server (Node + FFmpeg)  ← EC2 t3.small ~$15/mo OR Google Cloud Run
+  ↓  RTMP
+Twitch / YouTube / Facebook / AWS IVS
+  ↓
+Fans watch in ALL PLAYS (embedded iframe)
+```
+
+### Server Options
+| Option | Cost | Complexity | Notes |
+|---|---|---|---|
+| EC2 t3.small + NGINX-RTMP | ~$15/mo | Medium | Always-on, handles multiple streams |
+| Google Cloud Run + FFmpeg | Pay-per-use | Medium | Stays in Firebase ecosystem |
+| AWS IVS (fully managed) | ~$0.002/min | Low | Purpose-built, handles everything |
+| Mux | ~$0.006/min | Very Low | Best SDK, easiest to integrate |
+
+### Firebase Cloud Functions — NOT viable for streaming
+Cloud Functions time out (max ~9 min). A live game runs 1–2 hours. Not suitable for long-running RTMP processes.
+
+---
+
+## Multi-Platform Option (Future)
+
+Coach picks destination when going live:
+- ALL PLAYS Native (AWS IVS / Mux) — private, branded
+- YouTube — public, familiar
+- Twitch — public, free
+- Facebook — public, parents likely have accounts
+
+All use the same server/browser pipeline. Only the RTMP destination URL changes.
+
+---
+
+## What's Already Built
+
+- `team.youtubeEmbedUrl` field on team doc — stores embed URL (supports video ID and channel ID)
+- `setupVideoPanel()` in `live-game.js` — shows/hides video panel based on team data
+- YouTube live stream embed in `live-game.html` — 3-column desktop layout (plays | video | stats)
+- Team settings field in `edit-team.html` — paste any YouTube URL or channel ID
+
+## What Needs to Be Built for Twitch (Phase 1)
+
+- Add `twitchChannel` field to team doc (just the username string)
+- Update `edit-team.html` to accept a Twitch channel URL/username
+- Update `setupVideoPanel()` to generate correct embed URL for Twitch vs YouTube
+- `parent=allplays.ai` must be in the Twitch embed URL
+
+---
+
+## References
+
+- [Twitch Embedding Docs](https://dev.twitch.tv/docs/embed/)
+- [YouTube Live Streaming API](https://developers.google.com/youtube/v3/live/getting-started)
+- [Mux: State of Going Live from Browser](https://www.mux.com/blog/the-state-of-going-live-from-a-browser)
+- [AWS IVS Alternatives](https://getstream.io/blog/amazon-ivs-alternatives/)
+- [Live Streaming Requirements by Platform](https://switchboard.live/blog/live-streaming-requirements-for-going-live-on-social-platforms)
+- [RTMP Bypasses YouTube Mobile Subscriber Limit](https://ottverse.com/stream-to-youtube-live-from-mobile-without-1000-subscribers/)

--- a/team.html
+++ b/team.html
@@ -340,6 +340,28 @@
             return `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(locationText)}`;
         }
 
+        function streamLinkHtml(team) {
+            if (team.twitchChannel) {
+                return `<a class="inline-flex items-center gap-1 text-sm text-purple-600 hover:text-purple-700 font-medium transition" target="_blank" rel="noopener noreferrer" href="https://twitch.tv/${encodeURIComponent(team.twitchChannel)}">
+                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
+                    Watch on Twitch
+                </a>`;
+            }
+            const embedUrl = team.streamEmbedUrl || team.youtubeEmbedUrl;
+            if (embedUrl) {
+                const channelMatch = embedUrl.match(/channel=(UC[a-zA-Z0-9_-]{22})/);
+                const videoMatch = embedUrl.match(/\/embed\/([a-zA-Z0-9_-]{11})/);
+                const url = channelMatch
+                    ? `https://www.youtube.com/channel/${channelMatch[1]}`
+                    : videoMatch ? `https://www.youtube.com/watch?v=${videoMatch[1]}` : null;
+                if (url) return `<a class="inline-flex items-center gap-1 text-sm text-red-500 hover:text-red-600 font-medium transition" target="_blank" rel="noopener noreferrer" href="${url}">
+                    <svg class="w-4 h-4" fill="currentColor" viewBox="0 0 24 24"><path d="M8 5v14l11-7z"/></svg>
+                    Watch on YouTube
+                </a>`;
+            }
+            return '';
+        }
+
         function toDateSafe(value) {
             if (!value) return null;
             const d = value?.toDate ? value.toDate() : new Date(value);
@@ -682,6 +704,7 @@
                                     </a>`
                         : ''
                     }
+                                ${streamLinkHtml(team)}
                             </div>
                             ${team.description ? `<p class="text-gray-600 leading-relaxed">${escapeHtml(team.description)}</p>` : ''}
                         </div>

--- a/test-youtube-stream.html
+++ b/test-youtube-stream.html
@@ -1,0 +1,320 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Test Suite - Stream URL Parser</title>
+    <style>
+        body { font-family: monospace; padding: 20px; background: #f5f5f5; }
+        .test-section { background: white; margin: 20px 0; padding: 20px; border-radius: 8px; box-shadow: 0 1px 3px rgba(0,0,0,0.1); }
+        .test-case { margin: 10px 0; padding: 10px; border-left: 4px solid #ccc; }
+        .pass { border-left-color: #22c55e; background: #f0fdf4; }
+        .fail { border-left-color: #ef4444; background: #fef2f2; }
+        .test-name { font-weight: bold; margin-bottom: 5px; }
+        .test-detail { font-size: 0.85em; color: #555; margin-top: 4px; }
+        .test-error { font-size: 0.85em; color: #b91c1c; margin-top: 4px; }
+        h2 { color: #4338ca; margin-bottom: 4px; }
+        .summary { font-size: 1.1em; font-weight: bold; padding: 12px 16px; border-radius: 6px; margin-bottom: 20px; }
+        .summary.all-pass { background: #dcfce7; color: #15803d; }
+        .summary.has-fail { background: #fee2e2; color: #991b1b; }
+    </style>
+</head>
+<body>
+    <h1>🧪 Stream URL Parser Test Suite</h1>
+    <p>Tests for <code>parseStreamUrl()</code> (YouTube + Twitch) and <code>setupVideoPanel()</code> visibility logic.</p>
+
+    <div id="summary"></div>
+    <div id="test-results"></div>
+
+    <script>
+        // ─── Test harness ───────────────────────────────────────────────────────────
+        const results = [];
+
+        function test(name, fn) {
+            try {
+                fn();
+                results.push({ name, pass: true, detail: null, error: null });
+            } catch (e) {
+                results.push({ name, pass: false, detail: null, error: e.message });
+            }
+        }
+
+        function assertEquals(actual, expected, label) {
+            if (actual !== expected) {
+                throw new Error(`${label || ''}\n  Expected: ${JSON.stringify(expected)}\n  Got:      ${JSON.stringify(actual)}`);
+            }
+        }
+
+        function assertNull(actual, label) {
+            if (actual !== null) throw new Error(`${label || ''} — expected null, got ${JSON.stringify(actual)}`);
+        }
+
+        function assertContains(str, substr, label) {
+            if (!str || !str.includes(substr)) {
+                throw new Error(`${label || ''}\n  Expected "${str}" to contain "${substr}"`);
+            }
+        }
+
+        // ─── Function under test (copied from edit-team.html) ───────────────────────
+        function parseStreamUrl(input) {
+            if (!input) return null;
+            const str = input.trim();
+
+            // Extract src from a pasted <iframe> embed code
+            const iframeSrc = str.match(/src="([^"]+)"/);
+            const url = iframeSrc ? iframeSrc[1] : str;
+
+            // ── TWITCH ──────────────────────────────────────────────────────────
+            // Matches: twitch.tv/channel  or  player.twitch.tv/?channel=name
+            const twitchMatch = url.match(/(?:(?:www\.)?twitch\.tv\/|player\.twitch\.tv\/\?.*channel=)([a-zA-Z0-9_]{1,25})/);
+            if (twitchMatch) {
+                return { platform: 'twitch', twitchChannel: twitchMatch[1].toLowerCase() };
+            }
+
+            // ── YOUTUBE ─────────────────────────────────────────────────────────
+            // Already a YouTube embed URL — normalize params
+            if (url.includes('youtube.com/embed/')) {
+                return { platform: 'youtube', streamEmbedUrl: url.split('?')[0] + '?autoplay=1&mute=1' };
+            }
+            // Raw channel ID (UC + 22 chars)
+            if (/^UC[a-zA-Z0-9_-]{22}$/.test(url)) {
+                return { platform: 'youtube', streamEmbedUrl: `https://www.youtube.com/embed/live_stream?channel=${url}&autoplay=1&mute=1` };
+            }
+            // youtube.com/channel/UCxxxxxxxxxx
+            const channelMatch = url.match(/youtube\.com\/channel\/(UC[a-zA-Z0-9_-]{22})/);
+            if (channelMatch) {
+                return { platform: 'youtube', streamEmbedUrl: `https://www.youtube.com/embed/live_stream?channel=${channelMatch[1]}&autoplay=1&mute=1` };
+            }
+            // Path-based video ID: /live/ID, /embed/ID, youtu.be/ID
+            const pathMatch = url.match(/(?:youtube\.com\/(?:live|embed)\/|youtu\.be\/)([a-zA-Z0-9_-]{11})/);
+            // Query-based video ID: ?v=ID or &v=ID
+            const queryMatch = url.match(/[?&]v=([a-zA-Z0-9_-]{11})/);
+            const videoId = (pathMatch && pathMatch[1]) || (queryMatch && queryMatch[1]);
+            if (videoId) {
+                return { platform: 'youtube', streamEmbedUrl: `https://www.youtube.com/embed/${videoId}?autoplay=1&mute=1` };
+            }
+
+            return null;
+        }
+
+        // ─── SUITE 1: parseStreamUrl — YouTube video URLs ──────────────────────────
+
+        test('YouTube video: youtube.com/live/ID', () => {
+            const result = parseStreamUrl('https://www.youtube.com/live/LJNfHqRRhBI?si=abc');
+            assertEquals(result.platform, 'youtube', 'platform');
+            assertEquals(result.streamEmbedUrl, 'https://www.youtube.com/embed/LJNfHqRRhBI?autoplay=1&mute=1', 'embed URL');
+        });
+
+        test('YouTube video: youtube.com/watch?v=ID', () => {
+            const result = parseStreamUrl('https://www.youtube.com/watch?v=LJNfHqRRhBI');
+            assertEquals(result.platform, 'youtube', 'platform');
+            assertEquals(result.streamEmbedUrl, 'https://www.youtube.com/embed/LJNfHqRRhBI?autoplay=1&mute=1', 'embed URL');
+        });
+
+        test('YouTube video: youtu.be/ID (short link)', () => {
+            const result = parseStreamUrl('https://youtu.be/LJNfHqRRhBI');
+            assertEquals(result.platform, 'youtube', 'platform');
+            assertEquals(result.streamEmbedUrl, 'https://www.youtube.com/embed/LJNfHqRRhBI?autoplay=1&mute=1', 'embed URL');
+        });
+
+        test('YouTube video: watch URL with extra params', () => {
+            const result = parseStreamUrl('https://www.youtube.com/watch?v=LJNfHqRRhBI&t=30s&feature=share');
+            assertContains(result.streamEmbedUrl, 'LJNfHqRRhBI', 'extracts ID from URL with extra params');
+        });
+
+        test('YouTube video: full <iframe> embed code', () => {
+            const iframe = `<iframe width="560" height="315" src="https://www.youtube.com/embed/LJNfHqRRhBI?si=xyz" title="YouTube video player" frameborder="0" allowfullscreen></iframe>`;
+            const result = parseStreamUrl(iframe);
+            assertEquals(result.platform, 'youtube', 'platform');
+            assertEquals(result.streamEmbedUrl, 'https://www.youtube.com/embed/LJNfHqRRhBI?autoplay=1&mute=1', 'embed URL from iframe');
+        });
+
+        test('YouTube video: embed URL already — strips old params, adds autoplay+mute', () => {
+            const result = parseStreamUrl('https://www.youtube.com/embed/LJNfHqRRhBI?si=old&controls=0');
+            assertEquals(result.platform, 'youtube', 'platform');
+            assertEquals(result.streamEmbedUrl, 'https://www.youtube.com/embed/LJNfHqRRhBI?autoplay=1&mute=1', 'normalises existing embed URL');
+        });
+
+        // ─── SUITE 2: parseStreamUrl — YouTube channel IDs ────────────────────────
+
+        test('YouTube channel: raw Channel ID (UCa9ghvbup6VQmnDOdqwYpqQ)', () => {
+            const result = parseStreamUrl('UCa9ghvbup6VQmnDOdqwYpqQ');
+            assertEquals(result.platform, 'youtube', 'platform');
+            assertEquals(result.streamEmbedUrl,
+                'https://www.youtube.com/embed/live_stream?channel=UCa9ghvbup6VQmnDOdqwYpqQ&autoplay=1&mute=1',
+                'embed URL');
+        });
+
+        test('YouTube channel: youtube.com/channel/UCxxxxxxxxxx URL', () => {
+            const result = parseStreamUrl('https://www.youtube.com/channel/UCa9ghvbup6VQmnDOdqwYpqQ');
+            assertEquals(result.platform, 'youtube', 'platform');
+            assertEquals(result.streamEmbedUrl,
+                'https://www.youtube.com/embed/live_stream?channel=UCa9ghvbup6VQmnDOdqwYpqQ&autoplay=1&mute=1',
+                'embed URL');
+        });
+
+        test('YouTube channel: embed URL uses live_stream endpoint', () => {
+            const result = parseStreamUrl('UCa9ghvbup6VQmnDOdqwYpqQ');
+            assertContains(result.streamEmbedUrl, 'live_stream', 'uses live_stream embed endpoint');
+            assertContains(result.streamEmbedUrl, 'channel=UCa9ghvbup6VQmnDOdqwYpqQ', 'includes channel param');
+        });
+
+        // ─── SUITE 3: parseStreamUrl — Twitch URLs ─────────────────────────────────
+
+        test('Twitch: twitch.tv/username', () => {
+            const result = parseStreamUrl('twitch.tv/mychannelname');
+            assertEquals(result.platform, 'twitch', 'platform');
+            assertEquals(result.twitchChannel, 'mychannelname', 'channel name');
+        });
+
+        test('Twitch: https://www.twitch.tv/username', () => {
+            const result = parseStreamUrl('https://www.twitch.tv/allplayslive');
+            assertEquals(result.platform, 'twitch', 'platform');
+            assertEquals(result.twitchChannel, 'allplayslive', 'channel name');
+        });
+
+        test('Twitch: channel name is lowercased', () => {
+            const result = parseStreamUrl('https://twitch.tv/MyTeamChannel');
+            assertEquals(result.platform, 'twitch', 'platform');
+            assertEquals(result.twitchChannel, 'myteamchannel', 'lowercased');
+        });
+
+        test('Twitch: player.twitch.tv embed URL', () => {
+            const result = parseStreamUrl('https://player.twitch.tv/?channel=mychannelname&parent=allplays.ai');
+            assertEquals(result.platform, 'twitch', 'platform');
+            assertEquals(result.twitchChannel, 'mychannelname', 'channel from player URL');
+        });
+
+        // ─── SUITE 4: parseStreamUrl — null / unresolvable inputs ─────────────────
+
+        test('null: empty string returns null', () => {
+            assertNull(parseStreamUrl(''), 'empty string');
+        });
+
+        test('null: null input returns null', () => {
+            assertNull(parseStreamUrl(null), 'null input');
+        });
+
+        test('null: @handle URL returns null (not resolvable without API)', () => {
+            assertNull(parseStreamUrl('https://youtube.com/@pauljsnider?si=jEP5BI9XDQoo1jth'),
+                '@handle URL');
+        });
+
+        test('null: random URL returns null', () => {
+            assertNull(parseStreamUrl('https://example.com/video'), 'random URL');
+        });
+
+        test('null: garbage string returns null', () => {
+            assertNull(parseStreamUrl('not a url at all'), 'garbage string');
+        });
+
+        // ─── SUITE 5: autoplay + mute always present in YouTube embeds ────────────
+
+        test('YouTube params: video embed always has autoplay=1', () => {
+            const result = parseStreamUrl('https://youtu.be/LJNfHqRRhBI');
+            assertContains(result.streamEmbedUrl, 'autoplay=1', 'video embed has autoplay');
+        });
+
+        test('YouTube params: video embed always has mute=1', () => {
+            const result = parseStreamUrl('https://youtu.be/LJNfHqRRhBI');
+            assertContains(result.streamEmbedUrl, 'mute=1', 'video embed has mute');
+        });
+
+        test('YouTube params: channel embed always has autoplay=1', () => {
+            const result = parseStreamUrl('UCa9ghvbup6VQmnDOdqwYpqQ');
+            assertContains(result.streamEmbedUrl, 'autoplay=1', 'channel embed has autoplay');
+        });
+
+        test('YouTube params: channel embed always has mute=1', () => {
+            const result = parseStreamUrl('UCa9ghvbup6VQmnDOdqwYpqQ');
+            assertContains(result.streamEmbedUrl, 'mute=1', 'channel embed has mute');
+        });
+
+        // ─── SUITE 6: setupVideoPanel logic (DOM simulation) ──────────────────────
+
+        test('visibility: video panel hidden when no stream on team', () => {
+            const panel = { classList: { _h: true, add(c) { this._h = true; }, remove(c) { this._h = false; } } };
+            const tab   = { classList: { _h: true, add(c) { this._h = true; }, remove(c) { this._h = false; } } };
+            const team = {}; // no twitchChannel, no streamEmbedUrl, no youtubeEmbedUrl
+
+            const embedUrl = team.twitchChannel ? 'TWITCH' :
+                (team.streamEmbedUrl || team.youtubeEmbedUrl ||
+                 (team.youtubeVideoId ? `https://www.youtube.com/embed/${team.youtubeVideoId}?autoplay=1&mute=1` : null));
+
+            if (!embedUrl) {
+                panel.classList.add('hidden');
+                tab.classList.add('hidden');
+            }
+
+            if (!panel.classList._h) throw new Error('video panel should be hidden when team has no stream');
+            if (!tab.classList._h) throw new Error('video tab should be hidden when team has no stream');
+        });
+
+        test('visibility: video panel shown when team has streamEmbedUrl (YouTube)', () => {
+            let iframeSrc = '';
+            const iframe = { set src(v) { iframeSrc = v; } };
+            const tab = { classList: { _h: true, remove(c) { this._h = false; } } };
+            const team = { streamEmbedUrl: 'https://www.youtube.com/embed/live_stream?channel=UCa9ghvbup6VQmnDOdqwYpqQ&autoplay=1&mute=1' };
+
+            const embedUrl = team.streamEmbedUrl;
+            if (embedUrl) {
+                iframe.src = embedUrl;
+                tab.classList.remove('hidden');
+            }
+
+            if (tab.classList._h) throw new Error('video tab should be visible when team has a stream');
+            assertContains(iframeSrc, 'live_stream', 'iframe src set to channel embed URL');
+        });
+
+        test('visibility: team with twitchChannel generates Twitch player URL', () => {
+            let iframeSrc = '';
+            const iframe = { set src(v) { iframeSrc = v; } };
+            const team = { twitchChannel: 'myteam' };
+
+            if (team.twitchChannel) {
+                iframe.src = `https://player.twitch.tv/?channel=${team.twitchChannel}&parent=localhost&autoplay=true&muted=true`;
+            }
+
+            assertContains(iframeSrc, 'player.twitch.tv', 'uses Twitch player URL');
+            assertContains(iframeSrc, 'channel=myteam', 'includes channel param');
+            assertContains(iframeSrc, 'parent=localhost', 'includes parent param');
+        });
+
+        // ─── Render results ────────────────────────────────────────────────────────
+
+        const passed = results.filter(r => r.pass).length;
+        const failed = results.filter(r => !r.pass).length;
+
+        const summaryEl = document.getElementById('summary');
+        summaryEl.innerHTML = `<div class="summary ${failed === 0 ? 'all-pass' : 'has-fail'}">
+            ${failed === 0 ? '✅' : '❌'} ${passed} passed, ${failed} failed (${results.length} total)
+        </div>`;
+
+        // Group by suite
+        const suites = [
+            { label: 'Suite 1: YouTube video URL parsing', start: 0, count: 6 },
+            { label: 'Suite 2: YouTube channel ID parsing', start: 6, count: 3 },
+            { label: 'Suite 3: Twitch URL parsing', start: 9, count: 4 },
+            { label: 'Suite 4: Null / unresolvable inputs', start: 13, count: 5 },
+            { label: 'Suite 5: YouTube autoplay + mute params', start: 18, count: 4 },
+            { label: 'Suite 6: setupVideoPanel visibility logic', start: 22, count: 3 },
+        ];
+
+        const container = document.getElementById('test-results');
+        suites.forEach(suite => {
+            const section = document.createElement('div');
+            section.className = 'test-section';
+            section.innerHTML = `<h2>${suite.label}</h2>`;
+            const slice = results.slice(suite.start, suite.start + suite.count);
+            slice.forEach(r => {
+                section.innerHTML += `
+                    <div class="test-case ${r.pass ? 'pass' : 'fail'}">
+                        <div class="test-name">${r.pass ? '✅' : '❌'} ${r.name}</div>
+                        ${r.error ? `<div class="test-error"><pre>${r.error}</pre></div>` : ''}
+                    </div>`;
+            });
+            container.appendChild(section);
+        });
+    </script>
+</body>
+</html>

--- a/test-youtube-stream.html
+++ b/test-youtube-stream.html
@@ -404,13 +404,13 @@
         // Group by suite
         const suites = [
             { label: 'Suite 1: YouTube video URL parsing', start: 0, count: 6 },
-            { label: 'Suite 2: YouTube channel ID parsing', start: 6, count: 3 },
-            { label: 'Suite 3: Twitch URL parsing', start: 9, count: 4 },
-            { label: 'Suite 4: Null / unresolvable inputs', start: 13, count: 5 },
-            { label: 'Suite 5: YouTube autoplay + mute params', start: 18, count: 4 },
-            { label: 'Suite 6: setupVideoPanel visibility logic', start: 22, count: 3 },
-            { label: 'Suite 7: streamLinkHtml() — Watch Live link (team page)', start: 25, count: 6 },
-            { label: 'Suite 8: setupVideoPanel public URL resolution', start: 31, count: 5 },
+            { label: 'Suite 2: YouTube channel ID parsing + embed normalization', start: 6, count: 4 },
+            { label: 'Suite 3: Twitch URL parsing', start: 10, count: 4 },
+            { label: 'Suite 4: Null / unresolvable inputs', start: 14, count: 5 },
+            { label: 'Suite 5: YouTube autoplay + mute params', start: 19, count: 4 },
+            { label: 'Suite 6: setupVideoPanel visibility logic', start: 23, count: 3 },
+            { label: 'Suite 7: streamLinkHtml() — Watch Live link (team page)', start: 26, count: 6 },
+            { label: 'Suite 8: setupVideoPanel public URL resolution', start: 32, count: 5 },
         ];
 
         const container = document.getElementById('test-results');

--- a/test-youtube-stream.html
+++ b/test-youtube-stream.html
@@ -55,6 +55,13 @@
             }
         }
 
+        function normalizeYouTubeEmbedUrl(url) {
+            const parsed = new URL(url);
+            parsed.searchParams.set('autoplay', '1');
+            parsed.searchParams.set('mute', '1');
+            return parsed.toString();
+        }
+
         // ─── Function under test (copied from edit-team.html) ───────────────────────
         function parseStreamUrl(input) {
             if (!input) return null;
@@ -74,7 +81,7 @@
             // ── YOUTUBE ─────────────────────────────────────────────────────────
             // Already a YouTube embed URL — normalize params
             if (url.includes('youtube.com/embed/')) {
-                return { platform: 'youtube', streamEmbedUrl: url.split('?')[0] + '?autoplay=1&mute=1' };
+                return { platform: 'youtube', streamEmbedUrl: normalizeYouTubeEmbedUrl(url) };
             }
             // Raw channel ID (UC + 22 chars)
             if (/^UC[a-zA-Z0-9_-]{22}$/.test(url)) {
@@ -129,10 +136,21 @@
             assertEquals(result.streamEmbedUrl, 'https://www.youtube.com/embed/LJNfHqRRhBI?autoplay=1&mute=1', 'embed URL from iframe');
         });
 
-        test('YouTube video: embed URL already — strips old params, adds autoplay+mute', () => {
+        test('YouTube video: embed URL already — preserves params and sets autoplay+mute', () => {
             const result = parseStreamUrl('https://www.youtube.com/embed/LJNfHqRRhBI?si=old&controls=0');
             assertEquals(result.platform, 'youtube', 'platform');
-            assertEquals(result.streamEmbedUrl, 'https://www.youtube.com/embed/LJNfHqRRhBI?autoplay=1&mute=1', 'normalises existing embed URL');
+            assertContains(result.streamEmbedUrl, 'controls=0', 'preserves existing params');
+            assertContains(result.streamEmbedUrl, 'autoplay=1', 'enforces autoplay');
+            assertContains(result.streamEmbedUrl, 'mute=1', 'enforces mute');
+        });
+
+        test('YouTube channel: embed URL keeps channel query while normalising', () => {
+            const result = parseStreamUrl('https://www.youtube.com/embed/live_stream?channel=UCa9ghvbup6VQmnDOdqwYpqQ&controls=0');
+            assertEquals(result.platform, 'youtube', 'platform');
+            assertContains(result.streamEmbedUrl, 'channel=UCa9ghvbup6VQmnDOdqwYpqQ', 'keeps required channel query');
+            assertContains(result.streamEmbedUrl, 'controls=0', 'preserves other query params');
+            assertContains(result.streamEmbedUrl, 'autoplay=1', 'enforces autoplay');
+            assertContains(result.streamEmbedUrl, 'mute=1', 'enforces mute');
         });
 
         // ─── SUITE 2: parseStreamUrl — YouTube channel IDs ────────────────────────

--- a/test-youtube-stream.html
+++ b/test-youtube-stream.html
@@ -280,6 +280,99 @@
             assertContains(iframeSrc, 'parent=localhost', 'includes parent param');
         });
 
+        // ─── Functions under test (copied from team.html / live-game.js) ────────────
+
+        function streamLinkHtml(team) {
+            if (team.twitchChannel) {
+                return `<a href="https://twitch.tv/${encodeURIComponent(team.twitchChannel)}" class="text-purple-600">Watch on Twitch</a>`;
+            }
+            const embedUrl = team.streamEmbedUrl || team.youtubeEmbedUrl;
+            if (embedUrl) {
+                const channelMatch = embedUrl.match(/channel=(UC[a-zA-Z0-9_-]{22})/);
+                const videoMatch = embedUrl.match(/\/embed\/([a-zA-Z0-9_-]{11})/);
+                const url = channelMatch
+                    ? `https://www.youtube.com/channel/${channelMatch[1]}`
+                    : videoMatch ? `https://www.youtube.com/watch?v=${videoMatch[1]}` : null;
+                if (url) return `<a href="${url}" class="text-red-500">Watch on YouTube</a>`;
+            }
+            return '';
+        }
+
+        function buildPublicStreamUrl(team) {
+            if (team.twitchChannel) {
+                return { publicUrl: `https://twitch.tv/${team.twitchChannel}`, publicLabel: 'Watch on Twitch ↗' };
+            }
+            const src = team.streamEmbedUrl || team.youtubeEmbedUrl ||
+                (team.youtubeVideoId ? `https://www.youtube.com/embed/${team.youtubeVideoId}?autoplay=1&mute=1` : null);
+            if (src) {
+                const channelMatch = src.match(/channel=(UC[a-zA-Z0-9_-]{22})/);
+                const videoMatch = src.match(/\/embed\/([a-zA-Z0-9_-]{11})/);
+                const publicUrl = channelMatch
+                    ? `https://www.youtube.com/channel/${channelMatch[1]}`
+                    : videoMatch ? `https://www.youtube.com/watch?v=${videoMatch[1]}` : null;
+                return { publicUrl, publicLabel: 'Watch on YouTube ↗' };
+            }
+            return { publicUrl: null, publicLabel: null };
+        }
+
+        // ─── SUITE 7: streamLinkHtml() — Watch Live link on team page ─────────────
+
+        test('streamLink Twitch: href points to twitch.tv/channel', () => {
+            const html = streamLinkHtml({ twitchChannel: 'pauljsnider' });
+            assertContains(html, 'https://twitch.tv/pauljsnider', 'href');
+        });
+
+        test('streamLink Twitch: label says Watch on Twitch', () => {
+            const html = streamLinkHtml({ twitchChannel: 'pauljsnider' });
+            assertContains(html, 'Watch on Twitch', 'label');
+        });
+
+        test('streamLink Twitch: has purple color class', () => {
+            const html = streamLinkHtml({ twitchChannel: 'pauljsnider' });
+            assertContains(html, 'purple', 'purple color class');
+        });
+
+        test('streamLink YouTube channel embed: href points to youtube.com/channel/UCxxx', () => {
+            const html = streamLinkHtml({ streamEmbedUrl: 'https://www.youtube.com/embed/live_stream?channel=UCa9ghvbup6VQmnDOdqwYpqQ&autoplay=1&mute=1' });
+            assertContains(html, 'https://www.youtube.com/channel/UCa9ghvbup6VQmnDOdqwYpqQ', 'href');
+        });
+
+        test('streamLink YouTube video embed: href points to youtube.com/watch?v=ID', () => {
+            const html = streamLinkHtml({ streamEmbedUrl: 'https://www.youtube.com/embed/LJNfHqRRhBI?autoplay=1&mute=1' });
+            assertContains(html, 'https://www.youtube.com/watch?v=LJNfHqRRhBI', 'href');
+        });
+
+        test('streamLink no stream: returns empty string', () => {
+            assertEquals(streamLinkHtml({}), '', 'empty team returns empty string');
+        });
+
+        // ─── SUITE 8: setupVideoPanel public URL resolution ────────────────────────
+
+        test('publicUrl Twitch: resolves to twitch.tv/channel', () => {
+            const { publicUrl } = buildPublicStreamUrl({ twitchChannel: 'pauljsnider' });
+            assertEquals(publicUrl, 'https://twitch.tv/pauljsnider', 'publicUrl');
+        });
+
+        test('publicUrl Twitch: label is Watch on Twitch ↗', () => {
+            const { publicLabel } = buildPublicStreamUrl({ twitchChannel: 'pauljsnider' });
+            assertEquals(publicLabel, 'Watch on Twitch ↗', 'publicLabel');
+        });
+
+        test('publicUrl YouTube channel embed: resolves to youtube.com/channel/UCxxx', () => {
+            const { publicUrl } = buildPublicStreamUrl({ streamEmbedUrl: 'https://www.youtube.com/embed/live_stream?channel=UCa9ghvbup6VQmnDOdqwYpqQ&autoplay=1&mute=1' });
+            assertEquals(publicUrl, 'https://www.youtube.com/channel/UCa9ghvbup6VQmnDOdqwYpqQ', 'publicUrl');
+        });
+
+        test('publicUrl YouTube video embed: resolves to youtube.com/watch?v=ID', () => {
+            const { publicUrl } = buildPublicStreamUrl({ streamEmbedUrl: 'https://www.youtube.com/embed/LJNfHqRRhBI?autoplay=1&mute=1' });
+            assertEquals(publicUrl, 'https://www.youtube.com/watch?v=LJNfHqRRhBI', 'publicUrl');
+        });
+
+        test('publicUrl legacy youtubeVideoId: resolves to youtube.com/watch?v=ID', () => {
+            const { publicUrl } = buildPublicStreamUrl({ youtubeVideoId: 'LJNfHqRRhBI' });
+            assertEquals(publicUrl, 'https://www.youtube.com/watch?v=LJNfHqRRhBI', 'legacy youtubeVideoId');
+        });
+
         // ─── Render results ────────────────────────────────────────────────────────
 
         const passed = results.filter(r => r.pass).length;
@@ -298,6 +391,8 @@
             { label: 'Suite 4: Null / unresolvable inputs', start: 13, count: 5 },
             { label: 'Suite 5: YouTube autoplay + mute params', start: 18, count: 4 },
             { label: 'Suite 6: setupVideoPanel visibility logic', start: 22, count: 3 },
+            { label: 'Suite 7: streamLinkHtml() — Watch Live link (team page)', start: 25, count: 6 },
+            { label: 'Suite 8: setupVideoPanel public URL resolution', start: 31, count: 5 },
         ];
 
         const container = document.getElementById('test-results');

--- a/tests/unit/live-stream-utils.test.js
+++ b/tests/unit/live-stream-utils.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { computePanelVisibility, normalizeYouTubeEmbedUrl } from '../../js/live-stream-utils.js';
+
+describe('live stream URL normalization', () => {
+    it('preserves channel query when normalizing live_stream embed URLs', () => {
+        const normalized = normalizeYouTubeEmbedUrl(
+            'https://www.youtube.com/embed/live_stream?channel=UCa9ghvbup6VQmnDOdqwYpqQ&controls=0'
+        );
+        expect(normalized).toContain('channel=UCa9ghvbup6VQmnDOdqwYpqQ');
+        expect(normalized).toContain('controls=0');
+        expect(normalized).toContain('autoplay=1');
+        expect(normalized).toContain('mute=1');
+    });
+});
+
+describe('video panel visibility', () => {
+    it('keeps desktop video panel hidden when no stream exists', () => {
+        const visibility = computePanelVisibility({
+            isMobile: false,
+            activeTab: 'plays',
+            hasVideoStream: false
+        });
+        expect(visibility.videoHidden).toBe(true);
+        expect(visibility.playsHidden).toBe(false);
+    });
+
+    it('routes mobile away from video tab when no stream exists', () => {
+        const visibility = computePanelVisibility({
+            isMobile: true,
+            activeTab: 'video',
+            hasVideoStream: false
+        });
+        expect(visibility.activeTab).toBe('plays');
+        expect(visibility.videoHidden).toBe(true);
+        expect(visibility.playsHidden).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

- **Single stream input** in team settings (`edit-team.html`): paste any YouTube or Twitch URL/channel ID — the field auto-detects the platform and shows a live badge as you type. Expandable _"What can I paste?"_ helper lists all accepted formats.
- **Unified data model**: saves `twitchChannel` (Twitch) or `streamEmbedUrl` (YouTube) to the team doc; clears the legacy `youtubeEmbedUrl` field on every save. Load logic reads the new fields with legacy fallback.
- **Live game page** (`live-game.html` + `live-game.js`): 3-column desktop layout (plays | video | stats) with mobile tab support. `setupVideoPanel()` builds the correct embed URL for Twitch (`player.twitch.tv/?channel=…&parent=HOSTNAME`) or YouTube, and adds an _"Watch on Twitch ↗"_ / _"Watch on YouTube ↗"_ fallback link below the player.
- **Team page** (`team.html`): _"Watch on Twitch"_ (purple) or _"Watch on YouTube"_ (red) badge appears in the team header alongside the zip/league links, only when a stream is configured.
- **Research notes** added at `spec/live-streaming/notes.md`: platform comparison, RTMP constraints, long-term architecture options.

## Accepted input formats

| Format | Platform |
|---|---|
| `twitch.tv/channel` or `https://www.twitch.tv/channel` | Twitch |
| `youtube.com/live/VIDEO_ID` | YouTube |
| `youtube.com/watch?v=VIDEO_ID` | YouTube |
| `youtu.be/VIDEO_ID` | YouTube |
| `UCa9ghvbup6VQmnDOdqwYpqQ` (raw Channel ID) | YouTube |
| `youtube.com/channel/UCxxxxxxx` | YouTube |
| Paste full `<iframe>` embed code | YouTube |

## Test plan

- [ ] Open `test-youtube-stream.html` — all **36/36 tests pass** across 8 suites
- [ ] In `edit-team.html`, paste `twitch.tv/pauljsnider` → badge shows **✅ Twitch channel detected: pauljsnider**
- [ ] Paste a YouTube live URL → badge shows **✅ YouTube stream detected**
- [ ] Save team, re-open edit page → field repopulates correctly
- [ ] On team page, verify **Watch on Twitch** (purple) / **Watch on YouTube** (red) link appears in header
- [ ] On live game page (desktop), verify 3-column layout with stream in center and **Watch on Twitch ↗** link below player
- [ ] On live game page (mobile), verify video tab appears only when team has a stream configured
- [ ] Team with no stream: no link on team page, video tab hidden on game page

🤖 Generated with [Claude Code](https://claude.com/claude-code)