### PR TITLE
Add tournament sponsor ad placements

### DIFF
--- a/docs/pr-notes/runs/729-ci-fix-20260504T023831Z/architecture.md
+++ b/docs/pr-notes/runs/729-ci-fix-20260504T023831Z/architecture.md
@@ -1,0 +1,13 @@
+# Architecture Notes
+
+## Acceptance Criteria
+- Team page smoke stubs must satisfy the current `team.html` module contract.
+- The schedule rendering path should execute far enough to populate `#team-header` and `#schedule-list`.
+- No production behavior changes are needed for this CI-only failure.
+
+## Architecture Decisions
+- Root cause is test fixture drift: `team.html` now imports `getAdSpaceSponsors` from `js/db.js?v=18`, but the Playwright smoke stub for `js/db.js` does not export it.
+- Keep fix scoped to the smoke test fixture rather than adding defensive production code, because production `js/db.js` already exports `getAdSpaceSponsors`.
+
+## Risks And Rollback
+- Risk is limited to smoke tests. Rollback by removing the added stub export if the production import contract changes again.

--- a/docs/pr-notes/runs/729-ci-fix-20260504T023831Z/code-plan.md
+++ b/docs/pr-notes/runs/729-ci-fix-20260504T023831Z/code-plan.md
@@ -1,0 +1,8 @@
+# Code Plan
+
+## Implementation Plan
+- Add a no-op `getAdSpaceSponsors()` export to the `buildDbStub` module body in `tests/smoke/team-schedule-calendar.spec.js`.
+- Do not touch `team.html` or production database helpers.
+
+## Checks Addressed
+- `preview-smoke [preview-smoke]`

--- a/docs/pr-notes/runs/729-ci-fix-20260504T023831Z/qa.md
+++ b/docs/pr-notes/runs/729-ci-fix-20260504T023831Z/qa.md
@@ -1,0 +1,9 @@
+# QA Notes
+
+## QA Plan
+- Re-run the two failing Playwright smoke tests in `tests/smoke/team-schedule-calendar.spec.js`.
+- Run the full `team-schedule-calendar.spec.js` smoke file to catch adjacent schedule regressions.
+
+## Evidence Target
+- `npx playwright test -c playwright.smoke.config.js tests/smoke/team-schedule-calendar.spec.js --grep "team schedule calendar shows only practices|team schedule keeps tracked" --reporter=line`
+- `npx playwright test -c playwright.smoke.config.js tests/smoke/team-schedule-calendar.spec.js --reporter=line`

--- a/docs/pr-notes/runs/729-remediator-20260504T043822Z/architecture.md
+++ b/docs/pr-notes/runs/729-remediator-20260504T043822Z/architecture.md
@@ -1,0 +1,9 @@
+# Architecture Notes
+
+## Architecture Decisions
+- Keep the defensive guard at the module boundary/helper level instead of adding caller-specific handling. This limits blast radius and preserves existing data mapping behavior.
+- Return `[]` for missing or malformed attraction/sponsor collections, matching existing normalizer semantics for undefined inputs.
+
+## Risks And Rollback
+- Risk is low: no Firebase schema, auth, or tenant access changes.
+- Rollback is a single commit revert if downstream UI expected an exception, which would be undesirable and currently untested behavior.

--- a/docs/pr-notes/runs/729-remediator-20260504T043822Z/code-plan.md
+++ b/docs/pr-notes/runs/729-remediator-20260504T043822Z/code-plan.md
@@ -1,0 +1,7 @@
+# Code Plan
+
+## Implementation Plan
+- Inspect `js/local-attractions.js` for the referenced review feedback.
+- Since `fetchNearbyAttractions` is not present in the current branch, add the minimal equivalent defensive guard to sponsor sorting/normalization helpers.
+- Add focused unit coverage for null/malformed attraction collections.
+- Run the affected unit test file.

--- a/docs/pr-notes/runs/729-remediator-20260504T043822Z/qa.md
+++ b/docs/pr-notes/runs/729-remediator-20260504T043822Z/qa.md
@@ -1,0 +1,6 @@
+# QA Notes
+
+## QA Plan
+- Run unit tests for local attraction helpers.
+- Add/verify coverage that null and non-array upstream collections return empty arrays without throwing.
+- No manual browser validation required because this is a pure helper guard and there is no UI behavior change beyond avoiding a crash.

--- a/docs/pr-notes/runs/729-remediator-20260504T043822Z/requirements.md
+++ b/docs/pr-notes/runs/729-remediator-20260504T043822Z/requirements.md
@@ -1,0 +1,9 @@
+# Requirements Notes
+
+## Acceptance Criteria
+- Review threads PRRT_kwDOQe-T585_PFZr and PRRT_kwDOQe-T585_PFZz are addressed with a defensive null/non-array guard in the local-attractions helper path.
+- Local attraction/ad-space sponsor normalization must return an empty list instead of throwing when upstream attraction/sponsor data is missing, null, or not an array.
+- Change scope remains limited to `js/local-attractions.js` and direct unit coverage.
+
+## Assumptions
+- The review comment references `fetchNearbyAttractions`, but that function is not present in the current PR branch. The closest affected code path is sponsor/attraction list normalization in `js/local-attractions.js`.

--- a/js/db.js
+++ b/js/db.js
@@ -53,7 +53,7 @@ import {
     buildSharedScheduleDetachUpdate
 } from './shared-schedule-sync.js';
 import { normalizeTeamNotificationPreferences } from './notification-preferences.js?v=1';
-import { normalizeLocalAttractionSponsors } from './local-attractions.js?v=1';
+import { normalizeAdSpaceSponsors, normalizeLocalAttractionSponsors } from './local-attractions.js?v=2';
 import { buildRosterFieldDefinitionPayload } from './roster-profile-fields.js?v=2';
 import {
     decodeSharedGameSyntheticId,
@@ -408,12 +408,13 @@ export async function getTeam(teamId, options = {}) {
     }
 }
 
-export async function getLocalAttractionSponsors(teamId) {
+async function getPublishedSponsors(teamId) {
     if (!teamId) return [];
 
     const sponsorsRef = collection(db, `teams/${teamId}/sponsors`);
     const sponsorQueries = [
         query(sponsorsRef, where("status", "==", "published")),
+        query(sponsorsRef, where("status", "==", "active")),
         query(sponsorsRef, where("published", "==", true)),
         query(sponsorsRef, where("isPublished", "==", true))
     ];
@@ -421,7 +422,7 @@ export async function getLocalAttractionSponsors(teamId) {
     const successfulSnapshots = snapshots.filter((result) => result.status === 'fulfilled');
 
     if (successfulSnapshots.length === 0) {
-        throw snapshots[0]?.reason || new Error('Unable to load local attraction sponsors');
+        throw snapshots[0]?.reason || new Error('Unable to load sponsor placements');
     }
 
     const sponsorsById = new Map();
@@ -429,7 +430,15 @@ export async function getLocalAttractionSponsors(teamId) {
         result.value.docs.forEach(doc => sponsorsById.set(doc.id, { id: doc.id, ...doc.data() }));
     });
 
-    return normalizeLocalAttractionSponsors(Array.from(sponsorsById.values()));
+    return Array.from(sponsorsById.values());
+}
+
+export async function getLocalAttractionSponsors(teamId) {
+    return normalizeLocalAttractionSponsors(await getPublishedSponsors(teamId));
+}
+
+export async function getAdSpaceSponsors(teamId) {
+    return normalizeAdSpaceSponsors(await getPublishedSponsors(teamId));
 }
 
 export async function getUserTeams(userId, options = {}) {

--- a/js/local-attractions.js
+++ b/js/local-attractions.js
@@ -98,7 +98,9 @@ function normalizeSponsorDisplayFields(sponsor) {
 }
 
 function sortSponsors(sponsors) {
-    return sponsors.sort((a, b) => {
+    const sortableSponsors = Array.isArray(sponsors) ? sponsors : [];
+
+    return sortableSponsors.sort((a, b) => {
         if (a.sortOrder !== b.sortOrder) return a.sortOrder - b.sortOrder;
         return a.name.localeCompare(b.name);
     });

--- a/js/local-attractions.js
+++ b/js/local-attractions.js
@@ -18,9 +18,18 @@ function firstNumber(...values) {
     return Number.MAX_SAFE_INTEGER;
 }
 
-function hasLocalAttractionPlacement(sponsor) {
+function normalizedPlacements(sponsor) {
     const placements = Array.isArray(sponsor?.placements) ? sponsor.placements : [];
-    const placement = asString(sponsor?.placement || sponsor?.placementType || sponsor?.sponsorPlacement).toLowerCase();
+    return [sponsor?.placement, sponsor?.placementType, sponsor?.sponsorPlacement, ...placements]
+        .map((item) => asString(item).toLowerCase())
+        .filter(Boolean);
+}
+
+function hasPlacementToken(sponsor, tokens) {
+    return normalizedPlacements(sponsor).some((placement) => tokens.includes(placement));
+}
+
+function hasLocalAttractionPlacement(sponsor) {
     const flags = [
         sponsor?.localAttraction,
         sponsor?.isLocalAttraction,
@@ -28,13 +37,25 @@ function hasLocalAttractionPlacement(sponsor) {
         sponsor?.attraction === true,
         sponsor?.category === 'local-attraction',
         sponsor?.category === 'local_attraction',
-        placement === 'local-attraction',
-        placement === 'local_attraction',
-        placement === 'local attraction',
-        placements.some((item) => {
-            const normalized = asString(item).toLowerCase();
-            return normalized === 'local-attraction' || normalized === 'local_attraction' || normalized === 'local attraction';
-        })
+        hasPlacementToken(sponsor, ['local-attraction', 'local_attraction', 'local attraction'])
+    ];
+
+    return flags.some(Boolean);
+}
+
+function hasAdSpacePlacement(sponsor) {
+    const category = asString(sponsor?.category).toLowerCase();
+    const flags = [
+        sponsor?.adSpace,
+        sponsor?.isAdSpace,
+        sponsor?.adSpaceSponsor,
+        sponsor?.sponsorAdSpace,
+        sponsor?.showInAdSpace,
+        sponsor?.advertising === true,
+        category === 'ad-space',
+        category === 'ad_space',
+        category === 'ad space',
+        hasPlacementToken(sponsor, ['ad-space', 'ad_space', 'ad space', 'sponsor-ad', 'sponsor_ad', 'advertising'])
     ];
 
     return flags.some(Boolean);
@@ -42,7 +63,7 @@ function hasLocalAttractionPlacement(sponsor) {
 
 function isPublishedSponsor(sponsor) {
     const status = asString(sponsor?.status).toLowerCase();
-    return sponsor?.published === true || sponsor?.isPublished === true || status === 'published';
+    return sponsor?.published === true || sponsor?.isPublished === true || status === 'published' || status === 'active';
 }
 
 export function normalizeExternalWebsiteUrl(value) {
@@ -61,29 +82,55 @@ export function normalizeExternalWebsiteUrl(value) {
     }
 }
 
-export function normalizeLocalAttractionSponsor(sponsor) {
-    if (!sponsor || !isPublishedSponsor(sponsor) || !hasLocalAttractionPlacement(sponsor)) return null;
-
+function normalizeSponsorDisplayFields(sponsor) {
     const name = firstString(sponsor.name, sponsor.businessName, sponsor.title);
     if (!name) return null;
 
     return {
         id: sponsor.id || null,
         name,
-        description: firstString(sponsor.description, sponsor.summary, sponsor.shortDescription),
+        description: firstString(sponsor.description, sponsor.summary, sponsor.shortDescription, sponsor.tagline),
         phone: firstString(sponsor.phone, sponsor.phoneNumber, sponsor.contactPhone),
-        imageUrl: firstString(sponsor.imageUrl, sponsor.photoUrl, sponsor.logoUrl, sponsor.logo),
+        imageUrl: firstString(sponsor.imageUrl, sponsor.photoUrl, sponsor.logoUrl, sponsor.logo, sponsor.adImageUrl, sponsor.bannerUrl),
         websiteUrl: normalizeExternalWebsiteUrl(firstString(sponsor.websiteUrl, sponsor.website, sponsor.url, sponsor.linkUrl)),
         sortOrder: firstNumber(sponsor.sortOrder, sponsor.displayOrder, sponsor.order, sponsor.rank)
     };
 }
 
+function sortSponsors(sponsors) {
+    return sponsors.sort((a, b) => {
+        if (a.sortOrder !== b.sortOrder) return a.sortOrder - b.sortOrder;
+        return a.name.localeCompare(b.name);
+    });
+}
+
+export function normalizeLocalAttractionSponsor(sponsor) {
+    if (!sponsor || !isPublishedSponsor(sponsor) || !hasLocalAttractionPlacement(sponsor)) return null;
+    return normalizeSponsorDisplayFields(sponsor);
+}
+
 export function normalizeLocalAttractionSponsors(sponsors = []) {
-    return (Array.isArray(sponsors) ? sponsors : [])
+    return sortSponsors((Array.isArray(sponsors) ? sponsors : [])
         .map(normalizeLocalAttractionSponsor)
-        .filter(Boolean)
-        .sort((a, b) => {
-            if (a.sortOrder !== b.sortOrder) return a.sortOrder - b.sortOrder;
-            return a.name.localeCompare(b.name);
-        });
+        .filter(Boolean));
+}
+
+export function normalizeAdSpaceSponsor(sponsor) {
+    if (!sponsor || !isPublishedSponsor(sponsor) || !hasAdSpacePlacement(sponsor)) return null;
+    return normalizeSponsorDisplayFields(sponsor);
+}
+
+export function normalizeAdSpaceSponsors(sponsors = []) {
+    return sortSponsors((Array.isArray(sponsors) ? sponsors : [])
+        .map(normalizeAdSpaceSponsor)
+        .filter(Boolean));
+}
+
+export function selectRotatingSponsor(sponsors = [], previousSponsorId = '') {
+    const eligible = Array.isArray(sponsors) ? sponsors.filter(Boolean) : [];
+    if (eligible.length === 0) return null;
+    if (eligible.length === 1) return eligible[0];
+
+    const previousIndex = eligible.findIndex((sponsor) => sponsor.id && sponsor.id === previousSponsorId);
+    return eligible[(previousIndex + 1 + eligible.length) % eligible.length];
 }

--- a/team.html
+++ b/team.html
@@ -259,7 +259,8 @@
     </div>
 
     <script type="module">
-        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, saveTeamAvailabilityPreferences, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors } from './js/db.js?v=18';
+        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, saveTeamAvailabilityPreferences, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors } from './js/db.js?v=18';
+        import { normalizeExternalWebsiteUrl, selectRotatingSponsor } from './js/local-attractions.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, escapeHtml, shareOrCopy } from './js/utils.js?v=10';
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';
         import { computeNativeStandings } from './js/native-standings.js?v=1';
@@ -305,6 +306,7 @@
         let teamGames = [];
         let gamesById = {};
         let allScheduleEvents = [];
+        let adSpaceSponsors = [];
         let scheduleViewFilter = 'recent-results';
         let scheduleViewMode = 'list';
         let scheduleCalendarMonth = new Date().getMonth();
@@ -456,6 +458,35 @@
             }
         }
 
+        function renderSponsorAdPlacement(sponsor, context = 'schedule') {
+            if (!sponsor) return '';
+            const imageHtml = sponsor.imageUrl
+                ? `<img src="${escapeHtml(sponsor.imageUrl)}" alt="${escapeHtml(sponsor.name)}" class="h-16 w-16 rounded-xl object-cover bg-white/60 border border-white/60 flex-shrink-0">`
+                : '<div class="h-16 w-16 rounded-xl bg-white/60 border border-white/60 flex items-center justify-center text-primary-700 font-black text-2xl flex-shrink-0">★</div>';
+            const bodyHtml = `
+                <div class="flex items-center gap-4">
+                    ${imageHtml}
+                    <div class="min-w-0">
+                        <div class="text-[11px] font-bold uppercase tracking-[0.2em] text-primary-700">Tournament sponsor</div>
+                        <div class="text-base font-black text-gray-900 truncate">${escapeHtml(sponsor.name)}</div>
+                        ${sponsor.description ? `<div class="text-sm text-gray-600 line-clamp-2">${escapeHtml(sponsor.description)}</div>` : ''}
+                    </div>
+                </div>
+            `;
+            const className = context === 'standings'
+                ? 'block rounded-2xl border border-primary-200 bg-gradient-to-r from-primary-50 via-white to-amber-50 p-4 shadow-sm hover:shadow-md transition'
+                : 'block rounded-2xl border border-primary-200 bg-gradient-to-r from-primary-50 via-white to-amber-50 p-4 shadow-sm hover:shadow-md transition';
+            if (sponsor.websiteUrl) {
+                return `<a class="${className}" target="_blank" rel="noopener noreferrer" href="${escapeHtml(sponsor.websiteUrl)}" aria-label="Visit ${escapeHtml(sponsor.name)} sponsor website">${bodyHtml}</a>`;
+            }
+            return `<div class="${className}" aria-label="Tournament sponsor ${escapeHtml(sponsor.name)}">${bodyHtml}</div>`;
+        }
+
+        function getInlineSponsor(index) {
+            if (!Array.isArray(adSpaceSponsors) || adSpaceSponsors.length === 0) return null;
+            return adSpaceSponsors[index % adSpaceSponsors.length];
+        }
+
         function renderLocalAttractionsSection(sponsors, loadError = null) {
             const section = document.getElementById('local-attractions-section');
             const content = document.getElementById('local-attractions-content');
@@ -492,6 +523,68 @@
                     </div>
                 </article>
             `).join('');
+        }
+
+        function readSponsorPromoState(teamId) {
+            try {
+                return JSON.parse(localStorage.getItem(`allplays:sponsor-promo:${teamId}`) || '{}') || {};
+            } catch (error) {
+                return {};
+            }
+        }
+
+        function writeSponsorPromoState(teamId, state) {
+            try {
+                localStorage.setItem(`allplays:sponsor-promo:${teamId}`, JSON.stringify(state));
+            } catch (error) {
+                // Ignore storage failures; dismiss still removes the modal for this view.
+            }
+        }
+
+        function dismissSponsorPromo(teamId, sponsorId) {
+            const sixHoursMs = 6 * 60 * 60 * 1000;
+            writeSponsorPromoState(teamId, {
+                lastSponsorId: sponsorId || '',
+                nextEligibleAt: Date.now() + sixHoursMs
+            });
+            document.getElementById('sponsor-promo-modal')?.remove();
+        }
+
+        function maybeShowSponsorPromo(teamId, sponsors) {
+            if (!teamId || !Array.isArray(sponsors) || sponsors.length === 0) return;
+            const state = readSponsorPromoState(teamId);
+            if (Number(state.nextEligibleAt) > Date.now()) return;
+
+            const sponsor = selectRotatingSponsor(sponsors, state.lastSponsorId);
+            if (!sponsor) return;
+            const websiteUrl = normalizeExternalWebsiteUrl(sponsor.websiteUrl);
+            const linkHtml = websiteUrl
+                ? `<a class="inline-flex items-center justify-center rounded-full bg-primary-600 px-5 py-2.5 text-sm font-bold text-white hover:bg-primary-700" target="_blank" rel="noopener noreferrer" href="${escapeHtml(websiteUrl)}">Visit sponsor</a>`
+                : '';
+            const imageHtml = sponsor.imageUrl
+                ? `<img src="${escapeHtml(sponsor.imageUrl)}" alt="${escapeHtml(sponsor.name)}" class="mx-auto h-28 w-28 rounded-3xl object-cover shadow-lg border border-white">`
+                : '<div class="mx-auto h-28 w-28 rounded-3xl bg-primary-100 text-primary-700 flex items-center justify-center text-5xl font-black shadow-lg">★</div>';
+
+            const modal = document.createElement('div');
+            modal.id = 'sponsor-promo-modal';
+            modal.className = 'fixed inset-0 z-[70] bg-gray-950/70 p-4 flex items-center justify-center';
+            modal.innerHTML = `
+                <div class="w-full max-w-md rounded-3xl bg-white p-6 text-center shadow-2xl border border-primary-100">
+                    <div class="text-[11px] font-black uppercase tracking-[0.25em] text-primary-700 mb-4">Tournament sponsor spotlight</div>
+                    ${imageHtml}
+                    <h2 class="mt-5 text-2xl font-black text-gray-900">${escapeHtml(sponsor.name)}</h2>
+                    ${sponsor.description ? `<p class="mt-3 text-sm text-gray-600 leading-relaxed">${escapeHtml(sponsor.description)}</p>` : ''}
+                    <div class="mt-6 flex flex-col sm:flex-row justify-center gap-3">
+                        ${linkHtml}
+                        <button id="sponsor-promo-dismiss" class="inline-flex items-center justify-center rounded-full border border-gray-300 px-5 py-2.5 text-sm font-bold text-gray-700 hover:bg-gray-50">Dismiss</button>
+                    </div>
+                </div>
+            `;
+            document.body.appendChild(modal);
+            document.getElementById('sponsor-promo-dismiss')?.addEventListener('click', () => dismissSponsorPromo(teamId, sponsor.id));
+            modal.addEventListener('click', (event) => {
+                if (event.target === modal) dismissSponsorPromo(teamId, sponsor.id);
+            });
         }
 
         function renderNextGameBody(nextGame) {
@@ -614,7 +707,7 @@
 
             const metricLabel = team?.standingsConfig?.rankingMode === 'win_pct' ? 'PCT' : 'PTS';
             const currentTeamName = String(team?.name || '').trim();
-            content.innerHTML = pools.map((pool) => {
+            content.innerHTML = pools.map((pool, index) => {
                 const rows = Array.isArray(pool.rows) ? pool.rows : [];
                 const scheduledGameCount = Number(pool.scheduledGameCount) || 0;
                 const completedGameCount = Number(pool.gameCount) || 0;
@@ -627,7 +720,7 @@
                     ? 'No completed tournament games with scores yet. Final scores will populate this standings table.'
                     : 'No games are scheduled in this division or pool yet.';
 
-                return `
+                const standingsHtml = `
                     <div class="bg-white rounded-2xl shadow-md border border-gray-200 overflow-hidden">
                         <div class="px-6 py-4 border-b border-gray-100 bg-gray-50 flex items-center justify-between gap-3 flex-wrap">
                             <div>
@@ -684,6 +777,8 @@
                         }
                     </div>
                 `;
+                const sponsor = getInlineSponsor(index);
+                return sponsor ? `${standingsHtml}${renderSponsorAdPlacement(sponsor, 'standings')}` : standingsHtml;
             }).join('');
 
             section.classList.remove('hidden');
@@ -1183,6 +1278,13 @@
                         ? await fetchLeagueStandings(team.leagueUrl, { teamName: team.name })
                         : { ok: false, reason: 'missing-url', rows: [], match: null });
 
+                try {
+                    adSpaceSponsors = await getAdSpaceSponsors(teamId);
+                } catch (error) {
+                    console.error('Error loading sponsor ad placements:', error);
+                    adSpaceSponsors = [];
+                }
+
                 // Fetch calendar events and render schedule
                 await renderSchedule(team, dbGames);
 
@@ -1271,6 +1373,7 @@
                     console.error('Error loading local attractions:', error);
                     renderLocalAttractionsSection([], error);
                 }
+                maybeShowSponsorPromo(teamId, adSpaceSponsors);
 
                 // Start countdown updates
                 if (nextGame) {
@@ -1733,12 +1836,13 @@
                 return;
             }
 
-            scheduleList.innerHTML = events.map(event => {
-                if (event.type === 'calendar') {
-                    return renderCalendarEvent(event);
-                } else {
-                    return renderDbGame(event);
-                }
+            scheduleList.innerHTML = events.map((event, index) => {
+                const eventHtml = event.type === 'calendar'
+                    ? renderCalendarEvent(event)
+                    : renderDbGame(event);
+                if ((index + 1) % 3 !== 0 || index === events.length - 1) return eventHtml;
+                const sponsor = getInlineSponsor(Math.floor(index / 3));
+                return sponsor ? `${eventHtml}${renderSponsorAdPlacement(sponsor, 'schedule')}` : eventHtml;
             }).join('');
         }
 

--- a/tests/smoke/team-schedule-calendar.spec.js
+++ b/tests/smoke/team-schedule-calendar.spec.js
@@ -99,6 +99,10 @@ export async function getMyRsvp() {
 export async function getLocalAttractionSponsors() {
     return [];
 }
+
+export async function getAdSpaceSponsors() {
+    return [];
+}
 `;
 }
 

--- a/tests/unit/local-attractions.test.js
+++ b/tests/unit/local-attractions.test.js
@@ -99,6 +99,13 @@ describe('local attraction sponsor helpers', () => {
     });
   });
 
+  it('returns empty lists for missing or malformed sponsor collections', () => {
+    expect(normalizeLocalAttractionSponsors()).toEqual([]);
+    expect(normalizeLocalAttractionSponsors(null)).toEqual([]);
+    expect(normalizeAdSpaceSponsors()).toEqual([]);
+    expect(normalizeAdSpaceSponsors({ location: null })).toEqual([]);
+  });
+
   it('rotates away from the previously shown sponsor when possible', () => {
     const sponsors = [{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }, { id: 'c', name: 'C' }];
 

--- a/tests/unit/local-attractions.test.js
+++ b/tests/unit/local-attractions.test.js
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
+  normalizeAdSpaceSponsors,
   normalizeExternalWebsiteUrl,
-  normalizeLocalAttractionSponsors
+  normalizeLocalAttractionSponsors,
+  selectRotatingSponsor
 } from '../../js/local-attractions.js';
 
 describe('local attraction sponsor helpers', () => {
@@ -54,5 +56,54 @@ describe('local attraction sponsor helpers', () => {
     expect(normalizeExternalWebsiteUrl('javascript:alert(1)')).toBe('');
     expect(normalizeExternalWebsiteUrl('mailto:test@example.com')).toBe('');
     expect(normalizeExternalWebsiteUrl('https://safe.example.com/path')).toBe('https://safe.example.com/path');
+  });
+
+  it('normalizes only published ad-space sponsors with safe links', () => {
+    const sponsors = normalizeAdSpaceSponsors([
+      {
+        id: 'pizza',
+        name: 'Pizza Place',
+        status: 'active',
+        placements: ['ad-space'],
+        websiteUrl: 'pizza.example.com',
+        adImageUrl: 'https://img.example.com/pizza.png',
+        rank: 2
+      },
+      {
+        id: 'bank',
+        businessName: 'Community Bank',
+        published: true,
+        isAdSpace: true,
+        linkUrl: 'javascript:alert(1)',
+        displayOrder: 1
+      },
+      {
+        id: 'hidden',
+        name: 'Hidden Sponsor',
+        published: false,
+        adSpace: true
+      },
+      {
+        id: 'attraction',
+        name: 'Attraction Only',
+        published: true,
+        localAttraction: true
+      }
+    ]);
+
+    expect(sponsors.map((sponsor) => sponsor.name)).toEqual(['Community Bank', 'Pizza Place']);
+    expect(sponsors[0].websiteUrl).toBe('');
+    expect(sponsors[1]).toMatchObject({
+      imageUrl: 'https://img.example.com/pizza.png',
+      websiteUrl: 'https://pizza.example.com/'
+    });
+  });
+
+  it('rotates away from the previously shown sponsor when possible', () => {
+    const sponsors = [{ id: 'a', name: 'A' }, { id: 'b', name: 'B' }, { id: 'c', name: 'C' }];
+
+    expect(selectRotatingSponsor(sponsors, 'a')).toEqual(sponsors[1]);
+    expect(selectRotatingSponsor(sponsors, 'c')).toEqual(sponsors[0]);
+    expect(selectRotatingSponsor([sponsors[0]], 'a')).toEqual(sponsors[0]);
   });
 });


### PR DESCRIPTION
Closes #684

## Summary
- Adds ad-space sponsor normalization and loading from team sponsor records.
- Renders inline sponsor placements in tournament schedule and standings areas without replacing core game information.
- Adds a dismissible full-screen sponsor spotlight with local-storage frequency capping and sponsor rotation.

## Validation
- `npx vitest run tests/unit/local-attractions.test.js --reporter=dot`
- `node --check /tmp/team-script-check.mjs`