### PR TITLE
Advance finalized standings into bracket slots

### DIFF
--- a/docs/pr-notes/runs/606-review-4177049407-20260426T145355Z/architecture.md
+++ b/docs/pr-notes/runs/606-review-4177049407-20260426T145355Z/architecture.md
@@ -1,0 +1,21 @@
+# Architecture Role Artifact
+
+## Current State
+`tournament-standings.js` builds division-scoped group names such as `10U Gold • Pool A`. `tournament-brackets.js` previously matched pool-seed slots using only the slot object, so a slot with `{ poolName: 'Pool A', seed: 1 }` did not match the scoped key when `divisionName` was stored on `game.tournament`.
+
+## Proposed State
+Use a context-aware pool label helper in `js/tournament-brackets.js`:
+- slot provides `poolName`, `seed`, and optional slot-level division fields.
+- tournament/game context provides fallback `divisionName` or `division`.
+- resulting labels use the same `Division • Pool` format as standings.
+
+## Architecture Decisions
+- Keep persisted tournament data shape unchanged.
+- Apply contextual label resolution to seed collection, standings index construction, pool-seed team resolution, and preview source labels.
+- Preserve legacy unscoped matching by falling back to the slot-only pool label when no division context exists.
+
+## Blast Radius
+Limited to tournament bracket advancement helpers and their unit coverage. No auth, Firestore rules, deployment config, or schema changes.
+
+## Rollback
+Revert the helper signature/usage changes in `js/tournament-brackets.js` plus the focused unit regression test. No data rollback required.

--- a/docs/pr-notes/runs/606-review-4177049407-20260426T145355Z/code-plan.md
+++ b/docs/pr-notes/runs/606-review-4177049407-20260426T145355Z/code-plan.md
@@ -1,0 +1,18 @@
+# Code Role Artifact
+
+## Implementation Plan
+1. Update `getTournamentPoolLabel` in `js/tournament-brackets.js` to accept tournament context and use tournament-level division as a fallback.
+2. Pass tournament context through pool-seed resolution so advancement can resolve `Division • Pool` standings into slots that only store plain pool names.
+3. Use the same contextual label in seed collection, saved standings index construction, and advancement preview rows.
+4. Add a focused unit regression for division-scoped pool advancement and cross-division isolation.
+
+## Conflict Resolution
+- Requirements wanted missing division to fail safely, while architecture required legacy unscoped pools to keep working. Chosen path: use division context when present, otherwise preserve existing unscoped behavior.
+- Code and QA both flagged that fixing only `collectTournamentPoolSeeds` is incomplete. Chosen path: also patch `getPoolSeedTeamName` and preview label context.
+
+## Risks And Rollback
+- Risk: preview labels may change from `Pool A #1` to `10U Gold • Pool A #1` when division context exists. This is intentional and aligns preview with standings scope.
+- Rollback: revert `js/tournament-brackets.js` and the unit test addition.
+
+## Commit Message
+Fix division-scoped tournament advancement

--- a/docs/pr-notes/runs/606-review-4177049407-20260426T145355Z/qa.md
+++ b/docs/pr-notes/runs/606-review-4177049407-20260426T145355Z/qa.md
@@ -1,0 +1,20 @@
+# QA Role Artifact
+
+## Risk Matrix
+- High: valid division-scoped advancement silently skips because no eligible seeds are found.
+- Medium: same pool name across divisions could cross-populate incorrect bracket slots.
+- Low: legacy unscoped pool advancement could regress.
+
+## Automated Coverage
+- Add regression in `tests/unit/tournament-brackets.test.js` where `divisionName` lives on `game.tournament` and `poolName`/`seed` live on slot assignments.
+- Assert `collectTournamentPoolSeeds(games, '10U Gold • Pool A')` returns only the matching division seeds.
+- Assert `planTournamentPoolAdvancement` resolves the matching bracket game and does not update the other division.
+- Keep existing tests for legacy pool advancement, missing rankings, overwrite previews, and saved-resolution stability.
+
+## Commands
+- `npx vitest run tests/unit/tournament-brackets.test.js`
+- `npx vitest run tests/unit/tournament-brackets.test.js tests/unit/tournament-standings.test.js tests/unit/edit-schedule-tournament.test.js`
+- `npm run test:unit:ci`
+
+## Manual Checks
+- In schedule editor, create two divisions sharing `Pool A`, configure pool-seed bracket slots, finalize one division, advance, confirm preview and saved bracket slots only affect that division.

--- a/docs/pr-notes/runs/606-review-4177049407-20260426T145355Z/requirements.md
+++ b/docs/pr-notes/runs/606-review-4177049407-20260426T145355Z/requirements.md
@@ -1,0 +1,22 @@
+# Requirements Role Artifact
+
+## Objective
+Fix tournament advancement for division-scoped pools where the standings key is `Division • Pool`, but bracket slot assignments store only `poolName` and `seed` while `divisionName` lives on `game.tournament`.
+
+## User Impact
+- Coaches need finalized standings to advance into bracket slots without manual repair on tournament day.
+- Parents need bracket matchups to match visible standings and not cross divisions.
+- Program managers need same-named pools isolated across divisions.
+
+## Acceptance Criteria
+1. Advancing `10U Gold • Pool A` finds bracket slots whose game has `tournament.divisionName = 10U Gold` and whose slot has `poolName = Pool A`.
+2. Required seeds are collected from the matching division and pool only.
+3. `10U Gold • Pool A` does not collect or resolve slots from `12U Silver • Pool A`.
+4. Legacy unscoped pools still match by plain `Pool A`.
+5. Existing preview and overwrite confirmation behavior remains intact.
+6. Missing division, pool, ranking, or seed data fails safely through existing skipped-plan paths.
+
+## Assumptions
+- Division is tournament-level context.
+- Pool and seed are slot-level context.
+- No Firestore data migration is needed.

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -832,6 +832,7 @@
         let currentTournamentPoolStandings = {};
         let activeTournamentStandingsPoolKey = null;
         let tournamentStandingsDraft = [];
+        let tournamentAdvancementGames = [];
 
         const opponentInput = document.getElementById('opponent');
         const opponentResults = document.getElementById('opponent-search-results');
@@ -945,6 +946,13 @@
                 .filter(Boolean);
         }
 
+        function getTournamentStandingPoolName(tournament = {}) {
+            const divisionName = String(tournament?.divisionName || tournament?.division || '').trim();
+            const poolName = String(tournament?.poolName || '').trim();
+            if (divisionName && poolName) return `${divisionName} • ${poolName}`;
+            return poolName || divisionName;
+        }
+
         function buildTournamentRankingPromptDefault(poolName, games = []) {
             const currentPoolStandings = buildPoolStandingsIndex(games);
             const poolRows = Array.isArray(currentPoolStandings?.[poolName]) ? currentPoolStandings[poolName] : [];
@@ -958,7 +966,7 @@
 
         async function handleAdvanceTournamentPool(gameId) {
             const game = gamesCache[gameId] || allTeamGamesCache[gameId];
-            const poolName = (game?.tournament?.poolName || '').trim();
+            const poolName = getTournamentStandingPoolName(game?.tournament || {});
             if (!poolName) {
                 alert('This tournament game is missing a pool name, so advancement was skipped.');
                 return;
@@ -985,6 +993,8 @@
                 alert(`No bracket updates were needed for ${poolName}.`);
                 return;
             }
+
+            if (!confirm(formatTournamentAdvancementPreviewMessage({ poolName }, plan))) return;
 
             await applyTournamentAdvancementPatches(currentTeamId, plan.patches, games);
             await loadSchedule();
@@ -1074,6 +1084,56 @@
             const finalizedAt = toDateValue(override?.finalizedAt);
             if (!finalizedAt) return `Finalized by ${finalizedBy}`;
             return `Finalized by ${finalizedBy} on ${formatDate(finalizedAt)} at ${formatTime(finalizedAt)}`;
+        }
+
+        function getFinalizedTournamentRanking(pool = {}) {
+            if (!pool?.override) return [];
+            return (pool.rows || [])
+                .map((row) => String(row?.teamName || row?.team || '').trim())
+                .filter(Boolean);
+        }
+
+        function buildFinalizedTournamentAdvancementPlan(pool = {}) {
+            if (!pool?.override) {
+                return {
+                    skipped: true,
+                    reason: `Save a final ranking for ${pool?.poolName || 'this pool'} before advancing bracket slots.`,
+                    patches: [],
+                    previewRows: [],
+                    requiresOverwriteConfirmation: false
+                };
+            }
+
+            return planTournamentPoolAdvancement(tournamentAdvancementGames, {
+                poolName: pool.poolName,
+                ranking: getFinalizedTournamentRanking(pool)
+            });
+        }
+
+        function formatTournamentAdvancementStatus(plan = {}) {
+            if (plan.skipped) return plan.reason || 'Bracket advancement is not ready.';
+            if (!plan.patches?.length) return 'Bracket slots already match this final ranking.';
+            const slotCount = plan.previewRows?.length || plan.patches.length;
+            const overwriteText = plan.requiresOverwriteConfirmation ? ' Existing assignments will require confirmation.' : '';
+            return `${slotCount} bracket slot update${slotCount === 1 ? '' : 's'} ready for preview.${overwriteText}`;
+        }
+
+        function formatTournamentAdvancementPreviewMessage(pool = {}, plan = {}) {
+            const previewRows = Array.isArray(plan.previewRows) ? plan.previewRows : [];
+            const previewLines = previewRows.slice(0, 20).map((row) => {
+                const overwriteText = row.overwritesExistingTeam ? ' (overwrites existing team)' : '';
+                return `• ${row.gameId} ${row.slotLabel}: ${row.currentLabel || 'TBD'} => ${row.nextLabel || 'TBD'}${overwriteText}`;
+            });
+            const overflowText = previewRows.length > previewLines.length
+                ? `\n• ${previewRows.length - previewLines.length} more slot update${previewRows.length - previewLines.length === 1 ? '' : 's'}`
+                : '';
+            const fallbackLines = !previewLines.length
+                ? (plan.patches || []).map((patch) => `• ${patch.gameId}`)
+                : [];
+            const warning = plan.requiresOverwriteConfirmation
+                ? 'Existing bracket assignments will be overwritten.\n\n'
+                : '';
+            return `${warning}Preview bracket advancement for ${pool.poolName || plan.poolName}:\n\n${[...previewLines, ...fallbackLines].join('\n')}${overflowText}\n\nSave ${plan.patches?.length || 0} tournament game update${(plan.patches?.length || 0) === 1 ? '' : 's'}?`;
         }
 
         function closeTournamentStandingsModal() {
@@ -1199,6 +1259,27 @@
             await loadSchedule();
         }
 
+        async function handleAdvanceFinalizedTournamentPool(poolKey) {
+            const pool = getTournamentPoolStandingByKey(poolKey);
+            if (!pool) return;
+
+            const plan = buildFinalizedTournamentAdvancementPlan(pool);
+            if (plan.skipped) {
+                alert(plan.reason || `Skipped bracket advancement for ${pool.poolName}.`);
+                return;
+            }
+            if (!plan.patches.length) {
+                alert(`No bracket updates were needed for ${pool.poolName}.`);
+                return;
+            }
+
+            if (!confirm(formatTournamentAdvancementPreviewMessage(pool, plan))) return;
+
+            await applyTournamentAdvancementPatches(currentTeamId, plan.patches, tournamentAdvancementGames);
+            await loadSchedule();
+            alert(`Advanced ${pool.poolName} into ${plan.patches.length} tournament game${plan.patches.length === 1 ? '' : 's'}.`);
+        }
+
         function renderTournamentStandingsAdminPanel(poolStandings = {}) {
             currentTournamentPoolStandings = poolStandings || {};
             const panel = document.getElementById('tournament-standings-admin-panel');
@@ -1223,6 +1304,7 @@
                     <div class="grid gap-4 lg:grid-cols-2">
                         ${pools.map((pool) => {
                             const poolKey = buildTournamentPoolOverrideKey(pool.poolName);
+                            const advancementPlan = buildFinalizedTournamentAdvancementPlan(pool);
                             return `
                                 <div class="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
                                     <div class="flex items-start justify-between gap-3 mb-3">
@@ -1230,8 +1312,12 @@
                                             <div class="text-sm font-semibold text-gray-900">${escapeHtml(pool.poolName)}</div>
                                             <div class="text-xs text-gray-500">${pool.gameCount} completed pool game${pool.gameCount === 1 ? '' : 's'}</div>
                                             ${pool.isOverridden && pool.override ? `<div class="text-xs text-amber-700 mt-1">${escapeHtml(formatTournamentOverrideAudit(pool.override))}</div>` : '<div class="text-xs text-gray-500 mt-1">Using computed standings</div>'}
+                                            <div class="text-xs ${advancementPlan.skipped ? 'text-slate-500' : (advancementPlan.requiresOverwriteConfirmation ? 'text-amber-700' : 'text-emerald-700')} mt-1">${escapeHtml(formatTournamentAdvancementStatus(advancementPlan))}</div>
                                         </div>
-                                        <button type="button" data-edit-tournament-pool="${escapeHtml(poolKey)}" class="px-3 py-1.5 rounded bg-indigo-100 text-indigo-700 text-sm font-medium hover:bg-indigo-200">Edit final ranking</button>
+                                        <div class="flex flex-col gap-2">
+                                            <button type="button" data-edit-tournament-pool="${escapeHtml(poolKey)}" class="px-3 py-1.5 rounded bg-indigo-100 text-indigo-700 text-sm font-medium hover:bg-indigo-200">Edit final ranking</button>
+                                            <button type="button" data-advance-tournament-pool="${escapeHtml(poolKey)}" class="px-3 py-1.5 rounded bg-violet-100 text-violet-700 text-sm font-medium hover:bg-violet-200">Advance bracket slots</button>
+                                        </div>
                                     </div>
                                     <div class="overflow-x-auto">
                                         <table class="min-w-full text-sm">
@@ -1264,6 +1350,16 @@
 
             panel.querySelectorAll('[data-edit-tournament-pool]').forEach((button) => {
                 button.addEventListener('click', () => openTournamentStandingsEditor(button.dataset.editTournamentPool));
+            });
+            panel.querySelectorAll('[data-advance-tournament-pool]').forEach((button) => {
+                button.addEventListener('click', async () => {
+                    try {
+                        await handleAdvanceFinalizedTournamentPool(button.dataset.advanceTournamentPool);
+                    } catch (error) {
+                        console.error('Failed to advance finalized tournament pool:', error);
+                        alert(`Could not advance bracket slots: ${error.message}`);
+                    }
+                });
             });
         }
 
@@ -1513,6 +1609,7 @@
                     }
                 }
                 : event);
+            tournamentAdvancementGames = resolvedDbEvents.filter((event) => event?.id && (event?.type || 'game') !== 'practice');
             const tournamentPoolStandings = buildTournamentPoolStandings(resolvedDbEvents, {
                 currentTeamName: currentTeam?.name || null,
                 standingsConfig: currentTeam?.standingsConfig || {},

--- a/js/tournament-brackets.js
+++ b/js/tournament-brackets.js
@@ -8,6 +8,13 @@ function normalizeSeed(value) {
     return Number.isFinite(seed) && seed > 0 ? seed : null;
 }
 
+function getTournamentPoolLabel(source = {}) {
+    const divisionName = normalizeString(source.divisionName) || normalizeString(source.division);
+    const poolName = normalizeString(source.poolName);
+    if (divisionName && poolName) return `${divisionName} • ${poolName}`;
+    return poolName || divisionName;
+}
+
 function isCompletedTournamentGame(game) {
     return String(game?.status || '').toLowerCase() === 'completed'
         && Number.isFinite(Number(game?.homeScore))
@@ -33,7 +40,7 @@ function upsertPoolStanding(poolStandings = {}, poolName, seed, teamName) {
 export function describeTournamentSource(source = {}) {
     const sourceType = normalizeString(source.sourceType) || 'team';
     if (sourceType === 'pool_seed') {
-        const poolName = normalizeString(source.poolName) || 'Pool';
+        const poolName = getTournamentPoolLabel(source) || 'Pool';
         const seed = normalizeSeed(source.seed);
         return seed ? `${poolName} #${seed}` : poolName;
     }
@@ -61,10 +68,13 @@ function getTournamentLoser(game = {}) {
 }
 
 function getPoolSeedTeamName(poolStandings = {}, source = {}) {
-    const poolName = normalizeString(source.poolName);
+    const poolName = getTournamentPoolLabel(source);
     const seed = normalizeSeed(source.seed);
     if (!poolName || !seed) return null;
-    const poolRows = Array.isArray(poolStandings?.[poolName]) ? poolStandings[poolName] : [];
+    const fallbackPoolName = normalizeString(source.poolName);
+    const poolRows = Array.isArray(poolStandings?.[poolName])
+        ? poolStandings[poolName]
+        : (fallbackPoolName && Array.isArray(poolStandings?.[fallbackPoolName]) ? poolStandings[fallbackPoolName] : []);
     const row = poolRows[seed - 1];
     return normalizeString(row?.teamName || row?.team || row?.name);
 }
@@ -176,7 +186,7 @@ export function buildPoolStandingsIndex(games = []) {
             if ((normalizeString(slot.sourceType) || 'team') !== 'pool_seed') return;
             upsertPoolStanding(
                 poolStandings,
-                normalizeString(slot.poolName),
+                getTournamentPoolLabel(slot),
                 normalizeSeed(slot.seed),
                 normalizeString(teamName)
             );
@@ -194,7 +204,7 @@ export function collectTournamentPoolSeeds(games = [], poolNameInput) {
         const slotAssignments = game?.tournament?.slotAssignments || {};
         [slotAssignments.home || {}, slotAssignments.away || {}].forEach((slot) => {
             if ((normalizeString(slot.sourceType) || 'team') !== 'pool_seed') return;
-            if (normalizeString(slot.poolName) !== poolName) return;
+            if (getTournamentPoolLabel(slot) !== poolName) return;
             const seed = normalizeSeed(slot.seed);
             if (seed) seeds.add(seed);
         });
@@ -203,8 +213,43 @@ export function collectTournamentPoolSeeds(games = [], poolNameInput) {
     return Array.from(seeds).sort((a, b) => a - b);
 }
 
+function buildTournamentAdvancementPreviewRows(games = [], patches = []) {
+    const gamesById = new Map((games || []).filter((game) => game?.id).map((game) => [game.id, game]));
+
+    return (patches || []).flatMap((patch) => {
+        const game = gamesById.get(patch?.gameId) || {};
+        const currentResolved = game?.tournament?.resolved || {};
+        const nextResolved = patch?.tournament?.resolved || {};
+        const slotAssignments = game?.tournament?.slotAssignments || {};
+
+        return ['home', 'away'].map((slot) => {
+            const currentTeamName = normalizeString(currentResolved?.[`${slot}TeamName`]);
+            const nextTeamName = normalizeString(nextResolved?.[`${slot}TeamName`]);
+            const currentLabel = normalizeString(currentResolved?.[`${slot}Label`])
+                || describeTournamentSource(slotAssignments?.[slot] || {});
+            const nextLabel = normalizeString(nextResolved?.[`${slot}Label`])
+                || describeTournamentSource(slotAssignments?.[slot] || {});
+
+            if (currentTeamName === nextTeamName && currentLabel === nextLabel) return null;
+
+            return {
+                gameId: patch.gameId,
+                slot,
+                slotLabel: slot === 'home' ? 'Home' : 'Away',
+                sourceLabel: describeTournamentSource(slotAssignments?.[slot] || {}),
+                currentLabel,
+                nextLabel,
+                currentTeamName,
+                nextTeamName,
+                overwritesExistingTeam: !!(currentTeamName && nextTeamName && currentTeamName !== nextTeamName)
+            };
+        }).filter(Boolean);
+    });
+}
+
 export function collectTournamentAdvancementPatches(games = [], options = {}) {
-    const poolStandings = options?.poolStandings || {};
+    const hasPoolStandingsOption = Object.prototype.hasOwnProperty.call(options || {}, 'poolStandings');
+    const poolStandings = hasPoolStandingsOption ? (options?.poolStandings || {}) : buildPoolStandingsIndex(games);
     const gamesById = new Map((games || []).filter((game) => game?.id).map((game) => [game.id, game]));
     const memo = new Map();
 
@@ -235,7 +280,22 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
             poolName: null,
             requiredSeeds,
             missingSeeds: [],
-            patches: []
+            patches: [],
+            previewRows: [],
+            requiresOverwriteConfirmation: false
+        };
+    }
+
+    if (!requiredSeeds.length) {
+        return {
+            skipped: true,
+            reason: `No eligible pool-seed bracket slots were found for ${poolName}.`,
+            poolName,
+            requiredSeeds,
+            missingSeeds: [],
+            patches: [],
+            previewRows: [],
+            requiresOverwriteConfirmation: false
         };
     }
 
@@ -246,7 +306,9 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
             poolName,
             requiredSeeds,
             missingSeeds: requiredSeeds,
-            patches: []
+            patches: [],
+            previewRows: [],
+            requiresOverwriteConfirmation: false
         };
     }
 
@@ -258,7 +320,9 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
             poolName,
             requiredSeeds,
             missingSeeds,
-            patches: []
+            patches: [],
+            previewRows: [],
+            requiresOverwriteConfirmation: false
         };
     }
 
@@ -270,6 +334,8 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
         ...basePoolStandings,
         [poolName]: ranking
     };
+    const patches = collectTournamentAdvancementPatches(games, { poolStandings });
+    const previewRows = buildTournamentAdvancementPreviewRows(games, patches);
 
     return {
         skipped: false,
@@ -277,7 +343,9 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
         poolName,
         requiredSeeds,
         missingSeeds: [],
-        patches: collectTournamentAdvancementPatches(games, { poolStandings }),
+        patches,
+        previewRows,
+        requiresOverwriteConfirmation: previewRows.some((row) => row.overwritesExistingTeam),
         poolStandings
     };
 }

--- a/js/tournament-brackets.js
+++ b/js/tournament-brackets.js
@@ -8,9 +8,12 @@ function normalizeSeed(value) {
     return Number.isFinite(seed) && seed > 0 ? seed : null;
 }
 
-function getTournamentPoolLabel(source = {}) {
-    const divisionName = normalizeString(source.divisionName) || normalizeString(source.division);
-    const poolName = normalizeString(source.poolName);
+function getTournamentPoolLabel(source = {}, context = {}) {
+    const divisionName = normalizeString(source.divisionName)
+        || normalizeString(source.division)
+        || normalizeString(context.divisionName)
+        || normalizeString(context.division);
+    const poolName = normalizeString(source.poolName) || normalizeString(context.poolName);
     if (divisionName && poolName) return `${divisionName} • ${poolName}`;
     return poolName || divisionName;
 }
@@ -37,10 +40,10 @@ function upsertPoolStanding(poolStandings = {}, poolName, seed, teamName) {
     }
 }
 
-export function describeTournamentSource(source = {}) {
+export function describeTournamentSource(source = {}, context = {}) {
     const sourceType = normalizeString(source.sourceType) || 'team';
     if (sourceType === 'pool_seed') {
-        const poolName = getTournamentPoolLabel(source) || 'Pool';
+        const poolName = getTournamentPoolLabel(source, context) || 'Pool';
         const seed = normalizeSeed(source.seed);
         return seed ? `${poolName} #${seed}` : poolName;
     }
@@ -67,11 +70,11 @@ function getTournamentLoser(game = {}) {
     return winner === 'home' ? 'away' : 'home';
 }
 
-function getPoolSeedTeamName(poolStandings = {}, source = {}) {
-    const poolName = getTournamentPoolLabel(source);
+function getPoolSeedTeamName(poolStandings = {}, source = {}, context = {}) {
+    const poolName = getTournamentPoolLabel(source, context);
     const seed = normalizeSeed(source.seed);
     if (!poolName || !seed) return null;
-    const fallbackPoolName = normalizeString(source.poolName);
+    const fallbackPoolName = normalizeString(source.poolName) || normalizeString(context.poolName);
     const poolRows = Array.isArray(poolStandings?.[poolName])
         ? poolStandings[poolName]
         : (fallbackPoolName && Array.isArray(poolStandings?.[fallbackPoolName]) ? poolStandings[fallbackPoolName] : []);
@@ -79,21 +82,21 @@ function getPoolSeedTeamName(poolStandings = {}, source = {}) {
     return normalizeString(row?.teamName || row?.team || row?.name);
 }
 
-function resolveGameResultSlot(gamesById, source, poolStandings, memo) {
+function resolveGameResultSlot(gamesById, source, poolStandings, memo, context = {}) {
     const upstreamId = normalizeString(source.gameId);
     if (!upstreamId) {
-        return { teamName: null, label: describeTournamentSource(source), ready: false };
+        return { teamName: null, label: describeTournamentSource(source, context), ready: false };
     }
     const upstream = gamesById.get(upstreamId);
     if (!upstream) {
-        return { teamName: null, label: describeTournamentSource(source), ready: false };
+        return { teamName: null, label: describeTournamentSource(source, context), ready: false };
     }
 
     const upstreamResolved = resolveTournamentGame(upstream, gamesById, poolStandings, memo);
     const outcome = normalizeString(source.outcome) || 'winner';
     const side = outcome === 'loser' ? getTournamentLoser(upstream) : getTournamentWinner(upstream);
     if (!side) {
-        return { teamName: null, label: describeTournamentSource(source), ready: false };
+        return { teamName: null, label: describeTournamentSource(source, context), ready: false };
     }
 
     const teamName = side === 'home'
@@ -102,23 +105,23 @@ function resolveGameResultSlot(gamesById, source, poolStandings, memo) {
 
     return {
         teamName: teamName || null,
-        label: teamName || describeTournamentSource(source),
+        label: teamName || describeTournamentSource(source, context),
         ready: !!teamName
     };
 }
 
-function resolveTournamentSource(source = {}, gamesById, poolStandings, memo) {
+function resolveTournamentSource(source = {}, gamesById, poolStandings, memo, context = {}) {
     const sourceType = normalizeString(source.sourceType) || 'team';
     if (sourceType === 'pool_seed') {
-        const teamName = getPoolSeedTeamName(poolStandings, source);
+        const teamName = getPoolSeedTeamName(poolStandings, source, context);
         return {
             teamName,
-            label: teamName || describeTournamentSource(source),
+            label: teamName || describeTournamentSource(source, context),
             ready: !!teamName
         };
     }
     if (sourceType === 'game_result') {
-        return resolveGameResultSlot(gamesById, source, poolStandings, memo);
+        return resolveGameResultSlot(gamesById, source, poolStandings, memo, context);
     }
     const teamName = normalizeString(source.teamName);
     return {
@@ -148,8 +151,8 @@ export function resolveTournamentGame(game = {}, gamesByIdInput, poolStandings =
         ? gamesByIdInput
         : new Map(Array.isArray(gamesByIdInput) ? gamesByIdInput.map((item) => [item.id, item]) : []);
 
-    const home = resolveTournamentSource(slotAssignments.home || {}, gamesById, poolStandings, memo);
-    const away = resolveTournamentSource(slotAssignments.away || {}, gamesById, poolStandings, memo);
+    const home = resolveTournamentSource(slotAssignments.home || {}, gamesById, poolStandings, memo, tournament);
+    const away = resolveTournamentSource(slotAssignments.away || {}, gamesById, poolStandings, memo, tournament);
     const resolved = {
         homeLabel: home.label,
         awayLabel: away.label,
@@ -176,8 +179,9 @@ export function buildPoolStandingsIndex(games = []) {
     const poolStandings = {};
 
     (games || []).forEach((game) => {
-        const slotAssignments = game?.tournament?.slotAssignments || {};
-        const resolved = game?.tournament?.resolved || {};
+        const tournament = game?.tournament || {};
+        const slotAssignments = tournament.slotAssignments || {};
+        const resolved = tournament.resolved || {};
 
         [
             { slot: slotAssignments.home || {}, teamName: resolved.homeTeamName },
@@ -186,7 +190,7 @@ export function buildPoolStandingsIndex(games = []) {
             if ((normalizeString(slot.sourceType) || 'team') !== 'pool_seed') return;
             upsertPoolStanding(
                 poolStandings,
-                getTournamentPoolLabel(slot),
+                getTournamentPoolLabel(slot, tournament),
                 normalizeSeed(slot.seed),
                 normalizeString(teamName)
             );
@@ -201,10 +205,11 @@ export function collectTournamentPoolSeeds(games = [], poolNameInput) {
     const seeds = new Set();
 
     (games || []).forEach((game) => {
-        const slotAssignments = game?.tournament?.slotAssignments || {};
+        const tournament = game?.tournament || {};
+        const slotAssignments = tournament.slotAssignments || {};
         [slotAssignments.home || {}, slotAssignments.away || {}].forEach((slot) => {
             if ((normalizeString(slot.sourceType) || 'team') !== 'pool_seed') return;
-            if (getTournamentPoolLabel(slot) !== poolName) return;
+            if (getTournamentPoolLabel(slot, tournament) !== poolName) return;
             const seed = normalizeSeed(slot.seed);
             if (seed) seeds.add(seed);
         });
@@ -218,17 +223,18 @@ function buildTournamentAdvancementPreviewRows(games = [], patches = []) {
 
     return (patches || []).flatMap((patch) => {
         const game = gamesById.get(patch?.gameId) || {};
-        const currentResolved = game?.tournament?.resolved || {};
+        const tournament = game?.tournament || {};
+        const currentResolved = tournament.resolved || {};
         const nextResolved = patch?.tournament?.resolved || {};
-        const slotAssignments = game?.tournament?.slotAssignments || {};
+        const slotAssignments = tournament.slotAssignments || {};
 
         return ['home', 'away'].map((slot) => {
             const currentTeamName = normalizeString(currentResolved?.[`${slot}TeamName`]);
             const nextTeamName = normalizeString(nextResolved?.[`${slot}TeamName`]);
             const currentLabel = normalizeString(currentResolved?.[`${slot}Label`])
-                || describeTournamentSource(slotAssignments?.[slot] || {});
+                || describeTournamentSource(slotAssignments?.[slot] || {}, tournament);
             const nextLabel = normalizeString(nextResolved?.[`${slot}Label`])
-                || describeTournamentSource(slotAssignments?.[slot] || {});
+                || describeTournamentSource(slotAssignments?.[slot] || {}, tournament);
 
             if (currentTeamName === nextTeamName && currentLabel === nextLabel) return null;
 
@@ -236,7 +242,7 @@ function buildTournamentAdvancementPreviewRows(games = [], patches = []) {
                 gameId: patch.gameId,
                 slot,
                 slotLabel: slot === 'home' ? 'Home' : 'Away',
-                sourceLabel: describeTournamentSource(slotAssignments?.[slot] || {}),
+                sourceLabel: describeTournamentSource(slotAssignments?.[slot] || {}, tournament),
                 currentLabel,
                 nextLabel,
                 currentTeamName,

--- a/js/tournament-standings.js
+++ b/js/tournament-standings.js
@@ -138,7 +138,7 @@ function getTournamentGameTeams(game = {}, currentTeamName = null) {
 
 function isCompletedTournamentPoolGame(game = {}) {
     return isTournamentGame(game)
-        && getTournamentPoolName(game)
+        && getTournamentStandingsGroupName(game)
         && hasCompletedTournamentScore(game);
 }
 
@@ -202,7 +202,7 @@ export function buildTournamentPoolStandings(gamesInput = [], options = {}) {
 
     games.forEach((game) => {
         if (!isCompletedTournamentPoolGame(game)) return;
-        const poolName = normalizeString(game?.tournament?.poolName);
+        const poolName = getTournamentStandingsGroupName(game);
         const { homeTeam, awayTeam, homeScore, awayScore } = getTournamentGameTeams(game, currentTeamName);
         if (!poolName || !homeTeam || !awayTeam) return;
         if (homeTeam === awayTeam) return;

--- a/tests/unit/edit-schedule-tournament.test.js
+++ b/tests/unit/edit-schedule-tournament.test.js
@@ -46,13 +46,19 @@ describe('edit schedule tournament wiring', () => {
     expect(source).toContain('applyTournamentAdvancementPatches');
     expect(source).toContain('planTournamentPoolAdvancement');
     expect(source).toContain('class="advance-tournament-pool-btn');
+    expect(source).toContain('data-advance-tournament-pool');
+    expect(source).toContain('formatTournamentAdvancementPreviewMessage');
+    expect(source).toContain('buildFinalizedTournamentAdvancementPlan');
     expect(source).toContain("document.querySelectorAll('.advance-tournament-pool-btn').forEach(btn => {");
     expect(source).toContain('let allTeamGamesCache = {};');
+    expect(source).toContain('let tournamentAdvancementGames = [];');
     expect(source).toContain('allTeamGamesCache = {};');
+    expect(source).toContain('tournamentAdvancementGames = resolvedDbEvents.filter');
     expect(source).toContain('allTeamGamesCache[event.id] = eventRecord;');
     expect(source).toContain('const games = Object.values(allTeamGamesCache).filter((candidate) => candidate?.id);');
     expect(source).toContain('const plan = planTournamentPoolAdvancement(games, {');
     expect(source).toContain('await applyTournamentAdvancementPatches(currentTeamId, plan.patches, games);');
+    expect(source).toContain('await applyTournamentAdvancementPatches(currentTeamId, plan.patches, tournamentAdvancementGames);');
     expect(source).toContain('Skipped advancement for ${poolName}. ${plan.reason}');
   });
 

--- a/tests/unit/tournament-brackets.test.js
+++ b/tests/unit/tournament-brackets.test.js
@@ -266,4 +266,125 @@ describe('tournament bracket helpers', () => {
     expect(plan.patches).toEqual([]);
     expect(plan.reason).toContain('#2');
   });
+
+  it('skips pool advancement when finalized standings are missing', () => {
+    const games = [
+      {
+        id: 'semi-1',
+        competitionType: 'tournament',
+        tournament: {
+          slotAssignments: {
+            home: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 1 },
+            away: { sourceType: 'team', teamName: 'Lions' }
+          }
+        }
+      }
+    ];
+
+    const plan = planTournamentPoolAdvancement(games, {
+      poolName: 'Pool A'
+    });
+
+    expect(plan.skipped).toBe(true);
+    expect(plan.missingSeeds).toEqual([1]);
+    expect(plan.patches).toEqual([]);
+    expect(plan.reason).toContain('No finalized ranking');
+  });
+
+  it('skips pool advancement when no eligible bracket slots exist', () => {
+    const games = [
+      {
+        id: 'semi-1',
+        competitionType: 'tournament',
+        tournament: {
+          slotAssignments: {
+            home: { sourceType: 'pool_seed', poolName: 'Pool B', seed: 1 },
+            away: { sourceType: 'team', teamName: 'Lions' }
+          }
+        }
+      }
+    ];
+
+    const plan = planTournamentPoolAdvancement(games, {
+      poolName: 'Pool A',
+      ranking: ['Tigers']
+    });
+
+    expect(plan.skipped).toBe(true);
+    expect(plan.requiredSeeds).toEqual([]);
+    expect(plan.patches).toEqual([]);
+    expect(plan.reason).toContain('No eligible pool-seed bracket slots');
+  });
+
+  it('previews existing slot overwrites before saving advancement', () => {
+    const games = [
+      {
+        id: 'semi-1',
+        competitionType: 'tournament',
+        tournament: {
+          slotAssignments: {
+            home: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 1 },
+            away: { sourceType: 'team', teamName: 'Lions' }
+          },
+          resolved: {
+            homeLabel: 'Old Tigers',
+            awayLabel: 'Lions',
+            homeTeamName: 'Old Tigers',
+            awayTeamName: 'Lions',
+            matchupLabel: 'Old Tigers vs Lions',
+            ready: true
+          }
+        }
+      }
+    ];
+
+    const plan = planTournamentPoolAdvancement(games, {
+      poolName: 'Pool A',
+      ranking: ['Tigers']
+    });
+
+    expect(plan.skipped).toBe(false);
+    expect(plan.requiresOverwriteConfirmation).toBe(true);
+    expect(plan.previewRows).toEqual([
+      expect.objectContaining({
+        gameId: 'semi-1',
+        slot: 'home',
+        currentTeamName: 'Old Tigers',
+        nextTeamName: 'Tigers',
+        overwritesExistingTeam: true
+      })
+    ]);
+  });
+
+  it('keeps finalized pool-seed slots stable after advancement is saved', () => {
+    const games = [
+      {
+        id: 'semi-1',
+        competitionType: 'tournament',
+        tournament: {
+          slotAssignments: {
+            home: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 1 },
+            away: { sourceType: 'team', teamName: 'Lions' }
+          }
+        }
+      }
+    ];
+
+    const plan = planTournamentPoolAdvancement(games, {
+      poolName: 'Pool A',
+      ranking: ['Tigers']
+    });
+    const savedGames = games.map((game) => game.id === 'semi-1'
+      ? {
+          ...game,
+          tournament: {
+            ...game.tournament,
+            ...plan.patches[0].tournament
+          }
+        }
+      : game);
+
+    expect(plan.patches).toHaveLength(1);
+    expect(collectTournamentAdvancementPatches(savedGames)).toEqual([]);
+  });
 });

--- a/tests/unit/tournament-brackets.test.js
+++ b/tests/unit/tournament-brackets.test.js
@@ -234,6 +234,86 @@ describe('tournament bracket helpers', () => {
     ]);
   });
 
+  it('advances division-scoped pools when division lives on the tournament game', () => {
+    const games = [
+      {
+        id: 'gold-semi',
+        competitionType: 'tournament',
+        tournament: {
+          divisionName: '10U Gold',
+          bracketName: 'Gold',
+          roundName: 'Semifinal',
+          slotAssignments: {
+            home: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 1 },
+            away: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 2 }
+          }
+        }
+      },
+      {
+        id: 'silver-semi',
+        competitionType: 'tournament',
+        tournament: {
+          divisionName: '12U Silver',
+          bracketName: 'Silver',
+          roundName: 'Semifinal',
+          slotAssignments: {
+            home: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 1 },
+            away: { sourceType: 'team', teamName: 'Wolves' }
+          },
+          resolved: {
+            homeLabel: '12U Silver • Pool A #1',
+            awayLabel: 'Wolves',
+            homeTeamName: null,
+            awayTeamName: 'Wolves',
+            matchupLabel: '12U Silver • Pool A #1 vs Wolves',
+            ready: false
+          }
+        }
+      }
+    ];
+
+    expect(collectTournamentPoolSeeds(games, '10U Gold • Pool A')).toEqual([1, 2]);
+    expect(collectTournamentPoolSeeds(games, '12U Silver • Pool A')).toEqual([1]);
+
+    const plan = planTournamentPoolAdvancement(games, {
+      poolName: '10U Gold • Pool A',
+      ranking: ['Tigers', 'Lions']
+    });
+
+    expect(plan.skipped).toBe(false);
+    expect(plan.requiredSeeds).toEqual([1, 2]);
+    expect(plan.missingSeeds).toEqual([]);
+    expect(plan.patches).toEqual([
+      {
+        gameId: 'gold-semi',
+        tournament: {
+          resolved: {
+            homeLabel: 'Tigers',
+            awayLabel: 'Lions',
+            homeTeamName: 'Tigers',
+            awayTeamName: 'Lions',
+            matchupLabel: 'Tigers vs Lions',
+            ready: true
+          }
+        }
+      }
+    ]);
+    expect(plan.previewRows).toEqual([
+      expect.objectContaining({
+        gameId: 'gold-semi',
+        slot: 'home',
+        sourceLabel: '10U Gold • Pool A #1',
+        nextTeamName: 'Tigers'
+      }),
+      expect.objectContaining({
+        gameId: 'gold-semi',
+        slot: 'away',
+        sourceLabel: '10U Gold • Pool A #2',
+        nextTeamName: 'Lions'
+      })
+    ]);
+  });
+
   it('skips pool advancement when a required seed is missing', () => {
     const games = [
       {

--- a/tests/unit/tournament-standings.test.js
+++ b/tests/unit/tournament-standings.test.js
@@ -170,6 +170,43 @@ describe('tournament standings helpers', () => {
     expect(standings['Pool-A'].rows.map((row) => row.teamName)).toEqual(['Bears', 'Hawks']);
   });
 
+  it('keeps admin standings scoped by division and pool names', () => {
+    const standings = buildTournamentPoolStandings([
+      {
+        competitionType: 'tournament',
+        status: 'completed',
+        homeScore: 2,
+        awayScore: 1,
+        tournament: {
+          divisionName: '10U Gold',
+          poolName: 'Pool A',
+          slotAssignments: {
+            home: { sourceType: 'team', teamName: 'Tigers' },
+            away: { sourceType: 'team', teamName: 'Lions' }
+          }
+        }
+      },
+      {
+        competitionType: 'tournament',
+        status: 'completed',
+        homeScore: 3,
+        awayScore: 0,
+        tournament: {
+          divisionName: '12U Silver',
+          poolName: 'Pool A',
+          slotAssignments: {
+            home: { sourceType: 'team', teamName: 'Bears' },
+            away: { sourceType: 'team', teamName: 'Hawks' }
+          }
+        }
+      }
+    ]);
+
+    expect(Object.keys(standings)).toEqual(['10U Gold • Pool A', '12U Silver • Pool A']);
+    expect(standings['10U Gold • Pool A'].rows.map((row) => row.teamName)).toEqual(['Tigers', 'Lions']);
+    expect(standings['12U Silver • Pool A'].rows.map((row) => row.teamName)).toEqual(['Bears', 'Hawks']);
+  });
+
   it('falls back to exact pool-name matches when reading legacy override entries', () => {
     const legacyOverride = {
       poolName: 'Pool A',


### PR DESCRIPTION
Closes #604

## Summary
- Added finalized standings advancement from the tournament standings admin panel into matching pool_seed bracket slots.
- Added preview and overwrite confirmation before bracket updates are saved.
- Preserved saved pool-seed resolutions and added division/pool scoped standings support.

## Tests
- npm test