### PR TITLE
Show imported roster fields when editing players

### DIFF
--- a/js/roster-profile-fields.js
+++ b/js/roster-profile-fields.js
@@ -80,7 +80,12 @@ export function normalizeRosterFieldDefinitions(fields = [], options = {}) {
 }
 
 export function getRosterProfileValues(player = {}) {
-    return player?.profile?.customFields || player?.profile?.rosterFields || player?.customFields || {};
+    return {
+        ...(player?.rosterFieldValues || {}),
+        ...(player?.customFields || {}),
+        ...(player?.profile?.rosterFields || {}),
+        ...(player?.profile?.customFields || {})
+    };
 }
 
 export function validateRosterProfileValues(fields = [], values = {}) {

--- a/tests/unit/roster-profile-fields.test.js
+++ b/tests/unit/roster-profile-fields.test.js
@@ -52,9 +52,17 @@ describe('roster profile fields', () => {
         ]);
     });
 
-    it('loads existing custom field values from the structured profile object', () => {
+    it('loads existing custom field values from all persisted roster profile shapes', () => {
         expect(getRosterProfileValues({ profile: { customFields: { position: 'Guard' } } })).toEqual({ position: 'Guard' });
         expect(getRosterProfileValues({ customFields: { position: 'Forward' } })).toEqual({ position: 'Forward' });
+        expect(getRosterProfileValues({ rosterFieldValues: { grade: '6' } })).toEqual({ grade: '6' });
+    });
+
+    it('uses editable profile custom fields over imported roster field values', () => {
+        expect(getRosterProfileValues({
+            rosterFieldValues: { grade: '6', position: 'Forward' },
+            profile: { customFields: { position: 'Guard' } }
+        })).toEqual({ grade: '6', position: 'Guard' });
     });
 
     it('builds persisted roster field definitions with visibility and menu options', () => {


### PR DESCRIPTION
Closes #779

## Summary
- Updated roster profile value loading to include approved registration `rosterFieldValues`.
- Preserved editable profile custom fields as the preferred value when both persisted shapes exist.
- Added focused unit coverage for imported roster field values appearing in edit flows.

## Validation
- `npx vitest run tests/unit/roster-profile-fields.test.js`