### PR TITLE
Hide private teams from global search

### DIFF
--- a/js/global-search-visibility.js
+++ b/js/global-search-visibility.js
@@ -1,0 +1,11 @@
+import { getTeamAccessInfo } from './team-access.js';
+
+export function canUserDiscoverTeamInSearch(team, user) {
+    if (!team) return false;
+    if (team.isPublic !== false) return true;
+    return getTeamAccessInfo(user, team).hasAccess;
+}
+
+export function filterSearchableTeams(teams, user) {
+    return (Array.isArray(teams) ? teams : []).filter((team) => canUserDiscoverTeamInSearch(team, user));
+}

--- a/js/global-search.js
+++ b/js/global-search.js
@@ -1,5 +1,6 @@
 import { escapeHtml } from './utils.js?v=8';
 import { getTeams } from './db.js?v=15';
+import { filterSearchableTeams } from './global-search-visibility.js?v=1';
 import {
     db,
     collectionGroup,
@@ -297,7 +298,7 @@ function openModal({ initialQuery = '' } = {}) {
 
         const playerItems = (players || []);
 
-        const teamItems = (teams || []).map(t => ({
+        const teamItems = filterSearchableTeams(teams, currentUser).map(t => ({
             kind: 'team',
             title: t.name || 'Team',
             subtitle: [t.sport, t.zip].filter(Boolean).join(' • '),

--- a/tests/unit/global-search-visibility.test.js
+++ b/tests/unit/global-search-visibility.test.js
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { filterSearchableTeams } from '../../js/global-search-visibility.js';
+
+const teams = [
+  { id: 'public-team', name: 'Public Team', isPublic: true, ownerId: 'owner-1', adminEmails: ['coach@example.com'] },
+  { id: 'private-team', name: 'Private Team', isPublic: false, ownerId: 'owner-1', adminEmails: ['coach@example.com'] }
+];
+
+describe('global search visibility', () => {
+  it('hides private teams from anonymous search results', () => {
+    expect(filterSearchableTeams(teams, null).map((team) => team.id)).toEqual(['public-team']);
+  });
+
+  it('keeps private teams visible to the owner', () => {
+    expect(filterSearchableTeams(teams, { uid: 'owner-1', email: 'owner@example.com' }).map((team) => team.id)).toEqual([
+      'public-team',
+      'private-team'
+    ]);
+  });
+
+  it('keeps private teams visible to a team admin', () => {
+    expect(filterSearchableTeams(teams, { uid: 'coach-1', email: 'coach@example.com' }).map((team) => team.id)).toEqual([
+      'public-team',
+      'private-team'
+    ]);
+  });
+
+  it('keeps private teams visible to a linked parent', () => {
+    expect(filterSearchableTeams(teams, {
+      uid: 'parent-1',
+      email: 'parent@example.com',
+      parentOf: [{ teamId: 'private-team', playerId: 'player-1' }]
+    }).map((team) => team.id)).toEqual([
+      'public-team',
+      'private-team'
+    ]);
+  });
+});


### PR DESCRIPTION
Closes #537

## What changed
- added a small global-search visibility helper that only includes private teams when the current user already has team access
- updated global search to filter team results through that helper before building result links
- added targeted unit coverage for anonymous, owner, team admin, and parent-linked search visibility

## Why
Global search was exposing teams marked non-public to anonymous visitors, which broke the expected discoverability control. This patch makes search match the intended public behavior without hiding private teams from users who already have legitimate access.