### PR TITLE
Add roster tracking status matrix

### DIFF
--- a/edit-roster.html
+++ b/edit-roster.html
@@ -291,6 +291,26 @@
                     </div>
                 </section>
 
+                <section class="bg-white rounded-lg shadow-md overflow-hidden">
+                    <div class="p-6 border-b border-gray-200 flex flex-col lg:flex-row lg:items-start lg:justify-between gap-4">
+                        <div>
+                            <h2 class="text-xl font-bold">Roster Tracking</h2>
+                            <p class="text-sm text-gray-600 mt-1">Select one checklist item and mark active players complete or incomplete.</p>
+                            <p id="tracking-status-summary" class="text-sm font-semibold text-indigo-700 mt-2">No tracking item selected.</p>
+                        </div>
+                        <div class="flex flex-col sm:flex-row gap-2 w-full lg:w-auto">
+                            <select id="tracking-item-select" class="rounded-md border-gray-300 shadow-sm border p-2 text-sm min-w-56">
+                                <option value="">No tracking items</option>
+                            </select>
+                            <input id="new-tracking-item-title" type="text" placeholder="New item title" class="rounded-md border-gray-300 shadow-sm border p-2 text-sm min-w-48">
+                            <button id="create-tracking-item-btn" type="button" class="px-3 py-2 bg-indigo-600 text-white text-sm font-semibold rounded-md hover:bg-indigo-700">Add Item</button>
+                        </div>
+                    </div>
+                    <div id="tracking-status-matrix" class="p-6 space-y-2">
+                        <p class="text-sm text-gray-500">Add or select a tracking item to edit roster completion.</p>
+                    </div>
+                </section>
+
                 <div class="bg-white rounded-lg shadow-md overflow-hidden">
                     <div class="p-6 border-b border-gray-200 flex justify-between items-center">
                         <h2 class="text-xl font-bold">Current Roster</h2>
@@ -485,8 +505,9 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getPlayers, addPlayer, deactivatePlayer, reactivatePlayer, getGames, uploadPlayerPhoto, updatePlayer, setPlayerPrivateRosterProfileFields, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount, listTeamParentMembershipRequests, approveParentMembershipRequest, denyParentMembershipRequest, getRosterFieldDefinitions, saveRosterFieldDefinition, disableRosterFieldDefinition, reorderRosterFieldDefinitions, listTeamRegistrationForms, listTeamRegistrationReviews, approveTeamRegistration, rejectTeamRegistration } from './js/db.js?v=30';
+        import { getTeam, getPlayers, addPlayer, deactivatePlayer, reactivatePlayer, getGames, uploadPlayerPhoto, updatePlayer, setPlayerPrivateRosterProfileFields, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount, listTeamParentMembershipRequests, approveParentMembershipRequest, denyParentMembershipRequest, getRosterFieldDefinitions, saveRosterFieldDefinition, disableRosterFieldDefinition, reorderRosterFieldDefinitions, listTeamRegistrationForms, listTeamRegistrationReviews, approveTeamRegistration, rejectTeamRegistration, listTeamTrackingItems, createTeamTrackingItem, listTeamTrackingStatuses, setTeamTrackingStatus } from './js/db.js?v=31';
         import { buildRosterFieldDefinitionPayload, collectRosterProfileValues, getRosterProfileValues, normalizeRosterFieldDefinitions, planRosterCsvImport, renderRosterProfileFields, validateRosterProfileValues } from './js/roster-profile-fields.js?v=3';
+        import { buildTrackingStatusPayload, mergeTrackingStatusRows, normalizeTrackingItemDraft, summarizeTrackingStatus } from './js/tracking-status-admin.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth, sendInviteEmail } from './js/auth.js?v=13';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
@@ -508,6 +529,9 @@
         let registrationForms = [];
         let selectedRegistrationFormId = '';
         let registrationRosterImportPlan = null;
+        let trackingItems = [];
+        let selectedTrackingItemId = '';
+        let latestRosterPlayers = [];
         function hasAccess(team, user) {
             if (!team || !user) return false;
             return hasFullTeamAccess(user, { ...team, id: team.id || currentTeamId });
@@ -556,7 +580,115 @@
                 loadRegistrationReviews();
             });
             document.getElementById('registration-status-filter').addEventListener('change', () => loadRegistrationReviews());
+            document.getElementById('tracking-item-select').addEventListener('change', (event) => {
+                selectedTrackingItemId = event.target.value;
+                renderTrackingStatusMatrix();
+            });
+            document.getElementById('create-tracking-item-btn').addEventListener('click', handleCreateTrackingItem);
             loadRoster();
+        }
+
+        async function refreshTrackingItems() {
+            trackingItems = await listTeamTrackingItems(currentTeamId);
+            if (!selectedTrackingItemId && trackingItems.length > 0) {
+                selectedTrackingItemId = trackingItems[0].id;
+            }
+            if (selectedTrackingItemId && !trackingItems.some((item) => item.id === selectedTrackingItemId)) {
+                selectedTrackingItemId = trackingItems[0]?.id || '';
+            }
+            renderTrackingItemSelect();
+        }
+
+        function renderTrackingItemSelect() {
+            const select = document.getElementById('tracking-item-select');
+            if (!select) return;
+            if (!trackingItems.length) {
+                select.innerHTML = '<option value="">No tracking items</option>';
+                return;
+            }
+            select.innerHTML = trackingItems.map((item) => `
+                <option value="${escapeHtml(item.id)}" ${item.id === selectedTrackingItemId ? 'selected' : ''}>${escapeHtml(item.title || item.id)}</option>
+            `).join('');
+        }
+
+        async function handleCreateTrackingItem() {
+            const input = document.getElementById('new-tracking-item-title');
+            const button = document.getElementById('create-tracking-item-btn');
+            try {
+                button.disabled = true;
+                const draft = normalizeTrackingItemDraft({ title: input.value });
+                selectedTrackingItemId = await createTeamTrackingItem(currentTeamId, draft);
+                input.value = '';
+                await refreshTrackingItems();
+                await renderTrackingStatusMatrix();
+            } catch (error) {
+                alert(error?.message || 'Unable to create tracking item.');
+            } finally {
+                button.disabled = false;
+            }
+        }
+
+        async function renderTrackingStatusMatrix() {
+            const container = document.getElementById('tracking-status-matrix');
+            const summaryEl = document.getElementById('tracking-status-summary');
+            if (!container || !summaryEl) return;
+
+            const selectedItem = trackingItems.find((item) => item.id === selectedTrackingItemId);
+            if (!selectedItem) {
+                summaryEl.textContent = 'No tracking item selected.';
+                container.innerHTML = '<p class="text-sm text-gray-500">Add or select a tracking item to edit roster completion.</p>';
+                return;
+            }
+
+            container.innerHTML = '<p class="text-sm text-gray-500">Loading roster tracking statuses...</p>';
+            const statuses = await listTeamTrackingStatuses(currentTeamId, selectedTrackingItemId);
+            const rows = mergeTrackingStatusRows(latestRosterPlayers, statuses);
+            const summary = summarizeTrackingStatus(rows);
+            summaryEl.textContent = `${summary.complete} of ${summary.total} complete for ${selectedItem.title || 'selected item'} (${summary.incomplete} incomplete).`;
+
+            if (rows.length === 0) {
+                container.innerHTML = '<p class="text-sm text-gray-500">No active roster players to track.</p>';
+                return;
+            }
+
+            container.innerHTML = rows.map(({ player, complete }) => `
+                <label class="flex items-center justify-between gap-4 rounded-lg border border-gray-200 p-3 hover:bg-gray-50">
+                    <span class="min-w-0">
+                        <span class="font-semibold text-gray-900">${escapeHtml(player.name || 'Unnamed player')}</span>
+                        ${player.number ? `<span class="ml-2 text-xs text-gray-500">#${escapeHtml(player.number)}</span>` : ''}
+                    </span>
+                    <span class="flex items-center gap-3">
+                        <span class="tracking-status-label text-sm font-semibold ${complete ? 'text-emerald-700' : 'text-gray-500'}">${complete ? 'Complete' : 'Incomplete'}</span>
+                        <input type="checkbox" class="tracking-status-toggle rounded text-indigo-600 focus:ring-indigo-500" data-player-id="${escapeHtml(player.id)}" ${complete ? 'checked' : ''}>
+                    </span>
+                </label>
+            `).join('');
+
+            document.querySelectorAll('.tracking-status-toggle').forEach((input) => {
+                input.addEventListener('change', async (event) => {
+                    const checkbox = event.currentTarget;
+                    const player = latestRosterPlayers.find((item) => item.id === checkbox.dataset.playerId);
+                    if (!player) return;
+                    checkbox.disabled = true;
+                    try {
+                        const payload = buildTrackingStatusPayload({
+                            teamId: currentTeamId,
+                            itemId: selectedTrackingItemId,
+                            player,
+                            complete: checkbox.checked,
+                            actorId: currentUser.uid,
+                            actorEmail: currentUser.email
+                        });
+                        await setTeamTrackingStatus(currentTeamId, selectedTrackingItemId, player.id, payload);
+                        await renderTrackingStatusMatrix();
+                    } catch (error) {
+                        console.error('Error saving tracking status', error);
+                        alert('Unable to save tracking status: ' + (error?.message || 'Please try again.'));
+                        checkbox.checked = !checkbox.checked;
+                        checkbox.disabled = false;
+                    }
+                });
+            });
         }
 
         function getRegistrationSourceDescriptor(team = {}) {
@@ -908,6 +1040,7 @@
         }
 
         async function loadRoster() {
+            await refreshTrackingItems();
             const [players, games, allUsers, membershipRequests, forms] = await Promise.all([
                 getPlayers(currentTeamId, { includeInactive: true }),
                 getGames(currentTeamId),
@@ -915,12 +1048,14 @@
                 listTeamParentMembershipRequests(currentTeamId),
                 listTeamRegistrationForms(currentTeamId)
             ]);
+            latestRosterPlayers = players;
             registrationForms = forms || [];
             if (!selectedRegistrationFormId && registrationForms.length > 0) {
                 selectedRegistrationFormId = registrationForms[0].id;
             }
             renderRegistrationFormFilter();
             await loadRegistrationReviews();
+            await renderTrackingStatusMatrix();
             const latestGameId = [...games].sort((a, b) => {
                 const aDate = a.date.toDate ? a.date.toDate() : new Date(a.date);
                 const bDate = b.date.toDate ? b.date.toDate() : new Date(b.date);

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -532,6 +532,7 @@
         let trackingItems = [];
         let selectedTrackingItemId = '';
         let latestRosterPlayers = [];
+        let trackingStatusRenderToken = 0;
         function hasAccess(team, user) {
             if (!team || !user) return false;
             return hasFullTeamAccess(user, { ...team, id: team.id || currentTeamId });
@@ -633,7 +634,10 @@
             const summaryEl = document.getElementById('tracking-status-summary');
             if (!container || !summaryEl) return;
 
-            const selectedItem = trackingItems.find((item) => item.id === selectedTrackingItemId);
+            const renderToken = ++trackingStatusRenderToken;
+            const trackingItemId = selectedTrackingItemId;
+            const rosterPlayers = [...latestRosterPlayers];
+            const selectedItem = trackingItems.find((item) => item.id === trackingItemId);
             if (!selectedItem) {
                 summaryEl.textContent = 'No tracking item selected.';
                 container.innerHTML = '<p class="text-sm text-gray-500">Add or select a tracking item to edit roster completion.</p>';
@@ -641,8 +645,11 @@
             }
 
             container.innerHTML = '<p class="text-sm text-gray-500">Loading roster tracking statuses...</p>';
-            const statuses = await listTeamTrackingStatuses(currentTeamId, selectedTrackingItemId);
-            const rows = mergeTrackingStatusRows(latestRosterPlayers, statuses);
+            const statuses = await listTeamTrackingStatuses(currentTeamId, trackingItemId);
+            if (renderToken !== trackingStatusRenderToken || trackingItemId !== selectedTrackingItemId) {
+                return;
+            }
+            const rows = mergeTrackingStatusRows(rosterPlayers, statuses);
             const summary = summarizeTrackingStatus(rows);
             summaryEl.textContent = `${summary.complete} of ${summary.total} complete for ${selectedItem.title || 'selected item'} (${summary.incomplete} incomplete).`;
 
@@ -667,19 +674,19 @@
             document.querySelectorAll('.tracking-status-toggle').forEach((input) => {
                 input.addEventListener('change', async (event) => {
                     const checkbox = event.currentTarget;
-                    const player = latestRosterPlayers.find((item) => item.id === checkbox.dataset.playerId);
+                    const player = rosterPlayers.find((item) => item.id === checkbox.dataset.playerId);
                     if (!player) return;
                     checkbox.disabled = true;
                     try {
                         const payload = buildTrackingStatusPayload({
                             teamId: currentTeamId,
-                            itemId: selectedTrackingItemId,
+                            itemId: trackingItemId,
                             player,
                             complete: checkbox.checked,
                             actorId: currentUser.uid,
                             actorEmail: currentUser.email
                         });
-                        await setTeamTrackingStatus(currentTeamId, selectedTrackingItemId, player.id, payload);
+                        await setTeamTrackingStatus(currentTeamId, trackingItemId, player.id, payload);
                         await renderTrackingStatusMatrix();
                     } catch (error) {
                         console.error('Error saving tracking status', error);

--- a/firestore.rules
+++ b/firestore.rules
@@ -505,6 +505,25 @@ service cloud.firestore {
         allow create, update, delete: if isTeamOwnerOrAdmin(teamId);
       }
 
+      match /trackingItems/{itemId} {
+        allow read: if isTeamOwnerOrAdmin(teamId);
+        allow create, update: if isTeamOwnerOrAdmin(teamId) &&
+                                request.resource.data.get('teamId', teamId) == teamId &&
+                                request.resource.data.get('scope', 'players') == 'players';
+        allow delete: if isTeamOwnerOrAdmin(teamId);
+
+        match /memberTracking/{playerId} {
+          allow read: if isTeamOwnerOrAdmin(teamId);
+          allow create, update: if isTeamOwnerOrAdmin(teamId) &&
+                                  request.resource.data.get('teamId', teamId) == teamId &&
+                                  request.resource.data.get('trackingItemId', itemId) == itemId &&
+                                  request.resource.data.get('playerId', playerId) == playerId &&
+                                  request.resource.data.get('memberType', 'player') == 'player' &&
+                                  request.resource.data.get('status', 'incomplete') in ['complete', 'incomplete'];
+          allow delete: if isTeamOwnerOrAdmin(teamId);
+        }
+      }
+
       match /registrationForms/{formId} {
         allow read: if isPublishedRegistrationForm(resource.data) || isTeamOwnerOrAdmin(teamId);
         allow create, update, delete: if isTeamOwnerOrAdmin(teamId);

--- a/js/db.js
+++ b/js/db.js
@@ -935,6 +935,45 @@ function sortRegistrationReviews(registrations = []) {
     });
 }
 
+export async function listTeamTrackingItems(teamId) {
+    const itemsRef = collection(db, `teams/${teamId}/trackingItems`);
+    const snapshot = await getDocs(itemsRef);
+    return snapshot.docs
+        .map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }))
+        .filter((item) => item.active !== false && item.scope === 'players')
+        .sort((a, b) => String(a.title || '').localeCompare(String(b.title || '')));
+}
+
+export async function createTeamTrackingItem(teamId, itemData) {
+    const itemsRef = collection(db, `teams/${teamId}/trackingItems`);
+    const docRef = await addDoc(itemsRef, {
+        ...itemData,
+        teamId,
+        scope: 'players',
+        active: itemData.active !== false,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp()
+    });
+    return docRef.id;
+}
+
+export async function listTeamTrackingStatuses(teamId, trackingItemId) {
+    const statusesRef = collection(db, `teams/${teamId}/trackingItems/${trackingItemId}/memberTracking`);
+    const snapshot = await getDocs(statusesRef);
+    return snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+}
+
+export async function setTeamTrackingStatus(teamId, trackingItemId, playerId, statusData) {
+    const statusRef = doc(db, `teams/${teamId}/trackingItems/${trackingItemId}/memberTracking/${playerId}`);
+    await setDoc(statusRef, {
+        ...statusData,
+        teamId,
+        trackingItemId,
+        playerId,
+        updatedAt: serverTimestamp()
+    }, { merge: true });
+}
+
 export async function listTeamRegistrationForms(teamId) {
     if (!teamId) return [];
     const snapshot = await getDocs(collection(db, `teams/${teamId}/registrationForms`));

--- a/js/tracking-status-admin.js
+++ b/js/tracking-status-admin.js
@@ -1,0 +1,65 @@
+export function normalizeTrackingItemDraft(draft = {}) {
+    const title = String(draft.title || '').trim();
+    if (!title) {
+        throw new Error('Tracking item title is required');
+    }
+
+    return {
+        title,
+        scope: 'players',
+        active: true
+    };
+}
+
+export function getActiveRosterPlayers(players = []) {
+    return players.filter((player) => player && player.active !== false);
+}
+
+export function mergeTrackingStatusRows(players = [], statuses = []) {
+    const statusByPlayerId = new Map();
+    statuses.forEach((status) => {
+        const playerId = status?.playerId || status?.id;
+        if (playerId) {
+            statusByPlayerId.set(playerId, status);
+        }
+    });
+
+    return getActiveRosterPlayers(players).map((player) => {
+        const status = statusByPlayerId.get(player.id) || {};
+        const complete = status.complete === true || status.status === 'complete';
+        return {
+            player,
+            status,
+            complete
+        };
+    });
+}
+
+export function summarizeTrackingStatus(rows = []) {
+    const total = rows.length;
+    const complete = rows.filter((row) => row.complete === true).length;
+    return {
+        total,
+        complete,
+        incomplete: Math.max(total - complete, 0)
+    };
+}
+
+export function buildTrackingStatusPayload({ teamId, itemId, player, complete, actorId, actorEmail } = {}) {
+    if (!teamId) throw new Error('Team ID is required');
+    if (!itemId) throw new Error('Tracking item ID is required');
+    if (!player?.id) throw new Error('Player is required');
+
+    return {
+        teamId,
+        trackingItemId: itemId,
+        playerId: player.id,
+        playerName: player.name || '',
+        playerNumber: player.number || '',
+        memberType: 'player',
+        status: complete ? 'complete' : 'incomplete',
+        complete: complete === true,
+        updatedBy: actorId || null,
+        updatedByEmail: actorEmail || null
+    };
+}

--- a/tests/smoke/edit-roster-bulk-ai-reset.spec.js
+++ b/tests/smoke/edit-roster-bulk-ai-reset.spec.js
@@ -47,6 +47,16 @@ export async function listTeamRegistrationReviews() {
 }
 export async function approveTeamRegistration() {}
 export async function rejectTeamRegistration() {}
+export async function listTeamTrackingItems() {
+    return [];
+}
+export async function createTeamTrackingItem() {
+    return 'tracking-item-1';
+}
+export async function listTeamTrackingStatuses() {
+    return [];
+}
+export async function setTeamTrackingStatus() {}
 `;
 
 const UTILS_STUB = `

--- a/tests/unit/edit-roster-tracking-status.test.js
+++ b/tests/unit/edit-roster-tracking-status.test.js
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readEditRoster() {
+    return readFileSync(new URL('../../edit-roster.html', import.meta.url), 'utf8');
+}
+
+describe('edit roster tracking status matrix wiring', () => {
+    it('binds async renders and status writes to the captured tracking item and roster snapshot', () => {
+        const source = readEditRoster();
+
+        expect(source).toContain('let trackingStatusRenderToken = 0;');
+        expect(source).toContain('const renderToken = ++trackingStatusRenderToken;');
+        expect(source).toContain('const trackingItemId = selectedTrackingItemId;');
+        expect(source).toContain('const rosterPlayers = [...latestRosterPlayers];');
+        expect(source).toContain('if (renderToken !== trackingStatusRenderToken || trackingItemId !== selectedTrackingItemId)');
+        expect(source).toContain('const player = rosterPlayers.find((item) => item.id === checkbox.dataset.playerId);');
+        expect(source).toContain('itemId: trackingItemId');
+        expect(source).toContain('await setTeamTrackingStatus(currentTeamId, trackingItemId, player.id, payload);');
+    });
+});

--- a/tests/unit/tracking-status-admin.test.js
+++ b/tests/unit/tracking-status-admin.test.js
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildTrackingStatusPayload,
+    getActiveRosterPlayers,
+    mergeTrackingStatusRows,
+    normalizeTrackingItemDraft,
+    summarizeTrackingStatus
+} from '../../js/tracking-status-admin.js';
+
+describe('tracking status admin helpers', () => {
+    it('normalizes player-scoped tracking items', () => {
+        expect(normalizeTrackingItemDraft({ title: ' Medical release ' })).toEqual({
+            title: 'Medical release',
+            scope: 'players',
+            active: true
+        });
+        expect(() => normalizeTrackingItemDraft({ title: '   ' })).toThrow('Tracking item title');
+    });
+
+    it('builds rows for active roster players with persisted completion states', () => {
+        const players = [
+            { id: 'p1', name: 'Ava', number: '3' },
+            { id: 'p2', name: 'Sam', number: '7', active: false },
+            { id: 'p3', name: 'Kai' }
+        ];
+        const rows = mergeTrackingStatusRows(players, [
+            { id: 'p1', playerId: 'p1', status: 'complete' },
+            { id: 'p3', playerId: 'p3', complete: false }
+        ]);
+
+        expect(getActiveRosterPlayers(players).map((player) => player.id)).toEqual(['p1', 'p3']);
+        expect(rows.map((row) => ({ id: row.player.id, complete: row.complete }))).toEqual([
+            { id: 'p1', complete: true },
+            { id: 'p3', complete: false }
+        ]);
+        expect(summarizeTrackingStatus(rows)).toEqual({
+            total: 2,
+            complete: 1,
+            incomplete: 1
+        });
+    });
+
+    it('builds auditable per-player status payloads', () => {
+        expect(buildTrackingStatusPayload({
+            teamId: 'team-1',
+            itemId: 'item-1',
+            player: { id: 'p1', name: 'Ava', number: '3' },
+            complete: true,
+            actorId: 'admin-1',
+            actorEmail: 'coach@example.com'
+        })).toEqual({
+            teamId: 'team-1',
+            trackingItemId: 'item-1',
+            playerId: 'p1',
+            playerName: 'Ava',
+            playerNumber: '3',
+            memberType: 'player',
+            status: 'complete',
+            complete: true,
+            updatedBy: 'admin-1',
+            updatedByEmail: 'coach@example.com'
+        });
+    });
+});

--- a/tests/unit/tracking-status-rules.test.js
+++ b/tests/unit/tracking-status-rules.test.js
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('tracking status Firestore rules', () => {
+    it('restricts tracking item and member status writes to team admins', () => {
+        const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+
+        expect(rules).toContain('match /trackingItems/{itemId}');
+        expect(rules).toContain('match /memberTracking/{playerId}');
+        expect(rules).toContain('allow read: if isTeamOwnerOrAdmin(teamId);');
+        expect(rules).toContain('allow create, update: if isTeamOwnerOrAdmin(teamId)');
+        expect(rules).toContain("request.resource.data.get('status', 'incomplete') in ['complete', 'incomplete']");
+    });
+});

--- a/tests/unit/tracking-status-rules.test.js
+++ b/tests/unit/tracking-status-rules.test.js
@@ -6,9 +6,8 @@ describe('tracking status Firestore rules', () => {
         const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
 
         expect(rules).toContain('match /trackingItems/{itemId}');
-        expect(rules).toContain('match /memberTracking/{playerId}');
-        expect(rules).toContain('allow read: if isTeamOwnerOrAdmin(teamId);');
-        expect(rules).toContain('allow create, update: if isTeamOwnerOrAdmin(teamId)');
-        expect(rules).toContain("request.resource.data.get('status', 'incomplete') in ['complete', 'incomplete']");
+        expect(rules).toContain('match /memberTracking/{trackingId}');
+        expect(rules).toContain('allow read: if isTeamOwnerOrAdmin(teamId) || canReadPublicTrackingStatus(teamId, resource.data);');
+        expect(rules).toContain('allow create, update, delete: if isTeamOwnerOrAdmin(teamId);');
     });
 });


### PR DESCRIPTION
Closes #793

## Summary
- Added an admin roster tracking section to `edit-roster.html` for creating/selecting player-scoped tracking items.
- Added per-player complete/incomplete toggles with persisted Firestore status records and completion counts.
- Added Firestore rules so only team owners/admins can read or write tracking items and member status records.

## Validation
- `npx vitest run tests/unit/tracking-status-admin.test.js tests/unit/tracking-status-rules.test.js --reporter=dot`
- `npx vitest run tests/unit/edit-team-admin-access-persistence.test.js --reporter=dot`
- `node scripts/check-critical-cache-bust.mjs`