### PR TITLE
Hide private-team players from global search

### DIFF
--- a/js/global-search-visibility.js
+++ b/js/global-search-visibility.js
@@ -9,3 +9,9 @@ export function canUserDiscoverTeamInSearch(team, user) {
 export function filterSearchableTeams(teams, user) {
     return (Array.isArray(teams) ? teams : []).filter((team) => canUserDiscoverTeamInSearch(team, user));
 }
+
+export function canUserDiscoverPlayerInSearch(teamId, teamsById, user) {
+    if (!teamId || !teamsById) return false;
+    const team = typeof teamsById.get === 'function' ? teamsById.get(teamId) : null;
+    return canUserDiscoverTeamInSearch(team, user);
+}

--- a/js/global-search.js
+++ b/js/global-search.js
@@ -1,6 +1,6 @@
 import { escapeHtml } from './utils.js?v=8';
 import { getTeams } from './db.js?v=29';
-import { filterSearchableTeams } from './global-search-visibility.js?v=1';
+import { canUserDiscoverPlayerInSearch, filterSearchableTeams } from './global-search-visibility.js?v=2';
 import {
     db,
     collectionGroup,
@@ -464,19 +464,20 @@ function openModal({ initialQuery = '' } = {}) {
                 return;
             }
 
-            const items = Array.from(byPath.values()).map((d) => {
+            const items = Array.from(byPath.values()).flatMap((d) => {
                 const data = d.data() || {};
                 const name = data.name || 'Player';
                 const number = data.number || '';
                 const { teamId, playerId } = parseTeamAndPlayerIdFromPath(d.ref.path);
+                if (!canUserDiscoverPlayerInSearch(teamId, modalState.teamsById, currentUser)) return [];
                 const teamName = modalState.teamsById.get(teamId)?.name || teamId || 'Team';
 
-                return {
+                return [{
                     kind: 'player',
                     title: `${number ? `#${number} ` : ''}${name}`,
                     subtitle: teamName,
                     href: `player.html#teamId=${encodeURIComponent(teamId)}&playerId=${encodeURIComponent(playerId)}`
-                };
+                }];
             });
 
             // Basic ranking: starts-with match on name/number, then shorter strings first.
@@ -533,6 +534,9 @@ function openModal({ initialQuery = '' } = {}) {
             modalState.teamsById = new Map((teams || []).map(t => [t.id, t]));
             modalState.activeIndex = 0;
             renderResults();
+            if ((modalState.input.value || '').trim().length >= 2) {
+                runPlayerSearch(modalState.input.value);
+            }
         } catch (e) {
             console.error('[GlobalSearch] Failed to load teams:', e);
             if (!modalState) return;

--- a/tests/unit/global-search-visibility.test.js
+++ b/tests/unit/global-search-visibility.test.js
@@ -1,38 +1,58 @@
 import { describe, it, expect } from 'vitest';
-import { filterSearchableTeams } from '../../js/global-search-visibility.js';
+import { canUserDiscoverPlayerInSearch, filterSearchableTeams } from '../../js/global-search-visibility.js';
 
 const teams = [
-  { id: 'public-team', name: 'Public Team', isPublic: true, ownerId: 'owner-1', adminEmails: ['coach@example.com'] },
-  { id: 'private-team', name: 'Private Team', isPublic: false, ownerId: 'owner-1', adminEmails: ['coach@example.com'] }
+    { id: 'public-team', name: 'Public Team', isPublic: true, ownerId: 'owner-1', adminEmails: ['coach@example.com'] },
+    { id: 'private-team', name: 'Private Team', isPublic: false, ownerId: 'owner-1', adminEmails: ['coach@example.com'] }
 ];
 
 describe('global search visibility', () => {
-  it('hides private teams from anonymous search results', () => {
-    expect(filterSearchableTeams(teams, null).map((team) => team.id)).toEqual(['public-team']);
-  });
+    it('hides private teams from anonymous search results', () => {
+        expect(filterSearchableTeams(teams, null).map((team) => team.id)).toEqual(['public-team']);
+    });
 
-  it('keeps private teams visible to the owner', () => {
-    expect(filterSearchableTeams(teams, { uid: 'owner-1', email: 'owner@example.com' }).map((team) => team.id)).toEqual([
-      'public-team',
-      'private-team'
-    ]);
-  });
+    it('keeps private teams visible to the owner', () => {
+        expect(filterSearchableTeams(teams, { uid: 'owner-1', email: 'owner@example.com' }).map((team) => team.id)).toEqual([
+            'public-team',
+            'private-team'
+        ]);
+    });
 
-  it('keeps private teams visible to a team admin', () => {
-    expect(filterSearchableTeams(teams, { uid: 'coach-1', email: 'coach@example.com' }).map((team) => team.id)).toEqual([
-      'public-team',
-      'private-team'
-    ]);
-  });
+    it('keeps private teams visible to a team admin', () => {
+        expect(filterSearchableTeams(teams, { uid: 'coach-1', email: 'coach@example.com' }).map((team) => team.id)).toEqual([
+            'public-team',
+            'private-team'
+        ]);
+    });
 
-  it('keeps private teams visible to a linked parent', () => {
-    expect(filterSearchableTeams(teams, {
-      uid: 'parent-1',
-      email: 'parent@example.com',
-      parentOf: [{ teamId: 'private-team', playerId: 'player-1' }]
-    }).map((team) => team.id)).toEqual([
-      'public-team',
-      'private-team'
-    ]);
-  });
+    it('keeps private teams visible to a linked parent', () => {
+        expect(filterSearchableTeams(teams, {
+            uid: 'parent-1',
+            email: 'parent@example.com',
+            parentOf: [{ teamId: 'private-team', playerId: 'player-1' }]
+        }).map((team) => team.id)).toEqual([
+            'public-team',
+            'private-team'
+        ]);
+    });
+
+    it('hides players from private teams for users without team access', () => {
+        const teamsById = new Map(teams.map((team) => [team.id, team]));
+
+        expect(canUserDiscoverPlayerInSearch('private-team', teamsById, null)).toBe(false);
+        expect(canUserDiscoverPlayerInSearch('private-team', teamsById, { uid: 'other-user', email: 'other@example.com' })).toBe(false);
+    });
+
+    it('keeps players visible only when their team is searchable', () => {
+        const teamsById = new Map(teams.map((team) => [team.id, team]));
+
+        expect(canUserDiscoverPlayerInSearch('public-team', teamsById, null)).toBe(true);
+        expect(canUserDiscoverPlayerInSearch('private-team', teamsById, { uid: 'owner-1', email: 'owner@example.com' })).toBe(true);
+    });
+
+    it('hides players when the team was not loaded into searchable team context', () => {
+        const teamsById = new Map(teams.filter((team) => team.id !== 'private-team').map((team) => [team.id, team]));
+
+        expect(canUserDiscoverPlayerInSearch('private-team', teamsById, { uid: 'owner-1', email: 'owner@example.com' })).toBe(false);
+    });
 });


### PR DESCRIPTION
Closes #757

## What changed
- Added player-level global search visibility gating that reuses team discoverability rules.
- Filters collection-group player search results unless the player belongs to a team the current user can discover.
- Re-runs player search after teams load so authorized users can still see accessible private-team players.

## Validation
- `npx vitest run tests/unit/global-search-visibility.test.js`