### PR TITLE
Add team calendar sync controls

### DIFF
--- a/team.html
+++ b/team.html
@@ -198,6 +198,15 @@
                                 </svg>
                                 .ics
                             </button>
+                            <button id="sync-calendar"
+                                class="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-emerald-700 bg-emerald-50 rounded-lg hover:bg-emerald-100 transition border border-emerald-200">
+                                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
+                                        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z">
+                                    </path>
+                                </svg>
+                                Sync Calendar
+                            </button>
                         </div>
                     </div>
                     <div class="px-6 py-3 border-b border-gray-100 bg-gray-50">
@@ -255,6 +264,42 @@
                 </button>
             </div>
             <div id="schedule-day-modal-content" class="px-6 py-5"></div>
+        </div>
+    </div>
+
+    <div id="sync-calendar-modal" class="hidden fixed inset-0 z-50">
+        <div id="sync-calendar-backdrop" class="absolute inset-0 bg-black/50"></div>
+        <div class="relative z-10 min-h-full flex items-center justify-center p-4">
+            <div class="bg-white rounded-2xl shadow-2xl max-w-lg w-full overflow-hidden">
+                <div class="flex items-center justify-between px-6 py-4 border-b border-gray-100">
+                    <div>
+                        <p class="text-xs uppercase tracking-wide text-emerald-600 font-semibold">Live schedule feed</p>
+                        <h3 class="text-lg font-bold text-gray-900">Sync Calendar</h3>
+                    </div>
+                    <button id="sync-calendar-close" class="text-gray-400 hover:text-gray-700">
+                        <span class="sr-only">Close</span>
+                        <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path></svg>
+                    </button>
+                </div>
+                <div class="px-6 py-5 space-y-4">
+                    <p class="text-sm text-gray-600">Subscribe once to keep this team schedule updated in your personal calendar.</p>
+                    <div class="grid gap-3">
+                        <button id="sync-calendar-apple" class="w-full text-left px-4 py-3 rounded-xl border border-gray-200 hover:border-emerald-300 hover:bg-emerald-50 transition">
+                            <span class="block text-sm font-semibold text-gray-900">Apple Calendar</span>
+                            <span class="block text-xs text-gray-500">Open a webcal subscription link.</span>
+                        </button>
+                        <button id="sync-calendar-google" class="w-full text-left px-4 py-3 rounded-xl border border-gray-200 hover:border-emerald-300 hover:bg-emerald-50 transition">
+                            <span class="block text-sm font-semibold text-gray-900">Google Calendar</span>
+                            <span class="block text-xs text-gray-500">Open Google Calendar add-calendar flow.</span>
+                        </button>
+                        <button id="sync-calendar-copy" class="w-full text-left px-4 py-3 rounded-xl border border-gray-200 hover:border-emerald-300 hover:bg-emerald-50 transition">
+                            <span class="block text-sm font-semibold text-gray-900">Copy Link</span>
+                            <span class="block text-xs text-gray-500">Copy the private HTTPS subscription URL.</span>
+                        </button>
+                    </div>
+                    <p id="sync-calendar-feedback" class="text-sm text-gray-600" aria-live="polite"></p>
+                </div>
+            </div>
         </div>
     </div>
 
@@ -2253,6 +2298,86 @@
             return `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}T${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}Z`;
         }
 
+        function getPrivateCalendarFeedUrl() {
+            const directUrl = currentTeam?.privateCalendarFeedUrl ||
+                currentTeam?.calendarSubscriptionUrl ||
+                currentTeam?.calendarFeedUrl ||
+                currentTeam?.teamCalendarFeedUrl;
+            if (typeof directUrl === 'string' && directUrl.trim()) {
+                return directUrl.trim().replace(/^webcal:\/\//i, 'https://');
+            }
+
+            const token = currentTeam?.calendarSubscriptionToken ||
+                currentTeam?.privateCalendarToken ||
+                currentTeam?.calendarFeedToken ||
+                currentTeam?.teamCalendarToken;
+            if (!token || !currentTeamId) return '';
+
+            const configuredUrl = window.__ALLPLAYS_CONFIG__?.privateTeamCalendarIcsFunctionUrl || window.ALLPLAYS_PRIVATE_TEAM_CALENDAR_ICS_URL;
+            const fallbackUrl = window.__ALLPLAYS_CONFIG__?.calendarFetchFunctionUrl || window.ALLPLAYS_CALENDAR_FUNCTION_URL;
+            const baseUrl = (typeof configuredUrl === 'string' && configuredUrl.trim())
+                ? configuredUrl.trim()
+                : (typeof fallbackUrl === 'string' && fallbackUrl.includes('fetchCalendarIcs')
+                    ? fallbackUrl.replace('fetchCalendarIcs', 'privateTeamCalendarIcs')
+                    : 'https://us-central1-all-plays-prod.cloudfunctions.net/privateTeamCalendarIcs');
+            const separator = baseUrl.includes('?') ? '&' : '?';
+            return `${baseUrl}${separator}teamId=${encodeURIComponent(currentTeamId)}&token=${encodeURIComponent(token)}`;
+        }
+
+        function getAppleCalendarFeedUrl(feedUrl) {
+            return feedUrl.replace(/^https?:\/\//i, 'webcal://');
+        }
+
+        function getGoogleCalendarFeedUrl(feedUrl) {
+            return `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(feedUrl)}`;
+        }
+
+        function setSyncCalendarFeedback(message, tone = 'neutral') {
+            const feedback = document.getElementById('sync-calendar-feedback');
+            if (!feedback) return;
+            feedback.textContent = message;
+            feedback.className = `text-sm ${tone === 'error' ? 'text-red-600' : tone === 'success' ? 'text-emerald-700' : 'text-gray-600'}`;
+        }
+
+        function openSyncCalendarModal() {
+            const feedUrl = getPrivateCalendarFeedUrl();
+            document.getElementById('sync-calendar-modal')?.classList.remove('hidden');
+            setSyncCalendarFeedback(feedUrl ? 'Choose where to subscribe, or copy the private link.' : 'Calendar subscription link is not available yet.', feedUrl ? 'neutral' : 'error');
+        }
+
+        function closeSyncCalendarModal() {
+            document.getElementById('sync-calendar-modal')?.classList.add('hidden');
+        }
+
+        async function copyPrivateCalendarFeedUrl(feedUrl) {
+            if (!feedUrl) {
+                setSyncCalendarFeedback('Calendar subscription link is not available yet.', 'error');
+                return;
+            }
+            try {
+                if (navigator.clipboard?.writeText) {
+                    await navigator.clipboard.writeText(feedUrl);
+                } else {
+                    const input = document.createElement('textarea');
+                    input.value = feedUrl;
+                    input.setAttribute('readonly', '');
+                    input.style.position = 'fixed';
+                    input.style.left = '-9999px';
+                    document.body.appendChild(input);
+                    input.select();
+                    const copied = document.execCommand('copy');
+                    document.body.removeChild(input);
+                    if (!copied) throw new Error('Copy command failed');
+                }
+                setSyncCalendarFeedback('Subscription link copied.', 'success');
+                showToast('Calendar link copied!');
+            } catch (error) {
+                console.error('Failed to copy calendar feed URL:', error);
+                setSyncCalendarFeedback('Could not copy the link. Select Copy Link again or try manually.', 'error');
+                showToast('Failed to copy calendar link.');
+            }
+        }
+
         function buildIcs(games) {
             const teamName = currentTeam?.name || 'Team';
             const lines = ['BEGIN:VCALENDAR', 'VERSION:2.0', 'PRODID:-//ALL PLAYS//EN'];
@@ -2297,6 +2422,31 @@
             link.click();
             document.body.removeChild(link);
             URL.revokeObjectURL(url);
+        });
+
+        document.getElementById('sync-calendar')?.addEventListener('click', openSyncCalendarModal);
+        document.getElementById('sync-calendar-close')?.addEventListener('click', closeSyncCalendarModal);
+        document.getElementById('sync-calendar-backdrop')?.addEventListener('click', closeSyncCalendarModal);
+        document.getElementById('sync-calendar-apple')?.addEventListener('click', () => {
+            const feedUrl = getPrivateCalendarFeedUrl();
+            if (!feedUrl) {
+                setSyncCalendarFeedback('Calendar subscription link is not available yet.', 'error');
+                return;
+            }
+            window.open(getAppleCalendarFeedUrl(feedUrl), '_blank', 'noopener');
+            setSyncCalendarFeedback('Opening Apple Calendar subscription.', 'success');
+        });
+        document.getElementById('sync-calendar-google')?.addEventListener('click', () => {
+            const feedUrl = getPrivateCalendarFeedUrl();
+            if (!feedUrl) {
+                setSyncCalendarFeedback('Calendar subscription link is not available yet.', 'error');
+                return;
+            }
+            window.open(getGoogleCalendarFeedUrl(feedUrl), '_blank', 'noopener');
+            setSyncCalendarFeedback('Opening Google Calendar subscription.', 'success');
+        });
+        document.getElementById('sync-calendar-copy')?.addEventListener('click', () => {
+            copyPrivateCalendarFeedUrl(getPrivateCalendarFeedUrl());
         });
 
         // Practice filter

--- a/tests/unit/team-calendar-sync.test.js
+++ b/tests/unit/team-calendar-sync.test.js
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readTeamPage() {
+    return readFileSync(new URL('../../team.html', import.meta.url), 'utf8');
+}
+
+function readWorkflowSchedule() {
+    return readFileSync(new URL('../../workflow-schedule.html', import.meta.url), 'utf8');
+}
+
+describe('team calendar sync controls', () => {
+    it('adds Sync Calendar controls next to the static ICS export', () => {
+        const source = readTeamPage();
+
+        expect(source).toContain('id="download-ics"');
+        expect(source).toContain('id="sync-calendar"');
+        expect(source).toContain('Sync Calendar');
+        expect(source).toContain('id="sync-calendar-apple"');
+        expect(source).toContain('Apple Calendar');
+        expect(source).toContain('id="sync-calendar-google"');
+        expect(source).toContain('Google Calendar');
+        expect(source).toContain('id="sync-calendar-copy"');
+        expect(source).toContain('Copy Link');
+    });
+
+    it('builds Apple, Google, and HTTPS private feed URLs', () => {
+        const source = readTeamPage();
+
+        expect(source).toContain("function getPrivateCalendarFeedUrl()");
+        expect(source).toContain("currentTeam?.calendarSubscriptionUrl");
+        expect(source).toContain("currentTeam?.calendarSubscriptionToken");
+        expect(source).toContain("privateTeamCalendarIcs");
+        expect(source).toContain("return feedUrl.replace(/^https?:\\/\\//i, 'webcal://');");
+        expect(source).toContain("https://calendar.google.com/calendar/render?cid=${encodeURIComponent(feedUrl)}");
+        expect(source).toContain("navigator.clipboard.writeText(feedUrl)");
+    });
+
+    it('documents live personal calendar sync while preserving static export guidance', () => {
+        const source = readWorkflowSchedule();
+
+        expect(source).toContain('Use <strong>Sync Calendar</strong>');
+        expect(source).toContain('Apple Calendar');
+        expect(source).toContain('Google Calendar');
+        expect(source).toContain('copy the private HTTPS subscription link');
+        expect(source).toContain('Use the existing <code>.ics</code> export');
+    });
+});

--- a/workflow-schedule.html
+++ b/workflow-schedule.html
@@ -328,7 +328,7 @@
 <li>Import from another calendar: complete Step 2, then Step 7 for any games you need to track.</li>
 <li>Prepare game execution: use Step 8 and Step 9.</li>
 <li>Share live or replay access with families: use Step 10.</li>
-<li>Validate final visibility and export views: use Step 11.</li>
+<li>Validate final visibility, personal calendar sync, and export views: use Step 11.</li>
 </ol>
 <h2 id="step-by-step-workflow">Step-by-Step Workflow</h2>
 <ol class="ml-6 list-decimal space-y-1">
@@ -391,6 +391,8 @@
 <li>Validate visibility and export.</li>
 </ol>
 <p>In <code>team.html</code>, review list and calendar views and check live/replay/report links.</p>
+<p>Use <strong>Sync Calendar</strong> near the schedule export actions to subscribe through Apple Calendar, open the Google Calendar add-calendar flow, or copy the private HTTPS subscription link.</p>
+<p>Use the existing <code>.ics</code> export when you need a one-time static schedule file.</p>
 <p>In <code>calendar.html</code>, use filters (view, range, type, team), verify availability status, and export <code>.ics</code> when needed.</p>
 <h2 id="common-questions">Common Questions</h2>
 <ul class="ml-6 list-disc space-y-1">
@@ -412,7 +414,7 @@
 <ul class="ml-6 list-disc space-y-1">
 <li><strong>What is the fastest way to share with families?</strong></li>
 </ul>
-<p>Use <code>Share</code> from schedule or team cards.</p>
+<p>Use <code>Share</code> from schedule or team cards. Use <code>Sync Calendar</code> on the team schedule when families want a live personal calendar subscription instead of a one-time file export.</p>
 <h2 id="recovery-troubleshooting">Recovery &amp; Troubleshooting</h2>
 <ul class="ml-6 list-disc space-y-1">
 <li>Event missing after save: check filters, enable <code>Show Practices</code>, and confirm <code>Upcoming</code> vs <code>Past</code>.</li>


### PR DESCRIPTION
Closes #838

## Summary
- Added a Sync Calendar control beside the existing team schedule `.ics` export.
- Added a sync dialog with Apple Calendar, Google Calendar, and Copy Link actions wired to the private HTTPS feed URL.
- Documented the new live subscription workflow while preserving the one-time `.ics` export guidance.

## Validation
- `npx vitest run tests/unit/team-calendar-sync.test.js`