### PR TITLE
Map roster fields during registration import

### DIFF
--- a/docs/pr-notes/runs/759-pr-issue-comment-4390066735-20260506T163030Z/architecture.md
+++ b/docs/pr-notes/runs/759-pr-issue-comment-4390066735-20260506T163030Z/architecture.md
@@ -1,0 +1,16 @@
+## Architecture Decisions
+
+- Add a local `firstNonEmptyObject(...values)` helper beside `asObject()`.
+- Use it only for selecting the aggregate `submitted` and `playerSource` objects in `getRegistrationAnswerSources()`.
+- Preserve the existing answer source priority list and existing downstream filtering of empty sources.
+
+## Risk / Blast Radius
+
+- Blast radius is limited to registration roster import planning.
+- No Firestore schema, rules, auth, or storage changes.
+- Public/private field segregation remains governed by the existing split path.
+
+## Rollback
+
+- Revert the helper and the two selector substitutions in `js/edit-roster-registration-import.js`.
+- No migration rollback is required.

--- a/docs/pr-notes/runs/759-pr-issue-comment-4390066735-20260506T163030Z/code-plan.md
+++ b/docs/pr-notes/runs/759-pr-issue-comment-4390066735-20260506T163030Z/code-plan.md
@@ -1,0 +1,10 @@
+## Implementation Plan
+
+1. Add `firstNonEmptyObject(...values)` near `asObject()`.
+2. Replace the two object-shaped `||` chains for `submitted` and `playerSource` with the helper.
+3. Add a focused regression test in `tests/unit/edit-roster-registration-import.test.js`.
+4. Validate with focused and full unit tests.
+
+## Conflict Resolution
+
+- Requirements raised a possible merge-all-sources question. Chosen direction is first non-empty fallback only, because it directly fixes the reviewed defect while preserving current precedence and limiting blast radius.

--- a/docs/pr-notes/runs/759-pr-issue-comment-4390066735-20260506T163030Z/qa.md
+++ b/docs/pr-notes/runs/759-pr-issue-comment-4390066735-20260506T163030Z/qa.md
@@ -1,0 +1,11 @@
+## QA Plan
+
+- Add a unit regression where `submittedData` and `player` are empty objects and configured field data exists in a later nested payload source.
+- Assert imported field counts, generated profile payload, and preservation of unrelated custom fields.
+- Run the focused registration import unit test file and the full unit suite.
+
+## Guardrails
+
+- Empty wrappers must not suppress fallback sources.
+- Existing add/update/conflict behavior must remain unchanged.
+- Admin-only/private field leakage must not be introduced.

--- a/docs/pr-notes/runs/759-pr-issue-comment-4390066735-20260506T163030Z/requirements.md
+++ b/docs/pr-notes/runs/759-pr-issue-comment-4390066735-20260506T163030Z/requirements.md
@@ -1,0 +1,14 @@
+## Requirements
+
+- Re-import must preserve configured roster field imports when registration payloads include empty wrapper objects before populated later sources.
+- Empty `submittedData` or `player` objects must not block fallback to supported later sources such as `submission`, `payload`, or `athlete`.
+- Existing source priority remains unchanged when an earlier candidate is materially populated.
+- Public/private roster field visibility behavior must remain unchanged.
+
+## Acceptance Criteria
+
+1. `submittedData: {}` falls through to populated later registration answer containers.
+2. `player: {}` falls through to later populated player/athlete containers.
+3. Configured public fields import into `payload.profile.customFields`.
+4. Existing unrelated profile custom fields are preserved.
+5. Admin/private field handling remains on the existing private roster field path.

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -613,14 +613,19 @@
                 const plan = planRegistrationRosterImport({
                     sourcePlayers,
                     existingPlayers,
-                    source: getRegistrationSourceDescriptor(currentTeam)
+                    source: getRegistrationSourceDescriptor(currentTeam),
+                    fields: rosterFieldDefinitions
                 });
 
                 for (const operation of plan.operations) {
+                    let playerId = operation.playerId;
                     if (operation.type === 'update') {
-                        await updatePlayer(currentTeamId, operation.playerId, operation.payload);
+                        await updatePlayer(currentTeamId, playerId, operation.payload);
                     } else if (operation.type === 'add') {
-                        await addPlayer(currentTeamId, operation.payload);
+                        playerId = await addPlayer(currentTeamId, operation.payload);
+                    }
+                    if (operation.privateRosterFields) {
+                        await setPlayerPrivateRosterProfileFields(currentTeamId, playerId, operation.privateRosterFields);
                     }
                 }
 

--- a/js/edit-roster-registration-import.js
+++ b/js/edit-roster-registration-import.js
@@ -10,6 +10,12 @@ function asObject(value) {
     return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
 }
 
+function firstNonEmptyObject(...values) {
+    return values
+        .map(asObject)
+        .find((value) => Object.keys(value).length > 0) || {};
+}
+
 function normalizeAnswerKey(value) {
     return String(value || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '');
 }
@@ -90,8 +96,22 @@ function normalizeContacts(value) {
 }
 
 function getRegistrationAnswerSources(sourcePlayer = {}) {
-    const submitted = asObject(sourcePlayer.submittedData || sourcePlayer.submission || sourcePlayer.payload || sourcePlayer.formData || sourcePlayer.answers || sourcePlayer.data);
-    const playerSource = asObject(sourcePlayer.player || sourcePlayer.playerData || sourcePlayer.athlete || submitted.player || submitted.playerData || submitted.athlete);
+    const submitted = firstNonEmptyObject(
+        sourcePlayer.submittedData,
+        sourcePlayer.submission,
+        sourcePlayer.payload,
+        sourcePlayer.formData,
+        sourcePlayer.answers,
+        sourcePlayer.data
+    );
+    const playerSource = firstNonEmptyObject(
+        sourcePlayer.player,
+        sourcePlayer.playerData,
+        sourcePlayer.athlete,
+        submitted.player,
+        submitted.playerData,
+        submitted.athlete
+    );
     return [
         asObject(sourcePlayer.rosterFieldValues),
         asObject(sourcePlayer.customFields),

--- a/js/edit-roster-registration-import.js
+++ b/js/edit-roster-registration-import.js
@@ -1,5 +1,17 @@
+import { getRosterProfileValues, splitRosterProfileValuesByVisibility } from './roster-profile-fields.js';
+
+const SUPPORTED_ROSTER_FIELD_TYPES = new Set(['text', 'menu', 'checkbox', 'date']);
+
 function normalizeString(value) {
     return String(value || '').trim();
+}
+
+function asObject(value) {
+    return value && typeof value === 'object' && !Array.isArray(value) ? value : {};
+}
+
+function normalizeAnswerKey(value) {
+    return String(value || '').trim().toLowerCase().replace(/[^a-z0-9]+/g, '');
 }
 
 function normalizeSource(source = {}) {
@@ -77,6 +89,124 @@ function normalizeContacts(value) {
         .filter((contact) => contact.name || contact.email || contact.phone || contact.relation);
 }
 
+function getRegistrationAnswerSources(sourcePlayer = {}) {
+    const submitted = asObject(sourcePlayer.submittedData || sourcePlayer.submission || sourcePlayer.payload || sourcePlayer.formData || sourcePlayer.answers || sourcePlayer.data);
+    const playerSource = asObject(sourcePlayer.player || sourcePlayer.playerData || sourcePlayer.athlete || submitted.player || submitted.playerData || submitted.athlete);
+    return [
+        asObject(sourcePlayer.rosterFieldValues),
+        asObject(sourcePlayer.customFields),
+        asObject(sourcePlayer.profileFields),
+        asObject(sourcePlayer.extraFields),
+        asObject(sourcePlayer.answers),
+        asObject(sourcePlayer.formData),
+        asObject(sourcePlayer.submittedData),
+        asObject(playerSource.rosterFieldValues),
+        asObject(playerSource.customFields),
+        asObject(playerSource.profileFields),
+        asObject(submitted.rosterFieldValues),
+        asObject(submitted.customFields),
+        asObject(submitted.profileFields)
+    ].filter((source) => Object.keys(source).length > 0);
+}
+
+function buildRegistrationAnswerLookup(sourcePlayer = {}) {
+    const lookup = new Map();
+    getRegistrationAnswerSources(sourcePlayer).forEach((source) => {
+        Object.entries(source).forEach(([key, value]) => {
+            const normalizedKey = normalizeAnswerKey(key);
+            if (!normalizedKey || lookup.has(normalizedKey)) return;
+            lookup.set(normalizedKey, value);
+        });
+    });
+    return lookup;
+}
+
+function parseCheckboxValue(value) {
+    if (value === true || value === false) return { value };
+    const normalized = String(value ?? '').trim().toLowerCase();
+    if (['true', 'yes', 'y', '1', 'checked', 'x'].includes(normalized)) return { value: true };
+    if (['false', 'no', 'n', '0', 'unchecked'].includes(normalized)) return { value: false };
+    return { skipped: 'invalid' };
+}
+
+function parseRegistrationRosterFieldValue(field = {}, rawValue) {
+    const type = String(field.type || 'text').trim().toLowerCase();
+    if (!SUPPORTED_ROSTER_FIELD_TYPES.has(type)) return { skipped: 'unsupported' };
+    if (rawValue === null || rawValue === undefined || String(rawValue).trim() === '') return { skipped: 'blank' };
+
+    if (type === 'checkbox') return parseCheckboxValue(rawValue);
+
+    const value = String(rawValue).trim();
+    if (type === 'date') {
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return { skipped: 'invalid' };
+        const date = new Date(`${value}T00:00:00Z`);
+        if (Number.isNaN(date.getTime()) || date.toISOString().slice(0, 10) !== value) return { skipped: 'invalid' };
+        return { value };
+    }
+
+    if (type === 'menu') {
+        const option = (field.options || []).find((item) =>
+            String(item.value || '').trim().toLowerCase() === value.toLowerCase() ||
+            String(item.label || '').trim().toLowerCase() === value.toLowerCase()
+        );
+        if (!option) return { skipped: 'invalid' };
+        return { value: option.value };
+    }
+
+    return { value };
+}
+
+function collectRegistrationRosterFieldValues(sourcePlayer = {}, fields = [], results = null) {
+    const lookup = buildRegistrationAnswerLookup(sourcePlayer);
+    const values = {};
+    const skipReasons = results?.fieldSkipReasons || {};
+
+    (fields || []).forEach((field) => {
+        const keyMatches = [field.key, field.label].map(normalizeAnswerKey).filter(Boolean);
+        const matchKey = keyMatches.find((key) => lookup.has(key));
+        if (!matchKey) return;
+
+        const parsed = parseRegistrationRosterFieldValue(field, lookup.get(matchKey));
+        if (Object.prototype.hasOwnProperty.call(parsed, 'value')) {
+            values[field.key] = parsed.value;
+            if (results) results.fieldsImported = (results.fieldsImported || 0) + 1;
+            return;
+        }
+
+        const reason = parsed.skipped || 'invalid';
+        if (results) {
+            results.fieldsSkipped = (results.fieldsSkipped || 0) + 1;
+            skipReasons[reason] = (skipReasons[reason] || 0) + 1;
+            results.fieldSkipReasons = skipReasons;
+        }
+    });
+
+    return values;
+}
+
+function mergeRosterFieldValuesIntoPayload(payload, fieldValues, fields, existingPlayer = {}) {
+    if (!Object.keys(fieldValues).length) return { payload, privateRosterFields: null };
+
+    const { publicValues, privateValues } = splitRosterProfileValuesByVisibility(fields, fieldValues);
+    const privateRosterFields = Object.keys(privateValues).length > 0 ? privateValues : null;
+    if (Object.keys(publicValues).length === 0) return { payload, privateRosterFields };
+
+    const existingProfile = existingPlayer?.profile || {};
+    return {
+        payload: {
+            ...payload,
+            profile: {
+                ...existingProfile,
+                customFields: {
+                    ...getRosterProfileValues(existingPlayer),
+                    ...publicValues
+                }
+            }
+        },
+        privateRosterFields
+    };
+}
+
 export function isExternallyLinkedRosterTeam(team = {}) {
     return !!(
         team.registrationSource ||
@@ -139,7 +269,7 @@ function isSameLocalPlayer(sourcePlayer, existingPlayer) {
     return !sourceNumber || !existingNumber || sourceNumber === existingNumber;
 }
 
-export function planRegistrationRosterImport({ sourcePlayers = [], existingPlayers = [], source = {} } = {}) {
+export function planRegistrationRosterImport({ sourcePlayers = [], existingPlayers = [], source = {}, fields = [] } = {}) {
     const existingBySourceAndExternalId = new Map();
     const legacyExistingByExternalId = new Map();
     (existingPlayers || []).forEach((player) => {
@@ -161,6 +291,9 @@ export function planRegistrationRosterImport({ sourcePlayers = [], existingPlaye
         updated: 0,
         skipped: 0,
         conflicted: 0,
+        fieldsImported: 0,
+        fieldsSkipped: 0,
+        fieldSkipReasons: {},
         conflicts: []
     };
 
@@ -172,27 +305,32 @@ export function planRegistrationRosterImport({ sourcePlayers = [], existingPlaye
         }
         seenExternalIds.add(externalPlayerId);
 
+        const existing = existingBySourceAndExternalId.get(getSourceExternalKey(source, externalPlayerId)) || legacyExistingByExternalId.get(externalPlayerId);
         const payload = buildRegistrationRosterPlayerPayload(sourcePlayer, { source });
         if (!payload) {
             results.skipped += 1;
             return;
         }
 
-        const existing = existingBySourceAndExternalId.get(getSourceExternalKey(source, externalPlayerId)) || legacyExistingByExternalId.get(externalPlayerId);
+        if (!existing) {
+            const conflict = (existingPlayers || []).find((candidate) => isSameLocalPlayer(sourcePlayer, candidate));
+            if (conflict) {
+                results.conflicted += 1;
+                results.conflicts.push({ externalPlayerId, existingPlayerId: conflict.id || null });
+                return;
+            }
+        }
+
+        const fieldValues = collectRegistrationRosterFieldValues(sourcePlayer, fields, results);
+        const merged = mergeRosterFieldValuesIntoPayload(payload, fieldValues, fields, existing || {});
+
         if (existing?.id) {
-            operations.push({ type: 'update', playerId: existing.id, payload });
+            operations.push({ type: 'update', playerId: existing.id, payload: merged.payload, privateRosterFields: merged.privateRosterFields });
             results.updated += 1;
             return;
         }
 
-        const conflict = (existingPlayers || []).find((candidate) => isSameLocalPlayer(sourcePlayer, candidate));
-        if (conflict) {
-            results.conflicted += 1;
-            results.conflicts.push({ externalPlayerId, existingPlayerId: conflict.id || null });
-            return;
-        }
-
-        operations.push({ type: 'add', payload });
+        operations.push({ type: 'add', payload: merged.payload, privateRosterFields: merged.privateRosterFields });
         results.added += 1;
     });
 
@@ -200,5 +338,19 @@ export function planRegistrationRosterImport({ sourcePlayers = [], existingPlaye
 }
 
 export function formatRegistrationRosterImportResults(results = {}) {
-    return `${results.added || 0} added, ${results.updated || 0} updated, ${results.skipped || 0} skipped, ${results.conflicted || 0} conflicted`;
+    const parts = [`${results.added || 0} added, ${results.updated || 0} updated, ${results.skipped || 0} skipped, ${results.conflicted || 0} conflicted`];
+    if ((results.fieldsImported || 0) > 0 || (results.fieldsSkipped || 0) > 0) {
+        parts.push(`${results.fieldsImported || 0} configured field value${(results.fieldsImported || 0) === 1 ? '' : 's'} imported`);
+        parts.push(`${results.fieldsSkipped || 0} configured field value${(results.fieldsSkipped || 0) === 1 ? '' : 's'} skipped`);
+    }
+
+    const reasons = results.fieldSkipReasons || {};
+    const reasonText = [
+        reasons.blank ? `${reasons.blank} blank` : '',
+        reasons.unsupported ? `${reasons.unsupported} unsupported type` : '',
+        reasons.invalid ? `${reasons.invalid} invalid option/date/checkbox` : ''
+    ].filter(Boolean).join(', ');
+    if (reasonText) parts.push(`skipped: ${reasonText}`);
+
+    return parts.join(', ');
 }

--- a/tests/unit/edit-roster-registration-import.test.js
+++ b/tests/unit/edit-roster-registration-import.test.js
@@ -130,9 +130,96 @@ describe('registration roster import planning', () => {
         expect(plan.operations[0]).toMatchObject({ type: 'update', playerId: 'player-legacy' });
     });
 
+    it('maps configured roster profile fields from matching registration answer keys and labels', () => {
+        const plan = planRegistrationRosterImport({
+            source: { type: 'sports-connect', id: 'league-1' },
+            fields: [
+                { key: 'grade', label: 'Grade', type: 'text', visibility: 'team' },
+                { key: 'position', label: 'Primary Position', type: 'menu', visibility: 'team', options: [{ value: 'pg', label: 'Point Guard' }] },
+                { key: 'throwsRight', label: 'Throws Right?', type: 'checkbox', visibility: 'team' },
+                { key: 'birthDate', label: 'Birth Date', type: 'date', visibility: 'team' }
+            ],
+            sourcePlayers: [
+                {
+                    externalPlayerId: 'ext-1',
+                    name: 'Avery Lee',
+                    number: '4',
+                    answers: {
+                        Grade: '6',
+                        'Primary Position': 'Point Guard',
+                        throwsRight: 'yes',
+                        birthDate: '2014-02-03'
+                    }
+                }
+            ],
+            existingPlayers: [
+                {
+                    id: 'player-1',
+                    name: 'Avery Lee',
+                    number: '3',
+                    profile: { customFields: { grade: '5', note: 'keep' } },
+                    sourceMetadata: { sourceType: 'sports-connect', sourceId: 'league-1', externalPlayerId: 'ext-1' }
+                }
+            ]
+        });
+
+        expect(plan.results).toMatchObject({ updated: 1, fieldsImported: 4, fieldsSkipped: 0 });
+        expect(plan.operations[0].payload.profile.customFields).toEqual({
+            grade: '6',
+            note: 'keep',
+            position: 'pg',
+            throwsRight: true,
+            birthDate: '2014-02-03'
+        });
+    });
+
+    it('skips blank, unsupported, and invalid configured roster field answers without failing import', () => {
+        const plan = planRegistrationRosterImport({
+            source: { type: 'sports-connect', id: 'league-1' },
+            fields: [
+                { key: 'grade', label: 'Grade', type: 'text', visibility: 'team' },
+                { key: 'position', label: 'Position', type: 'menu', visibility: 'team', options: [{ value: 'pg', label: 'Point Guard' }] },
+                { key: 'height', label: 'Height', type: 'number', visibility: 'team' }
+            ],
+            sourcePlayers: [
+                {
+                    externalPlayerId: 'ext-1',
+                    name: 'Avery Lee',
+                    answers: { grade: '', position: 'Center', height: '60' }
+                }
+            ],
+            existingPlayers: [
+                {
+                    id: 'player-1',
+                    name: 'Avery Lee',
+                    profile: { customFields: { grade: '5', position: 'pg' } },
+                    sourceMetadata: { sourceType: 'sports-connect', sourceId: 'league-1', externalPlayerId: 'ext-1' }
+                }
+            ]
+        });
+
+        expect(plan.results).toMatchObject({ updated: 1, fieldsImported: 0, fieldsSkipped: 3 });
+        expect(plan.results.fieldSkipReasons).toEqual({ blank: 1, invalid: 1, unsupported: 1 });
+        expect(plan.operations[0].payload.profile).toBeUndefined();
+    });
+
+    it('keeps admin-only roster field imports out of the public player profile payload', () => {
+        const plan = planRegistrationRosterImport({
+            source: { type: 'sports-connect', id: 'league-1' },
+            fields: [{ key: 'lockerCode', label: 'Locker Code', type: 'text', visibility: 'admins' }],
+            sourcePlayers: [{ externalPlayerId: 'ext-1', name: 'Avery Lee', answers: { 'Locker Code': 'A-12' } }]
+        });
+
+        expect(plan.results).toMatchObject({ added: 1, fieldsImported: 1, fieldsSkipped: 0 });
+        expect(plan.operations[0].payload.profile).toBeUndefined();
+        expect(plan.operations[0].privateRosterFields).toEqual({ lockerCode: 'A-12' });
+    });
+
     it('formats import result counts for the UI', () => {
         expect(formatRegistrationRosterImportResults({ added: 2, updated: 1, skipped: 0, conflicted: 3 }))
             .toBe('2 added, 1 updated, 0 skipped, 3 conflicted');
+        expect(formatRegistrationRosterImportResults({ added: 1, updated: 0, skipped: 0, conflicted: 0, fieldsImported: 2, fieldsSkipped: 1, fieldSkipReasons: { invalid: 1 } }))
+            .toBe('1 added, 0 updated, 0 skipped, 0 conflicted, 2 configured field values imported, 1 configured field value skipped, skipped: 1 invalid option/date/checkbox');
     });
 });
 
@@ -144,6 +231,8 @@ describe('registration roster import wiring', () => {
         expect(source).toContain('Re-import Roster');
         expect(source).toContain("import { formatRegistrationRosterImportResults, getRegistrationRosterPlayers, isExternallyLinkedRosterTeam, planRegistrationRosterImport } from './js/edit-roster-registration-import.js?v=1';");
         expect(source).toContain('planRegistrationRosterImport({');
+        expect(source).toContain('fields: rosterFieldDefinitions');
+        expect(source).toContain('setPlayerPrivateRosterProfileFields(currentTeamId, playerId, operation.privateRosterFields)');
         expect(source).toContain('function getPlayerImportSourceType');
         expect(source).toContain('player.registrationSource?.externalPlayerId');
         expect(source).toContain('player.externalPlayerId');

--- a/tests/unit/edit-roster-registration-import.test.js
+++ b/tests/unit/edit-roster-registration-import.test.js
@@ -173,6 +173,40 @@ describe('registration roster import planning', () => {
         });
     });
 
+    it('falls back past empty registration wrappers when mapping configured roster fields', () => {
+        const plan = planRegistrationRosterImport({
+            source: { type: 'sports-connect', id: 'league-1' },
+            fields: [{ key: 'grade', label: 'Grade', type: 'text', visibility: 'team' }],
+            sourcePlayers: [
+                {
+                    externalPlayerId: 'ext-1',
+                    name: 'Avery Lee',
+                    submittedData: {},
+                    player: {},
+                    payload: {
+                        athlete: {
+                            customFields: { Grade: '7' }
+                        }
+                    }
+                }
+            ],
+            existingPlayers: [
+                {
+                    id: 'player-1',
+                    name: 'Avery Lee',
+                    profile: { customFields: { note: 'keep' } },
+                    sourceMetadata: { sourceType: 'sports-connect', sourceId: 'league-1', externalPlayerId: 'ext-1' }
+                }
+            ]
+        });
+
+        expect(plan.results).toMatchObject({ updated: 1, fieldsImported: 1, fieldsSkipped: 0 });
+        expect(plan.operations[0].payload.profile.customFields).toEqual({
+            grade: '7',
+            note: 'keep'
+        });
+    });
+
     it('skips blank, unsupported, and invalid configured roster field answers without failing import', () => {
         const plan = planRegistrationRosterImport({
             source: { type: 'sports-connect', id: 'league-1' },


### PR DESCRIPTION
Closes #753

## Summary
- Map configured roster profile fields from registration roster answers by field key or label during re-import.
- Preserve existing local configured field values when registration answers are blank, invalid, or unsupported.
- Include configured field import and skip counts, with skip reasons, in the import result summary.

## Validation
- `npx vitest run tests/unit/edit-roster-registration-import.test.js tests/unit/roster-profile-fields.test.js tests/unit/roster-csv-import.test.js`