### PR TITLE
Require codeId when redeeming admin invites

### DIFF
--- a/docs/pr-notes/runs/issue-145-fixer-20260303T172543Z/architecture.md
+++ b/docs/pr-notes/runs/issue-145-fixer-20260303T172543Z/architecture.md
@@ -1,0 +1,17 @@
+# Architecture Role Synthesis
+
+## Current state
+- `accept-invite.html` delegates invite handling to `createInviteProcessor`.
+- `createInviteProcessor` uses `redeemAdminInviteAtomically` when present, else fallback persistence + `markAccessCodeAsUsed`.
+- `redeemAdminInviteAtomically` transaction marks the access code as used.
+
+## Proposed state
+- Preserve current runtime behavior.
+- Add guardrail test that verifies admin invite acceptance uses atomic redemption and surfaces used-code rejection correctly.
+
+## Control equivalence
+- Atomic transaction keeps admin grant + code consumption in one controlled write boundary.
+- Shared processor keeps manual code and URL flows aligned.
+
+## Rollback
+- Revert targeted patch commit; no schema/data migration involved.

--- a/docs/pr-notes/runs/issue-145-fixer-20260303T172543Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-145-fixer-20260303T172543Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Role Synthesis
+
+## Minimal patch plan
+1. Identify exact gap enabling admin invite code reuse in processor/dependency wiring.
+2. Add focused unit test reproducing the gap.
+3. Apply smallest code change in invite acceptance flow.
+4. Run targeted invite unit tests.
+5. Commit test + fix together referencing issue #145.
+
+## Conflict resolution
+- Requested role-orchestration skills are unavailable in this runtime; synthesized role outputs are captured here and used as the decision record.

--- a/docs/pr-notes/runs/issue-145-fixer-20260303T172543Z/qa.md
+++ b/docs/pr-notes/runs/issue-145-fixer-20260303T172543Z/qa.md
@@ -1,0 +1,13 @@
+# QA Role Synthesis
+
+## Test strategy
+- Add/extend unit test in invite processor suite to validate one-time semantics in admin path.
+- Ensure failing path asserts exact user-visible error (`Code already used`).
+
+## Regression scope
+- Admin invite via accept-invite processor (covers URL and manual input callsites).
+- Existing invite tests should remain green to guard parent invite behavior.
+
+## Exit criteria
+1. New/updated unit test fails without fix and passes with fix.
+2. Invite-related test suite passes locally.

--- a/docs/pr-notes/runs/issue-145-fixer-20260303T172543Z/requirements.md
+++ b/docs/pr-notes/runs/issue-145-fixer-20260303T172543Z/requirements.md
@@ -1,0 +1,21 @@
+# Requirements Role Synthesis
+
+## Objective
+Ensure admin invite codes are one-time use: after first successful acceptance, every subsequent redemption attempt fails.
+
+## User-facing expectation
+- First redemption succeeds and grants admin access.
+- Reuse attempt returns a clear already-used failure (`Code already used`).
+
+## Risk and blast radius
+- High severity: privileged onboarding route.
+- Blast radius: unauthorized repeated admin enrollment attempts if invite code state is not consumed.
+
+## Acceptance criteria
+1. Admin invite redemption path always transitions code `used=false -> used=true` on success.
+2. Reuse attempt fails in both URL and manual code paths (shared processor path).
+3. Regression test covers consumption behavior and used-code rejection message.
+
+## Assumptions
+- `accept-invite` flow is mediated through `createInviteProcessor`.
+- Existing atomic redemption path is intended to be source-of-truth when available.

--- a/js/admin-invite.js
+++ b/js/admin-invite.js
@@ -11,6 +11,7 @@ export async function redeemAdminInviteAcceptance({
 }) {
     if (!userId) throw new Error('Missing userId');
     if (!teamId) throw new Error('Missing teamId');
+    if (!codeId) throw new Error('Missing codeId');
 
     const team = await getTeam(teamId);
     if (!team) {
@@ -44,9 +45,7 @@ export async function redeemAdminInviteAcceptance({
 
     await addTeamAdminEmail(teamId, resolvedUserEmail);
 
-    if (codeId) {
-        await markAccessCodeAsUsed(codeId, userId);
-    }
+    await markAccessCodeAsUsed(codeId, userId);
 
     return team;
 }

--- a/tests/unit/admin-invite.test.js
+++ b/tests/unit/admin-invite.test.js
@@ -5,7 +5,10 @@ describe('admin invite acceptance', () => {
     it('persists team admin email, merges profile access, and marks code used', async () => {
         const getTeam = vi.fn().mockResolvedValue({ id: 'team-1', name: 'Sharks' });
         const addTeamAdminEmail = vi.fn().mockResolvedValue(undefined);
-        const getUserProfile = vi.fn().mockResolvedValue({ coachOf: ['team-0'], roles: ['parent'] });
+        const getUserProfile = vi
+            .fn()
+            .mockResolvedValueOnce({ coachOf: ['team-0'], roles: ['parent'] })
+            .mockResolvedValueOnce({ coachOf: ['team-0', 'team-1'], roles: ['parent', 'coach'] });
         const updateUserProfile = vi.fn().mockResolvedValue(undefined);
         const markAccessCodeAsUsed = vi.fn().mockResolvedValue(undefined);
 
@@ -22,7 +25,7 @@ describe('admin invite acceptance', () => {
         });
 
         expect(team).toEqual({ id: 'team-1', name: 'Sharks' });
-        expect(addTeamAdminEmail).toHaveBeenCalledWith('team-1', 'Admin@Example.com');
+        expect(addTeamAdminEmail).toHaveBeenCalledWith('team-1', 'admin@example.com');
         expect(updateUserProfile).toHaveBeenCalledWith('user-1', {
             coachOf: ['team-0', 'team-1'],
             roles: ['parent', 'coach']
@@ -47,19 +50,21 @@ describe('admin invite acceptance', () => {
         ).rejects.toThrow('Team not found');
     });
 
-    it('skips code mark when codeId is absent', async () => {
+    it('fails closed when codeId is absent', async () => {
         const markAccessCodeAsUsed = vi.fn();
 
-        await redeemAdminInviteAcceptance({
-            userId: 'user-1',
-            userEmail: 'admin@example.com',
-            teamId: 'team-1',
-            markAccessCodeAsUsed,
-            getTeam: vi.fn().mockResolvedValue({ id: 'team-1' }),
-            addTeamAdminEmail: vi.fn().mockResolvedValue(undefined),
-            getUserProfile: vi.fn().mockResolvedValue({ coachOf: ['team-1'], roles: ['coach'] }),
-            updateUserProfile: vi.fn().mockResolvedValue(undefined)
-        });
+        await expect(
+            redeemAdminInviteAcceptance({
+                userId: 'user-1',
+                userEmail: 'admin@example.com',
+                teamId: 'team-1',
+                markAccessCodeAsUsed,
+                getTeam: vi.fn().mockResolvedValue({ id: 'team-1' }),
+                addTeamAdminEmail: vi.fn().mockResolvedValue(undefined),
+                getUserProfile: vi.fn().mockResolvedValue({ coachOf: ['team-1'], roles: ['coach'] }),
+                updateUserProfile: vi.fn().mockResolvedValue(undefined)
+            })
+        ).rejects.toThrow('Missing codeId');
 
         expect(markAccessCodeAsUsed).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
Closes #145

## What changed
- Updated `redeemAdminInviteAcceptance` to fail closed when `codeId` is missing instead of allowing admin invite acceptance to continue without consuming a code.
- Made code consumption mandatory in that helper by always calling `markAccessCodeAsUsed` after successful admin grant writes.
- Added regression coverage in `tests/unit/admin-invite.test.js` for the missing-`codeId` path and aligned existing expectations with current profile re-read and email normalization behavior.
- Added required role-synthesis artifacts under `docs/pr-notes/runs/issue-145-fixer-20260303T172543Z/`.

## Why
Admin invite acceptance must preserve one-time invite semantics. Allowing success without a `codeId` creates a bypass where onboarding can complete without marking the invite code as used, enabling reuse attempts.