### PR TITLE
Allow platform admins to load organization teams

### DIFF
--- a/organization-schedule.html
+++ b/organization-schedule.html
@@ -140,7 +140,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { addGame, getTeam, getUserTeamsWithAccess } from './js/db.js?v=29';
+        import { addGame, getTeam, getTeams, getUserTeamsWithAccess } from './js/db.js?v=29';
         import { parseCsvText } from './js/schedule-csv-import.js?v=2';
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=10';
         import { checkAuth } from './js/auth.js?v=13';
@@ -176,8 +176,6 @@
         const organizationNameEl = document.getElementById('organization-context-name');
         const organizationDetailEl = document.getElementById('organization-context-detail');
         const ORGANIZATION_CSV_IMPORT_ROW_LIMIT = 500;
-
-        const MAX_ORGANIZATION_SCHEDULE_CSV_IMPORT_ROWS = 500;
 
         let currentUser = null;
         let anchorTeam = null;
@@ -381,7 +379,9 @@
                 return;
             }
 
-            accessibleTeams = await getUserTeamsWithAccess(currentUser.uid, currentUser.email);
+            accessibleTeams = currentUser.isAdmin === true
+                ? await getTeams()
+                : await getUserTeamsWithAccess(currentUser.uid, currentUser.email);
             organizationTeams = getOrganizationTeams({
                 accessibleTeams,
                 organizationOwnerId: anchorTeam.ownerId

--- a/tests/unit/organization-schedule.test.js
+++ b/tests/unit/organization-schedule.test.js
@@ -156,6 +156,15 @@ describe('organization schedule helpers', () => {
         expect(source).toContain('preview.validRows.length > ORGANIZATION_CSV_IMPORT_ROW_LIMIT');
     });
 
+    it('loads all active teams for platform admins before organization filtering', () => {
+        const source = readFileSync(new URL('../../organization-schedule.html', import.meta.url), 'utf8');
+
+        expect(source).toContain('import { addGame, getTeam, getTeams, getUserTeamsWithAccess }');
+        expect(source).toContain('accessibleTeams = currentUser.isAdmin === true');
+        expect(source).toContain('? await getTeams()');
+        expect(source).toContain(': await getUserTeamsWithAccess(currentUser.uid, currentUser.email);');
+    });
+
     it('renders shared matchup success actions without using innerHTML', () => {
         const source = readFileSync(new URL('../../organization-schedule.html', import.meta.url), 'utf8');
 


### PR DESCRIPTION
Closes #847

## Summary
- Updated Organization Schedule so platform admins load all active teams before filtering to the anchor team's owner grouping.
- Preserved the existing owned/adminEmail team lookup for non-platform admins.
- Added focused unit coverage to lock the platform-admin loading path.

## Validation
- `npx vitest run tests/unit/organization-schedule.test.js`