### PR TITLE
Add registration schedule import preview

### DIFF
--- a/docs/pr-notes/runs/821-remediator-20260508T221206Z/architecture.md
+++ b/docs/pr-notes/runs/821-remediator-20260508T221206Z/architecture.md
@@ -1,0 +1,10 @@
+# Architecture
+
+## Decision
+Keep the fix local to `renderRegistrationScheduleImport` in `edit-schedule.html`.
+
+## Rationale
+The failure is caused by UI state set before an awaited Firestore read and not restored in the `catch` path. Restoring `button.disabled` in that catch keeps the blast radius small and does not change data writes, Firestore access, or import planning.
+
+## Risk And Rollback
+Risk is low: a transient preview error now leaves the UI actionable instead of locked. Rollback is a single-line removal if needed.

--- a/docs/pr-notes/runs/821-remediator-20260508T221206Z/code-plan.md
+++ b/docs/pr-notes/runs/821-remediator-20260508T221206Z/code-plan.md
@@ -1,0 +1,8 @@
+# Code Plan
+
+## Implementation Plan
+- In `renderRegistrationScheduleImport`, add `button.disabled = false;` inside the `catch` block after `getEvents(currentTeamId)` preview loading fails.
+- Do not change import planning, conflict detection, or persistence behavior.
+
+## Files
+- `edit-schedule.html`

--- a/docs/pr-notes/runs/821-remediator-20260508T221206Z/qa.md
+++ b/docs/pr-notes/runs/821-remediator-20260508T221206Z/qa.md
@@ -1,0 +1,10 @@
+# QA Plan
+
+## Manual Validation
+- Load `edit-schedule.html` for an externally linked registration team with schedule snapshot events.
+- Simulate `getEvents(currentTeamId)` rejecting during preview generation.
+- Confirm the preview failure message is shown and the import button is re-enabled after the catch path.
+- Confirm the normal successful preview path still disables the button only when no selectable rows exist.
+
+## Automated Tests
+No automated test runner is configured for this static site per `AGENTS.md` and `CLAUDE.md`.

--- a/docs/pr-notes/runs/821-remediator-20260508T221206Z/requirements.md
+++ b/docs/pr-notes/runs/821-remediator-20260508T221206Z/requirements.md
@@ -1,0 +1,10 @@
+# Requirements
+
+## Acceptance Criteria
+- If registration schedule preview conflict loading fails, the import action button is not left permanently disabled.
+- Admins can recover from a transient `getEvents(currentTeamId)` failure without reloading the page.
+- The change is limited to the registration schedule import preview error path for PR review thread `PRRT_kwDOQe-T586AthvG`.
+
+## Assumptions
+- No broader import flow redesign is requested.
+- Existing successful preview/import behavior must remain unchanged.

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -1769,6 +1769,7 @@
                 console.error('Registration schedule preview failed:', error);
                 status.textContent = `Preview failed: ${error.message}`;
                 preview.innerHTML = '';
+                button.disabled = false;
             }
         }
 

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -81,14 +81,15 @@
             <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
                 <div>
                     <h3 class="font-semibold text-emerald-900">Registration Schedule Sync</h3>
-                    <p class="text-sm text-emerald-800">Refresh this team's schedule from the latest linked registration snapshot.</p>
+                    <p class="text-sm text-emerald-800">Preview source games and practices, review conflicts, then import selected entries.</p>
                     <p id="registration-schedule-import-status" class="mt-2 text-sm text-emerald-700"></p>
                 </div>
                 <button id="registration-schedule-import-btn" type="button"
                     class="bg-emerald-600 text-white px-4 py-2 rounded-md text-sm font-semibold hover:bg-emerald-700 transition">
-                    Re-import Schedule
+                    Import Selected
                 </button>
             </div>
+            <div id="registration-schedule-import-preview" class="mt-4 overflow-x-auto"></div>
         </div>
 
         <div id="schedule-notification-settings" class="mb-6 bg-white border border-gray-200 rounded-lg p-4 shadow-sm">
@@ -915,7 +916,7 @@
         import { normalizeScheduleNotificationSettings, describeScheduleReminderWindow, buildScheduleNotificationMetadata, buildScheduleChangeMessage, buildScheduleNotificationTargets, postScheduleNotificationTargets, buildRsvpReminderMessage } from './js/schedule-notifications.js?v=4';
         import { buildTournamentPoolStandings, buildTournamentPoolOverrideKey } from './js/tournament-standings.js?v=3';
         import { SCHEDULE_CSV_IMPORT_FIELDS, buildScheduleImportPreview, inferScheduleCsvMapping, normalizeScheduleImportDraft, parseCsvText } from './js/schedule-csv-import.js?v=2';
-        import { formatRegistrationImportResults, getRegistrationScheduleEvents, isExternallyLinkedRegistrationTeam, planRegistrationScheduleImport } from './js/edit-schedule-registration-import.js?v=1';
+        import { buildRegistrationScheduleImportPreview, formatRegistrationImportResults, getRegistrationScheduleEvents, isExternallyLinkedRegistrationTeam, planRegistrationScheduleImport } from './js/edit-schedule-registration-import.js?v=2';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -1736,16 +1737,86 @@
             };
         }
 
-        function renderRegistrationScheduleImport(team = {}) {
+        async function renderRegistrationScheduleImport(team = {}) {
             const container = document.getElementById('registration-schedule-import');
             const status = document.getElementById('registration-schedule-import-status');
-            if (!container || !status) return;
+            const preview = document.getElementById('registration-schedule-import-preview');
+            const button = document.getElementById('registration-schedule-import-btn');
+            if (!container || !status || !preview || !button) return;
 
             const sourceEvents = getRegistrationScheduleEvents(team);
-            container.classList.toggle('hidden', !isExternallyLinkedRegistrationTeam(team));
-            status.textContent = sourceEvents.length
-                ? `${sourceEvents.length} source event${sourceEvents.length === 1 ? '' : 's'} ready to review.`
-                : 'No source schedule snapshot is available yet.';
+            const showImport = isExternallyLinkedRegistrationTeam(team) && sourceEvents.length > 0;
+            container.classList.toggle('hidden', !showImport);
+            if (!showImport) {
+                preview.innerHTML = '';
+                return;
+            }
+
+            status.textContent = `${sourceEvents.length} source event${sourceEvents.length === 1 ? '' : 's'} ready to review.`;
+            button.disabled = true;
+            preview.innerHTML = '<p class="text-sm text-emerald-700">Loading existing schedule conflicts...</p>';
+            try {
+                const existingEvents = await getEvents(currentTeamId);
+                const rows = buildRegistrationScheduleImportPreview({
+                    sourceEvents,
+                    existingEvents,
+                    Timestamp,
+                    source: getRegistrationSourceDescriptor(team)
+                });
+                button.disabled = !rows.some((row) => row.selectable);
+                preview.innerHTML = renderRegistrationScheduleImportPreviewRows(rows);
+            } catch (error) {
+                console.error('Registration schedule preview failed:', error);
+                status.textContent = `Preview failed: ${error.message}`;
+                preview.innerHTML = '';
+            }
+        }
+
+        function formatRegistrationSourceDate(dateValue) {
+            const date = dateValue?.toDate ? dateValue.toDate() : new Date(dateValue);
+            if (!dateValue || Number.isNaN(date.getTime())) return 'Date TBD';
+            return `${formatShortDate(date)} ${formatTime(date)}`;
+        }
+
+        function renderRegistrationScheduleImportPreviewRows(rows = []) {
+            if (!rows.length) return '<p class="text-sm text-emerald-700">No source schedule entries are available.</p>';
+            const actionClasses = {
+                add: 'bg-green-100 text-green-800',
+                update: 'bg-blue-100 text-blue-800',
+                conflict: 'bg-amber-100 text-amber-800',
+                skipped: 'bg-gray-100 text-gray-700'
+            };
+            return `
+                <table class="min-w-full divide-y divide-emerald-200 text-sm bg-white rounded border border-emerald-200">
+                    <thead class="bg-emerald-100 text-emerald-900">
+                        <tr>
+                            <th class="px-3 py-2 text-left">Import</th>
+                            <th class="px-3 py-2 text-left">Date/time</th>
+                            <th class="px-3 py-2 text-left">Type</th>
+                            <th class="px-3 py-2 text-left">Opponent/title</th>
+                            <th class="px-3 py-2 text-left">Location</th>
+                            <th class="px-3 py-2 text-left">Status</th>
+                        </tr>
+                    </thead>
+                    <tbody class="divide-y divide-emerald-100">
+                        ${rows.map((row) => `
+                            <tr>
+                                <td class="px-3 py-2">
+                                    <input type="checkbox" class="registration-schedule-import-choice rounded border-gray-300 text-emerald-600 focus:ring-emerald-500" data-source-index="${row.index}" ${row.selectable ? 'checked' : 'disabled'}>
+                                </td>
+                                <td class="px-3 py-2 whitespace-nowrap">${escapeHtml(formatRegistrationSourceDate(row.sourceEvent.date || row.sourceEvent.start || row.sourceEvent.startTime || row.sourceEvent.startsAt))}</td>
+                                <td class="px-3 py-2 capitalize">${escapeHtml(row.payload?.type || row.sourceEvent.type || row.sourceEvent.eventType || 'game')}</td>
+                                <td class="px-3 py-2">${escapeHtml(row.sourceEvent.opponent || row.sourceEvent.title || row.sourceEvent.summary || 'TBD')}</td>
+                                <td class="px-3 py-2">${escapeHtml(row.sourceEvent.location || row.sourceEvent.venue || '')}</td>
+                                <td class="px-3 py-2">
+                                    <span class="inline-flex px-2 py-1 rounded-full text-xs font-semibold ${actionClasses[row.action] || actionClasses.skipped}">${escapeHtml(row.action)}</span>
+                                    <span class="block mt-1 text-xs text-gray-600">${escapeHtml(row.reason || '')}</span>
+                                </td>
+                            </tr>
+                        `).join('')}
+                    </tbody>
+                </table>
+            `;
         }
 
         async function handleRegistrationScheduleImport() {
@@ -1760,9 +1831,17 @@
             button.disabled = true;
             button.textContent = 'Re-importing...';
             try {
+                const selectedIndexes = new Set(Array.from(document.querySelectorAll('.registration-schedule-import-choice:checked'))
+                    .map((input) => Number(input.dataset.sourceIndex)));
+                const selectedSourceEvents = sourceEvents.filter((_, index) => selectedIndexes.has(index));
+                if (!selectedSourceEvents.length) {
+                    status.textContent = 'Select at least one non-conflicting schedule entry to import.';
+                    return;
+                }
+
                 const existingEvents = await getEvents(currentTeamId);
                 const plan = planRegistrationScheduleImport({
-                    sourceEvents,
+                    sourceEvents: selectedSourceEvents,
                     existingEvents,
                     Timestamp,
                     source: getRegistrationSourceDescriptor(currentTeam)
@@ -1781,13 +1860,14 @@
                 }
 
                 status.textContent = `Import complete: ${formatRegistrationImportResults(plan.results)}.`;
+                await renderRegistrationScheduleImport(currentTeam);
                 await loadSchedule();
             } catch (error) {
                 console.error('Registration schedule import failed:', error);
                 status.textContent = `Import failed: ${error.message}`;
             } finally {
                 button.disabled = false;
-                button.textContent = 'Re-import Schedule';
+                button.textContent = 'Import Selected';
             }
         }
 

--- a/js/edit-schedule-registration-import.js
+++ b/js/edit-schedule-registration-import.js
@@ -105,7 +105,7 @@ export function buildRegistrationScheduleEventPayload(sourceEvent = {}, { Timest
     return payload;
 }
 
-export function planRegistrationScheduleImport({ sourceEvents = [], existingEvents = [], Timestamp, source = {} } = {}) {
+export function buildRegistrationScheduleImportPreview({ sourceEvents = [], existingEvents = [], Timestamp, source = {} } = {}) {
     const existingByExternalId = new Map();
     (existingEvents || []).forEach((event) => {
         const externalEventId = getExistingExternalEventId(event);
@@ -113,6 +113,29 @@ export function planRegistrationScheduleImport({ sourceEvents = [], existingEven
     });
 
     const seenExternalIds = new Set();
+    return (sourceEvents || []).map((sourceEvent, index) => {
+        const externalEventId = getExternalEventId(sourceEvent);
+        const payload = buildRegistrationScheduleEventPayload(sourceEvent, { Timestamp, source });
+        if (!externalEventId || seenExternalIds.has(externalEventId) || !payload) {
+            return { index, sourceEvent, payload, externalEventId, action: 'skipped', selectable: false, reason: 'Missing or duplicate source event id/date' };
+        }
+        seenExternalIds.add(externalEventId);
+
+        const existing = existingByExternalId.get(externalEventId);
+        if (existing?.id) {
+            return { index, sourceEvent, payload, externalEventId, action: 'update', selectable: true, existingEventId: existing.id, reason: 'Matches an imported event' };
+        }
+
+        const conflict = (existingEvents || []).find((candidate) => !getExistingExternalEventId(candidate) && isSameLocalEvent(sourceEvent, candidate));
+        if (conflict) {
+            return { index, sourceEvent, payload, externalEventId, action: 'conflict', selectable: false, existingEventId: conflict.id || null, reason: 'Likely duplicate: same date/time and opponent/title already exists' };
+        }
+
+        return { index, sourceEvent, payload, externalEventId, action: 'add', selectable: true, reason: 'Ready to import' };
+    });
+}
+
+export function planRegistrationScheduleImport({ sourceEvents = [], existingEvents = [], Timestamp, source = {} } = {}) {
     const operations = [];
     const results = {
         added: 0,
@@ -122,38 +145,26 @@ export function planRegistrationScheduleImport({ sourceEvents = [], existingEven
         conflicts: []
     };
 
-    (sourceEvents || []).forEach((sourceEvent) => {
-        const externalEventId = getExternalEventId(sourceEvent);
-        if (!externalEventId || seenExternalIds.has(externalEventId)) {
+    buildRegistrationScheduleImportPreview({ sourceEvents, existingEvents, Timestamp, source }).forEach((row) => {
+        if (row.action === 'skipped') {
             results.skipped += 1;
             return;
         }
-        seenExternalIds.add(externalEventId);
-
-        const payload = buildRegistrationScheduleEventPayload(sourceEvent, { Timestamp, source });
-        if (!payload) {
-            results.skipped += 1;
+        if (row.action === 'conflict') {
+            results.conflicted += 1;
+            results.conflicts.push({ externalEventId: row.externalEventId, existingEventId: row.existingEventId || null });
             return;
         }
-
-        const existing = existingByExternalId.get(externalEventId);
-        if (existing?.id) {
-            operations.push({ type: 'update', eventId: existing.id, eventType: payload.type, payload });
+        if (row.action === 'update') {
+            operations.push({ type: 'update', eventId: row.existingEventId, eventType: row.payload.type, payload: row.payload });
             results.updated += 1;
             return;
         }
 
-        const conflict = (existingEvents || []).find((candidate) => !getExistingExternalEventId(candidate) && isSameLocalEvent(sourceEvent, candidate));
-        if (conflict) {
-            results.conflicted += 1;
-            results.conflicts.push({ externalEventId, existingEventId: conflict.id || null });
-            return;
-        }
-
-        const addPayload = payload.type === 'game'
-            ? { status: 'scheduled', homeScore: 0, awayScore: 0, ...payload }
-            : payload;
-        operations.push({ type: 'add', eventType: payload.type, payload: addPayload });
+        const addPayload = row.payload.type === 'game'
+            ? { status: 'scheduled', homeScore: 0, awayScore: 0, ...row.payload }
+            : row.payload;
+        operations.push({ type: 'add', eventType: row.payload.type, payload: addPayload });
         results.added += 1;
     });
 

--- a/tests/unit/edit-schedule-registration-import.test.js
+++ b/tests/unit/edit-schedule-registration-import.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import {
+    buildRegistrationScheduleImportPreview,
     formatRegistrationImportResults,
     getRegistrationScheduleEvents,
     isExternallyLinkedRegistrationTeam,
@@ -104,6 +105,40 @@ describe('registration schedule import planning', () => {
         });
     });
 
+    it('builds preview rows for selectable imports and local conflicts', () => {
+        const rows = buildRegistrationScheduleImportPreview({
+            Timestamp,
+            sourceEvents: [
+                {
+                    externalEventId: 'ext-new',
+                    type: 'practice',
+                    start: '2026-05-01T18:00:00.000Z',
+                    title: 'Practice',
+                    location: 'Gym'
+                },
+                {
+                    externalEventId: 'ext-conflict',
+                    type: 'game',
+                    start: '2026-05-02T18:00:00.000Z',
+                    opponent: 'Bears'
+                }
+            ],
+            existingEvents: [
+                {
+                    id: 'game-2',
+                    type: 'game',
+                    date: new Date('2026-05-02T18:00:00.000Z'),
+                    opponent: 'Bears'
+                }
+            ]
+        });
+
+        expect(rows).toEqual([
+            expect.objectContaining({ action: 'add', selectable: true, payload: expect.objectContaining({ type: 'practice', title: 'Practice', location: 'Gym' }) }),
+            expect.objectContaining({ action: 'conflict', selectable: false, existingEventId: 'game-2' })
+        ]);
+    });
+
     it('formats import result counts for the UI', () => {
         expect(formatRegistrationImportResults({ added: 2, updated: 1, skipped: 0, conflicted: 3 }))
             .toBe('2 added, 1 updated, 0 skipped, 3 conflicted');
@@ -115,9 +150,11 @@ describe('registration schedule import wiring', () => {
         const source = readEditSchedule();
 
         expect(source).toContain('id="registration-schedule-import"');
-        expect(source).toContain('Re-import Schedule');
-        expect(source).toContain("import { formatRegistrationImportResults, getRegistrationScheduleEvents, isExternallyLinkedRegistrationTeam, planRegistrationScheduleImport } from './js/edit-schedule-registration-import.js?v=1';");
-        expect(source).toContain('planRegistrationScheduleImport({');
+        expect(source).toContain('id="registration-schedule-import-preview"');
+        expect(source).toContain('Import Selected');
+        expect(source).toContain("import { buildRegistrationScheduleImportPreview, formatRegistrationImportResults, getRegistrationScheduleEvents, isExternallyLinkedRegistrationTeam, planRegistrationScheduleImport } from './js/edit-schedule-registration-import.js?v=2';");
+        expect(source).toContain('buildRegistrationScheduleImportPreview({');
+        expect(source).toContain('registration-schedule-import-choice:checked');
         expect(source).toContain('sourceMetadata?.externalEventId');
     });
 });


### PR DESCRIPTION
Closes #800

## Summary
- Added a registration schedule snapshot preview on the team schedule editor.
- Shows date/time, type, opponent/title, location, and import status for each source entry.
- Flags likely duplicate local events as conflicts and lets admins import only selected non-conflicting entries.
- Preserves registration provider source metadata on imported events.

## Tests
- `npx vitest run tests/unit/edit-schedule-registration-import.test.js`