### PR TITLE
Add game-day lineup save/reload regression coverage

### DIFF
--- a/docs/pr-notes/runs/issue-444-fixer-20260401T022521Z/architecture.md
+++ b/docs/pr-notes/runs/issue-444-fixer-20260401T022521Z/architecture.md
@@ -1,0 +1,19 @@
+Current state
+- `buildLineupPublishPayload()` persists flattened lineup keys.
+- `buildRotationPlanFromGamePlan()` rebuilds nested period-to-position assignments.
+- `game-day.html` keeps separate active-period state for Pre-Game and Game Day views.
+
+Observed gap
+- Reloaded 4-period lineups can restore data correctly while still rendering an empty first Game Day view because `activePeriodGD` defaults to `H1`.
+
+Proposed change
+- Add a small period helper module:
+  - derive period labels from `numPeriods`
+  - normalize an active period against the allowed periods
+- Use that helper in `game-day.html` when rendering Game Day period tabs.
+- Add a regression test that round-trips a published basketball lineup and asserts visible-period normalization.
+
+Why this path
+- Minimal blast radius.
+- Testable with existing Vitest coverage.
+- No schema change and no dependency on browser automation.

--- a/docs/pr-notes/runs/issue-444-fixer-20260401T022521Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-444-fixer-20260401T022521Z/code-plan.md
@@ -1,0 +1,10 @@
+Implementation plan
+1. Add a small helper module for period lists and active-period normalization.
+2. Add a failing regression that covers publish payload round-trip and visible-period restoration.
+3. Wire `game-day.html` to use the helper when rendering Game Day period tabs.
+4. Run the affected unit tests, then the full unit suite if practical.
+5. Stage and commit with issue linkage.
+
+Assumptions
+- Vitest is the canonical automated path for this repo’s newer tests.
+- A unit-level round-trip test is acceptable evidence for the requested save/reload coverage in this repository.

--- a/docs/pr-notes/runs/issue-444-fixer-20260401T022521Z/qa.md
+++ b/docs/pr-notes/runs/issue-444-fixer-20260401T022521Z/qa.md
@@ -1,0 +1,14 @@
+Test strategy
+- Add one targeted regression in the unit suite.
+- Save a multi-period basketball lineup via `buildLineupPublishPayload()`.
+- Reload it via `buildRotationPlanFromGamePlan()`.
+- Assert the persisted payload keys, restored `rotationPlan`, and normalized visible Game Day period.
+
+Regression guardrails
+- Preserve current soccer and basketball period naming.
+- Preserve existing publish metadata behavior.
+- Verify the page wiring imports and uses the active-period normalization helper.
+
+Validation
+- Run `npm test -- tests/unit/game-day-lineup-publish.test.js tests/unit/game-plan-interop.test.js` if supported, otherwise run the repo unit suite.
+- Confirm no unrelated unit regressions.

--- a/docs/pr-notes/runs/issue-444-fixer-20260401T022521Z/requirements.md
+++ b/docs/pr-notes/runs/issue-444-fixer-20260401T022521Z/requirements.md
@@ -1,0 +1,23 @@
+Objective: prove a saved Game Day lineup can be reloaded from persisted `gamePlan` data without losing visible assignments.
+
+Current state
+- Save payload coverage exists only at helper level.
+- Reload coverage exists only for pure `lineups` parsing.
+- There is no automated regression proving a coach-visible lineup survives save and reload in the same flow.
+
+Proposed state
+- Add one regression that saves a multi-period lineup, reloads the persisted `gamePlan`, and verifies the same formation and assignments are restored.
+- Include visible-period behavior so the first rendered Game Day view shows the restored lineup immediately.
+
+Constraints
+- Keep the patch narrow.
+- Reuse existing Vitest unit coverage patterns.
+- Do not introduce unrelated UI or data-model changes.
+
+Risk surface
+- Core pregame workflow for coaches.
+- Blast radius is limited to Game Day period selection and lineup persistence helpers.
+
+Recommendation
+- Cover the round-trip in unit tests using the existing lineup publish and interop modules.
+- Fix the visible-period mismatch for 4-period formations during Game Day reload.

--- a/game-day.html
+++ b/game-day.html
@@ -493,6 +493,7 @@
         import { checkAuth } from './js/auth.js?v=10';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js?v=3';
         import { buildRotationPlanFromGamePlan } from './js/game-plan-interop.js';
+        import { getPeriodsForFormation, normalizeActivePeriod } from './js/game-day-periods.js?v=1';
         import {
             buildLineupDraftPayload,
             buildLineupPublishPayload,
@@ -1600,10 +1601,7 @@ Assistant:`;
 
         function getPeriods(formationId) {
             const f = FORMATIONS[formationId];
-            if (!f) return ['H1', 'H2'];
-            const n = f.numPeriods || 2;
-            if (n === 4) return ['Q1', 'Q2', 'Q3', 'Q4'];
-            return ['H1', 'H2'];
+            return getPeriodsForFormation(f);
         }
 
         function renderPeriodTabs() {
@@ -2013,6 +2011,7 @@ Respond ONLY with valid JSON.`;
 
         function renderGDPeriodTabs() {
             const periods = state.formationId ? getPeriods(state.formationId) : ['H1', 'H2'];
+            state.activePeriodGD = normalizeActivePeriod(periods, state.activePeriodGD);
             document.getElementById('gd-h1-btn').textContent = periods[0];
             document.getElementById('gd-h2-btn').textContent = periods[1] || 'H2';
         }

--- a/js/game-day-periods.js
+++ b/js/game-day-periods.js
@@ -1,0 +1,16 @@
+export function getPeriodsForNumPeriods(numPeriods) {
+  const parsed = Number.parseInt(numPeriods, 10) || 2;
+  if (parsed === 4) return ['Q1', 'Q2', 'Q3', 'Q4'];
+  return ['H1', 'H2'];
+}
+
+export function getPeriodsForFormation(formation = {}) {
+  return getPeriodsForNumPeriods(formation?.numPeriods);
+}
+
+export function normalizeActivePeriod(periods, currentPeriod) {
+  if (Array.isArray(periods) && periods.includes(currentPeriod)) {
+    return currentPeriod;
+  }
+  return Array.isArray(periods) && periods.length ? periods[0] : 'H1';
+}

--- a/tests/unit/game-day-lineup-publish.test.js
+++ b/tests/unit/game-day-lineup-publish.test.js
@@ -6,6 +6,8 @@ import {
   buildLineupPublishPayload,
   buildLineupPublishMessage
 } from '../../js/game-day-lineup-publish.js';
+import { buildRotationPlanFromGamePlan } from '../../js/game-plan-interop.js';
+import { getPeriodsForFormation, normalizeActivePeriod } from '../../js/game-day-periods.js';
 
 describe('game day lineup publish helpers', () => {
   it('builds a published lineup payload with versioned metadata and recipients', () => {
@@ -105,6 +107,38 @@ describe('game day lineup publish helpers', () => {
       changedAssignments: 3
     })).toContain('updated');
   });
+
+  it('round-trips a saved 4-period lineup and restores the first visible game-day period', () => {
+    const rotationPlan = {
+      Q1: { pg: 'p1', sg: 'p2' },
+      Q2: { pg: 'p3', sg: 'p4' },
+      Q3: { pg: 'p5' },
+      Q4: { pg: 'p6' }
+    };
+
+    const payload = buildLineupPublishPayload({
+      formationId: 'basketball-5v5',
+      numPeriods: 4,
+      rotationPlan,
+      previousGamePlan: {}
+    });
+
+    expect(payload).toMatchObject({
+      formationId: 'basketball-5v5',
+      numPeriods: 4,
+      lineups: {
+        'Q1-pg': 'p1',
+        'Q1-sg': 'p2',
+        'Q2-pg': 'p3',
+        'Q2-sg': 'p4',
+        'Q3-pg': 'p5',
+        'Q4-pg': 'p6'
+      }
+    });
+
+    expect(buildRotationPlanFromGamePlan(payload)).toEqual(rotationPlan);
+    expect(normalizeActivePeriod(getPeriodsForFormation(payload), 'H1')).toBe('Q1');
+  });
 });
 
 describe('game-day page wiring', () => {
@@ -126,5 +160,12 @@ describe('game-day page wiring', () => {
     expect(source).toContain('previousGamePlan: getPersistedGamePlan()');
     expect(source).toContain('previousGamePlan?.publishedLineups');
     expect(source).toContain("alert('Lineup published successfully, but the team notification could not be sent. Please notify your team manually.');");
+  });
+
+  it('normalizes the visible game-day period when a saved lineup reloads', () => {
+    const source = readFileSync(resolve(process.cwd(), 'game-day.html'), 'utf8');
+
+    expect(source).toContain("import { getPeriodsForFormation, normalizeActivePeriod } from './js/game-day-periods.js?v=1';");
+    expect(source).toContain('state.activePeriodGD = normalizeActivePeriod(periods, state.activePeriodGD);');
   });
 });


### PR DESCRIPTION
Closes #444

## What changed
- added a targeted Vitest regression for the Game Day lineup publish flow in `tests/unit/game-day-lineup-publish.test.js`
- verified the saved `gamePlan.lineups` payload for a multi-period basketball lineup round-trips back into the same nested `rotationPlan`
- added a small shared period helper in `js/game-day-periods.js` and wired `game-day.html` to normalize the visible Game Day period when persisted lineups reload
- recorded per-run role notes under `docs/pr-notes/runs/issue-444-fixer-20260401T022521Z/`

## Why
Saving and reload were covered only in isolated helper tests, which missed a real UI regression path: a restored 4-period lineup could load correctly in data but still render an empty first Game Day view because the active period defaulted to `H1` instead of the formation's first valid period.

## Validation
- ran targeted tests: `./node_modules/.bin/vitest run tests/unit/game-day-lineup-publish.test.js tests/unit/game-plan-interop.test.js`
- ran full unit suite: `./node_modules/.bin/vitest run tests/unit`