### PR TITLE
Guard photo-only player saves after private profile read failure

### DIFF
--- a/docs/pr-notes/runs/issue-471-fixer-20260403T032502Z/architecture.md
+++ b/docs/pr-notes/runs/issue-471-fixer-20260403T032502Z/architecture.md
@@ -1,0 +1,23 @@
+Objective: fix the destructive update path without changing Firestore write semantics outside the player edit UI.
+
+Current state:
+- `player.html` constructs the update payload inline in the submit handler.
+- `js/db.js:updatePlayerProfile()` only writes private profile fields when those keys are present.
+
+Proposed state:
+- Keep `updatePlayerProfile()` unchanged.
+- Move payload construction in `player.html` behind a small helper that decides whether to include private fields based on modal read status and per-field dirty flags.
+
+Why this path:
+- The bug originates in UI payload shaping, not in the Firestore helper.
+- Fixing in the UI keeps the blast radius narrow and preserves existing behavior for other callers of `updatePlayerProfile()`.
+
+Controls:
+- No schema changes.
+- No security-rule changes.
+- No behavioral change for successful private-profile reads.
+- Reduced destructive write risk when the private-profile read fails.
+
+Rollback:
+- Revert the `player.html` helper and event wiring if needed.
+- Unit tests added in this change should fail again on rollback, providing a quick signal.

--- a/docs/pr-notes/runs/issue-471-fixer-20260403T032502Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-471-fixer-20260403T032502Z/code-plan.md
@@ -1,0 +1,9 @@
+Thinking level: medium
+Reason: targeted UI-data-loss fix with existing test patterns and low architectural ambiguity.
+
+Implementation plan:
+1. Add a new unit test file for player private-profile edit payload behavior.
+2. Add a focused unit test for `updatePlayerProfile()` private-doc write gating.
+3. Introduce a small payload helper plus private-field dirty tracking in `player.html`.
+4. Reuse existing `updatePlayerProfile()` behavior by omitting untouched private keys rather than changing Firestore write logic.
+5. Run targeted Vitest commands, then stage and commit all changed files with an issue-referencing message.

--- a/docs/pr-notes/runs/issue-471-fixer-20260403T032502Z/qa.md
+++ b/docs/pr-notes/runs/issue-471-fixer-20260403T032502Z/qa.md
@@ -1,0 +1,16 @@
+Test strategy:
+- Add a Vitest regression test that extracts the player edit payload helper from `player.html`.
+- Cover three cases:
+  1. private-profile read failed and user only changed the photo
+  2. private-profile read succeeded and normal private fields are included
+  3. private-profile read failed but the user explicitly changed private fields
+- Add a `js/db.js` unit test confirming `updatePlayerProfile()` does not write the private profile doc when only `photoUrl` is present.
+
+Why unit coverage over Playwright:
+- The repo already has broad Vitest source-extraction coverage and no established Playwright setup for this flow.
+- The bug is deterministic in payload construction and Firestore call shaping, so unit tests give fast, stable regression protection.
+
+Validation plan:
+- Run the new targeted tests first to prove failure against current code.
+- After the fix, rerun the targeted tests.
+- Run the full unit suite if time permits and there is no unrelated breakage.

--- a/docs/pr-notes/runs/issue-471-fixer-20260403T032502Z/requirements.md
+++ b/docs/pr-notes/runs/issue-471-fixer-20260403T032502Z/requirements.md
@@ -1,0 +1,23 @@
+Objective: prevent photo-only saves on `player.html` from erasing private profile fields after a denied or failed private-profile read.
+
+Current state:
+- `openEditModal()` catches private profile read failures and renders empty emergency contact and medical fields.
+- The submit handler always sends `emergencyContact` and `medicalInfo`, so a photo-only save can overwrite existing sensitive data with blanks.
+
+Proposed state:
+- If the private profile read fails, preserve user intent by excluding untouched private fields from the update payload.
+- Continue allowing explicit edits to private fields in the same modal session when the user changes those fields.
+
+Risk surface and blast radius:
+- Affected data is sensitive player information in `teams/{teamId}/players/{playerId}/private/profile`.
+- Failure mode is silent destructive overwrite of emergency and medical details.
+- Blast radius is limited to the player edit modal, but impact is high because it touches safety-critical data.
+
+Assumptions:
+- Photo-only edits remain valid when the private profile fetch fails.
+- Existing `updatePlayerProfile()` semantics are correct when omitted keys are absent from `data`.
+- A targeted unit regression test is sufficient for this issue because the repo already uses Vitest source-extraction tests for HTML pages.
+
+Recommendation:
+- Add a payload-shaping helper in `player.html` and dirty-field tracking for the private fields.
+- Verify the helper omits untouched private fields after read failure and still includes them in normal edit flows.

--- a/player.html
+++ b/player.html
@@ -229,6 +229,11 @@
         let currentPlayer = null; // Store for modal access
         let currentPrivateProfile = null; // Sensitive fields live in a private doc
         let currentTeamId = null;
+        let privateProfileLoadFailed = false;
+        let privateFieldsDirty = {
+            emergencyContact: false,
+            medicalInfo: false
+        };
 
         checkAuth((user) => {
             currentUser = user;
@@ -1020,6 +1025,11 @@
         async function openEditModal() {
              if (!currentPlayer) return;
              document.getElementById('edit-player-modal').classList.remove('hidden');
+             privateProfileLoadFailed = false;
+             privateFieldsDirty = {
+                 emergencyContact: false,
+                 medicalInfo: false
+             };
 
              // Load sensitive fields from the private profile doc.
              // If denied or missing, treat as empty.
@@ -1028,6 +1038,7 @@
              } catch (e) {
                  console.warn('Failed to load private player profile:', e);
                  currentPrivateProfile = null;
+                 privateProfileLoadFailed = true;
              }
 
              document.getElementById('edit-ec-name').value = currentPrivateProfile?.emergencyContact?.name || '';
@@ -1042,8 +1053,50 @@
              }
         }
 
+        function buildPlayerProfileUpdatePayload({
+            emergencyContactName,
+            emergencyContactPhone,
+            medicalInfo,
+            photoUrl,
+            privateProfileLoadFailed,
+            privateFieldsDirty
+        }) {
+            const data = {};
+            const shouldIncludeEmergencyContact = !privateProfileLoadFailed || privateFieldsDirty.emergencyContact;
+            const shouldIncludeMedicalInfo = !privateProfileLoadFailed || privateFieldsDirty.medicalInfo;
+
+            if (shouldIncludeEmergencyContact) {
+                data.emergencyContact = {
+                    name: emergencyContactName,
+                    phone: emergencyContactPhone
+                };
+            }
+
+            if (shouldIncludeMedicalInfo) {
+                data.medicalInfo = medicalInfo;
+            }
+
+            if (typeof photoUrl !== 'undefined') {
+                data.photoUrl = photoUrl;
+            }
+
+            return data;
+        }
+
         document.getElementById('close-edit-modal').addEventListener('click', () => {
             document.getElementById('edit-player-modal').classList.add('hidden');
+        });
+
+        document.getElementById('edit-ec-name').addEventListener('input', () => {
+            privateFieldsDirty.emergencyContact = true;
+        });
+
+        document.getElementById('edit-ec-phone').addEventListener('input', () => {
+            privateFieldsDirty.emergencyContact = true;
+        });
+
+        document.getElementById('edit-medical-info').addEventListener('input', () => {
+            privateFieldsDirty.medicalInfo = true;
         });
 
         document.getElementById('edit-photo-input').addEventListener('change', (e) => {
@@ -1064,19 +1117,20 @@
             btn.textContent = 'Saving...';
 
             try {
-                const data = {
-                    emergencyContact: {
-                        name: document.getElementById('edit-ec-name').value,
-                        phone: document.getElementById('edit-ec-phone').value
-                    },
-                    medicalInfo: document.getElementById('edit-medical-info').value
-                };
-
                 const photoFile = document.getElementById('edit-photo-input').files[0];
+                let photoUrl;
                 if (photoFile) {
-                    const url = await uploadPlayerPhoto(photoFile);
-                    data.photoUrl = url;
+                    photoUrl = await uploadPlayerPhoto(photoFile);
                 }
+
+                const data = buildPlayerProfileUpdatePayload({
+                    emergencyContactName: document.getElementById('edit-ec-name').value,
+                    emergencyContactPhone: document.getElementById('edit-ec-phone').value,
+                    medicalInfo: document.getElementById('edit-medical-info').value,
+                    photoUrl,
+                    privateProfileLoadFailed,
+                    privateFieldsDirty
+                });
 
                 await updatePlayerProfile(currentTeamId, currentPlayer.id, data);
                 

--- a/tests/unit/player-private-profile-edit.test.js
+++ b/tests/unit/player-private-profile-edit.test.js
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readPlayerPage() {
+    return readFileSync(new URL('../../player.html', import.meta.url), 'utf8');
+}
+
+function readDbSource() {
+    return readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+}
+
+function extractFunction(source, signature) {
+    const start = source.indexOf(signature);
+    expect(start, `Expected function signature to exist: ${signature}`).toBeGreaterThanOrEqual(0);
+
+    const parenStart = source.indexOf('(', start);
+    expect(parenStart, `Expected opening paren for: ${signature}`).toBeGreaterThanOrEqual(0);
+
+    let parenDepth = 1;
+    let parenEnd = -1;
+    for (let i = parenStart + 1; i < source.length; i += 1) {
+        const ch = source[i];
+        if (ch === '(') parenDepth += 1;
+        if (ch === ')') parenDepth -= 1;
+        if (parenDepth === 0) {
+            parenEnd = i;
+            break;
+        }
+    }
+
+    expect(parenEnd, `Expected closing paren for: ${signature}`).toBeGreaterThanOrEqual(0);
+
+    const braceStart = source.indexOf('{', parenEnd);
+    expect(braceStart, `Expected opening brace for: ${signature}`).toBeGreaterThanOrEqual(0);
+
+    let depth = 1;
+    for (let i = braceStart + 1; i < source.length; i += 1) {
+        const ch = source[i];
+        if (ch === '{') depth += 1;
+        if (ch === '}') depth -= 1;
+        if (depth === 0) {
+            return source.slice(start, i + 1);
+        }
+    }
+
+    throw new Error(`Could not extract function for signature: ${signature}`);
+}
+
+function buildPlayerProfileUpdatePayload(overrides = {}) {
+    const source = readPlayerPage();
+    const fnSource = extractFunction(source, 'function buildPlayerProfileUpdatePayload(');
+    const factory = new Function(`${fnSource}; return buildPlayerProfileUpdatePayload;`);
+    const buildPayload = factory();
+
+    return buildPayload({
+        emergencyContactName: '',
+        emergencyContactPhone: '',
+        medicalInfo: '',
+        privateProfileLoadFailed: false,
+        privateFieldsDirty: {
+            emergencyContact: false,
+            medicalInfo: false
+        },
+        ...overrides
+    });
+}
+
+function buildUpdatePlayerProfile() {
+    const source = readDbSource();
+    const fnSource = extractFunction(source, 'export async function updatePlayerProfile(')
+        .replace('export async function updatePlayerProfile', 'async function updatePlayerProfile');
+
+    const factory = new Function('deps', `
+        const { Timestamp, updateDoc, doc, db, setDoc } = deps;
+        ${fnSource}
+        return updatePlayerProfile;
+    `);
+
+    const deps = {
+        Timestamp: {
+            now: vi.fn(() => 'ts-now')
+        },
+        updateDoc: vi.fn(() => Promise.resolve()),
+        setDoc: vi.fn(() => Promise.resolve()),
+        doc: vi.fn((database, path, maybeId) => maybeId ? `${path}/${maybeId}` : path),
+        db: {}
+    };
+
+    return {
+        deps,
+        updatePlayerProfile: factory(deps)
+    };
+}
+
+describe('player private-profile edit payload', () => {
+    it('omits untouched private fields when a photo-only save follows a private-profile load failure', () => {
+        const payload = buildPlayerProfileUpdatePayload({
+            privateProfileLoadFailed: true,
+            photoUrl: 'https://img.example/player.jpg'
+        });
+
+        expect(payload).toEqual({
+            photoUrl: 'https://img.example/player.jpg'
+        });
+        expect(payload).not.toHaveProperty('emergencyContact');
+        expect(payload).not.toHaveProperty('medicalInfo');
+    });
+
+    it('includes private fields during normal profile saves when the private-profile load succeeded', () => {
+        const payload = buildPlayerProfileUpdatePayload({
+            emergencyContactName: 'Pat Parent',
+            emergencyContactPhone: '555-0100',
+            medicalInfo: 'Asthma inhaler'
+        });
+
+        expect(payload).toEqual({
+            emergencyContact: {
+                name: 'Pat Parent',
+                phone: '555-0100'
+            },
+            medicalInfo: 'Asthma inhaler'
+        });
+    });
+
+    it('includes only explicitly edited private fields after a private-profile load failure', () => {
+        const payload = buildPlayerProfileUpdatePayload({
+            emergencyContactName: 'New Contact',
+            emergencyContactPhone: '555-0111',
+            privateProfileLoadFailed: true,
+            privateFieldsDirty: {
+                emergencyContact: true,
+                medicalInfo: false
+            }
+        });
+
+        expect(payload).toEqual({
+            emergencyContact: {
+                name: 'New Contact',
+                phone: '555-0111'
+            }
+        });
+        expect(payload).not.toHaveProperty('medicalInfo');
+    });
+});
+
+describe('updatePlayerProfile private doc writes', () => {
+    it('skips the private profile document when only photoUrl is present', async () => {
+        const { deps, updatePlayerProfile } = buildUpdatePlayerProfile();
+
+        await updatePlayerProfile('team-1', 'player-1', {
+            photoUrl: 'https://img.example/player.jpg'
+        });
+
+        expect(deps.updateDoc).toHaveBeenCalledTimes(1);
+        expect(deps.setDoc).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
Closes #471

## What changed
- added a focused Vitest regression test for the `player.html` edit flow that verifies photo-only saves do not send blank `emergencyContact` or `medicalInfo` after a private-profile read failure
- added a `player.html` payload helper and per-field dirty tracking so failed private-profile reads no longer cause untouched private fields to be submitted as empty values
- documented the requirements, architecture, QA, and code plan for this run under `docs/pr-notes/runs/issue-471-fixer-20260403T032502Z/`

## Why
The bug was in UI payload shaping, not in `updatePlayerProfile()`. When the modal opened after a denied or failed private-profile read, the form showed blank sensitive fields and the submit handler always sent them, which could silently overwrite existing emergency and medical data during a photo-only update.

## Validation
- ran the new targeted regression test before the fix and confirmed it failed because the payload helper guard did not exist
- ran `./node_modules/.bin/vitest run tests/unit/player-private-profile-edit.test.js`
- ran `./node_modules/.bin/vitest run tests/unit` and the full unit suite passed (129 files, 578 tests)