### PR TITLE
Include shared games on homepage

### DIFF
--- a/docs/pr-notes/runs/785-ci-fix-20260507T150823Z/architecture.md
+++ b/docs/pr-notes/runs/785-ci-fix-20260507T150823Z/architecture.md
@@ -1,0 +1,7 @@
+# Architecture note
+
+Root cause: PR #785 changes `js/db.js` homepage live-game discovery logic, but no direct import of `db.js` changed its cache-bust query parameter in the branch diff. The cache-bust guard requires at least one matching `db.js?v=<n>` import update whenever `js/db.js` changes.
+
+Decision: bump the homepage `index.html` import from `./js/db.js?v=29` to `./js/db.js?v=30` because the changed exports (`getUpcomingLiveGames`, `getLiveGamesNow`, `getRecentLiveTrackedGames`) are consumed there.
+
+Risk and rollback: low risk, static import URL only. Roll back by reverting the version bump if the underlying `js/db.js` change is reverted.

--- a/docs/pr-notes/runs/785-ci-fix-20260507T150823Z/code-plan.md
+++ b/docs/pr-notes/runs/785-ci-fix-20260507T150823Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code plan
+
+1. Locate imports of `js/db.js` used by the homepage functions changed in this PR.
+2. Update `index.html` from `./js/db.js?v=29` to `./js/db.js?v=30`.
+3. Do not change unrelated imports or refactor code.
+4. Run the cache-bust guard and targeted unit test, then commit.

--- a/docs/pr-notes/runs/785-ci-fix-20260507T150823Z/qa.md
+++ b/docs/pr-notes/runs/785-ci-fix-20260507T150823Z/qa.md
@@ -1,0 +1,9 @@
+# QA note
+
+Acceptance criteria:
+- `scripts/check-critical-cache-bust.mjs` passes for the PR diff.
+- Existing unit coverage for homepage shared games still passes.
+
+Validation:
+- Run `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=master node scripts/check-critical-cache-bust.mjs`.
+- Run `npm run test:unit -- tests/unit/db-homepage-shared-games.test.js` for the affected db behavior.

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -17,6 +17,22 @@
       ]
     },
     {
+      "collectionGroup": "sharedGames",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "type", "order": "ASCENDING" },
+        { "fieldPath": "date", "order": "ASCENDING" }
+      ]
+    },
+    {
+      "collectionGroup": "sharedGames",
+      "queryScope": "COLLECTION_GROUP",
+      "fields": [
+        { "fieldPath": "liveStatus", "order": "ASCENDING" },
+        { "fieldPath": "date", "order": "DESCENDING" }
+      ]
+    },
+    {
       "collectionGroup": "drillLibrary",
       "queryScope": "COLLECTION",
       "fields": [

--- a/index.html
+++ b/index.html
@@ -652,7 +652,7 @@
   <script type="module">
     import { checkAuth, getRedirectUrl } from './js/auth.js?v=13';
     import { renderHeader, formatDate, formatTime } from './js/utils.js?v=8';
-    import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=29';
+    import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=30';
     import { initHomepage } from './js/homepage.js?v=2';
 
     initHomepage({

--- a/js/db.js
+++ b/js/db.js
@@ -3402,6 +3402,85 @@ export async function getUnreadChatCounts(userId, teamIds) {
     return counts;
 }
 
+
+function normalizeGameDateValue(value) {
+    if (!value) return null;
+    if (typeof value?.toDate === 'function') return value.toDate();
+    if (value instanceof Date) return value;
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function compareGamesByDateAsc(a, b) {
+    const aDate = normalizeGameDateValue(a?.date);
+    const bDate = normalizeGameDateValue(b?.date);
+    if (!aDate && !bDate) return 0;
+    if (!aDate) return 1;
+    if (!bDate) return -1;
+    return aDate - bDate;
+}
+
+function compareGamesByDateDesc(a, b) {
+    return compareGamesByDateAsc(b, a);
+}
+
+function getSharedHomepageTeamIds(sharedGame) {
+    return Array.from(new Set([
+        sharedGame?.homeTeamId,
+        sharedGame?.awayTeamId,
+        ...(Array.isArray(sharedGame?.teamIds) ? sharedGame.teamIds : [])
+    ].filter(Boolean)));
+}
+
+async function projectSharedHomepageGame(sharedGame, shouldIncludeTeam) {
+    const teamIds = getSharedHomepageTeamIds(sharedGame);
+
+    for (const teamId of teamIds) {
+        const teamSnap = await getDoc(doc(db, 'teams', teamId));
+        if (!teamSnap.exists()) {
+            continue;
+        }
+
+        const team = { id: teamSnap.id, ...teamSnap.data() };
+        if (!shouldIncludeTeam(team)) {
+            continue;
+        }
+
+        const projectedGame = projectSharedGameForTeam(sharedGame, teamId);
+        if (!projectedGame) {
+            continue;
+        }
+
+        return {
+            ...projectedGame,
+            team
+        };
+    }
+
+    return null;
+}
+
+async function getSharedHomepageGames(queryConstraints, shouldIncludeTeam, maxResults) {
+    const sharedGamesRef = collectionGroup(db, 'sharedGames');
+    const snapshot = await getDocs(query(sharedGamesRef, ...queryConstraints));
+    const games = [];
+
+    for (const docSnap of snapshot.docs) {
+        const sharedGame = normalizeSharedGameSnapshot(docSnap);
+        const projectedGame = await projectSharedHomepageGame(sharedGame, shouldIncludeTeam);
+        if (!projectedGame) {
+            continue;
+        }
+
+        games.push(projectedGame);
+        if (maxResults && games.length >= maxResults) {
+            break;
+        }
+    }
+
+    return games;
+}
+
 // ============ LIVE GAME EVENTS ============
 
 /**
@@ -3700,11 +3779,22 @@ export async function getUpcomingLiveGames(limitCount = 10) {
         }
     }
 
-    games.sort((a, b) => {
-        const aDate = a.date?.toDate ? a.date.toDate() : new Date(a.date);
-        const bDate = b.date?.toDate ? b.date.toDate() : new Date(b.date);
-        return aDate - bDate;
-    });
+    try {
+        const sharedGames = await getSharedHomepageGames([
+            ...queryConstraints,
+            limitQuery(fetchBatchSize)
+        ], shouldIncludeTeamInLiveOrUpcoming);
+        games.push(...sharedGames.filter((game) => {
+            return game.type !== 'practice'
+                && game.status !== 'completed'
+                && game.status !== 'cancelled'
+                && game.liveStatus !== 'completed';
+        }));
+    } catch (error) {
+        console.warn('Could not load shared upcoming live games:', error?.message || error);
+    }
+
+    games.sort(compareGamesByDateAsc);
 
     return games.slice(0, limitCount);
 }
@@ -4163,6 +4253,15 @@ export async function getLiveGamesNow() {
         games.push(gameData);
     }
 
+    try {
+        const sharedGames = await getSharedHomepageGames([
+            where('liveStatus', '==', 'live')
+        ], shouldIncludeTeamInLiveOrUpcoming);
+        games.push(...sharedGames);
+    } catch (error) {
+        console.warn('Could not load shared live games:', error?.message || error);
+    }
+
     return games;
 }
 
@@ -4172,14 +4271,17 @@ export async function getLiveGamesNow() {
 export async function getRecentLiveTrackedGames(limitCount = 6) {
     const now = new Date();
     const oneWeekAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
-
-    const gamesRef = collectionGroup(db, 'games');
-    const q = query(
-        gamesRef,
+    const recentQueryConstraints = [
         where('liveStatus', '==', 'completed'),
         where('date', '>=', Timestamp.fromDate(oneWeekAgo)),
         orderBy('date', 'desc'),
         limitQuery(limitCount)
+    ];
+
+    const gamesRef = collectionGroup(db, 'games');
+    const q = query(
+        gamesRef,
+        ...recentQueryConstraints
     );
 
     const snapshot = await getDocs(q);
@@ -4201,7 +4303,16 @@ export async function getRecentLiveTrackedGames(limitCount = 6) {
         games.push(gameData);
     }
 
-    return games;
+    try {
+        const sharedGames = await getSharedHomepageGames(recentQueryConstraints, shouldIncludeTeamInReplay, limitCount);
+        games.push(...sharedGames);
+    } catch (error) {
+        console.warn('Could not load shared replay games:', error?.message || error);
+    }
+
+    games.sort(compareGamesByDateDesc);
+
+    return games.slice(0, limitCount);
 }
 
 // ============================================

--- a/tests/unit/db-homepage-shared-games.test.js
+++ b/tests/unit/db-homepage-shared-games.test.js
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readDbSource() {
+    return readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+}
+
+function getFunctionSource(source, functionName) {
+    const start = source.indexOf(`export async function ${functionName}`);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const nextExport = source.indexOf('\nexport async function ', start + 1);
+    return source.slice(start, nextExport === -1 ? source.length : nextExport);
+}
+
+describe('homepage shared game discovery queries', () => {
+    it('includes sharedGames in live, upcoming, and replay homepage discovery', () => {
+        const source = readDbSource();
+
+        expect(source).toContain("collectionGroup(db, 'sharedGames')");
+        expect(source).toContain('projectSharedGameForTeam(sharedGame, teamId)');
+
+        const upcomingSource = getFunctionSource(source, 'getUpcomingLiveGames');
+        expect(upcomingSource).toContain('getSharedHomepageGames');
+        expect(upcomingSource).toContain('shouldIncludeTeamInLiveOrUpcoming');
+        expect(upcomingSource).toContain('games.sort(compareGamesByDateAsc)');
+
+        const liveSource = getFunctionSource(source, 'getLiveGamesNow');
+        expect(liveSource).toContain('getSharedHomepageGames');
+        expect(liveSource).toContain("where('liveStatus', '==', 'live')");
+        expect(liveSource).toContain('shouldIncludeTeamInLiveOrUpcoming');
+
+        const replaySource = getFunctionSource(source, 'getRecentLiveTrackedGames');
+        expect(replaySource).toContain('getSharedHomepageGames(recentQueryConstraints, shouldIncludeTeamInReplay, limitCount)');
+        expect(replaySource).toContain('games.sort(compareGamesByDateDesc)');
+        expect(replaySource).toContain('return games.slice(0, limitCount)');
+    });
+});

--- a/tests/unit/db-homepage-shared-games.test.js
+++ b/tests/unit/db-homepage-shared-games.test.js
@@ -5,6 +5,10 @@ function readDbSource() {
     return readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
 }
 
+function readFirestoreIndexes() {
+    return JSON.parse(readFileSync(new URL('../../firestore.indexes.json', import.meta.url), 'utf8'));
+}
+
 function getFunctionSource(source, functionName) {
     const start = source.indexOf(`export async function ${functionName}`);
     expect(start).toBeGreaterThanOrEqual(0);
@@ -33,5 +37,15 @@ describe('homepage shared game discovery queries', () => {
         expect(replaySource).toContain('getSharedHomepageGames(recentQueryConstraints, shouldIncludeTeamInReplay, limitCount)');
         expect(replaySource).toContain('games.sort(compareGamesByDateDesc)');
         expect(replaySource).toContain('return games.slice(0, limitCount)');
+    });
+
+    it('declares sharedGames composite indexes used by homepage collection group queries', () => {
+        const indexConfig = readFirestoreIndexes();
+        const sharedGameIndexes = indexConfig.indexes
+            .filter((index) => index.collectionGroup === 'sharedGames')
+            .map((index) => index.fields.map((field) => `${field.fieldPath}:${field.order || field.arrayConfig}`).join(','));
+
+        expect(sharedGameIndexes).toContain('type:ASCENDING,date:ASCENDING');
+        expect(sharedGameIndexes).toContain('liveStatus:ASCENDING,date:DESCENDING');
     });
 });


### PR DESCRIPTION
Closes #784

## Summary
- Query `sharedGames` alongside native `games` for homepage live, upcoming, and replay discovery.
- Project shared games through the existing shared-game helper so homepage links use the synthetic shared game ID that `live-game.html` can load.
- Preserve public team visibility filters and date sorting before limiting homepage results.

## Tests
- `npx vitest run tests/unit/homepage-index.test.js tests/unit/db-homepage-shared-games.test.js`
- `node --check js/db.js`