### PR TITLE
Restore saved lineup when resuming live tracker

### DIFF
--- a/docs/pr-notes/runs/issue-175-fixer-20260306T052529Z/architecture.md
+++ b/docs/pr-notes/runs/issue-175-fixer-20260306T052529Z/architecture.md
@@ -1,0 +1,27 @@
+Objective: fix lineup resume without broad tracker refactoring.
+
+Current architecture:
+- `js/live-tracker.js` owns tracker state initialization and Firestore persistence.
+- Small pure helpers already exist for resume clock state and opponent stat hydration.
+
+Proposed architecture:
+- Introduce a small pure helper for lineup restoration and sanitization.
+- Import it into `live-tracker.js` and apply it only when `shouldResume` is true.
+
+Why this path:
+- Keeps logic testable without DOM or Firebase mocks.
+- Matches existing repo pattern of extracting pure resume logic into dedicated modules.
+- Minimizes blast radius to one new helper, one new test file, and one call site in init.
+
+Controls:
+- Filter restored lineup to current roster IDs only.
+- De-duplicate player IDs.
+- Put any roster players not restored to `onCourt` onto `bench`.
+- Preserve explicit reset path behavior.
+
+Rollback:
+- Revert the helper import and the single resume assignment block.
+
+Evidence that would change this approach:
+- If another initialization step intentionally rebuilds lineup from a different canonical source after resume.
+- If saved `liveLineup` is known to be incomplete or untrusted relative to another persisted model.

--- a/docs/pr-notes/runs/issue-175-fixer-20260306T052529Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-175-fixer-20260306T052529Z/code-plan.md
@@ -1,0 +1,14 @@
+Thinking level: medium
+Reason: targeted bug with existing helper-based architecture and a clear persistence regression.
+
+Implementation plan:
+1. Add a unit test file for a new lineup-restore helper. Run it before implementation so it fails.
+2. Add `js/live-tracker-lineup.js` with a pure helper that restores and sanitizes persisted lineup state.
+3. Import the helper in `js/live-tracker.js` and apply it inside the `shouldResume` branch before render/init sync.
+4. Run targeted live-tracker unit tests, then the full unit suite if time and environment allow.
+5. Commit all source, tests, and role notes together with an issue-referencing message.
+
+Non-goals:
+- No UI refactor.
+- No changes to viewer-side lineup rendering.
+- No changes to substitution logic beyond resume initialization.

--- a/docs/pr-notes/runs/issue-175-fixer-20260306T052529Z/qa.md
+++ b/docs/pr-notes/runs/issue-175-fixer-20260306T052529Z/qa.md
@@ -1,0 +1,20 @@
+Regression target:
+- Resuming a tracked game must restore persisted `liveLineup` and must not overwrite it with empty arrays during init.
+
+Primary test guardrail:
+- Unit-test a pure lineup restore helper that accepts `liveLineup` plus roster and returns sanitized `onCourt` and `bench`.
+
+Cases to cover:
+- Restores valid saved `onCourt` and `bench`.
+- Removes duplicates and non-roster IDs.
+- Backfills missing players onto `bench`.
+- Falls back to empty `onCourt` and full-roster `bench` when persisted lineup is absent or invalid.
+
+Manual spot check after code change:
+1. Start a game, put players on court, and confirm lineup renders in tracker.
+2. Reload tracker and choose resume.
+3. Confirm on-court lineup remains populated.
+4. Confirm `live-game.html` still shows the same lineup after resume.
+
+Residual risk:
+- This unit coverage proves restore behavior, but not the full browser prompt/init sequence end-to-end.

--- a/docs/pr-notes/runs/issue-175-fixer-20260306T052529Z/requirements.md
+++ b/docs/pr-notes/runs/issue-175-fixer-20260306T052529Z/requirements.md
@@ -1,0 +1,29 @@
+Objective: preserve the saved live lineup when a coach resumes an in-progress game in `live-tracker.html`.
+
+Current state:
+- Resume restores scores, clock, and stats.
+- Resume does not restore `game.liveLineup`.
+- Tracker init then persists `state.onCourt=[]` and `state.bench=full roster`, wiping the saved lineup for all viewers.
+
+Proposed state:
+- When resuming, hydrate tracker lineup from persisted `game.liveLineup` if it exists.
+- Keep lineup IDs ordered by the current roster and ignore invalid player IDs.
+- Preserve current reset behavior for explicit "start over".
+
+Risk surface and blast radius:
+- High user impact today because resume can destroy live lineup context across tracker and viewer pages.
+- Fix should stay inside live-tracker resume initialization and lineup sanitization only.
+
+Assumptions:
+- `game.liveLineup` is the durable source of truth for viewer lineup state.
+- A valid basketball lineup may have fewer than 5 players if the saved state was partial.
+- Roster order is the expected display order for restored on-court and bench lists.
+
+Recommendation:
+- Add a pure helper that sanitizes and restores persisted lineup data.
+- Use it only in the resume path before the initial `updateGame(... liveLineup ...)` call.
+
+Success criteria:
+- Resume keeps prior `onCourt` and `bench` values instead of resetting them.
+- Initial sync after resume re-persists the restored lineup, not an empty one.
+- Invalid or duplicate IDs in saved lineup do not break tracker rendering.

--- a/js/live-tracker-lineup.js
+++ b/js/live-tracker-lineup.js
@@ -1,0 +1,24 @@
+export function restoreLiveLineup({ liveLineup, roster }) {
+    const rosterIds = (roster || []).map((player) => player?.id).filter(Boolean);
+    const rosterSet = new Set(rosterIds);
+    const seen = new Set();
+
+    const savedOnCourt = Array.isArray(liveLineup?.onCourt) ? liveLineup.onCourt : [];
+    const savedBench = Array.isArray(liveLineup?.bench) ? liveLineup.bench : [];
+
+    const keepPlayer = (playerId) => {
+        if (!rosterSet.has(playerId)) return false;
+        if (seen.has(playerId)) return false;
+        seen.add(playerId);
+        return true;
+    };
+
+    savedOnCourt.forEach((playerId) => keepPlayer(playerId));
+    const onCourtSet = new Set(seen);
+    const onCourt = rosterIds.filter((playerId) => onCourtSet.has(playerId));
+
+    savedBench.forEach((playerId) => keepPlayer(playerId));
+    const bench = rosterIds.filter((playerId) => !onCourtSet.has(playerId));
+
+    return { onCourt, bench };
+}

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -10,6 +10,7 @@ import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLi
 import { canApplySubstitution, applySubstitution, canTrustScoreLogForFinalization, reconcileFinalScoreFromLog, acquireSingleFlightLock, releaseSingleFlightLock } from './live-tracker-integrity.js?v=1';
 import { hydrateOpponentStats } from './live-tracker-opponent-stats.js?v=1';
 import { deriveResumeClockState } from './live-tracker-resume.js?v=2';
+import { restoreLiveLineup } from './live-tracker-lineup.js?v=1';
 import { resolveSummaryRecipient } from './live-tracker-email.js?v=1';
 
 let currentTeamId = null;
@@ -2428,6 +2429,13 @@ async function init() {
       }
 
       if (shouldResume) {
+        const restoredLineup = restoreLiveLineup({
+          liveLineup: game.liveLineup,
+          roster
+        });
+        state.onCourt = restoredLineup.onCourt;
+        state.bench = restoredLineup.bench;
+
         const statsSnapshot = await safeGetDocs(collection(db, `teams/${teamId}/games/${gameId}/aggregatedStats`), 'aggregatedStats');
         const hasAggregatedStats = statsSnapshot.size > 0;
         const liveEventsSnapshot = await safeGetDocs(collection(db, `teams/${teamId}/games/${gameId}/liveEvents`), 'liveEvents');

--- a/tests/unit/live-tracker-lineup.test.js
+++ b/tests/unit/live-tracker-lineup.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { restoreLiveLineup } from '../../js/live-tracker-lineup.js';
+
+describe('live tracker lineup restore', () => {
+  it('restores persisted liveLineup for resume flows', () => {
+    const roster = [
+      { id: 'p1' },
+      { id: 'p2' },
+      { id: 'p3' },
+      { id: 'p4' },
+      { id: 'p5' },
+      { id: 'p6' },
+      { id: 'p7' }
+    ];
+
+    expect(restoreLiveLineup({
+      liveLineup: {
+        onCourt: ['p3', 'p1', 'p5', 'p2', 'p4'],
+        bench: ['p6', 'p7']
+      },
+      roster
+    })).toEqual({
+      onCourt: ['p1', 'p2', 'p3', 'p4', 'p5'],
+      bench: ['p6', 'p7']
+    });
+  });
+
+  it('filters invalid ids, de-duplicates players, and backfills remaining roster to bench', () => {
+    const roster = [
+      { id: 'p1' },
+      { id: 'p2' },
+      { id: 'p3' },
+      { id: 'p4' }
+    ];
+
+    expect(restoreLiveLineup({
+      liveLineup: {
+        onCourt: ['p2', 'ghost', 'p2'],
+        bench: ['p4', 'p3', 'ghost', 'p4']
+      },
+      roster
+    })).toEqual({
+      onCourt: ['p2'],
+      bench: ['p1', 'p3', 'p4']
+    });
+  });
+
+  it('falls back to empty on-court and full roster bench when persisted lineup is missing', () => {
+    const roster = [
+      { id: 'p1' },
+      { id: 'p2' }
+    ];
+
+    expect(restoreLiveLineup({
+      liveLineup: null,
+      roster
+    })).toEqual({
+      onCourt: [],
+      bench: ['p1', 'p2']
+    });
+  });
+});


### PR DESCRIPTION
Closes #175

## What changed
- added a focused lineup restore helper for `live-tracker` resume flows that sanitizes persisted `liveLineup` data against the current roster
- updated `live-tracker` initialization to restore saved `onCourt` and `bench` state before the initial `liveLineup` sync runs
- added a regression test covering saved lineup restoration, invalid ID filtering, deduplication, and fallback behavior
- persisted the required run notes for requirements, architecture, QA, and code plan under `docs/pr-notes/runs/issue-175-fixer-20260306T052529Z/`

## Why
The tracker resume path rebuilt stats and clock state but never restored the saved lineup, then immediately overwrote `game.liveLineup` with an empty snapshot. This patch makes resume preserve the durable lineup state so tracker users and live viewers keep the correct on-court context after refresh or reopen.

## Validation
- failing-first check: `./node_modules/.bin/vitest run tests/unit/live-tracker-lineup.test.js` failed before implementation because the restore helper did not exist
- targeted validation: `./node_modules/.bin/vitest run tests/unit/live-tracker-lineup.test.js tests/unit/live-tracker-resume.test.js tests/unit/live-tracker-opponent-stats.test.js tests/unit/live-tracker-field-status.test.js`
- full validation: `./node_modules/.bin/vitest run tests/unit`