### PR TITLE
Fix basketball tracker fallback for legacy configs

### DIFF
--- a/docs/pr-notes/runs/issue-486-fixer-20260404T052502Z/architecture.md
+++ b/docs/pr-notes/runs/issue-486-fixer-20260404T052502Z/architecture.md
@@ -1,0 +1,22 @@
+Current state:
+- `isBasketballConfig(configId)` looks up a config in `allConfigs`.
+- If a config object exists, the helper returns a direct comparison on `(config.baseType || '').toLowerCase()`.
+- That short-circuits fallback logic for incomplete config documents.
+
+Proposed state:
+- Normalize `config.baseType`.
+- Only return config-derived truth when the normalized value is non-empty.
+- Otherwise defer to `currentTeam.sport`.
+
+Why this path:
+- Smallest change that gets 80%+ of the value.
+- Preserves existing behavior for valid configs.
+- Keeps the fix localized to the shared helper already used by both routing entry points.
+
+Controls:
+- No data model change.
+- No new dependencies.
+- No broader routing refactor.
+
+Rollback:
+- Revert the helper change and the matching regression test if behavior proves incorrect.

--- a/docs/pr-notes/runs/issue-486-fixer-20260404T052502Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-486-fixer-20260404T052502Z/code-plan.md
@@ -1,0 +1,9 @@
+Thinking level: low
+Reason: Single-helper regression with an existing targeted test page and clear expected behavior.
+
+Plan:
+1. Update the test-page replica of `isBasketballConfig` so it matches the shipped bug and fails on the missing-`baseType` case.
+2. Run the page logic under a lightweight harness to prove the regression before the fix.
+3. Patch `edit-schedule.html` so missing `baseType` falls back to team sport.
+4. Update the test-page helper to match the fixed logic.
+5. Re-run the targeted validation and commit the change set.

--- a/docs/pr-notes/runs/issue-486-fixer-20260404T052502Z/qa.md
+++ b/docs/pr-notes/runs/issue-486-fixer-20260404T052502Z/qa.md
@@ -1,0 +1,13 @@
+Validation focus:
+- Basketball config with explicit `baseType` still returns `true`.
+- Non-basketball config still returns `false`.
+- Missing config id still falls back to team sport.
+- Existing config missing `baseType` now falls back to team sport.
+
+Regression guardrails:
+- Keep the test in `test-pr-changes.html` aligned with the page helper logic.
+- Validate the case-insensitive `baseType` path still works.
+- Validate invalid config id still falls back to team sport.
+
+Manual spot check recommendation:
+- Open `test-pr-changes.html` in a browser and confirm all basketball detection cases pass.

--- a/docs/pr-notes/runs/issue-486-fixer-20260404T052502Z/requirements.md
+++ b/docs/pr-notes/runs/issue-486-fixer-20260404T052502Z/requirements.md
@@ -1,0 +1,25 @@
+Objective: Keep basketball teams in the basketball tracker chooser flow when a referenced stat config exists but does not declare `baseType`.
+
+Current state:
+- `edit-schedule.html` treats any found config as authoritative.
+- If `config.baseType` is missing, basketball detection returns `false`.
+- The Track flow then opens the generic path instead of exposing the basketball chooser.
+
+Proposed state:
+- A config only overrides team-sport inference when it has a usable `baseType`.
+- Missing or empty `baseType` falls back to the team sport.
+
+Risk surface and blast radius:
+- Affects tracker routing from schedule cards and calendar-originated tracking on `edit-schedule.html`.
+- Blast radius is limited to basketball detection for configs missing `baseType`.
+
+Assumptions:
+- Legacy or incomplete config records without `baseType` can still exist in production.
+- Team sport remains the correct fallback when config type metadata is absent.
+
+Recommendation:
+- Apply a minimal helper fix and add a regression test in `test-pr-changes.html`.
+
+Success measure:
+- The regression test for config-without-`baseType` passes.
+- Existing basketball and non-basketball detection cases continue to pass.

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -1670,7 +1670,10 @@
             if (configId) {
                 const config = allConfigs.find(c => c.id === configId);
                 if (config) {
-                    return (config.baseType || '').toLowerCase() === 'basketball';
+                    const baseType = (config.baseType || '').toLowerCase();
+                    if (baseType) {
+                        return baseType === 'basketball';
+                    }
                 }
             }
             // If no config, infer from team sport

--- a/test-pr-changes.html
+++ b/test-pr-changes.html
@@ -72,7 +72,10 @@
             if (configId) {
                 const config = allConfigs.find(c => c.id === configId);
                 if (config) {
-                    return (config.baseType || '').toLowerCase() === 'basketball';
+                    const baseType = (config.baseType || '').toLowerCase();
+                    if (baseType) {
+                        return baseType === 'basketball';
+                    }
                 }
             }
             // If no config, infer from team sport

--- a/tests/unit/edit-schedule-basketball-routing.test.js
+++ b/tests/unit/edit-schedule-basketball-routing.test.js
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readEditSchedule() {
+    return readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
+}
+
+function buildIsBasketballConfig({ allConfigs, currentTeam }) {
+    const source = readEditSchedule();
+    const match = source.match(/function isBasketballConfig\(configId\) \{([\s\S]*?)\n        \}\n\n        function isBasketballForGame/);
+    expect(match, 'isBasketballConfig should exist').toBeTruthy();
+
+    const createHelper = new Function('deps', `
+        const { allConfigs, currentTeam } = deps;
+        return function(configId) {
+${match[1]}
+        };
+    `);
+
+    return createHelper({ allConfigs, currentTeam });
+}
+
+describe('edit schedule basketball tracker routing', () => {
+    it('falls back to the team sport when a referenced config has no baseType', () => {
+        const isBasketballConfig = buildIsBasketballConfig({
+            allConfigs: [{ id: 'config-1' }],
+            currentTeam: { sport: 'Basketball' }
+        });
+
+        expect(isBasketballConfig('config-1')).toBe(true);
+    });
+
+    it('still returns false when an explicit non-basketball baseType is present', () => {
+        const isBasketballConfig = buildIsBasketballConfig({
+            allConfigs: [{ id: 'config-2', baseType: 'Soccer' }],
+            currentTeam: { sport: 'Basketball' }
+        });
+
+        expect(isBasketballConfig('config-2')).toBe(false);
+    });
+});


### PR DESCRIPTION
Closes #486

## What changed
- updated `edit-schedule.html` so basketball detection only trusts `statTrackerConfig.baseType` when that field is present
- falls back to the team sport when a referenced config exists but has no `baseType`
- added a unit regression test for the missing-`baseType` case and aligned `test-pr-changes.html` with the fixed helper behavior
- recorded requirements, architecture, QA, and code-plan notes in the requested run artifact directory

## Why
Legacy or incomplete stat tracker configs could bypass the basketball chooser modal and send users straight to `track.html`. This keeps the existing behavior for valid configs while restoring the intended basketball routing flow when config metadata is incomplete.

## Validation
- `./node_modules/.bin/vitest run tests/unit/edit-schedule-basketball-routing.test.js`
- `./node_modules/.bin/vitest run tests/unit/edit-schedule-*.test.js`