### PR TITLE
Fix admin dashboard game stats scope

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -86,6 +86,8 @@ async function loadGameStats() {
 
 function updateDashboard() {
     const visibleTeams = getVisibleTeams();
+    const visibleTeamIds = new Set(visibleTeams.map(team => team.id));
+    const visibleGames = allGames.filter(game => visibleTeamIds.has(game.teamId));
     const now = new Date();
     const sevenDaysAgo = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
     const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
@@ -101,13 +103,13 @@ function updateDashboard() {
     document.getElementById('stat-users-growth').textContent = `+${newUsersLast30} this month`;
 
     // Total games
-    const completedGames = allGames.filter(g => g.status === 'completed').length;
-    const scheduledGames = allGames.filter(g => g.status === 'scheduled').length;
-    document.getElementById('stat-total-games').textContent = allGames.length;
+    const completedGames = visibleGames.filter(g => g.status === 'completed').length;
+    const scheduledGames = visibleGames.filter(g => g.status === 'scheduled').length;
+    document.getElementById('stat-total-games').textContent = visibleGames.length;
     document.getElementById('stat-games-breakdown').textContent = `${completedGames} played, ${scheduledGames} scheduled`;
 
     // Activity (teams with games in last 7 days)
-    const activeTeams = new Set(allGames.filter(g => {
+    const activeTeams = new Set(visibleGames.filter(g => {
         const gameDate = g.date.toDate ? g.date.toDate() : new Date(g.date);
         return gameDate > sevenDaysAgo;
     }).map(g => g.teamId)).size;
@@ -132,7 +134,7 @@ function updateDashboard() {
     // Team details
     const publicTeams = visibleTeams.filter(t => t.isPublic !== false).length;
     const privateTeams = visibleTeams.length - publicTeams;
-    const teamsWithGames = new Set(allGames.map(g => g.teamId)).size;
+    const teamsWithGames = new Set(visibleGames.map(g => g.teamId)).size;
     document.getElementById('stat-team-details').innerHTML = `
         <div class="flex justify-between items-center">
             <span class="text-gray-700">Public</span>

--- a/tests/unit/admin-dashboard-stats.test.js
+++ b/tests/unit/admin-dashboard-stats.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+
+describe('admin dashboard statistics scope', () => {
+    it('calculates game-based dashboard stats from the visible team set', () => {
+        const adminJs = fs.readFileSync('js/admin.js', 'utf8');
+
+        expect(adminJs).toContain('const visibleTeams = getVisibleTeams();');
+        expect(adminJs).toContain('const visibleTeamIds = new Set(visibleTeams.map(team => team.id));');
+        expect(adminJs).toContain('const visibleGames = allGames.filter(game => visibleTeamIds.has(game.teamId));');
+        expect(adminJs).toContain("document.getElementById('stat-total-games').textContent = visibleGames.length;");
+        expect(adminJs).toContain('const activeTeams = new Set(visibleGames.filter(g => {');
+        expect(adminJs).toContain('const teamsWithGames = new Set(visibleGames.map(g => g.teamId)).size;');
+    });
+});


### PR DESCRIPTION
Closes #843

## Summary
- Filter admin dashboard game-based metrics to the currently visible team set.
- Keep Total Games, Activity (7d), and With Games aligned with the Show inactive toggle.
- Add unit coverage verifying the dashboard uses visible games for those metrics.

## Validation
- `npm test -- tests/unit/admin-dashboard-stats.test.js`