### PR TITLE
Preserve overnight recurring practice ends

### DIFF
--- a/js/edit-schedule-practice-payload.js
+++ b/js/edit-schedule-practice-payload.js
@@ -4,6 +4,7 @@ const RECURRENCE_FIELD_KEYS = [
     'seriesId',
     'startTime',
     'endTime',
+    'endDayOffset',
     'exDates',
     'overrides'
 ];
@@ -38,8 +39,14 @@ export function applyPracticeRecurrenceFields({
         practiceData.seriesId = editingPracticeId
             ? (editingSeriesId || practiceData.seriesId || generateSeriesId())
             : generateSeriesId();
+        const startDay = new Date(startDate);
+        const endDay = new Date(endDate);
+        startDay.setHours(0, 0, 0, 0);
+        endDay.setHours(0, 0, 0, 0);
+
         practiceData.startTime = startDate.toTimeString().slice(0, 5);
         practiceData.endTime = endDate.toTimeString().slice(0, 5);
+        practiceData.endDayOffset = Math.max(0, Math.round((endDay.getTime() - startDay.getTime()) / 86400000));
         practiceData.recurrence = {
             freq,
             interval,

--- a/js/utils.js
+++ b/js/utils.js
@@ -1621,9 +1621,16 @@ export function expandRecurrence(master, windowDays = 180) {
         occurrence.date = occDate;
 
         if (master.endTime || override.endTime) {
-          const [endHours, endMinutes] = (override.endTime || master.endTime).split(':').map(Number);
+          const effectiveEndTime = override.endTime || master.endTime;
+          const [endHours, endMinutes] = effectiveEndTime.split(':').map(Number);
           const endDate = new Date(current);
+          const explicitEndDayOffset = override.endDayOffset ?? master.endDayOffset;
+          const endDayOffset = explicitEndDayOffset !== undefined
+            ? Math.max(0, Number(explicitEndDayOffset) || 0)
+            : ((endHours * 60 + endMinutes) < (hours * 60 + minutes) ? 1 : 0);
+
           endDate.setHours(endHours, endMinutes, 0, 0);
+          endDate.setDate(endDate.getDate() + endDayOffset);
           occurrence.end = endDate;
         }
       } else {

--- a/tests/unit/edit-schedule-practice-payload.test.js
+++ b/tests/unit/edit-schedule-practice-payload.test.js
@@ -32,6 +32,7 @@ describe('edit schedule practice recurrence payload', () => {
         expect(result.seriesId).toBe(deleteSentinel);
         expect(result.startTime).toBe(deleteSentinel);
         expect(result.endTime).toBe(deleteSentinel);
+        expect(result.endDayOffset).toBe(deleteSentinel);
         expect(result.exDates).toBe(deleteSentinel);
         expect(result.overrides).toBe(deleteSentinel);
     });
@@ -66,12 +67,42 @@ describe('edit schedule practice recurrence payload', () => {
         expect(result.seriesId).toBe('series-existing');
         expect(result.startTime).toBe('17:00');
         expect(result.endTime).toBe('18:30');
+        expect(result.endDayOffset).toBe(0);
         expect(result.recurrence).toEqual({
             freq: 'weekly',
             interval: 2,
             byDays: ['MO', 'WE'],
             count: 8
         });
+    });
+
+    it('stores overnight recurring practice end day offset', () => {
+        const practiceData = {
+            title: 'Late Practice'
+        };
+
+        const result = applyPracticeRecurrenceFields({
+            practiceData,
+            isRecurring: true,
+            recurrenceConfig: {
+                freq: 'weekly',
+                interval: 1,
+                byDays: ['TH'],
+                endType: 'count',
+                countValue: '4'
+            },
+            startDate: createLocalDate(2026, 4, 7, 23, 0),
+            endDate: createLocalDate(2026, 4, 8, 1, 0),
+            Timestamp: { fromDate: (value) => value },
+            deleteField: () => {
+                throw new Error('deleteField should not be used for recurring series creation');
+            },
+            generateSeriesId: () => 'series-overnight'
+        });
+
+        expect(result.startTime).toBe('23:00');
+        expect(result.endTime).toBe('01:00');
+        expect(result.endDayOffset).toBe(1);
     });
 
     it('wires the practice submit flow through the shared recurrence payload helper', () => {

--- a/tests/unit/edit-schedule-practice-submit.test.js
+++ b/tests/unit/edit-schedule-practice-submit.test.js
@@ -68,6 +68,7 @@ describe('edit schedule practice save flow', () => {
             seriesId: 'series-generated',
             startTime: '17:00',
             endTime: '18:30',
+            endDayOffset: 0,
             recurrence: {
                 freq: 'weekly',
                 interval: 2,
@@ -140,6 +141,7 @@ describe('edit schedule practice save flow', () => {
             seriesId: 'series-existing',
             startTime: '17:15',
             endTime: '18:45',
+            endDayOffset: 0,
             recurrence: {
                 freq: 'weekly',
                 interval: 1,

--- a/tests/unit/recurrence-expand.test.js
+++ b/tests/unit/recurrence-expand.test.js
@@ -156,6 +156,60 @@ describe('expandRecurrence interval guardrails', () => {
     expect(dates).not.toContain('2026-02-18');
   });
 
+  it('preserves overnight end day offset when expanding occurrences', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-07T12:00:00Z'));
+
+    const master = {
+      id: 'series-overnight-weekly',
+      isSeriesMaster: true,
+      date: new Date(2026, 4, 7, 23, 0),
+      startTime: '23:00',
+      endTime: '01:00',
+      endDayOffset: 1,
+      recurrence: {
+        freq: 'weekly',
+        interval: 1,
+        byDays: ['TH'],
+        count: 2
+      }
+    };
+
+    const occurrences = expandRecurrence(master, 14);
+    expect(occurrences[0].date.getFullYear()).toBe(2026);
+    expect(occurrences[0].date.getMonth()).toBe(4);
+    expect(occurrences[0].date.getDate()).toBe(7);
+    expect(occurrences[0].date.getHours()).toBe(23);
+    expect(occurrences[0].end.getFullYear()).toBe(2026);
+    expect(occurrences[0].end.getMonth()).toBe(4);
+    expect(occurrences[0].end.getDate()).toBe(8);
+    expect(occurrences[0].end.getHours()).toBe(1);
+    expect(occurrences[0].end.getTime()).toBeGreaterThan(occurrences[0].date.getTime());
+  });
+
+  it('infers overnight end date for legacy recurring payloads without an offset', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-07T12:00:00Z'));
+
+    const master = {
+      id: 'series-overnight-legacy',
+      isSeriesMaster: true,
+      date: new Date(2026, 4, 7, 23, 0),
+      startTime: '23:00',
+      endTime: '01:00',
+      recurrence: {
+        freq: 'weekly',
+        interval: 1,
+        byDays: ['TH'],
+        count: 1
+      }
+    };
+
+    const [occurrence] = expandRecurrence(master, 14);
+    expect(occurrence.end.getDate()).toBe(8);
+    expect(occurrence.end.getTime()).toBeGreaterThan(occurrence.date.getTime());
+  });
+
   it('does not resurface finite weekly series after recurrence count is exhausted before window start', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-01T12:00:00Z'));


### PR DESCRIPTION
Closes #774

## Summary
- Store an `endDayOffset` on recurring practice payloads so overnight end dates survive recurrence expansion.
- Apply the stored offset when expanding recurring occurrences, with a legacy fallback that infers overnight events when `endTime` is earlier than `startTime`.
- Added targeted unit coverage for payload creation, submit payload expectations, and recurrence expansion.

## Tests
- `npx vitest run tests/unit/edit-schedule-practice-payload.test.js tests/unit/edit-schedule-practice-submit.test.js tests/unit/recurrence-expand.test.js`