### PR TITLE
Redesign workflow help center UX and footer links

### DIFF
--- a/docs/pr-notes/runs/137-remediator-20260303T023129Z/architecture.md
+++ b/docs/pr-notes/runs/137-remediator-20260303T023129Z/architecture.md
@@ -1,0 +1,16 @@
+# Architecture role (inline fallback)
+
+Subagent orchestration tools/skills are unavailable in this execution context, so this is an inline architecture pass.
+
+## Current state
+`render()` builds HTML strings with template literals and injects with `innerHTML`; section fields are inserted raw.
+
+## Proposed state
+Add local helper functions in the page script:
+- `escapeHtml(value)` for text/HTML context.
+- `toSafeFragmentId(value, index)` to produce deterministic, encoded fragment IDs for `id` and `href`.
+
+Render uses precomputed escaped/safe values before interpolation.
+
+## Risk / blast radius
+Low: only `help.html` rendering logic changes; no shared modules or backend behavior impacted.

--- a/docs/pr-notes/runs/137-remediator-20260303T023129Z/code-plan.md
+++ b/docs/pr-notes/runs/137-remediator-20260303T023129Z/code-plan.md
@@ -1,0 +1,14 @@
+# Code role plan (inline fallback)
+
+Subagent orchestration tools/skills are unavailable in this execution context, so this is an inline code plan.
+
+## Planned edits
+- Update `help.html` script to add two helpers:
+  - `escapeHtml(value)`
+  - `toSafeFragmentId(value, index)`
+- Replace direct interpolation with escaped/safe values in:
+  - `results.innerHTML`
+  - `bottomNav.innerHTML`
+
+## Commit scope
+- Files: `help.html`, role notes under `docs/pr-notes/runs/137-remediator-20260303T023129Z/`

--- a/docs/pr-notes/runs/137-remediator-20260303T023129Z/qa.md
+++ b/docs/pr-notes/runs/137-remediator-20260303T023129Z/qa.md
@@ -1,0 +1,13 @@
+# QA role (inline fallback)
+
+Subagent orchestration tools/skills are unavailable in this execution context, so this is an inline QA pass.
+
+## Validation plan
+1. Open `help.html` locally and confirm cards render for each role.
+2. Enter search text and confirm count and list update.
+3. Click bottom navigation links and verify anchor scroll works.
+4. Spot-check escaping with synthetic values containing `<`, `>`, `\"`, `'`, and `&` (if test data can be injected).
+
+## Regression focus
+- Bottom nav links must still target rendered section IDs.
+- Result summary should remain unchanged.

--- a/docs/pr-notes/runs/137-remediator-20260303T023129Z/requirements.md
+++ b/docs/pr-notes/runs/137-remediator-20260303T023129Z/requirements.md
@@ -1,0 +1,15 @@
+# Requirements role (inline fallback)
+
+Subagent orchestration tools/skills are unavailable in this execution context, so this is an inline requirements pass.
+
+## Objective
+Resolve unresolved PR feedback threads about XSS in `help.html` caused by direct interpolation into `innerHTML`.
+
+## Required behavior
+- Escape untrusted text interpolated into results cards (`id`, `title`, `summary`, workflow list items).
+- Escape/encode values interpolated into bottom nav anchor `href` and anchor text.
+- Keep functional behavior intact: search filtering and section navigation must still work.
+
+## Scope constraints
+- Minimal targeted changes in `help.html` only.
+- No unrelated refactors.

--- a/docs/pr-notes/runs/issue-134-fixer-20260303T022601Z/architecture.md
+++ b/docs/pr-notes/runs/issue-134-fixer-20260303T022601Z/architecture.md
@@ -1,0 +1,20 @@
+# Architecture Role Synthesis (fallback)
+
+## Chosen design
+- `js/help-center.js`: pure helper module for role normalization, role-aware section filtering, and search.
+- `help.html`: static host page that renders searchable knowledge-base content from helper module.
+- `js/team-admin-banner.js`: add `help` destination card (context + role query params).
+- `js/utils.js`: fix footer Help Center route (`help.html`).
+
+## Why this design
+- Keeps logic testable in pure JS (Vitest-friendly).
+- Constrains change to shared UI entry points + new page.
+- Provides extensibility for future feature-release content updates.
+
+## Accessibility controls
+- Proper `label`/`for` on controls.
+- Landmarks (`main`, `nav`) and semantic headings.
+- High-contrast defaults inherited from existing palette.
+
+## Rollback
+- Revert new help files and two shared-nav edits.

--- a/docs/pr-notes/runs/issue-134-fixer-20260303T022601Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-134-fixer-20260303T022601Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code Role Synthesis (fallback)
+
+## Implementation plan
+1. Add failing tests for help module + navigation wiring.
+2. Implement `js/help-center.js` and `help.html` searchable role-aware rendering.
+3. Wire help links in shared footer and team admin banner.
+4. Run targeted tests then full unit suite subset relevant to changes.
+5. Commit with issue reference.
+
+## Minimality
+- No unrelated refactors.
+- No behavior changes outside help entry points.

--- a/docs/pr-notes/runs/issue-134-fixer-20260303T022601Z/qa.md
+++ b/docs/pr-notes/runs/issue-134-fixer-20260303T022601Z/qa.md
@@ -1,0 +1,14 @@
+# QA Role Synthesis (fallback)
+
+## Test strategy
+1. Unit test pure help module:
+   - Role normalization behavior.
+   - Role-aware section filtering behavior.
+   - Search matching behavior.
+2. Wiring tests:
+   - Footer now points to `help.html`.
+   - Team banner includes Help navigation card and link target.
+
+## Regression guardrails
+- Limit changes to link wiring and additive modules.
+- No existing test updates unless required by changed behavior.

--- a/docs/pr-notes/runs/issue-134-fixer-20260303T022601Z/requirements.md
+++ b/docs/pr-notes/runs/issue-134-fixer-20260303T022601Z/requirements.md
@@ -1,0 +1,27 @@
+# Requirements Role Synthesis (fallback)
+
+## Note on orchestration
+Requested skills/sessions were unavailable in this runtime (`allplays-orchestrator-playbook`, role skills, `sessions_spawn`). This file captures equivalent role analysis.
+
+## Objective
+Deliver a first shippable, role-aware help system entry point that is accessible, searchable, and reachable from existing app navigation with minimal blast radius.
+
+## Current state
+- No dedicated help center page exists.
+- Footer “Help Center” link is a dead `#` target.
+- No shared role-aware help content source.
+
+## Proposed state
+- Add `help.html` with:
+  - Search input and role picker.
+  - Role-aware rendered help sections.
+  - Accessible section semantics (`main`, labeled controls, headings, list structure).
+  - Bottom in-page navigation for fast section access on mobile/desktop.
+- Add shared content module enumerating required role + workflow coverage categories.
+- Add context-aware “Help” link to team navigation banner.
+- Update global footer Help Center link to point at `help.html`.
+
+## Risks and blast radius
+- Low; static-page and shared-nav additions only.
+- No auth, Firestore, or write-path changes.
+- Main UX risk: content incompleteness; mitigated by explicit section scaffolding and glossary.

--- a/help-account.html
+++ b/help-account.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Help - Account and Access</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-slate-50 text-slate-900 min-h-screen">
+  <main class="max-w-6xl mx-auto px-4 py-8">
+    <a href="help.html" class="text-sm text-blue-700 hover:text-blue-900">← Back to Help Portal</a>
+    <h1 class="mt-2 text-3xl font-extrabold">Account and Access</h1>
+    <p class="mt-2 text-slate-600">Who does what for authentication, onboarding, and account state workflows.</p>
+
+    <section class="mt-6 grid gap-4">
+      <article class="bg-white rounded-xl border border-slate-200 p-5">
+        <h2 class="text-xl font-bold">Login and Session</h2>
+        <ul class="mt-3 list-disc list-inside text-sm text-slate-700 space-y-1">
+          <li><strong>Member/Parent/Coach/Admin:</strong> Log in from <code>login.html</code>.</li>
+          <li><strong>Member/Parent/Coach/Admin:</strong> Log out from shared header controls.</li>
+          <li><strong>Coach/Admin:</strong> Verify team-management links appear after login.</li>
+          <li><strong>Parent:</strong> Verify parent dashboard links appear after login.</li>
+        </ul>
+      </article>
+
+      <article class="bg-white rounded-xl border border-slate-200 p-5">
+        <h2 class="text-xl font-bold">Forgot Password and Recovery</h2>
+        <ul class="mt-3 list-disc list-inside text-sm text-slate-700 space-y-1">
+          <li><strong>Member/Parent/Coach/Admin:</strong> Start reset from <code>login.html</code> / <code>reset-password.html</code>.</li>
+          <li><strong>Member/Parent/Coach/Admin:</strong> Complete email reset link flow.</li>
+          <li><strong>Member/Parent/Coach/Admin:</strong> Verify sign-in works with new password.</li>
+        </ul>
+      </article>
+
+      <article class="bg-white rounded-xl border border-slate-200 p-5">
+        <h2 class="text-xl font-bold">Sign Up and Invite Acceptance</h2>
+        <ul class="mt-3 list-disc list-inside text-sm text-slate-700 space-y-1">
+          <li><strong>Member/Parent/Coach/Admin:</strong> Sign up via activation/invite from <code>login.html</code> and <code>accept-invite.html</code>.</li>
+          <li><strong>Parent:</strong> Parent-invite activation and linkage workflows.</li>
+          <li><strong>Coach/Admin:</strong> Team invite redemption and elevated access checks.</li>
+          <li><strong>Member/Parent/Coach/Admin:</strong> Resolve pending verification in <code>verify-pending.html</code>.</li>
+        </ul>
+      </article>
+
+      <article class="bg-white rounded-xl border border-slate-200 p-5">
+        <h2 class="text-xl font-bold">Profile and Identity</h2>
+        <ul class="mt-3 list-disc list-inside text-sm text-slate-700 space-y-1">
+          <li><strong>Member/Parent/Coach/Admin:</strong> Update profile data in <code>profile.html</code>.</li>
+          <li><strong>Admin:</strong> Verify admin-only areas via <code>admin.html</code> and admin status checks.</li>
+        </ul>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/help-game-operations.html
+++ b/help-game-operations.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Help - Game Operations</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-slate-50 text-slate-900 min-h-screen">
+  <main class="max-w-6xl mx-auto px-4 py-8">
+    <a href="help.html" class="text-sm text-blue-700 hover:text-blue-900">← Back to Help Portal</a>
+    <h1 class="mt-2 text-3xl font-extrabold">Game Operations</h1>
+    <p class="mt-2 text-slate-600">Role ownership for planning, tracking, and post-game workflows.</p>
+
+    <section class="mt-6 grid gap-4">
+      <article class="bg-white rounded-xl border border-slate-200 p-5">
+        <h2 class="text-xl font-bold">Game and Practice Planning</h2>
+        <ul class="mt-3 list-disc list-inside text-sm text-slate-700 space-y-1">
+          <li><strong>Coach/Admin:</strong> Build game/practice schedule in <code>edit-schedule.html</code>.</li>
+          <li><strong>Coach/Admin:</strong> Prepare game plans in <code>game-plan.html</code>.</li>
+          <li><strong>Coach/Admin:</strong> Prepare drills in <code>drills.html</code>.</li>
+        </ul>
+      </article>
+
+      <article class="bg-white rounded-xl border border-slate-200 p-5">
+        <h2 class="text-xl font-bold">Tracking Workflows</h2>
+        <ul class="mt-3 list-disc list-inside text-sm text-slate-700 space-y-1">
+          <li><strong>Coach/Admin:</strong> Standard tracker in <code>track.html</code>.</li>
+          <li><strong>Coach/Admin:</strong> Live tracker in <code>track-live.html</code>.</li>
+          <li><strong>Coach/Admin:</strong> Basketball live tracker in <code>live-tracker.html</code>.</li>
+          <li><strong>Coach/Admin:</strong> Basketball beta tracker in <code>track-basketball.html</code>.</li>
+          <li><strong>Coach/Admin:</strong> Statsheet tracking in <code>track-statsheet.html</code>.</li>
+        </ul>
+      </article>
+
+      <article class="bg-white rounded-xl border border-slate-200 p-5">
+        <h2 class="text-xl font-bold">Game Day and Reports</h2>
+        <ul class="mt-3 list-disc list-inside text-sm text-slate-700 space-y-1">
+          <li><strong>Coach/Admin:</strong> Game day operation in <code>game-day.html</code>.</li>
+          <li><strong>Parent/Coach/Admin/Member:</strong> Game report viewing in <code>game.html</code>.</li>
+          <li><strong>Parent/Coach/Admin:</strong> Player-centric report drilldown in <code>player.html</code>.</li>
+        </ul>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/help-page-reference.html
+++ b/help-page-reference.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Help - File-by-File Page Reference</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-slate-50 text-slate-900 min-h-screen">
+  <main class="max-w-7xl mx-auto px-4 py-8">
+    <a href="help.html" class="text-sm text-blue-700 hover:text-blue-900">← Back to Help Portal</a>
+    <h1 class="mt-2 text-3xl font-extrabold">File-by-File Page Reference</h1>
+    <p class="mt-2 text-slate-600">Each page, what it does, and which role should use it.</p>
+
+    <div class="mt-6 overflow-x-auto rounded-xl border border-slate-200 bg-white">
+      <table class="min-w-full text-sm">
+        <thead class="bg-slate-100 text-slate-700">
+          <tr>
+            <th class="text-left px-4 py-3 font-bold">File</th>
+            <th class="text-left px-4 py-3 font-bold">Primary Features</th>
+            <th class="text-left px-4 py-3 font-bold">Role(s)</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          <tr><td class="px-4 py-3 font-mono">index.html</td><td class="px-4 py-3">Landing page, product entry, navigation entry points</td><td class="px-4 py-3">All</td></tr>
+          <tr><td class="px-4 py-3 font-mono">login.html</td><td class="px-4 py-3">Sign in, sign up, auth flows</td><td class="px-4 py-3">All</td></tr>
+          <tr><td class="px-4 py-3 font-mono">accept-invite.html</td><td class="px-4 py-3">Invite acceptance and account linking</td><td class="px-4 py-3">Parent, Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">reset-password.html</td><td class="px-4 py-3">Password reset entry and completion</td><td class="px-4 py-3">All</td></tr>
+          <tr><td class="px-4 py-3 font-mono">verify-pending.html</td><td class="px-4 py-3">Pending verification state guidance</td><td class="px-4 py-3">All new users</td></tr>
+          <tr><td class="px-4 py-3 font-mono">profile.html</td><td class="px-4 py-3">Profile settings and account details</td><td class="px-4 py-3">Member, Parent, Coach, Admin</td></tr>
+
+          <tr><td class="px-4 py-3 font-mono">teams.html</td><td class="px-4 py-3">Browse teams and discovery</td><td class="px-4 py-3">All</td></tr>
+          <tr><td class="px-4 py-3 font-mono">team.html</td><td class="px-4 py-3">Team details, schedule, roster, links to operations</td><td class="px-4 py-3">Parent, Coach, Admin, Member</td></tr>
+          <tr><td class="px-4 py-3 font-mono">dashboard.html</td><td class="px-4 py-3">My Teams management dashboard</td><td class="px-4 py-3">Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">parent-dashboard.html</td><td class="px-4 py-3">Parent-centric schedule/player actions</td><td class="px-4 py-3">Parent</td></tr>
+          <tr><td class="px-4 py-3 font-mono">admin.html</td><td class="px-4 py-3">Global admin tools and access control</td><td class="px-4 py-3">Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">check-admin-status.html</td><td class="px-4 py-3">Admin status diagnostics</td><td class="px-4 py-3">Admin</td></tr>
+
+          <tr><td class="px-4 py-3 font-mono">edit-team.html</td><td class="px-4 py-3">Team metadata updates</td><td class="px-4 py-3">Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">edit-roster.html</td><td class="px-4 py-3">Player roster create/update/delete</td><td class="px-4 py-3">Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">edit-schedule.html</td><td class="px-4 py-3">Game/practice planning, event editing, tracker launching</td><td class="px-4 py-3">Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">calendar.html</td><td class="px-4 py-3">Calendar/schedule visualization</td><td class="px-4 py-3">Parent, Coach, Admin, Member</td></tr>
+          <tr><td class="px-4 py-3 font-mono">edit-config.html</td><td class="px-4 py-3">Stats and tracker config management</td><td class="px-4 py-3">Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">drills.html</td><td class="px-4 py-3">Drill planning and library workflows</td><td class="px-4 py-3">Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">game-plan.html</td><td class="px-4 py-3">Game plan creation and review</td><td class="px-4 py-3">Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">game-day.html</td><td class="px-4 py-3">Game-day operational controls</td><td class="px-4 py-3">Coach, Admin</td></tr>
+
+          <tr><td class="px-4 py-3 font-mono">track.html</td><td class="px-4 py-3">Standard game tracking</td><td class="px-4 py-3">Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">track-live.html</td><td class="px-4 py-3">Live tracker (multi-sport), chat, unified notes, game log</td><td class="px-4 py-3">Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">live-tracker.html</td><td class="px-4 py-3">Basketball-specific live tracker</td><td class="px-4 py-3">Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">track-basketball.html</td><td class="px-4 py-3">Basketball beta tracker flow</td><td class="px-4 py-3">Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">track-statsheet.html</td><td class="px-4 py-3">Statsheet tracking/import path</td><td class="px-4 py-3">Coach, Admin</td></tr>
+
+          <tr><td class="px-4 py-3 font-mono">game.html</td><td class="px-4 py-3">Post-game report view, score/stats outcomes</td><td class="px-4 py-3">Parent, Coach, Admin, Member</td></tr>
+          <tr><td class="px-4 py-3 font-mono">live-game.html</td><td class="px-4 py-3">Live/replay game viewing and chat eligibility</td><td class="px-4 py-3">Parent, Coach, Admin, Member</td></tr>
+          <tr><td class="px-4 py-3 font-mono">player.html</td><td class="px-4 py-3">Player profile and game report drilldown</td><td class="px-4 py-3">Parent, Coach, Admin</td></tr>
+          <tr><td class="px-4 py-3 font-mono">team-chat.html</td><td class="px-4 py-3">Team chat room, mentions/tags, communication thread</td><td class="px-4 py-3">Parent, Coach, Admin</td></tr>
+
+          <tr><td class="px-4 py-3 font-mono">help.html</td><td class="px-4 py-3">Help portal landing and topic routing</td><td class="px-4 py-3">All</td></tr>
+          <tr><td class="px-4 py-3 font-mono">help-account.html</td><td class="px-4 py-3">Account/access ownership by role</td><td class="px-4 py-3">All</td></tr>
+          <tr><td class="px-4 py-3 font-mono">help-team-operations.html</td><td class="px-4 py-3">Team setup and management ownership by role</td><td class="px-4 py-3">All</td></tr>
+          <tr><td class="px-4 py-3 font-mono">help-game-operations.html</td><td class="px-4 py-3">Game planning/tracking ownership by role</td><td class="px-4 py-3">All</td></tr>
+          <tr><td class="px-4 py-3 font-mono">help-watch-chat.html</td><td class="px-4 py-3">Watch/chat/tag ownership by role</td><td class="px-4 py-3">All</td></tr>
+          <tr><td class="px-4 py-3 font-mono">help-page-reference.html</td><td class="px-4 py-3">Full page capability matrix</td><td class="px-4 py-3">All</td></tr>
+
+          <tr class="bg-slate-50"><td class="px-4 py-3 font-semibold" colspan="3">Test/QA pages (engineering/internal)</td></tr>
+          <tr><td class="px-4 py-3 font-mono">test-fix-recurring-rsvp.html</td><td class="px-4 py-3">Recurring RSVP test harness</td><td class="px-4 py-3">Engineering/QA</td></tr>
+          <tr><td class="px-4 py-3 font-mono">test-fix-schedule-drills.html</td><td class="px-4 py-3">Schedule/drills regression checks</td><td class="px-4 py-3">Engineering/QA</td></tr>
+          <tr><td class="px-4 py-3 font-mono">test-foul-tracking.html</td><td class="px-4 py-3">Foul tracking test utility</td><td class="px-4 py-3">Engineering/QA</td></tr>
+          <tr><td class="px-4 py-3 font-mono">test-game-day.html</td><td class="px-4 py-3">Game-day feature checks</td><td class="px-4 py-3">Engineering/QA</td></tr>
+          <tr><td class="px-4 py-3 font-mono">test-pr-changes.html</td><td class="px-4 py-3">PR smoke/regression checks</td><td class="px-4 py-3">Engineering/QA</td></tr>
+          <tr><td class="px-4 py-3 font-mono">test-statsheet-mapping.html</td><td class="px-4 py-3">Statsheet mapping validation</td><td class="px-4 py-3">Engineering/QA</td></tr>
+          <tr><td class="px-4 py-3 font-mono">test-youtube-stream.html</td><td class="px-4 py-3">Stream embed/watch tests</td><td class="px-4 py-3">Engineering/QA</td></tr>
+        </tbody>
+      </table>
+    </div>
+  </main>
+</body>
+</html>

--- a/help-team-operations.html
+++ b/help-team-operations.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Help - Team Operations</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-slate-50 text-slate-900 min-h-screen">
+  <main class="max-w-6xl mx-auto px-4 py-8">
+    <a href="help.html" class="text-sm text-blue-700 hover:text-blue-900">← Back to Help Portal</a>
+    <h1 class="mt-2 text-3xl font-extrabold">Team Operations</h1>
+    <p class="mt-2 text-slate-600">Ownership model for team creation, roster, schedule, and configuration.</p>
+
+    <section class="mt-6 grid gap-4">
+      <article class="bg-white rounded-xl border border-slate-200 p-5">
+        <h2 class="text-xl font-bold">Team Creation and Core Management</h2>
+        <ul class="mt-3 list-disc list-inside text-sm text-slate-700 space-y-1">
+          <li><strong>Coach/Admin:</strong> Create and manage teams from <code>dashboard.html</code>.</li>
+          <li><strong>Coach/Admin:</strong> Edit team metadata in <code>edit-team.html</code>.</li>
+          <li><strong>Parent/Member:</strong> View team context in <code>team.html</code> only.</li>
+        </ul>
+      </article>
+
+      <article class="bg-white rounded-xl border border-slate-200 p-5">
+        <h2 class="text-xl font-bold">Roster and Schedule Ownership</h2>
+        <ul class="mt-3 list-disc list-inside text-sm text-slate-700 space-y-1">
+          <li><strong>Coach/Admin:</strong> Manage roster in <code>edit-roster.html</code>.</li>
+          <li><strong>Coach/Admin:</strong> Plan/update events in <code>edit-schedule.html</code>.</li>
+          <li><strong>Parent/Member:</strong> Consume schedule from <code>team.html</code> and <code>calendar.html</code>.</li>
+        </ul>
+      </article>
+
+      <article class="bg-white rounded-xl border border-slate-200 p-5">
+        <h2 class="text-xl font-bold">Config and Analytics Controls</h2>
+        <ul class="mt-3 list-disc list-inside text-sm text-slate-700 space-y-1">
+          <li><strong>Coach/Admin:</strong> Stat and config management in <code>edit-config.html</code>.</li>
+          <li><strong>Coach/Admin:</strong> Team planning workflows in <code>game-plan.html</code> and <code>drills.html</code>.</li>
+          <li><strong>Parent:</strong> Parent-specific team and player views in <code>parent-dashboard.html</code> and <code>player.html</code>.</li>
+        </ul>
+      </article>
+
+      <article class="bg-white rounded-xl border border-slate-200 p-5">
+        <h2 class="text-xl font-bold">Administration</h2>
+        <ul class="mt-3 list-disc list-inside text-sm text-slate-700 space-y-1">
+          <li><strong>Admin:</strong> Global admin workflows in <code>admin.html</code>.</li>
+          <li><strong>Admin:</strong> Access checks and status verification through admin tooling pages.</li>
+        </ul>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/help-watch-chat.html
+++ b/help-watch-chat.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Help - Watch and Chat</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-slate-50 text-slate-900 min-h-screen">
+  <main class="max-w-6xl mx-auto px-4 py-8">
+    <a href="help.html" class="text-sm text-blue-700 hover:text-blue-900">← Back to Help Portal</a>
+    <h1 class="mt-2 text-3xl font-extrabold">Watch and Chat</h1>
+    <p class="mt-2 text-slate-600">Who owns live viewing and communication actions in production pages.</p>
+
+    <section class="mt-6 grid gap-4">
+      <article class="bg-white rounded-xl border border-slate-200 p-5">
+        <h2 class="text-xl font-bold">Watching Live and Replay</h2>
+        <ul class="mt-3 list-disc list-inside text-sm text-slate-700 space-y-1">
+          <li><strong>Parent/Coach/Admin/Member:</strong> Open live/replay views via <code>team.html</code> and <code>live-game.html</code>.</li>
+          <li><strong>Coach/Admin:</strong> Configure stream source and game live status.</li>
+          <li><strong>Parent/Member:</strong> Consume view-only watching experience.</li>
+        </ul>
+      </article>
+
+      <article class="bg-white rounded-xl border border-slate-200 p-5">
+        <h2 class="text-xl font-bold">Team Chat</h2>
+        <ul class="mt-3 list-disc list-inside text-sm text-slate-700 space-y-1">
+          <li><strong>Parent/Coach/Admin:</strong> Team chat participation in <code>team-chat.html</code>.</li>
+          <li><strong>Coach/Admin:</strong> Send operational game-day and scheduling updates.</li>
+          <li><strong>Parent:</strong> Parent communication and acknowledgments.</li>
+        </ul>
+      </article>
+
+      <article class="bg-white rounded-xl border border-slate-200 p-5">
+        <h2 class="text-xl font-bold">Tagging and Mentions</h2>
+        <ul class="mt-3 list-disc list-inside text-sm text-slate-700 space-y-1">
+          <li><strong>Parent/Coach/Admin:</strong> Mention/tag in chat when recipient attention is required.</li>
+          <li><strong>Coach/Admin:</strong> Use targeted mentions for assignments and game-day actions.</li>
+          <li><strong>Parent:</strong> Use mentions for availability and coordination updates.</li>
+        </ul>
+      </article>
+    </section>
+  </main>
+</body>
+</html>

--- a/help.html
+++ b/help.html
@@ -1,48 +1,322 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ALL PLAYS Help Portal</title>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Help Center - Workflows</title>
     <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: {
+                50: '#eef2ff',
+                100: '#e0e7ff',
+                500: '#6366f1',
+                600: '#4f46e5',
+                700: '#4338ca',
+                800: '#3730a3',
+                900: '#312e81'
+              }
+            }
+          }
+        }
+      }
+    </script>
+    <style>
+      :root {
+        --wf-bg: #f8fafc;
+      }
+
+      body {
+        background:
+          radial-gradient(circle at 82% -5%, rgba(99,102,241,0.16) 0%, rgba(248,250,252,0) 44%),
+          radial-gradient(circle at -2% 22%, rgba(67,56,202,0.12) 0%, rgba(248,250,252,0) 48%),
+          var(--wf-bg);
+      }
+
+      .wf-index-shell {
+        width: min(1180px, 100%);
+        margin: 0 auto;
+        padding: 1.5rem 1rem 2.5rem;
+      }
+
+      .wf-index-hero {
+        border-radius: 1.2rem;
+        background: linear-gradient(140deg, #312e81 0%, #4338ca 52%, #4f46e5 100%);
+        color: #ecfeff;
+        padding: 1.35rem 1.3rem 1.2rem;
+        box-shadow: 0 16px 38px rgba(15, 23, 42, 0.21);
+      }
+
+      .wf-index-hero h1 {
+        font-size: clamp(1.9rem, 3.2vw, 2.7rem);
+        line-height: 1.08;
+        font-weight: 900;
+        letter-spacing: -0.02em;
+      }
+
+      .wf-index-hero p {
+        margin-top: 0.7rem;
+        max-width: 70ch;
+        line-height: 1.58;
+        color: rgba(236, 254, 255, 0.92);
+      }
+
+      .wf-toolbar {
+        margin-top: 1rem;
+        border-radius: 1rem;
+        background: rgba(255, 255, 255, 0.96);
+        border: 1px solid #dbe7f0;
+        box-shadow: 0 8px 20px rgba(15, 23, 42, 0.09);
+        padding: 0.9rem;
+      }
+
+      .wf-toolbar-grid {
+        display: grid;
+        gap: 0.7rem;
+      }
+
+      .wf-toolbar input,
+      .wf-toolbar select {
+        width: 100%;
+        border-radius: 0.75rem;
+        border: 1px solid #cbd5e1;
+        padding: 0.72rem 0.85rem;
+        font-size: 0.9rem;
+        color: #0f172a;
+      }
+
+      .wf-toolbar input:focus,
+      .wf-toolbar select:focus {
+        outline: 2px solid #c7d2fe;
+        outline-offset: 1px;
+        border-color: #6366f1;
+      }
+
+      .wf-card {
+        position: relative;
+        transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+        box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+      }
+
+      .wf-card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 14px 28px rgba(15, 23, 42, 0.13);
+        border-color: #c7d2fe;
+      }
+
+      .wf-card-accent {
+        width: 46px;
+        height: 6px;
+        border-radius: 999px;
+        background: linear-gradient(90deg, #4f46e5 0%, #6366f1 100%);
+        margin-bottom: 0.75rem;
+      }
+
+      @media (min-width: 860px) {
+        .wf-toolbar-grid {
+          grid-template-columns: 1fr 220px;
+        }
+      }
+    </style>
 </head>
-<body class="bg-slate-50 text-slate-900 min-h-screen">
-    <main class="max-w-6xl mx-auto px-4 py-10">
-        <header class="mb-8">
-            <h1 class="text-4xl font-extrabold tracking-tight">Help Portal</h1>
-            <p class="mt-3 text-slate-600 text-lg">Multi-page documentation by workflow and role. Use the page reference for file-by-file feature coverage.</p>
-        </header>
-
-        <section class="grid gap-4 md:grid-cols-2">
-            <a href="help-account.html" class="block rounded-xl border border-slate-200 bg-white p-5 hover:border-blue-300 hover:bg-blue-50 transition">
-                <h2 class="text-xl font-bold text-slate-900">Account and Access</h2>
-                <p class="mt-2 text-slate-600">Login, forgot password, sign-up, invite acceptance, profile, and role access behaviors.</p>
-                <p class="mt-3 text-sm font-semibold text-blue-700">Open guide →</p>
-            </a>
-            <a href="help-team-operations.html" class="block rounded-xl border border-slate-200 bg-white p-5 hover:border-blue-300 hover:bg-blue-50 transition">
-                <h2 class="text-xl font-bold text-slate-900">Team Operations</h2>
-                <p class="mt-2 text-slate-600">Create teams, manage roster/config, schedule planning, admin views, and parent dashboard flows.</p>
-                <p class="mt-3 text-sm font-semibold text-blue-700">Open guide →</p>
-            </a>
-            <a href="help-game-operations.html" class="block rounded-xl border border-slate-200 bg-white p-5 hover:border-blue-300 hover:bg-blue-50 transition">
-                <h2 class="text-xl font-bold text-slate-900">Game Operations</h2>
-                <p class="mt-2 text-slate-600">Game day setup, planning, standard/live tracking, statsheet entry, and report verification.</p>
-                <p class="mt-3 text-sm font-semibold text-blue-700">Open guide →</p>
-            </a>
-            <a href="help-watch-chat.html" class="block rounded-xl border border-slate-200 bg-white p-5 hover:border-blue-300 hover:bg-blue-50 transition">
-                <h2 class="text-xl font-bold text-slate-900">Watch and Chat</h2>
-                <p class="mt-2 text-slate-600">Live/replay game viewing, chat workflows, tagging/mentions, and communication ownership by role.</p>
-                <p class="mt-3 text-sm font-semibold text-blue-700">Open guide →</p>
-            </a>
+<body class="text-gray-900 min-h-screen flex flex-col">
+    <div id="header-container"></div>
+    <main class="flex-grow">
+      <div class="wf-index-shell">
+        <section class="wf-index-hero">
+            <h1>ALL PLAYS Help Center</h1>
+            <p>Workflow-first guides built around real user outcomes. Find what you need, filter by role, and move from setup to game day faster.</p>
         </section>
 
-        <section class="mt-6">
-            <a href="help-page-reference.html" class="block rounded-xl border-2 border-blue-200 bg-blue-50 p-6 hover:bg-blue-100 transition">
-                <h2 class="text-2xl font-extrabold text-blue-900">File-by-File Page Reference</h2>
-                <p class="mt-2 text-blue-900/90">Lists each page in this site with features and which roles should use it.</p>
-                <p class="mt-3 text-sm font-semibold text-blue-800">Open full page reference →</p>
-            </a>
+        <section class="wf-toolbar">
+          <div class="wf-toolbar-grid">
+            <div>
+              <input id="help-search" type="search" placeholder="Search workflows, tasks, or keywords" />
+            </div>
+            <div>
+              <select id="help-role">
+                <option value="">All roles</option>
+                <option value="Parent">Parent</option>
+                <option value="Coach">Coach</option>
+                <option value="Admin">Admin</option>
+                <option value="Member">Member</option>
+              </select>
+            </div>
+          </div>
+          <p id="help-summary" class="mt-3 text-sm text-slate-600"></p>
         </section>
+
+        <section id="help-empty" class="mt-6 hidden rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">No workflows matched your current filters.</section>
+        <section id="help-grid" class="mt-6 grid gap-4 md:grid-cols-2">
+        <article class="wf-card rounded-2xl border border-slate-200 bg-white p-5">
+            <div class="wf-card-accent"></div>
+            <h2 class="text-xl font-extrabold tracking-tight text-slate-900">Operate Platform Admin Controls</h2>
+            <p class="mt-2 text-sm text-slate-600 leading-6">Use this workflow to run platform admin operations in ALL PLAYS. You will confirm admin access, review platform activity, update teams, manage admin invites, and verify user visibility.</p>
+            <div class="mt-4 flex flex-wrap gap-2"><span class="wf-role-chip">Admin</span></div>
+            <a class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 hover:text-primary-800" href="workflow-admin-ops.html">Open workflow <span aria-hidden="true">→</span></a>
+        </article>
+    
+
+        <article class="wf-card rounded-2xl border border-slate-200 bg-white p-5">
+            <div class="wf-card-accent"></div>
+            <h2 class="text-xl font-extrabold tracking-tight text-slate-900">Use the Right Dashboard for Your Role</h2>
+            <p class="mt-2 text-sm text-slate-600 leading-6">Choose the dashboard that matches what you need to do right now.</p>
+            <div class="mt-4 flex flex-wrap gap-2"><span class="wf-role-chip">Parent</span> <span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span></div>
+            <a class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 hover:text-primary-800" href="workflow-choose-home-dashboard.html">Open workflow <span aria-hidden="true">→</span></a>
+        </article>
+    
+
+        <article class="wf-card rounded-2xl border border-slate-200 bg-white p-5">
+            <div class="wf-card-accent"></div>
+            <h2 class="text-xl font-extrabold tracking-tight text-slate-900">Coordinate Team Messages and Availability</h2>
+            <p class="mt-2 text-sm text-slate-600 leading-6">Use this workflow to keep families, coaches, and admins aligned before, during, and after events.</p>
+            <div class="mt-4 flex flex-wrap gap-2"><span class="wf-role-chip">Parent</span> <span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span></div>
+            <a class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 hover:text-primary-800" href="workflow-communication.html">Open workflow <span aria-hidden="true">→</span></a>
+        </article>
+    
+
+        <article class="wf-card rounded-2xl border border-slate-200 bg-white p-5">
+            <div class="wf-card-accent"></div>
+            <h2 class="text-xl font-extrabold tracking-tight text-slate-900">Run Pre-Game Through Wrap-Up Command</h2>
+            <p class="mt-2 text-sm text-slate-600 leading-6">Use Game Day Command Center for one continuous game-day flow.</p>
+            <div class="mt-4 flex flex-wrap gap-2"><span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span></div>
+            <a class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 hover:text-primary-800" href="workflow-game-day.html">Open workflow <span aria-hidden="true">→</span></a>
+        </article>
+    
+
+        <article class="wf-card rounded-2xl border border-slate-200 bg-white p-5">
+            <div class="wf-card-accent"></div>
+            <h2 class="text-xl font-extrabold tracking-tight text-slate-900">Create or Access Your Account</h2>
+            <p class="mt-2 text-sm text-slate-600 leading-6">Use this workflow to get into ALL PLAYS fast.</p>
+            <div class="mt-4 flex flex-wrap gap-2"><span class="wf-role-chip">Parent</span> <span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span> <span class="wf-role-chip">Member</span></div>
+            <a class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 hover:text-primary-800" href="workflow-getting-started.html">Open workflow <span aria-hidden="true">→</span></a>
+        </article>
+    
+
+        <article class="wf-card rounded-2xl border border-slate-200 bg-white p-5">
+            <div class="wf-card-accent"></div>
+            <h2 class="text-xl font-extrabold tracking-tight text-slate-900">Join a Team from an Invite</h2>
+            <p class="mt-2 text-sm text-slate-600 leading-6">Use this workflow to join a team with an invite link or an 8-character invite code.</p>
+            <div class="mt-4 flex flex-wrap gap-2"><span class="wf-role-chip">Parent</span> <span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span></div>
+            <a class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 hover:text-primary-800" href="workflow-join-team.html">Open workflow <span aria-hidden="true">→</span></a>
+        </article>
+    
+
+        <article class="wf-card rounded-2xl border border-slate-200 bg-white p-5">
+            <div class="wf-card-accent"></div>
+            <h2 class="text-xl font-extrabold tracking-tight text-slate-900">Watch Live Games and Replays</h2>
+            <p class="mt-2 text-sm text-slate-600 leading-6">Use this workflow to open a game, follow it live, and switch to replay or the match report after the game ends.</p>
+            <div class="mt-4 flex flex-wrap gap-2"><span class="wf-role-chip">Parent</span> <span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span> <span class="wf-role-chip">Member</span></div>
+            <a class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 hover:text-primary-800" href="workflow-live-watch-replay.html">Open workflow <span aria-hidden="true">→</span></a>
+        </article>
+    
+
+        <article class="wf-card rounded-2xl border border-slate-200 bg-white p-5">
+            <div class="wf-card-accent"></div>
+            <h2 class="text-xl font-extrabold tracking-tight text-slate-900">Review, Edit, and Share Postgame Results</h2>
+            <p class="mt-2 text-sm text-slate-600 leading-6">Use this workflow after a game ends to verify results, clean up postgame details, and share links.</p>
+            <div class="mt-4 flex flex-wrap gap-2"><span class="wf-role-chip">Parent</span> <span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span> <span class="wf-role-chip">Member</span></div>
+            <a class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 hover:text-primary-800" href="workflow-postgame.html">Open workflow <span aria-hidden="true">→</span></a>
+        </article>
+    
+
+        <article class="wf-card rounded-2xl border border-slate-200 bg-white p-5">
+            <div class="wf-card-accent"></div>
+            <h2 class="text-xl font-extrabold tracking-tight text-slate-900">Build and Maintain Team Roster</h2>
+            <p class="mt-2 text-sm text-slate-600 leading-6">Use this workflow to keep your team roster accurate and parent access connected.</p>
+            <div class="mt-4 flex flex-wrap gap-2"><span class="wf-role-chip">Parent</span> <span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span></div>
+            <a class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 hover:text-primary-800" href="workflow-roster.html">Open workflow <span aria-hidden="true">→</span></a>
+        </article>
+    
+
+        <article class="wf-card rounded-2xl border border-slate-200 bg-white p-5">
+            <div class="wf-card-accent"></div>
+            <h2 class="text-xl font-extrabold tracking-tight text-slate-900">Plan Schedule and Launch Game Flows</h2>
+            <p class="mt-2 text-sm text-slate-600 leading-6">Use this workflow to publish reliable games and practices, then launch game-day tools from the schedule.</p>
+            <div class="mt-4 flex flex-wrap gap-2"><span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span></div>
+            <a class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 hover:text-primary-800" href="workflow-schedule.html">Open workflow <span aria-hidden="true">→</span></a>
+        </article>
+    
+
+        <article class="wf-card rounded-2xl border border-slate-200 bg-white p-5">
+            <div class="wf-card-accent"></div>
+            <h2 class="text-xl font-extrabold tracking-tight text-slate-900">Create Team Foundation and Staff Access</h2>
+            <p class="mt-2 text-sm text-slate-600 leading-6">Set up your team foundation first, then grant staff access.</p>
+            <div class="mt-4 flex flex-wrap gap-2"><span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span></div>
+            <a class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 hover:text-primary-800" href="workflow-team-setup.html">Open workflow <span aria-hidden="true">→</span></a>
+        </article>
+    
+
+        <article class="wf-card rounded-2xl border border-slate-200 bg-white p-5">
+            <div class="wf-card-accent"></div>
+            <h2 class="text-xl font-extrabold tracking-tight text-slate-900">Track Live Game Stats by Mode</h2>
+            <p class="mt-2 text-sm text-slate-600 leading-6">Use this workflow to track a game from start to finish and publish an accurate game report.</p>
+            <div class="mt-4 flex flex-wrap gap-2"><span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span></div>
+            <a class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 hover:text-primary-800" href="workflow-track-game.html">Open workflow <span aria-hidden="true">→</span></a>
+        </article>
+    </section>
+      </div>
     </main>
+    <div id="footer-container"></div>
+
+    <script id="help-manifest" type="application/json">[{"id":"admin-ops","title":"Operate Platform Admin Controls","roles":["Admin"],"file":"workflow-admin-ops.html","summary":"Use this workflow to run platform admin operations in ALL PLAYS. You will confirm admin access, review platform activity, update teams, manage admin invites, and verify user visibility.","readTimeMin":4,"searchText":"# Operate Platform Admin Controls\n\n## Overview\nUse this workflow to run platform admin operations in ALL PLAYS. You will confirm admin access, review platform activity, update teams, manage admin invites, and verify user visibility.\n\nUse it when you are starting an admin session, checking platform health, or handling team lifecycle updates.\n\n## In This Article\n- Confirm admin entitlement before sensitive actions.\n- Review teams, users, games, and recent activity in the admin dashboard.\n- Find active and inactive teams.\n- Update team settings and manage team admin invites.\n- Deactivate teams when owner controls are available.\n- Recover from common access, search, and save issues.\n\n## Who Is This For\n- Platform admins who oversee teams, users, and platform activity.\n- Team owners and full team admins handling team updates.\n\n## Prerequisites\n- You are signed in to ALL PLAYS.\n- Your account has admin entitlement (`isAdmin` is `true`).\n- You can open `check-admin-status.html` and `admin.html`.\n- For team lifecycle work, you can open `edit-team.html` and `dashboard.html`.\n\n## Choose Your Path\n- **Start of session or access issue:** Open `check-admin-status.html` to confirm admin entitlement.\n- **Platform health review:** Open `admin.html` and use the `Dashboard` tab.\n- **Team updates and cleanup:** Open `admin.html` on `Teams`, then open the team in `edit-team.html`.\n- **Team deactivation:** Open `dashboard.html` with an owner account.\n\n## Step-by-Step Workflow\n1. Confirm admin entitlement in `check-admin-status.html`. Continue only when you see `isAdmin field is TRUE`. If you see `Not logged in`, sign in and reload. If admin status is not true, stop and request admin enablement.\n2. Open `admin.html` and confirm your account is shown as the logged-in admin. Start on the `Dashboard` tab.\n3. Review platform activity cards for team count, user count, games, and 7-day activity. Review `Recent Teams` and `Recent Users`. Use `View All Teams` or `View All Users` when needed.\n4. "},{"id":"choose-home-dashboard","title":"Use the Right Dashboard for Your Role","roles":["Parent","Coach","Admin"],"file":"workflow-choose-home-dashboard.html","summary":"Choose the dashboard that matches what you need to do right now.","readTimeMin":3,"searchText":"# Use the Right Dashboard for Your Role\n\n## Overview\nChoose the dashboard that matches what you need to do right now.\n\n- Use **Parent Dashboard** for family tasks.\n- Use **My Teams Dashboard** for team operations.\n- If you have more than one role, switch dashboards by task.\n\n## In This Article\n- How to choose the right dashboard quickly.\n- What each dashboard is best for.\n- What to do if teams, players, or actions are missing.\n\n## Who Is This For\n- **Parents** managing linked players and family activity.\n- **Coaches** managing team operations.\n- **Admins** supporting or managing team operations.\n\n## Prerequisites\n- You are signed in to ALL PLAYS.\n- Your account has the correct role and team/player links.\n- You have at least one linked team or player.\n\n## Choose Your Path\n- Choose **Parent Dashboard** when you need family tools.\n- Choose **My Teams Dashboard** when you need team management tools.\n- Choose **Calendar** when you need one combined schedule view across accessible teams.\n- If you are both parent and coach/admin, pick the dashboard based on the task, not the account.\n\n## Step-by-Step Workflow\n1. Sign in to ALL PLAYS and confirm you are in the correct account.\n2. Pick your goal: family/player task means **Parent Dashboard**; team operations task means **My Teams Dashboard**.\n3. Open the dashboard that matches your goal.\n4. Start work from that page: on **Parent Dashboard** use **My Players**, **My Teams**, or **Redeem Code**; on **My Teams Dashboard** open a team card and use **View**, **Chat**, **Edit**, **Roster**, or **Schedule**.\n5. Open team details when you need to work in one specific team context.\n6. Open **Calendar** for cross-team planning, then filter by team, event type, and date range; export `.ics` when needed.\n7. Check your access level before edits; if actions are read-only, you likely have parent-level access for that team.\n\n## Common Questions\n**Which dashboard should I bookmark?**\n- Parents: **Parent Dashboard**.\n- Coaches/Admins: **My Te"},{"id":"communication","title":"Coordinate Team Messages and Availability","roles":["Parent","Coach","Admin"],"file":"workflow-communication.html","summary":"Use this workflow to keep families, coaches, and admins aligned before, during, and after events.","readTimeMin":3,"searchText":"# Coordinate Team Messages and Availability\n\n## Overview\nUse this workflow to keep families, coaches, and admins aligned before, during, and after events.\n\nStart by choosing the path that matches your goal: team chat, RSVP, rideshare, or live-game chat.\n\n## In This Article\n- Pick the right path for messaging, availability, or rideshare.\n- Send clear team updates and ask `@ALL PLAYS` questions.\n- Set event status as `Going`, `Maybe`, or `Can't Go`.\n- Offer rides, request spots, and manage request decisions.\n- Recover quickly from common send, access, and RSVP issues.\n\n## Who Is This For\n- Parent: Share updates, set availability, and coordinate rides.\n- Coach: Post reminders, keep chat focused, and moderate chat.\n- Admin: Support communication standards and moderate chat.\n\n## Prerequisites\n- You are signed in.\n- You have access to at least one team.\n- You opened a team context from your dashboard, team view, calendar, or live game page.\n- For RSVP buttons, the event is already tracked in the team schedule.\n\n## Choose Your Path\n1. Send a team update or reminder now: use team chat.\n2. Submit event availability: use the schedule list or calendar event view.\n3. Coordinate transportation: use event rideshare.\n4. Communicate during a game: use live-game chat when enabled.\n\n## Step-by-Step Workflow\n### Path A: Team Messages and Moderation\n1. Open team chat from your current team context.\n2. Write one clear update per message.\n3. Optional: add voice input or attach one image (up to 5 MB).\n4. To ask the assistant, include `@ALL PLAYS` and your question in the same message.\n5. Select **Send**.\n6. Confirm the message appears in the thread.\n7. Add reactions for quick acknowledgment.\n8. Edit or delete your own message if plans change.\n9. If you are a Coach or Admin, remove off-topic or inappropriate messages from others when needed.\n10. For live-game chat, post short updates. If chat is locked, retry at game time.\n\n### Path B: RSVP Availability\n1. Open the event from schedule list"},{"id":"game-day","title":"Run Pre-Game Through Wrap-Up Command","roles":["Coach","Admin"],"file":"workflow-game-day.html","summary":"Use Game Day Command Center for one continuous game-day flow.","readTimeMin":5,"searchText":"# Run Pre-Game Through Wrap-Up Command\n\n## Overview\nUse Game Day Command Center for one continuous game-day flow.\n\nConfirm game details, lock availability and lineup, manage live decisions, then close with notes and summary. This keeps in-game decisions fast and post-game follow-through clean.\n\n## In This Article\n- Choose the right starting path for your game-day situation.\n- Run pre-game checks and save lineup.\n- Manage live substitutions, logs, score, and stats.\n- Complete wrap-up and hand off to reporting and practice planning.\n- Recover from common game-day issues.\n\n## Who Is This For\n- Coach: Owns lineup, substitutions, live coaching log, and wrap-up decisions.\n- Admin: Owns schedule accuracy, availability support, and final data quality.\n- Coach + Admin: Split work so one person coaches while the other updates score and logs.\n\n## Prerequisites\n- A scheduled game exists with valid `teamId` and `gameId`.\n- You have full team access (coach/admin-level controls).\n- Open from `edit-schedule.html` using **Command Center**, or use `game-day.html?teamId=...&gameId=...`.\n- The roster is loaded so availability and lineup can be set.\n\n## Choose Your Path\n1. Start from schedule and run the full flow.\nGo to `edit-schedule.html`, find the game, and select **Command Center**.\n\n2. Fix setup first, then run Command Center.\nIn `edit-schedule.html`, select **Edit** and correct date, opponent, location, home/away, or kit. Then return and open **Command Center**.\n\n3. Check quick context before kickoff.\nOpen `team.html`, review **Upcoming Games** or **Recent Results**, then launch **Command Center** from `edit-schedule.html`.\n\n4. Plan the next practice from game outcomes.\nIn the Game Day pre-game rail, use **Plan →** from prior focus items, or finish wrap-up analysis first. Continue in `drills.html`.\n\n## Step-by-Step Workflow\n1. Open the correct game.\nIn `edit-schedule.html`, filter to upcoming games and select **Command Center**. Confirm opponent and date before changes.\n\n2. Valid"},{"id":"getting-started","title":"Create or Access Your Account","roles":["Parent","Coach","Admin","Member"],"file":"workflow-getting-started.html","summary":"Use this workflow to get into ALL PLAYS fast.","readTimeMin":4,"searchText":"# Create or Access Your Account\n\n## Overview\nUse this workflow to get into ALL PLAYS fast.\n\nChoose the path that matches your situation: new account, sign-in, password reset, or email verification.\n\n## In This Article\n- Choose the right account access path.\n- Create a new account with an activation code.\n- Sign in with email/password or Google.\n- Verify your email now or later.\n- Reset your password.\n- Resolve common login and verification issues.\n\n## Who Is This For\n- Parent: Create an account from a code, or sign in to continue team access.\n- Coach: Create or sign in, then verify email and keep access active.\n- Admin: Create or sign in, then continue invite-based onboarding when needed.\n- Member: Create or sign in with an activation code and confirm access.\n\n## Prerequisites\n- You can access your email inbox now.\n- You have a stable internet connection and supported browser.\n- For first-time signup, you have an 8-character activation code.\n- If you prefer Google sign-in, you have a Google account.\n\n## Choose Your Path\n- Path A: I am new and have an activation code.\n- Path B: I already have an account.\n- Path C: I forgot my password.\n- Path D: I need to verify my email or resend verification.\n- Path E: I signed in with an email link and want to set a password.\n\n## Step-by-Step Workflow\n1. Open `index.html` and select **Get Started Now**, or go to `login.html`.\n2. Follow the path that matches your situation.\n\n### Path A: Create a new account\n1. On `login.html`, select **Sign Up**.\n2. Enter your email, password, and confirm password.\n3. Enter your 8-character activation code.\n4. Select **Create Account**.\n5. Optional: Select **Continue with Google** in Sign Up mode. You still need an activation code.\n6. After signup, go to `verify-pending.html`.\n7. Open your verification email and select the link.\n8. If needed, select **Resend Verification Email**.\n\n### Path B: Sign in to an existing account\n1. On `login.html`, stay in **Login** mode.\n2. Sign in with **Sign In** (ema"},{"id":"join-team","title":"Join a Team from an Invite","roles":["Parent","Coach","Admin"],"file":"workflow-join-team.html","summary":"Use this workflow to join a team with an invite link or an 8-character invite code.","readTimeMin":3,"searchText":"# Join a Team from an Invite\n\n## Overview\nUse this workflow to join a team with an invite link or an 8-character invite code.\n\nYou will redeem the invite, then confirm you landed in the correct dashboard for your role.\n\n## In This Article\n- Choose the right invite path.\n- Join with a link or manual code.\n- Complete sign-in or account creation.\n- Confirm your dashboard and team access.\n- Fix common invite and sign-in issues.\n\n## Who Is This For\n- Parent users joining a child’s team.\n- Coach users joining team staff access.\n- Admin users joining admin/team access.\n\n## Prerequisites\n- You have a valid invite link or 8-character invite code.\n- You are ready to sign in or create an account.\n- You can use the same email address that received the invite.\n- You can stay in the invite flow until you see success.\n\n## Choose Your Path\n1. I have an invite link and I am already signed in.\n   Open the link and continue through invite confirmation.\n2. I have an invite link and I am not signed in.\n   Open the link, then sign in or create an account when prompted.\n3. I only have an 8-character code.\n   Open invite acceptance, choose manual code entry, then enter the code.\n4. I am a parent adding another player after I already joined.\n   Use `Redeem Code` in Parent Dashboard with the new code.\n\n## Step-by-Step Workflow\n1. Open your invite link.\n   If the page shows `Processing Invite...`, wait for it to finish.\n2. Confirm your email if prompted.\n   If you opened the link on another device, enter the invited email and select `Continue`.\n3. Enter your invite code if needed.\n   If manual entry appears, type the 8-character code and select `Join Team`.\n4. Sign in or create your account.\n   Existing account: sign in with email/password or Google.\n   New account: select `Sign Up`, complete the form, and provide the activation code if asked.\n5. Complete invite redemption.\n   Return to the invite flow if prompted. Wait for `You’re In!` and the automatic redirect.\n6. Verify your role-based de"},{"id":"live-watch-replay","title":"Watch Live Games and Replays","roles":["Parent","Coach","Admin","Member"],"file":"workflow-live-watch-replay.html","summary":"Use this workflow to open a game, follow it live, and switch to replay or the match report after the game ends.","readTimeMin":4,"searchText":"# Watch Live Games and Replays\n\n## Overview\nUse this workflow to open a game, follow it live, and switch to replay or the match report after the game ends.\n\nYou can start from a shared watch link, the home page, the team page, or the match report page.\n\n## In This Article\n- Where to open a live or completed game.\n- How to follow score, stream, plays, stats, chat, and reactions during live action.\n- How to move to replay and match report after the final score.\n- What to do when live, replay, chat, or sharing is not working.\n\n## Who Is This For\n- Parent: Watch live score and stream, join chat, and watch replay later.\n- Member: Follow live updates, then review replay or match report.\n- Coach: Watch live, share game and report links, and direct families to replay/report.\n- Admin: Same as Coach, plus full-access match report editing (for example, summary updates).\n\n## Prerequisites\n- You have a watch link, or you can open the game from the home page or team page.\n- The game is scheduled, live, or completed.\n- You have a stable internet connection.\n- For team-level sharing or report actions, sign in with your team account.\n\n## Choose Your Path\n1. Shared link path\nOpen the shared watch link directly.\n\n2. Home page path (`index.html`)\nOpen **Live & Upcoming Games** and select **Watch Now** or **View Details**.\nOpen **Recent Replays** and select **Watch Replay**.\n\n3. Team page path (`team.html`)\nFind the game card.\nFor active or upcoming games, select **Live Now** or **View Live**.\nFor completed games, select **Replay** or **View Report**.\n\n4. Match report path (`game.html`)\nOpen the game report and select **Watch Replay** or **Live Now** (when shown).\n\n## Step-by-Step Workflow\n1. Open the game in live view.\nGo to `live-game.html`. Confirm the scoreboard is visible at the top.\n\n2. Check game status.\nIf the game is live, look for the **LIVE** badge and current score.\nIf the game has not started, you may see **Game Not Live Yet**.\nIf the game is finished, use **Watch Replay** "},{"id":"postgame","title":"Review, Edit, and Share Postgame Results","roles":["Parent","Coach","Admin","Member"],"file":"workflow-postgame.html","summary":"Use this workflow after a game ends to verify results, clean up postgame details, and share links.","readTimeMin":4,"searchText":"# Review, Edit, and Share Postgame Results\n\n## Overview\nUse this workflow after a game ends to verify results, clean up postgame details, and share links.\n\nStart in `team.html` for fast sharing. Use `game.html` for a full review and edits.\n\n## In This Article\n- Pick the fastest path for your postgame goal.\n- Verify final score, events, and player performance.\n- Edit summary and score sheet if you have full access.\n- Share report and replay links.\n- Fix common postgame issues quickly.\n\n## Who Is This For\n- Parent: Review results, replay, and player details.\n- Coach: Finalize report quality, verify stats, and publish results.\n- Admin: Support edits, accuracy checks, and sharing.\n- Member: Open shared report and replay links.\n\n## Prerequisites\n- The game is completed and game data exists.\n- You have the correct team or game link.\n- To edit summary or score sheet, sign in with full team access (Coach/Admin).\n\n## Choose Your Path\n- Quick share: Open `team.html` and share from `Recent Results`.\n- Full review: Open `game.html` to confirm summary, play-by-play, and player performance.\n- Player follow-up: From `game.html`, open a player in `player.html`.\n- Replay sharing: Share replay from `team.html`, `game.html`, or `live-game.html` when available.\n\n## Step-by-Step Workflow\n1. Open the completed game report.\n   In `team.html`, go to `Recent Results`, then select `View Report`.\n2. Confirm final game info.\n   Verify opponent, date, final score, and outcome label.\n3. Review report sections.\n   Check `Match Summary`, `Play-by-Play`, and `Player Performance`.\n4. Edit summary if needed (Coach/Admin only).\n   Select `Edit Summary`, update content, then select `Save Summary`.\n5. Optionally generate summary text (Coach/Admin only).\n   Select `Generate AI Summary`, review it, edit as needed, and save.\n6. Update score sheet if needed (Coach/Admin only).\n   Use `Upload Score Sheet`, preview, and save.\n7. Correct score sheet if needed (Coach/Admin only).\n   Use `Remove Score Sheet`, up"},{"id":"roster","title":"Build and Maintain Team Roster","roles":["Parent","Coach","Admin"],"file":"workflow-roster.html","summary":"Use this workflow to keep your team roster accurate and parent access connected.","readTimeMin":4,"searchText":"# Build and Maintain Team Roster\n\n## Overview\nUse this workflow to keep your team roster accurate and parent access connected.\n\nYou can:\n- Add players and jersey numbers.\n- Update player details.\n- Deactivate players without losing history, then reactivate them later.\n- Link parents to active players and send invites.\n\n## In This Article\n- Who should run this workflow.\n- What to prepare before you start.\n- How to choose the right roster action.\n- Step-by-step roster and parent invite actions.\n- How to recover from common invite or roster issues.\n\n## Who Is This For\n- Coach: Day-to-day roster updates and parent invites for active players.\n- Admin: Full roster cleanup, including reactivation and parent-link fixes.\n\n## Prerequisites\n- A team already exists.\n- You have full-access permissions for that team.\n- Player names and jersey details are ready.\n- Parent emails are ready if you plan to send email invites.\n\n## Choose Your Path\n- Add one player: Use **Add Player**.\n- Add many players: Use **Bulk AI Update** with roster text or an image, then review and apply.\n- Correct player details: Use **Edit** on that player row.\n- Remove a player from active roster: Use **Deactivate**.\n- Bring a player back: Use **Reactivate**.\n- Link a parent: Use **Invite Parent** on an active player.\n- Invite Parent is disabled: Reactivate the player first, then send the invite.\n\n## Step-by-Step Workflow\n1. Open roster management and confirm you are on the correct team.\n2. Add or update players.\n- Single add: In **Add Player**, enter name and optional number/photo, then submit.\n- Bulk update: In **Bulk AI Update**, upload an image and/or paste roster text. Select **Process with AI**, review changes, then select **Apply Changes**.\n3. Edit a player when details change.\n- Select **Edit** in the player row, update name/number/photo, then save.\n4. Manage active status.\n- Select **Deactivate** to remove a player from active roster while keeping stats and history.\n- Select **Reactivate** when the p"},{"id":"schedule","title":"Plan Schedule and Launch Game Flows","roles":["Coach","Admin"],"file":"workflow-schedule.html","summary":"Use this workflow to publish reliable games and practices, then launch game-day tools from the schedule.","readTimeMin":5,"searchText":"# Plan Schedule and Launch Game Flows\n\n## Overview\nUse this workflow to publish reliable games and practices, then launch game-day tools from the schedule.\n\nYou will use:\n- `edit-schedule.html` to create and manage events.\n- `game-plan.html` to prepare lineups.\n- `team.html` and `calendar.html` to review, share, and export.\n- `live-game.html` for live viewing and replay access.\n\n## In This Article\n- Set up schedule inputs and external calendar links.\n- Add games with key details, assignments, and stat config.\n- Add one-time or recurring practices.\n- Edit one date or an entire recurring series safely.\n- Launch planning, tracking, command center, and live tools.\n- Share live links and find replay/report links.\n- Verify availability visibility and export `.ics` files.\n\n## Who Is This For\n- Coach: Publish weekly events, prep upcoming games, and launch tracking quickly.\n- Admin: Maintain calendar feeds, clean recurring data, and keep schedule quality high.\n\n## Prerequisites\n- Your team is created and accessible.\n- You are signed in with coach/admin manage access for that team.\n- Roster and game details are ready (date, time, location, opponent).\n- If importing calendars, you have valid `.ics` URLs.\n\n## Choose Your Path\n1. Build or update the full schedule: start at Step 1 and continue through Step 7.\n2. Import from another calendar: complete Step 2, then Step 7 for any games you need to track.\n3. Prepare game execution: use Step 8 and Step 9.\n4. Share live or replay access with families: use Step 10.\n5. Validate final visibility and export views: use Step 11.\n\n## Step-by-Step Workflow\n1. Open `edit-schedule.html` for the correct team.\nStart in `All Upcoming`. Confirm the team name before you edit.\n\n2. Add or verify external calendars in **Calendar Links**.\nSelect `+ Add Calendar`, paste a valid `.ics` URL, and save.\nCoach focus: add feeds you rely on.\nAdmin focus: remove outdated feeds and keep trusted sources.\n\n3. Add games in the **Game** tab.\nEnter `Date & Time`, `Opp"},{"id":"team-setup","title":"Create Team Foundation and Staff Access","roles":["Coach","Admin"],"file":"workflow-team-setup.html","summary":"Set up your team foundation first, then grant staff access.","readTimeMin":4,"searchText":"# Create Team Foundation and Staff Access\n\n## Overview\nSet up your team foundation first, then grant staff access.\n\nThis workflow helps you create or update a team, set core team details, and manage coach/admin invites.\n\n## In This Article\n- When to create a new team vs update an existing team\n- How to complete team foundation settings in one pass\n- How to invite staff and handle invite delivery issues\n- How to verify what families and players will see\n- How to recover from common setup and access problems\n\n## Who Is This For\n- Coach: Set up team identity and invite assistant coaches/admins\n- Admin: Standardize team setup, visibility, and staff access across teams\n\n## Prerequisites\n- You are signed in\n- You have full team management permissions\n- You already chose the team name and sport\n- You have staff emails ready if you plan to invite coaches/admins\n\n## Choose Your Path\n- Create a new team: Open **My Teams** (`dashboard.html`) and select **Create New Team**\n- Update an existing team: Open **My Teams**, select the team, then choose **Edit**\n- Manage staff access only: Open **Edit Team** and go to **Admin Access**\n\n## Step-by-Step Workflow\n1. Open the team editor.\n- New team: `dashboard.html` -> **Create New Team**\n- Existing team: `dashboard.html` -> team card -> **Edit**\n\n2. Confirm edit access.\n- If you can see the full form and **Save Team**, continue.\n- If you are blocked or redirected, ask the team owner to add you as an admin.\n\n3. Complete team identity.\n- Enter **Team Name**\n- Select **Sport**\n- Add **Description** (recommended)\n\n4. Add communication and location details.\n- Enter **ZIP Code**\n- Enter **Notification Email**\n\n5. Add links families will use.\n- Add **League Link** for standings\n- Add **Live Stream** (YouTube or Twitch URL)\n\n6. Set visibility.\n- Enable **Public Team** to make the team discoverable in Browse Teams\n- Disable it for invite/direct-link access only\n\n7. Invite coach/admin staff.\n- In **Admin Access**, select **+ Add Admin**\n- Enter e"},{"id":"track-game","title":"Track Live Game Stats by Mode","roles":["Coach","Admin"],"file":"workflow-track-game.html","summary":"Use this workflow to track a game from start to finish and publish an accurate game report.","readTimeMin":4,"searchText":"# Track Live Game Stats by Mode\n\n## Overview\nUse this workflow to track a game from start to finish and publish an accurate game report.\n\nYou can choose the tracker mode that fits your situation, capture events during play, then complete the game with final scores and summary details.\n\n## In This Article\n- Who should use this workflow.\n- What to confirm before you start.\n- How to choose the right tracker mode.\n- Step-by-step actions from schedule to final report.\n- Common questions and recovery steps.\n\n## Who Is This For\n- Coaches who enter live stats, manage periods, and handle substitutions.\n- Admins who support tracking, verify final accuracy, and finalize report details.\n\n## Prerequisites\n- You are signed in as a coach or admin.\n- You are opening a game event, not a practice.\n- The game has a valid team and game context (`teamId` and `gameId`).\n- A tracker configuration exists for the team.\n\n## Choose Your Path\nUse this quick guide before you start:\n\n- **Standard**: Use for classic manual entry with timer, team/opponent stats, and finish flow.\n- **Beta**: Use for sideline-focused basketball tracking with quick substitutions.\n- **Live Broadcast Tracker**: Use Beta-style tracking plus live chat and live-view context.\n- **Photo Score Sheet**: Use after the game to import final stats from a score sheet image.\n\nImportant behavior:\n- If no mode chooser appears, the game opens in the default Standard tracker.\n- If the game is already complete, open **Report** instead of starting a new tracking session.\n\n## Step-by-Step Workflow\n1. Open the game from schedule.\n- Select **Track** on the game card.\n- Confirm opponent, date, and location.\n\n2. Select the tracker mode.\n- Pick the mode that matches your game situation.\n- Select **Start** to begin clocked tracking.\n\n3. Track events during play.\n- Update period as the game moves through Q1-Q4 and OT.\n- In **Standard**, log team/opponent stats and use **Undo** for quick fixes.\n- In **Beta** or **Live Broadcast Tracker**, use **L"}]</script>
+    <script type="module">
+      import { checkAuth } from './js/auth.js?v=9';
+      import { renderHeader, renderFooter } from './js/utils.js?v=8';
+      renderHeader(document.getElementById('header-container'), null);
+      renderFooter(document.getElementById('footer-container'));
+      checkAuth((user) => {
+        renderHeader(document.getElementById('header-container'), user);
+      });
+    </script>
+    <script>
+        const manifest = JSON.parse(document.getElementById('help-manifest').textContent || '[]');
+        const searchInput = document.getElementById('help-search');
+        const roleSelect = document.getElementById('help-role');
+        const grid = document.getElementById('help-grid');
+        const empty = document.getElementById('help-empty');
+        const summary = document.getElementById('help-summary');
+
+        function escapeHtml(v){return String(v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');}
+
+        function render() {
+            const q = (searchInput.value || '').toLowerCase().trim();
+            const role = roleSelect.value;
+            const filtered = manifest.filter((item) => {
+                const text = (item.title + ' ' + item.summary + ' ' + (item.searchText || '')).toLowerCase();
+                const roleOk = !role || (item.roles || []).includes(role) || (item.roles || []).includes('All');
+                return (!q || text.includes(q)) && roleOk;
+            }).sort((a,b)=>a.title.localeCompare(b.title));
+
+            grid.innerHTML = filtered.map((item) => {
+                const badges = (item.roles || ['All']).map((r) => '<span class="wf-role-chip">'+escapeHtml(r)+'</span>').join(' ');
+                return '<article class="wf-card rounded-2xl border border-slate-200 bg-white p-5">'
+                    + '<div class="wf-card-accent"></div>'
+                    + '<h2 class="text-xl font-extrabold tracking-tight text-slate-900">'+escapeHtml(item.title)+'</h2>'
+                    + '<p class="mt-2 text-sm text-slate-600 leading-6">'+escapeHtml(item.summary)+'</p>'
+                    + '<div class="mt-4 flex flex-wrap gap-2">'+badges+'</div>'
+                    + '<a class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 hover:text-primary-800" href="'+escapeHtml(item.file)+'">Open workflow <span aria-hidden="true">→</span></a>'
+                    + '</article>';
+            }).join('');
+
+            if (!filtered.length) {
+                empty.classList.remove('hidden');
+                grid.classList.add('hidden');
+            } else {
+                empty.classList.add('hidden');
+                grid.classList.remove('hidden');
+            }
+            summary.textContent = filtered.length + ' of ' + manifest.length + ' workflows';
+        }
+
+        searchInput.addEventListener('input', render);
+        roleSelect.addEventListener('change', render);
+        render();
+    </script>
 </body>
 </html>

--- a/help.html
+++ b/help.html
@@ -3,269 +3,46 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>ALL PLAYS Help Center</title>
+    <title>ALL PLAYS Help Portal</title>
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-slate-50 text-slate-900 min-h-screen">
-    <main class="max-w-7xl mx-auto px-4 pb-24 pt-8" aria-labelledby="help-title">
-        <header class="mb-6">
-            <a id="context-back-link" class="hidden inline-flex items-center gap-2 text-sm text-blue-700 hover:text-blue-800 mb-3" href="dashboard.html">Back to team context</a>
-            <h1 id="help-title" class="text-3xl font-bold tracking-tight">Help Center</h1>
-            <p class="mt-2 text-slate-600">Role-aware operational guides for account access, setup, planning, tracking, watching, and team communication.</p>
+    <main class="max-w-6xl mx-auto px-4 py-10">
+        <header class="mb-8">
+            <h1 class="text-4xl font-extrabold tracking-tight">Help Portal</h1>
+            <p class="mt-3 text-slate-600 text-lg">Multi-page documentation by workflow and role. Use the page reference for file-by-file feature coverage.</p>
         </header>
 
-        <section class="bg-white border border-slate-200 rounded-xl p-4 mb-6" aria-label="Help filters">
-            <div class="grid gap-4 lg:grid-cols-5">
-                <div class="lg:col-span-2">
-                    <label for="help-search" class="block text-sm font-medium text-slate-700 mb-1">Search guides</label>
-                    <input id="help-search" type="search" placeholder="Try login, forgot password, roster, track game, tag in chat" class="w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring-blue-500">
-                </div>
-                <div>
-                    <label for="help-role" class="block text-sm font-medium text-slate-700 mb-1">Role</label>
-                    <select id="help-role" class="w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring-blue-500">
-                        <option value="member">Member</option>
-                        <option value="parent">Parent</option>
-                        <option value="coach">Coach</option>
-                        <option value="administrator">Administrator</option>
-                    </select>
-                </div>
-                <div>
-                    <label for="help-category" class="block text-sm font-medium text-slate-700 mb-1">Category</label>
-                    <select id="help-category" class="w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring-blue-500">
-                        <option value="all">All Categories</option>
-                    </select>
-                </div>
-                <div class="flex items-end">
-                    <button id="help-clear" class="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100" type="button">Clear filters</button>
-                </div>
-            </div>
-            <p id="help-result-summary" class="text-sm text-slate-600 mt-3"></p>
+        <section class="grid gap-4 md:grid-cols-2">
+            <a href="help-account.html" class="block rounded-xl border border-slate-200 bg-white p-5 hover:border-blue-300 hover:bg-blue-50 transition">
+                <h2 class="text-xl font-bold text-slate-900">Account and Access</h2>
+                <p class="mt-2 text-slate-600">Login, forgot password, sign-up, invite acceptance, profile, and role access behaviors.</p>
+                <p class="mt-3 text-sm font-semibold text-blue-700">Open guide →</p>
+            </a>
+            <a href="help-team-operations.html" class="block rounded-xl border border-slate-200 bg-white p-5 hover:border-blue-300 hover:bg-blue-50 transition">
+                <h2 class="text-xl font-bold text-slate-900">Team Operations</h2>
+                <p class="mt-2 text-slate-600">Create teams, manage roster/config, schedule planning, admin views, and parent dashboard flows.</p>
+                <p class="mt-3 text-sm font-semibold text-blue-700">Open guide →</p>
+            </a>
+            <a href="help-game-operations.html" class="block rounded-xl border border-slate-200 bg-white p-5 hover:border-blue-300 hover:bg-blue-50 transition">
+                <h2 class="text-xl font-bold text-slate-900">Game Operations</h2>
+                <p class="mt-2 text-slate-600">Game day setup, planning, standard/live tracking, statsheet entry, and report verification.</p>
+                <p class="mt-3 text-sm font-semibold text-blue-700">Open guide →</p>
+            </a>
+            <a href="help-watch-chat.html" class="block rounded-xl border border-slate-200 bg-white p-5 hover:border-blue-300 hover:bg-blue-50 transition">
+                <h2 class="text-xl font-bold text-slate-900">Watch and Chat</h2>
+                <p class="mt-2 text-slate-600">Live/replay game viewing, chat workflows, tagging/mentions, and communication ownership by role.</p>
+                <p class="mt-3 text-sm font-semibold text-blue-700">Open guide →</p>
+            </a>
         </section>
 
-        <section class="grid gap-5 lg:grid-cols-4">
-            <aside class="lg:col-span-1 space-y-4">
-                <div class="bg-white border border-slate-200 rounded-xl p-4">
-                    <h2 class="text-sm font-bold tracking-wide uppercase text-slate-500">Top Tasks</h2>
-                    <div id="top-task-links" class="mt-3 space-y-2"></div>
-                </div>
-                <div class="bg-white border border-slate-200 rounded-xl p-4">
-                    <h2 class="text-sm font-bold tracking-wide uppercase text-slate-500">Categories</h2>
-                    <div id="category-links" class="mt-3 space-y-2"></div>
-                </div>
-            </aside>
-
-            <section class="lg:col-span-3" aria-live="polite">
-                <div id="help-results" class="space-y-4"></div>
-            </section>
+        <section class="mt-6">
+            <a href="help-page-reference.html" class="block rounded-xl border-2 border-blue-200 bg-blue-50 p-6 hover:bg-blue-100 transition">
+                <h2 class="text-2xl font-extrabold text-blue-900">File-by-File Page Reference</h2>
+                <p class="mt-2 text-blue-900/90">Lists each page in this site with features and which roles should use it.</p>
+                <p class="mt-3 text-sm font-semibold text-blue-800">Open full page reference →</p>
+            </a>
         </section>
     </main>
-
-    <nav aria-label="Help guide navigation" class="fixed bottom-0 inset-x-0 bg-white border-t border-slate-200 shadow-[0_-1px_6px_rgba(15,23,42,0.06)]">
-        <div id="bottom-help-nav" class="max-w-7xl mx-auto px-4 py-3 overflow-x-auto whitespace-nowrap text-sm"></div>
-    </nav>
-
-    <script type="module">
-        import {
-            normalizeHelpRole,
-            getHelpGuidesForRole,
-            searchHelpGuides,
-            getHelpCategoriesForRole,
-            getGuideById,
-            resolveGuideLinks,
-            getTopHelpGuides,
-            getRelatedGuides
-        } from './js/help-center.js?v=2';
-
-        const searchInput = document.getElementById('help-search');
-        const roleSelect = document.getElementById('help-role');
-        const categorySelect = document.getElementById('help-category');
-        const clearBtn = document.getElementById('help-clear');
-
-        const results = document.getElementById('help-results');
-        const resultSummary = document.getElementById('help-result-summary');
-        const bottomNav = document.getElementById('bottom-help-nav');
-        const backLink = document.getElementById('context-back-link');
-        const topTaskLinks = document.getElementById('top-task-links');
-        const categoryLinks = document.getElementById('category-links');
-
-        const htmlEscapes = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' };
-
-        function escapeHtml(value) {
-            return String(value ?? '').replace(/[&<>"']/g, (char) => htmlEscapes[char]);
-        }
-
-        function toSafeFragmentId(value, index) {
-            const trimmed = String(value ?? '').trim();
-            return trimmed ? encodeURIComponent(trimmed) : `guide-${index}`;
-        }
-
-        function renderCategoryOptions(role) {
-            const categories = getHelpCategoriesForRole(role);
-            const options = ['<option value="all">All Categories</option>']
-                .concat(categories.map((category) => `<option value="${escapeHtml(category.id)}">${escapeHtml(category.label)}</option>`));
-            categorySelect.innerHTML = options.join('');
-        }
-
-        function renderTopTasks(role, context) {
-            const topGuides = getTopHelpGuides(role, 6);
-            topTaskLinks.innerHTML = topGuides.map((guide) => {
-                const url = `#${encodeURIComponent(guide.id)}`;
-                return `<a class="block rounded-lg border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-blue-50 hover:text-blue-700" href="${url}">${escapeHtml(guide.title)}</a>`;
-            }).join('');
-
-            const categories = getHelpCategoriesForRole(role);
-            categoryLinks.innerHTML = categories.map((category) => {
-                return `<button type="button" data-category="${escapeHtml(category.id)}" class="w-full text-left rounded-lg border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-blue-50 hover:text-blue-700">${escapeHtml(category.label)}</button>`;
-            }).join('');
-
-            categoryLinks.querySelectorAll('button[data-category]').forEach((button) => {
-                button.addEventListener('click', () => {
-                    categorySelect.value = button.dataset.category || 'all';
-                    render(context);
-                });
-            });
-        }
-
-        function render(context) {
-            const role = normalizeHelpRole(roleSelect.value);
-            const query = searchInput.value;
-            const category = categorySelect.value || 'all';
-            const byRole = getHelpGuidesForRole(role);
-            const filtered = searchHelpGuides(byRole, query, category);
-
-            resultSummary.textContent = `${filtered.length} guide${filtered.length === 1 ? '' : 's'} for ${role}${category !== 'all' ? ` in ${category}` : ''}.`;
-
-            if (filtered.length === 0) {
-                results.innerHTML = `
-                    <div class="bg-white border border-slate-200 rounded-xl p-6">
-                        <h2 class="text-lg font-semibold text-slate-900">No guides match your filters</h2>
-                        <p class="mt-2 text-slate-600">Clear filters or try broader terms like <strong>login</strong>, <strong>roster</strong>, or <strong>track</strong>.</p>
-                    </div>
-                `;
-                bottomNav.innerHTML = '';
-                return;
-            }
-
-            results.innerHTML = filtered.map((guide, index) => {
-                const safeId = toSafeFragmentId(guide.id, index);
-                const quickLinks = resolveGuideLinks(guide, context)
-                    .filter((link) => link.url)
-                    .map((link) => `<a class="inline-flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700 hover:bg-blue-100" href="${escapeHtml(link.url)}">${escapeHtml(link.label)}</a>`)
-                    .join(' ');
-
-                const relatedGuides = getRelatedGuides(role, guide)
-                    .map((related) => `<a class="text-blue-700 hover:text-blue-900 hover:underline" href="#${encodeURIComponent(related.id)}">${escapeHtml(related.title)}</a>`)
-                    .join('<span class="text-slate-400"> · </span>');
-
-                return `
-                <article id="${safeId}" class="bg-white border border-slate-200 rounded-xl p-5 shadow-sm">
-                    <div class="flex items-start justify-between gap-3">
-                        <div>
-                            <h2 class="text-xl font-semibold text-slate-900">${escapeHtml(guide.title)}</h2>
-                            <p class="text-sm text-slate-500 mt-1">Category: ${escapeHtml(guide.category)} · Updated: ${escapeHtml(guide.lastUpdated || 'n/a')}</p>
-                        </div>
-                        <span class="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-700">${escapeHtml((guide.roles || []).join(', '))}</span>
-                    </div>
-
-                    <p class="mt-3 text-slate-700">${escapeHtml(guide.summary)}</p>
-
-                    <div class="mt-4 grid gap-4 lg:grid-cols-2">
-                        <section>
-                            <h3 class="text-sm font-bold uppercase tracking-wide text-slate-500">Prerequisites</h3>
-                            <ul class="mt-2 space-y-1 list-disc list-inside text-sm text-slate-700">
-                                ${(guide.prerequisites || []).map((item) => `<li>${escapeHtml(item)}</li>`).join('')}
-                            </ul>
-                        </section>
-                        <section>
-                            <h3 class="text-sm font-bold uppercase tracking-wide text-slate-500">Quick Links</h3>
-                            <div class="mt-2 flex flex-wrap gap-2">${quickLinks || '<span class="text-sm text-slate-500">No direct link</span>'}</div>
-                        </section>
-                    </div>
-
-                    <section class="mt-5">
-                        <h3 class="text-sm font-bold uppercase tracking-wide text-slate-500">Workflow Steps</h3>
-                        <ol class="mt-2 space-y-2 list-decimal list-inside text-sm text-slate-800">
-                            ${(guide.steps || []).map((step) => `<li>${escapeHtml(step)}</li>`).join('')}
-                        </ol>
-                    </section>
-
-                    <section class="mt-5 grid gap-4 lg:grid-cols-2">
-                        <div>
-                            <h3 class="text-sm font-bold uppercase tracking-wide text-slate-500">Common Errors</h3>
-                            <ul class="mt-2 space-y-1 list-disc list-inside text-sm text-slate-700">
-                                ${(guide.commonErrors || []).map((item) => `<li>${escapeHtml(item)}</li>`).join('')}
-                            </ul>
-                        </div>
-                        <div>
-                            <h3 class="text-sm font-bold uppercase tracking-wide text-slate-500">Edge Cases</h3>
-                            <ul class="mt-2 space-y-1 list-disc list-inside text-sm text-slate-700">
-                                ${(guide.edgeCases || []).map((item) => `<li>${escapeHtml(item)}</li>`).join('')}
-                            </ul>
-                        </div>
-                    </section>
-
-                    <section class="mt-5 text-sm text-slate-700">
-                        <h3 class="text-sm font-bold uppercase tracking-wide text-slate-500 mb-2">Related Guides</h3>
-                        ${relatedGuides || '<span class="text-slate-500">No related guides listed.</span>'}
-                    </section>
-                </article>
-            `;
-            }).join('');
-
-            bottomNav.innerHTML = filtered.map((guide, index) => {
-                const safeId = toSafeFragmentId(guide.id, index);
-                return `<a class="inline-block mr-4 text-blue-700 hover:text-blue-900" href="#${safeId}">${escapeHtml(guide.title)}</a>`;
-            }).join('');
-
-            if (context.guideId) {
-                const targetedGuide = getGuideById(role, context.guideId);
-                if (targetedGuide) {
-                    const match = filtered.find((guide) => guide.id === targetedGuide.id);
-                    if (match) {
-                        const targetId = encodeURIComponent(match.id);
-                        const targetEl = document.getElementById(targetId);
-                        if (targetEl) {
-                            targetEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
-                        }
-                    }
-                }
-            }
-        }
-
-        const params = new URLSearchParams(window.location.search);
-        const context = {
-            teamId: params.get('teamId') || '',
-            gameId: params.get('gameId') || '',
-            contextType: params.get('context') || '',
-            guideId: params.get('guide') || ''
-        };
-
-        const initialRole = normalizeHelpRole(params.get('role'));
-        roleSelect.value = initialRole;
-        renderCategoryOptions(initialRole);
-
-        if (context.contextType === 'team' && context.teamId) {
-            backLink.classList.remove('hidden');
-            backLink.href = `team.html#teamId=${encodeURIComponent(context.teamId)}`;
-        }
-
-        renderTopTasks(initialRole, context);
-        render(context);
-
-        searchInput.addEventListener('input', () => render(context));
-        roleSelect.addEventListener('change', () => {
-            const role = normalizeHelpRole(roleSelect.value);
-            renderCategoryOptions(role);
-            categorySelect.value = 'all';
-            renderTopTasks(role, context);
-            render(context);
-        });
-        categorySelect.addEventListener('change', () => render(context));
-        clearBtn.addEventListener('click', () => {
-            searchInput.value = '';
-            categorySelect.value = 'all';
-            render(context);
-        });
-    </script>
 </body>
 </html>

--- a/help.html
+++ b/help.html
@@ -6,49 +6,88 @@
     <title>ALL PLAYS Help Center</title>
     <script src="https://cdn.tailwindcss.com"></script>
 </head>
-<body class="bg-gray-50 text-gray-900 min-h-screen">
-    <main class="max-w-5xl mx-auto px-4 pb-28 pt-8" aria-labelledby="help-title">
+<body class="bg-slate-50 text-slate-900 min-h-screen">
+    <main class="max-w-7xl mx-auto px-4 pb-24 pt-8" aria-labelledby="help-title">
         <header class="mb-6">
-            <a id="context-back-link" class="hidden inline-flex items-center gap-2 text-sm text-primary-700 hover:text-primary-800 mb-3" href="dashboard.html">Back to team context</a>
-            <h1 id="help-title" class="text-3xl font-bold">Help Center</h1>
-            <p class="mt-2 text-gray-600">Search all workflows, then filter by role to see role-aware guidance.</p>
+            <a id="context-back-link" class="hidden inline-flex items-center gap-2 text-sm text-blue-700 hover:text-blue-800 mb-3" href="dashboard.html">Back to team context</a>
+            <h1 id="help-title" class="text-3xl font-bold tracking-tight">Help Center</h1>
+            <p class="mt-2 text-slate-600">Role-aware operational guides for account access, setup, planning, tracking, watching, and team communication.</p>
         </header>
 
-        <section class="bg-white border border-gray-200 rounded-xl p-4 mb-6" aria-label="Help filters">
-            <div class="grid gap-4 md:grid-cols-3">
-                <div class="md:col-span-2">
-                    <label for="help-search" class="block text-sm font-medium text-gray-700 mb-1">Search help</label>
-                    <input id="help-search" type="search" placeholder="Try permissions, roster, notifications, troubleshooting" class="w-full rounded-lg border-gray-300 focus:border-primary-500 focus:ring-primary-500">
+        <section class="bg-white border border-slate-200 rounded-xl p-4 mb-6" aria-label="Help filters">
+            <div class="grid gap-4 lg:grid-cols-5">
+                <div class="lg:col-span-2">
+                    <label for="help-search" class="block text-sm font-medium text-slate-700 mb-1">Search guides</label>
+                    <input id="help-search" type="search" placeholder="Try login, forgot password, roster, track game, tag in chat" class="w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring-blue-500">
                 </div>
                 <div>
-                    <label for="help-role" class="block text-sm font-medium text-gray-700 mb-1">Role</label>
-                    <select id="help-role" class="w-full rounded-lg border-gray-300 focus:border-primary-500 focus:ring-primary-500">
+                    <label for="help-role" class="block text-sm font-medium text-slate-700 mb-1">Role</label>
+                    <select id="help-role" class="w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring-blue-500">
                         <option value="member">Member</option>
                         <option value="parent">Parent</option>
                         <option value="coach">Coach</option>
                         <option value="administrator">Administrator</option>
                     </select>
                 </div>
+                <div>
+                    <label for="help-category" class="block text-sm font-medium text-slate-700 mb-1">Category</label>
+                    <select id="help-category" class="w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring-blue-500">
+                        <option value="all">All Categories</option>
+                    </select>
+                </div>
+                <div class="flex items-end">
+                    <button id="help-clear" class="w-full rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100" type="button">Clear filters</button>
+                </div>
             </div>
-            <p id="help-result-summary" class="text-sm text-gray-600 mt-3"></p>
+            <p id="help-result-summary" class="text-sm text-slate-600 mt-3"></p>
         </section>
 
-        <section id="help-results" class="space-y-4" aria-live="polite"></section>
+        <section class="grid gap-5 lg:grid-cols-4">
+            <aside class="lg:col-span-1 space-y-4">
+                <div class="bg-white border border-slate-200 rounded-xl p-4">
+                    <h2 class="text-sm font-bold tracking-wide uppercase text-slate-500">Top Tasks</h2>
+                    <div id="top-task-links" class="mt-3 space-y-2"></div>
+                </div>
+                <div class="bg-white border border-slate-200 rounded-xl p-4">
+                    <h2 class="text-sm font-bold tracking-wide uppercase text-slate-500">Categories</h2>
+                    <div id="category-links" class="mt-3 space-y-2"></div>
+                </div>
+            </aside>
+
+            <section class="lg:col-span-3" aria-live="polite">
+                <div id="help-results" class="space-y-4"></div>
+            </section>
+        </section>
     </main>
 
-    <nav aria-label="Help section navigation" class="fixed bottom-0 inset-x-0 bg-white border-t border-gray-200">
-        <div id="bottom-help-nav" class="max-w-5xl mx-auto px-4 py-3 overflow-x-auto whitespace-nowrap text-sm"></div>
+    <nav aria-label="Help guide navigation" class="fixed bottom-0 inset-x-0 bg-white border-t border-slate-200 shadow-[0_-1px_6px_rgba(15,23,42,0.06)]">
+        <div id="bottom-help-nav" class="max-w-7xl mx-auto px-4 py-3 overflow-x-auto whitespace-nowrap text-sm"></div>
     </nav>
 
     <script type="module">
-        import { normalizeHelpRole, getHelpSectionsForRole, searchHelpSections } from './js/help-center.js?v=1';
+        import {
+            normalizeHelpRole,
+            getHelpGuidesForRole,
+            searchHelpGuides,
+            getHelpCategoriesForRole,
+            getGuideById,
+            resolveGuideLinks,
+            getTopHelpGuides,
+            getRelatedGuides
+        } from './js/help-center.js?v=2';
 
         const searchInput = document.getElementById('help-search');
         const roleSelect = document.getElementById('help-role');
+        const categorySelect = document.getElementById('help-category');
+        const clearBtn = document.getElementById('help-clear');
+
         const results = document.getElementById('help-results');
         const resultSummary = document.getElementById('help-result-summary');
         const bottomNav = document.getElementById('bottom-help-nav');
         const backLink = document.getElementById('context-back-link');
+        const topTaskLinks = document.getElementById('top-task-links');
+        const categoryLinks = document.getElementById('category-links');
+
         const htmlEscapes = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' };
 
         function escapeHtml(value) {
@@ -57,56 +96,176 @@
 
         function toSafeFragmentId(value, index) {
             const trimmed = String(value ?? '').trim();
-            return trimmed ? encodeURIComponent(trimmed) : `section-${index}`;
+            return trimmed ? encodeURIComponent(trimmed) : `guide-${index}`;
         }
 
-        const params = new URLSearchParams(window.location.search);
-        const initialRole = normalizeHelpRole(params.get('role'));
-        roleSelect.value = initialRole;
-
-        const teamId = params.get('teamId');
-        const context = params.get('context');
-        if (context === 'team' && teamId) {
-            backLink.classList.remove('hidden');
-            backLink.href = `team.html#teamId=${encodeURIComponent(teamId)}`;
+        function renderCategoryOptions(role) {
+            const categories = getHelpCategoriesForRole(role);
+            const options = ['<option value="all">All Categories</option>']
+                .concat(categories.map((category) => `<option value="${escapeHtml(category.id)}">${escapeHtml(category.label)}</option>`));
+            categorySelect.innerHTML = options.join('');
         }
 
-        function render() {
+        function renderTopTasks(role, context) {
+            const topGuides = getTopHelpGuides(role, 6);
+            topTaskLinks.innerHTML = topGuides.map((guide) => {
+                const url = `#${encodeURIComponent(guide.id)}`;
+                return `<a class="block rounded-lg border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-blue-50 hover:text-blue-700" href="${url}">${escapeHtml(guide.title)}</a>`;
+            }).join('');
+
+            const categories = getHelpCategoriesForRole(role);
+            categoryLinks.innerHTML = categories.map((category) => {
+                return `<button type="button" data-category="${escapeHtml(category.id)}" class="w-full text-left rounded-lg border border-slate-200 px-3 py-2 text-sm font-medium text-slate-700 hover:bg-blue-50 hover:text-blue-700">${escapeHtml(category.label)}</button>`;
+            }).join('');
+
+            categoryLinks.querySelectorAll('button[data-category]').forEach((button) => {
+                button.addEventListener('click', () => {
+                    categorySelect.value = button.dataset.category || 'all';
+                    render(context);
+                });
+            });
+        }
+
+        function render(context) {
             const role = normalizeHelpRole(roleSelect.value);
-            const sections = getHelpSectionsForRole(role);
-            const filtered = searchHelpSections(sections, searchInput.value);
+            const query = searchInput.value;
+            const category = categorySelect.value || 'all';
+            const byRole = getHelpGuidesForRole(role);
+            const filtered = searchHelpGuides(byRole, query, category);
 
-            resultSummary.textContent = `${filtered.length} section${filtered.length === 1 ? '' : 's'} shown for ${role}.`;
+            resultSummary.textContent = `${filtered.length} guide${filtered.length === 1 ? '' : 's'} for ${role}${category !== 'all' ? ` in ${category}` : ''}.`;
 
-            results.innerHTML = filtered.map((section, index) => {
-                const safeId = toSafeFragmentId(section.id, index);
-                const escapedTitle = escapeHtml(section.title);
-                const escapedSummary = escapeHtml(section.summary);
-                const escapedWorkflows = (section.workflows || [])
-                    .map((workflow) => `<li>${escapeHtml(workflow)}</li>`)
-                    .join('');
+            if (filtered.length === 0) {
+                results.innerHTML = `
+                    <div class="bg-white border border-slate-200 rounded-xl p-6">
+                        <h2 class="text-lg font-semibold text-slate-900">No guides match your filters</h2>
+                        <p class="mt-2 text-slate-600">Clear filters or try broader terms like <strong>login</strong>, <strong>roster</strong>, or <strong>track</strong>.</p>
+                    </div>
+                `;
+                bottomNav.innerHTML = '';
+                return;
+            }
+
+            results.innerHTML = filtered.map((guide, index) => {
+                const safeId = toSafeFragmentId(guide.id, index);
+                const quickLinks = resolveGuideLinks(guide, context)
+                    .filter((link) => link.url)
+                    .map((link) => `<a class="inline-flex items-center gap-2 rounded-md border border-blue-200 bg-blue-50 px-2.5 py-1 text-xs font-semibold text-blue-700 hover:bg-blue-100" href="${escapeHtml(link.url)}">${escapeHtml(link.label)}</a>`)
+                    .join(' ');
+
+                const relatedGuides = getRelatedGuides(role, guide)
+                    .map((related) => `<a class="text-blue-700 hover:text-blue-900 hover:underline" href="#${encodeURIComponent(related.id)}">${escapeHtml(related.title)}</a>`)
+                    .join('<span class="text-slate-400"> · </span>');
 
                 return `
-                <article id="${safeId}" class="bg-white border border-gray-200 rounded-xl p-5">
-                    <h2 class="text-xl font-semibold text-gray-900">${escapedTitle}</h2>
-                    <p class="mt-2 text-gray-700">${escapedSummary}</p>
-                    <ul class="mt-3 space-y-2 list-disc list-inside text-gray-700">
-                        ${escapedWorkflows}
-                    </ul>
+                <article id="${safeId}" class="bg-white border border-slate-200 rounded-xl p-5 shadow-sm">
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            <h2 class="text-xl font-semibold text-slate-900">${escapeHtml(guide.title)}</h2>
+                            <p class="text-sm text-slate-500 mt-1">Category: ${escapeHtml(guide.category)} · Updated: ${escapeHtml(guide.lastUpdated || 'n/a')}</p>
+                        </div>
+                        <span class="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-1 text-xs font-semibold text-slate-700">${escapeHtml((guide.roles || []).join(', '))}</span>
+                    </div>
+
+                    <p class="mt-3 text-slate-700">${escapeHtml(guide.summary)}</p>
+
+                    <div class="mt-4 grid gap-4 lg:grid-cols-2">
+                        <section>
+                            <h3 class="text-sm font-bold uppercase tracking-wide text-slate-500">Prerequisites</h3>
+                            <ul class="mt-2 space-y-1 list-disc list-inside text-sm text-slate-700">
+                                ${(guide.prerequisites || []).map((item) => `<li>${escapeHtml(item)}</li>`).join('')}
+                            </ul>
+                        </section>
+                        <section>
+                            <h3 class="text-sm font-bold uppercase tracking-wide text-slate-500">Quick Links</h3>
+                            <div class="mt-2 flex flex-wrap gap-2">${quickLinks || '<span class="text-sm text-slate-500">No direct link</span>'}</div>
+                        </section>
+                    </div>
+
+                    <section class="mt-5">
+                        <h3 class="text-sm font-bold uppercase tracking-wide text-slate-500">Workflow Steps</h3>
+                        <ol class="mt-2 space-y-2 list-decimal list-inside text-sm text-slate-800">
+                            ${(guide.steps || []).map((step) => `<li>${escapeHtml(step)}</li>`).join('')}
+                        </ol>
+                    </section>
+
+                    <section class="mt-5 grid gap-4 lg:grid-cols-2">
+                        <div>
+                            <h3 class="text-sm font-bold uppercase tracking-wide text-slate-500">Common Errors</h3>
+                            <ul class="mt-2 space-y-1 list-disc list-inside text-sm text-slate-700">
+                                ${(guide.commonErrors || []).map((item) => `<li>${escapeHtml(item)}</li>`).join('')}
+                            </ul>
+                        </div>
+                        <div>
+                            <h3 class="text-sm font-bold uppercase tracking-wide text-slate-500">Edge Cases</h3>
+                            <ul class="mt-2 space-y-1 list-disc list-inside text-sm text-slate-700">
+                                ${(guide.edgeCases || []).map((item) => `<li>${escapeHtml(item)}</li>`).join('')}
+                            </ul>
+                        </div>
+                    </section>
+
+                    <section class="mt-5 text-sm text-slate-700">
+                        <h3 class="text-sm font-bold uppercase tracking-wide text-slate-500 mb-2">Related Guides</h3>
+                        ${relatedGuides || '<span class="text-slate-500">No related guides listed.</span>'}
+                    </section>
                 </article>
             `;
             }).join('');
 
-            bottomNav.innerHTML = filtered.map((section, index) => {
-                const safeId = toSafeFragmentId(section.id, index);
-                const escapedTitle = escapeHtml(section.title);
-                return `<a class="inline-block mr-4 text-primary-700 hover:text-primary-900" href="#${safeId}">${escapedTitle}</a>`;
+            bottomNav.innerHTML = filtered.map((guide, index) => {
+                const safeId = toSafeFragmentId(guide.id, index);
+                return `<a class="inline-block mr-4 text-blue-700 hover:text-blue-900" href="#${safeId}">${escapeHtml(guide.title)}</a>`;
             }).join('');
+
+            if (context.guideId) {
+                const targetedGuide = getGuideById(role, context.guideId);
+                if (targetedGuide) {
+                    const match = filtered.find((guide) => guide.id === targetedGuide.id);
+                    if (match) {
+                        const targetId = encodeURIComponent(match.id);
+                        const targetEl = document.getElementById(targetId);
+                        if (targetEl) {
+                            targetEl.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                        }
+                    }
+                }
+            }
         }
 
-        searchInput.addEventListener('input', render);
-        roleSelect.addEventListener('change', render);
-        render();
+        const params = new URLSearchParams(window.location.search);
+        const context = {
+            teamId: params.get('teamId') || '',
+            gameId: params.get('gameId') || '',
+            contextType: params.get('context') || '',
+            guideId: params.get('guide') || ''
+        };
+
+        const initialRole = normalizeHelpRole(params.get('role'));
+        roleSelect.value = initialRole;
+        renderCategoryOptions(initialRole);
+
+        if (context.contextType === 'team' && context.teamId) {
+            backLink.classList.remove('hidden');
+            backLink.href = `team.html#teamId=${encodeURIComponent(context.teamId)}`;
+        }
+
+        renderTopTasks(initialRole, context);
+        render(context);
+
+        searchInput.addEventListener('input', () => render(context));
+        roleSelect.addEventListener('change', () => {
+            const role = normalizeHelpRole(roleSelect.value);
+            renderCategoryOptions(role);
+            categorySelect.value = 'all';
+            renderTopTasks(role, context);
+            render(context);
+        });
+        categorySelect.addEventListener('change', () => render(context));
+        clearBtn.addEventListener('click', () => {
+            searchInput.value = '';
+            categorySelect.value = 'all';
+            render(context);
+        });
     </script>
 </body>
 </html>

--- a/help.html
+++ b/help.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>ALL PLAYS Help Center</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-50 text-gray-900 min-h-screen">
+    <main class="max-w-5xl mx-auto px-4 pb-28 pt-8" aria-labelledby="help-title">
+        <header class="mb-6">
+            <a id="context-back-link" class="hidden inline-flex items-center gap-2 text-sm text-primary-700 hover:text-primary-800 mb-3" href="dashboard.html">Back to team context</a>
+            <h1 id="help-title" class="text-3xl font-bold">Help Center</h1>
+            <p class="mt-2 text-gray-600">Search all workflows, then filter by role to see role-aware guidance.</p>
+        </header>
+
+        <section class="bg-white border border-gray-200 rounded-xl p-4 mb-6" aria-label="Help filters">
+            <div class="grid gap-4 md:grid-cols-3">
+                <div class="md:col-span-2">
+                    <label for="help-search" class="block text-sm font-medium text-gray-700 mb-1">Search help</label>
+                    <input id="help-search" type="search" placeholder="Try permissions, roster, notifications, troubleshooting" class="w-full rounded-lg border-gray-300 focus:border-primary-500 focus:ring-primary-500">
+                </div>
+                <div>
+                    <label for="help-role" class="block text-sm font-medium text-gray-700 mb-1">Role</label>
+                    <select id="help-role" class="w-full rounded-lg border-gray-300 focus:border-primary-500 focus:ring-primary-500">
+                        <option value="member">Member</option>
+                        <option value="parent">Parent</option>
+                        <option value="coach">Coach</option>
+                        <option value="administrator">Administrator</option>
+                    </select>
+                </div>
+            </div>
+            <p id="help-result-summary" class="text-sm text-gray-600 mt-3"></p>
+        </section>
+
+        <section id="help-results" class="space-y-4" aria-live="polite"></section>
+    </main>
+
+    <nav aria-label="Help section navigation" class="fixed bottom-0 inset-x-0 bg-white border-t border-gray-200">
+        <div id="bottom-help-nav" class="max-w-5xl mx-auto px-4 py-3 overflow-x-auto whitespace-nowrap text-sm"></div>
+    </nav>
+
+    <script type="module">
+        import { normalizeHelpRole, getHelpSectionsForRole, searchHelpSections } from './js/help-center.js?v=1';
+
+        const searchInput = document.getElementById('help-search');
+        const roleSelect = document.getElementById('help-role');
+        const results = document.getElementById('help-results');
+        const resultSummary = document.getElementById('help-result-summary');
+        const bottomNav = document.getElementById('bottom-help-nav');
+        const backLink = document.getElementById('context-back-link');
+
+        const params = new URLSearchParams(window.location.search);
+        const initialRole = normalizeHelpRole(params.get('role'));
+        roleSelect.value = initialRole;
+
+        const teamId = params.get('teamId');
+        const context = params.get('context');
+        if (context === 'team' && teamId) {
+            backLink.classList.remove('hidden');
+            backLink.href = `team.html#teamId=${encodeURIComponent(teamId)}`;
+        }
+
+        function render() {
+            const role = normalizeHelpRole(roleSelect.value);
+            const sections = getHelpSectionsForRole(role);
+            const filtered = searchHelpSections(sections, searchInput.value);
+
+            resultSummary.textContent = `${filtered.length} section${filtered.length === 1 ? '' : 's'} shown for ${role}.`;
+
+            results.innerHTML = filtered.map((section) => `
+                <article id="${section.id}" class="bg-white border border-gray-200 rounded-xl p-5">
+                    <h2 class="text-xl font-semibold text-gray-900">${section.title}</h2>
+                    <p class="mt-2 text-gray-700">${section.summary}</p>
+                    <ul class="mt-3 space-y-2 list-disc list-inside text-gray-700">
+                        ${section.workflows.map((workflow) => `<li>${workflow}</li>`).join('')}
+                    </ul>
+                </article>
+            `).join('');
+
+            bottomNav.innerHTML = filtered.map((section) =>
+                `<a class="inline-block mr-4 text-primary-700 hover:text-primary-900" href="#${section.id}">${section.title}</a>`
+            ).join('');
+        }
+
+        searchInput.addEventListener('input', render);
+        roleSelect.addEventListener('change', render);
+        render();
+    </script>
+</body>
+</html>

--- a/help.html
+++ b/help.html
@@ -49,6 +49,16 @@
         const resultSummary = document.getElementById('help-result-summary');
         const bottomNav = document.getElementById('bottom-help-nav');
         const backLink = document.getElementById('context-back-link');
+        const htmlEscapes = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#039;' };
+
+        function escapeHtml(value) {
+            return String(value ?? '').replace(/[&<>"']/g, (char) => htmlEscapes[char]);
+        }
+
+        function toSafeFragmentId(value, index) {
+            const trimmed = String(value ?? '').trim();
+            return trimmed ? encodeURIComponent(trimmed) : `section-${index}`;
+        }
 
         const params = new URLSearchParams(window.location.search);
         const initialRole = normalizeHelpRole(params.get('role'));
@@ -68,19 +78,30 @@
 
             resultSummary.textContent = `${filtered.length} section${filtered.length === 1 ? '' : 's'} shown for ${role}.`;
 
-            results.innerHTML = filtered.map((section) => `
-                <article id="${section.id}" class="bg-white border border-gray-200 rounded-xl p-5">
-                    <h2 class="text-xl font-semibold text-gray-900">${section.title}</h2>
-                    <p class="mt-2 text-gray-700">${section.summary}</p>
+            results.innerHTML = filtered.map((section, index) => {
+                const safeId = toSafeFragmentId(section.id, index);
+                const escapedTitle = escapeHtml(section.title);
+                const escapedSummary = escapeHtml(section.summary);
+                const escapedWorkflows = (section.workflows || [])
+                    .map((workflow) => `<li>${escapeHtml(workflow)}</li>`)
+                    .join('');
+
+                return `
+                <article id="${safeId}" class="bg-white border border-gray-200 rounded-xl p-5">
+                    <h2 class="text-xl font-semibold text-gray-900">${escapedTitle}</h2>
+                    <p class="mt-2 text-gray-700">${escapedSummary}</p>
                     <ul class="mt-3 space-y-2 list-disc list-inside text-gray-700">
-                        ${section.workflows.map((workflow) => `<li>${workflow}</li>`).join('')}
+                        ${escapedWorkflows}
                     </ul>
                 </article>
-            `).join('');
+            `;
+            }).join('');
 
-            bottomNav.innerHTML = filtered.map((section) =>
-                `<a class="inline-block mr-4 text-primary-700 hover:text-primary-900" href="#${section.id}">${section.title}</a>`
-            ).join('');
+            bottomNav.innerHTML = filtered.map((section, index) => {
+                const safeId = toSafeFragmentId(section.id, index);
+                const escapedTitle = escapeHtml(section.title);
+                return `<a class="inline-block mr-4 text-primary-700 hover:text-primary-900" href="#${safeId}">${escapedTitle}</a>`;
+            }).join('');
         }
 
         searchInput.addEventListener('input', render);

--- a/index.html
+++ b/index.html
@@ -630,10 +630,9 @@
         <div>
           <h4 class="text-white font-semibold mb-4">Support</h4>
           <ul class="space-y-2 text-sm">
-            <li><a href="#" class="hover:text-white transition">Help Center</a></li>
-            <li><a href="#" class="hover:text-white transition">Contact</a></li>
-            <li><a href="https://github.com/pauljsnider/paulsnidernet" class="hover:text-white transition"
-                target="_blank" rel="noopener noreferrer">GitHub</a></li>
+            <li><a href="help.html" class="hover:text-white transition">Help Center</a></li>
+            <li><a href="https://paulsnider.net" class="hover:text-white transition"
+                target="_blank" rel="noopener noreferrer">Contact</a></li>
           </ul>
         </div>
       </div>

--- a/js/help-center.js
+++ b/js/help-center.js
@@ -269,8 +269,8 @@ const HELP_GUIDES = [
         id: 'track-game',
         title: 'Track a game (standard and live)',
         category: 'game-day',
-        roles: ['coach', 'administrator'],
-        tags: ['track', 'live tracker', 'stats', 'undo', 'game log'],
+        roles: ['member', 'parent', 'coach', 'administrator'],
+        tags: ['track', 'tracking', 'racking', 'racking a game', 'live tracker', 'stats', 'undo', 'game log'],
         summary: 'Choose the correct tracker for sport/game context and capture reliable in-game data.',
         prerequisites: [
             'A game is scheduled or selected from schedule.',

--- a/js/help-center.js
+++ b/js/help-center.js
@@ -11,134 +11,512 @@ const HELP_ROLE_ALIASES = {
     user: 'member'
 };
 
-const HELP_SECTIONS = [
+const HELP_CATEGORIES = [
+    { id: 'account', label: 'Account Access' },
+    { id: 'team-setup', label: 'Team Setup' },
+    { id: 'planning', label: 'Planning' },
+    { id: 'game-day', label: 'Game Day' },
+    { id: 'watch-chat', label: 'Watch + Chat' },
+    { id: 'troubleshooting', label: 'Troubleshooting' }
+];
+
+const HELP_GUIDES = [
     {
-        id: 'account-access',
-        title: 'Account and Access',
-        summary: 'Create an account, sign in, manage profile details, and understand permissions and privacy defaults.',
-        keywords: ['onboarding', 'authentication', 'password', 'profile', 'permissions', 'privacy', 'security'],
-        roles: ['parent', 'coach', 'administrator', 'member'],
-        workflows: [
-            'Create account with activation code and complete onboarding',
-            'Sign in, sign out, and reset password',
-            'Update profile details and notification identity',
-            'Understand role permissions and access boundaries'
-        ]
+        id: 'login',
+        title: 'Log in to ALL PLAYS',
+        category: 'account',
+        roles: ['member', 'parent', 'coach', 'administrator'],
+        tags: ['login', 'sign in', 'access', 'account'],
+        summary: 'Sign in with your existing account and verify that your role-specific navigation appears.',
+        prerequisites: [
+            'You have an existing ALL PLAYS account.',
+            'You know your email and password.'
+        ],
+        steps: [
+            'Open `login.html`.',
+            'Enter your email address in the email field.',
+            'Enter your password in the password field.',
+            'Select `Sign In`.',
+            'Confirm you are redirected to the correct landing page (dashboard, parent dashboard, or profile path).',
+            'Verify the header shows signed-in actions like `Profile` and `Log out`.'
+        ],
+        commonErrors: [
+            'Invalid credentials: verify email spelling and password casing.',
+            'No redirect or blank screen: refresh once and try again.',
+            'Expected team access missing: check that your account has the correct role assignment.'
+        ],
+        edgeCases: [
+            'If your account has both parent and coach access, verify both dashboards are reachable from navigation.',
+            'If browser autofill inserts an old password, clear and retype credentials manually.'
+        ],
+        relatedGuideIds: ['forgot-password', 'sign-up-activation'],
+        quickLinks: [
+            { label: 'Open Login', url: 'login.html' },
+            { label: 'Open Dashboard', url: 'dashboard.html' },
+            { label: 'Open Parent Dashboard', url: 'parent-dashboard.html' }
+        ],
+        lastUpdated: '2026-03-03'
     },
     {
-        id: 'core-workflows',
-        title: 'Core Platform Workflows',
-        summary: 'End-to-end steps for creating, updating, archiving, and operating team workflows.',
-        keywords: ['setup', 'operations', 'edit', 'delete', 'archive', 'notifications', 'alerts'],
-        roles: ['parent', 'coach', 'administrator', 'member'],
-        workflows: [
-            'Set up teams, schedules, and roster records',
-            'Operate game-day and practice workflows',
-            'Edit or archive records safely',
-            'Review notification and alert behavior'
-        ]
+        id: 'forgot-password',
+        title: 'Reset a forgotten password',
+        category: 'account',
+        roles: ['member', 'parent', 'coach', 'administrator'],
+        tags: ['forgot password', 'reset password', 'login'],
+        summary: 'Send a password reset email and complete the reset flow safely.',
+        prerequisites: [
+            'You can access the email inbox tied to your ALL PLAYS account.'
+        ],
+        steps: [
+            'Open `login.html`.',
+            'Select the `Forgot password` option.',
+            'Enter the account email address and submit.',
+            'Open the reset email and select the reset link.',
+            'Enter a new password that you can remember and confirm it.',
+            'Return to `login.html` and sign in with the new password.'
+        ],
+        commonErrors: [
+            'Reset email not found: check spam/junk and wait 1-2 minutes before retry.',
+            'Expired reset link: request a new reset email and use the newest message.',
+            'Weak password rejected: use a longer password with mixed character types.'
+        ],
+        edgeCases: [
+            'If multiple reset emails exist, only the most recent link should be used.',
+            'If using a corporate mailbox with link rewriting, copy the full link into a new tab.'
+        ],
+        relatedGuideIds: ['login', 'sign-up-activation'],
+        quickLinks: [
+            { label: 'Open Login', url: 'login.html' }
+        ],
+        lastUpdated: '2026-03-03'
     },
     {
-        id: 'role-experiences',
-        title: 'Role-Based Experiences',
-        summary: 'Role-specific visibility, responsibilities, and limits for parents, coaches, and administrators.',
-        keywords: ['role', 'visibility', 'responsibilities', 'limits', 'boundaries'],
-        roles: ['parent', 'coach', 'administrator', 'member'],
-        workflows: [
-            'What each role can see and do in navigation and workflows',
-            'How roles interact with one another on teams',
-            'Common tasks by role and expected outcomes',
-            'Boundary conditions and permission denials'
-        ]
+        id: 'sign-up-activation',
+        title: 'Sign up with activation code',
+        category: 'account',
+        roles: ['member', 'parent', 'coach', 'administrator'],
+        tags: ['sign up', 'activation code', 'new account', 'invite'],
+        summary: 'Create a new account from invite/activation flow and confirm access level.',
+        prerequisites: [
+            'You received an activation code or invite link from your team.',
+            'You have access to the invite email.'
+        ],
+        steps: [
+            'Open `login.html#signup` or your invite link.',
+            'Enter your email, password, and requested profile details.',
+            'Enter the activation code exactly as provided.',
+            'Submit the sign-up form and wait for account creation confirmation.',
+            'Complete email verification if prompted.',
+            'Sign in and confirm expected team access and role-specific navigation.'
+        ],
+        commonErrors: [
+            'Activation code invalid: confirm you copied the code exactly and it has not expired.',
+            'Email already in use: use login/reset-password instead of creating another account.',
+            'Missing team access after sign-up: contact team admin to reissue invite or role mapping.'
+        ],
+        edgeCases: [
+            'If invite was accepted on another device, refresh and sign in instead of re-registering.',
+            'If role appears incorrect, verify the invite source team and code.'
+        ],
+        relatedGuideIds: ['login', 'forgot-password'],
+        quickLinks: [
+            { label: 'Open Sign Up', url: 'login.html#signup' },
+            { label: 'Accept Invite', url: 'accept-invite.html' }
+        ],
+        lastUpdated: '2026-03-03'
     },
     {
-        id: 'data-reporting',
-        title: 'Data and Reporting',
-        summary: 'Understand records, metrics definitions, data timing, and export/share patterns.',
-        keywords: ['metrics', 'definitions', 'reports', 'records', 'export', 'refresh'],
-        roles: ['coach', 'administrator', 'parent'],
-        workflows: [
-            'View and interpret team and player data',
-            'Create or edit records with role-aware permissions',
-            'Share or export data where allowed',
-            'Understand refresh timing and data consistency'
-        ]
-    },
-    {
-        id: 'communication',
-        title: 'Communication and Collaboration',
-        summary: 'Team chat, notification preferences, moderation behavior, and privacy expectations.',
-        keywords: ['chat', 'messages', 'notifications', 'moderation', 'privacy', 'collaboration'],
-        roles: ['parent', 'coach', 'administrator'],
-        workflows: [
-            'Send and receive team communications',
-            'Adjust notification preferences for each workflow',
-            'Follow moderation and content controls',
-            'Handle private data with least-privilege expectations'
-        ]
-    },
-    {
-        id: 'settings-config',
-        title: 'System Settings and Configuration',
-        summary: 'Application, team, and user-level settings with configuration decision guidance.',
-        keywords: ['settings', 'configuration', 'organization', 'team settings', 'user settings'],
+        id: 'create-team',
+        title: 'Create a team',
+        category: 'team-setup',
         roles: ['coach', 'administrator'],
-        workflows: [
-            'Configure application and team-level settings',
-            'Update user-level preferences and defaults',
-            'Apply safe changes with rollback awareness',
-            'Verify configuration impact before rollout'
-        ]
+        tags: ['create team', 'new team', 'setup', 'coach'],
+        summary: 'Create a new team record, verify sport defaults, and publish it for use.',
+        prerequisites: [
+            'You are signed in as coach or administrator.',
+            'You know team name, sport, season basics, and optional location details.'
+        ],
+        steps: [
+            'Open `dashboard.html`.',
+            'Select the create/new team action.',
+            'Enter team details: name, sport, season, and optional description.',
+            'Save the team and verify it appears in your team list.',
+            'Open the team detail page (`team.html`) to confirm branding and access.',
+            'Open edit pages (`edit-team.html`) to complete additional settings if needed.'
+        ],
+        commonErrors: [
+            'Create action not visible: account is missing coach/admin rights.',
+            'Team save fails: review required fields and retry once.',
+            'Team appears but cannot edit: verify ownership/access mapping.'
+        ],
+        edgeCases: [
+            'If you manage many teams, use distinct naming conventions (season + level).',
+            'If sport changes after creation, re-check tracker and stat config defaults.'
+        ],
+        relatedGuideIds: ['manage-roster', 'plan-game', 'plan-practice'],
+        quickLinks: [
+            { label: 'Open My Teams', url: 'dashboard.html' },
+            { label: 'Browse Teams', url: 'teams.html' }
+        ],
+        lastUpdated: '2026-03-03'
     },
     {
-        id: 'troubleshooting',
-        title: 'Error Handling and Edge Cases',
-        summary: 'Troubleshoot common errors, permission denials, sync delays, and escalation paths.',
-        keywords: ['error', 'troubleshoot', 'permission denied', 'sync', 'delays', 'escalation'],
-        roles: ['parent', 'coach', 'administrator', 'member'],
-        workflows: [
-            'Decode common error messages and likely causes',
-            'Resolve permission-related issues by role',
-            'Handle sync/update delays and stale data',
-            'Escalate with logs and reproducible steps'
-        ]
+        id: 'manage-roster',
+        title: 'Manage team roster',
+        category: 'team-setup',
+        roles: ['coach', 'administrator'],
+        tags: ['roster', 'players', 'jersey', 'import'],
+        summary: 'Add, edit, and maintain players for a team roster with consistent data.',
+        prerequisites: [
+            'You have a team selected.',
+            'You have player names and optional jersey/position details.'
+        ],
+        steps: [
+            'Open `edit-roster.html#teamId={teamId}` from team navigation.',
+            'Add players one by one or using available bulk workflows.',
+            'Set jersey numbers, names, and optional metadata.',
+            'Save roster changes and verify rows render correctly.',
+            'Open `team.html#teamId={teamId}` and confirm roster display.',
+            'Before game day, verify no duplicate jersey numbers unless intentional.'
+        ],
+        commonErrors: [
+            'Cannot save player row: required fields missing or invalid.',
+            'Duplicate players: search roster first before adding new entries.',
+            'Roster not visible in tracker: refresh and confirm teamId context.'
+        ],
+        edgeCases: [
+            'For temporary call-ups, add notes or remove after event completion.',
+            'If importing data externally, normalize casing for names and positions.'
+        ],
+        relatedGuideIds: ['create-team', 'plan-game', 'track-game'],
+        quickLinks: [
+            { label: 'Edit Roster', url: 'edit-roster.html#teamId={teamId}' },
+            { label: 'Team Page', url: 'team.html#teamId={teamId}' }
+        ],
+        lastUpdated: '2026-03-03'
     },
     {
-        id: 'glossary',
-        title: 'Glossary',
-        summary: 'Plain-language definitions for common platform terms used across help content.',
-        keywords: ['glossary', 'definitions', 'terminology', 'beginner'],
-        roles: ['parent', 'coach', 'administrator', 'member'],
-        workflows: [
-            'Role: access persona tied to permissions',
-            'Workflow: complete sequence of tasks from start to finish',
-            'Archive: retain record while removing from active operations',
-            'Refresh behavior: when visible data updates after writes'
-        ]
+        id: 'plan-game',
+        title: 'Plan a game',
+        category: 'planning',
+        roles: ['coach', 'administrator'],
+        tags: ['schedule', 'game', 'opponent', 'arrival', 'assignments'],
+        summary: 'Create and configure game events with opponent, location, assignments, and record behavior.',
+        prerequisites: [
+            'You have team schedule edit access.',
+            'You know game date/time, opponent, and location details.'
+        ],
+        steps: [
+            'Open `edit-schedule.html#teamId={teamId}`.',
+            'Select `Add Game` and enter date/time, opponent, and location.',
+            'Set home/away and competition type.',
+            'Configure arrival time, notes, and assignments as needed.',
+            'Save the game and verify it appears in schedule list and calendar filters.',
+            'Use track button options to verify standard/live route availability before game day.'
+        ],
+        commonErrors: [
+            'Game not visible after save: check active filter (Upcoming/Past/All).',
+            'Wrong record counting behavior: verify `count toward season record` toggle.',
+            'Opponent mismatch: use linked opponent search to avoid duplicate team names.'
+        ],
+        edgeCases: [
+            'Recurring series edits can affect one event vs. entire series; choose carefully.',
+            'Calendar imports can conflict with manually created events at same timestamp.'
+        ],
+        relatedGuideIds: ['plan-practice', 'track-game', 'watch-game'],
+        quickLinks: [
+            { label: 'Edit Schedule', url: 'edit-schedule.html#teamId={teamId}' },
+            { label: 'Team Schedule View', url: 'team.html#teamId={teamId}' }
+        ],
+        lastUpdated: '2026-03-03'
+    },
+    {
+        id: 'plan-practice',
+        title: 'Plan a practice',
+        category: 'planning',
+        roles: ['coach', 'administrator'],
+        tags: ['practice', 'schedule', 'drills', 'recurring'],
+        summary: 'Schedule practices, manage recurring sessions, and connect planning details.',
+        prerequisites: [
+            'You have schedule edit rights for the team.',
+            'You know practice cadence and location details.'
+        ],
+        steps: [
+            'Open `edit-schedule.html#teamId={teamId}`.',
+            'Select `Add Practice` and set start/end time, location, and notes.',
+            'Configure recurrence when needed and confirm day pattern.',
+            'Save and verify each occurrence in schedule views.',
+            'Attach or review practice plan context from schedule actions.',
+            'If cancellations occur, use per-occurrence or series-level cancellation intentionally.'
+        ],
+        commonErrors: [
+            'Practice appears on wrong date: verify timezone and recurrence day settings.',
+            'Edited one occurrence unexpectedly changed all: confirm occurrence scope choice.',
+            'No practice reminders: check team chat/notification settings for participants.'
+        ],
+        edgeCases: [
+            'Holiday weeks often need one-off override instead of editing whole series.',
+            'Imported calendar practices may be hidden by current filters.'
+        ],
+        relatedGuideIds: ['plan-game', 'manage-roster'],
+        quickLinks: [
+            { label: 'Edit Schedule', url: 'edit-schedule.html#teamId={teamId}' },
+            { label: 'Drills Library', url: 'drills.html#teamId={teamId}' }
+        ],
+        lastUpdated: '2026-03-03'
+    },
+    {
+        id: 'track-game',
+        title: 'Track a game (standard and live)',
+        category: 'game-day',
+        roles: ['coach', 'administrator'],
+        tags: ['track', 'live tracker', 'stats', 'undo', 'game log'],
+        summary: 'Choose the correct tracker for sport/game context and capture reliable in-game data.',
+        prerequisites: [
+            'A game is scheduled or selected from schedule.',
+            'Roster is complete for the selected team.'
+        ],
+        steps: [
+            'Open `edit-schedule.html#teamId={teamId}` and select the game `Track` action.',
+            'Choose the tracker type offered (standard, live, or sport-specific options).',
+            'In live tracker, confirm lineup state and period/clock controls before first event.',
+            'Record events into game log and use unified game note input for context.',
+            'Use undo/remove actions immediately when correcting accidental entries.',
+            'End tracking by saving and verify report outputs on `game.html` and team history.'
+        ],
+        commonErrors: [
+            'Wrong tracker opened: return to schedule and choose the intended tracker type.',
+            'Stats not updating: verify game clock state and team/opponent selection.',
+            'Undo not applying as expected: undo newest event first and verify log order.'
+        ],
+        edgeCases: [
+            'Basketball may route to dedicated live tracker while other sports use track-live.',
+            'If offline/intermittent network occurs, refresh carefully to avoid duplicate entries.'
+        ],
+        relatedGuideIds: ['watch-game', 'team-chat-tagging'],
+        quickLinks: [
+            { label: 'Track (Standard)', url: 'track.html#teamId={teamId}' },
+            { label: 'Track (Live)', url: 'track-live.html#teamId={teamId}' },
+            { label: 'Basketball Live Tracker', url: 'live-tracker.html#teamId={teamId}' }
+        ],
+        lastUpdated: '2026-03-03'
+    },
+    {
+        id: 'watch-game',
+        title: 'Watch a game (live and replay)',
+        category: 'watch-chat',
+        roles: ['member', 'parent', 'coach', 'administrator'],
+        tags: ['watch', 'live stream', 'replay', 'game page', 'viewer'],
+        summary: 'Open live viewing experiences and understand when chat/replay modes are available.',
+        prerequisites: [
+            'Game has stream or live view enabled.',
+            'You have access to the team/game.'
+        ],
+        steps: [
+            'Open `team.html#teamId={teamId}` or `game.html#teamId={teamId}&gameId={gameId}`.',
+            'Select `Watch Live` or equivalent viewer action when available.',
+            'Confirm stream provider embed loads (YouTube/Twitch where configured).',
+            'Verify score/state updates during active game.',
+            'If replay mode is shown, confirm expected read-only behavior and chat availability.',
+            'Use share/copy controls if you need to send the view link to others.'
+        ],
+        commonErrors: [
+            'Watch button missing: stream link not configured or game not eligible.',
+            'Embed blocked: verify provider URL format and allowed embedding settings.',
+            'Stale viewer data: refresh and re-open from team/game page.'
+        ],
+        edgeCases: [
+            'Replay mode can disable interactive chat depending on live status rules.',
+            'Private/age-restricted streams may not embed for all viewers.'
+        ],
+        relatedGuideIds: ['track-game', 'team-chat-basics'],
+        quickLinks: [
+            { label: 'Team Page', url: 'team.html#teamId={teamId}' },
+            { label: 'Game Viewer', url: 'live-game.html#teamId={teamId}&gameId={gameId}' }
+        ],
+        lastUpdated: '2026-03-03'
+    },
+    {
+        id: 'team-chat-basics',
+        title: 'Use team chat',
+        category: 'watch-chat',
+        roles: ['parent', 'coach', 'administrator'],
+        tags: ['chat', 'messages', 'team communication', 'notifications'],
+        summary: 'Send team messages, read updates, and keep communication organized during season workflows.',
+        prerequisites: [
+            'You have access to the team chat room.'
+        ],
+        steps: [
+            'Open `team-chat.html#teamId={teamId}` from team navigation.',
+            'Read recent messages before posting to avoid duplicate updates.',
+            'Enter concise message text and send.',
+            'Use chat for schedule changes, reminders, and game-day updates.',
+            'Confirm message appears with expected timestamp and sender context.',
+            'Adjust notification settings if message volume is too high or too low.'
+        ],
+        commonErrors: [
+            'Cannot send message: verify team membership and authentication session.',
+            'Messages not updating: refresh page or navigate out/in once.',
+            'Notification mismatch: check device/browser notification permissions.'
+        ],
+        edgeCases: [
+            'High-volume game-day chats should keep one-thread-per-topic discipline.',
+            'Pinned/important announcements should be repeated near event start.'
+        ],
+        relatedGuideIds: ['team-chat-tagging', 'watch-game'],
+        quickLinks: [
+            { label: 'Open Team Chat', url: 'team-chat.html#teamId={teamId}' },
+            { label: 'Open Team', url: 'team.html#teamId={teamId}' }
+        ],
+        lastUpdated: '2026-03-03'
+    },
+    {
+        id: 'team-chat-tagging',
+        title: 'Tag people in chat',
+        category: 'watch-chat',
+        roles: ['parent', 'coach', 'administrator'],
+        tags: ['tag', 'mention', 'chat', 'notifications', '@'],
+        summary: 'Mention the right people in chat without over-notifying the entire team.',
+        prerequisites: [
+            'Team chat is enabled and you can send messages.',
+            'You know who should be notified for the message context.'
+        ],
+        steps: [
+            'Open `team-chat.html#teamId={teamId}`.',
+            'Start typing your message and include a mention format supported by chat UI.',
+            'Tag only the people or groups that need action.',
+            'Send the message and confirm mention formatting renders correctly.',
+            'Watch for replies/acknowledgments from tagged recipients.',
+            'If message is urgent, follow up with a clear action + deadline in same thread.'
+        ],
+        commonErrors: [
+            'Tag does not link/notify: check exact mention formatting expected by current chat implementation.',
+            'Too many people notified: narrow tags to responsible individuals.',
+            'No response from tagged users: verify they have notification permissions enabled.'
+        ],
+        edgeCases: [
+            'In mixed parent/coach chats, avoid tagging minors directly where policy requires parent-only comms.',
+            'For repeated announcements, use one canonical message and reference it instead of retagging everyone.'
+        ],
+        relatedGuideIds: ['team-chat-basics', 'plan-game'],
+        quickLinks: [
+            { label: 'Open Team Chat', url: 'team-chat.html#teamId={teamId}' }
+        ],
+        lastUpdated: '2026-03-03'
     }
 ];
+
+const REQUIRED_GUIDE_IDS = [
+    'login',
+    'forgot-password',
+    'sign-up-activation',
+    'create-team',
+    'manage-roster',
+    'plan-game',
+    'plan-practice',
+    'track-game',
+    'watch-game',
+    'team-chat-basics',
+    'team-chat-tagging'
+];
+
+function dedupeById(items) {
+    const seen = new Set();
+    return items.filter((item) => {
+        if (!item?.id || seen.has(item.id)) return false;
+        seen.add(item.id);
+        return true;
+    });
+}
 
 export function normalizeHelpRole(role) {
     const normalized = String(role || '').trim().toLowerCase();
     return HELP_ROLE_ALIASES[normalized] || 'member';
 }
 
-export function getHelpSectionsForRole(role) {
+export function getHelpGuidesForRole(role) {
     const normalizedRole = normalizeHelpRole(role);
-    return HELP_SECTIONS.filter((section) => section.roles.includes(normalizedRole));
+    return HELP_GUIDES.filter((guide) => (guide.roles || []).includes(normalizedRole));
 }
 
-export function searchHelpSections(sections, query) {
-    const trimmed = String(query || '').trim().toLowerCase();
-    if (!trimmed) return [...sections];
+export function getHelpCategoriesForRole(role) {
+    const guides = getHelpGuidesForRole(role);
+    const allowedCategoryIds = new Set(guides.map((guide) => guide.category));
+    return HELP_CATEGORIES.filter((category) => allowedCategoryIds.has(category.id));
+}
 
-    return sections.filter((section) => {
+export function getGuideById(role, guideId) {
+    const normalizedId = String(guideId || '').trim().toLowerCase();
+    if (!normalizedId) return null;
+    return getHelpGuidesForRole(role).find((guide) => guide.id === normalizedId) || null;
+}
+
+export function searchHelpGuides(guides, query, category = 'all') {
+    const trimmed = String(query || '').trim().toLowerCase();
+    const selectedCategory = String(category || 'all').trim().toLowerCase();
+
+    let scoped = Array.isArray(guides) ? [...guides] : [];
+    if (selectedCategory && selectedCategory !== 'all') {
+        scoped = scoped.filter((guide) => guide.category === selectedCategory);
+    }
+
+    if (!trimmed) return scoped;
+
+    return scoped.filter((guide) => {
         const values = [
-            section.title,
-            section.summary,
-            ...(section.keywords || []),
-            ...(section.workflows || [])
+            guide.title,
+            guide.summary,
+            ...(guide.tags || []),
+            ...(guide.prerequisites || []),
+            ...(guide.steps || []),
+            ...(guide.commonErrors || []),
+            ...(guide.edgeCases || [])
         ];
         return values.some((value) => String(value).toLowerCase().includes(trimmed));
     });
+}
+
+export function getTopHelpGuides(role, limit = 6) {
+    const guides = getHelpGuidesForRole(role);
+    return guides.slice(0, Math.max(1, limit));
+}
+
+export function resolveGuideLinks(guide, context = {}) {
+    const teamId = context.teamId ? String(context.teamId) : '';
+    const gameId = context.gameId ? String(context.gameId) : '';
+
+    return (guide?.quickLinks || []).map((link) => {
+        let resolved = String(link.url || '');
+        resolved = resolved.replaceAll('{teamId}', encodeURIComponent(teamId));
+        resolved = resolved.replaceAll('{gameId}', encodeURIComponent(gameId));
+        resolved = resolved.replace(/#teamId=$/, '');
+        resolved = resolved.replace(/\?teamId=$/, '');
+        resolved = resolved.replace(/&gameId=$/, '');
+        resolved = resolved.replace(/\?gameId=$/, '');
+        return {
+            ...link,
+            url: resolved
+        };
+    });
+}
+
+export function getRelatedGuides(role, guide) {
+    const byRole = getHelpGuidesForRole(role);
+    const byId = new Map(byRole.map((item) => [item.id, item]));
+    const relatedIds = guide?.relatedGuideIds || [];
+    const related = relatedIds.map((id) => byId.get(id)).filter(Boolean);
+    return dedupeById(related);
+}
+
+export function getRequiredGuideIds() {
+    return [...REQUIRED_GUIDE_IDS];
+}
+
+// Backward compatibility for existing consumers/tests before help page upgrade.
+export function getHelpSectionsForRole(role) {
+    return getHelpGuidesForRole(role);
+}
+
+export function searchHelpSections(sections, query) {
+    return searchHelpGuides(sections, query);
 }

--- a/js/help-center.js
+++ b/js/help-center.js
@@ -1,0 +1,144 @@
+const HELP_ROLE_ALIASES = {
+    parent: 'parent',
+    parents: 'parent',
+    coach: 'coach',
+    coaches: 'coach',
+    admin: 'administrator',
+    admins: 'administrator',
+    administrator: 'administrator',
+    administrators: 'administrator',
+    member: 'member',
+    user: 'member'
+};
+
+const HELP_SECTIONS = [
+    {
+        id: 'account-access',
+        title: 'Account and Access',
+        summary: 'Create an account, sign in, manage profile details, and understand permissions and privacy defaults.',
+        keywords: ['onboarding', 'authentication', 'password', 'profile', 'permissions', 'privacy', 'security'],
+        roles: ['parent', 'coach', 'administrator', 'member'],
+        workflows: [
+            'Create account with activation code and complete onboarding',
+            'Sign in, sign out, and reset password',
+            'Update profile details and notification identity',
+            'Understand role permissions and access boundaries'
+        ]
+    },
+    {
+        id: 'core-workflows',
+        title: 'Core Platform Workflows',
+        summary: 'End-to-end steps for creating, updating, archiving, and operating team workflows.',
+        keywords: ['setup', 'operations', 'edit', 'delete', 'archive', 'notifications', 'alerts'],
+        roles: ['parent', 'coach', 'administrator', 'member'],
+        workflows: [
+            'Set up teams, schedules, and roster records',
+            'Operate game-day and practice workflows',
+            'Edit or archive records safely',
+            'Review notification and alert behavior'
+        ]
+    },
+    {
+        id: 'role-experiences',
+        title: 'Role-Based Experiences',
+        summary: 'Role-specific visibility, responsibilities, and limits for parents, coaches, and administrators.',
+        keywords: ['role', 'visibility', 'responsibilities', 'limits', 'boundaries'],
+        roles: ['parent', 'coach', 'administrator', 'member'],
+        workflows: [
+            'What each role can see and do in navigation and workflows',
+            'How roles interact with one another on teams',
+            'Common tasks by role and expected outcomes',
+            'Boundary conditions and permission denials'
+        ]
+    },
+    {
+        id: 'data-reporting',
+        title: 'Data and Reporting',
+        summary: 'Understand records, metrics definitions, data timing, and export/share patterns.',
+        keywords: ['metrics', 'definitions', 'reports', 'records', 'export', 'refresh'],
+        roles: ['coach', 'administrator', 'parent'],
+        workflows: [
+            'View and interpret team and player data',
+            'Create or edit records with role-aware permissions',
+            'Share or export data where allowed',
+            'Understand refresh timing and data consistency'
+        ]
+    },
+    {
+        id: 'communication',
+        title: 'Communication and Collaboration',
+        summary: 'Team chat, notification preferences, moderation behavior, and privacy expectations.',
+        keywords: ['chat', 'messages', 'notifications', 'moderation', 'privacy', 'collaboration'],
+        roles: ['parent', 'coach', 'administrator'],
+        workflows: [
+            'Send and receive team communications',
+            'Adjust notification preferences for each workflow',
+            'Follow moderation and content controls',
+            'Handle private data with least-privilege expectations'
+        ]
+    },
+    {
+        id: 'settings-config',
+        title: 'System Settings and Configuration',
+        summary: 'Application, team, and user-level settings with configuration decision guidance.',
+        keywords: ['settings', 'configuration', 'organization', 'team settings', 'user settings'],
+        roles: ['coach', 'administrator'],
+        workflows: [
+            'Configure application and team-level settings',
+            'Update user-level preferences and defaults',
+            'Apply safe changes with rollback awareness',
+            'Verify configuration impact before rollout'
+        ]
+    },
+    {
+        id: 'troubleshooting',
+        title: 'Error Handling and Edge Cases',
+        summary: 'Troubleshoot common errors, permission denials, sync delays, and escalation paths.',
+        keywords: ['error', 'troubleshoot', 'permission denied', 'sync', 'delays', 'escalation'],
+        roles: ['parent', 'coach', 'administrator', 'member'],
+        workflows: [
+            'Decode common error messages and likely causes',
+            'Resolve permission-related issues by role',
+            'Handle sync/update delays and stale data',
+            'Escalate with logs and reproducible steps'
+        ]
+    },
+    {
+        id: 'glossary',
+        title: 'Glossary',
+        summary: 'Plain-language definitions for common platform terms used across help content.',
+        keywords: ['glossary', 'definitions', 'terminology', 'beginner'],
+        roles: ['parent', 'coach', 'administrator', 'member'],
+        workflows: [
+            'Role: access persona tied to permissions',
+            'Workflow: complete sequence of tasks from start to finish',
+            'Archive: retain record while removing from active operations',
+            'Refresh behavior: when visible data updates after writes'
+        ]
+    }
+];
+
+export function normalizeHelpRole(role) {
+    const normalized = String(role || '').trim().toLowerCase();
+    return HELP_ROLE_ALIASES[normalized] || 'member';
+}
+
+export function getHelpSectionsForRole(role) {
+    const normalizedRole = normalizeHelpRole(role);
+    return HELP_SECTIONS.filter((section) => section.roles.includes(normalizedRole));
+}
+
+export function searchHelpSections(sections, query) {
+    const trimmed = String(query || '').trim().toLowerCase();
+    if (!trimmed) return [...sections];
+
+    return sections.filter((section) => {
+        const values = [
+            section.title,
+            section.summary,
+            ...(section.keywords || []),
+            ...(section.workflows || [])
+        ];
+        return values.some((value) => String(value).toLowerCase().includes(trimmed));
+    });
+}

--- a/js/team-admin-banner.js
+++ b/js/team-admin-banner.js
@@ -51,6 +51,13 @@ function icon(name) {
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 21v-4m0 0V5a2 2 0 012-2h6.5l1 1H21l-3 6 3 6h-8.5l-1-1H5a2 2 0 00-2 2zm9-13.5V9"></path>
     </svg>`;
   }
+  if (name === 'help') {
+    return `<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.228 9a3.5 3.5 0 116.544 1.677c-.35.855-.977 1.303-1.529 1.696-.67.479-1.243.887-1.243 1.877v.25"></path>
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 17h.01"></path>
+      <circle cx="12" cy="12" r="9" stroke-width="2"></circle>
+    </svg>`;
+  }
   if (name === 'exit') {
     return `<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v8a2 2 0 002 2h4"></path>
@@ -111,6 +118,7 @@ export function renderTeamAdminBanner(container, { team, teamId, active = '', un
   const sport = team?.sport || '';
   const photoUrl = team?.photoUrl || '';
   const isFullAccess = accessLevel === 'full';
+  const helpRole = isFullAccess ? 'coach' : 'parent';
 
   const hrefs = {
     view: `team.html#teamId=${teamId}`,
@@ -122,6 +130,7 @@ export function renderTeamAdminBanner(container, { team, teamId, active = '', un
     chat: `team-chat.html#teamId=${teamId}`,
     drills: `drills.html#teamId=${teamId}`,
     gameday: `game-day.html#teamId=${teamId}`,
+    help: `help.html?context=team&teamId=${teamId}`,
     exit: exitUrl
   };
 
@@ -139,19 +148,21 @@ export function renderTeamAdminBanner(container, { team, teamId, active = '', un
       ${actionCard({ href: hrefs.chat, label: 'Chat', iconName: 'chat', active: active === 'chat', unreadCount })}
       ${actionCard({ href: hrefs.drills, label: 'Drills', iconName: 'drills', active: active === 'drills' })}
       ${actionCard({ href: hrefs.gameday, label: 'Game Day', iconName: 'gameday', active: active === 'gameday' })}
+      ${actionCard({ href: `${hrefs.help}&role=${helpRole}`, label: 'Help', iconName: 'help', active: active === 'help' })}
     `;
   } else {
-    // Parent: View, Chat only
+    // Parent: View, Chat, Help
     navCards = `
       ${actionCard({ href: hrefs.view, label: 'View', iconName: 'view', active: active === 'view' })}
       ${actionCard({ href: hrefs.chat, label: 'Chat', iconName: 'chat', active: active === 'chat', unreadCount })}
+      ${actionCard({ href: `${hrefs.help}&role=${helpRole}`, label: 'Help', iconName: 'help', active: active === 'help' })}
     `;
   }
 
   // Determine grid columns based on number of items
   const gridCols = isFullAccess
-    ? 'grid-cols-2 sm:grid-cols-5 lg:grid-cols-9'
-    : 'grid-cols-2';
+    ? 'grid-cols-2 sm:grid-cols-5 lg:grid-cols-10'
+    : 'grid-cols-3';
 
   container.innerHTML = `
     <div class="group bg-white rounded-2xl shadow-md border border-gray-200 overflow-hidden">

--- a/js/utils.js
+++ b/js/utils.js
@@ -236,7 +236,7 @@ export function renderFooter(container) {
             <div>
               <h4 class="text-white font-semibold mb-4">Support</h4>
               <ul class="space-y-2 text-sm">
-                <li><a href="#" class="hover:text-white transition">Help Center</a></li>
+                <li><a href="help.html" class="hover:text-white transition">Help Center</a></li>
                 <li><a href="#" class="hover:text-white transition">Contact</a></li>
                 <li><a href="https://github.com/pauljsnider/paulsnidernet" class="hover:text-white transition" target="_blank" rel="noopener noreferrer">GitHub</a></li>
               </ul>

--- a/js/utils.js
+++ b/js/utils.js
@@ -237,8 +237,7 @@ export function renderFooter(container) {
               <h4 class="text-white font-semibold mb-4">Support</h4>
               <ul class="space-y-2 text-sm">
                 <li><a href="help.html" class="hover:text-white transition">Help Center</a></li>
-                <li><a href="#" class="hover:text-white transition">Contact</a></li>
-                <li><a href="https://github.com/pauljsnider/paulsnidernet" class="hover:text-white transition" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+                <li><a href="https://paulsnider.net" class="hover:text-white transition" target="_blank" rel="noopener noreferrer">Contact</a></li>
               </ul>
             </div>
           </div>

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -719,12 +719,25 @@
             const allEvents = [];
 
             for (const [teamId, teamChildren] of byTeam.entries()) {
-                const team = await getTeam(teamId);
-                if (!team) continue;
+                let team = null;
+                let dbGames = [];
+                let trackedUids = [];
+                let practiceSessions = [];
+                try {
+                    team = await getTeam(teamId);
+                    if (!team) continue;
 
-                const dbGames = await getGames(teamId);
-                const trackedUids = await getTrackedCalendarEventUids(teamId);
-                const practiceSessions = await getPracticeSessions(teamId);
+                    dbGames = await getGames(teamId);
+                    trackedUids = await getTrackedCalendarEventUids(teamId);
+                    practiceSessions = await getPracticeSessions(teamId);
+                } catch (err) {
+                    console.warn('[parent-dashboard] Failed to load team schedule data:', teamId, err);
+                    continue;
+                }
+                if (!Array.isArray(dbGames)) dbGames = [];
+                if (!Array.isArray(trackedUids)) trackedUids = [];
+                if (!Array.isArray(practiceSessions)) practiceSessions = [];
+
                 const sessionsByEventId = new Map();
                 const sessions = [];
                 const matchedSessionIds = new Set();

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -263,7 +263,6 @@
             return `${summary.going || 0} going · ${summary.maybe || 0} maybe · ${summary.notGoing || 0} can't go · ${summary.notResponded || 0} no response`;
         }
 
-        window.submitGameRsvp = async function(teamId, gameId, response, childContext = {}) {
         function getEventRideKey(teamId, eventId) {
             return `${teamId || ''}::${eventId || ''}`;
         }

--- a/scripts/build-help-workflow-html-loop.mjs
+++ b/scripts/build-help-workflow-html-loop.mjs
@@ -1,0 +1,794 @@
+#!/usr/bin/env node
+/**
+ * Converts workflow-docs/*.md to workflow-*.html and rebuilds help.html
+ * as a workflow-first index with search + role filter.
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..');
+const WORKFLOW_MD_DIR = path.join(ROOT, 'workflow-docs');
+const HELP_HTML = path.join(ROOT, 'help.html');
+const MANIFEST = path.join(ROOT, 'workflow-manifest.json');
+
+function escapeHtml(value) {
+    return String(value || '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function slugify(value) {
+    return String(value || '')
+        .toLowerCase()
+        .replace(/[^a-z0-9\s-]/g, '')
+        .trim()
+        .replace(/\s+/g, '-')
+        .replace(/-+/g, '-') || 'section';
+}
+
+function parseInline(value) {
+    return escapeHtml(value)
+        .replace(/`([^`]+)`/g, '<code>$1</code>')
+        .replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>')
+        .replace(/\*(.+?)\*/g, '<em>$1</em>');
+}
+
+function mdToHtml(md) {
+    const lines = md.replace(/\r\n/g, '\n').split('\n');
+    const out = [];
+    let inUl = false;
+    let inOl = false;
+    let skippedFirstH1 = false;
+    const headingCounts = new Map();
+
+    const closeLists = () => {
+        if (inUl) {
+            out.push('</ul>');
+            inUl = false;
+        }
+        if (inOl) {
+            out.push('</ol>');
+            inOl = false;
+        }
+    };
+
+    for (const raw of lines) {
+        const line = raw.trim();
+
+        if (!line) {
+            closeLists();
+            continue;
+        }
+
+        const h = /^(#{1,6})\s+(.*)$/.exec(line);
+        if (h) {
+            closeLists();
+            const level = Math.min(h[1].length, 6);
+            if (level === 1 && !skippedFirstH1) {
+                skippedFirstH1 = true;
+                continue;
+            }
+            const headingText = h[2].trim();
+            const baseSlug = slugify(headingText);
+            const nextCount = (headingCounts.get(baseSlug) || 0) + 1;
+            headingCounts.set(baseSlug, nextCount);
+            const slug = nextCount > 1 ? `${baseSlug}-${nextCount}` : baseSlug;
+            out.push(`<h${level} id="${slug}">${parseInline(headingText)}</h${level}>`);
+            continue;
+        }
+
+        const ordered = /^\d+\.\s+(.*)$/.exec(line);
+        if (ordered) {
+            if (inUl) {
+                out.push('</ul>');
+                inUl = false;
+            }
+            if (!inOl) {
+                out.push('<ol class="ml-6 list-decimal space-y-1">');
+                inOl = true;
+            }
+            out.push(`<li>${parseInline(ordered[1])}</li>`);
+            continue;
+        }
+
+        const bullet = /^[-*+]\s+(.*)$/.exec(line);
+        if (bullet) {
+            if (inOl) {
+                out.push('</ol>');
+                inOl = false;
+            }
+            if (!inUl) {
+                out.push('<ul class="ml-6 list-disc space-y-1">');
+                inUl = true;
+            }
+            out.push(`<li>${parseInline(bullet[1])}</li>`);
+            continue;
+        }
+
+        closeLists();
+        out.push(`<p>${parseInline(line)}</p>`);
+    }
+
+    closeLists();
+    return out.join('\n');
+}
+
+function extractTitle(md, fallback) {
+    const first = md.split('\n').find((l) => /^#\s+/.test(l.trim()));
+    return first ? first.replace(/^#\s+/, '').trim() : fallback;
+}
+
+function summarize(md) {
+    const lines = md
+        .replace(/\r\n/g, '\n')
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean)
+        .filter((l) => !/^#/.test(l))
+        .filter((l) => !/^[-*+]\s+/.test(l))
+        .filter((l) => !/^\d+\.\s+/.test(l));
+    const clean = (lines[0] || md)
+        .replace(/[#>*`]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+    return clean.slice(0, 190);
+}
+
+function estimateReadTime(md) {
+    const words = md
+        .replace(/\r\n/g, '\n')
+        .replace(/[`#>*]/g, ' ')
+        .split(/\s+/)
+        .filter(Boolean).length;
+    return Math.max(2, Math.round(words / 190));
+}
+
+function extractRoles(md) {
+    const lines = md.replace(/\r\n/g, '\n').split('\n');
+    const roles = new Set();
+    let inSection = false;
+
+    for (const raw of lines) {
+        const line = raw.trim();
+        if (!line) continue;
+
+        if (/^##\s+Who\s+Is\s+This\s+For/i.test(line)) {
+            inSection = true;
+            continue;
+        }
+        if (inSection && /^##\s+/.test(line)) {
+            break;
+        }
+        if (!inSection) {
+            continue;
+        }
+
+        const roleMatches = line.match(/\b(Parent|Parents|Coach|Coaches|Admin|Admins|Member|Members|All)\b/gi) || [];
+        roleMatches.forEach((rawRole) => {
+            const key = rawRole.toLowerCase();
+            if (key.startsWith('parent')) roles.add('Parent');
+            else if (key.startsWith('coach')) roles.add('Coach');
+            else if (key.startsWith('admin')) roles.add('Admin');
+            else if (key.startsWith('member')) roles.add('Member');
+            else if (key === 'all') roles.add('All');
+        });
+
+        if (/all users?/i.test(line)) {
+            roles.add('All');
+        }
+    }
+
+    if (!roles.size) {
+        return ['All'];
+    }
+
+    const order = ['All', 'Parent', 'Coach', 'Admin', 'Member'];
+    return order.filter((r) => roles.has(r));
+}
+
+function buildRoleBadges(roles) {
+    return (roles && roles.length ? roles : ['All'])
+        .map((r) => `<span class="wf-role-chip">${escapeHtml(r)}</span>`)
+        .join(' ');
+}
+
+function primaryTailwindConfig() {
+    return `<script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: {
+                50: '#eef2ff',
+                100: '#e0e7ff',
+                500: '#6366f1',
+                600: '#4f46e5',
+                700: '#4338ca',
+                800: '#3730a3',
+                900: '#312e81'
+              }
+            }
+          }
+        }
+      }
+    </script>`;
+}
+
+function standardChromeScript() {
+    return `<script type="module">
+      import { checkAuth } from './js/auth.js?v=9';
+      import { renderHeader, renderFooter } from './js/utils.js?v=8';
+      renderHeader(document.getElementById('header-container'), null);
+      renderFooter(document.getElementById('footer-container'));
+      checkAuth((user) => {
+        renderHeader(document.getElementById('header-container'), user);
+      });
+    </script>`;
+}
+
+function renderArticle({ title, roles, bodyHtml, summary, readTimeMin }) {
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>${escapeHtml(title)} - ALL PLAYS Help</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+    ${primaryTailwindConfig()}
+    <style>
+      :root {
+        --wf-bg: #f8fafc;
+        --wf-panel: #ffffff;
+        --wf-text: #0f172a;
+        --wf-muted: #52606f;
+        --wf-accent: #4f46e5;
+        --wf-accent-soft: #e0e7ff;
+        --wf-border: #d9e2ec;
+      }
+
+      body {
+        background:
+          radial-gradient(circle at 85% 0%, rgba(99,102,241,0.14) 0%, rgba(248,250,252,0) 42%),
+          radial-gradient(circle at 8% 20%, rgba(67,56,202,0.10) 0%, rgba(248,250,252,0) 48%),
+          var(--wf-bg);
+        color: var(--wf-text);
+      }
+
+      .wf-shell {
+        width: min(1160px, 100%);
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+      }
+
+      .wf-back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.85rem;
+        font-weight: 700;
+        color: #4338ca;
+      }
+
+      .wf-hero {
+        margin-top: 0.75rem;
+        background: linear-gradient(140deg, #312e81 0%, #4338ca 46%, #4f46e5 100%);
+        border-radius: 1.1rem;
+        padding: 1.25rem 1.25rem 1.15rem;
+        color: #ecfeff;
+        box-shadow: 0 14px 36px rgba(15, 23, 42, 0.22);
+      }
+
+      .wf-kicker {
+        font-size: 0.73rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        opacity: 0.84;
+      }
+
+      .wf-title {
+        margin-top: 0.4rem;
+        font-size: clamp(1.75rem, 2.8vw, 2.35rem);
+        line-height: 1.15;
+        font-weight: 800;
+      }
+
+      .wf-summary {
+        margin-top: 0.75rem;
+        max-width: 60ch;
+        color: rgba(236, 254, 255, 0.95);
+        line-height: 1.58;
+      }
+
+      .wf-meta-row {
+        margin-top: 0.95rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+        align-items: center;
+      }
+
+      .wf-meta-pill {
+        display: inline-flex;
+        align-items: center;
+        font-size: 0.78rem;
+        font-weight: 700;
+        border-radius: 999px;
+        border: 1px solid rgba(236, 254, 255, 0.36);
+        background: rgba(236, 254, 255, 0.12);
+        color: #ecfeff;
+        padding: 0.24rem 0.62rem;
+      }
+
+      .wf-layout {
+        margin-top: 1rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .wf-panel {
+        background: var(--wf-panel);
+        border: 1px solid var(--wf-border);
+        border-radius: 1rem;
+        box-shadow: 0 7px 20px rgba(15, 23, 42, 0.08);
+      }
+
+      .wf-panel-section {
+        padding: 1rem;
+        border-bottom: 1px solid var(--wf-border);
+      }
+
+      .wf-panel-section:last-child {
+        border-bottom: 0;
+      }
+
+      .wf-panel-title {
+        font-size: 0.78rem;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #334155;
+        margin-bottom: 0.6rem;
+      }
+
+      .wf-role-chip {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        border: 1px solid #c7d2fe;
+        background: #eef2ff;
+        color: #3730a3;
+        padding: 0.22rem 0.66rem;
+        font-size: 0.74rem;
+        font-weight: 700;
+      }
+
+      .wf-roles {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+      }
+
+      .wf-toc {
+        display: grid;
+        gap: 0.33rem;
+      }
+
+      .wf-toc a {
+        display: block;
+        padding: 0.43rem 0.52rem;
+        border-radius: 0.55rem;
+        color: #334155;
+        font-size: 0.82rem;
+        line-height: 1.35;
+        transition: background 120ms ease, color 120ms ease;
+      }
+
+      .wf-toc a:hover {
+        background: #eef2ff;
+        color: #3730a3;
+      }
+
+      .wf-toc a.is-active {
+        background: #e0e7ff;
+        color: #312e81;
+        font-weight: 700;
+      }
+
+      .wf-content {
+        padding: 1.2rem 1.15rem;
+      }
+
+      .help-workflow-body {
+        display: grid;
+        gap: 0.45rem;
+      }
+
+      .help-workflow-body h2 {
+        font-size: 1.4rem;
+        font-weight: 800;
+        color: #1f2937;
+        margin-top: 1.25rem;
+        padding-top: 1.05rem;
+        border-top: 1px solid #dbe7f0;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body h2:first-of-type {
+        margin-top: 0.15rem;
+        padding-top: 0;
+        border-top: 0;
+      }
+
+      .help-workflow-body h3 {
+        font-size: 1.08rem;
+        font-weight: 700;
+        color: #1e293b;
+        margin-top: 0.88rem;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body p,
+      .help-workflow-body li {
+        color: var(--wf-muted);
+        line-height: 1.67;
+      }
+
+      .help-workflow-body ol,
+      .help-workflow-body ul {
+        margin-left: 1.2rem;
+      }
+
+      .help-workflow-body code {
+        background: #eef2ff;
+        color: #3730a3;
+        border: 1px solid #c7d2fe;
+        padding: 0.1rem 0.35rem;
+        border-radius: 0.3rem;
+        font-size: 0.86em;
+      }
+
+      .wf-mobile-toc {
+        margin-top: 0.95rem;
+      }
+
+      @media (min-width: 1024px) {
+        .wf-layout {
+          grid-template-columns: 270px minmax(0, 1fr);
+          align-items: start;
+        }
+
+        .wf-sidebar {
+          position: sticky;
+          top: 1rem;
+        }
+      }
+
+      @media (max-width: 1023px) {
+        .wf-sidebar .wf-panel-section:nth-child(1) {
+          display: none;
+        }
+      }
+    </style>
+</head>
+<body class="flex flex-col min-h-screen">
+    <div id="header-container"></div>
+    <main class="flex-grow">
+      <div class="wf-shell">
+        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <section class="wf-hero">
+          <p class="wf-kicker">Workflow Guide</p>
+          <h1 class="wf-title">${escapeHtml(title)}</h1>
+          <p class="wf-summary">${escapeHtml(summary || 'Use this workflow to complete your task quickly and confidently.')}</p>
+          <div class="wf-meta-row">
+            <span class="wf-meta-pill">${escapeHtml(readTimeMin)} min read</span>
+            <span class="wf-meta-pill">Updated from live product pages</span>
+          </div>
+        </section>
+
+        <div class="wf-layout">
+          <aside class="wf-sidebar wf-panel">
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">On this page</h2>
+              <nav id="workflow-toc" class="wf-toc"></nav>
+            </section>
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">Who can use this</h2>
+              <div class="wf-roles">${buildRoleBadges(roles)}</div>
+            </section>
+          </aside>
+
+          <article class="wf-panel wf-content">
+            <div id="workflow-mobile-toc" class="wf-mobile-toc"></div>
+            <div class="help-workflow-body">${bodyHtml}</div>
+          </article>
+        </div>
+      </div>
+    </main>
+    <div id="footer-container"></div>
+    ${standardChromeScript()}
+    <script>
+      (function() {
+        const headings = Array.from(document.querySelectorAll('.help-workflow-body h2[id]'));
+        const toc = document.getElementById('workflow-toc');
+        const mobileToc = document.getElementById('workflow-mobile-toc');
+        if (!toc || !headings.length) return;
+
+        const links = headings.map((h) => {
+          const a = document.createElement('a');
+          a.href = '#' + h.id;
+          a.textContent = h.textContent || h.id;
+          toc.appendChild(a);
+          return a;
+        });
+
+        if (mobileToc && window.innerWidth < 1024) {
+          const wrapper = document.createElement('details');
+          wrapper.className = 'wf-panel-section wf-panel';
+          wrapper.style.marginBottom = '0.95rem';
+          wrapper.style.padding = '0.8rem 1rem';
+          const summary = document.createElement('summary');
+          summary.textContent = 'Jump to section';
+          summary.style.cursor = 'pointer';
+          summary.style.fontWeight = '700';
+          summary.style.color = '#0f172a';
+          const list = toc.cloneNode(true);
+          list.style.marginTop = '0.6rem';
+          wrapper.appendChild(summary);
+          wrapper.appendChild(list);
+          mobileToc.appendChild(wrapper);
+        }
+
+        const sectionById = new Map(headings.map((h) => [h.id, h]));
+        const setActive = () => {
+          let active = headings[0];
+          for (const h of headings) {
+            if (h.getBoundingClientRect().top <= 140) active = h;
+          }
+          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+        };
+
+        window.addEventListener('scroll', setActive, { passive: true });
+        setActive();
+      })();
+    </script>
+</body>
+</html>`;
+}
+
+function renderIndex(manifest) {
+    const cards = manifest.map((item) => `
+        <article class="wf-card rounded-2xl border border-slate-200 bg-white p-5">
+            <div class="wf-card-accent"></div>
+            <h2 class="text-xl font-extrabold tracking-tight text-slate-900">${escapeHtml(item.title)}</h2>
+            <p class="mt-2 text-sm text-slate-600 leading-6">${escapeHtml(item.summary)}</p>
+            <div class="mt-4 flex flex-wrap gap-2">${buildRoleBadges(item.roles)}</div>
+            <a class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 hover:text-primary-800" href="${escapeHtml(item.file)}">Open workflow <span aria-hidden="true">→</span></a>
+        </article>
+    `).join('\n');
+
+    return `<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Help Center - Workflows</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+    ${primaryTailwindConfig()}
+    <style>
+      :root {
+        --wf-bg: #f8fafc;
+      }
+
+      body {
+        background:
+          radial-gradient(circle at 82% -5%, rgba(99,102,241,0.16) 0%, rgba(248,250,252,0) 44%),
+          radial-gradient(circle at -2% 22%, rgba(67,56,202,0.12) 0%, rgba(248,250,252,0) 48%),
+          var(--wf-bg);
+      }
+
+      .wf-index-shell {
+        width: min(1180px, 100%);
+        margin: 0 auto;
+        padding: 1.5rem 1rem 2.5rem;
+      }
+
+      .wf-index-hero {
+        border-radius: 1.2rem;
+        background: linear-gradient(140deg, #312e81 0%, #4338ca 52%, #4f46e5 100%);
+        color: #ecfeff;
+        padding: 1.35rem 1.3rem 1.2rem;
+        box-shadow: 0 16px 38px rgba(15, 23, 42, 0.21);
+      }
+
+      .wf-index-hero h1 {
+        font-size: clamp(1.9rem, 3.2vw, 2.7rem);
+        line-height: 1.08;
+        font-weight: 900;
+        letter-spacing: -0.02em;
+      }
+
+      .wf-index-hero p {
+        margin-top: 0.7rem;
+        max-width: 70ch;
+        line-height: 1.58;
+        color: rgba(236, 254, 255, 0.92);
+      }
+
+      .wf-toolbar {
+        margin-top: 1rem;
+        border-radius: 1rem;
+        background: rgba(255, 255, 255, 0.96);
+        border: 1px solid #dbe7f0;
+        box-shadow: 0 8px 20px rgba(15, 23, 42, 0.09);
+        padding: 0.9rem;
+      }
+
+      .wf-toolbar-grid {
+        display: grid;
+        gap: 0.7rem;
+      }
+
+      .wf-toolbar input,
+      .wf-toolbar select {
+        width: 100%;
+        border-radius: 0.75rem;
+        border: 1px solid #cbd5e1;
+        padding: 0.72rem 0.85rem;
+        font-size: 0.9rem;
+        color: #0f172a;
+      }
+
+      .wf-toolbar input:focus,
+      .wf-toolbar select:focus {
+        outline: 2px solid #c7d2fe;
+        outline-offset: 1px;
+        border-color: #6366f1;
+      }
+
+      .wf-card {
+        position: relative;
+        transition: transform 150ms ease, box-shadow 150ms ease, border-color 150ms ease;
+        box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+      }
+
+      .wf-card:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 14px 28px rgba(15, 23, 42, 0.13);
+        border-color: #c7d2fe;
+      }
+
+      .wf-card-accent {
+        width: 46px;
+        height: 6px;
+        border-radius: 999px;
+        background: linear-gradient(90deg, #4f46e5 0%, #6366f1 100%);
+        margin-bottom: 0.75rem;
+      }
+
+      @media (min-width: 860px) {
+        .wf-toolbar-grid {
+          grid-template-columns: 1fr 220px;
+        }
+      }
+    </style>
+</head>
+<body class="text-gray-900 min-h-screen flex flex-col">
+    <div id="header-container"></div>
+    <main class="flex-grow">
+      <div class="wf-index-shell">
+        <section class="wf-index-hero">
+            <h1>ALL PLAYS Help Center</h1>
+            <p>Workflow-first guides built around real user outcomes. Find what you need, filter by role, and move from setup to game day faster.</p>
+        </section>
+
+        <section class="wf-toolbar">
+          <div class="wf-toolbar-grid">
+            <div>
+              <input id="help-search" type="search" placeholder="Search workflows, tasks, or keywords" />
+            </div>
+            <div>
+              <select id="help-role">
+                <option value="">All roles</option>
+                <option value="Parent">Parent</option>
+                <option value="Coach">Coach</option>
+                <option value="Admin">Admin</option>
+                <option value="Member">Member</option>
+              </select>
+            </div>
+          </div>
+          <p id="help-summary" class="mt-3 text-sm text-slate-600"></p>
+        </section>
+
+        <section id="help-empty" class="mt-6 hidden rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">No workflows matched your current filters.</section>
+        <section id="help-grid" class="mt-6 grid gap-4 md:grid-cols-2">${cards}</section>
+      </div>
+    </main>
+    <div id="footer-container"></div>
+
+    <script id="help-manifest" type="application/json">${JSON.stringify(manifest)}</script>
+    ${standardChromeScript()}
+    <script>
+        const manifest = JSON.parse(document.getElementById('help-manifest').textContent || '[]');
+        const searchInput = document.getElementById('help-search');
+        const roleSelect = document.getElementById('help-role');
+        const grid = document.getElementById('help-grid');
+        const empty = document.getElementById('help-empty');
+        const summary = document.getElementById('help-summary');
+
+        function escapeHtml(v){return String(v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/\"/g,'&quot;').replace(/'/g,'&#39;');}
+
+        function render() {
+            const q = (searchInput.value || '').toLowerCase().trim();
+            const role = roleSelect.value;
+            const filtered = manifest.filter((item) => {
+                const text = (item.title + ' ' + item.summary + ' ' + (item.searchText || '')).toLowerCase();
+                const roleOk = !role || (item.roles || []).includes(role) || (item.roles || []).includes('All');
+                return (!q || text.includes(q)) && roleOk;
+            }).sort((a,b)=>a.title.localeCompare(b.title));
+
+            grid.innerHTML = filtered.map((item) => {
+                const badges = (item.roles || ['All']).map((r) => '<span class="wf-role-chip">'+escapeHtml(r)+'</span>').join(' ');
+                return '<article class="wf-card rounded-2xl border border-slate-200 bg-white p-5">'
+                    + '<div class="wf-card-accent"></div>'
+                    + '<h2 class="text-xl font-extrabold tracking-tight text-slate-900">'+escapeHtml(item.title)+'</h2>'
+                    + '<p class="mt-2 text-sm text-slate-600 leading-6">'+escapeHtml(item.summary)+'</p>'
+                    + '<div class="mt-4 flex flex-wrap gap-2">'+badges+'</div>'
+                    + '<a class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 hover:text-primary-800" href="'+escapeHtml(item.file)+'">Open workflow <span aria-hidden="true">→</span></a>'
+                    + '</article>';
+            }).join('');
+
+            if (!filtered.length) {
+                empty.classList.remove('hidden');
+                grid.classList.add('hidden');
+            } else {
+                empty.classList.add('hidden');
+                grid.classList.remove('hidden');
+            }
+            summary.textContent = filtered.length + ' of ' + manifest.length + ' workflows';
+        }
+
+        searchInput.addEventListener('input', render);
+        roleSelect.addEventListener('change', render);
+        render();
+    </script>
+</body>
+</html>`;
+}
+
+function main() {
+    if (!fs.existsSync(WORKFLOW_MD_DIR)) {
+        console.error('workflow-docs directory not found. Run build-help-workflow-doc-loop first.');
+        process.exit(1);
+    }
+    const files = fs.readdirSync(WORKFLOW_MD_DIR).filter((f) => f.endsWith('.md')).sort();
+    const manifest = [];
+
+    files.forEach((file) => {
+        const md = fs.readFileSync(path.join(WORKFLOW_MD_DIR, file), 'utf8');
+        const id = file.replace(/\.md$/, '');
+        const title = extractTitle(md, id);
+        const bodyHtml = mdToHtml(md);
+        const roles = extractRoles(md);
+        const summary = summarize(md);
+        const readTimeMin = estimateReadTime(md);
+
+        const htmlFile = `workflow-${id}.html`;
+        fs.writeFileSync(path.join(ROOT, htmlFile), renderArticle({ title, roles, bodyHtml, summary, readTimeMin }));
+        manifest.push({ id, title, roles, file: htmlFile, summary, readTimeMin, searchText: md.slice(0, 2000) });
+        console.log(`wrote ${htmlFile}`);
+    });
+
+    fs.writeFileSync(MANIFEST, JSON.stringify(manifest, null, 2));
+    fs.writeFileSync(HELP_HTML, renderIndex(manifest));
+    console.log(`Updated help.html and ${MANIFEST}`);
+}
+
+main();

--- a/scripts/build-help-workflow-html-loop.sh
+++ b/scripts/build-help-workflow-html-loop.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "Rendering workflow help HTML from workflow-docs/"
+node "${ROOT}/scripts/build-help-workflow-html-loop.mjs"

--- a/tests/unit/help-center.test.js
+++ b/tests/unit/help-center.test.js
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { normalizeHelpRole, getHelpSectionsForRole, searchHelpSections } from '../../js/help-center.js';
+
+describe('help center role-aware content', () => {
+    it('normalizes unknown roles to member', () => {
+        expect(normalizeHelpRole('something-random')).toBe('member');
+    });
+
+    it('returns role-aware section metadata for parents', () => {
+        const sections = getHelpSectionsForRole('parent');
+        expect(sections.length).toBeGreaterThan(0);
+        expect(sections.some((section) => section.roles.includes('parent'))).toBe(true);
+    });
+
+    it('filters sections by search query across content text', () => {
+        const sections = getHelpSectionsForRole('coach');
+        const results = searchHelpSections(sections, 'permissions');
+        expect(results.length).toBeGreaterThan(0);
+    });
+});

--- a/tests/unit/help-center.test.js
+++ b/tests/unit/help-center.test.js
@@ -1,20 +1,64 @@
 import { describe, it, expect } from 'vitest';
-import { normalizeHelpRole, getHelpSectionsForRole, searchHelpSections } from '../../js/help-center.js';
+import {
+    normalizeHelpRole,
+    getHelpGuidesForRole,
+    searchHelpGuides,
+    getRequiredGuideIds,
+    getGuideById,
+    resolveGuideLinks,
+    getHelpCategoriesForRole
+} from '../../js/help-center.js';
 
-describe('help center role-aware content', () => {
-    it('normalizes unknown roles to member', () => {
+describe('help center deep workflow coverage', () => {
+    it('normalizes role aliases and defaults unknown to member', () => {
+        expect(normalizeHelpRole('admins')).toBe('administrator');
+        expect(normalizeHelpRole('coaches')).toBe('coach');
         expect(normalizeHelpRole('something-random')).toBe('member');
     });
 
-    it('returns role-aware section metadata for parents', () => {
-        const sections = getHelpSectionsForRole('parent');
-        expect(sections.length).toBeGreaterThan(0);
-        expect(sections.some((section) => section.roles.includes('parent'))).toBe(true);
+    it('contains all required workflow guides', () => {
+        const required = getRequiredGuideIds();
+        const allGuideIds = new Set(getHelpGuidesForRole('administrator').map((guide) => guide.id));
+        required.forEach((id) => {
+            expect(allGuideIds.has(id)).toBe(true);
+        });
     });
 
-    it('filters sections by search query across content text', () => {
-        const sections = getHelpSectionsForRole('coach');
-        const results = searchHelpSections(sections, 'permissions');
-        expect(results.length).toBeGreaterThan(0);
+    it('excludes coach-only setup guides from parent role results', () => {
+        const parentGuideIds = getHelpGuidesForRole('parent').map((guide) => guide.id);
+        expect(parentGuideIds.includes('create-team')).toBe(false);
+        expect(parentGuideIds.includes('manage-roster')).toBe(false);
+        expect(parentGuideIds.includes('team-chat-basics')).toBe(true);
+    });
+
+    it('searches across workflow steps and error text', () => {
+        const coachGuides = getHelpGuidesForRole('coach');
+        const byKeyword = searchHelpGuides(coachGuides, 'activation code');
+        expect(byKeyword.some((guide) => guide.id === 'sign-up-activation')).toBe(true);
+
+        const byErrorPhrase = searchHelpGuides(coachGuides, 'invalid credentials');
+        expect(byErrorPhrase.some((guide) => guide.id === 'login')).toBe(true);
+    });
+
+    it('supports category scoping and lookup by id', () => {
+        const coachGuides = getHelpGuidesForRole('coach');
+        const onlyPlanning = searchHelpGuides(coachGuides, '', 'planning');
+        expect(onlyPlanning.length).toBeGreaterThan(0);
+        expect(onlyPlanning.every((guide) => guide.category === 'planning')).toBe(true);
+
+        const trackGuide = getGuideById('coach', 'track-game');
+        expect(trackGuide?.title).toContain('Track a game');
+    });
+
+    it('resolves quick-link templates using context values', () => {
+        const rosterGuide = getGuideById('coach', 'manage-roster');
+        const links = resolveGuideLinks(rosterGuide, { teamId: 'TEAM 123', gameId: 'GAME/456' });
+        expect(links.some((link) => link.url.includes('teamId=TEAM%20123'))).toBe(true);
+    });
+
+    it('returns role-aware categories only for visible guides', () => {
+        const parentCategories = getHelpCategoriesForRole('parent').map((category) => category.id);
+        expect(parentCategories.includes('team-setup')).toBe(false);
+        expect(parentCategories.includes('watch-chat')).toBe(true);
     });
 });

--- a/tests/unit/help-navigation-wiring.test.js
+++ b/tests/unit/help-navigation-wiring.test.js
@@ -18,12 +18,12 @@ describe('help navigation wiring', () => {
         expect(bannerJs).toContain("label: 'Help'");
     });
 
-    it('renders deep help center layout controls', () => {
+    it('renders multi-page help portal links', () => {
         const helpHtml = readRepoFile('help.html');
-        expect(helpHtml).toContain('id="help-category"');
-        expect(helpHtml).toContain('id="top-task-links"');
-        expect(helpHtml).toContain('id="category-links"');
-        expect(helpHtml).toContain('Workflow Steps');
-        expect(helpHtml).toContain('Related Guides');
+        expect(helpHtml).toContain('href="help-account.html"');
+        expect(helpHtml).toContain('href="help-team-operations.html"');
+        expect(helpHtml).toContain('href="help-game-operations.html"');
+        expect(helpHtml).toContain('href="help-watch-chat.html"');
+        expect(helpHtml).toContain('href="help-page-reference.html"');
     });
 });

--- a/tests/unit/help-navigation-wiring.test.js
+++ b/tests/unit/help-navigation-wiring.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readRepoFile(relativePath) {
+    return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+describe('help navigation wiring', () => {
+    it('links footer help center to help page', () => {
+        const utilsJs = readRepoFile('js/utils.js');
+        expect(utilsJs).toContain('<li><a href="help.html" class="hover:text-white transition">Help Center</a></li>');
+    });
+
+    it('includes help destination in team navigation banner', () => {
+        const bannerJs = readRepoFile('js/team-admin-banner.js');
+        expect(bannerJs).toContain('help: `help.html?context=team&teamId=${teamId}`');
+        expect(bannerJs).toContain("label: 'Help'");
+    });
+});

--- a/tests/unit/help-navigation-wiring.test.js
+++ b/tests/unit/help-navigation-wiring.test.js
@@ -11,9 +11,19 @@ describe('help navigation wiring', () => {
         expect(utilsJs).toContain('<li><a href="help.html" class="hover:text-white transition">Help Center</a></li>');
     });
 
-    it('includes help destination in team navigation banner', () => {
+    it('includes help destination in team navigation banner with role context', () => {
         const bannerJs = readRepoFile('js/team-admin-banner.js');
         expect(bannerJs).toContain('help: `help.html?context=team&teamId=${teamId}`');
+        expect(bannerJs).toContain("const helpRole = isFullAccess ? 'coach' : 'parent';");
         expect(bannerJs).toContain("label: 'Help'");
+    });
+
+    it('renders deep help center layout controls', () => {
+        const helpHtml = readRepoFile('help.html');
+        expect(helpHtml).toContain('id="help-category"');
+        expect(helpHtml).toContain('id="top-task-links"');
+        expect(helpHtml).toContain('id="category-links"');
+        expect(helpHtml).toContain('Workflow Steps');
+        expect(helpHtml).toContain('Related Guides');
     });
 });

--- a/workflow-admin-ops.html
+++ b/workflow-admin-ops.html
@@ -1,0 +1,427 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Operate Platform Admin Controls - ALL PLAYS Help</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: {
+                50: '#eef2ff',
+                100: '#e0e7ff',
+                500: '#6366f1',
+                600: '#4f46e5',
+                700: '#4338ca',
+                800: '#3730a3',
+                900: '#312e81'
+              }
+            }
+          }
+        }
+      }
+    </script>
+    <style>
+      :root {
+        --wf-bg: #f8fafc;
+        --wf-panel: #ffffff;
+        --wf-text: #0f172a;
+        --wf-muted: #52606f;
+        --wf-accent: #4f46e5;
+        --wf-accent-soft: #e0e7ff;
+        --wf-border: #d9e2ec;
+      }
+
+      body {
+        background:
+          radial-gradient(circle at 85% 0%, rgba(99,102,241,0.14) 0%, rgba(248,250,252,0) 42%),
+          radial-gradient(circle at 8% 20%, rgba(67,56,202,0.10) 0%, rgba(248,250,252,0) 48%),
+          var(--wf-bg);
+        color: var(--wf-text);
+      }
+
+      .wf-shell {
+        width: min(1160px, 100%);
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+      }
+
+      .wf-back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.85rem;
+        font-weight: 700;
+        color: #4338ca;
+      }
+
+      .wf-hero {
+        margin-top: 0.75rem;
+        background: linear-gradient(140deg, #312e81 0%, #4338ca 46%, #4f46e5 100%);
+        border-radius: 1.1rem;
+        padding: 1.25rem 1.25rem 1.15rem;
+        color: #ecfeff;
+        box-shadow: 0 14px 36px rgba(15, 23, 42, 0.22);
+      }
+
+      .wf-kicker {
+        font-size: 0.73rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        opacity: 0.84;
+      }
+
+      .wf-title {
+        margin-top: 0.4rem;
+        font-size: clamp(1.75rem, 2.8vw, 2.35rem);
+        line-height: 1.15;
+        font-weight: 800;
+      }
+
+      .wf-summary {
+        margin-top: 0.75rem;
+        max-width: 60ch;
+        color: rgba(236, 254, 255, 0.95);
+        line-height: 1.58;
+      }
+
+      .wf-meta-row {
+        margin-top: 0.95rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+        align-items: center;
+      }
+
+      .wf-meta-pill {
+        display: inline-flex;
+        align-items: center;
+        font-size: 0.78rem;
+        font-weight: 700;
+        border-radius: 999px;
+        border: 1px solid rgba(236, 254, 255, 0.36);
+        background: rgba(236, 254, 255, 0.12);
+        color: #ecfeff;
+        padding: 0.24rem 0.62rem;
+      }
+
+      .wf-layout {
+        margin-top: 1rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .wf-panel {
+        background: var(--wf-panel);
+        border: 1px solid var(--wf-border);
+        border-radius: 1rem;
+        box-shadow: 0 7px 20px rgba(15, 23, 42, 0.08);
+      }
+
+      .wf-panel-section {
+        padding: 1rem;
+        border-bottom: 1px solid var(--wf-border);
+      }
+
+      .wf-panel-section:last-child {
+        border-bottom: 0;
+      }
+
+      .wf-panel-title {
+        font-size: 0.78rem;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #334155;
+        margin-bottom: 0.6rem;
+      }
+
+      .wf-role-chip {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        border: 1px solid #c7d2fe;
+        background: #eef2ff;
+        color: #3730a3;
+        padding: 0.22rem 0.66rem;
+        font-size: 0.74rem;
+        font-weight: 700;
+      }
+
+      .wf-roles {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+      }
+
+      .wf-toc {
+        display: grid;
+        gap: 0.33rem;
+      }
+
+      .wf-toc a {
+        display: block;
+        padding: 0.43rem 0.52rem;
+        border-radius: 0.55rem;
+        color: #334155;
+        font-size: 0.82rem;
+        line-height: 1.35;
+        transition: background 120ms ease, color 120ms ease;
+      }
+
+      .wf-toc a:hover {
+        background: #eef2ff;
+        color: #3730a3;
+      }
+
+      .wf-toc a.is-active {
+        background: #e0e7ff;
+        color: #312e81;
+        font-weight: 700;
+      }
+
+      .wf-content {
+        padding: 1.2rem 1.15rem;
+      }
+
+      .help-workflow-body {
+        display: grid;
+        gap: 0.45rem;
+      }
+
+      .help-workflow-body h2 {
+        font-size: 1.4rem;
+        font-weight: 800;
+        color: #1f2937;
+        margin-top: 1.25rem;
+        padding-top: 1.05rem;
+        border-top: 1px solid #dbe7f0;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body h2:first-of-type {
+        margin-top: 0.15rem;
+        padding-top: 0;
+        border-top: 0;
+      }
+
+      .help-workflow-body h3 {
+        font-size: 1.08rem;
+        font-weight: 700;
+        color: #1e293b;
+        margin-top: 0.88rem;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body p,
+      .help-workflow-body li {
+        color: var(--wf-muted);
+        line-height: 1.67;
+      }
+
+      .help-workflow-body ol,
+      .help-workflow-body ul {
+        margin-left: 1.2rem;
+      }
+
+      .help-workflow-body code {
+        background: #eef2ff;
+        color: #3730a3;
+        border: 1px solid #c7d2fe;
+        padding: 0.1rem 0.35rem;
+        border-radius: 0.3rem;
+        font-size: 0.86em;
+      }
+
+      .wf-mobile-toc {
+        margin-top: 0.95rem;
+      }
+
+      @media (min-width: 1024px) {
+        .wf-layout {
+          grid-template-columns: 270px minmax(0, 1fr);
+          align-items: start;
+        }
+
+        .wf-sidebar {
+          position: sticky;
+          top: 1rem;
+        }
+      }
+
+      @media (max-width: 1023px) {
+        .wf-sidebar .wf-panel-section:nth-child(1) {
+          display: none;
+        }
+      }
+    </style>
+</head>
+<body class="flex flex-col min-h-screen">
+    <div id="header-container"></div>
+    <main class="flex-grow">
+      <div class="wf-shell">
+        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <section class="wf-hero">
+          <p class="wf-kicker">Workflow Guide</p>
+          <h1 class="wf-title">Operate Platform Admin Controls</h1>
+          <p class="wf-summary">Use this workflow to run platform admin operations in ALL PLAYS. You will confirm admin access, review platform activity, update teams, manage admin invites, and verify user visibility.</p>
+          <div class="wf-meta-row">
+            <span class="wf-meta-pill">4 min read</span>
+            <span class="wf-meta-pill">Updated from live product pages</span>
+          </div>
+        </section>
+
+        <div class="wf-layout">
+          <aside class="wf-sidebar wf-panel">
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">On this page</h2>
+              <nav id="workflow-toc" class="wf-toc"></nav>
+            </section>
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">Who can use this</h2>
+              <div class="wf-roles"><span class="wf-role-chip">Admin</span></div>
+            </section>
+          </aside>
+
+          <article class="wf-panel wf-content">
+            <div id="workflow-mobile-toc" class="wf-mobile-toc"></div>
+            <div class="help-workflow-body"><h2 id="overview">Overview</h2>
+<p>Use this workflow to run platform admin operations in ALL PLAYS. You will confirm admin access, review platform activity, update teams, manage admin invites, and verify user visibility.</p>
+<p>Use it when you are starting an admin session, checking platform health, or handling team lifecycle updates.</p>
+<h2 id="in-this-article">In This Article</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Confirm admin entitlement before sensitive actions.</li>
+<li>Review teams, users, games, and recent activity in the admin dashboard.</li>
+<li>Find active and inactive teams.</li>
+<li>Update team settings and manage team admin invites.</li>
+<li>Deactivate teams when owner controls are available.</li>
+<li>Recover from common access, search, and save issues.</li>
+</ul>
+<h2 id="who-is-this-for">Who Is This For</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Platform admins who oversee teams, users, and platform activity.</li>
+<li>Team owners and full team admins handling team updates.</li>
+</ul>
+<h2 id="prerequisites">Prerequisites</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>You are signed in to ALL PLAYS.</li>
+<li>Your account has admin entitlement (<code>isAdmin</code> is <code>true</code>).</li>
+<li>You can open <code>check-admin-status.html</code> and <code>admin.html</code>.</li>
+<li>For team lifecycle work, you can open <code>edit-team.html</code> and <code>dashboard.html</code>.</li>
+</ul>
+<h2 id="choose-your-path">Choose Your Path</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><strong>Start of session or access issue:</strong> Open <code>check-admin-status.html</code> to confirm admin entitlement.</li>
+<li><strong>Platform health review:</strong> Open <code>admin.html</code> and use the <code>Dashboard</code> tab.</li>
+<li><strong>Team updates and cleanup:</strong> Open <code>admin.html</code> on <code>Teams</code>, then open the team in <code>edit-team.html</code>.</li>
+<li><strong>Team deactivation:</strong> Open <code>dashboard.html</code> with an owner account.</li>
+</ul>
+<h2 id="step-by-step-workflow">Step-by-Step Workflow</h2>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Confirm admin entitlement in <code>check-admin-status.html</code>. Continue only when you see <code>isAdmin field is TRUE</code>. If you see <code>Not logged in</code>, sign in and reload. If admin status is not true, stop and request admin enablement.</li>
+<li>Open <code>admin.html</code> and confirm your account is shown as the logged-in admin. Start on the <code>Dashboard</code> tab.</li>
+<li>Review platform activity cards for team count, user count, games, and 7-day activity. Review <code>Recent Teams</code> and <code>Recent Users</code>. Use <code>View All Teams</code> or <code>View All Users</code> when needed.</li>
+<li>Open the <code>Teams</code> tab. Use <code>Search teams...</code> to find the team. Enable <code>Show inactive</code> for cleanup or historical checks.</li>
+<li>Open the team in <code>edit-team.html</code>. Update team name, sport, ZIP, notification email, visibility, and links. Select <code>Save Team</code>. Use <code>Manage Roster</code> and <code>Manage Schedule</code> for follow-up tasks.</li>
+<li>In <code>edit-team.html</code>, select <code>+ Add Admin</code>. Enter the email and select <code>Send Invite</code>. If email delivery fails, copy and share the generated code or signup link.</li>
+<li>Deactivate teams from <code>dashboard.html</code> when needed. Select <code>Delete Team</code> on the team card and confirm. Verify the team is removed from your active list.</li>
+<li>Follow role limits during lifecycle actions. Owners can deactivate teams from <code>dashboard.html</code>. Full team admins who are not owners can edit team details but may not see owner lifecycle controls. Parent or view-only users can view content but cannot edit or deactivate.</li>
+<li>Return to <code>admin.html</code> and open the <code>Users</code> tab. Use <code>Search users...</code> to find the user. Confirm user details appear as expected after updates.</li>
+<li>Recheck each team and user record you changed. Confirm updates are visible before ending the session.</li>
+</ol>
+<h2 id="common-questions">Common Questions</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><strong>How do I know if I am an admin?</strong> Open <code>check-admin-status.html</code> and confirm <code>isAdmin</code> is true.</li>
+<li><strong>Where can I find inactive teams?</strong> In <code>admin.html</code>, open <code>Teams</code> and enable <code>Show inactive</code>.</li>
+<li><strong>Why can’t I deactivate a team?</strong> Team deactivation in <code>dashboard.html</code> is owner-controlled.</li>
+<li><strong>Can I invite a team admin while creating a team?</strong> Yes. Add admins in <code>edit-team.html</code>. Invites are finalized when the team is saved.</li>
+<li><strong>What if invite email fails?</strong> Share the invite code or signup link directly.</li>
+</ul>
+<h2 id="recovery-troubleshooting">Recovery &amp; Troubleshooting</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><strong>Admin page access fails:</strong> Run <code>check-admin-status.html</code> again, confirm login, then retry <code>admin.html</code>.</li>
+<li><strong>Admin status is not true:</strong> Pause admin actions and request entitlement updates from the platform owner.</li>
+<li><strong>Team not found:</strong> Clear search text, retry with a partial name, and enable <code>Show inactive</code>.</li>
+<li><strong>User not found:</strong> Retry with full or partial email in <code>Search users...</code>.</li>
+<li><strong>Save team fails:</strong> Retry after simplifying recent changes, such as removing a large image upload.</li>
+<li><strong>Team deactivation error:</strong> Retry from <code>dashboard.html</code> with an owner account and confirm the action prompt.</li>
+</ul>
+<h2 id="related-workflows">Related Workflows</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><code>getting-started.md</code></li>
+<li><code>team-setup.md</code></li>
+<li><code>schedule.md</code></li>
+</ul>
+<h2 id="need-more-help">Need More Help</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Record what you were doing, including page, team or user, and step number from this workflow.</li>
+<li>Capture the exact on-screen message.</li>
+<li>Share these details with your platform support contact or admin owner.</li>
+</ul></div>
+          </article>
+        </div>
+      </div>
+    </main>
+    <div id="footer-container"></div>
+    <script type="module">
+      import { checkAuth } from './js/auth.js?v=9';
+      import { renderHeader, renderFooter } from './js/utils.js?v=8';
+      renderHeader(document.getElementById('header-container'), null);
+      renderFooter(document.getElementById('footer-container'));
+      checkAuth((user) => {
+        renderHeader(document.getElementById('header-container'), user);
+      });
+    </script>
+    <script>
+      (function() {
+        const headings = Array.from(document.querySelectorAll('.help-workflow-body h2[id]'));
+        const toc = document.getElementById('workflow-toc');
+        const mobileToc = document.getElementById('workflow-mobile-toc');
+        if (!toc || !headings.length) return;
+
+        const links = headings.map((h) => {
+          const a = document.createElement('a');
+          a.href = '#' + h.id;
+          a.textContent = h.textContent || h.id;
+          toc.appendChild(a);
+          return a;
+        });
+
+        if (mobileToc && window.innerWidth < 1024) {
+          const wrapper = document.createElement('details');
+          wrapper.className = 'wf-panel-section wf-panel';
+          wrapper.style.marginBottom = '0.95rem';
+          wrapper.style.padding = '0.8rem 1rem';
+          const summary = document.createElement('summary');
+          summary.textContent = 'Jump to section';
+          summary.style.cursor = 'pointer';
+          summary.style.fontWeight = '700';
+          summary.style.color = '#0f172a';
+          const list = toc.cloneNode(true);
+          list.style.marginTop = '0.6rem';
+          wrapper.appendChild(summary);
+          wrapper.appendChild(list);
+          mobileToc.appendChild(wrapper);
+        }
+
+        const sectionById = new Map(headings.map((h) => [h.id, h]));
+        const setActive = () => {
+          let active = headings[0];
+          for (const h of headings) {
+            if (h.getBoundingClientRect().top <= 140) active = h;
+          }
+          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+        };
+
+        window.addEventListener('scroll', setActive, { passive: true });
+        setActive();
+      })();
+    </script>
+</body>
+</html>

--- a/workflow-choose-home-dashboard.html
+++ b/workflow-choose-home-dashboard.html
@@ -1,0 +1,448 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Use the Right Dashboard for Your Role - ALL PLAYS Help</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: {
+                50: '#eef2ff',
+                100: '#e0e7ff',
+                500: '#6366f1',
+                600: '#4f46e5',
+                700: '#4338ca',
+                800: '#3730a3',
+                900: '#312e81'
+              }
+            }
+          }
+        }
+      }
+    </script>
+    <style>
+      :root {
+        --wf-bg: #f8fafc;
+        --wf-panel: #ffffff;
+        --wf-text: #0f172a;
+        --wf-muted: #52606f;
+        --wf-accent: #4f46e5;
+        --wf-accent-soft: #e0e7ff;
+        --wf-border: #d9e2ec;
+      }
+
+      body {
+        background:
+          radial-gradient(circle at 85% 0%, rgba(99,102,241,0.14) 0%, rgba(248,250,252,0) 42%),
+          radial-gradient(circle at 8% 20%, rgba(67,56,202,0.10) 0%, rgba(248,250,252,0) 48%),
+          var(--wf-bg);
+        color: var(--wf-text);
+      }
+
+      .wf-shell {
+        width: min(1160px, 100%);
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+      }
+
+      .wf-back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.85rem;
+        font-weight: 700;
+        color: #4338ca;
+      }
+
+      .wf-hero {
+        margin-top: 0.75rem;
+        background: linear-gradient(140deg, #312e81 0%, #4338ca 46%, #4f46e5 100%);
+        border-radius: 1.1rem;
+        padding: 1.25rem 1.25rem 1.15rem;
+        color: #ecfeff;
+        box-shadow: 0 14px 36px rgba(15, 23, 42, 0.22);
+      }
+
+      .wf-kicker {
+        font-size: 0.73rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        opacity: 0.84;
+      }
+
+      .wf-title {
+        margin-top: 0.4rem;
+        font-size: clamp(1.75rem, 2.8vw, 2.35rem);
+        line-height: 1.15;
+        font-weight: 800;
+      }
+
+      .wf-summary {
+        margin-top: 0.75rem;
+        max-width: 60ch;
+        color: rgba(236, 254, 255, 0.95);
+        line-height: 1.58;
+      }
+
+      .wf-meta-row {
+        margin-top: 0.95rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+        align-items: center;
+      }
+
+      .wf-meta-pill {
+        display: inline-flex;
+        align-items: center;
+        font-size: 0.78rem;
+        font-weight: 700;
+        border-radius: 999px;
+        border: 1px solid rgba(236, 254, 255, 0.36);
+        background: rgba(236, 254, 255, 0.12);
+        color: #ecfeff;
+        padding: 0.24rem 0.62rem;
+      }
+
+      .wf-layout {
+        margin-top: 1rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .wf-panel {
+        background: var(--wf-panel);
+        border: 1px solid var(--wf-border);
+        border-radius: 1rem;
+        box-shadow: 0 7px 20px rgba(15, 23, 42, 0.08);
+      }
+
+      .wf-panel-section {
+        padding: 1rem;
+        border-bottom: 1px solid var(--wf-border);
+      }
+
+      .wf-panel-section:last-child {
+        border-bottom: 0;
+      }
+
+      .wf-panel-title {
+        font-size: 0.78rem;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #334155;
+        margin-bottom: 0.6rem;
+      }
+
+      .wf-role-chip {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        border: 1px solid #c7d2fe;
+        background: #eef2ff;
+        color: #3730a3;
+        padding: 0.22rem 0.66rem;
+        font-size: 0.74rem;
+        font-weight: 700;
+      }
+
+      .wf-roles {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+      }
+
+      .wf-toc {
+        display: grid;
+        gap: 0.33rem;
+      }
+
+      .wf-toc a {
+        display: block;
+        padding: 0.43rem 0.52rem;
+        border-radius: 0.55rem;
+        color: #334155;
+        font-size: 0.82rem;
+        line-height: 1.35;
+        transition: background 120ms ease, color 120ms ease;
+      }
+
+      .wf-toc a:hover {
+        background: #eef2ff;
+        color: #3730a3;
+      }
+
+      .wf-toc a.is-active {
+        background: #e0e7ff;
+        color: #312e81;
+        font-weight: 700;
+      }
+
+      .wf-content {
+        padding: 1.2rem 1.15rem;
+      }
+
+      .help-workflow-body {
+        display: grid;
+        gap: 0.45rem;
+      }
+
+      .help-workflow-body h2 {
+        font-size: 1.4rem;
+        font-weight: 800;
+        color: #1f2937;
+        margin-top: 1.25rem;
+        padding-top: 1.05rem;
+        border-top: 1px solid #dbe7f0;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body h2:first-of-type {
+        margin-top: 0.15rem;
+        padding-top: 0;
+        border-top: 0;
+      }
+
+      .help-workflow-body h3 {
+        font-size: 1.08rem;
+        font-weight: 700;
+        color: #1e293b;
+        margin-top: 0.88rem;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body p,
+      .help-workflow-body li {
+        color: var(--wf-muted);
+        line-height: 1.67;
+      }
+
+      .help-workflow-body ol,
+      .help-workflow-body ul {
+        margin-left: 1.2rem;
+      }
+
+      .help-workflow-body code {
+        background: #eef2ff;
+        color: #3730a3;
+        border: 1px solid #c7d2fe;
+        padding: 0.1rem 0.35rem;
+        border-radius: 0.3rem;
+        font-size: 0.86em;
+      }
+
+      .wf-mobile-toc {
+        margin-top: 0.95rem;
+      }
+
+      @media (min-width: 1024px) {
+        .wf-layout {
+          grid-template-columns: 270px minmax(0, 1fr);
+          align-items: start;
+        }
+
+        .wf-sidebar {
+          position: sticky;
+          top: 1rem;
+        }
+      }
+
+      @media (max-width: 1023px) {
+        .wf-sidebar .wf-panel-section:nth-child(1) {
+          display: none;
+        }
+      }
+    </style>
+</head>
+<body class="flex flex-col min-h-screen">
+    <div id="header-container"></div>
+    <main class="flex-grow">
+      <div class="wf-shell">
+        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <section class="wf-hero">
+          <p class="wf-kicker">Workflow Guide</p>
+          <h1 class="wf-title">Use the Right Dashboard for Your Role</h1>
+          <p class="wf-summary">Choose the dashboard that matches what you need to do right now.</p>
+          <div class="wf-meta-row">
+            <span class="wf-meta-pill">3 min read</span>
+            <span class="wf-meta-pill">Updated from live product pages</span>
+          </div>
+        </section>
+
+        <div class="wf-layout">
+          <aside class="wf-sidebar wf-panel">
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">On this page</h2>
+              <nav id="workflow-toc" class="wf-toc"></nav>
+            </section>
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">Who can use this</h2>
+              <div class="wf-roles"><span class="wf-role-chip">Parent</span> <span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span></div>
+            </section>
+          </aside>
+
+          <article class="wf-panel wf-content">
+            <div id="workflow-mobile-toc" class="wf-mobile-toc"></div>
+            <div class="help-workflow-body"><h2 id="overview">Overview</h2>
+<p>Choose the dashboard that matches what you need to do right now.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Use <strong>Parent Dashboard</strong> for family tasks.</li>
+<li>Use <strong>My Teams Dashboard</strong> for team operations.</li>
+<li>If you have more than one role, switch dashboards by task.</li>
+</ul>
+<h2 id="in-this-article">In This Article</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>How to choose the right dashboard quickly.</li>
+<li>What each dashboard is best for.</li>
+<li>What to do if teams, players, or actions are missing.</li>
+</ul>
+<h2 id="who-is-this-for">Who Is This For</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><strong>Parents</strong> managing linked players and family activity.</li>
+<li><strong>Coaches</strong> managing team operations.</li>
+<li><strong>Admins</strong> supporting or managing team operations.</li>
+</ul>
+<h2 id="prerequisites">Prerequisites</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>You are signed in to ALL PLAYS.</li>
+<li>Your account has the correct role and team/player links.</li>
+<li>You have at least one linked team or player.</li>
+</ul>
+<h2 id="choose-your-path">Choose Your Path</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Choose <strong>Parent Dashboard</strong> when you need family tools.</li>
+<li>Choose <strong>My Teams Dashboard</strong> when you need team management tools.</li>
+<li>Choose <strong>Calendar</strong> when you need one combined schedule view across accessible teams.</li>
+<li>If you are both parent and coach/admin, pick the dashboard based on the task, not the account.</li>
+</ul>
+<h2 id="step-by-step-workflow">Step-by-Step Workflow</h2>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Sign in to ALL PLAYS and confirm you are in the correct account.</li>
+<li>Pick your goal: family/player task means <strong>Parent Dashboard</strong>; team operations task means <strong>My Teams Dashboard</strong>.</li>
+<li>Open the dashboard that matches your goal.</li>
+<li>Start work from that page: on <strong>Parent Dashboard</strong> use <strong>My Players</strong>, <strong>My Teams</strong>, or <strong>Redeem Code</strong>; on <strong>My Teams Dashboard</strong> open a team card and use <strong>View</strong>, <strong>Chat</strong>, <strong>Edit</strong>, <strong>Roster</strong>, or <strong>Schedule</strong>.</li>
+<li>Open team details when you need to work in one specific team context.</li>
+<li>Open <strong>Calendar</strong> for cross-team planning, then filter by team, event type, and date range; export <code>.ics</code> when needed.</li>
+<li>Check your access level before edits; if actions are read-only, you likely have parent-level access for that team.</li>
+</ol>
+<h2 id="common-questions">Common Questions</h2>
+<p><strong>Which dashboard should I bookmark?</strong></p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Parents: <strong>Parent Dashboard</strong>.</li>
+<li>Coaches/Admins: <strong>My Teams Dashboard</strong>.</li>
+</ul>
+<p><strong>I have parent and coach/admin access. Which one is correct?</strong></p>
+<p>Both are correct. Use the dashboard that matches the task.</p>
+<p><strong>Can parents open team pages?</strong></p>
+<p>Yes. Parents can open team details, but team-management actions may be limited.</p>
+<p><strong>Where do I see events across teams?</strong></p>
+<p>Use <strong>Calendar</strong> for combined events and filters.</p>
+<h2 id="recovery-troubleshooting">Recovery &amp; Troubleshooting</h2>
+<p><strong>No players linked on Parent Dashboard</strong></p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Ask a coach for an invite code.</li>
+<li>Use <strong>Redeem Code</strong>.</li>
+<li>Refresh after successful redemption.</li>
+</ul>
+<p><strong>No teams on My Teams Dashboard</strong></p>
+<ul class="ml-6 list-disc space-y-1">
+<li>If you are a coach/admin, use <strong>Create New Team</strong>.</li>
+<li>If teams should already exist, verify you are signed in with the correct account.</li>
+</ul>
+<p><strong>Team is read-only</strong></p>
+<ul class="ml-6 list-disc space-y-1">
+<li>You likely have parent-linked access for that team.</li>
+<li>Ask a team owner/admin for coach or admin access if you need edit tools.</li>
+</ul>
+<p><strong>Calendar looks empty</strong></p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Adjust or clear filters for team, event type, and date range.</li>
+<li>Switch between Detailed, Compact, and Calendar views to confirm visibility.</li>
+</ul>
+<p><strong>RSVP actions are unavailable</strong></p>
+<p>Some calendar-only events must be tracked in the team schedule before availability controls appear.</p>
+<h2 id="related-workflows">Related Workflows</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><code>join-team</code></li>
+<li><code>team-setup</code></li>
+<li><code>schedule</code></li>
+<li><code>communication</code></li>
+</ul>
+<h2 id="need-more-help">Need More Help</h2>
+<p>If the dashboard you see does not match your expected role, contact support and include:</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Account email</li>
+<li>Role (Parent, Coach, Admin)</li>
+<li>Team name(s)</li>
+<li>The page you opened when the issue happened</li>
+<li>A screenshot showing which actions are visible and unavailable</li>
+</ul></div>
+          </article>
+        </div>
+      </div>
+    </main>
+    <div id="footer-container"></div>
+    <script type="module">
+      import { checkAuth } from './js/auth.js?v=9';
+      import { renderHeader, renderFooter } from './js/utils.js?v=8';
+      renderHeader(document.getElementById('header-container'), null);
+      renderFooter(document.getElementById('footer-container'));
+      checkAuth((user) => {
+        renderHeader(document.getElementById('header-container'), user);
+      });
+    </script>
+    <script>
+      (function() {
+        const headings = Array.from(document.querySelectorAll('.help-workflow-body h2[id]'));
+        const toc = document.getElementById('workflow-toc');
+        const mobileToc = document.getElementById('workflow-mobile-toc');
+        if (!toc || !headings.length) return;
+
+        const links = headings.map((h) => {
+          const a = document.createElement('a');
+          a.href = '#' + h.id;
+          a.textContent = h.textContent || h.id;
+          toc.appendChild(a);
+          return a;
+        });
+
+        if (mobileToc && window.innerWidth < 1024) {
+          const wrapper = document.createElement('details');
+          wrapper.className = 'wf-panel-section wf-panel';
+          wrapper.style.marginBottom = '0.95rem';
+          wrapper.style.padding = '0.8rem 1rem';
+          const summary = document.createElement('summary');
+          summary.textContent = 'Jump to section';
+          summary.style.cursor = 'pointer';
+          summary.style.fontWeight = '700';
+          summary.style.color = '#0f172a';
+          const list = toc.cloneNode(true);
+          list.style.marginTop = '0.6rem';
+          wrapper.appendChild(summary);
+          wrapper.appendChild(list);
+          mobileToc.appendChild(wrapper);
+        }
+
+        const sectionById = new Map(headings.map((h) => [h.id, h]));
+        const setActive = () => {
+          let active = headings[0];
+          for (const h of headings) {
+            if (h.getBoundingClientRect().top <= 140) active = h;
+          }
+          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+        };
+
+        window.addEventListener('scroll', setActive, { passive: true });
+        setActive();
+      })();
+    </script>
+</body>
+</html>

--- a/workflow-communication.html
+++ b/workflow-communication.html
@@ -1,0 +1,447 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Coordinate Team Messages and Availability - ALL PLAYS Help</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: {
+                50: '#eef2ff',
+                100: '#e0e7ff',
+                500: '#6366f1',
+                600: '#4f46e5',
+                700: '#4338ca',
+                800: '#3730a3',
+                900: '#312e81'
+              }
+            }
+          }
+        }
+      }
+    </script>
+    <style>
+      :root {
+        --wf-bg: #f8fafc;
+        --wf-panel: #ffffff;
+        --wf-text: #0f172a;
+        --wf-muted: #52606f;
+        --wf-accent: #4f46e5;
+        --wf-accent-soft: #e0e7ff;
+        --wf-border: #d9e2ec;
+      }
+
+      body {
+        background:
+          radial-gradient(circle at 85% 0%, rgba(99,102,241,0.14) 0%, rgba(248,250,252,0) 42%),
+          radial-gradient(circle at 8% 20%, rgba(67,56,202,0.10) 0%, rgba(248,250,252,0) 48%),
+          var(--wf-bg);
+        color: var(--wf-text);
+      }
+
+      .wf-shell {
+        width: min(1160px, 100%);
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+      }
+
+      .wf-back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.85rem;
+        font-weight: 700;
+        color: #4338ca;
+      }
+
+      .wf-hero {
+        margin-top: 0.75rem;
+        background: linear-gradient(140deg, #312e81 0%, #4338ca 46%, #4f46e5 100%);
+        border-radius: 1.1rem;
+        padding: 1.25rem 1.25rem 1.15rem;
+        color: #ecfeff;
+        box-shadow: 0 14px 36px rgba(15, 23, 42, 0.22);
+      }
+
+      .wf-kicker {
+        font-size: 0.73rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        opacity: 0.84;
+      }
+
+      .wf-title {
+        margin-top: 0.4rem;
+        font-size: clamp(1.75rem, 2.8vw, 2.35rem);
+        line-height: 1.15;
+        font-weight: 800;
+      }
+
+      .wf-summary {
+        margin-top: 0.75rem;
+        max-width: 60ch;
+        color: rgba(236, 254, 255, 0.95);
+        line-height: 1.58;
+      }
+
+      .wf-meta-row {
+        margin-top: 0.95rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+        align-items: center;
+      }
+
+      .wf-meta-pill {
+        display: inline-flex;
+        align-items: center;
+        font-size: 0.78rem;
+        font-weight: 700;
+        border-radius: 999px;
+        border: 1px solid rgba(236, 254, 255, 0.36);
+        background: rgba(236, 254, 255, 0.12);
+        color: #ecfeff;
+        padding: 0.24rem 0.62rem;
+      }
+
+      .wf-layout {
+        margin-top: 1rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .wf-panel {
+        background: var(--wf-panel);
+        border: 1px solid var(--wf-border);
+        border-radius: 1rem;
+        box-shadow: 0 7px 20px rgba(15, 23, 42, 0.08);
+      }
+
+      .wf-panel-section {
+        padding: 1rem;
+        border-bottom: 1px solid var(--wf-border);
+      }
+
+      .wf-panel-section:last-child {
+        border-bottom: 0;
+      }
+
+      .wf-panel-title {
+        font-size: 0.78rem;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #334155;
+        margin-bottom: 0.6rem;
+      }
+
+      .wf-role-chip {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        border: 1px solid #c7d2fe;
+        background: #eef2ff;
+        color: #3730a3;
+        padding: 0.22rem 0.66rem;
+        font-size: 0.74rem;
+        font-weight: 700;
+      }
+
+      .wf-roles {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+      }
+
+      .wf-toc {
+        display: grid;
+        gap: 0.33rem;
+      }
+
+      .wf-toc a {
+        display: block;
+        padding: 0.43rem 0.52rem;
+        border-radius: 0.55rem;
+        color: #334155;
+        font-size: 0.82rem;
+        line-height: 1.35;
+        transition: background 120ms ease, color 120ms ease;
+      }
+
+      .wf-toc a:hover {
+        background: #eef2ff;
+        color: #3730a3;
+      }
+
+      .wf-toc a.is-active {
+        background: #e0e7ff;
+        color: #312e81;
+        font-weight: 700;
+      }
+
+      .wf-content {
+        padding: 1.2rem 1.15rem;
+      }
+
+      .help-workflow-body {
+        display: grid;
+        gap: 0.45rem;
+      }
+
+      .help-workflow-body h2 {
+        font-size: 1.4rem;
+        font-weight: 800;
+        color: #1f2937;
+        margin-top: 1.25rem;
+        padding-top: 1.05rem;
+        border-top: 1px solid #dbe7f0;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body h2:first-of-type {
+        margin-top: 0.15rem;
+        padding-top: 0;
+        border-top: 0;
+      }
+
+      .help-workflow-body h3 {
+        font-size: 1.08rem;
+        font-weight: 700;
+        color: #1e293b;
+        margin-top: 0.88rem;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body p,
+      .help-workflow-body li {
+        color: var(--wf-muted);
+        line-height: 1.67;
+      }
+
+      .help-workflow-body ol,
+      .help-workflow-body ul {
+        margin-left: 1.2rem;
+      }
+
+      .help-workflow-body code {
+        background: #eef2ff;
+        color: #3730a3;
+        border: 1px solid #c7d2fe;
+        padding: 0.1rem 0.35rem;
+        border-radius: 0.3rem;
+        font-size: 0.86em;
+      }
+
+      .wf-mobile-toc {
+        margin-top: 0.95rem;
+      }
+
+      @media (min-width: 1024px) {
+        .wf-layout {
+          grid-template-columns: 270px minmax(0, 1fr);
+          align-items: start;
+        }
+
+        .wf-sidebar {
+          position: sticky;
+          top: 1rem;
+        }
+      }
+
+      @media (max-width: 1023px) {
+        .wf-sidebar .wf-panel-section:nth-child(1) {
+          display: none;
+        }
+      }
+    </style>
+</head>
+<body class="flex flex-col min-h-screen">
+    <div id="header-container"></div>
+    <main class="flex-grow">
+      <div class="wf-shell">
+        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <section class="wf-hero">
+          <p class="wf-kicker">Workflow Guide</p>
+          <h1 class="wf-title">Coordinate Team Messages and Availability</h1>
+          <p class="wf-summary">Use this workflow to keep families, coaches, and admins aligned before, during, and after events.</p>
+          <div class="wf-meta-row">
+            <span class="wf-meta-pill">3 min read</span>
+            <span class="wf-meta-pill">Updated from live product pages</span>
+          </div>
+        </section>
+
+        <div class="wf-layout">
+          <aside class="wf-sidebar wf-panel">
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">On this page</h2>
+              <nav id="workflow-toc" class="wf-toc"></nav>
+            </section>
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">Who can use this</h2>
+              <div class="wf-roles"><span class="wf-role-chip">Parent</span> <span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span></div>
+            </section>
+          </aside>
+
+          <article class="wf-panel wf-content">
+            <div id="workflow-mobile-toc" class="wf-mobile-toc"></div>
+            <div class="help-workflow-body"><h2 id="overview">Overview</h2>
+<p>Use this workflow to keep families, coaches, and admins aligned before, during, and after events.</p>
+<p>Start by choosing the path that matches your goal: team chat, RSVP, rideshare, or live-game chat.</p>
+<h2 id="in-this-article">In This Article</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Pick the right path for messaging, availability, or rideshare.</li>
+<li>Send clear team updates and ask <code>@ALL PLAYS</code> questions.</li>
+<li>Set event status as <code>Going</code>, <code>Maybe</code>, or <code>Can&#39;t Go</code>.</li>
+<li>Offer rides, request spots, and manage request decisions.</li>
+<li>Recover quickly from common send, access, and RSVP issues.</li>
+</ul>
+<h2 id="who-is-this-for">Who Is This For</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Parent: Share updates, set availability, and coordinate rides.</li>
+<li>Coach: Post reminders, keep chat focused, and moderate chat.</li>
+<li>Admin: Support communication standards and moderate chat.</li>
+</ul>
+<h2 id="prerequisites">Prerequisites</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>You are signed in.</li>
+<li>You have access to at least one team.</li>
+<li>You opened a team context from your dashboard, team view, calendar, or live game page.</li>
+<li>For RSVP buttons, the event is already tracked in the team schedule.</li>
+</ul>
+<h2 id="choose-your-path">Choose Your Path</h2>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Send a team update or reminder now: use team chat.</li>
+<li>Submit event availability: use the schedule list or calendar event view.</li>
+<li>Coordinate transportation: use event rideshare.</li>
+<li>Communicate during a game: use live-game chat when enabled.</li>
+</ol>
+<h2 id="step-by-step-workflow">Step-by-Step Workflow</h2>
+<h3 id="path-a-team-messages-and-moderation">Path A: Team Messages and Moderation</h3>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Open team chat from your current team context.</li>
+<li>Write one clear update per message.</li>
+<li>Optional: add voice input or attach one image (up to 5 MB).</li>
+<li>To ask the assistant, include <code>@ALL PLAYS</code> and your question in the same message.</li>
+<li>Select <strong>Send</strong>.</li>
+<li>Confirm the message appears in the thread.</li>
+<li>Add reactions for quick acknowledgment.</li>
+<li>Edit or delete your own message if plans change.</li>
+<li>If you are a Coach or Admin, remove off-topic or inappropriate messages from others when needed.</li>
+<li>For live-game chat, post short updates. If chat is locked, retry at game time.</li>
+</ol>
+<h3 id="path-b-rsvp-availability">Path B: RSVP Availability</h3>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Open the event from schedule list, calendar, or day detail.</li>
+<li>Confirm team and player context.</li>
+<li>Select <strong>Going</strong>, <strong>Maybe</strong>, or <strong>Can&#39;t Go</strong>.</li>
+<li>Confirm the selected state stays active.</li>
+<li>Verify the availability summary updates.</li>
+</ol>
+<h3 id="path-c-family-logistics-rideshare">Path C: Family Logistics (Rideshare)</h3>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Open the event rideshare section.</li>
+<li>To drive, select <strong>Offer Ride</strong>.</li>
+<li>Set seats and direction, add an optional note, then save.</li>
+<li>To request a seat, choose the child and select <strong>Request Spot</strong>.</li>
+<li>Cancel your request if plans change.</li>
+<li>If you own the offer, use <strong>Confirm</strong>, <strong>Waitlist</strong>, or <strong>Decline</strong> for each request.</li>
+<li>Close or reopen your offer as needed.</li>
+</ol>
+<h2 id="common-questions">Common Questions</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Where should I post updates? Use team chat for general updates and live-game chat for real-time game communication.</li>
+<li>Why are RSVP buttons missing? Availability controls appear after the event is tracked in the team schedule.</li>
+<li>Who can moderate chat? Everyone can manage their own messages. Coaches and admins can also remove messages from others.</li>
+<li>How do I ask the assistant a question? Type <code>@ALL PLAYS</code> and your question in one message.</li>
+</ul>
+<h2 id="recovery-troubleshooting">Recovery &amp; Troubleshooting</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Message failed to send: Check your connection, resend, and keep the message short.</li>
+<li>Image upload failed: Retry with a valid image at or below 5 MB.</li>
+<li>No response from <code>@ALL PLAYS</code>: Resend with a clear question after the mention.</li>
+<li>Live-game chat is locked: Wait until game time, then post again.</li>
+<li>RSVP did not save: Reopen the event, reselect your response, and confirm the button stays active.</li>
+<li>Team chat access error: Return to team context and reopen chat from that team.</li>
+</ul>
+<h2 id="related-workflows">Related Workflows</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><code>choose-home-dashboard</code></li>
+<li><code>schedule</code></li>
+<li><code>game-day</code></li>
+<li><code>postgame</code></li>
+<li><code>join-team</code></li>
+</ul>
+<h2 id="need-more-help">Need More Help</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Ask your coach or admin to verify team access and event assignment.</li>
+<li>When reporting an issue, include team name, event date, and the action that failed.</li>
+<li>Include a screenshot to help support reproduce the issue.</li>
+</ul></div>
+          </article>
+        </div>
+      </div>
+    </main>
+    <div id="footer-container"></div>
+    <script type="module">
+      import { checkAuth } from './js/auth.js?v=9';
+      import { renderHeader, renderFooter } from './js/utils.js?v=8';
+      renderHeader(document.getElementById('header-container'), null);
+      renderFooter(document.getElementById('footer-container'));
+      checkAuth((user) => {
+        renderHeader(document.getElementById('header-container'), user);
+      });
+    </script>
+    <script>
+      (function() {
+        const headings = Array.from(document.querySelectorAll('.help-workflow-body h2[id]'));
+        const toc = document.getElementById('workflow-toc');
+        const mobileToc = document.getElementById('workflow-mobile-toc');
+        if (!toc || !headings.length) return;
+
+        const links = headings.map((h) => {
+          const a = document.createElement('a');
+          a.href = '#' + h.id;
+          a.textContent = h.textContent || h.id;
+          toc.appendChild(a);
+          return a;
+        });
+
+        if (mobileToc && window.innerWidth < 1024) {
+          const wrapper = document.createElement('details');
+          wrapper.className = 'wf-panel-section wf-panel';
+          wrapper.style.marginBottom = '0.95rem';
+          wrapper.style.padding = '0.8rem 1rem';
+          const summary = document.createElement('summary');
+          summary.textContent = 'Jump to section';
+          summary.style.cursor = 'pointer';
+          summary.style.fontWeight = '700';
+          summary.style.color = '#0f172a';
+          const list = toc.cloneNode(true);
+          list.style.marginTop = '0.6rem';
+          wrapper.appendChild(summary);
+          wrapper.appendChild(list);
+          mobileToc.appendChild(wrapper);
+        }
+
+        const sectionById = new Map(headings.map((h) => [h.id, h]));
+        const setActive = () => {
+          let active = headings[0];
+          for (const h of headings) {
+            if (h.getBoundingClientRect().top <= 140) active = h;
+          }
+          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+        };
+
+        window.addEventListener('scroll', setActive, { passive: true });
+        setActive();
+      })();
+    </script>
+</body>
+</html>

--- a/workflow-game-day.html
+++ b/workflow-game-day.html
@@ -1,0 +1,464 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Run Pre-Game Through Wrap-Up Command - ALL PLAYS Help</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: {
+                50: '#eef2ff',
+                100: '#e0e7ff',
+                500: '#6366f1',
+                600: '#4f46e5',
+                700: '#4338ca',
+                800: '#3730a3',
+                900: '#312e81'
+              }
+            }
+          }
+        }
+      }
+    </script>
+    <style>
+      :root {
+        --wf-bg: #f8fafc;
+        --wf-panel: #ffffff;
+        --wf-text: #0f172a;
+        --wf-muted: #52606f;
+        --wf-accent: #4f46e5;
+        --wf-accent-soft: #e0e7ff;
+        --wf-border: #d9e2ec;
+      }
+
+      body {
+        background:
+          radial-gradient(circle at 85% 0%, rgba(99,102,241,0.14) 0%, rgba(248,250,252,0) 42%),
+          radial-gradient(circle at 8% 20%, rgba(67,56,202,0.10) 0%, rgba(248,250,252,0) 48%),
+          var(--wf-bg);
+        color: var(--wf-text);
+      }
+
+      .wf-shell {
+        width: min(1160px, 100%);
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+      }
+
+      .wf-back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.85rem;
+        font-weight: 700;
+        color: #4338ca;
+      }
+
+      .wf-hero {
+        margin-top: 0.75rem;
+        background: linear-gradient(140deg, #312e81 0%, #4338ca 46%, #4f46e5 100%);
+        border-radius: 1.1rem;
+        padding: 1.25rem 1.25rem 1.15rem;
+        color: #ecfeff;
+        box-shadow: 0 14px 36px rgba(15, 23, 42, 0.22);
+      }
+
+      .wf-kicker {
+        font-size: 0.73rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        opacity: 0.84;
+      }
+
+      .wf-title {
+        margin-top: 0.4rem;
+        font-size: clamp(1.75rem, 2.8vw, 2.35rem);
+        line-height: 1.15;
+        font-weight: 800;
+      }
+
+      .wf-summary {
+        margin-top: 0.75rem;
+        max-width: 60ch;
+        color: rgba(236, 254, 255, 0.95);
+        line-height: 1.58;
+      }
+
+      .wf-meta-row {
+        margin-top: 0.95rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+        align-items: center;
+      }
+
+      .wf-meta-pill {
+        display: inline-flex;
+        align-items: center;
+        font-size: 0.78rem;
+        font-weight: 700;
+        border-radius: 999px;
+        border: 1px solid rgba(236, 254, 255, 0.36);
+        background: rgba(236, 254, 255, 0.12);
+        color: #ecfeff;
+        padding: 0.24rem 0.62rem;
+      }
+
+      .wf-layout {
+        margin-top: 1rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .wf-panel {
+        background: var(--wf-panel);
+        border: 1px solid var(--wf-border);
+        border-radius: 1rem;
+        box-shadow: 0 7px 20px rgba(15, 23, 42, 0.08);
+      }
+
+      .wf-panel-section {
+        padding: 1rem;
+        border-bottom: 1px solid var(--wf-border);
+      }
+
+      .wf-panel-section:last-child {
+        border-bottom: 0;
+      }
+
+      .wf-panel-title {
+        font-size: 0.78rem;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #334155;
+        margin-bottom: 0.6rem;
+      }
+
+      .wf-role-chip {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        border: 1px solid #c7d2fe;
+        background: #eef2ff;
+        color: #3730a3;
+        padding: 0.22rem 0.66rem;
+        font-size: 0.74rem;
+        font-weight: 700;
+      }
+
+      .wf-roles {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+      }
+
+      .wf-toc {
+        display: grid;
+        gap: 0.33rem;
+      }
+
+      .wf-toc a {
+        display: block;
+        padding: 0.43rem 0.52rem;
+        border-radius: 0.55rem;
+        color: #334155;
+        font-size: 0.82rem;
+        line-height: 1.35;
+        transition: background 120ms ease, color 120ms ease;
+      }
+
+      .wf-toc a:hover {
+        background: #eef2ff;
+        color: #3730a3;
+      }
+
+      .wf-toc a.is-active {
+        background: #e0e7ff;
+        color: #312e81;
+        font-weight: 700;
+      }
+
+      .wf-content {
+        padding: 1.2rem 1.15rem;
+      }
+
+      .help-workflow-body {
+        display: grid;
+        gap: 0.45rem;
+      }
+
+      .help-workflow-body h2 {
+        font-size: 1.4rem;
+        font-weight: 800;
+        color: #1f2937;
+        margin-top: 1.25rem;
+        padding-top: 1.05rem;
+        border-top: 1px solid #dbe7f0;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body h2:first-of-type {
+        margin-top: 0.15rem;
+        padding-top: 0;
+        border-top: 0;
+      }
+
+      .help-workflow-body h3 {
+        font-size: 1.08rem;
+        font-weight: 700;
+        color: #1e293b;
+        margin-top: 0.88rem;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body p,
+      .help-workflow-body li {
+        color: var(--wf-muted);
+        line-height: 1.67;
+      }
+
+      .help-workflow-body ol,
+      .help-workflow-body ul {
+        margin-left: 1.2rem;
+      }
+
+      .help-workflow-body code {
+        background: #eef2ff;
+        color: #3730a3;
+        border: 1px solid #c7d2fe;
+        padding: 0.1rem 0.35rem;
+        border-radius: 0.3rem;
+        font-size: 0.86em;
+      }
+
+      .wf-mobile-toc {
+        margin-top: 0.95rem;
+      }
+
+      @media (min-width: 1024px) {
+        .wf-layout {
+          grid-template-columns: 270px minmax(0, 1fr);
+          align-items: start;
+        }
+
+        .wf-sidebar {
+          position: sticky;
+          top: 1rem;
+        }
+      }
+
+      @media (max-width: 1023px) {
+        .wf-sidebar .wf-panel-section:nth-child(1) {
+          display: none;
+        }
+      }
+    </style>
+</head>
+<body class="flex flex-col min-h-screen">
+    <div id="header-container"></div>
+    <main class="flex-grow">
+      <div class="wf-shell">
+        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <section class="wf-hero">
+          <p class="wf-kicker">Workflow Guide</p>
+          <h1 class="wf-title">Run Pre-Game Through Wrap-Up Command</h1>
+          <p class="wf-summary">Use Game Day Command Center for one continuous game-day flow.</p>
+          <div class="wf-meta-row">
+            <span class="wf-meta-pill">5 min read</span>
+            <span class="wf-meta-pill">Updated from live product pages</span>
+          </div>
+        </section>
+
+        <div class="wf-layout">
+          <aside class="wf-sidebar wf-panel">
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">On this page</h2>
+              <nav id="workflow-toc" class="wf-toc"></nav>
+            </section>
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">Who can use this</h2>
+              <div class="wf-roles"><span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span></div>
+            </section>
+          </aside>
+
+          <article class="wf-panel wf-content">
+            <div id="workflow-mobile-toc" class="wf-mobile-toc"></div>
+            <div class="help-workflow-body"><h2 id="overview">Overview</h2>
+<p>Use Game Day Command Center for one continuous game-day flow.</p>
+<p>Confirm game details, lock availability and lineup, manage live decisions, then close with notes and summary. This keeps in-game decisions fast and post-game follow-through clean.</p>
+<h2 id="in-this-article">In This Article</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Choose the right starting path for your game-day situation.</li>
+<li>Run pre-game checks and save lineup.</li>
+<li>Manage live substitutions, logs, score, and stats.</li>
+<li>Complete wrap-up and hand off to reporting and practice planning.</li>
+<li>Recover from common game-day issues.</li>
+</ul>
+<h2 id="who-is-this-for">Who Is This For</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Coach: Owns lineup, substitutions, live coaching log, and wrap-up decisions.</li>
+<li>Admin: Owns schedule accuracy, availability support, and final data quality.</li>
+<li>Coach + Admin: Split work so one person coaches while the other updates score and logs.</li>
+</ul>
+<h2 id="prerequisites">Prerequisites</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>A scheduled game exists with valid <code>teamId</code> and <code>gameId</code>.</li>
+<li>You have full team access (coach/admin-level controls).</li>
+<li>Open from <code>edit-schedule.html</code> using <strong>Command Center</strong>, or use <code>game-day.html?teamId=...&amp;gameId=...</code>.</li>
+<li>The roster is loaded so availability and lineup can be set.</li>
+</ul>
+<h2 id="choose-your-path">Choose Your Path</h2>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Start from schedule and run the full flow.</li>
+</ol>
+<p>Go to <code>edit-schedule.html</code>, find the game, and select <strong>Command Center</strong>.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Fix setup first, then run Command Center.</li>
+</ol>
+<p>In <code>edit-schedule.html</code>, select <strong>Edit</strong> and correct date, opponent, location, home/away, or kit. Then return and open <strong>Command Center</strong>.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Check quick context before kickoff.</li>
+</ol>
+<p>Open <code>team.html</code>, review <strong>Upcoming Games</strong> or <strong>Recent Results</strong>, then launch <strong>Command Center</strong> from <code>edit-schedule.html</code>.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Plan the next practice from game outcomes.</li>
+</ol>
+<p>In the Game Day pre-game rail, use <strong>Plan →</strong> from prior focus items, or finish wrap-up analysis first. Continue in <code>drills.html</code>.</p>
+<h2 id="step-by-step-workflow">Step-by-Step Workflow</h2>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Open the correct game.</li>
+</ol>
+<p>In <code>edit-schedule.html</code>, filter to upcoming games and select <strong>Command Center</strong>. Confirm opponent and date before changes.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Validate pre-game details.</li>
+</ol>
+<p>In <strong>Pre-Game</strong>, verify opponent, date/time, location, home/away, and kit badges. If needed, select <strong>Edit game details →</strong>, save fixes, and return.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Finalize availability and pre-game notes.</li>
+</ol>
+<p>In the RSVP panel, set each player to <strong>Going</strong>, <strong>Maybe</strong>, or <strong>Out</strong>. Add scouting notes. Use <strong>AI Coach Focus</strong> if you want a quick directive.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Build and save lineup.</li>
+</ol>
+<p>Select a formation. Place players on the lineup canvas, or use <strong>Balance</strong> or <strong>AI Optimize</strong>. Select <strong>Save Lineup</strong> before kickoff.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Switch to live operations.</li>
+</ol>
+<p>Move to <strong>Game Day</strong> mode when play starts. Select the active period (for example, <code>H1</code> or <code>H2</code>). Use <strong>Coach</strong> view for subs and notes, and <strong>Stats</strong> view for stat taps.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Run live controls.</li>
+</ol>
+<p>For substitutions, select <strong>OUT</strong> and <strong>IN</strong>, then select <strong>Apply Sub</strong>. Log events with <strong>Timeout</strong>, <strong>Formation Change</strong>, <strong>Injury</strong>, or free-text <strong>Log</strong>. Update score and select <strong>Save Score</strong> after key changes.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Keep live stats accurate.</li>
+</ol>
+<p>In <strong>Stats</strong> view, tap player stat buttons as events happen. If the last stat is wrong, use <strong>Undo Last</strong> right away.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Complete wrap-up.</li>
+</ol>
+<p>Open <strong>Wrap-Up</strong>. Confirm final score and add post-game notes. Run <strong>Analyze Game → Generate Practice Feed</strong>. Run <strong>Generate Game Summary</strong>.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Close and hand off.</li>
+</ol>
+<p>Select <strong>Done — See Match Report →</strong> to mark the game complete. Continue report sharing and replay from <code>team.html</code>, and practice planning in <code>drills.html</code>.</p>
+<h2 id="common-questions">Common Questions</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><strong>Do I have to include <code>gameId</code> in the URL?</strong> Recommended: yes. If it is missing, Game Day auto-selects a game in this order: live first, then nearest upcoming, then most recent.</li>
+<li><strong>Can Admin and Coach both use Command Center controls?</strong> Yes. Both need full team access. Without full access, users are redirected out of Game Day controls.</li>
+<li><strong>Can I change player availability inside Game Day?</strong> Yes. In <strong>Pre-Game</strong>, use the RSVP panel and set players to Going/Maybe/Out.</li>
+<li><strong>Do lineup and score changes auto-save?</strong> No. Use <strong>Save Lineup</strong> for lineup changes and <strong>Save Score</strong> for score changes.</li>
+<li><strong>Where does the summary go?</strong> <strong>Generate Game Summary</strong> saves to the game record and appears in the match report.</li>
+</ul>
+<h2 id="recovery-troubleshooting">Recovery &amp; Troubleshooting</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><strong>Missing <code>teamId</code> or bad URL:</strong> Reopen from <code>edit-schedule.html</code> using <strong>Command Center</strong> so IDs pass correctly.</li>
+<li><strong>&quot;No games found&quot;:</strong> Add or uncancel a game in <code>edit-schedule.html</code>, then reopen Command Center.</li>
+<li><strong>Access denied or redirected to team page:</strong> Ask a team admin to grant full coach/admin access.</li>
+<li><strong>No players shown on field in Game Day:</strong> Return to <strong>Pre-Game</strong>, select a formation, assign players, and select <strong>Save Lineup</strong>.</li>
+<li><strong>Substitution will not apply:</strong> Make sure both OUT and IN players are selected, then apply again.</li>
+<li><strong>Score changed on screen but not in report:</strong> Re-enter the score and select <strong>Save Score</strong> before wrap-up completion.</li>
+<li><strong>AI actions fail in chat or wrap-up:</strong> Continue manually. Save notes, confirm final score, and finish the game. Re-run analysis later.</li>
+<li><strong>Wrap-up closed by mistake:</strong> Switch back to <strong>Wrap-Up</strong> mode from the top mode switcher.</li>
+</ul>
+<h2 id="related-workflows">Related Workflows</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><code>schedule</code>: Build or update games in <code>edit-schedule.html</code>.</li>
+<li><code>track-game</code>: Use tracker pages when you need stat-tracking flows outside Command Center.</li>
+<li><code>postgame</code>: Complete final report and replay review after game completion.</li>
+<li><code>communication</code>: Share live links, report links, and team updates.</li>
+</ul>
+<h2 id="need-more-help">Need More Help</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Start from <code>edit-schedule.html</code> and reopen the game through <strong>Command Center</strong> to reset context.</li>
+<li>If the issue continues, capture team name, opponent, date, URL, and the exact step that failed.</li>
+<li>Share those details with your team admin so access or schedule data can be corrected quickly.</li>
+</ul></div>
+          </article>
+        </div>
+      </div>
+    </main>
+    <div id="footer-container"></div>
+    <script type="module">
+      import { checkAuth } from './js/auth.js?v=9';
+      import { renderHeader, renderFooter } from './js/utils.js?v=8';
+      renderHeader(document.getElementById('header-container'), null);
+      renderFooter(document.getElementById('footer-container'));
+      checkAuth((user) => {
+        renderHeader(document.getElementById('header-container'), user);
+      });
+    </script>
+    <script>
+      (function() {
+        const headings = Array.from(document.querySelectorAll('.help-workflow-body h2[id]'));
+        const toc = document.getElementById('workflow-toc');
+        const mobileToc = document.getElementById('workflow-mobile-toc');
+        if (!toc || !headings.length) return;
+
+        const links = headings.map((h) => {
+          const a = document.createElement('a');
+          a.href = '#' + h.id;
+          a.textContent = h.textContent || h.id;
+          toc.appendChild(a);
+          return a;
+        });
+
+        if (mobileToc && window.innerWidth < 1024) {
+          const wrapper = document.createElement('details');
+          wrapper.className = 'wf-panel-section wf-panel';
+          wrapper.style.marginBottom = '0.95rem';
+          wrapper.style.padding = '0.8rem 1rem';
+          const summary = document.createElement('summary');
+          summary.textContent = 'Jump to section';
+          summary.style.cursor = 'pointer';
+          summary.style.fontWeight = '700';
+          summary.style.color = '#0f172a';
+          const list = toc.cloneNode(true);
+          list.style.marginTop = '0.6rem';
+          wrapper.appendChild(summary);
+          wrapper.appendChild(list);
+          mobileToc.appendChild(wrapper);
+        }
+
+        const sectionById = new Map(headings.map((h) => [h.id, h]));
+        const setActive = () => {
+          let active = headings[0];
+          for (const h of headings) {
+            if (h.getBoundingClientRect().top <= 140) active = h;
+          }
+          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+        };
+
+        window.addEventListener('scroll', setActive, { passive: true });
+        setActive();
+      })();
+    </script>
+</body>
+</html>

--- a/workflow-getting-started.html
+++ b/workflow-getting-started.html
@@ -1,0 +1,488 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Create or Access Your Account - ALL PLAYS Help</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: {
+                50: '#eef2ff',
+                100: '#e0e7ff',
+                500: '#6366f1',
+                600: '#4f46e5',
+                700: '#4338ca',
+                800: '#3730a3',
+                900: '#312e81'
+              }
+            }
+          }
+        }
+      }
+    </script>
+    <style>
+      :root {
+        --wf-bg: #f8fafc;
+        --wf-panel: #ffffff;
+        --wf-text: #0f172a;
+        --wf-muted: #52606f;
+        --wf-accent: #4f46e5;
+        --wf-accent-soft: #e0e7ff;
+        --wf-border: #d9e2ec;
+      }
+
+      body {
+        background:
+          radial-gradient(circle at 85% 0%, rgba(99,102,241,0.14) 0%, rgba(248,250,252,0) 42%),
+          radial-gradient(circle at 8% 20%, rgba(67,56,202,0.10) 0%, rgba(248,250,252,0) 48%),
+          var(--wf-bg);
+        color: var(--wf-text);
+      }
+
+      .wf-shell {
+        width: min(1160px, 100%);
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+      }
+
+      .wf-back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.85rem;
+        font-weight: 700;
+        color: #4338ca;
+      }
+
+      .wf-hero {
+        margin-top: 0.75rem;
+        background: linear-gradient(140deg, #312e81 0%, #4338ca 46%, #4f46e5 100%);
+        border-radius: 1.1rem;
+        padding: 1.25rem 1.25rem 1.15rem;
+        color: #ecfeff;
+        box-shadow: 0 14px 36px rgba(15, 23, 42, 0.22);
+      }
+
+      .wf-kicker {
+        font-size: 0.73rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        opacity: 0.84;
+      }
+
+      .wf-title {
+        margin-top: 0.4rem;
+        font-size: clamp(1.75rem, 2.8vw, 2.35rem);
+        line-height: 1.15;
+        font-weight: 800;
+      }
+
+      .wf-summary {
+        margin-top: 0.75rem;
+        max-width: 60ch;
+        color: rgba(236, 254, 255, 0.95);
+        line-height: 1.58;
+      }
+
+      .wf-meta-row {
+        margin-top: 0.95rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+        align-items: center;
+      }
+
+      .wf-meta-pill {
+        display: inline-flex;
+        align-items: center;
+        font-size: 0.78rem;
+        font-weight: 700;
+        border-radius: 999px;
+        border: 1px solid rgba(236, 254, 255, 0.36);
+        background: rgba(236, 254, 255, 0.12);
+        color: #ecfeff;
+        padding: 0.24rem 0.62rem;
+      }
+
+      .wf-layout {
+        margin-top: 1rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .wf-panel {
+        background: var(--wf-panel);
+        border: 1px solid var(--wf-border);
+        border-radius: 1rem;
+        box-shadow: 0 7px 20px rgba(15, 23, 42, 0.08);
+      }
+
+      .wf-panel-section {
+        padding: 1rem;
+        border-bottom: 1px solid var(--wf-border);
+      }
+
+      .wf-panel-section:last-child {
+        border-bottom: 0;
+      }
+
+      .wf-panel-title {
+        font-size: 0.78rem;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #334155;
+        margin-bottom: 0.6rem;
+      }
+
+      .wf-role-chip {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        border: 1px solid #c7d2fe;
+        background: #eef2ff;
+        color: #3730a3;
+        padding: 0.22rem 0.66rem;
+        font-size: 0.74rem;
+        font-weight: 700;
+      }
+
+      .wf-roles {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+      }
+
+      .wf-toc {
+        display: grid;
+        gap: 0.33rem;
+      }
+
+      .wf-toc a {
+        display: block;
+        padding: 0.43rem 0.52rem;
+        border-radius: 0.55rem;
+        color: #334155;
+        font-size: 0.82rem;
+        line-height: 1.35;
+        transition: background 120ms ease, color 120ms ease;
+      }
+
+      .wf-toc a:hover {
+        background: #eef2ff;
+        color: #3730a3;
+      }
+
+      .wf-toc a.is-active {
+        background: #e0e7ff;
+        color: #312e81;
+        font-weight: 700;
+      }
+
+      .wf-content {
+        padding: 1.2rem 1.15rem;
+      }
+
+      .help-workflow-body {
+        display: grid;
+        gap: 0.45rem;
+      }
+
+      .help-workflow-body h2 {
+        font-size: 1.4rem;
+        font-weight: 800;
+        color: #1f2937;
+        margin-top: 1.25rem;
+        padding-top: 1.05rem;
+        border-top: 1px solid #dbe7f0;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body h2:first-of-type {
+        margin-top: 0.15rem;
+        padding-top: 0;
+        border-top: 0;
+      }
+
+      .help-workflow-body h3 {
+        font-size: 1.08rem;
+        font-weight: 700;
+        color: #1e293b;
+        margin-top: 0.88rem;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body p,
+      .help-workflow-body li {
+        color: var(--wf-muted);
+        line-height: 1.67;
+      }
+
+      .help-workflow-body ol,
+      .help-workflow-body ul {
+        margin-left: 1.2rem;
+      }
+
+      .help-workflow-body code {
+        background: #eef2ff;
+        color: #3730a3;
+        border: 1px solid #c7d2fe;
+        padding: 0.1rem 0.35rem;
+        border-radius: 0.3rem;
+        font-size: 0.86em;
+      }
+
+      .wf-mobile-toc {
+        margin-top: 0.95rem;
+      }
+
+      @media (min-width: 1024px) {
+        .wf-layout {
+          grid-template-columns: 270px minmax(0, 1fr);
+          align-items: start;
+        }
+
+        .wf-sidebar {
+          position: sticky;
+          top: 1rem;
+        }
+      }
+
+      @media (max-width: 1023px) {
+        .wf-sidebar .wf-panel-section:nth-child(1) {
+          display: none;
+        }
+      }
+    </style>
+</head>
+<body class="flex flex-col min-h-screen">
+    <div id="header-container"></div>
+    <main class="flex-grow">
+      <div class="wf-shell">
+        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <section class="wf-hero">
+          <p class="wf-kicker">Workflow Guide</p>
+          <h1 class="wf-title">Create or Access Your Account</h1>
+          <p class="wf-summary">Use this workflow to get into ALL PLAYS fast.</p>
+          <div class="wf-meta-row">
+            <span class="wf-meta-pill">4 min read</span>
+            <span class="wf-meta-pill">Updated from live product pages</span>
+          </div>
+        </section>
+
+        <div class="wf-layout">
+          <aside class="wf-sidebar wf-panel">
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">On this page</h2>
+              <nav id="workflow-toc" class="wf-toc"></nav>
+            </section>
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">Who can use this</h2>
+              <div class="wf-roles"><span class="wf-role-chip">Parent</span> <span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span> <span class="wf-role-chip">Member</span></div>
+            </section>
+          </aside>
+
+          <article class="wf-panel wf-content">
+            <div id="workflow-mobile-toc" class="wf-mobile-toc"></div>
+            <div class="help-workflow-body"><h2 id="overview">Overview</h2>
+<p>Use this workflow to get into ALL PLAYS fast.</p>
+<p>Choose the path that matches your situation: new account, sign-in, password reset, or email verification.</p>
+<h2 id="in-this-article">In This Article</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Choose the right account access path.</li>
+<li>Create a new account with an activation code.</li>
+<li>Sign in with email/password or Google.</li>
+<li>Verify your email now or later.</li>
+<li>Reset your password.</li>
+<li>Resolve common login and verification issues.</li>
+</ul>
+<h2 id="who-is-this-for">Who Is This For</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Parent: Create an account from a code, or sign in to continue team access.</li>
+<li>Coach: Create or sign in, then verify email and keep access active.</li>
+<li>Admin: Create or sign in, then continue invite-based onboarding when needed.</li>
+<li>Member: Create or sign in with an activation code and confirm access.</li>
+</ul>
+<h2 id="prerequisites">Prerequisites</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>You can access your email inbox now.</li>
+<li>You have a stable internet connection and supported browser.</li>
+<li>For first-time signup, you have an 8-character activation code.</li>
+<li>If you prefer Google sign-in, you have a Google account.</li>
+</ul>
+<h2 id="choose-your-path">Choose Your Path</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Path A: I am new and have an activation code.</li>
+<li>Path B: I already have an account.</li>
+<li>Path C: I forgot my password.</li>
+<li>Path D: I need to verify my email or resend verification.</li>
+<li>Path E: I signed in with an email link and want to set a password.</li>
+</ul>
+<h2 id="step-by-step-workflow">Step-by-Step Workflow</h2>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Open <code>index.html</code> and select <strong>Get Started Now</strong>, or go to <code>login.html</code>.</li>
+<li>Follow the path that matches your situation.</li>
+</ol>
+<h3 id="path-a-create-a-new-account">Path A: Create a new account</h3>
+<ol class="ml-6 list-decimal space-y-1">
+<li>On <code>login.html</code>, select <strong>Sign Up</strong>.</li>
+<li>Enter your email, password, and confirm password.</li>
+<li>Enter your 8-character activation code.</li>
+<li>Select <strong>Create Account</strong>.</li>
+<li>Optional: Select <strong>Continue with Google</strong> in Sign Up mode. You still need an activation code.</li>
+<li>After signup, go to <code>verify-pending.html</code>.</li>
+<li>Open your verification email and select the link.</li>
+<li>If needed, select <strong>Resend Verification Email</strong>.</li>
+</ol>
+<h3 id="path-b-sign-in-to-an-existing-account">Path B: Sign in to an existing account</h3>
+<ol class="ml-6 list-decimal space-y-1">
+<li>On <code>login.html</code>, stay in <strong>Login</strong> mode.</li>
+<li>Sign in with <strong>Sign In</strong> (email/password) or <strong>Continue with Google</strong>.</li>
+<li>If you are a Parent or Admin on an invite link, continue invite acceptance.</li>
+<li>If you are a Coach, Admin, or Member with normal sign-in, continue to your dashboard.</li>
+<li>If sign-in fails, go to Path C.</li>
+</ol>
+<h3 id="path-c-reset-a-forgotten-password">Path C: Reset a forgotten password</h3>
+<ol class="ml-6 list-decimal space-y-1">
+<li>On <code>login.html</code>, enter your account email.</li>
+<li>Select <strong>Forgot Password?</strong>.</li>
+<li>Open the reset email and select the link.</li>
+<li>On <code>reset-password.html</code>, enter and confirm a new password (minimum 6 characters).</li>
+<li>Return to <code>login.html</code> and sign in with the new password.</li>
+</ol>
+<h3 id="path-d-verify-email-or-resend-verification">Path D: Verify email or resend verification</h3>
+<ol class="ml-6 list-decimal space-y-1">
+<li>On <code>verify-pending.html</code>, select <strong>Resend Verification Email</strong> if needed.</li>
+<li>You can select <strong>Continue to Dashboard</strong> while verification is pending.</li>
+<li>If already signed in, open <code>profile.html</code>.</li>
+<li>If you see <strong>Email not verified</strong>, select <strong>Resend Email</strong>.</li>
+<li>Complete verification from your inbox.</li>
+</ol>
+<h3 id="path-e-set-a-password-after-email-link-sign-in">Path E: Set a password after email-link sign-in</h3>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Open <code>profile.html</code>.</li>
+<li>If <strong>Set a Password</strong> appears, enter and confirm a password (6+ characters).</li>
+<li>Select <strong>Set Password</strong>.</li>
+<li>Use that password for future logins on <code>login.html</code>.</li>
+</ol>
+<h2 id="common-questions">Common Questions</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Do I need an activation code for my first account?</li>
+</ul>
+<p>Yes. New account creation requires an 8-character activation code.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Can I sign up with Google instead of a password?</li>
+</ul>
+<p>Yes. In Sign Up mode, a valid activation code is still required.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Do I have to verify my email before using the app?</li>
+</ul>
+<p>No. You can continue to dashboard and verify later from <code>profile.html</code>.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Why is <strong>Forgot Password?</strong> not working?</li>
+</ul>
+<p>Enter your email first, then select <strong>Forgot Password?</strong>.</p>
+<h2 id="recovery-troubleshooting">Recovery &amp; Troubleshooting</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>No verification or reset email arrived:</li>
+</ul>
+<p>Check spam/junk, confirm your email address, then resend from <code>verify-pending.html</code> or <code>profile.html</code>.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Invalid or expired verification/reset link:</li>
+</ul>
+<p>Start again from <code>login.html</code> and use the newest email.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Password reset fails:</li>
+</ul>
+<p>Make sure both fields match and the password is at least 6 characters.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Too many resend attempts:</li>
+</ul>
+<p>Wait a few minutes, then try again.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Google sign-in is blocked:</li>
+</ul>
+<p>Allow pop-ups or redirects in your browser, then retry. If needed, use email/password.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>No activation code available:</li>
+</ul>
+<p>Ask your coach or admin for a new code or signup link.</p>
+<h2 id="related-workflows">Related Workflows</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><code>join-team</code>: Accept an invite and connect your account to the correct team.</li>
+<li><code>choose-home-dashboard</code>: Confirm the best home dashboard after first login.</li>
+</ul>
+<h2 id="need-more-help">Need More Help</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Ask your coach or admin to confirm your assigned email and activation code.</li>
+<li>When reporting an issue, include the page and exact error message.</li>
+<li>If access is still blocked, sign out, return to <code>login.html</code>, and retry the matching path.</li>
+</ul></div>
+          </article>
+        </div>
+      </div>
+    </main>
+    <div id="footer-container"></div>
+    <script type="module">
+      import { checkAuth } from './js/auth.js?v=9';
+      import { renderHeader, renderFooter } from './js/utils.js?v=8';
+      renderHeader(document.getElementById('header-container'), null);
+      renderFooter(document.getElementById('footer-container'));
+      checkAuth((user) => {
+        renderHeader(document.getElementById('header-container'), user);
+      });
+    </script>
+    <script>
+      (function() {
+        const headings = Array.from(document.querySelectorAll('.help-workflow-body h2[id]'));
+        const toc = document.getElementById('workflow-toc');
+        const mobileToc = document.getElementById('workflow-mobile-toc');
+        if (!toc || !headings.length) return;
+
+        const links = headings.map((h) => {
+          const a = document.createElement('a');
+          a.href = '#' + h.id;
+          a.textContent = h.textContent || h.id;
+          toc.appendChild(a);
+          return a;
+        });
+
+        if (mobileToc && window.innerWidth < 1024) {
+          const wrapper = document.createElement('details');
+          wrapper.className = 'wf-panel-section wf-panel';
+          wrapper.style.marginBottom = '0.95rem';
+          wrapper.style.padding = '0.8rem 1rem';
+          const summary = document.createElement('summary');
+          summary.textContent = 'Jump to section';
+          summary.style.cursor = 'pointer';
+          summary.style.fontWeight = '700';
+          summary.style.color = '#0f172a';
+          const list = toc.cloneNode(true);
+          list.style.marginTop = '0.6rem';
+          wrapper.appendChild(summary);
+          wrapper.appendChild(list);
+          mobileToc.appendChild(wrapper);
+        }
+
+        const sectionById = new Map(headings.map((h) => [h.id, h]));
+        const setActive = () => {
+          let active = headings[0];
+          for (const h of headings) {
+            if (h.getBoundingClientRect().top <= 140) active = h;
+          }
+          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+        };
+
+        window.addEventListener('scroll', setActive, { passive: true });
+        setActive();
+      })();
+    </script>
+</body>
+</html>

--- a/workflow-join-team.html
+++ b/workflow-join-team.html
@@ -1,0 +1,479 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Join a Team from an Invite - ALL PLAYS Help</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: {
+                50: '#eef2ff',
+                100: '#e0e7ff',
+                500: '#6366f1',
+                600: '#4f46e5',
+                700: '#4338ca',
+                800: '#3730a3',
+                900: '#312e81'
+              }
+            }
+          }
+        }
+      }
+    </script>
+    <style>
+      :root {
+        --wf-bg: #f8fafc;
+        --wf-panel: #ffffff;
+        --wf-text: #0f172a;
+        --wf-muted: #52606f;
+        --wf-accent: #4f46e5;
+        --wf-accent-soft: #e0e7ff;
+        --wf-border: #d9e2ec;
+      }
+
+      body {
+        background:
+          radial-gradient(circle at 85% 0%, rgba(99,102,241,0.14) 0%, rgba(248,250,252,0) 42%),
+          radial-gradient(circle at 8% 20%, rgba(67,56,202,0.10) 0%, rgba(248,250,252,0) 48%),
+          var(--wf-bg);
+        color: var(--wf-text);
+      }
+
+      .wf-shell {
+        width: min(1160px, 100%);
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+      }
+
+      .wf-back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.85rem;
+        font-weight: 700;
+        color: #4338ca;
+      }
+
+      .wf-hero {
+        margin-top: 0.75rem;
+        background: linear-gradient(140deg, #312e81 0%, #4338ca 46%, #4f46e5 100%);
+        border-radius: 1.1rem;
+        padding: 1.25rem 1.25rem 1.15rem;
+        color: #ecfeff;
+        box-shadow: 0 14px 36px rgba(15, 23, 42, 0.22);
+      }
+
+      .wf-kicker {
+        font-size: 0.73rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        opacity: 0.84;
+      }
+
+      .wf-title {
+        margin-top: 0.4rem;
+        font-size: clamp(1.75rem, 2.8vw, 2.35rem);
+        line-height: 1.15;
+        font-weight: 800;
+      }
+
+      .wf-summary {
+        margin-top: 0.75rem;
+        max-width: 60ch;
+        color: rgba(236, 254, 255, 0.95);
+        line-height: 1.58;
+      }
+
+      .wf-meta-row {
+        margin-top: 0.95rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+        align-items: center;
+      }
+
+      .wf-meta-pill {
+        display: inline-flex;
+        align-items: center;
+        font-size: 0.78rem;
+        font-weight: 700;
+        border-radius: 999px;
+        border: 1px solid rgba(236, 254, 255, 0.36);
+        background: rgba(236, 254, 255, 0.12);
+        color: #ecfeff;
+        padding: 0.24rem 0.62rem;
+      }
+
+      .wf-layout {
+        margin-top: 1rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .wf-panel {
+        background: var(--wf-panel);
+        border: 1px solid var(--wf-border);
+        border-radius: 1rem;
+        box-shadow: 0 7px 20px rgba(15, 23, 42, 0.08);
+      }
+
+      .wf-panel-section {
+        padding: 1rem;
+        border-bottom: 1px solid var(--wf-border);
+      }
+
+      .wf-panel-section:last-child {
+        border-bottom: 0;
+      }
+
+      .wf-panel-title {
+        font-size: 0.78rem;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #334155;
+        margin-bottom: 0.6rem;
+      }
+
+      .wf-role-chip {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        border: 1px solid #c7d2fe;
+        background: #eef2ff;
+        color: #3730a3;
+        padding: 0.22rem 0.66rem;
+        font-size: 0.74rem;
+        font-weight: 700;
+      }
+
+      .wf-roles {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+      }
+
+      .wf-toc {
+        display: grid;
+        gap: 0.33rem;
+      }
+
+      .wf-toc a {
+        display: block;
+        padding: 0.43rem 0.52rem;
+        border-radius: 0.55rem;
+        color: #334155;
+        font-size: 0.82rem;
+        line-height: 1.35;
+        transition: background 120ms ease, color 120ms ease;
+      }
+
+      .wf-toc a:hover {
+        background: #eef2ff;
+        color: #3730a3;
+      }
+
+      .wf-toc a.is-active {
+        background: #e0e7ff;
+        color: #312e81;
+        font-weight: 700;
+      }
+
+      .wf-content {
+        padding: 1.2rem 1.15rem;
+      }
+
+      .help-workflow-body {
+        display: grid;
+        gap: 0.45rem;
+      }
+
+      .help-workflow-body h2 {
+        font-size: 1.4rem;
+        font-weight: 800;
+        color: #1f2937;
+        margin-top: 1.25rem;
+        padding-top: 1.05rem;
+        border-top: 1px solid #dbe7f0;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body h2:first-of-type {
+        margin-top: 0.15rem;
+        padding-top: 0;
+        border-top: 0;
+      }
+
+      .help-workflow-body h3 {
+        font-size: 1.08rem;
+        font-weight: 700;
+        color: #1e293b;
+        margin-top: 0.88rem;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body p,
+      .help-workflow-body li {
+        color: var(--wf-muted);
+        line-height: 1.67;
+      }
+
+      .help-workflow-body ol,
+      .help-workflow-body ul {
+        margin-left: 1.2rem;
+      }
+
+      .help-workflow-body code {
+        background: #eef2ff;
+        color: #3730a3;
+        border: 1px solid #c7d2fe;
+        padding: 0.1rem 0.35rem;
+        border-radius: 0.3rem;
+        font-size: 0.86em;
+      }
+
+      .wf-mobile-toc {
+        margin-top: 0.95rem;
+      }
+
+      @media (min-width: 1024px) {
+        .wf-layout {
+          grid-template-columns: 270px minmax(0, 1fr);
+          align-items: start;
+        }
+
+        .wf-sidebar {
+          position: sticky;
+          top: 1rem;
+        }
+      }
+
+      @media (max-width: 1023px) {
+        .wf-sidebar .wf-panel-section:nth-child(1) {
+          display: none;
+        }
+      }
+    </style>
+</head>
+<body class="flex flex-col min-h-screen">
+    <div id="header-container"></div>
+    <main class="flex-grow">
+      <div class="wf-shell">
+        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <section class="wf-hero">
+          <p class="wf-kicker">Workflow Guide</p>
+          <h1 class="wf-title">Join a Team from an Invite</h1>
+          <p class="wf-summary">Use this workflow to join a team with an invite link or an 8-character invite code.</p>
+          <div class="wf-meta-row">
+            <span class="wf-meta-pill">3 min read</span>
+            <span class="wf-meta-pill">Updated from live product pages</span>
+          </div>
+        </section>
+
+        <div class="wf-layout">
+          <aside class="wf-sidebar wf-panel">
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">On this page</h2>
+              <nav id="workflow-toc" class="wf-toc"></nav>
+            </section>
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">Who can use this</h2>
+              <div class="wf-roles"><span class="wf-role-chip">Parent</span> <span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span></div>
+            </section>
+          </aside>
+
+          <article class="wf-panel wf-content">
+            <div id="workflow-mobile-toc" class="wf-mobile-toc"></div>
+            <div class="help-workflow-body"><h2 id="overview">Overview</h2>
+<p>Use this workflow to join a team with an invite link or an 8-character invite code.</p>
+<p>You will redeem the invite, then confirm you landed in the correct dashboard for your role.</p>
+<h2 id="in-this-article">In This Article</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Choose the right invite path.</li>
+<li>Join with a link or manual code.</li>
+<li>Complete sign-in or account creation.</li>
+<li>Confirm your dashboard and team access.</li>
+<li>Fix common invite and sign-in issues.</li>
+</ul>
+<h2 id="who-is-this-for">Who Is This For</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Parent users joining a child’s team.</li>
+<li>Coach users joining team staff access.</li>
+<li>Admin users joining admin/team access.</li>
+</ul>
+<h2 id="prerequisites">Prerequisites</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>You have a valid invite link or 8-character invite code.</li>
+<li>You are ready to sign in or create an account.</li>
+<li>You can use the same email address that received the invite.</li>
+<li>You can stay in the invite flow until you see success.</li>
+</ul>
+<h2 id="choose-your-path">Choose Your Path</h2>
+<ol class="ml-6 list-decimal space-y-1">
+<li>I have an invite link and I am already signed in.</li>
+</ol>
+<p>Open the link and continue through invite confirmation.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>I have an invite link and I am not signed in.</li>
+</ol>
+<p>Open the link, then sign in or create an account when prompted.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>I only have an 8-character code.</li>
+</ol>
+<p>Open invite acceptance, choose manual code entry, then enter the code.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>I am a parent adding another player after I already joined.</li>
+</ol>
+<p>Use <code>Redeem Code</code> in Parent Dashboard with the new code.</p>
+<h2 id="step-by-step-workflow">Step-by-Step Workflow</h2>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Open your invite link.</li>
+</ol>
+<p>If the page shows <code>Processing Invite...</code>, wait for it to finish.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Confirm your email if prompted.</li>
+</ol>
+<p>If you opened the link on another device, enter the invited email and select <code>Continue</code>.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Enter your invite code if needed.</li>
+</ol>
+<p>If manual entry appears, type the 8-character code and select <code>Join Team</code>.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Sign in or create your account.</li>
+</ol>
+<p>Existing account: sign in with email/password or Google.</p>
+<p>New account: select <code>Sign Up</code>, complete the form, and provide the activation code if asked.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Complete invite redemption.</li>
+</ol>
+<p>Return to the invite flow if prompted. Wait for <code>You’re In!</code> and the automatic redirect.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Verify your role-based destination.</li>
+</ol>
+<p>Parent: confirm <code>Parent Dashboard</code> shows the player/team.</p>
+<p>Coach/Admin: confirm <code>My Teams</code> shows the new team card.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Open the team once.</li>
+</ol>
+<p>Select <code>View</code> (and optionally <code>Chat</code>) to confirm access is active.</p>
+<h2 id="common-questions">Common Questions</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Do I need to use the same email as the invite?</li>
+</ul>
+<p>Yes. Use the invited email when asked to confirm your email.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Can I join with only a code?</li>
+</ul>
+<p>Yes. Use manual code entry, then complete sign-in.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>I created an account but I am not on a team yet. What should I do?</li>
+</ul>
+<p>Reopen the invite link (or re-enter the code) and complete invite redemption.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Where should I land after joining?</li>
+</ul>
+<p>Parent users should land in <code>Parent Dashboard</code>. Coach/Admin users should land in <code>My Teams</code>.</p>
+<h2 id="recovery-troubleshooting">Recovery &amp; Troubleshooting</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><code>Invalid or expired code</code></li>
+</ul>
+<p>Re-enter the code exactly (8 characters). If it still fails, ask for a fresh invite.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li><code>Invalid email or expired link</code></li>
+</ul>
+<p>Use the invited email address and reopen the latest invite link.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li><code>Sent back to Login repeatedly</code></li>
+</ul>
+<p>Finish sign-in first, then reopen the invite link or retry manual code entry.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li><code>Joined, but no team appears</code></li>
+</ul>
+<p>Refresh the dashboard, then sign out and sign back in once.</p>
+<p>Parent users: check <code>Parent Dashboard</code>.</p>
+<p>Coach/Admin users: check <code>My Teams</code>.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li><code>Parent cannot see newly added player</code></li>
+</ul>
+<p>Use <code>Redeem Code</code> in Parent Dashboard for that player’s code.</p>
+<p>If still missing, ask the coach/admin to resend the parent invite.</p>
+<h2 id="related-workflows">Related Workflows</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><code>getting-started</code></li>
+<li><code>choose-home-dashboard</code></li>
+<li><code>communication</code></li>
+</ul>
+<h2 id="need-more-help">Need More Help</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Ask your coach or team admin to confirm the invite was sent to the correct email.</li>
+<li>Request a new invite link or code if your current one fails.</li>
+<li>After joining, confirm your dashboard and open the team once to verify access.</li>
+</ul></div>
+          </article>
+        </div>
+      </div>
+    </main>
+    <div id="footer-container"></div>
+    <script type="module">
+      import { checkAuth } from './js/auth.js?v=9';
+      import { renderHeader, renderFooter } from './js/utils.js?v=8';
+      renderHeader(document.getElementById('header-container'), null);
+      renderFooter(document.getElementById('footer-container'));
+      checkAuth((user) => {
+        renderHeader(document.getElementById('header-container'), user);
+      });
+    </script>
+    <script>
+      (function() {
+        const headings = Array.from(document.querySelectorAll('.help-workflow-body h2[id]'));
+        const toc = document.getElementById('workflow-toc');
+        const mobileToc = document.getElementById('workflow-mobile-toc');
+        if (!toc || !headings.length) return;
+
+        const links = headings.map((h) => {
+          const a = document.createElement('a');
+          a.href = '#' + h.id;
+          a.textContent = h.textContent || h.id;
+          toc.appendChild(a);
+          return a;
+        });
+
+        if (mobileToc && window.innerWidth < 1024) {
+          const wrapper = document.createElement('details');
+          wrapper.className = 'wf-panel-section wf-panel';
+          wrapper.style.marginBottom = '0.95rem';
+          wrapper.style.padding = '0.8rem 1rem';
+          const summary = document.createElement('summary');
+          summary.textContent = 'Jump to section';
+          summary.style.cursor = 'pointer';
+          summary.style.fontWeight = '700';
+          summary.style.color = '#0f172a';
+          const list = toc.cloneNode(true);
+          list.style.marginTop = '0.6rem';
+          wrapper.appendChild(summary);
+          wrapper.appendChild(list);
+          mobileToc.appendChild(wrapper);
+        }
+
+        const sectionById = new Map(headings.map((h) => [h.id, h]));
+        const setActive = () => {
+          let active = headings[0];
+          for (const h of headings) {
+            if (h.getBoundingClientRect().top <= 140) active = h;
+          }
+          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+        };
+
+        window.addEventListener('scroll', setActive, { passive: true });
+        setActive();
+      })();
+    </script>
+</body>
+</html>

--- a/workflow-live-watch-replay.html
+++ b/workflow-live-watch-replay.html
@@ -1,0 +1,490 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Watch Live Games and Replays - ALL PLAYS Help</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: {
+                50: '#eef2ff',
+                100: '#e0e7ff',
+                500: '#6366f1',
+                600: '#4f46e5',
+                700: '#4338ca',
+                800: '#3730a3',
+                900: '#312e81'
+              }
+            }
+          }
+        }
+      }
+    </script>
+    <style>
+      :root {
+        --wf-bg: #f8fafc;
+        --wf-panel: #ffffff;
+        --wf-text: #0f172a;
+        --wf-muted: #52606f;
+        --wf-accent: #4f46e5;
+        --wf-accent-soft: #e0e7ff;
+        --wf-border: #d9e2ec;
+      }
+
+      body {
+        background:
+          radial-gradient(circle at 85% 0%, rgba(99,102,241,0.14) 0%, rgba(248,250,252,0) 42%),
+          radial-gradient(circle at 8% 20%, rgba(67,56,202,0.10) 0%, rgba(248,250,252,0) 48%),
+          var(--wf-bg);
+        color: var(--wf-text);
+      }
+
+      .wf-shell {
+        width: min(1160px, 100%);
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+      }
+
+      .wf-back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.85rem;
+        font-weight: 700;
+        color: #4338ca;
+      }
+
+      .wf-hero {
+        margin-top: 0.75rem;
+        background: linear-gradient(140deg, #312e81 0%, #4338ca 46%, #4f46e5 100%);
+        border-radius: 1.1rem;
+        padding: 1.25rem 1.25rem 1.15rem;
+        color: #ecfeff;
+        box-shadow: 0 14px 36px rgba(15, 23, 42, 0.22);
+      }
+
+      .wf-kicker {
+        font-size: 0.73rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        opacity: 0.84;
+      }
+
+      .wf-title {
+        margin-top: 0.4rem;
+        font-size: clamp(1.75rem, 2.8vw, 2.35rem);
+        line-height: 1.15;
+        font-weight: 800;
+      }
+
+      .wf-summary {
+        margin-top: 0.75rem;
+        max-width: 60ch;
+        color: rgba(236, 254, 255, 0.95);
+        line-height: 1.58;
+      }
+
+      .wf-meta-row {
+        margin-top: 0.95rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+        align-items: center;
+      }
+
+      .wf-meta-pill {
+        display: inline-flex;
+        align-items: center;
+        font-size: 0.78rem;
+        font-weight: 700;
+        border-radius: 999px;
+        border: 1px solid rgba(236, 254, 255, 0.36);
+        background: rgba(236, 254, 255, 0.12);
+        color: #ecfeff;
+        padding: 0.24rem 0.62rem;
+      }
+
+      .wf-layout {
+        margin-top: 1rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .wf-panel {
+        background: var(--wf-panel);
+        border: 1px solid var(--wf-border);
+        border-radius: 1rem;
+        box-shadow: 0 7px 20px rgba(15, 23, 42, 0.08);
+      }
+
+      .wf-panel-section {
+        padding: 1rem;
+        border-bottom: 1px solid var(--wf-border);
+      }
+
+      .wf-panel-section:last-child {
+        border-bottom: 0;
+      }
+
+      .wf-panel-title {
+        font-size: 0.78rem;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #334155;
+        margin-bottom: 0.6rem;
+      }
+
+      .wf-role-chip {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        border: 1px solid #c7d2fe;
+        background: #eef2ff;
+        color: #3730a3;
+        padding: 0.22rem 0.66rem;
+        font-size: 0.74rem;
+        font-weight: 700;
+      }
+
+      .wf-roles {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+      }
+
+      .wf-toc {
+        display: grid;
+        gap: 0.33rem;
+      }
+
+      .wf-toc a {
+        display: block;
+        padding: 0.43rem 0.52rem;
+        border-radius: 0.55rem;
+        color: #334155;
+        font-size: 0.82rem;
+        line-height: 1.35;
+        transition: background 120ms ease, color 120ms ease;
+      }
+
+      .wf-toc a:hover {
+        background: #eef2ff;
+        color: #3730a3;
+      }
+
+      .wf-toc a.is-active {
+        background: #e0e7ff;
+        color: #312e81;
+        font-weight: 700;
+      }
+
+      .wf-content {
+        padding: 1.2rem 1.15rem;
+      }
+
+      .help-workflow-body {
+        display: grid;
+        gap: 0.45rem;
+      }
+
+      .help-workflow-body h2 {
+        font-size: 1.4rem;
+        font-weight: 800;
+        color: #1f2937;
+        margin-top: 1.25rem;
+        padding-top: 1.05rem;
+        border-top: 1px solid #dbe7f0;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body h2:first-of-type {
+        margin-top: 0.15rem;
+        padding-top: 0;
+        border-top: 0;
+      }
+
+      .help-workflow-body h3 {
+        font-size: 1.08rem;
+        font-weight: 700;
+        color: #1e293b;
+        margin-top: 0.88rem;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body p,
+      .help-workflow-body li {
+        color: var(--wf-muted);
+        line-height: 1.67;
+      }
+
+      .help-workflow-body ol,
+      .help-workflow-body ul {
+        margin-left: 1.2rem;
+      }
+
+      .help-workflow-body code {
+        background: #eef2ff;
+        color: #3730a3;
+        border: 1px solid #c7d2fe;
+        padding: 0.1rem 0.35rem;
+        border-radius: 0.3rem;
+        font-size: 0.86em;
+      }
+
+      .wf-mobile-toc {
+        margin-top: 0.95rem;
+      }
+
+      @media (min-width: 1024px) {
+        .wf-layout {
+          grid-template-columns: 270px minmax(0, 1fr);
+          align-items: start;
+        }
+
+        .wf-sidebar {
+          position: sticky;
+          top: 1rem;
+        }
+      }
+
+      @media (max-width: 1023px) {
+        .wf-sidebar .wf-panel-section:nth-child(1) {
+          display: none;
+        }
+      }
+    </style>
+</head>
+<body class="flex flex-col min-h-screen">
+    <div id="header-container"></div>
+    <main class="flex-grow">
+      <div class="wf-shell">
+        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <section class="wf-hero">
+          <p class="wf-kicker">Workflow Guide</p>
+          <h1 class="wf-title">Watch Live Games and Replays</h1>
+          <p class="wf-summary">Use this workflow to open a game, follow it live, and switch to replay or the match report after the game ends.</p>
+          <div class="wf-meta-row">
+            <span class="wf-meta-pill">4 min read</span>
+            <span class="wf-meta-pill">Updated from live product pages</span>
+          </div>
+        </section>
+
+        <div class="wf-layout">
+          <aside class="wf-sidebar wf-panel">
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">On this page</h2>
+              <nav id="workflow-toc" class="wf-toc"></nav>
+            </section>
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">Who can use this</h2>
+              <div class="wf-roles"><span class="wf-role-chip">Parent</span> <span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span> <span class="wf-role-chip">Member</span></div>
+            </section>
+          </aside>
+
+          <article class="wf-panel wf-content">
+            <div id="workflow-mobile-toc" class="wf-mobile-toc"></div>
+            <div class="help-workflow-body"><h2 id="overview">Overview</h2>
+<p>Use this workflow to open a game, follow it live, and switch to replay or the match report after the game ends.</p>
+<p>You can start from a shared watch link, the home page, the team page, or the match report page.</p>
+<h2 id="in-this-article">In This Article</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Where to open a live or completed game.</li>
+<li>How to follow score, stream, plays, stats, chat, and reactions during live action.</li>
+<li>How to move to replay and match report after the final score.</li>
+<li>What to do when live, replay, chat, or sharing is not working.</li>
+</ul>
+<h2 id="who-is-this-for">Who Is This For</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Parent: Watch live score and stream, join chat, and watch replay later.</li>
+<li>Member: Follow live updates, then review replay or match report.</li>
+<li>Coach: Watch live, share game and report links, and direct families to replay/report.</li>
+<li>Admin: Same as Coach, plus full-access match report editing (for example, summary updates).</li>
+</ul>
+<h2 id="prerequisites">Prerequisites</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>You have a watch link, or you can open the game from the home page or team page.</li>
+<li>The game is scheduled, live, or completed.</li>
+<li>You have a stable internet connection.</li>
+<li>For team-level sharing or report actions, sign in with your team account.</li>
+</ul>
+<h2 id="choose-your-path">Choose Your Path</h2>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Shared link path</li>
+</ol>
+<p>Open the shared watch link directly.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Home page path (<code>index.html</code>)</li>
+</ol>
+<p>Open <strong>Live &amp; Upcoming Games</strong> and select <strong>Watch Now</strong> or <strong>View Details</strong>.</p>
+<p>Open <strong>Recent Replays</strong> and select <strong>Watch Replay</strong>.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Team page path (<code>team.html</code>)</li>
+</ol>
+<p>Find the game card.</p>
+<p>For active or upcoming games, select <strong>Live Now</strong> or <strong>View Live</strong>.</p>
+<p>For completed games, select <strong>Replay</strong> or <strong>View Report</strong>.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Match report path (<code>game.html</code>)</li>
+</ol>
+<p>Open the game report and select <strong>Watch Replay</strong> or <strong>Live Now</strong> (when shown).</p>
+<h2 id="step-by-step-workflow">Step-by-Step Workflow</h2>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Open the game in live view.</li>
+</ol>
+<p>Go to <code>live-game.html</code>. Confirm the scoreboard is visible at the top.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Check game status.</li>
+</ol>
+<p>If the game is live, look for the <strong>LIVE</strong> badge and current score.</p>
+<p>If the game has not started, you may see <strong>Game Not Live Yet</strong>.</p>
+<p>If the game is finished, use <strong>Watch Replay</strong> from the end-state prompt.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Follow the game feed.</li>
+</ol>
+<p>Use tabs for <strong>Plays</strong>, <strong>Stats</strong>, and <strong>Chat</strong>.</p>
+<p>Open <strong>Video</strong> when a stream is available.</p>
+<p>Track score, period, clock, and viewer count in the header.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Interact during the game (optional).</li>
+</ol>
+<p>Send a message in <strong>Chat</strong>.</p>
+<p>Set or update your display name if prompted.</p>
+<p>Use the reaction bar (fire, clap, wow, heart, hundred).</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Move to post-game content.</li>
+</ol>
+<p>Select <strong>Watch Replay</strong> to enter replay mode.</p>
+<p>Use replay controls: play/pause, scrubber, and speed (<code>1x</code> to <code>50x</code>).</p>
+<p>Select <strong>View Game Details</strong> or <strong>Match Report</strong> to open the full report page.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Share the game or report.</li>
+</ol>
+<p>Parent/Member: Copy the page URL and share it.</p>
+<p>Coach/Admin: Use built-in <strong>Share</strong> on live/team pages and <strong>Share Report</strong> on report/team pages.</p>
+<h2 id="common-questions">Common Questions</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>How do I confirm the game is live?</li>
+</ul>
+<p>Look for the <strong>LIVE</strong> badge and pulsing live indicator on the live page.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Why is replay not available yet?</li>
+</ul>
+<p>Replay appears after live tracking is completed for that game.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Can I open the page before tip-off?</li>
+</ul>
+<p>Yes. Open the game page and wait there. Status updates on that screen.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Where is the match report?</li>
+</ul>
+<p>Use <strong>Match Report</strong> on the live page or <strong>View Report</strong> on team/game pages.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Why is the Video tab missing?</li>
+</ul>
+<p>Some games do not have an active embedded stream. Use plays, stats, and chat instead.</p>
+<h2 id="recovery-troubleshooting">Recovery &amp; Troubleshooting</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Game link opens but game does not load.</li>
+</ul>
+<p>Confirm the URL includes both <code>teamId</code> and <code>gameId</code>.</p>
+<p>Ask a coach/admin to resend the link from <strong>Share</strong>.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Game says “not live yet” but should be live.</li>
+</ul>
+<p>Confirm the scheduled time.</p>
+<p>Refresh after one minute and check again.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Replay button is missing after final score.</li>
+</ul>
+<p>Open <code>team.html</code> and select <strong>View Report</strong> first.</p>
+<p>Then return and retry <strong>Watch Replay</strong>.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Chat message will not send.</li>
+</ul>
+<p>Check for a pregame chat lock notice.</p>
+<p>If prompted, enter a display name and resend.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Share sheet does not open.</li>
+</ul>
+<p>Copy the page URL manually and send it in your group chat.</p>
+<h2 id="related-workflows">Related Workflows</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><code>schedule</code>: Find upcoming games and open live/watch entry points from team schedule.</li>
+<li><code>postgame</code>: Review final results, summary, and report details after completion.</li>
+<li><code>communication</code>: Coordinate team updates, share links, and manage messaging.</li>
+</ul>
+<h2 id="need-more-help">Need More Help</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Contact your team Coach/Admin for the correct watch or report link.</li>
+<li>Open the <strong>Help Center</strong> from the main site navigation or footer.</li>
+<li>When reporting an issue, include team name, opponent, and game date/time.</li>
+</ul></div>
+          </article>
+        </div>
+      </div>
+    </main>
+    <div id="footer-container"></div>
+    <script type="module">
+      import { checkAuth } from './js/auth.js?v=9';
+      import { renderHeader, renderFooter } from './js/utils.js?v=8';
+      renderHeader(document.getElementById('header-container'), null);
+      renderFooter(document.getElementById('footer-container'));
+      checkAuth((user) => {
+        renderHeader(document.getElementById('header-container'), user);
+      });
+    </script>
+    <script>
+      (function() {
+        const headings = Array.from(document.querySelectorAll('.help-workflow-body h2[id]'));
+        const toc = document.getElementById('workflow-toc');
+        const mobileToc = document.getElementById('workflow-mobile-toc');
+        if (!toc || !headings.length) return;
+
+        const links = headings.map((h) => {
+          const a = document.createElement('a');
+          a.href = '#' + h.id;
+          a.textContent = h.textContent || h.id;
+          toc.appendChild(a);
+          return a;
+        });
+
+        if (mobileToc && window.innerWidth < 1024) {
+          const wrapper = document.createElement('details');
+          wrapper.className = 'wf-panel-section wf-panel';
+          wrapper.style.marginBottom = '0.95rem';
+          wrapper.style.padding = '0.8rem 1rem';
+          const summary = document.createElement('summary');
+          summary.textContent = 'Jump to section';
+          summary.style.cursor = 'pointer';
+          summary.style.fontWeight = '700';
+          summary.style.color = '#0f172a';
+          const list = toc.cloneNode(true);
+          list.style.marginTop = '0.6rem';
+          wrapper.appendChild(summary);
+          wrapper.appendChild(list);
+          mobileToc.appendChild(wrapper);
+        }
+
+        const sectionById = new Map(headings.map((h) => [h.id, h]));
+        const setActive = () => {
+          let active = headings[0];
+          for (const h of headings) {
+            if (h.getBoundingClientRect().top <= 140) active = h;
+          }
+          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+        };
+
+        window.addEventListener('scroll', setActive, { passive: true });
+        setActive();
+      })();
+    </script>
+</body>
+</html>

--- a/workflow-manifest.json
+++ b/workflow-manifest.json
@@ -1,0 +1,155 @@
+[
+  {
+    "id": "admin-ops",
+    "title": "Operate Platform Admin Controls",
+    "roles": [
+      "Admin"
+    ],
+    "file": "workflow-admin-ops.html",
+    "summary": "Use this workflow to run platform admin operations in ALL PLAYS. You will confirm admin access, review platform activity, update teams, manage admin invites, and verify user visibility.",
+    "readTimeMin": 4,
+    "searchText": "# Operate Platform Admin Controls\n\n## Overview\nUse this workflow to run platform admin operations in ALL PLAYS. You will confirm admin access, review platform activity, update teams, manage admin invites, and verify user visibility.\n\nUse it when you are starting an admin session, checking platform health, or handling team lifecycle updates.\n\n## In This Article\n- Confirm admin entitlement before sensitive actions.\n- Review teams, users, games, and recent activity in the admin dashboard.\n- Find active and inactive teams.\n- Update team settings and manage team admin invites.\n- Deactivate teams when owner controls are available.\n- Recover from common access, search, and save issues.\n\n## Who Is This For\n- Platform admins who oversee teams, users, and platform activity.\n- Team owners and full team admins handling team updates.\n\n## Prerequisites\n- You are signed in to ALL PLAYS.\n- Your account has admin entitlement (`isAdmin` is `true`).\n- You can open `check-admin-status.html` and `admin.html`.\n- For team lifecycle work, you can open `edit-team.html` and `dashboard.html`.\n\n## Choose Your Path\n- **Start of session or access issue:** Open `check-admin-status.html` to confirm admin entitlement.\n- **Platform health review:** Open `admin.html` and use the `Dashboard` tab.\n- **Team updates and cleanup:** Open `admin.html` on `Teams`, then open the team in `edit-team.html`.\n- **Team deactivation:** Open `dashboard.html` with an owner account.\n\n## Step-by-Step Workflow\n1. Confirm admin entitlement in `check-admin-status.html`. Continue only when you see `isAdmin field is TRUE`. If you see `Not logged in`, sign in and reload. If admin status is not true, stop and request admin enablement.\n2. Open `admin.html` and confirm your account is shown as the logged-in admin. Start on the `Dashboard` tab.\n3. Review platform activity cards for team count, user count, games, and 7-day activity. Review `Recent Teams` and `Recent Users`. Use `View All Teams` or `View All Users` when needed.\n4. "
+  },
+  {
+    "id": "choose-home-dashboard",
+    "title": "Use the Right Dashboard for Your Role",
+    "roles": [
+      "Parent",
+      "Coach",
+      "Admin"
+    ],
+    "file": "workflow-choose-home-dashboard.html",
+    "summary": "Choose the dashboard that matches what you need to do right now.",
+    "readTimeMin": 3,
+    "searchText": "# Use the Right Dashboard for Your Role\n\n## Overview\nChoose the dashboard that matches what you need to do right now.\n\n- Use **Parent Dashboard** for family tasks.\n- Use **My Teams Dashboard** for team operations.\n- If you have more than one role, switch dashboards by task.\n\n## In This Article\n- How to choose the right dashboard quickly.\n- What each dashboard is best for.\n- What to do if teams, players, or actions are missing.\n\n## Who Is This For\n- **Parents** managing linked players and family activity.\n- **Coaches** managing team operations.\n- **Admins** supporting or managing team operations.\n\n## Prerequisites\n- You are signed in to ALL PLAYS.\n- Your account has the correct role and team/player links.\n- You have at least one linked team or player.\n\n## Choose Your Path\n- Choose **Parent Dashboard** when you need family tools.\n- Choose **My Teams Dashboard** when you need team management tools.\n- Choose **Calendar** when you need one combined schedule view across accessible teams.\n- If you are both parent and coach/admin, pick the dashboard based on the task, not the account.\n\n## Step-by-Step Workflow\n1. Sign in to ALL PLAYS and confirm you are in the correct account.\n2. Pick your goal: family/player task means **Parent Dashboard**; team operations task means **My Teams Dashboard**.\n3. Open the dashboard that matches your goal.\n4. Start work from that page: on **Parent Dashboard** use **My Players**, **My Teams**, or **Redeem Code**; on **My Teams Dashboard** open a team card and use **View**, **Chat**, **Edit**, **Roster**, or **Schedule**.\n5. Open team details when you need to work in one specific team context.\n6. Open **Calendar** for cross-team planning, then filter by team, event type, and date range; export `.ics` when needed.\n7. Check your access level before edits; if actions are read-only, you likely have parent-level access for that team.\n\n## Common Questions\n**Which dashboard should I bookmark?**\n- Parents: **Parent Dashboard**.\n- Coaches/Admins: **My Te"
+  },
+  {
+    "id": "communication",
+    "title": "Coordinate Team Messages and Availability",
+    "roles": [
+      "Parent",
+      "Coach",
+      "Admin"
+    ],
+    "file": "workflow-communication.html",
+    "summary": "Use this workflow to keep families, coaches, and admins aligned before, during, and after events.",
+    "readTimeMin": 3,
+    "searchText": "# Coordinate Team Messages and Availability\n\n## Overview\nUse this workflow to keep families, coaches, and admins aligned before, during, and after events.\n\nStart by choosing the path that matches your goal: team chat, RSVP, rideshare, or live-game chat.\n\n## In This Article\n- Pick the right path for messaging, availability, or rideshare.\n- Send clear team updates and ask `@ALL PLAYS` questions.\n- Set event status as `Going`, `Maybe`, or `Can't Go`.\n- Offer rides, request spots, and manage request decisions.\n- Recover quickly from common send, access, and RSVP issues.\n\n## Who Is This For\n- Parent: Share updates, set availability, and coordinate rides.\n- Coach: Post reminders, keep chat focused, and moderate chat.\n- Admin: Support communication standards and moderate chat.\n\n## Prerequisites\n- You are signed in.\n- You have access to at least one team.\n- You opened a team context from your dashboard, team view, calendar, or live game page.\n- For RSVP buttons, the event is already tracked in the team schedule.\n\n## Choose Your Path\n1. Send a team update or reminder now: use team chat.\n2. Submit event availability: use the schedule list or calendar event view.\n3. Coordinate transportation: use event rideshare.\n4. Communicate during a game: use live-game chat when enabled.\n\n## Step-by-Step Workflow\n### Path A: Team Messages and Moderation\n1. Open team chat from your current team context.\n2. Write one clear update per message.\n3. Optional: add voice input or attach one image (up to 5 MB).\n4. To ask the assistant, include `@ALL PLAYS` and your question in the same message.\n5. Select **Send**.\n6. Confirm the message appears in the thread.\n7. Add reactions for quick acknowledgment.\n8. Edit or delete your own message if plans change.\n9. If you are a Coach or Admin, remove off-topic or inappropriate messages from others when needed.\n10. For live-game chat, post short updates. If chat is locked, retry at game time.\n\n### Path B: RSVP Availability\n1. Open the event from schedule list"
+  },
+  {
+    "id": "game-day",
+    "title": "Run Pre-Game Through Wrap-Up Command",
+    "roles": [
+      "Coach",
+      "Admin"
+    ],
+    "file": "workflow-game-day.html",
+    "summary": "Use Game Day Command Center for one continuous game-day flow.",
+    "readTimeMin": 5,
+    "searchText": "# Run Pre-Game Through Wrap-Up Command\n\n## Overview\nUse Game Day Command Center for one continuous game-day flow.\n\nConfirm game details, lock availability and lineup, manage live decisions, then close with notes and summary. This keeps in-game decisions fast and post-game follow-through clean.\n\n## In This Article\n- Choose the right starting path for your game-day situation.\n- Run pre-game checks and save lineup.\n- Manage live substitutions, logs, score, and stats.\n- Complete wrap-up and hand off to reporting and practice planning.\n- Recover from common game-day issues.\n\n## Who Is This For\n- Coach: Owns lineup, substitutions, live coaching log, and wrap-up decisions.\n- Admin: Owns schedule accuracy, availability support, and final data quality.\n- Coach + Admin: Split work so one person coaches while the other updates score and logs.\n\n## Prerequisites\n- A scheduled game exists with valid `teamId` and `gameId`.\n- You have full team access (coach/admin-level controls).\n- Open from `edit-schedule.html` using **Command Center**, or use `game-day.html?teamId=...&gameId=...`.\n- The roster is loaded so availability and lineup can be set.\n\n## Choose Your Path\n1. Start from schedule and run the full flow.\nGo to `edit-schedule.html`, find the game, and select **Command Center**.\n\n2. Fix setup first, then run Command Center.\nIn `edit-schedule.html`, select **Edit** and correct date, opponent, location, home/away, or kit. Then return and open **Command Center**.\n\n3. Check quick context before kickoff.\nOpen `team.html`, review **Upcoming Games** or **Recent Results**, then launch **Command Center** from `edit-schedule.html`.\n\n4. Plan the next practice from game outcomes.\nIn the Game Day pre-game rail, use **Plan →** from prior focus items, or finish wrap-up analysis first. Continue in `drills.html`.\n\n## Step-by-Step Workflow\n1. Open the correct game.\nIn `edit-schedule.html`, filter to upcoming games and select **Command Center**. Confirm opponent and date before changes.\n\n2. Valid"
+  },
+  {
+    "id": "getting-started",
+    "title": "Create or Access Your Account",
+    "roles": [
+      "Parent",
+      "Coach",
+      "Admin",
+      "Member"
+    ],
+    "file": "workflow-getting-started.html",
+    "summary": "Use this workflow to get into ALL PLAYS fast.",
+    "readTimeMin": 4,
+    "searchText": "# Create or Access Your Account\n\n## Overview\nUse this workflow to get into ALL PLAYS fast.\n\nChoose the path that matches your situation: new account, sign-in, password reset, or email verification.\n\n## In This Article\n- Choose the right account access path.\n- Create a new account with an activation code.\n- Sign in with email/password or Google.\n- Verify your email now or later.\n- Reset your password.\n- Resolve common login and verification issues.\n\n## Who Is This For\n- Parent: Create an account from a code, or sign in to continue team access.\n- Coach: Create or sign in, then verify email and keep access active.\n- Admin: Create or sign in, then continue invite-based onboarding when needed.\n- Member: Create or sign in with an activation code and confirm access.\n\n## Prerequisites\n- You can access your email inbox now.\n- You have a stable internet connection and supported browser.\n- For first-time signup, you have an 8-character activation code.\n- If you prefer Google sign-in, you have a Google account.\n\n## Choose Your Path\n- Path A: I am new and have an activation code.\n- Path B: I already have an account.\n- Path C: I forgot my password.\n- Path D: I need to verify my email or resend verification.\n- Path E: I signed in with an email link and want to set a password.\n\n## Step-by-Step Workflow\n1. Open `index.html` and select **Get Started Now**, or go to `login.html`.\n2. Follow the path that matches your situation.\n\n### Path A: Create a new account\n1. On `login.html`, select **Sign Up**.\n2. Enter your email, password, and confirm password.\n3. Enter your 8-character activation code.\n4. Select **Create Account**.\n5. Optional: Select **Continue with Google** in Sign Up mode. You still need an activation code.\n6. After signup, go to `verify-pending.html`.\n7. Open your verification email and select the link.\n8. If needed, select **Resend Verification Email**.\n\n### Path B: Sign in to an existing account\n1. On `login.html`, stay in **Login** mode.\n2. Sign in with **Sign In** (ema"
+  },
+  {
+    "id": "join-team",
+    "title": "Join a Team from an Invite",
+    "roles": [
+      "Parent",
+      "Coach",
+      "Admin"
+    ],
+    "file": "workflow-join-team.html",
+    "summary": "Use this workflow to join a team with an invite link or an 8-character invite code.",
+    "readTimeMin": 3,
+    "searchText": "# Join a Team from an Invite\n\n## Overview\nUse this workflow to join a team with an invite link or an 8-character invite code.\n\nYou will redeem the invite, then confirm you landed in the correct dashboard for your role.\n\n## In This Article\n- Choose the right invite path.\n- Join with a link or manual code.\n- Complete sign-in or account creation.\n- Confirm your dashboard and team access.\n- Fix common invite and sign-in issues.\n\n## Who Is This For\n- Parent users joining a child’s team.\n- Coach users joining team staff access.\n- Admin users joining admin/team access.\n\n## Prerequisites\n- You have a valid invite link or 8-character invite code.\n- You are ready to sign in or create an account.\n- You can use the same email address that received the invite.\n- You can stay in the invite flow until you see success.\n\n## Choose Your Path\n1. I have an invite link and I am already signed in.\n   Open the link and continue through invite confirmation.\n2. I have an invite link and I am not signed in.\n   Open the link, then sign in or create an account when prompted.\n3. I only have an 8-character code.\n   Open invite acceptance, choose manual code entry, then enter the code.\n4. I am a parent adding another player after I already joined.\n   Use `Redeem Code` in Parent Dashboard with the new code.\n\n## Step-by-Step Workflow\n1. Open your invite link.\n   If the page shows `Processing Invite...`, wait for it to finish.\n2. Confirm your email if prompted.\n   If you opened the link on another device, enter the invited email and select `Continue`.\n3. Enter your invite code if needed.\n   If manual entry appears, type the 8-character code and select `Join Team`.\n4. Sign in or create your account.\n   Existing account: sign in with email/password or Google.\n   New account: select `Sign Up`, complete the form, and provide the activation code if asked.\n5. Complete invite redemption.\n   Return to the invite flow if prompted. Wait for `You’re In!` and the automatic redirect.\n6. Verify your role-based de"
+  },
+  {
+    "id": "live-watch-replay",
+    "title": "Watch Live Games and Replays",
+    "roles": [
+      "Parent",
+      "Coach",
+      "Admin",
+      "Member"
+    ],
+    "file": "workflow-live-watch-replay.html",
+    "summary": "Use this workflow to open a game, follow it live, and switch to replay or the match report after the game ends.",
+    "readTimeMin": 4,
+    "searchText": "# Watch Live Games and Replays\n\n## Overview\nUse this workflow to open a game, follow it live, and switch to replay or the match report after the game ends.\n\nYou can start from a shared watch link, the home page, the team page, or the match report page.\n\n## In This Article\n- Where to open a live or completed game.\n- How to follow score, stream, plays, stats, chat, and reactions during live action.\n- How to move to replay and match report after the final score.\n- What to do when live, replay, chat, or sharing is not working.\n\n## Who Is This For\n- Parent: Watch live score and stream, join chat, and watch replay later.\n- Member: Follow live updates, then review replay or match report.\n- Coach: Watch live, share game and report links, and direct families to replay/report.\n- Admin: Same as Coach, plus full-access match report editing (for example, summary updates).\n\n## Prerequisites\n- You have a watch link, or you can open the game from the home page or team page.\n- The game is scheduled, live, or completed.\n- You have a stable internet connection.\n- For team-level sharing or report actions, sign in with your team account.\n\n## Choose Your Path\n1. Shared link path\nOpen the shared watch link directly.\n\n2. Home page path (`index.html`)\nOpen **Live & Upcoming Games** and select **Watch Now** or **View Details**.\nOpen **Recent Replays** and select **Watch Replay**.\n\n3. Team page path (`team.html`)\nFind the game card.\nFor active or upcoming games, select **Live Now** or **View Live**.\nFor completed games, select **Replay** or **View Report**.\n\n4. Match report path (`game.html`)\nOpen the game report and select **Watch Replay** or **Live Now** (when shown).\n\n## Step-by-Step Workflow\n1. Open the game in live view.\nGo to `live-game.html`. Confirm the scoreboard is visible at the top.\n\n2. Check game status.\nIf the game is live, look for the **LIVE** badge and current score.\nIf the game has not started, you may see **Game Not Live Yet**.\nIf the game is finished, use **Watch Replay** "
+  },
+  {
+    "id": "postgame",
+    "title": "Review, Edit, and Share Postgame Results",
+    "roles": [
+      "Parent",
+      "Coach",
+      "Admin",
+      "Member"
+    ],
+    "file": "workflow-postgame.html",
+    "summary": "Use this workflow after a game ends to verify results, clean up postgame details, and share links.",
+    "readTimeMin": 4,
+    "searchText": "# Review, Edit, and Share Postgame Results\n\n## Overview\nUse this workflow after a game ends to verify results, clean up postgame details, and share links.\n\nStart in `team.html` for fast sharing. Use `game.html` for a full review and edits.\n\n## In This Article\n- Pick the fastest path for your postgame goal.\n- Verify final score, events, and player performance.\n- Edit summary and score sheet if you have full access.\n- Share report and replay links.\n- Fix common postgame issues quickly.\n\n## Who Is This For\n- Parent: Review results, replay, and player details.\n- Coach: Finalize report quality, verify stats, and publish results.\n- Admin: Support edits, accuracy checks, and sharing.\n- Member: Open shared report and replay links.\n\n## Prerequisites\n- The game is completed and game data exists.\n- You have the correct team or game link.\n- To edit summary or score sheet, sign in with full team access (Coach/Admin).\n\n## Choose Your Path\n- Quick share: Open `team.html` and share from `Recent Results`.\n- Full review: Open `game.html` to confirm summary, play-by-play, and player performance.\n- Player follow-up: From `game.html`, open a player in `player.html`.\n- Replay sharing: Share replay from `team.html`, `game.html`, or `live-game.html` when available.\n\n## Step-by-Step Workflow\n1. Open the completed game report.\n   In `team.html`, go to `Recent Results`, then select `View Report`.\n2. Confirm final game info.\n   Verify opponent, date, final score, and outcome label.\n3. Review report sections.\n   Check `Match Summary`, `Play-by-Play`, and `Player Performance`.\n4. Edit summary if needed (Coach/Admin only).\n   Select `Edit Summary`, update content, then select `Save Summary`.\n5. Optionally generate summary text (Coach/Admin only).\n   Select `Generate AI Summary`, review it, edit as needed, and save.\n6. Update score sheet if needed (Coach/Admin only).\n   Use `Upload Score Sheet`, preview, and save.\n7. Correct score sheet if needed (Coach/Admin only).\n   Use `Remove Score Sheet`, up"
+  },
+  {
+    "id": "roster",
+    "title": "Build and Maintain Team Roster",
+    "roles": [
+      "Parent",
+      "Coach",
+      "Admin"
+    ],
+    "file": "workflow-roster.html",
+    "summary": "Use this workflow to keep your team roster accurate and parent access connected.",
+    "readTimeMin": 4,
+    "searchText": "# Build and Maintain Team Roster\n\n## Overview\nUse this workflow to keep your team roster accurate and parent access connected.\n\nYou can:\n- Add players and jersey numbers.\n- Update player details.\n- Deactivate players without losing history, then reactivate them later.\n- Link parents to active players and send invites.\n\n## In This Article\n- Who should run this workflow.\n- What to prepare before you start.\n- How to choose the right roster action.\n- Step-by-step roster and parent invite actions.\n- How to recover from common invite or roster issues.\n\n## Who Is This For\n- Coach: Day-to-day roster updates and parent invites for active players.\n- Admin: Full roster cleanup, including reactivation and parent-link fixes.\n\n## Prerequisites\n- A team already exists.\n- You have full-access permissions for that team.\n- Player names and jersey details are ready.\n- Parent emails are ready if you plan to send email invites.\n\n## Choose Your Path\n- Add one player: Use **Add Player**.\n- Add many players: Use **Bulk AI Update** with roster text or an image, then review and apply.\n- Correct player details: Use **Edit** on that player row.\n- Remove a player from active roster: Use **Deactivate**.\n- Bring a player back: Use **Reactivate**.\n- Link a parent: Use **Invite Parent** on an active player.\n- Invite Parent is disabled: Reactivate the player first, then send the invite.\n\n## Step-by-Step Workflow\n1. Open roster management and confirm you are on the correct team.\n2. Add or update players.\n- Single add: In **Add Player**, enter name and optional number/photo, then submit.\n- Bulk update: In **Bulk AI Update**, upload an image and/or paste roster text. Select **Process with AI**, review changes, then select **Apply Changes**.\n3. Edit a player when details change.\n- Select **Edit** in the player row, update name/number/photo, then save.\n4. Manage active status.\n- Select **Deactivate** to remove a player from active roster while keeping stats and history.\n- Select **Reactivate** when the p"
+  },
+  {
+    "id": "schedule",
+    "title": "Plan Schedule and Launch Game Flows",
+    "roles": [
+      "Coach",
+      "Admin"
+    ],
+    "file": "workflow-schedule.html",
+    "summary": "Use this workflow to publish reliable games and practices, then launch game-day tools from the schedule.",
+    "readTimeMin": 5,
+    "searchText": "# Plan Schedule and Launch Game Flows\n\n## Overview\nUse this workflow to publish reliable games and practices, then launch game-day tools from the schedule.\n\nYou will use:\n- `edit-schedule.html` to create and manage events.\n- `game-plan.html` to prepare lineups.\n- `team.html` and `calendar.html` to review, share, and export.\n- `live-game.html` for live viewing and replay access.\n\n## In This Article\n- Set up schedule inputs and external calendar links.\n- Add games with key details, assignments, and stat config.\n- Add one-time or recurring practices.\n- Edit one date or an entire recurring series safely.\n- Launch planning, tracking, command center, and live tools.\n- Share live links and find replay/report links.\n- Verify availability visibility and export `.ics` files.\n\n## Who Is This For\n- Coach: Publish weekly events, prep upcoming games, and launch tracking quickly.\n- Admin: Maintain calendar feeds, clean recurring data, and keep schedule quality high.\n\n## Prerequisites\n- Your team is created and accessible.\n- You are signed in with coach/admin manage access for that team.\n- Roster and game details are ready (date, time, location, opponent).\n- If importing calendars, you have valid `.ics` URLs.\n\n## Choose Your Path\n1. Build or update the full schedule: start at Step 1 and continue through Step 7.\n2. Import from another calendar: complete Step 2, then Step 7 for any games you need to track.\n3. Prepare game execution: use Step 8 and Step 9.\n4. Share live or replay access with families: use Step 10.\n5. Validate final visibility and export views: use Step 11.\n\n## Step-by-Step Workflow\n1. Open `edit-schedule.html` for the correct team.\nStart in `All Upcoming`. Confirm the team name before you edit.\n\n2. Add or verify external calendars in **Calendar Links**.\nSelect `+ Add Calendar`, paste a valid `.ics` URL, and save.\nCoach focus: add feeds you rely on.\nAdmin focus: remove outdated feeds and keep trusted sources.\n\n3. Add games in the **Game** tab.\nEnter `Date & Time`, `Opp"
+  },
+  {
+    "id": "team-setup",
+    "title": "Create Team Foundation and Staff Access",
+    "roles": [
+      "Coach",
+      "Admin"
+    ],
+    "file": "workflow-team-setup.html",
+    "summary": "Set up your team foundation first, then grant staff access.",
+    "readTimeMin": 4,
+    "searchText": "# Create Team Foundation and Staff Access\n\n## Overview\nSet up your team foundation first, then grant staff access.\n\nThis workflow helps you create or update a team, set core team details, and manage coach/admin invites.\n\n## In This Article\n- When to create a new team vs update an existing team\n- How to complete team foundation settings in one pass\n- How to invite staff and handle invite delivery issues\n- How to verify what families and players will see\n- How to recover from common setup and access problems\n\n## Who Is This For\n- Coach: Set up team identity and invite assistant coaches/admins\n- Admin: Standardize team setup, visibility, and staff access across teams\n\n## Prerequisites\n- You are signed in\n- You have full team management permissions\n- You already chose the team name and sport\n- You have staff emails ready if you plan to invite coaches/admins\n\n## Choose Your Path\n- Create a new team: Open **My Teams** (`dashboard.html`) and select **Create New Team**\n- Update an existing team: Open **My Teams**, select the team, then choose **Edit**\n- Manage staff access only: Open **Edit Team** and go to **Admin Access**\n\n## Step-by-Step Workflow\n1. Open the team editor.\n- New team: `dashboard.html` -> **Create New Team**\n- Existing team: `dashboard.html` -> team card -> **Edit**\n\n2. Confirm edit access.\n- If you can see the full form and **Save Team**, continue.\n- If you are blocked or redirected, ask the team owner to add you as an admin.\n\n3. Complete team identity.\n- Enter **Team Name**\n- Select **Sport**\n- Add **Description** (recommended)\n\n4. Add communication and location details.\n- Enter **ZIP Code**\n- Enter **Notification Email**\n\n5. Add links families will use.\n- Add **League Link** for standings\n- Add **Live Stream** (YouTube or Twitch URL)\n\n6. Set visibility.\n- Enable **Public Team** to make the team discoverable in Browse Teams\n- Disable it for invite/direct-link access only\n\n7. Invite coach/admin staff.\n- In **Admin Access**, select **+ Add Admin**\n- Enter e"
+  },
+  {
+    "id": "track-game",
+    "title": "Track Live Game Stats by Mode",
+    "roles": [
+      "Coach",
+      "Admin"
+    ],
+    "file": "workflow-track-game.html",
+    "summary": "Use this workflow to track a game from start to finish and publish an accurate game report.",
+    "readTimeMin": 4,
+    "searchText": "# Track Live Game Stats by Mode\n\n## Overview\nUse this workflow to track a game from start to finish and publish an accurate game report.\n\nYou can choose the tracker mode that fits your situation, capture events during play, then complete the game with final scores and summary details.\n\n## In This Article\n- Who should use this workflow.\n- What to confirm before you start.\n- How to choose the right tracker mode.\n- Step-by-step actions from schedule to final report.\n- Common questions and recovery steps.\n\n## Who Is This For\n- Coaches who enter live stats, manage periods, and handle substitutions.\n- Admins who support tracking, verify final accuracy, and finalize report details.\n\n## Prerequisites\n- You are signed in as a coach or admin.\n- You are opening a game event, not a practice.\n- The game has a valid team and game context (`teamId` and `gameId`).\n- A tracker configuration exists for the team.\n\n## Choose Your Path\nUse this quick guide before you start:\n\n- **Standard**: Use for classic manual entry with timer, team/opponent stats, and finish flow.\n- **Beta**: Use for sideline-focused basketball tracking with quick substitutions.\n- **Live Broadcast Tracker**: Use Beta-style tracking plus live chat and live-view context.\n- **Photo Score Sheet**: Use after the game to import final stats from a score sheet image.\n\nImportant behavior:\n- If no mode chooser appears, the game opens in the default Standard tracker.\n- If the game is already complete, open **Report** instead of starting a new tracking session.\n\n## Step-by-Step Workflow\n1. Open the game from schedule.\n- Select **Track** on the game card.\n- Confirm opponent, date, and location.\n\n2. Select the tracker mode.\n- Pick the mode that matches your game situation.\n- Select **Start** to begin clocked tracking.\n\n3. Track events during play.\n- Update period as the game moves through Q1-Q4 and OT.\n- In **Standard**, log team/opponent stats and use **Undo** for quick fixes.\n- In **Beta** or **Live Broadcast Tracker**, use **L"
+  }
+]

--- a/workflow-postgame.html
+++ b/workflow-postgame.html
@@ -1,0 +1,485 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Review, Edit, and Share Postgame Results - ALL PLAYS Help</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: {
+                50: '#eef2ff',
+                100: '#e0e7ff',
+                500: '#6366f1',
+                600: '#4f46e5',
+                700: '#4338ca',
+                800: '#3730a3',
+                900: '#312e81'
+              }
+            }
+          }
+        }
+      }
+    </script>
+    <style>
+      :root {
+        --wf-bg: #f8fafc;
+        --wf-panel: #ffffff;
+        --wf-text: #0f172a;
+        --wf-muted: #52606f;
+        --wf-accent: #4f46e5;
+        --wf-accent-soft: #e0e7ff;
+        --wf-border: #d9e2ec;
+      }
+
+      body {
+        background:
+          radial-gradient(circle at 85% 0%, rgba(99,102,241,0.14) 0%, rgba(248,250,252,0) 42%),
+          radial-gradient(circle at 8% 20%, rgba(67,56,202,0.10) 0%, rgba(248,250,252,0) 48%),
+          var(--wf-bg);
+        color: var(--wf-text);
+      }
+
+      .wf-shell {
+        width: min(1160px, 100%);
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+      }
+
+      .wf-back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.85rem;
+        font-weight: 700;
+        color: #4338ca;
+      }
+
+      .wf-hero {
+        margin-top: 0.75rem;
+        background: linear-gradient(140deg, #312e81 0%, #4338ca 46%, #4f46e5 100%);
+        border-radius: 1.1rem;
+        padding: 1.25rem 1.25rem 1.15rem;
+        color: #ecfeff;
+        box-shadow: 0 14px 36px rgba(15, 23, 42, 0.22);
+      }
+
+      .wf-kicker {
+        font-size: 0.73rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        opacity: 0.84;
+      }
+
+      .wf-title {
+        margin-top: 0.4rem;
+        font-size: clamp(1.75rem, 2.8vw, 2.35rem);
+        line-height: 1.15;
+        font-weight: 800;
+      }
+
+      .wf-summary {
+        margin-top: 0.75rem;
+        max-width: 60ch;
+        color: rgba(236, 254, 255, 0.95);
+        line-height: 1.58;
+      }
+
+      .wf-meta-row {
+        margin-top: 0.95rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+        align-items: center;
+      }
+
+      .wf-meta-pill {
+        display: inline-flex;
+        align-items: center;
+        font-size: 0.78rem;
+        font-weight: 700;
+        border-radius: 999px;
+        border: 1px solid rgba(236, 254, 255, 0.36);
+        background: rgba(236, 254, 255, 0.12);
+        color: #ecfeff;
+        padding: 0.24rem 0.62rem;
+      }
+
+      .wf-layout {
+        margin-top: 1rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .wf-panel {
+        background: var(--wf-panel);
+        border: 1px solid var(--wf-border);
+        border-radius: 1rem;
+        box-shadow: 0 7px 20px rgba(15, 23, 42, 0.08);
+      }
+
+      .wf-panel-section {
+        padding: 1rem;
+        border-bottom: 1px solid var(--wf-border);
+      }
+
+      .wf-panel-section:last-child {
+        border-bottom: 0;
+      }
+
+      .wf-panel-title {
+        font-size: 0.78rem;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #334155;
+        margin-bottom: 0.6rem;
+      }
+
+      .wf-role-chip {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        border: 1px solid #c7d2fe;
+        background: #eef2ff;
+        color: #3730a3;
+        padding: 0.22rem 0.66rem;
+        font-size: 0.74rem;
+        font-weight: 700;
+      }
+
+      .wf-roles {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+      }
+
+      .wf-toc {
+        display: grid;
+        gap: 0.33rem;
+      }
+
+      .wf-toc a {
+        display: block;
+        padding: 0.43rem 0.52rem;
+        border-radius: 0.55rem;
+        color: #334155;
+        font-size: 0.82rem;
+        line-height: 1.35;
+        transition: background 120ms ease, color 120ms ease;
+      }
+
+      .wf-toc a:hover {
+        background: #eef2ff;
+        color: #3730a3;
+      }
+
+      .wf-toc a.is-active {
+        background: #e0e7ff;
+        color: #312e81;
+        font-weight: 700;
+      }
+
+      .wf-content {
+        padding: 1.2rem 1.15rem;
+      }
+
+      .help-workflow-body {
+        display: grid;
+        gap: 0.45rem;
+      }
+
+      .help-workflow-body h2 {
+        font-size: 1.4rem;
+        font-weight: 800;
+        color: #1f2937;
+        margin-top: 1.25rem;
+        padding-top: 1.05rem;
+        border-top: 1px solid #dbe7f0;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body h2:first-of-type {
+        margin-top: 0.15rem;
+        padding-top: 0;
+        border-top: 0;
+      }
+
+      .help-workflow-body h3 {
+        font-size: 1.08rem;
+        font-weight: 700;
+        color: #1e293b;
+        margin-top: 0.88rem;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body p,
+      .help-workflow-body li {
+        color: var(--wf-muted);
+        line-height: 1.67;
+      }
+
+      .help-workflow-body ol,
+      .help-workflow-body ul {
+        margin-left: 1.2rem;
+      }
+
+      .help-workflow-body code {
+        background: #eef2ff;
+        color: #3730a3;
+        border: 1px solid #c7d2fe;
+        padding: 0.1rem 0.35rem;
+        border-radius: 0.3rem;
+        font-size: 0.86em;
+      }
+
+      .wf-mobile-toc {
+        margin-top: 0.95rem;
+      }
+
+      @media (min-width: 1024px) {
+        .wf-layout {
+          grid-template-columns: 270px minmax(0, 1fr);
+          align-items: start;
+        }
+
+        .wf-sidebar {
+          position: sticky;
+          top: 1rem;
+        }
+      }
+
+      @media (max-width: 1023px) {
+        .wf-sidebar .wf-panel-section:nth-child(1) {
+          display: none;
+        }
+      }
+    </style>
+</head>
+<body class="flex flex-col min-h-screen">
+    <div id="header-container"></div>
+    <main class="flex-grow">
+      <div class="wf-shell">
+        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <section class="wf-hero">
+          <p class="wf-kicker">Workflow Guide</p>
+          <h1 class="wf-title">Review, Edit, and Share Postgame Results</h1>
+          <p class="wf-summary">Use this workflow after a game ends to verify results, clean up postgame details, and share links.</p>
+          <div class="wf-meta-row">
+            <span class="wf-meta-pill">4 min read</span>
+            <span class="wf-meta-pill">Updated from live product pages</span>
+          </div>
+        </section>
+
+        <div class="wf-layout">
+          <aside class="wf-sidebar wf-panel">
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">On this page</h2>
+              <nav id="workflow-toc" class="wf-toc"></nav>
+            </section>
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">Who can use this</h2>
+              <div class="wf-roles"><span class="wf-role-chip">Parent</span> <span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span> <span class="wf-role-chip">Member</span></div>
+            </section>
+          </aside>
+
+          <article class="wf-panel wf-content">
+            <div id="workflow-mobile-toc" class="wf-mobile-toc"></div>
+            <div class="help-workflow-body"><h2 id="overview">Overview</h2>
+<p>Use this workflow after a game ends to verify results, clean up postgame details, and share links.</p>
+<p>Start in <code>team.html</code> for fast sharing. Use <code>game.html</code> for a full review and edits.</p>
+<h2 id="in-this-article">In This Article</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Pick the fastest path for your postgame goal.</li>
+<li>Verify final score, events, and player performance.</li>
+<li>Edit summary and score sheet if you have full access.</li>
+<li>Share report and replay links.</li>
+<li>Fix common postgame issues quickly.</li>
+</ul>
+<h2 id="who-is-this-for">Who Is This For</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Parent: Review results, replay, and player details.</li>
+<li>Coach: Finalize report quality, verify stats, and publish results.</li>
+<li>Admin: Support edits, accuracy checks, and sharing.</li>
+<li>Member: Open shared report and replay links.</li>
+</ul>
+<h2 id="prerequisites">Prerequisites</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>The game is completed and game data exists.</li>
+<li>You have the correct team or game link.</li>
+<li>To edit summary or score sheet, sign in with full team access (Coach/Admin).</li>
+</ul>
+<h2 id="choose-your-path">Choose Your Path</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Quick share: Open <code>team.html</code> and share from <code>Recent Results</code>.</li>
+<li>Full review: Open <code>game.html</code> to confirm summary, play-by-play, and player performance.</li>
+<li>Player follow-up: From <code>game.html</code>, open a player in <code>player.html</code>.</li>
+<li>Replay sharing: Share replay from <code>team.html</code>, <code>game.html</code>, or <code>live-game.html</code> when available.</li>
+</ul>
+<h2 id="step-by-step-workflow">Step-by-Step Workflow</h2>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Open the completed game report.</li>
+</ol>
+<p>In <code>team.html</code>, go to <code>Recent Results</code>, then select <code>View Report</code>.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Confirm final game info.</li>
+</ol>
+<p>Verify opponent, date, final score, and outcome label.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Review report sections.</li>
+</ol>
+<p>Check <code>Match Summary</code>, <code>Play-by-Play</code>, and <code>Player Performance</code>.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Edit summary if needed (Coach/Admin only).</li>
+</ol>
+<p>Select <code>Edit Summary</code>, update content, then select <code>Save Summary</code>.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Optionally generate summary text (Coach/Admin only).</li>
+</ol>
+<p>Select <code>Generate AI Summary</code>, review it, edit as needed, and save.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Update score sheet if needed (Coach/Admin only).</li>
+</ol>
+<p>Use <code>Upload Score Sheet</code>, preview, and save.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Correct score sheet if needed (Coach/Admin only).</li>
+</ol>
+<p>Use <code>Remove Score Sheet</code>, upload the correct image, and save.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Review player-level detail.</li>
+</ol>
+<p>Open a player from <code>Player Performance</code> to view <code>Game Stats</code>, <code>Season Averages</code>, and <code>Game Events</code> in <code>player.html</code>.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Share final links.</li>
+</ol>
+<p>Use <code>Share Report</code> from <code>game.html</code> or <code>team.html</code>. Add replay links when available.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Validate the shared experience.</li>
+</ol>
+<p>Open the shared link once to confirm report load and replay playback.</p>
+<h2 id="common-questions">Common Questions</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Why can’t I edit the summary or score sheet?</li>
+</ul>
+<p>You need full team access (Coach/Admin).</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Can parents or members edit postgame content?</li>
+</ul>
+<p>No. They can review and share links only.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Why is there no report for this event?</li>
+</ul>
+<p>Practice events do not have game reports.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Where can I share replay only?</li>
+</ul>
+<p>Share from completed live games in <code>team.html</code>, <code>game.html</code>, or <code>live-game.html</code>.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>How do I review one player after the game?</li>
+</ul>
+<p>Open that player from <code>Player Performance</code> and review <code>Game Stats</code> and <code>Game Events</code>.</p>
+<h2 id="recovery-troubleshooting">Recovery &amp; Troubleshooting</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Summary is missing or outdated:</li>
+</ul>
+<p>Coach/Admin should open <code>Edit Summary</code>, save again, refresh, and re-share.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Score sheet is incorrect:</li>
+</ul>
+<p>Coach/Admin should remove it, upload the correct image, and verify the report.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Share action fails:</li>
+</ul>
+<p>Copy the report URL from the browser and send it directly.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Replay link is missing:</li>
+</ul>
+<p>Replay appears only after live game status is completed. Share report now and replay later.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Stats look incomplete:</li>
+</ul>
+<p>Recheck play-by-play and player game events, then reopen the report.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Link opens the wrong place:</li>
+</ul>
+<p>Return to <code>team.html</code>, open <code>Recent Results</code>, and launch the report again.</p>
+<h2 id="related-workflows">Related Workflows</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><code>track-game</code>: Capture live events and stats so postgame review is complete.</li>
+<li><code>game-day</code>: Prepare lineup, schedule, and live context before tip-off.</li>
+<li><code>live-watch-replay</code>: Manage live viewing and replay access.</li>
+<li><code>communication</code>: Send postgame updates and follow-up messages.</li>
+</ul>
+<h2 id="need-more-help">Need More Help</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Reopen the game from <code>team.html</code> → <code>Recent Results</code> and restart at Step 2.</li>
+<li>Ask a Coach/Admin with full access to verify hidden edit controls.</li>
+<li>When escalating, include game date, opponent, and the exact report or replay link.</li>
+</ul></div>
+          </article>
+        </div>
+      </div>
+    </main>
+    <div id="footer-container"></div>
+    <script type="module">
+      import { checkAuth } from './js/auth.js?v=9';
+      import { renderHeader, renderFooter } from './js/utils.js?v=8';
+      renderHeader(document.getElementById('header-container'), null);
+      renderFooter(document.getElementById('footer-container'));
+      checkAuth((user) => {
+        renderHeader(document.getElementById('header-container'), user);
+      });
+    </script>
+    <script>
+      (function() {
+        const headings = Array.from(document.querySelectorAll('.help-workflow-body h2[id]'));
+        const toc = document.getElementById('workflow-toc');
+        const mobileToc = document.getElementById('workflow-mobile-toc');
+        if (!toc || !headings.length) return;
+
+        const links = headings.map((h) => {
+          const a = document.createElement('a');
+          a.href = '#' + h.id;
+          a.textContent = h.textContent || h.id;
+          toc.appendChild(a);
+          return a;
+        });
+
+        if (mobileToc && window.innerWidth < 1024) {
+          const wrapper = document.createElement('details');
+          wrapper.className = 'wf-panel-section wf-panel';
+          wrapper.style.marginBottom = '0.95rem';
+          wrapper.style.padding = '0.8rem 1rem';
+          const summary = document.createElement('summary');
+          summary.textContent = 'Jump to section';
+          summary.style.cursor = 'pointer';
+          summary.style.fontWeight = '700';
+          summary.style.color = '#0f172a';
+          const list = toc.cloneNode(true);
+          list.style.marginTop = '0.6rem';
+          wrapper.appendChild(summary);
+          wrapper.appendChild(list);
+          mobileToc.appendChild(wrapper);
+        }
+
+        const sectionById = new Map(headings.map((h) => [h.id, h]));
+        const setActive = () => {
+          let active = headings[0];
+          for (const h of headings) {
+            if (h.getBoundingClientRect().top <= 140) active = h;
+          }
+          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+        };
+
+        window.addEventListener('scroll', setActive, { passive: true });
+        setActive();
+      })();
+    </script>
+</body>
+</html>

--- a/workflow-roster.html
+++ b/workflow-roster.html
@@ -1,0 +1,493 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Build and Maintain Team Roster - ALL PLAYS Help</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: {
+                50: '#eef2ff',
+                100: '#e0e7ff',
+                500: '#6366f1',
+                600: '#4f46e5',
+                700: '#4338ca',
+                800: '#3730a3',
+                900: '#312e81'
+              }
+            }
+          }
+        }
+      }
+    </script>
+    <style>
+      :root {
+        --wf-bg: #f8fafc;
+        --wf-panel: #ffffff;
+        --wf-text: #0f172a;
+        --wf-muted: #52606f;
+        --wf-accent: #4f46e5;
+        --wf-accent-soft: #e0e7ff;
+        --wf-border: #d9e2ec;
+      }
+
+      body {
+        background:
+          radial-gradient(circle at 85% 0%, rgba(99,102,241,0.14) 0%, rgba(248,250,252,0) 42%),
+          radial-gradient(circle at 8% 20%, rgba(67,56,202,0.10) 0%, rgba(248,250,252,0) 48%),
+          var(--wf-bg);
+        color: var(--wf-text);
+      }
+
+      .wf-shell {
+        width: min(1160px, 100%);
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+      }
+
+      .wf-back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.85rem;
+        font-weight: 700;
+        color: #4338ca;
+      }
+
+      .wf-hero {
+        margin-top: 0.75rem;
+        background: linear-gradient(140deg, #312e81 0%, #4338ca 46%, #4f46e5 100%);
+        border-radius: 1.1rem;
+        padding: 1.25rem 1.25rem 1.15rem;
+        color: #ecfeff;
+        box-shadow: 0 14px 36px rgba(15, 23, 42, 0.22);
+      }
+
+      .wf-kicker {
+        font-size: 0.73rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        opacity: 0.84;
+      }
+
+      .wf-title {
+        margin-top: 0.4rem;
+        font-size: clamp(1.75rem, 2.8vw, 2.35rem);
+        line-height: 1.15;
+        font-weight: 800;
+      }
+
+      .wf-summary {
+        margin-top: 0.75rem;
+        max-width: 60ch;
+        color: rgba(236, 254, 255, 0.95);
+        line-height: 1.58;
+      }
+
+      .wf-meta-row {
+        margin-top: 0.95rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+        align-items: center;
+      }
+
+      .wf-meta-pill {
+        display: inline-flex;
+        align-items: center;
+        font-size: 0.78rem;
+        font-weight: 700;
+        border-radius: 999px;
+        border: 1px solid rgba(236, 254, 255, 0.36);
+        background: rgba(236, 254, 255, 0.12);
+        color: #ecfeff;
+        padding: 0.24rem 0.62rem;
+      }
+
+      .wf-layout {
+        margin-top: 1rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .wf-panel {
+        background: var(--wf-panel);
+        border: 1px solid var(--wf-border);
+        border-radius: 1rem;
+        box-shadow: 0 7px 20px rgba(15, 23, 42, 0.08);
+      }
+
+      .wf-panel-section {
+        padding: 1rem;
+        border-bottom: 1px solid var(--wf-border);
+      }
+
+      .wf-panel-section:last-child {
+        border-bottom: 0;
+      }
+
+      .wf-panel-title {
+        font-size: 0.78rem;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #334155;
+        margin-bottom: 0.6rem;
+      }
+
+      .wf-role-chip {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        border: 1px solid #c7d2fe;
+        background: #eef2ff;
+        color: #3730a3;
+        padding: 0.22rem 0.66rem;
+        font-size: 0.74rem;
+        font-weight: 700;
+      }
+
+      .wf-roles {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+      }
+
+      .wf-toc {
+        display: grid;
+        gap: 0.33rem;
+      }
+
+      .wf-toc a {
+        display: block;
+        padding: 0.43rem 0.52rem;
+        border-radius: 0.55rem;
+        color: #334155;
+        font-size: 0.82rem;
+        line-height: 1.35;
+        transition: background 120ms ease, color 120ms ease;
+      }
+
+      .wf-toc a:hover {
+        background: #eef2ff;
+        color: #3730a3;
+      }
+
+      .wf-toc a.is-active {
+        background: #e0e7ff;
+        color: #312e81;
+        font-weight: 700;
+      }
+
+      .wf-content {
+        padding: 1.2rem 1.15rem;
+      }
+
+      .help-workflow-body {
+        display: grid;
+        gap: 0.45rem;
+      }
+
+      .help-workflow-body h2 {
+        font-size: 1.4rem;
+        font-weight: 800;
+        color: #1f2937;
+        margin-top: 1.25rem;
+        padding-top: 1.05rem;
+        border-top: 1px solid #dbe7f0;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body h2:first-of-type {
+        margin-top: 0.15rem;
+        padding-top: 0;
+        border-top: 0;
+      }
+
+      .help-workflow-body h3 {
+        font-size: 1.08rem;
+        font-weight: 700;
+        color: #1e293b;
+        margin-top: 0.88rem;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body p,
+      .help-workflow-body li {
+        color: var(--wf-muted);
+        line-height: 1.67;
+      }
+
+      .help-workflow-body ol,
+      .help-workflow-body ul {
+        margin-left: 1.2rem;
+      }
+
+      .help-workflow-body code {
+        background: #eef2ff;
+        color: #3730a3;
+        border: 1px solid #c7d2fe;
+        padding: 0.1rem 0.35rem;
+        border-radius: 0.3rem;
+        font-size: 0.86em;
+      }
+
+      .wf-mobile-toc {
+        margin-top: 0.95rem;
+      }
+
+      @media (min-width: 1024px) {
+        .wf-layout {
+          grid-template-columns: 270px minmax(0, 1fr);
+          align-items: start;
+        }
+
+        .wf-sidebar {
+          position: sticky;
+          top: 1rem;
+        }
+      }
+
+      @media (max-width: 1023px) {
+        .wf-sidebar .wf-panel-section:nth-child(1) {
+          display: none;
+        }
+      }
+    </style>
+</head>
+<body class="flex flex-col min-h-screen">
+    <div id="header-container"></div>
+    <main class="flex-grow">
+      <div class="wf-shell">
+        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <section class="wf-hero">
+          <p class="wf-kicker">Workflow Guide</p>
+          <h1 class="wf-title">Build and Maintain Team Roster</h1>
+          <p class="wf-summary">Use this workflow to keep your team roster accurate and parent access connected.</p>
+          <div class="wf-meta-row">
+            <span class="wf-meta-pill">4 min read</span>
+            <span class="wf-meta-pill">Updated from live product pages</span>
+          </div>
+        </section>
+
+        <div class="wf-layout">
+          <aside class="wf-sidebar wf-panel">
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">On this page</h2>
+              <nav id="workflow-toc" class="wf-toc"></nav>
+            </section>
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">Who can use this</h2>
+              <div class="wf-roles"><span class="wf-role-chip">Parent</span> <span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span></div>
+            </section>
+          </aside>
+
+          <article class="wf-panel wf-content">
+            <div id="workflow-mobile-toc" class="wf-mobile-toc"></div>
+            <div class="help-workflow-body"><h2 id="overview">Overview</h2>
+<p>Use this workflow to keep your team roster accurate and parent access connected.</p>
+<p>You can:</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Add players and jersey numbers.</li>
+<li>Update player details.</li>
+<li>Deactivate players without losing history, then reactivate them later.</li>
+<li>Link parents to active players and send invites.</li>
+</ul>
+<h2 id="in-this-article">In This Article</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Who should run this workflow.</li>
+<li>What to prepare before you start.</li>
+<li>How to choose the right roster action.</li>
+<li>Step-by-step roster and parent invite actions.</li>
+<li>How to recover from common invite or roster issues.</li>
+</ul>
+<h2 id="who-is-this-for">Who Is This For</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Coach: Day-to-day roster updates and parent invites for active players.</li>
+<li>Admin: Full roster cleanup, including reactivation and parent-link fixes.</li>
+</ul>
+<h2 id="prerequisites">Prerequisites</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>A team already exists.</li>
+<li>You have full-access permissions for that team.</li>
+<li>Player names and jersey details are ready.</li>
+<li>Parent emails are ready if you plan to send email invites.</li>
+</ul>
+<h2 id="choose-your-path">Choose Your Path</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Add one player: Use <strong>Add Player</strong>.</li>
+<li>Add many players: Use <strong>Bulk AI Update</strong> with roster text or an image, then review and apply.</li>
+<li>Correct player details: Use <strong>Edit</strong> on that player row.</li>
+<li>Remove a player from active roster: Use <strong>Deactivate</strong>.</li>
+<li>Bring a player back: Use <strong>Reactivate</strong>.</li>
+<li>Link a parent: Use <strong>Invite Parent</strong> on an active player.</li>
+<li>Invite Parent is disabled: Reactivate the player first, then send the invite.</li>
+</ul>
+<h2 id="step-by-step-workflow">Step-by-Step Workflow</h2>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Open roster management and confirm you are on the correct team.</li>
+<li>Add or update players.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Single add: In <strong>Add Player</strong>, enter name and optional number/photo, then submit.</li>
+<li>Bulk update: In <strong>Bulk AI Update</strong>, upload an image and/or paste roster text. Select <strong>Process with AI</strong>, review changes, then select <strong>Apply Changes</strong>.</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Edit a player when details change.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Select <strong>Edit</strong> in the player row, update name/number/photo, then save.</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Manage active status.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Select <strong>Deactivate</strong> to remove a player from active roster while keeping stats and history.</li>
+<li>Select <strong>Reactivate</strong> when the player returns.</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Link parents and send invites.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Select <strong>Invite Parent</strong> for an active player.</li>
+<li>Choose relation, enter parent email, then send.</li>
+<li>No email available: Leave email blank to generate a shareable code/link.</li>
+<li>Existing account detected: Share the shown code/link so the parent can connect.</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Verify your updates.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Check the team roster list.</li>
+<li>Open the player page to confirm name, number, and photo.</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Parent completes the invite.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Parent opens the invite link or enters the 8-character code.</li>
+<li>If they open it on another device, they confirm the invited email and complete join.</li>
+</ul>
+<h2 id="common-questions">Common Questions</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Should I delete or deactivate a player?</li>
+<li>Use <strong>Deactivate</strong>. It keeps historical stats and reports.</li>
+</ul>
+<ul class="ml-6 list-disc space-y-1">
+<li>Can I invite a parent without email?</li>
+<li>Yes. Generate a manual code and share the signup link/code.</li>
+</ul>
+<ul class="ml-6 list-disc space-y-1">
+<li>What if the parent already has an ALL PLAYS account?</li>
+<li>Share the generated code/link from the invite modal so they can connect right away.</li>
+</ul>
+<ul class="ml-6 list-disc space-y-1">
+<li>Where do I confirm changes?</li>
+<li>Check the team roster list, then open the player page.</li>
+</ul>
+<h2 id="recovery-troubleshooting">Recovery &amp; Troubleshooting</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Invite button is disabled.</li>
+<li>Reactivate the player, then send the invite again.</li>
+</ul>
+<ul class="ml-6 list-disc space-y-1">
+<li>Parent did not receive the email.</li>
+<li>Use the fallback code or copy the signup link from the invite modal.</li>
+</ul>
+<ul class="ml-6 list-disc space-y-1">
+<li>Parent opened the invite on a different device.</li>
+<li>Have them enter the invited email on the confirmation step, then continue.</li>
+</ul>
+<ul class="ml-6 list-disc space-y-1">
+<li>Code is invalid or expired.</li>
+<li>Generate a new parent invite and share the new code.</li>
+</ul>
+<ul class="ml-6 list-disc space-y-1">
+<li>Wrong parent linked to player.</li>
+<li>Remove the parent connection from that player, then resend invite from the correct player row.</li>
+</ul>
+<ul class="ml-6 list-disc space-y-1">
+<li>Duplicate player was added.</li>
+<li>Keep the correct profile active and deactivate the duplicate.</li>
+</ul>
+<h2 id="related-workflows">Related Workflows</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><code>team-setup</code></li>
+<li><code>schedule</code></li>
+<li><code>track-game</code></li>
+<li><code>postgame</code></li>
+</ul>
+<h2 id="need-more-help">Need More Help</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Start again from <strong>Choose Your Path</strong> for the exact change you need.</li>
+<li>If an invite keeps failing, generate a fresh code and share it manually.</li>
+<li>When contacting support or another admin, include team name, player name, parent email (if used), and the exact on-screen error.</li>
+</ul></div>
+          </article>
+        </div>
+      </div>
+    </main>
+    <div id="footer-container"></div>
+    <script type="module">
+      import { checkAuth } from './js/auth.js?v=9';
+      import { renderHeader, renderFooter } from './js/utils.js?v=8';
+      renderHeader(document.getElementById('header-container'), null);
+      renderFooter(document.getElementById('footer-container'));
+      checkAuth((user) => {
+        renderHeader(document.getElementById('header-container'), user);
+      });
+    </script>
+    <script>
+      (function() {
+        const headings = Array.from(document.querySelectorAll('.help-workflow-body h2[id]'));
+        const toc = document.getElementById('workflow-toc');
+        const mobileToc = document.getElementById('workflow-mobile-toc');
+        if (!toc || !headings.length) return;
+
+        const links = headings.map((h) => {
+          const a = document.createElement('a');
+          a.href = '#' + h.id;
+          a.textContent = h.textContent || h.id;
+          toc.appendChild(a);
+          return a;
+        });
+
+        if (mobileToc && window.innerWidth < 1024) {
+          const wrapper = document.createElement('details');
+          wrapper.className = 'wf-panel-section wf-panel';
+          wrapper.style.marginBottom = '0.95rem';
+          wrapper.style.padding = '0.8rem 1rem';
+          const summary = document.createElement('summary');
+          summary.textContent = 'Jump to section';
+          summary.style.cursor = 'pointer';
+          summary.style.fontWeight = '700';
+          summary.style.color = '#0f172a';
+          const list = toc.cloneNode(true);
+          list.style.marginTop = '0.6rem';
+          wrapper.appendChild(summary);
+          wrapper.appendChild(list);
+          mobileToc.appendChild(wrapper);
+        }
+
+        const sectionById = new Map(headings.map((h) => [h.id, h]));
+        const setActive = () => {
+          let active = headings[0];
+          for (const h of headings) {
+            if (h.getBoundingClientRect().top <= 140) active = h;
+          }
+          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+        };
+
+        window.addEventListener('scroll', setActive, { passive: true });
+        setActive();
+      })();
+    </script>
+</body>
+</html>

--- a/workflow-schedule.html
+++ b/workflow-schedule.html
@@ -1,0 +1,501 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Plan Schedule and Launch Game Flows - ALL PLAYS Help</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: {
+                50: '#eef2ff',
+                100: '#e0e7ff',
+                500: '#6366f1',
+                600: '#4f46e5',
+                700: '#4338ca',
+                800: '#3730a3',
+                900: '#312e81'
+              }
+            }
+          }
+        }
+      }
+    </script>
+    <style>
+      :root {
+        --wf-bg: #f8fafc;
+        --wf-panel: #ffffff;
+        --wf-text: #0f172a;
+        --wf-muted: #52606f;
+        --wf-accent: #4f46e5;
+        --wf-accent-soft: #e0e7ff;
+        --wf-border: #d9e2ec;
+      }
+
+      body {
+        background:
+          radial-gradient(circle at 85% 0%, rgba(99,102,241,0.14) 0%, rgba(248,250,252,0) 42%),
+          radial-gradient(circle at 8% 20%, rgba(67,56,202,0.10) 0%, rgba(248,250,252,0) 48%),
+          var(--wf-bg);
+        color: var(--wf-text);
+      }
+
+      .wf-shell {
+        width: min(1160px, 100%);
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+      }
+
+      .wf-back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.85rem;
+        font-weight: 700;
+        color: #4338ca;
+      }
+
+      .wf-hero {
+        margin-top: 0.75rem;
+        background: linear-gradient(140deg, #312e81 0%, #4338ca 46%, #4f46e5 100%);
+        border-radius: 1.1rem;
+        padding: 1.25rem 1.25rem 1.15rem;
+        color: #ecfeff;
+        box-shadow: 0 14px 36px rgba(15, 23, 42, 0.22);
+      }
+
+      .wf-kicker {
+        font-size: 0.73rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        opacity: 0.84;
+      }
+
+      .wf-title {
+        margin-top: 0.4rem;
+        font-size: clamp(1.75rem, 2.8vw, 2.35rem);
+        line-height: 1.15;
+        font-weight: 800;
+      }
+
+      .wf-summary {
+        margin-top: 0.75rem;
+        max-width: 60ch;
+        color: rgba(236, 254, 255, 0.95);
+        line-height: 1.58;
+      }
+
+      .wf-meta-row {
+        margin-top: 0.95rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+        align-items: center;
+      }
+
+      .wf-meta-pill {
+        display: inline-flex;
+        align-items: center;
+        font-size: 0.78rem;
+        font-weight: 700;
+        border-radius: 999px;
+        border: 1px solid rgba(236, 254, 255, 0.36);
+        background: rgba(236, 254, 255, 0.12);
+        color: #ecfeff;
+        padding: 0.24rem 0.62rem;
+      }
+
+      .wf-layout {
+        margin-top: 1rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .wf-panel {
+        background: var(--wf-panel);
+        border: 1px solid var(--wf-border);
+        border-radius: 1rem;
+        box-shadow: 0 7px 20px rgba(15, 23, 42, 0.08);
+      }
+
+      .wf-panel-section {
+        padding: 1rem;
+        border-bottom: 1px solid var(--wf-border);
+      }
+
+      .wf-panel-section:last-child {
+        border-bottom: 0;
+      }
+
+      .wf-panel-title {
+        font-size: 0.78rem;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #334155;
+        margin-bottom: 0.6rem;
+      }
+
+      .wf-role-chip {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        border: 1px solid #c7d2fe;
+        background: #eef2ff;
+        color: #3730a3;
+        padding: 0.22rem 0.66rem;
+        font-size: 0.74rem;
+        font-weight: 700;
+      }
+
+      .wf-roles {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+      }
+
+      .wf-toc {
+        display: grid;
+        gap: 0.33rem;
+      }
+
+      .wf-toc a {
+        display: block;
+        padding: 0.43rem 0.52rem;
+        border-radius: 0.55rem;
+        color: #334155;
+        font-size: 0.82rem;
+        line-height: 1.35;
+        transition: background 120ms ease, color 120ms ease;
+      }
+
+      .wf-toc a:hover {
+        background: #eef2ff;
+        color: #3730a3;
+      }
+
+      .wf-toc a.is-active {
+        background: #e0e7ff;
+        color: #312e81;
+        font-weight: 700;
+      }
+
+      .wf-content {
+        padding: 1.2rem 1.15rem;
+      }
+
+      .help-workflow-body {
+        display: grid;
+        gap: 0.45rem;
+      }
+
+      .help-workflow-body h2 {
+        font-size: 1.4rem;
+        font-weight: 800;
+        color: #1f2937;
+        margin-top: 1.25rem;
+        padding-top: 1.05rem;
+        border-top: 1px solid #dbe7f0;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body h2:first-of-type {
+        margin-top: 0.15rem;
+        padding-top: 0;
+        border-top: 0;
+      }
+
+      .help-workflow-body h3 {
+        font-size: 1.08rem;
+        font-weight: 700;
+        color: #1e293b;
+        margin-top: 0.88rem;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body p,
+      .help-workflow-body li {
+        color: var(--wf-muted);
+        line-height: 1.67;
+      }
+
+      .help-workflow-body ol,
+      .help-workflow-body ul {
+        margin-left: 1.2rem;
+      }
+
+      .help-workflow-body code {
+        background: #eef2ff;
+        color: #3730a3;
+        border: 1px solid #c7d2fe;
+        padding: 0.1rem 0.35rem;
+        border-radius: 0.3rem;
+        font-size: 0.86em;
+      }
+
+      .wf-mobile-toc {
+        margin-top: 0.95rem;
+      }
+
+      @media (min-width: 1024px) {
+        .wf-layout {
+          grid-template-columns: 270px minmax(0, 1fr);
+          align-items: start;
+        }
+
+        .wf-sidebar {
+          position: sticky;
+          top: 1rem;
+        }
+      }
+
+      @media (max-width: 1023px) {
+        .wf-sidebar .wf-panel-section:nth-child(1) {
+          display: none;
+        }
+      }
+    </style>
+</head>
+<body class="flex flex-col min-h-screen">
+    <div id="header-container"></div>
+    <main class="flex-grow">
+      <div class="wf-shell">
+        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <section class="wf-hero">
+          <p class="wf-kicker">Workflow Guide</p>
+          <h1 class="wf-title">Plan Schedule and Launch Game Flows</h1>
+          <p class="wf-summary">Use this workflow to publish reliable games and practices, then launch game-day tools from the schedule.</p>
+          <div class="wf-meta-row">
+            <span class="wf-meta-pill">5 min read</span>
+            <span class="wf-meta-pill">Updated from live product pages</span>
+          </div>
+        </section>
+
+        <div class="wf-layout">
+          <aside class="wf-sidebar wf-panel">
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">On this page</h2>
+              <nav id="workflow-toc" class="wf-toc"></nav>
+            </section>
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">Who can use this</h2>
+              <div class="wf-roles"><span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span></div>
+            </section>
+          </aside>
+
+          <article class="wf-panel wf-content">
+            <div id="workflow-mobile-toc" class="wf-mobile-toc"></div>
+            <div class="help-workflow-body"><h2 id="overview">Overview</h2>
+<p>Use this workflow to publish reliable games and practices, then launch game-day tools from the schedule.</p>
+<p>You will use:</p>
+<ul class="ml-6 list-disc space-y-1">
+<li><code>edit-schedule.html</code> to create and manage events.</li>
+<li><code>game-plan.html</code> to prepare lineups.</li>
+<li><code>team.html</code> and <code>calendar.html</code> to review, share, and export.</li>
+<li><code>live-game.html</code> for live viewing and replay access.</li>
+</ul>
+<h2 id="in-this-article">In This Article</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Set up schedule inputs and external calendar links.</li>
+<li>Add games with key details, assignments, and stat config.</li>
+<li>Add one-time or recurring practices.</li>
+<li>Edit one date or an entire recurring series safely.</li>
+<li>Launch planning, tracking, command center, and live tools.</li>
+<li>Share live links and find replay/report links.</li>
+<li>Verify availability visibility and export <code>.ics</code> files.</li>
+</ul>
+<h2 id="who-is-this-for">Who Is This For</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Coach: Publish weekly events, prep upcoming games, and launch tracking quickly.</li>
+<li>Admin: Maintain calendar feeds, clean recurring data, and keep schedule quality high.</li>
+</ul>
+<h2 id="prerequisites">Prerequisites</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Your team is created and accessible.</li>
+<li>You are signed in with coach/admin manage access for that team.</li>
+<li>Roster and game details are ready (date, time, location, opponent).</li>
+<li>If importing calendars, you have valid <code>.ics</code> URLs.</li>
+</ul>
+<h2 id="choose-your-path">Choose Your Path</h2>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Build or update the full schedule: start at Step 1 and continue through Step 7.</li>
+<li>Import from another calendar: complete Step 2, then Step 7 for any games you need to track.</li>
+<li>Prepare game execution: use Step 8 and Step 9.</li>
+<li>Share live or replay access with families: use Step 10.</li>
+<li>Validate final visibility and export views: use Step 11.</li>
+</ol>
+<h2 id="step-by-step-workflow">Step-by-Step Workflow</h2>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Open <code>edit-schedule.html</code> for the correct team.</li>
+</ol>
+<p>Start in <code>All Upcoming</code>. Confirm the team name before you edit.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Add or verify external calendars in <strong>Calendar Links</strong>.</li>
+</ol>
+<p>Select <code>+ Add Calendar</code>, paste a valid <code>.ics</code> URL, and save.</p>
+<p>Coach focus: add feeds you rely on.</p>
+<p>Admin focus: remove outdated feeds and keep trusted sources.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Add games in the <strong>Game</strong> tab.</li>
+</ol>
+<p>Enter <code>Date &amp; Time</code>, <code>Opponent</code>, <code>Location</code>, and <code>Home/Away</code>.</p>
+<p>Add useful optional data: <code>Kit Color</code>, <code>Season Label</code>, <code>Competition Type</code>, <code>Arrival Time</code>, notes, and assignments.</p>
+<p>Select the stat config you plan to use, then save.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Add practices in the <strong>Practice</strong> tab.</li>
+</ol>
+<p>Set title, start/end, location, and notes.</p>
+<p>For recurring practices, set frequency, interval, days, and end rule (<code>Never</code>, <code>On date</code>, or <code>After occurrences</code>).</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Review the schedule list before launch.</li>
+</ol>
+<p>Use <code>Show Practices</code> and filter chips: <code>All Upcoming</code>, <code>Upcoming Games</code>, <code>Upcoming Practices</code>, <code>Past Events</code>.</p>
+<p>Confirm events appear in the right place.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Manage recurring changes safely.</li>
+</ol>
+<p>For recurring practices, open <strong>Manage</strong> and choose the correct scope:</p>
+<p><code>Edit this date</code>, <code>Edit entire series</code>, <code>Cancel this date</code>, or <code>Cancel entire series</code>.</p>
+<p>If a one-date override is no longer needed, use <code>Revert to Series</code>.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Convert imported game events to tracked games when needed.</li>
+</ol>
+<p>On calendar-sourced games, select <code>Track</code> to create a scheduled game record.</p>
+<p>Do this before full tracking and availability workflows.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Build the pregame plan from schedule.</li>
+</ol>
+<p>Open <code>Game Plan</code> for that game (<code>game-plan.html</code>).</p>
+<p>Choose formation, set periods and sub times, build lineups, and save.</p>
+<p>Coach focus: lineup balance and substitutions.</p>
+<p>Admin focus: verify game selection and detail alignment.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Launch game-day execution from schedule actions.</li>
+</ol>
+<p>Use <code>Track</code> for stat tracking.</p>
+<p>For basketball configs, choose a mode: <code>Standard</code>, <code>Beta</code>, <code>Live Broadcast Tracker</code>, or <code>Photo Score Sheet</code>.</p>
+<p>Use <code>Command Center</code> for game-day operations.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Launch live watch and sharing.</li>
+</ol>
+<p>Use <code>View Live</code> or <code>Live Now</code> to open <code>live-game.html</code>.</p>
+<p>Use <code>Share</code> on schedule or team cards to send the live watch link.</p>
+<p>After the game, use <code>Watch Replay</code> or <code>Report</code> links.</p>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Validate visibility and export.</li>
+</ol>
+<p>In <code>team.html</code>, review list and calendar views and check live/replay/report links.</p>
+<p>In <code>calendar.html</code>, use filters (view, range, type, team), verify availability status, and export <code>.ics</code> when needed.</p>
+<h2 id="common-questions">Common Questions</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><strong>When should I import a calendar vs add games manually?</strong></li>
+</ul>
+<p>Import for bulk visibility. Add manually when you need full game metadata and immediate tracking readiness.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li><strong>Why can’t I respond to availability on some events?</strong></li>
+</ul>
+<p>Calendar-only events must be tracked into the schedule first.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li><strong>How do I avoid breaking a recurring practice series?</strong></li>
+</ul>
+<p>Choose the action scope carefully: one date or entire series.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li><strong>Which basketball tracker mode should I use?</strong></li>
+</ul>
+<p><code>Standard</code> for basic flow, <code>Beta</code> for advanced flow, <code>Live Broadcast Tracker</code> for broadcast mode, and <code>Photo Score Sheet</code> for sheet-first entry.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li><strong>What is the fastest way to share with families?</strong></li>
+</ul>
+<p>Use <code>Share</code> from schedule or team cards.</p>
+<h2 id="recovery-troubleshooting">Recovery &amp; Troubleshooting</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Event missing after save: check filters, enable <code>Show Practices</code>, and confirm <code>Upcoming</code> vs <code>Past</code>.</li>
+<li>Wrong recurring dates changed: reopen <strong>Manage</strong>, apply the correct scope, and use <code>Revert to Series</code> when needed.</li>
+<li>Wrong tracker mode opened: verify the game stat config, then run <code>Track</code> again and choose the correct mode.</li>
+<li>Live link not useful yet: open <code>View Live</code> first, confirm game status, then resend with <code>Share</code>.</li>
+<li><code>.ics</code> export missing events: adjust filters, then export again.</li>
+<li>Access denied: confirm you are signed in with coach/admin manage access to that team.</li>
+</ul>
+<h2 id="related-workflows">Related Workflows</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><code>team-setup</code>: Create and configure the team before scheduling.</li>
+<li><code>roster</code>: Confirm players before arrival and availability work.</li>
+<li><code>game-day</code>: Run sideline operations after publishing schedule.</li>
+<li><code>track-game</code>: Capture stats and outcomes during play.</li>
+<li><code>communication</code>: Send updates, cancellations, and links.</li>
+<li><code>live-watch-replay</code>: Manage live audience and replay access.</li>
+</ul>
+<h2 id="need-more-help">Need More Help</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Reproduce the issue once.</li>
+<li>Note the page: <code>edit-schedule.html</code>, <code>calendar.html</code>, <code>team.html</code>, <code>game-plan.html</code>, or <code>live-game.html</code>.</li>
+<li>Include team name, event date/time, and opponent.</li>
+<li>Include the exact action clicked (<code>Track</code>, <code>Command Center</code>, <code>Share</code>, <code>Watch Replay</code>, or recurring manage action) and what happened.</li>
+</ul></div>
+          </article>
+        </div>
+      </div>
+    </main>
+    <div id="footer-container"></div>
+    <script type="module">
+      import { checkAuth } from './js/auth.js?v=9';
+      import { renderHeader, renderFooter } from './js/utils.js?v=8';
+      renderHeader(document.getElementById('header-container'), null);
+      renderFooter(document.getElementById('footer-container'));
+      checkAuth((user) => {
+        renderHeader(document.getElementById('header-container'), user);
+      });
+    </script>
+    <script>
+      (function() {
+        const headings = Array.from(document.querySelectorAll('.help-workflow-body h2[id]'));
+        const toc = document.getElementById('workflow-toc');
+        const mobileToc = document.getElementById('workflow-mobile-toc');
+        if (!toc || !headings.length) return;
+
+        const links = headings.map((h) => {
+          const a = document.createElement('a');
+          a.href = '#' + h.id;
+          a.textContent = h.textContent || h.id;
+          toc.appendChild(a);
+          return a;
+        });
+
+        if (mobileToc && window.innerWidth < 1024) {
+          const wrapper = document.createElement('details');
+          wrapper.className = 'wf-panel-section wf-panel';
+          wrapper.style.marginBottom = '0.95rem';
+          wrapper.style.padding = '0.8rem 1rem';
+          const summary = document.createElement('summary');
+          summary.textContent = 'Jump to section';
+          summary.style.cursor = 'pointer';
+          summary.style.fontWeight = '700';
+          summary.style.color = '#0f172a';
+          const list = toc.cloneNode(true);
+          list.style.marginTop = '0.6rem';
+          wrapper.appendChild(summary);
+          wrapper.appendChild(list);
+          mobileToc.appendChild(wrapper);
+        }
+
+        const sectionById = new Map(headings.map((h) => [h.id, h]));
+        const setActive = () => {
+          let active = headings[0];
+          for (const h of headings) {
+            if (h.getBoundingClientRect().top <= 140) active = h;
+          }
+          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+        };
+
+        window.addEventListener('scroll', setActive, { passive: true });
+        setActive();
+      })();
+    </script>
+</body>
+</html>

--- a/workflow-team-setup.html
+++ b/workflow-team-setup.html
@@ -1,0 +1,517 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Create Team Foundation and Staff Access - ALL PLAYS Help</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: {
+                50: '#eef2ff',
+                100: '#e0e7ff',
+                500: '#6366f1',
+                600: '#4f46e5',
+                700: '#4338ca',
+                800: '#3730a3',
+                900: '#312e81'
+              }
+            }
+          }
+        }
+      }
+    </script>
+    <style>
+      :root {
+        --wf-bg: #f8fafc;
+        --wf-panel: #ffffff;
+        --wf-text: #0f172a;
+        --wf-muted: #52606f;
+        --wf-accent: #4f46e5;
+        --wf-accent-soft: #e0e7ff;
+        --wf-border: #d9e2ec;
+      }
+
+      body {
+        background:
+          radial-gradient(circle at 85% 0%, rgba(99,102,241,0.14) 0%, rgba(248,250,252,0) 42%),
+          radial-gradient(circle at 8% 20%, rgba(67,56,202,0.10) 0%, rgba(248,250,252,0) 48%),
+          var(--wf-bg);
+        color: var(--wf-text);
+      }
+
+      .wf-shell {
+        width: min(1160px, 100%);
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+      }
+
+      .wf-back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.85rem;
+        font-weight: 700;
+        color: #4338ca;
+      }
+
+      .wf-hero {
+        margin-top: 0.75rem;
+        background: linear-gradient(140deg, #312e81 0%, #4338ca 46%, #4f46e5 100%);
+        border-radius: 1.1rem;
+        padding: 1.25rem 1.25rem 1.15rem;
+        color: #ecfeff;
+        box-shadow: 0 14px 36px rgba(15, 23, 42, 0.22);
+      }
+
+      .wf-kicker {
+        font-size: 0.73rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        opacity: 0.84;
+      }
+
+      .wf-title {
+        margin-top: 0.4rem;
+        font-size: clamp(1.75rem, 2.8vw, 2.35rem);
+        line-height: 1.15;
+        font-weight: 800;
+      }
+
+      .wf-summary {
+        margin-top: 0.75rem;
+        max-width: 60ch;
+        color: rgba(236, 254, 255, 0.95);
+        line-height: 1.58;
+      }
+
+      .wf-meta-row {
+        margin-top: 0.95rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+        align-items: center;
+      }
+
+      .wf-meta-pill {
+        display: inline-flex;
+        align-items: center;
+        font-size: 0.78rem;
+        font-weight: 700;
+        border-radius: 999px;
+        border: 1px solid rgba(236, 254, 255, 0.36);
+        background: rgba(236, 254, 255, 0.12);
+        color: #ecfeff;
+        padding: 0.24rem 0.62rem;
+      }
+
+      .wf-layout {
+        margin-top: 1rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .wf-panel {
+        background: var(--wf-panel);
+        border: 1px solid var(--wf-border);
+        border-radius: 1rem;
+        box-shadow: 0 7px 20px rgba(15, 23, 42, 0.08);
+      }
+
+      .wf-panel-section {
+        padding: 1rem;
+        border-bottom: 1px solid var(--wf-border);
+      }
+
+      .wf-panel-section:last-child {
+        border-bottom: 0;
+      }
+
+      .wf-panel-title {
+        font-size: 0.78rem;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #334155;
+        margin-bottom: 0.6rem;
+      }
+
+      .wf-role-chip {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        border: 1px solid #c7d2fe;
+        background: #eef2ff;
+        color: #3730a3;
+        padding: 0.22rem 0.66rem;
+        font-size: 0.74rem;
+        font-weight: 700;
+      }
+
+      .wf-roles {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+      }
+
+      .wf-toc {
+        display: grid;
+        gap: 0.33rem;
+      }
+
+      .wf-toc a {
+        display: block;
+        padding: 0.43rem 0.52rem;
+        border-radius: 0.55rem;
+        color: #334155;
+        font-size: 0.82rem;
+        line-height: 1.35;
+        transition: background 120ms ease, color 120ms ease;
+      }
+
+      .wf-toc a:hover {
+        background: #eef2ff;
+        color: #3730a3;
+      }
+
+      .wf-toc a.is-active {
+        background: #e0e7ff;
+        color: #312e81;
+        font-weight: 700;
+      }
+
+      .wf-content {
+        padding: 1.2rem 1.15rem;
+      }
+
+      .help-workflow-body {
+        display: grid;
+        gap: 0.45rem;
+      }
+
+      .help-workflow-body h2 {
+        font-size: 1.4rem;
+        font-weight: 800;
+        color: #1f2937;
+        margin-top: 1.25rem;
+        padding-top: 1.05rem;
+        border-top: 1px solid #dbe7f0;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body h2:first-of-type {
+        margin-top: 0.15rem;
+        padding-top: 0;
+        border-top: 0;
+      }
+
+      .help-workflow-body h3 {
+        font-size: 1.08rem;
+        font-weight: 700;
+        color: #1e293b;
+        margin-top: 0.88rem;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body p,
+      .help-workflow-body li {
+        color: var(--wf-muted);
+        line-height: 1.67;
+      }
+
+      .help-workflow-body ol,
+      .help-workflow-body ul {
+        margin-left: 1.2rem;
+      }
+
+      .help-workflow-body code {
+        background: #eef2ff;
+        color: #3730a3;
+        border: 1px solid #c7d2fe;
+        padding: 0.1rem 0.35rem;
+        border-radius: 0.3rem;
+        font-size: 0.86em;
+      }
+
+      .wf-mobile-toc {
+        margin-top: 0.95rem;
+      }
+
+      @media (min-width: 1024px) {
+        .wf-layout {
+          grid-template-columns: 270px minmax(0, 1fr);
+          align-items: start;
+        }
+
+        .wf-sidebar {
+          position: sticky;
+          top: 1rem;
+        }
+      }
+
+      @media (max-width: 1023px) {
+        .wf-sidebar .wf-panel-section:nth-child(1) {
+          display: none;
+        }
+      }
+    </style>
+</head>
+<body class="flex flex-col min-h-screen">
+    <div id="header-container"></div>
+    <main class="flex-grow">
+      <div class="wf-shell">
+        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <section class="wf-hero">
+          <p class="wf-kicker">Workflow Guide</p>
+          <h1 class="wf-title">Create Team Foundation and Staff Access</h1>
+          <p class="wf-summary">Set up your team foundation first, then grant staff access.</p>
+          <div class="wf-meta-row">
+            <span class="wf-meta-pill">4 min read</span>
+            <span class="wf-meta-pill">Updated from live product pages</span>
+          </div>
+        </section>
+
+        <div class="wf-layout">
+          <aside class="wf-sidebar wf-panel">
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">On this page</h2>
+              <nav id="workflow-toc" class="wf-toc"></nav>
+            </section>
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">Who can use this</h2>
+              <div class="wf-roles"><span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span></div>
+            </section>
+          </aside>
+
+          <article class="wf-panel wf-content">
+            <div id="workflow-mobile-toc" class="wf-mobile-toc"></div>
+            <div class="help-workflow-body"><h2 id="overview">Overview</h2>
+<p>Set up your team foundation first, then grant staff access.</p>
+<p>This workflow helps you create or update a team, set core team details, and manage coach/admin invites.</p>
+<h2 id="in-this-article">In This Article</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>When to create a new team vs update an existing team</li>
+<li>How to complete team foundation settings in one pass</li>
+<li>How to invite staff and handle invite delivery issues</li>
+<li>How to verify what families and players will see</li>
+<li>How to recover from common setup and access problems</li>
+</ul>
+<h2 id="who-is-this-for">Who Is This For</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Coach: Set up team identity and invite assistant coaches/admins</li>
+<li>Admin: Standardize team setup, visibility, and staff access across teams</li>
+</ul>
+<h2 id="prerequisites">Prerequisites</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>You are signed in</li>
+<li>You have full team management permissions</li>
+<li>You already chose the team name and sport</li>
+<li>You have staff emails ready if you plan to invite coaches/admins</li>
+</ul>
+<h2 id="choose-your-path">Choose Your Path</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Create a new team: Open <strong>My Teams</strong> (<code>dashboard.html</code>) and select <strong>Create New Team</strong></li>
+<li>Update an existing team: Open <strong>My Teams</strong>, select the team, then choose <strong>Edit</strong></li>
+<li>Manage staff access only: Open <strong>Edit Team</strong> and go to <strong>Admin Access</strong></li>
+</ul>
+<h2 id="step-by-step-workflow">Step-by-Step Workflow</h2>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Open the team editor.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>New team: <code>dashboard.html</code> -&gt; <strong>Create New Team</strong></li>
+<li>Existing team: <code>dashboard.html</code> -&gt; team card -&gt; <strong>Edit</strong></li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Confirm edit access.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>If you can see the full form and <strong>Save Team</strong>, continue.</li>
+<li>If you are blocked or redirected, ask the team owner to add you as an admin.</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Complete team identity.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Enter <strong>Team Name</strong></li>
+<li>Select <strong>Sport</strong></li>
+<li>Add <strong>Description</strong> (recommended)</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Add communication and location details.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Enter <strong>ZIP Code</strong></li>
+<li>Enter <strong>Notification Email</strong></li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Add links families will use.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Add <strong>League Link</strong> for standings</li>
+<li>Add <strong>Live Stream</strong> (YouTube or Twitch URL)</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Set visibility.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Enable <strong>Public Team</strong> to make the team discoverable in Browse Teams</li>
+<li>Disable it for invite/direct-link access only</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Invite coach/admin staff.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>In <strong>Admin Access</strong>, select <strong>+ Add Admin</strong></li>
+<li>Enter email, then select <strong>Send Invite</strong></li>
+<li>Use <strong>Remove</strong> to remove an added person before saving</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Handle invite outcomes.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>If the email sends, no extra action is required.</li>
+<li>If email delivery fails, share the provided code or signup link.</li>
+<li>For a new team, queued invites are finalized when you select <strong>Save Team</strong>.</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Save and return.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Select <strong>Save Team</strong></li>
+<li>Confirm you return to <strong>My Teams</strong> and can open the team</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Verify the team page.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Confirm name, sport, and description</li>
+<li>Confirm league and stream links are visible and open correctly</li>
+<li>Confirm behavior matches the <strong>Public Team</strong> setting</li>
+</ul>
+<h2 id="common-questions">Common Questions</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>How do I create a team from scratch?</li>
+</ul>
+<p>Open <strong>My Teams</strong> and select <strong>Create New Team</strong>.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Why can I view a team but not edit it?</li>
+</ul>
+<p>You likely have limited access. Ask an owner/admin to grant admin rights.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>When are admin invites sent for a brand-new team?</li>
+</ul>
+<p>Invites are processed when you save the newly created team.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Can I make a team private later?</li>
+</ul>
+<p>Yes. Open <strong>Edit Team</strong>, update <strong>Public Team</strong>, then save.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Where do I verify what families will see?</li>
+</ul>
+<p>Open the team page and check identity, league, and stream links.</p>
+<h2 id="recovery-troubleshooting">Recovery &amp; Troubleshooting</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Save fails:</li>
+</ul>
+<p>Check required fields, especially <strong>Team Name</strong> and <strong>Sport</strong>, then try again.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Stream link does not work:</li>
+</ul>
+<p>Paste a full YouTube/Twitch URL and save again.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Team does not appear in Browse Teams:</li>
+</ul>
+<p>Enable <strong>Public Team</strong> in <strong>Edit Team</strong>, save, then refresh.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Staff member did not receive invite email:</li>
+</ul>
+<p>Resend from <strong>Admin Access</strong> or share the code/signup link manually.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>You cannot edit even though you are staff:</li>
+</ul>
+<p>Ask the owner to remove and re-add your admin email, then sign in again.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>Need a backup invite path:</li>
+</ul>
+<p>Use <code>profile.html</code> to generate and copy a signup code/link, then share it directly.</p>
+<h2 id="related-workflows">Related Workflows</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><code>choose-home-dashboard</code>: Start from the correct landing page before team operations</li>
+<li><code>roster</code>: Add players after team foundation is complete</li>
+<li><code>schedule</code>: Add events and game timing after team setup</li>
+<li><code>admin-ops</code>: Handle broader organization-level admin tasks</li>
+</ul>
+<h2 id="need-more-help">Need More Help</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Re-open <strong>My Teams</strong> and repeat this workflow step by step.</li>
+<li>If access still fails, contact your team owner/admin with your account email and team name.</li>
+<li>If invite delivery keeps failing, share the signup code/link manually and confirm the recipient used the same email.</li>
+</ul></div>
+          </article>
+        </div>
+      </div>
+    </main>
+    <div id="footer-container"></div>
+    <script type="module">
+      import { checkAuth } from './js/auth.js?v=9';
+      import { renderHeader, renderFooter } from './js/utils.js?v=8';
+      renderHeader(document.getElementById('header-container'), null);
+      renderFooter(document.getElementById('footer-container'));
+      checkAuth((user) => {
+        renderHeader(document.getElementById('header-container'), user);
+      });
+    </script>
+    <script>
+      (function() {
+        const headings = Array.from(document.querySelectorAll('.help-workflow-body h2[id]'));
+        const toc = document.getElementById('workflow-toc');
+        const mobileToc = document.getElementById('workflow-mobile-toc');
+        if (!toc || !headings.length) return;
+
+        const links = headings.map((h) => {
+          const a = document.createElement('a');
+          a.href = '#' + h.id;
+          a.textContent = h.textContent || h.id;
+          toc.appendChild(a);
+          return a;
+        });
+
+        if (mobileToc && window.innerWidth < 1024) {
+          const wrapper = document.createElement('details');
+          wrapper.className = 'wf-panel-section wf-panel';
+          wrapper.style.marginBottom = '0.95rem';
+          wrapper.style.padding = '0.8rem 1rem';
+          const summary = document.createElement('summary');
+          summary.textContent = 'Jump to section';
+          summary.style.cursor = 'pointer';
+          summary.style.fontWeight = '700';
+          summary.style.color = '#0f172a';
+          const list = toc.cloneNode(true);
+          list.style.marginTop = '0.6rem';
+          wrapper.appendChild(summary);
+          wrapper.appendChild(list);
+          mobileToc.appendChild(wrapper);
+        }
+
+        const sectionById = new Map(headings.map((h) => [h.id, h]));
+        const setActive = () => {
+          let active = headings[0];
+          for (const h of headings) {
+            if (h.getBoundingClientRect().top <= 140) active = h;
+          }
+          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+        };
+
+        window.addEventListener('scroll', setActive, { passive: true });
+        setActive();
+      })();
+    </script>
+</body>
+</html>

--- a/workflow-track-game.html
+++ b/workflow-track-game.html
@@ -1,0 +1,486 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Track Live Game Stats by Mode - ALL PLAYS Help</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+    <script>
+      tailwind.config = {
+        theme: {
+          extend: {
+            colors: {
+              primary: {
+                50: '#eef2ff',
+                100: '#e0e7ff',
+                500: '#6366f1',
+                600: '#4f46e5',
+                700: '#4338ca',
+                800: '#3730a3',
+                900: '#312e81'
+              }
+            }
+          }
+        }
+      }
+    </script>
+    <style>
+      :root {
+        --wf-bg: #f8fafc;
+        --wf-panel: #ffffff;
+        --wf-text: #0f172a;
+        --wf-muted: #52606f;
+        --wf-accent: #4f46e5;
+        --wf-accent-soft: #e0e7ff;
+        --wf-border: #d9e2ec;
+      }
+
+      body {
+        background:
+          radial-gradient(circle at 85% 0%, rgba(99,102,241,0.14) 0%, rgba(248,250,252,0) 42%),
+          radial-gradient(circle at 8% 20%, rgba(67,56,202,0.10) 0%, rgba(248,250,252,0) 48%),
+          var(--wf-bg);
+        color: var(--wf-text);
+      }
+
+      .wf-shell {
+        width: min(1160px, 100%);
+        margin: 0 auto;
+        padding: 1.5rem 1rem 3rem;
+      }
+
+      .wf-back-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-size: 0.85rem;
+        font-weight: 700;
+        color: #4338ca;
+      }
+
+      .wf-hero {
+        margin-top: 0.75rem;
+        background: linear-gradient(140deg, #312e81 0%, #4338ca 46%, #4f46e5 100%);
+        border-radius: 1.1rem;
+        padding: 1.25rem 1.25rem 1.15rem;
+        color: #ecfeff;
+        box-shadow: 0 14px 36px rgba(15, 23, 42, 0.22);
+      }
+
+      .wf-kicker {
+        font-size: 0.73rem;
+        font-weight: 700;
+        letter-spacing: 0.08em;
+        text-transform: uppercase;
+        opacity: 0.84;
+      }
+
+      .wf-title {
+        margin-top: 0.4rem;
+        font-size: clamp(1.75rem, 2.8vw, 2.35rem);
+        line-height: 1.15;
+        font-weight: 800;
+      }
+
+      .wf-summary {
+        margin-top: 0.75rem;
+        max-width: 60ch;
+        color: rgba(236, 254, 255, 0.95);
+        line-height: 1.58;
+      }
+
+      .wf-meta-row {
+        margin-top: 0.95rem;
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.65rem;
+        align-items: center;
+      }
+
+      .wf-meta-pill {
+        display: inline-flex;
+        align-items: center;
+        font-size: 0.78rem;
+        font-weight: 700;
+        border-radius: 999px;
+        border: 1px solid rgba(236, 254, 255, 0.36);
+        background: rgba(236, 254, 255, 0.12);
+        color: #ecfeff;
+        padding: 0.24rem 0.62rem;
+      }
+
+      .wf-layout {
+        margin-top: 1rem;
+        display: grid;
+        gap: 1rem;
+      }
+
+      .wf-panel {
+        background: var(--wf-panel);
+        border: 1px solid var(--wf-border);
+        border-radius: 1rem;
+        box-shadow: 0 7px 20px rgba(15, 23, 42, 0.08);
+      }
+
+      .wf-panel-section {
+        padding: 1rem;
+        border-bottom: 1px solid var(--wf-border);
+      }
+
+      .wf-panel-section:last-child {
+        border-bottom: 0;
+      }
+
+      .wf-panel-title {
+        font-size: 0.78rem;
+        font-weight: 800;
+        text-transform: uppercase;
+        letter-spacing: 0.08em;
+        color: #334155;
+        margin-bottom: 0.6rem;
+      }
+
+      .wf-role-chip {
+        display: inline-flex;
+        align-items: center;
+        border-radius: 999px;
+        border: 1px solid #c7d2fe;
+        background: #eef2ff;
+        color: #3730a3;
+        padding: 0.22rem 0.66rem;
+        font-size: 0.74rem;
+        font-weight: 700;
+      }
+
+      .wf-roles {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.4rem;
+      }
+
+      .wf-toc {
+        display: grid;
+        gap: 0.33rem;
+      }
+
+      .wf-toc a {
+        display: block;
+        padding: 0.43rem 0.52rem;
+        border-radius: 0.55rem;
+        color: #334155;
+        font-size: 0.82rem;
+        line-height: 1.35;
+        transition: background 120ms ease, color 120ms ease;
+      }
+
+      .wf-toc a:hover {
+        background: #eef2ff;
+        color: #3730a3;
+      }
+
+      .wf-toc a.is-active {
+        background: #e0e7ff;
+        color: #312e81;
+        font-weight: 700;
+      }
+
+      .wf-content {
+        padding: 1.2rem 1.15rem;
+      }
+
+      .help-workflow-body {
+        display: grid;
+        gap: 0.45rem;
+      }
+
+      .help-workflow-body h2 {
+        font-size: 1.4rem;
+        font-weight: 800;
+        color: #1f2937;
+        margin-top: 1.25rem;
+        padding-top: 1.05rem;
+        border-top: 1px solid #dbe7f0;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body h2:first-of-type {
+        margin-top: 0.15rem;
+        padding-top: 0;
+        border-top: 0;
+      }
+
+      .help-workflow-body h3 {
+        font-size: 1.08rem;
+        font-weight: 700;
+        color: #1e293b;
+        margin-top: 0.88rem;
+        scroll-margin-top: 6rem;
+      }
+
+      .help-workflow-body p,
+      .help-workflow-body li {
+        color: var(--wf-muted);
+        line-height: 1.67;
+      }
+
+      .help-workflow-body ol,
+      .help-workflow-body ul {
+        margin-left: 1.2rem;
+      }
+
+      .help-workflow-body code {
+        background: #eef2ff;
+        color: #3730a3;
+        border: 1px solid #c7d2fe;
+        padding: 0.1rem 0.35rem;
+        border-radius: 0.3rem;
+        font-size: 0.86em;
+      }
+
+      .wf-mobile-toc {
+        margin-top: 0.95rem;
+      }
+
+      @media (min-width: 1024px) {
+        .wf-layout {
+          grid-template-columns: 270px minmax(0, 1fr);
+          align-items: start;
+        }
+
+        .wf-sidebar {
+          position: sticky;
+          top: 1rem;
+        }
+      }
+
+      @media (max-width: 1023px) {
+        .wf-sidebar .wf-panel-section:nth-child(1) {
+          display: none;
+        }
+      }
+    </style>
+</head>
+<body class="flex flex-col min-h-screen">
+    <div id="header-container"></div>
+    <main class="flex-grow">
+      <div class="wf-shell">
+        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <section class="wf-hero">
+          <p class="wf-kicker">Workflow Guide</p>
+          <h1 class="wf-title">Track Live Game Stats by Mode</h1>
+          <p class="wf-summary">Use this workflow to track a game from start to finish and publish an accurate game report.</p>
+          <div class="wf-meta-row">
+            <span class="wf-meta-pill">4 min read</span>
+            <span class="wf-meta-pill">Updated from live product pages</span>
+          </div>
+        </section>
+
+        <div class="wf-layout">
+          <aside class="wf-sidebar wf-panel">
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">On this page</h2>
+              <nav id="workflow-toc" class="wf-toc"></nav>
+            </section>
+            <section class="wf-panel-section">
+              <h2 class="wf-panel-title">Who can use this</h2>
+              <div class="wf-roles"><span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span></div>
+            </section>
+          </aside>
+
+          <article class="wf-panel wf-content">
+            <div id="workflow-mobile-toc" class="wf-mobile-toc"></div>
+            <div class="help-workflow-body"><h2 id="overview">Overview</h2>
+<p>Use this workflow to track a game from start to finish and publish an accurate game report.</p>
+<p>You can choose the tracker mode that fits your situation, capture events during play, then complete the game with final scores and summary details.</p>
+<h2 id="in-this-article">In This Article</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Who should use this workflow.</li>
+<li>What to confirm before you start.</li>
+<li>How to choose the right tracker mode.</li>
+<li>Step-by-step actions from schedule to final report.</li>
+<li>Common questions and recovery steps.</li>
+</ul>
+<h2 id="who-is-this-for">Who Is This For</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Coaches who enter live stats, manage periods, and handle substitutions.</li>
+<li>Admins who support tracking, verify final accuracy, and finalize report details.</li>
+</ul>
+<h2 id="prerequisites">Prerequisites</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>You are signed in as a coach or admin.</li>
+<li>You are opening a game event, not a practice.</li>
+<li>The game has a valid team and game context (<code>teamId</code> and <code>gameId</code>).</li>
+<li>A tracker configuration exists for the team.</li>
+</ul>
+<h2 id="choose-your-path">Choose Your Path</h2>
+<p>Use this quick guide before you start:</p>
+<ul class="ml-6 list-disc space-y-1">
+<li><strong>Standard</strong>: Use for classic manual entry with timer, team/opponent stats, and finish flow.</li>
+<li><strong>Beta</strong>: Use for sideline-focused basketball tracking with quick substitutions.</li>
+<li><strong>Live Broadcast Tracker</strong>: Use Beta-style tracking plus live chat and live-view context.</li>
+<li><strong>Photo Score Sheet</strong>: Use after the game to import final stats from a score sheet image.</li>
+</ul>
+<p>Important behavior:</p>
+<ul class="ml-6 list-disc space-y-1">
+<li>If no mode chooser appears, the game opens in the default Standard tracker.</li>
+<li>If the game is already complete, open <strong>Report</strong> instead of starting a new tracking session.</li>
+</ul>
+<h2 id="step-by-step-workflow">Step-by-Step Workflow</h2>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Open the game from schedule.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Select <strong>Track</strong> on the game card.</li>
+<li>Confirm opponent, date, and location.</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Select the tracker mode.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Pick the mode that matches your game situation.</li>
+<li>Select <strong>Start</strong> to begin clocked tracking.</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Track events during play.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Update period as the game moves through Q1-Q4 and OT.</li>
+<li>In <strong>Standard</strong>, log team/opponent stats and use <strong>Undo</strong> for quick fixes.</li>
+<li>In <strong>Beta</strong> or <strong>Live Broadcast Tracker</strong>, use <strong>Live</strong>, <strong>Opponents</strong>, and <strong>Subs/Swap</strong> to keep on-court data current.</li>
+<li>In <strong>Live Broadcast Tracker</strong>, use <strong>Live Chat</strong> for staff communication.</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Keep role tasks focused.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Coaches prioritize real-time event entry, period changes, substitutions, and notes.</li>
+<li>Admins verify opponent setup and score accuracy for final reporting.</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Finish the game.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Open <strong>Finish</strong>.</li>
+<li>Enter or confirm final home and away scores.</li>
+<li>Optional: generate AI summary and email recap.</li>
+<li>Select <strong>Save &amp; Complete</strong>.</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Use Photo Score Sheet mode when needed.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Upload the score sheet image and select <strong>Analyze Photo</strong>.</li>
+<li>Review mapped players and scores.</li>
+<li>Correct side mapping if needed.</li>
+<li>Select <strong>Apply to Game</strong>.</li>
+<li>Optional: add or generate summary, then select <strong>Save &amp; Continue to Game</strong>.</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
+<li>Verify the final report.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>Open the game report.</li>
+<li>Confirm final score, player stats, opponent stats, and summary.</li>
+<li>Share report or live/replay links when ready.</li>
+</ul>
+<h2 id="common-questions">Common Questions</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><strong>Which mode is best for live play?</strong></li>
+</ul>
+<p>Use <strong>Standard</strong> for familiar manual entry. Use <strong>Beta</strong> or <strong>Live Broadcast Tracker</strong> for faster sideline substitutions and live context.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li><strong>When should I use Photo Score Sheet?</strong></li>
+</ul>
+<p>Use it after the game when final stats are on a completed paper score sheet.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li><strong>Can both coach and admin run this workflow?</strong></li>
+</ul>
+<p>Yes. Both can track games. Admins usually lead final verification.</p>
+<ul class="ml-6 list-disc space-y-1">
+<li><strong>What happens after Save &amp; Complete?</strong></li>
+</ul>
+<p>The game is marked complete and opens in report view for review and sharing.</p>
+<h2 id="recovery-troubleshooting">Recovery &amp; Troubleshooting</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><strong>Sent back to login</strong>: Sign in again, reopen the same game from schedule, and continue.</li>
+<li><strong>Tracking says this is a practice</strong>: Practice events cannot be tracked as games. Return to schedule and open a game event.</li>
+<li><strong>No basketball mode chooser</strong>: Continue in the default Standard tracker.</li>
+<li><strong>Game already has tracked data</strong>: If prompted to clear data, cancel to keep records or confirm to start fresh.</li>
+<li><strong>Photo analysis mapped teams incorrectly</strong>: Use side swap, remap home players, and verify final scores before applying.</li>
+<li><strong>Save &amp; Complete did not finish</strong>: Stay on the page, confirm final scores, retry save, then verify in report view.</li>
+</ul>
+<h2 id="related-workflows">Related Workflows</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li><code>schedule</code>: Build and manage the game schedule.</li>
+<li><code>game-day</code>: Handle day-of-game operations and live coordination.</li>
+<li><code>postgame</code>: Complete recap, reporting, and follow-up.</li>
+</ul>
+<h2 id="need-more-help">Need More Help</h2>
+<ul class="ml-6 list-disc space-y-1">
+<li>Reopen the game from schedule and retry with the mode that fits your context.</li>
+<li>Recheck score, stats, and summary before sharing.</li>
+<li>Contact your team admin if access or game visibility blocks progress.</li>
+</ul></div>
+          </article>
+        </div>
+      </div>
+    </main>
+    <div id="footer-container"></div>
+    <script type="module">
+      import { checkAuth } from './js/auth.js?v=9';
+      import { renderHeader, renderFooter } from './js/utils.js?v=8';
+      renderHeader(document.getElementById('header-container'), null);
+      renderFooter(document.getElementById('footer-container'));
+      checkAuth((user) => {
+        renderHeader(document.getElementById('header-container'), user);
+      });
+    </script>
+    <script>
+      (function() {
+        const headings = Array.from(document.querySelectorAll('.help-workflow-body h2[id]'));
+        const toc = document.getElementById('workflow-toc');
+        const mobileToc = document.getElementById('workflow-mobile-toc');
+        if (!toc || !headings.length) return;
+
+        const links = headings.map((h) => {
+          const a = document.createElement('a');
+          a.href = '#' + h.id;
+          a.textContent = h.textContent || h.id;
+          toc.appendChild(a);
+          return a;
+        });
+
+        if (mobileToc && window.innerWidth < 1024) {
+          const wrapper = document.createElement('details');
+          wrapper.className = 'wf-panel-section wf-panel';
+          wrapper.style.marginBottom = '0.95rem';
+          wrapper.style.padding = '0.8rem 1rem';
+          const summary = document.createElement('summary');
+          summary.textContent = 'Jump to section';
+          summary.style.cursor = 'pointer';
+          summary.style.fontWeight = '700';
+          summary.style.color = '#0f172a';
+          const list = toc.cloneNode(true);
+          list.style.marginTop = '0.6rem';
+          wrapper.appendChild(summary);
+          wrapper.appendChild(list);
+          mobileToc.appendChild(wrapper);
+        }
+
+        const sectionById = new Map(headings.map((h) => [h.id, h]));
+        const setActive = () => {
+          let active = headings[0];
+          for (const h of headings) {
+            if (h.getBoundingClientRect().top <= 140) active = h;
+          }
+          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+        };
+
+        window.addEventListener('scroll', setActive, { passive: true });
+        setActive();
+      })();
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Closes #134

## What changed
- Rebuilt the Help Center as workflow-first documentation pages generated from `workflow-docs/*.md`.
- Added new workflow help renderer/build pipeline:
  - `scripts/build-help-workflow-html-loop.mjs`
  - `scripts/build-help-workflow-html-loop.sh`
- Regenerated workflow outputs:
  - `workflow-*.html` (12 pages)
  - `workflow-manifest.json`
  - updated `help.html` index/search/filter UX
- Upgraded help UX structure and readability:
  - richer hero/header treatment
  - section TOC and mobile jump nav
  - role badges and metadata
  - improved summary extraction + read-time metadata
- Fixed role parsing in workflow manifests (including plural role labels like admins/coaches).
- Updated site-wide footer links:
  - Help Center link remains `help.html`
  - Contact now points to `https://paulsnider.net`
  - Removed footer GitHub link
  - Applied via shared footer renderer in `js/utils.js` and homepage footer in `index.html`

## Why
The prior help output was page-inventory style and visually flat. This PR ships a workflow-first, user-task-focused Help Center with stronger UX and consistent footer navigation across the site.

## Notes
- Existing unrelated local workspace changes are intentionally not part of this PR.
