### PR TITLE
Fix signup hash login mode

### DIFF
--- a/js/login-page.js
+++ b/js/login-page.js
@@ -47,6 +47,14 @@ export function createForgotPasswordHandler({ emailInput, errorDiv, resetPasswor
     };
 }
 
+export function shouldInitializeSignupMode({ windowObject = window, urlCodeParam = null } = {}) {
+    if (urlCodeParam && urlCodeParam.length === 8) {
+        return true;
+    }
+
+    return String(windowObject.location.hash || '').toLowerCase() === '#signup';
+}
+
 export function createLoginRedirectCoordinator({
     windowObject = window,
     getRedirectUrl,

--- a/login.html
+++ b/login.html
@@ -171,43 +171,61 @@
             }
         })();
 
-        // Auto-fill activation code from URL parameter
-        if (urlCodeParam && urlCodeParam.length === 8) {
-            // Switch to signup mode
+        function showSignupMode({ activationCode = null, hideActivationCode = false, showInviteBanner = false } = {}) {
             isLogin = false;
             document.getElementById('form-title').textContent = 'Sign Up';
             document.getElementById('submit-btn').textContent = 'Create Account';
             document.getElementById('toggle-text').textContent = 'Already have an account?';
             document.getElementById('toggle-btn').textContent = 'Login';
 
-            // Show signup fields
             const confirmPasswordField = document.getElementById('confirm-password-field');
             confirmPasswordField.classList.remove('hidden');
             document.getElementById('confirm-password').setAttribute('required', 'required');
             document.getElementById('forgot-password-link').classList.add('hidden');
 
-            // Pre-fill and hide the activation code (auto-applied)
+            const activationCodeField = document.getElementById('activation-code-field');
             const activationCodeInput = document.getElementById('activation-code');
-            activationCodeInput.value = urlCodeParam.toUpperCase();
+            if (activationCode) {
+                activationCodeInput.value = activationCode.toUpperCase();
+            }
             activationCodeInput.setAttribute('required', 'required');
-            // Keep the field hidden — code is applied automatically
 
-            // Insert invite banner above the form title
-            const formTitle = document.getElementById('form-title');
-            const banner = document.createElement('div');
-            banner.className = 'mb-4 p-4 bg-green-50 border border-green-200 rounded-lg';
-            banner.innerHTML = `
-                <div class="flex items-start gap-3">
-                    <svg class="w-6 h-6 text-green-600 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
-                    </svg>
-                    <div>
-                        <p class="font-semibold text-green-900">You've been invited to ALL PLAYS!</p>
-                        <p class="text-sm text-green-800 mt-1">Your activation code has been applied. Just create your account below.</p>
+            if (hideActivationCode) {
+                activationCodeField.classList.add('hidden');
+            } else {
+                activationCodeField.classList.remove('hidden');
+            }
+
+            if (showInviteBanner) {
+                const formTitle = document.getElementById('form-title');
+                const banner = document.createElement('div');
+                banner.className = 'mb-4 p-4 bg-green-50 border border-green-200 rounded-lg';
+                banner.innerHTML = `
+                    <div class="flex items-start gap-3">
+                        <svg class="w-6 h-6 text-green-600 flex-shrink-0 mt-0.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                        </svg>
+                        <div>
+                            <p class="font-semibold text-green-900">You've been invited to ALL PLAYS!</p>
+                            <p class="text-sm text-green-800 mt-1">Your activation code has been applied. Just create your account below.</p>
+                        </div>
                     </div>
-                </div>
-            `;
-            formTitle.parentNode.insertBefore(banner, formTitle);
+                `;
+                formTitle.parentNode.insertBefore(banner, formTitle);
+            }
+        }
+
+        // Auto-fill activation code from URL parameter or honor public signup hash links.
+        if (loginPageModule.shouldInitializeSignupMode({ windowObject: window, urlCodeParam })) {
+            if (urlCodeParam && urlCodeParam.length === 8) {
+                showSignupMode({
+                    activationCode: urlCodeParam,
+                    hideActivationCode: true,
+                    showInviteBanner: true
+                });
+            } else {
+                showSignupMode();
+            }
         }
 
         checkAuth((user) => {

--- a/tests/smoke/login-forgot-password.spec.js
+++ b/tests/smoke/login-forgot-password.spec.js
@@ -157,6 +157,23 @@ async function mockLoginPageModules(page, resetScenario = {}) {
                         }
                     };
                 }
+
+                export function shouldInitializeSignupMode() {
+                    return false;
+                }
+
+                export function createLoginAuthStateManager() {
+                    return {
+                        beginProcessing() {},
+                        finishProcessing() {},
+                        captureAuthenticatedUser(user) {
+                            return Boolean(user);
+                        },
+                        consumePendingRedirectUser() {
+                            return null;
+                        }
+                    };
+                }
             `
         });
     });

--- a/tests/smoke/login-invite-redirect.spec.js
+++ b/tests/smoke/login-invite-redirect.spec.js
@@ -46,7 +46,8 @@ async function mockInviteLoginModules(page, options = {}) {
                 callback(null);
             }
 
-            export async function loginWithGoogle() {
+            export async function loginWithGoogle(activationCode) {
+                window.__googleActivationCode = activationCode;
                 return null;
             }
 
@@ -149,4 +150,23 @@ test('google redirect login mode keeps existing admin invites on accept-invite',
     });
 
     await expect(page).toHaveURL(/\/accept-invite\.html\?code=AB12CD34&type=admin$/);
+});
+
+test('signup hash opens signup mode and passes activation code to Google signup', async ({ page, baseURL }) => {
+    await mockInviteLoginModules(page);
+
+    await page.goto(buildUrl(baseURL, '/login.html#signup'), {
+        waitUntil: 'domcontentloaded'
+    });
+
+    await expect(page.locator('#form-title')).toHaveText('Sign Up');
+    await expect(page.locator('#confirm-password-field')).toBeVisible();
+    await expect(page.locator('#activation-code-field')).toBeVisible();
+    await expect(page.locator('#forgot-password-link')).toBeHidden();
+
+    await page.locator('#activation-code').fill('ab12cd34');
+    await page.locator('#google-btn').click();
+
+    await expect.poll(() => page.evaluate(() => window.__googleActivationCode)).toBe('AB12CD34');
+    await expect.poll(() => page.evaluate(() => window.sessionStorage.getItem('postGoogleAuthMode'))).toBe('signup');
 });

--- a/tests/unit/login-page.test.js
+++ b/tests/unit/login-page.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createLoginRedirectCoordinator, createLoginAuthStateManager } from '../../js/login-page.js';
+import { createLoginRedirectCoordinator, createLoginAuthStateManager, shouldInitializeSignupMode } from '../../js/login-page.js';
 
 function createCoordinator({
     search = '?code=ab12cd34&type=parent',
@@ -35,6 +35,27 @@ function createCoordinator({
 
     return { coordinator, windowObject };
 }
+
+describe('login page initial mode', () => {
+    it('initializes signup mode for public #signup hash links', () => {
+        expect(shouldInitializeSignupMode({
+            windowObject: { location: { hash: '#signup' } }
+        })).toBe(true);
+    });
+
+    it('initializes signup mode for activation code invite links', () => {
+        expect(shouldInitializeSignupMode({
+            windowObject: { location: { hash: '' } },
+            urlCodeParam: 'ab12cd34'
+        })).toBe(true);
+    });
+
+    it('keeps login mode for ordinary login links', () => {
+        expect(shouldInitializeSignupMode({
+            windowObject: { location: { hash: '' } }
+        })).toBe(false);
+    });
+});
 
 describe('login page redirect coordination', () => {
     it('treats invite type values case-insensitively when code is present', () => {


### PR DESCRIPTION
Closes #767

## Summary
- Honor `login.html#signup` when initializing the login page.
- Show Sign Up mode with confirm password and activation code fields for public Get Started links.
- Keep existing invite-code behavior intact, including auto-applied activation codes.

## Tests
- `npx vitest run tests/unit/login-page.test.js`