### PR TITLE
Deduplicate RSVP summary by player for coach overrides

### DIFF
--- a/docs/pr-notes/runs/161-review-3888860497-20260304T113343Z/architecture.md
+++ b/docs/pr-notes/runs/161-review-3888860497-20260304T113343Z/architecture.md
@@ -1,0 +1,28 @@
+# Architecture Role (allplays-architecture-expert)
+
+## Current-State Read
+`computeRsvpSummary` always calls `getCachedRsvpRoster`, which memoizes roster reads per team for the full page session. `submitRsvpForPlayer` now relies on `computeRsvpSummary`, so coach overrides can aggregate against stale roster membership.
+
+## Proposed Design
+Add an opt-in fresh roster mode to summary computation:
+- Extend `getCachedRsvpRoster(teamId)` with an option to force refresh the cached roster promise.
+- Extend `computeRsvpSummary(teamId, gameId)` with `freshRoster` option.
+- Call `computeRsvpSummary(..., { freshRoster: true })` only from `submitRsvpForPlayer`.
+
+This keeps blast radius narrow while restoring pre-regression behavior for override path.
+
+## Files And Modules Touched
+- `js/db.js`
+- `docs/pr-notes/runs/161-review-3888860497-20260304T113343Z/*.md` (traceability artifacts)
+
+## Data/State Impacts
+- Cache state (`rosterPromise`) is refreshed on coach override recompute.
+- No schema changes. `rsvpSummary` payload shape unchanged.
+
+## Security/Permissions Impacts
+- No access-control boundary change.
+- Existing `permission-denied` and `not-found` handling preserved.
+
+## Failure Modes And Mitigations
+- Fresh roster read failure: existing error handling path remains in place.
+- Increased read cost on coach override path only: acceptable due to low frequency and correctness priority.

--- a/docs/pr-notes/runs/161-review-3888860497-20260304T113343Z/code-plan.md
+++ b/docs/pr-notes/runs/161-review-3888860497-20260304T113343Z/code-plan.md
@@ -1,0 +1,38 @@
+# Code Role (allplays-code-expert)
+
+## Patch Plan
+- Add `forceRefresh` option to roster cache helper.
+- Add `freshRoster` option to `computeRsvpSummary`.
+- Use fresh-roster compute only in `submitRsvpForPlayer`.
+- Keep all other call sites unchanged for minimal blast radius.
+
+## Code Changes Applied
+- `js/db.js`: implemented opt-in roster refresh path and wired coach override flow to it.
+
+## Validation Run
+- Run focused RSVP unit tests:
+  - `npx vitest tests/unit/rsvp-summary.test.js tests/unit/rsvp-hydration.test.js tests/unit/rsvp-doc-ids.test.js`
+
+## Residual Risks
+- `submitRsvp` still uses cached roster and may not reflect immediate roster edits in rare same-session timing windows.
+- `sessions_spawn` tool unavailable in this runtime; role outputs were produced as equivalent structured artifacts in this run directory.
+
+## Commit Message Draft
+Fix stale roster summary on coach RSVP overrides
+
+## Final Synthesis
+### Acceptance Criteria
+- Coach override summary recompute uses latest roster, preserving current error handling and behavior outside override path.
+
+### Architecture Decisions
+- Opt-in refresh flag chosen over global cache invalidation to control blast radius and maintain performance.
+
+### QA Plan
+- Focused RSVP unit regression tests plus explicit manual scenario for same-session roster change.
+
+### Implementation Plan
+- Minimal targeted changes in `js/db.js`; no schema/UI/rules updates.
+
+### Risks And Rollback
+- Risk: slight extra Firestore read on coach override path.
+- Rollback: revert this commit to restore prior cached-only behavior.

--- a/docs/pr-notes/runs/161-review-3888860497-20260304T113343Z/qa.md
+++ b/docs/pr-notes/runs/161-review-3888860497-20260304T113343Z/qa.md
@@ -1,0 +1,33 @@
+# QA Role (allplays-qa-expert)
+
+## Risk Matrix
+- High: incorrect RSVP totals after roster edits in same session (core coach workflow correctness).
+- Medium: unintended behavior change in non-override RSVP paths.
+- Low: doc-only artifact additions.
+
+## Automated Tests To Add/Update
+- No targeted unit seam currently exposes `computeRsvpSummary` cache toggle without broad test harness changes in `js/db.js`.
+- Run existing RSVP-focused unit tests as regression safety net:
+  - `tests/unit/rsvp-summary.test.js`
+  - `tests/unit/rsvp-hydration.test.js`
+  - `tests/unit/rsvp-doc-ids.test.js`
+
+## Manual Test Plan
+1. Open schedule/game context as coach.
+2. Submit override RSVP for player A; verify summary updates.
+3. Edit roster in same session (add/remove player).
+4. Submit another coach override.
+5. Verify `rsvpSummary.total` and `notResponded` match current roster size.
+
+## Negative Tests
+- Force a permission-denied scenario and confirm error handling unchanged.
+- Use recurring-occurrence game ID and confirm not-found suppression still prevents override crash during summary writeback.
+
+## Release Gates
+- Targeted RSVP unit tests pass.
+- No unrelated file modifications.
+- Patch limited to RSVP summary cache freshness behavior.
+
+## Post-Deploy Checks
+- Spot-check one real team where coach overrides follow same-session roster changes.
+- Monitor support/issue channel for RSVP count mismatch reports for 24 hours after deploy.

--- a/docs/pr-notes/runs/161-review-3888860497-20260304T113343Z/requirements.md
+++ b/docs/pr-notes/runs/161-review-3888860497-20260304T113343Z/requirements.md
@@ -1,0 +1,28 @@
+# Requirements Role (allplays-requirements-expert)
+
+## Problem Statement
+Coach override RSVP submissions can write a stale `rsvpSummary` when roster membership changed after initial page-session hydration, causing incorrect totals/not-responded counts for game-day decisions.
+
+## User Segments Impacted
+- Coach/admin: needs accurate attendance totals immediately after overrides.
+- Parent: needs trust that displayed availability matches latest roster.
+- Team manager/program owner: depends on accurate counts for operational planning.
+
+## Acceptance Criteria
+1. Submitting `submitRsvpForPlayer` recomputes summary using current roster membership from Firestore, not only session-cached roster data.
+2. If roster changed (add/remove player) earlier in the same session, resulting `rsvpSummary.total` and `rsvpSummary.notResponded` reflect the latest roster immediately after override save.
+3. Existing `submitRsvp` and `getRsvpSummaries` behavior remains unchanged to avoid broad performance/regression impact.
+4. Permission-denied and not-found handling in RSVP write paths remains unchanged.
+
+## Non-Goals
+- No redesign of RSVP hydration cache strategy across all RSVP entry points.
+- No Firestore schema or rules changes.
+- No UI rendering changes.
+
+## Edge Cases
+- Roster fetch fails after override write: function still throws non-permission errors as before.
+- Concurrent roster edits and override write: last successful summary recompute reflects latest fetched roster at recompute time.
+- Recurring occurrence game IDs remain handled by existing not-found suppression during game doc update.
+
+## Open Questions
+- Should parent `submitRsvp` also force a fresh roster read for strict consistency, or keep cached path for lower read volume?

--- a/docs/pr-notes/runs/issue-156-fixer-20260304T112507Z/architecture.md
+++ b/docs/pr-notes/runs/issue-156-fixer-20260304T112507Z/architecture.md
@@ -1,0 +1,25 @@
+# Architecture Role Synthesis (Fallback)
+
+## Objective
+Fix summary semantics with minimal blast radius in static web + Firebase client module.
+
+## Design
+- Introduce a pure helper to compute effective per-player RSVP summary from:
+  - RSVP docs
+  - active roster IDs
+  - existing player-resolution fallback map
+  - existing response normalization
+- Reuse this helper in all summary paths:
+  - `computeRsvpSummary`
+  - `getRsvpSummaries`
+  - `submitRsvpForPlayer` denormalized write
+
+## Risk Surface
+- Area: RSVP aggregation only.
+- Blast radius: summary counts in parent/coaching calendar and game docs.
+- Data model unchanged.
+
+## Controls and Rollback
+- No schema migration.
+- Rollback is single commit revert.
+- Unit tests isolate expected effective-per-player counting behavior.

--- a/docs/pr-notes/runs/issue-156-fixer-20260304T112507Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-156-fixer-20260304T112507Z/code-plan.md
@@ -1,0 +1,13 @@
+# Code Role Plan (Fallback)
+
+## Plan
+1. Add pure helper module for effective per-player RSVP summary.
+2. Add failing unit tests capturing parent+coach overlap bug.
+3. Wire helper into existing summary paths in `js/db.js`.
+4. Run targeted and related RSVP unit tests.
+5. Commit with issue reference.
+
+## Assumptions
+- `respondedAt` ordering determines latest effective response.
+- Existing player ID resolution and fallback behavior remains authoritative.
+- No backend/cloud function changes required.

--- a/docs/pr-notes/runs/issue-156-fixer-20260304T112507Z/qa.md
+++ b/docs/pr-notes/runs/issue-156-fixer-20260304T112507Z/qa.md
@@ -1,0 +1,13 @@
+# QA Role Synthesis (Fallback)
+
+## Test Strategy
+Add unit tests for pure summary helper with overlapping parent and coach docs for same player.
+
+## Primary Regression Guardrails
+- Latest response wins for same player across multiple docs.
+- Multi-player parent RSVP with one player override does not double-count overridden player.
+- Summary never exceeds roster size in overlap scenario.
+
+## Manual Verification Focus
+- Parent dashboard and calendar summary values after parent RSVP then coach override.
+- Game Day changes reflected as replacement for targeted player.

--- a/docs/pr-notes/runs/issue-156-fixer-20260304T112507Z/requirements.md
+++ b/docs/pr-notes/runs/issue-156-fixer-20260304T112507Z/requirements.md
@@ -1,0 +1,20 @@
+# Requirements Role Synthesis (Fallback)
+
+## Objective
+Ensure RSVP summaries count each player in exactly one availability bucket based on their latest effective RSVP.
+
+## Current State
+Summary aggregation counts RSVP documents and sums player counts per document. When a parent RSVP and coach override both exist for the same player, both are counted.
+
+## Proposed State
+Summary aggregation resolves an effective response per player by latest `respondedAt`, then computes totals from that per-player map.
+
+## User/UX Requirements
+- Parent and coach views show internally consistent counts.
+- A single player never appears in multiple summary buckets.
+- Coach override behavior should replace, not add to, prior parent response for that player.
+
+## Acceptance Criteria
+- For same player with parent + coach docs, only latest response counts.
+- Summary total remains bounded by active roster size.
+- Existing valid RSVP flows are unchanged for players without overlapping docs.

--- a/js/db.js
+++ b/js/db.js
@@ -2521,9 +2521,9 @@ function getRsvpSummaryHydrationCache(teamId) {
     return rsvpSummaryHydrationCacheByTeam.get(teamId);
 }
 
-function getCachedRsvpRoster(teamId) {
+function getCachedRsvpRoster(teamId, { forceRefresh = false } = {}) {
     const cache = getRsvpSummaryHydrationCache(teamId);
-    if (!cache.rosterPromise) {
+    if (forceRefresh || !cache.rosterPromise) {
         cache.rosterPromise = getPlayers(teamId).catch((err) => {
             cache.rosterPromise = null;
             throw err;
@@ -2610,10 +2610,11 @@ function resolveRsvpPlayerIds(rsvp, fallbackByUser) {
 }
 export { buildCoachOverrideRsvpDocId };
 
-async function computeRsvpSummary(teamId, gameId) {
+async function computeRsvpSummary(teamId, gameId, options = {}) {
+    const { freshRoster = false } = options;
     const [rsvps, roster] = await Promise.all([
         getRsvps(teamId, gameId),
-        getCachedRsvpRoster(teamId)
+        getCachedRsvpRoster(teamId, { forceRefresh: freshRoster })
     ]);
     const fallbackByUser = await buildFallbackPlayerIdsByUser(teamId, rsvps, {
         resolveIdsForUser: (uid) => getCachedFallbackPlayerIdsForUser(teamId, uid)
@@ -2737,7 +2738,7 @@ export async function submitRsvpForPlayer(teamId, gameId, userId, { displayName,
     // Keep denormalized summary consistent with submitRsvp behavior.
     let summary = null;
     try {
-        summary = await computeRsvpSummary(teamId, gameId);
+        summary = await computeRsvpSummary(teamId, gameId, { freshRoster: true });
     } catch (err) {
         if (err?.code !== 'permission-denied') throw err;
     }

--- a/js/db.js
+++ b/js/db.js
@@ -34,6 +34,7 @@ import { imageStorage, ensureImageAuth, requireImageAuth } from './firebase-imag
 import { buildDrillDiagramUploadPaths } from './drill-upload-paths.js?v=1';
 import { isAccessCodeExpired } from './access-code-utils.js?v=1';
 import { buildCoachOverrideRsvpDocId } from './rsvp-doc-ids.js';
+import { computeEffectiveRsvpSummary } from './rsvp-summary.js?v=1';
 import {
     isTeamActive,
     filterTeamsByActive,
@@ -2618,27 +2619,13 @@ async function computeRsvpSummary(teamId, gameId) {
         resolveIdsForUser: (uid) => getCachedFallbackPlayerIdsForUser(teamId, uid)
     });
     const activeRosterIds = new Set(roster.map((player) => player.id));
-    const summary = { going: 0, maybe: 0, notGoing: 0, notResponded: 0, total: 0 };
-
-    rsvps.forEach((rsvp) => {
-        const responseKey = normalizeRsvpResponse(rsvp.response);
-        if (responseKey === 'not_responded') return;
-
-        const playerCount = resolveRsvpPlayerIds(rsvp, fallbackByUser)
-            .filter((id) => activeRosterIds.has(id))
-            .length;
-        if (playerCount === 0) return;
-
-        if (responseKey === 'going') summary.going += playerCount;
-        else if (responseKey === 'maybe') summary.maybe += playerCount;
-        else if (responseKey === 'not_going') summary.notGoing += playerCount;
+    return computeEffectiveRsvpSummary({
+        rsvps,
+        activeRosterIds,
+        fallbackByUser,
+        normalizeResponse: normalizeRsvpResponse,
+        resolvePlayerIds: resolveRsvpPlayerIds
     });
-
-    summary.total = summary.going + summary.maybe + summary.notGoing;
-    summary.notResponded = Math.max(0, roster.length - summary.total);
-    summary.total = roster.length;
-
-    return summary;
 }
 
 export async function getRsvpSummaries(teamId, gameIds) {
@@ -2664,25 +2651,13 @@ export async function getRsvpSummaries(teamId, gameIds) {
         const fallbackByUser = await buildFallbackPlayerIdsByUser(teamId, rsvps, {
             resolveIdsForUser: (uid) => getCachedFallbackPlayerIdsForUser(teamId, uid)
         });
-        const summary = { going: 0, maybe: 0, notGoing: 0, notResponded: 0, total: 0 };
-
-        rsvps.forEach((rsvp) => {
-            const responseKey = normalizeRsvpResponse(rsvp.response);
-            if (responseKey === 'not_responded') return;
-
-            const playerCount = resolveRsvpPlayerIds(rsvp, fallbackByUser)
-                .filter((id) => activeRosterIds.has(id))
-                .length;
-            if (playerCount === 0) return;
-
-            if (responseKey === 'going') summary.going += playerCount;
-            else if (responseKey === 'maybe') summary.maybe += playerCount;
-            else if (responseKey === 'not_going') summary.notGoing += playerCount;
+        const summary = computeEffectiveRsvpSummary({
+            rsvps,
+            activeRosterIds,
+            fallbackByUser,
+            normalizeResponse: normalizeRsvpResponse,
+            resolvePlayerIds: resolveRsvpPlayerIds
         });
-
-        summary.total = summary.going + summary.maybe + summary.notGoing;
-        summary.notResponded = Math.max(0, roster.length - summary.total);
-        summary.total = roster.length;
         summaries.set(gameId, summary);
     }));
 
@@ -2762,29 +2737,7 @@ export async function submitRsvpForPlayer(teamId, gameId, userId, { displayName,
     // Keep denormalized summary consistent with submitRsvp behavior.
     let summary = null;
     try {
-        const [rsvps, roster] = await Promise.all([
-            getRsvps(teamId, gameId),
-            getPlayers(teamId)
-        ]);
-        const fallbackByUser = await buildFallbackPlayerIdsByUser(teamId, rsvps);
-        const activeRosterIds = new Set(roster.map((player) => player.id));
-        summary = { going: 0, maybe: 0, notGoing: 0, notResponded: 0, total: 0 };
-        rsvps.forEach((rsvp) => {
-            const responseKey = normalizeRsvpResponse(rsvp.response);
-            if (responseKey === 'not_responded') return;
-
-            const playerCount = resolveRsvpPlayerIds(rsvp, fallbackByUser)
-                .filter((id) => activeRosterIds.has(id))
-                .length;
-            if (playerCount === 0) return;
-
-            if (responseKey === 'going') summary.going += playerCount;
-            else if (responseKey === 'maybe') summary.maybe += playerCount;
-            else if (responseKey === 'not_going') summary.notGoing += playerCount;
-        });
-        summary.total = summary.going + summary.maybe + summary.notGoing;
-        summary.notResponded = Math.max(0, roster.length - summary.total);
-        summary.total = roster.length;
+        summary = await computeRsvpSummary(teamId, gameId);
     } catch (err) {
         if (err?.code !== 'permission-denied') throw err;
     }

--- a/js/rsvp-summary.js
+++ b/js/rsvp-summary.js
@@ -1,0 +1,54 @@
+function toMillis(value) {
+    if (!value) return 0;
+    if (typeof value?.toMillis === 'function') return value.toMillis();
+    if (value instanceof Date) return value.getTime();
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? 0 : parsed.getTime();
+}
+
+export function computeEffectiveRsvpSummary({
+    rsvps,
+    activeRosterIds,
+    fallbackByUser,
+    normalizeResponse,
+    resolvePlayerIds
+}) {
+    const summary = { going: 0, maybe: 0, notGoing: 0, notResponded: 0, total: 0 };
+    if (!Array.isArray(rsvps) || !(activeRosterIds instanceof Set) || activeRosterIds.size === 0) {
+        summary.total = activeRosterIds instanceof Set ? activeRosterIds.size : 0;
+        summary.notResponded = summary.total;
+        return summary;
+    }
+
+    const latestByPlayer = new Map();
+
+    rsvps.forEach((rsvp) => {
+        const responseKey = normalizeResponse(rsvp?.response);
+        const nextMillis = toMillis(rsvp?.respondedAt);
+        const playerIds = Array.from(new Set(
+            (resolvePlayerIds(rsvp, fallbackByUser) || [])
+                .filter((id) => activeRosterIds.has(id))
+        ));
+        if (!playerIds.length) return;
+
+        playerIds.forEach((playerId) => {
+            const existing = latestByPlayer.get(playerId);
+            if (existing && nextMillis < existing.respondedAtMillis) return;
+            latestByPlayer.set(playerId, {
+                responseKey,
+                respondedAtMillis: nextMillis
+            });
+        });
+    });
+
+    latestByPlayer.forEach((entry) => {
+        if (entry.responseKey === 'going') summary.going += 1;
+        else if (entry.responseKey === 'maybe') summary.maybe += 1;
+        else if (entry.responseKey === 'not_going') summary.notGoing += 1;
+    });
+
+    summary.total = activeRosterIds.size;
+    const respondedCount = summary.going + summary.maybe + summary.notGoing;
+    summary.notResponded = Math.max(0, summary.total - respondedCount);
+    return summary;
+}

--- a/tests/unit/rsvp-summary.test.js
+++ b/tests/unit/rsvp-summary.test.js
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+import { computeEffectiveRsvpSummary } from '../../js/rsvp-summary.js';
+
+const normalizeResponse = (response) => {
+    if (response === 'going' || response === 'maybe' || response === 'not_going') return response;
+    return 'not_responded';
+};
+
+const resolvePlayerIds = (rsvp) => Array.isArray(rsvp?.playerIds) ? rsvp.playerIds : [];
+
+describe('effective RSVP summary', () => {
+    it('counts each player once using their latest response when parent and coach docs overlap', () => {
+        const rosterIds = new Set(['p1', 'p2']);
+        const rsvps = [
+            {
+                userId: 'parent-1',
+                playerIds: ['p1', 'p2'],
+                response: 'going',
+                respondedAt: '2026-03-04T11:00:00.000Z'
+            },
+            {
+                userId: 'coach-1',
+                playerIds: ['p1'],
+                response: 'not_going',
+                respondedAt: '2026-03-04T11:05:00.000Z'
+            }
+        ];
+
+        const summary = computeEffectiveRsvpSummary({
+            rsvps,
+            activeRosterIds: rosterIds,
+            fallbackByUser: new Map(),
+            normalizeResponse,
+            resolvePlayerIds
+        });
+
+        expect(summary).toEqual({
+            going: 1,
+            maybe: 0,
+            notGoing: 1,
+            notResponded: 0,
+            total: 2
+        });
+    });
+
+    it('lets newer parent RSVP replace an older coach override for the same player', () => {
+        const rosterIds = new Set(['p1']);
+        const rsvps = [
+            {
+                userId: 'coach-1',
+                playerIds: ['p1'],
+                response: 'not_going',
+                respondedAt: '2026-03-04T11:00:00.000Z'
+            },
+            {
+                userId: 'parent-1',
+                playerIds: ['p1'],
+                response: 'going',
+                respondedAt: '2026-03-04T11:07:00.000Z'
+            }
+        ];
+
+        const summary = computeEffectiveRsvpSummary({
+            rsvps,
+            activeRosterIds: rosterIds,
+            fallbackByUser: new Map(),
+            normalizeResponse,
+            resolvePlayerIds
+        });
+
+        expect(summary).toEqual({
+            going: 1,
+            maybe: 0,
+            notGoing: 0,
+            notResponded: 0,
+            total: 1
+        });
+    });
+});


### PR DESCRIPTION
Closes #156

## What changed
- Added a new pure helper at `js/rsvp-summary.js` to compute RSVP summaries by resolving the latest effective response per player (`respondedAt` wins), instead of summing RSVP documents.
- Updated RSVP summary paths in `js/db.js` (`computeRsvpSummary`, `getRsvpSummaries`, and coach override submission summary refresh) to use that shared helper.
- Added unit regression coverage in `tests/unit/rsvp-summary.test.js` for parent RSVP + coach override overlap cases to ensure a player is counted in exactly one bucket.
- Added required orchestration analysis artifacts under `docs/pr-notes/runs/issue-156-fixer-20260304T112507Z/`.

## Why
The prior summary logic counted documents, so a parent RSVP and coach override for the same player were additive. This patch changes aggregation semantics to per-player latest-effective response, which keeps `going/maybe/notGoing/notResponded` internally consistent across parent and coach views.

## Validation
- `node /home/paul-bot1/.openclaw/workspace/allplays/node_modules/vitest/vitest.mjs run tests/unit/rsvp-summary.test.js tests/unit/rsvp-doc-ids.test.js tests/unit/rsvp-hydration.test.js tests/unit/parent-dashboard-rsvp.test.js`