### PR TITLE
Scope parent RSVP fallback to explicit child context

### DIFF
--- a/docs/pr-notes/runs/125-remediator-20260302T053041Z/architecture.md
+++ b/docs/pr-notes/runs/125-remediator-20260302T053041Z/architecture.md
@@ -1,0 +1,5 @@
+# Architecture role (manual fallback)
+
+- Current state: `resolveRsvpPlayerIdsForSubmission` returns `[]` for ambiguous/invalid scope, and `submitGameRsvp` still writes RSVP docs.
+- Proposed state: resolver throws on unresolved scope so submit path is interrupted before any DB write.
+- Blast radius: parent dashboard RSVP path only; no schema changes.

--- a/docs/pr-notes/runs/125-remediator-20260302T053041Z/code-plan.md
+++ b/docs/pr-notes/runs/125-remediator-20260302T053041Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code role plan (manual fallback)
+
+1. Modify `js/parent-dashboard-rsvp.js` to throw when submission scope resolves to zero player IDs.
+2. Keep valid explicit/single-child paths unchanged.
+3. Update `tests/unit/parent-dashboard-rsvp.test.js` to assert throw behavior for invalid/ambiguous scope.
+4. Run the targeted test file.

--- a/docs/pr-notes/runs/125-remediator-20260302T053041Z/qa.md
+++ b/docs/pr-notes/runs/125-remediator-20260302T053041Z/qa.md
@@ -1,0 +1,5 @@
+# QA role (manual fallback)
+
+- Update unit expectations in `tests/unit/parent-dashboard-rsvp.test.js` for ambiguous/invalid scope to assert throws.
+- Run targeted vitest suite for parent dashboard RSVP scope resolution.
+- Regression check: single-child and explicit valid child scope still return expected IDs.

--- a/docs/pr-notes/runs/125-remediator-20260302T053041Z/requirements.md
+++ b/docs/pr-notes/runs/125-remediator-20260302T053041Z/requirements.md
@@ -1,0 +1,5 @@
+# Requirements role (manual fallback)
+
+- Orchestration skills/sessions_spawn unavailable in this runtime, so analysis is inline.
+- Review thread requires preventing ambiguous parent RSVP submissions from persisting `playerIds: []`.
+- Success criteria: parent dashboard RSVP must not call `submitRsvp` when child scope cannot be resolved to at least one in-game child ID.

--- a/docs/pr-notes/runs/issue-121-fixer-20260302T052535Z/architecture.md
+++ b/docs/pr-notes/runs/issue-121-fixer-20260302T052535Z/architecture.md
@@ -1,0 +1,15 @@
+# Architecture Role Synthesis
+
+## Root Cause
+`resolveRsvpPlayerIdsForSubmission` allowed implicit fallback to all players in a team/event scope. With shared event docs, this can over-apply one RSVP action.
+
+## Minimal Patch Strategy
+- Keep data model and DB write path unchanged.
+- Tighten client-side resolver logic:
+  - return explicit scoped IDs when provided and valid
+  - if no explicit context and exactly one allowed player exists, use it
+  - if no explicit context and multiple allowed players exist, return empty (ambiguous)
+
+## Risk Surface
+- Low blast radius: only submission player ID resolution changes.
+- Potential UX effect: ambiguous grouped actions will no longer fan out silently.

--- a/docs/pr-notes/runs/issue-121-fixer-20260302T052535Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-121-fixer-20260302T052535Z/code-plan.md
@@ -1,0 +1,8 @@
+# Code Role Plan
+
+1. Update `tests/unit/parent-dashboard-rsvp.test.js`:
+   - Replace broad fallback expectation with ambiguous multi-child empty result.
+   - Add single-child fallback test.
+2. Update `js/parent-dashboard-rsvp.js` fallback logic for ambiguous contexts.
+3. Bump `parent-dashboard.html` import query for `parent-dashboard-rsvp.js`.
+4. Run targeted vitest file.

--- a/docs/pr-notes/runs/issue-121-fixer-20260302T052535Z/qa.md
+++ b/docs/pr-notes/runs/issue-121-fixer-20260302T052535Z/qa.md
@@ -1,0 +1,11 @@
+# QA Role Synthesis
+
+## Regression Guardrails
+- Unit test ambiguous multi-child fallback returns empty list.
+- Unit test single-child fallback still returns that child ID.
+- Re-run parent RSVP unit suite.
+
+## Manual Verification Focus
+- Parent with two children on same team:
+  - Child-specific list card click sends only clicked child ID.
+  - Any grouped/ambiguous context should not silently write both children.

--- a/docs/pr-notes/runs/issue-121-fixer-20260302T052535Z/requirements.md
+++ b/docs/pr-notes/runs/issue-121-fixer-20260302T052535Z/requirements.md
@@ -1,0 +1,16 @@
+# Requirements Role Synthesis
+
+## Objective
+Ensure parent RSVP actions from child-specific context do not implicitly apply to siblings on the same team event.
+
+## Current Behavior
+Parent RSVP resolution can fallback to a broad player scope for an event, allowing one action to include multiple linked children when explicit child context is absent.
+
+## Expected Behavior
+A single child-card RSVP should affect only that child. Multi-child updates must be explicit.
+
+## Acceptance Criteria
+- Multi-child team/event context without explicit child selection does not default to all child IDs.
+- Single-child team/event context still submits that child without extra prompts.
+- Existing explicit `childId`, `selectedChildId`, and `childIds` behavior remains scoped to allowed players.
+- Regression test covers ambiguous multi-child fallback.

--- a/js/parent-dashboard-rsvp.js
+++ b/js/parent-dashboard-rsvp.js
@@ -31,5 +31,6 @@ export function resolveRsvpPlayerIdsForSubmission(allScheduleEvents, teamId, gam
     const explicitChildIds = parseChildIds(childContext?.childIds);
     if (explicitChildIds.length > 0) return sanitizeToAllowedScope(explicitChildIds);
 
-    return allowedPlayerIds;
+    if (allowedPlayerIds.length === 1) return allowedPlayerIds;
+    return [];
 }

--- a/js/parent-dashboard-rsvp.js
+++ b/js/parent-dashboard-rsvp.js
@@ -21,16 +21,31 @@ export function resolveRsvpPlayerIdsForSubmission(allScheduleEvents, teamId, gam
     );
     const allowedSet = new Set(allowedPlayerIds);
     const sanitizeToAllowedScope = (ids) => ids.filter((id) => allowedSet.has(id));
+    const throwScopeError = () => {
+        throw new Error('Select a child in this game before submitting RSVP.');
+    };
 
     const selectedChildId = String(childContext?.selectedChildId || '').trim();
-    if (selectedChildId) return sanitizeToAllowedScope([selectedChildId]);
+    if (selectedChildId) {
+        const scoped = sanitizeToAllowedScope([selectedChildId]);
+        if (scoped.length === 0) throwScopeError();
+        return scoped;
+    }
 
     const explicitChildId = String(childContext?.childId || '').trim();
-    if (explicitChildId) return sanitizeToAllowedScope([explicitChildId]);
+    if (explicitChildId) {
+        const scoped = sanitizeToAllowedScope([explicitChildId]);
+        if (scoped.length === 0) throwScopeError();
+        return scoped;
+    }
 
     const explicitChildIds = parseChildIds(childContext?.childIds);
-    if (explicitChildIds.length > 0) return sanitizeToAllowedScope(explicitChildIds);
+    if (explicitChildIds.length > 0) {
+        const scoped = sanitizeToAllowedScope(explicitChildIds);
+        if (scoped.length === 0) throwScopeError();
+        return scoped;
+    }
 
     if (allowedPlayerIds.length === 1) return allowedPlayerIds;
-    return [];
+    throwScopeError();
 }

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -211,7 +211,7 @@
         import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence } from './js/utils.js?v=8';
         import { requireAuth, checkAuth } from './js/auth.js?v=9';
         import { resolvePracticePacketSessionIdForEvent as resolvePracticePacketSessionIdForEventBase, resolvePracticePacketContextForEvent as resolvePracticePacketContextForEventBase } from './js/parent-dashboard-packets.js?v=2';
-        import { resolveRsvpPlayerIdsForSubmission } from './js/parent-dashboard-rsvp.js?v=3';
+        import { resolveRsvpPlayerIdsForSubmission } from './js/parent-dashboard-rsvp.js?v=4';
         import { getEventRideshareSummary, getOfferSeatInfo, canRequestRide, findRequestForChild } from './js/rideshare-helpers.js?v=1';
         import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';
 

--- a/tests/unit/parent-dashboard-rsvp.test.js
+++ b/tests/unit/parent-dashboard-rsvp.test.js
@@ -35,17 +35,14 @@ describe('parent dashboard RSVP player scope', () => {
   });
 
   it('rejects explicit childId values outside the selected game scope', () => {
-    const result = resolveRsvpPlayerIdsForSubmission(allScheduleEvents, 'team-1', 'game-1', {
+    expect(() => resolveRsvpPlayerIdsForSubmission(allScheduleEvents, 'team-1', 'game-1', {
       childId: 'child-z'
-    });
-
-    expect(result).toEqual([]);
+    })).toThrow('Select a child in this game before submitting RSVP.');
   });
 
-  it('returns empty scope when fallback is ambiguous across multiple children', () => {
-    const result = resolveRsvpPlayerIdsForSubmission(allScheduleEvents, 'team-1', 'game-1', {});
-
-    expect(result).toEqual([]);
+  it('throws when fallback is ambiguous across multiple children', () => {
+    expect(() => resolveRsvpPlayerIdsForSubmission(allScheduleEvents, 'team-1', 'game-1', {}))
+      .toThrow('Select a child in this game before submitting RSVP.');
   });
 
   it('falls back to the only child when a game scope has exactly one child', () => {

--- a/tests/unit/parent-dashboard-rsvp.test.js
+++ b/tests/unit/parent-dashboard-rsvp.test.js
@@ -42,9 +42,15 @@ describe('parent dashboard RSVP player scope', () => {
     expect(result).toEqual([]);
   });
 
-  it('falls back to the clicked game scope instead of all team events', () => {
+  it('returns empty scope when fallback is ambiguous across multiple children', () => {
     const result = resolveRsvpPlayerIdsForSubmission(allScheduleEvents, 'team-1', 'game-1', {});
 
-    expect(result).toEqual(['child-a', 'child-b']);
+    expect(result).toEqual([]);
+  });
+
+  it('falls back to the only child when a game scope has exactly one child', () => {
+    const result = resolveRsvpPlayerIdsForSubmission(allScheduleEvents, 'team-1', 'game-2', {});
+
+    expect(result).toEqual(['child-c']);
   });
 });


### PR DESCRIPTION
Closes #121

## What changed
- Updated `resolveRsvpPlayerIdsForSubmission` in `js/parent-dashboard-rsvp.js` so ambiguous fallback no longer fans out to all children on the same team/event.
- New behavior: if no explicit child context is provided, fallback only proceeds when exactly one child is in scope; otherwise it returns an empty player list.
- Added regression coverage in `tests/unit/parent-dashboard-rsvp.test.js` for:
  - ambiguous multi-child fallback (must not auto-apply)
  - single-child fallback (still works)
- Bumped cache-bust import in `parent-dashboard.html` for the updated RSVP module.
- Added required run artifacts under `docs/pr-notes/runs/issue-121-fixer-20260302T052535Z/`.

## Why
The previous fallback could silently broaden a single RSVP action across siblings in shared team/event contexts. This patch keeps RSVP scope safe by default and prevents accidental multi-child updates unless explicitly scoped.