### PR TITLE
Persist opponent removals across live tracker resume

### DIFF
--- a/docs/pr-notes/runs/428-remediator-20260328T195540Z/architecture.md
+++ b/docs/pr-notes/runs/428-remediator-20260328T195540Z/architecture.md
@@ -1,0 +1,12 @@
+# Architecture synthesis
+
+- Root cause 1: `buildModuleSource()` depends on exact `import ... from './module.js?v=N';` strings, so any cache-buster or formatting change can leave raw ESM imports inside the `AsyncFunction` body.
+- Root cause 2: the injected timeout stub calls the callback before returning the timeout handle, which inverts the ordering assumed by production code that assigns `liveSync.opponentTimeout = setTimeout(...)`.
+- Control comparison:
+  - Current: test harness fidelity depends on literal import versions and impossible synchronous timer behavior.
+  - Proposed: regex-based import substitution normalizes version drift, and a queued timeout runner preserves the "handle assigned first, callback later" contract.
+- Smallest viable change: replace the chained exact-string `.replace()` calls with a helper that rewrites imports by module specifier regex, then swap the timer stub for a small queued scheduler flushed by the test.
+- Risk surface:
+  - Low product risk because the patch is test-only.
+  - Moderate harness risk if import regexes are too broad, so each pattern should stay anchored to full import statements and known specifiers.
+- Rollback: revert the test harness file if this introduces any unexpected evaluation issue.

--- a/docs/pr-notes/runs/428-remediator-20260328T195540Z/code-plan.md
+++ b/docs/pr-notes/runs/428-remediator-20260328T195540Z/code-plan.md
@@ -1,0 +1,9 @@
+# Code plan
+
+Thinking level: medium
+
+1. Refactor the `live-tracker` source rewrite helper to replace imports by regex against specifiers instead of exact versioned lines.
+2. Introduce a tiny queued timeout scheduler in the test harness so callbacks run asynchronously and can be flushed deterministically by the test.
+3. Update the delete interaction test to flush queued timers before asserting persisted writes.
+4. Run the targeted Vitest file and verify only the intended test harness file and run notes changed.
+5. Commit the scoped fix on the current branch without pushing.

--- a/docs/pr-notes/runs/428-remediator-20260328T195540Z/qa.md
+++ b/docs/pr-notes/runs/428-remediator-20260328T195540Z/qa.md
@@ -1,0 +1,13 @@
+# QA synthesis
+
+- Primary regressions to guard:
+  - `live-tracker.js` import query bumps should not break the `AsyncFunction` harness.
+  - Opponent deletion should still schedule persisted writes correctly when timeout callbacks run asynchronously.
+- Test shape:
+  - Keep the existing hydration assertions.
+  - Preserve the interaction test around `renderOpponents()` delete wiring while flushing the queued timeout callbacks explicitly.
+- Why this is sufficient:
+  - The review items target harness fragility and timer fidelity, both fully exercised by the existing source-backed module boot path in this test file.
+- Validation target:
+  - `npm test -- tests/unit/live-tracker-opponent-stats.test.js`
+  - Fall back to `npm run test:unit -- tests/unit/live-tracker-opponent-stats.test.js` only if argument forwarding differs in this repo.

--- a/docs/pr-notes/runs/428-remediator-20260328T195540Z/requirements.md
+++ b/docs/pr-notes/runs/428-remediator-20260328T195540Z/requirements.md
@@ -1,0 +1,11 @@
+# Requirements synthesis
+
+- Objective: harden the `live-tracker` unit harness so unrelated import cache-buster changes and real async timer ordering do not break or weaken opponent-stats regression coverage.
+- Current state: the harness rewrites `live-tracker.js` imports with exact versioned string matches and executes `setTimeout` callbacks synchronously.
+- Proposed state: import rewrites should match module specifiers without pinning exact query versions, and timer callbacks should run on a later microtask so timeout-backed flags behave like browser code.
+- Blast radius: limited to `tests/unit/live-tracker-opponent-stats.test.js` and only affects test harness behavior for the `live-tracker` module.
+- Assumptions:
+  - The production `live-tracker.js` import list and timeout usage remain valid; the review feedback is about test fidelity, not runtime bugs.
+  - Preserving async ordering in the harness is sufficient for the current opponent deletion regression test.
+- Recommendation: patch only the harness helpers, keep the production code unchanged, and validate with the affected unit file.
+- Success measure: the test keeps passing after the patch, remains resilient to import query version churn, and no timeout-backed flag stays spuriously truthy because of synchronous mock ordering.

--- a/docs/pr-notes/runs/428-review-comment-3005243536-20260328T200017Z/architecture.md
+++ b/docs/pr-notes/runs/428-review-comment-3005243536-20260328T200017Z/architecture.md
@@ -1,0 +1,7 @@
+## Architecture Role Summary
+
+- Smallest viable change: localize the fix to `tests/unit/live-tracker-opponent-stats.test.js`.
+- Implementation direction: replace per-import exact rewrites for app-local modules with a helper that removes any named import from the target module path, regardless of cache-buster suffix.
+- Blast radius: one unit-test harness. No shipped JS bundles or Firebase interactions change.
+- Controls: keep the existing explicit dependency injection surface (`deps.db`, `deps.firebase`, `deps.utils`, `deps.auth`) so the test still fails loudly if the target modules disappear entirely.
+- Rollback: revert this single test-file change if it causes unexpected harness regressions.

--- a/docs/pr-notes/runs/428-review-comment-3005243536-20260328T200017Z/code-plan.md
+++ b/docs/pr-notes/runs/428-review-comment-3005243536-20260328T200017Z/code-plan.md
@@ -1,0 +1,10 @@
+## Code Role Summary
+
+- File to change: `tests/unit/live-tracker-opponent-stats.test.js`
+- Steps:
+  1. Add a `rewriteModuleImports` helper that strips named imports by module path with optional cache-buster support.
+  2. Use that helper for `db`, `firebase`, `utils`, and `auth` rewrites.
+  3. Add a regression test that mutates `?v=` values and verifies the harness still rewrites the source.
+- Explicit non-goals:
+  - No changes to `js/live-tracker.js`
+  - No changes to runtime cache-busting strategy

--- a/docs/pr-notes/runs/428-review-comment-3005243536-20260328T200017Z/qa.md
+++ b/docs/pr-notes/runs/428-review-comment-3005243536-20260328T200017Z/qa.md
@@ -1,0 +1,9 @@
+## QA Role Summary
+
+- Primary regression risk: the broader import matcher could miss or over-match import blocks from the same module.
+- Guardrail added: assert that mutated `?v=` values still produce rewritten source with no raw `db`, `firebase`, `utils`, or `auth` imports left behind.
+- Validation target:
+  - `tests/unit/live-tracker-opponent-stats.test.js`
+- Acceptance criteria:
+  - New harness-specific test passes.
+  - Existing opponent hydration and opponent-removal regression tests continue to pass.

--- a/docs/pr-notes/runs/428-review-comment-3005243536-20260328T200017Z/requirements.md
+++ b/docs/pr-notes/runs/428-review-comment-3005243536-20260328T200017Z/requirements.md
@@ -1,0 +1,10 @@
+## Requirements Role Summary
+
+- Objective: keep the `live-tracker` unit harness stable when cache-buster query strings change on module imports.
+- Current state: the harness rewrites `live-tracker.js` imports before evaluating the module with `AsyncFunction`, but that rewrite path should not depend on exact `?v=` values.
+- Proposed state: rewrite imports by module path, not by specific query version, so unrelated cache-buster bumps do not break tests.
+- Risk surface: unit-test harness only. No production runtime behavior changes.
+- Success criteria:
+  - The harness still strips relevant imports when `./db.js`, `./firebase.js`, `./utils.js`, or `./auth.js` use different `?v=` values.
+  - Existing opponent-stats regression coverage still passes.
+- Assumption: the review concern is limited to harness brittleness, not application code behavior.

--- a/docs/pr-notes/runs/issue-421-fixer-20260328T194619Z/architecture.md
+++ b/docs/pr-notes/runs/issue-421-fixer-20260328T194619Z/architecture.md
@@ -1,0 +1,11 @@
+# Architecture synthesis
+
+- Root cause: persistence for opponent stats is edge-triggered through `scheduleOpponentStatsSync()`. Delete bypasses that edge, so Firestore keeps stale opponent entries.
+- Control comparison:
+  - Current: UI state changes locally, persisted state remains stale, resume restores stale opponent cards.
+  - Proposed: UI state change is immediately queued for persistence, keeping resume hydration and stored state equivalent.
+- Smallest viable change: call `scheduleOpponentStatsSync()` and `scheduleLiveHasData()` inside the `[data-opp-del]` click handler after filtering `state.opp`.
+- Risk surface:
+  - Low code risk because the same scheduling functions are already used for adjacent opponent edit/stat flows.
+  - No schema change, no migration, no new persistence path.
+- Rollback: revert the handler change if unexpected writes occur.

--- a/docs/pr-notes/runs/issue-421-fixer-20260328T194619Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-421-fixer-20260328T194619Z/code-plan.md
@@ -1,0 +1,9 @@
+# Code plan
+
+Thinking level: medium
+
+1. Extend opponent-stats unit coverage with a source-backed interaction harness for `live-tracker.js`.
+2. Prove the current delete handler removes local state but does not schedule persisted opponent snapshot updates.
+3. Patch the delete handler to queue opponent-stats sync and `liveHasData` writes.
+4. Run targeted unit tests for the changed area, then run the full unit suite if it is stable in this repo.
+5. Commit the fix and tests together with an issue-referencing message.

--- a/docs/pr-notes/runs/issue-421-fixer-20260328T194619Z/qa.md
+++ b/docs/pr-notes/runs/issue-421-fixer-20260328T194619Z/qa.md
@@ -1,0 +1,12 @@
+# QA synthesis
+
+- Primary regression to cover: delete an opponent with persisted stats and verify the next persisted `opponentStats` snapshot omits that player.
+- Test shape:
+  - Unit-level interaction test around `renderOpponents()` delete wiring.
+  - Existing hydration tests remain as baseline resume coverage for persisted opponent data.
+- Why this is sufficient:
+  - The user-visible bug is caused by a missing persistence trigger, not by incorrect snapshot or hydration logic.
+  - Verifying the delete interaction schedules writes with the filtered snapshot directly guards the regression.
+- Validation target:
+  - `tests/unit/live-tracker-opponent-stats.test.js`
+  - relevant `vitest` run for the changed area, then broader `tests/unit` run if time/cost is reasonable.

--- a/docs/pr-notes/runs/issue-421-fixer-20260328T194619Z/requirements.md
+++ b/docs/pr-notes/runs/issue-421-fixer-20260328T194619Z/requirements.md
@@ -1,0 +1,11 @@
+# Requirements synthesis
+
+- Objective: prevent removed opponent player cards from reappearing after a live tracker resume.
+- Current state: opponent delete mutates `state.opp` and re-renders, but does not persist the filtered opponent set back to `game.opponentStats`.
+- Proposed state: removing an opponent card must trigger the same persistence and `liveHasData` scheduling used by opponent edits and stat changes.
+- Blast radius: limited to live tracker opponent card deletion and the persisted `opponentStats` payload on the game doc.
+- Assumptions:
+  - The intended behavior is that a removed opponent remains removed across reload/resume.
+  - Existing resume hydration from `game.opponentStats` is correct when the stored payload is correct.
+- Recommendation: add regression coverage on the delete interaction and patch only the delete handler.
+- Success measure: automated test fails before the patch, passes after the patch, and the persisted snapshot excludes the removed opponent entry.

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -469,6 +469,8 @@ function renderOpponents() {
   els.oppCards.querySelectorAll('[data-opp-del]').forEach(btn => {
     btn.addEventListener('click', () => {
       state.opp = state.opp.filter(o => o.id !== btn.dataset.oppDel);
+      scheduleOpponentStatsSync();
+      scheduleLiveHasData();
       renderOpponents();
     });
   });

--- a/tests/unit/live-tracker-opponent-stats.test.js
+++ b/tests/unit/live-tracker-opponent-stats.test.js
@@ -101,106 +101,109 @@ function replaceImport(source, pattern, replacement) {
   return updated;
 }
 
-function rewriteModuleImports(source, modulePath, replacement) {
-  const escapedModulePath = modulePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  const importPattern = new RegExp(
-    `^import\\s*\\{[^}]*\\}\\s*from\\s*['"]${escapedModulePath}(?:\\?v=[^'"]+)?['"];\\s*$`,
-    'gm'
+function escapeRegex(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function replaceNamedImportByModulePath(source, modulePath, replacement) {
+  const pattern = new RegExp(
+    `import\\s*\\{[\\s\\S]*?\\}\\s*from\\s*['"]${escapeRegex(modulePath)}(?:\\?v=[^'"]+)?['"];?\\s*`
   );
-  const matches = source.match(importPattern);
-  if (!matches?.length) {
-    throw new Error(`Failed to rewrite imports for module: ${modulePath}`);
-  }
-  return source.replace(importPattern, '').replace(/^/, `${replacement}\n`);
+  return replaceImport(source, pattern, replacement);
 }
 
 function buildModuleSource(source = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8')) {
   const authHook = `checkAuth(async (user) => {\n  if (!user) {\n    window.location.href = 'login.html';\n    return;\n  }\n  currentUser = user;\n  await init();\n});`;
 
   let rewritten = source;
-  rewritten = rewriteModuleImports(
+  rewritten = replaceNamedImportByModulePath(
     rewritten,
     './db.js',
     'const { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } = deps.db;'
   );
-  rewritten = rewriteModuleImports(
+  rewritten = replaceImport(
     rewritten,
-    './firebase.js',
+    /import\s*\{(?=[\s\S]*\bdb\b)[\s\S]*?\}\s*from\s*['"]\.\/firebase\.js(?:\?v=[^'"]+)?['"];?\s*/,
     'const { db, writeBatch, doc, setDoc, addDoc, onSnapshot } = deps.firebase;'
   );
-  rewritten = rewriteModuleImports(
+  rewritten = replaceNamedImportByModulePath(
     rewritten,
     './utils.js',
     'const { getUrlParams, escapeHtml } = deps.utils;'
   );
-  rewritten = rewriteModuleImports(
+  rewritten = replaceNamedImportByModulePath(
     rewritten,
     './auth.js',
     'const { checkAuth } = deps.auth;'
   );
   rewritten = replaceImport(
     rewritten,
-    /import\s*\{\s*getAI,\s*getGenerativeModel,\s*GoogleAIBackend\s*\}\s*from\s*['"]\.\/vendor\/firebase-ai\.js['"];/,
+    /import\s*\{(?=[\s\S]*\bwriteBatch\b)(?=[\s\S]*\bonSnapshot\b)[\s\S]*?\}\s*from\s*['"]\.\/firebase\.js(?:\?v=[^'"]+)?['"];?\s*/,
+    ''
+  );
+  rewritten = replaceNamedImportByModulePath(
+    rewritten,
+    './vendor/firebase-ai.js',
     'const { getAI, getGenerativeModel, GoogleAIBackend } = deps.firebaseAi;'
   );
-  rewritten = replaceImport(
+  rewritten = replaceNamedImportByModulePath(
     rewritten,
-    /import\s*\{\s*getApp\s*\}\s*from\s*['"]\.\/vendor\/firebase-app\.js['"];/,
+    './vendor/firebase-app.js',
     'const { getApp } = deps.firebaseApp;'
   );
-  rewritten = replaceImport(
+  rewritten = replaceNamedImportByModulePath(
     rewritten,
-    /import\s*\{\s*isVoiceRecognitionSupported,\s*normalizeGameNoteText,\s*appendGameSummaryLine,\s*buildGameNoteLogText\s*\}\s*from\s*['"]\.\/live-tracker-notes\.js(?:\?v=[^'"]+)?['"];/,
+    './live-tracker-notes.js',
     'const { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } = deps.liveTrackerNotes;'
   );
-  rewritten = replaceImport(
+  rewritten = replaceNamedImportByModulePath(
     rewritten,
-    /import\s*\{\s*canApplySubstitution,\s*applySubstitution,\s*resolveFinalScoreForCompletion,\s*acquireSingleFlightLock,\s*releaseSingleFlightLock\s*\}\s*from\s*['"]\.\/live-tracker-integrity\.js(?:\?v=[^'"]+)?['"];/,
+    './live-tracker-integrity.js',
     'const { canApplySubstitution, applySubstitution, resolveFinalScoreForCompletion, acquireSingleFlightLock, releaseSingleFlightLock } = deps.liveTrackerIntegrity;'
   );
-  rewritten = replaceImport(
+  rewritten = replaceNamedImportByModulePath(
     rewritten,
-    /import\s*\{\s*hydrateOpponentStats\s*\}\s*from\s*['"]\.\/live-tracker-opponent-stats\.js(?:\?v=[^'"]+)?['"];/,
+    './live-tracker-opponent-stats.js',
     'const { hydrateOpponentStats } = deps.liveTrackerOpponentStats;'
   );
-  rewritten = replaceImport(
+  rewritten = replaceNamedImportByModulePath(
     rewritten,
-    /import\s*\{\s*buildPersistedResumeClockState,\s*deriveResumeClockState\s*\}\s*from\s*['"]\.\/live-tracker-resume\.js(?:\?v=[^'"]+)?['"];/,
+    './live-tracker-resume.js',
     'const { buildPersistedResumeClockState, deriveResumeClockState } = deps.liveTrackerResume;'
   );
-  rewritten = replaceImport(
+  rewritten = replaceNamedImportByModulePath(
     rewritten,
-    /import\s*\{\s*restoreLiveLineup\s*\}\s*from\s*['"]\.\/live-tracker-lineup\.js(?:\?v=[^'"]+)?['"];/,
+    './live-tracker-lineup.js',
     'const { restoreLiveLineup } = deps.liveTrackerLineup;'
   );
-  rewritten = replaceImport(
+  rewritten = replaceNamedImportByModulePath(
     rewritten,
-    /import\s*\{\s*resolveFinalScore,\s*resolveSummaryRecipient\s*\}\s*from\s*['"]\.\/live-tracker-email\.js(?:\?v=[^'"]+)?['"];/,
+    './live-tracker-email.js',
     'const { resolveFinalScore, resolveSummaryRecipient } = deps.liveTrackerEmail;'
   );
-  rewritten = replaceImport(
+  rewritten = replaceNamedImportByModulePath(
     rewritten,
-    /import\s*\{\s*buildLiveResetEvent\s*\}\s*from\s*['"]\.\/live-tracker-reset\.js(?:\?v=[^'"]+)?['"];/,
+    './live-tracker-reset.js',
     'const { buildLiveResetEvent } = deps.liveTrackerReset;'
   );
-  rewritten = replaceImport(
+  rewritten = replaceNamedImportByModulePath(
     rewritten,
-    /import\s*\{\s*advanceLiveChatUnreadState\s*\}\s*from\s*['"]\.\/live-tracker-chat-unread\.js(?:\?v=[^'"]+)?['"];/,
+    './live-tracker-chat-unread.js',
     'const { advanceLiveChatUnreadState } = deps.liveTrackerChatUnread;'
   );
-  rewritten = replaceImport(
+  rewritten = replaceNamedImportByModulePath(
     rewritten,
-    /import\s*\{\s*resolveLiveStatConfig,\s*resolveLiveStatColumns\s*\}\s*from\s*['"]\.\/live-game-state\.js(?:\?v=[^'"]+)?['"];/,
+    './live-game-state.js',
     'const { resolveLiveStatConfig, resolveLiveStatColumns } = deps.liveGameState;'
   );
-  rewritten = replaceImport(
+  rewritten = replaceNamedImportByModulePath(
     rewritten,
-    /import\s*\{\s*getDefaultLivePeriod,\s*getSportPeriodLabels\s*\}\s*from\s*['"]\.\/live-sport-config\.js(?:\?v=[^'"]+)?['"];/,
+    './live-sport-config.js',
     'const { getDefaultLivePeriod, getSportPeriodLabels } = deps.liveSportConfig;'
   );
-  rewritten = replaceImport(
+  rewritten = replaceNamedImportByModulePath(
     rewritten,
-    /import\s*\{\s*buildOpponentStatsSnapshotFromEntries,\s*buildFinishCompletionPlan,\s*executeFinishNavigationPlan\s*\}\s*from\s*['"]\.\/live-tracker-finish\.js(?:\?v=[^'"]+)?['"];/,
+    './live-tracker-finish.js',
     'const { buildOpponentStatsSnapshotFromEntries, buildFinishCompletionPlan, executeFinishNavigationPlan } = deps.liveTrackerFinish;'
   );
 
@@ -376,9 +379,12 @@ async function bootLiveTracker({ updateGame }) {
 }
 
 describe('live tracker opponent stats harness', () => {
-  it('rewrites module imports when cache-buster versions change', () => {
+  it('rewrites module imports when cache-buster versions and formatting change', () => {
     const source = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8')
-      .replace('./db.js?v=15', './db.js?v=999')
+      .replace(
+        "import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=15';",
+        "import {\n  getTeam,\n  getTeams,\n  getGame,\n  getPlayers,\n  getConfigs,\n  updateGame,\n  collection,\n  getDocs,\n  deleteDoc,\n  query,\n  broadcastLiveEvent,\n  subscribeLiveChat,\n  postLiveChatMessage,\n  setGameLiveStatus\n} from './db.js?v=999';"
+      )
       .replace('./firebase.js?v=10', './firebase.js?v=77')
       .replace('./utils.js?v=9', './utils.js?v=123')
       .replace('./auth.js?v=11', './auth.js?v=456');

--- a/tests/unit/live-tracker-opponent-stats.test.js
+++ b/tests/unit/live-tracker-opponent-stats.test.js
@@ -101,35 +101,42 @@ function replaceImport(source, pattern, replacement) {
   return updated;
 }
 
-function buildModuleSource() {
-  const source = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8');
+function rewriteModuleImports(source, modulePath, replacement) {
+  const escapedModulePath = modulePath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const importPattern = new RegExp(
+    `^import\\s*\\{[^}]*\\}\\s*from\\s*['"]${escapedModulePath}(?:\\?v=[^'"]+)?['"];\\s*$`,
+    'gm'
+  );
+  const matches = source.match(importPattern);
+  if (!matches?.length) {
+    throw new Error(`Failed to rewrite imports for module: ${modulePath}`);
+  }
+  return source.replace(importPattern, '').replace(/^/, `${replacement}\n`);
+}
+
+function buildModuleSource(source = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8')) {
   const authHook = `checkAuth(async (user) => {\n  if (!user) {\n    window.location.href = 'login.html';\n    return;\n  }\n  currentUser = user;\n  await init();\n});`;
 
   let rewritten = source;
-  rewritten = replaceImport(
+  rewritten = rewriteModuleImports(
     rewritten,
-    /import\s*\{\s*getTeam,\s*getTeams,\s*getGame,\s*getPlayers,\s*getConfigs,\s*updateGame,\s*collection,\s*getDocs,\s*deleteDoc,\s*query,\s*broadcastLiveEvent,\s*subscribeLiveChat,\s*postLiveChatMessage,\s*setGameLiveStatus\s*\}\s*from\s*['"]\.\/db\.js(?:\?v=[^'"]+)?['"];/,
+    './db.js',
     'const { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } = deps.db;'
   );
-  rewritten = replaceImport(
+  rewritten = rewriteModuleImports(
     rewritten,
-    /import\s*\{\s*db\s*\}\s*from\s*['"]\.\/firebase\.js(?:\?v=[^'"]+)?['"];/,
+    './firebase.js',
     'const { db, writeBatch, doc, setDoc, addDoc, onSnapshot } = deps.firebase;'
   );
-  rewritten = replaceImport(
+  rewritten = rewriteModuleImports(
     rewritten,
-    /import\s*\{\s*getUrlParams,\s*escapeHtml\s*\}\s*from\s*['"]\.\/utils\.js(?:\?v=[^'"]+)?['"];/,
+    './utils.js',
     'const { getUrlParams, escapeHtml } = deps.utils;'
   );
-  rewritten = replaceImport(
+  rewritten = rewriteModuleImports(
     rewritten,
-    /import\s*\{\s*checkAuth\s*\}\s*from\s*['"]\.\/auth\.js(?:\?v=[^'"]+)?['"];/,
+    './auth.js',
     'const { checkAuth } = deps.auth;'
-  );
-  rewritten = replaceImport(
-    rewritten,
-    /import\s*\{\s*writeBatch,\s*doc,\s*setDoc,\s*addDoc,\s*onSnapshot\s*\}\s*from\s*['"]\.\/firebase\.js(?:\?v=[^'"]+)?['"];\s*/,
-    ''
   );
   rewritten = replaceImport(
     rewritten,
@@ -367,6 +374,22 @@ async function bootLiveTracker({ updateGame }) {
     flushTimers
   };
 }
+
+describe('live tracker opponent stats harness', () => {
+  it('rewrites module imports when cache-buster versions change', () => {
+    const source = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8')
+      .replace('./db.js?v=15', './db.js?v=999')
+      .replace('./firebase.js?v=10', './firebase.js?v=77')
+      .replace('./utils.js?v=9', './utils.js?v=123')
+      .replace('./auth.js?v=11', './auth.js?v=456');
+
+    const rewritten = buildModuleSource(source);
+
+    expect(rewritten).toContain('const { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } = deps.db;');
+    expect(rewritten).toContain('const { db, writeBatch, doc, setDoc, addDoc, onSnapshot } = deps.firebase;');
+    expect(rewritten).not.toMatch(/import\s*\{[\s\S]*?\}\s*from\s*['"]\.\/(?:db|firebase|utils|auth)\.js\?v=/);
+  });
+});
 
 describe('live tracker opponent stats hydration', () => {
   it('preserves persisted fouls when resuming opponent stats', () => {

--- a/tests/unit/live-tracker-opponent-stats.test.js
+++ b/tests/unit/live-tracker-opponent-stats.test.js
@@ -1,5 +1,322 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
 import { hydrateOpponentStats } from '../../js/live-tracker-opponent-stats.js';
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+class MockClassList {
+  constructor() {
+    this.tokens = new Set();
+  }
+
+  toggle(token, force) {
+    if (force) {
+      this.tokens.add(token);
+      return true;
+    }
+    this.tokens.delete(token);
+    return false;
+  }
+}
+
+class MockElement {
+  constructor(id = '') {
+    this.id = id;
+    this.dataset = {};
+    this.listeners = new Map();
+    this.classList = new MockClassList();
+    this._innerHTML = '';
+    this.queryGroups = {
+      '[data-opp-edit]': [],
+      '[data-opp-del]': [],
+      '[data-opp-stat]': []
+    };
+  }
+
+  addEventListener(type, handler) {
+    const handlers = this.listeners.get(type) || [];
+    handlers.push(handler);
+    this.listeners.set(type, handlers);
+  }
+
+  click() {
+    (this.listeners.get('click') || []).forEach(handler => handler());
+  }
+
+  set innerHTML(value) {
+    this._innerHTML = String(value);
+    this.queryGroups = {
+      '[data-opp-edit]': [...this._innerHTML.matchAll(/data-opp-edit="([^"]+)"/g)].map(([, id]) => {
+        const element = new MockElement();
+        element.dataset.oppEdit = id;
+        element.value = '';
+        return element;
+      }),
+      '[data-opp-del]': [...this._innerHTML.matchAll(/data-opp-del="([^"]+)"/g)].map(([, id]) => {
+        const element = new MockElement();
+        element.dataset.oppDel = id;
+        return element;
+      }),
+      '[data-opp-stat]': []
+    };
+  }
+
+  get innerHTML() {
+    return this._innerHTML;
+  }
+
+  querySelectorAll(selector) {
+    return this.queryGroups[selector] || [];
+  }
+}
+
+function createEnvironment() {
+  const elements = new Map();
+
+  function ensureElement(id) {
+    if (!elements.has(id)) {
+      elements.set(id, new MockElement(id));
+    }
+    return elements.get(id);
+  }
+
+  return {
+    document: {
+      querySelector(selector) {
+        if (!selector.startsWith('#')) return null;
+        return ensureElement(selector.slice(1));
+      },
+      getElementById(id) {
+        return ensureElement(id);
+      }
+    }
+  };
+}
+
+function buildModuleSource() {
+  const source = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8');
+  const authHook = `checkAuth(async (user) => {\n  if (!user) {\n    window.location.href = 'login.html';\n    return;\n  }\n  currentUser = user;\n  await init();\n});`;
+
+  return source
+    .replace(
+      "import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=15';",
+      'const { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } = deps.db;'
+    )
+    .replace(
+      "import { db } from './firebase.js?v=10';",
+      'const { db, writeBatch, doc, setDoc, addDoc, onSnapshot } = deps.firebase;'
+    )
+    .replace(
+      "import { getUrlParams, escapeHtml } from './utils.js?v=9';",
+      'const { getUrlParams, escapeHtml } = deps.utils;'
+    )
+    .replace(
+      "import { checkAuth } from './auth.js?v=11';",
+      'const { checkAuth } = deps.auth;'
+    )
+    .replace(
+      "import { writeBatch, doc, setDoc, addDoc, onSnapshot } from './firebase.js?v=10';",
+      ''
+    )
+    .replace(
+      "import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';",
+      'const { getAI, getGenerativeModel, GoogleAIBackend } = deps.firebaseAi;'
+    )
+    .replace(
+      "import { getApp } from './vendor/firebase-app.js';",
+      'const { getApp } = deps.firebaseApp;'
+    )
+    .replace(
+      "import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './live-tracker-notes.js?v=1';",
+      'const { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } = deps.liveTrackerNotes;'
+    )
+    .replace(
+      "import { canApplySubstitution, applySubstitution, resolveFinalScoreForCompletion, acquireSingleFlightLock, releaseSingleFlightLock } from './live-tracker-integrity.js?v=2';",
+      'const { canApplySubstitution, applySubstitution, resolveFinalScoreForCompletion, acquireSingleFlightLock, releaseSingleFlightLock } = deps.liveTrackerIntegrity;'
+    )
+    .replace(
+      "import { hydrateOpponentStats } from './live-tracker-opponent-stats.js?v=1';",
+      'const { hydrateOpponentStats } = deps.liveTrackerOpponentStats;'
+    )
+    .replace(
+      "import { buildPersistedResumeClockState, deriveResumeClockState } from './live-tracker-resume.js?v=3';",
+      'const { buildPersistedResumeClockState, deriveResumeClockState } = deps.liveTrackerResume;'
+    )
+    .replace(
+      "import { restoreLiveLineup } from './live-tracker-lineup.js?v=1';",
+      'const { restoreLiveLineup } = deps.liveTrackerLineup;'
+    )
+    .replace(
+      "import { resolveFinalScore, resolveSummaryRecipient } from './live-tracker-email.js?v=2';",
+      'const { resolveFinalScore, resolveSummaryRecipient } = deps.liveTrackerEmail;'
+    )
+    .replace(
+      "import { buildLiveResetEvent } from './live-tracker-reset.js?v=1';",
+      'const { buildLiveResetEvent } = deps.liveTrackerReset;'
+    )
+    .replace(
+      "import { advanceLiveChatUnreadState } from './live-tracker-chat-unread.js?v=2';",
+      'const { advanceLiveChatUnreadState } = deps.liveTrackerChatUnread;'
+    )
+    .replace(
+      "import { resolveLiveStatConfig, resolveLiveStatColumns } from './live-game-state.js?v=3';",
+      'const { resolveLiveStatConfig, resolveLiveStatColumns } = deps.liveGameState;'
+    )
+    .replace(
+      "import { getDefaultLivePeriod, getSportPeriodLabels } from './live-sport-config.js?v=1';",
+      'const { getDefaultLivePeriod, getSportPeriodLabels } = deps.liveSportConfig;'
+    )
+    .replace(
+      "import { buildOpponentStatsSnapshotFromEntries, buildFinishCompletionPlan, executeFinishNavigationPlan } from './live-tracker-finish.js?v=1';",
+      'const { buildOpponentStatsSnapshotFromEntries, buildFinishCompletionPlan, executeFinishNavigationPlan } = deps.liveTrackerFinish;'
+    )
+    .replace(authHook, '')
+    .concat(`
+return {
+  state,
+  els,
+  renderOpponents,
+  setContext(context = {}) {
+    currentTeamId = context.teamId || null;
+    currentGameId = context.gameId || null;
+    currentConfig = context.config || null;
+    currentGame = context.game || null;
+  }
+};`);
+}
+
+const moduleSource = buildModuleSource();
+const runModule = new AsyncFunction(
+  'deps',
+  'window',
+  'document',
+  'console',
+  'setTimeout',
+  'clearTimeout',
+  'alert',
+  moduleSource
+);
+
+async function bootLiveTracker({ updateGame }) {
+  const { document } = createEnvironment();
+  const deps = {
+    db: {
+      getTeam: async () => ({}),
+      getTeams: async () => [],
+      getGame: async () => ({}),
+      getPlayers: async () => [],
+      getConfigs: async () => [],
+      updateGame,
+      collection: () => ({}),
+      getDocs: async () => ({ docs: [], size: 0, forEach() {} }),
+      deleteDoc: async () => {},
+      query: () => ({}),
+      broadcastLiveEvent: async () => {},
+      subscribeLiveChat: () => () => {},
+      postLiveChatMessage: async () => {},
+      setGameLiveStatus: async () => {}
+    },
+    firebase: {
+      db: {},
+      writeBatch: () => ({ set() {}, update() {}, commit: async () => {} }),
+      doc: () => ({}),
+      setDoc: async () => {},
+      addDoc: async () => {},
+      onSnapshot: () => () => {}
+    },
+    utils: {
+      getUrlParams: () => ({}),
+      escapeHtml: value => String(value ?? '')
+    },
+    auth: {
+      checkAuth: () => {}
+    },
+    firebaseAi: {
+      getAI: () => ({}),
+      getGenerativeModel: () => ({ generateContent: async () => ({ response: { text: () => '' } }) }),
+      GoogleAIBackend: class {}
+    },
+    firebaseApp: {
+      getApp: () => ({})
+    },
+    liveTrackerNotes: {
+      isVoiceRecognitionSupported: () => false,
+      normalizeGameNoteText: text => text,
+      appendGameSummaryLine: (summary, line) => `${summary}\n${line}`.trim(),
+      buildGameNoteLogText: text => text
+    },
+    liveTrackerIntegrity: {
+      canApplySubstitution: () => true,
+      applySubstitution: ({ onCourt = [], bench = [] } = {}) => ({ applied: false, onCourt, bench }),
+      resolveFinalScoreForCompletion: () => ({}),
+      acquireSingleFlightLock: () => true,
+      releaseSingleFlightLock: () => {}
+    },
+    liveTrackerOpponentStats: {
+      hydrateOpponentStats
+    },
+    liveTrackerResume: {
+      buildPersistedResumeClockState: () => ({}),
+      deriveResumeClockState: () => ({ restored: false, period: 'Q1', clock: 0 })
+    },
+    liveTrackerLineup: {
+      restoreLiveLineup: () => ({ onCourt: [], bench: [] })
+    },
+    liveTrackerEmail: {
+      resolveFinalScore: value => Number(value || 0),
+      resolveSummaryRecipient: () => ''
+    },
+    liveTrackerReset: {
+      buildLiveResetEvent: () => ({})
+    },
+    liveTrackerChatUnread: {
+      advanceLiveChatUnreadState: state => state
+    },
+    liveGameState: {
+      resolveLiveStatConfig: () => null,
+      resolveLiveStatColumns: () => []
+    },
+    liveSportConfig: {
+      getDefaultLivePeriod: () => 'Q1',
+      getSportPeriodLabels: () => []
+    },
+    liveTrackerFinish: {
+      buildOpponentStatsSnapshotFromEntries: ({ opponentEntries = [], columns = [] } = {}) => {
+        const opponentStats = {};
+        opponentEntries.forEach((opp) => {
+          opponentStats[opp.id] = {
+            name: opp.name || '',
+            number: opp.number || '',
+            playerId: opp.playerId || null,
+            photoUrl: opp.photoUrl || ''
+          };
+          columns.forEach((col) => {
+            const key = col.toLowerCase();
+            opponentStats[opp.id][key] = opp.stats?.[key] || 0;
+          });
+          opponentStats[opp.id].fouls = opp.stats?.fouls || 0;
+        });
+        return opponentStats;
+      },
+      buildFinishCompletionPlan: () => ({}),
+      executeFinishNavigationPlan: () => {}
+    }
+  };
+  const window = { location: { href: '' } };
+
+  return runModule(
+    deps,
+    window,
+    document,
+    console,
+    (callback) => {
+      callback();
+      return 1;
+    },
+    () => {},
+    () => {}
+  );
+}
 
 describe('live tracker opponent stats hydration', () => {
   it('preserves persisted fouls when resuming opponent stats', () => {
@@ -13,5 +330,59 @@ describe('live tracker opponent stats hydration', () => {
     const hydrated = hydrateOpponentStats({ pts: 4 }, ['PTS']);
     expect(hydrated.pts).toBe(4);
     expect(hydrated.fouls).toBe(0);
+  });
+
+  it('persists opponent removals so resume does not restore deleted cards', async () => {
+    const updateCalls = [];
+    const page = await bootLiveTracker({
+      updateGame: async (_teamId, _gameId, payload) => {
+        updateCalls.push(payload);
+      }
+    });
+
+    page.setContext({
+      teamId: 'team-1',
+      gameId: 'game-1',
+      config: { columns: ['PTS'] },
+      game: { liveHasData: false }
+    });
+    page.state.opp = [
+      {
+        id: 'opp1',
+        name: 'Removed Player',
+        number: '10',
+        playerId: null,
+        photoUrl: '',
+        stats: { pts: 4, fouls: 1, time: 0 }
+      },
+      {
+        id: 'opp2',
+        name: 'Remaining Player',
+        number: '12',
+        playerId: null,
+        photoUrl: '',
+        stats: { pts: 7, fouls: 0, time: 0 }
+      }
+    ];
+
+    page.renderOpponents();
+    page.els.oppCards.querySelectorAll('[data-opp-del]')[0].click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(page.state.opp.map((opp) => opp.id)).toEqual(['opp2']);
+    expect(updateCalls).toContainEqual({
+      opponentStats: {
+        opp2: {
+          name: 'Remaining Player',
+          number: '12',
+          playerId: null,
+          photoUrl: '',
+          pts: 7,
+          fouls: 0
+        }
+      }
+    });
+    expect(updateCalls).toContainEqual({ liveHasData: true });
   });
 });

--- a/tests/unit/live-tracker-opponent-stats.test.js
+++ b/tests/unit/live-tracker-opponent-stats.test.js
@@ -206,6 +206,11 @@ function buildModuleSource(source = readFileSync(new URL('../../js/live-tracker.
     './live-tracker-finish.js',
     'const { buildOpponentStatsSnapshotFromEntries, buildFinishCompletionPlan, executeFinishNavigationPlan } = deps.liveTrackerFinish;'
   );
+  rewritten = replaceNamedImportByModulePath(
+    rewritten,
+    './live-tracker-save-complete.js',
+    'const { runSaveAndCompleteWorkflow } = deps.liveTrackerSaveComplete;'
+  );
 
   return rewritten
     .replace(authHook, '')
@@ -340,6 +345,9 @@ async function bootLiveTracker({ updateGame }) {
       },
       buildFinishCompletionPlan: () => ({}),
       executeFinishNavigationPlan: () => {}
+    },
+    liveTrackerSaveComplete: {
+      runSaveAndCompleteWorkflow: async () => ({})
     }
   };
   const window = { location: { href: '' } };

--- a/tests/unit/live-tracker-opponent-stats.test.js
+++ b/tests/unit/live-tracker-opponent-stats.test.js
@@ -93,83 +93,111 @@ function createEnvironment() {
   };
 }
 
+function replaceImport(source, pattern, replacement) {
+  const updated = source.replace(pattern, replacement);
+  if (updated === source) {
+    throw new Error(`Failed to rewrite import for pattern: ${pattern}`);
+  }
+  return updated;
+}
+
 function buildModuleSource() {
   const source = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8');
   const authHook = `checkAuth(async (user) => {\n  if (!user) {\n    window.location.href = 'login.html';\n    return;\n  }\n  currentUser = user;\n  await init();\n});`;
 
-  return source
-    .replace(
-      "import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=15';",
-      'const { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } = deps.db;'
-    )
-    .replace(
-      "import { db } from './firebase.js?v=10';",
-      'const { db, writeBatch, doc, setDoc, addDoc, onSnapshot } = deps.firebase;'
-    )
-    .replace(
-      "import { getUrlParams, escapeHtml } from './utils.js?v=9';",
-      'const { getUrlParams, escapeHtml } = deps.utils;'
-    )
-    .replace(
-      "import { checkAuth } from './auth.js?v=11';",
-      'const { checkAuth } = deps.auth;'
-    )
-    .replace(
-      "import { writeBatch, doc, setDoc, addDoc, onSnapshot } from './firebase.js?v=10';",
-      ''
-    )
-    .replace(
-      "import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';",
-      'const { getAI, getGenerativeModel, GoogleAIBackend } = deps.firebaseAi;'
-    )
-    .replace(
-      "import { getApp } from './vendor/firebase-app.js';",
-      'const { getApp } = deps.firebaseApp;'
-    )
-    .replace(
-      "import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './live-tracker-notes.js?v=1';",
-      'const { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } = deps.liveTrackerNotes;'
-    )
-    .replace(
-      "import { canApplySubstitution, applySubstitution, resolveFinalScoreForCompletion, acquireSingleFlightLock, releaseSingleFlightLock } from './live-tracker-integrity.js?v=2';",
-      'const { canApplySubstitution, applySubstitution, resolveFinalScoreForCompletion, acquireSingleFlightLock, releaseSingleFlightLock } = deps.liveTrackerIntegrity;'
-    )
-    .replace(
-      "import { hydrateOpponentStats } from './live-tracker-opponent-stats.js?v=1';",
-      'const { hydrateOpponentStats } = deps.liveTrackerOpponentStats;'
-    )
-    .replace(
-      "import { buildPersistedResumeClockState, deriveResumeClockState } from './live-tracker-resume.js?v=3';",
-      'const { buildPersistedResumeClockState, deriveResumeClockState } = deps.liveTrackerResume;'
-    )
-    .replace(
-      "import { restoreLiveLineup } from './live-tracker-lineup.js?v=1';",
-      'const { restoreLiveLineup } = deps.liveTrackerLineup;'
-    )
-    .replace(
-      "import { resolveFinalScore, resolveSummaryRecipient } from './live-tracker-email.js?v=2';",
-      'const { resolveFinalScore, resolveSummaryRecipient } = deps.liveTrackerEmail;'
-    )
-    .replace(
-      "import { buildLiveResetEvent } from './live-tracker-reset.js?v=1';",
-      'const { buildLiveResetEvent } = deps.liveTrackerReset;'
-    )
-    .replace(
-      "import { advanceLiveChatUnreadState } from './live-tracker-chat-unread.js?v=2';",
-      'const { advanceLiveChatUnreadState } = deps.liveTrackerChatUnread;'
-    )
-    .replace(
-      "import { resolveLiveStatConfig, resolveLiveStatColumns } from './live-game-state.js?v=3';",
-      'const { resolveLiveStatConfig, resolveLiveStatColumns } = deps.liveGameState;'
-    )
-    .replace(
-      "import { getDefaultLivePeriod, getSportPeriodLabels } from './live-sport-config.js?v=1';",
-      'const { getDefaultLivePeriod, getSportPeriodLabels } = deps.liveSportConfig;'
-    )
-    .replace(
-      "import { buildOpponentStatsSnapshotFromEntries, buildFinishCompletionPlan, executeFinishNavigationPlan } from './live-tracker-finish.js?v=1';",
-      'const { buildOpponentStatsSnapshotFromEntries, buildFinishCompletionPlan, executeFinishNavigationPlan } = deps.liveTrackerFinish;'
-    )
+  let rewritten = source;
+  rewritten = replaceImport(
+    rewritten,
+    /import\s*\{\s*getTeam,\s*getTeams,\s*getGame,\s*getPlayers,\s*getConfigs,\s*updateGame,\s*collection,\s*getDocs,\s*deleteDoc,\s*query,\s*broadcastLiveEvent,\s*subscribeLiveChat,\s*postLiveChatMessage,\s*setGameLiveStatus\s*\}\s*from\s*['"]\.\/db\.js(?:\?v=[^'"]+)?['"];/,
+    'const { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } = deps.db;'
+  );
+  rewritten = replaceImport(
+    rewritten,
+    /import\s*\{\s*db\s*\}\s*from\s*['"]\.\/firebase\.js(?:\?v=[^'"]+)?['"];/,
+    'const { db, writeBatch, doc, setDoc, addDoc, onSnapshot } = deps.firebase;'
+  );
+  rewritten = replaceImport(
+    rewritten,
+    /import\s*\{\s*getUrlParams,\s*escapeHtml\s*\}\s*from\s*['"]\.\/utils\.js(?:\?v=[^'"]+)?['"];/,
+    'const { getUrlParams, escapeHtml } = deps.utils;'
+  );
+  rewritten = replaceImport(
+    rewritten,
+    /import\s*\{\s*checkAuth\s*\}\s*from\s*['"]\.\/auth\.js(?:\?v=[^'"]+)?['"];/,
+    'const { checkAuth } = deps.auth;'
+  );
+  rewritten = replaceImport(
+    rewritten,
+    /import\s*\{\s*writeBatch,\s*doc,\s*setDoc,\s*addDoc,\s*onSnapshot\s*\}\s*from\s*['"]\.\/firebase\.js(?:\?v=[^'"]+)?['"];\s*/,
+    ''
+  );
+  rewritten = replaceImport(
+    rewritten,
+    /import\s*\{\s*getAI,\s*getGenerativeModel,\s*GoogleAIBackend\s*\}\s*from\s*['"]\.\/vendor\/firebase-ai\.js['"];/,
+    'const { getAI, getGenerativeModel, GoogleAIBackend } = deps.firebaseAi;'
+  );
+  rewritten = replaceImport(
+    rewritten,
+    /import\s*\{\s*getApp\s*\}\s*from\s*['"]\.\/vendor\/firebase-app\.js['"];/,
+    'const { getApp } = deps.firebaseApp;'
+  );
+  rewritten = replaceImport(
+    rewritten,
+    /import\s*\{\s*isVoiceRecognitionSupported,\s*normalizeGameNoteText,\s*appendGameSummaryLine,\s*buildGameNoteLogText\s*\}\s*from\s*['"]\.\/live-tracker-notes\.js(?:\?v=[^'"]+)?['"];/,
+    'const { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } = deps.liveTrackerNotes;'
+  );
+  rewritten = replaceImport(
+    rewritten,
+    /import\s*\{\s*canApplySubstitution,\s*applySubstitution,\s*resolveFinalScoreForCompletion,\s*acquireSingleFlightLock,\s*releaseSingleFlightLock\s*\}\s*from\s*['"]\.\/live-tracker-integrity\.js(?:\?v=[^'"]+)?['"];/,
+    'const { canApplySubstitution, applySubstitution, resolveFinalScoreForCompletion, acquireSingleFlightLock, releaseSingleFlightLock } = deps.liveTrackerIntegrity;'
+  );
+  rewritten = replaceImport(
+    rewritten,
+    /import\s*\{\s*hydrateOpponentStats\s*\}\s*from\s*['"]\.\/live-tracker-opponent-stats\.js(?:\?v=[^'"]+)?['"];/,
+    'const { hydrateOpponentStats } = deps.liveTrackerOpponentStats;'
+  );
+  rewritten = replaceImport(
+    rewritten,
+    /import\s*\{\s*buildPersistedResumeClockState,\s*deriveResumeClockState\s*\}\s*from\s*['"]\.\/live-tracker-resume\.js(?:\?v=[^'"]+)?['"];/,
+    'const { buildPersistedResumeClockState, deriveResumeClockState } = deps.liveTrackerResume;'
+  );
+  rewritten = replaceImport(
+    rewritten,
+    /import\s*\{\s*restoreLiveLineup\s*\}\s*from\s*['"]\.\/live-tracker-lineup\.js(?:\?v=[^'"]+)?['"];/,
+    'const { restoreLiveLineup } = deps.liveTrackerLineup;'
+  );
+  rewritten = replaceImport(
+    rewritten,
+    /import\s*\{\s*resolveFinalScore,\s*resolveSummaryRecipient\s*\}\s*from\s*['"]\.\/live-tracker-email\.js(?:\?v=[^'"]+)?['"];/,
+    'const { resolveFinalScore, resolveSummaryRecipient } = deps.liveTrackerEmail;'
+  );
+  rewritten = replaceImport(
+    rewritten,
+    /import\s*\{\s*buildLiveResetEvent\s*\}\s*from\s*['"]\.\/live-tracker-reset\.js(?:\?v=[^'"]+)?['"];/,
+    'const { buildLiveResetEvent } = deps.liveTrackerReset;'
+  );
+  rewritten = replaceImport(
+    rewritten,
+    /import\s*\{\s*advanceLiveChatUnreadState\s*\}\s*from\s*['"]\.\/live-tracker-chat-unread\.js(?:\?v=[^'"]+)?['"];/,
+    'const { advanceLiveChatUnreadState } = deps.liveTrackerChatUnread;'
+  );
+  rewritten = replaceImport(
+    rewritten,
+    /import\s*\{\s*resolveLiveStatConfig,\s*resolveLiveStatColumns\s*\}\s*from\s*['"]\.\/live-game-state\.js(?:\?v=[^'"]+)?['"];/,
+    'const { resolveLiveStatConfig, resolveLiveStatColumns } = deps.liveGameState;'
+  );
+  rewritten = replaceImport(
+    rewritten,
+    /import\s*\{\s*getDefaultLivePeriod,\s*getSportPeriodLabels\s*\}\s*from\s*['"]\.\/live-sport-config\.js(?:\?v=[^'"]+)?['"];/,
+    'const { getDefaultLivePeriod, getSportPeriodLabels } = deps.liveSportConfig;'
+  );
+  rewritten = replaceImport(
+    rewritten,
+    /import\s*\{\s*buildOpponentStatsSnapshotFromEntries,\s*buildFinishCompletionPlan,\s*executeFinishNavigationPlan\s*\}\s*from\s*['"]\.\/live-tracker-finish\.js(?:\?v=[^'"]+)?['"];/,
+    'const { buildOpponentStatsSnapshotFromEntries, buildFinishCompletionPlan, executeFinishNavigationPlan } = deps.liveTrackerFinish;'
+  );
+
+  return rewritten
     .replace(authHook, '')
     .concat(`
 return {
@@ -199,6 +227,8 @@ const runModule = new AsyncFunction(
 
 async function bootLiveTracker({ updateGame }) {
   const { document } = createEnvironment();
+  const scheduledTimeouts = new Map();
+  let nextTimeoutId = 1;
   const deps = {
     db: {
       getTeam: async () => ({}),
@@ -303,19 +333,39 @@ async function bootLiveTracker({ updateGame }) {
     }
   };
   const window = { location: { href: '' } };
+  const setTimeoutStub = (callback) => {
+    const timeoutId = nextTimeoutId++;
+    scheduledTimeouts.set(timeoutId, callback);
+    return timeoutId;
+  };
+  const clearTimeoutStub = (timeoutId) => {
+    scheduledTimeouts.delete(timeoutId);
+  };
+  const flushTimers = async () => {
+    while (scheduledTimeouts.size) {
+      const pending = [...scheduledTimeouts.entries()];
+      scheduledTimeouts.clear();
+      for (const [, callback] of pending) {
+        await callback();
+      }
+      await Promise.resolve();
+    }
+  };
 
-  return runModule(
+  const page = await runModule(
     deps,
     window,
     document,
     console,
-    (callback) => {
-      callback();
-      return 1;
-    },
-    () => {},
+    setTimeoutStub,
+    clearTimeoutStub,
     () => {}
   );
+
+  return {
+    ...page,
+    flushTimers
+  };
 }
 
 describe('live tracker opponent stats hydration', () => {
@@ -367,8 +417,7 @@ describe('live tracker opponent stats hydration', () => {
 
     page.renderOpponents();
     page.els.oppCards.querySelectorAll('[data-opp-del]')[0].click();
-    await Promise.resolve();
-    await Promise.resolve();
+    await page.flushTimers();
 
     expect(page.state.opp.map((opp) => opp.id)).toEqual(['opp2']);
     expect(updateCalls).toContainEqual({


### PR DESCRIPTION
Closes #421

## What changed
- added a live-tracker regression test that boots `js/live-tracker.js`, removes an opponent card through the real `[data-opp-del]` interaction, and asserts the persisted `opponentStats` snapshot no longer includes the deleted opponent
- updated the opponent delete handler in `js/live-tracker.js` to schedule both opponent-stats persistence and `liveHasData` the same way opponent edits and stat updates already do
- persisted the required per-run role synthesis notes under `docs/pr-notes/runs/issue-421-fixer-20260328T194619Z/`

## Why
Removing an opponent card only changed in-memory state, so a reload could rebuild `state.opp` from stale persisted `game.opponentStats` and make the deleted opponent reappear. This patch closes that persistence gap and adds regression coverage around the exact user interaction.

## Validation
- `./node_modules/.bin/vitest run tests/unit/live-tracker-opponent-stats.test.js`
- `./node_modules/.bin/vitest run tests/unit/live-tracker*.test.js`