### PR TITLE
Add rideshare child picker modal coverage

### DIFF
--- a/docs/pr-notes/runs/issue-493-fixer-20260404T043551Z/architecture.md
+++ b/docs/pr-notes/runs/issue-493-fixer-20260404T043551Z/architecture.md
@@ -1,0 +1,22 @@
+# Architecture Role Notes
+
+## Current State
+- Modal rideshare rendering in `parent-dashboard.html` computes selected child, request lookup, button visibility, and status copy inline inside the offer map.
+- Submission handling already lives in `js/parent-dashboard-rideshare-controls.js`.
+
+## Proposed State
+- Keep the HTML page as the integration layer.
+- Move the per-offer action-state computation into `js/parent-dashboard-rideshare-controls.js` so rendering and tests share the same decision logic.
+
+## Why This Path
+- It is the smallest change that makes the modal workflow testable without introducing a framework or rewriting the page.
+- It reduces drift between inline rendering logic and request submission logic by centralizing the selected-child state derivation in one module.
+
+## Blast Radius
+- `parent-dashboard.html`
+- `js/parent-dashboard-rideshare-controls.js`
+- rideshare unit tests only
+
+## Controls
+- Preserve existing helper APIs and Firestore request/cancel calls.
+- Do not change selection persistence or rideshare data-loading behavior.

--- a/docs/pr-notes/runs/issue-493-fixer-20260404T043551Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-493-fixer-20260404T043551Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Role Plan
+
+## Plan
+1. Add a failing unit test for multi-child modal action-state switching.
+2. Extract a helper from `js/parent-dashboard-rideshare-controls.js` that returns selected-child rideshare UI state for one offer.
+3. Update `parent-dashboard.html` to consume the helper instead of recalculating request/cancel/status state inline.
+4. Run focused rideshare tests, then the full unit suite if the targeted run is clean enough.
+
+## Notes
+- Requested orchestration skill files and `sessions_spawn` are not available in this environment, so this file records the synthesized code lane output directly.
+- Keep the patch minimal and avoid unrelated HTML cleanup.

--- a/docs/pr-notes/runs/issue-493-fixer-20260404T043551Z/qa.md
+++ b/docs/pr-notes/runs/issue-493-fixer-20260404T043551Z/qa.md
@@ -1,0 +1,18 @@
+# QA Role Notes
+
+## Coverage Gap
+- No test currently proves that modal child-picker changes update the rendered rideshare action state for the selected sibling.
+
+## Test Strategy
+- Add a unit test around extracted modal action-state logic:
+  - Child A selected with no request -> `Request Spot`, no status copy.
+  - Child B selected with existing parent request -> no `Request Spot`, `Cancel` visible, status copy references Child B.
+- Keep the existing request-handler payload test and strengthen it only if needed.
+- Add a wiring assertion that the dashboard HTML uses the extracted action-state helper.
+
+## Regression Guardrails
+- Preserve behavior for requestable vs non-requestable states based on `findRequestForChild` and `canRequestRide`.
+- Ensure the selected child name used in status copy matches the child that drove the action state.
+
+## Validation
+- Run focused vitest coverage for rideshare controls/wiring.

--- a/docs/pr-notes/runs/issue-493-fixer-20260404T043551Z/requirements.md
+++ b/docs/pr-notes/runs/issue-493-fixer-20260404T043551Z/requirements.md
@@ -1,0 +1,28 @@
+# Requirements Role Notes
+
+## Objective
+Add regression coverage for the Parent Dashboard rideshare modal so multi-child picker state, rendered action state, and submitted child payload stay aligned.
+
+## Current State
+- `parent-dashboard.html` renders rideshare controls inline and decides `Request Spot` vs `Cancel` from the currently selected child.
+- `js/parent-dashboard-rideshare-controls.js` already covers selection resolution and submit payload handling, but not the modal's rendered sibling-switching workflow.
+- Existing tests stop at helper/payload checks and do not assert rendered modal output for multiple eligible children.
+
+## Proposed State
+- Extract the per-offer child-selection action-state calculation into a testable helper.
+- Use that helper from the modal rendering path.
+- Add tests that prove switching the picker from one sibling to another flips the action and status copy for the selected child, and that request submission still uses the selected child.
+
+## Risk Surface
+- Blast radius is limited to Parent Dashboard rideshare controls.
+- No Firestore schema or API contract changes.
+- Main regression risk is accidentally changing request/cancel visibility for edge cases such as driver-owned offers, closed offers, or invalid child ids.
+
+## Assumptions
+- The intended behavior is one active rideshare action per selected child: unrequested siblings show `Request Spot`; siblings with an existing pending/confirmed request show `Cancel` and status text.
+- The extracted helper can be treated as the canonical source of truth for modal per-offer UI state.
+
+## Success Criteria
+- A unit test proves sibling switching changes the rendered action from `Request Spot` to `Cancel` and updates the selected-child status copy.
+- A unit test proves the request handler submits the picker-selected `{ childId, childName }`.
+- Relevant rideshare unit tests pass.

--- a/js/parent-dashboard-rideshare-controls.js
+++ b/js/parent-dashboard-rideshare-controls.js
@@ -1,3 +1,5 @@
+import { canRequestRide, findRequestForChild } from './rideshare-helpers.js';
+
 export function resolveSelectedRideChildId({
     includeChildPicker = false,
     selectedChildId = '',
@@ -43,6 +45,27 @@ export function resolveRideRequestSelection({
     return {
         childId,
         childName: selectedChild?.childName || defaultChildName || 'Player'
+    };
+}
+
+export function getRideOfferUiState({
+    offer = {},
+    parentUserId = '',
+    selectedChildId = '',
+    selectedChildName = '',
+    defaultChildName = 'Player'
+} = {}) {
+    const myRequest = findRequestForChild(offer, parentUserId, selectedChildId);
+    const canRequest = canRequestRide(offer, parentUserId, selectedChildId);
+    const requestableChildName = myRequest?.childName || selectedChildName || defaultChildName || 'Player';
+
+    return {
+        myRequest,
+        canRequest,
+        requestableChildName,
+        showRequestButton: canRequest,
+        showCancelButton: Boolean(myRequest),
+        statusText: myRequest ? `Your request for ${requestableChildName}: ${myRequest.status || 'pending'}` : ''
     };
 }
 

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -292,8 +292,8 @@
         import { filterVisiblePracticeSessions } from './js/parent-dashboard-practice-sessions.js?v=1';
         import { resolveRsvpPlayerIdsForSubmission, resolveMyRsvpByChildForGame } from './js/parent-dashboard-rsvp.js?v=5';
         import { createParentDashboardRsvpController } from './js/parent-dashboard-rsvp-controls.js?v=1';
-        import { getEventRideshareSummary, getOfferSeatInfo, canRequestRide, findRequestForChild } from './js/rideshare-helpers.js?v=1';
-        import { resolveSelectedRideChildId, createRideRequestHandlers } from './js/parent-dashboard-rideshare-controls.js?v=1';
+        import { getEventRideshareSummary, getOfferSeatInfo } from './js/rideshare-helpers.js?v=1';
+        import { resolveSelectedRideChildId, getRideOfferUiState, createRideRequestHandlers } from './js/parent-dashboard-rideshare-controls.js?v=1';
         import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
@@ -604,9 +604,14 @@
                             );
                             const selectedChild = childChoices.find((child) => child.childId === selectedChildId);
                             const selectedChildName = selectedChild?.childName || defaultChildName;
-                            const myRequest = findRequestForChild(offer, currentUserId, selectedChildId);
-                            const canRequest = canRequestRide(offer, currentUserId, selectedChildId);
-                            const requestableChildName = myRequest?.childName || selectedChildName;
+                            const rideOfferUiState = getRideOfferUiState({
+                                offer,
+                                parentUserId: currentUserId,
+                                selectedChildId,
+                                selectedChildName,
+                                defaultChildName
+                            });
+                            const { myRequest, canRequest, statusText } = rideOfferUiState;
                             return `
                                 <div class="rounded-lg border border-gray-200 bg-white p-2">
                                     <div class="flex items-center justify-between gap-2">
@@ -632,7 +637,7 @@
                                             ` : ''}
                                         </div>
                                     </div>
-                                    ${myRequest ? `<div class="text-[11px] mt-1 font-semibold ${myRequest.status === 'confirmed' ? 'text-emerald-700' : myRequest.status === 'waitlisted' ? 'text-amber-700' : myRequest.status === 'declined' ? 'text-red-700' : 'text-gray-600'}">Your request for ${escapeHtml(requestableChildName)}: ${escapeHtml(myRequest.status || 'pending')}</div>` : ''}
+                                    ${myRequest ? `<div class="text-[11px] mt-1 font-semibold ${myRequest.status === 'confirmed' ? 'text-emerald-700' : myRequest.status === 'waitlisted' ? 'text-amber-700' : myRequest.status === 'declined' ? 'text-red-700' : 'text-gray-600'}">${escapeHtml(statusText)}</div>` : ''}
                                     ${canManageOffer && offer.requests?.length
                                         ? `<div class="mt-2 pt-2 border-t border-gray-100 space-y-1">
                                             ${offer.requests.map((request) => `

--- a/tests/unit/parent-dashboard-rideshare-controls.test.js
+++ b/tests/unit/parent-dashboard-rideshare-controls.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
     createRideRequestHandlers,
+    getRideOfferUiState,
     resolveRideRequestSelection,
     resolveSelectedRideChildId
 } from '../../js/parent-dashboard-rideshare-controls.js';
@@ -37,6 +38,43 @@ describe('parent dashboard rideshare controls', () => {
         })).toEqual({
             childId: 'child-b',
             childName: 'Child B'
+        });
+    });
+
+    it('switches modal rideshare actions and status copy with the selected sibling', () => {
+        const offer = {
+            id: 'offer-1',
+            status: 'open',
+            driverUserId: 'driver-1',
+            seatCapacity: 3,
+            seatCountConfirmed: 0,
+            requests: [
+                { id: 'req-b', parentUserId: 'parent-1', childId: 'child-b', childName: 'Child B', status: 'pending' }
+            ]
+        };
+
+        expect(getRideOfferUiState({
+            offer,
+            parentUserId: 'parent-1',
+            selectedChildId: 'child-a',
+            selectedChildName: 'Child A'
+        })).toMatchObject({
+            canRequest: true,
+            showRequestButton: true,
+            showCancelButton: false,
+            statusText: ''
+        });
+
+        expect(getRideOfferUiState({
+            offer,
+            parentUserId: 'parent-1',
+            selectedChildId: 'child-b',
+            selectedChildName: 'Child B'
+        })).toMatchObject({
+            canRequest: false,
+            showRequestButton: false,
+            showCancelButton: true,
+            statusText: 'Your request for Child B: pending'
         });
     });
 

--- a/tests/unit/parent-dashboard-rideshare-wiring.test.js
+++ b/tests/unit/parent-dashboard-rideshare-wiring.test.js
@@ -33,6 +33,7 @@ describe('parent dashboard rideshare wiring', () => {
 
         expect(html).toContain("from './js/parent-dashboard-rideshare-controls.js?v=1'");
         expect(html).toContain('resolveSelectedRideChildId({');
+        expect(html).toContain('getRideOfferUiState({');
         expect(html).toContain('createRideRequestHandlers({');
         expect(html).toContain('selectedRideChildByOffer');
     });


### PR DESCRIPTION
Closes #493

## What changed
- added rideshare modal coverage for multi-child parent flows in `tests/unit/parent-dashboard-rideshare-controls.test.js`
- added a wiring assertion in `tests/unit/parent-dashboard-rideshare-wiring.test.js` so the dashboard keeps using the extracted rideshare UI-state helper
- extracted `getRideOfferUiState` in `js/parent-dashboard-rideshare-controls.js` and updated `parent-dashboard.html` to use it for per-child request/cancel/status rendering
- recorded synthesized requirements, architecture, QA, and code-plan notes in the required run artifact directory

## Why
The dashboard already had helper coverage for child selection and request submission, but it did not prove the modal recalculates `Request Spot` vs `Cancel` and status copy when a parent switches between siblings. Centralizing that per-offer UI-state logic makes the modal behavior testable and keeps the rendered state aligned with the selected child payload submitted to rideshare requests.

## Validation
- `./node_modules/.bin/vitest run tests/unit/rideshare-helpers.test.js tests/unit/rideshare-rerequest-policy.test.js tests/unit/parent-dashboard-rideshare-access-sync.test.js tests/unit/parent-dashboard-rideshare-controls.test.js tests/unit/parent-dashboard-rideshare-wiring.test.js`