### PR TITLE
Preserve game metadata when editing schedule

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -1916,7 +1916,11 @@
                             countsTowardSeasonRecord: event.countsTowardSeasonRecord
                         }),
                         arrivalTime: event.arrivalTime || null,
+                        statTrackerConfigId: event.statTrackerConfigId || null,
                         assignments: Array.isArray(event.assignments) ? event.assignments : [],
+                        officiatingSlots: Array.isArray(event.officiatingSlots) ? event.officiatingSlots : [],
+                        officiatingSelfAssignmentEnabled: event.officiatingSelfAssignmentEnabled === true,
+                        officiatingCoverageStatus: event.officiatingCoverageStatus || null,
                         rsvpSummary: event.rsvpSummary || null,
                         status: event.status,
                         sourceMetadata: event.sourceMetadata || null,

--- a/tests/unit/edit-schedule-stat-config-selection.test.js
+++ b/tests/unit/edit-schedule-stat-config-selection.test.js
@@ -42,4 +42,19 @@ describe('edit schedule stat config selection', () => {
         expect(trackBlock).toContain('statTrackerConfigId: configId || null,');
         expect(trackBlock).not.toContain('getSelectedOrDefaultConfigId');
     });
+
+    it('keeps stat config and officiating metadata when caching database games for editing', () => {
+        const source = readEditSchedule();
+
+        const loadStart = source.indexOf('const eventRecord = {');
+        const loadEnd = source.indexOf('                    allEvents.push(eventRecord);', loadStart);
+        expect(loadStart).toBeGreaterThanOrEqual(0);
+        expect(loadEnd).toBeGreaterThan(loadStart);
+
+        const eventRecordBlock = source.slice(loadStart, loadEnd);
+        expect(eventRecordBlock).toContain('statTrackerConfigId: event.statTrackerConfigId || null,');
+        expect(eventRecordBlock).toContain('officiatingSlots: Array.isArray(event.officiatingSlots) ? event.officiatingSlots : [],');
+        expect(eventRecordBlock).toContain('officiatingSelfAssignmentEnabled: event.officiatingSelfAssignmentEnabled === true,');
+        expect(eventRecordBlock).toContain('officiatingCoverageStatus: event.officiatingCoverageStatus || null,');
+    });
 });


### PR DESCRIPTION
Closes #830

## Summary
- Preserve `statTrackerConfigId` when database games are projected into the edit schedule cache.
- Preserve officiating slot metadata, self-assignment state, and coverage status so editing normal fields does not silently clear assignments.
- Added unit coverage to lock the cached database game projection behavior.

## Validation
- `npx vitest run tests/unit/edit-schedule-stat-config-selection.test.js tests/unit/officiating-slots.test.js --reporter=dot`