### PR TITLE
Add live tracker Save & Complete workflow coverage

### DIFF
--- a/docs/pr-notes/runs/issue-440-fixer-20260331T212511Z/architecture.md
+++ b/docs/pr-notes/runs/issue-440-fixer-20260331T212511Z/architecture.md
@@ -1,0 +1,26 @@
+# Issue #440 Architecture Synthesis
+
+## Current State
+- `js/live-tracker.js` assembles the finish plan, mutates UI state, writes the batch, calls `endLiveBroadcast()`, and executes navigation in one function.
+- `js/live-tracker-finish.js` already isolates plan construction, including score reconciliation and navigation planning.
+
+## Proposed State
+- Introduce a narrow helper module for the executable finish workflow.
+- Keep `saveAndComplete()` as the entrypoint in `js/live-tracker.js`.
+- Move only the workflow body that depends on lock state, inputs, Firestore writes, and navigation into the helper.
+
+## Blast Radius
+- Low. One live tracker call site changes to delegate to a helper.
+- No Firestore schema changes.
+- No HTML changes.
+- No behavior changes intended outside improved testability.
+
+## Control Equivalence
+- Single-flight lock remains the first gate.
+- Button disabling remains tied to the in-flight submission.
+- Batch commit, completion status update, and navigation order remain unchanged.
+- Error recovery still re-enables the button, releases the lock, and removes the temporary reconciliation log entry.
+
+## What Would Change My Mind
+- If importing a helper causes browser-only dependencies to leak into the test runtime.
+- If the extracted seam requires broad state reshaping instead of a narrow dependency object.

--- a/docs/pr-notes/runs/issue-440-fixer-20260331T212511Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-440-fixer-20260331T212511Z/code-plan.md
@@ -1,0 +1,16 @@
+# Issue #440 Code Plan
+
+## Thinking Level
+Medium. The behavior is localized, but correctness depends on preserving ordering and failure handling across multiple side effects.
+
+## Plan
+1. Add a focused workflow helper for the `saveAndComplete()` execution path.
+2. Add fail-first tests that execute the helper with mocked Firestore/UI dependencies.
+3. Update `js/live-tracker.js` to delegate to the helper without changing user-visible behavior.
+4. Run targeted Vitest coverage for live tracker finish modules.
+5. Commit with issue reference once tests pass.
+
+## Constraints
+- Keep the patch targeted.
+- Avoid unrelated refactors in `js/live-tracker.js`.
+- Preserve existing cache-busting import style.

--- a/docs/pr-notes/runs/issue-440-fixer-20260331T212511Z/qa.md
+++ b/docs/pr-notes/runs/issue-440-fixer-20260331T212511Z/qa.md
@@ -1,0 +1,24 @@
+# Issue #440 QA Synthesis
+
+## Primary Regression Targets
+- Saved `homeScore` and `awayScore` match trusted score-log totals, not stale manual inputs.
+- Finish flow updates the game to completed and invokes live completion status handling.
+- Recap email body is built from reconciled totals.
+- Double-click during an in-flight save yields one batch commit and one navigation sequence.
+
+## Planned Automated Checks
+1. Build a finish workflow harness with mocked inputs, log, Firestore batch, and navigation.
+2. Seed `scoreLogIsComplete = true` with a scoring log that conflicts with manual final inputs.
+3. Assert:
+   - game update uses reconciled totals
+   - reconciliation note is inserted into the saved log
+   - email body sees reconciled totals
+   - completion logic runs
+4. Hold the first commit pending, invoke the workflow twice, and assert:
+   - second call returns without committing
+   - finish button stays disabled during the in-flight save
+   - one mailto/redirect sequence runs after resolution
+
+## Residual Risk
+- This remains a unit-style harness, not a full browser DOM integration test.
+- End-to-end wiring from the actual click listener to `saveAndComplete()` is still covered indirectly by the module call path rather than by browser automation.

--- a/docs/pr-notes/runs/issue-440-fixer-20260331T212511Z/requirements.md
+++ b/docs/pr-notes/runs/issue-440-fixer-20260331T212511Z/requirements.md
@@ -1,0 +1,29 @@
+# Issue #440 Requirements Synthesis
+
+## Objective
+Add automated coverage for the live tracker "Save & Complete" finalization path so regressions in final score persistence, completion state, recap composition, and duplicate-submit protection are caught before shipping.
+
+## Current State
+- Helper-level score reconciliation is covered.
+- Helper-level single-flight locking is covered.
+- Email finish wiring is only covered by source inspection.
+- The composed finish workflow in `saveAndComplete()` is not executed in tests.
+
+## Proposed State
+- A test executes the finish workflow with mocked Firestore and navigation dependencies.
+- Coverage proves the persisted game update uses reconciled totals from the score log when the log is trusted.
+- Coverage proves completion status logic runs before navigation side effects.
+- Coverage proves a second finish click is ignored while the first submission is in flight.
+
+## Risk Surface
+- Incorrect final score saved to the game document.
+- `liveStatus` left live instead of completed.
+- Summary email composed from stale manual scores.
+- Duplicate events, duplicate stats writes, or repeated redirect/mailto on double-click.
+
+## Assumptions
+- Existing unit tests under `tests/unit` are the correct automation surface for this repo despite older docs mentioning manual testing only.
+- A small extraction seam is acceptable if behavior is unchanged and the user-facing workflow remains owned by `saveAndComplete()`.
+
+## Recommendation
+Extract the finish execution path into a testable helper and cover it with focused unit tests. This preserves the existing UI flow while adding evidence for the exact high-risk path called out in the issue.

--- a/js/live-tracker-save-complete.js
+++ b/js/live-tracker-save-complete.js
@@ -1,0 +1,160 @@
+import { acquireSingleFlightLock, releaseSingleFlightLock } from './live-tracker-integrity.js?v=2';
+import { resolveSummaryRecipient } from './live-tracker-email.js?v=2';
+import { buildFinishCompletionPlan, executeFinishNavigationPlan } from './live-tracker-finish.js?v=1';
+
+function defaultFormatClock(ms) {
+  const s = Math.floor(ms / 1000);
+  const m = Math.floor(s / 60).toString().padStart(2, '0');
+  const sec = (s % 60).toString().padStart(2, '0');
+  return `${m}:${sec}`;
+}
+
+export async function runSaveAndCompleteWorkflow({
+  finishSubmissionLock,
+  finishButton,
+  homeFinalInput,
+  awayFinalInput,
+  notesFinalInput,
+  finishSendEmailInput,
+  state,
+  currentTeam,
+  currentGame,
+  currentUser,
+  currentConfig,
+  currentTeamId,
+  currentGameId,
+  roster = [],
+  db,
+  createBatch,
+  createCollectionRef,
+  createDocRef,
+  renderLog = () => {},
+  endLiveBroadcast = async () => {},
+  generateEmailBody = () => '',
+  executeFinishNavigationPlan: executeNavigationPlan = executeFinishNavigationPlan,
+  buildFinishCompletionPlan: buildPlan = buildFinishCompletionPlan,
+  resolveSummaryRecipient: resolveRecipient = resolveSummaryRecipient,
+  acquireLock = acquireSingleFlightLock,
+  releaseLock = releaseSingleFlightLock,
+  formatClock = defaultFormatClock,
+  onFinishStateChange = () => {},
+  alertFn = (message) => {
+    if (typeof alert === 'function') {
+      alert(message);
+    }
+  },
+  now = () => Date.now()
+} = {}) {
+  if (!acquireLock(finishSubmissionLock)) {
+    return { skipped: true, reason: 'locked' };
+  }
+
+  if (finishButton) {
+    finishButton.disabled = true;
+  }
+
+  const rawFinalHome = parseInt(homeFinalInput?.value, 10);
+  const rawFinalAway = parseInt(awayFinalInput?.value, 10);
+  const requestedHome = Number.isNaN(rawFinalHome) ? state.home : rawFinalHome;
+  const requestedAway = Number.isNaN(rawFinalAway) ? state.away : rawFinalAway;
+  const summary = notesFinalInput?.value?.trim() || '';
+  const sendEmail = Boolean(finishSendEmailInput?.checked);
+  const recipientEmail = resolveRecipient({
+    teamNotificationEmail: currentTeam?.notificationEmail,
+    userEmail: currentUser?.email
+  });
+  const finishPlanArgs = {
+    requestedHome,
+    requestedAway,
+    liveHome: state.home,
+    liveAway: state.away,
+    scoreLogIsComplete: state.scoreLogIsComplete,
+    log: state.log,
+    currentPeriod: state.period,
+    currentClock: formatClock(state.clock),
+    summary,
+    sendEmail,
+    teamId: currentTeamId,
+    gameId: currentGameId,
+    teamName: currentTeam?.name || '',
+    opponentName: currentGame?.opponent || 'Unknown Opponent',
+    recipientEmail,
+    columns: currentConfig?.columns || [],
+    roster,
+    statsByPlayerId: state.stats,
+    opponentEntries: state.opp,
+    currentUserUid: currentUser?.uid,
+    buildEmailBody: (finalHome, finalAway, recapSummary, logEntries) => generateEmailBody(finalHome, finalAway, recapSummary, logEntries)
+  };
+
+  let finishPlan = buildPlan(finishPlanArgs);
+  let addedReconciliationLogEntry = null;
+
+  if (finishPlan.scoreReconciliation.mismatch) {
+    addedReconciliationLogEntry = {
+      text: finishPlan.reconciliationNote,
+      ts: now(),
+      period: state.period,
+      clock: formatClock(state.clock)
+    };
+    state.log.unshift(addedReconciliationLogEntry);
+    renderLog();
+    if (homeFinalInput) {
+      homeFinalInput.value = String(finishPlan.finalHome);
+    }
+    if (awayFinalInput) {
+      awayFinalInput.value = String(finishPlan.finalAway);
+    }
+    finishPlan = buildPlan({
+      ...finishPlanArgs,
+      log: state.log
+    });
+  }
+
+  try {
+    const batch = createBatch(db);
+
+    finishPlan.eventWrites.forEach(({ data }) => {
+      const eventRef = createDocRef(createCollectionRef(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
+      batch.set(eventRef, data);
+    });
+
+    finishPlan.aggregatedStatsWrites.forEach(({ playerId, data }) => {
+      const statsRef = createDocRef(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`, playerId);
+      batch.set(statsRef, data);
+    });
+
+    const gameRef = createDocRef(db, `teams/${currentTeamId}/games`, currentGameId);
+    batch.update(gameRef, finishPlan.gameUpdate);
+
+    await batch.commit();
+    await endLiveBroadcast();
+    onFinishStateChange(true);
+
+    executeNavigationPlan(finishPlan.navigation);
+
+    return {
+      skipped: false,
+      finalHome: finishPlan.finalHome,
+      finalAway: finishPlan.finalAway,
+      finishPlan
+    };
+  } catch (error) {
+    if (addedReconciliationLogEntry && state.log[0] === addedReconciliationLogEntry) {
+      state.log.shift();
+      renderLog();
+    }
+    releaseLock(finishSubmissionLock);
+    onFinishStateChange(false);
+    if (finishButton) {
+      finishButton.disabled = false;
+    }
+    console.error('Error finishing game:', error);
+    alertFn('Error finishing game: ' + error.message);
+
+    return {
+      skipped: false,
+      error
+    };
+  }
+}

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -7,16 +7,17 @@ import { writeBatch, doc, setDoc, addDoc, onSnapshot } from './firebase.js?v=10'
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
 import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './live-tracker-notes.js?v=1';
-import { canApplySubstitution, applySubstitution, resolveFinalScoreForCompletion, acquireSingleFlightLock, releaseSingleFlightLock } from './live-tracker-integrity.js?v=2';
+import { canApplySubstitution, applySubstitution } from './live-tracker-integrity.js?v=2';
 import { hydrateOpponentStats } from './live-tracker-opponent-stats.js?v=1';
 import { buildPersistedResumeClockState, deriveResumeClockState } from './live-tracker-resume.js?v=3';
 import { restoreLiveLineup } from './live-tracker-lineup.js?v=1';
-import { resolveFinalScore, resolveSummaryRecipient } from './live-tracker-email.js?v=2';
+import { resolveFinalScore } from './live-tracker-email.js?v=2';
 import { buildLiveResetEvent } from './live-tracker-reset.js?v=1';
 import { advanceLiveChatUnreadState } from './live-tracker-chat-unread.js?v=2';
 import { resolveLiveStatConfig, resolveLiveStatColumns } from './live-game-state.js?v=3';
 import { getDefaultLivePeriod, getSportPeriodLabels } from './live-sport-config.js?v=1';
-import { buildOpponentStatsSnapshotFromEntries, buildFinishCompletionPlan, executeFinishNavigationPlan } from './live-tracker-finish.js?v=1';
+import { buildOpponentStatsSnapshotFromEntries } from './live-tracker-finish.js?v=1';
+import { runSaveAndCompleteWorkflow } from './live-tracker-save-complete.js';
 
 let currentTeamId = null;
 let currentGameId = null;
@@ -1423,101 +1424,33 @@ function generateEmailRecap() {
 }
 
 async function saveAndComplete() {
-  if (!acquireSingleFlightLock(finishSubmissionLock)) return;
-  if (els.finishSave) {
-    els.finishSave.disabled = true;
-  }
-
-  const rawFinalHome = parseInt(els.homeFinal.value, 10);
-  const rawFinalAway = parseInt(els.awayFinal.value, 10);
-  const requestedHome = Number.isNaN(rawFinalHome) ? state.home : rawFinalHome;
-  const requestedAway = Number.isNaN(rawFinalAway) ? state.away : rawFinalAway;
-  const summary = els.notesFinal.value.trim();
-  const sendEmail = els.finishSendEmail?.checked;
-  const recipientEmail = resolveSummaryRecipient({
-    teamNotificationEmail: currentTeam?.notificationEmail,
-    userEmail: currentUser?.email
-  });
-  const finishPlanArgs = {
-    requestedHome,
-    requestedAway,
-    liveHome: state.home,
-    liveAway: state.away,
-    scoreLogIsComplete: state.scoreLogIsComplete,
-    log: state.log,
-    currentPeriod: state.period,
-    currentClock: formatClock(state.clock),
-    summary,
-    sendEmail,
-    teamId: currentTeamId,
-    gameId: currentGameId,
-    teamName: currentTeam?.name || '',
-    opponentName: currentGame?.opponent || 'Unknown Opponent',
-    recipientEmail,
-    columns: currentConfig?.columns || [],
+  await runSaveAndCompleteWorkflow({
+    finishSubmissionLock,
+    finishButton: els.finishSave,
+    homeFinalInput: els.homeFinal,
+    awayFinalInput: els.awayFinal,
+    notesFinalInput: els.notesFinal,
+    finishSendEmailInput: els.finishSendEmail,
+    state,
+    currentTeam,
+    currentGame,
+    currentUser,
+    currentConfig,
+    currentTeamId,
+    currentGameId,
     roster,
-    statsByPlayerId: state.stats,
-    opponentEntries: state.opp,
-    currentUserUid: currentUser?.uid,
-    buildEmailBody: (finalHome, finalAway, recapSummary, logEntries) => generateEmailBody(finalHome, finalAway, recapSummary, logEntries)
-  };
-  let finishPlan = buildFinishCompletionPlan(finishPlanArgs);
-  let addedReconciliationLogEntry = null;
-
-  if (finishPlan.scoreReconciliation.mismatch) {
-    addedReconciliationLogEntry = {
-      text: finishPlan.reconciliationNote,
-      ts: Date.now(),
-      period: state.period,
-      clock: formatClock(state.clock)
-    };
-    state.log.unshift(addedReconciliationLogEntry);
-    renderLog();
-    els.homeFinal.value = String(finishPlan.finalHome);
-    els.awayFinal.value = String(finishPlan.finalAway);
-    finishPlan = buildFinishCompletionPlan({
-      ...finishPlanArgs,
-      log: state.log
-    });
-  }
-
-  try {
-    const batch = writeBatch(db);
-
-    // 1. Write all game log events
-    finishPlan.eventWrites.forEach(({ data }) => {
-      const eventRef = doc(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
-      batch.set(eventRef, data);
-    });
-
-    // 2. Write aggregated stats for each player
-    finishPlan.aggregatedStatsWrites.forEach(({ playerId, data }) => {
-      const statsRef = doc(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`, playerId);
-      batch.set(statsRef, data);
-    });
-
-    // 4. Update game doc
-    const gameRef = doc(db, `teams/${currentTeamId}/games`, currentGameId);
-    batch.update(gameRef, finishPlan.gameUpdate);
-
-    await batch.commit();
-    await endLiveBroadcast();
-    isFinishing = true;
-
-    executeFinishNavigationPlan(finishPlan.navigation);
-  } catch (error) {
-    if (addedReconciliationLogEntry && state.log[0] === addedReconciliationLogEntry) {
-      state.log.shift();
-      renderLog();
+    db,
+    createBatch: writeBatch,
+    createCollectionRef: collection,
+    createDocRef: doc,
+    renderLog,
+    endLiveBroadcast,
+    generateEmailBody,
+    formatClock,
+    onFinishStateChange: (value) => {
+      isFinishing = value;
     }
-    releaseSingleFlightLock(finishSubmissionLock);
-    isFinishing = false;
-    if (els.finishSave) {
-      els.finishSave.disabled = false;
-    }
-    console.error('Error finishing game:', error);
-    alert('Error finishing game: ' + error.message);
-  }
+  });
 }
 
 function copyEmailToClipboard() {

--- a/tests/unit/live-tracker-email.test.js
+++ b/tests/unit/live-tracker-email.test.js
@@ -33,13 +33,15 @@ describe('live tracker summary email recipient', () => {
   });
 
   it('wires recipient resolution into live tracker finish flow', () => {
-    const source = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8');
-    expect(source).toContain('resolveSummaryRecipient');
-    expect(source).toContain('teamNotificationEmail: currentTeam?.notificationEmail');
-    expect(source).toContain('buildFinishCompletionPlan');
-    expect(source).toContain('executeFinishNavigationPlan');
-    expect(source).not.toContain('<<<<<<<');
-    expect(source).not.toContain('=======');
-    expect(source).not.toContain('>>>>>>>');
+    const liveTrackerSource = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8');
+    const workflowSource = readFileSync(new URL('../../js/live-tracker-save-complete.js', import.meta.url), 'utf8');
+    expect(liveTrackerSource).toContain('runSaveAndCompleteWorkflow');
+    expect(workflowSource).toContain('resolveSummaryRecipient');
+    expect(workflowSource).toContain('teamNotificationEmail: currentTeam?.notificationEmail');
+    expect(workflowSource).toContain('buildFinishCompletionPlan');
+    expect(workflowSource).toContain('executeFinishNavigationPlan');
+    expect(workflowSource).not.toContain('<<<<<<<');
+    expect(workflowSource).not.toContain('=======');
+    expect(workflowSource).not.toContain('>>>>>>>');
   });
 });

--- a/tests/unit/live-tracker-integrity.test.js
+++ b/tests/unit/live-tracker-integrity.test.js
@@ -182,8 +182,10 @@ describe('live tracker integrity helpers', () => {
   });
 
   it('wires final score completion through the shared integrity helper in live tracker', () => {
-    const source = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8');
-    expect(source).toContain('resolveFinalScoreForCompletion');
-    expect(source).toContain('scoreLogIsComplete: state.scoreLogIsComplete');
+    const liveTrackerSource = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8');
+    const workflowSource = readFileSync(new URL('../../js/live-tracker-save-complete.js', import.meta.url), 'utf8');
+    expect(liveTrackerSource).toContain('runSaveAndCompleteWorkflow');
+    expect(workflowSource).toContain('scoreLogIsComplete: state.scoreLogIsComplete');
+    expect(workflowSource).toContain('buildFinishCompletionPlan');
   });
 });

--- a/tests/unit/live-tracker-save-complete.test.js
+++ b/tests/unit/live-tracker-save-complete.test.js
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi } from 'vitest';
+import { runSaveAndCompleteWorkflow } from '../../js/live-tracker-save-complete.js';
+
+function buildDocRef(...args) {
+  if (args.length === 1) {
+    return { kind: 'auto-doc', path: `${args[0].path}/AUTO_ID` };
+  }
+
+  const [, ...segments] = args;
+  return { kind: 'doc', path: segments.join('/') };
+}
+
+function buildHarness({ commitControl } = {}) {
+  const setCalls = [];
+  const updateCalls = [];
+  const navigationCalls = [];
+  const emailBodyCalls = [];
+  const renderLog = vi.fn();
+  const endLiveBroadcast = vi.fn(async () => {});
+
+  const batch = {
+    set: vi.fn((ref, data) => {
+      setCalls.push({ ref, data });
+    }),
+    update: vi.fn((ref, data) => {
+      updateCalls.push({ ref, data });
+    }),
+    commit: vi.fn(() => {
+      if (commitControl?.promise) {
+        return commitControl.promise;
+      }
+
+      return Promise.resolve();
+    })
+  };
+
+  const context = {
+    finishSubmissionLock: { active: false },
+    finishButton: { disabled: false },
+    homeFinalInput: { value: '44' },
+    awayFinalInput: { value: '41' },
+    notesFinalInput: { value: 'Closed well in the final minute.' },
+    finishSendEmailInput: { checked: true },
+    state: {
+      home: 5,
+      away: 2,
+      scoreLogIsComplete: true,
+      period: 'Q4',
+      clock: 0,
+      log: [
+        { text: 'Home layup', clock: '01:20', period: 'Q1', ts: 11, undoData: { type: 'stat', statKey: 'PTS', value: 2, isOpponent: false, playerId: 'p1' } },
+        { text: 'Home three', clock: '00:40', period: 'Q1', ts: 12, undoData: { type: 'stat', statKey: 'PTS', value: 3, isOpponent: false, playerId: 'p2' } },
+        { text: 'Away bucket', clock: '00:20', period: 'Q1', ts: 13, undoData: { type: 'stat', statKey: 'points', value: 2, isOpponent: true } }
+      ],
+      stats: {
+        p1: { pts: 2, ast: 1, fouls: 0, time: 123000 },
+        p2: { pts: 3, ast: 0, fouls: 2, time: 118000 }
+      },
+      opp: [
+        { id: 'opp-1', playerId: 'opp-1', name: 'Pat', number: '12', photoUrl: 'https://img/opp.jpg', stats: { pts: 2, ast: 0, fouls: 1 } }
+      ]
+    },
+    currentTeam: { name: 'Tigers', notificationEmail: 'team-notify@example.com' },
+    currentGame: { opponent: 'Bears' },
+    currentUser: { uid: 'user-1', email: 'coach-login@example.com' },
+    currentConfig: { columns: ['PTS', 'AST'] },
+    currentTeamId: 'team-1',
+    currentGameId: 'game-9',
+    roster: [
+      { id: 'p1', name: 'Alex', num: '4' },
+      { id: 'p2', name: 'Jamie', num: '7' }
+    ],
+    db: { name: 'db' },
+    renderLog,
+    endLiveBroadcast,
+    generateEmailBody: vi.fn((finalHome, finalAway, summary, logEntries) => {
+      emailBodyCalls.push({ finalHome, finalAway, summary, logEntries });
+      return `Final ${finalHome}-${finalAway}\n${summary}`;
+    }),
+    createBatch: vi.fn(() => batch),
+    createCollectionRef: vi.fn((db, path) => ({ db, path })),
+    createDocRef: vi.fn(buildDocRef),
+    executeFinishNavigationPlan: vi.fn((navigation) => {
+      navigationCalls.push(navigation);
+    }),
+    alertFn: vi.fn()
+  };
+
+  return {
+    context,
+    batch,
+    setCalls,
+    updateCalls,
+    navigationCalls,
+    emailBodyCalls,
+    renderLog,
+    endLiveBroadcast
+  };
+}
+
+describe('live tracker save-and-complete workflow', () => {
+  it('persists reconciled final scores, completes live status, and composes email from reconciled totals', async () => {
+    const harness = buildHarness();
+
+    const result = await runSaveAndCompleteWorkflow(harness.context);
+
+    expect(result).toMatchObject({
+      skipped: false,
+      finalHome: 5,
+      finalAway: 2
+    });
+    expect(harness.context.homeFinalInput.value).toBe('5');
+    expect(harness.context.awayFinalInput.value).toBe('2');
+    expect(harness.renderLog).toHaveBeenCalledTimes(1);
+    expect(harness.batch.commit).toHaveBeenCalledTimes(1);
+    expect(harness.endLiveBroadcast).toHaveBeenCalledTimes(1);
+    expect(harness.updateCalls).toEqual([
+      {
+        ref: { kind: 'doc', path: 'teams/team-1/games/game-9' },
+        data: {
+          homeScore: 5,
+          awayScore: 2,
+          summary: 'Closed well in the final minute.',
+          status: 'completed',
+          opponentStats: {
+            'opp-1': {
+              name: 'Pat',
+              number: '12',
+              playerId: 'opp-1',
+              photoUrl: 'https://img/opp.jpg',
+              pts: 2,
+              ast: 0,
+              fouls: 1
+            }
+          }
+        }
+      }
+    ]);
+    expect(harness.emailBodyCalls).toHaveLength(2);
+    expect(harness.emailBodyCalls.at(-1)).toEqual({
+      finalHome: 5,
+      finalAway: 2,
+      summary: 'Closed well in the final minute.',
+      logEntries: [
+        {
+          text: 'Score reconciled from 44-41 to 5-2 based on scoring events',
+          ts: expect.any(Number),
+          period: 'Q4',
+          clock: '00:00'
+        },
+        {
+          text: 'Home layup',
+          clock: '01:20',
+          period: 'Q1',
+          ts: 11,
+          undoData: { type: 'stat', statKey: 'PTS', value: 2, isOpponent: false, playerId: 'p1' }
+        },
+        {
+          text: 'Home three',
+          clock: '00:40',
+          period: 'Q1',
+          ts: 12,
+          undoData: { type: 'stat', statKey: 'PTS', value: 3, isOpponent: false, playerId: 'p2' }
+        },
+        {
+          text: 'Away bucket',
+          clock: '00:20',
+          period: 'Q1',
+          ts: 13,
+          undoData: { type: 'stat', statKey: 'points', value: 2, isOpponent: true }
+        }
+      ]
+    });
+    expect(harness.navigationCalls).toHaveLength(1);
+    expect(harness.navigationCalls[0]).toEqual([
+      {
+        type: 'mailto',
+        href: 'mailto:team-notify@example.com?subject=Tigers%20vs%20Bears%20-%20Game%20Summary&body=Final%205-2%0AClosed%20well%20in%20the%20final%20minute.',
+        delayMs: 0
+      },
+      {
+        type: 'redirect',
+        href: 'game.html#teamId=team-1&gameId=game-9',
+        delayMs: 500
+      }
+    ]);
+  });
+
+  it('accepts only one in-flight finish submission and keeps the button disabled until commit settles', async () => {
+    let resolveCommit;
+    const commitControl = {};
+    commitControl.promise = new Promise((resolve) => {
+      resolveCommit = resolve;
+    });
+
+    const harness = buildHarness({ commitControl });
+
+    const firstRun = runSaveAndCompleteWorkflow(harness.context);
+
+    expect(harness.context.finishButton.disabled).toBe(true);
+    expect(harness.batch.commit).toHaveBeenCalledTimes(1);
+
+    const secondResult = await runSaveAndCompleteWorkflow(harness.context);
+    expect(secondResult).toEqual({ skipped: true, reason: 'locked' });
+    expect(harness.batch.commit).toHaveBeenCalledTimes(1);
+    expect(harness.navigationCalls).toHaveLength(0);
+    expect(harness.endLiveBroadcast).toHaveBeenCalledTimes(0);
+
+    resolveCommit();
+    const firstResult = await firstRun;
+
+    expect(firstResult).toMatchObject({
+      skipped: false,
+      finalHome: 5,
+      finalAway: 2
+    });
+    expect(harness.context.finishButton.disabled).toBe(true);
+    expect(harness.endLiveBroadcast).toHaveBeenCalledTimes(1);
+    expect(harness.navigationCalls).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Closes #440

## What changed
- extracted the live tracker `saveAndComplete()` execution path into a focused `live-tracker-save-complete.js` helper so the real finish workflow can be exercised under test
- added workflow coverage for score reconciliation, batch persistence, completion status handling, recap email composition, navigation, and duplicate-submit guarding
- updated the existing wiring assertions to follow the new helper seam instead of relying on the pre-extraction file layout

## Why
The finalization path was the highest-risk untested live tracker workflow. This adds coverage for the full composed behavior that turns an in-progress live game into the permanent game record, including the single-flight protection against duplicate finish submissions.