### PR TITLE
Add statsheet apply/save regression coverage

### DIFF
--- a/docs/pr-notes/runs/481-ci-fix-20260403T054730Z/architecture.md
+++ b/docs/pr-notes/runs/481-ci-fix-20260403T054730Z/architecture.md
@@ -1,0 +1,16 @@
+Objective: restore PR #481 preview smoke by fixing the failing statsheet apply smoke tests.
+
+Current state: `tests/smoke/track-statsheet-apply.spec.js` seeds scenario state through `localStorage` after navigating to `about:blank`.
+Proposed state: seed the same state after navigating to an app URL on the preview origin so storage access uses the same origin as the tested page.
+
+Risk surface and blast radius:
+- Scope is limited to a single smoke spec.
+- No production runtime code changes.
+- Main risk is masking a broader storage bug, but the CI log points to test setup rather than app logic.
+
+Assumptions:
+- `SMOKE_BASE_URL` is present in preview smoke runs.
+- `track-statsheet.html` can be loaded safely before state seeding.
+
+Recommendation:
+- Use the preview origin for test seeding. This is the smallest change that preserves test intent and removes the cross-origin/restricted-document dependency.

--- a/docs/pr-notes/runs/481-ci-fix-20260403T054730Z/code-plan.md
+++ b/docs/pr-notes/runs/481-ci-fix-20260403T054730Z/code-plan.md
@@ -1,0 +1,11 @@
+Root cause:
+- `seedScenario()` navigated to `about:blank` and then wrote `localStorage`.
+- In CI Chromium, that document can deny storage access, causing both smoke tests to fail before the page under test loads.
+
+Implementation:
+- Change `seedScenario()` to navigate to `buildUrl(baseURL, '/track-statsheet.html')` before writing the store.
+- Pass `baseURL` from each affected test into `seedScenario()`.
+
+Why this is minimal:
+- One test helper and two call sites change.
+- No runtime modules or user-facing behavior are touched.

--- a/docs/pr-notes/runs/481-ci-fix-20260403T054730Z/qa.md
+++ b/docs/pr-notes/runs/481-ci-fix-20260403T054730Z/qa.md
@@ -1,0 +1,14 @@
+Objective: validate the failing preview smoke cases after correcting test setup.
+
+Evidence:
+- CI failed only in `tests/smoke/track-statsheet-apply.spec.js`.
+- Both failures throw `SecurityError` on `localStorage` inside `seedScenario`.
+- The failure occurs before assertions tied to app behavior, so the test harness is the defect source.
+
+Validation plan:
+- Run the targeted Playwright smoke spec with `playwright.smoke.config.js`.
+- Confirm both previously failing tests pass.
+- Avoid broad suite changes because the requested fix is scoped to one CI failure.
+
+Skill note:
+- `allplays-orchestrator-playbook`, `allplays-architecture-expert`, `allplays-qa-expert`, and `allplays-code-expert` were requested by instruction but are not available in this session’s skill list, so analysis was completed inline.

--- a/docs/pr-notes/runs/issue-470-fixer-20260403T052951Z/architecture.md
+++ b/docs/pr-notes/runs/issue-470-fixer-20260403T052951Z/architecture.md
@@ -1,0 +1,23 @@
+Objective: add coverage without introducing a second implementation of statsheet persistence.
+
+Current state:
+- The apply handler lives inline in `track-statsheet.html`.
+- Browser mocking is feasible, but persistence assertions are cleaner if the write-plan logic is isolated from DOM concerns.
+
+Proposed state:
+- Move validation and save-plan construction into `js/track-statsheet-apply.js`.
+- Keep page orchestration in `track-statsheet.html`: upload, overwrite prompt, deletes, batch creation, summary reveal.
+- Use Playwright module routing to mock `auth`, `db`, `firebase`, and AI responses while preserving the page’s real UI behavior.
+
+Controls and blast radius:
+- No schema changes.
+- No auth model changes.
+- The only production behavior change should be code organization plus any small correctness fixes found during test implementation.
+
+Tradeoffs:
+- Playwright-only assertions would work but would duplicate persistence expectations in the test.
+- A helper seam adds one module, but it centralizes the write shape and reduces future drift between UI and test expectations.
+
+Rollback:
+- Revert the helper import and new smoke spec.
+- No data migration or environment rollback is required.

--- a/docs/pr-notes/runs/issue-470-fixer-20260403T052951Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-470-fixer-20260403T052951Z/code-plan.md
@@ -1,0 +1,18 @@
+Thinking level: medium
+Reason: cross-page browser mocking plus a small production seam is needed, but the flow is bounded.
+
+Implementation plan:
+1. Add `js/track-statsheet-apply.js` with:
+   - included-row validation
+   - duplicate roster mapping validation
+   - aggregated stat payload generation
+   - opponent stat snapshot generation
+   - game update payload generation
+2. Rewire `track-statsheet.html` to call the helper instead of constructing payloads inline.
+3. Add `tests/smoke/track-statsheet-apply.spec.js` that:
+   - mocks page modules
+   - seeds track/game state in localStorage-backed fake Firestore data
+   - exercises alert and confirm branches
+   - verifies saved output on `game.html`
+4. Run the targeted Playwright spec and the relevant unit suite.
+5. Commit all changes with an issue-referencing message.

--- a/docs/pr-notes/runs/issue-470-fixer-20260403T052951Z/qa.md
+++ b/docs/pr-notes/runs/issue-470-fixer-20260403T052951Z/qa.md
@@ -1,0 +1,17 @@
+Test strategy:
+- Browser spec 1: analyze mocked rows with one unmatched included home player, verify apply is blocked, map the row, apply, verify persisted writes and summary visibility.
+- Browser spec 2: seed existing events and aggregated stats, reject overwrite confirm, verify no deletes or commit; accept confirm, verify deletes, rewritten saved data, and rendered game report tables.
+
+Regression guardrails:
+- Assert the exact alert/confirm paths.
+- Assert `aggregatedStats` payload shape by player id.
+- Assert `homeScore`, `awayScore`, `opponentStats`, and `status` persisted together.
+- Assert saved data is consumed by `game.html`, not just stored in the mock layer.
+
+Residual risks:
+- This remains mocked-browser coverage, not live Firebase integration.
+- AI extraction quality is still out of scope; the spec validates post-analysis review and persistence only.
+
+Validation commands planned:
+- `node_modules/.bin/playwright test tests/smoke/track-statsheet-apply.spec.js --config=playwright.smoke.config.js`
+- `node_modules/.bin/vitest run tests/unit`

--- a/docs/pr-notes/runs/issue-470-fixer-20260403T052951Z/requirements.md
+++ b/docs/pr-notes/runs/issue-470-fixer-20260403T052951Z/requirements.md
@@ -1,0 +1,28 @@
+Objective: cover the `track-statsheet.html` apply/save workflow end to end enough to catch silent save regressions before coaches see them.
+
+Current state:
+- Automated coverage reaches routing into the statsheet page, not the guarded save path.
+- The user-visible failure mode is silent persistence drift: success UI can appear while saved stats or report output are wrong.
+
+Proposed state:
+- Add automated browser coverage for the real statsheet page flow with mocked Firebase modules.
+- Prove three outcomes: unmatched included home rows block save, overwrite cancel preserves prior data, overwrite confirm rewrites data that the game report renders.
+
+Risk surface and blast radius:
+- `games/{gameId}/aggregatedStats/*`
+- `games/{gameId}/events/*` deletes on overwrite
+- `games/{gameId}` fields `homeScore`, `awayScore`, `opponentStats`, `status`, `statSheetPhotoUrl`
+- Post-game report rendering for coaches and parents
+
+Assumptions:
+- Mocked browser-module coverage is acceptable Playwright coverage for this repo’s static-page architecture.
+- Minimal production changes that improve testability are in scope for a coverage-gap issue.
+- We do not need live Firebase or AI calls to validate this workflow.
+
+Recommendation:
+- Extract the apply/save logic behind a small helper seam and keep page behavior unchanged.
+- Drive assertions from browser interactions plus mocked persistence state so failures stay user-meaningful and reviewable.
+
+Success measures:
+- New automated spec fails without the new seam/coverage work and passes after the patch.
+- Spec covers guard, cancel, confirm, persisted score/opponent/home stat data, and game report rendering.

--- a/js/track-statsheet-apply.js
+++ b/js/track-statsheet-apply.js
@@ -1,0 +1,108 @@
+export function isTrackStatsheetPointsColumn(colOrKey) {
+    const upper = String(colOrKey || '').toUpperCase();
+    return upper === 'PTS' || upper === 'POINTS' || upper === 'GOALS';
+}
+
+export function getTrackStatsheetPointsKey(columns = []) {
+    const match = (columns || []).find((col) => isTrackStatsheetPointsColumn(col));
+    return String(match || 'PTS').toLowerCase();
+}
+
+export function validateTrackStatsheetApplyRows(homeRows = []) {
+    const includedHome = (homeRows || []).filter((row) => row?.include);
+
+    if (includedHome.length === 0) {
+        return {
+            ok: false,
+            alertMessage: 'Please include at least one home player.'
+        };
+    }
+
+    const unmatched = includedHome.filter((row) => !row?.mappedPlayerId);
+    if (unmatched.length > 0) {
+        return {
+            ok: false,
+            alertMessage: 'Please map every included home row to a roster player or uncheck it.'
+        };
+    }
+
+    const duplicateCheck = new Set();
+    for (const row of includedHome) {
+        if (duplicateCheck.has(row.mappedPlayerId)) {
+            return {
+                ok: false,
+                alertMessage: 'A roster player is selected more than once. Please fix duplicates.'
+            };
+        }
+        duplicateCheck.add(row.mappedPlayerId);
+    }
+
+    return {
+        ok: true,
+        includedHome
+    };
+}
+
+export function buildTrackStatsheetApplyPlan({
+    includedHome = [],
+    includedVisitor = [],
+    roster = [],
+    columns = [],
+    homeScore = 0,
+    awayScore = 0,
+    statSheetPhotoUrl = null
+} = {}) {
+    const configColumns = (columns || []).map((col) => String(col || '').toLowerCase());
+    const pointsKey = getTrackStatsheetPointsKey(columns);
+
+    const aggregatedStatsWrites = includedHome.reduce((writes, row) => {
+        const player = (roster || []).find((candidate) => candidate.id === row.mappedPlayerId);
+        if (!player) {
+            return writes;
+        }
+
+        const stats = {};
+        configColumns.forEach((col) => {
+            stats[col] = 0;
+        });
+        stats[pointsKey] = Number(row.totalPoints || 0) || 0;
+        stats.fouls = Number(row.fouls || 0) || 0;
+
+        writes.push({
+            playerId: player.id,
+            data: {
+                playerName: player.name,
+                playerNumber: player.number,
+                stats
+            }
+        });
+        return writes;
+    }, []);
+
+    const opponentStats = {};
+    includedVisitor.forEach((row, index) => {
+        const opponentId = `statsheet_${index + 1}`;
+        opponentStats[opponentId] = {
+            name: row.name || '',
+            number: row.number || '',
+            fouls: Number(row.fouls || 0) || 0
+        };
+        opponentStats[opponentId][pointsKey] = Number(row.totalPoints || 0) || 0;
+        configColumns.forEach((col) => {
+            if (opponentStats[opponentId][col] === undefined) {
+                opponentStats[opponentId][col] = 0;
+            }
+        });
+    });
+
+    return {
+        aggregatedStatsWrites,
+        gameUpdate: {
+            homeScore: Number(homeScore || 0) || 0,
+            awayScore: Number(awayScore || 0) || 0,
+            opponentStats,
+            status: 'completed',
+            statSheetPhotoUrl: statSheetPhotoUrl || null
+        }
+    };
+}

--- a/tests/smoke/track-statsheet-apply.spec.js
+++ b/tests/smoke/track-statsheet-apply.spec.js
@@ -508,8 +508,10 @@ async function installModuleMocks(page) {
     });
 }
 
-async function seedScenario(page, scenario) {
-    await page.goto('about:blank');
+async function seedScenario(page, baseURL, scenario) {
+    await page.goto(buildUrl(baseURL, '/track-statsheet.html'), {
+        waitUntil: 'domcontentloaded'
+    });
     await page.evaluate(({ storeKey, value }) => {
         localStorage.setItem(storeKey, JSON.stringify(value));
     }, { storeKey: STORE_KEY, value: scenario });
@@ -534,7 +536,7 @@ test.beforeEach(async ({ page }) => {
 });
 
 test('blocks apply until every included home row is mapped, then saves report data', async ({ page, baseURL }) => {
-    await seedScenario(page, createScenario());
+    await seedScenario(page, baseURL, createScenario());
     await analyzeStatsheet(page, baseURL);
 
     await page.locator('#apply-btn').click();
@@ -573,7 +575,7 @@ test('blocks apply until every included home row is mapped, then saves report da
 });
 
 test('respects overwrite confirmation and renders rewritten stats on the game report', async ({ page, baseURL }) => {
-    await seedScenario(page, createScenario({
+    await seedScenario(page, baseURL, createScenario({
         aggregatedStats: {
             legacyPlayer: {
                 playerName: 'Old Player',

--- a/tests/smoke/track-statsheet-apply.spec.js
+++ b/tests/smoke/track-statsheet-apply.spec.js
@@ -1,0 +1,633 @@
+import { test, expect } from '@playwright/test';
+
+const STORE_KEY = '__trackStatsheetSmokeStore';
+
+function buildUrl(baseURL, path) {
+    const url = new URL(path, `${baseURL}/`);
+    url.searchParams.set('cb', String(Date.now()));
+    return url.toString();
+}
+
+function createScenario(overrides = {}) {
+    return {
+        team: {
+            id: 'team-1',
+            name: 'Comets',
+            sport: 'Basketball'
+        },
+        game: {
+            id: 'game-1',
+            opponent: 'Rockets',
+            date: '2026-04-03',
+            statTrackerConfigId: 'cfg-basketball',
+            status: 'scheduled',
+            homeScore: 0,
+            awayScore: 0,
+            opponentStats: {}
+        },
+        players: [
+            { id: 'p1', name: 'Ava Cole', number: '3' },
+            { id: 'p2', name: 'Mia Diaz', number: '5' }
+        ],
+        config: {
+            id: 'cfg-basketball',
+            columns: ['PTS', 'REB', 'AST']
+        },
+        aiResponse: {
+            homePlayers: [
+                { number: '3', name: 'Ava Cole', totalPoints: 12, fouls: 2 },
+                { number: '55', name: 'Mystery Player', totalPoints: 7, fouls: 1 }
+            ],
+            visitorPlayers: [
+                { number: '10', name: 'River Stone', totalPoints: 15, fouls: 4 },
+                { number: '11', name: 'Kai North', totalPoints: 9, fouls: 2 }
+            ],
+            scores: {
+                homeFinal: 19,
+                visitorFinal: 24
+            }
+        },
+        aggregatedStats: {},
+        events: {},
+        deleteCalls: [],
+        batchOps: [],
+        commitCalls: 0,
+        confirmResponses: [],
+        confirmMessages: [],
+        confirmResults: [],
+        alerts: [],
+        ...overrides
+    };
+}
+
+async function installModuleMocks(page) {
+    await page.addInitScript(({ storeKey }) => {
+        function loadStore() {
+            try {
+                return JSON.parse(window.localStorage.getItem(storeKey) || '{}');
+            } catch (error) {
+                return {};
+            }
+        }
+
+        function saveStore(next) {
+            window.localStorage.setItem(storeKey, JSON.stringify(next));
+        }
+
+        window.alert = (message) => {
+            const store = loadStore();
+            store.alerts = store.alerts || [];
+            store.alerts.push(String(message));
+            saveStore(store);
+        };
+
+        window.confirm = (message) => {
+            const store = loadStore();
+            store.confirmMessages = store.confirmMessages || [];
+            store.confirmResults = store.confirmResults || [];
+            store.confirmResponses = store.confirmResponses || [];
+            store.confirmMessages.push(String(message));
+            const next = store.confirmResponses.length > 0 ? !!store.confirmResponses.shift() : true;
+            store.confirmResults.push(next);
+            saveStore(store);
+            return next;
+        };
+    }, { storeKey: STORE_KEY });
+
+    const dbModule = `
+        const STORE_KEY = ${JSON.stringify(STORE_KEY)};
+
+        function loadStore() {
+            return JSON.parse(localStorage.getItem(STORE_KEY) || '{}');
+        }
+
+        function saveStore(store) {
+            localStorage.setItem(STORE_KEY, JSON.stringify(store));
+        }
+
+        function clone(value) {
+            return JSON.parse(JSON.stringify(value));
+        }
+
+        function createSnapshot(entries) {
+            const docs = entries.map(([id, data, path]) => ({
+                id,
+                ref: { path },
+                data() {
+                    return clone(data);
+                }
+            }));
+
+            return {
+                size: docs.length,
+                docs,
+                forEach(callback) {
+                    docs.forEach((doc) => callback(doc));
+                }
+            };
+        }
+
+        function createCollectionPath(teamId, gameId, collectionName, docId = '') {
+            const suffix = docId ? '/' + docId : '';
+            return 'teams/' + teamId + '/games/' + gameId + '/' + collectionName + suffix;
+        }
+
+        function buildSnapshot(path) {
+            const store = loadStore();
+
+            if (path.endsWith('/events')) {
+                return createSnapshot(Object.entries(store.events || {}).map(([id, data]) => [id, data, createCollectionPath(store.team.id, store.game.id, 'events', id)]));
+            }
+
+            if (path.endsWith('/aggregatedStats')) {
+                return createSnapshot(Object.entries(store.aggregatedStats || {}).map(([id, data]) => [id, data, createCollectionPath(store.team.id, store.game.id, 'aggregatedStats', id)]));
+            }
+
+            if (path.endsWith('/statTrackerConfigs')) {
+                const config = store.config ? [[store.config.id, store.config, 'teams/' + store.team.id + '/statTrackerConfigs/' + store.config.id]] : [];
+                return createSnapshot(config);
+            }
+
+            return createSnapshot([]);
+        }
+
+        export async function getTeam() {
+            return clone(loadStore().team);
+        }
+
+        export async function getGame() {
+            return clone(loadStore().game);
+        }
+
+        export async function getPlayers() {
+            return clone(loadStore().players || []);
+        }
+
+        export async function getConfigs() {
+            const store = loadStore();
+            return store.config ? [clone(store.config)] : [];
+        }
+
+        export function collection(_db, path) {
+            return { path };
+        }
+
+        export async function getDocs(ref) {
+            return buildSnapshot(ref.path);
+        }
+
+        export async function deleteDoc(ref) {
+            const store = loadStore();
+            const parts = String(ref.path || '').split('/');
+            const collectionName = parts[parts.length - 2];
+            const docId = parts[parts.length - 1];
+
+            store.deleteCalls = store.deleteCalls || [];
+            store.deleteCalls.push(ref.path);
+
+            if (collectionName === 'events') {
+                delete (store.events || {})[docId];
+            }
+            if (collectionName === 'aggregatedStats') {
+                delete (store.aggregatedStats || {})[docId];
+            }
+
+            saveStore(store);
+        }
+
+        export async function uploadStatSheetPhoto() {
+            const store = loadStore();
+            store.uploadCount = (store.uploadCount || 0) + 1;
+            saveStore(store);
+            return 'https://img.test/statsheet.png';
+        }
+
+        export async function updateGame(_teamId, _gameId, patch) {
+            const store = loadStore();
+            store.game = { ...(store.game || {}), ...clone(patch) };
+            store.updateCalls = store.updateCalls || [];
+            store.updateCalls.push(clone(patch));
+            saveStore(store);
+        }
+
+        export async function getUnreadChatCounts() {
+            return {};
+        }
+
+        export async function getUserProfile() {
+            return null;
+        }
+
+        export async function setCompletedGamePlayerStats() {
+            return null;
+        }
+    `;
+
+    const firebaseModule = `
+        const STORE_KEY = ${JSON.stringify(STORE_KEY)};
+
+        function loadStore() {
+            return JSON.parse(localStorage.getItem(STORE_KEY) || '{}');
+        }
+
+        function saveStore(store) {
+            localStorage.setItem(STORE_KEY, JSON.stringify(store));
+        }
+
+        function clone(value) {
+            return JSON.parse(JSON.stringify(value));
+        }
+
+        function createSnapshot(entries) {
+            const docs = entries.map(([id, data, path]) => ({
+                id,
+                ref: { path },
+                data() {
+                    return clone(data);
+                }
+            }));
+
+            return {
+                size: docs.length,
+                docs,
+                forEach(callback) {
+                    docs.forEach((doc) => callback(doc));
+                }
+            };
+        }
+
+        function createCollectionPath(teamId, gameId, collectionName, docId = '') {
+            const suffix = docId ? '/' + docId : '';
+            return 'teams/' + teamId + '/games/' + gameId + '/' + collectionName + suffix;
+        }
+
+        function buildSnapshot(path) {
+            const store = loadStore();
+
+            if (path.endsWith('/events')) {
+                return createSnapshot(Object.entries(store.events || {}).map(([id, data]) => [id, data, createCollectionPath(store.team.id, store.game.id, 'events', id)]));
+            }
+
+            if (path.endsWith('/aggregatedStats')) {
+                return createSnapshot(Object.entries(store.aggregatedStats || {}).map(([id, data]) => [id, data, createCollectionPath(store.team.id, store.game.id, 'aggregatedStats', id)]));
+            }
+
+            if (path.endsWith('/statTrackerConfigs')) {
+                const config = store.config ? [[store.config.id, store.config, 'teams/' + store.team.id + '/statTrackerConfigs/' + store.config.id]] : [];
+                return createSnapshot(config);
+            }
+
+            return createSnapshot([]);
+        }
+
+        export const db = {};
+
+        export function collection(_db, path) {
+            return { path };
+        }
+
+        export function doc(_db, path, maybeId) {
+            return { path: maybeId ? path + '/' + maybeId : path };
+        }
+
+        export function query(ref) {
+            return ref;
+        }
+
+        export function orderBy() {
+            return null;
+        }
+
+        export async function getDocs(ref) {
+            return buildSnapshot(ref.path);
+        }
+
+        export function writeBatch() {
+            const operations = [];
+
+            return {
+                set(ref, data) {
+                    operations.push({ type: 'set', path: ref.path, data: clone(data) });
+                },
+                update(ref, data) {
+                    operations.push({ type: 'update', path: ref.path, data: clone(data) });
+                },
+                async commit() {
+                    const store = loadStore();
+                    store.commitCalls = (store.commitCalls || 0) + 1;
+                    store.batchOps = store.batchOps || [];
+                    store.batchOps.push(...operations.map((operation) => clone(operation)));
+
+                    operations.forEach((operation) => {
+                        if (operation.path.includes('/aggregatedStats/')) {
+                            const playerId = operation.path.split('/').pop();
+                            store.aggregatedStats = store.aggregatedStats || {};
+                            store.aggregatedStats[playerId] = clone(operation.data);
+                            return;
+                        }
+
+                        if (operation.path.includes('/games/')) {
+                            store.game = { ...(store.game || {}), ...clone(operation.data) };
+                        }
+                    });
+
+                    saveStore(store);
+                }
+            };
+        }
+
+        export async function setDoc() {
+            return null;
+        }
+    `;
+
+    const utilsModule = `
+        export function renderHeader(container) {
+            if (container) {
+                container.innerHTML = '<div data-test-id="mock-header"></div>';
+            }
+        }
+
+        export function renderFooter(container) {
+            if (container) {
+                container.innerHTML = '<div data-test-id="mock-footer"></div>';
+            }
+        }
+
+        export function getUrlParams() {
+            const raw = window.location.hash.startsWith('#') ? window.location.hash.slice(1) : window.location.search.slice(1);
+            return Object.fromEntries(new URLSearchParams(raw));
+        }
+
+        export function escapeHtml(value) {
+            return String(value || '')
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
+
+        export function formatDate(value) {
+            return String(value || '');
+        }
+
+        export function formatShortDate(value) {
+            return String(value || '');
+        }
+
+        export async function shareOrCopy() {
+            return { status: 'copied' };
+        }
+    `;
+
+    const authModule = `
+        export function checkAuth(callback) {
+            callback({ uid: 'coach-1', email: 'coach@example.com' });
+        }
+    `;
+
+    const bannerModule = `
+        export function renderTeamAdminBanner(container) {
+            if (container) {
+                container.innerHTML = '';
+            }
+        }
+
+        export function getTeamAccessInfo() {
+            return {
+                hasAccess: false,
+                accessLevel: 'none',
+                exitUrl: 'team.html'
+            };
+        }
+    `;
+
+    const firebaseImagesModule = `
+        export async function ensureImageAuth() {
+            return { uid: 'image-user' };
+        }
+
+        export function getImageAuthError() {
+            return null;
+        }
+    `;
+
+    const firebaseAppModule = `
+        export function getApp() {
+            return {};
+        }
+    `;
+
+    const firebaseAiModule = `
+        const STORE_KEY = ${JSON.stringify(STORE_KEY)};
+
+        function loadStore() {
+            return JSON.parse(localStorage.getItem(STORE_KEY) || '{}');
+        }
+
+        export class GoogleAIBackend {}
+
+        export const Schema = {
+            object(value) { return value; },
+            array(value) { return value; },
+            string() { return {}; },
+            number() { return {}; }
+        };
+
+        export function getAI() {
+            return {};
+        }
+
+        export function getGenerativeModel() {
+            return {
+                async generateContent() {
+                    const store = loadStore();
+                    return {
+                        response: {
+                            text() {
+                                return JSON.stringify(store.aiResponse || {});
+                            }
+                        }
+                    };
+                }
+            };
+        }
+    `;
+
+    const insightsModule = `
+        export async function generateGameInsights() {
+            return { teamTakeaways: [], playerSignals: [] };
+        }
+    `;
+
+    const liveGameStateModule = `
+        export function resolveLiveStatConfig({ configs = [], game = {} } = {}) {
+            return configs.find((config) => config.id === game.statTrackerConfigId) || configs[0] || null;
+        }
+    `;
+
+    await page.route(/\/js\/db\.js\?v=\d+$/, async (route) => {
+        await route.fulfill({ status: 200, contentType: 'application/javascript', body: dbModule });
+    });
+
+    await page.route(/\/js\/firebase\.js\?v=\d+$/, async (route) => {
+        await route.fulfill({ status: 200, contentType: 'application/javascript', body: firebaseModule });
+    });
+
+    await page.route(/\/js\/utils\.js\?v=\d+$/, async (route) => {
+        await route.fulfill({ status: 200, contentType: 'application/javascript', body: utilsModule });
+    });
+
+    await page.route(/\/js\/auth\.js\?v=\d+$/, async (route) => {
+        await route.fulfill({ status: 200, contentType: 'application/javascript', body: authModule });
+    });
+
+    await page.route(/\/js\/team-admin-banner\.js$/, async (route) => {
+        await route.fulfill({ status: 200, contentType: 'application/javascript', body: bannerModule });
+    });
+
+    await page.route(/\/js\/firebase-images\.js\?v=\d+$/, async (route) => {
+        await route.fulfill({ status: 200, contentType: 'application/javascript', body: firebaseImagesModule });
+    });
+
+    await page.route(/\/js\/vendor\/firebase-app\.js$/, async (route) => {
+        await route.fulfill({ status: 200, contentType: 'application/javascript', body: firebaseAppModule });
+    });
+
+    await page.route(/\/js\/vendor\/firebase-ai\.js$/, async (route) => {
+        await route.fulfill({ status: 200, contentType: 'application/javascript', body: firebaseAiModule });
+    });
+
+    await page.route(/\/js\/post-game-insights\.js\?v=\d+$/, async (route) => {
+        await route.fulfill({ status: 200, contentType: 'application/javascript', body: insightsModule });
+    });
+
+    await page.route(/\/js\/live-game-state\.js\?v=\d+$/, async (route) => {
+        await route.fulfill({ status: 200, contentType: 'application/javascript', body: liveGameStateModule });
+    });
+}
+
+async function seedScenario(page, scenario) {
+    await page.goto('about:blank');
+    await page.evaluate(({ storeKey, value }) => {
+        localStorage.setItem(storeKey, JSON.stringify(value));
+    }, { storeKey: STORE_KEY, value: scenario });
+}
+
+async function analyzeStatsheet(page, baseURL) {
+    await page.goto(buildUrl(baseURL, '/track-statsheet.html#teamId=team-1&gameId=game-1'), {
+        waitUntil: 'domcontentloaded'
+    });
+
+    await page.locator('#stat-sheet-input').setInputFiles({
+        name: 'statsheet.png',
+        mimeType: 'image/png',
+        buffer: Buffer.from('fake-image')
+    });
+    await page.locator('#analyze-btn').click();
+    await page.locator('#home-rows tr').nth(1).waitFor();
+}
+
+test.beforeEach(async ({ page }) => {
+    await installModuleMocks(page);
+});
+
+test('blocks apply until every included home row is mapped, then saves report data', async ({ page, baseURL }) => {
+    await seedScenario(page, createScenario());
+    await analyzeStatsheet(page, baseURL);
+
+    await page.locator('#apply-btn').click();
+
+    const blockedState = await page.evaluate((storeKey) => JSON.parse(localStorage.getItem(storeKey) || '{}'), STORE_KEY);
+    expect(blockedState.alerts).toContain('Please map every included home row to a roster player or uncheck it.');
+    expect(blockedState.commitCalls).toBe(0);
+
+    await page.locator('#home-rows tr').nth(1).locator('select[data-field="mappedPlayerId"]').selectOption('p2');
+    await page.locator('#apply-btn').click();
+
+    await expect(page.locator('#apply-status')).toHaveText('Stats saved! Now you can add a game summary.');
+    await expect(page.locator('#summary-section')).not.toHaveClass(/hidden/);
+
+    const savedState = await page.evaluate((storeKey) => JSON.parse(localStorage.getItem(storeKey) || '{}'), STORE_KEY);
+    expect(savedState.commitCalls).toBe(1);
+    expect(savedState.aggregatedStats).toEqual({
+        p1: {
+            playerName: 'Ava Cole',
+            playerNumber: '3',
+            stats: { pts: 12, reb: 0, ast: 0, fouls: 2 }
+        },
+        p2: {
+            playerName: 'Mia Diaz',
+            playerNumber: '5',
+            stats: { pts: 7, reb: 0, ast: 0, fouls: 1 }
+        }
+    });
+    expect(savedState.game.homeScore).toBe(19);
+    expect(savedState.game.awayScore).toBe(24);
+    expect(savedState.game.status).toBe('completed');
+    expect(savedState.game.opponentStats).toEqual({
+        statsheet_1: { name: 'River Stone', number: '10', pts: 15, reb: 0, ast: 0, fouls: 4 },
+        statsheet_2: { name: 'Kai North', number: '11', pts: 9, reb: 0, ast: 0, fouls: 2 }
+    });
+});
+
+test('respects overwrite confirmation and renders rewritten stats on the game report', async ({ page, baseURL }) => {
+    await seedScenario(page, createScenario({
+        aggregatedStats: {
+            legacyPlayer: {
+                playerName: 'Old Player',
+                playerNumber: '99',
+                stats: { pts: 99, reb: 1, ast: 1, fouls: 5 }
+            }
+        },
+        events: {
+            oldEvent: { type: 'score', timestamp: 1 }
+        },
+        confirmResponses: [false, true]
+    }));
+
+    await analyzeStatsheet(page, baseURL);
+    await page.locator('#home-rows tr').nth(1).locator('select[data-field="mappedPlayerId"]').selectOption('p2');
+
+    await page.locator('#apply-btn').click();
+
+    let store = await page.evaluate((storeKey) => JSON.parse(localStorage.getItem(storeKey) || '{}'), STORE_KEY);
+    expect(store.confirmMessages).toEqual([
+        'This game already has tracked data. Replace it with the stat sheet results?'
+    ]);
+    expect(store.confirmResults).toEqual([false]);
+    expect(store.deleteCalls).toEqual([]);
+    expect(store.commitCalls).toBe(0);
+    expect(store.aggregatedStats.legacyPlayer.stats.pts).toBe(99);
+    await expect(page.locator('#apply-status')).toHaveText('Cancelled.');
+
+    await page.locator('#apply-btn').click();
+    await expect(page.locator('#apply-status')).toHaveText('Stats saved! Now you can add a game summary.');
+
+    store = await page.evaluate((storeKey) => JSON.parse(localStorage.getItem(storeKey) || '{}'), STORE_KEY);
+    expect(store.confirmResults).toEqual([false, true]);
+    expect(store.deleteCalls).toEqual([
+        'teams/team-1/games/game-1/events/oldEvent',
+        'teams/team-1/games/game-1/aggregatedStats/legacyPlayer'
+    ]);
+    expect(store.commitCalls).toBe(1);
+    expect(Object.keys(store.aggregatedStats)).toEqual(['p1', 'p2']);
+
+    await Promise.all([
+        page.waitForURL(/\/game\.html#/),
+        page.locator('#skip-summary-btn').click()
+    ]);
+
+    await page.locator('#stats-body tr').first().waitFor();
+    await expect(page.locator('#game-header')).toContainText('Comets');
+    await expect(page.locator('#game-header')).toContainText('Rockets');
+    await expect(page.locator('#stats-body')).toContainText('Ava Cole');
+    await expect(page.locator('#stats-body')).toContainText('Mia Diaz');
+    await expect(page.locator('#stats-body')).toContainText('12');
+    await expect(page.locator('#stats-body')).toContainText('7');
+    await expect(page.locator('#opponent-stats-body')).toContainText('River Stone');
+    await expect(page.locator('#opponent-stats-body')).toContainText('Kai North');
+    await expect(page.locator('#opponent-stats-body')).toContainText('15');
+    await expect(page.locator('#opponent-stats-body')).toContainText('9');
+});

--- a/tests/unit/track-statsheet-apply.test.js
+++ b/tests/unit/track-statsheet-apply.test.js
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    buildTrackStatsheetApplyPlan,
+    getTrackStatsheetPointsKey,
+    validateTrackStatsheetApplyRows
+} from '../../js/track-statsheet-apply.js';
+
+describe('track statsheet apply helpers', () => {
+    it('blocks apply when included home rows are still unmatched', () => {
+        expect(validateTrackStatsheetApplyRows([
+            { include: true, mappedPlayerId: 'p1' },
+            { include: true, mappedPlayerId: '' }
+        ])).toEqual({
+            ok: false,
+            alertMessage: 'Please map every included home row to a roster player or uncheck it.'
+        });
+    });
+
+    it('blocks apply when the same roster player is selected twice', () => {
+        expect(validateTrackStatsheetApplyRows([
+            { include: true, mappedPlayerId: 'p1' },
+            { include: true, mappedPlayerId: 'p1' }
+        ])).toEqual({
+            ok: false,
+            alertMessage: 'A roster player is selected more than once. Please fix duplicates.'
+        });
+    });
+
+    it('builds aggregated stat writes and game payloads that game.html can consume', () => {
+        expect(getTrackStatsheetPointsKey(['GOALS', 'SHOTS'])).toBe('goals');
+
+        expect(buildTrackStatsheetApplyPlan({
+            includedHome: [
+                { mappedPlayerId: 'p1', totalPoints: 4, fouls: 2 }
+            ],
+            includedVisitor: [
+                { name: 'Opp One', number: '10', totalPoints: 3, fouls: 1 }
+            ],
+            roster: [
+                { id: 'p1', name: 'Ava Cole', number: '3' }
+            ],
+            columns: ['GOALS', 'SHOTS'],
+            homeScore: 4,
+            awayScore: 3,
+            statSheetPhotoUrl: 'https://img.test/statsheet.png'
+        })).toEqual({
+            aggregatedStatsWrites: [
+                {
+                    playerId: 'p1',
+                    data: {
+                        playerName: 'Ava Cole',
+                        playerNumber: '3',
+                        stats: {
+                            goals: 4,
+                            shots: 0,
+                            fouls: 2
+                        }
+                    }
+                }
+            ],
+            gameUpdate: {
+                homeScore: 4,
+                awayScore: 3,
+                opponentStats: {
+                    statsheet_1: {
+                        name: 'Opp One',
+                        number: '10',
+                        goals: 3,
+                        shots: 0,
+                        fouls: 1
+                    }
+                },
+                status: 'completed',
+                statSheetPhotoUrl: 'https://img.test/statsheet.png'
+            }
+        });
+    });
+});

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -207,6 +207,7 @@
     import { checkAuth } from './js/auth.js?v=10';
     import { renderTeamAdminBanner } from './js/team-admin-banner.js';
     import { ensureImageAuth, getImageAuthError } from './js/firebase-images.js?v=3';
+    import { validateTrackStatsheetApplyRows, buildTrackStatsheetApplyPlan } from './js/track-statsheet-apply.js?v=1';
     import { getApp } from './js/vendor/firebase-app.js';
     import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
 
@@ -726,27 +727,11 @@ RETURN JSON:
       const applyBtn = document.getElementById('apply-btn');
       applyStatus.textContent = '';
 
-      const includedHome = homeRows.filter(r => r.include);
       const includedVisitor = visitorRows.filter(r => r.include);
-
-      if (!includedHome.length) {
-        alert('Please include at least one home player.');
+      const validation = validateTrackStatsheetApplyRows(homeRows);
+      if (!validation.ok) {
+        alert(validation.alertMessage);
         return;
-      }
-
-      const unmatched = includedHome.filter(r => !r.mappedPlayerId);
-      if (unmatched.length) {
-        alert('Please map every included home row to a roster player or uncheck it.');
-        return;
-      }
-
-      const duplicateCheck = new Set();
-      for (const row of includedHome) {
-        if (duplicateCheck.has(row.mappedPlayerId)) {
-          alert('A roster player is selected more than once. Please fix duplicates.');
-          return;
-        }
-        duplicateCheck.add(row.mappedPlayerId);
       }
 
       try {
@@ -765,8 +750,6 @@ RETURN JSON:
 
         const homeScore = Number(document.getElementById('home-score-input').value || 0);
         const visitorScore = Number(document.getElementById('visitor-score-input').value || 0);
-        const pointsKey = getPointsKey();
-        const configColumns = (currentConfig?.columns || []).map(col => col.toLowerCase());
 
         applyStatus.textContent = 'Checking existing game data…';
         const eventsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
@@ -782,48 +765,24 @@ RETURN JSON:
           await Promise.all(statsSnap.docs.map(docItem => deleteDoc(docItem.ref)));
         }
 
-        const batch = writeBatch(db);
-        includedHome.forEach(row => {
-          const player = roster.find(p => p.id === row.mappedPlayerId);
-          if (!player) return;
-          const statsObj = {};
-          configColumns.forEach(col => {
-            statsObj[col] = 0;
-          });
-          statsObj[pointsKey] = row.totalPoints || 0;
-          statsObj.fouls = row.fouls || 0;
-          const statsRef = doc(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`, player.id);
-          batch.set(statsRef, {
-            playerName: player.name,
-            playerNumber: player.number,
-            stats: statsObj
-          });
+        const applyPlan = buildTrackStatsheetApplyPlan({
+          includedHome: validation.includedHome,
+          includedVisitor,
+          roster,
+          columns: currentConfig?.columns || [],
+          homeScore,
+          awayScore: visitorScore,
+          statSheetPhotoUrl: statSheetUrl
         });
 
-        const opponentStats = {};
-        includedVisitor.forEach((row, index) => {
-          const oppId = `statsheet_${index + 1}`;
-          opponentStats[oppId] = {
-            name: row.name || '',
-            number: row.number || '',
-            fouls: row.fouls || 0
-          };
-          opponentStats[oppId][pointsKey] = row.totalPoints || 0;
-          configColumns.forEach(col => {
-            if (opponentStats[oppId][col] === undefined) {
-              opponentStats[oppId][col] = 0;
-            }
-          });
+        const batch = writeBatch(db);
+        applyPlan.aggregatedStatsWrites.forEach(({ playerId, data }) => {
+          const statsRef = doc(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`, playerId);
+          batch.set(statsRef, data);
         });
 
         const gameRef = doc(db, `teams/${currentTeamId}/games`, currentGameId);
-        batch.update(gameRef, {
-          homeScore,
-          awayScore: visitorScore,
-          opponentStats,
-          status: 'completed',
-          statSheetPhotoUrl: statSheetUrl || null
-        });
+        batch.update(gameRef, applyPlan.gameUpdate);
 
         applyStatus.textContent = 'Saving stats…';
         const commitPromise = batch.commit();
@@ -831,6 +790,10 @@ RETURN JSON:
           setTimeout(() => reject(new Error('Save timed out. Please try again.')), 30000);
         });
         await Promise.race([commitPromise, commitTimeout]);
+        currentGame = {
+          ...currentGame,
+          ...applyPlan.gameUpdate
+        };
         applyStatus.textContent = 'Stats saved! Now you can add a game summary.';
 
         // Show summary section instead of redirecting


### PR DESCRIPTION
Closes #470

## What changed
- extracted the `track-statsheet` apply/save validation and payload-building logic into `js/track-statsheet-apply.js` so the save path has one reviewable source of truth
- rewired `track-statsheet.html` to use that helper for unmapped-row guards, duplicate-player guards, aggregated stat writes, and persisted game report payloads
- added `tests/smoke/track-statsheet-apply.spec.js` to cover the real browser flow for blocked saves, overwrite cancel/confirm behavior, persisted stats writes, and `game.html` rendering
- added `tests/unit/track-statsheet-apply.test.js` to lock the extracted save-plan shapes and guard behavior
- stored the required role synthesis notes under `docs/pr-notes/runs/issue-470-fixer-20260403T052951Z/`

## Why
This closes the highest-risk gap in the statsheet workflow: coaches can review a parsed sheet, click apply, and rely on the saved game report. The new coverage now checks the guardrails before save, the overwrite confirmation branches, and the exact persisted data shape consumed by the post-game report.

## Validation
- `node_modules/.bin/vitest run tests/unit` ✅
- `node_modules/.bin/playwright test tests/smoke/track-statsheet-apply.spec.js --config=playwright.smoke.config.js --list` ✅
- Full Playwright browser execution is prepared but was blocked in this host by missing system browser libraries required by Playwright launch.