### PR TITLE
Add calendar import regression coverage

### DIFF
--- a/docs/pr-notes/runs/issue-354-fixer-20260320T022502Z/architecture.md
+++ b/docs/pr-notes/runs/issue-354-fixer-20260320T022502Z/architecture.md
@@ -1,0 +1,17 @@
+Current state:
+- `edit-schedule.html` performs URL validation with a direct string check and merges imported ICS events inline inside `loadSchedule()`.
+- Duplicate suppression currently depends on in-page logic for tracked calendar IDs and timestamp collisions with DB events.
+
+Proposed state:
+- Add `js/edit-schedule-calendar-import.js` with pure helpers:
+  - `validateCalendarImportUrl(url)`
+  - `mergeCalendarImportEvents(...)`
+- `edit-schedule.html` imports and uses those helpers, leaving rendering and persistence behavior unchanged.
+
+Why this shape:
+- Pure helpers are directly testable in Vitest without adding a browser harness.
+- The helper boundary is narrow and preserves existing data flow and UI behavior.
+
+Controls / rollback:
+- No storage, auth, or Firestore contract changes.
+- Rollback is isolated to removing the helper import and restoring the prior inline logic in `edit-schedule.html`.

--- a/docs/pr-notes/runs/issue-354-fixer-20260320T022502Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-354-fixer-20260320T022502Z/code-plan.md
@@ -1,0 +1,9 @@
+Thinking level: medium
+Reason: narrow implementation scope, but the issue references stale test infrastructure and needs a testable seam with minimal product risk.
+
+Plan:
+1. Add a pure helper module for calendar import URL validation and duplicate-safe merge behavior.
+2. Update `edit-schedule.html` to consume the helper in the add-calendar save handler and `loadSchedule()`.
+3. Add focused Vitest coverage for helper behavior and page wiring.
+4. Run targeted unit tests.
+5. Commit the helper, page wiring, tests, and role notes together with an issue-referencing message.

--- a/docs/pr-notes/runs/issue-354-fixer-20260320T022502Z/qa.md
+++ b/docs/pr-notes/runs/issue-354-fixer-20260320T022502Z/qa.md
@@ -1,0 +1,18 @@
+Regression target:
+- Coach/admin schedule import path on `edit-schedule.html`.
+
+Tests to add:
+1. Validate `.ics` URL acceptance and rejection through the shared helper used by the add-calendar save path.
+2. Verify imported calendar events merge into schedule candidates with correct `game` vs `practice` typing.
+3. Verify duplicate suppression skips:
+   - already tracked calendar occurrences
+   - imported events whose timestamp conflicts with an existing DB event
+4. Verify `edit-schedule.html` uses the helper and still exposes `Track` for games and `Plan Practice` for practices.
+
+Residual risk:
+- This remains unit-level coverage, so DOM wiring is protected by source assertions rather than a full browser run.
+- Real fetch/parsing integration still depends on `fetchAndParseCalendar()` coverage elsewhere.
+
+Validation plan:
+- Run the new calendar-import unit test file.
+- Run the existing ICS tracking and related edit-schedule unit tests to catch adjacent regressions.

--- a/docs/pr-notes/runs/issue-354-fixer-20260320T022502Z/requirements.md
+++ b/docs/pr-notes/runs/issue-354-fixer-20260320T022502Z/requirements.md
@@ -1,0 +1,21 @@
+Objective: cover the coach-facing calendar import path in `edit-schedule.html`, including calendar-link validation, imported event merge behavior, and duplicate suppression against tracked ICS events and existing DB events.
+
+Current state:
+- `edit-schedule.html` contains the add-calendar form behavior and the schedule merge logic inline.
+- Existing automated coverage exercises `window.trackCalendarEvent(...)` after import, not the import path itself.
+
+Proposed state:
+- Shared helper(s) own the `.ics` URL validation and imported calendar merge rules.
+- Unit tests assert the helper behavior and the page wiring so regressions fail in CI.
+
+Risk surface and blast radius:
+- Affects schedule import on `edit-schedule.html` only.
+- Blast radius stays limited if the patch is confined to helper extraction plus page wiring.
+
+Assumptions:
+- Repo-standard automated coverage is Vitest unit tests, not Playwright, in this worktree.
+- Preserving existing UI copy and rendering branches is preferable to broader refactoring.
+
+Recommendation:
+- Extract the import logic to a small pure module and test the business rules directly.
+- Add source-wiring assertions in `edit-schedule.html` for the add-calendar save path and the import merge path.

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -711,6 +711,7 @@
     <script type="module">
         import { getTeam, getTeams, getGames, getEvents, addGame, updateGame, updateTeam, deleteGame, addPractice, updateEvent, deleteEvent, getConfigs, addCalendarToTeam, removeCalendarFromTeam, getTrackedCalendarEventUids, cancelOccurrence, updateOccurrence, restoreOccurrence, clearOccurrenceOverride, updateSeries, deleteSeries, getUnreadChatCount, getPracticeSessions, cancelGame, getLatestGameAssignments, postChatMessage, getRsvpBreakdownByPlayer } from './js/db.js?v=20';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, formatTimeRange, getDefaultEndTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, getCalendarEventStatus, getCalendarEventTrackingId, isTrackedCalendarEvent, generateSeriesId, expandRecurrence, formatRecurrence, shareOrCopy, escapeHtml } from './js/utils.js?v=10';
+        import { mergeCalendarImportEvents, validateCalendarImportUrl } from './js/edit-schedule-calendar-import.js?v=1';
         import { checkAuth } from './js/auth.js?v=10';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { getTeamAccessInfo } from './js/team-access.js';
@@ -1140,37 +1141,16 @@
                     try {
                         const calendarEvents = await fetchAndParseCalendar(calendarUrl);
 
-                        calendarEvents.forEach(event => {
-                            // Skip if already tracked
-                            if (isTrackedCalendarEvent(event, trackedUids)) return;
-
-                            // Normalize common ICS and TeamSnap cancelled variants via shared helper
-                            const isCancelled = getCalendarEventStatus(event) === 'cancelled';
-
-                            // Skip if conflicts with DB event
-                            const hasConflict = dbEvents.some(dbEvent => {
-                                const dbDate = dbEvent.date?.toDate ? dbEvent.date.toDate() : new Date(dbEvent.date);
-                                const eventDate = event.dtstart;
-                                return Math.abs(dbDate - eventDate) < 60000;
-                            });
-                            if (hasConflict) return;
-
-                            const isPractice = isPracticeEvent(event.summary);
-                            // Clean cancelled prefix from summary before extracting opponent
-                            const cleanSummary = event.summary?.replace(/\[(?:CANCELED|CANCELLED)\]\s*/gi, '') || '';
-                            const opponent = extractOpponent(cleanSummary, currentTeam.name);
-
-                            allEvents.push({
-                                source: 'calendar',
-                                eventType: isPractice ? 'practice' : 'game',
-                                date: event.dtstart,
-                                opponent: opponent,
-                                location: event.location || 'TBD',
-                                isPractice: isPractice,
-                                isCancelled: isCancelled,
-                                calendarEvent: event
-                            });
-                        });
+                        allEvents.push(...mergeCalendarImportEvents({
+                            calendarEvents,
+                            dbEvents,
+                            trackedUids,
+                            currentTeamName: currentTeam.name,
+                            isTrackedCalendarEvent,
+                            getCalendarEventStatus,
+                            isPracticeEvent,
+                            extractOpponent
+                        }));
                     } catch (error) {
                         console.error('Error fetching calendar:', calendarUrl, error);
                     }
@@ -2320,19 +2300,14 @@
         });
 
         document.getElementById('save-calendar-btn').addEventListener('click', async () => {
-            const url = document.getElementById('calendar-url-input').value.trim();
-            if (!url) {
-                alert('Please enter a calendar URL');
-                return;
-            }
-
-            if (!url.includes('.ics')) {
-                alert('Please enter a valid .ics calendar URL (must include .ics)');
+            const validation = validateCalendarImportUrl(document.getElementById('calendar-url-input').value);
+            if (!validation.isValid) {
+                alert(validation.message);
                 return;
             }
 
             try {
-                await addCalendarToTeam(currentTeamId, url);
+                await addCalendarToTeam(currentTeamId, validation.normalizedUrl);
                 document.getElementById('add-calendar-form').classList.add('hidden');
                 document.getElementById('calendar-url-input').value = '';
 

--- a/js/edit-schedule-calendar-import.js
+++ b/js/edit-schedule-calendar-import.js
@@ -1,0 +1,69 @@
+export function validateCalendarImportUrl(url) {
+    const trimmedUrl = String(url || '').trim();
+    if (!trimmedUrl) {
+        return {
+            isValid: false,
+            message: 'Please enter a calendar URL'
+        };
+    }
+
+    if (!trimmedUrl.includes('.ics')) {
+        return {
+            isValid: false,
+            message: 'Please enter a valid .ics calendar URL (must include .ics)'
+        };
+    }
+
+    return {
+        isValid: true,
+        normalizedUrl: trimmedUrl
+    };
+}
+
+function toDate(value) {
+    if (value instanceof Date) return value;
+    if (typeof value?.toDate === 'function') return value.toDate();
+    return new Date(value);
+}
+
+export function mergeCalendarImportEvents({
+    calendarEvents,
+    dbEvents,
+    trackedUids,
+    currentTeamName,
+    isTrackedCalendarEvent,
+    getCalendarEventStatus,
+    isPracticeEvent,
+    extractOpponent
+}) {
+    const importedEvents = [];
+
+    (calendarEvents || []).forEach((event) => {
+        if (isTrackedCalendarEvent(event, trackedUids)) return;
+
+        const eventDate = event?.dtstart instanceof Date ? event.dtstart : new Date(event?.dtstart);
+        if (Number.isNaN(eventDate.getTime())) return;
+
+        const hasConflict = (dbEvents || []).some((dbEvent) => {
+            const dbDate = toDate(dbEvent?.date);
+            return !Number.isNaN(dbDate.getTime()) && Math.abs(dbDate - eventDate) < 60000;
+        });
+        if (hasConflict) return;
+
+        const isPractice = isPracticeEvent(event.summary);
+        const cleanSummary = event.summary?.replace(/\[(?:CANCELED|CANCELLED)\]\s*/gi, '') || '';
+
+        importedEvents.push({
+            source: 'calendar',
+            eventType: isPractice ? 'practice' : 'game',
+            date: eventDate,
+            opponent: extractOpponent(cleanSummary, currentTeamName),
+            location: event.location || 'TBD',
+            isPractice,
+            isCancelled: getCalendarEventStatus(event) === 'cancelled',
+            calendarEvent: event
+        });
+    });
+
+    return importedEvents;
+}

--- a/tests/unit/edit-schedule-calendar-cancellation.test.js
+++ b/tests/unit/edit-schedule-calendar-cancellation.test.js
@@ -5,19 +5,25 @@ function readEditSchedule() {
     return readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
 }
 
+function readCalendarImportHelper() {
+    return readFileSync(new URL('../../js/edit-schedule-calendar-import.js', import.meta.url), 'utf8');
+}
+
 describe('edit schedule calendar cancellation handling', () => {
-    it('uses the shared calendar cancellation helper instead of inline brittle checks', () => {
+    it('uses shared calendar cancellation handling instead of inline brittle checks', () => {
         const source = readEditSchedule();
+        const helperSource = readCalendarImportHelper();
 
         expect(source).toContain('getCalendarEventStatus');
-        expect(source).toContain("const isCancelled = getCalendarEventStatus(event) === 'cancelled';");
+        expect(source).toContain('mergeCalendarImportEvents');
+        expect(helperSource).toContain("isCancelled: getCalendarEventStatus(event) === 'cancelled'");
         expect(source).not.toContain("event.status?.toUpperCase() === 'CANCELLED'");
         expect(source).not.toContain("event.summary?.includes('[CANCELED]')");
     });
 
     it('strips both cancelled summary prefixes before opponent extraction', () => {
-        const source = readEditSchedule();
+        const helperSource = readCalendarImportHelper();
 
-        expect(source).toContain("replace(/\\[(?:CANCELED|CANCELLED)\\]\\s*/gi, '')");
+        expect(helperSource).toContain("replace(/\\[(?:CANCELED|CANCELLED)\\]\\s*/gi, '')");
     });
 });

--- a/tests/unit/edit-schedule-calendar-import.test.js
+++ b/tests/unit/edit-schedule-calendar-import.test.js
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import {
+    mergeCalendarImportEvents,
+    validateCalendarImportUrl
+} from '../../js/edit-schedule-calendar-import.js';
+
+function readEditSchedule() {
+    return readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
+}
+
+describe('edit schedule calendar import helpers', () => {
+    it('accepts valid .ics urls and rejects missing or non-ics values', () => {
+        expect(validateCalendarImportUrl('')).toEqual({
+            isValid: false,
+            message: 'Please enter a calendar URL'
+        });
+
+        expect(validateCalendarImportUrl('https://example.com/calendar')).toEqual({
+            isValid: false,
+            message: 'Please enter a valid .ics calendar URL (must include .ics)'
+        });
+
+        expect(validateCalendarImportUrl('  https://example.com/team.ics?token=abc  ')).toEqual({
+            isValid: true,
+            normalizedUrl: 'https://example.com/team.ics?token=abc'
+        });
+    });
+
+    it('merges imported game and practice events while suppressing tracked and conflicting duplicates', () => {
+        const trackedEvent = {
+            uid: 'tracked-uid',
+            dtstart: new Date('2026-03-25T18:00:00.000Z'),
+            summary: 'Wildcats vs Tigers',
+            location: 'Field 1'
+        };
+        const conflictingEvent = {
+            uid: 'conflict-uid',
+            dtstart: new Date('2026-03-26T18:00:00.000Z'),
+            summary: 'Wildcats vs Bears',
+            location: 'Field 2'
+        };
+        const importedGame = {
+            uid: 'new-game-uid',
+            dtstart: new Date('2026-03-27T18:00:00.000Z'),
+            summary: 'Wildcats vs Falcons',
+            location: 'Field 3'
+        };
+        const importedPractice = {
+            uid: 'new-practice-uid',
+            dtstart: new Date('2026-03-28T17:30:00.000Z'),
+            summary: 'Team Practice',
+            location: 'Gym'
+        };
+
+        const merged = mergeCalendarImportEvents({
+            calendarEvents: [trackedEvent, conflictingEvent, importedGame, importedPractice],
+            dbEvents: [
+                {
+                    id: 'db-game-1',
+                    date: { toDate: () => new Date('2026-03-26T18:00:00.000Z') }
+                }
+            ],
+            trackedUids: ['tracked-uid'],
+            currentTeamName: 'Wildcats',
+            isTrackedCalendarEvent: (event, trackedIds) => trackedIds.includes(event.uid),
+            getCalendarEventStatus: () => 'confirmed',
+            isPracticeEvent: (summary) => /practice/i.test(summary),
+            extractOpponent: (summary, teamName) => summary.replace(`${teamName} vs `, '')
+        });
+
+        expect(merged).toHaveLength(2);
+        expect(merged).toEqual([
+            expect.objectContaining({
+                source: 'calendar',
+                eventType: 'game',
+                isPractice: false,
+                opponent: 'Falcons',
+                location: 'Field 3',
+                calendarEvent: importedGame
+            }),
+            expect.objectContaining({
+                source: 'calendar',
+                eventType: 'practice',
+                isPractice: true,
+                opponent: 'Team Practice',
+                location: 'Gym',
+                calendarEvent: importedPractice
+            })
+        ]);
+    });
+});
+
+describe('edit schedule calendar import wiring', () => {
+    it('routes add-calendar validation and schedule merge through the shared helper', () => {
+        const source = readEditSchedule();
+
+        expect(source).toContain("import { mergeCalendarImportEvents, validateCalendarImportUrl } from './js/edit-schedule-calendar-import.js?v=1';");
+        expect(source).toContain("const validation = validateCalendarImportUrl(document.getElementById('calendar-url-input').value);");
+        expect(source).toContain('allEvents.push(...mergeCalendarImportEvents({');
+    });
+
+    it('keeps calendar game and practice actions visible in the schedule renderer', () => {
+        const source = readEditSchedule();
+
+        expect(source).toContain('Plan Practice');
+        expect(source).toContain('window.trackCalendarEvent');
+    });
+});


### PR DESCRIPTION
Closes #354

## What changed
- extracted calendar import URL validation and duplicate-safe merge logic into `js/edit-schedule-calendar-import.js`
- updated `edit-schedule.html` to use the shared helper for add-calendar validation and imported schedule event merging
- added targeted Vitest coverage for valid `.ics` URL handling, imported game/practice merge behavior, tracked UID suppression, DB timestamp conflict suppression, and page wiring
- updated the existing calendar cancellation regression test to follow the new shared helper seam

## Why
The schedule workflow had coverage for post-import tracking but not for the actual coach-facing calendar import path. This patch adds automated regression coverage around the rules most likely to fail silently: accepting only `.ics` links, merging imported events into the schedule list, and suppressing duplicates that are already tracked or already present in Firestore.

## Validation
- `./node_modules/.bin/vitest run tests/unit/edit-schedule-calendar-import.test.js`
- `./node_modules/.bin/vitest run tests/unit/ics-tracking-ids.test.js tests/unit/edit-schedule-calendar-cancellation.test.js tests/unit/edit-schedule-stat-config-selection.test.js`