### PR TITLE
Require matching email before accepting invite

### DIFF
--- a/accept-invite.html
+++ b/accept-invite.html
@@ -137,7 +137,7 @@
     <script type="module">
         import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=11';
         import { validateAccessCode, redeemParentInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=15';
-        import { createInviteProcessor } from './js/accept-invite-flow.js?v=4';
+        import { createInviteProcessor } from './js/accept-invite-flow.js?v=5';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 
         renderFooter(document.getElementById('footer-container'));

--- a/docs/pr-notes/runs/551-ci-fix-20260414T190038Z/architecture.md
+++ b/docs/pr-notes/runs/551-ci-fix-20260414T190038Z/architecture.md
@@ -1,0 +1,19 @@
+# Architecture
+
+## Current State
+- `accept-invite.html` imports `./js/accept-invite-flow.js?v=5`.
+- `tests/unit/accept-invite-page.test.js` already expects `?v=5` and passes.
+- `tests/unit/admin-invite-signup-cache-busting.test.js` still expects `?v=4` and fails.
+
+## Root Cause
+- The cache-busting regression test is stale relative to the shipped page import and the newer page-level unit test.
+- Runtime code and the broader test suite agree on version `v=5`; one targeted assertion was not updated.
+
+## Minimal Fix
+- Update the stale expectation in `tests/unit/admin-invite-signup-cache-busting.test.js` from `accept-invite-flow.js?v=4` to `accept-invite-flow.js?v=5`.
+
+## Risks
+- Low risk. This change only aligns the regression test with the current shipped import and does not alter runtime behavior.
+
+## Rollback
+- Revert the single assertion if a later change intentionally reverts the page import version.

--- a/docs/pr-notes/runs/551-ci-fix-20260414T190038Z/code-plan.md
+++ b/docs/pr-notes/runs/551-ci-fix-20260414T190038Z/code-plan.md
@@ -1,0 +1,13 @@
+# Code Plan
+
+## Files To Change
+- `tests/unit/admin-invite-signup-cache-busting.test.js`
+
+## Proposed Edit
+- Change the stale cache-busting expectation for `./js/accept-invite-flow.js` from `?v=4` to `?v=5` so it matches `accept-invite.html` and the existing passing page test.
+
+## Validation
+- `npx vitest run tests/unit/admin-invite-signup-cache-busting.test.js tests/unit/accept-invite-page.test.js`
+
+## Commit Description
+- `fix:address-ci-failure: align admin invite cache busting test with v5 import`

--- a/docs/pr-notes/runs/551-ci-fix-20260414T190038Z/qa.md
+++ b/docs/pr-notes/runs/551-ci-fix-20260414T190038Z/qa.md
@@ -1,0 +1,12 @@
+# QA
+
+## Test Impact
+- One failing unit test asserts the cache-busted `accept-invite-flow.js` import version in `accept-invite.html`.
+- Another unit test already validates the same page against `?v=5`, which indicates the failing test is the outlier.
+
+## Required Validation
+- Run `vitest` for `tests/unit/admin-invite-signup-cache-busting.test.js`.
+- Run `vitest` for `tests/unit/accept-invite-page.test.js` to confirm the aligned expectation still matches page behavior.
+
+## Regression Risk
+- Very low. Validation is limited to cache-busting assertions and does not exercise unrelated product flows.

--- a/js/accept-invite-flow.js
+++ b/js/accept-invite-flow.js
@@ -1,5 +1,23 @@
 import { hasFullTeamAccess } from './team-access.js?v=1';
 
+function normalizeEmail(email) {
+    return String(email || '').trim().toLowerCase();
+}
+
+function assertInviteEmailMatches(validation, authEmail) {
+    const invitedEmail = normalizeEmail(validation?.data?.email);
+    if (!invitedEmail) {
+        return;
+    }
+
+    const signedInEmail = normalizeEmail(authEmail);
+    if (signedInEmail === invitedEmail) {
+        return;
+    }
+
+    throw new Error(`This invite was sent to ${invitedEmail}. Sign in with that email to accept it.`);
+}
+
 export function createInviteProcessor(deps) {
     return async function processInvite(userId, code, authEmail = null) {
         return processInviteCode(userId, code, deps, authEmail);
@@ -22,6 +40,8 @@ export async function processInviteCode(userId, code, deps, authEmail = null) {
     if (!validation.valid) {
         throw new Error(validation.message || 'Invalid or expired invite code');
     }
+
+    assertInviteEmailMatches(validation, authEmail);
 
     if (validation.type === 'parent_invite') {
         await redeemParentInvite(userId, code);

--- a/tests/unit/accept-invite-flow.test.js
+++ b/tests/unit/accept-invite-flow.test.js
@@ -181,6 +181,52 @@ describe('accept invite flow', () => {
         expect(deps.markAccessCodeAsUsed).not.toHaveBeenCalled();
     });
 
+    it('rejects parent invite redemption when the signed-in email does not match the invited email', async () => {
+        const deps = {
+            validateAccessCode: vi.fn(async () => ({
+                valid: true,
+                type: 'parent_invite',
+                data: {
+                    teamId: 'team-1',
+                    playerNum: '12',
+                    email: 'invited@example.com'
+                }
+            })),
+            redeemParentInvite: vi.fn(),
+            getTeam: vi.fn()
+        };
+
+        const processInvite = createInviteProcessor(deps);
+
+        await expect(processInvite('user-9', 'ABCD1234', 'other@example.com')).rejects.toThrow(
+            'This invite was sent to invited@example.com. Sign in with that email to accept it.'
+        );
+        expect(deps.redeemParentInvite).not.toHaveBeenCalled();
+    });
+
+    it('rejects admin invite redemption when the signed-in email does not match the invited email', async () => {
+        const deps = {
+            validateAccessCode: vi.fn(async () => ({
+                valid: true,
+                codeId: 'code-999',
+                type: 'admin_invite',
+                data: {
+                    teamId: 'team-9',
+                    email: 'invited@example.com'
+                }
+            })),
+            redeemParentInvite: vi.fn(),
+            redeemAdminInviteAtomically: vi.fn()
+        };
+
+        const processInvite = createInviteProcessor(deps);
+
+        await expect(processInvite('user-9', 'ABCD9999', 'other@example.com')).rejects.toThrow(
+            'This invite was sent to invited@example.com. Sign in with that email to accept it.'
+        );
+        expect(deps.redeemAdminInviteAtomically).not.toHaveBeenCalled();
+    });
+
     it('does not mark code when validation fails', async () => {
         const deps = {
             validateAccessCode: vi.fn(async () => ({ valid: false, message: 'Code already used' })),

--- a/tests/unit/accept-invite-page.test.js
+++ b/tests/unit/accept-invite-page.test.js
@@ -111,7 +111,7 @@ const setTimeout = deps.setTimeout;
             'const { validateAccessCode, redeemParentInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } = deps.db;'
         )
         .replace(
-            "import { createInviteProcessor } from './js/accept-invite-flow.js?v=4';",
+            "import { createInviteProcessor } from './js/accept-invite-flow.js?v=5';",
             'const { createInviteProcessor } = deps.acceptInviteFlow;'
         )
         .replace(

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -18,7 +18,7 @@ describe('admin invite signup cache busting', () => {
             "import { validateAccessCode, redeemParentInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=15';"
         );
         expect(acceptInviteSource).toContain(
-            "import { createInviteProcessor } from './js/accept-invite-flow.js?v=4';"
+            "import { createInviteProcessor } from './js/accept-invite-flow.js?v=5';"
         );
     });
 


### PR DESCRIPTION
Closes #546

## What changed
- added an invite-email guard in `js/accept-invite-flow.js` that normalizes and compares the signed-in account email against the invite's stored target email before any parent or admin redemption runs
- blocked redemption with a clear switch-account error when the logged-in user does not match the invite recipient
- bumped the `accept-invite-flow.js` cache-busting import in `accept-invite.html`
- added regression coverage proving mismatched emails cannot redeem either parent or admin invite codes

## Why
Previously, any already-authenticated account could consume an email-targeted invite link. This patch fails closed before the code is redeemed, so the intended recipient keeps the invite and the wrong signed-in account is told to switch emails first.