### PR TITLE
Align soccer live tracker state sync with basketball tracker

### DIFF
--- a/docs/pr-notes/runs/174-remediator-20260305T040617Z/architecture.md
+++ b/docs/pr-notes/runs/174-remediator-20260305T040617Z/architecture.md
@@ -1,0 +1,14 @@
+# Architecture role (fallback inline)
+
+Current state:
+- Debounced writes (`scoreSyncTimeout`, `opponentTimeout`, `playerTimeouts`, `liveFlagTimeout`) can outlive destructive reset/delete operations.
+- `liveHasData` is used as a persisted-state signal for resume prompt, but not cleared by `resetTimer()` and `cancelGame()`.
+
+Proposed state:
+- Add one local utility in `track-live.html` to clear all pending `liveSync` timers atomically.
+- Invoke that utility at the start of each destructive flow.
+- Include `liveHasData: false` in reset/cancel game updates and update in-memory `currentGame.liveHasData` accordingly.
+
+Blast radius:
+- Limited to live tracker state transitions in one page.
+- No schema changes, no external module changes.

--- a/docs/pr-notes/runs/174-remediator-20260305T040617Z/code-plan.md
+++ b/docs/pr-notes/runs/174-remediator-20260305T040617Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code role plan (fallback inline)
+
+Implementation steps:
+1. Add `clearLiveSyncTimeouts()` function near existing live sync helpers.
+2. Call it in:
+   - `startTimer()` start-over destructive branch
+   - `resetTimer()` after user confirmation before any resets/deletes
+   - `cancelGame()` after confirm before deletes
+3. Update `resetTimer()` `updateGame` payload to set `liveHasData: false`.
+4. Update `cancelGame()` `updateGame` payload to set `liveHasData: false`.
+5. Update local `currentGame.liveHasData = false` in reset/cancel flows.

--- a/docs/pr-notes/runs/174-remediator-20260305T040617Z/qa.md
+++ b/docs/pr-notes/runs/174-remediator-20260305T040617Z/qa.md
@@ -1,0 +1,13 @@
+# QA role (fallback inline)
+
+Manual validation plan:
+1. Trigger stat updates, then immediately run Reset within 500ms.
+   - Verify no delayed writes recreate `aggregatedStats` or non-zero game score after reset.
+2. Trigger stat updates, then immediately run Cancel within 500ms.
+   - Verify no delayed writes repopulate game docs before redirect.
+3. Start game with existing data and choose "Cancel" on resume prompt (start over).
+   - Verify pending writes are canceled and state remains clean.
+4. After Reset, reload tracker and start timer with no new data.
+   - Verify resume prompt does not appear due to stale `liveHasData`.
+
+Repo has no automated runner for this page; execute targeted static checks only.

--- a/docs/pr-notes/runs/174-remediator-20260305T040617Z/requirements.md
+++ b/docs/pr-notes/runs/174-remediator-20260305T040617Z/requirements.md
@@ -1,0 +1,15 @@
+# Requirements role (fallback inline)
+
+Objective: Address unresolved PR #174 review feedback in `track-live.html` only.
+
+Required fixes:
+1. Ensure all pending debounced `liveSync` timers are canceled before destructive reset/delete flows, specifically:
+   - Start-over path in `startTimer()` when user declines resume
+   - `resetTimer()` flow
+   - `cancelGame()` flow
+2. Ensure `liveHasData` is cleared in regular reset/cancel flows so resume prompt signal reflects true persisted activity after start-fresh actions.
+
+Constraints:
+- Minimal targeted changes.
+- No unrelated refactors.
+- Keep behavior consistent with existing reset helper semantics.

--- a/docs/pr-notes/runs/174-review-comment-2887462757-20260305T041141Z/architecture.md
+++ b/docs/pr-notes/runs/174-review-comment-2887462757-20260305T041141Z/architecture.md
@@ -1,0 +1,18 @@
+# Architecture Role Summary
+
+Thinking level: medium (single-page tracker state consistency + Firestore document invariants).
+
+## Current state
+Resume gating checks doc-level and collection-level signals. Reset/cancel cleanup paths were not fully consistent across tracker implementations.
+
+## Proposed state
+Standardize cleanup contract for fresh-start flows:
+- Delete all event collections contributing to resume inference.
+- Set game doc flags/status to scheduled baseline (`liveHasData: false`, `liveStatus: 'scheduled'`).
+- Keep opponent identity linkage fields intact.
+- Mirror the same values into in-memory `currentGame` after successful update.
+
+## Risk surface / blast radius
+- Scope limited to tracker reset/start-fresh/cancel branches.
+- No auth/rules schema changes.
+- Potential risk is over-clearing game metadata; mitigated by preserving opponent identity fields explicitly.

--- a/docs/pr-notes/runs/174-review-comment-2887462757-20260305T041141Z/code-plan.md
+++ b/docs/pr-notes/runs/174-review-comment-2887462757-20260305T041141Z/code-plan.md
@@ -1,0 +1,10 @@
+# Code Role Plan
+
+Thinking level: medium (small targeted patch, no refactor).
+
+## Minimal patch steps
+1. In `track-live.html` `resetTimer()`, include `liveStatus: 'scheduled'` in `updateGame` payload and sync local `currentGame.liveStatus`.
+2. In `track-live.html` `cancelGame()`, delete `liveEvents` collection during cancellation.
+3. In `track-live.html` `cancelGame()`, always send reset metadata payload with `liveHasData: false`, `liveStatus: 'scheduled'`, zero scores, and empty `opponentStats`; keep opponent identity fields.
+4. In `js/live-tracker.js` start-fresh clear path, set `liveHasData: false` and `liveStatus: 'scheduled'` in payload and local `currentGame` state.
+5. Run targeted unit test for `tests/unit/track-live-state.test.js`.

--- a/docs/pr-notes/runs/174-review-comment-2887462757-20260305T041141Z/qa.md
+++ b/docs/pr-notes/runs/174-review-comment-2887462757-20260305T041141Z/qa.md
@@ -1,0 +1,13 @@
+# QA Role Summary
+
+Thinking level: medium (cross-flow regression checks across duplicated tracker logic).
+
+## Regression guardrails
+1. Start fresh from resume prompt no longer re-prompts solely due to stale `liveHasData`.
+2. Cancel removes `liveEvents` in addition to `events` and `aggregatedStats`.
+3. Reset sets `liveStatus` back to scheduled in both persisted and in-memory state.
+4. Opponent identity link fields remain unchanged after reset/cancel.
+
+## Validation focus
+- Static verification of patched payloads in `track-live.html` and `js/live-tracker.js`.
+- Existing unit tests for `track-live-state` helper still pass.

--- a/docs/pr-notes/runs/174-review-comment-2887462757-20260305T041141Z/requirements.md
+++ b/docs/pr-notes/runs/174-review-comment-2887462757-20260305T041141Z/requirements.md
@@ -1,0 +1,15 @@
+# Requirements Role Summary
+
+Thinking level: medium (behavioral bug in reset/restart flows with moderate regression risk).
+
+## Objective
+Ensure "start fresh" behavior does not prompt resume because of stale persisted flags after reset/cancel operations.
+
+## User-facing requirement
+- After reset or cancel, tracker should behave as a fresh game start unless new activity occurs.
+
+## Acceptance criteria
+1. Reset flow clears persisted signal fields used by resume prompt (`liveHasData`, `liveStatus`) and score/opponent stat artifacts.
+2. Cancel flow deletes tracked records (`events`, `aggregatedStats`, `liveEvents`) and clears game-level persisted signal fields.
+3. Local in-memory `currentGame` state is aligned with the persisted reset state to avoid stale prompt behavior in same session.
+4. No change to preserved linked-opponent identity fields (`opponent`, `opponentTeamId`, `opponentTeamName`, `opponentTeamPhoto`).

--- a/js/live-game-state.js
+++ b/js/live-game-state.js
@@ -39,3 +39,20 @@ export function applyResetEventState(currentState, event) {
     lastRunAnnounced: 0
   };
 }
+
+export function shouldResetViewerFromGameDoc(gameDoc = {}, currentState = {}) {
+  const isScheduledReset =
+    gameDoc?.liveStatus === 'scheduled' &&
+    !gameDoc?.liveHasData &&
+    (Number(gameDoc?.homeScore) || 0) === 0 &&
+    (Number(gameDoc?.awayScore) || 0) === 0;
+
+  if (!isScheduledReset) return false;
+
+  const hasEvents = Array.isArray(currentState?.events) && currentState.events.length > 0;
+  const hasHomeStats = !!(currentState?.stats && Object.keys(currentState.stats).length > 0);
+  const hasOpponentStats = !!(currentState?.opponentStats && Object.keys(currentState.opponentStats).length > 0);
+  const hasScore = (Number(currentState?.homeScore) || 0) > 0 || (Number(currentState?.awayScore) || 0) > 0;
+
+  return hasEvents || hasHomeStats || hasOpponentStats || hasScore;
+}

--- a/js/live-game-state.js
+++ b/js/live-game-state.js
@@ -56,3 +56,20 @@ export function shouldResetViewerFromGameDoc(gameDoc = {}, currentState = {}) {
 
   return hasEvents || hasHomeStats || hasOpponentStats || hasScore;
 }
+
+export function isLiveEventVisibleForResetBoundary(event = {}, resetBoundaryMs = 0) {
+  if (!resetBoundaryMs) return true;
+
+  if (event?.type === 'reset') return true;
+
+  const createdAt = event?.createdAt;
+  let eventMs = null;
+  if (typeof createdAt === 'number') {
+    eventMs = createdAt;
+  } else if (createdAt && typeof createdAt.toMillis === 'function') {
+    eventMs = createdAt.toMillis();
+  }
+
+  if (!Number.isFinite(eventMs)) return true;
+  return eventMs >= resetBoundaryMs;
+}

--- a/js/live-game-state.js
+++ b/js/live-game-state.js
@@ -18,6 +18,9 @@ export function applyResetEventState(currentState, event) {
   const period = event?.period || currentState?.period || 'Q1';
   const onCourt = Array.isArray(event?.onCourt) ? [...event.onCourt] : [];
   const bench = Array.isArray(event?.bench) ? [...event.bench] : [];
+  const priorEventIds = currentState?.eventIds instanceof Set
+    ? new Set(currentState.eventIds)
+    : new Set();
   return {
     ...currentState,
     homeScore: Number.isFinite(event?.homeScore) ? event.homeScore : 0,
@@ -25,7 +28,8 @@ export function applyResetEventState(currentState, event) {
     period,
     gameClockMs: Number.isFinite(event?.gameClockMs) ? event.gameClockMs : 0,
     events: [],
-    eventIds: new Set(),
+    // Keep already-seen ids so pre-reset events are not replayed into fresh state.
+    eventIds: priorEventIds,
     stats: {},
     opponentStats: {},
     onCourt,

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -21,7 +21,7 @@ import { isViewerChatEnabled } from './live-game-chat.js?v=1';
 import { getReplayElapsedMs, getReplayStartTimeAfterSpeedChange } from './live-game-replay.js?v=2';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
-import { resolveOpponentDisplayName, normalizeLiveStatColumns, applyResetEventState, shouldResetViewerFromGameDoc } from './live-game-state.js?v=1';
+import { resolveOpponentDisplayName, normalizeLiveStatColumns, applyResetEventState, shouldResetViewerFromGameDoc, isLiveEventVisibleForResetBoundary } from './live-game-state.js?v=1';
 
 const state = {
   teamId: null,
@@ -779,10 +779,18 @@ function resetViewerStateFromGameDoc(gameDoc, placeholder = 'Game reset. Waiting
 }
 
 function processNewEvents(events) {
-  const newEvents = events.filter(ev => !state.eventIds.has(ev.id));
+  const resetBoundaryMs = Number(state.lastResetAt) || 0;
+  const newEvents = events.filter(ev => (
+    !state.eventIds.has(ev.id) &&
+    isLiveEventVisibleForResetBoundary(ev, resetBoundaryMs)
+  ));
   newEvents.forEach(event => {
     state.eventIds.add(event.id);
     if (event.type === 'reset') {
+      const resetAt = getTimestampMs(event.createdAt) || Date.now();
+      if (resetAt > (state.lastResetAt || 0)) {
+        state.lastResetAt = resetAt;
+      }
       const next = applyResetEventState(state, event);
       Object.assign(state, next);
       state.eventIds.add(event.id);

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -73,7 +73,8 @@ const state = {
   lastStatChange: null,
   scoringRun: { team: null, points: 0 },
   lastRunAnnounced: 0,
-  hasVideoStream: false
+  hasVideoStream: false,
+  lastResetAt: 0
 };
 
 const els = {
@@ -758,6 +759,25 @@ function updateMomentum(event) {
   }
 }
 
+function resetViewerStateFromGameDoc(gameDoc, placeholder = 'Game reset. Waiting for plays...') {
+  const liveLineup = gameDoc?.liveLineup || {};
+  const next = applyResetEventState(state, {
+    period: gameDoc?.period || 'Q1',
+    homeScore: gameDoc?.homeScore || 0,
+    awayScore: gameDoc?.awayScore || 0,
+    gameClockMs: Number.isFinite(gameDoc?.liveClockMs) ? gameDoc.liveClockMs : 0,
+    onCourt: Array.isArray(liveLineup.onCourt) ? liveLineup.onCourt : [],
+    bench: Array.isArray(liveLineup.bench) ? liveLineup.bench : []
+  });
+  Object.assign(state, next);
+  if (els.playsFeed) {
+    els.playsFeed.innerHTML = `<div data-placeholder="plays" class="text-center text-sand/40 py-8">${placeholder}</div>`;
+  }
+  renderScoreboard();
+  renderStats();
+  renderLineup();
+}
+
 function processNewEvents(events) {
   const newEvents = events.filter(ev => !state.eventIds.has(ev.id));
   newEvents.forEach(event => {
@@ -888,22 +908,7 @@ function startLiveEvents() {
         Object.keys(state.stats || {}).length > 0 ||
         Object.keys(state.opponentStats || {}).length > 0;
       if (hadLiveState) {
-        const liveLineup = state.game?.liveLineup || {};
-        const next = applyResetEventState(state, {
-          period: state.game?.period || 'Q1',
-          homeScore: state.game?.homeScore || 0,
-          awayScore: state.game?.awayScore || 0,
-          gameClockMs: Number.isFinite(state.game?.liveClockMs) ? state.game.liveClockMs : 0,
-          onCourt: Array.isArray(liveLineup.onCourt) ? liveLineup.onCourt : [],
-          bench: Array.isArray(liveLineup.bench) ? liveLineup.bench : []
-        });
-        Object.assign(state, next);
-        if (els.playsFeed) {
-          els.playsFeed.innerHTML = '<div data-placeholder="plays" class="text-center text-sand/40 py-8">Game reset. Waiting for plays...</div>';
-        }
-        renderScoreboard();
-        renderStats();
-        renderLineup();
+        resetViewerStateFromGameDoc(state.game, 'Game reset. Waiting for plays...');
       }
     }
     state.liveEventsFirstLoad = false;
@@ -1356,23 +1361,13 @@ function handleGameUpdate(gameDoc) {
   if (!gameDoc) return;
   state.game = gameDoc;
   renderGameInfo();
+  const resetAt = getTimestampMs(gameDoc.liveResetAt) || 0;
+  if (resetAt > state.lastResetAt) {
+    state.lastResetAt = resetAt;
+    resetViewerStateFromGameDoc(gameDoc, 'Game reset. Waiting for plays...');
+  }
   if (shouldResetViewerFromGameDoc(gameDoc, state)) {
-    const liveLineup = gameDoc.liveLineup || {};
-    const next = applyResetEventState(state, {
-      period: gameDoc.period || 'Q1',
-      homeScore: gameDoc.homeScore || 0,
-      awayScore: gameDoc.awayScore || 0,
-      gameClockMs: Number.isFinite(gameDoc.liveClockMs) ? gameDoc.liveClockMs : 0,
-      onCourt: Array.isArray(liveLineup.onCourt) ? liveLineup.onCourt : [],
-      bench: Array.isArray(liveLineup.bench) ? liveLineup.bench : []
-    });
-    Object.assign(state, next);
-    if (els.playsFeed) {
-      els.playsFeed.innerHTML = '<div data-placeholder="plays" class="text-center text-sand/40 py-8">Game reset. Waiting for plays...</div>';
-    }
-    renderScoreboard();
-    renderStats();
-    renderLineup();
+    resetViewerStateFromGameDoc(gameDoc, 'Game reset. Waiting for plays...');
   }
   if (gameDoc.liveLineup) {
     state.onCourt = Array.isArray(gameDoc.liveLineup.onCourt) ? gameDoc.liveLineup.onCourt : state.onCourt;
@@ -1481,6 +1476,7 @@ async function init() {
   state.homeScore = game.homeScore || 0;
   state.awayScore = game.awayScore || 0;
   state.period = game.period || 'Q1';
+  state.lastResetAt = getTimestampMs(game.liveResetAt) || 0;
 
   setupVideoPanel();
   renderGameInfo();

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -21,7 +21,7 @@ import { isViewerChatEnabled } from './live-game-chat.js?v=1';
 import { getReplayElapsedMs, getReplayStartTimeAfterSpeedChange } from './live-game-replay.js?v=2';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
-import { resolveOpponentDisplayName, normalizeLiveStatColumns, applyResetEventState } from './live-game-state.js?v=1';
+import { resolveOpponentDisplayName, normalizeLiveStatColumns, applyResetEventState, shouldResetViewerFromGameDoc } from './live-game-state.js?v=1';
 
 const state = {
   teamId: null,
@@ -1356,6 +1356,24 @@ function handleGameUpdate(gameDoc) {
   if (!gameDoc) return;
   state.game = gameDoc;
   renderGameInfo();
+  if (shouldResetViewerFromGameDoc(gameDoc, state)) {
+    const liveLineup = gameDoc.liveLineup || {};
+    const next = applyResetEventState(state, {
+      period: gameDoc.period || 'Q1',
+      homeScore: gameDoc.homeScore || 0,
+      awayScore: gameDoc.awayScore || 0,
+      gameClockMs: Number.isFinite(gameDoc.liveClockMs) ? gameDoc.liveClockMs : 0,
+      onCourt: Array.isArray(liveLineup.onCourt) ? liveLineup.onCourt : [],
+      bench: Array.isArray(liveLineup.bench) ? liveLineup.bench : []
+    });
+    Object.assign(state, next);
+    if (els.playsFeed) {
+      els.playsFeed.innerHTML = '<div data-placeholder="plays" class="text-center text-sand/40 py-8">Game reset. Waiting for plays...</div>';
+    }
+    renderScoreboard();
+    renderStats();
+    renderLineup();
+  }
   if (gameDoc.liveLineup) {
     state.onCourt = Array.isArray(gameDoc.liveLineup.onCourt) ? gameDoc.liveLineup.onCourt : state.onCourt;
     state.bench = Array.isArray(gameDoc.liveLineup.bench) ? gameDoc.liveLineup.bench : state.bench;

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -14,7 +14,7 @@ import {
   getConfigs,
   subscribeGame
 } from './db.js?v=14';
-import { getUrlParams, escapeHtml, renderHeader, renderFooter, formatShortDate, formatTime, shareOrCopy } from './utils.js?v=8';
+import { getUrlParams, escapeHtml, renderHeader, renderFooter, formatShortDate, formatTime, shareOrCopy } from './utils.js?v=9';
 import { computePanelVisibility } from './live-stream-utils.js?v=1';
 import { checkAuth } from './auth.js?v=9';
 import { isViewerChatEnabled } from './live-game-chat.js?v=1';
@@ -883,6 +883,29 @@ function startLiveEvents() {
       const placeholder = els.playsFeed?.querySelector?.('[data-placeholder="plays"]');
       if (placeholder) placeholder.textContent = 'Connected. Waiting for plays...';
     }
+    if (!state.liveEventsFirstLoad && events.length === 0) {
+      const hadLiveState = state.events.length > 0 ||
+        Object.keys(state.stats || {}).length > 0 ||
+        Object.keys(state.opponentStats || {}).length > 0;
+      if (hadLiveState) {
+        const liveLineup = state.game?.liveLineup || {};
+        const next = applyResetEventState(state, {
+          period: state.game?.period || 'Q1',
+          homeScore: state.game?.homeScore || 0,
+          awayScore: state.game?.awayScore || 0,
+          gameClockMs: Number.isFinite(state.game?.liveClockMs) ? state.game.liveClockMs : 0,
+          onCourt: Array.isArray(liveLineup.onCourt) ? liveLineup.onCourt : [],
+          bench: Array.isArray(liveLineup.bench) ? liveLineup.bench : []
+        });
+        Object.assign(state, next);
+        if (els.playsFeed) {
+          els.playsFeed.innerHTML = '<div data-placeholder="plays" class="text-center text-sand/40 py-8">Game reset. Waiting for plays...</div>';
+        }
+        renderScoreboard();
+        renderStats();
+        renderLineup();
+      }
+    }
     state.liveEventsFirstLoad = false;
     processNewEvents(events);
   }, (error) => {
@@ -1342,6 +1365,11 @@ function handleGameUpdate(gameDoc) {
     state.homeScore = gameDoc.homeScore || state.homeScore;
     state.awayScore = gameDoc.awayScore || state.awayScore;
     state.period = gameDoc.period || state.period;
+    if (Number.isFinite(gameDoc.liveClockMs)) {
+      state.gameClockMs = gameDoc.liveClockMs;
+    } else if (Number.isFinite(gameDoc.gameClockMs)) {
+      state.gameClockMs = gameDoc.gameClockMs;
+    }
     renderScoreboard();
   }
 

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -1551,6 +1551,8 @@ async function startStop() {
         await updateGame(currentTeamId, currentGameId, { 
           homeScore: 0, 
           awayScore: 0, 
+          liveStatus: 'scheduled',
+          liveHasData: false,
           opponentStats: {},
           // Preserve opponent fields
           opponent: currentGame.opponent,
@@ -1558,6 +1560,11 @@ async function startStop() {
           opponentTeamName: currentGame.opponentTeamName,
           opponentTeamPhoto: currentGame.opponentTeamPhoto
         });
+        currentGame.liveStatus = 'scheduled';
+        currentGame.liveHasData = false;
+        currentGame.homeScore = 0;
+        currentGame.awayScore = 0;
+        currentGame.opponentStats = {};
       }
     }
 

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -1,7 +1,7 @@
 // Mobile-first basketball tracker, now backed by Firebase like track.html.
 import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=14';
 import { db } from './firebase.js?v=9';
-import { getUrlParams, escapeHtml } from './utils.js?v=8';
+import { getUrlParams, escapeHtml } from './utils.js?v=9';
 import { checkAuth } from './auth.js?v=9';
 import { writeBatch, doc, setDoc, addDoc, onSnapshot } from './firebase.js?v=9';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
@@ -844,6 +844,23 @@ function undo() {
   }
 }
 
+async function syncClockToGameDoc() {
+  if (!currentTeamId || !currentGameId) return;
+
+  const updates = {
+    liveClockMs: state.clock,
+    liveClockRunning: state.running,
+    liveClockPeriod: state.period,
+    liveClockUpdatedAt: Date.now()
+  };
+
+  try {
+    await updateGame(currentTeamId, currentGameId, updates);
+  } catch (error) {
+    console.warn('Failed to sync live clock to game doc:', error);
+  }
+}
+
 function renderAll() {
   renderHeader();
   renderLineup();
@@ -1178,6 +1195,7 @@ async function startLiveBroadcast() {
   } catch (error) {
     console.warn('Failed to set live status:', error);
   }
+  syncClockToGameDoc();
   scheduleScoreSync();
   initChat();
   initViewerCount();
@@ -1535,6 +1553,7 @@ async function startStop() {
       type: 'clock_pause',
       description: 'Game paused'
     }));
+    syncClockToGameDoc();
   } else {
     // If no local activity yet, check for existing tracked data and offer to clear
     const hasLocalActivity = state.clock > 0 || state.home > 0 || state.away > 0 || (state.log && state.log.length > 0);
@@ -1551,8 +1570,6 @@ async function startStop() {
         await updateGame(currentTeamId, currentGameId, { 
           homeScore: 0, 
           awayScore: 0, 
-          liveStatus: 'scheduled',
-          liveHasData: false,
           opponentStats: {},
           // Preserve opponent fields
           opponent: currentGame.opponent,
@@ -1560,11 +1577,6 @@ async function startStop() {
           opponentTeamName: currentGame.opponentTeamName,
           opponentTeamPhoto: currentGame.opponentTeamPhoto
         });
-        currentGame.liveStatus = 'scheduled';
-        currentGame.liveHasData = false;
-        currentGame.homeScore = 0;
-        currentGame.awayScore = 0;
-        currentGame.opponentStats = {};
       }
     }
 
@@ -1606,6 +1618,7 @@ function tick() {
       type: 'clock_sync',
       description: 'Clock sync'
     }));
+    syncClockToGameDoc();
   }
 }
 
@@ -2377,21 +2390,10 @@ async function init() {
       }
 
       if (!shouldResume) {
-        const [eventsSnapshot, statsSnapshot, liveEventsSnapshot] = await Promise.all([
+        const [eventsSnapshot, statsSnapshot] = await Promise.all([
           safeGetDocs(collection(db, `teams/${teamId}/games/${gameId}/events`), 'events'),
-          safeGetDocs(collection(db, `teams/${teamId}/games/${gameId}/aggregatedStats`), 'aggregatedStats'),
-          safeGetDocs(collection(db, `teams/${teamId}/games/${gameId}/liveEvents`), 'liveEvents')
+          safeGetDocs(collection(db, `teams/${teamId}/games/${gameId}/aggregatedStats`), 'aggregatedStats')
         ]);
-        const deletions = [
-          ...eventsSnapshot.docs.map(d => deleteDoc(d.ref)),
-          ...statsSnapshot.docs.map(d => deleteDoc(d.ref)),
-          ...liveEventsSnapshot.docs.map(d => deleteDoc(d.ref))
-        ];
-        const results = await Promise.allSettled(deletions);
-        const failedDeletes = results.filter(r => r.status === 'rejected');
-        if (failedDeletes.length) {
-          console.warn('Some live data could not be deleted:', failedDeletes);
-        }
         try {
           await updateGame(teamId, gameId, {
             homeScore: 0,
@@ -2399,6 +2401,7 @@ async function init() {
             opponentStats: {},
             liveStatus: 'scheduled',
             liveHasData: false,
+            liveResetAt: Date.now(),
             liveLineup: { onCourt: [], bench: roster.map(r => r.id) },
             // Preserve opponent fields
             opponent: game.opponent,
@@ -2410,6 +2413,15 @@ async function init() {
           currentGame.liveHasData = false;
         } catch (error) {
           console.warn('Failed to reset game metadata:', error);
+        }
+        const deletions = [
+          ...eventsSnapshot.docs.map(d => deleteDoc(d.ref)),
+          ...statsSnapshot.docs.map(d => deleteDoc(d.ref))
+        ];
+        const results = await Promise.allSettled(deletions);
+        const failedDeletes = results.filter(r => r.status === 'rejected');
+        if (failedDeletes.length) {
+          console.warn('Some live data could not be deleted:', failedDeletes);
         }
         state.home = 0;
         state.away = 0;

--- a/js/track-live-state.js
+++ b/js/track-live-state.js
@@ -25,7 +25,8 @@ export function summarizePersistedTrackingState({
 export function buildTrackLiveResetUpdate({
   currentGame = {},
   period = 'Q1',
-  liveLineup = { onCourt: [], bench: [] }
+  liveLineup = { onCourt: [], bench: [] },
+  liveResetAt = Date.now()
 } = {}) {
   const onCourt = Array.isArray(liveLineup?.onCourt) ? [...liveLineup.onCourt] : [];
   const bench = Array.isArray(liveLineup?.bench) ? [...liveLineup.bench] : [];
@@ -37,6 +38,7 @@ export function buildTrackLiveResetUpdate({
     opponentStats: {},
     liveStatus: 'scheduled',
     liveHasData: false,
+    liveResetAt,
     opponent: currentGame?.opponent,
     opponentTeamId: currentGame?.opponentTeamId || '',
     opponentTeamName: currentGame?.opponentTeamName || '',

--- a/js/track-live-state.js
+++ b/js/track-live-state.js
@@ -1,0 +1,45 @@
+export function summarizePersistedTrackingState({
+  eventsCount = 0,
+  statsCount = 0,
+  liveEventsCount = 0,
+  hasScores = false,
+  hasOpponentStats = false,
+  hasLiveFlag = false
+} = {}) {
+  const parts = [];
+  if (eventsCount > 0) parts.push(`${eventsCount} event(s)`);
+  if (statsCount > 0) parts.push(`${statsCount} player stat record(s)`);
+  if (liveEventsCount > 0) parts.push(`${liveEventsCount} live event(s)`);
+  if (hasScores) parts.push('saved score');
+  if (hasOpponentStats) parts.push('opponent stats');
+  if (hasLiveFlag) parts.push('live status');
+
+  const hasPersistedData = parts.length > 0;
+  return {
+    hasPersistedData,
+    parts,
+    summary: parts.join(', ') || 'tracked data'
+  };
+}
+
+export function buildTrackLiveResetUpdate({
+  currentGame = {},
+  period = 'Q1',
+  liveLineup = { onCourt: [], bench: [] }
+} = {}) {
+  const onCourt = Array.isArray(liveLineup?.onCourt) ? [...liveLineup.onCourt] : [];
+  const bench = Array.isArray(liveLineup?.bench) ? [...liveLineup.bench] : [];
+  return {
+    homeScore: 0,
+    awayScore: 0,
+    period,
+    liveLineup: { onCourt, bench },
+    opponentStats: {},
+    liveStatus: 'scheduled',
+    liveHasData: false,
+    opponent: currentGame?.opponent,
+    opponentTeamId: currentGame?.opponentTeamId || '',
+    opponentTeamName: currentGame?.opponentTeamName || '',
+    opponentTeamPhoto: currentGame?.opponentTeamPhoto || ''
+  };
+}

--- a/js/track-live-state.js
+++ b/js/track-live-state.js
@@ -45,3 +45,35 @@ export function buildTrackLiveResetUpdate({
     opponentTeamPhoto: currentGame?.opponentTeamPhoto || ''
   };
 }
+
+export async function runTrackLiveResetPersistence({
+  publishResetEvent,
+  updateResetState,
+  cleanupPersistedState,
+  logWarn = () => {},
+  logError = () => {}
+} = {}) {
+  if (typeof publishResetEvent === 'function') {
+    try {
+      await publishResetEvent();
+    } catch (error) {
+      logWarn('Failed to publish reset event:', error);
+    }
+  }
+
+  if (typeof updateResetState === 'function') {
+    try {
+      await updateResetState();
+    } catch (error) {
+      logError('Error updating game reset state:', error);
+    }
+  }
+
+  if (typeof cleanupPersistedState === 'function') {
+    try {
+      await cleanupPersistedState();
+    } catch (error) {
+      logWarn('Failed to clear persisted tracking records during reset:', error);
+    }
+  }
+}

--- a/tests/unit/live-game-state.test.js
+++ b/tests/unit/live-game-state.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveOpponentDisplayName, normalizeLiveStatColumns, applyResetEventState, shouldResetViewerFromGameDoc } from '../../js/live-game-state.js';
+import { resolveOpponentDisplayName, normalizeLiveStatColumns, applyResetEventState, shouldResetViewerFromGameDoc, isLiveEventVisibleForResetBoundary } from '../../js/live-game-state.js';
 
 describe('live game state helpers', () => {
   it('prefers linked opponent team name when opponent is missing', () => {
@@ -70,5 +70,24 @@ describe('live game state helpers', () => {
       { events: [], stats: {}, opponentStats: {}, homeScore: 0, awayScore: 0 }
     );
     expect(shouldReset).toBe(false);
+  });
+
+  it('filters non-reset events older than the live reset boundary', () => {
+    const oldEvent = {
+      type: 'stat',
+      createdAt: { toMillis: () => 1000 }
+    };
+    const newEvent = {
+      type: 'stat',
+      createdAt: { toMillis: () => 3000 }
+    };
+
+    expect(isLiveEventVisibleForResetBoundary(oldEvent, 2000)).toBe(false);
+    expect(isLiveEventVisibleForResetBoundary(newEvent, 2000)).toBe(true);
+  });
+
+  it('always keeps reset events and unknown timestamps', () => {
+    expect(isLiveEventVisibleForResetBoundary({ type: 'reset', createdAt: { toMillis: () => 1000 } }, 2000)).toBe(true);
+    expect(isLiveEventVisibleForResetBoundary({ type: 'stat' }, 2000)).toBe(true);
   });
 });

--- a/tests/unit/live-game-state.test.js
+++ b/tests/unit/live-game-state.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveOpponentDisplayName, normalizeLiveStatColumns, applyResetEventState } from '../../js/live-game-state.js';
+import { resolveOpponentDisplayName, normalizeLiveStatColumns, applyResetEventState, shouldResetViewerFromGameDoc } from '../../js/live-game-state.js';
 
 describe('live game state helpers', () => {
   it('prefers linked opponent team name when opponent is missing', () => {
@@ -54,5 +54,21 @@ describe('live game state helpers', () => {
 
     expect(Array.from(current.eventIds)).toEqual(['e1']);
     expect(Array.from(next.eventIds)).toEqual(['e1', 'e2']);
+  });
+
+  it('detects scheduled reset from game doc when tracked state exists', () => {
+    const shouldReset = shouldResetViewerFromGameDoc(
+      { liveStatus: 'scheduled', liveHasData: false, homeScore: 0, awayScore: 0 },
+      { events: [{ id: 'e1' }], stats: {}, opponentStats: {}, homeScore: 2, awayScore: 0 }
+    );
+    expect(shouldReset).toBe(true);
+  });
+
+  it('does not force reset from game doc when no tracked state exists', () => {
+    const shouldReset = shouldResetViewerFromGameDoc(
+      { liveStatus: 'scheduled', liveHasData: false, homeScore: 0, awayScore: 0 },
+      { events: [], stats: {}, opponentStats: {}, homeScore: 0, awayScore: 0 }
+    );
+    expect(shouldReset).toBe(false);
   });
 });

--- a/tests/unit/live-game-state.test.js
+++ b/tests/unit/live-game-state.test.js
@@ -37,10 +37,22 @@ describe('live game state helpers', () => {
     expect(next.awayScore).toBe(0);
     expect(next.gameClockMs).toBe(0);
     expect(next.events).toEqual([]);
-    expect(Array.from(next.eventIds)).toEqual([]);
+    expect(Array.from(next.eventIds)).toEqual(['e1']);
     expect(next.stats).toEqual({});
     expect(next.opponentStats).toEqual({});
     expect(next.onCourt).toEqual([]);
     expect(next.bench).toEqual(['p1', 'p2']);
+  });
+
+  it('clones prior event ids during reset to avoid mutating source state', () => {
+    const current = {
+      eventIds: new Set(['e1'])
+    };
+
+    const next = applyResetEventState(current, { homeScore: 0, awayScore: 0 });
+    next.eventIds.add('e2');
+
+    expect(Array.from(current.eventIds)).toEqual(['e1']);
+    expect(Array.from(next.eventIds)).toEqual(['e1', 'e2']);
   });
 });

--- a/tests/unit/track-live-reset-persistence.test.js
+++ b/tests/unit/track-live-reset-persistence.test.js
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runTrackLiveResetPersistence } from '../../js/track-live-state.js';
+
+describe('track live reset persistence orchestration', () => {
+  it('runs publish, update, then cleanup in order', async () => {
+    const calls = [];
+
+    await runTrackLiveResetPersistence({
+      publishResetEvent: async () => { calls.push('publish'); },
+      updateResetState: async () => { calls.push('update'); },
+      cleanupPersistedState: async () => { calls.push('cleanup'); }
+    });
+
+    expect(calls).toEqual(['publish', 'update', 'cleanup']);
+  });
+
+  it('continues when publishing reset event fails', async () => {
+    const calls = [];
+    const logWarn = vi.fn();
+
+    await runTrackLiveResetPersistence({
+      publishResetEvent: async () => {
+        calls.push('publish');
+        throw new Error('permission denied');
+      },
+      updateResetState: async () => { calls.push('update'); },
+      cleanupPersistedState: async () => { calls.push('cleanup'); },
+      logWarn
+    });
+
+    expect(calls).toEqual(['publish', 'update', 'cleanup']);
+    expect(logWarn).toHaveBeenCalledWith('Failed to publish reset event:', expect.any(Error));
+  });
+
+  it('continues cleanup when reset state update fails', async () => {
+    const calls = [];
+    const logError = vi.fn();
+
+    await runTrackLiveResetPersistence({
+      publishResetEvent: async () => { calls.push('publish'); },
+      updateResetState: async () => {
+        calls.push('update');
+        throw new Error('missing permissions');
+      },
+      cleanupPersistedState: async () => { calls.push('cleanup'); },
+      logError
+    });
+
+    expect(calls).toEqual(['publish', 'update', 'cleanup']);
+    expect(logError).toHaveBeenCalledWith('Error updating game reset state:', expect.any(Error));
+  });
+
+  it('logs cleanup failures without throwing', async () => {
+    const logWarn = vi.fn();
+
+    await expect(runTrackLiveResetPersistence({
+      publishResetEvent: async () => {},
+      updateResetState: async () => {},
+      cleanupPersistedState: async () => {
+        throw new Error('delete blocked');
+      },
+      logWarn
+    })).resolves.toBeUndefined();
+
+    expect(logWarn).toHaveBeenCalledWith('Failed to clear persisted tracking records during reset:', expect.any(Error));
+  });
+
+  it('is safe when callbacks are omitted', async () => {
+    await expect(runTrackLiveResetPersistence()).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/track-live-state.test.js
+++ b/tests/unit/track-live-state.test.js
@@ -43,7 +43,8 @@ describe('track live state helpers', () => {
       liveLineup: {
         onCourt: ['p1'],
         bench: ['p2', 'p3']
-      }
+      },
+      liveResetAt: 1700000000000
     });
 
     expect(payload).toEqual({
@@ -54,6 +55,7 @@ describe('track live state helpers', () => {
       opponentStats: {},
       liveStatus: 'scheduled',
       liveHasData: false,
+      liveResetAt: 1700000000000,
       opponent: 'Lions',
       opponentTeamId: 'opp-team-1',
       opponentTeamName: 'Lions Academy',
@@ -75,6 +77,7 @@ describe('track live state helpers', () => {
     expect(payload.opponentTeamId).toBe('');
     expect(payload.opponentTeamName).toBe('');
     expect(payload.opponentTeamPhoto).toBe('');
+    expect(payload.liveResetAt).toEqual(expect.any(Number));
     expect(payload.liveLineup).toEqual({ onCourt: ['p1'], bench: ['p2'] });
 
     input.onCourt.push('p3');

--- a/tests/unit/track-live-state.test.js
+++ b/tests/unit/track-live-state.test.js
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { summarizePersistedTrackingState, buildTrackLiveResetUpdate } from '../../js/track-live-state.js';
+
+describe('track live state helpers', () => {
+  it('summarizes when persisted data exists', () => {
+    const result = summarizePersistedTrackingState({
+      eventsCount: 2,
+      statsCount: 5,
+      liveEventsCount: 3,
+      hasScores: true,
+      hasOpponentStats: true,
+      hasLiveFlag: true
+    });
+
+    expect(result.hasPersistedData).toBe(true);
+    expect(result.parts).toEqual([
+      '2 event(s)',
+      '5 player stat record(s)',
+      '3 live event(s)',
+      'saved score',
+      'opponent stats',
+      'live status'
+    ]);
+  });
+
+  it('returns no persisted data for empty inputs', () => {
+    const result = summarizePersistedTrackingState({});
+
+    expect(result.hasPersistedData).toBe(false);
+    expect(result.summary).toBe('tracked data');
+    expect(result.parts).toEqual([]);
+  });
+
+  it('builds reset update payload with preserved opponent identity fields', () => {
+    const payload = buildTrackLiveResetUpdate({
+      currentGame: {
+        opponent: 'Lions',
+        opponentTeamId: 'opp-team-1',
+        opponentTeamName: 'Lions Academy',
+        opponentTeamPhoto: 'https://example.com/lions.png'
+      },
+      period: 'H2',
+      liveLineup: {
+        onCourt: ['p1'],
+        bench: ['p2', 'p3']
+      }
+    });
+
+    expect(payload).toEqual({
+      homeScore: 0,
+      awayScore: 0,
+      period: 'H2',
+      liveLineup: { onCourt: ['p1'], bench: ['p2', 'p3'] },
+      opponentStats: {},
+      liveStatus: 'scheduled',
+      liveHasData: false,
+      opponent: 'Lions',
+      opponentTeamId: 'opp-team-1',
+      opponentTeamName: 'Lions Academy',
+      opponentTeamPhoto: 'https://example.com/lions.png'
+    });
+  });
+
+  it('normalizes reset payload defaults and clones lineup arrays', () => {
+    const input = {
+      onCourt: ['p1'],
+      bench: ['p2']
+    };
+    const payload = buildTrackLiveResetUpdate({
+      currentGame: {},
+      liveLineup: input
+    });
+
+    expect(payload.period).toBe('Q1');
+    expect(payload.opponentTeamId).toBe('');
+    expect(payload.opponentTeamName).toBe('');
+    expect(payload.opponentTeamPhoto).toBe('');
+    expect(payload.liveLineup).toEqual({ onCourt: ['p1'], bench: ['p2'] });
+
+    input.onCourt.push('p3');
+    expect(payload.liveLineup.onCourt).toEqual(['p1']);
+  });
+});

--- a/track-live.html
+++ b/track-live.html
@@ -1556,6 +1556,25 @@
                     el.textContent = '0';
                 });
 
+                // Apply local reset immediately so UI always clears even if network writes stall/fail.
+                liveState.isLive = false;
+                liveState.lastClockSyncAt = 0;
+                if (currentGame) {
+                    currentGame.liveStatus = 'scheduled';
+                    currentGame.liveHasData = false;
+                    currentGame.homeScore = 0;
+                    currentGame.awayScore = 0;
+                    currentGame.opponentStats = {};
+                }
+                updateScoreDisplay();
+                renderGameLog();
+                renderStatsTable();
+                renderOpponentTable();
+                document.getElementById('liveBadge').classList.add('hidden');
+                document.getElementById('shareLiveBtn').classList.add('hidden');
+                document.getElementById('shareLiveShareBtn').classList.add('hidden');
+                updateTimer();
+
                 // Clear aggregated stats in Firebase
                 try {
                     const eventsSnapshot = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
@@ -1588,26 +1607,9 @@
                         opponentStats: gameState.opponentStats
                     });
                     await setGameLiveStatus(currentTeamId, currentGameId, 'scheduled').catch(console.warn);
-                    if (currentGame) {
-                        currentGame.liveStatus = 'scheduled';
-                        currentGame.liveHasData = false;
-                        currentGame.homeScore = 0;
-                        currentGame.awayScore = 0;
-                        currentGame.opponentStats = {};
-                    }
                 } catch (error) {
                     console.error('Error clearing stats:', error);
                 }
-
-                updateScoreDisplay();
-                renderGameLog();
-                renderStatsTable();
-                renderOpponentTable();
-                document.getElementById('liveBadge').classList.add('hidden');
-                document.getElementById('shareLiveBtn').classList.add('hidden');
-                document.getElementById('shareLiveShareBtn').classList.add('hidden');
-                liveState.isLive = false;
-                updateTimer();
             }
         }
 

--- a/track-live.html
+++ b/track-live.html
@@ -494,7 +494,7 @@
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { resolveOpponentDisplayName } from './js/live-game-state.js?v=1';
         import { createFieldState, setPlayerFieldStatus, startFieldClock, pauseFieldClock, getPlayerFieldElapsedMs, getLiveLineup } from './js/live-tracker-field-status.js?v=1';
-        import { summarizePersistedTrackingState, buildTrackLiveResetUpdate } from './js/track-live-state.js?v=1';
+        import { summarizePersistedTrackingState, buildTrackLiveResetUpdate, runTrackLiveResetPersistence } from './js/track-live-state.js?v=1';
         import { checkAuth } from './js/auth.js?v=9';
         import { getApp } from './js/vendor/firebase-app.js';
         import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './js/live-tracker-notes.js?v=1';
@@ -1406,16 +1406,6 @@
                         const shouldResume = confirm('This game already has tracked data. Continue where you left off?\n\nClick Cancel to start over and clear previous stats.');
                         if (!shouldResume) {
                             clearLiveSyncTimeouts();
-                            const deletions = [
-                                ...eventsSnap.docs.map(docItem => deleteDoc(docItem.ref)),
-                                ...statsSnap.docs.map(docItem => deleteDoc(docItem.ref)),
-                                ...liveEventsSnap.docs.map(docItem => deleteDoc(docItem.ref))
-                            ];
-                            const results = await Promise.allSettled(deletions);
-                            const failedDeletes = results.filter((result) => result.status === 'rejected');
-                            if (failedDeletes.length) {
-                                console.warn('Some persisted tracking records could not be deleted:', failedDeletes);
-                            }
 
                             gameState.playerStats = {};
                             gameState.gameLog = [];
@@ -1435,35 +1425,48 @@
                             });
 
                             const resetLineup = getLiveLineup(gameState.playerFieldStatus, players);
-                            await broadcastLiveEvent(currentTeamId, currentGameId, {
-                                type: 'reset',
-                                period: gameState.currentPeriod,
-                                gameClockMs: 0,
-                                homeScore: 0,
-                                awayScore: 0,
-                                onCourt: resetLineup.onCourt,
-                                bench: resetLineup.bench,
-                                description: `Tracker restarted from zero. Cleared: ${persistedState.summary}.`,
-                                createdBy: currentUser?.uid || null
-                            }).catch(console.warn);
-                            try {
-                                await updateGame(
-                                    currentTeamId,
-                                    currentGameId,
-                                    buildTrackLiveResetUpdate({
-                                        currentGame,
-                                        period: gameState.currentPeriod,
-                                        liveLineup: resetLineup
-                                    })
-                                );
-                                currentGame.liveStatus = 'scheduled';
-                                currentGame.liveHasData = false;
-                                currentGame.homeScore = 0;
-                                currentGame.awayScore = 0;
-                                currentGame.opponentStats = {};
-                            } catch (error) {
-                                console.warn('Failed to reset game metadata:', error);
-                            }
+                            await runTrackLiveResetPersistence({
+                                publishResetEvent: () => broadcastLiveEvent(currentTeamId, currentGameId, {
+                                    type: 'reset',
+                                    period: gameState.currentPeriod,
+                                    gameClockMs: 0,
+                                    homeScore: 0,
+                                    awayScore: 0,
+                                    onCourt: resetLineup.onCourt,
+                                    bench: resetLineup.bench,
+                                    description: `Tracker restarted from zero. Cleared: ${persistedState.summary}.`,
+                                    createdBy: currentUser?.uid || null
+                                }),
+                                updateResetState: async () => {
+                                    await updateGame(
+                                        currentTeamId,
+                                        currentGameId,
+                                        buildTrackLiveResetUpdate({
+                                            currentGame,
+                                            period: gameState.currentPeriod,
+                                            liveLineup: resetLineup
+                                        })
+                                    );
+                                    currentGame.liveStatus = 'scheduled';
+                                    currentGame.liveHasData = false;
+                                    currentGame.homeScore = 0;
+                                    currentGame.awayScore = 0;
+                                    currentGame.opponentStats = {};
+                                },
+                                cleanupPersistedState: async () => {
+                                    const deletions = [
+                                        ...eventsSnap.docs.map(docItem => deleteDoc(docItem.ref)),
+                                        ...statsSnap.docs.map(docItem => deleteDoc(docItem.ref))
+                                    ];
+                                    const results = await Promise.allSettled(deletions);
+                                    const failedDeletes = results.filter((result) => result.status === 'rejected');
+                                    if (failedDeletes.length) {
+                                        console.warn('Some persisted tracking records could not be deleted:', failedDeletes);
+                                    }
+                                },
+                                logWarn: (...args) => console.warn(...args),
+                                logError: (message, error) => console.warn(message, error)
+                            });
 
                             updateScoreDisplay();
                             renderGameLog();
@@ -1531,6 +1534,7 @@
                 gameState.startTime = null;
                 gameState.elapsed = 0;
                 gameState.isRunning = false;
+                gameState.currentPeriod = (currentConfig?.periods?.[0]?.label) || 'Q1';
                 liveState.lastClockSyncAt = 0;
                 gameState.gameLog = [];
                 gameState.playerStats = {}; // Clear in-memory player stats
@@ -1551,6 +1555,12 @@
 
                 document.getElementById('startBtn').disabled = false;
                 document.getElementById('stopBtn').disabled = true;
+
+                document.querySelectorAll('.period-btn').forEach((button) => {
+                    const isActive = button.dataset.period === gameState.currentPeriod;
+                    button.classList.toggle('period-active', isActive);
+                    button.classList.toggle('period-inactive', !isActive);
+                });
 
                 document.querySelectorAll('[id^="stat-"]').forEach(el => {
                     el.textContent = '0';
@@ -1575,19 +1585,9 @@
                 document.getElementById('shareLiveShareBtn').classList.add('hidden');
                 updateTimer();
 
-                // Clear aggregated stats in Firebase
-                try {
-                    const eventsSnapshot = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
-                    await Promise.all(eventsSnapshot.docs.map(eventDoc => deleteDoc(eventDoc.ref)));
-
-                    const statsSnapshot = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`));
-                    await Promise.all(statsSnapshot.docs.map(doc => deleteDoc(doc.ref)));
-
-                    const liveEventsSnapshot = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));
-                    await Promise.all(liveEventsSnapshot.docs.map(liveDoc => deleteDoc(liveDoc.ref)));
-
-                    const liveLineup = getLiveLineup(gameState.playerFieldStatus, players);
-                    await broadcastLiveEvent(currentTeamId, currentGameId, {
+                const liveLineup = getLiveLineup(gameState.playerFieldStatus, players);
+                await runTrackLiveResetPersistence({
+                    publishResetEvent: () => broadcastLiveEvent(currentTeamId, currentGameId, {
                         type: 'reset',
                         period: gameState.currentPeriod,
                         gameClockMs: 0,
@@ -1597,19 +1597,35 @@
                         bench: liveLineup.bench,
                         description: 'Game reset',
                         createdBy: currentUser?.uid || null
-                    }).catch(console.warn);
-                    await updateGame(currentTeamId, currentGameId, {
-                        ...buildTrackLiveResetUpdate({
-                            currentGame,
-                            period: gameState.currentPeriod,
-                            liveLineup
-                        }),
-                        opponentStats: gameState.opponentStats
-                    });
-                    await setGameLiveStatus(currentTeamId, currentGameId, 'scheduled').catch(console.warn);
-                } catch (error) {
-                    console.error('Error clearing stats:', error);
-                }
+                    }),
+                    updateResetState: async () => {
+                        await updateGame(currentTeamId, currentGameId, {
+                            ...buildTrackLiveResetUpdate({
+                                currentGame,
+                                period: gameState.currentPeriod,
+                                liveLineup
+                            }),
+                            opponentStats: gameState.opponentStats
+                        });
+                        await setGameLiveStatus(currentTeamId, currentGameId, 'scheduled').catch(console.warn);
+                    },
+                    cleanupPersistedState: async () => {
+                        const [eventsSnapshot, statsSnapshot] = await Promise.all([
+                            getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`)),
+                            getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`))
+                        ]);
+                        const cleanupResults = await Promise.allSettled([
+                            ...eventsSnapshot.docs.map(eventDoc => deleteDoc(eventDoc.ref)),
+                            ...statsSnapshot.docs.map(doc => deleteDoc(doc.ref))
+                        ]);
+                        const failedDeletes = cleanupResults.filter((result) => result.status === 'rejected');
+                        if (failedDeletes.length) {
+                            console.warn('Some persisted tracking records could not be deleted during reset:', failedDeletes);
+                        }
+                    },
+                    logWarn: (...args) => console.warn(...args),
+                    logError: (...args) => console.error(...args)
+                });
             }
         }
 
@@ -1620,7 +1636,6 @@
             }
 
             try {
-                clearLiveSyncTimeouts();
                 // Delete all events
                 const eventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
                 const deleteEventPromises = eventsSnap.docs.map(doc => deleteDoc(doc.ref));
@@ -1631,31 +1646,18 @@
                 const deleteStatsPromises = statsSnap.docs.map(doc => deleteDoc(doc.ref));
                 await Promise.all(deleteStatsPromises);
 
-                // Delete all live events
-                const liveEventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));
-                const deleteLiveEventPromises = liveEventsSnap.docs.map(doc => deleteDoc(doc.ref));
-                await Promise.all(deleteLiveEventPromises);
-
-                // Reset game status/flags after deleting tracked records
-                await updateGame(currentTeamId, currentGameId, {
-                    status: 'scheduled',
-                    liveStatus: 'scheduled',
-                    homeScore: 0,
-                    awayScore: 0,
-                    opponentStats: {},
-                    liveHasData: false,
-                    // Preserve opponent fields
-                    opponent: currentGame.opponent,
-                    opponentTeamId: currentGame.opponentTeamId,
-                    opponentTeamName: currentGame.opponentTeamName,
-                    opponentTeamPhoto: currentGame.opponentTeamPhoto
-                });
-                if (currentGame) {
-                    currentGame.liveHasData = false;
-                    currentGame.liveStatus = 'scheduled';
-                    currentGame.homeScore = 0;
-                    currentGame.awayScore = 0;
-                    currentGame.opponentStats = {};
+                // Reset game status to scheduled if it was started
+                if (currentGame.status !== 'scheduled') {
+                    await updateGame(currentTeamId, currentGameId, {
+                        status: 'scheduled',
+                        homeScore: 0,
+                        awayScore: 0,
+                        // Preserve opponent fields
+                        opponent: currentGame.opponent,
+                        opponentTeamId: currentGame.opponentTeamId,
+                        opponentTeamName: currentGame.opponentTeamName,
+                        opponentTeamPhoto: currentGame.opponentTeamPhoto
+                    });
                 }
                 liveState.isLive = false;
                 liveState.lastClockSyncAt = 0;

--- a/track-live.html
+++ b/track-live.html
@@ -1569,11 +1569,15 @@
                         homeScore: 0,
                         awayScore: 0,
                         period: gameState.currentPeriod,
+                        liveStatus: 'scheduled',
                         liveLineup,
                         liveHasData: false,
                         opponentStats: gameState.opponentStats
                     });
-                    if (currentGame) currentGame.liveHasData = false;
+                    if (currentGame) {
+                        currentGame.liveHasData = false;
+                        currentGame.liveStatus = 'scheduled';
+                    }
                     await setGameLiveStatus(currentTeamId, currentGameId, 'scheduled').catch(console.warn);
                     await broadcastLiveEvent(currentTeamId, currentGameId, {
                         type: 'reset',
@@ -1620,21 +1624,32 @@
                 const deleteStatsPromises = statsSnap.docs.map(doc => deleteDoc(doc.ref));
                 await Promise.all(deleteStatsPromises);
 
-                // Reset game status/flags when needed after deleting tracked records
-                if (currentGame.status !== 'scheduled' || currentGame.liveHasData) {
-                    await updateGame(currentTeamId, currentGameId, {
-                        status: 'scheduled',
-                        homeScore: 0,
-                        awayScore: 0,
-                        liveHasData: false,
-                        // Preserve opponent fields
-                        opponent: currentGame.opponent,
-                        opponentTeamId: currentGame.opponentTeamId,
-                        opponentTeamName: currentGame.opponentTeamName,
-                        opponentTeamPhoto: currentGame.opponentTeamPhoto
-                    });
+                // Delete all live events
+                const liveEventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`));
+                const deleteLiveEventPromises = liveEventsSnap.docs.map(doc => deleteDoc(doc.ref));
+                await Promise.all(deleteLiveEventPromises);
+
+                // Reset game status/flags after deleting tracked records
+                await updateGame(currentTeamId, currentGameId, {
+                    status: 'scheduled',
+                    liveStatus: 'scheduled',
+                    homeScore: 0,
+                    awayScore: 0,
+                    opponentStats: {},
+                    liveHasData: false,
+                    // Preserve opponent fields
+                    opponent: currentGame.opponent,
+                    opponentTeamId: currentGame.opponentTeamId,
+                    opponentTeamName: currentGame.opponentTeamName,
+                    opponentTeamPhoto: currentGame.opponentTeamPhoto
+                });
+                if (currentGame) {
+                    currentGame.liveHasData = false;
+                    currentGame.liveStatus = 'scheduled';
+                    currentGame.homeScore = 0;
+                    currentGame.awayScore = 0;
+                    currentGame.opponentStats = {};
                 }
-                if (currentGame) currentGame.liveHasData = false;
                 liveState.isLive = false;
                 liveState.lastClockSyncAt = 0;
 

--- a/track-live.html
+++ b/track-live.html
@@ -13,7 +13,7 @@
   </script>
 
     <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
   <meta name="robots" content="noindex,nofollow">
     <link rel="icon" type="image/png" href="img/logo_small.png">
     <title>Live Track Game - ALL PLAYS</title>
@@ -23,32 +23,116 @@
             theme: {
                 extend: {
                     colors: {
-                        primary: {
-                            50: '#eef2ff',
-                            100: '#e0e7ff',
-                            500: '#6366f1',
-                            600: '#4f46e5',
-                            700: '#4338ca',
-                            800: '#3730a3',
-                            900: '#312e81'
-                        }
+                        ink: '#0b132b',
+                        slate: '#1c2541',
+                        teal: '#5bc0be',
+                        coral: '#ff6b6b',
+                        gold: '#ffd93d',
+                        sand: '#f7f5ed'
+                    },
+                    fontFamily: {
+                        display: ['"Space Grotesk"', 'ui-sans-serif'],
+                        body: ['"Inter Tight"', 'ui-sans-serif']
                     }
                 }
             }
         }
     </script>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&family=Inter+Tight:wght@400;500;600&display=swap" rel="stylesheet">
     <style>
+        :root {
+            --ink: #0b132b;
+            --slate: #1c2541;
+            --teal: #5bc0be;
+            --coral: #ff6b6b;
+            --gold: #ffd93d;
+            --sand: #f7f5ed;
+        }
+
         body {
-            font-family: 'Montserrat', 'Roboto', sans-serif;
+            font-family: 'Inter Tight', ui-sans-serif;
             background:
-                radial-gradient(circle at 10% 10%, rgba(56, 189, 248, 0.14), transparent 35%),
-                radial-gradient(circle at 90% 0%, rgba(16, 185, 129, 0.10), transparent 32%),
-                #eef3f8;
+                radial-gradient(circle at 20% 20%, rgba(91, 192, 190, 0.14), transparent 40%),
+                radial-gradient(circle at 80% 0%, rgba(255, 217, 61, 0.10), transparent 35%),
+                var(--ink);
             font-size: 14px;
+            color: var(--sand);
+        }
+
+        #header-container header {
+            background: rgba(11, 19, 43, 0.95);
+            border-bottom: 1px solid rgba(91, 192, 190, 0.2);
+        }
+
+        #header-container a,
+        #header-container button,
+        #header-container p,
+        #header-container span,
+        #header-container h1,
+        #header-container h2 {
+            color: var(--sand);
+        }
+
+        #header-container a:hover,
+        #header-container button:hover {
+            color: var(--teal);
+        }
+
+        #footer-container footer {
+            background: #0f1b35;
+            color: rgba(247, 245, 237, 0.7);
+        }
+
+        #footer-container h4 {
+            color: var(--sand);
+        }
+
+        #footer-container a {
+            color: rgba(247, 245, 237, 0.7);
+        }
+
+        #footer-container a:hover {
+            color: var(--teal);
         }
 
         .stat-btn {
             touch-action: manipulation;
+        }
+
+        .track-panel {
+            background: linear-gradient(165deg, rgba(28, 37, 65, 0.74), rgba(11, 19, 43, 0.78));
+            border: 1px solid rgba(91, 192, 190, 0.22);
+            border-radius: 12px;
+            box-shadow: 0 12px 28px rgba(0, 0, 0, 0.28);
+        }
+
+        .track-panel-title {
+            background: rgba(11, 19, 43, 0.85);
+            border-bottom: 1px solid rgba(91, 192, 190, 0.24);
+            color: var(--teal);
+        }
+
+        .track-panel-title.away {
+            color: var(--coral);
+        }
+
+        .period-btn {
+            transition: background-color 0.18s ease, color 0.18s ease, border-color 0.18s ease;
+        }
+
+        .period-active {
+            background: var(--teal);
+            color: var(--ink);
+            border: 1px solid var(--teal);
+            font-weight: 700;
+        }
+
+        .period-inactive {
+            background: rgba(28, 37, 65, 0.9);
+            color: rgba(247, 245, 237, 0.72);
+            border: 1px solid rgba(91, 192, 190, 0.2);
         }
 
         .stat-cell {
@@ -84,52 +168,119 @@
             flex: 1;
             min-width: 0;
             padding: 3px;
-            border: 1px solid #d1d5db;
+            border: 1px solid rgba(91, 192, 190, 0.3);
             border-radius: 3px;
             font-size: 9px;
+            background: rgba(11, 19, 43, 0.55);
+            color: var(--sand);
         }
 
         .notes-btn {
             width: 30px;
             height: 24px;
             padding: 2px 4px;
-            background: #2563eb;
-            color: white;
+            background: var(--teal);
+            color: var(--ink);
             border: none;
             border-radius: 3px;
             font-size: 8px;
             cursor: pointer;
             flex-shrink: 0;
+            font-weight: 700;
         }
 
         .notes-btn:hover {
-            background: #1d4ed8;
+            background: #7bd3d1;
+        }
+
+        #statsTable,
+        #opponentTable {
+            color: rgba(247, 245, 237, 0.95);
+        }
+
+        #statsTable thead tr,
+        #opponentTable thead tr {
+            background: rgba(247, 245, 237, 0.08);
+            border-bottom-color: rgba(91, 192, 190, 0.3);
+        }
+
+        #statsTable tbody tr,
+        #opponentTable tbody tr {
+            border-bottom-color: rgba(91, 192, 190, 0.18);
+        }
+
+        #statsTable tbody tr:hover,
+        #opponentTable tbody tr:hover {
+            background: rgba(11, 19, 43, 0.35);
+        }
+
+        #gameLog .undo-log-btn {
+            background: var(--coral);
+        }
+
+        #gameLog .undo-log-btn:hover {
+            background: #ff8888;
+        }
+
+        #finish-modal > div {
+            background: linear-gradient(180deg, rgba(28, 37, 65, 0.96), rgba(11, 19, 43, 0.98));
+            border: 1px solid rgba(91, 192, 190, 0.24);
+            color: var(--sand);
+        }
+
+        #finish-modal label {
+            color: rgba(247, 245, 237, 0.9);
+        }
+
+        #finish-modal input,
+        #finish-modal textarea {
+            background: rgba(11, 19, 43, 0.6);
+            border-color: rgba(91, 192, 190, 0.28);
+            color: var(--sand);
+        }
+
+        #emailPreviewSection {
+            border-top-color: rgba(91, 192, 190, 0.22);
+        }
+
+        #emailPreviewSection > div {
+            background: rgba(11, 19, 43, 0.52);
+            border: 1px solid rgba(91, 192, 190, 0.18);
+        }
+
+        #emailPreview {
+            color: rgba(247, 245, 237, 0.85);
         }
     </style>
 </head>
 
-<body class="bg-transparent text-gray-900">
+<body class="bg-ink text-sand min-h-screen font-body">
     <div id="header-container"></div>
 
     <div class="p-2">
         <!-- Game Tracking Header -->
-        <div class="bg-slate-900 text-white p-3 rounded-lg mb-3 shadow-lg border border-sky-400/30">
+        <div class="track-panel p-3 mb-3">
             <div class="flex justify-between items-center mb-2">
                 <div>
                     <div class="flex items-center gap-2 mb-1">
-                        <h1 class="font-bold text-lg" id="game-title">Loading...</h1>
+                        <h1 class="font-display font-bold text-lg text-teal" id="game-title">Loading...</h1>
                         <span id="liveBadge" class="hidden inline-flex items-center gap-1 bg-red-500 text-white text-[10px] font-bold px-2 py-0.5 rounded-full">
                             <span class="w-1.5 h-1.5 bg-white rounded-full animate-pulse"></span>
                             LIVE
                         </span>
                     </div>
-                    <div class="text-sm opacity-90" id="game-meta"></div>
-                    <button id="shareLiveBtn" class="hidden mt-1 text-xs bg-white/20 hover:bg-white/30 text-white px-2 py-1 rounded transition">
-                        📋 Copy Live Link
-                    </button>
+                    <div class="text-sm text-sand/70" id="game-meta"></div>
+                    <div class="mt-1 flex flex-wrap gap-1">
+                        <button id="shareLiveShareBtn" class="hidden text-xs bg-teal text-ink px-2 py-1 rounded font-semibold hover:bg-teal/80 transition">
+                            🔗 Share
+                        </button>
+                        <button id="shareLiveBtn" class="hidden text-xs bg-slate border border-teal/30 hover:bg-ink text-sand px-2 py-1 rounded transition">
+                            📋 Copy Live Link
+                        </button>
+                    </div>
                 </div>
                 <div class="text-right">
-                    <div class="text-3xl font-mono font-bold mb-1">
+                    <div class="text-3xl font-display font-bold mb-1">
                         <span id="home-score">0</span> - <span id="away-score">0</span>
                     </div>
                 </div>
@@ -142,40 +293,40 @@
             <!-- Period Selector -->
             <div class="flex justify-center gap-1 mb-2">
                 <button
-                    class="period-btn bg-white text-blue-600 border-2 border-blue-600 px-3 py-1 rounded text-xs font-bold"
+                    class="period-btn period-active px-3 py-1 rounded text-xs"
                     data-period="Q1">Q1</button>
-                <button class="period-btn bg-white text-gray-600 border border-gray-300 px-3 py-1 rounded text-xs"
+                <button class="period-btn period-inactive px-3 py-1 rounded text-xs"
                     data-period="Q2">Q2</button>
-                <button class="period-btn bg-white text-gray-600 border border-gray-300 px-3 py-1 rounded text-xs"
+                <button class="period-btn period-inactive px-3 py-1 rounded text-xs"
                     data-period="Q3">Q3</button>
-                <button class="period-btn bg-white text-gray-600 border border-gray-300 px-3 py-1 rounded text-xs"
+                <button class="period-btn period-inactive px-3 py-1 rounded text-xs"
                     data-period="Q4">Q4</button>
-                <button class="period-btn bg-white text-gray-600 border border-gray-300 px-3 py-1 rounded text-xs"
+                <button class="period-btn period-inactive px-3 py-1 rounded text-xs"
                     data-period="OT">OT</button>
             </div>
 
             <div class="flex justify-center gap-2 flex-wrap">
                 <button id="startBtn"
-                    class="bg-white text-blue-600 px-3 py-1 rounded font-semibold text-sm">Start</button>
-                <button id="stopBtn" class="bg-red-600 text-white px-3 py-1 rounded text-sm" disabled>Stop</button>
-                <button id="resetBtn" class="bg-gray-700 text-white px-3 py-1 rounded text-sm">Reset</button>
-                <button id="undoLastBtn" class="bg-yellow-600 text-white px-3 py-1 rounded text-sm font-bold">↶ Undo
+                    class="bg-teal text-ink px-3 py-1 rounded font-semibold text-sm">Start</button>
+                <button id="stopBtn" class="bg-coral text-white px-3 py-1 rounded text-sm" disabled>Stop</button>
+                <button id="resetBtn" class="bg-slate text-sand px-3 py-1 rounded text-sm border border-teal/20">Reset</button>
+                <button id="undoLastBtn" class="bg-gold text-ink px-3 py-1 rounded text-sm font-bold">↶ Undo
                     Last</button>
-                <button id="cancelBtn" class="bg-orange-600 text-white px-3 py-1 rounded text-sm font-bold">Cancel
+                <button id="cancelBtn" class="bg-coral/90 text-white px-3 py-1 rounded text-sm font-bold">Cancel
                     Game</button>
                 <!-- Email button removed -->
                 <button id="finish-btn"
-                    class="bg-green-600 text-white px-3 py-1 rounded text-sm font-bold">Finish</button>
+                    class="bg-teal text-ink px-3 py-1 rounded text-sm font-bold">Finish</button>
             </div>
         </div>
 
         <!-- Team Stats Table -->
-        <div class="bg-white rounded-lg shadow-md overflow-hidden border-2 border-slate-800 mb-3">
-            <div class="bg-slate-800 text-white p-3 font-bold text-center">Team Stats</div>
+        <div class="track-panel overflow-hidden mb-3">
+            <div class="track-panel-title p-3 font-bold text-center">Team Stats</div>
             <div class="overflow-x-auto">
                 <table class="w-full text-center text-xs" id="statsTable">
                     <thead>
-                        <tr class="bg-gray-100 border-b-2 border-slate-800">
+                        <tr class="bg-slate/60 border-b-2 border-teal/40">
                             <th class="player-name text-left p-1">Player</th>
                             <!-- Column headers will be injected -->
                         </tr>
@@ -188,17 +339,18 @@
         </div>
 
         <!-- Opponent Stats Table -->
-        <div class="bg-white rounded-lg shadow-md overflow-hidden border-2 border-red-600 mb-3">
-            <div class="bg-red-600 text-white p-3 font-bold text-center flex justify-between items-center">
+        <div class="track-panel overflow-hidden mb-3">
+            <div class="track-panel-title away p-3 font-bold text-center flex justify-between items-center">
                 <span>Opponent Stats</span>
-                <button id="addOpponentBtn" class="bg-red-700 text-white px-2 py-1 rounded text-xs hover:bg-red-800">Add
+                <button id="addOpponentBtn" class="bg-coral text-white px-2 py-1 rounded text-xs hover:bg-coral/80">Add
                     Player</button>
             </div>
             <div class="overflow-x-auto">
                 <table class="w-full text-center text-xs" id="opponentTable">
                     <thead>
-                        <tr class="bg-gray-100 border-b-2 border-red-600">
+                        <tr class="bg-slate/60 border-b-2 border-coral/50">
                             <th class="player-name text-left p-1">Player</th>
+                            <th class="stat-cell-wide p-1">Status</th>
                             <!-- Column headers will be injected -->
                         </tr>
                     </thead>
@@ -210,37 +362,37 @@
         </div>
 
         <!-- Live Notes -->
-        <div class="bg-white rounded-lg shadow-md border-2 border-slate-300 p-3 mb-3 space-y-2">
+        <div class="track-panel p-3 mb-3 space-y-2">
             <div class="flex items-center justify-between gap-2">
-                <h3 class="font-bold text-sm text-slate-700">Live Notes</h3>
+                <h3 class="font-bold text-sm text-teal">Live Notes</h3>
                 <button id="voice-note-btn"
-                    class="px-2 py-1 rounded bg-white border border-slate-300 text-[11px] font-semibold text-slate-700 hover:bg-slate-50">
+                    class="px-2 py-1 rounded bg-slate border border-teal/30 text-[11px] font-semibold text-sand hover:bg-ink">
                     Start voice note
                 </button>
             </div>
-            <p id="voice-note-hint" class="text-[11px] text-slate-500">Tap Start voice note, speak, then tap Stop voice note.</p>
+            <p id="voice-note-hint" class="text-[11px] text-sand/60">Tap Start voice note, speak, then tap Stop voice note.</p>
             <div class="flex gap-2">
                 <input id="live-note-input"
-                    class="flex-1 px-3 py-2 rounded border border-slate-300 text-sm"
+                    class="flex-1 px-3 py-2 rounded border border-teal/30 bg-ink/40 text-sm text-sand"
                     placeholder="Quick note for this game...">
                 <button id="live-note-add"
-                    class="px-3 py-2 rounded bg-slate-800 text-white text-xs font-semibold hover:bg-slate-900">Add</button>
+                    class="px-3 py-2 rounded bg-teal text-ink text-xs font-semibold hover:bg-teal/80">Add</button>
             </div>
         </div>
 
         <!-- Game Log -->
-        <div class="bg-white rounded-lg shadow-md border-2 border-slate-800 p-3 max-h-48 overflow-y-auto">
-            <h3 class="font-bold text-sm text-slate-800 mb-2">Game Log</h3>
+        <div class="track-panel p-3 max-h-48 overflow-y-auto">
+            <h3 class="font-bold text-sm text-teal mb-2">Game Log</h3>
             <div id="gameLog" class="text-xs">
-                <div class="p-2 bg-gray-100 rounded text-gray-500 text-center">Game log will appear here</div>
+                <div class="p-2 bg-slate/70 rounded text-sand/60 text-center">Game log will appear here</div>
             </div>
         </div>
 
         <!-- Live Chat -->
-        <div id="chat-panel" class="mt-3 bg-gray-900 border border-blue-500/40 rounded-lg overflow-hidden shadow-md">
+        <div id="chat-panel" class="track-panel mt-3 overflow-hidden">
             <button id="chat-toggle" class="w-full p-3 flex items-center justify-between text-white">
                 <span class="flex items-center gap-2">
-                    <svg class="w-5 h-5 text-blue-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <svg class="w-5 h-5 text-teal" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
                             d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"></path>
                     </svg>
@@ -249,21 +401,21 @@
                         class="hidden bg-red-500 text-white text-[10px] font-bold rounded-full px-1.5 py-0.5 min-w-[18px] text-center">0</span>
                 </span>
                 <span class="flex items-center gap-3">
-                    <span id="chat-viewer-count" class="text-blue-200 text-xs">0 watching</span>
-                    <svg id="chat-chevron" class="w-5 h-5 text-blue-300 transition-transform" fill="none" stroke="currentColor"
+                    <span id="chat-viewer-count" class="text-teal/80 text-xs">0 watching</span>
+                    <svg id="chat-chevron" class="w-5 h-5 text-teal transition-transform" fill="none" stroke="currentColor"
                         viewBox="0 0 24 24">
                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"></path>
                     </svg>
                 </span>
             </button>
-            <div id="chat-content" class="hidden border-t border-blue-400/20">
-                <div id="chat-messages" class="h-48 overflow-y-auto p-3 space-y-2 bg-gray-950">
-                    <p class="text-center text-blue-300/60 text-xs py-4">Chat messages will appear here...</p>
+            <div id="chat-content" class="hidden border-t border-teal/20">
+                <div id="chat-messages" class="h-48 overflow-y-auto p-3 space-y-2 bg-ink/60">
+                    <p class="text-center text-teal/60 text-xs py-4">Chat messages will appear here...</p>
                 </div>
-                <form id="chat-form" class="p-3 border-t border-blue-400/20 flex gap-2">
+                <form id="chat-form" class="p-3 border-t border-teal/20 flex gap-2">
                     <input type="text" id="chat-input" placeholder="Send a message..."
-                        class="flex-1 bg-gray-900 border border-blue-400/40 rounded-lg px-3 py-2 text-blue-50 text-sm focus:outline-none focus:border-blue-300">
-                    <button type="submit" class="bg-blue-500 text-white px-4 py-2 rounded-lg font-semibold text-sm">Send</button>
+                        class="flex-1 bg-ink border border-teal/30 rounded-lg px-3 py-2 text-sand text-sm focus:outline-none focus:border-teal">
+                    <button type="submit" class="bg-teal text-ink px-4 py-2 rounded-lg font-semibold text-sm">Send</button>
                 </form>
             </div>
         </div>
@@ -271,33 +423,33 @@
         <!-- Finish Game Modal -->
         <div id="finish-modal"
             class="fixed inset-0 bg-black bg-opacity-80 hidden flex items-center justify-center p-4 z-50 overflow-y-auto">
-            <div class="bg-white rounded-lg max-w-4xl w-full p-6 my-8">
+            <div class="rounded-lg max-w-4xl w-full p-6 my-8">
                 <h2 class="text-2xl font-bold mb-4">Finish Game</h2>
                 <form id="finish-form" class="space-y-4">
                     <div class="grid grid-cols-2 gap-4">
                         <div>
-                            <label class="block text-sm font-medium text-gray-700">Home Score</label>
+                            <label class="block text-sm font-medium text-sand/90">Home Score</label>
                             <input type="number" id="finalHomeScore" required
-                                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm border p-2">
+                                class="mt-1 block w-full rounded-md shadow-sm border p-2">
                         </div>
                         <div>
-                            <label class="block text-sm font-medium text-gray-700">Away Score</label>
+                            <label class="block text-sm font-medium text-sand/90">Away Score</label>
                             <input type="number" id="finalAwayScore" required
-                                class="mt-1 block w-full border-gray-300 rounded-md shadow-sm border p-2">
+                                class="mt-1 block w-full rounded-md shadow-sm border p-2">
                         </div>
                     </div>
                     <div>
                         <div class="flex justify-between items-center mb-2">
-                            <label class="block text-sm font-medium text-gray-700">Game Summary</label>
+                            <label class="block text-sm font-medium text-sand/90">Game Summary</label>
                             <button type="button" id="generateAISummary"
-                                class="px-3 py-1 bg-blue-500 text-white text-sm rounded-md hover:bg-blue-600 flex items-center gap-1">
+                                class="px-3 py-1 bg-teal text-ink text-sm rounded-md hover:bg-teal/80 flex items-center gap-1 font-semibold">
                                 <span>✨</span> Generate AI Summary
                             </button>
                         </div>
                         <textarea id="gameSummary" rows="4"
-                            class="mt-1 block w-full border-gray-300 rounded-md shadow-sm border p-2"
+                            class="mt-1 block w-full rounded-md shadow-sm border p-2"
                             placeholder="Key moments, MVP, etc."></textarea>
-                        <div id="aiSummaryLoading" class="hidden mt-2 text-sm text-blue-600 flex items-center gap-2">
+                        <div id="aiSummaryLoading" class="hidden mt-2 text-sm text-teal flex items-center gap-2">
                             <svg class="animate-spin h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none"
                                 viewBox="0 0 24 24">
                                 <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor"
@@ -311,21 +463,21 @@
                     </div>
                     <div class="flex items-center">
                         <input type="checkbox" id="sendEmailCheckbox" checked
-                            class="h-4 w-4 text-blue-600 border-gray-300 rounded">
-                        <label for="sendEmailCheckbox" class="ml-2 text-sm font-medium text-gray-700">Send game summary
+                            class="h-4 w-4 text-teal border-teal/30 rounded">
+                        <label for="sendEmailCheckbox" class="ml-2 text-sm font-medium text-sand/90">Send game summary
                             email</label>
                     </div>
                     <div id="emailPreviewSection" class="border-t pt-4">
                         <h3 class="text-lg font-semibold mb-2">Email Preview</h3>
-                        <div class="bg-gray-50 p-4 rounded-md max-h-96 overflow-y-auto">
+                        <div class="p-4 rounded-md max-h-96 overflow-y-auto">
                             <pre id="emailPreview"
-                                class="text-xs whitespace-pre-wrap font-mono text-gray-700">Email preview will appear here...</pre>
+                                class="text-xs whitespace-pre-wrap font-mono">Email preview will appear here...</pre>
                         </div>
                     </div>
                     <div class="flex justify-end space-x-3 pt-4">
                         <button type="button" id="cancel-finish"
-                            class="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50">Cancel</button>
-                        <button type="submit" class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700">Save
+                            class="px-4 py-2 border border-teal/30 rounded-md text-sand/80 hover:bg-slate">Cancel</button>
+                        <button type="submit" class="px-4 py-2 bg-teal text-ink rounded-md hover:bg-teal/80 font-semibold">Save
                             & Complete</button>
                     </div>
                 </form>
@@ -342,6 +494,7 @@
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { resolveOpponentDisplayName } from './js/live-game-state.js?v=1';
         import { createFieldState, setPlayerFieldStatus, startFieldClock, pauseFieldClock, getPlayerFieldElapsedMs, getLiveLineup } from './js/live-tracker-field-status.js?v=1';
+        import { summarizePersistedTrackingState, buildTrackLiveResetUpdate } from './js/track-live-state.js?v=1';
         import { checkAuth } from './js/auth.js?v=9';
         import { getApp } from './js/vendor/firebase-app.js';
         import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './js/live-tracker-notes.js?v=1';
@@ -369,13 +522,24 @@
         ];
         let isFinishing = false; // Flag to disable beforeunload warning when finishing game
         let liveState = {
+            isLive: false,
             chatExpanded: false,
             unreadChatCount: 0,
             lastChatSeenAt: Date.now(),
             chatInitialized: false,
             unsubscribeChat: null,
             unsubscribeViewers: null,
-            lastChatSentAt: 0
+            lastChatSentAt: 0,
+            lastClockSyncAt: 0
+        };
+        const LIVE_CLOCK_SYNC_INTERVAL_MS = 5000;
+        let liveSync = {
+            scoreSyncTimeout: null,
+            lastSyncedHome: null,
+            lastSyncedAway: null,
+            playerTimeouts: new Map(),
+            opponentTimeout: null,
+            liveFlagTimeout: null
         };
         let gameState = {
             startTime: null,
@@ -411,14 +575,41 @@
             init();
         });
 
+        function getLiveShareUrl() {
+            return `${window.location.origin}/live-game.html?teamId=${currentTeamId}&gameId=${currentGameId}`;
+        }
+
         document.getElementById('shareLiveBtn').addEventListener('click', () => {
-            const url = `${window.location.origin}/live-game.html?teamId=${currentTeamId}&gameId=${currentGameId}`;
+            const url = getLiveShareUrl();
             navigator.clipboard.writeText(url).then(() => {
                 const btn = document.getElementById('shareLiveBtn');
                 btn.textContent = '✅ Copied!';
                 setTimeout(() => { btn.textContent = '📋 Copy Live Link'; }, 2000);
             }).catch(() => {
-                prompt('Copy this link:', `${window.location.origin}/live-game.html?teamId=${currentTeamId}&gameId=${currentGameId}`);
+                prompt('Copy this link:', url);
+            });
+        });
+
+        document.getElementById('shareLiveShareBtn').addEventListener('click', async () => {
+            const url = getLiveShareUrl();
+            const title = `${currentTeam?.name || 'Team'} Live Game`;
+            const text = `Watch ${currentTeam?.name || 'our team'} live on ALL PLAYS`;
+            if (navigator.share) {
+                try {
+                    await navigator.share({ title, text, url });
+                    return;
+                } catch (_) {
+                    // If user cancels share, do not fall back.
+                    return;
+                }
+            }
+            navigator.clipboard.writeText(url).then(() => {
+                const btn = document.getElementById('shareLiveShareBtn');
+                const previous = btn.textContent;
+                btn.textContent = '✅ Link Copied';
+                setTimeout(() => { btn.textContent = previous; }, 2000);
+            }).catch(() => {
+                prompt('Share this link:', url);
             });
         });
 
@@ -557,11 +748,11 @@
                     btn.addEventListener('click', () => {
                         // Update UI
                         document.querySelectorAll('.period-btn').forEach(b => {
-                            b.classList.remove('bg-blue-600', 'text-white', 'border-blue-600', 'font-bold');
-                            b.classList.add('bg-white', 'text-gray-600', 'border-gray-300');
+                            b.classList.remove('period-active');
+                            b.classList.add('period-inactive');
                         });
-                        btn.classList.remove('bg-white', 'text-gray-600', 'border-gray-300');
-                        btn.classList.add('bg-blue-600', 'text-white', 'border-blue-600', 'font-bold');
+                        btn.classList.remove('period-inactive');
+                        btn.classList.add('period-active');
 
                         // Update state
                         gameState.currentPeriod = btn.dataset.period;
@@ -589,6 +780,114 @@
 
         function getFieldStatus(playerId) {
             return gameState.playerFieldStatus[playerId]?.status === 'onField' ? 'onField' : 'bench';
+        }
+
+        function scheduleScoreSync() {
+            if (!currentTeamId || !currentGameId) return;
+            if (liveSync.scoreSyncTimeout) return;
+            liveSync.scoreSyncTimeout = setTimeout(async () => {
+                liveSync.scoreSyncTimeout = null;
+                if (homeScore === liveSync.lastSyncedHome && awayScore === liveSync.lastSyncedAway) return;
+                try {
+                    await updateGame(currentTeamId, currentGameId, { homeScore, awayScore });
+                    liveSync.lastSyncedHome = homeScore;
+                    liveSync.lastSyncedAway = awayScore;
+                } catch (error) {
+                    console.warn('Failed to sync live scores:', error);
+                }
+            }, 500);
+        }
+
+        function buildOpponentStatsSnapshot() {
+            const snapshot = {};
+            opponentPlayers.forEach((opp) => {
+                const existing = gameState.opponentStats[opp.id] || {};
+                snapshot[opp.id] = {
+                    ...existing,
+                    name: opp.name || existing.name || '',
+                    number: existing.number || ''
+                };
+                currentConfig.columns.forEach((col) => {
+                    const key = col.toLowerCase();
+                    snapshot[opp.id][key] = existing[key] || 0;
+                });
+            });
+            return snapshot;
+        }
+
+        function scheduleOpponentStatsSync() {
+            if (!currentTeamId || !currentGameId) return;
+            if (liveSync.opponentTimeout) return;
+            liveSync.opponentTimeout = setTimeout(async () => {
+                liveSync.opponentTimeout = null;
+                try {
+                    await updateGame(currentTeamId, currentGameId, {
+                        opponentStats: buildOpponentStatsSnapshot()
+                    });
+                } catch (error) {
+                    console.warn('Failed to sync opponent stats:', error);
+                }
+            }, 500);
+        }
+
+        function schedulePlayerStatsSync(playerId) {
+            if (!currentTeamId || !currentGameId || !playerId) return;
+            if (liveSync.playerTimeouts.has(playerId)) return;
+            const timeout = setTimeout(async () => {
+                liveSync.playerTimeouts.delete(playerId);
+                try {
+                    const player = players.find((p) => p.id === playerId);
+                    const statsObj = {};
+                    currentConfig.columns.forEach((col) => {
+                        const key = col.toLowerCase();
+                        statsObj[key] = gameState.playerStats[playerId]?.[key] || 0;
+                    });
+                    const timeMs = getPlayerFieldElapsedMs(
+                        gameState.playerFieldStatus,
+                        playerId,
+                        gameState.isRunning ? Date.now() : null
+                    );
+                    const statsRef = doc(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`, playerId);
+                    await setDoc(statsRef, {
+                        playerName: player?.name || '',
+                        playerNumber: player?.number || '',
+                        stats: statsObj,
+                        timeMs
+                    }, { merge: true });
+                } catch (error) {
+                    console.warn('Failed to sync player stats:', error);
+                }
+            }, 500);
+            liveSync.playerTimeouts.set(playerId, timeout);
+        }
+
+        function scheduleLiveHasData() {
+            if (!currentTeamId || !currentGameId) return;
+            if (currentGame?.liveHasData) return;
+            if (liveSync.liveFlagTimeout) return;
+            liveSync.liveFlagTimeout = setTimeout(async () => {
+                liveSync.liveFlagTimeout = null;
+                try {
+                    await updateGame(currentTeamId, currentGameId, { liveHasData: true });
+                    if (currentGame) currentGame.liveHasData = true;
+                } catch (error) {
+                    console.warn('Failed to mark live data flag:', error);
+                }
+            }, 500);
+        }
+
+        async function syncClockToGameDoc() {
+            if (!currentTeamId || !currentGameId) return;
+            try {
+                await updateGame(currentTeamId, currentGameId, {
+                    liveClockMs: gameState.elapsed,
+                    liveClockRunning: gameState.isRunning,
+                    liveClockPeriod: gameState.currentPeriod,
+                    liveClockUpdatedAt: Date.now()
+                });
+            } catch (error) {
+                console.warn('Failed to sync live clock to game doc:', error);
+            }
         }
 
         async function syncLiveLineup() {
@@ -619,6 +918,7 @@
             setPlayerFieldStatus(gameState.playerFieldStatus, playerId, status, now);
             renderStatsTable();
             syncLiveLineup().catch(console.warn);
+            scheduleLiveHasData();
         };
 
         function renderStatsTable() {
@@ -629,19 +929,19 @@
             let headersHTML = '<th class="player-name text-left p-1">Player</th>';
             headersHTML += '<th class="stat-cell-wide p-1">Status</th>';
             currentConfig.columns.forEach(col => {
-                const isPoints = col.toUpperCase() === 'PTS' || col.toUpperCase() === 'POINTS';
+                const isPoints = col.toUpperCase() === 'PTS' || col.toUpperCase() === 'POINTS' || col.toUpperCase() === 'GOALS';
                 headersHTML += `<th class="${isPoints ? 'stat-cell-wide' : 'stat-cell'} p-1">${col}</th>`;
             });
             thead.innerHTML = headersHTML;
 
             // Render player rows
             tbody.innerHTML = players.map(player => {
-                let rowHTML = `<tr class="border-b hover:bg-gray-50">
+                let rowHTML = `<tr class="border-b hover:bg-ink/30">
                     <td class="player-name text-left p-1 font-medium">
                         <div class="flex items-center gap-2">
-                            <span class="inline-flex h-8 w-8 rounded-full bg-gray-100 overflow-hidden border border-gray-200">
+                            <span class="inline-flex h-8 w-8 rounded-full bg-ink/50 overflow-hidden border border-teal/20">
                                 ${player.photoUrl ? `<img src="${escapeHtml(player.photoUrl)}" alt="${escapeHtml(player.name)}" class="w-full h-full object-cover">` : `
-                                    <svg class="w-full h-full text-gray-400 p-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <svg class="w-full h-full text-sand/40 p-1.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5.121 17.804A9 9 0 1119 12.999M15 21v-2a3 3 0 00-3-3H6a3 3 0 00-3 3v2"></path>
                                     </svg>
                                 `}
@@ -653,31 +953,31 @@
                 const onField = getFieldStatus(player.id) === 'onField';
                 rowHTML += `<td class="stat-cell-wide p-1">
                     <div class="flex flex-col items-center gap-1">
-                        <div id="field-time-${player.id}" class="text-[10px] font-semibold text-slate-700">${formatFieldTime(fieldMs)}</div>
+                        <div id="field-time-${player.id}" class="text-[10px] font-semibold text-sand/80">${formatFieldTime(fieldMs)}</div>
                         <div class="flex gap-0.5">
-                            <button class="stat-btn rounded px-1.5 h-5 text-[10px] font-bold border ${onField ? 'bg-blue-600 text-white border-blue-600' : 'bg-white text-blue-600 border-blue-300'}"
+                            <button class="stat-btn rounded px-1.5 h-5 text-[10px] font-bold border ${onField ? 'bg-teal text-ink border-teal' : 'bg-slate text-teal border-teal/40'}"
                                 onclick="setPlayerFieldStatus('${player.id}', 'onField')">On</button>
-                            <button class="stat-btn rounded px-1.5 h-5 text-[10px] font-bold border ${onField ? 'bg-white text-gray-600 border-gray-300' : 'bg-gray-700 text-white border-gray-700'}"
+                            <button class="stat-btn rounded px-1.5 h-5 text-[10px] font-bold border ${onField ? 'bg-slate text-sand/70 border-teal/20' : 'bg-coral text-white border-coral'}"
                                 onclick="setPlayerFieldStatus('${player.id}', 'bench')">Bench</button>
                         </div>
                     </div>
                 </td>`;
 
                 currentConfig.columns.forEach(col => {
-                    const isPoints = col.toUpperCase() === 'PTS' || col.toUpperCase() === 'POINTS';
+                    const isPoints = col.toUpperCase() === 'PTS' || col.toUpperCase() === 'POINTS' || col.toUpperCase() === 'GOALS';
                     const statKey = col.toLowerCase();
 
                     if (isPoints) {
                         const existingVal = (gameState.playerStats[player.id] && gameState.playerStats[player.id][statKey]) || 0;
                         rowHTML += `<td class="stat-cell-wide p-1">
                             <div class="flex flex-col items-center gap-1">
-                                <div class="font-bold text-sm text-blue-600" id="stat-${player.id}-${statKey}">${existingVal}</div>
+                                <div class="font-bold text-sm text-teal" id="stat-${player.id}-${statKey}">${existingVal}</div>
                                 <div class="flex gap-0.5">
-                                    <button class="stat-btn bg-blue-50 text-blue-600 border border-blue-300 rounded w-5 h-5 text-xs font-bold hover:bg-blue-100"
+                                    <button class="stat-btn bg-teal/20 text-teal border border-teal/40 rounded w-5 h-5 text-xs font-bold hover:bg-teal/30"
                                         onclick="incrementStat('${player.id}', '${statKey}', 1, false)">1</button>
-                                    <button class="stat-btn bg-blue-50 text-blue-600 border border-blue-300 rounded w-5 h-5 text-xs font-bold hover:bg-blue-100"
+                                    <button class="stat-btn bg-teal/20 text-teal border border-teal/40 rounded w-5 h-5 text-xs font-bold hover:bg-teal/30"
                                         onclick="incrementStat('${player.id}', '${statKey}', 2, false)">2</button>
-                                    <button class="stat-btn bg-blue-50 text-blue-600 border border-blue-300 rounded w-5 h-5 text-xs font-bold hover:bg-blue-100"
+                                    <button class="stat-btn bg-teal/20 text-teal border border-teal/40 rounded w-5 h-5 text-xs font-bold hover:bg-teal/30"
                                         onclick="incrementStat('${player.id}', '${statKey}', 3, false)">3</button>
                                 </div>
                             </div>
@@ -686,9 +986,9 @@
                         const existingVal = (gameState.playerStats[player.id] && gameState.playerStats[player.id][statKey]) || 0;
                         rowHTML += `<td class="stat-cell p-1">
                             <div class="flex flex-col items-center gap-1">
-                                <div class="font-bold text-sm text-blue-600" id="stat-${player.id}-${statKey}">${existingVal}</div>
+                                <div class="font-bold text-sm text-teal" id="stat-${player.id}-${statKey}">${existingVal}</div>
                                 <div class="flex gap-0.5">
-                                    <button class="stat-btn bg-green-50 text-green-600 border border-green-300 rounded w-5 h-5 text-xs font-bold hover:bg-green-100"
+                                    <button class="stat-btn bg-gold/20 text-gold border border-gold/40 rounded w-5 h-5 text-xs font-bold hover:bg-gold/30"
                                         onclick="incrementStat('${player.id}', '${statKey}', 1, false)">+</button>
                                 </div>
                             </div>
@@ -707,35 +1007,39 @@
 
             // Render column headers
             let headersHTML = '<th class="player-name text-left p-1">Player</th>';
+            headersHTML += '<th class="stat-cell-wide p-1">Status</th>';
             currentConfig.columns.forEach(col => {
-                const isPoints = col.toUpperCase() === 'PTS' || col.toUpperCase() === 'POINTS';
+                const isPoints = col.toUpperCase() === 'PTS' || col.toUpperCase() === 'POINTS' || col.toUpperCase() === 'GOALS';
                 headersHTML += `<th class="${isPoints ? 'stat-cell-wide' : 'stat-cell'} p-1">${col}</th>`;
             });
             thead.innerHTML = headersHTML;
 
             // Render opponent rows
             tbody.innerHTML = opponentPlayers.map(opp => {
-                let rowHTML = `<tr class="border-b hover:bg-gray-50">
+                let rowHTML = `<tr class="border-b hover:bg-ink/30">
                     <td class="player-name text-left p-1">
                         <input type="text" class="notes-input" placeholder="Player name..." value="${escapeHtml(opp.name)}"
                             onchange="updateOpponentName('${opp.id}', this.value)">
                     </td>`;
+                rowHTML += `<td class="stat-cell-wide p-1">
+                    <div class="text-[10px] text-sand/60 font-semibold">Away</div>
+                </td>`;
 
                 currentConfig.columns.forEach(col => {
-                    const isPoints = col.toUpperCase() === 'PTS' || col.toUpperCase() === 'POINTS';
+                    const isPoints = col.toUpperCase() === 'PTS' || col.toUpperCase() === 'POINTS' || col.toUpperCase() === 'GOALS';
                     const statKey = col.toLowerCase();
                     const existingVal = gameState.opponentStats[opp.id]?.[statKey] || 0;
 
                     if (isPoints) {
                         rowHTML += `<td class="stat-cell-wide p-1">
                             <div class="flex flex-col items-center gap-1">
-                                <div class="font-bold text-sm text-red-600" id="stat-${opp.id}-${statKey}">${existingVal}</div>
+                                <div class="font-bold text-sm text-coral" id="stat-${opp.id}-${statKey}">${existingVal}</div>
                                 <div class="flex gap-0.5">
-                                    <button class="stat-btn bg-red-50 text-red-600 border border-red-300 rounded w-5 h-5 text-xs font-bold hover:bg-red-100"
+                                    <button class="stat-btn bg-coral/20 text-coral border border-coral/40 rounded w-5 h-5 text-xs font-bold hover:bg-coral/30"
                                         onclick="incrementStat('${opp.id}', '${statKey}', 1, true)">1</button>
-                                    <button class="stat-btn bg-red-50 text-red-600 border border-red-300 rounded w-5 h-5 text-xs font-bold hover:bg-red-100"
+                                    <button class="stat-btn bg-coral/20 text-coral border border-coral/40 rounded w-5 h-5 text-xs font-bold hover:bg-coral/30"
                                         onclick="incrementStat('${opp.id}', '${statKey}', 2, true)">2</button>
-                                    <button class="stat-btn bg-red-50 text-red-600 border border-red-300 rounded w-5 h-5 text-xs font-bold hover:bg-red-100"
+                                    <button class="stat-btn bg-coral/20 text-coral border border-coral/40 rounded w-5 h-5 text-xs font-bold hover:bg-coral/30"
                                         onclick="incrementStat('${opp.id}', '${statKey}', 3, true)">3</button>
                                 </div>
                             </div>
@@ -743,9 +1047,9 @@
                     } else {
                         rowHTML += `<td class="stat-cell p-1">
                             <div class="flex flex-col items-center gap-1">
-                                <div class="font-bold text-sm text-red-600" id="stat-${opp.id}-${statKey}">${existingVal}</div>
+                                <div class="font-bold text-sm text-coral" id="stat-${opp.id}-${statKey}">${existingVal}</div>
                                 <div class="flex gap-0.5">
-                                    <button class="stat-btn bg-red-50 text-red-600 border border-red-300 rounded w-5 h-5 text-xs font-bold hover:bg-red-100"
+                                    <button class="stat-btn bg-coral/20 text-coral border border-coral/40 rounded w-5 h-5 text-xs font-bold hover:bg-coral/30"
                                         onclick="incrementStat('${opp.id}', '${statKey}', 1, true)">+</button>
                                 </div>
                             </div>
@@ -764,6 +1068,8 @@
             if (gameState.opponentStats[oppId]) {
                 gameState.opponentStats[oppId].name = name;
             }
+            scheduleOpponentStatsSync();
+            scheduleLiveHasData();
         };
 
 
@@ -901,6 +1207,7 @@
                 if (isPoints) {
                     awayScore += value;
                     updateScoreDisplay();
+                    scheduleScoreSync();
                 }
                 const opp = opponentPlayers.find(o => o.id === playerId);
                 const oppName = opp.name || 'Opponent Player';
@@ -926,6 +1233,8 @@
                     description: `${oppName} +${value} ${statKey.toUpperCase()}`,
                     createdBy: currentUser?.uid || null
                 }).catch(console.warn);
+                scheduleOpponentStatsSync();
+                scheduleLiveHasData();
             } else {
                 const player = players.find(p => p.id === playerId);
                 if (!player) return;
@@ -941,6 +1250,7 @@
                 if (isPoints) {
                     homeScore += value;
                     updateScoreDisplay();
+                    scheduleScoreSync();
                 }
 
                 addLogEntry(`#${player.number || '-'} ${player.name} +${value} ${statKey.toUpperCase()}`, {
@@ -967,6 +1277,8 @@
                     description: `#${player.number || '-'} ${player.name} +${value} ${statKey.toUpperCase()}`,
                     createdBy: currentUser?.uid || null
                 }).catch(console.warn);
+                schedulePlayerStatsSync(playerId);
+                scheduleLiveHasData();
             }
         };
 
@@ -990,10 +1302,12 @@
                 if (isPoints) {
                     awayScore = Math.max(0, awayScore - value);
                     updateScoreDisplay();
+                    scheduleScoreSync();
                 }
                 const opp = opponentPlayers.find(o => o.id === playerId);
                 const oppName = opp.name || 'Opponent Player';
                 addLogEntry(`${oppName} (Opp) -${value} ${statKey.toUpperCase()}`);
+                scheduleOpponentStatsSync();
             } else {
                 const player = players.find(p => p.id === playerId);
                 if (!player) return;
@@ -1006,10 +1320,14 @@
                 if (isPoints) {
                     homeScore = Math.max(0, homeScore - value);
                     updateScoreDisplay();
+                    scheduleScoreSync();
                 }
 
                 addLogEntry(`#${player.number || '-'} ${player.name} -${value} ${statKey.toUpperCase()}`);
+                schedulePlayerStatsSync(playerId);
             }
+
+            scheduleLiveHasData();
 
             broadcastLiveEvent(currentTeamId, currentGameId, {
                 type: 'undo',
@@ -1046,34 +1364,96 @@
                     (gameState.gameLog && gameState.gameLog.length > 0);
 
                 if (!hasLocalActivity) {
-                    const eventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
+                    const [eventsSnap, statsSnap, liveEventsSnap] = await Promise.all([
+                        getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`)),
+                        getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`)),
+                        getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/liveEvents`))
+                    ]);
 
-                    if (eventsSnap.size > 0) {
-                        const msg = currentGame?.status === 'completed'
-                            ? `This game was previously finished and has ${eventsSnap.size} event(s). Starting will clear that data. Continue?`
-                            : `This game already has ${eventsSnap.size} tracked event(s). Starting fresh will clear them. Continue?`;
+                    const persistedState = summarizePersistedTrackingState({
+                        eventsCount: eventsSnap.size,
+                        statsCount: statsSnap.size,
+                        liveEventsCount: liveEventsSnap.size,
+                        hasScores: (currentGame?.homeScore || 0) > 0 || (currentGame?.awayScore || 0) > 0,
+                        hasOpponentStats: !!(currentGame?.opponentStats && Object.keys(currentGame.opponentStats).length > 0),
+                        hasLiveFlag: !!currentGame?.liveHasData || currentGame?.liveStatus === 'live'
+                    });
 
-                        const confirmClear = confirm(msg);
-                        if (!confirmClear) {
-                            return; // User cancelled
+                    if (persistedState.hasPersistedData) {
+                        const shouldResume = confirm('This game already has tracked data. Continue where you left off?\n\nClick Cancel to start over and clear previous stats.');
+                        if (!shouldResume) {
+                            const deletions = [
+                                ...eventsSnap.docs.map(docItem => deleteDoc(docItem.ref)),
+                                ...statsSnap.docs.map(docItem => deleteDoc(docItem.ref)),
+                                ...liveEventsSnap.docs.map(docItem => deleteDoc(docItem.ref))
+                            ];
+                            const results = await Promise.allSettled(deletions);
+                            const failedDeletes = results.filter((result) => result.status === 'rejected');
+                            if (failedDeletes.length) {
+                                console.warn('Some persisted tracking records could not be deleted:', failedDeletes);
+                            }
+
+                            gameState.playerStats = {};
+                            gameState.gameLog = [];
+                            gameState.playerFieldStatus = createFieldState(players);
+                            homeScore = 0;
+                            awayScore = 0;
+                            opponentPlayers.forEach((opp) => {
+                                const existing = gameState.opponentStats[opp.id] || {};
+                                gameState.opponentStats[opp.id] = {
+                                    ...existing,
+                                    name: existing.name || opp.name || '',
+                                    number: existing.number || ''
+                                };
+                                currentConfig.columns.forEach((col) => {
+                                    gameState.opponentStats[opp.id][col.toLowerCase()] = 0;
+                                });
+                            });
+
+                            const resetLineup = getLiveLineup(gameState.playerFieldStatus, players);
+                            try {
+                                await updateGame(
+                                    currentTeamId,
+                                    currentGameId,
+                                    buildTrackLiveResetUpdate({
+                                        currentGame,
+                                        period: gameState.currentPeriod,
+                                        liveLineup: resetLineup
+                                    })
+                                );
+                                currentGame.liveStatus = 'scheduled';
+                                currentGame.liveHasData = false;
+                                currentGame.homeScore = 0;
+                                currentGame.awayScore = 0;
+                                currentGame.opponentStats = {};
+                            } catch (error) {
+                                console.warn('Failed to reset game metadata:', error);
+                            }
+
+                            await broadcastLiveEvent(currentTeamId, currentGameId, {
+                                type: 'reset',
+                                period: gameState.currentPeriod,
+                                gameClockMs: 0,
+                                homeScore: 0,
+                                awayScore: 0,
+                                onCourt: resetLineup.onCourt,
+                                bench: resetLineup.bench,
+                                description: `Tracker restarted from zero. Cleared: ${persistedState.summary}.`,
+                                createdBy: currentUser?.uid || null
+                            }).catch(console.warn);
+
+                            updateScoreDisplay();
+                            renderGameLog();
+                            renderStatsTable();
+                            renderOpponentTable();
                         }
-
-                        // Clear existing events and stats
-                        console.log('Clearing existing events and stats...');
-                        const deleteEventPromises = eventsSnap.docs.map(doc => deleteDoc(doc.ref));
-                        await Promise.all(deleteEventPromises);
-
-                        // Clear aggregated stats
-                        const statsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`));
-                        const deleteStatsPromises = statsSnap.docs.map(doc => deleteDoc(doc.ref));
-                        await Promise.all(deleteStatsPromises);
-
-                        console.log('Cleared existing data. Starting fresh...');
                     }
                 }
 
                 gameState.startTime = Date.now() - gameState.elapsed;
                 gameState.isRunning = true;
+                liveState.isLive = true;
+                liveState.lastClockSyncAt = 0;
                 startFieldClock(gameState.playerFieldStatus, Date.now());
                 document.getElementById('startBtn').disabled = true;
                 document.getElementById('stopBtn').disabled = false;
@@ -1093,6 +1473,9 @@
                 }).catch(console.warn);
                 document.getElementById('liveBadge').classList.remove('hidden');
                 document.getElementById('shareLiveBtn').classList.remove('hidden');
+                document.getElementById('shareLiveShareBtn').classList.remove('hidden');
+                syncClockToGameDoc().catch(console.warn);
+                scheduleScoreSync();
                 syncLiveLineup().catch(console.warn);
             }
         }
@@ -1104,6 +1487,16 @@
                 document.getElementById('startBtn').disabled = false;
                 document.getElementById('stopBtn').disabled = true;
                 addLogEntry('Game stopped');
+                broadcastLiveEvent(currentTeamId, currentGameId, {
+                    type: 'clock_pause',
+                    period: gameState.currentPeriod,
+                    gameClockMs: gameState.elapsed,
+                    homeScore,
+                    awayScore,
+                    description: 'Game paused',
+                    createdBy: currentUser?.uid || null
+                }).catch(console.warn);
+                syncClockToGameDoc().catch(console.warn);
                 renderStatsTable();
             }
         }
@@ -1114,6 +1507,7 @@
                 gameState.startTime = null;
                 gameState.elapsed = 0;
                 gameState.isRunning = false;
+                liveState.lastClockSyncAt = 0;
                 gameState.gameLog = [];
                 gameState.playerStats = {}; // Clear in-memory player stats
                 gameState.playerFieldStatus = createFieldState(players);
@@ -1179,6 +1573,8 @@
                 renderOpponentTable();
                 document.getElementById('liveBadge').classList.add('hidden');
                 document.getElementById('shareLiveBtn').classList.add('hidden');
+                document.getElementById('shareLiveShareBtn').classList.add('hidden');
+                liveState.isLive = false;
                 updateTimer();
             }
         }
@@ -1213,6 +1609,8 @@
                         opponentTeamPhoto: currentGame.opponentTeamPhoto
                     });
                 }
+                liveState.isLive = false;
+                liveState.lastClockSyncAt = 0;
 
                 // Navigate back to schedule
                 alert('Game cancelled. All data has been deleted.');
@@ -1240,6 +1638,27 @@
                 const elapsedMs = getPlayerFieldElapsedMs(gameState.playerFieldStatus, player.id, gameState.isRunning ? Date.now() : null);
                 timeEl.textContent = formatFieldTime(elapsedMs);
             });
+
+            const wallNow = Date.now();
+            if (
+                gameState.isRunning &&
+                liveState.isLive &&
+                currentTeamId &&
+                currentGameId &&
+                (wallNow - liveState.lastClockSyncAt >= LIVE_CLOCK_SYNC_INTERVAL_MS)
+            ) {
+                liveState.lastClockSyncAt = wallNow;
+                broadcastLiveEvent(currentTeamId, currentGameId, {
+                    type: 'clock_sync',
+                    period: gameState.currentPeriod,
+                    gameClockMs: gameState.elapsed,
+                    homeScore,
+                    awayScore,
+                    description: 'Clock sync',
+                    createdBy: currentUser?.uid || null
+                }).catch(console.warn);
+                syncClockToGameDoc().catch(console.warn);
+            }
         }
 
         function getGameTime() {
@@ -1265,15 +1684,15 @@
         function renderGameLog() {
             const logDiv = document.getElementById('gameLog');
             if (gameState.gameLog.length === 0) {
-                logDiv.innerHTML = '<div class="p-2 bg-gray-100 rounded text-gray-500 text-center">Game log will appear here</div>';
+                logDiv.innerHTML = '<div class="p-2 bg-slate/70 rounded text-sand/60 text-center">Game log will appear here</div>';
                 return;
             }
 
             logDiv.innerHTML = gameState.gameLog.map((entry, index) => `
-                <div class="p-2 mb-1 bg-gray-100 rounded flex justify-between items-start gap-2 border-l-2 border-blue-600">
+                <div class="p-2 mb-1 bg-slate/60 rounded flex justify-between items-start gap-2 border-l-2 border-teal/70">
                     <span class="flex-1 min-w-0 break-words whitespace-normal">${escapeHtml(entry.text)}</span>
-                    <span class="text-blue-600 font-medium text-xs mr-2">${escapeHtml(entry.period || 'Q1')} ${escapeHtml(entry.time)}</span>
-                    <button class="bg-red-600 text-white px-2 py-1 rounded text-xs hover:bg-red-700 undo-log-btn"
+                    <span class="text-teal font-medium text-xs mr-2">${escapeHtml(entry.period || 'Q1')} ${escapeHtml(entry.time)}</span>
+                    <button class="bg-coral text-white px-2 py-1 rounded text-xs hover:bg-coral/80 undo-log-btn"
                         data-undo-index="${index}">✕</button>
                 </div>
             `).join('');
@@ -1308,7 +1727,9 @@
                     if (isPoints) {
                         awayScore = Math.max(0, awayScore - parsedValue);
                         updateScoreDisplay();
+                        scheduleScoreSync();
                     }
+                    scheduleOpponentStatsSync();
                 } else {
                     if (!gameState.playerStats[playerId]) gameState.playerStats[playerId] = {};
                     const currentVal = Number(gameState.playerStats[playerId][statKey] || statEl?.textContent || 0);
@@ -1318,8 +1739,11 @@
                     if (isPoints) {
                         homeScore = Math.max(0, homeScore - parsedValue);
                         updateScoreDisplay();
+                        scheduleScoreSync();
                     }
+                    schedulePlayerStatsSync(playerId);
                 }
+                scheduleLiveHasData();
 
                 broadcastLiveEvent(currentTeamId, currentGameId, {
                     type: 'undo',
@@ -1381,13 +1805,13 @@
         function renderChatMessages(messages) {
             if (!chatEls.messages) return;
             if (!messages.length) {
-                chatEls.messages.innerHTML = '<p class="text-center text-blue-300/60 text-xs py-4">No messages yet. Start the conversation.</p>';
+                chatEls.messages.innerHTML = '<p class="text-center text-teal/60 text-xs py-4">No messages yet. Start the conversation.</p>';
                 return;
             }
             chatEls.messages.innerHTML = messages.slice().reverse().map((msg) => `
                 <div class="${msg.senderId === currentUser?.uid ? 'text-right' : ''}">
-                    <div class="text-[11px] text-blue-200">${escapeHtml(msg.senderName || 'Fan')}</div>
-                    <div class="inline-block mt-0.5 px-2 py-1 rounded-lg ${msg.senderId === currentUser?.uid ? 'bg-blue-600 text-white' : 'bg-gray-800 text-blue-50'} text-xs break-words max-w-[90%]">
+                    <div class="text-[11px] text-teal/80">${escapeHtml(msg.senderName || 'Fan')}</div>
+                    <div class="inline-block mt-0.5 px-2 py-1 rounded-lg ${msg.senderId === currentUser?.uid ? 'bg-teal text-ink' : 'bg-slate text-sand'} text-xs break-words max-w-[90%]">
                         ${escapeHtml(msg.text || '')}
                     </div>
                 </div>
@@ -1742,6 +2166,8 @@ Write the match report now:`;
 
                 // Mark live stream as completed
                 await setGameLiveStatus(currentTeamId, currentGameId, 'completed').catch(console.warn);
+                liveState.isLive = false;
+                liveState.lastClockSyncAt = 0;
 
                 // Disable beforeunload warning since we're finishing successfully
                 isFinishing = true;
@@ -1806,11 +2232,11 @@ Write the match report now:`;
 
                 // Update button styles
                 document.querySelectorAll('.period-btn').forEach(b => {
-                    b.classList.remove('bg-blue-600', 'text-white', 'border-blue-600', 'border-2', 'font-bold');
-                    b.classList.add('bg-white', 'text-gray-600', 'border-gray-300', 'border');
+                    b.classList.remove('period-active');
+                    b.classList.add('period-inactive');
                 });
-                this.classList.remove('bg-white', 'text-gray-600', 'border-gray-300', 'border');
-                this.classList.add('bg-blue-600', 'text-white', 'border-blue-600', 'border-2', 'font-bold');
+                this.classList.remove('period-inactive');
+                this.classList.add('period-active');
 
                 addLogEntry(`Period changed to ${period}`);
 

--- a/track-live.html
+++ b/track-live.html
@@ -889,10 +889,12 @@
                 clearTimeout(liveSync.liveFlagTimeout);
                 liveSync.liveFlagTimeout = null;
             }
-            liveSync.playerTimeouts.forEach((timeoutId) => {
-                clearTimeout(timeoutId);
+            liveSync.playerTimeouts.forEach((timeout) => {
+                clearTimeout(timeout);
             });
             liveSync.playerTimeouts.clear();
+            liveSync.lastSyncedHome = null;
+            liveSync.lastSyncedAway = null;
         }
 
         async function syncClockToGameDoc() {
@@ -1431,6 +1433,17 @@
                             });
 
                             const resetLineup = getLiveLineup(gameState.playerFieldStatus, players);
+                            await broadcastLiveEvent(currentTeamId, currentGameId, {
+                                type: 'reset',
+                                period: gameState.currentPeriod,
+                                gameClockMs: 0,
+                                homeScore: 0,
+                                awayScore: 0,
+                                onCourt: resetLineup.onCourt,
+                                bench: resetLineup.bench,
+                                description: `Tracker restarted from zero. Cleared: ${persistedState.summary}.`,
+                                createdBy: currentUser?.uid || null
+                            }).catch(console.warn);
                             try {
                                 await updateGame(
                                     currentTeamId,
@@ -1449,18 +1462,6 @@
                             } catch (error) {
                                 console.warn('Failed to reset game metadata:', error);
                             }
-
-                            await broadcastLiveEvent(currentTeamId, currentGameId, {
-                                type: 'reset',
-                                period: gameState.currentPeriod,
-                                gameClockMs: 0,
-                                homeScore: 0,
-                                awayScore: 0,
-                                onCourt: resetLineup.onCourt,
-                                bench: resetLineup.bench,
-                                description: `Tracker restarted from zero. Cleared: ${persistedState.summary}.`,
-                                createdBy: currentUser?.uid || null
-                            }).catch(console.warn);
 
                             updateScoreDisplay();
                             renderGameLog();
@@ -1565,20 +1566,6 @@
                     await Promise.all(liveEventsSnapshot.docs.map(liveDoc => deleteDoc(liveDoc.ref)));
 
                     const liveLineup = getLiveLineup(gameState.playerFieldStatus, players);
-                    await updateGame(currentTeamId, currentGameId, {
-                        homeScore: 0,
-                        awayScore: 0,
-                        period: gameState.currentPeriod,
-                        liveStatus: 'scheduled',
-                        liveLineup,
-                        liveHasData: false,
-                        opponentStats: gameState.opponentStats
-                    });
-                    if (currentGame) {
-                        currentGame.liveHasData = false;
-                        currentGame.liveStatus = 'scheduled';
-                    }
-                    await setGameLiveStatus(currentTeamId, currentGameId, 'scheduled').catch(console.warn);
                     await broadcastLiveEvent(currentTeamId, currentGameId, {
                         type: 'reset',
                         period: gameState.currentPeriod,
@@ -1590,6 +1577,22 @@
                         description: 'Game reset',
                         createdBy: currentUser?.uid || null
                     }).catch(console.warn);
+                    await updateGame(currentTeamId, currentGameId, {
+                        ...buildTrackLiveResetUpdate({
+                            currentGame,
+                            period: gameState.currentPeriod,
+                            liveLineup
+                        }),
+                        opponentStats: gameState.opponentStats
+                    });
+                    await setGameLiveStatus(currentTeamId, currentGameId, 'scheduled').catch(console.warn);
+                    if (currentGame) {
+                        currentGame.liveStatus = 'scheduled';
+                        currentGame.liveHasData = false;
+                        currentGame.homeScore = 0;
+                        currentGame.awayScore = 0;
+                        currentGame.opponentStats = {};
+                    }
                 } catch (error) {
                     console.error('Error clearing stats:', error);
                 }

--- a/track-live.html
+++ b/track-live.html
@@ -863,10 +863,12 @@
 
         function scheduleLiveHasData() {
             if (!currentTeamId || !currentGameId) return;
+            if (!liveState.isLive || !gameState.isRunning) return;
             if (currentGame?.liveHasData) return;
             if (liveSync.liveFlagTimeout) return;
             liveSync.liveFlagTimeout = setTimeout(async () => {
                 liveSync.liveFlagTimeout = null;
+                if (!liveState.isLive || !gameState.isRunning) return;
                 try {
                     await updateGame(currentTeamId, currentGameId, { liveHasData: true });
                     if (currentGame) currentGame.liveHasData = true;

--- a/track-live.html
+++ b/track-live.html
@@ -876,6 +876,25 @@
             }, 500);
         }
 
+        function clearLiveSyncTimeouts() {
+            if (liveSync.scoreSyncTimeout) {
+                clearTimeout(liveSync.scoreSyncTimeout);
+                liveSync.scoreSyncTimeout = null;
+            }
+            if (liveSync.opponentTimeout) {
+                clearTimeout(liveSync.opponentTimeout);
+                liveSync.opponentTimeout = null;
+            }
+            if (liveSync.liveFlagTimeout) {
+                clearTimeout(liveSync.liveFlagTimeout);
+                liveSync.liveFlagTimeout = null;
+            }
+            liveSync.playerTimeouts.forEach((timeoutId) => {
+                clearTimeout(timeoutId);
+            });
+            liveSync.playerTimeouts.clear();
+        }
+
         async function syncClockToGameDoc() {
             if (!currentTeamId || !currentGameId) return;
             try {
@@ -1382,6 +1401,7 @@
                     if (persistedState.hasPersistedData) {
                         const shouldResume = confirm('This game already has tracked data. Continue where you left off?\n\nClick Cancel to start over and clear previous stats.');
                         if (!shouldResume) {
+                            clearLiveSyncTimeouts();
                             const deletions = [
                                 ...eventsSnap.docs.map(docItem => deleteDoc(docItem.ref)),
                                 ...statsSnap.docs.map(docItem => deleteDoc(docItem.ref)),
@@ -1503,6 +1523,7 @@
 
         async function resetTimer() {
             if (confirm('Reset timer and clear all stats? This will also clear saved stats in the database.')) {
+                clearLiveSyncTimeouts();
                 pauseFieldClock(gameState.playerFieldStatus, Date.now());
                 gameState.startTime = null;
                 gameState.elapsed = 0;
@@ -1549,8 +1570,10 @@
                         awayScore: 0,
                         period: gameState.currentPeriod,
                         liveLineup,
+                        liveHasData: false,
                         opponentStats: gameState.opponentStats
                     });
+                    if (currentGame) currentGame.liveHasData = false;
                     await setGameLiveStatus(currentTeamId, currentGameId, 'scheduled').catch(console.warn);
                     await broadcastLiveEvent(currentTeamId, currentGameId, {
                         type: 'reset',
@@ -1586,6 +1609,7 @@
             }
 
             try {
+                clearLiveSyncTimeouts();
                 // Delete all events
                 const eventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
                 const deleteEventPromises = eventsSnap.docs.map(doc => deleteDoc(doc.ref));
@@ -1596,12 +1620,13 @@
                 const deleteStatsPromises = statsSnap.docs.map(doc => deleteDoc(doc.ref));
                 await Promise.all(deleteStatsPromises);
 
-                // Reset game status to scheduled if it was started
-                if (currentGame.status !== 'scheduled') {
+                // Reset game status/flags when needed after deleting tracked records
+                if (currentGame.status !== 'scheduled' || currentGame.liveHasData) {
                     await updateGame(currentTeamId, currentGameId, {
                         status: 'scheduled',
                         homeScore: 0,
                         awayScore: 0,
+                        liveHasData: false,
                         // Preserve opponent fields
                         opponent: currentGame.opponent,
                         opponentTeamId: currentGame.opponentTeamId,
@@ -1609,6 +1634,7 @@
                         opponentTeamPhoto: currentGame.opponentTeamPhoto
                     });
                 }
+                if (currentGame) currentGame.liveHasData = false;
                 liveState.isLive = false;
                 liveState.lastClockSyncAt = 0;
 


### PR DESCRIPTION
## Summary
- align `track-live.html` soccer tracker state persistence behavior with basketball live tracker behavior
- add explicit live-state lifecycle handling (`isLive`, `lastClockSyncAt`) and periodic `clock_sync` + game-doc clock sync updates
- add debounced sync parity for undo corrections (score, player stats, opponent stats, `liveHasData`)
- keep resume/reset prompt behavior aligned with persisted-data detection and reset metadata helper
- add unit-tested helper module for persisted-state summary + reset payload shaping

## Files Changed
- `track-live.html`
- `js/track-live-state.js`
- `tests/unit/track-live-state.test.js`

## Testing
- Focused tracker tests:
  - `npx --yes vitest run tests/unit/track-live-state.test.js tests/unit/live-tracker-field-status.test.js tests/unit/live-tracker-opponent-stats.test.js tests/unit/live-tracker-resume.test.js tests/unit/live-game-state.test.js`
  - Result: **pass** (5 files, 17 tests)
- Full suite:
  - `npx --yes vitest run`
  - Result in current repo baseline: **5 failing tests** in 4 files
    - `tests/unit/help-navigation-wiring.test.js`
    - `tests/unit/ics-recurrence-parse.test.js`
    - `tests/unit/parent-dashboard-rideshare-wiring.test.js`
    - `tests/unit/recurrence-until-inclusive.test.js`

Fixes #170
