### PR TITLE
[codex] Guard game-plan save for shared games

### DIFF
--- a/game-plan.html
+++ b/game-plan.html
@@ -505,8 +505,16 @@
             intervalsCache = [];
             lastSelectedPlayerId = null;
             dragSourceCellKey = null;
-            document.getElementById('save-plan-btn').disabled = !!game.isCalendar;
-            document.getElementById('save-plan-btn').title = game.isCalendar ? 'Create this as a scheduled game to save the plan' : '';
+            const savePlanButton = document.getElementById('save-plan-btn');
+            const isReadOnlyGame = !!game.isCalendar || !!game.isSharedGame;
+            savePlanButton.disabled = isReadOnlyGame;
+            if (game.isCalendar) {
+                savePlanButton.title = 'Create this as a scheduled game to save the plan';
+            } else if (game.isSharedGame) {
+                savePlanButton.title = 'Shared tournament games are read-only in Game Plan right now';
+            } else {
+                savePlanButton.title = '';
+            }
 
             // Update UI with game plan data
             document.getElementById('num-periods').value = gamePlan.numPeriods;

--- a/tests/unit/game-plan-switching.test.js
+++ b/tests/unit/game-plan-switching.test.js
@@ -230,4 +230,19 @@ describe('game plan game switching', () => {
         });
         expect(deps.updateGame.mock.calls[0][2].gamePlan.lineups).not.toHaveProperty('1-7-keeper');
     });
+
+    it('disables saving for shared projected games', async () => {
+        const { harness, document } = buildHarness();
+
+        await harness.loadGame({
+            id: 'shared_games%2Fabc123',
+            opponent: 'Wolves',
+            date: '2026-04-06T19:00:00.000Z',
+            isSharedGame: true
+        });
+
+        const saveButton = document.getElementById('save-plan-btn');
+        expect(saveButton.disabled).toBe(true);
+        expect(saveButton.title).toBe('Shared tournament games are read-only in Game Plan right now');
+    });
 });


### PR DESCRIPTION
## What changed
- disabled **Save Plan** for shared projected tournament games in `game-plan.html`
- added a specific tooltip so the UI explains why the game is read-only instead of failing on save
- added unit coverage for the shared-game case in `tests/unit/game-plan-switching.test.js`

## Why
Game Plan still saves by calling `updateGame(teamId, gameId, { gamePlan })`, but shared projected games are surfaced with synthetic IDs and resolve to shared game docs rather than writable team-owned `/teams/{teamId}/games/{gameId}` docs.

That mismatch causes save attempts on shared projected games to fail at write time. This change blocks the invalid save path in the planner UI and makes the behavior explicit.

## Root cause
The shared game projection rollout made shared tournament games appear in normal team game lists, but Game Plan still assumed every selected game was a writable team-owned game document.

## Validation
- ran `node node_modules/vitest/vitest.mjs run tests/unit/game-plan-switching.test.js`
- result: `1` test file passed, `3` tests passed