### PR TITLE
Fail closed Google admin invite onboarding

### DIFF
--- a/docs/pr-notes/runs/issue-198-fixer-20260307T142529Z/architecture.md
+++ b/docs/pr-notes/runs/issue-198-fixer-20260307T142529Z/architecture.md
@@ -1,0 +1,16 @@
+Current state:
+- `accept-invite.html` uses the shared atomic admin redemption path.
+- `js/auth.js` Google new-user onboarding handles `admin_invite` inline and catches errors without rollback or rethrow.
+
+Observed gap:
+- If `redeemAdminInviteAcceptance(...)` fails for a Google signup or redirect flow, the catch block logs the error and execution continues.
+- That can produce a successful auth result without guaranteed `team.adminEmails` persistence, which matches the false-success symptom in issue #198.
+
+Proposed change:
+1. In `processGoogleAuthResult`, isolate admin invite redemption in its own `try` block.
+2. On redemption failure, clear the pending activation code, delete/sign out the just-created auth user, and rethrow.
+3. Keep the profile write in a separate best-effort `try` block so a post-redeem Firestore profile failure does not roll back a successful access grant.
+
+Why this path:
+- Minimal patch with clear control equivalence.
+- Reuses the existing rollback helper and mirrors the parent invite fail-closed contract.

--- a/docs/pr-notes/runs/issue-198-fixer-20260307T142529Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-198-fixer-20260307T142529Z/code-plan.md
@@ -1,0 +1,10 @@
+Chosen fix:
+1. Add `tests/unit/auth-google-admin-invite-cleanup.test.js`.
+2. Update `js/auth.js` admin-invite branch inside `processGoogleAuthResult`:
+   - fail closed on invite redemption errors
+   - keep profile write best-effort after successful redemption
+3. Run focused Vitest coverage for the new file and adjacent admin invite suites.
+
+Assumptions:
+- Email/password admin invite signup is already fail-closed and should remain unchanged.
+- `cleanupFailedNewUser` is the right rollback primitive for Google new-user onboarding.

--- a/docs/pr-notes/runs/issue-198-fixer-20260307T142529Z/qa.md
+++ b/docs/pr-notes/runs/issue-198-fixer-20260307T142529Z/qa.md
@@ -1,0 +1,15 @@
+Focus:
+- Prevent false-success Google admin invite onboarding.
+
+Regression risks:
+- Swallowing admin redemption errors for popup or redirect Google auth.
+- Regressing successful admin invite signups when only the follow-up profile write fails.
+
+Coverage plan:
+1. Add unit coverage for popup Google admin invite failure cleanup.
+2. Add unit coverage for redirect Google admin invite failure cleanup.
+3. Add unit coverage proving post-redeem profile write failures remain non-fatal.
+
+Validation:
+- Run the new focused auth/admin invite test file first.
+- Run related invite/auth suites that cover shared admin invite behavior.

--- a/docs/pr-notes/runs/issue-198-fixer-20260307T142529Z/requirements.md
+++ b/docs/pr-notes/runs/issue-198-fixer-20260307T142529Z/requirements.md
@@ -1,0 +1,17 @@
+Objective: ensure accepted admin invites result in usable team-management access for the invited coach across supported onboarding paths.
+
+Current state:
+- Existing invite acceptance logic already treats `teams/{teamId}.adminEmails` as the canonical team-management grant.
+- Google signup/admin-invite onboarding can swallow invite redemption failures and continue as if access was granted.
+
+Proposed state:
+- Admin invite redemption failures during Google onboarding fail closed, clean up the new auth user, and do not leave a false-success dashboard redirect.
+- Best-effort profile decoration after a successful redemption remains non-blocking.
+
+Risk surface:
+- Affects only new-user Google admin invite onboarding and redirect handling.
+- Blast radius is limited to `js/auth.js` and related invite/auth tests.
+
+Recommendation:
+- Preserve `adminEmails` as the control source of truth.
+- Patch Google admin invite signup to match the fail-closed behavior already used for parent invites and email/password admin invite signup.

--- a/js/auth.js
+++ b/js/auth.js
@@ -198,7 +198,14 @@ async function processGoogleAuthResult(result, activationCode = null) {
                     getUserProfile,
                     updateUserProfile
                 });
+            } catch (e) {
+                console.error('Error linking admin invite:', e);
+                clearPendingActivationCode();
+                await cleanupFailedNewUser(result.user, 'admin invite link failure');
+                throw e;
+            }
 
+            try {
                 await updateUserProfile(userId, {
                     email: result.user.email,
                     fullName: result.user.displayName,
@@ -206,7 +213,7 @@ async function processGoogleAuthResult(result, activationCode = null) {
                     createdAt: new Date()
                 });
             } catch (e) {
-                console.error('Error linking admin invite:', e);
+                console.error('Error creating user profile after admin invite redeem:', e);
             }
         } else {
             try {

--- a/tests/unit/auth-google-admin-invite-cleanup.test.js
+++ b/tests/unit/auth-google-admin-invite-cleanup.test.js
@@ -1,0 +1,192 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const signInWithPopupMock = vi.fn();
+const signOutMock = vi.fn();
+const signInWithRedirectMock = vi.fn();
+const getRedirectResultMock = vi.fn();
+const validateAccessCodeMock = vi.fn();
+const updateUserProfileMock = vi.fn();
+const markAccessCodeAsUsedMock = vi.fn();
+const redeemAdminInviteAcceptanceMock = vi.fn();
+
+vi.mock('../../js/firebase.js?v=9', () => ({
+    auth: { currentUser: null },
+    signInWithEmailAndPassword: vi.fn(),
+    createUserWithEmailAndPassword: vi.fn(),
+    signOut: signOutMock,
+    onAuthStateChanged: vi.fn(),
+    GoogleAuthProvider: class MockGoogleAuthProvider {},
+    signInWithPopup: signInWithPopupMock,
+    signInWithRedirect: signInWithRedirectMock,
+    getRedirectResult: getRedirectResultMock,
+    sendPasswordResetEmail: vi.fn(),
+    sendEmailVerification: vi.fn(),
+    sendSignInLinkToEmail: vi.fn(),
+    isSignInWithEmailLink: vi.fn(),
+    signInWithEmailLink: vi.fn(),
+    updatePassword: vi.fn()
+}));
+
+vi.mock('../../js/db.js?v=14', () => ({
+    validateAccessCode: validateAccessCodeMock,
+    markAccessCodeAsUsed: markAccessCodeAsUsedMock,
+    updateUserProfile: updateUserProfileMock,
+    redeemParentInvite: vi.fn(),
+    getUserProfile: vi.fn(),
+    getUserTeams: vi.fn(),
+    getUserByEmail: vi.fn(),
+    getTeam: vi.fn(),
+    addTeamAdminEmail: vi.fn()
+}));
+
+vi.mock('../../js/admin-invite.js?v=3', () => ({
+    redeemAdminInviteAcceptance: redeemAdminInviteAcceptanceMock
+}));
+
+describe('loginWithGoogle admin invite failure handling', () => {
+    let sessionStorageMock;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.resetModules();
+
+        sessionStorageMock = {
+            setItem: vi.fn(),
+            getItem: vi.fn(),
+            removeItem: vi.fn()
+        };
+
+        vi.stubGlobal('window', {
+            sessionStorage: sessionStorageMock
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('deletes auth user, signs out, and rethrows when popup admin invite redemption fails', async () => {
+        const expectedError = new Error('admin invite redemption failed');
+        const deleteMock = vi.fn().mockResolvedValue(undefined);
+
+        signInWithPopupMock.mockResolvedValue({
+            user: {
+                uid: 'user-123',
+                email: 'coach@example.com',
+                displayName: 'Coach User',
+                photoURL: 'https://example.com/photo.png',
+                metadata: {
+                    creationTime: '2026-03-07T14:00:00.000Z',
+                    lastSignInTime: '2026-03-07T14:00:00.000Z'
+                },
+                delete: deleteMock
+            }
+        });
+        validateAccessCodeMock.mockResolvedValue({
+            valid: true,
+            type: 'admin_invite',
+            codeId: 'code-admin-1',
+            data: { teamId: 'team-1' }
+        });
+        redeemAdminInviteAcceptanceMock.mockRejectedValue(expectedError);
+        signOutMock.mockResolvedValue(undefined);
+
+        const { loginWithGoogle } = await import('../../js/auth.js');
+
+        await expect(loginWithGoogle('ADMINCODE')).rejects.toThrow('admin invite redemption failed');
+
+        expect(redeemAdminInviteAcceptanceMock).toHaveBeenCalledWith(expect.objectContaining({
+            userId: 'user-123',
+            userEmail: 'coach@example.com',
+            teamId: 'team-1',
+            codeId: 'code-admin-1'
+        }));
+        expect(updateUserProfileMock).not.toHaveBeenCalled();
+        expect(markAccessCodeAsUsedMock).not.toHaveBeenCalled();
+        expect(deleteMock).toHaveBeenCalledTimes(1);
+        expect(signOutMock).toHaveBeenCalledTimes(1);
+        expect(sessionStorageMock.removeItem).toHaveBeenCalledWith('pendingActivationCode');
+    });
+
+    it('applies the same fail-closed cleanup behavior for redirect admin invite auth', async () => {
+        const expectedError = new Error('admin invite redemption failed');
+        const deleteMock = vi.fn().mockResolvedValue(undefined);
+
+        getRedirectResultMock.mockResolvedValue({
+            user: {
+                uid: 'user-123',
+                email: 'coach@example.com',
+                displayName: 'Coach User',
+                photoURL: 'https://example.com/photo.png',
+                metadata: {
+                    creationTime: '2026-03-07T14:00:00.000Z',
+                    lastSignInTime: '2026-03-07T14:00:00.000Z'
+                },
+                delete: deleteMock
+            }
+        });
+        sessionStorageMock.getItem.mockReturnValue('ADMINCODE');
+        validateAccessCodeMock.mockResolvedValue({
+            valid: true,
+            type: 'admin_invite',
+            codeId: 'code-admin-2',
+            data: { teamId: 'team-2' }
+        });
+        redeemAdminInviteAcceptanceMock.mockRejectedValue(expectedError);
+        signOutMock.mockResolvedValue(undefined);
+
+        const { handleGoogleRedirectResult } = await import('../../js/auth.js');
+
+        await expect(handleGoogleRedirectResult()).rejects.toThrow('admin invite redemption failed');
+
+        expect(redeemAdminInviteAcceptanceMock).toHaveBeenCalledWith(expect.objectContaining({
+            userId: 'user-123',
+            userEmail: 'coach@example.com',
+            teamId: 'team-2',
+            codeId: 'code-admin-2'
+        }));
+        expect(updateUserProfileMock).not.toHaveBeenCalled();
+        expect(markAccessCodeAsUsedMock).not.toHaveBeenCalled();
+        expect(deleteMock).toHaveBeenCalledTimes(1);
+        expect(signOutMock).toHaveBeenCalledTimes(1);
+        expect(sessionStorageMock.removeItem).toHaveBeenCalledWith('pendingActivationCode');
+    });
+
+    it('does not clean up after successful admin redemption when profile finalization fails', async () => {
+        const deleteMock = vi.fn().mockResolvedValue(undefined);
+
+        signInWithPopupMock.mockResolvedValue({
+            user: {
+                uid: 'user-456',
+                email: 'coach2@example.com',
+                displayName: 'Coach Two',
+                photoURL: 'https://example.com/photo2.png',
+                metadata: {
+                    creationTime: '2026-03-07T14:00:00.000Z',
+                    lastSignInTime: '2026-03-07T14:00:00.000Z'
+                },
+                delete: deleteMock
+            }
+        });
+        validateAccessCodeMock.mockResolvedValue({
+            valid: true,
+            type: 'admin_invite',
+            codeId: 'code-admin-3',
+            data: { teamId: 'team-3' }
+        });
+        redeemAdminInviteAcceptanceMock.mockResolvedValue(undefined);
+        updateUserProfileMock.mockRejectedValue(new Error('profile write failed'));
+
+        const { loginWithGoogle } = await import('../../js/auth.js');
+
+        await expect(loginWithGoogle('ADMINCODE')).resolves.toMatchObject({
+            user: { uid: 'user-456' }
+        });
+
+        expect(redeemAdminInviteAcceptanceMock).toHaveBeenCalledTimes(1);
+        expect(updateUserProfileMock).toHaveBeenCalledTimes(1);
+        expect(deleteMock).not.toHaveBeenCalled();
+        expect(signOutMock).not.toHaveBeenCalled();
+        expect(sessionStorageMock.removeItem).toHaveBeenCalledWith('pendingActivationCode');
+    });
+});


### PR DESCRIPTION
Closes #198

## What changed
- fail closed when Google-based admin invite redemption fails during popup or redirect onboarding
- keep the follow-up profile write best-effort after a successful admin invite redemption so access is not rolled back for a non-critical profile save error
- add focused unit coverage for Google admin invite cleanup and success-path behavior

## Why
Accepted admin invites must result in usable team-management access. Before this change, the Google signup path could log an admin invite redemption failure and still continue as if onboarding succeeded, leaving the invited coach authenticated without a guaranteed team-management grant.

## Validation
- `./node_modules/.bin/vitest run tests/unit/auth-google-admin-invite-cleanup.test.js`
- `./node_modules/.bin/vitest run tests/unit/admin-invite.test.js tests/unit/admin-invite-redemption.test.js tests/unit/accept-invite-flow.test.js tests/unit/signup-flow.test.js tests/unit/auth-signup-parent-invite.test.js`