### PR TITLE
Add team media entry page

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -812,6 +812,12 @@ service cloud.firestore {
         }
       }
 
+      // Team media folders subcollection (read-only entry point)
+      match /mediaFolders/{folderId} {
+        allow read: if canAccessTeamChat(teamId);
+        allow create, update, delete: if false;
+      }
+
       // Chat messages subcollection
       match /chatMessages/{messageId} {
         // Read: any team member (owner, admin, global admin, parent)

--- a/js/team-admin-banner.js
+++ b/js/team-admin-banner.js
@@ -41,6 +41,11 @@ function icon(name) {
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"></path>
     </svg>`;
   }
+  if (name === 'media') {
+    return `<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 6h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2z"></path>
+    </svg>`;
+  }
   if (name === 'drills') {
     return `<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
       <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"></path>
@@ -128,6 +133,7 @@ export function renderTeamAdminBanner(container, { team, teamId, active = '', un
     gameplan: `game-plan.html#teamId=${teamId}`,
     stats: `edit-config.html#teamId=${teamId}`,
     chat: `team-chat.html#teamId=${teamId}`,
+    media: `team-media.html#teamId=${teamId}`,
     drills: `drills.html#teamId=${teamId}`,
     gameday: `game-day.html#teamId=${teamId}`,
     help: `help.html?context=team&teamId=${teamId}`,
@@ -137,7 +143,7 @@ export function renderTeamAdminBanner(container, { team, teamId, active = '', un
   // Build nav cards based on access level
   let navCards = '';
   if (isFullAccess) {
-    // Coach/Admin: View, Edit, Roster, Schedule, Game Plan, Stats, Chat
+    // Coach/Admin: View, Edit, Roster, Schedule, Game Plan, Stats, Chat, Media
     navCards = `
       ${actionCard({ href: hrefs.view, label: 'View', iconName: 'view', active: active === 'view' })}
       ${actionCard({ href: hrefs.edit, label: 'Edit', iconName: 'edit', active: active === 'edit' })}
@@ -146,23 +152,25 @@ export function renderTeamAdminBanner(container, { team, teamId, active = '', un
       ${actionCard({ href: hrefs.gameplan, label: 'Game Plan', iconName: 'gameplan', active: active === 'gameplan' })}
       ${actionCard({ href: hrefs.stats, label: 'Stats', iconName: 'stats', active: active === 'stats' })}
       ${actionCard({ href: hrefs.chat, label: 'Chat', iconName: 'chat', active: active === 'chat', unreadCount })}
+      ${actionCard({ href: hrefs.media, label: 'Media', iconName: 'media', active: active === 'media' })}
       ${actionCard({ href: hrefs.drills, label: 'Drills', iconName: 'drills', active: active === 'drills' })}
       ${actionCard({ href: hrefs.gameday, label: 'Game Day', iconName: 'gameday', active: active === 'gameday' })}
       ${actionCard({ href: `${hrefs.help}&role=${helpRole}`, label: 'Help', iconName: 'help', active: active === 'help' })}
     `;
   } else {
-    // Parent: View, Chat, Help
+    // Parent: View, Chat, Media, Help
     navCards = `
       ${actionCard({ href: hrefs.view, label: 'View', iconName: 'view', active: active === 'view' })}
       ${actionCard({ href: hrefs.chat, label: 'Chat', iconName: 'chat', active: active === 'chat', unreadCount })}
+      ${actionCard({ href: hrefs.media, label: 'Media', iconName: 'media', active: active === 'media' })}
       ${actionCard({ href: `${hrefs.help}&role=${helpRole}`, label: 'Help', iconName: 'help', active: active === 'help' })}
     `;
   }
 
   // Determine grid columns based on number of items
   const gridCols = isFullAccess
-    ? 'grid-cols-2 sm:grid-cols-5 lg:grid-cols-10'
-    : 'grid-cols-3';
+    ? 'grid-cols-2 sm:grid-cols-4 lg:grid-cols-6'
+    : 'grid-cols-2 sm:grid-cols-4';
 
   container.innerHTML = `
     <div class="group bg-white rounded-2xl shadow-md border border-gray-200 overflow-hidden">

--- a/js/team-admin-banner.js
+++ b/js/team-admin-banner.js
@@ -123,6 +123,7 @@ export function renderTeamAdminBanner(container, { team, teamId, active = '', un
   const sport = team?.sport || '';
   const photoUrl = team?.photoUrl || '';
   const isFullAccess = accessLevel === 'full';
+  const canViewMedia = isFullAccess || accessLevel === 'parent';
   const helpRole = isFullAccess ? 'coach' : 'parent';
 
   const hrefs = {
@@ -162,7 +163,7 @@ export function renderTeamAdminBanner(container, { team, teamId, active = '', un
     navCards = `
       ${actionCard({ href: hrefs.view, label: 'View', iconName: 'view', active: active === 'view' })}
       ${actionCard({ href: hrefs.chat, label: 'Chat', iconName: 'chat', active: active === 'chat', unreadCount })}
-      ${actionCard({ href: hrefs.media, label: 'Media', iconName: 'media', active: active === 'media' })}
+      ${canViewMedia ? actionCard({ href: hrefs.media, label: 'Media', iconName: 'media', active: active === 'media' }) : ''}
       ${actionCard({ href: `${hrefs.help}&role=${helpRole}`, label: 'Help', iconName: 'help', active: active === 'help' })}
     `;
   }

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -1,0 +1,183 @@
+import { checkAuth } from './auth.js?v=13';
+import { getTeam, getUserProfile, getUnreadChatCounts } from './db.js?v=30';
+import { db, collection, getDocs, query, orderBy } from './firebase.js?v=11';
+import { renderTeamAdminBanner, getTeamAccessInfo } from './team-admin-banner.js?v=3';
+import { renderHeader, renderFooter, escapeHtml } from './utils.js?v=8';
+
+function getTeamIdFromUrl() {
+    const hashParams = new URLSearchParams(window.location.hash.replace('#', ''));
+    const searchParams = new URLSearchParams(window.location.search);
+    return hashParams.get('teamId') || searchParams.get('teamId');
+}
+
+async function getTeamMediaFolders(teamId) {
+    const foldersRef = collection(db, 'teams', teamId, 'mediaFolders');
+    const snapshot = await getDocs(query(foldersRef, orderBy('createdAt', 'asc')));
+    return snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+}
+
+function getFolderItemCount(folder) {
+    if (Array.isArray(folder?.items)) return folder.items.length;
+    if (Array.isArray(folder?.videos)) return folder.videos.length;
+    if (Array.isArray(folder?.mediaLinks)) return folder.mediaLinks.length;
+    return Number(folder?.itemCount || folder?.videoCount || 0);
+}
+
+function renderEmptyState(accessLevel) {
+    const canManageLater = accessLevel === 'full';
+    const title = canManageLater ? 'No media folders yet' : 'No team media yet';
+    const body = canManageLater
+        ? 'This is where coaches and admins will organize team videos, highlight links, and shared folders. Folder and video management will be added in a later workflow.'
+        : 'Coaches have not shared team media folders yet. When they do, you will be able to browse them here.';
+    const footnote = canManageLater
+        ? 'For now, use this page as the read-only team media entry point.'
+        : 'This page is read-only for parents and team followers.';
+
+    return `
+        <div class="text-center py-14 px-4">
+            <div class="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-2xl bg-primary-50 text-primary-600">
+                <svg class="h-8 w-8" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 6h8a2 2 0 012 2v8a2 2 0 01-2 2H5a2 2 0 01-2-2V8a2 2 0 012-2z"></path>
+                </svg>
+            </div>
+            <h2 class="text-xl font-bold text-gray-900">${title}</h2>
+            <p class="mx-auto mt-2 max-w-xl text-gray-600">${body}</p>
+            <p class="mt-4 text-sm font-medium text-gray-500">${footnote}</p>
+        </div>
+    `;
+}
+
+function renderFolderCard(folder) {
+    const name = folder?.name || folder?.title || 'Untitled folder';
+    const description = folder?.description || 'Team media folder';
+    const itemCount = getFolderItemCount(folder);
+    const visibility = folder?.visibility ? String(folder.visibility) : 'Team access';
+
+    return `
+        <article class="rounded-xl border border-gray-200 bg-white p-5 shadow-sm hover:border-primary-200 transition">
+            <div class="flex items-start justify-between gap-3">
+                <div class="min-w-0">
+                    <h2 class="truncate text-lg font-bold text-gray-900">${escapeHtml(name)}</h2>
+                    <p class="mt-1 text-sm text-gray-600">${escapeHtml(description)}</p>
+                </div>
+                <div class="rounded-lg bg-primary-50 p-2 text-primary-600">
+                    <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 7a2 2 0 012-2h3l2 2h7a2 2 0 012 2v8a2 2 0 01-2 2H6a2 2 0 01-2-2V7z"></path>
+                    </svg>
+                </div>
+            </div>
+            <div class="mt-4 flex flex-wrap items-center gap-2 text-xs font-semibold text-gray-500">
+                <span class="rounded-full bg-gray-100 px-2.5 py-1">${itemCount} ${itemCount === 1 ? 'item' : 'items'}</span>
+                <span class="rounded-full bg-gray-100 px-2.5 py-1">${escapeHtml(visibility)}</span>
+            </div>
+        </article>
+    `;
+}
+
+function renderFolders(folders) {
+    return `
+        <div class="mb-5 flex items-center justify-between gap-3">
+            <div>
+                <h2 class="text-xl font-bold text-gray-900">Folders</h2>
+                <p class="text-sm text-gray-500">Read-only view of team-scoped media folders.</p>
+            </div>
+            <span class="rounded-full bg-primary-50 px-3 py-1 text-sm font-semibold text-primary-700">${folders.length} ${folders.length === 1 ? 'folder' : 'folders'}</span>
+        </div>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            ${folders.map(renderFolderCard).join('')}
+        </div>
+    `;
+}
+
+function showError(message) {
+    const content = document.getElementById('media-page-content');
+    if (!content) return;
+    content.innerHTML = `
+        <div class="text-center py-12">
+            <p class="text-red-600 font-semibold">${escapeHtml(message)}</p>
+            <button onclick="location.reload()" class="mt-4 rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700">Retry</button>
+        </div>
+    `;
+}
+
+renderFooter(document.getElementById('footer-container'));
+
+checkAuth(async (user) => {
+    if (!user) {
+        window.location.href = 'login.html';
+        return;
+    }
+
+    renderHeader(document.getElementById('header-container'), user);
+
+    const teamId = getTeamIdFromUrl();
+    if (!teamId) {
+        alert('No team specified');
+        window.location.href = 'dashboard.html';
+        return;
+    }
+
+    try {
+        const team = await getTeam(teamId);
+        if (!team) {
+            alert('Team not found');
+            window.location.href = 'dashboard.html';
+            return;
+        }
+
+        const profile = await getUserProfile(user.uid);
+        const userWithProfile = {
+            ...user,
+            parentOf: profile?.parentOf || [],
+            coachOf: profile?.coachOf || [],
+            isAdmin: profile?.isAdmin || false,
+            profileEmail: profile?.email || profile?.profileEmail
+        };
+        const teamWithId = { ...team, id: teamId };
+        const accessInfo = getTeamAccessInfo(userWithProfile, teamWithId);
+
+        if (!accessInfo.hasAccess || !['full', 'parent'].includes(accessInfo.accessLevel)) {
+            alert('You do not have access to this team media');
+            window.location.href = accessInfo.exitUrl || 'dashboard.html';
+            return;
+        }
+
+        let unreadCount = 0;
+        try {
+            const counts = await getUnreadChatCounts(user.uid, [teamId]);
+            unreadCount = counts[teamId] || 0;
+        } catch (error) {
+            console.error('Error fetching unread counts:', error);
+        }
+
+        renderTeamAdminBanner(document.getElementById('team-banner'), {
+            team,
+            teamId,
+            active: 'media',
+            unreadCount,
+            accessLevel: accessInfo.accessLevel,
+            exitUrl: accessInfo.exitUrl
+        });
+
+        const badge = document.getElementById('media-role-badge');
+        if (badge) {
+            badge.textContent = accessInfo.accessLevel === 'full' ? 'Coach/Admin view' : 'Read-only view';
+        }
+
+        const subtitle = document.getElementById('media-page-subtitle');
+        if (subtitle) {
+            subtitle.textContent = accessInfo.accessLevel === 'full'
+                ? 'Review the team media library entry point before folder management is added.'
+                : 'Browse media folders shared by coaches and admins.';
+        }
+
+        const folders = await getTeamMediaFolders(teamId);
+        const content = document.getElementById('media-page-content');
+        content.innerHTML = folders.length > 0
+            ? renderFolders(folders)
+            : renderEmptyState(accessInfo.accessLevel);
+    } catch (error) {
+        console.error('Error loading team media:', error);
+        showError('Failed to load team media. Please try again.');
+    }
+});

--- a/team-media.html
+++ b/team-media.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-3J13LHWFT3"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-3J13LHWFT3');
+    </script>
+
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex,nofollow">
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Team Media - ALL PLAYS</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        primary: {
+                            50: '#eef2ff',
+                            100: '#e0e7ff',
+                            500: '#6366f1',
+                            600: '#4f46e5',
+                            700: '#4338ca',
+                            800: '#3730a3',
+                            900: '#312e81'
+                        }
+                    }
+                }
+            }
+        }
+    </script>
+</head>
+
+<body class="bg-gray-50 text-gray-900">
+    <div id="header-container"></div>
+
+    <main class="container mx-auto px-4 py-6 max-w-5xl">
+        <div id="team-banner" class="mb-6"></div>
+
+        <section class="bg-white rounded-2xl shadow-lg border border-gray-200 overflow-hidden">
+            <div class="p-6 border-b border-gray-100 bg-gradient-to-r from-primary-50 to-white">
+                <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+                    <div>
+                        <p class="text-sm font-semibold text-primary-700 uppercase tracking-wide">Team library</p>
+                        <h1 class="text-2xl md:text-3xl font-bold text-gray-900 mt-1">Media</h1>
+                        <p id="media-page-subtitle" class="text-gray-600 mt-2">Browse team video folders and highlights shared with this team.</p>
+                    </div>
+                    <span id="media-role-badge" class="self-start rounded-full bg-gray-100 px-3 py-1 text-sm font-semibold text-gray-700">Loading...</span>
+                </div>
+            </div>
+
+            <div id="media-page-content" class="p-6">
+                <div class="text-center py-12">
+                    <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mx-auto mb-3"></div>
+                    <p class="text-sm text-gray-500">Loading team media...</p>
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <div id="footer-container"></div>
+
+    <script type="module" src="./js/team-media.js?v=1"></script>
+</body>
+
+</html>

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -12,6 +12,8 @@ describe('team media entry point', () => {
         expect(bannerJs).toContain('media: `team-media.html#teamId=${teamId}`');
         expect(bannerJs).toContain("label: 'Media', iconName: 'media', active: active === 'media'");
         expect(bannerJs).toContain('// Parent: View, Chat, Media, Help');
+        expect(bannerJs).toContain("const canViewMedia = isFullAccess || accessLevel === 'parent';");
+        expect(bannerJs).toContain('canViewMedia ? actionCard');
     });
 
     it('loads team media with team-scoped access checks and read-only empty states', () => {

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readRepoFile(relativePath) {
+    return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+describe('team media entry point', () => {
+    it('adds Media navigation for full-access and parent team users', () => {
+        const bannerJs = readRepoFile('js/team-admin-banner.js');
+
+        expect(bannerJs).toContain('media: `team-media.html#teamId=${teamId}`');
+        expect(bannerJs).toContain("label: 'Media', iconName: 'media', active: active === 'media'");
+        expect(bannerJs).toContain('// Parent: View, Chat, Media, Help');
+    });
+
+    it('loads team media with team-scoped access checks and read-only empty states', () => {
+        const pageHtml = readRepoFile('team-media.html');
+        const pageJs = readRepoFile('js/team-media.js');
+        const rules = readRepoFile('firestore.rules');
+
+        expect(pageHtml).toContain('<script type="module" src="./js/team-media.js?v=1"></script>');
+        expect(pageJs).toContain("collection(db, 'teams', teamId, 'mediaFolders')");
+        expect(pageJs).toContain("active: 'media'");
+        expect(pageJs).toContain("!['full', 'parent'].includes(accessInfo.accessLevel)");
+        expect(pageJs).toContain('Folder and video management will be added in a later workflow.');
+        expect(pageJs).toContain('This page is read-only for parents and team followers.');
+        expect(rules).toContain('match /mediaFolders/{folderId}');
+        expect(rules).toContain('allow read: if canAccessTeamChat(teamId);');
+        expect(rules).toContain('allow create, update, delete: if false;');
+    });
+});


### PR DESCRIPTION
Closes #812

## Summary
- Added a team-scoped Media page that loads the current `teamId`, applies existing team access checks, and renders read-only media folder hooks.
- Added Media navigation for coaches/admins and parents with team access.
- Added role-aware empty states for coaches/admins versus parents and read-only Firestore access for `mediaFolders`.

## Validation
- `npx vitest run tests/unit/team-media-page.test.js tests/unit/team-access.test.js --reporter=dot`