### PR TITLE
Expand smoke coverage for core pages

### DIFF
--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -41,3 +41,9 @@ jobs:
         run: npx playwright test --config=playwright.smoke.config.js --reporter=line
         env:
           SMOKE_BASE_URL: https://allplays.ai
+          SMOKE_SUITE: production
+          SMOKE_TEAM_ID: ${{ vars.SMOKE_TEAM_ID }}
+          SMOKE_GAME_ID: ${{ vars.SMOKE_GAME_ID }}
+          SMOKE_PLAYER_ID: ${{ vars.SMOKE_PLAYER_ID }}
+          SMOKE_AUTH_EMAIL: ${{ secrets.SMOKE_AUTH_EMAIL }}
+          SMOKE_AUTH_PASSWORD: ${{ secrets.SMOKE_AUTH_PASSWORD }}

--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -38,6 +38,10 @@ jobs:
         run: npx playwright test --config=playwright.smoke.config.js --reporter=line
         env:
           SMOKE_BASE_URL: http://127.0.0.1:4173
+          SMOKE_SUITE: preview
+          SMOKE_TEAM_ID: ${{ vars.SMOKE_TEAM_ID }}
+          SMOKE_GAME_ID: ${{ vars.SMOKE_GAME_ID }}
+          SMOKE_PLAYER_ID: ${{ vars.SMOKE_PLAYER_ID }}
 
       - name: Upload server log on failure
         if: failure()

--- a/.github/workflows/scheduled-prod-smoke.yml
+++ b/.github/workflows/scheduled-prod-smoke.yml
@@ -38,3 +38,9 @@ jobs:
         run: npx playwright test --config=playwright.smoke.config.js --reporter=line
         env:
           SMOKE_BASE_URL: https://allplays.ai
+          SMOKE_SUITE: production
+          SMOKE_TEAM_ID: ${{ vars.SMOKE_TEAM_ID }}
+          SMOKE_GAME_ID: ${{ vars.SMOKE_GAME_ID }}
+          SMOKE_PLAYER_ID: ${{ vars.SMOKE_PLAYER_ID }}
+          SMOKE_AUTH_EMAIL: ${{ secrets.SMOKE_AUTH_EMAIL }}
+          SMOKE_AUTH_PASSWORD: ${{ secrets.SMOKE_AUTH_PASSWORD }}

--- a/tests/smoke/helpers/boot-path.js
+++ b/tests/smoke/helpers/boot-path.js
@@ -3,7 +3,19 @@ import { expect } from '@playwright/test';
 const DEFAULT_FATAL_CONSOLE_PATTERNS = [
     /Missing Firebase image config/i,
     /Firebase config request failed/i,
-    /Uncaught/i
+    /Uncaught/i,
+    /ReferenceError/i,
+    /TypeError/i,
+    /Identifier .* has already been declared/i,
+    /Failed to fetch dynamically imported module/i
+];
+
+const DEFAULT_FORBIDDEN_TEXT_PATTERNS = [
+    /Error loading game\./i,
+    /Error loading player details/i,
+    /Game not found\.?/i,
+    /Player not found/i,
+    /Team not found/i
 ];
 
 function toRegExpList(patterns = []) {
@@ -119,7 +131,7 @@ export function createBootIssueCollector(page, options = {}) {
 }
 
 export async function assertPageBootsWithoutFatalErrors(page, options) {
-    const { baseURL, path, titlePatterns } = options;
+    const { baseURL, path, titlePatterns, readySelectors = [], forbiddenTexts = [] } = options;
     const issues = createBootIssueCollector(page, options);
 
     await page.goto(buildUrl(baseURL, path), { waitUntil: 'domcontentloaded' });
@@ -130,6 +142,23 @@ export async function assertPageBootsWithoutFatalErrors(page, options) {
         const matchers = Array.isArray(titlePatterns) ? titlePatterns : [titlePatterns];
         expect(matchers.some((pattern) => pattern.test(title))).toBeTruthy();
     }
+
+    if (readySelectors.length > 0) {
+        await Promise.any(
+            readySelectors.map((selector) =>
+                page.locator(selector).first().waitFor({ state: 'attached', timeout: 10000 })
+            )
+        );
+    }
+
+    const bodyText = await page.locator('body').innerText();
+    const forbiddenPatterns = [
+        ...DEFAULT_FORBIDDEN_TEXT_PATTERNS,
+        ...toRegExpList(forbiddenTexts)
+    ];
+    forbiddenPatterns.forEach((pattern) => {
+        expect(bodyText).not.toMatch(pattern);
+    });
 
     expect(issues).toEqual([]);
 }

--- a/tests/smoke/page-registry.js
+++ b/tests/smoke/page-registry.js
@@ -1,0 +1,142 @@
+const DEFAULT_TEAM_ID = 'ikouRgrXG66iHqgiDOxr';
+
+export function getSmokeContext() {
+    return {
+        suite: process.env.SMOKE_SUITE || 'preview',
+        teamId: process.env.SMOKE_TEAM_ID || DEFAULT_TEAM_ID,
+        gameId: process.env.SMOKE_GAME_ID || '',
+        playerId: process.env.SMOKE_PLAYER_ID || '',
+        authEmail: process.env.SMOKE_AUTH_EMAIL || '',
+        authPassword: process.env.SMOKE_AUTH_PASSWORD || ''
+    };
+}
+
+function buildOptionalCorePages({ teamId, gameId, playerId }) {
+    const pages = [
+        {
+            name: 'team details',
+            path: `/team.html#teamId=${teamId}`,
+            titlePatterns: [/Team Details - ALL PLAYS/i],
+            readySelectors: ['#schedule-list', 'main'],
+            forbiddenTexts: [/Team not found/i]
+        }
+    ];
+
+    if (gameId) {
+        pages.push(
+            {
+                name: 'game report',
+                path: `/game.html#teamId=${teamId}&gameId=${gameId}`,
+                titlePatterns: [/Match Report - ALL PLAYS/i],
+                readySelectors: ['#game-header', '#stats-body', '#game-log'],
+                forbiddenTexts: [/Error loading game\./i, /Game not found/i, /Please sign in to view this game\./i]
+            },
+            {
+                name: 'live game',
+                path: `/live-game.html?teamId=${teamId}&gameId=${gameId}`,
+                titlePatterns: [/Live Game - ALL PLAYS/i],
+                readySelectors: ['#scoreboard', '#plays-feed', '#stats-panel'],
+                forbiddenTexts: [/Game not found\./i]
+            }
+        );
+    }
+
+    if (gameId && playerId) {
+        pages.push({
+            name: 'player details',
+            path: `/player.html#teamId=${teamId}&gameId=${gameId}&playerId=${playerId}`,
+            titlePatterns: [/Player Details - ALL PLAYS/i],
+            readySelectors: ['#player-header', '#season-overview', '#game-stats'],
+            forbiddenTexts: [/Player not found/i, /Error loading player details/i]
+        });
+    }
+
+    return pages;
+}
+
+export function getPublicSmokePages() {
+    return [
+        {
+            name: 'homepage',
+            path: '/',
+            titlePatterns: [/ALL PLAYS/i],
+            readySelectors: ['body']
+        },
+        {
+            name: 'login',
+            path: '/login.html',
+            titlePatterns: [/Login - ALL PLAYS/i],
+            readySelectors: ['#login-form']
+        },
+        {
+            name: 'teams',
+            path: '/teams.html',
+            titlePatterns: [/Teams - ALL PLAYS/i],
+            readySelectors: ['#teams-list']
+        }
+    ];
+}
+
+export function getPreviewBootPages(context) {
+    const { teamId } = context;
+
+    return [
+        {
+            name: 'dashboard boot',
+            path: '/dashboard.html',
+            titlePatterns: [/My Teams/i, /Login - ALL PLAYS/i],
+            readySelectors: ['main', '#login-form']
+        },
+        {
+            name: 'parent dashboard boot',
+            path: '/parent-dashboard.html',
+            titlePatterns: [/Parent Dashboard/i, /Login - ALL PLAYS/i],
+            readySelectors: ['main', '#login-form']
+        },
+        {
+            name: 'edit schedule boot',
+            path: `/edit-schedule.html#teamId=${teamId}`,
+            titlePatterns: [/Edit Schedule - ALL PLAYS/i, /Login - ALL PLAYS/i],
+            readySelectors: ['#add-game-form', '#login-form']
+        },
+        {
+            name: 'team chat boot',
+            path: `/team-chat.html#teamId=${teamId}`,
+            titlePatterns: [/Team Chat - ALL PLAYS/i, /Login - ALL PLAYS/i],
+            readySelectors: ['#messages-container', '#login-form']
+        },
+        ...buildOptionalCorePages(context)
+    ];
+}
+
+export function getAuthenticatedSmokePages(context) {
+    const { teamId } = context;
+
+    return [
+        {
+            name: 'dashboard',
+            path: '/dashboard.html',
+            titlePatterns: [/My Teams/i],
+            readySelectors: ['main h1']
+        },
+        {
+            name: 'parent dashboard',
+            path: '/parent-dashboard.html',
+            titlePatterns: [/Parent Dashboard/i],
+            readySelectors: ['#my-players-list', '#schedule-list']
+        },
+        {
+            name: 'edit schedule',
+            path: `/edit-schedule.html#teamId=${teamId}`,
+            titlePatterns: [/Edit Schedule - ALL PLAYS/i],
+            readySelectors: ['#add-game-form', '#schedule-list']
+        },
+        {
+            name: 'team chat',
+            path: `/team-chat.html#teamId=${teamId}`,
+            titlePatterns: [/Team Chat - ALL PLAYS/i],
+            readySelectors: ['#messages-container', '#message-input']
+        },
+        ...buildOptionalCorePages(context)
+    ];
+}

--- a/tests/smoke/static-hosting-bootstrap.spec.js
+++ b/tests/smoke/static-hosting-bootstrap.spec.js
@@ -1,18 +1,69 @@
 import { test } from '@playwright/test';
 import { assertPageBootsWithoutFatalErrors } from './helpers/boot-path.js';
+import {
+    getAuthenticatedSmokePages,
+    getPreviewBootPages,
+    getPublicSmokePages,
+    getSmokeContext
+} from './page-registry.js';
 
-test('homepage boots under static-hosting constraints', async ({ page, baseURL }) => {
-    await assertPageBootsWithoutFatalErrors(page, {
-        baseURL,
-        path: '/',
-        titlePatterns: /ALL PLAYS/i
-    });
+async function loginWithPassword(page, baseURL, email, password) {
+    await page.goto(`${baseURL}/login.html`, { waitUntil: 'domcontentloaded' });
+    await page.locator('#email').fill(email);
+    await page.locator('#password').fill(password);
+    await Promise.all([
+        page.waitForURL((url) => !url.pathname.endsWith('/login.html'), { timeout: 20000 }),
+        page.locator('#submit-btn').click()
+    ]);
+    await page.waitForTimeout(1000);
+}
+
+const smokeContext = getSmokeContext();
+
+test.describe('public smoke pages', () => {
+    for (const definition of getPublicSmokePages()) {
+        test(`${definition.name} renders`, async ({ page, baseURL }) => {
+            await assertPageBootsWithoutFatalErrors(page, {
+                baseURL,
+                path: definition.path,
+                titlePatterns: definition.titlePatterns,
+                readySelectors: definition.readySelectors,
+                forbiddenTexts: definition.forbiddenTexts
+            });
+        });
+    }
 });
 
-test('dashboard boot path does not fatally fail under static-hosting constraints', async ({ page, baseURL }) => {
-    await assertPageBootsWithoutFatalErrors(page, {
-        baseURL,
-        path: '/dashboard.html',
-        titlePatterns: [/My Teams/i, /Login - ALL PLAYS/i]
+test.describe('preview boot smoke pages', () => {
+    for (const definition of getPreviewBootPages(smokeContext)) {
+        test(`${definition.name} boots without fatal runtime errors`, async ({ page, baseURL }) => {
+            await assertPageBootsWithoutFatalErrors(page, {
+                baseURL,
+                path: definition.path,
+                titlePatterns: definition.titlePatterns,
+                readySelectors: definition.readySelectors,
+                forbiddenTexts: definition.forbiddenTexts
+            });
+        });
+    }
+});
+
+test.describe('authenticated smoke pages', () => {
+    test.skip(!smokeContext.authEmail || !smokeContext.authPassword, 'SMOKE_AUTH_EMAIL and SMOKE_AUTH_PASSWORD are required');
+
+    test('authenticated coach and parent pages render', async ({ page, baseURL }) => {
+        await loginWithPassword(page, baseURL, smokeContext.authEmail, smokeContext.authPassword);
+
+        for (const definition of getAuthenticatedSmokePages(smokeContext)) {
+            await test.step(definition.name, async () => {
+                await assertPageBootsWithoutFatalErrors(page, {
+                    baseURL,
+                    path: definition.path,
+                    titlePatterns: definition.titlePatterns,
+                    readySelectors: definition.readySelectors,
+                    forbiddenTexts: definition.forbiddenTexts
+                });
+            });
+        }
     });
 });


### PR DESCRIPTION
## What changed
- add a reusable smoke page registry with optional seeded core routes
- extend smoke env support with `SMOKE_GAME_ID` and `SMOKE_PLAYER_ID`
- cover `team.html`, `game.html`, `live-game.html`, and `player.html` when seeded ids are configured
- fail smoke on rendered fallback states like `Error loading game.`, `Game not found`, and `Player not found`
- wire the new smoke env vars into preview, post-deploy, and scheduled production workflows

## Why
The current smoke setup catches runtime `pageerror` failures, but it did not exercise seeded report routes like `game.html#teamId=...&gameId=...`, so the recent production scope bug on the game report page was never visited by CI.

## Verification
- ran `npx playwright test tests/smoke/static-hosting-bootstrap.spec.js --config=playwright.smoke.config.js --reporter=line`
- result: `8 passed, 1 skipped`
- the skipped test is the authenticated suite because local env did not include `SMOKE_AUTH_EMAIL` and `SMOKE_AUTH_PASSWORD`

## Follow-up setup
- configure repo variables `SMOKE_GAME_ID` and `SMOKE_PLAYER_ID` to point at a stable completed game and player under `SMOKE_TEAM_ID`