### PR TITLE
Persist team reminder default selection

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -115,6 +115,7 @@
                     <button id="save-team-reminder-settings-btn" type="button" class="w-full bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700 transition">Save Reminder Settings</button>
                 </div>
             </div>
+            <p id="team-reminder-settings-summary" class="mt-3 text-sm text-gray-600"></p>
         </div>
 
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
@@ -1459,8 +1460,10 @@
             const windowDescription = describeScheduleReminderWindow(rawSettings);
             const enabledEl = document.getElementById('team-reminder-enabled');
             const hoursEl = document.getElementById('team-reminder-hours');
+            const summaryEl = document.getElementById('team-reminder-settings-summary');
             if (enabledEl) enabledEl.checked = settings.enabled;
             if (hoursEl) hoursEl.value = String(settings.reminderHours);
+            if (summaryEl) summaryEl.textContent = windowDescription;
             ['game', 'practice'].forEach((eventType) => {
                 const summaryEl = document.getElementById(`${eventType}-reminder-window-summary`);
                 const detailEl = document.getElementById(`${eventType}-reminder-window-detail`);

--- a/tests/unit/edit-schedule-notifications.test.js
+++ b/tests/unit/edit-schedule-notifications.test.js
@@ -11,7 +11,11 @@ describe('edit schedule notification wiring', () => {
 
         expect(source).toContain('id="schedule-notification-settings"');
         expect(source).toContain('id="team-reminder-hours"');
+        expect(source).toContain('<option value="24">24 hours before</option>');
+        expect(source).toContain('<option value="48">48 hours before</option>');
+        expect(source).toContain('<option value="72">72 hours before</option>');
         expect(source).toContain('id="save-team-reminder-settings-btn"');
+        expect(source).toContain('id="team-reminder-settings-summary"');
     });
 
     it('includes notify-team and reminder-window controls in game and practice forms', () => {
@@ -42,8 +46,17 @@ describe('edit schedule notification wiring', () => {
         const source = readEditSchedule();
 
         expect(source).toContain('const windowDescription = describeScheduleReminderWindow(rawSettings);');
-        expect(source).toContain('summaryEl.textContent = windowDescription;');
+        expect(source).toContain('if (summaryEl) summaryEl.textContent = windowDescription;');
         expect(source).toContain('Inherited from the team reminder default');
+    });
+
+    it('persists normalized team reminder settings to the team metadata path', () => {
+        const source = readEditSchedule();
+
+        expect(source).toContain('await updateTeam(currentTeamId, { scheduleNotifications: nextSettings });');
+        expect(source).toContain('reminderHours: document.getElementById(\'team-reminder-hours\').value');
+        expect(source).toContain('currentTeam = {\n                    ...(currentTeam || {}),\n                    scheduleNotifications: nextSettings\n                };');
+        expect(source).toContain('renderTeamScheduleNotificationSettings(currentTeam);');
     });
 
     it('uses the submitted linked-opponent state for counterpart notifications', () => {


### PR DESCRIPTION
Closes #678

## Summary
- Shows the loaded team reminder default summary on the schedule settings page so the persisted value is clear after reload.
- Confirms the team reminder selector offers 24, 48, and 72 hour choices.
- Adds focused coverage for saving normalized reminder settings to `scheduleNotifications` and re-rendering from the saved team metadata.

## Tests
- `npx vitest run tests/unit/schedule-notifications.test.js tests/unit/edit-schedule-notifications.test.js`