### PR TITLE
Fail closed admin invite redemption in accept flow

### DIFF
--- a/docs/pr-notes/runs/201-remediator-20260306T113119Z/architecture.md
+++ b/docs/pr-notes/runs/201-remediator-20260306T113119Z/architecture.md
@@ -1,0 +1,10 @@
+Current state:
+- `js/accept-invite-flow.js` is the caller boundary for the admin invite flow.
+- `js/db.js:redeemAdminInviteAtomically()` is still the transactional control point.
+
+Proposed state:
+- Add a caller-side contract check before using `redeemResult.teamName`.
+
+Blast radius:
+- Single branch inside `processInviteCode()`.
+- No schema, routing, or transaction changes.

--- a/docs/pr-notes/runs/201-remediator-20260306T113119Z/code-plan.md
+++ b/docs/pr-notes/runs/201-remediator-20260306T113119Z/code-plan.md
@@ -1,0 +1,7 @@
+Thinking level: low
+Reason: Single-thread review remediation with an existing unit test target.
+
+Plan:
+1. Guard `redeemResult` in `js/accept-invite-flow.js` before building the success response.
+2. Add a unit test for an invalid atomic redemption payload.
+3. Run the focused Vitest file and commit the scoped fix.

--- a/docs/pr-notes/runs/201-remediator-20260306T113119Z/qa.md
+++ b/docs/pr-notes/runs/201-remediator-20260306T113119Z/qa.md
@@ -1,0 +1,7 @@
+Validation target:
+- `tests/unit/accept-invite-flow.test.js`
+
+Checks:
+- Existing success path still returns dashboard redirect and team name.
+- Existing rejection path still bubbles transactional errors.
+- New regression proves malformed atomic results throw instead of returning a false success state.

--- a/docs/pr-notes/runs/201-remediator-20260306T113119Z/requirements.md
+++ b/docs/pr-notes/runs/201-remediator-20260306T113119Z/requirements.md
@@ -1,0 +1,9 @@
+Objective: Resolve PR #201 review feedback on admin invite redemption result validation.
+
+Current state:
+- `processInviteCode()` assumes `redeemAdminInviteAtomically()` returns a truthy success payload.
+- An empty or malformed object would still reach the success return path.
+
+Required change:
+- Fail closed unless the atomic redemption result exists and `success === true`.
+- Keep scope limited to the admin invite acceptance path and its regression coverage.

--- a/docs/pr-notes/runs/issue-191-fixer-20260306T112530Z/architecture.md
+++ b/docs/pr-notes/runs/issue-191-fixer-20260306T112530Z/architecture.md
@@ -1,0 +1,20 @@
+Objective: preserve one-time admin invite semantics by enforcing atomic redemption at the flow boundary.
+
+Current state:
+- Validation is read-only.
+- Consumption depends on the caller choosing the atomic helper.
+- A legacy fallback in `js/accept-invite-flow.js` can reintroduce non-atomic side effects.
+
+Proposed state:
+- `processInviteCode()` treats atomic admin redemption as mandatory.
+
+Blast radius comparison:
+- Before: any caller omitting the atomic dependency could grant coach access and leave the code reusable.
+- After: missing atomic wiring causes a controlled error before any privilege grant.
+
+Controls:
+- Single-write ownership remains in `redeemAdminInviteAtomically()` in `js/db.js`.
+- The flow layer enforces dependency presence instead of recreating persistence logic.
+
+Rollback:
+- Revert the single flow change and test if a caller unexpectedly depends on the fallback.

--- a/docs/pr-notes/runs/issue-191-fixer-20260306T112530Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-191-fixer-20260306T112530Z/code-plan.md
@@ -1,0 +1,5 @@
+Implementation plan:
+1. Update `tests/unit/accept-invite-flow.test.js` so missing atomic admin redemption is a failing condition instead of exercising the legacy fallback.
+2. Remove the non-atomic admin invite fallback from `js/accept-invite-flow.js`.
+3. Run targeted Vitest coverage for invite/admin redemption.
+4. Commit the scoped change referencing issue #191.

--- a/docs/pr-notes/runs/issue-191-fixer-20260306T112530Z/qa.md
+++ b/docs/pr-notes/runs/issue-191-fixer-20260306T112530Z/qa.md
@@ -1,0 +1,16 @@
+Test focus: regression guard for repeated admin invite redemption risk.
+
+Coverage added:
+- `tests/unit/accept-invite-flow.test.js`
+
+Cases:
+- Admin invite uses `redeemAdminInviteAtomically()` when available.
+- Admin invite errors propagate from the atomic helper.
+- Admin invite fails closed when atomic redemption is unavailable.
+- Validation failures do not trigger redemption.
+
+Manual risk notes:
+- Main production page already passes the atomic helper, so runtime behavior should remain unchanged except for unsupported misconfiguration cases.
+
+Validation command:
+- `npm test -- tests/unit/accept-invite-flow.test.js tests/unit/admin-invite-redemption.test.js tests/unit/admin-invite-atomic-persistence-guard.test.js`

--- a/docs/pr-notes/runs/issue-191-fixer-20260306T112530Z/requirements.md
+++ b/docs/pr-notes/runs/issue-191-fixer-20260306T112530Z/requirements.md
@@ -1,0 +1,25 @@
+Objective: ensure an admin invite code can grant coach access exactly once.
+
+Current state:
+- `accept-invite.html` uses the atomic redemption helper.
+- `js/accept-invite-flow.js` still contains a fallback path that grants access before consuming the code if the atomic helper is absent.
+
+Proposed state:
+- Admin invite redemption in the accept-invite flow fails closed unless the atomic redemption helper is available.
+
+Risk surface and blast radius:
+- Area is limited to admin invite redemption.
+- Failing closed is safer than allowing elevated access with non-atomic persistence.
+
+Assumptions:
+- `accept-invite.html` is the production caller and always provides `redeemAdminInviteAtomically`.
+- No supported caller relies on the legacy fallback behavior.
+
+Recommendation:
+- Remove the non-atomic fallback from `js/accept-invite-flow.js`.
+- Add a regression test that rejects admin invite processing when the atomic handler is missing.
+
+Success criteria:
+- Admin invite processing uses the atomic redemption callback when present.
+- Admin invite processing rejects when the atomic callback is missing.
+- Targeted invite-flow tests pass.

--- a/js/accept-invite-flow.js
+++ b/js/accept-invite-flow.js
@@ -32,51 +32,15 @@ export async function processInviteCode(userId, code, deps, authEmail = null) {
     }
 
     if (validation.type === 'admin_invite') {
-        if (typeof redeemAdminInviteAtomically === 'function') {
-            const redeemResult = await redeemAdminInviteAtomically(validation.codeId, userId, authEmail);
-            return {
-                success: true,
-                message: `You've been added as an admin of ${redeemResult.teamName || 'the team'}!`,
-                redirectUrl: 'dashboard.html'
-            };
+        if (typeof redeemAdminInviteAtomically !== 'function') {
+            throw new Error('Missing atomic admin invite redemption handler');
         }
 
-        const team = await getTeam(validation.data.teamId);
-        if (!team) {
-            throw new Error('Team not found');
-        }
-
-        const profile = await getUserProfile(userId);
-        const userEmail = profile?.email || authEmail || validation?.data?.email;
-        const adminEmails = Array.isArray(team.adminEmails) ? [...team.adminEmails] : [];
-        const normalizedEmail = userEmail ? userEmail.toLowerCase() : null;
-        const normalizedAdminEmails = adminEmails.map((email) => String(email || '').toLowerCase());
-
-        if (normalizedEmail && !normalizedAdminEmails.includes(normalizedEmail)) {
-            adminEmails.push(normalizedEmail);
-            await updateTeam(validation.data.teamId, {
-                adminEmails
-            });
-        }
-
-        const existingCoachOf = Array.isArray(profile?.coachOf) ? [...profile.coachOf] : [];
-        const mergedCoachOf = Array.from(new Set([...existingCoachOf, validation.data.teamId]));
-        const existingRoles = Array.isArray(profile?.roles) ? profile.roles : [];
-        const mergedRoles = existingRoles.includes('coach') ? existingRoles : [...existingRoles, 'coach'];
-
-        await updateUserProfile(userId, {
-            coachOf: mergedCoachOf,
-            roles: mergedRoles
-        });
-
-        if (!validation.codeId) {
-            throw new Error('Invite code record not found');
-        }
-        await markAccessCodeAsUsed(validation.codeId, userId);
+        const redeemResult = await redeemAdminInviteAtomically(validation.codeId, userId, authEmail);
 
         return {
             success: true,
-            message: `You've been added as an admin of ${team?.name || 'the team'}!`,
+            message: `You've been added as an admin of ${redeemResult.teamName || 'the team'}!`,
             redirectUrl: 'dashboard.html'
         };
     }

--- a/js/accept-invite-flow.js
+++ b/js/accept-invite-flow.js
@@ -37,6 +37,9 @@ export async function processInviteCode(userId, code, deps, authEmail = null) {
         }
 
         const redeemResult = await redeemAdminInviteAtomically(validation.codeId, userId, authEmail);
+        if (!redeemResult || !redeemResult.success) {
+            throw new Error('Failed to redeem admin invite atomically');
+        }
 
         return {
             success: true,

--- a/tests/unit/accept-invite-flow.test.js
+++ b/tests/unit/accept-invite-flow.test.js
@@ -46,7 +46,7 @@ describe('accept invite flow', () => {
         await expect(processInvite('user-1', 'ABCD1234')).rejects.toThrow('Code already used');
     });
 
-    it('falls back to profile + team updates when atomic redemption is unavailable', async () => {
+    it('fails closed when atomic admin redemption is unavailable', async () => {
         const deps = {
             validateAccessCode: vi.fn(async () => ({
                 valid: true,
@@ -67,14 +67,13 @@ describe('accept invite flow', () => {
         };
 
         const processInvite = createInviteProcessor(deps);
-        await processInvite('user-3', 'IJKL9012');
+        await expect(processInvite('user-3', 'IJKL9012')).rejects.toThrow(
+            'Missing atomic admin invite redemption handler'
+        );
 
-        expect(deps.updateTeam).toHaveBeenCalledWith('team-3', { adminEmails: ['other@example.com', 'coach@example.com'] });
-        expect(deps.updateUserProfile).toHaveBeenCalledWith('user-3', {
-            coachOf: ['team-1', 'team-3'],
-            roles: ['parent', 'coach']
-        });
-        expect(deps.markAccessCodeAsUsed).toHaveBeenCalledWith('code-125', 'user-3');
+        expect(deps.updateTeam).not.toHaveBeenCalled();
+        expect(deps.updateUserProfile).not.toHaveBeenCalled();
+        expect(deps.markAccessCodeAsUsed).not.toHaveBeenCalled();
     });
 
     it('does not mark code when validation fails', async () => {

--- a/tests/unit/accept-invite-flow.test.js
+++ b/tests/unit/accept-invite-flow.test.js
@@ -46,6 +46,26 @@ describe('accept invite flow', () => {
         await expect(processInvite('user-1', 'ABCD1234')).rejects.toThrow('Code already used');
     });
 
+    it('fails when atomic admin redemption returns an invalid result', async () => {
+        const deps = {
+            validateAccessCode: vi.fn(async () => ({
+                valid: true,
+                codeId: 'code-126',
+                type: 'admin_invite',
+                data: { teamId: 'team-4' }
+            })),
+            redeemParentInvite: vi.fn(),
+            getTeam: vi.fn(),
+            redeemAdminInviteAtomically: vi.fn().mockResolvedValue({})
+        };
+
+        const processInvite = createInviteProcessor(deps);
+
+        await expect(processInvite('user-4', 'MNOP3456')).rejects.toThrow(
+            'Failed to redeem admin invite atomically'
+        );
+    });
+
     it('fails closed when atomic admin redemption is unavailable', async () => {
         const deps = {
             validateAccessCode: vi.fn(async () => ({


### PR DESCRIPTION
Closes #191

## What changed
- removed the non-atomic admin invite fallback from `js/accept-invite-flow.js`
- require `redeemAdminInviteAtomically()` for admin invite processing in the accept-invite flow
- updated `tests/unit/accept-invite-flow.test.js` to prove the flow now fails closed when atomic redemption is unavailable
- added run notes under `docs/pr-notes/runs/issue-191-fixer-20260306T112530Z/`

## Why
The production accept-invite page already uses the atomic redemption helper, but the shared flow module still contained a legacy fallback that could grant coach/admin access before consuming the invite code if that helper was omitted. Removing that fallback preserves the one-time invite invariant and prevents this bug class from resurfacing through miswired callers.

## Validation
- `./node_modules/.bin/vitest run tests/unit/accept-invite-flow.test.js`
- `./node_modules/.bin/vitest run tests/unit/admin-invite-redemption.test.js tests/unit/admin-invite-atomic-persistence-guard.test.js`