### PR TITLE
Handle cancelled ICS events in calendar import

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -324,10 +324,9 @@
                                     if (trackedUids.includes(ev.uid)) continue;
                                     const evDate = ev.dtstart instanceof Date ? ev.dtstart : new Date(ev.dtstart);
                                     if (Number.isNaN(evDate.getTime())) continue;
-                                    const normalizedSummary = ev.summary?.trimStart().toUpperCase();
+                                    const hasCancelledPrefix = /^\s*\[(?:CANCELED|CANCELLED)\]/i.test(ev.summary || '');
                                     const isCancelled = ev.status?.toUpperCase() === 'CANCELLED' ||
-                                        normalizedSummary?.startsWith('[CANCELED]') ||
-                                        normalizedSummary?.startsWith('[CANCELLED]');
+                                        hasCancelledPrefix;
                                     events.push({
                                         id: ev.uid || `ics-${evDate.getTime()}`,
                                         teamId: team.id,

--- a/calendar.html
+++ b/calendar.html
@@ -324,6 +324,8 @@
                                     if (trackedUids.includes(ev.uid)) continue;
                                     const evDate = ev.dtstart instanceof Date ? ev.dtstart : new Date(ev.dtstart);
                                     if (Number.isNaN(evDate.getTime())) continue;
+                                    const isCancelled = ev.status?.toUpperCase() === 'CANCELLED' ||
+                                        ev.summary?.includes('[CANCELED]');
                                     events.push({
                                         id: ev.uid || `ics-${evDate.getTime()}`,
                                         teamId: team.id,
@@ -333,7 +335,7 @@
                                         title: ev.summary || 'Event',
                                         date: evDate,
                                         location: ev.location || 'TBD',
-                                        status: 'scheduled',
+                                        status: isCancelled ? 'cancelled' : 'scheduled',
                                         source: 'ics'
                                     });
                                 }

--- a/calendar.html
+++ b/calendar.html
@@ -324,8 +324,10 @@
                                     if (trackedUids.includes(ev.uid)) continue;
                                     const evDate = ev.dtstart instanceof Date ? ev.dtstart : new Date(ev.dtstart);
                                     if (Number.isNaN(evDate.getTime())) continue;
+                                    const normalizedSummary = ev.summary?.trimStart().toUpperCase();
                                     const isCancelled = ev.status?.toUpperCase() === 'CANCELLED' ||
-                                        ev.summary?.includes('[CANCELED]');
+                                        normalizedSummary?.startsWith('[CANCELED]') ||
+                                        normalizedSummary?.startsWith('[CANCELLED]');
                                     events.push({
                                         id: ev.uid || `ics-${evDate.getTime()}`,
                                         teamId: team.id,

--- a/docs/pr-notes/runs/148-remediator-20260303T203117Z/architecture.md
+++ b/docs/pr-notes/runs/148-remediator-20260303T203117Z/architecture.md
@@ -1,0 +1,14 @@
+# Architecture role notes
+
+## Current state
+ICS cancellation detection uses:
+- `ev.status?.toUpperCase() === 'CANCELLED'` (good)
+- `ev.summary?.includes('[CANCELED]')` (case-sensitive + substring match)
+
+## Proposed state
+Normalize summary via `trimStart().toUpperCase()`, then use `startsWith('[CANCELED]')` (and accept `[CANCELLED]` spelling variant) to avoid false positives from mid-string tokens.
+
+## Risk surface / blast radius
+- Blast radius is limited to ICS event ingestion in `calendar.html`.
+- UI rendering and downstream status use existing `status: 'cancelled' | 'scheduled'` behavior unchanged.
+- Prefix-only check reduces false-positive cancellations.

--- a/docs/pr-notes/runs/148-remediator-20260303T203117Z/code-plan.md
+++ b/docs/pr-notes/runs/148-remediator-20260303T203117Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code role notes
+
+## Planned edits
+1. `calendar.html`
+- Add normalized summary variable in ICS loop.
+- Replace summary cancellation detection with case-insensitive prefix detection.
+
+2. `tests/unit/calendar-ics-cancelled-status.test.js`
+- Update regex expectation to match the new normalized-prefix cancellation expression and status mapping.
+
+## Commit scope
+Only files needed to satisfy unresolved review threads, plus required run-note artifacts.

--- a/docs/pr-notes/runs/148-remediator-20260303T203117Z/qa.md
+++ b/docs/pr-notes/runs/148-remediator-20260303T203117Z/qa.md
@@ -1,0 +1,10 @@
+# QA role notes
+
+## Assertions
+- Mapping logic contains case-insensitive status check.
+- Mapping logic contains case-insensitive summary-prefix check.
+- Mapping logic does not rely on bare substring `includes('[CANCELED]')` directly on raw summary.
+- Existing mapping to `status: isCancelled ? 'cancelled' : 'scheduled'` remains intact.
+
+## Validation command
+- `node node_modules/vitest/vitest.mjs run tests/unit/calendar-ics-cancelled-status.test.js`

--- a/docs/pr-notes/runs/148-remediator-20260303T203117Z/requirements.md
+++ b/docs/pr-notes/runs/148-remediator-20260303T203117Z/requirements.md
@@ -1,0 +1,17 @@
+# Requirements role notes
+
+## Objective
+Resolve unresolved PR #148 review feedback on cancelled ICS event detection and matching test coverage.
+
+## Required changes
+- Thread `PRRT_kwDOQe-T585x5yAj`:
+  - Make summary cancel marker check case-insensitive.
+  - Maintain status check as case-insensitive (`ev.status?.toUpperCase() === 'CANCELLED'`).
+- Thread `PRRT_kwDOQe-T585x5yAq`:
+  - Update unit-test regex to match the corrected case-insensitive implementation for both `ev.status` and `ev.summary`.
+- Thread `PRRT_kwDOQe-T585x5yfM`:
+  - Ensure TeamSnap marker is matched only as a summary prefix (after optional trim), not as anywhere substring.
+
+## Non-goals
+- No refactor outside the ICS mapping cancellation logic.
+- No unrelated UI or data-model changes.

--- a/docs/pr-notes/runs/148-review-comment-2880330151-20260303T203617Z/architecture.md
+++ b/docs/pr-notes/runs/148-review-comment-2880330151-20260303T203617Z/architecture.md
@@ -1,0 +1,24 @@
+# Architecture Role Output
+
+## Current-State Read
+`calendar.html` ICS mapping sets `status` from `isCancelled`. Current logic normalizes status and checks summary markers, but the check can be made more explicit and maintainable with a single case-insensitive prefix matcher.
+
+## Proposed Design
+Introduce a single `hasCancelledPrefix` regex check: `/^\s*\[(?:CANCELED|CANCELLED)\]/i.test(ev.summary || '')`. Compute `isCancelled` from normalized `status` OR prefix matcher, then keep existing downstream `status: isCancelled ? 'cancelled' : 'scheduled'` mapping.
+
+## Files And Modules Touched
+- `calendar.html`
+- `tests/unit/calendar-ics-cancelled-status.test.js`
+- Run notes under `docs/pr-notes/runs/148-review-comment-2880330151-20260303T203617Z/`
+
+## Data/State Impacts
+No schema or persistence changes. In-memory event normalization only.
+
+## Security/Permissions Impacts
+None. No auth, permission, or data-access boundary changes.
+
+## Failure Modes And Mitigations
+- Failure mode: regex too strict/loose and misclassifies events.
+  - Mitigation: focused unit assertion of matcher and final status mapping.
+- Failure mode: UI regressions from changed status normalization.
+  - Mitigation: preserve status output contract (`cancelled`/`scheduled`) and run targeted tests.

--- a/docs/pr-notes/runs/148-review-comment-2880330151-20260303T203617Z/code-plan.md
+++ b/docs/pr-notes/runs/148-review-comment-2880330151-20260303T203617Z/code-plan.md
@@ -1,0 +1,19 @@
+# Code Role Output
+
+## Patch Plan
+1. Replace current summary marker checks with one case-insensitive prefix matcher in ICS mapping.
+2. Keep status normalization output contract unchanged.
+3. Update targeted unit assertion to match new logic.
+
+## Code Changes Applied
+- Planned change in `calendar.html` around ICS `isCancelled` derivation.
+- Planned update in `tests/unit/calendar-ics-cancelled-status.test.js` regex expectation.
+
+## Validation Run
+- `node ./node_modules/vitest/vitest.mjs run --root . tests/unit/calendar-ics-cancelled-status.test.js`
+
+## Residual Risks
+- Other pages contain independent cancellation parsing logic not part of this PR; unchanged intentionally for minimal blast radius.
+
+## Commit Message Draft
+`Harden ICS cancelled prefix detection for mixed-case markers`

--- a/docs/pr-notes/runs/148-review-comment-2880330151-20260303T203617Z/qa.md
+++ b/docs/pr-notes/runs/148-review-comment-2880330151-20260303T203617Z/qa.md
@@ -1,0 +1,28 @@
+# QA Role Output
+
+## Risk Matrix
+- High: Incorrect cancelled detection causes wrong schedule decisions by families/coaches.
+- Medium: False positives if matcher over-matches summaries.
+- Low: Presentation regressions in calendar cards/modals (status string contract unchanged).
+
+## Automated Tests To Add/Update
+- Update `tests/unit/calendar-ics-cancelled-status.test.js` to validate the new case-insensitive prefix matcher and status mapping contract.
+
+## Manual Test Plan
+- Load calendar with ICS events containing:
+  - `STATUS:CANCELLED`
+  - `[Canceled]` summary prefix with no status
+  - normal summary with no cancelled indicators
+- Confirm cancelled badge/strike-through appears only for cancelled normalized events.
+
+## Negative Tests
+- Summary containing similar text without bracketed prefix should not be auto-cancelled.
+- Empty/undefined summary with no cancelled status remains scheduled.
+
+## Release Gates
+- Focused unit suite for ICS cancelled mapping passes.
+- Branch is clean except intended changes.
+
+## Post-Deploy Checks
+- Spot-check calendar month, list, and day modal views for cancelled ICS events.
+- Verify no increase in support reports for missing or incorrect cancellation states.

--- a/docs/pr-notes/runs/148-review-comment-2880330151-20260303T203617Z/requirements.md
+++ b/docs/pr-notes/runs/148-review-comment-2880330151-20260303T203617Z/requirements.md
@@ -1,0 +1,28 @@
+# Requirements Role Output
+
+## Problem Statement
+ICS-imported cancelled events can be missed when the summary marker casing varies (for example `[Canceled]`), causing incorrect scheduled-state rendering in calendar views.
+
+## User Segments Impacted
+- Coaches: need fast, accurate cancelled-game visibility before practices/games.
+- Parents: need trustworthy schedule state to avoid travel mistakes.
+- Team admins/managers: need reliable imported calendar normalization without manual cleanup.
+
+## Acceptance Criteria
+1. ICS mapping marks an event cancelled when `STATUS:CANCELLED` is present, independent of summary text.
+2. ICS mapping marks an event cancelled when summary starts with cancellation marker in any casing, supporting both `[CANCELED]` and `[CANCELLED]` spellings.
+3. Non-cancelled events without cancelled status/marker remain `scheduled`.
+4. Existing UI logic that relies on normalized `status: 'cancelled'` behavior remains unchanged.
+
+## Non-Goals
+- Broad refactor of cancellation logic across unrelated pages.
+- Changing displayed labels/text for cancelled events.
+- Modifying Firestore event status semantics.
+
+## Edge Cases
+- Leading whitespace before cancellation marker.
+- Mixed-case marker text.
+- Missing or non-string summary.
+
+## Open Questions
+- Should cancellation marker matching also support marker text appearing mid-summary (not prefix)? Current behavior intentionally treats it as prefix semantics.

--- a/docs/pr-notes/runs/issue-147-fixer-20260303T202612Z/architecture.md
+++ b/docs/pr-notes/runs/issue-147-fixer-20260303T202612Z/architecture.md
@@ -1,0 +1,22 @@
+# Architecture Role - Issue #147
+
+## Decision
+Patch ICS normalization at calendar import boundary (where ICS event objects are converted to calendar event objects).
+
+## Why Here
+- Root cause exists at mapping line where status is hardcoded.
+- UI and filtering already key off `ev.status === 'cancelled'`.
+- Minimal change preserves existing behavior for non-cancelled events.
+
+## Control Equivalence
+- Existing controls for cancelled DB events remain unchanged.
+- New behavior aligns ICS events with same cancellation control path.
+
+## Conflict Resolution
+- Requirements suggests preserving cancellation semantics.
+- QA requires regression protection.
+- Code lane recommends single-line mapping fix plus targeted test.
+- Resolved path: keep fix local to calendar mapping; avoid broad refactor.
+
+## Rollback
+Revert single mapping change in `calendar.html` and associated test file if unexpected regression appears.

--- a/docs/pr-notes/runs/issue-147-fixer-20260303T202612Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-147-fixer-20260303T202612Z/code-plan.md
@@ -1,0 +1,13 @@
+# Code Role Plan - Issue #147
+
+Thinking level: low (single-path bug with clear root cause and existing cancellation semantics elsewhere).
+
+## Steps
+1. Add failing unit regression test in `tests/unit/calendar-ics-cancelled-status.test.js`.
+2. Update `calendar.html` ICS mapping to derive status from parsed ICS cancellation signals.
+3. Run targeted Vitest command for new test.
+4. Stage, commit with issue reference.
+
+## Minimal Patch Scope
+- `calendar.html`
+- `tests/unit/calendar-ics-cancelled-status.test.js`

--- a/docs/pr-notes/runs/issue-147-fixer-20260303T202612Z/qa.md
+++ b/docs/pr-notes/runs/issue-147-fixer-20260303T202612Z/qa.md
@@ -1,0 +1,15 @@
+# QA Role - Issue #147
+
+## Test Strategy
+1. Add regression test asserting `calendar.html` ICS mapping does not hardcode `status: 'scheduled'`.
+2. Assert mapping includes cancellation detection from:
+   - `event.status?.toUpperCase() === 'CANCELLED'`
+   - `event.summary?.includes('[CANCELED]')`
+3. Run targeted Vitest suite for new test.
+
+## Regression Guardrails
+- Keep assertions scoped to ICS mapping block near `fetchAndParseCalendar` usage.
+- Avoid brittle full-file snapshot tests.
+
+## Risks
+- False negatives if code formatting changes significantly; mitigate with focused regex checks for semantic expressions.

--- a/docs/pr-notes/runs/issue-147-fixer-20260303T202612Z/requirements.md
+++ b/docs/pr-notes/runs/issue-147-fixer-20260303T202612Z/requirements.md
@@ -1,0 +1,24 @@
+# Requirements Role - Issue #147
+
+## Objective
+Ensure cancelled ICS events are treated as cancelled in calendar view so users do not see active workflows (including RSVP) for cancelled events.
+
+## Current vs Proposed
+- Current: Calendar imports ICS events and forces `status: 'scheduled'`.
+- Proposed: Calendar preserves ICS cancellation signal (`STATUS:CANCELLED` and `[CANCELED]` prefix) by mapping affected events to `status: 'cancelled'`.
+
+## User-Critical Outcomes
+- Cancelled ICS events are visually marked and excluded from active event workflows.
+- Users no longer act on false upcoming events.
+
+## Risk Surface / Blast Radius
+- Risk: Incorrect over-cancellation if summary parsing is too broad.
+- Blast radius: `calendar.html` ICS event mapping path only.
+
+## Assumptions
+- `parseICS` continues to expose `event.status` from ICS payload.
+- Existing calendar UI behavior for `ev.status === 'cancelled'` is already correct.
+- TeamSnap-style prefix `[CANCELED]` should remain supported.
+
+## Recommendation
+Implement targeted status normalization during ICS-to-calendar event mapping and add a regression test that guards against reintroducing hardcoded scheduled status for ICS imports.

--- a/tests/unit/calendar-ics-cancelled-status.test.js
+++ b/tests/unit/calendar-ics-cancelled-status.test.js
@@ -12,8 +12,8 @@ describe('calendar ICS cancelled status mapping', () => {
         const mappingSection = getCalendarIcsMappingSection();
 
         expect(mappingSection).toBeTruthy();
-        expect(mappingSection).toMatch(/const normalizedSummary = ev\.summary\?\.trimStart\(\)\.toUpperCase\(\);/);
-        expect(mappingSection).toMatch(/const isCancelled = ev\.status\?\.toUpperCase\(\) === 'CANCELLED'\s*\|\|\s*normalizedSummary\?\.startsWith\('\[CANCELED\]'\)\s*\|\|\s*normalizedSummary\?\.startsWith\('\[CANCELLED\]'\);/);
+        expect(mappingSection).toMatch(/const hasCancelledPrefix = \/\^\\s\*\\\[\(\?:CANCELED\|CANCELLED\)\\\]\/i\.test\(ev\.summary \|\| ''\);/);
+        expect(mappingSection).toMatch(/const isCancelled = ev\.status\?\.toUpperCase\(\) === 'CANCELLED'\s*\|\|\s*hasCancelledPrefix;/);
         expect(mappingSection).toMatch(/status:\s*isCancelled\s*\?\s*'cancelled'\s*:\s*'scheduled'\s*,/);
         expect(mappingSection).not.toMatch(/^\s*status:\s*'scheduled'\s*,/m);
     });

--- a/tests/unit/calendar-ics-cancelled-status.test.js
+++ b/tests/unit/calendar-ics-cancelled-status.test.js
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function getCalendarIcsMappingSection() {
+    const html = readFileSync(new URL('../../calendar.html', import.meta.url), 'utf8');
+    const match = html.match(/const icsEvents = await fetchAndParseCalendar\(calUrl\);[\s\S]*?events\.push\(\{[\s\S]*?source:\s*'ics'[\s\S]*?\}\);/);
+    return match ? match[0] : '';
+}
+
+describe('calendar ICS cancelled status mapping', () => {
+    it('derives cancelled status from ICS status or [CANCELED] summary prefix', () => {
+        const mappingSection = getCalendarIcsMappingSection();
+
+        expect(mappingSection).toBeTruthy();
+        expect(mappingSection).toMatch(/const isCancelled = ev\.status\?\.toUpperCase\(\) === 'CANCELLED'\s*\|\|\s*ev\.summary\?\.includes\('\[CANCELED\]'\);/);
+        expect(mappingSection).toMatch(/status:\s*isCancelled\s*\?\s*'cancelled'\s*:\s*'scheduled'\s*,/);
+        expect(mappingSection).not.toMatch(/^\s*status:\s*'scheduled'\s*,/m);
+    });
+});

--- a/tests/unit/calendar-ics-cancelled-status.test.js
+++ b/tests/unit/calendar-ics-cancelled-status.test.js
@@ -8,11 +8,12 @@ function getCalendarIcsMappingSection() {
 }
 
 describe('calendar ICS cancelled status mapping', () => {
-    it('derives cancelled status from ICS status or [CANCELED] summary prefix', () => {
+    it('derives cancelled status from ICS status or case-insensitive summary prefix marker', () => {
         const mappingSection = getCalendarIcsMappingSection();
 
         expect(mappingSection).toBeTruthy();
-        expect(mappingSection).toMatch(/const isCancelled = ev\.status\?\.toUpperCase\(\) === 'CANCELLED'\s*\|\|\s*ev\.summary\?\.includes\('\[CANCELED\]'\);/);
+        expect(mappingSection).toMatch(/const normalizedSummary = ev\.summary\?\.trimStart\(\)\.toUpperCase\(\);/);
+        expect(mappingSection).toMatch(/const isCancelled = ev\.status\?\.toUpperCase\(\) === 'CANCELLED'\s*\|\|\s*normalizedSummary\?\.startsWith\('\[CANCELED\]'\)\s*\|\|\s*normalizedSummary\?\.startsWith\('\[CANCELLED\]'\);/);
         expect(mappingSection).toMatch(/status:\s*isCancelled\s*\?\s*'cancelled'\s*:\s*'scheduled'\s*,/);
         expect(mappingSection).not.toMatch(/^\s*status:\s*'scheduled'\s*,/m);
     });


### PR DESCRIPTION
Closes #147

## What changed
- Updated ICS event mapping in `calendar.html` to derive cancellation state from parsed ICS fields instead of hardcoding imported events as scheduled.
- Added cancellation detection for both `STATUS:CANCELLED` and TeamSnap-style `[CANCELED]` summary prefixes.
- Added a regression test in `tests/unit/calendar-ics-cancelled-status.test.js` to guard against reintroducing hardcoded scheduled status for ICS imports.
- Persisted required role-analysis artifacts for this run under `docs/pr-notes/runs/issue-147-fixer-20260303T202612Z/`.

## Why
Calendar UI cancellation behavior already depends on `ev.status === 'cancelled'`, but imported ICS events were always forced to `status: 'scheduled'`. This patch restores correct cancellation semantics so cancelled external events are not treated as active scheduled events.