### PR TITLE
Add tournament ranking override rendering

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -811,7 +811,7 @@
         import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
         import { buildPoolStandingsIndex, collectTournamentAdvancementPatches, collectTournamentPoolSeeds, describeTournamentSource, planTournamentPoolAdvancement } from './js/tournament-brackets.js?v=1';
         import { normalizeScheduleNotificationSettings, buildScheduleNotificationMetadata, buildScheduleChangeMessage, buildScheduleNotificationTargets, postScheduleNotificationTargets, buildRsvpReminderMessage } from './js/schedule-notifications.js?v=3';
-        import { buildTournamentPoolStandings, buildTournamentPoolOverrideKey } from './js/tournament-standings.js?v=2';
+        import { buildTournamentPoolStandings, buildTournamentPoolOverrideKey } from './js/tournament-standings.js?v=3';
         import { SCHEDULE_CSV_IMPORT_FIELDS, buildScheduleImportPreview, inferScheduleCsvMapping, normalizeScheduleImportDraft, parseCsvText } from './js/schedule-csv-import.js?v=2';
 
         renderFooter(document.getElementById('footer-container'));

--- a/js/tournament-standings.js
+++ b/js/tournament-standings.js
@@ -138,7 +138,7 @@ function getTournamentGameTeams(game = {}, currentTeamName = null) {
 
 function isCompletedTournamentPoolGame(game = {}) {
     return isTournamentGame(game)
-        && getTournamentPoolName(game)
+        && getTournamentStandingsGroupName(game)
         && hasCompletedTournamentScore(game);
 }
 
@@ -159,21 +159,26 @@ export function applyTournamentStandingsOverride(rowsInput = [], override = null
     const remaining = [...rows];
     const ordered = [];
     teamOrder.forEach((teamName) => {
-        const matchIndex = remaining.findIndex((row) => normalizeString(row?.team) === teamName);
+        const matchIndex = remaining.findIndex((row) => normalizeString(row?.teamName || row?.team) === teamName);
         if (matchIndex >= 0) {
             ordered.push(remaining.splice(matchIndex, 1)[0]);
         }
     });
 
+    const isApplied = ordered.length > 0;
     const finalRows = [...ordered, ...remaining].map((row, index) => ({
         ...row,
-        rank: index + 1
+        rank: index + 1,
+        ...(isApplied ? {
+            displayRank: String(index + 1),
+            unresolvedTie: false
+        } : {})
     }));
 
     return {
         rows: finalRows,
-        isOverridden: ordered.length > 0,
-        override: ordered.length > 0 ? override : null
+        isOverridden: isApplied,
+        override: isApplied ? override : null
     };
 }
 
@@ -202,7 +207,7 @@ export function buildTournamentPoolStandings(gamesInput = [], options = {}) {
 
     games.forEach((game) => {
         if (!isCompletedTournamentPoolGame(game)) return;
-        const poolName = normalizeString(game?.tournament?.poolName);
+        const poolName = getTournamentStandingsGroupName(game);
         const { homeTeam, awayTeam, homeScore, awayScore } = getTournamentGameTeams(game, currentTeamName);
         if (!poolName || !homeTeam || !awayTeam) return;
         if (homeTeam === awayTeam) return;
@@ -296,14 +301,19 @@ export function computeTournamentPoolStandings(gamesInput, options = {}) {
                 ...row,
                 teamName: row.team
             }));
+            const override = getPoolOverride(options?.poolOverrides || {}, poolName);
+            const applied = applyTournamentStandingsOverride(rows, override);
             return {
                 poolName,
                 groupName: poolName,
                 gameCount: poolGameList.length,
                 scheduledGameCount: pool.scheduledGameCount,
                 noScoreGameCount: pool.noScoreGameCount,
-                rows,
-                unresolvedTie: rows.some((row) => row.unresolvedTie)
+                computedRows: rows,
+                rows: applied.rows,
+                isOverridden: applied.isOverridden,
+                override: applied.override,
+                unresolvedTie: applied.isOverridden ? false : rows.some((row) => row.unresolvedTie)
             };
         });
 }

--- a/team.html
+++ b/team.html
@@ -245,7 +245,7 @@
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, escapeHtml, shareOrCopy } from './js/utils.js?v=10';
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';
         import { computeNativeStandings } from './js/native-standings.js?v=1';
-        import { computeTournamentPoolStandings } from './js/tournament-standings.js?v=2';
+        import { computeTournamentPoolStandings } from './js/tournament-standings.js?v=3';
         import { buildPlayerLeaderboardSnapshot, selectAnalyticsConfig } from './js/stat-leaderboards.js?v=1';
         import { calculateSeasonRecord, listSeasonLabels } from './js/season-record.js';
         import { checkAuth } from './js/auth.js?v=12';
@@ -387,6 +387,20 @@
             `;
         }
 
+        function getTournamentOverrideDate(value) {
+            if (!value) return null;
+            if (typeof value.toDate === 'function') return value.toDate();
+            const parsed = new Date(value);
+            return Number.isNaN(parsed.getTime()) ? null : parsed;
+        }
+
+        function formatTournamentOverrideAudit(override = {}) {
+            const finalizedBy = override?.finalizedBy?.name || override?.finalizedBy?.email || 'an admin';
+            const finalizedAt = getTournamentOverrideDate(override?.finalizedAt);
+            if (!finalizedAt) return `Finalized by ${finalizedBy}`;
+            return `Finalized by ${finalizedBy} on ${formatDate(finalizedAt)} at ${formatTime(finalizedAt)}`;
+        }
+
         function renderTournamentStandingsSection(pools, team) {
             const section = document.getElementById('tournament-standings-section');
             const content = document.getElementById('tournament-standings-content');
@@ -420,7 +434,9 @@
                                 <h3 class="text-lg font-bold text-gray-900">${escapeHtml(pool.poolName)}</h3>
                                 <p class="text-sm text-gray-500">${escapeHtml(summaryText)}</p>
                                 ${completedGameCount > 0 && rows.length === 0 ? '<p class="text-xs text-amber-700 mt-1">Completed games need valid teams before standings can be calculated.</p>' : ''}
+                                ${pool.isOverridden && pool.override ? `<p class="text-xs text-amber-700 mt-1">${escapeHtml(formatTournamentOverrideAudit(pool.override))}</p>` : ''}
                             </div>
+                            ${pool.isOverridden ? '<span class="inline-flex items-center rounded-full bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-800 border border-amber-200">Final ranking override</span>' : ''}
                             ${pool.unresolvedTie ? '<span class="inline-flex items-center rounded-full bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-800 border border-amber-200">Tie unresolved after configured tiebreakers</span>' : ''}
                         </div>
                         ${rows.length === 0
@@ -951,7 +967,8 @@
                     teamName: team?.name,
                     standingsConfig: team?.standingsConfig || {},
                     tournamentDivisions: team?.tournamentDivisions || team?.tournament?.divisions,
-                    tournamentPools: team?.tournamentPools || team?.tournament?.pools
+                    tournamentPools: team?.tournamentPools || team?.tournament?.pools,
+                    poolOverrides: team?.tournamentPoolOverrides || {}
                 });
                 const leagueSnapshot = (nativeStandingsSnapshot && nativeStandingsSnapshot.ok)
                     ? null

--- a/tests/unit/team-tournament-standings.test.js
+++ b/tests/unit/team-tournament-standings.test.js
@@ -8,7 +8,7 @@ describe('team tournament standings wiring', () => {
   it('imports the tournament standings helper and renders the public standings section', () => {
     const source = fs.readFileSync(TEAM_HTML_PATH, 'utf8');
 
-    expect(source).toContain("import { computeTournamentPoolStandings } from './js/tournament-standings.js?v=2';");
+    expect(source).toContain("import { computeTournamentPoolStandings } from './js/tournament-standings.js?v=3';");
     expect(source).toContain('id="tournament-standings-section"');
     expect(source).toContain('Results &amp; Standings');
     expect(source).toContain('No completed tournament games with scores yet.');

--- a/tests/unit/tournament-standings.test.js
+++ b/tests/unit/tournament-standings.test.js
@@ -200,6 +200,38 @@ describe('tournament standings helpers', () => {
     expect(standings['Pool A'].override).toEqual(legacyOverride);
   });
 
+  it('builds division-scoped admin standings and applies final ranking overrides', () => {
+    const override = {
+      poolName: '10U Gold',
+      teamOrder: ['Lions', 'Tigers']
+    };
+
+    const standings = buildTournamentPoolStandings([
+      {
+        competitionType: 'tournament',
+        status: 'completed',
+        homeScore: 2,
+        awayScore: 1,
+        tournament: {
+          divisionName: '10U Gold',
+          slotAssignments: {
+            home: { sourceType: 'team', teamName: 'Tigers' },
+            away: { sourceType: 'team', teamName: 'Lions' }
+          }
+        }
+      }
+    ], {
+      poolOverrides: {
+        [buildTournamentPoolOverrideKey('10U Gold')]: override
+      }
+    });
+
+    expect(Object.keys(standings)).toEqual(['10U Gold']);
+    expect(standings['10U Gold'].computedRows.map((row) => row.teamName)).toEqual(['Tigers', 'Lions']);
+    expect(standings['10U Gold'].rows.map((row) => row.teamName)).toEqual(['Lions', 'Tigers']);
+    expect(standings['10U Gold'].isOverridden).toBe(true);
+  });
+
   it('falls back to computed ranks when an override is cleared', () => {
     const applied = applyTournamentStandingsOverride([
       { team: 'Bears', rank: 2 },
@@ -211,6 +243,28 @@ describe('tournament standings helpers', () => {
       { team: 'Bears', rank: 1 },
       { team: 'Lions', rank: 2 }
     ]);
+  });
+
+  it('ignores malformed overrides and safely applies non-stale teams from stale overrides', () => {
+    const computedRows = [
+      { team: 'Tigers', teamName: 'Tigers', rank: 1 },
+      { team: 'Lions', teamName: 'Lions', rank: 2 }
+    ];
+
+    const malformed = applyTournamentStandingsOverride(computedRows, {
+      poolName: 'Pool A',
+      teamOrder: 'Lions,Tigers'
+    });
+    expect(malformed.isOverridden).toBe(false);
+    expect(malformed.rows.map((row) => row.teamName)).toEqual(['Tigers', 'Lions']);
+
+    const stale = applyTournamentStandingsOverride(computedRows, {
+      poolName: 'Pool A',
+      teamOrder: ['Ghosts', 'Lions']
+    });
+    expect(stale.isOverridden).toBe(true);
+    expect(stale.rows.map((row) => row.teamName)).toEqual(['Lions', 'Tigers']);
+    expect(stale.rows.map((row) => row.rank)).toEqual([1, 2]);
   });
 
   it('groups completed tournament games by pool for team pages', () => {
@@ -430,5 +484,40 @@ describe('tournament standings helpers', () => {
     expect(pools[0].unresolvedTie).toBe(true);
     expect(pools[0].rows.map((row) => row.displayRank)).toEqual(['T-1', 'T-1']);
     expect(pools[0].rows.every((row) => row.unresolvedTie)).toBe(true);
+  });
+
+  it('uses saved overrides for rendered team-page standings and clears unresolved tie labels', () => {
+    const pools = computeTournamentPoolStandings([
+      {
+        competitionType: 'tournament',
+        status: 'completed',
+        opponent: 'Lions',
+        isHome: true,
+        homeScore: 1,
+        awayScore: 1,
+        tournament: { poolName: 'Pool C' }
+      }
+    ], {
+      teamName: 'Tigers',
+      standingsConfig: {
+        rankingMode: 'points',
+        points: { win: 3, tie: 1, loss: 0 },
+        tiebreakers: ['name']
+      },
+      poolOverrides: {
+        [buildTournamentPoolOverrideKey('Pool C')]: {
+          poolName: 'Pool C',
+          teamOrder: ['Lions', 'Tigers'],
+          finalizedBy: { name: 'Coach Kim' },
+          finalizedAt: '2026-04-23T22:00:00.000Z'
+        }
+      }
+    });
+
+    expect(pools[0].isOverridden).toBe(true);
+    expect(pools[0].unresolvedTie).toBe(false);
+    expect(pools[0].rows.map((row) => row.teamName)).toEqual(['Lions', 'Tigers']);
+    expect(pools[0].rows.map((row) => row.displayRank)).toEqual(['1', '2']);
+    expect(pools[0].rows.every((row) => row.unresolvedTie)).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #603

## Summary
- Applied saved tournament ranking overrides to rendered team standings.
- Supported division-scoped standings groups in the admin override workflow.
- Hardened override handling for malformed or stale team orders.

## Tests
- `npx vitest run tests/unit/tournament-standings.test.js tests/unit/db-tournament-overrides.test.js`