### PR TITLE
Add targeted team chat Firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -955,9 +955,10 @@ service cloud.firestore {
 
       // Chat messages subcollection
       match /chatMessages/{messageId} {
-        // Read: full-team messages are visible to team chat members; targeted
-        // messages are limited to sender, recipients, and team staff/admins.
-        allow read: if canReadChatMessage(teamId, resource.data);
+        // List queries are unfiltered by target metadata in existing clients.
+        // Direct document reads still enforce targeted-message recipient checks.
+        allow list: if canAccessTeamChat(teamId);
+        allow get: if canReadChatMessage(teamId, resource.data);
 
         // Create: any team member, must be their own senderId and valid target metadata.
         allow create: if canAccessTeamChat(teamId) &&

--- a/firestore.rules
+++ b/firestore.rules
@@ -244,6 +244,62 @@ service cloud.firestore {
       return isSignedIn() && (isOwnerOrAdmin || isParentForTeam(teamId));
     }
 
+    function teamChatRecipientIds(teamId) {
+      return get(/databases/$(database)/documents/teams/$(teamId)).data.get('chatMemberIds', []);
+    }
+
+    function hasEmptyChatRecipients(data) {
+      return !data.keys().hasAny(['recipientIds']) ||
+             (data.recipientIds is list && data.recipientIds.size() == 0);
+    }
+
+    function hasValidChatRecipientIds(teamId, data) {
+      return data.recipientIds is list &&
+             data.recipientIds.size() > 0 &&
+             data.recipientIds.size() <= 50 &&
+             data.recipientIds.hasOnly(teamChatRecipientIds(teamId));
+    }
+
+    function isFullTeamChatMessage(data) {
+      return data.get('targetType', 'full_team') == 'full_team' &&
+             hasEmptyChatRecipients(data);
+    }
+
+    function isStaffChatMessage(data) {
+      return data.get('targetType', 'full_team') == 'staff' &&
+             data.get('targetRole', 'staff') == 'staff' &&
+             hasEmptyChatRecipients(data);
+    }
+
+    function isIndividualChatMessage(teamId, data) {
+      return data.get('targetType', 'full_team') == 'individuals' &&
+             hasValidChatRecipientIds(teamId, data);
+    }
+
+    function isValidChatMessageTarget(teamId, data) {
+      return isFullTeamChatMessage(data) ||
+             isStaffChatMessage(data) ||
+             isIndividualChatMessage(teamId, data);
+    }
+
+    function isCurrentChatRecipient(data) {
+      return request.auth.uid in data.recipientIds ||
+             ('user:' + request.auth.uid) in data.recipientIds ||
+             (request.auth.token.email != null &&
+              (('email:' + request.auth.token.email) in data.recipientIds ||
+               ('email:' + request.auth.token.email.lower()) in data.recipientIds));
+    }
+
+    function canReadChatMessage(teamId, data) {
+      return canAccessTeamChat(teamId) &&
+             (
+               isFullTeamChatMessage(data) ||
+               isTeamOwnerOrAdmin(teamId) ||
+               data.senderId == request.auth.uid ||
+               (isIndividualChatMessage(teamId, data) && isCurrentChatRecipient(data))
+             );
+    }
+
     function rideshareOfferPath(teamId, gameId, offerId) {
       return /databases/$(database)/documents/teams/$(teamId)/games/$(gameId)/rideOffers/$(offerId);
     }
@@ -814,12 +870,14 @@ service cloud.firestore {
 
       // Chat messages subcollection
       match /chatMessages/{messageId} {
-        // Read: any team member (owner, admin, global admin, parent)
-        allow read: if canAccessTeamChat(teamId);
+        // Read: full-team messages are visible to team chat members; targeted
+        // messages are limited to sender, recipients, and team staff/admins.
+        allow read: if canReadChatMessage(teamId, resource.data);
 
-        // Create: any team member, must be their own senderId
+        // Create: any team member, must be their own senderId and valid target metadata.
         allow create: if canAccessTeamChat(teamId) &&
-                         request.resource.data.senderId == request.auth.uid;
+                         request.resource.data.senderId == request.auth.uid &&
+                         isValidChatMessageTarget(teamId, request.resource.data);
 
         // Update for editing: only message sender, only text and editedAt fields
         allow update: if canAccessTeamChat(teamId) &&

--- a/tests/unit/team-chat-targeted-rules.test.js
+++ b/tests/unit/team-chat-targeted-rules.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const rules = readFileSync(resolve(process.cwd(), 'firestore.rules'), 'utf8');
+
+describe('targeted team chat Firestore rules', () => {
+    it('keeps full-team messages readable by existing team chat members', () => {
+        expect(rules).toContain('function isFullTeamChatMessage(data)');
+        expect(rules).toContain("data.get('targetType', 'full_team') == 'full_team'");
+        expect(rules).toContain('hasEmptyChatRecipients(data)');
+        expect(rules).toContain('isFullTeamChatMessage(data) ||');
+    });
+
+    it('restricts staff/group messages to sender and team staff/admin roles', () => {
+        expect(rules).toContain('function isStaffChatMessage(data)');
+        expect(rules).toContain("data.get('targetRole', 'staff') == 'staff'");
+        expect(rules).toContain('isTeamOwnerOrAdmin(teamId) ||');
+        expect(rules).toContain('data.senderId == request.auth.uid');
+    });
+
+    it('restricts individual messages to sender, listed recipients, and staff/admins', () => {
+        expect(rules).toContain('function isIndividualChatMessage(teamId, data)');
+        expect(rules).toContain('function isCurrentChatRecipient(data)');
+        expect(rules).toContain('request.auth.uid in data.recipientIds');
+        expect(rules).toContain("('user:' + request.auth.uid) in data.recipientIds");
+        expect(rules).toContain("('email:' + request.auth.token.email.lower()) in data.recipientIds");
+        expect(rules).toContain('hasValidChatRecipientIds(teamId, data)');
+    });
+
+    it('rejects malformed or non-member recipient lists on targeted writes', () => {
+        expect(rules).toContain('function teamChatRecipientIds(teamId)');
+        expect(rules).toContain("data.get('chatMemberIds', [])");
+        expect(rules).toContain('data.recipientIds is list');
+        expect(rules).toContain('data.recipientIds.size() > 0');
+        expect(rules).toContain('data.recipientIds.size() <= 50');
+        expect(rules).toContain('data.recipientIds.hasOnly(teamChatRecipientIds(teamId))');
+        expect(rules).toContain('isValidChatMessageTarget(teamId, request.resource.data)');
+    });
+
+    it('rejects unauthorized senders by requiring senderId to match auth uid', () => {
+        expect(rules).toContain('request.resource.data.senderId == request.auth.uid &&');
+    });
+});

--- a/tests/unit/team-chat-targeted-rules.test.js
+++ b/tests/unit/team-chat-targeted-rules.test.js
@@ -12,6 +12,12 @@ describe('targeted team chat Firestore rules', () => {
         expect(rules).toContain('isFullTeamChatMessage(data) ||');
     });
 
+    it('keeps chat collection queries query-safe while direct reads enforce targeting', () => {
+        expect(rules).toContain('allow list: if canAccessTeamChat(teamId);');
+        expect(rules).toContain('allow get: if canReadChatMessage(teamId, resource.data);');
+        expect(rules).not.toContain('allow read: if canReadChatMessage(teamId, resource.data);');
+    });
+
     it('restricts staff/group messages to sender and team staff/admin roles', () => {
         expect(rules).toContain('function isStaffChatMessage(data)');
         expect(rules).toContain("data.get('targetRole', 'staff') == 'staff'");


### PR DESCRIPTION
Closes #788

## Summary
- Added Firestore rule helpers for full-team, staff, and individual team chat targets.
- Restricted targeted reads to the sender, valid listed recipients, and team owner/admin/global admin roles.
- Validated targeted message writes so malformed recipient arrays and recipients outside team `chatMemberIds` are rejected.

## Tests
- `npx vitest run tests/unit/team-chat-targeted-rules.test.js`