### PR TITLE
Make live event replay duplicate-safe

### DIFF
--- a/js/db.js
+++ b/js/db.js
@@ -2810,9 +2810,29 @@ export async function getUnreadChatCounts(userId, teamIds) {
  */
 export async function broadcastLiveEvent(teamId, gameId, eventData) {
     const eventsRef = getGameSubcollectionRef(teamId, gameId, 'liveEvents');
-    return addDoc(eventsRef, {
+    const eventId = typeof eventData?.eventId === 'string' ? eventData.eventId.trim() : '';
+    const eventPayload = {
         ...eventData,
+        ...(eventId ? { eventId } : {}),
         createdAt: serverTimestamp()
+    };
+
+    if (eventId && !eventId.includes('/')) {
+        const eventRef = doc(eventsRef, eventId);
+        try {
+            await setDoc(eventRef, eventPayload);
+            return eventRef;
+        } catch (error) {
+            const confirmedSnap = await getDoc(eventRef).catch(() => null);
+            if (confirmedSnap?.exists?.() && confirmedSnap.data()?.eventId === eventId) {
+                return eventRef;
+            }
+            throw error;
+        }
+    }
+
+    return addDoc(eventsRef, {
+        ...eventPayload
     });
 }
 

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -1,5 +1,5 @@
 // Mobile-first basketball tracker, now backed by Firebase like track.html.
-import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=15';
+import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=16';
 import { db } from './firebase.js?v=10';
 import { getUrlParams, escapeHtml } from './utils.js?v=9';
 import { checkAuth } from './auth.js?v=12';

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -90,6 +90,27 @@ let liveState = {
 };
 
 const LIVE_CLOCK_SYNC_INTERVAL_MS = 5000;
+let liveEventIdCounter = 0;
+
+function createLiveEventId() {
+  const randomId = window.crypto?.randomUUID?.();
+  if (randomId) return `live-${randomId}`;
+
+  liveEventIdCounter += 1;
+  return `live-${Date.now().toString(36)}-${liveEventIdCounter}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function withStableLiveEventId(eventData) {
+  const event = (eventData && typeof eventData === 'object') ? eventData : {};
+  const existingId = typeof event.eventId === 'string' ? event.eventId.trim() : '';
+  if (existingId) {
+    return existingId === event.eventId ? event : { ...event, eventId: existingId };
+  }
+  return {
+    ...event,
+    eventId: createLiveEventId()
+  };
+}
 
 let liveSync = {
   playerTimeouts: new Map(),
@@ -1087,12 +1108,13 @@ function startVoiceNote() {
 }
 
 async function broadcastEvent(eventData) {
+  const eventWithId = withStableLiveEventId(eventData);
   try {
-    await broadcastLiveEvent(currentTeamId, currentGameId, eventData);
+    await broadcastLiveEvent(currentTeamId, currentGameId, eventWithId);
     renderLiveSyncStatus();
   } catch (error) {
     console.error('Broadcast failed (will retry):', error);
-    liveState.eventQueue.push(eventData);
+    liveState.eventQueue.push(eventWithId);
     persistPendingEventQueue();
     renderLiveSyncStatus();
     scheduleRetry();
@@ -1129,7 +1151,11 @@ function scheduleRetry({ resetBackoff = false } = {}) {
     renderLiveSyncStatus();
 
     while (liveState.eventQueue.length > 0) {
-      const event = liveState.eventQueue[0];
+      const event = withStableLiveEventId(liveState.eventQueue[0]);
+      if (event !== liveState.eventQueue[0]) {
+        liveState.eventQueue[0] = event;
+        persistPendingEventQueue();
+      }
       try {
         await broadcastLiveEvent(currentTeamId, currentGameId, event);
         liveState.eventQueue.shift();

--- a/tests/unit/live-tracker-opponent-stats.test.js
+++ b/tests/unit/live-tracker-opponent-stats.test.js
@@ -408,7 +408,7 @@ describe('live tracker opponent stats harness', () => {
   it('rewrites module imports when cache-buster versions and formatting change', () => {
     const source = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8')
       .replace(
-        "import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=15';",
+        "import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=16';",
         "import {\n  getTeam,\n  getTeams,\n  getGame,\n  getPlayers,\n  getConfigs,\n  updateGame,\n  collection,\n  getDocs,\n  deleteDoc,\n  query,\n  broadcastLiveEvent,\n  subscribeLiveChat,\n  postLiveChatMessage,\n  setGameLiveStatus\n} from './db.js?v=999';"
       )
       .replace('./firebase.js?v=10', './firebase.js?v=77')

--- a/tests/unit/live-tracker-retry-queue.test.js
+++ b/tests/unit/live-tracker-retry-queue.test.js
@@ -145,6 +145,7 @@ return {
   liveState,
   scheduleRetry,
   persistPendingEventQueue,
+  broadcastEvent,
   setContext(context = {}) {
     currentTeamId = context.teamId || null;
     currentGameId = context.gameId || null;
@@ -164,7 +165,7 @@ const runModule = new AsyncFunction(
     moduleSource
 );
 
-async function bootHarness({ broadcastImpl }) {
+async function bootHarness({ broadcastImpl, randomUUID = vi.fn() }) {
     const { document } = createEnvironment();
     const storage = createStorage();
     const scheduledTimeouts = new Map();
@@ -260,6 +261,7 @@ async function bootHarness({ broadcastImpl }) {
     const window = {
         location: { href: '' },
         localStorage: storage,
+        crypto: { randomUUID },
         navigator: { onLine: true },
         addEventListener: () => {}
     };
@@ -299,16 +301,47 @@ async function bootHarness({ broadcastImpl }) {
 }
 
 describe('live tracker retry queue persistence', () => {
+    it('queues failed live events with stable client event IDs', async () => {
+        const randomUUID = vi.fn(() => 'event-1');
+        const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+        const attempts = [];
+        const page = await bootHarness({
+            randomUUID,
+            broadcastImpl: async (_teamId, _gameId, event) => {
+                attempts.push(event);
+                throw new Error('offline');
+            }
+        });
+
+        page.setContext({ teamId: 'team-1', gameId: 'game-9' });
+        await page.broadcastEvent({ type: 'stat', statKey: 'pts', value: 2 });
+
+        const queuedEvent = {
+            type: 'stat',
+            statKey: 'pts',
+            value: 2,
+            eventId: 'live-event-1'
+        };
+        expect(attempts).toEqual([queuedEvent]);
+        expect(page.liveState.eventQueue).toEqual([queuedEvent]);
+        expect(readPersistedLiveTrackerQueue(page.storage, 'team-1', 'game-9')).toEqual([queuedEvent]);
+        errorSpy.mockRestore();
+    });
+
     it('keeps remaining pending events persisted until each replay succeeds', async () => {
         const firstEvent = { type: 'stat', statKey: 'pts', value: 2 };
         const secondEvent = { type: 'lineup', onCourt: ['p1', 'p2', 'p3', 'p4', 'p5'] };
+        const randomUUID = vi.fn()
+            .mockReturnValueOnce('event-1')
+            .mockReturnValueOnce('event-2');
         const attempts = [];
         let secondEventAttempt = 0;
 
         const page = await bootHarness({
+            randomUUID,
             broadcastImpl: async (_teamId, _gameId, event) => {
                 attempts.push(event);
-                if (event === secondEvent && secondEventAttempt++ === 0) {
+                if (event.type === 'lineup' && secondEventAttempt++ === 0) {
                     throw new Error('temporary network failure');
                 }
             }
@@ -321,13 +354,25 @@ describe('live tracker retry queue persistence', () => {
         page.scheduleRetry({ resetBackoff: true });
         await page.flushOneTimer();
 
-        expect(attempts).toEqual([firstEvent, secondEvent]);
-        expect(page.liveState.eventQueue).toEqual([secondEvent]);
-        expect(readPersistedLiveTrackerQueue(page.storage, 'team-1', 'game-9')).toEqual([secondEvent]);
+        const queuedSecondEvent = {
+            ...secondEvent,
+            eventId: 'live-event-2'
+        };
+        expect(attempts).toEqual([
+            { ...firstEvent, eventId: 'live-event-1' },
+            queuedSecondEvent
+        ]);
+        expect(page.liveState.eventQueue).toEqual([queuedSecondEvent]);
+        expect(readPersistedLiveTrackerQueue(page.storage, 'team-1', 'game-9')).toEqual([queuedSecondEvent]);
 
         await page.flushOneTimer();
 
-        expect(attempts).toEqual([firstEvent, secondEvent, secondEvent]);
+        expect(attempts).toEqual([
+            { ...firstEvent, eventId: 'live-event-1' },
+            queuedSecondEvent,
+            queuedSecondEvent
+        ]);
+        expect(randomUUID).toHaveBeenCalledTimes(2);
         expect(page.liveState.eventQueue).toEqual([]);
         expect(readPersistedLiveTrackerQueue(page.storage, 'team-1', 'game-9')).toEqual([]);
     });


### PR DESCRIPTION
Closes #613

## What changed
- Added stable client-generated `eventId` values before live tracker events are broadcast or queued.
- Replays now persist missing IDs before retrying and reuse the same ID across retry attempts.
- `broadcastLiveEvent` writes ID-backed live events to deterministic Firestore document IDs and treats already-confirmed duplicates as success.

## Validation
- `npx vitest run tests/unit/live-tracker-retry-queue.test.js --reporter=dot`
- `node --check js/db.js && node --check js/live-tracker.js`