### PR TITLE
Add team schedule calendar filter coverage

### DIFF
--- a/docs/pr-notes/runs/issue-446-fixer-20260401T082532Z/architecture.md
+++ b/docs/pr-notes/runs/issue-446-fixer-20260401T082532Z/architecture.md
@@ -1,0 +1,20 @@
+Current state:
+- `team.html` uses `getAllEvents()` to merge DB games and imported calendar events.
+- `getFilteredScheduleEvents()` applies the active filter and the practice checkbox.
+- `renderScheduleCalendar()` builds calendar cells from filtered events.
+- `openScheduleDayModal()` reuses `getFilteredScheduleEvents()` and then narrows to the selected day.
+
+Observed defect:
+- Practice events are removed before the `upcoming-practices` branch runs because `showPractices` defaults to `false`.
+- That causes the dedicated practice filter and the day modal to miss valid practice events.
+
+Reference behavior:
+- `edit-schedule.html` already uses `forcePracticeVisibility = scheduleViewFilter === 'upcoming-practices'`.
+
+Target change:
+- Mirror the `edit-schedule.html` guard in `team.html`.
+- Keep all other filtering, duplicate suppression, and cancellation rules unchanged.
+
+Blast radius:
+- Limited to Team page schedule filtering.
+- No Firestore schema changes, no backend changes, no routing changes.

--- a/docs/pr-notes/runs/issue-446-fixer-20260401T082532Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-446-fixer-20260401T082532Z/code-plan.md
@@ -1,0 +1,9 @@
+Thinking level: medium
+Reason: browser-level schedule behavior spans merged data, filter state, calendar rendering, and a modal path.
+
+Implementation plan:
+1. Add a Team page smoke spec with explicit module stubs for DB, utils, auth, Firebase, standings, and banner dependencies.
+2. Run the new smoke spec before the fix to confirm the current failure.
+3. Update `team.html` to force practice visibility when the `Upcoming Practices` filter is active.
+4. Re-run the smoke spec and the relevant unit test lane.
+5. Commit the targeted fix and coverage together.

--- a/docs/pr-notes/runs/issue-446-fixer-20260401T082532Z/qa.md
+++ b/docs/pr-notes/runs/issue-446-fixer-20260401T082532Z/qa.md
@@ -1,0 +1,23 @@
+Coverage strategy:
+- Add a Playwright smoke spec under `tests/smoke/` because that is the repo’s browser-level automated lane.
+
+Scenario 1:
+- Team page with one DB game and one imported practice on the same future date.
+- Switch to calendar.
+- Select `Upcoming Practices`.
+- Verify only the practice appears in the day cell and the day modal.
+
+Scenario 2:
+- Team page with:
+  - one tracked calendar UID that should be suppressed
+  - one cancelled calendar event
+  - one completed DB game
+  - one normal upcoming calendar event
+- Verify:
+  - `Recent Results` shows only the completed DB game
+  - `All Upcoming` excludes cancelled and tracked-duplicate items in list and calendar mode
+  - `Past Events` includes the completed DB game and cancelled event in list and calendar mode
+
+Validation:
+- Run the new smoke spec against a local static server.
+- Run the focused unit test command for confidence that the targeted change does not break the existing vitest lane.

--- a/docs/pr-notes/runs/issue-446-fixer-20260401T082532Z/requirements.md
+++ b/docs/pr-notes/runs/issue-446-fixer-20260401T082532Z/requirements.md
@@ -1,0 +1,28 @@
+Objective: protect the `team.html` schedule workflow where a coach or parent switches from list view to calendar view, filters the schedule, and opens a clicked-day modal.
+
+Current state:
+- `team.html` merges Firestore games with imported calendar events.
+- It renders list and calendar views through separate paths.
+- The clicked-day modal re-filters events again.
+
+Proposed state:
+- Add smoke coverage that exercises the Team page directly.
+- Ensure the `Upcoming Practices` filter works even when `Show Practices` remains off.
+- Confirm duplicate tracked calendar events and cancelled calendar events stay out of the wrong filters in both list and calendar modes.
+
+Risk surface:
+- User-facing schedule visibility on a public team page.
+- Duplicate suppression for tracked ICS events.
+- Calendar/list divergence and day-modal divergence.
+
+Assumptions:
+- Existing smoke tests are the repo’s Playwright coverage lane.
+- The intended behavior matches `edit-schedule.html`, which already forces practice visibility for the dedicated practice filter.
+
+Recommendation:
+- Add one focused Team page smoke spec with two scenarios matching the issue.
+- Apply the smallest behavioral fix in `team.html` only if the new smoke coverage exposes a defect.
+
+Success criteria:
+- `Upcoming Practices` shows practice-only results in list, calendar, and day-modal contexts without requiring the checkbox.
+- `Recent Results`, `All Upcoming`, and `Past Events` keep completed, future, cancelled, and duplicate-tracked items in the correct buckets.

--- a/team.html
+++ b/team.html
@@ -1224,8 +1224,9 @@
         function getFilteredScheduleEvents() {
             const now = new Date();
             const cutoff = new Date(now.getTime() - 3 * 60 * 60 * 1000);
+            const forcePracticeVisibility = scheduleViewFilter === 'upcoming-practices';
             const events = (allScheduleEvents || []).filter((event) => {
-                if (!showPractices && event.isPractice) return false;
+                if (!showPractices && event.isPractice && !forcePracticeVisibility) return false;
                 return true;
             });
 

--- a/tests/smoke/team-schedule-calendar.spec.js
+++ b/tests/smoke/team-schedule-calendar.spec.js
@@ -1,0 +1,426 @@
+import { test, expect } from '@playwright/test';
+
+function buildUrl(baseURL, path) {
+    const url = new URL(path, `${baseURL}/`);
+    url.searchParams.set('cb', String(Date.now()));
+    return url.toString();
+}
+
+function makeIso(date) {
+    return date.toISOString();
+}
+
+function addDays(baseDate, days, hour = 18) {
+    const next = new Date(baseDate);
+    next.setUTCDate(next.getUTCDate() + days);
+    next.setUTCHours(hour, 0, 0, 0);
+    return next;
+}
+
+function monthDelta(fromDate, toDate) {
+    return ((toDate.getUTCFullYear() - fromDate.getUTCFullYear()) * 12)
+        + (toDate.getUTCMonth() - fromDate.getUTCMonth());
+}
+
+function buildDbStub({ team, games, trackedUids }) {
+    return `
+const team = ${JSON.stringify(team)};
+const games = ${JSON.stringify(games)};
+const trackedUids = ${JSON.stringify(trackedUids)};
+
+function clone(value) {
+    return JSON.parse(JSON.stringify(value));
+}
+
+export async function getTeam(teamId) {
+    return { ...clone(team), id: teamId };
+}
+
+export async function getPlayers() {
+    return [];
+}
+
+export async function getGames() {
+    return clone(games);
+}
+
+export async function getConfigs() {
+    return [];
+}
+
+export async function getTrackedCalendarEventUids() {
+    return clone(trackedUids);
+}
+
+export async function getUnreadChatCounts() {
+    return {};
+}
+
+export async function getUserProfile() {
+    return null;
+}
+`;
+}
+
+function buildUtilsStub({ calendarEvents, teamId = 'team-a' }) {
+    return `
+const calendarEvents = ${JSON.stringify(calendarEvents)};
+
+function toDate(value) {
+    return value instanceof Date ? value : new Date(value);
+}
+
+export function renderHeader() {}
+export function renderFooter() {}
+
+export function getUrlParams() {
+    return { teamId: ${JSON.stringify(teamId)} };
+}
+
+export function formatDate(value) {
+    return toDate(value).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric'
+    });
+}
+
+export function formatShortDate(value) {
+    return formatDate(value);
+}
+
+export function formatTime(value) {
+    return toDate(value).toLocaleTimeString('en-US', {
+        hour: 'numeric',
+        minute: '2-digit'
+    });
+}
+
+export async function fetchAndParseCalendar() {
+    return calendarEvents.map((event) => ({
+        ...event,
+        dtstart: new Date(event.dtstart)
+    }));
+}
+
+export function extractOpponent(summary, teamName = '') {
+    const clean = String(summary || '')
+        .replace(/\\[CANCELED\\]\\s*/gi, '')
+        .replace(/\\s+/g, ' ')
+        .trim();
+
+    if (/practice/i.test(clean)) {
+        return clean.replace(new RegExp(teamName, 'ig'), '').trim() || 'Practice';
+    }
+
+    const withoutTeam = teamName ? clean.replace(new RegExp(teamName, 'ig'), '').trim() : clean;
+    const versusMatch = withoutTeam.match(/(?:vs\\.?|v\\.?|@)\\s*(.+)$/i);
+    if (versusMatch) {
+        return versusMatch[1].trim();
+    }
+
+    return withoutTeam || clean || 'Opponent';
+}
+
+export function isPracticeEvent(summary) {
+    return /practice/i.test(String(summary || ''));
+}
+
+export function isTrackedCalendarEvent(event, trackedUids) {
+    return Boolean(event?.uid) && Array.isArray(trackedUids) && trackedUids.includes(event.uid);
+}
+
+export function escapeHtml(value) {
+    return String(value ?? '');
+}
+
+export async function shareOrCopy() {}
+`;
+}
+
+const AUTH_STUB = `
+export function checkAuth(callback) {
+    callback(null);
+}
+`;
+
+const LEAGUE_STUB = `
+export async function fetchLeagueStandings() {
+    return { ok: false, rows: [], match: null };
+}
+`;
+
+const NATIVE_STUB = `
+export function computeNativeStandings() {
+    return [];
+}
+`;
+
+const STAT_STUB = `
+export function buildPlayerLeaderboardSnapshot() {
+    return null;
+}
+
+export function selectAnalyticsConfig() {
+    return null;
+}
+`;
+
+const SEASON_RECORD_STUB = `
+function toDate(value) {
+    return value?.toDate ? value.toDate() : new Date(value);
+}
+
+export function calculateSeasonRecord(games, options = {}) {
+    const selectedSeason = String(options.seasonLabel || '');
+    const filtered = (Array.isArray(games) ? games : []).filter((game) => {
+        const date = toDate(game.date);
+        return !selectedSeason || String(date.getUTCFullYear()) === selectedSeason;
+    }).filter((game) => game.status === 'completed' && game.type !== 'practice');
+
+    return filtered.reduce((record, game) => {
+        if (Number(game.homeScore) > Number(game.awayScore)) {
+            record.wins += 1;
+        } else if (Number(game.homeScore) < Number(game.awayScore)) {
+            record.losses += 1;
+        } else {
+            record.ties += 1;
+        }
+        return record;
+    }, { wins: 0, losses: 0, ties: 0 });
+}
+
+export function listSeasonLabels(games) {
+    const labels = Array.from(new Set((Array.isArray(games) ? games : []).map((game) => String(toDate(game.date).getUTCFullYear()))));
+    return labels.sort().reverse();
+}
+`;
+
+const FIREBASE_STUB = `
+export const db = {};
+
+export function collection() {
+    return {};
+}
+
+export async function getDocs() {
+    return {
+        empty: true,
+        docs: [],
+        forEach() {}
+    };
+}
+`;
+
+const TEAM_ADMIN_BANNER_STUB = `
+export function renderTeamAdminBanner() {}
+
+export function getTeamAccessInfo() {
+    return { hasAccess: false };
+}
+`;
+
+async function mockTeamPageModules(page, scenario) {
+    await page.route('https://www.googletagmanager.com/**', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: ''
+    }));
+    await page.route('https://cdn.tailwindcss.com/**', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: 'window.tailwind = window.tailwind || { config: {} };'
+    }));
+    await page.route('**/js/db.js?v=15', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: buildDbStub(scenario)
+    }));
+    await page.route('**/js/utils.js?v=10', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: buildUtilsStub(scenario)
+    }));
+    await page.route('**/js/league-standings.js?v=1', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: LEAGUE_STUB
+    }));
+    await page.route('**/js/native-standings.js?v=1', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: NATIVE_STUB
+    }));
+    await page.route('**/js/stat-leaderboards.js?v=1', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: STAT_STUB
+    }));
+    await page.route('**/js/season-record.js', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: SEASON_RECORD_STUB
+    }));
+    await page.route('**/js/auth.js?v=10', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: AUTH_STUB
+    }));
+    await page.route('**/js/firebase.js?v=10', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: FIREBASE_STUB
+    }));
+    await page.route('**/js/team-admin-banner.js', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: TEAM_ADMIN_BANNER_STUB
+    }));
+}
+
+async function gotoCalendarMonth(page, fromDate, targetDate) {
+    const delta = monthDelta(fromDate, targetDate);
+    if (delta > 0) {
+        for (let index = 0; index < delta; index += 1) {
+            await page.locator('#schedule-calendar-next').click();
+        }
+    } else if (delta < 0) {
+        for (let index = 0; index < Math.abs(delta); index += 1) {
+            await page.locator('#schedule-calendar-prev').click();
+        }
+    }
+}
+
+test('team schedule calendar shows only practices in the dedicated practice filter and modal', async ({ page, baseURL }) => {
+    const now = new Date();
+    const sharedDate = addDays(now, 7, 18);
+    const scenario = {
+        team: {
+            name: 'Team A',
+            sport: 'Soccer',
+            calendarUrls: ['https://calendar.test/team-a.ics']
+        },
+        games: [
+            {
+                id: 'game-1',
+                opponent: 'Rivals FC',
+                location: 'Field 1',
+                type: 'game',
+                status: 'scheduled',
+                date: makeIso(sharedDate)
+            }
+        ],
+        trackedUids: [],
+        calendarEvents: [
+            {
+                uid: 'practice-1',
+                dtstart: makeIso(new Date(sharedDate.getTime() + (60 * 60 * 1000))),
+                summary: 'Team A Practice',
+                location: 'Gym 1',
+                status: 'CONFIRMED'
+            }
+        ]
+    };
+
+    await mockTeamPageModules(page, scenario);
+    await page.goto(buildUrl(baseURL, '/team.html#teamId=team-a'), { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#team-header')).toContainText('Team A');
+
+    await page.locator('#schedule-view-calendar').click();
+    await page.locator('#schedule-filter-upcoming-practices').click();
+    await gotoCalendarMonth(page, now, sharedDate);
+
+    const dayCell = page.locator(`[data-schedule-day="${sharedDate.getUTCDate()}"]`);
+    await expect(dayCell).toContainText('Practice');
+    await expect(dayCell).not.toContainText('Rivals FC');
+
+    await dayCell.click();
+
+    await expect(page.locator('#schedule-day-modal')).not.toHaveClass(/hidden/);
+    await expect(page.locator('#schedule-day-modal-content')).toContainText('Practice');
+    await expect(page.locator('#schedule-day-modal-content')).toContainText('Gym 1');
+    await expect(page.locator('#schedule-day-modal-content')).not.toContainText('Rivals FC');
+});
+
+test('team schedule keeps tracked duplicates and cancelled items out of the wrong filter buckets', async ({ page, baseURL }) => {
+    const now = new Date();
+    const completedDate = addDays(now, -5, 18);
+    const upcomingDate = addDays(now, 5, 18);
+    const cancelledDate = addDays(now, 6, 18);
+    const scenario = {
+        team: {
+            name: 'Team A',
+            sport: 'Soccer',
+            calendarUrls: ['https://calendar.test/team-a.ics']
+        },
+        games: [
+            {
+                id: 'completed-1',
+                opponent: 'Falcons',
+                location: 'Stadium 1',
+                type: 'game',
+                status: 'completed',
+                homeScore: 3,
+                awayScore: 1,
+                date: makeIso(completedDate)
+            }
+        ],
+        trackedUids: ['tracked-uid-1'],
+        calendarEvents: [
+            {
+                uid: 'tracked-uid-1',
+                dtstart: makeIso(addDays(now, 4, 18)),
+                summary: 'Team A vs Duplicate FC',
+                location: 'Hidden Field',
+                status: 'CONFIRMED'
+            },
+            {
+                uid: 'upcoming-uid-1',
+                dtstart: makeIso(upcomingDate),
+                summary: 'Team A vs Meteors',
+                location: 'Field 2',
+                status: 'CONFIRMED'
+            },
+            {
+                uid: 'cancelled-uid-1',
+                dtstart: makeIso(cancelledDate),
+                summary: '[CANCELED] Team A vs Storm',
+                location: 'Field 3',
+                status: 'CANCELLED'
+            }
+        ]
+    };
+
+    await mockTeamPageModules(page, scenario);
+    await page.goto(buildUrl(baseURL, '/team.html#teamId=team-a'), { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#schedule-list')).toContainText('Falcons');
+    await expect(page.locator('#schedule-list')).not.toContainText('Meteors');
+    await expect(page.locator('#schedule-list')).not.toContainText('Storm');
+    await expect(page.locator('#schedule-list')).not.toContainText('Duplicate FC');
+
+    await page.locator('#schedule-filter-all-upcoming').click();
+    await expect(page.locator('#schedule-list')).toContainText('Meteors');
+    await expect(page.locator('#schedule-list')).not.toContainText('Storm');
+    await expect(page.locator('#schedule-list')).not.toContainText('Duplicate FC');
+    await expect(page.locator('#schedule-list')).not.toContainText('Falcons');
+
+    await page.locator('#schedule-view-calendar').click();
+    await gotoCalendarMonth(page, now, upcomingDate);
+    await expect(page.locator('#schedule-calendar-grid')).toContainText('vs Meteors');
+    await expect(page.locator('#schedule-calendar-grid')).not.toContainText('Storm');
+    await expect(page.locator('#schedule-calendar-grid')).not.toContainText('Duplicate FC');
+
+    await page.locator('#schedule-filter-past-events').click();
+    await page.locator('#schedule-view-list').click();
+    await expect(page.locator('#schedule-list')).toContainText('Falcons');
+    await expect(page.locator('#schedule-list')).toContainText('Storm');
+    await expect(page.locator('#schedule-list')).not.toContainText('Meteors');
+    await expect(page.locator('#schedule-list')).not.toContainText('Duplicate FC');
+
+    await page.locator('#schedule-view-calendar').click();
+    await gotoCalendarMonth(page, upcomingDate, cancelledDate);
+    await expect(page.locator('#schedule-calendar-grid')).toContainText('vs Storm');
+    await expect(page.locator('#schedule-calendar-grid')).not.toContainText('Duplicate FC');
+});

--- a/tests/unit/team-schedule-filter.test.js
+++ b/tests/unit/team-schedule-filter.test.js
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function loadGetFilteredScheduleEvents() {
+    const source = readFileSync(new URL('../../team.html', import.meta.url), 'utf8');
+    const start = source.indexOf('function getFilteredScheduleEvents() {');
+    const end = source.indexOf('\n        function renderScheduleFromControls()', start);
+
+    if (start === -1 || end === -1) {
+        throw new Error('Could not locate getFilteredScheduleEvents() in team.html');
+    }
+
+    const functionSource = source.slice(start, end);
+    return new Function('context', `
+        let allScheduleEvents = context.allScheduleEvents;
+        let showPractices = context.showPractices;
+        let scheduleViewFilter = context.scheduleViewFilter;
+        ${functionSource}
+        return getFilteredScheduleEvents();
+    `);
+}
+
+function hoursFromNow(offsetHours) {
+    return new Date(Date.now() + (offsetHours * 60 * 60 * 1000));
+}
+
+describe('team schedule filtering', () => {
+    it('forces practice visibility for the upcoming-practices filter even when the checkbox is off', () => {
+        const getFilteredScheduleEvents = loadGetFilteredScheduleEvents();
+        const result = getFilteredScheduleEvents({
+            showPractices: false,
+            scheduleViewFilter: 'upcoming-practices',
+            allScheduleEvents: [
+                {
+                    type: 'db',
+                    isPractice: false,
+                    status: 'scheduled',
+                    date: hoursFromNow(24),
+                    opponent: 'Rivals FC'
+                },
+                {
+                    type: 'calendar',
+                    isPractice: true,
+                    isCancelled: false,
+                    date: hoursFromNow(25),
+                    opponent: 'Practice'
+                }
+            ]
+        });
+
+        expect(result).toHaveLength(1);
+        expect(result[0].isPractice).toBe(true);
+        expect(result[0].opponent).toBe('Practice');
+    });
+
+    it('keeps cancelled future events out of all-upcoming and in past-events', () => {
+        const getFilteredScheduleEvents = loadGetFilteredScheduleEvents();
+        const cancelledEvent = {
+            type: 'calendar',
+            isPractice: false,
+            isCancelled: true,
+            date: hoursFromNow(48),
+            opponent: 'Storm'
+        };
+
+        const allUpcoming = getFilteredScheduleEvents({
+            showPractices: true,
+            scheduleViewFilter: 'all-upcoming',
+            allScheduleEvents: [cancelledEvent]
+        });
+        const pastEvents = getFilteredScheduleEvents({
+            showPractices: true,
+            scheduleViewFilter: 'past-events',
+            allScheduleEvents: [cancelledEvent]
+        });
+
+        expect(allUpcoming).toHaveLength(0);
+        expect(pastEvents).toHaveLength(1);
+        expect(pastEvents[0].opponent).toBe('Storm');
+    });
+});


### PR DESCRIPTION
Closes #446

## What changed
- added `tests/smoke/team-schedule-calendar.spec.js` to cover `team.html` schedule list/calendar behavior, duplicate tracked UID suppression, cancelled-event bucketing, and clicked-day modal filtering
- added `tests/unit/team-schedule-filter.test.js` to pin the Team page filter logic in the existing Vitest lane
- updated `team.html` so the dedicated `Upcoming Practices` filter forces practice visibility even when `Show Practices` remains off, matching the established `edit-schedule.html` behavior
- persisted the required run notes under `docs/pr-notes/runs/issue-446-fixer-20260401T082532Z/`

## Why
`team.html` was filtering out practice events before the `upcoming-practices` branch ran. That caused calendar mode and the clicked-day modal to miss valid practice events unless the user manually enabled the practice checkbox, which diverged from the intended dedicated-practice filter behavior.

## Validation
- passed: `./node_modules/.bin/vitest run tests/unit/team-schedule-filter.test.js`
- passed: `./node_modules/.bin/playwright test -c playwright.smoke.config.js tests/smoke/team-schedule-calendar.spec.js --list`
- blocked by host environment: `./node_modules/.bin/playwright test -c playwright.smoke.config.js tests/smoke/team-schedule-calendar.spec.js` could not launch Chromium because required Linux Playwright browser libraries are not installed on this machine