### PR TITLE
Add admin status checker page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ _migration/*
 !_migration/migrate-player-private-profile.js
 migrate_admin.js
 verify_admin.js
-check-admin-status.html
 
 # Temporary files
 _temp/

--- a/check-admin-status.html
+++ b/check-admin-status.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Admin Status - ALL PLAYS</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-slate-50 min-h-screen flex flex-col">
+    <div id="header-container"></div>
+
+    <main class="flex-grow max-w-3xl w-full mx-auto px-4 py-8">
+        <section class="bg-white border border-slate-200 rounded-lg shadow-sm p-6 space-y-6">
+            <div>
+                <p class="text-sm font-semibold uppercase tracking-wide text-blue-700">Admin entitlement check</p>
+                <h1 class="text-3xl font-bold text-slate-900 mt-2">Check Admin Status</h1>
+                <p class="text-slate-600 mt-2">Use this page before opening the platform admin dashboard to confirm whether your signed-in account has the Firestore <code class="bg-slate-100 px-1 rounded">isAdmin</code> entitlement.</p>
+            </div>
+
+            <div id="status-card" class="border border-slate-200 rounded-lg p-4 bg-slate-50" aria-live="polite">
+                <p id="admin-status" class="text-lg font-semibold text-slate-900">Checking admin status...</p>
+                <dl id="account-details" class="mt-4 grid gap-3 text-sm text-slate-700 hidden">
+                    <div>
+                        <dt class="font-semibold text-slate-900">Email</dt>
+                        <dd id="account-email">—</dd>
+                    </div>
+                    <div>
+                        <dt class="font-semibold text-slate-900">User ID</dt>
+                        <dd id="account-uid" class="break-all">—</dd>
+                    </div>
+                </dl>
+            </div>
+
+            <div id="next-steps" class="text-sm text-slate-700 space-y-2">
+                <p>If you are not logged in, sign in and reload this page. If admin status is not true, stop and request admin enablement before using <code class="bg-slate-100 px-1 rounded">admin.html</code>.</p>
+            </div>
+
+            <div class="flex flex-wrap gap-3">
+                <a href="login.html" class="inline-flex items-center justify-center rounded-md bg-slate-900 px-4 py-2 text-sm font-semibold text-white hover:bg-slate-700">Sign in</a>
+                <a href="admin.html" class="inline-flex items-center justify-center rounded-md bg-blue-700 px-4 py-2 text-sm font-semibold text-white hover:bg-blue-600">Open admin dashboard</a>
+                <button id="reload-button" type="button" class="inline-flex items-center justify-center rounded-md border border-slate-300 px-4 py-2 text-sm font-semibold text-slate-700 hover:bg-slate-100">Reload check</button>
+            </div>
+        </section>
+    </main>
+
+    <div id="footer-container"></div>
+
+    <script type="module">
+        import { checkAuth } from './js/auth.js?v=13';
+        import { renderHeader, renderFooter } from './js/utils.js?v=8';
+
+        const statusEl = document.getElementById('admin-status');
+        const detailsEl = document.getElementById('account-details');
+        const emailEl = document.getElementById('account-email');
+        const uidEl = document.getElementById('account-uid');
+        const statusCardEl = document.getElementById('status-card');
+
+        function setStatus(message, classes) {
+            statusEl.textContent = message;
+            statusCardEl.className = `border rounded-lg p-4 ${classes}`;
+        }
+
+        renderFooter(document.getElementById('footer-container'));
+        document.getElementById('reload-button').addEventListener('click', () => window.location.reload());
+
+        checkAuth((user) => {
+            if (!user) {
+                setStatus('Not logged in', 'border-amber-200 bg-amber-50');
+                detailsEl.classList.add('hidden');
+                return;
+            }
+
+            renderHeader(document.getElementById('header-container'), user);
+            detailsEl.classList.remove('hidden');
+            emailEl.textContent = user.email || user.profileEmail || 'No email available';
+            uidEl.textContent = user.uid || 'No user ID available';
+
+            if (user.isAdmin === true) {
+                setStatus('isAdmin field is TRUE', 'border-green-200 bg-green-50');
+                return;
+            }
+
+            setStatus('isAdmin field is not true', 'border-red-200 bg-red-50');
+        });
+    </script>
+</body>
+</html>

--- a/tests/unit/admin-status-page.test.js
+++ b/tests/unit/admin-status-page.test.js
@@ -1,0 +1,32 @@
+import { describe, it, expect } from 'vitest';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const TEST_DIR = dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = resolve(TEST_DIR, '../..');
+
+function readRepoFile(relativePath) {
+    return readFileSync(resolve(REPO_ROOT, relativePath), 'utf8');
+}
+
+describe('admin status page', () => {
+    it('ships the entitlement checker referenced by the admin ops workflow', () => {
+        const workflowHtml = readRepoFile('workflow-admin-ops.html');
+        const gitignore = readRepoFile('.gitignore');
+        const statusPagePath = resolve(REPO_ROOT, 'check-admin-status.html');
+
+        expect(workflowHtml).toContain('check-admin-status.html');
+        expect(existsSync(statusPagePath)).toBe(true);
+        expect(gitignore.split(/\r?\n/)).not.toContain('check-admin-status.html');
+    });
+
+    it('renders the documented admin and login status messages', () => {
+        const statusPageHtml = readRepoFile('check-admin-status.html');
+
+        expect(statusPageHtml).toContain("import { checkAuth } from './js/auth.js?v=13'");
+        expect(statusPageHtml).toContain('isAdmin field is TRUE');
+        expect(statusPageHtml).toContain('Not logged in');
+        expect(statusPageHtml).toContain('admin.html');
+    });
+});


### PR DESCRIPTION
Closes #858

## Summary
- Add the shipped `check-admin-status.html` page referenced by the Admin Ops workflow.
- Show explicit `Not logged in`, `isAdmin field is TRUE`, and non-admin status outcomes using the existing `checkAuth` flow.
- Stop ignoring the checker page and add unit coverage to ensure the workflow reference points to a shipped file.

## Tests
- `npx vitest run tests/unit/admin-status-page.test.js`