### PR TITLE
Deploy full Firebase surface in prod workflow

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -50,11 +50,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Install Functions dependencies
+        run: npm ci --prefix functions
+
       - name: Configure Firebase service account
         run: |
           credentials_file="$RUNNER_TEMP/firebase-service-account.json"
           printf '%s' '${{ secrets.FIREBASE_SERVICE_ACCOUNT_GAME_FLOW_C6311 }}' > "$credentials_file"
           echo "GOOGLE_APPLICATION_CREDENTIALS=$credentials_file" >> "$GITHUB_ENV"
 
-      - name: Deploy Firebase Hosting production
-        run: npx firebase-tools@14.25.0 deploy --only hosting --project game-flow-c6311 --non-interactive
+      - name: Deploy Firebase production
+        run: npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,functions --project game-flow-c6311 --non-interactive


### PR DESCRIPTION
## Summary
- deploy Firestore rules, indexes, and Functions alongside Hosting in the production workflow
- install Functions dependencies in CI before the Firebase deploy step
- keep using the existing Firebase service account secret without exposing it in logs

## Testing
- workflow diff review only
