### PR TITLE
Fix stats config access for platform admins

### DIFF
--- a/docs/pr-notes/runs/issue-268-fixer-20260310T202618Z/architecture.md
+++ b/docs/pr-notes/runs/issue-268-fixer-20260310T202618Z/architecture.md
@@ -1,0 +1,12 @@
+# Architecture
+
+Current state: `edit-config.html` decides access inline and only returns a boolean, which makes drift from shared access rules easy.
+
+Proposed state: move the page-specific authorization decision into `js/edit-config-access.js`, built on top of `getTeamAccessInfo(...)`.
+
+Controls:
+- Shared full-access policy stays in `js/team-access.js`.
+- `edit-config.html` consumes a page-specific decision object with `allowed` and `exitUrl`.
+- The page continues to deny parent-only users and unresolved teams.
+
+Rollback plan: revert the new helper and restore the prior inline access check in `edit-config.html`.

--- a/docs/pr-notes/runs/issue-268-fixer-20260310T202618Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-268-fixer-20260310T202618Z/code-plan.md
@@ -1,0 +1,9 @@
+# Code Plan
+
+Thinking level: medium. The bug is narrow, but the page has to stay aligned with shared access behavior.
+
+Plan:
+1. Add a unit test for the stats config page access decision, including platform-admin and parent-only paths.
+2. Introduce a tiny helper module for `edit-config.html` that uses `getTeamAccessInfo(...)` and preserves redirect targets.
+3. Replace the page's inline boolean gate with the shared decision helper.
+4. Run the focused Vitest suite and commit the fix with issue reference.

--- a/docs/pr-notes/runs/issue-268-fixer-20260310T202618Z/qa.md
+++ b/docs/pr-notes/runs/issue-268-fixer-20260310T202618Z/qa.md
@@ -1,0 +1,12 @@
+# QA
+
+Primary regression to cover:
+- Platform admin can open `edit-config.html#teamId=...` for a team they do not own and are not listed on.
+
+Guardrails:
+- Parent-linked users remain blocked from stats config management.
+- Missing or invalid team lookup still redirects safely.
+
+Validation plan:
+- Run `npm test -- edit-config-access.test.js team-management-access-wiring.test.js team-access.test.js`.
+- Manual spot-check: sign in as platform admin, open team page, click `Stats`, confirm page loads instead of redirecting.

--- a/docs/pr-notes/runs/issue-268-fixer-20260310T202618Z/requirements.md
+++ b/docs/pr-notes/runs/issue-268-fixer-20260310T202618Z/requirements.md
@@ -1,0 +1,15 @@
+# Requirements
+
+Objective: restore the Stats config workflow for platform admins on `edit-config.html`.
+
+Current state: team navigation exposes the Stats action to full-access users, including platform admins.
+Proposed state: `edit-config.html` must evaluate access with the same shared team-access policy used by the rest of team management.
+
+Risk surface: low. This touches a single page's client-side authorization gate and related unit coverage.
+Blast radius: limited to team stats config entry and redirect behavior.
+
+Assumptions:
+- Platform admins are identified by `user.isAdmin === true`.
+- Stats config management remains full-access only; parent access should still be denied.
+
+Recommendation: centralize the page-level allow/deny decision behind a small helper and cover platform-admin, parent, and missing-team paths with Vitest.

--- a/edit-config.html
+++ b/edit-config.html
@@ -108,16 +108,12 @@
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
-        import { hasFullTeamAccess } from './js/team-access.js';
+        import { getEditConfigAccessDecision } from './js/edit-config-access.js';
 
         renderFooter(document.getElementById('footer-container'));
 
         let currentTeamId = null;
         let currentUser = null;
-        function hasAccess(team, user) {
-            return hasFullTeamAccess(user, team);
-        }
-
         checkAuth((user) => {
             if (!user) {
                 window.location.href = 'login.html';
@@ -136,12 +132,13 @@
             }
             currentTeamId = teamId;
 
-            const team = await getTeam(teamId);
-            if (!hasAccess(team, currentUser)) {
+            const accessDecision = getEditConfigAccessDecision(currentUser, await getTeam(teamId), teamId);
+            if (!accessDecision.allowed) {
                 alert("Team not found or access denied.");
-                window.location.href = 'dashboard.html';
+                window.location.href = accessDecision.exitUrl || 'dashboard.html';
                 return;
             }
+            const team = accessDecision.team;
 
             // Fetch unread count and render banner
             let unreadCount = 0;

--- a/js/edit-config-access.js
+++ b/js/edit-config-access.js
@@ -1,0 +1,23 @@
+import { getTeamAccessInfo } from './team-access.js';
+
+export function getEditConfigAccessDecision(user, team, teamId) {
+    if (!team) {
+        return {
+            allowed: false,
+            exitUrl: 'dashboard.html',
+            team: null
+        };
+    }
+
+    const normalizedTeam = {
+        ...team,
+        id: team.id || teamId
+    };
+    const accessInfo = getTeamAccessInfo(user, normalizedTeam);
+
+    return {
+        allowed: accessInfo.accessLevel === 'full',
+        exitUrl: accessInfo.exitUrl,
+        team: normalizedTeam
+    };
+}

--- a/tests/unit/edit-config-access.test.js
+++ b/tests/unit/edit-config-access.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { getEditConfigAccessDecision } from '../../js/edit-config-access.js';
+
+const TEAM = {
+    id: 'team-1',
+    ownerId: 'owner-1',
+    adminEmails: ['coach@example.com']
+};
+
+describe('edit config access decision', () => {
+    it('allows platform admins to manage stats configs', () => {
+        expect(getEditConfigAccessDecision({ uid: 'admin-1', isAdmin: true }, TEAM, TEAM.id)).toEqual({
+            allowed: true,
+            exitUrl: 'dashboard.html',
+            team: TEAM
+        });
+    });
+
+    it('denies parent-only access for stats config page', () => {
+        expect(
+            getEditConfigAccessDecision(
+                { uid: 'parent-1', parentOf: [{ teamId: TEAM.id, playerId: 'player-1' }] },
+                TEAM,
+                TEAM.id
+            )
+        ).toEqual({
+            allowed: false,
+            exitUrl: 'parent-dashboard.html',
+            team: TEAM
+        });
+    });
+
+    it('denies access when the team cannot be resolved', () => {
+        expect(getEditConfigAccessDecision({ uid: 'admin-1', isAdmin: true }, null, 'missing-team')).toEqual({
+            allowed: false,
+            exitUrl: 'dashboard.html',
+            team: null
+        });
+    });
+});

--- a/tests/unit/team-management-access-wiring.test.js
+++ b/tests/unit/team-management-access-wiring.test.js
@@ -27,7 +27,7 @@ describe('team management page access wiring', () => {
 
     it('uses shared full-access helper in edit config page', () => {
         const html = readRepoFile('edit-config.html');
-        expect(html).toContain("from './js/team-access.js'");
-        expect(html).toContain('hasFullTeamAccess(');
+        expect(html).toContain("from './js/edit-config-access.js'");
+        expect(html).toContain('getEditConfigAccessDecision(');
     });
 });


### PR DESCRIPTION
Closes #268

## What changed
- extracted `edit-config.html` authorization into a small `js/edit-config-access.js` helper built on the shared team access policy
- updated the stats config page to use that decision object for allow/deny handling and redirect targets
- added a regression test covering platform-admin access, parent denial, and missing-team behavior
- updated the wiring test so `edit-config.html` stays pointed at the dedicated access helper

## Why
Platform admins were allowed into other full-access team-management screens, but the stats config flow needed an explicit, testable access decision that stayed aligned with the shared team-management policy. This patch keeps the stats page on the same authorization contract and adds regression coverage so the dead-end workflow does not return.

## Validation
- ran `./node_modules/.bin/vitest run tests/unit/edit-config-access.test.js tests/unit/team-management-access-wiring.test.js tests/unit/team-access.test.js`
- ran `./node_modules/.bin/vitest run tests/unit`