### PR TITLE
Retry chat last-read when team chat view becomes active

### DIFF
--- a/docs/pr-notes/runs/181-remediator-20260305T083647Z/architecture.md
+++ b/docs/pr-notes/runs/181-remediator-20260305T083647Z/architecture.md
@@ -1,0 +1,9 @@
+# Architecture role (inline fallback)
+
+- Current state: `retryChatLastReadOnViewReturn()` can call `maybeUpdateChatLastRead()` immediately after focus/visibility return if cached messages exist.
+- Risk: Writes `Timestamp.now()` before delayed snapshot delivery, potentially suppressing unread counts for messages that arrive later with `createdAt <= chatLastRead`.
+- Proposed state: Add resume lifecycle flags in `team-chat.html`:
+  - mark pending freshness when returning to view
+  - clear pending only after next realtime snapshot callback
+  - allow retry only when pending is clear and at least one snapshot has loaded
+- Blast radius: Team chat page last-read update timing only.

--- a/docs/pr-notes/runs/181-remediator-20260305T083647Z/code-plan.md
+++ b/docs/pr-notes/runs/181-remediator-20260305T083647Z/code-plan.md
@@ -1,0 +1,10 @@
+# Code role plan (inline fallback)
+
+1. Extend `shouldRetryChatLastReadOnViewReturn` to require two new booleans:
+   - `hasLoadedSnapshot`
+   - `isAwaitingPostResumeSnapshot` (must be false)
+2. In `team-chat.html`, track resume freshness lifecycle with module-level flags and wire them into retry calls:
+   - set awaiting flag on visibility/focus return
+   - clear awaiting flag after realtime snapshot callback executes
+3. Update unit tests to cover the new gating behavior.
+4. Run targeted unit tests and commit.

--- a/docs/pr-notes/runs/181-remediator-20260305T083647Z/qa.md
+++ b/docs/pr-notes/runs/181-remediator-20260305T083647Z/qa.md
@@ -1,0 +1,7 @@
+# QA role (inline fallback)
+
+- Regression target: ensure existing active-view update behavior remains unchanged.
+- New checks:
+  - retry denied while waiting for post-resume snapshot
+  - retry allowed once snapshot is marked fresh and messages exist
+- Validation: run `npx vitest tests/unit/team-chat-last-read.test.js` (or closest available local command).

--- a/docs/pr-notes/runs/181-remediator-20260305T083647Z/requirements.md
+++ b/docs/pr-notes/runs/181-remediator-20260305T083647Z/requirements.md
@@ -1,0 +1,6 @@
+# Requirements role (inline fallback)
+
+- Objective: Prevent `chatLastRead` from advancing on focus/visibility return until a post-resume realtime snapshot confirms message state is current.
+- Constraint: Keep unread badge correctness when browser was background-throttled or offline and reconnecting.
+- Required behavior: Resume-triggered retry must be gated by a "snapshot fresh after resume" signal, not only `messages.length > 0`.
+- Scope: Minimal targeted change in team chat last-read lifecycle and related unit tests.

--- a/docs/pr-notes/runs/issue-160-fixer-20260305T082610Z/architecture.md
+++ b/docs/pr-notes/runs/issue-160-fixer-20260305T082610Z/architecture.md
@@ -1,0 +1,18 @@
+# Architecture Role (synthesized fallback)
+
+Skill/tool note: `allplays-architecture-expert` subagent spawn unavailable; synthesized here.
+
+## Root Cause Hypothesis
+Unread derivation depends on `users/{uid}.chatLastRead.{teamId}`. If realtime writes are skipped or missed during transient view-state changes, unread counts remain stale until another message snapshot triggers a write.
+
+## Minimal Safe Change
+- Add one helper in `js/team-chat-last-read.js` to decide lifecycle retry eligibility.
+- In `team-chat.html`, centralize last-read update into one guarded function and call it from:
+  - realtime snapshot callback (existing path)
+  - `window.focus`
+  - `document.visibilitychange` when visible
+
+## Controls Equivalence
+- Access control unchanged (same `updateChatLastRead` call and auth context).
+- Blast radius contained to one page and one helper module.
+- Rollback is single-file reversion if needed.

--- a/docs/pr-notes/runs/issue-160-fixer-20260305T082610Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-160-fixer-20260305T082610Z/code-plan.md
@@ -1,0 +1,19 @@
+# Code Role Plan (synthesized fallback)
+
+Skill/tool note: `allplays-code-expert` subagent spawn unavailable; synthesized here.
+
+## Planned Edits
+1. `tests/unit/team-chat-last-read.test.js`
+- Add tests for lifecycle retry predicate:
+  - returns true with active view + message presence
+  - returns false when no messages
+
+2. `js/team-chat-last-read.js`
+- Add `shouldRetryChatLastReadOnViewReturn` helper using existing active-view constraints plus message-presence.
+
+3. `team-chat.html`
+- Extract last-read write into shared guarded function.
+- Invoke on snapshot and on `focus`/`visibilitychange` (visible only).
+
+## Validation
+- Run targeted unit test file for team-chat last-read policy.

--- a/docs/pr-notes/runs/issue-160-fixer-20260305T082610Z/qa.md
+++ b/docs/pr-notes/runs/issue-160-fixer-20260305T082610Z/qa.md
@@ -1,0 +1,17 @@
+# QA Role (synthesized fallback)
+
+Skill/tool note: `allplays-qa-expert` subagent spawn unavailable; synthesized here.
+
+## Regression Guardrails
+- Unit test should assert lifecycle retry policy only marks read when:
+  - user exists
+  - team exists
+  - page visible
+  - window focused
+  - at least one message is present
+- Ensure negative cases remain blocked (hidden, unfocused, no messages).
+
+## Manual Validation Targets
+1. Open chat as User A, send new message from User B while A is viewing chat.
+2. Switch focus away/back, read message, navigate to dashboard.
+3. Confirm unread badge is cleared.

--- a/docs/pr-notes/runs/issue-160-fixer-20260305T082610Z/requirements.md
+++ b/docs/pr-notes/runs/issue-160-fixer-20260305T082610Z/requirements.md
@@ -1,0 +1,19 @@
+# Requirements Role (synthesized fallback)
+
+Skill/tool note: `allplays-orchestrator-playbook` and `sessions_spawn` are unavailable in this runtime, so this analysis is produced directly in the main lane.
+
+## Objective
+Ensure team chat unread badges clear when a user has actually seen incoming messages during the same chat session.
+
+## Current vs Proposed
+- Current: last-read updates on snapshot callbacks, but there is no explicit retry when the user returns focus/visibility after transient inactive state.
+- Proposed: keep snapshot updates and add active-view lifecycle retry so read-state advances once the user is actively viewing messages.
+
+## Risk Surface / Blast Radius
+- Scope limited to team chat page last-read behavior.
+- No Firestore schema/rules change.
+- Main risk: over-marking read when user is not actually viewing chat; mitigated by existing visibility/focus gates.
+
+## Success Criteria
+- Realtime messages viewed in chat do not remain unread on dashboard/team pages.
+- No regression for hidden/unfocused tab behavior.

--- a/js/team-chat-last-read.js
+++ b/js/team-chat-last-read.js
@@ -28,6 +28,8 @@ export function shouldUpdateChatLastRead({
  * @param {boolean} params.isPageVisible
  * @param {boolean} params.isWindowFocused
  * @param {boolean} params.hasMessages
+ * @param {boolean} params.hasLoadedSnapshot
+ * @param {boolean} params.isAwaitingPostResumeSnapshot
  * @returns {boolean}
  */
 export function shouldRetryChatLastReadOnViewReturn({
@@ -35,10 +37,14 @@ export function shouldRetryChatLastReadOnViewReturn({
     hasTeamId,
     isPageVisible,
     isWindowFocused,
-    hasMessages
+    hasMessages,
+    hasLoadedSnapshot,
+    isAwaitingPostResumeSnapshot
 }) {
     return Boolean(
         hasMessages &&
+        hasLoadedSnapshot &&
+        !isAwaitingPostResumeSnapshot &&
         shouldUpdateChatLastRead({
             hasCurrentUser,
             hasTeamId,

--- a/js/team-chat-last-read.js
+++ b/js/team-chat-last-read.js
@@ -18,3 +18,32 @@ export function shouldUpdateChatLastRead({
 }) {
     return Boolean(hasCurrentUser && hasTeamId && isPageVisible && isWindowFocused);
 }
+
+/**
+ * Decide whether chat last-read should be retried when the user returns to the chat view.
+ * This protects unread state when snapshot-time writes are missed and no new snapshot arrives.
+ * @param {Object} params
+ * @param {boolean} params.hasCurrentUser
+ * @param {boolean} params.hasTeamId
+ * @param {boolean} params.isPageVisible
+ * @param {boolean} params.isWindowFocused
+ * @param {boolean} params.hasMessages
+ * @returns {boolean}
+ */
+export function shouldRetryChatLastReadOnViewReturn({
+    hasCurrentUser,
+    hasTeamId,
+    isPageVisible,
+    isWindowFocused,
+    hasMessages
+}) {
+    return Boolean(
+        hasMessages &&
+        shouldUpdateChatLastRead({
+            hasCurrentUser,
+            hasTeamId,
+            isPageVisible,
+            isWindowFocused
+        })
+    );
+}

--- a/team-chat.html
+++ b/team-chat.html
@@ -184,7 +184,7 @@
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, uploadChatImage, toggleChatReaction } from './js/db.js?v=20';
-        import { shouldUpdateChatLastRead } from './js/team-chat-last-read.js?v=1';
+        import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from './js/team-chat-last-read.js?v=2';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { getAI, getGenerativeModel, GoogleAIBackend } from './js/vendor/firebase-ai.js';
         import { getApp } from './js/vendor/firebase-app.js';
@@ -496,21 +496,40 @@
                     scrollToBottom();
                 }
 
-                const isPageVisible = document.visibilityState === 'visible' && !document.hidden;
-                const isWindowFocused = document.hasFocus();
-
-                if (shouldUpdateChatLastRead({
-                    hasCurrentUser: Boolean(currentUser?.uid),
-                    hasTeamId: Boolean(teamId),
-                    isPageVisible,
-                    isWindowFocused
-                })) {
-                    updateChatLastRead(currentUser.uid, teamId).catch(err =>
-                        console.warn('Failed to update last read:', err)
-                    );
-                }
+                maybeUpdateChatLastRead();
                 pendingScrollToBottom = false;
             });
+        }
+
+        function maybeUpdateChatLastRead() {
+            const isPageVisible = document.visibilityState === 'visible' && !document.hidden;
+            const isWindowFocused = document.hasFocus();
+
+            if (shouldUpdateChatLastRead({
+                hasCurrentUser: Boolean(currentUser?.uid),
+                hasTeamId: Boolean(teamId),
+                isPageVisible,
+                isWindowFocused
+            })) {
+                updateChatLastRead(currentUser.uid, teamId).catch(err =>
+                    console.warn('Failed to update last read:', err)
+                );
+            }
+        }
+
+        function retryChatLastReadOnViewReturn() {
+            const isPageVisible = document.visibilityState === 'visible' && !document.hidden;
+            const isWindowFocused = document.hasFocus();
+
+            if (shouldRetryChatLastReadOnViewReturn({
+                hasCurrentUser: Boolean(currentUser?.uid),
+                hasTeamId: Boolean(teamId),
+                isPageVisible,
+                isWindowFocused,
+                hasMessages: messages.length > 0
+            })) {
+                maybeUpdateChatLastRead();
+            }
         }
 
         function renderMessages() {
@@ -1506,6 +1525,12 @@
                 }
             });
             document.addEventListener('touchend', () => window.endReactionLongPress(), { passive: true });
+            document.addEventListener('visibilitychange', () => {
+                if (document.visibilityState === 'visible') {
+                    retryChatLastReadOnViewReturn();
+                }
+            });
+            window.addEventListener('focus', retryChatLastReadOnViewReturn);
             window.addEventListener('beforeunload', stopVoiceCapture);
             sendBtn.disabled = true;
             updateComposerState();

--- a/team-chat.html
+++ b/team-chat.html
@@ -184,7 +184,7 @@
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, uploadChatImage, toggleChatReaction } from './js/db.js?v=20';
-        import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from './js/team-chat-last-read.js?v=2';
+        import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from './js/team-chat-last-read.js?v=3';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { getAI, getGenerativeModel, GoogleAIBackend } from './js/vendor/firebase-ai.js';
         import { getApp } from './js/vendor/firebase-app.js';
@@ -308,6 +308,7 @@
         let canModerate = false;
         let unsubscribeChat = null;
         let initialSnapshotLoaded = false;
+        let awaitingPostResumeSnapshot = false;
         let pendingScrollToBottom = false;
         let aiInFlight = false;
         let aiThinkingStartedAt = null;
@@ -496,6 +497,7 @@
                     scrollToBottom();
                 }
 
+                awaitingPostResumeSnapshot = false;
                 maybeUpdateChatLastRead();
                 pendingScrollToBottom = false;
             });
@@ -526,10 +528,17 @@
                 hasTeamId: Boolean(teamId),
                 isPageVisible,
                 isWindowFocused,
-                hasMessages: messages.length > 0
+                hasMessages: messages.length > 0,
+                hasLoadedSnapshot: initialSnapshotLoaded,
+                isAwaitingPostResumeSnapshot: awaitingPostResumeSnapshot
             })) {
                 maybeUpdateChatLastRead();
             }
+        }
+
+        function handleChatViewReturn() {
+            awaitingPostResumeSnapshot = initialSnapshotLoaded;
+            retryChatLastReadOnViewReturn();
         }
 
         function renderMessages() {
@@ -1527,10 +1536,10 @@
             document.addEventListener('touchend', () => window.endReactionLongPress(), { passive: true });
             document.addEventListener('visibilitychange', () => {
                 if (document.visibilityState === 'visible') {
-                    retryChatLastReadOnViewReturn();
+                    handleChatViewReturn();
                 }
             });
-            window.addEventListener('focus', retryChatLastReadOnViewReturn);
+            window.addEventListener('focus', handleChatViewReturn);
             window.addEventListener('beforeunload', stopVoiceCapture);
             sendBtn.disabled = true;
             updateComposerState();

--- a/tests/unit/team-chat-last-read.test.js
+++ b/tests/unit/team-chat-last-read.test.js
@@ -56,13 +56,15 @@ describe('team chat last-read snapshot policy', () => {
 });
 
 describe('team chat last-read lifecycle retry policy', () => {
-    it('retries last-read when user returns to an active chat view with messages loaded', () => {
+    it('retries last-read when user returns to an active chat view with a fresh loaded snapshot and messages', () => {
         expect(shouldRetryChatLastReadOnViewReturn({
             hasCurrentUser: true,
             hasTeamId: true,
             isPageVisible: true,
             isWindowFocused: true,
-            hasMessages: true
+            hasMessages: true,
+            hasLoadedSnapshot: true,
+            isAwaitingPostResumeSnapshot: false
         })).toBe(true);
     });
 
@@ -72,7 +74,33 @@ describe('team chat last-read lifecycle retry policy', () => {
             hasTeamId: true,
             isPageVisible: true,
             isWindowFocused: true,
-            hasMessages: false
+            hasMessages: false,
+            hasLoadedSnapshot: true,
+            isAwaitingPostResumeSnapshot: false
+        })).toBe(false);
+    });
+
+    it('does not retry last-read while waiting for post-resume snapshot freshness', () => {
+        expect(shouldRetryChatLastReadOnViewReturn({
+            hasCurrentUser: true,
+            hasTeamId: true,
+            isPageVisible: true,
+            isWindowFocused: true,
+            hasMessages: true,
+            hasLoadedSnapshot: true,
+            isAwaitingPostResumeSnapshot: true
+        })).toBe(false);
+    });
+
+    it('does not retry last-read before any realtime snapshot has loaded', () => {
+        expect(shouldRetryChatLastReadOnViewReturn({
+            hasCurrentUser: true,
+            hasTeamId: true,
+            isPageVisible: true,
+            isWindowFocused: true,
+            hasMessages: true,
+            hasLoadedSnapshot: false,
+            isAwaitingPostResumeSnapshot: false
         })).toBe(false);
     });
 });

--- a/tests/unit/team-chat-last-read.test.js
+++ b/tests/unit/team-chat-last-read.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { shouldUpdateChatLastRead } from '../../js/team-chat-last-read.js';
+import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from '../../js/team-chat-last-read.js';
 
 describe('team chat last-read snapshot policy', () => {
     it('updates last-read when user/team context exists and chat is actively visible/focused', () => {
@@ -51,6 +51,28 @@ describe('team chat last-read snapshot policy', () => {
         expect(shouldUpdateChatLastRead({
             hasCurrentUser: true,
             hasTeamId: true
+        })).toBe(false);
+    });
+});
+
+describe('team chat last-read lifecycle retry policy', () => {
+    it('retries last-read when user returns to an active chat view with messages loaded', () => {
+        expect(shouldRetryChatLastReadOnViewReturn({
+            hasCurrentUser: true,
+            hasTeamId: true,
+            isPageVisible: true,
+            isWindowFocused: true,
+            hasMessages: true
+        })).toBe(true);
+    });
+
+    it('does not retry last-read when no messages are loaded', () => {
+        expect(shouldRetryChatLastReadOnViewReturn({
+            hasCurrentUser: true,
+            hasTeamId: true,
+            isPageVisible: true,
+            isWindowFocused: true,
+            hasMessages: false
         })).toBe(false);
     });
 });


### PR DESCRIPTION
Closes #160

## What changed
- Added lifecycle retry logic for team chat last-read state so read markers can be advanced when the chat view becomes active again (window focus or tab visibility return).
- Kept the existing realtime snapshot last-read update path and centralized it behind a shared guard.
- Added regression tests for the new lifecycle retry policy in `tests/unit/team-chat-last-read.test.js`.
- Persisted required role-analysis artifacts for this run under `docs/pr-notes/runs/issue-160-fixer-20260305T082610Z/`.

## Why
Unread badges are derived from `chatLastRead`. If a realtime write is missed during transient view-state changes and no new snapshot arrives, unread counts can remain stale even after messages were seen. The lifecycle retry closes that gap while preserving active-view gating.

## Validation
- `pnpm dlx vitest run tests/unit/team-chat-last-read.test.js` (passes)
- New tests were run first and failed before implementation, then passed after the fix.