### PR TITLE
Block deleting stat configs still used by games

### DIFF
--- a/docs/pr-notes/runs/482-ci-fix-20260403T061503Z/architecture.md
+++ b/docs/pr-notes/runs/482-ci-fix-20260403T061503Z/architecture.md
@@ -1,0 +1,6 @@
+# Architecture Role Notes
+
+- Skills requested by repo guidance were not available in this session, so analysis was done inline.
+- Current state: PR adds a shared-game reference check inside `deleteConfig(teamId, configId)`.
+- Proposed state: keep that runtime guard and align tests plus cache-bust wiring with the new `db.js` diff.
+- Blast radius: limited to the edit-config deletion path, its unit assertion, and the matching smoke stub import version.

--- a/docs/pr-notes/runs/482-ci-fix-20260403T061503Z/code-plan.md
+++ b/docs/pr-notes/runs/482-ci-fix-20260403T061503Z/code-plan.md
@@ -1,0 +1,7 @@
+# Code Role Notes
+
+1. Keep the shared-game delete protection in `js/db.js` unchanged.
+2. Update `tests/unit/edit-config-delete-guard.test.js` to assert the new combined guard condition.
+3. Bump `edit-config.html` to `./js/db.js?v=16` so the cache-bust guard sees a matching import update.
+4. Update the related smoke test route stub to `v=16`.
+5. Run targeted validation, then stage and commit only the scoped CI-fix files.

--- a/docs/pr-notes/runs/482-ci-fix-20260403T061503Z/qa.md
+++ b/docs/pr-notes/runs/482-ci-fix-20260403T061503Z/qa.md
@@ -1,0 +1,5 @@
+# QA Role Notes
+
+- Root cause: `tests/unit/edit-config-delete-guard.test.js` asserted an exact source string that no longer matched after the shared-game guard was added.
+- Cache-bust risk: `js/db.js` changed in the PR diff without a matching `db.js?v=` bump in changed imports, which trips `scripts/check-critical-cache-bust.mjs`.
+- Validation target: run the focused unit test file and the cache-bust guard script; confirm the smoke stub matches the new `edit-config.html` import.

--- a/docs/pr-notes/runs/482-remediator-20260403T060801Z/architecture.md
+++ b/docs/pr-notes/runs/482-remediator-20260403T060801Z/architecture.md
@@ -1,0 +1,6 @@
+# Architecture Role Notes
+
+- Current state: `deleteConfig(teamId, configId)` queries only `teams/{teamId}/games`.
+- Proposed state: retain the team-games query and add a shared-games existence check using the same participation selectors as `getSharedGamesForTeam`.
+- Blast radius: limited to config deletion validation in `js/db.js`; no data model or UI changes.
+- Control goal: prevent deleting a config while any shared schedule or tournament game still points at that config.

--- a/docs/pr-notes/runs/482-remediator-20260403T060801Z/code-plan.md
+++ b/docs/pr-notes/runs/482-remediator-20260403T060801Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code Role Notes
+
+1. Add a helper in `js/db.js` to detect shared games for a team that reference a given `statTrackerConfigId`.
+2. Update `deleteConfig(teamId, configId)` to block deletion when either team games or shared games still reference the config.
+3. Run a lightweight validation pass for syntax and inspect the diff for scope.
+4. Stage the scoped remediation plus required run notes and commit with a short imperative message.

--- a/docs/pr-notes/runs/482-remediator-20260403T060801Z/qa.md
+++ b/docs/pr-notes/runs/482-remediator-20260403T060801Z/qa.md
@@ -1,0 +1,6 @@
+# QA Role Notes
+
+- Manual validation target: attempt config deletion with one local game referencing the config and with one shared game referencing the config.
+- Expected result: both cases throw the existing "still assigned" error and do not delete the config.
+- Regression check: deleting an unused config should still succeed.
+- Repo guidance indicates no automated test runner; validation will rely on targeted code inspection plus any lightweight manual/static checks available.

--- a/docs/pr-notes/runs/482-remediator-20260403T060801Z/requirements.md
+++ b/docs/pr-notes/runs/482-remediator-20260403T060801Z/requirements.md
@@ -1,0 +1,6 @@
+# Requirements Role Notes
+
+- Scope: address PR #482 review thread `PRRT_kwDOQe-T5854qRhi` only.
+- Requirement: block stat tracker config deletion when any team-owned game or participating shared-game document still references the config.
+- Evidence: `getGames(teamId)` already merges `teams/{teamId}/games` with `collectionGroup(db, 'sharedGames')` results for the same team, so the delete guard must cover both sources to avoid dangling `statTrackerConfigId` references.
+- Assumption: only shared games involving the team being edited should block deletion for that team's config.

--- a/docs/pr-notes/runs/issue-462-fixer-20260403T054013Z/architecture.md
+++ b/docs/pr-notes/runs/issue-462-fixer-20260403T054013Z/architecture.md
@@ -1,0 +1,17 @@
+# Architecture Role (allplays-architecture-expert)
+
+## Root Cause
+`edit-config.html` delegates delete directly to `deleteConfig`, and `js/db.js` deletes the config document without checking for dependent `games/{gameId}.statTrackerConfigId` references.
+
+## Minimal Safe Fix
+- Enforce the guard in `js/db.js` before `deleteDoc` by querying the current team's games for `statTrackerConfigId == configId` with `limit(1)`.
+- Throw a user-safe error when a reference exists.
+- Catch that error in `edit-config.html` and surface it via `alert(...)`.
+
+## Blast Radius
+- Data-layer change is limited to stat config deletion.
+- UI change is limited to the delete button flow on `edit-config.html`.
+
+## Controls
+- Team-scoped query preserves tenant isolation.
+- Guard at the shared DB helper prevents future callers from bypassing the protection accidentally.

--- a/docs/pr-notes/runs/issue-462-fixer-20260403T054013Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-462-fixer-20260403T054013Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Role (allplays-code-expert)
+
+## Plan
+1. Add `tests/unit/edit-config-delete-guard.test.js` to pin the new data-layer guard and UI error handling.
+2. Update `js/db.js` so `deleteConfig(teamId, configId)` refuses deletion when any team game still references that config.
+3. Update `edit-config.html` to catch delete failures, alert the admin, and keep the config list intact.
+4. Run focused vitest coverage for the new test and nearby edit-config tests, then commit with the issue reference.
+
+## Non-Goals
+- No migration of existing games.
+- No tracker fallback refactor.

--- a/docs/pr-notes/runs/issue-462-fixer-20260403T054013Z/qa.md
+++ b/docs/pr-notes/runs/issue-462-fixer-20260403T054013Z/qa.md
@@ -1,0 +1,14 @@
+# QA Role (allplays-qa-expert)
+
+## Test Strategy
+1. Add a unit regression test that inspects `js/db.js` for a team-scoped referenced-game guard before config deletion.
+2. Add a unit regression test that inspects `edit-config.html` for delete-flow error handling and user messaging.
+3. Run the focused vitest file first, then run the broader edit-config related unit tests.
+
+## Regression Guardrails
+- Keep assertions tied to the delete path only.
+- Verify the UI still reloads configs after a successful delete.
+
+## Manual Smoke (optional)
+- In `edit-config.html`, try deleting a config that is assigned to a game and confirm the config remains visible with a clear alert.
+- Delete an unused config and confirm it disappears normally.

--- a/docs/pr-notes/runs/issue-462-fixer-20260403T054013Z/requirements.md
+++ b/docs/pr-notes/runs/issue-462-fixer-20260403T054013Z/requirements.md
@@ -1,0 +1,21 @@
+# Requirements Role (allplays-requirements-expert)
+
+## Objective
+Prevent admins from deleting a stat config that scheduled or live games still reference.
+
+## Current vs Proposed
+- Current: Edit Config deletes the stat config immediately and existing games keep a dangling `statTrackerConfigId`.
+- Proposed: Deletion is blocked when any team game still references the config, and the admin gets a clear message explaining why.
+
+## User Impact
+- Coaches should not be able to break live or upcoming stat tracking from the config screen.
+- Existing games must keep a resolvable stat set so game-day tracking remains accurate.
+
+## Acceptance Criteria
+1. Attempting to delete a config referenced by at least one game does not remove the config.
+2. The delete flow shows a clear error message that the config is still assigned to games.
+3. Unreferenced configs can still be deleted normally.
+
+## Risks
+- Firestore query must stay scoped to the current team to avoid cross-tenant leakage.
+- UI must surface the blocked-delete state instead of failing silently.

--- a/edit-config.html
+++ b/edit-config.html
@@ -212,8 +212,13 @@
             document.querySelectorAll('.delete-btn').forEach(btn => {
                 btn.addEventListener('click', async (e) => {
                     if (confirm('Are you sure you want to delete this config?')) {
-                        await deleteConfig(currentTeamId, e.target.dataset.id);
-                        loadConfigs();
+                        try {
+                            await deleteConfig(currentTeamId, e.target.dataset.id);
+                            loadConfigs();
+                        } catch (error) {
+                            console.error(error);
+                            alert(error?.message || 'Error deleting config.');
+                        }
                     }
                 });
             });

--- a/edit-config.html
+++ b/edit-config.html
@@ -110,7 +110,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getConfigs, createConfig, deleteConfig, getUnreadChatCount } from './js/db.js?v=15';
+        import { getTeam, getConfigs, createConfig, deleteConfig, getUnreadChatCount } from './js/db.js?v=16';
         import { parseAdvancedStatDefinitions } from './js/stat-leaderboards.js?v=1';
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=10';

--- a/js/db.js
+++ b/js/db.js
@@ -136,6 +136,18 @@ async function getSharedGamesForTeam(teamId) {
     return Array.from(sharedGamesByPath.values());
 }
 
+async function hasSharedGameUsingConfig(teamId, configId) {
+    const sharedGamesRef = collectionGroup(db, 'sharedGames');
+    const queries = [
+        query(sharedGamesRef, where('homeTeamId', '==', teamId), where('statTrackerConfigId', '==', configId), limit(1)),
+        query(sharedGamesRef, where('awayTeamId', '==', teamId), where('statTrackerConfigId', '==', configId), limit(1)),
+        query(sharedGamesRef, where('teamIds', 'array-contains', teamId), where('statTrackerConfigId', '==', configId), limit(1))
+    ];
+
+    const snapshots = await Promise.allSettled(queries.map((q) => getDocs(q)));
+    return snapshots.some((result) => result.status === 'fulfilled' && !result.value.empty);
+}
+
 export async function uploadTeamPhoto(file) {
     console.log('Starting photo upload...', {
         fileName: file.name,
@@ -1350,7 +1362,7 @@ export async function deleteConfig(teamId, configId) {
         where("statTrackerConfigId", "==", configId),
         limit(1)
     ));
-    if (!referencingGames.empty) {
+    if (!referencingGames.empty || await hasSharedGameUsingConfig(teamId, configId)) {
         throw new Error('This config is still assigned to one or more games. Remove it from those games before deleting the config.');
     }
     await deleteDoc(doc(db, `teams/${teamId}/statTrackerConfigs`, configId));

--- a/js/db.js
+++ b/js/db.js
@@ -1345,6 +1345,14 @@ export async function addConfig(teamId, configData) {
 }
 
 export async function deleteConfig(teamId, configId) {
+    const referencingGames = await getDocs(query(
+        collection(db, `teams/${teamId}/games`),
+        where("statTrackerConfigId", "==", configId),
+        limit(1)
+    ));
+    if (!referencingGames.empty) {
+        throw new Error('This config is still assigned to one or more games. Remove it from those games before deleting the config.');
+    }
     await deleteDoc(doc(db, `teams/${teamId}/statTrackerConfigs`, configId));
 }
 

--- a/tests/smoke/edit-config-platform-admin.spec.js
+++ b/tests/smoke/edit-config-platform-admin.spec.js
@@ -118,7 +118,7 @@ async function mockDependencies(page) {
         contentType: 'application/javascript',
         body: ''
     }));
-    await page.route('**/js/db.js?v=15', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: DB_STUB }));
+    await page.route('**/js/db.js?v=16', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: DB_STUB }));
     await page.route('**/js/utils.js?v=8', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: UTILS_STUB }));
     await page.route('**/js/auth.js?v=10', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
     await page.route('**/js/edit-config-access.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: EDIT_CONFIG_ACCESS_STUB }));

--- a/tests/unit/edit-config-delete-guard.test.js
+++ b/tests/unit/edit-config-delete-guard.test.js
@@ -22,7 +22,7 @@ describe('edit config delete guard', () => {
         expect(block).toContain('collection(db, `teams/${teamId}/games`)');
         expect(block).toContain('where("statTrackerConfigId", "==", configId)');
         expect(block).toContain('limit(1)');
-        expect(block).toContain('if (!referencingGames.empty)');
+        expect(block).toContain('if (!referencingGames.empty || await hasSharedGameUsingConfig(teamId, configId)) {');
         expect(block).toContain("throw new Error('This config is still assigned to one or more games. Remove it from those games before deleting the config.')");
         expect(block).toContain('await deleteDoc(doc(db, `teams/${teamId}/statTrackerConfigs`, configId));');
     });

--- a/tests/unit/edit-config-delete-guard.test.js
+++ b/tests/unit/edit-config-delete-guard.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readDbSource() {
+    return readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+}
+
+function readEditConfigSource() {
+    return readFileSync(new URL('../../edit-config.html', import.meta.url), 'utf8');
+}
+
+describe('edit config delete guard', () => {
+    it('blocks deleting configs that existing team games still reference', () => {
+        const source = readDbSource();
+
+        const start = source.indexOf('export async function deleteConfig(teamId, configId) {');
+        const end = source.indexOf('// Stats', start);
+        expect(start).toBeGreaterThanOrEqual(0);
+        expect(end).toBeGreaterThan(start);
+
+        const block = source.slice(start, end);
+        expect(block).toContain('collection(db, `teams/${teamId}/games`)');
+        expect(block).toContain('where("statTrackerConfigId", "==", configId)');
+        expect(block).toContain('limit(1)');
+        expect(block).toContain('if (!referencingGames.empty)');
+        expect(block).toContain("throw new Error('This config is still assigned to one or more games. Remove it from those games before deleting the config.')");
+        expect(block).toContain('await deleteDoc(doc(db, `teams/${teamId}/statTrackerConfigs`, configId));');
+    });
+
+    it('surfaces a clear alert when deletion is blocked', () => {
+        const source = readEditConfigSource();
+
+        const start = source.indexOf("btn.addEventListener('click', async (e) => {");
+        const end = source.indexOf('        });', start) + '        });'.length;
+        expect(start).toBeGreaterThanOrEqual(0);
+        expect(end).toBeGreaterThan(start);
+
+        const block = source.slice(start, end);
+        expect(block).toContain('try {');
+        expect(block).toContain('await deleteConfig(currentTeamId, e.target.dataset.id);');
+        expect(block).toContain('loadConfigs();');
+        expect(block).toContain('} catch (error) {');
+        expect(block).toContain("alert(error?.message || 'Error deleting config.');");
+    });
+});


### PR DESCRIPTION
Closes #462

## What changed
- blocked `deleteConfig(teamId, configId)` from deleting a stat config when any game in the same team still references that `statTrackerConfigId`
- surfaced the blocking error in `edit-config.html` so admins get a clear alert instead of a silent breakage
- added a regression test covering both the data-layer guard and the edit-config delete flow wiring

## Why
Deleting a referenced stat config left existing games with dangling config ids, which caused tracker and game-day pages to fall back to unrelated default stat columns. This patch stops the delete at the source and makes the failure explicit to the admin.

## Validation
- ran `./node_modules/.bin/vitest run tests/unit/edit-config-delete-guard.test.js tests/unit/edit-config-access.test.js tests/unit/edit-schedule-stat-config-selection.test.js`
- ran `./node_modules/.bin/vitest run tests/unit`