### PR TITLE
Make live scoring period defaults sport-aware

### DIFF
--- a/docs/pr-notes/runs/issue-205-fixer-20260308T052559Z/architecture.md
+++ b/docs/pr-notes/runs/issue-205-fixer-20260308T052559Z/architecture.md
@@ -1,0 +1,20 @@
+Decision: centralize sport-specific phase defaults behind a shared helper instead of duplicating `Q1` fallbacks across tracker and viewer modules.
+
+Why this path:
+- Lowest blast radius: touches only default-value resolution and leaves Firestore schema unchanged.
+- Preserves backward compatibility for basketball.
+- Creates a reusable adapter seam for later sport-specific tracker expansion.
+
+Control points:
+- Helper resolves sport from `game.sport`, `team.sport`, or `config.baseType`.
+- Helper prefers explicit `config.periods[].label` values when available.
+- Call sites use helper for reset event creation, reset payload creation, viewer reset state, replay bootstrap, and tracker initialization.
+
+Conflict resolution:
+- Requirements wanted sport-correct UX immediately.
+- Code minimization favored a narrow patch.
+- Chosen compromise: fix sport-specific phase defaults end-to-end now, defer deeper baseball situation state to a later change because it would require new UI, persistence, and event schemas.
+
+Blast radius:
+- Low. Changes are isolated to live-tracking helper flows and initialization logic.
+- No auth, rules, or server-side surfaces changed.

--- a/docs/pr-notes/runs/issue-205-fixer-20260308T052559Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-205-fixer-20260308T052559Z/code-plan.md
@@ -1,0 +1,20 @@
+Thinking level: medium
+Reason: multiple modules share the same defective fallback; fix needs to stay small and testable.
+
+Implementation plan:
+1. Add `js/live-sport-config.js` to normalize sport names and resolve default period labels.
+2. Add failing unit tests for soccer/baseball defaults and config-period precedence.
+3. Replace hardcoded `Q1` fallbacks in:
+   - `js/live-tracker-reset.js`
+   - `js/track-live-state.js`
+   - `js/live-game-state.js`
+   - `js/live-tracker-resume.js`
+   - `js/live-game.js`
+   - `js/live-tracker.js`
+4. Run targeted Vitest suites.
+5. Commit with issue reference.
+
+Out of scope for this patch:
+- Baseball balls/strikes/outs/base-runner UI
+- New Firestore fields for baseball/soccer situation state
+- Large tracker UI refactor

--- a/docs/pr-notes/runs/issue-205-fixer-20260308T052559Z/qa.md
+++ b/docs/pr-notes/runs/issue-205-fixer-20260308T052559Z/qa.md
@@ -1,0 +1,17 @@
+Primary risk:
+- Non-basketball games silently reset to `Q1`, creating inconsistent scoreboard state between tracker and viewer.
+
+Regression targets:
+- Basketball remains `Q1` by default.
+- Explicit config periods still win over sport defaults.
+- Replay/reset helpers do not mutate caller arrays.
+
+Test plan:
+- Add unit tests for shared sport-profile resolution.
+- Extend reset helper tests for soccer/baseball defaults.
+- Extend viewer state tests so reset fallback honors sport-specific defaults.
+- Run targeted unit suites plus a broader live-tracker/live-game-related suite subset.
+
+Manual spot-checks if time allows:
+- Soccer game in `track-live.html` shows `H1` after reset.
+- Baseball game viewer shows inning label instead of `Q1` on initial load/reset path.

--- a/docs/pr-notes/runs/issue-205-fixer-20260308T052559Z/requirements.md
+++ b/docs/pr-notes/runs/issue-205-fixer-20260308T052559Z/requirements.md
@@ -1,0 +1,24 @@
+Objective: remove basketball-only live scoring defaults so non-basketball games keep sport-correct phase labels through start, reset, resume, and viewer flows.
+
+Current state:
+- `track-live.html` partially adapts period labels for soccer and can read config-defined periods.
+- `js/live-tracker.js`, `js/live-tracker-reset.js`, `js/track-live-state.js`, and `js/live-game-state.js` still fall back to `Q1`.
+- That creates a broken experience for soccer/baseball after reset/replay/resume even when the tracker UI or config implies a different sport model.
+
+Proposed state:
+- Introduce one shared sport-profile helper that resolves the default phase label from sport and optional config periods.
+- Use that helper anywhere live state is initialized or reset.
+
+User value:
+- Soccer live scoring resumes at `H1` instead of `Q1`.
+- Baseball/softball live scoring can initialize and reset to inning-based labels instead of basketball quarters.
+- Viewer and tracker remain aligned after reset/replay.
+
+Assumptions:
+- The smallest safe fix for issue #205 in this pass is correcting sport-specific default tracker state, not shipping full baseball count/base-runner UI.
+- Existing arbitrary stat-column support in `track-live.html` remains the primary non-basketball stat model.
+- Configs may optionally provide `periods`, which should override sport defaults when present.
+
+Success criteria:
+- Unit tests prove soccer/baseball defaults no longer fall back to basketball labels.
+- No regression in existing basketball reset/resume behavior.

--- a/js/live-game-state.js
+++ b/js/live-game-state.js
@@ -1,3 +1,5 @@
+import { getDefaultLivePeriod } from './live-sport-config.js';
+
 export function resolveOpponentDisplayName(game) {
   const opponent = String(game?.opponent || '').trim();
   if (opponent) return opponent;
@@ -52,7 +54,10 @@ export function resolveLiveStatColumns({ columns = [], configs = [], game = null
 }
 
 export function applyResetEventState(currentState, event) {
-  const period = event?.period || currentState?.period || 'Q1';
+  const period = event?.period || currentState?.period || getDefaultLivePeriod({
+    sport: event?.sport || currentState?.sport,
+    periods: event?.periods || currentState?.periods
+  });
   const onCourt = Array.isArray(event?.onCourt) ? [...event.onCourt] : [];
   const bench = Array.isArray(event?.bench) ? [...event.bench] : [];
   const priorEventIds = currentState?.eventIds instanceof Set
@@ -73,7 +78,9 @@ export function applyResetEventState(currentState, event) {
     bench,
     lastStatChange: null,
     scoringRun: { team: null, points: 0 },
-    lastRunAnnounced: 0
+    lastRunAnnounced: 0,
+    sport: event?.sport || currentState?.sport || null,
+    periods: Array.isArray(event?.periods) ? [...event.periods] : currentState?.periods || null
   };
 }
 

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -22,6 +22,7 @@ import { getReplayElapsedMs, getReplayStartTimeAfterSpeedChange } from './live-g
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
 import { resolveOpponentDisplayName, normalizeLiveStatColumns, resolveLiveStatColumns, applyResetEventState, shouldResetViewerFromGameDoc, isLiveEventVisibleForResetBoundary } from './live-game-state.js?v=2';
+import { getDefaultLivePeriod } from './live-sport-config.js?v=1';
 
 const state = {
   teamId: null,
@@ -43,8 +44,10 @@ const state = {
   statColumns: [],
   homeScore: 0,
   awayScore: 0,
-  period: 'Q1',
+  period: getDefaultLivePeriod(),
   gameClockMs: 0,
+  sport: null,
+  periods: null,
 
   chatMessages: [],
   unreadChatCount: 0,
@@ -762,10 +765,11 @@ function updateMomentum(event) {
 function resetViewerStateFromGameDoc(gameDoc, placeholder = 'Game reset. Waiting for plays...') {
   const liveLineup = gameDoc?.liveLineup || {};
   const next = applyResetEventState(state, {
-    period: gameDoc?.period || 'Q1',
+    period: gameDoc?.period || getDefaultLivePeriod({ game: gameDoc, team: state.team }),
     homeScore: gameDoc?.homeScore || 0,
     awayScore: gameDoc?.awayScore || 0,
     gameClockMs: Number.isFinite(gameDoc?.liveClockMs) ? gameDoc.liveClockMs : 0,
+    sport: gameDoc?.sport || state.sport,
     onCourt: Array.isArray(liveLineup.onCourt) ? liveLineup.onCourt : [],
     bench: Array.isArray(liveLineup.bench) ? liveLineup.bench : []
   });
@@ -1018,7 +1022,7 @@ async function startReplay() {
   state.opponentStats = {};
   state.homeScore = 0;
   state.awayScore = 0;
-  state.period = 'Q1';
+  state.period = getDefaultLivePeriod({ game: state.game, team: state.team });
   state.gameClockMs = 0;
   state.replayIndex = 0;
   state.replayChatIndex = 0;
@@ -1139,7 +1143,7 @@ function seekReplay(targetMs) {
   state.opponentStats = {};
   state.homeScore = 0;
   state.awayScore = 0;
-  state.period = 'Q1';
+  state.period = getDefaultLivePeriod({ game: state.game, team: state.team });
   state.gameClockMs = targetMs;
   state.replayIndex = 0;
   state.replayChatIndex = 0;
@@ -1469,6 +1473,8 @@ async function init() {
   state.team = team;
   state.game = game;
   state.players = players || [];
+  state.sport = game?.sport || team?.sport || null;
+  state.periods = null;
   state.statColumns = resolveLiveStatColumns({
     columns: state.statColumns,
     configs,
@@ -1482,7 +1488,7 @@ async function init() {
   }
   state.homeScore = game.homeScore || 0;
   state.awayScore = game.awayScore || 0;
-  state.period = game.period || 'Q1';
+  state.period = game.period || getDefaultLivePeriod({ game, team });
   state.lastResetAt = getTimestampMs(game.liveResetAt) || 0;
 
   setupVideoPanel();

--- a/js/live-sport-config.js
+++ b/js/live-sport-config.js
@@ -1,0 +1,36 @@
+function normalizeSport(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function getExplicitPeriodLabels(periods) {
+  if (!Array.isArray(periods)) return [];
+  return periods
+    .map((period) => String(period?.label || period || '').trim())
+    .filter(Boolean);
+}
+
+function getSportDefaults(sport) {
+  switch (normalizeSport(sport)) {
+    case 'soccer':
+      return ['H1', 'H2', 'ET1', 'ET2', 'PK'];
+    case 'baseball':
+    case 'softball':
+      return ['T1', 'B1', 'T2', 'B2', 'T3', 'B3', 'T4', 'B4', 'T5', 'B5', 'T6', 'B6', 'T7', 'B7'];
+    default:
+      return ['Q1', 'Q2', 'Q3', 'Q4', 'OT'];
+  }
+}
+
+export function resolveLiveSport({ sport = '', game = null, team = null, config = null } = {}) {
+  return String(sport || game?.sport || team?.sport || config?.baseType || '').trim();
+}
+
+export function getSportPeriodLabels({ sport = '', periods = null, game = null, team = null, config = null } = {}) {
+  const explicit = getExplicitPeriodLabels(periods || config?.periods || game?.periods);
+  if (explicit.length) return explicit;
+  return getSportDefaults(resolveLiveSport({ sport, game, team, config }));
+}
+
+export function getDefaultLivePeriod(options = {}) {
+  return getSportPeriodLabels(options)[0] || 'Q1';
+}

--- a/js/live-tracker-reset.js
+++ b/js/live-tracker-reset.js
@@ -1,17 +1,21 @@
+import { getDefaultLivePeriod } from './live-sport-config.js';
+
 export function buildLiveResetEvent({
-  period = 'Q1',
+  period,
   gameClockMs = 0,
   homeScore = 0,
   awayScore = 0,
   onCourt = [],
   bench = [],
+  sport = '',
+  periods = null,
   createdBy = null,
   description = 'Tracker reset. Live viewer state cleared.'
 } = {}) {
   return {
     type: 'reset',
     description,
-    period,
+    period: period || getDefaultLivePeriod({ sport, periods }),
     gameClockMs,
     homeScore,
     awayScore,

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -15,6 +15,7 @@ import { resolveSummaryRecipient } from './live-tracker-email.js?v=1';
 import { buildLiveResetEvent } from './live-tracker-reset.js?v=1';
 import { advanceLiveChatUnreadState } from './live-tracker-chat-unread.js?v=2';
 import { normalizeLiveStatColumns, resolveLiveStatColumns } from './live-game-state.js?v=2';
+import { getDefaultLivePeriod, getSportPeriodLabels } from './live-sport-config.js?v=1';
 
 let currentTeamId = null;
 let currentGameId = null;
@@ -41,7 +42,7 @@ function statDefaults(columns) {
 }
 
 let state = {
-  period: 'Q1',
+  period: getDefaultLivePeriod(),
   clock: 0,
   running: false,
   lastTick: null,
@@ -1000,12 +1001,14 @@ async function broadcastEvent(eventData) {
 async function broadcastResetEvent(description = 'Tracker reset. Live viewer state cleared.') {
   if (!currentTeamId || !currentGameId) return;
   await broadcastEvent(buildLiveResetEvent({
-    period: state.period || 'Q1',
+    period: state.period || getDefaultLivePeriod({ game: currentGame, team: currentTeam, config: currentConfig }),
     gameClockMs: 0,
     homeScore: 0,
     awayScore: 0,
     onCourt: state.onCourt || [],
     bench: state.bench || roster.map((player) => player.id),
+    sport: currentTeam?.sport || currentGame?.sport || currentConfig?.baseType || '',
+    periods: currentConfig?.periods || null,
     createdBy: currentUser?.uid || null,
     description
   }));
@@ -1682,6 +1685,16 @@ function setPeriod(p) {
   }
 
   renderHeader();
+}
+
+function applyPeriodButtons() {
+  const labels = getSportPeriodLabels({ game: currentGame, team: currentTeam, config: currentConfig }).slice(0, 5);
+  const fallbackLabel = labels[0] || getDefaultLivePeriod({ game: currentGame, team: currentTeam, config: currentConfig });
+  document.querySelectorAll('.period-btn').forEach((button, index) => {
+    const label = labels[index] || fallbackLabel;
+    button.dataset.period = label;
+    button.textContent = label;
+  });
 }
 
 function addStat(id, key, delta) {
@@ -2389,7 +2402,7 @@ async function init() {
     }
 
     // Reset base state
-    state.period = 'Q1';
+    state.period = getDefaultLivePeriod({ game, team, config: currentConfig });
     state.clock = 0;
     state.running = false;
     state.lastTick = null;
@@ -2412,6 +2425,7 @@ async function init() {
     state.activeVoiceRecognition = null;
     setVoiceNoteButtonLabel(false);
     setVoiceNoteHint(false);
+    applyPeriodButtons();
 
     let shouldResume = true;
     const hasOpponentStats = !!(game.opponentStats && Object.keys(game.opponentStats).length > 0);

--- a/js/track-live-state.js
+++ b/js/track-live-state.js
@@ -1,3 +1,5 @@
+import { getDefaultLivePeriod } from './live-sport-config.js';
+
 export function summarizePersistedTrackingState({
   eventsCount = 0,
   statsCount = 0,
@@ -24,7 +26,8 @@ export function summarizePersistedTrackingState({
 
 export function buildTrackLiveResetUpdate({
   currentGame = {},
-  period = 'Q1',
+  currentConfig = null,
+  period,
   liveLineup = { onCourt: [], bench: [] },
   liveResetAt = Date.now()
 } = {}) {
@@ -33,7 +36,7 @@ export function buildTrackLiveResetUpdate({
   return {
     homeScore: 0,
     awayScore: 0,
-    period,
+    period: period || getDefaultLivePeriod({ game: currentGame, config: currentConfig }),
     liveLineup: { onCourt, bench },
     opponentStats: {},
     liveStatus: 'scheduled',

--- a/tests/unit/live-game-state.test.js
+++ b/tests/unit/live-game-state.test.js
@@ -86,6 +86,16 @@ describe('live game state helpers', () => {
     expect(Array.from(next.eventIds)).toEqual(['e1', 'e2']);
   });
 
+  it('uses a sport-specific reset period when no explicit period is provided', () => {
+    const next = applyResetEventState({
+      sport: 'Soccer',
+      period: '',
+      eventIds: new Set()
+    }, {});
+
+    expect(next.period).toBe('H1');
+  });
+
   it('detects scheduled reset from game doc when tracked state exists', () => {
     const shouldReset = shouldResetViewerFromGameDoc(
       { liveStatus: 'scheduled', liveHasData: false, homeScore: 0, awayScore: 0 },

--- a/tests/unit/live-sport-config.test.js
+++ b/tests/unit/live-sport-config.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { getDefaultLivePeriod, getSportPeriodLabels } from '../../js/live-sport-config.js';
+
+describe('live sport config helpers', () => {
+  it('returns basketball defaults when sport is missing', () => {
+    expect(getDefaultLivePeriod()).toBe('Q1');
+    expect(getSportPeriodLabels()).toEqual(['Q1', 'Q2', 'Q3', 'Q4', 'OT']);
+  });
+
+  it('returns soccer half labels by sport', () => {
+    expect(getDefaultLivePeriod({ sport: 'Soccer' })).toBe('H1');
+    expect(getSportPeriodLabels({ sport: 'Soccer' })).toEqual(['H1', 'H2', 'ET1', 'ET2', 'PK']);
+  });
+
+  it('returns inning labels for baseball and softball', () => {
+    expect(getDefaultLivePeriod({ sport: 'Baseball' })).toBe('T1');
+    expect(getDefaultLivePeriod({ sport: 'Softball' })).toBe('T1');
+    expect(getSportPeriodLabels({ sport: 'Baseball' })).toEqual(['T1', 'B1', 'T2', 'B2', 'T3', 'B3', 'T4', 'B4', 'T5', 'B5', 'T6', 'B6', 'T7', 'B7']);
+  });
+
+  it('prefers explicit config period labels over sport defaults', () => {
+    expect(getDefaultLivePeriod({
+      sport: 'Soccer',
+      periods: [
+        { label: '1st Half' },
+        { label: '2nd Half' }
+      ]
+    })).toBe('1st Half');
+
+    expect(getSportPeriodLabels({
+      sport: 'Basketball',
+      periods: [
+        { label: 'Set 1' },
+        { label: 'Set 2' }
+      ]
+    })).toEqual(['Set 1', 'Set 2']);
+  });
+});

--- a/tests/unit/live-tracker-reset.test.js
+++ b/tests/unit/live-tracker-reset.test.js
@@ -38,4 +38,9 @@ describe('live tracker reset event helper', () => {
     expect(event.onCourt).toEqual([]);
     expect(event.bench).toEqual([]);
   });
+
+  it('uses a sport-specific default period when none is provided', () => {
+    expect(buildLiveResetEvent({ sport: 'Soccer' }).period).toBe('H1');
+    expect(buildLiveResetEvent({ sport: 'Baseball' }).period).toBe('T1');
+  });
 });

--- a/tests/unit/track-live-state.test.js
+++ b/tests/unit/track-live-state.test.js
@@ -83,4 +83,14 @@ describe('track live state helpers', () => {
     input.onCourt.push('p3');
     expect(payload.liveLineup.onCourt).toEqual(['p1']);
   });
+
+  it('uses sport-specific default periods for non-basketball resets', () => {
+    expect(buildTrackLiveResetUpdate({
+      currentGame: { sport: 'Soccer' }
+    }).period).toBe('H1');
+
+    expect(buildTrackLiveResetUpdate({
+      currentGame: { sport: 'Baseball' }
+    }).period).toBe('T1');
+  });
 });

--- a/track-live.html
+++ b/track-live.html
@@ -495,6 +495,7 @@
         import { resolveOpponentDisplayName } from './js/live-game-state.js?v=1';
         import { createFieldState, setPlayerFieldStatus, startFieldClock, pauseFieldClock, getPlayerFieldElapsedMs, getLiveLineup } from './js/live-tracker-field-status.js?v=1';
         import { summarizePersistedTrackingState, buildTrackLiveResetUpdate, runTrackLiveResetPersistence } from './js/track-live-state.js?v=1';
+        import { getDefaultLivePeriod, getSportPeriodLabels } from './js/live-sport-config.js?v=1';
         import { checkAuth } from './js/auth.js?v=9';
         import { getApp } from './js/vendor/firebase-app.js';
         import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './js/live-tracker-notes.js?v=1';
@@ -550,7 +551,7 @@
             gameLog: [],
             playerStats: {}, // In-memory player stats (replaces real-time DB writes)
             opponentStats: {},
-            currentPeriod: 'Q1',
+            currentPeriod: getDefaultLivePeriod(),
             playerFieldStatus: {}
         };
 
@@ -692,17 +693,14 @@
                     };
                 }
 
-                const sportType = String(currentTeam?.sport || currentConfig?.baseType || '').toLowerCase();
-                const periodLabels = sportType.includes('soccer')
-                    ? ['H1', 'H2', 'ET1', 'ET2', 'PK']
-                    : ['Q1', 'Q2', 'Q3', 'Q4', 'OT'];
+                const periodLabels = getSportPeriodLabels({ team: currentTeam, config: currentConfig }).slice(0, 5);
                 const periodButtons = document.querySelectorAll('.period-btn');
                 periodButtons.forEach((btn, index) => {
                     const label = periodLabels[index] || periodLabels[0];
                     btn.dataset.period = label;
                     btn.textContent = label;
                 });
-                gameState.currentPeriod = periodLabels[0];
+                gameState.currentPeriod = periodLabels[0] || getDefaultLivePeriod({ team: currentTeam, config: currentConfig });
 
                 // Load existing aggregated stats from Firestore into gameState
                 const statsSnapshot = await getDocs(collection(db, `teams/${teamId}/games/${gameId}/aggregatedStats`));
@@ -1443,6 +1441,7 @@
                                         currentGameId,
                                         buildTrackLiveResetUpdate({
                                             currentGame,
+                                            currentConfig,
                                             period: gameState.currentPeriod,
                                             liveLineup: resetLineup
                                         })
@@ -1534,7 +1533,7 @@
                 gameState.startTime = null;
                 gameState.elapsed = 0;
                 gameState.isRunning = false;
-                gameState.currentPeriod = (currentConfig?.periods?.[0]?.label) || 'Q1';
+                gameState.currentPeriod = getDefaultLivePeriod({ team: currentTeam, config: currentConfig, game: currentGame });
                 liveState.lastClockSyncAt = 0;
                 gameState.gameLog = [];
                 gameState.playerStats = {}; // Clear in-memory player stats
@@ -1602,6 +1601,7 @@
                         await updateGame(currentTeamId, currentGameId, {
                             ...buildTrackLiveResetUpdate({
                                 currentGame,
+                                currentConfig,
                                 period: gameState.currentPeriod,
                                 liveLineup
                             }),


### PR DESCRIPTION
Closes #205

## What changed
- added a shared `live-sport-config` helper to resolve sport-specific live period labels and defaults for basketball, soccer, baseball, and softball
- replaced hardcoded `Q1` fallbacks in live tracker reset/state helpers so non-basketball games keep the correct phase label after reset, replay bootstrap, and viewer refresh
- updated `track-live.html` and `js/live-tracker.js` to apply sport-aware period labels from the shared helper instead of basketball-only defaults
- persisted the required run notes under `docs/pr-notes/runs/issue-205-fixer-20260308T052559Z/`

## Why
The live scoring flow already had some non-basketball support, but reset and initialization paths still snapped back to basketball quarter labels. That broke soccer and baseball experiences by reintroducing `Q1` during restart, replay, and viewer state rebuilds.

## Tests
- added unit coverage for sport-specific period defaults and config-period precedence
- ran `./node_modules/.bin/vitest run tests/unit/live-sport-config.test.js tests/unit/live-game-state.test.js tests/unit/track-live-state.test.js tests/unit/live-tracker-reset.test.js`
- ran `./node_modules/.bin/vitest run tests/unit/live-*.test.js tests/unit/track-live-state.test.js`