### PR TITLE
Preserve live playing time on finish

### DIFF
--- a/tests/unit/track-live-finish-time.test.js
+++ b/tests/unit/track-live-finish-time.test.js
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+describe('track-live finish playing time persistence', () => {
+    it('saves current player field elapsed time when completing a live game', () => {
+        const source = readFileSync(new URL('../../track-live.html', import.meta.url), 'utf8');
+        const finishStatsBlock = source.match(/\/\/ 2\. Write aggregated stats for each player[\s\S]*?\/\/ 3\. Update game document with final data/)?.[0] || '';
+
+        expect(finishStatsBlock).toContain('const timeMs = getPlayerFieldElapsedMs(');
+        expect(finishStatsBlock).toContain('gameState.playerFieldStatus');
+        expect(finishStatsBlock).toContain('gameState.isRunning ? Date.now() : null');
+        expect(finishStatsBlock).toMatch(/batch\.set\(statsRef, \{[\s\S]*stats: stats,[\s\S]*timeMs[\s\S]*\}\);/);
+    });
+});

--- a/track-live.html
+++ b/track-live.html
@@ -3170,11 +3170,17 @@ Write the match report now:`;
                 Object.entries(gameState.playerStats).forEach(([playerId, stats]) => {
                     const player = players.find(p => p.id === playerId);
                     if (player) {
+                        const timeMs = getPlayerFieldElapsedMs(
+                            gameState.playerFieldStatus,
+                            playerId,
+                            gameState.isRunning ? Date.now() : null
+                        );
                         const statsRef = doc(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`, playerId);
                         batch.set(statsRef, {
                             playerName: player.name,
                             playerNumber: player.number,
-                            stats: stats
+                            stats: stats,
+                            timeMs
                         });
                     }
                 });


### PR DESCRIPTION
Closes #832

## Summary
- Persist the current `timeMs` value when Test Track Live writes final aggregated player stats.
- Added focused unit coverage to guard that the finish path includes elapsed field time in the completed-game save.

## Validation
- `npx vitest run tests/unit/track-live-finish-time.test.js`