### PR TITLE
Fix parent dashboard rideshare handler scope wiring

### DIFF
--- a/docs/pr-notes/runs/issue-140-fixer-20260303T082542Z/architecture.md
+++ b/docs/pr-notes/runs/issue-140-fixer-20260303T082542Z/architecture.md
@@ -1,0 +1,14 @@
+# Architecture role synthesis (fallback)
+
+## Current state
+`parent-dashboard.html` module has an accidental early `window.submitGameRsvp = async function(...) {` opening brace, causing rideshare helper declarations to be nested in that function scope. Global wiring for rideshare handlers executes before valid top-level declarations.
+
+## Proposed state
+Remove the accidental early function opener so rideshare helpers remain top-level declarations, and keep a single canonical `window.submitGameRsvp` implementation later in the script.
+
+## Blast radius
+Single file, single script block, no API contract changes, no schema/rules changes.
+
+## Control equivalence
+- Keeps existing public `window.*` handler surface.
+- Eliminates malformed scope that prevents initialization.

--- a/docs/pr-notes/runs/issue-140-fixer-20260303T082542Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-140-fixer-20260303T082542Z/code-plan.md
@@ -1,0 +1,9 @@
+# Code role plan (fallback)
+
+## Minimal patch steps
+1. Add a unit test file that reads `parent-dashboard.html` and fails when:
+   - duplicate `window.submitGameRsvp = async function(` assignments exist
+   - accidental nesting pattern (`submitGameRsvp` opener immediately wrapping rideshare helper declarations) exists
+2. Remove the stray early `window.submitGameRsvp = async function(...) {` line from `parent-dashboard.html`.
+3. Run targeted Vitest suite to confirm failure->pass and no local regressions.
+4. Commit test + fix together with issue reference.

--- a/docs/pr-notes/runs/issue-140-fixer-20260303T082542Z/qa.md
+++ b/docs/pr-notes/runs/issue-140-fixer-20260303T082542Z/qa.md
@@ -1,0 +1,14 @@
+# QA role synthesis (fallback)
+
+## Regression guardrails
+- Add unit test on `parent-dashboard.html` source to catch malformed nesting pattern.
+- Assert exactly one `window.submitGameRsvp` assignment to prevent duplicate handler blocks.
+
+## Validation plan
+- Run targeted unit test for parent dashboard script wiring.
+- Run related rideshare helper and RSVP tests for nearby behavior confidence.
+
+## Manual sanity checklist
+- Open `/parent-dashboard.html`.
+- Verify no console init error.
+- Verify Offer Ride, Request Spot, and Confirm/Decline actions call handlers.

--- a/docs/pr-notes/runs/issue-140-fixer-20260303T082542Z/requirements.md
+++ b/docs/pr-notes/runs/issue-140-fixer-20260303T082542Z/requirements.md
@@ -1,0 +1,17 @@
+# Requirements role synthesis (fallback)
+
+## Objective
+Restore parent dashboard rideshare actions (offer ride, request spot, confirm/decline/cancel) by ensuring script initialization completes without runtime reference errors.
+
+## User-visible acceptance criteria
+- Parent dashboard loads without JavaScript initialization errors.
+- Rideshare buttons invoke callable handlers from `window`.
+- Existing RSVP behavior remains unchanged.
+
+## Constraints
+- Keep patch minimal and localized to `parent-dashboard.html`.
+- Preserve current UI copy and event card behavior.
+
+## Risks
+- Any broader script reshuffling could regress unrelated dashboard flows.
+- Inline handler names are a contract with rendered HTML; renames would break clicks.

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -263,7 +263,6 @@
             return `${summary.going || 0} going · ${summary.maybe || 0} maybe · ${summary.notGoing || 0} can't go · ${summary.notResponded || 0} no response`;
         }
 
-        window.submitGameRsvp = async function(teamId, gameId, response, childContext = {}) {
         function getEventRideKey(teamId, eventId) {
             return `${teamId || ''}::${eventId || ''}`;
         }

--- a/tests/unit/parent-dashboard-rideshare-wiring.test.js
+++ b/tests/unit/parent-dashboard-rideshare-wiring.test.js
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readRepoFile(relativePath) {
+    return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+describe('parent dashboard rideshare wiring', () => {
+    it('keeps a single submitGameRsvp assignment and no accidental wrapper around rideshare helpers', () => {
+        const html = readRepoFile('parent-dashboard.html');
+        const submitAssignments = html.match(/window\.submitGameRsvp\s*=\s*async function\s*\(/g) || [];
+
+        expect(submitAssignments).toHaveLength(1);
+        expect(html).not.toMatch(/window\.submitGameRsvp\s*=\s*async function\s*\([^)]*\)\s*\{\s*function\s+getEventRideKey\s*\(/s);
+    });
+});


### PR DESCRIPTION
Closes #140

## What changed
- Removed the stray early `window.submitGameRsvp = async function(...) {` opener in `parent-dashboard.html` that accidentally wrapped rideshare helper declarations in function scope.
- Kept the existing canonical `window.submitGameRsvp` implementation later in the script as the single assignment.
- Added a regression unit test that reads `parent-dashboard.html` and asserts:
  - only one `window.submitGameRsvp` assignment exists
  - no accidental `submitGameRsvp` wrapper directly enclosing rideshare helper declarations
- Added required role artifact notes under `docs/pr-notes/runs/issue-140-fixer-20260303T082542Z/`.

## Why
The duplicate/malformed `submitGameRsvp` block caused script-scope breakage during initialization, making rideshare actions unavailable from `window` and breaking parent rideshare workflows.

## Validation
- `node /home/paul-bot1/.openclaw/workspace/allplays/node_modules/vitest/vitest.mjs run --root /home/paul-bot1/.local/state/paul-bot1/issue-fixer/workspaces/pauljsnider__allplays tests/unit/parent-dashboard-rideshare-wiring.test.js tests/unit/parent-dashboard-rsvp.test.js tests/unit/rideshare-helpers.test.js`
- Result: 3 files passed, 13 tests passed.