### PR TITLE
Fix wrap-up AI prompts to use the team sport

### DIFF
--- a/docs/pr-notes/runs/issue-495-fixer-20260404T045502Z/architecture.md
+++ b/docs/pr-notes/runs/issue-495-fixer-20260404T045502Z/architecture.md
@@ -1,0 +1,27 @@
+Thinking level: medium
+Reason: small code change across existing page/module seam with low architectural complexity.
+
+Current state:
+- `game-day.html` owns inline prompt construction for `analyzeGame()` and `generateSummary()`.
+- `js/game-day-wrapup.js` already exists as the wrap-up helper module used by page wiring tests.
+
+Proposed state:
+- Add sport-aware prompt builder helpers to `js/game-day-wrapup.js`.
+- Resolve sport from `sport`, `game.sport`, `team.sport`, or `config.baseType`, then normalize wording for prompts.
+- `game-day.html` passes current state into those helpers before calling Gemini.
+
+Controls equivalence:
+- Same AI model call path.
+- Same Firestore writes (`practiceFeedItems`, `summary`).
+- Same user-triggered actions and access path.
+
+Blast radius comparison:
+- Before: every wrap-up AI request forced soccer framing for all sports.
+- After: only prompt text changes, scoped to the same two wrap-up actions.
+
+Rollback:
+- Revert the helper import usage and restore inline prompt strings.
+
+What would change my mind:
+- Evidence that another shared module already centralizes sport phrasing for wrap-up prompts.
+- Evidence that `game-day.html` intentionally excludes non-soccer sports in wrap-up, which current specs contradict.

--- a/docs/pr-notes/runs/issue-495-fixer-20260404T045502Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-495-fixer-20260404T045502Z/code-plan.md
@@ -1,0 +1,10 @@
+Plan:
+1. Extend `js/game-day-wrapup.js` with sport resolution plus prompt builder helpers.
+2. Update `tests/unit/game-day-wrapup.test.js` with failing prompt coverage.
+3. Replace inline wrap-up prompt strings in `game-day.html` with helper calls.
+4. Run `npm test -- tests/unit/game-day-wrapup.test.js` or the closest supported Vitest invocation, then run the full unit suite if practical.
+5. Commit the fix with issue reference once tests pass.
+
+Non-goals:
+- No changes to broader AI chat context.
+- No changes to tracker routing, stat config loading, or Firestore data shape.

--- a/docs/pr-notes/runs/issue-495-fixer-20260404T045502Z/qa.md
+++ b/docs/pr-notes/runs/issue-495-fixer-20260404T045502Z/qa.md
@@ -1,0 +1,18 @@
+QA focus:
+- Reproduce the bug at the prompt-construction layer.
+- Guard against regressions for soccer and basketball.
+
+Unit coverage to add:
+- `buildPracticeFeedPrompt()` uses basketball wording when sport resolves to basketball.
+- `buildPracticeFeedPrompt()` uses soccer wording when sport resolves to soccer.
+- `buildGameSummaryPrompt()` uses basketball wording and does not mention soccer for basketball context.
+- `buildGameSummaryPrompt()` uses soccer wording for soccer context.
+
+Manual validation targets:
+1. Open `game-day.html` for a basketball team with a completed game.
+2. Run `Generate Practice Feed` and confirm saved guidance is basketball-framed.
+3. Run `Generate Game Summary` and confirm saved summary is basketball-framed.
+4. Repeat on a soccer team to confirm no behavior regression.
+
+Residual risk:
+- If sport metadata is missing in legacy teams, prompts will use a generic youth sports fallback instead of sport-specific wording.

--- a/docs/pr-notes/runs/issue-495-fixer-20260404T045502Z/requirements.md
+++ b/docs/pr-notes/runs/issue-495-fixer-20260404T045502Z/requirements.md
@@ -1,0 +1,28 @@
+Objective: make Game Day Wrap-Up AI use the actual team sport so basketball teams get basketball-specific outputs.
+
+Current state:
+- Wrap-Up AI prompts in `game-day.html` are hardcoded to soccer.
+- Basketball is a supported Game Day mode, so this produces user-visible wrong-sport summaries and practice guidance.
+
+Proposed state:
+- Prompt wording resolves sport from the current team/game tracker context.
+- Basketball teams receive basketball wording; soccer teams keep soccer wording; unknown sports degrade gracefully to a generic label.
+
+Risk surface and blast radius:
+- Blast radius is limited to two wrap-up AI actions in `game-day.html`.
+- No Firestore schema changes, auth changes, or routing changes.
+- Main regression risk is prompt wording drift for existing soccer teams.
+
+Assumptions:
+- Team sport or tracker config base type is the source of truth for wrap-up sport context.
+- A generic fallback is acceptable if sport data is missing.
+- Existing manual and unit test conventions remain the preferred path.
+
+Recommendation:
+- Extract prompt builders into `js/game-day-wrapup.js` and cover sport resolution with unit tests.
+- Keep page behavior and saved payload structure unchanged.
+
+Success criteria:
+- Basketball wrap-up prompts mention basketball, not soccer.
+- Soccer behavior remains soccer-specific.
+- Unit tests cover both prompt builders and page wiring still references the helper module.

--- a/game-day.html
+++ b/game-day.html
@@ -503,7 +503,9 @@
             shouldPromptWrapupOnCompletion,
             getWrapupFormState,
             buildFinishGamePayload,
-            buildMatchReportUrl
+            buildMatchReportUrl,
+            buildPracticeFeedPrompt,
+            buildGameSummaryPrompt
         } from './js/game-day-wrapup.js?v=1';
         import { pickBestGameId, normalizeGameDayUrl } from './js/game-day-entry.js?v=1';
 
@@ -2393,17 +2395,18 @@ Respond ONLY with valid JSON.`;
             status.textContent = 'Analyzing game… this may take a moment.';
             try {
                 const model = getAIModel();
-                const stats = state.aggregatedStats;
                 const events = state.liveEvents.slice(-30);
                 const notes = document.getElementById('post-game-notes').value;
 
-                const prompt = `Analyze this soccer game and return JSON: { "practiceFeedItems": [ { "weakness": "...", "evidence": "...", "drillCategory": "...", "urgency": "high|medium|low" } ] }
-Game: ${state.team?.name || 'Team'} vs ${state.game?.opponent || 'Opponent'}
-Score: ${state.score.home}-${state.score.away}
-Coaching notes: ${state.coachingNotes.map(n => n.text).join(', ') || 'None'}
-Post-game notes: ${notes || 'None'}
-Key events: ${events.map(e => `${e.playerName || ''} ${e.stat || e.type || ''}`).join(', ') || 'None'}
-Identify 2-4 specific areas to improve. Respond ONLY with valid JSON.`;
+                const prompt = buildPracticeFeedPrompt({
+                    game: state.game,
+                    team: state.team,
+                    config: state.statConfig,
+                    score: state.score,
+                    coachingNotes: state.coachingNotes,
+                    notes,
+                    events
+                });
 
                 const result = await model.generateContent(prompt);
                 const text = result.response.text().trim();
@@ -2432,12 +2435,14 @@ Identify 2-4 specific areas to improve. Respond ONLY with valid JSON.`;
             try {
                 const model = getAIModel();
                 const notes = document.getElementById('post-game-notes').value;
-                const prompt = `Write a 3-5 sentence game summary for a youth soccer team.
-Team: ${state.team?.name || 'Team'} vs ${state.game?.opponent || 'Opponent'}
-Final score: ${state.score.home}-${state.score.away}
-Coach notes: ${notes || 'None'}
-Key highlights: ${state.coachingNotes.map(n => n.text).join(', ') || 'None'}
-Be encouraging and specific. No markdown.`;
+                const prompt = buildGameSummaryPrompt({
+                    game: state.game,
+                    team: state.team,
+                    config: state.statConfig,
+                    score: state.score,
+                    coachingNotes: state.coachingNotes,
+                    notes
+                });
                 const result = await model.generateContent(prompt);
                 const summary = result.response.text().trim();
                 await updateGame(state.teamId, state.gameId, { summary });

--- a/js/game-day-wrapup.js
+++ b/js/game-day-wrapup.js
@@ -1,3 +1,5 @@
+import { resolveLiveSport } from './live-sport-config.js';
+
 export function shouldPromptWrapupOnCompletion({ prevLiveStatus, nextLiveStatus, mode }) {
     return nextLiveStatus === 'completed'
         && prevLiveStatus !== 'completed'
@@ -24,4 +26,65 @@ export function buildFinishGamePayload({ homeScoreValue, awayScoreValue, postGam
 
 export function buildMatchReportUrl({ teamId, gameId }) {
     return `game.html#teamId=${encodeURIComponent(teamId)}&gameId=${encodeURIComponent(gameId)}`;
+}
+
+function normalizeSportLabel(value) {
+    const normalized = String(value || '').trim().toLowerCase();
+    if (normalized === 'basketball') return 'basketball';
+    if (normalized === 'soccer') return 'soccer';
+    return 'sports';
+}
+
+function resolveWrapupSportLabel({ sport = '', game = null, team = null, config = null } = {}) {
+    return normalizeSportLabel(resolveLiveSport({ sport, game, team, config }));
+}
+
+function getCoachingNotesText(coachingNotes = []) {
+    return coachingNotes.map((note) => note.text).join(', ') || 'None';
+}
+
+function getEventSummary(events = []) {
+    return events.map((event) => `${event.playerName || ''} ${event.stat || event.type || ''}`.trim()).join(', ') || 'None';
+}
+
+export function buildPracticeFeedPrompt({
+    sport = '',
+    game = null,
+    team = null,
+    config = null,
+    score = {},
+    coachingNotes = [],
+    notes = '',
+    events = []
+} = {}) {
+    const sportLabel = resolveWrapupSportLabel({ sport, game, team, config });
+    const gameLabel = sportLabel === 'sports' ? 'youth sports game' : `${sportLabel} game`;
+
+    return `Analyze this ${gameLabel} and return JSON: { "practiceFeedItems": [ { "weakness": "...", "evidence": "...", "drillCategory": "...", "urgency": "high|medium|low" } ] }
+Game: ${team?.name || 'Team'} vs ${game?.opponent || 'Opponent'}
+Score: ${score?.home || 0}-${score?.away || 0}
+Coaching notes: ${getCoachingNotesText(coachingNotes)}
+Post-game notes: ${notes || 'None'}
+Key events: ${getEventSummary(events)}
+Identify 2-4 specific areas to improve. Respond ONLY with valid JSON.`;
+}
+
+export function buildGameSummaryPrompt({
+    sport = '',
+    game = null,
+    team = null,
+    config = null,
+    score = {},
+    coachingNotes = [],
+    notes = ''
+} = {}) {
+    const sportLabel = resolveWrapupSportLabel({ sport, game, team, config });
+    const teamLabel = sportLabel === 'sports' ? 'youth sports team' : `youth ${sportLabel} team`;
+
+    return `Write a 3-5 sentence game summary for a ${teamLabel}.
+Team: ${team?.name || 'Team'} vs ${game?.opponent || 'Opponent'}
+Final score: ${score?.home || 0}-${score?.away || 0}
+Coach notes: ${notes || 'None'}
+Key highlights: ${getCoachingNotesText(coachingNotes)}
+Be encouraging and specific. No markdown.`;
 }

--- a/tests/unit/game-day-wrapup.test.js
+++ b/tests/unit/game-day-wrapup.test.js
@@ -5,7 +5,9 @@ import {
   shouldPromptWrapupOnCompletion,
   getWrapupFormState,
   buildFinishGamePayload,
-  buildMatchReportUrl
+  buildMatchReportUrl,
+  buildPracticeFeedPrompt,
+  buildGameSummaryPrompt
 } from '../../js/game-day-wrapup.js';
 
 describe('game day wrap-up helpers', () => {
@@ -62,6 +64,58 @@ describe('game day wrap-up helpers', () => {
       gameId: 'game-7'
     })).toBe('game.html#teamId=team-42&gameId=game-7');
   });
+
+  it('builds a basketball-specific practice feed prompt', () => {
+    const prompt = buildPracticeFeedPrompt({
+      team: { name: 'Falcons', sport: 'Basketball' },
+      game: { opponent: 'Tigers' },
+      score: { home: 48, away: 42 },
+      coachingNotes: [{ text: 'Need better weak-side help.' }],
+      notes: 'Rotations improved late.',
+      events: [{ playerName: 'Ava', stat: '3PT Made' }]
+    });
+
+    expect(prompt).toContain('Analyze this basketball game');
+    expect(prompt).not.toContain('Analyze this soccer game');
+  });
+
+  it('builds a soccer-specific practice feed prompt', () => {
+    const prompt = buildPracticeFeedPrompt({
+      team: { name: 'United', sport: 'Soccer' },
+      game: { opponent: 'Rovers' },
+      score: { home: 3, away: 1 },
+      coachingNotes: [],
+      notes: '',
+      events: []
+    });
+
+    expect(prompt).toContain('Analyze this soccer game');
+  });
+
+  it('builds a basketball-specific summary prompt', () => {
+    const prompt = buildGameSummaryPrompt({
+      team: { name: 'Falcons', sport: 'Basketball' },
+      game: { opponent: 'Tigers' },
+      score: { home: 48, away: 42 },
+      coachingNotes: [{ text: 'Strong rebounding finish.' }],
+      notes: 'Bench energy changed the game.'
+    });
+
+    expect(prompt).toContain('youth basketball team');
+    expect(prompt).not.toContain('youth soccer team');
+  });
+
+  it('builds a soccer-specific summary prompt', () => {
+    const prompt = buildGameSummaryPrompt({
+      team: { name: 'United', sport: 'Soccer' },
+      game: { opponent: 'Rovers' },
+      score: { home: 3, away: 1 },
+      coachingNotes: [],
+      notes: ''
+    });
+
+    expect(prompt).toContain('youth soccer team');
+  });
 });
 
 describe('game-day wrap-up page wiring', () => {
@@ -71,6 +125,8 @@ describe('game-day wrap-up page wiring', () => {
     expect(source).toContain("from './js/game-day-wrapup.js?v=1'");
     expect(source).toContain('shouldPromptWrapupOnCompletion({');
     expect(source).toContain('const wrapupFormState = getWrapupFormState({');
+    expect(source).toContain('const prompt = buildPracticeFeedPrompt({');
+    expect(source).toContain('const prompt = buildGameSummaryPrompt({');
     expect(source).toContain('const completionPayload = buildFinishGamePayload({');
     expect(source).toContain('window.location.href = buildMatchReportUrl({');
   });


### PR DESCRIPTION
Closes #495

## What changed
- moved Wrap-Up AI prompt construction into `js/game-day-wrapup.js` so the prompt can resolve sport from the current game, team, or stat config context
- updated `game-day.html` to use the new helper builders for both practice-feed analysis and game-summary generation
- added unit coverage for basketball and soccer prompt wording, plus page wiring assertions
- persisted the requested run notes under `docs/pr-notes/runs/issue-495-fixer-20260404T045502Z/`

## Why
The Wrap-Up panel hardcoded soccer-specific wording for every team. That caused basketball teams to get misleading summaries and practice recommendations.

## Validation
- `./node_modules/.bin/vitest run tests/unit/game-day-wrapup.test.js`
- `./node_modules/.bin/vitest run tests/unit`