### PR TITLE
Add roster CSV import

### DIFF
--- a/docs/pr-notes/runs/755-pr-issue-comment-4389600553-20260506T153110Z/architecture.md
+++ b/docs/pr-notes/runs/755-pr-issue-comment-4389600553-20260506T153110Z/architecture.md
@@ -1,0 +1,11 @@
+# Architecture
+
+Decision: make `planRosterCsvImport` patch-like for the optional core `number` field.
+
+- Detect whether the CSV mapped a Number/Jersey column.
+- Build player payloads without `number` by default.
+- Add `payload.number` only when the CSV includes a mapped number column.
+- Firestore update payloads then preserve existing player numbers for partial CSV imports.
+
+Blast radius: one static JS module and one unit regression. No Firestore rules, schema migration, or backend changes.
+Rollback: revert the conditional payload inclusion and regression test.

--- a/docs/pr-notes/runs/755-pr-issue-comment-4389600553-20260506T153110Z/code-plan.md
+++ b/docs/pr-notes/runs/755-pr-issue-comment-4389600553-20260506T153110Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code Plan
+
+- In `js/roster-profile-fields.js`, compute `hasNumberColumn` from mapped CSV headers.
+- Keep parsing number values from mapped number columns.
+- Change payload construction from always including `number` to conditionally including it only when `hasNumberColumn` is true.
+- Add unit coverage in `tests/unit/roster-csv-import.test.js` for omitted Number header preserving existing jersey numbers.

--- a/docs/pr-notes/runs/755-pr-issue-comment-4389600553-20260506T153110Z/qa.md
+++ b/docs/pr-notes/runs/755-pr-issue-comment-4389600553-20260506T153110Z/qa.md
@@ -1,0 +1,13 @@
+# QA Plan
+
+Automated checks:
+
+- Regression: existing matched player with number `3`, CSV `Name,Grade`, update payload must not include `number` and grade still updates.
+- Existing coverage: CSV with `Number` header still updates number to the provided value.
+- Existing coverage: admin-only fields still split into private roster fields.
+
+Manual impacted workflows:
+
+- Coach/admin imports profile-only CSV for an existing roster member. Expected: profile changes apply and jersey number remains unchanged.
+- Coach/admin imports CSV with Number column. Expected: jersey number updates intentionally.
+- Coach/admin imports new player without Number column. Expected: player is created without a jersey number.

--- a/docs/pr-notes/runs/755-pr-issue-comment-4389600553-20260506T153110Z/requirements.md
+++ b/docs/pr-notes/runs/755-pr-issue-comment-4389600553-20260506T153110Z/requirements.md
@@ -1,0 +1,7 @@
+# Requirements
+
+- Preserve existing jersey numbers when matched-player CSV updates omit the Number header.
+- Continue to update jersey numbers when a Number/Jersey header is present.
+- Treat omitted optional fields as no-change for existing players.
+- Allow new players without a Number header to be created without a number value.
+- Keep the fix limited to roster CSV import planning. No permissions or roster visibility changes.

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -69,6 +69,9 @@
                         <button id="tab-add-player" class="flex-1 px-4 py-3 text-sm font-medium text-indigo-600 border-b-2 border-indigo-600 bg-indigo-50">
                             Add Player
                         </button>
+                        <button id="tab-csv-import" class="flex-1 px-4 py-3 text-sm font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-50">
+                            CSV Import
+                        </button>
                         <button id="tab-bulk-ai" class="flex-1 px-4 py-3 text-sm font-medium text-gray-600 hover:text-gray-800 hover:bg-gray-50">
                             ✨ Bulk AI Update
                         </button>
@@ -114,6 +117,31 @@
                             class="w-full bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700 transition">Add
                             Player</button>
                     </form>
+                    </div>
+
+                    <!-- CSV Import Tab Content -->
+                    <div id="content-csv-import" class="p-6 hidden">
+                        <div class="mb-3">
+                            <h2 class="text-xl font-bold">CSV Roster Import</h2>
+                            <p class="text-sm text-gray-600">Upload or paste a CSV with Name, Number, and roster field label/key columns. Unknown headers and invalid field values are rejected before anything is saved.</p>
+                        </div>
+
+                        <div class="space-y-4">
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-2">Upload CSV (optional)</label>
+                                <input type="file" id="roster-csv-file" accept=".csv,text/csv"
+                                    class="w-full text-sm text-gray-600 file:mr-4 file:py-2 file:px-4 file:rounded-md file:border-0 file:text-sm file:font-semibold file:bg-indigo-50 file:text-indigo-700 hover:file:bg-indigo-100">
+                            </div>
+                            <div>
+                                <label class="block text-sm font-medium text-gray-700 mb-2">CSV data</label>
+                                <textarea id="roster-csv-input" rows="8"
+                                    class="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:border-indigo-500 focus:ring-indigo-500 text-sm font-mono"
+                                    placeholder="Name,Number,Grade,Throws Right&#10;Avery Lee,4,6,yes"></textarea>
+                            </div>
+                            <button id="import-csv-btn" type="button"
+                                class="w-full bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700 transition">Import CSV</button>
+                            <div id="csv-import-status" class="hidden rounded-md border p-3 text-sm"></div>
+                        </div>
                     </div>
 
                     <!-- Bulk AI Update Tab Content -->
@@ -452,8 +480,8 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getPlayers, addPlayer, deactivatePlayer, reactivatePlayer, getGames, uploadPlayerPhoto, updatePlayer, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount, listTeamParentMembershipRequests, approveParentMembershipRequest, denyParentMembershipRequest, getRosterFieldDefinitions, saveRosterFieldDefinition, disableRosterFieldDefinition, reorderRosterFieldDefinitions, listTeamRegistrationForms, listTeamRegistrationReviews, approveTeamRegistration, rejectTeamRegistration } from './js/db.js?v=29';
-        import { buildRosterFieldDefinitionPayload, collectRosterProfileValues, getRosterProfileValues, normalizeRosterFieldDefinitions, renderRosterProfileFields, validateRosterProfileValues } from './js/roster-profile-fields.js?v=2';
+        import { getTeam, getPlayers, addPlayer, deactivatePlayer, reactivatePlayer, getGames, uploadPlayerPhoto, updatePlayer, setPlayerPrivateRosterProfileFields, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount, listTeamParentMembershipRequests, approveParentMembershipRequest, denyParentMembershipRequest, getRosterFieldDefinitions, saveRosterFieldDefinition, disableRosterFieldDefinition, reorderRosterFieldDefinitions, listTeamRegistrationForms, listTeamRegistrationReviews, approveTeamRegistration, rejectTeamRegistration } from './js/db.js?v=30';
+        import { buildRosterFieldDefinitionPayload, collectRosterProfileValues, getRosterProfileValues, normalizeRosterFieldDefinitions, planRosterCsvImport, renderRosterProfileFields, validateRosterProfileValues } from './js/roster-profile-fields.js?v=3';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth, sendInviteEmail } from './js/auth.js?v=13';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
@@ -1152,14 +1180,82 @@
             renderRosterProfileFields(document.getElementById('roster-profile-fields'), rosterFieldDefinitions);
         }
 
+        function activateRosterTab(tabName) {
+            ['add-player', 'csv-import', 'bulk-ai'].forEach((name) => {
+                const tab = document.getElementById(`tab-${name}`);
+                const content = document.getElementById(`content-${name}`);
+                const active = name === tabName;
+                tab.classList.toggle('text-indigo-600', active);
+                tab.classList.toggle('border-b-2', active);
+                tab.classList.toggle('border-indigo-600', active);
+                tab.classList.toggle('bg-indigo-50', active);
+                tab.classList.toggle('text-gray-600', !active);
+                content.classList.toggle('hidden', !active);
+            });
+        }
+
+        function renderCsvImportStatus(messages = [], tone = 'info') {
+            const status = document.getElementById('csv-import-status');
+            if (!status) return;
+            status.classList.remove('hidden', 'border-red-200', 'bg-red-50', 'text-red-800', 'border-green-200', 'bg-green-50', 'text-green-800', 'border-gray-200', 'bg-gray-50', 'text-gray-800');
+            const classes = tone === 'error'
+                ? ['border-red-200', 'bg-red-50', 'text-red-800']
+                : tone === 'success'
+                    ? ['border-green-200', 'bg-green-50', 'text-green-800']
+                    : ['border-gray-200', 'bg-gray-50', 'text-gray-800'];
+            status.classList.add(...classes);
+            status.innerHTML = Array.isArray(messages)
+                ? `<ul class="list-disc pl-5 space-y-1">${messages.map((message) => `<li>${escapeHtml(message)}</li>`).join('')}</ul>`
+                : escapeHtml(String(messages || ''));
+        }
+
+        async function handleRosterCsvImport() {
+            const csvText = document.getElementById('roster-csv-input').value;
+            const button = document.getElementById('import-csv-btn');
+            const currentPlayers = await getPlayers(currentTeamId, { includeInactive: true });
+            const plan = planRosterCsvImport({
+                csvText,
+                fields: rosterFieldDefinitions,
+                existingPlayers: currentPlayers
+            });
+
+            if (plan.errors.length) {
+                renderCsvImportStatus(plan.errors, 'error');
+                return;
+            }
+            if (plan.operations.length === 0) {
+                renderCsvImportStatus('No CSV rows to import.', 'info');
+                return;
+            }
+            if (!confirm(`Import ${plan.operations.length} player row${plan.operations.length === 1 ? '' : 's'}?`)) return;
+
+            try {
+                button.disabled = true;
+                button.textContent = 'Importing...';
+                for (const operation of plan.operations) {
+                    let playerId = operation.playerId;
+                    if (operation.type === 'update') {
+                        await updatePlayer(currentTeamId, playerId, operation.payload);
+                    } else {
+                        playerId = await addPlayer(currentTeamId, operation.payload);
+                    }
+                    if (operation.privateRosterFields) {
+                        await setPlayerPrivateRosterProfileFields(currentTeamId, playerId, operation.privateRosterFields);
+                    }
+                }
+                renderCsvImportStatus(`Imported ${plan.operations.length} player row${plan.operations.length === 1 ? '' : 's'}.`, 'success');
+                await loadRoster();
+            } catch (error) {
+                console.error('CSV roster import failed:', error);
+                renderCsvImportStatus(error?.message || 'CSV roster import failed.', 'error');
+            } finally {
+                button.disabled = false;
+                button.textContent = 'Import CSV';
+            }
+        }
+
         function startEditPlayer(player) {
-            // Switch to Add Player tab
-            document.getElementById('tab-add-player').classList.add('text-indigo-600', 'border-b-2', 'border-indigo-600', 'bg-indigo-50');
-            document.getElementById('tab-add-player').classList.remove('text-gray-600');
-            document.getElementById('tab-bulk-ai').classList.remove('text-indigo-600', 'border-b-2', 'border-indigo-600', 'bg-indigo-50');
-            document.getElementById('tab-bulk-ai').classList.add('text-gray-600');
-            document.getElementById('content-add-player').classList.remove('hidden');
-            document.getElementById('content-bulk-ai').classList.add('hidden');
+            activateRosterTab('add-player');
 
             editingPlayerId = player.id;
             editingPhotoUrl = player.photoUrl || null;
@@ -1292,29 +1388,16 @@
         let proposedOperations = [];
 
         // Tab switching
-        document.getElementById('tab-add-player').addEventListener('click', () => {
-            // Update tab styles
-            document.getElementById('tab-add-player').classList.add('text-indigo-600', 'border-b-2', 'border-indigo-600', 'bg-indigo-50');
-            document.getElementById('tab-add-player').classList.remove('text-gray-600');
-            document.getElementById('tab-bulk-ai').classList.remove('text-indigo-600', 'border-b-2', 'border-indigo-600', 'bg-indigo-50');
-            document.getElementById('tab-bulk-ai').classList.add('text-gray-600');
+        document.getElementById('tab-add-player').addEventListener('click', () => activateRosterTab('add-player'));
+        document.getElementById('tab-csv-import').addEventListener('click', () => activateRosterTab('csv-import'));
+        document.getElementById('tab-bulk-ai').addEventListener('click', () => activateRosterTab('bulk-ai'));
 
-            // Show/hide content
-            document.getElementById('content-add-player').classList.remove('hidden');
-            document.getElementById('content-bulk-ai').classList.add('hidden');
+        document.getElementById('roster-csv-file').addEventListener('change', async (e) => {
+            const file = e.target.files[0];
+            if (!file) return;
+            document.getElementById('roster-csv-input').value = await file.text();
         });
-
-        document.getElementById('tab-bulk-ai').addEventListener('click', () => {
-            // Update tab styles
-            document.getElementById('tab-bulk-ai').classList.add('text-indigo-600', 'border-b-2', 'border-indigo-600', 'bg-indigo-50');
-            document.getElementById('tab-bulk-ai').classList.remove('text-gray-600');
-            document.getElementById('tab-add-player').classList.remove('text-indigo-600', 'border-b-2', 'border-indigo-600', 'bg-indigo-50');
-            document.getElementById('tab-add-player').classList.add('text-gray-600');
-
-            // Show/hide content
-            document.getElementById('content-bulk-ai').classList.remove('hidden');
-            document.getElementById('content-add-player').classList.add('hidden');
-        });
+        document.getElementById('import-csv-btn').addEventListener('click', () => handleRosterCsvImport());
 
         // Image preview handler
         document.getElementById('roster-image-input').addEventListener('change', (e) => {

--- a/js/db.js
+++ b/js/db.js
@@ -896,6 +896,13 @@ export async function updatePlayer(teamId, playerId, playerData) {
     await updateDoc(doc(db, `teams/${teamId}/players`, playerId), playerData);
 }
 
+export async function setPlayerPrivateRosterProfileFields(teamId, playerId, rosterFields = {}) {
+    await setDoc(doc(db, `teams/${teamId}/players/${playerId}/private/profile`), {
+        rosterFields,
+        updatedAt: Timestamp.now()
+    }, { merge: true });
+}
+
 export async function deletePlayer(teamId, playerId) {
     await updateDoc(doc(db, `teams/${teamId}/players`, playerId), {
         active: false,

--- a/js/roster-profile-fields.js
+++ b/js/roster-profile-fields.js
@@ -86,11 +86,19 @@ export function getRosterProfileValues(player = {}) {
 export function validateRosterProfileValues(fields = [], values = {}) {
     const errors = [];
     fields.forEach((field) => {
-        if (!field.required) return;
         const value = values?.[field.key];
         const missing = field.type === 'checkbox' ? value !== true : String(value ?? '').trim() === '';
-        if (missing) {
+        if (field.required && missing) {
             errors.push(`${field.label} is required.`);
+            return;
+        }
+        if (missing) return;
+        if (field.type === 'menu' && (field.options || []).length > 0) {
+            const valid = (field.options || []).some((option) => String(option.value) === String(value));
+            if (!valid) errors.push(`${field.label} must be one of the configured options.`);
+        }
+        if (field.type === 'date' && !/^\d{4}-\d{2}-\d{2}$/.test(String(value))) {
+            errors.push(`${field.label} must use YYYY-MM-DD format.`);
         }
     });
     return errors;
@@ -110,6 +118,236 @@ export function collectRosterProfileValues(container, fields = []) {
         values[field.key] = coerceRosterProfileValue(field, field.type === 'checkbox' ? input.checked : input.value);
     });
     return values;
+}
+
+
+function normalizeHeaderKey(value) {
+    return String(value || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '');
+}
+
+function parseCsvRows(csvText = '') {
+    const rows = [];
+    let row = [];
+    let cell = '';
+    let inQuotes = false;
+    const text = String(csvText || '').replace(/^\uFEFF/, '');
+
+    for (let i = 0; i < text.length; i += 1) {
+        const char = text[i];
+        const next = text[i + 1];
+        if (char === '"') {
+            if (inQuotes && next === '"') {
+                cell += '"';
+                i += 1;
+            } else {
+                inQuotes = !inQuotes;
+            }
+        } else if (char === ',' && !inQuotes) {
+            row.push(cell);
+            cell = '';
+        } else if ((char === '\n' || char === '\r') && !inQuotes) {
+            if (char === '\r' && next === '\n') i += 1;
+            row.push(cell);
+            if (row.some((value) => String(value || '').trim() !== '')) rows.push(row);
+            row = [];
+            cell = '';
+        } else {
+            cell += char;
+        }
+    }
+
+    row.push(cell);
+    if (row.some((value) => String(value || '').trim() !== '')) rows.push(row);
+    return rows;
+}
+
+function parseCheckboxValue(value) {
+    const normalized = String(value ?? '').trim().toLowerCase();
+    if (normalized === '') return false;
+    if (['true', 'yes', 'y', '1', 'checked', 'x'].includes(normalized)) return true;
+    if (['false', 'no', 'n', '0', 'unchecked'].includes(normalized)) return false;
+    return null;
+}
+
+function parseRosterCsvFieldValue(field, rawValue) {
+    const value = String(rawValue ?? '').trim();
+    if (value === '') return { value: field.type === 'checkbox' ? false : '' };
+
+    if (field.type === 'checkbox') {
+        const parsed = parseCheckboxValue(value);
+        if (parsed === null) return { error: `${field.label} must be yes/no.` };
+        return { value: parsed };
+    }
+
+    if (field.type === 'date') {
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return { error: `${field.label} must use YYYY-MM-DD format.` };
+        const date = new Date(`${value}T00:00:00Z`);
+        if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== value) {
+            return { error: `${field.label} must be a valid date.` };
+        }
+        return { value };
+    }
+
+    if (field.type === 'menu') {
+        const option = (field.options || []).find((item) =>
+            String(item.value || '').trim().toLowerCase() === value.toLowerCase() ||
+            String(item.label || '').trim().toLowerCase() === value.toLowerCase()
+        );
+        if (!option) {
+            const choices = (field.options || []).map((item) => item.label || item.value).filter(Boolean).join(', ');
+            return { error: `${field.label} must be one of: ${choices}.` };
+        }
+        return { value: option.value };
+    }
+
+    return { value };
+}
+
+function isAdminOnlyRosterField(field = {}) {
+    const visibility = String(field.visibility || '').trim().toLowerCase();
+    return ['admin', 'admins', 'private', 'restricted'].includes(visibility);
+}
+
+export function splitRosterProfileValuesByVisibility(fields = [], values = {}) {
+    const publicValues = {};
+    const privateValues = {};
+    fields.forEach((field) => {
+        if (!Object.prototype.hasOwnProperty.call(values || {}, field.key)) return;
+        if (isAdminOnlyRosterField(field)) {
+            privateValues[field.key] = values[field.key];
+        } else {
+            publicValues[field.key] = values[field.key];
+        }
+    });
+    return { publicValues, privateValues };
+}
+
+function getExistingPlayersByName(existingPlayers = []) {
+    const byName = new Map();
+    existingPlayers.forEach((player) => {
+        const key = String(player?.name || '').trim().toLowerCase();
+        if (!key) return;
+        if (!byName.has(key)) byName.set(key, []);
+        byName.get(key).push(player);
+    });
+    return byName;
+}
+
+export function planRosterCsvImport({ csvText = '', fields = [], existingPlayers = [] } = {}) {
+    const errors = [];
+    const normalizedFields = normalizeRosterFieldDefinitions(fields);
+    const rows = parseCsvRows(csvText);
+    if (rows.length === 0) return { errors: ['CSV is empty.'], operations: [] };
+
+    const headers = rows[0].map((header) => String(header || '').trim());
+    const fieldByHeader = new Map();
+    normalizedFields.forEach((field) => {
+        fieldByHeader.set(normalizeHeaderKey(field.key), field);
+        fieldByHeader.set(normalizeHeaderKey(field.label), field);
+    });
+
+    const coreAliases = new Map([
+        ['name', 'name'],
+        ['player', 'name'],
+        ['playername', 'name'],
+        ['athlete', 'name'],
+        ['athletename', 'name'],
+        ['number', 'number'],
+        ['jersey', 'number'],
+        ['jerseynumber', 'number'],
+        ['uniformnumber', 'number'],
+        ['no', 'number']
+    ]);
+
+    const mappings = headers.map((header, index) => {
+        const normalized = normalizeHeaderKey(header);
+        if (!normalized) return { index, type: 'blank' };
+        const core = coreAliases.get(normalized);
+        if (core) return { index, type: core, label: header };
+        const field = fieldByHeader.get(normalized);
+        if (field) return { index, type: 'field', field, label: header };
+        return { index, type: 'unknown', label: header };
+    });
+
+    if (!mappings.some((mapping) => mapping.type === 'name')) {
+        errors.push('CSV must include a player name header.');
+    }
+
+    const seenTypes = new Set();
+    const seenFields = new Set();
+    mappings.forEach((mapping) => {
+        if (mapping.type === 'unknown') {
+            errors.push(`Unknown CSV header "${mapping.label}". Use Name, Number, or a configured roster field label/key.`);
+        } else if (mapping.type === 'name' || mapping.type === 'number') {
+            if (seenTypes.has(mapping.type)) errors.push(`Duplicate ${mapping.type === 'name' ? 'name' : 'number'} header.`);
+            seenTypes.add(mapping.type);
+        } else if (mapping.type === 'field') {
+            if (seenFields.has(mapping.field.key)) errors.push(`Duplicate roster field header for ${mapping.field.label}.`);
+            seenFields.add(mapping.field.key);
+        }
+    });
+
+    if (errors.length) return { errors, operations: [] };
+
+    const existingByName = getExistingPlayersByName(existingPlayers);
+    const operations = [];
+    rows.slice(1).forEach((row, rowIndex) => {
+        const rowNumber = rowIndex + 2;
+        if (!row.some((value) => String(value || '').trim() !== '')) return;
+
+        const values = {};
+        let name = '';
+        let number = '';
+        mappings.forEach((mapping) => {
+            const rawValue = row[mapping.index] ?? '';
+            if (mapping.type === 'name') name = String(rawValue || '').trim();
+            if (mapping.type === 'number') number = String(rawValue || '').trim();
+            if (mapping.type === 'field') values[mapping.field.key] = rawValue;
+        });
+
+        if (!name) errors.push(`Row ${rowNumber}: player name is required.`);
+
+        const parsedValues = {};
+        normalizedFields.forEach((field) => {
+            if (!Object.prototype.hasOwnProperty.call(values, field.key)) return;
+            const parsed = parseRosterCsvFieldValue(field, values[field.key]);
+            if (parsed.error) {
+                errors.push(`Row ${rowNumber}: ${parsed.error}`);
+            } else {
+                parsedValues[field.key] = parsed.value;
+            }
+        });
+
+        validateRosterProfileValues(normalizedFields, parsedValues).forEach((error) => {
+            errors.push(`Row ${rowNumber}: ${error}`);
+        });
+
+        if (!name) return;
+        const { publicValues, privateValues } = splitRosterProfileValuesByVisibility(normalizedFields, parsedValues);
+        const matches = existingByName.get(name.toLowerCase()) || [];
+        if (matches.length > 1) {
+            errors.push(`Row ${rowNumber}: multiple existing players named ${name}; update this player manually.`);
+            return;
+        }
+
+        const existing = matches[0];
+        const existingProfile = existing?.profile || {};
+        const profile = {
+            ...existingProfile,
+            customFields: {
+                ...(existingProfile.customFields || {}),
+                ...publicValues
+            }
+        };
+        const payload = { name, number, profile };
+        const privateRosterFields = Object.keys(privateValues).length > 0 ? privateValues : null;
+        operations.push(existing
+            ? { type: 'update', playerId: existing.id, payload, privateRosterFields }
+            : { type: 'add', payload, privateRosterFields });
+    });
+
+    if (errors.length) return { errors, operations: [] };
+    return { errors: [], operations };
 }
 
 function createBaseField(field) {

--- a/js/roster-profile-fields.js
+++ b/js/roster-profile-fields.js
@@ -298,6 +298,7 @@ export function planRosterCsvImport({ csvText = '', fields = [], existingPlayers
         const values = {};
         let name = '';
         let number = '';
+        const hasNumberColumn = mappings.some((mapping) => mapping.type === 'number');
         mappings.forEach((mapping) => {
             const rawValue = row[mapping.index] ?? '';
             if (mapping.type === 'name') name = String(rawValue || '').trim();
@@ -339,7 +340,8 @@ export function planRosterCsvImport({ csvText = '', fields = [], existingPlayers
                 ...publicValues
             }
         };
-        const payload = { name, number, profile };
+        const payload = { name, profile };
+        if (hasNumberColumn) payload.number = number;
         const privateRosterFields = Object.keys(privateValues).length > 0 ? privateValues : null;
         operations.push(existing
             ? { type: 'update', playerId: existing.id, payload, privateRosterFields }

--- a/tests/smoke/edit-roster-bulk-ai-reset.spec.js
+++ b/tests/smoke/edit-roster-bulk-ai-reset.spec.js
@@ -17,6 +17,7 @@ export async function uploadPlayerPhoto() {
     return 'https://example.test/photo.png';
 }
 export async function updatePlayer() {}
+export async function setPlayerPrivateRosterProfileFields() {}
 export async function inviteParent() {
     return {};
 }

--- a/tests/unit/roster-csv-import.test.js
+++ b/tests/unit/roster-csv-import.test.js
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+import { planRosterCsvImport, splitRosterProfileValuesByVisibility } from '../../js/roster-profile-fields.js';
+
+describe('roster CSV import planning', () => {
+    const fields = [
+        { key: 'grade', label: 'Grade', type: 'menu', options: ['5', '6', '7'].map((value) => ({ value, label: value })), active: true },
+        { key: 'throwsRight', label: 'Throws Right', type: 'checkbox', active: true },
+        { key: 'birthDate', label: 'Birth Date', type: 'date', active: true },
+        { key: 'medicalNote', label: 'Medical Note', type: 'text', visibility: 'admins', active: true }
+    ];
+
+    it('creates and updates players from core and roster field columns', () => {
+        const plan = planRosterCsvImport({
+            fields,
+            existingPlayers: [{ id: 'p1', name: 'Avery Lee', number: '3', profile: { customFields: { grade: '5' } } }],
+            csvText: 'Name,Number,Grade,Throws Right,Birth Date,Medical Note\nAvery Lee,4,6,yes,2014-02-03,Allergy\nSam Jones,12,7,no,2013-09-01,'
+        });
+
+        expect(plan.errors).toEqual([]);
+        expect(plan.operations).toHaveLength(2);
+        expect(plan.operations[0]).toMatchObject({
+            type: 'update',
+            playerId: 'p1',
+            payload: {
+                name: 'Avery Lee',
+                number: '4',
+                profile: { customFields: { grade: '6', throwsRight: true, birthDate: '2014-02-03' } }
+            },
+            privateRosterFields: { medicalNote: 'Allergy' }
+        });
+        expect(plan.operations[1]).toMatchObject({
+            type: 'add',
+            payload: {
+                name: 'Sam Jones',
+                number: '12',
+                profile: { customFields: { grade: '7', throwsRight: false, birthDate: '2013-09-01' } }
+            }
+        });
+    });
+
+    it('accepts configured field keys as headers and rejects unknown headers', () => {
+        const valid = planRosterCsvImport({ fields, csvText: 'playerName,jersey,throwsRight\nAvery Lee,4,true' });
+        expect(valid.errors).toEqual([]);
+        expect(valid.operations[0].payload.profile.customFields.throwsRight).toBe(true);
+
+        const invalid = planRosterCsvImport({ fields, csvText: 'Name,Favorite Snack\nAvery Lee,Crackers' });
+        expect(invalid.errors).toEqual([
+            'Unknown CSV header "Favorite Snack". Use Name, Number, or a configured roster field label/key.'
+        ]);
+        expect(invalid.operations).toEqual([]);
+    });
+
+    it('returns actionable row validation errors without producing operations', () => {
+        const plan = planRosterCsvImport({
+            fields,
+            csvText: 'Name,Grade,Throws Right,Birth Date\nAvery Lee,8,maybe,02/03/2014\n,6,yes,2014-02-03'
+        });
+
+        expect(plan.operations).toEqual([]);
+        expect(plan.errors).toEqual([
+            'Row 2: Grade must be one of: 5, 6, 7.',
+            'Row 2: Throws Right must be yes/no.',
+            'Row 2: Birth Date must use YYYY-MM-DD format.',
+            'Row 3: player name is required.'
+        ]);
+    });
+
+    it('splits admin-only field values away from public player payloads', () => {
+        expect(splitRosterProfileValuesByVisibility(fields, { grade: '6', medicalNote: 'private' })).toEqual({
+            publicValues: { grade: '6' },
+            privateValues: { medicalNote: 'private' }
+        });
+    });
+});

--- a/tests/unit/roster-csv-import.test.js
+++ b/tests/unit/roster-csv-import.test.js
@@ -38,6 +38,26 @@ describe('roster CSV import planning', () => {
         });
     });
 
+    it('preserves existing jersey numbers when the CSV omits the number header', () => {
+        const plan = planRosterCsvImport({
+            fields,
+            existingPlayers: [{ id: 'p1', name: 'Avery Lee', number: '3', profile: { customFields: { grade: '5' } } }],
+            csvText: 'Name,Grade\nAvery Lee,6'
+        });
+
+        expect(plan.errors).toEqual([]);
+        expect(plan.operations).toHaveLength(1);
+        expect(plan.operations[0]).toMatchObject({
+            type: 'update',
+            playerId: 'p1',
+            payload: {
+                name: 'Avery Lee',
+                profile: { customFields: { grade: '6' } }
+            }
+        });
+        expect(plan.operations[0].payload).not.toHaveProperty('number');
+    });
+
     it('accepts configured field keys as headers and rejects unknown headers', () => {
         const valid = planRosterCsvImport({ fields, csvText: 'playerName,jersey,throwsRight\nAvery Lee,4,true' });
         expect(valid.errors).toEqual([]);


### PR DESCRIPTION
Closes #754

## Summary
- Added an admin CSV import tab on the edit roster page for upload or paste-based roster imports.
- Added CSV header/value validation against active roster profile field definitions before writes occur.
- Stores public roster profile fields on player docs and admin-only field values in the private player profile document.

## Tests
- `npx vitest run tests/unit/roster-csv-import.test.js tests/unit/roster-profile-fields.test.js --reporter=dot`