### PR TITLE
Auto-save game plan with debounce, status badge, and unit tests

### DIFF
--- a/game-plan.html
+++ b/game-plan.html
@@ -95,9 +95,14 @@
                     <p class="text-gray-600">Plan formations, lineups, substitutions, and playing time</p>
                 </div>
                 <div class="flex items-center gap-3">
-                    <button id="save-plan-btn" class="hidden px-6 py-3 bg-gradient-to-r from-green-600 to-green-700 text-white rounded-xl hover:from-green-700 hover:to-green-800 transition shadow-md font-semibold">
-                        Save Plan
-                    </button>
+                    <div id="save-status" class="hidden items-center gap-2 text-sm font-medium px-4 py-2 rounded-xl">
+                        <svg id="save-status-spinner" class="hidden animate-spin h-4 w-4 flex-shrink-0" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                            <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                            <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"></path>
+                        </svg>
+                        <span id="save-status-dot" class="w-2 h-2 rounded-full flex-shrink-0"></span>
+                        <span id="save-status-text"></span>
+                    </div>
                 </div>
             </div>
         </div>
@@ -319,6 +324,72 @@
         let dragSourceCellKey = null;
         let combinedGames = [];
         let plannerInitialized = false;
+        let autoSaveTimer = null;
+        let hasPendingSave = false;
+
+        function setAutoSaveStatus(status) {
+            const el = document.getElementById('save-status');
+            const dot = document.getElementById('save-status-dot');
+            const spinner = document.getElementById('save-status-spinner');
+            const text = document.getElementById('save-status-text');
+            el.classList.remove('hidden');
+            el.classList.add('flex');
+            if (status === 'unsaved') {
+                el.className = 'flex items-center gap-2 text-sm font-medium px-4 py-2 rounded-xl bg-gray-100 text-gray-500';
+                spinner.classList.add('hidden');
+                dot.classList.remove('hidden');
+                dot.className = 'w-2 h-2 rounded-full bg-gray-400 flex-shrink-0';
+                text.textContent = 'Unsaved changes';
+            } else if (status === 'saving') {
+                el.className = 'flex items-center gap-2 text-sm font-medium px-4 py-2 rounded-xl bg-blue-50 text-blue-600';
+                spinner.classList.remove('hidden');
+                dot.classList.add('hidden');
+                text.textContent = 'Saving...';
+            } else if (status === 'saved') {
+                el.className = 'flex items-center gap-2 text-sm font-medium px-4 py-2 rounded-xl bg-green-50 text-green-700';
+                spinner.classList.add('hidden');
+                dot.classList.remove('hidden');
+                dot.className = 'w-2 h-2 rounded-full bg-green-500 flex-shrink-0';
+                text.textContent = 'Saved ✓';
+                setTimeout(() => {
+                    if (text.textContent === 'Saved ✓') {
+                        el.classList.add('hidden');
+                        el.classList.remove('flex');
+                    }
+                }, 3000);
+            } else if (status === 'error') {
+                el.className = 'flex items-center gap-2 text-sm font-medium px-4 py-2 rounded-xl bg-red-50 text-red-600';
+                spinner.classList.add('hidden');
+                dot.classList.remove('hidden');
+                dot.className = 'w-2 h-2 rounded-full bg-red-500 flex-shrink-0';
+                text.textContent = 'Save failed — try again';
+            }
+        }
+
+        function scheduleSave() {
+            if (!currentGameId || currentGame?.isCalendar || currentGame?.isSharedGame) return;
+            hasPendingSave = true;
+            setAutoSaveStatus('unsaved');
+            clearTimeout(autoSaveTimer);
+            autoSaveTimer = setTimeout(async () => {
+                setAutoSaveStatus('saving');
+                try {
+                    await updateGame(currentTeamId, currentGameId, { gamePlan });
+                    hasPendingSave = false;
+                    setAutoSaveStatus('saved');
+                } catch (err) {
+                    console.error('Auto-save failed:', err);
+                    setAutoSaveStatus('error');
+                }
+            }, 1500);
+        }
+
+        window.addEventListener('beforeunload', (e) => {
+            if (hasPendingSave) {
+                e.preventDefault();
+                e.returnValue = '';
+            }
+        });
 
         function createDefaultGamePlan(sportName = null) {
             const gamePlanDefaults = {
@@ -531,16 +602,12 @@
             intervalsCache = [];
             lastSelectedPlayerId = null;
             dragSourceCellKey = null;
-            const savePlanButton = document.getElementById('save-plan-btn');
-            const isReadOnlyGame = !!game.isCalendar || !!game.isSharedGame;
-            savePlanButton.disabled = isReadOnlyGame;
-            if (game.isCalendar) {
-                savePlanButton.title = 'Create this as a scheduled game to save the plan';
-            } else if (game.isSharedGame) {
-                savePlanButton.title = 'Shared tournament games are read-only in Game Plan right now';
-            } else {
-                savePlanButton.title = '';
-            }
+            clearTimeout(autoSaveTimer);
+            hasPendingSave = false;
+            // Hide status badge on game switch; it reappears on first change
+            const saveStatusEl = document.getElementById('save-status');
+            saveStatusEl.classList.add('hidden');
+            saveStatusEl.classList.remove('flex');
 
             // Update UI with game plan data
             document.getElementById('num-periods').value = gamePlan.numPeriods;
@@ -551,7 +618,6 @@
             const hasPlan = gamePlan.formationId && (gamePlan.subTimes || []).length > 0;
 
             document.getElementById('planning-wizard').classList.remove('hidden');
-            document.getElementById('save-plan-btn').classList.remove('hidden');
 
             if (hasPlan) {
                 // Skip setup steps; go straight to lineup
@@ -790,6 +856,7 @@
                         lastSelectedPlayerId = draggedPlayerId;
                         renderSubMatrix();
                         renderPlayingTimeSummary();
+                        scheduleSave();
                     }
                 });
             });
@@ -968,6 +1035,7 @@
             recentAssignments.delete(cellKey);
             renderSubMatrix();
             renderPlayingTimeSummary();
+            scheduleSave();
         };
 
         function playerAssignedInInterval(playerId, intervalKey) {
@@ -1001,6 +1069,7 @@
             renderSubMatrix();
             renderPlayingTimeSummary();
             updatePlanSummary();
+            scheduleSave();
         }
 
         function fillRowWithLastSelected(positionId) {
@@ -1020,6 +1089,7 @@
             renderSubMatrix();
             renderPlayingTimeSummary();
             updatePlanSummary();
+            scheduleSave();
         }
 
         // Step navigation
@@ -1061,6 +1131,7 @@
             renderSubMatrix();
             renderPlayingTimeSummary();
             updatePlanSummary();
+            scheduleSave();
         });
 
         // From Step 3 (Lineup) back to Step 2 (Periods)
@@ -1071,16 +1142,6 @@
             });
         });
 
-        // Save game plan
-        document.getElementById('save-plan-btn')?.addEventListener('click', async () => {
-            try {
-                await updateGame(currentTeamId, currentGameId, { gamePlan });
-                alert('Game plan saved successfully!');
-            } catch (error) {
-                console.error('Error saving game plan:', error);
-                alert('Error saving game plan. Please try again.');
-            }
-        });
 
     </script>
 </body>

--- a/game-plan.html
+++ b/game-plan.html
@@ -281,6 +281,7 @@
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent } from './js/utils.js?v=10';
         import { checkAuth } from './js/auth.js?v=12';
         import { getTeamAccessInfo } from './js/team-access.js';
+        import { createAutoSaveController } from './js/game-plan-autosave.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -324,8 +325,6 @@
         let dragSourceCellKey = null;
         let combinedGames = [];
         let plannerInitialized = false;
-        let autoSaveTimer = null;
-        let hasPendingSave = false;
 
         function setAutoSaveStatus(status) {
             const el = document.getElementById('save-status');
@@ -366,26 +365,14 @@
             }
         }
 
+        const autoSave = createAutoSaveController({ updateGame, onStatusChange: setAutoSaveStatus });
+
         function scheduleSave() {
-            if (!currentGameId || currentGame?.isCalendar || currentGame?.isSharedGame) return;
-            hasPendingSave = true;
-            setAutoSaveStatus('unsaved');
-            clearTimeout(autoSaveTimer);
-            autoSaveTimer = setTimeout(async () => {
-                setAutoSaveStatus('saving');
-                try {
-                    await updateGame(currentTeamId, currentGameId, { gamePlan });
-                    hasPendingSave = false;
-                    setAutoSaveStatus('saved');
-                } catch (err) {
-                    console.error('Auto-save failed:', err);
-                    setAutoSaveStatus('error');
-                }
-            }, 1500);
+            autoSave.scheduleSave(currentTeamId, currentGameId, gamePlan, currentGame);
         }
 
         window.addEventListener('beforeunload', (e) => {
-            if (hasPendingSave) {
+            if (autoSave.isPending()) {
                 e.preventDefault();
                 e.returnValue = '';
             }
@@ -602,8 +589,7 @@
             intervalsCache = [];
             lastSelectedPlayerId = null;
             dragSourceCellKey = null;
-            clearTimeout(autoSaveTimer);
-            hasPendingSave = false;
+            autoSave.cancel();
             // Hide status badge on game switch; it reappears on first change
             const saveStatusEl = document.getElementById('save-status');
             saveStatusEl.classList.add('hidden');

--- a/js/game-plan-autosave.js
+++ b/js/game-plan-autosave.js
@@ -1,0 +1,43 @@
+/**
+ * Creates a debounced auto-save controller for the game plan editor.
+ *
+ * @param {object} opts
+ * @param {Function} opts.updateGame - (teamId, gameId, data) => Promise
+ * @param {Function} [opts.onStatusChange] - (status: 'unsaved'|'saving'|'saved'|'error') => void
+ * @param {number} [opts.delay] - debounce ms (default 1500)
+ */
+export function createAutoSaveController({ updateGame, onStatusChange, delay = 1500 } = {}) {
+    let timer = null;
+    let hasPendingSave = false;
+
+    async function executeSave(teamId, gameId, gamePlan) {
+        onStatusChange?.('saving');
+        try {
+            await updateGame(teamId, gameId, { gamePlan });
+            hasPendingSave = false;
+            onStatusChange?.('saved');
+        } catch (err) {
+            console.error('Auto-save failed:', err);
+            onStatusChange?.('error');
+        }
+    }
+
+    function scheduleSave(teamId, gameId, gamePlan, game) {
+        if (!gameId || game?.isCalendar || game?.isSharedGame) return;
+        hasPendingSave = true;
+        onStatusChange?.('unsaved');
+        clearTimeout(timer);
+        timer = setTimeout(() => executeSave(teamId, gameId, gamePlan), delay);
+    }
+
+    function cancel() {
+        clearTimeout(timer);
+        hasPendingSave = false;
+    }
+
+    function isPending() {
+        return hasPendingSave;
+    }
+
+    return { scheduleSave, cancel, isPending };
+}

--- a/tests/unit/game-plan-autosave.test.js
+++ b/tests/unit/game-plan-autosave.test.js
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createAutoSaveController } from '../../js/game-plan-autosave.js';
+
+describe('createAutoSaveController', () => {
+    let updateGame;
+    let onStatusChange;
+    let autoSave;
+
+    beforeEach(() => {
+        vi.useFakeTimers();
+        updateGame = vi.fn().mockResolvedValue(undefined);
+        onStatusChange = vi.fn();
+        autoSave = createAutoSaveController({ updateGame, onStatusChange, delay: 1500 });
+    });
+
+    afterEach(() => {
+        vi.useRealTimers();
+    });
+
+    describe('scheduleSave — guard conditions', () => {
+        it('does nothing when gameId is falsy', () => {
+            autoSave.scheduleSave('team-1', null, {}, {});
+            vi.runAllTimers();
+            expect(updateGame).not.toHaveBeenCalled();
+            expect(onStatusChange).not.toHaveBeenCalled();
+        });
+
+        it('does nothing for a calendar game', () => {
+            autoSave.scheduleSave('team-1', 'game-1', {}, { isCalendar: true });
+            vi.runAllTimers();
+            expect(updateGame).not.toHaveBeenCalled();
+            expect(onStatusChange).not.toHaveBeenCalled();
+        });
+
+        it('does nothing for a shared game', () => {
+            autoSave.scheduleSave('team-1', 'game-1', {}, { isSharedGame: true });
+            vi.runAllTimers();
+            expect(updateGame).not.toHaveBeenCalled();
+            expect(onStatusChange).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('scheduleSave — happy path', () => {
+        it('immediately signals unsaved status', () => {
+            autoSave.scheduleSave('team-1', 'game-1', { lineups: {} }, {});
+            expect(onStatusChange).toHaveBeenCalledWith('unsaved');
+        });
+
+        it('marks isPending true right after scheduling', () => {
+            autoSave.scheduleSave('team-1', 'game-1', { lineups: {} }, {});
+            expect(autoSave.isPending()).toBe(true);
+        });
+
+        it('signals saving then saved after the debounce delay', async () => {
+            autoSave.scheduleSave('team-1', 'game-1', { lineups: {} }, {});
+            await vi.runAllTimersAsync();
+            expect(onStatusChange).toHaveBeenCalledWith('saving');
+            expect(onStatusChange).toHaveBeenCalledWith('saved');
+            expect(onStatusChange).toHaveBeenCalledTimes(3); // unsaved, saving, saved
+        });
+
+        it('calls updateGame with the correct arguments', async () => {
+            const gamePlan = { lineups: { '1-7-pg': 'player-1' } };
+            autoSave.scheduleSave('team-1', 'game-1', gamePlan, {});
+            await vi.runAllTimersAsync();
+            expect(updateGame).toHaveBeenCalledWith('team-1', 'game-1', { gamePlan });
+        });
+
+        it('clears isPending after a successful save', async () => {
+            autoSave.scheduleSave('team-1', 'game-1', { lineups: {} }, {});
+            await vi.runAllTimersAsync();
+            expect(autoSave.isPending()).toBe(false);
+        });
+    });
+
+    describe('scheduleSave — debounce', () => {
+        it('debounces rapid calls into a single updateGame call', async () => {
+            const gamePlan = { lineups: {} };
+            autoSave.scheduleSave('team-1', 'game-1', gamePlan, {});
+            autoSave.scheduleSave('team-1', 'game-1', gamePlan, {});
+            autoSave.scheduleSave('team-1', 'game-1', gamePlan, {});
+            await vi.runAllTimersAsync();
+            expect(updateGame).toHaveBeenCalledTimes(1);
+        });
+
+        it('uses the gamePlan from the final call', async () => {
+            autoSave.scheduleSave('team-1', 'game-1', { lineups: { a: 'p1' } }, {});
+            const finalPlan = { lineups: { a: 'p2' } };
+            autoSave.scheduleSave('team-1', 'game-1', finalPlan, {});
+            await vi.runAllTimersAsync();
+            expect(updateGame).toHaveBeenCalledWith('team-1', 'game-1', { gamePlan: finalPlan });
+        });
+    });
+
+    describe('scheduleSave — error handling', () => {
+        it('signals error status when updateGame rejects', async () => {
+            updateGame.mockRejectedValue(new Error('Firestore unavailable'));
+            autoSave.scheduleSave('team-1', 'game-1', { lineups: {} }, {});
+            await vi.runAllTimersAsync();
+            expect(onStatusChange).toHaveBeenCalledWith('error');
+        });
+
+        it('keeps isPending true after a failed save', async () => {
+            updateGame.mockRejectedValue(new Error('network'));
+            autoSave.scheduleSave('team-1', 'game-1', { lineups: {} }, {});
+            await vi.runAllTimersAsync();
+            expect(autoSave.isPending()).toBe(true);
+        });
+
+        it('does not signal saved after an error', async () => {
+            updateGame.mockRejectedValue(new Error('network'));
+            autoSave.scheduleSave('team-1', 'game-1', { lineups: {} }, {});
+            await vi.runAllTimersAsync();
+            const calls = onStatusChange.mock.calls.map(([s]) => s);
+            expect(calls).not.toContain('saved');
+        });
+    });
+
+    describe('cancel', () => {
+        it('prevents a pending save from firing', async () => {
+            autoSave.scheduleSave('team-1', 'game-1', { lineups: {} }, {});
+            autoSave.cancel();
+            await vi.runAllTimersAsync();
+            expect(updateGame).not.toHaveBeenCalled();
+        });
+
+        it('resets isPending to false', () => {
+            autoSave.scheduleSave('team-1', 'game-1', { lineups: {} }, {});
+            autoSave.cancel();
+            expect(autoSave.isPending()).toBe(false);
+        });
+    });
+
+    describe('onStatusChange optional', () => {
+        it('does not throw when onStatusChange is not provided', async () => {
+            const bare = createAutoSaveController({ updateGame, delay: 1500 });
+            bare.scheduleSave('team-1', 'game-1', { lineups: {} }, {});
+            await expect(vi.runAllTimersAsync()).resolves.not.toThrow();
+        });
+    });
+});

--- a/tests/unit/game-plan-switching.test.js
+++ b/tests/unit/game-plan-switching.test.js
@@ -19,13 +19,6 @@ function extractCreateDefaultGamePlanSource() {
     return match[0];
 }
 
-function extractSavePlanBody() {
-    const source = readGamePlanPage();
-    const match = source.match(/document\.getElementById\('save-plan-btn'\)\?\.addEventListener\('click', async \(\) => \{([\s\S]*?)\n        \}\);/);
-    expect(match, 'save-plan handler should exist').toBeTruthy();
-    return match[1];
-}
-
 function createClassList() {
     const classes = new Set(['hidden']);
     return {
@@ -61,13 +54,12 @@ function createDocument() {
 function buildHarness(overrides = {}) {
     const createDefaultGamePlanSource = extractCreateDefaultGamePlanSource();
     const loadGameBody = extractLoadGameBody();
-    const savePlanBody = extractSavePlanBody();
     const document = createDocument();
 
     [
         'selected-game-info',
         'game-details',
-        'save-plan-btn',
+        'save-status',
         'num-periods',
         'period-duration',
         'sub-times-input',
@@ -103,8 +95,11 @@ function buildHarness(overrides = {}) {
         renderSubMatrix: vi.fn(),
         renderPlayingTimeSummary: vi.fn(),
         updatePlanSummary: vi.fn(),
-        updateGame: vi.fn().mockResolvedValue(undefined),
-        alert: vi.fn(),
+        autoSave: {
+            cancel: vi.fn(),
+            isPending: vi.fn().mockReturnValue(false),
+            scheduleSave: vi.fn()
+        },
         console: {
             error: vi.fn()
         },
@@ -130,8 +125,7 @@ function buildHarness(overrides = {}) {
         const renderSubMatrix = deps.renderSubMatrix;
         const renderPlayingTimeSummary = deps.renderPlayingTimeSummary;
         const updatePlanSummary = deps.updatePlanSummary;
-        const updateGame = deps.updateGame;
-        const alert = deps.alert;
+        const autoSave = deps.autoSave;
         const console = deps.console;
 
         ${createDefaultGamePlanSource}
@@ -140,13 +134,8 @@ function buildHarness(overrides = {}) {
 ${loadGameBody}
         }
 
-        async function clickSave() {
-${savePlanBody}
-        }
-
         return {
             loadGame,
-            clickSave,
             getState: () => ({
                 currentGameId,
                 currentGame,
@@ -196,8 +185,8 @@ describe('game plan game switching', () => {
         expect(deps.renderSubMatrix).toHaveBeenCalledTimes(2);
     });
 
-    it('saves the switched game without carrying over the previous game lineup payload', async () => {
-        const { harness, deps } = buildHarness();
+    it('isolates gamePlan per game so a subsequent auto-save cannot carry over a previous lineup', async () => {
+        const { harness } = buildHarness();
 
         await harness.loadGame({
             id: 'game-a',
@@ -208,9 +197,7 @@ describe('game plan game switching', () => {
                 periodDuration: 25,
                 subTimes: [7, 14, 21],
                 formationId: 'soccer-9v9',
-                lineups: {
-                    '1-7-keeper': 'player-1'
-                }
+                lineups: { '1-7-keeper': 'player-1' }
             }
         });
 
@@ -220,29 +207,29 @@ describe('game plan game switching', () => {
             date: '2026-04-05T19:00:00.000Z'
         });
 
-        await harness.clickSave();
-
-        expect(deps.updateGame).toHaveBeenCalledWith('team-1', 'game-b', {
-            gamePlan: expect.objectContaining({
-                formationId: 'soccer-9v9',
-                lineups: {}
-            })
-        });
-        expect(deps.updateGame.mock.calls[0][2].gamePlan.lineups).not.toHaveProperty('1-7-keeper');
+        // The in-memory gamePlan after switching must not contain game-a's lineup
+        const { gamePlan } = harness.getState();
+        expect(gamePlan.lineups).toEqual({});
+        expect(gamePlan.lineups).not.toHaveProperty('1-7-keeper');
+        expect(harness.getState().currentGameId).toBe('game-b');
     });
 
-    it('disables saving for shared projected games', async () => {
-        const { harness, document } = buildHarness();
+    it('cancels any pending auto-save when switching games', async () => {
+        const { harness, deps } = buildHarness();
 
         await harness.loadGame({
-            id: 'shared_games%2Fabc123',
-            opponent: 'Wolves',
-            date: '2026-04-06T19:00:00.000Z',
-            isSharedGame: true
+            id: 'game-a',
+            opponent: 'Sharks',
+            date: '2026-04-04T19:00:00.000Z'
         });
 
-        const saveButton = document.getElementById('save-plan-btn');
-        expect(saveButton.disabled).toBe(true);
-        expect(saveButton.title).toBe('Shared tournament games are read-only in Game Plan right now');
+        await harness.loadGame({
+            id: 'game-b',
+            opponent: 'Bears',
+            date: '2026-04-05T19:00:00.000Z'
+        });
+
+        // autoSave.cancel should be called once per loadGame call
+        expect(deps.autoSave.cancel).toHaveBeenCalledTimes(2);
     });
 });


### PR DESCRIPTION
## Summary

- Replaces the manual "Save Plan" button with an auto-save status badge in the page header
- Changes are debounced 1.5s — the save fires after the last edit, not on every drag/drop
- Badge cycles through three states: **Unsaved changes** (grey) → **Saving...** (blue spinner) → **Saved ✓** (green, fades after 3s)
- Save errors show a persistent **Save failed — try again** state (red)
- Calendar and shared games are skipped silently (already read-only)
- `beforeunload` warning fires if the tab is closed while a save is still pending
- Auto-save triggers on: player assigned/removed, push-forward, fill-row, and advancing to the lineup step
- Extracts save logic into `js/game-plan-autosave.js` for testability
- Adds 16 unit tests covering debounce, guard conditions, error handling, and cancel
- Updates existing `game-plan-switching` tests to work with the new auto-save pattern (848 tests passing)

## Test plan

- [ ] Load game plan for a DB game, drag a player to a cell — badge shows "Unsaved changes" immediately, then "Saving..." after 1.5s, then "Saved ✓" and fades
- [ ] Rapid drag-and-drop several players — only one save fires (debounce resets each time)
- [ ] Remove a player from a cell — auto-save triggers
- [ ] Use push-forward and fill-row buttons — auto-save triggers
- [ ] Set up a new formation from scratch (steps 1→2→3) — save fires when advancing to lineup
- [ ] Load a calendar game — no badge appears, no save fires
- [ ] Make a change and immediately close the tab — browser prompts "Leave site?"
- [ ] Simulate a save error (go offline) — badge shows red "Save failed — try again"
- [ ] Switch games — badge resets/hides, no stale save state carries over

https://claude.ai/code/session_01Xb5Q44g5Yk9cMRNjNi4Jiu