### PR TITLE
Add parent dashboard multi-child modal RSVP coverage

### DIFF
--- a/docs/pr-notes/runs/issue-469-fixer-20260403T065503Z/architecture.md
+++ b/docs/pr-notes/runs/issue-469-fixer-20260403T065503Z/architecture.md
@@ -1,0 +1,7 @@
+Current state: `parent-dashboard.html` aggregates duplicate child schedule rows into one calendar entry via `getCalendarEntries`, renders modal RSVP buttons with `data-child-ids`, and delegates submission to `createParentDashboardRsvpController`.
+
+Observed gap: the controller mutates `allScheduleEvents` and calls `renderScheduleFromControls`, but it has no hook to refresh `activeDayModal`, so an already-open modal can keep stale button classes and summary text after a successful save.
+
+Proposed state: add an optional post-render callback to the shared RSVP controller and pass `rerenderActiveDayModal` from `parent-dashboard.html`. This keeps the fix targeted to RSVP flows and avoids broad render-path changes.
+
+Blast radius: small. The change touches only the shared RSVP controller contract and the parent dashboard caller.

--- a/docs/pr-notes/runs/issue-469-fixer-20260403T065503Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-469-fixer-20260403T065503Z/code-plan.md
@@ -1,0 +1,7 @@
+Thinking level: medium.
+
+Plan:
+1. Add a `parent-dashboard.html` module test harness that exposes the calendar modal helpers without running full page init.
+2. Seed two child rows for one tracked game, open the day modal, submit grouped RSVP, and assert the stale-modal failure.
+3. Add the smallest production change that refreshes the active modal after RSVP render.
+4. Re-run focused Vitest coverage and commit the targeted patch.

--- a/docs/pr-notes/runs/issue-469-fixer-20260403T065503Z/qa.md
+++ b/docs/pr-notes/runs/issue-469-fixer-20260403T065503Z/qa.md
@@ -1,0 +1,11 @@
+Validation target:
+- A page-level test should fail against current code because the open day modal does not refresh after RSVP submission.
+- After the fix, the same test should prove:
+  - `submitRsvp` receives both child IDs.
+  - The modal remains open.
+  - The selected RSVP button class updates.
+  - The rendered RSVP summary updates.
+
+Regression guardrails:
+- Keep existing controller tests green to protect list-row and single-child behavior.
+- Run the new focused test file plus the existing RSVP controller/unit suite.

--- a/docs/pr-notes/runs/issue-469-fixer-20260403T065503Z/requirements.md
+++ b/docs/pr-notes/runs/issue-469-fixer-20260403T065503Z/requirements.md
@@ -1,0 +1,11 @@
+Objective: cover the parent dashboard calendar-day modal flow where one parent RSVP updates multiple children on a shared game.
+
+Current state: helper-level tests cover child scoping and controller-level tests cover grouped submissions, but no page-level test drives the aggregated calendar entry, modal button dataset, and optimistic modal refresh together.
+
+Risk surface: parent-facing availability writes. Blast radius is limited to parent dashboard RSVP interactions, but a regression here can silently submit partial child coverage or leave stale state in the modal.
+
+Assumptions:
+- The existing Vitest HTML-module harness is the right test layer for this repo.
+- The highest-value gap is the shared game day modal path, not list-row RSVP.
+
+Recommendation: add one integration-style `parent-dashboard.html` test that opens the calendar day modal for a shared game, submits `Going` for both child IDs, and verifies both the write payload and refreshed modal state.

--- a/js/parent-dashboard-rsvp-controls.js
+++ b/js/parent-dashboard-rsvp-controls.js
@@ -7,6 +7,7 @@ export function createParentDashboardRsvpController({
     submitRsvp,
     submitRsvpForPlayer,
     renderScheduleFromControls,
+    afterRender = () => {},
     alertFn = (message) => alert(message),
     consoleRef = console
 }) {
@@ -39,6 +40,7 @@ export function createParentDashboardRsvpController({
             });
 
             renderScheduleFromControls();
+            afterRender();
             return summary;
         } catch (err) {
             consoleRef.error('RSVP error:', err);

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -772,6 +772,7 @@
             submitRsvp,
             submitRsvpForPlayer,
             renderScheduleFromControls,
+            afterRender: rerenderActiveDayModal,
             alertFn: (message) => alert(message),
             consoleRef: console
         });

--- a/tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js
+++ b/tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js
@@ -1,0 +1,402 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import * as parentDashboardRsvp from '../../js/parent-dashboard-rsvp.js';
+import * as parentDashboardRsvpControls from '../../js/parent-dashboard-rsvp-controls.js';
+
+const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
+
+class MockClassList {
+    constructor(initial = []) {
+        this.tokens = new Set(initial);
+    }
+
+    add(...tokens) {
+        tokens.forEach((token) => this.tokens.add(token));
+    }
+
+    remove(...tokens) {
+        tokens.forEach((token) => this.tokens.delete(token));
+    }
+
+    contains(token) {
+        return this.tokens.has(token);
+    }
+
+    toggle(token, force) {
+        if (typeof force === 'boolean') {
+            if (force) this.tokens.add(token);
+            else this.tokens.delete(token);
+            return force;
+        }
+
+        if (this.tokens.has(token)) {
+            this.tokens.delete(token);
+            return false;
+        }
+
+        this.tokens.add(token);
+        return true;
+    }
+}
+
+class MockElement {
+    constructor(id = '', tagName = 'div') {
+        this.id = id;
+        this.tagName = tagName.toUpperCase();
+        this.value = '';
+        this.textContent = '';
+        this.innerHTML = '';
+        this.className = '';
+        this.children = [];
+        this.dataset = {};
+        this.style = {};
+        this.options = [];
+        this.disabled = false;
+        this.checked = false;
+        this.classList = new MockClassList(
+            id === 'schedule-day-modal' ? ['hidden'] : []
+        );
+    }
+
+    appendChild(child) {
+        this.children.push(child);
+        if (child?.tagName === 'OPTION') {
+            this.options.push(child);
+        }
+        return child;
+    }
+
+    removeChild(child) {
+        this.children = this.children.filter((candidate) => candidate !== child);
+        return child;
+    }
+
+    addEventListener() {}
+
+    removeEventListener() {}
+
+    setAttribute(name, value) {
+        this[name] = value;
+    }
+
+    querySelectorAll() {
+        return [];
+    }
+
+    querySelector() {
+        return null;
+    }
+
+    click() {}
+}
+
+function readParentDashboardModuleSource() {
+    const html = readFileSync(new URL('../../parent-dashboard.html', import.meta.url), 'utf8');
+    const match = html.match(/<script type="module">([\s\S]*?)<\/script>/);
+    if (!match) {
+        throw new Error('Parent dashboard module script not found');
+    }
+
+    return `
+const window = deps.window;
+const document = deps.document;
+const alert = deps.alert;
+const location = deps.location;
+const URL = deps.URL;
+const Blob = deps.Blob;
+` + match[1]
+        .replace(/import\s*\{[\s\S]*?\}\s*from '\.\/js\/db\.js\?v=26';/, 'const { getParentDashboardData, redeemParentInvite, getTeam, getTeams, getPlayers, getGames, getTrackedCalendarEventUids, getUnreadChatCounts, getPracticeSessions, getPracticePacketCompletions, upsertPracticePacketCompletion, updateUserProfile, getUserProfile, submitRsvp, submitRsvpForPlayer, getRsvps, getRsvpSummaries, createRideOffer, listRideOffersForEvent, requestRideSpot, updateRideRequestStatus, closeRideOffer, cancelRideRequest, getAggregatedStatsForPlayer, createParentMembershipRequest, listMyParentMembershipRequests } = deps.db;')
+        .replace(/import\s*\{[\s\S]*?\}\s*from '\.\/js\/utils\.js\?v=10';/, 'const { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence, getCalendarEventTrackingId, isTrackedCalendarEvent } = deps.utils;')
+        .replace(/import\s*\{[\s\S]*?\}\s*from '\.\/js\/parent-incentives\.js\?v=3';/, 'const { getIncentiveRules, saveIncentiveRule: saveIncentiveRuleFn, toggleIncentiveRule: toggleIncentiveRuleFn, retireIncentiveRule: retireIncentiveRuleFn, markGamePaid: markGamePaidFn, unmarkGamePaid: unmarkGamePaidFn, getPaidGames, calculateEarnings, formatCents, getApplicableRulesForGame, getStatOptionsForTeam, renderIncentivesPanel, renderRuleBuilder, getCapSetting, saveCapSetting: saveCapSettingFn } = deps.parentIncentives;')
+        .replace("import { requireAuth, checkAuth } from './js/auth.js?v=10';", 'const { requireAuth, checkAuth } = deps.auth;')
+        .replace("import { resolvePracticePacketSessionIdForEvent as resolvePracticePacketSessionIdForEventBase, resolvePracticePacketContextForEvent as resolvePracticePacketContextForEventBase } from './js/parent-dashboard-packets.js?v=2';", 'const { resolvePracticePacketSessionIdForEvent: resolvePracticePacketSessionIdForEventBase, resolvePracticePacketContextForEvent: resolvePracticePacketContextForEventBase } = deps.parentDashboardPackets;')
+        .replace("import { filterVisiblePracticeSessions } from './js/parent-dashboard-practice-sessions.js?v=1';", 'const { filterVisiblePracticeSessions } = deps.parentDashboardPracticeSessions;')
+        .replace("import { resolveRsvpPlayerIdsForSubmission, resolveMyRsvpByChildForGame } from './js/parent-dashboard-rsvp.js?v=5';", 'const { resolveRsvpPlayerIdsForSubmission, resolveMyRsvpByChildForGame } = deps.parentDashboardRsvp;')
+        .replace("import { createParentDashboardRsvpController } from './js/parent-dashboard-rsvp-controls.js?v=1';", 'const { createParentDashboardRsvpController } = deps.parentDashboardRsvpControls;')
+        .replace("import { getEventRideshareSummary, getOfferSeatInfo, canRequestRide, findRequestForChild } from './js/rideshare-helpers.js?v=1';", 'const { getEventRideshareSummary, getOfferSeatInfo, canRequestRide, findRequestForChild } = deps.rideshareHelpers;')
+        .replace("import { resolveSelectedRideChildId, createRideRequestHandlers } from './js/parent-dashboard-rideshare-controls.js?v=1';", 'const { resolveSelectedRideChildId, createRideRequestHandlers } = deps.parentDashboardRideshareControls;')
+        .replace("import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';", 'const { applyRsvpHydration } = deps.rsvpHydration;')
+        .replace(/\binit\(\);\s*$/, `
+window.__parentDashboardTestHooks = {
+    setAllScheduleEvents(value) {
+        allScheduleEvents = value;
+    },
+    getAllScheduleEvents() {
+        return allScheduleEvents;
+    },
+    setCurrentUser(user) {
+        currentUser = user;
+        currentUserId = user?.uid || null;
+    },
+    setScheduleCalendar(year, month) {
+        scheduleCalendarYear = year;
+        scheduleCalendarMonth = month;
+    },
+    setScheduleViewMode(mode) {
+        scheduleViewMode = mode;
+    },
+    renderScheduleFromControls,
+    openScheduleDayModal,
+    submitGameRsvpFromButton
+};
+`);
+}
+
+const runParentDashboardModule = new AsyncFunction('deps', readParentDashboardModuleSource());
+
+function createEnvironment() {
+    const ids = [
+        'footer-container',
+        'header-container',
+        'player-filter',
+        'schedule-list',
+        'schedule-calendar-grid',
+        'schedule-calendar-nav',
+        'schedule-calendar-month-label',
+        'schedule-day-modal',
+        'schedule-day-modal-title',
+        'schedule-day-modal-content',
+        'schedule-view-list',
+        'schedule-view-calendar'
+    ];
+    const elements = new Map(ids.map((id) => [id, new MockElement(id)]));
+
+    const document = {
+        body: new MockElement('body', 'body'),
+        getElementById(id) {
+            if (!elements.has(id)) {
+                elements.set(id, new MockElement(id));
+            }
+            return elements.get(id);
+        },
+        createElement(tagName) {
+            return new MockElement('', tagName);
+        },
+        querySelectorAll() {
+            return [];
+        }
+    };
+
+    const window = {
+        document,
+        location: {
+            reload() {}
+        },
+        alert(message) {
+            throw new Error(`Unexpected alert: ${message}`);
+        }
+    };
+
+    return { document, elements, window };
+}
+
+function createDeps(submitRecorder) {
+    return {
+        db: {
+            async getParentDashboardData() { return { children: [] }; },
+            async redeemParentInvite() {},
+            async getTeam() { return null; },
+            async getTeams() { return []; },
+            async getPlayers() { return []; },
+            async getGames() { return []; },
+            async getTrackedCalendarEventUids() { return []; },
+            async getUnreadChatCounts() { return new Map(); },
+            async getPracticeSessions() { return []; },
+            async getPracticePacketCompletions() { return []; },
+            async upsertPracticePacketCompletion() {},
+            async updateUserProfile() {},
+            async getUserProfile() { return {}; },
+            async submitRsvp(teamId, gameId, currentUserId, payload) {
+                submitRecorder.calls.push({ teamId, gameId, currentUserId, payload });
+                return submitRecorder.updatedSummary;
+            },
+            async submitRsvpForPlayer() {
+                throw new Error('Unexpected submitRsvpForPlayer call');
+            },
+            async getRsvps() { return []; },
+            async getRsvpSummaries() { return new Map(); },
+            async createRideOffer() {},
+            async listRideOffersForEvent() { return []; },
+            async requestRideSpot() {},
+            async updateRideRequestStatus() {},
+            async closeRideOffer() {},
+            async cancelRideRequest() {},
+            async getAggregatedStatsForPlayer() { return null; },
+            async createParentMembershipRequest() {},
+            async listMyParentMembershipRequests() { return []; }
+        },
+        utils: {
+            renderHeader() {},
+            renderFooter() {},
+            escapeHtml(value) { return String(value ?? ''); },
+            async fetchAndParseCalendar() { return []; },
+            extractOpponent() { return 'Opponent'; },
+            isPracticeEvent() { return false; },
+            expandRecurrence() { return []; },
+            getCalendarEventTrackingId(event) { return event?.uid || null; },
+            isTrackedCalendarEvent() { return false; }
+        },
+        parentIncentives: {
+            async getIncentiveRules() { return []; },
+            async saveIncentiveRule() {},
+            async toggleIncentiveRule() {},
+            async retireIncentiveRule() {},
+            async markGamePaid() {},
+            async unmarkGamePaid() {},
+            async getPaidGames() { return new Map(); },
+            calculateEarnings() { return { totalCents: 0 }; },
+            formatCents() { return '$0.00'; },
+            getApplicableRulesForGame() { return []; },
+            async getStatOptionsForTeam() { return []; },
+            renderIncentivesPanel() { return ''; },
+            renderRuleBuilder() { return ''; },
+            async getCapSetting() { return null; },
+            async saveCapSetting() {}
+        },
+        auth: {
+            async requireAuth() { return null; },
+            checkAuth() {}
+        },
+        parentDashboardPackets: {
+            resolvePracticePacketSessionIdForEvent() { return null; },
+            resolvePracticePacketContextForEvent() { return { sessionId: null, homePacket: null }; }
+        },
+        parentDashboardPracticeSessions: {
+            filterVisiblePracticeSessions(sessions) { return sessions || []; }
+        },
+        parentDashboardRsvp,
+        parentDashboardRsvpControls,
+        rideshareHelpers: {
+            getEventRideshareSummary() { return { seatsLeft: 0, requests: 0, isFull: false }; },
+            getOfferSeatInfo() { return { seatCountConfirmed: 0, seatCapacity: 0, seatsLeft: 0 }; },
+            canRequestRide() { return false; },
+            findRequestForChild() { return null; }
+        },
+        parentDashboardRideshareControls: {
+            resolveSelectedRideChildId({ defaultChildId }) { return defaultChildId || ''; },
+            createRideRequestHandlers() {
+                return {
+                    requestRideSpotForChild: async () => {},
+                    cancelMyRideRequest: async () => {}
+                };
+            }
+        },
+        rsvpHydration: {
+            applyRsvpHydration(allEvents, teamId, gameId, hydration) {
+                allEvents.forEach((event) => {
+                    if (event.teamId === teamId && event.id === gameId) {
+                        if (Object.prototype.hasOwnProperty.call(hydration, 'myRsvp')) {
+                            event.myRsvp = hydration.myRsvp;
+                        }
+                        if (Object.prototype.hasOwnProperty.call(hydration, 'summary')) {
+                            event.rsvpSummary = hydration.summary;
+                        }
+                    }
+                });
+            }
+        }
+    };
+}
+
+async function bootParentDashboard() {
+    const submitRecorder = {
+        calls: [],
+        updatedSummary: { going: 2, maybe: 0, notGoing: 0, notResponded: 0, total: 2 }
+    };
+    const env = createEnvironment();
+    const deps = createDeps(submitRecorder);
+
+    await runParentDashboardModule({
+        ...deps,
+        window: env.window,
+        document: env.document,
+        alert: env.window.alert,
+        location: env.window.location,
+        URL: globalThis.URL,
+        Blob: globalThis.Blob
+    });
+
+    return {
+        ...env,
+        submitRecorder,
+        hooks: env.window.__parentDashboardTestHooks
+    };
+}
+
+describe('parent dashboard calendar day modal RSVP flow', () => {
+    it('submits both child ids from the shared-game modal and refreshes the open modal state', async () => {
+        const { elements, hooks, submitRecorder } = await bootParentDashboard();
+        const eventDate = new Date('2026-04-15T18:00:00.000Z');
+        const initialSummary = { going: 0, maybe: 0, notGoing: 0, notResponded: 2, total: 2 };
+
+        hooks.setCurrentUser({
+            uid: 'parent-1',
+            displayName: 'Parent One',
+            email: 'parent@example.com'
+        });
+        hooks.setAllScheduleEvents([
+            {
+                teamId: 'team-1',
+                id: 'game-1',
+                type: 'game',
+                isDbGame: true,
+                date: eventDate,
+                opponent: 'Lions',
+                location: 'North Field',
+                childId: 'child-a',
+                childName: 'Avery',
+                myRsvp: null,
+                rsvpSummary: initialSummary
+            },
+            {
+                teamId: 'team-1',
+                id: 'game-1',
+                type: 'game',
+                isDbGame: true,
+                date: eventDate,
+                opponent: 'Lions',
+                location: 'North Field',
+                childId: 'child-b',
+                childName: 'Blake',
+                myRsvp: null,
+                rsvpSummary: initialSummary
+            }
+        ]);
+        hooks.setScheduleCalendar(eventDate.getFullYear(), eventDate.getMonth());
+        hooks.setScheduleViewMode('calendar');
+        hooks.renderScheduleFromControls();
+        hooks.openScheduleDayModal(eventDate.getFullYear(), eventDate.getMonth(), eventDate.getDate());
+
+        const beforeHtml = elements.get('schedule-day-modal-content').innerHTML;
+        expect(beforeHtml).toContain('data-child-ids="child-a,child-b"');
+        expect(beforeHtml).toContain("bg-white text-green-700 border-green-300 hover:bg-green-50");
+        expect(beforeHtml).toContain(`${initialSummary.going} going · ${initialSummary.maybe} maybe · ${initialSummary.notGoing} can't go · ${initialSummary.notResponded} no response`);
+
+        await hooks.submitGameRsvpFromButton({
+            dataset: {
+                teamId: 'team-1',
+                gameId: 'game-1',
+                childIds: 'child-a,child-b'
+            }
+        }, 'going');
+
+        expect(submitRecorder.calls).toEqual([
+            {
+                teamId: 'team-1',
+                gameId: 'game-1',
+                currentUserId: 'parent-1',
+                payload: {
+                    displayName: 'Parent One',
+                    playerIds: ['child-a', 'child-b'],
+                    response: 'going'
+                }
+            }
+        ]);
+
+        const afterHtml = elements.get('schedule-day-modal-content').innerHTML;
+        expect(elements.get('schedule-day-modal').classList.contains('hidden')).toBe(false);
+        expect(afterHtml).toContain("bg-green-600 text-white border-green-600");
+        expect(afterHtml).toContain(`${submitRecorder.updatedSummary.going} going · ${submitRecorder.updatedSummary.maybe} maybe · ${submitRecorder.updatedSummary.notGoing} can't go · ${submitRecorder.updatedSummary.notResponded} no response`);
+        expect(afterHtml).toContain('For Avery, Blake');
+    });
+});

--- a/tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js
+++ b/tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js
@@ -109,12 +109,15 @@ const Blob = deps.Blob;
         .replace(/import\s*\{[\s\S]*?\}\s*from '\.\/js\/utils\.js\?v=10';/, 'const { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence, getCalendarEventTrackingId, isTrackedCalendarEvent } = deps.utils;')
         .replace(/import\s*\{[\s\S]*?\}\s*from '\.\/js\/parent-incentives\.js\?v=3';/, 'const { getIncentiveRules, saveIncentiveRule: saveIncentiveRuleFn, toggleIncentiveRule: toggleIncentiveRuleFn, retireIncentiveRule: retireIncentiveRuleFn, markGamePaid: markGamePaidFn, unmarkGamePaid: unmarkGamePaidFn, getPaidGames, calculateEarnings, formatCents, getApplicableRulesForGame, getStatOptionsForTeam, renderIncentivesPanel, renderRuleBuilder, getCapSetting, saveCapSetting: saveCapSettingFn } = deps.parentIncentives;')
         .replace("import { requireAuth, checkAuth } from './js/auth.js?v=10';", 'const { requireAuth, checkAuth } = deps.auth;')
-        .replace("import { resolvePracticePacketSessionIdForEvent as resolvePracticePacketSessionIdForEventBase, resolvePracticePacketContextForEvent as resolvePracticePacketContextForEventBase } from './js/parent-dashboard-packets.js?v=2';", 'const { resolvePracticePacketSessionIdForEvent: resolvePracticePacketSessionIdForEventBase, resolvePracticePacketContextForEvent: resolvePracticePacketContextForEventBase } = deps.parentDashboardPackets;')
+        .replace(
+            /import\s*\{[\s\S]*?\}\s*from '\.\/js\/parent-dashboard-packets\.js\?v=3';/,
+            'const { resolvePracticePacketSessionIdForEvent: resolvePracticePacketSessionIdForEventBase, resolvePracticePacketContextForEvent: resolvePracticePacketContextForEventBase, getScopedPracticePacketRow: getScopedPracticePacketRowBase, buildPracticePacketCompletionPayload: buildPracticePacketCompletionPayloadBase } = deps.parentDashboardPackets;'
+        )
         .replace("import { filterVisiblePracticeSessions } from './js/parent-dashboard-practice-sessions.js?v=1';", 'const { filterVisiblePracticeSessions } = deps.parentDashboardPracticeSessions;')
         .replace("import { resolveRsvpPlayerIdsForSubmission, resolveMyRsvpByChildForGame } from './js/parent-dashboard-rsvp.js?v=5';", 'const { resolveRsvpPlayerIdsForSubmission, resolveMyRsvpByChildForGame } = deps.parentDashboardRsvp;')
         .replace("import { createParentDashboardRsvpController } from './js/parent-dashboard-rsvp-controls.js?v=1';", 'const { createParentDashboardRsvpController } = deps.parentDashboardRsvpControls;')
-        .replace("import { getEventRideshareSummary, getOfferSeatInfo, canRequestRide, findRequestForChild } from './js/rideshare-helpers.js?v=1';", 'const { getEventRideshareSummary, getOfferSeatInfo, canRequestRide, findRequestForChild } = deps.rideshareHelpers;')
-        .replace("import { resolveSelectedRideChildId, createRideRequestHandlers } from './js/parent-dashboard-rideshare-controls.js?v=1';", 'const { resolveSelectedRideChildId, createRideRequestHandlers } = deps.parentDashboardRideshareControls;')
+        .replace("import { getEventRideshareSummary, getOfferSeatInfo } from './js/rideshare-helpers.js?v=1';", 'const { getEventRideshareSummary, getOfferSeatInfo } = deps.rideshareHelpers;')
+        .replace("import { resolveSelectedRideChildId, getRideOfferUiState, createRideRequestHandlers } from './js/parent-dashboard-rideshare-controls.js?v=1';", 'const { resolveSelectedRideChildId, getRideOfferUiState, createRideRequestHandlers } = deps.parentDashboardRideshareControls;')
         .replace("import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';", 'const { applyRsvpHydration } = deps.rsvpHydration;')
         .replace(/\binit\(\);\s*$/, `
 window.__parentDashboardTestHooks = {
@@ -259,7 +262,9 @@ function createDeps(submitRecorder) {
         },
         parentDashboardPackets: {
             resolvePracticePacketSessionIdForEvent() { return null; },
-            resolvePracticePacketContextForEvent() { return { sessionId: null, homePacket: null }; }
+            resolvePracticePacketContextForEvent() { return { sessionId: null, homePacket: null }; },
+            getScopedPracticePacketRow() { return null; },
+            buildPracticePacketCompletionPayload() { return {}; }
         },
         parentDashboardPracticeSessions: {
             filterVisiblePracticeSessions(sessions) { return sessions || []; }
@@ -268,12 +273,11 @@ function createDeps(submitRecorder) {
         parentDashboardRsvpControls,
         rideshareHelpers: {
             getEventRideshareSummary() { return { seatsLeft: 0, requests: 0, isFull: false }; },
-            getOfferSeatInfo() { return { seatCountConfirmed: 0, seatCapacity: 0, seatsLeft: 0 }; },
-            canRequestRide() { return false; },
-            findRequestForChild() { return null; }
+            getOfferSeatInfo() { return { seatCountConfirmed: 0, seatCapacity: 0, seatsLeft: 0 }; }
         },
         parentDashboardRideshareControls: {
             resolveSelectedRideChildId({ defaultChildId }) { return defaultChildId || ''; },
+            getRideOfferUiState() { return { disabled: false, reason: '' }; },
             createRideRequestHandlers() {
                 return {
                     requestRideSpotForChild: async () => {},

--- a/tests/unit/parent-dashboard-rsvp-controls.test.js
+++ b/tests/unit/parent-dashboard-rsvp-controls.test.js
@@ -148,6 +148,43 @@ describe('parent dashboard RSVP controller', () => {
         });
         expect(allScheduleEvents[0].myRsvp).toBe('going');
     });
+
+    it('runs the optional post-render hook after a grouped RSVP save', async () => {
+        const allScheduleEvents = [
+            { teamId: 'team-1', id: 'game-1', childId: 'child-a', myRsvp: null, rsvpSummary: null },
+            { teamId: 'team-1', id: 'game-1', childId: 'child-b', myRsvp: null, rsvpSummary: null }
+        ];
+        const submitRsvp = vi.fn().mockResolvedValue({ going: 2, maybe: 0, notGoing: 0, notResponded: 0, total: 2 });
+        const afterRender = vi.fn();
+        const controller = createParentDashboardRsvpController({
+            getAllScheduleEvents: () => allScheduleEvents,
+            getCurrentUserId: () => 'parent-1',
+            getCurrentUser: () => ({ displayName: 'Parent One', email: 'parent@example.com' }),
+            documentRef: {
+                getElementById(id) {
+                    if (id === 'player-filter') return { value: '' };
+                    return null;
+                }
+            },
+            resolveRsvpPlayerIdsForSubmission,
+            submitRsvp,
+            submitRsvpForPlayer: vi.fn(),
+            renderScheduleFromControls: vi.fn(),
+            afterRender,
+            alertFn: vi.fn(),
+            consoleRef: { error: vi.fn() }
+        });
+
+        await controller.submitGameRsvpFromButton({
+            dataset: {
+                teamId: 'team-1',
+                gameId: 'game-1',
+                childIds: 'child-a,child-b'
+            }
+        }, 'going');
+
+        expect(afterRender).toHaveBeenCalledTimes(1);
+    });
 });
 
 describe('parent dashboard RSVP wiring', () => {


### PR DESCRIPTION
Closes #469

## What changed
- added a page-level Vitest harness for `parent-dashboard.html` that opens the calendar day modal, submits a grouped RSVP for two children, and verifies both the `submitRsvp` payload and the refreshed modal UI state
- extended the shared parent dashboard RSVP controller with an optional post-render hook and wired `parent-dashboard.html` to rerender the active day modal after RSVP saves
- added a controller unit test covering the new post-render callback contract
- persisted the required per-run role notes under `docs/pr-notes/runs/issue-469-fixer-20260403T065503Z/`

## Why
The existing helper and controller tests did not exercise the actual parent dashboard modal path that aggregates duplicate child rows into one calendar entry. The modal could submit the correct multi-child payload while leaving the open modal stale, which is exactly the kind of parent-facing regression this issue called out.

## Validation
- `./node_modules/.bin/vitest run tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js tests/unit/parent-dashboard-rsvp-controls.test.js`
- `./node_modules/.bin/vitest run tests/unit/parent-dashboard-rsvp.test.js tests/unit/parent-dashboard-rsvp-controls.test.js tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js`