### PR TITLE
Bust accept-invite caches for admin invite redemption

### DIFF
--- a/accept-invite.html
+++ b/accept-invite.html
@@ -136,8 +136,8 @@
 
     <script type="module">
         import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=10';
-        import { validateAccessCode, redeemParentInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=14';
-        import { createInviteProcessor } from './js/accept-invite-flow.js?v=2';
+        import { validateAccessCode, redeemParentInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=15';
+        import { createInviteProcessor } from './js/accept-invite-flow.js?v=3';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 
         renderFooter(document.getElementById('footer-container'));

--- a/docs/pr-notes/runs/issue-276-fixer-20260310T112618Z/architecture.md
+++ b/docs/pr-notes/runs/issue-276-fixer-20260310T112618Z/architecture.md
@@ -1,0 +1,20 @@
+Current state:
+- `accept-invite.html` delegates admin invite handling to `js/accept-invite-flow.js`.
+- `js/accept-invite-flow.js` calls `redeemAdminInviteAtomically(...)` from `js/db.js`, which appends the normalized email to `adminEmails`, adds coach membership, and marks the code used in a transaction.
+- Because the page still imports `db.js?v=14` and `accept-invite-flow.js?v=2`, browsers can reuse cached pre-fix assets for this path.
+
+Proposed state:
+- Bump the `accept-invite.html` module URLs so the page loads the fixed redemption code path immediately after deploy.
+
+Blast radius:
+- One HTML entry point and one regression test.
+- No data model or Firestore rule changes.
+
+Tradeoff:
+- Minimal blast-radius cache invalidation versus broader refactoring of invite flow modules that are already correct on this branch.
+
+Rollback:
+- Revert the import version bump if it causes an unexpected asset-loading issue, although risk is low because the module APIs are unchanged.
+
+Note:
+- The requested `allplays-orchestrator-playbook` skill and `sessions_spawn` subagent tooling were not available in this session, so these notes capture the equivalent role synthesis directly.

--- a/docs/pr-notes/runs/issue-276-fixer-20260310T112618Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-276-fixer-20260310T112618Z/code-plan.md
@@ -1,0 +1,10 @@
+Thinking level: medium
+Reason: the reported production bug overlaps with code that is already fixed on this branch, so the remaining work is to confirm the true exposure and patch the narrowest path that still fails.
+
+Implementation plan:
+1. Add a regression test that fails if `accept-invite.html` still points at stale invite-flow module versions.
+2. Bump the page imports for `db.js` and `accept-invite-flow.js` so browsers fetch the fixed admin invite redemption logic.
+3. Run the focused invite and access-control unit tests.
+
+What would change my mind:
+- Evidence that the deployed failure is caused by a still-active inline invite implementation rather than cached module URLs, which would require a functional code-path patch instead of cache invalidation.

--- a/docs/pr-notes/runs/issue-276-fixer-20260310T112618Z/qa.md
+++ b/docs/pr-notes/runs/issue-276-fixer-20260310T112618Z/qa.md
@@ -1,0 +1,17 @@
+Focus:
+- Prevent stale cached invite assets from reintroducing the false-success admin invite path.
+
+Primary test:
+- Read `accept-invite.html` and assert it imports the fresh `db.js` and `accept-invite-flow.js` versions required for atomic admin invite redemption.
+
+Additional validation:
+1. Run the invite flow unit tests to confirm the admin acceptance path still calls `redeemAdminInviteAtomically(...)`.
+2. Run the existing admin invite redemption and access-control tests to confirm `adminEmails` remains the access source of truth.
+
+Manual spot check to recommend in PR:
+1. Generate an admin invite from `edit-team.html`.
+2. Open the invite link in a browser with cached assets, accept it, and verify the invited admin sees the team on `dashboard.html`.
+3. Confirm edit/chat actions succeed immediately after redirect.
+
+Residual risk:
+- A client that never reloads `accept-invite.html` after deploy would still hold stale code until navigation refreshes the page.

--- a/docs/pr-notes/runs/issue-276-fixer-20260310T112618Z/requirements.md
+++ b/docs/pr-notes/runs/issue-276-fixer-20260310T112618Z/requirements.md
@@ -1,0 +1,22 @@
+Objective: ensure accepted admin invites result in immediate, real team-admin access on the dashboard and protected team actions.
+
+Current state:
+- The codebase already routes `accept-invite.html` through the atomic admin invite redemption flow.
+- The invite page still references older cache-busted module URLs, so a browser with cached pre-fix assets can keep running the stale acceptance logic.
+
+Proposed state:
+- `accept-invite.html` must pin fresh versions of the invite-flow modules that persist `teams/{teamId}.adminEmails` during admin invite redemption.
+
+Risk surface and blast radius:
+- Invite acceptance only.
+- High user impact because the UI can claim success while the invited admin still lacks dashboard visibility and write access.
+
+Assumptions:
+- The atomic redemption path in `js/db.js` is the intended source of truth for admin invite acceptance.
+- The remaining production exposure for issue #276 is stale cached client code on `accept-invite.html`.
+
+Recommendation:
+- Ship a cache-busting bump on the invite acceptance page and lock it in with a unit test that reads the HTML import pins directly.
+
+Success measure:
+- A regression test fails on the stale import versions and passes once the page references the fresh invite modules.

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -10,6 +10,17 @@ describe('admin invite signup cache busting', () => {
         expect(authSource).toContain("import { redeemAdminInviteAcceptance } from './admin-invite.js?v=3';");
     });
 
+    it('pins fresh invite acceptance module versions for admin invite redemption', () => {
+        const acceptInviteSource = readFileSync(resolve(process.cwd(), 'accept-invite.html'), 'utf8');
+
+        expect(acceptInviteSource).toContain(
+            "import { validateAccessCode, redeemParentInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=15';"
+        );
+        expect(acceptInviteSource).toContain(
+            "import { createInviteProcessor } from './js/accept-invite-flow.js?v=3';"
+        );
+    });
+
     it('bumps auth module consumers after signup flow changes', () => {
         const authConsumers = [
             'login.html',


### PR DESCRIPTION
Closes #276

## What changed
- bumped `accept-invite.html` to load fresh `db.js` and `accept-invite-flow.js` module versions so browsers fetch the fixed atomic admin invite redemption path
- added a regression test that pins the invite acceptance page to the fresh module versions required for admin invite persistence
- recorded the requirements, architecture, QA, and code-plan notes for this fixer run under `docs/pr-notes/runs/issue-276-fixer-20260310T112618Z/`

## Why
- the branch already contains the functional fix that persists invited admin emails through `redeemAdminInviteAtomically(...)`, but `accept-invite.html` was still pointing at older cache-busted module URLs
- that left a stale-client path where invite acceptance could still claim success without actually granting team admin access

## Validation
- `node node_modules/vitest/vitest.mjs run tests/unit/admin-invite-signup-cache-busting.test.js tests/unit/accept-invite-flow.test.js tests/unit/admin-invite-redemption.test.js tests/unit/admin-invite-atomic-persistence-guard.test.js tests/unit/team-access.test.js`
- attempted `npm run test:unit -- ...`, but `npm` is not installed in this runner