### PR TITLE
Add baseline SEO indexing controls and metadata

### DIFF
--- a/accept-invite.html
+++ b/accept-invite.html
@@ -14,6 +14,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Accept Invite - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/admin.html
+++ b/admin.html
@@ -14,6 +14,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Admin Dashboard - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/beta/cheer/track-cheer-mobile.html
+++ b/beta/cheer/track-cheer-mobile.html
@@ -13,6 +13,7 @@
 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
   <title>Cheer Track (Beta) - ALL PLAYS</title>
   <link rel="icon" type="image/png" href="../img/logo_small.png">
   <script src="https://cdn.tailwindcss.com"></script>

--- a/beta/sub-tracker-prototype.html
+++ b/beta/sub-tracker-prototype.html
@@ -13,6 +13,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <title>Basketball Substitution & Playing Time - UX Prototype</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <style>

--- a/beta/track-basketball-mobile-mock.html
+++ b/beta/track-basketball-mobile-mock.html
@@ -13,6 +13,7 @@
 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
   <title>Track Basketball (Mobile Mock) - ALL PLAYS</title>
   <link rel="icon" type="image/png" href="../img/logo_small.png">
   <script src="https://cdn.tailwindcss.com"></script>

--- a/beta/track-basketball-mock.html
+++ b/beta/track-basketball-mock.html
@@ -13,6 +13,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <title>Track Basketball (Mock) - ALL PLAYS</title>
     <link rel="icon" type="image/png" href="../img/logo_small.png">
     <script src="https://cdn.tailwindcss.com"></script>

--- a/calendar.html
+++ b/calendar.html
@@ -13,6 +13,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Calendar - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/dashboard.html
+++ b/dashboard.html
@@ -14,6 +14,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
   <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>My Teams - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/docs/pr-notes/runs/158-remediator-20260304T054231Z/architecture.md
+++ b/docs/pr-notes/runs/158-remediator-20260304T054231Z/architecture.md
@@ -1,0 +1,6 @@
+# Architecture role notes
+
+- Current state: Static sitemap with hard-coded `lastmod` dates set to `2026-03-03`.
+- Proposed state: Keep static sitemap structure unchanged; replace hard-coded date with reviewer-requested valid historical date.
+- Blast radius: Single static XML file; no JS/runtime/API impact.
+- Controls: No auth/data access impact; zero tenant/PHI surface touched.

--- a/docs/pr-notes/runs/158-remediator-20260304T054231Z/code-plan.md
+++ b/docs/pr-notes/runs/158-remediator-20260304T054231Z/code-plan.md
@@ -1,0 +1,5 @@
+# Code role plan
+
+1. Edit `sitemap.xml` and replace both `2026-03-03` values with `2025-03-04` to match review suggestion.
+2. Validate by re-reading file and running XML lint check if available.
+3. Stage changed files and commit with an imperative, sentence-case message.

--- a/docs/pr-notes/runs/158-remediator-20260304T054231Z/qa.md
+++ b/docs/pr-notes/runs/158-remediator-20260304T054231Z/qa.md
@@ -1,0 +1,7 @@
+# QA role notes
+
+- Risk focus: XML validity and crawler interpretation of `lastmod`.
+- Validation plan:
+  - Confirm both `lastmod` tags are updated to `2025-03-04`.
+  - Confirm XML remains well-formed.
+- Regression risk: Very low, isolated to metadata consumed by search crawlers.

--- a/docs/pr-notes/runs/158-remediator-20260304T054231Z/requirements.md
+++ b/docs/pr-notes/runs/158-remediator-20260304T054231Z/requirements.md
@@ -1,0 +1,8 @@
+# Requirements role notes
+
+- Objective: Resolve PR thread PRRT_kwDOQe-T585x-bYh by fixing invalid/future `lastmod` values in `sitemap.xml`.
+- Scope: Only adjust sitemap `lastmod` dates as requested by review feedback.
+- Acceptance criteria:
+  - `sitemap.xml` uses a non-future date accepted by crawlers.
+  - Both URL entries have consistent `lastmod` values.
+  - No unrelated file behavior changes.

--- a/drills.html
+++ b/drills.html
@@ -11,6 +11,7 @@
     </script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Practice Command Center - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/edit-config.html
+++ b/edit-config.html
@@ -14,6 +14,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
   <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Edit Configs - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -14,6 +14,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Edit Roster - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -14,6 +14,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Edit Schedule - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/edit-team.html
+++ b/edit-team.html
@@ -14,6 +14,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Edit Team - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/game-day.html
+++ b/game-day.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <title>Game Day Command Center — ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>

--- a/game-plan.html
+++ b/game-plan.html
@@ -14,6 +14,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
   <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Game Day Planner - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/game.html
+++ b/game.html
@@ -14,6 +14,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Match Report - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/index.html
+++ b/index.html
@@ -14,10 +14,15 @@
 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Allplays is a free youth sports platform for team management, live tracking, schedules, communication, and AI-powered game insights.">
+  <link rel="canonical" href="https://allplays.ai/">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="ALL PLAYS">
+  <meta property="og:title" content="ALL PLAYS - Modern Team Management &amp; Statistics Platform">
+  <meta property="og:description" content="Allplays is a free youth sports platform for team management, live tracking, schedules, communication, and AI-powered game insights.">
+  <meta property="og:url" content="https://allplays.ai/">
   <link rel="icon" type="image/png" href="img/logo_small.png">
   <title>ALL PLAYS - Modern Team Management & Statistics Platform</title>
-  <meta name="description"
-    content="ALL PLAYS is a modern, free team management platform for coaches. Track stats in real-time, manage schedules, and build winning teams.">
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="css/styles.css">
   <script>

--- a/live-game.html
+++ b/live-game.html
@@ -13,6 +13,7 @@
 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+  <meta name="robots" content="noindex,nofollow">
   <title>Live Game - ALL PLAYS</title>
   <link rel="icon" type="image/png" href="img/logo_small.png">
   <script src="https://cdn.tailwindcss.com"></script>

--- a/live-tracker.html
+++ b/live-tracker.html
@@ -13,6 +13,7 @@
 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
   <title>Live Tracker - ALL PLAYS</title>
   <link rel="icon" type="image/png" href="img/logo_small.png">
   <script src="https://cdn.tailwindcss.com"></script>

--- a/login.html
+++ b/login.html
@@ -14,6 +14,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Login - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/mockups/game-day-command-center.html
+++ b/mockups/game-day-command-center.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <title>Game Day Command Center - UI Mockup</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>

--- a/mockups/practice-command-center.html
+++ b/mockups/practice-command-center.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <title>Practice Command Center - UI Mockup</title>
     <script src="https://cdn.tailwindcss.com"></script>
     <script>

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -14,6 +14,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Parent Dashboard - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/player.html
+++ b/player.html
@@ -14,6 +14,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Player Details - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/profile.html
+++ b/profile.html
@@ -14,6 +14,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Profile - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/reset-password.html
+++ b/reset-password.html
@@ -14,6 +14,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Account Action - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://allplays.ai/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -2,10 +2,10 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://allplays.ai/</loc>
-    <lastmod>2026-03-03</lastmod>
+    <lastmod>2025-03-04</lastmod>
   </url>
   <url>
     <loc>https://allplays.ai/teams.html</loc>
-    <lastmod>2026-03-03</lastmod>
+    <lastmod>2025-03-04</lastmod>
   </url>
 </urlset>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://allplays.ai/</loc>
+    <lastmod>2026-03-03</lastmod>
+  </url>
+  <url>
+    <loc>https://allplays.ai/teams.html</loc>
+    <lastmod>2026-03-03</lastmod>
+  </url>
+</urlset>

--- a/team-chat.html
+++ b/team-chat.html
@@ -13,6 +13,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Team Chat - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/team.html
+++ b/team.html
@@ -14,6 +14,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Team Details - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/teams.html
+++ b/teams.html
@@ -14,6 +14,13 @@
 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="Browse public youth sports teams on Allplays and explore schedules, live games, replays, and team activity.">
+  <link rel="canonical" href="https://allplays.ai/teams.html">
+  <meta property="og:type" content="website">
+  <meta property="og:site_name" content="ALL PLAYS">
+  <meta property="og:title" content="Browse Teams - ALL PLAYS">
+  <meta property="og:description" content="Browse public youth sports teams on Allplays and explore schedules, live games, replays, and team activity.">
+  <meta property="og:url" content="https://allplays.ai/teams.html">
   <link rel="icon" type="image/png" href="img/logo_small.png">
   <title>Browse Teams - ALL PLAYS</title>
   <script src="https://cdn.tailwindcss.com"></script>

--- a/test-fix-recurring-rsvp.html
+++ b/test-fix-recurring-rsvp.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <title>Test Suite — Recurring Practice RSVP Fix (Issue #50)</title>
     <style>
         body { font-family: monospace; padding: 20px; background: #f5f5f5; }

--- a/test-fix-schedule-drills.html
+++ b/test-fix-schedule-drills.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <title>Test Suite — Schedule Buffer, Drill Markdown, Photo Fix</title>
     <style>
         body { font-family: monospace; padding: 20px; background: #f5f5f5; }

--- a/test-foul-tracking.html
+++ b/test-foul-tracking.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <title>Foul Tracking & Score Undo Test Suite</title>
     <style>
         body { font-family: monospace; padding: 20px; background: #f5f5f5; }

--- a/test-game-day.html
+++ b/test-game-day.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <title>Test Suite — Game Day Command Center</title>
     <style>
         body { font-family: monospace; padding: 20px; background: #f5f5f5; }

--- a/test-pr-changes.html
+++ b/test-pr-changes.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <title>PR Test Suite - Basketball Detection & Auth Flow</title>
     <style>
         body { font-family: monospace; padding: 20px; background: #f5f5f5; }

--- a/test-statsheet-mapping.html
+++ b/test-statsheet-mapping.html
@@ -3,6 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
   <title>Score Sheet Mapping Tests</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>

--- a/test-track-live.html
+++ b/test-track-live.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <title>Test Suite - track-live.html Live Broadcasting</title>
     <style>
         body { font-family: monospace; padding: 20px; background: #f5f5f5; }

--- a/test-youtube-stream.html
+++ b/test-youtube-stream.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <title>Test Suite - Stream URL Parser</title>
     <style>
         body { font-family: monospace; padding: 20px; background: #f5f5f5; }

--- a/track-basketball.html
+++ b/track-basketball.html
@@ -13,6 +13,7 @@
 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
   <title>Track Basketball - ALL PLAYS</title>
   <link rel="icon" type="image/png" href="img/logo_small.png">
   <script src="https://cdn.tailwindcss.com"></script>

--- a/track-live.html
+++ b/track-live.html
@@ -14,6 +14,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Live Track Game - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -14,6 +14,7 @@
 
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
   <link rel="icon" type="image/png" href="img/logo_small.png">
   <title>Track from Score Sheet - ALL PLAYS</title>
   <script src="https://cdn.tailwindcss.com"></script>

--- a/track.html
+++ b/track.html
@@ -14,6 +14,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Track Game - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>

--- a/verify-pending.html
+++ b/verify-pending.html
@@ -14,6 +14,7 @@
 
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Verify Your Email - ALL PLAYS</title>
     <script src="https://cdn.tailwindcss.com"></script>


### PR DESCRIPTION
## What changed
- Added `robots.txt` with sitemap reference.
- Added `sitemap.xml` for indexable public URLs (`/` and `/teams.html`).
- Added crawl/index metadata across all HTML pages:
  - `index.html` and `teams.html`: `description`, `canonical`, and Open Graph tags.
  - all other HTML pages: `meta name="robots" content="noindex,nofollow"`.

## Why
- Establishes clear crawler discovery and URL indexing policy.
- Prevents private/app/test pages from appearing in search results.
- Improves snippet quality and canonical consistency for public landing pages.

## Manual test steps
1. Open `index.html` and `teams.html`; verify `description`, `canonical`, and OG tags are present in `<head>`.
2. Open a non-public page (for example `login.html` or `dashboard.html`); verify `noindex,nofollow` meta tag exists in `<head>`.
3. Open `robots.txt`; verify sitemap line points to `https://allplays.ai/sitemap.xml`.
4. Validate `sitemap.xml` structure and confirm it contains only:
   - `https://allplays.ai/`
   - `https://allplays.ai/teams.html`
