### PR TITLE
Add tournament season-record regression coverage

### DIFF
--- a/docs/pr-notes/runs/issue-438-fixer-20260331T222503Z/architecture.md
+++ b/docs/pr-notes/runs/issue-438-fixer-20260331T222503Z/architecture.md
@@ -1,0 +1,22 @@
+Current state:
+- The schedule editor duplicates season-record metadata rules inline when loading DB events, populating the edit form, and building submit payloads.
+- `team.html` relies on saved game data and `js/season-record.js` for record display.
+
+Proposed state:
+- Introduce a focused helper module that owns season-record metadata normalization for schedule games.
+- Reuse that helper in `edit-schedule.html` for:
+- DB event normalization into schedule cache
+- Edit form hydration
+- Submit payload construction
+
+Blast radius:
+- Limited to schedule game metadata handling.
+- No Firebase schema changes.
+- No team page behavior changes beyond consuming the same persisted fields with lower drift risk.
+
+Controls:
+- Existing field names and default values remain unchanged.
+- Vitest regression tests cover both create and edit flows tied back to `calculateSeasonRecord`.
+
+Rollback:
+- Revert the helper import and inline the prior logic.

--- a/docs/pr-notes/runs/issue-438-fixer-20260331T222503Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-438-fixer-20260331T222503Z/code-plan.md
@@ -1,0 +1,9 @@
+Thinking level: medium
+Reason: the workflow crosses editor hydration, submit serialization, and season-record calculation, but the smallest reliable fix is still local.
+
+Implementation plan:
+1. Add a regression test file for schedule-game season-record metadata create/edit/reload behavior.
+2. Run the targeted test to confirm failure because the shared helper seam does not exist yet.
+3. Add a new helper module for season-record metadata defaults and form payload shaping.
+4. Wire `edit-schedule.html` to the helper at load, edit, and submit points.
+5. Run targeted unit tests and commit the minimal patch.

--- a/docs/pr-notes/runs/issue-438-fixer-20260331T222503Z/qa.md
+++ b/docs/pr-notes/runs/issue-438-fixer-20260331T222503Z/qa.md
@@ -1,0 +1,17 @@
+Scope:
+- Regression coverage for tournament/bracket games excluded from season record after save and reload.
+
+Test strategy:
+- Add one Vitest file that validates:
+- Form-state to saved-game payload for a completed tournament game with unchecked record flag.
+- Saved-game payload back to form-state on reload.
+- `calculateSeasonRecord` still excludes the tournament game while counting same-season league games.
+
+Why this approach:
+- The repo currently uses Vitest for durable automation.
+- This covers the highest-risk serialization and hydration seams without introducing a new browser test stack.
+
+Pass criteria:
+- New tests fail before helper implementation.
+- Targeted unit suite passes after helper extraction and wiring.
+- No unrelated test regressions in season-record or schedule-editor helpers.

--- a/docs/pr-notes/runs/issue-438-fixer-20260331T222503Z/requirements.md
+++ b/docs/pr-notes/runs/issue-438-fixer-20260331T222503Z/requirements.md
@@ -1,0 +1,23 @@
+Objective: Add automated coverage for the coach workflow where tournament/bracket games remain excluded from season record after save, reload, and subsequent edit.
+
+Current state:
+- `edit-schedule.html` exposes `seasonLabel`, `competitionType`, and `countsTowardSeasonRecord`.
+- `team.html` calculates season record from saved games.
+- Automated coverage only validates helper behavior in isolation, not the schedule-editor workflow.
+
+Proposed state:
+- Add regression tests that exercise create/edit/reload behavior through shared season-record metadata helpers.
+- Keep the existing UX and payload contract unchanged.
+
+Primary risks:
+- Silent regression if the unchecked checkbox defaults back to `true`.
+- Drift between create and edit code paths if metadata handling stays duplicated.
+
+Assumptions:
+- The repo’s current automation standard is Vitest-based source and helper testing, not full browser E2E.
+- A shared helper extraction is acceptable as the smallest change that improves regression protection without refactoring the page.
+
+Recommendation:
+- Extract the season-record metadata read/write rules into a tiny helper module and cover two workflows:
+- New completed tournament game saved with `countsTowardSeasonRecord=false` stays excluded after reload.
+- Existing completed tournament game edited and re-saved keeps exclusion while same-season league games still count.

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -774,6 +774,7 @@
         import { cancelScheduledGame } from './js/edit-schedule-cancel-game.js?v=1';
         import { applyPracticeRecurrenceFields } from './js/edit-schedule-practice-payload.js?v=1';
         import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=1';
+        import { buildSeasonRecordGameFields, hydrateSeasonRecordFormFields } from './js/edit-schedule-season-record.js?v=1';
         import { Timestamp, deleteField } from "./js/firebase.js?v=10";
         import { getApp } from './js/vendor/firebase-app.js';
         import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
@@ -1270,9 +1271,12 @@
                         notes: event.notes,
                         isHome: event.isHome ?? null,
                         kitColor: event.kitColor || null,
-                        seasonLabel: event.seasonLabel || null,
-                        competitionType: event.competitionType || 'league',
-                        countsTowardSeasonRecord: event.countsTowardSeasonRecord !== false,
+                        ...buildSeasonRecordGameFields({
+                            parsedGameDate: eventDate,
+                            seasonLabel: event.seasonLabel,
+                            competitionType: event.competitionType,
+                            countsTowardSeasonRecord: event.countsTowardSeasonRecord
+                        }),
                         arrivalTime: event.arrivalTime || null,
                         assignments: Array.isArray(event.assignments) ? event.assignments : [],
                         rsvpSummary: event.rsvpSummary || null,
@@ -1790,11 +1794,15 @@
             // Populate new fields
             setHomeAway(game.isHome === true ? 'home' : (game.isHome === false ? 'away' : null));
             document.getElementById('kitColor').value = game.kitColor || '';
-            document.getElementById('seasonLabel').value = game.seasonLabel || inferSeasonLabel(date);
-            document.getElementById('competitionType').value = game.competitionType || 'league';
+            const seasonRecordFields = hydrateSeasonRecordFormFields({
+                game,
+                fallbackDate: date
+            });
+            document.getElementById('seasonLabel').value = seasonRecordFields.seasonLabel;
+            document.getElementById('competitionType').value = seasonRecordFields.competitionType;
             populateTournamentForm(game.tournament || null);
             updateTournamentSettingsVisibility();
-            document.getElementById('countsTowardSeasonRecord').checked = game.countsTowardSeasonRecord !== false;
+            document.getElementById('countsTowardSeasonRecord').checked = seasonRecordFields.countsTowardSeasonRecord;
             if (game.arrivalTime) {
                 const at = game.arrivalTime.toDate ? game.arrivalTime.toDate() : new Date(game.arrivalTime);
                 document.getElementById('arrivalTime').value = formatIsoForInput(at);
@@ -1915,6 +1923,12 @@
                 const notifyNote = document.getElementById('game-notify-note').value.trim();
                 const notificationSettings = getTeamScheduleNotificationSettings();
                 const tournamentData = readTournamentFormState();
+                const seasonRecordFields = buildSeasonRecordGameFields({
+                    parsedGameDate,
+                    seasonLabel: document.getElementById('seasonLabel').value.trim(),
+                    competitionType: document.getElementById('competitionType').value,
+                    countsTowardSeasonRecord: document.getElementById('countsTowardSeasonRecord').checked
+                });
                 const gameData = {
                     type: 'game',
                     date: Timestamp.fromDate(parsedGameDate),
@@ -1926,9 +1940,7 @@
                     opponentTeamPhoto: selectedOpponentTeam ? selectedOpponentTeam.photoUrl || null : null,
                     isHome: isHomeVal === 'home' ? true : (isHomeVal === 'away' ? false : null),
                     kitColor: document.getElementById('kitColor').value.trim() || null,
-                    seasonLabel: document.getElementById('seasonLabel').value.trim() || inferSeasonLabel(parsedGameDate),
-                    competitionType: document.getElementById('competitionType').value || 'league',
-                    countsTowardSeasonRecord: document.getElementById('countsTowardSeasonRecord').checked,
+                    ...seasonRecordFields,
                     arrivalTime: arrivalVal ? Timestamp.fromDate(new Date(arrivalVal)) : null,
                     notes: document.getElementById('gameNotes').value.trim() || null,
                     assignments: getAssignmentsFromForm(),

--- a/js/edit-schedule-season-record.js
+++ b/js/edit-schedule-season-record.js
@@ -1,0 +1,35 @@
+import { inferSeasonLabelFromGame } from './season-record.js';
+
+export function hydrateSeasonRecordFormFields({ game, fallbackDate } = {}) {
+    const resolvedDate = fallbackDate || game?.date;
+    return {
+        seasonLabel: inferSeasonLabelFromGame({
+            seasonLabel: game?.seasonLabel,
+            date: resolvedDate
+        }),
+        competitionType: game?.competitionType || 'league',
+        countsTowardSeasonRecord: game?.countsTowardSeasonRecord !== false
+    };
+}
+
+export function buildSeasonRecordGameFields({
+    parsedGameDate,
+    seasonLabel,
+    competitionType,
+    countsTowardSeasonRecord
+} = {}) {
+    const hydratedFields = hydrateSeasonRecordFormFields({
+        game: {
+            seasonLabel,
+            competitionType,
+            countsTowardSeasonRecord
+        },
+        fallbackDate: parsedGameDate
+    });
+
+    return {
+        seasonLabel: hydratedFields.seasonLabel,
+        competitionType: hydratedFields.competitionType,
+        countsTowardSeasonRecord: hydratedFields.countsTowardSeasonRecord
+    };
+}

--- a/tests/unit/edit-schedule-season-record-workflow.test.js
+++ b/tests/unit/edit-schedule-season-record-workflow.test.js
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { calculateSeasonRecord } from '../../js/season-record.js';
+import {
+    buildSeasonRecordGameFields,
+    hydrateSeasonRecordFormFields
+} from '../../js/edit-schedule-season-record.js';
+
+describe('edit schedule season record workflow', () => {
+    it('keeps a saved tournament game excluded from the selected season record after reload', () => {
+        const parsedGameDate = new Date('2026-06-14T18:00:00.000Z');
+        const savedGameFields = buildSeasonRecordGameFields({
+            parsedGameDate,
+            seasonLabel: '2026',
+            competitionType: 'tournament',
+            countsTowardSeasonRecord: false
+        });
+
+        expect(savedGameFields).toEqual({
+            seasonLabel: '2026',
+            competitionType: 'tournament',
+            countsTowardSeasonRecord: false
+        });
+
+        expect(hydrateSeasonRecordFormFields({
+            game: {
+                ...savedGameFields,
+                date: parsedGameDate
+            },
+            fallbackDate: new Date('2026-06-01T12:00:00.000Z')
+        })).toEqual({
+            seasonLabel: '2026',
+            competitionType: 'tournament',
+            countsTowardSeasonRecord: false
+        });
+
+        const record = calculateSeasonRecord([
+            {
+                type: 'game',
+                status: 'completed',
+                homeScore: 4,
+                awayScore: 2,
+                ...savedGameFields
+            }
+        ], { seasonLabel: '2026' });
+
+        expect(record).toEqual({ wins: 0, losses: 0, ties: 0 });
+    });
+
+    it('preserves an existing tournament exclusion on edit while league games in the same season still count', () => {
+        const tournamentGame = {
+            type: 'game',
+            status: 'completed',
+            homeScore: 3,
+            awayScore: 1,
+            date: new Date('2026-07-01T17:00:00.000Z'),
+            seasonLabel: '2026',
+            competitionType: 'tournament',
+            countsTowardSeasonRecord: false
+        };
+        const hydratedFields = hydrateSeasonRecordFormFields({
+            game: tournamentGame,
+            fallbackDate: new Date('2026-07-01T17:00:00.000Z')
+        });
+
+        expect(hydratedFields).toEqual({
+            seasonLabel: '2026',
+            competitionType: 'tournament',
+            countsTowardSeasonRecord: false
+        });
+
+        const editedTournamentFields = buildSeasonRecordGameFields({
+            parsedGameDate: new Date('2026-07-01T17:00:00.000Z'),
+            ...hydratedFields
+        });
+        const sameSeasonLeagueGame = buildSeasonRecordGameFields({
+            parsedGameDate: new Date('2026-07-08T17:00:00.000Z'),
+            seasonLabel: '2026',
+            competitionType: 'league',
+            countsTowardSeasonRecord: true
+        });
+
+        const record = calculateSeasonRecord([
+            {
+                ...tournamentGame,
+                ...editedTournamentFields
+            },
+            {
+                type: 'game',
+                status: 'completed',
+                homeScore: 2,
+                awayScore: 0,
+                date: new Date('2026-07-08T17:00:00.000Z'),
+                ...sameSeasonLeagueGame
+            }
+        ], { seasonLabel: '2026' });
+
+        expect(record).toEqual({ wins: 1, losses: 0, ties: 0 });
+    });
+
+    it('wires edit-schedule through the shared season-record helper', () => {
+        const source = readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
+
+        expect(source).toContain("import { buildSeasonRecordGameFields, hydrateSeasonRecordFormFields } from './js/edit-schedule-season-record.js?v=1';");
+        expect(source).toContain('const seasonRecordFields = hydrateSeasonRecordFormFields({');
+        expect(source).toContain('const seasonRecordFields = buildSeasonRecordGameFields({');
+        expect(source).toContain('...seasonRecordFields,');
+    });
+});


### PR DESCRIPTION
Closes #438

## What changed
- added a focused Vitest regression for the schedule editor workflow that saves a tournament game with `countsTowardSeasonRecord=false`, reloads it, and confirms the selected season record still excludes it
- added a second regression covering edit-and-resave of an existing excluded tournament game while a same-season league game still counts normally
- extracted the schedule editor's season-record metadata defaults into a shared helper and wired `edit-schedule.html` to use it for DB hydration, edit-form population, and submit payload construction
- persisted the required per-run role synthesis notes under `docs/pr-notes/runs/issue-438-fixer-20260331T222503Z/`

## Why
- the repo already had season-record helper coverage, but not the higher-risk schedule-editor workflow where a default-checked checkbox could silently flip an excluded tournament game back into the season record
- centralizing the season-record field handling reduces drift between create, edit, and reload paths while keeping the fix narrowly scoped