### PR TITLE
Restore Track Live clock on reopen

### DIFF
--- a/js/track-live-state.js
+++ b/js/track-live-state.js
@@ -33,10 +33,14 @@ export function buildTrackLiveResetUpdate({
 } = {}) {
   const onCourt = Array.isArray(liveLineup?.onCourt) ? [...liveLineup.onCourt] : [];
   const bench = Array.isArray(liveLineup?.bench) ? [...liveLineup.bench] : [];
+  const resetPeriod = period || getDefaultLivePeriod({ game: currentGame, config: currentConfig });
   const resetUpdate = {
     homeScore: 0,
     awayScore: 0,
-    period: period || getDefaultLivePeriod({ game: currentGame, config: currentConfig }),
+    period: resetPeriod,
+    liveClockMs: 0,
+    liveClockRunning: false,
+    liveClockPeriod: resetPeriod,
     liveLineup: { onCourt, bench },
     opponentStats: {},
     liveStatus: 'scheduled',
@@ -54,6 +58,33 @@ export function buildTrackLiveResetUpdate({
   }
 
   return resetUpdate;
+}
+
+function normalizeNonNegativeMs(value) {
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) && numericValue > 0 ? numericValue : 0;
+}
+
+export function resolveTrackLiveClockResume({
+  currentGame = {},
+  currentPeriod = '',
+  fallbackPeriod = getDefaultLivePeriod({ game: currentGame }),
+  now = Date.now()
+} = {}) {
+  const savedClockMs = normalizeNonNegativeMs(currentGame?.liveClockMs);
+  const savedUpdatedAt = normalizeNonNegativeMs(currentGame?.liveClockUpdatedAt);
+  const isRunning = currentGame?.liveClockRunning === true;
+  const elapsedSinceLastSync = isRunning && savedUpdatedAt > 0
+    ? Math.max(0, normalizeNonNegativeMs(now) - savedUpdatedAt)
+    : 0;
+  const liveClockPeriod = String(currentGame?.liveClockPeriod || '').trim();
+  const savedPeriod = String(currentGame?.period || '').trim();
+
+  return {
+    elapsed: savedClockMs + elapsedSinceLastSync,
+    currentPeriod: liveClockPeriod || savedPeriod || currentPeriod || fallbackPeriod,
+    wasRunning: isRunning
+  };
 }
 
 export async function runTrackLiveResetPersistence({

--- a/tests/unit/track-live-state.test.js
+++ b/tests/unit/track-live-state.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { summarizePersistedTrackingState, buildTrackLiveResetUpdate } from '../../js/track-live-state.js';
+import { summarizePersistedTrackingState, buildTrackLiveResetUpdate, resolveTrackLiveClockResume } from '../../js/track-live-state.js';
 
 describe('track live state helpers', () => {
   it('summarizes when persisted data exists', () => {
@@ -51,6 +51,9 @@ describe('track live state helpers', () => {
       homeScore: 0,
       awayScore: 0,
       period: 'H2',
+      liveClockMs: 0,
+      liveClockRunning: false,
+      liveClockPeriod: 'H2',
       liveLineup: { onCourt: ['p1'], bench: ['p2', 'p3'] },
       opponentStats: {},
       liveStatus: 'scheduled',
@@ -75,6 +78,9 @@ describe('track live state helpers', () => {
     });
 
     expect(payload.period).toBe('Q1');
+    expect(payload.liveClockMs).toBe(0);
+    expect(payload.liveClockRunning).toBe(false);
+    expect(payload.liveClockPeriod).toBe('Q1');
     expect(payload.opponentTeamId).toBe('');
     expect(payload.opponentTeamName).toBe('');
     expect(payload.opponentTeamPhoto).toBe('');
@@ -103,5 +109,43 @@ describe('track live state helpers', () => {
     expect(buildTrackLiveResetUpdate({
       currentGame: { sport: 'Baseball' }
     }).period).toBe('T1');
+  });
+
+  it('restores persisted live clock and period from the game document', () => {
+    const resumed = resolveTrackLiveClockResume({
+      currentGame: {
+        liveClockMs: 125000,
+        liveClockRunning: false,
+        liveClockPeriod: 'H2',
+        period: 'H1'
+      },
+      currentPeriod: 'H1',
+      now: 1700000000000
+    });
+
+    expect(resumed).toEqual({
+      elapsed: 125000,
+      currentPeriod: 'H2',
+      wasRunning: false
+    });
+  });
+
+  it('advances a persisted running live clock from its last sync time', () => {
+    const resumed = resolveTrackLiveClockResume({
+      currentGame: {
+        liveClockMs: 60000,
+        liveClockRunning: true,
+        liveClockUpdatedAt: 1700000000000,
+        liveClockPeriod: 'Q3'
+      },
+      currentPeriod: 'Q1',
+      now: 1700000015000
+    });
+
+    expect(resumed).toEqual({
+      elapsed: 75000,
+      currentPeriod: 'Q3',
+      wasRunning: true
+    });
   });
 });

--- a/track-live.html
+++ b/track-live.html
@@ -669,7 +669,7 @@
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { resolveOpponentDisplayName, resolveLiveStatConfig, resolveLiveStatColumns } from './js/live-game-state.js?v=6';
         import { createFieldState, setPlayerFieldStatus, startFieldClock, pauseFieldClock, getPlayerFieldElapsedMs, getLiveLineup } from './js/live-tracker-field-status.js?v=1';
-        import { summarizePersistedTrackingState, buildTrackLiveResetUpdate, runTrackLiveResetPersistence } from './js/track-live-state.js?v=1';
+        import { summarizePersistedTrackingState, buildTrackLiveResetUpdate, resolveTrackLiveClockResume, runTrackLiveResetPersistence } from './js/track-live-state.js?v=2';
         import { getDefaultLivePeriod, getGoalSportProfile, getSportPeriodLabels, resolveLiveSport, isFootballSport } from './js/live-sport-config.js?v=3';
         import { applyGoalSportScore, buildGoalSportEvent } from './js/live-scorekeeping-goal-sports.js?v=1';
 
@@ -927,9 +927,16 @@
                 }
                 gameState.currentPeriod = gameState.isBaseballScorekeeping
                     ? getBaseballPeriodLabel(gameState.baseballState)
-                    : (isFootballTrackingConfig() && (game.period || game.liveClockPeriod))
-                        ? (game.period || game.liveClockPeriod)
-                        : periodLabels[0] || getDefaultLivePeriod({ game: currentGame, team: currentTeam, config: currentConfig });
+                    : periodLabels[0] || getDefaultLivePeriod({ game: currentGame, team: currentTeam, config: currentConfig });
+                const restoredClockState = resolveTrackLiveClockResume({
+                    currentGame: game,
+                    currentPeriod: gameState.currentPeriod,
+                    fallbackPeriod: getDefaultLivePeriod({ game: currentGame, team: currentTeam, config: currentConfig })
+                });
+                gameState.elapsed = restoredClockState.elapsed;
+                if (!gameState.isBaseballScorekeeping) {
+                    gameState.currentPeriod = restoredClockState.currentPeriod;
+                }
                 updateActivePeriodButtons();
                 configureGoalSportControls();
                 updateVolleyballDisplay();
@@ -979,6 +986,7 @@
                     renderStatsTable();
                     renderOpponentTable();
                 }
+                updateTimer();
                 setInterval(updateTimer, 1000);
                 initLiveChat();
                 watchViewerCount();
@@ -2323,7 +2331,7 @@
                 broadcastLiveEvent(currentTeamId, currentGameId, {
                     type: 'clock_start',
                     period: gameState.currentPeriod,
-                    gameClockMs: 0,
+                    gameClockMs: gameState.elapsed,
                     homeScore,
                     awayScore,
                     baseballState: gameState.isBaseballScorekeeping ? gameState.baseballState : null,


### PR DESCRIPTION
Closes #882

## Summary
- Restores persisted `liveClockMs` and `liveClockPeriod` when Track Live loads an in-progress game.
- Advances a previously running clock from `liveClockUpdatedAt` so refreshes do not resume from stale zero state.
- Broadcasts `clock_start` with the restored elapsed time instead of hardcoded `0`.
- Clears persisted live clock fields when resetting tracked game state.

## Tests
- `npx vitest run tests/unit/track-live-state.test.js tests/unit/track-live-live-events.test.js`