### PR TITLE
Add team fee management view

### DIFF
--- a/docs/pr-notes/runs/746-ci-fix-20260505T163831Z/architecture.md
+++ b/docs/pr-notes/runs/746-ci-fix-20260505T163831Z/architecture.md
@@ -1,0 +1,17 @@
+# Architecture Notes
+
+## Root cause
+PR #746 added a `team-entitlements.js` import to `js/live-game.js`. The replay init unit test evaluates `live-game.js` by rewriting ES module imports into dependency destructuring before passing the source to `AsyncFunction`.
+
+The test harness did not rewrite the new `team-entitlements` import. Its broad `live-game-state` import regex then consumed across the leftover import boundary and generated invalid destructuring, producing `SyntaxError: Missing initializer in destructuring declaration` before any assertions ran.
+
+## Minimal fix
+Update `tests/unit/live-game-replay-init.test.js` only:
+- Add an explicit rewrite for the `team-entitlements.js` import before the broad `live-game-state` rewrite.
+- Add a `deps.teamEntitlements` mock object for the rewritten dependency.
+
+## Risk and blast radius
+Production blast radius is none because the change is test harness only. The main residual risk is future import drift in `js/live-game.js` breaking this dynamic source-rewrite harness again.
+
+## Rollback
+Revert the test harness changes in `tests/unit/live-game-replay-init.test.js`.

--- a/docs/pr-notes/runs/746-ci-fix-20260505T163831Z/code-plan.md
+++ b/docs/pr-notes/runs/746-ci-fix-20260505T163831Z/code-plan.md
@@ -1,0 +1,16 @@
+# Code Plan
+
+## Implementation plan
+1. In `buildModuleSource()`, add a replacement for the `team-entitlements.js` import.
+2. Map the imported entitlement symbols to `deps.teamEntitlements`.
+3. Add a minimal `teamEntitlements` mock in `bootReplayPage()`.
+4. Run the targeted replay init test and full unit test command.
+
+## Acceptance criteria
+- No production files changed.
+- `tests/unit/live-game-replay-init.test.js` no longer leaves the `team-entitlements` import in generated module source.
+- Replay init tests pass locally.
+- Full unit suite passes locally.
+
+## Risks and rollback
+The test remains brittle because it rewrites page source with string replacements. Rollback is a single-file revert if needed.

--- a/docs/pr-notes/runs/746-ci-fix-20260505T163831Z/qa.md
+++ b/docs/pr-notes/runs/746-ci-fix-20260505T163831Z/qa.md
@@ -1,0 +1,16 @@
+# QA Notes
+
+## Affected behavior
+The failure is a unit test harness parse failure, not a runtime replay behavior failure. The affected suite covers replay initialization, scoreboard fallback, replay controls visibility, and replay chat lockout.
+
+## Validation commands
+- `npx vitest run tests/unit/live-game-replay-init.test.js`
+- `npm run test:unit:ci`
+
+## Edge cases to preserve
+- Replay pages with no saved events keep chat disabled and show the locked notice.
+- Replay pages with saved events use the same chat lockout behavior.
+- Scoreboard fallback continues to render for replay pages without saved events.
+
+## Confidence criteria
+The targeted replay init unit test must parse and pass, and the full unit CI command must complete without the prior `AsyncFunction` syntax failure.

--- a/firestore.rules
+++ b/firestore.rules
@@ -438,6 +438,14 @@ service cloud.firestore {
         }
       }
 
+      match /feeBatches/{batchId} {
+        allow read, create, update, delete: if isTeamOwnerOrAdmin(teamId);
+
+        match /feeRecipients/{recipientId} {
+          allow read, create, update, delete: if isTeamOwnerOrAdmin(teamId);
+        }
+      }
+
       match /membershipRequests/{requestId} {
         allow read: if isTeamOwnerOrAdmin(teamId) ||
                        (isSignedIn() && resource.data.requesterUserId == request.auth.uid);

--- a/js/db.js
+++ b/js/db.js
@@ -2519,6 +2519,36 @@ export async function listParentTeamFeeRecipients(userId, children = []) {
     return Array.from(feesByPath.values());
 }
 
+export async function getTeamFeeBatch(teamId, batchId) {
+    if (!teamId || !batchId) return null;
+    const batchRef = doc(db, 'teams', teamId, 'feeBatches', batchId);
+    const batchSnap = await getDoc(batchRef);
+    return batchSnap.exists() ? { id: batchSnap.id, ...batchSnap.data() } : null;
+}
+
+export async function listTeamFeeRecipients(teamId, batchId) {
+    if (!teamId || !batchId) return [];
+    const recipientsRef = collection(db, 'teams', teamId, 'feeBatches', batchId, 'feeRecipients');
+    const snapshot = await getDocs(recipientsRef);
+    return snapshot.docs
+        .map((recipientDoc) => ({ id: recipientDoc.id, ...recipientDoc.data() }))
+        .sort((a, b) => String(a.playerName || a.childName || a.parentName || a.parentEmail || '').localeCompare(String(b.playerName || b.childName || b.parentName || b.parentEmail || '')));
+}
+
+export async function updateTeamFeeRecipient(teamId, batchId, recipientId, updates = {}) {
+    if (!teamId || !batchId || !recipientId) {
+        throw new Error('Missing fee recipient context.');
+    }
+
+    const recipientRef = doc(db, 'teams', teamId, 'feeBatches', batchId, 'feeRecipients', recipientId);
+    await updateDoc(recipientRef, {
+        ...updates,
+        teamId,
+        batchId,
+        updatedAt: serverTimestamp()
+    });
+}
+
 export async function getParentDashboardData(userId) {
     const userProfile = await getUserProfile(userId);
     if (!userProfile || !userProfile.parentOf || userProfile.parentOf.length === 0) {

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -1,0 +1,128 @@
+const STATUS_LABELS = {
+    paid: 'Paid',
+    unpaid: 'Unpaid',
+    adjusted: 'Adjusted',
+    canceled: 'Canceled'
+};
+
+export function toFeeCents(value) {
+    if (value === null || value === undefined || value === '') return null;
+    const amount = Number(value);
+    if (!Number.isFinite(amount) || amount < 0) return null;
+    return Math.round(amount * 100);
+}
+
+export function getRecipientBalanceCents(recipient) {
+    if (recipient?.status === 'canceled') return 0;
+    const raw = recipient?.amountDueCents ?? recipient?.adjustedAmountCents ?? recipient?.amountCents ?? 0;
+    const cents = Number(raw);
+    return Number.isFinite(cents) ? Math.max(0, cents) : 0;
+}
+
+export function getRecipientPaidCents(recipient) {
+    if (recipient?.status === 'canceled') return 0;
+    if (recipient?.status === 'paid') {
+        const paid = Number(recipient?.amountPaidCents ?? recipient?.paidAmountCents);
+        return Number.isFinite(paid) ? Math.max(0, paid) : getRecipientBalanceCents(recipient);
+    }
+    const paid = Number(recipient?.amountPaidCents ?? recipient?.paidAmountCents ?? 0);
+    return Number.isFinite(paid) ? Math.max(0, paid) : 0;
+}
+
+export function normalizeFeeStatus(status) {
+    const normalized = String(status || 'unpaid').trim().toLowerCase();
+    return Object.prototype.hasOwnProperty.call(STATUS_LABELS, normalized) ? normalized : 'unpaid';
+}
+
+export function summarizeFeeRecipients(recipients = []) {
+    const summary = {
+        totalAssignedCents: 0,
+        totalPaidCents: 0,
+        totalOutstandingCents: 0,
+        counts: {
+            paid: 0,
+            unpaid: 0,
+            adjusted: 0,
+            canceled: 0
+        }
+    };
+
+    recipients.forEach((recipient) => {
+        const status = normalizeFeeStatus(recipient?.status);
+        const balance = getRecipientBalanceCents(recipient);
+        const paid = getRecipientPaidCents(recipient);
+        summary.counts[status] += 1;
+        summary.totalAssignedCents += status === 'canceled' ? 0 : balance;
+        summary.totalPaidCents += paid;
+        summary.totalOutstandingCents += status === 'paid' || status === 'canceled' ? 0 : Math.max(0, balance - paid);
+    });
+
+    return summary;
+}
+
+export function formatFeeCurrency(cents) {
+    const amount = Number(cents);
+    if (!Number.isFinite(amount)) return '$0.00';
+    return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD'
+    }).format(amount / 100);
+}
+
+export function buildManualPaymentUpdate({ amount, date, note, actorId }) {
+    const amountPaidCents = toFeeCents(amount);
+    if (amountPaidCents === null || amountPaidCents <= 0) {
+        throw new Error('Enter a manual payment amount greater than $0.');
+    }
+    if (!date) {
+        throw new Error('Enter a manual payment date.');
+    }
+
+    return {
+        status: 'paid',
+        amountPaidCents,
+        paidAt: date,
+        manualPayment: {
+            amountPaidCents,
+            paidAt: date,
+            note: String(note || '').trim(),
+            recordedBy: actorId || null
+        }
+    };
+}
+
+export function buildBalanceAdjustmentUpdate({ amount, note, actorId }) {
+    const amountDueCents = toFeeCents(amount);
+    if (amountDueCents === null) {
+        throw new Error('Enter a valid adjusted balance.');
+    }
+
+    return {
+        status: amountDueCents === 0 ? 'paid' : 'adjusted',
+        amountDueCents,
+        adjustment: {
+            amountDueCents,
+            note: String(note || '').trim(),
+            adjustedBy: actorId || null
+        }
+    };
+}
+
+export function buildCancelRecipientUpdate({ note, actorId }) {
+    return {
+        status: 'canceled',
+        amountDueCents: 0,
+        canceled: {
+            note: String(note || '').trim(),
+            canceledBy: actorId || null
+        }
+    };
+}
+
+export function getRecipientDisplayName(recipient) {
+    return recipient?.playerName || recipient?.childName || recipient?.name || recipient?.parentName || recipient?.parentEmail || 'Recipient';
+}
+
+export function getStatusLabel(status) {
+    return STATUS_LABELS[normalizeFeeStatus(status)];
+}

--- a/team-fees.html
+++ b/team-fees.html
@@ -1,0 +1,219 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex,nofollow">
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Manage Team Fees - ALL PLAYS</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+</head>
+<body class="bg-gradient-to-br from-gray-50 to-gray-100 text-gray-900 min-h-screen">
+    <div id="header-container"></div>
+
+    <main class="container mx-auto px-4 py-8">
+        <div class="mb-6 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div>
+                <a id="back-link" href="dashboard.html" class="text-sm font-semibold text-indigo-600 hover:text-indigo-800">← Back to dashboard</a>
+                <h1 id="page-title" class="mt-2 text-3xl font-bold text-gray-900">Manage team fee</h1>
+                <p id="page-subtitle" class="mt-1 text-sm text-gray-600">Review assigned recipients, record offline payments, and adjust balances.</p>
+            </div>
+            <button id="refresh-btn" type="button" class="rounded-lg bg-white px-4 py-2 text-sm font-semibold text-gray-700 border border-gray-200 shadow-sm hover:bg-gray-50">Refresh</button>
+        </div>
+
+        <div id="status-message" class="mb-4 hidden rounded-xl border px-4 py-3 text-sm"></div>
+
+        <section id="summary-cards" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 mb-6"></section>
+
+        <section class="bg-white rounded-2xl shadow-lg border border-gray-200 overflow-hidden">
+            <div class="px-5 py-4 border-b border-gray-200 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+                <div>
+                    <h2 class="text-lg font-bold text-gray-900">Recipients</h2>
+                    <p id="recipient-count" class="text-sm text-gray-500">Loading recipients…</p>
+                </div>
+            </div>
+            <div id="recipients-list" class="divide-y divide-gray-100">
+                <div class="p-6 text-sm text-gray-500">Loading…</div>
+            </div>
+        </section>
+    </main>
+
+    <div id="footer-container"></div>
+
+    <script type="module">
+        import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
+        import { checkAuth } from './js/auth.js?v=12';
+        import { getTeam, canModerateChat, getTeamFeeBatch, listTeamFeeRecipients, updateTeamFeeRecipient } from './js/db.js?v=22';
+        import {
+            buildBalanceAdjustmentUpdate,
+            buildCancelRecipientUpdate,
+            buildManualPaymentUpdate,
+            formatFeeCurrency,
+            getRecipientBalanceCents,
+            getRecipientDisplayName,
+            getRecipientPaidCents,
+            getStatusLabel,
+            summarizeFeeRecipients
+        } from './js/team-fees-admin.js?v=1';
+
+        document.getElementById('header-container').innerHTML = renderHeader();
+        document.getElementById('footer-container').innerHTML = renderFooter();
+
+        const params = new URLSearchParams(window.location.search);
+        const teamId = params.get('teamId') || '';
+        const batchId = params.get('batchId') || params.get('feeBatchId') || '';
+        const els = {
+            title: document.getElementById('page-title'),
+            subtitle: document.getElementById('page-subtitle'),
+            backLink: document.getElementById('back-link'),
+            status: document.getElementById('status-message'),
+            summary: document.getElementById('summary-cards'),
+            count: document.getElementById('recipient-count'),
+            list: document.getElementById('recipients-list'),
+            refresh: document.getElementById('refresh-btn')
+        };
+        let currentUser = null;
+        let currentTeam = null;
+
+        function showStatus(message, tone = 'info') {
+            const classes = tone === 'error'
+                ? 'border-red-200 bg-red-50 text-red-800'
+                : tone === 'success'
+                    ? 'border-green-200 bg-green-50 text-green-800'
+                    : 'border-blue-200 bg-blue-50 text-blue-800';
+            els.status.className = `mb-4 rounded-xl border px-4 py-3 text-sm ${classes}`;
+            els.status.textContent = message;
+            els.status.classList.remove('hidden');
+        }
+
+        function renderSummary(recipients) {
+            const summary = summarizeFeeRecipients(recipients);
+            const cards = [
+                ['Total assigned', formatFeeCurrency(summary.totalAssignedCents)],
+                ['Total paid', formatFeeCurrency(summary.totalPaidCents)],
+                ['Outstanding', formatFeeCurrency(summary.totalOutstandingCents)],
+                ['Status counts', `${summary.counts.paid} paid · ${summary.counts.unpaid} unpaid · ${summary.counts.adjusted} adjusted · ${summary.counts.canceled} canceled`]
+            ];
+            els.summary.innerHTML = cards.map(([label, value]) => `
+                <div class="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
+                    <div class="text-xs uppercase tracking-wide text-gray-500 font-semibold">${label}</div>
+                    <div class="mt-1 text-xl font-bold text-gray-900">${value}</div>
+                </div>
+            `).join('');
+        }
+
+        function renderRecipients(recipients) {
+            els.count.textContent = `${recipients.length} assigned recipient${recipients.length === 1 ? '' : 's'}`;
+            if (recipients.length === 0) {
+                els.list.innerHTML = '<div class="p-6 text-sm text-gray-500">No recipients are assigned to this fee batch.</div>';
+                return;
+            }
+
+            els.list.innerHTML = recipients.map((recipient) => {
+                const name = escapeHtml(getRecipientDisplayName(recipient));
+                const status = getStatusLabel(recipient.status);
+                const balance = formatFeeCurrency(getRecipientBalanceCents(recipient));
+                const paid = formatFeeCurrency(getRecipientPaidCents(recipient));
+                const note = recipient.manualPayment?.note || recipient.adjustment?.note || recipient.canceled?.note || recipient.notes || '';
+                return `
+                    <article class="p-5" data-recipient-id="${escapeHtml(recipient.id)}">
+                        <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
+                            <div>
+                                <div class="flex items-center gap-2 flex-wrap">
+                                    <h3 class="font-bold text-gray-900">${name}</h3>
+                                    <span class="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-bold text-gray-700">${status}</span>
+                                </div>
+                                <div class="mt-1 text-sm text-gray-500">Balance ${balance} · Paid ${paid}</div>
+                                ${note ? `<p class="mt-2 text-sm text-gray-600">${escapeHtml(note)}</p>` : ''}
+                            </div>
+                            <div class="grid grid-cols-1 md:grid-cols-3 gap-3 w-full lg:max-w-4xl">
+                                <form data-action="paid" class="rounded-xl border border-gray-200 bg-gray-50 p-3 space-y-2">
+                                    <div class="text-xs font-bold uppercase tracking-wide text-gray-500">Manual payment</div>
+                                    <input name="amount" type="number" min="0" step="0.01" value="${(getRecipientBalanceCents(recipient) / 100).toFixed(2)}" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Payment amount">
+                                    <input name="date" type="date" value="${new Date().toISOString().slice(0, 10)}" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Payment date">
+                                    <input name="note" type="text" placeholder="Optional note" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Payment note">
+                                    <button class="w-full rounded-lg bg-green-600 px-3 py-2 text-sm font-semibold text-white hover:bg-green-700">Mark paid</button>
+                                </form>
+                                <form data-action="adjust" class="rounded-xl border border-gray-200 bg-gray-50 p-3 space-y-2">
+                                    <div class="text-xs font-bold uppercase tracking-wide text-gray-500">Adjust balance</div>
+                                    <input name="amount" type="number" min="0" step="0.01" value="${(getRecipientBalanceCents(recipient) / 100).toFixed(2)}" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Adjusted balance">
+                                    <input name="note" type="text" placeholder="Reason" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Adjustment note">
+                                    <button class="w-full rounded-lg bg-amber-600 px-3 py-2 text-sm font-semibold text-white hover:bg-amber-700">Save adjustment</button>
+                                </form>
+                                <form data-action="cancel" class="rounded-xl border border-gray-200 bg-gray-50 p-3 space-y-2">
+                                    <div class="text-xs font-bold uppercase tracking-wide text-gray-500">Cancel recipient</div>
+                                    <input name="note" type="text" placeholder="Reason" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Cancellation note">
+                                    <button class="w-full rounded-lg bg-gray-700 px-3 py-2 text-sm font-semibold text-white hover:bg-gray-800">Cancel balance</button>
+                                </form>
+                            </div>
+                        </div>
+                    </article>
+                `;
+            }).join('');
+        }
+
+        async function loadBatch() {
+            if (!teamId || !batchId) {
+                throw new Error('Open this page with teamId and batchId query parameters.');
+            }
+
+            currentTeam = await getTeam(teamId, { includeInactive: true });
+            if (!currentTeam) throw new Error('Team not found.');
+            if (!canModerateChat(currentUser, currentTeam)) {
+                throw new Error('You need team admin access to manage this fee batch.');
+            }
+
+            const batch = await getTeamFeeBatch(teamId, batchId);
+            if (!batch) throw new Error('Fee batch not found.');
+            els.backLink.href = `team.html?id=${encodeURIComponent(teamId)}`;
+            els.title.textContent = batch.title || batch.feeTitle || batch.name || 'Manage team fee';
+            els.subtitle.textContent = `${currentTeam.name || 'Team'} · Offline payment tracking`;
+            const recipients = await listTeamFeeRecipients(teamId, batchId);
+            renderSummary(recipients);
+            renderRecipients(recipients);
+        }
+
+        async function handleRecipientSubmit(event) {
+            const form = event.target.closest('form[data-action]');
+            if (!form) return;
+            event.preventDefault();
+            const article = form.closest('[data-recipient-id]');
+            const recipientId = article?.dataset?.recipientId;
+            const data = Object.fromEntries(new FormData(form).entries());
+            let updates;
+            try {
+                if (form.dataset.action === 'paid') {
+                    updates = buildManualPaymentUpdate({ ...data, actorId: currentUser.uid });
+                } else if (form.dataset.action === 'adjust') {
+                    updates = buildBalanceAdjustmentUpdate({ ...data, actorId: currentUser.uid });
+                } else {
+                    updates = buildCancelRecipientUpdate({ ...data, actorId: currentUser.uid });
+                }
+                await updateTeamFeeRecipient(teamId, batchId, recipientId, updates);
+                showStatus('Fee recipient updated.', 'success');
+                await loadBatch();
+            } catch (error) {
+                showStatus(error.message || 'Unable to update fee recipient.', 'error');
+            }
+        }
+
+        els.refresh.addEventListener('click', () => loadBatch().catch((error) => showStatus(error.message, 'error')));
+        els.list.addEventListener('submit', handleRecipientSubmit);
+
+        checkAuth(async (user) => {
+            if (!user) {
+                window.location.href = 'login.html';
+                return;
+            }
+            currentUser = user;
+            try {
+                await loadBatch();
+            } catch (error) {
+                els.list.innerHTML = '<div class="p-6 text-sm text-red-700">Unable to load fee batch.</div>';
+                showStatus(error.message || 'Unable to load fee batch.', 'error');
+            }
+        });
+    </script>
+</body>
+</html>

--- a/tests/unit/live-game-replay-init.test.js
+++ b/tests/unit/live-game-replay-init.test.js
@@ -244,6 +244,10 @@ function buildModuleSource() {
             'const { MAX_HIGHLIGHT_CLIP_MS, buildHighlightShareUrl, createHighlightClipDraft, resolveReplayVideoOptions, shouldReloadVideoPlayback } = deps.liveGameVideo;'
         )
         .replace(
+            /import \{ TEAM_PASS_FEATURES, canAccessPremiumFanFeature, getTeamEntitlementStatus, resolveTeamEntitlementSeasonId \} from '\.\/team-entitlements\.js\?v=\d+';/,
+            'const { TEAM_PASS_FEATURES, canAccessPremiumFanFeature, getTeamEntitlementStatus, resolveTeamEntitlementSeasonId } = deps.teamEntitlements;'
+        )
+        .replace(
             "import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';",
             'const { getAI, getGenerativeModel, GoogleAIBackend } = deps.firebaseAi;'
         )
@@ -423,6 +427,12 @@ async function bootReplayPage({ replayEvents }) {
             createHighlightClipDraft: () => ({ startMs: 0, endMs: 0, title: '' }),
             resolveReplayVideoOptions: () => null,
             shouldReloadVideoPlayback: () => false
+        },
+        teamEntitlements: {
+            TEAM_PASS_FEATURES: {},
+            canAccessPremiumFanFeature: () => false,
+            getTeamEntitlementStatus: () => ({ isActive: false }),
+            resolveTeamEntitlementSeasonId: () => null
         },
         firebaseAi: {
             getAI: () => ({}),

--- a/tests/unit/team-fees-admin.test.js
+++ b/tests/unit/team-fees-admin.test.js
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildBalanceAdjustmentUpdate,
+    buildCancelRecipientUpdate,
+    buildManualPaymentUpdate,
+    formatFeeCurrency,
+    getRecipientBalanceCents,
+    getRecipientPaidCents,
+    summarizeFeeRecipients,
+    toFeeCents
+} from '../../js/team-fees-admin.js';
+
+describe('team fees admin helpers', () => {
+    it('summarizes assigned, paid, outstanding, and status counts', () => {
+        const summary = summarizeFeeRecipients([
+            { status: 'paid', amountDueCents: 5000, amountPaidCents: 5000 },
+            { status: 'unpaid', amountDueCents: 7500 },
+            { status: 'adjusted', amountDueCents: 2500, amountPaidCents: 500 },
+            { status: 'canceled', amountDueCents: 3000 }
+        ]);
+
+        expect(summary).toEqual({
+            totalAssignedCents: 15000,
+            totalPaidCents: 5500,
+            totalOutstandingCents: 9500,
+            counts: {
+                paid: 1,
+                unpaid: 1,
+                adjusted: 1,
+                canceled: 1
+            }
+        });
+        expect(formatFeeCurrency(summary.totalOutstandingCents)).toBe('$95.00');
+    });
+
+    it('builds manual payment, adjustment, and cancellation updates', () => {
+        expect(buildManualPaymentUpdate({
+            amount: '42.50',
+            date: '2026-05-05',
+            note: 'Cash',
+            actorId: 'coach-1'
+        })).toMatchObject({
+            status: 'paid',
+            amountPaidCents: 4250,
+            paidAt: '2026-05-05',
+            manualPayment: {
+                amountPaidCents: 4250,
+                paidAt: '2026-05-05',
+                note: 'Cash',
+                recordedBy: 'coach-1'
+            }
+        });
+
+        expect(buildBalanceAdjustmentUpdate({ amount: '10', note: 'Sibling discount', actorId: 'coach-1' })).toMatchObject({
+            status: 'adjusted',
+            amountDueCents: 1000,
+            adjustment: {
+                amountDueCents: 1000,
+                note: 'Sibling discount',
+                adjustedBy: 'coach-1'
+            }
+        });
+
+        expect(buildCancelRecipientUpdate({ note: 'No longer on roster', actorId: 'coach-1' })).toMatchObject({
+            status: 'canceled',
+            amountDueCents: 0,
+            canceled: {
+                note: 'No longer on roster',
+                canceledBy: 'coach-1'
+            }
+        });
+    });
+
+    it('normalizes currency inputs and recipient balances safely', () => {
+        expect(toFeeCents('12.345')).toBe(1235);
+        expect(toFeeCents('-1')).toBeNull();
+        expect(getRecipientBalanceCents({ status: 'canceled', amountDueCents: 5000 })).toBe(0);
+        expect(getRecipientPaidCents({ status: 'paid', amountDueCents: 2500 })).toBe(2500);
+        expect(() => buildManualPaymentUpdate({ amount: '0', date: '2026-05-05' })).toThrow('greater than $0');
+    });
+});


### PR DESCRIPTION
Closes #702

## Summary
- Added a coach/admin fee management page for existing fee batches.
- Shows assigned, paid, outstanding, and status-count collection totals.
- Supports manual paid recording, balance adjustments, and recipient cancellation with Firestore persistence.

## Validation
- Ran `npm run test:unit -- tests/unit/team-fees-admin.test.js tests/unit/parent-dashboard-fees.test.js`.