### PR TITLE
Wait for auth before loading private athlete profiles

### DIFF
--- a/athlete-profile.html
+++ b/athlete-profile.html
@@ -32,8 +32,16 @@
         const params = getUrlParams();
         const content = document.getElementById('profile-content');
 
+        let hasStartedProfileLoad = false;
+
         renderFooter(document.getElementById('footer-container'));
-        checkAuth((user) => renderHeader(document.getElementById('header-container'), user));
+        checkAuth((user) => {
+            renderHeader(document.getElementById('header-container'), user);
+            if (!hasStartedProfileLoad) {
+                hasStartedProfileLoad = true;
+                loadProfile();
+            }
+        });
 
         function renderStatGrid(summary) {
             const cards = Object.entries(summary?.statTotals || {}).slice(0, 8).map(([key, total]) => `
@@ -155,7 +163,6 @@
             }
         }
 
-        loadProfile();
     </script>
 </body>
 </html>

--- a/test-pr-changes.html
+++ b/test-pr-changes.html
@@ -234,6 +234,51 @@
         });
 
         // ============================================
+        // TEST SUITE 4: Athlete Profile Auth Readiness
+        // ============================================
+
+        function initializeAthleteProfilePage(onAuthResolved, loadProfile) {
+            let hasStartedProfileLoad = false;
+
+            onAuthResolved(() => {
+                if (!hasStartedProfileLoad) {
+                    hasStartedProfileLoad = true;
+                    loadProfile();
+                }
+            });
+        }
+
+        test('Athlete profile waits for auth before loading once', () => {
+            let loadCount = 0;
+            let authCallback = null;
+
+            initializeAthleteProfilePage((callback) => {
+                authCallback = callback;
+            }, () => {
+                loadCount += 1;
+            });
+
+            assertEquals(loadCount, 0, 'Profile should not load before auth callback runs');
+            authCallback({ uid: 'parent-1' });
+            assertEquals(loadCount, 1, 'Profile should load after auth callback runs');
+        });
+
+        test('Athlete profile does not reload on later auth updates', () => {
+            let loadCount = 0;
+            let authCallback = null;
+
+            initializeAthleteProfilePage((callback) => {
+                authCallback = callback;
+            }, () => {
+                loadCount += 1;
+            });
+
+            authCallback(null);
+            authCallback({ uid: 'parent-1' });
+            assertEquals(loadCount, 1, 'Profile should load only once even if auth changes again');
+        });
+
+        // ============================================
         // Display Results
         // ============================================
 
@@ -252,13 +297,15 @@
         const grouped = {
             'Basketball Detection': [],
             'Session Storage': [],
-            'Edge Cases': []
+            'Edge Cases': [],
+            'Athlete Profile Auth': []
         };
 
         results.forEach((result, idx) => {
             if (idx < 10) grouped['Basketball Detection'].push(result);
             else if (idx < 13) grouped['Session Storage'].push(result);
-            else grouped['Edge Cases'].push(result);
+            else if (idx < 18) grouped['Edge Cases'].push(result);
+            else grouped['Athlete Profile Auth'].push(result);
         });
 
         Object.entries(grouped).forEach(([section, tests]) => {


### PR DESCRIPTION
Closes #533

## What changed
- delayed `athlete-profile.html`'s first `loadProfile()` call until the initial auth state callback fires
- kept the page load idempotent so later auth updates do not trigger duplicate profile fetches
- added focused regression coverage in `test-pr-changes.html` for the auth-gated load behavior

## Why
Private athlete profiles determine owner access from the signed-in parent. On a cold load, the page could fetch before Firebase auth finished restoring the session, so the owner was briefly treated as unauthorized and saw the not found/private fallback. Waiting for the first auth resolution fixes that race without changing public profile behavior.