### PR TITLE
Fix game report playing-time scope bug

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -105,7 +105,7 @@ jobs:
           body="$marker
 
           Preview URL: $PREVIEW_URL"
-          comment_id="$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq '.[] | select(.user.login == \"github-actions[bot]\") | select(.body | contains(\"<!-- allplays-preview-url -->\")) | .id' | head -n1)"
+          comment_id="$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("<!-- allplays-preview-url -->")) | .id' | head -n1)"
           if [ -n "$comment_id" ]; then
             gh api repos/${{ github.repository }}/issues/comments/"$comment_id" --method PATCH -f body="$body" >/dev/null
           else

--- a/docs/pr-notes/runs/422-ci-fix-20260328T152042Z/architecture.md
+++ b/docs/pr-notes/runs/422-ci-fix-20260328T152042Z/architecture.md
@@ -1,0 +1,7 @@
+# Architecture notes
+
+- Objective: fix deploy-preview PR comment step without changing deploy behavior.
+- Current state: workflow passes a jq expression with backslash-escaped quotes to `gh api --jq`; `gh` parses it as invalid jq.
+- Proposed state: use a valid jq expression string and keep comment upsert behavior unchanged.
+- Blast radius: one GitHub Actions step in preview deploy reporting only; no runtime app impact.
+- Assumptions: workflow uses `gh` built-in jq evaluator as shown in logs; failure is reproducible from the logged command.

--- a/docs/pr-notes/runs/422-ci-fix-20260328T152042Z/code-plan.md
+++ b/docs/pr-notes/runs/422-ci-fix-20260328T152042Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code plan
+
+1. Open the workflow file containing the deploy preview comment step.
+2. Replace the invalid escaped-quote jq expression with a valid single-quoted jq filter.
+3. Validate the expression against sample JSON locally.
+4. Stage changed files and commit with the required CI-fix message.

--- a/docs/pr-notes/runs/422-ci-fix-20260328T152042Z/qa.md
+++ b/docs/pr-notes/runs/422-ci-fix-20260328T152042Z/qa.md
@@ -1,0 +1,5 @@
+# QA notes
+
+- Validate by inspecting workflow syntax and running the jq expression locally through `jq` with representative data.
+- Repo has no automated test suite; use targeted command-level validation for the affected workflow snippet only.
+- Risk: none to deployed app; only PR comment reporting could regress if expression is malformed.

--- a/game.html
+++ b/game.html
@@ -1195,13 +1195,14 @@ Write the match report now:`;
 
                 // Setup summary controls
                 setupSummaryControls(teamId, gameId, game, team, players, statsMap, statKeys, statLabels);
+                let hasPlayingTime = Object.values(timeMap).some((t) => t > 0);
                 const headerRow = document.getElementById('stats-header-row');
                 function renderStatsTable() {
                     const { statKeys: tableStatKeys, statLabels: tableStatLabels } = resolveReportStatColumns({
                         statsMap,
                         resolvedConfig
                     });
-                    const hasPlayingTime = Object.values(timeMap).some((t) => t > 0);
+                    hasPlayingTime = Object.values(timeMap).some((t) => t > 0);
 
                     if (headerRow) {
                         headerRow.innerHTML = `


### PR DESCRIPTION
## What changed
- hoist `hasPlayingTime` into the outer `loadGame()` scope in `game.html`
- keep `renderStatsTable()` updating the same variable instead of shadowing it
- prevent the production `ReferenceError` that collapses the report into `Error loading game.`

## Why
The deployed `game.html` introduced `renderStatsTable()` and declared `hasPlayingTime` inside that helper, but the later Playing Time Insights block still referenced `hasPlayingTime` from `loadGame()`. That throws on report load for affected games.

## Manual verification
- reproduced the error on `https://allplays.ai/game.html#teamId=X8Tmh8wkp5U2tNWiHQ2I&gameId=xwZWSJE1qKBd27ZHWyxa`
- confirmed browser console showed `ReferenceError: hasPlayingTime is not defined`
- served the patched production-aligned file locally and verified the same route no longer throws that error