### PR TITLE
Harden replay speed rebasing to prevent timeline jumps

### DIFF
--- a/docs/pr-notes/runs/issue-129-fixer-20260302T202513Z/architecture.md
+++ b/docs/pr-notes/runs/issue-129-fixer-20260302T202513Z/architecture.md
@@ -1,0 +1,13 @@
+# Architecture Role Synthesis
+
+## Root Cause
+Elapsed replay time is derived from wall clock and speed multiplier. If speed changes without rebasing effective start time, prior elapsed time is retroactively multiplied.
+
+## Design
+- Keep elapsed calculation in shared replay helper.
+- On speed change during active playback, compute elapsed at current speed, then derive a new start time for the target speed.
+- Add fallback rebasing using `gameClockMs` when `replayStartTime` is not finite to avoid resets/jumps.
+
+## Blast Radius
+- Files: `js/live-game-replay.js`, `js/live-game.js`, replay speed unit tests.
+- No Firestore schema, auth, routing, or multi-tenant access changes.

--- a/docs/pr-notes/runs/issue-129-fixer-20260302T202513Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-129-fixer-20260302T202513Z/code-plan.md
@@ -1,0 +1,10 @@
+# Code Role Synthesis
+
+## Implementation Plan
+1. Extend replay timing helper with speed-change rebasing function that supports fallback to `gameClockMs`.
+2. Update live-game replay speed button handler to use shared helper.
+3. Add unit coverage for fallback continuity and existing jump scenario.
+4. Run targeted unit tests.
+
+## Conflict Resolution
+Requested orchestration skills/subagent APIs were unavailable in this runtime, so role outputs were synthesized manually and persisted at required paths.

--- a/docs/pr-notes/runs/issue-129-fixer-20260302T202513Z/qa.md
+++ b/docs/pr-notes/runs/issue-129-fixer-20260302T202513Z/qa.md
@@ -1,0 +1,15 @@
+# QA Role Synthesis
+
+## Risk Surface
+- Replay time math regressions could skip events or stall playback.
+- Speed change handler wiring regressions could reintroduce jumps.
+
+## Test Strategy
+- Unit test continuity across speed changes.
+- Unit test fallback path when speed changes while replaying but `replayStartTime` is invalid.
+- Run focused Vitest file: `tests/unit/live-game-replay-speed.test.js`.
+
+## Pass Criteria
+- No jump in elapsed time at speed-change boundary.
+- Future elapsed increments reflect new speed.
+- Fallback path preserves `gameClockMs` continuity.

--- a/docs/pr-notes/runs/issue-129-fixer-20260302T202513Z/requirements.md
+++ b/docs/pr-notes/runs/issue-129-fixer-20260302T202513Z/requirements.md
@@ -1,0 +1,19 @@
+# Requirements Role Synthesis
+
+## Objective
+Prevent replay timeline jumps and skipped events when changing playback speed mid-replay.
+
+## User-visible Current State
+Replay elapsed time can jump forward when speed is changed during active playback, causing events/chat/reactions to be consumed too quickly.
+
+## Proposed State
+Speed changes preserve the current replay position exactly, then apply new speed only to future playback progression.
+
+## Acceptance Criteria
+- Changing speed while replay is playing does not cause immediate timeline jumps.
+- Replay events/chat/reactions remain ordered and are not skipped due to speed changes.
+- Regression test fails on old behavior and passes with fix.
+
+## Assumptions
+- Replay speed controls are available only in replay mode.
+- Replay timeline continuity is represented by `gameClockMs` / elapsed replay milliseconds.

--- a/js/live-game-replay.js
+++ b/js/live-game-replay.js
@@ -11,3 +11,20 @@ export function rebaseReplayStartTimeMs(nowMs, currentElapsedMs, nextReplaySpeed
   }
   return nowMs - (Math.max(0, currentElapsedMs) / nextReplaySpeed);
 }
+
+export function getReplayStartTimeAfterSpeedChange(nowMs, replayStartTimeMs, replaySpeed, nextReplaySpeed, gameClockMs) {
+  if (!Number.isFinite(nowMs) || !Number.isFinite(nextReplaySpeed) || nextReplaySpeed <= 0) {
+    return nowMs;
+  }
+
+  if (Number.isFinite(replayStartTimeMs) && Number.isFinite(replaySpeed) && replaySpeed > 0) {
+    const elapsedMs = getReplayElapsedMs(nowMs, replayStartTimeMs, replaySpeed);
+    return rebaseReplayStartTimeMs(nowMs, elapsedMs, nextReplaySpeed);
+  }
+
+  if (Number.isFinite(gameClockMs)) {
+    return nowMs - (Math.max(0, gameClockMs) / nextReplaySpeed);
+  }
+
+  return nowMs;
+}

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -18,7 +18,7 @@ import { getUrlParams, escapeHtml, renderHeader, renderFooter, formatShortDate, 
 import { computePanelVisibility } from './live-stream-utils.js?v=1';
 import { checkAuth } from './auth.js?v=9';
 import { isViewerChatEnabled } from './live-game-chat.js?v=1';
-import { getReplayElapsedMs, rebaseReplayStartTimeMs } from './live-game-replay.js?v=1';
+import { getReplayElapsedMs, getReplayStartTimeAfterSpeedChange } from './live-game-replay.js?v=1';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
 
@@ -1142,10 +1142,15 @@ function initReplayControls() {
     btn.addEventListener('click', () => {
       const speed = Number(btn.dataset.speed);
       if (!Number.isFinite(speed) || speed <= 0) return;
-      if (state.replayPlaying && Number.isFinite(state.replayStartTime)) {
+      if (state.replayPlaying) {
         const nowMs = Date.now();
-        const elapsedMs = getReplayElapsedMs(nowMs, state.replayStartTime, state.replaySpeed);
-        state.replayStartTime = rebaseReplayStartTimeMs(nowMs, elapsedMs, speed);
+        state.replayStartTime = getReplayStartTimeAfterSpeedChange(
+          nowMs,
+          state.replayStartTime,
+          state.replaySpeed,
+          speed,
+          state.gameClockMs
+        );
       }
       state.replaySpeed = speed;
       document.querySelectorAll('.speed-btn').forEach(b => b.classList.remove('bg-teal', 'text-ink'));

--- a/tests/unit/live-game-replay-speed.test.js
+++ b/tests/unit/live-game-replay-speed.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getReplayElapsedMs, rebaseReplayStartTimeMs } from '../../js/live-game-replay.js';
+import { getReplayElapsedMs, rebaseReplayStartTimeMs, getReplayStartTimeAfterSpeedChange } from '../../js/live-game-replay.js';
 
 describe('live game replay speed timing', () => {
   it('keeps replay elapsed continuous when speed changes during playback', () => {
@@ -27,5 +27,16 @@ describe('live game replay speed timing', () => {
 
     expect(getReplayElapsedMs(20_100, rebasedStartTimeMs, 10)).toBe(9_000);
     expect(getReplayElapsedMs(20_250, rebasedStartTimeMs, 10)).toBe(10_500);
+  });
+
+  it('falls back to current game clock when speed changes and replayStartTime is invalid', () => {
+    const nowMs = 50_000;
+    const nextSpeed = 2;
+    const gameClockMs = 12_000;
+
+    const startTimeMs = getReplayStartTimeAfterSpeedChange(nowMs, null, 1, nextSpeed, gameClockMs);
+    const elapsedAfterChange = getReplayElapsedMs(nowMs, startTimeMs, nextSpeed);
+
+    expect(elapsedAfterChange).toBe(12_000);
   });
 });


### PR DESCRIPTION
Closes #129

## What changed
- Added `getReplayStartTimeAfterSpeedChange` in `js/live-game-replay.js` to centralize replay speed-change rebasing.
- Updated `js/live-game.js` replay speed button handling to use the shared helper and preserve continuity even if `replayStartTime` is invalid during active playback.
- Extended `tests/unit/live-game-replay-speed.test.js` with a fallback continuity regression case.
- Persisted required role artifacts for this run under `docs/pr-notes/runs/issue-129-fixer-20260302T202513Z/`.

## Why
The replay timeline must not jump when playback speed changes mid-stream. This patch preserves the current replay position and applies the new multiplier only to future progression, including a defensive fallback path.

## Validation
- `pnpm dlx vitest run tests/unit/live-game-replay-speed.test.js` (passed: 3/3).