### PR TITLE
Preserve Game Plan substitution intervals

### DIFF
--- a/docs/pr-notes/runs/771-remediator-20260508T071337Z/architecture.md
+++ b/docs/pr-notes/runs/771-remediator-20260508T071337Z/architecture.md
@@ -1,0 +1,7 @@
+# Architecture notes
+
+- Subagent spawn was unavailable in this environment, so inline architecture analysis was used.
+- Keep ordering centralized in getGameDayPeriods(), because renderGDPeriodTabs() consumes that list for display and fallback selection.
+- Put the reusable comparator in js/game-day-periods.js beside normalizeActivePeriod so it can be unit tested.
+- Sort by base period, numeric suffix, then substitution minute; fall back to stable label comparison.
+- No Firebase, storage, or access-control surface changes.

--- a/docs/pr-notes/runs/771-remediator-20260508T071337Z/code-plan.md
+++ b/docs/pr-notes/runs/771-remediator-20260508T071337Z/code-plan.md
@@ -1,0 +1,7 @@
+# Code plan
+
+- Subagent spawn was unavailable in this environment, so inline code planning was used.
+- Add sortSubstitutionPeriods helper in js/game-day-periods.js.
+- Import it in game-day.html and sort Object.keys(state.rotationPlan) in getGameDayPeriods().
+- Add a focused unit test for non-chronological persisted interval keys.
+- Run targeted vitest coverage and commit.

--- a/docs/pr-notes/runs/771-remediator-20260508T071337Z/qa.md
+++ b/docs/pr-notes/runs/771-remediator-20260508T071337Z/qa.md
@@ -1,0 +1,6 @@
+# QA notes
+
+- Subagent spawn was unavailable in this environment, so inline QA analysis was used.
+- Automated coverage: unit test sortSubstitutionPeriods with non-chronological persisted labels.
+- Existing source-inspection test should continue to verify game-day period normalization is wired.
+- Manual scenario: persisted rotationPlan keys inserted as H1 14', H1 7', H1 21' should render H1 7', H1 14', H1 21' and default active tab to H1 7'.

--- a/docs/pr-notes/runs/771-remediator-20260508T071337Z/requirements.md
+++ b/docs/pr-notes/runs/771-remediator-20260508T071337Z/requirements.md
@@ -1,0 +1,7 @@
+# Requirements notes
+
+- Subagent spawn was unavailable in this environment, so inline requirements analysis was used.
+- Acceptance: substitution period tabs are ordered chronologically for persisted rotationPlan maps.
+- Acceptance: fallback active period in renderGDPeriodTabs selects the earliest chronological interval, not arbitrary object key order.
+- Acceptance: sorting handles labels with base period plus minute, e.g. H1 7', H1 14', H1 21'.
+- Scope: minimal change in game-day period ordering, no data model changes.

--- a/game-day.html
+++ b/game-day.html
@@ -488,7 +488,7 @@
         import { checkAuth } from './js/auth.js?v=13';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js?v=3';
         import { buildRotationPlanFromGamePlan } from './js/game-plan-interop.js';
-        import { getPeriodsForFormation, normalizeActivePeriod } from './js/game-day-periods.js?v=1';
+        import { getPeriodsForFormation, normalizeActivePeriod, sortSubstitutionPeriods } from './js/game-day-periods.js?v=1';
         import {
             buildLineupDraftPayload,
             buildLineupPublishPayload,
@@ -1968,7 +1968,7 @@ Respond ONLY with valid JSON.`;
 
         function getGameDayPeriods() {
             const plannedPeriods = Object.keys(state.rotationPlan || {});
-            if (plannedPeriods.length) return plannedPeriods;
+            if (plannedPeriods.length) return sortSubstitutionPeriods(plannedPeriods);
             return state.formationId ? getPeriods(state.formationId) : ['H1', 'H2'];
         }
 

--- a/game-day.html
+++ b/game-day.html
@@ -288,7 +288,7 @@
                     <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
                         <div class="flex items-center justify-between mb-3">
                             <div class="text-xs font-semibold text-gray-400 uppercase tracking-wider">On Field</div>
-                            <div class="flex gap-2" id="gd-period-tabs"></div>
+                            <div class="flex gap-2 flex-wrap justify-end" id="gd-period-tabs"></div>
                         </div>
                         <div id="field-diagram-container">
                             <div class="text-xs text-gray-400">No players assigned for this period</div>
@@ -1966,24 +1966,20 @@ Respond ONLY with valid JSON.`;
             }
         }
 
+        function getGameDayPeriods() {
+            const plannedPeriods = Object.keys(state.rotationPlan || {});
+            if (plannedPeriods.length) return plannedPeriods;
+            return state.formationId ? getPeriods(state.formationId) : ['H1', 'H2'];
+        }
+
         function getGDPeriodButtonClass(isActive) {
             return isActive
                 ? 'px-2 py-0.5 rounded text-xs font-semibold bg-primary-100 text-primary-700'
                 : 'px-2 py-0.5 rounded text-xs font-semibold text-gray-500 hover:bg-gray-100';
         }
 
-        function updateGDPeriodButtonStates(periods) {
-            periods.forEach((period) => {
-                const button = document.querySelector(`#gd-period-tabs [data-period="${period}"]`);
-                if (button) {
-                    button.className = getGDPeriodButtonClass(period === state.activePeriodGD);
-                }
-            });
-            document.getElementById('gd-period-chip').textContent = state.activePeriodGD;
-        }
-
         function renderGDPeriodTabs() {
-            const periods = state.formationId ? getPeriods(state.formationId) : ['H1', 'H2'];
+            const periods = getGameDayPeriods();
             state.activePeriodGD = normalizeActivePeriod(periods, state.activePeriodGD);
 
             const container = document.getElementById('gd-period-tabs');
@@ -1998,13 +1994,14 @@ Respond ONLY with valid JSON.`;
                 button.addEventListener('click', () => window.setActivePeriod(period));
                 container.appendChild(button);
             });
-            document.getElementById('gd-period-chip').textContent = state.activePeriodGD;
+            const chip = document.getElementById('gd-period-chip');
+            if (chip) chip.textContent = state.activePeriodGD;
         }
 
         window.setActivePeriod = function(period) {
-            const periods = state.formationId ? getPeriods(state.formationId) : ['H1', 'H2'];
+            const periods = getGameDayPeriods();
             state.activePeriodGD = normalizeActivePeriod(periods, period);
-            updateGDPeriodButtonStates(periods);
+            renderGDPeriodTabs();
             renderOnFieldList();
             populateSubDropdowns();
         };

--- a/js/game-day-periods.js
+++ b/js/game-day-periods.js
@@ -8,6 +8,34 @@ export function getPeriodsForFormation(formation = {}) {
   return getPeriodsForNumPeriods(formation?.numPeriods);
 }
 
+function parseSubstitutionPeriodLabel(period) {
+  const label = String(period || '').trim();
+  const minuteMatch = label.match(/^(.*\D)\s+(\d+(?:\.\d+)?)\s*'?$/);
+  const basePeriod = minuteMatch ? minuteMatch[1].trim() : label;
+  const baseMatch = basePeriod.match(/^([A-Za-z]+)(\d+)$/);
+
+  return {
+    label,
+    basePrefix: baseMatch ? baseMatch[1] : basePeriod,
+    baseNumber: baseMatch ? Number.parseInt(baseMatch[2], 10) : Number.MAX_SAFE_INTEGER,
+    minute: minuteMatch ? Number.parseFloat(minuteMatch[2]) : -1
+  };
+}
+
+export function compareSubstitutionPeriods(a, b) {
+  const left = parseSubstitutionPeriodLabel(a);
+  const right = parseSubstitutionPeriodLabel(b);
+  const prefixCompare = left.basePrefix.localeCompare(right.basePrefix, undefined, { numeric: true, sensitivity: 'base' });
+  if (prefixCompare !== 0) return prefixCompare;
+  if (left.baseNumber !== right.baseNumber) return left.baseNumber - right.baseNumber;
+  if (left.minute !== right.minute) return left.minute - right.minute;
+  return left.label.localeCompare(right.label, undefined, { numeric: true, sensitivity: 'base' });
+}
+
+export function sortSubstitutionPeriods(periods = []) {
+  return [...periods].sort(compareSubstitutionPeriods);
+}
+
 export function normalizeActivePeriod(periods, currentPeriod) {
   if (Array.isArray(periods) && periods.includes(currentPeriod)) {
     return currentPeriod;

--- a/js/game-plan-interop.js
+++ b/js/game-plan-interop.js
@@ -1,12 +1,12 @@
 export function buildRotationPlanFromGamePlan(gamePlan) {
   if (!gamePlan?.lineups || typeof gamePlan.lineups !== 'object') return {};
   const plan = {};
-  const legacyByPeriodPos = {};
+  const legacyByPeriodTime = {};
   const numPeriods = Number.parseInt(gamePlan?.numPeriods, 10) || 2;
   const periodPrefix = numPeriods === 4 ? 'Q' : 'H';
 
   Object.entries(gamePlan.lineups).forEach(([key, playerId]) => {
-    const currentMatch = /^([HQ]\d+)-(.+)$/.exec(key);
+    const currentMatch = /^([HQ]\d+(?: \d+')?)-(.+)$/.exec(key);
     if (currentMatch) {
       const period = currentMatch[1];
       const posId = currentMatch[2];
@@ -23,23 +23,18 @@ export function buildRotationPlanFromGamePlan(gamePlan) {
     if (!Number.isFinite(periodNum)) return;
 
     const period = `${periodPrefix}${periodNum}`;
-    const legacyKey = `${period}::${posId}`;
-    const existing = legacyByPeriodPos[legacyKey];
-    if (!existing || (Number.isFinite(timeNum) && timeNum < existing.time)) {
-      legacyByPeriodPos[legacyKey] = {
-        period,
-        posId,
-        time: Number.isFinite(timeNum) ? timeNum : 999,
-        playerId
-      };
-    }
+    const periodTime = Number.isFinite(timeNum) ? `${period} ${timeNum}'` : period;
+    if (!legacyByPeriodTime[periodTime]) legacyByPeriodTime[periodTime] = {};
+    legacyByPeriodTime[periodTime][posId] = playerId;
   });
 
-  Object.values(legacyByPeriodPos).forEach((row) => {
-    if (!plan[row.period]) plan[row.period] = {};
-    if (!plan[row.period][row.posId]) {
-      plan[row.period][row.posId] = row.playerId;
-    }
+  Object.entries(legacyByPeriodTime).forEach(([periodTime, assignments]) => {
+    if (!plan[periodTime]) plan[periodTime] = {};
+    Object.entries(assignments).forEach(([posId, playerId]) => {
+      if (!plan[periodTime][posId]) {
+        plan[periodTime][posId] = playerId;
+      }
+    });
   });
 
   return plan;

--- a/tests/unit/game-day-lineup-publish.test.js
+++ b/tests/unit/game-day-lineup-publish.test.js
@@ -165,7 +165,7 @@ describe('game-day page wiring', () => {
   it('normalizes the visible game-day period when a saved lineup reloads', () => {
     const source = readFileSync(resolve(process.cwd(), 'game-day.html'), 'utf8');
 
-    expect(source).toContain("import { getPeriodsForFormation, normalizeActivePeriod } from './js/game-day-periods.js?v=1';");
+    expect(source).toContain("import { getPeriodsForFormation, normalizeActivePeriod, sortSubstitutionPeriods } from './js/game-day-periods.js?v=1';");
     expect(source).toContain('state.activePeriodGD = normalizeActivePeriod(periods, state.activePeriodGD);');
   });
 

--- a/tests/unit/game-day-periods.test.js
+++ b/tests/unit/game-day-periods.test.js
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { sortSubstitutionPeriods } from '../../js/game-day-periods.js';
+
+describe('game day period helpers', () => {
+  it('sorts persisted substitution intervals by base period and minute', () => {
+    const periods = ["H1 14'", "H1 7'", "H2 7'", "H1 21'"];
+
+    expect(sortSubstitutionPeriods(periods)).toEqual(["H1 7'", "H1 14'", "H1 21'", "H2 7'"]);
+  });
+
+  it('does not mutate the caller period list', () => {
+    const periods = ["Q1 8'", "Q1 4'"];
+
+    expect(sortSubstitutionPeriods(periods)).toEqual(["Q1 4'", "Q1 8'"]);
+    expect(periods).toEqual(["Q1 8'", "Q1 4'"]);
+  });
+});

--- a/tests/unit/game-plan-interop.test.js
+++ b/tests/unit/game-plan-interop.test.js
@@ -17,19 +17,36 @@ describe('game plan interop helpers', () => {
     });
   });
 
-  it('maps legacy game-plan period-time-position shape to period-position', () => {
+  it('maps each legacy game-plan period-time-position shape to a Game Day substitution point', () => {
     const plan = buildRotationPlanFromGamePlan({
       numPeriods: 2,
       lineups: {
         '1-7-keeper': 'p1',
         '1-14-keeper': 'p2',
+        '1-21-keeper': 'p4',
         '2-7-striker': 'p3'
       }
     });
 
     expect(plan).toEqual({
-      H1: { keeper: 'p1' },
-      H2: { striker: 'p3' }
+      "H1 7'": { keeper: 'p1' },
+      "H1 14'": { keeper: 'p2' },
+      "H1 21'": { keeper: 'p4' },
+      "H2 7'": { striker: 'p3' }
+    });
+  });
+
+  it('round-trips saved Game Day substitution point labels', () => {
+    const plan = buildRotationPlanFromGamePlan({
+      lineups: {
+        "H1 7'-keeper": 'p1',
+        "H1 14'-keeper": 'p2'
+      }
+    });
+
+    expect(plan).toEqual({
+      "H1 7'": { keeper: 'p1' },
+      "H1 14'": { keeper: 'p2' }
     });
   });
 
@@ -43,8 +60,8 @@ describe('game plan interop helpers', () => {
     });
 
     expect(plan).toEqual({
-      Q1: { pg: 'p1' },
-      Q2: { pg: 'p2' }
+      "Q1 4'": { pg: 'p1' },
+      "Q2 4'": { pg: 'p2' }
     });
   });
 });


### PR DESCRIPTION
Closes #770

## Summary
- Preserve each legacy Game Plan period/time/position lineup as its own Game Day substitution point instead of collapsing by period and position.
- Render Game Day period tabs dynamically from the loaded rotation plan so planned intervals like `H1 7'`, `H1 14'`, and `H1 21'` are visible and selectable.
- Keep round-trip support for saved Game Day interval labels.

## Validation
- `npx vitest run tests/unit/game-plan-interop.test.js tests/unit/game-day-lineup-publish.test.js tests/unit/game-day-live-substitutions.test.js`