### PR TITLE
Fix post-game DNP stat edits

### DIFF
--- a/game.html
+++ b/game.html
@@ -356,7 +356,7 @@
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js';
         import { resolveLiveStatConfig } from './js/live-game-state.js?v=3';
         import { resolveReportStatColumns, resolveOpponentReportStatColumns } from './js/game-report-stats.js?v=1';
-        import { resolvePostGameStatFields, buildCompletedGamePlayerStatsPayload, getPostGameEditorNextIndex } from './js/post-game-stat-editor.js?v=1';
+        import { resolvePostGameStatFields, resolvePostGameEditorDidNotPlay, buildCompletedGamePlayerStatsPayload, getPostGameEditorNextIndex } from './js/post-game-stat-editor.js?v=2';
         import { buildHighlightShareUrl, normalizeGameRecapHighlightClips } from './js/live-game-video.js?v=3';
 
         let currentUser = null;
@@ -929,13 +929,18 @@ Write the match report now:`;
             }
 
             const statFields = resolvePostGameStatFields({ resolvedConfig, statsMap });
+            const pendingDidNotPlayMap = {};
             let currentIndex = 0;
 
             function renderEditor() {
                 const player = players[currentIndex];
                 if (!player) return;
                 const playerStats = statsMap[player.id] || {};
-                const didNotPlay = didNotPlayMap[player.id] === true;
+                const didNotPlay = resolvePostGameEditorDidNotPlay({
+                    playerId: player.id,
+                    didNotPlayMap,
+                    pendingDidNotPlayMap
+                });
 
                 nameEl.textContent = player.name || 'Player';
                 metaEl.textContent = `#${player.number || '-'} • Player ${currentIndex + 1} of ${players.length}`;
@@ -964,6 +969,9 @@ Write the match report now:`;
             }
 
             function openEditor() {
+                Object.keys(pendingDidNotPlayMap).forEach((playerId) => {
+                    delete pendingDidNotPlayMap[playerId];
+                });
                 admin.classList.remove('hidden');
                 panel.classList.remove('hidden');
                 status.textContent = '';
@@ -1002,6 +1010,7 @@ Write the match report now:`;
                     await setCompletedGamePlayerStats(teamId, gameId, player.id, payload);
                     statsMap[player.id] = { ...(payload.stats || {}) };
                     didNotPlayMap[player.id] = payload.didNotPlay === true;
+                    pendingDidNotPlayMap[player.id] = payload.didNotPlay === true;
                     timeMap[player.id] = payload.timeMs || 0;
                     rerenderTable();
 
@@ -1036,7 +1045,13 @@ Write the match report now:`;
                 currentIndex = getPostGameEditorNextIndex(currentIndex, 'next', players.length);
                 renderEditor();
             });
-            dnpToggle.addEventListener('change', renderEditor);
+            dnpToggle.addEventListener('change', () => {
+                const player = players[currentIndex];
+                if (player) {
+                    pendingDidNotPlayMap[player.id] = dnpToggle.checked;
+                }
+                renderEditor();
+            });
             saveBtn?.addEventListener('click', () => saveCurrent(null));
             savePrevBtn?.addEventListener('click', () => saveCurrent('previous'));
             saveNextBtn?.addEventListener('click', () => saveCurrent('next'));

--- a/js/post-game-stat-editor.js
+++ b/js/post-game-stat-editor.js
@@ -35,6 +35,17 @@ function normalizeNumericInput(value) {
     return Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
 }
 
+export function resolvePostGameEditorDidNotPlay({
+    playerId = '',
+    didNotPlayMap = {},
+    pendingDidNotPlayMap = {}
+} = {}) {
+    if (Object.prototype.hasOwnProperty.call(pendingDidNotPlayMap || {}, playerId)) {
+        return pendingDidNotPlayMap[playerId] === true;
+    }
+    return didNotPlayMap?.[playerId] === true;
+}
+
 export function buildCompletedGamePlayerStatsPayload({
     player = {},
     statFields = [],

--- a/tests/unit/post-game-stat-editor.test.js
+++ b/tests/unit/post-game-stat-editor.test.js
@@ -4,6 +4,7 @@ import { readFileSync } from 'node:fs';
 import {
     buildCompletedGamePlayerStatsPayload,
     getPostGameEditorNextIndex,
+    resolvePostGameEditorDidNotPlay,
     resolvePostGameStatFields
 } from '../../js/post-game-stat-editor.js';
 
@@ -48,6 +49,20 @@ describe('post-game stat editor helpers', () => {
         });
     });
 
+    it('keeps an unsaved DNP checkbox change ahead of the persisted row value', () => {
+        expect(resolvePostGameEditorDidNotPlay({
+            playerId: 'p1',
+            didNotPlayMap: { p1: true },
+            pendingDidNotPlayMap: { p1: false }
+        })).toBe(false);
+
+        expect(resolvePostGameEditorDidNotPlay({
+            playerId: 'p2',
+            didNotPlayMap: { p2: false },
+            pendingDidNotPlayMap: { p2: true }
+        })).toBe(true);
+    });
+
     it('steps through the roster for save and next or previous actions', () => {
         expect(getPostGameEditorNextIndex(0, 'previous', 4)).toBe(0);
         expect(getPostGameEditorNextIndex(0, 'next', 4)).toBe(1);
@@ -60,6 +75,7 @@ describe('post-game stat editor helpers', () => {
 
         expect(pageSource).toContain('id="edit-stats-btn"');
         expect(pageSource).toContain('id="stats-save-next-btn"');
+        expect(pageSource).toContain('resolvePostGameEditorDidNotPlay');
         expect(pageSource).toContain('setCompletedGamePlayerStats');
     });
 });


### PR DESCRIPTION
Closes #786

## Summary
- Track pending Did Not Play checkbox changes in the post-game stat editor instead of immediately re-reading the persisted value.
- Re-render stat inputs from the pending DNP state so the checkbox retains the user's change and enables or disables inputs correctly.
- Added unit coverage for pending DNP state resolution.

## Validation
- `npx vitest run tests/unit/post-game-stat-editor.test.js`