### PR TITLE
Honor team notification email in legacy trackers

### DIFF
--- a/docs/pr-notes/runs/issue-260-fixer-20260311T142557Z/architecture.md
+++ b/docs/pr-notes/runs/issue-260-fixer-20260311T142557Z/architecture.md
@@ -1,0 +1,23 @@
+Objective: patch legacy trackers with the smallest control-preserving change.
+
+Current state:
+- Recipient selection logic is duplicated in each tracker.
+- `js/live-tracker.js` already centralizes the intended fallback in `js/live-tracker-email.js`.
+
+Proposed state:
+- Import `resolveSummaryRecipient()` into `track.html` and `js/track-basketball.js`.
+- Replace direct `currentUser.email` usage with helper-based recipient selection.
+
+Risk surface and blast radius:
+- Small import and call-site changes in two tracker entry points.
+- Cache-busting remains unchanged for existing imports except for the newly added helper import.
+
+Tradeoffs:
+- Source-level wiring tests are less behavioral than DOM execution tests, but they are stable and sufficient for this regression class in a static HTML app.
+- Reusing the helper avoids future drift across tracker implementations.
+
+Rollback:
+- Revert the helper imports and recipient call-site substitutions.
+
+Instrumentation:
+- Regression is covered by focused unit tests checking helper behavior and wiring in both legacy trackers.

--- a/docs/pr-notes/runs/issue-260-fixer-20260311T142557Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-260-fixer-20260311T142557Z/code-plan.md
@@ -1,0 +1,12 @@
+Chosen thinking level: medium.
+Reason: the bug is narrow, but it spans two tracker implementations and needs regression protection without overbuilding test harnesses.
+
+Implementation plan:
+1. Add a focused unit test covering legacy tracker email helper usage.
+2. Run the focused test to confirm it fails on current source.
+3. Import `resolveSummaryRecipient()` into `track.html` and `js/track-basketball.js`.
+4. Replace direct `currentUser.email` mailto recipients with helper-based selection.
+5. Run focused tests, then the relevant broader unit suite.
+
+Fallback path:
+- If importing the helper into `track.html` causes module issues, inline a tiny wrapper that delegates to the existing helper module loaded from a separate script. Prefer direct import first.

--- a/docs/pr-notes/runs/issue-260-fixer-20260311T142557Z/qa.md
+++ b/docs/pr-notes/runs/issue-260-fixer-20260311T142557Z/qa.md
@@ -1,0 +1,15 @@
+Test strategy:
+- Add a focused unit test for legacy tracker email recipient behavior.
+- Verify both `track.html` and `js/track-basketball.js` reference `resolveSummaryRecipient()` and pass `currentTeam?.notificationEmail`.
+
+Failure proof:
+- The new test should fail against the current source because neither legacy tracker references the shared helper or team notification email.
+
+Regression guardrails:
+- Preserve fallback to `currentUser.email` when the team notification email is blank.
+- Confirm the existing live-tracker email tests still pass.
+
+Manual spot checks recommended:
+1. Set a team notification email in `edit-team.html`.
+2. Finish one game through `track.html` and one through `track-basketball.html` with send-email enabled.
+3. Confirm the opened mail client addresses the team inbox.

--- a/docs/pr-notes/runs/issue-260-fixer-20260311T142557Z/requirements.md
+++ b/docs/pr-notes/runs/issue-260-fixer-20260311T142557Z/requirements.md
@@ -1,0 +1,25 @@
+Objective: ensure all legacy game-summary email flows honor the team notification inbox before falling back to the signed-in coach email.
+
+Current state:
+- `track.html` and `js/track-basketball.js` address summary mailto links to `currentUser.email`.
+- Team settings already expose `notificationEmail`, so the workflow violates a visible user control.
+
+Proposed state:
+- All summary email flows use the same recipient preference as `js/live-tracker.js`.
+- Behavior is `currentTeam.notificationEmail` first, then `currentUser.email`, then empty string.
+
+Risk surface and blast radius:
+- Affects only client-side summary email recipient selection on legacy trackers.
+- No schema, auth, or persistence changes.
+
+Assumptions:
+- `currentTeam` is loaded before summary actions are available.
+- Reusing the existing helper keeps behavior consistent across trackers.
+
+Recommendation:
+- Reuse `resolveSummaryRecipient()` rather than duplicating fallback logic.
+- Add regression tests that verify helper usage is wired into both legacy trackers.
+
+Success measure:
+- Focused tests fail before the patch and pass after it.
+- Manual behavior aligns with the configured team notification inbox on both legacy tracker paths.

--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -7,6 +7,7 @@ import { writeBatch, doc, setDoc, addDoc } from './firebase.js?v=9';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
 import { canApplySubstitution, applySubstitution, canTrustScoreLogForFinalization, reconcileFinalScoreFromLog } from './live-tracker-integrity.js?v=1';
+import { resolveSummaryRecipient } from './live-tracker-email.js?v=1';
 
 let currentTeamId = null;
 let currentGameId = null;
@@ -723,8 +724,11 @@ async function saveAndComplete() {
     if (sendEmail) {
       const subject = `${currentTeam.name} vs ${currentGame.opponent || 'Unknown Opponent'} - Game Summary`;
       const body = generateEmailBody(finalHome, finalAway, summary);
-      const userEmail = currentUser.email || '';
-      const mailto = `mailto:${userEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+      const recipientEmail = resolveSummaryRecipient({
+        teamNotificationEmail: currentTeam?.notificationEmail,
+        userEmail: currentUser?.email
+      });
+      const mailto = `mailto:${recipientEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
       window.location.href = mailto;
       setTimeout(() => {
         window.location.href = `game.html#teamId=${currentTeamId}&gameId=${currentGameId}`;

--- a/tests/unit/legacy-tracker-email.test.js
+++ b/tests/unit/legacy-tracker-email.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolveSummaryRecipient } from '../../js/live-tracker-email.js';
+
+describe('legacy tracker summary email recipient', () => {
+    it('prefers team notification email over signed-in user email', () => {
+        expect(resolveSummaryRecipient({
+            teamNotificationEmail: 'team-notify@example.com',
+            userEmail: 'coach-login@example.com'
+        })).toBe('team-notify@example.com');
+    });
+
+    it('falls back to signed-in user email when team notification email is blank', () => {
+        expect(resolveSummaryRecipient({
+            teamNotificationEmail: '   ',
+            userEmail: 'coach-login@example.com'
+        })).toBe('coach-login@example.com');
+    });
+
+    it('wires recipient resolution into track.html summary email flows', () => {
+        const source = readFileSync(new URL('../../track.html', import.meta.url), 'utf8');
+        expect(source).toContain('resolveSummaryRecipient');
+        expect(source).toContain('teamNotificationEmail: currentTeam?.notificationEmail');
+    });
+
+    it('wires recipient resolution into the beta basketball tracker finish flow', () => {
+        const source = readFileSync(new URL('../../js/track-basketball.js', import.meta.url), 'utf8');
+        expect(source).toContain('resolveSummaryRecipient');
+        expect(source).toContain('teamNotificationEmail: currentTeam?.notificationEmail');
+    });
+});

--- a/track.html
+++ b/track.html
@@ -279,6 +279,7 @@
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { isAISummaryEnabled, applyAISummaryAvailability } from './js/track-ai-summary.js';
+        import { resolveSummaryRecipient } from './js/live-tracker-email.js?v=1';
         import { getApp } from './js/vendor/firebase-app.js';
         // Note: firebase-ai will be lazy-loaded when AI summary is requested
 
@@ -1046,8 +1047,11 @@
             const body = generateEmailBody(homeScore, awayScore, '');
 
             // Create mailto link
-            const userEmail = currentUser.email || '';
-            const mailto = `mailto:${userEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+            const recipientEmail = resolveSummaryRecipient({
+                teamNotificationEmail: currentTeam?.notificationEmail,
+                userEmail: currentUser?.email
+            });
+            const mailto = `mailto:${recipientEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
             window.location.href = mailto;
         }
 
@@ -1276,8 +1280,11 @@ Write the match report now:`;
                 if (sendEmail) {
                     const subject = `${currentTeam.name} vs ${currentGame.opponent || 'Unknown Opponent'} - Game Summary`;
                     const body = generateEmailBody(finalHome, finalAway, summary);
-                    const userEmail = currentUser.email || '';
-                    const mailto = `mailto:${userEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
+                    const recipientEmail = resolveSummaryRecipient({
+                        teamNotificationEmail: currentTeam?.notificationEmail,
+                        userEmail: currentUser?.email
+                    });
+                    const mailto = `mailto:${recipientEmail}?subject=${encodeURIComponent(subject)}&body=${encodeURIComponent(body)}`;
                     window.location.href = mailto;
 
                     // Small delay to allow mailto to open before redirecting


### PR DESCRIPTION
Closes #260

## What changed
- updated `track.html` to use the shared summary-recipient resolver when building game summary `mailto:` links
- updated `js/track-basketball.js` to use the same resolver in the beta basketball finish flow
- added `tests/unit/legacy-tracker-email.test.js` to lock in notification-email preference for both legacy tracker paths
- added per-run synthesis notes under `docs/pr-notes/runs/issue-260-fixer-20260311T142557Z/`

## Why
Legacy trackers were always sending summary emails to `currentUser.email`, which ignored the team-level `notificationEmail` setting and broke shared inbox workflows. This change aligns the legacy trackers with the newer live tracker behavior by preferring `currentTeam.notificationEmail` and only falling back to the signed-in user's email when the team setting is blank.

## Validation
- proved the regression with a new focused failing test before the fix
- ran `node node_modules/vitest/vitest.mjs run tests/unit/legacy-tracker-email.test.js tests/unit/live-tracker-email.test.js`
- ran `node node_modules/vitest/vitest.mjs run tests/unit` with `377/377` tests passing