### PR TITLE
Cover homepage dashboard routing for parent and coach users

### DIFF
--- a/docs/pr-notes/runs/issue-473-fixer-20260403T040010Z/architecture.md
+++ b/docs/pr-notes/runs/issue-473-fixer-20260403T040010Z/architecture.md
@@ -1,0 +1,20 @@
+## Current State
+- `index.html` boots the homepage through `initHomepage(...)`.
+- `initHomepage` uses `checkAuth(...)` and `applyHeroCta(...)`.
+- `applyHeroCta(...)` currently hard-codes `dashboard.html` for any truthy user object.
+- `js/auth.js#getRedirectUrl(...)` already owns the correct role precedence.
+
+## Proposed State
+- Thread `getRedirectUrl` into `initHomepage(...)`.
+- Update `applyHeroCta(...)` to delegate authenticated CTA destination selection to that function, with a safe fallback to `dashboard.html`.
+- Keep the change local to homepage composition instead of moving auth or routing rules.
+
+## Why This Shape
+- It eliminates policy drift between login redirects and homepage CTA routing.
+- It keeps the blast radius narrow: one homepage module, one page entrypoint import, one test file.
+- It preserves existing behavior for guests and for any user shape not recognized by role routing.
+
+## Controls
+- No new storage, network, or auth side effects.
+- No change to role derivation logic itself.
+- Existing role precedence remains centralized in `js/auth.js`.

--- a/docs/pr-notes/runs/issue-473-fixer-20260403T040010Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-473-fixer-20260403T040010Z/code-plan.md
@@ -1,0 +1,10 @@
+## Plan
+- Add failing homepage unit expectations for parent vs coach CTA destinations.
+- Update homepage CTA logic to consume the shared auth redirect helper.
+- Run targeted and broad unit validation.
+- Commit the focused patch for issue #473 without unrelated changes.
+
+## Implementation Notes
+- Keep the patch minimal and homepage-scoped.
+- Avoid duplicating role logic in `js/homepage.js`.
+- Preserve existing guest copy and link behavior.

--- a/docs/pr-notes/runs/issue-473-fixer-20260403T040010Z/qa.md
+++ b/docs/pr-notes/runs/issue-473-fixer-20260403T040010Z/qa.md
@@ -1,0 +1,15 @@
+## Coverage Target
+- Homepage hero CTA routing for authenticated parent users
+- Homepage hero CTA routing for authenticated coach users
+- Guest CTA regression guardrail
+
+## Test Strategy
+1. Extend `tests/unit/homepage-index.test.js`.
+2. Add an authenticated parent case and assert CTA text is `Go to Dashboard` while href is `parent-dashboard.html`.
+3. Keep an authenticated coach case asserting href is `dashboard.html`.
+4. Preserve guest CTA assertions to catch unintended regression.
+
+## Validation Notes
+- Preferred command: `npm test -- tests/unit/homepage-index.test.js`
+- Secondary command: `npm test` to confirm the broader unit suite still passes.
+- If Playwright is later required for browser-level CTA click coverage, add it as a follow-up; the repo’s existing automated homepage coverage is currently in Vitest.

--- a/docs/pr-notes/runs/issue-473-fixer-20260403T040010Z/requirements.md
+++ b/docs/pr-notes/runs/issue-473-fixer-20260403T040010Z/requirements.md
@@ -1,0 +1,32 @@
+## Objective
+- Add authenticated homepage coverage for role-aware dashboard routing so parents and coaches do not silently share the same CTA destination.
+
+## Current State
+- `js/homepage.js` changes the homepage hero CTA for any signed-in user.
+- That CTA always points to `dashboard.html`, regardless of whether the signed-in user is a coach or a parent.
+- Existing homepage unit coverage asserts only the generic signed-in destination and misses the parent path.
+
+## Proposed State
+- The homepage CTA should mirror auth redirect behavior:
+  - coaches/admins -> `dashboard.html`
+  - parents -> `parent-dashboard.html`
+- Automated coverage should exercise both authenticated roles from the homepage entry flow.
+
+## Risk Surface
+- Blast radius is limited to homepage CTA wiring and homepage-specific tests.
+- No Firestore schema, auth backend, or multi-tenant access rules change.
+- Main regression risk is accidentally changing guest CTA behavior or coach routing while fixing parents.
+
+## Assumptions
+- `getRedirectUrl(user)` in `js/auth.js` is the canonical role-routing policy.
+- A user with both coach/admin and parent attributes should still follow the existing coach/admin precedence.
+- The requested subagent skills and `sessions_spawn` tool are unavailable in this environment, so this artifact records the synthesized role output directly.
+
+## Recommendation
+- Reuse `getRedirectUrl` for homepage CTA selection rather than duplicating role checks in `js/homepage.js`.
+- Add focused homepage tests for parent and coach users, while preserving guest CTA assertions already in place.
+
+## Success Criteria
+- Authenticated parent homepage CTA resolves to `parent-dashboard.html`.
+- Authenticated coach homepage CTA resolves to `dashboard.html`.
+- Existing guest homepage CTA remains `login.html#signup`.

--- a/index.html
+++ b/index.html
@@ -651,7 +651,7 @@
   </footer>
 
   <script type="module">
-    import { checkAuth } from './js/auth.js?v=10';
+    import { checkAuth, getRedirectUrl } from './js/auth.js?v=10';
     import { renderHeader, formatDate, formatTime } from './js/utils.js?v=8';
     import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=15';
     import { initHomepage } from './js/homepage.js?v=1';
@@ -659,6 +659,7 @@
     initHomepage({
       document,
       checkAuth,
+      getRedirectUrl,
       renderHeader,
       getLiveGamesNow,
       getUpcomingLiveGames,

--- a/js/homepage.js
+++ b/js/homepage.js
@@ -40,14 +40,14 @@ function renderTeamAvatar(game) {
     return `<div class="w-10 h-10 rounded-full bg-primary-100 flex items-center justify-center text-primary-600 font-bold">${teamInitial}</div>`;
 }
 
-export function applyHeroCta(user, heroCta) {
+export function applyHeroCta(user, heroCta, getRedirectUrl = () => 'dashboard.html') {
     if (!heroCta) {
         return;
     }
 
     if (user) {
         heroCta.textContent = 'Go to Dashboard';
-        heroCta.href = 'dashboard.html';
+        heroCta.href = getRedirectUrl(user);
         return;
     }
 
@@ -165,6 +165,7 @@ export async function loadPastGames({
 export async function initHomepage({
     document = globalThis.document,
     checkAuth,
+    getRedirectUrl = () => 'dashboard.html',
     renderHeader,
     getLiveGamesNow,
     getUpcomingLiveGames,
@@ -177,7 +178,7 @@ export async function initHomepage({
 
     checkAuth((user) => {
         renderHeader(document.getElementById('header-container'), user);
-        applyHeroCta(user, heroCta);
+        applyHeroCta(user, heroCta, getRedirectUrl);
     });
 
     await Promise.all([

--- a/tests/unit/homepage-index.test.js
+++ b/tests/unit/homepage-index.test.js
@@ -68,7 +68,8 @@ async function runHomepage({
     replayGames = [],
     liveError = null,
     upcomingError = null,
-    replayError = null
+    replayError = null,
+    getRedirectUrl = () => 'dashboard.html'
 } = {}) {
     const { document, elements } = createEnvironment();
     const renderHeader = vi.fn((container, currentUser) => {
@@ -80,6 +81,7 @@ async function runHomepage({
         checkAuth(callback) {
             callback(user);
         },
+        getRedirectUrl,
         renderHeader,
         async getLiveGamesNow() {
             if (liveError) {
@@ -115,7 +117,7 @@ async function runHomepage({
 }
 
 describe('homepage index workflow', () => {
-    it('renders auth-aware CTA, deduplicates live and upcoming games, and preserves replay links', async () => {
+    it('routes coach users to the team dashboard CTA, deduplicates live and upcoming games, and preserves replay links', async () => {
         const duplicatedLiveGame = createGame({ liveViewerCount: 5 });
         const replayGame = createGame({
             id: 'game-2',
@@ -125,13 +127,16 @@ describe('homepage index workflow', () => {
         });
 
         const { elements, renderHeader } = await runHomepage({
-            user: { uid: 'coach-1' },
+            user: { uid: 'coach-1', coachOf: ['team-1'] },
             liveGames: [duplicatedLiveGame],
             upcomingGames: [duplicatedLiveGame],
-            replayGames: [replayGame]
+            replayGames: [replayGame],
+            getRedirectUrl(user) {
+                return user.coachOf?.length ? 'dashboard.html' : 'parent-dashboard.html';
+            }
         });
 
-        expect(renderHeader).toHaveBeenCalledWith(elements.get('header-container'), { uid: 'coach-1' });
+        expect(renderHeader).toHaveBeenCalledWith(elements.get('header-container'), { uid: 'coach-1', coachOf: ['team-1'] });
         expect(elements.get('hero-cta').textContent).toBe('Go to Dashboard');
         expect(elements.get('hero-cta').href).toBe('dashboard.html');
 
@@ -146,6 +151,25 @@ describe('homepage index workflow', () => {
         expect(replayMarkup).not.toContain('Loading replays...');
         expect(replayMarkup).toContain('Watch Replay');
         expect(replayMarkup).toContain('gameId=game-2&replay=true');
+    });
+
+    it('routes parent users to the parent dashboard CTA', async () => {
+        const { elements, renderHeader } = await runHomepage({
+            user: {
+                uid: 'parent-1',
+                parentOf: [{ teamId: 'team-1', playerId: 'player-1' }]
+            },
+            getRedirectUrl(user) {
+                return user.parentOf?.length ? 'parent-dashboard.html' : 'dashboard.html';
+            }
+        });
+
+        expect(renderHeader).toHaveBeenCalledWith(elements.get('header-container'), {
+            uid: 'parent-1',
+            parentOf: [{ teamId: 'team-1', playerId: 'player-1' }]
+        });
+        expect(elements.get('hero-cta').textContent).toBe('Go to Dashboard');
+        expect(elements.get('hero-cta').href).toBe('parent-dashboard.html');
     });
 
     it('keeps upcoming cards visible when live games fail and sets the guest CTA', async () => {


### PR DESCRIPTION
Closes #473

## What changed
- added homepage unit coverage for authenticated coach and parent users so the hero CTA follows the correct dashboard destination for each role
- updated homepage CTA wiring to reuse `getRedirectUrl(...)` from `js/auth.js` instead of hard-coding `dashboard.html` for every signed-in user
- recorded the required requirements, architecture, QA, and code-plan artifacts under the issue run notes directory

## Why
The homepage is a real signed-in entrypoint, but its CTA had drifted from the existing auth redirect policy. This patch closes that gap by testing the parent path explicitly and making homepage routing follow the same shared role-aware logic as auth redirects.

## Validation
- `pnpm exec vitest run tests/unit/homepage-index.test.js`
- `pnpm test`