### PR TITLE
Preserve cancelled ICS events on calendar

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -135,7 +135,7 @@
 
     <script type="module">
         import { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, getMyRsvp, getRsvpSummaries } from './js/db.js?v=23';
-        import { renderHeader, renderFooter, escapeHtml, formatDate, formatTime, fetchAndParseCalendar, expandRecurrence, buildGlobalCalendarIcsEvent } from './js/utils.js?v=10';
+        import { renderHeader, renderFooter, escapeHtml, formatDate, formatTime, fetchAndParseCalendar, expandRecurrence, buildGlobalCalendarIcsEvent } from './js/utils.js?v=11';
         import { requireAuth, checkAuth } from './js/auth.js?v=9';
         import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';
 

--- a/docs/pr-notes/runs/issue-308-fixer-20260312T202502Z/architecture.md
+++ b/docs/pr-notes/runs/issue-308-fixer-20260312T202502Z/architecture.md
@@ -1,0 +1,23 @@
+Objective: preserve ICS cancellation semantics at the shared utility boundary and ensure the calendar page consumes that boundary.
+
+Current state:
+- `js/utils.js` exposes `getCalendarEventStatus(...)` and `buildGlobalCalendarIcsEvent(...)`.
+- `calendar.html` imports that helper and uses it while merging Firestore and ICS events into one view model.
+
+Proposed state:
+- Keep status normalization centralized in `js/utils.js`.
+- Add a static regression test against `calendar.html` so the page cannot regress to an inline object literal with `status: 'scheduled'`.
+- Update the `calendar.html` utility import query string to invalidate stale browser caches.
+
+Blast radius:
+- `calendar.html` import path
+- unit-test coverage in `tests/unit`
+- no Firestore, auth, or data-model changes
+
+Controls:
+- No behavior changes for Firestore-backed schedule events.
+- No new parser heuristics; reuse the existing shared normalization.
+- Cache busting is isolated to the global calendar page’s `utils.js` import.
+
+Rollback:
+- Revert the single commit if the cache-busting import causes an unexpected deployment issue.

--- a/docs/pr-notes/runs/issue-308-fixer-20260312T202502Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-308-fixer-20260312T202502Z/code-plan.md
@@ -1,0 +1,10 @@
+Chosen thinking level: low
+Reason: the underlying helper behavior already exists in the current codebase; the remaining work is a narrow regression guard plus cache invalidation.
+
+Implementation plan:
+1. Add a failing page-level unit test for `calendar.html` that requires `buildGlobalCalendarIcsEvent(...)` usage and rejects a hard-coded `status: 'scheduled'` ICS mapping.
+2. Update `calendar.html` to bump the `js/utils.js` import version so browsers pull the helper that preserves cancelled ICS state.
+3. Run the focused calendar ICS unit tests.
+
+Fallback path:
+- If the page-level test proves too brittle, keep the helper-level test and add a narrower assertion around the exact ICS merge block in `calendar.html`.

--- a/docs/pr-notes/runs/issue-308-fixer-20260312T202502Z/qa.md
+++ b/docs/pr-notes/runs/issue-308-fixer-20260312T202502Z/qa.md
@@ -1,0 +1,11 @@
+Test strategy:
+- Add a unit test that inspects `calendar.html` and verifies synced ICS events are built through `buildGlobalCalendarIcsEvent(...)` rather than an inline mapping with hard-coded `scheduled` status.
+- Re-run the shared ICS event-type suite to confirm cancelled status stays normalized.
+
+Key regressions to watch:
+- `STATUS:CANCELLED` and `STATUS:CANCELED` both map to `cancelled`
+- TeamSnap `[CANCELED]` and `[CANCELLED]` prefixes remain cancelled
+- Global calendar page keeps delegating ICS view-model shaping to the shared helper
+
+Manual spot-check if needed:
+- Load a team with a cancelled external event on `calendar.html` and verify the cancelled badge/line-through styling appears in detailed, compact, and day-detail views.

--- a/docs/pr-notes/runs/issue-308-fixer-20260312T202502Z/requirements.md
+++ b/docs/pr-notes/runs/issue-308-fixer-20260312T202502Z/requirements.md
@@ -1,0 +1,25 @@
+Objective: ensure cancelled ICS events remain cancelled on the global calendar so families do not see canceled games or practices as active.
+
+Current state:
+- The shared calendar utilities already normalize ICS cancellation from both `STATUS:CANCELLED` and TeamSnap-style summary prefixes.
+- `calendar.html` currently builds synced ICS entries through `buildGlobalCalendarIcsEvent(...)`, but there is no page-level regression test proving that contract remains in place.
+
+Proposed state:
+- Keep the global calendar page wired to the shared cancellation helper path.
+- Add regression coverage so a future inline remap cannot silently force synced ICS events back to `scheduled`.
+
+Risk surface and blast radius:
+- Blast radius is limited to global calendar ICS rendering and cache invalidation for `js/utils.js`.
+- Main risk is stale browser cache serving an older `utils.js` bundle that predates the cancellation-preserving helper path.
+
+Assumptions:
+- Cancelled ICS events should remain visible but styled as cancelled, matching the rest of the app.
+- Shipping the current helper logic to clients may require a cache-busting import version update on `calendar.html`.
+
+Recommendation:
+- Lock the page to the shared helper with a focused regression test.
+- Bump the `utils.js` import version in `calendar.html` so the fixed helper is fetched by browsers.
+
+Success criteria:
+- Unit tests fail if `calendar.html` stops using `buildGlobalCalendarIcsEvent(...)`.
+- The global calendar page fetches the latest shared utility module instead of a potentially cached pre-fix copy.

--- a/tests/unit/calendar-page-cancellation.test.js
+++ b/tests/unit/calendar-page-cancellation.test.js
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readCalendarPage() {
+    return readFileSync(new URL('../../calendar.html', import.meta.url), 'utf8');
+}
+
+describe('calendar page ICS cancellation handling', () => {
+    it('delegates synced ICS event mapping to the shared global calendar helper', () => {
+        const source = readCalendarPage();
+
+        expect(source).toContain('buildGlobalCalendarIcsEvent');
+        expect(source).toContain('const mappedEvent = buildGlobalCalendarIcsEvent({');
+        expect(source).not.toContain("status: 'scheduled'");
+    });
+});


### PR DESCRIPTION
Closes #308

## What changed
- added a regression test that verifies `calendar.html` maps synced ICS events through `buildGlobalCalendarIcsEvent(...)` instead of reintroducing an inline hard-coded `scheduled` status
- bumped the `calendar.html` import for `js/utils.js` to a new cache-busting version so browsers fetch the shared helper that preserves cancelled ICS status
- recorded the required run notes under `docs/pr-notes/runs/issue-308-fixer-20260312T202502Z/`

## Why
The current shared calendar utility code already preserves cancelled ICS state, but the global calendar page did not have a page-level regression guard and could still serve a stale cached utility bundle. This change locks the wiring in place and makes sure clients pick up the cancellation-preserving implementation.

## Validation
- ran `/home/paul-bot1/.local/bin/node ./node_modules/vitest/vitest.mjs run tests/unit/calendar-ics-event-type.test.js tests/unit/calendar-page-cancellation.test.js tests/unit/edit-schedule-calendar-cancellation.test.js`