### PR TITLE
Fix live tracker stat column resolution

### DIFF
--- a/js/live-game-state.js
+++ b/js/live-game-state.js
@@ -14,6 +14,43 @@ export function normalizeLiveStatColumns(columns) {
   return ['PTS', 'REB', 'AST', 'STL', 'TO'];
 }
 
+function normalizeSportLabel(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+export function resolveLiveStatColumns({ columns = [], configs = [], game = null, team = null } = {}) {
+  const directColumns = normalizeLiveStatColumns(columns);
+  if (Array.isArray(columns) && columns.length) return directColumns;
+
+  const safeConfigs = Array.isArray(configs) ? configs : [];
+  const desiredSport = normalizeSportLabel(game?.sport || team?.sport);
+  const configId = String(game?.statTrackerConfigId || '').trim();
+
+  if (configId) {
+    const configMatch = safeConfigs.find((config) => String(config?.id || '').trim() === configId);
+    if (Array.isArray(configMatch?.columns) && configMatch.columns.length) {
+      return normalizeLiveStatColumns(configMatch.columns);
+    }
+  }
+
+  if (desiredSport) {
+    const sportMatch = safeConfigs.find((config) => (
+      normalizeSportLabel(config?.baseType) === desiredSport &&
+      Array.isArray(config?.columns) &&
+      config.columns.length
+    ));
+    if (sportMatch) {
+      return normalizeLiveStatColumns(sportMatch.columns);
+    }
+  }
+
+  if (safeConfigs.length === 1 && Array.isArray(safeConfigs[0]?.columns) && safeConfigs[0].columns.length) {
+    return normalizeLiveStatColumns(safeConfigs[0].columns);
+  }
+
+  return directColumns;
+}
+
 export function applyResetEventState(currentState, event) {
   const period = event?.period || currentState?.period || 'Q1';
   const onCourt = Array.isArray(event?.onCourt) ? [...event.onCourt] : [];

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -21,7 +21,7 @@ import { isViewerChatEnabled } from './live-game-chat.js?v=1';
 import { getReplayElapsedMs, getReplayStartTimeAfterSpeedChange } from './live-game-replay.js?v=2';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
-import { resolveOpponentDisplayName, normalizeLiveStatColumns, applyResetEventState, shouldResetViewerFromGameDoc, isLiveEventVisibleForResetBoundary } from './live-game-state.js?v=1';
+import { resolveOpponentDisplayName, normalizeLiveStatColumns, resolveLiveStatColumns, applyResetEventState, shouldResetViewerFromGameDoc, isLiveEventVisibleForResetBoundary } from './live-game-state.js?v=2';
 
 const state = {
   teamId: null,
@@ -1469,13 +1469,12 @@ async function init() {
   state.team = team;
   state.game = game;
   state.players = players || [];
-  if (game?.statTrackerConfigId && Array.isArray(configs)) {
-    const config = configs.find(c => c.id === game.statTrackerConfigId);
-    if (config && Array.isArray(config.columns)) {
-      state.statColumns = normalizeLiveStatColumns(config.columns);
-    }
-  }
-  state.statColumns = normalizeLiveStatColumns(state.statColumns);
+  state.statColumns = resolveLiveStatColumns({
+    columns: state.statColumns,
+    configs,
+    game,
+    team
+  });
   state.opponentStats = game.opponentStats || {};
   if (game.liveLineup) {
     state.onCourt = Array.isArray(game.liveLineup.onCourt) ? game.liveLineup.onCourt : [];

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -14,6 +14,7 @@ import { restoreLiveLineup } from './live-tracker-lineup.js?v=1';
 import { resolveSummaryRecipient } from './live-tracker-email.js?v=1';
 import { buildLiveResetEvent } from './live-tracker-reset.js?v=1';
 import { advanceLiveChatUnreadState } from './live-tracker-chat-unread.js?v=2';
+import { normalizeLiveStatColumns, resolveLiveStatColumns } from './live-game-state.js?v=2';
 
 let currentTeamId = null;
 let currentGameId = null;
@@ -2362,15 +2363,28 @@ async function init() {
       photoUrl: p.photoUrl || p.photo || ''
     }));
 
+    const configs = await getConfigs(teamId);
+    const resolvedColumns = resolveLiveStatColumns({
+      configs,
+      game,
+      team
+    });
+
     if (game.statTrackerConfigId) {
-      const configs = await getConfigs(teamId);
       currentConfig = configs.find(c => c.id === game.statTrackerConfigId) || null;
+    }
+    if (!currentConfig && Array.isArray(configs) && configs.length) {
+      currentConfig = configs.find((config) => (
+        Array.isArray(config?.columns) &&
+        config.columns.length &&
+        JSON.stringify(normalizeLiveStatColumns(config.columns)) === JSON.stringify(resolvedColumns)
+      )) || null;
     }
     if (!currentConfig) {
       currentConfig = {
         name: 'Default',
-        baseType: 'Basketball',
-        columns: ['PTS', 'REB', 'AST', 'STL', 'TO']
+        baseType: team?.sport || 'Basketball',
+        columns: resolvedColumns
       };
     }
 

--- a/tests/unit/live-game-state.test.js
+++ b/tests/unit/live-game-state.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveOpponentDisplayName, normalizeLiveStatColumns, applyResetEventState, shouldResetViewerFromGameDoc, isLiveEventVisibleForResetBoundary } from '../../js/live-game-state.js';
+import { resolveOpponentDisplayName, normalizeLiveStatColumns, resolveLiveStatColumns, applyResetEventState, shouldResetViewerFromGameDoc, isLiveEventVisibleForResetBoundary } from '../../js/live-game-state.js';
 
 describe('live game state helpers', () => {
   it('prefers linked opponent team name when opponent is missing', () => {
@@ -9,6 +9,36 @@ describe('live game state helpers', () => {
 
   it('does not force foul column into generic stat columns', () => {
     expect(normalizeLiveStatColumns(['PTS', 'REB', 'AST'])).toEqual(['PTS', 'REB', 'AST']);
+  });
+
+  it('resolves stat columns from matching sport config when game config id is missing', () => {
+    expect(resolveLiveStatColumns({
+      configs: [
+        { id: 'cfg-basketball', baseType: 'Basketball', columns: ['PTS', 'REB', 'AST'] },
+        { id: 'cfg-soccer', baseType: 'Soccer', columns: ['G', 'A', 'SOG', 'YC'] }
+      ],
+      team: { sport: 'Soccer' }
+    })).toEqual(['G', 'A', 'SOG', 'YC']);
+  });
+
+  it('prefers direct game config id over sport matching', () => {
+    expect(resolveLiveStatColumns({
+      configs: [
+        { id: 'cfg-basketball', baseType: 'Basketball', columns: ['PTS', 'REB', 'AST'] },
+        { id: 'cfg-custom', baseType: 'Soccer', columns: ['SHOT', 'SAVE'] }
+      ],
+      game: { statTrackerConfigId: 'cfg-custom', sport: 'Soccer' },
+      team: { sport: 'Soccer' }
+    })).toEqual(['SHOT', 'SAVE']);
+  });
+
+  it('falls back to the only available config before basketball defaults', () => {
+    expect(resolveLiveStatColumns({
+      configs: [
+        { id: 'cfg-only', baseType: 'Custom', columns: ['A', 'B', 'C', 'D'] }
+      ],
+      team: { sport: 'Unknown' }
+    })).toEqual(['A', 'B', 'C', 'D']);
   });
 
   it('resets live viewer state from reset event payload', () => {


### PR DESCRIPTION
## What changed
- resolve live-game stat columns from the game config, matching sport config, or the only available config before falling back
- apply the same stat-column resolution to js/live-tracker.js so non-basketball trackers do not silently degrade to basketball defaults
- add unit coverage for sport-matched and config-id-based column resolution

## Why
A regression caused non-basketball live game and tracker views to render the wrong stat columns when the game config was missing or mismatched. During verification, the linked soccer game was confirmed to be explicitly assigned to a custom Soccer 2 config with a, b, c, d, e columns, so this PR fixes fallback behavior without overriding intentional per-game config assignments.

## Testing
- npm run test:unit
- manual data check on track-live.html for game l8ZI7yRQBGmujY8NcZKP to confirm the page was loading its assigned config from Firestore