### PR TITLE
Fix footer support contact workflow

### DIFF
--- a/docs/pr-notes/runs/issue-459-fixer-20260403T062503Z/architecture.md
+++ b/docs/pr-notes/runs/issue-459-fixer-20260403T062503Z/architecture.md
@@ -1,0 +1,18 @@
+Objective: remove ambiguity in the support footer contract with the smallest possible production change.
+
+Current state:
+- Footer support links are duplicated between `index.html` and `js/utils.js`.
+- Shared footer already avoids the `#` dead end, but the contact path is an external profile site rather than a direct support flow.
+
+Proposed state:
+- Both footer implementations expose the same concrete support destinations:
+  - `Help Center` -> `help.html`
+  - `Contact` -> `mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Support`
+
+Blast radius:
+- Public landing page footer.
+- Any page using `renderFooter()`.
+
+Controls:
+- No data handling changes.
+- Regression tests pin both href values so future drift fails fast.

--- a/docs/pr-notes/runs/issue-459-fixer-20260403T062503Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-459-fixer-20260403T062503Z/code-plan.md
@@ -1,0 +1,9 @@
+Thinking level: low
+Reason: small, localized footer wiring change with existing tests nearby.
+
+Implementation plan:
+1. Update unit and smoke expectations so `Contact` must be a direct support `mailto:` workflow.
+2. Run targeted tests to confirm the new expectation fails against current code.
+3. Patch `index.html` and `js/utils.js` footer contact links.
+4. Re-run targeted tests.
+5. Commit the docs, tests, and production change together.

--- a/docs/pr-notes/runs/issue-459-fixer-20260403T062503Z/qa.md
+++ b/docs/pr-notes/runs/issue-459-fixer-20260403T062503Z/qa.md
@@ -1,0 +1,12 @@
+Test focus:
+- Footer support links must never regress to `#`, empty hrefs, or unrelated destinations.
+- Public homepage and shared-footer pages must expose the same help workflow contract.
+
+Fail conditions:
+- `Help Center` is not `help.html`.
+- `Contact` is not a direct `mailto:` support destination.
+- Clicking `Help Center` fails to load the help center page.
+
+Validation plan:
+- Run targeted Vitest coverage for footer/help navigation.
+- Keep the existing smoke spec aligned with the production hrefs.

--- a/docs/pr-notes/runs/issue-459-fixer-20260403T062503Z/requirements.md
+++ b/docs/pr-notes/runs/issue-459-fixer-20260403T062503Z/requirements.md
@@ -1,0 +1,20 @@
+Objective: close the help dead end by ensuring the footer exposes a direct support workflow on public and authenticated pages.
+
+Current state:
+- `Help Center` resolves to `help.html`.
+- `Contact` resolves to `https://paulsnider.net`, which is live but indirect as a support path.
+
+Proposed state:
+- `Contact` resolves to a direct `mailto:` support workflow from both the shared footer and the homepage footer.
+
+Risk surface and blast radius:
+- Touches only footer support links on pages that render the shared footer and the homepage.
+- No auth, data, or tenant isolation behavior changes.
+
+Assumptions:
+- `paul@paulsnider.net` is the intended support inbox.
+- A direct email compose flow is acceptable for the reported workflow.
+
+Recommendation:
+- Keep `Help Center` on `help.html`.
+- Change `Contact` to a direct `mailto:` destination and add regression coverage for both footer implementations.

--- a/index.html
+++ b/index.html
@@ -636,8 +636,7 @@
           <h4 class="text-white font-semibold mb-4">Support</h4>
           <ul class="space-y-2 text-sm">
             <li><a href="help.html" class="hover:text-white transition">Help Center</a></li>
-            <li><a href="https://paulsnider.net" class="hover:text-white transition"
-                target="_blank" rel="noopener noreferrer">Contact</a></li>
+            <li><a href="mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Support" class="hover:text-white transition">Contact</a></li>
           </ul>
         </div>
       </div>

--- a/js/utils.js
+++ b/js/utils.js
@@ -237,7 +237,7 @@ export function renderFooter(container) {
               <h4 class="text-white font-semibold mb-4">Support</h4>
               <ul class="space-y-2 text-sm">
                 <li><a href="help.html" class="hover:text-white transition">Help Center</a></li>
-                <li><a href="https://paulsnider.net" class="hover:text-white transition" target="_blank" rel="noopener noreferrer">Contact</a></li>
+                <li><a href="mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Support" class="hover:text-white transition">Contact</a></li>
               </ul>
             </div>
           </div>

--- a/tests/smoke/footer-support-links.spec.js
+++ b/tests/smoke/footer-support-links.spec.js
@@ -40,7 +40,7 @@ test('homepage footer support links navigate to live support destinations', asyn
     const { helpLink, helpHref, contactHref } = await getFooterSupportLinks(page);
 
     expectLiveSupportHref(helpHref, 'help.html');
-    expectLiveSupportHref(contactHref, 'https://paulsnider.net');
+    expectLiveSupportHref(contactHref, 'mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Support');
 
     const navigationPromise = page.waitForNavigation({ url: '**/help.html' });
     await helpLink.click();
@@ -58,5 +58,5 @@ test('shared footer support links stay wired on login page', async ({ page, base
     const { helpHref, contactHref } = await getFooterSupportLinks(page);
 
     expectLiveSupportHref(helpHref, 'help.html');
-    expectLiveSupportHref(contactHref, 'https://paulsnider.net');
+    expectLiveSupportHref(contactHref, 'mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Support');
 });

--- a/tests/unit/help-navigation-wiring.test.js
+++ b/tests/unit/help-navigation-wiring.test.js
@@ -9,6 +9,13 @@ describe('help navigation wiring', () => {
     it('links footer help center to help page', () => {
         const utilsJs = readRepoFile('js/utils.js');
         expect(utilsJs).toContain('<li><a href="help.html" class="hover:text-white transition">Help Center</a></li>');
+        expect(utilsJs).toContain('mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Support');
+    });
+
+    it('keeps homepage footer support links aligned with the shared footer contract', () => {
+        const indexHtml = readRepoFile('index.html');
+        expect(indexHtml).toContain('<li><a href="help.html" class="hover:text-white transition">Help Center</a></li>');
+        expect(indexHtml).toContain('mailto:paul@paulsnider.net?subject=ALL%20PLAYS%20Support');
     });
 
     it('includes help destination in team navigation banner with role context', () => {


### PR DESCRIPTION
Closes #459

## What changed
- changed the shared footer and landing page footer `Contact` link to a direct support email workflow: `mailto:[REDACTED_EMAIL]?subject=ALL%20PLAYS%20Support`
- kept `Help Center` pointed at `help.html`
- tightened regression coverage so both the shared footer and homepage footer must expose live help/support destinations
- persisted the required run notes under `docs/pr-notes/runs/issue-459-fixer-20260403T062503Z/`

## Why
The reported bug was that the shipped help workflow could strand users at a dead end. This patch makes the support path explicit and direct across the app footer implementations, and it adds tests so future regressions fail fast.

## Validation
- passed: `./node_modules/.bin/vitest run tests/unit/help-navigation-wiring.test.js tests/unit/help-center.test.js`
- attempted: `./node_modules/.bin/playwright test tests/smoke/footer-support-links.spec.js --config=playwright.smoke.config.js`
- blocked: Playwright browser launch failed in this environment because required system libraries are missing