### PR TITLE
Show parent fee invoice details

### DIFF
--- a/js/parent-dashboard-fees.js
+++ b/js/parent-dashboard-fees.js
@@ -21,6 +21,116 @@ const STATUS_META = {
     }
 };
 
+
+function getFirstDefined(...values) {
+    return values.find((value) => value !== undefined && value !== null && value !== '');
+}
+
+function getFeeLineItems(fee) {
+    const rawItems = getFirstDefined(fee?.lineItems, fee?.invoiceLineItems, fee?.invoiceItems, fee?.items);
+    return Array.isArray(rawItems) ? rawItems.filter(Boolean) : [];
+}
+
+function getFeeInstallments(fee) {
+    const rawInstallments = getFirstDefined(fee?.installments, fee?.installmentSchedule, fee?.paymentSchedule, fee?.scheduledPayments);
+    return Array.isArray(rawInstallments) ? rawInstallments.filter(Boolean) : [];
+}
+
+function getFeeBalanceCents(fee) {
+    return getFirstDefined(fee?.balanceDueCents, fee?.remainingBalanceCents, fee?.amountDueCents);
+}
+
+function getFeeCheckoutUrl(fee) {
+    return getFirstDefined(fee?.checkoutUrl, fee?.checkoutURL, fee?.paymentLink, fee?.paymentLinkUrl, fee?.paymentUrl);
+}
+
+function formatCents(value) {
+    const cents = Number(value);
+    if (!Number.isFinite(cents)) return '';
+    return new Intl.NumberFormat('en-US', {
+        style: 'currency',
+        currency: 'USD'
+    }).format(cents / 100);
+}
+
+function formatInvoiceQuantity(item) {
+    const quantity = Number(item?.quantity ?? item?.qty);
+    return Number.isFinite(quantity) && quantity > 0 ? quantity : null;
+}
+
+function formatInstallmentStatus(installment) {
+    const status = String(installment?.status || '').trim().toLowerCase();
+    if (installment?.paid === true || status === 'paid' || installment?.paidAt) return 'Paid';
+    if (status === 'canceled' || status === 'cancelled') return 'Canceled';
+    if (status === 'adjusted') return 'Adjusted';
+    return 'Unpaid';
+}
+
+function renderInvoiceLineItems(fee) {
+    const lineItems = getFeeLineItems(fee);
+    if (!lineItems.length) return '';
+
+    const rows = lineItems.map((item) => {
+        const description = getFirstDefined(item?.description, item?.title, item?.name, item?.label, 'Fee line item');
+        const quantity = formatInvoiceQuantity(item);
+        const amount = formatCents(getFirstDefined(item?.amountCents, item?.totalCents, item?.unitAmountCents, item?.priceCents));
+        const details = [
+            quantity ? `Qty ${escapeHtml(quantity)}` : '',
+            item?.dueDate || item?.dueAt ? `Due ${escapeHtml(formatParentFeeDueDate(item.dueDate || item.dueAt))}` : ''
+        ].filter(Boolean).join(' · ');
+
+        return `
+            <div class="flex items-start justify-between gap-3 py-2 border-t border-gray-100 first:border-t-0">
+                <div>
+                    <div class="font-medium text-gray-900">${escapeHtml(description)}</div>
+                    ${details ? `<div class="text-xs text-gray-500 mt-0.5">${details}</div>` : ''}
+                </div>
+                <div class="font-semibold text-gray-900 whitespace-nowrap">${escapeHtml(amount || 'Amount not set')}</div>
+            </div>
+        `;
+    }).join('');
+
+    return `
+        <div class="mt-4 rounded-lg border border-gray-200 bg-white p-3">
+            <div class="text-xs uppercase tracking-wide text-gray-500 font-semibold mb-1">Invoice line items</div>
+            ${rows}
+        </div>
+    `;
+}
+
+function renderInstallmentSchedule(fee) {
+    const installments = getFeeInstallments(fee);
+    if (!installments.length) return '';
+
+    const rows = installments.map((installment, index) => {
+        const label = getFirstDefined(installment?.label, installment?.title, installment?.name, `Installment ${index + 1}`);
+        const dueDate = formatParentFeeDueDate(installment?.dueDate || installment?.dueAt);
+        const amount = formatCents(getFirstDefined(installment?.amountCents, installment?.dueAmountCents, installment?.balanceDueCents));
+        const status = formatInstallmentStatus(installment);
+        const statusClass = status === 'Paid'
+            ? 'bg-green-100 text-green-800 border-green-200'
+            : 'bg-red-100 text-red-800 border-red-200';
+
+        return `
+            <div class="grid grid-cols-1 sm:grid-cols-[1fr_auto_auto] gap-2 sm:items-center py-2 border-t border-gray-100 first:border-t-0">
+                <div>
+                    <div class="font-medium text-gray-900">${escapeHtml(label)}</div>
+                    <div class="text-xs text-gray-500">Due ${escapeHtml(dueDate)}</div>
+                </div>
+                <div class="font-semibold text-gray-900 sm:text-right">${escapeHtml(amount || 'Amount not set')}</div>
+                <span class="inline-flex w-fit items-center rounded-full border px-2 py-0.5 text-xs font-bold ${statusClass}">${escapeHtml(status)}</span>
+            </div>
+        `;
+    }).join('');
+
+    return `
+        <div class="mt-4 rounded-lg border border-gray-200 bg-white p-3">
+            <div class="text-xs uppercase tracking-wide text-gray-500 font-semibold mb-1">Installment schedule</div>
+            ${rows}
+        </div>
+    `;
+}
+
 function escapeHtml(value) {
     return String(value ?? '')
         .replace(/&/g, '&amp;')
@@ -54,12 +164,7 @@ export function getParentFeeStatusMeta(status) {
 
 export function formatParentFeeAmount(fee) {
     const raw = fee?.amountDueCents ?? fee?.adjustedAmountCents ?? fee?.amountCents ?? fee?.amount;
-    const cents = Number(raw);
-    if (!Number.isFinite(cents)) return 'Amount not set';
-    return new Intl.NumberFormat('en-US', {
-        style: 'currency',
-        currency: 'USD'
-    }).format(cents / 100);
+    return formatCents(raw) || 'Amount not set';
 }
 
 export function formatParentFeeDueDate(value) {
@@ -81,7 +186,9 @@ export function normalizeParentFeeRecord(fee) {
         status: normalizeParentFeeStatus(fee?.status),
         dueDate: fee?.dueDate || fee?.dueAt || null,
         notes: fee?.notes || fee?.feeNotes || '',
-        offlinePaymentInstructions: fee?.offlinePaymentInstructions || fee?.paymentInstructions || ''
+        offlinePaymentInstructions: fee?.offlinePaymentInstructions || fee?.paymentInstructions || '',
+        balanceDueCents: getFeeBalanceCents(fee),
+        checkoutUrl: getFeeCheckoutUrl(fee)
     };
 }
 
@@ -109,6 +216,14 @@ export function renderParentTeamFees(fees) {
         const instructions = fee.offlinePaymentInstructions
             ? `<p class="text-sm text-gray-700 mt-2"><span class="font-semibold">Offline payment:</span> ${escapeHtml(fee.offlinePaymentInstructions)}</p>`
             : '';
+        const balance = fee.balanceDueCents !== undefined && fee.balanceDueCents !== null
+            ? `<div class="rounded-lg bg-gray-50 border border-gray-100 px-3 py-2"><div class="text-xs uppercase tracking-wide text-gray-500 font-semibold">Balance</div><div class="font-bold text-gray-900">${escapeHtml(formatCents(fee.balanceDueCents) || 'Amount not set')}</div></div>`
+            : '';
+        const lineItems = renderInvoiceLineItems(fee);
+        const installmentSchedule = renderInstallmentSchedule(fee);
+        const payLink = fee.checkoutUrl
+            ? `<a class="inline-flex items-center justify-center rounded-lg bg-blue-600 px-3 py-2 text-sm font-bold text-white hover:bg-blue-700" href="${escapeHtml(fee.checkoutUrl)}">Pay</a>`
+            : '';
 
         return `
             <div class="rounded-xl border border-gray-200 border-l-4 ${meta.accentClass} bg-white p-4 shadow-sm">
@@ -120,7 +235,10 @@ export function renderParentTeamFees(fees) {
                             ${playerLine}
                         </div>
                     </div>
-                    <span class="self-start inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-bold ${meta.badgeClass}">${meta.label}</span>
+                    <div class="flex flex-col sm:items-end gap-2">
+                        <span class="self-start sm:self-end inline-flex items-center rounded-full border px-2.5 py-1 text-xs font-bold ${meta.badgeClass}">${meta.label}</span>
+                        ${payLink}
+                    </div>
                 </div>
                 <div class="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
                     <div class="rounded-lg bg-gray-50 border border-gray-100 px-3 py-2">
@@ -131,7 +249,10 @@ export function renderParentTeamFees(fees) {
                         <div class="text-xs uppercase tracking-wide text-gray-500 font-semibold">Due date</div>
                         <div class="font-bold text-gray-900">${escapeHtml(formatParentFeeDueDate(fee.dueDate))}</div>
                     </div>
+                    ${balance}
                 </div>
+                ${lineItems}
+                ${installmentSchedule}
                 ${notes}
                 ${instructions}
             </div>

--- a/js/parent-dashboard-fees.js
+++ b/js/parent-dashboard-fees.js
@@ -23,7 +23,7 @@ const STATUS_META = {
 
 
 function getFirstDefined(...values) {
-    return values.find((value) => value !== undefined && value !== null && value !== '');
+    return values.find((value) => value !== undefined && value !== null && value !== '' && !(Array.isArray(value) && value.length === 0));
 }
 
 function getFeeLineItems(fee) {

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -313,7 +313,7 @@
         import { getEventRideshareSummary, getOfferSeatInfo } from './js/rideshare-helpers.js?v=1';
         import { resolveSelectedRideChildId, getRideOfferUiState, createRideRequestHandlers } from './js/parent-dashboard-rideshare-controls.js?v=1';
         import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';
-        import { renderParentTeamFees } from './js/parent-dashboard-fees.js?v=2';
+        import { renderParentTeamFees } from './js/parent-dashboard-fees.js?v=3';
         import { renderFamilyPlanSection } from './js/family-plan.js?v=1';
         import { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';
 

--- a/tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js
+++ b/tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js
@@ -119,7 +119,7 @@ const Blob = deps.Blob;
         .replace("import { getEventRideshareSummary, getOfferSeatInfo } from './js/rideshare-helpers.js?v=1';", 'const { getEventRideshareSummary, getOfferSeatInfo } = deps.rideshareHelpers;')
         .replace("import { resolveSelectedRideChildId, getRideOfferUiState, createRideRequestHandlers } from './js/parent-dashboard-rideshare-controls.js?v=1';", 'const { resolveSelectedRideChildId, getRideOfferUiState, createRideRequestHandlers } = deps.parentDashboardRideshareControls;')
         .replace("import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';", 'const { applyRsvpHydration } = deps.rsvpHydration;')
-        .replace("import { renderParentTeamFees } from './js/parent-dashboard-fees.js?v=2';", 'const { renderParentTeamFees } = deps.parentDashboardFees;')
+        .replace("import { renderParentTeamFees } from './js/parent-dashboard-fees.js?v=3';", 'const { renderParentTeamFees } = deps.parentDashboardFees;')
         .replace("import { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';", 'const { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } = deps.availabilityPreferences;')
         .replace("import { renderFamilyPlanSection } from './js/family-plan.js?v=1';", 'const { renderFamilyPlanSection } = deps.familyPlan;')
         .replace(/\binit\(\);\s*$/, `

--- a/tests/unit/parent-dashboard-fees.test.js
+++ b/tests/unit/parent-dashboard-fees.test.js
@@ -79,4 +79,48 @@ describe('parent dashboard team fees', () => {
             process.env.TZ = previousTimeZone;
         }
     });
+
+    it('renders invoice line items, balances, and installment schedules', () => {
+        const html = renderParentTeamFees([
+            {
+                title: 'Spring team invoice',
+                amountCents: 30000,
+                balanceDueCents: 20000,
+                lineItems: [
+                    { description: 'Uniform kit', quantity: 1, amountCents: 12500 },
+                    { name: 'Tournament entry', amountCents: 17500, dueDate: '2026-06-15' }
+                ],
+                installmentSchedule: [
+                    { label: 'Deposit', dueDate: '2026-06-01', amountCents: 10000, paid: true },
+                    { label: 'Final payment', dueDate: '2026-07-01', amountCents: 20000, status: 'unpaid' }
+                ]
+            }
+        ]);
+
+        expect(html).toContain('Invoice line items');
+        expect(html).toContain('Uniform kit');
+        expect(html).toContain('Qty 1');
+        expect(html).toContain('Tournament entry');
+        expect(html).toContain('Due Jun 15, 2026');
+        expect(html).toContain('Balance');
+        expect(html).toContain('$200.00');
+        expect(html).toContain('Installment schedule');
+        expect(html).toContain('Deposit');
+        expect(html).toContain('Final payment');
+        expect(html).toContain('Paid');
+        expect(html).toContain('Unpaid');
+    });
+
+    it('only renders a Pay action when a checkout or payment link exists', () => {
+        const manualOnlyHtml = renderParentTeamFees([
+            { title: 'Manual collection', amountCents: 1000 }
+        ]);
+        const checkoutHtml = renderParentTeamFees([
+            { title: 'Online collection', amountCents: 1000, checkoutUrl: 'https://pay.example/checkout' }
+        ]);
+
+        expect(manualOnlyHtml).not.toContain('>Pay</a>');
+        expect(checkoutHtml).toContain('>Pay</a>');
+        expect(checkoutHtml).toContain('https://pay.example/checkout');
+    });
 });

--- a/tests/unit/parent-dashboard-fees.test.js
+++ b/tests/unit/parent-dashboard-fees.test.js
@@ -111,6 +111,28 @@ describe('parent dashboard team fees', () => {
         expect(html).toContain('Unpaid');
     });
 
+    it('falls back to populated fee aliases when primary arrays are empty', () => {
+        const html = renderParentTeamFees([
+            {
+                title: 'Alias-backed invoice',
+                amountCents: 17500,
+                lineItems: [],
+                invoiceLineItems: [
+                    { description: 'Warmup shirt', quantity: 2, amountCents: 7500 }
+                ],
+                installments: [],
+                installmentSchedule: [
+                    { label: 'Opening payment', dueDate: '2026-06-10', amountCents: 10000 }
+                ]
+            }
+        ]);
+
+        expect(html).toContain('Warmup shirt');
+        expect(html).toContain('Qty 2');
+        expect(html).toContain('Opening payment');
+        expect(html).toContain('Due Jun 10, 2026');
+    });
+
     it('only renders a Pay action when a checkout or payment link exists', () => {
         const manualOnlyHtml = renderParentTeamFees([
             { title: 'Manual collection', amountCents: 1000 }


### PR DESCRIPTION
Closes #804

## Summary
- Render invoice-style line items when parent fee records include line item data.
- Render fee balances and installment schedules with due dates, amounts, and paid/unpaid status.
- Preserve offline payment instructions and only show a Pay action when a checkout/payment URL exists.

## Tests
- `npx vitest run tests/unit/parent-dashboard-fees.test.js tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js`
- `node scripts/check-critical-cache-bust.mjs`