### PR TITLE
Add team media bulk management

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -184,7 +184,7 @@
 
                         <!-- Quick Actions -->
                         <div class="p-6">
-                            <div class="grid grid-cols-2 sm:grid-cols-4 gap-2 mb-4">
+                            <div class="grid grid-cols-2 sm:grid-cols-5 gap-2 mb-4">
                                 <a href="team.html#teamId=${team.id}"
                                    class="flex flex-col items-center justify-center p-3 rounded-lg border border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition group/btn">
                                     <svg class="w-5 h-5 text-gray-600 group-hover/btn:text-primary-600 transition mb-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -200,6 +200,13 @@
                                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z"></path>
                                     </svg>
                                     <span class="text-xs font-medium ${unread > 0 ? 'text-primary-700' : 'text-gray-600 group-hover/btn:text-primary-700'}">Chat</span>
+                                </a>
+                                <a href="team-media.html#teamId=${team.id}"
+                                   class="flex flex-col items-center justify-center p-3 rounded-lg border border-gray-200 hover:border-primary-300 hover:bg-primary-50 transition group/btn">
+                                    <svg class="w-5 h-5 text-gray-600 group-hover/btn:text-primary-600 transition mb-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 10l4.553-2.276A1 1 0 0121 8.618v6.764a1 1 0 01-1.447.894L15 14M5 18h8a2 2 0 002-2V8a2 2 0 00-2-2H5a2 2 0 00-2 2v8a2 2 0 002 2z"></path>
+                                    </svg>
+                                    <span class="text-xs font-medium text-gray-600 group-hover/btn:text-primary-700">Media</span>
                                 </a>
                                 ${hasFullAccess ? `
                                 <a href="edit-team.html#teamId=${team.id}"

--- a/firestore.rules
+++ b/firestore.rules
@@ -505,6 +505,16 @@ service cloud.firestore {
         allow create, update, delete: if isTeamOwnerOrAdmin(teamId);
       }
 
+      match /mediaFolders/{folderId} {
+        allow read: if canAccessTeamChat(teamId);
+        allow create, update, delete: if isTeamOwnerOrAdmin(teamId);
+      }
+
+      match /mediaItems/{itemId} {
+        allow read: if canAccessTeamChat(teamId);
+        allow create, update, delete: if isTeamOwnerOrAdmin(teamId);
+      }
+
       match /registrationForms/{formId} {
         allow read: if isPublishedRegistrationForm(resource.data) || isTeamOwnerOrAdmin(teamId);
         allow create, update, delete: if isTeamOwnerOrAdmin(teamId);

--- a/js/db.js
+++ b/js/db.js
@@ -85,6 +85,7 @@ import {
     summarizeRegistration
 } from './registration-review.js?v=1';
 import { buildTournamentPoolOverrideKey } from './tournament-standings.js?v=1';
+import { buildBulkDeleteUpdates, buildMoveUpdates, buildReorderUpdates, isSafeTeamMediaUrl, sortByMediaOrder } from './team-media-utils.js?v=1';
 import { getApp } from './vendor/firebase-app.js';
 import {
     claimOfficiatingSlot,
@@ -415,6 +416,121 @@ export async function getTeam(teamId, options = {}) {
     } else {
         return null;
     }
+}
+
+function getTeamMediaFoldersRef(teamId) {
+    return collection(db, `teams/${teamId}/mediaFolders`);
+}
+
+function getTeamMediaItemsRef(teamId) {
+    return collection(db, `teams/${teamId}/mediaItems`);
+}
+
+export async function getTeamMediaFolders(teamId) {
+    if (!teamId) return [];
+    const snapshot = await getDocs(getTeamMediaFoldersRef(teamId));
+    return sortByMediaOrder(snapshot.docs.map((folderDoc) => ({ id: folderDoc.id, ...folderDoc.data() })));
+}
+
+export async function getTeamMediaItems(teamId, folderId = null) {
+    if (!teamId) return [];
+    const snapshot = await getDocs(getTeamMediaItemsRef(teamId));
+    const items = snapshot.docs
+        .map((itemDoc) => ({ id: itemDoc.id, ...itemDoc.data() }))
+        .filter((item) => item.deleted !== true)
+        .filter((item) => !folderId || item.folderId === folderId);
+    return sortByMediaOrder(items);
+}
+
+export async function createTeamMediaFolder(teamId, name) {
+    const folderName = String(name || '').trim();
+    if (!teamId || !folderName) throw new Error('Folder name is required.');
+    const existingFolders = await getTeamMediaFolders(teamId);
+    const docRef = await addDoc(getTeamMediaFoldersRef(teamId), {
+        name: folderName,
+        order: existingFolders.length,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp()
+    });
+    return docRef.id;
+}
+
+export async function createTeamMediaLink(teamId, folderId, media = {}) {
+    const cleanFolderId = String(folderId || '').trim();
+    const title = String(media.title || '').trim();
+    const url = String(media.url || '').trim();
+    if (!teamId || !cleanFolderId) throw new Error('Choose a folder for this media link.');
+    if (!title || !url) throw new Error('Media title and URL are required.');
+    if (!isSafeTeamMediaUrl(url)) throw new Error('Use a valid http or https media link.');
+    const existingItems = await getTeamMediaItems(teamId, cleanFolderId);
+    const docRef = await addDoc(getTeamMediaItemsRef(teamId), {
+        folderId: cleanFolderId,
+        title,
+        url,
+        type: 'video-link',
+        order: existingItems.length,
+        deleted: false,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp()
+    });
+    return docRef.id;
+}
+
+export async function reorderTeamMediaFolders(teamId, folderIds = []) {
+    const updates = buildReorderUpdates(folderIds);
+    if (!teamId || updates.length === 0) return;
+    const batch = writeBatch(db);
+    updates.forEach(({ id, order }) => {
+        batch.update(doc(db, `teams/${teamId}/mediaFolders`, id), {
+            order,
+            updatedAt: serverTimestamp()
+        });
+    });
+    await batch.commit();
+}
+
+export async function reorderTeamMediaItems(teamId, itemIds = []) {
+    const updates = buildReorderUpdates(itemIds);
+    if (!teamId || updates.length === 0) return;
+    const batch = writeBatch(db);
+    updates.forEach(({ id, order }) => {
+        batch.update(doc(db, `teams/${teamId}/mediaItems`, id), {
+            order,
+            updatedAt: serverTimestamp()
+        });
+    });
+    await batch.commit();
+}
+
+export async function moveTeamMediaItems(teamId, itemIds = [], targetFolderId) {
+    if (!teamId) throw new Error('Team is required.');
+    const targetItems = await getTeamMediaItems(teamId, targetFolderId);
+    const updates = buildMoveUpdates(itemIds, targetFolderId, targetItems.length);
+    if (updates.length === 0) throw new Error('Select at least one media item to move.');
+    const batch = writeBatch(db);
+    updates.forEach(({ id, folderId, order }) => {
+        batch.update(doc(db, `teams/${teamId}/mediaItems`, id), {
+            folderId,
+            order,
+            updatedAt: serverTimestamp()
+        });
+    });
+    await batch.commit();
+}
+
+export async function bulkDeleteTeamMediaItems(teamId, itemIds = []) {
+    const updates = buildBulkDeleteUpdates(itemIds);
+    if (!teamId) throw new Error('Team is required.');
+    if (updates.length === 0) throw new Error('Select at least one media item to delete.');
+    const batch = writeBatch(db);
+    updates.forEach(({ id }) => {
+        batch.update(doc(db, `teams/${teamId}/mediaItems`, id), {
+            deleted: true,
+            deletedAt: serverTimestamp(),
+            updatedAt: serverTimestamp()
+        });
+    });
+    await batch.commit();
 }
 
 async function getPublishedSponsors(teamId) {

--- a/js/team-media-utils.js
+++ b/js/team-media-utils.js
@@ -1,0 +1,55 @@
+import { hasFullTeamAccess } from './team-access.js';
+
+export function canManageTeamMedia(user, team) {
+    return hasFullTeamAccess(user, team);
+}
+
+export function normalizeMediaOrderIds(ids = []) {
+    return Array.from(new Set((Array.isArray(ids) ? ids : [])
+        .map((id) => String(id || '').trim())
+        .filter(Boolean)));
+}
+
+export function buildReorderUpdates(ids = []) {
+    return normalizeMediaOrderIds(ids).map((id, index) => ({ id, order: index }));
+}
+
+export function normalizeSelectedMediaIds(ids = []) {
+    return normalizeMediaOrderIds(ids);
+}
+
+export function buildMoveUpdates(ids = [], targetFolderId, startOrder = 0) {
+    const folderId = String(targetFolderId || '').trim();
+    if (!folderId) {
+        throw new Error('Choose a destination folder.');
+    }
+
+    const firstOrder = Number.isFinite(Number(startOrder)) ? Number(startOrder) : 0;
+    return normalizeSelectedMediaIds(ids).map((id, index) => ({
+        id,
+        folderId,
+        order: firstOrder + index
+    }));
+}
+
+export function buildBulkDeleteUpdates(ids = []) {
+    return normalizeSelectedMediaIds(ids).map((id) => ({ id, deleted: true }));
+}
+
+export function isSafeTeamMediaUrl(value) {
+    try {
+        const url = new URL(String(value || '').trim());
+        return ['http:', 'https:'].includes(url.protocol);
+    } catch (error) {
+        return false;
+    }
+}
+
+export function sortByMediaOrder(items = []) {
+    return [...items].sort((a, b) => {
+        const aOrder = Number.isFinite(Number(a?.order)) ? Number(a.order) : Number.MAX_SAFE_INTEGER;
+        const bOrder = Number.isFinite(Number(b?.order)) ? Number(b.order) : Number.MAX_SAFE_INTEGER;
+        if (aOrder !== bOrder) return aOrder - bOrder;
+        return String(a?.name || a?.title || a?.id || '').localeCompare(String(b?.name || b?.title || b?.id || ''));
+    });
+}

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -1,0 +1,258 @@
+import { auth, onAuthStateChanged } from './firebase.js?v=11';
+import {
+    getTeam,
+    getTeamMediaFolders,
+    getTeamMediaItems,
+    createTeamMediaFolder,
+    createTeamMediaLink,
+    reorderTeamMediaFolders,
+    reorderTeamMediaItems,
+    moveTeamMediaItems,
+    bulkDeleteTeamMediaItems
+} from './db.js?v=12';
+import { canManageTeamMedia, isSafeTeamMediaUrl, sortByMediaOrder } from './team-media-utils.js?v=1';
+
+const state = {
+    teamId: '',
+    team: null,
+    user: null,
+    canManage: false,
+    folders: [],
+    items: [],
+    selectedIds: new Set()
+};
+
+const els = {
+    title: document.getElementById('team-media-title'),
+    subtitle: document.getElementById('team-media-subtitle'),
+    alert: document.getElementById('team-media-alert'),
+    adminPanel: document.getElementById('team-media-admin-panel'),
+    bulkActions: document.getElementById('bulk-actions'),
+    selectedCount: document.getElementById('selected-count'),
+    foldersList: document.getElementById('folders-list'),
+    folderForm: document.getElementById('folder-form'),
+    folderName: document.getElementById('folder-name'),
+    linkForm: document.getElementById('link-form'),
+    linkFolder: document.getElementById('link-folder'),
+    linkTitle: document.getElementById('link-title'),
+    linkUrl: document.getElementById('link-url'),
+    moveFolder: document.getElementById('move-folder'),
+    moveSelected: document.getElementById('move-selected'),
+    deleteSelected: document.getElementById('delete-selected'),
+    backLink: document.getElementById('team-back-link')
+};
+
+function getTeamIdFromLocation() {
+    const params = new URLSearchParams(window.location.search);
+    const queryTeamId = params.get('teamId');
+    if (queryTeamId) return queryTeamId;
+    return String(window.location.hash || '').replace(/^#teamId=/, '').replace(/^#/, '');
+}
+
+function escapeHtml(value) {
+    return String(value ?? '').replace(/[&<>'"]/g, (char) => ({
+        '&': '&amp;',
+        '<': '&lt;',
+        '>': '&gt;',
+        "'": '&#39;',
+        '"': '&quot;'
+    }[char]));
+}
+
+function showAlert(message, type = 'info') {
+    els.alert.textContent = message;
+    els.alert.className = `mb-4 rounded-xl border px-4 py-3 text-sm ${type === 'error'
+        ? 'border-red-200 bg-red-50 text-red-700'
+        : 'border-green-200 bg-green-50 text-green-700'}`;
+    els.alert.classList.remove('hidden');
+}
+
+function clearAlert() {
+    els.alert.classList.add('hidden');
+    els.alert.textContent = '';
+}
+
+function getItemsForFolder(folderId) {
+    return sortByMediaOrder(state.items
+        .filter((item) => item.folderId === folderId)
+        .filter((item) => isSafeTeamMediaUrl(item.url)));
+}
+
+function renderFolderOptions() {
+    const options = state.folders.map((folder) => `<option value="${escapeHtml(folder.id)}">${escapeHtml(folder.name || 'Untitled folder')}</option>`).join('');
+    const placeholder = '<option value="">Choose folder</option>';
+    els.linkFolder.innerHTML = placeholder + options;
+    els.moveFolder.innerHTML = placeholder + options;
+}
+
+function renderBulkActions() {
+    const count = state.selectedIds.size;
+    els.selectedCount.textContent = String(count);
+    els.bulkActions.classList.toggle('hidden', !state.canManage || count === 0);
+}
+
+function render() {
+    els.title.textContent = state.team?.name ? `${state.team.name} Media` : 'Media Library';
+    els.subtitle.textContent = state.canManage
+        ? 'Select video links to move or delete. Use up/down controls to persist ordering.'
+        : 'Organized video links and highlights for this team.';
+    els.adminPanel.classList.toggle('hidden', !state.canManage);
+    els.backLink.href = state.teamId ? `team.html#${encodeURIComponent(state.teamId)}` : 'team.html';
+    renderFolderOptions();
+    renderBulkActions();
+
+    if (state.folders.length === 0) {
+        els.foldersList.innerHTML = `<div class="rounded-2xl border border-gray-200 bg-white p-6 text-sm text-gray-500">${state.canManage ? 'No folders yet. Add one to start organizing video links.' : 'No media folders have been shared yet.'}</div>`;
+        return;
+    }
+
+    els.foldersList.innerHTML = state.folders.map((folder, folderIndex) => {
+        const items = getItemsForFolder(folder.id);
+        const folderControls = state.canManage ? `
+            <div class="flex gap-2">
+                <button type="button" data-folder-move="up" data-folder-id="${escapeHtml(folder.id)}" ${folderIndex === 0 ? 'disabled' : ''} class="rounded-lg border px-3 py-1 text-xs font-semibold disabled:opacity-40">Up</button>
+                <button type="button" data-folder-move="down" data-folder-id="${escapeHtml(folder.id)}" ${folderIndex === state.folders.length - 1 ? 'disabled' : ''} class="rounded-lg border px-3 py-1 text-xs font-semibold disabled:opacity-40">Down</button>
+            </div>` : '';
+        const itemRows = items.length === 0
+            ? '<div class="rounded-xl border border-dashed border-gray-200 p-4 text-sm text-gray-500">No video links in this folder.</div>'
+            : items.map((item, itemIndex) => `
+                <div class="flex flex-col gap-3 rounded-xl border border-gray-200 p-4 sm:flex-row sm:items-center sm:justify-between" data-item-id="${escapeHtml(item.id)}">
+                    <div class="flex items-start gap-3">
+                        ${state.canManage ? `<input type="checkbox" data-select-item="${escapeHtml(item.id)}" ${state.selectedIds.has(item.id) ? 'checked' : ''} class="mt-1 h-4 w-4 rounded border-gray-300">` : ''}
+                        <div>
+                            <a href="${escapeHtml(item.url)}" target="_blank" rel="noopener noreferrer" class="font-semibold text-primary-700 hover:text-primary-900">${escapeHtml(item.title || 'Untitled video')}</a>
+                            <div class="break-all text-xs text-gray-500">${escapeHtml(item.url)}</div>
+                        </div>
+                    </div>
+                    ${state.canManage ? `<div class="flex gap-2">
+                        <button type="button" data-item-move="up" data-item-id="${escapeHtml(item.id)}" data-folder-id="${escapeHtml(folder.id)}" ${itemIndex === 0 ? 'disabled' : ''} class="rounded-lg border px-3 py-1 text-xs font-semibold disabled:opacity-40">Up</button>
+                        <button type="button" data-item-move="down" data-item-id="${escapeHtml(item.id)}" data-folder-id="${escapeHtml(folder.id)}" ${itemIndex === items.length - 1 ? 'disabled' : ''} class="rounded-lg border px-3 py-1 text-xs font-semibold disabled:opacity-40">Down</button>
+                    </div>` : ''}
+                </div>
+            `).join('');
+
+        return `
+            <article class="rounded-2xl border border-gray-200 bg-white shadow-sm">
+                <header class="flex items-center justify-between gap-3 border-b border-gray-100 p-5">
+                    <div>
+                        <h2 class="text-xl font-bold">${escapeHtml(folder.name || 'Untitled folder')}</h2>
+                        <p class="text-sm text-gray-500">${items.length} item${items.length === 1 ? '' : 's'}</p>
+                    </div>
+                    ${folderControls}
+                </header>
+                <div class="space-y-3 p-5">${itemRows}</div>
+            </article>`;
+    }).join('');
+}
+
+async function loadLibrary() {
+    state.folders = await getTeamMediaFolders(state.teamId);
+    state.items = await getTeamMediaItems(state.teamId);
+    state.selectedIds = new Set([...state.selectedIds].filter((id) => state.items.some((item) => item.id === id)));
+    render();
+}
+
+async function persistAndReload(action, successMessage) {
+    clearAlert();
+    try {
+        await action();
+        await loadLibrary();
+        showAlert(successMessage, 'success');
+    } catch (error) {
+        console.error('Team media action failed:', error);
+        showAlert(error.message || 'Unable to save media changes. Refresh and try again.', 'error');
+    }
+}
+
+function moveInArray(items, id, direction) {
+    const next = [...items];
+    const index = next.findIndex((item) => item.id === id);
+    const target = direction === 'up' ? index - 1 : index + 1;
+    if (index < 0 || target < 0 || target >= next.length) return next;
+    [next[index], next[target]] = [next[target], next[index]];
+    return next;
+}
+
+els.foldersList.addEventListener('click', (event) => {
+    if (!state.canManage) return;
+    const folderButton = event.target.closest('[data-folder-move]');
+    if (folderButton) {
+        const reordered = moveInArray(state.folders, folderButton.dataset.folderId, folderButton.dataset.folderMove);
+        persistAndReload(() => reorderTeamMediaFolders(state.teamId, reordered.map((folder) => folder.id)), 'Folder order saved.');
+        return;
+    }
+
+    const itemButton = event.target.closest('[data-item-move]');
+    if (itemButton) {
+        const items = getItemsForFolder(itemButton.dataset.folderId);
+        const reordered = moveInArray(items, itemButton.dataset.itemId, itemButton.dataset.itemMove);
+        persistAndReload(() => reorderTeamMediaItems(state.teamId, reordered.map((item) => item.id)), 'Item order saved.');
+    }
+});
+
+els.foldersList.addEventListener('change', (event) => {
+    if (!state.canManage) return;
+    const checkbox = event.target.closest('[data-select-item]');
+    if (!checkbox) return;
+    if (checkbox.checked) {
+        state.selectedIds.add(checkbox.dataset.selectItem);
+    } else {
+        state.selectedIds.delete(checkbox.dataset.selectItem);
+    }
+    renderBulkActions();
+});
+
+els.folderForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    persistAndReload(async () => {
+        await createTeamMediaFolder(state.teamId, els.folderName.value);
+        els.folderName.value = '';
+    }, 'Folder added.');
+});
+
+els.linkForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    persistAndReload(async () => {
+        await createTeamMediaLink(state.teamId, els.linkFolder.value, {
+            title: els.linkTitle.value,
+            url: els.linkUrl.value
+        });
+        els.linkTitle.value = '';
+        els.linkUrl.value = '';
+    }, 'Video link added.');
+});
+
+els.moveSelected.addEventListener('click', () => {
+    const ids = [...state.selectedIds];
+    persistAndReload(async () => {
+        await moveTeamMediaItems(state.teamId, ids, els.moveFolder.value);
+        state.selectedIds.clear();
+    }, 'Selected media moved.');
+});
+
+els.deleteSelected.addEventListener('click', () => {
+    const ids = [...state.selectedIds];
+    if (!window.confirm(`Delete ${ids.length} selected media item${ids.length === 1 ? '' : 's'}? This cannot be undone.`)) return;
+    persistAndReload(async () => {
+        await bulkDeleteTeamMediaItems(state.teamId, ids);
+        state.selectedIds.clear();
+    }, 'Selected media deleted.');
+});
+
+onAuthStateChanged(auth, async (user) => {
+    state.user = user;
+    state.teamId = getTeamIdFromLocation();
+    if (!state.teamId) {
+        els.foldersList.innerHTML = '<div class="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-700">Missing team id.</div>';
+        return;
+    }
+
+    try {
+        state.team = await getTeam(state.teamId, { includeInactive: true });
+        state.canManage = canManageTeamMedia(user, state.team);
+        await loadLibrary();
+    } catch (error) {
+        console.error('Unable to load team media:', error);
+        els.foldersList.innerHTML = '<div class="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-700">Unable to load team media.</div>';
+    }
+});

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -1,4 +1,4 @@
-import { auth, onAuthStateChanged } from './firebase.js?v=11';
+import { checkAuth } from './auth.js?v=13';
 import {
     getTeam,
     getTeamMediaFolders,
@@ -97,7 +97,7 @@ function render() {
         ? 'Select video links to move or delete. Use up/down controls to persist ordering.'
         : 'Organized video links and highlights for this team.';
     els.adminPanel.classList.toggle('hidden', !state.canManage);
-    els.backLink.href = state.teamId ? `team.html#${encodeURIComponent(state.teamId)}` : 'team.html';
+    els.backLink.href = state.teamId ? `team.html#teamId=${encodeURIComponent(state.teamId)}` : 'team.html';
     renderFolderOptions();
     renderBulkActions();
 
@@ -239,7 +239,7 @@ els.deleteSelected.addEventListener('click', () => {
     }, 'Selected media deleted.');
 });
 
-onAuthStateChanged(auth, async (user) => {
+checkAuth(async (user) => {
     state.user = user;
     state.teamId = getTeamIdFromLocation();
     if (!state.teamId) {

--- a/team-media.html
+++ b/team-media.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex,nofollow">
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Team Media - ALL PLAYS</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+</head>
+<body class="bg-gray-50 text-gray-900">
+    <div id="header-container"></div>
+
+    <main class="container mx-auto px-4 py-8 max-w-6xl">
+        <div class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+                <p class="text-xs font-semibold uppercase tracking-[0.25em] text-primary-600">Team Media</p>
+                <h1 id="team-media-title" class="text-3xl font-bold">Media Library</h1>
+                <p id="team-media-subtitle" class="text-sm text-gray-500">Organized video links and highlights for this team.</p>
+            </div>
+            <a id="team-back-link" href="team.html" class="text-sm font-semibold text-primary-700 hover:text-primary-900">Back to team</a>
+        </div>
+
+        <div id="team-media-alert" class="hidden mb-4 rounded-xl border px-4 py-3 text-sm"></div>
+
+        <section id="team-media-admin-panel" class="hidden mb-6 rounded-2xl border border-primary-100 bg-white p-5 shadow-sm">
+            <div class="grid gap-4 lg:grid-cols-2">
+                <form id="folder-form" class="space-y-3">
+                    <h2 class="font-semibold text-gray-900">Add folder</h2>
+                    <div class="flex gap-2">
+                        <input id="folder-name" class="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm" placeholder="Folder name" required>
+                        <button class="rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700">Add</button>
+                    </div>
+                </form>
+
+                <form id="link-form" class="space-y-3">
+                    <h2 class="font-semibold text-gray-900">Add video link</h2>
+                    <select id="link-folder" class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" required></select>
+                    <input id="link-title" class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" placeholder="Title" required>
+                    <input id="link-url" type="url" class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" placeholder="https://..." required>
+                    <button class="rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700">Add link</button>
+                </form>
+            </div>
+        </section>
+
+        <section id="bulk-actions" class="hidden sticky top-2 z-10 mb-4 rounded-2xl border border-gray-200 bg-white p-4 shadow-md">
+            <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+                <div class="text-sm font-semibold"><span id="selected-count">0</span> selected</div>
+                <div class="flex flex-wrap gap-2">
+                    <select id="move-folder" class="rounded-lg border border-gray-300 px-3 py-2 text-sm"></select>
+                    <button id="move-selected" class="rounded-lg border border-primary-200 px-4 py-2 text-sm font-semibold text-primary-700 hover:bg-primary-50">Move selected</button>
+                    <button id="delete-selected" class="rounded-lg border border-red-200 px-4 py-2 text-sm font-semibold text-red-700 hover:bg-red-50">Delete selected</button>
+                </div>
+            </div>
+        </section>
+
+        <section id="folders-list" class="space-y-4">
+            <div class="rounded-2xl border border-gray-200 bg-white p-6 text-sm text-gray-500">Loading media library...</div>
+        </section>
+    </main>
+
+    <script type="module" src="js/team-media.js?v=1"></script>
+</body>
+</html>

--- a/tests/unit/team-media-utils.test.js
+++ b/tests/unit/team-media-utils.test.js
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest';
+import {
+    canManageTeamMedia,
+    buildBulkDeleteUpdates,
+    buildMoveUpdates,
+    buildReorderUpdates,
+    isSafeTeamMediaUrl,
+    normalizeSelectedMediaIds,
+    sortByMediaOrder
+} from '../../js/team-media-utils.js';
+
+describe('team media management permissions', () => {
+    it('allows only owners, admins, and platform admins to see management controls', () => {
+        const team = { ownerId: 'coach-1', adminEmails: ['admin@example.com'] };
+
+        expect(canManageTeamMedia({ uid: 'coach-1', email: 'coach@example.com' }, team)).toBe(true);
+        expect(canManageTeamMedia({ uid: 'parent-1', email: 'admin@example.com' }, team)).toBe(true);
+        expect(canManageTeamMedia({ uid: 'global-1', email: 'other@example.com', isAdmin: true }, team)).toBe(true);
+        expect(canManageTeamMedia({ uid: 'parent-1', email: 'parent@example.com' }, team)).toBe(false);
+        expect(canManageTeamMedia(null, team)).toBe(false);
+    });
+});
+
+describe('team media bulk actions', () => {
+    it('deduplicates selected ids before building bulk delete updates', () => {
+        expect(normalizeSelectedMediaIds([' a ', 'b', 'a', '', null])).toEqual(['a', 'b']);
+        expect(buildBulkDeleteUpdates(['a', 'b', 'a'])).toEqual([
+            { id: 'a', deleted: true },
+            { id: 'b', deleted: true }
+        ]);
+    });
+
+    it('builds move updates with destination folder and contiguous order', () => {
+        expect(buildMoveUpdates(['clip-1', 'clip-2'], 'folder-b', 3)).toEqual([
+            { id: 'clip-1', folderId: 'folder-b', order: 3 },
+            { id: 'clip-2', folderId: 'folder-b', order: 4 }
+        ]);
+
+        expect(() => buildMoveUpdates(['clip-1'], '')).toThrow(/destination folder/i);
+    });
+
+    it('builds persistent reorder updates from visible order', () => {
+        expect(buildReorderUpdates(['folder-c', 'folder-a', 'folder-b'])).toEqual([
+            { id: 'folder-c', order: 0 },
+            { id: 'folder-a', order: 1 },
+            { id: 'folder-b', order: 2 }
+        ]);
+    });
+
+    it('accepts only safe http and https media links', () => {
+        expect(isSafeTeamMediaUrl('https://videos.example.com/clip')).toBe(true);
+        expect(isSafeTeamMediaUrl('http://videos.example.com/clip')).toBe(true);
+        expect(isSafeTeamMediaUrl('javascript:alert(1)')).toBe(false);
+        expect(isSafeTeamMediaUrl('not a url')).toBe(false);
+    });
+
+    it('sorts by saved order with stable name fallback', () => {
+        expect(sortByMediaOrder([
+            { id: 'b', name: 'B', order: 2 },
+            { id: 'a', name: 'A', order: 1 },
+            { id: 'c', name: 'C' }
+        ]).map((item) => item.id)).toEqual(['a', 'b', 'c']);
+    });
+});

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -16,6 +16,9 @@ describe('team media page wiring', () => {
 
         expect(page).toContain('src="js/team-media.js?v=1"');
         expect(source).toContain("from './db.js?v=12'");
+        expect(source).toContain("import { checkAuth } from './auth.js?v=13';");
+        expect(source).toContain('checkAuth(async (user) => {');
+        expect(source).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
     });
 
     it('keeps media reads member-scoped and writes admin-scoped', () => {

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const repoRoot = path.resolve(path.dirname(new URL(import.meta.url).pathname), '../..');
+
+describe('team media page wiring', () => {
+    it('links the dashboard to the team media library', () => {
+        const dashboard = fs.readFileSync(path.join(repoRoot, 'dashboard.html'), 'utf8');
+        expect(dashboard).toContain('team-media.html#teamId=${team.id}');
+    });
+
+    it('loads the team media module and cache-busted db dependency', () => {
+        const page = fs.readFileSync(path.join(repoRoot, 'team-media.html'), 'utf8');
+        const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
+
+        expect(page).toContain('src="js/team-media.js?v=1"');
+        expect(source).toContain("from './db.js?v=12'");
+    });
+
+    it('keeps media reads member-scoped and writes admin-scoped', () => {
+        const rules = fs.readFileSync(path.join(repoRoot, 'firestore.rules'), 'utf8');
+        expect(rules).toContain('match /mediaFolders/{folderId}');
+        expect(rules).toContain('allow read: if canAccessTeamChat(teamId);');
+        expect(rules).toContain('allow create, update, delete: if isTeamOwnerOrAdmin(teamId);');
+    });
+});


### PR DESCRIPTION
Closes #814

## Summary
- Added a team media library page with folder and video link management.
- Added coach/admin-only selection, bulk delete, move, and reorder controls with confirmation and persistence-backed success/failure feedback.
- Scoped Firestore media reads to team members and writes to team owners/admins/global admins.

## Validation
- `npx vitest run tests/unit/team-media-utils.test.js tests/unit/team-media-wiring.test.js`
- `node scripts/check-critical-cache-bust.mjs`