### PR TITLE
Fix live reset sync and generic tracker UX/state gaps

### DIFF
--- a/docs/pr-notes/runs/issue-155-fixer-20260304T082513Z/architecture.md
+++ b/docs/pr-notes/runs/issue-155-fixer-20260304T082513Z/architecture.md
@@ -1,0 +1,19 @@
+# Architecture Role Synthesis
+
+## Current state
+- `track-live.html` holds tracker logic inline and does not publish a reset semantic event to viewers.
+- `live-game.js` is append-only for event processing and does not handle state reset events.
+- `live-game.js` forcibly injects `FLS` into display columns.
+- Opponent display relies on `game.opponent` first, causing linked-opponent name misses.
+
+## Proposed state
+- Introduce tiny shared helper modules:
+  - `js/live-game-state.js` for opponent name resolution, stat column normalization, and reset-state projection.
+  - `js/live-tracker-field-status.js` for player on-field/bench state + elapsed time accounting.
+- Use `reset` live event from tracker and consume it in viewer to clear viewer state in-session.
+- Keep `liveLineup` shape (`onCourt`, `bench`) for compatibility, but update UI copy to generic language.
+
+## Risk and blast radius
+- Blast radius limited to `live-game` and `track-live` pages plus new helper modules.
+- Firestore document updates remain on existing fields (`liveLineup`, scores, period, opponent fields).
+- Main risk is inline-script integration regressions in `track-live.html`; mitigated by unit tests for helper logic and targeted manual flow checks.

--- a/docs/pr-notes/runs/issue-155-fixer-20260304T082513Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-155-fixer-20260304T082513Z/code-plan.md
@@ -1,0 +1,25 @@
+# Code Role Plan
+
+## Files to change
+- `js/live-game.js`
+- `track-live.html`
+- `live-game.html`
+- `js/live-game-state.js` (new)
+- `js/live-tracker-field-status.js` (new)
+- `tests/unit/live-game-state.test.js` (new)
+- `tests/unit/live-tracker-field-status.test.js` (new)
+
+## Minimal patch strategy
+1. Add helper modules and tests (initially failing against current behavior assumptions).
+2. Wire `live-game.js` to helper functions:
+   - opponent name resolver
+   - normalized stat column list (no forced FLS)
+   - reset event handling
+   - generic lineup labels
+3. Update `track-live.html`:
+   - emit reset event and reset game doc/liveLineup on reset
+   - implement on-field/bench column + timer bookkeeping with helper module
+   - opponent name fallback
+   - style refresh only
+4. Update copy in `live-game.html` for generic language/icon.
+5. Run targeted unit tests and finalize commit.

--- a/docs/pr-notes/runs/issue-155-fixer-20260304T082513Z/qa.md
+++ b/docs/pr-notes/runs/issue-155-fixer-20260304T082513Z/qa.md
@@ -1,0 +1,19 @@
+# QA Role Synthesis
+
+## Failing-first coverage targets
+- Reset event projection clears live viewer state.
+- Foul column is not added unless configured.
+- Opponent display name picks linked-opponent fields when present.
+- On-field timing accumulates only while player is on field.
+
+## Regression checks
+- Live chat still initializes and sends.
+- Score updates still reflect stat buttons.
+- Period changes still broadcast and render.
+- Replay mode unaffected by new reset logic.
+
+## Manual scenarios
+1. Start game in `track-live.html`, add stats, open `live-game.html`, click Reset in tracker, verify viewer zeros/clears immediately.
+2. Use config without foul column, verify `FLS` absent in viewer player cards/opponent cards.
+3. Linked opponent team game with `opponentTeamName`, verify title and away team name populate.
+4. Toggle player `On`/`Bench`, run timer, verify elapsed field time increments only while `On`.

--- a/docs/pr-notes/runs/issue-155-fixer-20260304T082513Z/requirements.md
+++ b/docs/pr-notes/runs/issue-155-fixer-20260304T082513Z/requirements.md
@@ -1,0 +1,17 @@
+# Requirements Role Synthesis
+
+## Objective
+Fix live tracker and live viewer regressions for generic (non-basketball-specific) game tracking UX and state sync.
+
+## User-facing requirements
+- Reset in `track-live.html` must also reset what viewers see in `live-game.html` without requiring a page refresh.
+- Foul stat label/value (`FLS`) must only appear when configured as a trackable column.
+- Opponent name must display reliably from linked-opponent fields.
+- Remove basketball-specific wording in live viewer UI (`On Court`, basketball icon, `Lineup not set`).
+- Team stats table in `track-live.html` needs a status control (`On Field` / `Bench`) and tracked time-on-field.
+- Modernize theme of `track-live.html` (visual only, no behavior changes outside requested items).
+
+## Constraints
+- Keep changes minimal and compatible with existing Firestore structures.
+- Preserve existing event logging behavior.
+- Avoid introducing sport-specific assumptions in generic tracker.

--- a/js/live-game-state.js
+++ b/js/live-game-state.js
@@ -1,0 +1,37 @@
+export function resolveOpponentDisplayName(game) {
+  const opponent = String(game?.opponent || '').trim();
+  if (opponent) return opponent;
+  const linkedName = String(game?.opponentTeamName || '').trim();
+  if (linkedName) return linkedName;
+  return 'Opponent';
+}
+
+export function normalizeLiveStatColumns(columns) {
+  const normalized = Array.isArray(columns)
+    ? columns.map((column) => String(column || '').trim().toUpperCase()).filter(Boolean)
+    : [];
+  if (normalized.length) return normalized;
+  return ['PTS', 'REB', 'AST', 'STL', 'TO'];
+}
+
+export function applyResetEventState(currentState, event) {
+  const period = event?.period || currentState?.period || 'Q1';
+  const onCourt = Array.isArray(event?.onCourt) ? [...event.onCourt] : [];
+  const bench = Array.isArray(event?.bench) ? [...event.bench] : [];
+  return {
+    ...currentState,
+    homeScore: Number.isFinite(event?.homeScore) ? event.homeScore : 0,
+    awayScore: Number.isFinite(event?.awayScore) ? event.awayScore : 0,
+    period,
+    gameClockMs: Number.isFinite(event?.gameClockMs) ? event.gameClockMs : 0,
+    events: [],
+    eventIds: new Set(),
+    stats: {},
+    opponentStats: {},
+    onCourt,
+    bench,
+    lastStatChange: null,
+    scoringRun: { team: null, points: 0 },
+    lastRunAnnounced: 0
+  };
+}

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -21,6 +21,7 @@ import { isViewerChatEnabled } from './live-game-chat.js?v=1';
 import { getReplayElapsedMs, getReplayStartTimeAfterSpeedChange } from './live-game-replay.js?v=2';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
+import { resolveOpponentDisplayName, normalizeLiveStatColumns, applyResetEventState } from './live-game-state.js?v=1';
 
 const state = {
   teamId: null,
@@ -166,7 +167,7 @@ function showToast(message) {
 
 function buildShareText(mode, url) {
   const teamName = state.team?.name || 'Team';
-  const opponent = state.game?.opponent || 'Opponent';
+  const opponent = resolveOpponentDisplayName(state.game);
   const dateLabel = formatShortDate(state.game?.date);
   const timeLabel = formatTime(state.game?.date);
   if (mode === 'report') {
@@ -277,7 +278,7 @@ function setupVideoPanel() {
 
 function renderGameInfo() {
   els.homeTeamName.textContent = state.team?.name || 'Home Team';
-  els.awayTeamName.textContent = state.game?.opponent || 'Away Team';
+  els.awayTeamName.textContent = resolveOpponentDisplayName(state.game);
   if (els.homeTeamPhoto) {
     if (state.team?.photoUrl) {
       els.homeTeamPhoto.src = state.team.photoUrl;
@@ -367,9 +368,7 @@ function renderPlayByPlay(event, isNew = false) {
 function renderStats() {
   if (!els.opponentStats) return;
   const oppEntries = Object.entries(state.opponentStats || {});
-  const columns = (state.statColumns && state.statColumns.length)
-    ? state.statColumns
-    : ['PTS', 'REB', 'AST', 'FLS'];
+  const columns = normalizeLiveStatColumns(state.statColumns);
   els.opponentStats.innerHTML = oppEntries.map(([id, player]) => {
     const highlight = state.lastStatChange?.isOpponent && state.lastStatChange?.playerId === id;
     const nameClass = highlight ? 'text-coral' : 'text-sand';
@@ -414,9 +413,7 @@ function renderLineup() {
       const highlight = state.lastStatChange?.playerId === id && !state.lastStatChange?.isOpponent;
       const nameClass = highlight ? 'text-teal' : 'text-sand';
       const statClass = highlight ? 'text-teal' : 'text-sand';
-      const columns = (state.statColumns && state.statColumns.length)
-        ? state.statColumns
-        : ['PTS', 'REB', 'AST', 'FLS'];
+      const columns = normalizeLiveStatColumns(state.statColumns);
       const statItems = columns.map(col => {
         const key = statKeyMap[col] || col.toLowerCase();
         const val = stats[key] || 0;
@@ -443,8 +440,8 @@ function renderLineup() {
     }).join('');
   };
 
-  els.lineupOnCourt.innerHTML = renderList(onCourtIds, 'Lineup not set');
-  els.lineupBench.innerHTML = renderList(benchIds, 'Bench not set');
+  els.lineupOnCourt.innerHTML = renderList(onCourtIds, 'No players currently on field');
+  els.lineupBench.innerHTML = renderList(benchIds, 'No players currently on bench');
 }
 
 function renderChat() {
@@ -765,6 +762,18 @@ function processNewEvents(events) {
   const newEvents = events.filter(ev => !state.eventIds.has(ev.id));
   newEvents.forEach(event => {
     state.eventIds.add(event.id);
+    if (event.type === 'reset') {
+      const next = applyResetEventState(state, event);
+      Object.assign(state, next);
+      state.eventIds.add(event.id);
+      if (els.playsFeed) {
+        els.playsFeed.innerHTML = '<div data-placeholder="plays" class="text-center text-sand/40 py-8">Game reset. Waiting for plays...</div>';
+      }
+      renderScoreboard();
+      renderStats();
+      renderLineup();
+      return;
+    }
     if (Array.isArray(event.onCourt)) state.onCourt = event.onCourt;
     if (Array.isArray(event.bench)) state.bench = event.bench;
     if (Array.isArray(event.onCourt) || Array.isArray(event.bench)) {
@@ -1323,6 +1332,7 @@ function formatFirestoreError(error) {
 function handleGameUpdate(gameDoc) {
   if (!gameDoc) return;
   state.game = gameDoc;
+  renderGameInfo();
   if (gameDoc.liveLineup) {
     state.onCourt = Array.isArray(gameDoc.liveLineup.onCourt) ? gameDoc.liveLineup.onCourt : state.onCourt;
     state.bench = Array.isArray(gameDoc.liveLineup.bench) ? gameDoc.liveLineup.bench : state.bench;
@@ -1413,15 +1423,10 @@ async function init() {
   if (game?.statTrackerConfigId && Array.isArray(configs)) {
     const config = configs.find(c => c.id === game.statTrackerConfigId);
     if (config && Array.isArray(config.columns)) {
-      state.statColumns = config.columns.map(c => String(c).toUpperCase());
+      state.statColumns = normalizeLiveStatColumns(config.columns);
     }
   }
-  if (!state.statColumns.length) {
-    state.statColumns = ['PTS', 'REB', 'AST', 'STL', 'TO'];
-  }
-  if (!state.statColumns.includes('FLS') && !state.statColumns.includes('FOULS')) {
-    state.statColumns.push('FLS');
-  }
+  state.statColumns = normalizeLiveStatColumns(state.statColumns);
   state.opponentStats = game.opponentStats || {};
   if (game.liveLineup) {
     state.onCourt = Array.isArray(game.liveLineup.onCourt) ? game.liveLineup.onCourt : [];

--- a/js/live-tracker-field-status.js
+++ b/js/live-tracker-field-status.js
@@ -1,0 +1,81 @@
+function ensurePlayer(state, playerId) {
+  if (!state[playerId]) {
+    state[playerId] = {
+      status: 'bench',
+      elapsedMs: 0,
+      lastStartedAt: null
+    };
+  }
+  return state[playerId];
+}
+
+export function createFieldState(players) {
+  const state = {};
+  (players || []).forEach((player) => {
+    if (!player?.id) return;
+    state[player.id] = {
+      status: 'bench',
+      elapsedMs: 0,
+      lastStartedAt: null
+    };
+  });
+  return state;
+}
+
+export function setPlayerFieldStatus(state, playerId, status, nowMs) {
+  const entry = ensurePlayer(state, playerId);
+  const nextStatus = status === 'onField' ? 'onField' : 'bench';
+  const hasNow = Number.isFinite(nowMs);
+
+  if (entry.status === nextStatus) return entry;
+
+  if (entry.status === 'onField' && Number.isFinite(entry.lastStartedAt) && hasNow) {
+    entry.elapsedMs += Math.max(0, nowMs - entry.lastStartedAt);
+  }
+
+  entry.status = nextStatus;
+  entry.lastStartedAt = nextStatus === 'onField' && hasNow ? nowMs : null;
+  return entry;
+}
+
+export function startFieldClock(state, nowMs) {
+  if (!Number.isFinite(nowMs)) return;
+  Object.values(state || {}).forEach((entry) => {
+    if (entry.status === 'onField' && !Number.isFinite(entry.lastStartedAt)) {
+      entry.lastStartedAt = nowMs;
+    }
+  });
+}
+
+export function pauseFieldClock(state, nowMs) {
+  if (!Number.isFinite(nowMs)) return;
+  Object.values(state || {}).forEach((entry) => {
+    if (entry.status === 'onField' && Number.isFinite(entry.lastStartedAt)) {
+      entry.elapsedMs += Math.max(0, nowMs - entry.lastStartedAt);
+      entry.lastStartedAt = null;
+    }
+  });
+}
+
+export function getPlayerFieldElapsedMs(state, playerId, nowMs) {
+  const entry = ensurePlayer(state, playerId);
+  if (entry.status === 'onField' && Number.isFinite(entry.lastStartedAt) && Number.isFinite(nowMs)) {
+    return entry.elapsedMs + Math.max(0, nowMs - entry.lastStartedAt);
+  }
+  return entry.elapsedMs;
+}
+
+export function getLiveLineup(state, players) {
+  const orderedIds = (players || []).map((player) => player.id).filter(Boolean);
+  const onCourt = [];
+  const bench = [];
+  orderedIds.forEach((playerId) => {
+    const entry = ensurePlayer(state, playerId);
+    if (entry.status === 'onField') {
+      onCourt.push(playerId);
+    } else {
+      bench.push(playerId);
+    }
+  });
+  return { onCourt, bench };
+}

--- a/live-game.html
+++ b/live-game.html
@@ -277,7 +277,7 @@
         <div class="overflow-y-auto flex-1 pr-1 space-y-4">
           <div>
             <div class="text-teal/70 text-xs uppercase tracking-[0.2em] mb-2">Lineup</div>
-            <div class="text-sand/60 text-xs mb-1">On Court</div>
+            <div class="text-sand/60 text-xs mb-1">On Field</div>
             <div id="lineup-oncourt" class="grid grid-cols-1 gap-2"></div>
             <div class="text-sand/60 text-xs mt-3 mb-1">Bench</div>
             <div id="lineup-bench" class="grid grid-cols-1 gap-2"></div>
@@ -396,7 +396,7 @@
   <!-- GAME NOT LIVE STATE -->
   <div id="not-live-overlay" class="hidden fixed right-4 bottom-24 z-40 max-w-xs w-[90%] bg-slate/95 border border-teal/30 rounded-2xl p-4 shadow-xl">
     <div class="flex items-start gap-3">
-      <div class="text-3xl">&#127936;</div>
+      <div class="text-3xl">&#127939;</div>
       <div>
         <h2 class="text-base font-bold mb-1">Game Not Live Yet</h2>
         <p class="text-sand/70 text-xs mb-2">Chat is open while you wait.</p>

--- a/tests/unit/live-game-state.test.js
+++ b/tests/unit/live-game-state.test.js
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { resolveOpponentDisplayName, normalizeLiveStatColumns, applyResetEventState } from '../../js/live-game-state.js';
+
+describe('live game state helpers', () => {
+  it('prefers linked opponent team name when opponent is missing', () => {
+    expect(resolveOpponentDisplayName({ opponent: '', opponentTeamName: 'Riverside FC' })).toBe('Riverside FC');
+    expect(resolveOpponentDisplayName({ opponent: 'Lions', opponentTeamName: 'Riverside FC' })).toBe('Lions');
+  });
+
+  it('does not force foul column into generic stat columns', () => {
+    expect(normalizeLiveStatColumns(['PTS', 'REB', 'AST'])).toEqual(['PTS', 'REB', 'AST']);
+  });
+
+  it('resets live viewer state from reset event payload', () => {
+    const next = applyResetEventState({
+      period: 'Q4',
+      homeScore: 33,
+      awayScore: 21,
+      gameClockMs: 123000,
+      events: [{ id: 'e1' }],
+      eventIds: new Set(['e1']),
+      stats: { p1: { pts: 2 } },
+      opponentStats: { o1: { pts: 4 } },
+      onCourt: ['p1'],
+      bench: ['p2']
+    }, {
+      period: 'Q1',
+      homeScore: 0,
+      awayScore: 0,
+      gameClockMs: 0,
+      onCourt: [],
+      bench: ['p1', 'p2']
+    });
+
+    expect(next.period).toBe('Q1');
+    expect(next.homeScore).toBe(0);
+    expect(next.awayScore).toBe(0);
+    expect(next.gameClockMs).toBe(0);
+    expect(next.events).toEqual([]);
+    expect(Array.from(next.eventIds)).toEqual([]);
+    expect(next.stats).toEqual({});
+    expect(next.opponentStats).toEqual({});
+    expect(next.onCourt).toEqual([]);
+    expect(next.bench).toEqual(['p1', 'p2']);
+  });
+});

--- a/tests/unit/live-tracker-field-status.test.js
+++ b/tests/unit/live-tracker-field-status.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { createFieldState, setPlayerFieldStatus, getPlayerFieldElapsedMs, getLiveLineup } from '../../js/live-tracker-field-status.js';
+
+describe('live tracker field status helpers', () => {
+  it('tracks elapsed time only while player is on field', () => {
+    const state = createFieldState([{ id: 'p1' }]);
+
+    setPlayerFieldStatus(state, 'p1', 'onField', 1000);
+    expect(getPlayerFieldElapsedMs(state, 'p1', 5000)).toBe(4000);
+
+    setPlayerFieldStatus(state, 'p1', 'bench', 5000);
+    expect(getPlayerFieldElapsedMs(state, 'p1', 8000)).toBe(4000);
+  });
+
+  it('returns lineup arrays compatible with liveLineup shape', () => {
+    const state = createFieldState([{ id: 'p1' }, { id: 'p2' }]);
+    setPlayerFieldStatus(state, 'p1', 'onField', 0);
+    const lineup = getLiveLineup(state, [{ id: 'p1' }, { id: 'p2' }]);
+    expect(lineup.onCourt).toEqual(['p1']);
+    expect(lineup.bench).toEqual(['p2']);
+  });
+});

--- a/track-live.html
+++ b/track-live.html
@@ -39,7 +39,10 @@
     <style>
         body {
             font-family: 'Montserrat', 'Roboto', sans-serif;
-            background: #f4f4f4;
+            background:
+                radial-gradient(circle at 10% 10%, rgba(56, 189, 248, 0.14), transparent 35%),
+                radial-gradient(circle at 90% 0%, rgba(16, 185, 129, 0.10), transparent 32%),
+                #eef3f8;
             font-size: 14px;
         }
 
@@ -104,12 +107,12 @@
     </style>
 </head>
 
-<body class="bg-gray-50 text-gray-900">
+<body class="bg-transparent text-gray-900">
     <div id="header-container"></div>
 
     <div class="p-2">
         <!-- Game Tracking Header -->
-        <div class="bg-blue-600 text-white p-3 rounded-lg mb-3 shadow-md">
+        <div class="bg-slate-900 text-white p-3 rounded-lg mb-3 shadow-lg border border-sky-400/30">
             <div class="flex justify-between items-center mb-2">
                 <div>
                     <div class="flex items-center gap-2 mb-1">
@@ -166,12 +169,12 @@
         </div>
 
         <!-- Team Stats Table -->
-        <div class="bg-white rounded-lg shadow-md overflow-hidden border-2 border-blue-600 mb-3">
-            <div class="bg-blue-600 text-white p-3 font-bold text-center">Team Stats</div>
+        <div class="bg-white rounded-lg shadow-md overflow-hidden border-2 border-slate-800 mb-3">
+            <div class="bg-slate-800 text-white p-3 font-bold text-center">Team Stats</div>
             <div class="overflow-x-auto">
                 <table class="w-full text-center text-xs" id="statsTable">
                     <thead>
-                        <tr class="bg-gray-100 border-b-2 border-blue-600">
+                        <tr class="bg-gray-100 border-b-2 border-slate-800">
                             <th class="player-name text-left p-1">Player</th>
                             <!-- Column headers will be injected -->
                         </tr>
@@ -225,8 +228,8 @@
         </div>
 
         <!-- Game Log -->
-        <div class="bg-white rounded-lg shadow-md border-2 border-blue-600 p-3 max-h-48 overflow-y-auto">
-            <h3 class="font-bold text-sm text-blue-600 mb-2">Game Log</h3>
+        <div class="bg-white rounded-lg shadow-md border-2 border-slate-800 p-3 max-h-48 overflow-y-auto">
+            <h3 class="font-bold text-sm text-slate-800 mb-2">Game Log</h3>
             <div id="gameLog" class="text-xs">
                 <div class="p-2 bg-gray-100 rounded text-gray-500 text-center">Game log will appear here</div>
             </div>
@@ -336,6 +339,8 @@
         import { db } from './js/firebase.js?v=9';
         import { writeBatch, doc, setDoc, addDoc, onSnapshot } from './js/firebase.js?v=9';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
+        import { resolveOpponentDisplayName } from './js/live-game-state.js?v=1';
+        import { createFieldState, setPlayerFieldStatus, startFieldClock, pauseFieldClock, getPlayerFieldElapsedMs, getLiveLineup } from './js/live-tracker-field-status.js?v=1';
         import { checkAuth } from './js/auth.js?v=9';
         import { getApp } from './js/vendor/firebase-app.js';
         import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './js/live-tracker-notes.js?v=1';
@@ -380,7 +385,8 @@
             gameLog: [],
             playerStats: {}, // In-memory player stats (replaces real-time DB writes)
             opponentStats: {},
-            currentPeriod: 'Q1'
+            currentPeriod: 'Q1',
+            playerFieldStatus: {}
         };
 
         const chatEls = {
@@ -472,11 +478,14 @@
                     });
                 }
 
-                document.getElementById('game-title').textContent = `vs. ${escapeHtml(game.opponent)}`;
+                document.getElementById('game-title').textContent = `vs. ${escapeHtml(resolveOpponentDisplayName(game))}`;
                 document.getElementById('game-meta').textContent = escapeHtml(team.name);
                 homeScore = game.homeScore || 0;
                 awayScore = game.awayScore || 0;
                 updateScoreDisplay();
+                gameState.playerFieldStatus = createFieldState(players);
+                const existingOnField = Array.isArray(game.liveLineup?.onCourt) ? game.liveLineup.onCourt : [];
+                existingOnField.forEach((playerId) => setPlayerFieldStatus(gameState.playerFieldStatus, playerId, 'onField', null));
 
                 // Load Config
                 if (game.statTrackerConfigId) {
@@ -570,12 +579,54 @@
             document.getElementById('away-score').textContent = awayScore;
         }
 
+        function formatFieldTime(ms) {
+            const totalSeconds = Math.floor((ms || 0) / 1000);
+            const minutes = Math.floor(totalSeconds / 60);
+            const seconds = totalSeconds % 60;
+            return `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+        }
+
+        function getFieldStatus(playerId) {
+            return gameState.playerFieldStatus[playerId]?.status === 'onField' ? 'onField' : 'bench';
+        }
+
+        async function syncLiveLineup() {
+            if (!currentTeamId || !currentGameId) return;
+            const liveLineup = getLiveLineup(gameState.playerFieldStatus, players);
+            try {
+                await updateGame(currentTeamId, currentGameId, { liveLineup });
+            } catch (error) {
+                console.warn('Failed to sync live lineup:', error);
+            }
+            if (gameState.isRunning) {
+                broadcastLiveEvent(currentTeamId, currentGameId, {
+                    type: 'lineup',
+                    period: gameState.currentPeriod,
+                    gameClockMs: gameState.elapsed,
+                    homeScore,
+                    awayScore,
+                    onCourt: liveLineup.onCourt,
+                    bench: liveLineup.bench,
+                    description: 'Lineup updated',
+                    createdBy: currentUser?.uid || null
+                }).catch(console.warn);
+            }
+        }
+
+        window.setPlayerFieldStatus = function (playerId, status) {
+            const now = gameState.isRunning ? Date.now() : null;
+            setPlayerFieldStatus(gameState.playerFieldStatus, playerId, status, now);
+            renderStatsTable();
+            syncLiveLineup().catch(console.warn);
+        };
+
         function renderStatsTable() {
             const thead = document.querySelector('#statsTable thead tr');
             const tbody = document.getElementById('statsTableBody');
 
             // Render column headers
             let headersHTML = '<th class="player-name text-left p-1">Player</th>';
+            headersHTML += '<th class="stat-cell-wide p-1">Status</th>';
             currentConfig.columns.forEach(col => {
                 const isPoints = col.toUpperCase() === 'PTS' || col.toUpperCase() === 'POINTS';
                 headersHTML += `<th class="${isPoints ? 'stat-cell-wide' : 'stat-cell'} p-1">${col}</th>`;
@@ -597,6 +648,19 @@
                             <span>#${escapeHtml(player.number || '-')} ${escapeHtml(player.name)}</span>
                         </div>
                     </td>`;
+                const fieldMs = getPlayerFieldElapsedMs(gameState.playerFieldStatus, player.id, gameState.isRunning ? Date.now() : null);
+                const onField = getFieldStatus(player.id) === 'onField';
+                rowHTML += `<td class="stat-cell-wide p-1">
+                    <div class="flex flex-col items-center gap-1">
+                        <div id="field-time-${player.id}" class="text-[10px] font-semibold text-slate-700">${formatFieldTime(fieldMs)}</div>
+                        <div class="flex gap-0.5">
+                            <button class="stat-btn rounded px-1.5 h-5 text-[10px] font-bold border ${onField ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-blue-600 border-blue-300'}"
+                                onclick="setPlayerFieldStatus('${player.id}', 'onField')">On</button>
+                            <button class="stat-btn rounded px-1.5 h-5 text-[10px] font-bold border ${onField ? 'bg-white text-gray-600 border-gray-300' : 'bg-gray-700 text-white border-gray-700'}"
+                                onclick="setPlayerFieldStatus('${player.id}', 'bench')">Bench</button>
+                        </div>
+                    </div>
+                </td>`;
 
                 currentConfig.columns.forEach(col => {
                     const isPoints = col.toUpperCase() === 'PTS' || col.toUpperCase() === 'POINTS';
@@ -1009,6 +1073,7 @@
 
                 gameState.startTime = Date.now() - gameState.elapsed;
                 gameState.isRunning = true;
+                startFieldClock(gameState.playerFieldStatus, Date.now());
                 document.getElementById('startBtn').disabled = true;
                 document.getElementById('stopBtn').disabled = false;
                 addLogEntry('Game started');
@@ -1027,25 +1092,41 @@
                 }).catch(console.warn);
                 document.getElementById('liveBadge').classList.remove('hidden');
                 document.getElementById('shareLiveBtn').classList.remove('hidden');
+                syncLiveLineup().catch(console.warn);
             }
         }
 
         function stopTimer() {
             if (gameState.isRunning) {
                 gameState.isRunning = false;
+                pauseFieldClock(gameState.playerFieldStatus, Date.now());
                 document.getElementById('startBtn').disabled = false;
                 document.getElementById('stopBtn').disabled = true;
                 addLogEntry('Game stopped');
+                renderStatsTable();
             }
         }
 
         async function resetTimer() {
             if (confirm('Reset timer and clear all stats? This will also clear saved stats in the database.')) {
+                pauseFieldClock(gameState.playerFieldStatus, Date.now());
                 gameState.startTime = null;
                 gameState.elapsed = 0;
                 gameState.isRunning = false;
                 gameState.gameLog = [];
                 gameState.playerStats = {}; // Clear in-memory player stats
+                gameState.playerFieldStatus = createFieldState(players);
+                opponentPlayers.forEach((opp) => {
+                    const existing = gameState.opponentStats[opp.id] || {};
+                    gameState.opponentStats[opp.id] = {
+                        ...existing,
+                        name: existing.name || opp.name || '',
+                        number: existing.number || '',
+                    };
+                    currentConfig.columns.forEach((col) => {
+                        gameState.opponentStats[opp.id][col.toLowerCase()] = 0;
+                    });
+                });
                 homeScore = 0;
                 awayScore = 0;
 
@@ -1058,14 +1139,45 @@
 
                 // Clear aggregated stats in Firebase
                 try {
+                    const eventsSnapshot = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
+                    await Promise.all(eventsSnapshot.docs.map(eventDoc => deleteDoc(eventDoc.ref)));
+
                     const statsSnapshot = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`));
                     await Promise.all(statsSnapshot.docs.map(doc => deleteDoc(doc.ref)));
+
+                    const liveEventsSnapshot = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));
+                    await Promise.all(liveEventsSnapshot.docs.map(liveDoc => deleteDoc(liveDoc.ref)));
+
+                    const liveLineup = getLiveLineup(gameState.playerFieldStatus, players);
+                    await updateGame(currentTeamId, currentGameId, {
+                        homeScore: 0,
+                        awayScore: 0,
+                        period: gameState.currentPeriod,
+                        liveLineup,
+                        opponentStats: gameState.opponentStats
+                    });
+                    await setGameLiveStatus(currentTeamId, currentGameId, 'scheduled').catch(console.warn);
+                    await broadcastLiveEvent(currentTeamId, currentGameId, {
+                        type: 'reset',
+                        period: gameState.currentPeriod,
+                        gameClockMs: 0,
+                        homeScore: 0,
+                        awayScore: 0,
+                        onCourt: liveLineup.onCourt,
+                        bench: liveLineup.bench,
+                        description: 'Game reset',
+                        createdBy: currentUser?.uid || null
+                    }).catch(console.warn);
                 } catch (error) {
                     console.error('Error clearing stats:', error);
                 }
 
                 updateScoreDisplay();
                 renderGameLog();
+                renderStatsTable();
+                renderOpponentTable();
+                document.getElementById('liveBadge').classList.add('hidden');
+                document.getElementById('shareLiveBtn').classList.add('hidden');
                 updateTimer();
             }
         }
@@ -1121,6 +1233,12 @@
 
             document.getElementById('timer').textContent =
                 `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+            players.forEach((player) => {
+                const timeEl = document.getElementById(`field-time-${player.id}`);
+                if (!timeEl) return;
+                const elapsedMs = getPlayerFieldElapsedMs(gameState.playerFieldStatus, player.id, gameState.isRunning ? Date.now() : null);
+                timeEl.textContent = formatFieldTime(elapsedMs);
+            });
         }
 
         function getGameTime() {
@@ -1337,7 +1455,7 @@
         // Email Summary Function
         function generateEmailBody(finalHomeScore, finalAwayScore, summary = '') {
             const gameData = {
-                opponent: currentGame.opponent || 'Unknown Opponent',
+                opponent: resolveOpponentDisplayName(currentGame),
                 date: currentGame.date ? new Date(currentGame.date.seconds * 1000).toLocaleDateString() : new Date().toLocaleDateString(),
                 gameTime: getGameTime(),
                 homeScore: finalHomeScore,
@@ -1406,7 +1524,7 @@
 
         function emailSummary() {
             const gameData = {
-                opponent: currentGame.opponent || 'Unknown Opponent'
+                opponent: resolveOpponentDisplayName(currentGame)
             };
             const subject = `${currentTeam.name} vs ${gameData.opponent} - Game Summary`;
             const body = generateEmailBody(homeScore, awayScore, '');
@@ -1437,7 +1555,7 @@
                 const finalAwayScore = parseInt(document.getElementById('finalAwayScore').value) || awayScore;
 
                 // Build comprehensive game context
-                let context = `Game: ${currentTeam.name} vs ${currentGame.opponent}\n`;
+                let context = `Game: ${currentTeam.name} vs ${resolveOpponentDisplayName(currentGame)}\n`;
                 context += `Final Score: ${finalHomeScore} - ${finalAwayScore}\n`;
                 context += `Date: ${currentGame.date ? new Date(currentGame.date.seconds * 1000).toLocaleDateString() : new Date().toLocaleDateString()}\n`;
                 context += `Sport: ${currentTeam.sport || 'Unknown'}\n\n`;
@@ -1629,7 +1747,7 @@ Write the match report now:`;
 
                 // Send email if checkbox is checked
                 if (sendEmail) {
-                    const subject = `${currentTeam.name} vs ${currentGame.opponent || 'Unknown Opponent'} - Game Summary`;
+                    const subject = `${currentTeam.name} vs ${resolveOpponentDisplayName(currentGame)} - Game Summary`;
                     const body = generateEmailBody(finalHome, finalAway, summary);
                     const userEmail = currentUser.email || '';
                     const mailto = `mailto:${userEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;


### PR DESCRIPTION
Closes #155

## What changed
- Added shared helper modules for live viewer state and tracker field-status timing:
  - `js/live-game-state.js`
  - `js/live-tracker-field-status.js`
- Added unit tests for the above helpers:
  - reset-state projection for live viewer
  - opponent-name fallback behavior
  - no forced foul column (`FLS`) for generic configs
  - on-field/bench elapsed-time tracking
- Updated `js/live-game.js` to:
  - consume reset events and clear in-session live viewer state immediately
  - stop forcing foul columns when not configured
  - use linked-opponent fallback name (`opponentTeamName`)
  - replace basketball-specific empty-lineup copy with generic wording
- Updated `live-game.html` labels/icons to remove basketball-specific wording in the lineup/not-live areas.
- Updated `track-live.html` to:
  - add Team Stats `Status` column with `On` / `Bench` buttons and per-player time-on-field tracking
  - sync lineup (`liveLineup`) to the game doc and broadcast lineup updates
  - make reset clear stored events/liveEvents/aggregates, reset scores+lineup/opponent stats, and broadcast a live `reset` event
  - use opponent display fallback (`opponentTeamName` when `opponent` is missing)
  - apply a more modern visual theme update without changing core tracker workflows
- Added required run artifacts:
  - `docs/pr-notes/runs/issue-155-fixer-20260304T082513Z/{requirements,architecture,qa,code-plan}.md`

## Why
The live viewer previously remained stale after tracker reset, foul columns were shown even when not configured, linked-opponent names could be lost in display, and the generic tracker lacked field-status/time controls. This patch targets those regressions and requested enhancements with small shared utilities and focused page updates.