### PR TITLE
Compare schedule fields by value for game notifications

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -250,6 +250,42 @@ function toNumericScore(value) {
   return Number.isFinite(num) ? num : 0;
 }
 
+function normalizeComparableValue(value) {
+  if (value == null) {
+    return null;
+  }
+
+  if (typeof value?.toMillis === 'function') {
+    const millis = value.toMillis();
+    if (Number.isFinite(millis)) {
+      return { __type: 'timestamp', value: millis };
+    }
+  }
+
+  if (value instanceof Date) {
+    return { __type: 'date', value: value.getTime() };
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => normalizeComparableValue(entry));
+  }
+
+  if (typeof value === 'object') {
+    return Object.keys(value)
+      .sort()
+      .reduce((normalized, key) => {
+        normalized[key] = normalizeComparableValue(value[key]);
+        return normalized;
+      }, {});
+  }
+
+  return value;
+}
+
+function valuesDiffer(beforeValue, afterValue) {
+  return JSON.stringify(normalizeComparableValue(beforeValue)) !== JSON.stringify(normalizeComparableValue(afterValue));
+}
+
 function detectGameNotificationCategory(beforeGame, afterGame) {
   const beforeHome = toNumericScore(beforeGame?.homeScore);
   const beforeAway = toNumericScore(beforeGame?.awayScore);
@@ -260,11 +296,7 @@ function detectGameNotificationCategory(beforeGame, afterGame) {
   }
 
   const scheduleFields = ['date', 'location', 'status', 'opponent', 'title'];
-  const scheduleChanged = scheduleFields.some((field) => {
-    const before = beforeGame?.[field] ?? null;
-    const after = afterGame?.[field] ?? null;
-    return before !== after;
-  });
+  const scheduleChanged = scheduleFields.some((field) => valuesDiffer(beforeGame?.[field] ?? null, afterGame?.[field] ?? null));
 
   return scheduleChanged ? 'schedule' : null;
 }

--- a/js/notification-preferences.js
+++ b/js/notification-preferences.js
@@ -22,8 +22,42 @@ function asNumber(value) {
     return Number.isFinite(n) ? n : 0;
 }
 
+function normalizeComparableValue(value) {
+    if (value == null) {
+        return null;
+    }
+
+    if (typeof value?.toMillis === 'function') {
+        const millis = value.toMillis();
+        if (Number.isFinite(millis)) {
+            return { __type: 'timestamp', value: millis };
+        }
+    }
+
+    if (value instanceof Date) {
+        return { __type: 'date', value: value.getTime() };
+    }
+
+    if (Array.isArray(value)) {
+        return value.map((entry) => normalizeComparableValue(entry));
+    }
+
+    if (typeof value === 'object') {
+        return Object.keys(value)
+            .sort()
+            .reduce((normalized, key) => {
+                normalized[key] = normalizeComparableValue(value[key]);
+                return normalized;
+            }, {});
+    }
+
+    return value;
+}
+
 function changed(before, after, key) {
-    return (before?.[key] ?? null) !== (after?.[key] ?? null);
+    const beforeValue = normalizeComparableValue(before?.[key] ?? null);
+    const afterValue = normalizeComparableValue(after?.[key] ?? null);
+    return JSON.stringify(beforeValue) !== JSON.stringify(afterValue);
 }
 
 export function getNotificationCategoryForGameChange(beforeGame, afterGame) {

--- a/tests/unit/notification-preferences.test.js
+++ b/tests/unit/notification-preferences.test.js
@@ -38,6 +38,24 @@ describe('game notification category detection', () => {
     )).toBe('schedule');
   });
 
+  it('compares object-valued schedule fields by value', () => {
+    expect(getNotificationCategoryForGameChange(
+      {
+        date: { seconds: 1712345678, nanoseconds: 0 },
+        scoutingNotes: 'Old notes'
+      },
+      {
+        date: { seconds: 1712345678, nanoseconds: 0 },
+        scoutingNotes: 'New notes'
+      }
+    )).toBe(null);
+
+    expect(getNotificationCategoryForGameChange(
+      { date: { seconds: 1712345678, nanoseconds: 0 } },
+      { date: { seconds: 1712432078, nanoseconds: 0 } }
+    )).toBe('schedule');
+  });
+
   it('returns null when no relevant fields changed', () => {
     expect(getNotificationCategoryForGameChange(
       { date: '2026-03-01', notes: 'A' },


### PR DESCRIPTION
Closes #548

## What changed
- compare schedule notification fields by normalized value instead of object reference when classifying game updates
- handle Timestamp, Date, array, and plain object schedule values so unchanged schedule data does not look dirty after partial document updates
- add a regression test covering object-valued `date` fields to ensure non-schedule edits stay silent

## Why
Firestore game updates can preserve the same schedule value while rehydrating `date` as a new object instance. That made routine edits like scouting note saves look like schedule changes and triggered bogus push notifications.