### PR TITLE
Fix parent dashboard request load failures

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -156,8 +156,8 @@ service cloud.firestore {
       }
     }
 
-    // Access codes - allow public read for validation during signup
-    match /accessCodes/{codeId} {
+	    // Access codes - allow public read for validation during signup
+	    match /accessCodes/{codeId} {
       // Allow anyone to read for code validation (needed for unauthenticated signup)
       // This is secure because users can only query by exact code match
       allow read: if true;
@@ -168,11 +168,19 @@ service cloud.firestore {
                         // Allow marking as used only if setting these specific fields
                         (request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt']) &&
                          request.resource.data.usedBy == request.auth.uid));
-      allow delete: if isSignedIn() && resource.data.generatedBy == request.auth.uid;
-    }
+	      allow delete: if isSignedIn() && resource.data.generatedBy == request.auth.uid;
+	    }
 
-    // Collection group rule for games - allows cross-team queries (e.g., live games, recent games)
-    match /{path=**}/games/{gameId} {
+	    // Collection-group read for a parent's own membership requests.
+	    // This keeps parent-dashboard collectionGroup queries query-safe even
+	    // when the team-scoped rule also grants broader coach/admin access.
+	    match /{path=**}/membershipRequests/{requestId} {
+	      allow read: if isSignedIn() &&
+	                     resource.data.requesterUserId == request.auth.uid;
+	    }
+
+	    // Collection group rule for games - allows cross-team queries (e.g., live games, recent games)
+	    match /{path=**}/games/{gameId} {
       allow read: if true;  // Public read for collection group queries
     }
 

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -440,8 +440,17 @@
         }
 
         async function refreshParentMembershipRequestList(userId) {
-            parentMembershipRequests = await listMyParentMembershipRequests(userId);
-            renderParentMembershipRequests();
+            try {
+                parentMembershipRequests = await listMyParentMembershipRequests(userId);
+                renderParentMembershipRequests();
+            } catch (err) {
+                console.warn('[parent-dashboard] Failed to load parent membership requests:', err);
+                parentMembershipRequests = [];
+                const listEl = document.getElementById('parent-membership-request-list');
+                if (listEl) {
+                    listEl.innerHTML = '<div class="text-xs text-red-600">Unable to load your access requests right now.</div>';
+                }
+            }
         }
 
         async function submitParentAccessRequest() {

--- a/tests/unit/parent-membership-request-wiring.test.js
+++ b/tests/unit/parent-membership-request-wiring.test.js
@@ -15,6 +15,8 @@ describe('parent membership request wiring', () => {
         expect(html).toContain('submit-parent-access-request-btn');
         expect(html).toContain('createParentMembershipRequest');
         expect(html).toContain('listMyParentMembershipRequests');
+        expect(html).toContain('Failed to load parent membership requests');
+        expect(html).toContain('Unable to load your access requests right now.');
     });
 
     it('adds roster approval controls for pending parent membership requests', () => {
@@ -32,6 +34,7 @@ describe('parent membership request wiring', () => {
         const rules = readRepoFile('firestore.rules');
 
         expect(rules).toContain('match /membershipRequests/{requestId}');
+        expect(rules).toContain('match /{path=**}/membershipRequests/{requestId}');
         expect(rules).toContain("request.resource.data.status == 'pending'");
         expect(rules).toContain("request.resource.data.requesterUserId == request.auth.uid");
         expect(rules).toContain("request.resource.data.status in ['approved', 'denied']");


### PR DESCRIPTION
## Summary
- stop parent-dashboard from dead-spinning when the membership request sidebar query fails
- add a collection-group membership request read rule for the requesting parent
- add wiring coverage for the dashboard fallback and the new rules path

## Validation
- npm run test:unit -- tests/unit/parent-membership-request-wiring.test.js
