### PR TITLE
Cover invite login redirects in browser auth flows

### DIFF
--- a/docs/pr-notes/runs/503-remediator-20260404T063727Z/architecture.md
+++ b/docs/pr-notes/runs/503-remediator-20260404T063727Z/architecture.md
@@ -1,0 +1,10 @@
+Current state vs proposed state:
+- Current: values are serialized with `JSON.stringify()` and embedded directly into a JavaScript template literal that becomes the mock module source.
+- Proposed: values are serialized to JSON, base64-encoded in the test runtime, embedded as inert ASCII, then decoded and parsed in the generated module.
+
+Controls:
+- Eliminates backtick and `${...}` breakout from the template literal context.
+- Keeps generated source deterministic and local to the test.
+- Avoids broad test harness changes.
+
+Rollback plan: revert the helper and restore direct interpolation in this spec file.

--- a/docs/pr-notes/runs/503-remediator-20260404T063727Z/code-plan.md
+++ b/docs/pr-notes/runs/503-remediator-20260404T063727Z/code-plan.md
@@ -1,0 +1,6 @@
+Implementation plan:
+1. Add a small helper in `tests/smoke/login-invite-redirect.spec.js` to base64-encode JSON payloads for safe embedding.
+2. Update the mocked `auth.js` module source to decode and parse `loginResult`, `googleRedirectResult`, and `defaultRedirect`.
+3. Update the mocked `db.js` module source to decode and parse `profile`.
+4. Run the affected Playwright spec.
+5. Commit only the scoped changes.

--- a/docs/pr-notes/runs/503-remediator-20260404T063727Z/qa.md
+++ b/docs/pr-notes/runs/503-remediator-20260404T063727Z/qa.md
@@ -1,0 +1,9 @@
+Validation plan:
+- Run the affected Playwright spec file only.
+- Confirm both tests still pass.
+
+Evidence to collect:
+- Passing output for `tests/smoke/login-invite-redirect.spec.js`.
+
+Residual risk:
+- This validates only the targeted smoke spec because the repo does not define a broader automated test suite in repo guidance.

--- a/docs/pr-notes/runs/503-remediator-20260404T063727Z/requirements.md
+++ b/docs/pr-notes/runs/503-remediator-20260404T063727Z/requirements.md
@@ -1,0 +1,14 @@
+Objective: address the two unresolved review comments on `tests/smoke/login-invite-redirect.spec.js`.
+
+Current state: test mocks generate JavaScript module source with direct interpolation of serialized test data inside a template literal.
+Proposed state: test mocks pass structured data through a transport-safe encoding and decode it inside the generated module source.
+
+Risk surface: only Playwright smoke-test mocking in one spec file. No production code path changes.
+Blast radius: confined to `login-invite-redirect.spec.js`.
+
+Assumptions:
+- Review feedback applies only to the mocked `auth.js` and `db.js` module bodies.
+- Node `Buffer` is available in the Playwright test runtime.
+- Minimal change is preferred over refactoring the mocking approach.
+
+Recommendation: encode mock payloads before interpolation and parse them inside the mock module source. This removes template-literal breakout risk while preserving current test behavior.

--- a/docs/pr-notes/runs/issue-502-fixer-20260404T062502Z/architecture.md
+++ b/docs/pr-notes/runs/issue-502-fixer-20260404T062502Z/architecture.md
@@ -1,0 +1,16 @@
+Current state:
+- `login.html` owns UI mode switching and auth event handlers.
+- `js/login-page.js` owns redirect coordination using URL params plus `postGoogleAuthMode`.
+- `js/invite-redirect.js` normalizes invite codes and builds `accept-invite.html` targets.
+
+Proposed state:
+- Keep the architecture unchanged.
+- Add integration coverage at the page boundary so regressions in module wiring fail fast.
+
+Blast radius:
+- No data model or Firebase rule changes.
+- Expected code changes should stay inside login-page redirect handling and test coverage.
+
+Controls:
+- Preserve invite redemption only for `type=parent|admin`.
+- Preserve existing dashboard redirects for non-invite logins and Google signup mode.

--- a/docs/pr-notes/runs/issue-502-fixer-20260404T062502Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-502-fixer-20260404T062502Z/code-plan.md
@@ -1,0 +1,8 @@
+Thinking level: medium
+Reason: narrow issue, but the failure can hide in page/module integration rather than a single pure function.
+
+Plan:
+1. Add a smoke spec against the real `login.html` using mocked `auth.js`, `db.js`, and `utils.js`.
+2. Run the new spec first to determine whether there is an actual regression.
+3. If red, patch the minimal redirect wiring responsible for the wrong destination.
+4. Re-run focused browser and unit tests, then commit with issue reference.

--- a/docs/pr-notes/runs/issue-502-fixer-20260404T062502Z/qa.md
+++ b/docs/pr-notes/runs/issue-502-fixer-20260404T062502Z/qa.md
@@ -1,0 +1,14 @@
+Coverage target:
+- Existing user email/password login from `/login.html?code=ab12cd34&type=parent`.
+- Existing user Google redirect login from `/login.html?code=ab12cd34&type=admin` with `postGoogleAuthMode=login`.
+
+Assertions:
+- Final URL is `accept-invite.html?code=AB12CD34`.
+- Redirect does not fall back to `dashboard.html` or `parent-dashboard.html`.
+
+Validation plan:
+- Run the new smoke spec in isolation.
+- Run the focused unit tests for redirect helpers if app code changes.
+
+Residual risk:
+- This suite uses module mocks for auth/db, so it verifies page wiring rather than live Firebase behavior.

--- a/docs/pr-notes/runs/issue-502-fixer-20260404T062502Z/requirements.md
+++ b/docs/pr-notes/runs/issue-502-fixer-20260404T062502Z/requirements.md
@@ -1,0 +1,19 @@
+Objective: Protect the invite redemption login flow for existing parent/admin users.
+
+Current state:
+- Unit coverage proves helper-level invite redirect behavior.
+- Browser coverage does not exercise the real `login.html` handlers with invite query params.
+
+Proposed state:
+- Add browser coverage for email/password login and Google login redirect paths when `?code` and `?type` are present.
+
+Risk surface and blast radius:
+- A regression strands invited existing users after successful authentication.
+- Blast radius is limited to invite-based login entry points, but the user-facing failure is immediate.
+
+Assumptions:
+- Existing users may arrive on invite links containing `type=parent` or `type=admin`.
+- The current repo-standard browser coverage lives under `tests/smoke`.
+
+Recommendation:
+- Add browser tests around the real page wiring and only patch app code if the test exposes a redirect break.

--- a/js/login-page.js
+++ b/js/login-page.js
@@ -54,8 +54,11 @@ export function createLoginRedirectCoordinator({
 } = {}) {
     const urlParams = new URLSearchParams(windowObject.location.search);
     const urlCodeParam = urlParams.get('code');
-    const urlInviteType = urlParams.get('type');
-    const shouldRedeemInviteFromLogin = urlInviteType === 'parent' || urlInviteType === 'admin';
+    const urlInviteType = typeof urlParams.get('type') === 'string'
+        ? urlParams.get('type').trim().toLowerCase()
+        : '';
+    const shouldRedeemInviteFromLogin = Boolean(urlCodeParam) &&
+        (urlInviteType === 'parent' || urlInviteType === 'admin');
     let inviteRedemptionOverride = null;
 
     function getPostAuthRedirect(userWithRoles, shouldRedeemInvite = false) {

--- a/login.html
+++ b/login.html
@@ -100,7 +100,7 @@
         import { getUserProfile } from './js/db.js?v=15';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import { getPostAuthRedirectUrl } from './js/invite-redirect.js?v=1';
-        import { createForgotPasswordHandler, createLoginRedirectCoordinator } from './js/login-page.js?v=1';
+        import { createForgotPasswordHandler, createLoginRedirectCoordinator } from './js/login-page.js?v=2';
 
         renderFooter(document.getElementById('footer-container'));
 

--- a/tests/smoke/login-invite-redirect.spec.js
+++ b/tests/smoke/login-invite-redirect.spec.js
@@ -1,0 +1,144 @@
+import { test, expect } from '@playwright/test';
+
+function buildUrl(baseURL, path) {
+    const url = new URL(path, `${baseURL}/`);
+    url.searchParams.set('cb', String(Date.now()));
+    return url.toString();
+}
+
+async function mockInviteLoginModules(page, options = {}) {
+    const {
+        profile = {},
+        loginResult = {
+            user: {
+                uid: 'user-123',
+                email: 'existing@example.com'
+            }
+        },
+        googleRedirectResult = null,
+        defaultRedirect = 'dashboard.html'
+    } = options;
+
+    await page.route(/\/js\/auth\.js\?v=\d+$/, async (route) => {
+        const moduleSource = `
+            const loginResult = ${JSON.stringify(loginResult)};
+            const googleRedirectResult = ${JSON.stringify(googleRedirectResult)};
+            const defaultRedirect = ${JSON.stringify(defaultRedirect)};
+
+            export async function login(email, password) {
+                window.__authMock = { email, password };
+                return loginResult;
+            }
+
+            export async function signup() {
+                throw new Error('signup not mocked');
+            }
+
+            export function checkAuth(callback) {
+                callback(null);
+            }
+
+            export async function loginWithGoogle() {
+                return null;
+            }
+
+            export async function handleGoogleRedirectResult() {
+                return googleRedirectResult;
+            }
+
+            export async function resetPassword() {
+                return null;
+            }
+
+            export function getRedirectUrl() {
+                return defaultRedirect;
+            }
+        `;
+
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: moduleSource
+        });
+    });
+
+    await page.route(/\/js\/db\.js\?v=\d+$/, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: `
+                export async function getUserProfile() {
+                    return ${JSON.stringify(profile)};
+                }
+            `
+        });
+    });
+
+    await page.route(/\/js\/utils\.js\?v=\d+$/, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: `
+                export function renderHeader(container) {
+                    if (container) {
+                        container.innerHTML = '<header data-test-id="mock-header"></header>';
+                    }
+                }
+
+                export function renderFooter(container) {
+                    if (container) {
+                        container.innerHTML = '<footer data-test-id="mock-footer"></footer>';
+                    }
+                }
+            `
+        });
+    });
+}
+
+test('email/password login from an invite link redirects existing parents to accept-invite', async ({ page, baseURL }) => {
+    await mockInviteLoginModules(page, {
+        profile: {
+            parentOf: [{ teamId: 'team-1' }]
+        },
+        defaultRedirect: 'parent-dashboard.html'
+    });
+
+    await page.goto(buildUrl(baseURL, '/login.html?code=ab12cd34&type=parent'), {
+        waitUntil: 'domcontentloaded'
+    });
+
+    await expect(page.locator('#form-title')).toHaveText('Sign Up');
+    await page.locator('#toggle-btn').click();
+    await expect(page.locator('#form-title')).toHaveText('Login');
+
+    await page.locator('#email').fill('parent@example.com');
+    await page.locator('#password').fill('secret123');
+    await page.locator('#login-form').dispatchEvent('submit');
+
+    await expect(page).toHaveURL(/\/accept-invite\.html\?code=AB12CD34$/);
+});
+
+test('google redirect login mode keeps existing admin invites on accept-invite', async ({ page, baseURL }) => {
+    await page.addInitScript(() => {
+        window.sessionStorage.setItem('postGoogleAuthMode', 'login');
+    });
+
+    await mockInviteLoginModules(page, {
+        profile: {
+            isAdmin: true
+        },
+        googleRedirectResult: {
+            user: {
+                uid: 'admin-123',
+                email: 'coach@example.com'
+            }
+        },
+        defaultRedirect: 'dashboard.html'
+    });
+
+    await page.goto(buildUrl(baseURL, '/login.html?code=ab12cd34&type=admin'), {
+        waitUntil: 'domcontentloaded'
+    });
+
+    await expect(page).toHaveURL(/\/accept-invite\.html\?code=AB12CD34$/);
+});

--- a/tests/smoke/login-invite-redirect.spec.js
+++ b/tests/smoke/login-invite-redirect.spec.js
@@ -6,6 +6,10 @@ function buildUrl(baseURL, path) {
     return url.toString();
 }
 
+function encodeModuleValue(value) {
+    return Buffer.from(JSON.stringify(value), 'utf8').toString('base64');
+}
+
 async function mockInviteLoginModules(page, options = {}) {
     const {
         profile = {},
@@ -18,12 +22,16 @@ async function mockInviteLoginModules(page, options = {}) {
         googleRedirectResult = null,
         defaultRedirect = 'dashboard.html'
     } = options;
+    const encodedLoginResult = encodeModuleValue(loginResult);
+    const encodedGoogleRedirectResult = encodeModuleValue(googleRedirectResult);
+    const encodedDefaultRedirect = encodeModuleValue(defaultRedirect);
+    const encodedProfile = encodeModuleValue(profile);
 
     await page.route(/\/js\/auth\.js\?v=\d+$/, async (route) => {
         const moduleSource = `
-            const loginResult = ${JSON.stringify(loginResult)};
-            const googleRedirectResult = ${JSON.stringify(googleRedirectResult)};
-            const defaultRedirect = ${JSON.stringify(defaultRedirect)};
+            const loginResult = JSON.parse(atob('${encodedLoginResult}'));
+            const googleRedirectResult = JSON.parse(atob('${encodedGoogleRedirectResult}'));
+            const defaultRedirect = JSON.parse(atob('${encodedDefaultRedirect}'));
 
             export async function login(email, password) {
                 window.__authMock = { email, password };
@@ -68,7 +76,7 @@ async function mockInviteLoginModules(page, options = {}) {
             contentType: 'application/javascript',
             body: `
                 export async function getUserProfile() {
-                    return ${JSON.stringify(profile)};
+                    return JSON.parse(atob('${encodedProfile}'));
                 }
             `
         });

--- a/tests/unit/login-page-cache-busting.test.js
+++ b/tests/unit/login-page-cache-busting.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('login page cache busting', () => {
+    it('loads the current login-page coordinator module version', () => {
+        const source = readFileSync(resolve(process.cwd(), 'login.html'), 'utf8');
+
+        expect(source).toContain(
+            "import { createForgotPasswordHandler, createLoginRedirectCoordinator } from './js/login-page.js?v=2';"
+        );
+    });
+});

--- a/tests/unit/login-page.test.js
+++ b/tests/unit/login-page.test.js
@@ -37,6 +37,27 @@ function createCoordinator({
 }
 
 describe('login page redirect coordination', () => {
+    it('treats invite type values case-insensitively when code is present', () => {
+        const { coordinator } = createCoordinator({
+            search: '?code=ab12cd34&type= Admin ',
+            defaultRedirect: 'dashboard.html'
+        });
+
+        expect(coordinator.shouldRedeemInviteFromLogin).toBe(true);
+        expect(coordinator.getPostAuthRedirect({ isAdmin: true }, coordinator.shouldRedeemInviteFromLogin))
+            .toBe('accept-invite.html?code=AB12CD34');
+    });
+
+    it('does not redeem invite redirects when the invite code is missing', () => {
+        const { coordinator } = createCoordinator({
+            search: '?type=parent',
+            defaultRedirect: 'parent-dashboard.html'
+        });
+
+        expect(coordinator.shouldRedeemInviteFromLogin).toBe(false);
+        expect(coordinator.getAutoRedirectUrl({ parentOf: [{ teamId: 'team-1' }] })).toBe('parent-dashboard.html');
+    });
+
     it('redeems the invite after Google redirect when the stored mode is login', () => {
         const { coordinator, windowObject } = createCoordinator({ postGoogleAuthMode: 'login' });
 


### PR DESCRIPTION
Closes #502

## What changed
- added a new Playwright smoke spec for the real `login.html` wiring that covers:
  - existing parent email/password login from an invite link redirecting to `accept-invite.html`
  - existing admin Google redirect login in `postGoogleAuthMode=login` redirecting to `accept-invite.html`
- hardened `createLoginRedirectCoordinator` so invite redemption only activates when a code is present and the invite type is normalized case-insensitively
- bumped the `login-page.js` cache-busting import in `login.html` and added a focused unit test to lock that in
- captured the required requirements, architecture, QA, and code-plan notes under `docs/pr-notes/runs/issue-502-fixer-20260404T062502Z/`

## Why
The redirect behavior was already split across `login.html`, `js/login-page.js`, and `js/invite-redirect.js`, but browser coverage for the actual invite-aware login handlers was missing. This change adds that coverage and tightens the coordinator so invite redemption only applies on valid invite-bearing login flows.

## Validation
- passed: `./node_modules/.bin/vitest run tests/unit/login-page.test.js tests/unit/login-page-cache-busting.test.js tests/unit/invite-redirect.test.js --reporter=dot`
- passed: `./node_modules/.bin/playwright test tests/smoke/login-invite-redirect.spec.js --config=playwright.smoke.config.js --list`
- blocked on this worker: executing the Playwright browser spec itself because the host is missing required Playwright OS libraries