### PR TITLE
Add volleyball live scorekeeping

### DIFF
--- a/docs/pr-notes/runs/630-review-4177749802-20260427T011805Z/architecture.md
+++ b/docs/pr-notes/runs/630-review-4177749802-20260427T011805Z/architecture.md
@@ -1,0 +1,15 @@
+# Architecture
+
+## Decision
+Use stored pre-action volleyball state for undo rather than trying to infer the reverse transition.
+
+## Design
+- Capture `before` state before applying a volleyball outcome: `homeScore`, `awayScore`, `servingTeam`, and `period`.
+- Store `before` and `after` in the log row `undoData` for volleyball entries.
+- Add a volleyball branch in `undoLogEntry()` that restores from `undoData.before`, refreshes UI, syncs the game document, and broadcasts an undo live event.
+- Guard volleyball undo to newest entry only. Older volleyball log deletion is order-dependent because later serve outcomes depend on prior serving team.
+
+## Blast Radius
+- Touches live volleyball scorekeeping only plus pure helper tests.
+- No Firestore schema or rules change.
+- Existing stat undo branch remains unchanged.

--- a/docs/pr-notes/runs/630-review-4177749802-20260427T011805Z/code-plan.md
+++ b/docs/pr-notes/runs/630-review-4177749802-20260427T011805Z/code-plan.md
@@ -1,0 +1,20 @@
+# Code Plan
+
+## Implementation
+- Add pure volleyball undo helpers in `js/live-scorekeeping-volleyball.js`:
+  - `createVolleyballUndoState()`
+  - `restoreVolleyballUndoState()`
+- Import those helpers in `track-live.html` with cache-bust version update.
+- Save `before` and `after` state into volleyball log undo metadata.
+- Add volleyball handling in `undoLogEntry()`:
+  - require newest entry
+  - restore prior scores and serving team
+  - update display
+  - schedule score sync and live data flag
+  - broadcast live undo event with restored score and serving team
+- Track last synced serving team so volleyball serving-only state changes are not skipped.
+
+## Validation Commands
+- `npm test -- tests/unit/live-scorekeeping-volleyball.test.js`
+- `npm test -- tests/unit/track-live-live-events.test.js`
+- `git diff --check`

--- a/docs/pr-notes/runs/630-review-4177749802-20260427T011805Z/qa.md
+++ b/docs/pr-notes/runs/630-review-4177749802-20260427T011805Z/qa.md
@@ -1,0 +1,16 @@
+# QA Plan
+
+## Automated
+- Extend volleyball unit coverage for undo state capture and restore.
+- Validate malformed undo data does not restore.
+
+## Manual Regression Targets
+- Ace then Undo Last: score and server return to previous state.
+- Service error then Undo Last: opponent point and side-out are reversed.
+- Home point while away serves then Undo Last: score and serving team restore.
+- Repeated Undo Last: walks newest-to-oldest without negative scores.
+- Existing generic stat undo still decrements stats and score as before.
+
+## Release Gate
+- `unit-tests` must pass for the touched volleyball test file.
+- CI checks on the PR must remain green after push.

--- a/docs/pr-notes/runs/630-review-4177749802-20260427T011805Z/requirements.md
+++ b/docs/pr-notes/runs/630-review-4177749802-20260427T011805Z/requirements.md
@@ -1,0 +1,14 @@
+# Requirements
+
+## Acceptance Criteria
+- Undo Last for a volleyball point restores the exact prior home score, away score, and serving team.
+- Volleyball UI updates immediately after undo: main score, volleyball panel score, serving indicator, and game log.
+- Volleyball undo must not remove a log row unless rollback data is present and usable.
+- Home point, away point, ace, and service error undo paths all preserve rally scoring and side-out behavior.
+- Repeated volleyball undos move backward newest-to-oldest without negative scores or serve corruption.
+- Non-volleyball stat undo behavior remains unchanged.
+
+## User Impact
+- Coach/stat keeper can correct a bad tap under game pressure.
+- Parent/live viewer receives corrected score state instead of stale scoreboard data.
+- Program manager gets consistent tracker behavior across sports.

--- a/js/live-scorekeeping-volleyball.js
+++ b/js/live-scorekeeping-volleyball.js
@@ -1,0 +1,73 @@
+function normalizeTeam(value) {
+    return value === 'away' ? 'away' : 'home';
+}
+
+function normalizeOutcome(value) {
+    return String(value || '').trim().toLowerCase();
+}
+
+export function isVolleyballSport(value) {
+    return normalizeOutcome(value) === 'volleyball';
+}
+
+export function getVolleyballSetLabels(count = 5) {
+    return Array.from({ length: count }, (_, index) => `Set ${index + 1}`);
+}
+
+export function getDefaultVolleyballState({ homeScore = 0, awayScore = 0, servingTeam = 'home', period = 'Set 1' } = {}) {
+    return {
+        homeScore: Number(homeScore) || 0,
+        awayScore: Number(awayScore) || 0,
+        servingTeam: normalizeTeam(servingTeam),
+        period: String(period || '').trim() || 'Set 1'
+    };
+}
+
+export function applyVolleyballServeOutcome(state = {}, outcome) {
+    const current = getDefaultVolleyballState(state);
+    const normalizedOutcome = normalizeOutcome(outcome);
+    let pointWinner = null;
+    let label = '';
+
+    switch (normalizedOutcome) {
+        case 'ace':
+            pointWinner = current.servingTeam;
+            label = `${current.servingTeam === 'home' ? 'Home' : 'Away'} ace`;
+            break;
+        case 'service_error':
+        case 'service-error':
+        case 'service error':
+            pointWinner = current.servingTeam === 'home' ? 'away' : 'home';
+            label = `${current.servingTeam === 'home' ? 'Home' : 'Away'} service error`;
+            break;
+        case 'home_point':
+        case 'home-point':
+        case 'home point':
+            pointWinner = 'home';
+            label = 'Home in-play point';
+            break;
+        case 'away_point':
+        case 'away-point':
+        case 'away point':
+            pointWinner = 'away';
+            label = 'Away in-play point';
+            break;
+        default:
+            throw new Error(`Unknown volleyball outcome: ${outcome}`);
+    }
+
+    const next = {
+        ...current,
+        homeScore: current.homeScore + (pointWinner === 'home' ? 1 : 0),
+        awayScore: current.awayScore + (pointWinner === 'away' ? 1 : 0),
+        servingTeam: pointWinner
+    };
+
+    return {
+        ...next,
+        pointWinner,
+        sideOut: current.servingTeam !== pointWinner,
+        outcome: normalizedOutcome,
+        description: `${label}: ${next.homeScore}-${next.awayScore}`
+    };
+}

--- a/js/live-scorekeeping-volleyball.js
+++ b/js/live-scorekeeping-volleyball.js
@@ -23,6 +23,21 @@ export function getDefaultVolleyballState({ homeScore = 0, awayScore = 0, servin
     };
 }
 
+export function createVolleyballUndoState(before = {}, after = {}) {
+    return {
+        before: getDefaultVolleyballState(before),
+        after: getDefaultVolleyballState(after)
+    };
+}
+
+export function restoreVolleyballUndoState(undoData = {}) {
+    if (undoData.type !== 'volleyball' || !undoData.before) {
+        return null;
+    }
+
+    return getDefaultVolleyballState(undoData.before);
+}
+
 export function applyVolleyballServeOutcome(state = {}, outcome) {
     const current = getDefaultVolleyballState(state);
     const normalizedOutcome = normalizeOutcome(outcome);

--- a/js/live-sport-config.js
+++ b/js/live-sport-config.js
@@ -11,6 +11,8 @@ function getExplicitPeriodLabels(periods) {
 
 function getSportDefaults(sport) {
   switch (normalizeSport(sport)) {
+    case 'volleyball':
+      return ['Set 1', 'Set 2', 'Set 3', 'Set 4', 'Set 5'];
     case 'soccer':
       return ['H1', 'H2', 'ET1', 'ET2', 'PK'];
     case 'baseball':

--- a/js/live-sport-config.js
+++ b/js/live-sport-config.js
@@ -60,6 +60,8 @@ function getSportDefaults(sport) {
   if (goalProfile) return [...goalProfile.periodLabels];
 
   switch (normalizeSport(sport)) {
+    case 'volleyball':
+      return ['Set 1', 'Set 2', 'Set 3', 'Set 4', 'Set 5'];
     case 'baseball':
     case 'softball':
       return ['T1', 'B1', 'T2', 'B2', 'T3', 'B3', 'T4', 'B4', 'T5', 'B5', 'T6', 'B6', 'T7', 'B7'];

--- a/js/track-live-state.js
+++ b/js/track-live-state.js
@@ -42,6 +42,7 @@ export function buildTrackLiveResetUpdate({
     liveStatus: 'scheduled',
     liveHasData: false,
     liveResetAt,
+    servingTeam: 'home',
     opponent: currentGame?.opponent,
     opponentTeamId: currentGame?.opponentTeamId || '',
     opponentTeamName: currentGame?.opponentTeamName || '',

--- a/tests/unit/live-scorekeeping-volleyball.test.js
+++ b/tests/unit/live-scorekeeping-volleyball.test.js
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import {
+  applyVolleyballServeOutcome,
+  getDefaultVolleyballState,
+  getVolleyballSetLabels,
+  isVolleyballSport
+} from '../../js/live-scorekeeping-volleyball.js';
+
+describe('volleyball live scorekeeping', () => {
+  it('defaults to set one and home serving', () => {
+    expect(isVolleyballSport('Volleyball')).toBe(true);
+    expect(isVolleyballSport('Basketball')).toBe(false);
+    expect(getVolleyballSetLabels()).toEqual(['Set 1', 'Set 2', 'Set 3', 'Set 4', 'Set 5']);
+    expect(getDefaultVolleyballState()).toEqual({
+      homeScore: 0,
+      awayScore: 0,
+      servingTeam: 'home',
+      period: 'Set 1'
+    });
+  });
+
+  it('keeps the serving team on an ace', () => {
+    const result = applyVolleyballServeOutcome({ homeScore: 2, awayScore: 1, servingTeam: 'home' }, 'ace');
+
+    expect(result.homeScore).toBe(3);
+    expect(result.awayScore).toBe(1);
+    expect(result.servingTeam).toBe('home');
+    expect(result.sideOut).toBe(false);
+    expect(result.description).toBe('Home ace: 3-1');
+  });
+
+  it('switches the serving team after a side-out service error', () => {
+    const result = applyVolleyballServeOutcome({ homeScore: 7, awayScore: 4, servingTeam: 'home' }, 'service_error');
+
+    expect(result.homeScore).toBe(7);
+    expect(result.awayScore).toBe(5);
+    expect(result.servingTeam).toBe('away');
+    expect(result.sideOut).toBe(true);
+  });
+
+  it('awards rally points and moves serve to the rally winner', () => {
+    const homePoint = applyVolleyballServeOutcome({ homeScore: 10, awayScore: 10, servingTeam: 'away' }, 'home_point');
+    const awayPoint = applyVolleyballServeOutcome(homePoint, 'away_point');
+
+    expect(homePoint.homeScore).toBe(11);
+    expect(homePoint.awayScore).toBe(10);
+    expect(homePoint.servingTeam).toBe('home');
+    expect(homePoint.sideOut).toBe(true);
+
+    expect(awayPoint.homeScore).toBe(11);
+    expect(awayPoint.awayScore).toBe(11);
+    expect(awayPoint.servingTeam).toBe('away');
+    expect(awayPoint.sideOut).toBe(true);
+  });
+});

--- a/tests/unit/live-scorekeeping-volleyball.test.js
+++ b/tests/unit/live-scorekeeping-volleyball.test.js
@@ -1,9 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
   applyVolleyballServeOutcome,
+  createVolleyballUndoState,
   getDefaultVolleyballState,
   getVolleyballSetLabels,
-  isVolleyballSport
+  isVolleyballSport,
+  restoreVolleyballUndoState
 } from '../../js/live-scorekeeping-volleyball.js';
 
 describe('volleyball live scorekeeping', () => {
@@ -51,5 +53,25 @@ describe('volleyball live scorekeeping', () => {
     expect(awayPoint.awayScore).toBe(11);
     expect(awayPoint.servingTeam).toBe('away');
     expect(awayPoint.sideOut).toBe(true);
+  });
+
+  it('captures and restores previous volleyball state for undo', () => {
+    const before = { homeScore: 7, awayScore: 4, servingTeam: 'home', period: 'Set 2' };
+    const after = applyVolleyballServeOutcome(before, 'service_error');
+    const undoState = createVolleyballUndoState(before, after);
+
+    expect(undoState.before).toEqual(before);
+    expect(undoState.after).toEqual({
+      homeScore: 7,
+      awayScore: 5,
+      servingTeam: 'away',
+      period: 'Set 2'
+    });
+    expect(restoreVolleyballUndoState({ type: 'volleyball', ...undoState })).toEqual(before);
+  });
+
+  it('does not restore malformed volleyball undo data', () => {
+    expect(restoreVolleyballUndoState({ type: 'volleyball' })).toBeNull();
+    expect(restoreVolleyballUndoState({ type: 'stat', before: { homeScore: 1 } })).toBeNull();
   });
 });

--- a/tests/unit/live-sport-config.test.js
+++ b/tests/unit/live-sport-config.test.js
@@ -2,9 +2,16 @@ import { describe, it, expect } from 'vitest';
 import { getDefaultLivePeriod, getSportPeriodLabels } from '../../js/live-sport-config.js';
 
 describe('live sport config helpers', () => {
-  it('returns basketball defaults when sport is missing', () => {
+  it('returns basketball defaults when sport is missing or basketball', () => {
     expect(getDefaultLivePeriod()).toBe('Q1');
     expect(getSportPeriodLabels()).toEqual(['Q1', 'Q2', 'Q3', 'Q4', 'OT']);
+    expect(getDefaultLivePeriod({ sport: 'Basketball' })).toBe('Q1');
+    expect(getSportPeriodLabels({ sport: 'Basketball' })).toEqual(['Q1', 'Q2', 'Q3', 'Q4', 'OT']);
+  });
+
+  it('returns volleyball set labels by sport', () => {
+    expect(getDefaultLivePeriod({ sport: 'Volleyball' })).toBe('Set 1');
+    expect(getSportPeriodLabels({ sport: 'Volleyball' })).toEqual(['Set 1', 'Set 2', 'Set 3', 'Set 4', 'Set 5']);
   });
 
   it('returns soccer half labels by sport', () => {

--- a/tests/unit/live-sport-config.test.js
+++ b/tests/unit/live-sport-config.test.js
@@ -2,9 +2,16 @@ import { describe, it, expect } from 'vitest';
 import { getDefaultLivePeriod, getGoalSportProfile, getSportPeriodLabels, isGoalSport } from '../../js/live-sport-config.js';
 
 describe('live sport config helpers', () => {
-  it('returns basketball defaults when sport is missing', () => {
+  it('returns basketball defaults when sport is missing or basketball', () => {
     expect(getDefaultLivePeriod()).toBe('Q1');
     expect(getSportPeriodLabels()).toEqual(['Q1', 'Q2', 'Q3', 'Q4', 'OT']);
+    expect(getDefaultLivePeriod({ sport: 'Basketball' })).toBe('Q1');
+    expect(getSportPeriodLabels({ sport: 'Basketball' })).toEqual(['Q1', 'Q2', 'Q3', 'Q4', 'OT']);
+  });
+
+  it('returns volleyball set labels by sport', () => {
+    expect(getDefaultLivePeriod({ sport: 'Volleyball' })).toBe('Set 1');
+    expect(getSportPeriodLabels({ sport: 'Volleyball' })).toEqual(['Set 1', 'Set 2', 'Set 3', 'Set 4', 'Set 5']);
   });
 
   it('returns soccer half labels by sport', () => {

--- a/tests/unit/track-live-state.test.js
+++ b/tests/unit/track-live-state.test.js
@@ -56,6 +56,7 @@ describe('track live state helpers', () => {
       liveStatus: 'scheduled',
       liveHasData: false,
       liveResetAt: 1700000000000,
+      servingTeam: 'home',
       opponent: 'Lions',
       opponentTeamId: 'opp-team-1',
       opponentTeamName: 'Lions Academy',

--- a/track-live.html
+++ b/track-live.html
@@ -522,7 +522,7 @@
         import { createFieldState, setPlayerFieldStatus, startFieldClock, pauseFieldClock, getPlayerFieldElapsedMs, getLiveLineup } from './js/live-tracker-field-status.js?v=1';
         import { summarizePersistedTrackingState, buildTrackLiveResetUpdate, runTrackLiveResetPersistence } from './js/track-live-state.js?v=1';
         import { getDefaultLivePeriod, getSportPeriodLabels } from './js/live-sport-config.js?v=1';
-        import { applyVolleyballServeOutcome, isVolleyballSport } from './js/live-scorekeeping-volleyball.js?v=1';
+        import { applyVolleyballServeOutcome, createVolleyballUndoState, restoreVolleyballUndoState, isVolleyballSport } from './js/live-scorekeeping-volleyball.js?v=2';
         import { checkAuth } from './js/auth.js?v=12';
         import { getApp } from './js/vendor/firebase-app.js';
         import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './js/live-tracker-notes.js?v=1';
@@ -566,6 +566,7 @@
             scoreSyncTimeout: null,
             lastSyncedHome: null,
             lastSyncedAway: null,
+            lastSyncedServingTeam: null,
             playerTimeouts: new Map(),
             opponentTimeout: null,
             liveFlagTimeout: null
@@ -847,13 +848,15 @@
             if (liveSync.scoreSyncTimeout) return;
             liveSync.scoreSyncTimeout = setTimeout(async () => {
                 liveSync.scoreSyncTimeout = null;
-                if (homeScore === liveSync.lastSyncedHome && awayScore === liveSync.lastSyncedAway) return;
+                const servingTeamChanged = isVolleyballGame() && gameState.servingTeam !== liveSync.lastSyncedServingTeam;
+                if (homeScore === liveSync.lastSyncedHome && awayScore === liveSync.lastSyncedAway && !servingTeamChanged) return;
                 try {
                     const update = { homeScore, awayScore };
                     if (isVolleyballGame()) update.servingTeam = gameState.servingTeam;
                     await updateGame(currentTeamId, currentGameId, update);
                     liveSync.lastSyncedHome = homeScore;
                     liveSync.lastSyncedAway = awayScore;
+                    liveSync.lastSyncedServingTeam = gameState.servingTeam;
                 } catch (error) {
                     console.warn('Failed to sync live scores:', error);
                 }
@@ -959,6 +962,7 @@
             liveSync.playerTimeouts.clear();
             liveSync.lastSyncedHome = null;
             liveSync.lastSyncedAway = null;
+            liveSync.lastSyncedServingTeam = null;
         }
 
         async function syncClockToGameDoc() {
@@ -1187,12 +1191,14 @@
                 return;
             }
 
-            const result = applyVolleyballServeOutcome({
+            const before = {
                 homeScore,
                 awayScore,
                 servingTeam: gameState.servingTeam,
                 period: gameState.currentPeriod
-            }, outcome);
+            };
+            const result = applyVolleyballServeOutcome(before, outcome);
+            const undoState = createVolleyballUndoState(before, result);
 
             homeScore = result.homeScore;
             awayScore = result.awayScore;
@@ -1204,7 +1210,9 @@
                 outcome: result.outcome,
                 pointWinner: result.pointWinner,
                 sideOut: result.sideOut,
-                servingTeam: result.servingTeam
+                servingTeam: result.servingTeam,
+                before: undoState.before,
+                after: undoState.after
             });
             broadcastLiveEvent(currentTeamId, currentGameId, {
                 type: 'volleyball',
@@ -1970,6 +1978,35 @@
                     isOpponent,
                     description: `Undo stat: ${entry.text}`
                 });
+            } else if (undoData && undoData.type === 'volleyball') {
+                if (index !== 0) {
+                    alert('Undo volleyball entries from newest to oldest so score and serve order stay accurate.');
+                    return;
+                }
+                const previousState = restoreVolleyballUndoState(undoData);
+                if (!previousState) {
+                    console.warn('Cannot undo volleyball entry without previous state:', entry);
+                    alert('This volleyball entry cannot be undone because its prior score state is missing.');
+                    return;
+                }
+                homeScore = Math.max(0, previousState.homeScore);
+                awayScore = Math.max(0, previousState.awayScore);
+                gameState.servingTeam = previousState.servingTeam;
+                updateScoreDisplay();
+                scheduleScoreSync();
+                scheduleLiveHasData();
+
+                broadcastLiveEvent(currentTeamId, currentGameId, {
+                    type: 'undo',
+                    sport: 'volleyball',
+                    period: gameState.currentPeriod,
+                    gameClockMs: gameState.elapsed,
+                    homeScore,
+                    awayScore,
+                    servingTeam: gameState.servingTeam,
+                    description: `Undo volleyball: ${entry.text}`,
+                    createdBy: currentUser?.uid || null
+                }).catch(console.warn);
             }
 
             gameState.gameLog.splice(index, 1);

--- a/track-live.html
+++ b/track-live.html
@@ -320,8 +320,34 @@
             </div>
         </div>
 
+        <!-- Volleyball Scorekeeping -->
+        <div id="volleyballPanel" class="track-panel p-3 mb-3 hidden">
+            <div class="flex items-center justify-between gap-3 mb-3">
+                <div>
+                    <div class="text-[11px] uppercase tracking-wide text-sand/60">Current set</div>
+                    <div id="volleyball-set-label" class="text-lg font-bold text-teal">Set 1</div>
+                </div>
+                <div class="text-center">
+                    <div class="text-[11px] uppercase tracking-wide text-sand/60">Set score</div>
+                    <div class="text-2xl font-display font-bold"><span id="volleyball-home-score">0</span> - <span id="volleyball-away-score">0</span></div>
+                </div>
+                <div class="text-right">
+                    <div class="text-[11px] uppercase tracking-wide text-sand/60">Serving</div>
+                    <div id="volleyball-serving-team" class="text-lg font-bold text-gold">Home</div>
+                </div>
+            </div>
+            <div class="grid grid-cols-2 gap-2 mb-3">
+                <button class="volleyball-outcome-btn bg-teal text-ink rounded px-3 py-2 text-sm font-bold" data-outcome="home_point">Home point</button>
+                <button class="volleyball-outcome-btn bg-coral text-white rounded px-3 py-2 text-sm font-bold" data-outcome="away_point">Away point</button>
+            </div>
+            <div class="grid grid-cols-2 gap-2">
+                <button class="volleyball-outcome-btn bg-gold text-ink rounded px-3 py-2 text-sm font-bold" data-outcome="ace">Ace</button>
+                <button class="volleyball-outcome-btn bg-slate text-sand rounded px-3 py-2 text-sm font-bold border border-coral/40" data-outcome="service_error">Service error</button>
+            </div>
+        </div>
+
         <!-- Team Stats Table -->
-        <div class="track-panel overflow-hidden mb-3">
+        <div id="teamStatsPanel" class="track-panel overflow-hidden mb-3">
             <div class="track-panel-title p-3 font-bold text-center">Team Stats</div>
             <div class="overflow-x-auto">
                 <table class="w-full text-center text-xs" id="statsTable">
@@ -339,7 +365,7 @@
         </div>
 
         <!-- Opponent Stats Table -->
-        <div class="track-panel overflow-hidden mb-3">
+        <div id="opponentStatsPanel" class="track-panel overflow-hidden mb-3">
             <div class="track-panel-title away p-3 font-bold text-center flex justify-between items-center">
                 <span>Opponent Stats</span>
                 <button id="addOpponentBtn" class="bg-coral text-white px-2 py-1 rounded text-xs hover:bg-coral/80">Add
@@ -496,6 +522,7 @@
         import { createFieldState, setPlayerFieldStatus, startFieldClock, pauseFieldClock, getPlayerFieldElapsedMs, getLiveLineup } from './js/live-tracker-field-status.js?v=1';
         import { summarizePersistedTrackingState, buildTrackLiveResetUpdate, runTrackLiveResetPersistence } from './js/track-live-state.js?v=1';
         import { getDefaultLivePeriod, getSportPeriodLabels } from './js/live-sport-config.js?v=1';
+        import { applyVolleyballServeOutcome, isVolleyballSport } from './js/live-scorekeeping-volleyball.js?v=1';
         import { checkAuth } from './js/auth.js?v=12';
         import { getApp } from './js/vendor/firebase-app.js';
         import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './js/live-tracker-notes.js?v=1';
@@ -553,8 +580,18 @@
             playerStats: {}, // In-memory player stats (replaces real-time DB writes)
             opponentStats: {},
             currentPeriod: getDefaultLivePeriod(),
-            playerFieldStatus: {}
+            playerFieldStatus: {},
+            servingTeam: 'home'
         };
+
+        function isVolleyballGame() {
+            return isVolleyballSport(currentGame?.sport || currentTeam?.sport || currentConfig?.baseType);
+        }
+
+        function getTeamServingLabel(team) {
+            if (team === 'away') return resolveOpponentDisplayName(currentGame);
+            return currentTeam?.name || 'Home';
+        }
 
         const chatEls = {
             panel: document.getElementById('chat-panel'),
@@ -676,6 +713,7 @@
                 document.getElementById('game-meta').textContent = escapeHtml(team.name);
                 homeScore = game.homeScore || 0;
                 awayScore = game.awayScore || 0;
+                gameState.servingTeam = game.servingTeam === 'away' ? 'away' : 'home';
                 updateScoreDisplay();
                 gameState.playerFieldStatus = createFieldState(players);
                 const existingOnField = Array.isArray(game.liveLineup?.onCourt) ? game.liveLineup.onCourt : [];
@@ -700,14 +738,20 @@
                     };
                 }
 
-                const periodLabels = getSportPeriodLabels({ team: currentTeam, config: currentConfig }).slice(0, 5);
+                const volleyballMode = isVolleyballGame();
+                document.getElementById('volleyballPanel')?.classList.toggle('hidden', !volleyballMode);
+                document.getElementById('teamStatsPanel')?.classList.toggle('hidden', volleyballMode);
+                document.getElementById('opponentStatsPanel')?.classList.toggle('hidden', volleyballMode);
+
+                const periodLabels = getSportPeriodLabels({ game: currentGame, team: currentTeam, config: currentConfig }).slice(0, 5);
                 const periodButtons = document.querySelectorAll('.period-btn');
                 periodButtons.forEach((btn, index) => {
                     const label = periodLabels[index] || periodLabels[0];
                     btn.dataset.period = label;
                     btn.textContent = label;
                 });
-                gameState.currentPeriod = periodLabels[0] || getDefaultLivePeriod({ team: currentTeam, config: currentConfig });
+                gameState.currentPeriod = periodLabels[0] || getDefaultLivePeriod({ game: currentGame, team: currentTeam, config: currentConfig });
+                updateVolleyballDisplay();
 
                 // Load existing aggregated stats from Firestore into gameState
                 const statsSnapshot = await getDocs(collection(db, `teams/${teamId}/games/${gameId}/aggregatedStats`));
@@ -761,6 +805,7 @@
 
                         // Update state
                         gameState.currentPeriod = btn.dataset.period;
+                        updateVolleyballDisplay();
                         addLogEntry(`Period changed to ${gameState.currentPeriod}`);
                     });
                 });
@@ -774,6 +819,16 @@
         function updateScoreDisplay() {
             document.getElementById('home-score').textContent = homeScore;
             document.getElementById('away-score').textContent = awayScore;
+            updateVolleyballDisplay();
+        }
+
+        function updateVolleyballDisplay() {
+            const panel = document.getElementById('volleyballPanel');
+            if (!panel || panel.classList.contains('hidden')) return;
+            document.getElementById('volleyball-set-label').textContent = gameState.currentPeriod || 'Set 1';
+            document.getElementById('volleyball-home-score').textContent = homeScore;
+            document.getElementById('volleyball-away-score').textContent = awayScore;
+            document.getElementById('volleyball-serving-team').textContent = getTeamServingLabel(gameState.servingTeam);
         }
 
         function formatFieldTime(ms) {
@@ -794,7 +849,9 @@
                 liveSync.scoreSyncTimeout = null;
                 if (homeScore === liveSync.lastSyncedHome && awayScore === liveSync.lastSyncedAway) return;
                 try {
-                    await updateGame(currentTeamId, currentGameId, { homeScore, awayScore });
+                    const update = { homeScore, awayScore };
+                    if (isVolleyballGame()) update.servingTeam = gameState.servingTeam;
+                    await updateGame(currentTeamId, currentGameId, update);
                     liveSync.lastSyncedHome = homeScore;
                     liveSync.lastSyncedAway = awayScore;
                 } catch (error) {
@@ -1124,6 +1181,53 @@
             scheduleLiveHasData();
         };
 
+        async function recordVolleyballOutcome(outcome) {
+            if (!gameState.isRunning && gameState.elapsed === 0) {
+                alert('Please start the game timer before recording points.');
+                return;
+            }
+
+            const result = applyVolleyballServeOutcome({
+                homeScore,
+                awayScore,
+                servingTeam: gameState.servingTeam,
+                period: gameState.currentPeriod
+            }, outcome);
+
+            homeScore = result.homeScore;
+            awayScore = result.awayScore;
+            gameState.servingTeam = result.servingTeam;
+            updateScoreDisplay();
+            scheduleScoreSync();
+            await addLogEntry(result.description, {
+                type: 'volleyball',
+                outcome: result.outcome,
+                pointWinner: result.pointWinner,
+                sideOut: result.sideOut,
+                servingTeam: result.servingTeam
+            });
+            broadcastLiveEvent(currentTeamId, currentGameId, {
+                type: 'volleyball',
+                period: gameState.currentPeriod,
+                gameClockMs: gameState.elapsed,
+                homeScore,
+                awayScore,
+                servingTeam: gameState.servingTeam,
+                outcome: result.outcome,
+                pointWinner: result.pointWinner,
+                sideOut: result.sideOut,
+                description: result.description,
+                createdBy: currentUser?.uid || null
+            }).catch(console.warn);
+            scheduleLiveHasData();
+        }
+
+        document.querySelectorAll('.volleyball-outcome-btn').forEach((button) => {
+            button.addEventListener('click', () => {
+                recordVolleyballOutcome(button.dataset.outcome).catch(console.warn);
+            });
+        });
+
 
         function setVoiceNoteButtonLabel(isListening) {
             const btn = document.getElementById('voice-note-btn');
@@ -1448,6 +1552,7 @@
                             gameState.playerFieldStatus = createFieldState(players);
                             homeScore = 0;
                             awayScore = 0;
+                            gameState.servingTeam = 'home';
                             opponentPlayers.forEach((opp) => {
                                 const existing = gameState.opponentStats[opp.id] || {};
                                 gameState.opponentStats[opp.id] = {
@@ -1488,6 +1593,7 @@
                                     currentGame.liveHasData = false;
                                     currentGame.homeScore = 0;
                                     currentGame.awayScore = 0;
+                                    currentGame.servingTeam = 'home';
                                     currentGame.opponentStats = {};
                                 },
                                 cleanupPersistedState: async () => {
@@ -1589,6 +1695,7 @@
                 });
                 homeScore = 0;
                 awayScore = 0;
+                gameState.servingTeam = 'home';
 
                 document.getElementById('startBtn').disabled = false;
                 document.getElementById('stopBtn').disabled = true;
@@ -1611,6 +1718,7 @@
                     currentGame.liveHasData = false;
                     currentGame.homeScore = 0;
                     currentGame.awayScore = 0;
+                    currentGame.servingTeam = 'home';
                     currentGame.opponentStats = {};
                 }
                 updateScoreDisplay();
@@ -1650,6 +1758,7 @@
                             currentGame.liveStatus = 'scheduled';
                             currentGame.homeScore = 0;
                             currentGame.awayScore = 0;
+                            currentGame.servingTeam = 'home';
                             currentGame.opponentStats = gameState.opponentStats;
                         }
                         await setGameLiveStatus(currentTeamId, currentGameId, 'scheduled').catch(console.warn);

--- a/track-live.html
+++ b/track-live.html
@@ -549,7 +549,7 @@
         import { summarizePersistedTrackingState, buildTrackLiveResetUpdate, runTrackLiveResetPersistence } from './js/track-live-state.js?v=1';
         import { getDefaultLivePeriod, getGoalSportProfile, getSportPeriodLabels } from './js/live-sport-config.js?v=2';
         import { applyGoalSportScore, buildGoalSportEvent } from './js/live-scorekeeping-goal-sports.js?v=1';
-        import { applyVolleyballServeOutcome, isVolleyballSport } from './js/live-scorekeeping-volleyball.js?v=1';
+        import { applyVolleyballServeOutcome, createVolleyballUndoState, restoreVolleyballUndoState, isVolleyballSport } from './js/live-scorekeeping-volleyball.js?v=2';
         import { checkAuth } from './js/auth.js?v=13';
         import { getApp } from './js/vendor/firebase-app.js';
         import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './js/live-tracker-notes.js?v=1';
@@ -594,6 +594,7 @@
             scoreSyncTimeout: null,
             lastSyncedHome: null,
             lastSyncedAway: null,
+            lastSyncedServingTeam: null,
             playerTimeouts: new Map(),
             opponentTimeout: null,
             liveFlagTimeout: null
@@ -953,13 +954,15 @@
             if (liveSync.scoreSyncTimeout) return;
             liveSync.scoreSyncTimeout = setTimeout(async () => {
                 liveSync.scoreSyncTimeout = null;
-                if (homeScore === liveSync.lastSyncedHome && awayScore === liveSync.lastSyncedAway) return;
+                const servingTeamChanged = isVolleyballGame() && gameState.servingTeam !== liveSync.lastSyncedServingTeam;
+                if (homeScore === liveSync.lastSyncedHome && awayScore === liveSync.lastSyncedAway && !servingTeamChanged) return;
                 try {
                     const update = { homeScore, awayScore };
                     if (isVolleyballGame()) update.servingTeam = gameState.servingTeam;
                     await updateGame(currentTeamId, currentGameId, update);
                     liveSync.lastSyncedHome = homeScore;
                     liveSync.lastSyncedAway = awayScore;
+                    liveSync.lastSyncedServingTeam = gameState.servingTeam;
                 } catch (error) {
                     console.warn('Failed to sync live scores:', error);
                 }
@@ -1065,6 +1068,7 @@
             liveSync.playerTimeouts.clear();
             liveSync.lastSyncedHome = null;
             liveSync.lastSyncedAway = null;
+            liveSync.lastSyncedServingTeam = null;
         }
 
         async function syncClockToGameDoc() {
@@ -1293,12 +1297,14 @@
                 return;
             }
 
-            const result = applyVolleyballServeOutcome({
+            const before = {
                 homeScore,
                 awayScore,
                 servingTeam: gameState.servingTeam,
                 period: gameState.currentPeriod
-            }, outcome);
+            };
+            const result = applyVolleyballServeOutcome(before, outcome);
+            const undoState = createVolleyballUndoState(before, result);
 
             homeScore = result.homeScore;
             awayScore = result.awayScore;
@@ -1310,7 +1316,9 @@
                 outcome: result.outcome,
                 pointWinner: result.pointWinner,
                 sideOut: result.sideOut,
-                servingTeam: result.servingTeam
+                servingTeam: result.servingTeam,
+                before: undoState.before,
+                after: undoState.after
             });
             broadcastLiveEvent(currentTeamId, currentGameId, {
                 type: 'volleyball',
@@ -2076,6 +2084,35 @@
                     isOpponent,
                     description: `Undo stat: ${entry.text}`
                 });
+            } else if (undoData && undoData.type === 'volleyball') {
+                if (index !== 0) {
+                    alert('Undo volleyball entries from newest to oldest so score and serve order stay accurate.');
+                    return;
+                }
+                const previousState = restoreVolleyballUndoState(undoData);
+                if (!previousState) {
+                    console.warn('Cannot undo volleyball entry without previous state:', entry);
+                    alert('This volleyball entry cannot be undone because its prior score state is missing.');
+                    return;
+                }
+                homeScore = Math.max(0, previousState.homeScore);
+                awayScore = Math.max(0, previousState.awayScore);
+                gameState.servingTeam = previousState.servingTeam;
+                updateScoreDisplay();
+                scheduleScoreSync();
+                scheduleLiveHasData();
+
+                broadcastLiveEvent(currentTeamId, currentGameId, {
+                    type: 'undo',
+                    sport: 'volleyball',
+                    period: gameState.currentPeriod,
+                    gameClockMs: gameState.elapsed,
+                    homeScore,
+                    awayScore,
+                    servingTeam: gameState.servingTeam,
+                    description: `Undo volleyball: ${entry.text}`,
+                    createdBy: currentUser?.uid || null
+                }).catch(console.warn);
             }
 
             if (undoData && undoData.type === 'goal') {

--- a/track-live.html
+++ b/track-live.html
@@ -344,9 +344,35 @@
             </div>
         </div>
 
+        <!-- Volleyball Scorekeeping -->
+        <div id="volleyballPanel" class="track-panel p-3 mb-3 hidden">
+            <div class="flex items-center justify-between gap-3 mb-3">
+                <div>
+                    <div class="text-[11px] uppercase tracking-wide text-sand/60">Current set</div>
+                    <div id="volleyball-set-label" class="text-lg font-bold text-teal">Set 1</div>
+                </div>
+                <div class="text-center">
+                    <div class="text-[11px] uppercase tracking-wide text-sand/60">Set score</div>
+                    <div class="text-2xl font-display font-bold"><span id="volleyball-home-score">0</span> - <span id="volleyball-away-score">0</span></div>
+                </div>
+                <div class="text-right">
+                    <div class="text-[11px] uppercase tracking-wide text-sand/60">Serving</div>
+                    <div id="volleyball-serving-team" class="text-lg font-bold text-gold">Home</div>
+                </div>
+            </div>
+            <div class="grid grid-cols-2 gap-2 mb-3">
+                <button class="volleyball-outcome-btn bg-teal text-ink rounded px-3 py-2 text-sm font-bold" data-outcome="home_point">Home point</button>
+                <button class="volleyball-outcome-btn bg-coral text-white rounded px-3 py-2 text-sm font-bold" data-outcome="away_point">Away point</button>
+            </div>
+            <div class="grid grid-cols-2 gap-2">
+                <button class="volleyball-outcome-btn bg-gold text-ink rounded px-3 py-2 text-sm font-bold" data-outcome="ace">Ace</button>
+                <button class="volleyball-outcome-btn bg-slate text-sand rounded px-3 py-2 text-sm font-bold border border-coral/40" data-outcome="service_error">Service error</button>
+            </div>
+        </div>
+
         <div id="generic-stat-tracking">
             <!-- Team Stats Table -->
-            <div class="track-panel overflow-hidden mb-3">
+            <div id="teamStatsPanel" class="track-panel overflow-hidden mb-3">
                 <div class="track-panel-title p-3 font-bold text-center">Team Stats</div>
                 <div class="overflow-x-auto">
                     <table class="w-full text-center text-xs" id="statsTable">
@@ -364,7 +390,7 @@
             </div>
 
             <!-- Opponent Stats Table -->
-            <div class="track-panel overflow-hidden mb-3">
+            <div id="opponentStatsPanel" class="track-panel overflow-hidden mb-3">
                 <div class="track-panel-title away p-3 font-bold text-center flex justify-between items-center">
                     <span>Opponent Stats</span>
                     <button id="addOpponentBtn" class="bg-coral text-white px-2 py-1 rounded text-xs hover:bg-coral/80">Add
@@ -523,6 +549,7 @@
         import { summarizePersistedTrackingState, buildTrackLiveResetUpdate, runTrackLiveResetPersistence } from './js/track-live-state.js?v=1';
         import { getDefaultLivePeriod, getGoalSportProfile, getSportPeriodLabels } from './js/live-sport-config.js?v=2';
         import { applyGoalSportScore, buildGoalSportEvent } from './js/live-scorekeeping-goal-sports.js?v=1';
+        import { applyVolleyballServeOutcome, isVolleyballSport } from './js/live-scorekeeping-volleyball.js?v=1';
         import { checkAuth } from './js/auth.js?v=13';
         import { getApp } from './js/vendor/firebase-app.js';
         import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './js/live-tracker-notes.js?v=1';
@@ -581,8 +608,18 @@
             playerStats: {}, // In-memory player stats (replaces real-time DB writes)
             opponentStats: {},
             currentPeriod: getDefaultLivePeriod(),
-            playerFieldStatus: {}
+            playerFieldStatus: {},
+            servingTeam: 'home'
         };
+
+        function isVolleyballGame() {
+            return isVolleyballSport(currentGame?.sport || currentTeam?.sport || currentConfig?.baseType);
+        }
+
+        function getTeamServingLabel(team) {
+            if (team === 'away') return resolveOpponentDisplayName(currentGame);
+            return currentTeam?.name || 'Home';
+        }
 
         const chatEls = {
             panel: document.getElementById('chat-panel'),
@@ -704,6 +741,7 @@
                 document.getElementById('game-meta').textContent = escapeHtml(team.name);
                 homeScore = game.homeScore || 0;
                 awayScore = game.awayScore || 0;
+                gameState.servingTeam = game.servingTeam === 'away' ? 'away' : 'home';
                 updateScoreDisplay();
                 gameState.playerFieldStatus = createFieldState(players);
                 const existingOnField = Array.isArray(game.liveLineup?.onCourt) ? game.liveLineup.onCourt : [];
@@ -732,15 +770,21 @@
                     ? null
                     : getGoalSportProfile({ game: currentGame, team: currentTeam, config: currentConfig });
 
-                const periodLabels = getSportPeriodLabels({ team: currentTeam, config: currentConfig }).slice(0, 5);
+                const volleyballMode = isVolleyballGame();
+                document.getElementById('volleyballPanel')?.classList.toggle('hidden', !volleyballMode);
+                document.getElementById('teamStatsPanel')?.classList.toggle('hidden', volleyballMode);
+                document.getElementById('opponentStatsPanel')?.classList.toggle('hidden', volleyballMode);
+
+                const periodLabels = getSportPeriodLabels({ game: currentGame, team: currentTeam, config: currentConfig }).slice(0, 5);
                 const periodButtons = document.querySelectorAll('.period-btn');
                 periodButtons.forEach((btn, index) => {
                     const label = periodLabels[index] || periodLabels[0];
                     btn.dataset.period = label;
                     btn.textContent = label;
                 });
-                gameState.currentPeriod = periodLabels[0] || getDefaultLivePeriod({ team: currentTeam, config: currentConfig });
+                gameState.currentPeriod = periodLabels[0] || getDefaultLivePeriod({ game: currentGame, team: currentTeam, config: currentConfig });
                 configureGoalSportControls();
+                updateVolleyballDisplay();
 
                 // Load existing aggregated stats from Firestore into gameState
                 const statsSnapshot = await getDocs(collection(db, `teams/${teamId}/games/${gameId}/aggregatedStats`));
@@ -794,6 +838,7 @@
 
                         // Update state
                         gameState.currentPeriod = btn.dataset.period;
+                        updateVolleyballDisplay();
                         addLogEntry(`Period changed to ${gameState.currentPeriod}`);
                     });
                 });
@@ -807,6 +852,16 @@
         function updateScoreDisplay() {
             document.getElementById('home-score').textContent = homeScore;
             document.getElementById('away-score').textContent = awayScore;
+            updateVolleyballDisplay();
+        }
+
+        function updateVolleyballDisplay() {
+            const panel = document.getElementById('volleyballPanel');
+            if (!panel || panel.classList.contains('hidden')) return;
+            document.getElementById('volleyball-set-label').textContent = gameState.currentPeriod || 'Set 1';
+            document.getElementById('volleyball-home-score').textContent = homeScore;
+            document.getElementById('volleyball-away-score').textContent = awayScore;
+            document.getElementById('volleyball-serving-team').textContent = getTeamServingLabel(gameState.servingTeam);
         }
 
         function configureGoalSportControls() {
@@ -900,7 +955,9 @@
                 liveSync.scoreSyncTimeout = null;
                 if (homeScore === liveSync.lastSyncedHome && awayScore === liveSync.lastSyncedAway) return;
                 try {
-                    await updateGame(currentTeamId, currentGameId, { homeScore, awayScore });
+                    const update = { homeScore, awayScore };
+                    if (isVolleyballGame()) update.servingTeam = gameState.servingTeam;
+                    await updateGame(currentTeamId, currentGameId, update);
                     liveSync.lastSyncedHome = homeScore;
                     liveSync.lastSyncedAway = awayScore;
                 } catch (error) {
@@ -1230,6 +1287,53 @@
             scheduleLiveHasData();
         };
 
+        async function recordVolleyballOutcome(outcome) {
+            if (!gameState.isRunning && gameState.elapsed === 0) {
+                alert('Please start the game timer before recording points.');
+                return;
+            }
+
+            const result = applyVolleyballServeOutcome({
+                homeScore,
+                awayScore,
+                servingTeam: gameState.servingTeam,
+                period: gameState.currentPeriod
+            }, outcome);
+
+            homeScore = result.homeScore;
+            awayScore = result.awayScore;
+            gameState.servingTeam = result.servingTeam;
+            updateScoreDisplay();
+            scheduleScoreSync();
+            await addLogEntry(result.description, {
+                type: 'volleyball',
+                outcome: result.outcome,
+                pointWinner: result.pointWinner,
+                sideOut: result.sideOut,
+                servingTeam: result.servingTeam
+            });
+            broadcastLiveEvent(currentTeamId, currentGameId, {
+                type: 'volleyball',
+                period: gameState.currentPeriod,
+                gameClockMs: gameState.elapsed,
+                homeScore,
+                awayScore,
+                servingTeam: gameState.servingTeam,
+                outcome: result.outcome,
+                pointWinner: result.pointWinner,
+                sideOut: result.sideOut,
+                description: result.description,
+                createdBy: currentUser?.uid || null
+            }).catch(console.warn);
+            scheduleLiveHasData();
+        }
+
+        document.querySelectorAll('.volleyball-outcome-btn').forEach((button) => {
+            button.addEventListener('click', () => {
+                recordVolleyballOutcome(button.dataset.outcome).catch(console.warn);
+            });
+        });
+
 
         function setVoiceNoteButtonLabel(isListening) {
             const btn = document.getElementById('voice-note-btn');
@@ -1554,6 +1658,7 @@
                             gameState.playerFieldStatus = createFieldState(players);
                             homeScore = 0;
                             awayScore = 0;
+                            gameState.servingTeam = 'home';
                             opponentPlayers.forEach((opp) => {
                                 const existing = gameState.opponentStats[opp.id] || {};
                                 gameState.opponentStats[opp.id] = {
@@ -1594,6 +1699,7 @@
                                     currentGame.liveHasData = false;
                                     currentGame.homeScore = 0;
                                     currentGame.awayScore = 0;
+                                    currentGame.servingTeam = 'home';
                                     currentGame.opponentStats = {};
                                 },
                                 cleanupPersistedState: async () => {
@@ -1695,6 +1801,7 @@
                 });
                 homeScore = 0;
                 awayScore = 0;
+                gameState.servingTeam = 'home';
 
                 document.getElementById('startBtn').disabled = false;
                 document.getElementById('stopBtn').disabled = true;
@@ -1717,6 +1824,7 @@
                     currentGame.liveHasData = false;
                     currentGame.homeScore = 0;
                     currentGame.awayScore = 0;
+                    currentGame.servingTeam = 'home';
                     currentGame.opponentStats = {};
                 }
                 updateScoreDisplay();
@@ -1756,6 +1864,7 @@
                             currentGame.liveStatus = 'scheduled';
                             currentGame.homeScore = 0;
                             currentGame.awayScore = 0;
+                            currentGame.servingTeam = 'home';
                             currentGame.opponentStats = gameState.opponentStats;
                         }
                         await setGameLiveStatus(currentTeamId, currentGameId, 'scheduled').catch(console.warn);


### PR DESCRIPTION
Closes #620

## Summary
- Added volleyball set defaults and a volleyball-specific scorekeeping panel on `track-live.html`.
- Added rally point and serve outcome handling for ace, service error, home point, and away point.
- Persisted serving team with live score updates and reset state.
- Added focused unit coverage for volleyball scoring, set labels, reset state, and basketball fallback behavior.

## Tests
- `npx vitest run tests/unit/live-sport-config.test.js tests/unit/track-live-state.test.js tests/unit/live-scorekeeping-volleyball.test.js`