### PR TITLE
Add team chat recipient targeting

### DIFF
--- a/docs/team-chat.md
+++ b/docs/team-chat.md
@@ -15,6 +15,7 @@ Goal: Add persistent team chat for anyone who has access to a team (owner, admin
 - Message deletion (own messages, or any message for moderators)
 - Pagination (50 messages per load)
 - Manual refresh button
+- Coach/admin recipient picker for full team, staff-only, or selected roster/community members
 
 ### Deferred Features
 - Real-time updates (Firestore onSnapshot) - using manual refresh instead
@@ -41,6 +42,9 @@ Goal: Add persistent team chat for anyone who has access to a team (owner, admin
   - `createdAt: Timestamp`
   - `editedAt: Timestamp` (optional, set when edited)
   - `deleted: boolean` (soft delete flag)
+  - `targetType: "full_team" | "staff" | "individuals"` (defaults to `full_team`)
+  - `recipientIds: string[]` (selected roster/community recipient identifiers for targeted sends)
+  - `targetRole: string | null` (for role targets such as `staff`)
 
 ## Access Control
 A user can read/post if they have team access:
@@ -65,7 +69,7 @@ Moderation (delete others' messages):
 | `dashboard.html` | Added Chat button to team cards |
 | `parent-dashboard.html` | Added Team Chats section |
 | `js/team-admin-banner.js` | Added Chat icon and navigation card |
-| `team-chat.html` | NEW - Full chat page |
+| `team-chat.html` | NEW - Full chat page with recipient selection for coach/admin sends |
 | `firestore.rules` | Added `canAccessTeamChat` helper and `chatMessages` subcollection rules |
 
 ## Firestore Index Required
@@ -87,6 +91,8 @@ This index may be auto-created when the first query runs, or can be created manu
 - [x] Unauthenticated user redirected to login
 - [x] User without team access redirected to dashboard
 - [x] Send message appears in list
+- [x] Coach/admin can choose full team, staff-only, or selected roster/community recipients before sending
+- [x] Targeted sends persist `targetType`, `recipientIds`, and `targetRole` metadata with the chat message
 - [x] Edit own message shows "edited" indicator
 - [x] Delete own message shows "Message removed"
 - [x] Coach/Admin can delete any message (moderation)

--- a/js/db.js
+++ b/js/db.js
@@ -3246,7 +3246,10 @@ export async function postChatMessage(teamId, {
     ai = false,
     aiName = null,
     aiQuestion = null,
-    aiMeta = null
+    aiMeta = null,
+    targetType = 'full_team',
+    recipientIds = [],
+    targetRole = null
 }) {
     const messagesRef = collection(db, 'teams', teamId, 'chatMessages');
     const createdAt = Timestamp.now();
@@ -3265,6 +3268,16 @@ export async function postChatMessage(teamId, {
         ...attachment,
         uploadedAt: createdAt
     }));
+    const allowedTargetTypes = new Set(['full_team', 'staff', 'individuals']);
+    const normalizedTargetType = allowedTargetTypes.has(targetType) ? targetType : 'full_team';
+    const normalizedRecipientIds = normalizedTargetType === 'individuals'
+        ? Array.from(new Set((Array.isArray(recipientIds) ? recipientIds : [])
+            .map((id) => String(id || '').trim())
+            .filter(Boolean)))
+        : [];
+    const effectiveTargetType = normalizedTargetType === 'individuals' && normalizedRecipientIds.length === 0
+        ? 'full_team'
+        : normalizedTargetType;
     return await addDoc(messagesRef, {
         text,
         senderId,
@@ -3285,7 +3298,10 @@ export async function postChatMessage(teamId, {
         ai: ai === true,
         aiName: aiName || null,
         aiQuestion: aiQuestion || null,
-        aiMeta: aiMeta || null
+        aiMeta: aiMeta || null,
+        targetType: effectiveTargetType,
+        recipientIds: normalizedRecipientIds,
+        targetRole: effectiveTargetType === 'staff' ? (targetRole || 'staff') : null
     });
 }
 

--- a/team-chat.html
+++ b/team-chat.html
@@ -99,6 +99,20 @@
 
             <!-- Composer -->
             <div class="p-4 border-t border-gray-200 bg-gray-50">
+                <div id="recipient-picker" class="hidden mb-3 rounded-xl border border-gray-200 bg-white p-3">
+                    <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+                        <div>
+                            <label for="recipient-target" class="block text-xs font-semibold uppercase tracking-wide text-gray-500">Send to</label>
+                            <select id="recipient-target" class="mt-1 rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500">
+                                <option value="full_team">Full team</option>
+                                <option value="staff">Staff only</option>
+                                <option value="individuals">Selected members</option>
+                            </select>
+                        </div>
+                        <div id="recipient-summary" class="text-sm text-gray-700 sm:text-right">Audience: Full team</div>
+                    </div>
+                    <div id="recipient-list" class="hidden mt-3 max-h-44 overflow-y-auto rounded-lg border border-gray-200 divide-y divide-gray-100"></div>
+                </div>
                 <div class="flex gap-2 items-start">
                     <div class="relative flex-1">
                         <div class="flex items-center gap-1 w-full rounded-lg border border-gray-300 bg-white px-2 focus-within:ring-2 focus-within:ring-primary-500 focus-within:border-primary-500">
@@ -369,6 +383,9 @@
         let activeReactionInfo = null;
         const pendingReactionOps = new Set();
         const reactionUserNameCache = new Map();
+        let recipientOptions = [];
+        let selectedRecipientTarget = 'full_team';
+        let selectedRecipientIds = new Set();
         const reactionLongPress = {
             timer: null,
             key: null,
@@ -429,6 +446,9 @@
                 }
 
                 canModerate = canModerateChat(userWithProfile, currentTeam);
+                if (canModerate) {
+                    await loadRecipientOptions();
+                }
 
                 // Render team navigation banner with appropriate access level
                 const accessLevel = canModerate ? 'full' : 'parent';
@@ -440,6 +460,7 @@
                     accessLevel,
                     exitUrl
                 });
+                renderRecipientPicker();
 
                 // Load messages (real-time)
                 startRealtimeUpdates();
@@ -980,6 +1001,129 @@
             }).join('');
 
             preview.classList.remove('hidden');
+        }
+
+        function getRecipientOptionId(kind, value) {
+            return `${kind}:${String(value || '').trim()}`;
+        }
+
+        function getRecipientOptionLabel(option) {
+            return option.detail ? `${option.name} (${option.detail})` : option.name;
+        }
+
+        async function loadRecipientOptions() {
+            try {
+                const players = await getPlayers(teamId);
+                const options = [];
+                players.forEach((player) => {
+                    if (!player?.id) return;
+                    const number = player.number !== undefined && player.number !== null && String(player.number).trim() !== ''
+                        ? `#${player.number}`
+                        : 'Roster';
+                    options.push({
+                        id: getRecipientOptionId('player', player.id),
+                        name: player.name || `Player ${player.id.slice(0, 6)}`,
+                        detail: number
+                    });
+                    (Array.isArray(player.parents) ? player.parents : []).forEach((parent) => {
+                        const parentKey = parent?.userId || parent?.email || '';
+                        if (!parentKey) return;
+                        const parentName = parent.name || parent.fullName || parent.email || 'Guardian';
+                        options.push({
+                            id: getRecipientOptionId(parent.userId ? 'user' : 'email', parentKey),
+                            name: parentName,
+                            detail: player.name ? `Guardian for ${player.name}` : 'Guardian'
+                        });
+                    });
+                });
+                const uniqueById = new Map();
+                options.forEach((option) => uniqueById.set(option.id, option));
+                recipientOptions = Array.from(uniqueById.values())
+                    .sort((a, b) => getRecipientOptionLabel(a).localeCompare(getRecipientOptionLabel(b)));
+            } catch (error) {
+                console.warn('Failed to load chat recipient options:', error);
+                recipientOptions = [];
+            }
+        }
+
+        function buildRecipientTargetMetadata() {
+            if (selectedRecipientTarget === 'staff') {
+                return {
+                    targetType: 'staff',
+                    recipientIds: [],
+                    targetRole: 'staff'
+                };
+            }
+            if (selectedRecipientTarget === 'individuals' && selectedRecipientIds.size > 0) {
+                return {
+                    targetType: 'individuals',
+                    recipientIds: Array.from(selectedRecipientIds).sort(),
+                    targetRole: null
+                };
+            }
+            return {
+                targetType: 'full_team',
+                recipientIds: [],
+                targetRole: null
+            };
+        }
+
+        function getRecipientSummaryText() {
+            const target = buildRecipientTargetMetadata();
+            if (target.targetType === 'staff') {
+                return 'Audience: Staff only';
+            }
+            if (target.targetType === 'individuals') {
+                const selected = recipientOptions.filter((option) => selectedRecipientIds.has(option.id));
+                if (selected.length === 0) {
+                    return 'Audience: Full team (no selected members yet)';
+                }
+                if (selected.length <= 3) {
+                    return `Audience: ${selected.map(getRecipientOptionLabel).join(', ')}`;
+                }
+                return `Audience: ${selected.slice(0, 3).map(getRecipientOptionLabel).join(', ')} +${selected.length - 3} more`;
+            }
+            return 'Audience: Full team';
+        }
+
+        function renderRecipientPicker() {
+            const picker = document.getElementById('recipient-picker');
+            const summary = document.getElementById('recipient-summary');
+            const list = document.getElementById('recipient-list');
+            const select = document.getElementById('recipient-target');
+            if (!picker || !summary || !list || !select) return;
+
+            if (!canModerate) {
+                picker.classList.add('hidden');
+                return;
+            }
+
+            picker.classList.remove('hidden');
+            select.value = selectedRecipientTarget;
+            summary.textContent = getRecipientSummaryText();
+
+            if (selectedRecipientTarget !== 'individuals') {
+                list.classList.add('hidden');
+                list.innerHTML = '';
+                return;
+            }
+
+            list.classList.remove('hidden');
+            if (recipientOptions.length === 0) {
+                list.innerHTML = '<div class="px-3 py-2 text-sm text-gray-500">No roster or community members are available yet.</div>';
+                return;
+            }
+
+            list.innerHTML = recipientOptions.map((option) => `
+                <label class="flex cursor-pointer items-center gap-3 px-3 py-2 hover:bg-gray-50">
+                    <input type="checkbox" data-recipient-id="${escapeHtml(option.id)}" ${selectedRecipientIds.has(option.id) ? 'checked' : ''}
+                        class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500">
+                    <span class="min-w-0 flex-1">
+                        <span class="block truncate text-sm font-medium text-gray-800">${escapeHtml(option.name)}</span>
+                        ${option.detail ? `<span class="block truncate text-xs text-gray-500">${escapeHtml(option.detail)}</span>` : ''}
+                    </span>
+                </label>
+            `).join('');
         }
 
         function updateComposerState() {
@@ -1762,6 +1906,23 @@
                 if (!actionButton) return;
                 handleGalleryMediaAction(actionButton);
             });
+            document.getElementById('recipient-target').addEventListener('change', (event) => {
+                selectedRecipientTarget = event.target.value || 'full_team';
+                if (selectedRecipientTarget !== 'individuals') {
+                    selectedRecipientIds = new Set();
+                }
+                renderRecipientPicker();
+            });
+            document.getElementById('recipient-list').addEventListener('change', (event) => {
+                const recipientId = event.target?.dataset?.recipientId;
+                if (!recipientId) return;
+                if (event.target.checked) {
+                    selectedRecipientIds.add(recipientId);
+                } else {
+                    selectedRecipientIds.delete(recipientId);
+                }
+                renderRecipientPicker();
+            });
 
             // Enter key to send
             document.getElementById('message-input').addEventListener('keypress', (e) => {
@@ -1931,7 +2092,8 @@
                     senderName: currentUserProfile?.fullName || null,
                     senderEmail: currentUser.email,
                     senderPhotoUrl: currentUserProfile?.photoUrl || null,
-                    attachments: mediaPayloads
+                    attachments: mediaPayloads,
+                    ...buildRecipientTargetMetadata()
                 });
 
                 input.value = '';

--- a/team-chat.html
+++ b/team-chat.html
@@ -217,7 +217,7 @@
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=13';
-        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=29';
+        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=30';
         import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from './js/team-chat-last-read.js?v=3';
         import {
             MAX_CHAT_MEDIA_SIZE,

--- a/tests/unit/team-chat-recipient-targets.test.js
+++ b/tests/unit/team-chat-recipient-targets.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readRepoFile(relativePath) {
+    return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+describe('team chat recipient targets', () => {
+    it('exposes recipient options and audience summary in the composer', () => {
+        const html = readRepoFile('team-chat.html');
+
+        expect(html).toContain('id="recipient-picker"');
+        expect(html).toContain('id="recipient-target"');
+        expect(html).toContain('<option value="full_team">Full team</option>');
+        expect(html).toContain('<option value="staff">Staff only</option>');
+        expect(html).toContain('<option value="individuals">Selected members</option>');
+        expect(html).toContain('id="recipient-summary"');
+    });
+
+    it('loads roster/community recipient options and sends target metadata', () => {
+        const html = readRepoFile('team-chat.html');
+
+        expect(html).toContain('await loadRecipientOptions();');
+        expect(html).toContain('const players = await getPlayers(teamId);');
+        expect(html).toContain('Array.isArray(player.parents)');
+        expect(html).toContain('...buildRecipientTargetMetadata()');
+        expect(html).toContain("targetType: 'staff'");
+        expect(html).toContain("targetType: 'full_team'");
+        expect(html).toContain('recipientIds: Array.from(selectedRecipientIds).sort()');
+    });
+
+    it('persists normalized target metadata from postChatMessage', () => {
+        const db = readRepoFile('js/db.js');
+
+        expect(db).toContain("targetType = 'full_team'");
+        expect(db).toContain('recipientIds = []');
+        expect(db).toContain('targetRole = null');
+        expect(db).toContain("const allowedTargetTypes = new Set(['full_team', 'staff', 'individuals']);");
+        expect(db).toContain("const effectiveTargetType = normalizedTargetType === 'individuals' && normalizedRecipientIds.length === 0");
+        expect(db).toContain('targetType: effectiveTargetType');
+        expect(db).toContain('recipientIds: normalizedRecipientIds');
+        expect(db).toContain("targetRole: effectiveTargetType === 'staff' ? (targetRole || 'staff') : null");
+    });
+});


### PR DESCRIPTION
Closes #787

## Summary
- Added a coach/admin recipient picker to team chat with full team, staff-only, and selected member options.
- Summarized the selected audience before send so senders can confirm the target.
- Persisted target metadata on chat messages via `targetType`, `recipientIds`, and `targetRole` while keeping full-team behavior as the default.

## Tests
- `npx vitest run tests/unit/team-chat-recipient-targets.test.js`
- Also ran full unit suite via `npm test -- tests/unit/team-chat-recipient-targets.test.js`, which passed.