### PR TITLE
Add homepage rail and replay fallback coverage

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -69,6 +69,7 @@ jobs:
           open_channels="$(gh pr list --state open --limit 200 --json number --jq '.[].number' | sed 's/^/pr-/')"
           channels_file="$RUNNER_TEMP/firebase-preview-channels.txt"
           prune_file="$RUNNER_TEMP/firebase-preview-prune.txt"
+          delete_log="$RUNNER_TEMP/firebase-preview-delete.log"
           npx firebase-tools@14.25.0 hosting:channel:list --site game-flow-c6311 --project game-flow-c6311 > "$channels_file"
           awk -F '│' 'NF > 2 {gsub(/^[[:space:]]+|[[:space:]]+$/, "", $2); if ($2 ~ /^pr-/) print $2 }' "$channels_file" | sort -u > "$prune_file"
           while read -r channel; do
@@ -78,7 +79,13 @@ jobs:
             if printf '%s\n' "$open_channels" | grep -qx "$channel"; then
               continue
             fi
-            npx firebase-tools@14.25.0 hosting:channel:delete "$channel" --site game-flow-c6311 --project game-flow-c6311 --force
+            if ! npx firebase-tools@14.25.0 hosting:channel:delete "$channel" --site game-flow-c6311 --project game-flow-c6311 --force > "$delete_log" 2>&1; then
+              if grep -Eq 'HTTP Error: 404|Not Found' "$delete_log"; then
+                continue
+              fi
+              cat "$delete_log" >&2
+              exit 1
+            fi
           done < "$prune_file"
 
       - name: Deploy Firebase Hosting preview

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -105,7 +105,7 @@ jobs:
           body="$marker
 
           Preview URL: $PREVIEW_URL"
-          comment_id="$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq '.[] | select(.user.login == \"github-actions[bot]\") | select(.body | contains(\"<!-- allplays-preview-url -->\")) | .id' | head -n1)"
+          comment_id="$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("<!-- allplays-preview-url -->")) | .id' | head -n1)"
           if [ -n "$comment_id" ]; then
             gh api repos/${{ github.repository }}/issues/comments/"$comment_id" --method PATCH -f body="$body" >/dev/null
           else

--- a/docs/pr-notes/runs/417-ci-fix-20260328T043833Z/architecture.md
+++ b/docs/pr-notes/runs/417-ci-fix-20260328T043833Z/architecture.md
@@ -1,0 +1,8 @@
+# Architecture
+
+- Objective: restore deploy-preview PR comment reporting.
+- Current state: workflow passes an over-escaped jq filter to `gh api --jq`, causing parse failure before comment create/update.
+- Proposed state: workflow uses a valid jq expression with normal shell single-quote protection.
+- Risk surface: limited to PR preview comment update step in deploy-preview workflow.
+- Blast radius: low; no application code or deployment behavior changes.
+- Assumptions: GitHub CLI jq support behaves as in the failing log; existing auth/token scopes are valid.

--- a/docs/pr-notes/runs/417-ci-fix-20260328T043833Z/code-plan.md
+++ b/docs/pr-notes/runs/417-ci-fix-20260328T043833Z/code-plan.md
@@ -1,0 +1,5 @@
+# Code Plan
+
+1. Edit `.github/workflows/deploy-preview.yml` to remove unnecessary backslash escaping inside the single-quoted `--jq` argument.
+2. Verify the updated line and diff scope.
+3. Stage workflow and note files, commit with required message.

--- a/docs/pr-notes/runs/417-ci-fix-20260328T043833Z/qa.md
+++ b/docs/pr-notes/runs/417-ci-fix-20260328T043833Z/qa.md
@@ -1,0 +1,5 @@
+# QA
+
+- Root cause evidence: CI log shows `unexpected token "\\"` at escaped quotes inside the jq expression.
+- Validation plan: inspect workflow, run a local syntax-level reproduction against jq-compatible filter quoting, then confirm git diff is scoped.
+- Residual risk: no full GitHub Actions run locally, so final confirmation depends on CI rerun.

--- a/docs/pr-notes/runs/417-ci-fix-20260328T183612Z/architecture.md
+++ b/docs/pr-notes/runs/417-ci-fix-20260328T183612Z/architecture.md
@@ -1,0 +1,13 @@
+Objective: keep `deploy-preview` from failing when Firebase preview channels disappear between list and delete.
+
+Current state: the prune loop treats every `hosting:channel:delete` failure as fatal.
+Proposed state: ignore only the expected `404 Not Found` delete race and preserve hard failure for other errors.
+
+Risk surface: limited to `.github/workflows/deploy-preview.yml`.
+Blast radius: only PR preview channel pruning before deploy.
+
+Assumptions:
+- The failing `404` is caused by stale channel state or concurrent deletion outside this job.
+- A missing stale preview channel is safe to treat as already-pruned.
+
+Recommendation: wrap channel deletion, capture stderr/stdout, and continue only when Firebase reports channel not found.

--- a/docs/pr-notes/runs/417-ci-fix-20260328T183612Z/code-plan.md
+++ b/docs/pr-notes/runs/417-ci-fix-20260328T183612Z/code-plan.md
@@ -1,0 +1,7 @@
+Skills note: `allplays-orchestrator-playbook`, `allplays-architecture-expert`, `allplays-qa-expert`, and `allplays-code-expert` were not available in this session, so analysis was done inline.
+
+Plan:
+1. Edit `.github/workflows/deploy-preview.yml` in the prune loop only.
+2. Capture delete output to a temp file and inspect failures.
+3. Continue when the failure is the known missing-channel `404`; otherwise print the captured error and exit 1.
+4. Run focused validation on the workflow file and commit the scoped fix.

--- a/docs/pr-notes/runs/417-ci-fix-20260328T183612Z/qa.md
+++ b/docs/pr-notes/runs/417-ci-fix-20260328T183612Z/qa.md
@@ -1,0 +1,12 @@
+Objective: validate the workflow change without broadening behavior.
+
+Checks:
+- Confirm the failing step matches the logged `404` on `hosting:channel:delete`.
+- Ensure the new logic continues on `404`/`Not Found`.
+- Ensure non-404 delete failures still exit non-zero.
+
+Manual validation:
+- Review the workflow shell block for `set -euo pipefail` compatibility.
+- Run YAML parse check with `python3 -c 'import yaml'` fallback unavailable, so use `git diff --check` and direct file inspection.
+
+Residual risk: Firebase CLI error wording could change; matching `HTTP Error: 404` and `Not Found` reduces that risk.

--- a/docs/pr-notes/runs/417-remediator-20260328T043041Z/architecture.md
+++ b/docs/pr-notes/runs/417-remediator-20260328T043041Z/architecture.md
@@ -1,0 +1,12 @@
+Decision: Keep the existing string-template rendering path, but add local escaping helpers and safe URL builders inside `js/homepage.js`.
+
+Why:
+- This is the smallest change that closes the XSS gap without refactoring the homepage to imperative DOM construction.
+- Escaping text/attribute content and encoding query params directly addresses the reported attack surface with low blast radius.
+
+Blast radius:
+- Limited to homepage live-game and replay card markup generation.
+- No backend, schema, or cross-page behavior changes.
+
+Rollback:
+- Revert the helper additions and card-template substitutions in `js/homepage.js`.

--- a/docs/pr-notes/runs/417-remediator-20260328T043041Z/code-plan.md
+++ b/docs/pr-notes/runs/417-remediator-20260328T043041Z/code-plan.md
@@ -1,0 +1,7 @@
+Implementation plan:
+1. Add small local helpers in `js/homepage.js` for HTML escaping, query param encoding, and safe card field normalization.
+2. Update both live-game and replay markup generation to use escaped text/attribute values and encoded `href` query params.
+3. Extend `tests/unit/homepage-index.test.js` with a malicious-input case that proves the XSS vectors are neutralized.
+
+Note:
+- The requested orchestrator/subagent skills and `sessions_spawn` tool are not available in this session, so these notes capture the fallback inline role analysis.

--- a/docs/pr-notes/runs/417-remediator-20260328T043041Z/qa.md
+++ b/docs/pr-notes/runs/417-remediator-20260328T043041Z/qa.md
@@ -1,0 +1,13 @@
+Risk focus:
+- Malicious team or opponent names must render as inert text, not executable HTML.
+- Malicious `teamId` or `game.id` values must not break out of the generated `href`.
+- Existing live/upcoming/replay homepage rendering should still work for normal inputs.
+
+Validation plan:
+1. Run the homepage unit test file.
+2. Assert normal live and replay links still render.
+3. Add hostile input coverage for names, image URLs, and IDs, then verify the rendered HTML contains escaped content and encoded query parameters.
+
+Residual risk:
+- The homepage still uses `innerHTML`, so future interpolations in this module must use the same helpers consistently.
+- No browser-level manual test is included in this remediation run.

--- a/docs/pr-notes/runs/417-remediator-20260328T043041Z/requirements.md
+++ b/docs/pr-notes/runs/417-remediator-20260328T043041Z/requirements.md
@@ -1,0 +1,13 @@
+Objective: Resolve PR #417 homepage review feedback about XSS in live-game and replay card rendering.
+
+Current state:
+- `js/homepage.js` builds card markup with `innerHTML` and interpolates Firestore-derived values directly into text nodes and HTML attributes.
+- Untrusted team names, opponent names, IDs, and image URLs can break markup or inject script-bearing HTML.
+
+Required behavior:
+- All user-controlled values rendered in homepage live/replay cards must be escaped before HTML insertion.
+- Link query parameter values must be encoded so untrusted IDs cannot break the `href`.
+
+Assumptions:
+- The requested scope is limited to the homepage card rendering paths called out in the two review threads.
+- Existing card layout and empty/error states should remain unchanged.

--- a/docs/pr-notes/runs/issue-346-fixer-20260328T042502Z/architecture.md
+++ b/docs/pr-notes/runs/issue-346-fixer-20260328T042502Z/architecture.md
@@ -1,0 +1,20 @@
+Objective: isolate homepage discovery behavior behind a thin module boundary without changing product behavior.
+
+Current state:
+- `index.html` inline module imports auth, utils, and db functions directly, then mutates DOM.
+
+Proposed state:
+- `js/homepage.js` exports `initHomepage` plus focused helpers for CTA, live rail, and replay rail rendering.
+- `index.html` becomes a thin bootstrap that imports dependencies and calls `initHomepage`.
+
+Blast radius comparison:
+- Current: logic is trapped in inline HTML and difficult to validate, so regressions escape silently.
+- New: same runtime dependencies and DOM targets, but behavior is covered by unit tests with no backend or routing changes.
+
+Control equivalence:
+- Auth still drives CTA through `checkAuth`.
+- Firestore query functions are unchanged.
+- Rendered hrefs, fallback messages, and dedupe semantics remain identical.
+
+Rollback plan:
+- Revert `js/homepage.js`, restore the previous inline module in `index.html`, remove the new tests.

--- a/docs/pr-notes/runs/issue-346-fixer-20260328T042502Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-346-fixer-20260328T042502Z/code-plan.md
@@ -1,0 +1,8 @@
+Thinking level: medium
+Reason: HTML-inline workflow extraction plus custom DOM harness, but narrow scope and low architectural ambiguity.
+
+Implementation plan:
+1. Add `js/homepage.js` with dependency-injected helpers mirroring current homepage behavior.
+2. Replace the inline homepage logic in `index.html` with a thin bootstrap call into the new module.
+3. Add `tests/unit/homepage-index.test.js` using a lightweight mock DOM environment.
+4. Run the targeted unit tests, then the full unit suite if time allows, and commit the focused patch.

--- a/docs/pr-notes/runs/issue-346-fixer-20260328T042502Z/qa.md
+++ b/docs/pr-notes/runs/issue-346-fixer-20260328T042502Z/qa.md
@@ -1,0 +1,15 @@
+Test strategy:
+- Unit-test the homepage module with mocked DOM elements and injected auth/db/utils dependencies.
+- Cover both anonymous and authenticated CTA states.
+- Cover live rail merge behavior with a duplicate game returned by both live and upcoming queries.
+- Cover replay card rendering and confirm replay URLs include `replay=true`.
+- Cover partial failure where live query throws and upcoming still renders.
+- Cover empty live/upcoming plus replay failure fallbacks, asserting exact copy replacement instead of lingering loading text.
+
+Regression guardrails:
+- Assert container HTML no longer contains loading placeholders after loaders finish.
+- Assert only one duplicated game card is rendered.
+- Assert error handling remains isolated per rail.
+
+Validation command:
+- `npm test -- tests/unit/homepage-index.test.js`

--- a/docs/pr-notes/runs/issue-346-fixer-20260328T042502Z/requirements.md
+++ b/docs/pr-notes/runs/issue-346-fixer-20260328T042502Z/requirements.md
@@ -1,0 +1,27 @@
+Objective: add automated homepage index coverage for hero CTA state, live/upcoming discovery rails, replay links, and fallback states.
+
+Current state:
+- `index.html` owns auth-aware CTA text plus Firestore-backed live/upcoming/replay rendering in one inline module.
+- Existing homepage coverage does not exercise dynamic replacement of loading placeholders or partial-failure behavior.
+
+Proposed state:
+- Preserve current visitor behavior.
+- Add deterministic automated coverage for the homepage discovery workflow with mocked auth/db/utils dependencies.
+
+Risk surface and blast radius:
+- Homepage is anonymous-user entry traffic, so a regression affects first-touch conversion and replay discovery.
+- Changes should stay local to homepage rendering and test harness only.
+
+Assumptions:
+- Existing CTA labels and fallback copy in `index.html` are the intended product copy.
+- Deduplication by `game.id` is the desired merge rule for live plus upcoming rails.
+
+Recommendation:
+- Extract homepage logic into a small testable module and cover the actual workflow branches through dependency injection.
+- This minimizes blast radius while making the current resilience logic enforceable in CI.
+
+Success criteria:
+- Automated tests prove loading placeholders are replaced.
+- Duplicate live/upcoming entries collapse to one card.
+- Replay links retain `replay=true`.
+- Partial and full query failures render the expected fallback copy.

--- a/index.html
+++ b/index.html
@@ -651,126 +651,21 @@
   </footer>
 
   <script type="module">
-    import { checkAuth, logout } from './js/auth.js?v=10';
+    import { checkAuth } from './js/auth.js?v=10';
     import { renderHeader, formatDate, formatTime } from './js/utils.js?v=8';
     import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=15';
+    import { initHomepage } from './js/homepage.js?v=1';
 
-    const heroCta = document.getElementById('hero-cta');
-
-    checkAuth((user) => {
-      renderHeader(document.getElementById('header-container'), user);
-
-      if (user) {
-        heroCta.textContent = 'Go to Dashboard';
-        heroCta.href = 'dashboard.html';
-      } else {
-        heroCta.textContent = 'Create Your Team';
-        heroCta.href = 'login.html#signup';
-      }
+    initHomepage({
+      document,
+      checkAuth,
+      renderHeader,
+      getLiveGamesNow,
+      getUpcomingLiveGames,
+      getRecentLiveTrackedGames,
+      formatDate,
+      formatTime
     });
-
-    async function loadLiveGames() {
-      const container = document.getElementById('live-games-list');
-      if (!container) return;
-
-      try {
-        // Fetch live and upcoming games separately to handle partial failures
-        let liveGames = [];
-        let upcomingGames = [];
-
-        try {
-          liveGames = await getLiveGamesNow();
-        } catch (e) {
-          console.warn('Could not load live games:', e.message);
-        }
-
-        try {
-          upcomingGames = await getUpcomingLiveGames(6);
-        } catch (e) {
-          console.warn('Could not load upcoming games:', e.message);
-        }
-
-        const combined = [
-          ...liveGames.map(game => ({ ...game, isLive: true })),
-          ...upcomingGames.filter(g => !liveGames.find(lg => lg.id === g.id))
-        ].slice(0, 6);
-
-        if (combined.length === 0) {
-          container.innerHTML = '<div class="text-center py-8 text-gray-500 col-span-full">No upcoming live games scheduled</div>';
-          return;
-        }
-
-        container.innerHTML = combined.map(game => `
-          <a href="live-game.html?teamId=${game.teamId || game.team?.id}&gameId=${game.id}"
-             class="block bg-white rounded-xl shadow hover:shadow-lg transition border border-gray-200 p-5 ${game.isLive ? 'ring-2 ring-red-500' : ''}">
-            ${game.isLive ? `
-              <div class="flex items-center gap-2 mb-2">
-                <span class="w-2 h-2 bg-red-500 rounded-full animate-pulse"></span>
-                <span class="text-red-600 text-xs font-semibold uppercase">Live Now</span>
-                ${game.liveViewerCount ? `<span class="text-gray-400 text-xs">${game.liveViewerCount} watching</span>` : ''}
-              </div>
-            ` : ''}
-            <div class="flex items-center gap-3 mb-2">
-              ${game.team?.photoUrl
-                ? `<img src="${game.team.photoUrl}" class="w-10 h-10 rounded-full object-cover" alt="${game.team?.name || 'Team'}">`
-                : `<div class="w-10 h-10 rounded-full bg-primary-100 flex items-center justify-center text-primary-600 font-bold">${game.team?.name?.[0] || '?'}</div>`
-              }
-              <div>
-                <div class="font-semibold text-gray-900">${game.team?.name || 'Team'}</div>
-                <div class="text-sm text-gray-500">vs ${game.opponent || 'Opponent'}</div>
-              </div>
-            </div>
-            ${game.isLive ? `
-              <div class="text-2xl font-bold text-center py-2">${game.homeScore || 0} - ${game.awayScore || 0}</div>
-            ` : `
-              <div class="text-sm text-gray-500">${formatDate(game.date)} • ${formatTime(game.date)}</div>
-            `}
-            <div class="mt-2 text-center text-primary-600 text-sm font-semibold">${game.isLive ? 'Watch Now →' : 'View Details →'}</div>
-          </a>
-        `).join('');
-      } catch (error) {
-        console.error('Failed to load live games:', error);
-        container.innerHTML = '<div class="text-center py-8 text-gray-500 col-span-full">Unable to load games</div>';
-      }
-    }
-
-    async function loadPastGames() {
-      const container = document.getElementById('past-games-list');
-      if (!container) return;
-
-      try {
-        const pastGames = await getRecentLiveTrackedGames(6);
-        if (pastGames.length === 0) {
-          container.innerHTML = '<div class="text-center py-8 text-gray-500 col-span-full">No recent replays available</div>';
-          return;
-        }
-
-        container.innerHTML = pastGames.map(game => `
-          <a href="live-game.html?teamId=${game.teamId || game.team?.id}&gameId=${game.id}&replay=true"
-             class="block bg-white rounded-xl shadow hover:shadow-lg transition border border-gray-200 p-5">
-            <div class="flex items-center gap-3 mb-3">
-              ${game.team?.photoUrl
-                ? `<img src="${game.team.photoUrl}" class="w-10 h-10 rounded-full object-cover" alt="${game.team?.name || 'Team'}">`
-                : `<div class="w-10 h-10 rounded-full bg-primary-100 flex items-center justify-center text-primary-600 font-bold">${game.team?.name?.[0] || '?'}</div>`
-              }
-              <div>
-                <div class="font-semibold text-gray-900">${game.team?.name || 'Team'}</div>
-                <div class="text-sm text-gray-500">vs ${game.opponent || 'Opponent'}</div>
-              </div>
-            </div>
-            <div class="text-2xl font-bold text-center py-2 text-gray-900">${game.homeScore || 0} - ${game.awayScore || 0}</div>
-            <div class="text-xs text-gray-400 text-center mb-2">${formatDate(game.date)}</div>
-            <div class="text-center text-teal-600 text-sm font-semibold">Watch Replay →</div>
-          </a>
-        `).join('');
-      } catch (error) {
-        console.error('Failed to load past games:', error);
-        container.innerHTML = '<div class="text-center py-8 text-gray-500 col-span-full">Unable to load replays</div>';
-      }
-    }
-
-    loadLiveGames();
-    loadPastGames();
   </script>
 </body>
 

--- a/js/homepage.js
+++ b/js/homepage.js
@@ -2,6 +2,44 @@ function resolveTeamId(game) {
     return game.teamId || game.team?.id || '';
 }
 
+function escapeHtml(value) {
+    if (value === null || value === undefined) {
+        return '';
+    }
+
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
+function buildLiveGameHref(game, replay = false) {
+    const params = new URLSearchParams({
+        teamId: String(resolveTeamId(game) ?? ''),
+        gameId: String(game?.id ?? '')
+    });
+
+    if (replay) {
+        params.set('replay', 'true');
+    }
+
+    return `live-game.html?${params.toString()}`;
+}
+
+function renderTeamAvatar(game) {
+    const teamName = escapeHtml(game.team?.name || 'Team');
+    const teamPhotoUrl = game.team?.photoUrl ? escapeHtml(game.team.photoUrl) : '';
+    const teamInitial = escapeHtml(game.team?.name?.[0] || '?');
+
+    if (teamPhotoUrl) {
+        return `<img src="${teamPhotoUrl}" class="w-10 h-10 rounded-full object-cover" alt="${teamName}">`;
+    }
+
+    return `<div class="w-10 h-10 rounded-full bg-primary-100 flex items-center justify-center text-primary-600 font-bold">${teamInitial}</div>`;
+}
+
 export function applyHeroCta(user, heroCta) {
     if (!heroCta) {
         return;
@@ -56,29 +94,26 @@ export async function loadLiveGames({
         }
 
         container.innerHTML = combined.map((game) => `
-          <a href="live-game.html?teamId=${resolveTeamId(game)}&gameId=${game.id}"
+          <a href="${buildLiveGameHref(game)}"
              class="block bg-white rounded-xl shadow hover:shadow-lg transition border border-gray-200 p-5 ${game.isLive ? 'ring-2 ring-red-500' : ''}">
             ${game.isLive ? `
               <div class="flex items-center gap-2 mb-2">
                 <span class="w-2 h-2 bg-red-500 rounded-full animate-pulse"></span>
                 <span class="text-red-600 text-xs font-semibold uppercase">Live Now</span>
-                ${game.liveViewerCount ? `<span class="text-gray-400 text-xs">${game.liveViewerCount} watching</span>` : ''}
+                ${game.liveViewerCount ? `<span class="text-gray-400 text-xs">${escapeHtml(game.liveViewerCount)} watching</span>` : ''}
               </div>
             ` : ''}
             <div class="flex items-center gap-3 mb-2">
-              ${game.team?.photoUrl
-                ? `<img src="${game.team.photoUrl}" class="w-10 h-10 rounded-full object-cover" alt="${game.team?.name || 'Team'}">`
-                : `<div class="w-10 h-10 rounded-full bg-primary-100 flex items-center justify-center text-primary-600 font-bold">${game.team?.name?.[0] || '?'}</div>`
-              }
+              ${renderTeamAvatar(game)}
               <div>
-                <div class="font-semibold text-gray-900">${game.team?.name || 'Team'}</div>
-                <div class="text-sm text-gray-500">vs ${game.opponent || 'Opponent'}</div>
+                <div class="font-semibold text-gray-900">${escapeHtml(game.team?.name || 'Team')}</div>
+                <div class="text-sm text-gray-500">vs ${escapeHtml(game.opponent || 'Opponent')}</div>
               </div>
             </div>
             ${game.isLive ? `
-              <div class="text-2xl font-bold text-center py-2">${game.homeScore || 0} - ${game.awayScore || 0}</div>
+              <div class="text-2xl font-bold text-center py-2">${escapeHtml(game.homeScore || 0)} - ${escapeHtml(game.awayScore || 0)}</div>
             ` : `
-              <div class="text-sm text-gray-500">${formatDate(game.date)} • ${formatTime(game.date)}</div>
+              <div class="text-sm text-gray-500">${escapeHtml(formatDate(game.date))} • ${escapeHtml(formatTime(game.date))}</div>
             `}
             <div class="mt-2 text-center text-primary-600 text-sm font-semibold">${game.isLive ? 'Watch Now →' : 'View Details →'}</div>
           </a>
@@ -107,20 +142,17 @@ export async function loadPastGames({
         }
 
         container.innerHTML = pastGames.map((game) => `
-          <a href="live-game.html?teamId=${resolveTeamId(game)}&gameId=${game.id}&replay=true"
+          <a href="${buildLiveGameHref(game, true)}"
              class="block bg-white rounded-xl shadow hover:shadow-lg transition border border-gray-200 p-5">
             <div class="flex items-center gap-3 mb-3">
-              ${game.team?.photoUrl
-                ? `<img src="${game.team.photoUrl}" class="w-10 h-10 rounded-full object-cover" alt="${game.team?.name || 'Team'}">`
-                : `<div class="w-10 h-10 rounded-full bg-primary-100 flex items-center justify-center text-primary-600 font-bold">${game.team?.name?.[0] || '?'}</div>`
-              }
+              ${renderTeamAvatar(game)}
               <div>
-                <div class="font-semibold text-gray-900">${game.team?.name || 'Team'}</div>
-                <div class="text-sm text-gray-500">vs ${game.opponent || 'Opponent'}</div>
+                <div class="font-semibold text-gray-900">${escapeHtml(game.team?.name || 'Team')}</div>
+                <div class="text-sm text-gray-500">vs ${escapeHtml(game.opponent || 'Opponent')}</div>
               </div>
             </div>
-            <div class="text-2xl font-bold text-center py-2 text-gray-900">${game.homeScore || 0} - ${game.awayScore || 0}</div>
-            <div class="text-xs text-gray-400 text-center mb-2">${formatDate(game.date)}</div>
+            <div class="text-2xl font-bold text-center py-2 text-gray-900">${escapeHtml(game.homeScore || 0)} - ${escapeHtml(game.awayScore || 0)}</div>
+            <div class="text-xs text-gray-400 text-center mb-2">${escapeHtml(formatDate(game.date))}</div>
             <div class="text-center text-teal-600 text-sm font-semibold">Watch Replay →</div>
           </a>
         `).join('');

--- a/js/homepage.js
+++ b/js/homepage.js
@@ -1,0 +1,167 @@
+function resolveTeamId(game) {
+    return game.teamId || game.team?.id || '';
+}
+
+export function applyHeroCta(user, heroCta) {
+    if (!heroCta) {
+        return;
+    }
+
+    if (user) {
+        heroCta.textContent = 'Go to Dashboard';
+        heroCta.href = 'dashboard.html';
+        return;
+    }
+
+    heroCta.textContent = 'Create Your Team';
+    heroCta.href = 'login.html#signup';
+}
+
+export async function loadLiveGames({
+    container,
+    getLiveGamesNow,
+    getUpcomingLiveGames,
+    formatDate,
+    formatTime,
+    logger = console
+}) {
+    if (!container) {
+        return;
+    }
+
+    try {
+        let liveGames = [];
+        let upcomingGames = [];
+
+        try {
+            liveGames = await getLiveGamesNow();
+        } catch (error) {
+            logger.warn('Could not load live games:', error?.message || error);
+        }
+
+        try {
+            upcomingGames = await getUpcomingLiveGames(6);
+        } catch (error) {
+            logger.warn('Could not load upcoming games:', error?.message || error);
+        }
+
+        const combined = [
+            ...liveGames.map((game) => ({ ...game, isLive: true })),
+            ...upcomingGames.filter((game) => !liveGames.find((liveGame) => liveGame.id === game.id))
+        ].slice(0, 6);
+
+        if (combined.length === 0) {
+            container.innerHTML = '<div class="text-center py-8 text-gray-500 col-span-full">No upcoming live games scheduled</div>';
+            return;
+        }
+
+        container.innerHTML = combined.map((game) => `
+          <a href="live-game.html?teamId=${resolveTeamId(game)}&gameId=${game.id}"
+             class="block bg-white rounded-xl shadow hover:shadow-lg transition border border-gray-200 p-5 ${game.isLive ? 'ring-2 ring-red-500' : ''}">
+            ${game.isLive ? `
+              <div class="flex items-center gap-2 mb-2">
+                <span class="w-2 h-2 bg-red-500 rounded-full animate-pulse"></span>
+                <span class="text-red-600 text-xs font-semibold uppercase">Live Now</span>
+                ${game.liveViewerCount ? `<span class="text-gray-400 text-xs">${game.liveViewerCount} watching</span>` : ''}
+              </div>
+            ` : ''}
+            <div class="flex items-center gap-3 mb-2">
+              ${game.team?.photoUrl
+                ? `<img src="${game.team.photoUrl}" class="w-10 h-10 rounded-full object-cover" alt="${game.team?.name || 'Team'}">`
+                : `<div class="w-10 h-10 rounded-full bg-primary-100 flex items-center justify-center text-primary-600 font-bold">${game.team?.name?.[0] || '?'}</div>`
+              }
+              <div>
+                <div class="font-semibold text-gray-900">${game.team?.name || 'Team'}</div>
+                <div class="text-sm text-gray-500">vs ${game.opponent || 'Opponent'}</div>
+              </div>
+            </div>
+            ${game.isLive ? `
+              <div class="text-2xl font-bold text-center py-2">${game.homeScore || 0} - ${game.awayScore || 0}</div>
+            ` : `
+              <div class="text-sm text-gray-500">${formatDate(game.date)} • ${formatTime(game.date)}</div>
+            `}
+            <div class="mt-2 text-center text-primary-600 text-sm font-semibold">${game.isLive ? 'Watch Now →' : 'View Details →'}</div>
+          </a>
+        `).join('');
+    } catch (error) {
+        logger.error('Failed to load live games:', error);
+        container.innerHTML = '<div class="text-center py-8 text-gray-500 col-span-full">Unable to load games</div>';
+    }
+}
+
+export async function loadPastGames({
+    container,
+    getRecentLiveTrackedGames,
+    formatDate,
+    logger = console
+}) {
+    if (!container) {
+        return;
+    }
+
+    try {
+        const pastGames = await getRecentLiveTrackedGames(6);
+        if (pastGames.length === 0) {
+            container.innerHTML = '<div class="text-center py-8 text-gray-500 col-span-full">No recent replays available</div>';
+            return;
+        }
+
+        container.innerHTML = pastGames.map((game) => `
+          <a href="live-game.html?teamId=${resolveTeamId(game)}&gameId=${game.id}&replay=true"
+             class="block bg-white rounded-xl shadow hover:shadow-lg transition border border-gray-200 p-5">
+            <div class="flex items-center gap-3 mb-3">
+              ${game.team?.photoUrl
+                ? `<img src="${game.team.photoUrl}" class="w-10 h-10 rounded-full object-cover" alt="${game.team?.name || 'Team'}">`
+                : `<div class="w-10 h-10 rounded-full bg-primary-100 flex items-center justify-center text-primary-600 font-bold">${game.team?.name?.[0] || '?'}</div>`
+              }
+              <div>
+                <div class="font-semibold text-gray-900">${game.team?.name || 'Team'}</div>
+                <div class="text-sm text-gray-500">vs ${game.opponent || 'Opponent'}</div>
+              </div>
+            </div>
+            <div class="text-2xl font-bold text-center py-2 text-gray-900">${game.homeScore || 0} - ${game.awayScore || 0}</div>
+            <div class="text-xs text-gray-400 text-center mb-2">${formatDate(game.date)}</div>
+            <div class="text-center text-teal-600 text-sm font-semibold">Watch Replay →</div>
+          </a>
+        `).join('');
+    } catch (error) {
+        logger.error('Failed to load past games:', error);
+        container.innerHTML = '<div class="text-center py-8 text-gray-500 col-span-full">Unable to load replays</div>';
+    }
+}
+
+export async function initHomepage({
+    document = globalThis.document,
+    checkAuth,
+    renderHeader,
+    getLiveGamesNow,
+    getUpcomingLiveGames,
+    getRecentLiveTrackedGames,
+    formatDate,
+    formatTime,
+    logger = console
+}) {
+    const heroCta = document.getElementById('hero-cta');
+
+    checkAuth((user) => {
+        renderHeader(document.getElementById('header-container'), user);
+        applyHeroCta(user, heroCta);
+    });
+
+    await Promise.all([
+        loadLiveGames({
+            container: document.getElementById('live-games-list'),
+            getLiveGamesNow,
+            getUpcomingLiveGames,
+            formatDate,
+            formatTime,
+            logger
+        }),
+        loadPastGames({
+            container: document.getElementById('past-games-list'),
+            getRecentLiveTrackedGames,
+            formatDate,
+            logger
+        })
+    ]);
+}

--- a/tests/unit/homepage-index.test.js
+++ b/tests/unit/homepage-index.test.js
@@ -179,4 +179,53 @@ describe('homepage index workflow', () => {
         expect(elements.get('live-games-list').textContent).toBe('No upcoming live games scheduled');
         expect(elements.get('past-games-list').textContent).toBe('Unable to load replays');
     });
+
+    it('escapes untrusted homepage game fields before inserting markup', async () => {
+        const hostileLiveGame = createGame({
+            id: 'game-1"&bad=<svg>',
+            teamId: 'team-1"&evil=<script>',
+            opponent: '<img src=x onerror=alert(1)>',
+            liveViewerCount: '7<script>alert(1)</script>',
+            homeScore: '<b>12</b>',
+            awayScore: '"10"',
+            team: {
+                id: 'team-1',
+                name: 'Tigers"><script>alert(1)</script>',
+                photoUrl: 'https://img.example.com/logo.png" onerror="alert(1)'
+            }
+        });
+        const hostileReplayGame = createGame({
+            id: 'game-2"&replay=false',
+            teamId: 'team-2"&x=<img>',
+            opponent: '<svg onload=alert(2)>',
+            team: {
+                id: 'team-2',
+                name: 'Bears & <wolves>',
+                photoUrl: ''
+            }
+        });
+
+        const { elements } = await runHomepage({
+            liveGames: [hostileLiveGame],
+            replayGames: [hostileReplayGame]
+        });
+
+        const liveMarkup = elements.get('live-games-list').innerHTML;
+        expect(liveMarkup).toContain('Tigers&quot;&gt;&lt;script&gt;alert(1)&lt;/script&gt;');
+        expect(liveMarkup).toContain('vs &lt;img src=x onerror=alert(1)&gt;');
+        expect(liveMarkup).toContain('7&lt;script&gt;alert(1)&lt;/script&gt; watching');
+        expect(liveMarkup).toContain('&lt;b&gt;12&lt;/b&gt; - &quot;10&quot;');
+        expect(liveMarkup).toContain('teamId=team-1%22%26evil%3D%3Cscript%3E');
+        expect(liveMarkup).toContain('gameId=game-1%22%26bad%3D%3Csvg%3E');
+        expect(liveMarkup).toContain('src="https://img.example.com/logo.png&quot; onerror=&quot;alert(1)"');
+        expect(liveMarkup).not.toContain('<script>alert(1)</script>');
+        expect(liveMarkup).not.toContain('<img src=x onerror=alert(1)>');
+
+        const replayMarkup = elements.get('past-games-list').innerHTML;
+        expect(replayMarkup).toContain('Bears &amp; &lt;wolves&gt;');
+        expect(replayMarkup).toContain('vs &lt;svg onload=alert(2)&gt;');
+        expect(replayMarkup).toContain('teamId=team-2%22%26x%3D%3Cimg%3E');
+        expect(replayMarkup).toContain('gameId=game-2%22%26replay%3Dfalse&replay=true');
+        expect(replayMarkup).not.toContain('<svg onload=alert(2)>');
+    });
 });

--- a/tests/unit/homepage-index.test.js
+++ b/tests/unit/homepage-index.test.js
@@ -1,0 +1,182 @@
+import { describe, expect, it, vi } from 'vitest';
+import { initHomepage } from '../../js/homepage.js';
+
+class MockElement {
+    constructor(id = '') {
+        this.id = id;
+        this.textContent = '';
+        this.href = '';
+        this._innerHTML = '';
+    }
+
+    set innerHTML(value) {
+        this._innerHTML = String(value);
+        this.textContent = this._innerHTML.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
+    }
+
+    get innerHTML() {
+        return this._innerHTML;
+    }
+}
+
+function createEnvironment() {
+    const elements = new Map([
+        ['header-container', new MockElement('header-container')],
+        ['hero-cta', new MockElement('hero-cta')],
+        ['live-games-list', new MockElement('live-games-list')],
+        ['past-games-list', new MockElement('past-games-list')]
+    ]);
+
+    elements.get('live-games-list').innerHTML = '<div>Loading games...</div>';
+    elements.get('past-games-list').innerHTML = '<div>Loading replays...</div>';
+
+    return {
+        document: {
+            getElementById(id) {
+                const element = elements.get(id);
+                if (!element) {
+                    throw new Error(`Unknown element: ${id}`);
+                }
+                return element;
+            }
+        },
+        elements
+    };
+}
+
+function createGame(overrides = {}) {
+    return {
+        id: 'game-1',
+        teamId: 'team-1',
+        opponent: 'Falcons',
+        date: '2026-03-28T18:00:00.000Z',
+        homeScore: 12,
+        awayScore: 10,
+        team: {
+            id: 'team-1',
+            name: 'Tigers',
+            photoUrl: ''
+        },
+        ...overrides
+    };
+}
+
+async function runHomepage({
+    user = null,
+    liveGames = [],
+    upcomingGames = [],
+    replayGames = [],
+    liveError = null,
+    upcomingError = null,
+    replayError = null
+} = {}) {
+    const { document, elements } = createEnvironment();
+    const renderHeader = vi.fn((container, currentUser) => {
+        container.textContent = currentUser ? 'signed-in' : 'signed-out';
+    });
+
+    await initHomepage({
+        document,
+        checkAuth(callback) {
+            callback(user);
+        },
+        renderHeader,
+        async getLiveGamesNow() {
+            if (liveError) {
+                throw liveError;
+            }
+            return liveGames;
+        },
+        async getUpcomingLiveGames() {
+            if (upcomingError) {
+                throw upcomingError;
+            }
+            return upcomingGames;
+        },
+        async getRecentLiveTrackedGames() {
+            if (replayError) {
+                throw replayError;
+            }
+            return replayGames;
+        },
+        formatDate(value) {
+            return `DATE:${value}`;
+        },
+        formatTime(value) {
+            return `TIME:${value}`;
+        },
+        logger: {
+            warn: vi.fn(),
+            error: vi.fn()
+        }
+    });
+
+    return { elements, renderHeader };
+}
+
+describe('homepage index workflow', () => {
+    it('renders auth-aware CTA, deduplicates live and upcoming games, and preserves replay links', async () => {
+        const duplicatedLiveGame = createGame({ liveViewerCount: 5 });
+        const replayGame = createGame({
+            id: 'game-2',
+            opponent: 'Bears',
+            homeScore: 77,
+            awayScore: 72
+        });
+
+        const { elements, renderHeader } = await runHomepage({
+            user: { uid: 'coach-1' },
+            liveGames: [duplicatedLiveGame],
+            upcomingGames: [duplicatedLiveGame],
+            replayGames: [replayGame]
+        });
+
+        expect(renderHeader).toHaveBeenCalledWith(elements.get('header-container'), { uid: 'coach-1' });
+        expect(elements.get('hero-cta').textContent).toBe('Go to Dashboard');
+        expect(elements.get('hero-cta').href).toBe('dashboard.html');
+
+        const liveMarkup = elements.get('live-games-list').innerHTML;
+        expect(liveMarkup).not.toContain('Loading games...');
+        expect(liveMarkup).toContain('Live Now');
+        expect(liveMarkup).toContain('5 watching');
+        expect(liveMarkup).toContain('Watch Now');
+        expect((liveMarkup.match(/gameId=game-1/g) || []).length).toBe(1);
+
+        const replayMarkup = elements.get('past-games-list').innerHTML;
+        expect(replayMarkup).not.toContain('Loading replays...');
+        expect(replayMarkup).toContain('Watch Replay');
+        expect(replayMarkup).toContain('gameId=game-2&replay=true');
+    });
+
+    it('keeps upcoming cards visible when live games fail and sets the guest CTA', async () => {
+        const upcomingGame = createGame({ id: 'game-3', opponent: 'Owls' });
+
+        const { elements } = await runHomepage({
+            liveError: new Error('missing live index'),
+            upcomingGames: [upcomingGame]
+        });
+
+        expect(elements.get('hero-cta').textContent).toBe('Create Your Team');
+        expect(elements.get('hero-cta').href).toBe('login.html#signup');
+
+        const liveMarkup = elements.get('live-games-list').innerHTML;
+        expect(liveMarkup).not.toContain('Loading games...');
+        expect(liveMarkup).toContain('View Details');
+        expect(liveMarkup).toContain('gameId=game-3');
+        expect(liveMarkup).toContain('DATE:2026-03-28T18:00:00.000Z');
+        expect(liveMarkup).toContain('TIME:2026-03-28T18:00:00.000Z');
+    });
+
+    it('replaces loading placeholders with exact empty and error fallback copy', async () => {
+        const { elements } = await runHomepage({
+            liveGames: [],
+            upcomingGames: [],
+            replayError: new Error('replay query failed')
+        });
+
+        expect(elements.get('live-games-list').innerHTML).not.toContain('Loading games...');
+        expect(elements.get('past-games-list').innerHTML).not.toContain('Loading replays...');
+        expect(elements.get('live-games-list').textContent).toBe('No upcoming live games scheduled');
+        expect(elements.get('past-games-list').textContent).toBe('Unable to load replays');
+    });
+});


### PR DESCRIPTION
Closes #346

## What changed
- extracted the homepage CTA and discovery-rail logic from `index.html` into a small `js/homepage.js` module so the real workflow can be unit tested without changing runtime behavior
- added `tests/unit/homepage-index.test.js` to cover auth-aware CTA state, live/upcoming deduplication, replay links with `replay=true`, and the exact empty/error fallback copy that replaces the loading placeholders
- persisted the required run artifacts under `docs/pr-notes/runs/issue-346-fixer-20260328T042502Z/`

## Why
The homepage rails were relying on untested Firestore-backed merge and fallback behavior. This patch makes those paths enforceable in CI while keeping the page behavior and copy unchanged.

## Validation
- `node node_modules/vitest/vitest.mjs run tests/unit/homepage-index.test.js`
- `node node_modules/vitest/vitest.mjs run tests/unit/login-page.test.js tests/unit/live-game-replay-init.test.js`
- `node node_modules/vitest/vitest.mjs run tests/unit`