### PR TITLE
Show standalone practice sessions on parent dashboard

### DIFF
--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -1088,8 +1088,9 @@
                 const sessions = [];
                 const matchedSessionIds = new Set();
                 visibleSessions.forEach((session) => {
-                    if (!session?.eventId) return;
-                    sessionsByEventId.set(session.eventId, session);
+                    if (session?.eventId) {
+                        sessionsByEventId.set(session.eventId, session);
+                    }
                     sessions.push({
                         ...session,
                         _parsedDate: toDateSafe(session.date)

--- a/tests/unit/parent-dashboard-practice-sessions-wiring.test.js
+++ b/tests/unit/parent-dashboard-practice-sessions-wiring.test.js
@@ -13,4 +13,11 @@ describe('parent dashboard practice session cancellation wiring', () => {
         expect(html).toContain('filterVisiblePracticeSessions(practiceSessions, dbGames)');
         expect(html).toContain('filterVisiblePracticeSessions(sessions || [], dbGames)');
     });
+
+    it('does not drop standalone sessions before fallback schedule rendering', () => {
+        const html = readRepoFile('parent-dashboard.html');
+
+        expect(html).not.toContain('if (!session?.eventId) return;');
+        expect(html).toContain('if (session?.eventId) {\n                        sessionsByEventId.set(session.eventId, session);\n                    }');
+    });
 });

--- a/tests/unit/parent-dashboard-practice-sessions.test.js
+++ b/tests/unit/parent-dashboard-practice-sessions.test.js
@@ -56,4 +56,15 @@ describe('parent dashboard practice session visibility', () => {
         expect(isCancelledPracticeSession(session, [])).toBe(false);
         expect(filterVisiblePracticeSessions([session], []).map((candidate) => candidate.id)).toEqual(['draft-session']);
     });
+
+    it('keeps standalone draft sessions without event IDs visible', () => {
+        const session = {
+            id: 'standalone-draft',
+            eventId: null,
+            date: '2026-03-24T18:00:00.000Z'
+        };
+
+        expect(isCancelledPracticeSession(session, [])).toBe(false);
+        expect(filterVisiblePracticeSessions([session], []).map((candidate) => candidate.id)).toEqual(['standalone-draft']);
+    });
 });


### PR DESCRIPTION
Closes #834

## Summary
- Keep visible practice sessions in the parent dashboard schedule candidate list even when they do not have an `eventId`.
- Only index sessions by event ID when one exists, preserving linked schedule matching while allowing fallback rendering for standalone drafts/planned sessions.
- Added focused unit coverage for eventId-less standalone sessions and wiring coverage to prevent the early filter from returning.

## Tests
- `npx vitest run tests/unit/parent-dashboard-practice-sessions.test.js tests/unit/parent-dashboard-practice-sessions-wiring.test.js`