### PR TITLE
Fix sibling RSVPs to persist per child on parent dashboard

### DIFF
--- a/docs/pr-notes/runs/169-remediator-20260304T233608Z/architecture.md
+++ b/docs/pr-notes/runs/169-remediator-20260304T233608Z/architecture.md
@@ -1,0 +1,7 @@
+# Architecture role notes
+- Data-model compatibility: system currently has two RSVP doc shapes: legacy parent-level by `uid` and per-player by `uid__playerId`.
+- Failure mode 1: counting logic aggregates per-document player IDs, so coexistence of both shapes for same parent/game can double count.
+- Chosen fix: in per-player submit path, delete legacy parent-level `rsvps/{uid}` after writing `rsvps/{uid__playerId}`.
+- Failure mode 2: hydration resolver only trusts explicit child IDs on doc; legacy docs with no IDs become invisible.
+- Chosen fix: resolver falls back to scoped child IDs for the current parent/game when a matching user RSVP lacks explicit IDs.
+- Blast radius: confined to RSVP write path and parent dashboard hydration utility.

--- a/docs/pr-notes/runs/169-remediator-20260304T233608Z/code-plan.md
+++ b/docs/pr-notes/runs/169-remediator-20260304T233608Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code role notes
+- File `js/db.js`:
+  - In `submitRsvpForPlayer`, after writing per-player doc, best-effort delete legacy doc id `effectiveUserId` when different from per-player doc id.
+- File `js/parent-dashboard-rsvp.js`:
+  - In `resolveMyRsvpByChildForGame`, when `extractRsvpPlayerIds(rsvp)` is empty for current user RSVP, fallback to current game scoped child IDs.
+- Keep all other behavior unchanged.

--- a/docs/pr-notes/runs/169-remediator-20260304T233608Z/qa.md
+++ b/docs/pr-notes/runs/169-remediator-20260304T233608Z/qa.md
@@ -1,0 +1,11 @@
+# QA role notes
+- Validate stale-doc remediation:
+  1. Seed `rsvps/{uid}` for a game.
+  2. Submit single-child RSVP via `submitRsvpForPlayer`.
+  3. Confirm `rsvps/{uid}` no longer exists and only `rsvps/{uid__child}` remains.
+  4. Confirm summary counts reflect one child response, not duplicated totals.
+- Validate legacy hydration:
+  1. Seed legacy RSVP doc for current user with response but no player fields.
+  2. Load parent dashboard where game has scoped children.
+  3. Confirm `resolveMyRsvpByChildForGame` maps response to all scoped children, not `not_responded`.
+- Regression check: explicit per-player docs still override by latest `respondedAt` for same child.

--- a/docs/pr-notes/runs/169-remediator-20260304T233608Z/requirements.md
+++ b/docs/pr-notes/runs/169-remediator-20260304T233608Z/requirements.md
@@ -1,0 +1,5 @@
+# Requirements role notes
+- Objective: Remediate PR #169 unresolved review feedback threads PRRT_kwDOQe-T585yMHyI and PRRT_kwDOQe-T585yMHyJ.
+- Required behavior 1: When saving per-player RSVP (`rsvps/{uid__playerId}`), avoid coexistence with legacy parent-level doc `rsvps/{uid}` for same game/user to prevent duplicate counting in RSVP summary aggregation.
+- Required behavior 2: Hydration of parent dashboard RSVP state must continue to support legacy RSVP docs that have no `playerIds`, `playerId`, or `childId` fields.
+- Scope constraints: minimal targeted change in RSVP write and hydration resolution paths only.

--- a/docs/pr-notes/runs/issue-162-fixer-20260304T232527Z/architecture.md
+++ b/docs/pr-notes/runs/issue-162-fixer-20260304T232527Z/architecture.md
@@ -1,0 +1,18 @@
+# Architecture role (fallback synthesis)
+
+## Root cause
+- Document identity for parent RSVP in `submitRsvp` is `rsvps/{uid}`.
+- Multiple child submissions for same event overwrite one doc's `playerIds/response`.
+- Parent dashboard read path uses single `getMyRsvp(teamId, gameId, uid)` and broadcasts response across all child rows.
+
+## Minimal safe design
+1. In `parent-dashboard.html`, route child-scoped submissions to `submitRsvpForPlayer(...)` when exactly one child/player ID is resolved.
+2. In `parent-dashboard.html`, replace single-user RSVP hydration with per-child resolution from `getRsvps(...)` filtered by `userId` and matching `playerIds`.
+3. Add pure helper(s) in `js/parent-dashboard-rsvp.js` so hydration behavior is unit-testable and deterministic.
+
+## Blast radius
+- Touched surface: parent dashboard RSVP write/read behavior and helper tests.
+- Unchanged: firestore rules, coach breakdown logic, calendar flow, existing per-player RSVP write API.
+
+## Rollback
+- Revert this commit to return to legacy single-doc parent RSVP behavior.

--- a/docs/pr-notes/runs/issue-162-fixer-20260304T232527Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-162-fixer-20260304T232527Z/code-plan.md
@@ -1,0 +1,15 @@
+# Code role (fallback synthesis)
+
+## Plan
+1. Add failing tests in `tests/unit/parent-dashboard-rsvp.test.js` for per-child RSVP hydration mapping.
+2. Implement helper(s) in `js/parent-dashboard-rsvp.js` to map current parent's RSVPs by child/player.
+3. Update `parent-dashboard.html`:
+   - import `submitRsvpForPlayer` and `getRsvps`
+   - submit child-scoped RSVP through `submitRsvpForPlayer` when one player is selected
+   - hydrate `myRsvp` per child row using RSVP docs map
+4. Run targeted vitest file(s).
+5. Commit with issue reference.
+
+## Assumptions
+- Parent dashboard child cards submit exactly one player ID per click.
+- Firestore rules already allow `uid__playerId` doc IDs for parent/team users.

--- a/docs/pr-notes/runs/issue-162-fixer-20260304T232527Z/qa.md
+++ b/docs/pr-notes/runs/issue-162-fixer-20260304T232527Z/qa.md
@@ -1,0 +1,21 @@
+# QA role (fallback synthesis)
+
+## Regression risks
+- Parent dashboard may fail to show RSVP state if per-child hydration logic is wrong.
+- Latest-response precedence across multiple docs for same player must be deterministic.
+- Team summary hydration must continue loading.
+
+## Test strategy
+- Add unit tests for new helper that resolves child-specific responses from RSVP docs:
+  - Distinct sibling responses are preserved.
+  - Latest timestamp wins for same child.
+  - Other users' RSVP docs are ignored.
+- Add/update unit tests for parent-dashboard RSVP submission scope to enforce single-child submissions from child-specific UI context.
+
+## Validation commands
+- `node ./node_modules/vitest/vitest.mjs run tests/unit/parent-dashboard-rsvp.test.js`
+- Optional confidence run: `node ./node_modules/vitest/vitest.mjs run tests/unit/rsvp-hydration.test.js`
+
+## Manual checks
+- Parent with two children on same event: set child A Going, child B Can't Go; refresh page and verify both remain distinct.
+- Coach RSVP breakdown counts both children in their selected buckets.

--- a/docs/pr-notes/runs/issue-162-fixer-20260304T232527Z/requirements.md
+++ b/docs/pr-notes/runs/issue-162-fixer-20260304T232527Z/requirements.md
@@ -1,0 +1,24 @@
+# Requirements role (fallback synthesis)
+
+## Objective
+Prevent parent RSVP submissions for one child from overwriting sibling RSVPs on the same event, while keeping coach counts accurate.
+
+## Current state
+- Parent dashboard buttons are child-specific (`data-child-id`).
+- Parent submission path writes RSVP docs keyed by `userId` only in `submitRsvp`.
+- Hydration reads one `myRsvp` by `userId` and applies it to all child rows for that event.
+
+## Proposed state
+- Parent dashboard writes child-specific RSVP docs (`uid__playerId`) using the existing per-player RSVP API.
+- Parent dashboard hydrates RSVP UI per child from event RSVP docs belonging to the current parent.
+- Existing summary hydration remains intact.
+
+## Constraints
+- Keep patch minimal and local to parent RSVP flow.
+- Preserve Firestore rules compatibility (already supports `uid__playerId`).
+- Avoid changing unrelated calendar/team coach flows.
+
+## Success criteria
+- Parent can set different RSVP responses for siblings on same event and both persist.
+- Re-opening parent dashboard shows each child’s own response.
+- RSVP summary counts reflect both children independently.

--- a/js/db.js
+++ b/js/db.js
@@ -2758,6 +2758,10 @@ export async function submitRsvpForPlayer(teamId, gameId, userId, { displayName,
         respondedAt: Timestamp.now(),
         note: note || null
     });
+    if (docId !== effectiveUserId) {
+        const legacyRsvpRef = doc(db, `teams/${teamId}/games/${gameId}/rsvps`, effectiveUserId);
+        await deleteDoc(legacyRsvpRef);
+    }
 
     // Keep denormalized summary consistent with submitRsvp behavior.
     let summary = null;

--- a/js/parent-dashboard-rsvp.js
+++ b/js/parent-dashboard-rsvp.js
@@ -12,6 +12,26 @@ function parseChildIds(childIds) {
     return [];
 }
 
+function normalizeRsvpResponse(response) {
+    const value = String(response || '').trim().toLowerCase();
+    if (value === 'going' || value === 'maybe' || value === 'not_going') return value;
+    return 'not_responded';
+}
+
+function toMillis(value) {
+    if (!value) return 0;
+    if (typeof value?.toMillis === 'function') return value.toMillis();
+    if (value instanceof Date) return value.getTime();
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? 0 : parsed.getTime();
+}
+
+function extractRsvpPlayerIds(rsvp) {
+    const direct = uniqNonEmpty(rsvp?.playerIds);
+    if (direct.length > 0) return direct;
+    return uniqNonEmpty([rsvp?.playerId, rsvp?.childId]);
+}
+
 export function resolveRsvpPlayerIdsForSubmission(allScheduleEvents, teamId, gameId, childContext = {}) {
     const events = Array.isArray(allScheduleEvents) ? allScheduleEvents : [];
     const allowedPlayerIds = uniqNonEmpty(
@@ -48,4 +68,37 @@ export function resolveRsvpPlayerIdsForSubmission(allScheduleEvents, teamId, gam
 
     if (allowedPlayerIds.length === 1) return allowedPlayerIds;
     throwScopeError();
+}
+
+export function resolveMyRsvpByChildForGame(allScheduleEvents, teamId, gameId, rsvps, userId) {
+    const events = Array.isArray(allScheduleEvents) ? allScheduleEvents : [];
+    const scopedPlayerIds = uniqNonEmpty(
+        events
+            .filter((event) => event?.teamId === teamId && event?.id === gameId)
+            .map((event) => event?.childId || event?.playerId)
+    );
+    const scopedSet = new Set(scopedPlayerIds);
+    const byChild = new Map();
+
+    (Array.isArray(rsvps) ? rsvps : []).forEach((rsvp) => {
+        if ((rsvp?.userId || '') !== userId) return;
+        const response = normalizeRsvpResponse(rsvp?.response);
+        if (response === 'not_responded') return;
+        const respondedAtMillis = toMillis(rsvp?.respondedAt);
+
+        extractRsvpPlayerIds(rsvp).forEach((playerId) => {
+            if (!scopedSet.has(playerId)) return;
+            const existing = byChild.get(playerId);
+            if (!existing || respondedAtMillis >= existing.respondedAtMillis) {
+                byChild.set(playerId, {
+                    response,
+                    respondedAtMillis
+                });
+            }
+        });
+    });
+
+    return Object.fromEntries(
+        Array.from(byChild.entries()).map(([playerId, value]) => [playerId, value.response])
+    );
 }

--- a/js/parent-dashboard-rsvp.js
+++ b/js/parent-dashboard-rsvp.js
@@ -85,8 +85,10 @@ export function resolveMyRsvpByChildForGame(allScheduleEvents, teamId, gameId, r
         const response = normalizeRsvpResponse(rsvp?.response);
         if (response === 'not_responded') return;
         const respondedAtMillis = toMillis(rsvp?.respondedAt);
+        const resolvedPlayerIds = extractRsvpPlayerIds(rsvp);
+        const playerIdsForHydration = resolvedPlayerIds.length > 0 ? resolvedPlayerIds : scopedPlayerIds;
 
-        extractRsvpPlayerIds(rsvp).forEach((playerId) => {
+        playerIdsForHydration.forEach((playerId) => {
             if (!scopedSet.has(playerId)) return;
             const existing = byChild.get(playerId);
             if (!existing || respondedAtMillis >= existing.respondedAtMillis) {

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -200,7 +200,8 @@
             updateUserProfile,
             getUserProfile,
             submitRsvp,
-            getMyRsvp,
+            submitRsvpForPlayer,
+            getRsvps,
             getRsvpSummaries,
             createRideOffer,
             listRideOffersForEvent,
@@ -212,7 +213,7 @@
         import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence } from './js/utils.js?v=8';
         import { requireAuth, checkAuth } from './js/auth.js?v=9';
         import { resolvePracticePacketSessionIdForEvent as resolvePracticePacketSessionIdForEventBase, resolvePracticePacketContextForEvent as resolvePracticePacketContextForEventBase } from './js/parent-dashboard-packets.js?v=2';
-        import { resolveRsvpPlayerIdsForSubmission } from './js/parent-dashboard-rsvp.js?v=4';
+        import { resolveRsvpPlayerIdsForSubmission, resolveMyRsvpByChildForGame } from './js/parent-dashboard-rsvp.js?v=5';
         import { getEventRideshareSummary, getOfferSeatInfo, canRequestRide, findRequestForChild } from './js/rideshare-helpers.js?v=1';
         import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';
 
@@ -521,18 +522,26 @@
         window.submitGameRsvp = async function(teamId, gameId, response, childContext = {}) {
             try {
                 const playerIds = resolveRsvpPlayerIdsForSubmission(allScheduleEvents, teamId, gameId, childContext);
-                const summary = await submitRsvp(teamId, gameId, currentUserId, {
-                    displayName: currentUser?.displayName || currentUser?.email,
-                    playerIds,
-                    response
-                });
+                const isSinglePlayerSelection = playerIds.length === 1;
+                const summary = isSinglePlayerSelection
+                    ? await submitRsvpForPlayer(teamId, gameId, currentUserId, {
+                        displayName: currentUser?.displayName || currentUser?.email,
+                        playerId: playerIds[0],
+                        response
+                    })
+                    : await submitRsvp(teamId, gameId, currentUserId, {
+                        displayName: currentUser?.displayName || currentUser?.email,
+                        playerIds,
+                        response
+                    });
                 // Update local state and re-render
-                const game = allScheduleEvents.find(e => e.teamId === teamId && e.id === gameId);
-                if (game) {
-                    game.myRsvp = response;
-                    if (summary) game.rsvpSummary = summary;
-                    else if (!game.rsvpSummary) game.rsvpSummary = { going: 0, maybe: 0, notGoing: 0, notResponded: 0, total: 0 };
-                }
+                allScheduleEvents.forEach((event) => {
+                    if (event?.teamId !== teamId || event?.id !== gameId) return;
+                    if (isSinglePlayerSelection && (event?.childId || event?.playerId) !== playerIds[0]) return;
+                    event.myRsvp = response;
+                    if (summary) event.rsvpSummary = summary;
+                    else if (!event.rsvpSummary) event.rsvpSummary = { going: 0, maybe: 0, notGoing: 0, notResponded: 0, total: 0 };
+                });
                 renderScheduleFromControls();
             } catch (err) {
                 console.error('RSVP error:', err);
@@ -634,11 +643,19 @@
                 await Promise.all(uniqueGameKeys.map(async (key) => {
                     const [teamId, gameId] = key.split('::');
                     try {
-                        const myRsvp = await getMyRsvp(teamId, gameId, currentUserId);
+                        const rsvps = await getRsvps(teamId, gameId);
+                        const myRsvpByChild = resolveMyRsvpByChildForGame(allScheduleEvents, teamId, gameId, rsvps, currentUserId);
                         const summary = summaryMapsByTeam.get(teamId)?.get(gameId) || null;
                         applyRsvpHydration(allScheduleEvents, teamId, gameId, {
-                            myRsvp: myRsvp ? myRsvp.response : null,
                             summary
+                        });
+                        allScheduleEvents.forEach((event) => {
+                            if (event?.teamId !== teamId || event?.id !== gameId) return;
+                            const childId = event?.childId || event?.playerId || '';
+                            if (!childId) return;
+                            event.myRsvp = Object.prototype.hasOwnProperty.call(myRsvpByChild, childId)
+                                ? myRsvpByChild[childId]
+                                : null;
                         });
                     } catch (e) {
                         // Ignore per-game RSVP read failures.

--- a/tests/unit/parent-dashboard-rsvp.test.js
+++ b/tests/unit/parent-dashboard-rsvp.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { resolveRsvpPlayerIdsForSubmission } from '../../js/parent-dashboard-rsvp.js';
+import {
+  resolveRsvpPlayerIdsForSubmission,
+  resolveMyRsvpByChildForGame
+} from '../../js/parent-dashboard-rsvp.js';
 
 describe('parent dashboard RSVP player scope', () => {
   const allScheduleEvents = [
@@ -49,5 +52,49 @@ describe('parent dashboard RSVP player scope', () => {
     const result = resolveRsvpPlayerIdsForSubmission(allScheduleEvents, 'team-1', 'game-2', {});
 
     expect(result).toEqual(['child-c']);
+  });
+});
+
+describe('parent dashboard RSVP hydration scope', () => {
+  const allScheduleEvents = [
+    { teamId: 'team-1', id: 'game-1', childId: 'child-a' },
+    { teamId: 'team-1', id: 'game-1', childId: 'child-b' },
+    { teamId: 'team-1', id: 'game-1', childId: 'child-c' }
+  ];
+
+  it('returns distinct responses per child for the same parent and game', () => {
+    const result = resolveMyRsvpByChildForGame(
+      allScheduleEvents,
+      'team-1',
+      'game-1',
+      [
+        { userId: 'parent-1', playerIds: ['child-a'], response: 'going', respondedAt: '2026-03-01T10:00:00Z' },
+        { userId: 'parent-1', playerIds: ['child-b'], response: 'not_going', respondedAt: '2026-03-01T10:01:00Z' }
+      ],
+      'parent-1'
+    );
+
+    expect(result).toEqual({
+      'child-a': 'going',
+      'child-b': 'not_going'
+    });
+  });
+
+  it('ignores RSVP docs from other users and keeps latest response per child', () => {
+    const result = resolveMyRsvpByChildForGame(
+      allScheduleEvents,
+      'team-1',
+      'game-1',
+      [
+        { userId: 'parent-2', playerIds: ['child-a'], response: 'maybe', respondedAt: '2026-03-01T10:02:00Z' },
+        { userId: 'parent-1', playerIds: ['child-a'], response: 'going', respondedAt: '2026-03-01T10:00:00Z' },
+        { userId: 'parent-1', playerIds: ['child-a'], response: 'not_going', respondedAt: '2026-03-01T10:03:00Z' }
+      ],
+      'parent-1'
+    );
+
+    expect(result).toEqual({
+      'child-a': 'not_going'
+    });
   });
 });


### PR DESCRIPTION
Closes #162

## What changed
- Updated parent dashboard RSVP submission flow to use `submitRsvpForPlayer(...)` when a child-specific RSVP is submitted, so each child writes to a separate RSVP document (`uid__playerId`) instead of overwriting one parent-level RSVP doc.
- Reworked parent dashboard RSVP hydration to read RSVP docs for each event and map the current parent's responses by child/player ID, so sibling rows render independent RSVP states after reload.
- Added a new helper in `js/parent-dashboard-rsvp.js` to deterministically resolve per-child RSVP state from RSVP documents, including latest-response-wins behavior.
- Persisted required role-orchestration artifacts under `docs/pr-notes/runs/issue-162-fixer-20260304T232527Z/`.

## Why
- The prior parent flow stored one RSVP doc per user per event and hydrated one `myRsvp` across all sibling rows, causing the latest sibling action to overwrite earlier child-specific selections.
- The new flow aligns storage and UI hydration with child-scoped RSVP intent so families with multiple children can keep distinct responses for the same event.

## Validation
- `node /home/paul-bot1/.openclaw/workspace/allplays/node_modules/vitest/vitest.mjs run --root /home/paul-bot1/.local/state/paul-bot1/issue-fixer/workspaces/pauljsnider__allplays tests/unit/parent-dashboard-rsvp.test.js`
- `node /home/paul-bot1/.openclaw/workspace/allplays/node_modules/vitest/vitest.mjs run --root /home/paul-bot1/.local/state/paul-bot1/issue-fixer/workspaces/pauljsnider__allplays tests/unit/rsvp-hydration.test.js`