### PR TITLE
Add tournament-grade native standings rules

### DIFF
--- a/docs/pr-notes/runs/461-remediator-20260402T054156Z/architecture.md
+++ b/docs/pr-notes/runs/461-remediator-20260402T054156Z/architecture.md
@@ -1,0 +1,12 @@
+Current state:
+- `js/native-standings.js` already distinguishes two-team and multi-team tiebreaker stacks.
+- That distinction is bypassed after a partition split because recursion carries `rest` from the previous stack.
+
+Proposed state:
+- Keep the existing recursive resolver.
+- On a successful split, recurse each partition with `getApplicableTiebreakers(config, partition.length)` instead of the previous `rest`.
+- Keep the current `rest` behavior only when the active tiebreaker is unsupported or fails to split the group.
+
+Risk surface and blast radius:
+- Blast radius is limited to standings ordering for tied groups in native standings.
+- Main regression risk is changing behavior for partitions that intentionally should continue within the same stack; the test should pin the desired restart behavior.

--- a/docs/pr-notes/runs/461-remediator-20260402T054156Z/code-plan.md
+++ b/docs/pr-notes/runs/461-remediator-20260402T054156Z/code-plan.md
@@ -1,0 +1,4 @@
+Planned change:
+1. Update `resolveTieGroup()` in `js/native-standings.js` so each split partition restarts with the tiebreaker stack appropriate for its new size.
+2. Add one regression test in `tests/unit/native-standings.test.js` covering the split-from-multi-team-to-two-team case.
+3. Run the targeted Vitest file and commit only the remediation files.

--- a/docs/pr-notes/runs/461-remediator-20260402T054156Z/qa.md
+++ b/docs/pr-notes/runs/461-remediator-20260402T054156Z/qa.md
@@ -1,0 +1,10 @@
+Validation target:
+- Prove that a multi-team tie which splits into a 2-team subgroup restarts with `twoTeamTiebreakers`.
+
+Test plan:
+1. Add a unit test in `tests/unit/native-standings.test.js` where a 3-team tie is partially resolved, leaving 2 teams tied.
+2. Make the remaining 2-team direct result disagree with the next multi-team fallback rule so the regression is observable.
+3. Run `npx vitest run tests/unit/native-standings.test.js`.
+
+Residual risk:
+- There is no broader integration harness for rendered standings pages, so validation remains unit-level for this remediation.

--- a/docs/pr-notes/runs/461-remediator-20260402T054156Z/requirements.md
+++ b/docs/pr-notes/runs/461-remediator-20260402T054156Z/requirements.md
@@ -1,0 +1,17 @@
+Objective: Remediate PR #461 review feedback in native standings tie resolution with the smallest safe change.
+
+Thinking level: medium
+Reason: single-module bug fix with ranking behavior implications and a focused regression test requirement.
+
+Current state:
+- `resolveTieGroup()` continues with the remaining multi-team tiebreakers after any partition split.
+- A 3+ team tie that shrinks to 2 teams does not restart using `twoTeamTiebreakers`.
+
+Required outcome:
+- When a tie partition changes size, reselect the tiebreaker stack based on the new partition size.
+- Preserve existing behavior for unresolved groups that stay the same size.
+- Add regression coverage that fails under the current implementation and passes with the fix.
+
+Assumptions:
+- The intended rule is to restart evaluation from the beginning of the applicable stack for the new partition size.
+- Existing legacy single-list configs must remain backward compatible via normalized fallback stacks.

--- a/docs/pr-notes/runs/issue-443-fixer-20260402T052503Z/architecture.md
+++ b/docs/pr-notes/runs/issue-443-fixer-20260402T052503Z/architecture.md
@@ -1,0 +1,25 @@
+## Current State
+- `js/native-standings.js` sorts rows with pairwise comparisons, which is insufficient for true multi-team tie groups.
+- `edit-team.html` persists only `enabled`, `rankingMode`, and a single `tiebreakers` array.
+
+## Proposed State
+- Normalize standings config with:
+  - `points`
+  - `maxGoalDiff`
+  - `twoTeamTiebreakers`
+  - `multiTeamTiebreakers`
+  - legacy `tiebreakers` fallback
+- Replace pairwise-only tie handling with tie-group resolution that:
+  - groups rows by primary metric
+  - applies the appropriate ordered tiebreaker stack for that group size
+  - uses mini-table summaries for head-to-head and group-head-to-head
+
+## Why This Shape
+- Group-based resolution fixes the core logic gap without changing unrelated team-page rendering.
+- Backward-compatible normalization avoids breaking existing saved teams.
+- Keeping the change inside the standings module and edit form preserves a small blast radius.
+
+## Controls
+- Deterministic fallback remains alphabetical.
+- Capped differential is applied only to differential accumulation, not to raw scored/allowed totals.
+- Unsupported tiebreakers are ignored rather than crashing standings calculation.

--- a/docs/pr-notes/runs/issue-443-fixer-20260402T052503Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-443-fixer-20260402T052503Z/code-plan.md
@@ -1,0 +1,15 @@
+## Plan
+- Extend unit coverage first for the missing tournament-grade standings behaviors.
+- Update `js/native-standings.js` to normalize the expanded schema, cap differential, and resolve tied groups by applicable tiebreaker stacks.
+- Update `edit-team.html` to expose and persist the new standings fields with sensible defaults.
+
+## Implementation Notes
+- Keep the patch targeted to standings and edit-team configuration.
+- Preserve existing saved configs by mapping legacy `tiebreakers` into both two-team and multi-team defaults.
+- Prefer alias support for goal/point terminology so existing configs and tournament wording both work.
+
+## Expected Files
+- `js/native-standings.js`
+- `tests/unit/native-standings.test.js`
+- `edit-team.html`
+- `tests/unit/edit-team-admin-access-persistence.test.js`

--- a/docs/pr-notes/runs/issue-443-fixer-20260402T052503Z/qa.md
+++ b/docs/pr-notes/runs/issue-443-fixer-20260402T052503Z/qa.md
@@ -1,0 +1,19 @@
+## Coverage Target
+- Native standings engine
+- Edit-team standings-config persistence
+
+## Test Strategy
+1. Add a unit test that proves `maxGoalDiff` caps cumulative differential while leaving records intact.
+2. Add a unit test that proves a three-team tie is resolved by `group_head_to_head` before downstream rules.
+3. Add a unit test that proves two-team ties still use direct head-to-head with the new config shape.
+4. Add an edit-team unit test that saves and reloads point values, cap, and separate tie stacks.
+
+## Regression Guardrails
+- Preserve legacy single-list `tiebreakers` behavior when new fields are absent.
+- Keep deterministic name ordering as the final fallback.
+- Validate that new form fields round-trip through the existing update flow.
+
+## Validation
+- Run targeted Vitest suites:
+  - `tests/unit/native-standings.test.js`
+  - `tests/unit/edit-team-admin-access-persistence.test.js`

--- a/docs/pr-notes/runs/issue-443-fixer-20260402T052503Z/requirements.md
+++ b/docs/pr-notes/runs/issue-443-fixer-20260402T052503Z/requirements.md
@@ -1,0 +1,31 @@
+## Objective
+- Add tournament-grade native standings rules that match common event/tournament expectations.
+
+## Current State
+- Native standings support only one ordered tiebreaker list and a small rule set.
+- Score differential is accumulated from raw scores, so blowouts can distort standings.
+- Admins cannot configure points values, capped differential, or separate two-team and multi-team tie behavior.
+
+## Proposed State
+- Support configurable point values, capped goal differential, and separate ordered tiebreaker stacks for two-team and multi-team ties.
+- Preserve existing native-standings behavior for teams that only use the legacy config fields.
+- Keep standings deterministic with a final alphabetical fallback.
+
+## Risk Surface
+- Blast radius is limited to native standings calculation and the team edit form persistence path.
+- No Firestore rules, auth, or tenant-access logic changes.
+- Main regression risk is reordering existing standings when teams rely on legacy tiebreaker config.
+
+## Assumptions
+- Tournament admins expect capped differential to affect only differential-based rules, not raw goals for/against.
+- Separate multi-team handling is needed only when more than two teams remain tied on the primary ranking metric.
+- Requested role skills are not exposed in this session, so this file captures the requirements-role synthesis directly.
+
+## Recommendation
+- Add the new controls and schema now, while keeping legacy `tiebreakers` as a backward-compatible fallback.
+- Implement group tie resolution with mini-table head-to-head logic before falling through to secondary rules.
+
+## Success Criteria
+- Admins can save standings point values, capped differential, and separate two-team and multi-team tiebreaker lists.
+- Multi-team ties resolve consistently using group head-to-head and downstream tournament rules.
+- Blowout margins above the configured cap no longer over-influence standings.

--- a/edit-team.html
+++ b/edit-team.html
@@ -116,7 +116,46 @@
                         </select>
                     </div>
                     <div>
-                        <label class="block text-sm font-medium text-gray-700">Tiebreakers (ordered, comma-separated)</label>
+                        <label class="block text-sm font-medium text-gray-700">Standings Points</label>
+                        <div class="mt-1 grid grid-cols-3 gap-3">
+                            <div>
+                                <label for="standingsPointWin" class="block text-xs text-gray-500">Win</label>
+                                <input type="number" id="standingsPointWin" value="3"
+                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2">
+                            </div>
+                            <div>
+                                <label for="standingsPointTie" class="block text-xs text-gray-500">Tie</label>
+                                <input type="number" id="standingsPointTie" value="1"
+                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2">
+                            </div>
+                            <div>
+                                <label for="standingsPointLoss" class="block text-xs text-gray-500">Loss</label>
+                                <input type="number" id="standingsPointLoss" value="0"
+                                    class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2">
+                            </div>
+                        </div>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">Max Goal Differential</label>
+                        <input type="number" id="standingsMaxGoalDiff" min="1"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2"
+                            placeholder="Leave blank for no cap">
+                        <p class="text-xs text-gray-500 mt-1">Caps the per-game goal differential used by differential tiebreakers.</p>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">Two-Team Tiebreakers (ordered, comma-separated)</label>
+                        <input type="text" id="standingsTwoTeamTiebreakers"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2"
+                            placeholder="head_to_head, goal_diff, goals_for, fewest_goals_allowed, wins, name">
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-gray-700">Multi-Team Tiebreakers (ordered, comma-separated)</label>
+                        <input type="text" id="standingsMultiTeamTiebreakers"
+                            class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2"
+                            placeholder="group_head_to_head, goal_diff, goals_for, fewest_goals_allowed, wins, name">
+                    </div>
+                    <div class="hidden">
+                        <label class="block text-sm font-medium text-gray-700">Legacy Tiebreakers</label>
                         <input type="text" id="standingsTiebreakers"
                             class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2"
                             placeholder="head_to_head, point_diff, points_for, fewest_points_against, name">
@@ -258,6 +297,18 @@
         let pendingAdminInviteEmails = [];
         let isInitPending = true;
 
+        function parseStandingsNumber(value, fallback) {
+            const parsed = Number.parseInt(String(value ?? ''), 10);
+            return Number.isFinite(parsed) ? parsed : fallback;
+        }
+
+        function splitStandingsList(value) {
+            return String(value || '')
+                .split(',')
+                .map((item) => item.trim())
+                .filter(Boolean);
+        }
+
         const saveBtn = document.getElementById('save-btn');
         saveBtn.disabled = true;
         saveBtn.textContent = initialTeamId ? 'Loading Team...' : 'Loading...';
@@ -324,9 +375,24 @@
                 document.getElementById('leagueUrl').value = team.leagueUrl || '';
                 document.getElementById('standingsEnabled').checked = team.standingsConfig?.enabled === true;
                 document.getElementById('standingsRankingMode').value = team.standingsConfig?.rankingMode === 'win_pct' ? 'win_pct' : 'points';
-                document.getElementById('standingsTiebreakers').value = Array.isArray(team.standingsConfig?.tiebreakers)
-                    ? team.standingsConfig.tiebreakers.join(', ')
+                document.getElementById('standingsPointWin').value = String(parseStandingsNumber(team.standingsConfig?.points?.win, 3));
+                document.getElementById('standingsPointTie').value = String(parseStandingsNumber(team.standingsConfig?.points?.tie, 1));
+                document.getElementById('standingsPointLoss').value = String(parseStandingsNumber(team.standingsConfig?.points?.loss, 0));
+                document.getElementById('standingsMaxGoalDiff').value = team.standingsConfig?.maxGoalDiff != null
+                    ? String(parseStandingsNumber(team.standingsConfig?.maxGoalDiff, ''))
                     : '';
+                const legacyTiebreakers = Array.isArray(team.standingsConfig?.tiebreakers)
+                    ? team.standingsConfig.tiebreakers
+                    : [];
+                const twoTeamTiebreakers = Array.isArray(team.standingsConfig?.twoTeamTiebreakers)
+                    ? team.standingsConfig.twoTeamTiebreakers
+                    : legacyTiebreakers;
+                const multiTeamTiebreakers = Array.isArray(team.standingsConfig?.multiTeamTiebreakers)
+                    ? team.standingsConfig.multiTeamTiebreakers
+                    : legacyTiebreakers.map((value) => value === 'head_to_head' ? 'group_head_to_head' : value);
+                document.getElementById('standingsTiebreakers').value = legacyTiebreakers.join(', ');
+                document.getElementById('standingsTwoTeamTiebreakers').value = twoTeamTiebreakers.join(', ');
+                document.getElementById('standingsMultiTeamTiebreakers').value = multiTeamTiebreakers.join(', ');
                 document.getElementById('zip').value = team.zip || '';
                 document.getElementById('isPublic').checked = team.isPublic !== false; // Default to true
                 // Populate Live Stream field from twitchChannel, streamEmbedUrl, or legacy youtubeEmbedUrl
@@ -619,10 +685,19 @@
                 const zipRaw = document.getElementById('zip').value.trim();
                 const zipDigits = zipRaw ? zipRaw.replace(/[^0-9]/g, '') : '';
                 const zip = zipDigits.length >= 5 ? zipDigits.slice(0, 9) : '';
-                const standingsTiebreakers = document.getElementById('standingsTiebreakers').value
-                    .split(',')
-                    .map((value) => value.trim())
-                    .filter(Boolean);
+                const standingsTiebreakers = splitStandingsList(document.getElementById('standingsTiebreakers').value);
+                const standingsTwoTeamTiebreakers = splitStandingsList(document.getElementById('standingsTwoTeamTiebreakers').value);
+                const standingsMultiTeamTiebreakers = splitStandingsList(document.getElementById('standingsMultiTeamTiebreakers').value);
+                const points = {
+                    win: parseStandingsNumber(document.getElementById('standingsPointWin').value, 3),
+                    tie: parseStandingsNumber(document.getElementById('standingsPointTie').value, 1),
+                    loss: parseStandingsNumber(document.getElementById('standingsPointLoss').value, 0)
+                };
+                const maxGoalDiffRaw = document.getElementById('standingsMaxGoalDiff').value.trim();
+                const maxGoalDiff = maxGoalDiffRaw === '' ? null : parseStandingsNumber(maxGoalDiffRaw, null);
+                const legacyFallbackTiebreakers = standingsTwoTeamTiebreakers.length > 0
+                    ? standingsTwoTeamTiebreakers
+                    : standingsTiebreakers;
 
                 const normalizedAdminEmails = normalizeAdminEmailList(adminEmails);
                 adminEmails = normalizedAdminEmails;
@@ -635,7 +710,11 @@
                     standingsConfig: {
                         enabled: document.getElementById('standingsEnabled').checked,
                         rankingMode: document.getElementById('standingsRankingMode').value === 'win_pct' ? 'win_pct' : 'points',
-                        tiebreakers: standingsTiebreakers
+                        points,
+                        maxGoalDiff: Number.isFinite(maxGoalDiff) && maxGoalDiff > 0 ? maxGoalDiff : null,
+                        tiebreakers: legacyFallbackTiebreakers,
+                        twoTeamTiebreakers: standingsTwoTeamTiebreakers.length > 0 ? standingsTwoTeamTiebreakers : legacyFallbackTiebreakers,
+                        multiTeamTiebreakers: standingsMultiTeamTiebreakers
                     },
                     zip,
                     photoUrl: currentPhotoUrl,

--- a/js/native-standings.js
+++ b/js/native-standings.js
@@ -270,7 +270,10 @@ function resolveTieGroup(group, tiebreakers, allGames, config) {
         return resolveTieGroup(group, rest, allGames, config);
     }
 
-    return partitions.flatMap((partition) => resolveTieGroup(partition, rest, allGames, config));
+    return partitions.flatMap((partition) => {
+        const nextTiebreakers = getApplicableTiebreakers(config, partition.length);
+        return resolveTieGroup(partition, nextTiebreakers, allGames, config);
+    });
 }
 
 function sortStandingsTable(table, allGames, config) {

--- a/js/native-standings.js
+++ b/js/native-standings.js
@@ -3,6 +3,12 @@ function toInt(value) {
     return Number.isFinite(n) ? n : 0;
 }
 
+function toNullableInt(value) {
+    if (value === '' || value == null) return null;
+    const n = Number.parseInt(String(value), 10);
+    return Number.isFinite(n) ? n : null;
+}
+
 function normalizeTeamName(value) {
     return String(value || '').trim();
 }
@@ -20,12 +26,28 @@ function safePointsSchema(points) {
     };
 }
 
-function safeTiebreakers(list) {
-    const defaults = ['head_to_head', 'point_diff', 'points_for', 'fewest_points_against', 'name'];
-    if (!Array.isArray(list) || list.length === 0) return defaults;
-    return list
-        .map((item) => String(item || '').trim())
+function normalizeTiebreaker(value) {
+    const normalized = String(value || '').trim().toLowerCase();
+    if (!normalized) return '';
+    if (normalized === 'goal_diff') return 'point_diff';
+    if (normalized === 'goals_for') return 'points_for';
+    if (normalized === 'fewest_goals_allowed') return 'fewest_points_against';
+    if (normalized === 'most_games_won') return 'wins';
+    return normalized;
+}
+
+function safeTiebreakers(list, defaults) {
+    if (!Array.isArray(list) || list.length === 0) return [...defaults];
+    const normalized = list
+        .map(normalizeTiebreaker)
         .filter(Boolean);
+    return normalized.length > 0 ? normalized : [...defaults];
+}
+
+function safeMaxGoalDiff(value) {
+    const parsed = toNullableInt(value);
+    if (!Number.isFinite(parsed) || parsed == null || parsed <= 0) return null;
+    return parsed;
 }
 
 function compareNumbersDesc(a, b) {
@@ -43,69 +65,40 @@ function isFinalGameStatus(game) {
     return status === 'completed' || status === 'final';
 }
 
-function getHeadToHeadSummary(games, teamA, teamB) {
-    let winsA = 0;
-    let winsB = 0;
-    let ties = 0;
+function safeStandingsConfig(configInput = {}) {
+    const points = safePointsSchema(configInput.points);
+    const defaults = ['head_to_head', 'point_diff', 'points_for', 'fewest_points_against', 'name'];
+    const multiDefaults = ['group_head_to_head', 'point_diff', 'points_for', 'fewest_points_against', 'name'];
+    const legacyTiebreakers = safeTiebreakers(configInput.tiebreakers, defaults);
+    const twoTeamTiebreakers = safeTiebreakers(configInput.twoTeamTiebreakers, legacyTiebreakers);
+    const multiTeamFallback = legacyTiebreakers.map((item) => item === 'head_to_head' ? 'group_head_to_head' : item);
+    const multiTeamTiebreakers = safeTiebreakers(configInput.multiTeamTiebreakers, multiTeamFallback.length ? multiTeamFallback : multiDefaults);
 
-    for (const game of games) {
-        if (!game) continue;
-        const homeTeam = normalizeTeamName(game.homeTeam);
-        const awayTeam = normalizeTeamName(game.awayTeam);
-        const involvesPair = (homeTeam === teamA && awayTeam === teamB) || (homeTeam === teamB && awayTeam === teamA);
-        if (!involvesPair) continue;
-
-        const homeScore = Number(game.homeScore);
-        const awayScore = Number(game.awayScore);
-        if (!Number.isFinite(homeScore) || !Number.isFinite(awayScore)) continue;
-
-        if (homeScore === awayScore) {
-            ties += 1;
-            continue;
-        }
-
-        const homeWon = homeScore > awayScore;
-        const winner = homeWon ? homeTeam : awayTeam;
-        if (winner === teamA) winsA += 1;
-        if (winner === teamB) winsB += 1;
-    }
-
-    const total = winsA + winsB + ties;
-    if (total === 0) return null;
     return {
-        teamAWinPct: (winsA + ties * 0.5) / total,
-        teamBWinPct: (winsB + ties * 0.5) / total
+        rankingMode: safeRankingMode(configInput.rankingMode),
+        points,
+        maxGoalDiff: safeMaxGoalDiff(configInput.maxGoalDiff),
+        tiebreakers: legacyTiebreakers,
+        twoTeamTiebreakers,
+        multiTeamTiebreakers
     };
 }
 
-function compareByTiebreaker(tiebreaker, a, b, allGames) {
-    if (tiebreaker === 'head_to_head') {
-        const hh = getHeadToHeadSummary(allGames, a.team, b.team);
-        if (!hh) return 0;
-        return compareNumbersDesc(hh.teamAWinPct, hh.teamBWinPct);
-    }
-    if (tiebreaker === 'point_diff') return compareNumbersDesc(a.pd, b.pd);
-    if (tiebreaker === 'points_for') return compareNumbersDesc(a.pf, b.pf);
-    if (tiebreaker === 'fewest_points_against') return compareNumbersAsc(a.pa, b.pa);
-    if (tiebreaker === 'wins') return compareNumbersDesc(a.w, b.w);
-    if (tiebreaker === 'name') return a.team.localeCompare(b.team);
-    return 0;
+function getCappedDiff(homeScore, awayScore, maxGoalDiff) {
+    const diff = homeScore - awayScore;
+    if (!Number.isFinite(maxGoalDiff)) return diff;
+    if (diff === 0) return 0;
+    return Math.sign(diff) * Math.min(Math.abs(diff), maxGoalDiff);
 }
 
 function buildRecordString(entry) {
     return entry.t > 0 ? `${entry.w}-${entry.l}-${entry.t}` : `${entry.w}-${entry.l}`;
 }
 
-export function computeNativeStandings(gamesInput, configInput = {}) {
-    const games = Array.isArray(gamesInput) ? gamesInput : [];
-    const completedGames = games.filter(isFinalGameStatus);
-    const rankingMode = safeRankingMode(configInput.rankingMode);
-    const pointsSchema = safePointsSchema(configInput.points);
-    const tiebreakers = safeTiebreakers(configInput.tiebreakers);
-
+function buildRawTable(games, config) {
     const tableByTeam = new Map();
 
-    for (const game of completedGames) {
+    for (const game of games) {
         const homeTeam = normalizeTeamName(game?.homeTeam);
         const awayTeam = normalizeTeamName(game?.awayTeam);
         const homeScore = Number(game?.homeScore);
@@ -123,6 +116,7 @@ export function computeNativeStandings(gamesInput, configInput = {}) {
 
         const homeEntry = tableByTeam.get(homeTeam);
         const awayEntry = tableByTeam.get(awayTeam);
+        const cappedDiff = getCappedDiff(homeScore, awayScore, config.maxGoalDiff);
 
         homeEntry.gp += 1;
         awayEntry.gp += 1;
@@ -130,52 +124,184 @@ export function computeNativeStandings(gamesInput, configInput = {}) {
         homeEntry.pa += awayScore;
         awayEntry.pf += awayScore;
         awayEntry.pa += homeScore;
+        homeEntry.pd += cappedDiff;
+        awayEntry.pd -= cappedDiff;
 
         if (homeScore > awayScore) {
             homeEntry.w += 1;
             awayEntry.l += 1;
-            homeEntry.points += pointsSchema.win;
-            awayEntry.points += pointsSchema.loss;
+            homeEntry.points += config.points.win;
+            awayEntry.points += config.points.loss;
         } else if (homeScore < awayScore) {
             awayEntry.w += 1;
             homeEntry.l += 1;
-            awayEntry.points += pointsSchema.win;
-            homeEntry.points += pointsSchema.loss;
+            awayEntry.points += config.points.win;
+            homeEntry.points += config.points.loss;
         } else {
             homeEntry.t += 1;
             awayEntry.t += 1;
-            homeEntry.points += pointsSchema.tie;
-            awayEntry.points += pointsSchema.tie;
+            homeEntry.points += config.points.tie;
+            awayEntry.points += config.points.tie;
         }
     }
 
-    const table = Array.from(tableByTeam.values()).map((entry) => {
+    return Array.from(tableByTeam.values()).map((entry) => {
         const gp = entry.gp || 0;
-        const winPct = gp > 0 ? (entry.w + (entry.t * 0.5)) / gp : 0;
-        const pd = entry.pf - entry.pa;
         return {
             ...entry,
-            pd,
-            winPct,
+            winPct: gp > 0 ? (entry.w + (entry.t * 0.5)) / gp : 0,
             record: buildRecordString(entry)
         };
     });
+}
 
-    table.sort((a, b) => {
-        const primary = rankingMode === 'win_pct'
-            ? compareNumbersDesc(a.winPct, b.winPct)
-            : compareNumbersDesc(a.points, b.points);
-        if (primary !== 0) return primary;
+function getPrimaryMetric(entry, config) {
+    return config.rankingMode === 'win_pct' ? entry.winPct : entry.points;
+}
 
-        for (const tiebreaker of tiebreakers) {
-            const decision = compareByTiebreaker(tiebreaker, a, b, completedGames);
+function getApplicableTiebreakers(config, groupSize) {
+    if (groupSize > 2) return config.multiTeamTiebreakers;
+    return config.twoTeamTiebreakers;
+}
+
+function buildHeadToHeadMetric(group, allGames, config) {
+    const teamSet = new Set(group.map((row) => row.team));
+    const relevantGames = allGames.filter((game) => teamSet.has(normalizeTeamName(game?.homeTeam)) && teamSet.has(normalizeTeamName(game?.awayTeam)));
+    if (relevantGames.length === 0) return null;
+
+    const miniTable = buildRawTable(relevantGames, config);
+    if (miniTable.length === 0) return null;
+
+    const values = new Map();
+    for (const row of miniTable) {
+        values.set(row.team, getPrimaryMetric(row, config));
+    }
+
+    return group.map((row) => ({
+        row,
+        value: values.has(row.team) ? values.get(row.team) : null
+    }));
+}
+
+function buildTiebreakerValues(tiebreaker, group, allGames, config) {
+    if (tiebreaker === 'head_to_head') {
+        if (group.length !== 2) return null;
+        return buildHeadToHeadMetric(group, allGames, config);
+    }
+    if (tiebreaker === 'group_head_to_head') {
+        if (group.length <= 2) return null;
+        return buildHeadToHeadMetric(group, allGames, config);
+    }
+    if (tiebreaker === 'point_diff') {
+        return group.map((row) => ({ row, value: row.pd }));
+    }
+    if (tiebreaker === 'points_for') {
+        return group.map((row) => ({ row, value: row.pf }));
+    }
+    if (tiebreaker === 'fewest_points_against') {
+        return group.map((row) => ({ row, value: row.pa }));
+    }
+    if (tiebreaker === 'wins') {
+        return group.map((row) => ({ row, value: row.w }));
+    }
+    if (tiebreaker === 'name') {
+        return group.map((row) => ({ row, value: row.team }));
+    }
+    return null;
+}
+
+function compareTiebreakerValues(tiebreaker, a, b) {
+    if (tiebreaker === 'fewest_points_against') return compareNumbersAsc(a, b);
+    if (tiebreaker === 'name') return String(a).localeCompare(String(b));
+    return compareNumbersDesc(a, b);
+}
+
+function partitionTieGroup(group, tiebreaker, values) {
+    const ordered = values
+        .filter((item) => item.value != null)
+        .sort((a, b) => {
+            const decision = compareTiebreakerValues(tiebreaker, a.value, b.value);
             if (decision !== 0) return decision;
+            return a.row.team.localeCompare(b.row.team);
+        });
+
+    if (ordered.length !== group.length) return [group];
+
+    const partitions = [];
+    let current = [];
+
+    for (const item of ordered) {
+        if (current.length === 0) {
+            current.push(item);
+            continue;
         }
 
-        return a.team.localeCompare(b.team);
-    });
+        const last = current[current.length - 1];
+        if (compareTiebreakerValues(tiebreaker, last.value, item.value) === 0) {
+            current.push(item);
+            continue;
+        }
 
-    return table.map((row, index) => ({
+        partitions.push(current.map((entry) => entry.row));
+        current = [item];
+    }
+
+    if (current.length > 0) {
+        partitions.push(current.map((entry) => entry.row));
+    }
+
+    return partitions.length > 0 ? partitions : [group];
+}
+
+function resolveTieGroup(group, tiebreakers, allGames, config) {
+    if (group.length <= 1) return [...group];
+    if (!Array.isArray(tiebreakers) || tiebreakers.length === 0) {
+        return [...group].sort((a, b) => a.team.localeCompare(b.team));
+    }
+
+    const [current, ...rest] = tiebreakers;
+    const values = buildTiebreakerValues(current, group, allGames, config);
+    if (!values) {
+        return resolveTieGroup(group, rest, allGames, config);
+    }
+
+    const partitions = partitionTieGroup(group, current, values);
+    if (partitions.length === 1 && partitions[0].length === group.length) {
+        return resolveTieGroup(group, rest, allGames, config);
+    }
+
+    return partitions.flatMap((partition) => resolveTieGroup(partition, rest, allGames, config));
+}
+
+function sortStandingsTable(table, allGames, config) {
+    const primaryGroups = new Map();
+    for (const row of table) {
+        const key = String(getPrimaryMetric(row, config));
+        const existing = primaryGroups.get(key) || [];
+        existing.push(row);
+        primaryGroups.set(key, existing);
+    }
+
+    const sortedPrimaryKeys = Array.from(primaryGroups.keys()).sort((a, b) => compareNumbersDesc(Number(a), Number(b)));
+    const resolved = [];
+
+    for (const key of sortedPrimaryKeys) {
+        const group = primaryGroups.get(key) || [];
+        const tiebreakers = getApplicableTiebreakers(config, group.length);
+        resolved.push(...resolveTieGroup(group, tiebreakers, allGames, config));
+    }
+
+    return resolved;
+}
+
+export function computeNativeStandings(gamesInput, configInput = {}) {
+    const games = Array.isArray(gamesInput) ? gamesInput : [];
+    const completedGames = games.filter(isFinalGameStatus);
+    const config = safeStandingsConfig(configInput);
+    const table = buildRawTable(completedGames, config);
+    const sortedTable = sortStandingsTable(table, completedGames, config);
+
+    return sortedTable.map((row, index) => ({
         ...row,
         rank: index + 1
     }));

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -145,7 +145,13 @@ function createEnvironment(initialState, overrides = {}) {
         'leagueUrl',
         'standingsEnabled',
         'standingsRankingMode',
+        'standingsPointWin',
+        'standingsPointTie',
+        'standingsPointLoss',
+        'standingsMaxGoalDiff',
         'standingsTiebreakers',
+        'standingsTwoTeamTiebreakers',
+        'standingsMultiTeamTiebreakers',
         'zip',
         'isPublic',
         'streamUrl',
@@ -359,6 +365,7 @@ async function bootEditTeam(initialState, overrides = {}) {
     };
 
     await runEditTeamModule(deps);
+    await Promise.resolve();
 
     return env;
 }
@@ -409,7 +416,7 @@ describe('edit team admin access persistence', () => {
         }
     });
 
-    it('adds a mixed-case admin once in lowercase and keeps next-load access aligned with the saved list', async () => {
+  it('adds a mixed-case admin once in lowercase and keeps next-load access aligned with the saved list', async () => {
         const initialState = {
             currentUser: { uid: 'owner-1', email: 'owner@example.com' },
             team: {
@@ -455,6 +462,63 @@ describe('edit team admin access persistence', () => {
             expect(reloadEnv.elements.get('admin-list').querySelectorAll('.remove-admin-btn')).toHaveLength(2);
         } finally {
             reloadEnv.cleanup();
+        }
+    });
+
+    it('round-trips expanded standings settings for tournament rules', async () => {
+        const initialState = {
+            currentUser: { uid: 'owner-1', email: 'owner@example.com' },
+            team: {
+                id: 'team-1',
+                ownerId: 'owner-1',
+                name: 'Sharks',
+                description: 'Travel team',
+                sport: 'Soccer',
+                notificationEmail: 'notify@example.com',
+                leagueUrl: '',
+                standingsConfig: {
+                    enabled: true,
+                    rankingMode: 'points',
+                    points: { win: 3, tie: 1, loss: 0 },
+                    maxGoalDiff: 4,
+                    twoTeamTiebreakers: ['head_to_head', 'goal_diff', 'name'],
+                    multiTeamTiebreakers: ['group_head_to_head', 'goal_diff', 'goals_for', 'name']
+                },
+                zip: '66209',
+                isPublic: true,
+                adminEmails: []
+            },
+            updateCalls: []
+        };
+
+        const env = await bootEditTeam(initialState);
+        try {
+            expect(env.elements.get('standingsPointWin').value).toBe('3');
+            expect(env.elements.get('standingsMaxGoalDiff').value).toBe('4');
+            expect(env.elements.get('standingsTwoTeamTiebreakers').value).toBe('head_to_head, goal_diff, name');
+            expect(env.elements.get('standingsMultiTeamTiebreakers').value).toBe('group_head_to_head, goal_diff, goals_for, name');
+
+            env.elements.get('standingsPointWin').value = '5';
+            env.elements.get('standingsPointTie').value = '2';
+            env.elements.get('standingsPointLoss').value = '1';
+            env.elements.get('standingsMaxGoalDiff').value = '3';
+            env.elements.get('standingsTwoTeamTiebreakers').value = 'head_to_head, wins';
+            env.elements.get('standingsMultiTeamTiebreakers').value = 'group_head_to_head, goals_for, fewest_goals_allowed';
+
+            await env.elements.get('team-form').requestSubmit();
+
+            expect(env.state.updateCalls).toHaveLength(1);
+            expect(env.state.updateCalls[0].teamData.standingsConfig).toEqual({
+                enabled: true,
+                rankingMode: 'points',
+                points: { win: 5, tie: 2, loss: 1 },
+                maxGoalDiff: 3,
+                tiebreakers: ['head_to_head', 'wins'],
+                twoTeamTiebreakers: ['head_to_head', 'wins'],
+                multiTeamTiebreakers: ['group_head_to_head', 'goals_for', 'fewest_goals_allowed']
+            });
+        } finally {
+            env.cleanup();
         }
     });
 });

--- a/tests/unit/native-standings.test.js
+++ b/tests/unit/native-standings.test.js
@@ -167,4 +167,25 @@ describe('computeNativeStandings', () => {
 
     expect(table.slice(0, 2).map((row) => row.team)).toEqual(['Alpha', 'Comets']);
   });
+
+  it('restarts with the two-team stack after a multi-team split leaves two teams tied', () => {
+    const games = [
+      { homeTeam: 'Bravo', awayTeam: 'Comets', homeScore: 3, awayScore: 0, status: 'completed' },
+      { homeTeam: 'Dragons', awayTeam: 'Bravo', homeScore: 3, awayScore: 1, status: 'completed' },
+      { homeTeam: 'Bravo', awayTeam: 'Eagles', homeScore: 1, awayScore: 2, status: 'completed' },
+      { homeTeam: 'Eagles', awayTeam: 'Bravo', homeScore: 1, awayScore: 3, status: 'completed' },
+      { homeTeam: 'Comets', awayTeam: 'Dragons', homeScore: 1, awayScore: 3, status: 'completed' },
+      { homeTeam: 'Dragons', awayTeam: 'Eagles', homeScore: 0, awayScore: 2, status: 'completed' }
+    ];
+
+    const table = computeNativeStandings(games, {
+      rankingMode: 'points',
+      points: { win: 3, tie: 1, loss: 0 },
+      twoTeamTiebreakers: ['head_to_head', 'point_diff', 'name'],
+      multiTeamTiebreakers: ['group_head_to_head', 'point_diff', 'name']
+    });
+
+    expect(table.map((row) => row.team)).toEqual(['Eagles', 'Dragons', 'Bravo', 'Comets']);
+    expect(table.find((row) => row.team === 'Dragons').pd).toBe(table.find((row) => row.team === 'Bravo').pd);
+  });
 });

--- a/tests/unit/native-standings.test.js
+++ b/tests/unit/native-standings.test.js
@@ -97,4 +97,74 @@ describe('computeNativeStandings', () => {
     expect(table[0].team).toBe('Alpha');
     expect(table[1].team).toBe('Bravo');
   });
+
+  it('caps goal differential without changing raw goals for and against', () => {
+    const games = [
+      { homeTeam: 'Alpha', awayTeam: 'Bravo', homeScore: 10, awayScore: 0, status: 'completed' }
+    ];
+
+    const table = computeNativeStandings(games, {
+      rankingMode: 'points',
+      points: { win: 3, tie: 1, loss: 0 },
+      maxGoalDiff: 3,
+      tiebreakers: ['point_diff', 'name']
+    });
+
+    expect(table.find((row) => row.team === 'Alpha')).toMatchObject({
+      pf: 10,
+      pa: 0,
+      pd: 3,
+      points: 3
+    });
+    expect(table.find((row) => row.team === 'Bravo')).toMatchObject({
+      pf: 0,
+      pa: 10,
+      pd: -3,
+      points: 0
+    });
+  });
+
+  it('resolves multi-team ties with group head-to-head before overall point differential', () => {
+    const games = [
+      { homeTeam: 'Alpha', awayTeam: 'Bravo', homeScore: 1, awayScore: 0, status: 'completed' },
+      { homeTeam: 'Alpha', awayTeam: 'Comets', homeScore: 1, awayScore: 0, status: 'completed' },
+      { homeTeam: 'Dragons', awayTeam: 'Alpha', homeScore: 1, awayScore: 0, status: 'completed' },
+      { homeTeam: 'Eagles', awayTeam: 'Alpha', homeScore: 1, awayScore: 0, status: 'completed' },
+      { homeTeam: 'Bravo', awayTeam: 'Comets', homeScore: 1, awayScore: 0, status: 'completed' },
+      { homeTeam: 'Bravo', awayTeam: 'Dragons', homeScore: 4, awayScore: 0, status: 'completed' },
+      { homeTeam: 'Eagles', awayTeam: 'Bravo', homeScore: 1, awayScore: 0, status: 'completed' },
+      { homeTeam: 'Comets', awayTeam: 'Dragons', homeScore: 10, awayScore: 0, status: 'completed' },
+      { homeTeam: 'Comets', awayTeam: 'Falcons', homeScore: 10, awayScore: 0, status: 'completed' },
+      { homeTeam: 'Eagles', awayTeam: 'Comets', homeScore: 1, awayScore: 0, status: 'completed' }
+    ];
+
+    const table = computeNativeStandings(games, {
+      rankingMode: 'points',
+      points: { win: 3, tie: 1, loss: 0 },
+      twoTeamTiebreakers: ['head_to_head', 'point_diff', 'name'],
+      multiTeamTiebreakers: ['group_head_to_head', 'point_diff', 'name']
+    });
+
+    expect(table.slice(1, 4).map((row) => row.team)).toEqual(['Alpha', 'Bravo', 'Comets']);
+    expect(table.find((row) => row.team === 'Comets').pd).toBeGreaterThan(table.find((row) => row.team === 'Alpha').pd);
+  });
+
+  it('uses the two-team tiebreaker stack when the new config shape is present', () => {
+    const games = [
+      { homeTeam: 'Alpha', awayTeam: 'Comets', homeScore: 1, awayScore: 0, status: 'completed' },
+      { homeTeam: 'Bravo', awayTeam: 'Alpha', homeScore: 1, awayScore: 0, status: 'completed' },
+      { homeTeam: 'Comets', awayTeam: 'Bravo', homeScore: 5, awayScore: 0, status: 'completed' },
+      { homeTeam: 'Alpha', awayTeam: 'Dragons', homeScore: 1, awayScore: 0, status: 'completed' },
+      { homeTeam: 'Comets', awayTeam: 'Dragons', homeScore: 5, awayScore: 0, status: 'completed' }
+    ];
+
+    const table = computeNativeStandings(games, {
+      rankingMode: 'points',
+      points: { win: 3, tie: 1, loss: 0 },
+      twoTeamTiebreakers: ['head_to_head', 'point_diff', 'name'],
+      multiTeamTiebreakers: ['group_head_to_head', 'point_diff', 'name']
+    });
+
+    expect(table.slice(0, 2).map((row) => row.team)).toEqual(['Alpha', 'Comets']);
+  });
 });


### PR DESCRIPTION
Closes #443

## What changed
- expanded native standings config to support tournament point values, capped goal differential, and separate two-team vs multi-team tiebreaker stacks
- updated the standings engine to resolve tied groups deterministically, including group head-to-head mini-table logic and capped differential scoring
- added edit-team controls and persistence for the new standings settings while keeping legacy `tiebreakers` compatibility
- added unit coverage for capped blowouts, multi-team tie resolution, new config-shape handling, and standings config round-trips in the admin form

## Why
Tournament admins need standings that match real competition rules. The prior implementation only handled a narrow tiebreaker set, used uncapped score differential, and could not represent separate multi-team tie logic or richer standings settings from the admin UI.

## Validation
- `./node_modules/.bin/vitest run tests/unit/native-standings.test.js tests/unit/edit-team-admin-access-persistence.test.js`