### PR TITLE
Fix team schedule cancelled-game state handling

### DIFF
--- a/docs/pr-notes/runs/issue-523-issue-comment-4196131991-20260407T024201Z/architecture.md
+++ b/docs/pr-notes/runs/issue-523-issue-comment-4196131991-20260407T024201Z/architecture.md
@@ -1,0 +1,25 @@
+## Current State
+- `team.html` composes schedule cards from mixed calendar events and Firestore game docs.
+- DB event normalization previously dropped CTA-driving fields like `id`, `liveStatus`, and metadata used by the schedule card.
+- Cancelled DB games could still win next-game selection or render conflicting upcoming/live affordances.
+- Focused regression coverage for the agreed state matrix was missing.
+
+## Proposed State
+- Normalize DB games once at `getAllEvents()` so downstream schedule rendering receives a complete event shape, including `id`, `gameId`, `liveStatus`, metadata fields, and derived `isCancelled`.
+- Treat cancelled as fail-closed across next-game selection, upcoming filtering, and schedule-card CTA rendering.
+- Derive schedule-card UI from normalized status values so upcoming, live, completed, replay, and tie behavior stays deterministic.
+- Keep the change local to `team.html` and focused unit tests.
+
+## Key Decisions
+- Normalize once at the page boundary instead of changing Firestore schema or upstream writers.
+- Carry explicit `isCancelled` rather than repeating raw string checks across filters.
+- Suppress live/upcoming CTA paths when cancelled.
+- Use the repo’s actual default branch, `master`, for the PR target because the active worktree is based on `origin/master`.
+
+## Blast Radius
+- User-visible impact is limited to the team-page schedule card, next-game countdown selection, and upcoming filtering.
+- No backend, auth, rules, or permission changes.
+
+## Rollback
+- Revert the `team.html` normalization, filtering, and renderer changes.
+- Remove the two Issue #523 regression test files if needed.

--- a/docs/pr-notes/runs/issue-523-issue-comment-4196131991-20260407T024201Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-523-issue-comment-4196131991-20260407T024201Z/code-plan.md
@@ -1,0 +1,28 @@
+## Minimal Patch
+- Normalize `status` and `liveStatus` case-insensitively in `renderDbGame()`.
+- Treat `status === cancelled` as fail-closed so cancelled future games never render upcoming/live CTAs.
+- Preserve CTA-driving DB fields in `getAllEvents()`: `id`, `gameId`, `liveStatus`, `isHome`, `kitColor`, `arrivalTime`, `notes`, `assignments`, `rsvpSummary`, and derived `isCancelled`.
+- Exclude cancelled events from `getNextGame()`.
+
+## Test Additions
+- `tests/unit/team-schedule-card-render.test.js`
+  - cancelled future
+  - upcoming scheduled
+  - live
+  - completed report vs replay
+  - completed tie
+- `tests/unit/team-schedule-events.test.js`
+  - DB event normalization preserves CTA-driving fields
+  - cancelled future events are skipped for next-game selection
+
+## Validation Commands
+```bash
+cd /home/paul-bot1/.openclaw/workspace/worktrees/issue-523-20260407T013700Z
+pnpm dlx vitest@4.0.18 run tests/unit/team-schedule-card-render.test.js tests/unit/team-schedule-events.test.js
+pnpm dlx vitest@4.0.18 run tests/unit
+```
+
+## Risks
+- Replay gating still depends on the current replay-ready signal convention.
+- Mixed-case values outside the normalized paths could still be inconsistent elsewhere.
+- This patch adds regression coverage but not browser-level integration coverage.

--- a/docs/pr-notes/runs/issue-523-issue-comment-4196131991-20260407T024201Z/qa.md
+++ b/docs/pr-notes/runs/issue-523-issue-comment-4196131991-20260407T024201Z/qa.md
@@ -1,0 +1,28 @@
+## Coverage Matrix
+| Scope | State / branch covered | Evidence |
+| --- | --- | --- |
+| Schedule card render | Cancelled future game | `tests/unit/team-schedule-card-render.test.js` `fails closed for cancelled future games` |
+| Schedule card render | Upcoming scheduled game | `tests/unit/team-schedule-card-render.test.js` `renders upcoming scheduled games with live-view CTAs` |
+| Schedule card render | Live game | `tests/unit/team-schedule-card-render.test.js` `renders live games with live badge, score block, and live URL` |
+| Schedule card render | Completed report vs replay branching | `tests/unit/team-schedule-card-render.test.js` `renders completed replay CTAs only when live playback exists` |
+| Schedule card render | Completed tie | `tests/unit/team-schedule-card-render.test.js` `renders tied completed games with the tie badge` |
+| Event normalization | DB event preserves CTA-driving fields | `tests/unit/team-schedule-events.test.js` `preserves CTA-driving db game fields and marks cancelled games explicitly` |
+| Next-game selection | Cancelled games excluded | `tests/unit/team-schedule-events.test.js` `keeps non-cancelled future games eligible for next game selection` |
+
+## Assertions
+- Cancelled cards fail closed before any live or upcoming CTA renders.
+- Upcoming scheduled cards retain their live/share CTA path.
+- Live cards retain live badge, score block, and live link behavior.
+- Completed cards retain report/share actions, with replay gated to replay-ready state.
+- `getAllEvents()` preserves the fields the renderer depends on.
+- `getNextGame()` excludes cancelled future games.
+
+## Gaps
+- No explicit `Not Tracked` branch test yet.
+- No explicit practice-card coverage yet.
+- No explicit win/loss badge split assertion yet.
+- No list/calendar integration coverage yet.
+
+## Validation
+- Targeted regression run passed for the two Issue #523 test files.
+- Full unit suite passed in the active worktree.

--- a/docs/pr-notes/runs/issue-523-issue-comment-4196131991-20260407T024201Z/requirements.md
+++ b/docs/pr-notes/runs/issue-523-issue-comment-4196131991-20260407T024201Z/requirements.md
@@ -1,0 +1,21 @@
+## Objective
+Define deterministic, branch-safe schedule-card coverage in `team.html` for the agreed db-backed states: cancelled, upcoming, live, completed-report, and completed-replay. The immediate fix must make future cancelled games fail closed so they never surface as actionable upcoming games.
+
+## Acceptance Criteria
+1. Cancelled future db games render cancelled treatment and do not render `Upcoming`, `Live Now`, `View Live`, or live-share CTAs.
+2. Cancelled future db games are excluded from next-game selection and upcoming surfaces.
+3. Upcoming scheduled db games render `Upcoming` and retain the live-view/share CTA path.
+4. Live db games render the live badge, score block, and live URL.
+5. Completed db games render report access, with replay shown only when the replay-ready signal is present.
+6. Deterministic unit coverage exists for the five-state matrix in `renderDbGame()` plus the normalized event shape that drives selection.
+7. Completed tie behavior remains valid as a completed-state variant.
+
+## Non-Goals
+- Building crawler-driven state discovery in this change.
+- Redesigning schedule-card layout or copy beyond the state fix.
+- Reworking unrelated calendar or practice flows.
+
+## Open Questions
+- Whether tied completed games should become an explicit sixth matrix state.
+- Whether replay readiness should stay tied to `liveStatus === 'completed'` or move to a dedicated replay flag.
+- Whether cancelled games should remain visible in future views as non-actionable items long term.

--- a/team.html
+++ b/team.html
@@ -653,6 +653,7 @@
             const upcomingEvents = allEvents
                 .filter(event => {
                     if (event.type === 'db' && event.status === 'completed') return false;
+                    if (event.isCancelled) return false;
                     if (event.isPractice && !showPractices) return false;
                     return event.date > cutoff;
                 })
@@ -1199,15 +1200,25 @@
                 const gameDate = game.date.toDate ? game.date.toDate() : new Date(game.date);
                 const id = game.id || game.gameId;
                 const isPractice = game.type === 'practice';
+                const isCancelled = String(game.status || '').toLowerCase() === 'cancelled';
                 allEvents.push({
                     type: 'db',
+                    id,
+                    gameId: id,
                     date: gameDate,
                     opponent: game.opponent,
                     location: game.location || 'TBD',
                     status: game.status,
+                    liveStatus: game.liveStatus,
                     homeScore: game.homeScore,
                     awayScore: game.awayScore,
-                    gameId: id,
+                    isHome: game.isHome,
+                    kitColor: game.kitColor,
+                    arrivalTime: game.arrivalTime,
+                    notes: game.notes,
+                    assignments: game.assignments,
+                    rsvpSummary: game.rsvpSummary,
+                    isCancelled,
                     isPractice
                 });
             });
@@ -1511,28 +1522,35 @@
 
         function renderDbGame(game) {
             const isPractice = !!game.isPractice;
-            const isCompleted = game.status === 'completed' && !isPractice;
-            const isLive = game.liveStatus === 'live';
+            const normalizedStatus = String(game.status || '').toLowerCase();
+            const normalizedLiveStatus = String(game.liveStatus || '').toLowerCase();
+            const isCancelled = normalizedStatus === 'cancelled';
+            const isCompleted = normalizedStatus === 'completed' && !isPractice;
+            const isLive = normalizedLiveStatus === 'live' && !isCancelled;
             const gameDate = game.date?.toDate ? game.date.toDate() : new Date(game.date);
-            const isUpcoming = !isCompleted && gameDate > new Date();
+            const isUpcoming = !isCancelled && !isCompleted && gameDate > new Date();
             const won = isCompleted && game.homeScore > game.awayScore;
             const lost = isCompleted && game.homeScore < game.awayScore;
             const tied = isCompleted && game.homeScore === game.awayScore;
+            const borderAccentClass = isCancelled
+                ? 'border-gray-400'
+                : (won ? 'border-green-500' : (lost ? 'border-red-500' : (tied ? 'border-yellow-500' : 'border-primary-500')));
 
             return `
-                <div class="group bg-white rounded-xl shadow-md hover:shadow-lg transition border-l-4 ${won ? 'border-green-500' : (lost ? 'border-red-500' : (tied ? 'border-yellow-500' : 'border-primary-500'))
-                } overflow-hidden border border-gray-200">
+                <div class="group bg-white rounded-xl shadow-md hover:shadow-lg transition border-l-4 ${borderAccentClass} overflow-hidden border border-gray-200">
                     <div class="p-5">
                         <div class="flex flex-col md:flex-row justify-between items-start gap-4">
                             <div class="flex-grow">
                                 <div class="flex flex-wrap items-center gap-2 mb-2">
-                                    ${isCompleted
-                    ? `<span class="text-xs ${won ? 'bg-green-100 text-green-800' : (lost ? 'bg-red-100 text-red-800' : 'bg-yellow-100 text-yellow-800')} px-2.5 py-0.5 rounded-full font-semibold">
+                                    ${isCancelled
+                    ? '<span class="text-xs bg-red-100 text-red-800 px-2.5 py-0.5 rounded-full font-semibold">Cancelled</span>'
+                    : (isCompleted
+                        ? `<span class="text-xs ${won ? 'bg-green-100 text-green-800' : (lost ? 'bg-red-100 text-red-800' : 'bg-yellow-100 text-yellow-800')} px-2.5 py-0.5 rounded-full font-semibold">
                                             ${won ? 'W' : (lost ? 'L' : 'T')}
                                           </span>`
-                    : (isUpcoming
-                        ? `<span class="text-xs bg-primary-100 text-primary-800 px-2.5 py-0.5 rounded-full font-semibold">Upcoming</span>`
-                        : `<span class="text-xs bg-gray-100 text-gray-600 px-2.5 py-0.5 rounded-full font-semibold">Not Tracked</span>`)
+                        : (isUpcoming
+                            ? `<span class="text-xs bg-primary-100 text-primary-800 px-2.5 py-0.5 rounded-full font-semibold">Upcoming</span>`
+                            : `<span class="text-xs bg-gray-100 text-gray-600 px-2.5 py-0.5 rounded-full font-semibold">Not Tracked</span>`))
                 }
                                     ${isLive ? `
                                         <span class="inline-flex items-center gap-1 text-xs bg-red-100 text-red-700 px-2.5 py-0.5 rounded-full font-semibold">
@@ -1556,7 +1574,7 @@
                                     ${game.isHome === true ? '<span class="text-xs bg-blue-100 text-blue-800 px-2 py-0.5 rounded-full font-semibold">HOME</span>' : ''}
                                     ${game.isHome === false ? '<span class="text-xs bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full font-semibold">AWAY</span>' : ''}
                                     ${game.kitColor ? `<span class="text-xs bg-purple-100 text-purple-800 px-2 py-0.5 rounded-full font-semibold">${escapeHtml(game.kitColor)}</span>` : ''}
-                                    ${game.status === 'cancelled' ? '<span class="text-xs bg-red-100 text-red-800 px-2 py-0.5 rounded-full font-semibold">CANCELLED</span>' : ''}
+                                    ${isCancelled ? '<span class="text-xs bg-red-100 text-red-800 px-2 py-0.5 rounded-full font-semibold">CANCELLED</span>' : ''}
                                 </div>
                                 ${game.arrivalTime ? `<div class="text-xs text-amber-600 mt-1">Arrive by ${formatTime(game.arrivalTime)}</div>` : ''}
                                 ${game.notes ? `<div class="text-xs text-gray-500 mt-1 italic">${escapeHtml(game.notes)}</div>` : ''}

--- a/tests/unit/team-schedule-card-render.test.js
+++ b/tests/unit/team-schedule-card-render.test.js
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readTeamPage() {
+    return readFileSync(new URL('../../team.html', import.meta.url), 'utf8');
+}
+
+function extractRenderDbGameBody() {
+    const source = readTeamPage();
+    const match = source.match(/function renderDbGame\(game\) \{([\s\S]*?)\n        \}\n\n        \/\/ ICS export helpers/);
+    expect(match, 'renderDbGame should exist').toBeTruthy();
+    return match[1];
+}
+
+function buildRenderDbGame(overrides = {}) {
+    const body = extractRenderDbGameBody();
+    const deps = {
+        currentTeamId: 'team-1',
+        formatDate: () => 'Tue, Mar 10',
+        formatTime: () => '6:00 PM',
+        escapeHtml: (value) => String(value ?? ''),
+        mapLink: () => '',
+        ...overrides
+    };
+
+    const createRenderer = new Function('deps', `
+        const { currentTeamId, formatDate, formatTime, escapeHtml, mapLink } = deps;
+        return function(game) {
+${body}
+        };
+    `);
+
+    return { deps, renderDbGame: createRenderer(deps) };
+}
+
+describe('team page schedule card rendering', () => {
+    it('fails closed for cancelled future games', () => {
+        const { renderDbGame } = buildRenderDbGame();
+
+        const html = renderDbGame({
+            id: 'game-cancelled',
+            opponent: 'Tigers',
+            location: 'Main Gym',
+            date: '2099-03-10T18:00:00.000Z',
+            status: 'cancelled',
+            liveStatus: 'scheduled'
+        });
+
+        expect(html).toContain('>Cancelled</span>');
+        expect(html).toContain('CANCELLED');
+        expect(html).not.toContain('Upcoming</span>');
+        expect(html).not.toContain('View Live');
+        expect(html).not.toContain('Live Now');
+        expect(html).not.toContain('data-share-mode="live"');
+    });
+
+    it('renders upcoming scheduled games with live-view CTAs', () => {
+        const { renderDbGame } = buildRenderDbGame();
+
+        const html = renderDbGame({
+            id: 'game-upcoming',
+            opponent: 'Wolves',
+            location: 'North Field',
+            date: '2099-03-10T18:00:00.000Z',
+            status: 'scheduled'
+        });
+
+        expect(html).toContain('Upcoming</span>');
+        expect(html).toContain('View Live');
+        expect(html).toContain('data-share-mode="live"');
+        expect(html).not.toContain('Replay');
+    });
+
+    it('renders live games with live badge, score block, and live URL', () => {
+        const { renderDbGame } = buildRenderDbGame();
+
+        const html = renderDbGame({
+            id: 'game-live',
+            opponent: 'Falcons',
+            location: 'South Gym',
+            date: '2099-03-10T18:00:00.000Z',
+            status: 'scheduled',
+            liveStatus: 'live',
+            homeScore: 12,
+            awayScore: 10
+        });
+
+        expect(html).toContain('LIVE NOW');
+        expect(html).toContain('Live Now');
+        expect(html).toContain('live-game.html?teamId=team-1&gameId=game-live');
+        expect(html).toContain('>12</div>');
+        expect(html).toContain('>10</div>');
+        expect(html).not.toContain('View Report');
+    });
+
+    it('renders completed replay CTAs only when live playback exists', () => {
+        const { renderDbGame } = buildRenderDbGame();
+
+        const replayHtml = renderDbGame({
+            id: 'game-completed-replay',
+            opponent: 'Bears',
+            location: 'Arena',
+            date: '2024-03-10T18:00:00.000Z',
+            status: 'completed',
+            liveStatus: 'completed',
+            homeScore: 55,
+            awayScore: 49
+        });
+
+        expect(replayHtml).toContain('View Report');
+        expect(replayHtml).toContain('Share Report');
+        expect(replayHtml).toContain('Replay');
+        expect(replayHtml).toContain('live-game.html?teamId=team-1&gameId=game-completed-replay&replay=true');
+        expect(replayHtml).not.toContain('View Live');
+
+        const reportOnlyHtml = renderDbGame({
+            id: 'game-completed-report-only',
+            opponent: 'Sharks',
+            location: 'Arena',
+            date: '2024-03-10T18:00:00.000Z',
+            status: 'completed',
+            liveStatus: 'scheduled',
+            homeScore: 60,
+            awayScore: 58
+        });
+
+        expect(reportOnlyHtml).toContain('View Report');
+        expect(reportOnlyHtml).toContain('Share Report');
+        expect(reportOnlyHtml).not.toContain('Replay');
+    });
+
+    it('renders tied completed games with the tie badge', () => {
+        const { renderDbGame } = buildRenderDbGame();
+
+        const html = renderDbGame({
+            id: 'game-tied',
+            opponent: 'Raiders',
+            location: 'Arena',
+            date: '2024-03-10T18:00:00.000Z',
+            status: 'completed',
+            homeScore: 3,
+            awayScore: 3
+        });
+
+        expect(html).toMatch(/>\s*T\s*<\/span>/);
+        expect(html).toContain('bg-yellow-100 text-yellow-800');
+        expect(html).toContain('View Report');
+    });
+});

--- a/tests/unit/team-schedule-events.test.js
+++ b/tests/unit/team-schedule-events.test.js
@@ -1,0 +1,127 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readTeamPage() {
+    return readFileSync(new URL('../../team.html', import.meta.url), 'utf8');
+}
+
+function extractFunctionBody(source, name, nextSignature) {
+    const pattern = new RegExp(`function ${name}\\([^)]*\\) \\{([\\s\\S]*?)\\n        \\}\\n\\n        ${nextSignature}`);
+    const match = source.match(pattern);
+    expect(match, `${name} should exist`).toBeTruthy();
+    return match[1];
+}
+
+function extractAsyncFunctionBody(source, name, nextSignature) {
+    const pattern = new RegExp(`async function ${name}\\([^)]*\\) \\{([\\s\\S]*?)\\n        \\}\\n\\n        ${nextSignature}`);
+    const match = source.match(pattern);
+    expect(match, `${name} should exist`).toBeTruthy();
+    return match[1];
+}
+
+function buildGetAllEvents(overrides = {}) {
+    const source = readTeamPage();
+    const body = extractAsyncFunctionBody(source, 'getAllEvents', 'async function renderSchedule');
+    const deps = {
+        currentTeamId: 'team-1',
+        getTrackedCalendarEventUids: async () => [],
+        fetchAndParseCalendar: async () => [],
+        isTrackedCalendarEvent: () => false,
+        isPracticeEvent: () => false,
+        extractOpponent: () => 'Opponent',
+        ...overrides
+    };
+
+    const createGetAllEvents = new Function('deps', `
+        const {
+            currentTeamId,
+            getTrackedCalendarEventUids,
+            fetchAndParseCalendar,
+            isTrackedCalendarEvent,
+            isPracticeEvent,
+            extractOpponent
+        } = deps;
+        return async function(team, dbGames) {
+${body}
+        };
+    `);
+
+    return createGetAllEvents(deps);
+}
+
+function buildGetNextGame(overrides = {}) {
+    const source = readTeamPage();
+    const body = extractFunctionBody(source, 'getNextGame', 'function updateCountdown');
+    const deps = {
+        showPractices: false,
+        ...overrides
+    };
+
+    const createGetNextGame = new Function('deps', `
+        const { showPractices } = deps;
+        return function(allEvents) {
+${body}
+        };
+    `);
+
+    return createGetNextGame(deps);
+}
+
+describe('team page schedule event normalization', () => {
+    it('preserves CTA-driving db game fields and marks cancelled games explicitly', async () => {
+        const getAllEvents = buildGetAllEvents();
+        const [event] = await getAllEvents({ calendarUrls: [] }, [{
+            id: 'game-123',
+            type: 'game',
+            date: '2099-03-10T18:00:00.000Z',
+            opponent: 'Tigers',
+            location: 'Main Gym',
+            status: 'cancelled',
+            liveStatus: 'completed',
+            homeScore: 20,
+            awayScore: 18,
+            isHome: true,
+            kitColor: 'Blue',
+            arrivalTime: '2099-03-10T17:15:00.000Z',
+            notes: 'Bring warmups',
+            assignments: [{ role: 'Book', value: 'Sam' }],
+            rsvpSummary: { going: 8, maybe: 1, notGoing: 2 }
+        }]);
+
+        expect(event).toMatchObject({
+            type: 'db',
+            id: 'game-123',
+            gameId: 'game-123',
+            status: 'cancelled',
+            liveStatus: 'completed',
+            isCancelled: true,
+            isHome: true,
+            kitColor: 'Blue',
+            notes: 'Bring warmups',
+            rsvpSummary: { going: 8, maybe: 1, notGoing: 2 }
+        });
+        expect(event.assignments).toEqual([{ role: 'Book', value: 'Sam' }]);
+    });
+
+    it('keeps non-cancelled future games eligible for next game selection', () => {
+        const getNextGame = buildGetNextGame();
+        const nextGame = getNextGame([
+            {
+                type: 'db',
+                status: 'cancelled',
+                isCancelled: true,
+                date: new Date('2099-03-10T18:00:00.000Z'),
+                opponent: 'Cancelled Opponent'
+            },
+            {
+                type: 'db',
+                status: 'scheduled',
+                isCancelled: false,
+                date: new Date('2099-03-10T19:00:00.000Z'),
+                opponent: 'Playable Opponent'
+            }
+        ]);
+
+        expect(nextGame?.opponent).toBe('Playable Opponent');
+    });
+});


### PR DESCRIPTION
Closes #523

## Summary
- fail closed for cancelled future team schedule cards so they do not render upcoming or live CTAs
- preserve CTA-driving db game fields during `getAllEvents()` normalization, including `liveStatus`, metadata fields, and derived `isCancelled`
- exclude cancelled future games from `getNextGame()` and add deterministic unit coverage for cancelled, upcoming, live, completed-report, completed-replay, and tie behavior

## Validation
- `pnpm dlx vitest@4.0.18 run tests/unit/team-schedule-card-render.test.js tests/unit/team-schedule-events.test.js`
- `pnpm dlx vitest@4.0.18 run tests/unit`
