### PR TITLE
Honor streaming team permissions

### DIFF
--- a/game-day.html
+++ b/game-day.html
@@ -957,7 +957,8 @@
                 state.game = game;
 
                 const needsRsvpForScopedAccess = ['confirmed_members', 'all_confirmed'].includes(String(team.streamAccessMode || '').toLowerCase())
-                    || String(team.teamPermissions?.scorekeeping?.mode || '').toLowerCase() === 'all_confirmed';
+                    || String(team.teamPermissions?.scorekeeping?.mode || '').toLowerCase() === 'all_confirmed'
+                    || String(team.teamPermissions?.streaming?.mode || '').toLowerCase() === 'all_confirmed';
                 const scopedRsvp = needsRsvpForScopedAccess
                     ? await getMyRsvp(teamId, resolvedGameId, state.user.uid).catch(() => null)
                     : null;

--- a/js/team-access.js
+++ b/js/team-access.js
@@ -51,6 +51,17 @@ export function hasStreamTeamAccess(user, team, game = null, rsvp = null) {
   if (!user || !team || !isScheduledGame(game)) return false;
   if (hasFullTeamAccess(user, team)) return true;
 
+  if (team.teamPermissions?.streaming) {
+    const permissions = normalizeTeamPermissions(team.teamPermissions);
+    const streaming = permissions.streaming;
+    if (streaming.mode === 'all_confirmed' && hasConfirmedRsvp(rsvp)) {
+      return true;
+    }
+    if (streaming.mode === 'selected' && normalizeMemberIdList(streaming.memberIds).includes(String(user.uid || '').trim())) {
+      return true;
+    }
+  }
+
   const mode = String(team.streamAccessMode || 'admins').trim().toLowerCase();
   if (mode === 'confirmed_members' || mode === 'all_confirmed') {
     return hasConfirmedRsvp(rsvp);

--- a/tests/unit/game-day-rsvp-controls.test.js
+++ b/tests/unit/game-day-rsvp-controls.test.js
@@ -119,4 +119,10 @@ describe('game day RSVP wiring', () => {
         expect(source).toContain('window.setCoachPlayerRsvp = gameDayRsvpController.setCoachPlayerRsvp;');
         expect(source).toContain('gameDayRsvpController.renderRsvpPanel();');
     });
+
+    it('loads RSVP context for all-confirmed streaming team permissions', () => {
+        const source = readFileSync(resolve(process.cwd(), 'game-day.html'), 'utf8');
+
+        expect(source).toContain("String(team.teamPermissions?.streaming?.mode || '').toLowerCase() === 'all_confirmed'");
+    });
 });

--- a/tests/unit/team-access.test.js
+++ b/tests/unit/team-access.test.js
@@ -76,6 +76,36 @@ describe('team access helpers', () => {
     expect(hasStreamTeamAccess({ uid: 'u6', email: 'parent@example.com' }, team, game, { response: 'maybe' })).toBe(false);
   });
 
+  it('grants limited stream access to selected team permission members', () => {
+    const team = {
+      ...TEAM,
+      teamPermissions: {
+        streaming: { mode: 'selected', memberIds: [' selected-user ', 'selected-user'] }
+      }
+    };
+    const game = { id: 'game-1', status: 'scheduled' };
+
+    expect(hasStreamTeamAccess({ uid: 'selected-user', email: 'parent@example.com' }, team, game)).toBe(true);
+    expect(getTeamAccessInfo({ uid: 'selected-user', email: 'parent@example.com' }, team, { game })).toEqual({
+      hasAccess: true,
+      accessLevel: 'stream',
+      exitUrl: 'team.html#teamId=team-1'
+    });
+  });
+
+  it('grants limited stream access to all confirmed team permission members', () => {
+    const team = {
+      ...TEAM,
+      teamPermissions: {
+        streaming: { mode: 'all_confirmed' }
+      }
+    };
+    const game = { id: 'game-1', status: 'scheduled' };
+
+    expect(hasStreamTeamAccess({ uid: 'u6', email: 'parent@example.com' }, team, game, { response: 'going' })).toBe(true);
+    expect(hasStreamTeamAccess({ uid: 'u6', email: 'parent@example.com' }, team, game, { response: 'maybe' })).toBe(false);
+  });
+
   it('denies limited stream access to unrelated users', () => {
     const team = { ...TEAM, streamAccessMode: 'selected_volunteers', streamVolunteerEmails: ['video@example.com'] };
     const game = { id: 'game-1', status: 'scheduled' };


### PR DESCRIPTION
Closes #845

## Summary
- Updated Game Day stream access checks to honor `team.teamPermissions.streaming` for selected confirmed members and all-confirmed members.
- Ensured Game Day loads RSVP context when all-confirmed streaming permissions require it.
- Added focused unit coverage for selected streaming members, all-confirmed streaming members, and Game Day RSVP wiring.

## Tests
- `npx vitest run tests/unit/team-access.test.js tests/unit/game-day-rsvp-controls.test.js`