### PR TITLE
Preserve entered zero scores in recap emails

### DIFF
--- a/js/live-tracker-email.js
+++ b/js/live-tracker-email.js
@@ -6,3 +6,8 @@ export function resolveSummaryRecipient({ teamNotificationEmail, userEmail }) {
 
   return (userEmail || '').trim();
 }
+
+export function resolveFinalScore(inputValue, liveScore) {
+  const parsedScore = Number.parseInt(inputValue, 10);
+  return Number.isNaN(parsedScore) ? liveScore : parsedScore;
+}

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -11,7 +11,7 @@ import { canApplySubstitution, applySubstitution, canTrustScoreLogForFinalizatio
 import { hydrateOpponentStats } from './live-tracker-opponent-stats.js?v=1';
 import { buildPersistedResumeClockState, deriveResumeClockState } from './live-tracker-resume.js?v=3';
 import { restoreLiveLineup } from './live-tracker-lineup.js?v=1';
-import { resolveSummaryRecipient } from './live-tracker-email.js?v=1';
+import { resolveFinalScore, resolveSummaryRecipient } from './live-tracker-email.js?v=2';
 import { buildLiveResetEvent } from './live-tracker-reset.js?v=1';
 import { advanceLiveChatUnreadState } from './live-tracker-chat-unread.js?v=2';
 import { resolveLiveStatConfig, resolveLiveStatColumns } from './live-game-state.js?v=3';
@@ -1285,8 +1285,8 @@ async function generateAISummary() {
   els.aiSummaryOutput.classList.remove('hidden');
 
   try {
-    const finalHome = parseInt(els.homeFinal.value) || state.home;
-    const finalAway = parseInt(els.awayFinal.value) || state.away;
+    const finalHome = resolveFinalScore(els.homeFinal.value, state.home);
+    const finalAway = resolveFinalScore(els.awayFinal.value, state.away);
 
     let context = `Game: ${currentTeam.name} vs ${currentGame.opponent}\n`;
     context += `Final Score: ${finalHome} - ${finalAway}\n`;
@@ -1422,8 +1422,8 @@ function generateEmailBody(finalHome, finalAway, summary = '') {
 }
 
 function generateEmailRecap() {
-  const finalHome = parseInt(els.homeFinal.value) || state.home;
-  const finalAway = parseInt(els.awayFinal.value) || state.away;
+  const finalHome = resolveFinalScore(els.homeFinal.value, state.home);
+  const finalAway = resolveFinalScore(els.awayFinal.value, state.away);
   const summary = els.notesFinal.value.trim();
 
   const body = generateEmailBody(finalHome, finalAway, summary);

--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -7,7 +7,7 @@ import { writeBatch, doc, setDoc, addDoc } from './firebase.js?v=10';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
 import { canApplySubstitution, applySubstitution, canTrustScoreLogForFinalization, reconcileFinalScoreFromLog } from './live-tracker-integrity.js?v=1';
-import { resolveSummaryRecipient } from './live-tracker-email.js?v=1';
+import { resolveFinalScore, resolveSummaryRecipient } from './live-tracker-email.js?v=2';
 
 let currentTeamId = null;
 let currentGameId = null;
@@ -485,8 +485,8 @@ async function generateAISummary() {
   els.aiSummaryOutput.classList.remove('hidden');
 
   try {
-    const finalHome = parseInt(els.homeFinal.value) || state.home;
-    const finalAway = parseInt(els.awayFinal.value) || state.away;
+    const finalHome = resolveFinalScore(els.homeFinal.value, state.home);
+    const finalAway = resolveFinalScore(els.awayFinal.value, state.away);
 
     let context = `Game: ${currentTeam.name} vs ${currentGame.opponent}\n`;
     context += `Final Score: ${finalHome} - ${finalAway}\n`;
@@ -622,8 +622,8 @@ function generateEmailBody(finalHome, finalAway, summary = '') {
 }
 
 function generateEmailRecap() {
-  const finalHome = parseInt(els.homeFinal.value) || state.home;
-  const finalAway = parseInt(els.awayFinal.value) || state.away;
+  const finalHome = resolveFinalScore(els.homeFinal.value, state.home);
+  const finalAway = resolveFinalScore(els.awayFinal.value, state.away);
   const summary = els.notesFinal.value.trim();
 
   const body = generateEmailBody(finalHome, finalAway, summary);

--- a/tests/unit/legacy-tracker-email.test.js
+++ b/tests/unit/legacy-tracker-email.test.js
@@ -26,6 +26,7 @@ describe('legacy tracker summary email recipient', () => {
     it('wires recipient resolution into the beta basketball tracker finish flow', () => {
         const source = readFileSync(new URL('../../js/track-basketball.js', import.meta.url), 'utf8');
         expect(source).toContain('resolveSummaryRecipient');
+        expect(source).toContain('resolveFinalScore');
         expect(source).toContain('teamNotificationEmail: currentTeam?.notificationEmail');
     });
 });

--- a/tests/unit/live-tracker-email.test.js
+++ b/tests/unit/live-tracker-email.test.js
@@ -1,8 +1,16 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
-import { resolveSummaryRecipient } from '../../js/live-tracker-email.js';
+import { resolveFinalScore, resolveSummaryRecipient } from '../../js/live-tracker-email.js';
 
 describe('live tracker summary email recipient', () => {
+  it('keeps an entered zero final score instead of falling back to the live score', () => {
+    expect(resolveFinalScore('0', 45)).toBe(0);
+  });
+
+  it('falls back to the live score when no final score was entered', () => {
+    expect(resolveFinalScore('', 45)).toBe(45);
+  });
+
   it('prefers team notification email over signed-in user email', () => {
     expect(resolveSummaryRecipient({
       teamNotificationEmail: 'team-notify@example.com',
@@ -27,6 +35,7 @@ describe('live tracker summary email recipient', () => {
   it('wires recipient resolution into live tracker finish flow', () => {
     const source = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8');
     expect(source).toContain('resolveSummaryRecipient');
+    expect(source).toContain('resolveFinalScore');
     expect(source).toContain('teamNotificationEmail: currentTeam?.notificationEmail');
   });
 });


### PR DESCRIPTION
Closes #182

## What changed
- added a shared `resolveFinalScore(...)` helper that preserves entered `0` values and only falls back to the live score when the final score input is blank or invalid
- updated both `js/live-tracker.js` and `js/track-basketball.js` recap generation paths to use the helper
- updated the same helper usage in the AI summary score context so final-score handling stays consistent in both tracker flows
- added regression coverage for the helper behavior and wiring checks for both tracker files

## Why
The recap flow used `parseInt(...) || liveScore`, which treats `0` as falsy and replaced a valid finalized score with the in-game live score. This caused incorrect final scores in generated recap content whenever either side finished with 0.

## Validation
- ran `/home/paul-bot1/.local/bin/node node_modules/vitest/vitest.mjs run tests/unit/live-tracker-email.test.js tests/unit/legacy-tracker-email.test.js`
- result: 2 test files passed, 10 tests passed