### PR TITLE
Add read-only tournament standings preview

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -811,7 +811,7 @@
         import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
         import { buildPoolStandingsIndex, collectTournamentAdvancementPatches, collectTournamentPoolSeeds, describeTournamentSource, planTournamentPoolAdvancement } from './js/tournament-brackets.js?v=1';
         import { normalizeScheduleNotificationSettings, buildScheduleNotificationMetadata, buildScheduleChangeMessage, buildScheduleNotificationTargets, postScheduleNotificationTargets, buildRsvpReminderMessage } from './js/schedule-notifications.js?v=3';
-        import { buildTournamentPoolStandings, buildTournamentPoolOverrideKey } from './js/tournament-standings.js?v=1';
+        import { buildTournamentPoolStandings, buildTournamentPoolOverrideKey } from './js/tournament-standings.js?v=2';
         import { SCHEDULE_CSV_IMPORT_FIELDS, buildScheduleImportPreview, inferScheduleCsvMapping, normalizeScheduleImportDraft, parseCsvText } from './js/schedule-csv-import.js?v=2';
 
         renderFooter(document.getElementById('footer-container'));

--- a/js/tournament-standings.js
+++ b/js/tournament-standings.js
@@ -35,6 +35,66 @@ function getSlotTeamName(slot = {}) {
     return normalizeString(slot?.teamName);
 }
 
+function isTournamentGame(game = {}) {
+    return String(game?.competitionType || '').toLowerCase() === 'tournament';
+}
+
+function hasFiniteScore(value) {
+    if (value === '' || value == null) return false;
+    if (typeof value === 'string' && value.trim() === '') return false;
+    return Number.isFinite(Number(value));
+}
+
+function hasCompletedTournamentScore(game = {}) {
+    return ['completed', 'final'].includes(String(game?.status || '').toLowerCase())
+        && hasFiniteScore(game?.homeScore)
+        && hasFiniteScore(game?.awayScore);
+}
+
+function getTournamentPoolName(game = {}) {
+    return normalizeString(game?.tournament?.poolName);
+}
+
+function getTournamentDivisionName(game = {}) {
+    return normalizeString(game?.tournament?.divisionName)
+        || normalizeString(game?.tournament?.division);
+}
+
+function getTournamentStandingsGroupName(game = {}) {
+    const divisionName = getTournamentDivisionName(game);
+    const poolName = getTournamentPoolName(game);
+    if (divisionName && poolName) return `${divisionName} • ${poolName}`;
+    return poolName || divisionName;
+}
+
+function normalizeTournamentGroupOption(value) {
+    if (typeof value === 'string') return normalizeString(value);
+    if (!value || typeof value !== 'object') return null;
+    const divisionName = normalizeString(value.divisionName) || normalizeString(value.division);
+    const poolName = normalizeString(value.poolName);
+    if (divisionName && poolName) return `${divisionName} • ${poolName}`;
+    return normalizeString(value.name)
+        || normalizeString(value.label)
+        || poolName
+        || divisionName;
+}
+
+function getConfiguredTournamentGroupNames(options = {}) {
+    const sources = [
+        options.groupNames,
+        options.poolNames,
+        options.divisionNames,
+        options.tournamentGroups,
+        options.tournamentPools,
+        options.tournamentDivisions
+    ];
+
+    return sources
+        .flatMap((source) => Array.isArray(source) ? source : [])
+        .map(normalizeTournamentGroupOption)
+        .filter(Boolean);
+}
+
 function getTournamentGameTeams(game = {}, currentTeamName = null) {
     const resolved = game?.tournament?.resolved || {};
     const slotAssignments = game?.tournament?.slotAssignments || {};
@@ -77,11 +137,9 @@ function getTournamentGameTeams(game = {}, currentTeamName = null) {
 }
 
 function isCompletedTournamentPoolGame(game = {}) {
-    return String(game?.competitionType || '').toLowerCase() === 'tournament'
-        && normalizeString(game?.tournament?.poolName)
-        && ['completed', 'final'].includes(String(game?.status || '').toLowerCase())
-        && Number.isFinite(Number(game?.homeScore))
-        && Number.isFinite(Number(game?.awayScore));
+    return isTournamentGame(game)
+        && getTournamentPoolName(game)
+        && hasCompletedTournamentScore(game);
 }
 
 export function applyTournamentStandingsOverride(rowsInput = [], override = null) {
@@ -187,10 +245,35 @@ export function computeTournamentPoolStandings(gamesInput, options = {}) {
     const currentTeamName = normalizeString(options?.teamName || options?.currentTeamName);
     if (!currentTeamName) return [];
 
-    const poolGames = new Map();
+    const groupGames = new Map();
+    const ensureGroup = (groupName) => {
+        const normalizedGroupName = normalizeString(groupName);
+        if (!normalizedGroupName) return null;
+        if (!groupGames.has(normalizedGroupName)) {
+            groupGames.set(normalizedGroupName, {
+                games: [],
+                scheduledGameCount: 0,
+                noScoreGameCount: 0
+            });
+        }
+        return groupGames.get(normalizedGroupName);
+    };
+
+    getConfiguredTournamentGroupNames(options).forEach(ensureGroup);
+
     games.forEach((game) => {
-        if (!isCompletedTournamentPoolGame(game)) return;
-        const poolName = normalizeString(game?.tournament?.poolName);
+        if (!isTournamentGame(game)) return;
+        const poolName = getTournamentStandingsGroupName(game);
+        const group = ensureGroup(poolName);
+        if (!group) return;
+
+        group.scheduledGameCount += 1;
+
+        if (!hasCompletedTournamentScore(game)) {
+            group.noScoreGameCount += 1;
+            return;
+        }
+
         const { homeTeam, awayTeam, homeScore, awayScore } = getTournamentGameTeams(game, currentTeamName);
         if (!poolName || !homeTeam || !awayTeam) return;
         if (homeTeam === awayTeam) return;
@@ -202,23 +285,25 @@ export function computeTournamentPoolStandings(gamesInput, options = {}) {
             awayScore: Number(awayScore ?? game.awayScore),
             status: 'completed'
         };
-        const existing = poolGames.get(poolName) || [];
-        existing.push(normalizedGame);
-        poolGames.set(poolName, existing);
+        group.games.push(normalizedGame);
     });
 
-    return Array.from(poolGames.entries())
+    return Array.from(groupGames.entries())
         .sort((a, b) => a[0].localeCompare(b[0]))
-        .map(([poolName, poolGameList]) => {
+        .map(([poolName, pool]) => {
+            const poolGameList = pool.games;
             const rows = computeNativeStandingsDetailed(poolGameList, options?.standingsConfig || {}).map((row) => ({
                 ...row,
                 teamName: row.team
             }));
             return {
                 poolName,
+                groupName: poolName,
+                gameCount: poolGameList.length,
+                scheduledGameCount: pool.scheduledGameCount,
+                noScoreGameCount: pool.noScoreGameCount,
                 rows,
                 unresolvedTie: rows.some((row) => row.unresolvedTie)
             };
-        })
-        .filter((pool) => pool.rows.length > 0);
+        });
 }

--- a/team.html
+++ b/team.html
@@ -245,7 +245,7 @@
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, escapeHtml, shareOrCopy } from './js/utils.js?v=10';
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';
         import { computeNativeStandings } from './js/native-standings.js?v=1';
-        import { computeTournamentPoolStandings } from './js/tournament-standings.js?v=1';
+        import { computeTournamentPoolStandings } from './js/tournament-standings.js?v=2';
         import { buildPlayerLeaderboardSnapshot, selectAnalyticsConfig } from './js/stat-leaderboards.js?v=1';
         import { calculateSeasonRecord, listSeasonLabels } from './js/season-record.js';
         import { checkAuth } from './js/auth.js?v=12';
@@ -400,57 +400,75 @@
 
             const metricLabel = team?.standingsConfig?.rankingMode === 'win_pct' ? 'PCT' : 'PTS';
             const currentTeamName = String(team?.name || '').trim();
-            content.innerHTML = pools.map((pool) => `
-                <div class="bg-white rounded-2xl shadow-md border border-gray-200 overflow-hidden">
-                    <div class="px-6 py-4 border-b border-gray-100 bg-gray-50 flex items-center justify-between gap-3 flex-wrap">
-                        <div>
-                            <h3 class="text-lg font-bold text-gray-900">${escapeHtml(pool.poolName)}</h3>
-                            <p class="text-sm text-gray-500">${pool.rows.length} team${pool.rows.length === 1 ? '' : 's'} in standings</p>
+            content.innerHTML = pools.map((pool) => {
+                const rows = Array.isArray(pool.rows) ? pool.rows : [];
+                const scheduledGameCount = Number(pool.scheduledGameCount) || 0;
+                const completedGameCount = Number(pool.gameCount) || 0;
+                const summaryText = rows.length > 0
+                    ? `${rows.length} team${rows.length === 1 ? '' : 's'} in standings`
+                    : (scheduledGameCount > 0
+                        ? `${scheduledGameCount} tournament game${scheduledGameCount === 1 ? '' : 's'}, no completed scored results yet`
+                        : 'No games scheduled yet');
+                const emptyMessage = scheduledGameCount > 0
+                    ? 'No completed tournament games with scores yet. Final scores will populate this standings table.'
+                    : 'No games are scheduled in this division or pool yet.';
+
+                return `
+                    <div class="bg-white rounded-2xl shadow-md border border-gray-200 overflow-hidden">
+                        <div class="px-6 py-4 border-b border-gray-100 bg-gray-50 flex items-center justify-between gap-3 flex-wrap">
+                            <div>
+                                <h3 class="text-lg font-bold text-gray-900">${escapeHtml(pool.poolName)}</h3>
+                                <p class="text-sm text-gray-500">${escapeHtml(summaryText)}</p>
+                                ${completedGameCount > 0 && rows.length === 0 ? '<p class="text-xs text-amber-700 mt-1">Completed games need valid teams before standings can be calculated.</p>' : ''}
+                            </div>
+                            ${pool.unresolvedTie ? '<span class="inline-flex items-center rounded-full bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-800 border border-amber-200">Tie unresolved after configured tiebreakers</span>' : ''}
                         </div>
-                        ${pool.unresolvedTie ? '<span class="inline-flex items-center rounded-full bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-800 border border-amber-200">Tie unresolved after configured tiebreakers</span>' : ''}
-                    </div>
-                    <div class="overflow-x-auto">
-                        <table class="min-w-full divide-y divide-gray-200">
-                            <thead class="bg-white">
-                                <tr class="text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
-                                    <th class="px-4 py-3">Place</th>
-                                    <th class="px-4 py-3">Team</th>
-                                    <th class="px-4 py-3">GP</th>
-                                    <th class="px-4 py-3">W</th>
-                                    <th class="px-4 py-3">L</th>
-                                    <th class="px-4 py-3">T</th>
-                                    <th class="px-4 py-3">${metricLabel}</th>
-                                    <th class="px-4 py-3">PF</th>
-                                    <th class="px-4 py-3">PA</th>
-                                    <th class="px-4 py-3">PD</th>
-                                </tr>
-                            </thead>
-                            <tbody class="divide-y divide-gray-100">
-                                ${pool.rows.map((row) => {
-                                    const isCurrentTeam = row.teamName === currentTeamName;
-                                    return `
-                                        <tr class="${isCurrentTeam ? 'bg-primary-50/70' : 'bg-white'}">
-                                            <td class="px-4 py-3 text-sm font-semibold text-gray-900">
-                                                ${escapeHtml(row.displayRank)}
-                                                ${row.unresolvedTie ? '<span class="ml-1 text-xs font-medium text-amber-700">(unresolved)</span>' : ''}
-                                            </td>
-                                            <td class="px-4 py-3 text-sm ${isCurrentTeam ? 'font-bold text-primary-800' : 'font-medium text-gray-900'}">${escapeHtml(row.teamName)}</td>
-                                            <td class="px-4 py-3 text-sm text-gray-700">${Number(row.gp) || 0}</td>
-                                            <td class="px-4 py-3 text-sm text-gray-700">${Number(row.w) || 0}</td>
-                                            <td class="px-4 py-3 text-sm text-gray-700">${Number(row.l) || 0}</td>
-                                            <td class="px-4 py-3 text-sm text-gray-700">${Number(row.t) || 0}</td>
-                                            <td class="px-4 py-3 text-sm text-gray-700">${metricLabel === 'PCT' ? (Number(row.winPct) || 0).toFixed(3) : Number(row.points) || 0}</td>
-                                            <td class="px-4 py-3 text-sm text-gray-700">${Number(row.pf) || 0}</td>
-                                            <td class="px-4 py-3 text-sm text-gray-700">${Number(row.pa) || 0}</td>
-                                            <td class="px-4 py-3 text-sm text-gray-700">${Number(row.pd) || 0}</td>
+                        ${rows.length === 0
+                            ? `<div class="px-6 py-8 text-sm text-gray-500 bg-white">${emptyMessage}</div>`
+                            : `<div class="overflow-x-auto">
+                                <table class="min-w-full divide-y divide-gray-200">
+                                    <thead class="bg-white">
+                                        <tr class="text-left text-xs font-semibold uppercase tracking-wide text-gray-500">
+                                            <th class="px-4 py-3">Place</th>
+                                            <th class="px-4 py-3">Team</th>
+                                            <th class="px-4 py-3">GP</th>
+                                            <th class="px-4 py-3">W</th>
+                                            <th class="px-4 py-3">L</th>
+                                            <th class="px-4 py-3">T</th>
+                                            <th class="px-4 py-3">${metricLabel}</th>
+                                            <th class="px-4 py-3">PF</th>
+                                            <th class="px-4 py-3">PA</th>
+                                            <th class="px-4 py-3">PD</th>
                                         </tr>
-                                    `;
-                                }).join('')}
-                            </tbody>
-                        </table>
+                                    </thead>
+                                    <tbody class="divide-y divide-gray-100">
+                                        ${rows.map((row) => {
+                                            const isCurrentTeam = row.teamName === currentTeamName;
+                                            return `
+                                                <tr class="${isCurrentTeam ? 'bg-primary-50/70' : 'bg-white'}">
+                                                    <td class="px-4 py-3 text-sm font-semibold text-gray-900">
+                                                        ${escapeHtml(row.displayRank)}
+                                                        ${row.unresolvedTie ? '<span class="ml-1 text-xs font-medium text-amber-700">(unresolved)</span>' : ''}
+                                                    </td>
+                                                    <td class="px-4 py-3 text-sm ${isCurrentTeam ? 'font-bold text-primary-800' : 'font-medium text-gray-900'}">${escapeHtml(row.teamName)}</td>
+                                                    <td class="px-4 py-3 text-sm text-gray-700">${Number(row.gp) || 0}</td>
+                                                    <td class="px-4 py-3 text-sm text-gray-700">${Number(row.w) || 0}</td>
+                                                    <td class="px-4 py-3 text-sm text-gray-700">${Number(row.l) || 0}</td>
+                                                    <td class="px-4 py-3 text-sm text-gray-700">${Number(row.t) || 0}</td>
+                                                    <td class="px-4 py-3 text-sm text-gray-700">${metricLabel === 'PCT' ? (Number(row.winPct) || 0).toFixed(3) : Number(row.points) || 0}</td>
+                                                    <td class="px-4 py-3 text-sm text-gray-700">${Number(row.pf) || 0}</td>
+                                                    <td class="px-4 py-3 text-sm text-gray-700">${Number(row.pa) || 0}</td>
+                                                    <td class="px-4 py-3 text-sm text-gray-700">${Number(row.pd) || 0}</td>
+                                                </tr>
+                                            `;
+                                        }).join('')}
+                                    </tbody>
+                                </table>
+                            </div>`
+                        }
                     </div>
-                </div>
-            `).join('');
+                `;
+            }).join('');
 
             section.classList.remove('hidden');
         }
@@ -931,7 +949,9 @@
                 const nativeStandingsSnapshot = buildNativeStandingsSnapshot(team, dbGames);
                 const tournamentStandings = computeTournamentPoolStandings(dbGames, {
                     teamName: team?.name,
-                    standingsConfig: team?.standingsConfig || {}
+                    standingsConfig: team?.standingsConfig || {},
+                    tournamentDivisions: team?.tournamentDivisions || team?.tournament?.divisions,
+                    tournamentPools: team?.tournamentPools || team?.tournament?.pools
                 });
                 const leagueSnapshot = (nativeStandingsSnapshot && nativeStandingsSnapshot.ok)
                     ? null

--- a/tests/unit/team-tournament-standings.test.js
+++ b/tests/unit/team-tournament-standings.test.js
@@ -8,9 +8,10 @@ describe('team tournament standings wiring', () => {
   it('imports the tournament standings helper and renders the public standings section', () => {
     const source = fs.readFileSync(TEAM_HTML_PATH, 'utf8');
 
-    expect(source).toContain("import { computeTournamentPoolStandings } from './js/tournament-standings.js?v=1';");
+    expect(source).toContain("import { computeTournamentPoolStandings } from './js/tournament-standings.js?v=2';");
     expect(source).toContain('id="tournament-standings-section"');
     expect(source).toContain('Results &amp; Standings');
+    expect(source).toContain('No completed tournament games with scores yet.');
     expect(source).toContain('renderTournamentStandingsSection(tournamentStandings, team);');
   });
 });

--- a/tests/unit/tournament-standings.test.js
+++ b/tests/unit/tournament-standings.test.js
@@ -273,6 +273,115 @@ describe('tournament standings helpers', () => {
     });
   });
 
+  it('computes division-scoped standings when tournament games use division names', () => {
+    const pools = computeTournamentPoolStandings([
+      {
+        competitionType: 'tournament',
+        status: 'completed',
+        opponent: 'Lions',
+        isHome: true,
+        homeScore: 7,
+        awayScore: 3,
+        tournament: { divisionName: '10U Gold' }
+      },
+      {
+        competitionType: 'tournament',
+        status: 'completed',
+        opponent: 'Bears',
+        isHome: true,
+        homeScore: 2,
+        awayScore: 2,
+        tournament: { divisionName: '10U Gold' }
+      },
+      {
+        competitionType: 'tournament',
+        status: 'completed',
+        opponent: 'Hawks',
+        isHome: false,
+        homeScore: 5,
+        awayScore: 1,
+        tournament: { divisionName: '12U Silver' }
+      }
+    ], {
+      teamName: 'Tigers',
+      standingsConfig: {
+        rankingMode: 'points',
+        points: { win: 3, tie: 1, loss: 0 }
+      }
+    });
+
+    expect(pools.map((pool) => pool.poolName)).toEqual(['10U Gold', '12U Silver']);
+    expect(pools[0].rows.map((row) => row.teamName)).toEqual(['Tigers', 'Bears', 'Lions']);
+    expect(pools[0].rows[0]).toMatchObject({
+      teamName: 'Tigers',
+      w: 1,
+      l: 0,
+      t: 1,
+      points: 4,
+      pf: 9,
+      pa: 5,
+      displayRank: '1'
+    });
+    expect(pools[1].rows[0]).toMatchObject({
+      teamName: 'Tigers',
+      points: 3,
+      displayRank: '1'
+    });
+  });
+
+  it('keeps empty and unscored tournament groups visible with empty rows', () => {
+    const pools = computeTournamentPoolStandings([
+      {
+        competitionType: 'tournament',
+        status: 'scheduled',
+        opponent: 'Lions',
+        isHome: true,
+        tournament: { poolName: 'Pool A' }
+      },
+      {
+        competitionType: 'tournament',
+        status: 'completed',
+        opponent: 'Bears',
+        isHome: true,
+        homeScore: '',
+        awayScore: '',
+        tournament: { poolName: 'Pool A' }
+      },
+      {
+        competitionType: 'tournament',
+        status: 'completed',
+        opponent: 'Hawks',
+        isHome: true,
+        homeScore: null,
+        awayScore: 1,
+        tournament: { divisionName: '10U Gold' }
+      }
+    ], {
+      teamName: 'Tigers',
+      divisionNames: ['8U Bronze']
+    });
+
+    expect(pools.map((pool) => pool.poolName)).toEqual(['10U Gold', '8U Bronze', 'Pool A']);
+    expect(pools.find((pool) => pool.poolName === 'Pool A')).toMatchObject({
+      gameCount: 0,
+      scheduledGameCount: 2,
+      noScoreGameCount: 2,
+      rows: []
+    });
+    expect(pools.find((pool) => pool.poolName === '10U Gold')).toMatchObject({
+      gameCount: 0,
+      scheduledGameCount: 1,
+      noScoreGameCount: 1,
+      rows: []
+    });
+    expect(pools.find((pool) => pool.poolName === '8U Bronze')).toMatchObject({
+      gameCount: 0,
+      scheduledGameCount: 0,
+      noScoreGameCount: 0,
+      rows: []
+    });
+  });
+
   it('swaps team-relative scores for away tournament games before computing team-page standings', () => {
     const pools = computeTournamentPoolStandings([
       {


### PR DESCRIPTION
Closes #602

## What changed
- Added division-or-pool tournament standings grouping for team pages.
- Kept tournament groups visible when games are empty, scheduled, or missing final scores.
- Rendered clear empty states instead of hiding the Results & Standings section.
- Added unit coverage for division-scoped standings and empty/no-score tournament groups.

## Validation
- `npx vitest run tests/unit --reporter=dot`