### PR TITLE
Add fee receivables balance totals

### DIFF
--- a/docs/pr-notes/runs/808-remediator-20260508T060916Z/architecture.md
+++ b/docs/pr-notes/runs/808-remediator-20260508T060916Z/architecture.md
@@ -1,0 +1,6 @@
+# Architecture Notes
+
+- Keep the change inside the existing team fee admin helper and render path.
+- Add current paid cents to the DOM dataset alongside current balance/status so the existing submit handler can pass complete recipient state into `buildManualPaymentUpdate`.
+- Compute `totalPaidCents = currentPaidCents + newlyEnteredPaymentCents` in the helper, then derive status from total paid versus current balance.
+- Preserve the Firestore update shape and avoid data model migrations.

--- a/docs/pr-notes/runs/808-remediator-20260508T060916Z/code-plan.md
+++ b/docs/pr-notes/runs/808-remediator-20260508T060916Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code Plan
+
+- Update `buildManualPaymentUpdate` in `js/team-fees-admin.js` to accept `currentPaidCents` and calculate cumulative paid cents.
+- Render `data-paid-cents` on each fee recipient article and pass it from the submit handler.
+- Prefer the outstanding balance as the manual payment input default so coaches are prompted for the remaining amount.
+- Extend `tests/unit/team-fees-admin.test.js` for cumulative partial payments.

--- a/docs/pr-notes/runs/808-remediator-20260508T060916Z/qa.md
+++ b/docs/pr-notes/runs/808-remediator-20260508T060916Z/qa.md
@@ -1,0 +1,6 @@
+# QA Notes
+
+- Unit test cumulative payment behavior: prior $25 + new $25 against $50 balance returns `paid` and `amountPaidCents: 5000`.
+- Unit test partial cumulative behavior remains not paid when cumulative amount is below balance.
+- Regression: full one-time payment still marks paid.
+- Run affected unit test file with Vitest.

--- a/docs/pr-notes/runs/808-remediator-20260508T060916Z/requirements.md
+++ b/docs/pr-notes/runs/808-remediator-20260508T060916Z/requirements.md
@@ -1,0 +1,6 @@
+# Requirements Notes
+
+- Manual payment updates must evaluate paid status against cumulative paid amount, not only the newly entered payment.
+- Prior partial payments must count toward the total. Example: $25 paid against a $50 balance, then another $25 should transition the recipient to `paid`.
+- Partial payments below the balance should remain `unpaid`, or remain `adjusted` when the current status is adjusted and not fully paid.
+- The persisted recipient `amountPaidCents` should represent cumulative paid cents so summaries and outstanding calculations stay correct.

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -116,6 +116,8 @@ export function summarizeFeeRecipients(recipients = []) {
     const summary = {
         totalAssignedCents: 0,
         totalPaidCents: 0,
+        totalAdjustedCents: 0,
+        totalCanceledCents: 0,
         totalOutstandingCents: 0,
         counts: {
             paid: 0,
@@ -129,9 +131,13 @@ export function summarizeFeeRecipients(recipients = []) {
         const status = normalizeFeeStatus(recipient?.status);
         const balance = getRecipientBalanceCents(recipient);
         const paid = getRecipientPaidCents(recipient);
+        const assigned = Number(recipient?.amountCents ?? recipient?.originalAmountCents ?? recipient?.assignedAmountCents ?? balance);
+        const assignedCents = Number.isFinite(assigned) ? Math.max(0, assigned) : 0;
         summary.counts[status] += 1;
-        summary.totalAssignedCents += status === 'canceled' ? 0 : balance;
+        summary.totalAssignedCents += assignedCents;
         summary.totalPaidCents += paid;
+        summary.totalCanceledCents += status === 'canceled' ? assignedCents : 0;
+        summary.totalAdjustedCents += status === 'adjusted' ? Math.max(0, assignedCents - balance) : 0;
         summary.totalOutstandingCents += status === 'paid' || status === 'canceled' ? 0 : Math.max(0, balance - paid);
     });
 
@@ -147,15 +153,19 @@ export function formatFeeCurrency(cents) {
     }).format(amount / 100);
 }
 
-export function buildManualPaymentUpdate({ amount, date, note, actorId }) {
+export function buildManualPaymentUpdate({ amount, date, note, actorId, currentBalanceCents, currentStatus }) {
     const amountPaidCents = toFeeCents(amount);
     if (amountPaidCents === null || amountPaidCents <= 0) {
         throw new Error('Enter a manual payment amount greater than $0.');
     }
     if (!date) throw new Error('Enter a manual payment date.');
 
+    const currentBalance = Number(currentBalanceCents);
+    const isPaidInFull = Number.isFinite(currentBalance) ? amountPaidCents >= Math.max(0, currentBalance) : true;
+    const status = isPaidInFull ? 'paid' : normalizeFeeStatus(currentStatus) === 'adjusted' ? 'adjusted' : 'unpaid';
+
     return {
-        status: 'paid',
+        status,
         amountPaidCents,
         paidAt: date,
         manualPayment: {
@@ -249,6 +259,8 @@ function renderSummary(container, recipients) {
     const cards = [
         ['Total assigned', formatFeeCurrency(summary.totalAssignedCents)],
         ['Total paid', formatFeeCurrency(summary.totalPaidCents)],
+        ['Adjusted', formatFeeCurrency(summary.totalAdjustedCents)],
+        ['Canceled', formatFeeCurrency(summary.totalCanceledCents)],
         ['Outstanding', formatFeeCurrency(summary.totalOutstandingCents)],
         ['Status counts', `${summary.counts.paid} paid · ${summary.counts.unpaid} unpaid · ${summary.counts.adjusted} adjusted · ${summary.counts.canceled} canceled`]
     ];
@@ -270,18 +282,20 @@ function renderRecipients(container, countEl, recipients) {
     container.innerHTML = recipients.map((recipient) => {
         const name = escapeHtml(getRecipientDisplayName(recipient));
         const status = getStatusLabel(recipient.status);
+        const assigned = formatFeeCurrency(recipient.amountCents ?? recipient.originalAmountCents ?? recipient.assignedAmountCents ?? 0);
         const balance = formatFeeCurrency(getRecipientBalanceCents(recipient));
         const paid = formatFeeCurrency(getRecipientPaidCents(recipient));
+        const outstanding = formatFeeCurrency(recipient.status === 'paid' || recipient.status === 'canceled' ? 0 : Math.max(0, getRecipientBalanceCents(recipient) - getRecipientPaidCents(recipient)));
         const note = recipient.manualPayment?.note || recipient.adjustment?.note || recipient.canceled?.note || recipient.notes || '';
         return `
-            <article class="p-5" data-recipient-id="${escapeHtml(recipient.id)}">
+            <article class="p-5" data-recipient-id="${escapeHtml(recipient.id)}" data-balance-cents="${getRecipientBalanceCents(recipient)}" data-status="${escapeHtml(normalizeFeeStatus(recipient.status))}">
                 <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
                     <div>
                         <div class="flex items-center gap-2 flex-wrap">
                             <h3 class="font-bold text-gray-900">${name}</h3>
                             <span class="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-bold text-gray-700">${status}</span>
                         </div>
-                        <div class="mt-1 text-sm text-gray-500">Balance ${balance} · Paid ${paid}</div>
+                        <div class="mt-1 text-sm text-gray-500">Assigned ${assigned} · Balance ${balance} · Paid ${paid} · Outstanding ${outstanding}</div>
                         ${note ? `<p class="mt-2 text-sm text-gray-600">${escapeHtml(note)}</p>` : ''}
                     </div>
                     <div class="grid grid-cols-1 md:grid-cols-3 gap-3 w-full lg:max-w-4xl">
@@ -444,7 +458,7 @@ async function renderManageMode({ container, teamId, batchId, team, user, getTea
 
         try {
             if (form.dataset.action === 'paid') {
-                updates = buildManualPaymentUpdate({ ...data, actorId: user.uid });
+                updates = buildManualPaymentUpdate({ ...data, actorId: user.uid, currentBalanceCents: article?.dataset?.balanceCents, currentStatus: article?.dataset?.status });
             } else if (form.dataset.action === 'adjust') {
                 updates = buildBalanceAdjustmentUpdate({ ...data, actorId: user.uid });
             } else {

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -153,14 +153,17 @@ export function formatFeeCurrency(cents) {
     }).format(amount / 100);
 }
 
-export function buildManualPaymentUpdate({ amount, date, note, actorId, currentBalanceCents, currentStatus }) {
-    const amountPaidCents = toFeeCents(amount);
-    if (amountPaidCents === null || amountPaidCents <= 0) {
+export function buildManualPaymentUpdate({ amount, date, note, actorId, currentBalanceCents, currentPaidCents, currentStatus }) {
+    const paymentAmountCents = toFeeCents(amount);
+    if (paymentAmountCents === null || paymentAmountCents <= 0) {
         throw new Error('Enter a manual payment amount greater than $0.');
     }
     if (!date) throw new Error('Enter a manual payment date.');
 
     const currentBalance = Number(currentBalanceCents);
+    const priorPaid = Number(currentPaidCents);
+    const priorPaidCents = Number.isFinite(priorPaid) ? Math.max(0, priorPaid) : 0;
+    const amountPaidCents = priorPaidCents + paymentAmountCents;
     const isPaidInFull = Number.isFinite(currentBalance) ? amountPaidCents >= Math.max(0, currentBalance) : true;
     const status = isPaidInFull ? 'paid' : normalizeFeeStatus(currentStatus) === 'adjusted' ? 'adjusted' : 'unpaid';
 
@@ -169,7 +172,7 @@ export function buildManualPaymentUpdate({ amount, date, note, actorId, currentB
         amountPaidCents,
         paidAt: date,
         manualPayment: {
-            amountPaidCents,
+            amountPaidCents: paymentAmountCents,
             paidAt: date,
             note: normalizeString(note),
             recordedBy: actorId || null
@@ -283,12 +286,15 @@ function renderRecipients(container, countEl, recipients) {
         const name = escapeHtml(getRecipientDisplayName(recipient));
         const status = getStatusLabel(recipient.status);
         const assigned = formatFeeCurrency(recipient.amountCents ?? recipient.originalAmountCents ?? recipient.assignedAmountCents ?? 0);
-        const balance = formatFeeCurrency(getRecipientBalanceCents(recipient));
-        const paid = formatFeeCurrency(getRecipientPaidCents(recipient));
-        const outstanding = formatFeeCurrency(recipient.status === 'paid' || recipient.status === 'canceled' ? 0 : Math.max(0, getRecipientBalanceCents(recipient) - getRecipientPaidCents(recipient)));
+        const balanceCents = getRecipientBalanceCents(recipient);
+        const paidCents = getRecipientPaidCents(recipient);
+        const outstandingCents = recipient.status === 'paid' || recipient.status === 'canceled' ? 0 : Math.max(0, balanceCents - paidCents);
+        const balance = formatFeeCurrency(balanceCents);
+        const paid = formatFeeCurrency(paidCents);
+        const outstanding = formatFeeCurrency(outstandingCents);
         const note = recipient.manualPayment?.note || recipient.adjustment?.note || recipient.canceled?.note || recipient.notes || '';
         return `
-            <article class="p-5" data-recipient-id="${escapeHtml(recipient.id)}" data-balance-cents="${getRecipientBalanceCents(recipient)}" data-status="${escapeHtml(normalizeFeeStatus(recipient.status))}">
+            <article class="p-5" data-recipient-id="${escapeHtml(recipient.id)}" data-balance-cents="${balanceCents}" data-paid-cents="${paidCents}" data-status="${escapeHtml(normalizeFeeStatus(recipient.status))}">
                 <div class="flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
                     <div>
                         <div class="flex items-center gap-2 flex-wrap">
@@ -301,7 +307,7 @@ function renderRecipients(container, countEl, recipients) {
                     <div class="grid grid-cols-1 md:grid-cols-3 gap-3 w-full lg:max-w-4xl">
                         <form data-action="paid" class="rounded-xl border border-gray-200 bg-gray-50 p-3 space-y-2">
                             <div class="text-xs font-bold uppercase tracking-wide text-gray-500">Manual payment</div>
-                            <input name="amount" type="number" min="0" step="0.01" value="${(getRecipientBalanceCents(recipient) / 100).toFixed(2)}" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Payment amount">
+                            <input name="amount" type="number" min="0" step="0.01" value="${(outstandingCents / 100).toFixed(2)}" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Payment amount">
                             <input name="date" type="date" value="${new Date().toISOString().slice(0, 10)}" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Payment date">
                             <input name="note" type="text" placeholder="Optional note" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Payment note">
                             <button class="w-full rounded-lg bg-green-600 px-3 py-2 text-sm font-semibold text-white hover:bg-green-700">Mark paid</button>
@@ -458,7 +464,7 @@ async function renderManageMode({ container, teamId, batchId, team, user, getTea
 
         try {
             if (form.dataset.action === 'paid') {
-                updates = buildManualPaymentUpdate({ ...data, actorId: user.uid, currentBalanceCents: article?.dataset?.balanceCents, currentStatus: article?.dataset?.status });
+                updates = buildManualPaymentUpdate({ ...data, actorId: user.uid, currentBalanceCents: article?.dataset?.balanceCents, currentPaidCents: article?.dataset?.paidCents, currentStatus: article?.dataset?.status });
             } else if (form.dataset.action === 'adjust') {
                 updates = buildBalanceAdjustmentUpdate({ ...data, actorId: user.uid });
             } else {

--- a/team-fees.html
+++ b/team-fees.html
@@ -44,7 +44,7 @@
 
     <div id="footer-container"></div>
 
-    <script type="module" src="./js/team-fees-admin.js?v=2"></script>
+    <script type="module" src="./js/team-fees-admin.js?v=3"></script>
 </body>
 
 </html>

--- a/tests/unit/team-fees-admin.test.js
+++ b/tests/unit/team-fees-admin.test.js
@@ -107,6 +107,29 @@ describe('team fees admin helpers', () => {
         });
 
         expect(buildManualPaymentUpdate({
+            amount: '20.00',
+            date: '2026-05-05',
+            currentBalanceCents: 5000,
+            currentPaidCents: 2500
+        })).toMatchObject({
+            status: 'unpaid',
+            amountPaidCents: 4500
+        });
+
+        expect(buildManualPaymentUpdate({
+            amount: '25.00',
+            date: '2026-05-05',
+            currentBalanceCents: 5000,
+            currentPaidCents: 2500
+        })).toMatchObject({
+            status: 'paid',
+            amountPaidCents: 5000,
+            manualPayment: {
+                amountPaidCents: 2500
+            }
+        });
+
+        expect(buildManualPaymentUpdate({
             amount: '50.00',
             date: '2026-05-05',
             currentBalanceCents: 5000

--- a/tests/unit/team-fees-admin.test.js
+++ b/tests/unit/team-fees-admin.test.js
@@ -74,15 +74,17 @@ describe('team fees admin helpers', () => {
 
     it('summarizes assigned, paid, outstanding, and status counts', () => {
         const summary = summarizeFeeRecipients([
-            { status: 'paid', amountDueCents: 5000, amountPaidCents: 5000 },
-            { status: 'unpaid', amountDueCents: 7500 },
-            { status: 'adjusted', amountDueCents: 2500, amountPaidCents: 500 },
-            { status: 'canceled', amountDueCents: 3000 }
+            { status: 'paid', amountCents: 5000, amountDueCents: 5000, amountPaidCents: 5000 },
+            { status: 'unpaid', amountCents: 7500, amountDueCents: 7500 },
+            { status: 'adjusted', amountCents: 4000, amountDueCents: 2500, amountPaidCents: 500 },
+            { status: 'canceled', amountCents: 3000, amountDueCents: 3000 }
         ]);
 
         expect(summary).toEqual({
-            totalAssignedCents: 15000,
+            totalAssignedCents: 19500,
             totalPaidCents: 5500,
+            totalAdjustedCents: 1500,
+            totalCanceledCents: 3000,
             totalOutstandingCents: 9500,
             counts: {
                 paid: 1,
@@ -92,6 +94,26 @@ describe('team fees admin helpers', () => {
             }
         });
         expect(formatFeeCurrency(summary.totalOutstandingCents)).toBe('$95.00');
+    });
+
+    it('keeps partial manual payments outstanding until the balance is fully paid', () => {
+        expect(buildManualPaymentUpdate({
+            amount: '25.00',
+            date: '2026-05-05',
+            currentBalanceCents: 5000
+        })).toMatchObject({
+            status: 'unpaid',
+            amountPaidCents: 2500
+        });
+
+        expect(buildManualPaymentUpdate({
+            amount: '50.00',
+            date: '2026-05-05',
+            currentBalanceCents: 5000
+        })).toMatchObject({
+            status: 'paid',
+            amountPaidCents: 5000
+        });
     });
 
     it('builds manual payment, adjustment, and cancellation updates', () => {


### PR DESCRIPTION
Closes #805

## Summary
- Added adjusted and canceled amount totals to the admin fee receivables summary.
- Expanded recipient rows to show assigned, balance, paid, and outstanding amounts.
- Preserved manual collection behavior while keeping partial offline payments outstanding until fully paid.

## Validation
- `npx vitest run tests/unit/team-fees-admin.test.js`
- `node scripts/check-critical-cache-bust.mjs`