### PR TITLE
Preserve sibling RSVPs on coach player overrides

### DIFF
--- a/docs/pr-notes/runs/issue-144-fixer-20260306T022517Z/architecture.md
+++ b/docs/pr-notes/runs/issue-144-fixer-20260306T022517Z/architecture.md
@@ -1,0 +1,24 @@
+# Architecture role (fallback synthesis)
+
+## Current state
+- `submitRsvp` writes aggregate parent RSVP doc keyed by `userId` with `playerIds[]`.
+- `submitRsvpForPlayer` writes per-player override doc keyed by `userId__playerId`.
+- Effective summary computation de-duplicates at player level via `computeEffectiveRsvpSummary`.
+- Override submit path currently deletes the legacy `userId` RSVP doc unconditionally.
+
+## Risk surface
+- Unconditional delete can remove sibling player statuses that still belong in summary.
+- Blast radius: RSVP summaries on calendar, parent dashboard, and game-day views.
+
+## Proposed state
+- Keep current summary de-duplication logic.
+- Narrow legacy cleanup in `submitRsvpForPlayer` to delete only true single-player legacy docs targeting the overridden player.
+- Preserve multi-player parent docs so sibling statuses remain intact.
+
+## Tradeoffs
+- Adds one read (`getDoc`) before optional cleanup delete.
+- Slightly higher write-path latency, but safer correctness semantics.
+
+## Control equivalence
+- Access control unchanged.
+- Data consistency improves with lower risk of status loss.

--- a/docs/pr-notes/runs/issue-144-fixer-20260306T022517Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-144-fixer-20260306T022517Z/code-plan.md
@@ -1,0 +1,16 @@
+# Code role (fallback synthesis)
+
+## Constraint note
+Requested `allplays-orchestrator-playbook` and role skills are not installed in this environment; proceeding with equivalent in-run synthesized role outputs.
+
+## Plan
+1. Add a small pure helper in RSVP domain to decide when legacy `userId` doc is safe to delete after per-player override.
+2. Add failing unit tests for that helper to encode sibling-preservation behavior.
+3. Wire helper into `submitRsvpForPlayer` cleanup path in `js/db.js`.
+4. Add/adjust RSVP summary regression test for override doc-id shape.
+5. Run targeted unit tests.
+6. Commit with issue reference.
+
+## Assumptions
+- Legacy cleanup is intended for stale single-player docs, not parent multi-player docs.
+- Existing summary de-duplication remains source of truth for one-player-one-status counting.

--- a/docs/pr-notes/runs/issue-144-fixer-20260306T022517Z/qa.md
+++ b/docs/pr-notes/runs/issue-144-fixer-20260306T022517Z/qa.md
@@ -1,0 +1,18 @@
+# QA role (fallback synthesis)
+
+## Primary regression to guard
+Coach per-player override must not remove sibling availability from parent multi-player RSVP.
+
+## Automated tests
+1. Add unit coverage for legacy cleanup predicate:
+   - Do not delete multi-player parent docs when overriding one child.
+   - Delete single-player legacy docs for same player.
+2. Extend RSVP summary tests to include parent aggregate doc + override doc-id shape (`uid__playerId`) and confirm one-player-one-bucket counting.
+
+## Manual validation checklist
+1. Parent (2 linked players) sets both to going for same event.
+2. Coach overrides one player to can't go in game day.
+3. Calendar and parent dashboard summary should show `1 going`, `1 can't go`, `0 maybe`, `0 no response` for 2-player roster.
+
+## Residual risk
+- Existing docs with missing/legacy player IDs still rely on fallback resolution path; covered by existing hydration tests but not expanded here.

--- a/docs/pr-notes/runs/issue-144-fixer-20260306T022517Z/requirements.md
+++ b/docs/pr-notes/runs/issue-144-fixer-20260306T022517Z/requirements.md
@@ -1,0 +1,24 @@
+# Requirements role (fallback synthesis)
+
+## Objective
+Ensure RSVP summaries remain mathematically correct when a coach overrides one child from a parent RSVP that includes multiple children.
+
+## User-visible failure
+- Parent marks two children as `going` in one RSVP doc.
+- Coach overrides one child to `not_going` via per-player controls.
+- Summary can become wrong if one child is counted twice or sibling status is dropped.
+
+## Expected behavior
+- Each roster player contributes to exactly one summary bucket.
+- A coach override replaces only that player's prior state.
+- Sibling players from the original parent RSVP remain represented.
+
+## Constraints
+- Minimal patch; avoid broad RSVP refactors.
+- Preserve existing parent + coach workflows.
+- Keep denormalized game `rsvpSummary` updates intact.
+
+## Acceptance criteria
+- Regression test covers parent multi-player RSVP + coach single-player override.
+- Summary after override is consistent (no over-counting, no sibling loss).
+- Existing RSVP summary unit tests still pass.

--- a/js/db.js
+++ b/js/db.js
@@ -33,7 +33,7 @@ import {
 import { imageStorage, ensureImageAuth, requireImageAuth } from './firebase-images.js?v=2';
 import { buildDrillDiagramUploadPaths } from './drill-upload-paths.js?v=1';
 import { isAccessCodeExpired } from './access-code-utils.js?v=1';
-import { buildCoachOverrideRsvpDocId } from './rsvp-doc-ids.js';
+import { buildCoachOverrideRsvpDocId, shouldDeleteLegacyRsvpForOverride } from './rsvp-doc-ids.js';
 import { computeEffectiveRsvpSummary } from './rsvp-summary.js?v=1';
 import {
     isTeamActive,
@@ -2794,7 +2794,15 @@ export async function submitRsvpForPlayer(teamId, gameId, userId, { displayName,
     });
     if (docId !== effectiveUserId) {
         const legacyRsvpRef = doc(db, `teams/${teamId}/games/${gameId}/rsvps`, effectiveUserId);
-        await deleteDoc(legacyRsvpRef);
+        let legacySnap = null;
+        try {
+            legacySnap = await getDoc(legacyRsvpRef);
+        } catch (err) {
+            if (err?.code !== 'permission-denied') throw err;
+        }
+        if (legacySnap?.exists() && shouldDeleteLegacyRsvpForOverride(legacySnap.data(), normalizedPlayerId)) {
+            await deleteDoc(legacyRsvpRef);
+        }
     }
 
     // Keep denormalized summary consistent with submitRsvp behavior.

--- a/js/rsvp-doc-ids.js
+++ b/js/rsvp-doc-ids.js
@@ -4,3 +4,30 @@ export function buildCoachOverrideRsvpDocId(userId, playerId) {
   if (!uid || !pid) return '';
   return `${uid}__${pid}`;
 }
+
+function extractLegacyPlayerIds(rsvp) {
+  const ids = [];
+  if (Array.isArray(rsvp?.playerIds)) {
+    rsvp.playerIds.forEach((id) => {
+      const normalized = String(id || '').trim();
+      if (normalized) ids.push(normalized);
+    });
+  }
+
+  const legacyPlayerId = String(rsvp?.playerId || '').trim();
+  if (legacyPlayerId) ids.push(legacyPlayerId);
+
+  const legacyChildId = String(rsvp?.childId || '').trim();
+  if (legacyChildId) ids.push(legacyChildId);
+
+  return Array.from(new Set(ids));
+}
+
+export function shouldDeleteLegacyRsvpForOverride(legacyRsvp, overridePlayerId) {
+  const normalizedOverridePlayerId = String(overridePlayerId || '').trim();
+  if (!normalizedOverridePlayerId || !legacyRsvp) return false;
+
+  const legacyPlayerIds = extractLegacyPlayerIds(legacyRsvp);
+  if (legacyPlayerIds.length !== 1) return false;
+  return legacyPlayerIds[0] === normalizedOverridePlayerId;
+}

--- a/tests/unit/rsvp-doc-ids.test.js
+++ b/tests/unit/rsvp-doc-ids.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildCoachOverrideRsvpDocId } from '../../js/rsvp-doc-ids.js';
+import { buildCoachOverrideRsvpDocId, shouldDeleteLegacyRsvpForOverride } from '../../js/rsvp-doc-ids.js';
 
 describe('rsvp doc id helpers', () => {
   it('builds player-specific override doc ids', () => {
@@ -9,5 +9,27 @@ describe('rsvp doc id helpers', () => {
   it('returns empty string when user or player id is missing', () => {
     expect(buildCoachOverrideRsvpDocId('', 'player456')).toBe('');
     expect(buildCoachOverrideRsvpDocId('coach123', '')).toBe('');
+  });
+
+  it('deletes only matching single-player legacy RSVP docs on override', () => {
+    expect(shouldDeleteLegacyRsvpForOverride(
+      { playerIds: ['player456'] },
+      'player456'
+    )).toBe(true);
+  });
+
+  it('keeps multi-player parent RSVP docs when overriding one player', () => {
+    expect(shouldDeleteLegacyRsvpForOverride(
+      { playerIds: ['player123', 'player456'] },
+      'player123'
+    )).toBe(false);
+  });
+
+  it('keeps non-matching or ambiguous legacy docs', () => {
+    expect(shouldDeleteLegacyRsvpForOverride(
+      { playerIds: ['player999'] },
+      'player456'
+    )).toBe(false);
+    expect(shouldDeleteLegacyRsvpForOverride({}, 'player456')).toBe(false);
   });
 });

--- a/tests/unit/rsvp-summary.test.js
+++ b/tests/unit/rsvp-summary.test.js
@@ -13,12 +13,14 @@ describe('effective RSVP summary', () => {
         const rosterIds = new Set(['p1', 'p2']);
         const rsvps = [
             {
+                id: 'parent-1',
                 userId: 'parent-1',
                 playerIds: ['p1', 'p2'],
                 response: 'going',
                 respondedAt: '2026-03-04T11:00:00.000Z'
             },
             {
+                id: 'parent-1__p1',
                 userId: 'coach-1',
                 playerIds: ['p1'],
                 response: 'not_going',


### PR DESCRIPTION
Closes #144

## What changed
- Added role-orchestration run artifacts for this fix in `docs/pr-notes/runs/issue-144-fixer-20260306T022517Z/`.
- Added `shouldDeleteLegacyRsvpForOverride` in `js/rsvp-doc-ids.js` to guard legacy RSVP cleanup so only matching single-player legacy docs are deleted.
- Updated `submitRsvpForPlayer` in `js/db.js` to read the legacy `userId` RSVP doc and delete it only when safe, instead of unconditionally deleting it.
- Expanded RSVP unit coverage in `tests/unit/rsvp-doc-ids.test.js` for multi-player parent RSVP preservation and cleanup edge cases.
- Updated `tests/unit/rsvp-summary.test.js` with parent/override doc-id shape in the overlap scenario.

## Why
The coach override path could delete a parent multi-player RSVP doc, which could drop sibling player availability and produce incorrect summaries across calendar/parent dashboard/game-day. This patch keeps sibling statuses intact while still allowing cleanup of true single-player legacy docs.

## Validation
- `pnpm dlx vitest run tests/unit/rsvp-doc-ids.test.js tests/unit/rsvp-summary.test.js`
- `pnpm dlx vitest run tests/unit/rsvp-hydration.test.js`