### PR TITLE
Add scoped videographer grants

### DIFF
--- a/edit-team.html
+++ b/edit-team.html
@@ -321,7 +321,7 @@
                 <div id="team-permissions-section" class="bg-emerald-50 border border-emerald-200 rounded-lg p-4 space-y-4">
                     <div>
                         <h3 class="font-semibold text-emerald-900 text-sm">Team Permissions</h3>
-                        <p class="text-xs text-emerald-700 mt-1">Choose who can help with scorekeeping and streaming without granting full admin access.</p>
+                        <p class="text-xs text-emerald-700 mt-1">Choose who can help with scorekeeping, streaming, and game video without granting full admin access.</p>
                     </div>
                     <div class="space-y-3">
                         <div class="bg-white border border-emerald-200 rounded p-3">
@@ -339,6 +339,11 @@
                                 <option value="selected">Selected confirmed members only</option>
                             </select>
                             <div id="streaming-member-list" class="mt-3 space-y-2 text-sm"></div>
+                        </div>
+                        <div class="bg-white border border-emerald-200 rounded p-3">
+                            <label class="block text-sm font-semibold text-gray-800 mb-1">Videographer Access</label>
+                            <p class="text-xs text-gray-500 mb-2">Selected confirmed members can use live-game camera/media tools. This does not grant Staff/admin access.</p>
+                            <div id="videography-member-list" class="mt-3 space-y-2 text-sm"></div>
                         </div>
                     </div>
                     <p id="team-permissions-empty" class="hidden text-xs text-emerald-700 bg-white border border-emerald-200 rounded p-2">Confirmed member selections appear after parents/members have joined the roster.</p>
@@ -429,7 +434,7 @@
         import { checkAuth, sendInviteEmail } from './js/auth.js?v=13';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { normalizeYouTubeEmbedUrl } from './js/live-stream-utils.js?v=1';
-        import { hasFullTeamAccess, normalizeAdminEmailList, normalizeStreamVolunteerEmailList, normalizeTeamPermissions } from './js/team-access.js?v=2';
+        import { hasFullTeamAccess, normalizeAdminEmailList, normalizeStreamVolunteerEmailList, normalizeTeamPermissions } from './js/team-access.js?v=3';
         import { processPendingAdminInvites, buildAdminInviteFollowUp, inviteExistingTeamAdmin } from './js/edit-team-admin-invites.js?v=4';
         import { buildRolloverAccessPreview, buildStaffAdminRolloverUpdate } from './js/rollover-access.js?v=1';
         import { buildRosterRolloverPreviewRows } from './js/roster-rollover-preview.js?v=1';
@@ -794,7 +799,7 @@
 
         function renderPermissionMemberList(kind) {
             const list = document.getElementById(`${kind}-member-list`);
-            const mode = document.getElementById(`${kind}AccessMode`).value;
+            const mode = kind === 'videography' ? 'selected' : document.getElementById(`${kind}AccessMode`).value;
             const selectedIds = new Set(getPermissionState(kind).memberIds);
             if (!list) return;
 
@@ -864,6 +869,7 @@
                 modeSelect.value = getPermissionState(kind).mode;
                 renderPermissionMemberList(kind);
             });
+            renderPermissionMemberList('videography');
             document.getElementById('team-permissions-empty').classList.toggle('hidden', confirmedTeamMembers.length > 0);
         }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -49,6 +49,16 @@ service cloud.firestore {
              );
     }
 
+    function canVideographGame(teamId, gameId) {
+      let team = get(/databases/$(database)/documents/teams/$(teamId)).data;
+      let permission = team.get('teamPermissions', {}).get('videography', {});
+      return isSignedIn() &&
+             !isTeamOwnerOrAdmin(teamId) &&
+             get(/databases/$(database)/documents/teams/$(teamId)/games/$(gameId)).data.get('status', 'scheduled') != 'cancelled' &&
+             get(/databases/$(database)/documents/teams/$(teamId)/games/$(gameId)).data.get('liveStatus', '') != 'deleted' &&
+             request.auth.uid in permission.get('memberIds', []);
+    }
+
     function keepsScorekeeperGameLifecycleVisible() {
       return request.resource.data.get('status', resource.data.get('status', 'scheduled')) != 'cancelled' &&
              request.resource.data.get('liveStatus', resource.data.get('liveStatus', '')) != 'deleted';
@@ -61,6 +71,14 @@ service cloud.firestore {
                'completedAt', 'completedBy', 'completedByName', 'updatedAt'
              ]) &&
              keepsScorekeeperGameLifecycleVisible();
+    }
+
+    function isVideographyGameUpdate(teamId, gameId) {
+      return canVideographGame(teamId, gameId) &&
+             request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+               'highlightClips', 'clipRecords', 'gameClips', 'videoClips', 'mediaClips',
+               'replayVideo', 'recordedVideo', 'videoReplay', 'updatedAt'
+             ]);
     }
 
     // Check if user is a parent for a specific player.
@@ -712,7 +730,8 @@ service cloud.firestore {
         allow create, delete: if isTeamOwnerOrAdmin(teamId);
         allow update: if isTeamOwnerOrAdmin(teamId) ||
                         (isOfficialForGame() && isOfficialGameUpdate()) ||
-                        isScorekeepingGameUpdate(teamId, gameId);
+                        isScorekeepingGameUpdate(teamId, gameId) ||
+                        isVideographyGameUpdate(teamId, gameId);
         allow update: if isOpenOfficiatingSelfAssignmentUpdate();
 
         // Events subcollection

--- a/js/live-game-video.js
+++ b/js/live-game-video.js
@@ -122,6 +122,12 @@ function normalizeUidSet(values) {
         .filter(Boolean));
 }
 
+function hasSelectedVideographerGrant(user, team) {
+    const videography = team?.teamPermissions?.videography || {};
+    if (videography.mode && videography.mode !== 'selected') return false;
+    return Boolean(user?.uid && normalizeUidSet(videography.memberIds).has(user.uid));
+}
+
 function isGameCameraEligible(game) {
     if (!game || typeof game !== 'object') return false;
     const status = String(game.status || game.liveStatus || '').toLowerCase();
@@ -137,6 +143,7 @@ export function canAccessNativeCameraCapture({ user, team, game }) {
     const userEmail = typeof user.email === 'string' ? user.email.trim().toLowerCase() : '';
     const adminEmails = normalizeStringSet(team.adminEmails);
     if (userEmail && adminEmails.has(userEmail)) return true;
+    if (hasSelectedVideographerGrant(user, team)) return true;
 
     const approvedUidFields = [
         team.mediaContributorUids,

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -30,7 +30,7 @@ import {
   getReplayStartTimeAfterSpeedChange,
   getReplayTimestampMs
 } from './live-game-replay.js?v=3';
-import { MAX_HIGHLIGHT_CLIP_MS, buildHighlightShareUrl, canAccessNativeCameraCapture, createHighlightClipDraft, resolveReplayVideoOptions, shouldReloadVideoPlayback } from './live-game-video.js?v=4';
+import { MAX_HIGHLIGHT_CLIP_MS, buildHighlightShareUrl, canAccessNativeCameraCapture, createHighlightClipDraft, resolveReplayVideoOptions, shouldReloadVideoPlayback } from './live-game-video.js?v=5';
 import { TEAM_PASS_FEATURES, canAccessPremiumFanFeature, getTeamEntitlementStatus, resolveTeamEntitlementSeasonId } from './team-entitlements.js?v=1';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';

--- a/js/team-access.js
+++ b/js/team-access.js
@@ -145,9 +145,17 @@ function normalizeCapabilityPermission(permission) {
   };
 }
 
+function normalizeSelectedMemberPermission(permission) {
+  return {
+    mode: 'selected',
+    memberIds: normalizeMemberIdList(permission?.memberIds)
+  };
+}
+
 export function normalizeTeamPermissions(teamPermissions = {}) {
   return {
     scorekeeping: normalizeCapabilityPermission(teamPermissions.scorekeeping),
-    streaming: normalizeCapabilityPermission(teamPermissions.streaming)
+    streaming: normalizeCapabilityPermission(teamPermissions.streaming),
+    videography: normalizeSelectedMemberPermission(teamPermissions.videography)
   };
 }

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -213,6 +213,7 @@ function createEnvironment(initialState, overrides = {}) {
         'scorekeeping-member-list',
         'streamingAccessMode',
         'streaming-member-list',
+        'videography-member-list',
         'streamAccessMode',
         'stream-volunteer-panel',
         'stream-volunteer-list',
@@ -340,7 +341,7 @@ function extractEditTeamModule() {
             'const { normalizeYouTubeEmbedUrl } = deps.liveStreamUtils;'
         )
         .replace(
-            "import { hasFullTeamAccess, normalizeAdminEmailList, normalizeStreamVolunteerEmailList, normalizeTeamPermissions } from './js/team-access.js?v=2';",
+            "import { hasFullTeamAccess, normalizeAdminEmailList, normalizeStreamVolunteerEmailList, normalizeTeamPermissions } from './js/team-access.js?v=3';",
             'const { hasFullTeamAccess, normalizeAdminEmailList, normalizeStreamVolunteerEmailList, normalizeTeamPermissions } = deps.teamAccess;'
         )
         .replace(

--- a/tests/unit/live-game-video.test.js
+++ b/tests/unit/live-game-video.test.js
@@ -426,6 +426,32 @@ describe('native camera capture authorization', () => {
         })).toBe(true);
     });
 
+    it('allows selected videographers without granting full staff access', () => {
+        expect(canAccessNativeCameraCapture({
+            user: { uid: 'video-1', email: 'video@example.com' },
+            team: {
+                ownerId: 'owner-1',
+                adminEmails: [],
+                teamPermissions: {
+                    videography: { mode: 'selected', memberIds: ['video-1'] }
+                }
+            },
+            game: scheduledGame
+        })).toBe(true);
+
+        expect(canAccessNativeCameraCapture({
+            user: { uid: 'video-2', email: 'video2@example.com' },
+            team: {
+                ownerId: 'owner-1',
+                adminEmails: [],
+                teamPermissions: {
+                    videography: { mode: 'selected', memberIds: ['video-1'] }
+                }
+            },
+            game: scheduledGame
+        })).toBe(false);
+    });
+
     it('blocks regular viewers and ended games', () => {
         expect(canAccessNativeCameraCapture({
             user: { uid: 'viewer-1', email: 'viewer@example.com' },

--- a/tests/unit/scorekeeping-access-wiring.test.js
+++ b/tests/unit/scorekeeping-access-wiring.test.js
@@ -30,7 +30,7 @@ describe('scorekeeping access wiring', () => {
         const rules = readFileSync(resolve(process.cwd(), 'firestore.rules'), 'utf8');
 
         expect(rules).toContain('function canScorekeepGame(teamId, gameId)');
-        expect(rules).toMatch(/allow update: if isTeamOwnerOrAdmin\(teamId\) \|\|\s+\(isOfficialForGame\(\) && isOfficialGameUpdate\(\)\) \|\|\s+isScorekeepingGameUpdate\(teamId, gameId\);/);
+        expect(rules).toMatch(/allow update: if isTeamOwnerOrAdmin\(teamId\) \|\|\s+\(isOfficialForGame\(\) && isOfficialGameUpdate\(\)\) \|\|\s+isScorekeepingGameUpdate\(teamId, gameId\) \|\|\s+isVideographyGameUpdate\(teamId, gameId\);/);
         expect(rules).toContain('allow create, update: if isTeamOwnerOrAdmin(teamId) || canScorekeepGame(teamId, gameId);');
         expect(rules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId);');
     });

--- a/tests/unit/team-access.test.js
+++ b/tests/unit/team-access.test.js
@@ -124,10 +124,12 @@ describe('team access helpers', () => {
   it('normalizes scoped volunteer permissions without granting admin access', () => {
     expect(normalizeTeamPermissions({
       scorekeeping: { mode: 'selected', memberIds: [' user-1 ', 'user-1', '', null, 'user-2'] },
-      streaming: { mode: 'all_confirmed', memberIds: ['user-3'] }
+      streaming: { mode: 'all_confirmed', memberIds: ['user-3'] },
+      videography: { mode: 'selected', memberIds: [' video-1 ', 'video-1'] }
     })).toEqual({
       scorekeeping: { mode: 'selected', memberIds: ['user-1', 'user-2'] },
-      streaming: { mode: 'all_confirmed', memberIds: [] }
+      streaming: { mode: 'all_confirmed', memberIds: [] },
+      videography: { mode: 'selected', memberIds: ['video-1'] }
     });
 
     expect(hasFullTeamAccess({ uid: 'user-1' }, {
@@ -136,6 +138,14 @@ describe('team access helpers', () => {
         scorekeeping: { mode: 'selected', memberIds: ['user-1'] }
       }
     })).toBe(false);
+  });
+
+  it('defaults videography to selected members only', () => {
+    expect(normalizeTeamPermissions()).toEqual({
+      scorekeeping: { mode: 'all_confirmed', memberIds: [] },
+      streaming: { mode: 'all_confirmed', memberIds: [] },
+      videography: { mode: 'selected', memberIds: [] }
+    });
   });
 
 });

--- a/tests/unit/team-management-access-wiring.test.js
+++ b/tests/unit/team-management-access-wiring.test.js
@@ -19,7 +19,7 @@ describe('team management page access wiring', () => {
 
     it('uses shared full-access helper in edit team page', () => {
         const html = readRepoFile('edit-team.html');
-        expect(html).toContain("from './js/team-access.js?v=2'");
+        expect(html).toContain("from './js/team-access.js?v=3'");
         expect(html).toContain('hasFullTeamAccess(');
     });
 


### PR DESCRIPTION
Closes #852

- Adds a separate Videographer Access section to Team Permissions so coaches/admins can grant or revoke live-game media access for selected confirmed members without making them staff/admins.
- Connects selected videographer grants to native camera capture checks and scoped Firestore media update permissions.
- Updates cache-busted imports and targeted coverage for permission normalization, live-game camera access, edit-team wiring, and rules wiring.

Validation:
- `npx vitest run tests/unit/team-access.test.js tests/unit/live-game-video.test.js tests/unit/edit-team-admin-access-persistence.test.js tests/unit/team-management-access-wiring.test.js tests/unit/scorekeeping-access-wiring.test.js --reporter=dot`
- `node scripts/check-critical-cache-bust.mjs`