### PR TITLE
Persist zero-stat player appearances in tracker

### DIFF
--- a/docs/pr-notes/runs/557-remediator-20260414T204502Z/architecture.md
+++ b/docs/pr-notes/runs/557-remediator-20260414T204502Z/architecture.md
@@ -1,0 +1,27 @@
+Current-State Read
+- `track.html` already lowercases configured column names and reads player stats through a lowercase lookup map, which addresses the original case-sensitivity defect.
+- `track.html` already splits aggregated-stats writes into secondary batches, reducing risk of Firestore's 500-write limit.
+- The current finish flow commits secondary aggregated-stats batches before the primary game completion batch, which leaves core completion persistence later than necessary.
+
+Proposed Design
+- Extract the stat-normalization logic into a small helper in `track.html` so the case-insensitive behavior is explicit and reusable.
+- Reuse the same normalization helper shape in the regression test file.
+- Commit the primary batch first, then commit chunked aggregated-stats batches, preserving core completion data before secondary writes.
+
+Files And Modules Touched
+- `track.html`
+- `test-track-zero-stat-player-history.js`
+- `docs/pr-notes/runs/557-remediator-20260414T204502Z/*`
+
+Data/State Impacts
+- No schema changes.
+- Aggregated stat documents keep lowercase configured keys plus any preserved non-config keys.
+- Finish ordering changes only write sequence, not document shape.
+
+Security/Permissions Impacts
+- None. Existing Firestore paths and auth expectations stay unchanged.
+
+Failure Modes And Mitigations
+- Mixed-case historical stat keys could regress: mitigated by explicit helper and regression test.
+- Large finish flows could overflow a batch: mitigated by keeping primary batch bounded and chunking aggregated writes.
+- Partial failure after primary commit could still leave missing aggregated stats: accepted tradeoff because persisted game completion data is more important than secondary rollups, and this matches the reviewer concern about preserving completion data.

--- a/docs/pr-notes/runs/557-remediator-20260414T204502Z/code-plan.md
+++ b/docs/pr-notes/runs/557-remediator-20260414T204502Z/code-plan.md
@@ -1,0 +1,19 @@
+Patch Plan
+1. Extract tracker stat normalization into a helper in `track.html` so the case-insensitive behavior is explicit and reused at the write site.
+2. Commit the primary finish batch before chunked aggregated-stats batches.
+3. Mirror the normalization helper in `test-track-zero-stat-player-history.js` and add the exact uppercase-key regression case from review.
+
+Code Changes Applied
+- Planned before implementation; update after edits:
+  - `track.html`: helper extraction, primary-batch-first finish ordering.
+  - `test-track-zero-stat-player-history.js`: helper extraction, uppercase-key regression test.
+
+Validation Run
+- `node test-track-zero-stat-player-history.js`
+
+Residual Risks
+- Finish still cannot be fully atomic across more than 500 writes; preserving primary game completion data first is the chosen tradeoff.
+- Browser-only manual verification is still needed for full end-to-end tracker confidence.
+
+Commit Message Draft
+- Harden tracker stat normalization and finish batching

--- a/docs/pr-notes/runs/557-remediator-20260414T204502Z/qa.md
+++ b/docs/pr-notes/runs/557-remediator-20260414T204502Z/qa.md
@@ -1,0 +1,28 @@
+Risk Matrix
+- High: tracker finish persistence regresses for live games near Firestore batch limits.
+- Medium: mixed-case stat keys silently zero out saved player history.
+- Low: zero-stat roster players disappear from aggregated history.
+
+Automated Tests To Add/Update
+- Update `test-track-zero-stat-player-history.js` to use the same normalization helper pattern as production.
+- Add an explicit regression case for uppercase source keys (`PTS`, `REB`) with lowercase-normalized configured columns.
+
+Manual Test Plan
+1. Run `node test-track-zero-stat-player-history.js`.
+2. In a local browser session, finish a tracked game with players who have uppercase/mixed-case stats and confirm saved history values are preserved.
+3. Finish a game with a scoreless rostered player and confirm the player still has zeroed configured stats.
+4. Smoke test a larger game log flow and confirm completion data persists.
+
+Negative Tests
+- Player stats object empty for a rostered player.
+- Configured columns present while source stats use uppercase keys only.
+- Extra non-config stats present in player history.
+
+Release Gates
+- Regression script passes.
+- Tracker finish path still writes within Firestore batch limits.
+- No unrelated file churn.
+
+Post-Deploy Checks
+- Verify one newly completed game shows correct aggregated player stats.
+- Check that completed game summary/status saves even when roster-wide stat writes are chunked.

--- a/docs/pr-notes/runs/557-remediator-20260414T204502Z/requirements.md
+++ b/docs/pr-notes/runs/557-remediator-20260414T204502Z/requirements.md
@@ -1,0 +1,28 @@
+Problem Statement
+PR #557 needs review remediation for tracker finish behavior. The branch already contains fixes for case-insensitive stat normalization and split aggregated-stats batching, but the review threads remain unresolved and need explicit regression coverage plus confirmation that finish preserves completion data.
+
+User Segments Impacted
+- Coach running the live tracker during a game.
+- Team admin reviewing saved player histories after the game.
+- Parents consuming completed game stats and summaries.
+
+Acceptance Criteria
+1. Configured stat columns normalize to lowercase without losing values when source stat keys are uppercase or mixed case.
+2. Scoreless rostered players still receive zeroed configured stats in aggregated history.
+3. Non-configured stat keys already present in player stats remain preserved.
+4. Finishing a game keeps the primary game completion writes within Firestore batch limits.
+5. The finish flow commits the historical completion data before secondary aggregated-stats batches so the core game result is persisted first.
+
+Non-Goals
+- No refactor of tracker UI, roster flow, or Firestore schema.
+- No new automation framework.
+- No changes to non-tracker pages.
+
+Edge Cases
+- Source stats with uppercase keys like PTS/REB.
+- Mixed-case keys across historical data.
+- Large game logs near Firestore's 500-write limit.
+- Rostered players with no tracked events.
+
+Open Questions
+- None blocking for this remediation. The current branch state already addresses the underlying review concerns; this pass mainly hardens regression coverage and finish ordering.

--- a/docs/pr-notes/runs/557-review-comment-3082052747-20260414T200919Z/architecture.md
+++ b/docs/pr-notes/runs/557-review-comment-3082052747-20260414T200919Z/architecture.md
@@ -1,0 +1,41 @@
+## Current State
+
+- `track.html` saves final `aggregatedStats` for every rostered player when the game is finished.
+- The buggy pattern was `normalizedStats[key] = Number(playerStats[key]) || 0`, where `key` is the lowercased configured column. That drops values when `playerStats` contains mixed-case keys like `PTS` or `ReB`.
+- The in-flight fix changes that save path to first build a lowercase shadow map, then resolve configured columns from that map, while still preserving non-config stats.
+- `test-track-zero-stat-player-history.js` now covers:
+  - one write per rostered player,
+  - zero-stat players getting zeroed configured columns,
+  - mixed-case configured keys surviving normalization,
+  - non-config keys being preserved.
+- The test passes as written.
+
+## Proposed State
+
+- Keep the fix narrowly scoped to the final serialization boundary in `track.html`.
+- Canonicalize configured stat columns through a lowercase lookup map derived from `playerStats`.
+- Continue writing configured stats out in lowercase canonical form.
+- Preserve extra, non-config stat keys only if their lowercase equivalent was not already emitted.
+- Keep the regression test in `test-track-zero-stat-player-history.js` as the contract for this behavior.
+
+## Architecture Decisions
+
+- **Safest implementation pattern:** normalize at the persistence boundary, not by refactoring all in-memory tracker state.
+- **Blast radius:** limited to:
+  - `track.html` finish-game aggregated stats write path,
+  - `test-track-zero-stat-player-history.js` parity/regression coverage.
+- **Why this is safest:** no schema change, no Firebase rule change, no routing/UI flow change, no broader tracker behavior change during live entry.
+- **Canonical form:** configured columns should remain lowercase in stored `aggregatedStats.stats`, which matches existing downstream expectations in this file.
+
+## Risks
+
+- If `playerStats` somehow contains both `PTS` and `pts` with different values, the lowercase shadow map collapses them, effectively last-write-wins. That is acceptable for a minimal fix, but it is still a collision policy.
+- This does not migrate already completed historical docs that were previously saved with mixed-case-only configured keys.
+- Read-time display code in `track.html` still prefers lowercase keys, so historical mixed-case docs may still render as zero until re-saved. That is outside this PR’s scoped fix but worth noting.
+
+## Rollback
+
+- Roll back by reverting only the `track.html` serialization hunk and the matching test additions in `test-track-zero-stat-player-history.js`.
+- No data/schema rollback is required.
+- Any docs already written in lowercase canonical form are forward-compatible, so reverting code does not require cleanup of saved data.
+- Operationally, this is a low-risk static-page redeploy rollback.

--- a/docs/pr-notes/runs/557-review-comment-3082052747-20260414T200919Z/code-plan.md
+++ b/docs/pr-notes/runs/557-review-comment-3082052747-20260414T200919Z/code-plan.md
@@ -1,0 +1,109 @@
+## Minimal Patch Plan
+
+1. In `track.html`, normalize `gameState.playerStats[player.id]` into a lowercase lookup map before building `normalizedStats`.
+2. Fill configured columns from that lowercase map so persisted keys always match the lowercase schema, even if in-memory stats arrived as `PTS`, `ReB`, etc.
+3. Preserve unexpected non-config stats, but only when neither the original key nor its lowercase equivalent is already represented, to avoid duplicate case variants.
+4. Mirror the same normalization logic in `test-track-zero-stat-player-history.js` and add a regression for mixed-case source keys.
+
+## Concrete Changes
+
+```diff
+--- track.html
++++ track.html
+@@
+ players.forEach((player) => {
+     const playerStats = gameState.playerStats[player.id] || {};
++    const playerStatsByLowerKey = {};
+     const normalizedStats = {};
+ 
++    Object.entries(playerStats).forEach(([statKey, value]) => {
++        playerStatsByLowerKey[String(statKey).toLowerCase()] = Number(value) || 0;
++    });
++
+     currentConfig.columns.forEach((col) => {
+         const key = String(col || '').toLowerCase();
+-        normalizedStats[key] = Number(playerStats[key]) || 0;
++        normalizedStats[key] = Object.prototype.hasOwnProperty.call(playerStatsByLowerKey, key)
++            ? playerStatsByLowerKey[key]
++            : 0;
+     });
+ 
+     Object.entries(playerStats).forEach(([statKey, value]) => {
+-        if (normalizedStats[statKey] === undefined) {
++        const normalizedKey = String(statKey).toLowerCase();
++        if (normalizedStats[statKey] === undefined && normalizedStats[normalizedKey] === undefined) {
+             normalizedStats[statKey] = Number(value) || 0;
+         }
+     });
+ });
+```
+
+```diff
+--- test-track-zero-stat-player-history.js
++++ test-track-zero-stat-player-history.js
+@@
+ function buildAggregatedStatsWrites(players, columns, playerStatsById) {
+     return players.map((player) => {
+         const playerStats = playerStatsById[player.id] || {};
++        const playerStatsByLowerKey = {};
+         const normalizedStats = {};
+ 
++        Object.entries(playerStats).forEach(([statKey, value]) => {
++            playerStatsByLowerKey[String(statKey).toLowerCase()] = Number(value) || 0;
++        });
++
+         columns.forEach((col) => {
+             const key = String(col || '').toLowerCase();
+-            normalizedStats[key] = Number(playerStats[key]) || 0;
++            normalizedStats[key] = Object.prototype.hasOwnProperty.call(playerStatsByLowerKey, key)
++                ? playerStatsByLowerKey[key]
++                : 0;
+         });
+ 
+         Object.entries(playerStats).forEach(([statKey, value]) => {
+-            if (normalizedStats[statKey] === undefined) {
++            const normalizedKey = String(statKey).toLowerCase();
++            if (normalizedStats[statKey] === undefined && normalizedStats[normalizedKey] === undefined) {
+                 normalizedStats[statKey] = Number(value) || 0;
+             }
+         });
+@@
++test('mixed-case configured stat keys are normalized without losing values', () => {
++    const writes = buildAggregatedStatsWrites(
++        [{ id: 'player-a', name: 'Player A', number: '12' }],
++        ['PTS', 'REB', 'AST'],
++        {
++            'player-a': { PTS: 8, ReB: 5, ast: 2 }
++        }
++    );
++
++    assertDeepEquals(
++        writes[0].data.stats,
++        { pts: 8, reb: 5, ast: 2 },
++        'Configured stat values should survive mixed-case source keys without duplicate variants'
++    );
++});
+```
+
+## Validation Commands
+
+```bash
+cd /tmp/allplays-pr557
+node test-track-zero-stat-player-history.js
+```
+
+Ran in the repo, result:
+
+```text
+PASS writes one aggregated stats doc per rostered player
+PASS zero-stat players get zeroed configured stats
+PASS mixed-case configured stat keys are normalized without losing values
+PASS existing non-config stat keys are preserved
+All 4 tests passed.
+```
+
+## Notes
+
+- The critical bug is real: mixed-case in-memory keys cause configured stats to persist as zeroed lowercase fields plus duplicate uppercase/mixed-case extras.
+- This patch is minimal and backward-compatible. It fixes configured stat persistence without stripping unexpected non-config stats like `blocks`.
+- The current local diff in `/tmp/allplays-pr557` already matches this plan and passes the targeted harness.

--- a/docs/pr-notes/runs/557-review-comment-3082052747-20260414T200919Z/qa.md
+++ b/docs/pr-notes/runs/557-review-comment-3082052747-20260414T200919Z/qa.md
@@ -1,0 +1,40 @@
+## Test Focus
+- **Mixed-case configured stat-key normalization, high risk**: Verify `track.html` saves configured columns by lowercased canonical keys while retaining values entered under mixed-case source keys like `PTS`, `ReB`, and `ast`.
+- **Zero-stat roster persistence, high risk**: Verify every rostered player still gets an `aggregatedStats/{playerId}` document with zeroed configured stats when they finish with no logged events.
+- **Non-config stat preservation, medium risk**: Verify existing in-memory stats outside `currentConfig.columns` remain in the saved `stats` object and are not dropped during finish-game normalization.
+- **Regression surface, medium risk**: Confirm finish flow still writes one doc per rostered player, preserves player metadata, and does not introduce duplicate case variants for configured stats.
+
+## Regression Risks
+- **High**: Mixed-case stat input could be saved as `0` if lookup normalization and configured-column matching diverge.
+- **High**: Bench or zero-stat players could disappear from historical views if finish flow skips players without tracked events.
+- **Medium**: Custom or legacy stat keys not present in current config could be silently removed from player history.
+- **Medium**: Configured stats could be duplicated across `PTS` and `pts`, causing downstream summaries or history pages to read inconsistent values.
+- **Low**: Player name/number metadata could drift if aggregated writes no longer map one-to-one with roster players.
+
+## Validation Matrix
+| Area | Scenario | Expected Result | Coverage |
+|---|---|---|---|
+| Mixed-case normalization | `playerStats` contains `{ PTS: 8, ReB: 5, ast: 2 }` with config `['PTS','REB','AST']` | Saved stats are exactly `{ pts: 8, reb: 5, ast: 2 }` with no duplicate mixed-case configured keys | **Automated**: `mixed-case configured stat keys are normalized without losing values` |
+| Zero-stat roster persistence | One player has stats, second player has none | Finish flow writes two `aggregatedStats` docs, including zeroed configured stats for the scoreless player | **Automated**: `writes one aggregated stats doc per rostered player`, `zero-stat players get zeroed configured stats` |
+| Non-config stat preservation | `playerStats` contains configured keys plus `blocks: 3` while config omits `BLOCKS` | Saved stats keep `{ pts, reb, blocks }`; non-config key is preserved | **Automated**: `existing non-config stat keys are preserved` |
+| Duplicate-key avoidance | Source contains mixed-case configured keys only | Saved object contains lowercase configured keys only, not both `PTS` and `pts` | **Automated**, implied by mixed-case normalization assertion |
+| Finish-flow integrity | Submit finish form after tracking or with zero-stat roster players | Batch write succeeds, game status completes, opponent stats still persist on game doc | **Manual** |
+| History/readback confidence | Reopen saved game or inspect Firestore `aggregatedStats` docs | Stored stats reflect normalized configured keys, zero-stat players exist, non-config keys remain readable | **Manual** |
+
+## Manual Checks
+1. Serve `/tmp/allplays-pr557` locally and open `track.html` with a game using a config that includes mixed-case display labels like `PTS`, `REB`, `AST`.
+2. Track stats for one player, leave another rostered player at zero, finish the game, and inspect Firestore `aggregatedStats`:
+   - every rostered player has a doc,
+   - zero-stat player doc exists,
+   - configured keys are lowercase,
+   - values match what was entered.
+3. Seed or simulate a player stats object containing a non-config key such as `blocks`, finish the game, and confirm the saved `stats` object still includes `blocks`.
+4. Confirm no configured stat is duplicated under both mixed-case and lowercase keys after save.
+5. Reopen any player-history or game-summary surface that reads `aggregatedStats` and confirm zero-stat players and normalized stats render without blanks or regressions.
+
+## Exit Criteria
+- Automated check `node test-track-zero-stat-player-history.js` passes all four assertions.
+- Firestore/manual verification confirms one `aggregatedStats` doc per rostered player, including zero-stat players.
+- Mixed-case configured keys save to lowercase canonical keys with correct non-zero values.
+- Non-config stat keys remain present after finish-game save.
+- No duplicate configured stat keys or finish-flow regressions are observed in manual validation.

--- a/docs/pr-notes/runs/557-review-comment-3082052747-20260414T200919Z/requirements.md
+++ b/docs/pr-notes/runs/557-review-comment-3082052747-20260414T200919Z/requirements.md
@@ -1,0 +1,34 @@
+## Objective
+
+Define the minimum requirements for the PR #557 fix so `track.html` preserves configured stat values when player stat keys use mixed case, and so the regression test in `test-track-zero-stat-player-history.js` proves that behavior stays correct.
+
+## Acceptance Criteria
+
+1. When a coach finishes a game from `track.html`, each configured stat column is saved for every rostered player using the expected configured/lowercase output keys, even if the in-memory `playerStats` source uses mixed-case keys like `PTS`, `ReB`, or `ast`.
+
+2. If a player has a recorded value for a configured stat under a mixed-case key, that saved value is not replaced with `0` in the aggregated stats written at game finish.
+
+3. If a rostered player has no recorded stats, that player still receives an aggregated stats record with all configured stat columns present and set to `0`.
+
+4. Any non-configured stat already present on a player remains preserved in the saved stats payload and is not dropped by the normalization for configured columns.
+
+5. `test-track-zero-stat-player-history.js` includes regression coverage that fails if mixed-case configured stat keys are zeroed or duplicated during aggregated stats generation, and passes when the saved stats object contains the correct normalized configured keys with the original values intact.
+
+## User/Coach Impact
+
+- **Coach:** Post-game stats remain accurate when finishing a game, which avoids losing credited performance for players under time pressure.
+- **Parent:** Player history and shared stat views reflect the real game output instead of showing false zeroes.
+- **Admin/Program Manager:** Stored aggregated stats stay reliable for reporting, season summaries, and downstream views without manual cleanup.
+
+## Assumptions
+
+- Configured stat columns should continue to be stored under the existing normalized lowercase keys used by `track.html`.
+- The bug scope is limited to aggregated stats written when finishing the game, not a broader redesign of stat-key handling across the app.
+- The regression test file is the intended lightweight guardrail for this PR, since the repo does not use a full automated test framework.
+
+## Out of Scope
+
+- Changing the displayed column labels or tracker UI wording.
+- Backfilling or migrating previously saved game data.
+- Altering opponent stat handling, non-finish save flows, or unrelated stat normalization behavior elsewhere in the app.
+- Adding broader test infrastructure beyond the targeted regression coverage in `test-track-zero-stat-player-history.js`.

--- a/docs/pr-notes/runs/557-review-comment-3082052757-20260414T201150Z/architecture.md
+++ b/docs/pr-notes/runs/557-review-comment-3082052757-20260414T201150Z/architecture.md
@@ -1,0 +1,38 @@
+## Current State
+
+- `track.html` finishes a game by building `aggregatedStats` inline:
+  - configured columns are lowercased,
+  - source stat keys are matched case-insensitively,
+  - missing configured stats default to `0`,
+  - non-config stats are preserved if they do not collide with the normalized configured key.
+- `test-track-zero-stat-player-history.js` currently reimplements that same normalization block in its own helper.
+- That duplication is what let the original case-sensitivity bug exist in both places at once. The test looked realistic, but it was not truly anchored to the production path.
+
+## Proposed State
+
+- Extract the normalization block from `track.html` into one tiny pure helper, for example `js/normalize-aggregated-stats.js`.
+- Have `track.html` call that helper during finish-game batch creation.
+- Update `test-track-zero-stat-player-history.js` to call the shared helper and keep its expectations explicit and literal:
+  - zero-stat player gets `{ pts: 0, reb: 0, ast: 0 }`,
+  - mixed-case input like `{ PTS: 8, ReB: 5, ast: 2 }` becomes `{ pts: 8, reb: 5, ast: 2 }`,
+  - non-config keys like `blocks` remain preserved.
+- Keep the Firestore write shape exactly as it is now. No schema or document-path changes.
+
+## Architecture Decisions
+
+- **Single source of truth for normalization:** the case-folding rules should live in one pure function, not in parallel copies.
+- **Explicit contract in the test:** the test should still assert hard-coded expected objects, so it verifies behavior, not just “whatever the helper does.”
+- **Minimal blast radius:** only the finish-game aggregated-stats assembly path and this regression test are touched.
+- **Preserve current storage contract:** configured stat keys remain lowercase in saved `stats`, and unexpected extra keys remain supported.
+
+## Risks
+
+- **Small runtime risk:** moving inline code into a helper can introduce an import/wiring mistake in `track.html`.
+- **Shared-helper tradeoff:** the test and runtime now share the same function, so the value of the test depends on keeping explicit expected outputs. Without those explicit assertions, the test would become too weak.
+- **Blast radius:** limited to completed-game aggregated stat writes from `track.html`; no auth, rules, or unrelated tracker flows should move.
+
+## Rollback
+
+- Revert `track.html` to the current inline normalization block.
+- Point `test-track-zero-stat-player-history.js` back to its local fixture/helper if needed.
+- No data migration or cleanup is required, because this does not change stored schema, document IDs, or permissions.

--- a/docs/pr-notes/runs/557-review-comment-3082052757-20260414T201150Z/code-plan.md
+++ b/docs/pr-notes/runs/557-review-comment-3082052757-20260414T201150Z/code-plan.md
@@ -1,0 +1,52 @@
+## Minimal Patch Plan
+
+1. Treat `track.html` aggregated-stats write logic as the source of truth.
+2. Update only `buildAggregatedStatsWrites()` in `test-track-zero-stat-player-history.js` to mirror that logic exactly:
+   - pre-normalize incoming `playerStats` keys to lowercase,
+   - resolve configured columns from that lowercase map,
+   - preserve non-config stats only when neither the original key nor its lowercase form is already present.
+3. Add one focused regression test proving mixed-case source keys like `PTS` / `ReB` still land as lowercase configured stats without duplicate keys.
+
+## Concrete Changes
+
+- In `test-track-zero-stat-player-history.js`, inside `buildAggregatedStatsWrites()`:
+  - add `playerStatsByLowerKey = {}`.
+  - populate it with `String(statKey).toLowerCase()` keys and numeric values.
+  - replace `Number(playerStats[key]) || 0` with a lookup against `playerStatsByLowerKey` using `hasOwnProperty`.
+  - tighten the preservation guard from:
+    - `normalizedStats[statKey] === undefined`
+    to:
+    - `normalizedStats[statKey] === undefined && normalizedStats[normalizedKey] === undefined`
+- Add the mixed-case regression:
+  - input: `{ PTS: 8, ReB: 5, ast: 2 }`
+  - expected saved stats: `{ pts: 8, reb: 5, ast: 2 }`
+
+## Validation Commands
+
+```bash
+cd /tmp/allplays-pr557
+node test-track-zero-stat-player-history.js
+```
+
+```bash
+cd /tmp/allplays-pr557
+python3 - <<'PY'
+from pathlib import Path
+track = Path('track.html').read_text()
+test = Path('test-track-zero-stat-player-history.js').read_text()
+needles = [
+    'const playerStatsByLowerKey = {};',
+    "playerStatsByLowerKey[String(statKey).toLowerCase()] = Number(value) || 0;",
+    "normalizedStats[key] = Object.prototype.hasOwnProperty.call(playerStatsByLowerKey, key)",
+    "if (normalizedStats[statKey] === undefined && normalizedStats[normalizedKey] === undefined) {"
+]
+for n in needles:
+    print(('OK' if n in track and n in test else 'MISSING') + ' :: ' + n)
+PY
+```
+
+## Notes
+
+- The helper logic and `track.html` now match on the case-normalization flow.
+- The targeted helper test passes with all 4 assertions green.
+- This keeps scope tight to the review comment and avoids touching unrelated tracker behavior.

--- a/docs/pr-notes/runs/557-review-comment-3082052757-20260414T201150Z/qa.md
+++ b/docs/pr-notes/runs/557-review-comment-3082052757-20260414T201150Z/qa.md
@@ -1,0 +1,47 @@
+## Test Focus
+
+- Verified regression coverage for the three scoped acceptance criteria in `/tmp/allplays-pr557/test-track-zero-stat-player-history.js`:
+  1. **Mixed-case configured stats normalize correctly** (`PTS`, `ReB`, `ast` → `pts`, `reb`, `ast`)
+  2. **Zero-stat rostered players still get aggregated stats docs**
+  3. **Non-config stat keys remain preserved**
+- Confirmed `track.html` uses the same lowercasing + fallback-preservation behavior in the finish-game aggregated stats write path.
+- Executed:
+  - `node /tmp/allplays-pr557/test-track-zero-stat-player-history.js`
+  - Result: **4/4 tests passed**
+
+## Regression Risks
+
+- **Medium:** The standalone test now covers the mixed-case regression Amazon Q flagged, so the original blind spot is closed.
+- **Medium:** The test helper still **mirrors production logic** instead of invoking `track.html` behavior directly. If both implementations drift together in a future edit, this test can still false-pass.
+- **Low:** Zero-stat roster persistence is well represented because the test asserts one write per rostered player and zero-filled configured stats for scoreless players.
+- **Low:** Non-config stat preservation is explicitly asserted and protected against accidental pruning.
+- **Coverage gap:** No browser/manual automation currently validates the real finish flow from UI state through Firestore write payload assembly.
+
+## Validation Matrix
+
+| Acceptance criterion | Evidence | Result |
+|---|---|---|
+| Mixed-case configured stats should retain values and normalize to configured lowercase keys | `mixed-case configured stat keys are normalized without losing values` test; `track.html` now builds `playerStatsByLowerKey` before writing configured columns | Pass |
+| Rostered players with no recorded stats should still persist with zeroed configured stats | `writes one aggregated stats doc per rostered player` and `zero-stat players get zeroed configured stats` tests | Pass |
+| Existing non-config stats should not be dropped during save | `existing non-config stat keys are preserved` test; `track.html` preserves keys not already represented by configured lowercase keys | Pass |
+| Regression test should specifically catch the prior case-sensitivity bug | New mixed-case test would fail against the old `Number(playerStats[key]) || 0` behavior | Pass |
+| Real UI finish flow should be proven end-to-end | No direct automated/browser coverage in this PR | Gap |
+
+## Manual Checks
+
+1. Serve repo locally (`python3 -m http.server 8000`) and open a game in `track.html`.
+2. Use a stat config whose columns are uppercase or mixed-case (`PTS`, `REB`, `AST`).
+3. Record stats in a way that leaves in-memory/player payload keys mixed-case, then finish the game.
+4. Inspect saved `aggregatedStats/{playerId}` docs and confirm:
+   - configured stats are stored once, in lowercase
+   - values are preserved, not zeroed by case mismatch
+   - rostered players with no actions still get docs with zeroed configured stats
+   - non-config keys such as `blocks` remain present
+5. Re-open the completed game/history view and confirm zero-stat players still appear in saved player history.
+
+## Exit Criteria
+
+- ✅ Scoped regression test updated to cover the mixed-case bug Amazon Q identified
+- ✅ Automated script passes for all three requested behaviors
+- ✅ Production `track.html` write path matches the intended normalization/preservation logic
+- ⚠️ Recommended before merge: one manual finish-flow check, because current automation is a mirrored unit script, not an end-to-end tracker save test

--- a/docs/pr-notes/runs/557-review-comment-3082052757-20260414T201150Z/requirements.md
+++ b/docs/pr-notes/runs/557-review-comment-3082052757-20260414T201150Z/requirements.md
@@ -1,0 +1,23 @@
+## Objective
+Define the minimum regression requirements for `test-track-zero-stat-player-history.js` so it catches the case-sensitivity bug Amazon Q identified, while matching the current aggregated-stats behavior in `track.html`.
+
+## Acceptance Criteria
+1. The regression test must verify that every rostered player is included in the aggregated player-history output, even when that player recorded no in-game stats.
+2. The regression test must verify that a zero-stat player receives a stats object containing each configured stat column from the tracker, with each configured stat saved as `0`.
+3. The regression test must verify that when configured columns and recorded stat keys use different letter casing, the saved player-history stats preserve the correct numeric values instead of falling back to zero.
+4. The regression test must verify that the normalized saved stat keys match `track.html` behavior by using a single lowercase key per configured stat, without duplicate mixed-case variants.
+
+## User/Coach Impact
+- Coaches can trust post-game history to include bench or scoreless players instead of silently dropping them.
+- Coaches and parents see correct stat totals in player history even if stat keys were entered or configured with inconsistent casing.
+- Admins get more reliable regression protection for a high-pressure game workflow without changing the intended tracker behavior.
+
+## Assumptions
+- `track.html` is the source of truth for the expected aggregated-stats shape.
+- Configured stat columns are intended to be persisted under lowercase keys in aggregated player-history data.
+- This fix is limited to protecting the existing behavior, not redefining stat-storage rules.
+
+## Out of Scope
+- Changing the production aggregation logic in `track.html`.
+- Expanding this test to unrelated tracker flows, Firestore wiring, or UI rendering.
+- Broadening coverage for unrelated stat-shape behavior beyond the specific zero-stat and case-normalization regression.

--- a/docs/pr-notes/runs/557-review-comment-3082064728-20260414T201837Z/architecture.md
+++ b/docs/pr-notes/runs/557-review-comment-3082064728-20260414T201837Z/architecture.md
@@ -1,0 +1,39 @@
+## Current State
+
+- `track.html` finish-game work now consists of three write groups:
+  - event docs under `games/{gameId}/events`,
+  - one `aggregatedStats/{playerId}` doc for every rostered player,
+  - one final update to `games/{gameId}`.
+- The branch already takes the right first step for the review comment: it removes roster-wide `aggregatedStats` from the primary batch and chunks them into secondary batches capped at 450 writes.
+- Those secondary stats batches commit before the primary batch. That matters because `aggregatedStats/{playerId}` writes are deterministic upserts, while event docs still use auto-generated IDs and are not naturally idempotent across retries.
+- One remaining gap is recovery behavior: `startTimer()` checks existing `events` before offering a clear-and-restart path, but it does not treat `aggregatedStats`-only residue as persisted activity.
+
+## Proposed State
+
+- Keep the current split-batch pattern. It is the safest minimal remediation for the 500-write limit.
+- Keep `aggregatedStats` in separate chunked batches, with deterministic doc IDs by `playerId`.
+- Keep the primary batch focused on the historical authoritative writes: `events + final game update`.
+- Add two small guardrails in `track.html`:
+  1. **Preflight batch-size guard**: if `gameState.gameLog.length + 1 > 500`, block finish and show an explicit error instead of attempting the commit.
+  2. **Restart detection guard**: when starting fresh, check both `events` and `aggregatedStats`; if either exists, prompt and clear both.
+- Do **not** add new Firestore schema, new game statuses, or backend finalize jobs for this fix.
+
+## Architecture Decisions
+
+- **Use derived-doc fanout as the separate step**: `aggregatedStats` is derived data and safe to overwrite by stable `playerId`; that makes it the right payload to chunk.
+- **Avoid retrying non-idempotent event creation**: because event docs still use auto IDs, keeping them in one atomic primary batch minimizes duplicate-history risk.
+- **Prefer contained client-side hardening over lifecycle redesign**: adding a `finishing` or `completed_pending_stats` state would force reader changes across `game.html`, team views, and reporting flows.
+- **Blast radius stays small**: this should stay confined to `track.html` plus the batch-limit regression coverage.
+
+## Risks
+
+- Multi-batch writes are still not all-or-nothing. If stats batches succeed and the primary batch fails, Firestore can temporarily contain `aggregatedStats` without the final event/game commit.
+- That partial state is acceptable for a minimal fix because the stats docs are overwrite-safe, but it can confuse resume/start behavior unless the restart detection also checks `aggregatedStats`.
+- Chunking roster stats does **not** protect against a too-large primary batch if the event log alone exceeds 500 writes. The preflight guard is required.
+- There is a small chance of stale derived stats being visible after a failed finish attempt, but that is a smaller blast radius than duplicated event history.
+
+## Rollback
+
+- Revert the finish-flow chunking and preflight/restart guards in `track.html`.
+- Revert the matching batch-limit test coverage.
+- No data migration or Firestore cleanup is required, because document paths, schemas, and permissions remain unchanged.

--- a/docs/pr-notes/runs/557-review-comment-3082064728-20260414T201837Z/code-plan.md
+++ b/docs/pr-notes/runs/557-review-comment-3082064728-20260414T201837Z/code-plan.md
@@ -1,0 +1,50 @@
+## Minimal Patch Plan
+
+1. Keep the finish flow in `track.html` split into two write phases instead of one oversized Firestore batch.
+2. Build `aggregatedStatsWrites` in memory first, but do not add those writes to the same batch as game-log events.
+3. Keep the primary batch limited to:
+   - all `events/*` writes
+   - the final `games/{gameId}` update
+4. Commit the primary batch first, then commit `aggregatedStats/*` writes in sequential secondary batches capped below Firestore’s 500-write limit, for example `450` per batch.
+5. Add a focused regression script that asserts:
+   - roster-wide aggregated stats are excluded from the primary batch
+   - secondary aggregated-stats batches are chunked under the configured cap
+
+## Concrete Changes
+
+- In `track.html` around the finish-game submit handler (`~1229-1300`):
+  - replace the single `batch` flow with:
+    - `const primaryBatch = writeBatch(db);`
+    - `const aggregatedStatsWrites = players.map(...)`
+  - keep existing normalized stats generation unchanged
+  - write game-log entries to `primaryBatch`
+  - write the final game document update to `primaryBatch`
+  - chunk `aggregatedStatsWrites` into `writeBatch(db)` calls using `MAX_AGGREGATED_STATS_BATCH_WRITES = 450`
+  - `await primaryBatch.commit();` before the secondary stats batches, to preserve the old “finish game” success path as much as possible
+- Add `test-track-finish-batch-limit.js` with math-only regression coverage for:
+  - `490 events + 25 players => primary batch stays at 491 writes, stats go to a separate batch`
+  - `905 aggregated stats writes => [450, 450, 5]`
+
+## Validation Commands
+
+```bash
+cd /tmp/allplays-pr557
+node test-track-finish-batch-limit.js
+```
+
+```bash
+cd /tmp/allplays-pr557
+python3 -m http.server 8000
+```
+
+Manual check after starting the server:
+1. Open `http://127.0.0.1:8000/track.html#teamId=<teamId>&gameId=<gameId>`
+2. Use a game with a large event log plus normal roster size
+3. Finish the game
+4. Confirm there is no Firestore 500-write batch failure and the game redirects successfully
+
+## Notes
+
+- I ran `node test-track-finish-batch-limit.js` in `/tmp/allplays-pr557`, and it passed.
+- The current split-batch approach addresses the regression Codex flagged.
+- Residual risk: if `gameState.gameLog.length + 1 > 500`, the primary batch can still overflow. That appears to be a pre-existing limit, not the new regression. Fixing that would require a broader batching redesign beyond this minimal patch.

--- a/docs/pr-notes/runs/557-review-comment-3082064728-20260414T201837Z/qa.md
+++ b/docs/pr-notes/runs/557-review-comment-3082064728-20260414T201837Z/qa.md
@@ -1,0 +1,99 @@
+## Test Focus
+
+- **High: finish-flow write safety at Firestore limits**
+  - Verify the finish action keeps **aggregatedStats** writes out of the primary batch.
+  - Verify secondary aggregated-stats batches stay **well below 500 writes** (current cap in code is 450).
+  - Verify the primary batch stays safe for realistic and boundary-sized game logs.
+
+- **High: large game-log behavior**
+  - Validate finish succeeds at the safe boundary (**499 event writes + 1 game update = 500 total writes**).
+  - Validate behavior for **500+ logged events**. This is the biggest remaining risk, because the current remediation chunks roster writes but still leaves the primary event batch unchunked.
+
+- **High: zero-stat player history preservation**
+  - Every rostered player must receive an `aggregatedStats/{playerId}` doc, even with no recorded events.
+  - Configured stat columns should persist as explicit zeroes.
+  - Mixed-case keys should normalize correctly, and non-config stat keys should not be dropped.
+
+- **Medium: finish-flow integrity and partial-write safety**
+  - If finish fails, verify the game is not left in a misleading partial state, especially because aggregated-stats batches commit before the primary batch.
+  - Confirm no orphaned zero-stat history is written without the game actually being marked completed.
+
+- **Coverage gap to call out**
+  - Repo checks currently cover:
+    - aggregated-stats batching split
+    - zero-stat player history generation
+  - Repo checks do **not** currently cover:
+    - **499 / 500 / 501 event** finish boundaries
+    - partial-commit behavior when the primary batch fails
+
+## Regression Risks
+
+- **High:** Games with very large logs can still exceed Firestore’s 500-write limit in the **primary** batch.
+- **High:** Partial persistence risk, where `aggregatedStats` commits succeed but `events` + final game update fail, leaving inconsistent post-game data.
+- **High:** Zero-stat bench or inactive players disappearing from post-game history if roster-wide writes regress.
+- **Medium:** Mixed-case stat keys creating duplicate or malformed stats (`PTS` vs `pts`) in saved history.
+- **Medium:** Unexpected/custom stat keys being lost during normalization.
+- **Medium:** Coach/admin sees a completed game summary, but parent/player-facing history omits zero-stat players or shows stale totals.
+
+## Validation Matrix
+
+| Priority | Scenario | Acceptance criterion | Method |
+|---|---|---|---|
+| High | Normal finish, small log, mixed roster usage | Finish succeeds, game status becomes `completed`, all game-log events persist, all rostered players get `aggregatedStats` docs | Manual + Firestore inspection |
+| High | Boundary case: **499** logged events | Finish succeeds with no Firestore batch-limit error; primary write count stays at 500 including final game update | Add targeted automated check or scripted/manual data setup |
+| High | Over-limit case: **500+** logged events | System must **either** chunk events **or** fail cleanly before partial persistence. No orphaned `aggregatedStats` docs, no false completed state | Manual negative test, Firestore inspection |
+| High | Large roster / large aggregated stats payload | Aggregated-stats writes are split into batches of **<= 450**; no secondary batch exceeds Firestore limit | Existing `test-track-finish-batch-limit.js` plus boundary extension |
+| High | Zero-stat rostered player | Player with no events still gets persisted stats doc with configured stat keys set to `0` | Existing `test-track-zero-stat-player-history.js` + manual verification |
+| Medium | Mixed-case stat input | Persisted stats normalize correctly without duplicate-case keys and without value loss | Existing automated test |
+| Medium | Extra non-config stats present | Non-config stat keys are preserved in saved history | Existing automated test |
+| Medium | Post-finish reload | Reloaded completed game shows final score, event history, and zero-stat players still present in post-game stats/history views | Manual UI verification |
+| Medium | Retry / interrupted finish | Re-click, refresh, or transient error does not create duplicated or inconsistent persisted finish data | Manual negative test |
+
+## Manual Checks
+
+1. **Baseline small game**
+   - Track a game with a few events and at least one rostered player who records no stats.
+   - Finish the game.
+   - Verify in Firestore:
+     - `games/{gameId}.status == "completed"`
+     - `events` count matches logged events
+     - every rostered player has an `aggregatedStats/{playerId}` doc
+     - zero-stat player doc contains configured stats with zero values
+
+2. **Boundary finish at 499 events**
+   - Seed or simulate a game log with exactly 499 entries.
+   - Finish the game.
+   - Verify no console/Firebase batch-limit error and all expected writes land.
+
+3. **Negative test at 500+ events**
+   - Seed or simulate 500 and then 501 log entries.
+   - Finish the game.
+   - Verify the app does not silently corrupt state.
+   - Specifically inspect for:
+     - aggregated stats written without game completion
+     - missing final game update
+     - partial event persistence
+
+4. **Large-roster coverage**
+   - Use a roster large enough to force multiple aggregated-stats batches in synthetic/scripted testing.
+   - Confirm no secondary batch exceeds 450 writes.
+
+5. **History visibility check**
+   - After finish, reload the game and any downstream stat/history view used by coaches/parents.
+   - Confirm zero-stat players still appear in persisted history, not just in the live tracker state.
+
+6. **Stat-shape regression check**
+   - Use mixed-case stat keys and one unexpected stat key.
+   - Confirm saved data is normalized and preserved correctly.
+
+## Exit Criteria
+
+- Existing repo checks pass:
+  - `test-track-finish-batch-limit.js`
+  - `test-track-zero-stat-player-history.js`
+- Boundary validation exists for **499 / 500 / 501** event finishes, with evidence.
+- No finish path can exceed Firestore’s 500-write limit without a clean, user-safe outcome.
+- No partial-write state is observed when finish fails.
+- Every rostered player, including zero-stat players, has persisted post-game history after finish and reload.
+- Coach/admin and downstream history views reflect the same saved outcome.
+- If 500+ event logs are not yet safely handled, treat that as a **release blocker or explicitly accepted known risk**, not a silent pass.

--- a/docs/pr-notes/runs/557-review-comment-3082064728-20260414T201837Z/requirements.md
+++ b/docs/pr-notes/runs/557-review-comment-3082064728-20260414T201837Z/requirements.md
@@ -1,0 +1,55 @@
+## Objective
+
+Define the minimum safe behavior for fixing `track.html` finish-game saves so a coach can complete a game even when total Firestore writes for finalization exceed the single-batch 500-write limit, without changing the expected completed-game experience for coaches, parents, or admins.
+
+## Acceptance Criteria
+
+1. **Large-write games can still be finished successfully.**  
+   A coach can finish a game from `track.html` in a scenario where the combined finalization writes exceed 500 total writes, including:
+   - all logged game events,
+   - the completed game record update,
+   - aggregated stats for every rostered player.
+
+2. **The coach only sees success after all required finish-game saves succeed.**  
+   The app must not redirect away from the tracker or behave as if the game is finished until all required finish-game data has been saved successfully.
+
+3. **Failure remains recoverable for the coach.**  
+   If any part of the finish flow fails, the coach stays on the current page, sees a clear error, and can retry finishing the game without re-entering the entire game from scratch.
+
+4. **Completed-game data remains intact and consistent for end users.**  
+   After a successful finish:
+   - final score is correct,
+   - summary is preserved,
+   - all intended game events are available,
+   - every rostered player has the expected aggregated stats entry,
+   - opponent stats remain preserved.
+
+5. **Existing normal-size games still work the same way.**  
+   For games that do not approach the 500-write limit, the finish flow still behaves as before from the coach’s point of view.
+
+6. **Parent and admin views are not degraded by the fix.**  
+   After a successful finish, parents and admins viewing the completed game see the same final score and player stat outcomes they would expect today, with no missing players caused by roster size.
+
+7. **Retrying a failed finish does not create visible duplicate completed-game data.**  
+   A coach retrying after a failed finish must not end up with duplicate visible results such as duplicated player aggregates or a broken completed-game view.
+
+## User/Coach Impact
+
+- **Coach:** Must be able to finish the game quickly and reliably at the end of play, even for large rosters or long games, without hitting a technical Firestore limit.
+- **Parents:** Must see a trustworthy completed game with the correct score and player stats once the coach finishes.
+- **Admins/Program staff:** Must not have to clean up missing or inconsistent completed-game records caused by large-game finalization.
+
+## Assumptions
+
+- Firestore’s 500-write limit applies per batch/commit, and the safe fix may use more than one commit.
+- A fully atomic single-commit finish is not required for this remediation, as long as the UI does not report success before all required writes succeed.
+- The minimum safe fix should preserve the current user-facing workflow and not require coaches to change how they track or finish games.
+- Manual validation is acceptable for this PR, including at least one scenario that exceeds 500 total finalization writes.
+
+## Out of Scope
+
+- Redesigning how live tracking works during the game.
+- Reworking the data model for events or aggregated stats beyond what is needed for safe finalization.
+- Backfilling or repairing old completed games.
+- Broader performance optimizations unrelated to preventing the finish-game write-limit failure.
+- Changes to parent-facing or admin-facing UX beyond preserving current expected behavior.

--- a/test-track-finish-batch-limit.js
+++ b/test-track-finish-batch-limit.js
@@ -1,0 +1,124 @@
+const results = [];
+
+function test(name, fn) {
+    try {
+        fn();
+        results.push({ name, pass: true });
+    } catch (error) {
+        results.push({ name, pass: false, error: error.message });
+    }
+}
+
+function assertEquals(actual, expected, label) {
+    if (actual !== expected) {
+        throw new Error(`${label}\nExpected: ${JSON.stringify(expected)}\nActual: ${JSON.stringify(actual)}`);
+    }
+}
+
+function assertDeepEquals(actual, expected, label) {
+    const actualJson = JSON.stringify(actual);
+    const expectedJson = JSON.stringify(expected);
+    if (actualJson !== expectedJson) {
+        throw new Error(`${label}\nExpected: ${expectedJson}\nActual: ${actualJson}`);
+    }
+}
+
+function buildFinishWritePlan(gameLogEntries, aggregatedStatsWrites, maxAggregatedStatsBatchWrites = 450) {
+    const primaryBatchWriteCount = gameLogEntries.length + 1;
+    const canCommitPrimaryBatch = primaryBatchWriteCount <= 500;
+    const aggregatedStatsBatchSizes = [];
+
+    if (canCommitPrimaryBatch) {
+        for (let i = 0; i < aggregatedStatsWrites.length; i += maxAggregatedStatsBatchWrites) {
+            aggregatedStatsBatchSizes.push(
+                aggregatedStatsWrites.slice(i, i + maxAggregatedStatsBatchWrites).length
+            );
+        }
+    }
+
+    return {
+        primaryBatchWriteCount,
+        canCommitPrimaryBatch,
+        aggregatedStatsBatchSizes
+    };
+}
+
+test('keeps roster-wide aggregated stats writes out of the primary finish batch', () => {
+    const plan = buildFinishWritePlan(
+        new Array(490).fill({}),
+        new Array(25).fill({})
+    );
+
+    assertEquals(
+        plan.primaryBatchWriteCount,
+        491,
+        'Primary finish batch should only contain game-log writes plus the final game update'
+    );
+    assertDeepEquals(
+        plan.aggregatedStatsBatchSizes,
+        [25],
+        'Roster-wide aggregated stats should be committed in a separate batch'
+    );
+});
+
+test('chunks aggregated stats writes into sub-500 secondary batches', () => {
+    const plan = buildFinishWritePlan(
+        new Array(499).fill({}),
+        new Array(905).fill({})
+    );
+
+    assertEquals(
+        plan.canCommitPrimaryBatch,
+        true,
+        'Primary batch should remain commit-safe at 499 event writes plus the game update'
+    );
+    assertDeepEquals(
+        plan.aggregatedStatsBatchSizes,
+        [450, 450, 5],
+        'Large roster-wide aggregated stats writes should be split across multiple secondary batches'
+    );
+    plan.aggregatedStatsBatchSizes.forEach((size) => {
+        if (size > 450) {
+            throw new Error(`Secondary batch exceeded the configured write cap: ${size}`);
+        }
+    });
+});
+
+test('fails cleanly before writing secondary batches when the primary batch would overflow', () => {
+    const plan = buildFinishWritePlan(
+        new Array(500).fill({}),
+        new Array(25).fill({})
+    );
+
+    assertEquals(
+        plan.primaryBatchWriteCount,
+        501,
+        '500 event writes plus the final game update should exceed Firestore batch limits'
+    );
+    assertEquals(
+        plan.canCommitPrimaryBatch,
+        false,
+        'Primary batch should be rejected before any secondary aggregated stats batches are committed'
+    );
+    assertDeepEquals(
+        plan.aggregatedStatsBatchSizes,
+        [],
+        'No secondary aggregated stats batches should be planned when the primary batch is already unsafe'
+    );
+});
+
+const failed = results.filter((result) => !result.pass);
+results.forEach((result) => {
+    if (result.pass) {
+        console.log(`PASS ${result.name}`);
+        return;
+    }
+    console.error(`FAIL ${result.name}`);
+    console.error(result.error);
+});
+
+if (failed.length > 0) {
+    process.exit(1);
+}
+
+console.log(`All ${results.length} tests passed.`);

--- a/test-track-zero-stat-player-history.js
+++ b/test-track-zero-stat-player-history.js
@@ -26,15 +26,23 @@ function assertDeepEquals(actual, expected, label) {
 function buildAggregatedStatsWrites(players, columns, playerStatsById) {
     return players.map((player) => {
         const playerStats = playerStatsById[player.id] || {};
+        const playerStatsByLowerKey = {};
         const normalizedStats = {};
+
+        Object.entries(playerStats).forEach(([statKey, value]) => {
+            playerStatsByLowerKey[String(statKey).toLowerCase()] = Number(value) || 0;
+        });
 
         columns.forEach((col) => {
             const key = String(col || '').toLowerCase();
-            normalizedStats[key] = Number(playerStats[key]) || 0;
+            normalizedStats[key] = Object.prototype.hasOwnProperty.call(playerStatsByLowerKey, key)
+                ? playerStatsByLowerKey[key]
+                : 0;
         });
 
         Object.entries(playerStats).forEach(([statKey, value]) => {
-            if (normalizedStats[statKey] === undefined) {
+            const normalizedKey = String(statKey).toLowerCase();
+            if (normalizedStats[statKey] === undefined && normalizedStats[normalizedKey] === undefined) {
                 normalizedStats[statKey] = Number(value) || 0;
             }
         });
@@ -77,6 +85,22 @@ test('zero-stat players get zeroed configured stats', () => {
         writes[0].data.stats,
         { pts: 0, reb: 0, ast: 0 },
         'Scoreless player should still get a zeroed stats object'
+    );
+});
+
+test('mixed-case configured stat keys are normalized without losing values', () => {
+    const writes = buildAggregatedStatsWrites(
+        [{ id: 'player-a', name: 'Player A', number: '12' }],
+        ['PTS', 'REB', 'AST'],
+        {
+            'player-a': { PTS: 8, ReB: 5, ast: 2 }
+        }
+    );
+
+    assertDeepEquals(
+        writes[0].data.stats,
+        { pts: 8, reb: 5, ast: 2 },
+        'Configured stat values should survive mixed-case source keys without duplicate variants'
     );
 });
 

--- a/test-track-zero-stat-player-history.js
+++ b/test-track-zero-stat-player-history.js
@@ -23,36 +23,41 @@ function assertDeepEquals(actual, expected, label) {
     }
 }
 
+function buildNormalizedPlayerStats(playerStats = {}, columns = []) {
+    const playerStatsByLowerKey = {};
+    const normalizedStats = {};
+
+    Object.entries(playerStats).forEach(([statKey, value]) => {
+        playerStatsByLowerKey[String(statKey).toLowerCase()] = Number(value) || 0;
+    });
+
+    columns.forEach((col) => {
+        const key = String(col || '').toLowerCase();
+        normalizedStats[key] = Object.prototype.hasOwnProperty.call(playerStatsByLowerKey, key)
+            ? playerStatsByLowerKey[key]
+            : 0;
+    });
+
+    Object.entries(playerStats).forEach(([statKey, value]) => {
+        const normalizedKey = String(statKey).toLowerCase();
+        if (normalizedStats[statKey] === undefined && normalizedStats[normalizedKey] === undefined) {
+            normalizedStats[statKey] = Number(value) || 0;
+        }
+    });
+
+    return normalizedStats;
+}
+
 function buildAggregatedStatsWrites(players, columns, playerStatsById) {
     return players.map((player) => {
         const playerStats = playerStatsById[player.id] || {};
-        const playerStatsByLowerKey = {};
-        const normalizedStats = {};
-
-        Object.entries(playerStats).forEach(([statKey, value]) => {
-            playerStatsByLowerKey[String(statKey).toLowerCase()] = Number(value) || 0;
-        });
-
-        columns.forEach((col) => {
-            const key = String(col || '').toLowerCase();
-            normalizedStats[key] = Object.prototype.hasOwnProperty.call(playerStatsByLowerKey, key)
-                ? playerStatsByLowerKey[key]
-                : 0;
-        });
-
-        Object.entries(playerStats).forEach(([statKey, value]) => {
-            const normalizedKey = String(statKey).toLowerCase();
-            if (normalizedStats[statKey] === undefined && normalizedStats[normalizedKey] === undefined) {
-                normalizedStats[statKey] = Number(value) || 0;
-            }
-        });
 
         return {
             playerId: player.id,
             data: {
                 playerName: player.name,
                 playerNumber: player.number,
-                stats: normalizedStats
+                stats: buildNormalizedPlayerStats(playerStats, columns)
             }
         };
     });
@@ -85,6 +90,22 @@ test('zero-stat players get zeroed configured stats', () => {
         writes[0].data.stats,
         { pts: 0, reb: 0, ast: 0 },
         'Scoreless player should still get a zeroed stats object'
+    );
+});
+
+test('uppercase source stat keys survive lowercase configured lookups', () => {
+    const writes = buildAggregatedStatsWrites(
+        [{ id: 'player-a', name: 'Player A', number: '12' }],
+        ['PTS', 'REB'],
+        {
+            'player-a': { PTS: 5, REB: 3 }
+        }
+    );
+
+    assertDeepEquals(
+        writes[0].data.stats,
+        { pts: 5, reb: 3 },
+        'Configured stat values should survive uppercase source keys when config columns normalize to lowercase'
     );
 });
 

--- a/test-track-zero-stat-player-history.js
+++ b/test-track-zero-stat-player-history.js
@@ -1,0 +1,113 @@
+const results = [];
+
+function test(name, fn) {
+    try {
+        fn();
+        results.push({ name, pass: true });
+    } catch (error) {
+        results.push({ name, pass: false, error: error.message });
+    }
+}
+
+function assertEquals(actual, expected, label) {
+    if (actual !== expected) {
+        throw new Error(`${label}\nExpected: ${JSON.stringify(expected)}\nActual: ${JSON.stringify(actual)}`);
+    }
+}
+
+function assertDeepEquals(actual, expected, label) {
+    const actualJson = JSON.stringify(actual);
+    const expectedJson = JSON.stringify(expected);
+    if (actualJson !== expectedJson) {
+        throw new Error(`${label}\nExpected: ${expectedJson}\nActual: ${actualJson}`);
+    }
+}
+
+function buildAggregatedStatsWrites(players, columns, playerStatsById) {
+    return players.map((player) => {
+        const playerStats = playerStatsById[player.id] || {};
+        const normalizedStats = {};
+
+        columns.forEach((col) => {
+            const key = String(col || '').toLowerCase();
+            normalizedStats[key] = Number(playerStats[key]) || 0;
+        });
+
+        Object.entries(playerStats).forEach(([statKey, value]) => {
+            if (normalizedStats[statKey] === undefined) {
+                normalizedStats[statKey] = Number(value) || 0;
+            }
+        });
+
+        return {
+            playerId: player.id,
+            data: {
+                playerName: player.name,
+                playerNumber: player.number,
+                stats: normalizedStats
+            }
+        };
+    });
+}
+
+test('writes one aggregated stats doc per rostered player', () => {
+    const writes = buildAggregatedStatsWrites(
+        [
+            { id: 'player-a', name: 'Player A', number: '12' },
+            { id: 'player-b', name: 'Player B', number: '34' }
+        ],
+        ['PTS', 'REB', 'AST'],
+        {
+            'player-a': { pts: 10, reb: 4, ast: 2 }
+        }
+    );
+
+    assertEquals(writes.length, 2, 'Expected one write per rostered player');
+    assertEquals(writes[1].playerId, 'player-b', 'Second write should belong to scoreless player');
+});
+
+test('zero-stat players get zeroed configured stats', () => {
+    const writes = buildAggregatedStatsWrites(
+        [{ id: 'player-b', name: 'Player B', number: '34' }],
+        ['PTS', 'REB', 'AST'],
+        {}
+    );
+
+    assertDeepEquals(
+        writes[0].data.stats,
+        { pts: 0, reb: 0, ast: 0 },
+        'Scoreless player should still get a zeroed stats object'
+    );
+});
+
+test('existing non-config stat keys are preserved', () => {
+    const writes = buildAggregatedStatsWrites(
+        [{ id: 'player-a', name: 'Player A', number: '12' }],
+        ['PTS', 'REB'],
+        {
+            'player-a': { pts: 8, reb: 5, blocks: 3 }
+        }
+    );
+
+    assertDeepEquals(
+        writes[0].data.stats,
+        { pts: 8, reb: 5, blocks: 3 },
+        'Unexpected stat keys should be preserved when saving'
+    );
+});
+
+const failed = results.filter((result) => !result.pass);
+results.forEach((result) => {
+    if (result.pass) {
+        console.log(`PASS ${result.name}`);
+        return;
+    }
+    console.error(`FAIL ${result.name}`);
+    console.error(result.error);
+});
+
+if (failed.length > 0) {
+    process.exit(1);
+}
+
+console.log(`All ${results.length} tests passed.`);

--- a/track.html
+++ b/track.html
@@ -1214,6 +1214,31 @@ Write the match report now:`;
             document.getElementById('emailPreview').textContent = emailBody;
         }
 
+        function buildNormalizedPlayerStats(playerStats = {}, columns = []) {
+            const playerStatsByLowerKey = {};
+            const normalizedStats = {};
+
+            Object.entries(playerStats).forEach(([statKey, value]) => {
+                playerStatsByLowerKey[String(statKey).toLowerCase()] = Number(value) || 0;
+            });
+
+            columns.forEach((col) => {
+                const key = String(col || '').toLowerCase();
+                normalizedStats[key] = Object.prototype.hasOwnProperty.call(playerStatsByLowerKey, key)
+                    ? playerStatsByLowerKey[key]
+                    : 0;
+            });
+
+            Object.entries(playerStats).forEach(([statKey, value]) => {
+                const normalizedKey = String(statKey).toLowerCase();
+                if (normalizedStats[statKey] === undefined && normalizedStats[normalizedKey] === undefined) {
+                    normalizedStats[statKey] = Number(value) || 0;
+                }
+            });
+
+            return normalizedStats;
+        }
+
         cancelBtn.addEventListener('click', () => {
             modal.classList.add('hidden');
         });
@@ -1237,33 +1262,13 @@ Write the match report now:`;
                 const primaryBatch = writeBatch(db);
                 const aggregatedStatsWrites = players.map((player) => {
                     const playerStats = gameState.playerStats[player.id] || {};
-                    const playerStatsByLowerKey = {};
-                    const normalizedStats = {};
-
-                    Object.entries(playerStats).forEach(([statKey, value]) => {
-                        playerStatsByLowerKey[String(statKey).toLowerCase()] = Number(value) || 0;
-                    });
-
-                    currentConfig.columns.forEach((col) => {
-                        const key = String(col || '').toLowerCase();
-                        normalizedStats[key] = Object.prototype.hasOwnProperty.call(playerStatsByLowerKey, key)
-                            ? playerStatsByLowerKey[key]
-                            : 0;
-                    });
-
-                    Object.entries(playerStats).forEach(([statKey, value]) => {
-                        const normalizedKey = String(statKey).toLowerCase();
-                        if (normalizedStats[statKey] === undefined && normalizedStats[normalizedKey] === undefined) {
-                            normalizedStats[statKey] = Number(value) || 0;
-                        }
-                    });
 
                     return {
                         playerId: player.id,
                         data: {
                             playerName: player.name,
                             playerNumber: player.number,
-                            stats: normalizedStats
+                            stats: buildNormalizedPlayerStats(playerStats, currentConfig.columns)
                         }
                     };
                 });
@@ -1294,7 +1299,10 @@ Write the match report now:`;
                     opponentStats: gameState.opponentStats
                 });
 
-                // 2. Chunk roster-wide aggregated stats writes into secondary batches to avoid Firestore's 500-write limit.
+                // 2. Commit the historical finish data first so completion data lands even if a later stats batch fails.
+                await primaryBatch.commit();
+
+                // 3. Chunk roster-wide aggregated stats writes into secondary batches to avoid Firestore's 500-write limit.
                 for (let i = 0; i < aggregatedStatsWrites.length; i += MAX_AGGREGATED_STATS_BATCH_WRITES) {
                     const statsBatch = writeBatch(db);
                     aggregatedStatsWrites.slice(i, i + MAX_AGGREGATED_STATS_BATCH_WRITES).forEach(({ playerId, data }) => {
@@ -1304,7 +1312,6 @@ Write the match report now:`;
                     await statsBatch.commit();
                 }
 
-                await primaryBatch.commit();
                 console.log('Game data saved successfully');
 
                 // Disable beforeunload warning since we're finishing successfully

--- a/track.html
+++ b/track.html
@@ -1226,28 +1226,16 @@ Write the match report now:`;
             const sendEmail = document.getElementById('sendEmailCheckbox').checked;
 
             try {
-                // Create a batch write for all data
-                const batch = writeBatch(db);
+                const MAX_PRIMARY_BATCH_WRITES = 500;
+                const MAX_AGGREGATED_STATS_BATCH_WRITES = 450;
+                const primaryBatchWriteCount = gameState.gameLog.length + 1;
 
-                // 1. Write all game log events
-                gameState.gameLog.forEach(entry => {
-                    const eventRef = doc(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
-                    batch.set(eventRef, {
-                        text: entry.text,
-                        gameTime: entry.time,
-                        period: entry.period,
-                        timestamp: entry.timestamp || Date.now(),
-                        type: entry.undoData?.type || 'game_log',
-                        playerId: entry.undoData?.playerId || null,
-                        statKey: entry.undoData?.statKey || null,
-                        value: entry.undoData?.value || null,
-                        isOpponent: entry.undoData?.isOpponent || false,
-                        createdBy: currentUser.uid
-                    });
-                });
+                if (primaryBatchWriteCount > MAX_PRIMARY_BATCH_WRITES) {
+                    throw new Error(`Game has ${gameState.gameLog.length} logged events. Finish requires chunked event persistence before it can safely exceed Firestore's ${MAX_PRIMARY_BATCH_WRITES}-write batch limit.`);
+                }
 
-                // 2. Write aggregated stats for every rostered player, including zero-stat appearances
-                players.forEach((player) => {
+                const primaryBatch = writeBatch(db);
+                const aggregatedStatsWrites = players.map((player) => {
                     const playerStats = gameState.playerStats[player.id] || {};
                     const playerStatsByLowerKey = {};
                     const normalizedStats = {};
@@ -1270,17 +1258,35 @@ Write the match report now:`;
                         }
                     });
 
-                    const statsRef = doc(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`, player.id);
-                    batch.set(statsRef, {
-                        playerName: player.name,
-                        playerNumber: player.number,
-                        stats: normalizedStats
+                    return {
+                        playerId: player.id,
+                        data: {
+                            playerName: player.name,
+                            playerNumber: player.number,
+                            stats: normalizedStats
+                        }
+                    };
+                });
+
+                // 1. Keep the primary batch at its historical size: events + final game update.
+                gameState.gameLog.forEach(entry => {
+                    const eventRef = doc(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
+                    primaryBatch.set(eventRef, {
+                        text: entry.text,
+                        gameTime: entry.time,
+                        period: entry.period,
+                        timestamp: entry.timestamp || Date.now(),
+                        type: entry.undoData?.type || 'game_log',
+                        playerId: entry.undoData?.playerId || null,
+                        statKey: entry.undoData?.statKey || null,
+                        value: entry.undoData?.value || null,
+                        isOpponent: entry.undoData?.isOpponent || false,
+                        createdBy: currentUser.uid
                     });
                 });
 
-                // 3. Update game document with final data
                 const gameRef = doc(db, `teams/${currentTeamId}/games`, currentGameId);
-                batch.update(gameRef, {
+                primaryBatch.update(gameRef, {
                     homeScore: finalHome,
                     awayScore: finalAway,
                     summary: summary,
@@ -1288,8 +1294,17 @@ Write the match report now:`;
                     opponentStats: gameState.opponentStats
                 });
 
-                // Commit all writes in a single batch
-                await batch.commit();
+                // 2. Chunk roster-wide aggregated stats writes into secondary batches to avoid Firestore's 500-write limit.
+                for (let i = 0; i < aggregatedStatsWrites.length; i += MAX_AGGREGATED_STATS_BATCH_WRITES) {
+                    const statsBatch = writeBatch(db);
+                    aggregatedStatsWrites.slice(i, i + MAX_AGGREGATED_STATS_BATCH_WRITES).forEach(({ playerId, data }) => {
+                        const statsRef = doc(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`, playerId);
+                        statsBatch.set(statsRef, data);
+                    });
+                    await statsBatch.commit();
+                }
+
+                await primaryBatch.commit();
                 console.log('Game data saved successfully');
 
                 // Disable beforeunload warning since we're finishing successfully

--- a/track.html
+++ b/track.html
@@ -1246,17 +1246,28 @@ Write the match report now:`;
                     });
                 });
 
-                // 2. Write aggregated stats for each player
-                Object.entries(gameState.playerStats).forEach(([playerId, stats]) => {
-                    const player = players.find(p => p.id === playerId);
-                    if (player) {
-                        const statsRef = doc(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`, playerId);
-                        batch.set(statsRef, {
-                            playerName: player.name,
-                            playerNumber: player.number,
-                            stats: stats
-                        });
-                    }
+                // 2. Write aggregated stats for every rostered player, including zero-stat appearances
+                players.forEach((player) => {
+                    const playerStats = gameState.playerStats[player.id] || {};
+                    const normalizedStats = {};
+
+                    currentConfig.columns.forEach((col) => {
+                        const key = String(col || '').toLowerCase();
+                        normalizedStats[key] = Number(playerStats[key]) || 0;
+                    });
+
+                    Object.entries(playerStats).forEach(([statKey, value]) => {
+                        if (normalizedStats[statKey] === undefined) {
+                            normalizedStats[statKey] = Number(value) || 0;
+                        }
+                    });
+
+                    const statsRef = doc(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`, player.id);
+                    batch.set(statsRef, {
+                        playerName: player.name,
+                        playerNumber: player.number,
+                        stats: normalizedStats
+                    });
                 });
 
                 // 3. Update game document with final data

--- a/track.html
+++ b/track.html
@@ -1249,15 +1249,23 @@ Write the match report now:`;
                 // 2. Write aggregated stats for every rostered player, including zero-stat appearances
                 players.forEach((player) => {
                     const playerStats = gameState.playerStats[player.id] || {};
+                    const playerStatsByLowerKey = {};
                     const normalizedStats = {};
+
+                    Object.entries(playerStats).forEach(([statKey, value]) => {
+                        playerStatsByLowerKey[String(statKey).toLowerCase()] = Number(value) || 0;
+                    });
 
                     currentConfig.columns.forEach((col) => {
                         const key = String(col || '').toLowerCase();
-                        normalizedStats[key] = Number(playerStats[key]) || 0;
+                        normalizedStats[key] = Object.prototype.hasOwnProperty.call(playerStatsByLowerKey, key)
+                            ? playerStatsByLowerKey[key]
+                            : 0;
                     });
 
                     Object.entries(playerStats).forEach(([statKey, value]) => {
-                        if (normalizedStats[statKey] === undefined) {
+                        const normalizedKey = String(statKey).toLowerCase();
+                        if (normalizedStats[statKey] === undefined && normalizedStats[normalizedKey] === undefined) {
                             normalizedStats[statKey] = Number(value) || 0;
                         }
                     });


### PR DESCRIPTION
Closes #540

## What changed
- updated `track.html` to write an `aggregatedStats` document for every rostered player when a game is finished, even if that player logged no stats
- normalized configured stat columns to zero for statless players while preserving any existing non-config stat keys already present in memory
- added a focused regression script covering zero-stat roster saves and write shape expectations

## Why
Player profiles only count completed games when a per-player `aggregatedStats` document exists. By always persisting a zeroed stats record for rostered players, scoreless or statless appearances now remain visible in season history, games played, and downstream profile summaries.