### PR TITLE
Allow delegated scorekeepers into Game Day

### DIFF
--- a/docs/pr-notes/runs/716-ci-fix-20260504T190839Z/architecture.md
+++ b/docs/pr-notes/runs/716-ci-fix-20260504T190839Z/architecture.md
@@ -1,0 +1,13 @@
+# Architecture Notes
+
+## Root cause
+The Firestore rules already grant scoped scorekeeper game updates through `isScorekeepingGameUpdate(teamId, gameId)`, but the unit test asserts an exact single-line `allow update` rule that predates the additional official-game update path.
+
+## Minimal safe decision
+Keep the production rule unchanged. Update the wiring test to assert the effective access predicates are present in the games update rule instead of requiring the outdated exact line.
+
+## Risk and blast radius
+Blast radius is limited to test code. No runtime behavior or Firestore access control changes are introduced.
+
+## Rollback
+Revert the test assertion change if the rules contract changes back to a single owner/admin plus scorekeeper predicate.

--- a/docs/pr-notes/runs/716-ci-fix-20260504T190839Z/code-plan.md
+++ b/docs/pr-notes/runs/716-ci-fix-20260504T190839Z/code-plan.md
@@ -1,0 +1,14 @@
+# Code Plan
+
+## Files to inspect/change
+- Inspect: `firestore.rules`
+- Change: `tests/unit/scorekeeping-access-wiring.test.js`
+
+## Minimal patch
+Replace the exact `allow update` string assertion with assertions that the rules include the owner/admin branch and the scoped scorekeeping update predicate. Leave Firestore rules unchanged.
+
+## Validation command
+`npm test -- --run tests/unit/scorekeeping-access-wiring.test.js`
+
+## Commit message
+`fix:address-ci-failure: update scorekeeping rules assertion`

--- a/docs/pr-notes/runs/716-ci-fix-20260504T190839Z/qa.md
+++ b/docs/pr-notes/runs/716-ci-fix-20260504T190839Z/qa.md
@@ -1,0 +1,10 @@
+# QA Notes
+
+## Affected behavior
+Only the unit-test expectation for Firestore scorekeeping access wiring is affected. The test should continue to prove scorekeeper writes are allowed for game score updates/events/stats and roster or schedule delete/write controls remain restricted.
+
+## Validation
+Run `npm test -- --run tests/unit/scorekeeping-access-wiring.test.js` for the focused failing area, then `npm test` if time permits.
+
+## Pass criteria
+The scorekeeping access wiring test passes locally and the full unit suite has no failures.

--- a/docs/pr-notes/runs/716-remediator-20260504T180822Z/architecture.md
+++ b/docs/pr-notes/runs/716-remediator-20260504T180822Z/architecture.md
@@ -1,0 +1,11 @@
+# Architecture
+
+## Decisions
+- Enforce scorekeeper scope server-side in `firestore.rules`, not in client code.
+- Keep `status` and `liveStatus` in the scorekeeper update allowlist because live scoring flows use non-destructive lifecycle transitions.
+- Add an explicit lifecycle guard to reject destructive post-update document states for delegated scorekeepers.
+
+## Risk And Rollback
+- Blast radius is limited to delegated scorekeeper updates on `teams/{teamId}/games/{gameId}`.
+- Admin and owner update paths are unchanged.
+- Rollback is reverting the single Firestore rules change if a legitimate scorekeeper flow is blocked.

--- a/docs/pr-notes/runs/716-remediator-20260504T180822Z/code-plan.md
+++ b/docs/pr-notes/runs/716-remediator-20260504T180822Z/code-plan.md
@@ -1,0 +1,9 @@
+# Code Plan
+
+## Implementation Plan
+- Update `firestore.rules` only.
+- Keep scorekeeping update fields scoped to the existing list.
+- Factor destructive lifecycle rejection into an explicit helper used by `isScorekeepingGameUpdate` so the post-update state cannot be `status == cancelled` or `liveStatus == deleted`.
+
+## Notes
+- Subagent history was not readable from this remediator session due session visibility restrictions, so these role notes capture the inline fallback analysis required before implementation.

--- a/docs/pr-notes/runs/716-remediator-20260504T180822Z/qa.md
+++ b/docs/pr-notes/runs/716-remediator-20260504T180822Z/qa.md
@@ -1,0 +1,12 @@
+# QA Plan
+
+## Validation
+- Static inspect `firestore.rules` to confirm `isScorekeepingGameUpdate` requires both field allowlist and non-destructive lifecycle state.
+- Confirm owner/admin path remains `isTeamOwnerOrAdmin(teamId) || isScorekeepingGameUpdate(teamId, gameId)`.
+- No automated test runner is defined in `AGENTS.md`; manual Firebase rules emulator tests are recommended if available in CI.
+
+## Scenarios
+- Non-admin scorekeeper updating score fields succeeds when game is not cancelled/deleted.
+- Non-admin scorekeeper update with `status: cancelled` is rejected.
+- Non-admin scorekeeper update with `liveStatus: deleted` is rejected.
+- Owner/admin can still cancel or delete according to existing permissions.

--- a/docs/pr-notes/runs/716-remediator-20260504T180822Z/requirements.md
+++ b/docs/pr-notes/runs/716-remediator-20260504T180822Z/requirements.md
@@ -1,0 +1,11 @@
+# Requirements
+
+## Acceptance Criteria
+- Delegated scorekeepers may continue to write scoring fields for active, visible games.
+- Delegated scorekeepers must not be able to set `status` to `cancelled`.
+- Delegated scorekeepers must not be able to set `liveStatus` to `deleted`.
+- Team owners, team admins, and global admins retain existing schedule-level permissions.
+
+## Scope
+- Minimal Firestore rules change only.
+- No client behavior or data model changes.

--- a/firestore.rules
+++ b/firestore.rules
@@ -49,14 +49,18 @@ service cloud.firestore {
              );
     }
 
+    function keepsScorekeeperGameLifecycleVisible() {
+      return request.resource.data.get('status', resource.data.get('status', 'scheduled')) != 'cancelled' &&
+             request.resource.data.get('liveStatus', resource.data.get('liveStatus', '')) != 'deleted';
+    }
+
     function isScorekeepingGameUpdate(teamId, gameId) {
       return canScorekeepGame(teamId, gameId) &&
              request.resource.data.diff(resource.data).affectedKeys().hasOnly([
                'homeScore', 'awayScore', 'summary', 'status', 'liveStatus', 'opponentStats',
                'completedAt', 'completedBy', 'completedByName', 'updatedAt'
              ]) &&
-             request.resource.data.get('status', 'scheduled') != 'cancelled' &&
-             request.resource.data.get('liveStatus', '') != 'deleted';
+             keepsScorekeeperGameLifecycleVisible();
     }
 
     // Check if user is a parent for a specific player.

--- a/firestore.rules
+++ b/firestore.rules
@@ -54,7 +54,9 @@ service cloud.firestore {
              request.resource.data.diff(resource.data).affectedKeys().hasOnly([
                'homeScore', 'awayScore', 'summary', 'status', 'liveStatus', 'opponentStats',
                'completedAt', 'completedBy', 'completedByName', 'updatedAt'
-             ]);
+             ]) &&
+             request.resource.data.get('status', 'scheduled') != 'cancelled' &&
+             request.resource.data.get('liveStatus', '') != 'deleted';
     }
 
     // Check if user is a parent for a specific player.

--- a/firestore.rules
+++ b/firestore.rules
@@ -28,6 +28,35 @@ service cloud.firestore {
               isGlobalAdmin());
     }
 
+
+    function hasConfirmedGameRsvp(teamId, gameId) {
+      let rsvpPath = /databases/$(database)/documents/teams/$(teamId)/games/$(gameId)/rsvps/$(request.auth.uid);
+      return exists(rsvpPath) &&
+             get(rsvpPath).data.get('response', get(rsvpPath).data.get('status', '')) in ['going', 'yes', 'confirmed', 'attending'];
+    }
+
+    function canScorekeepGame(teamId, gameId) {
+      let team = get(/databases/$(database)/documents/teams/$(teamId)).data;
+      let permission = team.get('teamPermissions', {}).get('scorekeeping', {});
+      let mode = permission.get('mode', '');
+      return isSignedIn() &&
+             !isTeamOwnerOrAdmin(teamId) &&
+             get(/databases/$(database)/documents/teams/$(teamId)/games/$(gameId)).data.get('status', 'scheduled') != 'cancelled' &&
+             get(/databases/$(database)/documents/teams/$(teamId)/games/$(gameId)).data.get('liveStatus', '') != 'deleted' &&
+             (
+               (mode == 'all_confirmed' && hasConfirmedGameRsvp(teamId, gameId)) ||
+               (mode == 'selected' && request.auth.uid in permission.get('memberIds', []))
+             );
+    }
+
+    function isScorekeepingGameUpdate(teamId, gameId) {
+      return canScorekeepGame(teamId, gameId) &&
+             request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+               'homeScore', 'awayScore', 'summary', 'status', 'liveStatus', 'opponentStats',
+               'completedAt', 'completedBy', 'completedByName', 'updatedAt'
+             ]);
+    }
+
     // Check if user is a parent for a specific player.
     // IMPORTANT: must validate both teamId AND playerId (least privilege).
     // Uses denormalized key `${teamId}::${playerId}` in users.parentPlayerKeys.
@@ -509,32 +538,28 @@ service cloud.firestore {
       match /games/{gameId} {
         allow read: if true;  // Public game data
         allow create, delete: if isTeamOwnerOrAdmin(teamId);
-        allow update: if isTeamOwnerOrAdmin(teamId) || (isOfficialForGame() && isOfficialGameUpdate());
+        allow update: if isTeamOwnerOrAdmin(teamId) ||
+                        (isOfficialForGame() && isOfficialGameUpdate()) ||
+                        isScorekeepingGameUpdate(teamId, gameId);
 
         // Events subcollection
         match /events/{eventId} {
           allow read: if true;
-          allow write: if isSignedIn() &&
-                          (get(/databases/$(database)/documents/teams/$(teamId)).data.ownerId == request.auth.uid ||
-                           (request.auth.token.email != null &&
-                            request.auth.token.email.lower() in get(/databases/$(database)/documents/teams/$(teamId)).data.get('adminEmails', [])) ||
-                            isGlobalAdmin());
+          allow create, update: if isTeamOwnerOrAdmin(teamId) || canScorekeepGame(teamId, gameId);
+          allow delete: if isTeamOwnerOrAdmin(teamId);
         }
 
         // Aggregated stats subcollection
         match /aggregatedStats/{statId} {
           allow read: if true;
-          allow write: if isSignedIn() &&
-                          (get(/databases/$(database)/documents/teams/$(teamId)).data.ownerId == request.auth.uid ||
-                           (request.auth.token.email != null &&
-                            request.auth.token.email.lower() in get(/databases/$(database)/documents/teams/$(teamId)).data.get('adminEmails', [])) ||
-                            isGlobalAdmin());
+          allow create, update: if isTeamOwnerOrAdmin(teamId) || canScorekeepGame(teamId, gameId);
+          allow delete: if isTeamOwnerOrAdmin(teamId);
         }
 
         // Live Events subcollection - for real-time game broadcasting
         match /liveEvents/{eventId} {
           allow read: if true;  // Public read for viewers
-          allow create: if isTeamOwnerOrAdmin(teamId);  // Only stat tracker can write
+          allow create: if isTeamOwnerOrAdmin(teamId) || canScorekeepGame(teamId, gameId);  // Stat tracker writes
           allow update, delete: if false;  // Events are immutable
         }
 

--- a/game-day.html
+++ b/game-day.html
@@ -961,12 +961,18 @@
                 }
                 state.game = game;
 
-                const streamRsvp = String(team.streamAccessMode || '').toLowerCase() === 'confirmed_members'
+                const needsRsvpForScopedAccess = ['confirmed_members', 'all_confirmed'].includes(String(team.streamAccessMode || '').toLowerCase())
+                    || String(team.teamPermissions?.scorekeeping?.mode || '').toLowerCase() === 'all_confirmed';
+                const scopedRsvp = needsRsvpForScopedAccess
                     ? await getMyRsvp(teamId, resolvedGameId, state.user.uid).catch(() => null)
                     : null;
-                const accessInfo = getTeamAccessInfo(state.user, { ...team, id: teamId }, { game, rsvp: streamRsvp });
-                if (!accessInfo.hasAccess || (accessInfo.accessLevel !== 'full' && accessInfo.accessLevel !== 'stream')) {
-                    window.location.href = `team.html#teamId=${teamId}&message=Game+Day+is+for+coaches,+admins,+and+approved+streaming+volunteers+only`;
+                const accessInfo = getTeamAccessInfo(state.user, { ...team, id: teamId }, { game, rsvp: scopedRsvp });
+                if (!accessInfo.hasAccess || !['full', 'scorekeep', 'stream'].includes(accessInfo.accessLevel)) {
+                    window.location.href = `team.html#teamId=${teamId}&message=Game+Day+is+for+coaches,+admins,+approved+scorekeepers,+and+approved+streaming+volunteers+only`;
+                    return;
+                }
+                if (accessInfo.accessLevel === 'scorekeep') {
+                    renderLimitedScorekeepingAccess(accessInfo);
                     return;
                 }
                 if (accessInfo.accessLevel === 'stream') {
@@ -2453,6 +2459,49 @@ Respond ONLY with valid JSON.`;
             if (channelMatch) return `https://www.youtube.com/channel/${encodeURIComponent(channelMatch[1])}/live`;
             if (videoMatch) return `https://www.youtube.com/watch?v=${encodeURIComponent(videoMatch[1])}`;
             return '';
+        }
+
+
+        function getScorekeepingTrackerUrl() {
+            const config = state.game?.statTrackerConfigId && Array.isArray(state.configs)
+                ? state.configs.find((c) => c.id === state.game.statTrackerConfigId)
+                : null;
+            const baseType = String(config?.baseType || '').toLowerCase();
+            const page = baseType === 'basketball' ? 'track-basketball.html' : 'track.html';
+            return `${page}#teamId=${encodeURIComponent(state.teamId)}&gameId=${encodeURIComponent(state.gameId)}`;
+        }
+
+        function renderLimitedScorekeepingAccess(accessInfo) {
+            hideLoading();
+            const trackerUrl = getScorekeepingTrackerUrl();
+            const watchUrl = `live-game.html#teamId=${encodeURIComponent(state.teamId)}&gameId=${encodeURIComponent(state.gameId)}`;
+            renderTeamAdminBanner(document.getElementById('banner-container'), {
+                team: state.team,
+                teamId: state.teamId,
+                active: 'gameday',
+                accessLevel: accessInfo.accessLevel,
+                exitUrl: accessInfo.exitUrl
+            });
+            const gameTitle = state.game?.opponent ? `vs ${escapeHtml(state.game.opponent)}` : 'Scheduled event';
+            document.getElementById('game-subbanner')?.classList.add('hidden');
+            document.getElementById('pre-game-view')?.classList.add('hidden');
+            document.getElementById('game-day-view')?.classList.add('hidden');
+            document.getElementById('wrap-up-view')?.classList.add('hidden');
+            const main = document.createElement('main');
+            main.className = 'max-w-3xl mx-auto px-4 py-8';
+            main.innerHTML = `
+                <section class="bg-white rounded-2xl shadow-sm border border-gray-200 p-6 space-y-4">
+                    <div>
+                        <div class="text-xs font-semibold uppercase tracking-wide text-emerald-600">Scorekeeping access</div>
+                        <h1 class="text-2xl font-bold text-gray-900 mt-1">${gameTitle}</h1>
+                        <p class="text-sm text-gray-600 mt-2">You can start or continue live scorekeeping for this scheduled game. Roster management, schedule editing, team settings, and other coach/admin controls remain restricted.</p>
+                    </div>
+                    <div class="flex flex-col sm:flex-row gap-3">
+                        <a href="${trackerUrl}" class="inline-flex items-center justify-center rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700">Open scorekeeper</a>
+                        <a href="${watchUrl}" class="inline-flex items-center justify-center rounded-lg bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-gray-800">Open live viewer</a>
+                    </div>
+                </section>`;
+            document.getElementById('footer-container')?.before(main);
         }
 
         function renderLimitedStreamAccess(accessInfo) {

--- a/js/team-access.js
+++ b/js/team-access.js
@@ -65,9 +65,29 @@ export function hasStreamTeamAccess(user, team, game = null, rsvp = null) {
   return false;
 }
 
+
+/**
+ * Check whether a user can scorekeep a scheduled game without full team access.
+ * Scorekeeping access never implies team management, roster, schedule, or settings access.
+ */
+export function hasScorekeepingTeamAccess(user, team, game = null, rsvp = null) {
+  if (!user || !team || !isScheduledGame(game)) return false;
+  if (hasFullTeamAccess(user, team)) return true;
+
+  if (!team.teamPermissions?.scorekeeping) return false;
+
+  const permissions = normalizeTeamPermissions(team.teamPermissions);
+  const scorekeeping = permissions.scorekeeping;
+  if (scorekeeping.mode === 'all_confirmed') {
+    return hasConfirmedRsvp(rsvp);
+  }
+
+  return normalizeMemberIdList(scorekeeping.memberIds).includes(String(user.uid || '').trim());
+}
+
 /**
  * Determine user's access level for a team.
- * @returns {{ hasAccess: boolean, accessLevel: 'full'|'stream'|'parent'|null, exitUrl: string }}
+ * @returns {{ hasAccess: boolean, accessLevel: 'full'|'scorekeep'|'stream'|'parent'|null, exitUrl: string }}
  */
 export function getTeamAccessInfo(user, team, options = {}) {
   if (!user || !team) {
@@ -76,6 +96,11 @@ export function getTeamAccessInfo(user, team, options = {}) {
 
   if (hasFullTeamAccess(user, team)) {
     return { hasAccess: true, accessLevel: 'full', exitUrl: 'dashboard.html' };
+  }
+
+  if (hasScorekeepingTeamAccess(user, team, options.game, options.rsvp)) {
+    const teamExitUrl = team.id ? `team.html#teamId=${team.id}` : 'team.html';
+    return { hasAccess: true, accessLevel: 'scorekeep', exitUrl: teamExitUrl };
   }
 
   if (hasStreamTeamAccess(user, team, options.game, options.rsvp)) {

--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -1,5 +1,5 @@
 // Mobile-first basketball tracker, now backed by Firebase like track.html.
-import { getTeam, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query } from './db.js?v=29';
+import { getTeam, getGame, getPlayers, getConfigs, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './db.js?v=29';
 import { db } from './firebase.js?v=11';
 import { getUrlParams, escapeHtml } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=13';
@@ -8,6 +8,7 @@ import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai
 import { getApp } from './vendor/firebase-app.js';
 import { canApplySubstitution, applySubstitution, resolveFinalScoreForCompletion } from './live-tracker-integrity.js?v=3';
 import { resolveFinalScore, resolveSummaryRecipient } from './live-tracker-email.js?v=2';
+import { hasScorekeepingTeamAccess } from './team-access.js?v=2';
 
 let currentTeamId = null;
 let currentGameId = null;
@@ -1339,6 +1340,16 @@ async function init() {
     if (game.type === 'practice') {
       alert('Practice events cannot be tracked.');
       window.location.href = `edit-schedule.html#teamId=${teamId}`;
+      return;
+    }
+
+    const needsScorekeepingRsvp = String(team?.teamPermissions?.scorekeeping?.mode || '').toLowerCase() === 'all_confirmed';
+    const scorekeepingRsvp = needsScorekeepingRsvp
+      ? await getMyRsvp(teamId, gameId, currentUser.uid).catch(() => null)
+      : null;
+    if (!hasScorekeepingTeamAccess(currentUser, { ...team, id: teamId }, game, scorekeepingRsvp)) {
+      alert('You do not have scorekeeping access for this game.');
+      window.location.href = `team.html#teamId=${teamId}`;
       return;
     }
 

--- a/tests/unit/scorekeeping-access-wiring.test.js
+++ b/tests/unit/scorekeeping-access-wiring.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+describe('scorekeeping access wiring', () => {
+    it('wires Game Day to limited scorekeeping access instead of full admin only', () => {
+        const source = readFileSync(resolve(process.cwd(), 'game-day.html'), 'utf8');
+
+        expect(source).toContain("['full', 'scorekeep', 'stream'].includes(accessInfo.accessLevel)");
+        expect(source).toContain("accessInfo.accessLevel === 'scorekeep'");
+        expect(source).toContain('renderLimitedScorekeepingAccess(accessInfo)');
+        expect(source).toContain('Roster management, schedule editing, team settings, and other coach/admin controls remain restricted.');
+
+        const workflow = readFileSync(resolve(process.cwd(), 'workflow-track-game.html'), 'utf8');
+        expect(workflow).toContain('approved scorekeeper for the scheduled game');
+        expect(workflow).toContain('do not receive roster, schedule, or team settings access');
+    });
+
+    it('gates both live scoring trackers with scorekeeping access', () => {
+        const standardTracker = readFileSync(resolve(process.cwd(), 'track.html'), 'utf8');
+        const basketballTracker = readFileSync(resolve(process.cwd(), 'js/track-basketball.js'), 'utf8');
+
+        expect(standardTracker).toContain("import { hasScorekeepingTeamAccess } from './js/team-access.js?v=2';");
+        expect(standardTracker).toContain('hasScorekeepingTeamAccess(currentUser, { ...team, id: teamId }, game, scorekeepingRsvp)');
+        expect(basketballTracker).toContain("import { hasScorekeepingTeamAccess } from './team-access.js?v=2';");
+        expect(basketballTracker).toContain('hasScorekeepingTeamAccess(currentUser, { ...team, id: teamId }, game, scorekeepingRsvp)');
+    });
+
+    it('allows scoped scorekeeper writes in Firestore rules without opening roster or schedule writes', () => {
+        const rules = readFileSync(resolve(process.cwd(), 'firestore.rules'), 'utf8');
+
+        expect(rules).toContain('function canScorekeepGame(teamId, gameId)');
+        expect(rules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isScorekeepingGameUpdate(teamId, gameId);');
+        expect(rules).toContain('allow create, update: if isTeamOwnerOrAdmin(teamId) || canScorekeepGame(teamId, gameId);');
+        expect(rules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId);');
+    });
+});

--- a/tests/unit/scorekeeping-access-wiring.test.js
+++ b/tests/unit/scorekeeping-access-wiring.test.js
@@ -30,7 +30,7 @@ describe('scorekeeping access wiring', () => {
         const rules = readFileSync(resolve(process.cwd(), 'firestore.rules'), 'utf8');
 
         expect(rules).toContain('function canScorekeepGame(teamId, gameId)');
-        expect(rules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isScorekeepingGameUpdate(teamId, gameId);');
+        expect(rules).toMatch(/allow update: if isTeamOwnerOrAdmin\(teamId\) \|\|\s+\(isOfficialForGame\(\) && isOfficialGameUpdate\(\)\) \|\|\s+isScorekeepingGameUpdate\(teamId, gameId\);/);
         expect(rules).toContain('allow create, update: if isTeamOwnerOrAdmin(teamId) || canScorekeepGame(teamId, gameId);');
         expect(rules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId);');
     });

--- a/tests/unit/scorekeeping-access.test.js
+++ b/tests/unit/scorekeeping-access.test.js
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { getTeamAccessInfo, hasFullTeamAccess, hasScorekeepingTeamAccess } from '../../js/team-access.js';
+
+const TEAM = {
+    id: 'team-1',
+    ownerId: 'owner-1',
+    adminEmails: ['admin@example.com']
+};
+const GAME = { id: 'game-1', status: 'scheduled' };
+
+describe('scorekeeping access helpers', () => {
+    it('grants delegated scorekeepers limited scorekeeping access without full access', () => {
+        const team = {
+            ...TEAM,
+            teamPermissions: {
+                scorekeeping: { mode: 'selected', memberIds: ['scorekeeper-1'] }
+            }
+        };
+        const user = { uid: 'scorekeeper-1', email: 'volunteer@example.com' };
+
+        expect(hasScorekeepingTeamAccess(user, team, GAME)).toBe(true);
+        expect(hasFullTeamAccess(user, team)).toBe(false);
+        expect(getTeamAccessInfo(user, team, { game: GAME })).toEqual({
+            hasAccess: true,
+            accessLevel: 'scorekeep',
+            exitUrl: 'team.html#teamId=team-1'
+        });
+    });
+
+    it('grants any confirmed member scorekeeping access when enabled', () => {
+        const team = {
+            ...TEAM,
+            teamPermissions: {
+                scorekeeping: { mode: 'all_confirmed', memberIds: [] }
+            }
+        };
+
+        expect(hasScorekeepingTeamAccess({ uid: 'member-1' }, team, GAME, { response: 'going' })).toBe(true);
+        expect(hasScorekeepingTeamAccess({ uid: 'member-1' }, team, GAME, { response: 'maybe' })).toBe(false);
+    });
+
+    it('denies confirmed users when scorekeeping permissions are not configured', () => {
+        expect(hasScorekeepingTeamAccess({ uid: 'member-1' }, TEAM, GAME, { response: 'going' })).toBe(false);
+    });
+
+    it('denies users without full access or scorekeeping permission', () => {
+        const team = {
+            ...TEAM,
+            teamPermissions: {
+                scorekeeping: { mode: 'selected', memberIds: ['scorekeeper-1'] }
+            }
+        };
+
+        expect(hasScorekeepingTeamAccess({ uid: 'random-1' }, team, GAME)).toBe(false);
+        expect(getTeamAccessInfo({ uid: 'random-1' }, team, { game: GAME })).toEqual({
+            hasAccess: false,
+            accessLevel: null,
+            exitUrl: 'index.html'
+        });
+    });
+
+    it('does not grant scorekeeping access for cancelled games', () => {
+        const team = {
+            ...TEAM,
+            teamPermissions: {
+                scorekeeping: { mode: 'selected', memberIds: ['scorekeeper-1'] }
+            }
+        };
+
+        expect(hasScorekeepingTeamAccess({ uid: 'scorekeeper-1' }, team, { id: 'game-1', status: 'cancelled' })).toBe(false);
+    });
+});

--- a/track.html
+++ b/track.html
@@ -273,13 +273,14 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, collection, getDocs, deleteDoc, query } from './js/db.js?v=29';
+        import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './js/db.js?v=29';
         import { db } from './js/firebase.js?v=11';
         import { writeBatch, doc, setDoc, addDoc } from './js/firebase.js?v=11';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=13';
         import { isAISummaryEnabled, applyAISummaryAvailability } from './js/track-ai-summary.js';
         import { resolveSummaryRecipient } from './js/live-tracker-email.js?v=1';
+        import { hasScorekeepingTeamAccess } from './js/team-access.js?v=2';
         import { commitStandardTrackerFinishData } from './js/track-finish.js?v=1';
         import { getApp } from './js/vendor/firebase-app.js';
         // Note: firebase-ai will be lazy-loaded when AI summary is requested
@@ -356,6 +357,16 @@
                 if (game.type === 'practice') {
                     alert('Practice events cannot be tracked. Use game tracking for games only.');
                     window.location.href = `edit-schedule.html#teamId=${teamId}`;
+                    return;
+                }
+
+                const needsScorekeepingRsvp = String(team?.teamPermissions?.scorekeeping?.mode || '').toLowerCase() === 'all_confirmed';
+                const scorekeepingRsvp = needsScorekeepingRsvp
+                    ? await getMyRsvp(teamId, gameId, currentUser.uid).catch(() => null)
+                    : null;
+                if (!hasScorekeepingTeamAccess(currentUser, { ...team, id: teamId }, game, scorekeepingRsvp)) {
+                    alert('You do not have scorekeeping access for this game.');
+                    window.location.href = `team.html#teamId=${teamId}`;
                     return;
                 }
 

--- a/workflow-track-game.html
+++ b/workflow-track-game.html
@@ -285,7 +285,7 @@
             </section>
             <section class="wf-panel-section">
               <h2 class="wf-panel-title">Who can use this</h2>
-              <div class="wf-roles"><span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span></div>
+              <div class="wf-roles"><span class="wf-role-chip">Coach</span> <span class="wf-role-chip">Admin</span> <span class="wf-role-chip">Scorekeeper</span></div>
             </section>
           </aside>
 
@@ -306,10 +306,11 @@
 <ul class="ml-6 list-disc space-y-1">
 <li>Coaches who enter live stats, manage periods, and handle substitutions.</li>
 <li>Admins who support tracking, verify final accuracy, and finalize report details.</li>
+<li>Delegated scorekeepers assigned by staff, or confirmed members when team scorekeeping access allows it.</li>
 </ul>
 <h2 id="prerequisites">Prerequisites</h2>
 <ul class="ml-6 list-disc space-y-1">
-<li>You are signed in as a coach or admin.</li>
+<li>You are signed in as a coach, admin, or approved scorekeeper for the scheduled game.</li>
 <li>You are opening a game event, not a practice.</li>
 <li>The game has a valid team and game context (<code>teamId</code> and <code>gameId</code>).</li>
 <li>A tracker configuration exists for the team.</li>
@@ -357,6 +358,7 @@
 <ul class="ml-6 list-disc space-y-1">
 <li>Coaches prioritize real-time event entry, period changes, substitutions, and notes.</li>
 <li>Admins verify opponent setup and score accuracy for final reporting.</li>
+<li>Delegated scorekeepers focus on live score entry and do not receive roster, schedule, or team settings access.</li>
 </ul>
 <ol class="ml-6 list-decimal space-y-1">
 <li>Finish the game.</li>
@@ -395,9 +397,9 @@
 </ul>
 <p>Use it after the game when final stats are on a completed paper score sheet.</p>
 <ul class="ml-6 list-disc space-y-1">
-<li><strong>Can both coach and admin run this workflow?</strong></li>
+<li><strong>Can coaches, admins, and delegated scorekeepers run this workflow?</strong></li>
 </ul>
-<p>Yes. Both can track games. Admins usually lead final verification.</p>
+<p>Yes. Coaches and admins retain full access. Delegated scorekeepers can track scheduled games when they have scorekeeping permission, but team management remains restricted.</p>
 <ul class="ml-6 list-disc space-y-1">
 <li><strong>What happens after Save &amp; Complete?</strong></li>
 </ul>


### PR DESCRIPTION
Closes #651

## Summary
- Added scoped scorekeeping access checks for selected scorekeepers and all-confirmed-member mode.
- Allowed delegated scorekeepers to enter Game Day with a limited scoring-only panel and gated both scoring tracker entry points with the same permission check.
- Updated Firestore rules so delegated scorekeepers can write live scoring data without opening roster, schedule, or team settings access.

## Tests
- `npx vitest run tests/unit/scorekeeping-access.test.js tests/unit/scorekeeping-access-wiring.test.js tests/unit/team-access.test.js`