### PR TITLE
Add Parent Dashboard rideshare child-request coverage

### DIFF
--- a/docs/pr-notes/runs/issue-360-fixer-20260319T232502Z/architecture.md
+++ b/docs/pr-notes/runs/issue-360-fixer-20260319T232502Z/architecture.md
@@ -1,0 +1,25 @@
+# Architecture Role (allplays-architecture-expert equivalent fallback)
+
+Requested orchestration skill `allplays-orchestrator-playbook`, role skill `allplays-architecture-expert`, and `sessions_spawn` are unavailable in this runtime. This artifact captures equivalent architecture analysis.
+
+## Current State
+
+- `parent-dashboard.html` owns rideshare rendering, child-selection resolution, and async handlers inline.
+- That structure makes the stateful child-request path hard to test directly.
+
+## Proposed Change
+
+- Extract rideshare child-selection and request/cancel handler logic into a dedicated ES module.
+- Keep DOM rendering in `parent-dashboard.html`; move only pure/handler logic needed for automated coverage.
+
+## Blast Radius
+
+- Limited to Parent Dashboard rideshare logic.
+- No Firestore schema changes.
+- No changes to unrelated schedule, RSVP, or practice packet flows.
+
+## Control Notes
+
+- Preserve existing backend function calls and rerender order.
+- Keep inline HTML event handlers intact by wiring the same `window.*` functions from the new module.
+- Prefer additive changes over refactoring large modal sections.

--- a/docs/pr-notes/runs/issue-360-fixer-20260319T232502Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-360-fixer-20260319T232502Z/code-plan.md
@@ -1,0 +1,10 @@
+# Code Role (allplays-code-expert equivalent fallback)
+
+Requested orchestration skill `allplays-orchestrator-playbook`, role skill `allplays-code-expert`, and `sessions_spawn` are unavailable in this runtime. This artifact captures equivalent implementation plan.
+
+## Plan
+
+1. Add a small rideshare controller module for child-selection resolution and request/cancel handlers.
+2. Wire `parent-dashboard.html` to use the new module while preserving existing UI markup and `window.*` handlers.
+3. Add failing Vitest coverage for child-B request selection, existing-request selection preference, and cancel rerender side effects.
+4. Run focused tests, then the relevant rideshare suite, and commit with an issue-linked message.

--- a/docs/pr-notes/runs/issue-360-fixer-20260319T232502Z/qa.md
+++ b/docs/pr-notes/runs/issue-360-fixer-20260319T232502Z/qa.md
@@ -1,0 +1,20 @@
+# QA Role (allplays-qa-expert equivalent fallback)
+
+Requested orchestration skill `allplays-orchestrator-playbook`, role skill `allplays-qa-expert`, and `sessions_spawn` are unavailable in this runtime. This artifact captures equivalent QA analysis.
+
+## Risk Focus
+
+- Wrong child ID/name submitted on request.
+- Modal rerender hiding the parent's existing request by snapping back to child A.
+- Cancel action firing backend writes but leaving stale UI state assumptions.
+
+## Test Plan
+
+- Add a unit test for child-selection resolution when the parent already has a request for child B.
+- Add a unit test for request handler behavior with a selector value for child B and verify backend + rerender side effects.
+- Add a unit test for cancel handler behavior and verify backend + rerender side effects.
+
+## Regression Guardrails
+
+- Keep existing rideshare helper and wiring tests green.
+- Run the focused new test file plus the existing rideshare-related suite.

--- a/docs/pr-notes/runs/issue-360-fixer-20260319T232502Z/requirements.md
+++ b/docs/pr-notes/runs/issue-360-fixer-20260319T232502Z/requirements.md
@@ -1,0 +1,30 @@
+# Requirements Role (allplays-requirements-expert equivalent fallback)
+
+Requested orchestration skill `allplays-orchestrator-playbook`, role skill `allplays-requirements-expert`, and `sessions_spawn` are unavailable in this runtime. This artifact captures equivalent requirements analysis.
+
+## Objective
+
+Add automated coverage for the Parent Dashboard rideshare modal flow where a multi-child parent selects a specific child, requests a spot, and can later cancel from the rerendered modal state.
+
+## Current State
+
+- Parent Dashboard rideshare coverage is limited to helper and wiring tests.
+- The user-facing flow depends on inline modal rendering and several async write handlers.
+- Multi-child selection state is high risk because modal events are aggregated per event/day, not per child row.
+
+## Proposed State
+
+- Add automated tests for child-specific request and cancel behavior using the repo's existing Vitest framework.
+- Make the child selection logic deterministic so the modal prefers the child that already has the parent's request.
+- Preserve the active child selection across the request write and modal rerender path.
+
+## Assumptions
+
+- Vitest is the supported automated framework in this branch, despite the issue text referencing Playwright.
+- A targeted extraction into a small JS module is acceptable if it improves testability without changing UX.
+
+## Success Criteria
+
+- A test proves the request path submits child B when child B is selected.
+- A test proves cancel triggers the backend call and rerender path.
+- The modal state resolves to the child with the parent's existing request instead of defaulting to the first child.

--- a/js/parent-dashboard-rideshare-controls.js
+++ b/js/parent-dashboard-rideshare-controls.js
@@ -1,0 +1,101 @@
+export function resolveSelectedRideChildId({
+    includeChildPicker = false,
+    selectedChildId = '',
+    defaultChildId = '',
+    childChoices = [],
+    offer = {},
+    parentUserId = ''
+} = {}) {
+    if (!includeChildPicker) return defaultChildId;
+
+    const validChildIds = new Set(
+        (Array.isArray(childChoices) ? childChoices : [])
+            .map((child) => child?.childId)
+            .filter(Boolean)
+    );
+
+    if (selectedChildId && validChildIds.has(selectedChildId)) {
+        return selectedChildId;
+    }
+
+    const ownRequestChildId = (Array.isArray(offer?.requests) ? offer.requests : []).find((request) =>
+        request?.parentUserId === parentUserId && validChildIds.has(request?.childId)
+    )?.childId || '';
+    if (ownRequestChildId) {
+        return ownRequestChildId;
+    }
+
+    if (defaultChildId && validChildIds.has(defaultChildId)) {
+        return defaultChildId;
+    }
+
+    return childChoices[0]?.childId || '';
+}
+
+export function resolveRideRequestSelection({
+    defaultChildId = '',
+    defaultChildName = '',
+    selectorValue = '',
+    childChoices = []
+} = {}) {
+    const childId = selectorValue || defaultChildId || '';
+    const selectedChild = (Array.isArray(childChoices) ? childChoices : []).find((child) => child?.childId === childId);
+    return {
+        childId,
+        childName: selectedChild?.childName || defaultChildName || 'Player'
+    };
+}
+
+export function createRideRequestHandlers({
+    documentRef,
+    resolveChildChoices,
+    getRideOfferSelectionKey,
+    selectedRideChildByOffer,
+    requestRideSpot,
+    cancelRideRequest,
+    refreshRideshareForEvent,
+    renderScheduleFromControls,
+    rerenderActiveDayModal,
+    alertFn = globalThis.alert,
+    consoleRef = globalThis.console
+} = {}) {
+    return {
+        async requestRideSpotForChild(teamId, gameId, legacyGameId, offerGameId, offerId, defaultChildId, defaultChildName, selectorId = '') {
+            try {
+                const selector = selectorId ? documentRef?.getElementById(selectorId) : null;
+                const { childId, childName } = resolveRideRequestSelection({
+                    defaultChildId,
+                    defaultChildName,
+                    selectorValue: selector?.value || '',
+                    childChoices: resolveChildChoices(teamId)
+                });
+                if (!childId) throw new Error('Select a child first.');
+
+                const selectionKey = getRideOfferSelectionKey(teamId, gameId, offerId);
+                if (selectionKey && selectedRideChildByOffer?.set) {
+                    selectedRideChildByOffer.set(selectionKey, childId);
+                }
+
+                await requestRideSpot(teamId, offerGameId, offerId, { childId, childName });
+                await refreshRideshareForEvent(teamId, gameId, legacyGameId);
+                renderScheduleFromControls();
+                rerenderActiveDayModal();
+            } catch (err) {
+                consoleRef?.error?.('Failed to request spot:', err);
+                alertFn?.(`Could not request spot: ${err?.message || err}`);
+            }
+        },
+
+        async cancelMyRideRequest(teamId, gameId, legacyGameId, offerGameId, offerId, requestId) {
+            try {
+                await cancelRideRequest(teamId, offerGameId, offerId, requestId);
+                await refreshRideshareForEvent(teamId, gameId, legacyGameId);
+                renderScheduleFromControls();
+                rerenderActiveDayModal();
+            } catch (err) {
+                consoleRef?.error?.('Failed to cancel request:', err);
+                alertFn?.(`Could not cancel request: ${err?.message || err}`);
+            }
+        }
+    };
+}

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -292,6 +292,7 @@
         import { filterVisiblePracticeSessions } from './js/parent-dashboard-practice-sessions.js?v=1';
         import { resolveRsvpPlayerIdsForSubmission, resolveMyRsvpByChildForGame } from './js/parent-dashboard-rsvp.js?v=5';
         import { getEventRideshareSummary, getOfferSeatInfo, canRequestRide, findRequestForChild } from './js/rideshare-helpers.js?v=1';
+        import { resolveSelectedRideChildId, createRideRequestHandlers } from './js/parent-dashboard-rideshare-controls.js?v=1';
         import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
@@ -328,10 +329,8 @@
         window.submitGameRsvpFromButton = submitGameRsvpFromButton;
         window.toggleRideOfferForm = toggleRideOfferForm;
         window.submitRideOfferFromForm = submitRideOfferFromForm;
-        window.requestRideSpotForChild = requestRideSpotForChild;
         window.updateRideRequestDecision = updateRideRequestDecision;
         window.toggleRideOfferClosed = toggleRideOfferClosed;
-        window.cancelMyRideRequest = cancelMyRideRequest;
         window.setRideChildSelection = setRideChildSelection;
         window.openIncentivesPanel = openIncentivesPanel;
         window.closeIncentivesPanel = closeIncentivesPanel;
@@ -541,11 +540,15 @@
         }
 
         function getSelectedRideChildId(teamId, eventId, offerId, defaultChildId, childChoices, includeChildPicker) {
-            if (!includeChildPicker) return defaultChildId;
             const selectionKey = getRideOfferSelectionKey(teamId, eventId, offerId);
-            const selectedChildId = selectedRideChildByOffer.get(selectionKey) || defaultChildId;
-            if (childChoices.some((child) => child.childId === selectedChildId)) return selectedChildId;
-            return childChoices[0]?.childId || '';
+            return resolveSelectedRideChildId({
+                includeChildPicker,
+                selectedChildId: selectedRideChildByOffer.get(selectionKey) || '',
+                defaultChildId,
+                childChoices,
+                offer: getEventRideOffers(teamId, eventId).find((offer) => offer?.id === offerId) || {},
+                parentUserId: currentUserId
+            });
         }
 
         function renderEventRideshare(event, { includeChildPicker = false } = {}) {
@@ -717,26 +720,23 @@
             }
         }
 
-        async function requestRideSpotForChild(teamId, gameId, legacyGameId, offerGameId, offerId, defaultChildId, defaultChildName, selectorId = '') {
-            try {
-                let childId = defaultChildId;
-                let childName = defaultChildName;
-                const selector = selectorId ? document.getElementById(selectorId) : null;
-                if (selector) {
-                    childId = selector.value || childId;
-                    const selected = resolveChildChoices(teamId).find((child) => child.childId === childId);
-                    childName = selected?.childName || childName;
-                }
-                if (!childId) throw new Error('Select a child first.');
-                await requestRideSpot(teamId, offerGameId, offerId, { childId, childName });
-                await refreshRideshareForEvent(teamId, gameId, legacyGameId);
-                renderScheduleFromControls();
-                rerenderActiveDayModal();
-            } catch (err) {
-                console.error('Failed to request spot:', err);
-                alert(`Could not request spot: ${err?.message || err}`);
-            }
-        }
+        const rideshareRequestHandlers = createRideRequestHandlers({
+            documentRef: document,
+            resolveChildChoices,
+            getRideOfferSelectionKey,
+            selectedRideChildByOffer,
+            requestRideSpot,
+            cancelRideRequest,
+            refreshRideshareForEvent,
+            renderScheduleFromControls,
+            rerenderActiveDayModal,
+            alertFn: (message) => alert(message),
+            consoleRef: console
+        });
+
+        const { requestRideSpotForChild, cancelMyRideRequest } = rideshareRequestHandlers;
+        window.requestRideSpotForChild = requestRideSpotForChild;
+        window.cancelMyRideRequest = cancelMyRideRequest;
 
         async function updateRideRequestDecision(teamId, gameId, legacyGameId, offerGameId, offerId, requestId, status) {
             try {
@@ -760,18 +760,6 @@
             } catch (err) {
                 console.error('Failed to update offer status:', err);
                 alert(`Could not update offer: ${err?.message || err}`);
-            }
-        }
-
-        async function cancelMyRideRequest(teamId, gameId, legacyGameId, offerGameId, offerId, requestId) {
-            try {
-                await cancelRideRequest(teamId, offerGameId, offerId, requestId);
-                await refreshRideshareForEvent(teamId, gameId, legacyGameId);
-                renderScheduleFromControls();
-                rerenderActiveDayModal();
-            } catch (err) {
-                console.error('Failed to cancel request:', err);
-                alert(`Could not cancel request: ${err?.message || err}`);
             }
         }
 

--- a/tests/unit/parent-dashboard-rideshare-controls.test.js
+++ b/tests/unit/parent-dashboard-rideshare-controls.test.js
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    createRideRequestHandlers,
+    resolveRideRequestSelection,
+    resolveSelectedRideChildId
+} from '../../js/parent-dashboard-rideshare-controls.js';
+
+describe('parent dashboard rideshare controls', () => {
+    it('prefers the child with the parent request in the modal picker state', () => {
+        const selectedChildId = resolveSelectedRideChildId({
+            includeChildPicker: true,
+            defaultChildId: 'child-a',
+            childChoices: [
+                { childId: 'child-a', childName: 'Child A' },
+                { childId: 'child-b', childName: 'Child B' }
+            ],
+            offer: {
+                requests: [
+                    { id: 'req-b', parentUserId: 'parent-1', childId: 'child-b', childName: 'Child B', status: 'pending' }
+                ]
+            },
+            parentUserId: 'parent-1'
+        });
+
+        expect(selectedChildId).toBe('child-b');
+    });
+
+    it('resolves the selected child name from the active picker value', () => {
+        expect(resolveRideRequestSelection({
+            defaultChildId: 'child-a',
+            defaultChildName: 'Child A',
+            selectorValue: 'child-b',
+            childChoices: [
+                { childId: 'child-a', childName: 'Child A' },
+                { childId: 'child-b', childName: 'Child B' }
+            ]
+        })).toEqual({
+            childId: 'child-b',
+            childName: 'Child B'
+        });
+    });
+
+    it('requests a ride for child B and preserves the picker selection before rerender', async () => {
+        const requestRideSpot = vi.fn().mockResolvedValue('parent-1__child-b');
+        const refreshRideshareForEvent = vi.fn().mockResolvedValue(undefined);
+        const renderScheduleFromControls = vi.fn();
+        const rerenderActiveDayModal = vi.fn();
+        const selectedRideChildByOffer = new Map();
+        const handlers = createRideRequestHandlers({
+            documentRef: {
+                getElementById(id) {
+                    if (id === 'ride-child-picker') return { value: 'child-b' };
+                    return null;
+                }
+            },
+            resolveChildChoices() {
+                return [
+                    { childId: 'child-a', childName: 'Child A' },
+                    { childId: 'child-b', childName: 'Child B' }
+                ];
+            },
+            getRideOfferSelectionKey(teamId, gameId, offerId) {
+                return `${teamId}::${gameId}::${offerId}`;
+            },
+            selectedRideChildByOffer,
+            requestRideSpot,
+            cancelRideRequest: vi.fn(),
+            refreshRideshareForEvent,
+            renderScheduleFromControls,
+            rerenderActiveDayModal,
+            alertFn: vi.fn(),
+            consoleRef: { error: vi.fn() }
+        });
+
+        await handlers.requestRideSpotForChild(
+            'team-1',
+            'event-1',
+            '',
+            'offer-game-1',
+            'offer-1',
+            'child-a',
+            'Child A',
+            'ride-child-picker'
+        );
+
+        expect(requestRideSpot).toHaveBeenCalledWith('team-1', 'offer-game-1', 'offer-1', {
+            childId: 'child-b',
+            childName: 'Child B'
+        });
+        expect(selectedRideChildByOffer.get('team-1::event-1::offer-1')).toBe('child-b');
+        expect(refreshRideshareForEvent).toHaveBeenCalledWith('team-1', 'event-1', '');
+        expect(renderScheduleFromControls).toHaveBeenCalledTimes(1);
+        expect(rerenderActiveDayModal).toHaveBeenCalledTimes(1);
+    });
+
+    it('cancels an existing ride request and rerenders the modal state', async () => {
+        const cancelRideRequest = vi.fn().mockResolvedValue(undefined);
+        const refreshRideshareForEvent = vi.fn().mockResolvedValue(undefined);
+        const renderScheduleFromControls = vi.fn();
+        const rerenderActiveDayModal = vi.fn();
+        const handlers = createRideRequestHandlers({
+            documentRef: null,
+            resolveChildChoices: vi.fn(),
+            getRideOfferSelectionKey: vi.fn(),
+            selectedRideChildByOffer: new Map(),
+            requestRideSpot: vi.fn(),
+            cancelRideRequest,
+            refreshRideshareForEvent,
+            renderScheduleFromControls,
+            rerenderActiveDayModal,
+            alertFn: vi.fn(),
+            consoleRef: { error: vi.fn() }
+        });
+
+        await handlers.cancelMyRideRequest('team-1', 'event-1', 'legacy-1', 'offer-game-1', 'offer-1', 'req-1');
+
+        expect(cancelRideRequest).toHaveBeenCalledWith('team-1', 'offer-game-1', 'offer-1', 'req-1');
+        expect(refreshRideshareForEvent).toHaveBeenCalledWith('team-1', 'event-1', 'legacy-1');
+        expect(renderScheduleFromControls).toHaveBeenCalledTimes(1);
+        expect(rerenderActiveDayModal).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/unit/parent-dashboard-rideshare-wiring.test.js
+++ b/tests/unit/parent-dashboard-rideshare-wiring.test.js
@@ -27,4 +27,13 @@ describe('parent dashboard rideshare wiring', () => {
 
         expect(html).toContain('.filter((ev) => canShowRideshareForEvent(ev))');
     });
+
+    it('wires the extracted rideshare control helpers into the dashboard modal flow', () => {
+        const html = readRepoFile('parent-dashboard.html');
+
+        expect(html).toContain("from './js/parent-dashboard-rideshare-controls.js?v=1'");
+        expect(html).toContain('resolveSelectedRideChildId({');
+        expect(html).toContain('createRideRequestHandlers({');
+        expect(html).toContain('selectedRideChildByOffer');
+    });
 });


### PR DESCRIPTION
Closes #360

## What changed
- extracted Parent Dashboard rideshare child-selection and request/cancel handler logic into a small testable module
- added automated Vitest coverage for the child-specific request flow, existing-request child selection, and cancel rerender path
- updated the dashboard rideshare modal to prefer the child that already has the parent's request and to persist the selected child before rerendering after a request
- recorded the required requirements, architecture, QA, and code-plan artifacts for this fixer run

## Why
The Parent Dashboard rideshare modal had no automated coverage for the high-risk multi-child request flow. This change adds regression protection around the parent selecting child B, requesting a ride spot, and cancelling from the rerendered modal state without snapping back to the wrong child.

## Validation
- `./node_modules/.bin/vitest run tests/unit/parent-dashboard-rideshare-controls.test.js tests/unit/parent-dashboard-rideshare-wiring.test.js tests/unit/rideshare-helpers.test.js tests/unit/parent-dashboard-rideshare-access-sync.test.js`
- `./node_modules/.bin/vitest run tests/unit`