### PR TITLE
Persist Live Tracker substitutions

### DIFF
--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -1528,6 +1528,11 @@ function lineupSnapshot() {
   };
 }
 
+function persistLiveLineup() {
+  updateGame(currentTeamId, currentGameId, { liveLineup: lineupSnapshot() })
+    .catch(err => console.warn('Failed to sync live lineup:', err));
+}
+
 function broadcastLineupUpdate(description = 'Lineup updated') {
   if (liveState.isLive) {
     broadcastEvent(baseLiveEvent({
@@ -1536,8 +1541,7 @@ function broadcastLineupUpdate(description = 'Lineup updated') {
       ...lineupSnapshot()
     }));
   }
-  updateGame(currentTeamId, currentGameId, { liveLineup: lineupSnapshot() })
-    .catch(err => console.warn('Failed to sync live lineup:', err));
+  persistLiveLineup();
 }
 
 function buildVideoTimestampMetadataForStat(statKey) {
@@ -2670,6 +2674,8 @@ function applySub(outId, inId) {
       ...lineupSnapshot()
     }));
   }
+  persistLocalTrackerState();
+  persistLiveLineup();
   renderLineup();
   renderLive();
 }
@@ -2701,6 +2707,8 @@ function applyQueue(closeModal = true) {
   });
 
   state.subQueue = [];
+  persistLocalTrackerState();
+  persistLiveLineup();
   renderQueue();
   if (closeModal) {
     closeSubModal();

--- a/tests/unit/live-tracker-integrity.test.js
+++ b/tests/unit/live-tracker-integrity.test.js
@@ -188,4 +188,14 @@ describe('live tracker integrity helpers', () => {
     expect(workflowSource).toContain('scoreLogIsComplete: state.scoreLogIsComplete');
     expect(workflowSource).toContain('buildFinishCompletionPlan');
   });
+
+  it('persists live lineup after quick and queued substitutions', () => {
+    const liveTrackerSource = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8');
+    const quickSubBody = liveTrackerSource.match(/function applySub\([\s\S]*?function applyQueue/)?.[0] || '';
+    const queuedSubBody = liveTrackerSource.match(/function applyQueue[\s\S]*?function subIn/)?.[0] || '';
+
+    expect(liveTrackerSource).toContain('function persistLiveLineup()');
+    expect(quickSubBody).toContain('persistLiveLineup();');
+    expect(queuedSubBody).toContain('persistLiveLineup();');
+  });
 });


### PR DESCRIPTION
Closes #876

## Summary
- Added a dedicated live lineup persistence helper for the Live Tracker.
- Persist quick substitutions and queued substitutions to `game.liveLineup` after lineup state changes.
- Preserve existing substitution live events while avoiding extra lineup broadcasts.

## Validation
- `npx vitest run tests/unit/live-tracker-integrity.test.js`