### PR TITLE
Add admin registration form setup

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -260,6 +260,81 @@
             </div>
         </div>
 
+        <div id="registration-forms-modal" class="hidden fixed inset-0 z-50 overflow-y-auto bg-gray-900/50 px-4 py-8">
+            <div class="mx-auto max-w-4xl rounded-xl bg-white shadow-xl">
+                <div class="flex items-start justify-between border-b border-gray-200 p-5">
+                    <div>
+                        <p class="text-sm font-semibold uppercase tracking-wide text-primary-600">Registration setup</p>
+                        <h2 class="text-2xl font-bold text-gray-900"><span id="registration-team-name">Team</span> forms</h2>
+                        <p class="mt-1 text-sm text-gray-600">Create draft or published parent registration links without checkout or roster automation.</p>
+                    </div>
+                    <button onclick="window.closeRegistrationFormsAdmin()" class="rounded px-2 py-1 text-gray-500 hover:bg-gray-100" aria-label="Close registration form setup">✕</button>
+                </div>
+                <div class="grid gap-6 p-5 lg:grid-cols-2">
+                    <section>
+                        <div class="mb-3 flex items-center justify-between">
+                            <h3 class="font-semibold text-gray-900">Existing forms</h3>
+                            <button onclick="window.startRegistrationFormAdmin()" class="rounded bg-primary-600 px-3 py-2 text-sm font-semibold text-white hover:bg-primary-700">New form</button>
+                        </div>
+                        <div id="registration-forms-list" class="space-y-3">
+                            <p class="text-sm text-gray-500">Select a team to load forms.</p>
+                        </div>
+                    </section>
+
+                    <form id="registration-form-editor" class="hidden space-y-4 rounded border border-gray-200 p-4">
+                        <input type="hidden" id="registration-form-id">
+                        <div>
+                            <label for="registration-title" class="block text-sm font-medium text-gray-700">Title</label>
+                            <input id="registration-title" required class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Spring Soccer Registration">
+                        </div>
+                        <div>
+                            <label for="registration-description" class="block text-sm font-medium text-gray-700">Description</label>
+                            <textarea id="registration-description" rows="2" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Who this registration is for and what parents should expect"></textarea>
+                        </div>
+                        <div class="grid gap-4 sm:grid-cols-3">
+                            <div>
+                                <label for="registration-program-type" class="block text-sm font-medium text-gray-700">Program</label>
+                                <select id="registration-program-type" class="mt-1 w-full rounded border border-gray-300 p-2">
+                                    <option value="season">Season</option>
+                                    <option value="camp">Camp</option>
+                                    <option value="team">Team program</option>
+                                </select>
+                            </div>
+                            <div>
+                                <label for="registration-season" class="block text-sm font-medium text-gray-700">Season</label>
+                                <input id="registration-season" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Spring 2026">
+                            </div>
+                            <div>
+                                <label for="registration-fee" class="block text-sm font-medium text-gray-700">Fee amount</label>
+                                <input id="registration-fee" type="number" min="0" step="0.01" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="125.00">
+                            </div>
+                        </div>
+                        <div>
+                            <label for="registration-participant-fields" class="block text-sm font-medium text-gray-700">Participant fields</label>
+                            <textarea id="registration-participant-fields" rows="3" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Participant name&#10;Birthdate"></textarea>
+                            <p class="mt-1 text-xs text-gray-500">One field per line or comma. Fields are required on the public form.</p>
+                        </div>
+                        <div>
+                            <label for="registration-guardian-fields" class="block text-sm font-medium text-gray-700">Guardian fields</label>
+                            <textarea id="registration-guardian-fields" rows="3" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Guardian name&#10;Guardian email&#10;Guardian phone"></textarea>
+                        </div>
+                        <div>
+                            <label for="registration-waiver" class="block text-sm font-medium text-gray-700">Waiver text</label>
+                            <textarea id="registration-waiver" rows="4" required class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Waiver and acknowledgement text parents must accept"></textarea>
+                        </div>
+                        <div>
+                            <label for="registration-status" class="block text-sm font-medium text-gray-700">Status</label>
+                            <select id="registration-status" class="mt-1 w-full rounded border border-gray-300 p-2">
+                                <option value="draft">Save as draft</option>
+                                <option value="published">Publish and show link</option>
+                            </select>
+                        </div>
+                        <p id="registration-form-message" class="text-sm text-gray-600"></p>
+                        <button type="submit" class="w-full rounded bg-primary-600 px-4 py-2 font-semibold text-white hover:bg-primary-700">Save registration form</button>
+                    </form>
+                </div>
+            </div>
+        </div>
     </main>
 
     <div id="footer-container"></div>

--- a/docs/admin-role.md
+++ b/docs/admin-role.md
@@ -2,6 +2,12 @@
 
 Team owners and team admins can manage roster operations for their teams. Global admins retain platform-wide access through the Admin Dashboard.
 
+## Registration form setup
+
+Global admins can open `admin.html`, choose a team, and use **Registration forms** to create or edit season, camp, or team-program forms. Each form stores title, description, program type, season, participant fields, guardian fields, waiver text, fee display amount, and draft/published status under `teams/{teamId}/registrationForms/{formId}`.
+
+Published forms show a copyable `registration.html?teamId=...&formId=...` URL in the admin UI. Draft forms remain editable but are not readable or submittable by parents because public registration reads and pending submission writes require a published form in Firestore rules.
+
 ## Registration review
 
 Registration submissions are reviewed from `edit-roster.html` for the team. Admins can filter a registration form by pending, approved, rejected, or all submissions.

--- a/js/admin-registration-forms.js
+++ b/js/admin-registration-forms.js
@@ -78,7 +78,7 @@ function inferFieldType(label) {
     const normalized = String(label || '').toLowerCase();
     if (normalized.includes('email')) return 'email';
     if (normalized.includes('phone')) return 'tel';
-    if (normalized.includes('birth') || normalized.includes('date')) return 'date';
+    if (/\b(date|birth|dob)\b/.test(normalized) || normalized.includes('birthdate')) return 'date';
     return 'text';
 }
 

--- a/js/admin-registration-forms.js
+++ b/js/admin-registration-forms.js
@@ -1,0 +1,88 @@
+const DEFAULT_PARTICIPANT_LABELS = ['Participant name', 'Birthdate'];
+const DEFAULT_GUARDIAN_LABELS = ['Guardian name', 'Guardian email', 'Guardian phone'];
+
+export function fieldLabelsToDefinitions(labels = [], prefix = 'field') {
+    return labels
+        .map((label) => String(label || '').trim())
+        .filter(Boolean)
+        .map((label, index) => ({
+            id: `${prefix}_${index + 1}`,
+            label,
+            type: inferFieldType(label),
+            required: true,
+            options: []
+        }));
+}
+
+export function parseFieldLabels(value = '') {
+    return String(value || '')
+        .split(/[\n,]+/)
+        .map((label) => label.trim())
+        .filter(Boolean);
+}
+
+export function formatFieldLabels(fields = [], fallbackLabels = []) {
+    const labels = Array.isArray(fields) ? fields.map((field) => field?.label).filter(Boolean) : [];
+    return (labels.length ? labels : fallbackLabels).join('\n');
+}
+
+export function buildAdminRegistrationFormPayload(input = {}, context = {}) {
+    const participantLabels = parseFieldLabels(input.participantFieldsText);
+    const guardianLabels = parseFieldLabels(input.guardianFieldsText);
+    const feeAmount = Number(input.feeAmount || 0);
+    const status = input.status === 'published' ? 'published' : 'draft';
+
+    return {
+        teamId: context.teamId || input.teamId || '',
+        programType: String(input.programType || 'season').trim() || 'season',
+        programName: String(input.title || input.programName || '').trim(),
+        title: String(input.title || input.programName || '').trim(),
+        description: String(input.description || '').trim(),
+        season: String(input.season || '').trim(),
+        feeAmountCents: Math.max(0, Math.round(feeAmount * 100)),
+        currency: 'USD',
+        participantFields: fieldLabelsToDefinitions(
+            participantLabels.length ? participantLabels : DEFAULT_PARTICIPANT_LABELS,
+            'participant'
+        ),
+        guardianFields: fieldLabelsToDefinitions(
+            guardianLabels.length ? guardianLabels : DEFAULT_GUARDIAN_LABELS,
+            'guardian'
+        ),
+        waiverText: String(input.waiverText || '').trim(),
+        status,
+        published: status === 'published'
+    };
+}
+
+export function validateAdminRegistrationFormPayload(payload = {}) {
+    const errors = [];
+    if (!payload.teamId) errors.push('Team is required.');
+    if (!payload.programName) errors.push('Title is required.');
+    if (!payload.waiverText) errors.push('Waiver text is required.');
+    if (!Array.isArray(payload.participantFields) || payload.participantFields.length < 1) {
+        errors.push('At least one participant field is required.');
+    }
+    if (!Array.isArray(payload.guardianFields) || payload.guardianFields.length < 1) {
+        errors.push('At least one guardian field is required.');
+    }
+    return errors;
+}
+
+export function getAdminRegistrationShareUrl(teamId, formId, origin = '') {
+    const base = String(origin || '').replace(/\/$/, '');
+    return `${base}/registration.html?teamId=${encodeURIComponent(teamId)}&formId=${encodeURIComponent(formId)}`;
+}
+
+function inferFieldType(label) {
+    const normalized = String(label || '').toLowerCase();
+    if (normalized.includes('email')) return 'email';
+    if (normalized.includes('phone')) return 'tel';
+    if (normalized.includes('birth') || normalized.includes('date')) return 'date';
+    return 'text';
+}
+
+export const adminRegistrationDefaults = {
+    participantLabels: DEFAULT_PARTICIPANT_LABELS,
+    guardianLabels: DEFAULT_GUARDIAN_LABELS
+};

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,11 +1,21 @@
 import { getTeams, getAllUsers, deleteTeam } from './db.js?v=29';
+import { db, collection, getDocs, doc, setDoc, updateDoc, serverTimestamp } from './firebase.js?v=10';
 import { renderHeader, renderFooter, escapeHtml } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=13';
+import {
+    adminRegistrationDefaults,
+    buildAdminRegistrationFormPayload,
+    formatFieldLabels,
+    getAdminRegistrationShareUrl,
+    validateAdminRegistrationFormPayload
+} from './admin-registration-forms.js?v=1';
 
 let allTeams = [];
 let allUsers = [];
 let currentUser = null; // Declare currentUser
 let showInactiveTeams = false;
+let activeRegistrationTeam = null;
+let activeRegistrationForms = [];
 
 function isTeamActive(team) {
     return team?.active !== false;
@@ -215,6 +225,7 @@ function renderTeams(teams) {
                 ${team.createdAt?.toDate ? team.createdAt.toDate().toLocaleDateString() : '-'}
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                <button onclick="window.openRegistrationFormsAdmin('${team.id}')" class="text-indigo-600 hover:text-indigo-900 mr-4">Registration forms</button>
                 <a href="edit-team.html?teamId=${team.id}" class="text-indigo-600 hover:text-indigo-900 mr-4">Edit</a>
                 <button onclick="window.deleteTeamAdmin('${team.id}', '${escapeHtml(team.name.replace(/'/g, "\\'"))}')" class="text-red-600 hover:text-red-900">Delete</button>
             </td>
@@ -270,6 +281,123 @@ window.deleteTeamAdmin = async function (teamId, teamName) {
     }
 };
 
+window.openRegistrationFormsAdmin = async function (teamId) {
+    activeRegistrationTeam = allTeams.find(team => team.id === teamId) || null;
+    if (!activeRegistrationTeam) return;
+
+    document.getElementById('registration-team-name').textContent = activeRegistrationTeam.name || 'Team';
+    document.getElementById('registration-form-editor').classList.add('hidden');
+    document.getElementById('registration-forms-modal').classList.remove('hidden');
+    await loadRegistrationFormsForActiveTeam();
+};
+
+window.closeRegistrationFormsAdmin = function () {
+    document.getElementById('registration-forms-modal').classList.add('hidden');
+};
+
+window.startRegistrationFormAdmin = function (formId = '') {
+    const form = activeRegistrationForms.find(item => item.id === formId) || {};
+    const editor = document.getElementById('registration-form-editor');
+    document.getElementById('registration-form-id').value = form.id || '';
+    document.getElementById('registration-title').value = form.programName || form.title || '';
+    document.getElementById('registration-description').value = form.description || '';
+    document.getElementById('registration-program-type').value = form.programType || 'season';
+    document.getElementById('registration-season').value = form.season || '';
+    document.getElementById('registration-fee').value = Number(form.feeAmountCents || 0) / 100;
+    document.getElementById('registration-participant-fields').value = formatFieldLabels(form.participantFields, adminRegistrationDefaults.participantLabels);
+    document.getElementById('registration-guardian-fields').value = formatFieldLabels(form.guardianFields, adminRegistrationDefaults.guardianLabels);
+    document.getElementById('registration-waiver').value = form.waiverText || '';
+    document.getElementById('registration-status').value = form.status === 'published' || form.published === true ? 'published' : 'draft';
+    document.getElementById('registration-form-message').textContent = '';
+    editor.classList.remove('hidden');
+};
+
+window.copyRegistrationLinkAdmin = async function (teamId, formId) {
+    const url = getAdminRegistrationShareUrl(teamId, formId, window.location.origin);
+    await navigator.clipboard.writeText(url);
+    document.getElementById('registration-form-message').textContent = 'Registration link copied.';
+};
+
+async function loadRegistrationFormsForActiveTeam() {
+    const list = document.getElementById('registration-forms-list');
+    list.innerHTML = '<p class="text-sm text-gray-500">Loading registration forms...</p>';
+    const snapshot = await getDocs(collection(db, `teams/${activeRegistrationTeam.id}/registrationForms`));
+    activeRegistrationForms = snapshot.docs
+        .map(formDoc => ({ id: formDoc.id, ...formDoc.data() }))
+        .sort((a, b) => String(a.programName || a.title || '').localeCompare(String(b.programName || b.title || '')));
+    renderRegistrationFormsList();
+}
+
+function renderRegistrationFormsList() {
+    const list = document.getElementById('registration-forms-list');
+    if (!activeRegistrationForms.length) {
+        list.innerHTML = '<p class="text-sm text-gray-500">No registration forms yet.</p>';
+        return;
+    }
+
+    list.innerHTML = activeRegistrationForms.map(form => {
+        const published = form.status === 'published' || form.published === true;
+        const link = getAdminRegistrationShareUrl(activeRegistrationTeam.id, form.id, window.location.origin);
+        return `
+            <div class="rounded border border-gray-200 p-3">
+                <div class="flex items-start justify-between gap-3">
+                    <div>
+                        <p class="font-semibold text-gray-900">${escapeHtml(form.programName || form.title || 'Untitled form')}</p>
+                        <p class="text-xs text-gray-500">${escapeHtml(form.programType || 'season')} • ${published ? 'Published' : 'Draft'}</p>
+                    </div>
+                    <button onclick="window.startRegistrationFormAdmin('${form.id}')" class="text-sm text-indigo-600 hover:text-indigo-800">Edit</button>
+                </div>
+                ${published ? `<div class="mt-2 rounded bg-green-50 p-2 text-xs text-green-800 break-all">${escapeHtml(link)} <button onclick="window.copyRegistrationLinkAdmin('${activeRegistrationTeam.id}', '${form.id}')" class="ml-2 font-semibold underline">Copy</button></div>` : '<p class="mt-2 text-xs text-gray-500">Publish to generate a parent-facing registration link.</p>'}
+            </div>
+        `;
+    }).join('');
+}
+
+async function saveRegistrationForm(event) {
+    event.preventDefault();
+    if (!activeRegistrationTeam) return;
+
+    const formId = document.getElementById('registration-form-id').value;
+    const payload = buildAdminRegistrationFormPayload({
+        title: document.getElementById('registration-title').value,
+        description: document.getElementById('registration-description').value,
+        programType: document.getElementById('registration-program-type').value,
+        season: document.getElementById('registration-season').value,
+        feeAmount: document.getElementById('registration-fee').value,
+        participantFieldsText: document.getElementById('registration-participant-fields').value,
+        guardianFieldsText: document.getElementById('registration-guardian-fields').value,
+        waiverText: document.getElementById('registration-waiver').value,
+        status: document.getElementById('registration-status').value
+    }, { teamId: activeRegistrationTeam.id });
+    const errors = validateAdminRegistrationFormPayload(payload);
+    const message = document.getElementById('registration-form-message');
+    if (errors.length) {
+        message.textContent = errors.join(' ');
+        return;
+    }
+
+    if (formId) {
+        await updateDoc(doc(db, `teams/${activeRegistrationTeam.id}/registrationForms`, formId), {
+            ...payload,
+            updatedAt: serverTimestamp(),
+            updatedBy: currentUser.uid
+        });
+    } else {
+        const formRef = doc(collection(db, `teams/${activeRegistrationTeam.id}/registrationForms`));
+        await setDoc(formRef, {
+            ...payload,
+            createdAt: serverTimestamp(),
+            createdBy: currentUser.uid,
+            updatedAt: serverTimestamp(),
+            updatedBy: currentUser.uid
+        });
+    }
+
+    message.textContent = payload.published ? 'Registration form saved and published.' : 'Registration form saved as draft.';
+    await loadRegistrationFormsForActiveTeam();
+    document.getElementById('registration-form-editor').classList.add('hidden');
+}
+
 function setupTabs() {
     const tabs = ['dashboard', 'teams', 'users'];
     tabs.forEach(tab => {
@@ -293,6 +421,8 @@ function setupTabs() {
 }
 
 function setupSearch() {
+    document.getElementById('registration-form-editor').addEventListener('submit', saveRegistrationForm);
+
     const inactiveToggle = document.getElementById('filter-inactive-teams');
     if (inactiveToggle) {
         inactiveToggle.addEventListener('change', (e) => {

--- a/js/admin.js
+++ b/js/admin.js
@@ -17,6 +17,10 @@ let showInactiveTeams = false;
 let activeRegistrationTeam = null;
 let activeRegistrationForms = [];
 
+function inlineJsString(value) {
+    return escapeHtml(JSON.stringify(String(value || '')));
+}
+
 function isTeamActive(team) {
     return team?.active !== false;
 }
@@ -225,9 +229,9 @@ function renderTeams(teams) {
                 ${team.createdAt?.toDate ? team.createdAt.toDate().toLocaleDateString() : '-'}
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
-                <button onclick="window.openRegistrationFormsAdmin('${team.id}')" class="text-indigo-600 hover:text-indigo-900 mr-4">Registration forms</button>
+                <button onclick="window.openRegistrationFormsAdmin(${inlineJsString(team.id)})" class="text-indigo-600 hover:text-indigo-900 mr-4">Registration forms</button>
                 <a href="edit-team.html?teamId=${team.id}" class="text-indigo-600 hover:text-indigo-900 mr-4">Edit</a>
-                <button onclick="window.deleteTeamAdmin('${team.id}', '${escapeHtml(team.name.replace(/'/g, "\\'"))}')" class="text-red-600 hover:text-red-900">Delete</button>
+                <button onclick="window.deleteTeamAdmin(${inlineJsString(team.id)}, ${inlineJsString(team.name)})" class="text-red-600 hover:text-red-900">Delete</button>
             </td>
         </tr>
     `).join('');
@@ -314,18 +318,37 @@ window.startRegistrationFormAdmin = function (formId = '') {
 
 window.copyRegistrationLinkAdmin = async function (teamId, formId) {
     const url = getAdminRegistrationShareUrl(teamId, formId, window.location.origin);
-    await navigator.clipboard.writeText(url);
-    document.getElementById('registration-form-message').textContent = 'Registration link copied.';
+    const message = document.getElementById('registration-form-message');
+    try {
+        await navigator.clipboard.writeText(url);
+        message.textContent = 'Registration link copied.';
+    } catch (error) {
+        console.error('Failed to copy registration link:', error);
+        message.textContent = `Unable to copy automatically. Use this link: ${url}`;
+    }
 };
 
 async function loadRegistrationFormsForActiveTeam() {
+    const team = activeRegistrationTeam;
+    const teamId = team?.id;
+    if (!teamId) return;
+
     const list = document.getElementById('registration-forms-list');
     list.innerHTML = '<p class="text-sm text-gray-500">Loading registration forms...</p>';
-    const snapshot = await getDocs(collection(db, `teams/${activeRegistrationTeam.id}/registrationForms`));
-    activeRegistrationForms = snapshot.docs
-        .map(formDoc => ({ id: formDoc.id, ...formDoc.data() }))
-        .sort((a, b) => String(a.programName || a.title || '').localeCompare(String(b.programName || b.title || '')));
-    renderRegistrationFormsList();
+    try {
+        const snapshot = await getDocs(collection(db, `teams/${teamId}/registrationForms`));
+        if (activeRegistrationTeam?.id !== teamId) return;
+
+        activeRegistrationForms = snapshot.docs
+            .map(formDoc => ({ id: formDoc.id, ...formDoc.data() }))
+            .sort((a, b) => String(a.programName || a.title || '').localeCompare(String(b.programName || b.title || '')));
+        renderRegistrationFormsList();
+    } catch (error) {
+        console.error('Error loading registration forms:', error);
+        if (activeRegistrationTeam?.id === teamId) {
+            list.innerHTML = '<p class="text-sm text-red-600">Failed to load registration forms. Please try again.</p>';
+        }
+    }
 }
 
 function renderRegistrationFormsList() {
@@ -338,6 +361,8 @@ function renderRegistrationFormsList() {
     list.innerHTML = activeRegistrationForms.map(form => {
         const published = form.status === 'published' || form.published === true;
         const link = getAdminRegistrationShareUrl(activeRegistrationTeam.id, form.id, window.location.origin);
+        const teamIdArg = inlineJsString(activeRegistrationTeam.id);
+        const formIdArg = inlineJsString(form.id);
         return `
             <div class="rounded border border-gray-200 p-3">
                 <div class="flex items-start justify-between gap-3">
@@ -345,9 +370,9 @@ function renderRegistrationFormsList() {
                         <p class="font-semibold text-gray-900">${escapeHtml(form.programName || form.title || 'Untitled form')}</p>
                         <p class="text-xs text-gray-500">${escapeHtml(form.programType || 'season')} • ${published ? 'Published' : 'Draft'}</p>
                     </div>
-                    <button onclick="window.startRegistrationFormAdmin('${form.id}')" class="text-sm text-indigo-600 hover:text-indigo-800">Edit</button>
+                    <button onclick="window.startRegistrationFormAdmin(${formIdArg})" class="text-sm text-indigo-600 hover:text-indigo-800">Edit</button>
                 </div>
-                ${published ? `<div class="mt-2 rounded bg-green-50 p-2 text-xs text-green-800 break-all">${escapeHtml(link)} <button onclick="window.copyRegistrationLinkAdmin('${activeRegistrationTeam.id}', '${form.id}')" class="ml-2 font-semibold underline">Copy</button></div>` : '<p class="mt-2 text-xs text-gray-500">Publish to generate a parent-facing registration link.</p>'}
+                ${published ? `<div class="mt-2 rounded bg-green-50 p-2 text-xs text-green-800 break-all">${escapeHtml(link)} <button onclick="window.copyRegistrationLinkAdmin(${teamIdArg}, ${formIdArg})" class="ml-2 font-semibold underline">Copy</button></div>` : '<p class="mt-2 text-xs text-gray-500">Publish to generate a parent-facing registration link.</p>'}
             </div>
         `;
     }).join('');
@@ -357,6 +382,7 @@ async function saveRegistrationForm(event) {
     event.preventDefault();
     if (!activeRegistrationTeam) return;
 
+    const teamId = activeRegistrationTeam.id;
     const formId = document.getElementById('registration-form-id').value;
     const payload = buildAdminRegistrationFormPayload({
         title: document.getElementById('registration-title').value,
@@ -368,7 +394,7 @@ async function saveRegistrationForm(event) {
         guardianFieldsText: document.getElementById('registration-guardian-fields').value,
         waiverText: document.getElementById('registration-waiver').value,
         status: document.getElementById('registration-status').value
-    }, { teamId: activeRegistrationTeam.id });
+    }, { teamId });
     const errors = validateAdminRegistrationFormPayload(payload);
     const message = document.getElementById('registration-form-message');
     if (errors.length) {
@@ -376,26 +402,34 @@ async function saveRegistrationForm(event) {
         return;
     }
 
-    if (formId) {
-        await updateDoc(doc(db, `teams/${activeRegistrationTeam.id}/registrationForms`, formId), {
-            ...payload,
-            updatedAt: serverTimestamp(),
-            updatedBy: currentUser.uid
-        });
-    } else {
-        const formRef = doc(collection(db, `teams/${activeRegistrationTeam.id}/registrationForms`));
-        await setDoc(formRef, {
-            ...payload,
-            createdAt: serverTimestamp(),
-            createdBy: currentUser.uid,
-            updatedAt: serverTimestamp(),
-            updatedBy: currentUser.uid
-        });
+    try {
+        if (formId) {
+            await updateDoc(doc(db, `teams/${teamId}/registrationForms`, formId), {
+                ...payload,
+                updatedAt: serverTimestamp(),
+                updatedBy: currentUser.uid
+            });
+        } else {
+            const formRef = doc(collection(db, `teams/${teamId}/registrationForms`));
+            await setDoc(formRef, {
+                ...payload,
+                createdAt: serverTimestamp(),
+                createdBy: currentUser.uid,
+                updatedAt: serverTimestamp(),
+                updatedBy: currentUser.uid
+            });
+        }
+    } catch (error) {
+        console.error('Error saving registration form:', error);
+        message.textContent = 'Failed to save registration form. Please try again.';
+        return;
     }
 
     message.textContent = payload.published ? 'Registration form saved and published.' : 'Registration form saved as draft.';
-    await loadRegistrationFormsForActiveTeam();
-    document.getElementById('registration-form-editor').classList.add('hidden');
+    if (activeRegistrationTeam?.id === teamId) {
+        await loadRegistrationFormsForActiveTeam();
+        document.getElementById('registration-form-editor').classList.add('hidden');
+    }
 }
 
 function setupTabs() {

--- a/tests/unit/admin-registration-forms.test.js
+++ b/tests/unit/admin-registration-forms.test.js
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import {
+    buildAdminRegistrationFormPayload,
+    getAdminRegistrationShareUrl,
+    validateAdminRegistrationFormPayload
+} from '../../js/admin-registration-forms.js';
+
+describe('admin registration form setup', () => {
+    it('builds draft and published form payloads with metadata, fields, waiver, and fee', () => {
+        const payload = buildAdminRegistrationFormPayload({
+            title: 'Spring Soccer',
+            description: 'Season registration',
+            programType: 'season',
+            season: 'Spring 2026',
+            feeAmount: '125.50',
+            participantFieldsText: 'Player name\nBirthdate',
+            guardianFieldsText: 'Guardian name, Guardian email, Guardian phone',
+            waiverText: 'I accept the risk.',
+            status: 'published'
+        }, { teamId: 'team-1' });
+
+        expect(payload).toMatchObject({
+            teamId: 'team-1',
+            programName: 'Spring Soccer',
+            title: 'Spring Soccer',
+            description: 'Season registration',
+            programType: 'season',
+            season: 'Spring 2026',
+            feeAmountCents: 12550,
+            currency: 'USD',
+            waiverText: 'I accept the risk.',
+            status: 'published',
+            published: true
+        });
+        expect(payload.participantFields).toEqual([
+            { id: 'participant_1', label: 'Player name', type: 'text', required: true, options: [] },
+            { id: 'participant_2', label: 'Birthdate', type: 'date', required: true, options: [] }
+        ]);
+        expect(payload.guardianFields[1]).toMatchObject({ label: 'Guardian email', type: 'email', required: true });
+        expect(validateAdminRegistrationFormPayload(payload)).toEqual([]);
+    });
+
+    it('keeps unpublished forms as drafts and validates required admin setup', () => {
+        const payload = buildAdminRegistrationFormPayload({
+            title: '',
+            waiverText: '',
+            status: 'draft'
+        }, { teamId: 'team-1' });
+
+        expect(payload.status).toBe('draft');
+        expect(payload.published).toBe(false);
+        expect(validateAdminRegistrationFormPayload(payload)).toEqual([
+            'Title is required.',
+            'Waiver text is required.'
+        ]);
+    });
+
+    it('creates a shareable public registration URL for published forms', () => {
+        expect(getAdminRegistrationShareUrl('team 1', 'form/2', 'https://allplays.example')).toBe(
+            'https://allplays.example/registration.html?teamId=team%201&formId=form%2F2'
+        );
+    });
+
+    it('wires the admin dashboard to create, edit, publish, and copy registration links', () => {
+        const adminPage = fs.readFileSync('admin.html', 'utf8');
+        const adminJs = fs.readFileSync('js/admin.js', 'utf8');
+
+        expect(adminPage).toContain('registration-forms-modal');
+        expect(adminPage).toContain('registration-participant-fields');
+        expect(adminPage).toContain('registration-guardian-fields');
+        expect(adminPage).toContain('registration-waiver');
+        expect(adminPage).toContain('Publish and show link');
+        expect(adminJs).toContain('window.openRegistrationFormsAdmin');
+        expect(adminJs).toContain('teams/${activeRegistrationTeam.id}/registrationForms');
+        expect(adminJs).toContain('setDoc(formRef');
+        expect(adminJs).toContain('updateDoc(doc(db, `teams/${activeRegistrationTeam.id}/registrationForms`, formId)');
+        expect(adminJs).toContain('copyRegistrationLinkAdmin');
+    });
+});

--- a/tests/unit/admin-registration-forms.test.js
+++ b/tests/unit/admin-registration-forms.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import fs from 'node:fs';
 import {
     buildAdminRegistrationFormPayload,
+    fieldLabelsToDefinitions,
     getAdminRegistrationShareUrl,
     validateAdminRegistrationFormPayload
 } from '../../js/admin-registration-forms.js';
@@ -62,6 +63,15 @@ describe('admin registration form setup', () => {
         );
     });
 
+    it('infers date inputs only from date-specific labels', () => {
+        expect(fieldLabelsToDefinitions(['Birthdate', 'Start date', 'Update notes', 'Candidate info'])).toEqual([
+            { id: 'field_1', label: 'Birthdate', type: 'date', required: true, options: [] },
+            { id: 'field_2', label: 'Start date', type: 'date', required: true, options: [] },
+            { id: 'field_3', label: 'Update notes', type: 'text', required: true, options: [] },
+            { id: 'field_4', label: 'Candidate info', type: 'text', required: true, options: [] }
+        ]);
+    });
+
     it('wires the admin dashboard to create, edit, publish, and copy registration links', () => {
         const adminPage = fs.readFileSync('admin.html', 'utf8');
         const adminJs = fs.readFileSync('js/admin.js', 'utf8');
@@ -72,9 +82,13 @@ describe('admin registration form setup', () => {
         expect(adminPage).toContain('registration-waiver');
         expect(adminPage).toContain('Publish and show link');
         expect(adminJs).toContain('window.openRegistrationFormsAdmin');
-        expect(adminJs).toContain('teams/${activeRegistrationTeam.id}/registrationForms');
+        expect(adminJs).toContain('const teamId = activeRegistrationTeam.id;');
+        expect(adminJs).toContain('if (activeRegistrationTeam?.id !== teamId) return;');
+        expect(adminJs).toContain('teams/${teamId}/registrationForms');
         expect(adminJs).toContain('setDoc(formRef');
-        expect(adminJs).toContain('updateDoc(doc(db, `teams/${activeRegistrationTeam.id}/registrationForms`, formId)');
+        expect(adminJs).toContain('updateDoc(doc(db, `teams/${teamId}/registrationForms`, formId)');
+        expect(adminJs).toContain('try {');
+        expect(adminJs).toContain('inlineJsString');
         expect(adminJs).toContain('copyRegistrationLinkAdmin');
     });
 });


### PR DESCRIPTION
Closes #718

## Summary
- Adds an admin dashboard modal for creating and editing team registration forms.
- Supports form metadata, program type, participant and guardian fields, waiver text, fee display amount, draft/published status, and copyable published links.
- Documents the setup workflow and adds unit coverage for payload generation, validation, share URLs, and admin UI wiring.

## Validation
- `npm test -- --run tests/unit/admin-registration-forms.test.js`
- `node --check js/admin.js && node --check js/admin-registration-forms.js`