### PR TITLE
Add Team Pass management panel

### DIFF
--- a/docs/pr-notes/runs/748-ci-fix-20260506T093805Z/architecture.md
+++ b/docs/pr-notes/runs/748-ci-fix-20260506T093805Z/architecture.md
@@ -1,0 +1,7 @@
+# Architecture notes
+
+Root cause: `team.html` imports `./js/team-pass.js?v=2`, but the smoke test route still stubs only `team-pass.js?v=1`. When the smoke page boots with mocked Firebase, the real Team Pass module can enter the module graph instead of the test stub, which is outside this test's mocked dependency surface.
+
+Decision: keep production code unchanged. Make the smoke stub version-tolerant for Team Pass imports so cache-busting query changes do not break unrelated schedule smoke coverage.
+
+Risks and rollback: scoped to Playwright smoke test setup only. Roll back by restoring the exact `?v=1` route if a future test intentionally needs the real Team Pass module.

--- a/docs/pr-notes/runs/748-ci-fix-20260506T093805Z/code-plan.md
+++ b/docs/pr-notes/runs/748-ci-fix-20260506T093805Z/code-plan.md
@@ -1,0 +1,5 @@
+# Code plan
+
+1. Update `tests/smoke/team-schedule-calendar.spec.js` so the Team Pass route stub matches `**/js/team-pass.js?v=*` instead of only `?v=1`.
+2. Run the two failing smoke tests locally.
+3. Commit only the smoke setup fix and role notes.

--- a/docs/pr-notes/runs/748-ci-fix-20260506T093805Z/qa.md
+++ b/docs/pr-notes/runs/748-ci-fix-20260506T093805Z/qa.md
@@ -1,0 +1,9 @@
+# QA notes
+
+Acceptance criteria:
+- `team.html#teamId=team-a` boots under `mockTeamPageModules()`.
+- The team header renders the mocked team name.
+- Schedule calendar/list filters retain existing assertions for practices, tracked duplicates, cancelled events, and past/upcoming buckets.
+
+Validation command:
+- `npx playwright test tests/smoke/team-schedule-calendar.spec.js --grep "team schedule calendar shows only practices|team schedule keeps tracked duplicates"`

--- a/js/team-pass.js
+++ b/js/team-pass.js
@@ -54,6 +54,54 @@ function escapeTeamPassHtml(value) {
         .replace(/'/g, '&#39;');
 }
 
+function normalizeString(value) {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeStatus(value) {
+    return normalizeString(value).toLowerCase();
+}
+
+function normalizeDateValue(value) {
+    if (!value) return null;
+    if (value instanceof Date) return Number.isNaN(value.getTime()) ? undefined : value;
+    if (typeof value.toDate === 'function') {
+        const date = value.toDate();
+        return date instanceof Date && !Number.isNaN(date.getTime()) ? date : undefined;
+    }
+    if (typeof value.seconds === 'number') {
+        const date = new Date(value.seconds * 1000);
+        return Number.isNaN(date.getTime()) ? undefined : date;
+    }
+    if (typeof value === 'number' || typeof value === 'string') {
+        const date = new Date(value);
+        return Number.isNaN(date.getTime()) ? undefined : date;
+    }
+    return undefined;
+}
+
+function getExpirationDate(data) {
+    if (!data || typeof data !== 'object') return null;
+    const fields = ['expiresAt', 'validUntil', 'endsAt', 'endAt'];
+    for (const field of fields) {
+        if (Object.prototype.hasOwnProperty.call(data, field)) {
+            return normalizeDateValue(data[field]);
+        }
+    }
+    return null;
+}
+
+function getUpdatedDate(data) {
+    if (!data || typeof data !== 'object') return null;
+    const fields = ['updatedAt', 'lastUpdatedAt', 'createdAt', 'purchasedAt'];
+    for (const field of fields) {
+        if (Object.prototype.hasOwnProperty.call(data, field)) {
+            return normalizeDateValue(data[field]);
+        }
+    }
+    return null;
+}
+
 function arrayIncludesTeamId(values, teamId) {
     return Array.isArray(values) && values.some((value) => {
         if (typeof value === 'string') return value === teamId;
@@ -61,32 +109,139 @@ function arrayIncludesTeamId(values, teamId) {
     });
 }
 
+function loadFirebase(deps = {}) {
+    if (deps.firebase) return deps.firebase;
+    return import('./firebase.js?v=11');
+}
+
+function dataFromSnapshot(docSnap) {
+    return typeof docSnap?.data === 'function' ? docSnap.data() : null;
+}
+
+function compareByUpdatedAtDesc(a, b) {
+    const aTime = getUpdatedDate(a)?.getTime?.() || 0;
+    const bTime = getUpdatedDate(b)?.getTime?.() || 0;
+    return bTime - aTime;
+}
+
 export function getTeamPassAccess(user, team) {
     const teamId = team?.id;
-    const isCoachOrAdmin = hasFullTeamAccess(user, team) || arrayIncludesTeamId(user?.coachOf, teamId);
-    const isConfirmedParent = arrayIncludesTeamId(user?.parentOf, teamId);
-    const isEligible = Boolean(user && teamId && (isCoachOrAdmin || isConfirmedParent));
+    const isStaff = hasFullTeamAccess(user, team) || arrayIncludesTeamId(user?.coachOf, teamId);
+    const isConfirmedParent = arrayIncludesTeamId(user?.parentOf, teamId) || arrayIncludesTeamId(user?.parentTeamIds, teamId);
 
-    if (isCoachOrAdmin) {
-        return { isEligible, label: 'Coach/Admin access', mode: 'eligible' };
+    if (isStaff) {
+        return { isStaff: true, canReadStatus: true, label: 'Coach/Admin access', mode: 'staff' };
     }
 
     if (isConfirmedParent) {
-        return { isEligible, label: 'Confirmed parent access', mode: 'eligible' };
+        return { isStaff: false, canReadStatus: false, label: 'Team member access', mode: 'readonly' };
     }
 
-    return { isEligible: false, label: 'Read-only preview', mode: 'readonly' };
+    return { isStaff: false, canReadStatus: false, label: 'Read-only preview', mode: 'readonly' };
 }
 
-export function buildTeamPassMarkup({ team = {}, access = { isEligible: false, label: 'Read-only preview' } } = {}) {
+export function normalizeTeamPassStatus(record, { team = {}, now = new Date() } = {}) {
+    if (!record || typeof record !== 'object') {
+        return { status: 'missing', label: 'Missing', record: null, expiresAt: null, updatedAt: null };
+    }
+
+    const rawStatus = normalizeStatus(record.status);
+    const expiresAt = getExpirationDate(record);
+    const updatedAt = getUpdatedDate(record);
+    const entitlementTeamId = normalizeString(record.teamId);
+    const isWrongTeam = entitlementTeamId && team?.id && entitlementTeamId !== team.id;
+    const isRevoked = rawStatus === 'revoked' || rawStatus === 'deleted' || record.revoked === true || record.isRevoked === true || Boolean(normalizeDateValue(record.revokedAt));
+    const isExpired = rawStatus === 'expired' || (expiresAt instanceof Date && expiresAt <= now);
+
+    if (isWrongTeam) {
+        return { status: 'missing', label: 'Missing', record: null, expiresAt: null, updatedAt: null };
+    }
+
+    if (isRevoked) {
+        return { status: 'revoked', label: 'Revoked', record, expiresAt, updatedAt };
+    }
+
+    if (isExpired) {
+        return { status: 'expired', label: 'Expired', record, expiresAt, updatedAt };
+    }
+
+    if (rawStatus === 'active') {
+        return { status: 'active', label: 'Active', record, expiresAt, updatedAt };
+    }
+
+    return { status: 'missing', label: 'Missing', record: null, expiresAt: null, updatedAt: null };
+}
+
+export function selectTeamPassRecord(records = [], { team = {}, now = new Date() } = {}) {
+    const candidates = (Array.isArray(records) ? records : [])
+        .filter((record) => {
+            if (!record || typeof record !== 'object') return false;
+            const tier = normalizeString(record.tier);
+            const entitlementTeamId = normalizeString(record.teamId);
+            return (!tier || tier === 'team-pass') && (!entitlementTeamId || entitlementTeamId === team?.id);
+        })
+        .sort(compareByUpdatedAtDesc);
+
+    const normalized = candidates.map((record) => normalizeTeamPassStatus(record, { team, now }));
+    return normalized.find((item) => item.status === 'active')
+        || normalized.find((item) => item.status === 'expired')
+        || normalized.find((item) => item.status === 'revoked')
+        || normalizeTeamPassStatus(null, { team, now });
+}
+
+export async function readTeamPassStatus({ team, access, deps = {} } = {}) {
+    if (!team?.id || !access?.canReadStatus) {
+        return { status: 'readonly', label: 'Read-only', record: null, expiresAt: null, updatedAt: null };
+    }
+
+    try {
+        const { db, collection, getDocs } = await loadFirebase(deps);
+        const snapshot = await getDocs(collection(db, `teams/${team.id}/entitlements`));
+        return selectTeamPassRecord(snapshot.docs.map(dataFromSnapshot), { team });
+    } catch (error) {
+        console.error('Unable to read Team Pass status:', error);
+        return { status: 'unavailable', label: 'Unavailable', record: null, expiresAt: null, updatedAt: null };
+    }
+}
+
+function formatDateForPanel(value) {
+    if (!(value instanceof Date)) return 'Not set';
+    return value.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+function getStatusClasses(status) {
+    if (status === 'active') return 'bg-green-50 text-green-700 border-green-200';
+    if (status === 'expired') return 'bg-amber-50 text-amber-800 border-amber-200';
+    if (status === 'revoked') return 'bg-red-50 text-red-700 border-red-200';
+    if (status === 'unavailable') return 'bg-gray-50 text-gray-700 border-gray-200';
+    return 'bg-gray-50 text-gray-700 border-gray-200';
+}
+
+function getPanelCopy(status, access) {
+    if (!access?.isStaff) {
+        return 'Team Pass access is managed by team staff. You can view team content normally when your team access allows it.';
+    }
+    if (status === 'missing') {
+        return 'No Team Pass is configured for this team yet. Checkout is not available, so staff will need to configure the pass later.';
+    }
+    if (status === 'expired') {
+        return 'This Team Pass has expired. Checkout is not available, so renewal must be configured later.';
+    }
+    if (status === 'revoked') {
+        return 'This Team Pass has been revoked. This panel is informational only and does not grant or revoke access.';
+    }
+    if (status === 'active') {
+        return 'This team has an active Team Pass. This panel is informational only and does not grant or revoke access.';
+    }
+    return 'Team Pass status could not be verified right now. No entitlement changes were made.';
+}
+
+export function buildTeamPassMarkup({ team = {}, access = getTeamPassAccess(null, team), pass = { status: 'readonly', label: 'Read-only' } } = {}) {
     const teamName = escapeTeamPassHtml(team?.name || 'this team');
-    const ctaText = access.isEligible ? 'Buy Team Pass' : 'Purchase unavailable';
-    const ctaClasses = access.isEligible
-        ? 'bg-primary-600 text-white hover:bg-primary-700 cursor-not-allowed'
-        : 'bg-gray-200 text-gray-500 cursor-not-allowed';
-    const helperText = access.isEligible
-        ? 'Checkout is not connected yet, so this button is intentionally disabled.'
-        : 'Sign in as a coach, admin, or confirmed parent to start purchase when checkout is configured.';
+    const status = pass?.status || 'readonly';
+    const label = escapeTeamPassHtml(pass?.label || 'Read-only');
+    const statusClasses = getStatusClasses(status);
+    const showStaffMetadata = access?.isStaff;
 
     return `
         <section id="team-pass" class="mb-8 bg-white rounded-2xl shadow-lg border border-primary-200 overflow-hidden">
@@ -94,38 +249,31 @@ export function buildTeamPassMarkup({ team = {}, access = { isEligible: false, l
                 <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-6">
                     <div class="max-w-3xl">
                         <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full text-xs font-bold uppercase tracking-wide bg-amber-100 text-amber-800 border border-amber-200 mb-4">
-                            Team-wide fan access
+                            Team Pass management
                         </div>
-                        <h2 class="text-2xl md:text-3xl font-bold text-gray-900 mb-3">Buy Team Pass for ${teamName}</h2>
-                        <p class="text-gray-600 leading-relaxed">
-                            A Team Pass will cover fan-facing Plus or Premium features for the whole team for the selected season. One team purchase keeps families on the same access level without per-parent setup.
-                        </p>
-                        <div class="mt-4 flex flex-wrap gap-2 text-sm">
-                            <span class="inline-flex px-3 py-1 rounded-full bg-white border border-primary-100 text-primary-700 font-semibold">Season-scoped coverage</span>
-                            <span class="inline-flex px-3 py-1 rounded-full bg-white border border-primary-100 text-primary-700 font-semibold">Applies team-wide</span>
-                            <span class="inline-flex px-3 py-1 rounded-full bg-white border border-primary-100 text-primary-700 font-semibold">No charges today</span>
-                        </div>
+                        <h2 class="text-2xl md:text-3xl font-bold text-gray-900 mb-3">Team Pass for ${teamName}</h2>
+                        <p class="text-gray-600 leading-relaxed">${escapeTeamPassHtml(getPanelCopy(status, access))}</p>
                     </div>
-                    <div class="lg:w-72 bg-white rounded-xl border border-gray-200 p-4 shadow-sm">
-                        <div class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Your access</div>
-                        <div class="text-lg font-bold text-gray-900">${escapeTeamPassHtml(access.label)}</div>
-                        <button type="button" disabled aria-disabled="true" class="mt-4 w-full inline-flex justify-center items-center px-4 py-2.5 rounded-lg text-sm font-bold transition ${ctaClasses}">
-                            ${ctaText}
-                        </button>
-                        <p class="mt-2 text-xs text-gray-500 leading-relaxed">${helperText}</p>
-                    </div>
-                </div>
-
-                <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
-                    <div class="bg-white rounded-xl border border-gray-200 p-5">
-                        <h3 class="text-lg font-bold text-gray-900 mb-2">Plus Team Pass</h3>
-                        <p class="text-sm text-gray-600 leading-relaxed">Designed for core fan features such as enhanced live following, replay convenience, and season access for families.</p>
-                        <div class="mt-4 text-sm font-semibold text-gray-500">Checkout pending backend configuration</div>
-                    </div>
-                    <div class="bg-white rounded-xl border border-amber-200 p-5">
-                        <h3 class="text-lg font-bold text-gray-900 mb-2">Premium Team Pass</h3>
-                        <p class="text-sm text-gray-600 leading-relaxed">Designed for the full fan experience, including Premium fan capabilities when entitlement support is added later.</p>
-                        <div class="mt-4 text-sm font-semibold text-gray-500">Checkout pending backend configuration</div>
+                    <div class="lg:w-80 bg-white rounded-xl border border-gray-200 p-4 shadow-sm">
+                        <div class="text-xs font-semibold text-gray-500 uppercase tracking-wider mb-1">Current status</div>
+                        <div class="inline-flex items-center px-3 py-1 rounded-full text-sm font-bold border ${statusClasses}">${label}</div>
+                        <dl class="mt-4 space-y-3 text-sm">
+                            <div>
+                                <dt class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Covered team</dt>
+                                <dd class="mt-1 font-semibold text-gray-900">${teamName}</dd>
+                            </div>
+                            ${showStaffMetadata ? `
+                            <div>
+                                <dt class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Expiration</dt>
+                                <dd class="mt-1 text-gray-700">${escapeTeamPassHtml(formatDateForPanel(pass?.expiresAt))}</dd>
+                            </div>
+                            <div>
+                                <dt class="text-xs font-semibold text-gray-500 uppercase tracking-wider">Last updated</dt>
+                                <dd class="mt-1 text-gray-700">${escapeTeamPassHtml(formatDateForPanel(pass?.updatedAt))}</dd>
+                            </div>
+                            ` : ''}
+                        </dl>
+                        ${showStaffMetadata && status === 'missing' ? '<div class="mt-4 rounded-lg border border-amber-200 bg-amber-50 p-3 text-xs font-semibold text-amber-800">Checkout is not available yet. Configure this Team Pass later when entitlement setup is ready.</div>' : ''}
                     </div>
                 </div>
             </div>
@@ -133,8 +281,10 @@ export function buildTeamPassMarkup({ team = {}, access = { isEligible: false, l
     `;
 }
 
-export function renderTeamPassCard(container, { user, team } = {}) {
+export async function renderTeamPassCard(container, { user, team, deps = {} } = {}) {
     if (!container) return;
     const access = getTeamPassAccess(user, team);
-    container.innerHTML = buildTeamPassMarkup({ team, access });
+    container.innerHTML = buildTeamPassMarkup({ team, access, pass: { status: 'loading', label: 'Loading' } });
+    const pass = await readTeamPassStatus({ team, access, deps });
+    container.innerHTML = buildTeamPassMarkup({ team, access, pass });
 }

--- a/js/team-pass.js
+++ b/js/team-pass.js
@@ -62,6 +62,12 @@ function normalizeStatus(value) {
     return normalizeString(value).toLowerCase();
 }
 
+function resolveTeamPassSeasonId(team = {}, now = new Date()) {
+    const explicitSeason = team.currentSeasonId || team.seasonId || team.season;
+    if (explicitSeason) return String(explicitSeason).trim();
+    return String(now.getUTCFullYear());
+}
+
 function normalizeDateValue(value) {
     if (!value) return null;
     if (value instanceof Date) return Number.isNaN(value.getTime()) ? undefined : value;
@@ -173,20 +179,21 @@ export function normalizeTeamPassStatus(record, { team = {}, now = new Date() } 
 }
 
 export function selectTeamPassRecord(records = [], { team = {}, now = new Date() } = {}) {
+    const currentSeasonId = resolveTeamPassSeasonId(team, now);
     const candidates = (Array.isArray(records) ? records : [])
         .filter((record) => {
             if (!record || typeof record !== 'object') return false;
             const tier = normalizeString(record.tier);
             const entitlementTeamId = normalizeString(record.teamId);
-            return (!tier || tier === 'team-pass') && (!entitlementTeamId || entitlementTeamId === team?.id);
+            const seasonId = normalizeString(record.seasonId || record.season);
+            return (!tier || tier === 'team-pass') &&
+                (!entitlementTeamId || entitlementTeamId === team?.id) &&
+                (!currentSeasonId || seasonId === currentSeasonId);
         })
         .sort(compareByUpdatedAtDesc);
 
     const normalized = candidates.map((record) => normalizeTeamPassStatus(record, { team, now }));
-    return normalized.find((item) => item.status === 'active')
-        || normalized.find((item) => item.status === 'expired')
-        || normalized.find((item) => item.status === 'revoked')
-        || normalizeTeamPassStatus(null, { team, now });
+    return normalized[0] || normalizeTeamPassStatus(null, { team, now });
 }
 
 export async function readTeamPassStatus({ team, access, deps = {} } = {}) {

--- a/team.html
+++ b/team.html
@@ -273,7 +273,7 @@
         import { getVisibleRosterFieldValues } from './js/roster-field-privacy.js';
         import { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';
         import { readTeamPremiumEntitlement, renderPremiumGateState } from './js/premium-entitlements.js?v=1';
-        import { renderTeamPassCard } from './js/team-pass.js?v=1';
+        import { renderTeamPassCard } from './js/team-pass.js?v=2';
 
         renderFooter(document.getElementById('footer-container'));
 

--- a/tests/smoke/team-schedule-calendar.spec.js
+++ b/tests/smoke/team-schedule-calendar.spec.js
@@ -320,7 +320,7 @@ async function mockTeamPageModules(page, scenario) {
         contentType: 'application/javascript',
         body: TEAM_ADMIN_BANNER_STUB
     }));
-    await page.route('**/js/team-pass.js?v=1', (route) => route.fulfill({
+    await page.route('**/js/team-pass.js?v=*', (route) => route.fulfill({
         status: 200,
         contentType: 'application/javascript',
         body: TEAM_PASS_STUB

--- a/tests/unit/team-pass.test.js
+++ b/tests/unit/team-pass.test.js
@@ -10,6 +10,7 @@ import {
 const TEAM = {
     id: 'team-1',
     name: 'Blue Jays',
+    currentSeasonId: '2026',
     ownerId: 'owner-1',
     adminEmails: ['admin@example.com']
 };
@@ -84,21 +85,22 @@ describe('team pass UI helpers', () => {
         expect(normalizeTeamPassStatus(null, { team: TEAM, now })).toMatchObject({ status: 'missing', label: 'Missing' });
     });
 
-    it('selects an active Team Pass before older expired or revoked records', () => {
+    it('selects the newest Team Pass record for the current season', () => {
         const pass = selectTeamPassRecord([
-            { status: 'revoked', tier: 'team-pass', teamId: 'team-1', updatedAt: '2026-05-04T00:00:00.000Z' },
-            { status: 'active', tier: 'team-pass', teamId: 'team-1', expiresAt: '2026-12-31T00:00:00.000Z', updatedAt: '2026-05-01T00:00:00.000Z' },
-            { status: 'active', tier: 'family-plan', teamId: 'team-1', updatedAt: '2026-05-05T00:00:00.000Z' }
+            { status: 'active', tier: 'team-pass', teamId: 'team-1', seasonId: '2025', updatedAt: '2026-05-05T00:00:00.000Z' },
+            { status: 'active', tier: 'team-pass', teamId: 'team-1', seasonId: '2026', expiresAt: '2026-12-31T00:00:00.000Z', updatedAt: '2026-05-01T00:00:00.000Z' },
+            { status: 'revoked', tier: 'team-pass', teamId: 'team-1', seasonId: '2026', updatedAt: '2026-05-04T00:00:00.000Z' },
+            { status: 'active', tier: 'family-plan', teamId: 'team-1', seasonId: '2026', updatedAt: '2026-05-06T00:00:00.000Z' }
         ], { team: TEAM, now: new Date('2026-05-05T00:00:00.000Z') });
 
-        expect(pass).toMatchObject({ status: 'active', label: 'Active' });
+        expect(pass).toMatchObject({ status: 'revoked', label: 'Revoked' });
     });
 
     it('reads raw team entitlement status only for staff access', async () => {
         await expect(readTeamPassStatus({
             team: TEAM,
             access: { canReadStatus: true },
-            deps: { firebase: mockFirebaseForDocs([{ status: 'active', tier: 'team-pass', teamId: 'team-1' }]) }
+            deps: { firebase: mockFirebaseForDocs([{ status: 'active', tier: 'team-pass', teamId: 'team-1', seasonId: '2026' }]) }
         })).resolves.toMatchObject({ status: 'active' });
 
         await expect(readTeamPassStatus({

--- a/tests/unit/team-pass.test.js
+++ b/tests/unit/team-pass.test.js
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
-import { buildTeamPassMarkup, getTeamPassAccess } from '../../js/team-pass.js';
+import {
+    buildTeamPassMarkup,
+    getTeamPassAccess,
+    normalizeTeamPassStatus,
+    readTeamPassStatus,
+    selectTeamPassRecord
+} from '../../js/team-pass.js';
 
 const TEAM = {
     id: 'team-1',
@@ -8,56 +14,129 @@ const TEAM = {
     adminEmails: ['admin@example.com']
 };
 
+function mockFirebaseForDocs(docs) {
+    return {
+        db: {},
+        collection: (_db, path) => ({ path }),
+        getDocs: async () => ({
+            docs: docs.map((data) => ({ data: () => data }))
+        })
+    };
+}
+
 describe('team pass UI helpers', () => {
-    it('allows coaches and admins to see the buy team pass entry point', () => {
+    it('treats coaches and admins as staff for the management panel', () => {
         expect(getTeamPassAccess({ uid: 'coach-1', coachOf: ['team-1'] }, TEAM)).toMatchObject({
-            isEligible: true,
-            label: 'Coach/Admin access'
+            isStaff: true,
+            canReadStatus: true,
+            label: 'Coach/Admin access',
+            mode: 'staff'
         });
 
         expect(getTeamPassAccess({ uid: 'admin-1', email: 'admin@example.com' }, TEAM)).toMatchObject({
-            isEligible: true,
-            label: 'Coach/Admin access'
+            isStaff: true,
+            canReadStatus: true,
+            label: 'Coach/Admin access',
+            mode: 'staff'
         });
     });
 
-    it('allows confirmed parents to see the buy team pass entry point', () => {
+    it('keeps parents and fans in read-only mode without staff metadata controls', () => {
         expect(getTeamPassAccess({ uid: 'parent-1', parentOf: [{ teamId: 'team-1', playerId: 'p1' }] }, TEAM)).toMatchObject({
-            isEligible: true,
-            label: 'Confirmed parent access'
+            isStaff: false,
+            canReadStatus: false,
+            label: 'Team member access',
+            mode: 'readonly'
         });
-    });
 
-    it('keeps non-eligible users in read-only mode', () => {
-        expect(getTeamPassAccess({ uid: 'fan-1', email: 'fan@example.com' }, TEAM)).toEqual({
-            isEligible: false,
+        expect(getTeamPassAccess({ uid: 'fan-1', email: 'fan@example.com' }, TEAM)).toMatchObject({
+            isStaff: false,
+            canReadStatus: false,
             label: 'Read-only preview',
             mode: 'readonly'
         });
     });
 
-    it('renders plan options and disabled checkout messaging', () => {
-        const markup = buildTeamPassMarkup({
-            team: TEAM,
-            access: { isEligible: true, label: 'Coach/Admin access' }
-        });
+    it('normalizes active, expired, revoked, and missing team pass states', () => {
+        const now = new Date('2026-05-05T00:00:00.000Z');
 
-        expect(markup).toContain('Buy Team Pass');
-        expect(markup).toContain('Plus Team Pass');
-        expect(markup).toContain('Premium Team Pass');
-        expect(markup).toContain('Season-scoped coverage');
-        expect(markup).toContain('disabled aria-disabled="true"');
-        expect(markup).toContain('Checkout is not connected yet');
+        expect(normalizeTeamPassStatus({
+            status: 'active',
+            tier: 'team-pass',
+            teamId: 'team-1',
+            expiresAt: '2026-12-31T00:00:00.000Z'
+        }, { team: TEAM, now })).toMatchObject({ status: 'active', label: 'Active' });
+
+        expect(normalizeTeamPassStatus({
+            status: 'active',
+            tier: 'team-pass',
+            teamId: 'team-1',
+            expiresAt: '2026-01-01T00:00:00.000Z'
+        }, { team: TEAM, now })).toMatchObject({ status: 'expired', label: 'Expired' });
+
+        expect(normalizeTeamPassStatus({
+            status: 'active',
+            tier: 'team-pass',
+            teamId: 'team-1',
+            revokedAt: '2026-04-01T00:00:00.000Z'
+        }, { team: TEAM, now })).toMatchObject({ status: 'revoked', label: 'Revoked' });
+
+        expect(normalizeTeamPassStatus(null, { team: TEAM, now })).toMatchObject({ status: 'missing', label: 'Missing' });
     });
 
-    it('renders non-eligible users as unable to purchase', () => {
+    it('selects an active Team Pass before older expired or revoked records', () => {
+        const pass = selectTeamPassRecord([
+            { status: 'revoked', tier: 'team-pass', teamId: 'team-1', updatedAt: '2026-05-04T00:00:00.000Z' },
+            { status: 'active', tier: 'team-pass', teamId: 'team-1', expiresAt: '2026-12-31T00:00:00.000Z', updatedAt: '2026-05-01T00:00:00.000Z' },
+            { status: 'active', tier: 'family-plan', teamId: 'team-1', updatedAt: '2026-05-05T00:00:00.000Z' }
+        ], { team: TEAM, now: new Date('2026-05-05T00:00:00.000Z') });
+
+        expect(pass).toMatchObject({ status: 'active', label: 'Active' });
+    });
+
+    it('reads raw team entitlement status only for staff access', async () => {
+        await expect(readTeamPassStatus({
+            team: TEAM,
+            access: { canReadStatus: true },
+            deps: { firebase: mockFirebaseForDocs([{ status: 'active', tier: 'team-pass', teamId: 'team-1' }]) }
+        })).resolves.toMatchObject({ status: 'active' });
+
+        await expect(readTeamPassStatus({
+            team: TEAM,
+            access: { canReadStatus: false },
+            deps: { firebase: mockFirebaseForDocs([{ status: 'active', tier: 'team-pass', teamId: 'team-1' }]) }
+        })).resolves.toMatchObject({ status: 'readonly' });
+    });
+
+    it('renders staff status metadata and missing checkout callout without checkout controls', () => {
         const markup = buildTeamPassMarkup({
             team: TEAM,
-            access: { isEligible: false, label: 'Read-only preview' }
+            access: { isStaff: true, label: 'Coach/Admin access' },
+            pass: { status: 'missing', label: 'Missing', expiresAt: null, updatedAt: null }
         });
 
-        expect(markup).toContain('Read-only preview');
-        expect(markup).toContain('Purchase unavailable');
-        expect(markup).toContain('coach, admin, or confirmed parent');
+        expect(markup).toContain('Team Pass management');
+        expect(markup).toContain('Current status');
+        expect(markup).toContain('Missing');
+        expect(markup).toContain('Covered team');
+        expect(markup).toContain('Blue Jays');
+        expect(markup).toContain('Expiration');
+        expect(markup).toContain('Last updated');
+        expect(markup).toContain('Checkout is not available yet');
+        expect(markup).not.toContain('Buy Team Pass');
+    });
+
+    it('renders read-only team access without staff metadata controls', () => {
+        const markup = buildTeamPassMarkup({
+            team: TEAM,
+            access: { isStaff: false, label: 'Team member access' },
+            pass: { status: 'readonly', label: 'Read-only' }
+        });
+
+        expect(markup).toContain('Read-only');
+        expect(markup).toContain('Team Pass access is managed by team staff');
+        expect(markup).not.toContain('Expiration');
+        expect(markup).not.toContain('Last updated');
+        expect(markup).not.toContain('Checkout is not available yet');
     });
 });


### PR DESCRIPTION
Closes #738

## Summary
- Replaced the Team Pass purchase preview with a staff-facing management panel on the team page.
- Added Team Pass status normalization for active, expired, revoked, missing, unavailable, and read-only states.
- Shows covered team, expiration, and last updated metadata for staff while keeping non-staff users read-only.

## Validation
- `npx vitest run tests/unit/team-pass.test.js`
- `npx vitest run tests/unit/team-pass.test.js tests/unit/premium-entitlements.test.js`