### PR TITLE
Fix mobile workflow TOC active state

### DIFF
--- a/scripts/build-help-workflow-html-loop.mjs
+++ b/scripts/build-help-workflow-html-loop.mjs
@@ -526,6 +526,8 @@ function renderArticle({ title, roles, bodyHtml, summary, readTimeMin }) {
           toc.appendChild(a);
           return a;
         });
+        const allLinks = [...links];
+        let mobileWrapper = null;
 
         if (mobileToc && window.innerWidth < 1024) {
           const wrapper = document.createElement('details');
@@ -539,22 +541,36 @@ function renderArticle({ title, roles, bodyHtml, summary, readTimeMin }) {
           summary.style.color = '#0f172a';
           const list = toc.cloneNode(true);
           list.style.marginTop = '0.6rem';
+          allLinks.push(...Array.from(list.querySelectorAll('a')));
           wrapper.appendChild(summary);
           wrapper.appendChild(list);
           mobileToc.appendChild(wrapper);
+          mobileWrapper = wrapper;
         }
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
-        const setActive = () => {
-          let active = headings[0];
-          for (const h of headings) {
-            if (h.getBoundingClientRect().top <= 140) active = h;
+        const setActive = (activeId) => {
+          let active = sectionById.get(activeId) || headings[0];
+          if (!sectionById.has(activeId)) {
+            for (const h of headings) {
+              if (h.getBoundingClientRect().top <= 140) active = h;
+            }
           }
-          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+          allLinks.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
         };
 
-        window.addEventListener('scroll', setActive, { passive: true });
-        setActive();
+        allLinks.forEach((a) => {
+          a.addEventListener('click', () => {
+            setActive(a.getAttribute('href').slice(1));
+            if (mobileWrapper && mobileWrapper.contains(a)) {
+              mobileWrapper.open = false;
+            }
+          });
+        });
+
+        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
+        setActive(window.location.hash.slice(1) || null);
       })();
     </script>
 </body>

--- a/test-workflow-mobile-toc-active-state.html
+++ b/test-workflow-mobile-toc-active-state.html
@@ -201,8 +201,13 @@
         })();
 
         // Helper to check if a link is active
-        function isLinkActive(id) {
-            return !!document.querySelector(`a[href="#${id}"].is-active`);
+        function isLinkActive(id, scope = document) {
+            return !!scope.querySelector(`a[href="#${id}"].is-active`);
+        }
+
+        function isMobileLinkActive(id) {
+            const mobileToc = document.querySelector('details .wf-toc');
+            return !!mobileToc && isLinkActive(id, mobileToc);
         }
 
         // ============================================
@@ -213,24 +218,24 @@
 
 
         test('Mobile TOC: Initial active state (section1) on page load', () => {
-            assertTrue(isLinkActive('section1'), 'Section 1 should be active initially');
-            assertFalse(isLinkActive('section2'), 'Section 2 should not be active initially');
+            assertTrue(isMobileLinkActive('section1'), 'Mobile section 1 should be active initially');
+            assertFalse(isMobileLinkActive('section2'), 'Mobile section 2 should not be active initially');
         });
 
         test('Mobile TOC: Active state on clicking a link (section2)', () => {
             const link2 = document.querySelector('details .wf-toc a[href="#section2"]');
             assertTrue(link2 !== null, 'Mobile link for section 2 should exist');
             link2.click(); // Simulate click
-            assertTrue(isLinkActive('section2'), 'Section 2 should be active after click');
-            assertFalse(isLinkActive('section1'), 'Section 1 should not be active after click');
+            assertTrue(isMobileLinkActive('section2'), 'Mobile section 2 should be active after click');
+            assertFalse(isMobileLinkActive('section1'), 'Mobile section 1 should not be active after click');
         });
 
         test('Mobile TOC: Active state on scroll (section3)', () => {
             mockHeadingPositions({ section1: -220, section2: -40, section3: 100, section4: 360 });
             window.dispatchEvent(new Event('scroll'));
 
-            assertTrue(isLinkActive('section3'), 'Section 3 should be active after scroll');
-            assertFalse(isLinkActive('section2'), 'Section 2 should not be active after scroll');
+            assertTrue(isMobileLinkActive('section3'), 'Mobile section 3 should be active after scroll');
+            assertFalse(isMobileLinkActive('section2'), 'Mobile section 2 should not be active after scroll');
         });
 
         test('Desktop TOC: Active state on initial load', () => {

--- a/tests/unit/workflow-mobile-toc-active-state.test.js
+++ b/tests/unit/workflow-mobile-toc-active-state.test.js
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readRepoFile(relativePath) {
+    return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+function expectMobileTocActiveStateSupport(source) {
+    expect(source).toContain('const allLinks = [...links];');
+    expect(source).toContain("allLinks.push(...Array.from(list.querySelectorAll('a')));");
+    expect(source).toContain("allLinks.forEach((a) => a.classList.toggle('is-active'");
+    expect(source).toContain("a.addEventListener('click', () => {");
+    expect(source).toContain("window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));");
+    expect(source).not.toContain("links.forEach((a) => a.classList.toggle('is-active'");
+}
+
+describe('workflow mobile TOC active state', () => {
+    it('keeps generated workflow pages updating cloned mobile TOC links', () => {
+        expectMobileTocActiveStateSupport(readRepoFile('workflow-game-day.html'));
+    });
+
+    it('keeps the workflow HTML generator aligned with the runtime fix', () => {
+        expectMobileTocActiveStateSupport(readRepoFile('scripts/build-help-workflow-html-loop.mjs'));
+    });
+});

--- a/workflow-admin-ops.html
+++ b/workflow-admin-ops.html
@@ -392,6 +392,8 @@
           toc.appendChild(a);
           return a;
         });
+        const allLinks = [...links];
+        let mobileWrapper = null;
 
         if (mobileToc && window.innerWidth < 1024) {
           const wrapper = document.createElement('details');
@@ -405,22 +407,36 @@
           summary.style.color = '#0f172a';
           const list = toc.cloneNode(true);
           list.style.marginTop = '0.6rem';
+          allLinks.push(...Array.from(list.querySelectorAll('a')));
           wrapper.appendChild(summary);
           wrapper.appendChild(list);
           mobileToc.appendChild(wrapper);
+          mobileWrapper = wrapper;
         }
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
-        const setActive = () => {
-          let active = headings[0];
-          for (const h of headings) {
-            if (h.getBoundingClientRect().top <= 140) active = h;
+        const setActive = (activeId) => {
+          let active = sectionById.get(activeId) || headings[0];
+          if (!sectionById.has(activeId)) {
+            for (const h of headings) {
+              if (h.getBoundingClientRect().top <= 140) active = h;
+            }
           }
-          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+          allLinks.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
         };
 
-        window.addEventListener('scroll', setActive, { passive: true });
-        setActive();
+        allLinks.forEach((a) => {
+          a.addEventListener('click', () => {
+            setActive(a.getAttribute('href').slice(1));
+            if (mobileWrapper && mobileWrapper.contains(a)) {
+              mobileWrapper.open = false;
+            }
+          });
+        });
+
+        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
+        setActive(window.location.hash.slice(1) || null);
       })();
     </script>
 </body>

--- a/workflow-choose-home-dashboard.html
+++ b/workflow-choose-home-dashboard.html
@@ -413,6 +413,8 @@
           toc.appendChild(a);
           return a;
         });
+        const allLinks = [...links];
+        let mobileWrapper = null;
 
         if (mobileToc && window.innerWidth < 1024) {
           const wrapper = document.createElement('details');
@@ -426,22 +428,36 @@
           summary.style.color = '#0f172a';
           const list = toc.cloneNode(true);
           list.style.marginTop = '0.6rem';
+          allLinks.push(...Array.from(list.querySelectorAll('a')));
           wrapper.appendChild(summary);
           wrapper.appendChild(list);
           mobileToc.appendChild(wrapper);
+          mobileWrapper = wrapper;
         }
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
-        const setActive = () => {
-          let active = headings[0];
-          for (const h of headings) {
-            if (h.getBoundingClientRect().top <= 140) active = h;
+        const setActive = (activeId) => {
+          let active = sectionById.get(activeId) || headings[0];
+          if (!sectionById.has(activeId)) {
+            for (const h of headings) {
+              if (h.getBoundingClientRect().top <= 140) active = h;
+            }
           }
-          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+          allLinks.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
         };
 
-        window.addEventListener('scroll', setActive, { passive: true });
-        setActive();
+        allLinks.forEach((a) => {
+          a.addEventListener('click', () => {
+            setActive(a.getAttribute('href').slice(1));
+            if (mobileWrapper && mobileWrapper.contains(a)) {
+              mobileWrapper.open = false;
+            }
+          });
+        });
+
+        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
+        setActive(window.location.hash.slice(1) || null);
       })();
     </script>
 </body>

--- a/workflow-communication.html
+++ b/workflow-communication.html
@@ -412,6 +412,8 @@
           toc.appendChild(a);
           return a;
         });
+        const allLinks = [...links];
+        let mobileWrapper = null;
 
         if (mobileToc && window.innerWidth < 1024) {
           const wrapper = document.createElement('details');
@@ -425,22 +427,36 @@
           summary.style.color = '#0f172a';
           const list = toc.cloneNode(true);
           list.style.marginTop = '0.6rem';
+          allLinks.push(...Array.from(list.querySelectorAll('a')));
           wrapper.appendChild(summary);
           wrapper.appendChild(list);
           mobileToc.appendChild(wrapper);
+          mobileWrapper = wrapper;
         }
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
-        const setActive = () => {
-          let active = headings[0];
-          for (const h of headings) {
-            if (h.getBoundingClientRect().top <= 140) active = h;
+        const setActive = (activeId) => {
+          let active = sectionById.get(activeId) || headings[0];
+          if (!sectionById.has(activeId)) {
+            for (const h of headings) {
+              if (h.getBoundingClientRect().top <= 140) active = h;
+            }
           }
-          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+          allLinks.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
         };
 
-        window.addEventListener('scroll', setActive, { passive: true });
-        setActive();
+        allLinks.forEach((a) => {
+          a.addEventListener('click', () => {
+            setActive(a.getAttribute('href').slice(1));
+            if (mobileWrapper && mobileWrapper.contains(a)) {
+              mobileWrapper.open = false;
+            }
+          });
+        });
+
+        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
+        setActive(window.location.hash.slice(1) || null);
       })();
     </script>
 </body>

--- a/workflow-game-day.html
+++ b/workflow-game-day.html
@@ -429,6 +429,8 @@
           toc.appendChild(a);
           return a;
         });
+        const allLinks = [...links];
+        let mobileWrapper = null;
 
         if (mobileToc && window.innerWidth < 1024) {
           const wrapper = document.createElement('details');
@@ -442,22 +444,36 @@
           summary.style.color = '#0f172a';
           const list = toc.cloneNode(true);
           list.style.marginTop = '0.6rem';
+          allLinks.push(...Array.from(list.querySelectorAll('a')));
           wrapper.appendChild(summary);
           wrapper.appendChild(list);
           mobileToc.appendChild(wrapper);
+          mobileWrapper = wrapper;
         }
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
-        const setActive = () => {
-          let active = headings[0];
-          for (const h of headings) {
-            if (h.getBoundingClientRect().top <= 140) active = h;
+        const setActive = (activeId) => {
+          let active = sectionById.get(activeId) || headings[0];
+          if (!sectionById.has(activeId)) {
+            for (const h of headings) {
+              if (h.getBoundingClientRect().top <= 140) active = h;
+            }
           }
-          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+          allLinks.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
         };
 
-        window.addEventListener('scroll', setActive, { passive: true });
-        setActive();
+        allLinks.forEach((a) => {
+          a.addEventListener('click', () => {
+            setActive(a.getAttribute('href').slice(1));
+            if (mobileWrapper && mobileWrapper.contains(a)) {
+              mobileWrapper.open = false;
+            }
+          });
+        });
+
+        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
+        setActive(window.location.hash.slice(1) || null);
       })();
     </script>
 </body>

--- a/workflow-getting-started.html
+++ b/workflow-getting-started.html
@@ -453,6 +453,8 @@
           toc.appendChild(a);
           return a;
         });
+        const allLinks = [...links];
+        let mobileWrapper = null;
 
         if (mobileToc && window.innerWidth < 1024) {
           const wrapper = document.createElement('details');
@@ -466,22 +468,36 @@
           summary.style.color = '#0f172a';
           const list = toc.cloneNode(true);
           list.style.marginTop = '0.6rem';
+          allLinks.push(...Array.from(list.querySelectorAll('a')));
           wrapper.appendChild(summary);
           wrapper.appendChild(list);
           mobileToc.appendChild(wrapper);
+          mobileWrapper = wrapper;
         }
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
-        const setActive = () => {
-          let active = headings[0];
-          for (const h of headings) {
-            if (h.getBoundingClientRect().top <= 140) active = h;
+        const setActive = (activeId) => {
+          let active = sectionById.get(activeId) || headings[0];
+          if (!sectionById.has(activeId)) {
+            for (const h of headings) {
+              if (h.getBoundingClientRect().top <= 140) active = h;
+            }
           }
-          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+          allLinks.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
         };
 
-        window.addEventListener('scroll', setActive, { passive: true });
-        setActive();
+        allLinks.forEach((a) => {
+          a.addEventListener('click', () => {
+            setActive(a.getAttribute('href').slice(1));
+            if (mobileWrapper && mobileWrapper.contains(a)) {
+              mobileWrapper.open = false;
+            }
+          });
+        });
+
+        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
+        setActive(window.location.hash.slice(1) || null);
       })();
     </script>
 </body>

--- a/workflow-join-team.html
+++ b/workflow-join-team.html
@@ -444,6 +444,8 @@
           toc.appendChild(a);
           return a;
         });
+        const allLinks = [...links];
+        let mobileWrapper = null;
 
         if (mobileToc && window.innerWidth < 1024) {
           const wrapper = document.createElement('details');
@@ -457,22 +459,36 @@
           summary.style.color = '#0f172a';
           const list = toc.cloneNode(true);
           list.style.marginTop = '0.6rem';
+          allLinks.push(...Array.from(list.querySelectorAll('a')));
           wrapper.appendChild(summary);
           wrapper.appendChild(list);
           mobileToc.appendChild(wrapper);
+          mobileWrapper = wrapper;
         }
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
-        const setActive = () => {
-          let active = headings[0];
-          for (const h of headings) {
-            if (h.getBoundingClientRect().top <= 140) active = h;
+        const setActive = (activeId) => {
+          let active = sectionById.get(activeId) || headings[0];
+          if (!sectionById.has(activeId)) {
+            for (const h of headings) {
+              if (h.getBoundingClientRect().top <= 140) active = h;
+            }
           }
-          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+          allLinks.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
         };
 
-        window.addEventListener('scroll', setActive, { passive: true });
-        setActive();
+        allLinks.forEach((a) => {
+          a.addEventListener('click', () => {
+            setActive(a.getAttribute('href').slice(1));
+            if (mobileWrapper && mobileWrapper.contains(a)) {
+              mobileWrapper.open = false;
+            }
+          });
+        });
+
+        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
+        setActive(window.location.hash.slice(1) || null);
       })();
     </script>
 </body>

--- a/workflow-postgame.html
+++ b/workflow-postgame.html
@@ -450,6 +450,8 @@
           toc.appendChild(a);
           return a;
         });
+        const allLinks = [...links];
+        let mobileWrapper = null;
 
         if (mobileToc && window.innerWidth < 1024) {
           const wrapper = document.createElement('details');
@@ -463,22 +465,36 @@
           summary.style.color = '#0f172a';
           const list = toc.cloneNode(true);
           list.style.marginTop = '0.6rem';
+          allLinks.push(...Array.from(list.querySelectorAll('a')));
           wrapper.appendChild(summary);
           wrapper.appendChild(list);
           mobileToc.appendChild(wrapper);
+          mobileWrapper = wrapper;
         }
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
-        const setActive = () => {
-          let active = headings[0];
-          for (const h of headings) {
-            if (h.getBoundingClientRect().top <= 140) active = h;
+        const setActive = (activeId) => {
+          let active = sectionById.get(activeId) || headings[0];
+          if (!sectionById.has(activeId)) {
+            for (const h of headings) {
+              if (h.getBoundingClientRect().top <= 140) active = h;
+            }
           }
-          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+          allLinks.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
         };
 
-        window.addEventListener('scroll', setActive, { passive: true });
-        setActive();
+        allLinks.forEach((a) => {
+          a.addEventListener('click', () => {
+            setActive(a.getAttribute('href').slice(1));
+            if (mobileWrapper && mobileWrapper.contains(a)) {
+              mobileWrapper.open = false;
+            }
+          });
+        });
+
+        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
+        setActive(window.location.hash.slice(1) || null);
       })();
     </script>
 </body>

--- a/workflow-roster.html
+++ b/workflow-roster.html
@@ -458,6 +458,8 @@
           toc.appendChild(a);
           return a;
         });
+        const allLinks = [...links];
+        let mobileWrapper = null;
 
         if (mobileToc && window.innerWidth < 1024) {
           const wrapper = document.createElement('details');
@@ -471,22 +473,36 @@
           summary.style.color = '#0f172a';
           const list = toc.cloneNode(true);
           list.style.marginTop = '0.6rem';
+          allLinks.push(...Array.from(list.querySelectorAll('a')));
           wrapper.appendChild(summary);
           wrapper.appendChild(list);
           mobileToc.appendChild(wrapper);
+          mobileWrapper = wrapper;
         }
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
-        const setActive = () => {
-          let active = headings[0];
-          for (const h of headings) {
-            if (h.getBoundingClientRect().top <= 140) active = h;
+        const setActive = (activeId) => {
+          let active = sectionById.get(activeId) || headings[0];
+          if (!sectionById.has(activeId)) {
+            for (const h of headings) {
+              if (h.getBoundingClientRect().top <= 140) active = h;
+            }
           }
-          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+          allLinks.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
         };
 
-        window.addEventListener('scroll', setActive, { passive: true });
-        setActive();
+        allLinks.forEach((a) => {
+          a.addEventListener('click', () => {
+            setActive(a.getAttribute('href').slice(1));
+            if (mobileWrapper && mobileWrapper.contains(a)) {
+              mobileWrapper.open = false;
+            }
+          });
+        });
+
+        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
+        setActive(window.location.hash.slice(1) || null);
       })();
     </script>
 </body>

--- a/workflow-schedule.html
+++ b/workflow-schedule.html
@@ -466,6 +466,8 @@
           toc.appendChild(a);
           return a;
         });
+        const allLinks = [...links];
+        let mobileWrapper = null;
 
         if (mobileToc && window.innerWidth < 1024) {
           const wrapper = document.createElement('details');
@@ -479,22 +481,36 @@
           summary.style.color = '#0f172a';
           const list = toc.cloneNode(true);
           list.style.marginTop = '0.6rem';
+          allLinks.push(...Array.from(list.querySelectorAll('a')));
           wrapper.appendChild(summary);
           wrapper.appendChild(list);
           mobileToc.appendChild(wrapper);
+          mobileWrapper = wrapper;
         }
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
-        const setActive = () => {
-          let active = headings[0];
-          for (const h of headings) {
-            if (h.getBoundingClientRect().top <= 140) active = h;
+        const setActive = (activeId) => {
+          let active = sectionById.get(activeId) || headings[0];
+          if (!sectionById.has(activeId)) {
+            for (const h of headings) {
+              if (h.getBoundingClientRect().top <= 140) active = h;
+            }
           }
-          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+          allLinks.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
         };
 
-        window.addEventListener('scroll', setActive, { passive: true });
-        setActive();
+        allLinks.forEach((a) => {
+          a.addEventListener('click', () => {
+            setActive(a.getAttribute('href').slice(1));
+            if (mobileWrapper && mobileWrapper.contains(a)) {
+              mobileWrapper.open = false;
+            }
+          });
+        });
+
+        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
+        setActive(window.location.hash.slice(1) || null);
       })();
     </script>
 </body>

--- a/workflow-team-setup.html
+++ b/workflow-team-setup.html
@@ -482,6 +482,8 @@
           toc.appendChild(a);
           return a;
         });
+        const allLinks = [...links];
+        let mobileWrapper = null;
 
         if (mobileToc && window.innerWidth < 1024) {
           const wrapper = document.createElement('details');
@@ -495,22 +497,36 @@
           summary.style.color = '#0f172a';
           const list = toc.cloneNode(true);
           list.style.marginTop = '0.6rem';
+          allLinks.push(...Array.from(list.querySelectorAll('a')));
           wrapper.appendChild(summary);
           wrapper.appendChild(list);
           mobileToc.appendChild(wrapper);
+          mobileWrapper = wrapper;
         }
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
-        const setActive = () => {
-          let active = headings[0];
-          for (const h of headings) {
-            if (h.getBoundingClientRect().top <= 140) active = h;
+        const setActive = (activeId) => {
+          let active = sectionById.get(activeId) || headings[0];
+          if (!sectionById.has(activeId)) {
+            for (const h of headings) {
+              if (h.getBoundingClientRect().top <= 140) active = h;
+            }
           }
-          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+          allLinks.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
         };
 
-        window.addEventListener('scroll', setActive, { passive: true });
-        setActive();
+        allLinks.forEach((a) => {
+          a.addEventListener('click', () => {
+            setActive(a.getAttribute('href').slice(1));
+            if (mobileWrapper && mobileWrapper.contains(a)) {
+              mobileWrapper.open = false;
+            }
+          });
+        });
+
+        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
+        setActive(window.location.hash.slice(1) || null);
       })();
     </script>
 </body>

--- a/workflow-track-game.html
+++ b/workflow-track-game.html
@@ -451,6 +451,8 @@
           toc.appendChild(a);
           return a;
         });
+        const allLinks = [...links];
+        let mobileWrapper = null;
 
         if (mobileToc && window.innerWidth < 1024) {
           const wrapper = document.createElement('details');
@@ -464,22 +466,36 @@
           summary.style.color = '#0f172a';
           const list = toc.cloneNode(true);
           list.style.marginTop = '0.6rem';
+          allLinks.push(...Array.from(list.querySelectorAll('a')));
           wrapper.appendChild(summary);
           wrapper.appendChild(list);
           mobileToc.appendChild(wrapper);
+          mobileWrapper = wrapper;
         }
 
         const sectionById = new Map(headings.map((h) => [h.id, h]));
-        const setActive = () => {
-          let active = headings[0];
-          for (const h of headings) {
-            if (h.getBoundingClientRect().top <= 140) active = h;
+        const setActive = (activeId) => {
+          let active = sectionById.get(activeId) || headings[0];
+          if (!sectionById.has(activeId)) {
+            for (const h of headings) {
+              if (h.getBoundingClientRect().top <= 140) active = h;
+            }
           }
-          links.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
+          allLinks.forEach((a) => a.classList.toggle('is-active', a.getAttribute('href') === '#' + active.id));
         };
 
-        window.addEventListener('scroll', setActive, { passive: true });
-        setActive();
+        allLinks.forEach((a) => {
+          a.addEventListener('click', () => {
+            setActive(a.getAttribute('href').slice(1));
+            if (mobileWrapper && mobileWrapper.contains(a)) {
+              mobileWrapper.open = false;
+            }
+          });
+        });
+
+        window.addEventListener('scroll', () => setActive(null), { passive: true });
+        window.addEventListener('hashchange', () => setActive(window.location.hash.slice(1)));
+        setActive(window.location.hash.slice(1) || null);
       })();
     </script>
 </body>


### PR DESCRIPTION
Closes #640

## Summary
- Update workflow TOC runtime logic to track both desktop links and cloned mobile links.
- Apply `is-active` to visible mobile TOC links on scroll, hash changes, and mobile link clicks.
- Keep the workflow HTML generator aligned so regenerated workflow pages retain the fix.

## Tests
- Added `tests/unit/workflow-mobile-toc-active-state.test.js`.
- Tightened `test-workflow-mobile-toc-active-state.html` to assert mobile TOC links specifically.
- Ran `npx vitest run tests/unit/workflow-mobile-toc-active-state.test.js --reporter=dot`.
- Also ran `npm run test:unit -- tests/unit/workflow-mobile-toc-active-state.test.js`, which executed the full unit suite and passed.