### PR TITLE
Add team access rollover options

### DIFF
--- a/docs/pr-notes/runs/644-review-4182463916-20260427T162032Z/architecture.md
+++ b/docs/pr-notes/runs/644-review-4182463916-20260427T162032Z/architecture.md
@@ -1,0 +1,16 @@
+# Architecture Review
+
+## Decision
+Use a minimal client-state preservation patch in `edit-team.html`. The bug is transient DOM state loss during preview rerender, not a backend access-model issue.
+
+## Design
+- Track the last rendered rollover source team ID.
+- Before rebuilding the preview, capture current carry-over enabled state and checked staff emails from the DOM.
+- If the same source team is still selected, render from the captured state.
+- If the source team changed, reset to the existing default: enabled and all eligible staff checked.
+- Keep Firestore schema, rules, and `js/rollover-access.js` unchanged.
+
+## Risk And Rollback
+- Reduces team-level privilege expansion risk from accidental re-selection.
+- Rollback is a simple revert of the `edit-team.html` and unit-test changes.
+- No data migration required. If bad data was already written, remove unintended emails from the affected team `adminEmails` array.

--- a/docs/pr-notes/runs/644-review-4182463916-20260427T162032Z/code-plan.md
+++ b/docs/pr-notes/runs/644-review-4182463916-20260427T162032Z/code-plan.md
@@ -1,0 +1,13 @@
+# Code Plan
+
+## Implementation
+- Add `lastRenderedRolloverSourceTeamId` page state.
+- Capture current rollover enabled state and checked rollover staff before rerender.
+- Preserve those values when rerendering the same source team.
+- Reset to default checked state only when the selected source team changes.
+- Extend the edit-team DOM test harness to parse rollover staff checkboxes.
+- Add unit coverage for disabled rollover and individual deselection persistence.
+
+## Files
+- `edit-team.html`
+- `tests/unit/edit-team-admin-access-persistence.test.js`

--- a/docs/pr-notes/runs/644-review-4182463916-20260427T162032Z/qa.md
+++ b/docs/pr-notes/runs/644-review-4182463916-20260427T162032Z/qa.md
@@ -1,0 +1,16 @@
+# QA Review
+
+## Regression Guardrails
+- Preserve disabled rollover state across admin add/remove rerenders.
+- Preserve individual staff deselections across admin add/remove rerenders.
+- Confirm source-team changes reset the preview defaults.
+- Confirm manually added admins are not duplicated by rollover.
+- Confirm saved `adminEmails` matches visible UI selections.
+
+## Validation Commands
+```bash
+npm test -- --run tests/unit/rollover-access.test.js tests/unit/edit-team-admin-access-persistence.test.js
+```
+
+## Manual Workflow
+Create a new team, choose a rollover source, deselect one staff admin, add and remove a manual admin, then save. Verify the deselected staff admin is not in the saved `adminEmails` and rollover audit includes only selected staff.

--- a/docs/pr-notes/runs/644-review-4182463916-20260427T162032Z/requirements.md
+++ b/docs/pr-notes/runs/644-review-4182463916-20260427T162032Z/requirements.md
@@ -1,0 +1,15 @@
+# Requirements Review
+
+## Acceptance Criteria
+- Rollover source selection shows eligible staff/admins with the carry-over toggle enabled by default.
+- Manual deselection of one or more staff/admin checkboxes persists after adding or removing a manual admin.
+- Disabling `Carry over staff/admin access` persists after adding or removing a manual admin.
+- Manual admins are not duplicated through rollover.
+- Save grants access only to manual admins plus rollover staff still checked at save time.
+- Source team changes reset the preview to that source team defaults.
+- Empty eligible rollover state remains disabled and clearly communicates that existing admins are skipped.
+
+## Non-Goals
+- No Firestore rules or schema changes.
+- No parent/member rollover.
+- No invite delivery redesign.

--- a/docs/pr-notes/runs/646-ci-fix-20260427T171047Z/architecture.md
+++ b/docs/pr-notes/runs/646-ci-fix-20260427T171047Z/architecture.md
@@ -1,0 +1,13 @@
+# Architecture Notes
+
+## Acceptance Criteria
+- Existing-user admin invite smoke test boots `edit-team.html` with mocked dependencies.
+- Clicking `#save-admin-btn` calls the mocked invite flow, renders the existing-account status, exposes invite code `EXIST111`, and updates the admin list.
+
+## Architecture Decisions
+- Keep the fix in the smoke test dependency stub, not production code. The production page imports `getUserTeamsWithAccess` from `js/db.js?v=15`; the smoke stub for `js/db.js?v=15` omitted that export, which prevents the page module from evaluating and leaves the click handler unregistered.
+- Add a no-op `getUserTeamsWithAccess` export to the edit-team DB stub so the module contract matches the page imports.
+
+## Risks And Rollback
+- Risk is limited to test harness behavior for one smoke file.
+- Rollback by removing the stub export if production imports change and the stub is no longer needed.

--- a/docs/pr-notes/runs/646-ci-fix-20260427T171047Z/code-plan.md
+++ b/docs/pr-notes/runs/646-ci-fix-20260427T171047Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code Plan
+
+## Files To Inspect
+- `edit-team.html`
+- `tests/smoke/admin-invite-redemption.spec.js`
+- `js/edit-team-admin-invites.js`
+
+## Minimal Patch
+- Add `export async function getUserTeamsWithAccess() { return []; }` to `EDIT_TEAM_DB_STUB` in `tests/smoke/admin-invite-redemption.spec.js`.
+
+## Validation
+- Run the affected Playwright smoke spec.

--- a/docs/pr-notes/runs/646-ci-fix-20260427T171047Z/qa.md
+++ b/docs/pr-notes/runs/646-ci-fix-20260427T171047Z/qa.md
@@ -1,0 +1,12 @@
+# QA Notes
+
+## Root Cause Hypothesis
+- The smoke test route fulfills `js/db.js?v=15` with `EDIT_TEAM_DB_STUB`, but that stub does not export every symbol imported by `edit-team.html`.
+- Browser ES module linking fails before the page registers the `#save-admin-btn` listener, so the test click is a no-op and `#admin-invite-status` stays empty.
+
+## Targeted Validation
+- Run `npx playwright test --config=playwright.smoke.config.js --reporter=line tests/smoke/admin-invite-redemption.spec.js`.
+- Optionally run the full preview smoke command if time permits.
+
+## Regression Risk
+- Low. This only aligns the smoke mock with the production module import surface.

--- a/edit-team.html
+++ b/edit-team.html
@@ -338,6 +338,7 @@
         let pendingAdminInviteEmails = [];
         let rolloverSourceTeams = [];
         let rolloverAccessPreview = null;
+        let lastRenderedRolloverSourceTeamId = null;
         let isInitPending = true;
 
         function buildTeamEditUrl(teamId, created = false) {
@@ -432,6 +433,13 @@
             if (!sourceSelect || !review || !enabled || !list) return;
 
             const sourceTeam = rolloverSourceTeams.find((team) => team.id === sourceSelect.value);
+            const sourceTeamId = sourceTeam?.id || null;
+            const isSameSource = sourceTeamId && sourceTeamId === lastRenderedRolloverSourceTeamId;
+            const wasEnabled = enabled.checked;
+            const previouslySelectedEmails = new Set(
+                Array.from(document.querySelectorAll('.rollover-staff-email:checked'))
+                    .map((input) => input.value)
+            );
             rolloverAccessPreview = sourceTeam
                 ? buildRolloverAccessPreview(sourceTeam, { adminEmails })
                 : null;
@@ -443,18 +451,23 @@
                 list.innerHTML = sourceTeam
                     ? '<p class="text-gray-500 italic">No eligible staff/admin access to copy. Existing admins are skipped.</p>'
                     : '';
+                lastRenderedRolloverSourceTeamId = sourceTeamId;
                 return;
             }
 
             enabled.disabled = false;
-            enabled.checked = true;
+            enabled.checked = isSameSource ? wasEnabled : true;
             review.classList.remove('hidden');
-            list.innerHTML = rolloverAccessPreview.staffAdmins.map((entry) => `
+            list.innerHTML = rolloverAccessPreview.staffAdmins.map((entry) => {
+                const checked = !isSameSource || previouslySelectedEmails.has(entry.email) ? ' checked' : '';
+                return `
                 <label class="flex items-center gap-2">
-                    <input type="checkbox" class="rollover-staff-email h-3.5 w-3.5 text-amber-600 border-gray-300 rounded" value="${entry.email}" checked>
+                    <input type="checkbox" class="rollover-staff-email h-3.5 w-3.5 text-amber-600 border-gray-300 rounded" value="${entry.email}"${checked}>
                     <span>${entry.email}</span>
                 </label>
-            `).join('');
+            `;
+            }).join('');
+            lastRenderedRolloverSourceTeamId = sourceTeamId;
         }
 
         async function loadRolloverSourceTeams() {

--- a/edit-team.html
+++ b/edit-team.html
@@ -239,6 +239,29 @@
                     </div>
                 </div>
 
+                <div id="access-rollover-panel" class="hidden bg-amber-50 border border-amber-200 rounded-lg p-4 space-y-3">
+                    <div>
+                        <h3 class="font-semibold text-amber-900 text-sm">Access Rollover</h3>
+                        <p class="text-xs text-amber-800 mt-1">Optionally carry staff/admin access forward from a prior team after creating this team.</p>
+                    </div>
+                    <div>
+                        <label class="block text-sm font-medium text-amber-900">Source Team</label>
+                        <select id="rollover-source-team" class="mt-1 block w-full rounded-md border-amber-300 shadow-sm focus:border-amber-500 focus:ring-amber-500 border p-2 text-sm">
+                            <option value="">Do not copy access</option>
+                        </select>
+                    </div>
+                    <div id="rollover-staff-review" class="hidden rounded border border-amber-200 bg-white p-3">
+                        <div class="flex items-start gap-2">
+                            <input id="rollover-staff-enabled" type="checkbox" class="mt-1 h-4 w-4 text-amber-600 border-gray-300 rounded">
+                            <div class="flex-1">
+                                <label for="rollover-staff-enabled" class="text-sm font-medium text-gray-800">Carry over staff/admin access</label>
+                                <div id="rollover-staff-list" class="mt-2 space-y-1 text-xs text-gray-700"></div>
+                            </div>
+                        </div>
+                    </div>
+                    <p id="rollover-member-note" class="text-xs text-amber-800">Fan/member carry-forward is omitted because member access is tied to player links in the current data model.</p>
+                </div>
+
                 <div class="bg-indigo-50 border border-indigo-200 rounded-lg p-4">
                     <h3 class="font-semibold text-indigo-900 text-sm mb-3">Team Management</h3>
                     <div class="flex gap-3">
@@ -295,7 +318,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { createTeam, updateTeam, getTeam, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail } from './js/db.js?v=15';
+        import { createTeam, updateTeam, getTeam, getUserTeamsWithAccess, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail } from './js/db.js?v=15';
         import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=8';
         import { checkAuth, sendInviteEmail } from './js/auth.js?v=12';
@@ -303,6 +326,7 @@
         import { normalizeYouTubeEmbedUrl } from './js/live-stream-utils.js?v=1';
         import { hasFullTeamAccess, normalizeAdminEmailList } from './js/team-access.js?v=1';
         import { processPendingAdminInvites, buildAdminInviteFollowUp, inviteExistingTeamAdmin } from './js/edit-team-admin-invites.js?v=4';
+        import { buildRolloverAccessPreview, buildStaffAdminRolloverUpdate } from './js/rollover-access.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -312,6 +336,8 @@
         let currentPhotoUrl = null;
         let adminEmails = [];
         let pendingAdminInviteEmails = [];
+        let rolloverSourceTeams = [];
+        let rolloverAccessPreview = null;
         let isInitPending = true;
 
         function buildTeamEditUrl(teamId, created = false) {
@@ -392,6 +418,65 @@
             }
         });
 
+        function getSelectedRolloverStaffEmails() {
+            if (!document.getElementById('rollover-staff-enabled')?.checked) return [];
+            return Array.from(document.querySelectorAll('.rollover-staff-email:checked'))
+                .map((input) => input.value);
+        }
+
+        function renderRolloverAccessPreview() {
+            const sourceSelect = document.getElementById('rollover-source-team');
+            const review = document.getElementById('rollover-staff-review');
+            const enabled = document.getElementById('rollover-staff-enabled');
+            const list = document.getElementById('rollover-staff-list');
+            if (!sourceSelect || !review || !enabled || !list) return;
+
+            const sourceTeam = rolloverSourceTeams.find((team) => team.id === sourceSelect.value);
+            rolloverAccessPreview = sourceTeam
+                ? buildRolloverAccessPreview(sourceTeam, { adminEmails })
+                : null;
+
+            if (!rolloverAccessPreview || rolloverAccessPreview.staffAdmins.length === 0) {
+                review.classList.toggle('hidden', !sourceTeam);
+                enabled.checked = false;
+                enabled.disabled = true;
+                list.innerHTML = sourceTeam
+                    ? '<p class="text-gray-500 italic">No eligible staff/admin access to copy. Existing admins are skipped.</p>'
+                    : '';
+                return;
+            }
+
+            enabled.disabled = false;
+            enabled.checked = true;
+            review.classList.remove('hidden');
+            list.innerHTML = rolloverAccessPreview.staffAdmins.map((entry) => `
+                <label class="flex items-center gap-2">
+                    <input type="checkbox" class="rollover-staff-email h-3.5 w-3.5 text-amber-600 border-gray-300 rounded" value="${entry.email}" checked>
+                    <span>${entry.email}</span>
+                </label>
+            `).join('');
+        }
+
+        async function loadRolloverSourceTeams() {
+            const panel = document.getElementById('access-rollover-panel');
+            const sourceSelect = document.getElementById('rollover-source-team');
+            if (!panel || !sourceSelect || currentTeamId) return;
+
+            try {
+                const teams = await getUserTeamsWithAccess(currentUser.uid, currentUser.email, { includeInactive: true });
+                rolloverSourceTeams = teams.filter((team) => Array.isArray(team.adminEmails) && team.adminEmails.length > 0);
+                if (rolloverSourceTeams.length === 0) return;
+
+                sourceSelect.innerHTML = '<option value="">Do not copy access</option>' + rolloverSourceTeams.map((team) => `
+                    <option value="${team.id}">${team.name || 'Untitled team'}</option>
+                `).join('');
+                sourceSelect.addEventListener('change', renderRolloverAccessPreview);
+                panel.classList.remove('hidden');
+            } catch (error) {
+                console.warn('Failed to load rollover source teams:', error);
+            }
+        }
+
         function renderAdminList() {
             const list = document.getElementById('admin-list');
             if (!list) return;
@@ -411,11 +496,17 @@
                     adminEmails = normalizeAdminEmailList(adminEmails.filter(e => e !== email));
                     pendingAdminInviteEmails = normalizeAdminEmailList(pendingAdminInviteEmails.filter(e => e !== email));
                     renderAdminList();
+                    renderRolloverAccessPreview();
                 });
             });
         }
 
         async function init() {
+            if (!initialTeamId) {
+                await loadRolloverSourceTeams();
+                return;
+            }
+
             if (initialTeamId) {
                 const team = await getTeam(initialTeamId);
                 if (!team) {
@@ -425,7 +516,7 @@
                     return;
                 }
                 document.getElementById('page-title').textContent = 'Edit Team';
-                if (!hasFullTeamAccess(currentUser, { ...team, id: team.id || teamId })) {
+                if (!hasFullTeamAccess(currentUser, { ...team, id: team.id || initialTeamId })) {
                     alert("You don't have permission to edit this team.");
                     window.location.href = 'dashboard.html';
                     return;
@@ -613,6 +704,7 @@
                 // Add to local list and update UI
                 adminEmails = normalizeAdminEmailList([...adminEmails, email]);
                 renderAdminList();
+                renderRolloverAccessPreview();
                 input.value = '';
 
                 // Only auto-hide if no code is displayed (user needs time to copy)
@@ -784,6 +876,17 @@
 
                 const normalizedAdminEmails = normalizeAdminEmailList(adminEmails);
                 adminEmails = normalizedAdminEmails;
+                const rolloverSourceTeam = rolloverSourceTeams.find((team) => team.id === document.getElementById('rollover-source-team')?.value);
+                const selectedRolloverStaffEmails = rolloverSourceTeam ? getSelectedRolloverStaffEmails() : [];
+                const rolloverStaffUpdate = rolloverSourceTeam && selectedRolloverStaffEmails.length > 0
+                    ? buildStaffAdminRolloverUpdate({
+                        sourceTeam: rolloverSourceTeam,
+                        targetTeam: { adminEmails: normalizedAdminEmails },
+                        selectedEmails: selectedRolloverStaffEmails,
+                        rolledOverAt: new Date().toISOString()
+                    })
+                    : null;
+
                 const teamData = {
                     name: document.getElementById('name').value,
                     description: document.getElementById('description').value,
@@ -802,7 +905,8 @@
                     zip,
                     photoUrl: currentPhotoUrl,
                     isPublic: document.getElementById('isPublic').checked,
-                    adminEmails: normalizedAdminEmails,
+                    adminEmails: rolloverStaffUpdate ? rolloverStaffUpdate.adminEmails : normalizedAdminEmails,
+                    ...(rolloverStaffUpdate ? { accessRolloverAudit: rolloverStaffUpdate.accessRolloverAudit } : {}),
                     ...((() => {
                         const sr = parseStreamUrl(document.getElementById('streamUrl').value);
                         return {

--- a/js/rollover-access.js
+++ b/js/rollover-access.js
@@ -1,0 +1,83 @@
+export function normalizeRolloverEmail(email) {
+    return String(email || '').trim().toLowerCase();
+}
+
+export function buildRolloverAccessPreview(sourceTeam = {}, targetTeam = {}) {
+    const sourceTeamId = sourceTeam.id || sourceTeam.teamId || null;
+    const targetAdminEmails = new Set(
+        (Array.isArray(targetTeam.adminEmails) ? targetTeam.adminEmails : [])
+            .map(normalizeRolloverEmail)
+            .filter(Boolean)
+    );
+
+    const seen = new Set();
+    const staffAdmins = (Array.isArray(sourceTeam.adminEmails) ? sourceTeam.adminEmails : [])
+        .map(normalizeRolloverEmail)
+        .filter((email) => {
+            if (!email || seen.has(email) || targetAdminEmails.has(email)) return false;
+            seen.add(email);
+            return true;
+        })
+        .map((email) => ({
+            email,
+            sourceTeamId
+        }));
+
+    return {
+        sourceTeamId,
+        staffAdmins,
+        memberAccessSupported: false,
+        memberAccessReason: 'Fan/member access is tied to player links in the current data model, so it is omitted until player rollover can map copied players.'
+    };
+}
+
+export function buildStaffAdminRolloverUpdate({
+    sourceTeam = {},
+    targetTeam = {},
+    selectedEmails = [],
+    rolledOverAt = new Date()
+} = {}) {
+    const sourceTeamId = sourceTeam.id || sourceTeam.teamId || null;
+    const existingEmails = (Array.isArray(targetTeam.adminEmails) ? targetTeam.adminEmails : [])
+        .map(normalizeRolloverEmail)
+        .filter(Boolean);
+    const existingSet = new Set(existingEmails);
+    const sourceEmails = new Set(
+        (Array.isArray(sourceTeam.adminEmails) ? sourceTeam.adminEmails : [])
+            .map(normalizeRolloverEmail)
+            .filter(Boolean)
+    );
+    const selectedSet = new Set(
+        selectedEmails
+            .map(normalizeRolloverEmail)
+            .filter(Boolean)
+    );
+
+    const copiedEmails = [];
+    selectedSet.forEach((email) => {
+        if (!sourceEmails.has(email) || existingSet.has(email)) return;
+        existingSet.add(email);
+        copiedEmails.push(email);
+    });
+
+    const previousAudit = Array.isArray(targetTeam.accessRolloverAudit?.staffAdmins)
+        ? targetTeam.accessRolloverAudit.staffAdmins
+        : [];
+    const staffAdminsAudit = [
+        ...previousAudit,
+        ...copiedEmails.map((email) => ({
+            email,
+            sourceTeamId,
+            rolledOverAt
+        }))
+    ];
+
+    return {
+        adminEmails: [...existingEmails, ...copiedEmails],
+        copiedEmails,
+        accessRolloverAudit: {
+            ...(targetTeam.accessRolloverAudit || {}),
+            staffAdmins: staffAdminsAudit
+        }
+    };
+}

--- a/tests/smoke/admin-invite-redemption.spec.js
+++ b/tests/smoke/admin-invite-redemption.spec.js
@@ -26,6 +26,10 @@ export async function getTeam(teamId) {
     };
 }
 
+export async function getUserTeamsWithAccess() {
+    return [];
+}
+
 export async function uploadTeamPhoto() {
     return null;
 }

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -24,6 +24,16 @@ class MockClassList {
         tokens.forEach((token) => this.tokens.delete(token));
     }
 
+    toggle(token, force) {
+        const shouldAdd = force === undefined ? !this.tokens.has(token) : !!force;
+        if (shouldAdd) {
+            this.tokens.add(token);
+        } else {
+            this.tokens.delete(token);
+        }
+        return shouldAdd;
+    }
+
     contains(token) {
         return this.tokens.has(token);
     }
@@ -156,6 +166,12 @@ function createEnvironment(initialState, overrides = {}) {
         'isPublic',
         'streamUrl',
         'stream-detect',
+        'access-rollover-panel',
+        'rollover-source-team',
+        'rollover-staff-review',
+        'rollover-staff-enabled',
+        'rollover-staff-list',
+        'rollover-member-note',
         'add-admin-btn',
         'admin-list',
         'add-admin-form',
@@ -183,6 +199,8 @@ function createEnvironment(initialState, overrides = {}) {
     elements.get('add-admin-form').classList.add('hidden');
     elements.get('admin-invite-status').classList.add('hidden');
     elements.get('admin-invite-code').classList.add('hidden');
+    elements.get('access-rollover-panel').classList.add('hidden');
+    elements.get('rollover-staff-review').classList.add('hidden');
     elements.get('save-btn').textContent = 'Save Team';
     elements.get('photo-upload').files = [];
 
@@ -234,8 +252,8 @@ function extractEditTeamModule() {
 
     return match[1]
         .replace(
-            "import { createTeam, updateTeam, getTeam, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail } from './js/db.js?v=15';",
-            'const { createTeam, updateTeam, getTeam, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail } = deps.db;'
+            "import { createTeam, updateTeam, getTeam, getUserTeamsWithAccess, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail } from './js/db.js?v=15';",
+            'const { createTeam, updateTeam, getTeam, getUserTeamsWithAccess, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail } = deps.db;'
         )
         .replace(
             "import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';",
@@ -264,6 +282,10 @@ function extractEditTeamModule() {
         .replace(
             "import { processPendingAdminInvites, buildAdminInviteFollowUp, inviteExistingTeamAdmin } from './js/edit-team-admin-invites.js?v=4';",
             'const { processPendingAdminInvites, buildAdminInviteFollowUp, inviteExistingTeamAdmin } = deps.editTeamAdminInvites;'
+        )
+        .replace(
+            "import { buildRolloverAccessPreview, buildStaffAdminRolloverUpdate } from './js/rollover-access.js?v=1';",
+            'const { buildRolloverAccessPreview, buildStaffAdminRolloverUpdate } = deps.rolloverAccess;'
         );
 }
 
@@ -306,6 +328,9 @@ async function bootEditTeam(initialState, overrides = {}) {
             },
             async getTeam(teamId) {
                 return env.state.team && env.state.team.id === teamId ? deepClone(env.state.team) : null;
+            },
+            async getUserTeamsWithAccess() {
+                return deepClone(env.state.sourceTeams || []);
             },
             async uploadTeamPhoto() {
                 throw new Error('Not implemented in test');
@@ -354,6 +379,7 @@ async function bootEditTeam(initialState, overrides = {}) {
             }
         },
         teamAccess: await import('../../js/team-access.js'),
+        rolloverAccess: await import('../../js/rollover-access.js'),
         editTeamAdminInvites: {
             async processPendingAdminInvites() {
                 return { results: [], fallbackCodeCount: 0, failedCount: 0 };

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -66,6 +66,7 @@ class MockElement {
         this.classList = new MockClassList();
         this._innerHTML = '';
         this._removeButtons = [];
+        this._rolloverStaffInputs = [];
     }
 
     addEventListener(type, handler) {
@@ -94,12 +95,31 @@ class MockElement {
         if (selector === '.remove-admin-btn') {
             return this._removeButtons;
         }
+        if (selector === '.rollover-staff-email') {
+            return this._rolloverStaffInputs;
+        }
+        if (selector === '.rollover-staff-email:checked') {
+            return this._rolloverStaffInputs.filter((input) => input.checked);
+        }
         return [];
     }
 
     set innerHTML(value) {
         this._innerHTML = value;
         this.textContent = stripHtml(value);
+        if (this.id === 'rollover-staff-list') {
+            const rolloverStaffInputs = [];
+            for (const match of String(value).matchAll(/<input[^>]*class="[^"]*rollover-staff-email[^"]*"[^>]*value="([^"]+)"([^>]*)>/g)) {
+                const input = new MockElement();
+                input.value = match[1];
+                input.checked = /\bchecked\b/.test(match[2]);
+                input.classList.add('rollover-staff-email');
+                rolloverStaffInputs.push(input);
+            }
+            this._rolloverStaffInputs = rolloverStaffInputs;
+            return;
+        }
+
         if (this.id !== 'admin-list') {
             return;
         }
@@ -211,6 +231,9 @@ function createEnvironment(initialState, overrides = {}) {
                 throw new Error(`Unknown test element: ${id}`);
             }
             return element;
+        },
+        querySelectorAll(selector) {
+            return Array.from(elements.values()).flatMap((element) => element.querySelectorAll(selector));
         }
     };
 
@@ -319,7 +342,9 @@ async function bootEditTeam(initialState, overrides = {}) {
 
     const deps = {
         db: {
-            async createTeam() {
+            async createTeam(teamData) {
+                env.state.createCalls = env.state.createCalls || [];
+                env.state.createCalls.push({ teamData: deepClone(teamData) });
                 return 'team-created';
             },
             async updateTeam(teamId, teamData) {
@@ -501,6 +526,90 @@ describe('edit team admin access persistence', () => {
             expect(reloadEnv.elements.get('admin-list').querySelectorAll('.remove-admin-btn')).toHaveLength(2);
         } finally {
             reloadEnv.cleanup();
+        }
+    });
+
+    it('preserves disabled rollover access across new-team admin rerenders', async () => {
+        const initialState = {
+            currentUser: { uid: 'owner-1', email: 'owner@example.com' },
+            sourceTeams: [
+                {
+                    id: 'source-1',
+                    name: 'Spring Sharks',
+                    adminEmails: ['coach-a@example.com', 'coach-b@example.com']
+                }
+            ],
+            createCalls: [],
+            updateCalls: []
+        };
+
+        const env = await bootEditTeam(initialState, { href: 'http://example.com/edit-team.html' });
+        try {
+            env.elements.get('rollover-source-team').value = 'source-1';
+            await env.elements.get('rollover-source-team').dispatchEvent(new MockEvent('change'));
+            expect(env.elements.get('rollover-staff-enabled').checked).toBe(true);
+
+            env.elements.get('rollover-staff-enabled').checked = false;
+            await env.elements.get('add-admin-btn').click();
+            env.elements.get('admin-email-input').value = 'manual@example.com';
+            await env.elements.get('save-admin-btn').click();
+
+            expect(env.elements.get('rollover-staff-enabled').checked).toBe(false);
+            await env.elements.get('team-form').requestSubmit();
+
+            expect(env.state.createCalls).toHaveLength(1);
+            expect(env.state.createCalls[0].teamData.adminEmails).toEqual(['manual@example.com']);
+        } finally {
+            env.cleanup();
+        }
+    });
+
+    it('preserves individual rollover staff deselections across admin add and remove rerenders', async () => {
+        const initialState = {
+            currentUser: { uid: 'owner-1', email: 'owner@example.com' },
+            sourceTeams: [
+                {
+                    id: 'source-1',
+                    name: 'Spring Sharks',
+                    adminEmails: ['coach-a@example.com', 'coach-b@example.com']
+                }
+            ],
+            createCalls: [],
+            updateCalls: []
+        };
+
+        const env = await bootEditTeam(initialState, { href: 'http://example.com/edit-team.html' });
+        try {
+            env.elements.get('rollover-source-team').value = 'source-1';
+            await env.elements.get('rollover-source-team').dispatchEvent(new MockEvent('change'));
+
+            const findRolloverInput = (email) => env.elements.get('rollover-staff-list')
+                .querySelectorAll('.rollover-staff-email')
+                .find((input) => input.value === email);
+
+            expect(findRolloverInput('coach-a@example.com').checked).toBe(true);
+            expect(findRolloverInput('coach-b@example.com').checked).toBe(true);
+            findRolloverInput('coach-b@example.com').checked = false;
+
+            await env.elements.get('add-admin-btn').click();
+            env.elements.get('admin-email-input').value = 'manual@example.com';
+            await env.elements.get('save-admin-btn').click();
+            expect(findRolloverInput('coach-b@example.com').checked).toBe(false);
+
+            const removeButtons = env.elements.get('admin-list').querySelectorAll('.remove-admin-btn');
+            expect(removeButtons).toHaveLength(1);
+            await removeButtons[0].click();
+            expect(findRolloverInput('coach-b@example.com').checked).toBe(false);
+
+            await env.elements.get('team-form').requestSubmit();
+
+            expect(env.state.createCalls).toHaveLength(1);
+            expect(env.state.createCalls[0].teamData.adminEmails).toEqual(['coach-a@example.com']);
+            expect(env.state.createCalls[0].teamData.accessRolloverAudit.staffAdmins).toEqual([
+                { email: 'coach-a@example.com', sourceTeamId: 'source-1', rolledOverAt: expect.any(String) }
+            ]);
+        } finally {
+            env.cleanup();
         }
     });
 

--- a/tests/unit/rollover-access.test.js
+++ b/tests/unit/rollover-access.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import { buildRolloverAccessPreview, buildStaffAdminRolloverUpdate } from '../../js/rollover-access.js';
+
+describe('rollover access helpers', () => {
+    it('shows eligible staff/admin emails without target duplicates', () => {
+        const preview = buildRolloverAccessPreview(
+            { id: 'source-1', adminEmails: ['Coach@Example.com', 'coach@example.com', 'asst@example.com'] },
+            { adminEmails: ['ASST@example.com'] }
+        );
+
+        expect(preview.staffAdmins).toEqual([
+            { email: 'coach@example.com', sourceTeamId: 'source-1' }
+        ]);
+        expect(preview.memberAccessSupported).toBe(false);
+    });
+
+    it('copies selected staff/admin emails with audit metadata only once', () => {
+        const rolledOverAt = new Date('2026-04-27T16:00:00.000Z');
+        const update = buildStaffAdminRolloverUpdate({
+            sourceTeam: { id: 'source-1', adminEmails: ['coach@example.com', 'asst@example.com'] },
+            targetTeam: { adminEmails: ['coach@example.com'] },
+            selectedEmails: ['coach@example.com', 'asst@example.com', 'other@example.com'],
+            rolledOverAt
+        });
+
+        expect(update.adminEmails).toEqual(['coach@example.com', 'asst@example.com']);
+        expect(update.copiedEmails).toEqual(['asst@example.com']);
+        expect(update.accessRolloverAudit.staffAdmins).toEqual([
+            {
+                email: 'asst@example.com',
+                sourceTeamId: 'source-1',
+                rolledOverAt
+            }
+        ]);
+    });
+
+    it('preserves existing rollover audit records', () => {
+        const previous = { email: 'old@example.com', sourceTeamId: 'source-0', rolledOverAt: 'then' };
+        const update = buildStaffAdminRolloverUpdate({
+            sourceTeam: { id: 'source-1', adminEmails: ['new@example.com'] },
+            targetTeam: {
+                adminEmails: [],
+                accessRolloverAudit: { staffAdmins: [previous] }
+            },
+            selectedEmails: ['new@example.com'],
+            rolledOverAt: 'now'
+        });
+
+        expect(update.accessRolloverAudit.staffAdmins).toEqual([
+            previous,
+            { email: 'new@example.com', sourceTeamId: 'source-1', rolledOverAt: 'now' }
+        ]);
+    });
+});

--- a/workflow-team-setup.html
+++ b/workflow-team-setup.html
@@ -373,6 +373,15 @@
 <li>Use <strong>Remove</strong> to remove an added person before saving</li>
 </ul>
 <ol class="ml-6 list-decimal space-y-1">
+<li>Optionally roll over staff/admin access for a new season team.</li>
+</ol>
+<ul class="ml-6 list-disc space-y-1">
+<li>On a new team, choose a <strong>Source Team</strong> under <strong>Access Rollover</strong>.</li>
+<li>Review eligible staff/admin emails separately from roster work and leave <strong>Carry over staff/admin access</strong> enabled only for the people to copy.</li>
+<li>Existing admins on the new team are skipped to avoid duplicates.</li>
+<li>Fan/member carry-forward is omitted until player rollover can map parent access to copied players.</li>
+</ul>
+<ol class="ml-6 list-decimal space-y-1">
 <li>Handle invite outcomes.</li>
 </ol>
 <ul class="ml-6 list-disc space-y-1">


### PR DESCRIPTION
Closes #643

## Summary
- Added an Access Rollover section to new team setup so staff can choose a prior source team and carry forward eligible staff/admin emails.
- Added duplicate detection against admins already on the target team and stored rollover audit metadata with sourceTeamId and rolledOverAt.
- Clearly omitted fan/member rollover because the current model ties member access to player links, which are out of scope without player mapping.

## Validation
- `npx vitest run tests/unit/rollover-access.test.js tests/unit/edit-team-admin-access-persistence.test.js`