### PR TITLE
Align player profile edit access with save permissions

### DIFF
--- a/docs/pr-notes/runs/issue-475-fixer-20260403T045502Z/architecture.md
+++ b/docs/pr-notes/runs/issue-475-fixer-20260403T045502Z/architecture.md
@@ -1,0 +1,17 @@
+Decision: align player-page UI authorization with the existing shared team access model instead of maintaining a second, looser rule in the page script.
+
+Why:
+- `js/team-access.js` already defines the canonical full-access rule used elsewhere.
+- Reusing that helper reduces authorization drift and keeps UI behavior consistent with Firestore rules.
+
+Current state:
+- `player.html` computes `isCoachForTeam` from `currentUser.coachOf` and treats it as edit authorization.
+
+Proposed state:
+- Track the loaded team in page state.
+- Call `hasFullTeamAccess(currentUser, currentTeam)` inside `updateEditButton()`.
+- Combine that result with the existing linked-parent checks only.
+
+Blast radius:
+- Static page script only.
+- No data model changes, no rule changes, no API changes.

--- a/docs/pr-notes/runs/issue-475-fixer-20260403T045502Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-475-fixer-20260403T045502Z/code-plan.md
@@ -1,0 +1,6 @@
+Implementation plan:
+1. Add a string-based unit test for `player.html` authorization wiring.
+2. Store the loaded team object in page state.
+3. Import `hasFullTeamAccess` from `js/team-access.js`.
+4. Replace `coachOf`-based edit gating with `hasFullTeamAccess(currentUser, currentTeam) || isParent`.
+5. Run focused and full unit tests, then commit the targeted patch.

--- a/docs/pr-notes/runs/issue-475-fixer-20260403T045502Z/qa.md
+++ b/docs/pr-notes/runs/issue-475-fixer-20260403T045502Z/qa.md
@@ -1,0 +1,11 @@
+Test strategy:
+- Add a unit wiring test for `player.html` that asserts the page uses `hasFullTeamAccess` and no longer derives edit permission from `coachOf`.
+- Run the new focused test first to demonstrate the existing bug.
+- Run the full unit suite after the fix to check for regressions in adjacent access-control helpers.
+
+Primary regression to guard:
+- `coachOf`-only users see Edit Profile again.
+
+Secondary regression to watch:
+- Linked parents still retain edit access.
+- Team owner/admin/platform admin still retain edit access through the shared helper.

--- a/docs/pr-notes/runs/issue-475-fixer-20260403T045502Z/requirements.md
+++ b/docs/pr-notes/runs/issue-475-fixer-20260403T045502Z/requirements.md
@@ -1,0 +1,20 @@
+Objective: Remove the misleading Edit Profile affordance for users who cannot save private player profile changes.
+
+Current state:
+- `player.html` shows Edit Profile when the signed-in user is global admin, linked parent, or listed in `coachOf`.
+- Firestore only allows writes for team owner, team admin email, global admin, or linked parent.
+
+Proposed state:
+- `player.html` should only show Edit Profile when the user has full team access under the shared helper or is a linked parent for that player.
+
+Risk surface and blast radius:
+- Affects one button and one modal entry point on `player.html`.
+- Sensitive profile fields are involved, so false-positive access is worse than a conservative hide.
+
+Assumptions:
+- `coachOf` remains intentionally excluded from private profile write authorization.
+- Parent access continues to be valid through either legacy `player.parents` or `user.parentOf`.
+
+Recommendation:
+- Reuse the shared `hasFullTeamAccess` helper in `player.html` and keep parent checks local to the page.
+- Add a regression test that fails if `player.html` reintroduces `coachOf`-only gating.

--- a/player.html
+++ b/player.html
@@ -224,11 +224,13 @@
         import { collection, getDocs, doc, getDoc, query, orderBy } from "./js/firebase.js?v=10";
         import { db } from './js/firebase.js?v=10';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js';
+        import { hasFullTeamAccess } from './js/team-access.js';
 
         let currentUser = null;
         let currentPlayer = null; // Store for modal access
         let currentPrivateProfile = null; // Sensitive fields live in a private doc
         let currentTeamId = null;
+        let currentTeam = null;
 
         checkAuth((user) => {
             currentUser = user;
@@ -365,6 +367,7 @@
                     document.querySelector('main').innerHTML = '<div class="text-center py-12 text-red-500">Player not found</div>';
                     return;
                 }
+                currentTeam = team;
                 currentPlayer = player; // Store global
 
                 // Render team navigation banner if user has access
@@ -1005,8 +1008,8 @@
                 currentUser.parentOf.some(p => p.teamId === currentTeamId && p.playerId === currentPlayer.id);
 
             const isParent = isParentViaPlayer || isParentViaProfile;
-            const isCoachForTeam = Array.isArray(currentUser.coachOf) && currentUser.coachOf.includes(currentTeamId);
-            const canEdit = currentUser.isAdmin || isParent || isCoachForTeam;
+            const hasFullAccess = hasFullTeamAccess(currentUser, currentTeam);
+            const canEdit = hasFullAccess || isParent;
 
             if (canEdit) {
                 const btnContainer = document.getElementById('edit-btn-container');

--- a/tests/unit/player-profile-edit-access.test.js
+++ b/tests/unit/player-profile-edit-access.test.js
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readRepoFile(relativePath) {
+    return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+describe('player profile edit access wiring', () => {
+    it('reuses full team access rules instead of granting edit access from coachOf alone', () => {
+        const html = readRepoFile('player.html');
+
+        expect(html).toContain("import { hasFullTeamAccess } from './js/team-access.js';");
+        expect(html).toContain('const hasFullAccess = hasFullTeamAccess(currentUser, currentTeam);');
+        expect(html).toContain('const canEdit = hasFullAccess || isParent;');
+        expect(html).not.toContain('const isCoachForTeam = Array.isArray(currentUser.coachOf) && currentUser.coachOf.includes(currentTeamId);');
+        expect(html).not.toContain('const canEdit = currentUser.isAdmin || isParent || isCoachForTeam;');
+    });
+});


### PR DESCRIPTION
Closes #475

## What changed
- aligned `player.html` edit-button gating with the shared full team access helper instead of treating `coachOf` as sufficient
- kept linked parent edit access intact while removing the misleading `coachOf`-only path
- added a regression test that locks the player page to the shared access model and rejects the old `coachOf`-based wiring
- recorded requirements, architecture, QA, and code-plan notes for this run under `docs/pr-notes/runs/issue-475-fixer-20260403T045502Z/`

## Why
The player page was advertising an Edit Profile flow to some users who could not actually save private profile updates under Firestore rules. Reusing the existing shared team access helper keeps the UI in sync with the backend authorization model and prevents users from entering sensitive data only to hit a permission error on submit.

## Validation
- `./node_modules/.bin/vitest run tests/unit/player-profile-edit-access.test.js`
- `./node_modules/.bin/vitest run tests/unit/team-access.test.js`
- `./node_modules/.bin/vitest run tests/unit`