### PR TITLE
Handle denied public roster reads in live viewer

### DIFF
--- a/js/live-game.js
+++ b/js/live-game.js
@@ -1775,9 +1775,16 @@ async function init() {
 
   let team, game, players, configs;
   try {
-    const playersPromise = state.isReplay
+    const playersPromise = (state.isReplay
       ? getPlayers(state.teamId, { includeInactive: true })
-      : getPlayers(state.teamId);
+      : getPlayers(state.teamId)
+    ).catch((error) => {
+      if (error?.code === 'permission-denied') {
+        console.warn('Failed to load public roster for live game viewer:', error);
+        return [];
+      }
+      throw error;
+    });
     [team, game, players, configs] = await Promise.all([
       // Replay/live links should still load team metadata for inactive teams.
       getTeam(state.teamId, { includeInactive: true }),

--- a/tests/unit/live-game-public-roster-fallback.test.js
+++ b/tests/unit/live-game-public-roster-fallback.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+
+function readFile(relPath) {
+    return fs.readFileSync(path.join(repoRoot, relPath), 'utf8');
+}
+
+describe('live game public roster fallback', () => {
+    it('keeps roster loading optional when Firestore denies public player reads', () => {
+        const source = readFile('js/live-game.js');
+
+        expect(source).toContain("console.warn('Failed to load public roster for live game viewer:', error);");
+        expect(source).toContain("if (error?.code === 'permission-denied') {");
+        expect(source).toContain('return [];');
+        expect(source).toContain('throw error;');
+    });
+});

--- a/tests/unit/player-soft-delete-policy.test.js
+++ b/tests/unit/player-soft-delete-policy.test.js
@@ -54,7 +54,7 @@ describe('player soft-delete policy', () => {
 
         expect(playerPage).toContain('getPlayers(teamId, { includeInactive: true })');
         expect(liveGame).toContain('? getPlayers(state.teamId, { includeInactive: true })');
-        expect(liveGame).toContain(': getPlayers(state.teamId);');
+        expect(liveGame).toContain(': getPlayers(state.teamId)');
         expect(teamChat).toContain('getPlayers(teamId, { includeInactive: true })');
     });
 });


### PR DESCRIPTION
Closes #303

## What changed
- made `js/live-game.js` treat roster loading as optional when Firestore returns `permission-denied` for public player docs, so the public live-game page still loads team, game, and config data
- kept non-permission roster failures fatal, preserving the existing initialization guard for real load errors
- added a unit regression test covering the new public-roster fallback and relaxed the existing source assertion so it still verifies inactive-player loading without depending on exact ternary formatting

## Why
Public spectators should be able to open shared live-game links even when a legacy player doc still contains restricted `medicalInfo` or `emergencyContact` fields. Before this change, that denied roster query rejected the page's initialization `Promise.all(...)` and stopped the viewer entirely.

## Validation
- ran `/home/paul-bot1/.local/bin/node ./node_modules/vitest/vitest.mjs run tests/unit/live-game-public-roster-fallback.test.js tests/unit/live-game-state.test.js tests/unit/live-game-video.test.js tests/unit/live-game-chat.test.js tests/unit/player-soft-delete-policy.test.js`
- result: 5 test files passed, 28 tests passed