### PR TITLE
Add team tracking item admin setup

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -252,6 +252,13 @@
                                     </svg>
                                     <span class="text-xs font-medium text-gray-600 group-hover/btn:text-amber-700">Fees</span>
                                 </a>
+                                <a href="tracking-items.html#teamId=${team.id}"
+                                   class="flex flex-col items-center justify-center p-3 rounded-lg border border-emerald-200 hover:border-emerald-300 hover:bg-emerald-50 transition group/btn">
+                                    <svg class="w-5 h-5 text-gray-600 group-hover/btn:text-emerald-600 transition mb-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2m-4 0a2 2 0 012-2h2a2 2 0 012 2m-6 4l2 2 4-4m-6 8h6"></path>
+                                    </svg>
+                                    <span class="text-xs font-medium text-gray-600 group-hover/btn:text-emerald-700">Tracking</span>
+                                </a>
                                 ` : `
                                 <!-- Parent-only view: keep actions read-only (filler for grid) -->
                                 <div class="hidden sm:block"></div>

--- a/firestore.rules
+++ b/firestore.rules
@@ -172,6 +172,11 @@ service cloud.firestore {
              data.get('active', true) != false;
     }
 
+    function canReadPublicTrackingItem(teamId, data) {
+      return isActivePublicTrackingItem(data) &&
+             (isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId));
+    }
+
     function isTrackingItemPayloadValid(teamId, data) {
       return data.keys().hasOnly([
                'teamId', 'name', 'description', 'visibility', 'status', 'active', 'archived',
@@ -586,7 +591,7 @@ service cloud.firestore {
       }
 
       match /trackingItems/{itemId} {
-        allow read: if isTeamOwnerOrAdmin(teamId) || isActivePublicTrackingItem(resource.data);
+        allow read: if isTeamOwnerOrAdmin(teamId) || canReadPublicTrackingItem(teamId, resource.data);
         allow create: if isTeamOwnerOrAdmin(teamId) &&
                       isTrackingItemPayloadValid(teamId, request.resource.data) &&
                       hasTrackingItemCreateAudit(request.resource.data);

--- a/firestore.rules
+++ b/firestore.rules
@@ -165,6 +165,40 @@ service cloud.firestore {
              data.get('published', false) == true;
     }
 
+    function isActivePublicTrackingItem(data) {
+      return data.get('visibility', 'private') == 'public' &&
+             data.get('status', 'active') == 'active' &&
+             data.get('archived', false) != true &&
+             data.get('active', true) != false;
+    }
+
+    function isTrackingItemPayloadValid(teamId, data) {
+      return data.keys().hasOnly([
+               'teamId', 'name', 'description', 'visibility', 'status', 'active', 'archived',
+               'createdAt', 'createdBy', 'updatedAt', 'updatedBy'
+             ]) &&
+             data.teamId == teamId &&
+             data.name is string &&
+             data.name.size() > 0 &&
+             data.name.size() <= 120 &&
+             (!('description' in data) || (data.description is string && data.description.size() <= 2000)) &&
+             data.visibility in ['private', 'public'] &&
+             data.status in ['active', 'archived'] &&
+             data.active is bool &&
+             data.archived is bool &&
+             ((data.status == 'active' && data.active == true && data.archived == false) ||
+              (data.status == 'archived' && data.active == false && data.archived == true));
+    }
+
+    function hasTrackingItemCreateAudit(data) {
+      return data.createdBy == request.auth.uid &&
+             data.updatedBy == request.auth.uid;
+    }
+
+    function hasTrackingItemUpdateAudit(data) {
+      return data.updatedBy == request.auth.uid;
+    }
+
     function hasOnlyFlatStringValues(data) {
       return data is map &&
              data.keys().size() <= 20 &&
@@ -517,6 +551,19 @@ service cloud.firestore {
                           (isPublishedRegistrationForm(get(/databases/$(database)/documents/teams/$(teamId)/registrationForms/$(formId)).data) &&
                            isPendingRegistrationPayloadValid(teamId, formId, request.resource.data));
         }
+      }
+
+      match /trackingItems/{itemId} {
+        allow read: if isTeamOwnerOrAdmin(teamId) || isActivePublicTrackingItem(resource.data);
+        allow create: if isTeamOwnerOrAdmin(teamId) &&
+                      isTrackingItemPayloadValid(teamId, request.resource.data) &&
+                      hasTrackingItemCreateAudit(request.resource.data);
+        allow update: if isTeamOwnerOrAdmin(teamId) &&
+                      isTrackingItemPayloadValid(teamId, request.resource.data) &&
+                      request.resource.data.createdBy == resource.data.createdBy &&
+                      request.resource.data.createdAt == resource.data.createdAt &&
+                      hasTrackingItemUpdateAudit(request.resource.data);
+        allow delete: if isTeamOwnerOrAdmin(teamId);
       }
 
       match /entitlements/{entitlementId} {

--- a/js/tracking-items-admin.js
+++ b/js/tracking-items-admin.js
@@ -1,0 +1,331 @@
+import { escapeHtml, getUrlParams, renderFooter, renderHeader } from './utils.js?v=8';
+
+const VISIBILITY_VALUES = ['private', 'public'];
+const STATUS_VALUES = ['active', 'archived'];
+
+function normalizeString(value) {
+    return String(value || '').trim();
+}
+
+export function isTrackingItemAdmin(team, user = {}, canModerateChat = null) {
+    if (!team || !user) return false;
+    if (user.isAdmin === true) return true;
+    if (team.ownerId && user.uid && team.ownerId === user.uid) return true;
+    if (typeof canModerateChat === 'function' && canModerateChat(team, user)) return true;
+
+    const email = normalizeString(user.email || user.profileEmail).toLowerCase();
+    if (!email) return false;
+
+    return (team.adminEmails || [])
+        .map((adminEmail) => normalizeString(adminEmail).toLowerCase())
+        .includes(email);
+}
+
+export function normalizeTrackingItemDraft(formValues = {}) {
+    const name = normalizeString(formValues.name);
+    const description = normalizeString(formValues.description);
+    const visibility = VISIBILITY_VALUES.includes(formValues.visibility) ? formValues.visibility : 'private';
+    const status = STATUS_VALUES.includes(formValues.status) ? formValues.status : 'active';
+
+    if (!name) throw new Error('Tracking item name is required.');
+
+    return {
+        name,
+        description,
+        visibility,
+        status,
+        archived: status === 'archived',
+        active: status === 'active'
+    };
+}
+
+export function filterTrackingItemsForAdminList(items = [], { includeArchived = false } = {}) {
+    return (items || [])
+        .filter((item) => includeArchived || normalizeTrackingItemStatus(item) !== 'archived')
+        .sort((a, b) => String(a.name || '').localeCompare(String(b.name || '')));
+}
+
+export function normalizeTrackingItemStatus(item = {}) {
+    if (item.status === 'archived' || item.archived === true || item.active === false) return 'archived';
+    return 'active';
+}
+
+function formatVisibilityLabel(visibility) {
+    return visibility === 'public' ? 'Public' : 'Private';
+}
+
+function renderShell({ team }) {
+    return `
+        <div class="mb-6 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <div>
+                <p class="text-sm font-semibold uppercase tracking-wide text-primary-600">Team admin</p>
+                <h1 class="text-3xl font-bold text-gray-900">Tracking checklist items</h1>
+                <p class="mt-1 text-sm text-gray-600">${escapeHtml(team.name || 'Team')} · Create reusable forms, tasks, and compliance checklist items.</p>
+            </div>
+            <a href="dashboard.html" class="text-sm font-semibold text-primary-700 hover:text-primary-900">Back to dashboard</a>
+        </div>
+
+        <div id="tracking-item-message" class="mb-4 hidden rounded-lg p-3 text-sm"></div>
+
+        <div class="grid gap-6 lg:grid-cols-[minmax(0,1fr)_22rem]">
+            <section class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+                <div class="mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div>
+                        <h2 class="text-xl font-bold text-gray-900">Items</h2>
+                        <p class="text-sm text-gray-500">Archived items are hidden by default.</p>
+                    </div>
+                    <label class="flex items-center gap-2 text-sm text-gray-600">
+                        <input id="show-archived-tracking-items" type="checkbox" class="rounded border-gray-300 text-primary-600">
+                        Show archived
+                    </label>
+                </div>
+                <div id="tracking-items-list" class="space-y-3">
+                    <p class="text-sm text-gray-500">Loading tracking items...</p>
+                </div>
+            </section>
+
+            <form id="tracking-item-form" class="rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+                <input id="tracking-item-id" type="hidden">
+                <h2 id="tracking-item-form-title" class="mb-4 text-xl font-bold text-gray-900">Create item</h2>
+                <div class="space-y-4">
+                    <div>
+                        <label for="tracking-item-name" class="block text-sm font-medium text-gray-700">Name</label>
+                        <input id="tracking-item-name" required class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Medical release form">
+                    </div>
+                    <div>
+                        <label for="tracking-item-description" class="block text-sm font-medium text-gray-700">Description</label>
+                        <textarea id="tracking-item-description" rows="4" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Optional instructions for admins or families"></textarea>
+                    </div>
+                    <div>
+                        <label for="tracking-item-visibility" class="block text-sm font-medium text-gray-700">Visibility</label>
+                        <select id="tracking-item-visibility" class="mt-1 w-full rounded border border-gray-300 p-2">
+                            <option value="private">Private admin-only</option>
+                            <option value="public">Public to team members</option>
+                        </select>
+                    </div>
+                    <div>
+                        <label for="tracking-item-status" class="block text-sm font-medium text-gray-700">Status</label>
+                        <select id="tracking-item-status" class="mt-1 w-full rounded border border-gray-300 p-2">
+                            <option value="active">Active</option>
+                            <option value="archived">Archived</option>
+                        </select>
+                    </div>
+                    <div class="flex gap-2">
+                        <button type="submit" class="flex-1 rounded bg-primary-600 px-4 py-2 font-semibold text-white hover:bg-primary-700">Save item</button>
+                        <button id="tracking-item-cancel" type="button" class="rounded border border-gray-300 px-4 py-2 font-semibold text-gray-700 hover:bg-gray-50">Reset</button>
+                    </div>
+                </div>
+            </form>
+        </div>
+    `;
+}
+
+function showMessage(message, type = 'success') {
+    const el = document.getElementById('tracking-item-message');
+    if (!el) return;
+    el.textContent = message;
+    el.className = `mb-4 rounded-lg p-3 text-sm ${type === 'error' ? 'border border-red-200 bg-red-50 text-red-700' : 'border border-green-200 bg-green-50 text-green-700'}`;
+}
+
+function resetForm() {
+    document.getElementById('tracking-item-id').value = '';
+    document.getElementById('tracking-item-name').value = '';
+    document.getElementById('tracking-item-description').value = '';
+    document.getElementById('tracking-item-visibility').value = 'private';
+    document.getElementById('tracking-item-status').value = 'active';
+    document.getElementById('tracking-item-form-title').textContent = 'Create item';
+}
+
+function populateForm(item) {
+    document.getElementById('tracking-item-id').value = item.id || '';
+    document.getElementById('tracking-item-name').value = item.name || '';
+    document.getElementById('tracking-item-description').value = item.description || '';
+    document.getElementById('tracking-item-visibility').value = item.visibility === 'public' ? 'public' : 'private';
+    document.getElementById('tracking-item-status').value = normalizeTrackingItemStatus(item);
+    document.getElementById('tracking-item-form-title').textContent = 'Edit item';
+}
+
+function renderList(items, { includeArchived = false, onEdit, onArchive }) {
+    const list = document.getElementById('tracking-items-list');
+    const visibleItems = filterTrackingItemsForAdminList(items, { includeArchived });
+
+    if (!visibleItems.length) {
+        list.innerHTML = `<p class="text-sm text-gray-500">${includeArchived ? 'No tracking items yet.' : 'No active tracking items yet.'}</p>`;
+        return;
+    }
+
+    list.innerHTML = visibleItems.map((item) => {
+        const status = normalizeTrackingItemStatus(item);
+        return `
+            <article class="rounded-xl border border-gray-200 p-4" data-item-id="${escapeHtml(item.id)}">
+                <div class="flex items-start justify-between gap-3">
+                    <div>
+                        <h3 class="font-semibold text-gray-900">${escapeHtml(item.name || 'Untitled item')}</h3>
+                        <p class="mt-1 text-sm text-gray-600">${escapeHtml(item.description || 'No description.')}</p>
+                        <div class="mt-2 flex flex-wrap gap-2 text-xs">
+                            <span class="rounded-full bg-blue-50 px-2 py-1 font-semibold text-blue-700">${formatVisibilityLabel(item.visibility)}</span>
+                            <span class="rounded-full ${status === 'archived' ? 'bg-gray-100 text-gray-700' : 'bg-green-50 text-green-700'} px-2 py-1 font-semibold">${status === 'archived' ? 'Archived' : 'Active'}</span>
+                        </div>
+                    </div>
+                    <div class="flex shrink-0 gap-2">
+                        <button type="button" data-action="edit" class="text-sm font-semibold text-primary-700 hover:text-primary-900">Edit</button>
+                        ${status === 'active' ? '<button type="button" data-action="archive" class="text-sm font-semibold text-red-600 hover:text-red-800">Archive</button>' : ''}
+                    </div>
+                </div>
+            </article>
+        `;
+    }).join('');
+
+    list.querySelectorAll('[data-action="edit"]').forEach((button) => {
+        button.addEventListener('click', () => {
+            const itemId = button.closest('[data-item-id]')?.dataset?.itemId;
+            const item = items.find((candidate) => candidate.id === itemId);
+            if (item) onEdit(item);
+        });
+    });
+    list.querySelectorAll('[data-action="archive"]').forEach((button) => {
+        button.addEventListener('click', () => {
+            const itemId = button.closest('[data-item-id]')?.dataset?.itemId;
+            const item = items.find((candidate) => candidate.id === itemId);
+            if (item) onArchive(item);
+        });
+    });
+}
+
+async function initTrackingItemsAdminPage() {
+    if (typeof document === 'undefined') return;
+
+    const container = document.getElementById('tracking-items-admin-root');
+    if (!container) return;
+
+    renderFooter(document.getElementById('footer-container'));
+
+    const [dbModule, authModule, firebaseModule] = await Promise.all([
+        import('./db.js?v=31'),
+        import('./auth.js?v=12'),
+        import('./firebase.js?v=11')
+    ]);
+    const { getTeam, getUserProfile, canModerateChat } = dbModule;
+    const { requireAuth } = authModule;
+    const { db, collection, getDocs, doc, setDoc, updateDoc, serverTimestamp } = firebaseModule;
+
+    try {
+        const user = await requireAuth();
+        try {
+            const profile = await getUserProfile(user.uid);
+            if (profile?.isAdmin) user.isAdmin = true;
+            if (profile?.email) user.profileEmail = profile.email;
+        } catch (error) {
+            console.warn('[tracking-items] Unable to load profile:', error);
+        }
+
+        renderHeader(document.getElementById('header-container'), user);
+
+        const params = getUrlParams();
+        const teamId = params.teamId || '';
+        if (!teamId) {
+            container.innerHTML = '<div class="rounded-2xl border border-red-200 bg-red-50 p-6 text-red-700">Missing teamId.</div>';
+            return;
+        }
+
+        const team = await getTeam(teamId, { includeInactive: true });
+        if (!team) {
+            container.innerHTML = '<div class="rounded-2xl border border-red-200 bg-red-50 p-6 text-red-700">Team not found.</div>';
+            return;
+        }
+
+        if (!isTrackingItemAdmin(team, user, canModerateChat)) {
+            container.innerHTML = `
+                <div class="rounded-2xl border border-red-200 bg-red-50 p-6 text-red-700">
+                    <h1 class="mb-2 text-2xl font-bold">Tracking items are admin-only</h1>
+                    <p>Only team owners, team admins, and global admins can create, edit, or archive tracking items.</p>
+                </div>
+            `;
+            return;
+        }
+
+        let items = [];
+        container.innerHTML = renderShell({ team });
+
+        const includeArchivedInput = document.getElementById('show-archived-tracking-items');
+        const refreshList = () => renderList(items, {
+            includeArchived: includeArchivedInput.checked,
+            onEdit: populateForm,
+            onArchive: async (item) => {
+                if (!confirm(`Archive "${item.name || 'this item'}"?`)) return;
+                await updateDoc(doc(db, `teams/${teamId}/trackingItems`, item.id), {
+                    status: 'archived',
+                    archived: true,
+                    active: false,
+                    updatedAt: serverTimestamp(),
+                    updatedBy: user.uid
+                });
+                showMessage('Tracking item archived.');
+                await loadItems();
+                resetForm();
+            }
+        });
+
+        async function loadItems() {
+            const snapshot = await getDocs(collection(db, `teams/${teamId}/trackingItems`));
+            items = snapshot.docs.map((itemDoc) => ({ id: itemDoc.id, ...itemDoc.data() }));
+            refreshList();
+        }
+
+        includeArchivedInput.addEventListener('change', refreshList);
+        document.getElementById('tracking-item-cancel').addEventListener('click', resetForm);
+        document.getElementById('tracking-item-form').addEventListener('submit', async (event) => {
+            event.preventDefault();
+            const itemId = document.getElementById('tracking-item-id').value;
+            let draft;
+            try {
+                draft = normalizeTrackingItemDraft({
+                    name: document.getElementById('tracking-item-name').value,
+                    description: document.getElementById('tracking-item-description').value,
+                    visibility: document.getElementById('tracking-item-visibility').value,
+                    status: document.getElementById('tracking-item-status').value
+                });
+            } catch (error) {
+                showMessage(error.message, 'error');
+                return;
+            }
+
+            try {
+                if (itemId) {
+                    await updateDoc(doc(db, `teams/${teamId}/trackingItems`, itemId), {
+                        ...draft,
+                        teamId,
+                        updatedAt: serverTimestamp(),
+                        updatedBy: user.uid
+                    });
+                    showMessage('Tracking item updated.');
+                } else {
+                    const itemRef = doc(collection(db, `teams/${teamId}/trackingItems`));
+                    await setDoc(itemRef, {
+                        ...draft,
+                        teamId,
+                        createdAt: serverTimestamp(),
+                        createdBy: user.uid,
+                        updatedAt: serverTimestamp(),
+                        updatedBy: user.uid
+                    });
+                    showMessage('Tracking item created.');
+                }
+                await loadItems();
+                resetForm();
+            } catch (error) {
+                console.error('[tracking-items] save failed:', error);
+                showMessage('Unable to save tracking item.', 'error');
+            }
+        });
+
+        await loadItems();
+    } catch (error) {
+        console.error('[tracking-items] init failed:', error);
+        container.innerHTML = '<div class="rounded-2xl border border-red-200 bg-red-50 p-6 text-red-700">Unable to load tracking items.</div>';
+    }
+}
+
+if (typeof window !== 'undefined') {
+    window.addEventListener('DOMContentLoaded', initTrackingItemsAdminPage);
+}

--- a/tests/unit/tracking-items-admin.test.js
+++ b/tests/unit/tracking-items-admin.test.js
@@ -1,10 +1,15 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
 import {
     filterTrackingItemsForAdminList,
     isTrackingItemAdmin,
     normalizeTrackingItemDraft,
     normalizeTrackingItemStatus
 } from '../../js/tracking-items-admin.js';
+
+function readFirestoreRules() {
+    return readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+}
 
 describe('tracking items admin helpers', () => {
     it('normalizes draft metadata and defaults active private items', () => {
@@ -57,5 +62,14 @@ describe('tracking items admin helpers', () => {
         expect(isTrackingItemAdmin(team, { isAdmin: true })).toBe(true);
         expect(isTrackingItemAdmin(team, { uid: 'moderator-1' }, () => true)).toBe(true);
         expect(isTrackingItemAdmin(team, { email: 'parent@example.com' })).toBe(false);
+    });
+
+    it('keeps public tracking item reads scoped to team members in Firestore rules', () => {
+        const rules = readFirestoreRules();
+
+        expect(rules).toContain('function canReadPublicTrackingItem(teamId, data)');
+        expect(rules).toContain('isActivePublicTrackingItem(data) &&');
+        expect(rules).toContain('(isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId))');
+        expect(rules).toContain('allow read: if isTeamOwnerOrAdmin(teamId) || canReadPublicTrackingItem(teamId, resource.data);');
     });
 });

--- a/tests/unit/tracking-items-admin.test.js
+++ b/tests/unit/tracking-items-admin.test.js
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import {
+    filterTrackingItemsForAdminList,
+    isTrackingItemAdmin,
+    normalizeTrackingItemDraft,
+    normalizeTrackingItemStatus
+} from '../../js/tracking-items-admin.js';
+
+describe('tracking items admin helpers', () => {
+    it('normalizes draft metadata and defaults active private items', () => {
+        expect(normalizeTrackingItemDraft({
+            name: ' Medical release ',
+            description: ' Upload before first practice ',
+            visibility: 'public'
+        })).toEqual({
+            name: 'Medical release',
+            description: 'Upload before first practice',
+            visibility: 'public',
+            status: 'active',
+            archived: false,
+            active: true
+        });
+    });
+
+    it('requires a name and normalizes invalid visibility and status values', () => {
+        expect(() => normalizeTrackingItemDraft({ name: ' ' })).toThrow('Tracking item name');
+        expect(normalizeTrackingItemDraft({ name: 'Waiver', visibility: 'team', status: 'done' })).toMatchObject({
+            visibility: 'private',
+            status: 'active',
+            archived: false,
+            active: true
+        });
+    });
+
+    it('tracks archived status consistently for active lists', () => {
+        const items = [
+            { id: 'archived-status', name: 'Z', status: 'archived', archived: true, active: false },
+            { id: 'archived-legacy', name: 'A', active: false },
+            { id: 'active', name: 'M', status: 'active', archived: false, active: true }
+        ];
+
+        expect(normalizeTrackingItemStatus(items[0])).toBe('archived');
+        expect(normalizeTrackingItemStatus(items[1])).toBe('archived');
+        expect(filterTrackingItemsForAdminList(items).map((item) => item.id)).toEqual(['active']);
+        expect(filterTrackingItemsForAdminList(items, { includeArchived: true }).map((item) => item.id)).toEqual([
+            'archived-legacy',
+            'active',
+            'archived-status'
+        ]);
+    });
+
+    it('allows only owners, team admins, global admins, or delegated moderators', () => {
+        const team = { ownerId: 'owner-1', adminEmails: ['Coach@Example.com'] };
+
+        expect(isTrackingItemAdmin(team, { uid: 'owner-1' })).toBe(true);
+        expect(isTrackingItemAdmin(team, { email: 'coach@example.com' })).toBe(true);
+        expect(isTrackingItemAdmin(team, { isAdmin: true })).toBe(true);
+        expect(isTrackingItemAdmin(team, { uid: 'moderator-1' }, () => true)).toBe(true);
+        expect(isTrackingItemAdmin(team, { email: 'parent@example.com' })).toBe(false);
+    });
+});

--- a/tracking-items.html
+++ b/tracking-items.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex,nofollow">
+    <link rel="icon" type="image/png" href="img/logo_small.png">
+    <title>Tracking Items - ALL PLAYS</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <link rel="stylesheet" href="css/styles.css">
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        primary: {
+                            50: '#eef2ff',
+                            100: '#e0e7ff',
+                            500: '#6366f1',
+                            600: '#4f46e5',
+                            700: '#4338ca',
+                            800: '#3730a3',
+                            900: '#312e81'
+                        }
+                    }
+                }
+            }
+        };
+    </script>
+</head>
+
+<body class="bg-gradient-to-br from-gray-50 to-gray-100 text-gray-900">
+    <div id="header-container"></div>
+
+    <main class="container mx-auto px-4 py-8 md:py-12">
+        <div id="tracking-items-admin-root">
+            <div class="rounded-2xl border border-gray-200 bg-white p-8 text-center shadow-md">
+                <div class="mx-auto mb-4 h-12 w-12 animate-spin rounded-full border-b-2 border-primary-600"></div>
+                <p class="text-gray-500">Loading tracking items...</p>
+            </div>
+        </div>
+    </main>
+
+    <div id="footer-container"></div>
+
+    <script type="module" src="./js/tracking-items-admin.js?v=1"></script>
+</body>
+
+</html>


### PR DESCRIPTION
Closes #792

## Summary
- Added a team-scoped tracking items admin page for creating, editing, archiving, and listing checklist metadata.
- Added active/private/public status handling, with archived items hidden by default in the admin list.
- Added Firestore rules for tracking item access and payload validation so only team admins can write items.

## Validation
- `npx vitest run tests/unit/tracking-items-admin.test.js`
- `firebase deploy --only firestore:rules --dry-run --project game-flow-c6311`