### PR TITLE
Add team availability schedule view

### DIFF
--- a/docs/pr-notes/runs/722-ci-fix-20260503T221740Z/architecture.md
+++ b/docs/pr-notes/runs/722-ci-fix-20260503T221740Z/architecture.md
@@ -1,0 +1,76 @@
+1. Current-State Read
+
+`edit-roster.html` is a static HTML page with inline ES module logic. The roster image preview is local browser state only: the `change` listener on `#roster-image-input` reads the selected file with `FileReader`, sets `#roster-image-preview-img.src`, and removes `hidden` from `#roster-image-preview`.
+
+The smoke failure where `#roster-image-preview` remains hidden after `uploadRosterImage` is most consistent with the page module not reaching listener registration. The DOM exists, so Playwright can set the file input, but the app-side `change` handler is not active. In this test, that usually means one of the Playwright route mocks drifted from the cache-busted imports in `edit-roster.html`, causing the real Firebase-backed module to load or a named ES module import to fail before the preview handler is registered.
+
+Current relevant imports are `./js/db.js?v=16`, `./js/roster-profile-fields.js?v=1`, `./js/utils.js?v=8`, `./js/auth.js?v=12`, `./js/team-admin-banner.js`, `./js/team-access.js`, and Firebase vendor AI/app modules. The test already uses a version-tolerant regex for `db.js`, but exact route patterns for `utils.js` and `auth.js` remain brittle. Prior CI fixes for this same smoke area were caused by dependency/mock drift around `db.js` cache-busting and missing exports.
+
+Local validation note: the targeted smoke command currently passes in this workspace (`npx playwright test tests/smoke/edit-roster-bulk-ai-reset.spec.js --config=playwright.smoke.config.js --reporter=line`, 2 passed). That supports the architecture read that the product preview path is sound and the CI failure is likely branch/test harness drift rather than a required production behavior change.
+
+2. Proposed Design
+
+Keep the fix in the smoke harness unless browser console evidence proves product code is broken.
+
+Minimal direction:
+
+- Make dependency route mocks version-tolerant for all cache-busted imports used by `edit-roster.html`, not only `db.js`.
+- Ensure `DB_STUB` exports every named symbol imported by `edit-roster.html` on the PR branch.
+- If `roster-profile-fields.js` changes again and becomes coupled to unmocked browser/Firebase state, add a focused test stub for that module. Otherwise leaving the real self-contained helper module is acceptable.
+- Do not move or rewrite the preview logic. It is intentionally client-only and independent of Firebase.
+
+The smallest coherent fix is to adjust `tests/smoke/edit-roster-bulk-ai-reset.spec.js` so the mocked module graph stays aligned with the HTML page’s current import contract. This preserves the smoke’s purpose: verify bulk AI image/text reset behavior without relying on Firebase, auth, or network services.
+
+3. Files And Modules Touched
+
+Expected implementation touch:
+
+- `tests/smoke/edit-roster-bulk-ai-reset.spec.js`
+  - Broaden route patterns for versioned imports such as `auth.js?v=N` and `utils.js?v=N`.
+  - Keep `db.js` route regex version-tolerant.
+  - Mirror any new named exports imported from `js/db.js`.
+
+Affected source, read-only for this fix:
+
+- `edit-roster.html`
+  - Owns the roster image preview handler and bulk AI reset flow.
+- `js/db.js`
+  - Source module represented by `DB_STUB`.
+- `js/auth.js`, `js/utils.js`, `js/team-access.js`, `js/team-admin-banner.js`
+  - Page dependencies mocked by the smoke harness.
+- `js/roster-profile-fields.js`
+  - Roster field helper import used during page initialization.
+
+4. Data/State Impacts
+
+No persistent application data impact is expected. The failing behavior is limited to client/test state:
+
+- selected file on `#roster-image-input`
+- preview image `src`
+- `hidden` class on `#roster-image-preview`
+- bulk AI proposed-operation draft state
+- reset behavior after cancel
+
+No Firestore documents, Storage objects, roster records, team membership, or auth claims should change.
+
+5. Security/Permissions Impacts
+
+No runtime security impact if the fix remains in the smoke test. Keeping Firebase/auth dependencies mocked reduces CI blast radius and avoids accidental dependence on real tenant data, auth sessions, or networked Firebase services.
+
+Production access boundaries remain unchanged: team access continues through existing auth/team checks and Firestore rules. Do not bypass admin/team access checks in product code to make the smoke pass.
+
+6. Failure Modes And Mitigations
+
+- Failure mode: another cache-bust bump causes an exact route mock to miss and loads real modules in CI.
+  - Mitigation: use regex or glob patterns that allow optional `?v=N` for cache-busted app modules.
+
+- Failure mode: `DB_STUB` misses a newly imported named export, aborting ES module evaluation before DOM listeners register.
+  - Mitigation: compare `edit-roster.html` named imports with the stub exports whenever this smoke fails; add no-op test exports for unrelated database functions.
+
+- Failure mode: broad mocks hide a real product regression.
+  - Mitigation: treat this smoke as a focused UI-state test. If it fails after the mock graph is aligned, inspect browser console errors and add a targeted assertion that `#roster-image-preview-img[src^="data:image/png;base64,"]` appears after upload.
+
+- Failure mode: the failure is a true async preview race rather than module abort.
+  - Mitigation: only after console/import errors are ruled out, wait on the data URL attribute as the readiness condition instead of relying only on visibility timing.
+
+Rollback: revert only the smoke-test mock changes. Since no production code or data model should change, rollback blast radius is limited to CI coverage for `tests/smoke/edit-roster-bulk-ai-reset.spec.js`.

--- a/docs/pr-notes/runs/722-ci-fix-20260503T221740Z/code-plan.md
+++ b/docs/pr-notes/runs/722-ci-fix-20260503T221740Z/code-plan.md
@@ -1,0 +1,16 @@
+# Code Plan
+
+## Acceptance criteria
+- Bulk AI smoke tests load `edit-roster.html` without module import failures.
+- Image upload preview handler is registered and makes `#roster-image-preview` visible.
+- Cancel/reset assertions continue to verify stale image state is cleared.
+
+## Implementation plan
+- Add no-op exports for `saveRosterFieldDefinition`, `disableRosterFieldDefinition`, and `reorderRosterFieldDefinitions` to the `DB_STUB` in `tests/smoke/edit-roster-bulk-ai-reset.spec.js`.
+- Do not change runtime code.
+
+## Validation
+- `npx playwright test -c playwright.smoke.config.js tests/smoke/edit-roster-bulk-ai-reset.spec.js --reporter=line`
+
+## Rollback
+- Revert the smoke test stub additions.

--- a/docs/pr-notes/runs/722-ci-fix-20260503T221740Z/qa.md
+++ b/docs/pr-notes/runs/722-ci-fix-20260503T221740Z/qa.md
@@ -1,0 +1,21 @@
+# QA Notes
+
+## Failing check
+- `preview-smoke [preview-smoke]`
+
+## Diagnosis
+The two failing Bulk AI smoke tests timed out waiting for `#roster-image-preview` to become visible. The issue is test drift, not product behavior: the mocked `db.js` module was missing named exports now imported by `edit-roster.html`, so the page module aborted before the image change handler was attached.
+
+## Validation command
+Run with a static server serving the repo at `http://127.0.0.1:4173`:
+
+```bash
+npx playwright test -c playwright.smoke.config.js tests/smoke/edit-roster-bulk-ai-reset.spec.js --reporter=line
+```
+
+Expected result: both tests pass.
+
+## Edge cases covered
+- Upload preview becomes visible after file selection.
+- Cancel clears file input, preview visibility, and preview image `src`.
+- Fresh text-only run after cancel does not include stale image data.

--- a/docs/pr-notes/runs/723-ci-fix-20260503T220826Z/architecture.md
+++ b/docs/pr-notes/runs/723-ci-fix-20260503T220826Z/architecture.md
@@ -1,0 +1,14 @@
+# Architecture Notes
+
+## Acceptance Criteria
+- Preview smoke tests for `team.html` load the page module successfully.
+- Calendar schedule smoke tests continue to validate practice-only and filter-bucket behavior.
+- No production behavior or data model changes.
+
+## Architecture Decisions
+- Root cause: `team.html` imports new RSVP helpers from `js/db.js?v=17`, while the smoke test DB module stub did not export them. ES module import resolution failed before `loadTeam()` rendered the header or schedule.
+- Minimal fix: align the smoke stub export surface with `team.html` by adding neutral test exports for `getRsvpSummaries`, `submitRsvp`, and `getMyRsvp`.
+
+## Risks And Rollback
+- Risk is isolated to test harness behavior. Production code and Firestore access controls are untouched.
+- Rollback is reverting the test stub additions if the page import contract changes again.

--- a/docs/pr-notes/runs/723-ci-fix-20260503T220826Z/code-plan.md
+++ b/docs/pr-notes/runs/723-ci-fix-20260503T220826Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code Plan
+
+## Implementation Plan
+- Edit only `tests/smoke/team-schedule-calendar.spec.js`.
+- Add missing named exports to the `buildDbStub` JavaScript string:
+  - `getRsvpSummaries()` returns `new Map()`
+  - `submitRsvp()` returns `undefined`
+  - `getMyRsvp()` returns `null`
+- Re-run affected smoke spec.
+
+## Summary
+The fix is test-only and aligns the smoke stub with the current `team.html` DB import contract.

--- a/docs/pr-notes/runs/723-ci-fix-20260503T220826Z/qa.md
+++ b/docs/pr-notes/runs/723-ci-fix-20260503T220826Z/qa.md
@@ -1,0 +1,15 @@
+# QA Notes
+
+## QA Plan
+- Run the affected preview smoke spec locally:
+  `npx playwright test --config=playwright.smoke.config.js tests/smoke/team-schedule-calendar.spec.js --reporter=line`
+- Verify both failing tests pass:
+  - practice calendar filter and modal
+  - duplicate/cancelled event filter buckets
+
+## Validation Result
+- Local affected smoke spec passed: 2 passed.
+
+## Risk Focus
+- Confirms the test harness no longer fails at ES module import time.
+- Keeps assertions focused on existing schedule filtering behavior rather than weakening expectations.

--- a/docs/pr-notes/runs/723-remediator-20260503T223833Z/architecture.md
+++ b/docs/pr-notes/runs/723-remediator-20260503T223833Z/architecture.md
@@ -1,0 +1,6 @@
+# Architecture
+
+- `team.html` gates `getRsvpSummaries`, `getRsvps`, and `getMyRsvp` hydration behind RSVP read eligibility that mirrors current Firestore rules.
+- Visitors without RSVP read access continue to render denormalized `game.rsvpSummary` from the public game document.
+- `getMyRsvp` accepts optional linked player IDs, reads matching `uid__playerId` override docs, and returns a consistent response or `mixed` when child responses differ.
+- Rollback is reverting `team.html` and `js/db.js`.

--- a/docs/pr-notes/runs/723-remediator-20260503T223833Z/code-plan.md
+++ b/docs/pr-notes/runs/723-remediator-20260503T223833Z/code-plan.md
@@ -1,0 +1,5 @@
+# Code Plan
+
+1. In `team.html`, compute RSVP read eligibility before summary, note, and current RSVP hydration.
+2. Pass linked player IDs into `getMyRsvp` when hydrating team schedule events.
+3. In `js/db.js`, extend `getMyRsvp` to resolve per-player override docs and mixed child responses while preserving existing callers.

--- a/docs/pr-notes/runs/723-remediator-20260503T223833Z/qa.md
+++ b/docs/pr-notes/runs/723-remediator-20260503T223833Z/qa.md
@@ -1,0 +1,4 @@
+# QA Plan
+
+- Run `npm test` for repository unit coverage.
+- Manual cases: public visitor and unrelated signed-in user load team schedule without RSVP read denials; parent/admin hydrate summaries; parent with same override responses sees the matching selection; parent with mixed child override responses sees a non-destructive mixed state.

--- a/docs/pr-notes/runs/723-remediator-20260503T223833Z/requirements.md
+++ b/docs/pr-notes/runs/723-remediator-20260503T223833Z/requirements.md
@@ -1,0 +1,6 @@
+# Requirements
+
+- Public and unrelated signed-in visitors must not trigger RSVP subcollection reads from `team.html`; they should use the denormalized `game.rsvpSummary` available through public game reads.
+- Team users who can read RSVP docs under Firestore rules, namely full team access users and parents, may hydrate live RSVP summaries and note rows.
+- Current-user RSVP state on the team schedule must consider per-player override RSVP docs (`uid__playerId`) for the user linked players, not only the legacy aggregate `uid` RSVP doc.
+- Mixed per-player responses must not be collapsed into an aggregate action that can overwrite child-specific availability.

--- a/js/db.js
+++ b/js/db.js
@@ -4221,9 +4221,47 @@ export async function getRsvps(teamId, gameId) {
     return snap.docs.map(d => ({ id: d.id, ...d.data() }));
 }
 
-export async function getMyRsvp(teamId, gameId, userId) {
-    const rsvpRef = doc(db, `teams/${teamId}/games/${gameId}/rsvps`, userId);
-    const snap = await getDoc(rsvpRef);
+export async function getMyRsvp(teamId, gameId, userId, playerIds = []) {
+    const rsvpCollectionPath = `teams/${teamId}/games/${gameId}/rsvps`;
+    const linkedPlayerIds = uniqueNonEmptyIds(playerIds);
+    const directRsvpRef = doc(db, rsvpCollectionPath, userId);
+
+    if (linkedPlayerIds.length === 0) {
+        const snap = await getDoc(directRsvpRef);
+        return snap.exists() ? { id: snap.id, ...snap.data() } : null;
+    }
+
+    const [directResult, ...overrideResults] = await Promise.allSettled([
+        getDoc(directRsvpRef),
+        ...linkedPlayerIds.map((playerId) => getDoc(doc(db, rsvpCollectionPath, buildCoachOverrideRsvpDocId(userId, playerId))))
+    ]);
+
+    const overrideRsvps = overrideResults
+        .filter((result) => result.status === 'fulfilled' && result.value.exists())
+        .map((result) => ({ id: result.value.id, ...result.value.data() }));
+
+    if (overrideRsvps.length > 0) {
+        const responses = Array.from(new Set(overrideRsvps.map((rsvp) => normalizeRsvpResponse(rsvp.response))));
+        if (responses.length === 1) {
+            return {
+                id: `${userId}__linkedPlayers`,
+                userId,
+                playerIds: overrideRsvps.flatMap((rsvp) => extractDirectRsvpPlayerIds(rsvp)),
+                response: responses[0],
+                playerRsvps: overrideRsvps
+            };
+        }
+        return {
+            id: `${userId}__linkedPlayers`,
+            userId,
+            playerIds: overrideRsvps.flatMap((rsvp) => extractDirectRsvpPlayerIds(rsvp)),
+            response: 'mixed',
+            playerRsvps: overrideRsvps
+        };
+    }
+
+    if (directResult.status === 'rejected') throw directResult.reason;
+    const snap = directResult.value;
     return snap.exists() ? { id: snap.id, ...snap.data() } : null;
 }
 

--- a/team.html
+++ b/team.html
@@ -203,6 +203,7 @@
                             <button id="schedule-filter-upcoming-games" class="px-2.5 py-1 text-xs font-semibold rounded-full border border-gray-200 bg-white text-gray-600 hover:bg-gray-100">Upcoming Games</button>
                             <button id="schedule-filter-upcoming-practices" class="px-2.5 py-1 text-xs font-semibold rounded-full border border-gray-200 bg-white text-gray-600 hover:bg-gray-100">Upcoming Practices</button>
                             <button id="schedule-filter-all-upcoming" class="px-2.5 py-1 text-xs font-semibold rounded-full border border-gray-200 bg-white text-gray-600 hover:bg-gray-100">All Upcoming</button>
+                            <button id="schedule-filter-availability" class="px-2.5 py-1 text-xs font-semibold rounded-full border border-gray-200 bg-white text-gray-600 hover:bg-gray-100">Availability</button>
                             <button id="schedule-filter-past-events" class="px-2.5 py-1 text-xs font-semibold rounded-full border border-gray-200 bg-white text-gray-600 hover:bg-gray-100">Past Events</button>
                         </div>
                     </div>
@@ -255,7 +256,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, saveTeamAvailabilityPreferences, getRsvps, getLocalAttractionSponsors } from './js/db.js?v=17';
+        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, saveTeamAvailabilityPreferences, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors } from './js/db.js?v=17';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, escapeHtml, shareOrCopy } from './js/utils.js?v=10';
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';
         import { computeNativeStandings } from './js/native-standings.js?v=1';
@@ -267,7 +268,7 @@
         import { db } from './js/firebase.js?v=10';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js';
         import { getVisibleRosterFieldValues } from './js/roster-field-privacy.js';
-        import { buildAvailabilityNoteRows, formatAvailabilityCutoff, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';
+        import { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -308,6 +309,7 @@
         window.setScheduleFilter = setScheduleFilter;
         window.setScheduleView = setScheduleView;
         window.navScheduleMonth = navScheduleMonth;
+        window.submitTeamAvailabilityFromButton = submitTeamAvailabilityFromButton;
         window.openScheduleDayModal = openScheduleDayModal;
         window.closeScheduleDayModal = closeScheduleDayModal;
         window.saveAvailabilityPreferences = saveAvailabilityPreferences;
@@ -374,6 +376,75 @@
                 if (nextStatus) nextStatus.textContent = 'Saved.';
             } catch (err) {
                 if (status) status.textContent = `Unable to save: ${err?.message || err}`;
+            }
+        }
+
+
+        function escapeAttr(value) {
+            return String(value ?? '').replace(/[&<>'"]/g, (char) => ({
+                '&': '&amp;',
+                '<': '&lt;',
+                '>': '&gt;',
+                "'": '&#39;',
+                '"': '&quot;'
+            }[char]));
+        }
+
+        function formatRsvpSummary(summary) {
+            if (!summary) return '0 going · 0 maybe · 0 not going · 0 no response';
+            return `${summary.going || 0} going · ${summary.maybe || 0} maybe · ${summary.notGoing || 0} not going · ${summary.notResponded || 0} no response`;
+        }
+
+        function getLinkedPlayerIdsForCurrentTeam() {
+            const links = Array.isArray(currentUser?.parentOf) ? currentUser.parentOf : [];
+            return Array.from(new Set(links
+                .filter((link) => link?.teamId === currentTeamId && typeof link?.playerId === 'string' && link.playerId.trim())
+                .map((link) => link.playerId.trim())));
+        }
+
+        function renderTeamAvailabilityControls(game, isUpcoming) {
+            if (!isUpcoming || game.isCancelled || !currentUser || !currentTeamAccessInfo?.hasAccess) return '';
+            const locked = !!game.availabilityLocked;
+            const summary = formatRsvpSummary(game.rsvpSummary);
+            const lockCopy = locked ? `Availability locked ${formatAvailabilityCutoff(game.availabilityPreferences).toLowerCase()}.` : '';
+            return `
+                <div class="mt-3 border-t border-gray-100 pt-3" data-team-availability-container>
+                    <div class="flex items-center justify-between gap-2 mb-2">
+                        <div class="text-[11px] font-bold uppercase tracking-wide text-gray-500">Availability</div>
+                        <div class="text-[11px] text-gray-500">${summary}</div>
+                    </div>
+                    <div class="flex gap-2">
+                        <button ${locked ? 'disabled aria-disabled="true"' : ''} data-team-id="${escapeAttr(currentTeamId)}" data-game-id="${escapeAttr(game.gameId || game.id)}" onclick="submitTeamAvailabilityFromButton(this, 'going')" class="rsvp-btn rsvp-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${locked ? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed' : (game.myRsvp === 'going' ? 'bg-green-600 text-white border-green-600' : 'bg-white text-green-700 border-green-300 hover:bg-green-50')}">Going</button>
+                        <button ${locked ? 'disabled aria-disabled="true"' : ''} data-team-id="${escapeAttr(currentTeamId)}" data-game-id="${escapeAttr(game.gameId || game.id)}" onclick="submitTeamAvailabilityFromButton(this, 'maybe')" class="rsvp-btn rsvp-maybe flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${locked ? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed' : (game.myRsvp === 'maybe' ? 'bg-yellow-500 text-white border-yellow-500' : 'bg-white text-yellow-700 border-yellow-300 hover:bg-yellow-50')}">Maybe</button>
+                        <button ${locked ? 'disabled aria-disabled="true"' : ''} data-team-id="${escapeAttr(currentTeamId)}" data-game-id="${escapeAttr(game.gameId || game.id)}" onclick="submitTeamAvailabilityFromButton(this, 'not_going')" class="rsvp-btn rsvp-not-going flex-1 px-2 py-1.5 text-xs font-semibold rounded-lg border transition ${locked ? 'bg-gray-100 text-gray-400 border-gray-200 cursor-not-allowed' : (game.myRsvp === 'not_going' ? 'bg-red-500 text-white border-red-500' : 'bg-white text-red-700 border-red-300 hover:bg-red-50')}">Not Going</button>
+                    </div>
+                    ${lockCopy ? `<div class="mt-1 text-xs font-semibold text-amber-700">${escapeHtml(lockCopy)}</div>` : ''}
+                    <div data-team-availability-status class="mt-1 text-xs text-gray-500"></div>
+                </div>
+            `;
+        }
+
+        async function submitTeamAvailabilityFromButton(btn, response) {
+            if (btn?.disabled) return;
+            const teamId = btn?.dataset?.teamId || currentTeamId;
+            const gameId = btn?.dataset?.gameId || '';
+            if (!teamId || !gameId || !currentUser) return;
+            const container = btn.closest('[data-team-availability-container]');
+            const status = container?.querySelector('[data-team-availability-status]');
+            try {
+                if (status) status.textContent = 'Saving...';
+                const summary = await submitRsvp(teamId, gameId, currentUser.uid, {
+                    displayName: currentUser.displayName || currentUser.email || 'Team member',
+                    playerIds: getLinkedPlayerIdsForCurrentTeam(),
+                    response
+                });
+                allScheduleEvents = (allScheduleEvents || []).map((event) => {
+                    if (event.type !== 'db' || (event.gameId || event.id) !== gameId) return event;
+                    return { ...event, myRsvp: response, rsvpSummary: summary || event.rsvpSummary };
+                });
+                renderScheduleFromControls();
+            } catch (err) {
+                if (status) status.textContent = err?.message || 'Unable to save availability.';
             }
         }
 
@@ -1477,6 +1548,13 @@
             const availabilityPreferences = normalizeAvailabilityPreferences(team?.availabilityPreferences);
             const isTeamAdmin = currentTeamAccessInfo?.accessLevel === 'owner' || currentTeamAccessInfo?.accessLevel === 'admin' || currentUser?.isAdmin;
             const canSeeTeamNotes = isTeamAdmin || (availabilityPreferences.noteVisibility === 'team' && currentTeamAccessInfo?.hasAccess);
+            const dbGameIds = (dbGames || []).map((game) => game.id || game.gameId).filter(Boolean);
+            let rsvpSummaries = new Map();
+            try {
+                rsvpSummaries = typeof getRsvpSummaries === 'function' ? await getRsvpSummaries(currentTeamId, dbGameIds) : new Map();
+            } catch (_) {
+                rsvpSummaries = new Map();
+            }
 
             for (const game of dbGames) {
                 const gameDate = game.date.toDate ? game.date.toDate() : new Date(game.date);
@@ -1484,11 +1562,19 @@
                 const isPractice = game.type === 'practice';
                 const isCancelled = String(game.status || '').toLowerCase() === 'cancelled';
                 let availabilityNotes = [];
+                let myRsvp = null;
                 if (canSeeTeamNotes) {
                     try {
                         availabilityNotes = buildAvailabilityNoteRows(await getRsvps(currentTeamId, id), availabilityPreferences, isTeamAdmin);
                     } catch (_) {
                         availabilityNotes = [];
+                    }
+                }
+                if (currentUser?.uid) {
+                    try {
+                        myRsvp = typeof getMyRsvp === 'function' ? (await getMyRsvp(currentTeamId, id, currentUser.uid))?.response || null : null;
+                    } catch (_) {
+                        myRsvp = null;
                     }
                 }
                 allEvents.push({
@@ -1507,8 +1593,10 @@
                     arrivalTime: game.arrivalTime,
                     notes: game.notes,
                     assignments: game.assignments,
-                    rsvpSummary: game.rsvpSummary,
+                    rsvpSummary: rsvpSummaries.get(id) || game.rsvpSummary,
+                    myRsvp,
                     availabilityPreferences,
+                    availabilityLocked: typeof isAvailabilityLocked === 'function' ? isAvailabilityLocked(gameDate, availabilityPreferences) : false,
                     availabilityNotes,
                     isCancelled,
                     isPractice
@@ -1527,7 +1615,7 @@
         function getFilteredScheduleEvents() {
             const now = new Date();
             const cutoff = new Date(now.getTime() - 3 * 60 * 60 * 1000);
-            const forcePracticeVisibility = scheduleViewFilter === 'upcoming-practices';
+            const forcePracticeVisibility = scheduleViewFilter === 'upcoming-practices' || scheduleViewFilter === 'availability';
             const events = (allScheduleEvents || []).filter((event) => {
                 if (!showPractices && event.isPractice && !forcePracticeVisibility) return false;
                 return true;
@@ -1551,6 +1639,10 @@
             }
             if (scheduleViewFilter === 'all-upcoming') {
                 filtered = events.filter((event) => event.date >= cutoff && !event.isCancelled);
+                return filtered.sort((a, b) => a.date - b.date);
+            }
+            if (scheduleViewFilter === 'availability') {
+                filtered = events.filter((event) => event.type === 'db' && event.date >= cutoff && !event.isCancelled);
                 return filtered.sort((a, b) => a.date - b.date);
             }
             if (scheduleViewFilter === 'past-events') {
@@ -1596,7 +1688,9 @@
                             ? 'upcoming practices'
                             : scheduleViewFilter === 'all-upcoming'
                                 ? 'upcoming events'
-                                : 'events';
+                                : scheduleViewFilter === 'availability'
+                                    ? 'upcoming availability events'
+                                    : 'events';
                 scheduleList.innerHTML = `
                     <div class="bg-white p-8 rounded-2xl shadow-md text-center border border-gray-200">
                         <svg class="w-16 h-16 text-gray-300 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -1763,7 +1857,7 @@
 
         function setScheduleFilter(next) {
             scheduleViewFilter = next || 'recent-results';
-            const ids = ['recent-results', 'upcoming-games', 'upcoming-practices', 'all-upcoming', 'past-events'];
+            const ids = ['recent-results', 'upcoming-games', 'upcoming-practices', 'all-upcoming', 'availability', 'past-events'];
             ids.forEach((id) => {
                 const btn = document.getElementById(`schedule-filter-${id}`);
                 if (!btn) return;
@@ -1872,8 +1966,9 @@
                                 ${game.arrivalTime ? `<div class="text-xs text-amber-600 mt-1">Arrive by ${formatTime(game.arrivalTime)}</div>` : ''}
                                 ${game.notes ? `<div class="text-xs text-gray-500 mt-1 italic">${escapeHtml(game.notes)}</div>` : ''}
                                 ${game.assignments && game.assignments.length > 0 ? `<div class="mt-2 flex flex-wrap gap-1">${game.assignments.map(a => `<span class="text-xs bg-gray-100 rounded px-2 py-0.5"><b>${escapeHtml(a.role)}:</b> ${escapeHtml(a.value || 'TBD')}</span>`).join('')}</div>` : ''}
-                                ${game.rsvpSummary ? `<div class="mt-2 flex items-center gap-3 text-xs"><span class="text-green-600 font-semibold">${game.rsvpSummary.going || 0} going</span><span class="text-yellow-600">${game.rsvpSummary.maybe || 0} maybe</span><span class="text-red-600">${game.rsvpSummary.notGoing || 0} can't go</span></div>` : ''}
+                                ${game.rsvpSummary ? `<div class="mt-2 flex flex-wrap items-center gap-3 text-xs"><span class="text-green-600 font-semibold">${game.rsvpSummary.going || 0} going</span><span class="text-yellow-600">${game.rsvpSummary.maybe || 0} maybe</span><span class="text-red-600">${game.rsvpSummary.notGoing || 0} not going</span><span class="text-gray-500">${game.rsvpSummary.notResponded || 0} no response</span></div>` : ''}
                                 ${Array.isArray(game.availabilityNotes) && game.availabilityNotes.length ? `<div class="mt-2 space-y-1">${game.availabilityNotes.map((row) => `<div class="text-[11px] text-gray-500 italic"><span class="font-semibold not-italic">${escapeHtml(row.displayName)}:</span> ${escapeHtml(row.note)}</div>`).join('')}</div>` : ''}
+                                ${typeof renderTeamAvailabilityControls === 'function' ? renderTeamAvailabilityControls(game, isUpcoming) : ''}
                             </div>
                             <div class="flex flex-col items-end gap-2">
                                 ${(isLive || isUpcoming) ? `
@@ -2015,7 +2110,7 @@
             if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) return;
             openScheduleDayModal(year, month, day);
         });
-        ['recent-results', 'upcoming-games', 'upcoming-practices', 'all-upcoming', 'past-events'].forEach((id) => {
+        ['recent-results', 'upcoming-games', 'upcoming-practices', 'all-upcoming', 'availability', 'past-events'].forEach((id) => {
             document.getElementById(`schedule-filter-${id}`)?.addEventListener('click', () => setScheduleFilter(id));
         });
 

--- a/team.html
+++ b/team.html
@@ -404,9 +404,12 @@
 
         function renderTeamAvailabilityControls(game, isUpcoming) {
             if (!isUpcoming || game.isCancelled || !currentUser || !currentTeamAccessInfo?.hasAccess) return '';
-            const locked = !!game.availabilityLocked;
+            const hasMixedPlayerRsvps = game.myRsvp === 'mixed';
+            const locked = !!game.availabilityLocked || hasMixedPlayerRsvps;
             const summary = formatRsvpSummary(game.rsvpSummary);
-            const lockCopy = locked ? `Availability locked ${formatAvailabilityCutoff(game.availabilityPreferences).toLowerCase()}.` : '';
+            const lockCopy = hasMixedPlayerRsvps
+                ? 'Player-specific RSVP responses differ. Update each player from the parent dashboard to avoid overwriting child-specific availability.'
+                : (locked ? `Availability locked ${formatAvailabilityCutoff(game.availabilityPreferences).toLowerCase()}.` : '');
             return `
                 <div class="mt-3 border-t border-gray-100 pt-3" data-team-availability-container>
                     <div class="flex items-center justify-between gap-2 mb-2">
@@ -1546,14 +1549,26 @@
             }
 
             const availabilityPreferences = normalizeAvailabilityPreferences(team?.availabilityPreferences);
-            const isTeamAdmin = currentTeamAccessInfo?.accessLevel === 'owner' || currentTeamAccessInfo?.accessLevel === 'admin' || currentUser?.isAdmin;
-            const canSeeTeamNotes = isTeamAdmin || (availabilityPreferences.noteVisibility === 'team' && currentTeamAccessInfo?.hasAccess);
+            const isTeamAdmin = currentTeamAccessInfo?.accessLevel === 'full' || currentUser?.isAdmin;
+            const linkedPlayerIds = Array.from(new Set((Array.isArray(currentUser?.parentOf) ? currentUser.parentOf : [])
+                .filter((link) => link?.teamId === currentTeamId && typeof link?.playerId === 'string' && link.playerId.trim())
+                .map((link) => link.playerId.trim())));
+            const canReadRsvps = !!currentUser && !!currentTeamId && (
+                currentUser?.isAdmin ||
+                currentTeamAccessInfo?.accessLevel === 'full' ||
+                currentTeamAccessInfo?.accessLevel === 'parent' ||
+                (Array.isArray(currentUser?.parentTeamIds) && currentUser.parentTeamIds.includes(currentTeamId)) ||
+                linkedPlayerIds.length > 0
+            );
+            const canSeeTeamNotes = canReadRsvps && (isTeamAdmin || (availabilityPreferences.noteVisibility === 'team' && currentTeamAccessInfo?.hasAccess));
             const dbGameIds = (dbGames || []).map((game) => game.id || game.gameId).filter(Boolean);
             let rsvpSummaries = new Map();
-            try {
-                rsvpSummaries = typeof getRsvpSummaries === 'function' ? await getRsvpSummaries(currentTeamId, dbGameIds) : new Map();
-            } catch (_) {
-                rsvpSummaries = new Map();
+            if (canReadRsvps) {
+                try {
+                    rsvpSummaries = typeof getRsvpSummaries === 'function' ? await getRsvpSummaries(currentTeamId, dbGameIds) : new Map();
+                } catch (_) {
+                    rsvpSummaries = new Map();
+                }
             }
 
             for (const game of dbGames) {
@@ -1570,9 +1585,9 @@
                         availabilityNotes = [];
                     }
                 }
-                if (currentUser?.uid) {
+                if (currentUser?.uid && canReadRsvps) {
                     try {
-                        myRsvp = typeof getMyRsvp === 'function' ? (await getMyRsvp(currentTeamId, id, currentUser.uid))?.response || null : null;
+                        myRsvp = typeof getMyRsvp === 'function' ? (await getMyRsvp(currentTeamId, id, currentUser.uid, linkedPlayerIds))?.response || null : null;
                     } catch (_) {
                         myRsvp = null;
                     }

--- a/tests/smoke/edit-roster-bulk-ai-reset.spec.js
+++ b/tests/smoke/edit-roster-bulk-ai-reset.spec.js
@@ -30,6 +30,9 @@ export async function getUnreadChatCount() {
 export async function getRosterFieldDefinitions() {
     return [];
 }
+export async function saveRosterFieldDefinition() {}
+export async function disableRosterFieldDefinition() {}
+export async function reorderRosterFieldDefinitions() {}
 export async function listTeamParentMembershipRequests() {
     return [];
 }

--- a/tests/smoke/team-schedule-calendar.spec.js
+++ b/tests/smoke/team-schedule-calendar.spec.js
@@ -84,6 +84,18 @@ export async function getRsvps() {
     return [];
 }
 
+export async function getRsvpSummaries() {
+    return new Map();
+}
+
+export async function submitRsvp() {
+    return undefined;
+}
+
+export async function getMyRsvp() {
+    return null;
+}
+
 export async function getLocalAttractionSponsors() {
     return [];
 }

--- a/tests/unit/team-schedule-filter.test.js
+++ b/tests/unit/team-schedule-filter.test.js
@@ -78,4 +78,30 @@ describe('team schedule filtering', () => {
         expect(pastEvents).toHaveLength(1);
         expect(pastEvents[0].opponent).toBe('Storm');
     });
+
+    it('shows only upcoming tracked games and practices in the availability view', () => {
+        const getFilteredScheduleEvents = loadGetFilteredScheduleEvents();
+        const result = getFilteredScheduleEvents({
+            showPractices: false,
+            scheduleViewFilter: 'availability',
+            allScheduleEvents: [
+                { type: 'calendar', isPractice: false, isCancelled: false, date: hoursFromNow(24), opponent: 'Imported' },
+                { type: 'db', isPractice: false, isCancelled: false, date: hoursFromNow(25), opponent: 'Rivals' },
+                { type: 'db', isPractice: true, isCancelled: false, date: hoursFromNow(26), opponent: 'Practice' },
+                { type: 'db', isPractice: false, isCancelled: true, date: hoursFromNow(27), opponent: 'Cancelled' },
+                { type: 'db', isPractice: false, isCancelled: false, date: hoursFromNow(-24), opponent: 'Past' }
+            ]
+        });
+
+        expect(result.map((event) => event.opponent)).toEqual(['Rivals', 'Practice']);
+    });
+
+    it('wires the team availability filter and RSVP controls into team.html', () => {
+        const source = readFileSync(new URL('../../team.html', import.meta.url), 'utf8');
+
+        expect(source).toContain('id="schedule-filter-availability"');
+        expect(source).toContain('submitTeamAvailabilityFromButton');
+        expect(source).toContain('getRsvpSummaries');
+        expect(source).toContain('no response');
+    });
 });


### PR DESCRIPTION
Closes #686

## What changed
- Added an Availability filter to the team schedule workflow for upcoming tracked games and practices.
- Hydrated RSVP summaries for team events so coaches/admins can scan Going, Maybe, Not Going, and no-response counts without editing event details.
- Added inline RSVP controls in the team availability cards so signed-in team members can update Going, Maybe, or Not Going from the team page.

## Validation
- `npm test -- tests/unit/team-schedule-filter.test.js tests/unit/team-schedule-events.test.js tests/unit/team-schedule-card-render.test.js`