### PR TITLE
Fix recurrence expansion for long-running practice series

### DIFF
--- a/docs/pr-notes/runs/163-remediator-20260304T143110Z/architecture.md
+++ b/docs/pr-notes/runs/163-remediator-20260304T143110Z/architecture.md
@@ -1,0 +1,15 @@
+# Architecture role notes
+
+- Current state:
+  - `expandRecurrence` iterates day-by-day.
+  - Cursor may jump from `seriesStart` to `windowStart` for performance.
+  - Weekly cadence is anchored to `seriesStartWeekStartDayNumber`.
+  - Iteration cap is derived from `windowDays` and computed span.
+- Risk surface:
+  - Fast-forwarded cursors can be off cadence for interval-weekly schedules unless explicitly re-aligned.
+  - Iteration cap mis-sizing can silently drop occurrences.
+- Proposed state:
+  - Keep day-by-day strategy, but when fast-forwarding weekly schedules, align cursor to the next interval-matching week based on the original series anchor.
+  - Set iteration cap to traversal days plus a fixed safety buffer so it cannot underflow the day-by-day loop.
+- Blast radius:
+  - Confined to recurrence expansion behavior and related recurrence unit tests.

--- a/docs/pr-notes/runs/163-remediator-20260304T143110Z/code-plan.md
+++ b/docs/pr-notes/runs/163-remediator-20260304T143110Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code role notes
+
+- Orchestration note:
+  - Requested `allplays-orchestrator-playbook` and role skills were not available in this environment, so inline role analysis was performed.
+- Implementation plan:
+  1. Update `js/utils.js` in `expandRecurrence`:
+     - After jump to `windowStart`, re-align weekly cursor week parity against series anchor.
+     - Replace iteration cap formula with traversal-length + safety margin.
+  2. Update `tests/unit/recurrence-expand.test.js`:
+     - Replace loose long-running assertion with exact expected in-window dates and count.
+  3. Run targeted test file and commit.

--- a/docs/pr-notes/runs/163-remediator-20260304T143110Z/qa.md
+++ b/docs/pr-notes/runs/163-remediator-20260304T143110Z/qa.md
@@ -1,0 +1,11 @@
+# QA role notes
+
+- Test focus for this remediation:
+  - Biweekly multi-day cadence remains anchored correctly after fast-forward.
+  - Long-running weekly series returns a complete contiguous set of occurrences in-window.
+  - No early truncation from iteration guard.
+- Validation plan:
+  - Run `tests/unit/recurrence-expand.test.js` with Vitest.
+  - Confirm long-running weekly test asserts exact expected list and count over window.
+- Residual risk:
+  - Broader recurrence scenarios (count-limited old series) are unchanged by this patch and should be covered separately if needed.

--- a/docs/pr-notes/runs/163-remediator-20260304T143110Z/requirements.md
+++ b/docs/pr-notes/runs/163-remediator-20260304T143110Z/requirements.md
@@ -1,0 +1,13 @@
+# Requirements role notes
+
+- Objective: Resolve the three unresolved PR review threads on recurrence expansion in PR #163.
+- Required outcomes:
+  - Fix weekly cadence logic when the recurrence cursor is fast-forwarded to `windowStart`.
+  - Ensure iteration guard cannot truncate day-by-day traversal for long-running series.
+  - Strengthen tests to verify no missing weekly occurrences in the full visible window for long-running series.
+- Scope constraints:
+  - Minimal targeted edits only in recurrence expansion logic and affected unit tests.
+  - No unrelated refactors or behavior changes outside recurrence expansion guardrails.
+- Acceptance signals:
+  - Updated unit test(s) fail before and pass after fix.
+  - Existing recurrence-expand tests pass.

--- a/docs/pr-notes/runs/163-remediator-20260304T143840Z/architecture.md
+++ b/docs/pr-notes/runs/163-remediator-20260304T143840Z/architecture.md
@@ -1,0 +1,7 @@
+# Architecture Role Notes
+
+- Skill/session orchestration requested but unavailable in this environment (`allplays-orchestrator-playbook` and `sessions_spawn` not present), so using inline role analysis fallback.
+- Design change: initialize `generated` with occurrences already consumed before the fast-forward cursor and continue incrementing on each recurrence match.
+- Keep existing recurrence pattern computation (`weekly`, `daily`, `interval`, `byDays`) intact to avoid widening blast radius.
+- Blast radius: isolated to `expandRecurrence` in `js/utils.js`; no schema/API or cross-module contract changes.
+- Risk: minor behavior adjustment for count+exDates interactions; acceptable for correctness of count exhaustion bug.

--- a/docs/pr-notes/runs/163-remediator-20260304T143840Z/code-plan.md
+++ b/docs/pr-notes/runs/163-remediator-20260304T143840Z/code-plan.md
@@ -1,0 +1,7 @@
+# Code Role Plan
+
+1. Update `expandRecurrence` in `js/utils.js` to precompute consumed recurrence count before `current` when fast-forwarding occurs.
+2. Increment recurrence count on rule match independently of visibility window inclusion.
+3. Keep occurrence creation conditions (`windowStart`, `exDates`, overrides) unchanged.
+4. Run targeted recurrence tests.
+5. Stage and commit only scoped files.

--- a/docs/pr-notes/runs/163-remediator-20260304T143840Z/qa.md
+++ b/docs/pr-notes/runs/163-remediator-20260304T143840Z/qa.md
@@ -1,0 +1,9 @@
+# QA Role Notes
+
+- Targeted regression to validate:
+  - Old weekly series with small finite `count` and start date far before `windowStart` should produce zero occurrences once count is exhausted.
+  - Active finite series should still produce expected in-window occurrences until count is reached.
+  - Infinite/without-count recurrence should remain unchanged.
+- Validation approach:
+  - Run recurrence unit spec(s) under `tests/` related to `expandRecurrence`.
+  - If no direct test runner target exists, run the nearest recurrence-related node test file and report outcome.

--- a/docs/pr-notes/runs/163-remediator-20260304T143840Z/requirements.md
+++ b/docs/pr-notes/runs/163-remediator-20260304T143840Z/requirements.md
@@ -1,0 +1,7 @@
+# Requirements Role Notes
+
+- Objective: Resolve PR thread `PRRT_kwDOQe-T585yEy7G` by preventing finite recurrence series from generating instances after their `recurrence.count` is already exhausted.
+- Current behavior: `expandRecurrence` fast-forwards old series to `windowStart`, but `generated` starts at 0, so count termination only reflects post-window occurrences.
+- Required behavior: count-based recurrence must terminate based on total matched recurrence instances since series start, not just those iterated in the visible window.
+- Scope: Minimal change in `js/utils.js` recurrence expansion logic only.
+- Assumptions: `count` applies to recurrence matches globally (series lifespan), and visibility/exclusions should not reset count progression.

--- a/docs/pr-notes/runs/163-review-comment-2884121890-20260304T143512Z/architecture.md
+++ b/docs/pr-notes/runs/163-review-comment-2884121890-20260304T143512Z/architecture.md
@@ -1,0 +1,18 @@
+# Architecture Role Summary
+
+## Current state
+- `expandRecurrence` computes `seriesStartWeekStartDayNumber` from `seriesStart`.
+- When old series are expanded, cursor is moved to `windowStart` with original time-of-day.
+- Weekly cadence matching uses `weeksSinceSeriesStart` derived from the same series week anchor.
+
+## Risk surface
+- Any mismatch between pre-loop skip alignment and per-day interval checks can produce off-cadence weekdays.
+- Blast radius is schedule rendering and downstream RSVP state for recurring practices.
+
+## Decision
+- Preserve implementation in `js/utils.js` (already anchored correctly at PR head).
+- Add explicit regression test to lock the long-running biweekly multi-day case.
+
+## Control equivalence
+- No data model or auth/rules changes.
+- Behavioral contract tightened with deterministic unit coverage.

--- a/docs/pr-notes/runs/163-review-comment-2884121890-20260304T143512Z/code-plan.md
+++ b/docs/pr-notes/runs/163-review-comment-2884121890-20260304T143512Z/code-plan.md
@@ -1,0 +1,16 @@
+# Code Role Summary
+
+## Plan executed
+- Confirmed weekly anchor alignment logic already present in `js/utils.js`.
+- Added focused regression test in `tests/unit/recurrence-expand.test.js`:
+  - `keeps biweekly multi-day cadence anchored to series start after window jump`
+- Re-ran recurrence unit tests.
+
+## Why minimal patch
+- Review comment targets a logic concern that is already fixed at current head.
+- Test-only reinforcement is the safest change that prevents future regressions without broad code churn.
+
+## Role conflict resolution
+- Requirements/architecture considered optional code change.
+- QA required explicit reproducible coverage for reported scenario.
+- Final decision: test reinforcement only.

--- a/docs/pr-notes/runs/163-review-comment-2884121890-20260304T143512Z/qa.md
+++ b/docs/pr-notes/runs/163-review-comment-2884121890-20260304T143512Z/qa.md
@@ -1,0 +1,14 @@
+# QA Role Summary
+
+## Regression risks
+- Off-cadence weekly dates emitted after window jump.
+- Hidden regressions for daily interval and weekly interval=1 behavior.
+
+## Test strategy
+- Keep existing 4 recurrence interval guardrail tests.
+- Add one targeted test for 2024->2026 long-running biweekly MO/WE cadence.
+
+## Pass criteria
+- First six emitted dates match expected on-cadence weeks only.
+- Immediate off-cadence week dates are explicitly absent.
+- Entire recurrence-expand suite remains green.

--- a/docs/pr-notes/runs/163-review-comment-2884121890-20260304T143512Z/requirements.md
+++ b/docs/pr-notes/runs/163-review-comment-2884121890-20260304T143512Z/requirements.md
@@ -1,0 +1,17 @@
+# Requirements Role Summary
+
+## Objective
+Confirm whether weekly recurrence expansion preserves RRULE cadence when iteration jumps from series start to visible window.
+
+## User-impact framing
+- A coach/parent expects recurring Monday/Wednesday practices set as biweekly to remain biweekly even for long-running series.
+- Any cadence drift causes incorrect schedule visibility and RSVP confusion.
+
+## Acceptance criteria
+- Weekly interval math remains anchored to series week boundary, not the jumped cursor week.
+- Long-running series (start in 2024, viewed in 2026) with `interval: 2` and `byDays: ['MO','WE']` only emits on-cadence weeks.
+- No false positives in the immediate off-cadence week after window start.
+
+## Assumptions
+- Week boundary semantics are local `Date.getDay()` based (Sunday start), consistent with current implementation.
+- Existing behavior for daily and interval=1 weekly rules must remain unchanged.

--- a/docs/pr-notes/runs/163-review-comment-2884121900-20260304T144215Z/architecture.md
+++ b/docs/pr-notes/runs/163-review-comment-2884121900-20260304T144215Z/architecture.md
@@ -1,0 +1,24 @@
+# Current-State Read
+`tests/unit/recurrence-expand.test.js` includes a long-running weekly test with a static expected list. It proves some dates exist but weakly communicates completeness across the entire recurrence window.
+
+# Proposed Design
+Strengthen only the test by deriving expected in-window Monday occurrences from `windowStart` and `windowEnd`, then assert:
+- exact equality of returned date list,
+- exact expected count,
+- no internal gaps via 7-day interval checks.
+
+# Files And Modules Touched
+- `tests/unit/recurrence-expand.test.js`
+
+# Data/State Impacts
+- Test-only change; no production data paths.
+- No runtime state changes.
+
+# Security/Permissions Impacts
+- None. No auth/rules/network surface changes.
+
+# Failure Modes And Mitigations
+- Risk: Test mirrors implementation too closely.
+  Mitigation: Build expected dates from independent window arithmetic and invariant cadence checks.
+- Risk: Timezone drift in expectations.
+  Mitigation: Use fixed UTC timestamps and `instanceDate` string assertions.

--- a/docs/pr-notes/runs/163-review-comment-2884121900-20260304T144215Z/code-plan.md
+++ b/docs/pr-notes/runs/163-review-comment-2884121900-20260304T144215Z/code-plan.md
@@ -1,0 +1,21 @@
+# Patch Plan
+1. Replace static long-running weekly expectation with computed expected dates over the actual visible window.
+2. Add explicit cadence gap assertion (7-day intervals between neighboring occurrences).
+3. Keep patch scoped to unit test file.
+
+# Code Changes Applied
+- Updated `tests/unit/recurrence-expand.test.js` long-running weekly test to:
+  - compute `now`, `windowStart`, and `windowEnd` explicitly,
+  - derive the expected weekly Mondays from the 2024-01-01 anchor across the full visible window,
+  - assert exact returned date list and exact count,
+  - assert every adjacent occurrence is exactly 7 days apart.
+
+# Validation Run
+- `cd /home/paul-bot1/.openclaw/workspace/worktrees/allplays-pr163-review-comment-2884121900 && /home/paul-bot1/.openclaw/workspace/allplays/node_modules/.bin/vitest run tests/unit/recurrence-expand.test.js`
+- Result: pass (`5/5` tests in file).
+
+# Residual Risks
+- Test still focuses on weekly cadence; separate tests cover other recurrence frequencies.
+
+# Commit Message Draft
+Strengthen long-running weekly recurrence test for full-window gap detection

--- a/docs/pr-notes/runs/163-review-comment-2884121900-20260304T144215Z/qa.md
+++ b/docs/pr-notes/runs/163-review-comment-2884121900-20260304T144215Z/qa.md
@@ -1,0 +1,21 @@
+# Risk Matrix
+- High: Missing in-window occurrences for long-running series due to traversal/iteration constraints.
+- Medium: Boundary off-by-one around computed `windowStart` and `windowEnd`.
+- Low: Regression to existing daily/biweekly recurrence tests from unrelated changes.
+
+# Automated Tests To Add/Update
+- Update `does not drop in-window occurrences for long-running weekly series` in `tests/unit/recurrence-expand.test.js` to assert exact in-window count and no-gap cadence.
+
+# Manual Test Plan
+- Not required for this scope (unit-test-only regression guard).
+
+# Negative Tests
+- Assert no date gaps by checking all adjacent occurrence deltas are exactly 7 days.
+- Assert count equals expected in-window Mondays so hidden missing occurrences fail.
+
+# Release Gates
+- `npx vitest run tests/unit/recurrence-expand.test.js` passes.
+- Git diff limited to test and run-note artifacts.
+
+# Post-Deploy Checks
+- PR CI should pass unit suite including recurrence tests.

--- a/docs/pr-notes/runs/163-review-comment-2884121900-20260304T144215Z/requirements.md
+++ b/docs/pr-notes/runs/163-review-comment-2884121900-20260304T144215Z/requirements.md
@@ -1,0 +1,25 @@
+# Problem Statement
+The current long-running weekly recurrence test confirms a few future dates but does not prove there are no missing occurrences within the full visible window (`windowStart` to `windowEnd`) for a series that began on 2024-01-01.
+
+# User Segments Impacted
+- Coach: needs reliable recurring practice/game visibility without silent gaps.
+- Parent: expects predictable calendar continuity and trust in schedule completeness.
+- Team admin/program manager: relies on recurrence expansion integrity when series run for years.
+
+# Acceptance Criteria
+1. For a weekly Monday series started on 2024-01-01 and evaluated at fixed time `2026-03-01T12:00:00Z` with `windowDays=30`, the test validates the exact number of occurrences returned from computed `windowStart` to `windowEnd`.
+2. The test validates cadence continuity by asserting each adjacent returned occurrence is exactly 7 days apart.
+3. The test validates boundary correctness by asserting first and last returned occurrence dates match the expected in-window Mondays.
+4. The test fails if any in-window occurrence is skipped due to iteration/fast-forward behavior.
+
+# Non-Goals
+- Changing recurrence runtime behavior in `js/utils.js`.
+- Extending coverage to monthly/custom rules in this comment response.
+
+# Edge Cases
+- `windowStart` may begin mid-week and not on series weekday.
+- Long-running series start far before visible window.
+- Time-of-day from series start must not shift date-key matching.
+
+# Open Questions
+- None for this review comment scope.

--- a/docs/pr-notes/runs/163-review-comment-2884131383-20260304T144751Z/architecture.md
+++ b/docs/pr-notes/runs/163-review-comment-2884131383-20260304T144751Z/architecture.md
@@ -1,0 +1,14 @@
+# Architecture Role Summary
+
+## Decision
+Keep recurrence logic in `expandRecurrence` unchanged (already includes pre-window count accounting), and strengthen verification through a regression test.
+
+## Rationale
+- Lowest-risk path: avoid touching stable recurrence arithmetic unless behavior is still wrong.
+- Existing logic already computes pre-window `generated` via `precountCursor` before enforcing `count` in main loop.
+- A targeted regression test reduces future regression risk without expanding blast radius.
+
+## Controls
+- No schema/data migrations.
+- No API contract changes.
+- Deterministic fake-time test guards correctness across long-running historical series.

--- a/docs/pr-notes/runs/163-review-comment-2884131383-20260304T144751Z/code-plan.md
+++ b/docs/pr-notes/runs/163-review-comment-2884131383-20260304T144751Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code Role Summary
+
+## Implementation
+- Added one regression test to `tests/unit/recurrence-expand.test.js`:
+  - `does not resurface finite weekly series after recurrence count is exhausted before window start`
+
+## Why this patch
+- Review concern targets correctness gap that is now handled in runtime logic; test codifies expected behavior and protects against regressions.
+
+## Files
+- `tests/unit/recurrence-expand.test.js`
+- `docs/pr-notes/runs/163-review-comment-2884131383-20260304T144751Z/*.md`

--- a/docs/pr-notes/runs/163-review-comment-2884131383-20260304T144751Z/qa.md
+++ b/docs/pr-notes/runs/163-review-comment-2884131383-20260304T144751Z/qa.md
@@ -1,0 +1,16 @@
+# QA Role Summary
+
+## Regression Focus
+- Finite weekly recurrence with historical start date and exhausted `count` before visible window.
+
+## Test Strategy
+- Freeze time to `2026-03-01T12:00:00Z`.
+- Create weekly Monday series starting `2024-01-01T17:00:00Z` with `count: 5`.
+- Expand 45 days and assert zero occurrences.
+
+## Guardrails
+- Ensures no ended series resurfacing in calendar views.
+- Complements existing interval/cadence tests already in file.
+
+## Residual Risk
+- Full suite execution unavailable in this repo snapshot (no package test runner config in checkout).

--- a/docs/pr-notes/runs/163-review-comment-2884131383-20260304T144751Z/requirements.md
+++ b/docs/pr-notes/runs/163-review-comment-2884131383-20260304T144751Z/requirements.md
@@ -1,0 +1,21 @@
+# Requirements Role Summary
+
+## Objective
+Prevent ended finite recurring series from reappearing in calendar/schedule views when expansion starts near the visible window.
+
+## Current vs Proposed
+- Current state: `expandRecurrence` fast-forwards cursor near `windowStart`; without counting prior matches, `recurrence.count` can be misapplied.
+- Proposed state: Preserve effective count semantics by ensuring pre-window occurrences are accounted for before in-window expansion and lock behavior with regression coverage.
+
+## Risk Surface / Blast Radius
+- Surface: recurrence expansion used by scheduling/calendar rendering.
+- Blast radius: incorrect visibility of ended practices, confusing parents/coaches and undermining trust in schedule accuracy.
+
+## Assumptions
+- `recurrence.count` counts generated rule matches; `exDates` only suppress display/output, not count budget.
+- Weekly rules with historical start dates are common in production teams.
+
+## Acceptance Criteria
+1. A weekly series with `count` fully consumed before `windowStart` returns no visible occurrences.
+2. Existing daily/weekly interval behavior remains unchanged.
+3. Change is covered by deterministic unit-style test in `tests/unit/recurrence-expand.test.js`.

--- a/docs/pr-notes/runs/issue-149-fixer-20260304T142556Z/architecture.md
+++ b/docs/pr-notes/runs/issue-149-fixer-20260304T142556Z/architecture.md
@@ -1,0 +1,20 @@
+# Architecture Role Synthesis (Fallback)
+
+## Note on orchestration tooling
+Requested skills (`allplays-orchestrator-playbook`, `allplays-architecture-expert`) and `sessions_spawn` are not available in this runtime. This artifact captures equivalent architecture analysis.
+
+## Root cause model
+The loop starts at `seriesStart` and advances one day per iteration. For old series, the guard `iterations < windowDays * 2` trips before `current` reaches the visible window, producing zero occurrences.
+
+## Minimal-safe patch strategy
+- Preserve existing matching logic for daily/weekly recurrence.
+- Introduce an aligned cursor start:
+  - compute an initial day at or before `windowStart` for each recurrence type.
+  - for weekly rules, align to week boundaries used by existing `weeksSinceSeriesStart` modulo logic.
+  - for daily rules, align by interval modulo from series start.
+- Keep the existing day-by-day traversal and max-iteration safety bound, but make it relative to window traversal instead of series age.
+
+## Conflict resolution
+- Requirements wants correctness for old series.
+- QA wants minimal regression risk.
+- Resolved by changing only loop start alignment and adding regression tests without refactoring recurrence data model.

--- a/docs/pr-notes/runs/issue-149-fixer-20260304T142556Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-149-fixer-20260304T142556Z/code-plan.md
@@ -1,0 +1,14 @@
+# Code Role Synthesis (Fallback)
+
+## Note on orchestration tooling
+Requested skills (`allplays-orchestrator-playbook`, `allplays-code-expert`) and `sessions_spawn` are not available in this runtime. This artifact captures equivalent implementation plan.
+
+## Plan
+1. Add failing regression test in `tests/unit/recurrence-expand.test.js` for old weekly series still producing future occurrences.
+2. Patch `expandRecurrence` in `js/utils.js` to initialize `current` near `windowStart` while preserving interval alignment.
+3. Run targeted Vitest files for recurrence.
+4. Stage changes and commit with issue reference `#149`.
+
+## Non-goals
+- No edits to `edit-schedule.html` rendering.
+- No recurrence schema changes.

--- a/docs/pr-notes/runs/issue-149-fixer-20260304T142556Z/qa.md
+++ b/docs/pr-notes/runs/issue-149-fixer-20260304T142556Z/qa.md
@@ -1,0 +1,16 @@
+# QA Role Synthesis (Fallback)
+
+## Note on orchestration tooling
+Requested skills (`allplays-orchestrator-playbook`, `allplays-qa-expert`) and `sessions_spawn` are not available in this runtime. This artifact captures equivalent QA analysis.
+
+## Failure reproduction coverage
+Add a unit test that freezes time in 2026 and uses a weekly series starting in 2024. Assert upcoming window occurrences are returned.
+
+## Regression guardrails
+1. Verify no change to near-term daily interval expectations.
+2. Verify weekly interval cadence with multi-day `byDays` remains stable.
+3. Verify old series no longer returns empty when no end date is set.
+
+## Validation commands
+- Run targeted recurrence tests first.
+- Run full recurrence-related unit suite (`tests/unit/recurrence-*.test.js`) for confidence.

--- a/docs/pr-notes/runs/issue-149-fixer-20260304T142556Z/requirements.md
+++ b/docs/pr-notes/runs/issue-149-fixer-20260304T142556Z/requirements.md
@@ -1,0 +1,25 @@
+# Requirements Role Synthesis (Fallback)
+
+## Note on orchestration tooling
+Requested skills (`allplays-orchestrator-playbook`, `allplays-requirements-expert`) and `sessions_spawn` are not available in this runtime. This artifact captures equivalent requirements analysis.
+
+## Objective
+Ensure active recurring practice series continue to render upcoming occurrences in `edit-schedule.html` even when the master start date is more than a year in the past.
+
+## Current vs proposed behavior
+- Current: `expandRecurrence(master)` iterates day-by-day from original `seriesStart` with `maxIterations = windowDays * 2` (default 360), which can terminate before reaching the current visible window for older series.
+- Proposed: anchor recurrence expansion near the visible window start while preserving recurrence cadence, so old series can still generate occurrences in the active schedule window.
+
+## Acceptance criteria
+1. Weekly recurring series that started well before the 180-day horizon still produce upcoming occurrences when recurrence has no end.
+2. Daily/weekly interval logic remains unchanged for recent series.
+3. Existing recurrence end constraints (`until`, `count`, `exDates`, `overrides`) continue to apply.
+
+## Risk surface and blast radius
+- Surface: `expandRecurrence` in `js/utils.js`.
+- Blast radius: schedule and any consumers of recurrence expansion.
+- No Firestore write path changes.
+
+## Assumptions
+- UI expects only occurrences within `[now-14d, now+windowDays]`.
+- `count` semantics should remain based on generated matching occurrences from series start when in-range alignment is reconstructed.

--- a/js/utils.js
+++ b/js/utils.js
@@ -1300,6 +1300,41 @@ export function expandRecurrence(master, windowDays = 180) {
     }
   }
   let generated = 0;
+  if (count && current > seriesStart) {
+    const precountCursor = new Date(seriesStart);
+    const precountMaxIterations = Math.max(366, Math.ceil((current.getTime() - seriesStart.getTime()) / MS_PER_DAY) + 366);
+    let precountIterations = 0;
+
+    while (precountCursor < current && generated < count && precountIterations < precountMaxIterations) {
+      precountIterations++;
+
+      const precountDayOfWeek = precountCursor.getDay();
+      const precountDayCode = DAY_CODES[precountDayOfWeek];
+      const precountDayNumber = Math.floor(precountCursor.getTime() / MS_PER_DAY);
+      const precountDaysSinceSeriesStart = precountDayNumber - seriesStartDayNumber;
+      const precountWeekStartDayNumber = precountDayNumber - precountDayOfWeek;
+      const precountWeeksSinceSeriesStart = Math.floor((precountWeekStartDayNumber - seriesStartWeekStartDayNumber) / 7);
+      const precountWeeklyIntervalMatch =
+        precountWeeksSinceSeriesStart >= 0 &&
+        (precountWeeksSinceSeriesStart % normalizedInterval === 0);
+
+      let matches = false;
+      if (freq === 'weekly' && byDays.length > 0) {
+        matches = byDays.includes(precountDayCode) && precountWeeklyIntervalMatch && precountDaysSinceSeriesStart >= 0;
+      } else if (freq === 'daily') {
+        matches = precountDaysSinceSeriesStart >= 0 && (precountDaysSinceSeriesStart % normalizedInterval === 0);
+      } else if (freq === 'weekly' && byDays.length === 0) {
+        matches = precountDayOfWeek === seriesStartDayOfWeek && precountWeeklyIntervalMatch;
+        matches = matches && precountDaysSinceSeriesStart >= 0;
+      }
+
+      if (matches) {
+        generated++;
+      }
+
+      precountCursor.setDate(precountCursor.getDate() + 1);
+    }
+  }
 
   // Safety limit for day-by-day traversal plus one-year buffer for edge cases.
   const daysToTraverse = Math.ceil((windowEnd.getTime() - current.getTime()) / MS_PER_DAY);
@@ -1336,6 +1371,10 @@ export function expandRecurrence(master, windowDays = 180) {
       // If no specific days, match the same day as series start
       matches = currentDayOfWeek === seriesStartDayOfWeek && weeklyIntervalMatch;
       matches = matches && daysSinceSeriesStart >= 0;
+    }
+
+    if (matches) {
+      generated++;
     }
 
     // Only process if within visible window and matches pattern
@@ -1377,7 +1416,6 @@ export function expandRecurrence(master, windowDays = 180) {
       }
 
       occurrences.push(occurrence);
-      generated++;
     }
 
     // Advance to next day

--- a/js/utils.js
+++ b/js/utils.js
@@ -1275,10 +1275,21 @@ export function expandRecurrence(master, windowDays = 180) {
   const seriesStartDayOfWeek = seriesStart.getDay();
   const seriesStartWeekStartDayNumber = seriesStartDayNumber - seriesStartDayOfWeek;
   let current = new Date(seriesStart);
+  if (current < windowStart) {
+    // Start iteration near the visible window so old series are still expanded.
+    current = new Date(windowStart);
+    current.setHours(
+      seriesStart.getHours(),
+      seriesStart.getMinutes(),
+      seriesStart.getSeconds(),
+      seriesStart.getMilliseconds()
+    );
+  }
   let generated = 0;
 
-  // For weekly recurrence, we need to check each day
-  const maxIterations = windowDays * 2; // Safety limit
+  // Safety limit based on visible traversal distance, not series age.
+  const daysToTraverse = Math.ceil((windowEnd.getTime() - current.getTime()) / MS_PER_DAY);
+  const maxIterations = Math.max(windowDays * 2, (daysToTraverse + 31) * 2);
   let iterations = 0;
 
   while (current <= windowEnd && iterations < maxIterations) {

--- a/js/utils.js
+++ b/js/utils.js
@@ -1284,12 +1284,26 @@ export function expandRecurrence(master, windowDays = 180) {
       seriesStart.getSeconds(),
       seriesStart.getMilliseconds()
     );
+
+    if (freq === 'weekly') {
+      const currentDayNumber = Math.floor(current.getTime() / MS_PER_DAY);
+      const currentDayOfWeek = current.getDay();
+      const currentWeekStartDayNumber = currentDayNumber - currentDayOfWeek;
+      const weeksSinceSeriesStartAtCursor = Math.floor(
+        (currentWeekStartDayNumber - seriesStartWeekStartDayNumber) / 7
+      );
+      const weekOffset = ((weeksSinceSeriesStartAtCursor % normalizedInterval) + normalizedInterval) % normalizedInterval;
+
+      if (weekOffset !== 0) {
+        current.setDate(current.getDate() + ((normalizedInterval - weekOffset) * 7));
+      }
+    }
   }
   let generated = 0;
 
-  // Safety limit based on visible traversal distance, not series age.
+  // Safety limit for day-by-day traversal plus one-year buffer for edge cases.
   const daysToTraverse = Math.ceil((windowEnd.getTime() - current.getTime()) / MS_PER_DAY);
-  const maxIterations = Math.max(windowDays * 2, (daysToTraverse + 31) * 2);
+  const maxIterations = Math.max(366, daysToTraverse + 366);
   let iterations = 0;
 
   while (current <= windowEnd && iterations < maxIterations) {

--- a/tests/unit/recurrence-expand.test.js
+++ b/tests/unit/recurrence-expand.test.js
@@ -109,4 +109,32 @@ describe('expandRecurrence interval guardrails', () => {
     ]);
     expect(dates).toHaveLength(7);
   });
+
+  it('keeps biweekly multi-day cadence anchored to series start after window jump', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-01T12:00:00Z'));
+
+    const master = {
+      id: 'series-weekly-biweekly-long-running',
+      isSeriesMaster: true,
+      date: new Date('2024-01-03T17:00:00Z'),
+      recurrence: {
+        freq: 'weekly',
+        interval: 2,
+        byDays: ['MO', 'WE']
+      }
+    };
+
+    const dates = expandRecurrence(master, 45).map((occ) => occ.instanceDate);
+    expect(dates.slice(0, 6)).toEqual([
+      '2026-02-23',
+      '2026-02-25',
+      '2026-03-09',
+      '2026-03-11',
+      '2026-03-23',
+      '2026-03-25'
+    ]);
+    expect(dates).not.toContain('2026-02-16');
+    expect(dates).not.toContain('2026-02-18');
+  });
 });

--- a/tests/unit/recurrence-expand.test.js
+++ b/tests/unit/recurrence-expand.test.js
@@ -84,12 +84,17 @@ describe('expandRecurrence interval guardrails', () => {
 
   it('does not drop in-window occurrences for long-running weekly series', () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-03-01T12:00:00Z'));
+    const now = new Date('2026-03-01T12:00:00Z');
+    vi.setSystemTime(now);
+    const windowDays = 30;
+    const dayMs = 24 * 60 * 60 * 1000;
+    const pastWindowDays = 14;
 
+    const seriesStart = new Date('2024-01-01T17:00:00Z');
     const master = {
       id: 'series-weekly-long-running',
       isSeriesMaster: true,
-      date: new Date('2024-01-01T17:00:00Z'),
+      date: seriesStart,
       recurrence: {
         freq: 'weekly',
         interval: 1,
@@ -97,17 +102,30 @@ describe('expandRecurrence interval guardrails', () => {
       }
     };
 
-    const dates = expandRecurrence(master, 30).map((occ) => occ.instanceDate);
-    expect(dates).toEqual([
-      '2026-02-16',
-      '2026-02-23',
-      '2026-03-02',
-      '2026-03-09',
-      '2026-03-16',
-      '2026-03-23',
-      '2026-03-30'
-    ]);
-    expect(dates).toHaveLength(7);
+    const dates = expandRecurrence(master, windowDays).map((occ) => occ.instanceDate);
+    const windowStart = new Date(now.getTime() - pastWindowDays * dayMs);
+    const windowEnd = new Date(now.getTime() + windowDays * dayMs);
+    expect((windowEnd.getTime() - seriesStart.getTime()) / dayMs).toBeGreaterThan(730);
+
+    const firstExpected = new Date(seriesStart);
+    while (firstExpected < windowStart) {
+      firstExpected.setDate(firstExpected.getDate() + 7);
+    }
+
+    const expectedDates = [];
+    const cursor = new Date(firstExpected);
+    while (cursor <= windowEnd) {
+      expectedDates.push(cursor.toISOString().slice(0, 10));
+      cursor.setDate(cursor.getDate() + 7);
+    }
+
+    expect(dates).toEqual(expectedDates);
+    expect(dates).toHaveLength(expectedDates.length);
+    for (let i = 1; i < dates.length; i++) {
+      const previous = new Date(`${dates[i - 1]}T00:00:00Z`);
+      const current = new Date(`${dates[i]}T00:00:00Z`);
+      expect((current.getTime() - previous.getTime()) / dayMs).toBe(7);
+    }
   });
 
   it('keeps biweekly multi-day cadence anchored to series start after window jump', () => {

--- a/tests/unit/recurrence-expand.test.js
+++ b/tests/unit/recurrence-expand.test.js
@@ -81,4 +81,28 @@ describe('expandRecurrence interval guardrails', () => {
     ]);
     expect(dates).not.toContain('2026-03-09');
   });
+
+  it('includes upcoming occurrences for long-running weekly series', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-01T12:00:00Z'));
+
+    const master = {
+      id: 'series-weekly-long-running',
+      isSeriesMaster: true,
+      date: new Date('2024-01-01T17:00:00Z'),
+      recurrence: {
+        freq: 'weekly',
+        interval: 1,
+        byDays: ['MO']
+      }
+    };
+
+    const dates = expandRecurrence(master, 30).map((occ) => occ.instanceDate);
+    expect(dates.slice(0, 4)).toEqual([
+      '2026-02-16',
+      '2026-02-23',
+      '2026-03-02',
+      '2026-03-09'
+    ]);
+  });
 });

--- a/tests/unit/recurrence-expand.test.js
+++ b/tests/unit/recurrence-expand.test.js
@@ -82,7 +82,7 @@ describe('expandRecurrence interval guardrails', () => {
     expect(dates).not.toContain('2026-03-09');
   });
 
-  it('includes upcoming occurrences for long-running weekly series', () => {
+  it('does not drop in-window occurrences for long-running weekly series', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-01T12:00:00Z'));
 
@@ -98,11 +98,15 @@ describe('expandRecurrence interval guardrails', () => {
     };
 
     const dates = expandRecurrence(master, 30).map((occ) => occ.instanceDate);
-    expect(dates.slice(0, 4)).toEqual([
+    expect(dates).toEqual([
       '2026-02-16',
       '2026-02-23',
       '2026-03-02',
-      '2026-03-09'
+      '2026-03-09',
+      '2026-03-16',
+      '2026-03-23',
+      '2026-03-30'
     ]);
+    expect(dates).toHaveLength(7);
   });
 });

--- a/tests/unit/recurrence-expand.test.js
+++ b/tests/unit/recurrence-expand.test.js
@@ -155,4 +155,24 @@ describe('expandRecurrence interval guardrails', () => {
     expect(dates).not.toContain('2026-02-16');
     expect(dates).not.toContain('2026-02-18');
   });
+
+  it('does not resurface finite weekly series after recurrence count is exhausted before window start', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-01T12:00:00Z'));
+
+    const master = {
+      id: 'series-weekly-finite-exhausted',
+      isSeriesMaster: true,
+      date: new Date('2024-01-01T17:00:00Z'),
+      recurrence: {
+        freq: 'weekly',
+        interval: 1,
+        byDays: ['MO'],
+        count: 5
+      }
+    };
+
+    const dates = expandRecurrence(master, 45).map((occ) => occ.instanceDate);
+    expect(dates).toEqual([]);
+  });
 });


### PR DESCRIPTION
Closes #149

## What changed
- Added a regression test for `expandRecurrence` that reproduces the bug where a weekly series starting in 2024 produced no 2026 occurrences.
- Updated `expandRecurrence` in `js/utils.js` to begin iteration near the visible schedule window when a series started far in the past.
- Reworked the iteration safety cap to depend on visible traversal distance instead of series age, preventing premature loop termination.
- Added required role-analysis artifacts for this run under `docs/pr-notes/runs/issue-149-fixer-20260304T142556Z/`.

## Why
The old logic iterated day-by-day from the original series start and stopped at `windowDays * 2` iterations. For long-running series, that cap could be hit before reaching current/future dates, causing active recurring practices to disappear from schedule management.

## Validation
- `pnpm dlx vitest run tests/unit/recurrence-expand.test.js tests/unit/recurrence-interval.test.js`