### PR TITLE
Hotfix authenticated production smoke timeout

### DIFF
--- a/tests/smoke/static-hosting-bootstrap.spec.js
+++ b/tests/smoke/static-hosting-bootstrap.spec.js
@@ -50,7 +50,7 @@ test.describe('preview boot smoke pages', () => {
 
 test.describe('authenticated smoke pages', () => {
     test.skip(!smokeContext.authEmail || !smokeContext.authPassword, 'SMOKE_AUTH_EMAIL and SMOKE_AUTH_PASSWORD are required');
-    test.setTimeout(90_000);
+    test.setTimeout(300_000);
 
     test('authenticated coach and parent pages render', async ({ page, baseURL }) => {
         await loginWithPassword(page, baseURL, smokeContext.authEmail, smokeContext.authPassword);


### PR DESCRIPTION
## What changed
- raise the timeout on the single aggregated authenticated production smoke test from 90s to 300s

## Why
- after the parent-dashboard boot fix landed, scheduled-prod-smoke progressed past that page and then timed out later in the same long authenticated smoke flow on game report
- this test walks multiple real production pages in one session, so the timeout needs to cover the full flow rather than one page

## Verification
- previous follow-up production run on master reached game report before timing out at the 90s test budget
- this change is intentionally scoped to the single authenticated end-to-end smoke path
