### PR TITLE
Warn on officiating assignment conflicts

### DIFF
--- a/docs/pr-notes/runs/733-remediator-20260505T030830Z/architecture.md
+++ b/docs/pr-notes/runs/733-remediator-20260505T030830Z/architecture.md
@@ -1,0 +1,13 @@
+# Architecture
+
+## Decision
+Keep the filtering in `js/officiating-utils.js`, where conflict detection is centralized, instead of filtering only at the `edit-schedule.html` call site.
+
+## Rationale
+- `edit-schedule.html` passes `Object.values(gamesCache)`, which can include cancelled games.
+- Centralizing the status guard prevents the same false-positive behavior for any future caller of `getOfficiatingAssignmentConflictWarnings`.
+- The patch is scoped to the conflict detection path and does not change scheduling data or persistence.
+
+## Risks And Rollback
+- Risk is low: cancelled games are removed from warning calculations only.
+- Rollback is reverting the helper guard and related unit assertions.

--- a/docs/pr-notes/runs/733-remediator-20260505T030830Z/code-plan.md
+++ b/docs/pr-notes/runs/733-remediator-20260505T030830Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Plan
+
+## Implementation Plan
+1. Add a small cancellation predicate in `js/officiating-utils.js`.
+2. Return no warnings when the candidate game is cancelled.
+3. Skip cancelled existing games inside the conflict scan loop.
+4. Extend `tests/unit/officiating-utils.test.js` to cover cancelled existing games and cancelled candidate games.
+
+## Files
+- `js/officiating-utils.js`
+- `tests/unit/officiating-utils.test.js`

--- a/docs/pr-notes/runs/733-remediator-20260505T030830Z/qa.md
+++ b/docs/pr-notes/runs/733-remediator-20260505T030830Z/qa.md
@@ -1,0 +1,14 @@
+# QA Plan
+
+## Automated
+- Run targeted unit tests for officiating helpers: `npm test -- --run tests/unit/officiating-utils.test.js`.
+
+## Manual
+- In `edit-schedule.html`, create or edit a game with an official assigned.
+- Ensure an overlapping cancelled game with the same official exists in the cache.
+- Save should not show the conflict confirmation for the cancelled game.
+- Confirm an overlapping active game with the same official still shows the warning.
+
+## Regression Focus
+- Back-to-back active assignments still warn.
+- Editing the same game still does not warn against itself.

--- a/docs/pr-notes/runs/733-remediator-20260505T030830Z/requirements.md
+++ b/docs/pr-notes/runs/733-remediator-20260505T030830Z/requirements.md
@@ -1,0 +1,12 @@
+# Requirements
+
+## Acceptance Criteria
+- Save-time officiating conflict warnings must ignore cancelled games from the existing games cache.
+- Cancelled or canceled status values must not produce false conflict confirmation prompts.
+- A cancelled candidate game should not produce officiating conflict warnings.
+- Active overlapping and back-to-back conflicts must continue to warn.
+
+## Edge Cases
+- Editing the same game remains ignored by id.
+- Declined, cannot-make, and open officiating slots remain non-conflicting.
+- Missing dates continue to skip conflict evaluation.

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -899,7 +899,7 @@
         import { mergeCalendarImportEvents, validateCalendarImportUrl } from './js/edit-schedule-calendar-import.js?v=1';
         import { checkAuth } from './js/auth.js?v=12';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
-        import { computeOfficiatingCoverageStatus, normalizeOfficiatingSlots as normalizeAssignmentOfficiatingSlots } from './js/officiating-utils.js?v=1';
+        import { computeOfficiatingCoverageStatus, getOfficiatingAssignmentConflictWarnings, normalizeOfficiatingSlots as normalizeAssignmentOfficiatingSlots } from './js/officiating-utils.js?v=2';
         import { getTeamAccessInfo } from './js/team-access.js';
         import { resolvePreferredStatConfigId } from './js/live-game-state.js?v=3';
         import { cancelScheduledGame } from './js/edit-schedule-cancel-game.js?v=3';
@@ -2816,6 +2816,26 @@
             };
         }
 
+        function formatOfficiatingConflictWarning(warning) {
+            const conflictLabel = warning.conflictType === 'back-to-back' ? 'back-to-back' : 'overlapping';
+            return `${warning.officialName} has ${conflictLabel} assignments: ${warning.candidateGameLabel} and ${warning.conflictingGameLabel}`;
+        }
+
+        function confirmOfficiatingAssignmentConflicts(gameData) {
+            const warnings = getOfficiatingAssignmentConflictWarnings(gameData, Object.values(gamesCache), {
+                editingGameId
+            });
+            if (!warnings.length) return true;
+
+            return confirm([
+                'Officiating assignment conflict warning:',
+                '',
+                ...warnings.map(formatOfficiatingConflictWarning),
+                '',
+                'Save this game anyway?'
+            ].join('\n'));
+        }
+
         function populateOfficiatingSlots(slots) {
             const container = document.getElementById('officiating-slot-rows');
             container.innerHTML = '';
@@ -2933,6 +2953,8 @@
                 };
                 Object.assign(gameData, getOfficiatingAuthorizationFields(gameData.officiatingSlots));
                 gameData.officiatingCoverageStatus = computeOfficiatingCoverageStatus(gameData.officiatingSlots);
+
+                if (!confirmOfficiatingAssignmentConflicts(gameData)) return;
 
                 if (tournamentData) {
                     gameData.tournament = tournamentData;

--- a/js/officiating-utils.js
+++ b/js/officiating-utils.js
@@ -92,9 +92,14 @@ function hasSharedOfficialIdentity(a, b) {
     return b.identityKeys.some((key) => keys.has(key));
 }
 
+function isCancelledGame(game = {}) {
+    const status = String(game?.status || '').trim().toLowerCase();
+    return status === 'cancelled' || status === 'canceled' || game?.deleted === true;
+}
+
 export function getOfficiatingAssignmentConflictWarnings(candidateGame = {}, existingGames = [], options = {}) {
     const candidateWindow = getGameWindow(candidateGame, options.defaultGameMinutes);
-    if (!candidateWindow || !Array.isArray(existingGames)) return [];
+    if (!candidateWindow || isCancelledGame(candidateGame) || !Array.isArray(existingGames)) return [];
 
     const candidateAssignments = getActiveOfficialAssignments(candidateGame);
     if (!candidateAssignments.length) return [];
@@ -103,6 +108,8 @@ export function getOfficiatingAssignmentConflictWarnings(candidateGame = {}, exi
     const warnings = [];
 
     existingGames.forEach((existingGame) => {
+        if (isCancelledGame(existingGame)) return;
+
         const existingId = String(existingGame?.id || '').trim();
         if (candidateId && existingId && candidateId === existingId) return;
 

--- a/js/officiating-utils.js
+++ b/js/officiating-utils.js
@@ -42,6 +42,96 @@ export function computeOfficiatingCoverageStatus(slots = []) {
     return normalized.every((slot) => slot.status === 'accepted') ? 'covered' : 'needs_attention';
 }
 
+function getDateMillis(dateValue) {
+    if (!dateValue) return null;
+    if (typeof dateValue.toMillis === 'function') return dateValue.toMillis();
+    if (typeof dateValue.toDate === 'function') return dateValue.toDate().getTime();
+    if (typeof dateValue.seconds === 'number') return dateValue.seconds * 1000;
+    const parsed = dateValue instanceof Date ? dateValue : new Date(dateValue);
+    const millis = parsed.getTime();
+    return Number.isNaN(millis) ? null : millis;
+}
+
+function getGameWindow(game = {}, defaultGameMinutes = 120) {
+    const start = getDateMillis(game.date);
+    if (start === null) return null;
+    const explicitEnd = getDateMillis(game.endTime || game.endDate || game.endsAt);
+    const end = explicitEnd && explicitEnd > start
+        ? explicitEnd
+        : start + Math.max(1, Number(defaultGameMinutes) || 120) * 60000;
+    return { start, end };
+}
+
+function getGameLabel(game = {}) {
+    const opponent = String(game.opponent || game.title || 'TBD').trim();
+    const location = String(game.location || '').trim();
+    return location ? `vs. ${opponent} at ${location}` : `vs. ${opponent}`;
+}
+
+function getActiveOfficialAssignments(game = {}) {
+    return normalizeOfficiatingSlots(game.officiatingSlots || [])
+        .filter((slot) => !['open', 'declined', 'cant_make'].includes(slot.status))
+        .map((slot) => {
+            const identityKeys = [
+                slot.officialId ? `id:${slot.officialId}` : '',
+                slot.officialUserId ? `uid:${slot.officialUserId}` : '',
+                slot.officialEmail ? `email:${slot.officialEmail}` : '',
+                slot.officialName ? `name:${slot.officialName.toLowerCase()}` : ''
+            ].filter(Boolean);
+            return {
+                slot,
+                identityKeys,
+                label: slot.officialName || slot.officialEmail || 'Official'
+            };
+        })
+        .filter((assignment) => assignment.identityKeys.length > 0);
+}
+
+function hasSharedOfficialIdentity(a, b) {
+    const keys = new Set(a.identityKeys);
+    return b.identityKeys.some((key) => keys.has(key));
+}
+
+export function getOfficiatingAssignmentConflictWarnings(candidateGame = {}, existingGames = [], options = {}) {
+    const candidateWindow = getGameWindow(candidateGame, options.defaultGameMinutes);
+    if (!candidateWindow || !Array.isArray(existingGames)) return [];
+
+    const candidateAssignments = getActiveOfficialAssignments(candidateGame);
+    if (!candidateAssignments.length) return [];
+
+    const candidateId = String(options.editingGameId || candidateGame.id || '').trim();
+    const warnings = [];
+
+    existingGames.forEach((existingGame) => {
+        const existingId = String(existingGame?.id || '').trim();
+        if (candidateId && existingId && candidateId === existingId) return;
+
+        const existingWindow = getGameWindow(existingGame, options.defaultGameMinutes);
+        if (!existingWindow) return;
+
+        const overlaps = candidateWindow.start < existingWindow.end && existingWindow.start < candidateWindow.end;
+        const backToBack = candidateWindow.end === existingWindow.start || existingWindow.end === candidateWindow.start;
+        if (!overlaps && !backToBack) return;
+
+        const existingAssignments = getActiveOfficialAssignments(existingGame);
+        candidateAssignments.forEach((candidateAssignment) => {
+            existingAssignments.forEach((existingAssignment) => {
+                if (!hasSharedOfficialIdentity(candidateAssignment, existingAssignment)) return;
+                warnings.push({
+                    officialName: candidateAssignment.label || existingAssignment.label,
+                    conflictType: overlaps ? 'overlap' : 'back-to-back',
+                    candidateGameId: candidateId || null,
+                    conflictingGameId: existingId || null,
+                    candidateGameLabel: getGameLabel(candidateGame),
+                    conflictingGameLabel: getGameLabel(existingGame)
+                });
+            });
+        });
+    });
+
+    return warnings;
+}
+
 export function getAssignedOfficiatingSlots(game = {}, user = {}) {
     const uid = String(user?.uid || '').trim();
     const email = normalizeOfficialEmail(user?.email || '');

--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -47,6 +47,8 @@ describe('officiating slots', () => {
         expect(source).toContain('Officiating Slots');
         expect(source).toContain('populateOfficiatingSlots(game.officiatingSlots || [])');
         expect(source).toContain('officiatingSlots: getOfficiatingSlotsFromForm()');
+        expect(source).toContain('confirmOfficiatingAssignmentConflicts(gameData)');
+        expect(source).toContain('Officiating assignment conflict warning:');
         expect(source).toContain('${renderOfficiatingSummary(game.officiatingSlots)}');
         expect(source).toContain('assignments: getAssignmentsFromForm()');
     });

--- a/tests/unit/officiating-utils.test.js
+++ b/tests/unit/officiating-utils.test.js
@@ -126,7 +126,7 @@ describe('officiating assignment helpers', () => {
     ]);
   });
 
-  it('does not warn for different officials, ignored statuses, or the game being edited', () => {
+  it('does not warn for different officials, ignored statuses, cancelled games, or the game being edited', () => {
     const warnings = getOfficiatingAssignmentConflictWarnings({
       id: 'game-1',
       date: new Date('2026-05-04T10:00:00Z'),
@@ -158,8 +158,40 @@ describe('officiating assignment helpers', () => {
         officiatingSlots: [
           { position: 'Referee', officialEmail: 'ref@example.com', status: 'declined' }
         ]
+      },
+      {
+        id: 'game-4',
+        date: new Date('2026-05-04T10:30:00Z'),
+        opponent: 'Cancelled game',
+        status: 'cancelled',
+        officiatingSlots: [
+          { position: 'Referee', officialEmail: 'ref@example.com', status: 'accepted' }
+        ]
       }
     ], { editingGameId: 'game-1' });
+
+    expect(warnings).toEqual([]);
+  });
+
+  it('does not warn when the candidate game is cancelled', () => {
+    const warnings = getOfficiatingAssignmentConflictWarnings({
+      id: 'game-cancelled',
+      date: new Date('2026-05-04T10:00:00Z'),
+      opponent: 'Lions',
+      status: 'cancelled',
+      officiatingSlots: [
+        { position: 'Referee', officialEmail: 'ref@example.com', status: 'pending' }
+      ]
+    }, [
+      {
+        id: 'game-active',
+        date: new Date('2026-05-04T10:30:00Z'),
+        opponent: 'Tigers',
+        officiatingSlots: [
+          { position: 'Referee', officialEmail: 'ref@example.com', status: 'accepted' }
+        ]
+      }
+    ]);
 
     expect(warnings).toEqual([]);
   });

--- a/tests/unit/officiating-utils.test.js
+++ b/tests/unit/officiating-utils.test.js
@@ -3,6 +3,7 @@ import {
   claimOfficiatingSlot,
   computeOfficiatingCoverageStatus,
   getAssignedOfficiatingSlots,
+  getOfficiatingAssignmentConflictWarnings,
   getOpenOfficiatingSlots,
   normalizeOfficiatingSlots,
   updateOfficiatingSlotResponse
@@ -77,5 +78,89 @@ describe('officiating assignment helpers', () => {
     expect(() => claimOfficiatingSlot([
       { id: 'slot-1', position: 'Referee', officialEmail: 'taken@example.com', status: 'pending' }
     ], 'slot-1', { uid: 'user-1' })).toThrow('already filled');
+  });
+
+  it('warns when the same official has overlapping or back-to-back assignments', () => {
+    const warnings = getOfficiatingAssignmentConflictWarnings({
+      id: 'game-new',
+      date: new Date('2026-05-04T10:00:00Z'),
+      opponent: 'Lions',
+      location: 'Field 1',
+      officiatingSlots: [
+        { position: 'Referee', officialEmail: 'Ref@Example.com', officialName: 'Jordan Ref', status: 'pending' }
+      ]
+    }, [
+      {
+        id: 'game-overlap',
+        date: new Date('2026-05-04T11:00:00Z'),
+        opponent: 'Tigers',
+        location: 'Field 2',
+        officiatingSlots: [
+          { position: 'Referee', officialEmail: 'ref@example.com', officialName: 'Jordan Ref', status: 'accepted' }
+        ]
+      },
+      {
+        id: 'game-back-to-back',
+        date: new Date('2026-05-04T12:00:00Z'),
+        opponent: 'Bears',
+        location: 'Field 3',
+        officiatingSlots: [
+          { position: 'Referee', officialEmail: 'ref@example.com', officialName: 'Jordan Ref', status: 'pending' }
+        ]
+      }
+    ]);
+
+    expect(warnings).toMatchObject([
+      {
+        officialName: 'Jordan Ref',
+        conflictType: 'overlap',
+        conflictingGameId: 'game-overlap',
+        conflictingGameLabel: 'vs. Tigers at Field 2'
+      },
+      {
+        officialName: 'Jordan Ref',
+        conflictType: 'back-to-back',
+        conflictingGameId: 'game-back-to-back',
+        conflictingGameLabel: 'vs. Bears at Field 3'
+      }
+    ]);
+  });
+
+  it('does not warn for different officials, ignored statuses, or the game being edited', () => {
+    const warnings = getOfficiatingAssignmentConflictWarnings({
+      id: 'game-1',
+      date: new Date('2026-05-04T10:00:00Z'),
+      opponent: 'Lions',
+      officiatingSlots: [
+        { position: 'Referee', officialEmail: 'ref@example.com', status: 'pending' }
+      ]
+    }, [
+      {
+        id: 'game-1',
+        date: new Date('2026-05-04T10:30:00Z'),
+        opponent: 'Same game',
+        officiatingSlots: [
+          { position: 'Referee', officialEmail: 'ref@example.com', status: 'pending' }
+        ]
+      },
+      {
+        id: 'game-2',
+        date: new Date('2026-05-04T10:30:00Z'),
+        opponent: 'Different official',
+        officiatingSlots: [
+          { position: 'Referee', officialEmail: 'other@example.com', status: 'pending' }
+        ]
+      },
+      {
+        id: 'game-3',
+        date: new Date('2026-05-04T10:30:00Z'),
+        opponent: 'Declined slot',
+        officiatingSlots: [
+          { position: 'Referee', officialEmail: 'ref@example.com', status: 'declined' }
+        ]
+      }
+    ], { editingGameId: 'game-1' });
+
+    expect(warnings).toEqual([]);
   });
 });


### PR DESCRIPTION
Closes #730

## Summary
- Added client-side conflict detection for officiating slots before schedule saves.
- Warns assigners when the same official has overlapping or back-to-back game assignments, identifying the official and conflicting games.
- Keeps warnings non-blocking so assigners can still save intentionally.

## Tests
- `npx vitest run tests/unit/officiating-utils.test.js tests/unit/officiating-slots.test.js`