### PR TITLE
Use shared full-access check on edit-config page

### DIFF
--- a/docs/pr-notes/runs/issue-131-fixer-20260302T232559Z/architecture.md
+++ b/docs/pr-notes/runs/issue-131-fixer-20260302T232559Z/architecture.md
@@ -1,0 +1,19 @@
+# Architecture Role - Issue #131
+
+## Root Cause
+Access logic diverged across pages:
+- Shared module `js/team-access.js` defines full access as owner/adminEmail/platform admin.
+- `edit-config.html` duplicated logic and omitted platform admin.
+
+## Minimal Safe Design
+- Import `hasFullTeamAccess` from `js/team-access.js` inside `edit-config.html`.
+- Replace local duplicated `hasAccess` logic with a wrapper calling `hasFullTeamAccess(user, team)`.
+
+## Risk Surface / Blast Radius
+- Blast radius limited to `edit-config.html` page gating.
+- No Firestore schema/rules changes.
+- No API signature changes.
+
+## Compatibility
+- Aligns with existing patterns in `edit-team.html` and `edit-roster.html`.
+- Preserves existing behavior for owner/team admin and denies unrelated users.

--- a/docs/pr-notes/runs/issue-131-fixer-20260302T232559Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-131-fixer-20260302T232559Z/code-plan.md
@@ -1,0 +1,15 @@
+# Code Role Plan - Issue #131
+
+## Patch Steps
+1. Add failing test in `tests/unit/team-management-access-wiring.test.js` for `edit-config.html` helper wiring.
+2. Update `edit-config.html`:
+   - import `hasFullTeamAccess` from `./js/team-access.js`
+   - simplify `hasAccess(team, user)` to return `hasFullTeamAccess(user, team)`
+3. Run targeted Vitest suites:
+   - `tests/unit/team-management-access-wiring.test.js`
+   - `tests/unit/team-access.test.js`
+4. Stage all changed files and commit with issue reference.
+
+## Non-Goals
+- No refactor of banner rendering or team access module.
+- No changes to Firebase rules or backend checks.

--- a/docs/pr-notes/runs/issue-131-fixer-20260302T232559Z/qa.md
+++ b/docs/pr-notes/runs/issue-131-fixer-20260302T232559Z/qa.md
@@ -1,0 +1,17 @@
+# QA Role - Issue #131
+
+## Regression Strategy
+Add static wiring regression coverage to ensure `edit-config.html` uses shared team access helper.
+
+## Test Plan
+1. Update `tests/unit/team-management-access-wiring.test.js` with a new case for `edit-config.html` expecting:
+   - import from `./js/team-access.js`
+   - usage of `hasFullTeamAccess(`
+2. Run targeted test file to validate failure before fix.
+3. Apply code fix.
+4. Re-run targeted test file to confirm pass.
+5. Run `tests/unit/team-access.test.js` as guardrail for full-access semantics.
+
+## Residual Risk
+- Static wiring tests validate integration pattern, not browser runtime.
+- Risk considered low because page imports are already module-based and helper is stable.

--- a/docs/pr-notes/runs/issue-131-fixer-20260302T232559Z/requirements.md
+++ b/docs/pr-notes/runs/issue-131-fixer-20260302T232559Z/requirements.md
@@ -1,0 +1,22 @@
+# Requirements Role - Issue #131
+
+## Objective
+Allow platform admins (`user.isAdmin === true`) to access `edit-config.html` for any team, matching team management banner behavior.
+
+## Current vs Proposed
+- Current: `edit-config.html` applies a page-local `hasAccess` check (owner/adminEmails only) and denies platform admins.
+- Proposed: `edit-config.html` uses shared full-access policy (`hasFullTeamAccess`) already used by other team management pages.
+
+## User Impact
+- Blocker today: platform admins see Stats action but hit deny+redirect dead-end.
+- Success: platform admin can open team stats config page when navigating from Team Admin banner.
+
+## Constraints
+- Keep patch minimal and targeted.
+- Preserve deny behavior for unrelated users.
+- Avoid changing broader routing or permissions model.
+
+## Acceptance Criteria
+1. `edit-config.html` access logic includes platform admin path.
+2. Regression test fails before fix and passes after.
+3. Existing team-management access wiring tests continue passing.

--- a/edit-config.html
+++ b/edit-config.html
@@ -107,16 +107,14 @@
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
+        import { hasFullTeamAccess } from './js/team-access.js';
 
         renderFooter(document.getElementById('footer-container'));
 
         let currentTeamId = null;
         let currentUser = null;
         function hasAccess(team, user) {
-            if (!team || !user) return false;
-            if (team.ownerId === user.uid) return true;
-            const email = (user.email || '').toLowerCase();
-            return (team.adminEmails || []).map(e => e.toLowerCase()).includes(email);
+            return hasFullTeamAccess(user, team);
         }
 
         checkAuth((user) => {

--- a/tests/unit/team-management-access-wiring.test.js
+++ b/tests/unit/team-management-access-wiring.test.js
@@ -17,4 +17,10 @@ describe('team management page access wiring', () => {
         expect(html).toContain("from './js/team-access.js'");
         expect(html).toContain('hasFullTeamAccess(');
     });
+
+    it('uses shared full-access helper in edit config page', () => {
+        const html = readRepoFile('edit-config.html');
+        expect(html).toContain("from './js/team-access.js'");
+        expect(html).toContain('hasFullTeamAccess(');
+    });
 });


### PR DESCRIPTION
Closes #131

## What changed
- Added required run artifacts for requirements, architecture, QA, and code plan under `docs/pr-notes/runs/issue-131-fixer-20260302T232559Z/`.
- Added regression coverage in `tests/unit/team-management-access-wiring.test.js` to enforce that `edit-config.html` uses the shared team access helper.
- Updated `edit-config.html` to import `hasFullTeamAccess` from `js/team-access.js` and use it for page access gating.

## Why
`edit-config.html` had a local access check that only allowed owner/adminEmails and excluded `user.isAdmin`, which blocked platform admins from the Stats config page despite being granted full access in team management flows.

## Validation
- `node /home/paul-bot1/.openclaw/workspace/allplays/node_modules/vitest/vitest.mjs run --root /home/paul-bot1/.local/state/paul-bot1/issue-fixer/workspaces/pauljsnider__allplays tests/unit/team-management-access-wiring.test.js`
- `node /home/paul-bot1/.openclaw/workspace/allplays/node_modules/vitest/vitest.mjs run --root /home/paul-bot1/.local/state/paul-bot1/issue-fixer/workspaces/pauljsnider__allplays tests/unit/team-access.test.js`