### PR TITLE
Show game clips on athlete profiles

### DIFF
--- a/athlete-profile-builder.html
+++ b/athlete-profile-builder.html
@@ -81,7 +81,7 @@
                         <div>
                             <div class="flex items-center justify-between gap-3">
                                 <div>
-                                    <h2 class="text-lg font-bold text-gray-900">Highlight Clips</h2>
+                                    <h2 class="text-lg font-bold text-gray-900">Manual Highlight Clips</h2>
                                     <p class="text-sm text-gray-500 mt-1">Upload native clips or keep compatible external links for legacy highlights.</p>
                                 </div>
                                 <div class="flex flex-wrap gap-2">
@@ -91,6 +91,12 @@
                                 </div>
                             </div>
                             <div id="clip-list" class="mt-3 space-y-3"></div>
+                        </div>
+
+                        <div>
+                            <h2 class="text-lg font-bold text-gray-900">Game Clips</h2>
+                            <p class="text-sm text-gray-500 mt-1">Score-linked clips from included games. These stay separate from manual highlights.</p>
+                            <div id="game-clip-list" class="mt-3 space-y-3"></div>
                         </div>
 
                         <div>
@@ -148,11 +154,12 @@
             listAthleteProfilesForParent,
             uploadAthleteProfileMedia,
             deleteAthleteProfileMediaByPath
-        } from './js/db.js?v=25';
-        import { buildAthleteProfileShareUrl } from './js/athlete-profile-utils.js?v=1';
+        } from './js/db.js?v=26';
+        import { buildAthleteProfileShareUrl } from './js/athlete-profile-utils.js?v=2';
 
         const params = getUrlParams();
         const clipList = document.getElementById('clip-list');
+        const gameClipList = document.getElementById('game-clip-list');
         const seasonOptions = document.getElementById('season-options');
         const saveStatus = document.getElementById('save-status');
         const previewLink = document.getElementById('preview-profile-link');
@@ -455,6 +462,26 @@
             `).join('');
         }
 
+        function renderGameClipList(gameClips = []) {
+            if (!gameClipList) return;
+            if (!Array.isArray(gameClips) || !gameClips.length) {
+                gameClipList.innerHTML = '<div class="rounded-2xl border border-dashed border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">No score-linked game clips found for the selected seasons yet.</div>';
+                return;
+            }
+
+            gameClipList.innerHTML = gameClips.map((clip) => `
+                <div class="rounded-2xl border border-emerald-200 bg-emerald-50 p-4">
+                    <div class="flex items-center gap-2 mb-2">
+                        <span class="rounded-full bg-emerald-100 px-2 py-1 text-xs font-semibold text-emerald-800">Game clip</span>
+                        <span class="text-xs text-emerald-700">${escapeHtml(clip.date || 'Date not set')}</span>
+                    </div>
+                    <div class="font-semibold text-gray-900">${escapeHtml(clip.game || 'Game')}</div>
+                    <div class="text-sm text-gray-700 mt-1">${escapeHtml(clip.playDescription || clip.title || 'Score-linked highlight')}</div>
+                    <div class="text-xs font-semibold text-emerald-800 mt-2">${escapeHtml(clip.scoreContext || 'Score context unavailable')}</div>
+                </div>
+            `).join('');
+        }
+
         function hydrateProfileState(profile) {
             releaseProfilePhotoPreview();
             currentProfile = profile || null;
@@ -478,6 +505,7 @@
                 : [];
             clips.forEach((clip) => renderClipCard(clip));
             ensureClipPlaceholder();
+            renderGameClipList(currentProfile?.gameClips || []);
         }
 
         async function loadBuilder() {

--- a/athlete-profile.html
+++ b/athlete-profile.html
@@ -26,8 +26,8 @@
     <script type="module">
         import { renderHeader, renderFooter, getUrlParams, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=12';
-        import { getAthleteProfile } from './js/db.js?v=25';
-        import { buildAthleteProfileShareUrl } from './js/athlete-profile-utils.js?v=1';
+        import { getAthleteProfile } from './js/db.js?v=26';
+        import { buildAthleteProfileShareUrl } from './js/athlete-profile-utils.js?v=2';
 
         const params = getUrlParams();
         const content = document.getElementById('profile-content');
@@ -55,6 +55,23 @@
             return cards || '<div class="text-sm text-slate-500">Career stats will appear here once games with tracked stats are included.</div>';
         }
 
+        function buildGameClipUrl(clip) {
+            const url = new URL('/live-game.html', window.location.origin);
+            url.searchParams.set('teamId', clip.teamId || '');
+            url.searchParams.set('gameId', clip.gameId || '');
+            url.searchParams.set('replay', 'true');
+            if (Number.isFinite(clip.startMs)) url.searchParams.set('clipStart', `${clip.startMs}`);
+            if (Number.isFinite(clip.endMs)) url.searchParams.set('clipEnd', `${clip.endMs}`);
+            return url.toString();
+        }
+
+        function formatGameClipDate(value) {
+            if (!value) return 'Date not set';
+            const date = new Date(value);
+            if (Number.isNaN(date.getTime())) return value;
+            return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+        }
+
         function renderClipMedia(clip) {
             const url = String(clip?.url || '').trim();
             if (!url) {
@@ -74,7 +91,7 @@
 
         function renderClips(clips) {
             if (!Array.isArray(clips) || !clips.length) {
-                return '<div class="text-sm text-slate-500">No clips attached yet.</div>';
+                return '<div class="rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-4 text-sm text-slate-500">No manually uploaded highlights attached yet.</div>';
             }
 
             return clips.map((clip) => `
@@ -83,6 +100,35 @@
                     <div class="mt-4">
                         <div class="font-semibold text-slate-900">${escapeHtml(clip?.title || 'Highlight Clip')}</div>
                         <div class="text-sm text-slate-500 mt-1">${escapeHtml(clip?.label || (clip?.source === 'upload' ? 'Hosted by ALL PLAYS' : clip?.url || ''))}</div>
+                    </div>
+                </article>
+            `).join('');
+        }
+
+        function renderGameClipMedia(clip) {
+            if (clip?.url && clip?.mediaType === 'video') {
+                return `<video controls preload="metadata" class="w-full h-56 rounded-2xl border border-emerald-200 bg-black" src="${escapeHtml(clip.url)}"></video>`;
+            }
+
+            return `<a href="${escapeHtml(buildGameClipUrl(clip))}" target="_blank" rel="noopener noreferrer" class="flex h-56 items-center justify-center rounded-2xl border border-emerald-200 bg-emerald-50 text-emerald-800 font-semibold hover:bg-emerald-100">Open game replay clip ↗</a>`;
+        }
+
+        function renderGameClips(gameClips) {
+            if (!Array.isArray(gameClips) || !gameClips.length) {
+                return '<div class="rounded-2xl border border-dashed border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">No score-linked game clips found for this athlete yet.</div>';
+            }
+
+            return gameClips.map((clip) => `
+                <article data-athlete-game-clip-card class="rounded-3xl border border-emerald-200 p-4 bg-emerald-50/60 shadow-sm">
+                    ${renderGameClipMedia(clip)}
+                    <div class="mt-4 space-y-2">
+                        <div class="flex flex-wrap items-center gap-2">
+                            <span class="rounded-full bg-emerald-100 px-2 py-1 text-xs font-semibold text-emerald-800">Game clip</span>
+                            <span class="text-xs text-emerald-700">${escapeHtml(formatGameClipDate(clip?.date))}</span>
+                        </div>
+                        <div class="font-semibold text-slate-900">${escapeHtml(clip?.game || 'Game')}</div>
+                        <div class="text-sm text-slate-700">${escapeHtml(clip?.playDescription || clip?.title || 'Score-linked highlight')}</div>
+                        <div class="text-xs font-semibold text-emerald-800">${escapeHtml(clip?.scoreContext || 'Score context unavailable')}</div>
                     </div>
                 </article>
             `).join('');
@@ -105,6 +151,7 @@
                 const seasons = Array.isArray(profile.seasons) ? profile.seasons : [];
                 const bio = profile.bio || {};
                 const summary = profile.careerSummary || {};
+                const gameClips = Array.isArray(profile.gameClips) ? profile.gameClips : [];
 
                 content.innerHTML = `
                     <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-6">
@@ -165,7 +212,13 @@
                     </div>
 
                     <div class="mt-8">
-                        <h2 class="text-2xl font-bold text-slate-900">Highlight Clips</h2>
+                        <h2 class="text-2xl font-bold text-slate-900">Game Clips</h2>
+                        <p class="text-sm text-slate-500 mt-1">Score-linked clips generated from included games. These are separate from manually uploaded highlights.</p>
+                        <div class="grid md:grid-cols-2 gap-4 mt-4">${renderGameClips(gameClips)}</div>
+                    </div>
+
+                    <div class="mt-8">
+                        <h2 class="text-2xl font-bold text-slate-900">Manual Highlight Clips</h2>
                         <div class="grid md:grid-cols-2 gap-4 mt-4">${renderClips(profile.clips)}</div>
                     </div>
                 `;

--- a/js/athlete-profile-utils.js
+++ b/js/athlete-profile-utils.js
@@ -24,6 +24,94 @@ function inferUploadMediaType({ mediaType = '', mimeType = '', url = '' } = {}) 
     return 'link';
 }
 
+
+function formatGameDateValue(value) {
+    if (!value) return '';
+    if (typeof value === 'string') return value;
+    if (typeof value?.toDate === 'function') return value.toDate().toISOString();
+    if (typeof value?.seconds === 'number') return new Date(value.seconds * 1000).toISOString();
+    return '';
+}
+
+function playerMatchesClip(clip = {}, playerId = '') {
+    const target = toCleanString(playerId);
+    if (!target) return false;
+
+    const directIds = [
+        clip.playerId,
+        clip.athleteId,
+        clip.taggedPlayerId,
+        clip.scoringPlayerId
+    ].map(toCleanString);
+    if (directIds.includes(target)) return true;
+
+    const arrayFields = [clip.playerIds, clip.athleteIds, clip.taggedPlayerIds, clip.players, clip.taggedPlayers];
+    return arrayFields.some((field) => Array.isArray(field) && field.some((entry) => {
+        if (typeof entry === 'string') return toCleanString(entry) === target;
+        return [entry?.id, entry?.playerId, entry?.athleteId].map(toCleanString).includes(target);
+    }));
+}
+
+function isTruthyFlag(value) {
+    return value === true || toCleanString(value).toLowerCase() === 'true';
+}
+
+function buildScoreContext(clip = {}, game = {}) {
+    const explicit = toCleanString(clip.scoreContext || clip.score || clip.scoreLabel);
+    if (explicit) return explicit;
+
+    const homeScore = toFiniteNumber(clip.homeScore ?? game.homeScore ?? game.score?.home);
+    const awayScore = toFiniteNumber(clip.awayScore ?? game.awayScore ?? game.score?.away);
+    if (homeScore !== null && awayScore !== null) {
+        const homeLabel = toCleanString(game.homeTeamName || game.teamName) || 'Home';
+        const awayLabel = toCleanString(game.awayTeamName || game.opponent || game.opponentName || game.opponentTeamName) || 'Away';
+        return `${homeLabel} ${homeScore}, ${awayLabel} ${awayScore}`;
+    }
+
+    const teamScore = toFiniteNumber(clip.teamScore ?? game.teamScore);
+    const opponentScore = toFiniteNumber(clip.opponentScore ?? game.opponentScore);
+    if (teamScore !== null && opponentScore !== null) {
+        return `Score: ${teamScore}-${opponentScore}`;
+    }
+
+    return '';
+}
+
+export function collectAthleteGameClipsForPlayer(games = [], { teamId = '', teamName = '', playerId = '', isStaff = false } = {}) {
+    return (Array.isArray(games) ? games : []).flatMap((game) => {
+        const rawClips = [
+            ...(Array.isArray(game?.gameClips) ? game.gameClips : []),
+            ...(Array.isArray(game?.highlightClips) ? game.highlightClips : []),
+            ...(Array.isArray(game?.replayVideo?.highlights) ? game.replayVideo.highlights : []),
+            ...(Array.isArray(game?.replayHighlights) ? game.replayHighlights : [])
+        ];
+
+        return rawClips
+            .filter((clip) => playerMatchesClip(clip, playerId))
+            .filter((clip) => isStaff || (!isTruthyFlag(clip?.hidden) && !isTruthyFlag(clip?.deleted) && !isTruthyFlag(clip?.isDeleted)))
+            .map((clip, index) => {
+                const startMs = toFiniteNumber(clip.startMs ?? clip.clipStartMs);
+                const endMs = toFiniteNumber(clip.endMs ?? clip.clipEndMs);
+                return {
+                    id: toCleanString(clip.id || clip.clipId) || `${toCleanString(game?.id || game?.gameId)}-${index}`,
+                    source: 'game',
+                    mediaType: toCleanString(clip.mediaType).toLowerCase() === 'video' ? 'video' : 'link',
+                    title: toCleanString(clip.title || clip.playDescription || clip.description) || 'Game clip',
+                    url: toCleanString(clip.url || clip.publicUrl || clip.videoUrl),
+                    teamId: toCleanString(teamId || game?.teamId),
+                    teamName: toCleanString(teamName || game?.teamName),
+                    gameId: toCleanString(game?.id || game?.gameId),
+                    game: toCleanString(game?.title || game?.name || game?.opponent || game?.opponentName || game?.opponentTeamName) || 'Game',
+                    date: formatGameDateValue(game?.date || game?.gameDate || game?.startTime),
+                    playDescription: toCleanString(clip.playDescription || clip.description || clip.title) || 'Score-linked highlight',
+                    scoreContext: buildScoreContext(clip, game),
+                    startMs,
+                    endMs
+                };
+            });
+    });
+}
+
 function normalizeClip(clip = {}) {
     const url = toCleanString(clip.url);
     if (!url) return null;

--- a/js/db.js
+++ b/js/db.js
@@ -61,8 +61,9 @@ import {
 import {
     normalizeAthleteProfileDraft,
     collectAthleteProfileMediaCleanupPaths,
-    summarizeAthleteProfileCareer
-} from './athlete-profile-utils.js?v=1';
+    summarizeAthleteProfileCareer,
+    collectAthleteGameClipsForPlayer
+} from './athlete-profile-utils.js?v=2';
 import {
     isTeamActive,
     filterTeamsByActive,
@@ -2392,7 +2393,12 @@ async function buildAthleteProfileSeasonSummary(link) {
         playerPhotoUrl: player.photoUrl || link.playerPhotoUrl || null,
         gamesPlayed,
         totalTimeMs,
-        statTotals
+        statTotals,
+        gameClips: collectAthleteGameClipsForPlayer(games, {
+            teamId: link.teamId,
+            teamName: team.name || link.teamName || 'Team',
+            playerId: link.playerId
+        })
     };
 }
 
@@ -2519,6 +2525,7 @@ export async function saveAthleteProfile(userId, draft, options = {}) {
         bio: normalized.bio,
         privacy: normalized.privacy,
         clips: normalized.clips,
+        gameClips: seasonSummaries.flatMap((season) => Array.isArray(season.gameClips) ? season.gameClips : []),
         seasons: seasonSummaries,
         careerSummary: summarizeAthleteProfileCareer(seasonSummaries),
         profilePhotoUrl: normalized.profilePhoto?.url || coverSeason.playerPhotoUrl || null,

--- a/tests/unit/athlete-profile-utils.test.js
+++ b/tests/unit/athlete-profile-utils.test.js
@@ -3,7 +3,8 @@ import {
     normalizeAthleteProfileDraft,
     collectAthleteProfileMediaCleanupPaths,
     summarizeAthleteProfileCareer,
-    buildAthleteProfileShareUrl
+    buildAthleteProfileShareUrl,
+    collectAthleteGameClipsForPlayer
 } from '../../js/athlete-profile-utils.js';
 
 describe('athlete profile helpers', () => {
@@ -138,6 +139,66 @@ describe('athlete profile helpers', () => {
             statTotals: { PTS: 33, AST: 6, REB: 5 },
             statAverages: { PTS: '11.0', AST: '2.0', REB: '1.7' }
         });
+    });
+
+
+    it('collects score-linked game clips for a player and hides non-public clips', () => {
+        const clips = collectAthleteGameClipsForPlayer([
+            {
+                id: 'game-1',
+                opponentName: 'Tigers',
+                date: '2026-04-26',
+                homeTeamName: 'Eagles',
+                awayTeamName: 'Tigers',
+                highlightClips: [
+                    { id: 'clip-1', playerIds: ['player-1'], title: 'Fast break', homeScore: 12, awayScore: 10, startMs: '1000', endMs: '9000' },
+                    { id: 'clip-2', playerIds: ['player-1'], title: 'Hidden bucket', hidden: true },
+                    { id: 'clip-3', playerIds: ['player-2'], title: 'Other player' }
+                ]
+            },
+            {
+                id: 'game-2',
+                opponent: 'Bears',
+                gameClips: [
+                    { clipId: 'clip-4', playerId: 'player-1', playDescription: 'Corner three', scoreContext: 'Eagles lead 44-41' }
+                ]
+            }
+        ], { teamId: 'team-1', teamName: 'Eagles', playerId: 'player-1' });
+
+        expect(clips).toEqual([
+            {
+                id: 'clip-1',
+                source: 'game',
+                mediaType: 'link',
+                title: 'Fast break',
+                url: '',
+                teamId: 'team-1',
+                teamName: 'Eagles',
+                gameId: 'game-1',
+                game: 'Tigers',
+                date: '2026-04-26',
+                playDescription: 'Fast break',
+                scoreContext: 'Eagles 12, Tigers 10',
+                startMs: 1000,
+                endMs: 9000
+            },
+            {
+                id: 'clip-4',
+                source: 'game',
+                mediaType: 'link',
+                title: 'Corner three',
+                url: '',
+                teamId: 'team-1',
+                teamName: 'Eagles',
+                gameId: 'game-2',
+                game: 'Bears',
+                date: '',
+                playDescription: 'Corner three',
+                scoreContext: 'Eagles lead 44-41',
+                startMs: null,
+                endMs: null
+            }
+        ]);
     });
 
     it('builds a shareable athlete profile URL', () => {


### PR DESCRIPTION
Closes #628

## Summary
- Adds score-linked game clips to saved athlete profile data from included player seasons.
- Renders game clips separately from manually uploaded highlights on the builder and public athlete profile pages.
- Includes game, date, play description, and score context, while excluding hidden or deleted clips for non-staff profile generation.

## Validation
- `npx vitest run tests/unit/athlete-profile-utils.test.js tests/unit/athlete-profile-wiring.test.js`