### PR TITLE
Ensure admin invite acceptance persists team admin access

### DIFF
--- a/docs/pr-notes/runs/issue-188-fixer-20260305T232608Z/architecture.md
+++ b/docs/pr-notes/runs/issue-188-fixer-20260305T232608Z/architecture.md
@@ -1,0 +1,18 @@
+# Architecture Role (fallback synthesis)
+
+## Note
+Requested skill/subagent lane `allplays-architecture-expert` was not available in this runtime. This is a main-lane synthesis.
+
+## Current state
+- `accept-invite-flow.js` prefers `redeemAdminInviteAtomically(validation.codeId, userId)`.
+- `js/db.js:redeemAdminInviteAtomically` resolves email from user profile or `auth.currentUser.email`.
+- If email resolution fails, function still marks code used and updates user profile but can skip team `adminEmails` write.
+
+## Proposed state
+- Pass `authEmail` from invite flow into atomic redemption.
+- In atomic redemption, resolve email from user profile, auth context, or provided invite-flow authEmail.
+- Fail closed if normalized email is unavailable before marking code used.
+
+## Why minimal
+- Two-file targeted change, no API surface change beyond optional arg.
+- Aligns with existing access model that requires `team.adminEmails` for full team-management access.

--- a/docs/pr-notes/runs/issue-188-fixer-20260305T232608Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-188-fixer-20260305T232608Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Role (fallback synthesis)
+
+## Note
+Requested skill/subagent lane `allplays-code-expert` was not available in this runtime. This is a main-lane synthesis.
+
+## Plan
+1. Add failing test asserting `createInviteProcessor` calls `redeemAdminInviteAtomically(codeId, userId, authEmail)`.
+2. Update `js/accept-invite-flow.js` to pass `authEmail` through.
+3. Update `js/db.js` `redeemAdminInviteAtomically` to accept optional `fallbackEmail`, require a normalized email, and throw before any write if absent.
+4. Run targeted unit tests for invite flow and admin invite persistence.
+5. Stage and commit with issue reference.

--- a/docs/pr-notes/runs/issue-188-fixer-20260305T232608Z/qa.md
+++ b/docs/pr-notes/runs/issue-188-fixer-20260305T232608Z/qa.md
@@ -1,0 +1,17 @@
+# QA Role (fallback synthesis)
+
+## Note
+Requested skill/subagent lane `allplays-qa-expert` was not available in this runtime. This is a main-lane synthesis.
+
+## Regression test strategy
+- Add unit test in `tests/unit/accept-invite-flow.test.js` proving `authEmail` is passed to atomic redemption path.
+- Existing flow-level tests already cover fallback non-atomic path updating `team.adminEmails`.
+
+## Manual checks
+- Invite existing user as admin.
+- Accept invite and confirm dashboard team visibility.
+- Confirm edit-team and edit-roster access.
+
+## Risk checks
+- Ensure no behavior change to parent invite path.
+- Ensure no behavior change to redirect destinations.

--- a/docs/pr-notes/runs/issue-188-fixer-20260305T232608Z/requirements.md
+++ b/docs/pr-notes/runs/issue-188-fixer-20260305T232608Z/requirements.md
@@ -1,0 +1,21 @@
+# Requirements Role (fallback synthesis)
+
+## Note
+Requested skill/subagent lane `allplays-requirements-expert` was not available in this runtime. This is a main-lane synthesis.
+
+## Objective
+Ensure accepting an admin invite always grants real team-management access.
+
+## User-visible acceptance criteria
+- After invite acceptance success, invited admin can open `edit-team.html#teamId=<teamId>`.
+- After invite acceptance success, invited admin can open `edit-roster.html#teamId=<teamId>`.
+- Team appears in dashboard/team lists that rely on `teams.adminEmails` queries.
+
+## Constraints
+- Keep fix minimal and isolated to invite acceptance persistence path.
+- Preserve existing success UX and redirect behavior.
+- Prefer fail-closed behavior if persistence prerequisites are missing.
+
+## Risks and blast radius
+- High user impact if team admin membership is not persisted.
+- Blast radius limited to admin invite acceptance flow.

--- a/js/accept-invite-flow.js
+++ b/js/accept-invite-flow.js
@@ -33,7 +33,7 @@ export async function processInviteCode(userId, code, deps, authEmail = null) {
 
     if (validation.type === 'admin_invite') {
         if (typeof redeemAdminInviteAtomically === 'function') {
-            const redeemResult = await redeemAdminInviteAtomically(validation.codeId, userId);
+            const redeemResult = await redeemAdminInviteAtomically(validation.codeId, userId, authEmail);
             return {
                 success: true,
                 message: `You've been added as an admin of ${redeemResult.teamName || 'the team'}!`,

--- a/js/db.js
+++ b/js/db.js
@@ -1029,7 +1029,7 @@ export async function redeemAdminInviteAtomicPersistence({
     }
 }
 
-export async function redeemAdminInviteAtomically(codeId, userId) {
+export async function redeemAdminInviteAtomically(codeId, userId, fallbackEmail = null) {
     return runTransaction(db, async (transaction) => {
         const codeRef = doc(db, "accessCodes", codeId);
         const codeSnap = await transaction.get(codeRef);
@@ -1070,13 +1070,14 @@ export async function redeemAdminInviteAtomically(codeId, userId) {
         const teamData = teamSnap.data() || {};
         const userData = userSnap.exists() ? (userSnap.data() || {}) : {};
         const authEmail = auth.currentUser?.email || '';
-        const userEmail = (userData.email || authEmail || '').toLowerCase().trim();
-
-        if (userEmail) {
-            transaction.set(teamRef, {
-                adminEmails: arrayUnion(userEmail)
-            }, { merge: true });
+        const userEmail = (userData.email || authEmail || fallbackEmail || '').toLowerCase().trim();
+        if (!userEmail) {
+            throw new Error('Unable to determine user email for admin invite');
         }
+
+        transaction.set(teamRef, {
+            adminEmails: arrayUnion(userEmail)
+        }, { merge: true });
 
         transaction.set(userRef, {
             coachOf: arrayUnion(teamId),

--- a/tests/unit/accept-invite-flow.test.js
+++ b/tests/unit/accept-invite-flow.test.js
@@ -20,12 +20,12 @@ describe('accept invite flow', () => {
         };
 
         const processInvite = createInviteProcessor(deps);
-        const result = await processInvite('user-1', 'ABCD1234');
+        const result = await processInvite('user-1', 'ABCD1234', 'Coach@Example.com');
 
         expect(result.success).toBe(true);
         expect(result.redirectUrl).toBe('dashboard.html');
         expect(result.message).toContain('Tigers');
-        expect(deps.redeemAdminInviteAtomically).toHaveBeenCalledWith('code-123', 'user-1');
+        expect(deps.redeemAdminInviteAtomically).toHaveBeenCalledWith('code-123', 'user-1', 'Coach@Example.com');
     });
 
     it('bubbles atomic admin redemption errors', async () => {


### PR DESCRIPTION
Closes #188

## What changed
- Updated `js/accept-invite-flow.js` to pass the authenticated invite email into atomic admin invite redemption.
- Updated `js/db.js` `redeemAdminInviteAtomically` to accept a fallback email, require a resolved normalized email, and fail closed if none is available before marking invite codes used.
- Added a regression assertion in `tests/unit/accept-invite-flow.test.js` to verify atomic redemption receives the invite/auth email from the accept flow.
- Added required role-analysis artifacts under `docs/pr-notes/runs/issue-188-fixer-20260305T232608Z/` (requirements, architecture, QA, code plan).

## Why
Admin invite acceptance could report success while skipping `teams.adminEmails` when user email resolution failed in the atomic path, which prevented actual team-management access. Passing the invite/auth email and failing closed on missing email ensures success only occurs when team admin membership can be persisted.

## Validation
- `pnpm dlx vitest run tests/unit/accept-invite-flow.test.js tests/unit/admin-invite-redemption.test.js tests/unit/admin-invite-atomic-persistence-guard.test.js`