### PR TITLE
Stop recurring series metadata on one-time practice edits

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -716,6 +716,7 @@
         import { getTeamAccessInfo } from './js/team-access.js';
         import { resolvePreferredStatConfigId } from './js/live-game-state.js?v=3';
         import { cancelScheduledGame } from './js/edit-schedule-cancel-game.js?v=1';
+        import { applyPracticeRecurrenceFields } from './js/edit-schedule-practice-payload.js?v=1';
         import { Timestamp, deleteField } from "./js/firebase.js?v=10";
         import { getApp } from './js/vendor/firebase-app.js';
         import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
@@ -2051,40 +2052,25 @@
                     })
                 };
 
-                // Handle recurring practice
-                if (isRecurring) {
-                    const freq = document.getElementById('recurrenceFreq').value;
-                    const interval = parseInt(document.getElementById('recurrenceInterval').value) || 1;
-                    const byDays = Array.from(document.querySelectorAll('.day-checkbox:checked')).map(cb => cb.value);
-                    const endType = document.querySelector('input[name="recurrenceEnd"]:checked').value;
-
-                    practiceData.isSeriesMaster = true;
-                    // Preserve existing seriesId on edit; generate new on create
-                    practiceData.seriesId = editingPracticeId
-                        ? (editingSeriesId || practiceData.seriesId || generateSeriesId())
-                        : generateSeriesId();
-
-                    // Store start/end as time strings for recurring (HH:mm)
-                    practiceData.startTime = startDate.toTimeString().slice(0, 5);
-                    practiceData.endTime = endDate.toTimeString().slice(0, 5);
-
-                    practiceData.recurrence = { freq, interval, byDays };
-
-                    if (endType === 'until') {
-                        const untilVal = document.getElementById('recurrenceUntil').value;
-                        if (untilVal) {
-                            practiceData.recurrence.until = Timestamp.fromDate(new Date(untilVal));
-                        }
-                    } else if (endType === 'count') {
-                        practiceData.recurrence.count = parseInt(document.getElementById('recurrenceCount').value) || 10;
-                    }
-
-                    // Initialize empty exDates and overrides
-                    if (!editingPracticeId) {
-                        practiceData.exDates = [];
-                        practiceData.overrides = {};
-                    }
-                }
+                applyPracticeRecurrenceFields({
+                    practiceData,
+                    isRecurring,
+                    editingPracticeId,
+                    editingSeriesId,
+                    recurrenceConfig: {
+                        freq: document.getElementById('recurrenceFreq').value,
+                        interval: parseInt(document.getElementById('recurrenceInterval').value) || 1,
+                        byDays: Array.from(document.querySelectorAll('.day-checkbox:checked')).map(cb => cb.value),
+                        endType: document.querySelector('input[name="recurrenceEnd"]:checked').value,
+                        untilValue: document.getElementById('recurrenceUntil').value,
+                        countValue: document.getElementById('recurrenceCount').value
+                    },
+                    startDate,
+                    endDate,
+                    Timestamp,
+                    deleteField,
+                    generateSeriesId
+                });
 
                 let savedPracticeId = editingPracticeId;
                 if (editingPracticeId) {

--- a/js/edit-schedule-practice-payload.js
+++ b/js/edit-schedule-practice-payload.js
@@ -1,0 +1,70 @@
+const RECURRENCE_FIELD_KEYS = [
+    'isSeriesMaster',
+    'recurrence',
+    'seriesId',
+    'startTime',
+    'endTime',
+    'exDates',
+    'overrides'
+];
+
+export function applyPracticeRecurrenceFields({
+    practiceData,
+    isRecurring,
+    editingPracticeId = null,
+    editingSeriesId = null,
+    recurrenceConfig = {},
+    startDate,
+    endDate,
+    Timestamp,
+    deleteField,
+    generateSeriesId
+} = {}) {
+    if (!practiceData || !Timestamp || !deleteField || !generateSeriesId) {
+        throw new Error('applyPracticeRecurrenceFields requires practice data, firestore helpers, and a series ID generator');
+    }
+
+    if (isRecurring) {
+        const {
+            freq = 'weekly',
+            interval = 1,
+            byDays = [],
+            endType = 'never',
+            untilValue = '',
+            countValue = 10
+        } = recurrenceConfig;
+
+        practiceData.isSeriesMaster = true;
+        practiceData.seriesId = editingPracticeId
+            ? (editingSeriesId || practiceData.seriesId || generateSeriesId())
+            : generateSeriesId();
+        practiceData.startTime = startDate.toTimeString().slice(0, 5);
+        practiceData.endTime = endDate.toTimeString().slice(0, 5);
+        practiceData.recurrence = {
+            freq,
+            interval,
+            byDays
+        };
+
+        if (endType === 'until' && untilValue) {
+            practiceData.recurrence.until = Timestamp.fromDate(new Date(untilValue));
+        } else if (endType === 'count') {
+            practiceData.recurrence.count = Number.parseInt(countValue, 10) || 10;
+        }
+
+        if (!editingPracticeId) {
+            practiceData.exDates = [];
+            practiceData.overrides = {};
+        }
+
+        return practiceData;
+    }
+
+    if (editingPracticeId) {
+        RECURRENCE_FIELD_KEYS.forEach((fieldName) => {
+            practiceData[fieldName] = deleteField();
+        });
+    }
+
+    return practiceData;
+}

--- a/tests/unit/edit-schedule-practice-payload.test.js
+++ b/tests/unit/edit-schedule-practice-payload.test.js
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { applyPracticeRecurrenceFields } from '../../js/edit-schedule-practice-payload.js';
+
+describe('edit schedule practice recurrence payload', () => {
+    it('clears recurrence-only fields when editing a series into a one-time practice', () => {
+        const deleteSentinel = Symbol('deleteField');
+        const practiceData = {
+            title: 'Practice'
+        };
+
+        const result = applyPracticeRecurrenceFields({
+            practiceData,
+            isRecurring: false,
+            editingPracticeId: 'practice-1',
+            startDate: new Date('2026-03-16T17:00:00.000Z'),
+            endDate: new Date('2026-03-16T18:30:00.000Z'),
+            Timestamp: { fromDate: (value) => value },
+            deleteField: () => deleteSentinel,
+            generateSeriesId: () => 'series-new'
+        });
+
+        expect(result).toMatchObject({
+            title: 'Practice'
+        });
+        expect(result.isSeriesMaster).toBe(deleteSentinel);
+        expect(result.recurrence).toBe(deleteSentinel);
+        expect(result.seriesId).toBe(deleteSentinel);
+        expect(result.startTime).toBe(deleteSentinel);
+        expect(result.endTime).toBe(deleteSentinel);
+        expect(result.exDates).toBe(deleteSentinel);
+        expect(result.overrides).toBe(deleteSentinel);
+    });
+
+    it('preserves recurring series metadata when recurrence remains enabled', () => {
+        const practiceData = {
+            title: 'Practice'
+        };
+
+        const result = applyPracticeRecurrenceFields({
+            practiceData,
+            isRecurring: true,
+            editingPracticeId: 'practice-1',
+            editingSeriesId: 'series-existing',
+            recurrenceConfig: {
+                freq: 'weekly',
+                interval: 2,
+                byDays: ['MO', 'WE'],
+                endType: 'count',
+                countValue: '8'
+            },
+            startDate: new Date('2026-03-16T17:00:00.000Z'),
+            endDate: new Date('2026-03-16T18:30:00.000Z'),
+            Timestamp: { fromDate: (value) => value },
+            deleteField: () => {
+                throw new Error('deleteField should not be used for recurring series updates');
+            },
+            generateSeriesId: () => 'series-new'
+        });
+
+        expect(result.isSeriesMaster).toBe(true);
+        expect(result.seriesId).toBe('series-existing');
+        expect(result.startTime).toBe('17:00');
+        expect(result.endTime).toBe('18:30');
+        expect(result.recurrence).toEqual({
+            freq: 'weekly',
+            interval: 2,
+            byDays: ['MO', 'WE'],
+            count: 8
+        });
+    });
+
+    it('wires the practice submit flow through the shared recurrence payload helper', () => {
+        const source = readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
+
+        expect(source).toContain("import { applyPracticeRecurrenceFields } from './js/edit-schedule-practice-payload.js?v=1';");
+        expect(source).toContain('applyPracticeRecurrenceFields({');
+        expect(source).toContain('deleteField,');
+    });
+});


### PR DESCRIPTION
Closes #271

## What changed
- added a shared `applyPracticeRecurrenceFields(...)` helper used by `edit-schedule.html` when saving practices
- when a coach edits an existing recurring practice and leaves recurrence unchecked, the update payload now sends `deleteField()` for recurrence-only fields (`isSeriesMaster`, `recurrence`, `seriesId`, `startTime`, `endTime`, `exDates`, `overrides`) so Firestore removes the stale series metadata instead of merging around it
- kept the existing recurring-series edit behavior intact when recurrence stays enabled

## Why
The bug was caused by `updateDoc(...)` merging the non-recurring edit payload into an existing series master document without clearing the old recurrence fields. That left the practice still qualifying as a recurring series, so future instances continued to expand in schedule views.

## Validation
- added Vitest coverage for converting a recurring practice into a one-time practice and for preserving metadata when recurrence remains enabled
- ran:
  - `/home/paul-bot1/.local/bin/node node_modules/vitest/vitest.mjs run tests/unit/edit-schedule-practice-payload.test.js tests/unit/recurrence-expand.test.js tests/unit/recurrence-interval.test.js tests/unit/recurrence-until-inclusive.test.js tests/unit/edit-schedule-cancellation.test.js tests/unit/edit-schedule-calendar-cancellation.test.js`
- result: 6 test files passed, 17 tests passed