### PR TITLE
Fix track-live stat undo live sync

### DIFF
--- a/docs/pr-notes/runs/430-remediator-20260328T213604Z/architecture.md
+++ b/docs/pr-notes/runs/430-remediator-20260328T213604Z/architecture.md
@@ -1,0 +1,10 @@
+Decision: keep the fix inside `window.undoLogEntry` in `track-live.html`.
+
+Why:
+- The bug originates where local clamping and live-event emission diverge.
+- A local variable for the effective undo delta keeps the change minimal and reviewable.
+
+Controls:
+- No schema changes.
+- No changes to broadcast consumers.
+- Existing live event shape is preserved; only `value` becomes accurate.

--- a/docs/pr-notes/runs/430-remediator-20260328T213604Z/code-plan.md
+++ b/docs/pr-notes/runs/430-remediator-20260328T213604Z/code-plan.md
@@ -1,0 +1,5 @@
+Implementation plan:
+1. Read `undoLogEntry` and the live event broadcast helper.
+2. Compute an effective applied delta from `currentVal` and `newVal`.
+3. Use that delta for score rollback and reversed stat broadcasting.
+4. Run a targeted diff/status review, then commit only the scoped changes.

--- a/docs/pr-notes/runs/430-remediator-20260328T213604Z/qa.md
+++ b/docs/pr-notes/runs/430-remediator-20260328T213604Z/qa.md
@@ -1,0 +1,7 @@
+Validation target:
+- Undo a stat when current total is at least the logged value: viewer should receive the full negative delta.
+- Undo a stat after prior corrections reduced the current total below the logged value: viewer should receive only the remaining reversible amount.
+- Undo a stat when current total is already zero: viewer should not receive a negative delta.
+
+Regression watch:
+- Point-like stats (`pts`, `points`, `goals`) must roll back `homeScore` or `awayScore` by the same effective delta used for the stat event.

--- a/docs/pr-notes/runs/430-remediator-20260328T213604Z/requirements.md
+++ b/docs/pr-notes/runs/430-remediator-20260328T213604Z/requirements.md
@@ -1,0 +1,13 @@
+Objective: fix PR thread `PRRT_kwDOQe-T5853e7ZS` in `track-live.html`.
+
+Current state: `undoLogEntry` subtracts the logged stat value locally with a zero clamp, but always emits `-parsedValue` to live viewers.
+Proposed state: emit the actual applied undo delta after clamping so remote totals match the local tracker state.
+
+Risk surface: live stat event consumers and score updates for point-like stats.
+Blast radius: limited to the undo path in `track-live.html`.
+
+Assumptions:
+- Live viewers apply `event.value` directly to running totals.
+- Undo should not force remote totals below zero when the local tracker did not.
+
+Recommendation: compute `appliedDelta = currentVal - newVal`, use it for score rollback, and publish `-appliedDelta`.

--- a/docs/pr-notes/runs/430-review-comment-3005354313-20260328T213552Z/architecture.md
+++ b/docs/pr-notes/runs/430-review-comment-3005354313-20260328T213552Z/architecture.md
@@ -1,0 +1,10 @@
+## Architecture Role Summary
+
+- Blast radius is limited to the tracker undo flow in `track-live.html`.
+- The data contract should preserve control equivalence: `liveEvents.type=stat` must represent the same delta that was actually committed to local tracker state.
+- Smallest safe change: derive `appliedDelta = currentVal - newVal` after clamping, then use `appliedDelta` for:
+  - stat persistence in memory and DOM
+  - point-score rollback
+  - `broadcastReversedStatEvent`
+- Rollback is trivial because the change is isolated to client-side event emission and one unit test.
+- Instrumentation signal: the emitted `liveEvents.value` now matches the user-visible tracker delta in partial-undo scenarios.

--- a/docs/pr-notes/runs/430-review-comment-3005354313-20260328T213552Z/code-plan.md
+++ b/docs/pr-notes/runs/430-review-comment-3005354313-20260328T213552Z/code-plan.md
@@ -1,0 +1,6 @@
+## Code Role Plan
+
+- Patch `window.undoLogEntry` in `track-live.html`.
+- Compute `appliedDelta` separately for opponent and home-player branches using `currentVal - newVal`.
+- Reuse `appliedDelta` for point-score rollback and `broadcastReversedStatEvent({ value: -appliedDelta })`.
+- Update the focused `tests/unit/track-live-live-events.test.js` assertion to require the effective delta variable instead of the old raw logged value.

--- a/docs/pr-notes/runs/430-review-comment-3005354313-20260328T213552Z/qa.md
+++ b/docs/pr-notes/runs/430-review-comment-3005354313-20260328T213552Z/qa.md
@@ -1,0 +1,10 @@
+## QA Role Summary
+
+- Primary regression to cover: stat current value lower than logged undo value should emit only the remaining amount.
+- Manual scenario:
+  1. Record a +3 stat event for a player.
+  2. Correct the stat down by 2.
+  3. Undo the original +3 log entry.
+  4. Verify local stat lands at 0 and the emitted reverse live event is `-1`, not `-3`.
+- Additional check: point stats must roll back `homeScore` or `awayScore` by the same effective delta.
+- Validation target: focused unit test plus targeted source inspection because this repo does not have an end-to-end automated tracker harness.

--- a/docs/pr-notes/runs/430-review-comment-3005354313-20260328T213552Z/requirements.md
+++ b/docs/pr-notes/runs/430-review-comment-3005354313-20260328T213552Z/requirements.md
@@ -1,0 +1,11 @@
+## Requirements Role Summary
+
+- Objective: ensure undoing a logged stat emits the actual reversed delta applied locally, not the original logged amount.
+- Current state: `undoLogEntry` clamps local stat totals at zero but can still publish the full negative logged value into `liveEvents`.
+- Proposed state: compute the effective undo delta after clamping and reuse that value for live stat broadcasting and any score rollback tied to point stats.
+- Risk surface: live viewer totals and visible scoreboard can diverge from the tracker if remote consumers apply a larger negative delta than the tracker actually applied.
+- Assumptions:
+  - `live-game.js` and other viewers rebuild totals from `liveEvents`.
+  - Undo is allowed after prior manual corrections, so the original logged value may exceed the remaining current stat.
+- Recommendation: patch only `track-live.html` and add a focused regression test that asserts the effective delta variable is used in the undo broadcaster.
+- Success measure: undoing a previously corrected stat produces identical post-undo totals locally and in any viewer fed by `liveEvents`.

--- a/docs/pr-notes/runs/issue-426-fixer-20260328T212522Z/architecture.md
+++ b/docs/pr-notes/runs/issue-426-fixer-20260328T212522Z/architecture.md
@@ -1,0 +1,16 @@
+Decision: Fix the publisher, not the consumer.
+
+Why:
+- `js/live-game-state.js` already applies negative `stat` deltas correctly.
+- `js/live-tracker.js` already emits reverse `stat` events on undo/remove.
+- `track-live.html` is the inconsistent producer.
+
+Evidence:
+- `track-live.html` broadcasts `type: 'undo'` with updated score.
+- `track-live.html` does not emit a second `type: 'stat'` event with a negative value in the undo/remove path.
+- The live-game viewer updates score from event payload fields, which explains why score changes but player stat sections remain stale.
+
+Control equivalence:
+- Preserves the existing live event model.
+- Avoids introducing new event types or replay semantics.
+- Keeps downstream consumers aligned with the already-working mobile tracker contract.

--- a/docs/pr-notes/runs/issue-426-fixer-20260328T212522Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-426-fixer-20260328T212522Z/code-plan.md
@@ -1,0 +1,8 @@
+Implementation plan:
+1. Add a source-level unit test for `track-live.html` asserting reverse `stat` broadcasts in stat undo and stat removal flows.
+2. Patch `track-live.html` to emit the reverse `stat` event after publishing the `undo` system event.
+3. Reuse the same payload shape as the working `js/live-tracker.js` contract: `type`, `playerId`, `statKey`, `value`, `isOpponent`, score, period, clock, description, `createdBy`.
+4. Run targeted unit tests.
+
+Blocked orchestration note:
+- The requested `allplays-orchestrator-playbook` skill and `sessions_spawn` tool are not available in this session, so these notes are the direct synthesis fallback.

--- a/docs/pr-notes/runs/issue-426-fixer-20260328T212522Z/qa.md
+++ b/docs/pr-notes/runs/issue-426-fixer-20260328T212522Z/qa.md
@@ -1,0 +1,12 @@
+Primary regression to guard:
+- Undoing or removing a stat in `track-live.html` must decrement the live-game viewer player stat sections, not just the score.
+
+Test strategy:
+- Add a unit test that reads `track-live.html` and asserts the undo/remove code paths publish a reverse `stat` event using a negative value.
+- Run the targeted unit test plus adjacent live-game state tests to confirm the consumer contract still passes.
+
+Manual spot checks recommended:
+- Start a live game in `track-live.html`.
+- Record a player stat.
+- Verify the live-game viewer section increments.
+- Undo/remove the stat and verify both score and player section decrement.

--- a/docs/pr-notes/runs/issue-426-fixer-20260328T212522Z/requirements.md
+++ b/docs/pr-notes/runs/issue-426-fixer-20260328T212522Z/requirements.md
@@ -1,0 +1,23 @@
+Objective: Make live-game player stat sections reflect stat undo and removal actions from `track-live.html`.
+
+Current state:
+- `track-live.html` updates in-page stats and score during undo/remove.
+- It publishes an `undo` system event with refreshed score.
+- It does not publish the matching negative `stat` event needed for the viewer to decrement player sections.
+
+Proposed state:
+- Keep the existing `undo` system event for play-by-play clarity.
+- Also publish a reverse `stat` live event for stat undos and removals so the viewer can reconcile player totals in real time.
+
+Risk surface:
+- Affects only track-live live event publishing for stat undo/remove.
+- No Firestore schema changes.
+- Low blast radius because the viewer already consumes `stat` events.
+
+Assumptions:
+- The live-game viewer is expected to update player stat sections from incremental `liveEvents`.
+- `track-live` stat keys already match the viewer's existing stat handling for positive events.
+
+Recommendation:
+- Add the missing reverse stat broadcast in both stat undo and stat remove flows.
+- Cover it with a unit test that fails on the missing event contract.

--- a/tests/unit/track-live-live-events.test.js
+++ b/tests/unit/track-live-live-events.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readTrackLive() {
+  return readFileSync(new URL('../../track-live.html', import.meta.url), 'utf8');
+}
+
+describe('track-live live event publishing', () => {
+  it('publishes reverse stat events when stats are undone or corrected', () => {
+    const source = readTrackLive();
+
+    expect(source).toContain("type: 'undo'");
+    expect(source).toContain("type: 'stat'");
+    expect(source).toContain('value: -parsedValue');
+    expect(source).toContain('value: -value');
+    expect(source).toContain('description: `Undo stat: ${entry.text}`');
+    expect(source).toContain('description: `Corrected stat: ${statKey.toUpperCase()} adjusted`');
+  });
+});

--- a/tests/unit/track-live-live-events.test.js
+++ b/tests/unit/track-live-live-events.test.js
@@ -11,7 +11,8 @@ describe('track-live live event publishing', () => {
 
     expect(source).toContain("type: 'undo'");
     expect(source).toContain("type: 'stat'");
-    expect(source).toContain('value: -parsedValue');
+    expect(source).toContain('let appliedDelta = 0;');
+    expect(source).toContain('value: -appliedDelta');
     expect(source).toContain('value: -value');
     expect(source).toContain('description: `Undo stat: ${entry.text}`');
     expect(source).toContain('description: `Corrected stat: ${statKey.toUpperCase()} adjusted`');

--- a/track-live.html
+++ b/track-live.html
@@ -941,6 +941,30 @@
             }
         }
 
+        function broadcastReversedStatEvent({ playerId, statKey, value, isOpponent, description }) {
+            const player = !isOpponent ? players.find((entry) => entry.id === playerId) : null;
+            const opponent = isOpponent ? opponentPlayers.find((entry) => entry.id === playerId) : null;
+
+            broadcastLiveEvent(currentTeamId, currentGameId, {
+                type: 'stat',
+                period: gameState.currentPeriod,
+                gameClockMs: gameState.elapsed,
+                homeScore,
+                awayScore,
+                playerId,
+                playerName: player?.name || opponent?.name || null,
+                playerNumber: player?.number || '',
+                statKey,
+                value,
+                isOpponent: !!isOpponent,
+                opponentPlayerName: opponent?.name || null,
+                opponentPlayerNumber: opponent?.number || '',
+                opponentPlayerPhoto: opponent?.photoUrl || '',
+                description,
+                createdBy: currentUser?.uid || null
+            }).catch(console.warn);
+        }
+
         window.setPlayerFieldStatus = function (playerId, status) {
             const now = gameState.isRunning ? Date.now() : null;
             setPlayerFieldStatus(gameState.playerFieldStatus, playerId, status, now);
@@ -1366,6 +1390,13 @@
                 description: `Corrected: ${statKey.toUpperCase()} adjusted`,
                 createdBy: currentUser?.uid || null
             }).catch(console.warn);
+            broadcastReversedStatEvent({
+                playerId,
+                statKey,
+                value: -value,
+                isOpponent,
+                description: `Corrected stat: ${statKey.toUpperCase()} adjusted`
+            });
         };
 
         // Add opponent player
@@ -1811,6 +1842,13 @@
                     description: `Undo: ${entry.text}`,
                     createdBy: currentUser?.uid || null
                 }).catch(console.warn);
+                broadcastReversedStatEvent({
+                    playerId,
+                    statKey,
+                    value: -parsedValue,
+                    isOpponent,
+                    description: `Undo stat: ${entry.text}`
+                });
             }
 
             gameState.gameLog.splice(index, 1);

--- a/track-live.html
+++ b/track-live.html
@@ -1805,15 +1805,17 @@
                 const statEl = document.getElementById(`stat-${playerId}-${statKey}`);
                 const isPoints = statKey === 'pts' || statKey === 'points' || statKey === 'goals';
                 const parsedValue = Number(value) || 0;
+                let appliedDelta = 0;
 
                 if (isOpponent) {
                     const currentVal = Number(gameState.opponentStats[playerId]?.[statKey] || statEl?.textContent || 0);
                     const newVal = Math.max(0, currentVal - parsedValue);
+                    appliedDelta = currentVal - newVal;
                     if (!gameState.opponentStats[playerId]) gameState.opponentStats[playerId] = {};
                     gameState.opponentStats[playerId][statKey] = newVal;
                     if (statEl) statEl.textContent = `${newVal}`;
                     if (isPoints) {
-                        awayScore = Math.max(0, awayScore - parsedValue);
+                        awayScore = Math.max(0, awayScore - appliedDelta);
                         updateScoreDisplay();
                         scheduleScoreSync();
                     }
@@ -1822,10 +1824,11 @@
                     if (!gameState.playerStats[playerId]) gameState.playerStats[playerId] = {};
                     const currentVal = Number(gameState.playerStats[playerId][statKey] || statEl?.textContent || 0);
                     const newVal = Math.max(0, currentVal - parsedValue);
+                    appliedDelta = currentVal - newVal;
                     gameState.playerStats[playerId][statKey] = newVal;
                     if (statEl) statEl.textContent = `${newVal}`;
                     if (isPoints) {
-                        homeScore = Math.max(0, homeScore - parsedValue);
+                        homeScore = Math.max(0, homeScore - appliedDelta);
                         updateScoreDisplay();
                         scheduleScoreSync();
                     }
@@ -1845,7 +1848,7 @@
                 broadcastReversedStatEvent({
                     playerId,
                     statKey,
-                    value: -parsedValue,
+                    value: -appliedDelta,
                     isOpponent,
                     description: `Undo stat: ${entry.text}`
                 });


### PR DESCRIPTION
Closes #426

## What changed
- added a unit test covering the `track-live.html` live-event contract for stat reversals
- updated `track-live.html` to publish reverse `stat` live events when a stat is undone from the game log
- updated `track-live.html` to publish reverse `stat` live events when a stat is corrected with the decrement control
- captured requirements, architecture, QA, and code-plan notes for this run in `docs/pr-notes/runs/issue-426-fixer-20260328T212522Z/`

## Why
The live game viewer already knows how to apply negative stat deltas to player stat sections. `track-live.html` was only broadcasting an `undo` system event with the updated score, so the scoreboard changed but player stat sections stayed stale.

## Validation
- `./node_modules/.bin/vitest run tests/unit/track-live-live-events.test.js`
- `./node_modules/.bin/vitest run tests/unit/live-game-state.test.js tests/unit/live-game-lineup-sync.test.js`