### PR TITLE
Introduce team chat conversations

### DIFF
--- a/docs/team-chat.md
+++ b/docs/team-chat.md
@@ -16,6 +16,7 @@ Goal: Add persistent team chat for anyone who has access to a team (owner, admin
 - Pagination (50 messages per load)
 - Manual refresh button
 - Coach/admin recipient picker for full team, staff-only, or selected roster/community members
+- Lightweight conversations list for the default team-wide channel plus targeted direct/group conversation records
 
 ### Deferred Features
 - Real-time updates (Firestore onSnapshot) - using manual refresh instead
@@ -33,7 +34,21 @@ Goal: Add persistent team chat for anyone who has access to a team (owner, admin
 - Data stays inside each `team` namespace to match the rest of the app
 
 ## Data Model (Firestore)
-- Collection: `teams/{teamId}/chatMessages/{messageId}`
+- Legacy/default team channel: `teams/{teamId}/chatMessages/{messageId}`
+  - This remains the compatibility path for the team-wide stream and existing clients.
+- Targeted conversations: `teams/{teamId}/chatConversations/{conversationId}`
+  - `type: "team" | "group" | "direct"`
+  - `name: string | null`
+  - `participantIds: string[]` (user IDs or stable recipient identifiers such as `user:{uid}`, `email:{email}`, or `player:{playerId}`)
+  - `participantRoles: string[]` (for role conversations such as `staff`)
+  - `lastMessageAt: Timestamp` (set after the first message)
+  - `mutedBy: string[]`
+  - `createdAt: Timestamp`
+  - `updatedAt: Timestamp`
+- Targeted conversation messages: `teams/{teamId}/chatConversations/{conversationId}/chatMessages/{messageId}`
+  - Same message shape as the default channel, with `conversationId` populated.
+
+### Message Fields
   - `text: string`
   - `senderId: string`
   - `senderName: string`
@@ -64,7 +79,8 @@ Moderation (delete others' messages):
 ## Files Changed
 | File | Changes |
 |------|---------|
-| `js/db.js` | Added `uploadUserPhoto`, `canAccessTeamChat`, `canModerateChat`, `getChatMessages`, `postChatMessage`, `editChatMessage`, `deleteChatMessage` |
+| `js/db.js` | Added `uploadUserPhoto`, `canAccessTeamChat`, `canModerateChat`, `getChatConversations`, `upsertChatConversation`, `getChatMessages`, `postChatMessage`, `editChatMessage`, `deleteChatMessage` |
+| `js/team-chat-conversations.js` | Conversation normalization, default channel, display name, and participation helpers |
 | `profile.html` | Added profile photo upload section |
 | `dashboard.html` | Added Chat button to team cards |
 | `parent-dashboard.html` | Added Team Chats section |
@@ -92,7 +108,9 @@ This index may be auto-created when the first query runs, or can be created manu
 - [x] User without team access redirected to dashboard
 - [x] Send message appears in list
 - [x] Coach/admin can choose full team, staff-only, or selected roster/community recipients before sending
-- [x] Targeted sends persist `targetType`, `recipientIds`, and `targetRole` metadata with the chat message
+- [x] Team chat shows the default team-wide channel and targeted conversations the signed-in user participates in
+- [x] Opening a targeted conversation loads and sends under `chatConversations/{conversationId}/chatMessages`
+- [x] Targeted sends persist `targetType`, `recipientIds`, `targetRole`, and conversation metadata
 - [x] Edit own message shows "edited" indicator
 - [x] Delete own message shows "Message removed"
 - [x] Coach/Admin can delete any message (moderation)

--- a/firestore.rules
+++ b/firestore.rules
@@ -244,6 +244,31 @@ service cloud.firestore {
       return isSignedIn() && (isOwnerOrAdmin || isParentForTeam(teamId));
     }
 
+    function canAccessChatConversation(teamId, conversationData) {
+      let participantIds = conversationData.get('participantIds', []);
+      let participantRoles = conversationData.get('participantRoles', []);
+      return canAccessTeamChat(teamId) &&
+             (
+               conversationData.get('type', '') == 'team' ||
+               isTeamOwnerOrAdmin(teamId) ||
+               request.auth.uid in participantIds ||
+               ('user:' + request.auth.uid) in participantIds ||
+               (request.auth.token.email != null && ('email:' + request.auth.token.email.lower()) in participantIds) ||
+               'team' in participantRoles
+             );
+    }
+
+    function isChatConversationPayloadValid(data) {
+      return data.keys().hasOnly([
+               'type', 'name', 'participantIds', 'participantRoles', 'lastMessageAt',
+               'mutedBy', 'createdAt', 'updatedAt'
+             ]) &&
+             data.get('type', '') in ['team', 'group', 'direct'] &&
+             data.get('participantIds', []) is list &&
+             data.get('participantRoles', []) is list &&
+             data.get('mutedBy', []) is list;
+    }
+
     function rideshareOfferPath(teamId, gameId, offerId) {
       return /databases/$(database)/documents/teams/$(teamId)/games/$(gameId)/rideOffers/$(offerId);
     }
@@ -861,6 +886,60 @@ service cloud.firestore {
                              ])
                            )
                          );
+      }
+
+      // First-class team messaging conversations. The default team-wide channel
+      // remains teams/{teamId}/chatMessages for compatibility; targeted threads
+      // store messages under their conversation record.
+      match /chatConversations/{conversationId} {
+        allow read: if canAccessTeamChat(teamId);
+        allow create: if canAccessTeamChat(teamId) &&
+                         isChatConversationPayloadValid(request.resource.data) &&
+                         canAccessChatConversation(teamId, request.resource.data);
+        allow update: if canAccessChatConversation(teamId, resource.data) &&
+                         isChatConversationPayloadValid(request.resource.data) &&
+                         request.resource.data.diff(resource.data).affectedKeys()
+                           .hasOnly(['name', 'participantIds', 'participantRoles', 'lastMessageAt', 'mutedBy', 'updatedAt']);
+        allow delete: if isTeamOwnerOrAdmin(teamId);
+
+        match /chatMessages/{messageId} {
+          allow read: if canAccessChatConversation(teamId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data);
+          allow create: if canAccessChatConversation(teamId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data) &&
+                           request.resource.data.senderId == request.auth.uid;
+          allow update: if canAccessChatConversation(teamId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data) &&
+                           resource.data.senderId == request.auth.uid &&
+                           request.resource.data.diff(resource.data).affectedKeys()
+                               .hasOnly(['text', 'editedAt']);
+          allow update: if canAccessChatConversation(teamId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data) &&
+                           request.resource.data.diff(resource.data).affectedKeys()
+                               .hasOnly(['deleted']) &&
+                           request.resource.data.deleted == true &&
+                           (resource.data.senderId == request.auth.uid ||
+                            isTeamOwnerOrAdmin(teamId));
+          allow update: if canAccessChatConversation(teamId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data) &&
+                           (
+                             request.resource.data.diff(resource.data).affectedKeys()
+                               .hasOnly([
+                                 'reactions.thumbs_up',
+                                 'reactions.heart',
+                                 'reactions.joy',
+                                 'reactions.wow',
+                                 'reactions.sad',
+                                 'reactions.clap'
+                               ]) ||
+                             (
+                               request.resource.data.diff(resource.data).affectedKeys().hasOnly(['reactions']) &&
+                               request.resource.data.get('reactions', {}).keys().hasOnly([
+                                 'thumbs_up',
+                                 'heart',
+                                 'joy',
+                                 'wow',
+                                 'sad',
+                                 'clap'
+                               ])
+                             )
+                           );
+        }
       }
     }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -977,11 +977,12 @@ service cloud.firestore {
       // remains teams/{teamId}/chatMessages for compatibility; targeted threads
       // store messages under their conversation record.
       match /chatConversations/{conversationId} {
-        allow read: if canAccessTeamChat(teamId);
+        allow read: if canAccessChatConversation(teamId, resource.data);
         allow create: if canAccessTeamChat(teamId) &&
                          isChatConversationPayloadValid(request.resource.data) &&
                          canAccessChatConversation(teamId, request.resource.data);
         allow update: if canAccessChatConversation(teamId, resource.data) &&
+                         canAccessChatConversation(teamId, request.resource.data) &&
                          isChatConversationPayloadValid(request.resource.data) &&
                          request.resource.data.diff(resource.data).affectedKeys()
                            .hasOnly(['name', 'participantIds', 'participantRoles', 'lastMessageAt', 'mutedBy', 'updatedAt']);

--- a/js/db.js
+++ b/js/db.js
@@ -46,6 +46,15 @@ import { buildGameDayRsvpBreakdown } from './game-day-rsvp-breakdown.js?v=1';
 import { isAvailabilityLocked, normalizeAvailabilityPreferences } from './availability-preferences.js?v=1';
 import { normalizeChatAttachments } from './team-chat-media.js';
 import {
+    DEFAULT_TEAM_CONVERSATION_ID,
+    buildConversationId,
+    buildDefaultTeamConversation,
+    isDefaultTeamConversation,
+    isUserInConversation,
+    normalizeConversationParticipantIds,
+    normalizeConversationType
+} from './team-chat-conversations.js';
+import {
     shouldMirrorSharedGame,
     createSharedScheduleId,
     buildMirroredGamePayload,
@@ -3198,12 +3207,69 @@ export function canModerateChat(user, team) {
     return false;
 }
 
+function getTeamChatMessagesRef(teamId, conversationId = DEFAULT_TEAM_CONVERSATION_ID) {
+    if (isDefaultTeamConversation(conversationId)) {
+        return collection(db, 'teams', teamId, 'chatMessages');
+    }
+    return collection(db, 'teams', teamId, 'chatConversations', conversationId, 'chatMessages');
+}
+
+/**
+ * Get conversations for a team. The default team-wide channel is virtual and keeps
+ * using teams/{teamId}/chatMessages for backwards compatibility.
+ */
+export async function getChatConversations(teamId, user = null, { team = null, canModerate = false } = {}) {
+    const conversationsRef = collection(db, 'teams', teamId, 'chatConversations');
+    const snapshot = await getDocs(query(conversationsRef, orderBy('updatedAt', 'desc')));
+    const stored = snapshot.docs
+        .map(d => ({ id: d.id, ...d.data() }))
+        .filter((conversation) => !user || isUserInConversation(conversation, user, { canModerate }));
+
+    return [buildDefaultTeamConversation(team), ...stored];
+}
+
+/**
+ * Create or update a lightweight conversation record.
+ */
+export async function upsertChatConversation(teamId, {
+    type = 'group',
+    participantIds = [],
+    participantRoles = [],
+    mutedBy = [],
+    name = null
+} = {}) {
+    const normalizedType = normalizeConversationType(type);
+    const normalizedParticipantIds = normalizeConversationParticipantIds(participantIds);
+    const conversationId = buildConversationId(normalizedType, normalizedParticipantIds);
+    const now = Timestamp.now();
+    const conversationRef = doc(db, 'teams', teamId, 'chatConversations', conversationId);
+    const existing = await getDoc(conversationRef);
+    const payload = {
+        type: normalizedType,
+        participantIds: normalizedParticipantIds,
+        participantRoles: Array.from(new Set((Array.isArray(participantRoles) ? participantRoles : [])
+            .map((role) => String(role || '').trim())
+            .filter(Boolean)))
+            .sort(),
+        mutedBy: Array.from(new Set(Array.isArray(mutedBy) ? mutedBy : [])),
+        updatedAt: now
+    };
+    if (name) {
+        payload.name = name;
+    }
+    if (!existing.exists()) {
+        payload.createdAt = now;
+    }
+    await setDoc(conversationRef, payload, { merge: true });
+    return { id: conversationId, ...payload };
+}
+
 /**
  * Get chat messages for a team with pagination support.
  * Returns messages ordered by createdAt descending (newest first).
  */
-export async function getChatMessages(teamId, { limit = 50, startAfterDoc = null } = {}) {
-    const messagesRef = collection(db, 'teams', teamId, 'chatMessages');
+export async function getChatMessages(teamId, { limit = 50, startAfterDoc = null, conversationId = DEFAULT_TEAM_CONVERSATION_ID } = {}) {
+    const messagesRef = getTeamChatMessagesRef(teamId, conversationId);
     let q = query(messagesRef, orderBy('createdAt', 'desc'), limitQuery(limit));
 
     if (startAfterDoc) {
@@ -3218,8 +3284,8 @@ export async function getChatMessages(teamId, { limit = 50, startAfterDoc = null
  * Subscribe to chat messages in real time (newest first).
  * Returns an unsubscribe function.
  */
-export function subscribeToChatMessages(teamId, { limit = 50 } = {}, onMessages) {
-    const messagesRef = collection(db, 'teams', teamId, 'chatMessages');
+export function subscribeToChatMessages(teamId, { limit = 50, conversationId = DEFAULT_TEAM_CONVERSATION_ID } = {}, onMessages) {
+    const messagesRef = getTeamChatMessagesRef(teamId, conversationId);
     const q = query(messagesRef, orderBy('createdAt', 'desc'), limitQuery(limit));
     return onSnapshot(q, (snapshot) => {
         const docs = snapshot.docs.map(d => ({ id: d.id, ...d.data(), _doc: d }));
@@ -3249,9 +3315,10 @@ export async function postChatMessage(teamId, {
     aiMeta = null,
     targetType = 'full_team',
     recipientIds = [],
-    targetRole = null
+    targetRole = null,
+    conversationId = DEFAULT_TEAM_CONVERSATION_ID
 }) {
-    const messagesRef = collection(db, 'teams', teamId, 'chatMessages');
+    const messagesRef = getTeamChatMessagesRef(teamId, conversationId);
     const createdAt = Timestamp.now();
     const normalizedMedia = normalizeChatAttachments(
         attachments.length > 0
@@ -3278,7 +3345,7 @@ export async function postChatMessage(teamId, {
     const effectiveTargetType = normalizedTargetType === 'individuals' && normalizedRecipientIds.length === 0
         ? 'full_team'
         : normalizedTargetType;
-    return await addDoc(messagesRef, {
+    const docRef = await addDoc(messagesRef, {
         text,
         senderId,
         senderName: senderName || null,
@@ -3301,15 +3368,28 @@ export async function postChatMessage(teamId, {
         aiMeta: aiMeta || null,
         targetType: effectiveTargetType,
         recipientIds: normalizedRecipientIds,
-        targetRole: effectiveTargetType === 'staff' ? (targetRole || 'staff') : null
+        targetRole: effectiveTargetType === 'staff' ? (targetRole || 'staff') : null,
+        conversationId: isDefaultTeamConversation(conversationId) ? null : conversationId
     });
+
+    if (!isDefaultTeamConversation(conversationId)) {
+        const conversationRef = doc(db, 'teams', teamId, 'chatConversations', conversationId);
+        await setDoc(conversationRef, {
+            lastMessageAt: createdAt,
+            updatedAt: createdAt
+        }, { merge: true });
+    }
+
+    return docRef;
 }
 
 /**
  * Edit an existing chat message (sender only).
  */
-export async function editChatMessage(teamId, messageId, newText) {
-    const messageRef = doc(db, 'teams', teamId, 'chatMessages', messageId);
+export async function editChatMessage(teamId, messageId, newText, { conversationId = DEFAULT_TEAM_CONVERSATION_ID } = {}) {
+    const messageRef = isDefaultTeamConversation(conversationId)
+        ? doc(db, 'teams', teamId, 'chatMessages', messageId)
+        : doc(db, 'teams', teamId, 'chatConversations', conversationId, 'chatMessages', messageId);
     return await updateDoc(messageRef, {
         text: newText,
         editedAt: Timestamp.now()
@@ -3319,14 +3399,16 @@ export async function editChatMessage(teamId, messageId, newText) {
 /**
  * Soft-delete a chat message.
  */
-export async function deleteChatMessage(teamId, messageId) {
-    const messageRef = doc(db, 'teams', teamId, 'chatMessages', messageId);
+export async function deleteChatMessage(teamId, messageId, { conversationId = DEFAULT_TEAM_CONVERSATION_ID } = {}) {
+    const messageRef = isDefaultTeamConversation(conversationId)
+        ? doc(db, 'teams', teamId, 'chatMessages', messageId)
+        : doc(db, 'teams', teamId, 'chatConversations', conversationId, 'chatMessages', messageId);
     return await updateDoc(messageRef, {
         deleted: true
     });
 }
 
-export async function toggleChatReaction(teamId, messageId, reactionKey, userId) {
+export async function toggleChatReaction(teamId, messageId, reactionKey, userId, { conversationId = DEFAULT_TEAM_CONVERSATION_ID } = {}) {
     if (!CHAT_REACTION_KEYS.has(reactionKey)) {
         throw new Error('Unsupported reaction key');
     }
@@ -3334,7 +3416,9 @@ export async function toggleChatReaction(teamId, messageId, reactionKey, userId)
         throw new Error('Missing userId for reaction');
     }
 
-    const messageRef = doc(db, 'teams', teamId, 'chatMessages', messageId);
+    const messageRef = isDefaultTeamConversation(conversationId)
+        ? doc(db, 'teams', teamId, 'chatMessages', messageId)
+        : doc(db, 'teams', teamId, 'chatConversations', conversationId, 'chatMessages', messageId);
     const snap = await getDoc(messageRef);
     if (!snap.exists()) {
         throw new Error('Message not found');

--- a/js/db.js
+++ b/js/db.js
@@ -3224,10 +3224,35 @@ function getTeamChatMessagesRef(teamId, conversationId = DEFAULT_TEAM_CONVERSATI
  */
 export async function getChatConversations(teamId, user = null, { team = null, canModerate = false } = {}) {
     const conversationsRef = collection(db, 'teams', teamId, 'chatConversations');
-    const snapshot = await getDocs(query(conversationsRef, orderBy('updatedAt', 'desc')));
-    const stored = snapshot.docs
-        .map(d => ({ id: d.id, ...d.data() }))
+    const normalizedEmail = user?.email ? String(user.email).trim().toLowerCase() : '';
+    const participantQueries = canModerate
+        ? [query(conversationsRef, orderBy('updatedAt', 'desc'))]
+        : [
+            ...(user?.uid ? [
+                query(conversationsRef, where('participantIds', 'array-contains', user.uid), orderBy('updatedAt', 'desc')),
+                query(conversationsRef, where('participantIds', 'array-contains', `user:${user.uid}`), orderBy('updatedAt', 'desc'))
+            ] : []),
+            ...(normalizedEmail ? [
+                query(conversationsRef, where('participantIds', 'array-contains', `email:${normalizedEmail}`), orderBy('updatedAt', 'desc'))
+            ] : []),
+            query(conversationsRef, where('participantRoles', 'array-contains', 'team'), orderBy('updatedAt', 'desc'))
+        ];
+    const snapshots = participantQueries.length > 0
+        ? await Promise.all(participantQueries.map((conversationQuery) => getDocs(conversationQuery)))
+        : [];
+    const conversationsById = new Map();
+    snapshots.forEach((snapshot) => {
+        snapshot.docs.forEach((d) => {
+            conversationsById.set(d.id, { id: d.id, ...d.data() });
+        });
+    });
+    const stored = Array.from(conversationsById.values())
         .filter((conversation) => !user || isUserInConversation(conversation, user, { canModerate }));
+    stored.sort((a, b) => {
+        const aTime = a.updatedAt?.toMillis ? a.updatedAt.toMillis() : new Date(a.updatedAt || 0).getTime();
+        const bTime = b.updatedAt?.toMillis ? b.updatedAt.toMillis() : new Date(b.updatedAt || 0).getTime();
+        return bTime - aTime;
+    });
 
     return [buildDefaultTeamConversation(team), ...stored];
 }

--- a/js/team-chat-conversations.js
+++ b/js/team-chat-conversations.js
@@ -1,0 +1,65 @@
+export const DEFAULT_TEAM_CONVERSATION_ID = 'team';
+
+const CONVERSATION_TYPES = new Set(['team', 'group', 'direct']);
+
+export function normalizeConversationType(type) {
+    return CONVERSATION_TYPES.has(type) ? type : 'group';
+}
+
+export function normalizeConversationParticipantIds(participantIds = []) {
+    return Array.from(new Set((Array.isArray(participantIds) ? participantIds : [])
+        .map((id) => String(id || '').trim())
+        .filter(Boolean)))
+        .sort();
+}
+
+export function buildConversationId(type, participantIds = []) {
+    const normalizedType = normalizeConversationType(type);
+    if (normalizedType === 'team') return DEFAULT_TEAM_CONVERSATION_ID;
+
+    const participants = normalizeConversationParticipantIds(participantIds);
+    const prefix = normalizedType === 'direct' && participants.length === 2 ? 'direct' : 'group';
+    const suffix = participants.map((id) => encodeURIComponent(id)).join('__');
+    return suffix ? `${prefix}_${suffix}` : `${prefix}_empty`;
+}
+
+export function buildDefaultTeamConversation(team = {}) {
+    return {
+        id: DEFAULT_TEAM_CONVERSATION_ID,
+        type: 'team',
+        name: team?.name ? `${team.name} Team Chat` : 'Team Chat',
+        participantIds: [],
+        participantRoles: ['team'],
+        mutedBy: [],
+        isDefault: true,
+        isLegacy: true
+    };
+}
+
+export function isDefaultTeamConversation(conversationId) {
+    return !conversationId || conversationId === DEFAULT_TEAM_CONVERSATION_ID;
+}
+
+export function isUserInConversation(conversation, user = {}, { canModerate = false } = {}) {
+    if (!conversation) return false;
+    if (conversation.id === DEFAULT_TEAM_CONVERSATION_ID || conversation.type === 'team') return true;
+    if (canModerate) return true;
+
+    const participantIds = Array.isArray(conversation.participantIds) ? conversation.participantIds : [];
+    const participantRoles = Array.isArray(conversation.participantRoles) ? conversation.participantRoles : [];
+    return participantIds.includes(user?.uid) ||
+        (user?.uid && participantIds.includes(`user:${user.uid}`)) ||
+        (user?.email && participantIds.includes(`email:${user.email}`)) ||
+        (user?.email && participantIds.includes(`email:${String(user.email).toLowerCase()}`)) ||
+        participantRoles.includes('team');
+}
+
+export function getConversationDisplayName(conversation, team = {}) {
+    if (!conversation) return 'Team Chat';
+    if (conversation.name) return conversation.name;
+    if (conversation.id === DEFAULT_TEAM_CONVERSATION_ID || conversation.type === 'team') {
+        return team?.name ? `${team.name} Team Chat` : 'Team Chat';
+    }
+    if (conversation.type === 'direct') return 'Direct conversation';
+    return 'Group conversation';
+}

--- a/js/team-chat-conversations.js
+++ b/js/team-chat-conversations.js
@@ -8,7 +8,12 @@ export function normalizeConversationType(type) {
 
 export function normalizeConversationParticipantIds(participantIds = []) {
     return Array.from(new Set((Array.isArray(participantIds) ? participantIds : [])
-        .map((id) => String(id || '').trim())
+        .map((id) => {
+            const normalizedId = String(id || '').trim();
+            return normalizedId.toLowerCase().startsWith('email:')
+                ? `email:${normalizedId.slice(6).trim().toLowerCase()}`
+                : normalizedId;
+        })
         .filter(Boolean)))
         .sort();
 }

--- a/team-chat.html
+++ b/team-chat.html
@@ -61,7 +61,10 @@
         <div class="bg-white rounded-2xl shadow-lg border border-gray-200 overflow-hidden flex flex-col">
             <!-- Chat Header -->
             <div class="p-4 border-b border-gray-100 bg-gray-50 flex items-center justify-between">
-                <h2 class="text-lg font-bold text-gray-900">Team Chat</h2>
+                <div>
+                    <h2 class="text-lg font-bold text-gray-900">Team Chat</h2>
+                    <p id="active-conversation-label" class="text-sm text-gray-500">Team-wide channel</p>
+                </div>
                 <div class="flex items-center gap-2">
                     <button id="media-gallery-btn"
                         class="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-gray-600 hover:text-primary-600 hover:bg-primary-50 rounded-lg transition">
@@ -78,6 +81,14 @@
                         </svg>
                         Refresh
                     </button>
+                </div>
+            </div>
+
+            <!-- Conversations -->
+            <div id="conversations-container" class="border-b border-gray-100 bg-white px-4 py-3">
+                <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">Conversations</div>
+                <div id="conversations-list" class="flex gap-2 overflow-x-auto pb-1">
+                    <button type="button" class="rounded-full bg-primary-600 px-3 py-1.5 text-sm font-medium text-white">Team-wide</button>
                 </div>
             </div>
 
@@ -217,7 +228,8 @@
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=13';
-        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=30';
+        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=31';
+        import { DEFAULT_TEAM_CONVERSATION_ID, getConversationDisplayName, isDefaultTeamConversation } from './js/team-chat-conversations.js?v=1';
         import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from './js/team-chat-last-read.js?v=3';
         import {
             MAX_CHAT_MEDIA_SIZE,
@@ -383,6 +395,8 @@
         let activeReactionInfo = null;
         const pendingReactionOps = new Set();
         const reactionUserNameCache = new Map();
+        let conversations = [];
+        let selectedConversationId = DEFAULT_TEAM_CONVERSATION_ID;
         let recipientOptions = [];
         let selectedRecipientTarget = 'full_team';
         let selectedRecipientIds = new Set();
@@ -460,7 +474,7 @@
                     accessLevel,
                     exitUrl
                 });
-                renderRecipientPicker();
+                await loadConversations();
 
                 // Load messages (real-time)
                 startRealtimeUpdates();
@@ -487,7 +501,7 @@
                     return;
                 }
 
-                const newMessages = await getChatMessages(teamId, { limit: 50, startAfterDoc: cursor });
+                const newMessages = await getChatMessages(teamId, { limit: 50, startAfterDoc: cursor, conversationId: selectedConversationId });
 
                 if (newMessages.length < 50) {
                     hasMoreMessages = false;
@@ -525,7 +539,7 @@
             liveMessages = [];
             liveOldestDoc = null;
 
-            unsubscribeChat = subscribeToChatMessages(teamId, { limit: 50 }, async (newMessages, oldestDoc) => {
+            unsubscribeChat = subscribeToChatMessages(teamId, { limit: 50, conversationId: selectedConversationId }, async (newMessages, oldestDoc) => {
                 const container = document.getElementById('messages-container');
                 const wasNearBottom = isNearBottom(container);
 
@@ -1046,7 +1060,80 @@
             }
         }
 
+        async function loadConversations() {
+            conversations = await getChatConversations(teamId, currentUser, {
+                team: currentTeam,
+                canModerate
+            });
+            if (!conversations.some((conversation) => conversation.id === selectedConversationId)) {
+                selectedConversationId = DEFAULT_TEAM_CONVERSATION_ID;
+            }
+            renderConversations();
+        }
+
+        function getSelectedConversation() {
+            return conversations.find((conversation) => conversation.id === selectedConversationId) || conversations[0] || null;
+        }
+
+        function renderConversations() {
+            const list = document.getElementById('conversations-list');
+            const label = document.getElementById('active-conversation-label');
+            if (!list) return;
+
+            const visibleConversations = conversations.length > 0
+                ? conversations
+                : [{ id: DEFAULT_TEAM_CONVERSATION_ID, type: 'team', name: 'Team-wide' }];
+            list.innerHTML = visibleConversations.map((conversation) => {
+                const active = conversation.id === selectedConversationId;
+                const name = getConversationDisplayName(conversation, currentTeam);
+                const type = conversation.type === 'direct' ? 'Direct' : (conversation.type === 'group' ? 'Group' : 'Team');
+                return `
+                    <button type="button" data-conversation-id="${escapeHtml(conversation.id)}"
+                        class="shrink-0 rounded-full px-3 py-1.5 text-sm font-medium transition ${active ? 'bg-primary-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-primary-50 hover:text-primary-700'}">
+                        ${escapeHtml(name)}
+                        <span class="ml-1 text-xs ${active ? 'text-primary-100' : 'text-gray-400'}">${escapeHtml(type)}</span>
+                    </button>
+                `;
+            }).join('');
+
+            const activeConversation = getSelectedConversation();
+            if (label) {
+                label.textContent = isDefaultTeamConversation(selectedConversationId)
+                    ? 'Team-wide channel'
+                    : `${getConversationDisplayName(activeConversation, currentTeam)} conversation`;
+            }
+            renderRecipientPicker();
+        }
+
+        async function switchConversation(conversationId) {
+            if (!conversationId || conversationId === selectedConversationId) return;
+            selectedConversationId = conversationId;
+            messages = [];
+            olderMessages = [];
+            liveMessages = [];
+            liveOldestDoc = null;
+            hasMoreMessages = true;
+            activeReactionPickerMessageId = null;
+            activeReactionInfo = null;
+            document.getElementById('messages-container').innerHTML = `
+                <div class="text-center py-8">
+                    <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mx-auto mb-2"></div>
+                    <p class="text-sm text-gray-500">Loading messages...</p>
+                </div>
+            `;
+            renderConversations();
+            startRealtimeUpdates();
+        }
+
         function buildRecipientTargetMetadata() {
+            const activeConversation = getSelectedConversation();
+            if (activeConversation && !isDefaultTeamConversation(selectedConversationId)) {
+                return {
+                    targetType: activeConversation.type === 'direct' ? 'individuals' : 'individuals',
+                    recipientIds: Array.isArray(activeConversation.participantIds) ? activeConversation.participantIds : [],
+                    targetRole: null
+                };
+            }
             if (selectedRecipientTarget === 'staff') {
                 return {
                     targetType: 'staff',
@@ -1093,7 +1180,7 @@
             const select = document.getElementById('recipient-target');
             if (!picker || !summary || !list || !select) return;
 
-            if (!canModerate) {
+            if (!canModerate || !isDefaultTeamConversation(selectedConversationId)) {
                 picker.classList.add('hidden');
                 return;
             }
@@ -1807,6 +1894,8 @@
                     ai: true,
                     aiName: 'ALL PLAYS',
                     aiQuestion: question,
+                    conversationId: selectedConversationId,
+                    ...buildRecipientTargetMetadata(),
                     aiMeta: {
                         statsGameLimit: AI_STATS_GAMES_LIMIT,
                         gamesContextLimit: AI_GAMES_CONTEXT_LIMIT,
@@ -1880,7 +1969,7 @@
             pendingReactionOps.add(opKey);
 
             try {
-                await toggleChatReaction(teamId, messageId, reactionKey, currentUser.uid);
+                await toggleChatReaction(teamId, messageId, reactionKey, currentUser.uid, { conversationId: selectedConversationId });
                 activeReactionPickerMessageId = null;
                 activeReactionInfo = null;
             } catch (error) {
@@ -1901,6 +1990,11 @@
             document.getElementById('chat-image-input').addEventListener('change', handleImageSelection);
             document.getElementById('media-gallery-btn').addEventListener('click', openMediaGallery);
             document.getElementById('media-gallery-close-btn').addEventListener('click', closeMediaGallery);
+            document.getElementById('conversations-list').addEventListener('click', (event) => {
+                const button = event.target.closest('[data-conversation-id]');
+                if (!button) return;
+                switchConversation(button.dataset.conversationId);
+            });
             document.getElementById('media-gallery-grid').addEventListener('click', (event) => {
                 const actionButton = event.target.closest('[data-media-action]');
                 if (!actionButton) return;
@@ -2069,6 +2163,7 @@
             const text = input.value.trim();
             const imageFiles = pendingImageFiles.slice();
             const wantsAi = /@all\s*plays/i.test(text);
+            const originalConversationId = selectedConversationId;
 
             if (!text && imageFiles.length === 0) return;
 
@@ -2086,6 +2181,24 @@
                     }
                 }
                 pendingScrollToBottom = true;
+                const targetMetadata = buildRecipientTargetMetadata();
+                let conversationId = selectedConversationId;
+                if (isDefaultTeamConversation(conversationId) && targetMetadata.targetType !== 'full_team') {
+                    const participantIds = targetMetadata.targetType === 'staff'
+                        ? [currentUser.uid]
+                        : Array.from(new Set([currentUser.uid, ...targetMetadata.recipientIds]));
+                    const participantRoles = targetMetadata.targetType === 'staff' ? ['staff'] : [];
+                    const conversation = await upsertChatConversation(teamId, {
+                        type: participantIds.length === 2 ? 'direct' : 'group',
+                        participantIds,
+                        participantRoles,
+                        mutedBy: [],
+                        name: targetMetadata.targetType === 'staff' ? 'Staff only' : null
+                    });
+                    conversationId = conversation.id;
+                    selectedConversationId = conversationId;
+                    await loadConversations();
+                }
                 await postChatMessage(teamId, {
                     text,
                     senderId: currentUser.uid,
@@ -2093,12 +2206,19 @@
                     senderEmail: currentUser.email,
                     senderPhotoUrl: currentUserProfile?.photoUrl || null,
                     attachments: mediaPayloads,
-                    ...buildRecipientTargetMetadata()
+                    conversationId,
+                    ...targetMetadata
                 });
 
                 input.value = '';
                 clearSelectedImage();
                 document.getElementById('send-error').classList.add('hidden');
+                if (selectedConversationId !== originalConversationId) {
+                    olderMessages = [];
+                    liveMessages = [];
+                    messages = [];
+                    startRealtimeUpdates();
+                }
                 scrollToBottom();
                 hideMentionMenu();
 
@@ -2163,7 +2283,7 @@
             saveBtn.textContent = 'Saving...';
 
             try {
-                await editChatMessage(teamId, editingMessageId, newText);
+                await editChatMessage(teamId, editingMessageId, newText, { conversationId: selectedConversationId });
                 closeEditModal();
 
             } catch (error) {
@@ -2180,7 +2300,7 @@
             if (!confirm('Delete this message?')) return;
 
             try {
-                await deleteChatMessage(teamId, messageId);
+                await deleteChatMessage(teamId, messageId, { conversationId: selectedConversationId });
 
             } catch (error) {
                 console.error('Error deleting message:', error);

--- a/tests/unit/team-chat-conversations.test.js
+++ b/tests/unit/team-chat-conversations.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest';
+import {
+    DEFAULT_TEAM_CONVERSATION_ID,
+    buildConversationId,
+    buildDefaultTeamConversation,
+    getConversationDisplayName,
+    isDefaultTeamConversation,
+    isUserInConversation,
+    normalizeConversationParticipantIds
+} from '../../js/team-chat-conversations.js';
+
+describe('team chat conversations', () => {
+    it('keeps the default team channel as the legacy compatibility conversation', () => {
+        const conversation = buildDefaultTeamConversation({ name: 'U12 Tigers' });
+
+        expect(conversation).toMatchObject({
+            id: DEFAULT_TEAM_CONVERSATION_ID,
+            type: 'team',
+            isDefault: true,
+            isLegacy: true,
+            name: 'U12 Tigers Team Chat'
+        });
+        expect(isDefaultTeamConversation(null)).toBe(true);
+        expect(isDefaultTeamConversation(DEFAULT_TEAM_CONVERSATION_ID)).toBe(true);
+        expect(getConversationDisplayName(conversation)).toBe('U12 Tigers Team Chat');
+    });
+
+    it('normalizes targeted participant IDs and produces stable direct/group ids', () => {
+        expect(normalizeConversationParticipantIds(['user:b', '', 'user:a', 'user:b'])).toEqual(['user:a', 'user:b']);
+        expect(buildConversationId('direct', ['user:b', 'user:a'])).toBe('direct_user%3Aa__user%3Ab');
+        expect(buildConversationId('group', ['player:42', 'email:parent@example.com'])).toBe('group_email%3Aparent%40example.com__player%3A42');
+    });
+
+    it('recognizes user, email, role, moderator, and team conversation participation', () => {
+        const user = { uid: 'u1', email: 'parent@example.com' };
+
+        expect(isUserInConversation({ id: 'group-1', type: 'group', participantIds: ['user:u1'] }, user)).toBe(true);
+        expect(isUserInConversation({ id: 'group-2', type: 'group', participantIds: ['email:parent@example.com'] }, user)).toBe(true);
+        expect(isUserInConversation({ id: 'group-3', type: 'group', participantIds: [] }, user)).toBe(false);
+        expect(isUserInConversation({ id: 'group-3', type: 'group', participantIds: [] }, user, { canModerate: true })).toBe(true);
+        expect(isUserInConversation({ id: DEFAULT_TEAM_CONVERSATION_ID, type: 'team' }, user)).toBe(true);
+    });
+});

--- a/tests/unit/team-chat-conversations.test.js
+++ b/tests/unit/team-chat-conversations.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
 import {
     DEFAULT_TEAM_CONVERSATION_ID,
     buildConversationId,
@@ -8,6 +9,10 @@ import {
     isUserInConversation,
     normalizeConversationParticipantIds
 } from '../../js/team-chat-conversations.js';
+
+function readRepoFile(path) {
+    return readFileSync(new URL(`../../${path}`, import.meta.url), 'utf8');
+}
 
 describe('team chat conversations', () => {
     it('keeps the default team channel as the legacy compatibility conversation', () => {
@@ -27,6 +32,7 @@ describe('team chat conversations', () => {
 
     it('normalizes targeted participant IDs and produces stable direct/group ids', () => {
         expect(normalizeConversationParticipantIds(['user:b', '', 'user:a', 'user:b'])).toEqual(['user:a', 'user:b']);
+        expect(normalizeConversationParticipantIds(['email:Parent@Example.com'])).toEqual(['email:parent@example.com']);
         expect(buildConversationId('direct', ['user:b', 'user:a'])).toBe('direct_user%3Aa__user%3Ab');
         expect(buildConversationId('group', ['player:42', 'email:parent@example.com'])).toBe('group_email%3Aparent%40example.com__player%3A42');
     });
@@ -39,5 +45,17 @@ describe('team chat conversations', () => {
         expect(isUserInConversation({ id: 'group-3', type: 'group', participantIds: [] }, user)).toBe(false);
         expect(isUserInConversation({ id: 'group-3', type: 'group', participantIds: [] }, user, { canModerate: true })).toBe(true);
         expect(isUserInConversation({ id: DEFAULT_TEAM_CONVERSATION_ID, type: 'team' }, user)).toBe(true);
+    });
+
+    it('keeps Firestore conversation reads participant-scoped and client queries participant-aware', () => {
+        const rules = readRepoFile('firestore.rules');
+        const db = readRepoFile('js/db.js');
+
+        expect(rules).toContain('allow read: if canAccessChatConversation(teamId, resource.data);');
+        expect(rules).toContain('canAccessChatConversation(teamId, request.resource.data) &&');
+        expect(db).toContain("where('participantIds', 'array-contains', user.uid)");
+        expect(db).toContain("where('participantIds', 'array-contains', `user:${user.uid}`)");
+        expect(db).toContain("where('participantIds', 'array-contains', `email:${normalizedEmail}`)");
+        expect(db).toContain("where('participantRoles', 'array-contains', 'team')");
     });
 });


### PR DESCRIPTION
Closes #789

## Summary
- Adds a lightweight `chatConversations` layer for targeted team messaging while preserving the legacy team-wide `teams/{teamId}/chatMessages` path.
- Adds a conversations list to `team-chat.html` so users can switch between the default team channel and conversations they participate in.
- Stores targeted messages under `teams/{teamId}/chatConversations/{conversationId}/chatMessages` with conversation metadata and Firestore rules coverage.
- Documents the conversation model and compatibility path.

## Validation
- `npx vitest run tests/unit/team-chat-conversations.test.js tests/unit/team-chat-media.test.js`
- `node scripts/check-critical-cache-bust.mjs`
- `node --check /tmp/team-chat-inline.mjs`
- `node --check js/db.js`
- `node --check js/team-chat-conversations.js`