### PR TITLE
Fix team location link bubbling on Teams page

### DIFF
--- a/docs/pr-notes/runs/530-remediator-20260413T185004Z/code-plan.md
+++ b/docs/pr-notes/runs/530-remediator-20260413T185004Z/code-plan.md
@@ -1,0 +1,19 @@
+## Target Files
+- `tests/unit/teams-location-link-navigation.test.js`
+- `teams.html` (reference only to confirm the exact selector already used in production)
+
+## Minimal Patch
+- Tighten the mocked `closest()` behavior in `tests/unit/teams-location-link-navigation.test.js` so it only returns a truthy value when the selector exactly matches `a, button, input, select, textarea, summary, [role="button"], [role="link"]`.
+- Leave production code unchanged if `teams.html` already uses that exact selector.
+
+## Validation Plan
+- Confirm the selector string in `teams.html` matches the expected interactive selector.
+- Re-read the test to verify the mock no longer passes on partial selector matches such as any string containing `a`.
+- If a local unit test command is available in the PR branch, run the focused test file; otherwise document validation as static review only.
+
+## Risks
+- Low risk, test-only change.
+- If the production selector changes later, this test will need to be updated to stay aligned.
+
+## Rollback
+- Revert the test mock change in `tests/unit/teams-location-link-navigation.test.js`.

--- a/docs/pr-notes/runs/530-review-comment-3075055607-20260413T184416Z/architecture.md
+++ b/docs/pr-notes/runs/530-review-comment-3075055607-20260413T184416Z/architecture.md
@@ -1,0 +1,23 @@
+## Acceptance Criteria
+- Production behavior in `teams.html` remains unchanged because the shipped click guard already checks the intended interactive selector.
+- The unit test must only return a truthy `closest()` result when the selector exactly equals `a, button, input, select, textarea, summary, [role="button"], [role="link"]`.
+- The test must fail if the mock uses loose partial matching that could mask a broken nested-link guard.
+
+## Architecture Decisions
+- Treat this as a test-contract correction, not a production architecture change.
+- Keep `teams.html` as the source of truth for the interactive selector contract.
+- Align the test mock to the exact selector string used by the card click guard.
+
+## QA Impact
+- Validation focuses on preserving existing card navigation while proving nested interactive elements bypass card-level routing.
+- Main QA risk is future selector drift between `teams.html` and the unit test.
+
+## Implementation Notes
+- Update only `tests/unit/teams-location-link-navigation.test.js`.
+- Replace the loose `selector.includes('a')` mock behavior with exact selector equality.
+- Keep the patch minimal and reversible.
+
+## Risks And Rollback
+- Risk is low because the change is test-only.
+- If the selector changes intentionally later, the test must be updated in the same change.
+- Rollback is a simple revert of the test file and run-note artifacts.

--- a/docs/pr-notes/runs/530-review-comment-3075055607-20260413T184416Z/code-plan.md
+++ b/docs/pr-notes/runs/530-review-comment-3075055607-20260413T184416Z/code-plan.md
@@ -1,0 +1,19 @@
+## Target Files
+- `tests/unit/teams-location-link-navigation.test.js`
+- `teams.html` (reference only to confirm the exact selector already used in production)
+
+## Minimal Patch
+- Tighten the mocked `closest()` behavior in `tests/unit/teams-location-link-navigation.test.js` so it only returns a truthy value when the selector exactly matches `a, button, input, select, textarea, summary, [role="button"], [role="link"]`.
+- Leave production code unchanged if `teams.html` already uses that exact selector.
+
+## Validation Plan
+- Confirm the selector string in `teams.html` matches the expected interactive selector.
+- Re-read the test to verify the mock no longer passes on partial selector matches such as any string containing `a`.
+- If a local unit test command is available in the PR branch, run the focused test file; otherwise document validation as static review only.
+
+## Risks
+- Low risk, test-only change.
+- If the production selector changes later, this test will need to be updated to stay aligned.
+
+## Rollback
+- Revert the test mock change in `tests/unit/teams-location-link-navigation.test.js`.

--- a/docs/pr-notes/runs/530-review-comment-3075055607-20260413T184416Z/qa.md
+++ b/docs/pr-notes/runs/530-review-comment-3075055607-20260413T184416Z/qa.md
@@ -1,0 +1,23 @@
+## Scope
+- QA review for PR #530 review-comment remediation in `tests/unit/teams-location-link-navigation.test.js`.
+- Verified `teams.html` click handler checks `event.target.closest('a, button, input, select, textarea, summary, [role="button"], [role="link"]')` before card navigation.
+- Confirmed the updated unit-test expectation should match that exact selector string so the test only passes when the production guard stays aligned.
+
+## Regression Risks
+- Low: change is test-only and tightens mock behavior.
+- Main risk is future drift between the selector in `teams.html` and the selector asserted by the mock/test.
+- If the selector broadens or narrows intentionally later, this test will need an explicit update.
+
+## Test Matrix
+- Pass: card-body click with `closest()` returning `null` navigates to `team.html#teamId=team-123`.
+- Pass: nested interactive element click with `closest()` returning a node only for the exact selector leaves `window.location.href` unchanged.
+- Negative: mock must not return truthy for partial selector matches such as any selector containing `a`.
+
+## Manual Checks
+- On `teams.html`, click a non-interactive area of a team card and confirm navigation to the team page.
+- Click the nested location link and confirm Google Maps opens in a new tab while the current teams page stays put.
+- Spot check keyboard/interactive elements inside cards still behave independently from card-level navigation.
+
+## Recommendation
+- Approve from QA once the test mock is constrained to the exact selector string used in `teams.html`.
+- No additional regression concerns beyond keeping test and production selector strings synchronized.

--- a/docs/pr-notes/runs/530-review-comment-3075055607-20260413T184416Z/requirements.md
+++ b/docs/pr-notes/runs/530-review-comment-3075055607-20260413T184416Z/requirements.md
@@ -1,0 +1,22 @@
+## Acceptance Criteria
+1. The team card click behavior must navigate to `team.html#teamId={id}` only when the click originates from a non-interactive area of the card.
+2. Clicking the nested location link must not trigger card-level navigation in the current tab, so coaches, parents, and admins can open the map destination without losing their place in the teams list.
+3. The unit test for the nested location link scenario must only treat the exact interactive selector string `a, button, input, select, textarea, summary, [role="button"], [role="link"]` as interactive, so the test matches the shipped UI behavior instead of passing on partial selector matches.
+4. If any other selector string is passed to the mocked `closest`, the test must return `null` and must not create a false positive for blocked navigation.
+
+## UX Notes
+- The card should feel tappable for quick browsing, especially on mobile.
+- Nested controls, especially the location link, must preserve their own expected behavior and must not hijack the user into the team detail page.
+- This matters most in fast parent and coach browsing flows where losing the current list context is frustrating.
+
+## Edge Cases
+- Clicks on text or icons inside the location link should still count as interactive and avoid card navigation.
+- Future nested buttons or link-like controls should remain protected by the same interactive selector contract.
+- A test that passes because a mock matches any selector containing `a` is invalid, because it can hide regressions in the interactive guard.
+
+## Risks
+- A loose mock can approve broken click-guard logic and let regressions reach production.
+- If the selector contract drifts between implementation and test, users may see unexpected navigation when trying to use nested controls.
+
+## Recommendation
+Tighten the mock to recognize only the exact selector string used by the production click guard. This keeps the test aligned with real behavior and gives high confidence that nested interactive elements, especially the location link, do not trigger accidental card navigation.

--- a/docs/pr-notes/runs/issue-512-fixer-20260413T182836Z/architecture.md
+++ b/docs/pr-notes/runs/issue-512-fixer-20260413T182836Z/architecture.md
@@ -1,0 +1,23 @@
+# Issue #512 Architecture
+
+## Architecture Decisions
+- Keep the fix local to `teams.html`.
+- Preserve the existing card navigation to `team.html#teamId=...`.
+- Guard the card click handler so nested interactive elements, especially the Google Maps anchor, do not trigger card navigation.
+- Do not cancel the anchor default, so Maps still opens in a new tab.
+
+## Minimal Change Scope
+- Touch only `teams.html` for the production fix.
+- Do not change Firebase logic, routing structure, styling, or data models.
+
+## Tradeoffs Considered
+1. Add `stopPropagation()` on the Maps link only. Smallest literal fix, but less robust for future nested controls.
+2. Guard navigation in the card click handler. Slightly more logic, still minimal, and protects future nested interactive targets.
+3. Refactor the card UX so only a dedicated button navigates. Cleaner model, but too large for this bug.
+
+## Risks And Rollback
+- Risk: a selector that is too narrow may miss future controls; too broad may suppress normal card clicks.
+- Rollback: revert the single listener change in `teams.html`.
+
+## Recommendation
+Use the card-level guard as the smallest coherent fix with the lowest blast radius.

--- a/docs/pr-notes/runs/issue-512-fixer-20260413T182836Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-512-fixer-20260413T182836Z/code-plan.md
@@ -1,0 +1,26 @@
+# Issue #512 Execution Plan
+
+## Acceptance Criteria
+- Location link opens Google Maps without redirecting the current tab.
+- Card clicks outside nested interactive elements still navigate to the team page.
+
+## Architecture Decisions
+- Keep the production change inside `teams.html`.
+- Guard the card click handler instead of modifying routing or layout.
+
+## QA Plan
+- Add a focused Vitest unit test that proves card clicks navigate and nested link clicks do not.
+- Run the targeted unit test file, then run the full unit suite if the changed area remains stable.
+
+## Implementation Plan
+1. Add a unit test that extracts the team-card click handler from `teams.html` and reproduces the bubbling bug.
+2. Update the card click handler to return early when the event target is inside an interactive element.
+3. Re-run the targeted test and the unit test suite.
+
+## Risks And Rollback
+- Risk: suppressing too many clicks could block intended navigation.
+- Mitigation: use a conventional interactive selector and keep the patch isolated.
+- Rollback: revert the `teams.html` listener change and the associated test if needed.
+
+## Chosen Direction
+Use a card-level guard for nested interactive targets. It is minimal, reversible, and less brittle than fixing only the current anchor.

--- a/docs/pr-notes/runs/issue-512-fixer-20260413T182836Z/qa.md
+++ b/docs/pr-notes/runs/issue-512-fixer-20260413T182836Z/qa.md
@@ -1,0 +1,25 @@
+# Issue #512 QA
+
+## QA Plan
+- Add focused unit coverage for `teams.html` click handling.
+- Manually verify that card clicks still navigate and location link clicks open Maps without moving the current tab.
+
+## Test Cases
+1. Clicking a non-link area of a team card navigates to `team.html#teamId=<id>`.
+2. Clicking the Google Maps location link does not navigate the current tab.
+3. Cards without a location link retain existing card navigation behavior.
+4. Clicking near the location row but not on the anchor still navigates.
+
+## Regression Risks
+- Over-broad event suppression could disable intended card navigation.
+- Under-broad suppression could allow nested interactive elements to bubble again.
+
+## Manual Verification
+1. Open `teams.html`.
+2. Click a team card body and confirm navigation to the team page.
+3. Return to `teams.html`.
+4. Click the location link and confirm Google Maps opens in a new tab while the current tab stays on `teams.html`.
+5. Repeat with keyboard activation on the focused location link.
+
+## Recommendation
+Back the fix with a narrow Vitest unit test and targeted manual verification.

--- a/docs/pr-notes/runs/issue-512-fixer-20260413T182836Z/requirements.md
+++ b/docs/pr-notes/runs/issue-512-fixer-20260413T182836Z/requirements.md
@@ -1,0 +1,26 @@
+# Issue #512 Requirements
+
+## Acceptance Criteria
+1. Clicking a team's location link on `teams.html` opens Google Maps in a new tab or window only.
+2. Clicking the location link does not navigate the current tab away from `teams.html`.
+3. Clicking anywhere else on the same team card still navigates to `team.html#teamId=...`.
+4. Keyboard activation of the focused location link behaves the same as mouse activation.
+5. Team cards without a location link keep their existing navigation behavior unchanged.
+
+## UX Notes
+- The Teams browse flow is location-first, so users must be able to inspect a map and keep their place in the list.
+- The location text should keep behaving like a normal external link.
+- Scope stays limited to the location interaction bug.
+
+## Edge Cases
+- Ctrl/Cmd-click or middle-click on the location link should follow normal browser behavior.
+- Double-clicking the location link should not redirect the current tab.
+- Clicking the location row outside the anchor should still trigger team-card navigation.
+- Cards without a rendered location link should remain unchanged.
+
+## Risks
+- A mouse-only fix could still fail for keyboard activation.
+- Overly broad suppression could block intended team-card navigation.
+
+## Recommendation
+Treat the location link as an independent interactive target and ensure the team-card navigation does not run when that link is activated.

--- a/teams.html
+++ b/teams.html
@@ -215,7 +215,12 @@
 
         // Attach card navigation
         container.querySelectorAll('.team-card').forEach(cardEl => {
-          cardEl.addEventListener('click', () => {
+          cardEl.addEventListener('click', (event) => {
+            const interactiveTarget = event.target.closest('a, button, input, select, textarea, summary, [role="button"], [role="link"]');
+            if (interactiveTarget) {
+              return;
+            }
+
             const id = cardEl.dataset.teamId;
             window.location.href = `team.html#teamId=${id}`;
           });

--- a/tests/unit/teams-location-link-navigation.test.js
+++ b/tests/unit/teams-location-link-navigation.test.js
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 
+const interactiveSelector = 'a, button, input, select, textarea, summary, [role="button"], [role="link"]';
+
 function readTeamsPage() {
     return readFileSync(new URL('../../teams.html', import.meta.url), 'utf8');
 }
@@ -44,8 +46,6 @@ ${body}
 }
 
 describe('teams page location link navigation', () => {
-    const interactiveSelector = 'a, button, input, select, textarea, summary, [role="button"], [role="link"]';
-
     it('navigates to the team page when the card body is clicked', () => {
         const { window, handler } = buildTeamCardClickHandler();
 
@@ -60,15 +60,18 @@ describe('teams page location link navigation', () => {
 
     it('does not navigate the current tab when the nested location link is clicked', () => {
         const { window, handler } = buildTeamCardClickHandler();
+        const closest = (selector) => {
+            if (selector === interactiveSelector) {
+                return { tagName: 'A' };
+            }
+            return null;
+        };
+
+        expect(closest('article')).toBeNull();
 
         handler({
             target: {
-                closest: (selector) => {
-                    if (selector === interactiveSelector) {
-                        return {};
-                    }
-                    return null;
-                }
+                closest
             }
         });
 

--- a/tests/unit/teams-location-link-navigation.test.js
+++ b/tests/unit/teams-location-link-navigation.test.js
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readTeamsPage() {
+    return readFileSync(new URL('../../teams.html', import.meta.url), 'utf8');
+}
+
+function extractTeamCardClickHandler() {
+    const source = readTeamsPage();
+    const match = source.match(/cardEl\.addEventListener\('click',\s*(\([^)]*\)|[A-Za-z_$][\w$]*)\s*=>\s*\{([\s\S]*?)\n\s*\}\);/);
+
+    expect(match, 'team card click handler should exist').toBeTruthy();
+    return {
+        params: match[1],
+        body: match[2]
+    };
+}
+
+function buildTeamCardClickHandler({ href = 'http://example.com/teams.html', teamId = 'team-123' } = {}) {
+    const { params, body } = extractTeamCardClickHandler();
+    const window = {
+        location: {
+            href
+        }
+    };
+    const cardEl = {
+        dataset: {
+            teamId
+        }
+    };
+
+    const createHandler = new Function('context', `
+        const window = context.window;
+        const cardEl = context.cardEl;
+        return ${params} => {
+${body}
+        };
+    `);
+
+    return {
+        window,
+        handler: createHandler({ window, cardEl })
+    };
+}
+
+describe('teams page location link navigation', () => {
+    it('navigates to the team page when the card body is clicked', () => {
+        const { window, handler } = buildTeamCardClickHandler();
+
+        handler({
+            target: {
+                closest: () => null
+            }
+        });
+
+        expect(window.location.href).toBe('team.html#teamId=team-123');
+    });
+
+    it('does not navigate the current tab when the nested location link is clicked', () => {
+        const { window, handler } = buildTeamCardClickHandler();
+
+        handler({
+            target: {
+                closest: (selector) => (selector.includes('a') ? {} : null)
+            }
+        });
+
+        expect(window.location.href).toBe('http://example.com/teams.html');
+    });
+});

--- a/tests/unit/teams-location-link-navigation.test.js
+++ b/tests/unit/teams-location-link-navigation.test.js
@@ -44,6 +44,8 @@ ${body}
 }
 
 describe('teams page location link navigation', () => {
+    const interactiveSelector = 'a, button, input, select, textarea, summary, [role="button"], [role="link"]';
+
     it('navigates to the team page when the card body is clicked', () => {
         const { window, handler } = buildTeamCardClickHandler();
 
@@ -61,7 +63,12 @@ describe('teams page location link navigation', () => {
 
         handler({
             target: {
-                closest: (selector) => (selector.includes('a') ? {} : null)
+                closest: (selector) => {
+                    if (selector === interactiveSelector) {
+                        return {};
+                    }
+                    return null;
+                }
             }
         });
 


### PR DESCRIPTION
Closes #512

## What changed
- guarded the `.team-card` click handler in `teams.html` so nested interactive elements, including the Google Maps location link, no longer trigger card navigation
- added a focused Vitest regression test covering both normal card clicks and nested location-link clicks
- persisted the required role artifacts for requirements, architecture, QA, and implementation planning under the run notes directory

## Why
The Teams browse workflow is location-first. Clicking the location link should open Google Maps without forcing the current tab away from `teams.html`, while clicks on the rest of the card should still navigate to the team details page.

## Validation
- verified the pre-fix handler from `HEAD` reproduced the bug behavior
- `npx vitest run tests/unit/teams-location-link-navigation.test.js`
- `npm test -- tests/unit`