### PR TITLE
Fix schedule datetime-local timezone drift

### DIFF
--- a/docs/pr-notes/runs/issue-203-fixer-20260306T142619Z/architecture.md
+++ b/docs/pr-notes/runs/issue-203-fixer-20260306T142619Z/architecture.md
@@ -1,0 +1,16 @@
+Current state:
+- `edit-schedule.html` contains a shared `formatIsoForInput()` helper that converts a stored instant into the local string required by `datetime-local`.
+- Some schedule edit paths use the helper, while another editable schedule row still uses `date.toISOString().slice(0, 16)`.
+
+Proposed state:
+- Reuse the shared helper for the remaining editable datetime field instead of open-coding UTC serialization.
+
+Blast radius:
+- Single page, single rendering branch in the schedule editor.
+- No data model changes, no API changes, no Firebase contract changes.
+
+Tradeoff:
+- Minimal patch with low regression risk versus a larger refactor of all date formatting on the page.
+
+Rollback:
+- Revert the single helper substitution commit if the schedule preview renders unexpectedly.

--- a/docs/pr-notes/runs/issue-203-fixer-20260306T142619Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-203-fixer-20260306T142619Z/code-plan.md
@@ -1,0 +1,10 @@
+Thinking level: medium
+Reason: narrow bug, but it requires confirming which schedule-edit paths still bypass the local-input helper.
+
+Implementation plan:
+1. Strengthen the existing timezone regression test so it catches any raw UTC `datetime-local` prefill left in `edit-schedule.html`.
+2. Replace the remaining direct `toISOString().slice(0, 16)` schedule-edit prefill with `formatIsoForInput(...)`.
+3. Run the targeted unit test under `TZ=America/Chicago`.
+
+What would change my mind:
+- Evidence that the remaining raw UTC prefill is intentionally storing UTC wall-clock values, which would make helper reuse incorrect.

--- a/docs/pr-notes/runs/issue-203-fixer-20260306T142619Z/qa.md
+++ b/docs/pr-notes/runs/issue-203-fixer-20260306T142619Z/qa.md
@@ -1,0 +1,13 @@
+Focus:
+- Regression-proof local-time prefill for schedule editing in a non-UTC timezone.
+
+Primary test:
+- Read `edit-schedule.html` and assert the scheduling `datetime-local` inputs use `formatIsoForInput(...)` instead of direct UTC slicing.
+
+Manual spot check to recommend in PR:
+1. In `America/Chicago`, create a practice at 2026-03-10 20:00.
+2. Reopen edit form and confirm the input still shows `2026-03-10T20:00`.
+3. Save without changing time and confirm the practice remains on 2026-03-10 20:00 local.
+
+Residual risk:
+- Other pages outside `edit-schedule.html` could still have independent timezone-prefill bugs.

--- a/docs/pr-notes/runs/issue-203-fixer-20260306T142619Z/requirements.md
+++ b/docs/pr-notes/runs/issue-203-fixer-20260306T142619Z/requirements.md
@@ -1,0 +1,22 @@
+Objective: prevent schedule editing flows from rewriting saved local practice times as UTC-looking `datetime-local` values.
+
+Current state:
+- Practice edit/save is expected to preserve the stored local wall-clock time.
+- The page already has a local-input formatter, but schedule editing code is inconsistent about using it.
+
+Proposed state:
+- Every scheduling `datetime-local` prefill in scope uses the same local-time formatter before the value is written into the input.
+
+Risk surface and blast radius:
+- Scheduling UI only.
+- High user impact if wrong because datetime drift silently republishes incorrect practice times.
+
+Assumptions:
+- `datetime-local` inputs must always receive local wall-clock strings.
+- Existing `formatIsoForInput()` is the canonical helper for this page.
+
+Recommendation:
+- Standardize on `formatIsoForInput()` anywhere this page prefills editable schedule datetimes.
+
+Success measure:
+- A timezone-focused unit test fails on raw UTC prefill patterns and passes after the helper is used consistently.

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -2361,7 +2361,7 @@ PARSING RULES:
                                         <input type="text" value="${game.opponent}"
                                             onchange="updateOperation(${index}, 'opponent', this.value)"
                                             class="font-semibold bg-white border border-gray-300 rounded px-2 py-1 w-full mb-1">
-                                        <input type="datetime-local" value="${date.toISOString().slice(0, 16)}"
+                                        <input type="datetime-local" value="${formatIsoForInput(date)}"
                                             onchange="updateOperation(${index}, 'date', this.value)"
                                             class="text-xs bg-white border border-gray-300 rounded px-2 py-1 w-full mb-1">
                                         <input type="text" value="${game.location || ''}" placeholder="Location"

--- a/tests/unit/edit-schedule-practice-timezone.test.js
+++ b/tests/unit/edit-schedule-practice-timezone.test.js
@@ -21,4 +21,13 @@ describe('edit schedule practice datetime-local prefill', () => {
         expect(block).not.toContain("document.getElementById('practiceStart').value = date.toISOString().slice(0, 16)");
         expect(block).not.toContain("document.getElementById('practiceEnd').value = endDate.toISOString().slice(0, 16)");
     });
+
+    it('does not leave any editable schedule datetime-local input on raw UTC slicing', () => {
+        const source = readEditSchedule();
+
+        expect(source).toContain('function formatIsoForInput(value) {');
+        expect(source).toContain('value="${formatIsoForInput(game.arrivalTime)}"');
+        expect(source).toContain('value="${formatIsoForInput(date)}"');
+        expect(source).not.toContain('value="${date.toISOString().slice(0, 16)}"');
+    });
 });


### PR DESCRIPTION
Closes #203

## What changed
- replaced the remaining raw `toISOString().slice(0, 16)` schedule editor prefill with the shared `formatIsoForInput(...)` helper so editable `datetime-local` fields stay in local time instead of rendering UTC wall-clock values
- strengthened the existing timezone regression test to fail if `edit-schedule.html` leaves any editable schedule datetime field on raw UTC slicing
- added the requested run notes under `docs/pr-notes/runs/issue-203-fixer-20260306T142619Z/`

## Why
The scheduling page was mixing two datetime-local formatting patterns. That made some editable schedule fields vulnerable to the same UTC-to-local round-trip drift described in the issue, so this patch standardizes the page on the local-input helper and adds coverage to keep it from regressing.