### PR TITLE
Prevent canceled AI summaries from being saved

### DIFF
--- a/docs/pr-notes/runs/issue-466-fixer-20260403T035503Z/architecture.md
+++ b/docs/pr-notes/runs/issue-466-fixer-20260403T035503Z/architecture.md
@@ -1,0 +1,20 @@
+Objective: close a client-side state leak in the stat-sheet-to-game-report workflow.
+
+Current architecture:
+- `track-statsheet.html` contains inline workflow logic.
+- AI generation writes to both preview UI and textarea while also retaining the draft in `generatedSummary`.
+- Save derives persisted summary text from two sources: textarea first, then cached AI output.
+
+Proposed architecture:
+- Keep the textarea as the single persisted source of truth.
+- Keep `generatedSummary` only as transient draft state for preview and "Use Summary".
+- Clear transient draft state when the user dismisses the preview so rejected content cannot be reused implicitly.
+
+Tradeoffs:
+- This is the smallest safe patch and avoids larger refactors such as extracting inline handlers to a dedicated module.
+- Clearing `generatedSummary` on cancel means "Use Summary" after cancel is not possible without regenerating, which matches the explicit reject action.
+
+Controls and blast radius:
+- No backend schema, Firestore rule, or API contract changes.
+- Rollback is trivial: revert the single page and regression test if unexpected behavior appears.
+- Instrumentation remains manual through the existing workflow and unit tests.

--- a/docs/pr-notes/runs/issue-466-fixer-20260403T035503Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-466-fixer-20260403T035503Z/code-plan.md
@@ -1,0 +1,9 @@
+Thinking level: medium
+Reason: single-page workflow bug with low blast radius, but it needs a precise regression guard before editing inline logic.
+
+Implementation plan:
+1. Add a unit test in `tests/unit/` that inspects `track-statsheet.html` for the correct cancel and save semantics.
+2. Update `track-statsheet.html` so `hideSummaryPreview()` clears `generatedSummary`.
+3. Update the save handler to persist only `summary-notes.value.trim()`.
+4. Run the focused unit test first, then the full unit suite if the focused run passes.
+5. Stage the test, page change, and run-note artifacts, then commit with an issue-referencing message.

--- a/docs/pr-notes/runs/issue-466-fixer-20260403T035503Z/qa.md
+++ b/docs/pr-notes/runs/issue-466-fixer-20260403T035503Z/qa.md
@@ -1,0 +1,17 @@
+Objective: add regression coverage for issue #466 and validate the post-game summary workflow.
+
+Primary regression to catch:
+- Generated AI summary remains savable after preview cancel/close and textarea clear.
+
+Test strategy:
+- Add a focused unit test against `track-statsheet.html` source that fails if save still falls back to `generatedSummary`.
+- Assert cancel/close logic clears both preview visibility and cached generated text.
+- Assert generation and explicit "Use Summary" wiring remain present so the happy path is still covered.
+
+Manual validation targets:
+1. Generate AI summary, cancel preview, clear textarea, click Save & Continue, confirm no summary is written.
+2. Generate AI summary, keep or edit text in textarea, click Save & Continue, confirm saved summary matches textarea.
+3. Enter a manual summary without using AI, click Save & Continue, confirm manual text saves.
+
+Residual risk:
+- Coverage is source-level, not browser-executed, so runtime DOM regressions outside the changed logic still rely on manual validation.

--- a/docs/pr-notes/runs/issue-466-fixer-20260403T035503Z/requirements.md
+++ b/docs/pr-notes/runs/issue-466-fixer-20260403T035503Z/requirements.md
@@ -1,0 +1,30 @@
+Objective: prevent rejected or cleared AI summaries from being saved in the post-game stat editor flow.
+
+Current state:
+- `track-statsheet.html` stores AI output in a module-level `generatedSummary`.
+- Canceling or closing the preview only hides UI state.
+- Saving uses textarea content or falls back to `generatedSummary`, which overrides explicit user intent to clear the summary.
+
+Proposed state:
+- Save only the current textarea value.
+- Treat cancel or preview close as rejection of the generated draft by clearing the in-memory generated summary.
+- Preserve the existing flow where accepted AI text is still editable in the textarea before save.
+
+Risk surface and blast radius:
+- Scope is limited to the post-game stat editor summary step in `track-statsheet.html`.
+- Main regression risk is breaking the AI-assisted summary happy path or preventing manual summaries from saving.
+- No tenant boundary, auth, or PHI blast radius change. This is client-side workflow state only.
+
+Assumptions:
+- The textarea is the source of truth for what should be persisted.
+- Cancel and close mean "do not keep this generated draft" unless the user reuses or re-enters content.
+- Existing unit tests may validate wiring by source inspection rather than browser execution.
+
+Recommendation:
+- Add a regression test that encodes the expected behavior around cancel/clear and save.
+- Make the minimal code change to clear stale generated state and remove the save fallback.
+
+Success criteria:
+- A blank textarea results in no summary save.
+- Canceling or closing the AI preview does not leave generated text eligible for later save.
+- Manual text and accepted AI text still save normally.

--- a/tests/unit/track-statsheet-summary-save.test.js
+++ b/tests/unit/track-statsheet-summary-save.test.js
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('track-statsheet summary save behavior', () => {
+    it('clears rejected generated summaries and saves only textarea content', () => {
+        const source = readFileSync(new URL('../../track-statsheet.html', import.meta.url), 'utf8');
+
+        expect(source).toContain("document.getElementById('cancel-summary-btn').addEventListener('click', hideSummaryPreview);");
+        expect(source).toContain("document.getElementById('close-summary-preview').addEventListener('click', hideSummaryPreview);");
+        expect(source).toMatch(/const hideSummaryPreview = \(\) => \{[\s\S]*generatedSummary = '';/);
+        expect(source).toContain("const summaryText = document.getElementById('summary-notes').value.trim();");
+        expect(source).not.toContain("|| generatedSummary.trim()");
+    });
+});

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -938,6 +938,7 @@ Write the match report now:`;
 
     // Cancel/Close preview buttons
     const hideSummaryPreview = () => {
+      generatedSummary = '';
       document.getElementById('summary-preview').classList.add('hidden');
       document.getElementById('summary-status').textContent = '';
     };
@@ -949,7 +950,7 @@ Write the match report now:`;
     document.getElementById('save-continue-btn').addEventListener('click', async () => {
       const saveBtn = document.getElementById('save-continue-btn');
       const status = document.getElementById('summary-status');
-      const summaryText = document.getElementById('summary-notes').value.trim() || generatedSummary.trim();
+      const summaryText = document.getElementById('summary-notes').value.trim();
 
       saveBtn.disabled = true;
 


### PR DESCRIPTION
Closes #466

## What changed
- cleared the cached AI-generated summary when the preview is canceled or closed in `track-statsheet.html`
- removed the save fallback that used stale generated text when the summary textarea was blank
- added a unit regression test covering the cancel/clear-and-save behavior
- captured requirements, architecture, QA, and code-plan notes for this fixer run

## Why
Canceling or clearing the AI summary should respect the coach's explicit intent. Before this change, the page still saved the last generated AI text even when the preview was dismissed and the textarea was empty.

## Validation
- `pnpm exec vitest run tests/unit/track-statsheet-summary-save.test.js`
- `pnpm exec vitest run tests/unit/post-game-stat-editor.test.js tests/unit/track-ai-summary-gating.test.js`