### PR TITLE
Fix team availability admin access

### DIFF
--- a/docs/pr-notes/runs/761-ci-fix-20260508T001312Z/architecture.md
+++ b/docs/pr-notes/runs/761-ci-fix-20260508T001312Z/architecture.md
@@ -1,0 +1,5 @@
+# Architecture note
+
+Root cause: `team.html` `getAllEvents()` now calls `canManageTeamAvailability()` directly while normalizing RSVP visibility. The focused unit test extracts `getAllEvents()` into an isolated `new Function` harness, but the harness did not provide that dependency, causing a `ReferenceError` before behavior assertions ran.
+
+Decision: keep production code unchanged. Add the missing dependency to the unit harness with a non-admin default, preserving the existing access-control behavior and limiting blast radius to the failing test fixture.

--- a/docs/pr-notes/runs/761-ci-fix-20260508T001312Z/code-plan.md
+++ b/docs/pr-notes/runs/761-ci-fix-20260508T001312Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code plan
+
+Smallest fix:
+1. Update `buildGetAllEvents()` in `tests/unit/team-schedule-events.test.js` to include a default `canManageTeamAvailability: () => false` dependency.
+2. Destructure `canManageTeamAvailability` inside the generated function scope before evaluating the extracted `getAllEvents()` body.
+3. Do not change unrelated production schedule logic.

--- a/docs/pr-notes/runs/761-ci-fix-20260508T001312Z/qa.md
+++ b/docs/pr-notes/runs/761-ci-fix-20260508T001312Z/qa.md
@@ -1,0 +1,10 @@
+# QA note
+
+Acceptance criteria:
+- `tests/unit/team-schedule-events.test.js` no longer throws `ReferenceError`.
+- Existing schedule normalization assertions still pass.
+- Full unit test suite passes because the failing CI checks run `vitest run tests/unit`.
+
+Validation:
+- Run the targeted unit test.
+- Run full `npm test` before commit.

--- a/team.html
+++ b/team.html
@@ -324,10 +324,19 @@
         window.closeScheduleDayModal = closeScheduleDayModal;
         window.saveAvailabilityPreferences = saveAvailabilityPreferences;
 
+        function canManageTeamAvailability() {
+            return !!currentUser && (
+                currentUser?.isAdmin ||
+                currentTeamAccessInfo?.accessLevel === 'full' ||
+                currentTeamAccessInfo?.accessLevel === 'owner' ||
+                currentTeamAccessInfo?.accessLevel === 'admin'
+            );
+        }
+
         function renderAvailabilitySettings(team) {
             const section = document.getElementById('availability-settings-section');
             if (!section) return;
-            const canManage = currentTeamAccessInfo?.accessLevel === 'owner' || currentTeamAccessInfo?.accessLevel === 'admin' || currentUser?.isAdmin;
+            const canManage = canManageTeamAvailability();
             if (!canManage) {
                 section.classList.add('hidden');
                 section.innerHTML = '';
@@ -413,7 +422,7 @@
         }
 
         function canSendAvailabilityReminders() {
-            return !!currentUser && (currentUser?.isAdmin || currentTeamAccessInfo?.accessLevel === 'full' || currentTeamAccessInfo?.accessLevel === 'owner' || currentTeamAccessInfo?.accessLevel === 'admin');
+            return canManageTeamAvailability();
         }
 
         function renderTeamAvailabilityControls(game, isUpcoming) {
@@ -1735,7 +1744,7 @@
             }
 
             const availabilityPreferences = normalizeAvailabilityPreferences(team?.availabilityPreferences);
-            const isTeamAdmin = currentTeamAccessInfo?.accessLevel === 'full' || currentUser?.isAdmin;
+            const isTeamAdmin = canManageTeamAvailability();
             const linkedPlayerIds = Array.from(new Set((Array.isArray(currentUser?.parentOf) ? currentUser.parentOf : [])
                 .filter((link) => link?.teamId === currentTeamId && typeof link?.playerId === 'string' && link.playerId.trim())
                 .map((link) => link.playerId.trim())));

--- a/tests/unit/team-availability-admin-access.test.js
+++ b/tests/unit/team-availability-admin-access.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function loadCanManageTeamAvailability() {
+    const source = readFileSync(new URL('../../team.html', import.meta.url), 'utf8');
+    const start = source.indexOf('function canManageTeamAvailability() {');
+    const end = source.indexOf('\n\n        function renderAvailabilitySettings(team)', start);
+
+    if (start === -1 || end === -1) {
+        throw new Error('Could not locate canManageTeamAvailability() in team.html');
+    }
+
+    const functionSource = source.slice(start, end);
+    return new Function('context', `
+        let currentUser = context.currentUser;
+        let currentTeamAccessInfo = context.currentTeamAccessInfo;
+        ${functionSource}
+        return canManageTeamAvailability();
+    `);
+}
+
+describe('team availability admin access', () => {
+    it('treats full team access as availability admin access', () => {
+        const canManageTeamAvailability = loadCanManageTeamAvailability();
+
+        expect(canManageTeamAvailability({
+            currentUser: { uid: 'owner-1', email: 'owner@example.com' },
+            currentTeamAccessInfo: { hasAccess: true, accessLevel: 'full' }
+        })).toBe(true);
+    });
+
+    it('does not treat parent-only access as availability admin access', () => {
+        const canManageTeamAvailability = loadCanManageTeamAvailability();
+
+        expect(canManageTeamAvailability({
+            currentUser: { uid: 'parent-1', email: 'parent@example.com' },
+            currentTeamAccessInfo: { hasAccess: true, accessLevel: 'parent' }
+        })).toBe(false);
+    });
+
+    it('uses the shared availability admin check for settings, reminders, and RSVP notes', () => {
+        const source = readFileSync(new URL('../../team.html', import.meta.url), 'utf8');
+
+        expect(source).toContain('const canManage = canManageTeamAvailability();');
+        expect(source).toContain('return canManageTeamAvailability();');
+        expect(source).toContain('const isTeamAdmin = canManageTeamAvailability();');
+    });
+});

--- a/tests/unit/team-schedule-events.test.js
+++ b/tests/unit/team-schedule-events.test.js
@@ -32,6 +32,7 @@ function buildGetAllEvents(overrides = {}) {
         normalizeAvailabilityPreferences: () => ({ cutoffMinutesBeforeStart: 0, noteVisibility: 'admins' }),
         buildAvailabilityNoteRows: () => [],
         getRsvps: async () => [],
+        canManageTeamAvailability: () => false,
         currentTeamAccessInfo: null,
         currentUser: null,
         ...overrides
@@ -48,6 +49,7 @@ function buildGetAllEvents(overrides = {}) {
             normalizeAvailabilityPreferences,
             buildAvailabilityNoteRows,
             getRsvps,
+            canManageTeamAvailability,
             currentTeamAccessInfo,
             currentUser
         } = deps;


### PR DESCRIPTION
Closes #760

## Summary
- Added a shared team availability admin check that recognizes `accessLevel: "full"` from team owners/admin emails.
- Reused the same check for availability settings, reminders, and admin-only RSVP note visibility.
- Added focused unit coverage for full-access admins and parent-only denial.

## Validation
- `npx vitest run tests/unit/team-availability-admin-access.test.js tests/unit/team-access.test.js tests/unit/availability-preferences.test.js`