### PR TITLE
Reset Game Plan state when switching games

### DIFF
--- a/docs/pr-notes/runs/issue-488-fixer-20260404T043058Z/architecture.md
+++ b/docs/pr-notes/runs/issue-488-fixer-20260404T043058Z/architecture.md
@@ -1,0 +1,24 @@
+Objective: contain stale state by removing cross-game reuse of the module-level `gamePlan` object.
+
+Evidence:
+- `game-plan.html` initializes `gamePlan` once at module scope.
+- `loadGame(game)` currently merges saved plans with `gamePlan = { ...gamePlan, ...game.gamePlan }`.
+- The `else` branch only changes defaults like `formationId` and `subTimes`, leaving `lineups` intact.
+- Save writes the full in-memory `gamePlan` through `updateGame(currentTeamId, currentGameId, { gamePlan })`.
+
+Architecture decision:
+- Introduce a small factory/helper that returns a fresh game-plan baseline.
+- In `loadGame(game)`, rebuild `gamePlan` from defaults per selected sport, then merge persisted `game.gamePlan`.
+
+Why this is the simplest viable path:
+- It preserves existing page structure, UI flow, and Firestore payload shape.
+- It reduces blast radius to one page and one state object.
+- It avoids a larger refactor to externalize planner state.
+
+Controls:
+- Persisted plans keep precedence over defaults.
+- Unsaved games start from explicit defaults plus empty `lineups`.
+- Regression tests cover both display-state and save-payload controls.
+
+Rollback:
+- Revert the helper/reset patch in `game-plan.html` if any unexpected planner initialization issue appears.

--- a/docs/pr-notes/runs/issue-488-fixer-20260404T043058Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-488-fixer-20260404T043058Z/code-plan.md
@@ -1,0 +1,13 @@
+Thinking level: medium
+Reason: one-page state bug with a narrow persistence blast radius and an existing inline-page unit-test pattern.
+
+Implementation plan:
+1. Extract `loadGame(game)` and save-click handler behavior into a new Vitest regression file that uses page-source evaluation plus DOM stubs.
+2. Write assertions that reproduce the stale `lineups` carryover and the incorrect save payload for Game B.
+3. Patch `game-plan.html` with a fresh game-plan factory/reset path, keeping the data shape unchanged.
+4. Run the new regression file and the existing `tests/unit/game-plan-interop.test.js`.
+5. Commit the docs, test, and page fix together with an issue-referencing message.
+
+Tradeoffs:
+- This is not a full browser E2E test, but it exercises the real inline page code path under automation with much lower setup cost.
+- A helper-based reset is slightly more code than ad hoc field clearing, but it is easier to reason about and less likely to miss future fields.

--- a/docs/pr-notes/runs/issue-488-fixer-20260404T043058Z/qa.md
+++ b/docs/pr-notes/runs/issue-488-fixer-20260404T043058Z/qa.md
@@ -1,0 +1,18 @@
+Test objective: prove stale game-plan state does not survive a game switch and is not persisted by save.
+
+Primary regression scenarios:
+1. Load a game with a saved lineup, then switch to a game with no `gamePlan`; expect empty lineups and no carried-over assignment chips.
+2. After the switch, save the unsaved game; expect `updateGame` payload to exclude the prior game's lineup keys and player ids.
+
+Coverage approach:
+- Use Vitest and the repo's inline-page extraction pattern to evaluate `loadGame` and the save click handler from `game-plan.html`.
+- Stub minimal DOM elements and page dependencies needed by these flows.
+
+Validation commands:
+- `npm test -- tests/unit/game-plan-switching.test.js` is not supported by this repo script shape, so run direct Vitest commands instead.
+- `node ./node_modules/vitest/vitest.mjs run tests/unit/game-plan-switching.test.js`
+- `node ./node_modules/vitest/vitest.mjs run tests/unit/game-plan-interop.test.js`
+
+Exit criteria:
+- New regression test fails before the fix and passes after the fix.
+- Adjacent existing Game Plan helper test still passes.

--- a/docs/pr-notes/runs/issue-488-fixer-20260404T043058Z/requirements.md
+++ b/docs/pr-notes/runs/issue-488-fixer-20260404T043058Z/requirements.md
@@ -1,0 +1,28 @@
+Objective: prevent stale Game Plan assignments from leaking between games when a coach switches selections on `game-plan.html`.
+
+Current state:
+- Selecting Game A with `game.gamePlan.lineups` seeds the shared module-level `gamePlan`.
+- Switching to Game B without `game.gamePlan` preserves `lineups` and prior shape because only sport defaults are reassigned.
+
+Proposed state:
+- Every game selection starts from a clean per-game plan baseline.
+- Saved games hydrate from their persisted plan only.
+- Unsaved games show the correct formation defaults with an empty substitution matrix.
+
+Risk surface and blast radius:
+- Real coach workflow can display and save the wrong lineup to the wrong game.
+- Blast radius is limited to `game-plan.html` selection and save flow, but persisted bad plans create downstream rotation errors.
+
+Assumptions:
+- Teams still use soccer and basketball defaults defined in `game-plan.html`.
+- Existing saved plans should continue to render without migration.
+- Unit coverage that evaluates inline page functions is acceptable in this repo because there is no dedicated browser harness for this page.
+
+Recommendation:
+- Reset `gamePlan` from a clean default object on every `loadGame(game)` call, then merge persisted `game.gamePlan` if present.
+- Add regression coverage for both render state and save payload after switching from a saved game to an unsaved game.
+
+Success metrics:
+- Switching from a saved game to an unsaved game leaves `gamePlan.lineups` empty.
+- The lineup step does not render prior player assignments for the second game.
+- Saving the second game sends an empty or newly created lineup only, never stale keys from the first game.

--- a/game-plan.html
+++ b/game-plan.html
@@ -310,14 +310,38 @@
         let combinedGames = [];
         let plannerInitialized = false;
 
+        function createDefaultGamePlan(sportName = null) {
+            const gamePlanDefaults = {
+                numPeriods: 2,
+                periodDuration: 25,
+                subTimes: [7, 14, 21],
+                formationId: null,
+                lineups: {}
+            };
+
+            const sport = sportName?.toLowerCase();
+            if (sport === 'basketball') {
+                return {
+                    ...gamePlanDefaults,
+                    numPeriods: 4,
+                    periodDuration: 8,
+                    subTimes: [4],
+                    formationId: 'basketball-5v5'
+                };
+            }
+
+            if (sport === 'soccer') {
+                return {
+                    ...gamePlanDefaults,
+                    formationId: 'soccer-9v9'
+                };
+            }
+
+            return gamePlanDefaults;
+        }
+
         // Game plan state
-        let gamePlan = {
-            numPeriods: 2,
-            periodDuration: 25,
-            subTimes: [7, 14, 21],
-            formationId: null,
-            lineups: {} // { 'period-time': { positionId: playerId } }
-        };
+        let gamePlan = createDefaultGamePlan();
 
         let draggedPlayerId = null;
 
@@ -468,26 +492,14 @@
                 <span class="text-sm text-gray-600">${formatDate(date)} @ ${formatTime(date)}</span>
             `;
 
-            // Load existing game plan if it exists
-            if (game.gamePlan) {
-                gamePlan = { ...gamePlan, ...game.gamePlan };
-            } else {
-                // Set defaults based on team sport
-                if (currentTeam.sport) {
-                    const sport = currentTeam.sport.toLowerCase();
-                    if (sport === 'basketball') {
-                        gamePlan.numPeriods = 4;
-                        gamePlan.periodDuration = 8;
-                        gamePlan.subTimes = [4];
-                        gamePlan.formationId = 'basketball-5v5';
-                    } else if (sport === 'soccer') {
-                        gamePlan.numPeriods = 2;
-                        gamePlan.periodDuration = 25;
-                        gamePlan.subTimes = [7, 14, 21];
-                        gamePlan.formationId = 'soccer-9v9';
-                    }
+            const baseGamePlan = createDefaultGamePlan(currentTeam?.sport);
+            gamePlan = game.gamePlan
+                ? {
+                    ...baseGamePlan,
+                    ...game.gamePlan,
+                    lineups: { ...(game.gamePlan.lineups || {}) }
                 }
-            }
+                : baseGamePlan;
 
             recentAssignments.clear();
             intervalsCache = [];

--- a/tests/unit/game-plan-switching.test.js
+++ b/tests/unit/game-plan-switching.test.js
@@ -1,0 +1,233 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readGamePlanPage() {
+    return readFileSync(new URL('../../game-plan.html', import.meta.url), 'utf8');
+}
+
+function extractLoadGameBody() {
+    const source = readGamePlanPage();
+    const match = source.match(/async function loadGame\(game\) \{([\s\S]*?)\n        \}\n\n        function renderPlayerPool/);
+    expect(match, 'loadGame should exist').toBeTruthy();
+    return match[1];
+}
+
+function extractCreateDefaultGamePlanSource() {
+    const source = readGamePlanPage();
+    const match = source.match(/function createDefaultGamePlan\(sportName = null\) \{[\s\S]*?\n        \}/);
+    expect(match, 'createDefaultGamePlan should exist').toBeTruthy();
+    return match[0];
+}
+
+function extractSavePlanBody() {
+    const source = readGamePlanPage();
+    const match = source.match(/document\.getElementById\('save-plan-btn'\)\?\.addEventListener\('click', async \(\) => \{([\s\S]*?)\n        \}\);/);
+    expect(match, 'save-plan handler should exist').toBeTruthy();
+    return match[1];
+}
+
+function createClassList() {
+    const classes = new Set(['hidden']);
+    return {
+        add: (name) => classes.add(name),
+        remove: (name) => classes.delete(name),
+        contains: (name) => classes.has(name)
+    };
+}
+
+function createElement() {
+    return {
+        classList: createClassList(),
+        value: '',
+        innerHTML: '',
+        disabled: false,
+        title: ''
+    };
+}
+
+function createDocument() {
+    const elements = new Map();
+    return {
+        elements,
+        getElementById(id) {
+            if (!elements.has(id)) {
+                elements.set(id, createElement());
+            }
+            return elements.get(id);
+        }
+    };
+}
+
+function buildHarness(overrides = {}) {
+    const createDefaultGamePlanSource = extractCreateDefaultGamePlanSource();
+    const loadGameBody = extractLoadGameBody();
+    const savePlanBody = extractSavePlanBody();
+    const document = createDocument();
+
+    [
+        'selected-game-info',
+        'game-details',
+        'save-plan-btn',
+        'num-periods',
+        'period-duration',
+        'sub-times-input',
+        'planning-wizard',
+        'step-formation',
+        'step-periods',
+        'step-lineup'
+    ].forEach((id) => document.getElementById(id));
+
+    const deps = {
+        currentTeamId: 'team-1',
+        currentTeam: { sport: 'Soccer' },
+        gamePlan: {
+            numPeriods: 2,
+            periodDuration: 25,
+            subTimes: [7, 14, 21],
+            formationId: null,
+            lineups: {}
+        },
+        FORMATIONS: {
+            'soccer-9v9': { name: 'Soccer 9v9', positions: [{ id: 'keeper', name: 'Keeper' }] },
+            'basketball-5v5': { name: 'Basketball 5v5', positions: [{ id: 'pg', name: 'Point Guard' }] }
+        },
+        document,
+        recentAssignments: new Map([['stale-key', Date.now()]]),
+        intervalsCache: ['stale'],
+        lastSelectedPlayerId: 'old-player',
+        dragSourceCellKey: '1-7-keeper',
+        formatDate: () => 'Apr 4, 2026',
+        formatTime: () => '7:00 PM',
+        renderSubTimesDisplay: vi.fn(),
+        renderPlayerPool: vi.fn(),
+        renderSubMatrix: vi.fn(),
+        renderPlayingTimeSummary: vi.fn(),
+        updatePlanSummary: vi.fn(),
+        updateGame: vi.fn().mockResolvedValue(undefined),
+        alert: vi.fn(),
+        console: {
+            error: vi.fn()
+        },
+        ...overrides
+    };
+
+    const createHarness = new Function('deps', `
+        let currentTeamId = deps.currentTeamId;
+        let currentGameId = null;
+        let currentGame = null;
+        let currentTeam = deps.currentTeam;
+        let lastSelectedPlayerId = deps.lastSelectedPlayerId;
+        let intervalsCache = deps.intervalsCache;
+        const recentAssignments = deps.recentAssignments;
+        let dragSourceCellKey = deps.dragSourceCellKey;
+        let gamePlan = deps.gamePlan;
+        const FORMATIONS = deps.FORMATIONS;
+        const document = deps.document;
+        const formatDate = deps.formatDate;
+        const formatTime = deps.formatTime;
+        const renderSubTimesDisplay = deps.renderSubTimesDisplay;
+        const renderPlayerPool = deps.renderPlayerPool;
+        const renderSubMatrix = deps.renderSubMatrix;
+        const renderPlayingTimeSummary = deps.renderPlayingTimeSummary;
+        const updatePlanSummary = deps.updatePlanSummary;
+        const updateGame = deps.updateGame;
+        const alert = deps.alert;
+        const console = deps.console;
+
+        ${createDefaultGamePlanSource}
+
+        async function loadGame(game) {
+${loadGameBody}
+        }
+
+        async function clickSave() {
+${savePlanBody}
+        }
+
+        return {
+            loadGame,
+            clickSave,
+            getState: () => ({
+                currentGameId,
+                currentGame,
+                gamePlan,
+                lastSelectedPlayerId,
+                intervalsCache,
+                dragSourceCellKey
+            })
+        };
+    `);
+
+    return { deps, document, harness: createHarness(deps) };
+}
+
+describe('game plan game switching', () => {
+    it('clears saved lineup assignments when switching to a game without a plan', async () => {
+        const { harness, deps } = buildHarness();
+
+        await harness.loadGame({
+            id: 'game-a',
+            opponent: 'Sharks',
+            date: '2026-04-04T19:00:00.000Z',
+            gamePlan: {
+                numPeriods: 2,
+                periodDuration: 25,
+                subTimes: [7, 14, 21],
+                formationId: 'soccer-9v9',
+                lineups: {
+                    '1-7-keeper': 'player-1'
+                }
+            }
+        });
+
+        await harness.loadGame({
+            id: 'game-b',
+            opponent: 'Bears',
+            date: '2026-04-05T19:00:00.000Z'
+        });
+
+        expect(harness.getState().currentGameId).toBe('game-b');
+        expect(harness.getState().gamePlan.lineups).toEqual({});
+        expect(harness.getState().gamePlan.formationId).toBe('soccer-9v9');
+        expect(harness.getState().lastSelectedPlayerId).toBeNull();
+        expect(harness.getState().intervalsCache).toEqual([]);
+        expect(harness.getState().dragSourceCellKey).toBeNull();
+        expect(deps.recentAssignments.size).toBe(0);
+        expect(deps.renderSubMatrix).toHaveBeenCalledTimes(2);
+    });
+
+    it('saves the switched game without carrying over the previous game lineup payload', async () => {
+        const { harness, deps } = buildHarness();
+
+        await harness.loadGame({
+            id: 'game-a',
+            opponent: 'Sharks',
+            date: '2026-04-04T19:00:00.000Z',
+            gamePlan: {
+                numPeriods: 2,
+                periodDuration: 25,
+                subTimes: [7, 14, 21],
+                formationId: 'soccer-9v9',
+                lineups: {
+                    '1-7-keeper': 'player-1'
+                }
+            }
+        });
+
+        await harness.loadGame({
+            id: 'game-b',
+            opponent: 'Bears',
+            date: '2026-04-05T19:00:00.000Z'
+        });
+
+        await harness.clickSave();
+
+        expect(deps.updateGame).toHaveBeenCalledWith('team-1', 'game-b', {
+            gamePlan: expect.objectContaining({
+                formationId: 'soccer-9v9',
+                lineups: {}
+            })
+        });
+        expect(deps.updateGame.mock.calls[0][2].gamePlan.lineups).not.toHaveProperty('1-7-keeper');
+    });
+});


### PR DESCRIPTION
Closes #488

## What changed
- added a targeted Vitest regression for `game-plan.html` that exercises switching from a saved game plan to an unsaved game and verifies both rendered state and save payload behavior
- reset the in-page `gamePlan` state from fresh sport defaults on every game selection before merging any persisted plan
- captured the run synthesis artifacts for requirements, architecture, QA, and code plan under `docs/pr-notes/runs/issue-488-fixer-20260404T043058Z/`

## Why
Selecting a saved game and then switching to a game without `game.gamePlan` reused stale module-level lineup state. That could show the wrong assignments in the substitution matrix and persist the previous game's lineup when saving the second game.