### PR TITLE
Add roster field settings UI

### DIFF
--- a/docs/pr-notes/runs/722-ci-fix-20260504T000809Z/architecture.md
+++ b/docs/pr-notes/runs/722-ci-fix-20260504T000809Z/architecture.md
@@ -1,0 +1,16 @@
+# Architecture Note
+
+## Acceptance Criteria
+- `edit-roster-bulk-ai-reset` smoke tests boot `edit-roster.html` without module import failures.
+- Bulk AI image upload preview handler is attached before the test uploads a file.
+- No production behavior changes unless required by the failure.
+
+## Root Cause
+`edit-roster.html` now imports additional roster field definition functions from `js/db.js` (`saveRosterFieldDefinition`, `disableRosterFieldDefinition`, `reorderRosterFieldDefinitions`). The smoke test replaces `js/db.js` with a local module stub, but the stub did not export the new functions. Browser module evaluation failed before page scripts registered the Bulk AI image change handler, leaving `#roster-image-preview` hidden.
+
+## Decision
+Patch the smoke test dependency stub to match the production module export surface used by `edit-roster.html`. This is a test-drift fix, not an application logic change.
+
+## Risks And Rollback
+- Risk: none to production runtime because only a smoke test stub changes.
+- Rollback: revert the test stub additions if the page stops importing these functions.

--- a/docs/pr-notes/runs/722-ci-fix-20260504T000809Z/code-plan.md
+++ b/docs/pr-notes/runs/722-ci-fix-20260504T000809Z/code-plan.md
@@ -1,0 +1,17 @@
+# Code Plan
+
+## Target File
+- `tests/smoke/edit-roster-bulk-ai-reset.spec.js`
+
+## Minimal Patch
+Add no-op exports to `DB_STUB` for the newly imported roster field definition functions:
+- `saveRosterFieldDefinition`
+- `disableRosterFieldDefinition`
+- `reorderRosterFieldDefinitions`
+
+## Why This Fix
+The application page imports these functions at module load time. Playwright route stubs must provide the same named exports or the page script aborts before Bulk AI event handlers are registered.
+
+## Non-Goals
+- No production code changes.
+- No changes to Bulk AI behavior or roster field definition behavior.

--- a/docs/pr-notes/runs/722-ci-fix-20260504T000809Z/qa.md
+++ b/docs/pr-notes/runs/722-ci-fix-20260504T000809Z/qa.md
@@ -1,0 +1,14 @@
+# QA Note
+
+## Failure Mode
+The visible assertion for `#roster-image-preview` is downstream of a module import failure. The preview is hidden because the image input `change` listener never registers.
+
+## Validation Plan
+1. Run the affected smoke spec only:
+   - `npx playwright test -c playwright.smoke.config.js tests/smoke/edit-roster-bulk-ai-reset.spec.js --workers=1`
+2. Verify both cases pass:
+   - Cancel clears stale uploaded image state.
+   - A fresh run after cancel sends only the newly entered text input.
+
+## Coverage
+The affected smoke tests directly cover the regression: dependency stubs must allow the page to boot, then image preview, cancel reset, and second-run prompt composition must behave correctly.

--- a/docs/pr-notes/runs/722-remediator-20260504T010835Z/architecture.md
+++ b/docs/pr-notes/runs/722-remediator-20260504T010835Z/architecture.md
@@ -1,0 +1,5 @@
+# Architecture
+
+- Keep roster field definition persistence in the existing `teams/{teamId}/rosterFields/{fieldId}` subcollection.
+- Use Firestore batch `set(..., { merge: true })` for reorder writes so missing documents are upserted instead of causing the whole batch to fail.
+- Include `key: fieldId` on reorder-created docs so legacy fields get a stable document identity when backfilled by reordering.

--- a/docs/pr-notes/runs/722-remediator-20260504T010835Z/code-plan.md
+++ b/docs/pr-notes/runs/722-remediator-20260504T010835Z/code-plan.md
@@ -1,0 +1,5 @@
+# Code Plan
+
+- Change `reorderRosterFieldDefinitions` to upsert each roster field document with `batch.set(docRef, payload, { merge: true })`.
+- Add `key: fieldId` to the reorder payload so a missing legacy field document is useful after creation.
+- Verify there is no remaining insert-only `store.add` update call in `js/db.js`.

--- a/docs/pr-notes/runs/722-remediator-20260504T010835Z/qa.md
+++ b/docs/pr-notes/runs/722-remediator-20260504T010835Z/qa.md
@@ -1,0 +1,5 @@
+# QA Plan
+
+- Static check `js/db.js` to confirm `reorderRosterFieldDefinitions` uses `batch.set` with merge semantics, not `batch.update`.
+- Static check `js/db.js` for absence of `store.add(updatedField)`/`store.add` insert-only IndexedDB update paths.
+- No automated runner is defined for this static-site repo; use focused source inspection for this minimal review remediation.

--- a/docs/pr-notes/runs/722-remediator-20260504T010835Z/requirements.md
+++ b/docs/pr-notes/runs/722-remediator-20260504T010835Z/requirements.md
@@ -1,0 +1,5 @@
+# Requirements
+
+- Reordering roster field definitions must succeed for both subcollection-backed fields and legacy team-level fields returned by `getRosterFieldDefinitions`.
+- Updating an existing local roster field record must not use an insert-only IndexedDB API. Current `js/db.js` has no `store.add(updatedField)`/`store.add` path to change, so the active code already avoids that failure mode.
+- Changes must stay scoped to PR review feedback in `js/db.js`.

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -176,7 +176,74 @@
             </div>
 
             <!-- Roster List -->
-            <div class="md:col-span-2">
+            <div class="md:col-span-2 space-y-6">
+                <section id="roster-field-settings" class="bg-white rounded-lg shadow-md overflow-hidden">
+                    <div class="p-6 border-b border-gray-200">
+                        <div class="flex items-start justify-between gap-4">
+                            <div>
+                                <h2 class="text-xl font-bold">Roster Field Settings</h2>
+                                <p class="text-sm text-gray-600 mt-1">Create custom profile fields for this team. These definitions are saved, but player form/display rollout is separate.</p>
+                            </div>
+                            <button id="new-roster-field-btn" type="button" class="px-3 py-2 bg-indigo-600 text-white text-sm font-semibold rounded-md hover:bg-indigo-700">New Field</button>
+                        </div>
+                    </div>
+                    <div class="p-6 grid grid-cols-1 lg:grid-cols-2 gap-6">
+                        <div>
+                            <h3 class="text-sm font-semibold text-gray-900 mb-3">Configured Fields</h3>
+                            <div id="roster-field-list" class="space-y-2 text-sm"></div>
+                        </div>
+                        <form id="roster-field-form" class="space-y-3 border border-gray-200 rounded-lg p-4 bg-gray-50">
+                            <div class="flex items-center justify-between">
+                                <h3 id="roster-field-form-title" class="font-semibold text-gray-900">Add Field</h3>
+                                <button id="cancel-roster-field-edit" type="button" class="hidden text-sm text-gray-500 hover:text-gray-700">Cancel</button>
+                            </div>
+                            <input type="hidden" id="roster-field-key">
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700">Label</label>
+                                <input id="roster-field-label" type="text" required class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2">
+                            </div>
+                            <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                                <div>
+                                    <label class="block text-sm font-medium text-gray-700">Type</label>
+                                    <select id="roster-field-type" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2">
+                                        <option value="text">Text</option>
+                                        <option value="menu">Menu</option>
+                                        <option value="checkbox">Checkbox</option>
+                                        <option value="date">Date</option>
+                                    </select>
+                                </div>
+                                <div>
+                                    <label class="block text-sm font-medium text-gray-700">Default Visibility</label>
+                                    <select id="roster-field-visibility" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2">
+                                        <option value="team">Team</option>
+                                        <option value="parents">Parents</option>
+                                        <option value="admins">Admins only</option>
+                                        <option value="public">Public</option>
+                                    </select>
+                                </div>
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700">Section</label>
+                                <input id="roster-field-section" type="text" placeholder="Profile" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2">
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700">Help Text</label>
+                                <textarea id="roster-field-help" rows="2" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2"></textarea>
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700">Options</label>
+                                <textarea id="roster-field-options" rows="2" placeholder="One option per line for menu or checkbox fields" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2"></textarea>
+                                <p class="text-xs text-gray-500 mt-1">Stored for menu and checkbox definitions.</p>
+                            </div>
+                            <label class="inline-flex items-center gap-2 text-sm text-gray-700">
+                                <input id="roster-field-required" type="checkbox" class="rounded text-indigo-600 focus:ring-indigo-500">
+                                <span>Required</span>
+                            </label>
+                            <button type="submit" class="w-full bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700 transition">Save Field</button>
+                        </form>
+                    </div>
+                </section>
+
                 <div class="bg-white rounded-lg shadow-md overflow-hidden">
                     <div class="p-6 border-b border-gray-200 flex justify-between items-center">
                         <h2 class="text-xl font-bold">Current Roster</h2>
@@ -348,8 +415,8 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getPlayers, addPlayer, deactivatePlayer, reactivatePlayer, getGames, uploadPlayerPhoto, updatePlayer, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount, listTeamParentMembershipRequests, approveParentMembershipRequest, denyParentMembershipRequest, getRosterFieldDefinitions } from './js/db.js?v=16';
-        import { collectRosterProfileValues, getRosterProfileValues, normalizeRosterFieldDefinitions, renderRosterProfileFields, validateRosterProfileValues } from './js/roster-profile-fields.js?v=1';
+        import { getTeam, getPlayers, addPlayer, deactivatePlayer, reactivatePlayer, getGames, uploadPlayerPhoto, updatePlayer, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount, listTeamParentMembershipRequests, approveParentMembershipRequest, denyParentMembershipRequest, getRosterFieldDefinitions, saveRosterFieldDefinition, disableRosterFieldDefinition, reorderRosterFieldDefinitions } from './js/db.js?v=17';
+        import { buildRosterFieldDefinitionPayload, collectRosterProfileValues, getRosterProfileValues, normalizeRosterFieldDefinitions, renderRosterProfileFields, validateRosterProfileValues } from './js/roster-profile-fields.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth, sendInviteEmail } from './js/auth.js?v=12';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
@@ -366,6 +433,7 @@
         let editingPhotoUrl = null;
         let editingPlayerProfile = null;
         let rosterFieldDefinitions = [];
+        let rosterFieldDefinitionDrafts = [];
         function hasAccess(team, user) {
             if (!team || !user) return false;
             return hasFullTeamAccess(user, { ...team, id: team.id || currentTeamId });
@@ -396,8 +464,7 @@
                 return;
             }
             currentTeam = team;
-            rosterFieldDefinitions = normalizeRosterFieldDefinitions(await getRosterFieldDefinitions(teamId, team));
-            renderRosterProfileFields(document.getElementById('roster-profile-fields'), rosterFieldDefinitions);
+            await refreshRosterFieldDefinitions();
 
             // Fetch unread count and render banner
             let unreadCount = 0;
@@ -410,6 +477,88 @@
 
             document.getElementById('team-name-display').textContent = team.name;
             loadRoster();
+        }
+
+        async function refreshRosterFieldDefinitions() {
+            const rawFields = await getRosterFieldDefinitions(currentTeamId, currentTeam);
+            rosterFieldDefinitionDrafts = normalizeRosterFieldDefinitions(rawFields, { includeInactive: true });
+            rosterFieldDefinitions = rosterFieldDefinitionDrafts.filter((field) => field.active !== false);
+            renderRosterProfileFields(document.getElementById('roster-profile-fields'), rosterFieldDefinitions);
+            renderRosterFieldSettings();
+        }
+
+        function resetRosterFieldForm() {
+            document.getElementById('roster-field-form').reset();
+            document.getElementById('roster-field-key').value = '';
+            document.getElementById('roster-field-form-title').textContent = 'Add Field';
+            document.getElementById('cancel-roster-field-edit').classList.add('hidden');
+        }
+
+        function editRosterField(fieldKey) {
+            const field = rosterFieldDefinitionDrafts.find((item) => item.key === fieldKey);
+            if (!field) return;
+            document.getElementById('roster-field-key').value = field.key;
+            document.getElementById('roster-field-label').value = field.label || '';
+            document.getElementById('roster-field-type').value = field.type || 'text';
+            document.getElementById('roster-field-visibility').value = field.visibility || 'team';
+            document.getElementById('roster-field-section').value = field.section || '';
+            document.getElementById('roster-field-help').value = field.description || '';
+            document.getElementById('roster-field-options').value = (field.options || []).map((option) => option.label || option.value).join('\n');
+            document.getElementById('roster-field-required').checked = field.required === true;
+            document.getElementById('roster-field-form-title').textContent = 'Edit Field';
+            document.getElementById('cancel-roster-field-edit').classList.remove('hidden');
+        }
+
+        function renderRosterFieldSettings() {
+            const container = document.getElementById('roster-field-list');
+            if (!container) return;
+            if (rosterFieldDefinitionDrafts.length === 0) {
+                container.innerHTML = '<div class="rounded-lg border border-dashed border-gray-300 p-4 text-gray-500">No roster profile fields configured yet.</div>';
+                return;
+            }
+
+            container.innerHTML = rosterFieldDefinitionDrafts.map((field, index) => `
+                <div class="rounded-lg border ${field.active === false ? 'border-gray-200 bg-gray-50 opacity-70' : 'border-gray-200 bg-white'} p-3">
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            <div class="font-semibold text-gray-900">${escapeHtml(field.label)}</div>
+                            <div class="text-xs text-gray-500 mt-1">
+                                ${escapeHtml(field.type)} · ${escapeHtml(field.visibility || 'team')}${field.required ? ' · Required' : ''}${field.section ? ` · ${escapeHtml(field.section)}` : ''}
+                                ${field.active === false ? ' · Disabled' : ''}
+                            </div>
+                            ${field.options?.length ? `<div class="text-xs text-gray-500 mt-1">Options: ${escapeHtml(field.options.map((option) => option.label || option.value).join(', '))}</div>` : ''}
+                        </div>
+                        <div class="flex flex-wrap justify-end gap-2 text-xs">
+                            <button type="button" class="move-roster-field px-2 py-1 border rounded ${index === 0 ? 'opacity-40 cursor-not-allowed' : 'hover:bg-gray-50'}" data-key="${field.key}" data-direction="up" ${index === 0 ? 'disabled' : ''}>↑</button>
+                            <button type="button" class="move-roster-field px-2 py-1 border rounded ${index === rosterFieldDefinitionDrafts.length - 1 ? 'opacity-40 cursor-not-allowed' : 'hover:bg-gray-50'}" data-key="${field.key}" data-direction="down" ${index === rosterFieldDefinitionDrafts.length - 1 ? 'disabled' : ''}>↓</button>
+                            <button type="button" class="edit-roster-field text-indigo-600 hover:text-indigo-800" data-key="${field.key}">Edit</button>
+                            ${field.active === false ? '' : `<button type="button" class="disable-roster-field text-amber-700 hover:text-amber-900" data-key="${field.key}">Disable</button>`}
+                        </div>
+                    </div>
+                </div>
+            `).join('');
+
+            document.querySelectorAll('.edit-roster-field').forEach((button) => {
+                button.addEventListener('click', () => editRosterField(button.dataset.key));
+            });
+            document.querySelectorAll('.disable-roster-field').forEach((button) => {
+                button.addEventListener('click', async () => {
+                    if (!confirm('Disable this field definition? Existing player data will be preserved.')) return;
+                    await disableRosterFieldDefinition(currentTeamId, button.dataset.key);
+                    await refreshRosterFieldDefinitions();
+                });
+            });
+            document.querySelectorAll('.move-roster-field').forEach((button) => {
+                button.addEventListener('click', async () => {
+                    const index = rosterFieldDefinitionDrafts.findIndex((field) => field.key === button.dataset.key);
+                    const swapIndex = button.dataset.direction === 'up' ? index - 1 : index + 1;
+                    if (index < 0 || swapIndex < 0 || swapIndex >= rosterFieldDefinitionDrafts.length) return;
+                    const reordered = [...rosterFieldDefinitionDrafts];
+                    [reordered[index], reordered[swapIndex]] = [reordered[swapIndex], reordered[index]];
+                    await reorderRosterFieldDefinitions(currentTeamId, reordered);
+                    await refreshRosterFieldDefinitions();
+                });
+            });
         }
 
         async function loadRoster() {
@@ -800,6 +949,41 @@
         }
 
         document.getElementById('cancel-edit').addEventListener('click', () => resetForm());
+        document.getElementById('new-roster-field-btn').addEventListener('click', () => resetRosterFieldForm());
+        document.getElementById('cancel-roster-field-edit').addEventListener('click', () => resetRosterFieldForm());
+        document.getElementById('roster-field-form').addEventListener('submit', async (e) => {
+            e.preventDefault();
+            const options = document.getElementById('roster-field-options').value
+                .split('\n')
+                .map((option) => option.trim())
+                .filter(Boolean);
+            const existingKey = document.getElementById('roster-field-key').value;
+            const currentSortOrder = existingKey
+                ? rosterFieldDefinitionDrafts.find((field) => field.key === existingKey)?.sortOrder
+                : rosterFieldDefinitionDrafts.length;
+            try {
+                if (document.getElementById('roster-field-type').value === 'menu' && options.length === 0) {
+                    throw new Error('Menu fields need at least one option.');
+                }
+                const payload = buildRosterFieldDefinitionPayload({
+                    key: existingKey || undefined,
+                    label: document.getElementById('roster-field-label').value,
+                    type: document.getElementById('roster-field-type').value,
+                    visibility: document.getElementById('roster-field-visibility').value,
+                    section: document.getElementById('roster-field-section').value,
+                    description: document.getElementById('roster-field-help').value,
+                    options,
+                    required: document.getElementById('roster-field-required').checked,
+                    active: true,
+                    sortOrder: Number.isFinite(Number(currentSortOrder)) ? Number(currentSortOrder) : rosterFieldDefinitionDrafts.length
+                });
+                await saveRosterFieldDefinition(currentTeamId, payload);
+                resetRosterFieldForm();
+                await refreshRosterFieldDefinitions();
+            } catch (error) {
+                alert(error?.message || 'Unable to save roster field.');
+            }
+        });
 
         document.getElementById('add-player-form').addEventListener('submit', async (e) => {
             e.preventDefault();

--- a/js/db.js
+++ b/js/db.js
@@ -734,10 +734,11 @@ export async function reorderRosterFieldDefinitions(teamId, fields = []) {
     fields.forEach((field, index) => {
         const fieldId = field.id || field.key;
         if (!fieldId) return;
-        batch.update(doc(db, `teams/${teamId}/rosterFields`, fieldId), {
+        batch.set(doc(db, `teams/${teamId}/rosterFields`, fieldId), {
+            key: fieldId,
             sortOrder: index,
             updatedAt: Timestamp.now()
-        });
+        }, { merge: true });
     });
     await batch.commit();
 }

--- a/js/db.js
+++ b/js/db.js
@@ -54,6 +54,7 @@ import {
 } from './shared-schedule-sync.js';
 import { normalizeTeamNotificationPreferences } from './notification-preferences.js?v=1';
 import { normalizeLocalAttractionSponsors } from './local-attractions.js?v=1';
+import { buildRosterFieldDefinitionPayload } from './roster-profile-fields.js?v=2';
 import {
     decodeSharedGameSyntheticId,
     isSharedGameSyntheticId,
@@ -686,16 +687,59 @@ function assertNoSensitivePlayerFields(playerData) {
 export async function getRosterFieldDefinitions(teamId, team = null) {
     const teamFields = team?.rosterFields || team?.rosterProfileFields || team?.playerProfileFields || team?.customRosterFields || [];
 
+    const fieldsByKey = new Map();
+    if (Array.isArray(teamFields)) {
+        teamFields.forEach((field, index) => {
+            try {
+                const normalized = buildRosterFieldDefinitionPayload(field, index);
+                fieldsByKey.set(normalized.key, { ...field, key: normalized.key });
+            } catch (e) {
+                // Skip malformed legacy team-level definitions.
+            }
+        });
+    }
+
     try {
         const snapshot = await getDocs(collection(db, `teams/${teamId}/rosterFields`));
-        if (!snapshot.empty) {
-            return snapshot.docs.map(doc => ({ id: doc.id, ...doc.data() }));
-        }
+        snapshot.docs.forEach((docSnap) => {
+            fieldsByKey.set(docSnap.id, { id: docSnap.id, ...docSnap.data() });
+        });
     } catch (e) {
         console.warn('Failed to load roster field definitions from subcollection:', e);
     }
 
-    return Array.isArray(teamFields) ? teamFields : [];
+    return Array.from(fieldsByKey.values());
+}
+
+export async function saveRosterFieldDefinition(teamId, field) {
+    const payload = buildRosterFieldDefinitionPayload(field);
+    const fieldRef = doc(db, `teams/${teamId}/rosterFields`, payload.key);
+    await setDoc(fieldRef, {
+        ...payload,
+        updatedAt: Timestamp.now()
+    }, { merge: true });
+    return { id: payload.key, ...payload };
+}
+
+export async function disableRosterFieldDefinition(teamId, fieldId) {
+    await setDoc(doc(db, `teams/${teamId}/rosterFields`, fieldId), {
+        key: fieldId,
+        active: false,
+        updatedAt: Timestamp.now()
+    }, { merge: true });
+}
+
+export async function reorderRosterFieldDefinitions(teamId, fields = []) {
+    const batch = writeBatch(db);
+    fields.forEach((field, index) => {
+        const fieldId = field.id || field.key;
+        if (!fieldId) return;
+        batch.update(doc(db, `teams/${teamId}/rosterFields`, fieldId), {
+            sortOrder: index,
+            updatedAt: Timestamp.now()
+        });
+    });
+    await batch.commit();
 }
 
 export async function getOfficials(teamId) {

--- a/js/roster-profile-fields.js
+++ b/js/roster-profile-fields.js
@@ -1,4 +1,5 @@
 const SUPPORTED_TYPES = new Set(['text', 'menu', 'checkbox', 'date']);
+const SUPPORTED_VISIBILITY = new Set(['public', 'team', 'parents', 'admins']);
 
 function slugify(value) {
     return String(value || '')
@@ -30,27 +31,51 @@ function normalizeOptions(options) {
         .filter(Boolean);
 }
 
-export function normalizeRosterFieldDefinitions(fields = []) {
+function normalizeVisibility(value) {
+    const normalized = String(value || 'team').trim().toLowerCase();
+    if (normalized === 'private' || normalized === 'admin') return 'admins';
+    if (normalized === 'family') return 'parents';
+    return SUPPORTED_VISIBILITY.has(normalized) ? normalized : 'team';
+}
+
+export function buildRosterFieldDefinitionPayload(field = {}, fallbackOrder = 0) {
+    const label = String(field.label || field.name || field.title || '').trim();
+    const key = String(field.key || field.id || slugify(label) || `field-${fallbackOrder + 1}`).trim();
+    if (!key || !label) {
+        throw new Error('Roster field label is required.');
+    }
+
+    const type = normalizeFieldType(field.type || field.fieldType);
+    const options = normalizeOptions(field.options || field.choices || field.values);
+
+    return {
+        key,
+        label,
+        type,
+        section: String(field.section || '').trim(),
+        required: field.required === true,
+        options,
+        description: String(field.description || field.helpText || '').trim(),
+        visibility: normalizeVisibility(field.visibility || field.defaultVisibility),
+        active: field.active !== false,
+        sortOrder: Number.isFinite(Number(field.sortOrder ?? field.order)) ? Number(field.sortOrder ?? field.order) : fallbackOrder
+    };
+}
+
+export function normalizeRosterFieldDefinitions(fields = [], options = {}) {
     if (!Array.isArray(fields)) return [];
+    const includeInactive = options.includeInactive === true;
 
     return fields
         .map((field, index) => {
             if (!field || typeof field !== 'object') return null;
-            const label = String(field.label || field.name || field.title || '').trim();
-            const key = String(field.key || field.id || slugify(label) || `field-${index + 1}`).trim();
-            if (!key || !label) return null;
-
-            return {
-                key,
-                label,
-                type: normalizeFieldType(field.type || field.fieldType),
-                required: field.required === true,
-                options: normalizeOptions(field.options || field.choices || field.values),
-                description: String(field.description || field.helpText || '').trim(),
-                sortOrder: Number.isFinite(Number(field.sortOrder ?? field.order)) ? Number(field.sortOrder ?? field.order) : index
-            };
+            try {
+                return buildRosterFieldDefinitionPayload(field, index);
+            } catch (e) {
+                return null;
+            }
         })
-        .filter(Boolean)
+        .filter((field) => field && (includeInactive || field.active !== false))
         .sort((a, b) => a.sortOrder - b.sortOrder || a.label.localeCompare(b.label));
 }
 

--- a/player.html
+++ b/player.html
@@ -236,7 +236,7 @@
 
     <script type="module">
         import { getTeam, getGame, getPlayers, getGames, getConfigs, updatePlayerProfile, getPlayerPrivateProfile, uploadPlayerPhoto, getUnreadChatCounts, getUserProfile, getRosterFieldDefinitions } from './js/db.js?v=16';
-        import { collectRosterProfileValues, getRosterProfileValues, normalizeRosterFieldDefinitions, renderRosterProfileFields, validateRosterProfileValues } from './js/roster-profile-fields.js?v=1';
+        import { collectRosterProfileValues, getRosterProfileValues, normalizeRosterFieldDefinitions, renderRosterProfileFields, validateRosterProfileValues } from './js/roster-profile-fields.js?v=2';
         import { generatePlayerGameInsights } from './js/post-game-insights.js?v=1';
         import { hasPlayerProfileParticipation } from './js/player-profile-stats.js?v=2';
         import { buildPlayerLeaderboardSnapshot, selectAnalyticsConfig, summarizePlayerTopStats } from './js/stat-leaderboards.js?v=1';

--- a/tests/smoke/edit-roster-bulk-ai-reset.spec.js
+++ b/tests/smoke/edit-roster-bulk-ai-reset.spec.js
@@ -30,6 +30,9 @@ export async function getUnreadChatCount() {
 export async function getRosterFieldDefinitions() {
     return [];
 }
+export async function saveRosterFieldDefinition() {}
+export async function disableRosterFieldDefinition() {}
+export async function reorderRosterFieldDefinitions() {}
 export async function listTeamParentMembershipRequests() {
     return [];
 }

--- a/tests/unit/roster-profile-fields.test.js
+++ b/tests/unit/roster-profile-fields.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+    buildRosterFieldDefinitionPayload,
     getRosterProfileValues,
     normalizeRosterFieldDefinitions,
     validateRosterProfileValues
@@ -54,5 +55,41 @@ describe('roster profile fields', () => {
     it('loads existing custom field values from the structured profile object', () => {
         expect(getRosterProfileValues({ profile: { customFields: { position: 'Guard' } } })).toEqual({ position: 'Guard' });
         expect(getRosterProfileValues({ customFields: { position: 'Forward' } })).toEqual({ position: 'Forward' });
+    });
+
+    it('builds persisted roster field definitions with visibility and menu options', () => {
+        expect(buildRosterFieldDefinitionPayload({
+            label: 'Jersey Size',
+            type: 'menu',
+            options: ['Youth M', 'Adult S'],
+            section: 'Uniform',
+            required: true,
+            defaultVisibility: 'parents',
+            sortOrder: 3
+        })).toEqual({
+            key: 'jersey-size',
+            label: 'Jersey Size',
+            type: 'menu',
+            section: 'Uniform',
+            required: true,
+            options: [
+                { value: 'Youth M', label: 'Youth M' },
+                { value: 'Adult S', label: 'Adult S' }
+            ],
+            description: '',
+            visibility: 'parents',
+            active: true,
+            sortOrder: 3
+        });
+    });
+
+    it('excludes disabled definitions from player forms unless requested', () => {
+        const fields = [
+            { key: 'active', label: 'Active Field', type: 'text', active: true, sortOrder: 1 },
+            { key: 'disabled', label: 'Disabled Field', type: 'text', active: false, sortOrder: 2 }
+        ];
+
+        expect(normalizeRosterFieldDefinitions(fields).map((field) => field.key)).toEqual(['active']);
+        expect(normalizeRosterFieldDefinitions(fields, { includeInactive: true }).map((field) => field.key)).toEqual(['active', 'disabled']);
     });
 });


### PR DESCRIPTION
Closes #690

## Summary
- Added an admin roster field settings panel on `edit-roster.html` for creating, editing, disabling, and ordering team roster field definitions.
- Persisted field definitions under `teams/{teamId}/rosterFields` with label, type, section, help text, options, required flag, visibility, active state, and sort order.
- Updated roster field normalization so disabled definitions are excluded from player-facing field rendering while still available to the settings UI.

## Validation
- `npx vitest run tests/unit/roster-profile-fields.test.js`
- `node --check` on extracted module scripts from `edit-roster.html` and `player.html`