### PR TITLE
Surface rescheduled officiating assignments

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -894,13 +894,13 @@
     </div>
 
     <script type="module">
-        import { getTeam, getTeams, getGames, getEvents, addGame, updateGame, updateTeam, deleteGame, addPractice, updateEvent, deleteEvent, getConfigs, addCalendarToTeam, removeCalendarFromTeam, getTrackedCalendarEventUids, cancelOccurrence, updateOccurrence, restoreOccurrence, clearOccurrenceOverride, updateSeries, deleteSeries, getUnreadChatCount, getPracticeSessions, cancelGame, getLatestGameAssignments, postChatMessage, getRsvpBreakdownByPlayer, applyTournamentAdvancementPatches, saveTournamentPoolOverride, clearTournamentPoolOverride, getOfficials, addOfficial, updateOfficial, deleteOfficial, createOfficiatingAssignmentNotificationRecords } from './js/db.js?v=29';
+        import { getTeam, getTeams, getGames, getEvents, addGame, updateGame, updateTeam, deleteGame, addPractice, updateEvent, deleteEvent, getConfigs, addCalendarToTeam, removeCalendarFromTeam, getTrackedCalendarEventUids, cancelOccurrence, updateOccurrence, restoreOccurrence, clearOccurrenceOverride, updateSeries, deleteSeries, getUnreadChatCount, getPracticeSessions, cancelGame, getLatestGameAssignments, postChatMessage, getRsvpBreakdownByPlayer, applyTournamentAdvancementPatches, saveTournamentPoolOverride, clearTournamentPoolOverride, getOfficials, addOfficial, updateOfficial, deleteOfficial, createOfficiatingAssignmentNotificationRecords } from './js/db.js?v=30';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, formatTimeRange, getDefaultEndTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, getCalendarEventStatus, getCalendarEventTrackingId, isTrackedCalendarEvent, generateSeriesId, expandRecurrence, formatRecurrence, shareOrCopy, escapeHtml } from './js/utils.js?v=10';
         import { mergeCalendarImportEvents, validateCalendarImportUrl } from './js/edit-schedule-calendar-import.js?v=1';
         import { checkAuth } from './js/auth.js?v=13';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
-        import { computeOfficiatingCoverageStatus, getOfficiatingAssignmentConflictWarnings, normalizeOfficiatingSlots as normalizeAssignmentOfficiatingSlots } from './js/officiating-utils.js?v=2';
-        import { buildOfficiatingAssignmentNotificationRecords } from './js/officiating-notifications.js?v=1';
+        import { computeOfficiatingCoverageStatus, flagRescheduledOfficiatingSlots, getOfficiatingAssignmentConflictWarnings, normalizeOfficiatingSlots as normalizeAssignmentOfficiatingSlots } from './js/officiating-utils.js?v=3';
+        import { buildOfficiatingAssignmentNotificationRecords } from './js/officiating-notifications.js?v=2';
         import { getTeamAccessInfo } from './js/team-access.js';
         import { resolvePreferredStatConfigId } from './js/live-game-state.js?v=3';
         import { cancelScheduledGame } from './js/edit-schedule-cancel-game.js?v=3';
@@ -2688,7 +2688,8 @@
                 : (slotsOrGame.officiatingCoverageStatus || computeOfficiatingCoverageStatus(slots));
             const slotBadges = slots.map((slot) => {
                 const name = slot.officialName || slot.officialEmail || 'Open';
-                return `<span class="inline-block bg-indigo-50 border border-indigo-100 rounded px-1.5 py-0.5 mr-1 mb-1"><b>${escapeHtml(slot.position)}:</b> ${escapeHtml(name)} · ${escapeHtml(getOfficiatingStatusLabel(slot.status))}</span>`;
+                const reviewBadge = slot.scheduleReviewRequired ? ' · <span class="font-semibold text-amber-700">Rescheduled, needs review</span>' : '';
+                return `<span class="inline-block bg-indigo-50 border border-indigo-100 rounded px-1.5 py-0.5 mr-1 mb-1"><b>${escapeHtml(slot.position)}:</b> ${escapeHtml(name)} · ${escapeHtml(getOfficiatingStatusLabel(slot.status))}${reviewBadge}</span>`;
             }).join('');
             return `<div class="mt-1 text-xs text-indigo-800"><span class="inline-block ${getCoverageBadgeClass(coverageStatus)} rounded px-1.5 py-0.5 mr-1 mb-1 font-semibold">Officials: ${escapeHtml(getCoverageLabel(coverageStatus))}</span>${slotBadges}</div>`;
         }
@@ -2736,6 +2737,7 @@
                         <option value="accepted" ${slot.status === 'accepted' ? 'selected' : ''}>Accepted</option>
                         <option value="declined" ${slot.status === 'declined' ? 'selected' : ''}>Declined</option>
                         <option value="cant_make" ${slot.status === 'cant_make' ? 'selected' : ''}>Can't make it</option>
+                        <option value="needs_review" ${slot.status === 'needs_review' ? 'selected' : ''}>Needs review</option>
                         <option value="open" ${!slot.status || slot.status === 'open' ? 'selected' : ''}>Open</option>
                     </select>
                     <button type="button" class="remove-officiating-slot text-red-400 hover:text-red-600 text-lg font-bold">&times;</button>
@@ -2967,9 +2969,10 @@
                         eventDate: parsedGameDate
                     })
                 };
+                const previousGame = editingGameId ? (gamesCache[editingGameId] || null) : null;
+                gameData.officiatingSlots = flagRescheduledOfficiatingSlots(previousGame, gameData);
                 Object.assign(gameData, getOfficiatingAuthorizationFields(gameData.officiatingSlots));
                 gameData.officiatingCoverageStatus = computeOfficiatingCoverageStatus(gameData.officiatingSlots);
-                const previousGame = editingGameId ? (gamesCache[editingGameId] || null) : null;
 
                 if (!confirmOfficiatingAssignmentConflicts(gameData)) return;
 

--- a/js/db.js
+++ b/js/db.js
@@ -90,8 +90,8 @@ import {
     claimOfficiatingSlot,
     computeOfficiatingCoverageStatus,
     updateOfficiatingSlotResponse
-} from './officiating-utils.js?v=1';
-import { buildOfficiatingNotificationRecord } from './officiating-notifications.js?v=1';
+} from './officiating-utils.js?v=3';
+import { buildOfficiatingNotificationRecord } from './officiating-notifications.js?v=2';
 // import { getAI, getGenerativeModel, GoogleAIBackend } from 'https://www.gstatic.com/firebasejs/12.6.0/firebase-vertexai.js';
 export { collection, getDocs, deleteDoc, query };
 const limitQuery = limit;

--- a/js/officiating-notifications.js
+++ b/js/officiating-notifications.js
@@ -1,4 +1,4 @@
-import { normalizeOfficiatingSlots } from './officiating-utils.js?v=1';
+import { hasOfficiatingScheduleChange, normalizeOfficiatingSlots } from './officiating-utils.js?v=3';
 
 function normalizeId(value) {
     return String(value || '').trim();
@@ -6,13 +6,6 @@ function normalizeId(value) {
 
 function normalizeEmail(value) {
     return String(value || '').trim().toLowerCase();
-}
-
-function toDateMillis(value) {
-    if (!value) return null;
-    const date = typeof value.toDate === 'function' ? value.toDate() : new Date(value);
-    const millis = date.getTime();
-    return Number.isFinite(millis) ? millis : null;
 }
 
 export function normalizeOfficiatingNotificationActor(actor = {}) {
@@ -92,9 +85,7 @@ export function buildOfficiatingAssignmentNotificationRecords({
     const nextSlots = normalizeOfficiatingSlots(nextGame.officiatingSlots || []);
     const previousSlots = normalizeOfficiatingSlots(previousGame?.officiatingSlots || []);
     const previousById = new Map(previousSlots.map((slot) => [slot.id, slot]));
-    const previousDateMillis = toDateMillis(previousGame?.date);
-    const nextDateMillis = toDateMillis(nextGame.date);
-    const wasRescheduled = previousGame && previousDateMillis !== null && nextDateMillis !== null && previousDateMillis !== nextDateMillis;
+    const wasRescheduled = hasOfficiatingScheduleChange(previousGame, nextGame);
 
     return nextSlots.flatMap((slot) => {
         if (!hasAssignedOfficial(slot)) return [];

--- a/js/officiating-utils.js
+++ b/js/officiating-utils.js
@@ -1,4 +1,4 @@
-export const OFFICIATING_ASSIGNMENT_STATUSES = ['pending', 'accepted', 'declined', 'cant_make', 'open'];
+export const OFFICIATING_ASSIGNMENT_STATUSES = ['pending', 'accepted', 'declined', 'cant_make', 'needs_review', 'open'];
 
 export function normalizeOfficialEmail(email) {
     return String(email || '').trim().toLowerCase();
@@ -22,6 +22,11 @@ export function normalizeOfficiatingSlots(slots = []) {
                 ? requestedStatus
                 : (hasOfficial ? 'pending' : 'open');
 
+            const scheduleReviewRequired = slot?.scheduleReviewRequired === true
+                || slot?.needsReview === true
+                || slot?.rescheduled === true
+                || status === 'needs_review';
+
             return {
                 id: String(slot?.id || `slot-${index + 1}`).trim(),
                 position,
@@ -30,7 +35,10 @@ export function normalizeOfficiatingSlots(slots = []) {
                 officialName,
                 officialEmail,
                 status: hasOfficial ? (status === 'open' ? 'pending' : status) : 'open',
-                selfAssigned: slot?.selfAssigned === true
+                selfAssigned: slot?.selfAssigned === true,
+                scheduleReviewRequired,
+                scheduleReviewReason: scheduleReviewRequired ? String(slot?.scheduleReviewReason || 'Game schedule changed').trim() : '',
+                scheduleReviewMarkedAt: scheduleReviewRequired ? (slot?.scheduleReviewMarkedAt || null) : null
             };
         })
         .filter(Boolean);
@@ -50,6 +58,42 @@ function getDateMillis(dateValue) {
     const parsed = dateValue instanceof Date ? dateValue : new Date(dateValue);
     const millis = parsed.getTime();
     return Number.isNaN(millis) ? null : millis;
+}
+
+function normalizeLocation(value) {
+    return String(value || '').trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+export function hasOfficiatingScheduleChange(previousGame = null, nextGame = {}) {
+    if (!previousGame) return false;
+
+    const previousDateMillis = getDateMillis(previousGame.date);
+    const nextDateMillis = getDateMillis(nextGame.date);
+    const dateChanged = previousDateMillis !== null
+        && nextDateMillis !== null
+        && previousDateMillis !== nextDateMillis;
+    const locationChanged = normalizeLocation(previousGame.location) !== normalizeLocation(nextGame.location);
+
+    return dateChanged || locationChanged;
+}
+
+export function flagRescheduledOfficiatingSlots(previousGame = null, nextGame = {}, options = {}) {
+    const slots = normalizeOfficiatingSlots(nextGame.officiatingSlots || []);
+    if (!hasOfficiatingScheduleChange(previousGame, nextGame)) return slots;
+
+    const markedAt = options.markedAt || new Date().toISOString();
+    return slots.map((slot) => {
+        const hasAssignedOfficial = !!(slot.officialId || slot.officialUserId || slot.officialEmail || slot.officialName);
+        if (!hasAssignedOfficial || ['declined', 'cant_make', 'open'].includes(slot.status)) return slot;
+
+        return {
+            ...slot,
+            status: 'needs_review',
+            scheduleReviewRequired: true,
+            scheduleReviewReason: 'Game schedule changed',
+            scheduleReviewMarkedAt: markedAt
+        };
+    });
 }
 
 function getGameWindow(game = {}, defaultGameMinutes = 120) {
@@ -161,7 +205,13 @@ export function updateOfficiatingSlotResponse(slots = [], slotId, status) {
     const nextSlots = normalizeOfficiatingSlots(slots).map((slot) => {
         if (slot.id !== slotId) return slot;
         updated = true;
-        return { ...slot, status };
+        return {
+            ...slot,
+            status,
+            scheduleReviewRequired: false,
+            scheduleReviewReason: '',
+            scheduleReviewMarkedAt: null
+        };
     });
 
     if (!updated) throw new Error('Officiating slot not found');

--- a/officials.html
+++ b/officials.html
@@ -42,9 +42,9 @@
 
     <script type="module">
         import { checkAuth } from './js/auth.js?v=13';
-        import { getGames, claimOpenOfficiatingSlot, respondToOfficiatingAssignment } from './js/db.js?v=29';
+        import { getGames, claimOpenOfficiatingSlot, respondToOfficiatingAssignment } from './js/db.js?v=30';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime, escapeHtml } from './js/utils.js?v=10';
-        import { getAssignedOfficiatingSlots, getOpenOfficiatingSlots } from './js/officiating-utils.js?v=1';
+        import { getAssignedOfficiatingSlots, getOpenOfficiatingSlots } from './js/officiating-utils.js?v=3';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -69,6 +69,7 @@
                 <div class="text-lg font-bold text-gray-900">vs. ${escapeHtml(game.opponent || 'TBD')}</div>
                 <div class="text-sm text-gray-600">${escapeHtml(game.location || 'Location TBD')}</div>
                 <div class="text-sm text-gray-700 mt-1"><span class="font-semibold">Position:</span> ${escapeHtml(slot.position)}</div>
+                ${slot.scheduleReviewRequired ? '<div class="mt-2 inline-block rounded bg-amber-100 px-2 py-1 text-xs font-semibold text-amber-800">Game rescheduled, please review</div>' : ''}
             `;
         }
 
@@ -89,7 +90,7 @@
                     ${renderGameMeta(game, slot)}
                     <div class="mt-2 text-sm"><span class="font-semibold">Status:</span> ${escapeHtml(slot.status.replace(/_/g, ' '))}</div>
                     <div class="mt-3 flex flex-wrap gap-2">
-                        ${slot.status === 'pending' ? '<button data-action="accepted" class="official-response px-3 py-1 bg-green-100 text-green-700 rounded text-sm hover:bg-green-200">Accept</button><button data-action="declined" class="official-response px-3 py-1 bg-red-100 text-red-700 rounded text-sm hover:bg-red-200">Decline</button>' : ''}
+                        ${['pending', 'needs_review'].includes(slot.status) ? '<button data-action="accepted" class="official-response px-3 py-1 bg-green-100 text-green-700 rounded text-sm hover:bg-green-200">Accept</button><button data-action="declined" class="official-response px-3 py-1 bg-red-100 text-red-700 rounded text-sm hover:bg-red-200">Decline</button>' : ''}
                         ${slot.status === 'accepted' ? '<button data-action="cant_make" class="official-response px-3 py-1 bg-amber-100 text-amber-700 rounded text-sm hover:bg-amber-200">Can\'t make it</button>' : ''}
                     </div>
                 </div>

--- a/tests/unit/officiating-notifications.test.js
+++ b/tests/unit/officiating-notifications.test.js
@@ -46,18 +46,20 @@ describe('officiating notification records', () => {
         });
     });
 
-    it('creates rescheduled records for unchanged officials when the game time changes', () => {
+    it('creates rescheduled records for unchanged officials when the game schedule changes', () => {
         const records = buildOfficiatingAssignmentNotificationRecords({
             teamId: 'team-1',
             gameId: 'game-1',
             previousGame: {
                 date: new Date('2026-05-06T20:00:00Z'),
+                location: 'Field 2',
                 officiatingSlots: [
                     { id: 'slot-1', position: 'Umpire', officialUserId: 'official-1', status: 'accepted' }
                 ]
             },
             nextGame: {
-                date: new Date('2026-05-06T22:00:00Z'),
+                date: new Date('2026-05-06T20:00:00Z'),
+                location: 'Field 3',
                 officiatingSlots: [
                     { id: 'slot-1', position: 'Umpire', officialUserId: 'official-1', status: 'accepted' }
                 ]

--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -10,6 +10,10 @@ function readEditSchedule() {
     return readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
 }
 
+function readOfficialsPage() {
+    return readFileSync(new URL('../../officials.html', import.meta.url), 'utf8');
+}
+
 describe('officiating slots', () => {
     it('normalizes officials and fills slot display names from the directory', () => {
         const officials = normalizeOfficialsDirectory([
@@ -54,5 +58,16 @@ describe('officiating slots', () => {
         expect(source).toContain('Officiating assignment conflict warning:');
         expect(source).toContain('${renderOfficiatingSummary(game.officiatingSlots)}');
         expect(source).toContain('assignments: getAssignmentsFromForm()');
+    });
+
+    it('surfaces rescheduled officiating assignments to assigners and officials', () => {
+        const editSource = readEditSchedule();
+        const officialsSource = readOfficialsPage();
+
+        expect(editSource).toContain('flagRescheduledOfficiatingSlots(previousGame, gameData)');
+        expect(editSource).toContain('Rescheduled, needs review');
+        expect(editSource).toContain('Needs review');
+        expect(officialsSource).toContain('Game rescheduled, please review');
+        expect(officialsSource).toContain("['pending', 'needs_review'].includes(slot.status)");
     });
 });

--- a/tests/unit/officiating-utils.test.js
+++ b/tests/unit/officiating-utils.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   claimOfficiatingSlot,
   computeOfficiatingCoverageStatus,
+  flagRescheduledOfficiatingSlots,
   getAssignedOfficiatingSlots,
   getOfficiatingAssignmentConflictWarnings,
   getOpenOfficiatingSlots,
@@ -21,6 +22,33 @@ describe('officiating assignment helpers', () => {
       { position: 'AR1', status: 'open' }
     ]);
     expect(computeOfficiatingCoverageStatus(slots)).toBe('needs_attention');
+  });
+
+
+
+  it('flags staffed assignments as needing review when date, time, or location changes', () => {
+    const previousGame = {
+      date: new Date('2026-05-04T10:00:00Z'),
+      location: 'Field 1',
+      officiatingSlots: [
+        { id: 'slot-1', position: 'Referee', officialEmail: 'ref@example.com', status: 'accepted' },
+        { id: 'slot-2', position: 'AR1', status: 'open' }
+      ]
+    };
+
+    const slots = flagRescheduledOfficiatingSlots(previousGame, {
+      date: new Date('2026-05-04T10:00:00Z'),
+      location: 'Field 2',
+      officiatingSlots: previousGame.officiatingSlots
+    }, { markedAt: '2026-05-01T12:00:00.000Z' });
+
+    expect(slots[0]).toMatchObject({
+      status: 'needs_review',
+      scheduleReviewRequired: true,
+      scheduleReviewReason: 'Game schedule changed',
+      scheduleReviewMarkedAt: '2026-05-01T12:00:00.000Z'
+    });
+    expect(slots[1]).toMatchObject({ status: 'open', scheduleReviewRequired: false });
   });
 
   it('lets an assigned official accept and then mark cannot make it', () => {


### PR DESCRIPTION
Closes #731

## Summary
- Flags staffed officiating slots as `needs_review` when an edited game changes date, time, or location.
- Shows rescheduled review status to assigners on the schedule editor and to officials on the officials page.
- Extends officiating notification detection to treat location changes as reschedules.

## Tests
- `npx vitest run tests/unit/officiating-utils.test.js tests/unit/officiating-notifications.test.js tests/unit/officiating-slots.test.js`