### PR TITLE
Verify admin invite acceptance grants team access

### DIFF
--- a/accept-invite.html
+++ b/accept-invite.html
@@ -137,7 +137,7 @@
     <script type="module">
         import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=11';
         import { validateAccessCode, redeemParentInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=15';
-        import { createInviteProcessor } from './js/accept-invite-flow.js?v=3';
+        import { createInviteProcessor } from './js/accept-invite-flow.js?v=4';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 
         renderFooter(document.getElementById('footer-container'));

--- a/docs/pr-notes/runs/issue-427-fixer-20260401T202503Z/architecture.md
+++ b/docs/pr-notes/runs/issue-427-fixer-20260401T202503Z/architecture.md
@@ -1,0 +1,4 @@
+# Architecture synthesis
+
+- Authorization source of truth is teams/{teamId}.adminEmails.
+- Minimal safe fix should align invite acceptance with that source of truth rather than broadening access rules.

--- a/docs/pr-notes/runs/issue-427-fixer-20260401T202503Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-427-fixer-20260401T202503Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code plan
+
+- Inspect existing critical/spec/unit tests around auth and invite acceptance.
+- Write failing tests for admin invite acceptance and resulting access state.
+- Apply minimal code fix to persist admin email on the team during acceptance.
+- Run targeted tests and commit.

--- a/docs/pr-notes/runs/issue-427-fixer-20260401T202503Z/qa.md
+++ b/docs/pr-notes/runs/issue-427-fixer-20260401T202503Z/qa.md
@@ -1,0 +1,4 @@
+# QA synthesis
+
+- Add end-to-end style coverage for admin invite acceptance success path.
+- Add regression coverage proving coachOf alone does not unlock team management.

--- a/docs/pr-notes/runs/issue-427-fixer-20260401T202503Z/requirements.md
+++ b/docs/pr-notes/runs/issue-427-fixer-20260401T202503Z/requirements.md
@@ -1,0 +1,5 @@
+# Requirements synthesis
+
+- Role skills unavailable in this session; synthesized by main lane.
+- Objective: prove invited admins can actually manage a team after accepting the invite.
+- Risk: false success path where acceptance updates user profile but not team admin authorization.

--- a/js/accept-invite-flow.js
+++ b/js/accept-invite-flow.js
@@ -1,3 +1,5 @@
+import { hasFullTeamAccess } from './team-access.js?v=1';
+
 export function createInviteProcessor(deps) {
     return async function processInvite(userId, code, authEmail = null) {
         return processInviteCode(userId, code, deps, authEmail);
@@ -39,6 +41,22 @@ export async function processInviteCode(userId, code, deps, authEmail = null) {
         const redeemResult = await redeemAdminInviteAtomically(validation.codeId, userId, authEmail);
         if (!redeemResult || !redeemResult.success) {
             throw new Error('Failed to redeem admin invite atomically');
+        }
+
+        const teamId = redeemResult.teamId || validation?.data?.teamId || null;
+        const [team, profile] = await Promise.all([
+            typeof getTeam === 'function' && teamId ? getTeam(teamId) : null,
+            typeof getUserProfile === 'function' ? getUserProfile(userId) : null
+        ]);
+        const accessUser = {
+            uid: userId,
+            email: authEmail,
+            profileEmail: profile?.email,
+            isAdmin: profile?.isAdmin === true
+        };
+
+        if (!team || !hasFullTeamAccess(accessUser, { ...team, id: team?.id || teamId })) {
+            throw new Error('Admin invite did not grant team management access');
         }
 
         return {

--- a/tests/unit/accept-invite-flow.test.js
+++ b/tests/unit/accept-invite-flow.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { createInviteProcessor } from '../../js/accept-invite-flow.js';
+import { hasFullTeamAccess } from '../../js/team-access.js';
 
 describe('accept invite flow', () => {
     it('redeems admin invite codes via atomic redemption when available', async () => {
@@ -11,7 +12,15 @@ describe('accept invite flow', () => {
                 data: { teamId: 'team-1' }
             })),
             redeemParentInvite: vi.fn(),
-            getTeam: vi.fn(),
+            getTeam: vi.fn(async () => ({
+                id: 'team-1',
+                name: 'Tigers',
+                ownerId: 'owner-1',
+                adminEmails: ['coach@example.com']
+            })),
+            getUserProfile: vi.fn(async () => ({
+                email: 'coach@example.com'
+            })),
             redeemAdminInviteAtomically: vi.fn().mockResolvedValue({
                 success: true,
                 teamId: 'team-1',
@@ -26,6 +35,48 @@ describe('accept invite flow', () => {
         expect(result.redirectUrl).toBe('dashboard.html');
         expect(result.message).toContain('Tigers');
         expect(deps.redeemAdminInviteAtomically).toHaveBeenCalledWith('code-123', 'user-1', 'Coach@Example.com');
+    });
+
+    it('verifies admin invite acceptance leaves the invited user with edit-team access', async () => {
+        const team = {
+            id: 'team-7',
+            ownerId: 'owner-1',
+            name: 'Falcons',
+            adminEmails: ['newadmin@example.com']
+        };
+        const deps = {
+            validateAccessCode: vi.fn(async () => ({
+                valid: true,
+                codeId: 'code-127',
+                type: 'admin_invite',
+                data: { teamId: 'team-7' }
+            })),
+            redeemParentInvite: vi.fn(),
+            getTeam: vi.fn(async () => team),
+            getUserProfile: vi.fn(async () => ({
+                email: 'newadmin@example.com',
+                coachOf: ['team-7'],
+                roles: ['coach']
+            })),
+            redeemAdminInviteAtomically: vi.fn().mockResolvedValue({
+                success: true,
+                teamId: 'team-7',
+                teamName: 'Falcons'
+            })
+        };
+
+        const processInvite = createInviteProcessor(deps);
+        const result = await processInvite('user-7', 'ABCD7777', 'NewAdmin@Example.com');
+
+        expect(result).toEqual({
+            success: true,
+            message: "You've been added as an admin of Falcons!",
+            redirectUrl: 'dashboard.html'
+        });
+        expect(hasFullTeamAccess(
+            { uid: 'user-7', email: 'NewAdmin@Example.com', coachOf: ['team-7'], roles: ['coach'] },
+            team
+        )).toBe(true);
     });
 
     it('bubbles atomic admin redemption errors', async () => {
@@ -63,6 +114,40 @@ describe('accept invite flow', () => {
 
         await expect(processInvite('user-4', 'MNOP3456')).rejects.toThrow(
             'Failed to redeem admin invite atomically'
+        );
+    });
+
+    it('rejects false-success admin invite redemption when team admin access was not actually granted', async () => {
+        const deps = {
+            validateAccessCode: vi.fn(async () => ({
+                valid: true,
+                codeId: 'code-128',
+                type: 'admin_invite',
+                data: { teamId: 'team-8' }
+            })),
+            redeemParentInvite: vi.fn(),
+            getTeam: vi.fn(async () => ({
+                id: 'team-8',
+                ownerId: 'owner-1',
+                name: 'Owls',
+                adminEmails: ['owner@example.com']
+            })),
+            getUserProfile: vi.fn(async () => ({
+                email: 'newadmin@example.com',
+                coachOf: ['team-8'],
+                roles: ['coach']
+            })),
+            redeemAdminInviteAtomically: vi.fn().mockResolvedValue({
+                success: true,
+                teamId: 'team-8',
+                teamName: 'Owls'
+            })
+        };
+
+        const processInvite = createInviteProcessor(deps);
+
+        await expect(processInvite('user-8', 'WXYZ8888', 'newadmin@example.com')).rejects.toThrow(
+            'Admin invite did not grant team management access'
         );
     });
 

--- a/tests/unit/accept-invite-page.test.js
+++ b/tests/unit/accept-invite-page.test.js
@@ -111,7 +111,7 @@ const setTimeout = deps.setTimeout;
             'const { validateAccessCode, redeemParentInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } = deps.db;'
         )
         .replace(
-            "import { createInviteProcessor } from './js/accept-invite-flow.js?v=3';",
+            "import { createInviteProcessor } from './js/accept-invite-flow.js?v=4';",
             'const { createInviteProcessor } = deps.acceptInviteFlow;'
         )
         .replace(

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -18,7 +18,7 @@ describe('admin invite signup cache busting', () => {
             "import { validateAccessCode, redeemParentInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=15';"
         );
         expect(acceptInviteSource).toContain(
-            "import { createInviteProcessor } from './js/accept-invite-flow.js?v=3';"
+            "import { createInviteProcessor } from './js/accept-invite-flow.js?v=4';"
         );
     });
 


### PR DESCRIPTION
Closes #427

## What changed
- added admin-invite acceptance coverage that follows the success path through invite redemption and asserts the invited user ends with real `edit-team.html` access
- added a regression test for the false-success case where invite redemption returns success but the team still does not authorize the user through `adminEmails`
- hardened `accept-invite-flow.js` so it only reports admin invite success after verifying the same full-team-access rule used by team management pages
- bumped the `accept-invite` flow module version and updated the cache-busting test so browsers pull the hardened invite flow

## Why
The previous acceptance flow trusted the redemption callback's success flag and could show a success message without confirming that the invited user could actually manage the team afterward. This change makes the invite acceptance path enforce the real authorization outcome and locks that behavior in with targeted tests.