### PR TITLE
Hide cancelled games from the homepage list

### DIFF
--- a/docs/pr-notes/runs/460-ci-fix-20260402T040112Z/architecture.md
+++ b/docs/pr-notes/runs/460-ci-fix-20260402T040112Z/architecture.md
@@ -1,0 +1,8 @@
+# Architecture
+
+- Objective: restore the `cache-bust-guard` check for PR #460.
+- Current state: `js/db.js` changed in this PR, but `index.html` still imports `./js/db.js?v=15`, so the homepage can keep serving the cached pre-fix module.
+- Proposed state: bump the homepage import to `./js/db.js?v=16` so the changed `getUpcomingLiveGames` logic is cache-busted where this PR uses it.
+- Risk surface: limited to the homepage module import in `index.html`.
+- Blast radius: low; no runtime logic changes beyond loading the updated `db.js` asset for the index page.
+- Assumptions: the changed `db.js` behavior is only required for the homepage flow touched by this PR, and broader app-wide cache busting is unnecessary for this fix.

--- a/docs/pr-notes/runs/460-ci-fix-20260402T040112Z/code-plan.md
+++ b/docs/pr-notes/runs/460-ci-fix-20260402T040112Z/code-plan.md
@@ -1,0 +1,5 @@
+# Code Plan
+
+1. Add the required run notes for architecture, QA, and code plan under `docs/pr-notes/runs/460-ci-fix-20260402T040112Z/`.
+2. Bump the `index.html` import of `./js/db.js` from `?v=15` to `?v=16` so the homepage loads the changed module.
+3. Run the cache-bust guard locally, review the diff scope, then stage and commit the fix with the required commit message format.

--- a/docs/pr-notes/runs/460-ci-fix-20260402T040112Z/qa.md
+++ b/docs/pr-notes/runs/460-ci-fix-20260402T040112Z/qa.md
@@ -1,0 +1,6 @@
+# QA
+
+- Root cause evidence: the CI log reports `js/db.js changed without a matching db.js version bump in imports.`
+- Scope evidence: PR #460 changes `getUpcomingLiveGames` in `js/db.js` and the homepage consumes that function via the direct `index.html` import.
+- Validation plan: run `node scripts/check-critical-cache-bust.mjs` against the PR diff and confirm the check passes; inspect the diff to ensure only the cache-bust import and requested notes were added.
+- Residual risk: there is no automated browser test for cache invalidation itself, so final end-to-end confirmation still relies on CI rerun behavior.

--- a/docs/pr-notes/runs/460-remediator-20260402T040904Z/architecture.md
+++ b/docs/pr-notes/runs/460-remediator-20260402T040904Z/architecture.md
@@ -1,0 +1,8 @@
+Architecture role
+Objective: preserve user-visible card count without broad refactor.
+Current state: query uses date window + ordering + limit, then filters cancelled in JS.
+Proposed state: move cancelled exclusion into the query if Firestore supports it with the current ordering, else keep the query stable and over-fetch modestly before final slice.
+Blast radius: one read helper in js/db.js; no schema changes.
+Controls: keep same public interface and same returned shape.
+Tradeoff: in-query filtering is cleaner and cheaper, but may require composite index support; bounded over-fetch is more compatible but slightly increases reads.
+Recommendation: choose the smallest compatible fix after inspecting current query shape.

--- a/docs/pr-notes/runs/460-remediator-20260402T040904Z/code-plan.md
+++ b/docs/pr-notes/runs/460-remediator-20260402T040904Z/code-plan.md
@@ -1,0 +1,2 @@
+Code role
+Plan: inspect getUpcomingLiveGames implementation, apply the smallest change that preserves returned count after cancelled filtering, then run a lightweight validation and commit only the scoped files plus required role notes.

--- a/docs/pr-notes/runs/460-remediator-20260402T040904Z/qa.md
+++ b/docs/pr-notes/runs/460-remediator-20260402T040904Z/qa.md
@@ -1,0 +1,5 @@
+QA role
+Focus: verify visible count and filtering behavior.
+Manual checks: 1) with first N games cancelled and later games active, function still yields limitCount active games when enough exist. 2) when fewer than limitCount active games exist in the 7-day window, function returns only available active games. 3) live games remain unaffected.
+Risk: Firestore query/operator combination could fail if unsupported or missing index.
+Validation: run any available targeted static/manual checks and inspect diff carefully since there is no automated runner.

--- a/docs/pr-notes/runs/460-remediator-20260402T040904Z/requirements.md
+++ b/docs/pr-notes/runs/460-remediator-20260402T040904Z/requirements.md
@@ -1,0 +1,8 @@
+Requirements role
+Objective: preserve the requested visible upcoming-game count after excluding cancelled games.
+Current state: Firestore query limits before client-side status filtering, so cancelled records consume slots.
+Proposed state: cancelled games must be excluded before the effective count is applied, while keeping the 7-day window and existing sort order.
+Risk surface: homepage upcoming cards and any callers of getUpcomingLiveGames(limit). Blast radius is limited to this data fetch path.
+Assumptions: game status values are stored as lowercase strings and cancelled games should never appear in upcoming/live sections.
+Recommendation: prefer adding a Firestore where-clause that excludes cancelled status if supported by existing query constraints; otherwise over-fetch with a bounded buffer and trim after filtering.
+Success: getUpcomingLiveGames(6) returns up to 6 non-cancelled games when enough exist within the window.

--- a/docs/pr-notes/runs/issue-456-fixer-20260402T035507Z/architecture.md
+++ b/docs/pr-notes/runs/issue-456-fixer-20260402T035507Z/architecture.md
@@ -1,0 +1,16 @@
+# Architecture Role (allplays-architecture-expert)
+
+## Root Cause
+`getUpcomingLiveGames()` excludes practices and completed games but does not exclude `status: 'cancelled'`, so homepage consumers receive cancelled records and render them as normal upcoming cards.
+
+## Minimal Safe Fix
+- Filter cancelled games out of `getUpcomingLiveGames()` at the source.
+- Add a homepage-level guard so cancelled upcoming entries do not render even if upstream data is stale or partially filtered.
+
+## Blast Radius
+- Data source change is limited to `js/db.js` upcoming-game discovery.
+- UI guard is limited to `js/homepage.js` card composition for the index page.
+
+## Controls
+- Add a unit regression test for homepage rendering with mixed upcoming game statuses.
+- Keep the patch local to cancellation filtering; no routing or schema changes.

--- a/docs/pr-notes/runs/issue-456-fixer-20260402T035507Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-456-fixer-20260402T035507Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Role (allplays-code-expert)
+
+## Plan
+1. Add a homepage regression test covering cancelled upcoming games.
+2. Filter cancelled items from homepage upcoming rendering.
+3. Tighten `getUpcomingLiveGames()` to exclude cancelled records at the data source.
+4. Run focused Vitest coverage for the homepage workflow and commit with issue reference.
+
+## Non-Goals
+- No redesign of cancelled-game presentation on `live-game.html`.
+- No broader schedule status refactor.

--- a/docs/pr-notes/runs/issue-456-fixer-20260402T035507Z/qa.md
+++ b/docs/pr-notes/runs/issue-456-fixer-20260402T035507Z/qa.md
@@ -1,0 +1,16 @@
+# QA Role (allplays-qa-expert)
+
+## Test Strategy
+1. Reproduce the bug at the homepage layer with one cancelled upcoming game and one valid upcoming game.
+2. Assert the cancelled game does not appear in rendered markup and does not contribute a `live-game.html` link.
+3. Run the focused homepage unit test file, then run the repo unit suite if the focused test is clean and execution time is reasonable.
+
+## Regression Guardrails
+- Preserve rendering for non-cancelled upcoming cards.
+- Preserve dedupe behavior between live and upcoming lists.
+- Preserve empty-state messaging when every upcoming item is filtered out.
+
+## Manual Smoke
+- Cancel a game scheduled within seven days.
+- Load `index.html`.
+- Confirm the cancelled game card is absent from "Live & Upcoming Games".

--- a/docs/pr-notes/runs/issue-456-fixer-20260402T035507Z/requirements.md
+++ b/docs/pr-notes/runs/issue-456-fixer-20260402T035507Z/requirements.md
@@ -1,0 +1,21 @@
+# Requirements Role (allplays-requirements-expert)
+
+## Objective
+Keep cancelled games out of the public homepage "Live & Upcoming Games" list so visitors are not sent into a misleading watch flow.
+
+## Current vs Proposed
+- Current: homepage upcoming cards treat cancelled games like ordinary scheduled games.
+- Proposed: cancelled games are excluded from the homepage live/upcoming feed and no watch link is rendered for them there.
+
+## User Impact
+- Visitors should only see genuinely live or upcoming watchable games.
+- Staff cancellation actions should propagate cleanly to the public homepage experience.
+
+## Acceptance Criteria
+1. A game with `status: 'cancelled'` does not render in the homepage live/upcoming list.
+2. Non-cancelled upcoming games still render with their normal watch/details link.
+3. Existing live-game and replay homepage behavior remains unchanged.
+
+## Risks
+- If filtering only happens at render time, other consumers of the same query could still receive cancelled games.
+- If filtering happens too broadly, valid scheduled games could disappear from the homepage.

--- a/index.html
+++ b/index.html
@@ -653,7 +653,7 @@
   <script type="module">
     import { checkAuth } from './js/auth.js?v=10';
     import { renderHeader, formatDate, formatTime } from './js/utils.js?v=8';
-    import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=15';
+    import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=16';
     import { initHomepage } from './js/homepage.js?v=1';
 
     initHomepage({

--- a/js/db.js
+++ b/js/db.js
@@ -2770,7 +2770,7 @@ export async function getUpcomingLiveGames(limitCount = 10) {
 
     for (const docSnap of snapshot.docs) {
         const gameData = { id: docSnap.id, ...docSnap.data() };
-        if (gameData.type === 'practice' || gameData.status === 'completed' || gameData.liveStatus === 'completed') {
+        if (gameData.type === 'practice' || gameData.status === 'completed' || gameData.status === 'cancelled' || gameData.liveStatus === 'completed') {
             continue;
         }
         if (!gameData.type) {

--- a/js/db.js
+++ b/js/db.js
@@ -2745,54 +2745,101 @@ export async function getUpcomingLiveGames(limitCount = 10) {
     const now = new Date();
     const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate());
     const oneWeekFromNow = new Date(now.getTime() + 7 * 24 * 60 * 60 * 1000);
+    const fetchBatchSize = Math.max(limitCount * 3, 20);
 
     const gamesRef = collectionGroup(db, 'games');
-    const q = query(
-        gamesRef,
+    const queryConstraints = [
         where('type', '==', 'game'),
         where('date', '>=', Timestamp.fromDate(startOfToday)),
         where('date', '<=', Timestamp.fromDate(oneWeekFromNow)),
-        orderBy('date', 'asc'),
-        limitQuery(limitCount)
-    );
-
-    let snapshot;
+        orderBy('date', 'asc')
+    ];
     const games = [];
+    let snapshot;
 
     try {
-        snapshot = await getDocs(q);
+        let lastDoc = null;
+        let exhausted = false;
+
+        while (games.length < limitCount && !exhausted) {
+            const pageConstraints = [...queryConstraints, limitQuery(fetchBatchSize)];
+            if (lastDoc) {
+                pageConstraints.push(startAfterQuery(lastDoc));
+            }
+
+            snapshot = await getDocs(query(gamesRef, ...pageConstraints));
+            if (snapshot.empty) {
+                break;
+            }
+
+            lastDoc = snapshot.docs[snapshot.docs.length - 1];
+
+            for (const docSnap of snapshot.docs) {
+                const gameData = { id: docSnap.id, ...docSnap.data() };
+                if (gameData.type === 'practice' || gameData.status === 'completed' || gameData.status === 'cancelled' || gameData.liveStatus === 'completed') {
+                    continue;
+                }
+                if (!gameData.type) {
+                    gameData.type = 'game';
+                }
+                const gameDate = gameData.date?.toDate ? gameData.date.toDate() : new Date(gameData.date);
+                if (gameDate < startOfToday || gameDate > oneWeekFromNow) {
+                    continue;
+                }
+                // Get team info (parent document)
+                const teamRef = docSnap.ref.parent.parent;
+                const teamSnap = await getDoc(teamRef);
+                if (teamSnap.exists()) {
+                    gameData.team = { id: teamSnap.id, ...teamSnap.data() };
+                    gameData.teamId = teamSnap.id;
+                    if (!shouldIncludeTeamInLiveOrUpcoming(gameData.team)) {
+                        continue;
+                    }
+                } else {
+                    continue;
+                }
+                games.push(gameData);
+                if (games.length >= limitCount) {
+                    break;
+                }
+            }
+
+            exhausted = snapshot.docs.length < fetchBatchSize;
+        }
     } catch (error) {
         // Fallback when the collection group date index isn't ready yet.
         // Pull a limited sample and filter client-side.
         const fallbackQuery = query(gamesRef, limitQuery(200));
         snapshot = await getDocs(fallbackQuery);
-    }
-
-    for (const docSnap of snapshot.docs) {
-        const gameData = { id: docSnap.id, ...docSnap.data() };
-        if (gameData.type === 'practice' || gameData.status === 'completed' || gameData.status === 'cancelled' || gameData.liveStatus === 'completed') {
-            continue;
-        }
-        if (!gameData.type) {
-            gameData.type = 'game';
-        }
-        const gameDate = gameData.date?.toDate ? gameData.date.toDate() : new Date(gameData.date);
-        if (gameDate < startOfToday || gameDate > oneWeekFromNow) {
-            continue;
-        }
-        // Get team info (parent document)
-        const teamRef = docSnap.ref.parent.parent;
-        const teamSnap = await getDoc(teamRef);
-        if (teamSnap.exists()) {
-            gameData.team = { id: teamSnap.id, ...teamSnap.data() };
-            gameData.teamId = teamSnap.id;
-            if (!shouldIncludeTeamInLiveOrUpcoming(gameData.team)) {
+        for (const docSnap of snapshot.docs) {
+            const gameData = { id: docSnap.id, ...docSnap.data() };
+            if (gameData.type === 'practice' || gameData.status === 'completed' || gameData.status === 'cancelled' || gameData.liveStatus === 'completed') {
                 continue;
             }
-        } else {
-            continue;
+            if (!gameData.type) {
+                gameData.type = 'game';
+            }
+            const gameDate = gameData.date?.toDate ? gameData.date.toDate() : new Date(gameData.date);
+            if (gameDate < startOfToday || gameDate > oneWeekFromNow) {
+                continue;
+            }
+            // Get team info (parent document)
+            const teamRef = docSnap.ref.parent.parent;
+            const teamSnap = await getDoc(teamRef);
+            if (teamSnap.exists()) {
+                gameData.team = { id: teamSnap.id, ...teamSnap.data() };
+                gameData.teamId = teamSnap.id;
+                if (!shouldIncludeTeamInLiveOrUpcoming(gameData.team)) {
+                    continue;
+                }
+            } else {
+                continue;
+            }
+            games.push(gameData);
+            if (games.length >= limitCount) {
+                break;
+            }
         }
-        games.push(gameData);
     }
 
     games.sort((a, b) => {
@@ -2801,7 +2848,7 @@ export async function getUpcomingLiveGames(limitCount = 10) {
         return aDate - bDate;
     });
 
-    return games;
+    return games.slice(0, limitCount);
 }
 
 // ============================================

--- a/js/homepage.js
+++ b/js/homepage.js
@@ -28,6 +28,10 @@ function buildLiveGameHref(game, replay = false) {
     return `live-game.html?${params.toString()}`;
 }
 
+function isVisibleUpcomingHomepageGame(game) {
+    return (game?.status || '').toLowerCase() !== 'cancelled';
+}
+
 function renderTeamAvatar(game) {
     const teamName = escapeHtml(game.team?.name || 'Team');
     const teamPhotoUrl = game.team?.photoUrl ? escapeHtml(game.team.photoUrl) : '';
@@ -82,6 +86,8 @@ export async function loadLiveGames({
         } catch (error) {
             logger.warn('Could not load upcoming games:', error?.message || error);
         }
+
+        upcomingGames = upcomingGames.filter(isVisibleUpcomingHomepageGame);
 
         const combined = [
             ...liveGames.map((game) => ({ ...game, isLive: true })),

--- a/tests/unit/homepage-index.test.js
+++ b/tests/unit/homepage-index.test.js
@@ -167,6 +167,28 @@ describe('homepage index workflow', () => {
         expect(liveMarkup).toContain('TIME:2026-03-28T18:00:00.000Z');
     });
 
+    it('excludes cancelled upcoming games from the homepage list', async () => {
+        const cancelledGame = createGame({
+            id: 'game-cancelled',
+            opponent: 'Cancelled Falcons',
+            status: 'cancelled'
+        });
+        const scheduledGame = createGame({
+            id: 'game-4',
+            opponent: 'Owls'
+        });
+
+        const { elements } = await runHomepage({
+            upcomingGames: [cancelledGame, scheduledGame]
+        });
+
+        const liveMarkup = elements.get('live-games-list').innerHTML;
+        expect(liveMarkup).toContain('gameId=game-4');
+        expect(liveMarkup).toContain('vs Owls');
+        expect(liveMarkup).not.toContain('gameId=game-cancelled');
+        expect(liveMarkup).not.toContain('Cancelled Falcons');
+    });
+
     it('replaces loading placeholders with exact empty and error fallback copy', async () => {
         const { elements } = await runHomepage({
             liveGames: [],


### PR DESCRIPTION
Closes #456

## What changed
- filtered cancelled games out of `getUpcomingLiveGames()` so the homepage source query no longer returns cancelled events as upcoming watchable games
- added a homepage-level guard to skip cancelled upcoming games before rendering cards
- added a regression test covering mixed upcoming data so cancelled games do not render or link into `live-game.html`
- persisted the required per-run role notes under `docs/pr-notes/runs/issue-456-fixer-20260402T035507Z/`

## Why
Cancelled games were still being surfaced in the public "Live & Upcoming Games" list, which let visitors click into a misleading not-live viewer state. This patch removes cancelled games from that homepage flow while preserving normal live, upcoming, and replay behavior.

## Validation
- ran `./node_modules/.bin/vitest run tests/unit/homepage-index.test.js tests/unit/game-day-entry.test.js`