### PR TITLE
Show family player tracking items

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -82,6 +82,35 @@ service cloud.firestore {
              teamId in get(userPath).data.get('parentTeamIds', []);
     }
 
+    function isPlayerSelf(teamId, playerId) {
+      let playerPath = /databases/$(database)/documents/teams/$(teamId)/players/$(playerId);
+      let userPath = /databases/$(database)/documents/users/$(request.auth.uid);
+      let playerKey = teamId + "::" + playerId;
+      return isSignedIn() &&
+             (
+               (exists(playerPath) && get(playerPath).data.get('userId', get(playerPath).data.get('authUid', get(playerPath).data.get('accountUserId', ''))) == request.auth.uid) ||
+               (exists(userPath) && playerKey in get(userPath).data.get('playerKeys', []))
+             );
+    }
+
+    function isPublicTrackingItem(data) {
+      return data.get('public', false) == true &&
+             data.get('private', false) != true &&
+             data.get('isPrivate', false) != true;
+    }
+
+    function canReadPublicTrackingStatus(teamId, data) {
+      let playerId = data.get('playerId', data.get('childId', data.get('memberId', '')));
+      let itemId = data.get('itemId', data.get('trackingItemId', ''));
+      let itemPath = /databases/$(database)/documents/teams/$(teamId)/trackingItems/$(itemId);
+      return data.get('public', false) == true &&
+             playerId is string &&
+             itemId is string &&
+             (isParentForPlayer(teamId, playerId) || isPlayerSelf(teamId, playerId)) &&
+             exists(itemPath) &&
+             isPublicTrackingItem(get(itemPath).data);
+    }
+
     function hasIncentivePlayerLink(data) {
       return data.teamId is string &&
              data.playerId is string &&
@@ -502,6 +531,16 @@ service cloud.firestore {
 
       match /rosterFields/{fieldId} {
         allow read: if true;
+        allow create, update, delete: if isTeamOwnerOrAdmin(teamId);
+      }
+
+      match /trackingItems/{itemId} {
+        allow read: if isTeamOwnerOrAdmin(teamId) || isPublicTrackingItem(resource.data);
+        allow create, update, delete: if isTeamOwnerOrAdmin(teamId);
+      }
+
+      match /memberTracking/{trackingId} {
+        allow read: if isTeamOwnerOrAdmin(teamId) || canReadPublicTrackingStatus(teamId, resource.data);
         allow create, update, delete: if isTeamOwnerOrAdmin(teamId);
       }
 

--- a/js/db.js
+++ b/js/db.js
@@ -4988,7 +4988,12 @@ export async function getRsvpBreakdownByPlayer(teamId, gameId) {
 }
 
 export async function getPublicTrackingItems(teamId) {
-    const snap = await getDocs(query(collection(db, `teams/${teamId}/trackingItems`), where('public', '==', true)));
+    const snap = await getDocs(query(
+        collection(db, `teams/${teamId}/trackingItems`),
+        where('public', '==', true),
+        where('private', '==', false),
+        where('isPrivate', '==', false)
+    ));
     return snap.docs
         .map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }))
         .filter(isPublicTrackingItem);
@@ -5000,16 +5005,24 @@ export async function getPlayerTrackingStatuses(teamId, playerIds = []) {
         .filter(Boolean)));
     if (uniquePlayerIds.length === 0) return [];
 
-    const snapshots = await Promise.all(uniquePlayerIds.map((playerId) => (
-        getDocs(query(
-            collection(db, `teams/${teamId}/memberTracking`),
-            where('playerId', '==', playerId),
+    const playerIdFields = ['playerId', 'childId', 'memberId'];
+    const trackingCollection = collection(db, `teams/${teamId}/memberTracking`);
+    const snapshots = await Promise.all(uniquePlayerIds.flatMap((playerId) => (
+        playerIdFields.map((fieldName) => getDocs(query(
+            trackingCollection,
+            where(fieldName, '==', playerId),
             where('public', '==', true)
-        ))
+        )))
     )));
 
-    return snapshots.flatMap((snap) => snap.docs.map((docSnap) => normalizeTrackingStatus({
-        id: docSnap.id,
-        ...docSnap.data()
-    })));
+    const statusesById = new Map();
+    snapshots.forEach((snap) => {
+        snap.docs.forEach((docSnap) => {
+            statusesById.set(docSnap.id, normalizeTrackingStatus({
+                id: docSnap.id,
+                ...docSnap.data()
+            }));
+        });
+    });
+    return Array.from(statusesById.values());
 }

--- a/js/db.js
+++ b/js/db.js
@@ -76,6 +76,7 @@ import {
 import { normalizeStatTrackerConfig } from './stat-leaderboards.js?v=1';
 import { buildPublishedBracketView } from './bracket-management.js?v=1';
 import { buildRolloverPlayerCopy } from './team-rollover.js?v=1';
+import { isPublicTrackingItem, normalizeTrackingStatus } from './player-tracking-summary.js?v=1';
 import {
     buildRegistrationRosterDecision,
     getRegistrationGuardianDrafts,
@@ -4957,4 +4958,31 @@ export async function getRsvpBreakdownByPlayer(teamId, gameId) {
     ]);
     const fallbackByUser = await buildFallbackPlayerIdsByUser(teamId, rsvps);
     return buildGameDayRsvpBreakdown({ players, rsvps, fallbackByUser });
+}
+
+export async function getPublicTrackingItems(teamId) {
+    const snap = await getDocs(query(collection(db, `teams/${teamId}/trackingItems`), where('public', '==', true)));
+    return snap.docs
+        .map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }))
+        .filter(isPublicTrackingItem);
+}
+
+export async function getPlayerTrackingStatuses(teamId, playerIds = []) {
+    const uniquePlayerIds = Array.from(new Set((Array.isArray(playerIds) ? playerIds : [])
+        .map((id) => String(id || '').trim())
+        .filter(Boolean)));
+    if (uniquePlayerIds.length === 0) return [];
+
+    const snapshots = await Promise.all(uniquePlayerIds.map((playerId) => (
+        getDocs(query(
+            collection(db, `teams/${teamId}/memberTracking`),
+            where('playerId', '==', playerId),
+            where('public', '==', true)
+        ))
+    )));
+
+    return snapshots.flatMap((snap) => snap.docs.map((docSnap) => normalizeTrackingStatus({
+        id: docSnap.id,
+        ...docSnap.data()
+    })));
 }

--- a/js/player-tracking-summary.js
+++ b/js/player-tracking-summary.js
@@ -1,0 +1,63 @@
+function cleanString(value) {
+    return String(value ?? '').trim();
+}
+
+export function isPublicTrackingItem(item = {}) {
+    const visibility = cleanString(item.visibility || item.access || '').toLowerCase();
+    if (visibility === 'private' || visibility === 'admin') return false;
+    if (item.isPrivate === true || item.private === true) return false;
+    return item.public === true || item.isPublic === true || visibility === 'public';
+}
+
+export function normalizeTrackingItem(item = {}) {
+    const id = cleanString(item.id || item.itemId || item.trackingItemId);
+    return {
+        ...item,
+        id,
+        title: cleanString(item.title || item.name || item.label || 'Tracking item'),
+        description: cleanString(item.description || item.note || ''),
+        sortOrder: Number.isFinite(Number(item.sortOrder)) ? Number(item.sortOrder) : 9999,
+        isPublic: isPublicTrackingItem(item)
+    };
+}
+
+export function normalizeTrackingStatus(status = {}) {
+    const itemId = cleanString(status.itemId || status.trackingItemId || status.id);
+    const playerId = cleanString(status.playerId || status.childId || status.memberId);
+    const value = cleanString(status.status || status.state).toLowerCase();
+    const isComplete = status.complete === true || status.completed === true || status.isComplete === true || value === 'complete' || value === 'completed' || value === 'done';
+    return {
+        ...status,
+        itemId,
+        playerId,
+        isComplete
+    };
+}
+
+export function getVisiblePlayerTrackingSummary({ items = [], statuses = [], playerIds = [] } = {}) {
+    const allowedPlayerIds = new Set((Array.isArray(playerIds) ? playerIds : [])
+        .map(cleanString)
+        .filter(Boolean));
+    const publicItems = (Array.isArray(items) ? items : [])
+        .map(normalizeTrackingItem)
+        .filter((item) => item.id && item.isPublic)
+        .sort((a, b) => a.sortOrder - b.sortOrder || a.title.localeCompare(b.title));
+    const publicItemIds = new Set(publicItems.map((item) => item.id));
+    const statusByPlayerAndItem = new Map();
+
+    (Array.isArray(statuses) ? statuses : [])
+        .map(normalizeTrackingStatus)
+        .filter((status) => status.itemId && status.playerId && publicItemIds.has(status.itemId) && allowedPlayerIds.has(status.playerId))
+        .forEach((status) => {
+            statusByPlayerAndItem.set(`${status.playerId}::${status.itemId}`, status);
+        });
+
+    return Array.from(allowedPlayerIds).map((playerId) => ({
+        playerId,
+        items: publicItems.map((item) => ({
+            ...item,
+            status: statusByPlayerAndItem.get(`${playerId}::${item.id}`) || null,
+            isComplete: statusByPlayerAndItem.get(`${playerId}::${item.id}`)?.isComplete === true
+        }))
+    }));
+}

--- a/team.html
+++ b/team.html
@@ -224,6 +224,7 @@
 
             <!-- Roster Section -->
             <section>
+                <section id="player-tracking-section" class="mb-6 hidden"></section>
                 <h2 class="text-2xl md:text-3xl font-bold mb-6 text-gray-900">Roster</h2>
                 <div class="bg-white shadow-lg rounded-2xl overflow-hidden border border-gray-200">
                     <div class="bg-gradient-to-r from-gray-50 to-white border-b border-gray-200">
@@ -259,7 +260,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, saveTeamAvailabilityPreferences, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage } from './js/db.js?v=18';
+        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, saveTeamAvailabilityPreferences, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=19';
         import { normalizeExternalWebsiteUrl, selectRotatingSponsor } from './js/local-attractions.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, escapeHtml, shareOrCopy } from './js/utils.js?v=10';
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';
@@ -276,6 +277,7 @@
         import { buildAvailabilityReminderRecipients, buildRsvpReminderMessage } from './js/schedule-notifications.js?v=4';
         import { readTeamPremiumEntitlement, renderPremiumGateState } from './js/premium-entitlements.js?v=1';
         import { renderTeamPassCard } from './js/team-pass.js?v=2';
+        import { getVisiblePlayerTrackingSummary } from './js/player-tracking-summary.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -1238,6 +1240,8 @@
                         if (profile) {
                             if (profile.isAdmin) currentUser.isAdmin = true;
                             if (profile.parentOf) currentUser.parentOf = profile.parentOf;
+                            if (profile.playerKeys) currentUser.playerKeys = profile.playerKeys;
+                            if (profile.playerOf) currentUser.playerOf = profile.playerOf;
                             if (profile.coachOf) currentUser.coachOf = profile.coachOf;
                         }
                     } catch (e) {
@@ -1624,6 +1628,8 @@
                 }
                 }
 
+                await renderPlayerTrackingSection(teamId, players);
+
                 // Render Roster
                 const rosterBody = document.getElementById('roster-list');
                 if (players.length === 0) {
@@ -1674,6 +1680,88 @@
 
             } catch (error) {
                 console.error(error);
+            }
+        }
+
+        function getPlayerTrackingVisiblePlayerIds(players) {
+            if (!currentUser || !currentTeamId) return [];
+            const ids = new Set();
+            (Array.isArray(currentUser.parentOf) ? currentUser.parentOf : [])
+                .filter((link) => link?.teamId === currentTeamId && link?.playerId)
+                .forEach((link) => ids.add(String(link.playerId).trim()));
+            (Array.isArray(currentUser.playerKeys) ? currentUser.playerKeys : [])
+                .map((key) => String(key || '').split('::'))
+                .filter(([teamId, playerId]) => teamId === currentTeamId && playerId)
+                .forEach(([, playerId]) => ids.add(playerId.trim()));
+            (Array.isArray(currentUser.playerOf) ? currentUser.playerOf : [])
+                .filter((link) => link?.teamId === currentTeamId && link?.playerId)
+                .forEach((link) => ids.add(String(link.playerId).trim()));
+            (Array.isArray(players) ? players : [])
+                .filter((player) => player?.id && [player.userId, player.authUid, player.accountUserId].includes(currentUser.uid))
+                .forEach((player) => ids.add(player.id));
+            return Array.from(ids).filter(Boolean);
+        }
+
+        function renderTrackingStatusPill(item) {
+            const classes = item.isComplete
+                ? 'bg-green-50 text-green-700 border-green-200'
+                : 'bg-amber-50 text-amber-700 border-amber-200';
+            const label = item.isComplete ? 'Complete' : 'Incomplete';
+            return `<span class="inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-semibold ${classes}">${label}</span>`;
+        }
+
+        async function renderPlayerTrackingSection(teamId, players) {
+            const section = document.getElementById('player-tracking-section');
+            if (!section) return;
+            section.classList.add('hidden');
+            section.innerHTML = '';
+
+            const visiblePlayerIds = getPlayerTrackingVisiblePlayerIds(players);
+            if (!currentUser || visiblePlayerIds.length === 0) return;
+
+            try {
+                const [items, statuses] = await Promise.all([
+                    getPublicTrackingItems(teamId),
+                    getPlayerTrackingStatuses(teamId, visiblePlayerIds)
+                ]);
+                const summaries = getVisiblePlayerTrackingSummary({ items, statuses, playerIds: visiblePlayerIds })
+                    .filter((summary) => summary.items.length > 0);
+                if (summaries.length === 0) return;
+
+                const playersById = new Map((players || []).map((player) => [player.id, player]));
+                section.classList.remove('hidden');
+                section.innerHTML = `
+                    <div class="bg-white rounded-2xl shadow-lg border border-gray-200 overflow-hidden">
+                        <div class="p-4 border-b border-gray-100 bg-gray-50">
+                            <h2 class="text-xl font-bold text-gray-900">Player checklist</h2>
+                            <p class="text-sm text-gray-500 mt-1">Public tracking items for your linked player${summaries.length === 1 ? '' : 's'}.</p>
+                        </div>
+                        <div class="divide-y divide-gray-100">
+                            ${summaries.map((summary) => {
+                                const player = playersById.get(summary.playerId) || {};
+                                const playerName = player.name || 'Player';
+                                return `
+                                    <div class="p-4">
+                                        <div class="font-semibold text-gray-900 mb-3">${escapeHtml(playerName)}</div>
+                                        <div class="space-y-2">
+                                            ${summary.items.map((item) => `
+                                                <div class="flex items-start justify-between gap-3 rounded-xl border border-gray-100 bg-gray-50 px-3 py-2">
+                                                    <div>
+                                                        <div class="text-sm font-semibold text-gray-900">${escapeHtml(item.title)}</div>
+                                                        ${item.description ? `<div class="text-xs text-gray-500 mt-0.5">${escapeHtml(item.description)}</div>` : ''}
+                                                    </div>
+                                                    ${renderTrackingStatusPill(item)}
+                                                </div>
+                                            `).join('')}
+                                        </div>
+                                    </div>
+                                `;
+                            }).join('')}
+                        </div>
+                    </div>
+                `;
+            } catch (error) {
+                console.error('Error loading player tracking summary:', error);
             }
         }
 

--- a/tests/smoke/team-schedule-calendar.spec.js
+++ b/tests/smoke/team-schedule-calendar.spec.js
@@ -107,7 +107,15 @@ export async function getLocalAttractionSponsors() {
 export async function getAdSpaceSponsors() {
     return [];
 }
-`;
+
+export async function getPublicTrackingItems() {
+    return [];
+}
+
+export async function getPlayerTrackingStatuses() {
+    return [];
+}
+	`;
 }
 
 function buildUtilsStub({ calendarEvents, teamId = 'team-a' }) {

--- a/tests/unit/player-tracking-summary.test.js
+++ b/tests/unit/player-tracking-summary.test.js
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { getVisiblePlayerTrackingSummary, isPublicTrackingItem } from '../../js/player-tracking-summary.js';
+
+describe('player tracking summary', () => {
+    it('shows only public items for requested players', () => {
+        const summary = getVisiblePlayerTrackingSummary({
+            playerIds: ['p1'],
+            items: [
+                { id: 'waiver', title: 'Waiver', public: true, sortOrder: 2 },
+                { id: 'medical', title: 'Medical form', public: false, private: true, sortOrder: 1 },
+                { id: 'photo', title: 'Photo release', visibility: 'public', sortOrder: 3 }
+            ],
+            statuses: [
+                { itemId: 'waiver', playerId: 'p1', completed: true },
+                { itemId: 'waiver', playerId: 'p2', completed: false },
+                { itemId: 'medical', playerId: 'p1', completed: true }
+            ]
+        });
+
+        expect(summary).toHaveLength(1);
+        expect(summary[0].playerId).toBe('p1');
+        expect(summary[0].items.map((item) => item.id)).toEqual(['waiver', 'photo']);
+        expect(summary[0].items[0].isComplete).toBe(true);
+        expect(summary[0].items[1].isComplete).toBe(false);
+    });
+
+    it('treats private visibility as non-public even when public is true', () => {
+        expect(isPublicTrackingItem({ public: true, visibility: 'private' })).toBe(false);
+        expect(isPublicTrackingItem({ public: true, isPrivate: true })).toBe(false);
+    });
+
+    it('wires team page and Firestore rules for family read-only access', () => {
+        const teamHtml = readFileSync(resolve(process.cwd(), 'team.html'), 'utf8');
+        const dbSource = readFileSync(resolve(process.cwd(), 'js/db.js'), 'utf8');
+        const rules = readFileSync(resolve(process.cwd(), 'firestore.rules'), 'utf8');
+
+        expect(teamHtml).toContain('id="player-tracking-section"');
+        expect(teamHtml).toContain('getPublicTrackingItems');
+        expect(teamHtml).toContain('getPlayerTrackingStatuses');
+        expect(dbSource).toContain("where('public', '==', true)");
+        expect(rules).toContain('match /trackingItems/{itemId}');
+        expect(rules).toContain('match /memberTracking/{trackingId}');
+        expect(rules).toContain('canReadPublicTrackingStatus(teamId, resource.data)');
+        expect(rules).toContain("data.get('public', false) == true");
+        expect(rules).toContain('isParentForPlayer(teamId, playerId) || isPlayerSelf(teamId, playerId)');
+        expect(rules).toContain('allow create, update, delete: if isTeamOwnerOrAdmin(teamId);');
+    });
+});

--- a/tests/unit/player-tracking-summary.test.js
+++ b/tests/unit/player-tracking-summary.test.js
@@ -40,6 +40,12 @@ describe('player tracking summary', () => {
         expect(teamHtml).toContain('getPublicTrackingItems');
         expect(teamHtml).toContain('getPlayerTrackingStatuses');
         expect(dbSource).toContain("where('public', '==', true)");
+        expect(dbSource).toContain("where('private', '==', false)");
+        expect(dbSource).toContain("where('isPrivate', '==', false)");
+        expect(dbSource).toContain("const playerIdFields = ['playerId', 'childId', 'memberId'];");
+        expect(dbSource).toContain('uniquePlayerIds.flatMap');
+        expect(dbSource).toContain("where(fieldName, '==', playerId)");
+        expect(dbSource).toContain('const statusesById = new Map();');
         expect(rules).toContain('match /trackingItems/{itemId}');
         expect(rules).toContain('match /memberTracking/{trackingId}');
         expect(rules).toContain('canReadPublicTrackingStatus(teamId, resource.data)');


### PR DESCRIPTION
Closes #794

## Summary
- Added read-only family visibility for public player tracking items on the team page.
- Added Firestore rules for roster tracking items and per-player tracking statuses so parents/players can only read public items for their linked player.
- Added unit coverage for public/private filtering, per-player isolation, and wiring/rules guardrails.

## Validation
- `npx vitest run tests/unit/player-tracking-summary.test.js`
- `firebase deploy --only firestore:rules --dry-run --project game-flow-c6311`