### PR TITLE
Enforce atomic single-use access code redemption

### DIFF
--- a/docs/pr-notes/runs/165-remediator-20260304T173616Z/architecture.md
+++ b/docs/pr-notes/runs/165-remediator-20260304T173616Z/architecture.md
@@ -1,0 +1,5 @@
+# Architecture Analysis
+- Affected boundary: client-side Firestore data access helper `redeemParentInvite` in `js/db.js`.
+- Data shape: `/accessCodes` docs can be non-unique by `code` due to `addDoc` creation path.
+- Safe fix pattern: filter candidate docs to `type === 'parent_invite'`, then prefer `used !== true` and `!isAccessCodeExpired(expiresAt)` before selecting a document reference for transaction.
+- Blast radius: limited to parent invite redemption lookup; no schema or API contract changes.

--- a/docs/pr-notes/runs/165-remediator-20260304T173616Z/code-plan.md
+++ b/docs/pr-notes/runs/165-remediator-20260304T173616Z/code-plan.md
@@ -1,0 +1,5 @@
+# Code Plan
+1. Update candidate selection in `redeemParentInvite` to inspect all matched docs.
+2. Select first `parent_invite` doc that is both unused and unexpired.
+3. Fall back to first `parent_invite` doc (for legacy error paths) if no usable candidate exists.
+4. Keep transaction checks unchanged to preserve correctness under races.

--- a/docs/pr-notes/runs/165-remediator-20260304T173616Z/qa.md
+++ b/docs/pr-notes/runs/165-remediator-20260304T173616Z/qa.md
@@ -1,0 +1,6 @@
+# QA Analysis
+- Regression to verify: duplicated invite code where first matching doc is used and later one unused should redeem successfully.
+- Negative checks:
+  - No parent_invite docs for code -> still `Invalid or used code`.
+  - Only used/expired parent_invite docs -> still fail.
+- Validation in this run: syntax check of modified file via Node parser; repository has no automated tests.

--- a/docs/pr-notes/runs/165-remediator-20260304T173616Z/requirements.md
+++ b/docs/pr-notes/runs/165-remediator-20260304T173616Z/requirements.md
@@ -1,0 +1,5 @@
+# Requirements Analysis
+- Objective: Resolve PR thread PRRT_kwDOQe-T585yHspq by preventing false negatives when redeeming duplicated parent invite access codes.
+- Current behavior risk: `redeemParentInvite` selects first `parent_invite` code doc by matching `code` only, then fails if that one is already used even when another unused duplicate exists.
+- Required behavior: choose an unused, unexpired `parent_invite` document among matched duplicates before claiming in transaction.
+- Scope: Minimal update in code-selection logic only; preserve existing transaction claim and side-effect flow.

--- a/docs/pr-notes/runs/issue-164-fixer-20260304T172519Z/architecture.md
+++ b/docs/pr-notes/runs/issue-164-fixer-20260304T172519Z/architecture.md
@@ -1,0 +1,19 @@
+# Architecture Role Synthesis
+
+## Current state
+- `validateAccessCode` performs non-locking read.
+- `markAccessCodeAsUsed` performs blind `updateDoc` overwrite.
+- `redeemParentInvite` reads unused code, performs profile/player writes, then marks used.
+
+## Proposed state
+- Move single-use claim into Firestore transaction for generic code consumption (`markAccessCodeAsUsed`).
+- Parent invite redemption starts with transaction-based code claim (`used=false -> true`) before downstream writes.
+- If downstream parent invite writes fail after claim, rollback claimed code to unused for same claimant.
+
+## Blast radius
+- Limited to access-code redemption semantics in `js/db.js` and signup error handling in `js/signup-flow.js`.
+- No schema change.
+
+## Risks
+- Rollback path could fail and leave code consumed; handled by throwing explicit error and logging.
+- Existing flows relying on best-effort success may now fail closed when code claim fails (intended).

--- a/docs/pr-notes/runs/issue-164-fixer-20260304T172519Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-164-fixer-20260304T172519Z/code-plan.md
@@ -1,0 +1,8 @@
+# Code Role Synthesis
+
+## Minimal patch plan
+1. Update `markAccessCodeAsUsed` to transactionally read and set `used` fields; throw if already used.
+2. Update `executeEmailPasswordSignup` standard flow to fail closed on code-claim error and cleanup created auth user.
+3. Refactor `redeemParentInvite` to transactionally claim code at start; keep existing profile/player writes; add rollback of code claim on downstream failure.
+4. Add/extend unit tests for failing-first behavior and atomic guardrails.
+5. Run targeted Vitest files and then broader related tests.

--- a/docs/pr-notes/runs/issue-164-fixer-20260304T172519Z/qa.md
+++ b/docs/pr-notes/runs/issue-164-fixer-20260304T172519Z/qa.md
@@ -1,0 +1,15 @@
+# QA Role Synthesis
+
+## Regression focus
+- Standard signup: claim failure from concurrent loser must reject signup and cleanup auth account.
+- Parent invite redemption: source guard confirms transaction claim in function body.
+
+## Test plan
+- Unit test in `tests/unit/signup-flow.test.js` for non-parent/non-admin flow where `markAccessCodeAsUsed` rejects.
+- Unit source-guard test in `tests/unit/access-code-atomic-redemption-guard.test.js` asserting:
+  - `markAccessCodeAsUsed` uses `runTransaction`.
+  - `redeemParentInvite` uses `runTransaction`.
+
+## Manual spot checks (post-merge)
+- Two concurrent signups with same standard code: one success, one failure.
+- Two concurrent parent dashboard redeems with same parent invite: one success, one failure.

--- a/docs/pr-notes/runs/issue-164-fixer-20260304T172519Z/requirements.md
+++ b/docs/pr-notes/runs/issue-164-fixer-20260304T172519Z/requirements.md
@@ -1,0 +1,19 @@
+# Requirements Role Synthesis
+
+## Objective
+Guarantee single-use access/invite code redemption under concurrency so exactly one claimant succeeds and all others fail before side effects.
+
+## User-visible behavior
+- Concurrent redeems of the same code must not both show success.
+- Losing claimant should receive a clear already-used/invalid failure.
+- No duplicate parent linking from the same invite.
+
+## Constraints
+- Keep changes minimal and local to redemption paths.
+- Preserve existing invite type semantics (`standard`, `parent_invite`, `admin_invite`).
+- Avoid introducing new UX flows in this fix.
+
+## Acceptance criteria
+- A regression test fails on current flow where standard signup swallows mark-used failure.
+- Code paths enforce atomic claim/check for single-use codes.
+- Parent invite path no longer queries with `used == false` then marks later without atomic precondition.

--- a/js/db.js
+++ b/js/db.js
@@ -1205,7 +1205,14 @@ export async function redeemParentInvite(userId, code) {
     const snapshot = await getDocs(q);
     if (snapshot.empty) throw new Error("Invalid or used code");
 
-    const codeDoc = snapshot.docs.find(d => (d.data() || {}).type === 'parent_invite') || snapshot.docs[0];
+    const parentInviteDocs = snapshot.docs.filter(d => (d.data() || {}).type === 'parent_invite');
+    if (parentInviteDocs.length === 0) throw new Error("Invalid or used code");
+
+    // Duplicates can exist; prefer a currently redeemable parent invite doc.
+    const codeDoc = parentInviteDocs.find((d) => {
+        const invite = d.data() || {};
+        return invite.used !== true && !isAccessCodeExpired(invite.expiresAt);
+    }) || parentInviteDocs[0];
     const codeRef = codeDoc.ref;
     let codeData;
 

--- a/js/db.js
+++ b/js/db.js
@@ -870,11 +870,27 @@ export async function validateAccessCode(code) {
 }
 
 export async function markAccessCodeAsUsed(codeId, userId) {
-    const docRef = doc(db, "accessCodes", codeId);
-    await updateDoc(docRef, {
-        used: true,
-        usedBy: userId,
-        usedAt: Timestamp.now()
+    const codeRef = doc(db, "accessCodes", codeId);
+    await runTransaction(db, async (transaction) => {
+        const codeSnapshot = await transaction.get(codeRef);
+        if (!codeSnapshot.exists()) {
+            throw new Error("Invalid access code");
+        }
+
+        const codeData = codeSnapshot.data() || {};
+        if (codeData.used) {
+            throw new Error("Code already used");
+        }
+
+        if (isAccessCodeExpired(codeData.expiresAt)) {
+            throw new Error("Code has expired");
+        }
+
+        transaction.update(codeRef, {
+            used: true,
+            usedBy: userId,
+            usedAt: Timestamp.now()
+        });
     });
 }
 
@@ -1181,17 +1197,45 @@ export async function inviteAdmin(teamId, adminEmail) {
 export async function redeemParentInvite(userId, code) {
     console.log('[redeemParentInvite] start', { userId, code });
 
-    // 1. Validate Code
+    // 1. Find candidate code document
     const q = query(
         collection(db, "accessCodes"),
-        where("code", "==", code.toUpperCase()),
-        where("used", "==", false)
+        where("code", "==", code.toUpperCase())
     );
     const snapshot = await getDocs(q);
     if (snapshot.empty) throw new Error("Invalid or used code");
-    
-    const codeDoc = snapshot.docs[0];
-    const codeData = codeDoc.data() || {};
+
+    const codeDoc = snapshot.docs.find(d => (d.data() || {}).type === 'parent_invite') || snapshot.docs[0];
+    const codeRef = codeDoc.ref;
+    let codeData;
+
+    // 2. Atomically claim code before side effects
+    await runTransaction(db, async (transaction) => {
+        const latestCodeSnapshot = await transaction.get(codeRef);
+        if (!latestCodeSnapshot.exists()) {
+            throw new Error("Invalid or used code");
+        }
+
+        const latestCodeData = latestCodeSnapshot.data() || {};
+        if (latestCodeData.type !== 'parent_invite') {
+            throw new Error("Not a parent invite code");
+        }
+        if (latestCodeData.used) {
+            throw new Error("Invalid or used code");
+        }
+        if (isAccessCodeExpired(latestCodeData.expiresAt)) {
+            throw new Error("Code has expired");
+        }
+
+        transaction.update(codeRef, {
+            used: true,
+            usedBy: userId,
+            usedAt: Timestamp.now()
+        });
+
+        codeData = latestCodeData;
+    });
+
     console.log('[redeemParentInvite] code loaded', {
         codeId: codeDoc.id,
         type: codeData.type,
@@ -1199,111 +1243,118 @@ export async function redeemParentInvite(userId, code) {
         playerId: codeData.playerId,
         generatedBy: codeData.generatedBy
     });
-
-    if (codeData.type !== 'parent_invite') throw new Error("Not a parent invite code");
-    if (isAccessCodeExpired(codeData.expiresAt)) throw new Error("Code has expired");
-
-    // 2. Get Team & Player details for caching
-    console.log('[redeemParentInvite] fetching team & player', {
-        teamId: codeData.teamId,
-        playerId: codeData.playerId
-    });
-    const [team, player] = await Promise.all([
-        getTeam(codeData.teamId),
-        getPlayers(codeData.teamId).then(ps => ps.find(p => p.id === codeData.playerId))
-    ]);
-
-    if (!team || !player) {
-        console.error('[redeemParentInvite] missing team or player', { teamExists: !!team, playerExists: !!player });
-        throw new Error("Team or Player not found");
-    }
-    console.log('[redeemParentInvite] team & player resolved', {
-        teamName: team.name,
-        playerName: player.name,
-        playerNumber: player.number
-    });
-
-    // 3. Update User Profile (parentOf + parentTeamIds for Firestore rules)
     try {
-        const userRef = doc(db, "users", userId);
-        await setDoc(userRef, {
-            parentOf: arrayUnion({
-                teamId: codeData.teamId,
-                playerId: codeData.playerId,
-                teamName: team.name,
-                playerName: player.name,
-                playerNumber: player.number,
-                playerPhotoUrl: player.photoUrl || null,
-                relation: codeData.relation || null
-            }),
-            // Denormalized array for fast Firestore rules lookup
-            parentTeamIds: arrayUnion(codeData.teamId),
-            parentPlayerKeys: arrayUnion(`${codeData.teamId}::${codeData.playerId}`),
-            roles: arrayUnion('parent')
-        }, { merge: true });
-        console.log('[redeemParentInvite] user profile updated');
-    } catch (err) {
-        console.error('redeemParentInvite: error updating user profile', err);
-        throw new Error('Unable to link parent (profile). ' + (err?.message || ''));
-    }
+        // 3. Get Team & Player details for caching
+        console.log('[redeemParentInvite] fetching team & player', {
+            teamId: codeData.teamId,
+            playerId: codeData.playerId
+        });
+        const [team, player] = await Promise.all([
+            getTeam(codeData.teamId),
+            getPlayers(codeData.teamId).then(ps => ps.find(p => p.id === codeData.playerId))
+        ]);
 
-    // 4. Update Player Doc (parents list)
-    try {
-        const playerRef = doc(db, `teams/${codeData.teamId}/players`, codeData.playerId);
+        if (!team || !player) {
+            console.error('[redeemParentInvite] missing team or player', { teamExists: !!team, playerExists: !!player });
+            throw new Error("Team or Player not found");
+        }
+        console.log('[redeemParentInvite] team & player resolved', {
+            teamName: team.name,
+            playerName: player.name,
+            playerNumber: player.number
+        });
 
-        // Log current parents state for debugging
+        // 4. Update User Profile (parentOf + parentTeamIds for Firestore rules)
         try {
-            const snap = await getDoc(playerRef);
-            if (snap.exists()) {
-                const data = snap.data() || {};
-                console.log('[redeemParentInvite] current player parents before update', {
+            const userRef = doc(db, "users", userId);
+            await setDoc(userRef, {
+                parentOf: arrayUnion({
                     teamId: codeData.teamId,
                     playerId: codeData.playerId,
-                    parents: data.parents || []
-                });
-            } else {
-                console.log('[redeemParentInvite] player doc not found before parents update', {
-                    teamId: codeData.teamId,
-                    playerId: codeData.playerId
-                });
-            }
-        } catch (innerErr) {
-            console.warn('[redeemParentInvite] failed to read player before update (non-fatal)', innerErr);
+                    teamName: team.name,
+                    playerName: player.name,
+                    playerNumber: player.number,
+                    playerPhotoUrl: player.photoUrl || null,
+                    relation: codeData.relation || null
+                }),
+                // Denormalized array for fast Firestore rules lookup
+                parentTeamIds: arrayUnion(codeData.teamId),
+                parentPlayerKeys: arrayUnion(`${codeData.teamId}::${codeData.playerId}`),
+                roles: arrayUnion('parent')
+            }, { merge: true });
+            console.log('[redeemParentInvite] user profile updated');
+        } catch (err) {
+            console.error('redeemParentInvite: error updating user profile', err);
+            throw new Error('Unable to link parent (profile). ' + (err?.message || ''));
         }
 
-        await updateDoc(playerRef, {
-            parents: arrayUnion({
-                userId,
-                email: codeData.email || 'pending', // Will be updated if email not provided in invite
-                relation: codeData.relation,
-                addedAt: Timestamp.now()
-            })
-        });
-        console.log('[redeemParentInvite] player parents updated');
+        // 5. Update Player Doc (parents list)
+        try {
+            const playerRef = doc(db, `teams/${codeData.teamId}/players`, codeData.playerId);
+
+            // Log current parents state for debugging
+            try {
+                const snap = await getDoc(playerRef);
+                if (snap.exists()) {
+                    const data = snap.data() || {};
+                    console.log('[redeemParentInvite] current player parents before update', {
+                        teamId: codeData.teamId,
+                        playerId: codeData.playerId,
+                        parents: data.parents || []
+                    });
+                } else {
+                    console.log('[redeemParentInvite] player doc not found before parents update', {
+                        teamId: codeData.teamId,
+                        playerId: codeData.playerId
+                    });
+                }
+            } catch (innerErr) {
+                console.warn('[redeemParentInvite] failed to read player before update (non-fatal)', innerErr);
+            }
+
+            await updateDoc(playerRef, {
+                parents: arrayUnion({
+                    userId,
+                    email: codeData.email || 'pending', // Will be updated if email not provided in invite
+                    relation: codeData.relation,
+                    addedAt: Timestamp.now()
+                })
+            });
+            console.log('[redeemParentInvite] player parents updated');
+        } catch (err) {
+            // If this fails (e.g., due to stricter live rules), we still
+            // consider the parent linked via their user profile. Coaches
+            // simply won't see the connection until rules are updated.
+            console.error('redeemParentInvite: error updating player parents (non-fatal)', {
+                message: err?.message,
+                code: err?.code,
+                name: err?.name
+            });
+        }
     } catch (err) {
-        // If this fails (e.g., due to stricter live rules), we still
-        // consider the parent linked via their user profile. Coaches
-        // simply won't see the connection until rules are updated.
-        console.error('redeemParentInvite: error updating player parents (non-fatal)', {
-            message: err?.message,
-            code: err?.code,
-            name: err?.name
-        });
+        try {
+            await runTransaction(db, async (transaction) => {
+                const latestCodeSnapshot = await transaction.get(codeRef);
+                if (!latestCodeSnapshot.exists()) {
+                    return;
+                }
+
+                const latestCodeData = latestCodeSnapshot.data() || {};
+                if (latestCodeData.used === true && latestCodeData.usedBy === userId) {
+                    transaction.update(codeRef, {
+                        used: false,
+                        usedBy: null,
+                        usedAt: null
+                    });
+                }
+            });
+        } catch (rollbackErr) {
+            console.error('redeemParentInvite: failed to rollback code claim', rollbackErr);
+        }
+        throw err;
     }
 
-    // 5. Mark Code Used
-    try {
-        await updateDoc(codeDoc.ref, {
-            used: true,
-            usedBy: userId,
-            usedAt: Timestamp.now()
-        });
-        console.log('[redeemParentInvite] access code marked used', { codeId: codeDoc.id });
-    } catch (err) {
-        console.error('redeemParentInvite: error marking code used', err);
-        throw new Error('Unable to link parent (access code). ' + (err?.message || ''));
-    }
-
+    console.log('[redeemParentInvite] access code marked used', { codeId: codeDoc.id });
     return { success: true, teamId: codeData.teamId };
 }
 

--- a/js/signup-flow.js
+++ b/js/signup-flow.js
@@ -93,6 +93,14 @@ export async function executeEmailPasswordSignup({
         }
     } else {
         try {
+            await markAccessCodeAsUsed(validation.codeId, userId);
+        } catch (error) {
+            console.error('Error marking code as used:', error);
+            await cleanupFailedParentInviteSignup(userCredential?.user);
+            throw error;
+        }
+
+        try {
             await updateUserProfile(userId, {
                 email: email,
                 createdAt: new Date(),
@@ -100,12 +108,6 @@ export async function executeEmailPasswordSignup({
             });
         } catch (e) {
             console.error('Error creating user profile:', e);
-        }
-
-        try {
-            await markAccessCodeAsUsed(validation.codeId, userId);
-        } catch (error) {
-            console.error('Error marking code as used:', error);
         }
     }
 

--- a/tests/unit/access-code-atomic-redemption-guard.test.js
+++ b/tests/unit/access-code-atomic-redemption-guard.test.js
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('access code atomic redemption guard', () => {
+    it('keeps generic access-code use inside a transaction', () => {
+        const dbSourcePath = resolve(process.cwd(), 'js/db.js');
+        const source = readFileSync(dbSourcePath, 'utf8');
+
+        const fnAnchor = 'export async function markAccessCodeAsUsed';
+        const fnIndex = source.indexOf(fnAnchor);
+        expect(fnIndex).toBeGreaterThanOrEqual(0);
+
+        const afterFunction = source.slice(fnIndex, fnIndex + 1800);
+        expect(afterFunction).toContain('runTransaction(db, async (transaction) =>');
+    });
+
+    it('claims parent invite codes atomically before side effects', () => {
+        const dbSourcePath = resolve(process.cwd(), 'js/db.js');
+        const source = readFileSync(dbSourcePath, 'utf8');
+
+        const fnAnchor = 'export async function redeemParentInvite';
+        const fnIndex = source.indexOf(fnAnchor);
+        expect(fnIndex).toBeGreaterThanOrEqual(0);
+
+        const afterFunction = source.slice(fnIndex, fnIndex + 5000);
+        expect(afterFunction).toContain('runTransaction(db, async (transaction) =>');
+    });
+});

--- a/tests/unit/signup-flow.test.js
+++ b/tests/unit/signup-flow.test.js
@@ -199,4 +199,43 @@ describe('executeEmailPasswordSignup', () => {
         expect(dependencies.updateUserProfile).not.toHaveBeenCalled();
         expect(dependencies.sendEmailVerification).not.toHaveBeenCalled();
     });
+
+    it('fails closed and cleans up when standard access code claim fails', async () => {
+        const expectedError = new Error('Code already used');
+        const deleteAuthUser = vi.fn().mockResolvedValue(undefined);
+        const dependencies = createDependencies({
+            validateAccessCode: vi.fn().mockResolvedValue({
+                valid: true,
+                type: 'standard',
+                codeId: 'code-standard-1',
+                data: { code: 'STANDARD1' }
+            }),
+            createUserWithEmailAndPassword: vi.fn().mockResolvedValue({
+                user: {
+                    uid: 'user-456',
+                    delete: deleteAuthUser
+                }
+            }),
+            markAccessCodeAsUsed: vi.fn().mockRejectedValue(expectedError)
+        });
+        const auth = {
+            currentUser: {
+                email: 'user@example.com',
+                reload: vi.fn().mockResolvedValue(undefined)
+            }
+        };
+
+        await expect(executeEmailPasswordSignup({
+            email: 'user@example.com',
+            password: 'password123',
+            activationCode: 'STANDARD1',
+            auth,
+            dependencies
+        })).rejects.toThrow('Code already used');
+
+        expect(dependencies.updateUserProfile).not.toHaveBeenCalled();
+        expect(dependencies.sendEmailVerification).not.toHaveBeenCalled();
+        expect(deleteAuthUser).toHaveBeenCalledTimes(1);
+        expect(dependencies.signOut).toHaveBeenCalledWith(auth);
+    });
 });


### PR DESCRIPTION
Closes #164

## What changed
- Made `markAccessCodeAsUsed` transactional in `js/db.js` so code use is atomic (`used` is checked and set in one `runTransaction`).
- Updated standard signup in `js/signup-flow.js` to fail closed if code claim fails: it now cleans up the created auth user and rethrows instead of logging and continuing.
- Refactored `redeemParentInvite` in `js/db.js` to claim invite codes atomically before side effects, and added rollback of the code claim if downstream profile/team linking fails.
- Added regression coverage:
  - `tests/unit/signup-flow.test.js` now asserts standard signup rejects and cleans up when code claim loses the race (`Code already used`).
  - `tests/unit/access-code-atomic-redemption-guard.test.js` asserts atomic transaction guards are present for generic code claim and parent invite redemption.
- Added required role-synthesis run artifacts under `docs/pr-notes/runs/issue-164-fixer-20260304T172519Z/`.

## Why
The prior validate-then-mark pattern allowed concurrent redemptions to pass validation and both report success. This patch moves single-use enforcement into atomic transactions and makes the losing redemption fail visibly before completing as success.

## Validation
- Attempted: `npx vitest run tests/unit/signup-flow.test.js tests/unit/access-code-atomic-redemption-guard.test.js`
- Environment limitation: `npx`/`vitest` are not available in this runner (`npx: command not found`, `vitest: command not found`).
- Performed syntax checks: `node --check` on changed JS/test files.