### PR TITLE
Fix team chat notification links

### DIFF
--- a/team-chat.html
+++ b/team-chat.html
@@ -377,9 +377,9 @@
 
         // Get teamId from URL
         function getTeamIdFromUrl() {
-            const hash = window.location.hash;
-            const params = new URLSearchParams(hash.replace('#', ''));
-            return params.get('teamId');
+            const hashParams = new URLSearchParams(window.location.hash.replace('#', ''));
+            const searchParams = new URLSearchParams(window.location.search);
+            return hashParams.get('teamId') || searchParams.get('teamId');
         }
 
         // Initialize

--- a/tests/unit/team-chat-url.test.js
+++ b/tests/unit/team-chat-url.test.js
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readTeamChat() {
+    return readFileSync(new URL('../../team-chat.html', import.meta.url), 'utf8');
+}
+
+function buildGetTeamIdFromUrl({ hash = '', search = '' } = {}) {
+    const source = readTeamChat();
+    const match = source.match(/function getTeamIdFromUrl\(\) \{([\s\S]*?)\n        \}\n\n        \/\/ Initialize/);
+    expect(match, 'getTeamIdFromUrl should exist').toBeTruthy();
+
+    const createHelper = new Function('deps', `
+        const { window, URLSearchParams } = deps;
+        return function() {
+${match[1]}
+        };
+    `);
+
+    return createHelper({
+        window: { location: { hash, search } },
+        URLSearchParams
+    });
+}
+
+describe('team chat URL routing', () => {
+    it('reads teamId from the existing hash route format', () => {
+        const getTeamIdFromUrl = buildGetTeamIdFromUrl({ hash: '#teamId=team-123' });
+
+        expect(getTeamIdFromUrl()).toBe('team-123');
+    });
+
+    it('reads teamId from notification query-string links', () => {
+        const getTeamIdFromUrl = buildGetTeamIdFromUrl({ search: '?teamId=team-456' });
+
+        expect(getTeamIdFromUrl()).toBe('team-456');
+    });
+});


### PR DESCRIPTION
Closes #635

- Updated team chat routing to accept `teamId` from both the existing hash route and notification query-string links.
- Added focused unit coverage for hash-based dashboard links and query-string push notification links.

Validation:
- `npx vitest run tests/unit/team-chat-url.test.js`