### PR TITLE
Fix cancelled ICS events in calendar

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -135,7 +135,7 @@
 
     <script type="module">
         import { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvpSummaries } from './js/db.js?v=23';
-        import { renderHeader, renderFooter, escapeHtml, formatDate, formatTime, fetchAndParseCalendar, expandRecurrence, buildGlobalCalendarIcsEvent, isTrackedCalendarEvent } from './js/utils.js?v=11';
+        import { renderHeader, renderFooter, escapeHtml, formatDate, formatTime, fetchAndParseCalendar, expandRecurrence, buildGlobalCalendarIcsEvent, isTrackedCalendarEvent } from './js/utils.js?v=12';
         import { requireAuth, checkAuth } from './js/auth.js?v=9';
         import { buildLinkedPlayersByTeam, resolveCalendarRsvpSubmission } from './js/calendar-rsvp.js?v=1';
         import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';
@@ -531,6 +531,7 @@
                     <div class="text-xs text-gray-500 w-28 flex-shrink-0 font-medium">${dateStr} ${timeStr}</div>
                     <span class="text-xs font-bold uppercase ${ev.type === 'practice' ? 'text-amber-700' : 'text-primary-700'} w-16 flex-shrink-0">${ev.type === 'practice' ? 'Prac' : 'Game'}</span>
                     <div class="text-sm font-medium text-gray-900 truncate flex-grow ${isCancelled ? 'line-through' : ''}">${escapeHtml(ev.title)}</div>
+                    ${isCancelled ? '<span class="text-[10px] font-bold text-red-700 bg-red-100 px-1.5 py-0.5 rounded">CANCELLED</span>' : ''}
                     <div class="text-xs text-gray-500 truncate max-w-[150px] hidden sm:block">${escapeHtml(ev.teamName)}</div>
                     ${renderRsvpBlock(ev, true)}
                     ${ev.isHome === true ? '<span class="text-[10px] bg-blue-100 text-blue-800 px-1.5 py-0.5 rounded font-bold">H</span>' : ''}

--- a/docs/pr-notes/runs/issue-233-fixer-20260312T232525Z/architecture.md
+++ b/docs/pr-notes/runs/issue-233-fixer-20260312T232525Z/architecture.md
@@ -1,0 +1,17 @@
+# Architecture Role (allplays-architecture-expert)
+
+## Root Cause
+The historical failure mode was page-level ICS mapping overriding parsed cancellation metadata. The current safe path is the shared `buildGlobalCalendarIcsEvent` helper in `js/utils.js`; the remaining architecture concern is keeping cancellation normalization centralized so page views stay consistent.
+
+## Minimal Safe Fix
+- Keep global calendar ICS mapping in the shared helper.
+- Normalize cancelled summary prefixes once in `js/utils.js` so the helper can preserve status while cleaning the displayed title.
+- Add an explicit cancelled label in compact rendering for consistency with detailed and day-detail views.
+
+## Blast Radius
+- Limited to global calendar ICS rendering in `js/utils.js` and `calendar.html`.
+- No Firestore, auth, or schedule write-path changes.
+
+## Controls
+- Add focused unit tests around helper mapping and calendar source rendering.
+- Bump the `utils.js` cache-busting query parameter in `calendar.html`.

--- a/docs/pr-notes/runs/issue-233-fixer-20260312T232525Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-233-fixer-20260312T232525Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Role (allplays-code-expert)
+
+## Plan
+1. Update calendar cancellation regression tests in `tests/unit/calendar-ics-event-type.test.js` and `tests/unit/calendar-page-cancellation.test.js`.
+2. Add a small shared helper in `js/utils.js` to strip cancelled summary prefixes before display while keeping cancellation status.
+3. Add a compact-view cancelled badge in `calendar.html` and bump the `utils.js` import version.
+4. Run targeted tests, then the full unit suite, and commit with issue reference.
+
+## Non-Goals
+- No change to ICS parsing, Firestore data, or recurrence logic.
+- No unrelated calendar layout refactor.

--- a/docs/pr-notes/runs/issue-233-fixer-20260312T232525Z/qa.md
+++ b/docs/pr-notes/runs/issue-233-fixer-20260312T232525Z/qa.md
@@ -1,0 +1,14 @@
+# QA Role (allplays-qa-expert)
+
+## Test Strategy
+1. Extend unit coverage for `buildGlobalCalendarIcsEvent` to verify cancelled TeamSnap-style titles map to `status: 'cancelled'` and display a cleaned title.
+2. Extend the calendar page source regression test to require explicit cancelled presentation in compact mode.
+3. Run the targeted Vitest files, then the full unit suite if the focused run passes.
+
+## Regression Guardrails
+- Keep tests deterministic and isolated from DOM/browser runtime by asserting helper output and page source.
+- Preserve existing cancelled detection for both ICS `STATUS` and summary prefix variants.
+
+## Manual Smoke (optional)
+- Subscribe a team to an ICS feed with a cancelled event.
+- Verify `calendar.html` detailed, compact, and day-detail views all show the event as cancelled rather than active.

--- a/docs/pr-notes/runs/issue-233-fixer-20260312T232525Z/requirements.md
+++ b/docs/pr-notes/runs/issue-233-fixer-20260312T232525Z/requirements.md
@@ -1,0 +1,21 @@
+# Requirements Role (allplays-requirements-expert)
+
+## Objective
+Ensure cancelled external ICS events do not appear as active upcoming events in the global calendar.
+
+## Current vs Proposed
+- Current: synced ICS events can lose cancellation intent in the calendar UI, making cancelled activities look active.
+- Proposed: global calendar keeps cancelled status for imported ICS events and renders them with clear cancelled affordances.
+
+## User Impact
+- Coaches and parents rely on the aggregated calendar as the source of truth for whether a game or practice is still on.
+- A cancelled event shown as active is a schedule-trust failure with immediate real-world impact.
+
+## Acceptance Criteria
+1. ICS events marked `STATUS:CANCELLED` or prefixed with `[CANCELED]` or `[CANCELLED]` resolve to `status: 'cancelled'` in global calendar mapping.
+2. Cancelled synced events render as visibly cancelled in detailed, compact, and day-detail calendar surfaces.
+3. Non-cancelled synced ICS events remain unchanged.
+
+## Risks
+- Over-matching event titles that happen to contain cancellation text but are not actually cancelled.
+- Browser cache serving stale `utils.js` if the import version is not bumped where needed.

--- a/js/utils.js
+++ b/js/utils.js
@@ -1300,6 +1300,10 @@ export function getCalendarEventStatus(event) {
   return 'scheduled';
 }
 
+function stripCancelledCalendarPrefix(summary) {
+  return String(summary || '').replace(/^\s*\[(?:CANCELED|CANCELLED)\]\s*/i, '');
+}
+
 /**
  * Resolve the id used to track a parsed ICS event in Firestore and the UI.
  * Recurring occurrences should prefer their generated occurrence id.
@@ -1353,13 +1357,15 @@ export function buildGlobalCalendarIcsEvent({ team, teamColor, event }) {
     return null;
   }
 
+  const title = stripCancelledCalendarPrefix(event?.summary) || 'Event';
+
   return {
     id: getCalendarEventTrackingId(event) || `ics-${eventDate.getTime()}`,
     teamId: team.id,
     teamName: team.name,
     teamColor,
     type: getCalendarEventType(event),
-    title: event.summary || 'Event',
+    title,
     date: eventDate,
     location: event.location || 'TBD',
     status: getCalendarEventStatus(event),

--- a/tests/unit/calendar-ics-event-type.test.js
+++ b/tests/unit/calendar-ics-event-type.test.js
@@ -46,7 +46,7 @@ describe('getCalendarEventStatus', () => {
 });
 
 describe('buildGlobalCalendarIcsEvent', () => {
-    it('preserves cancelled status for synced ICS events in the global calendar', () => {
+    it('preserves cancelled status and cleans cancelled prefixes for synced ICS events in the global calendar', () => {
         const mappedEvent = buildGlobalCalendarIcsEvent({
             team: { id: 'team-1', name: 'Wildcats' },
             teamColor: '#f97316',
@@ -64,7 +64,7 @@ describe('buildGlobalCalendarIcsEvent', () => {
             teamName: 'Wildcats',
             teamColor: '#f97316',
             type: 'practice',
-            title: '[CANCELED] Practice',
+            title: 'Practice',
             location: 'Main Field',
             status: 'cancelled',
             source: 'ics'

--- a/tests/unit/calendar-page-cancellation.test.js
+++ b/tests/unit/calendar-page-cancellation.test.js
@@ -13,4 +13,10 @@ describe('calendar page ICS cancellation handling', () => {
         expect(source).toContain('const mappedEvent = buildGlobalCalendarIcsEvent({');
         expect(source).not.toContain("status: 'scheduled'");
     });
+
+    it('renders compact cancelled events with an explicit cancelled badge', () => {
+        const source = readCalendarPage();
+
+        expect(source).toContain("isCancelled ? '<span class=\"text-[10px] font-bold text-red-700 bg-red-100 px-1.5 py-0.5 rounded\">CANCELLED</span>' : ''");
+    });
 });


### PR DESCRIPTION
Closes #233

## What changed
- kept cancelled ICS events clearly marked in the global calendar by cleaning TeamSnap-style `[CANCELED]` prefixes in the shared ICS event mapper while preserving `status: 'cancelled'`
- added an explicit `CANCELLED` badge in `calendar.html` compact view so synced cancelled events are visibly cancelled across detailed, compact, and day-detail presentations
- extended unit coverage for cancelled ICS mapping and calendar page rendering, and saved the synthesized role notes for this run

## Why
Cancelled external events were a schedule-trust risk. This keeps imported ICS cancellation state visible in the calendar UI and adds regression coverage so cancelled feeds do not silently look active again.