### PR TITLE
Fix save button appearing active for read-only calendar and shared games

### DIFF
--- a/game-plan.html
+++ b/game-plan.html
@@ -103,6 +103,12 @@
                         <span id="save-status-dot" class="w-2 h-2 rounded-full flex-shrink-0"></span>
                         <span id="save-status-text"></span>
                     </div>
+                    <div class="flex flex-col items-end gap-1">
+                        <button id="save-plan-btn" class="hidden px-6 py-3 bg-gradient-to-r from-green-600 to-green-700 text-white rounded-xl hover:from-green-700 hover:to-green-800 transition shadow-md font-semibold disabled:opacity-50 disabled:cursor-not-allowed disabled:from-gray-400 disabled:to-gray-500 disabled:hover:from-gray-400 disabled:hover:to-gray-500">
+                            Save Plan
+                        </button>
+                        <p id="save-plan-note" class="hidden text-xs text-amber-700 max-w-xs text-right"></p>
+                    </div>
                 </div>
             </div>
         </div>
@@ -594,6 +600,24 @@
             const saveStatusEl = document.getElementById('save-status');
             saveStatusEl.classList.add('hidden');
             saveStatusEl.classList.remove('flex');
+
+            const savePlanButton = document.getElementById('save-plan-btn');
+            const savePlanNote = document.getElementById('save-plan-note');
+            const isReadOnlyGame = !!game.isCalendar || !!game.isSharedGame;
+            savePlanButton.disabled = isReadOnlyGame;
+            if (game.isCalendar) {
+                savePlanButton.title = 'Create this as a scheduled game to save the plan';
+                savePlanNote.textContent = 'Calendar games are read-only. Create a scheduled game to save a plan.';
+                savePlanNote.classList.remove('hidden');
+            } else if (game.isSharedGame) {
+                savePlanButton.title = 'Shared tournament games are read-only in Game Plan right now';
+                savePlanNote.textContent = 'Shared tournament games are read-only.';
+                savePlanNote.classList.remove('hidden');
+            } else {
+                savePlanButton.title = '';
+                savePlanNote.classList.add('hidden');
+                savePlanNote.textContent = '';
+            }
 
             // Update UI with game plan data
             document.getElementById('num-periods').value = gamePlan.numPeriods;

--- a/tests/unit/game-plan-switching.test.js
+++ b/tests/unit/game-plan-switching.test.js
@@ -33,6 +33,7 @@ function createElement() {
         classList: createClassList(),
         value: '',
         innerHTML: '',
+        textContent: '',
         disabled: false,
         title: ''
     };
@@ -60,6 +61,8 @@ function buildHarness(overrides = {}) {
         'selected-game-info',
         'game-details',
         'save-status',
+        'save-plan-btn',
+        'save-plan-note',
         'num-periods',
         'period-duration',
         'sub-times-input',
@@ -231,5 +234,37 @@ describe('game plan game switching', () => {
 
         // autoSave.cancel should be called once per loadGame call
         expect(deps.autoSave.cancel).toHaveBeenCalledTimes(2);
+    });
+
+    it('disables saving for calendar games and shows an explanatory note', async () => {
+        const { harness, document } = buildHarness();
+
+        await harness.loadGame({
+            id: 'cal-abc123',
+            opponent: 'Eagles',
+            date: '2026-04-07T19:00:00.000Z',
+            isCalendar: true
+        });
+
+        const saveButton = document.getElementById('save-plan-btn');
+        const saveNote = document.getElementById('save-plan-note');
+        expect(saveButton.disabled).toBe(true);
+        expect(saveNote.classList.contains('hidden')).toBe(false);
+        expect(saveNote.textContent).toMatch(/calendar/i);
+    });
+
+    it('enables saving and hides note for regular db games', async () => {
+        const { harness, document } = buildHarness();
+
+        await harness.loadGame({
+            id: 'game-a',
+            opponent: 'Sharks',
+            date: '2026-04-04T19:00:00.000Z'
+        });
+
+        const saveButton = document.getElementById('save-plan-btn');
+        const saveNote = document.getElementById('save-plan-note');
+        expect(saveButton.disabled).toBe(false);
+        expect(saveNote.classList.contains('hidden')).toBe(true);
     });
 });


### PR DESCRIPTION
The Save Plan button was visually identical whether enabled or disabled,
so clicks on calendar/shared games silently did nothing. Now disabled
buttons render grayed-out with a not-allowed cursor, and an inline note
explains why saving is unavailable for that game type.

https://claude.ai/code/session_019A41UH6aQWrLz6tAt69Mzb