### PR TITLE
Accept seconds in schedule CSV times

### DIFF
--- a/docs/pr-notes/runs/552-ci-fix-20260418T162541Z/architecture.md
+++ b/docs/pr-notes/runs/552-ci-fix-20260418T162541Z/architecture.md
@@ -1,0 +1,17 @@
+# Architecture
+
+## Current State
+- The parent dashboard calendar modal test seeds a shared game on a fixed date: 2026-04-15.
+- `getFilteredScheduleEvents()` defaults to `upcoming-all`, which excludes events older than roughly 3 hours before the current runtime.
+- Once wall clock time passed the seeded date, the modal rendered `No events on this day.` and the test failed before RSVP assertions.
+
+## Proposed State
+- Make the test fixture date relative to runtime so the seeded event remains in the upcoming set.
+
+## Architecture Decisions
+- Fix the brittle test input, not production code.
+- Keep the default schedule filtering behavior unchanged because the failure is caused by stale test data, not incorrect modal logic.
+
+## Risks And Rollback
+- Low risk. Scope is limited to one unit test fixture.
+- Rollback is reverting the test-date change if it unexpectedly masks a real product issue.

--- a/docs/pr-notes/runs/552-ci-fix-20260418T162541Z/code-plan.md
+++ b/docs/pr-notes/runs/552-ci-fix-20260418T162541Z/code-plan.md
@@ -1,0 +1,15 @@
+# Code Plan
+
+## Root Cause
+- The failing test uses a hard-coded event date that has aged into the past.
+- In calendar mode, the parent dashboard filters to upcoming events by default, so the modal receives no events and renders the empty state.
+
+## Files To Change
+- `tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js`
+
+## Minimal Patch Plan
+- Replace the fixed event date with a runtime-relative future date.
+- Leave RSVP control logic and schedule filtering unchanged.
+
+## Validation Command
+- `npx vitest run tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js`

--- a/docs/pr-notes/runs/552-ci-fix-20260418T162541Z/qa.md
+++ b/docs/pr-notes/runs/552-ci-fix-20260418T162541Z/qa.md
@@ -1,0 +1,13 @@
+# QA
+
+## QA Plan
+- Run the targeted Vitest file: `tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js`.
+- Confirm the modal renders shared-game RSVP controls before submission.
+- Confirm RSVP submission still sends both child IDs and refreshes the open modal state.
+
+## Targeted Regression Risks
+- Time-sensitive tests around schedule filtering can silently expire again if they use fixed calendar dates.
+- The change should not affect production behavior because only test data moved.
+
+## Minimal Validation Set
+- `npx vitest run tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js`

--- a/js/schedule-csv-import.js
+++ b/js/schedule-csv-import.js
@@ -381,14 +381,15 @@ function parseTimeText(value) {
     const trimmed = String(value || '').trim();
     if (!trimmed) return null;
 
-    const match = trimmed.match(/^(\d{1,2})(?::(\d{2}))?\s*(AM|PM)?$/i);
+    const match = trimmed.match(/^(\d{1,2})(?::(\d{2}))?(?::(\d{2}))?\s*(AM|PM)?$/i);
     if (!match) return null;
 
     let hours = Number(match[1]);
     const minutes = Number(match[2] || '0');
-    const meridiem = match[3] ? match[3].toUpperCase() : null;
+    const seconds = Number(match[3] || '0');
+    const meridiem = match[4] ? match[4].toUpperCase() : null;
 
-    if (minutes > 59 || hours > 23 || hours < 0) return null;
+    if (minutes > 59 || seconds > 59 || hours > 23 || hours < 0) return null;
 
     if (meridiem) {
         if (hours < 1 || hours > 12) return null;

--- a/tests/unit/schedule-csv-import.test.js
+++ b/tests/unit/schedule-csv-import.test.js
@@ -81,6 +81,62 @@ describe('schedule CSV import helpers', () => {
         });
     });
 
+    it('accepts times with optional seconds in split and combined datetime mappings', () => {
+        const splitParsed = parseCsvText([
+            'Type,Date,Start,End,Arrival,Opponent',
+            'Game,4/2/2026,18:30:00,20:00:00,17:45:00,Tigers',
+            'Game,4/3/2026,6:30:00 PM,8:00:00 PM,5:45:00 PM,Lions'
+        ].join('\n'));
+
+        const splitPreview = buildScheduleImportPreview({
+            rows: splitParsed.rows,
+            mapping: {
+                eventType: 'Type',
+                date: 'Date',
+                startTime: 'Start',
+                endTime: 'End',
+                arrivalTime: 'Arrival',
+                opponent: 'Opponent'
+            }
+        });
+
+        expect(splitPreview.rows[0].errors).toEqual([]);
+        expect(splitPreview.rows[0].normalized).toMatchObject({
+            startsAt: '2026-04-02T18:30',
+            endsAt: '2026-04-02T20:00',
+            arrivalTime: '2026-04-02T17:45'
+        });
+        expect(splitPreview.rows[1].errors).toEqual([]);
+        expect(splitPreview.rows[1].normalized).toMatchObject({
+            startsAt: '2026-04-03T18:30',
+            endsAt: '2026-04-03T20:00',
+            arrivalTime: '2026-04-03T17:45'
+        });
+
+        const combinedParsed = parseCsvText([
+            'Type,Start Date & Time,End Time,Arrival Time,Opponent',
+            'Game,2026-04-04 18:30:00,20:00:00,17:45:00,Bears'
+        ].join('\n'));
+
+        const combinedPreview = buildScheduleImportPreview({
+            rows: combinedParsed.rows,
+            mapping: {
+                eventType: 'Type',
+                startDateTime: 'Start Date & Time',
+                endTime: 'End Time',
+                arrivalTime: 'Arrival Time',
+                opponent: 'Opponent'
+            }
+        });
+
+        expect(combinedPreview.rows[0].errors).toEqual([]);
+        expect(combinedPreview.rows[0].normalized).toMatchObject({
+            startsAt: '2026-04-04T18:30',
+            endsAt: '2026-04-04T20:00',
+            arrivalTime: '2026-04-04T17:45'
+        });
+    });
+
     it('flags missing mapping requirements and invalid game rows before import', () => {
         expect(validateScheduleCsvMapping({
             eventType: 'Type',


### PR DESCRIPTION
Closes #538

## What changed
- updated `parseTimeText` in `js/schedule-csv-import.js` to accept optional `:SS` segments for both 24-hour and AM/PM time values
- added a focused regression test covering split date/time imports and combined datetime imports that include seconds

## Why
Common CSV exports include seconds by default, and the importer was rejecting otherwise valid schedule rows like `18:30:00` and `6:30:00 PM`. This patch keeps the existing minute-based normalization but allows those inputs to parse so preview and import can proceed normally.

## Validation
- ran `npx vitest run tests/unit/schedule-csv-import.test.js`