### PR TITLE
Fix admin invite signup team access

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -105,7 +105,7 @@ jobs:
           body="$marker
 
           Preview URL: $PREVIEW_URL"
-          comment_id="$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq '.[] | select(.user.login == \"github-actions[bot]\") | select(.body | contains(\"<!-- allplays-preview-url -->\")) | .id' | head -n1)"
+          comment_id="$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("<!-- allplays-preview-url -->")) | .id' | head -n1)"
           if [ -n "$comment_id" ]; then
             gh api repos/${{ github.repository }}/issues/comments/"$comment_id" --method PATCH -f body="$body" >/dev/null
           else

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -78,7 +78,16 @@ jobs:
             if printf '%s\n' "$open_channels" | grep -qx "$channel"; then
               continue
             fi
-            npx firebase-tools@14.25.0 hosting:channel:delete "$channel" --site game-flow-c6311 --project game-flow-c6311 --force
+            delete_output="$(
+              npx firebase-tools@14.25.0 hosting:channel:delete "$channel" --site game-flow-c6311 --project game-flow-c6311 --force 2>&1
+            )" || {
+              if printf '%s' "$delete_output" | grep -q 'HTTP Error: 404'; then
+                echo "Skipping missing Firebase preview channel: $channel"
+                continue
+              fi
+              printf '%s\n' "$delete_output" >&2
+              exit 1
+            }
           done < "$prune_file"
 
       - name: Deploy Firebase Hosting preview

--- a/accept-invite.html
+++ b/accept-invite.html
@@ -135,7 +135,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=10';
+        import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=11';
         import { validateAccessCode, redeemParentInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=15';
         import { createInviteProcessor } from './js/accept-invite-flow.js?v=3';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';

--- a/docs/pr-notes/runs/327-ci-fix-20260328T030948Z/architecture.md
+++ b/docs/pr-notes/runs/327-ci-fix-20260328T030948Z/architecture.md
@@ -1,0 +1,1 @@
+Architecture role unavailable; inline analysis: failure is test harness string replacement drift after auth import cache-bust moved from ?v=10 to ?v=11. Minimal fix is to make replacements version-agnostic for the affected imports only.

--- a/docs/pr-notes/runs/327-ci-fix-20260328T030948Z/code-plan.md
+++ b/docs/pr-notes/runs/327-ci-fix-20260328T030948Z/code-plan.md
@@ -1,0 +1,1 @@
+Code role unavailable; patch the two tests to replace auth imports via regex so future cache-bust bumps do not break AsyncFunction evaluation.

--- a/docs/pr-notes/runs/327-ci-fix-20260328T030948Z/qa.md
+++ b/docs/pr-notes/runs/327-ci-fix-20260328T030948Z/qa.md
@@ -1,0 +1,1 @@
+QA role unavailable; validate by running the two failing Vitest files and confirm no residual import-syntax errors. Blast radius is limited to test fixtures.

--- a/docs/pr-notes/runs/327-ci-fix-20260328T031551Z/architecture.md
+++ b/docs/pr-notes/runs/327-ci-fix-20260328T031551Z/architecture.md
@@ -1,0 +1,21 @@
+Objective: restore PR preview comment reporting in the deploy-preview workflow.
+
+Current state:
+- Firebase preview deploy completes and exports `PREVIEW_URL`.
+- The follow-up `gh api --jq` call fails before it can patch or create the PR comment.
+
+Proposed state:
+- Keep the existing workflow shape and comment behavior.
+- Pass a valid jq expression to `gh api` without shell-escaped quotes leaking into jq.
+
+Risk surface and blast radius:
+- Limited to `.github/workflows/deploy-preview.yml`.
+- No runtime app impact. Only the preview-commenting step changes.
+
+Assumptions:
+- `gh api --jq` expects raw jq syntax, not backslash-escaped quotes.
+- Existing GitHub token permissions remain sufficient once parsing succeeds.
+
+Recommendation:
+- Apply the minimal quoting fix in the workflow rather than restructuring the job.
+- This preserves behavior and minimizes regression risk.

--- a/docs/pr-notes/runs/327-ci-fix-20260328T031551Z/code-plan.md
+++ b/docs/pr-notes/runs/327-ci-fix-20260328T031551Z/code-plan.md
@@ -1,0 +1,7 @@
+Thinking level: low
+Reason: the CI log identifies a deterministic quoting bug in a single workflow step.
+
+Plan:
+1. Patch `.github/workflows/deploy-preview.yml` to remove escaped quotes from the jq expression.
+2. Validate the filter locally with representative JSON and `jq`.
+3. Stage the modified files and commit with the required CI-fix message.

--- a/docs/pr-notes/runs/327-ci-fix-20260328T031551Z/qa.md
+++ b/docs/pr-notes/runs/327-ci-fix-20260328T031551Z/qa.md
@@ -1,0 +1,17 @@
+Objective: validate the deploy-preview CI fix locally as far as the environment allows.
+
+Evidence:
+- CI log shows Firebase deploy succeeded and provided `PREVIEW_URL`.
+- Failure occurs at jq parse time with `unexpected token "\\"`.
+
+Targeted validation:
+- Confirm the workflow now contains an unescaped jq filter string.
+- Run the filter through local `jq` with representative JSON to verify it selects the expected comment id.
+
+Risk:
+- No automated test suite exists for GitHub Actions in this repo.
+- Validation is limited to syntax and command-shape correctness.
+
+Success criteria:
+- Local jq evaluation succeeds with the same filter logic.
+- Git diff is scoped to the workflow and required run notes only.

--- a/docs/pr-notes/runs/327-ci-fix-20260328T183744Z/architecture.md
+++ b/docs/pr-notes/runs/327-ci-fix-20260328T183744Z/architecture.md
@@ -1,0 +1,6 @@
+# Architecture role
+
+- Root cause: workflow deletes stale Firebase preview channels and exits on 404.
+- Current state: delete command is fatal for already-missing channels.
+- Proposed state: treat missing channel deletion as non-fatal while keeping other errors fatal.
+- Blast radius: GitHub Actions deploy-preview workflow only.

--- a/docs/pr-notes/runs/327-ci-fix-20260328T183744Z/code-plan.md
+++ b/docs/pr-notes/runs/327-ci-fix-20260328T183744Z/code-plan.md
@@ -1,0 +1,5 @@
+# Code role
+
+- Edit the deploy-preview workflow prune loop only.
+- Wrap delete in conditional so 404/Not Found is ignored, but unexpected failures still exit non-zero.
+- Keep change minimal and workflow-scoped.

--- a/docs/pr-notes/runs/327-ci-fix-20260328T183744Z/qa.md
+++ b/docs/pr-notes/runs/327-ci-fix-20260328T183744Z/qa.md
@@ -1,0 +1,5 @@
+# QA role
+
+- Validate by inspecting workflow logic and shell error handling.
+- No app test suite covers GitHub Actions; local validation is limited to syntax/readability review.
+- Manual check: ensure 404 delete failures no longer stop preview deploy, other failures still surface.

--- a/docs/pr-notes/runs/327-remediator-20260313T021501Z/architecture.md
+++ b/docs/pr-notes/runs/327-remediator-20260313T021501Z/architecture.md
@@ -1,0 +1,10 @@
+Current state: admin invite redemption performs a preflight read, grants coach role on the user doc, then runs a transaction to append `adminEmails` and consume the access code.
+
+Proposed state: keep the flow intact and add an `expiresAt` guard in `redeemAdminInviteAtomicPersistence(...)` both before the user grant and inside the transaction, matching the existing standard-code fail-closed pattern.
+
+Blast radius:
+- Limited to admin invite redemption in `js/db.js`.
+- One focused unit test to lock the regression.
+
+Tradeoff:
+- Duplicate expiration checks are intentional here because the code performs reads both before and during the transaction.

--- a/docs/pr-notes/runs/327-remediator-20260313T021501Z/code-plan.md
+++ b/docs/pr-notes/runs/327-remediator-20260313T021501Z/code-plan.md
@@ -1,0 +1,8 @@
+Thinking level: medium.
+Reason: narrow code change, but it touches access control and rollback behavior.
+
+Implementation plan:
+1. Patch `redeemAdminInviteAtomicPersistence(...)` to reject expired admin invite codes before any user grant and again inside the transaction.
+2. Add a regression test that asserts the expiration guard exists in the atomic persistence function.
+3. Run targeted Vitest coverage for admin invite redemption files.
+4. Stage and commit only the scoped changes plus the required run notes.

--- a/docs/pr-notes/runs/327-remediator-20260313T021501Z/qa.md
+++ b/docs/pr-notes/runs/327-remediator-20260313T021501Z/qa.md
@@ -1,0 +1,7 @@
+Validation plan:
+- Run the targeted unit tests covering admin invite acceptance and the new atomic expiration guard.
+- If the focused suite passes, no broader test run is necessary because the change is isolated to one data-layer function and one regression test.
+
+Risk focus:
+- Ensure expired admin invite codes now throw before granting access.
+- Ensure existing caller-shape coverage still passes so the signature regression does not reappear.

--- a/docs/pr-notes/runs/327-remediator-20260313T021501Z/requirements.md
+++ b/docs/pr-notes/runs/327-remediator-20260313T021501Z/requirements.md
@@ -1,0 +1,13 @@
+Objective: close the two unresolved PR review threads for admin invite redemption with the smallest reviewable change.
+
+Current state:
+- `js/signup-flow.js` and `js/auth.js` already call `redeemAdminInviteAcceptance(...)` with the new object signature on this branch.
+- `js/db.js` re-checks `used` and team/type inside `redeemAdminInviteAtomicPersistence(...)`, but does not re-check `expiresAt` before marking the invite used.
+
+Required outcome:
+- Preserve the updated caller signature.
+- Restore fail-closed expiration enforcement at the atomic write step for admin invites.
+
+Assumptions:
+- The prior caller-signature comment can be addressed by confirming the branch already includes the fix.
+- Minimal scope means no broader refactor of the invite redemption flow.

--- a/docs/pr-notes/runs/327-review-3941124123-20260313T021423Z/architecture.md
+++ b/docs/pr-notes/runs/327-review-3941124123-20260313T021423Z/architecture.md
@@ -1,0 +1,6 @@
+## Architecture Role
+
+- Decision: keep atomic persistence centralized in `js/admin-invite.js`; fix callers instead of widening the helper API again.
+- Why: restoring the removed parameters would re-couple signup flows to the old multi-step persistence path and weaken the refactor that issue #305 intended.
+- Controls: team lookup and profile lookup still happen in `redeemAdminInviteAcceptance(...)`, and the atomic DB write remains the only place that grants admin access and consumes the code.
+- Rollback: revert the caller argument cleanup commit if a downstream consumer unexpectedly depends on the removed shape.

--- a/docs/pr-notes/runs/327-review-3941124123-20260313T021423Z/code-plan.md
+++ b/docs/pr-notes/runs/327-review-3941124123-20260313T021423Z/code-plan.md
@@ -1,0 +1,6 @@
+## Code Role
+
+1. Remove stale admin-invite arguments in `js/signup-flow.js`.
+2. Remove stale admin-invite arguments in `js/auth.js` and drop unused `addTeamAdminEmail` imports/plumbing.
+3. Strengthen `tests/unit/signup-flow.test.js` and `tests/unit/auth-google-admin-invite-cleanup.test.js` to assert the obsolete fields are absent.
+4. Run focused Vitest coverage for the impacted signup and Google admin-invite paths.

--- a/docs/pr-notes/runs/327-review-3941124123-20260313T021423Z/qa.md
+++ b/docs/pr-notes/runs/327-review-3941124123-20260313T021423Z/qa.md
@@ -1,0 +1,8 @@
+## QA Role
+
+- Regression target: admin-invite signup via email/password and Google popup/redirect.
+- Test strategy:
+  - assert the signup helper still routes admin invites through `redeemAdminInviteAcceptance(...)`
+  - assert the passed object omits `markAccessCodeAsUsed`, `addTeamAdminEmail`, and `updateUserProfile`
+  - rerun focused auth/signup unit tests covering admin cleanup behavior
+- Residual risk: no browser-level manual run in this lane; confidence comes from existing unit coverage around the exact invocation points.

--- a/docs/pr-notes/runs/327-review-3941124123-20260313T021423Z/requirements.md
+++ b/docs/pr-notes/runs/327-review-3941124123-20260313T021423Z/requirements.md
@@ -1,0 +1,10 @@
+## Requirements Role
+
+- Problem: admin-invite signup must call `redeemAdminInviteAcceptance(...)` with the current atomic-persistence contract, or new coach/admin signups fail at runtime.
+- Current state: `js/signup-flow.js` and `js/auth.js` still pass removed callback parameters from the pre-refactor API.
+- Proposed state: both signup paths pass only `userId`, `userEmail`, `teamId`, `codeId`, `getTeam`, and `getUserProfile`, then keep profile finalization separate.
+- Blast radius: limited to new admin-invite signup flows for email/password and Google OAuth; parent invites and standard activation remain unchanged.
+- Acceptance criteria:
+  - email/password admin invite signup reaches `redeemAdminInviteAcceptance(...)` without obsolete arguments
+  - Google admin invite signup reaches the same helper without obsolete arguments
+  - regression tests fail if old parameters are reintroduced

--- a/docs/pr-notes/runs/issue-305-fixer-20260313T020032Z/architecture.md
+++ b/docs/pr-notes/runs/issue-305-fixer-20260313T020032Z/architecture.md
@@ -1,0 +1,17 @@
+Current state:
+- `accept-invite.html` uses `redeemAdminInviteAtomically(...)` through `js/accept-invite-flow.js`.
+- `js/auth.js` email/password signup still imports `js/admin-invite.js`, which performs multi-step profile/team/code writes itself.
+
+Proposed state:
+- `js/admin-invite.js` becomes a thin adapter over `redeemAdminInviteAtomicPersistence(...)` in `js/db.js`.
+- `js/auth.js` keeps the same call site, but the persistence path becomes equivalent to direct invite acceptance.
+
+Controls comparison:
+- Better than current: admin email append, coach role grant, and code consumption stay in the same guarded persistence helper.
+- Blast radius stays limited to `admin_invite` redemptions.
+
+Rollback:
+- Revert the helper delegation and cache-bust version bumps.
+
+Instrumentation:
+- Unit tests should prove the signup helper delegates atomic persistence and normalizes the user email before grant.

--- a/docs/pr-notes/runs/issue-305-fixer-20260313T020032Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-305-fixer-20260313T020032Z/code-plan.md
@@ -1,0 +1,9 @@
+Chosen thinking level: medium.
+Reason: the bug is flow-specific, but invite persistence already has two parallel implementations and the safest fix is to unify them without broad refactoring.
+
+Plan:
+1. Update `js/admin-invite.js` to delegate persistence to `redeemAdminInviteAtomicPersistence(...)`.
+2. Keep the public helper signature stable for `js/auth.js`.
+3. Add regression coverage for atomic delegation and normalized email handling.
+4. Bump cache-bust versions for the changed auth import chain.
+5. Run targeted Vitest files that cover signup and admin invite redemption.

--- a/docs/pr-notes/runs/issue-305-fixer-20260313T020032Z/qa.md
+++ b/docs/pr-notes/runs/issue-305-fixer-20260313T020032Z/qa.md
@@ -1,0 +1,13 @@
+Test focus:
+- Email/password signup admin invite path delegates to atomic persistence.
+- Normalized email is used for the admin grant.
+- Cache-bust references update when `auth.js` import wiring changes.
+
+Regression guardrails:
+- Parent invite signup tests must still pass unchanged.
+- Existing admin invite redemption tests for `accept-invite.html` should remain green.
+
+Manual spot-check recommendation:
+1. Generate an admin invite from `edit-team.html`.
+2. Open `login.html?code=...&type=admin` while logged out.
+3. Complete signup and verify the invited team appears on the dashboard with team-management access.

--- a/docs/pr-notes/runs/issue-305-fixer-20260313T020032Z/requirements.md
+++ b/docs/pr-notes/runs/issue-305-fixer-20260313T020032Z/requirements.md
@@ -1,0 +1,20 @@
+Objective: ensure signup from `login.html?code=...&type=admin` grants the invited user team-admin access, not just account creation.
+
+Current state:
+- Direct invite acceptance already has a dedicated admin invite redemption path.
+- Email/password signup validates the same invite, but its helper path is inconsistent with the direct acceptance flow.
+
+Proposed state:
+- Route email/password admin invite redemption through the same authoritative persistence model used for invite acceptance.
+
+Risk surface and blast radius:
+- Affects only `admin_invite` signup redemption.
+- Parent invites and generic activation codes must remain unchanged.
+- High user impact if wrong: invite is consumed without access.
+
+Assumptions:
+- `validation.data.teamId` and `validation.codeId` are present for `admin_invite`.
+- Atomic persistence in `js/db.js` is the intended source of truth for admin grants.
+
+Recommendation:
+- Keep the fix narrow: update the signup-side admin invite helper to delegate to atomic persistence and add regression tests around that delegation and cache-bust wiring.

--- a/edit-team.html
+++ b/edit-team.html
@@ -242,7 +242,7 @@
     <script type="module">
         import { createTeam, updateTeam, getTeam, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail } from './js/db.js?v=15';
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=8';
-        import { checkAuth, sendInviteEmail } from './js/auth.js?v=10';
+        import { checkAuth, sendInviteEmail } from './js/auth.js?v=11';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { normalizeYouTubeEmbedUrl } from './js/live-stream-utils.js?v=1';
         import { hasFullTeamAccess } from './js/team-access.js';

--- a/js/admin-invite.js
+++ b/js/admin-invite.js
@@ -1,13 +1,13 @@
+import { redeemAdminInviteAtomicPersistence } from './db.js?v=16';
+
 export async function redeemAdminInviteAcceptance({
     userId,
     userEmail,
     teamId,
     codeId = null,
-    markAccessCodeAsUsed,
     getTeam,
-    addTeamAdminEmail,
     getUserProfile,
-    updateUserProfile
+    redeemAdminInviteAtomicPersistence: redeemAdminInviteAtomicPersistenceOverride = redeemAdminInviteAtomicPersistence
 }) {
     if (!userId) throw new Error('Missing userId');
     if (!teamId) throw new Error('Missing teamId');
@@ -24,28 +24,16 @@ export async function redeemAdminInviteAcceptance({
         throw new Error('Missing user email');
     }
 
-    const existingCoachOf = Array.isArray(profile?.coachOf) ? profile.coachOf : [];
-    const existingRoles = Array.isArray(profile?.roles) ? profile.roles : [];
-
-    const coachOf = Array.from(new Set([...existingCoachOf, teamId]));
-    const roles = Array.from(new Set([...existingRoles, 'coach']));
-
-    await updateUserProfile(userId, {
-        coachOf,
-        roles
-    });
-
-    // Verify membership persisted before writing the team doc, because
-    // team updates are authorized by owner/admin/coach checks in rules.
-    const updatedProfile = await getUserProfile(userId);
-    const updatedCoachOf = Array.isArray(updatedProfile?.coachOf) ? updatedProfile.coachOf : [];
-    if (!updatedCoachOf.includes(teamId)) {
-        throw new Error('Unable to grant team coach access before admin assignment');
+    if (typeof redeemAdminInviteAtomicPersistenceOverride !== 'function') {
+        throw new Error('Missing atomic admin invite persistence handler');
     }
 
-    await addTeamAdminEmail(teamId, resolvedUserEmail);
-
-    await markAccessCodeAsUsed(codeId, userId);
+    await redeemAdminInviteAtomicPersistenceOverride({
+        teamId,
+        userId,
+        userEmail: resolvedUserEmail,
+        codeId
+    });
 
     return team;
 }

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,6 +1,6 @@
 import { getTeams, getAllUsers, deleteTeam } from './db.js?v=15';
 import { renderHeader, renderFooter, escapeHtml } from './utils.js?v=8';
-import { checkAuth } from './auth.js?v=10';
+import { checkAuth } from './auth.js?v=11';
 
 let allTeams = [];
 let allUsers = [];

--- a/js/auth.js
+++ b/js/auth.js
@@ -15,9 +15,9 @@ import {
     signInWithEmailLink,
     updatePassword
 } from './firebase.js?v=10';
-import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, getUserProfile, getUserTeams, getUserByEmail, getTeam, addTeamAdminEmail, listMyParentMembershipRequests } from './db.js?v=15';
+import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, getUserProfile, getUserTeams, getUserByEmail, getTeam, addTeamAdminEmail, listMyParentMembershipRequests } from './db.js?v=16';
 import { executeEmailPasswordSignup } from './signup-flow.js?v=2';
-import { redeemAdminInviteAcceptance } from './admin-invite.js?v=3';
+import { redeemAdminInviteAcceptance } from './admin-invite.js?v=4';
 import { mergeApprovedParentMembershipRequests } from './parent-membership-utils.js?v=1';
 
 async function cleanupFailedNewUser(user, context) {

--- a/js/auth.js
+++ b/js/auth.js
@@ -15,7 +15,7 @@ import {
     signInWithEmailLink,
     updatePassword
 } from './firebase.js?v=10';
-import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, getUserProfile, getUserTeams, getUserByEmail, getTeam, addTeamAdminEmail, listMyParentMembershipRequests } from './db.js?v=16';
+import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, getUserProfile, getUserTeams, getUserByEmail, getTeam, listMyParentMembershipRequests } from './db.js?v=16';
 import { executeEmailPasswordSignup } from './signup-flow.js?v=2';
 import { redeemAdminInviteAcceptance } from './admin-invite.js?v=4';
 import { mergeApprovedParentMembershipRequests } from './parent-membership-utils.js?v=1';
@@ -85,7 +85,6 @@ export async function signup(email, password, activationCode) {
             updateUserProfile,
             markAccessCodeAsUsed,
             getTeam,
-            addTeamAdminEmail,
             getUserProfile,
             sendEmailVerification,
             signOut
@@ -193,11 +192,8 @@ async function processGoogleAuthResult(result, activationCode = null) {
                     userEmail: result.user.email,
                     teamId: validation.data.teamId,
                     codeId: validation.codeId,
-                    markAccessCodeAsUsed,
                     getTeam,
-                    addTeamAdminEmail,
-                    getUserProfile,
-                    updateUserProfile
+                    getUserProfile
                 });
             } catch (e) {
                 console.error('Error linking admin invite:', e);

--- a/js/db.js
+++ b/js/db.js
@@ -1539,6 +1539,9 @@ export async function redeemAdminInviteAtomicPersistence({
         if (codeData.used === true) {
             throw new Error('Access code has already been used');
         }
+        if (isAccessCodeExpired(codeData.expiresAt)) {
+            throw new Error('Code has expired');
+        }
 
         const existingUserData = userSnapshot.exists() ? (userSnapshot.data() || {}) : {};
         const existingCoachOf = Array.isArray(existingUserData.coachOf) ? existingUserData.coachOf : [];
@@ -1576,6 +1579,9 @@ export async function redeemAdminInviteAtomicPersistence({
             }
             if (latestCodeData.used === true) {
                 throw new Error('Access code has already been used');
+            }
+            if (isAccessCodeExpired(latestCodeData.expiresAt)) {
+                throw new Error('Code has expired');
             }
 
             const now = Timestamp.now();

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -17,7 +17,7 @@ import {
 } from './db.js?v=15';
 import { getUrlParams, escapeHtml, renderHeader, renderFooter, formatShortDate, formatTime, shareOrCopy } from './utils.js?v=9';
 import { computePanelVisibility } from './live-stream-utils.js?v=1';
-import { checkAuth } from './auth.js?v=10';
+import { checkAuth } from './auth.js?v=11';
 import { isViewerChatEnabled } from './live-game-chat.js?v=1';
 import { getReplayElapsedMs, getReplayStartTimeAfterSpeedChange } from './live-game-replay.js?v=2';
 import { MAX_HIGHLIGHT_CLIP_MS, buildHighlightShareUrl, createHighlightClipDraft, resolveReplayVideoOptions, shouldReloadVideoPlayback } from './live-game-video.js?v=2';

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -2,7 +2,7 @@
 import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=15';
 import { db } from './firebase.js?v=10';
 import { getUrlParams, escapeHtml } from './utils.js?v=9';
-import { checkAuth } from './auth.js?v=10';
+import { checkAuth } from './auth.js?v=11';
 import { writeBatch, doc, setDoc, addDoc, onSnapshot } from './firebase.js?v=10';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';

--- a/js/signup-flow.js
+++ b/js/signup-flow.js
@@ -13,7 +13,6 @@ export async function executeEmailPasswordSignup({
         updateUserProfile,
         markAccessCodeAsUsed,
         getTeam,
-        addTeamAdminEmail,
         getUserProfile,
         sendEmailVerification,
         signOut
@@ -75,11 +74,8 @@ export async function executeEmailPasswordSignup({
                 userEmail: email,
                 teamId: validation?.data?.teamId,
                 codeId: validation.codeId,
-                markAccessCodeAsUsed,
                 getTeam,
-                addTeamAdminEmail,
-                getUserProfile,
-                updateUserProfile
+                getUserProfile
             });
             await updateUserProfile(userId, {
                 email: email,

--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -2,7 +2,7 @@
 import { getTeam, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query } from './db.js?v=15';
 import { db } from './firebase.js?v=10';
 import { getUrlParams, escapeHtml } from './utils.js?v=8';
-import { checkAuth } from './auth.js?v=10';
+import { checkAuth } from './auth.js?v=11';
 import { writeBatch, doc, setDoc, addDoc } from './firebase.js?v=10';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';

--- a/js/utils.js
+++ b/js/utils.js
@@ -183,7 +183,7 @@ export function renderHeader(container, user) {
 
     // Add logout handler
     navLogout.addEventListener('click', async () => {
-      const { logout } = await import('./auth.js?v=10');
+      const { logout } = await import('./auth.js?v=11');
       await logout();
       window.location.href = 'index.html';
     });

--- a/login.html
+++ b/login.html
@@ -96,7 +96,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=10';
+        import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=11';
         import { getUserProfile } from './js/db.js?v=15';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import { getPostAuthRedirectUrl } from './js/invite-redirect.js?v=1';

--- a/tests/unit/admin-invite-atomic-persistence-guard.test.js
+++ b/tests/unit/admin-invite-atomic-persistence-guard.test.js
@@ -15,4 +15,20 @@ describe('admin invite atomic persistence guard', () => {
         expect(afterFunction).toContain('runTransaction(db, async (transaction) =>');
         expect(afterFunction).toContain('adminEmails: arrayUnion(normalizedEmail)');
     });
+
+    it('re-checks invite expiration before and during atomic redemption', () => {
+        const dbSourcePath = resolve(process.cwd(), 'js/db.js');
+        const source = readFileSync(dbSourcePath, 'utf8');
+
+        const fnAnchor = 'export async function redeemAdminInviteAtomicPersistence';
+        const fnIndex = source.indexOf(fnAnchor);
+        expect(fnIndex).toBeGreaterThanOrEqual(0);
+
+        const afterFunction = source.slice(fnIndex, fnIndex + 6000);
+        const expirationGuard = "if (isAccessCodeExpired(codeData.expiresAt))";
+        const latestExpirationGuard = "if (isAccessCodeExpired(latestCodeData.expiresAt))";
+
+        expect(afterFunction).toContain(expirationGuard);
+        expect(afterFunction).toContain(latestExpirationGuard);
+    });
 });

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -7,7 +7,8 @@ describe('admin invite signup cache busting', () => {
         const authSource = readFileSync(resolve(process.cwd(), 'js/auth.js'), 'utf8');
 
         expect(authSource).toContain("import { executeEmailPasswordSignup } from './signup-flow.js?v=2';");
-        expect(authSource).toContain("import { redeemAdminInviteAcceptance } from './admin-invite.js?v=3';");
+        expect(authSource).toContain("import { redeemAdminInviteAcceptance } from './admin-invite.js?v=4';");
+        expect(authSource).toContain("from './db.js?v=16';");
     });
 
     it('pins fresh invite acceptance module versions for admin invite redemption', () => {
@@ -35,7 +36,7 @@ describe('admin invite signup cache busting', () => {
 
         for (const relativePath of authConsumers) {
             const source = readFileSync(resolve(process.cwd(), relativePath), 'utf8');
-            expect(source).toContain('auth.js?v=10');
+            expect(source).toContain('auth.js?v=11');
         }
     });
 });

--- a/tests/unit/admin-invite.test.js
+++ b/tests/unit/admin-invite.test.js
@@ -1,37 +1,36 @@
 import { describe, it, expect, vi } from 'vitest';
-import { redeemAdminInviteAcceptance } from '../../js/admin-invite.js';
+
+const dbMocks = vi.hoisted(() => ({
+    redeemAdminInviteAtomicPersistence: vi.fn()
+}));
+
+vi.mock('../../js/db.js?v=16', () => dbMocks);
+
+const { redeemAdminInviteAcceptance } = await import('../../js/admin-invite.js');
 
 describe('admin invite acceptance', () => {
-    it('persists team admin email, merges profile access, and marks code used', async () => {
+    it('delegates signup admin redemption to atomic persistence', async () => {
         const getTeam = vi.fn().mockResolvedValue({ id: 'team-1', name: 'Sharks' });
-        const addTeamAdminEmail = vi.fn().mockResolvedValue(undefined);
-        const getUserProfile = vi
-            .fn()
-            .mockResolvedValueOnce({ coachOf: ['team-0'], roles: ['parent'] })
-            .mockResolvedValueOnce({ coachOf: ['team-0', 'team-1'], roles: ['parent', 'coach'] });
-        const updateUserProfile = vi.fn().mockResolvedValue(undefined);
-        const markAccessCodeAsUsed = vi.fn().mockResolvedValue(undefined);
+        const getUserProfile = vi.fn().mockResolvedValue({ coachOf: ['team-0'], roles: ['parent'] });
+        const redeemAdminInviteAtomicPersistence = dbMocks.redeemAdminInviteAtomicPersistence.mockResolvedValue(undefined);
 
         const team = await redeemAdminInviteAcceptance({
             userId: 'user-1',
             userEmail: 'Admin@Example.com',
             teamId: 'team-1',
             codeId: 'code-1',
-            markAccessCodeAsUsed,
             getTeam,
-            addTeamAdminEmail,
             getUserProfile,
-            updateUserProfile
+            redeemAdminInviteAtomicPersistence
         });
 
         expect(team).toEqual({ id: 'team-1', name: 'Sharks' });
-        expect(addTeamAdminEmail).toHaveBeenCalledWith('team-1', 'admin@example.com');
-        expect(updateUserProfile).toHaveBeenCalledWith('user-1', {
-            coachOf: ['team-0', 'team-1'],
-            roles: ['parent', 'coach']
+        expect(redeemAdminInviteAtomicPersistence).toHaveBeenCalledWith({
+            teamId: 'team-1',
+            userId: 'user-1',
+            userEmail: 'admin@example.com',
+            codeId: 'code-1'
         });
-        expect(updateUserProfile.mock.invocationCallOrder[0]).toBeLessThan(addTeamAdminEmail.mock.invocationCallOrder[0]);
-        expect(markAccessCodeAsUsed).toHaveBeenCalledWith('code-1', 'user-1');
     });
 
     it('throws when team is missing', async () => {
@@ -51,26 +50,19 @@ describe('admin invite acceptance', () => {
     });
 
     it('fails closed when codeId is absent', async () => {
-        const markAccessCodeAsUsed = vi.fn();
-
         await expect(
             redeemAdminInviteAcceptance({
                 userId: 'user-1',
                 userEmail: 'admin@example.com',
                 teamId: 'team-1',
-                markAccessCodeAsUsed,
                 getTeam: vi.fn().mockResolvedValue({ id: 'team-1' }),
-                addTeamAdminEmail: vi.fn().mockResolvedValue(undefined),
                 getUserProfile: vi.fn().mockResolvedValue({ coachOf: ['team-1'], roles: ['coach'] }),
-                updateUserProfile: vi.fn().mockResolvedValue(undefined)
+                redeemAdminInviteAtomicPersistence: vi.fn().mockResolvedValue(undefined)
             })
         ).rejects.toThrow('Missing codeId');
-
-        expect(markAccessCodeAsUsed).not.toHaveBeenCalled();
     });
 
-    it('does not write team admin email when coach membership is not persisted', async () => {
-        const addTeamAdminEmail = vi.fn();
+    it('fails closed when atomic persistence handler is missing', async () => {
 
         await expect(
             redeemAdminInviteAcceptance({
@@ -78,17 +70,10 @@ describe('admin invite acceptance', () => {
                 userEmail: 'admin@example.com',
                 teamId: 'team-1',
                 codeId: 'code-1',
-                markAccessCodeAsUsed: vi.fn(),
                 getTeam: vi.fn().mockResolvedValue({ id: 'team-1', name: 'Sharks' }),
-                addTeamAdminEmail,
-                getUserProfile: vi
-                    .fn()
-                    .mockResolvedValueOnce({ coachOf: [], roles: [] })
-                    .mockResolvedValueOnce({ coachOf: [], roles: ['coach'] }),
-                updateUserProfile: vi.fn().mockResolvedValue(undefined)
+                getUserProfile: vi.fn().mockResolvedValue({ coachOf: [], roles: [] }),
+                redeemAdminInviteAtomicPersistence: null
             })
-        ).rejects.toThrow('Unable to grant team coach access before admin assignment');
-
-        expect(addTeamAdminEmail).not.toHaveBeenCalled();
+        ).rejects.toThrow('Missing atomic admin invite persistence handler');
     });
 });

--- a/tests/unit/auth-google-admin-invite-cleanup.test.js
+++ b/tests/unit/auth-google-admin-invite-cleanup.test.js
@@ -27,7 +27,7 @@ vi.mock('../../js/firebase.js?v=10', () => ({
     updatePassword: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=15', () => ({
+vi.mock('../../js/db.js?v=16', () => ({
     validateAccessCode: validateAccessCodeMock,
     markAccessCodeAsUsed: markAccessCodeAsUsedMock,
     updateUserProfile: updateUserProfileMock,
@@ -39,7 +39,7 @@ vi.mock('../../js/db.js?v=15', () => ({
     addTeamAdminEmail: vi.fn()
 }));
 
-vi.mock('../../js/admin-invite.js?v=3', () => ({
+vi.mock('../../js/admin-invite.js?v=4', () => ({
     redeemAdminInviteAcceptance: redeemAdminInviteAcceptanceMock
 }));
 

--- a/tests/unit/auth-google-admin-invite-cleanup.test.js
+++ b/tests/unit/auth-google-admin-invite-cleanup.test.js
@@ -101,6 +101,9 @@ describe('loginWithGoogle admin invite failure handling', () => {
             teamId: 'team-1',
             codeId: 'code-admin-1'
         }));
+        expect(redeemAdminInviteAcceptanceMock.mock.calls[0][0]).not.toHaveProperty('markAccessCodeAsUsed');
+        expect(redeemAdminInviteAcceptanceMock.mock.calls[0][0]).not.toHaveProperty('addTeamAdminEmail');
+        expect(redeemAdminInviteAcceptanceMock.mock.calls[0][0]).not.toHaveProperty('updateUserProfile');
         expect(updateUserProfileMock).not.toHaveBeenCalled();
         expect(markAccessCodeAsUsedMock).not.toHaveBeenCalled();
         expect(deleteMock).toHaveBeenCalledTimes(1);
@@ -145,6 +148,9 @@ describe('loginWithGoogle admin invite failure handling', () => {
             teamId: 'team-2',
             codeId: 'code-admin-2'
         }));
+        expect(redeemAdminInviteAcceptanceMock.mock.calls[0][0]).not.toHaveProperty('markAccessCodeAsUsed');
+        expect(redeemAdminInviteAcceptanceMock.mock.calls[0][0]).not.toHaveProperty('addTeamAdminEmail');
+        expect(redeemAdminInviteAcceptanceMock.mock.calls[0][0]).not.toHaveProperty('updateUserProfile');
         expect(updateUserProfileMock).not.toHaveBeenCalled();
         expect(markAccessCodeAsUsedMock).not.toHaveBeenCalled();
         expect(deleteMock).toHaveBeenCalledTimes(1);

--- a/tests/unit/auth-google-parent-invite-cleanup.test.js
+++ b/tests/unit/auth-google-parent-invite-cleanup.test.js
@@ -27,7 +27,7 @@ vi.mock('../../js/firebase.js?v=10', () => ({
     updatePassword: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=15', () => ({
+vi.mock('../../js/db.js?v=16', () => ({
     validateAccessCode: validateAccessCodeMock,
     markAccessCodeAsUsed: markAccessCodeAsUsedMock,
     updateUserProfile: updateUserProfileMock,

--- a/tests/unit/auth-parent-membership-sync.test.js
+++ b/tests/unit/auth-parent-membership-sync.test.js
@@ -32,11 +32,11 @@ const dbMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../js/firebase.js?v=10', () => firebaseMocks);
-vi.mock('../../js/db.js?v=15', () => dbMocks);
+vi.mock('../../js/db.js?v=16', () => dbMocks);
 vi.mock('../../js/signup-flow.js?v=2', () => ({
     executeEmailPasswordSignup: vi.fn()
 }));
-vi.mock('../../js/admin-invite.js?v=3', () => ({
+vi.mock('../../js/admin-invite.js?v=4', () => ({
     redeemAdminInviteAcceptance: vi.fn()
 }));
 

--- a/tests/unit/auth-signup-parent-invite.test.js
+++ b/tests/unit/auth-signup-parent-invite.test.js
@@ -36,7 +36,7 @@ const dbMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../js/firebase.js?v=10', () => firebaseMocks);
-vi.mock('../../js/db.js?v=15', () => dbMocks);
+vi.mock('../../js/db.js?v=16', () => dbMocks);
 
 const { signup, loginWithGoogle } = await import('../../js/auth.js');
 

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -232,7 +232,7 @@ function extractEditTeamModule() {
             'const { renderHeader, renderFooter, getUrlParams } = deps.utils;'
         )
         .replace(
-            "import { checkAuth, sendInviteEmail } from './js/auth.js?v=10';",
+            /import\s+\{\s*checkAuth,\s*sendInviteEmail\s*\}\s+from\s+'\.\/js\/auth\.js\?v=\d+';/,
             'const { checkAuth, sendInviteEmail } = deps.auth;'
         )
         .replace(

--- a/tests/unit/live-game-replay-init.test.js
+++ b/tests/unit/live-game-replay-init.test.js
@@ -228,7 +228,7 @@ function buildModuleSource() {
             'const { computePanelVisibility } = deps.liveStreamUtils;'
         )
         .replace(
-            "import { checkAuth } from './auth.js?v=10';",
+            /import\s+\{\s*checkAuth\s*\}\s+from\s+'\.\/auth\.js\?v=\d+';/,
             'const { checkAuth } = deps.auth;'
         )
         .replace(

--- a/tests/unit/signup-flow.test.js
+++ b/tests/unit/signup-flow.test.js
@@ -153,6 +153,9 @@ describe('executeEmailPasswordSignup', () => {
             teamId: 'team-42',
             codeId: 'code-admin-1'
         }));
+        expect(dependencies.redeemAdminInviteAcceptance.mock.calls[0][0]).not.toHaveProperty('markAccessCodeAsUsed');
+        expect(dependencies.redeemAdminInviteAcceptance.mock.calls[0][0]).not.toHaveProperty('addTeamAdminEmail');
+        expect(dependencies.redeemAdminInviteAcceptance.mock.calls[0][0]).not.toHaveProperty('updateUserProfile');
         expect(dependencies.updateUserProfile).toHaveBeenCalledWith('user-123', expect.objectContaining({
             email: 'newadmin@example.com',
             emailVerificationRequired: true


### PR DESCRIPTION
Closes #305

## What changed
- routed email/password admin-invite signup through the same atomic admin redemption persistence used by the invite acceptance flow
- updated `js/admin-invite.js` to normalize the invited email and delegate the team/admin/code grant to `redeemAdminInviteAtomicPersistence(...)`
- added regression coverage for the signup-side admin invite helper and refreshed cache-bust version pins for the updated auth import chain
- recorded requirements, architecture, QA, and code-plan notes for this fixer run under `docs/pr-notes/runs/issue-305-fixer-20260313T020032Z/`

## Why
The signup path had drifted from the authoritative admin invite redemption flow. Unifying it with the atomic persistence path prevents invite consumption without the corresponding team-admin grant.

## Validation
- ran `vitest` for signup/admin invite/auth cleanup coverage:
  - `tests/unit/admin-invite.test.js`
  - `tests/unit/admin-invite-signup-cache-busting.test.js`
  - `tests/unit/signup-flow.test.js`
  - `tests/unit/auth-signup-parent-invite.test.js`
  - `tests/unit/auth-google-admin-invite-cleanup.test.js`
  - `tests/unit/auth-google-parent-invite-cleanup.test.js`
  - `tests/unit/auth-parent-membership-sync.test.js`
- ran adjacent invite redemption tests:
  - `tests/unit/admin-invite-redemption.test.js`
  - `tests/unit/accept-invite-flow.test.js`