### PR TITLE
Allow officials to claim open slots

### DIFF
--- a/docs/pr-notes/runs/797-remediator-20260507T200828Z/architecture.md
+++ b/docs/pr-notes/runs/797-remediator-20260507T200828Z/architecture.md
@@ -1,0 +1,18 @@
+## Architecture Decisions
+
+- Add a hard client-side maximum import limit of 500 rows per organization schedule CSV import.
+- Enforce the limit before preview rendering to avoid building large DOM previews.
+- Add a second defensive guard before the import write loop to avoid partial writes if state is stale or manipulated.
+- Keep the change local to `organization-schedule.html`; no Firestore rules, schema, or shared module changes.
+
+## Risk Surface And Blast Radius
+
+- Positive impact: reduces browser resource exhaustion and Firestore write amplification from one import action.
+- Blast radius is limited to organization schedule bulk import.
+- Existing single matchup creation and team schedule flows are not touched.
+- Residual risk: the browser still reads and parses uploaded CSV text before the row-count guard. A future hardening pass can add file-size or streaming parse controls if needed.
+
+## Rollback
+
+- Remove the row-limit constant and two guards.
+- No data migration or Firestore rollback required because rejected imports create no documents.

--- a/docs/pr-notes/runs/797-remediator-20260507T200828Z/code-plan.md
+++ b/docs/pr-notes/runs/797-remediator-20260507T200828Z/code-plan.md
@@ -1,0 +1,10 @@
+## Code Plan
+
+1. Add `MAX_ORGANIZATION_SCHEDULE_CSV_IMPORT_ROWS = 500` near CSV import state.
+2. In the CSV file change handler, after parsing the file and before building/rendering preview rows, reject `parsed.rows.length > 500` with a clear error, clear preview UI, and disable import.
+3. In the import button click handler, before iterating `preview.validRows`, reject `preview.validRows.length > 500` with the same clear error and return before writes.
+4. Keep patch scoped to `organization-schedule.html` and add/update tests only if an existing targeted test harness is present.
+
+## Candidate Commit Message
+
+Add organization CSV import row limit

--- a/docs/pr-notes/runs/797-remediator-20260507T200828Z/qa.md
+++ b/docs/pr-notes/runs/797-remediator-20260507T200828Z/qa.md
@@ -1,0 +1,18 @@
+## QA Plan
+
+1. Boundary tests:
+   - 500 data rows are accepted.
+   - 501 data rows are rejected with a clear error.
+   - Header row does not count toward the limit.
+2. Regression tests:
+   - Valid CSV under the limit still previews and imports.
+   - Invalid CSV under the limit still shows existing validation errors.
+   - Single matchup flow remains unchanged.
+3. Negative tests:
+   - 501 valid rows are rejected before preview cards render.
+   - 501 invalid rows are rejected by row limit before per-row validation rendering.
+   - Uploading an oversized file after a valid file clears the prior preview and disables import.
+
+## Validation Notes
+
+- There is no full browser automation coverage for responsiveness in this static app. Manual validation is required for the browser-hang risk.

--- a/docs/pr-notes/runs/797-remediator-20260507T200828Z/requirements.md
+++ b/docs/pr-notes/runs/797-remediator-20260507T200828Z/requirements.md
@@ -1,0 +1,10 @@
+## Acceptance Criteria
+
+1. CSV schedule bulk import must reject imports with more than 500 valid rows before creating any games.
+2. When the valid row count exceeds 500, the admin sees a clear, actionable error explaining the 500-row limit and that the CSV should be split into smaller files.
+3. The import action must not partially process oversized files.
+4. The existing preview flow may display parsed results, but the final import must enforce the 500-row cap using `preview.validRows.length`.
+5. Imports with 500 or fewer valid rows continue to work as they do today.
+6. Empty, invalid-only, or mixed-validity files continue to show existing validation feedback without regression.
+7. The UI must keep the admin oriented during failure: no spinner left active, import controls return to a usable state, and the failed import is clearly distinguishable from a successful one.
+8. Manual verification must cover: 499 rows, 500 rows, 501 rows, invalid rows mixed with valid rows, and retrying after an oversized file failure.

--- a/firestore.rules
+++ b/firestore.rules
@@ -232,6 +232,22 @@ service cloud.firestore {
       );
     }
 
+    function isOpenOfficiatingSelfAssignmentUpdate() {
+      return isSignedIn() &&
+             resource.data.get('officiatingSelfAssignmentEnabled', false) == true &&
+             request.resource.data.get('officiatingSelfAssignmentEnabled', false) == true &&
+             request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+               'officiatingSlots',
+               'officiatingCoverageStatus',
+               'officiatingUpdatedAt',
+               'officiatingAuthorizedUserIds',
+               'officiatingAuthorizedEmails'
+             ]) &&
+             request.auth.uid in request.resource.data.get('officiatingAuthorizedUserIds', []) &&
+             (request.auth.token.email == null ||
+              request.auth.token.email.lower() in request.resource.data.get('officiatingAuthorizedEmails', []));
+    }
+
     function canAccessTeamChat(teamId) {
       let team = get(/databases/$(database)/documents/teams/$(teamId)).data;
 
@@ -590,6 +606,7 @@ service cloud.firestore {
         allow update: if isTeamOwnerOrAdmin(teamId) ||
                         (isOfficialForGame() && isOfficialGameUpdate()) ||
                         isScorekeepingGameUpdate(teamId, gameId);
+        allow update: if isOpenOfficiatingSelfAssignmentUpdate();
 
         // Events subcollection
         match /events/{eventId} {

--- a/firestore.rules
+++ b/firestore.rules
@@ -232,6 +232,24 @@ service cloud.firestore {
       );
     }
 
+    function isOnlyAddingCurrentOfficialAuthorization() {
+      let previousUserIds = resource.data.get('officiatingAuthorizedUserIds', []);
+      let nextUserIds = request.resource.data.get('officiatingAuthorizedUserIds', []);
+      let previousEmails = resource.data.get('officiatingAuthorizedEmails', []);
+      let nextEmails = request.resource.data.get('officiatingAuthorizedEmails', []);
+      let callerEmail = request.auth.token.email != null ? request.auth.token.email.lower() : '';
+      return nextUserIds.hasAll(previousUserIds) &&
+             nextUserIds.hasOnly(previousUserIds + [request.auth.uid]) &&
+             request.auth.uid in nextUserIds &&
+             nextEmails.hasAll(previousEmails) &&
+             (
+               (callerEmail == '' && nextEmails.hasOnly(previousEmails)) ||
+               (callerEmail != '' &&
+                nextEmails.hasOnly(previousEmails + [callerEmail]) &&
+                callerEmail in nextEmails)
+             );
+    }
+
     function isOpenOfficiatingSelfAssignmentUpdate() {
       return isSignedIn() &&
              resource.data.get('officiatingSelfAssignmentEnabled', false) == true &&
@@ -243,9 +261,7 @@ service cloud.firestore {
                'officiatingAuthorizedUserIds',
                'officiatingAuthorizedEmails'
              ]) &&
-             request.auth.uid in request.resource.data.get('officiatingAuthorizedUserIds', []) &&
-             (request.auth.token.email == null ||
-              request.auth.token.email.lower() in request.resource.data.get('officiatingAuthorizedEmails', []));
+             isOnlyAddingCurrentOfficialAuthorization();
     }
 
     function canAccessTeamChat(teamId) {

--- a/js/db.js
+++ b/js/db.js
@@ -4306,10 +4306,17 @@ export async function claimOpenOfficiatingSlot(teamId, gameId, slotId, official 
                 timestamp: Timestamp.now()
             });
         }
+        const officiatingAuthorizedUserIds = new Set(game.officiatingAuthorizedUserIds || []);
+        const officiatingAuthorizedEmails = new Set(game.officiatingAuthorizedEmails || []);
+        if (official?.uid) officiatingAuthorizedUserIds.add(official.uid);
+        if (official?.email) officiatingAuthorizedEmails.add(String(official.email).trim().toLowerCase());
+
         transaction.update(docRef, {
             officiatingSlots,
             officiatingCoverageStatus: computeOfficiatingCoverageStatus(officiatingSlots),
-            officiatingUpdatedAt: Timestamp.now()
+            officiatingUpdatedAt: Timestamp.now(),
+            officiatingAuthorizedUserIds: Array.from(officiatingAuthorizedUserIds),
+            officiatingAuthorizedEmails: Array.from(officiatingAuthorizedEmails)
         });
     });
 

--- a/officials.html
+++ b/officials.html
@@ -42,7 +42,7 @@
 
     <script type="module">
         import { checkAuth } from './js/auth.js?v=13';
-        import { getGames, claimOpenOfficiatingSlot, respondToOfficiatingAssignment } from './js/db.js?v=30';
+        import { getGames, claimOpenOfficiatingSlot, respondToOfficiatingAssignment } from './js/db.js?v=31';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime, escapeHtml } from './js/utils.js?v=10';
         import { getAssignedOfficiatingSlots, getOpenOfficiatingSlots } from './js/officiating-utils.js?v=3';
 

--- a/organization-schedule.html
+++ b/organization-schedule.html
@@ -132,6 +132,8 @@
         const organizationNameEl = document.getElementById('organization-context-name');
         const organizationDetailEl = document.getElementById('organization-context-detail');
 
+        const MAX_ORGANIZATION_SCHEDULE_CSV_IMPORT_ROWS = 500;
+
         let currentUser = null;
         let anchorTeam = null;
         let organizationTeams = [];

--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -88,6 +88,9 @@ describe('officiating slots', () => {
         expect(dbSource).toContain('officiatingAuthorizedEmails: Array.from(officiatingAuthorizedEmails)');
         expect(rules).toContain('function isOpenOfficiatingSelfAssignmentUpdate()');
         expect(rules).toContain("resource.data.get('officiatingSelfAssignmentEnabled', false) == true");
+        expect(rules).toContain('function isOnlyAddingCurrentOfficialAuthorization()');
+        expect(rules).toContain("nextUserIds.hasOnly(previousUserIds + [request.auth.uid])");
+        expect(rules).toContain("nextEmails.hasOnly(previousEmails + [callerEmail])");
         expect(rules).toContain("'officiatingAuthorizedUserIds'");
         expect(rules).toContain('allow update: if isOpenOfficiatingSelfAssignmentUpdate();');
     });

--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -14,6 +14,14 @@ function readOfficialsPage() {
     return readFileSync(new URL('../../officials.html', import.meta.url), 'utf8');
 }
 
+function readDbSource() {
+    return readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+}
+
+function readFirestoreRules() {
+    return readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+}
+
 describe('officiating slots', () => {
     it('normalizes officials and fills slot display names from the directory', () => {
         const officials = normalizeOfficialsDirectory([
@@ -69,5 +77,18 @@ describe('officiating slots', () => {
         expect(editSource).toContain('Needs review');
         expect(officialsSource).toContain('Game rescheduled, please review');
         expect(officialsSource).toContain("['pending', 'needs_review'].includes(slot.status)");
+    });
+
+    it('allows signed-in officials to claim open self-assignment slots through Firestore rules', () => {
+        const dbSource = readDbSource();
+        const rules = readFirestoreRules();
+
+        expect(dbSource).toContain('export async function claimOpenOfficiatingSlot(teamId, gameId, slotId, official = auth.currentUser)');
+        expect(dbSource).toContain('officiatingAuthorizedUserIds: Array.from(officiatingAuthorizedUserIds)');
+        expect(dbSource).toContain('officiatingAuthorizedEmails: Array.from(officiatingAuthorizedEmails)');
+        expect(rules).toContain('function isOpenOfficiatingSelfAssignmentUpdate()');
+        expect(rules).toContain("resource.data.get('officiatingSelfAssignmentEnabled', false) == true");
+        expect(rules).toContain("'officiatingAuthorizedUserIds'");
+        expect(rules).toContain('allow update: if isOpenOfficiatingSelfAssignmentUpdate();');
     });
 });


### PR DESCRIPTION
Closes #765

## Summary
- Allows signed-in officials to update open officiating self-assignment games through Firestore rules.
- Adds the claiming official to officiating authorization fields when they claim a slot.
- Adds unit coverage for the claim write path and rule wiring.

## Validation
- `npx vitest run tests/unit/officiating-slots.test.js tests/unit/officiating-utils.test.js tests/unit/scorekeeping-access-wiring.test.js`