### PR TITLE
Expose registration roster import preview

### DIFF
--- a/docs/pr-notes/runs/806-remediator-20260507T220929Z/architecture.md
+++ b/docs/pr-notes/runs/806-remediator-20260507T220929Z/architecture.md
@@ -1,0 +1,15 @@
+# Architecture
+
+## Decision
+Keep `getFirstDefined()` unchanged for scalar aliases and add array-specific alias resolution for fee collections.
+
+## Design
+- Add a helper near `getFirstDefined()` that selects the first non-empty array candidate.
+- Treat empty arrays as missing for line-item/installment alias fallback.
+- Update only `getFeeLineItems()` and `getFeeInstallments()`.
+
+## Blast Radius
+Read/render behavior only in `js/parent-dashboard-fees.js`. No Firestore writes, rules, auth, or schema changes.
+
+## Rollback
+Revert the helper and restore the two functions to their previous `getFirstDefined()` calls. No data cleanup required.

--- a/docs/pr-notes/runs/806-remediator-20260507T220929Z/code-plan.md
+++ b/docs/pr-notes/runs/806-remediator-20260507T220929Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code Plan
+
+1. Inspect `js/parent-dashboard-fees.js` for `getFirstDefined`, `getFeeLineItems`, and `getFeeInstallments`.
+2. Add a minimal helper that returns the first array candidate with length > 0, otherwise `[]`.
+3. Replace only the two collection alias resolvers to use the new helper.
+4. Run lightweight validation and commit the source plus role notes.

--- a/docs/pr-notes/runs/806-remediator-20260507T220929Z/qa.md
+++ b/docs/pr-notes/runs/806-remediator-20260507T220929Z/qa.md
@@ -1,0 +1,14 @@
+# QA Plan
+
+Automated test runner is not defined for this static site. Validate with direct code inspection and syntax parsing.
+
+## Cases
+- `lineItems: []`, populated `invoiceLineItems` falls back and renders rows.
+- populated `lineItems`, populated `invoiceLineItems` keeps `lineItems` as winner.
+- `installments: []`, populated `installmentSchedule` falls back and renders schedule.
+- populated `installments`, populated `installmentSchedule` keeps `installments` as winner.
+- both aliases empty/missing returns an empty array without errors.
+
+## Validation
+- Run JavaScript syntax validation on `js/parent-dashboard-fees.js` with Node module import/parse check where possible.
+- Inspect diff to confirm only scoped alias fallback code changed.

--- a/docs/pr-notes/runs/806-remediator-20260507T220929Z/requirements.md
+++ b/docs/pr-notes/runs/806-remediator-20260507T220929Z/requirements.md
@@ -1,0 +1,18 @@
+# Requirements
+
+## Problem Statement
+Parent fee detail rendering can show incomplete invoice or installment information when the primary array field exists but is empty. Empty arrays currently block fallback to legacy or alternate fields, so parents may not see available line items or installment schedules.
+
+## Acceptance Criteria
+1. When a fee record has `lineItems: []` and `invoiceLineItems` contains one or more items, the parent fee UI displays the `invoiceLineItems` entries.
+2. When a fee record has `installments: []` and `installmentSchedule` contains one or more entries, the parent fee UI displays the `installmentSchedule` entries.
+3. When the primary field contains one or more entries, the UI uses the primary field and does not fall back.
+4. When both primary and fallback fields are empty or missing, the UI shows the existing empty/no-detail behavior without errors.
+5. Empty arrays are treated as no usable values for fee line items and fee installments only where fallback behavior is expected.
+6. Existing scalar fallback behavior remains unchanged.
+
+## Non-Goals
+- No schema migration.
+- No Firestore rules changes.
+- No payment processing changes.
+- No redesign of parent fee cards.

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -53,15 +53,20 @@
                     <div id="registration-roster-import" class="hidden border-b border-emerald-200 bg-emerald-50 p-4">
                         <div class="flex items-start justify-between gap-3">
                             <div>
-                                <h3 class="font-semibold text-emerald-900">Registration Roster Sync</h3>
-                                <p class="text-sm text-emerald-800">Refresh this roster from the latest linked registration snapshot.</p>
+                                <h3 class="font-semibold text-emerald-900">Import from registration provider</h3>
+                                <p class="text-sm text-emerald-800">Preview players and guardian/contact records from the latest registration snapshot before importing.</p>
                                 <p id="registration-roster-import-status" class="mt-2 text-sm text-emerald-700"></p>
                             </div>
+                            <button id="registration-roster-preview-btn" type="button"
+                                class="shrink-0 rounded-md bg-white px-3 py-2 text-sm font-semibold text-emerald-700 ring-1 ring-emerald-300 hover:bg-emerald-100">
+                                Preview Import
+                            </button>
                             <button id="registration-roster-import-btn" type="button"
                                 class="shrink-0 rounded-md bg-emerald-600 px-3 py-2 text-sm font-semibold text-white hover:bg-emerald-700">
-                                Re-import Roster
+                                Import Roster
                             </button>
                         </div>
+                        <div id="registration-roster-import-preview" class="hidden mt-4 space-y-2 text-sm"></div>
                     </div>
 
                     <!-- Tab Navigation -->
@@ -502,6 +507,7 @@
         let rosterFieldDefinitionDrafts = [];
         let registrationForms = [];
         let selectedRegistrationFormId = '';
+        let registrationRosterImportPlan = null;
         function hasAccess(team, user) {
             if (!team || !user) return false;
             return hasFullTeamAccess(user, { ...team, id: team.id || currentTeamId });
@@ -576,21 +582,105 @@
                 'registration';
         }
 
+        function formatRegistrationContacts(player = {}) {
+            const contacts = [...(player.guardians || []), ...(player.contacts || [])]
+                .map((contact) => [contact.name, contact.relation, contact.email, contact.phone].filter(Boolean).join(' · '));
+            return contacts.length ? contacts.join('; ') : 'No guardian/contact records provided';
+        }
+
+        function renderRegistrationRosterImportPreview(plan) {
+            const preview = document.getElementById('registration-roster-import-preview');
+            const importButton = document.getElementById('registration-roster-import-btn');
+            if (!preview || !importButton || !plan) return;
+
+            const operationRows = plan.operations.map((operation) => {
+                const label = operation.type === 'update' ? 'Update existing player' : 'Add new player';
+                return `
+                    <div class="rounded-md border border-emerald-200 bg-white p-3">
+                        <div class="font-semibold text-gray-900">${escapeHtml(label)}: ${escapeHtml(operation.payload.name || 'Unnamed player')}${operation.payload.number ? ` #${escapeHtml(operation.payload.number)}` : ''}</div>
+                        <div class="text-xs text-gray-600 mt-1">Contacts: ${escapeHtml(formatRegistrationContacts(operation.payload))}</div>
+                        <div class="text-xs text-emerald-700 mt-1">Source: ${escapeHtml(operation.payload.sourceMetadata?.sourceType || 'registration')} · ${escapeHtml(operation.payload.sourceMetadata?.externalPlayerId || '')}</div>
+                    </div>
+                `;
+            });
+            const conflictRows = (plan.results.conflicts || []).map((conflict) => `
+                <div class="rounded-md border border-amber-300 bg-amber-50 p-3 text-amber-900">
+                    <div class="font-semibold">Review conflict before import</div>
+                    <div class="text-xs mt-1">External player ${escapeHtml(conflict.externalPlayerId || 'unknown')} likely conflicts with existing player ${escapeHtml(conflict.existingPlayerId || 'unknown')}${conflict.contact ? ` by ${escapeHtml(conflict.contact)}` : ' by name/number match'}.</div>
+                </div>
+            `);
+
+            preview.classList.remove('hidden');
+            preview.innerHTML = `
+                <div class="rounded-md border border-emerald-200 bg-emerald-100/60 p-3 font-semibold text-emerald-900">
+                    Preview: ${escapeHtml(formatRegistrationRosterImportResults(plan.results))}.
+                </div>
+                ${operationRows.length ? operationRows.join('') : '<div class="rounded-md border border-gray-200 bg-white p-3 text-gray-600">No importable player changes found.</div>'}
+                ${conflictRows.join('')}
+            `;
+            importButton.disabled = plan.operations.length === 0;
+            importButton.classList.toggle('opacity-50', importButton.disabled);
+        }
+
         function renderRegistrationRosterImport(team = {}) {
             const container = document.getElementById('registration-roster-import');
             const status = document.getElementById('registration-roster-import-status');
-            if (!container || !status) return;
+            const previewButton = document.getElementById('registration-roster-preview-btn');
+            const importButton = document.getElementById('registration-roster-import-btn');
+            const preview = document.getElementById('registration-roster-import-preview');
+            if (!container || !status || !previewButton || !importButton || !preview) return;
 
-            if (!isExternallyLinkedRosterTeam(team)) {
-                container.classList.add('hidden');
+            registrationRosterImportPlan = null;
+            container.classList.remove('hidden');
+            preview.classList.add('hidden');
+            preview.innerHTML = '';
+
+            const sourcePlayers = getRegistrationRosterPlayers(team);
+            const hasSnapshot = isExternallyLinkedRosterTeam(team);
+            previewButton.disabled = !hasSnapshot || sourcePlayers.length === 0;
+            previewButton.classList.toggle('opacity-50', previewButton.disabled);
+            importButton.disabled = true;
+            importButton.classList.toggle('opacity-50', importButton.disabled);
+            status.textContent = hasSnapshot
+                ? (sourcePlayers.length > 0
+                    ? `${sourcePlayers.length} player${sourcePlayers.length === 1 ? '' : 's'} available in the latest source snapshot. Preview before importing.`
+                    : 'No roster players were found in the latest source snapshot.')
+                : 'No registration provider data is available yet. Connect or load a registration roster snapshot before importing.';
+        }
+
+        async function handleRegistrationRosterPreview() {
+            const button = document.getElementById('registration-roster-preview-btn');
+            const status = document.getElementById('registration-roster-import-status');
+            if (!currentTeam || !button || !status) return;
+
+            const sourcePlayers = getRegistrationRosterPlayers(currentTeam);
+            if (sourcePlayers.length === 0) {
+                status.textContent = isExternallyLinkedRosterTeam(currentTeam)
+                    ? 'No roster players were found in the latest source snapshot.'
+                    : 'No registration provider data is available yet. Connect or load a registration roster snapshot before importing.';
                 return;
             }
 
-            const sourcePlayers = getRegistrationRosterPlayers(team);
-            container.classList.remove('hidden');
-            status.textContent = sourcePlayers.length > 0
-                ? `${sourcePlayers.length} player${sourcePlayers.length === 1 ? '' : 's'} available in the latest source snapshot.`
-                : 'No roster players were found in the latest source snapshot.';
+            try {
+                button.disabled = true;
+                button.textContent = 'Previewing...';
+                status.textContent = 'Comparing source roster to current roster...';
+                const existingPlayers = await getPlayers(currentTeamId, { includeInactive: true });
+                registrationRosterImportPlan = planRegistrationRosterImport({
+                    sourcePlayers,
+                    existingPlayers,
+                    source: getRegistrationSourceDescriptor(currentTeam),
+                    fields: rosterFieldDefinitions
+                });
+                renderRegistrationRosterImportPreview(registrationRosterImportPlan);
+                status.textContent = 'Preview ready. Review players, contacts, and conflicts before importing.';
+            } catch (error) {
+                console.error('Error previewing registration roster:', error);
+                status.textContent = 'Roster preview failed: ' + (error?.message || 'Please try again.');
+            } finally {
+                button.disabled = false;
+                button.textContent = 'Preview Import';
+            }
         }
 
         async function handleRegistrationRosterImport() {
@@ -598,26 +688,17 @@
             const status = document.getElementById('registration-roster-import-status');
             if (!currentTeam || !button || !status) return;
 
-            const sourcePlayers = getRegistrationRosterPlayers(currentTeam);
-            if (sourcePlayers.length === 0) {
-                status.textContent = 'No roster players were found in the latest source snapshot.';
+            if (!registrationRosterImportPlan) {
+                status.textContent = 'Preview the registration roster before importing.';
                 return;
             }
 
             try {
                 button.disabled = true;
                 button.textContent = 'Importing...';
-                status.textContent = 'Comparing source roster to current roster...';
+                status.textContent = 'Importing previewed roster changes...';
 
-                const existingPlayers = await getPlayers(currentTeamId, { includeInactive: true });
-                const plan = planRegistrationRosterImport({
-                    sourcePlayers,
-                    existingPlayers,
-                    source: getRegistrationSourceDescriptor(currentTeam),
-                    fields: rosterFieldDefinitions
-                });
-
-                for (const operation of plan.operations) {
+                for (const operation of registrationRosterImportPlan.operations) {
                     let playerId = operation.playerId;
                     if (operation.type === 'update') {
                         await updatePlayer(currentTeamId, playerId, operation.payload);
@@ -629,17 +710,19 @@
                     }
                 }
 
-                status.textContent = `Import complete: ${formatRegistrationRosterImportResults(plan.results)}.`;
-                if (plan.results.conflicted > 0) {
+                status.textContent = `Import complete: ${formatRegistrationRosterImportResults(registrationRosterImportPlan.results)}.`;
+                if (registrationRosterImportPlan.results.conflicted > 0) {
                     status.textContent += ' Conflicts were left unchanged so local-only players are preserved.';
                 }
+                registrationRosterImportPlan = null;
                 await loadRoster();
             } catch (error) {
                 console.error('Error importing registration roster:', error);
                 status.textContent = 'Roster import failed: ' + (error?.message || 'Please try again.');
             } finally {
-                button.disabled = false;
-                button.textContent = 'Re-import Roster';
+                button.disabled = !registrationRosterImportPlan;
+                button.classList.toggle('opacity-50', button.disabled);
+                button.textContent = 'Import Roster';
             }
         }
 
@@ -1169,6 +1252,7 @@
         setupCopyLinkButton('copy-manual-link-btn', 'generated-code');
         setupCopyLinkButton('copy-fallback-link-btn', 'fallback-code');
         setupCopyLinkButton('copy-existing-link-btn', 'existing-user-code');
+        document.getElementById('registration-roster-preview-btn')?.addEventListener('click', handleRegistrationRosterPreview);
         document.getElementById('registration-roster-import-btn')?.addEventListener('click', handleRegistrationRosterImport);
 
         function resetForm() {

--- a/js/edit-roster-registration-import.js
+++ b/js/edit-roster-registration-import.js
@@ -46,6 +46,43 @@ function getExistingExternalPlayerId(player = {}) {
     );
 }
 
+function getContactConflictKeys(contacts = []) {
+    return contacts.flatMap((contact) => [
+        contact.email ? `email:${contact.email}` : '',
+        contact.phone ? `phone:${contact.phone}` : ''
+    ]).filter(Boolean);
+}
+
+function collectExistingContactOwners(existingPlayers = []) {
+    const owners = new Map();
+    existingPlayers.forEach((player) => {
+        const contacts = [
+            ...normalizeContacts(player.guardians),
+            ...normalizeContacts(player.contacts),
+            ...normalizeContacts(player.parents),
+            ...normalizeContacts(player.familyContacts)
+        ];
+        getContactConflictKeys(contacts).forEach((key) => {
+            if (!owners.has(key)) owners.set(key, []);
+            owners.get(key).push(player);
+        });
+    });
+    return owners;
+}
+
+function findContactConflict(sourceContacts = [], existingContactOwners, existingPlayer = null) {
+    for (const key of getContactConflictKeys(sourceContacts)) {
+        const owner = (existingContactOwners.get(key) || []).find((player) => !existingPlayer?.id || player.id !== existingPlayer.id);
+        if (owner) {
+            return {
+                existingPlayerId: owner.id || null,
+                contact: key.replace(':', ': ')
+            };
+        }
+    }
+    return null;
+}
+
 function getKnownExistingSource(player = {}) {
     const source = player.sourceMetadata || player.registrationSource || {};
     const sourceType = normalizeString(source.sourceType || source.type || source.provider || source.name);
@@ -229,12 +266,9 @@ function mergeRosterFieldValuesIntoPayload(payload, fieldValues, fields, existin
 
 export function isExternallyLinkedRosterTeam(team = {}) {
     return !!(
-        team.registrationSource ||
-        team.registrationSourceId ||
-        team.externalRegistrationTeamId ||
         team.registrationSourceSnapshot ||
         team.registrationRosterSnapshot ||
-        team.registrationScheduleSnapshot
+        team.externalRosterPlayers
     );
 }
 
@@ -305,6 +339,7 @@ export function planRegistrationRosterImport({ sourcePlayers = [], existingPlaye
     });
 
     const seenExternalIds = new Set();
+    const existingContactOwners = collectExistingContactOwners(existingPlayers);
     const operations = [];
     const results = {
         added: 0,
@@ -339,6 +374,19 @@ export function planRegistrationRosterImport({ sourcePlayers = [], existingPlaye
                 results.conflicts.push({ externalPlayerId, existingPlayerId: conflict.id || null });
                 return;
             }
+        }
+
+        const sourceContacts = [...(payload.guardians || []), ...(payload.contacts || [])];
+        const contactConflict = findContactConflict(sourceContacts, existingContactOwners, existing);
+        if (contactConflict) {
+            results.conflicted += 1;
+            results.conflicts.push({
+                externalPlayerId,
+                existingPlayerId: contactConflict.existingPlayerId,
+                conflictType: 'contact',
+                contact: contactConflict.contact
+            });
+            return;
         }
 
         const fieldValues = collectRegistrationRosterFieldValues(sourcePlayer, fields, results);

--- a/tests/unit/edit-roster-registration-import.test.js
+++ b/tests/unit/edit-roster-registration-import.test.js
@@ -14,7 +14,8 @@ function readEditRoster() {
 describe('registration roster import planning', () => {
     it('detects linked roster teams and source roster snapshots', () => {
         expect(isExternallyLinkedRosterTeam({})).toBe(false);
-        expect(isExternallyLinkedRosterTeam({ registrationSourceId: 'sports-connect' })).toBe(true);
+        expect(isExternallyLinkedRosterTeam({ registrationSourceId: 'sports-connect' })).toBe(false);
+        expect(isExternallyLinkedRosterTeam({ externalRosterPlayers: [{ id: 'p1' }] })).toBe(true);
         expect(getRegistrationRosterPlayers({ registrationSourceSnapshot: { rosterPlayers: [{ id: 'p1' }] } })).toEqual([{ id: 'p1' }]);
     });
 
@@ -128,6 +129,32 @@ describe('registration roster import planning', () => {
 
         expect(plan.results).toMatchObject({ added: 0, updated: 1, skipped: 0, conflicted: 0 });
         expect(plan.operations[0]).toMatchObject({ type: 'update', playerId: 'player-legacy' });
+    });
+
+    it('flags contact conflicts before import operations are applied', () => {
+        const plan = planRegistrationRosterImport({
+            source: { type: 'sports-connect', id: 'league-1' },
+            sourcePlayers: [
+                {
+                    externalPlayerId: 'ext-2',
+                    name: 'New Player',
+                    guardians: [{ name: 'Pat Lee', email: 'pat@example.com', relation: 'Parent' }]
+                }
+            ],
+            existingPlayers: [
+                {
+                    id: 'player-1',
+                    name: 'Avery Lee',
+                    guardians: [{ name: 'Pat Lee', email: 'PAT@example.com', relation: 'Parent' }]
+                }
+            ]
+        });
+
+        expect(plan.results).toMatchObject({ added: 0, updated: 0, skipped: 0, conflicted: 1 });
+        expect(plan.results.conflicts).toEqual([
+            { externalPlayerId: 'ext-2', existingPlayerId: 'player-1', conflictType: 'contact', contact: 'email: pat@example.com' }
+        ]);
+        expect(plan.operations).toHaveLength(0);
     });
 
     it('maps configured roster profile fields from matching registration answer keys and labels', () => {
@@ -262,9 +289,12 @@ describe('registration roster import wiring', () => {
         const source = readEditRoster();
 
         expect(source).toContain('id="registration-roster-import"');
-        expect(source).toContain('Re-import Roster');
+        expect(source).toContain('Import from registration provider');
+        expect(source).toContain('Preview Import');
         expect(source).toContain("import { formatRegistrationRosterImportResults, getRegistrationRosterPlayers, isExternallyLinkedRosterTeam, planRegistrationRosterImport } from './js/edit-roster-registration-import.js?v=1';");
         expect(source).toContain('planRegistrationRosterImport({');
+        expect(source).toContain('renderRegistrationRosterImportPreview');
+        expect(source).toContain('No registration provider data is available yet.');
         expect(source).toContain('fields: rosterFieldDefinitions');
         expect(source).toContain('setPlayerPrivateRosterProfileFields(currentTeamId, playerId, operation.privateRosterFields)');
         expect(source).toContain('function getPlayerImportSourceType');


### PR DESCRIPTION
Closes #799

## Summary
- Exposes the registration provider roster import workflow on edit roster.
- Adds a preview step showing player and guardian/contact records before import.
- Flags duplicate player and contact conflicts before changes are applied, while preserving source metadata on imported records.
- Shows a clear no-data message when no registration roster snapshot is available.

## Tests
- `npx vitest run tests/unit/edit-roster-registration-import.test.js`
- `git diff --check`