### PR TITLE
Handle cancelled ICS variants in calendar sync

### DIFF
--- a/docs/pr-notes/runs/issue-172-fixer-20260307T202559Z/architecture.md
+++ b/docs/pr-notes/runs/issue-172-fixer-20260307T202559Z/architecture.md
@@ -1,0 +1,20 @@
+Current state:
+- `edit-schedule.html` duplicates cancellation detection instead of using shared utility logic.
+- `js/utils.js#getCalendarEventStatus` already supports both `CANCELED` and `CANCELLED` plus summary prefixes.
+
+Proposed state:
+- Import `getCalendarEventStatus` into `edit-schedule.html`.
+- Use helper output to derive `isCancelled`.
+- Expand summary prefix cleanup regex to strip both `[CANCELED]` and `[CANCELLED]` case-insensitively before opponent extraction.
+
+Tradeoffs:
+- Reusing the helper removes drift and reduces future toil.
+- Keeping the change local to the calendar import path minimizes regression risk versus broader refactoring.
+
+Controls:
+- No data model changes.
+- No auth or Firestore behavior changes.
+- Blast radius is limited to imported calendar card normalization.
+
+Rollback:
+- Revert the helper import and the two cancellation-related lines in `edit-schedule.html`.

--- a/docs/pr-notes/runs/issue-172-fixer-20260307T202559Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-172-fixer-20260307T202559Z/code-plan.md
@@ -1,0 +1,6 @@
+Implementation plan:
+1. Extend `tests/unit/calendar-ics-event-type.test.js` with missed cancelled variants.
+2. Add `tests/unit/edit-schedule-calendar-cancellation.test.js` to lock `edit-schedule.html` onto shared cancellation logic.
+3. Update `edit-schedule.html` to import and use `getCalendarEventStatus`.
+4. Normalize cancelled summary prefix cleanup for both spellings.
+5. Run targeted Vitest commands, then commit with issue reference.

--- a/docs/pr-notes/runs/issue-172-fixer-20260307T202559Z/qa.md
+++ b/docs/pr-notes/runs/issue-172-fixer-20260307T202559Z/qa.md
@@ -1,0 +1,14 @@
+Test strategy:
+- Utility regression: assert `getCalendarEventStatus` treats `STATUS:CANCELED`, `STATUS:CANCELLED`, `[CANCELED]`, and `[CANCELLED]` case-insensitively as cancelled.
+- Source regression: assert `edit-schedule.html` imports and uses `getCalendarEventStatus` and strips both cancelled prefix spellings before opponent extraction.
+
+Primary regression risks:
+- Missing one spelling variant in summary cleanup, leaving ugly titles or wrong opponent parsing.
+- Future inline duplication in `edit-schedule.html` drifting from the shared helper again.
+
+Validation plan:
+- Run targeted Vitest files first to prove failure/fix quickly.
+- Run the broader relevant calendar/edit-schedule unit tests after the fix.
+
+Manual spot check if needed:
+- In `edit-schedule.html`, sync an ICS event with `STATUS:CANCELED` or `[cancelled]` prefix and verify the imported card shows Cancelled with no tracking action.

--- a/docs/pr-notes/runs/issue-172-fixer-20260307T202559Z/requirements.md
+++ b/docs/pr-notes/runs/issue-172-fixer-20260307T202559Z/requirements.md
@@ -1,0 +1,25 @@
+Objective: Prevent cancelled ICS imports from appearing trackable in `edit-schedule.html`.
+
+Current state:
+- Schedule sync treats only `STATUS:CANCELLED` and exact-case `[CANCELED]` as cancelled in `edit-schedule.html`.
+- Common variants like `STATUS:CANCELED`, `[CANCELLED]`, and lowercase prefixes remain actionable.
+
+Proposed state:
+- Calendar imports normalize cancelled status consistently across status and summary variants.
+- Cancelled imported calendar cards render as cancelled and suppress `Track` / practice planning actions.
+
+Risk surface and blast radius:
+- Affects imported calendar event classification in team schedule management only.
+- Low blast radius if fix stays within calendar import normalization and preserves existing rendering branches.
+
+Assumptions:
+- Imported calendar cards rely on `isCancelled` set during `loadSchedule()`.
+- Shared helper behavior in `js/utils.js` is the intended normalization contract.
+
+Recommendation:
+- Reuse the shared cancellation helper in `edit-schedule.html` and normalize summary cleanup for both prefix spellings.
+- Add regression tests for helper behavior and for the HTML source path to prevent duplicate weak logic from returning.
+
+Success measure:
+- Cancelled variants are classified as cancelled.
+- Imported cancelled cards no longer show `Track` or `Plan Practice`.

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -586,7 +586,7 @@
 
     <script type="module">
         import { getTeam, getTeams, getGames, getEvents, addGame, updateGame, deleteGame, addPractice, updateEvent, deleteEvent, getConfigs, addCalendarToTeam, removeCalendarFromTeam, getTrackedCalendarEventUids, cancelOccurrence, updateOccurrence, restoreOccurrence, clearOccurrenceOverride, updateSeries, deleteSeries, getUnreadChatCount, getPracticeSessions, cancelGame, getLatestGameAssignments, postChatMessage, getRsvpBreakdownByPlayer } from './js/db.js?v=20';
-        import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, formatTimeRange, getDefaultEndTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, generateSeriesId, expandRecurrence, formatRecurrence, shareOrCopy, escapeHtml } from './js/utils.js?v=8';
+        import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, formatTimeRange, getDefaultEndTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, getCalendarEventStatus, generateSeriesId, expandRecurrence, formatRecurrence, shareOrCopy, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { getTeamAccessInfo } from './js/team-access.js';
@@ -849,9 +849,8 @@
                             // Skip if already tracked
                             if (trackedUids.includes(event.uid)) return;
 
-                            // Check if event is cancelled (standard iCal STATUS or TeamSnap [CANCELED] prefix)
-                            const isCancelled = event.status?.toUpperCase() === 'CANCELLED' ||
-                                event.summary?.includes('[CANCELED]');
+                            // Normalize common ICS and TeamSnap cancelled variants via shared helper
+                            const isCancelled = getCalendarEventStatus(event) === 'cancelled';
 
                             // Skip if conflicts with DB event
                             const hasConflict = dbEvents.some(dbEvent => {
@@ -862,8 +861,8 @@
                             if (hasConflict) return;
 
                             const isPractice = isPracticeEvent(event.summary);
-                            // Clean [CANCELED] prefix from summary before extracting opponent
-                            const cleanSummary = event.summary?.replace(/\[CANCELED\]\s*/gi, '') || '';
+                            // Clean cancelled prefix from summary before extracting opponent
+                            const cleanSummary = event.summary?.replace(/\[(?:CANCELED|CANCELLED)\]\s*/gi, '') || '';
                             const opponent = extractOpponent(cleanSummary, currentTeam.name);
 
                             allEvents.push({

--- a/tests/unit/calendar-ics-event-type.test.js
+++ b/tests/unit/calendar-ics-event-type.test.js
@@ -24,8 +24,18 @@ describe('getCalendarEventStatus', () => {
         expect(status).toBe('cancelled');
     });
 
+    it('maps ICS STATUS:CANCELED to cancelled', () => {
+        const status = getCalendarEventStatus({ status: 'CANCELED', summary: 'U12 vs Lions' });
+        expect(status).toBe('cancelled');
+    });
+
     it('maps TeamSnap [CANCELED] summary to cancelled', () => {
         const status = getCalendarEventStatus({ summary: '[CANCELED] U12 Practice' });
+        expect(status).toBe('cancelled');
+    });
+
+    it('maps [cancelled] summary variants case-insensitively to cancelled', () => {
+        const status = getCalendarEventStatus({ summary: '[cancelled] U12 Practice' });
         expect(status).toBe('cancelled');
     });
 

--- a/tests/unit/edit-schedule-calendar-cancellation.test.js
+++ b/tests/unit/edit-schedule-calendar-cancellation.test.js
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readEditSchedule() {
+    return readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
+}
+
+describe('edit schedule calendar cancellation handling', () => {
+    it('uses the shared calendar cancellation helper instead of inline brittle checks', () => {
+        const source = readEditSchedule();
+
+        expect(source).toContain('getCalendarEventStatus');
+        expect(source).toContain("const isCancelled = getCalendarEventStatus(event) === 'cancelled';");
+        expect(source).not.toContain("event.status?.toUpperCase() === 'CANCELLED'");
+        expect(source).not.toContain("event.summary?.includes('[CANCELED]')");
+    });
+
+    it('strips both cancelled summary prefixes before opponent extraction', () => {
+        const source = readEditSchedule();
+
+        expect(source).toContain("replace(/\\[(?:CANCELED|CANCELLED)\\]\\s*/gi, '')");
+    });
+});


### PR DESCRIPTION
Closes #172

## What changed
- reused the shared `getCalendarEventStatus()` helper in `edit-schedule.html` so imported ICS events recognize both `CANCELED` and `CANCELLED` status variants
- normalized cancelled summary prefix cleanup to strip both `[CANCELED]` and `[CANCELLED]` case-insensitively before opponent extraction
- added regression tests for the missed cancellation variants and a source-level guard to keep `edit-schedule.html` aligned with the shared helper

## Why
Cancelled external calendar events were being treated as active when they used common variant spellings, which left `Track` available for events that should have been blocked as cancelled.

## Validation
- ran `node node_modules/vitest/vitest.mjs run tests/unit/calendar-ics-event-type.test.js tests/unit/edit-schedule-calendar-cancellation.test.js tests/unit/edit-schedule-practice-timezone.test.js tests/unit/utils-calendar-fetch.test.js`
- all targeted tests passed