### PR TITLE
Guard resumed finish flow from partial score log overwrite

### DIFF
--- a/docs/pr-notes/runs/issue-450-fixer-20260401T225503Z/architecture.md
+++ b/docs/pr-notes/runs/issue-450-fixer-20260401T225503Z/architecture.md
@@ -1,0 +1,21 @@
+Thinking level: medium
+Reason: this is a targeted regression test gap with a narrow runtime branch in a large page module.
+
+Current state:
+- `js/live-tracker.js` builds a finish plan, conditionally injects a reconciliation log entry, then writes events/stats/game update.
+- `js/live-tracker-finish.js` already owns the pure finish-plan construction.
+
+Proposed state:
+- Move the conditional "prepare the plan for save execution" step into `js/live-tracker-finish.js`.
+- Keep DOM mutation and rendering in `js/live-tracker.js`, but make the branch decision testable as a pure function.
+
+Why this path:
+- Smallest change that gets execution coverage without adding a browser/Firebase harness.
+- Preserves current controls and limits blast radius to the finish-flow composition layer.
+
+Controls comparison:
+- Current: branch logic is embedded in page code and only source-wiring-tested.
+- New: same branch logic is still used by page code, but enforced by unit tests on a pure helper.
+
+Rollback:
+- Revert the helper extraction and accompanying test file changes only.

--- a/docs/pr-notes/runs/issue-450-fixer-20260401T225503Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-450-fixer-20260401T225503Z/code-plan.md
@@ -1,0 +1,10 @@
+Plan:
+1. Add a fail-first unit test in `tests/unit/live-tracker-finish.test.js` for resumed incomplete logs through a new save-preparation seam.
+2. Extract the conditional mismatch/log-entry logic from `saveAndComplete()` into `js/live-tracker-finish.js`.
+3. Update `js/live-tracker.js` to use the helper and keep DOM/render side effects local.
+4. Run targeted Vitest coverage for finish and integrity behavior.
+5. Commit all changes with an issue-referencing message.
+
+Non-goals:
+- No refactor of unrelated tracker behavior.
+- No change to reconciliation rules themselves.

--- a/docs/pr-notes/runs/issue-450-fixer-20260401T225503Z/qa.md
+++ b/docs/pr-notes/runs/issue-450-fixer-20260401T225503Z/qa.md
@@ -1,0 +1,17 @@
+Primary regression to catch:
+- Resumed game with persisted live data, partial score log, coach-entered final score differs from derived log score, save must preserve entered score.
+
+Test intent:
+1. Build a finish-save preparation with `scoreLogIsComplete: false` and a partial scoring log.
+2. Assert no reconciliation log entry is added.
+3. Assert `gameUpdate.homeScore` and `gameUpdate.awayScore` match the entered wrap-up score.
+4. Assert `gameUpdate.status` is still `completed`.
+5. Assert `live-tracker.js` uses the extracted helper so the page path stays covered.
+
+Risk notes:
+- False positives if the test only exercises `buildFinishCompletionPlan()`. That path is already covered and is not sufficient.
+- Avoid broad DOM mocks. The branch decision is pure and should stay that way.
+
+Validation:
+- Run the targeted unit test file first to observe failure before the helper exists.
+- Run the targeted finish-related unit suite after the patch.

--- a/docs/pr-notes/runs/issue-450-fixer-20260401T225503Z/requirements.md
+++ b/docs/pr-notes/runs/issue-450-fixer-20260401T225503Z/requirements.md
@@ -1,0 +1,27 @@
+Objective: prevent finish-flow regressions from overwriting a coach-entered final score when a resumed live tracker has an incomplete score log.
+
+Current state:
+- Helper tests cover score reconciliation rules.
+- No execution-level test covers the `saveAndComplete()` branch that decides whether reconciliation is allowed.
+
+Proposed state:
+- Add a regression test around the finish-flow execution seam that preserves entered scores when `scoreLogIsComplete` is `false`.
+- Assert the flow still persists `status: 'completed'` and does not append a reconciliation note.
+
+Risk surface:
+- User-visible final score on completed games.
+- Audit trail pollution if a false reconciliation note is added.
+- Low blast radius if fixed in the finish-flow helper path only.
+
+Assumptions:
+- Resumed persisted games intentionally mark `scoreLogIsComplete = false`.
+- Partial score logs are expected and must not be trusted at completion.
+- Existing helper behavior is correct; the gap is runtime coverage around the save wrapper.
+
+Recommendation:
+- Extract the small reconciliation-and-log-entry step out of `saveAndComplete()` into a pure helper in `js/live-tracker-finish.js`.
+- Cover the resumed incomplete-log scenario there and keep the page flow behavior unchanged.
+
+Success measure:
+- A test fails if finish flow ever reconciles or logs reconciliation when `scoreLogIsComplete` is false.
+- Targeted unit tests pass with no unrelated behavior changes.

--- a/js/live-tracker-finish.js
+++ b/js/live-tracker-finish.js
@@ -159,6 +159,38 @@ export function buildFinishCompletionPlan({
   };
 }
 
+export function prepareFinishPlanForSave({
+  finishPlanArgs = {},
+  period = '',
+  clock = '',
+  now = () => Date.now(),
+  buildPlan = buildFinishCompletionPlan
+} = {}) {
+  let finishPlan = buildPlan(finishPlanArgs);
+  let addedReconciliationLogEntry = null;
+  let updatedLog = Array.isArray(finishPlanArgs.log) ? finishPlanArgs.log : [];
+
+  if (finishPlan.scoreReconciliation.mismatch) {
+    addedReconciliationLogEntry = {
+      text: finishPlan.reconciliationNote,
+      ts: now(),
+      period,
+      clock
+    };
+    updatedLog = [addedReconciliationLogEntry, ...updatedLog];
+    finishPlan = buildPlan({
+      ...finishPlanArgs,
+      log: updatedLog
+    });
+  }
+
+  return {
+    finishPlan,
+    addedReconciliationLogEntry,
+    updatedLog
+  };
+}
+
 export function executeFinishNavigationPlan(navigation = [], {
   navigate = (href) => {
     window.location.href = href;

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -16,7 +16,7 @@ import { buildLiveResetEvent } from './live-tracker-reset.js?v=1';
 import { advanceLiveChatUnreadState } from './live-tracker-chat-unread.js?v=2';
 import { resolveLiveStatConfig, resolveLiveStatColumns } from './live-game-state.js?v=3';
 import { getDefaultLivePeriod, getSportPeriodLabels } from './live-sport-config.js?v=1';
-import { buildOpponentStatsSnapshotFromEntries, buildFinishCompletionPlan, executeFinishNavigationPlan } from './live-tracker-finish.js?v=1';
+import { buildOpponentStatsSnapshotFromEntries, buildFinishCompletionPlan, prepareFinishPlanForSave, executeFinishNavigationPlan } from './live-tracker-finish.js?v=1';
 
 let currentTeamId = null;
 let currentGameId = null;
@@ -1461,24 +1461,19 @@ async function saveAndComplete() {
     currentUserUid: currentUser?.uid,
     buildEmailBody: (finalHome, finalAway, recapSummary, logEntries) => generateEmailBody(finalHome, finalAway, recapSummary, logEntries)
   };
-  let finishPlan = buildFinishCompletionPlan(finishPlanArgs);
-  let addedReconciliationLogEntry = null;
+  const preparedFinish = prepareFinishPlanForSave({
+    finishPlanArgs,
+    period: state.period,
+    clock: formatClock(state.clock)
+  });
+  let finishPlan = preparedFinish.finishPlan;
+  const addedReconciliationLogEntry = preparedFinish.addedReconciliationLogEntry;
 
-  if (finishPlan.scoreReconciliation.mismatch) {
-    addedReconciliationLogEntry = {
-      text: finishPlan.reconciliationNote,
-      ts: Date.now(),
-      period: state.period,
-      clock: formatClock(state.clock)
-    };
-    state.log.unshift(addedReconciliationLogEntry);
+  if (addedReconciliationLogEntry) {
+    state.log = preparedFinish.updatedLog;
     renderLog();
     els.homeFinal.value = String(finishPlan.finalHome);
     els.awayFinal.value = String(finishPlan.finalAway);
-    finishPlan = buildFinishCompletionPlan({
-      ...finishPlanArgs,
-      log: state.log
-    });
   }
 
   try {

--- a/tests/unit/live-tracker-finish.test.js
+++ b/tests/unit/live-tracker-finish.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { buildFinishCompletionPlan } from '../../js/live-tracker-finish.js';
+import { readFileSync } from 'node:fs';
+import { buildFinishCompletionPlan, prepareFinishPlanForSave } from '../../js/live-tracker-finish.js';
 
 describe('live tracker finish completion plan', () => {
   it('reconciles the saved game outcome and persisted stats from the score log', () => {
@@ -207,5 +208,51 @@ describe('live tracker finish completion plan', () => {
         }
       ]
     });
+  });
+
+  it('keeps the coach-entered final score when resumed data marks the score log incomplete', () => {
+    const originalLog = [
+      { text: 'Home bucket', clock: '05:10', period: 'Q1', ts: 11, undoData: { type: 'stat', statKey: 'PTS', value: 2, isOpponent: false, playerId: 'p1' } }
+    ];
+
+    const prepared = prepareFinishPlanForSave({
+      finishPlanArgs: {
+        requestedHome: 51,
+        requestedAway: 48,
+        liveHome: 51,
+        liveAway: 48,
+        scoreLogIsComplete: false,
+        log: originalLog,
+        summary: 'Closed it out.',
+        sendEmail: false,
+        teamId: 'team-1',
+        gameId: 'game-9',
+        teamName: 'Tigers',
+        opponentName: 'Bears',
+        recipientEmail: 'coach@example.com',
+        columns: ['PTS'],
+        roster: [],
+        statsByPlayerId: {},
+        opponentEntries: [],
+        buildEmailBody: () => 'unused body'
+      },
+      period: 'Q4',
+      clock: '00:00',
+      now: () => 99
+    });
+
+    expect(prepared.addedReconciliationLogEntry).toBeNull();
+    expect(prepared.updatedLog).toEqual(originalLog);
+    expect(prepared.finishPlan.reconciliationNote).toBe('');
+    expect(prepared.finishPlan.gameUpdate).toMatchObject({
+      homeScore: 51,
+      awayScore: 48,
+      status: 'completed'
+    });
+  });
+
+  it('wires save preparation through the shared finish helper in live tracker', () => {
+    const source = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8');
+    expect(source).toContain('prepareFinishPlanForSave');
   });
 });


### PR DESCRIPTION
Closes #450

## What changed
- extracted the `saveAndComplete()` reconciliation-or-not preparation step into `prepareFinishPlanForSave()` in `js/live-tracker-finish.js`
- updated `js/live-tracker.js` to use that shared helper before persisting finish-flow writes
- added a regression test that covers a resumed game with `scoreLogIsComplete = false` and verifies the entered wrap-up score is preserved, no reconciliation note is added, and the game still saves as completed
- added the required per-run requirements, architecture, QA, and code-plan notes under `docs/pr-notes/runs/issue-450-fixer-20260401T225503Z/`

## Why
The existing helper tests covered score reconciliation rules, but the runtime finish-flow branch in `saveAndComplete()` was not execution-tested. This patch makes that branch testable and locks in the behavior that resumed incomplete score logs must not overwrite the coach's final score at completion.

## Validation
- `./node_modules/.bin/vitest run tests/unit/live-tracker-finish.test.js tests/unit/live-tracker-integrity.test.js tests/unit/live-tracker-email.test.js`