### PR TITLE
Fix player profile games played counts

### DIFF
--- a/docs/pr-notes/runs/638-review-comment-3145123326-20260427T060553Z/architecture.md
+++ b/docs/pr-notes/runs/638-review-comment-3145123326-20260427T060553Z/architecture.md
@@ -1,0 +1,19 @@
+# Architecture
+
+## Decision
+Add explicit participation provenance to score-sheet import aggregate stat rows, and make player-profile participation detection honor that marker before falling back to time/stat inference.
+
+## Precedence
+1. `didNotPlay === true` excludes the row.
+2. `participated === true` or `participationStatus === 'appeared'` includes the row.
+3. `participationStatus === 'unused'` excludes the row.
+4. Legacy fallback includes positive `timeMs` or any non-zero stat.
+5. Otherwise exclude.
+
+## Data Impact
+New optional fields on `teams/{teamId}/games/{gameId}/aggregatedStats/{playerId}`:
+- `participated: true`
+- `participationStatus: 'appeared'`
+- `participationSource: 'statsheet-import'`
+
+No Firestore rules change. No tenant boundary change. Legacy ambiguous imported zero-stat rows remain ambiguous unless re-imported or migrated.

--- a/docs/pr-notes/runs/638-review-comment-3145123326-20260427T060553Z/code-plan.md
+++ b/docs/pr-notes/runs/638-review-comment-3145123326-20260427T060553Z/code-plan.md
@@ -1,0 +1,14 @@
+# Code Plan
+
+## Implementation Plan
+- Update `js/player-profile-stats.js` so explicit participation markers count all-zero appearances while `didNotPlay` remains highest precedence.
+- Update `js/track-statsheet-apply.js` so included mapped home rows write `participated: true`, `participationStatus: 'appeared'`, and `participationSource: 'statsheet-import'`.
+- Add unit coverage in `tests/unit/player-profile-stats.test.js` for explicit zero-stat appearances, explicit unused rows, and DNP precedence.
+- Add unit coverage in `tests/unit/track-statsheet-apply.test.js` proving zero-stat included imports emit the marker.
+- Bump static import cache params in `player.html` and `track-statsheet.html`.
+
+## Conflict Resolution
+Requirements and QA preferred an explicit participation marker to avoid counting unused roster placeholders. Architecture recommended `participationStatus`/`participationSource`; code lane proposed `participated: true`. Chosen direction uses both `participated: true` for compatibility/simple checks and structured status/source fields for provenance.
+
+## Rollback
+Revert the follow-up commit. Existing PR behavior returns to stats/time-only participation filtering.

--- a/docs/pr-notes/runs/638-review-comment-3145123326-20260427T060553Z/qa.md
+++ b/docs/pr-notes/runs/638-review-comment-3145123326-20260427T060553Z/qa.md
@@ -1,0 +1,18 @@
+# QA
+
+## Automated Coverage
+- `hasPlayerProfileParticipation` includes explicitly marked all-zero appearances.
+- `hasPlayerProfileParticipation` excludes all-zero unused roster aggregate docs without an appearance marker.
+- `didNotPlay === true` overrides participation markers, time, and non-zero stats.
+- Positive `timeMs` and non-zero stats continue to count.
+- `buildTrackStatsheetApplyPlan` emits explicit participation fields for included zero-stat home rows.
+
+## Manual Regression Plan
+- Import a score sheet where an included mapped player has 0 points and 0 fouls. Confirm player profile games played includes the game and stats are zero.
+- Confirm a roster player not included/mapped by the score-sheet import does not gain a game played.
+- Confirm a DNP aggregate row does not increase games played.
+
+## Release Gates
+- `npx vitest run tests/unit/player-profile-stats.test.js tests/unit/track-statsheet-apply.test.js`
+- `npm run test:unit`
+- PR checks green after push.

--- a/docs/pr-notes/runs/638-review-comment-3145123326-20260427T060553Z/requirements.md
+++ b/docs/pr-notes/runs/638-review-comment-3145123326-20260427T060553Z/requirements.md
@@ -1,0 +1,13 @@
+# Requirements
+
+## Acceptance Criteria
+- Included, mapped score-sheet players count as game participants even when all stats are `0` and tracked time is `0` or absent.
+- Unchecked or unmapped score-sheet rows remain non-participants.
+- Player profile games played and season averages distinguish “appeared with no recorded stats” from “did not play.”
+- Explicit DNP records remain excluded regardless of stats, time, or import provenance.
+- Existing time-based insights must not imply minutes were logged for zero-time appearances.
+
+## Requirements Risks
+- Inferring participation from stats/time alone is too weak for score-sheet imports.
+- Broadening participation without an explicit marker could count placeholder aggregate docs.
+- Parent/coach trust risk: low-stat players who appeared can disappear from profile history.

--- a/js/player-profile-stats.js
+++ b/js/player-profile-stats.js
@@ -3,7 +3,11 @@ export function hasPlayerProfileParticipation(statData = {}) {
         return false;
     }
 
-    if (statData.participated === true || statData.participationStatus === 'appeared') {
+    if (
+        statData.participated === true
+        || statData.participationStatus === 'appeared'
+        || statData.participationSource === 'statsheet-import'
+    ) {
         return true;
     }
 

--- a/js/player-profile-stats.js
+++ b/js/player-profile-stats.js
@@ -1,0 +1,13 @@
+export function hasPlayerProfileParticipation(statData = {}) {
+    if (statData.didNotPlay === true) {
+        return false;
+    }
+
+    const timeMs = Number(statData.timeMs || 0);
+    if (timeMs > 0) {
+        return true;
+    }
+
+    const stats = statData.stats || {};
+    return Object.values(stats).some((value) => Number(value || 0) !== 0);
+}

--- a/js/player-profile-stats.js
+++ b/js/player-profile-stats.js
@@ -3,6 +3,14 @@ export function hasPlayerProfileParticipation(statData = {}) {
         return false;
     }
 
+    if (statData.participated === true || statData.participationStatus === 'appeared') {
+        return true;
+    }
+
+    if (statData.participationStatus === 'unused') {
+        return false;
+    }
+
     const timeMs = Number(statData.timeMs || 0);
     if (timeMs > 0) {
         return true;

--- a/js/track-statsheet-apply.js
+++ b/js/track-statsheet-apply.js
@@ -73,6 +73,9 @@ export function buildTrackStatsheetApplyPlan({
             data: {
                 playerName: player.name,
                 playerNumber: player.number,
+                participated: true,
+                participationStatus: 'appeared',
+                participationSource: 'statsheet-import',
                 stats
             }
         });

--- a/player.html
+++ b/player.html
@@ -218,7 +218,7 @@
     <script type="module">
         import { getTeam, getGame, getPlayers, getGames, getConfigs, updatePlayerProfile, getPlayerPrivateProfile, uploadPlayerPhoto, getUnreadChatCounts, getUserProfile } from './js/db.js?v=15';
         import { generatePlayerGameInsights } from './js/post-game-insights.js?v=1';
-        import { hasPlayerProfileParticipation } from './js/player-profile-stats.js?v=1';
+        import { hasPlayerProfileParticipation } from './js/player-profile-stats.js?v=2';
         import { buildPlayerLeaderboardSnapshot, selectAnalyticsConfig, summarizePlayerTopStats } from './js/stat-leaderboards.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=12';

--- a/player.html
+++ b/player.html
@@ -485,10 +485,12 @@
                     }
                 }
 
-                // Choose a primary game for back link
-                const selectedGameId = (gameId && perGameStats.find(g => g.gameId === gameId))
-                    ? gameId
-                    : (perGameStats.sort((a, b) => b.date - a.date)[0]?.gameId || games[0]?.id || null);
+                // Choose a primary game for back link and insights. Honor a requested game
+                // even when the player has a filtered DNP/zero-stat entry for that game.
+                const requestedGame = gameId ? games.find((entry) => entry.id === gameId) : null;
+                const selectedGameId = requestedGame
+                    ? requestedGame.id
+                    : ([...perGameStats].sort((a, b) => b.date - a.date)[0]?.gameId || games[0]?.id || null);
                 const selectedGame = games.find((entry) => entry.id === selectedGameId) || null;
                 // Set back-link href to team page (fallback navigation when banner not shown)
                 document.getElementById('back-link').href = `team.html#teamId=${teamId}`;

--- a/player.html
+++ b/player.html
@@ -218,6 +218,7 @@
     <script type="module">
         import { getTeam, getGame, getPlayers, getGames, getConfigs, updatePlayerProfile, getPlayerPrivateProfile, uploadPlayerPhoto, getUnreadChatCounts, getUserProfile } from './js/db.js?v=15';
         import { generatePlayerGameInsights } from './js/post-game-insights.js?v=1';
+        import { hasPlayerProfileParticipation } from './js/player-profile-stats.js?v=1';
         import { buildPlayerLeaderboardSnapshot, selectAnalyticsConfig, summarizePlayerTopStats } from './js/stat-leaderboards.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=12';
@@ -439,7 +440,7 @@
                         Object.entries(playerStats).forEach(([stat, value]) => {
                             seasonStatsByPlayerId[docSnap.id][stat] = (seasonStatsByPlayerId[docSnap.id][stat] || 0) + (Number(value) || 0);
                         });
-                        if (docSnap.id === playerId) {
+                        if (docSnap.id === playerId && hasPlayerProfileParticipation(statData)) {
                             selectedPlayerStats = {
                                 stats: playerStats,
                                 timeMs: typeof statData.timeMs === 'number' ? statData.timeMs : 0

--- a/tests/smoke/track-statsheet-apply.spec.js
+++ b/tests/smoke/track-statsheet-apply.spec.js
@@ -557,11 +557,17 @@ test('blocks apply until every included home row is mapped, then saves report da
         p1: {
             playerName: 'Ava Cole',
             playerNumber: '3',
+            participated: true,
+            participationStatus: 'appeared',
+            participationSource: 'statsheet-import',
             stats: { pts: 12, reb: 0, ast: 0, fouls: 2 }
         },
         p2: {
             playerName: 'Mia Diaz',
             playerNumber: '5',
+            participated: true,
+            participationStatus: 'appeared',
+            participationSource: 'statsheet-import',
             stats: { pts: 7, reb: 0, ast: 0, fouls: 1 }
         }
     });

--- a/tests/unit/player-profile-stats.test.js
+++ b/tests/unit/player-profile-stats.test.js
@@ -17,6 +17,37 @@ describe('player profile stats participation', () => {
         })).toBe(false);
     });
 
+    it('includes explicitly marked zero-stat appearances', () => {
+        expect(hasPlayerProfileParticipation({
+            participated: true,
+            timeMs: 0,
+            stats: { pts: 0, ast: 0, reb: 0, fouls: 0 }
+        })).toBe(true);
+
+        expect(hasPlayerProfileParticipation({
+            participationStatus: 'appeared',
+            stats: { pts: 0, fouls: 0 }
+        })).toBe(true);
+    });
+
+    it('keeps did not play as the highest precedence participation signal', () => {
+        expect(hasPlayerProfileParticipation({
+            didNotPlay: true,
+            participated: true,
+            participationStatus: 'appeared',
+            timeMs: 120000,
+            stats: { pts: 8 }
+        })).toBe(false);
+    });
+
+    it('excludes explicitly unused aggregate documents', () => {
+        expect(hasPlayerProfileParticipation({
+            participationStatus: 'unused',
+            timeMs: 0,
+            stats: { pts: 0, ast: 0, reb: 0, fouls: 0 }
+        })).toBe(false);
+    });
+
     it('includes players with recorded time or non-zero stats', () => {
         expect(hasPlayerProfileParticipation({ timeMs: 30000, stats: { pts: 0 } })).toBe(true);
         expect(hasPlayerProfileParticipation({ timeMs: 0, stats: { pts: 0, ast: 1 } })).toBe(true);

--- a/tests/unit/player-profile-stats.test.js
+++ b/tests/unit/player-profile-stats.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest';
+import { hasPlayerProfileParticipation } from '../../js/player-profile-stats.js';
+
+describe('player profile stats participation', () => {
+    it('excludes players explicitly marked did not play', () => {
+        expect(hasPlayerProfileParticipation({
+            didNotPlay: true,
+            timeMs: 0,
+            stats: { pts: 12 }
+        })).toBe(false);
+    });
+
+    it('excludes unused roster aggregate documents with only zero stats', () => {
+        expect(hasPlayerProfileParticipation({
+            timeMs: 0,
+            stats: { pts: 0, ast: 0, reb: 0, fouls: 0 }
+        })).toBe(false);
+    });
+
+    it('includes players with recorded time or non-zero stats', () => {
+        expect(hasPlayerProfileParticipation({ timeMs: 30000, stats: { pts: 0 } })).toBe(true);
+        expect(hasPlayerProfileParticipation({ timeMs: 0, stats: { pts: 0, ast: 1 } })).toBe(true);
+    });
+});

--- a/tests/unit/track-statsheet-apply.test.js
+++ b/tests/unit/track-statsheet-apply.test.js
@@ -51,6 +51,9 @@ describe('track statsheet apply helpers', () => {
                     data: {
                         playerName: 'Ava Cole',
                         playerNumber: '3',
+                        participated: true,
+                        participationStatus: 'appeared',
+                        participationSource: 'statsheet-import',
                         stats: {
                             goals: 4,
                             shots: 0,
@@ -75,5 +78,34 @@ describe('track statsheet apply helpers', () => {
                 statSheetPhotoUrl: 'https://img.test/statsheet.png'
             }
         });
+    });
+
+    it('marks included zero-stat home rows as player profile appearances', () => {
+        expect(buildTrackStatsheetApplyPlan({
+            includedHome: [
+                { mappedPlayerId: 'p1', totalPoints: 0, fouls: 0 }
+            ],
+            roster: [
+                { id: 'p1', name: 'Ava Cole', number: '3' }
+            ],
+            columns: ['PTS'],
+            homeScore: 0,
+            awayScore: 0
+        }).aggregatedStatsWrites).toEqual([
+            {
+                playerId: 'p1',
+                data: {
+                    playerName: 'Ava Cole',
+                    playerNumber: '3',
+                    participated: true,
+                    participationStatus: 'appeared',
+                    participationSource: 'statsheet-import',
+                    stats: {
+                        pts: 0,
+                        fouls: 0
+                    }
+                }
+            }
+        ]);
     });
 });

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -207,7 +207,7 @@
     import { checkAuth } from './js/auth.js?v=12';
     import { renderTeamAdminBanner } from './js/team-admin-banner.js';
     import { ensureImageAuth, getImageAuthError } from './js/firebase-images.js?v=3';
-    import { validateTrackStatsheetApplyRows, buildTrackStatsheetApplyPlan } from './js/track-statsheet-apply.js?v=1';
+    import { validateTrackStatsheetApplyRows, buildTrackStatsheetApplyPlan } from './js/track-statsheet-apply.js?v=2';
     import { getApp } from './js/vendor/firebase-app.js';
     import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
 


### PR DESCRIPTION
Closes #637

## Summary
- Added a player profile participation helper that excludes explicit Did Not Play records.
- Excluded unused roster aggregate documents with only zero stats and no playing time from player profile games played and season averages.
- Added focused unit coverage for DNP, unused roster, and participating player cases.

## Tests
- `npx vitest run tests/unit/player-profile-stats.test.js`