### PR TITLE
Add live viewer opponent stats contract coverage

### DIFF
--- a/docs/pr-notes/runs/497-ci-fix-20260404T043144Z/architecture.md
+++ b/docs/pr-notes/runs/497-ci-fix-20260404T043144Z/architecture.md
@@ -1,0 +1,9 @@
+Objective: restore PR #497 unit-test stability with the smallest change.
+
+Current state: `tests/unit/live-game-replay-init.test.js` rewrites `js/live-game.js` imports into injected dependency objects before evaluating the module source with `AsyncFunction`.
+Proposed state: keep the production module unchanged and update the test harness so its rewrite logic matches the current `live-game-state` import contract.
+
+Risk surface: test-only change, no runtime code path changes, no tenant or data-plane blast radius.
+Assumptions: the CI failure is isolated to this brittle import-rewrite mismatch and no production behavior regression is implied by the log.
+
+Recommendation: patch the test harness instead of `js/live-game.js` because the application import is valid and the failure only exists in the synthetic evaluation path.

--- a/docs/pr-notes/runs/497-ci-fix-20260404T043144Z/code-plan.md
+++ b/docs/pr-notes/runs/497-ci-fix-20260404T043144Z/code-plan.md
@@ -1,0 +1,6 @@
+Thinking level: low. The failure is a direct syntax break in a test harness caused by source/test drift.
+
+Implementation steps:
+1. Update the `live-game-state` import rewrite in `tests/unit/live-game-replay-init.test.js` to include `renderOpponentStatsCards` and use a regex so version bumps do not break the fixture.
+2. Add a no-op `renderOpponentStatsCards` stub to the injected `deps.liveGameState` object.
+3. Run the targeted unit test file and commit the scoped fix if green.

--- a/docs/pr-notes/runs/497-ci-fix-20260404T043144Z/qa.md
+++ b/docs/pr-notes/runs/497-ci-fix-20260404T043144Z/qa.md
@@ -1,0 +1,7 @@
+Root cause under test: `live-game.js` now imports `renderOpponentStatsCards`, but the replay init test still matches the prior exact import string, leaving an `import` statement in the generated source and causing `AsyncFunction` to fail parse.
+
+Validation plan:
+- Run `vitest` for `tests/unit/live-game-replay-init.test.js`.
+- Confirm the file parses and replay-specific assertions still pass.
+
+Blast radius: unit-test fixture only. No user-facing behavior or Firebase integration changes.

--- a/docs/pr-notes/runs/497-remediator-20260404T044311Z/architecture.md
+++ b/docs/pr-notes/runs/497-remediator-20260404T044311Z/architecture.md
@@ -1,0 +1,5 @@
+# Architecture
+
+- Current state: tests build AsyncFunction source by string-replacing ESM imports in js/live-game.js.
+- Proposed state: replay-init import rewrite is updated to match the current state import or generalized to avoid future breakage from named import list changes.
+- Blast radius: test-only transformation path; production module code should remain untouched unless needed for parity.

--- a/docs/pr-notes/runs/497-remediator-20260404T044311Z/code-plan.md
+++ b/docs/pr-notes/runs/497-remediator-20260404T044311Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code Plan
+
+1. Inspect js/live-game.js and tests/unit/live-game-replay-init.test.js.
+2. Make the smallest test-transform change that handles the current import signature robustly.
+3. Run the affected test command.
+4. Stage and commit only the scoped fix.

--- a/docs/pr-notes/runs/497-remediator-20260404T044311Z/qa.md
+++ b/docs/pr-notes/runs/497-remediator-20260404T044311Z/qa.md
@@ -1,0 +1,5 @@
+# QA
+
+- Validate the affected unit test file directly.
+- If the repo exposes a broader related test command, prefer the narrowest command covering replay-init.
+- Confirm no SyntaxError from leftover import statements in AsyncFunction source.

--- a/docs/pr-notes/runs/497-remediator-20260404T044311Z/requirements.md
+++ b/docs/pr-notes/runs/497-remediator-20260404T044311Z/requirements.md
@@ -1,0 +1,7 @@
+# Requirements
+
+- Objective: fix PR #497 review feedback in live-game replay init transform.
+- Current state: test transform rewrites a hard-coded import signature that no longer matches source after adding renderOpponentStatsCards.
+- Proposed state: transform matches current import or is resilient to import-list changes, with no unrelated behavior changes.
+- Risk surface: limited to replay-init unit test harness and live-game replay module loading.
+- Assumptions: only this thread is unresolved; minimal targeted fix is preferred.

--- a/docs/pr-notes/runs/issue-487-fixer-20260404T042502Z/architecture.md
+++ b/docs/pr-notes/runs/issue-487-fixer-20260404T042502Z/architecture.md
@@ -1,0 +1,20 @@
+Decision: fix the viewer contract in a small pure helper, then call it from `live-game.js`.
+
+Why:
+- The bug boundary is not tracker persistence.
+- Existing tests already validate tracker-side hydration and event ingestion.
+- A helper in `live-game-state.js` keeps alias mapping and fallback `FLS` injection in one place without changing generic lineup columns.
+
+Current state:
+- `normalizeLiveStatColumns()` normalizes configured labels only.
+- `renderStats()` in `live-game.js` renders opponent stats directly from `state.statColumns`.
+- If fouls are persisted but the config omits a fouls label, the viewer omits the foul stat entirely.
+
+Proposed state:
+- Add a viewer-specific opponent column resolver that appends `FLS` once when opponent stats exist and no foul alias is configured.
+- Add a pure HTML renderer for opponent cards so the contract is unit-testable.
+
+Blast radius:
+- `js/live-game-state.js`
+- `js/live-game.js`
+- new unit test coverage only

--- a/docs/pr-notes/runs/issue-487-fixer-20260404T042502Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-487-fixer-20260404T042502Z/code-plan.md
@@ -1,0 +1,10 @@
+Thinking level: medium
+Reason: single-path rendering contract with existing helper structure and low blast radius.
+
+Plan:
+1. Add unit tests for viewer opponent rendering contract in `tests/unit/live-game-state.test.js`.
+2. Run the targeted test file to confirm failure before implementation.
+3. Add a pure opponent-render helper in `js/live-game-state.js`.
+4. Switch `js/live-game.js` to use the helper.
+5. Run targeted tests, then the broader unit subset around live game and tracker helpers.
+6. Commit with issue reference.

--- a/docs/pr-notes/runs/issue-487-fixer-20260404T042502Z/qa.md
+++ b/docs/pr-notes/runs/issue-487-fixer-20260404T042502Z/qa.md
@@ -1,0 +1,12 @@
+Test strategy:
+- Reproduce with persisted opponent snapshot data, not live event accumulation.
+- Cover both missing-fouls-column fallback and explicit foul alias mapping.
+
+Primary assertions:
+- Rendered markup includes opponent `name`, `number`, and `photoUrl`.
+- When configured columns omit fouls, rendered markup still shows `FLS` with the persisted `fouls` value.
+- When configured columns use `FOULS` or `FLS`, the renderer maps those labels to `player.fouls` and never prints `0` for a non-zero persisted foul count.
+
+Regression guardrails:
+- Do not change generic home lineup column normalization.
+- Keep fallback empty-state output for no opponent stats.

--- a/docs/pr-notes/runs/issue-487-fixer-20260404T042502Z/requirements.md
+++ b/docs/pr-notes/runs/issue-487-fixer-20260404T042502Z/requirements.md
@@ -1,0 +1,23 @@
+Objective: protect the live viewer contract for persisted opponent stats.
+
+Current state:
+- Tracker persistence stores opponent identity fields plus numeric stats, with fouls written separately.
+- Viewer rendering trusts configured stat columns and has no contract test tying saved opponent snapshots to rendered output.
+
+Proposed state:
+- Add a unit-level contract test around the viewer-facing opponent panel output.
+- Require persisted opponent identity and fouls to render even when configured columns omit fouls.
+
+Risk surface:
+- Live viewer only.
+- Blast radius is limited to opponent stats rendering on `live-game.html`.
+
+Assumptions:
+- Opponent snapshots keep `name`, `number`, `photoUrl`, and `fouls` in Firestore.
+- Viewer should show fouls as `FLS` when the config omits a fouls column.
+
+Recommendation:
+- Extract the opponent-panel rendering contract into a pure helper and test alias handling there.
+
+Success measure:
+- A persisted opponent snapshot with non-zero fouls renders identity plus the foul value on the viewer path.

--- a/js/live-game-state.js
+++ b/js/live-game-state.js
@@ -192,6 +192,58 @@ export function renderViewerLineupSections({
   };
 }
 
+export function resolveOpponentStatColumns(statColumns = [], opponentStats = {}) {
+  const columns = normalizeLiveStatColumns(statColumns);
+  const hasFoulAlias = columns.some((column) => statKeyMap[column] === 'fouls');
+  const hasOpponentEntries = Object.keys(opponentStats || {}).length > 0;
+
+  if (!hasFoulAlias && hasOpponentEntries) {
+    return [...columns, 'FLS'];
+  }
+
+  return columns;
+}
+
+export function renderOpponentStatsCards({
+  opponentStats = {},
+  statColumns = [],
+  lastStatChange = null
+} = {}) {
+  const oppEntries = Object.entries(opponentStats || {});
+  if (!oppEntries.length) {
+    return '<div class="text-sand/40 text-xs">No opponent stats yet</div>';
+  }
+
+  const columns = resolveOpponentStatColumns(statColumns, opponentStats);
+  return oppEntries.map(([id, player]) => {
+    const highlight = lastStatChange?.isOpponent && lastStatChange?.playerId === id;
+    const nameClass = highlight ? 'text-coral' : 'text-sand';
+    const statClass = highlight ? 'text-coral' : 'text-sand';
+    const statItems = columns.map((column) => {
+      const key = statKeyMap[column] || column.toLowerCase();
+      const value = player?.[key] || 0;
+      return `<span class="${statClass}">${value} ${escapeHtml(column)}</span>`;
+    }).join('');
+    const initial = escapeHtml((player?.name || 'O')[0]);
+    const avatar = player?.photoUrl
+      ? `<img src="${escapeHtml(player.photoUrl)}" class="w-6 h-6 rounded-full object-cover" alt="">`
+      : `<div class="w-6 h-6 rounded-full bg-coral/20 text-coral text-[10px] flex items-center justify-center">${initial}</div>`;
+
+    return `
+      <div class="bg-slate/50 rounded-lg px-3 py-2">
+        <div class="flex items-center gap-2 min-w-0">
+          ${avatar}
+          <span class="text-coral font-mono text-xs">#${escapeHtml(player?.number || '')}</span>
+          <span class="${nameClass} text-xs truncate">${escapeHtml(player?.name || 'Opponent')}</span>
+        </div>
+        <div class="mt-2 flex flex-wrap gap-2 text-[11px] text-sand/70">
+          ${statItems}
+        </div>
+      </div>
+    `;
+  }).join('');
+}
+
 export function applyResetEventState(currentState, event) {
   const period = event?.period || currentState?.period || getDefaultLivePeriod({
     sport: event?.sport || currentState?.sport,

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -30,7 +30,7 @@ import {
 import { MAX_HIGHLIGHT_CLIP_MS, buildHighlightShareUrl, createHighlightClipDraft, resolveReplayVideoOptions, shouldReloadVideoPlayback } from './live-game-video.js?v=2';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
-import { resolveOpponentDisplayName, normalizeLiveStatColumns, resolveLiveStatColumns, renderViewerLineupSections, applyResetEventState, applyViewerEventToState, shouldResetViewerFromGameDoc, collectVisibleLiveEventsSequentially } from './live-game-state.js?v=5';
+import { resolveOpponentDisplayName, normalizeLiveStatColumns, resolveLiveStatColumns, renderViewerLineupSections, renderOpponentStatsCards, applyResetEventState, applyViewerEventToState, shouldResetViewerFromGameDoc, collectVisibleLiveEventsSequentially } from './live-game-state.js?v=5';
 import { getDefaultLivePeriod } from './live-sport-config.js?v=1';
 
 const state = {
@@ -701,34 +701,11 @@ function renderPlayByPlay(event, isNew = false) {
 
 function renderStats() {
   if (!els.opponentStats) return;
-  const oppEntries = Object.entries(state.opponentStats || {});
-  const columns = normalizeLiveStatColumns(state.statColumns);
-  els.opponentStats.innerHTML = oppEntries.map(([id, player]) => {
-    const highlight = state.lastStatChange?.isOpponent && state.lastStatChange?.playerId === id;
-    const nameClass = highlight ? 'text-coral' : 'text-sand';
-    const statClass = highlight ? 'text-coral' : 'text-sand';
-    const statItems = columns.map(col => {
-      const key = statKeyMap[col] || col.toLowerCase();
-      const val = player[key] || 0;
-      return `<span class="${statClass}">${val} ${escapeHtml(col)}</span>`;
-    }).join('');
-    const initial = escapeHtml((player.name || 'O')[0]);
-    const avatar = player.photoUrl
-      ? `<img src="${escapeHtml(player.photoUrl)}" class="w-6 h-6 rounded-full object-cover" alt="">`
-      : `<div class="w-6 h-6 rounded-full bg-coral/20 text-coral text-[10px] flex items-center justify-center">${initial}</div>`;
-    return `
-      <div class="bg-slate/50 rounded-lg px-3 py-2">
-        <div class="flex items-center gap-2 min-w-0">
-          ${avatar}
-          <span class="text-coral font-mono text-xs">#${escapeHtml(player.number || '')}</span>
-          <span class="${nameClass} text-xs truncate">${escapeHtml(player.name || 'Opponent')}</span>
-        </div>
-        <div class="mt-2 flex flex-wrap gap-2 text-[11px] text-sand/70">
-          ${statItems}
-        </div>
-      </div>
-    `;
-  }).join('') || '<div class="text-sand/40 text-xs">No opponent stats yet</div>';
+  els.opponentStats.innerHTML = renderOpponentStatsCards({
+    opponentStats: state.opponentStats,
+    statColumns: state.statColumns,
+    lastStatChange: state.lastStatChange
+  });
 }
 
 function renderLineup() {

--- a/tests/unit/live-game-replay-init.test.js
+++ b/tests/unit/live-game-replay-init.test.js
@@ -252,8 +252,8 @@ function buildModuleSource() {
             'const { getApp } = deps.firebaseApp;'
         )
         .replace(
-            /import\s+\{\s*resolveOpponentDisplayName,\s*normalizeLiveStatColumns,\s*resolveLiveStatColumns,\s*renderViewerLineupSections,\s*renderOpponentStatsCards,\s*applyResetEventState,\s*applyViewerEventToState,\s*shouldResetViewerFromGameDoc,\s*collectVisibleLiveEventsSequentially\s*\}\s+from\s+'\.\/live-game-state\.js\?v=\d+';/,
-            'const { resolveOpponentDisplayName, normalizeLiveStatColumns, resolveLiveStatColumns, renderViewerLineupSections, renderOpponentStatsCards, applyResetEventState, applyViewerEventToState, shouldResetViewerFromGameDoc, collectVisibleLiveEventsSequentially } = deps.liveGameState;'
+            /import\s+\{([\s\S]*?)\}\s+from\s+'\.\/live-game-state\.js\?v=\d+';/,
+            (_, imports) => `const { ${imports.replace(/\s+/g, ' ').trim()} } = deps.liveGameState;`
         )
         .replace(
             "import { getDefaultLivePeriod } from './live-sport-config.js?v=1';",

--- a/tests/unit/live-game-replay-init.test.js
+++ b/tests/unit/live-game-replay-init.test.js
@@ -252,8 +252,8 @@ function buildModuleSource() {
             'const { getApp } = deps.firebaseApp;'
         )
         .replace(
-            "import { resolveOpponentDisplayName, normalizeLiveStatColumns, resolveLiveStatColumns, renderViewerLineupSections, applyResetEventState, applyViewerEventToState, shouldResetViewerFromGameDoc, collectVisibleLiveEventsSequentially } from './live-game-state.js?v=5';",
-            'const { resolveOpponentDisplayName, normalizeLiveStatColumns, resolveLiveStatColumns, renderViewerLineupSections, applyResetEventState, applyViewerEventToState, shouldResetViewerFromGameDoc, collectVisibleLiveEventsSequentially } = deps.liveGameState;'
+            /import\s+\{\s*resolveOpponentDisplayName,\s*normalizeLiveStatColumns,\s*resolveLiveStatColumns,\s*renderViewerLineupSections,\s*renderOpponentStatsCards,\s*applyResetEventState,\s*applyViewerEventToState,\s*shouldResetViewerFromGameDoc,\s*collectVisibleLiveEventsSequentially\s*\}\s+from\s+'\.\/live-game-state\.js\?v=\d+';/,
+            'const { resolveOpponentDisplayName, normalizeLiveStatColumns, resolveLiveStatColumns, renderViewerLineupSections, renderOpponentStatsCards, applyResetEventState, applyViewerEventToState, shouldResetViewerFromGameDoc, collectVisibleLiveEventsSequentially } = deps.liveGameState;'
         )
         .replace(
             "import { getDefaultLivePeriod } from './live-sport-config.js?v=1';",
@@ -440,6 +440,7 @@ async function bootReplayPage({ replayEvents }) {
                 onCourtHtml: '',
                 benchHtml: ''
             }),
+            renderOpponentStatsCards: () => '',
             applyResetEventState() {},
             shouldResetViewerFromGameDoc: () => false,
             collectVisibleLiveEventsSequentially: (events) => events

--- a/tests/unit/live-game-state.test.js
+++ b/tests/unit/live-game-state.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveOpponentDisplayName, normalizeLiveStatColumns, resolveLiveStatConfig, resolvePreferredStatConfigId, resolveLiveStatColumns, applyResetEventState, shouldResetViewerFromGameDoc, isLiveEventVisibleForResetBoundary, collectVisibleLiveEventsSequentially } from '../../js/live-game-state.js';
+import { resolveOpponentDisplayName, normalizeLiveStatColumns, resolveLiveStatConfig, resolvePreferredStatConfigId, resolveLiveStatColumns, renderOpponentStatsCards, applyResetEventState, shouldResetViewerFromGameDoc, isLiveEventVisibleForResetBoundary, collectVisibleLiveEventsSequentially } from '../../js/live-game-state.js';
 
 describe('live game state helpers', () => {
   it('prefers linked opponent team name when opponent is missing', () => {
@@ -58,6 +58,55 @@ describe('live game state helpers', () => {
       ],
       team: { sport: 'Soccer' }
     })).toBe('cfg-only');
+  });
+
+  it('renders persisted opponent identity and injects FLS when config omits fouls', () => {
+    const html = renderOpponentStatsCards({
+      opponentStats: {
+        opp1: {
+          name: 'Jordan Lee',
+          number: '21',
+          photoUrl: 'https://img.test/opp1.png',
+          pts: 12,
+          ast: 3,
+          fouls: 4
+        }
+      },
+      statColumns: ['PTS', 'AST']
+    });
+
+    expect(html).toContain('Jordan Lee');
+    expect(html).toContain('#21');
+    expect(html).toContain('https://img.test/opp1.png');
+    expect(html).toContain('12 PTS');
+    expect(html).toContain('3 AST');
+    expect(html).toContain('4 FLS');
+  });
+
+  it('maps foul aliases to persisted opponent fouls without zeroing the value', () => {
+    const foulsHtml = renderOpponentStatsCards({
+      opponentStats: {
+        opp1: {
+          name: 'Jordan Lee',
+          fouls: 5
+        }
+      },
+      statColumns: ['PTS', 'FOULS']
+    });
+
+    const flsHtml = renderOpponentStatsCards({
+      opponentStats: {
+        opp1: {
+          name: 'Jordan Lee',
+          fouls: 5
+        }
+      },
+      statColumns: ['PTS', 'FLS']
+    });
+
+    expect(foulsHtml).toContain('5 FOULS');
+    expect(flsHtml).toContain('5 FLS');
+    expect(flsHtml).not.toContain('0 FLS');
   });
 
   it('resets live viewer state from reset event payload', () => {


### PR DESCRIPTION
Closes #487

## What changed
- added live viewer contract coverage for persisted opponent stats in `tests/unit/live-game-state.test.js`
- extracted opponent stats rendering into a pure helper in `js/live-game-state.js` so the viewer contract is testable
- updated `js/live-game.js` to use the shared helper for opponent stat card rendering
- recorded requirements, architecture, QA, and code-plan notes for this run under `docs/pr-notes/runs/issue-487-fixer-20260404T042502Z/`

## Why
The tracker already persisted opponent identity fields and fouls, but the live viewer path had no test tying that persisted shape to the rendered opponent panel. This change covers the user-facing contract so persisted opponent name, number, photo, and fouls render correctly, including `FLS` fallback injection and `FOULS`/`FLS` alias mapping.