### PR TITLE
Fix practice edit local time prefill

### DIFF
--- a/docs/pr-notes/runs/issue-263-fixer-20260312T082515Z/architecture.md
+++ b/docs/pr-notes/runs/issue-263-fixer-20260312T082515Z/architecture.md
@@ -1,0 +1,14 @@
+Decision: use the existing shared `formatIsoForInput()` helper as the single formatter for editable schedule `datetime-local` fields.
+
+Why this path:
+- It matches the already-correct pattern used elsewhere in `edit-schedule.html`.
+- It avoids introducing a new date library or changing persistence semantics.
+- It reduces duplication in the game edit flow while preserving the narrow blast radius required for a scheduling bug fix.
+
+Controls:
+- No Firestore schema changes.
+- No recurrence expansion logic changes.
+- No changes to how form submission parses `datetime-local`; only prefill formatting is normalized.
+
+Rollback:
+- Revert the helper call sites and regression test additions if unexpected UI behavior appears.

--- a/docs/pr-notes/runs/issue-263-fixer-20260312T082515Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-263-fixer-20260312T082515Z/code-plan.md
@@ -1,0 +1,5 @@
+Implementation plan:
+1. Replace duplicated `datetime-local` formatting in `startEditGame()` with the shared `formatIsoForInput()` helper for consistency.
+2. Upgrade the practice timezone regression from source inspection to executable behavior checks under a non-UTC timezone.
+3. Validate with focused and full unit runs.
+4. Commit the targeted fix and tests with an issue-referencing message.

--- a/docs/pr-notes/runs/issue-263-fixer-20260312T082515Z/qa.md
+++ b/docs/pr-notes/runs/issue-263-fixer-20260312T082515Z/qa.md
@@ -1,0 +1,14 @@
+Coverage plan:
+- Reproduce the bug with a fixed UTC timestamp under `TZ=America/Chicago`.
+- Assert `formatIsoForInput()` returns the local wall-clock value expected by a `datetime-local` input.
+- Execute `startEditPractice()` with stubbed DOM elements and verify the populated start and end inputs match the original local practice time.
+- Add a source guard that editable schedule datetime-local fields use the shared helper instead of ad hoc UTC slicing.
+
+Regression focus:
+- Existing practice edits.
+- Practice end time prefill.
+- Shared schedule edit fields that also depend on local datetime formatting.
+
+Validation:
+- Run the focused unit test file first.
+- Run the full unit suite if the focused coverage passes.

--- a/docs/pr-notes/runs/issue-263-fixer-20260312T082515Z/requirements.md
+++ b/docs/pr-notes/runs/issue-263-fixer-20260312T082515Z/requirements.md
@@ -1,0 +1,20 @@
+Objective: preserve the originally scheduled local practice time when an existing practice or recurring practice is opened and saved from `edit-schedule.html`.
+
+Current state:
+- Existing practice timestamps are stored correctly.
+- The edit UI historically risked displaying UTC-adjusted values in `datetime-local` fields, which can silently shift the saved time on update.
+
+Proposed state:
+- Practice edit inputs always show the same local wall-clock time the coach originally scheduled.
+- Saving without changing the time preserves the stored start and end exactly.
+
+Risk surface and blast radius:
+- High user-facing scheduling impact.
+- Recurring practice edits can affect an entire series, so the fix must stay narrowly scoped to datetime-local prefill behavior.
+
+Assumptions:
+- Stored practice timestamps are canonical and should not be rewritten unless the coach edits them.
+- Browser `datetime-local` inputs expect a local wall-clock string, not a UTC ISO string.
+
+Recommendation:
+- Keep the fix targeted to local-input formatting and add a regression test that executes the extracted edit-schedule logic under a non-UTC timezone.

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -1548,10 +1548,8 @@
 
             // Populate form
             const date = game.date.toDate ? game.date.toDate() : new Date(game.date);
-            // Format for datetime-local input: YYYY-MM-DDThh:mm
-            const dateStr = new Date(date.getTime() - date.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
 
-            document.getElementById('gameDate').value = dateStr;
+            document.getElementById('gameDate').value = formatIsoForInput(date);
             document.getElementById('opponent').value = game.opponent || '';
             document.getElementById('location').value = game.location || '';
             document.getElementById('statConfig').value = game.statTrackerConfigId || '';
@@ -1576,8 +1574,7 @@
             document.getElementById('countsTowardSeasonRecord').checked = game.countsTowardSeasonRecord !== false;
             if (game.arrivalTime) {
                 const at = game.arrivalTime.toDate ? game.arrivalTime.toDate() : new Date(game.arrivalTime);
-                const atStr = new Date(at.getTime() - at.getTimezoneOffset() * 60000).toISOString().slice(0, 16);
-                document.getElementById('arrivalTime').value = atStr;
+                document.getElementById('arrivalTime').value = formatIsoForInput(at);
             } else {
                 document.getElementById('arrivalTime').value = '';
             }

--- a/tests/unit/edit-schedule-practice-timezone.test.js
+++ b/tests/unit/edit-schedule-practice-timezone.test.js
@@ -1,33 +1,116 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
 
 function readEditSchedule() {
     return readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
 }
 
+function extractFunction(source, signature) {
+    const startIndex = source.indexOf(signature);
+    expect(startIndex).toBeGreaterThanOrEqual(0);
+
+    const bodyStart = source.indexOf('{', startIndex);
+    expect(bodyStart).toBeGreaterThan(startIndex);
+
+    let depth = 0;
+    for (let index = bodyStart; index < source.length; index += 1) {
+        const char = source[index];
+        if (char === '{') depth += 1;
+        if (char === '}') {
+            depth -= 1;
+            if (depth === 0) {
+                return source.slice(startIndex, index + 1);
+            }
+        }
+    }
+
+    throw new Error(`Could not extract function for signature: ${signature}`);
+}
+
+function runInTimezone(script, tz = 'America/Chicago') {
+    return execFileSync(process.execPath, ['--input-type=module', '--eval', script], {
+        encoding: 'utf8',
+        env: {
+            ...process.env,
+            TZ: tz
+        }
+    }).trim();
+}
+
 describe('edit schedule practice datetime-local prefill', () => {
-    it('uses local-input helper for practice start/end instead of UTC slicing', () => {
+    it('formats stored practice timestamps into local datetime-local values', () => {
         const source = readEditSchedule();
+        const formatIsoForInput = extractFunction(source, 'function formatIsoForInput(value) {');
 
-        const startIndex = source.indexOf('function startEditPractice(practice) {');
-        const endIndex = source.indexOf("document.getElementById('cancel-edit-practice-btn').addEventListener('click', resetPracticeForm);");
-        expect(startIndex).toBeGreaterThanOrEqual(0);
-        expect(endIndex).toBeGreaterThan(startIndex);
+        const output = runInTimezone(`
+${formatIsoForInput}
+console.log(formatIsoForInput('2026-01-16T00:00:00.000Z'));
+        `);
 
-        const block = source.slice(startIndex, endIndex);
-        expect(block).toContain("document.getElementById('practiceStart').value = formatIsoForInput(practice.date)");
-        expect(block).toContain("document.getElementById('practiceEnd').value = formatIsoForInput(practice.end)");
-
-        expect(block).not.toContain("document.getElementById('practiceStart').value = date.toISOString().slice(0, 16)");
-        expect(block).not.toContain("document.getElementById('practiceEnd').value = endDate.toISOString().slice(0, 16)");
+        expect(output).toBe('2026-01-15T18:00');
     });
 
-    it('does not leave any editable schedule datetime-local input on raw UTC slicing', () => {
+    it('prefills practice edit inputs without shifting by the timezone offset', () => {
+        const source = readEditSchedule();
+        const formatIsoForInput = extractFunction(source, 'function formatIsoForInput(value) {');
+        const startEditPractice = extractFunction(source, 'function startEditPractice(practice) {');
+
+        const output = runInTimezone(`
+let editingPracticeId = null;
+let editingSeriesId = null;
+const elements = {};
+const document = {
+    getElementById(id) {
+        if (!elements[id]) {
+            elements[id] = {
+                value: '',
+                textContent: '',
+                classList: {
+                    add() {},
+                    remove() {}
+                }
+            };
+        }
+        return elements[id];
+    },
+    querySelectorAll() {
+        return [];
+    }
+};
+function switchTab() {}
+${formatIsoForInput}
+${startEditPractice}
+startEditPractice({
+    id: 'practice-1',
+    title: 'Practice',
+    date: '2026-01-16T00:00:00.000Z',
+    end: '2026-01-16T01:30:00.000Z',
+    location: 'Main Gym',
+    notes: 'Keep time stable'
+});
+console.log(JSON.stringify({
+    practiceStart: elements.practiceStart.value,
+    practiceEnd: elements.practiceEnd.value,
+    submitLabel: elements['submit-practice-btn'].textContent
+}));
+        `);
+
+        expect(JSON.parse(output)).toEqual({
+            practiceStart: '2026-01-15T18:00',
+            practiceEnd: '2026-01-15T19:30',
+            submitLabel: 'Update Practice'
+        });
+    });
+
+    it('uses the shared local-input helper for editable schedule datetime-local fields', () => {
         const source = readEditSchedule();
 
         expect(source).toContain('function formatIsoForInput(value) {');
-        expect(source).toContain('value="${formatIsoForInput(game.arrivalTime)}"');
-        expect(source).toContain('value="${formatIsoForInput(date)}"');
+        expect(source).toContain("document.getElementById('practiceStart').value = formatIsoForInput(practice.date);");
+        expect(source).toContain("document.getElementById('practiceEnd').value = formatIsoForInput(practice.end);");
+        expect(source).toContain("document.getElementById('gameDate').value = formatIsoForInput(date);");
+        expect(source).toContain("document.getElementById('arrivalTime').value = formatIsoForInput(at);");
         expect(source).not.toContain('value="${date.toISOString().slice(0, 16)}"');
     });
 });


### PR DESCRIPTION
Closes #263

## What changed
- kept schedule editor `datetime-local` prefills on the shared `formatIsoForInput()` path so existing practices and the remaining edit-schedule datetime fields use local wall-clock values instead of ad hoc UTC slicing
- upgraded the practice timezone regression test to execute the extracted edit logic under `TZ=America/Chicago`, proving that opening an existing practice preserves the original local start and end times
- persisted the required per-run analysis notes under `docs/pr-notes/runs/issue-263-fixer-20260312T082515Z/`

## Why
Editing an existing practice could silently shift the saved time by the local UTC offset if the form was ever populated with UTC-formatted values. This change locks the edit flow to local-input formatting and adds executable coverage for the exact non-UTC bug scenario reported in the issue.

## Validation
- `node node_modules/vitest/vitest.mjs run tests/unit/edit-schedule-practice-timezone.test.js`
- `node node_modules/vitest/vitest.mjs run tests/unit`