### PR TITLE
Add accept-invite parent invite regression coverage

### DIFF
--- a/accept-invite.html
+++ b/accept-invite.html
@@ -182,6 +182,31 @@
             getUserProfile,
             markAccessCodeAsUsed
         });
+        const processedInviteKeys = new Set();
+        const inFlightInviteKeys = new Set();
+
+        async function processInviteOnce(userId, code, authEmail) {
+            const normalizedCode = String(code || '').trim().toUpperCase();
+            const inviteKey = `${userId}:${normalizedCode}`;
+
+            if (!normalizedCode) {
+                throw new Error('Invalid or expired invite code');
+            }
+
+            if (processedInviteKeys.has(inviteKey) || inFlightInviteKeys.has(inviteKey)) {
+                return null;
+            }
+
+            inFlightInviteKeys.add(inviteKey);
+
+            try {
+                const inviteResult = await processInvite(userId, code, authEmail);
+                processedInviteKeys.add(inviteKey);
+                return inviteResult;
+            } finally {
+                inFlightInviteKeys.delete(inviteKey);
+            }
+        }
 
         async function init() {
             renderHeader(document.getElementById('header-container'), null);
@@ -211,8 +236,10 @@
 
                     // Process the invite code
                     if (inviteCode) {
-                        const inviteResult = await processInvite(userId, inviteCode, result?.user?.email || email);
-                        showSuccess(inviteResult.message, inviteResult.redirectUrl);
+                        const inviteResult = await processInviteOnce(userId, inviteCode, result?.user?.email || email);
+                        if (inviteResult) {
+                            showSuccess(inviteResult.message, inviteResult.redirectUrl);
+                        }
                     } else {
                         // No invite code - just redirect to dashboard
                         const profile = await getUserProfile(userId);
@@ -237,8 +264,10 @@
                     if (user && inviteCode) {
                         // User is logged in and has an invite code - process it
                         try {
-                            const inviteResult = await processInvite(user.uid, inviteCode, user.email);
-                            showSuccess(inviteResult.message, inviteResult.redirectUrl);
+                            const inviteResult = await processInviteOnce(user.uid, inviteCode, user.email);
+                            if (inviteResult) {
+                                showSuccess(inviteResult.message, inviteResult.redirectUrl);
+                            }
                         } catch (error) {
                             console.error('Error processing invite:', error);
                             showError(error.message);
@@ -330,8 +359,10 @@
                 }
 
                 try {
-                    const inviteResult = await processInvite(user.uid, code, user.email);
-                    showSuccess(inviteResult.message, inviteResult.redirectUrl);
+                    const inviteResult = await processInviteOnce(user.uid, code, user.email);
+                    if (inviteResult) {
+                        showSuccess(inviteResult.message, inviteResult.redirectUrl);
+                    }
                 } catch (error) {
                     console.error('Error:', error);
                     errorDiv.textContent = error.message || 'Invalid or expired code';

--- a/docs/pr-notes/runs/issue-419-fixer-20260328T202531Z/architecture.md
+++ b/docs/pr-notes/runs/issue-419-fixer-20260328T202531Z/architecture.md
@@ -1,0 +1,17 @@
+Objective: close the coverage gap without widening the runtime blast radius.
+
+Current state:
+- `accept-invite.html` wires auth, DOM state, and invite processing inside one inline module.
+- The shared invite processor already handles parent/admin branching correctly once invoked.
+
+Proposed state:
+- Test the page by executing the real inline module with stubbed imports and a lightweight mock DOM.
+- Keep the runtime fix inside `accept-invite.html` as a page-scoped guard against duplicate processing for the same user/code pair.
+
+Risk surface and blast radius:
+- The new tests are isolated to one file and do not change production behavior.
+- The runtime change is local to invite processing entry points and does not modify Firestore logic or shared auth utilities.
+
+Tradeoffs:
+- This is not a full browser-plus-Firebase integration test.
+- It is the smallest change that verifies the page contract users depend on and guards the duplicate-auth edge case.

--- a/docs/pr-notes/runs/issue-419-fixer-20260328T202531Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-419-fixer-20260328T202531Z/code-plan.md
@@ -1,0 +1,8 @@
+Objective: make the smallest safe patch that closes issue #419.
+
+Plan:
+1. Add `tests/unit/accept-invite-page.test.js` to execute the real inline module with mocked imports and DOM state.
+2. Write one test for authenticated parent invite success plus duplicate-auth idempotency.
+3. Write one test for logged-out manual code redirect, then authenticated continuation with single redemption.
+4. Patch `accept-invite.html` with a page-local guard that suppresses duplicate processing for the same `userId` and invite code while preserving retry on failure.
+5. Run targeted Vitest commands and commit the test plus runtime fix together.

--- a/docs/pr-notes/runs/issue-419-fixer-20260328T202531Z/qa.md
+++ b/docs/pr-notes/runs/issue-419-fixer-20260328T202531Z/qa.md
@@ -1,0 +1,17 @@
+Objective: prove the parent invite flow works from the page entry point and stays idempotent under auth churn.
+
+Coverage plan:
+- Boot `accept-invite.html?code=AB12CD34` with an authenticated parent and verify:
+- `validateAccessCode`, `redeemParentInvite`, and `getTeam` are used
+- success copy includes player and team context
+- redirect lands on `parent-dashboard.html`
+- duplicate auth callbacks do not redeem twice
+- Boot the page logged out, submit `ab12cd34`, and verify redirect to `login.html?code=AB12CD34&type=parent`.
+- Reboot the page as authenticated after that redirect and verify invite redemption still occurs exactly once.
+
+Regression guardrails:
+- Assert on user-visible state and redirect target, not just helper calls.
+- Fail the test if the same invite is redeemed twice in one page session.
+
+Validation:
+- Run focused Vitest for the new page test file, then rerun the touched invite-flow unit test alongside it.

--- a/docs/pr-notes/runs/issue-419-fixer-20260328T202531Z/requirements.md
+++ b/docs/pr-notes/runs/issue-419-fixer-20260328T202531Z/requirements.md
@@ -1,0 +1,23 @@
+Objective: add coverage for the real parent invite redemption flow in `accept-invite.html` and prevent regressions that strand invited parents after login.
+
+Current state:
+- `js/accept-invite-flow.js` is unit-tested, but the page workflow is not.
+- `accept-invite.html` contains the auth callback, success UI, manual code form, and redirect behavior that real users hit.
+- Repeated auth callbacks can re-enter the page flow because the page has no local redemption guard.
+
+Proposed state:
+- Add page-level regression coverage for:
+- authenticated parent invite redemption success
+- manual logged-out code submission redirect to `login.html?code=...&type=parent`
+- single redemption even if auth notifies the page more than once
+
+Risk surface and blast radius:
+- This flow controls parent access to team data, so failures block onboarding and team joining.
+- Blast radius is limited to `accept-invite.html`, but the broken path is user-facing and high-value.
+
+Assumptions:
+- Parent invite redemption should happen once per page session for a given user and code.
+- The existing Vitest harness with mocked DOM/module imports is the right level for this repo.
+
+Recommendation:
+- Add page-level tests around the real inline module and fix the page with the smallest possible state guard.

--- a/tests/unit/accept-invite-page.test.js
+++ b/tests/unit/accept-invite-page.test.js
@@ -1,0 +1,317 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { createInviteProcessor } from '../../js/accept-invite-flow.js';
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+class MockClassList {
+    constructor(initial = []) {
+        this.tokens = new Set(initial);
+    }
+
+    add(...tokens) {
+        tokens.forEach((token) => this.tokens.add(token));
+    }
+
+    remove(...tokens) {
+        tokens.forEach((token) => this.tokens.delete(token));
+    }
+
+    contains(token) {
+        return this.tokens.has(token);
+    }
+}
+
+class MockEvent {
+    constructor(type) {
+        this.type = type;
+        this.defaultPrevented = false;
+        this.target = null;
+        this.currentTarget = null;
+    }
+
+    preventDefault() {
+        this.defaultPrevented = true;
+    }
+}
+
+class MockElement {
+    constructor(id = '') {
+        this.id = id;
+        this.value = '';
+        this.textContent = '';
+        this.disabled = false;
+        this.listeners = new Map();
+        this.classList = new MockClassList(
+            id === 'loading-state'
+                ? []
+                : ['hidden']
+        );
+    }
+
+    addEventListener(type, handler) {
+        const handlers = this.listeners.get(type) || [];
+        handlers.push(handler);
+        this.listeners.set(type, handlers);
+    }
+
+    async dispatchEvent(event) {
+        event.target = this;
+        event.currentTarget = this;
+        const handlers = this.listeners.get(event.type) || [];
+        for (const handler of handlers) {
+            await handler.call(this, event);
+        }
+        return !event.defaultPrevented;
+    }
+}
+
+class MockLocation {
+    constructor(href) {
+        this._href = href;
+    }
+
+    get href() {
+        return this._href;
+    }
+
+    set href(value) {
+        this._href = new URL(value, this._href).toString();
+    }
+
+    get search() {
+        return new URL(this._href).search;
+    }
+
+    get pathname() {
+        return new URL(this._href).pathname;
+    }
+}
+
+function extractAcceptInviteModule() {
+    const html = readFileSync(new URL('../../accept-invite.html', import.meta.url), 'utf8');
+    const match = html.match(/<script type="module">([\s\S]*?)<\/script>/);
+    if (!match) {
+        throw new Error('Accept invite module script not found');
+    }
+
+    return `
+const window = deps.window;
+const document = deps.document;
+const localStorage = window.localStorage;
+const URLSearchParams = deps.URLSearchParams;
+const setTimeout = deps.setTimeout;
+` + match[1]
+        .replace(
+            "import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=11';",
+            'const { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } = deps.auth;'
+        )
+        .replace(
+            "import { validateAccessCode, redeemParentInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=15';",
+            'const { validateAccessCode, redeemParentInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } = deps.db;'
+        )
+        .replace(
+            "import { createInviteProcessor } from './js/accept-invite-flow.js?v=3';",
+            'const { createInviteProcessor } = deps.acceptInviteFlow;'
+        )
+        .replace(
+            "import { renderHeader, renderFooter } from './js/utils.js?v=8';",
+            'const { renderHeader, renderFooter } = deps.utils;'
+        )
+        .replace(/\binit\(\);\s*$/, 'await init();');
+}
+
+const runAcceptInviteModule = new AsyncFunction('deps', extractAcceptInviteModule());
+
+function createStorage(initialEntries = {}) {
+    const state = new Map(Object.entries(initialEntries));
+    return {
+        getItem(key) {
+            return state.has(key) ? state.get(key) : null;
+        },
+        setItem(key, value) {
+            state.set(key, String(value));
+        },
+        removeItem(key) {
+            state.delete(key);
+        }
+    };
+}
+
+function createEnvironment({ href, storage } = {}) {
+    const ids = [
+        'header-container',
+        'footer-container',
+        'loading-state',
+        'email-required-state',
+        'manual-code-state',
+        'success-state',
+        'error-state',
+        'email-form',
+        'email-input',
+        'email-error',
+        'confirm-email-btn',
+        'code-form',
+        'code-input',
+        'code-error',
+        'submit-code-btn',
+        'success-message',
+        'error-message',
+        'try-manual-code-btn'
+    ];
+
+    const elements = new Map(ids.map((id) => [id, new MockElement(id)]));
+    const document = {
+        getElementById(id) {
+            const element = elements.get(id);
+            if (!element) {
+                throw new Error(`Unknown test element: ${id}`);
+            }
+            return element;
+        }
+    };
+
+    const window = {
+        document,
+        location: new MockLocation(href || 'http://example.com/accept-invite.html'),
+        localStorage: storage || createStorage()
+    };
+
+    return { document, elements, window };
+}
+
+async function bootAcceptInvite({
+    href,
+    authUser,
+    authCallbackCount = 1,
+    storageEntries,
+    dbOverrides = {}
+} = {}) {
+    const env = createEnvironment({ href, storage: createStorage(storageEntries) });
+    const db = {
+        validateAccessCode: vi.fn().mockResolvedValue({
+            valid: true,
+            type: 'parent_invite',
+            data: {
+                teamId: 'team-1',
+                playerNum: '22'
+            }
+        }),
+        redeemParentInvite: vi.fn().mockResolvedValue(undefined),
+        redeemAdminInviteAtomically: vi.fn(),
+        updateUserProfile: vi.fn().mockResolvedValue(undefined),
+        updateTeam: vi.fn().mockResolvedValue(undefined),
+        getTeam: vi.fn().mockResolvedValue({ id: 'team-1', name: 'Tigers' }),
+        getUserProfile: vi.fn().mockResolvedValue({}),
+        markAccessCodeAsUsed: vi.fn().mockResolvedValue(undefined),
+        ...dbOverrides
+    };
+    const auth = {
+        isEmailSignInLink: vi.fn(() => false),
+        completeEmailLinkSignIn: vi.fn(),
+        getRedirectUrl: vi.fn(() => 'dashboard.html'),
+        pendingCheckAuth: null,
+        checkAuth: vi.fn((callback) => {
+            auth.pendingCheckAuth = (async () => {
+                for (let index = 0; index < authCallbackCount; index += 1) {
+                    await callback(authUser);
+                }
+                return () => {};
+            })();
+            return auth.pendingCheckAuth;
+        })
+    };
+    const previousGlobals = new Map();
+    const globalOverrides = {
+        window: env.window,
+        document: env.document,
+        localStorage: env.window.localStorage,
+        Event: MockEvent,
+        URLSearchParams,
+        setTimeout: (callback) => {
+            callback();
+            return 1;
+        }
+    };
+
+    try {
+        for (const [key, value] of Object.entries(globalOverrides)) {
+            previousGlobals.set(key, Object.getOwnPropertyDescriptor(globalThis, key));
+            Object.defineProperty(globalThis, key, {
+                configurable: true,
+                writable: true,
+                value
+            });
+        }
+
+        await runAcceptInviteModule({
+            window: env.window,
+            document: env.document,
+            URLSearchParams,
+            setTimeout: globalOverrides.setTimeout,
+            auth,
+            db,
+            utils: {
+                renderHeader: vi.fn(),
+                renderFooter: vi.fn()
+            },
+            acceptInviteFlow: {
+                createInviteProcessor
+            }
+        });
+        await auth.pendingCheckAuth;
+    } finally {
+        for (const [key, descriptor] of previousGlobals.entries()) {
+            if (descriptor) {
+                Object.defineProperty(globalThis, key, descriptor);
+            } else {
+                delete globalThis[key];
+            }
+        }
+    }
+
+    return { ...env, auth, db };
+}
+
+describe('accept-invite page parent flow', () => {
+    it('processes an authenticated parent invite once, shows success, and redirects to the parent dashboard', async () => {
+        const { elements, window, db } = await bootAcceptInvite({
+            href: 'http://example.com/accept-invite.html?code=ab12cd34',
+            authUser: { uid: 'parent-1', email: 'parent@example.com' },
+            authCallbackCount: 2
+        });
+
+        expect(db.validateAccessCode).toHaveBeenCalledOnce();
+        expect(db.redeemParentInvite).toHaveBeenCalledOnce();
+        expect(db.redeemParentInvite).toHaveBeenCalledWith('parent-1', 'ab12cd34');
+        expect(db.getTeam).toHaveBeenCalledWith('team-1');
+        expect(elements.get('success-state').classList.contains('hidden')).toBe(false);
+        expect(elements.get('success-message').textContent).toContain("#22");
+        expect(elements.get('success-message').textContent).toContain('Tigers');
+        expect(window.location.href).toBe('http://example.com/parent-dashboard.html');
+    });
+
+    it('uppercases the manual code for login redirect and redeems exactly once after the user returns authenticated', async () => {
+        const loggedOut = await bootAcceptInvite({
+            href: 'http://example.com/accept-invite.html',
+            authUser: null
+        });
+
+        loggedOut.elements.get('code-input').value = 'ab12cd34';
+        await loggedOut.elements.get('code-form').dispatchEvent(new MockEvent('submit'));
+
+        expect(loggedOut.window.location.href).toBe('http://example.com/login.html?code=AB12CD34&type=parent');
+        expect(loggedOut.db.redeemParentInvite).not.toHaveBeenCalled();
+
+        const authenticated = await bootAcceptInvite({
+            href: 'http://example.com/accept-invite.html?code=AB12CD34&type=parent',
+            authUser: { uid: 'parent-2', email: 'family@example.com' },
+            authCallbackCount: 2
+        });
+
+        expect(authenticated.db.validateAccessCode).toHaveBeenCalledOnce();
+        expect(authenticated.db.redeemParentInvite).toHaveBeenCalledOnce();
+        expect(authenticated.db.redeemParentInvite).toHaveBeenCalledWith('parent-2', 'AB12CD34');
+        expect(authenticated.window.location.href).toBe('http://example.com/parent-dashboard.html');
+    });
+});


### PR DESCRIPTION
Closes #419

## What changed
- added page-level Vitest coverage for `accept-invite.html` that exercises the real parent invite redemption path for authenticated parents
- added coverage for the logged-out manual code path to verify uppercase login redirect behavior and successful redemption after returning authenticated
- hardened `accept-invite.html` with a page-scoped guard so repeated auth callbacks do not redeem the same parent invite more than once
- persisted per-run requirements, architecture, QA, and code-plan notes under `docs/pr-notes/runs/issue-419-fixer-20260328T202531Z/`

## Why
The shared invite processor already had unit coverage, but the actual page workflow did not. That left the parent join flow exposed to regressions in success messaging, redirect behavior, and duplicate invite redemption when auth listeners fire more than once.

## Validation
- `./node_modules/.bin/vitest run tests/unit/accept-invite-page.test.js tests/unit/accept-invite-flow.test.js tests/unit/invite-redirect.test.js`