### PR TITLE
Show saved player clips on profiles

### DIFF
--- a/docs/pr-notes/runs/764-remediator-20260506T200832Z/architecture.md
+++ b/docs/pr-notes/runs/764-remediator-20260506T200832Z/architecture.md
@@ -1,0 +1,11 @@
+# Architecture notes
+
+## Architecture decisions
+- Keep clip aggregation centralized in `collectPlayerVideoClips` in `js/player-profile-stats.js`.
+- Treat `game.clipMetadata` and `game.clips` as additional normalized input collections, not separate rendering paths.
+- Continue to use the existing player matching, hidden/deleted filtering, replay URL construction, and URL safety guards.
+
+## Risks and rollback
+- Risk surface is limited to player profile video clip collection.
+- Blast radius is low because the current implementation only adds two array sources to the existing clip pipeline.
+- Rollback is the PR commit that added the two source arrays and corresponding tests.

--- a/docs/pr-notes/runs/764-remediator-20260506T200832Z/code-plan.md
+++ b/docs/pr-notes/runs/764-remediator-20260506T200832Z/code-plan.md
@@ -1,0 +1,10 @@
+# Code plan
+
+## Implementation plan
+- Inspect PR changed files: `js/player-profile-stats.js` and `tests/unit/player-video-clips-tab.test.js`.
+- Confirm `game.clipMetadata` and `game.clips` are included in the raw clip source list.
+- Confirm tests cover both new saved clip sources and existing URL-safety behavior.
+- No additional code edit is needed because the unresolved review feedback contains no blocking defect or requested change.
+
+## Subagent fallback
+Role-specific subagents were requested but unavailable in this runtime due to `sessions_spawn` agent allowlist restrictions. Inline role analysis was used instead and persisted here.

--- a/docs/pr-notes/runs/764-remediator-20260506T200832Z/qa.md
+++ b/docs/pr-notes/runs/764-remediator-20260506T200832Z/qa.md
@@ -1,0 +1,11 @@
+# QA notes
+
+## QA plan
+- Run the affected unit test: `npm run test:unit -- tests/unit/player-video-clips-tab.test.js`.
+- Verify saved clips from both `clipMetadata` and `clips` render as replay clip links.
+- Verify unsafe direct clip URLs remain excluded.
+
+## Result
+- `npm run test:unit -- tests/unit/player-video-clips-tab.test.js` completed successfully.
+- Vitest executed the unit suite in this repo invocation: 206 test files passed, 998 tests passed.
+- The review item is a positive review summary with no requested change.

--- a/docs/pr-notes/runs/764-remediator-20260506T200832Z/requirements.md
+++ b/docs/pr-notes/runs/764-remediator-20260506T200832Z/requirements.md
@@ -1,0 +1,10 @@
+# Requirements notes
+
+## Acceptance criteria
+- Player profile video clips include player-tagged entries from `game.clipMetadata`.
+- Player profile video clips include player-tagged entries from `game.clips`.
+- Existing clip sources continue to render unchanged.
+- Unsafe clip URLs remain filtered by existing URL validation.
+
+## Review remediation finding
+Amazon Q's review summary identified no blocking defects. The current PR already satisfies the requested behavior, so no functional source change is required for this review item.

--- a/js/player-profile-stats.js
+++ b/js/player-profile-stats.js
@@ -131,6 +131,8 @@ export function collectPlayerVideoClips(games = [], { teamId = '', playerId = ''
         const rawClips = [
             ...(Array.isArray(game.gameClips) ? game.gameClips : []),
             ...(Array.isArray(game.highlightClips) ? game.highlightClips : []),
+            ...(Array.isArray(game.clipMetadata) ? game.clipMetadata : []),
+            ...(Array.isArray(game.clips) ? game.clips : []),
             ...(Array.isArray(game.videoClips) ? game.videoClips : []),
             ...(Array.isArray(game.replayVideo?.highlights) ? game.replayVideo.highlights : []),
             ...(Array.isArray(game.replayHighlights) ? game.replayHighlights : [])

--- a/tests/unit/player-video-clips-tab.test.js
+++ b/tests/unit/player-video-clips-tab.test.js
@@ -44,6 +44,12 @@ describe('player video clips tab', () => {
                 gameClips: [
                     { id: 'clip-4', playerId: 'player-1', title: 'Corner three', videoUrl: 'https://video.example.com/clip-4.mp4', thumbnailUrl: 'https://video.example.com/thumb.jpg' },
                     { id: 'clip-5', playerId: 'player-1', title: 'Unsafe', videoUrl: 'javascript:alert(1)' }
+                ],
+                clipMetadata: [
+                    { id: 'clip-6', playerIds: ['player-1'], title: 'Metadata three', playDescription: 'Three pointer', startMs: 10000, endMs: 35000 }
+                ],
+                clips: [
+                    { id: 'clip-7', taggedPlayerIds: ['player-1'], title: 'Saved replay clip', startMs: 40000, endMs: 52000 }
                 ]
             }
         ], { teamId: 'team-1', playerId: 'player-1' });
@@ -56,6 +62,24 @@ describe('player video clips tab', () => {
                 playLabel: 'Highlight',
                 url: 'https://video.example.com/clip-4.mp4',
                 thumbnailUrl: 'https://video.example.com/thumb.jpg',
+                gameLabel: 'Tigers'
+            },
+            {
+                id: 'clip-6',
+                title: 'Metadata three',
+                gameDate: '4/25/2026',
+                playLabel: 'Three pointer',
+                url: 'live-game.html?teamId=team-1&gameId=game-1&replay=true&clipStart=10000&clipEnd=35000',
+                thumbnailUrl: 'https://cdn.example.com/poster.jpg',
+                gameLabel: 'Tigers'
+            },
+            {
+                id: 'clip-7',
+                title: 'Saved replay clip',
+                gameDate: '4/25/2026',
+                playLabel: 'Highlight',
+                url: 'live-game.html?teamId=team-1&gameId=game-1&replay=true&clipStart=40000&clipEnd=52000',
+                thumbnailUrl: 'https://cdn.example.com/poster.jpg',
                 gameLabel: 'Tigers'
             },
             {


### PR DESCRIPTION
Closes #763

## Summary
- Included `game.clipMetadata` and `game.clips` in player profile video clip collection.
- Added unit coverage proving player-tagged clips from both sources render as replay clip links.

## Validation
- `npx vitest run tests/unit/player-video-clips-tab.test.js`