### PR TITLE
Allow team media photo uploads

### DIFF
--- a/docs/pr-notes/runs/875-remediator-20260509T220904Z/architecture.md
+++ b/docs/pr-notes/runs/875-remediator-20260509T220904Z/architecture.md
@@ -1,0 +1,10 @@
+# Architecture
+
+Decisions:
+- Keep team-media under `team-media/{teamId}/{folderId}/{userId}/{fileName}` and gate object reads with the existing team membership helper.
+- Split Storage read into `get` and `list` so direct object reads work for authorized members while bucket listing stays denied.
+- Add narrow legacy fallback matches for `stat-sheets/**` and `game-clips/**`, limited to signed-in users and no listing.
+- Keep deletion logic in `js/db.js` where Firebase document and Storage references are built.
+
+Risks and rollback:
+- Fallback path rules preserve current behavior but still have broader blast radius than team-scoped paths. Roll back by removing those matches after all callers migrate to scoped storage.

--- a/docs/pr-notes/runs/875-remediator-20260509T220904Z/code-plan.md
+++ b/docs/pr-notes/runs/875-remediator-20260509T220904Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code Plan
+
+Implementation plan:
+- Update `storage.rules` to deny listing team media, allow authorized object gets, and restore signed-in access for known fallback prefixes.
+- Update `deleteTeamMediaItem` to validate required file/doc references before deletion work.
+- Run available unit tests and commit only scoped files.

--- a/docs/pr-notes/runs/875-remediator-20260509T220904Z/qa.md
+++ b/docs/pr-notes/runs/875-remediator-20260509T220904Z/qa.md
@@ -1,0 +1,6 @@
+# QA Plan
+
+Validation:
+- Run unit tests if available for affected helpers.
+- Inspect Storage rules for scoped team-media access and fallback path coverage.
+- Manual test targets: team member can open uploaded team media photo; unrelated signed-in user cannot open team media object; signed-in fallback upload succeeds for `stat-sheets/**` and `game-clips/**`; delete of malformed photo item reports a clear missing file reference error.

--- a/docs/pr-notes/runs/875-remediator-20260509T220904Z/requirements.md
+++ b/docs/pr-notes/runs/875-remediator-20260509T220904Z/requirements.md
@@ -1,0 +1,8 @@
+# Requirements
+
+Acceptance criteria:
+- Team media Storage object reads must be limited to users with team access: owner, admin, global admin, or parent linked to the team.
+- Team media Storage listing must not be exposed broadly.
+- Existing main-bucket fallback upload paths used by chat, game clips, stat sheets, and drill diagrams must remain available to signed-in users.
+- Deleting a team media photo must fail with a clear error before Firebase delete operations if the file reference is missing.
+- Deleting a team media item must use a validated document reference before updating the Firestore record.

--- a/firebase.json
+++ b/firebase.json
@@ -51,5 +51,8 @@
       "host": "localhost",
       "port": 8000
     }
+  },
+  "storage": {
+    "rules": "storage.rules"
   }
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -370,6 +370,47 @@ service cloud.firestore {
       return isSignedIn() && (isOwnerOrAdmin || isParentForTeam(teamId));
     }
 
+
+    function isTeamMediaPhotoCreate(teamId, data) {
+      return canAccessTeamChat(teamId) &&
+             data.keys().hasAll([
+               'folderId', 'title', 'type', 'url', 'storagePath', 'uploadedBy',
+               'size', 'mimeType', 'deleted', 'createdAt', 'updatedAt'
+             ]) &&
+             data.keys().hasOnly([
+               'folderId', 'title', 'type', 'url', 'storagePath', 'uploadedBy',
+               'size', 'mimeType', 'order', 'deleted', 'createdAt', 'updatedAt'
+             ]) &&
+             data.folderId is string &&
+             data.folderId.size() > 0 &&
+             data.type == 'photo' &&
+             data.url is string &&
+             data.storagePath is string &&
+             data.storagePath.matches('team-media/' + teamId + '/' + data.folderId + '/' + request.auth.uid + '/.*') &&
+             data.uploadedBy == request.auth.uid &&
+             data.size is number &&
+             data.size > 0 &&
+             data.size <= 10485760 &&
+             data.mimeType is string &&
+             data.mimeType.matches('image/.*') &&
+             data.deleted == false &&
+             data.createdAt == request.time &&
+             data.updatedAt == request.time;
+    }
+
+    function isOwnTeamMediaPhotoSoftDelete(teamId) {
+      return canAccessTeamChat(teamId) &&
+             resource.data.type == 'photo' &&
+             resource.data.uploadedBy == request.auth.uid &&
+             request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+               'deleted', 'deletedAt', 'deletedBy', 'updatedAt'
+             ]) &&
+             request.resource.data.deleted == true &&
+             request.resource.data.deletedBy == request.auth.uid &&
+             request.resource.data.deletedAt == request.time &&
+             request.resource.data.updatedAt == request.time;
+    }
+
     function teamChatRecipientIds(teamId) {
       return get(/databases/$(database)/documents/teams/$(teamId)).data.get('chatMemberIds', []);
     }
@@ -719,7 +760,9 @@ service cloud.firestore {
 
       match /mediaItems/{itemId} {
         allow read: if canAccessTeamChat(teamId);
-        allow create, update, delete: if isTeamOwnerOrAdmin(teamId);
+        allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaPhotoCreate(teamId, request.resource.data);
+        allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaPhotoSoftDelete(teamId);
+        allow delete: if isTeamOwnerOrAdmin(teamId);
       }
 
       match /settings/{settingId} {

--- a/js/db.js
+++ b/js/db.js
@@ -32,6 +32,7 @@ import {
     deleteObject
 } from './firebase.js?v=11';
 import { imageStorage, ensureImageAuth, requireImageAuth } from './firebase-images.js?v=4';
+import { uploadBytesResumable } from './vendor/firebase-storage.js';
 import { buildDrillDiagramUploadPaths } from './drill-upload-paths.js?v=1';
 import { isAccessCodeExpired } from './access-code-utils.js?v=1';
 import {
@@ -498,6 +499,80 @@ export async function setTeamMediaAlbumCover(teamId, folderId, item = {}) {
         coverPhotoTitle: String(item.title || item.fileName || '').trim(),
         updatedAt: serverTimestamp()
     });
+}
+
+function sanitizeTeamMediaFileName(name) {
+    return String(name || 'photo')
+        .trim()
+        .replace(/[^a-zA-Z0-9._-]+/g, '-')
+        .replace(/^-+|-+$/g, '')
+        .slice(0, 120) || 'photo';
+}
+
+export async function uploadTeamMediaPhoto(teamId, folderId, file, options = {}) {
+    const cleanTeamId = String(teamId || '').trim();
+    const cleanFolderId = String(folderId || '').trim();
+    const currentUser = auth.currentUser;
+    if (!cleanTeamId || !cleanFolderId) throw new Error('Choose an album before uploading photos.');
+    if (!currentUser?.uid) throw new Error('Sign in before uploading photos.');
+    if (!file || !String(file.type || '').startsWith('image/')) throw new Error('Choose a supported image file.');
+
+    const storagePath = `team-media/${cleanTeamId}/${cleanFolderId}/${currentUser.uid}/${Date.now()}-${sanitizeTeamMediaFileName(file.name)}`;
+    const storageRef = ref(storage, storagePath);
+    const uploadTask = uploadBytesResumable(storageRef, file, { contentType: file.type || 'image/jpeg' });
+
+    const snapshot = await new Promise((resolve, reject) => {
+        uploadTask.on('state_changed', (progressSnapshot) => {
+            if (typeof options.onProgress === 'function') {
+                const percent = progressSnapshot.totalBytes > 0
+                    ? Math.round((progressSnapshot.bytesTransferred / progressSnapshot.totalBytes) * 100)
+                    : 0;
+                options.onProgress({
+                    bytesTransferred: progressSnapshot.bytesTransferred,
+                    totalBytes: progressSnapshot.totalBytes,
+                    percent
+                });
+            }
+        }, reject, () => resolve(uploadTask.snapshot));
+    });
+
+    const url = await getDownloadURL(snapshot.ref);
+    const existingItems = await getTeamMediaItems(cleanTeamId, cleanFolderId);
+    const docRef = await addDoc(getTeamMediaItemsRef(cleanTeamId), {
+        folderId: cleanFolderId,
+        title: String(file.name || 'Uploaded photo').trim() || 'Uploaded photo',
+        type: 'photo',
+        url,
+        storagePath,
+        uploadedBy: currentUser.uid,
+        size: Number(file.size || 0),
+        mimeType: file.type || 'image/jpeg',
+        order: existingItems.length,
+        deleted: false,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp()
+    });
+    return docRef.id;
+}
+
+export async function deleteTeamMediaItem(teamId, item) {
+    const cleanTeamId = String(teamId || '').trim();
+    const itemId = String(item?.id || '').trim();
+    if (!cleanTeamId || !itemId) throw new Error('Media item is required.');
+    await updateDoc(doc(db, `teams/${cleanTeamId}/mediaItems`, itemId), {
+        deleted: true,
+        deletedAt: serverTimestamp(),
+        deletedBy: auth.currentUser?.uid || null,
+        updatedAt: serverTimestamp()
+    });
+
+    if (item?.type === 'photo' && item.storagePath) {
+        try {
+            await deleteObject(ref(storage, item.storagePath));
+        } catch (error) {
+            console.warn('Unable to delete team media storage object:', error);
+        }
+    }
 }
 
 export async function reorderTeamMediaFolders(teamId, folderIds = []) {

--- a/js/db.js
+++ b/js/db.js
@@ -559,14 +559,25 @@ export async function deleteTeamMediaItem(teamId, item) {
     const cleanTeamId = String(teamId || '').trim();
     const itemId = String(item?.id || '').trim();
     if (!cleanTeamId || !itemId) throw new Error('Media item is required.');
-    await updateDoc(doc(db, `teams/${cleanTeamId}/mediaItems`, itemId), {
+    if (item?.type === 'photo' && !item.storagePath) {
+        console.error('Media object missing file reference:', itemId);
+        throw new Error('Cannot delete media: missing file reference');
+    }
+
+    const mediaDocRef = doc(db, `teams/${cleanTeamId}/mediaItems`, itemId);
+    if (!mediaDocRef) {
+        console.error('Media object missing document reference:', itemId);
+        throw new Error('Cannot delete media: missing document reference');
+    }
+
+    await updateDoc(mediaDocRef, {
         deleted: true,
         deletedAt: serverTimestamp(),
         deletedBy: auth.currentUser?.uid || null,
         updatedAt: serverTimestamp()
     });
 
-    if (item?.type === 'photo' && item.storagePath) {
+    if (item?.type === 'photo') {
         try {
             await deleteObject(ref(storage, item.storagePath));
         } catch (error) {

--- a/js/team-media-utils.js
+++ b/js/team-media-utils.js
@@ -44,8 +44,26 @@ export function canViewTeamMediaFolder(folder, accessLevel) {
     return ['full', 'parent'].includes(accessLevel);
 }
 
+export function canContributeTeamMedia(user, team) {
+    if (!user || !team) return false;
+    if (hasFullTeamAccess(user, team)) return true;
+    const teamId = String(team.id || '').trim();
+    if (!teamId) return false;
+    return (Array.isArray(user.parentTeamIds) && user.parentTeamIds.includes(teamId)) ||
+        (Array.isArray(user.parentOf) && user.parentOf.some((parentLink) => parentLink?.teamId === teamId));
+}
+
 export function isSupportedTeamMediaVideoUrl(value) {
     return Boolean(getSafeVideoUrl(value));
+}
+
+export function isSupportedTeamMediaImage(file) {
+    return Boolean(file && String(file.type || '').startsWith('image/'));
+}
+
+export function canDeleteTeamMediaItem(user, team, item) {
+    if (!user || !item) return false;
+    return canManageTeamMedia(user, team) || (item.type === 'photo' && item.uploadedBy === user.uid);
 }
 
 export function normalizeTeamMediaFolderDraft(draft = {}) {

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -12,8 +12,18 @@ import {
     moveTeamMediaItems,
     bulkDeleteTeamMediaItems,
     setTeamMediaAlbumCover
-} from './db.js?v=13';
-import { canContributeTeamMedia, canDeleteTeamMediaItem, canManageTeamMedia, getTeamMediaItemUrl, getTeamMediaUploaderName, isSafeTeamMediaPhoto, isSafeTeamMediaUrl, isSupportedTeamMediaImage, sortByMediaOrder } from './team-media-utils.js?v=2';
+} from './db.js?v=14';
+import {
+    canContributeTeamMedia,
+    canDeleteTeamMediaItem,
+    canManageTeamMedia,
+    getTeamMediaItemUrl,
+    getTeamMediaUploaderName,
+    isSafeTeamMediaPhoto,
+    isSafeTeamMediaUrl,
+    isSupportedTeamMediaImage,
+    sortByMediaOrder
+} from './team-media-utils.js?v=2';
 
 const state = {
     teamId: '',

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -5,19 +5,22 @@ import {
     getTeamMediaItems,
     createTeamMediaFolder,
     createTeamMediaLink,
+    uploadTeamMediaPhoto,
+    deleteTeamMediaItem,
     reorderTeamMediaFolders,
     reorderTeamMediaItems,
     moveTeamMediaItems,
     bulkDeleteTeamMediaItems,
     setTeamMediaAlbumCover
 } from './db.js?v=13';
-import { canManageTeamMedia, getTeamMediaItemUrl, getTeamMediaUploaderName, isSafeTeamMediaPhoto, isSafeTeamMediaUrl, sortByMediaOrder } from './team-media-utils.js?v=1';
+import { canContributeTeamMedia, canDeleteTeamMediaItem, canManageTeamMedia, getTeamMediaItemUrl, getTeamMediaUploaderName, isSafeTeamMediaPhoto, isSafeTeamMediaUrl, isSupportedTeamMediaImage, sortByMediaOrder } from './team-media-utils.js?v=2';
 
 const state = {
     teamId: '',
     team: null,
     user: null,
     canManage: false,
+    canContribute: false,
     folders: [],
     items: [],
     selectedIds: new Set()
@@ -27,6 +30,11 @@ const els = {
     title: document.getElementById('team-media-title'),
     subtitle: document.getElementById('team-media-subtitle'),
     alert: document.getElementById('team-media-alert'),
+    uploadPanel: document.getElementById('team-media-upload-panel'),
+    uploadForm: document.getElementById('photo-upload-form'),
+    photoFolder: document.getElementById('photo-folder'),
+    photoFiles: document.getElementById('photo-files'),
+    uploadProgress: document.getElementById('upload-progress'),
     adminPanel: document.getElementById('team-media-admin-panel'),
     bulkActions: document.getElementById('bulk-actions'),
     selectedCount: document.getElementById('selected-count'),
@@ -83,6 +91,7 @@ function renderFolderOptions() {
     const options = state.folders.map((folder) => `<option value="${escapeHtml(folder.id)}">${escapeHtml(folder.name || 'Untitled folder')}</option>`).join('');
     const placeholder = '<option value="">Choose folder</option>';
     els.linkFolder.innerHTML = placeholder + options;
+    els.photoFolder.innerHTML = placeholder + options;
     els.moveFolder.innerHTML = placeholder + options;
 }
 
@@ -104,14 +113,17 @@ function render() {
     els.title.textContent = state.team?.name ? `${state.team.name} Media` : 'Media Library';
     els.subtitle.textContent = state.canManage
         ? 'Select media to move or delete. Use up/down controls to persist ordering.'
-        : 'Organized photos, video links, and highlights for this team.';
+        : state.canContribute
+            ? 'Upload team photos or browse shared video links and highlights.'
+            : 'Organized photos, video links, and highlights for this team.';
+    els.uploadPanel.classList.toggle('hidden', !state.canContribute);
     els.adminPanel.classList.toggle('hidden', !state.canManage);
     els.backLink.href = state.teamId ? `team.html#teamId=${encodeURIComponent(state.teamId)}` : 'team.html';
     renderFolderOptions();
     renderBulkActions();
 
     if (state.folders.length === 0) {
-        els.foldersList.innerHTML = `<div class="rounded-2xl border border-gray-200 bg-white p-6 text-sm text-gray-500">${state.canManage ? 'No folders yet. Add one to start organizing video links.' : 'No media folders have been shared yet.'}</div>`;
+        els.foldersList.innerHTML = `<div class="rounded-2xl border border-gray-200 bg-white p-6 text-sm text-gray-500">${state.canManage ? 'No folders yet. Add one to start organizing media.' : 'No media folders have been shared yet.'}</div>`;
         return;
     }
 
@@ -123,14 +135,16 @@ function render() {
                 <button type="button" data-folder-move="down" data-folder-id="${escapeHtml(folder.id)}" ${folderIndex === state.folders.length - 1 ? 'disabled' : ''} class="rounded-lg border px-3 py-1 text-xs font-semibold disabled:opacity-40">Down</button>
             </div>` : '';
         const itemRows = items.length === 0
-            ? '<div class="rounded-xl border border-dashed border-gray-200 p-4 text-sm text-gray-500">No media in this folder.</div>'
+            ? `<div class="rounded-xl border border-dashed border-gray-200 p-4 text-sm text-gray-500">No media in this folder.</div>`
             : `<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">${items.map((item, itemIndex) => {
                 const itemUrl = getTeamMediaItemUrl(item);
                 const isPhoto = isSafeTeamMediaPhoto(item);
+                const canDeleteItem = canDeleteTeamMediaItem(state.user, state.team, item);
                 const title = item.title || item.fileName || (isPhoto ? 'Untitled photo' : 'Untitled video');
                 const uploadedBy = getTeamMediaUploaderName(item);
                 const uploadedAt = formatMediaDate(item.uploadedAt || item.createdAt);
-                const metadata = [uploadedBy ? `Uploaded by ${uploadedBy}` : '', uploadedAt].filter(Boolean).join(' • ');
+                const fileDetails = isPhoto ? `${item.mimeType || 'image'}${item.size ? ` · ${Number(item.size || 0).toLocaleString()} bytes` : ''}` : '';
+                const metadata = [uploadedBy ? `Uploaded by ${uploadedBy}` : '', uploadedAt, fileDetails].filter(Boolean).join(' • ');
                 return `
                     <div class="flex h-full flex-col gap-3 rounded-xl border border-gray-200 p-4" data-item-id="${escapeHtml(item.id)}">
                         ${isPhoto ? `<a href="${escapeHtml(itemUrl)}" target="_blank" rel="noopener noreferrer" class="block overflow-hidden rounded-lg bg-gray-100"><img src="${escapeHtml(itemUrl)}" alt="${escapeHtml(title)}" loading="lazy" class="h-48 w-full object-cover"></a>` : ''}
@@ -147,6 +161,7 @@ function render() {
                             ${state.canManage && isPhoto ? `<button type="button" data-set-cover="${escapeHtml(item.id)}" data-folder-id="${escapeHtml(folder.id)}" class="rounded-lg border border-primary-200 px-3 py-1 text-xs font-semibold text-primary-700 hover:bg-primary-50">Set cover</button>` : ''}
                             ${state.canManage ? `<button type="button" data-item-move="up" data-item-id="${escapeHtml(item.id)}" data-folder-id="${escapeHtml(folder.id)}" ${itemIndex === 0 ? 'disabled' : ''} class="rounded-lg border px-3 py-1 text-xs font-semibold disabled:opacity-40">Up</button>
                             <button type="button" data-item-move="down" data-item-id="${escapeHtml(item.id)}" data-folder-id="${escapeHtml(folder.id)}" ${itemIndex === items.length - 1 ? 'disabled' : ''} class="rounded-lg border px-3 py-1 text-xs font-semibold disabled:opacity-40">Down</button>` : ''}
+                            ${canDeleteItem ? `<button type="button" data-item-delete="${escapeHtml(item.id)}" class="rounded-lg border border-red-200 px-3 py-1 text-xs font-semibold text-red-700 hover:bg-red-50">Delete</button>` : ''}
                         </div>
                     </div>`;
             }).join('')}</div>`;
@@ -198,6 +213,15 @@ function moveInArray(items, id, direction) {
 }
 
 els.foldersList.addEventListener('click', (event) => {
+    const deleteButton = event.target.closest('[data-item-delete]');
+    if (deleteButton) {
+        const item = state.items.find((candidate) => candidate.id === deleteButton.dataset.itemDelete);
+        if (!canDeleteTeamMediaItem(state.user, state.team, item)) return;
+        if (!window.confirm('Delete this media item? This cannot be undone.')) return;
+        persistAndReload(() => deleteTeamMediaItem(state.teamId, item), 'Media item deleted.');
+        return;
+    }
+
     if (!state.canManage) return;
     const folderButton = event.target.closest('[data-folder-move]');
     if (folderButton) {
@@ -253,6 +277,55 @@ els.linkForm.addEventListener('submit', (event) => {
     }, 'Video link added.');
 });
 
+els.uploadForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    clearAlert();
+    const files = Array.from(els.photoFiles.files || []);
+    if (!state.canContribute) return;
+    if (!els.photoFolder.value) {
+        showAlert('Choose an album before uploading photos.', 'error');
+        return;
+    }
+    if (files.length === 0) {
+        showAlert('Choose at least one image to upload.', 'error');
+        return;
+    }
+
+    els.uploadProgress.innerHTML = files.map((file, index) => `
+        <div data-upload-row="${index}" class="rounded-lg border border-gray-200 p-3">
+            <div class="flex justify-between gap-3"><span>${escapeHtml(file.name)}</span><span data-upload-status="${index}">Waiting</span></div>
+            <div class="mt-2 h-2 rounded-full bg-gray-100"><div data-upload-bar="${index}" class="h-2 rounded-full bg-primary-600" style="width:0%"></div></div>
+        </div>`).join('');
+
+    let uploadedCount = 0;
+    let failedCount = 0;
+    for (const [index, file] of files.entries()) {
+        const status = els.uploadProgress.querySelector(`[data-upload-status="${index}"]`);
+        const bar = els.uploadProgress.querySelector(`[data-upload-bar="${index}"]`);
+        try {
+            if (!isSupportedTeamMediaImage(file)) throw new Error('Unsupported file type. Choose an image.');
+            status.textContent = 'Uploading';
+            await uploadTeamMediaPhoto(state.teamId, els.photoFolder.value, file, {
+                onProgress: ({ percent }) => {
+                    bar.style.width = `${percent}%`;
+                    status.textContent = `${percent}%`;
+                }
+            });
+            uploadedCount += 1;
+            bar.style.width = '100%';
+            status.textContent = 'Uploaded';
+        } catch (error) {
+            failedCount += 1;
+            status.textContent = error.message || 'Failed. Try again.';
+            status.classList.add('text-red-700');
+        }
+    }
+
+    await loadLibrary();
+    if (uploadedCount > 0) els.photoFiles.value = '';
+    showAlert(`${uploadedCount} photo${uploadedCount === 1 ? '' : 's'} uploaded${failedCount ? `, ${failedCount} failed` : ''}.`, failedCount ? 'error' : 'success');
+});
+
 els.moveSelected.addEventListener('click', () => {
     const ids = [...state.selectedIds];
     persistAndReload(async () => {
@@ -280,7 +353,9 @@ checkAuth(async (user) => {
 
     try {
         state.team = await getTeam(state.teamId, { includeInactive: true });
+        state.team.id = state.team.id || state.teamId;
         state.canManage = canManageTeamMedia(user, state.team);
+        state.canContribute = canContributeTeamMedia(user, state.team);
         await loadLibrary();
     } catch (error) {
         console.error('Unable to load team media:', error);

--- a/storage.rules
+++ b/storage.rules
@@ -31,7 +31,8 @@ service firebase.storage {
     }
 
     match /team-media/{teamId}/{folderId}/{userId}/{fileName} {
-      allow read: if canAccessTeamMedia(teamId);
+      allow get: if canAccessTeamMedia(teamId);
+      allow list: if false;
       allow create: if canAccessTeamMedia(teamId) &&
         request.auth.uid == userId &&
         request.resource.size > 0 &&
@@ -39,6 +40,16 @@ service firebase.storage {
         request.resource.contentType.matches('image/.*');
       allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;
       allow update: if false;
+    }
+
+    match /stat-sheets/{fileName=**} {
+      allow get, create, delete: if isSignedIn();
+      allow list, update: if false;
+    }
+
+    match /game-clips/{fileName=**} {
+      allow get, create, delete: if isSignedIn();
+      allow list, update: if false;
     }
   }
 }

--- a/storage.rules
+++ b/storage.rules
@@ -1,0 +1,44 @@
+rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    function isSignedIn() {
+      return request.auth != null;
+    }
+
+    function isGlobalAdmin() {
+      return isSignedIn() &&
+        firestore.get(/databases/(default)/documents/users/$(request.auth.uid)).data.isAdmin == true;
+    }
+
+    function isTeamOwnerOrAdmin(teamId) {
+      let team = firestore.get(/databases/(default)/documents/teams/$(teamId)).data;
+      return isSignedIn() &&
+        (team.ownerId == request.auth.uid ||
+         (request.auth.token.email != null &&
+          request.auth.token.email.lower() in team.get('adminEmails', [])) ||
+         isGlobalAdmin());
+    }
+
+    function isParentForTeam(teamId) {
+      let userPath = /databases/(default)/documents/users/$(request.auth.uid);
+      return isSignedIn() &&
+        firestore.exists(userPath) &&
+        teamId in firestore.get(userPath).data.get('parentTeamIds', []);
+    }
+
+    function canAccessTeamMedia(teamId) {
+      return isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId);
+    }
+
+    match /team-media/{teamId}/{folderId}/{userId}/{fileName} {
+      allow read: if canAccessTeamMedia(teamId);
+      allow create: if canAccessTeamMedia(teamId) &&
+        request.auth.uid == userId &&
+        request.resource.size > 0 &&
+        request.resource.size <= 10 * 1024 * 1024 &&
+        request.resource.contentType.matches('image/.*');
+      allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;
+      allow update: if false;
+    }
+  }
+}

--- a/team-media.html
+++ b/team-media.html
@@ -24,6 +24,17 @@
 
         <div id="team-media-alert" class="hidden mb-4 rounded-xl border px-4 py-3 text-sm"></div>
 
+        <section id="team-media-upload-panel" class="hidden mb-6 rounded-2xl border border-primary-100 bg-white p-5 shadow-sm">
+            <form id="photo-upload-form" class="space-y-3">
+                <h2 class="font-semibold text-gray-900">Upload photos</h2>
+                <p class="text-sm text-gray-500">Choose an album and add one or more image files.</p>
+                <select id="photo-folder" class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" required></select>
+                <input id="photo-files" type="file" accept="image/*" multiple class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" required>
+                <button class="rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700">Upload photos</button>
+                <div id="upload-progress" class="space-y-2 text-sm"></div>
+            </form>
+        </section>
+
         <section id="team-media-admin-panel" class="hidden mb-6 rounded-2xl border border-primary-100 bg-white p-5 shadow-sm">
             <div class="grid gap-4 lg:grid-cols-2">
                 <form id="folder-form" class="space-y-3">

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -26,7 +26,7 @@ describe('team media entry point', () => {
         expect(pageHtml).toContain('id="team-media-admin-panel"');
         expect(pageHtml).toContain('id="bulk-actions"');
         expect(pageJs).toContain("import { checkAuth } from './auth.js?v=13';");
-        expect(pageJs).toContain("from './db.js?v=13'");
+        expect(pageJs).toContain("from './db.js?v=14'");
         expect(pageJs).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
         expect(pageJs).toContain('state.canManage = canManageTeamMedia(user, state.team);');
         expect(pageJs).toContain('uploadTeamMediaPhoto');

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -22,18 +22,21 @@ describe('team media entry point', () => {
         const rules = readRepoFile('firestore.rules');
 
         expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=2"></script>');
+        expect(pageHtml).toContain('id="team-media-upload-panel"');
         expect(pageHtml).toContain('id="team-media-admin-panel"');
         expect(pageHtml).toContain('id="bulk-actions"');
         expect(pageJs).toContain("import { checkAuth } from './auth.js?v=13';");
         expect(pageJs).toContain("from './db.js?v=13'");
         expect(pageJs).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
         expect(pageJs).toContain('state.canManage = canManageTeamMedia(user, state.team);');
+        expect(pageJs).toContain('uploadTeamMediaPhoto');
         expect(pageJs).toContain('bulkDeleteTeamMediaItems');
         expect(pageJs).toContain('setTeamMediaAlbumCover');
         expect(pageJs).toContain('download class="rounded-lg');
         expect(pageJs).toContain('data-set-cover');
         expect(rules).toContain('match /mediaFolders/{folderId}');
         expect(rules).toContain('allow read: if canAccessTeamChat(teamId);');
-        expect(rules).toContain('allow create, update, delete: if isTeamOwnerOrAdmin(teamId);');
+        expect(rules).toContain('allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaPhotoCreate(teamId, request.resource.data);');
+        expect(rules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaPhotoSoftDelete(teamId);');
     });
 });

--- a/tests/unit/team-media-utils.test.js
+++ b/tests/unit/team-media-utils.test.js
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest';
 import {
     canManageTeamMedia,
     canViewTeamMediaFolder,
+    canContributeTeamMedia,
+    canDeleteTeamMediaItem,
     buildBulkDeleteUpdates,
     buildMoveUpdates,
     buildReorderUpdates,
@@ -10,6 +12,7 @@ import {
     isSafeTeamMediaPhoto,
     isSafeTeamMediaUrl,
     isSupportedTeamMediaVideoUrl,
+    isSupportedTeamMediaImage,
     normalizeSelectedMediaIds,
     normalizeTeamMediaFolderDraft,
     normalizeTeamMediaVideoDraft,
@@ -25,6 +28,24 @@ describe('team media management permissions', () => {
         expect(canManageTeamMedia({ uid: 'global-1', email: 'other@example.com', isAdmin: true }, team)).toBe(true);
         expect(canManageTeamMedia({ uid: 'parent-1', email: 'parent@example.com' }, team)).toBe(false);
         expect(canManageTeamMedia(null, team)).toBe(false);
+    });
+
+    it('allows team parents and admins to contribute photos', () => {
+        const team = { id: 'team-1', ownerId: 'coach-1', adminEmails: ['admin@example.com'] };
+
+        expect(canContributeTeamMedia({ uid: 'coach-1', email: 'coach@example.com' }, team)).toBe(true);
+        expect(canContributeTeamMedia({ uid: 'parent-1', parentTeamIds: ['team-1'] }, team)).toBe(true);
+        expect(canContributeTeamMedia({ uid: 'parent-2', parentOf: [{ teamId: 'team-1' }] }, team)).toBe(true);
+        expect(canContributeTeamMedia({ uid: 'other-1', parentTeamIds: ['other-team'] }, team)).toBe(false);
+    });
+
+    it('allows owners or admins to moderate all photos and uploaders to delete their own photos', () => {
+        const team = { id: 'team-1', ownerId: 'coach-1', adminEmails: [] };
+        const item = { id: 'photo-1', type: 'photo', uploadedBy: 'parent-1' };
+
+        expect(canDeleteTeamMediaItem({ uid: 'parent-1' }, team, item)).toBe(true);
+        expect(canDeleteTeamMediaItem({ uid: 'parent-2' }, team, item)).toBe(false);
+        expect(canDeleteTeamMediaItem({ uid: 'coach-1' }, team, item)).toBe(true);
     });
 });
 
@@ -115,6 +136,13 @@ describe('team media bulk actions', () => {
         expect(isSafeTeamMediaPhoto({ url: 'https://cdn.example.com/photo.jpg?token=1' })).toBe(true);
         expect(isSafeTeamMediaPhoto({ url: 'javascript:alert(1)', type: 'photo' })).toBe(false);
         expect(getTeamMediaUploaderName(item)).toBe('Coach Pat');
+    });
+
+    it('accepts only image files for team album uploads', () => {
+        expect(isSupportedTeamMediaImage({ type: 'image/jpeg' })).toBe(true);
+        expect(isSupportedTeamMediaImage({ type: 'image/png' })).toBe(true);
+        expect(isSupportedTeamMediaImage({ type: 'video/mp4' })).toBe(false);
+        expect(isSupportedTeamMediaImage(null)).toBe(false);
     });
 
     it('sorts by saved order with stable name fallback', () => {

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -25,6 +25,17 @@ describe('team media page wiring', () => {
         const rules = fs.readFileSync(path.join(repoRoot, 'firestore.rules'), 'utf8');
         expect(rules).toContain('match /mediaFolders/{folderId}');
         expect(rules).toContain('allow read: if canAccessTeamChat(teamId);');
-        expect(rules).toContain('allow create, update, delete: if isTeamOwnerOrAdmin(teamId);');
+        expect(rules).toContain('allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaPhotoCreate(teamId, request.resource.data);');
+        expect(rules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaPhotoSoftDelete(teamId);');
     });
+    it('configures team-scoped storage rules for album photos', () => {
+        const firebaseJson = JSON.parse(fs.readFileSync(path.join(repoRoot, 'firebase.json'), 'utf8'));
+        const storageRules = fs.readFileSync(path.join(repoRoot, 'storage.rules'), 'utf8');
+
+        expect(firebaseJson.storage.rules).toBe('storage.rules');
+        expect(storageRules).toContain('match /team-media/{teamId}/{folderId}/{userId}/{fileName}');
+        expect(storageRules).toContain("request.resource.contentType.matches('image/.*')");
+        expect(storageRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
+    });
+
 });

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -15,7 +15,7 @@ describe('team media page wiring', () => {
         const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
 
         expect(page).toContain('src="js/team-media.js?v=2"');
-        expect(source).toContain("from './db.js?v=13'");
+        expect(source).toContain("from './db.js?v=14'");
         expect(source).toContain("import { checkAuth } from './auth.js?v=13';");
         expect(source).toContain('checkAuth(async (user) => {');
         expect(source).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');


### PR DESCRIPTION
Closes #869

## Summary
- Added team album photo upload UI with per-file progress and isolated per-file failure handling.
- Stored uploaded photos as typed team media items with URL, storage path, uploader, size, MIME type, and timestamps.
- Added Firestore and Storage rules for team-scoped reads/uploads plus owner/admin moderation and uploader self-delete.

## Validation
- `npx vitest run tests/unit/team-media-utils.test.js tests/unit/team-media-page.test.js tests/unit/team-media-wiring.test.js --reporter=dot`
- `node scripts/check-critical-cache-bust.mjs`