### PR TITLE
Track schedule reminder state

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -1532,6 +1532,29 @@
             alert(`${eventLabel} saved, but the team notification failed: ${error.message}`);
         }
 
+        async function refreshEventReminderStateForTeamSettings(settings) {
+            const events = await getEvents(currentTeamId);
+            for (const event of events) {
+                if (!event?.id) continue;
+                const eventType = String(event.type || 'game').toLowerCase();
+                const isCanceled = event.status === 'cancelled' || event.status === 'canceled' || event.deleted === true;
+                const payload = {
+                    scheduleNotifications: buildScheduleNotificationMetadata({
+                        settings,
+                        action: isCanceled ? 'cancelled' : 'updated',
+                        userId: currentUser?.uid || null,
+                        eventDate: event.date,
+                        canceled: isCanceled
+                    })
+                };
+                if (eventType === 'practice') {
+                    await updateEvent(currentTeamId, event.id, payload);
+                } else {
+                    await updateGame(currentTeamId, event.id, payload);
+                }
+            }
+        }
+
         async function sendRsvpReminder({
             eventId,
             eventDocId,
@@ -3354,11 +3377,13 @@
 
             try {
                 await updateTeam(currentTeamId, { scheduleNotifications: nextSettings });
+                await refreshEventReminderStateForTeamSettings(nextSettings);
                 currentTeam = {
                     ...(currentTeam || {}),
                     scheduleNotifications: nextSettings
                 };
                 renderTeamScheduleNotificationSettings(currentTeam);
+                await loadSchedule();
                 alert('Schedule reminder settings saved.');
             } catch (error) {
                 alert('Error saving reminder settings: ' + error.message);

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -115,6 +115,7 @@
                     <button id="save-team-reminder-settings-btn" type="button" class="w-full bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 transition">Save Reminder Settings</button>
                 </div>
             </div>
+            <p id="team-reminder-settings-summary" class="mt-3 text-sm text-gray-600"></p>
         </div>
 
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
@@ -1459,8 +1460,10 @@
             const windowDescription = describeScheduleReminderWindow(rawSettings);
             const enabledEl = document.getElementById('team-reminder-enabled');
             const hoursEl = document.getElementById('team-reminder-hours');
+            const summaryEl = document.getElementById('team-reminder-settings-summary');
             if (enabledEl) enabledEl.checked = settings.enabled;
             if (hoursEl) hoursEl.value = String(settings.reminderHours);
+            if (summaryEl) summaryEl.textContent = windowDescription;
             ['game', 'practice'].forEach((eventType) => {
                 const summaryEl = document.getElementById(`${eventType}-reminder-window-summary`);
                 const detailEl = document.getElementById(`${eventType}-reminder-window-detail`);

--- a/js/schedule-notifications.js
+++ b/js/schedule-notifications.js
@@ -53,23 +53,36 @@ export function buildScheduleNotificationMetadata({
     sent = false,
     userId = null,
     note = null,
-    eventDate = null
+    eventDate = null,
+    cancelled = false,
+    canceled = false
 } = {}) {
     const normalized = normalizeScheduleNotificationSettings(settings);
     const effectiveReminderHours = coerceReminderHours(reminderHours, normalized.reminderHours);
-    const nextReminderAt = normalized.enabled ? buildNextReminderAt(eventDate, effectiveReminderHours) : null;
+    const isCanceled = cancelled || canceled || action === 'cancelled' || action === 'canceled' || action === 'deleted';
+    const nextReminderAt = normalized.enabled && !isCanceled ? buildNextReminderAt(eventDate, effectiveReminderHours) : null;
+    const reminderStatus = isCanceled
+        ? 'canceled'
+        : nextReminderAt
+            ? 'pending'
+            : 'disabled';
+    const sentAt = sent ? new Date().toISOString() : null;
+    const canceledAt = isCanceled ? new Date().toISOString() : null;
     return {
         enabled: normalized.enabled,
         reminderHours: effectiveReminderHours,
         delivery: normalized.delivery,
         nextReminderAt,
-        reminderStatus: nextReminderAt ? 'pending' : 'disabled',
+        reminderStatus,
         reminderSent: false,
         reminderSentAt: null,
+        reminderCanceled: isCanceled,
+        reminderCanceledAt: canceledAt,
+        reminderCanceledBy: isCanceled ? (userId || null) : null,
         sent,
-        sentAt: sent ? new Date().toISOString() : null,
+        sentAt,
         lastAction: action || null,
-        lastSentAt: sent ? new Date().toISOString() : null,
+        lastSentAt: sentAt,
         lastSentBy: sent ? (userId || null) : null,
         lastNote: note ? String(note).trim() : null
     };

--- a/tests/unit/edit-schedule-notifications.test.js
+++ b/tests/unit/edit-schedule-notifications.test.js
@@ -11,7 +11,11 @@ describe('edit schedule notification wiring', () => {
 
         expect(source).toContain('id="schedule-notification-settings"');
         expect(source).toContain('id="team-reminder-hours"');
+        expect(source).toContain('<option value="24">24 hours before</option>');
+        expect(source).toContain('<option value="48">48 hours before</option>');
+        expect(source).toContain('<option value="72">72 hours before</option>');
         expect(source).toContain('id="save-team-reminder-settings-btn"');
+        expect(source).toContain('id="team-reminder-settings-summary"');
     });
 
     it('includes notify-team and reminder-window controls in game and practice forms', () => {
@@ -42,7 +46,7 @@ describe('edit schedule notification wiring', () => {
         const source = readEditSchedule();
 
         expect(source).toContain('const windowDescription = describeScheduleReminderWindow(rawSettings);');
-        expect(source).toContain('summaryEl.textContent = windowDescription;');
+        expect(source).toContain('if (summaryEl) summaryEl.textContent = windowDescription;');
         expect(source).toContain('Inherited from the team reminder default');
     });
 
@@ -52,6 +56,15 @@ describe('edit schedule notification wiring', () => {
         expect(source).toContain('async function refreshEventReminderStateForTeamSettings(settings)');
         expect(source).toContain('await refreshEventReminderStateForTeamSettings(nextSettings);');
         expect(source).toContain("action: isCanceled ? 'cancelled' : 'updated'");
+    });
+
+    it('persists normalized team reminder settings to the team metadata path', () => {
+        const source = readEditSchedule();
+
+        expect(source).toContain('await updateTeam(currentTeamId, { scheduleNotifications: nextSettings });');
+        expect(source).toContain('reminderHours: document.getElementById(\'team-reminder-hours\').value');
+        expect(source).toContain('currentTeam = {\n                    ...(currentTeam || {}),\n                    scheduleNotifications: nextSettings\n                };');
+        expect(source).toContain('renderTeamScheduleNotificationSettings(currentTeam);');
     });
 
     it('uses the submitted linked-opponent state for counterpart notifications', () => {

--- a/tests/unit/edit-schedule-notifications.test.js
+++ b/tests/unit/edit-schedule-notifications.test.js
@@ -46,6 +46,14 @@ describe('edit schedule notification wiring', () => {
         expect(source).toContain('Inherited from the team reminder default');
     });
 
+    it('refreshes stored event reminder state when team reminder settings change', () => {
+        const source = readEditSchedule();
+
+        expect(source).toContain('async function refreshEventReminderStateForTeamSettings(settings)');
+        expect(source).toContain('await refreshEventReminderStateForTeamSettings(nextSettings);');
+        expect(source).toContain("action: isCanceled ? 'cancelled' : 'updated'");
+    });
+
     it('uses the submitted linked-opponent state for counterpart notifications', () => {
         const source = readEditSchedule();
 

--- a/tests/unit/schedule-notifications.test.js
+++ b/tests/unit/schedule-notifications.test.js
@@ -63,10 +63,44 @@ describe('schedule notification helpers', () => {
             reminderStatus: 'pending',
             reminderSent: false,
             reminderSentAt: null,
+            reminderCanceled: false,
+            reminderCanceledAt: null,
             sent: false,
             sentAt: null,
             lastAction: 'created'
         });
+    });
+
+    it('marks disabled and canceled reminder state without leaving a due timestamp', () => {
+        expect(buildScheduleNotificationMetadata({
+            settings: { enabled: false, reminderHours: 24 },
+            action: 'updated',
+            eventDate: '2026-05-03T18:00:00.000Z'
+        })).toMatchObject({
+            enabled: false,
+            nextReminderAt: null,
+            reminderStatus: 'disabled',
+            reminderSent: false,
+            reminderCanceled: false
+        });
+
+        const canceledMetadata = buildScheduleNotificationMetadata({
+            settings: { enabled: true, reminderHours: 24 },
+            action: 'cancelled',
+            userId: 'coach-1',
+            eventDate: '2026-05-03T18:00:00.000Z'
+        });
+
+        expect(canceledMetadata).toMatchObject({
+            enabled: true,
+            nextReminderAt: null,
+            reminderStatus: 'canceled',
+            reminderSent: false,
+            reminderCanceled: true,
+            reminderCanceledBy: 'coach-1',
+            lastAction: 'cancelled'
+        });
+        expect(canceledMetadata.reminderCanceledAt).toEqual(expect.any(String));
     });
 
     it('builds schedule change messages with event context and coach note', () => {


### PR DESCRIPTION
Closes #660

## Summary
- Store explicit pending, disabled, and canceled reminder state with next reminder timestamps and audit fields.
- Recalculate reminder metadata when team reminder settings change across existing events.
- Added focused unit coverage for reminder metadata and edit-schedule wiring.

## Tests
- `npx vitest run tests/unit/schedule-notifications.test.js tests/unit/edit-schedule-notifications.test.js`