### PR TITLE
Add team media gallery actions

### DIFF
--- a/js/db.js
+++ b/js/db.js
@@ -486,6 +486,20 @@ export async function createTeamMediaLink(teamId, folderId, media = {}) {
     return docRef.id;
 }
 
+export async function setTeamMediaAlbumCover(teamId, folderId, item = {}) {
+    const cleanFolderId = String(folderId || '').trim();
+    const itemId = String(item.id || '').trim();
+    const coverPhotoUrl = String(item.downloadUrl || item.url || item.src || '').trim();
+    if (!teamId || !cleanFolderId || !itemId) throw new Error('Choose a photo to use as the album cover.');
+    if (!isSafeTeamMediaUrl(coverPhotoUrl)) throw new Error('Album cover must use a valid photo URL.');
+    await updateDoc(doc(db, `teams/${teamId}/mediaFolders`, cleanFolderId), {
+        coverPhotoId: itemId,
+        coverPhotoUrl,
+        coverPhotoTitle: String(item.title || item.fileName || '').trim(),
+        updatedAt: serverTimestamp()
+    });
+}
+
 export async function reorderTeamMediaFolders(teamId, folderIds = []) {
     const updates = buildReorderUpdates(folderIds);
     if (!teamId || updates.length === 0) return;

--- a/js/team-media-utils.js
+++ b/js/team-media-utils.js
@@ -36,6 +36,24 @@ export function buildBulkDeleteUpdates(ids = []) {
     return normalizeSelectedMediaIds(ids).map((id) => ({ id, deleted: true }));
 }
 
+export function getTeamMediaItemUrl(item = {}) {
+    return String(item.downloadUrl || item.url || item.src || '').trim();
+}
+
+export function isSafeTeamMediaPhoto(item = {}) {
+    const url = getTeamMediaItemUrl(item);
+    if (!isSafeTeamMediaUrl(url)) return false;
+    const type = String(item.type || '').toLowerCase();
+    const contentType = String(item.contentType || item.mimeType || '').toLowerCase();
+    return ['photo', 'image', 'team-photo'].includes(type)
+        || contentType.startsWith('image/')
+        || /\.(avif|gif|jpe?g|png|webp)(\?|#|$)/i.test(url);
+}
+
+export function getTeamMediaUploaderName(item = {}) {
+    return String(item.uploadedByName || item.uploaderName || item.createdByName || item.authorName || '').trim();
+}
+
 export function isSafeTeamMediaUrl(value) {
     try {
         const url = new URL(String(value || '').trim());

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -8,9 +8,10 @@ import {
     reorderTeamMediaFolders,
     reorderTeamMediaItems,
     moveTeamMediaItems,
-    bulkDeleteTeamMediaItems
-} from './db.js?v=12';
-import { canManageTeamMedia, isSafeTeamMediaUrl, sortByMediaOrder } from './team-media-utils.js?v=1';
+    bulkDeleteTeamMediaItems,
+    setTeamMediaAlbumCover
+} from './db.js?v=13';
+import { canManageTeamMedia, getTeamMediaItemUrl, getTeamMediaUploaderName, isSafeTeamMediaPhoto, isSafeTeamMediaUrl, sortByMediaOrder } from './team-media-utils.js?v=1';
 
 const state = {
     teamId: '',
@@ -75,7 +76,7 @@ function clearAlert() {
 function getItemsForFolder(folderId) {
     return sortByMediaOrder(state.items
         .filter((item) => item.folderId === folderId)
-        .filter((item) => isSafeTeamMediaUrl(item.url)));
+        .filter((item) => isSafeTeamMediaUrl(getTeamMediaItemUrl(item))));
 }
 
 function renderFolderOptions() {
@@ -91,11 +92,19 @@ function renderBulkActions() {
     els.bulkActions.classList.toggle('hidden', !state.canManage || count === 0);
 }
 
+
+function formatMediaDate(value) {
+    const raw = value?.toDate ? value.toDate() : value;
+    const date = raw instanceof Date ? raw : raw ? new Date(raw) : null;
+    if (!date || Number.isNaN(date.getTime())) return '';
+    return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
 function render() {
     els.title.textContent = state.team?.name ? `${state.team.name} Media` : 'Media Library';
     els.subtitle.textContent = state.canManage
-        ? 'Select video links to move or delete. Use up/down controls to persist ordering.'
-        : 'Organized video links and highlights for this team.';
+        ? 'Select media to move or delete. Use up/down controls to persist ordering.'
+        : 'Organized photos, video links, and highlights for this team.';
     els.adminPanel.classList.toggle('hidden', !state.canManage);
     els.backLink.href = state.teamId ? `team.html#teamId=${encodeURIComponent(state.teamId)}` : 'team.html';
     renderFolderOptions();
@@ -114,33 +123,48 @@ function render() {
                 <button type="button" data-folder-move="down" data-folder-id="${escapeHtml(folder.id)}" ${folderIndex === state.folders.length - 1 ? 'disabled' : ''} class="rounded-lg border px-3 py-1 text-xs font-semibold disabled:opacity-40">Down</button>
             </div>` : '';
         const itemRows = items.length === 0
-            ? '<div class="rounded-xl border border-dashed border-gray-200 p-4 text-sm text-gray-500">No video links in this folder.</div>'
-            : items.map((item, itemIndex) => `
-                <div class="flex flex-col gap-3 rounded-xl border border-gray-200 p-4 sm:flex-row sm:items-center sm:justify-between" data-item-id="${escapeHtml(item.id)}">
-                    <div class="flex items-start gap-3">
-                        ${state.canManage ? `<input type="checkbox" data-select-item="${escapeHtml(item.id)}" ${state.selectedIds.has(item.id) ? 'checked' : ''} class="mt-1 h-4 w-4 rounded border-gray-300">` : ''}
-                        <div>
-                            <a href="${escapeHtml(item.url)}" target="_blank" rel="noopener noreferrer" class="font-semibold text-primary-700 hover:text-primary-900">${escapeHtml(item.title || 'Untitled video')}</a>
-                            <div class="break-all text-xs text-gray-500">${escapeHtml(item.url)}</div>
+            ? '<div class="rounded-xl border border-dashed border-gray-200 p-4 text-sm text-gray-500">No media in this folder.</div>'
+            : `<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">${items.map((item, itemIndex) => {
+                const itemUrl = getTeamMediaItemUrl(item);
+                const isPhoto = isSafeTeamMediaPhoto(item);
+                const title = item.title || item.fileName || (isPhoto ? 'Untitled photo' : 'Untitled video');
+                const uploadedBy = getTeamMediaUploaderName(item);
+                const uploadedAt = formatMediaDate(item.uploadedAt || item.createdAt);
+                const metadata = [uploadedBy ? `Uploaded by ${uploadedBy}` : '', uploadedAt].filter(Boolean).join(' • ');
+                return `
+                    <div class="flex h-full flex-col gap-3 rounded-xl border border-gray-200 p-4" data-item-id="${escapeHtml(item.id)}">
+                        ${isPhoto ? `<a href="${escapeHtml(itemUrl)}" target="_blank" rel="noopener noreferrer" class="block overflow-hidden rounded-lg bg-gray-100"><img src="${escapeHtml(itemUrl)}" alt="${escapeHtml(title)}" loading="lazy" class="h-48 w-full object-cover"></a>` : ''}
+                        <div class="flex items-start gap-3">
+                            ${state.canManage ? `<input type="checkbox" data-select-item="${escapeHtml(item.id)}" ${state.selectedIds.has(item.id) ? 'checked' : ''} class="mt-1 h-4 w-4 rounded border-gray-300">` : ''}
+                            <div class="min-w-0 flex-1">
+                                <a href="${escapeHtml(itemUrl)}" target="_blank" rel="noopener noreferrer" class="font-semibold text-primary-700 hover:text-primary-900">${escapeHtml(title)}</a>
+                                <div class="text-xs text-gray-500">${escapeHtml(metadata || 'Media item')}</div>
+                                ${!isPhoto ? `<div class="break-all text-xs text-gray-500">${escapeHtml(itemUrl)}</div>` : ''}
+                            </div>
                         </div>
-                    </div>
-                    ${state.canManage ? `<div class="flex gap-2">
-                        <button type="button" data-item-move="up" data-item-id="${escapeHtml(item.id)}" data-folder-id="${escapeHtml(folder.id)}" ${itemIndex === 0 ? 'disabled' : ''} class="rounded-lg border px-3 py-1 text-xs font-semibold disabled:opacity-40">Up</button>
-                        <button type="button" data-item-move="down" data-item-id="${escapeHtml(item.id)}" data-folder-id="${escapeHtml(folder.id)}" ${itemIndex === items.length - 1 ? 'disabled' : ''} class="rounded-lg border px-3 py-1 text-xs font-semibold disabled:opacity-40">Down</button>
-                    </div>` : ''}
-                </div>
-            `).join('');
+                        <div class="mt-auto flex flex-wrap gap-2">
+                            <a href="${escapeHtml(itemUrl)}" download class="rounded-lg border border-primary-200 px-3 py-1 text-xs font-semibold text-primary-700 hover:bg-primary-50">Download</a>
+                            ${state.canManage && isPhoto ? `<button type="button" data-set-cover="${escapeHtml(item.id)}" data-folder-id="${escapeHtml(folder.id)}" class="rounded-lg border border-primary-200 px-3 py-1 text-xs font-semibold text-primary-700 hover:bg-primary-50">Set cover</button>` : ''}
+                            ${state.canManage ? `<button type="button" data-item-move="up" data-item-id="${escapeHtml(item.id)}" data-folder-id="${escapeHtml(folder.id)}" ${itemIndex === 0 ? 'disabled' : ''} class="rounded-lg border px-3 py-1 text-xs font-semibold disabled:opacity-40">Up</button>
+                            <button type="button" data-item-move="down" data-item-id="${escapeHtml(item.id)}" data-folder-id="${escapeHtml(folder.id)}" ${itemIndex === items.length - 1 ? 'disabled' : ''} class="rounded-lg border px-3 py-1 text-xs font-semibold disabled:opacity-40">Down</button>` : ''}
+                        </div>
+                    </div>`;
+            }).join('')}</div>`;
 
+        const coverUrl = isSafeTeamMediaUrl(folder.coverPhotoUrl) ? folder.coverPhotoUrl : '';
         return `
             <article class="rounded-2xl border border-gray-200 bg-white shadow-sm">
                 <header class="flex items-center justify-between gap-3 border-b border-gray-100 p-5">
-                    <div>
-                        <h2 class="text-xl font-bold">${escapeHtml(folder.name || 'Untitled folder')}</h2>
-                        <p class="text-sm text-gray-500">${items.length} item${items.length === 1 ? '' : 's'}</p>
+                    <div class="flex items-center gap-4">
+                        ${coverUrl ? `<img src="${escapeHtml(coverUrl)}" alt="${escapeHtml(folder.coverPhotoTitle || folder.name || 'Album cover')}" class="h-16 w-16 rounded-xl object-cover">` : ''}
+                        <div>
+                            <h2 class="text-xl font-bold">${escapeHtml(folder.name || 'Untitled folder')}</h2>
+                            <p class="text-sm text-gray-500">${items.length} item${items.length === 1 ? '' : 's'}</p>
+                        </div>
                     </div>
                     ${folderControls}
                 </header>
-                <div class="space-y-3 p-5">${itemRows}</div>
+                <div class="p-5">${itemRows}</div>
             </article>`;
     }).join('');
 }
@@ -179,6 +203,13 @@ els.foldersList.addEventListener('click', (event) => {
     if (folderButton) {
         const reordered = moveInArray(state.folders, folderButton.dataset.folderId, folderButton.dataset.folderMove);
         persistAndReload(() => reorderTeamMediaFolders(state.teamId, reordered.map((folder) => folder.id)), 'Folder order saved.');
+        return;
+    }
+
+    const coverButton = event.target.closest('[data-set-cover]');
+    if (coverButton) {
+        const item = state.items.find((candidate) => candidate.id === coverButton.dataset.setCover);
+        persistAndReload(() => setTeamMediaAlbumCover(state.teamId, coverButton.dataset.folderId, item), 'Album cover saved.');
         return;
     }
 

--- a/team-media.html
+++ b/team-media.html
@@ -17,7 +17,7 @@
             <div>
                 <p class="text-xs font-semibold uppercase tracking-[0.25em] text-primary-600">Team Media</p>
                 <h1 id="team-media-title" class="text-3xl font-bold">Media Library</h1>
-                <p id="team-media-subtitle" class="text-sm text-gray-500">Organized video links and highlights for this team.</p>
+                <p id="team-media-subtitle" class="text-sm text-gray-500">Organized photos, video links, and highlights for this team.</p>
             </div>
             <a id="team-back-link" href="team.html" class="text-sm font-semibold text-primary-700 hover:text-primary-900">Back to team</a>
         </div>
@@ -60,6 +60,6 @@
         </section>
     </main>
 
-    <script type="module" src="js/team-media.js?v=1"></script>
+    <script type="module" src="js/team-media.js?v=2"></script>
 </body>
 </html>

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -21,13 +21,17 @@ describe('team media entry point', () => {
         const pageJs = readRepoFile('js/team-media.js');
         const rules = readRepoFile('firestore.rules');
 
-        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=1"></script>');
+        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=2"></script>');
         expect(pageHtml).toContain('id="team-media-admin-panel"');
         expect(pageHtml).toContain('id="bulk-actions"');
         expect(pageJs).toContain("import { checkAuth } from './auth.js?v=13';");
+        expect(pageJs).toContain("from './db.js?v=13'");
         expect(pageJs).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
         expect(pageJs).toContain('state.canManage = canManageTeamMedia(user, state.team);');
         expect(pageJs).toContain('bulkDeleteTeamMediaItems');
+        expect(pageJs).toContain('setTeamMediaAlbumCover');
+        expect(pageJs).toContain('download class="rounded-lg');
+        expect(pageJs).toContain('data-set-cover');
         expect(rules).toContain('match /mediaFolders/{folderId}');
         expect(rules).toContain('allow read: if canAccessTeamChat(teamId);');
         expect(rules).toContain('allow create, update, delete: if isTeamOwnerOrAdmin(teamId);');

--- a/tests/unit/team-media-utils.test.js
+++ b/tests/unit/team-media-utils.test.js
@@ -4,6 +4,9 @@ import {
     buildBulkDeleteUpdates,
     buildMoveUpdates,
     buildReorderUpdates,
+    getTeamMediaItemUrl,
+    getTeamMediaUploaderName,
+    isSafeTeamMediaPhoto,
     isSafeTeamMediaUrl,
     normalizeSelectedMediaIds,
     sortByMediaOrder
@@ -52,6 +55,20 @@ describe('team media bulk actions', () => {
         expect(isSafeTeamMediaUrl('http://videos.example.com/clip')).toBe(true);
         expect(isSafeTeamMediaUrl('javascript:alert(1)')).toBe(false);
         expect(isSafeTeamMediaUrl('not a url')).toBe(false);
+    });
+
+    it('identifies uploaded photo items and uploader metadata', () => {
+        const item = {
+            downloadUrl: 'https://cdn.example.com/photo.png',
+            type: 'photo',
+            uploadedByName: 'Coach Pat'
+        };
+
+        expect(getTeamMediaItemUrl(item)).toBe('https://cdn.example.com/photo.png');
+        expect(isSafeTeamMediaPhoto(item)).toBe(true);
+        expect(isSafeTeamMediaPhoto({ url: 'https://cdn.example.com/photo.jpg?token=1' })).toBe(true);
+        expect(isSafeTeamMediaPhoto({ url: 'javascript:alert(1)', type: 'photo' })).toBe(false);
+        expect(getTeamMediaUploaderName(item)).toBe('Coach Pat');
     });
 
     it('sorts by saved order with stable name fallback', () => {

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -14,8 +14,8 @@ describe('team media page wiring', () => {
         const page = fs.readFileSync(path.join(repoRoot, 'team-media.html'), 'utf8');
         const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
 
-        expect(page).toContain('src="js/team-media.js?v=1"');
-        expect(source).toContain("from './db.js?v=12'");
+        expect(page).toContain('src="js/team-media.js?v=2"');
+        expect(source).toContain("from './db.js?v=13'");
         expect(source).toContain("import { checkAuth } from './auth.js?v=13';");
         expect(source).toContain('checkAuth(async (user) => {');
         expect(source).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');


### PR DESCRIPTION
Closes #870

## Summary
- Render team media items in a gallery that supports uploaded photos and existing video links.
- Add uploader/date metadata, per-item download links, admin cover selection, and album cover display.
- Add Firestore update support for saving album cover metadata and cache-bust the team media module import.

## Tests
- `npm test -- tests/unit/team-media-utils.test.js tests/unit/team-media-page.test.js tests/unit/team-media-wiring.test.js`
- `node scripts/check-critical-cache-bust.mjs`