### PR TITLE
Add team registration provider fields

### DIFF
--- a/edit-team.html
+++ b/edit-team.html
@@ -488,6 +488,7 @@
         let teamPermissions = normalizeTeamPermissions();
         let rolloverSourceTeams = [];
         let rolloverAccessPreview = null;
+        let currentRegistrationSource = null;
         let lastRenderedRolloverSourceTeamId = null;
         let isInitPending = true;
         let selectedRegistrationTeam = null;
@@ -577,6 +578,9 @@
         }
 
         function populateRegistrationProviderFields(team = {}) {
+            currentRegistrationSource = team.registrationSource && typeof team.registrationSource === 'object'
+                ? { ...team.registrationSource }
+                : null;
             document.getElementById('registrationProviderName').value = getRegistrationSourceValue(team, 'provider') || getRegistrationSourceValue(team, 'providerName');
             document.getElementById('registrationExternalTeamId').value = getRegistrationSourceValue(team, 'externalTeamId');
             document.getElementById('registrationLastSyncStatus').value = getRegistrationSourceValue(team, 'lastSyncStatus') || getRegistrationSourceValue(team, 'syncStatus');
@@ -597,6 +601,7 @@
                 return null;
             }
             return {
+                ...(currentTeamId && currentRegistrationSource ? currentRegistrationSource : {}),
                 provider,
                 externalTeamId,
                 teamId: currentTeamId || null,

--- a/edit-team.html
+++ b/edit-team.html
@@ -397,6 +397,46 @@
                     </div>
                 </div>
 
+                <div class="rounded-lg border border-blue-200 bg-blue-50 p-4 space-y-3">
+                    <div class="flex items-start justify-between gap-3">
+                        <div>
+                            <h3 class="font-semibold text-blue-900 text-sm">Registration Provider Connection</h3>
+                            <p class="text-xs text-blue-700 mt-1">Document the registration source for this team. No provider login, sync job, or network call runs from these fields.</p>
+                        </div>
+                        <button id="clear-registration-provider-btn" type="button" class="shrink-0 px-3 py-1.5 bg-white border border-blue-200 text-blue-700 text-xs font-semibold rounded-lg hover:bg-blue-100 transition">
+                            Clear
+                        </button>
+                    </div>
+                    <div class="grid gap-3 sm:grid-cols-2">
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700">Provider Name</label>
+                            <input type="text" id="registrationProviderName"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 border p-2 bg-white"
+                                placeholder="Sports Connect">
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700">External Team ID</label>
+                            <input type="text" id="registrationExternalTeamId"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 border p-2 bg-white"
+                                placeholder="Provider team identifier">
+                        </div>
+                    </div>
+                    <div class="grid gap-3 sm:grid-cols-2">
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700">Copied Team ID</label>
+                            <input type="text" id="registrationCopiedTeamId" readonly
+                                class="mt-1 block w-full rounded-md border-gray-200 bg-white text-gray-600 shadow-sm border p-2"
+                                placeholder="Save this team to generate a Team ID">
+                        </div>
+                        <div>
+                            <label class="block text-sm font-medium text-gray-700">Last Sync Status</label>
+                            <input type="text" id="registrationLastSyncStatus"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 border p-2 bg-white"
+                                placeholder="Not synced">
+                        </div>
+                    </div>
+                </div>
+
                 <div>
                     <label class="block text-sm font-medium text-gray-700">Team Photo</label>
                     <div class="mt-1 flex items-center space-x-4">
@@ -516,17 +556,52 @@
         function updateTeamIdPanel(teamId) {
             const panel = document.getElementById('team-id-panel');
             const teamIdText = document.getElementById('team-id-text');
+            const copiedTeamIdInput = document.getElementById('registrationCopiedTeamId');
             const status = document.getElementById('team-id-status');
             if (!teamId) {
                 panel.classList.add('hidden');
                 teamIdText.textContent = '';
+                copiedTeamIdInput.value = '';
                 status.classList.add('hidden');
                 return;
             }
 
             teamIdText.textContent = teamId;
+            copiedTeamIdInput.value = teamId;
             status.classList.add('hidden');
             panel.classList.remove('hidden');
+        }
+
+        function getRegistrationSourceValue(team, key) {
+            return String(team?.registrationSource?.[key] || team?.registrationProvider?.[key] || '').trim();
+        }
+
+        function populateRegistrationProviderFields(team = {}) {
+            document.getElementById('registrationProviderName').value = getRegistrationSourceValue(team, 'provider') || getRegistrationSourceValue(team, 'providerName');
+            document.getElementById('registrationExternalTeamId').value = getRegistrationSourceValue(team, 'externalTeamId');
+            document.getElementById('registrationLastSyncStatus').value = getRegistrationSourceValue(team, 'lastSyncStatus') || getRegistrationSourceValue(team, 'syncStatus');
+            document.getElementById('registrationCopiedTeamId').value = currentTeamId || '';
+        }
+
+        function clearRegistrationProviderFields() {
+            document.getElementById('registrationProviderName').value = '';
+            document.getElementById('registrationExternalTeamId').value = '';
+            document.getElementById('registrationLastSyncStatus').value = '';
+        }
+
+        function buildRegistrationSourcePayload() {
+            const provider = document.getElementById('registrationProviderName').value.trim();
+            const externalTeamId = document.getElementById('registrationExternalTeamId').value.trim();
+            const lastSyncStatus = document.getElementById('registrationLastSyncStatus').value.trim();
+            if (!provider && !externalTeamId && !lastSyncStatus) {
+                return null;
+            }
+            return {
+                provider,
+                externalTeamId,
+                teamId: currentTeamId || null,
+                lastSyncStatus: lastSyncStatus || 'Not synced'
+            };
         }
 
         function getSelectedCreateMode() {
@@ -553,6 +628,9 @@
         function applyRegistrationTeam(record) {
             if (!record) return;
             document.getElementById('name').value = record.externalTeamName;
+            document.getElementById('registrationProviderName').value = record.provider;
+            document.getElementById('registrationExternalTeamId').value = record.externalTeamId;
+            document.getElementById('registrationLastSyncStatus').value = 'Not synced';
             if (record.sport) {
                 document.getElementById('sport').value = record.sport;
             }
@@ -978,6 +1056,7 @@
                 renderStreamVolunteerList();
                 syncStreamVolunteerPanel();
                 updateTeamIdPanel(initialTeamId);
+                populateRegistrationProviderFields(team);
 
                 if (team.photoUrl) {
                     currentPhotoUrl = team.photoUrl;
@@ -1055,6 +1134,8 @@
                 setRosterRolloverStatus('Could not load roster preview. You can still create this team without rollover.', true);
             }
         });
+
+        document.getElementById('clear-registration-provider-btn').addEventListener('click', clearRegistrationProviderFields);
 
         document.getElementById('copy-team-id-btn').addEventListener('click', async () => {
             if (!currentTeamId) return;
@@ -1367,6 +1448,7 @@
 
                 const normalizedAdminEmails = normalizeAdminEmailList(adminEmails);
                 const normalizedStreamVolunteerEmails = normalizeStreamVolunteerEmailList(streamVolunteerEmails);
+                const registrationSourcePayload = buildRegistrationSourcePayload();
                 adminEmails = normalizedAdminEmails;
                 streamVolunteerEmails = normalizedStreamVolunteerEmails;
                 const createMode = currentTeamId ? 'manual' : getSelectedCreateMode();
@@ -1406,13 +1488,13 @@
                     photoUrl: currentPhotoUrl,
                     isPublic: document.getElementById('isPublic').checked,
                     adminEmails: rolloverStaffUpdate ? rolloverStaffUpdate.adminEmails : normalizedAdminEmails,
-                    ...(createMode === 'registration' && selectedRegistrationTeam ? {
+                    registrationSource: registrationSourcePayload,
+                    ...(createMode === 'registration' && selectedRegistrationTeam && registrationSourcePayload ? {
                         season: selectedRegistrationTeam.season || null,
                         division: selectedRegistrationTeam.division || null,
                         registrationSource: {
-                            provider: selectedRegistrationTeam.provider,
+                            ...registrationSourcePayload,
                             sourceId: selectedRegistrationTeam.sourceId,
-                            externalTeamId: selectedRegistrationTeam.externalTeamId,
                             externalTeamName: selectedRegistrationTeam.externalTeamName,
                             season: selectedRegistrationTeam.season || null,
                             division: selectedRegistrationTeam.division || null

--- a/team.html
+++ b/team.html
@@ -893,6 +893,38 @@
             return '';
         }
 
+        function getRegistrationProviderDetails(team, teamId) {
+            const source = team?.registrationSource || team?.registrationProvider || {};
+            const provider = String(source.provider || source.providerName || '').trim();
+            const externalTeamId = String(source.externalTeamId || '').trim();
+            const copiedTeamId = String(source.teamId || teamId || '').trim();
+            const lastSyncStatus = String(source.lastSyncStatus || source.syncStatus || '').trim();
+            if (!provider && !externalTeamId && !lastSyncStatus) {
+                return null;
+            }
+            return { provider, externalTeamId, copiedTeamId, lastSyncStatus };
+        }
+
+        function registrationProviderHtml(team, teamId) {
+            const details = getRegistrationProviderDetails(team, teamId);
+            if (!details) return '';
+            const rows = [
+                ['Provider', details.provider],
+                ['External Team ID', details.externalTeamId],
+                ['Team ID', details.copiedTeamId],
+                ['Last Sync Status', details.lastSyncStatus]
+            ].filter(([, value]) => value);
+            return `<div class="mt-4 rounded-xl border border-blue-100 bg-blue-50 p-4">
+                <div class="text-xs font-bold uppercase tracking-wide text-blue-700 mb-2">Registration Provider</div>
+                <div class="grid gap-2 sm:grid-cols-2">
+                    ${rows.map(([label, value]) => `<div class="rounded-lg bg-white border border-blue-100 px-3 py-2">
+                        <div class="text-[11px] font-semibold uppercase tracking-wide text-gray-500">${escapeHtml(label)}</div>
+                        <div class="mt-1 text-sm font-semibold text-gray-900 break-all">${escapeHtml(value)}</div>
+                    </div>`).join('')}
+                </div>
+            </div>`;
+        }
+
         function toDateSafe(value) {
             if (!value) return null;
             const d = value?.toDate ? value.toDate() : new Date(value);
@@ -1323,6 +1355,7 @@
                                 ${streamLinkHtml(team)}
                             </div>
                             ${team.description ? `<p class="text-gray-600 leading-relaxed">${escapeHtml(team.description)}</p>` : ''}
+                            ${registrationProviderHtml(team, teamId)}
                         </div>
                     </div>
                 `;

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -243,6 +243,11 @@ function createEnvironment(initialState, overrides = {}) {
         'team-id-text',
         'team-id-status',
         'copy-team-id-btn',
+        'registrationProviderName',
+        'registrationExternalTeamId',
+        'registrationCopiedTeamId',
+        'registrationLastSyncStatus',
+        'clear-registration-provider-btn',
         'save-admin-btn',
         'cancel-admin-btn',
         'manage-roster-btn',
@@ -676,6 +681,62 @@ describe('edit team admin access persistence', () => {
             expect(env.state.createCalls[0].teamData.accessRolloverAudit.staffAdmins).toEqual([
                 { email: 'coach-a@example.com', sourceTeamId: 'source-1', rolledOverAt: expect.any(String) }
             ]);
+        } finally {
+            env.cleanup();
+        }
+    });
+
+
+    it('allows admins to edit and clear registration provider metadata without external calls', async () => {
+        const initialState = {
+            currentUser: { uid: 'owner-1', email: 'owner@example.com' },
+            team: {
+                id: 'team-1',
+                ownerId: 'owner-1',
+                name: 'Sharks',
+                description: 'Travel team',
+                sport: 'Basketball',
+                notificationEmail: 'notify@example.com',
+                leagueUrl: '',
+                standingsConfig: { enabled: false, rankingMode: 'points', tiebreakers: [] },
+                zip: '66209',
+                isPublic: true,
+                adminEmails: [],
+                registrationSource: {
+                    provider: 'Sports Connect',
+                    externalTeamId: 'SC-123',
+                    teamId: 'team-1',
+                    lastSyncStatus: 'Not synced'
+                }
+            },
+            updateCalls: []
+        };
+
+        const env = await bootEditTeam(initialState);
+        try {
+            expect(env.elements.get('registrationProviderName').value).toBe('Sports Connect');
+            expect(env.elements.get('registrationExternalTeamId').value).toBe('SC-123');
+            expect(env.elements.get('registrationCopiedTeamId').value).toBe('team-1');
+            expect(env.elements.get('registrationLastSyncStatus').value).toBe('Not synced');
+
+            env.elements.get('registrationProviderName').value = 'League Apps';
+            env.elements.get('registrationExternalTeamId').value = 'LA-456';
+            env.elements.get('registrationLastSyncStatus').value = 'Documented only';
+            await env.elements.get('team-form').requestSubmit();
+
+            expect(env.state.updateCalls).toHaveLength(1);
+            expect(env.state.updateCalls[0].teamData.registrationSource).toEqual({
+                provider: 'League Apps',
+                externalTeamId: 'LA-456',
+                teamId: 'team-1',
+                lastSyncStatus: 'Documented only'
+            });
+
+            await env.elements.get('clear-registration-provider-btn').click();
+            await env.elements.get('team-form').requestSubmit();
+
+            expect(env.state.updateCalls).toHaveLength(2);
+            expect(env.state.updateCalls[1].teamData.registrationSource).toBeNull();
         } finally {
             env.cleanup();
         }

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -705,6 +705,10 @@ describe('edit team admin access persistence', () => {
                 registrationSource: {
                     provider: 'Sports Connect',
                     externalTeamId: 'SC-123',
+                    sourceId: 'sports-connect',
+                    externalTeamName: 'Sharks 12U',
+                    season: 'Spring 2026',
+                    division: '12U',
                     teamId: 'team-1',
                     lastSyncStatus: 'Not synced'
                 }
@@ -728,6 +732,10 @@ describe('edit team admin access persistence', () => {
             expect(env.state.updateCalls[0].teamData.registrationSource).toEqual({
                 provider: 'League Apps',
                 externalTeamId: 'LA-456',
+                sourceId: 'sports-connect',
+                externalTeamName: 'Sharks 12U',
+                season: 'Spring 2026',
+                division: '12U',
                 teamId: 'team-1',
                 lastSyncStatus: 'Documented only'
             });

--- a/tests/unit/edit-team-registration-import.test.js
+++ b/tests/unit/edit-team-registration-import.test.js
@@ -21,10 +21,29 @@ describe('edit team registration import', () => {
         expect(source).toContain('season: selectedRegistrationTeam.season || null');
         expect(source).toContain('division: selectedRegistrationTeam.division || null');
         expect(source).toContain('registrationSource:');
-        expect(source).toContain('provider: selectedRegistrationTeam.provider');
+        expect(source).toContain('registrationSourcePayload');
         expect(source).toContain('sourceId: selectedRegistrationTeam.sourceId');
-        expect(source).toContain('externalTeamId: selectedRegistrationTeam.externalTeamId');
         expect(source).toContain('externalTeamName: selectedRegistrationTeam.externalTeamName');
+    });
+
+    it('adds editable registration provider fields without live provider calls', () => {
+        const source = readRepoFile('edit-team.html');
+
+        expect(source).toContain('Registration Provider Connection');
+        expect(source).toContain('registrationProviderName');
+        expect(source).toContain('registrationExternalTeamId');
+        expect(source).toContain('registrationCopiedTeamId');
+        expect(source).toContain('registrationLastSyncStatus');
+        expect(source).toContain('No provider login, sync job, or network call runs from these fields');
+    });
+
+    it('renders registration provider metadata on the team page', () => {
+        const source = readRepoFile('team.html');
+
+        expect(source).toContain('registrationProviderHtml(team, teamId)');
+        expect(source).toContain('Registration Provider');
+        expect(source).toContain('External Team ID');
+        expect(source).toContain('Last Sync Status');
     });
 
     it('documents the registration import path in the team setup workflow', () => {


### PR DESCRIPTION
Closes #798

## Summary
- Added editable registration provider metadata fields to Edit Team: provider name, external team ID, copied Team ID, and last sync status.
- Added a clear action that removes provider metadata without affecting existing Team ID copy behavior.
- Display registration provider metadata on the team details page when present.

## Tests
- `npx vitest run tests/unit/edit-team-registration-import.test.js tests/unit/edit-team-admin-access-persistence.test.js`