### PR TITLE
Fix athlete builder name prefill

### DIFF
--- a/athlete-profile-builder.html
+++ b/athlete-profile-builder.html
@@ -526,9 +526,12 @@
             }
 
             const defaultKey = params.teamId && params.playerId ? `${params.teamId}::${params.playerId}` : '';
+            const defaultLink = defaultKey
+                ? availableLinks.find((link) => `${link.teamId}::${link.playerId}` === defaultKey)
+                : null;
             const selectedKeys = currentProfile?.seasons?.map((season) => season.seasonKey) || (defaultKey ? [defaultKey] : []);
 
-            document.getElementById('athlete-name').value = currentProfile?.athlete?.name || availableLinks[0]?.playerName || '';
+            document.getElementById('athlete-name').value = currentProfile?.athlete?.name || defaultLink?.playerName || availableLinks[0]?.playerName || '';
             document.getElementById('athlete-headline').value = currentProfile?.athlete?.headline || '';
             document.getElementById('athlete-position').value = currentProfile?.bio?.position || '';
             document.getElementById('athlete-grad-year').value = currentProfile?.bio?.graduationYear || '';

--- a/tests/unit/athlete-profile-wiring.test.js
+++ b/tests/unit/athlete-profile-wiring.test.js
@@ -30,6 +30,14 @@ describe('athlete profile wiring', () => {
         expect(source).toContain('releaseProfilePhotoPreview();');
     });
 
+    it('prefills new builder profiles from the linked athlete selected in the URL', () => {
+        const source = readFile('athlete-profile-builder.html');
+
+        expect(source).toContain("const defaultKey = params.teamId && params.playerId ? `${params.teamId}::${params.playerId}` : '';");
+        expect(source).toContain('availableLinks.find((link) => `${link.teamId}::${link.playerId}` === defaultKey)');
+        expect(source).toContain("currentProfile?.athlete?.name || defaultLink?.playerName || availableLinks[0]?.playerName || ''");
+    });
+
     it('includes a public athlete profile page with inline media rendering and share action', () => {
         const source = readFile('athlete-profile.html');
 


### PR DESCRIPTION
Closes #853

## Summary
- Prefill new athlete profile names from the linked player matching the `teamId` and `playerId` URL parameters.
- Preserve existing saved profile names and keep the first linked athlete as a fallback when no URL match exists.
- Added focused unit coverage for the builder prefill wiring.

## Validation
- `npx vitest run tests/unit/athlete-profile-wiring.test.js`