### PR TITLE
Add standard tracker finish batch tests

### DIFF
--- a/js/track-finish.js
+++ b/js/track-finish.js
@@ -1,0 +1,130 @@
+export const STANDARD_TRACKER_MAX_PRIMARY_BATCH_WRITES = 500;
+export const STANDARD_TRACKER_MAX_AGGREGATED_STATS_BATCH_WRITES = 450;
+
+export function buildNormalizedPlayerStats(playerStats = {}, columns = []) {
+    const playerStatsByLowerKey = {};
+    const normalizedStats = {};
+
+    Object.entries(playerStats || {}).forEach(([statKey, value]) => {
+        playerStatsByLowerKey[String(statKey).toLowerCase()] = Number(value) || 0;
+    });
+
+    (Array.isArray(columns) ? columns : []).forEach((col) => {
+        const key = String(col || '').toLowerCase();
+        normalizedStats[key] = Object.prototype.hasOwnProperty.call(playerStatsByLowerKey, key)
+            ? playerStatsByLowerKey[key]
+            : 0;
+    });
+
+    Object.entries(playerStats || {}).forEach(([statKey, value]) => {
+        const normalizedKey = String(statKey).toLowerCase();
+        if (normalizedStats[statKey] === undefined && normalizedStats[normalizedKey] === undefined) {
+            normalizedStats[statKey] = Number(value) || 0;
+        }
+    });
+
+    return normalizedStats;
+}
+
+export function buildFinishBatchLimitError(gameLogLength, maxPrimaryBatchWrites = STANDARD_TRACKER_MAX_PRIMARY_BATCH_WRITES) {
+    return new Error(`Game has ${gameLogLength} logged events. Finish requires chunked event persistence before it can safely exceed Firestore's ${maxPrimaryBatchWrites}-write batch limit.`);
+}
+
+export function buildAggregatedStatsWrites({ players = [], playerStatsByPlayerId = {}, columns = [] } = {}) {
+    const safePlayers = Array.isArray(players) ? players : [];
+    const safeStatsByPlayerId = playerStatsByPlayerId && typeof playerStatsByPlayerId === 'object'
+        ? playerStatsByPlayerId
+        : {};
+
+    return safePlayers.map((player) => {
+        const playerStats = safeStatsByPlayerId[player.id] || {};
+
+        return {
+            playerId: player.id,
+            data: {
+                playerName: player.name,
+                playerNumber: player.number,
+                stats: buildNormalizedPlayerStats(playerStats, columns)
+            }
+        };
+    });
+}
+
+export async function commitStandardTrackerFinishData({
+    db,
+    writeBatch,
+    doc,
+    collection,
+    teamId,
+    gameId,
+    currentUserUid,
+    gameLog = [],
+    players = [],
+    playerStatsByPlayerId = {},
+    columns = [],
+    finalHome,
+    finalAway,
+    summary = '',
+    opponentStats = {},
+    maxPrimaryBatchWrites = STANDARD_TRACKER_MAX_PRIMARY_BATCH_WRITES,
+    maxAggregatedStatsBatchWrites = STANDARD_TRACKER_MAX_AGGREGATED_STATS_BATCH_WRITES
+} = {}) {
+    const safeGameLog = Array.isArray(gameLog) ? gameLog : [];
+    const primaryBatchWriteCount = safeGameLog.length + 1;
+
+    if (primaryBatchWriteCount > maxPrimaryBatchWrites) {
+        throw buildFinishBatchLimitError(safeGameLog.length, maxPrimaryBatchWrites);
+    }
+
+    const primaryBatch = writeBatch(db);
+    const aggregatedStatsWrites = buildAggregatedStatsWrites({
+        players,
+        playerStatsByPlayerId,
+        columns
+    });
+
+    safeGameLog.forEach((entry) => {
+        const eventRef = doc(collection(db, `teams/${teamId}/games/${gameId}/events`));
+        primaryBatch.set(eventRef, {
+            text: entry.text,
+            gameTime: entry.time,
+            period: entry.period,
+            timestamp: entry.timestamp || Date.now(),
+            type: entry.undoData?.type || 'game_log',
+            playerId: entry.undoData?.playerId || null,
+            statKey: entry.undoData?.statKey || null,
+            value: entry.undoData?.value || null,
+            isOpponent: entry.undoData?.isOpponent || false,
+            createdBy: currentUserUid
+        });
+    });
+
+    const gameRef = doc(db, `teams/${teamId}/games`, gameId);
+    primaryBatch.update(gameRef, {
+        homeScore: finalHome,
+        awayScore: finalAway,
+        summary,
+        status: 'completed',
+        opponentStats
+    });
+
+    await primaryBatch.commit();
+
+    const aggregatedStatsBatchSizes = [];
+    for (let i = 0; i < aggregatedStatsWrites.length; i += maxAggregatedStatsBatchWrites) {
+        const statsBatch = writeBatch(db);
+        const statsChunk = aggregatedStatsWrites.slice(i, i + maxAggregatedStatsBatchWrites);
+        statsChunk.forEach(({ playerId, data }) => {
+            const statsRef = doc(db, `teams/${teamId}/games/${gameId}/aggregatedStats`, playerId);
+            statsBatch.set(statsRef, data);
+        });
+        aggregatedStatsBatchSizes.push(statsChunk.length);
+        await statsBatch.commit();
+    }
+
+    return {
+        primaryBatchWriteCount,
+        aggregatedStatsBatchSizes,
+        aggregatedStatsWriteCount: aggregatedStatsWrites.length
+    };
+}

--- a/tests/unit/track-finish-batch-limit.test.js
+++ b/tests/unit/track-finish-batch-limit.test.js
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { commitStandardTrackerFinishData } from '../../js/track-finish.js';
+
+function createFirestoreHarness() {
+    const batches = [];
+    let autoId = 0;
+
+    return {
+        db: { name: 'mock-db' },
+        batches,
+        writeBatch: () => {
+            const batch = {
+                operations: [],
+                commitCount: 0,
+                set(ref, data) {
+                    this.operations.push({ type: 'set', ref, data });
+                },
+                update(ref, data) {
+                    this.operations.push({ type: 'update', ref, data });
+                },
+                async commit() {
+                    this.commitCount += 1;
+                }
+            };
+            batches.push(batch);
+            return batch;
+        },
+        collection: (_db, path) => ({ type: 'collection', path }),
+        doc: (...args) => {
+            if (args.length === 1 && args[0]?.type === 'collection') {
+                autoId += 1;
+                return { path: `${args[0].path}/auto-${autoId}` };
+            }
+
+            if (args.length === 3) {
+                return { path: `${args[1]}/${args[2]}` };
+            }
+
+            throw new Error(`Unsupported doc() call: ${JSON.stringify(args)}`);
+        }
+    };
+}
+
+function buildGameLog(count) {
+    return Array.from({ length: count }, (_, index) => ({
+        text: `Event ${index + 1}`,
+        time: '00:01',
+        period: 'Q1',
+        timestamp: index + 1,
+        undoData: {
+            type: 'stat',
+            playerId: `player-${index + 1}`,
+            statKey: 'PTS',
+            value: 1,
+            isOpponent: false
+        }
+    }));
+}
+
+function buildRoster(count) {
+    return Array.from({ length: count }, (_, index) => ({
+        id: `player-${index + 1}`,
+        name: `Player ${index + 1}`,
+        number: String(index + 1)
+    }));
+}
+
+async function runFinishSave({ eventCount, rosterCount }) {
+    const harness = createFirestoreHarness();
+
+    const result = await commitStandardTrackerFinishData({
+        db: harness.db,
+        writeBatch: harness.writeBatch,
+        doc: harness.doc,
+        collection: harness.collection,
+        teamId: 'team-1',
+        gameId: 'game-1',
+        currentUserUid: 'coach-1',
+        gameLog: buildGameLog(eventCount),
+        players: buildRoster(rosterCount),
+        playerStatsByPlayerId: {},
+        columns: ['PTS', 'AST'],
+        finalHome: 12,
+        finalAway: 10,
+        summary: 'Finished cleanly.',
+        opponentStats: {}
+    });
+
+    return { harness, result };
+}
+
+describe('standard tracker finish batch limits', () => {
+    it('commits 499 game logs plus final update and chunks 905 aggregated stat writes', async () => {
+        const { harness, result } = await runFinishSave({
+            eventCount: 499,
+            rosterCount: 905
+        });
+
+        expect(result.primaryBatchWriteCount).toBe(500);
+        expect(result.aggregatedStatsBatchSizes).toEqual([450, 450, 5]);
+        expect(harness.batches).toHaveLength(4);
+
+        const [primaryBatch, ...secondaryBatches] = harness.batches;
+        expect(primaryBatch.commitCount).toBe(1);
+        expect(primaryBatch.operations).toHaveLength(500);
+        expect(primaryBatch.operations.filter((op) => op.type === 'set')).toHaveLength(499);
+        expect(primaryBatch.operations.filter((op) => op.type === 'update')).toHaveLength(1);
+
+        expect(secondaryBatches.map((batch) => batch.operations.length)).toEqual([450, 450, 5]);
+        secondaryBatches.forEach((batch) => {
+            expect(batch.commitCount).toBe(1);
+            expect(batch.operations.every((op) => op.type === 'set')).toBe(true);
+        });
+    });
+
+    it('rejects 500 game logs plus final update before any batch commit', async () => {
+        const harness = createFirestoreHarness();
+
+        await expect(commitStandardTrackerFinishData({
+            db: harness.db,
+            writeBatch: harness.writeBatch,
+            doc: harness.doc,
+            collection: harness.collection,
+            teamId: 'team-1',
+            gameId: 'game-1',
+            currentUserUid: 'coach-1',
+            gameLog: buildGameLog(500),
+            players: buildRoster(905),
+            playerStatsByPlayerId: {},
+            columns: ['PTS'],
+            finalHome: 12,
+            finalAway: 10,
+            summary: 'Should not save.',
+            opponentStats: {}
+        })).rejects.toThrow("Game has 500 logged events. Finish requires chunked event persistence before it can safely exceed Firestore's 500-write batch limit.");
+
+        expect(harness.batches).toHaveLength(0);
+    });
+
+    it('wires the production track.html submit path through the tested finish helper', () => {
+        const source = readFileSync(new URL('../../track.html', import.meta.url), 'utf8');
+
+        expect(source).toContain("import { commitStandardTrackerFinishData } from './js/track-finish.js?v=1';");
+        expect(source).toContain('await commitStandardTrackerFinishData({');
+    });
+});

--- a/track.html
+++ b/track.html
@@ -280,6 +280,7 @@
         import { checkAuth } from './js/auth.js?v=12';
         import { isAISummaryEnabled, applyAISummaryAvailability } from './js/track-ai-summary.js';
         import { resolveSummaryRecipient } from './js/live-tracker-email.js?v=1';
+        import { commitStandardTrackerFinishData } from './js/track-finish.js?v=1';
         import { getApp } from './js/vendor/firebase-app.js';
         // Note: firebase-ai will be lazy-loaded when AI summary is requested
 
@@ -1214,31 +1215,6 @@ Write the match report now:`;
             document.getElementById('emailPreview').textContent = emailBody;
         }
 
-        function buildNormalizedPlayerStats(playerStats = {}, columns = []) {
-            const playerStatsByLowerKey = {};
-            const normalizedStats = {};
-
-            Object.entries(playerStats).forEach(([statKey, value]) => {
-                playerStatsByLowerKey[String(statKey).toLowerCase()] = Number(value) || 0;
-            });
-
-            columns.forEach((col) => {
-                const key = String(col || '').toLowerCase();
-                normalizedStats[key] = Object.prototype.hasOwnProperty.call(playerStatsByLowerKey, key)
-                    ? playerStatsByLowerKey[key]
-                    : 0;
-            });
-
-            Object.entries(playerStats).forEach(([statKey, value]) => {
-                const normalizedKey = String(statKey).toLowerCase();
-                if (normalizedStats[statKey] === undefined && normalizedStats[normalizedKey] === undefined) {
-                    normalizedStats[statKey] = Number(value) || 0;
-                }
-            });
-
-            return normalizedStats;
-        }
-
         cancelBtn.addEventListener('click', () => {
             modal.classList.add('hidden');
         });
@@ -1251,66 +1227,23 @@ Write the match report now:`;
             const sendEmail = document.getElementById('sendEmailCheckbox').checked;
 
             try {
-                const MAX_PRIMARY_BATCH_WRITES = 500;
-                const MAX_AGGREGATED_STATS_BATCH_WRITES = 450;
-                const primaryBatchWriteCount = gameState.gameLog.length + 1;
-
-                if (primaryBatchWriteCount > MAX_PRIMARY_BATCH_WRITES) {
-                    throw new Error(`Game has ${gameState.gameLog.length} logged events. Finish requires chunked event persistence before it can safely exceed Firestore's ${MAX_PRIMARY_BATCH_WRITES}-write batch limit.`);
-                }
-
-                const primaryBatch = writeBatch(db);
-                const aggregatedStatsWrites = players.map((player) => {
-                    const playerStats = gameState.playerStats[player.id] || {};
-
-                    return {
-                        playerId: player.id,
-                        data: {
-                            playerName: player.name,
-                            playerNumber: player.number,
-                            stats: buildNormalizedPlayerStats(playerStats, currentConfig.columns)
-                        }
-                    };
-                });
-
-                // 1. Keep the primary batch at its historical size: events + final game update.
-                gameState.gameLog.forEach(entry => {
-                    const eventRef = doc(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
-                    primaryBatch.set(eventRef, {
-                        text: entry.text,
-                        gameTime: entry.time,
-                        period: entry.period,
-                        timestamp: entry.timestamp || Date.now(),
-                        type: entry.undoData?.type || 'game_log',
-                        playerId: entry.undoData?.playerId || null,
-                        statKey: entry.undoData?.statKey || null,
-                        value: entry.undoData?.value || null,
-                        isOpponent: entry.undoData?.isOpponent || false,
-                        createdBy: currentUser.uid
-                    });
-                });
-
-                const gameRef = doc(db, `teams/${currentTeamId}/games`, currentGameId);
-                primaryBatch.update(gameRef, {
-                    homeScore: finalHome,
-                    awayScore: finalAway,
-                    summary: summary,
-                    status: 'completed',
+                await commitStandardTrackerFinishData({
+                    db,
+                    writeBatch,
+                    doc,
+                    collection,
+                    teamId: currentTeamId,
+                    gameId: currentGameId,
+                    currentUserUid: currentUser.uid,
+                    gameLog: gameState.gameLog,
+                    players,
+                    playerStatsByPlayerId: gameState.playerStats,
+                    columns: currentConfig.columns,
+                    finalHome,
+                    finalAway,
+                    summary,
                     opponentStats: gameState.opponentStats
                 });
-
-                // 2. Commit the historical finish data first so completion data lands even if a later stats batch fails.
-                await primaryBatch.commit();
-
-                // 3. Chunk roster-wide aggregated stats writes into secondary batches to avoid Firestore's 500-write limit.
-                for (let i = 0; i < aggregatedStatsWrites.length; i += MAX_AGGREGATED_STATS_BATCH_WRITES) {
-                    const statsBatch = writeBatch(db);
-                    aggregatedStatsWrites.slice(i, i + MAX_AGGREGATED_STATS_BATCH_WRITES).forEach(({ playerId, data }) => {
-                        const statsRef = doc(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`, playerId);
-                        statsBatch.set(statsRef, data);
-                    });
-                    await statsBatch.commit();
-                }
 
                 console.log('Game data saved successfully');
 


### PR DESCRIPTION
Closes #615

## Summary
- Extracted the standard tracker finish persistence path into a tested helper used by `track.html`.
- Added CI-backed Vitest coverage for the 499 event boundary with 905 aggregated stat writes chunked as 450, 450, and 5.
- Added a negative boundary test proving 500 events plus the final update rejects before any batch is created or committed.

## Validation
- `npx vitest run tests/unit/track-finish-batch-limit.test.js`
- `git diff --check`