### PR TITLE
Fix cancelled ICS events in the global calendar

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -135,7 +135,7 @@
 
     <script type="module">
         import { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, getMyRsvp, getRsvpSummaries } from './js/db.js?v=23';
-        import { renderHeader, renderFooter, escapeHtml, formatDate, formatTime, fetchAndParseCalendar, expandRecurrence, getCalendarEventType, getCalendarEventStatus } from './js/utils.js?v=9';
+        import { renderHeader, renderFooter, escapeHtml, formatDate, formatTime, fetchAndParseCalendar, expandRecurrence, buildGlobalCalendarIcsEvent } from './js/utils.js?v=10';
         import { requireAuth, checkAuth } from './js/auth.js?v=9';
         import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';
 
@@ -323,20 +323,14 @@
                                 const icsEvents = await fetchAndParseCalendar(calUrl);
                                 for (const ev of icsEvents) {
                                     if (trackedUids.includes(ev.uid)) continue;
-                                    const evDate = ev.dtstart instanceof Date ? ev.dtstart : new Date(ev.dtstart);
-                                    if (Number.isNaN(evDate.getTime())) continue;
-                                    events.push({
-                                        id: ev.uid || `ics-${evDate.getTime()}`,
-                                        teamId: team.id,
-                                        teamName: team.name,
+                                    const mappedEvent = buildGlobalCalendarIcsEvent({
+                                        team,
                                         teamColor: teamColors[team.id],
-                                        type: getCalendarEventType(ev),
-                                        title: ev.summary || 'Event',
-                                        date: evDate,
-                                        location: ev.location || 'TBD',
-                                        status: getCalendarEventStatus(ev),
-                                        source: 'ics'
+                                        event: ev
                                     });
+                                    if (mappedEvent) {
+                                        events.push(mappedEvent);
+                                    }
                                 }
                             } catch (e) {
                                 console.warn('Failed to load ICS calendar:', e);

--- a/docs/pr-notes/runs/issue-212-fixer-20260307T052559Z/architecture.md
+++ b/docs/pr-notes/runs/issue-212-fixer-20260307T052559Z/architecture.md
@@ -1,0 +1,17 @@
+Decision: centralize global-calendar ICS event shaping in a small utility function instead of leaving the mapping inline in `calendar.html`.
+
+Why:
+- The calendar page needs a testable seam for `type` and `status` normalization.
+- Reusing existing helpers (`getCalendarEventType`, `getCalendarEventStatus`) keeps behavior aligned and avoids a second cancellation parser.
+
+Current state:
+- `calendar.html` loads parsed ICS events and converts them into calendar view models inline.
+
+Proposed state:
+- `js/utils.js` exports a helper that converts one parsed ICS event into the global-calendar event object.
+- `calendar.html` calls that helper and skips invalid dates.
+
+Controls:
+- No new network calls.
+- No schema changes.
+- Existing cancelled rendering paths remain unchanged.

--- a/docs/pr-notes/runs/issue-212-fixer-20260307T052559Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-212-fixer-20260307T052559Z/code-plan.md
@@ -1,0 +1,7 @@
+Chosen thinking level: medium.
+
+Implementation plan:
+1. Add a failing unit test for global-calendar ICS event shaping.
+2. Export a focused helper from `js/utils.js` that builds the global-calendar event object from a parsed ICS event.
+3. Replace the inline mapping in `calendar.html` with the helper.
+4. Run the unit tests and commit the targeted patch.

--- a/docs/pr-notes/runs/issue-212-fixer-20260307T052559Z/qa.md
+++ b/docs/pr-notes/runs/issue-212-fixer-20260307T052559Z/qa.md
@@ -1,0 +1,12 @@
+Regression target:
+- A cancelled ICS event mapped into the global calendar must have `status: 'cancelled'`.
+
+Test strategy:
+- Add a unit test for the global-calendar ICS mapping helper.
+- Cover both status normalization and the event-shaping fields the calendar relies on.
+- Run `npm test -- tests/unit/calendar-ics-event-type.test.js` and then the full unit suite.
+
+Manual spot check if needed:
+1. Sync an ICS event with `STATUS:CANCELLED` or `[CANCELED]`.
+2. Open `calendar.html`.
+3. Confirm the event renders with cancelled treatment instead of as an active event.

--- a/docs/pr-notes/runs/issue-212-fixer-20260307T052559Z/requirements.md
+++ b/docs/pr-notes/runs/issue-212-fixer-20260307T052559Z/requirements.md
@@ -1,0 +1,21 @@
+Objective: ensure cancelled synced ICS events stay cancelled in the global calendar, matching team schedule behavior.
+
+Current state:
+- ICS parsing already captures `STATUS`.
+- Global calendar depends on normalized `status === 'cancelled'` for cancelled styling and filtering.
+- The regression risk is any ingestion path that defaults synced ICS events back to scheduled.
+
+Proposed state:
+- Global calendar uses a shared normalization seam for ICS event type and status.
+- Cancelled markers from `STATUS:CANCELLED`, `STATUS:CANCELED`, `[CANCELED]`, and `[CANCELLED]` continue through to the rendered event.
+
+Risk surface and blast radius:
+- Low blast radius. This only affects synced ICS events shown in the consolidated calendar.
+- Wrong behavior is user-facing and high impact because families can act on cancelled events.
+
+Assumptions:
+- Existing cancelled rendering in `calendar.html` is the intended UX.
+- No data migration is needed because the source of truth remains the ICS feed.
+
+Recommendation:
+- Add a regression test at the mapping seam and keep the implementation minimal.

--- a/js/utils.js
+++ b/js/utils.js
@@ -1192,6 +1192,34 @@ export function getCalendarEventStatus(event) {
   return 'scheduled';
 }
 
+/**
+ * Convert a parsed ICS event into the view model used by the global calendar.
+ * @param {Object} options
+ * @param {Object} options.team
+ * @param {string} options.teamColor
+ * @param {Object} options.event
+ * @returns {Object|null}
+ */
+export function buildGlobalCalendarIcsEvent({ team, teamColor, event }) {
+  const eventDate = event?.dtstart instanceof Date ? event.dtstart : new Date(event?.dtstart);
+  if (Number.isNaN(eventDate.getTime())) {
+    return null;
+  }
+
+  return {
+    id: event.uid || `ics-${eventDate.getTime()}`,
+    teamId: team.id,
+    teamName: team.name,
+    teamColor,
+    type: getCalendarEventType(event),
+    title: event.summary || 'Event',
+    date: eventDate,
+    location: event.location || 'TBD',
+    status: getCalendarEventStatus(event),
+    source: 'ics'
+  };
+}
+
 // ============================================
 // Practice & Event Utilities - Phase 1
 // ============================================

--- a/tests/unit/calendar-ics-event-type.test.js
+++ b/tests/unit/calendar-ics-event-type.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { getCalendarEventType, getCalendarEventStatus } from '../../js/utils.js';
+import { buildGlobalCalendarIcsEvent, getCalendarEventType, getCalendarEventStatus } from '../../js/utils.js';
 
 describe('getCalendarEventType', () => {
     it('classifies ICS practice events from summary when isPractice is missing', () => {
@@ -32,5 +32,33 @@ describe('getCalendarEventStatus', () => {
     it('keeps non-cancelled ICS events scheduled', () => {
         const status = getCalendarEventStatus({ status: 'CONFIRMED', summary: 'U12 vs Lions' });
         expect(status).toBe('scheduled');
+    });
+});
+
+describe('buildGlobalCalendarIcsEvent', () => {
+    it('preserves cancelled status for synced ICS events in the global calendar', () => {
+        const mappedEvent = buildGlobalCalendarIcsEvent({
+            team: { id: 'team-1', name: 'Wildcats' },
+            teamColor: '#f97316',
+            event: {
+                uid: 'ics-1',
+                summary: '[CANCELED] Practice',
+                dtstart: new Date('2026-03-07T12:15:29Z'),
+                location: 'Main Field'
+            }
+        });
+
+        expect(mappedEvent).toMatchObject({
+            id: 'ics-1',
+            teamId: 'team-1',
+            teamName: 'Wildcats',
+            teamColor: '#f97316',
+            type: 'practice',
+            title: '[CANCELED] Practice',
+            location: 'Main Field',
+            status: 'cancelled',
+            source: 'ics'
+        });
+        expect(mappedEvent.date).toBeInstanceOf(Date);
     });
 });


### PR DESCRIPTION
Closes #212

## What changed
- added a unit regression for the global calendar ICS mapping path so cancelled synced events stay `cancelled`
- extracted global calendar ICS event shaping into a shared `buildGlobalCalendarIcsEvent` helper in `js/utils.js`
- updated `calendar.html` to use the shared helper and bumped the `utils.js` cache-busting version
- persisted the required requirements, architecture, QA, and code-plan notes under `docs/pr-notes/runs/issue-212-fixer-20260307T052559Z/`

## Why
The global calendar needs to carry through ICS cancellation markers instead of treating synced cancelled events like active scheduled events. This patch puts the type/status normalization behind a testable helper so the consolidated calendar stays aligned with the intended cancellation behavior.

## Validation
- `./node_modules/.bin/vitest run tests/unit/calendar-ics-event-type.test.js`
- `./node_modules/.bin/vitest run tests/unit`