### PR TITLE
Add native standings computation with configurable rules

### DIFF
--- a/docs/pr-notes/runs/178-remediator-20260305T053056Z/architecture.md
+++ b/docs/pr-notes/runs/178-remediator-20260305T053056Z/architecture.md
@@ -1,0 +1,5 @@
+# Architecture Role Notes
+- Current state: `buildNativeStandingsSnapshot()` maps each game with `homeTeam = teamName` and `awayTeam = opponent` regardless of venue.
+- Risk: For away games that store true home/away scores, standings engine interprets results backwards.
+- Proposed state: Map `homeTeam`/`awayTeam` conditionally using `game.isHome` when provided.
+- Blast radius: Limited to native standings snapshot transformation in `team.html`.

--- a/docs/pr-notes/runs/178-remediator-20260305T053056Z/code-plan.md
+++ b/docs/pr-notes/runs/178-remediator-20260305T053056Z/code-plan.md
@@ -1,0 +1,5 @@
+# Code Role Notes
+- Edit only `team.html` in `buildNativeStandingsSnapshot`.
+- Add local `isHome` boolean derivation (`game?.isHome !== false`) and map home/away teams from it.
+- Keep score fields unchanged; rely on persisted homeScore/awayScore orientation.
+- Run lightweight validation (diff + optional grep) and commit.

--- a/docs/pr-notes/runs/178-remediator-20260305T053056Z/qa.md
+++ b/docs/pr-notes/runs/178-remediator-20260305T053056Z/qa.md
@@ -1,0 +1,6 @@
+# QA Role Notes
+- Manual checks:
+  1. Completed home game still computes same W/L/PF/PA as before.
+  2. Completed away game (`isHome: false`) now maps current team as away and preserves score orientation.
+  3. Standings row for current team reflects expected record after including away games.
+- Regression focus: ensure games without `isHome` keep prior behavior (team treated as home fallback).

--- a/docs/pr-notes/runs/178-remediator-20260305T053056Z/requirements.md
+++ b/docs/pr-notes/runs/178-remediator-20260305T053056Z/requirements.md
@@ -1,0 +1,5 @@
+# Requirements Role Notes
+- Objective: Fix PR #178 review thread PRRT_kwDOQe-T585yO9RL by correcting standings transformation in `team.html`.
+- Constraint: Minimal targeted code change only; no unrelated refactors.
+- Expected behavior: Native standings input must preserve correct home/away team assignment so win/loss and PF/PA are computed correctly.
+- Acceptance: Away games (where current team is not home) no longer flip outcome in `computeNativeStandings`.

--- a/docs/pr-notes/runs/178-remediator-20260305T053730Z/architecture.md
+++ b/docs/pr-notes/runs/178-remediator-20260305T053730Z/architecture.md
@@ -1,0 +1,13 @@
+# Architecture role notes
+
+Current state:
+- Standings loop applies permissive status filter (`if status && status !== completed/final`) allowing missing status rows.
+- Tiebreaker comparison receives original `games` input, not filtered standings subset.
+
+Proposed state:
+- Introduce a shared `isFinalGameStatus` guard and derive `completedGames` once.
+- Build table from `completedGames` and pass `completedGames` into `compareByTiebreaker`.
+
+Risk/blast radius:
+- Scoped to native standings calculation logic only.
+- Potential behavior shift: legacy status-less games no longer counted (intended by review feedback).

--- a/docs/pr-notes/runs/178-remediator-20260305T053730Z/code-plan.md
+++ b/docs/pr-notes/runs/178-remediator-20260305T053730Z/code-plan.md
@@ -1,0 +1,9 @@
+# Code role notes
+
+Implementation plan:
+1. Add `isFinalGameStatus(game)` helper near other utilities.
+2. In `computeNativeStandings`, create `completedGames = games.filter(isFinalGameStatus)`.
+3. Replace standings loop input from `games` to `completedGames` and remove inline permissive status check.
+4. Pass `completedGames` to `compareByTiebreaker`.
+5. Add two focused unit tests for missing-status exclusion and head-to-head filtering.
+6. Execute targeted unit test file.

--- a/docs/pr-notes/runs/178-remediator-20260305T053730Z/qa.md
+++ b/docs/pr-notes/runs/178-remediator-20260305T053730Z/qa.md
@@ -1,0 +1,9 @@
+# QA role notes
+
+Targeted test additions in `tests/unit/native-standings.test.js`:
+1. Verify status-less games are ignored and do not inflate GP/points.
+2. Verify in-progress rematch does not affect `head_to_head` tie ordering.
+
+Validation plan:
+- Run `npx vitest run tests/unit/native-standings.test.js` from repo root.
+- Confirm new tests fail before fix (conceptually) and pass after fix.

--- a/docs/pr-notes/runs/178-remediator-20260305T053730Z/requirements.md
+++ b/docs/pr-notes/runs/178-remediator-20260305T053730Z/requirements.md
@@ -1,0 +1,12 @@
+# Requirements role notes
+
+Objective: Remediate unresolved PR #178 review feedback in `js/native-standings.js` only.
+
+Feedback requirements:
+1. Tiebreaker `head_to_head` must evaluate only completed/final games, matching the same subset used for standings totals.
+2. Game rows with missing/unknown status must not count toward standings, even when scores are numeric.
+
+Acceptance criteria:
+- `computeNativeStandings` ignores any game where normalized status is not explicitly `completed` or `final`.
+- Tiebreakers receive the same status-filtered game list used in table aggregation.
+- Existing standings behavior remains unchanged for valid completed/final rows.

--- a/docs/pr-notes/runs/issue-177-fixer-20260305T052537Z/architecture.md
+++ b/docs/pr-notes/runs/issue-177-fixer-20260305T052537Z/architecture.md
@@ -1,0 +1,18 @@
+# Architecture Role (fallback synthesis)
+
+## Current state
+`team.html` fetches external standings via `fetchLeagueStandings(team.leagueUrl)` and renders snapshot only.
+
+## Proposed minimal state
+- Add pure JS standings engine module to compute rows from completed games.
+- Support config object: ranking mode + points schema + ordered tiebreakers.
+- Integrate in team page rendering path with feature flag on team object (`standingsConfig.enabled`).
+- Keep external parser untouched as fallback path.
+
+## Blast radius
+- Low: additive module + localized team page rendering decision.
+- No Firestore schema migration required for initial delivery; config stored as optional team fields.
+
+## Controls
+- Fail-closed fallback to existing external standings source.
+- Pure function engine enables unit-level auditability.

--- a/docs/pr-notes/runs/issue-177-fixer-20260305T052537Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-177-fixer-20260305T052537Z/code-plan.md
@@ -1,0 +1,7 @@
+# Code Role Plan (fallback synthesis)
+
+1. Add failing unit tests for native standings compute/sort behavior.
+2. Implement new `js/native-standings.js` pure engine with config-driven ranking/tiebreakers.
+3. Update `team.html` to compute native standings from loaded games when enabled, fallback to current external standings fetch.
+4. Update `edit-team.html` to persist minimal standings config controls.
+5. Run targeted vitest for new tests and existing league standings tests.

--- a/docs/pr-notes/runs/issue-177-fixer-20260305T052537Z/qa.md
+++ b/docs/pr-notes/runs/issue-177-fixer-20260305T052537Z/qa.md
@@ -1,0 +1,17 @@
+# QA Role (fallback synthesis)
+
+## Test strategy
+- Unit tests for standings engine sorting behavior:
+  - rank by points mode
+  - rank by win percentage mode
+  - ordered tiebreaker precedence
+  - deterministic fallback ordering
+- Regression check existing `league-standings.test.js` external parser tests.
+
+## Manual validation
+- Team page with `standingsConfig.enabled=true` and sample completed games shows internal standings.
+- Team page with disabled config still uses external standings card/link.
+
+## Risks
+- Historical game docs may have missing/variant score fields.
+- Tie logic can regress silently without tests; require explicit tiebreaker coverage.

--- a/docs/pr-notes/runs/issue-177-fixer-20260305T052537Z/requirements.md
+++ b/docs/pr-notes/runs/issue-177-fixer-20260305T052537Z/requirements.md
@@ -1,0 +1,17 @@
+# Requirements Role (fallback synthesis)
+
+## Objective
+Deliver native standings from internal game data with configurable ranking mode and ordered tiebreakers, while preserving existing external `leagueUrl` behavior as fallback.
+
+## User-facing requirements
+- Team admin can configure standings behavior in team settings:
+  - ranking mode: `points` or `win_pct`
+  - ordered tiebreakers list
+- Team page shows standings computed from internal finalized games when native standings is enabled.
+- If native standings is not enabled or no internal data is available, continue existing external standings snapshot behavior.
+
+## Acceptance criteria
+- Deterministic standings order for identical inputs.
+- Ranking mode affects primary sort key.
+- Ordered tiebreakers are applied in provided order.
+- Existing external standings flow remains intact.

--- a/edit-team.html
+++ b/edit-team.html
@@ -96,6 +96,33 @@
                     <p class="text-xs text-gray-500 mt-1">Used to display external league standings (W/L/T) on the team page.</p>
                 </div>
 
+                <div class="rounded-lg border border-gray-200 p-4 space-y-3">
+                    <div class="flex items-start">
+                        <div class="flex items-center h-5">
+                            <input id="standingsEnabled" type="checkbox"
+                                class="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded">
+                        </div>
+                        <div class="ml-3 text-sm">
+                            <label for="standingsEnabled" class="font-medium text-gray-700">Enable Native Standings</label>
+                            <p class="text-gray-500">Compute standings from completed in-app games.</p>
+                        </div>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">Standings Ranking Mode</label>
+                        <select id="standingsRankingMode"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2">
+                            <option value="points">Total points</option>
+                            <option value="win_pct">Win percentage</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">Tiebreakers (ordered, comma-separated)</label>
+                        <input type="text" id="standingsTiebreakers"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2"
+                            placeholder="head_to_head, point_diff, points_for, fewest_points_against, name">
+                    </div>
+                </div>
+
                 <div>
                     <label class="block text-sm font-medium text-gray-700">
                         Live Stream <span class="font-normal text-gray-400">(optional)</span>
@@ -280,6 +307,11 @@
                     document.getElementById('sport').value = team.sport || '';
                     document.getElementById('notificationEmail').value = team.notificationEmail || '';
                     document.getElementById('leagueUrl').value = team.leagueUrl || '';
+                    document.getElementById('standingsEnabled').checked = team.standingsConfig?.enabled === true;
+                    document.getElementById('standingsRankingMode').value = team.standingsConfig?.rankingMode === 'win_pct' ? 'win_pct' : 'points';
+                    document.getElementById('standingsTiebreakers').value = Array.isArray(team.standingsConfig?.tiebreakers)
+                        ? team.standingsConfig.tiebreakers.join(', ')
+                        : '';
                     document.getElementById('zip').value = team.zip || '';
                     document.getElementById('isPublic').checked = team.isPublic !== false; // Default to true
                     // Populate Live Stream field from twitchChannel, streamEmbedUrl, or legacy youtubeEmbedUrl
@@ -571,6 +603,10 @@
                 const zipRaw = document.getElementById('zip').value.trim();
                 const zipDigits = zipRaw ? zipRaw.replace(/[^0-9]/g, '') : '';
                 const zip = zipDigits.length >= 5 ? zipDigits.slice(0, 9) : '';
+                const standingsTiebreakers = document.getElementById('standingsTiebreakers').value
+                    .split(',')
+                    .map((value) => value.trim())
+                    .filter(Boolean);
 
                 const teamData = {
                     name: document.getElementById('name').value,
@@ -578,6 +614,11 @@
                     sport: document.getElementById('sport').value,
                     notificationEmail: document.getElementById('notificationEmail').value,
                     leagueUrl: document.getElementById('leagueUrl').value.trim(),
+                    standingsConfig: {
+                        enabled: document.getElementById('standingsEnabled').checked,
+                        rankingMode: document.getElementById('standingsRankingMode').value === 'win_pct' ? 'win_pct' : 'points',
+                        tiebreakers: standingsTiebreakers
+                    },
                     zip,
                     photoUrl: currentPhotoUrl,
                     isPublic: document.getElementById('isPublic').checked,

--- a/js/native-standings.js
+++ b/js/native-standings.js
@@ -1,0 +1,179 @@
+function toInt(value) {
+    const n = Number.parseInt(String(value ?? ''), 10);
+    return Number.isFinite(n) ? n : 0;
+}
+
+function normalizeTeamName(value) {
+    return String(value || '').trim();
+}
+
+function safeRankingMode(value) {
+    return value === 'win_pct' ? 'win_pct' : 'points';
+}
+
+function safePointsSchema(points) {
+    const source = points && typeof points === 'object' ? points : {};
+    return {
+        win: toInt(source.win ?? 3),
+        tie: toInt(source.tie ?? 1),
+        loss: toInt(source.loss ?? 0)
+    };
+}
+
+function safeTiebreakers(list) {
+    const defaults = ['head_to_head', 'point_diff', 'points_for', 'fewest_points_against', 'name'];
+    if (!Array.isArray(list) || list.length === 0) return defaults;
+    return list
+        .map((item) => String(item || '').trim())
+        .filter(Boolean);
+}
+
+function compareNumbersDesc(a, b) {
+    if (a === b) return 0;
+    return a > b ? -1 : 1;
+}
+
+function compareNumbersAsc(a, b) {
+    if (a === b) return 0;
+    return a < b ? -1 : 1;
+}
+
+function getHeadToHeadSummary(games, teamA, teamB) {
+    let winsA = 0;
+    let winsB = 0;
+    let ties = 0;
+
+    for (const game of games) {
+        if (!game) continue;
+        const homeTeam = normalizeTeamName(game.homeTeam);
+        const awayTeam = normalizeTeamName(game.awayTeam);
+        const involvesPair = (homeTeam === teamA && awayTeam === teamB) || (homeTeam === teamB && awayTeam === teamA);
+        if (!involvesPair) continue;
+
+        const homeScore = Number(game.homeScore);
+        const awayScore = Number(game.awayScore);
+        if (!Number.isFinite(homeScore) || !Number.isFinite(awayScore)) continue;
+
+        if (homeScore === awayScore) {
+            ties += 1;
+            continue;
+        }
+
+        const homeWon = homeScore > awayScore;
+        const winner = homeWon ? homeTeam : awayTeam;
+        if (winner === teamA) winsA += 1;
+        if (winner === teamB) winsB += 1;
+    }
+
+    const total = winsA + winsB + ties;
+    if (total === 0) return null;
+    return {
+        teamAWinPct: (winsA + ties * 0.5) / total,
+        teamBWinPct: (winsB + ties * 0.5) / total
+    };
+}
+
+function compareByTiebreaker(tiebreaker, a, b, allGames) {
+    if (tiebreaker === 'head_to_head') {
+        const hh = getHeadToHeadSummary(allGames, a.team, b.team);
+        if (!hh) return 0;
+        return compareNumbersDesc(hh.teamAWinPct, hh.teamBWinPct);
+    }
+    if (tiebreaker === 'point_diff') return compareNumbersDesc(a.pd, b.pd);
+    if (tiebreaker === 'points_for') return compareNumbersDesc(a.pf, b.pf);
+    if (tiebreaker === 'fewest_points_against') return compareNumbersAsc(a.pa, b.pa);
+    if (tiebreaker === 'wins') return compareNumbersDesc(a.w, b.w);
+    if (tiebreaker === 'name') return a.team.localeCompare(b.team);
+    return 0;
+}
+
+function buildRecordString(entry) {
+    return entry.t > 0 ? `${entry.w}-${entry.l}-${entry.t}` : `${entry.w}-${entry.l}`;
+}
+
+export function computeNativeStandings(gamesInput, configInput = {}) {
+    const games = Array.isArray(gamesInput) ? gamesInput : [];
+    const rankingMode = safeRankingMode(configInput.rankingMode);
+    const pointsSchema = safePointsSchema(configInput.points);
+    const tiebreakers = safeTiebreakers(configInput.tiebreakers);
+
+    const tableByTeam = new Map();
+
+    for (const game of games) {
+        const status = String(game?.status || '').toLowerCase();
+        if (status && status !== 'completed' && status !== 'final') continue;
+
+        const homeTeam = normalizeTeamName(game?.homeTeam);
+        const awayTeam = normalizeTeamName(game?.awayTeam);
+        const homeScore = Number(game?.homeScore);
+        const awayScore = Number(game?.awayScore);
+
+        if (!homeTeam || !awayTeam) continue;
+        if (!Number.isFinite(homeScore) || !Number.isFinite(awayScore)) continue;
+
+        if (!tableByTeam.has(homeTeam)) {
+            tableByTeam.set(homeTeam, { team: homeTeam, gp: 0, w: 0, l: 0, t: 0, pf: 0, pa: 0, pd: 0, points: 0 });
+        }
+        if (!tableByTeam.has(awayTeam)) {
+            tableByTeam.set(awayTeam, { team: awayTeam, gp: 0, w: 0, l: 0, t: 0, pf: 0, pa: 0, pd: 0, points: 0 });
+        }
+
+        const homeEntry = tableByTeam.get(homeTeam);
+        const awayEntry = tableByTeam.get(awayTeam);
+
+        homeEntry.gp += 1;
+        awayEntry.gp += 1;
+        homeEntry.pf += homeScore;
+        homeEntry.pa += awayScore;
+        awayEntry.pf += awayScore;
+        awayEntry.pa += homeScore;
+
+        if (homeScore > awayScore) {
+            homeEntry.w += 1;
+            awayEntry.l += 1;
+            homeEntry.points += pointsSchema.win;
+            awayEntry.points += pointsSchema.loss;
+        } else if (homeScore < awayScore) {
+            awayEntry.w += 1;
+            homeEntry.l += 1;
+            awayEntry.points += pointsSchema.win;
+            homeEntry.points += pointsSchema.loss;
+        } else {
+            homeEntry.t += 1;
+            awayEntry.t += 1;
+            homeEntry.points += pointsSchema.tie;
+            awayEntry.points += pointsSchema.tie;
+        }
+    }
+
+    const table = Array.from(tableByTeam.values()).map((entry) => {
+        const gp = entry.gp || 0;
+        const winPct = gp > 0 ? (entry.w + (entry.t * 0.5)) / gp : 0;
+        const pd = entry.pf - entry.pa;
+        return {
+            ...entry,
+            pd,
+            winPct,
+            record: buildRecordString(entry)
+        };
+    });
+
+    table.sort((a, b) => {
+        const primary = rankingMode === 'win_pct'
+            ? compareNumbersDesc(a.winPct, b.winPct)
+            : compareNumbersDesc(a.points, b.points);
+        if (primary !== 0) return primary;
+
+        for (const tiebreaker of tiebreakers) {
+            const decision = compareByTiebreaker(tiebreaker, a, b, games);
+            if (decision !== 0) return decision;
+        }
+
+        return a.team.localeCompare(b.team);
+    });
+
+    return table.map((row, index) => ({
+        ...row,
+        rank: index + 1
+    }));
+}

--- a/js/native-standings.js
+++ b/js/native-standings.js
@@ -38,6 +38,11 @@ function compareNumbersAsc(a, b) {
     return a < b ? -1 : 1;
 }
 
+function isFinalGameStatus(game) {
+    const status = String(game?.status || '').toLowerCase();
+    return status === 'completed' || status === 'final';
+}
+
 function getHeadToHeadSummary(games, teamA, teamB) {
     let winsA = 0;
     let winsB = 0;
@@ -93,16 +98,14 @@ function buildRecordString(entry) {
 
 export function computeNativeStandings(gamesInput, configInput = {}) {
     const games = Array.isArray(gamesInput) ? gamesInput : [];
+    const completedGames = games.filter(isFinalGameStatus);
     const rankingMode = safeRankingMode(configInput.rankingMode);
     const pointsSchema = safePointsSchema(configInput.points);
     const tiebreakers = safeTiebreakers(configInput.tiebreakers);
 
     const tableByTeam = new Map();
 
-    for (const game of games) {
-        const status = String(game?.status || '').toLowerCase();
-        if (status && status !== 'completed' && status !== 'final') continue;
-
+    for (const game of completedGames) {
         const homeTeam = normalizeTeamName(game?.homeTeam);
         const awayTeam = normalizeTeamName(game?.awayTeam);
         const homeScore = Number(game?.homeScore);
@@ -165,7 +168,7 @@ export function computeNativeStandings(gamesInput, configInput = {}) {
         if (primary !== 0) return primary;
 
         for (const tiebreaker of tiebreakers) {
-            const decision = compareByTiebreaker(tiebreaker, a, b, games);
+            const decision = compareByTiebreaker(tiebreaker, a, b, completedGames);
             if (decision !== 0) return decision;
         }
 

--- a/team.html
+++ b/team.html
@@ -330,13 +330,17 @@
 
             const leagueGames = (Array.isArray(dbGames) ? dbGames : [])
                 .filter((game) => game?.type !== 'practice')
-                .map((game) => ({
-                    homeTeam: teamName,
-                    awayTeam: String(game?.opponent || '').trim(),
-                    homeScore: game?.homeScore,
-                    awayScore: game?.awayScore,
-                    status: game?.status
-                }));
+                .map((game) => {
+                    const opponent = String(game?.opponent || '').trim();
+                    const isHome = game?.isHome !== false;
+                    return {
+                        homeTeam: isHome ? teamName : opponent,
+                        awayTeam: isHome ? opponent : teamName,
+                        homeScore: game?.homeScore,
+                        awayScore: game?.awayScore,
+                        status: game?.status
+                    };
+                });
 
             const rows = computeNativeStandings(leagueGames, standingsConfig);
             const match = rows.find((row) => row.team === teamName) || rows[0] || null;

--- a/team.html
+++ b/team.html
@@ -233,6 +233,7 @@
         import { getTeam, getPlayers, getGames, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile } from './js/db.js?v=14';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';
+        import { computeNativeStandings } from './js/native-standings.js?v=1';
         import { calculateSeasonRecord, listSeasonLabels } from './js/season-record.js';
         import { checkAuth } from './js/auth.js?v=9';
         import { collection, getDocs } from "./js/firebase.js?v=9";
@@ -317,6 +318,55 @@
                 </div>
                 <div class="text-xs text-gray-500">PF ${row.pf} · PA ${row.pa} · PD ${row.pd}</div>
                 <a class="text-xs text-primary-600 hover:underline mt-2 inline-block" target="_blank" rel="noopener noreferrer" href="${sourceUrl}">Open league page</a>
+            `;
+        }
+
+        function buildNativeStandingsSnapshot(team, dbGames) {
+            const standingsConfig = team?.standingsConfig || {};
+            if (!standingsConfig.enabled) return null;
+
+            const teamName = String(team?.name || '').trim();
+            if (!teamName) return null;
+
+            const leagueGames = (Array.isArray(dbGames) ? dbGames : [])
+                .filter((game) => game?.type !== 'practice')
+                .map((game) => ({
+                    homeTeam: teamName,
+                    awayTeam: String(game?.opponent || '').trim(),
+                    homeScore: game?.homeScore,
+                    awayScore: game?.awayScore,
+                    status: game?.status
+                }));
+
+            const rows = computeNativeStandings(leagueGames, standingsConfig);
+            const match = rows.find((row) => row.team === teamName) || rows[0] || null;
+
+            return {
+                ok: rows.length > 0,
+                rows,
+                match,
+                config: standingsConfig
+            };
+        }
+
+        function renderNativeStandingsOverviewBody(snapshot) {
+            if (!snapshot || !snapshot.ok || !snapshot.match) {
+                return '<p class="text-sm text-gray-500">No completed games yet for native standings</p>';
+            }
+
+            const row = snapshot.match;
+            const mode = snapshot.config?.rankingMode === 'win_pct' ? 'Win %' : 'Points';
+            const rankLabel = typeof row.rank === 'number' ? `#${row.rank}` : 'N/A';
+
+            return `
+                <div class="mb-2">
+                    <div class="text-2xl md:text-3xl font-bold text-gray-900">${escapeHtml(row.record)}</div>
+                    <div class="text-xs text-gray-600">${escapeHtml(row.team)} • ${escapeHtml(rankLabel)} • ${escapeHtml(mode)}</div>
+                </div>
+                <div class="text-xs text-gray-500">
+                    PTS ${Number(row.points) || 0} · PCT ${(Number(row.winPct) || 0).toFixed(3)} · PF ${Number(row.pf) || 0} · PA ${Number(row.pa) || 0} · PD ${Number(row.pd) || 0}
+                </div>
+                <div class="text-xs text-gray-400 mt-2">Computed from completed in-app games</div>
             `;
         }
 
@@ -716,9 +766,12 @@
                 const totalGames = seasonMeta.totalGames;
                 const winPercentage = seasonMeta.winPercentage;
                 const record = seasonMeta.record;
-                const leagueSnapshot = team.leagueUrl
-                    ? await fetchLeagueStandings(team.leagueUrl, { teamName: team.name })
-                    : { ok: false, reason: 'missing-url', rows: [], match: null };
+                const nativeStandingsSnapshot = buildNativeStandingsSnapshot(team, dbGames);
+                const leagueSnapshot = (nativeStandingsSnapshot && nativeStandingsSnapshot.ok)
+                    ? null
+                    : (team.leagueUrl
+                        ? await fetchLeagueStandings(team.leagueUrl, { teamName: team.name })
+                        : { ok: false, reason: 'missing-url', rows: [], match: null });
 
                 // Fetch calendar events and render schedule
                 await renderSchedule(team, dbGames);
@@ -785,7 +838,9 @@
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 17v-5m3 5V7m3 10v-3m4 8H5a2 2 0 01-2-2V4a2 2 0 012-2h14a2 2 0 012 2v16a2 2 0 01-2 2z"></path>
                             </svg>
                         </div>
-                        ${renderLeagueOverviewBody(leagueSnapshot, team)}
+                        ${(nativeStandingsSnapshot && nativeStandingsSnapshot.ok)
+                            ? renderNativeStandingsOverviewBody(nativeStandingsSnapshot)
+                            : renderLeagueOverviewBody(leagueSnapshot, team)}
                     </div>
                 `;
 

--- a/tests/unit/native-standings.test.js
+++ b/tests/unit/native-standings.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { computeNativeStandings } from '../../js/native-standings.js';
+
+const SAMPLE_GAMES = [
+  { homeTeam: 'Tigers', awayTeam: 'Lions', homeScore: 10, awayScore: 7, status: 'completed' },
+  { homeTeam: 'Lions', awayTeam: 'Bears', homeScore: 14, awayScore: 3, status: 'completed' },
+  { homeTeam: 'Bears', awayTeam: 'Tigers', homeScore: 12, awayScore: 2, status: 'completed' },
+  { homeTeam: 'Tigers', awayTeam: 'Bears', homeScore: 8, awayScore: 8, status: 'completed' }
+];
+
+describe('computeNativeStandings', () => {
+  it('ranks by points when ranking mode is points', () => {
+    const table = computeNativeStandings(SAMPLE_GAMES, {
+      rankingMode: 'points',
+      points: { win: 3, tie: 1, loss: 0 }
+    });
+
+    expect(table.map((row) => row.team)).toEqual(['Bears', 'Tigers', 'Lions']);
+    expect(table[0]).toMatchObject({ points: 4, record: '1-1-1' });
+    expect(table[1]).toMatchObject({ points: 4, record: '1-1-1' });
+    expect(table[2]).toMatchObject({ points: 3, record: '1-1' });
+  });
+
+  it('ranks by win percentage when ranking mode is win_pct', () => {
+    const table = computeNativeStandings(SAMPLE_GAMES, {
+      rankingMode: 'win_pct',
+      tiebreakers: ['point_diff']
+    });
+
+    expect(table.map((row) => row.team)).toEqual(['Lions', 'Bears', 'Tigers']);
+    expect(table[0].winPct).toBeCloseTo(0.5, 5);
+    expect(table[1].winPct).toBeCloseTo(0.5, 5);
+  });
+
+  it('applies ordered tiebreakers in order', () => {
+    const games = [
+      { homeTeam: 'Alpha', awayTeam: 'Bravo', homeScore: 10, awayScore: 7, status: 'completed' },
+      { homeTeam: 'Bravo', awayTeam: 'Alpha', homeScore: 30, awayScore: 0, status: 'completed' },
+      { homeTeam: 'Alpha', awayTeam: 'Comets', homeScore: 21, awayScore: 7, status: 'completed' },
+      { homeTeam: 'Bravo', awayTeam: 'Comets', homeScore: 14, awayScore: 0, status: 'completed' }
+    ];
+
+    const table = computeNativeStandings(games, {
+      rankingMode: 'points',
+      points: { win: 2, tie: 1, loss: 0 },
+      tiebreakers: ['head_to_head', 'point_diff', 'name']
+    });
+
+    expect(table[0].team).toBe('Bravo');
+    expect(table[1].team).toBe('Alpha');
+    expect(table[0].points).toBe(table[1].points);
+  });
+
+  it('returns deterministic name ordering as final fallback', () => {
+    const games = [
+      { homeTeam: 'Beta', awayTeam: 'Alpha', homeScore: 7, awayScore: 7, status: 'completed' }
+    ];
+
+    const table = computeNativeStandings(games, {
+      rankingMode: 'points',
+      points: { win: 2, tie: 1, loss: 0 },
+      tiebreakers: []
+    });
+
+    expect(table.map((row) => row.team)).toEqual(['Alpha', 'Beta']);
+  });
+});

--- a/tests/unit/native-standings.test.js
+++ b/tests/unit/native-standings.test.js
@@ -64,4 +64,37 @@ describe('computeNativeStandings', () => {
 
     expect(table.map((row) => row.team)).toEqual(['Alpha', 'Beta']);
   });
+
+  it('counts only explicitly completed or final games', () => {
+    const games = [
+      { homeTeam: 'Alpha', awayTeam: 'Bravo', homeScore: 3, awayScore: 0, status: 'completed' },
+      { homeTeam: 'Alpha', awayTeam: 'Bravo', homeScore: 0, awayScore: 0 }
+    ];
+
+    const table = computeNativeStandings(games, {
+      rankingMode: 'points',
+      points: { win: 3, tie: 1, loss: 0 }
+    });
+
+    expect(table.find((row) => row.team === 'Alpha')).toMatchObject({ gp: 1, points: 3, record: '1-0' });
+    expect(table.find((row) => row.team === 'Bravo')).toMatchObject({ gp: 1, points: 0, record: '0-1' });
+  });
+
+  it('uses only completed games for head-to-head tiebreakers', () => {
+    const games = [
+      { homeTeam: 'Alpha', awayTeam: 'Bravo', homeScore: 10, awayScore: 0, status: 'completed' },
+      { homeTeam: 'Alpha', awayTeam: 'Comets', homeScore: 8, awayScore: 1, status: 'completed' },
+      { homeTeam: 'Bravo', awayTeam: 'Comets', homeScore: 7, awayScore: 0, status: 'completed' },
+      { homeTeam: 'Bravo', awayTeam: 'Alpha', homeScore: 50, awayScore: 0, status: 'live' }
+    ];
+
+    const table = computeNativeStandings(games, {
+      rankingMode: 'points',
+      points: { win: 2, tie: 1, loss: 0 },
+      tiebreakers: ['head_to_head', 'point_diff', 'name']
+    });
+
+    expect(table[0].team).toBe('Alpha');
+    expect(table[1].team).toBe('Bravo');
+  });
 });


### PR DESCRIPTION
Closes #177

## What changed
- Added a new native standings engine in `js/native-standings.js` that computes standings from completed games and supports configurable ranking mode (`points` or `win_pct`), points schema, and ordered tiebreakers.
- Added unit coverage in `tests/unit/native-standings.test.js` for ranking mode behavior, ordered tiebreakers, and deterministic fallback ordering.
- Updated `team.html` to use native standings when `team.standingsConfig.enabled` is true, with existing external `leagueUrl` standings fetch preserved as fallback.
- Updated `edit-team.html` with minimal standings configuration controls (enable toggle, ranking mode, ordered tiebreakers) and persisted those settings to `team.standingsConfig`.
- Persisted required run-role analysis artifacts under `docs/pr-notes/runs/issue-177-fixer-20260305T052537Z/`.

## Why
This closes the standings feature gap by enabling in-app standings computation with configurable policy controls, while keeping current external-standings behavior intact for migration and safety.