### PR TITLE
Add Game Day wrap-up regression coverage

### DIFF
--- a/docs/pr-notes/runs/issue-374-fixer-20260320T202502Z/architecture.md
+++ b/docs/pr-notes/runs/issue-374-fixer-20260320T202502Z/architecture.md
@@ -1,0 +1,17 @@
+Current state:
+- `game-day.html` owns status-transition prompting, wrap-up field hydration, completion payload construction, and redirect URL assembly inline.
+
+Proposed state:
+- Move the wrap-up-specific decision and payload construction into `js/game-day-wrapup.js`.
+- Keep DOM reads/writes in `game-day.html`; only extract deterministic behavior.
+
+Control and blast-radius comparison:
+- Current state has no CI-visible contract for this path, so regressions land silently.
+- New state adds an explicit contract around transition gating, field hydration, completion payload, and redirect while keeping page behavior unchanged.
+
+Tradeoffs:
+- Small extra module/import to maintain.
+- In return, the highest-risk wrap-up path becomes testable without introducing a browser runner migration.
+
+Rollback:
+- Revert the helper import and inline the three small behaviors back into `game-day.html`.

--- a/docs/pr-notes/runs/issue-374-fixer-20260320T202502Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-374-fixer-20260320T202502Z/code-plan.md
@@ -1,0 +1,9 @@
+Thinking level: medium
+Reason: existing behavior is mostly correct; the work is finding the smallest extraction that creates reliable CI coverage without widening scope.
+
+Plan:
+1. Add failing Vitest coverage for wrap-up transition/prefill/persist/redirect behavior.
+2. Implement a minimal `js/game-day-wrapup.js` helper for deterministic wrap-up logic.
+3. Rewire `game-day.html` to call the helper for completed transition, wrap-up render values, and finish payload/redirect.
+4. Run the focused Vitest suite.
+5. Stage changed files and commit with an issue-referencing message.

--- a/docs/pr-notes/runs/issue-374-fixer-20260320T202502Z/qa.md
+++ b/docs/pr-notes/runs/issue-374-fixer-20260320T202502Z/qa.md
@@ -1,0 +1,14 @@
+Coverage target:
+- Real-time status change from scheduled/live into `liveStatus: 'completed'`.
+- Wrap-Up form prefill from current game state.
+- Final submit payload and redirect target.
+
+Validation plan:
+1. Add a focused Vitest file for the new wrap-up helper module.
+2. Include page-wiring assertions against `game-day.html` so the page is forced to use the tested helpers.
+3. Run the targeted Vitest file.
+
+Guardrails:
+- Assert completed transition only prompts when not already in wrap-up.
+- Assert wrap-up field values come from current score state and saved post-game notes.
+- Assert submit payload includes `status: 'completed'` and `liveStatus: 'completed'` before redirecting to `game.html#teamId=...&gameId=...`.

--- a/docs/pr-notes/runs/issue-374-fixer-20260320T202502Z/requirements.md
+++ b/docs/pr-notes/runs/issue-374-fixer-20260320T202502Z/requirements.md
@@ -1,0 +1,24 @@
+Objective: add automated coverage for the highest-risk Game Day end-of-game path without broad page refactors.
+
+Current state:
+- `game-day.html` handles the live-to-completed transition and wrap-up submit inline.
+- Existing `test-game-day.html` only covers replicated helper logic and misses page workflow behavior.
+
+Proposed state:
+- Extract the wrap-up transition and completion payload/redirect rules into a small helper module.
+- Add Vitest coverage for those rules plus page wiring assertions so CI guards the real flow.
+
+Risk surface and blast radius:
+- Scope is limited to the Game Day wrap-up path.
+- Main risk is changing completion behavior or redirect format; tests should lock both down.
+
+Assumptions:
+- Vitest is the repo's supported automated test path for CI.
+- A small extraction is acceptable as the minimal code change that enables durable coverage.
+
+Recommendation:
+- Prefer a narrow helper extraction over a larger browser harness because it gives reliable automated coverage with lower maintenance cost and no new framework setup.
+
+Success criteria:
+- A focused automated test proves the completed-status transition opens Wrap-Up with current score state.
+- A focused automated test proves finish flow persists final score/notes/completed flags and redirects to the match report.

--- a/game-day.html
+++ b/game-day.html
@@ -499,6 +499,12 @@
             buildLineupPublishMessage,
             countLineupChanges
         } from './js/game-day-lineup-publish.js?v=1';
+        import {
+            shouldPromptWrapupOnCompletion,
+            getWrapupFormState,
+            buildFinishGamePayload,
+            buildMatchReportUrl
+        } from './js/game-day-wrapup.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -1063,7 +1069,11 @@
                     // Detect transitions
                     if (updatedGame.liveStatus === 'live' && prevLiveStatus !== 'live' && state.mode !== 'gameday') {
                         if (confirm('The game is now live! Switch to Game Day mode?')) setMode('gameday');
-                    } else if (updatedGame.liveStatus === 'completed' && prevLiveStatus !== 'completed' && state.mode !== 'wrapup') {
+                    } else if (shouldPromptWrapupOnCompletion({
+                        prevLiveStatus,
+                        nextLiveStatus: updatedGame.liveStatus,
+                        mode: state.mode
+                    })) {
                         if (confirm('Game marked as completed. Open Wrap-Up?')) setMode('wrapup');
                     }
                 }, (err) => console.error('subscribeGame error', err));
@@ -2418,9 +2428,13 @@ Respond ONLY with valid JSON.`;
 
         // ==================== WRAP-UP ====================
         function renderWrapup() {
-            document.getElementById('wrapup-home-score').value = state.score.home;
-            document.getElementById('wrapup-away-score').value = state.score.away;
-            document.getElementById('post-game-notes').value = state.game?.postGameNotes || '';
+            const wrapupFormState = getWrapupFormState({
+                score: state.score,
+                game: state.game
+            });
+            document.getElementById('wrapup-home-score').value = wrapupFormState.homeScore;
+            document.getElementById('wrapup-away-score').value = wrapupFormState.awayScore;
+            document.getElementById('post-game-notes').value = wrapupFormState.postGameNotes;
         }
 
         window.closeWrapup = function() {
@@ -2490,16 +2504,18 @@ Be encouraging and specific. No markdown.`;
         };
 
         window.finishGame = async function() {
-            const homeScore = parseInt(document.getElementById('wrapup-home-score').value) || 0;
-            const awayScore = parseInt(document.getElementById('wrapup-away-score').value) || 0;
-            const postGameNotes = document.getElementById('post-game-notes').value.trim();
+            const completionPayload = buildFinishGamePayload({
+                homeScoreValue: document.getElementById('wrapup-home-score').value,
+                awayScoreValue: document.getElementById('wrapup-away-score').value,
+                postGameNotesValue: document.getElementById('post-game-notes').value
+            });
 
             try {
-                await updateGame(state.teamId, state.gameId, {
-                    homeScore, awayScore, postGameNotes,
-                    status: 'completed', liveStatus: 'completed'
+                await updateGame(state.teamId, state.gameId, completionPayload);
+                window.location.href = buildMatchReportUrl({
+                    teamId: state.teamId,
+                    gameId: state.gameId
                 });
-                window.location.href = `game.html#teamId=${state.teamId}&gameId=${state.gameId}`;
             } catch (err) {
                 console.error('finishGame error', err);
                 alert('Error saving: ' + err.message);

--- a/js/game-day-wrapup.js
+++ b/js/game-day-wrapup.js
@@ -1,0 +1,27 @@
+export function shouldPromptWrapupOnCompletion({ prevLiveStatus, nextLiveStatus, mode }) {
+    return nextLiveStatus === 'completed'
+        && prevLiveStatus !== 'completed'
+        && mode !== 'wrapup';
+}
+
+export function getWrapupFormState({ score, game }) {
+    return {
+        homeScore: score?.home || 0,
+        awayScore: score?.away || 0,
+        postGameNotes: game?.postGameNotes || ''
+    };
+}
+
+export function buildFinishGamePayload({ homeScoreValue, awayScoreValue, postGameNotesValue }) {
+    return {
+        homeScore: parseInt(homeScoreValue, 10) || 0,
+        awayScore: parseInt(awayScoreValue, 10) || 0,
+        postGameNotes: (postGameNotesValue || '').trim(),
+        status: 'completed',
+        liveStatus: 'completed'
+    };
+}
+
+export function buildMatchReportUrl({ teamId, gameId }) {
+    return `game.html#teamId=${encodeURIComponent(teamId)}&gameId=${encodeURIComponent(gameId)}`;
+}

--- a/tests/unit/game-day-wrapup.test.js
+++ b/tests/unit/game-day-wrapup.test.js
@@ -1,0 +1,77 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import {
+  shouldPromptWrapupOnCompletion,
+  getWrapupFormState,
+  buildFinishGamePayload,
+  buildMatchReportUrl
+} from '../../js/game-day-wrapup.js';
+
+describe('game day wrap-up helpers', () => {
+  it('opens wrap-up when a real-time update marks the game completed outside wrap-up mode', () => {
+    expect(shouldPromptWrapupOnCompletion({
+      prevLiveStatus: 'live',
+      nextLiveStatus: 'completed',
+      mode: 'gameday'
+    })).toBe(true);
+  });
+
+  it('does not prompt when the game was already completed or wrap-up is already open', () => {
+    expect(shouldPromptWrapupOnCompletion({
+      prevLiveStatus: 'completed',
+      nextLiveStatus: 'completed',
+      mode: 'gameday'
+    })).toBe(false);
+
+    expect(shouldPromptWrapupOnCompletion({
+      prevLiveStatus: 'live',
+      nextLiveStatus: 'completed',
+      mode: 'wrapup'
+    })).toBe(false);
+  });
+
+  it('prefills wrap-up fields from current score state and saved notes', () => {
+    expect(getWrapupFormState({
+      score: { home: 4, away: 2 },
+      game: { postGameNotes: 'Closed out strong.' }
+    })).toEqual({
+      homeScore: 4,
+      awayScore: 2,
+      postGameNotes: 'Closed out strong.'
+    });
+  });
+
+  it('builds the completion payload with trimmed notes and completed statuses', () => {
+    expect(buildFinishGamePayload({
+      homeScoreValue: '5',
+      awayScoreValue: '3',
+      postGameNotesValue: '  Great defensive shape.  '
+    })).toEqual({
+      homeScore: 5,
+      awayScore: 3,
+      postGameNotes: 'Great defensive shape.',
+      status: 'completed',
+      liveStatus: 'completed'
+    });
+  });
+
+  it('builds the match report redirect URL from the team and game ids', () => {
+    expect(buildMatchReportUrl({
+      teamId: 'team-42',
+      gameId: 'game-7'
+    })).toBe('game.html#teamId=team-42&gameId=game-7');
+  });
+});
+
+describe('game-day wrap-up page wiring', () => {
+  it('routes the completion transition, wrap-up prefill, and finish flow through the helper module', () => {
+    const source = readFileSync(resolve(process.cwd(), 'game-day.html'), 'utf8');
+
+    expect(source).toContain("from './js/game-day-wrapup.js?v=1'");
+    expect(source).toContain('shouldPromptWrapupOnCompletion({');
+    expect(source).toContain('const wrapupFormState = getWrapupFormState({');
+    expect(source).toContain('const completionPayload = buildFinishGamePayload({');
+    expect(source).toContain('window.location.href = buildMatchReportUrl({');
+  });
+});


### PR DESCRIPTION
Closes #374

## What changed
- added focused Vitest coverage for the Game Day wrap-up flow, including completed-status transition gating, wrap-up field prefills, final completion payload, and redirect target
- extracted the wrap-up transition/payload/redirect rules into a small `js/game-day-wrapup.js` helper so the real page behavior is testable in CI
- wired `game-day.html` to use the helper for completed-game prompting, wrap-up form hydration, and `finishGame()` persistence/redirect behavior
- persisted per-run requirements, architecture, QA, and code-plan notes under `docs/pr-notes/runs/issue-374-fixer-20260320T202502Z/`

## Why
The end-of-game path in Game Day had no automated coverage even though it combines a live status transition, wrap-up UI state, Firestore writes, and navigation. This change adds a durable regression guard around that highest-risk flow with a minimal page refactor.

## Validation
- `node ./node_modules/vitest/vitest.mjs run tests/unit/game-day-wrapup.test.js`