### PR TITLE
Preserve imported practice context in Plan Practice

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -1574,13 +1574,14 @@
             const isCancelled = event.isCancelled;
             const borderColor = isCancelled ? 'border-gray-400' : (isPractice ? 'border-yellow-500' : 'border-blue-500');
             const calendarPracticeEventId = event.calendarEvent?.id || event.calendarEvent?.uid || `calendar_${event.date?.toISOString?.() || Date.now()}`;
+            const practiceTitle = event.title || event.opponent || 'Practice';
             const planSummary = isPractice ? renderPracticePlanSummary(calendarPracticeEventId) : '';
             const calendarPlanHref = buildPracticePlanHref({
                 eventId: calendarPracticeEventId,
                 date: event.date,
                 end: event.end,
                 location: event.location,
-                title: event.opponent || 'Practice'
+                title: practiceTitle
             });
             return `
                 <div class="p-6 hover:bg-gray-50 flex flex-col md:flex-row justify-between items-start md:items-center gap-4 border-l-4 ${borderColor} ${isCancelled ? 'opacity-60' : ''}">
@@ -1591,7 +1592,7 @@
                             ${isPractice ? '<span class="text-xs bg-yellow-100 text-yellow-800 px-2 py-0.5 rounded font-semibold">Practice</span>' : ''}
                         </div>
                         <div class="text-sm text-gray-500 font-semibold uppercase tracking-wide mb-1 ${isCancelled ? 'line-through' : ''}">${formatDate(event.date)} • ${formatTime(event.date)}</div>
-                        <div class="text-lg font-bold text-gray-900 ${isCancelled ? 'line-through' : ''}">${isPractice ? event.opponent : `vs. ${event.opponent}`}</div>
+                        <div class="text-lg font-bold text-gray-900 ${isCancelled ? 'line-through' : ''}">${isPractice ? practiceTitle : `vs. ${event.opponent}`}</div>
                         <div class="text-sm text-gray-600">
                             ${mapLink(event.location) ? `<a class="text-indigo-600 hover:underline" target="_blank" rel="noopener noreferrer" href="${mapLink(event.location)}">${event.location || 'TBD'}</a>` : (event.location || 'TBD')}
                         </div>

--- a/js/edit-schedule-calendar-import.js
+++ b/js/edit-schedule-calendar-import.js
@@ -54,7 +54,8 @@ export function mergeCalendarImportEvents({
 
         const summary = typeof event?.summary === 'string' ? event.summary.trim() : '';
         const isPractice = typeof event?.isPractice === 'boolean' ? event.isPractice : isPracticeEvent(summary);
-        const cleanSummary = summary.replace(/\[(?:CANCELED|CANCELLED)\]\s*/gi, '');
+        const cleanSummary = summary.replace(/\[(?:CANCELED|CANCELLED)\]\s*/gi, '').trim();
+        const practiceTitle = cleanSummary || 'Practice';
 
         importedEvents.push({
             source: 'calendar',
@@ -62,6 +63,7 @@ export function mergeCalendarImportEvents({
             date: eventDate,
             end: toDate(event?.dtend),
             opponent: extractOpponent(cleanSummary, currentTeamName),
+            title: isPractice ? practiceTitle : null,
             location: event.location || 'TBD',
             isPractice,
             isCancelled: getCalendarEventStatus(event) === 'cancelled',

--- a/tests/smoke/edit-schedule-calendar-import.spec.js
+++ b/tests/smoke/edit-schedule-calendar-import.spec.js
@@ -407,8 +407,13 @@ test.describe('edit schedule imported calendar rows', () => {
         const scheduleList = page.locator('#schedule-list');
         await expect(scheduleList).toContainText('Calendar');
         await expect(scheduleList).toContainText('Practice');
+        await expect(scheduleList).toContainText('Evening Practice');
+        await expect(scheduleList).toContainText('Training Field');
         await expect(scheduleList).toContainText('Plan Practice');
         await expect(scheduleList).not.toContainText('Track');
+
+        const importedPracticeRow = scheduleList.locator('div').filter({ hasText: 'Evening Practice' }).first();
+        await expect(importedPracticeRow).toContainText('Training Field');
 
         const planLink = scheduleList.getByRole('link', { name: 'Plan Practice' });
         await expect(planLink).toHaveAttribute('href', /drills\.html#/);

--- a/tests/unit/edit-schedule-calendar-import.test.js
+++ b/tests/unit/edit-schedule-calendar-import.test.js
@@ -85,6 +85,7 @@ describe('edit schedule calendar import helpers', () => {
                 eventType: 'practice',
                 isPractice: true,
                 opponent: 'Team Practice',
+                title: 'Team Practice',
                 location: 'Gym',
                 end: importedPractice.dtend,
                 calendarEvent: importedPractice
@@ -117,7 +118,8 @@ describe('edit schedule calendar import helpers', () => {
                 eventType: 'practice',
                 isPractice: true,
                 isCancelled: true,
-                opponent: 'Team Session'
+                opponent: 'Team Session',
+                title: 'Team Session'
             })
         ]);
     });
@@ -136,6 +138,7 @@ describe('edit schedule calendar import wiring', () => {
         const source = readEditSchedule();
 
         expect(source).toContain('Plan Practice');
+        expect(source).toContain("const practiceTitle = event.title || event.opponent || 'Practice';");
         expect(source).toContain('window.trackCalendarEvent');
     });
 });


### PR DESCRIPTION
Closes #506

## What changed
- preserve a dedicated `title` on imported calendar practice rows when schedule events are merged
- use that preserved practice title when rendering imported practice rows and when building the `Plan Practice` link
- extend unit and smoke coverage so imported practice rows keep their visible title, location, date, and duration context when linking into drill planning

## Why
Imported calendar practices should carry the same planning context as DB-backed practices. This keeps the row the coach sees in `edit-schedule.html` aligned with the drill-planner link payload, so regressions around imported practice metadata and duration are caught quickly.