### PR TITLE
Fix single-sub-time game plan summaries

### DIFF
--- a/docs/pr-notes/runs/558-ci-fix-20260418T155548Z/architecture.md
+++ b/docs/pr-notes/runs/558-ci-fix-20260418T155548Z/architecture.md
@@ -1,0 +1,13 @@
+# Acceptance Criteria
+- The parent dashboard calendar day modal test remains valid regardless of the current date.
+- The shared-game modal still renders merged child RSVP controls and refreshed summary state for the selected game day.
+- No production behavior changes.
+
+# Architecture Decisions
+- Treat this as a brittle unit-test fixture issue, not an application regression.
+- Freeze test time before the hard-coded event date so the dashboard's existing upcoming-event cutoff logic continues to include the fixture.
+- Keep the fix scoped to the failing test file only.
+
+# Risks And Rollback
+- Risk is low because the change only affects test runtime clock state within one test.
+- Rollback is a single-file revert of the timer setup if a better fixture strategy is chosen later.

--- a/docs/pr-notes/runs/558-ci-fix-20260418T155548Z/code-plan.md
+++ b/docs/pr-notes/runs/558-ci-fix-20260418T155548Z/code-plan.md
@@ -1,0 +1,4 @@
+# Implementation Plan
+- Update `tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js` to import `vi` from Vitest.
+- Freeze system time to a point before the fixture event date, run the existing assertions unchanged, then restore real timers in `finally`.
+- Avoid touching production files because the root cause is a date-sensitive test fixture.

--- a/docs/pr-notes/runs/558-ci-fix-20260418T155548Z/qa.md
+++ b/docs/pr-notes/runs/558-ci-fix-20260418T155548Z/qa.md
@@ -1,0 +1,4 @@
+# QA Plan
+- Re-run `npm test -- --run tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js` to confirm the specific failure is fixed.
+- Verify the test still asserts both merged child ids, RSVP submission payload, refreshed modal styling, and updated summary text.
+- No broader regression sweep is required because the patch only stabilizes test time handling.

--- a/game-plan.html
+++ b/game-plan.html
@@ -864,7 +864,7 @@
             // Count intervals each player is in
             const intervalsPerPeriod = Math.max(1, gamePlan.subTimes.length || 0);
             const minutesPerInterval = gamePlan.periodDuration / intervalsPerPeriod;
-            const intervalTimes = intervalsPerPeriod === 1 ? ['full'] : gamePlan.subTimes;
+            const intervalTimes = gamePlan.subTimes.length > 0 ? gamePlan.subTimes : ['full'];
 
             for (let period = 1; period <= gamePlan.numPeriods; period++) {
                 intervalTimes.forEach(time => {

--- a/tests/unit/game-plan-playing-time-summary.test.js
+++ b/tests/unit/game-plan-playing-time-summary.test.js
@@ -1,0 +1,164 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readGamePlanPage() {
+    return readFileSync(new URL('../../game-plan.html', import.meta.url), 'utf8');
+}
+
+function extractCreateDefaultGamePlanSource() {
+    const source = readGamePlanPage();
+    const match = source.match(/function createDefaultGamePlan\(sportName = null\) \{[\s\S]*?\n        \}/);
+    expect(match, 'createDefaultGamePlan should exist').toBeTruthy();
+    return match[0];
+}
+
+function extractRenderSubMatrixBody() {
+    const source = readGamePlanPage();
+    const match = source.match(/function renderSubMatrix\(\) \{([\s\S]*?)\n        \}\n\n        function getBenchPlayersForInterval/);
+    expect(match, 'renderSubMatrix should exist').toBeTruthy();
+    return match[1];
+}
+
+function extractRenderPlayingTimeSummaryBody() {
+    const source = readGamePlanPage();
+    const match = source.match(/function renderPlayingTimeSummary\(\) \{([\s\S]*?)\n        \}\n\n        window\.removePlayerFromCell/);
+    expect(match, 'renderPlayingTimeSummary should exist').toBeTruthy();
+    return match[1];
+}
+
+function createElement() {
+    return {
+        innerHTML: '',
+        querySelectorAll() {
+            return [];
+        }
+    };
+}
+
+function createDocument() {
+    const elements = new Map();
+    return {
+        getElementById(id) {
+            if (!elements.has(id)) {
+                elements.set(id, createElement());
+            }
+            return elements.get(id);
+        },
+        querySelectorAll() {
+            return [];
+        }
+    };
+}
+
+function escapeRegExp(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function extractMinutesForPlayer(summaryHtml, playerName) {
+    const pattern = new RegExp(`${escapeRegExp(playerName)}[\\s\\S]*?<div class="text-2xl[^>]*">(\\d+)<\\/div>`);
+    const match = summaryHtml.match(pattern);
+    expect(match, `minutes should render for ${playerName}`).toBeTruthy();
+    return Number(match[1]);
+}
+
+function buildHarness(overrides = {}) {
+    const createDefaultGamePlanSource = extractCreateDefaultGamePlanSource();
+    const renderSubMatrixBody = extractRenderSubMatrixBody();
+    const renderPlayingTimeSummaryBody = extractRenderPlayingTimeSummaryBody();
+    const document = createDocument();
+
+    ['sub-matrix-header', 'sub-matrix-body', 'playing-time-summary'].forEach((id) => {
+        document.getElementById(id);
+    });
+
+    const deps = {
+        players: [
+            { id: 'p1', name: 'Jordan', number: 23 },
+            { id: 'p2', name: 'Casey', number: 7 }
+        ],
+        FORMATIONS: {
+            'basketball-5v5': { name: 'Basketball 5v5', positions: [{ id: 'pg', name: 'Point Guard' }] },
+            'soccer-9v9': { name: 'Soccer 9v9', positions: [{ id: 'keeper', name: 'Keeper' }] }
+        },
+        document,
+        gamePlan: null,
+        ...overrides
+    };
+
+    const createHarness = new Function('deps', `
+        let players = deps.players;
+        let gamePlan = deps.gamePlan;
+        const FORMATIONS = deps.FORMATIONS;
+        const document = deps.document;
+        let intervalsCache = [];
+        const recentAssignments = new Map();
+        let draggedPlayerId = null;
+        let lastSelectedPlayerId = null;
+        let dragSourceCellKey = null;
+        const renderPlayerPool = () => {};
+        const pushColumnForward = () => {};
+        const fillRowWithLastSelected = () => {};
+        const getBenchPlayersForInterval = () => [];
+        const playerAssignedInInterval = () => false;
+
+        ${createDefaultGamePlanSource}
+
+        function renderSubMatrix() {
+${renderSubMatrixBody}
+        }
+
+        function renderPlayingTimeSummary() {
+${renderPlayingTimeSummaryBody}
+        }
+
+        return {
+            createDefaultGamePlan,
+            renderSubMatrix,
+            renderPlayingTimeSummary,
+            setGamePlan: (nextGamePlan) => {
+                gamePlan = nextGamePlan;
+            },
+            getDocument: () => document
+        };
+    `);
+
+    return createHarness(deps);
+}
+
+describe('game plan single-sub-time playing time summary', () => {
+    it('counts basketball default summary minutes from saved quarter-time lineup keys', () => {
+        const harness = buildHarness();
+        const gamePlan = harness.createDefaultGamePlan('Basketball');
+
+        gamePlan.lineups['1-4-pg'] = 'p1';
+        harness.setGamePlan(gamePlan);
+        harness.renderPlayingTimeSummary();
+
+        const summaryHtml = harness.getDocument().getElementById('playing-time-summary').innerHTML;
+        expect(extractMinutesForPlayer(summaryHtml, 'Jordan')).toBe(8);
+        expect(extractMinutesForPlayer(summaryHtml, 'Casey')).toBe(0);
+    });
+
+    it('keeps sub-matrix and summary interval keys aligned for non-basketball single-sub-time plans', () => {
+        const harness = buildHarness({
+            gamePlan: {
+                numPeriods: 2,
+                periodDuration: 24,
+                subTimes: [12],
+                formationId: 'soccer-9v9',
+                lineups: {
+                    '2-12-keeper': 'p1'
+                }
+            }
+        });
+
+        harness.renderSubMatrix();
+        harness.renderPlayingTimeSummary();
+
+        const matrixHtml = harness.getDocument().getElementById('sub-matrix-body').innerHTML;
+        const summaryHtml = harness.getDocument().getElementById('playing-time-summary').innerHTML;
+
+        expect(matrixHtml).toContain('data-cell-key="2-12-keeper"');
+        expect(extractMinutesForPlayer(summaryHtml, 'Jordan')).toBe(24);
+    });
+});

--- a/tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js
+++ b/tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 import * as parentDashboardRsvp from '../../js/parent-dashboard-rsvp.js';
 import * as parentDashboardRsvpControls from '../../js/parent-dashboard-rsvp-controls.js';
@@ -329,78 +329,85 @@ async function bootParentDashboard() {
 
 describe('parent dashboard calendar day modal RSVP flow', () => {
     it('submits both child ids from the shared-game modal and refreshes the open modal state', async () => {
-        const { elements, hooks, submitRecorder } = await bootParentDashboard();
-        const eventDate = new Date('2026-04-15T18:00:00.000Z');
-        const initialSummary = { going: 0, maybe: 0, notGoing: 0, notResponded: 2, total: 2 };
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date('2026-04-14T12:00:00Z'));
 
-        hooks.setCurrentUser({
-            uid: 'parent-1',
-            displayName: 'Parent One',
-            email: 'parent@example.com'
-        });
-        hooks.setAllScheduleEvents([
-            {
-                teamId: 'team-1',
-                id: 'game-1',
-                type: 'game',
-                isDbGame: true,
-                date: eventDate,
-                opponent: 'Lions',
-                location: 'North Field',
-                childId: 'child-a',
-                childName: 'Avery',
-                myRsvp: null,
-                rsvpSummary: initialSummary
-            },
-            {
-                teamId: 'team-1',
-                id: 'game-1',
-                type: 'game',
-                isDbGame: true,
-                date: eventDate,
-                opponent: 'Lions',
-                location: 'North Field',
-                childId: 'child-b',
-                childName: 'Blake',
-                myRsvp: null,
-                rsvpSummary: initialSummary
-            }
-        ]);
-        hooks.setScheduleCalendar(eventDate.getFullYear(), eventDate.getMonth());
-        hooks.setScheduleViewMode('calendar');
-        hooks.renderScheduleFromControls();
-        hooks.openScheduleDayModal(eventDate.getFullYear(), eventDate.getMonth(), eventDate.getDate());
+        try {
+            const { elements, hooks, submitRecorder } = await bootParentDashboard();
+            const eventDate = new Date('2026-04-15T18:00:00.000Z');
+            const initialSummary = { going: 0, maybe: 0, notGoing: 0, notResponded: 2, total: 2 };
 
-        const beforeHtml = elements.get('schedule-day-modal-content').innerHTML;
-        expect(beforeHtml).toContain('data-child-ids="child-a,child-b"');
-        expect(beforeHtml).toContain("bg-white text-green-700 border-green-300 hover:bg-green-50");
-        expect(beforeHtml).toContain(`${initialSummary.going} going · ${initialSummary.maybe} maybe · ${initialSummary.notGoing} can't go · ${initialSummary.notResponded} no response`);
-
-        await hooks.submitGameRsvpFromButton({
-            dataset: {
-                teamId: 'team-1',
-                gameId: 'game-1',
-                childIds: 'child-a,child-b'
-            }
-        }, 'going');
-
-        expect(submitRecorder.calls).toEqual([
-            {
-                teamId: 'team-1',
-                gameId: 'game-1',
-                currentUserId: 'parent-1',
-                payload: {
-                    displayName: 'Parent One',
-                    playerIds: ['child-a', 'child-b'],
-                    response: 'going'
+            hooks.setCurrentUser({
+                uid: 'parent-1',
+                displayName: 'Parent One',
+                email: 'parent@example.com'
+            });
+            hooks.setAllScheduleEvents([
+                {
+                    teamId: 'team-1',
+                    id: 'game-1',
+                    type: 'game',
+                    isDbGame: true,
+                    date: eventDate,
+                    opponent: 'Lions',
+                    location: 'North Field',
+                    childId: 'child-a',
+                    childName: 'Avery',
+                    myRsvp: null,
+                    rsvpSummary: initialSummary
+                },
+                {
+                    teamId: 'team-1',
+                    id: 'game-1',
+                    type: 'game',
+                    isDbGame: true,
+                    date: eventDate,
+                    opponent: 'Lions',
+                    location: 'North Field',
+                    childId: 'child-b',
+                    childName: 'Blake',
+                    myRsvp: null,
+                    rsvpSummary: initialSummary
                 }
-            }
-        ]);
+            ]);
+            hooks.setScheduleCalendar(eventDate.getFullYear(), eventDate.getMonth());
+            hooks.setScheduleViewMode('calendar');
+            hooks.renderScheduleFromControls();
+            hooks.openScheduleDayModal(eventDate.getFullYear(), eventDate.getMonth(), eventDate.getDate());
 
-        const afterHtml = elements.get('schedule-day-modal-content').innerHTML;
-        expect(elements.get('schedule-day-modal').classList.contains('hidden')).toBe(false);
-        expect(afterHtml).toContain("bg-green-600 text-white border-green-600");
-        expect(afterHtml).toContain(`${submitRecorder.updatedSummary.going} going · ${submitRecorder.updatedSummary.maybe} maybe · ${submitRecorder.updatedSummary.notGoing} can't go · ${submitRecorder.updatedSummary.notResponded} no response`);
-        expect(afterHtml).toContain('For Avery, Blake');
+            const beforeHtml = elements.get('schedule-day-modal-content').innerHTML;
+            expect(beforeHtml).toContain('data-child-ids="child-a,child-b"');
+            expect(beforeHtml).toContain("bg-white text-green-700 border-green-300 hover:bg-green-50");
+            expect(beforeHtml).toContain(`${initialSummary.going} going · ${initialSummary.maybe} maybe · ${initialSummary.notGoing} can't go · ${initialSummary.notResponded} no response`);
+
+            await hooks.submitGameRsvpFromButton({
+                dataset: {
+                    teamId: 'team-1',
+                    gameId: 'game-1',
+                    childIds: 'child-a,child-b'
+                }
+            }, 'going');
+
+            expect(submitRecorder.calls).toEqual([
+                {
+                    teamId: 'team-1',
+                    gameId: 'game-1',
+                    currentUserId: 'parent-1',
+                    payload: {
+                        displayName: 'Parent One',
+                        playerIds: ['child-a', 'child-b'],
+                        response: 'going'
+                    }
+                }
+            ]);
+
+            const afterHtml = elements.get('schedule-day-modal-content').innerHTML;
+            expect(elements.get('schedule-day-modal').classList.contains('hidden')).toBe(false);
+            expect(afterHtml).toContain("bg-green-600 text-white border-green-600");
+            expect(afterHtml).toContain(`${submitRecorder.updatedSummary.going} going · ${submitRecorder.updatedSummary.maybe} maybe · ${submitRecorder.updatedSummary.notGoing} can't go · ${submitRecorder.updatedSummary.notResponded} no response`);
+            expect(afterHtml).toContain('For Avery, Blake');
+        } finally {
+            vi.useRealTimers();
+        }
     });
 });


### PR DESCRIPTION
Closes #550

## What changed
- fixed `renderPlayingTimeSummary()` so single-sub-time plans read the real saved `period-time-position` lineup keys instead of switching to a synthetic `full` interval
- added focused regression coverage for the default basketball 5v5 plan (`subTimes: [4]`) to verify `1-4-pg` renders as 8 minutes
- added a single-sub-time non-basketball regression to verify `renderSubMatrix()` and `renderPlayingTimeSummary()` stay aligned on keys like `2-12-keeper`

## Why
Single-sub-time plans, including the default basketball workflow, could show 0 or undercounted minutes in Playing Time Summary even when lineup assignments were present. These tests lock the summary math to the actual saved lineup key format used by the Game Plan page.