### PR TITLE
Fix score sheet upload controls

### DIFF
--- a/game.html
+++ b/game.html
@@ -656,6 +656,8 @@
                     empty.classList.add('hidden');
                     preview.classList.add('hidden');
                     fileInput.value = '';
+                    uploadBtn.classList.add('hidden');
+                    removeBtn?.classList.remove('hidden');
                     status.textContent = 'Saved.';
                 } catch (error) {
                     console.error('Stat sheet upload failed:', error);

--- a/tests/unit/game-statsheet-controls.test.js
+++ b/tests/unit/game-statsheet-controls.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readGameHtml() {
+    return readFileSync(new URL('../../game.html', import.meta.url), 'utf8');
+}
+
+function getFunctionBody(source, functionName) {
+    const signature = `function ${functionName}(`;
+    const start = source.indexOf(signature);
+    if (start === -1) return null;
+
+    const braceStart = source.indexOf('{', start);
+    if (braceStart === -1) return null;
+
+    let depth = 1;
+    for (let i = braceStart + 1; i < source.length; i += 1) {
+        const ch = source[i];
+        if (ch === '{') depth += 1;
+        if (ch === '}') depth -= 1;
+        if (depth === 0) return source.slice(braceStart + 1, i);
+    }
+
+    return null;
+}
+
+describe('game score sheet controls', () => {
+    it('reveals the remove action immediately after a successful upload', () => {
+        const body = getFunctionBody(readGameHtml(), 'setupStatSheetControls');
+
+        expect(body).toBeTruthy();
+        expect(body).toContain("uploadBtn.classList.add('hidden');");
+        expect(body).toContain("removeBtn?.classList.remove('hidden');");
+        expect(body.indexOf("uploadBtn.classList.add('hidden');")).toBeLessThan(body.indexOf("status.textContent = 'Saved.';"));
+        expect(body.indexOf("removeBtn?.classList.remove('hidden');")).toBeLessThan(body.indexOf("status.textContent = 'Saved.';"));
+    });
+});


### PR DESCRIPTION
Closes #772

## Summary
- Hide Upload Score Sheet after a successful upload on the game report page.
- Reveal Remove Score Sheet immediately after the uploaded image is saved.
- Added focused regression coverage for the post-upload control visibility update.

## Validation
- `npx vitest run tests/unit/game-statsheet-controls.test.js`