### PR TITLE
Reject bracket seeds outside the generated field

### DIFF
--- a/js/bracket-management.js
+++ b/js/bracket-management.js
@@ -123,6 +123,11 @@ export function createSingleEliminationBracket({ teamId, name, seeds = [], brack
     }
 
     const slotCount = nextPowerOfTwo(normalizedSeeds.length);
+    const maxSeedNumber = normalizedSeeds.reduce((maxSeed, entry) => Math.max(maxSeed, entry.seed), 0);
+    if (maxSeedNumber > slotCount) {
+        throw new Error(`seed numbers must be between 1 and ${slotCount} for a ${normalizedSeeds.length}-team bracket`);
+    }
+
     const roundCount = Math.log2(slotCount);
     const seedOrder = buildSeedOrder(slotCount);
     const seedsByNumber = new Map(normalizedSeeds.map((entry) => [entry.seed, entry]));

--- a/tests/unit/bracket-management.test.js
+++ b/tests/unit/bracket-management.test.js
@@ -72,6 +72,19 @@ describe('bracket management helpers', () => {
         expect(final.awaySlot.teamId).toBe('t2');
     });
 
+    it('rejects explicit seeds that exceed the bracket size', () => {
+        expect(() => createSingleEliminationBracket({
+            teamId: 'team-1',
+            name: 'Sparse Seed Cup',
+            seeds: [
+                { seed: 1, teamId: 't1', teamName: 'Seed 1' },
+                { seed: 2, teamId: 't2', teamName: 'Seed 2' },
+                { seed: 7, teamId: 't7', teamName: 'Seed 7' },
+                { seed: 8, teamId: 't8', teamName: 'Seed 8' }
+            ]
+        })).toThrow('seed numbers must be between 1 and 4 for a 4-team bracket');
+    });
+
     it('auto-advances BYE teams during bracket creation', () => {
         const bracket = createSingleEliminationBracket({
             teamId: 'team-1',


### PR DESCRIPTION
Closes #541

## What changed
- reject explicit single-elimination seed numbers that exceed the generated bracket size instead of silently creating a broken bracket
- add a regression test covering a 4-team bracket submitted with seeds 1, 2, 7, and 8

## Why
The bracket builder sized the field from the number of seed entries, so higher explicit seeds could never be placed and teams disappeared from the bracket. This change fails fast with a clear validation error, which is the smallest safe fix for the broken creation path.