### PR TITLE
Add live play announcer

### DIFF
--- a/js/live-game-announcer.js
+++ b/js/live-game-announcer.js
@@ -1,0 +1,123 @@
+const DEFAULT_STORAGE_KEY = 'allplaysPlayAnnouncerEnabled';
+
+export function cleanAnnouncementText(value) {
+    return String(value || '')
+        .replace(/<[^>]*>/g, ' ')
+        .replace(/&nbsp;/gi, ' ')
+        .replace(/&amp;/gi, '&')
+        .replace(/&lt;/gi, '<')
+        .replace(/&gt;/gi, '>')
+        .replace(/&quot;/gi, '"')
+        .replace(/&#39;/g, "'")
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+export function buildPlayAnnouncement(event = {}) {
+    const description = cleanAnnouncementText(event.description);
+    if (!description) return '';
+
+    const period = cleanAnnouncementText(event.period);
+    const parts = [];
+    if (period) parts.push(period);
+    parts.push(description);
+
+    return parts.join('. ');
+}
+
+function safeGetStorage(storage, key) {
+    try {
+        return storage?.getItem?.(key) || null;
+    } catch {
+        return null;
+    }
+}
+
+function safeSetStorage(storage, key, value) {
+    try {
+        storage?.setItem?.(key, value);
+    } catch {
+        // Ignore storage failures in private browsing or restricted contexts.
+    }
+}
+
+function getAnnouncementEventKey(event = {}) {
+    if (event.id) return String(event.id);
+    const timestamp = event.createdAt?.toMillis?.() ?? event.createdAt ?? '';
+    return [event.type || '', event.period || '', event.gameClockMs ?? '', timestamp, cleanAnnouncementText(event.description)].join('|');
+}
+
+export function createPlayAnnouncer({
+    speechSynthesis = globalThis.speechSynthesis,
+    SpeechSynthesisUtterance = globalThis.SpeechSynthesisUtterance,
+    storage = globalThis.localStorage,
+    storageKey = DEFAULT_STORAGE_KEY
+} = {}) {
+    const announcedEventIds = new Set();
+    const supported = Boolean(speechSynthesis && SpeechSynthesisUtterance);
+    let enabled = safeGetStorage(storage, storageKey) === 'true';
+    let paused = false;
+
+    function persist() {
+        safeSetStorage(storage, storageKey, enabled ? 'true' : 'false');
+    }
+
+    function cancelCurrentSpeech() {
+        if (!supported) return;
+        try {
+            speechSynthesis.cancel();
+        } catch {
+            // Ignore browser speech engine failures.
+        }
+    }
+
+    return {
+        isSupported() {
+            return supported;
+        },
+        isEnabled() {
+            return enabled;
+        },
+        isPaused() {
+            return paused;
+        },
+        setEnabled(nextEnabled) {
+            enabled = Boolean(nextEnabled) && supported;
+            if (!enabled) {
+                paused = false;
+                cancelCurrentSpeech();
+            }
+            persist();
+            return enabled;
+        },
+        setPaused(nextPaused) {
+            paused = Boolean(nextPaused) && enabled;
+            if (paused) {
+                cancelCurrentSpeech();
+            }
+            return paused;
+        },
+        clearHistory() {
+            announcedEventIds.clear();
+        },
+        announceEvent(event, { allowReplay = true } = {}) {
+            if (!supported || !enabled || paused) return false;
+            if (!allowReplay && event?.replayOnly) return false;
+            const eventId = getAnnouncementEventKey(event);
+            if (eventId && announcedEventIds.has(eventId)) return false;
+            const text = buildPlayAnnouncement(event);
+            if (!text) return false;
+            if (eventId) announcedEventIds.add(eventId);
+
+            try {
+                const utterance = new SpeechSynthesisUtterance(text);
+                utterance.rate = 1;
+                utterance.pitch = 1;
+                speechSynthesis.speak(utterance);
+                return true;
+            } catch {
+                return false;
+            }
+        }
+    };
+}

--- a/js/live-game-announcer.js
+++ b/js/live-game-announcer.js
@@ -41,10 +41,11 @@ function safeSetStorage(storage, key, value) {
     }
 }
 
-function getAnnouncementEventKey(event = {}) {
-    if (event.id) return String(event.id);
+function getAnnouncementEventKey(event = {}, playbackSessionId = 'live') {
+    const sessionKey = cleanAnnouncementText(playbackSessionId) || 'live';
+    if (event.id) return `${sessionKey}:${String(event.id)}`;
     const timestamp = event.createdAt?.toMillis?.() ?? event.createdAt ?? '';
-    return [event.type || '', event.period || '', event.gameClockMs ?? '', timestamp, cleanAnnouncementText(event.description)].join('|');
+    return [sessionKey, event.type || '', event.period || '', event.gameClockMs ?? '', timestamp, cleanAnnouncementText(event.description)].join('|');
 }
 
 export function createPlayAnnouncer({
@@ -100,20 +101,20 @@ export function createPlayAnnouncer({
         clearHistory() {
             announcedEventIds.clear();
         },
-        announceEvent(event, { allowReplay = true } = {}) {
+        announceEvent(event, { allowReplay = true, playbackSessionId = 'live' } = {}) {
             if (!supported || !enabled || paused) return false;
             if (!allowReplay && event?.replayOnly) return false;
-            const eventId = getAnnouncementEventKey(event);
+            const eventId = getAnnouncementEventKey(event, playbackSessionId);
             if (eventId && announcedEventIds.has(eventId)) return false;
             const text = buildPlayAnnouncement(event);
             if (!text) return false;
-            if (eventId) announcedEventIds.add(eventId);
 
             try {
                 const utterance = new SpeechSynthesisUtterance(text);
                 utterance.rate = 1;
                 utterance.pitch = 1;
                 speechSynthesis.speak(utterance);
+                if (eventId) announcedEventIds.add(eventId);
                 return true;
             } catch {
                 return false;

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -22,6 +22,7 @@ import { buildScoreLinkedClipRecord, isScoredPlayEvent, validateGameClipFile } f
 import { computePanelVisibility } from './live-stream-utils.js?v=1';
 import { checkAuth } from './auth.js?v=13';
 import { isViewerChatEnabled } from './live-game-chat.js?v=1';
+import { createPlayAnnouncer } from './live-game-announcer.js?v=1';
 import {
   buildReplaySessionState,
   collectReplayEventWindow,
@@ -99,6 +100,8 @@ const state = {
   selectedClipEvent: null
 };
 
+const playAnnouncer = createPlayAnnouncer();
+
 const els = {
   homeTeamName: q('#home-team-name'),
   awayTeamName: q('#away-team-name'),
@@ -113,6 +116,9 @@ const els = {
   connectionBanner: q('#connection-banner'),
 
   playsFeed: q('#plays-feed'),
+  announcerToggle: q('#announcer-toggle'),
+  announcerPause: q('#announcer-pause'),
+  announcerStatus: q('#announcer-status'),
   statsList: q('#stats-list'),
   opponentStats: q('#opponent-stats'),
   lineupOnCourt: q('#lineup-oncourt'),
@@ -249,6 +255,51 @@ function updateShareButton() {
 
 function canAttachScoreLinkedClips() {
   return hasFullTeamAccess(state.user, state.team);
+}
+
+function renderAnnouncerControls() {
+  if (!els.announcerToggle || !els.announcerPause || !els.announcerStatus) return;
+  const supported = playAnnouncer.isSupported();
+  const enabled = playAnnouncer.isEnabled();
+  const paused = playAnnouncer.isPaused();
+
+  els.announcerToggle.disabled = !supported;
+  els.announcerToggle.textContent = enabled ? 'Stop announcer' : 'Listen live';
+  els.announcerToggle.classList.toggle('bg-teal', enabled);
+  els.announcerToggle.classList.toggle('text-ink', enabled);
+  els.announcerPause.classList.toggle('hidden', !enabled);
+  els.announcerPause.textContent = paused ? 'Resume' : 'Pause';
+
+  if (!supported) {
+    els.announcerStatus.textContent = 'Play Announcer is not supported in this browser.';
+  } else if (!enabled) {
+    els.announcerStatus.textContent = 'Opt in to hear new plays during live games and replay.';
+  } else if (paused) {
+    els.announcerStatus.textContent = 'Announcer paused.';
+  } else {
+    els.announcerStatus.textContent = state.isReplay ? 'Replay announcer on.' : 'Live announcer on.';
+  }
+}
+
+function initAnnouncerControls() {
+  renderAnnouncerControls();
+  if (els.announcerToggle) {
+    els.announcerToggle.addEventListener('click', () => {
+      playAnnouncer.setEnabled(!playAnnouncer.isEnabled());
+      renderAnnouncerControls();
+    });
+  }
+  if (els.announcerPause) {
+    els.announcerPause.addEventListener('click', () => {
+      playAnnouncer.setPaused(!playAnnouncer.isPaused());
+      renderAnnouncerControls();
+    });
+  }
+}
+
+function announcePlayEvent(event, shouldAnnounce = true) {
+  if (!shouldAnnounce) return;
+  playAnnouncer.announceEvent(event);
 }
 
 function initTabs() {
@@ -1601,7 +1652,7 @@ function resetViewerStateFromGameDoc(gameDoc, placeholder = 'Game reset. Waiting
   renderLineup();
 }
 
-function processNewEvents(events) {
+function processNewEvents(events, { announce = true } = {}) {
   const newEvents = collectVisibleLiveEventsSequentially(events, {
     seenIds: state.eventIds,
     resetBoundaryMs: state.lastResetAt
@@ -1635,6 +1686,7 @@ function processNewEvents(events) {
     }
     if (transition.shouldRenderPlayByPlay) {
       renderPlayByPlay(event, true);
+      announcePlayEvent(event, announce);
     }
     if (transition.shouldRenderStats) {
       renderStats();
@@ -1694,6 +1746,7 @@ function startLiveEvents() {
   state.liveEventsFirstLoad = true;
   const unsubEvents = subscribeLiveEvents(state.teamId, state.gameId, (events) => {
     setConnectionBanner(false);
+    const isInitialLiveEventsLoad = state.liveEventsFirstLoad;
     if (state.liveEventsFirstLoad && events.length === 0) {
       // Show a message while waiting for first events
       const placeholder = els.playsFeed?.querySelector?.('[data-placeholder="plays"]');
@@ -1708,7 +1761,7 @@ function startLiveEvents() {
       }
     }
     state.liveEventsFirstLoad = false;
-    processNewEvents(events);
+    processNewEvents(events, { announce: !isInitialLiveEventsLoad });
   }, (error) => {
     console.warn('Live events subscription failed:', error);
     setConnectionBanner(true, formatFirestoreError(error));
@@ -1926,7 +1979,7 @@ function seekReplay(targetMs) {
     elapsedMs: targetMs
   });
   if (replayWindow.events.length) {
-    processNewEvents(replayWindow.events);
+    processNewEvents(replayWindow.events, { announce: false });
   }
   state.replayIndex = replayWindow.nextReplayIndex;
 
@@ -2282,6 +2335,7 @@ async function init() {
   initReplayControls();
   initRecordedReplayControls();
   initNativeCameraControls();
+  initAnnouncerControls();
   if (els.shareGameBtn) {
     els.shareGameBtn.addEventListener('click', async () => {
       const isReport = state.isReplay || state.game?.status === 'completed' || state.game?.liveStatus === 'completed';

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -299,7 +299,7 @@ function initAnnouncerControls() {
 
 function announcePlayEvent(event, shouldAnnounce = true) {
   if (!shouldAnnounce) return;
-  playAnnouncer.announceEvent(event);
+  playAnnouncer.announceEvent(event, { playbackSessionId: state.isReplay ? 'replay' : 'live' });
 }
 
 function initTabs() {

--- a/live-game.html
+++ b/live-game.html
@@ -263,6 +263,13 @@
           <span>&#9654;</span>
           Play-by-Play
         </h2>
+        <div class="mb-3 rounded-xl border border-teal/20 bg-ink/55 p-3 shrink-0">
+          <div class="flex flex-wrap items-center gap-2">
+            <button id="announcer-toggle" type="button" class="rounded-lg border border-teal/30 px-3 py-2 text-xs font-semibold text-teal hover:bg-slate/70 disabled:cursor-not-allowed disabled:opacity-50">Listen live</button>
+            <button id="announcer-pause" type="button" class="hidden rounded-lg border border-sand/20 px-3 py-2 text-xs font-semibold text-sand/80 hover:bg-slate/70">Pause</button>
+          </div>
+          <p id="announcer-status" class="mt-2 text-xs text-sand/55">Opt in to hear new plays during live games and replay.</p>
+        </div>
         <div id="plays-feed" class="space-y-2 overflow-y-auto flex-1 pr-1">
           <div data-placeholder="plays" class="text-center text-sand/40 py-8">Waiting for game to start...</div>
         </div>
@@ -568,6 +575,6 @@
 
   <div id="footer-container"></div>
 
-  <script type="module" src="js/live-game.js?v=4"></script>
+  <script type="module" src="js/live-game.js?v=5"></script>
 </body>
 </html>

--- a/tests/unit/live-game-announcer.test.js
+++ b/tests/unit/live-game-announcer.test.js
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+    buildPlayAnnouncement,
+    cleanAnnouncementText,
+    createPlayAnnouncer
+} from '../../js/live-game-announcer.js';
+
+function createStorage(initial = {}) {
+    const values = new Map(Object.entries(initial));
+    return {
+        getItem: vi.fn((key) => values.get(key) || null),
+        setItem: vi.fn((key, value) => values.set(key, value))
+    };
+}
+
+describe('live game play announcer', () => {
+    it('sanitizes event descriptions before speaking', () => {
+        expect(cleanAnnouncementText('  <b>Goal</b> &amp; assist&nbsp; ')).toBe('Goal & assist');
+        expect(buildPlayAnnouncement({ period: 'Q2', description: '<span>Layup</span>' })).toBe('Q2. Layup');
+    });
+
+    it('speaks each enabled event once and persists the preference', () => {
+        const speak = vi.fn();
+        const cancel = vi.fn();
+        const storage = createStorage();
+        const Utterance = vi.fn(function MockUtterance(text) {
+            this.text = text;
+        });
+        const announcer = createPlayAnnouncer({
+            speechSynthesis: { speak, cancel },
+            SpeechSynthesisUtterance: Utterance,
+            storage
+        });
+
+        expect(announcer.announceEvent({ id: 'event-1', period: 'Q1', description: 'Tip-off' })).toBe(false);
+        expect(announcer.setEnabled(true)).toBe(true);
+        expect(storage.setItem).toHaveBeenLastCalledWith('allplaysPlayAnnouncerEnabled', 'true');
+
+        expect(announcer.announceEvent({ id: 'event-1', period: 'Q1', description: 'Tip-off' })).toBe(true);
+        expect(announcer.announceEvent({ id: 'event-1', period: 'Q1', description: 'Tip-off' })).toBe(false);
+        expect(speak).toHaveBeenCalledTimes(1);
+        expect(Utterance.mock.instances[0].text).toBe('Q1. Tip-off');
+
+        announcer.setEnabled(false);
+        expect(cancel).toHaveBeenCalledTimes(1);
+        expect(storage.setItem).toHaveBeenLastCalledWith('allplaysPlayAnnouncerEnabled', 'false');
+    });
+
+    it('supports pause without losing duplicate-event protection', () => {
+        const speak = vi.fn();
+        const cancel = vi.fn();
+        const storage = createStorage({ allplaysPlayAnnouncerEnabled: 'true' });
+        const announcer = createPlayAnnouncer({
+            speechSynthesis: { speak, cancel },
+            SpeechSynthesisUtterance: function MockUtterance(text) { this.text = text; },
+            storage
+        });
+
+        expect(announcer.isEnabled()).toBe(true);
+        expect(announcer.setPaused(true)).toBe(true);
+        expect(cancel).toHaveBeenCalledTimes(1);
+        expect(announcer.announceEvent({ id: 'event-2', description: 'Three pointer' })).toBe(false);
+
+        announcer.setPaused(false);
+        expect(announcer.announceEvent({ id: 'event-2', description: 'Three pointer' })).toBe(true);
+        expect(announcer.announceEvent({ id: 'event-2', description: 'Three pointer' })).toBe(false);
+        expect(speak).toHaveBeenCalledTimes(1);
+    });
+
+    it('deduplicates events without ids by their play content', () => {
+        const speak = vi.fn();
+        const announcer = createPlayAnnouncer({
+            speechSynthesis: { speak, cancel: vi.fn() },
+            SpeechSynthesisUtterance: function MockUtterance(text) { this.text = text; },
+            storage: createStorage({ allplaysPlayAnnouncerEnabled: 'true' })
+        });
+        const play = { type: 'goal', period: 'P1', gameClockMs: 12_000, description: 'Goal by Smith' };
+
+        expect(announcer.announceEvent(play)).toBe(true);
+        expect(announcer.announceEvent({ ...play })).toBe(false);
+        expect(speak).toHaveBeenCalledTimes(1);
+    });
+});

--- a/tests/unit/live-game-announcer.test.js
+++ b/tests/unit/live-game-announcer.test.js
@@ -80,4 +80,37 @@ describe('live game play announcer', () => {
         expect(announcer.announceEvent({ ...play })).toBe(false);
         expect(speak).toHaveBeenCalledTimes(1);
     });
+
+    it('scopes duplicate protection by playback session', () => {
+        const speak = vi.fn();
+        const announcer = createPlayAnnouncer({
+            speechSynthesis: { speak, cancel: vi.fn() },
+            SpeechSynthesisUtterance: function MockUtterance(text) { this.text = text; },
+            storage: createStorage({ allplaysPlayAnnouncerEnabled: 'true' })
+        });
+        const play = { id: 'event-3', description: 'Replayable goal' };
+
+        expect(announcer.announceEvent(play, { playbackSessionId: 'live' })).toBe(true);
+        expect(announcer.announceEvent(play, { playbackSessionId: 'live' })).toBe(false);
+        expect(announcer.announceEvent(play, { playbackSessionId: 'replay' })).toBe(true);
+        expect(speak).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not mark an event announced when speech synthesis throws', () => {
+        const speak = vi.fn()
+            .mockImplementationOnce(() => {
+                throw new Error('speech unavailable');
+            })
+            .mockImplementationOnce(() => {});
+        const announcer = createPlayAnnouncer({
+            speechSynthesis: { speak, cancel: vi.fn() },
+            SpeechSynthesisUtterance: function MockUtterance(text) { this.text = text; },
+            storage: createStorage({ allplaysPlayAnnouncerEnabled: 'true' })
+        });
+        const play = { id: 'event-4', description: 'Retry after failure' };
+
+        expect(announcer.announceEvent(play)).toBe(false);
+        expect(announcer.announceEvent(play)).toBe(true);
+        expect(speak).toHaveBeenCalledTimes(2);
+    });
 });

--- a/tests/unit/live-game-replay-init.test.js
+++ b/tests/unit/live-game-replay-init.test.js
@@ -244,6 +244,10 @@ function buildModuleSource() {
             'const { isViewerChatEnabled } = deps.liveGameChat;'
         )
         .replace(
+            "import { createPlayAnnouncer } from './live-game-announcer.js?v=1';",
+            'const { createPlayAnnouncer } = deps.liveGameAnnouncer;'
+        )
+        .replace(
             "import {\n  buildReplaySessionState,\n  collectReplayEventWindow,\n  collectReplayStreamWindow,\n  getReplayElapsedMs,\n  getReplayStartTimeAfterSpeedChange,\n  getReplayTimestampMs\n} from './live-game-replay.js?v=3';",
             'const { buildReplaySessionState, collectReplayEventWindow, collectReplayStreamWindow, getReplayElapsedMs, getReplayStartTimeAfterSpeedChange, getReplayTimestampMs } = deps.liveGameReplay;'
         )
@@ -384,6 +388,16 @@ async function bootReplayPage({ replayEvents }) {
             }
         },
         liveGameChat: { isViewerChatEnabled },
+        liveGameAnnouncer: {
+            createPlayAnnouncer: () => ({
+                isSupported: () => true,
+                isEnabled: () => false,
+                isPaused: () => false,
+                setEnabled: () => false,
+                setPaused: () => false,
+                announceEvent: () => false
+            })
+        },
         liveGameReplay: {
             buildReplaySessionState: ({ teamId, gameId, game = {}, defaultPeriod = 'Q1', replayEvents = [], replayChat = [], replayReactions = [] } = {}) => ({
                 hasReplayEvents: replayEvents.length > 0,


### PR DESCRIPTION
Closes #809

## Summary
- Added an opt-in Play Announcer control to the live play-by-play panel.
- Added a Web Speech API announcer helper with sanitized narration, mute/stop, pause/resume, persisted preference, unsupported-browser fallback, and duplicate-event protection.
- Wired narration into new live events and replay playback while avoiding initial live backfill and replay seek floods.

## Tests
- `npx vitest run tests/unit/live-game-announcer.test.js tests/unit/live-game-replay-init.test.js tests/unit/admin-invite-signup-cache-busting.test.js`