### PR TITLE
Gate track AI summary behind availability flag

### DIFF
--- a/docs/pr-notes/runs/issue-126-fixer-20260305T022557Z/architecture.md
+++ b/docs/pr-notes/runs/issue-126-fixer-20260305T022557Z/architecture.md
@@ -1,0 +1,15 @@
+# Architecture Role (fallback local synthesis)
+
+## Current state
+`track.html` always renders and wires `#generateAISummary`, then always attempts `getAI(...GoogleAIBackend...)` and model generation.
+
+## Proposed state
+Introduce a small helper module that determines AI summary capability via explicit runtime flag and applies UI gating before event listener wiring.
+
+## Design decision
+Use explicit opt-in flag (`globalThis.ALLPLAYS_ENABLE_AI_SUMMARY === true`) for `track.html` AI summary capability.
+
+## Rationale
+- Static-hosted app has no reliable server-side capability negotiation.
+- Explicit opt-in prevents deterministic failures in non-billing environments.
+- Minimal blast radius: only `track.html` AI button behavior changes.

--- a/docs/pr-notes/runs/issue-126-fixer-20260305T022557Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-126-fixer-20260305T022557Z/code-plan.md
@@ -1,0 +1,16 @@
+# Code Role Plan (fallback local synthesis)
+
+## Minimal patch
+1. Create `js/track-ai-summary.js` with:
+   - `isAISummaryEnabled(flag)`
+   - `applyAISummaryAvailability({ button, loadingDiv, enabled })`
+2. Update `track.html`:
+   - import helper functions
+   - evaluate `const aiSummaryEnabled = isAISummaryEnabled();`
+   - apply UI gating to button/loading area
+   - attach click listener only when enabled
+3. Add unit test `tests/unit/track-ai-summary-gating.test.js` that validates wiring in source.
+
+## Conflict resolution
+- Requirements/QA prefer hide-or-disable; architecture prefers explicit capability control.
+- Chosen synthesis: explicit opt-in + hide button by default to eliminate deterministic runtime failure in unsupported environments.

--- a/docs/pr-notes/runs/issue-126-fixer-20260305T022557Z/qa.md
+++ b/docs/pr-notes/runs/issue-126-fixer-20260305T022557Z/qa.md
@@ -1,0 +1,11 @@
+# QA Role (fallback local synthesis)
+
+## Risk focus
+- Regression: finish modal submit/email preview must still work.
+- Guard correctness: AI button should be hidden and not wired when unavailable.
+- Positive path: explicit enable flag should keep existing AI flow accessible.
+
+## Test strategy
+- Add unit test asserting `track.html` imports and uses availability gate.
+- Assert guarded listener attachment pattern exists and unguarded attachment is absent.
+- Manual spot check (if needed): finish modal open/save unaffected.

--- a/docs/pr-notes/runs/issue-126-fixer-20260305T022557Z/requirements.md
+++ b/docs/pr-notes/runs/issue-126-fixer-20260305T022557Z/requirements.md
@@ -1,0 +1,13 @@
+# Requirements Role (fallback local synthesis)
+
+## Objective
+Prevent users from seeing a deterministic-fail AI action in the Finish Game flow when Firebase AI/billing is unavailable.
+
+## User constraints
+- Coaches finishing a game must complete the flow without avoidable errors.
+- If AI capability is not enabled, UI must not present a primary action that fails.
+
+## Acceptance criteria
+- Finish modal no longer exposes active AI generation by default when capability flag is off.
+- AI button is hidden/disabled before click-path runtime failure.
+- Existing non-AI finish flow remains unchanged.

--- a/js/track-ai-summary.js
+++ b/js/track-ai-summary.js
@@ -1,0 +1,24 @@
+export function isAISummaryEnabled(flagValue = globalThis.ALLPLAYS_ENABLE_AI_SUMMARY) {
+    return flagValue === true;
+}
+
+export function applyAISummaryAvailability({ button, loadingDiv, enabled }) {
+    if (!button) {
+        return;
+    }
+
+    if (enabled) {
+        button.classList.remove('hidden');
+        button.disabled = false;
+        button.removeAttribute('aria-disabled');
+        return;
+    }
+
+    button.classList.add('hidden');
+    button.disabled = true;
+    button.setAttribute('aria-disabled', 'true');
+
+    if (loadingDiv) {
+        loadingDiv.classList.add('hidden');
+    }
+}

--- a/tests/unit/track-ai-summary-gating.test.js
+++ b/tests/unit/track-ai-summary-gating.test.js
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { isAISummaryEnabled } from '../../js/track-ai-summary.js';
+
+describe('track finish modal AI summary gating', () => {
+  it('requires explicit enablement for AI summary', () => {
+    expect(isAISummaryEnabled()).toBe(false);
+    expect(isAISummaryEnabled(true)).toBe(true);
+    expect(isAISummaryEnabled(false)).toBe(false);
+  });
+
+  it('wires AI summary behind an availability gate', () => {
+    const source = readFileSync(new URL('../../track.html', import.meta.url), 'utf8');
+
+    expect(source).toContain("import { isAISummaryEnabled, applyAISummaryAvailability } from './js/track-ai-summary.js';");
+    expect(source).toContain('const aiSummaryEnabled = isAISummaryEnabled();');
+    expect(source).toContain('applyAISummaryAvailability({');
+    expect(source).toContain('if (aiSummaryEnabled) {');
+    expect(source).toContain("document.getElementById('generateAISummary').addEventListener('click', generateAIMatchReport);");
+  });
+});

--- a/track.html
+++ b/track.html
@@ -278,6 +278,7 @@
         import { writeBatch, doc, setDoc, addDoc } from './js/firebase.js?v=9';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
+        import { isAISummaryEnabled, applyAISummaryAvailability } from './js/track-ai-summary.js';
         import { getApp } from './js/vendor/firebase-app.js';
         // Note: firebase-ai will be lazy-loaded when AI summary is requested
 
@@ -1170,6 +1171,15 @@ Write the match report now:`;
         const finishBtn = document.getElementById('finish-btn');
         const cancelBtn = document.getElementById('cancel-finish');
         const finishForm = document.getElementById('finish-form');
+        const aiSummaryButton = document.getElementById('generateAISummary');
+        const aiSummaryLoading = document.getElementById('aiSummaryLoading');
+        const aiSummaryEnabled = isAISummaryEnabled();
+
+        applyAISummaryAvailability({
+            button: aiSummaryButton,
+            loadingDiv: aiSummaryLoading,
+            enabled: aiSummaryEnabled
+        });
 
         finishBtn.addEventListener('click', () => {
             document.getElementById('finalHomeScore').value = homeScore;
@@ -1188,7 +1198,9 @@ Write the match report now:`;
         document.getElementById('gameSummary').addEventListener('input', updateEmailPreview);
 
         // AI Summary button
-        document.getElementById('generateAISummary').addEventListener('click', generateAIMatchReport);
+        if (aiSummaryEnabled) {
+            document.getElementById('generateAISummary').addEventListener('click', generateAIMatchReport);
+        }
 
         function updateEmailPreview() {
             const finalHome = parseInt(document.getElementById('finalHomeScore').value) || 0;


### PR DESCRIPTION
Closes #126

## What changed
- Added `js/track-ai-summary.js` with explicit AI summary capability helpers.
- Updated `track.html` to:
  - import and evaluate AI summary availability (`isAISummaryEnabled()`),
  - hide/disable the AI summary action when unavailable,
  - only attach the AI summary click handler when enabled.
- Added unit coverage in `tests/unit/track-ai-summary-gating.test.js` to verify:
  - AI summary requires explicit enablement,
  - `track.html` wiring is guarded by the availability check.
- Added required run artifacts under `docs/pr-notes/runs/issue-126-fixer-20260305T022557Z/`.

## Why
The finish-game modal always exposed an AI action that deterministically failed when Firebase AI/billing was not enabled. This patch makes the AI action capability-gated so unsupported environments no longer present a failing primary action.

## Validation
- `pnpm dlx vitest run tests/unit/track-ai-summary-gating.test.js`