### PR TITLE
Add Game Day RSVP override regression coverage

### DIFF
--- a/docs/pr-notes/runs/432-ci-fix-20260329T024312Z/architecture.md
+++ b/docs/pr-notes/runs/432-ci-fix-20260329T024312Z/architecture.md
@@ -1,0 +1,7 @@
+Objective: Clear PR #432 CI with the smallest safe change.
+
+Current state: `js/game-day-rsvp-controls.js` assumes `loadRsvps()` must return a truthy success flag and does not guarantee a re-render after state refresh. `game-day.html` still imports `js/db.js?v=15` even though `js/db.js` changed in this PR.
+
+Proposed state: Treat only an explicit `false` reload result as failure, re-render the RSVP panel after a successful reload, and bump the `db.js` cache-bust query in `game-day.html`.
+
+Blast radius: Limited to the Game Day RSVP control flow and cache invalidation for `game-day.html`.

--- a/docs/pr-notes/runs/432-ci-fix-20260329T024312Z/code-plan.md
+++ b/docs/pr-notes/runs/432-ci-fix-20260329T024312Z/code-plan.md
@@ -1,0 +1,4 @@
+1. Update `js/game-day-rsvp-controls.js` so only `false` from `loadRsvps()` is treated as failure.
+2. Re-render the RSVP panel after a successful reload so the controller remains correct even when callers only mutate state.
+3. Bump the `game-day.html` import for `js/db.js` from `?v=15` to `?v=16`.
+4. Run the affected unit test, the cache-bust guard, and the unit test CI command.

--- a/docs/pr-notes/runs/432-ci-fix-20260329T024312Z/qa.md
+++ b/docs/pr-notes/runs/432-ci-fix-20260329T024312Z/qa.md
@@ -1,0 +1,9 @@
+Root cause evidence:
+- Unit failure shows `setCoachPlayerRsvp('p1', 'going')` leaves `#rsvp-panel` containing `No Response (1)`.
+- In `js/game-day-rsvp-controls.js`, `await loadRsvps()` is treated as failed when it returns `undefined`, which is a valid outcome for mocks and some wrappers.
+- Cache-bust guard reports `js/db.js changed without a matching db.js version bump in imports.`
+
+Validation plan:
+- Run `npx vitest run tests/unit/game-day-rsvp-controls.test.js`.
+- Run `node scripts/check-critical-cache-bust.mjs`.
+- Run `npm run test:unit:ci` to cover the reported unit check.

--- a/docs/pr-notes/runs/432-remediator-20260329T023640Z/architecture.md
+++ b/docs/pr-notes/runs/432-remediator-20260329T023640Z/architecture.md
@@ -1,0 +1,6 @@
+Architecture note
+
+Risk surface: coach RSVP panel and save status messaging on game-day page.
+Blast radius: one shared controller module and one page-local loader function.
+Control change: preserve existing error rendering in loadRsvps, but prevent stale state from overwriting it after failed refresh.
+Tradeoff: boolean return is a small contract change, but it is simpler and lower risk than introducing exceptions through existing callers.

--- a/docs/pr-notes/runs/432-remediator-20260329T023640Z/code-plan.md
+++ b/docs/pr-notes/runs/432-remediator-20260329T023640Z/code-plan.md
@@ -1,0 +1,5 @@
+Code plan
+
+1. Update game-day.html loadRsvps() to return true on success and false on caught error.
+2. Update js/game-day-rsvp-controls.js to remove manual renderRsvpPanel() call after reload and gate Saved status on the boolean result.
+3. Run lightweight validation and commit only the scoped files.

--- a/docs/pr-notes/runs/432-remediator-20260329T023640Z/qa.md
+++ b/docs/pr-notes/runs/432-remediator-20260329T023640Z/qa.md
@@ -1,0 +1,9 @@
+QA note
+
+Primary regression to check:
+- Successful coach RSVP update still refreshes the panel and shows Saved.
+- Failed RSVP reload leaves the Failed to load RSVPs message visible and shows Save failed instead of Saved.
+
+Validation plan:
+- Module import/syntax check for js/game-day-rsvp-controls.js.
+- Manual follow-up in game-day.html flow if needed because repo has no automated tests.

--- a/docs/pr-notes/runs/432-remediator-20260329T023640Z/requirements.md
+++ b/docs/pr-notes/runs/432-remediator-20260329T023640Z/requirements.md
@@ -1,0 +1,10 @@
+Objective: remediate PR #432 review feedback for RSVP save/reload state.
+
+Current state: setCoachPlayerRsvp saves, awaits loadRsvps(), then always re-renders from state.rsvpBreakdown and shows Saved.
+Proposed state: loadRsvps returns a success boolean; save flow only shows Saved on successful reload and does not manually re-render stale state.
+
+Assumptions:
+- loadRsvps is the canonical renderer for the RSVP panel.
+- Existing callers tolerate a boolean return without changes.
+
+Recommendation: make loadRsvps signal failure instead of relying on side effects alone; keep blast radius to RSVP UI only.

--- a/docs/pr-notes/runs/issue-431-fixer-20260329T022612Z/architecture.md
+++ b/docs/pr-notes/runs/issue-431-fixer-20260329T022612Z/architecture.md
@@ -1,0 +1,21 @@
+# Architecture Role Synthesis
+
+## Current State
+- `game-day.html` contains inline RSVP rendering and submit logic.
+- `js/db.js` mixes Firestore access with per-player breakdown grouping logic.
+- Inline page code is hard to unit test directly.
+
+## Proposed State
+- Move Game Day RSVP panel behavior into a small helper module used by `game-day.html`.
+- Move per-player RSVP breakdown grouping into a pure helper used by `js/db.js`.
+
+## Why
+- Preserves the existing static-page architecture.
+- Creates narrow seams for deterministic Vitest coverage.
+- Keeps Firebase access in `js/db.js` while isolating business rules for grouping and last-write-wins selection.
+
+## Controls
+- No data model changes.
+- No Firestore path changes.
+- No auth/control changes.
+- Blast radius stays within Game Day RSVP rendering and breakdown calculation.

--- a/docs/pr-notes/runs/issue-431-fixer-20260329T022612Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-431-fixer-20260329T022612Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code Role Synthesis
+
+## Planned Changes
+1. Add `tests/unit/game-day-rsvp-controls.test.js` for panel moves, counts, and visible save status.
+2. Add `tests/unit/game-day-rsvp-breakdown.test.js` for persisted last-write-wins grouping.
+3. Add `js/game-day-rsvp-controls.js` for render + submit behavior used by `game-day.html`.
+4. Add `js/game-day-rsvp-breakdown.js` for pure grouped breakdown calculation used by `js/db.js`.
+5. Update `game-day.html` to import and use the RSVP controls helper.
+6. Update `js/db.js` to delegate grouped breakdown calculation to the pure helper.
+
+## Minimal Fix
+- After RSVP save and panel reload, set the status on the current DOM node, not the detached pre-render node.

--- a/docs/pr-notes/runs/issue-431-fixer-20260329T022612Z/qa.md
+++ b/docs/pr-notes/runs/issue-431-fixer-20260329T022612Z/qa.md
@@ -1,0 +1,16 @@
+# QA Role Synthesis
+
+## Primary Regression Targets
+- Coach can move a player between `No Response`, `Going`, `Maybe`, and `Not Going`.
+- Section counts update on each click.
+- Success state reaches visible `Saved` after the async save path completes.
+- Stored RSVP docs resolve by latest timestamp when parent and coach writes overlap.
+
+## Test Strategy
+- Unit test a Game Day RSVP controller/helper with mocked DOM and save/load dependencies.
+- Unit test pure breakdown logic with roster + stored RSVP docs representing reload state.
+- Keep assertions user-visible: section labels/counts, called payloads, and visible status text.
+
+## Residual Risk
+- Full browser wiring remains indirectly covered rather than end-to-end.
+- Firebase permission edge cases remain covered by existing RSVP logic and manual tests.

--- a/docs/pr-notes/runs/issue-431-fixer-20260329T022612Z/requirements.md
+++ b/docs/pr-notes/runs/issue-431-fixer-20260329T022612Z/requirements.md
@@ -1,0 +1,26 @@
+# Requirements Role Synthesis
+
+## Objective
+Add automated coverage for the Game Day coach/admin RSVP override workflow so regressions in player availability, counts, persistence, and overwrite behavior are caught before release.
+
+## Current State
+- Manual guide covers Game Day coach overrides and parent/coach overwrite behavior.
+- No automated test exercises the `game-day.html` panel controls.
+- No automated test proves persisted stored RSVP docs still resolve to the latest write on reload.
+
+## Proposed State
+- Automated test covers coach changing one player from no response to `Going`, `Maybe`, and `Out`.
+- Automated test proves the visible panel regrouping/counts and success status.
+- Automated test proves stored parent + coach RSVP docs resolve with last-write-wins after reload.
+
+## Risk Surface
+- Coach-facing pre-game workflow.
+- Wrong player grouping or stale counts can produce bad lineup decisions.
+- Blast radius is limited to RSVP availability rendering and write-path hydration.
+
+## Assumptions
+- Existing last-write-wins semantics are the intended behavior.
+- A small extraction to helper modules is acceptable if it keeps behavior unchanged and improves testability.
+
+## Recommendation
+Extract only the Game Day RSVP panel rendering/submit flow and player-breakdown logic needed for test coverage. This is the smallest change that gives durable automation without broad page rewrites.

--- a/game-day.html
+++ b/game-day.html
@@ -488,7 +488,7 @@
             getConfigs, updateGame, logStatEvent, updatePlayerStats,
             broadcastLiveEvent, subscribeLiveEvents, subscribeAggregatedStats,
             setGameLiveStatus, submitRsvpForPlayer, postChatMessage
-        } from './js/db.js?v=15';
+        } from './js/db.js?v=16';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=10';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js?v=3';

--- a/game-day.html
+++ b/game-day.html
@@ -506,6 +506,7 @@
             buildMatchReportUrl
         } from './js/game-day-wrapup.js?v=1';
         import { pickBestGameId, normalizeGameDayUrl } from './js/game-day-entry.js?v=1';
+        import { createGameDayRsvpController } from './js/game-day-rsvp-controls.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -610,6 +611,14 @@
             // Unsubs
             unsubscribers: []
         };
+        const gameDayRsvpController = createGameDayRsvpController({
+            state,
+            documentRef: document,
+            escapeHtml,
+            submitRsvpForPlayer,
+            loadRsvps
+        });
+        window.setCoachPlayerRsvp = gameDayRsvpController.setCoachPlayerRsvp;
         let pageInitialized = false;
 
         function getChatStorageKey() {
@@ -1152,84 +1161,12 @@
                 const breakdown = await getRsvpBreakdownByPlayer(state.teamId, state.gameId);
                 state.rsvpBreakdown = breakdown?.grouped || breakdown || null;
                 markAiChatContextDirty();
-                renderRsvpPanel();
+                gameDayRsvpController.renderRsvpPanel();
             } catch (err) {
                 console.error('loadRsvps error', err);
                 document.getElementById('rsvp-panel').innerHTML = '<span class="text-xs text-red-400">Failed to load RSVPs</span>';
             }
         }
-
-        function renderRsvpPanel() {
-            const breakdown = state.rsvpBreakdown;
-            if (!breakdown) return;
-            const el = document.getElementById('rsvp-panel');
-            if (!el) return;
-
-            const going = Array.isArray(breakdown.going) ? breakdown.going : [];
-            const maybe = Array.isArray(breakdown.maybe) ? breakdown.maybe : [];
-            const notGoing = Array.isArray(breakdown.not_going) ? breakdown.not_going : [];
-            const noResponse = Array.isArray(breakdown.not_responded) ? breakdown.not_responded : [];
-
-            const rowActions = (p, currentResponse) => {
-                const mkBtn = (label, response, activeClass, idleClass) => `
-                    <button
-                        onclick="setCoachPlayerRsvp(decodeURIComponent('${encodeURIComponent(p.playerId || '')}'),'${response}')"
-                        class="px-1.5 py-0.5 rounded border text-[10px] font-semibold ${currentResponse === response ? activeClass : idleClass}">
-                        ${label}
-                    </button>`;
-                return `
-                    <span class="ml-1 inline-flex items-center gap-1">
-                        ${mkBtn('Going', 'going', 'bg-green-600 text-white border-green-600', 'bg-white text-green-700 border-green-300 hover:bg-green-50')}
-                        ${mkBtn('Maybe', 'maybe', 'bg-amber-500 text-white border-amber-500', 'bg-white text-amber-700 border-amber-300 hover:bg-amber-50')}
-                        ${mkBtn('Out', 'not_going', 'bg-red-500 text-white border-red-500', 'bg-white text-red-700 border-red-300 hover:bg-red-50')}
-                    </span>
-                `;
-            };
-
-            const chip = (p, responseKey) => `
-                <span class="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 rounded-full text-xs font-medium">
-                    ${p.playerNumber ? `#${p.playerNumber} ` : ''}${escapeHtml(p.playerName)}
-                    ${rowActions(p, responseKey)}
-                </span>
-            `;
-
-            const section = (label, color, players) => {
-                if (!players.length) return '';
-                return `<div class="mb-2">
-                    <div class="text-xs font-semibold ${color} mb-1">${label} (${players.length})</div>
-                    <div class="flex flex-wrap gap-1">${players.map((p) => chip(p, p.response)).join('')}</div>
-                </div>`;
-            };
-
-            el.innerHTML =
-                section('Going', 'text-green-600', going) +
-                section('Maybe', 'text-amber-600', maybe) +
-                section('Not Going', 'text-red-500', notGoing) +
-                section('No Response', 'text-gray-400', noResponse) +
-                '<div id="coach-rsvp-status" class="text-[11px] text-gray-400 mt-2"></div>';
-        }
-
-        window.setCoachPlayerRsvp = async function(playerId, response) {
-            const statusEl = document.getElementById('coach-rsvp-status');
-            if (!playerId || !response) return;
-            try {
-                if (statusEl) statusEl.textContent = 'Saving availability…';
-                await submitRsvpForPlayer(state.teamId, state.gameId, state.user?.uid, {
-                    displayName: state.user?.displayName || state.user?.email || null,
-                    playerId,
-                    response
-                });
-                await loadRsvps();
-                if (statusEl) statusEl.textContent = 'Saved';
-                setTimeout(() => {
-                    const nextStatusEl = document.getElementById('coach-rsvp-status');
-                    if (nextStatusEl) nextStatusEl.textContent = '';
-                }, 1800);
-            } catch (err) {
-                console.error('setCoachPlayerRsvp error', err);
-                if (statusEl) statusEl.textContent = 'Save failed';
-            }
-        };
 
         function renderScoutingNotes() {
             const ta = document.getElementById('scouting-notes');

--- a/game-day.html
+++ b/game-day.html
@@ -1162,9 +1162,11 @@
                 state.rsvpBreakdown = breakdown?.grouped || breakdown || null;
                 markAiChatContextDirty();
                 gameDayRsvpController.renderRsvpPanel();
+                return true;
             } catch (err) {
                 console.error('loadRsvps error', err);
                 document.getElementById('rsvp-panel').innerHTML = '<span class="text-xs text-red-400">Failed to load RSVPs</span>';
+                return false;
             }
         }
 

--- a/js/db.js
+++ b/js/db.js
@@ -42,6 +42,7 @@ import {
 } from './parent-membership-utils.js?v=1';
 import { buildCoachOverrideRsvpDocId, shouldDeleteLegacyRsvpForOverride } from './rsvp-doc-ids.js';
 import { computeEffectiveRsvpSummary } from './rsvp-summary.js?v=1';
+import { buildGameDayRsvpBreakdown } from './game-day-rsvp-breakdown.js?v=1';
 import { normalizeChatAttachments } from './team-chat-media.js';
 import {
     shouldMirrorSharedGame,
@@ -3883,90 +3884,5 @@ export async function getRsvpBreakdownByPlayer(teamId, gameId) {
         getRsvps(teamId, gameId)
     ]);
     const fallbackByUser = await buildFallbackPlayerIdsByUser(teamId, rsvps);
-
-    const byPlayer = new Map();
-    players.forEach((player) => {
-        byPlayer.set(player.id, {
-            playerId: player.id,
-            playerName: player.name || `#${player.number || ''}`.trim() || 'Unknown Player',
-            playerNumber: player.number || '',
-            response: 'not_responded',
-            respondedAt: null,
-            note: null,
-            responderUserId: null
-        });
-    });
-
-    const toMillis = (value) => {
-        if (!value) return 0;
-        if (typeof value?.toMillis === 'function') return value.toMillis();
-        if (value instanceof Date) return value.getTime();
-        const parsed = new Date(value);
-        return Number.isNaN(parsed.getTime()) ? 0 : parsed.getTime();
-    };
-
-    rsvps.forEach((rsvp) => {
-        const ids = resolveRsvpPlayerIds(rsvp, fallbackByUser);
-        if (!ids.length) return;
-        ids.forEach((playerId) => {
-            let existing = byPlayer.get(playerId);
-            if (!existing) {
-                existing = {
-                    playerId,
-                    playerName: 'Former Player',
-                    playerNumber: '',
-                    response: 'not_responded',
-                    respondedAt: null,
-                    note: null,
-                    responderUserId: null
-                };
-            }
-            const existingMillis = toMillis(existing.respondedAt);
-            const nextMillis = toMillis(rsvp.respondedAt);
-            if (nextMillis < existingMillis) return;
-            existing.response = normalizeRsvpResponse(rsvp.response);
-            existing.respondedAt = rsvp.respondedAt || null;
-            existing.note = rsvp.note || null;
-            existing.responderUserId = rsvp.userId || null;
-            byPlayer.set(playerId, existing);
-        });
-    });
-
-    const grouped = {
-        going: [],
-        maybe: [],
-        not_going: [],
-        not_responded: []
-    };
-
-    Array.from(byPlayer.values())
-        .sort((a, b) => {
-            const an = (a.playerNumber ?? '').toString();
-            const bn = (b.playerNumber ?? '').toString();
-            const ai = Number.parseInt(an, 10);
-            const bi = Number.parseInt(bn, 10);
-            const aNum = Number.isFinite(ai);
-            const bNum = Number.isFinite(bi);
-            if (aNum && bNum && ai !== bi) return ai - bi;
-            if (aNum && !bNum) return -1;
-            if (!aNum && bNum) return 1;
-            return (a.playerName || '').localeCompare(b.playerName || '');
-        })
-        .forEach((row) => {
-            const key = row.response === 'going' || row.response === 'maybe' || row.response === 'not_going'
-                ? row.response
-                : 'not_responded';
-            grouped[key].push(row);
-        });
-
-    return {
-        grouped,
-        counts: {
-            going: grouped.going.length,
-            maybe: grouped.maybe.length,
-            notGoing: grouped.not_going.length,
-            notResponded: grouped.not_responded.length,
-            total: players.length
-        }
-    };
+    return buildGameDayRsvpBreakdown({ players, rsvps, fallbackByUser });
 }

--- a/js/game-day-rsvp-breakdown.js
+++ b/js/game-day-rsvp-breakdown.js
@@ -1,0 +1,120 @@
+function normalizeRsvpResponse(response) {
+    if (response === 'going' || response === 'maybe' || response === 'not_going') {
+        return response;
+    }
+    return 'not_responded';
+}
+
+function uniqueNonEmptyIds(ids) {
+    if (!Array.isArray(ids)) return [];
+    return Array.from(new Set(
+        ids.filter((id) => typeof id === 'string' && id.trim())
+    ));
+}
+
+function extractDirectRsvpPlayerIds(rsvp) {
+    const direct = uniqueNonEmptyIds(rsvp?.playerIds);
+    if (direct.length) return direct;
+    const legacy = [];
+    if (typeof rsvp?.playerId === 'string' && rsvp.playerId.trim()) legacy.push(rsvp.playerId.trim());
+    if (typeof rsvp?.childId === 'string' && rsvp.childId.trim()) legacy.push(rsvp.childId.trim());
+    return uniqueNonEmptyIds(legacy);
+}
+
+function resolveRsvpPlayerIds(rsvp, fallbackByUser) {
+    const direct = extractDirectRsvpPlayerIds(rsvp);
+    if (direct.length) return direct;
+    const uid = rsvp?.userId || rsvp?.id;
+    return uid ? uniqueNonEmptyIds(fallbackByUser.get(uid) || []) : [];
+}
+
+function toMillis(value) {
+    if (!value) return 0;
+    if (typeof value?.toMillis === 'function') return value.toMillis();
+    if (value instanceof Date) return value.getTime();
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? 0 : parsed.getTime();
+}
+
+export function buildGameDayRsvpBreakdown({ players, rsvps, fallbackByUser = new Map() }) {
+    const roster = Array.isArray(players) ? players : [];
+    const responses = Array.isArray(rsvps) ? rsvps : [];
+
+    const byPlayer = new Map();
+    roster.forEach((player) => {
+        byPlayer.set(player.id, {
+            playerId: player.id,
+            playerName: player.name || `#${player.number || ''}`.trim() || 'Unknown Player',
+            playerNumber: player.number || '',
+            response: 'not_responded',
+            respondedAt: null,
+            note: null,
+            responderUserId: null
+        });
+    });
+
+    responses.forEach((rsvp) => {
+        const ids = resolveRsvpPlayerIds(rsvp, fallbackByUser);
+        if (!ids.length) return;
+        ids.forEach((playerId) => {
+            let existing = byPlayer.get(playerId);
+            if (!existing) {
+                existing = {
+                    playerId,
+                    playerName: 'Former Player',
+                    playerNumber: '',
+                    response: 'not_responded',
+                    respondedAt: null,
+                    note: null,
+                    responderUserId: null
+                };
+            }
+            const existingMillis = toMillis(existing.respondedAt);
+            const nextMillis = toMillis(rsvp.respondedAt);
+            if (nextMillis < existingMillis) return;
+            existing.response = normalizeRsvpResponse(rsvp.response);
+            existing.respondedAt = rsvp.respondedAt || null;
+            existing.note = rsvp.note || null;
+            existing.responderUserId = rsvp.userId || null;
+            byPlayer.set(playerId, existing);
+        });
+    });
+
+    const grouped = {
+        going: [],
+        maybe: [],
+        not_going: [],
+        not_responded: []
+    };
+
+    Array.from(byPlayer.values())
+        .sort((a, b) => {
+            const an = (a.playerNumber ?? '').toString();
+            const bn = (b.playerNumber ?? '').toString();
+            const ai = Number.parseInt(an, 10);
+            const bi = Number.parseInt(bn, 10);
+            const aNum = Number.isFinite(ai);
+            const bNum = Number.isFinite(bi);
+            if (aNum && bNum && ai !== bi) return ai - bi;
+            if (aNum && !bNum) return -1;
+            if (!aNum && bNum) return 1;
+            return (a.playerName || '').localeCompare(b.playerName || '');
+        })
+        .forEach((row) => {
+            const key = row.response === 'going' || row.response === 'maybe' || row.response === 'not_going'
+                ? row.response
+                : 'not_responded';
+            grouped[key].push(row);
+        });
+
+    return {
+        grouped,
+        counts: {
+            going: grouped.going.length,
+            maybe: grouped.maybe.length,
+            notGoing: grouped.not_going.length,
+            notResponded: grouped.not_responded.length,
+            total: roster.length
+        }
+    };
+}

--- a/js/game-day-rsvp-controls.js
+++ b/js/game-day-rsvp-controls.js
@@ -71,8 +71,10 @@ export function createGameDayRsvpController({
                 playerId,
                 response
             });
-            await loadRsvps();
-            renderRsvpPanel();
+            const reloadSucceeded = await loadRsvps();
+            if (!reloadSucceeded) {
+                throw new Error('RSVP reload failed');
+            }
             const nextStatusEl = getStatusElement(documentRef);
             if (nextStatusEl) nextStatusEl.textContent = 'Saved';
             setTimeoutFn(() => {

--- a/js/game-day-rsvp-controls.js
+++ b/js/game-day-rsvp-controls.js
@@ -1,0 +1,93 @@
+function getStatusElement(documentRef) {
+    return documentRef.getElementById('coach-rsvp-status');
+}
+
+export function createGameDayRsvpController({
+    state,
+    documentRef = document,
+    escapeHtml,
+    submitRsvpForPlayer,
+    loadRsvps,
+    setTimeoutFn = setTimeout,
+    consoleRef = console
+}) {
+    function renderRsvpPanel() {
+        const breakdown = state.rsvpBreakdown;
+        if (!breakdown) return;
+        const el = documentRef.getElementById('rsvp-panel');
+        if (!el) return;
+
+        const going = Array.isArray(breakdown.going) ? breakdown.going : [];
+        const maybe = Array.isArray(breakdown.maybe) ? breakdown.maybe : [];
+        const notGoing = Array.isArray(breakdown.not_going) ? breakdown.not_going : [];
+        const noResponse = Array.isArray(breakdown.not_responded) ? breakdown.not_responded : [];
+
+        const rowActions = (player, currentResponse) => {
+            const mkBtn = (label, response, activeClass, idleClass) => `
+                <button
+                    onclick="setCoachPlayerRsvp(decodeURIComponent('${encodeURIComponent(player.playerId || '')}'),'${response}')"
+                    class="px-1.5 py-0.5 rounded border text-[10px] font-semibold ${currentResponse === response ? activeClass : idleClass}">
+                    ${label}
+                </button>`;
+            return `
+                <span class="ml-1 inline-flex items-center gap-1">
+                    ${mkBtn('Going', 'going', 'bg-green-600 text-white border-green-600', 'bg-white text-green-700 border-green-300 hover:bg-green-50')}
+                    ${mkBtn('Maybe', 'maybe', 'bg-amber-500 text-white border-amber-500', 'bg-white text-amber-700 border-amber-300 hover:bg-amber-50')}
+                    ${mkBtn('Out', 'not_going', 'bg-red-500 text-white border-red-500', 'bg-white text-red-700 border-red-300 hover:bg-red-50')}
+                </span>
+            `;
+        };
+
+        const chip = (player, responseKey) => `
+            <span class="inline-flex items-center gap-1 px-2 py-1 bg-gray-100 rounded-full text-xs font-medium">
+                ${player.playerNumber ? `#${player.playerNumber} ` : ''}${escapeHtml(player.playerName)}
+                ${rowActions(player, responseKey)}
+            </span>
+        `;
+
+        const section = (label, color, players) => {
+            if (!players.length) return '';
+            return `<div class="mb-2">
+                <div class="text-xs font-semibold ${color} mb-1">${label} (${players.length})</div>
+                <div class="flex flex-wrap gap-1">${players.map((player) => chip(player, player.response)).join('')}</div>
+            </div>`;
+        };
+
+        el.innerHTML =
+            section('Going', 'text-green-600', going) +
+            section('Maybe', 'text-amber-600', maybe) +
+            section('Not Going', 'text-red-500', notGoing) +
+            section('No Response', 'text-gray-400', noResponse) +
+            '<div id="coach-rsvp-status" class="text-[11px] text-gray-400 mt-2"></div>';
+    }
+
+    async function setCoachPlayerRsvp(playerId, response) {
+        const statusEl = getStatusElement(documentRef);
+        if (!playerId || !response) return;
+        try {
+            if (statusEl) statusEl.textContent = 'Saving availability...';
+            await submitRsvpForPlayer(state.teamId, state.gameId, state.user?.uid, {
+                displayName: state.user?.displayName || state.user?.email || null,
+                playerId,
+                response
+            });
+            await loadRsvps();
+            renderRsvpPanel();
+            const nextStatusEl = getStatusElement(documentRef);
+            if (nextStatusEl) nextStatusEl.textContent = 'Saved';
+            setTimeoutFn(() => {
+                const currentStatusEl = getStatusElement(documentRef);
+                if (currentStatusEl) currentStatusEl.textContent = '';
+            }, 1800);
+        } catch (err) {
+            consoleRef.error('setCoachPlayerRsvp error', err);
+            const nextStatusEl = getStatusElement(documentRef);
+            if (nextStatusEl) nextStatusEl.textContent = 'Save failed';
+        }
+    }
+
+    return {
+        renderRsvpPanel,
+        setCoachPlayerRsvp
+    };
+}

--- a/js/game-day-rsvp-controls.js
+++ b/js/game-day-rsvp-controls.js
@@ -72,9 +72,10 @@ export function createGameDayRsvpController({
                 response
             });
             const reloadSucceeded = await loadRsvps();
-            if (!reloadSucceeded) {
+            if (reloadSucceeded === false) {
                 throw new Error('RSVP reload failed');
             }
+            renderRsvpPanel();
             const nextStatusEl = getStatusElement(documentRef);
             if (nextStatusEl) nextStatusEl.textContent = 'Saved';
             setTimeoutFn(() => {

--- a/tests/unit/game-day-rsvp-breakdown.test.js
+++ b/tests/unit/game-day-rsvp-breakdown.test.js
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { buildGameDayRsvpBreakdown } from '../../js/game-day-rsvp-breakdown.js';
+
+describe('game day RSVP breakdown', () => {
+    it('keeps the latest stored write for a player after parent and coach overwrite each other', () => {
+        const breakdown = buildGameDayRsvpBreakdown({
+            players: [
+                { id: 'p1', name: 'Avery', number: '7' },
+                { id: 'p2', name: 'Blake', number: '12' }
+            ],
+            rsvps: [
+                {
+                    id: 'parent-1',
+                    userId: 'parent-1',
+                    playerIds: ['p1'],
+                    response: 'going',
+                    respondedAt: '2026-03-29T02:00:00.000Z'
+                },
+                {
+                    id: 'coach-1__p1',
+                    userId: 'coach-1',
+                    playerIds: ['p1'],
+                    response: 'maybe',
+                    respondedAt: '2026-03-29T02:05:00.000Z'
+                },
+                {
+                    id: 'parent-1',
+                    userId: 'parent-1',
+                    playerIds: ['p1'],
+                    response: 'not_going',
+                    respondedAt: '2026-03-29T02:10:00.000Z'
+                }
+            ],
+            fallbackByUser: new Map()
+        });
+
+        expect(breakdown.grouped.going).toEqual([]);
+        expect(breakdown.grouped.maybe).toEqual([]);
+        expect(breakdown.grouped.not_going).toEqual([
+            expect.objectContaining({
+                playerId: 'p1',
+                playerName: 'Avery',
+                playerNumber: '7',
+                response: 'not_going',
+                responderUserId: 'parent-1'
+            })
+        ]);
+        expect(breakdown.grouped.not_responded).toEqual([
+            expect.objectContaining({
+                playerId: 'p2',
+                playerName: 'Blake',
+                response: 'not_responded'
+            })
+        ]);
+        expect(breakdown.counts).toEqual({
+            going: 0,
+            maybe: 0,
+            notGoing: 1,
+            notResponded: 1,
+            total: 2
+        });
+    });
+});

--- a/tests/unit/game-day-rsvp-controls.test.js
+++ b/tests/unit/game-day-rsvp-controls.test.js
@@ -1,0 +1,122 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { createGameDayRsvpController } from '../../js/game-day-rsvp-controls.js';
+
+class MockElement {
+    constructor(id = '', documentRef = null) {
+        this.id = id;
+        this._innerHTML = '';
+        this.textContent = '';
+        this.documentRef = documentRef;
+    }
+
+    set innerHTML(value) {
+        this._innerHTML = value;
+        if (this.documentRef && value.includes('id="coach-rsvp-status"')) {
+            this.documentRef.elements.set('coach-rsvp-status', new MockElement('coach-rsvp-status', this.documentRef));
+        }
+    }
+
+    get innerHTML() {
+        return this._innerHTML;
+    }
+}
+
+function createDocumentRef() {
+    const documentRef = {
+        elements: new Map(),
+        getElementById(id) {
+            return this.elements.get(id) || null;
+        }
+    };
+    documentRef.elements.set('rsvp-panel', new MockElement('rsvp-panel', documentRef));
+    return documentRef;
+}
+
+describe('game day RSVP controls', () => {
+    it('moves a player between sections, updates counts, and shows Saved on the current status element', async () => {
+        const documentRef = createDocumentRef();
+        const state = {
+            teamId: 'team-1',
+            gameId: 'game-1',
+            user: { uid: 'coach-1', displayName: 'Coach One' },
+            rsvpBreakdown: {
+                going: [],
+                maybe: [],
+                not_going: [],
+                not_responded: [
+                    { playerId: 'p1', playerName: 'Avery', playerNumber: '7', response: 'not_responded' }
+                ]
+            }
+        };
+        const submitRsvpForPlayer = vi.fn(async (_teamId, _gameId, _userId, payload) => payload);
+        const loadRsvps = vi.fn(async () => {
+            const latestResponse = submitRsvpForPlayer.mock.calls.at(-1)?.[3]?.response;
+            state.rsvpBreakdown = {
+                going: latestResponse === 'going'
+                    ? [{ playerId: 'p1', playerName: 'Avery', playerNumber: '7', response: 'going' }]
+                    : [],
+                maybe: latestResponse === 'maybe'
+                    ? [{ playerId: 'p1', playerName: 'Avery', playerNumber: '7', response: 'maybe' }]
+                    : [],
+                not_going: latestResponse === 'not_going'
+                    ? [{ playerId: 'p1', playerName: 'Avery', playerNumber: '7', response: 'not_going' }]
+                    : [],
+                not_responded: latestResponse
+                    ? []
+                    : [{ playerId: 'p1', playerName: 'Avery', playerNumber: '7', response: 'not_responded' }]
+            };
+        });
+        const controller = createGameDayRsvpController({
+            state,
+            documentRef,
+            escapeHtml: (value) => String(value ?? ''),
+            submitRsvpForPlayer,
+            loadRsvps,
+            setTimeoutFn: vi.fn()
+        });
+
+        controller.renderRsvpPanel();
+        expect(documentRef.getElementById('rsvp-panel').innerHTML).toContain('No Response (1)');
+
+        await controller.setCoachPlayerRsvp('p1', 'going');
+        expect(documentRef.getElementById('rsvp-panel').innerHTML).toContain('Going (1)');
+        expect(documentRef.getElementById('coach-rsvp-status').textContent).toBe('Saved');
+
+        await controller.setCoachPlayerRsvp('p1', 'maybe');
+        expect(documentRef.getElementById('rsvp-panel').innerHTML).toContain('Maybe (1)');
+        expect(documentRef.getElementById('coach-rsvp-status').textContent).toBe('Saved');
+
+        await controller.setCoachPlayerRsvp('p1', 'not_going');
+        expect(documentRef.getElementById('rsvp-panel').innerHTML).toContain('Not Going (1)');
+        expect(documentRef.getElementById('coach-rsvp-status').textContent).toBe('Saved');
+
+        expect(submitRsvpForPlayer).toHaveBeenNthCalledWith(1, 'team-1', 'game-1', 'coach-1', {
+            displayName: 'Coach One',
+            playerId: 'p1',
+            response: 'going'
+        });
+        expect(submitRsvpForPlayer).toHaveBeenNthCalledWith(2, 'team-1', 'game-1', 'coach-1', {
+            displayName: 'Coach One',
+            playerId: 'p1',
+            response: 'maybe'
+        });
+        expect(submitRsvpForPlayer).toHaveBeenNthCalledWith(3, 'team-1', 'game-1', 'coach-1', {
+            displayName: 'Coach One',
+            playerId: 'p1',
+            response: 'not_going'
+        });
+    });
+});
+
+describe('game day RSVP wiring', () => {
+    it('imports the RSVP controller helper and exports the click handler from that controller', () => {
+        const source = readFileSync(resolve(process.cwd(), 'game-day.html'), 'utf8');
+
+        expect(source).toContain("import { createGameDayRsvpController } from './js/game-day-rsvp-controls.js?v=1';");
+        expect(source).toContain('const gameDayRsvpController = createGameDayRsvpController({');
+        expect(source).toContain('window.setCoachPlayerRsvp = gameDayRsvpController.setCoachPlayerRsvp;');
+        expect(source).toContain('gameDayRsvpController.renderRsvpPanel();');
+    });
+});


### PR DESCRIPTION
Closes #431

## What changed
- added focused Vitest coverage for the Game Day coach RSVP panel flow, including player section moves, count updates, and the visible `Saved` status after async persistence
- added persisted last-write-wins coverage for stored parent and coach RSVP docs so reloads keep the latest player availability
- extracted the Game Day RSVP panel/controller and per-player RSVP breakdown logic into small helpers so the workflow can be tested without broad page rewrites
- wired `game-day.html` to the new controller and updated `js/db.js` to reuse the shared breakdown helper

## Why
The Game Day coach override path was only covered by manual checks even though it directly affects live attendance decisions. This patch closes that gap and fixes a real UI defect where the success message was written to a detached status node after the panel re-rendered, so coaches would not reliably see `Saved`.

## Validation
- `./node_modules/.bin/vitest run tests/unit/game-day-rsvp-controls.test.js tests/unit/game-day-rsvp-breakdown.test.js`
- `./node_modules/.bin/vitest run tests/unit/game-day-rsvp-controls.test.js tests/unit/game-day-rsvp-breakdown.test.js tests/unit/rsvp-summary.test.js tests/unit/rsvp-doc-ids.test.js tests/unit/parent-dashboard-rsvp-controls.test.js tests/unit/game-day-entry.test.js tests/unit/game-day-lineup-publish.test.js tests/unit/game-day-wrapup.test.js`