### PR TITLE
Scope parent dashboard packets to the selected child

### DIFF
--- a/docs/pr-notes/runs/issue-434-fixer-20260329T082503Z/architecture.md
+++ b/docs/pr-notes/runs/issue-434-fixer-20260329T082503Z/architecture.md
@@ -1,0 +1,26 @@
+# Architecture Role
+
+## Decision
+Extract packet-row scoping into reusable helpers in `js/parent-dashboard-packets.js` and consume them from `parent-dashboard.html`.
+
+## Why
+- The defect is data-shaping, not transport or persistence.
+- A shared pure helper keeps the fix reviewable and testable without introducing DOM-heavy tests.
+- The blast radius stays narrow: row rendering and preview controls only.
+
+## Control Equivalence
+- No data model changes.
+- No Firestore path changes.
+- No auth or authorization changes.
+- Completion writes continue to carry an explicit `childId`.
+
+## Minimal Fix Shape
+1. Add a helper that returns the visible child set for a packet row given the selected player id.
+2. Add a helper that computes completed child ids and the scoped completion count.
+3. Update packet card rendering to use the scoped data for:
+   - `Packet Completed`
+   - `Applies to`
+   - visible completion buttons
+
+## Rollback
+Revert the helper usage in `parent-dashboard.html` and the associated helper additions in `js/parent-dashboard-packets.js`.

--- a/docs/pr-notes/runs/issue-434-fixer-20260329T082503Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-434-fixer-20260329T082503Z/code-plan.md
@@ -1,0 +1,17 @@
+# Code Role
+
+## Root Cause
+`renderPracticePackets()` filters row visibility by `selectedPlayerId`, but it still renders `row.childNames`, `row.children`, and the completion denominator from the full family row. A child filter therefore leaves multi-child packet content partially unscoped.
+
+## Planned Change
+1. Extend `js/parent-dashboard-packets.js` with pure helpers for:
+   - visible children for a row
+   - scoped completion summary
+   - child-specific completion request payload
+2. Add focused unit coverage for multi-child scoped rendering data and completion payloads.
+3. Swap `parent-dashboard.html` packet rendering to use the scoped helper outputs.
+
+## Why This Is Smallest Viable
+- No new framework or harness.
+- No refactor of packet data loading.
+- Fix is isolated to the exact row fields that currently ignore the filter.

--- a/docs/pr-notes/runs/issue-434-fixer-20260329T082503Z/qa.md
+++ b/docs/pr-notes/runs/issue-434-fixer-20260329T082503Z/qa.md
@@ -1,0 +1,21 @@
+# QA Role
+
+## Coverage Goal
+Guard against regressions where a multi-child family sees packet UI from the wrong child after filtering.
+
+## Test Focus
+- All players view shows both children and a `0/2` denominator before completion.
+- Single-player filter scopes:
+  - visible child buttons
+  - `Applies to` text
+  - completion denominator
+- Completing one child only marks that child complete and preserves the other child as incomplete.
+- Completion payload remains child-specific.
+
+## Preferred Test Shape
+- Unit tests around shared pure helpers and the completion request payload builder.
+- Avoid brittle HTML snapshot tests.
+
+## Residual Risk
+- Full browser wiring of `#player-filter` is not exercised end-to-end here.
+- Existing integration behavior is still dependent on the page calling the shared helpers correctly.

--- a/docs/pr-notes/runs/issue-434-fixer-20260329T082503Z/requirements.md
+++ b/docs/pr-notes/runs/issue-434-fixer-20260329T082503Z/requirements.md
@@ -1,0 +1,27 @@
+# Requirements Role
+
+## Objective
+Close the parent dashboard coverage gap for multi-child incentive packet behavior.
+
+## Current State
+- Practice packet rows are built per session with all linked children attached to a shared row.
+- The player filter limits which rows render, but not which children render inside a visible row.
+- Existing coverage does not assert multi-child packet counts, child buttons, or child-specific completion state.
+
+## Proposed State
+- Multi-child packet rendering respects the selected child when a specific player filter is active.
+- Packet completion UI remains child-specific and optimistic updates only affect the selected child.
+- Tests cover both all-player and single-player filter states for packet counts, labels, and completion controls.
+
+## Risk Surface
+- Parent-facing workflow.
+- Wrong child scoping is user-visible and can create incorrect trust in incentive progress.
+- Blast radius is limited to parent dashboard packet rendering and completion UI state.
+
+## Assumptions
+- Unit coverage is the repo-standard path for this regression.
+- Existing completion writes are already keyed by `sessionId + childId`; the main product bug is render scoping.
+- The issue-fixer lane does not have access to the requested external subagent runtime, so this note is the direct substitute artifact.
+
+## Recommendation
+Use a shared helper that derives the visible children, names, and completion counts from a row plus selected player id. Reuse it in packet card rendering so the filter affects denominator, labels, and buttons consistently.

--- a/js/parent-dashboard-packets.js
+++ b/js/parent-dashboard-packets.js
@@ -8,6 +8,38 @@ function normalizeTitle(value) {
   return String(value || '').trim().toLowerCase().replace(/\s+/g, ' ');
 }
 
+export function getScopedPracticePacketRow(row, selectedPlayerId = '') {
+  const children = Array.isArray(row?.children) ? row.children : [];
+  const visibleChildren = selectedPlayerId
+    ? children.filter((child) => child?.id === selectedPlayerId)
+    : [...children];
+  const visibleChildIds = new Set(visibleChildren.map((child) => child?.id).filter(Boolean));
+  const visibleChildNames = visibleChildren.map((child) => child?.name).filter(Boolean);
+  const completionChildIds = new Set(
+    (Array.isArray(row?.completions) ? row.completions : [])
+      .filter((completion) => completion?.status === 'completed')
+      .map((completion) => completion?.childId)
+      .filter((childId) => visibleChildIds.has(childId))
+  );
+
+  return {
+    ...row,
+    visibleChildren,
+    visibleChildNames,
+    completionChildIds,
+    completedCount: visibleChildren.filter((child) => completionChildIds.has(child?.id)).length
+  };
+}
+
+export function buildPracticePacketCompletionPayload({ currentUserId, currentUser, childId, childName }) {
+  return {
+    parentUserId: currentUserId,
+    parentName: currentUser?.displayName || currentUser?.email || 'Parent',
+    childId,
+    childName: childName || null
+  };
+}
+
 export function resolvePracticePacketSessionIdForEvent(event, allPracticePacketSessions = []) {
   if (event?.practiceSessionId) return event.practiceSessionId;
   const sessions = Array.isArray(allPracticePacketSessions) ? allPracticePacketSessions : [];

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -288,7 +288,12 @@
             saveCapSetting as saveCapSettingFn,
         } from './js/parent-incentives.js?v=3';
         import { requireAuth, checkAuth } from './js/auth.js?v=10';
-        import { resolvePracticePacketSessionIdForEvent as resolvePracticePacketSessionIdForEventBase, resolvePracticePacketContextForEvent as resolvePracticePacketContextForEventBase } from './js/parent-dashboard-packets.js?v=2';
+        import {
+            resolvePracticePacketSessionIdForEvent as resolvePracticePacketSessionIdForEventBase,
+            resolvePracticePacketContextForEvent as resolvePracticePacketContextForEventBase,
+            getScopedPracticePacketRow as getScopedPracticePacketRowBase,
+            buildPracticePacketCompletionPayload as buildPracticePacketCompletionPayloadBase
+        } from './js/parent-dashboard-packets.js?v=3';
         import { filterVisiblePracticeSessions } from './js/parent-dashboard-practice-sessions.js?v=1';
         import { resolveRsvpPlayerIdsForSubmission, resolveMyRsvpByChildForGame } from './js/parent-dashboard-rsvp.js?v=5';
         import { createParentDashboardRsvpController } from './js/parent-dashboard-rsvp-controls.js?v=1';
@@ -802,6 +807,10 @@
 
         function resolvePracticePacketContextForEvent(event) {
             return resolvePracticePacketContextForEventBase(event, allPracticePacketSessions);
+        }
+
+        function getScopedPracticePacketRow(row, selectedPlayerId = '') {
+            return getScopedPracticePacketRowBase(row, selectedPlayerId);
         }
 
         async function init() {
@@ -1534,20 +1543,22 @@
             card.classList.remove('hidden');
             practicePacketSessionMap.clear();
             list.innerHTML = rows.map((row) => {
+                const scopedRow = getScopedPracticePacketRow(row, selectedPlayerId);
                 const dateStr = row.date.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
                 const timeStr = row.date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
                 const blocks = Array.isArray(row.homePacket?.blocks) ? row.homePacket.blocks : [];
                 const homePacketReady = blocks.length > 0;
                 const totalMinutes = row.homePacket?.totalMinutes || blocks.reduce((sum, b) => sum + (parseInt(b?.duration, 10) || 0), 0);
                 const preview = blocks.slice(0, 3).map(b => b?.drillTitle || b?.title).filter(Boolean);
-                const names = [...row.childNames];
+                const names = [...scopedRow.visibleChildNames];
                 const att = row.attendance;
                 const attendanceReady = !!(att && Array.isArray(att.players) && att.players.length > 0);
                 const attSummary = attendanceReady
                     ? `${att.players.filter(p => p.status === 'present' || p.status === 'late').length}/${att.players.length} present`
                     : null;
-                const completionChildIds = new Set((row.completions || []).filter(c => c.status === 'completed').map(c => c.childId));
-                const completedCount = (row.children || []).filter(c => completionChildIds.has(c.id)).length;
+                const completionChildIds = scopedRow.completionChildIds;
+                const completedCount = scopedRow.completedCount;
+                const visibleChildren = scopedRow.visibleChildren;
                 practicePacketSessionMap.set(row.sessionId, row);
                 return `
                     <div class="p-5">
@@ -1568,12 +1579,12 @@
                         <div class="mt-2 text-xs ${attendanceReady ? 'text-amber-800 bg-amber-50 border-amber-100' : 'text-gray-600 bg-gray-50 border-gray-200'} border rounded px-2 py-1 inline-block">
                             ${attendanceReady ? `Attendance: ${attSummary}` : 'Attendance: Not recorded yet'}
                         </div>
-                        ${homePacketReady ? `<div class="mt-2 text-xs text-emerald-800 bg-emerald-50 border border-emerald-100 rounded px-2 py-1 inline-block">Packet Completed: ${completedCount}/${(row.children || []).length}</div>` : ''}
+                        ${homePacketReady ? `<div class="mt-2 text-xs text-emerald-800 bg-emerald-50 border border-emerald-100 rounded px-2 py-1 inline-block">Packet Completed: ${completedCount}/${visibleChildren.length}</div>` : ''}
                         ${preview.length ? `<p class="mt-2 text-xs text-gray-700">${escapeHtml(preview.join(' • '))}</p>` : ''}
                         ${names.length ? `<p class="mt-2 text-[11px] text-gray-500">Applies to: ${escapeHtml(names.join(', '))}</p>` : ''}
-                        ${homePacketReady && (row.children || []).length ? `
+                        ${homePacketReady && visibleChildren.length ? `
                             <div class="mt-2 flex flex-wrap gap-2">
-                                ${(row.children || []).map(child => {
+                                ${visibleChildren.map(child => {
                                     const done = completionChildIds.has(child.id);
                                     return `<button onclick="markPracticePacketComplete('${row.sessionId}', '${child.id}')" class="text-[11px] px-2 py-1 rounded border ${done ? 'bg-emerald-50 text-emerald-700 border-emerald-200' : 'bg-white text-gray-700 border-gray-200 hover:bg-gray-50'}">${done ? 'Completed' : 'Mark Complete'}: ${escapeHtml(child.name || 'Child')}</button>`;
                                 }).join('')}
@@ -1590,19 +1601,17 @@
             const child = (row.children || []).find(c => c.id === childId) || null;
             try {
                 await ensureParentTeamAccess(currentUserId, [row.teamId]);
-                await upsertPracticePacketCompletion(row.teamId, sessionId, {
-                    parentUserId: currentUserId,
-                    parentName: currentUser?.displayName || currentUser?.email || 'Parent',
+                const completionPayload = buildPracticePacketCompletionPayloadBase({
+                    currentUserId,
+                    currentUser,
                     childId,
                     childName: child?.name || null
                 });
+                await upsertPracticePacketCompletion(row.teamId, sessionId, completionPayload);
                 const existing = Array.isArray(row.completions) ? row.completions : [];
                 const next = existing.filter(c => !(c.childId === childId && c.parentUserId === currentUserId));
                 next.push({
-                    parentUserId: currentUserId,
-                    parentName: currentUser?.displayName || currentUser?.email || 'Parent',
-                    childId,
-                    childName: child?.name || null,
+                    ...completionPayload,
                     status: 'completed'
                 });
                 row.completions = next;
@@ -1642,8 +1651,10 @@
             if (!content) return;
             const blocks = row.homePacket.blocks;
             const total = row.homePacket.totalMinutes || blocks.reduce((sum, b) => sum + (parseInt(b?.duration, 10) || 0), 0);
-            const completionChildIds = new Set((row.completions || []).filter(c => c.status === 'completed').map(c => c.childId));
-            const completionControls = (row.children || []).map(child => {
+            const selectedPlayerId = document.getElementById('player-filter')?.value || '';
+            const scopedRow = getScopedPracticePacketRow(row, selectedPlayerId);
+            const completionChildIds = scopedRow.completionChildIds;
+            const completionControls = scopedRow.visibleChildren.map(child => {
                 const done = completionChildIds.has(child.id);
                 return `<button onclick="markPracticePacketComplete('${row.sessionId}', '${child.id}')" class="text-[11px] px-2 py-1 rounded border ${done ? 'bg-emerald-50 text-emerald-700 border-emerald-200' : 'bg-white text-gray-700 border-gray-200 hover:bg-gray-50'}">${done ? 'Completed' : 'Mark Complete'}: ${escapeHtml(child.name || 'Child')}</button>`;
             }).join('');

--- a/tests/unit/parent-dashboard-packets.test.js
+++ b/tests/unit/parent-dashboard-packets.test.js
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { resolvePracticePacketSessionIdForEvent, resolvePracticePacketContextForEvent } from '../../js/parent-dashboard-packets.js';
+import {
+  resolvePracticePacketSessionIdForEvent,
+  resolvePracticePacketContextForEvent,
+  getScopedPracticePacketRow,
+  buildPracticePacketCompletionPayload
+} from '../../js/parent-dashboard-packets.js';
 
 describe('parent dashboard packet session resolver', () => {
   it('returns event practiceSessionId when present', () => {
@@ -91,5 +96,67 @@ describe('parent dashboard packet session resolver', () => {
     );
     expect(result.sessionId).toBeNull();
     expect(result.homePacket).toBeNull();
+  });
+});
+
+describe('parent dashboard packet row scoping', () => {
+  const baseRow = {
+    sessionId: 'session-1',
+    children: [
+      { id: 'p1', name: 'Ava' },
+      { id: 'p2', name: 'Ben' }
+    ],
+    childNames: ['Ava', 'Ben'],
+    completions: []
+  };
+
+  it('keeps both children visible with all players selected', () => {
+    const result = getScopedPracticePacketRow(baseRow, '');
+
+    expect(result.visibleChildren.map((child) => child.name)).toEqual(['Ava', 'Ben']);
+    expect(result.visibleChildNames).toEqual(['Ava', 'Ben']);
+    expect(result.completedCount).toBe(0);
+    expect(result.visibleChildren).toHaveLength(2);
+  });
+
+  it('scopes names buttons and denominator to the selected child', () => {
+    const result = getScopedPracticePacketRow(baseRow, 'p1');
+
+    expect(result.visibleChildren.map((child) => child.name)).toEqual(['Ava']);
+    expect(result.visibleChildNames).toEqual(['Ava']);
+    expect(result.completedCount).toBe(0);
+    expect(result.visibleChildren).toHaveLength(1);
+  });
+
+  it('marks only the completed child when one child finishes the packet', () => {
+    const result = getScopedPracticePacketRow({
+      ...baseRow,
+      completions: [
+        { childId: 'p1', status: 'completed' }
+      ]
+    }, '');
+
+    expect(result.completedCount).toBe(1);
+    expect(result.completionChildIds.has('p1')).toBe(true);
+    expect(result.completionChildIds.has('p2')).toBe(false);
+  });
+});
+
+describe('parent dashboard packet completion payloads', () => {
+  it('builds a child-specific completion write payload', () => {
+    expect(buildPracticePacketCompletionPayload({
+      currentUserId: 'parent-1',
+      currentUser: {
+        displayName: 'Pat Parent',
+        email: 'pat@example.com'
+      },
+      childId: 'p1',
+      childName: 'Ava'
+    })).toEqual({
+      parentUserId: 'parent-1',
+      parentName: 'Pat Parent',
+      childId: 'p1',
+      childName: 'Ava'
+    });
   });
 });


### PR DESCRIPTION
Closes #434

## What changed
- added focused unit coverage for multi-child parent packet rows, including all-player rendering, single-child filter scoping, and child-specific completion payloads
- extracted shared packet-row scoping helpers so the parent dashboard computes visible children, `Applies to` text, and completion counts from the selected player filter
- updated packet completion writes to use a shared payload builder and reused the scoped child set in the packet preview controls
- persisted the required per-run requirements, architecture, QA, and code-plan artifacts under `docs/pr-notes/runs/issue-434-fixer-20260329T082503Z/`

## Why
The parent dashboard was filtering packet rows by child, but still rendering names, buttons, and completion denominators from the full multi-child family row. That could show the wrong child, inflate `Packet Completed` counts, and weaken confidence in the parent incentives flow for multi-child households.

## Validation
- ran `./node_modules/.bin/vitest run tests/unit/parent-dashboard-packets.test.js`
- ran `./node_modules/.bin/vitest run tests/unit/parent-dashboard-practice-sessions.test.js tests/unit/parent-dashboard-rsvp-controls.test.js tests/unit/parent-incentives.test.js`
- ran `./node_modules/.bin/vitest run tests/unit`