### PR TITLE
Handle chat write failures after game cancellation

### DIFF
--- a/docs/pr-notes/runs/issue-265-fixer-20260310T052558Z/architecture.md
+++ b/docs/pr-notes/runs/issue-265-fixer-20260310T052558Z/architecture.md
@@ -1,0 +1,21 @@
+Objective: preserve correct write semantics and reduce blast radius from a secondary Firestore failure.
+
+Current state:
+- The page script awaits game cancellation and team-chat notification inside the same `try/catch`.
+- The client therefore collapses two different failure domains into one fatal outcome.
+
+Proposed state:
+- Keep `cancelGame(...)` as the only required write for the cancel action.
+- Execute chat notification as a second awaited step with its own error boundary.
+
+Why this path:
+- It is the smallest change that preserves current data model and UI structure.
+- No backend change is required because the bug is in client-side error handling, not write semantics.
+
+Control equivalence:
+- No permissions are expanded.
+- No additional writes are introduced.
+- The change narrows false-negative UX without changing the committed game state behavior.
+
+Rollback:
+- Revert the helper module import and restore the previous inline handler if needed.

--- a/docs/pr-notes/runs/issue-265-fixer-20260310T052558Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-265-fixer-20260310T052558Z/code-plan.md
@@ -1,0 +1,12 @@
+Implementation plan:
+1. Add a small module for the cancel workflow so behavior can be unit-tested directly.
+2. In that helper:
+   - await `cancelGame(...)`
+   - attempt `postChatMessage(...)` in a nested `try/catch`
+   - return a result object describing `cancelled`, optional `notificationError`, or fatal `error`
+3. Update `edit-schedule.html` to call the helper from the existing click handler and keep the UI messages aligned with the returned result.
+4. Add a focused Vitest regression covering success-with-warning and fatal failure.
+
+Tradeoffs:
+- This introduces one new JS module, but it avoids brittle HTML-string-only testing for behavior.
+- The patch remains narrow and keeps existing page structure intact.

--- a/docs/pr-notes/runs/issue-265-fixer-20260310T052558Z/qa.md
+++ b/docs/pr-notes/runs/issue-265-fixer-20260310T052558Z/qa.md
@@ -1,0 +1,14 @@
+Test strategy:
+- Add a unit test for the cancel flow helper that proves:
+  1. cancellation success + chat failure still resolves as successful cancellation with a warning
+  2. cancellation failure still returns a fatal error and does not attempt chat
+- Add a lightweight wiring assertion in `edit-schedule.html` only if needed to confirm the page uses the helper.
+
+Regression risks to watch:
+- Users should not see a fatal cancel error when the game document was already updated.
+- Chat warning text should be explicit enough to explain the partial failure without implying rollback.
+- Schedule reload should still happen after a successful cancellation, including when chat notification fails.
+
+Validation:
+- Run the new focused unit test file.
+- Run the existing edit-schedule unit test file to catch accidental page-script regressions.

--- a/docs/pr-notes/runs/issue-265-fixer-20260310T052558Z/requirements.md
+++ b/docs/pr-notes/runs/issue-265-fixer-20260310T052558Z/requirements.md
@@ -1,0 +1,24 @@
+Objective: keep game cancellation successful when the follow-up team chat notification fails.
+
+Current state:
+- Cancel flow in `edit-schedule.html` treats `cancelGame(...)` and `postChatMessage(...)` as one atomic operation in the UI.
+- A chat write failure after the game document update misreports the result as a failed cancellation.
+
+Proposed state:
+- Cancellation remains the source-of-truth operation.
+- Chat notification is a best-effort follow-up. If it fails, the UI must still reflect that the game was cancelled.
+
+Risk surface and blast radius:
+- Affects only the cancel-game action in Edit Schedule.
+- Blast radius is limited to user messaging for one workflow, but current behavior can trigger duplicate retries and support confusion.
+
+Assumptions:
+- Users care more about the schedule state being correct than a non-critical chat side effect succeeding.
+- A warning is acceptable when chat notification fails, but the cancellation must not be rolled back or described as failed.
+
+Recommendation:
+- Separate fatal cancellation failure from non-fatal chat notification failure in the client workflow.
+- Add regression coverage for both branches so the distinction does not regress.
+
+Success measure:
+- When `cancelGame(...)` succeeds and `postChatMessage(...)` throws, the UI still reports success and refreshes the schedule.

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -590,6 +590,7 @@
         import { checkAuth } from './js/auth.js?v=9';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { getTeamAccessInfo } from './js/team-access.js';
+        import { cancelScheduledGame } from './js/edit-schedule-cancel-game.js?v=1';
         import { Timestamp } from "./js/firebase.js?v=9";
         import { getApp } from './js/vendor/firebase-app.js';
         import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
@@ -1049,22 +1050,24 @@
                     const game = gamesCache[gameId];
                     if (!game) return;
                     if (!confirm(`Cancel the game vs. ${game.opponent}? This will notify the team via chat.`)) return;
-                    try {
-                        await cancelGame(currentTeamId, gameId, currentUser.uid);
-                        // Post cancellation to team chat
-                        const gameDate = game.date?.toDate ? game.date.toDate() : new Date(game.date);
-                        const dateStr = gameDate.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
-                        await postChatMessage(currentTeamId, {
-                            text: `⚠️ Game cancelled: vs. ${game.opponent} on ${dateStr}`,
-                            senderId: currentUser.uid,
-                            senderName: currentUser.displayName || currentUser.email,
-                            senderEmail: currentUser.email
-                        });
+                    const result = await cancelScheduledGame({
+                        teamId: currentTeamId,
+                        gameId,
+                        user: currentUser,
+                        game,
+                        cancelGame,
+                        postChatMessage
+                    });
+                    if (result.cancelled) {
                         loadSchedule();
-                    } catch (err) {
-                        console.error('Failed to cancel game:', err);
-                        alert('Error cancelling game: ' + err.message);
+                        if (result.notificationError) {
+                            console.error('Game cancelled but team chat notification failed:', result.notificationError);
+                            alert(`Game cancelled, but team chat notification failed: ${result.notificationError}`);
+                        }
+                        return;
                     }
+                    console.error('Failed to cancel game:', result.error);
+                    alert('Error cancelling game: ' + result.error);
                 });
             });
 

--- a/js/edit-schedule-cancel-game.js
+++ b/js/edit-schedule-cancel-game.js
@@ -1,0 +1,45 @@
+function formatCancelledGameDate(value) {
+    const gameDate = value?.toDate ? value.toDate() : new Date(value);
+    return gameDate.toLocaleDateString('en-US', {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric'
+    });
+}
+
+export async function cancelScheduledGame({
+    teamId,
+    gameId,
+    user,
+    game,
+    cancelGame,
+    postChatMessage
+}) {
+    try {
+        await cancelGame(teamId, gameId, user.uid);
+    } catch (error) {
+        return {
+            cancelled: false,
+            error: error?.message || 'Unknown cancellation error'
+        };
+    }
+
+    try {
+        await postChatMessage(teamId, {
+            text: `⚠️ Game cancelled: vs. ${game.opponent} on ${formatCancelledGameDate(game.date)}`,
+            senderId: user.uid,
+            senderName: user.displayName || user.email,
+            senderEmail: user.email
+        });
+
+        return {
+            cancelled: true,
+            notificationError: null
+        };
+    } catch (error) {
+        return {
+            cancelled: true,
+            notificationError: error?.message || 'Unknown chat notification error'
+        };
+    }
+}

--- a/tests/unit/edit-schedule-cancel-game.test.js
+++ b/tests/unit/edit-schedule-cancel-game.test.js
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { cancelScheduledGame } from '../../js/edit-schedule-cancel-game.js';
+
+function readEditSchedule() {
+    return readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
+}
+
+describe('cancelScheduledGame', () => {
+    it('wires edit schedule through the shared cancellation helper', () => {
+        const source = readEditSchedule();
+
+        expect(source).toContain("import { cancelScheduledGame } from './js/edit-schedule-cancel-game.js?v=1';");
+        expect(source).toContain('const result = await cancelScheduledGame({');
+        expect(source).toContain('Game cancelled, but team chat notification failed:');
+        expect(source).not.toContain("alert('Error cancelling game: ' + err.message);");
+    });
+
+    it('keeps the cancellation successful when the follow-up chat notification fails', async () => {
+        const cancelGame = vi.fn().mockResolvedValue(undefined);
+        const postChatMessage = vi.fn().mockRejectedValue(new Error('chat writes blocked'));
+
+        const result = await cancelScheduledGame({
+            teamId: 'team-123',
+            gameId: 'game-456',
+            user: {
+                uid: 'user-789',
+                displayName: 'Coach Kelly',
+                email: 'coach@example.com'
+            },
+            game: {
+                opponent: 'Tigers',
+                date: '2026-03-10T18:00:00.000Z'
+            },
+            cancelGame,
+            postChatMessage
+        });
+
+        expect(cancelGame).toHaveBeenCalledWith('team-123', 'game-456', 'user-789');
+        expect(postChatMessage).toHaveBeenCalledWith('team-123', {
+            text: '⚠️ Game cancelled: vs. Tigers on Tue, Mar 10',
+            senderId: 'user-789',
+            senderName: 'Coach Kelly',
+            senderEmail: 'coach@example.com'
+        });
+        expect(result).toEqual({
+            cancelled: true,
+            notificationError: 'chat writes blocked'
+        });
+    });
+
+    it('returns a fatal error when the cancellation write itself fails', async () => {
+        const cancelGame = vi.fn().mockRejectedValue(new Error('permission denied'));
+        const postChatMessage = vi.fn();
+
+        const result = await cancelScheduledGame({
+            teamId: 'team-123',
+            gameId: 'game-456',
+            user: {
+                uid: 'user-789',
+                displayName: 'Coach Kelly',
+                email: 'coach@example.com'
+            },
+            game: {
+                opponent: 'Tigers',
+                date: '2026-03-10T18:00:00.000Z'
+            },
+            cancelGame,
+            postChatMessage
+        });
+
+        expect(postChatMessage).not.toHaveBeenCalled();
+        expect(result).toEqual({
+            cancelled: false,
+            error: 'permission denied'
+        });
+    });
+});


### PR DESCRIPTION
Closes #265

## What changed
- moved the Edit Schedule game-cancellation workflow into a small shared helper so the behavior is unit-testable
- treated the chat notification write as a non-fatal follow-up after `cancelGame(...)` succeeds
- updated the UI flow to reload the schedule after a successful cancellation and show a warning if the chat post fails instead of reporting the cancellation itself as failed
- added regression coverage for both partial-failure and fatal cancellation-failure paths, plus a wiring check that `edit-schedule.html` uses the helper
- captured the required requirements, architecture, QA, and code-plan notes in the per-run `docs/pr-notes` directory

## Why
The bug was caused by awaiting `cancelGame(...)` and `postChatMessage(...)` inside one `try/catch`, which made a secondary chat write failure look like the cancellation itself failed. This patch preserves the committed cancellation state as the source of truth while still surfacing notification problems accurately.