### PR TITLE
Fix practice edit datetime-local timezone drift

### DIFF
--- a/docs/pr-notes/runs/issue-138-fixer-20260303T052600Z/architecture.md
+++ b/docs/pr-notes/runs/issue-138-fixer-20260303T052600Z/architecture.md
@@ -1,0 +1,20 @@
+# Architecture Role Output
+
+## Current-State Read
+`startEditPractice` writes UTC-formatted strings via `toISOString().slice(0, 16)` into `datetime-local` inputs. Browser treats input as local wall time on submit, causing timezone-offset drift on resave.
+
+## Proposed Design
+Reuse existing in-file helper `formatIsoForInput()` for practice start/end prefill to normalize Date/Timestamp into local-input-safe text.
+
+## Files And Modules Touched
+- `edit-schedule.html`
+- `tests/unit/edit-schedule-practice-timezone.test.js`
+
+## Data/State Impacts
+No schema changes. Stored timestamps continue through `Timestamp.fromDate(...)`; only input prefill string construction changes.
+
+## Security/Permissions Impacts
+No access control or tenant boundary changes.
+
+## Failure Modes And Mitigations
+- Risk: helper misuse/regression later. Mitigation: unit test asserts `startEditPractice` uses helper and avoids UTC slicing.

--- a/docs/pr-notes/runs/issue-138-fixer-20260303T052600Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-138-fixer-20260303T052600Z/code-plan.md
@@ -1,0 +1,18 @@
+# Code Role Output
+
+## Patch Plan
+1. Add a unit regression test reading `edit-schedule.html` and asserting local formatting helper usage for practice edit prefill.
+2. Replace the two UTC prefill assignments in `startEditPractice` with `formatIsoForInput(...)`.
+3. Run targeted vitest command for new test.
+
+## Code Changes Applied
+Planned minimal patch only in `edit-schedule.html` plus one unit test file.
+
+## Validation Run
+- `node node_modules/vitest/vitest.mjs run tests/unit/edit-schedule-practice-timezone.test.js`
+
+## Residual Risks
+- Runtime behavior still depends on browser `datetime-local` local-time semantics by design.
+
+## Commit Message Draft
+Fix practice edit datetime-local timezone drift (#138)

--- a/docs/pr-notes/runs/issue-138-fixer-20260303T052600Z/qa.md
+++ b/docs/pr-notes/runs/issue-138-fixer-20260303T052600Z/qa.md
@@ -1,0 +1,24 @@
+# QA Role Output
+
+## Risk Matrix
+- High: timezone drift on schedule save alters player/parent expectations.
+- Medium: regression via future edits to schedule prefill code path.
+- Low: unrelated schedule operations.
+
+## Automated Tests To Add/Update
+- Add unit guard test validating practice edit prefill uses `formatIsoForInput` and not direct UTC `toISOString().slice(0, 16)` assignment.
+
+## Manual Test Plan
+1. In non-UTC timezone (e.g., America/Chicago), create practice at 6:30 PM.
+2. Open edit modal/form, do not change times, save.
+3. Reload schedule and confirm practice remains at 6:30 PM.
+
+## Negative Tests
+- Ensure no reintroduction of direct UTC prefill for `practiceStart`/`practiceEnd`.
+
+## Release Gates
+- New regression unit test passes.
+- Existing targeted schedule-related tests pass.
+
+## Post-Deploy Checks
+- Spot-check at least one non-UTC team practice edit-save cycle in production-like environment.

--- a/docs/pr-notes/runs/issue-138-fixer-20260303T052600Z/requirements.md
+++ b/docs/pr-notes/runs/issue-138-fixer-20260303T052600Z/requirements.md
@@ -1,0 +1,27 @@
+# Requirements Role Output
+
+## Problem Statement
+Editing an existing practice must preserve the exact intended local start/end wall-clock time when the user opens and saves the form without changing datetime values.
+
+## User Segments Impacted
+- Coaches editing existing practices in schedule.
+- Parents and players consuming schedule and RSVPs derived from stored practice time.
+- Team admins responsible for schedule reliability.
+
+## Acceptance Criteria
+1. Practice edit prefill sets `practiceStart` using local `datetime-local` formatting, not UTC text.
+2. Practice edit prefill sets `practiceEnd` using the same local formatting path when an end exists.
+3. Saving a practice without datetime edits preserves original local wall-clock time semantics.
+4. Regression coverage fails if `startEditPractice` reintroduces direct `toISOString().slice(0, 16)` assignment for practice fields.
+
+## Non-Goals
+- Refactor schedule architecture.
+- Change Firestore timestamp storage format.
+- Modify game edit behavior beyond preserving existing behavior.
+
+## Edge Cases
+- Practice with no explicit end time still uses default duration logic.
+- Date values passed as Firestore Timestamp, Date, or ISO-compatible values.
+
+## Open Questions
+- None blocking for this targeted fix.

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -1579,13 +1579,11 @@
             editingSeriesId = practice.seriesId || null;
             switchTab('tab-add-practice');
 
-            const date = practice.date?.toDate ? practice.date.toDate() : new Date(practice.date);
             document.getElementById('practiceTitle').value = practice.title || 'Practice';
-            document.getElementById('practiceStart').value = date.toISOString().slice(0, 16);
+            document.getElementById('practiceStart').value = formatIsoForInput(practice.date);
 
             if (practice.end) {
-                const endDate = practice.end?.toDate ? practice.end.toDate() : new Date(practice.end);
-                document.getElementById('practiceEnd').value = endDate.toISOString().slice(0, 16);
+                document.getElementById('practiceEnd').value = formatIsoForInput(practice.end);
             }
 
             document.getElementById('practiceLocation').value = practice.location || '';

--- a/tests/unit/edit-schedule-practice-timezone.test.js
+++ b/tests/unit/edit-schedule-practice-timezone.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readEditSchedule() {
+    return readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
+}
+
+describe('edit schedule practice datetime-local prefill', () => {
+    it('uses local-input helper for practice start/end instead of UTC slicing', () => {
+        const source = readEditSchedule();
+
+        const startIndex = source.indexOf('function startEditPractice(practice) {');
+        const endIndex = source.indexOf("document.getElementById('cancel-edit-practice-btn').addEventListener('click', resetPracticeForm);");
+        expect(startIndex).toBeGreaterThanOrEqual(0);
+        expect(endIndex).toBeGreaterThan(startIndex);
+
+        const block = source.slice(startIndex, endIndex);
+        expect(block).toContain("document.getElementById('practiceStart').value = formatIsoForInput(practice.date)");
+        expect(block).toContain("document.getElementById('practiceEnd').value = formatIsoForInput(practice.end)");
+
+        expect(block).not.toContain("document.getElementById('practiceStart').value = date.toISOString().slice(0, 16)");
+        expect(block).not.toContain("document.getElementById('practiceEnd').value = endDate.toISOString().slice(0, 16)");
+    });
+});


### PR DESCRIPTION
Closes #138

## What changed
- Fixed `startEditPractice` in `edit-schedule.html` to prefill `practiceStart` and `practiceEnd` with `formatIsoForInput(...)` instead of `toISOString().slice(0, 16)`.
- Added regression test `tests/unit/edit-schedule-practice-timezone.test.js` to enforce local-input formatting for practice edit prefill and prevent UTC-slice regressions.
- Added run-scoped role artifacts under `docs/pr-notes/runs/issue-138-fixer-20260303T052600Z/`.

## Why
`datetime-local` expects local wall-clock text. Prefilling with UTC text caused values to shift by timezone offset when saved, corrupting practice times on edit-without-change flows.

## Validation
- `node /home/paul-bot1/.openclaw/workspace/allplays/node_modules/vitest/vitest.mjs run --root /home/paul-bot1/.local/state/paul-bot1/issue-fixer/workspaces/pauljsnider__allplays tests/unit/edit-schedule-practice-timezone.test.js tests/unit/recurrence-expand.test.js`
- Result: 2 test files passed, 4 tests passed.