### PR TITLE
Add homepage replay card regression coverage

### DIFF
--- a/docs/pr-notes/runs/issue-494-fixer-20260404T063111Z/architecture.md
+++ b/docs/pr-notes/runs/issue-494-fixer-20260404T063111Z/architecture.md
@@ -1,0 +1,19 @@
+# Architecture Role (fallback synthesis)
+
+## Root Cause
+The product behavior already exists in `js/homepage.js`, but the regression net is incomplete. Replay rendering is data-driven and therefore vulnerable to silent breakage if query return shapes or fallback handling drift.
+
+## Minimal Safe Fix
+- Extend `tests/unit/homepage-index.test.js` with explicit replay-card and replay-fallback assertions.
+- Harden `loadPastGames` to treat unexpected non-array query results as empty state rather than leaving the section vulnerable to runtime shape errors.
+- Bump the homepage module cache version in `index.html` so the deployed page pulls the updated script.
+
+## Blast Radius
+- `js/homepage.js`
+- `index.html`
+- `tests/unit/homepage-index.test.js`
+
+## Controls
+- Keep changes local to `loadPastGames`.
+- Preserve existing user-facing copy.
+- Validate with focused Vitest coverage for homepage behavior.

--- a/docs/pr-notes/runs/issue-494-fixer-20260404T063111Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-494-fixer-20260404T063111Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Role (fallback synthesis)
+
+## Plan
+1. Tighten `tests/unit/homepage-index.test.js` around replay rendering and fallback behavior.
+2. Update `loadPastGames` in `js/homepage.js` to normalize query output before rendering.
+3. Bump the homepage module cache key in `index.html`.
+4. Run focused homepage unit tests, then stage and commit with issue reference.
+
+## Non-Goals
+- No changes to Firestore query logic in `js/db.js`.
+- No refactor of live-game card rendering outside the replay coverage gap.

--- a/docs/pr-notes/runs/issue-494-fixer-20260404T063111Z/qa.md
+++ b/docs/pr-notes/runs/issue-494-fixer-20260404T063111Z/qa.md
@@ -1,0 +1,14 @@
+# QA Role (fallback synthesis)
+
+## Test Strategy
+1. Add a replay rendering test that asserts the dynamic card replaces the loading placeholder and includes team name, opponent, score, formatted date, and the replay URL contract.
+2. Add an empty-state test for `No recent replays available`.
+3. Keep the existing error-state coverage for `Unable to load replays`.
+
+## Regression Guardrails
+- Assert against exact user-facing strings for fallback states.
+- Check the generated href contains the expected `teamId`, `gameId`, and `replay=true` parameters.
+- Keep live-games assertions intact so homepage parallel loading behavior still has coverage.
+
+## Manual Smoke (optional)
+- Load `index.html` with seeded completed live-tracked game data and confirm the replay card links into `live-game.html?...&replay=true`.

--- a/docs/pr-notes/runs/issue-494-fixer-20260404T063111Z/requirements.md
+++ b/docs/pr-notes/runs/issue-494-fixer-20260404T063111Z/requirements.md
@@ -1,0 +1,17 @@
+# Requirements Role (fallback synthesis)
+
+## Objective
+Add regression coverage for the homepage `Recent Replays` section so a public visitor reliably sees replay cards when data exists and clear fallback text when it does not.
+
+## Current vs Proposed
+- Current: Homepage unit coverage proves the shell loads and that replay links exist, but it does not explicitly validate replay card content, exact replay URL parameters, or the empty-state copy.
+- Proposed: Add targeted assertions for replay team/opponent/score/date/link rendering and for the two replay fallbacks: empty result and query failure.
+
+## Acceptance Criteria
+1. When a completed game is returned, `#past-games-list` replaces `Loading replays...` with a replay card showing team name, opponent, final score, date text, and a replay URL containing `live-game.html`, `teamId`, `gameId`, and `replay=true`.
+2. When no replay games are returned, the homepage shows `No recent replays available`.
+3. When the replay query throws, the homepage shows `Unable to load replays`.
+
+## Risks
+- Low blast radius. The change is limited to homepage replay rendering and its tests.
+- Main regression risk is altering homepage placeholder or fallback copy unexpectedly.

--- a/index.html
+++ b/index.html
@@ -654,7 +654,7 @@
     import { checkAuth } from './js/auth.js?v=10';
     import { renderHeader, formatDate, formatTime } from './js/utils.js?v=8';
     import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=15';
-    import { initHomepage } from './js/homepage.js?v=1';
+    import { initHomepage } from './js/homepage.js?v=2';
 
     initHomepage({
       document,

--- a/js/homepage.js
+++ b/js/homepage.js
@@ -135,7 +135,8 @@ export async function loadPastGames({
     }
 
     try {
-        const pastGames = await getRecentLiveTrackedGames(6);
+        const pastGamesResult = await getRecentLiveTrackedGames(6);
+        const pastGames = Array.isArray(pastGamesResult) ? pastGamesResult : [];
         if (pastGames.length === 0) {
             container.innerHTML = '<div class="text-center py-8 text-gray-500 col-span-full">No recent replays available</div>';
             return;
@@ -151,7 +152,7 @@ export async function loadPastGames({
                 <div class="text-sm text-gray-500">vs ${escapeHtml(game.opponent || 'Opponent')}</div>
               </div>
             </div>
-            <div class="text-2xl font-bold text-center py-2 text-gray-900">${escapeHtml(game.homeScore || 0)} - ${escapeHtml(game.awayScore || 0)}</div>
+            <div class="text-2xl font-bold text-center py-2 text-gray-900">${escapeHtml(game.homeScore ?? 0)} - ${escapeHtml(game.awayScore ?? 0)}</div>
             <div class="text-xs text-gray-400 text-center mb-2">${escapeHtml(formatDate(game.date))}</div>
             <div class="text-center text-teal-600 text-sm font-semibold">Watch Replay →</div>
           </a>

--- a/tests/unit/homepage-index.test.js
+++ b/tests/unit/homepage-index.test.js
@@ -119,9 +119,16 @@ describe('homepage index workflow', () => {
         const duplicatedLiveGame = createGame({ liveViewerCount: 5 });
         const replayGame = createGame({
             id: 'game-2',
+            teamId: 'team-9',
             opponent: 'Bears',
             homeScore: 77,
-            awayScore: 72
+            awayScore: 72,
+            date: '2026-03-29T19:30:00.000Z',
+            team: {
+                id: 'team-9',
+                name: 'Panthers',
+                photoUrl: ''
+            }
         });
 
         const { elements, renderHeader } = await runHomepage({
@@ -144,8 +151,12 @@ describe('homepage index workflow', () => {
 
         const replayMarkup = elements.get('past-games-list').innerHTML;
         expect(replayMarkup).not.toContain('Loading replays...');
+        expect(replayMarkup).toContain('Panthers');
+        expect(replayMarkup).toContain('vs Bears');
+        expect(replayMarkup).toContain('77 - 72');
+        expect(replayMarkup).toContain('DATE:2026-03-29T19:30:00.000Z');
         expect(replayMarkup).toContain('Watch Replay');
-        expect(replayMarkup).toContain('gameId=game-2&replay=true');
+        expect(replayMarkup).toContain('href="live-game.html?teamId=team-9&gameId=game-2&replay=true"');
     });
 
     it('keeps upcoming cards visible when live games fail and sets the guest CTA', async () => {
@@ -167,7 +178,18 @@ describe('homepage index workflow', () => {
         expect(liveMarkup).toContain('TIME:2026-03-28T18:00:00.000Z');
     });
 
-    it('replaces loading placeholders with exact empty and error fallback copy', async () => {
+    it('replaces replay loading placeholder with exact empty-state copy', async () => {
+        const { elements } = await runHomepage({
+            liveGames: [],
+            upcomingGames: [],
+            replayGames: []
+        });
+
+        expect(elements.get('past-games-list').innerHTML).not.toContain('Loading replays...');
+        expect(elements.get('past-games-list').textContent).toBe('No recent replays available');
+    });
+
+    it('replaces loading placeholders with exact error fallback copy when replay loading fails', async () => {
         const { elements } = await runHomepage({
             liveGames: [],
             upcomingGames: [],


### PR DESCRIPTION
Closes #494

## What changed
- expanded `tests/unit/homepage-index.test.js` to verify Recent Replays renders a real replay card with team name, opponent, final score, formatted date, and a `live-game.html?...&replay=true` link containing the expected `teamId` and `gameId`
- added explicit replay fallback coverage for both the empty state (`No recent replays available`) and the query failure state (`Unable to load replays`)
- hardened `loadPastGames` in `js/homepage.js` to treat unexpected non-array results as an empty replay state, and bumped the homepage module cache key in `index.html`
- persisted the required role-synthesis notes for this run under `docs/pr-notes/runs/issue-494-fixer-20260404T063111Z/`

## Validation
- ran `./node_modules/.bin/vitest run tests/unit/homepage-index.test.js`

## Why
The homepage replay section is a public discovery path driven entirely by Firestore-backed data. This closes the regression gap around dynamic replay rendering and ensures visitors get clear fallback copy instead of a broken or stuck loading state.