### PR TITLE
Label fouled-out live tracker players

### DIFF
--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -730,7 +730,7 @@ function liveCard(id) {
   // Foul pill with warning colors
   const fouls = s.fouls || 0;
   const foulBgClass = fouls >= 5 ? 'bg-red-600 text-white' : fouls >= 4 ? 'bg-amber-500 text-white' : 'bg-sand';
-  const foulWarning = fouls >= 5 ? ' ⚠️' : fouls >= 4 ? ' ⚠️' : '';
+  const foulWarning = fouls >= 5 ? ' FOULED OUT!' : fouls >= 4 ? ' ⚠️' : '';
   const foulPill = `<div class="${foulBgClass} rounded-lg py-1">FLS <span class="font-display text-sm">${fouls}${foulWarning}</span></div>`;
 
   const btnHtml = cols.map(col => {
@@ -797,7 +797,7 @@ function renderOpponents() {
     // Add fouls to quick stats display
     const fouls = s.fouls || 0;
     const foulBgClass = fouls >= 5 ? 'bg-red-600 text-white' : fouls >= 4 ? 'bg-amber-500 text-white' : '';
-    const foulWarning = fouls >= 5 ? ' ⚠️' : fouls >= 4 ? ' ⚠️' : '';
+    const foulWarning = fouls >= 5 ? ' FOULED OUT!' : fouls >= 4 ? ' ⚠️' : '';
     const foulDisplay = foulBgClass ? `<span class="${foulBgClass} px-1 rounded">FLS ${fouls}${foulWarning}</span>` : `FLS ${fouls}`;
     const quickLineWithFouls = quickLine ? `${quickLine} · ${foulDisplay}` : foulDisplay;
 

--- a/tests/unit/live-tracker-foul-warning.test.js
+++ b/tests/unit/live-tracker-foul-warning.test.js
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8');
+
+describe('live tracker foul warnings', () => {
+    it('labels 5+ fouls as fouled out instead of only showing a warning icon', () => {
+        expect(source).toContain("fouls >= 5 ? ' FOULED OUT!'");
+        expect(source).not.toContain("fouls >= 5 ? ' ⚠️'");
+    });
+});


### PR DESCRIPTION
Closes #859

## Summary
- Updated live tracker foul displays to show `FOULED OUT!` at 5+ fouls instead of only the warning icon.
- Applied the same 5+ foul label to opponent quick stats for consistency.
- Added focused unit coverage to guard against regressing back to icon-only labeling.

## Tests
- `npx vitest run tests/unit/live-tracker-foul-warning.test.js --reporter=dot`