### PR TITLE
Add game recap highlights panel

### DIFF
--- a/docs/pr-notes/runs/696-remediator-20260501T050742Z/architecture.md
+++ b/docs/pr-notes/runs/696-remediator-20260501T050742Z/architecture.md
@@ -1,0 +1,15 @@
+# Architecture
+
+## Decision
+Scope the change to `normalizeGameRecapHighlightClips` in `js/live-game-video.js`.
+
+## Data flow
+`collectRawHighlightClips` gathers recap sources, then `normalizeGameRecapHighlightClips` maps them for completed-game recap rendering. The bug came from passing metadata-only clips into `createHighlightClipDraft`, whose default behavior is correct for drafting timed clips but wrong for untimed recap metadata.
+
+## Implementation shape
+- Read raw timing with `toFiniteNumber` before calling `createHighlightClipDraft`.
+- Only call `createHighlightClipDraft` when a finite source `startMs` exists.
+- Preserve absent timing as `null` while keeping metadata and URLs unchanged.
+
+## Blast radius
+Limited to completed-game recap normalization and its unit tests. No schema, auth, Firestore rules, or replay playback architecture changes.

--- a/docs/pr-notes/runs/696-remediator-20260501T050742Z/code-plan.md
+++ b/docs/pr-notes/runs/696-remediator-20260501T050742Z/code-plan.md
@@ -1,0 +1,14 @@
+# Code Plan
+
+## Files
+- `js/live-game-video.js`
+- `tests/unit/live-game-video.test.js`
+
+## Patch
+- In `normalizeGameRecapHighlightClips`, calculate `rawStartMs` and `rawEndMs` before normalization.
+- Only use `createHighlightClipDraft` when `rawStartMs` is finite.
+- Return `null` timing values when timing is absent instead of synthesized defaults.
+- Extend tests to assert untimed recap clips preserve null timing.
+
+## Validation
+Run `npm run test:unit -- tests/unit/live-game-video.test.js`.

--- a/docs/pr-notes/runs/696-remediator-20260501T050742Z/qa.md
+++ b/docs/pr-notes/runs/696-remediator-20260501T050742Z/qa.md
@@ -1,0 +1,15 @@
+# QA Plan
+
+## Automated checks
+- Add/verify unit coverage in `tests/unit/live-game-video.test.js` for metadata-only recap clips with explicit clip URL.
+- Add coverage for metadata-only recap clips using replay fallback URL.
+- Preserve existing timed clip expectations.
+
+## Manual checks
+- Completed game recap with metadata-only clip should show title/context/players but no synthetic time range.
+- Timed clip should still show authored range and use replay fallback URL when no clip URL exists.
+- Browser console should remain clean on completed game recap rendering.
+
+## Regression risks
+- Accidentally changing `createHighlightClipDraft` behavior for saved timed highlights.
+- Sorting mixed timed/untimed clips incorrectly. Existing order-first sorting is preserved.

--- a/docs/pr-notes/runs/696-remediator-20260501T050742Z/requirements.md
+++ b/docs/pr-notes/runs/696-remediator-20260501T050742Z/requirements.md
@@ -1,0 +1,13 @@
+# Requirements
+
+## Acceptance criteria
+- Recap highlight clips with no source timing preserve `startMs: null` and `endMs: null`.
+- Untimed recap clips do not render as synthetic `0:00 - 1:00` clips.
+- Timed recap clips with valid bounds keep their authored timing.
+- Metadata, players, period, game time, ordering, and explicit/fallback video URLs remain intact.
+
+## Edge cases
+- A legitimate `startMs: 0` with valid `endMs` remains timed.
+- Metadata-only clips with explicit `videoUrl` remain visible without timing.
+- Metadata-only clips using replay fallback URL remain visible without timing.
+- Invalid or absent source timing must not become `0/60000`.

--- a/game.html
+++ b/game.html
@@ -114,6 +114,17 @@
             </div>
         </div>
 
+        <!-- Highlights Section -->
+        <div id="highlights-section" class="mb-8 md:mb-10 hidden">
+            <div class="flex items-center gap-3 mb-4">
+                <div class="h-1 w-8 bg-gradient-to-r from-primary-500 to-primary-700 rounded-full"></div>
+                <h2 class="text-2xl md:text-3xl font-bold text-gray-900">Highlights</h2>
+            </div>
+            <div class="bg-white shadow-lg rounded-2xl p-6 md:p-8 border border-gray-200">
+                <div id="highlights-body" class="space-y-4"></div>
+            </div>
+        </div>
+
         <!-- Score Sheet Photo -->
         <div id="stat-sheet-section" class="mb-8 md:mb-10 hidden">
             <div class="flex items-center gap-3 mb-4">
@@ -346,6 +357,7 @@
         import { resolveLiveStatConfig } from './js/live-game-state.js?v=3';
         import { resolveReportStatColumns, resolveOpponentReportStatColumns } from './js/game-report-stats.js?v=1';
         import { resolvePostGameStatFields, buildCompletedGamePlayerStatsPayload, getPostGameEditorNextIndex } from './js/post-game-stat-editor.js?v=1';
+        import { buildHighlightShareUrl, normalizeGameRecapHighlightClips } from './js/live-game-video.js?v=3';
 
         let currentUser = null;
         let canManageStatSheet = false;
@@ -387,6 +399,71 @@
                 return 'border-amber-200 bg-amber-50';
             }
             return 'border-gray-200 bg-gray-50';
+        }
+
+        function resolveHighlightPlayerNames(clip, playerLookup) {
+            return (clip.players || []).map((player) => {
+                const rosterPlayer = player.id ? playerLookup.get(player.id) : null;
+                const name = rosterPlayer?.name || player.name || player.id || 'Player';
+                const number = rosterPlayer?.number || player.number || '';
+                return number ? `#${number} ${name}` : name;
+            });
+        }
+
+        function renderHighlightsSection(game, players, teamId, gameId) {
+            const section = document.getElementById('highlights-section');
+            const body = document.getElementById('highlights-body');
+            if (!section || !body) return;
+
+            const gameCompleted = game?.status === 'completed' || game?.liveStatus === 'completed';
+            if (!gameCompleted) {
+                section.classList.add('hidden');
+                return;
+            }
+
+            const playerLookup = new Map((players || []).map((player) => [player.id, player]));
+            const clips = normalizeGameRecapHighlightClips(game);
+            section.classList.remove('hidden');
+
+            if (!clips.length) {
+                body.innerHTML = `
+                    <div class="rounded-xl border border-dashed border-gray-300 px-4 py-8 text-center">
+                        <div class="text-sm font-semibold text-gray-700">No highlights available yet.</div>
+                        <p class="mt-1 text-sm text-gray-500">Clip metadata can be added after the game to build a recap reel here.</p>
+                    </div>
+                `;
+                return;
+            }
+
+            body.innerHTML = clips.map((clip, index) => {
+                const playerNames = resolveHighlightPlayerNames(clip, playerLookup);
+                const context = [clip.period, clip.gameTime].filter(Boolean).join(' • ');
+                const clipUrl = clip.videoUrl || buildHighlightShareUrl({
+                    origin: window.location.origin,
+                    teamId,
+                    gameId,
+                    startMs: clip.startMs,
+                    endMs: clip.endMs
+                });
+                return `
+                    <article class="rounded-xl border border-gray-200 bg-gray-50 p-4 md:p-5">
+                        <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4">
+                            <div class="min-w-0 flex-1">
+                                <div class="flex flex-wrap items-center gap-2 mb-2">
+                                    <span class="inline-flex items-center rounded-full bg-primary-100 px-2.5 py-1 text-xs font-bold text-primary-700">#${index + 1}</span>
+                                    ${context ? `<span class="text-xs font-semibold uppercase tracking-wider text-gray-500">${escapeHtml(context)}</span>` : ''}
+                                </div>
+                                <h3 class="text-base md:text-lg font-bold text-gray-900">${escapeHtml(clip.description || clip.title || `Highlight ${index + 1}`)}</h3>
+                                ${playerNames.length ? `<p class="mt-2 text-sm text-gray-600"><span class="font-semibold text-gray-700">Players:</span> ${escapeHtml(playerNames.join(', '))}</p>` : ''}
+                                ${Number.isFinite(clip.startMs) && Number.isFinite(clip.endMs) ? `<p class="mt-1 text-xs font-mono text-gray-500">${formatMMSS(clip.startMs)} - ${formatMMSS(clip.endMs)}</p>` : ''}
+                            </div>
+                            <a href="${escapeHtml(clipUrl)}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700 transition">
+                                Watch clip ↗
+                            </a>
+                        </div>
+                    </article>
+                `;
+            }).join('');
         }
 
         function renderInsightsSection({ teamInsights, playerInsightsById, emptyMessage }, players, teamId, gameId) {
@@ -1158,6 +1235,7 @@ Write the match report now:`;
                     summaryDiv.style.maxHeight = summaryDiv.scrollHeight + 'px';
                 }, 100);
 
+                renderHighlightsSection(game, players, teamId, gameId);
                 setupStatSheetControls(teamId, gameId, game);
 
                 // Fetch Aggregated Stats

--- a/js/live-game-video.js
+++ b/js/live-game-video.js
@@ -220,15 +220,17 @@ export function normalizeGameRecapHighlightClips(game, options = {}) {
     return collectRawHighlightClips(game)
         .map((clip, index) => {
             const videoUrl = getClipVideoUrl(clip) || replayUrl;
-            const normalized = createHighlightClipDraft({
-                startMs: clip?.startMs ?? clip?.clipStartMs,
-                endMs: clip?.endMs ?? clip?.clipEndMs,
+            const rawStartMs = toFiniteNumber(clip?.startMs ?? clip?.clipStartMs);
+            const rawEndMs = toFiniteNumber(clip?.endMs ?? clip?.clipEndMs);
+            const normalized = Number.isFinite(rawStartMs) ? createHighlightClipDraft({
+                startMs: rawStartMs,
+                endMs: rawEndMs,
                 durationMs: durationMs ?? recorded?.durationMs,
                 title: clip?.title || clip?.playDescription || clip?.description || `Highlight ${index + 1}`
-            }, options);
+            }, options) : null;
             if (!normalized && !videoUrl) return null;
-            const startMs = normalized?.startMs ?? toFiniteNumber(clip?.startMs ?? clip?.clipStartMs);
-            const endMs = normalized?.endMs ?? toFiniteNumber(clip?.endMs ?? clip?.clipEndMs);
+            const startMs = normalized?.startMs ?? rawStartMs;
+            const endMs = normalized?.endMs ?? rawEndMs;
             return {
                 title: normalized?.title || firstSafeString([clip?.title, clip?.playDescription, clip?.description]) || `Highlight ${index + 1}`,
                 description: firstSafeString([clip?.playDescription, clip?.description, clip?.text, clip?.message]) || normalized?.title || `Highlight ${index + 1}`,

--- a/js/live-game-video.js
+++ b/js/live-game-video.js
@@ -11,6 +11,37 @@ function firstSafeString(values) {
     return values.find(value => typeof value === 'string' && value.trim()) || null;
 }
 
+function getClipVideoUrl(clip) {
+    if (!clip || typeof clip !== 'object') return null;
+    const video = clip.video && typeof clip.video === 'object' ? clip.video : {};
+    return firstSafeString([
+        clip.videoUrl,
+        clip.url,
+        clip.publicUrl,
+        clip.sourceUrl,
+        video.url,
+        video.publicUrl,
+        video.sourceUrl
+    ]);
+}
+
+function normalizeAssociatedPlayers(value) {
+    const rawPlayers = Array.isArray(value) ? value : value ? [value] : [];
+    return rawPlayers
+        .map((player) => {
+            if (typeof player === 'string') {
+                return { id: player, name: player };
+            }
+            if (!player || typeof player !== 'object') return null;
+            const name = firstSafeString([player.name, player.displayName, player.fullName, player.label]);
+            const id = firstSafeString([player.id, player.playerId, player.uid]);
+            const number = firstSafeString([player.number, player.jerseyNumber]);
+            if (!name && !id && !number) return null;
+            return { id, name, number };
+        })
+        .filter(Boolean);
+}
+
 function getRecordedReplayConfig(game) {
     if (!game || typeof game !== 'object') return null;
 
@@ -132,12 +163,17 @@ export function createHighlightClipDraft({ startMs, endMs, durationMs = null, ti
     return normalized;
 }
 
-export function normalizeSavedHighlightClips(game, options = {}) {
-    const durationMs = toFiniteNumber(options.durationMs);
+export function collectRawHighlightClips(game) {
     const rawClips = [];
 
     if (Array.isArray(game?.highlightClips)) {
         rawClips.push(...game.highlightClips);
+    }
+    if (Array.isArray(game?.clipMetadata)) {
+        rawClips.push(...game.clipMetadata);
+    }
+    if (Array.isArray(game?.clips)) {
+        rawClips.push(...game.clips);
     }
     if (Array.isArray(game?.replayVideo?.highlights)) {
         rawClips.push(...game.replayVideo.highlights);
@@ -146,18 +182,67 @@ export function normalizeSavedHighlightClips(game, options = {}) {
         rawClips.push(...game.replayHighlights);
     }
 
-    return rawClips
+    return rawClips;
+}
+
+export function normalizeSavedHighlightClips(game, options = {}) {
+    const durationMs = toFiniteNumber(options.durationMs);
+
+    return collectRawHighlightClips(game)
         .map((clip, index) => {
             const normalized = createHighlightClipDraft({
                 startMs: clip?.startMs,
                 endMs: clip?.endMs,
                 durationMs,
-                title: clip?.title || `Highlight ${index + 1}`,
+                title: clip?.title || clip?.playDescription || clip?.description || `Highlight ${index + 1}`,
                 taggedPlayerIds: clip?.taggedPlayerIds
             }, options);
-            return normalized;
+            if (!normalized) return null;
+            return {
+                ...normalized,
+                description: firstSafeString([clip?.playDescription, clip?.description, clip?.text, clip?.message]) || normalized.title,
+                period: firstSafeString([clip?.period, clip?.inning, clip?.quarter, clip?.half]),
+                gameTime: firstSafeString([clip?.gameTime, clip?.clock, clip?.time]),
+                players: normalizeAssociatedPlayers(clip?.players || clip?.associatedPlayers || clip?.playerIds || clip?.playerId),
+                videoUrl: getClipVideoUrl(clip),
+                order: toFiniteNumber(clip?.order ?? clip?.sortOrder ?? clip?.sequence ?? clip?.rank) ?? index
+            };
         })
-        .filter(Boolean);
+        .filter(Boolean)
+        .sort((a, b) => (a.order - b.order) || (a.startMs - b.startMs));
+}
+
+export function normalizeGameRecapHighlightClips(game, options = {}) {
+    const durationMs = toFiniteNumber(options.durationMs);
+    const recorded = getRecordedReplayConfig(game);
+    const replayUrl = recorded?.publicUrl || recorded?.sourceUrl || null;
+
+    return collectRawHighlightClips(game)
+        .map((clip, index) => {
+            const videoUrl = getClipVideoUrl(clip) || replayUrl;
+            const normalized = createHighlightClipDraft({
+                startMs: clip?.startMs ?? clip?.clipStartMs,
+                endMs: clip?.endMs ?? clip?.clipEndMs,
+                durationMs: durationMs ?? recorded?.durationMs,
+                title: clip?.title || clip?.playDescription || clip?.description || `Highlight ${index + 1}`
+            }, options);
+            if (!normalized && !videoUrl) return null;
+            const startMs = normalized?.startMs ?? toFiniteNumber(clip?.startMs ?? clip?.clipStartMs);
+            const endMs = normalized?.endMs ?? toFiniteNumber(clip?.endMs ?? clip?.clipEndMs);
+            return {
+                title: normalized?.title || firstSafeString([clip?.title, clip?.playDescription, clip?.description]) || `Highlight ${index + 1}`,
+                description: firstSafeString([clip?.playDescription, clip?.description, clip?.text, clip?.message]) || normalized?.title || `Highlight ${index + 1}`,
+                startMs: Number.isFinite(startMs) ? startMs : null,
+                endMs: Number.isFinite(endMs) ? endMs : null,
+                period: firstSafeString([clip?.period, clip?.inning, clip?.quarter, clip?.half]),
+                gameTime: firstSafeString([clip?.gameTime, clip?.clock, clip?.time]),
+                players: normalizeAssociatedPlayers(clip?.players || clip?.associatedPlayers || clip?.playerIds || clip?.playerId),
+                videoUrl,
+                order: toFiniteNumber(clip?.order ?? clip?.sortOrder ?? clip?.sequence ?? clip?.rank) ?? index
+            };
+        })
+        .filter(Boolean)
+        .sort((a, b) => (a.order - b.order) || ((a.startMs ?? 0) - (b.startMs ?? 0)));
 }
 
 export function buildHighlightShareUrl({ origin, teamId, gameId, startMs, endMs }) {

--- a/tests/unit/live-game-video.test.js
+++ b/tests/unit/live-game-video.test.js
@@ -3,6 +3,7 @@ import {
     MAX_HIGHLIGHT_CLIP_MS,
     buildHighlightShareUrl,
     createHighlightClipDraft,
+    normalizeGameRecapHighlightClips,
     normalizeSavedHighlightClips,
     resolveReplayVideoOptions,
     shouldReloadVideoPlayback
@@ -58,9 +59,53 @@ describe('live game replay video helpers', () => {
             durationMs: 90_000
         });
 
-        expect(clips).toEqual([
-            { title: 'Layup', startMs: 5_000, endMs: 55_000 },
-            { title: 'Too long', startMs: 0, endMs: 60_000 }
+        expect(clips).toMatchObject([
+            { title: 'Layup', startMs: 5_000, endMs: 55_000, description: 'Layup' },
+            { title: 'Too long', startMs: 0, endMs: 60_000, description: 'Too long' }
+        ]);
+    });
+
+    it('normalizes game recap clip metadata with context players and links', () => {
+        const clips = normalizeGameRecapHighlightClips({
+            replayVideo: {
+                url: 'https://cdn.example.com/full-game.mp4',
+                publicUrl: 'https://video.example.com/full-game'
+            },
+            clipMetadata: [
+                {
+                    order: 2,
+                    playDescription: 'Riley hits the go-ahead three',
+                    period: 'Q4',
+                    gameTime: '0:42',
+                    playerIds: ['p1'],
+                    videoUrl: 'https://video.example.com/clip-2'
+                },
+                {
+                    order: 1,
+                    title: 'Opening run',
+                    startMs: 10_000,
+                    endMs: 35_000,
+                    players: [{ id: 'p2', name: 'Jordan', number: '12' }]
+                }
+            ]
+        });
+
+        expect(clips).toMatchObject([
+            {
+                title: 'Opening run',
+                startMs: 10_000,
+                endMs: 35_000,
+                videoUrl: 'https://video.example.com/full-game',
+                players: [{ id: 'p2', name: 'Jordan', number: '12' }]
+            },
+            {
+                title: 'Riley hits the go-ahead three',
+                description: 'Riley hits the go-ahead three',
+                period: 'Q4',
+                gameTime: '0:42',
+                videoUrl: 'https://video.example.com/clip-2',
+                players: [{ id: 'p1', name: 'p1' }]
+            }
         ]);
     });
 

--- a/tests/unit/live-game-video.test.js
+++ b/tests/unit/live-game-video.test.js
@@ -101,6 +101,8 @@ describe('live game replay video helpers', () => {
             {
                 title: 'Riley hits the go-ahead three',
                 description: 'Riley hits the go-ahead three',
+                startMs: null,
+                endMs: null,
                 period: 'Q4',
                 gameTime: '0:42',
                 videoUrl: 'https://video.example.com/clip-2',
@@ -131,9 +133,32 @@ describe('live game replay video helpers', () => {
             ]
         });
 
-        expect(clips).toEqual([
+        expect(clips).toMatchObject([
             { title: 'Assist', startMs: 12_000, endMs: 42_000, taggedPlayerIds: ['player-3'] },
             { title: 'Untagged', startMs: 45_000, endMs: 55_000 }
+        ]);
+    });
+
+    it('preserves null timing for untimed recap clips that use the replay fallback', () => {
+        const clips = normalizeGameRecapHighlightClips({
+            replayVideo: {
+                url: 'https://cdn.example.com/full-game.mp4',
+                publicUrl: 'https://video.example.com/full-game'
+            },
+            clipMetadata: [
+                {
+                    playDescription: 'Post-game note with no timestamp'
+                }
+            ]
+        });
+
+        expect(clips).toMatchObject([
+            {
+                title: 'Post-game note with no timestamp',
+                startMs: null,
+                endMs: null,
+                videoUrl: 'https://video.example.com/full-game'
+            }
         ]);
     });
 


### PR DESCRIPTION
Closes #668

## Summary
- Added a completed-game Highlights panel on the game report page.
- Normalized clip metadata from existing game highlight fields, including play descriptions, period/clock context, associated players, clip ordering, and video links.
- Added a clear empty state for completed games without clip metadata while preserving existing live stream embed behavior.

## Validation
- `npx vitest run tests/unit/live-game-video.test.js`