### PR TITLE
Add browser coverage for imported ICS schedule rows

### DIFF
--- a/docs/pr-notes/runs/496-remediator-20260404T040707Z/architecture.md
+++ b/docs/pr-notes/runs/496-remediator-20260404T040707Z/architecture.md
@@ -1,0 +1,12 @@
+Decision: make the smallest fix at the conflict-check call site.
+
+Why:
+- Lowest blast radius. Only the dereference path is unsafe.
+- Preserves the intentional `toDate(null) -> null` change elsewhere in the PR.
+
+Risk surface:
+- Calendar import merge logic in `js/edit-schedule-calendar-import.js`.
+- No schema, routing, or rendering changes.
+
+Rollback:
+- Revert the single guarded check if later review requires a different null-handling policy.

--- a/docs/pr-notes/runs/496-remediator-20260404T040707Z/code-plan.md
+++ b/docs/pr-notes/runs/496-remediator-20260404T040707Z/code-plan.md
@@ -1,0 +1,4 @@
+Implementation plan:
+1. Patch `mergeCalendarImportEvents` to guard `dbDate` before calling `getTime()`.
+2. Run a targeted Node import/execution against the module to verify null dates no longer throw.
+3. Stage changed files and commit with a short imperative message.

--- a/docs/pr-notes/runs/496-remediator-20260404T040707Z/qa.md
+++ b/docs/pr-notes/runs/496-remediator-20260404T040707Z/qa.md
@@ -1,0 +1,10 @@
+Targeted validation:
+- Confirm `mergeCalendarImportEvents` skips `dbEvents` entries with empty or missing `date`.
+- Confirm valid date conflicts within 60 seconds still return `hasConflict = true`.
+- Confirm imported events continue rendering when malformed legacy records are present.
+
+Manual test path:
+- Use `test-pr-changes.html` or a small console invocation after serving the repo locally.
+
+Residual risk:
+- No automated test runner exists in this repo, so validation is manual/targeted only.

--- a/docs/pr-notes/runs/496-remediator-20260404T040707Z/requirements.md
+++ b/docs/pr-notes/runs/496-remediator-20260404T040707Z/requirements.md
@@ -1,0 +1,17 @@
+Objective: resolve PR thread PRRT_kwDOQe-T58540beW without broadening scope.
+
+Current state:
+- `toDate` returns `null` for falsy values.
+- `mergeCalendarImportEvents` conflict detection still calls `dbDate.getTime()` unguarded.
+
+Proposed state:
+- Keep `toDate` behavior unchanged.
+- Guard conflict detection so legacy or empty `dbEvents[].date` values are skipped safely.
+
+Assumptions:
+- The review thread is limited to this null-handling regression.
+- No broader date parsing changes are required for PR #496.
+
+Success:
+- Missing or empty `dbEvent.date` does not throw.
+- Valid conflicting events still suppress imported duplicates.

--- a/docs/pr-notes/runs/issue-492-fixer-20260404T035502Z/architecture.md
+++ b/docs/pr-notes/runs/issue-492-fixer-20260404T035502Z/architecture.md
@@ -1,0 +1,16 @@
+Current state:
+- `edit-schedule.html` calls `loadSchedule()`, fetches DB events plus calendar events, then renders merged rows.
+- `mergeCalendarImportEvents()` normalizes imported rows before `renderCalendarEvent()` decides the visible CTA.
+
+Proposed state:
+- Preserve imported calendar `dtend` during merge so `buildPracticePlanHref()` can compute duration for imported practice planning.
+- Add a page harness that stubs imported modules at the network layer while still executing the real HTML and merge helper.
+
+Blast radius:
+- Low. The code change is confined to the calendar import helper.
+- Browser test blast radius is isolated to a new Playwright file and local stubs.
+
+Controls:
+- No production dependency changes.
+- No auth or Firestore behavior changes.
+- Existing helper behavior for tracked UID suppression, conflict suppression, and cancellation stays intact.

--- a/docs/pr-notes/runs/issue-492-fixer-20260404T035502Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-492-fixer-20260404T035502Z/code-plan.md
@@ -1,0 +1,6 @@
+Implementation plan:
+1. Add `tests/smoke/edit-schedule-calendar-import.spec.js` with a local static server and route-based module stubs.
+2. Prove failure against current code by asserting imported practice planning preserves duration.
+3. Patch `js/edit-schedule-calendar-import.js` to carry imported `dtend` into merged rows.
+4. Re-run the focused browser test and existing helper unit test.
+5. Commit test plus fix together.

--- a/docs/pr-notes/runs/issue-492-fixer-20260404T035502Z/qa.md
+++ b/docs/pr-notes/runs/issue-492-fixer-20260404T035502Z/qa.md
@@ -1,0 +1,21 @@
+Test strategy:
+- Add browser coverage for two issue-defined flows on the real `edit-schedule.html` page.
+
+Scenarios:
+1. Imported practice row:
+- load with `calendarUrls`
+- mock one future untracked practice ICS event with `dtstart`, `dtend`, `uid`, and `location`
+- switch to `Upcoming Practices`
+- assert calendar/practice badges
+- assert `Plan Practice` shows and `Track` does not
+- assert generated `drills.html` hash includes `eventId`, `eventDate`, `eventDuration`, `eventLocation`, and `eventTitle`
+
+2. Duplicate suppression and cancellation:
+- mock one tracked UID, one event conflicting with a DB event within 60 seconds, and one cancelled import
+- assert tracked/conflicting rows do not render
+- assert cancelled row renders with `Cancelled`
+- assert cancelled row has no action CTA
+
+Validation:
+- Run the focused Playwright spec.
+- Run the existing unit calendar import test to guard helper behavior.

--- a/docs/pr-notes/runs/issue-492-fixer-20260404T035502Z/requirements.md
+++ b/docs/pr-notes/runs/issue-492-fixer-20260404T035502Z/requirements.md
@@ -1,0 +1,25 @@
+Objective: cover imported ICS rows in `edit-schedule.html` from page load through visible coach actions.
+
+Current state:
+- Unit tests cover calendar import helpers and string wiring.
+- No browser test exercises `loadSchedule()` with `team.calendarUrls`.
+
+Proposed state:
+- Browser coverage loads `edit-schedule.html`, mocks ICS payloads, and verifies imported practice/game rows as a coach sees them.
+
+Risk surface:
+- Silent regression can hide imported events, render duplicate rows, or expose the wrong CTA.
+- Imported practice planning loses context if the calendar merge drops required fields.
+
+Assumptions:
+- Existing coach UX is acceptable: imported practices are visible when the practice filter is enabled or the practice-only view is selected.
+- Calendar practice planning should preserve UID, date, duration, title, and location in the generated `drills.html` link.
+
+Recommendation:
+- Add one focused Playwright spec with two scenarios matching the issue.
+- Keep the code fix limited to import merge behavior needed by the page test.
+
+Success:
+- Imported practice row renders with calendar/practice badges and `Plan Practice` link containing preserved calendar context.
+- Tracked and conflicting imports stay hidden.
+- Cancelled imports render a cancelled row with no action button.

--- a/js/edit-schedule-calendar-import.js
+++ b/js/edit-schedule-calendar-import.js
@@ -47,7 +47,8 @@ export function mergeCalendarImportEvents({
 
         const hasConflict = (dbEvents || []).some((dbEvent) => {
             const dbDate = toDate(dbEvent?.date);
-            return !Number.isNaN(dbDate.getTime()) && Math.abs(dbDate - eventDate) < 60000;
+            if (!(dbDate instanceof Date) || Number.isNaN(dbDate.getTime())) return false;
+            return Math.abs(dbDate - eventDate) < 60000;
         });
         if (hasConflict) return;
 

--- a/js/edit-schedule-calendar-import.js
+++ b/js/edit-schedule-calendar-import.js
@@ -23,6 +23,7 @@ export function validateCalendarImportUrl(url) {
 function toDate(value) {
     if (value instanceof Date) return value;
     if (typeof value?.toDate === 'function') return value.toDate();
+    if (!value) return null;
     return new Date(value);
 }
 
@@ -57,6 +58,7 @@ export function mergeCalendarImportEvents({
             source: 'calendar',
             eventType: isPractice ? 'practice' : 'game',
             date: eventDate,
+            end: toDate(event?.dtend),
             opponent: extractOpponent(cleanSummary, currentTeamName),
             location: event.location || 'TBD',
             isPractice,

--- a/tests/smoke/edit-schedule-calendar-import.spec.js
+++ b/tests/smoke/edit-schedule-calendar-import.spec.js
@@ -1,0 +1,480 @@
+import { test, expect } from '@playwright/test';
+import { createServer } from 'node:http';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '../..');
+
+let server;
+let serverOrigin;
+
+const moduleSources = {
+    '/js/db.js': `
+const state = () => window.__editScheduleTestState || {};
+
+export async function getTeam() {
+    return state().team || null;
+}
+
+export async function getTeams() {
+    return state().teams || [];
+}
+
+export async function getGames() {
+    return [];
+}
+
+export async function getEvents() {
+    return state().dbEvents || [];
+}
+
+export async function addGame() {
+    return 'game-created';
+}
+
+export async function updateGame() {}
+export async function updateTeam() {}
+export async function deleteGame() {}
+export async function addPractice() { return 'practice-created'; }
+export async function updateEvent() {}
+export async function deleteEvent() {}
+export async function getConfigs() { return []; }
+export async function addCalendarToTeam() {}
+export async function removeCalendarFromTeam() {}
+export async function getTrackedCalendarEventUids() { return state().trackedUids || []; }
+export async function cancelOccurrence() {}
+export async function updateOccurrence() {}
+export async function restoreOccurrence() {}
+export async function clearOccurrenceOverride() {}
+export async function updateSeries() {}
+export async function deleteSeries() {}
+export async function getUnreadChatCount() { return 0; }
+export async function getPracticeSessions() { return state().practiceSessions || []; }
+export async function cancelGame() {}
+export async function getLatestGameAssignments() { return []; }
+export async function postChatMessage() {}
+export async function getRsvpBreakdownByPlayer() {
+    return {
+        grouped: { going: [], maybe: [], not_going: [], not_responded: [] },
+        counts: { going: 0, maybe: 0, notGoing: 0, notResponded: 0 }
+    };
+}
+`,
+    '/js/utils.js': `
+const state = () => window.__editScheduleTestState || {};
+
+function normalizeDate(value) {
+    const date = value instanceof Date ? value : new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function format(value, options) {
+    const date = normalizeDate(value);
+    if (!date) return '';
+    return new Intl.DateTimeFormat('en-US', { timeZone: 'UTC', ...options }).format(date);
+}
+
+export function renderHeader(container) {
+    if (container) container.innerHTML = '<div>Header</div>';
+}
+
+export function renderFooter(container) {
+    if (container) container.innerHTML = '<div>Footer</div>';
+}
+
+export function getUrlParams() {
+    const hash = window.location.hash.startsWith('#') ? window.location.hash.slice(1) : window.location.hash;
+    return Object.fromEntries(new URLSearchParams(hash).entries());
+}
+
+export function formatDate(value) {
+    return format(value, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+export function formatShortDate(value) {
+    return formatDate(value);
+}
+
+export function formatTime(value) {
+    return format(value, { hour: 'numeric', minute: '2-digit' });
+}
+
+export function formatTimeRange(start, end) {
+    const normalizedStart = normalizeDate(start);
+    const normalizedEnd = normalizeDate(end);
+    if (!normalizedStart || !normalizedEnd) return '';
+    return \`\${formatTime(normalizedStart)} - \${formatTime(normalizedEnd)}\`;
+}
+
+export function getDefaultEndTime() {
+    return '';
+}
+
+export async function fetchAndParseCalendar(url) {
+    return (state().calendarEventsByUrl || {})[url] || [];
+}
+
+export function extractOpponent(summary, teamName) {
+    const cleanSummary = String(summary || '');
+    const prefix = \`\${teamName || ''} vs \`;
+    return cleanSummary.startsWith(prefix) ? cleanSummary.slice(prefix.length) : cleanSummary;
+}
+
+export function isPracticeEvent(summary) {
+    return /practice|training/i.test(String(summary || ''));
+}
+
+export function getCalendarEventStatus(event) {
+    if (String(event?.status || '').toLowerCase() === 'cancelled') return 'cancelled';
+    if (/\\[(?:canceled|cancelled)\\]/i.test(String(event?.summary || ''))) return 'cancelled';
+    return 'confirmed';
+}
+
+export function getCalendarEventTrackingId(event) {
+    return event?.uid || event?.id || '';
+}
+
+export function isTrackedCalendarEvent(event, trackedIds = []) {
+    return trackedIds.includes(getCalendarEventTrackingId(event));
+}
+
+export function generateSeriesId() {
+    return 'series-1';
+}
+
+export function expandRecurrence() {
+    return [];
+}
+
+export function formatRecurrence() {
+    return '';
+}
+
+export async function shareOrCopy() {
+    return true;
+}
+
+export function escapeHtml(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;');
+}
+`,
+    '/js/auth.js': `
+export function checkAuth(callback) {
+    Promise.resolve().then(() => callback({
+        uid: 'coach-1',
+        email: 'coach@example.com',
+        displayName: 'Coach Example'
+    }));
+}
+`,
+    '/js/team-admin-banner.js': `
+export function renderTeamAdminBanner(container) {
+    if (container) container.innerHTML = '<div>Banner</div>';
+}
+`,
+    '/js/team-access.js': `
+export function getTeamAccessInfo() {
+    return { hasAccess: true, accessLevel: 'full' };
+}
+`,
+    '/js/live-game-state.js': `
+export function resolvePreferredStatConfigId() {
+    return null;
+}
+`,
+    '/js/edit-schedule-cancel-game.js': `
+export async function cancelScheduledGame() {
+    return { cancelled: false, error: 'not implemented in test' };
+}
+`,
+    '/js/edit-schedule-practice-payload.js': `
+export function applyPracticeRecurrenceFields() {}
+`,
+    '/js/edit-schedule-practice-submit.js': `
+export async function savePracticeForm() {
+    return { savedPracticeId: 'practice-created' };
+}
+`,
+    '/js/firebase.js': `
+export const Timestamp = {
+    fromDate(date) {
+        return {
+            toDate() {
+                return date;
+            }
+        };
+    }
+};
+
+export function deleteField() {
+    return '__delete_field__';
+}
+`,
+    '/js/vendor/firebase-app.js': `
+export function getApp() {
+    return {};
+}
+`,
+    '/js/vendor/firebase-ai.js': `
+export function getAI() {
+    return {};
+}
+
+export function getGenerativeModel() {
+    return {};
+}
+
+export const GoogleAIBackend = {};
+export const Schema = {};
+`,
+    '/js/tournament-brackets.js': `
+export function collectTournamentAdvancementPatches() {
+    return [];
+}
+
+export function describeTournamentSource() {
+    return '';
+}
+`,
+    '/js/schedule-notifications.js': `
+export function normalizeScheduleNotificationSettings() {
+    return { enabled: false, reminderHours: 24 };
+}
+
+export function buildScheduleNotificationMetadata() {
+    return {};
+}
+
+export function buildScheduleChangeMessage() {
+    return '';
+}
+
+export function buildRsvpReminderMessage() {
+    return '';
+}
+`,
+    '/js/schedule-csv-import.js': `
+export const SCHEDULE_CSV_IMPORT_FIELDS = [];
+export function buildScheduleImportPreview() { return []; }
+export function inferScheduleCsvMapping() { return {}; }
+export function normalizeScheduleImportDraft() { return {}; }
+export function parseCsvText() { return []; }
+`
+};
+
+function contentTypeFor(filePath) {
+    if (filePath.endsWith('.html')) return 'text/html; charset=utf-8';
+    if (filePath.endsWith('.js')) return 'application/javascript; charset=utf-8';
+    if (filePath.endsWith('.css')) return 'text/css; charset=utf-8';
+    if (filePath.endsWith('.json')) return 'application/json; charset=utf-8';
+    if (filePath.endsWith('.png')) return 'image/png';
+    return 'text/plain; charset=utf-8';
+}
+
+async function startStaticServer() {
+    server = createServer(async (req, res) => {
+        try {
+            const url = new URL(req.url, 'http://127.0.0.1');
+            let pathname = decodeURIComponent(url.pathname);
+            if (pathname === '/') pathname = '/index.html';
+            const filePath = path.join(repoRoot, pathname);
+            const body = await readFile(filePath);
+            res.writeHead(200, { 'content-type': contentTypeFor(filePath) });
+            res.end(body);
+        } catch (error) {
+            res.writeHead(404, { 'content-type': 'text/plain; charset=utf-8' });
+            res.end(String(error));
+        }
+    });
+
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const address = server.address();
+    serverOrigin = `http://127.0.0.1:${address.port}`;
+}
+
+async function stopStaticServer() {
+    if (!server) return;
+    await new Promise((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())));
+    server = null;
+    serverOrigin = null;
+}
+
+async function registerRoutes(page) {
+    await page.route('https://www.googletagmanager.com/**', async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript; charset=utf-8',
+            body: ''
+        });
+    });
+
+    await page.route('https://cdn.tailwindcss.com/**', async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript; charset=utf-8',
+            body: 'window.tailwind = window.tailwind || { config: {} };'
+        });
+    });
+
+    await page.route('**/*', async (route) => {
+        const url = new URL(route.request().url());
+        if (url.origin !== serverOrigin) {
+            await route.continue();
+            return;
+        }
+
+        const source = moduleSources[url.pathname];
+        if (!source) {
+            await route.continue();
+            return;
+        }
+
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript; charset=utf-8',
+            body: source
+        });
+    });
+}
+
+function buildState(overrides = {}) {
+    return {
+        team: {
+            id: 'team-1',
+            name: 'Wildcats',
+            sport: 'soccer',
+            calendarUrls: ['https://calendar.test/team.ics']
+        },
+        teams: [],
+        dbEvents: [],
+        trackedUids: [],
+        practiceSessions: [],
+        calendarEventsByUrl: {},
+        ...overrides
+    };
+}
+
+function hashParamsFromHref(href) {
+    const url = new URL(href, serverOrigin);
+    const hash = url.hash.startsWith('#') ? url.hash.slice(1) : url.hash;
+    return new URLSearchParams(hash);
+}
+
+test.beforeAll(async () => {
+    await startStaticServer();
+});
+
+test.afterAll(async () => {
+    await stopStaticServer();
+});
+
+test.describe('edit schedule imported calendar rows', () => {
+    test.beforeEach(async ({ page }) => {
+        await registerRoutes(page);
+    });
+
+    test('renders imported practice rows with practice planning context', async ({ page }) => {
+        const eventStart = '2030-04-04T19:00:00.000Z';
+        const eventEnd = '2030-04-04T20:30:00.000Z';
+
+        await page.addInitScript((state) => {
+            window.__editScheduleTestState = state;
+            window.HTMLElement.prototype.scrollIntoView = function scrollIntoView() {};
+        }, buildState({
+            calendarEventsByUrl: {
+                'https://calendar.test/team.ics': [
+                    {
+                        uid: 'practice-uid-1',
+                        dtstart: eventStart,
+                        dtend: eventEnd,
+                        summary: 'Evening Practice',
+                        location: 'Training Field'
+                    }
+                ]
+            }
+        }));
+
+        await page.goto(`${serverOrigin}/edit-schedule.html#teamId=team-1`, { waitUntil: 'domcontentloaded' });
+        await page.getByRole('button', { name: 'Upcoming Practices' }).click();
+
+        const scheduleList = page.locator('#schedule-list');
+        await expect(scheduleList).toContainText('Calendar');
+        await expect(scheduleList).toContainText('Practice');
+        await expect(scheduleList).toContainText('Plan Practice');
+        await expect(scheduleList).not.toContainText('Track');
+
+        const planLink = scheduleList.getByRole('link', { name: 'Plan Practice' });
+        await expect(planLink).toHaveAttribute('href', /drills\.html#/);
+
+        const params = hashParamsFromHref(await planLink.getAttribute('href'));
+        expect(params.get('teamId')).toBe('team-1');
+        expect(params.get('eventId')).toBe('practice-uid-1');
+        expect(params.get('eventDate')).toBe('2030-04-04');
+        expect(params.get('eventDuration')).toBe('90');
+        expect(params.get('eventLocation')).toBe('Training Field');
+        expect(params.get('eventTitle')).toBe('Evening Practice');
+    });
+
+    test('suppresses tracked and conflicting imports while rendering cancelled rows without actions', async ({ page }) => {
+        await page.addInitScript((state) => {
+            window.__editScheduleTestState = state;
+            window.HTMLElement.prototype.scrollIntoView = function scrollIntoView() {};
+        }, buildState({
+            dbEvents: [
+                {
+                    id: 'db-existing-game',
+                    type: 'game',
+                    date: '2030-04-06T18:00:00.000Z',
+                    opponent: 'Existing Opponent',
+                    location: 'Main Field'
+                }
+            ],
+            trackedUids: ['tracked-uid'],
+            calendarEventsByUrl: {
+                'https://calendar.test/team.ics': [
+                    {
+                        uid: 'tracked-uid',
+                        dtstart: '2030-04-05T18:00:00.000Z',
+                        dtend: '2030-04-05T20:00:00.000Z',
+                        summary: 'Wildcats vs Tigers',
+                        location: 'Field 1'
+                    },
+                    {
+                        uid: 'conflict-uid',
+                        dtstart: '2030-04-06T18:00:30.000Z',
+                        dtend: '2030-04-06T20:00:30.000Z',
+                        summary: 'Wildcats vs Bears',
+                        location: 'Field 2'
+                    },
+                    {
+                        uid: 'cancelled-uid',
+                        dtstart: '2030-04-07T18:00:00.000Z',
+                        dtend: '2030-04-07T20:00:00.000Z',
+                        summary: '[CANCELED] Wildcats vs Storm',
+                        location: 'Field 3',
+                        status: 'CANCELLED'
+                    }
+                ]
+            }
+        }));
+
+        await page.goto(`${serverOrigin}/edit-schedule.html#teamId=team-1`, { waitUntil: 'domcontentloaded' });
+
+        const scheduleList = page.locator('#schedule-list');
+        await expect(scheduleList).toContainText('Storm');
+        await expect(scheduleList).toContainText('Cancelled');
+        await expect(scheduleList).not.toContainText('Tigers');
+        await expect(scheduleList).not.toContainText('Bears');
+
+        const cancelledRow = scheduleList.locator('div').filter({ hasText: 'Storm' }).first();
+        await expect(cancelledRow).not.toContainText('Track');
+        await expect(cancelledRow).not.toContainText('Plan Practice');
+    });
+});

--- a/tests/unit/edit-schedule-calendar-import.test.js
+++ b/tests/unit/edit-schedule-calendar-import.test.js
@@ -49,6 +49,7 @@ describe('edit schedule calendar import helpers', () => {
         const importedPractice = {
             uid: 'new-practice-uid',
             dtstart: new Date('2026-03-28T17:30:00.000Z'),
+            dtend: new Date('2026-03-28T19:00:00.000Z'),
             summary: 'Team Practice',
             location: 'Gym'
         };
@@ -85,6 +86,7 @@ describe('edit schedule calendar import helpers', () => {
                 isPractice: true,
                 opponent: 'Team Practice',
                 location: 'Gym',
+                end: importedPractice.dtend,
                 calendarEvent: importedPractice
             })
         ]);


### PR DESCRIPTION
Closes #492

## What changed
- added a focused Playwright spec for `edit-schedule.html` that boots the real page with mocked calendar imports and verifies imported practice/game row behavior from `loadSchedule()` through `renderCalendarEvent()`
- covered the coach-visible cases called out in the issue: imported practice planning CTA/link context, tracked UID suppression, DB conflict suppression, and cancelled imported rows without action buttons
- fixed the calendar import merge helper to preserve imported `dtend` so practice planning links keep the expected duration context
- extended the existing unit helper test to assert imported practice rows retain their end time during merge

## Why
- imported calendar rows currently had no browser-level regression coverage, so silent schedule import/render regressions could ship undetected
- preserving `dtend` is required for imported practice rows to carry full planning context into `drills.html`

## Validation
- passed: `pnpm exec vitest run tests/unit/edit-schedule-calendar-import.test.js --reporter=dot`
- added: `tests/smoke/edit-schedule-calendar-import.spec.js`
- note: Playwright execution in this runner is blocked by missing system browser libraries, so the new browser spec could not be executed locally here