### PR TITLE
Add live game media hub

### DIFF
--- a/docs/pr-notes/runs/745-remediator-20260505T214505Z/architecture.md
+++ b/docs/pr-notes/runs/745-remediator-20260505T214505Z/architecture.md
@@ -1,0 +1,13 @@
+# Architecture
+
+## Architecture Decisions
+- Reuse the existing `isSafeUrl` protocol gate already used for chat links.
+- Add a narrow helper that wraps media hub highlight URL construction and returns `null` unless the URL passes the same safety check.
+- Keep `buildMediaHubHighlightUrl` unchanged so existing share URL construction remains isolated.
+
+## Risks And Rollback
+- Risk is low: invalid or unsafe stored clip URLs stop rendering as playable/copyable links.
+- Rollback is a single-file revert in `js/live-game.js`.
+
+## Notes
+- Role subagents were unavailable in this runtime, so architecture analysis was completed inline.

--- a/docs/pr-notes/runs/745-remediator-20260505T214505Z/code-plan.md
+++ b/docs/pr-notes/runs/745-remediator-20260505T214505Z/code-plan.md
@@ -1,0 +1,10 @@
+# Code Plan
+
+## Implementation Plan
+- Add `buildSafeMediaHubHighlightUrl(clip)` beside existing media hub URL construction.
+- Use the safe helper when rendering media hub highlight anchors.
+- Use the same safe helper in the media hub Copy click handler.
+- Avoid unrelated refactors or broad URL policy changes.
+
+## Notes
+- Role subagents were unavailable in this runtime, so code planning was completed inline.

--- a/docs/pr-notes/runs/745-remediator-20260505T214505Z/qa.md
+++ b/docs/pr-notes/runs/745-remediator-20260505T214505Z/qa.md
@@ -1,0 +1,10 @@
+# QA Plan
+
+## Validation
+- Verify `javascript:` media hub highlight URLs do not produce a Play anchor or copyable URL.
+- Verify generated relative highlight URLs still pass through because they resolve against the page origin.
+- Verify HTTP and HTTPS clip URLs still render and copy.
+- Run a syntax check for `js/live-game.js` because this repo has no automated test runner.
+
+## Notes
+- Role subagents were unavailable in this runtime, so QA analysis was completed inline.

--- a/docs/pr-notes/runs/745-remediator-20260505T214505Z/requirements.md
+++ b/docs/pr-notes/runs/745-remediator-20260505T214505Z/requirements.md
@@ -1,0 +1,9 @@
+# Requirements
+
+## Acceptance Criteria
+- Media hub highlight links must not render `href` values for unsafe URL schemes such as `javascript:` or `data:`.
+- Valid HTTP, HTTPS, and same-origin relative highlight URLs continue to render and copy normally.
+- Unsafe highlight URLs fall back to the existing `No link` UI and cannot be copied through the highlight copy action.
+
+## Notes
+- Role subagents were unavailable in this runtime, so requirements analysis was completed inline.

--- a/js/live-game-video.js
+++ b/js/live-game-video.js
@@ -151,9 +151,10 @@ function getRecordedReplayConfig(game) {
 }
 
 function getLiveEmbedConfig(team) {
+    const parentHost = typeof window !== 'undefined' ? window.location.hostname : 'localhost';
     if (team?.twitchChannel) {
         return {
-            embedUrl: `https://player.twitch.tv/?channel=${team.twitchChannel}&parent=${window.location.hostname}&autoplay=true&muted=true`,
+            embedUrl: `https://player.twitch.tv/?channel=${team.twitchChannel}&parent=${parentHost}&autoplay=true&muted=true`,
             publicUrl: `https://twitch.tv/${team.twitchChannel}`,
             publicLabel: 'Watch on Twitch ↗'
         };
@@ -304,6 +305,29 @@ export function normalizeGameRecapHighlightClips(game, options = {}) {
         .sort((a, b) => (a.order - b.order) || ((a.startMs ?? 0) - (b.startMs ?? 0)));
 }
 
+
+export function resolveGameMediaHub({ team, game, durationMs = null } = {}) {
+    const recorded = getRecordedReplayConfig(game);
+    const liveEmbed = getLiveEmbedConfig(team);
+    const highlightDurationMs = toFiniteNumber(durationMs) ?? recorded?.durationMs ?? null;
+
+    return {
+        liveStream: liveEmbed?.embedUrl ? {
+            sourceUrl: liveEmbed.embedUrl,
+            publicUrl: liveEmbed.publicUrl,
+            publicLabel: liveEmbed.publicLabel || 'Open live stream ↗'
+        } : null,
+        replay: recorded?.sourceUrl ? {
+            sourceUrl: recorded.sourceUrl,
+            publicUrl: recorded.publicUrl || recorded.sourceUrl,
+            publicLabel: recorded.publicUrl ? 'Open replay video ↗' : 'Open replay video',
+            title: recorded.title,
+            durationMs: recorded.durationMs
+        } : null,
+        highlights: normalizeSavedHighlightClips(game, { durationMs: highlightDurationMs })
+    };
+}
+
 export function buildHighlightShareUrl({ origin, teamId, gameId, startMs, endMs }) {
     const url = new URL('/live-game.html', origin);
     url.searchParams.set('teamId', teamId);
@@ -315,6 +339,7 @@ export function buildHighlightShareUrl({ origin, teamId, gameId, startMs, endMs 
 }
 
 export function resolveReplayVideoOptions({ team, game, isReplay, clipStartMs = null, clipEndMs = null }) {
+    const mediaHub = resolveGameMediaHub({ team, game });
     const recorded = getRecordedReplayConfig(game);
     const canUseRecordedReplay = Boolean(recorded?.sourceUrl) && (isReplay || game?.liveStatus === 'completed' || game?.status === 'completed');
 
@@ -336,7 +361,8 @@ export function resolveReplayVideoOptions({ team, game, isReplay, clipStartMs = 
             durationMs: recorded.durationMs,
             clipStartMs: activeClip?.startMs ?? null,
             clipEndMs: activeClip?.endMs ?? null,
-            savedHighlights: normalizeSavedHighlightClips(game, { durationMs: recorded.durationMs })
+            savedHighlights: mediaHub.highlights,
+            mediaHub
         };
     }
 
@@ -353,7 +379,8 @@ export function resolveReplayVideoOptions({ team, game, isReplay, clipStartMs = 
             durationMs: null,
             clipStartMs: null,
             clipEndMs: null,
-            savedHighlights: []
+            savedHighlights: mediaHub.highlights,
+            mediaHub
         };
     }
 
@@ -368,7 +395,8 @@ export function resolveReplayVideoOptions({ team, game, isReplay, clipStartMs = 
         durationMs: null,
         clipStartMs: null,
         clipEndMs: null,
-        savedHighlights: []
+        savedHighlights: mediaHub.highlights,
+        mediaHub
     };
 }
 

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -490,6 +490,11 @@ function buildMediaHubHighlightUrl(clip) {
   });
 }
 
+function buildSafeMediaHubHighlightUrl(clip) {
+  const clipUrl = buildMediaHubHighlightUrl(clip);
+  return clipUrl && isSafeUrl(clipUrl) ? clipUrl : null;
+}
+
 function renderGameMediaHub() {
   if (!els.gameMediaHub || !els.gameMediaHubContent) return;
   const mediaHub = state.videoPlayback?.mediaHub || {};
@@ -525,7 +530,7 @@ function renderGameMediaHub() {
   }
   if (mediaHub.highlights?.length) {
     const highlights = mediaHub.highlights.map((clip, index) => {
-      const clipUrl = buildMediaHubHighlightUrl(clip);
+      const clipUrl = buildSafeMediaHubHighlightUrl(clip);
       return `
         <div class="rounded-lg border border-teal/15 bg-ink/45 px-3 py-2">
           <div class="flex items-start justify-between gap-3">
@@ -873,7 +878,7 @@ function initRecordedReplayControls() {
       const button = event.target.closest('[data-media-highlight-index]');
       if (!button) return;
       const clip = state.videoPlayback?.mediaHub?.highlights?.[Number(button.dataset.mediaHighlightIndex)];
-      const clipUrl = buildMediaHubHighlightUrl(clip);
+      const clipUrl = buildSafeMediaHubHighlightUrl(clip);
       if (!clipUrl) return;
       const result = await shareOrCopy({
         title: clip.title || 'Game highlight',

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -27,7 +27,7 @@ import {
   getReplayStartTimeAfterSpeedChange,
   getReplayTimestampMs
 } from './live-game-replay.js?v=3';
-import { MAX_HIGHLIGHT_CLIP_MS, buildHighlightShareUrl, canAccessNativeCameraCapture, createHighlightClipDraft, resolveReplayVideoOptions, shouldReloadVideoPlayback } from './live-game-video.js?v=3';
+import { MAX_HIGHLIGHT_CLIP_MS, buildHighlightShareUrl, canAccessNativeCameraCapture, createHighlightClipDraft, resolveReplayVideoOptions, shouldReloadVideoPlayback } from './live-game-video.js?v=4';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
 import { resolveOpponentDisplayName, normalizeLiveStatColumns, resolveLiveStatColumns, renderViewerLineupSections, renderOpponentStatsCards, applyResetEventState, applyViewerEventToState, shouldResetViewerFromGameDoc, collectVisibleLiveEventsSequentially } from './live-game-state.js?v=6';
@@ -169,7 +169,9 @@ const els = {
   nativeCameraPlaceholder: q('#native-camera-placeholder'),
   nativeCameraStartBtn: q('#native-camera-start-btn'),
   nativeCameraStopBtn: q('#native-camera-stop-btn'),
-  nativeCameraStatus: q('#native-camera-status')
+  nativeCameraStatus: q('#native-camera-status'),
+  gameMediaHub: q('#game-media-hub'),
+  gameMediaHubContent: q('#game-media-hub-content')
 };
 
 const mentionState = { active: false, atPos: null };
@@ -377,6 +379,11 @@ function initNativeCameraControls() {
 function refreshVideoPanel({ force = false } = {}) {
   const nextPlayback = resolveVideoPlayback();
   if (!force && !shouldReloadVideoPlayback(state.videoPlayback, nextPlayback)) {
+    state.videoPlayback = nextPlayback;
+    state.hasVideoStream = Boolean(state.videoPlayback?.hasVideo || hasMediaHubContent(state.videoPlayback?.mediaHub));
+    renderRecordedReplayTools();
+    renderGameMediaHub();
+    updateTabs();
     return false;
   }
   setupVideoPanel(nextPlayback);
@@ -392,7 +399,8 @@ function setupVideoPanel(nextPlayback = resolveVideoPlayback()) {
   const shouldReloadPlayback = shouldReloadVideoPlayback(previousPlayback, nextPlayback);
   state.videoPlayback = nextPlayback;
   const canUseNativeCamera = userCanUseNativeCamera();
-  state.hasVideoStream = Boolean(state.videoPlayback?.hasVideo || canUseNativeCamera);
+  const hasMediaHub = hasMediaHubContent(state.videoPlayback?.mediaHub);
+  state.hasVideoStream = Boolean(state.videoPlayback?.hasVideo || canUseNativeCamera || hasMediaHub);
   updateNativeCameraPanel();
 
   if (state.videoPlayback?.mode === 'recorded') {
@@ -453,16 +461,97 @@ function setupVideoPanel(nextPlayback = resolveVideoPlayback()) {
       iframe.classList.add('hidden');
     }
     els.recordedReplayTools?.classList.add('hidden');
-    els.videoPanel?.classList.toggle('hidden', !canUseNativeCamera);
-    if (videoTab) videoTab.classList.toggle('hidden', !canUseNativeCamera);
+    els.videoPanel?.classList.toggle('hidden', !(canUseNativeCamera || hasMediaHub));
+    if (videoTab) videoTab.classList.toggle('hidden', !(canUseNativeCamera || hasMediaHub));
     if (extLink) {
       extLink.classList.add('hidden');
       extLink.removeAttribute('href');
     }
-    if (state.activeTab === 'video' && !canUseNativeCamera) state.activeTab = 'plays';
+    if (state.activeTab === 'video' && !(canUseNativeCamera || hasMediaHub)) state.activeTab = 'plays';
   }
 
+  renderGameMediaHub();
   updateTabs();
+}
+
+function hasMediaHubContent(mediaHub) {
+  return Boolean(mediaHub?.liveStream || mediaHub?.replay || mediaHub?.highlights?.length);
+}
+
+function buildMediaHubHighlightUrl(clip) {
+  if (clip?.videoUrl) return clip.videoUrl;
+  if (!Number.isFinite(clip?.startMs) || !Number.isFinite(clip?.endMs)) return null;
+  return buildHighlightShareUrl({
+    origin: window.location.origin,
+    teamId: state.teamId,
+    gameId: state.gameId,
+    startMs: clip.startMs,
+    endMs: clip.endMs
+  });
+}
+
+function renderGameMediaHub() {
+  if (!els.gameMediaHub || !els.gameMediaHubContent) return;
+  const mediaHub = state.videoPlayback?.mediaHub || {};
+  if (!hasMediaHubContent(mediaHub)) {
+    els.gameMediaHub.classList.add('hidden');
+    els.gameMediaHubContent.innerHTML = '';
+    return;
+  }
+
+  const sections = [];
+  if (mediaHub.liveStream) {
+    sections.push(`
+      <div class="rounded-lg border border-teal/15 bg-ink/45 px-3 py-2">
+        <div class="text-[11px] uppercase tracking-[0.2em] text-teal/70">Live stream</div>
+        <div class="mt-1 flex items-center justify-between gap-3">
+          <span class="text-sm text-sand/75">External provider stream</span>
+          ${mediaHub.liveStream.publicUrl ? `<a href="${escapeHtml(mediaHub.liveStream.publicUrl)}" target="_blank" rel="noopener noreferrer" class="text-xs text-teal hover:text-teal/80">${escapeHtml(mediaHub.liveStream.publicLabel || 'Open stream ↗')}</a>` : '<span class="text-xs text-sand/45">Embedded above</span>'}
+        </div>
+      </div>
+    `);
+  }
+  if (mediaHub.replay) {
+    const replayUrl = `live-game.html?teamId=${encodeURIComponent(state.teamId)}&gameId=${encodeURIComponent(state.gameId)}&replay=true`;
+    sections.push(`
+      <div class="rounded-lg border border-teal/15 bg-ink/45 px-3 py-2">
+        <div class="text-[11px] uppercase tracking-[0.2em] text-teal/70">Replay</div>
+        <div class="mt-1 flex items-center justify-between gap-3">
+          <span class="text-sm text-sand/75">${escapeHtml(mediaHub.replay.title || 'Recorded game replay')}</span>
+          <a href="${escapeHtml(replayUrl)}" class="text-xs text-teal hover:text-teal/80">Watch replay</a>
+        </div>
+      </div>
+    `);
+  }
+  if (mediaHub.highlights?.length) {
+    const highlights = mediaHub.highlights.map((clip, index) => {
+      const clipUrl = buildMediaHubHighlightUrl(clip);
+      return `
+        <div class="rounded-lg border border-teal/15 bg-ink/45 px-3 py-2">
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <div class="text-sm font-medium text-sand">${escapeHtml(clip.title || `Highlight ${index + 1}`)}</div>
+              <div class="text-xs text-sand/55">${formatVideoTimestamp(clip.startMs)} - ${formatVideoTimestamp(clip.endMs)}</div>
+            </div>
+            <div class="flex shrink-0 gap-2">
+              ${clipUrl ? `<a href="${escapeHtml(clipUrl)}" target="_blank" rel="noopener noreferrer" class="text-xs text-teal hover:text-teal/80">Play</a><button type="button" data-media-highlight-index="${index}" class="text-xs text-teal hover:text-teal/80">Copy</button>` : '<span class="text-xs text-sand/45">No link</span>'}
+            </div>
+          </div>
+        </div>
+      `;
+    }).join('');
+    sections.push(`
+      <div>
+        <div class="mb-2 text-[11px] uppercase tracking-[0.2em] text-teal/70">Saved highlights</div>
+        <div class="space-y-2">${highlights}</div>
+      </div>
+    `);
+  } else {
+    sections.push('<div class="rounded-lg border border-dashed border-teal/20 px-3 py-3 text-sm text-sand/50">No replay highlights have been saved for this game yet.</div>');
+  }
+
+  els.gameMediaHubContent.innerHTML = sections.join('');
+  els.gameMediaHub.classList.remove('hidden');
 }
 
 function formatVideoTimestamp(ms) {
@@ -695,9 +784,14 @@ async function saveHighlightClip() {
     };
     state.videoPlayback = {
       ...state.videoPlayback,
-      savedHighlights: nextHighlights
+      savedHighlights: nextHighlights,
+      mediaHub: {
+        ...(state.videoPlayback?.mediaHub || {}),
+        highlights: nextHighlights
+      }
     };
     renderRecordedReplayTools();
+    renderGameMediaHub();
     showToast('Highlight saved.');
   } catch (error) {
     console.warn('Failed to save highlight clip:', error);
@@ -771,6 +865,25 @@ function initRecordedReplayControls() {
       }
       setSelectedTaggedPlayerIds(clip.taggedPlayerIds);
       applyHighlightSelection(clip, { autoplay: false });
+    });
+  }
+  if (els.gameMediaHubContent && !els.gameMediaHubContent.dataset.bound) {
+    els.gameMediaHubContent.dataset.bound = 'true';
+    els.gameMediaHubContent.addEventListener('click', async (event) => {
+      const button = event.target.closest('[data-media-highlight-index]');
+      if (!button) return;
+      const clip = state.videoPlayback?.mediaHub?.highlights?.[Number(button.dataset.mediaHighlightIndex)];
+      const clipUrl = buildMediaHubHighlightUrl(clip);
+      if (!clipUrl) return;
+      const result = await shareOrCopy({
+        title: clip.title || 'Game highlight',
+        text: clip.title || 'Watch this highlight',
+        url: clipUrl,
+        clipboardText: `${clip.title || 'Game highlight'}\n${clipUrl}`
+      });
+      if (result.status === 'shared') showToast('Clip share sheet opened!');
+      if (result.status === 'copied') showToast('Clip link copied!');
+      if (result.status === 'failed') showToast('Failed to copy clip link.');
     });
   }
 }

--- a/live-game.html
+++ b/live-game.html
@@ -352,6 +352,15 @@
         <a id="stream-external-link" href="#" target="_blank" rel="noopener noreferrer"
           class="hidden mt-1 text-xs text-center text-sand/50 hover:text-sand/80 transition">
         </a>
+        <section id="game-media-hub" class="hidden mt-3 rounded-xl border border-teal/20 bg-slate/45 p-3">
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <p class="text-[11px] uppercase tracking-[0.25em] text-teal/70">Game Media Hub</p>
+              <p class="text-sm text-sand/70">Live stream, replay, and saved highlights in one place.</p>
+            </div>
+          </div>
+          <div id="game-media-hub-content" class="mt-3 space-y-3"></div>
+        </section>
       </section>
 
       <!-- STATS (right sidebar) -->

--- a/tests/unit/live-game-video.test.js
+++ b/tests/unit/live-game-video.test.js
@@ -6,6 +6,7 @@ import {
     normalizeGameRecapHighlightClips,
     normalizeSavedHighlightClips,
     canAccessNativeCameraCapture,
+    resolveGameMediaHub,
     resolveReplayVideoOptions,
     shouldReloadVideoPlayback
 } from '../../js/live-game-video.js';
@@ -109,6 +110,38 @@ describe('live game replay video helpers', () => {
                 videoUrl: 'https://video.example.com/clip-2',
                 players: [{ id: 'p1', name: 'p1' }]
             }
+        ]);
+    });
+
+    it('collects live stream, replay, and saved highlights for the media hub', () => {
+        const hub = resolveGameMediaHub({
+            team: {
+                streamEmbedUrl: 'https://www.youtube.com/embed/abcdefghijk'
+            },
+            game: {
+                replayVideo: {
+                    url: 'https://cdn.example.com/game.mp4',
+                    publicUrl: 'https://video.example.com/game',
+                    title: 'Full replay',
+                    durationMs: 120_000
+                },
+                highlightClips: [
+                    { title: 'Big save', startMs: 15_000, endMs: 35_000, videoUrl: 'https://video.example.com/clip' }
+                ]
+            }
+        });
+
+        expect(hub.liveStream).toMatchObject({
+            sourceUrl: 'https://www.youtube.com/embed/abcdefghijk?autoplay=1&mute=1',
+            publicUrl: 'https://www.youtube.com/watch?v=abcdefghijk'
+        });
+        expect(hub.replay).toMatchObject({
+            sourceUrl: 'https://cdn.example.com/game.mp4',
+            publicUrl: 'https://video.example.com/game',
+            title: 'Full replay'
+        });
+        expect(hub.highlights).toMatchObject([
+            { title: 'Big save', startMs: 15_000, endMs: 35_000, videoUrl: 'https://video.example.com/clip' }
         ]);
     });
 


### PR DESCRIPTION
Closes #663

## Summary
- Added a Game Media Hub on the live game video panel that surfaces live stream, replay, and saved highlights together.
- Added clear empty-state messaging when no saved replay highlights exist.
- Added playable and copyable highlight links while preserving the existing manual replay clipping controls.

## Validation
- `npx vitest run tests/unit/live-game-video.test.js tests/unit/live-game-replay-init.test.js`