### PR TITLE
Add parent membership request index

### DIFF
--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -101,6 +101,13 @@
         { "order": "ASCENDING", "queryScope": "COLLECTION" },
         { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
       ]
+    },
+    {
+      "collectionGroup": "membershipRequests",
+      "fieldPath": "requesterUserId",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
     }
   ]
 }

--- a/tests/unit/parent-membership-request-wiring.test.js
+++ b/tests/unit/parent-membership-request-wiring.test.js
@@ -40,4 +40,12 @@ describe('parent membership request wiring', () => {
         expect(rules).toContain("request.resource.data.status in ['approved', 'denied']");
         expect(rules).toContain('isTeamOwnerOrAdmin(teamId)');
     });
+
+    it('defines the parent membership request collection-group index', () => {
+        const indexes = readRepoFile('firestore.indexes.json');
+
+        expect(indexes).toContain('"collectionGroup": "membershipRequests"');
+        expect(indexes).toContain('"fieldPath": "requesterUserId"');
+        expect(indexes).toContain('"queryScope": "COLLECTION_GROUP"');
+    });
 });


### PR DESCRIPTION
## Summary
- add the collection-group single-field index override for membershipRequests.requesterUserId
- cover the new index entry in the parent membership request wiring test

## Validation
- npm run test:unit -- tests/unit/parent-membership-request-wiring.test.js
- firebase deploy --only firestore:indexes --project game-flow-c6311
