### PR TITLE
Respect cancelled ICS events in calendar import

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -134,7 +134,7 @@
 
     <script type="module">
         import { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, getMyRsvp, getRsvpSummaries } from './js/db.js?v=23';
-        import { renderHeader, renderFooter, escapeHtml, formatDate, formatTime, fetchAndParseCalendar, expandRecurrence, getCalendarEventType } from './js/utils.js?v=9';
+        import { renderHeader, renderFooter, escapeHtml, formatDate, formatTime, fetchAndParseCalendar, expandRecurrence, getCalendarEventType, getCalendarEventStatus } from './js/utils.js?v=9';
         import { requireAuth, checkAuth } from './js/auth.js?v=9';
         import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';
 
@@ -333,7 +333,7 @@
                                         title: ev.summary || 'Event',
                                         date: evDate,
                                         location: ev.location || 'TBD',
-                                        status: 'scheduled',
+                                        status: getCalendarEventStatus(ev),
                                         source: 'ics'
                                     });
                                 }

--- a/docs/pr-notes/runs/issue-151-fixer-20260304T022525Z/architecture.md
+++ b/docs/pr-notes/runs/issue-151-fixer-20260304T022525Z/architecture.md
@@ -1,0 +1,19 @@
+# Architecture Role Synthesis (Fallback)
+
+## Note on orchestration tooling
+Requested skills (`allplays-orchestrator-playbook`, `allplays-architecture-expert`) and `sessions_spawn` are not available in this runtime. This artifact captures equivalent architecture analysis.
+
+## Root cause model
+ICS parsing in `js/utils.js` preserves `STATUS`, but calendar ingestion discards it and writes a fixed status. This severs cancellation metadata from render-time policy.
+
+## Minimal-safe patch strategy
+- Add a tiny cancellation helper in `calendar.html` near ICS ingestion.
+- Derive status during import:
+  - cancelled if `ev.status?.toUpperCase() === 'CANCELLED'`
+  - cancelled if summary contains `[CANCELED]` (case-insensitive)
+  - otherwise scheduled
+- Keep scope constrained to ICS import block; do not alter DB event handling or parseICS internals.
+
+## Conflict resolution
+- Parent dashboard already supports both cancellation signals; align calendar behavior with that precedent.
+- Preserve existing summary/title text behavior (no summary rewriting in this bugfix).

--- a/docs/pr-notes/runs/issue-151-fixer-20260304T022525Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-151-fixer-20260304T022525Z/code-plan.md
@@ -1,0 +1,14 @@
+# Code Role Synthesis (Fallback)
+
+## Note on orchestration tooling
+Requested skills (`allplays-orchestrator-playbook`, `allplays-code-expert`) and `sessions_spawn` are not available in this runtime. This artifact captures equivalent implementation plan.
+
+## Implementation plan
+1. Add test-first coverage in `tests/unit/calendar-ics-event-type.test.js` for an exported cancellation status helper.
+2. Implement helper in `js/utils.js` and use it in `calendar.html` ICS import mapping.
+3. Run targeted Vitest files.
+4. Stage run artifacts + code/test changes and commit with `#151` reference.
+
+## Non-goals
+- No changes to parent dashboard logic.
+- No refactors of ICS parsing date/field utilities.

--- a/docs/pr-notes/runs/issue-151-fixer-20260304T022525Z/qa.md
+++ b/docs/pr-notes/runs/issue-151-fixer-20260304T022525Z/qa.md
@@ -1,0 +1,20 @@
+# QA Role Synthesis (Fallback)
+
+## Note on orchestration tooling
+Requested skills (`allplays-orchestrator-playbook`, `allplays-qa-expert`) and `sessions_spawn` are not available in this runtime. This artifact captures equivalent QA analysis.
+
+## Regression risks
+- Missing one cancellation variant (`STATUS` vs `[CANCELED]`) can leave inconsistent behavior.
+- Over-broad matching could falsely cancel normal events.
+
+## Test strategy
+1. Add unit tests for cancellation detection helper behavior:
+   - `STATUS:CANCELLED` => cancelled
+   - `[CANCELED]` in summary => cancelled
+   - neither => scheduled
+2. Keep tests focused to avoid brittle DOM rendering tests.
+3. Run targeted unit test file and a nearby ICS classification suite for smoke coverage.
+
+## Manual sanity checks
+- Load a team calendar with one cancelled ICS event and one scheduled ICS event.
+- Verify cancelled badge/styling appears only on cancelled event in detailed/compact views.

--- a/docs/pr-notes/runs/issue-151-fixer-20260304T022525Z/requirements.md
+++ b/docs/pr-notes/runs/issue-151-fixer-20260304T022525Z/requirements.md
@@ -1,0 +1,25 @@
+# Requirements Role Synthesis (Fallback)
+
+## Note on orchestration tooling
+Requested skills (`allplays-orchestrator-playbook`, `allplays-requirements-expert`) and `sessions_spawn` are not available in this runtime. This artifact captures equivalent requirements analysis.
+
+## Objective
+Ensure cancelled events from ICS feeds do not appear as active scheduled events on `calendar.html`.
+
+## Current vs proposed behavior
+- Current: ICS imports in `calendar.html` hardcode `status: 'scheduled'`, ignoring parsed cancellation signals.
+- Proposed: ICS events map to `status: 'cancelled'` when either ICS `STATUS:CANCELLED` is present or TeamSnap-style `[CANCELED]` appears in `SUMMARY`.
+
+## Acceptance criteria
+1. ICS `STATUS:CANCELLED` events render with cancelled styling/logic in calendar views.
+2. ICS `[CANCELED]` summary events render with cancelled styling/logic in calendar views.
+3. Non-cancelled ICS events remain scheduled and unchanged.
+
+## Risk surface and blast radius
+- Surface: calendar ICS event mapping only.
+- Blast radius: `calendar.html` display logic for imported (source=`ics`) events.
+- No Firestore writes, auth, or schedule CRUD path changes.
+
+## Assumptions
+- `parseICS` already populates `event.status` from ICS fields.
+- Existing UI treats `ev.status === 'cancelled'` as cancellation source of truth.

--- a/js/utils.js
+++ b/js/utils.js
@@ -886,6 +886,25 @@ export function getCalendarEventType(event) {
   return isPractice ? 'practice' : 'game';
 }
 
+/**
+ * Resolve normalized calendar event status for ICS events.
+ * @param {Object} event - Parsed ICS event
+ * @returns {'scheduled'|'cancelled'} Event status
+ */
+export function getCalendarEventStatus(event) {
+  const normalizedStatus = String(event?.status || '').trim().toUpperCase();
+  if (normalizedStatus === 'CANCELLED' || normalizedStatus === 'CANCELED') {
+    return 'cancelled';
+  }
+
+  const normalizedSummary = String(event?.summary || '').toUpperCase();
+  if (normalizedSummary.includes('[CANCELED]') || normalizedSummary.includes('[CANCELLED]')) {
+    return 'cancelled';
+  }
+
+  return 'scheduled';
+}
+
 // ============================================
 // Practice & Event Utilities - Phase 1
 // ============================================

--- a/tests/unit/calendar-ics-event-type.test.js
+++ b/tests/unit/calendar-ics-event-type.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getCalendarEventType } from '../../js/utils.js';
+import { getCalendarEventType, getCalendarEventStatus } from '../../js/utils.js';
 
 describe('getCalendarEventType', () => {
     it('classifies ICS practice events from summary when isPractice is missing', () => {
@@ -15,5 +15,22 @@ describe('getCalendarEventType', () => {
     it('classifies non-practice summaries as game', () => {
         const type = getCalendarEventType({ summary: 'U12 vs Lions' });
         expect(type).toBe('game');
+    });
+});
+
+describe('getCalendarEventStatus', () => {
+    it('maps ICS STATUS:CANCELLED to cancelled', () => {
+        const status = getCalendarEventStatus({ status: 'CANCELLED', summary: 'U12 vs Lions' });
+        expect(status).toBe('cancelled');
+    });
+
+    it('maps TeamSnap [CANCELED] summary to cancelled', () => {
+        const status = getCalendarEventStatus({ summary: '[CANCELED] U12 Practice' });
+        expect(status).toBe('cancelled');
+    });
+
+    it('keeps non-cancelled ICS events scheduled', () => {
+        const status = getCalendarEventStatus({ status: 'CONFIRMED', summary: 'U12 vs Lions' });
+        expect(status).toBe('scheduled');
     });
 });


### PR DESCRIPTION
Closes #151

## What changed
- Added `getCalendarEventStatus(event)` in `js/utils.js` to normalize ICS cancellation signals:
  - `STATUS:CANCELLED` / `STATUS:CANCELED`
  - TeamSnap-style `[CANCELED]` / `[CANCELLED]` in `SUMMARY`
- Updated `calendar.html` ICS import mapping to use `getCalendarEventStatus(ev)` instead of hardcoding `status: 'scheduled'`.
- Added unit coverage in `tests/unit/calendar-ics-event-type.test.js` for cancelled and scheduled status mapping.
- Added required role-synthesis run artifacts under `docs/pr-notes/runs/issue-151-fixer-20260304T022525Z/`.

## Why
`calendar.html` was dropping parsed cancellation metadata and always treating ICS events as scheduled. This patch preserves cancellation intent so cancelled synced events are rendered consistently with existing cancellation UI logic.

## Validation
- `pnpm dlx vitest run tests/unit/calendar-ics-event-type.test.js` (pass)
- `pnpm dlx vitest run tests/unit/calendar-ics-event-type.test.js tests/unit/utils-ics-practice-classification.test.js` (pass)
- Confirmed test-first failure before fix: `getCalendarEventStatus` missing and new tests failed.