### PR TITLE
Fix resumed live-game substitution dropdown state

### DIFF
--- a/docs/pr-notes/runs/532-ci-fix-20260418T214507Z/architecture.md
+++ b/docs/pr-notes/runs/532-ci-fix-20260418T214507Z/architecture.md
@@ -1,0 +1,20 @@
+# Architecture
+
+## Current State
+- `applyLiveSubstitution()` now persists stable player IDs alongside display names in `rotationActual`.
+- The CI assertions in `tests/unit/game-day-live-substitutions.test.js` still expected the older name-only payload shape.
+
+## Proposed State
+- Keep the runtime payload unchanged.
+- Update the failing unit assertions to validate the additive ID fields instead of rejecting them.
+
+## Blast Radius
+- Scoped to one unit test file covering game-day live substitutions.
+- No production behavior changes.
+
+## Controls And Rollback
+- Validation is the targeted Vitest file for the affected helper module.
+- Rollback is a single test-file revert if needed.
+
+## Recommendation
+- Treat the persisted ID fields as intentional schema growth and assert them explicitly so the test protects the regression it was meant to cover.

--- a/docs/pr-notes/runs/532-ci-fix-20260418T214507Z/code-plan.md
+++ b/docs/pr-notes/runs/532-ci-fix-20260418T214507Z/code-plan.md
@@ -1,0 +1,19 @@
+# Code Plan
+
+## Acceptance Criteria
+- The failing game-day live substitution tests pass in CI.
+- Assertions verify the stable ID fields now persisted on substitution records.
+- No production code changes are required for this CI fix.
+
+## Root Cause
+- `js/game-day-live-substitutions.js` persists additive `outId`/`inId` and alias ID fields.
+- `tests/unit/game-day-live-substitutions.test.js` still deep-equaled the old name-only objects, so Vitest failed on extra keys.
+
+## Implementation Plan
+1. Update the two failing assertions to inspect the first saved substitution entry.
+2. Assert the existing display fields plus the new stable ID fields with `toMatchObject`.
+3. Run the targeted Vitest file.
+
+## Risks And Rollback
+- Low risk because only test expectations change.
+- Roll back by reverting the note files and the unit test if needed.

--- a/docs/pr-notes/runs/532-ci-fix-20260418T214507Z/qa.md
+++ b/docs/pr-notes/runs/532-ci-fix-20260418T214507Z/qa.md
@@ -1,0 +1,16 @@
+# QA
+
+## Highest-Risk Scenarios
+- Reloaded game-day state drops the substituted player because persisted IDs are not honored.
+- Tests reject additive substitution metadata and fail CI even though runtime behavior is correct.
+
+## Minimal Validation Plan
+1. Run `npx vitest run tests/unit/game-day-live-substitutions.test.js`.
+2. Confirm the persisted substitution entries assert both display names and stable IDs.
+
+## Expected Outcomes
+- The helper still preserves the on-field map across reloads.
+- CI passes because the unit tests match the current persisted payload shape.
+
+## Regression Concern
+- Future payload growth should prefer partial object assertions when the behavior under test is lineup reconstruction, not exact serialization ordering.

--- a/docs/pr-notes/runs/532-remediator-20260413T192509Z/architecture.md
+++ b/docs/pr-notes/runs/532-remediator-20260413T192509Z/architecture.md
@@ -1,0 +1,20 @@
+# Architecture
+
+## Current State
+- `rotationPlan[period][position]` stores player IDs.
+- `rotationActual` substitution replay was updating the live lineup by matching `sub.in` against `state.players.find(p => p.name === sub.in)`.
+
+## Proposed State
+- Store additive `outId` and `inId` on new substitution records.
+- Replay substitutions into the on-field map by ID first, with legacy name fallback.
+
+## Blast Radius
+- Scoped to game-day substitution persistence and reload behavior.
+- No schema migration required because the new fields are additive and old records still replay via fallback.
+
+## Controls And Rollback
+- Backward compatibility limits risk for existing saved games.
+- Rollback is a single-file revert if the live lineup rendering regresses.
+
+## Recommendation
+- Keep the patch minimal in `game-day.html` and mirror the logic in `test-game-day.html` so the documented regression case stays covered.

--- a/docs/pr-notes/runs/532-remediator-20260413T192509Z/code-plan.md
+++ b/docs/pr-notes/runs/532-remediator-20260413T192509Z/code-plan.md
@@ -1,0 +1,14 @@
+# Code Plan
+
+## Root Cause
+- The merged on-field map stopped using stable roster IDs and instead replayed substitutions through display-name lookup.
+
+## Minimal Patch Shape
+1. Add a helper that resolves substitution participants by stored player ID first, then by legacy name.
+2. Update `buildOnFieldMap(period)` to use the helper when applying `rotationActual` substitutions.
+3. Persist `outId` and `inId` when saving a new substitution entry.
+4. Update `test-game-day.html` to mirror the production logic and cover duplicate-name replay.
+
+## Validation
+- Load the HTML test page and confirm Suite 5 passes.
+- Review the diff to ensure only substitution replay and test coverage changed.

--- a/docs/pr-notes/runs/532-remediator-20260413T192509Z/qa.md
+++ b/docs/pr-notes/runs/532-remediator-20260413T192509Z/qa.md
@@ -1,0 +1,21 @@
+# QA
+
+## Highest-Risk Scenarios
+- Two rostered players share the same display name.
+- A player name changes after a substitution is saved, then the game is reopened.
+- Legacy saved games only contain name-based substitution payloads.
+
+## Manual Test Cases
+1. Start with a planned lineup, apply a substitution, reload the page, and confirm the field diagram plus OUT/IN dropdowns show the substituted player on the field.
+2. Apply a second substitution after reload and confirm it targets the substituted-in player's current position.
+3. Use two players with the same name, substitute one for the other, reload, and confirm the correct player remains on the field.
+4. Open a legacy record with name-only substitution data and confirm replay still works.
+
+## Expected Outcomes
+- Current on-field map is derived from stable player IDs when available.
+- Dropdown eligibility matches the actual lineup after reload.
+- Legacy substitution data remains readable.
+
+## Regression Checks
+- Run `test-game-day.html` and confirm Suite 5 passes.
+- Spot-check that field rendering and bench chips still use the merged on-field map.

--- a/docs/pr-notes/runs/532-remediator-20260413T192509Z/requirements.md
+++ b/docs/pr-notes/runs/532-remediator-20260413T192509Z/requirements.md
@@ -1,0 +1,19 @@
+# Requirements
+
+## Acceptance Criteria
+- Reopening a game must preserve the actual on-field lineup using stable player IDs, not display-name matching.
+- Substitution OUT and IN dropdowns must reflect the true current lineup after prior substitutions.
+- Follow-up substitutions must resolve the outgoing player's current position from the merged live lineup.
+- Existing saved games that only have legacy name-based substitution entries must continue to load.
+
+## Risks
+- Duplicate display names can map substitutions to the wrong roster player if name lookup remains in the live-path.
+- Name edits between save and reload can break substitution replay if IDs are not stored.
+
+## Assumptions
+- `rotationActual` is only consumed in `game-day.html` and can safely store additive `outId`/`inId` fields.
+- Backward compatibility is required for older records that already persist names only.
+
+## Recommendation
+- Persist `outId` and `inId` with each substitution while retaining the existing name fields for display/history.
+- Resolve on-field substitutions by stored player ID first, then fall back to legacy name matching for older data.

--- a/docs/pr-notes/runs/532-review-comment-3075270806-20260413T192854Z/architecture.md
+++ b/docs/pr-notes/runs/532-review-comment-3075270806-20260413T192854Z/architecture.md
@@ -1,0 +1,42 @@
+## Current State
+- `rotationActual` substitution entries are persisted with names only, for example `{ position, out, in, appliedAt }`.
+- `buildOnFieldMap()` reconstructs the live lineup by resolving `sub.in` back to a player via `players.find(p => p.name === sub.in)`.
+- That is unsafe for duplicate display names and for players renamed after the substitution was recorded.
+- Because `rotationActual` is the durable source used to rebuild on-field state after reload, name ambiguity becomes a correctness bug.
+
+## Proposed State
+- Keep the existing substitution record shape additive and backward compatible by adding stable player IDs on new writes:
+  ```js
+  {
+      position,
+      out,
+      outPlayerId,
+      in,
+      inPlayerId,
+      appliedAt
+  }
+  ```
+- Update `buildOnFieldMap()` to resolve substitutions by `inPlayerId` first, then fall back to legacy name lookup only when ID fields are absent.
+- Retain `in` and `out` name snapshots for UI and log readability.
+
+## Architecture Decisions
+- ID-first, name-second read path fixes the regression without a data migration.
+- Backward-compatible dual-write keeps new records safe immediately while old records continue to replay.
+- Minimal schema expansion inside existing `rotationActual` entries avoids a new collection or document reshape.
+- No Firestore rules or deployment config changes are required.
+- Chosen field names are `inPlayerId` and `outPlayerId` for clarity. Read logic also tolerates `inId` if encountered.
+
+## Blast Radius
+- `game-day.html`: substitution write path and lineup reconstruction logic.
+- `test-game-day.html`: mirrored helper logic and regression coverage.
+- Persisted game documents: mixed old and new `rotationActual` entries can coexist safely.
+
+## Risks
+- Legacy name-only substitutions remain ambiguous if duplicate names already exist in historical data.
+- If an `inPlayerId` points to a missing roster player, reconstruction should fail safe and not guess by name.
+- Mixed-format records require explicit regression coverage so fallback behavior does not mask malformed new writes.
+
+## Rollback
+- Safe rollback is code-only: revert the ID-first read/write logic and continue ignoring the added fields.
+- Added `inPlayerId` and `outPlayerId` fields are additive, so older code ignores them.
+- No migration or data cleanup is needed to roll back.

--- a/docs/pr-notes/runs/532-review-comment-3075270806-20260413T192854Z/code-plan.md
+++ b/docs/pr-notes/runs/532-review-comment-3075270806-20260413T192854Z/code-plan.md
@@ -1,0 +1,37 @@
+## Root Cause
+- `buildOnFieldMap()` in both `game-day.html` and `test-game-day.html` replayed `rotationActual` by resolving `sub.in` with `players.find(p => p.name === sub.in)`.
+- `applySub()` persisted only player names in `rotationActual`, so saved substitutions depended on mutable, non-unique display names.
+- That breaks substitution reconstruction after reload when two players share a name or when a player has been renamed.
+
+## Minimal Patch Plan
+- In `applySub()`, keep the current human-readable fields, but also persist stable IDs:
+  - `outPlayerId: outPlayer.id`
+  - `inPlayerId: inPlayer.id`
+- Update `buildOnFieldMap()` to apply subs by stable ID first:
+  - `const nextPlayerId = sub.inPlayerId || sub.inId || players.find(p => p.name === sub.in)?.id;`
+- Keep the name lookup only as a backward-compatible read fallback for older `rotationActual` entries stored without IDs.
+- Do not add a migration. New writes become safe immediately and old records continue to replay.
+
+## Test Updates
+- Update the current substitution reload assertion to use a stored `inPlayerId`.
+- Add duplicate-name regression coverage where two players share the same `name` and the persisted `inPlayerId` must keep the intended player on the field.
+- Add renamed-player regression coverage where persisted `inPlayerId` must still resolve after the player object's current `name` differs from stored `sub.in`.
+- Keep one legacy coverage case proving old name-only `rotationActual` entries still work via fallback.
+
+## Validation Commands
+```bash
+git diff -- game-day.html test-game-day.html docs/pr-notes/runs/532-review-comment-3075270806-20260413T192854Z
+node .tmp-run-test-game-day.cjs
+git status --short
+```
+
+## Commit Scope
+- `game-day.html`
+  - Persist `inPlayerId` and `outPlayerId` on new substitution writes.
+  - Resolve actual substitutions with ID-first, name-fallback logic.
+- `test-game-day.html`
+  - Mirror the ID-first helper behavior.
+  - Add regression tests for duplicate names, renamed players, and legacy name-only records.
+- `docs/pr-notes/runs/532-review-comment-3075270806-20260413T192854Z/*`
+  - Persist run-scoped requirements, architecture, QA, and code-plan notes for traceability.
+- No schema migration, build-step change, or unrelated refactor.

--- a/docs/pr-notes/runs/532-review-comment-3075270806-20260413T192854Z/qa.md
+++ b/docs/pr-notes/runs/532-review-comment-3075270806-20260413T192854Z/qa.md
@@ -1,0 +1,35 @@
+## Risk Assessment
+- **High:** Reload can put the wrong player on the field when `rotationActual` resolves `sub.in` by display name instead of stable player ID.
+- **High:** Renaming a player after a substitution can orphan the saved sub on reload if only the old name is persisted.
+- **Medium:** Mixed data is likely in production, with some subs saved as legacy name-only entries and newer subs saved with IDs.
+- **Medium:** Ambiguous legacy duplicate-name entries cannot be safely disambiguated from name alone, so the fix must fail safe rather than silently pick the wrong player.
+
+## Regression Targets
+1. `buildOnFieldMap()` prefers persisted player ID for `sub.in` when available.
+2. Duplicate display names do not cause the wrong player to appear after reload.
+3. Player rename after sub save still resolves the same roster player after reload.
+4. Legacy name-only substitution records still hydrate for unique-name rosters.
+5. Mixed legacy and new substitution records in the same game and period render consistently.
+6. Ambiguous or stale legacy records do not crash and do not silently remap to the wrong player.
+
+## Test Matrix
+| Scenario | Data shape | Method | Expected |
+|---|---|---|---|
+| Planned lineup only | plan only | automated | Returns planned IDs unchanged |
+| New sub record with stable `inPlayerId` | new format | automated | On-field map uses persisted ID, not name lookup |
+| Duplicate names, sub in second `Alex` | new format | automated | Correct `Alex` ID remains on field after reload |
+| Player renamed after sub save | new format with rename | automated | Same player ID resolves after reload |
+| Legacy unique-name sub | name-only legacy | automated | Existing legacy behavior still works |
+| Mixed old and new subs in same period | hybrid | automated | New ID-backed subs win, legacy unique-name entries still hydrate |
+
+## Manual Checks
+1. In `test-game-day.html`, verify duplicate-name and renamed-player regressions pass.
+2. In `game-day.html`, save a sub, refresh, and confirm the on-field player remains correct for duplicate-name and renamed-player fixtures.
+3. Open a fixture with legacy name-only `rotationActual` entries and unique names, then reload and confirm prior games still render correctly.
+4. Verify no regressions in normal substitution flow, live event log text, and position rendering.
+
+## Exit Criteria
+- Automated coverage exists for duplicate-name, renamed-player, and legacy-fallback cases in `test-game-day.html`.
+- Reloaded `game-day.html` preserves the substituted player by stable ID whenever an ID is available.
+- Legacy unique-name substitution records remain compatible.
+- No regressions appear in standard substitution rendering or planned-lineup fallback.

--- a/docs/pr-notes/runs/532-review-comment-3075270806-20260413T192854Z/requirements.md
+++ b/docs/pr-notes/runs/532-review-comment-3075270806-20260413T192854Z/requirements.md
@@ -1,0 +1,26 @@
+## Objective
+Preserve the correct on-field player after a substitution is saved and the page reloads, using stable player identity rather than mutable display name. The fix should be as small as possible and still work when two players share a name or a player is renamed later.
+
+## User/Roster Risk
+- Coaches can make the wrong next substitution if the field view reloads with the wrong player in a position.
+- Stats, playing-time decisions, and live-game trust can attach to the wrong player.
+- Parents lose confidence quickly if the app shows the wrong child on the field.
+- Duplicate names, preferred-name changes, and midseason roster edits are normal in youth sports, so this is a real game-day risk.
+
+## Acceptance Criteria
+1. After a coach records a substitution, reloads the page, and returns to the same period, the same player remains shown in that position.
+2. If two rostered players have the same display name, a substitution for one of them does not resolve to the other after reload.
+3. If a substituted player is renamed after the substitution is recorded, the app still restores the correct player after reload.
+4. Subsequent substitutions in that period use the correct current on-field player, not a name-matched lookalike.
+5. Existing planned lineups with no actual substitutions still behave exactly as they do today.
+6. Older saved substitution records without stable player identity do not break the page and fall back safely.
+
+## Assumptions
+- Each rostered player already has a stable unique player ID available in game-day state.
+- This PR should prefer a minimal, low-risk patch over a broader rotation-data redesign.
+- Historical `rotationActual` entries may exist with names only, so backward-safe handling matters.
+
+## Open Questions
+- Forward-only additive support plus graceful fallback is sufficient for this PR. No migration is included.
+- Internal correctness is the priority for this fix. UI duplicate-name disambiguation can be handled separately if needed.
+- If a stored player ID no longer resolves because the player was removed, current logic should fail safe by preserving the prior assignment instead of guessing.

--- a/js/game-day-live-substitutions.js
+++ b/js/game-day-live-substitutions.js
@@ -7,6 +7,16 @@ function getPlayersByName(players = []) {
     return byName;
 }
 
+function getSubPlayerId(sub, direction, playerIdsByName, players = []) {
+    if (!sub) return null;
+    const idKey = `${direction}Id`;
+    const nameKey = direction;
+    const directId = sub[idKey] || sub[nameKey];
+    if (directId && players.some((player) => player.id === directId)) return directId;
+    const playerName = sub[nameKey];
+    return playerName ? playerIdsByName.get(playerName) || null : null;
+}
+
 export function buildOnFieldMap({
     period,
     rotationPlan = {},
@@ -19,8 +29,8 @@ export function buildOnFieldMap({
     const playerIdsByName = getPlayersByName(players);
 
     Object.values(actual).flat().forEach((sub) => {
-        if (!sub?.position || !sub?.in) return;
-        const playerId = playerIdsByName.get(sub.in);
+        if (!sub?.position) return;
+        const playerId = getSubPlayerId(sub, 'in', playerIdsByName, players);
         if (playerId) onField[sub.position] = playerId;
     });
 
@@ -84,7 +94,9 @@ export function applyLiveSubstitution({
             [subKey]: [{
                 position,
                 out: outPlayer.name,
+                outId: outPlayer.id,
                 in: inPlayer.name,
+                inId: inPlayer.id,
                 appliedAt: now.toISOString()
             }]
         }

--- a/js/game-day-live-substitutions.js
+++ b/js/game-day-live-substitutions.js
@@ -9,12 +9,11 @@ function getPlayersByName(players = []) {
 
 function getSubPlayerId(sub, direction, playerIdsByName, players = []) {
     if (!sub) return null;
-    const idKey = `${direction}Id`;
-    const nameKey = direction;
-    const directId = sub[idKey] || sub[nameKey];
+    const directId = sub[`${direction}PlayerId`] || sub[`${direction}Id`] || null;
     if (directId && players.some((player) => player.id === directId)) return directId;
-    const playerName = sub[nameKey];
-    return playerName ? playerIdsByName.get(playerName) || null : null;
+    const directValue = sub[direction];
+    if (directValue && players.some((player) => player.id === directValue)) return directValue;
+    return directValue ? playerIdsByName.get(directValue) || null : null;
 }
 
 export function buildOnFieldMap({
@@ -95,8 +94,10 @@ export function applyLiveSubstitution({
                 position,
                 out: outPlayer.name,
                 outId: outPlayer.id,
+                outPlayerId: outPlayer.id,
                 in: inPlayer.name,
                 inId: inPlayer.id,
+                inPlayerId: inPlayer.id,
                 appliedAt: now.toISOString()
             }]
         }

--- a/test-game-day.html
+++ b/test-game-day.html
@@ -157,12 +157,11 @@
 
         function getSubPlayerId(players, sub, direction) {
             if (!sub) return null;
-            const idKey = `${direction}Id`;
-            const nameKey = direction;
-            const directId = sub[idKey] || sub[nameKey];
+            const directId = sub[`${direction}PlayerId`] || sub[`${direction}Id`] || null;
             if (directId && players.some(p => p.id === directId)) return directId;
-            const playerName = sub[nameKey];
-            const player = playerName ? players.find(p => p.name === playerName) : null;
+            const directValue = sub[direction];
+            if (directValue && players.some(p => p.id === directValue)) return directValue;
+            const player = directValue ? players.find(p => p.name === directValue) : null;
             return player?.id || null;
         }
 
@@ -470,7 +469,7 @@
         test('next substitution resolves position from current occupant after reload', () => {
             const plan = { H1: { keeper: 'p1', striker: 'p2' } };
             const actual = {
-                H1: { 'sub-1': [{ position: 'striker', out: 'Bob', outId: 'p2', in: 'Carol', inId: 'p3', appliedAt: '2024-01-01' }] }
+                H1: { 'sub-1': [{ position: 'striker', out: 'Bob', outPlayerId: 'p2', in: 'Carol', inPlayerId: 'p3', appliedAt: '2024-01-01' }] }
             };
             const position = findSubPosition(plan, actual, mockPlayers, 'H1', 'p3');
             assertEquals(position, 'striker', 'Follow-up substitution should target Carol\'s current position, not stale plan data');
@@ -489,6 +488,45 @@
             };
             const map = buildOnFieldMap(plan, actual, players, 'H1');
             assertEquals(map['striker'], 'p4', 'Duplicate names should resolve using the stored player id');
+        });
+
+        test('buildOnFieldMap prefers substitution inPlayerId when roster names collide', () => {
+            const players = [
+                { id: 'p1', name: 'Alex' },
+                { id: 'p2', name: 'Jordan' },
+                { id: 'p3', name: 'Alex' },
+                { id: 'p4', name: 'Taylor' }
+            ];
+            const plan = { H1: { keeper: 'p1', striker: 'p2' } };
+            const actual = {
+                H1: { 'sub-1': [{ position: 'striker', out: 'Jordan', outPlayerId: 'p2', in: 'Alex', inPlayerId: 'p3', appliedAt: '2024-01-01' }] }
+            };
+            const map = buildOnFieldMap(plan, actual, players, 'H1');
+            assertEquals(map.striker, 'p3', 'Reloaded state should keep the substituted player by ID, not the first matching name');
+        });
+
+        test('buildOnFieldMap falls back to legacy name matching when inPlayerId is absent', () => {
+            const plan = { H1: { keeper: 'p1', striker: 'p2' } };
+            const actual = {
+                H1: { 'sub-1': [{ position: 'striker', out: 'Bob', in: 'Carol', appliedAt: '2024-01-01' }] }
+            };
+            const map = buildOnFieldMap(plan, actual, mockPlayers, 'H1');
+            assertEquals(map.striker, 'p3', 'Legacy substitution records without IDs should still resolve by name');
+        });
+
+        test('buildOnFieldMap keeps substituted player after roster rename when inPlayerId exists', () => {
+            const players = [
+                { id: 'p1', name: 'Alice' },
+                { id: 'p2', name: 'Bob' },
+                { id: 'p3', name: 'Carolyn' },
+                { id: 'p4', name: 'Dana' }
+            ];
+            const plan = { H1: { keeper: 'p1', striker: 'p2' } };
+            const actual = {
+                H1: { 'sub-1': [{ position: 'striker', out: 'Bob', outPlayerId: 'p2', in: 'Carol', inPlayerId: 'p3', appliedAt: '2024-01-01' }] }
+            };
+            const map = buildOnFieldMap(plan, actual, players, 'H1');
+            assertEquals(map.striker, 'p3', 'Reloaded state should survive later player renames when IDs are stored');
         });
 
         // ============================================================
@@ -710,7 +748,7 @@
             { name: 'Suite 2: Rotation Plan — Flatten & Rebuild', count: 7 },
             { name: 'Suite 3: Mode State Machine', count: 6 },
             { name: 'Suite 4: Player Color System', count: 8 },
-            { name: 'Suite 5: On-Field Map / Sub Logic', count: 9 },
+            { name: 'Suite 5: On-Field Map / Sub Logic', count: 12 },
             { name: 'Suite 6: Balance Playing Time', count: 5 },
             { name: 'Suite 7: escapeHtml / XSS Prevention', count: 8 },
             { name: 'Suite 8: Access Control Logic', count: 7 },

--- a/test-game-day.html
+++ b/test-game-day.html
@@ -155,14 +155,25 @@
             return playerColors[playerId];
         }
 
+        function getSubPlayerId(players, sub, direction) {
+            if (!sub) return null;
+            const idKey = `${direction}Id`;
+            const nameKey = direction;
+            const directId = sub[idKey] || sub[nameKey];
+            if (directId && players.some(p => p.id === directId)) return directId;
+            const playerName = sub[nameKey];
+            const player = playerName ? players.find(p => p.name === playerName) : null;
+            return player?.id || null;
+        }
+
         function buildOnFieldMap(rotationPlan, rotationActual, players, period) {
             const actual = rotationActual?.[period] || {};
             const plan = rotationPlan?.[period] || {};
             const onField = { ...plan };
             Object.values(actual).flat().forEach(sub => {
-                if (sub && sub.position && sub.in) {
-                    const player = players.find(p => p.name === sub.in);
-                    if (player) onField[sub.position] = player.id;
+                if (sub && sub.position) {
+                    const inPlayerId = getSubPlayerId(players, sub, 'in');
+                    if (inPlayerId) onField[sub.position] = inPlayerId;
                 }
             });
             return onField;
@@ -406,20 +417,29 @@
             assertEquals(map['striker'], 'p2', 'Striker should be p2 from plan');
         });
 
-        test('buildOnFieldMap applies actual sub over planned lineup', () => {
+        test('buildOnFieldMap applies actual sub over planned lineup using player ids', () => {
             const plan = { H1: { keeper: 'p1', striker: 'p2' } };
             const actual = {
-                H1: { 'sub-1': [{ position: 'striker', out: 'Bob', in: 'Carol', appliedAt: '2024-01-01' }] }
+                H1: { 'sub-1': [{ position: 'striker', out: 'Bob', outId: 'p2', in: 'Carol', inId: 'p3', appliedAt: '2024-01-01' }] }
             };
             const map = buildOnFieldMap(plan, actual, mockPlayers, 'H1');
             assertEquals(map['keeper'], 'p1', 'Keeper unchanged by sub');
             assertEquals(map['striker'], 'p3', 'Striker should be updated to Carol (p3) after sub');
         });
 
-        test('buildOnFieldMap ignores subs for unknown player names', () => {
+        test('buildOnFieldMap falls back to legacy name-based subs', () => {
+            const plan = { H1: { keeper: 'p1', striker: 'p2' } };
+            const actual = {
+                H1: { 'sub-1': [{ position: 'striker', out: 'Bob', in: 'Carol', appliedAt: '2024-01-01' }] }
+            };
+            const map = buildOnFieldMap(plan, actual, mockPlayers, 'H1');
+            assertEquals(map['striker'], 'p3', 'Legacy name-based substitutions should still resolve');
+        });
+
+        test('buildOnFieldMap ignores subs for unknown player ids and names', () => {
             const plan = { H1: { keeper: 'p1' } };
             const actual = {
-                H1: { 'sub-1': [{ position: 'keeper', out: 'p1', in: 'NoSuchPlayer', appliedAt: '2024-01-01' }] }
+                H1: { 'sub-1': [{ position: 'keeper', out: 'p1', outId: 'p1', in: 'NoSuchPlayer', inId: 'missing', appliedAt: '2024-01-01' }] }
             };
             const map = buildOnFieldMap(plan, actual, mockPlayers, 'H1');
             assertEquals(map['keeper'], 'p1', 'Should keep original if sub player not found');
@@ -440,7 +460,7 @@
         test('sub dropdowns use merged on-field state after reopening live game', () => {
             const plan = { H1: { keeper: 'p1', striker: 'p2' } };
             const actual = {
-                H1: { 'sub-1': [{ position: 'striker', out: 'Bob', in: 'Carol', appliedAt: '2024-01-01' }] }
+                H1: { 'sub-1': [{ position: 'striker', out: 'Bob', outId: 'p2', in: 'Carol', inId: 'p3', appliedAt: '2024-01-01' }] }
             };
             const dropdowns = getSubDropdownPlayerIds(plan, actual, mockPlayers, 'H1');
             assertDeepEquals(dropdowns.outIds, ['p1', 'p3'], 'OUT choices should reflect current on-field players');
@@ -450,10 +470,25 @@
         test('next substitution resolves position from current occupant after reload', () => {
             const plan = { H1: { keeper: 'p1', striker: 'p2' } };
             const actual = {
-                H1: { 'sub-1': [{ position: 'striker', out: 'Bob', in: 'Carol', appliedAt: '2024-01-01' }] }
+                H1: { 'sub-1': [{ position: 'striker', out: 'Bob', outId: 'p2', in: 'Carol', inId: 'p3', appliedAt: '2024-01-01' }] }
             };
             const position = findSubPosition(plan, actual, mockPlayers, 'H1', 'p3');
             assertEquals(position, 'striker', 'Follow-up substitution should target Carol\'s current position, not stale plan data');
+        });
+
+        test('buildOnFieldMap prefers player ids when duplicate names exist', () => {
+            const players = [
+                { id: 'p1', name: 'Alex', number: '1' },
+                { id: 'p2', name: 'Jordan', number: '2' },
+                { id: 'p3', name: 'Sam', number: '3' },
+                { id: 'p4', name: 'Sam', number: '4' }
+            ];
+            const plan = { H1: { keeper: 'p1', striker: 'p3' } };
+            const actual = {
+                H1: { 'sub-1': [{ position: 'striker', out: 'Sam', outId: 'p3', in: 'Sam', inId: 'p4', appliedAt: '2024-01-01' }] }
+            };
+            const map = buildOnFieldMap(plan, actual, players, 'H1');
+            assertEquals(map['striker'], 'p4', 'Duplicate names should resolve using the stored player id');
         });
 
         // ============================================================
@@ -675,7 +710,7 @@
             { name: 'Suite 2: Rotation Plan — Flatten & Rebuild', count: 7 },
             { name: 'Suite 3: Mode State Machine', count: 6 },
             { name: 'Suite 4: Player Color System', count: 8 },
-            { name: 'Suite 5: On-Field Map / Sub Logic', count: 7 },
+            { name: 'Suite 5: On-Field Map / Sub Logic', count: 9 },
             { name: 'Suite 6: Balance Playing Time', count: 5 },
             { name: 'Suite 7: escapeHtml / XSS Prevention', count: 8 },
             { name: 'Suite 8: Access Control Logic', count: 7 },

--- a/test-game-day.html
+++ b/test-game-day.html
@@ -168,6 +168,20 @@
             return onField;
         }
 
+        function getSubDropdownPlayerIds(rotationPlan, rotationActual, players, period) {
+            const onField = buildOnFieldMap(rotationPlan, rotationActual, players, period);
+            const onFieldIds = new Set(Object.values(onField).filter(Boolean));
+            return {
+                outIds: players.filter(p => onFieldIds.has(p.id)).map(p => p.id),
+                inIds: players.filter(p => !onFieldIds.has(p.id)).map(p => p.id)
+            };
+        }
+
+        function findSubPosition(rotationPlan, rotationActual, players, period, outId) {
+            const onField = buildOnFieldMap(rotationPlan, rotationActual, players, period);
+            return Object.entries(onField).find(([_, playerId]) => playerId === outId)?.[0] || 'unknown';
+        }
+
         function determineInitialMode(liveStatus, status) {
             if (liveStatus === 'live') return 'gameday';
             if (liveStatus === 'completed' || status === 'completed') return 'wrapup';
@@ -423,6 +437,25 @@
             assertEquals(Object.keys(map).length, 0, 'H2 with no plan should return empty map');
         });
 
+        test('sub dropdowns use merged on-field state after reopening live game', () => {
+            const plan = { H1: { keeper: 'p1', striker: 'p2' } };
+            const actual = {
+                H1: { 'sub-1': [{ position: 'striker', out: 'Bob', in: 'Carol', appliedAt: '2024-01-01' }] }
+            };
+            const dropdowns = getSubDropdownPlayerIds(plan, actual, mockPlayers, 'H1');
+            assertDeepEquals(dropdowns.outIds, ['p1', 'p3'], 'OUT choices should reflect current on-field players');
+            assertDeepEquals(dropdowns.inIds, ['p2', 'p4'], 'IN choices should exclude players already subbed onto the field');
+        });
+
+        test('next substitution resolves position from current occupant after reload', () => {
+            const plan = { H1: { keeper: 'p1', striker: 'p2' } };
+            const actual = {
+                H1: { 'sub-1': [{ position: 'striker', out: 'Bob', in: 'Carol', appliedAt: '2024-01-01' }] }
+            };
+            const position = findSubPosition(plan, actual, mockPlayers, 'H1', 'p3');
+            assertEquals(position, 'striker', 'Follow-up substitution should target Carol\'s current position, not stale plan data');
+        });
+
         // ============================================================
         // SUITE 6: Balance Playing Time
         // ============================================================
@@ -642,7 +675,7 @@
             { name: 'Suite 2: Rotation Plan — Flatten & Rebuild', count: 7 },
             { name: 'Suite 3: Mode State Machine', count: 6 },
             { name: 'Suite 4: Player Color System', count: 8 },
-            { name: 'Suite 5: On-Field Map / Sub Logic', count: 5 },
+            { name: 'Suite 5: On-Field Map / Sub Logic', count: 7 },
             { name: 'Suite 6: Balance Playing Time', count: 5 },
             { name: 'Suite 7: escapeHtml / XSS Prevention', count: 8 },
             { name: 'Suite 8: Access Control Logic', count: 7 },

--- a/tests/unit/game-day-live-substitutions.test.js
+++ b/tests/unit/game-day-live-substitutions.test.js
@@ -44,14 +44,17 @@ describe('game day live substitutions', () => {
         });
 
         expect(subResult.rotationPlan.H1).toEqual({ keeper: 'p1', striker: 'p3' });
-        expect(subResult.rotationActual.H1['sub-1776194700000']).toEqual([
-            {
-                position: 'striker',
-                out: 'Blake',
-                in: 'Casey',
-                appliedAt: '2026-04-14T19:25:00.000Z'
-            }
-        ]);
+        expect(subResult.rotationActual.H1['sub-1776194700000']).toHaveLength(1);
+        expect(subResult.rotationActual.H1['sub-1776194700000'][0]).toMatchObject({
+            position: 'striker',
+            out: 'Blake',
+            outId: 'p2',
+            outPlayerId: 'p2',
+            in: 'Casey',
+            inId: 'p3',
+            inPlayerId: 'p3',
+            appliedAt: '2026-04-14T19:25:00.000Z'
+        });
 
         const reloadedRotationPlan = buildRotationPlanFromGamePlan(createSavedGamePlan());
         expect(buildOnFieldMap({
@@ -95,14 +98,17 @@ describe('game day live substitutions', () => {
 
         expect(secondSub.position).toBe('striker');
         expect(secondSub.rotationPlan.H1).toEqual({ keeper: 'p1', striker: 'p2' });
-        expect(secondSub.rotationActual.H1['sub-1776194760000']).toEqual([
-            {
-                position: 'striker',
-                out: 'Casey',
-                in: 'Blake',
-                appliedAt: '2026-04-14T19:26:00.000Z'
-            }
-        ]);
+        expect(secondSub.rotationActual.H1['sub-1776194760000']).toHaveLength(1);
+        expect(secondSub.rotationActual.H1['sub-1776194760000'][0]).toMatchObject({
+            position: 'striker',
+            out: 'Casey',
+            outId: 'p3',
+            outPlayerId: 'p3',
+            in: 'Blake',
+            inId: 'p2',
+            inPlayerId: 'p2',
+            appliedAt: '2026-04-14T19:26:00.000Z'
+        });
     });
 });
 


### PR DESCRIPTION
Closes #526

## What changed
- updated Game Day substitution controls to derive OUT and IN choices from the merged on-field state, not just the original saved rotation plan
- updated follow-up substitution handling to resolve the outgoing player's position from the current merged lineup after a live game is reopened
- added regression coverage for resumed live-game substitution dropdowns and position targeting

## Why
When a live game was reopened after prior substitutions, the field diagram reflected `rotationActual` but the substitution controls still read from the stale planned lineup. That could show the wrong OUT and IN choices and log the next substitution against the wrong player position.