### PR TITLE
[codex] Fix roster, chat, media, and replay gating

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -32,9 +32,47 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit:ci
 
+  regression-guards:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate Firebase rules and deploy gates
+        run: npm run ci:firebase-rules
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Start local static server
+        run: python3 -m http.server 4173 >/tmp/allplays-preview-regression-guards.log 2>&1 &
+
+      - name: Run roster/chat/media/replay regression smoke
+        run: npm run test:smoke:team-fallback
+        env:
+          SMOKE_BASE_URL: http://127.0.0.1:4173
+
+      - name: Upload server log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: preview-regression-guards-http-log
+          path: /tmp/allplays-preview-regression-guards.log
+
   deploy:
     if: github.event.pull_request.head.repo.full_name == github.repository
-    needs: unit-tests
+    needs: [unit-tests, regression-guards]
     runs-on: ubuntu-latest
     permissions:
       checks: write

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -29,8 +29,45 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit:ci
 
+  regression-guards:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate Firebase rules and deploy gates
+        run: npm run ci:firebase-rules
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Start local static server
+        run: python3 -m http.server 4173 >/tmp/allplays-prod-regression-guards.log 2>&1 &
+
+      - name: Run roster/chat/media/replay regression smoke
+        run: npm run test:smoke:team-fallback
+        env:
+          SMOKE_BASE_URL: http://127.0.0.1:4173
+
+      - name: Upload server log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: prod-regression-guards-http-log
+          path: /tmp/allplays-prod-regression-guards.log
+
   deploy:
-    needs: unit-tests
+    needs: [unit-tests, regression-guards]
     runs-on: ubuntu-latest
     environment: production
     permissions:

--- a/.github/workflows/regression-guards.yml
+++ b/.github/workflows/regression-guards.yml
@@ -1,0 +1,61 @@
+name: regression-guards
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+concurrency:
+  group: regression-guards-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  firebase-rules-deploy-guard:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+
+      - name: Validate Firebase rules and deploy gates
+        run: npm run ci:firebase-rules
+
+  roster-chat-media-replay-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Start local static server
+        run: python3 -m http.server 4173 >/tmp/allplays-regression-guards.log 2>&1 &
+
+      - name: Run roster/chat/media/replay regression smoke
+        run: npm run test:smoke:team-fallback
+        env:
+          SMOKE_BASE_URL: http://127.0.0.1:4173
+
+      - name: Upload server log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: regression-guards-http-log
+          path: /tmp/allplays-regression-guards.log

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -1046,17 +1046,46 @@
             }
         }
 
+        async function loadOptionalRosterData(label, loader, fallback) {
+            try {
+                return await loader();
+            } catch (err) {
+                console.warn(`Failed to load ${label}:`, err);
+                return fallback;
+            }
+        }
+
         async function loadRoster() {
-            await refreshTrackingItems();
-            const [players, games, allUsers, membershipRequests, forms] = await Promise.all([
-                getPlayers(currentTeamId, { includeInactive: true }),
-                getGames(currentTeamId),
-                getAllUsers(),
-                listTeamParentMembershipRequests(currentTeamId),
-                listTeamRegistrationForms(currentTeamId)
+            const tbody = document.getElementById('roster-list');
+            try {
+                await refreshTrackingItems();
+            } catch (err) {
+                console.warn('Failed to load tracking items for roster:', err);
+                trackingItems = [];
+                selectedTrackingItemId = '';
+                renderTrackingItemSelect();
+            }
+
+            let players = [];
+            try {
+                players = await getPlayers(currentTeamId, { includeInactive: true });
+            } catch (err) {
+                console.error('Error loading roster players:', err);
+                tbody.innerHTML = `<tr><td colspan="3" class="px-6 py-4 text-center text-red-600">Unable to load roster players: ${escapeHtml(err?.message || 'Please try again.')}</td></tr>`;
+                return;
+            }
+
+            const [games, allUsers, membershipRequests, forms] = await Promise.all([
+                loadOptionalRosterData('games for roster links', () => getGames(currentTeamId), []),
+                loadOptionalRosterData('parent profiles for roster', () => getAllUsers(), []),
+                loadOptionalRosterData('parent membership requests for roster', () => listTeamParentMembershipRequests(currentTeamId), []),
+                loadOptionalRosterData('registration forms for roster', () => listTeamRegistrationForms(currentTeamId), [])
             ]);
             latestRosterPlayers = players;
             registrationForms = forms || [];
+            if (selectedRegistrationFormId && !registrationForms.some((form) => form.id === selectedRegistrationFormId)) {
+                selectedRegistrationFormId = '';
+            }
             if (!selectedRegistrationFormId && registrationForms.length > 0) {
                 selectedRegistrationFormId = registrationForms[0].id;
             }
@@ -1068,7 +1097,6 @@
                 const bDate = b.date.toDate ? b.date.toDate() : new Date(b.date);
                 return bDate - aDate;
             })[0]?.id || null;
-            const tbody = document.getElementById('roster-list');
 
             // Build parent lookup from user profiles (single source of truth)
             const parentsByPlayerId = new Map();

--- a/edit-team.html
+++ b/edit-team.html
@@ -260,6 +260,19 @@
                     </div>
                 </div>
 
+                <div class="rounded-lg border border-amber-200 bg-amber-50 p-4">
+                    <div class="flex items-start">
+                        <div class="flex items-center h-5">
+                            <input id="teamPassRecordedReplayPaywallEnabled" type="checkbox"
+                                class="focus:ring-amber-500 h-4 w-4 text-amber-600 border-gray-300 rounded">
+                        </div>
+                        <div class="ml-3 text-sm">
+                            <label for="teamPassRecordedReplayPaywallEnabled" class="font-medium text-amber-900">Require Team Pass for Archived Replays</label>
+                            <p class="text-amber-700">When enabled, completed game replay videos are locked unless this team has an active Team Pass for the season.</p>
+                        </div>
+                    </div>
+                </div>
+
                 <div class="flex items-start">
                     <div class="flex items-center h-5">
                         <input id="isPublic" type="checkbox"
@@ -513,6 +526,7 @@
         let rolloverSourceTeams = [];
         let rolloverAccessPreview = null;
         let currentRegistrationSource = null;
+        let currentTeamPassConfig = {};
         let lastRenderedRolloverSourceTeamId = null;
         let isInitPending = true;
         let selectedRegistrationTeam = null;
@@ -571,6 +585,16 @@
             const legacyKey = key === 'primary' ? 'primaryColor' : 'secondaryColor';
             const alternateKey = key === 'primary' ? 'colorPrimary' : 'colorSecondary';
             return normalizeHexColor(colors[key] || team[legacyKey] || team[alternateKey], fallback);
+        }
+
+        function getRecordedReplayPaywallConfigValue(team = {}) {
+            return [
+                team.teamPassConfig?.recordedReplayPaywallEnabled,
+                team.teamPass?.recordedReplayPaywallEnabled,
+                team.premiumFeatures?.recordedReplayPaywallEnabled,
+                team.recordedReplayPaywallEnabled,
+                team.recordedReplayTeamPassRequired
+            ].find((value) => typeof value === 'boolean') === true;
         }
 
         async function copyTextToClipboard(value) {
@@ -1084,6 +1108,10 @@
                 document.getElementById('standingsMultiTeamTiebreakers').value = multiTeamTiebreakers.join(', ');
                 document.getElementById('zip').value = team.zip || '';
                 document.getElementById('isPublic').checked = team.isPublic !== false; // Default to true
+                currentTeamPassConfig = team.teamPassConfig && typeof team.teamPassConfig === 'object'
+                    ? { ...team.teamPassConfig }
+                    : {};
+                document.getElementById('teamPassRecordedReplayPaywallEnabled').checked = getRecordedReplayPaywallConfigValue(team);
                 // Populate Live Stream field from twitchChannel, streamEmbedUrl, or legacy youtubeEmbedUrl
                 const streamInput = document.getElementById('streamUrl');
                 if (team.twitchChannel) {
@@ -1539,6 +1567,10 @@
                     },
                     photoUrl: currentPhotoUrl,
                     isPublic: document.getElementById('isPublic').checked,
+                    teamPassConfig: {
+                        ...currentTeamPassConfig,
+                        recordedReplayPaywallEnabled: document.getElementById('teamPassRecordedReplayPaywallEnabled').checked
+                    },
                     adminEmails: rolloverStaffUpdate ? rolloverStaffUpdate.adminEmails : normalizedAdminEmails,
                     registrationSource: registrationSourcePayload,
                     ...(createMode === 'registration' && selectedRegistrationTeam && registrationSourcePayload ? {

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -32,7 +32,7 @@ import {
   getReplayTimestampMs
 } from './live-game-replay.js?v=3';
 import { MAX_HIGHLIGHT_CLIP_MS, buildHighlightShareUrl, canAccessNativeCameraCapture, createHighlightClipDraft, resolveReplayVideoOptions, shouldReloadVideoPlayback } from './live-game-video.js?v=5';
-import { TEAM_PASS_FEATURES, canAccessPremiumFanFeature, getTeamEntitlementStatus, resolveTeamEntitlementSeasonId } from './team-entitlements.js?v=1';
+import { TEAM_PASS_FEATURES, canAccessPremiumFanFeature, getTeamEntitlementStatus, isRecordedReplayTeamPassGateEnabled, resolveTeamEntitlementSeasonId } from './team-entitlements.js?v=2';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
 import { resolveOpponentDisplayName, normalizeLiveStatColumns, resolveLiveStatColumns, renderViewerLineupSections, renderOpponentStatsCards, applyResetEventState, applyViewerEventToState, shouldResetViewerFromGameDoc, collectVisibleLiveEventsSequentially } from './live-game-state.js?v=6';
@@ -474,8 +474,9 @@ function setupVideoPanel(nextPlayback = resolveVideoPlayback()) {
   const previousPlayback = state.videoPlayback;
   const shouldReloadPlayback = shouldReloadVideoPlayback(previousPlayback, nextPlayback);
   state.videoPlayback = nextPlayback;
+  const recordedReplayGateEnabled = isRecordedReplayTeamPassGateEnabled({ game: state.game, team: state.team });
   const videoUnlocked = canAccessPremiumFanFeature(TEAM_PASS_FEATURES.RECORDED_REPLAY, state.teamEntitlement);
-  const isGatedRecordedReplay = state.videoPlayback?.mode === 'recorded' && !videoUnlocked;
+  const isGatedRecordedReplay = state.videoPlayback?.mode === 'recorded' && recordedReplayGateEnabled && !videoUnlocked;
   const canUseNativeCamera = userCanUseNativeCamera();
   const hasMediaHub = hasMediaHubContent(state.videoPlayback?.mediaHub);
   const hasGameClips = Boolean(state.videoPlayback?.gameClips?.length);
@@ -2318,11 +2319,15 @@ async function init() {
   state.lastResetAt = getTimestampMs(game.liveResetAt) || 0;
 
   const seasonId = resolveTeamEntitlementSeasonId({ game, team });
-  try {
-    state.teamEntitlement = await getTeamEntitlementStatus({ teamId: state.teamId, seasonId });
-  } catch (error) {
-    console.warn('Failed to load team entitlement:', error);
-    state.teamEntitlement = { active: false, reason: 'load-failed', seasonId, tier: 'team-pass' };
+  if (isRecordedReplayTeamPassGateEnabled({ game, team })) {
+    try {
+      state.teamEntitlement = await getTeamEntitlementStatus({ teamId: state.teamId, seasonId });
+    } catch (error) {
+      console.warn('Failed to load team entitlement:', error);
+      state.teamEntitlement = { active: false, reason: 'load-failed', seasonId, tier: 'team-pass' };
+    }
+  } else {
+    state.teamEntitlement = { active: false, reason: 'feature-disabled', seasonId, tier: 'team-pass' };
   }
 
   refreshVideoPanel({ force: true });

--- a/js/team-entitlements-core.js
+++ b/js/team-entitlements-core.js
@@ -3,6 +3,29 @@ export const TEAM_PASS_FEATURES = Object.freeze({
     RECORDED_REPLAY: 'recorded-replay'
 });
 
+function firstBoolean(values) {
+    return values.find(value => typeof value === 'boolean');
+}
+
+export function isRecordedReplayTeamPassGateEnabled({ game = {}, team = {} } = {}) {
+    const gameOverride = firstBoolean([
+        game.teamPassConfig?.recordedReplayPaywallEnabled,
+        game.teamPass?.recordedReplayPaywallEnabled,
+        game.premiumFeatures?.recordedReplayPaywallEnabled,
+        game.recordedReplayPaywallEnabled,
+        game.recordedReplayTeamPassRequired
+    ]);
+    if (typeof gameOverride === 'boolean') return gameOverride;
+
+    return firstBoolean([
+        team.teamPassConfig?.recordedReplayPaywallEnabled,
+        team.teamPass?.recordedReplayPaywallEnabled,
+        team.premiumFeatures?.recordedReplayPaywallEnabled,
+        team.recordedReplayPaywallEnabled,
+        team.recordedReplayTeamPassRequired
+    ]) === true;
+}
+
 export function resolveTeamEntitlementSeasonId({ game = {}, team = {}, fallbackDate = new Date() } = {}) {
     const explicitSeason = game.seasonId || game.season || team.currentSeasonId || team.seasonId || team.season;
     if (explicitSeason) return String(explicitSeason).trim();

--- a/js/team-entitlements.js
+++ b/js/team-entitlements.js
@@ -3,16 +3,18 @@ import {
     TEAM_PASS_TIER,
     buildTeamEntitlementId,
     canAccessPremiumFanFeature,
+    isRecordedReplayTeamPassGateEnabled,
     isTeamEntitlementActive,
     resolveTeamEntitlementSeasonId,
     TEAM_PASS_FEATURES
-} from './team-entitlements-core.js?v=1';
+} from './team-entitlements-core.js?v=2';
 
 export {
     TEAM_PASS_TIER,
     TEAM_PASS_FEATURES,
     buildTeamEntitlementId,
     canAccessPremiumFanFeature,
+    isRecordedReplayTeamPassGateEnabled,
     isTeamEntitlementActive,
     resolveTeamEntitlementSeasonId
 };

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -55,6 +55,8 @@ const els = {
     linkFolder: document.getElementById('link-folder'),
     linkTitle: document.getElementById('link-title'),
     linkUrl: document.getElementById('link-url'),
+    linkSubmit: document.getElementById('link-submit'),
+    linkFormHelp: document.getElementById('link-form-help'),
     moveFolder: document.getElementById('move-folder'),
     moveSelected: document.getElementById('move-selected'),
     deleteSelected: document.getElementById('delete-selected'),
@@ -98,11 +100,23 @@ function getItemsForFolder(folderId) {
 }
 
 function renderFolderOptions() {
+    const hasFolders = state.folders.length > 0;
     const options = state.folders.map((folder) => `<option value="${escapeHtml(folder.id)}">${escapeHtml(folder.name || 'Untitled folder')}</option>`).join('');
-    const placeholder = '<option value="">Choose folder</option>';
+    const placeholder = `<option value="">${hasFolders ? 'Choose folder' : 'Create a folder first'}</option>`;
     els.linkFolder.innerHTML = placeholder + options;
     els.photoFolder.innerHTML = placeholder + options;
     els.moveFolder.innerHTML = placeholder + options;
+    [els.linkFolder, els.linkTitle, els.linkUrl, els.linkSubmit].forEach((element) => {
+        if (!element) return;
+        element.disabled = !hasFolders;
+        element.classList.toggle('opacity-50', !hasFolders);
+        element.classList.toggle('cursor-not-allowed', !hasFolders);
+    });
+    if (els.linkFormHelp) {
+        els.linkFormHelp.textContent = hasFolders
+            ? 'Choose a folder, then save the video link.'
+            : 'Save a folder first. Video links need a folder destination.';
+    }
 }
 
 function renderBulkActions() {
@@ -161,14 +175,14 @@ function render() {
                         <div class="flex items-start gap-3">
                             ${state.canManage ? `<input type="checkbox" data-select-item="${escapeHtml(item.id)}" ${state.selectedIds.has(item.id) ? 'checked' : ''} class="mt-1 h-4 w-4 rounded border-gray-300">` : ''}
                             <div class="min-w-0 flex-1">
-                                <a href="${escapeHtml(itemUrl)}" target="_blank" rel="noopener noreferrer" class="font-semibold text-primary-700 hover:text-primary-900">${escapeHtml(title)}</a>
+                                <a href="${escapeHtml(itemUrl)}" target="_blank" rel="noopener noreferrer" class="font-semibold text-indigo-700 hover:text-indigo-900">${escapeHtml(title)}</a>
                                 <div class="text-xs text-gray-500">${escapeHtml(metadata || 'Media item')}</div>
                                 ${!isPhoto ? `<div class="break-all text-xs text-gray-500">${escapeHtml(itemUrl)}</div>` : ''}
                             </div>
                         </div>
                         <div class="mt-auto flex flex-wrap gap-2">
-                            <a href="${escapeHtml(itemUrl)}" download class="rounded-lg border border-primary-200 px-3 py-1 text-xs font-semibold text-primary-700 hover:bg-primary-50">Download</a>
-                            ${state.canManage && isPhoto ? `<button type="button" data-set-cover="${escapeHtml(item.id)}" data-folder-id="${escapeHtml(folder.id)}" class="rounded-lg border border-primary-200 px-3 py-1 text-xs font-semibold text-primary-700 hover:bg-primary-50">Set cover</button>` : ''}
+                            <a href="${escapeHtml(itemUrl)}" download class="rounded-lg border border-indigo-200 px-3 py-1 text-xs font-semibold text-indigo-700 hover:bg-indigo-50">Download</a>
+                            ${state.canManage && isPhoto ? `<button type="button" data-set-cover="${escapeHtml(item.id)}" data-folder-id="${escapeHtml(folder.id)}" class="rounded-lg border border-indigo-200 px-3 py-1 text-xs font-semibold text-indigo-700 hover:bg-indigo-50">Set cover</button>` : ''}
                             ${state.canManage ? `<button type="button" data-item-move="up" data-item-id="${escapeHtml(item.id)}" data-folder-id="${escapeHtml(folder.id)}" ${itemIndex === 0 ? 'disabled' : ''} class="rounded-lg border px-3 py-1 text-xs font-semibold disabled:opacity-40">Up</button>
                             <button type="button" data-item-move="down" data-item-id="${escapeHtml(item.id)}" data-folder-id="${escapeHtml(folder.id)}" ${itemIndex === items.length - 1 ? 'disabled' : ''} class="rounded-lg border px-3 py-1 text-xs font-semibold disabled:opacity-40">Down</button>` : ''}
                             ${canDeleteItem ? `<button type="button" data-item-delete="${escapeHtml(item.id)}" class="rounded-lg border border-red-200 px-3 py-1 text-xs font-semibold text-red-700 hover:bg-red-50">Delete</button>` : ''}
@@ -194,9 +208,40 @@ function render() {
     }).join('');
 }
 
+function isPermissionDenied(error) {
+    return error?.code === 'permission-denied' ||
+        String(error?.message || '').toLowerCase().includes('permission');
+}
+
+function getMediaPermissionMessage() {
+    return 'Team media permissions are not enabled for this Firebase project yet. Deploy the latest Firestore rules before adding folders or video links.';
+}
+
 async function loadLibrary() {
-    state.folders = await getTeamMediaFolders(state.teamId);
-    state.items = await getTeamMediaItems(state.teamId);
+    try {
+        [state.folders, state.items] = await Promise.all([
+            getTeamMediaFolders(state.teamId),
+            getTeamMediaItems(state.teamId)
+        ]);
+    } catch (error) {
+        if (!isPermissionDenied(error)) {
+            throw error;
+        }
+        if (state.canManage) {
+            console.warn('Team media management is blocked by Firestore rules:', error);
+            state.folders = [];
+            state.items = [];
+            state.selectedIds.clear();
+            render();
+            els.adminPanel.classList.add('hidden');
+            showAlert(getMediaPermissionMessage(), 'error');
+            els.foldersList.innerHTML = `<div class="rounded-2xl border border-red-200 bg-red-50 p-6 text-sm text-red-700">${escapeHtml(getMediaPermissionMessage())}</div>`;
+            return;
+        }
+        console.warn('Unable to load team media library; showing empty state:', error);
+        state.folders = [];
+        state.items = [];
+    }
     state.selectedIds = new Set([...state.selectedIds].filter((id) => state.items.some((item) => item.id === id)));
     render();
 }
@@ -209,7 +254,7 @@ async function persistAndReload(action, successMessage) {
         showAlert(successMessage, 'success');
     } catch (error) {
         console.error('Team media action failed:', error);
-        showAlert(error.message || 'Unable to save media changes. Refresh and try again.', 'error');
+        showAlert(isPermissionDenied(error) ? getMediaPermissionMessage() : (error.message || 'Unable to save media changes. Refresh and try again.'), 'error');
     }
 }
 
@@ -270,9 +315,10 @@ els.foldersList.addEventListener('change', (event) => {
 els.folderForm.addEventListener('submit', (event) => {
     event.preventDefault();
     persistAndReload(async () => {
-        await createTeamMediaFolder(state.teamId, els.folderName.value);
+        const folderName = els.folderName.value.trim();
+        await createTeamMediaFolder(state.teamId, folderName);
         els.folderName.value = '';
-    }, 'Folder added.');
+    }, 'Folder saved.');
 });
 
 els.linkForm.addEventListener('submit', (event) => {
@@ -284,7 +330,7 @@ els.linkForm.addEventListener('submit', (event) => {
         });
         els.linkTitle.value = '';
         els.linkUrl.value = '';
-    }, 'Video link added.');
+    }, 'Video link saved.');
 });
 
 els.uploadForm.addEventListener('submit', async (event) => {
@@ -304,7 +350,7 @@ els.uploadForm.addEventListener('submit', async (event) => {
     els.uploadProgress.innerHTML = files.map((file, index) => `
         <div data-upload-row="${index}" class="rounded-lg border border-gray-200 p-3">
             <div class="flex justify-between gap-3"><span>${escapeHtml(file.name)}</span><span data-upload-status="${index}">Waiting</span></div>
-            <div class="mt-2 h-2 rounded-full bg-gray-100"><div data-upload-bar="${index}" class="h-2 rounded-full bg-primary-600" style="width:0%"></div></div>
+            <div class="mt-2 h-2 rounded-full bg-gray-100"><div data-upload-bar="${index}" class="h-2 rounded-full bg-indigo-600" style="width:0%"></div></div>
         </div>`).join('');
 
     let uploadedCount = 0;

--- a/live-game.html
+++ b/live-game.html
@@ -284,7 +284,7 @@
           playsinline
           preload="metadata"
         ></video>
-        <div id="video-paywall" class="hidden flex-1 rounded-xl border border-gold/25 bg-ink/70 p-6 text-center md:flex md:flex-col md:items-center md:justify-center">
+        <div id="video-paywall" class="hidden flex-1 rounded-xl border border-gold/25 bg-ink/70 p-6 text-center">
           <p class="text-[11px] uppercase tracking-[0.25em] text-gold/80">Team Pass required</p>
           <h2 class="mt-2 text-xl font-display font-bold text-sand">Archived replay video is locked</h2>
           <p class="mt-2 max-w-md text-sm text-sand/70">This premium fan feature unlocks when your team has an active paid Team Pass for the season. Ask a coach or team admin to activate access.</p>
@@ -575,6 +575,6 @@
 
   <div id="footer-container"></div>
 
-  <script type="module" src="js/live-game.js?v=5"></script>
+  <script type="module" src="js/live-game.js?v=6"></script>
 </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "test:unit": "vitest run tests/unit",
     "test:unit:ci": "vitest run tests/unit --reporter=dot",
     "test:smoke": "playwright test --config=playwright.smoke.config.js",
+    "test:smoke:team-fallback": "playwright test tests/smoke/team-fallback-regressions.spec.js --config=playwright.smoke.config.js --reporter=line",
+    "ci:firebase-rules": "node scripts/validate-firebase-rules-ci.mjs",
     "serve:firebase": "firebase emulators:start --only hosting --project demo-allplays"
   },
   "devDependencies": {

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -1,0 +1,45 @@
+import { readFileSync } from 'node:fs';
+
+function readText(path) {
+    return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+}
+
+function assertIncludes(text, expected, label) {
+    if (!text.includes(expected)) {
+        throw new Error(`${label} is missing: ${expected}`);
+    }
+}
+
+function assertMatches(text, pattern, label) {
+    if (!pattern.test(text)) {
+        throw new Error(`${label} did not match ${pattern}`);
+    }
+}
+
+const firebaseJson = JSON.parse(readText('firebase.json'));
+const firestoreRules = readText('firestore.rules');
+const deployProd = readText('.github/workflows/deploy-prod.yml');
+const deployPreview = readText('.github/workflows/deploy-preview.yml');
+const regressionGuards = readText('.github/workflows/regression-guards.yml');
+
+if (firebaseJson.firestore?.rules !== 'firestore.rules') {
+    throw new Error('firebase.json must deploy firestore.rules.');
+}
+
+if (firebaseJson.firestore?.indexes !== 'firestore.indexes.json') {
+    throw new Error('firebase.json must deploy firestore.indexes.json.');
+}
+
+assertIncludes(firestoreRules, 'match /mediaFolders/{folderId}', 'Firestore media folder rules');
+assertIncludes(firestoreRules, 'match /mediaItems/{itemId}', 'Firestore media item rules');
+assertIncludes(firestoreRules, 'allow read: if canAccessTeamChat(teamId);', 'Firestore media read rules');
+assertIncludes(firestoreRules, 'allow create, update, delete: if isTeamOwnerOrAdmin(teamId);', 'Firestore media write rules');
+
+assertIncludes(deployProd, 'firestore:rules', 'Production deploy');
+assertIncludes(deployProd, 'firestore:indexes', 'Production deploy');
+assertMatches(deployProd, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Production deploy gate');
+
+assertMatches(deployPreview, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Preview deploy gate');
+
+assertIncludes(regressionGuards, 'npm run ci:firebase-rules', 'Regression guard workflow');
+assertIncludes(regressionGuards, 'npm run test:smoke:team-fallback', 'Regression guard workflow');

--- a/team-chat.html
+++ b/team-chat.html
@@ -229,7 +229,7 @@
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=13';
         import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=31';
-        import { DEFAULT_TEAM_CONVERSATION_ID, getConversationDisplayName, isDefaultTeamConversation } from './js/team-chat-conversations.js?v=1';
+        import { DEFAULT_TEAM_CONVERSATION_ID, buildDefaultTeamConversation, getConversationDisplayName, isDefaultTeamConversation } from './js/team-chat-conversations.js?v=1';
         import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from './js/team-chat-last-read.js?v=3';
         import {
             MAX_CHAT_MEDIA_SIZE,
@@ -1061,10 +1061,15 @@
         }
 
         async function loadConversations() {
-            conversations = await getChatConversations(teamId, currentUser, {
-                team: currentTeam,
-                canModerate
-            });
+            try {
+                conversations = await getChatConversations(teamId, currentUser, {
+                    team: currentTeam,
+                    canModerate
+                });
+            } catch (error) {
+                console.warn('Failed to load chat conversations; falling back to team-wide channel:', error);
+                conversations = [buildDefaultTeamConversation(currentTeam)];
+            }
             if (!conversations.some((conversation) => conversation.id === selectedConversationId)) {
                 selectedConversationId = DEFAULT_TEAM_CONVERSATION_ID;
             }

--- a/team-media.html
+++ b/team-media.html
@@ -15,42 +15,52 @@
     <main class="container mx-auto px-4 py-8 max-w-6xl">
         <div class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
             <div>
-                <p class="text-xs font-semibold uppercase tracking-[0.25em] text-primary-600">Team Media</p>
+                <p class="text-xs font-semibold uppercase tracking-[0.25em] text-indigo-600">Team Media</p>
                 <h1 id="team-media-title" class="text-3xl font-bold">Media Library</h1>
                 <p id="team-media-subtitle" class="text-sm text-gray-500">Organized photos, video links, and highlights for this team.</p>
             </div>
-            <a id="team-back-link" href="team.html" class="text-sm font-semibold text-primary-700 hover:text-primary-900">Back to team</a>
+            <a id="team-back-link" href="team.html" class="text-sm font-semibold text-indigo-700 hover:text-indigo-900">Back to team</a>
         </div>
 
         <div id="team-media-alert" class="hidden mb-4 rounded-xl border px-4 py-3 text-sm"></div>
 
-        <section id="team-media-upload-panel" class="hidden mb-6 rounded-2xl border border-primary-100 bg-white p-5 shadow-sm">
+        <section id="team-media-upload-panel" class="hidden mb-6 rounded-xl border border-indigo-100 bg-white p-5 shadow-sm">
             <form id="photo-upload-form" class="space-y-3">
                 <h2 class="font-semibold text-gray-900">Upload photos</h2>
                 <p class="text-sm text-gray-500">Choose an album and add one or more image files.</p>
                 <select id="photo-folder" class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" required></select>
                 <input id="photo-files" type="file" accept="image/*" multiple class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" required>
-                <button class="rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700">Upload photos</button>
+                <button class="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2">Upload photos</button>
                 <div id="upload-progress" class="space-y-2 text-sm"></div>
             </form>
         </section>
 
-        <section id="team-media-admin-panel" class="hidden mb-6 rounded-2xl border border-primary-100 bg-white p-5 shadow-sm">
-            <div class="grid gap-4 lg:grid-cols-2">
+        <section id="team-media-admin-panel" class="hidden mb-6 rounded-xl border border-indigo-100 bg-white p-5 shadow-sm">
+            <div class="grid gap-5 lg:grid-cols-2">
                 <form id="folder-form" class="space-y-3">
-                    <h2 class="font-semibold text-gray-900">Add folder</h2>
-                    <div class="flex gap-2">
-                        <input id="folder-name" class="flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm" placeholder="Folder name" required>
-                        <button class="rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700">Add</button>
+                    <div>
+                        <h2 class="font-semibold text-gray-900">Folders</h2>
+                        <p class="text-xs text-gray-500">Create a folder before adding video links.</p>
+                    </div>
+                    <div class="flex flex-col gap-2 sm:flex-row">
+                        <label for="folder-name" class="sr-only">Folder name</label>
+                        <input id="folder-name" class="min-w-0 flex-1 rounded-lg border border-gray-300 px-3 py-2 text-sm" placeholder="Folder name" required>
+                        <button id="folder-submit" type="submit" class="inline-flex justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2">Save folder</button>
                     </div>
                 </form>
 
                 <form id="link-form" class="space-y-3">
-                    <h2 class="font-semibold text-gray-900">Add video link</h2>
+                    <div>
+                        <h2 class="font-semibold text-gray-900">Video links</h2>
+                        <p id="link-form-help" class="text-xs text-gray-500">Choose a folder, then save the video link.</p>
+                    </div>
+                    <label for="link-folder" class="sr-only">Folder</label>
                     <select id="link-folder" class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" required></select>
-                    <input id="link-title" class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" placeholder="Title" required>
+                    <label for="link-title" class="sr-only">Video title</label>
+                    <input id="link-title" class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" placeholder="Video title" required>
+                    <label for="link-url" class="sr-only">Video URL</label>
                     <input id="link-url" type="url" class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" placeholder="https://..." required>
-                    <button class="rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700">Add link</button>
+                    <button id="link-submit" type="submit" class="inline-flex w-full justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2 sm:w-auto">Save video link</button>
                 </form>
             </div>
         </section>
@@ -60,7 +70,7 @@
                 <div class="text-sm font-semibold"><span id="selected-count">0</span> selected</div>
                 <div class="flex flex-wrap gap-2">
                     <select id="move-folder" class="rounded-lg border border-gray-300 px-3 py-2 text-sm"></select>
-                    <button id="move-selected" class="rounded-lg border border-primary-200 px-4 py-2 text-sm font-semibold text-primary-700 hover:bg-primary-50">Move selected</button>
+                    <button id="move-selected" class="rounded-lg border border-indigo-200 px-4 py-2 text-sm font-semibold text-indigo-700 hover:bg-indigo-50">Move selected</button>
                     <button id="delete-selected" class="rounded-lg border border-red-200 px-4 py-2 text-sm font-semibold text-red-700 hover:bg-red-50">Delete selected</button>
                 </div>
             </div>
@@ -71,6 +81,6 @@
         </section>
     </main>
 
-    <script type="module" src="js/team-media.js?v=2"></script>
+    <script type="module" src="js/team-media.js?v=3"></script>
 </body>
 </html>

--- a/tests/smoke/team-fallback-regressions.spec.js
+++ b/tests/smoke/team-fallback-regressions.spec.js
@@ -1,0 +1,719 @@
+import { test, expect } from '@playwright/test';
+
+const PERMISSION_ERROR = `
+function permissionDenied() {
+    const error = new Error('Missing or insufficient permissions.');
+    error.code = 'permission-denied';
+    return error;
+}
+`;
+
+const AUTH_STUB = `
+export function checkAuth(callback) {
+    callback({
+        uid: 'user-1',
+        email: 'coach@example.com',
+        isAdmin: false,
+        parentOf: [{ teamId: 'team-1', playerId: 'player-1' }]
+    });
+}
+export async function sendInviteEmail() {}
+`;
+
+const UTILS_STUB = `
+export function renderHeader() {}
+export function renderFooter() {}
+export function getUrlParams() {
+    return { teamId: 'team-1' };
+}
+export function escapeHtml(value) {
+    if (value === null || value === undefined) return '';
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+`;
+
+const TEAM_ADMIN_BANNER_STUB = `
+export function renderTeamAdminBanner() {}
+export function getTeamAccessInfo() {
+    return { hasAccess: true, accessLevel: 'full', exitUrl: 'dashboard.html' };
+}
+`;
+
+const TEAM_ACCESS_STUB = `
+export function hasFullTeamAccess() {
+    return true;
+}
+`;
+
+const FIREBASE_APP_STUB = `
+export function getApp() {
+    return {};
+}
+`;
+
+const FIREBASE_AI_STUB = `
+export class GoogleAIBackend {}
+export const Schema = {};
+export function getAI() {
+    return {};
+}
+export function getGenerativeModel() {
+    return {};
+}
+`;
+
+const ROSTER_PROFILE_FIELDS_STUB = `
+export function buildRosterFieldDefinitionPayload(field = {}, index = 0) {
+    return { key: field.key || 'field-' + index, label: field.label || 'Field' };
+}
+export function collectRosterProfileValues() {
+    return {};
+}
+export function getRosterProfileValues() {
+    return {};
+}
+export function normalizeRosterFieldDefinitions(fields = []) {
+    return Array.isArray(fields) ? fields : [];
+}
+export function planRosterCsvImport() {
+    return { operations: [], errors: [] };
+}
+export function renderRosterProfileFields(container) {
+    if (container) container.innerHTML = '';
+}
+export function validateRosterProfileValues() {
+    return [];
+}
+`;
+
+const REGISTRATION_IMPORT_STUB = `
+export function formatRegistrationRosterImportResults() {
+    return '0 players';
+}
+export function getRegistrationRosterPlayers() {
+    return [];
+}
+export function isExternallyLinkedRosterTeam() {
+    return false;
+}
+export function planRegistrationRosterImport() {
+    return { operations: [], results: { conflicts: [] } };
+}
+`;
+
+const ROSTER_DB_STUB = `
+${PERMISSION_ERROR}
+export async function getTeam(teamId) {
+    return { id: teamId, name: 'Roster Test Team', ownerId: 'user-1', adminEmails: [] };
+}
+export async function getPlayers() {
+    return [
+        { id: 'player-1', name: 'Avery Carter', number: '12', active: true },
+        { id: 'player-2', name: 'Jordan Reed', number: '22', active: true }
+    ];
+}
+export async function addPlayer() {}
+export async function deactivatePlayer() {}
+export async function reactivatePlayer() {}
+export async function getGames() {
+    return [];
+}
+export async function uploadPlayerPhoto() {
+    return '';
+}
+export async function updatePlayer() {}
+export async function setPlayerPrivateRosterProfileFields() {}
+export async function inviteParent() {
+    return {};
+}
+export async function removeParentFromPlayer() {}
+export async function getAllUsers() {
+    throw permissionDenied();
+}
+export async function getUnreadChatCount() {
+    return 0;
+}
+export async function listTeamParentMembershipRequests() {
+    throw permissionDenied();
+}
+export async function approveParentMembershipRequest() {}
+export async function denyParentMembershipRequest() {}
+export async function getRosterFieldDefinitions() {
+    return [];
+}
+export async function saveRosterFieldDefinition() {}
+export async function disableRosterFieldDefinition() {}
+export async function reorderRosterFieldDefinitions() {}
+export async function listTeamRegistrationForms() {
+    throw permissionDenied();
+}
+export async function listTeamRegistrationReviews() {
+    throw permissionDenied();
+}
+export async function approveTeamRegistration() {}
+export async function rejectTeamRegistration() {}
+export async function listTeamTrackingItems() {
+    throw permissionDenied();
+}
+export async function createTeamTrackingItem() {}
+export async function listTeamTrackingStatuses() {
+    return [];
+}
+export async function setTeamTrackingStatus() {}
+`;
+
+const CHAT_DB_STUB = `
+${PERMISSION_ERROR}
+const createdAt = {
+    toDate() {
+        return new Date('2026-05-09T16:00:00Z');
+    }
+};
+export async function getTeam(teamId) {
+    return { id: teamId, name: 'Chat Test Team', ownerId: 'owner-1', adminEmails: [] };
+}
+export async function getUserProfile() {
+    return { parentOf: [{ teamId: 'team-1', playerId: 'player-1' }], email: 'coach@example.com' };
+}
+export async function getPlayers() {
+    return [];
+}
+export async function getGames() {
+    return [];
+}
+export async function getGameEvents() {
+    return [];
+}
+export async function getAggregatedStatsForGames() {
+    return [];
+}
+export async function getChatConversations() {
+    throw permissionDenied();
+}
+export async function upsertChatConversation() {}
+export async function getChatMessages() {
+    return [];
+}
+export async function postChatMessage() {}
+export async function editChatMessage() {}
+export async function deleteChatMessage() {}
+export function canAccessTeamChat() {
+    return true;
+}
+export function canModerateChat() {
+    return false;
+}
+export async function updateChatLastRead() {}
+export function subscribeToChatMessages(teamId, options, onMessages) {
+    setTimeout(() => {
+        onMessages([
+            {
+                id: 'message-1',
+                text: 'Hello team',
+                senderId: 'coach-2',
+                senderName: 'Coach Lee',
+                createdAt,
+                reactions: {}
+            }
+        ], { id: 'oldest-doc' });
+    }, 0);
+    return () => {};
+}
+export async function uploadChatImage() {}
+export async function deleteUploadedChatAttachments() {}
+export async function toggleChatReaction() {}
+`;
+
+const MEDIA_DB_STUB = `
+${PERMISSION_ERROR}
+export async function getTeam(teamId) {
+    return { id: teamId, name: 'Media Test Team', ownerId: 'owner-1', adminEmails: [] };
+}
+export async function getTeamMediaFolders() {
+    throw permissionDenied();
+}
+export async function getTeamMediaItems() {
+    throw permissionDenied();
+}
+export async function createTeamMediaFolder() {}
+export async function createTeamMediaLink() {}
+export async function reorderTeamMediaFolders() {}
+export async function reorderTeamMediaItems() {}
+export async function moveTeamMediaItems() {}
+export async function bulkDeleteTeamMediaItems() {}
+export async function setTeamMediaAlbumCover() {}
+`;
+
+const MEDIA_DB_WITH_FOLDER_STUB = `
+export async function getTeam(teamId) {
+    return { id: teamId, name: 'Media Test Team', ownerId: 'owner-1', adminEmails: [] };
+}
+export async function getTeamMediaFolders() {
+    return [{ id: 'folder-1', name: 'Highlights', order: 0 }];
+}
+export async function getTeamMediaItems() {
+    return [];
+}
+export async function createTeamMediaFolder() {}
+export async function createTeamMediaLink() {}
+export async function reorderTeamMediaFolders() {}
+export async function reorderTeamMediaItems() {}
+export async function moveTeamMediaItems() {}
+export async function bulkDeleteTeamMediaItems() {}
+export async function setTeamMediaAlbumCover() {}
+`;
+
+const MEDIA_UTILS_STUB = `
+export function canManageTeamMedia() {
+    return false;
+}
+export function getTeamMediaItemUrl(item = {}) {
+    return item.url || item.downloadUrl || '';
+}
+export function getTeamMediaUploaderName() {
+    return '';
+}
+export function isSafeTeamMediaPhoto() {
+    return false;
+}
+export function isSafeTeamMediaUrl() {
+    return true;
+}
+export function sortByMediaOrder(items = []) {
+    return items;
+}
+`;
+
+const MEDIA_UTILS_ADMIN_STUB = `
+export function canManageTeamMedia() {
+    return true;
+}
+export function getTeamMediaItemUrl(item = {}) {
+    return item.url || item.downloadUrl || '';
+}
+export function getTeamMediaUploaderName() {
+    return '';
+}
+export function isSafeTeamMediaPhoto() {
+    return false;
+}
+export function isSafeTeamMediaUrl() {
+    return true;
+}
+export function sortByMediaOrder(items = []) {
+    return items;
+}
+`;
+
+const LIVE_GAME_UTILS_STUB = `
+export function renderHeader() {}
+export function renderFooter() {}
+export function getUrlParams() {
+    return { teamId: 'team-1', gameId: 'game-1', replay: 'true' };
+}
+export function escapeHtml(value) {
+    if (value === null || value === undefined) return '';
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+export function formatShortDate() {
+    return 'May 9';
+}
+export function formatTime() {
+    return '7:00 PM';
+}
+export async function shareOrCopy() {
+    return { status: 'copied' };
+}
+`;
+
+const LIVE_GAME_DB_STUB = `
+export async function getTeam(teamId) {
+    return {
+        ...(window.__LIVE_GAME_TEAM__ || {}),
+        id: teamId,
+        name: 'Replay Test Team',
+        sport: 'basketball'
+    };
+}
+export async function getGame(gameId) {
+    return {
+        id: gameId,
+        date: '2026-05-09T19:00:00Z',
+        liveStatus: 'completed',
+        status: 'completed',
+        homeScore: 42,
+        awayScore: 38,
+        period: 'Final',
+        sport: 'basketball',
+        recordedVideo: { url: 'https://cdn.example.test/replay.mp4' }
+    };
+}
+export async function getPlayers() {
+    return [];
+}
+export function subscribeLiveEvents() {
+    return () => {};
+}
+export function subscribeLiveChat() {
+    return () => {};
+}
+export async function postLiveChatMessage() {}
+export function subscribeReactions() {
+    return () => {};
+}
+export async function sendReaction() {}
+export function trackViewerPresence() {
+    return () => {};
+}
+export async function getLiveEvents() {
+    return [];
+}
+export async function getLiveChatHistory() {
+    return [];
+}
+export async function getLiveReactions() {
+    return [];
+}
+export async function getConfigs() {
+    return [];
+}
+export function subscribeGame() {
+    return () => {};
+}
+export async function updateGame() {}
+export async function uploadGameClip() {
+    return { url: '' };
+}
+`;
+
+const LIVE_GAME_STREAM_UTILS_STUB = `
+export function computePanelVisibility() {
+    return {
+        showVideoPanel: true,
+        showVideoTab: true,
+        showExternalLink: false
+    };
+}
+`;
+
+const LIVE_GAME_ACCESS_STUB = `
+export function hasFullTeamAccess() {
+    return false;
+}
+`;
+
+const LIVE_GAME_CLIPS_STUB = `
+export function buildScoreLinkedClipRecord() {
+    return {};
+}
+export function isScoredPlayEvent() {
+    return false;
+}
+export function validateGameClipFile() {}
+`;
+
+const LIVE_GAME_CHAT_STUB = `
+export function isViewerChatEnabled() {
+    return false;
+}
+`;
+
+const LIVE_GAME_ANNOUNCER_STUB = `
+export function createPlayAnnouncer() {
+    return {
+        isSupported: () => false,
+        isEnabled: () => false,
+        isPaused: () => false,
+        setEnabled: () => false,
+        setPaused: () => false,
+        announceEvent: () => false
+    };
+}
+`;
+
+const LIVE_GAME_REPLAY_STUB = `
+export function buildReplaySessionState({ teamId, gameId, game = {} } = {}) {
+    return {
+        hasReplayEvents: false,
+        showReplayControls: true,
+        hideReactionsBar: true,
+        hideEndedOverlay: true,
+        replayGameHref: 'game.html#teamId=' + teamId + '&gameId=' + gameId,
+        emptyStateMessage: 'No play-by-play data available for this game.',
+        scoreboard: {
+            homeScore: game.homeScore || 0,
+            awayScore: game.awayScore || 0,
+            period: game.period || 'Final',
+            gameClockMs: 0
+        },
+        replayEvents: [],
+        replayChat: [],
+        replayReactions: [],
+        replayStartAt: 0
+    };
+}
+export function collectReplayEventWindow() {
+    return { events: [], nextReplayIndex: 0 };
+}
+export function collectReplayStreamWindow() {
+    return { chatMessages: [], nextReplayChatIndex: 0, reactions: [], nextReplayReactionIndex: 0 };
+}
+export function getReplayElapsedMs() {
+    return 0;
+}
+export function getReplayStartTimeAfterSpeedChange() {
+    return 0;
+}
+export function getReplayTimestampMs(value) {
+    return value?.toMillis?.() ?? value ?? null;
+}
+`;
+
+const LIVE_GAME_VIDEO_STUB = `
+export const MAX_HIGHLIGHT_CLIP_MS = 60000;
+export function buildHighlightShareUrl() {
+    return '';
+}
+export function canAccessNativeCameraCapture() {
+    return false;
+}
+export function createHighlightClipDraft() {
+    return { startMs: 0, endMs: 0, title: '' };
+}
+export function resolveReplayVideoOptions() {
+    return {
+        mode: 'recorded',
+        hasVideo: true,
+        sourceUrl: 'https://cdn.example.test/replay.mp4',
+        publicUrl: 'https://cdn.example.test/replay.mp4'
+    };
+}
+export function shouldReloadVideoPlayback() {
+    return true;
+}
+`;
+
+const LIVE_GAME_ENTITLEMENTS_STUB = `
+export const TEAM_PASS_FEATURES = { RECORDED_REPLAY: 'recorded-replay' };
+function firstBoolean(values) {
+    return values.find((value) => typeof value === 'boolean');
+}
+export function isRecordedReplayTeamPassGateEnabled({ game = {}, team = {} } = {}) {
+    const gameOverride = firstBoolean([
+        game.teamPassConfig?.recordedReplayPaywallEnabled,
+        game.recordedReplayPaywallEnabled,
+        game.recordedReplayTeamPassRequired
+    ]);
+    if (typeof gameOverride === 'boolean') return gameOverride;
+    return firstBoolean([
+        team.teamPassConfig?.recordedReplayPaywallEnabled,
+        team.recordedReplayPaywallEnabled,
+        team.recordedReplayTeamPassRequired
+    ]) === true;
+}
+export function canAccessPremiumFanFeature(featureKey, entitlementStatus = {}) {
+    return Boolean(featureKey && entitlementStatus.active);
+}
+export async function getTeamEntitlementStatus() {
+    window.__TEAM_PASS_ENTITLEMENT_READS__ = (window.__TEAM_PASS_ENTITLEMENT_READS__ || 0) + 1;
+    return { active: false, reason: 'not-active', seasonId: '2026', tier: 'team-pass' };
+}
+export function resolveTeamEntitlementSeasonId() {
+    return '2026';
+}
+`;
+
+const LIVE_GAME_STATE_STUB = `
+export function resolveOpponentDisplayName() {
+    return 'Opponent';
+}
+export function normalizeLiveStatColumns(columns) {
+    return columns || [];
+}
+export function resolveLiveStatColumns() {
+    return [];
+}
+export function renderViewerLineupSections() {
+    return { onCourtIds: [], benchIds: [], onCourtHtml: '', benchHtml: '' };
+}
+export function renderOpponentStatsCards() {
+    return '';
+}
+export function applyResetEventState() {}
+export function applyViewerEventToState() {}
+export function shouldResetViewerFromGameDoc() {
+    return false;
+}
+export function collectVisibleLiveEventsSequentially(events) {
+    return events || [];
+}
+`;
+
+const LIVE_GAME_SPORT_CONFIG_STUB = `
+export function getDefaultLivePeriod() {
+    return 'Final';
+}
+`;
+
+async function routeCommonPageStubs(page) {
+    await page.route('**/js/auth.js?v=13', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
+    await page.route('**/js/utils.js?v=8', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: UTILS_STUB }));
+    await page.route(/\/js\/team-admin-banner\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ADMIN_BANNER_STUB }));
+    await page.route('**/js/vendor/firebase-app.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_APP_STUB }));
+    await page.route('**/js/vendor/firebase-ai.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_AI_STUB }));
+}
+
+async function routeLiveGameStubs(page) {
+    await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: LIVE_GAME_DB_STUB }));
+    await page.route(/\/js\/utils\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: LIVE_GAME_UTILS_STUB }));
+    await page.route(/\/js\/team-access\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: LIVE_GAME_ACCESS_STUB }));
+    await page.route(/\/js\/game-clips\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: LIVE_GAME_CLIPS_STUB }));
+    await page.route(/\/js\/live-stream-utils\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: LIVE_GAME_STREAM_UTILS_STUB }));
+    await page.route(/\/js\/auth\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
+    await page.route(/\/js\/live-game-chat\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: LIVE_GAME_CHAT_STUB }));
+    await page.route(/\/js\/live-game-announcer\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: LIVE_GAME_ANNOUNCER_STUB }));
+    await page.route(/\/js\/live-game-replay\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: LIVE_GAME_REPLAY_STUB }));
+    await page.route(/\/js\/live-game-video\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: LIVE_GAME_VIDEO_STUB }));
+    await page.route(/\/js\/team-entitlements\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: LIVE_GAME_ENTITLEMENTS_STUB }));
+    await page.route(/\/js\/live-game-state\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: LIVE_GAME_STATE_STUB }));
+    await page.route(/\/js\/live-sport-config\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: LIVE_GAME_SPORT_CONFIG_STUB }));
+    await page.route('**/js/vendor/firebase-app.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_APP_STUB }));
+    await page.route('**/js/vendor/firebase-ai.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_AI_STUB }));
+    await page.route('https://cdn.example.test/replay.mp4', (route) => route.fulfill({ status: 200, contentType: 'video/mp4', body: '' }));
+}
+
+async function collectPageErrors(page) {
+    const errors = [];
+    page.on('pageerror', (error) => errors.push(error.message));
+    return errors;
+}
+
+test('edit roster renders players when optional registration and parent reads are denied', async ({ page, baseURL }) => {
+    const pageErrors = await collectPageErrors(page);
+    await routeCommonPageStubs(page);
+    await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: ROSTER_DB_STUB }));
+    await page.route('**/js/team-access.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ACCESS_STUB }));
+    await page.route('**/js/roster-profile-fields.js?v=3', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: ROSTER_PROFILE_FIELDS_STUB }));
+    await page.route('**/js/edit-roster-registration-import.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: REGISTRATION_IMPORT_STUB }));
+
+    await page.goto(`${baseURL}/edit-roster.html?teamId=team-1`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#team-name-display')).toHaveText('Roster Test Team');
+    await expect(page.locator('#roster-list')).toContainText('Avery Carter');
+    await expect(page.locator('#roster-list')).toContainText('Jordan Reed');
+    await expect(page.locator('#registration-review-list')).toContainText('No registration forms configured for this team.');
+    expect(pageErrors).toEqual([]);
+});
+
+test('team chat falls back to the team-wide channel when conversation listing is denied', async ({ page, baseURL }) => {
+    const pageErrors = await collectPageErrors(page);
+    await routeCommonPageStubs(page);
+    await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: CHAT_DB_STUB }));
+
+    await page.goto(`${baseURL}/team-chat.html?teamId=team-1`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#conversations-list')).toContainText('Chat Test Team Team Chat');
+    await expect(page.locator('#messages-container')).toContainText('Hello team');
+    await expect(page.locator('#messages-container')).not.toContainText('Loading messages');
+    await expect(page.locator('#send-error')).toBeHidden();
+    expect(pageErrors).toEqual([]);
+});
+
+test('team media shows an empty library when media reads are denied', async ({ page, baseURL }) => {
+    const pageErrors = await collectPageErrors(page);
+    await page.route('**/js/auth.js?v=13', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
+    await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: MEDIA_DB_STUB }));
+    await page.route('**/js/team-media-utils.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: MEDIA_UTILS_STUB }));
+
+    await page.goto(`${baseURL}/team-media.html?teamId=team-1`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#team-media-title')).toHaveText('Media Test Team Media');
+    await expect(page.locator('#folders-list')).toContainText('No media folders have been shared yet.');
+    await expect(page.locator('#folders-list')).not.toContainText('Unable to load team media');
+    expect(pageErrors).toEqual([]);
+});
+
+test('team media shows a staff permission error when rules block management reads', async ({ page, baseURL }) => {
+    const pageErrors = await collectPageErrors(page);
+    await page.route('**/js/auth.js?v=13', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
+    await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: MEDIA_DB_STUB }));
+    await page.route('**/js/team-media-utils.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: MEDIA_UTILS_ADMIN_STUB }));
+
+    await page.goto(`${baseURL}/team-media.html?teamId=team-1`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#team-media-title')).toHaveText('Media Test Team Media');
+    await expect(page.locator('#team-media-admin-panel')).toBeHidden();
+    await expect(page.locator('#team-media-alert')).toContainText('Team media permissions are not enabled');
+    await expect(page.locator('#folders-list')).toContainText('Deploy the latest Firestore rules');
+    expect(pageErrors).toEqual([]);
+});
+
+test('team media renders visible save actions for staff', async ({ page, baseURL }) => {
+    const pageErrors = await collectPageErrors(page);
+    await page.route('**/js/auth.js?v=13', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
+    await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: MEDIA_DB_WITH_FOLDER_STUB }));
+    await page.route('**/js/team-media-utils.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: MEDIA_UTILS_ADMIN_STUB }));
+
+    await page.goto(`${baseURL}/team-media.html?teamId=team-1`, { waitUntil: 'domcontentloaded' });
+
+    const folderButton = page.locator('#folder-submit');
+    const linkButton = page.locator('#link-submit');
+    await expect(folderButton).toBeVisible();
+    await expect(folderButton).toHaveText('Save folder');
+    await expect(linkButton).toBeVisible();
+    await expect(linkButton).toHaveText('Save video link');
+    await expect(page.locator('#link-folder')).toContainText('Highlights');
+
+    const colors = await page.evaluate(() => ({
+        folderBackground: getComputedStyle(document.querySelector('#folder-submit')).backgroundColor,
+        linkBackground: getComputedStyle(document.querySelector('#link-submit')).backgroundColor
+    }));
+    expect(colors.folderBackground).not.toBe('rgba(0, 0, 0, 0)');
+    expect(colors.linkBackground).not.toBe('rgba(0, 0, 0, 0)');
+    expect(pageErrors).toEqual([]);
+});
+
+test('live game archived replay Team Pass gate is off by default', async ({ page, baseURL }) => {
+    const pageErrors = await collectPageErrors(page);
+    await page.addInitScript(() => {
+        window.__LIVE_GAME_TEAM__ = {};
+        window.__TEAM_PASS_ENTITLEMENT_READS__ = 0;
+    });
+    await routeLiveGameStubs(page);
+
+    await page.goto(`${baseURL}/live-game.html?teamId=team-1&gameId=game-1&replay=true`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#video-paywall')).toBeHidden();
+    await expect(page.locator('#recorded-replay-video')).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.__TEAM_PASS_ENTITLEMENT_READS__ || 0)).toBe(0);
+    expect(pageErrors).toEqual([]);
+});
+
+test('live game archived replay Team Pass gate locks replay when config is enabled', async ({ page, baseURL }) => {
+    const pageErrors = await collectPageErrors(page);
+    await page.addInitScript(() => {
+        window.__LIVE_GAME_TEAM__ = {
+            teamPassConfig: { recordedReplayPaywallEnabled: true }
+        };
+        window.__TEAM_PASS_ENTITLEMENT_READS__ = 0;
+    });
+    await routeLiveGameStubs(page);
+
+    await page.goto(`${baseURL}/live-game.html?teamId=team-1&gameId=game-1&replay=true`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#video-paywall')).toBeVisible();
+    await expect(page.locator('#video-paywall')).toContainText('Team Pass required');
+    await expect(page.locator('#recorded-replay-video')).toBeHidden();
+    await expect.poll(() => page.evaluate(() => window.__TEAM_PASS_ENTITLEMENT_READS__ || 0)).toBe(1);
+    expect(pageErrors).toEqual([]);
+});

--- a/tests/smoke/team-fallback-regressions.spec.js
+++ b/tests/smoke/team-fallback-regressions.spec.js
@@ -242,6 +242,8 @@ export async function getTeamMediaItems() {
 }
 export async function createTeamMediaFolder() {}
 export async function createTeamMediaLink() {}
+export async function uploadTeamMediaPhoto() {}
+export async function deleteTeamMediaItem() {}
 export async function reorderTeamMediaFolders() {}
 export async function reorderTeamMediaItems() {}
 export async function moveTeamMediaItems() {}
@@ -261,6 +263,8 @@ export async function getTeamMediaItems() {
 }
 export async function createTeamMediaFolder() {}
 export async function createTeamMediaLink() {}
+export async function uploadTeamMediaPhoto() {}
+export async function deleteTeamMediaItem() {}
 export async function reorderTeamMediaFolders() {}
 export async function reorderTeamMediaItems() {}
 export async function moveTeamMediaItems() {}
@@ -272,6 +276,12 @@ const MEDIA_UTILS_STUB = `
 export function canManageTeamMedia() {
     return false;
 }
+export function canContributeTeamMedia() {
+    return false;
+}
+export function canDeleteTeamMediaItem() {
+    return false;
+}
 export function getTeamMediaItemUrl(item = {}) {
     return item.url || item.downloadUrl || '';
 }
@@ -282,6 +292,9 @@ export function isSafeTeamMediaPhoto() {
     return false;
 }
 export function isSafeTeamMediaUrl() {
+    return true;
+}
+export function isSupportedTeamMediaImage() {
     return true;
 }
 export function sortByMediaOrder(items = []) {
@@ -293,6 +306,12 @@ const MEDIA_UTILS_ADMIN_STUB = `
 export function canManageTeamMedia() {
     return true;
 }
+export function canContributeTeamMedia() {
+    return true;
+}
+export function canDeleteTeamMediaItem() {
+    return true;
+}
 export function getTeamMediaItemUrl(item = {}) {
     return item.url || item.downloadUrl || '';
 }
@@ -303,6 +322,9 @@ export function isSafeTeamMediaPhoto() {
     return false;
 }
 export function isSafeTeamMediaUrl() {
+    return true;
+}
+export function isSupportedTeamMediaImage() {
     return true;
 }
 export function sortByMediaOrder(items = []) {
@@ -633,7 +655,7 @@ test('team media shows an empty library when media reads are denied', async ({ p
     const pageErrors = await collectPageErrors(page);
     await page.route('**/js/auth.js?v=13', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
     await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: MEDIA_DB_STUB }));
-    await page.route('**/js/team-media-utils.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: MEDIA_UTILS_STUB }));
+    await page.route(/\/js\/team-media-utils\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: MEDIA_UTILS_STUB }));
 
     await page.goto(`${baseURL}/team-media.html?teamId=team-1`, { waitUntil: 'domcontentloaded' });
 
@@ -647,7 +669,7 @@ test('team media shows a staff permission error when rules block management read
     const pageErrors = await collectPageErrors(page);
     await page.route('**/js/auth.js?v=13', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
     await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: MEDIA_DB_STUB }));
-    await page.route('**/js/team-media-utils.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: MEDIA_UTILS_ADMIN_STUB }));
+    await page.route(/\/js\/team-media-utils\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: MEDIA_UTILS_ADMIN_STUB }));
 
     await page.goto(`${baseURL}/team-media.html?teamId=team-1`, { waitUntil: 'domcontentloaded' });
 
@@ -662,7 +684,7 @@ test('team media renders visible save actions for staff', async ({ page, baseURL
     const pageErrors = await collectPageErrors(page);
     await page.route('**/js/auth.js?v=13', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
     await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: MEDIA_DB_WITH_FOLDER_STUB }));
-    await page.route('**/js/team-media-utils.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: MEDIA_UTILS_ADMIN_STUB }));
+    await page.route(/\/js\/team-media-utils\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: MEDIA_UTILS_ADMIN_STUB }));
 
     await page.goto(`${baseURL}/team-media.html?teamId=team-1`, { waitUntil: 'domcontentloaded' });
 

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -208,6 +208,7 @@ function createEnvironment(initialState, overrides = {}) {
         'standingsMultiTeamTiebreakers',
         'zip',
         'isPublic',
+        'teamPassRecordedReplayPaywallEnabled',
         'streamUrl',
         'stream-detect',
         'team-permissions-empty',
@@ -748,6 +749,46 @@ describe('edit team admin access persistence', () => {
 
             expect(env.state.updateCalls).toHaveLength(2);
             expect(env.state.updateCalls[1].teamData.registrationSource).toBeNull();
+        } finally {
+            env.cleanup();
+        }
+    });
+
+    it('round-trips the archived replay Team Pass gate setting', async () => {
+        const initialState = {
+            currentUser: { uid: 'owner-1', email: 'owner@example.com' },
+            team: {
+                id: 'team-1',
+                ownerId: 'owner-1',
+                name: 'Sharks',
+                description: 'Travel team',
+                sport: 'Basketball',
+                notificationEmail: 'notify@example.com',
+                leagueUrl: '',
+                standingsConfig: { enabled: false, rankingMode: 'points', tiebreakers: [] },
+                zip: '66209',
+                isPublic: true,
+                adminEmails: [],
+                teamPassConfig: {
+                    checkoutEnabled: false,
+                    recordedReplayPaywallEnabled: true
+                }
+            },
+            updateCalls: []
+        };
+
+        const env = await bootEditTeam(initialState);
+        try {
+            expect(env.elements.get('teamPassRecordedReplayPaywallEnabled').checked).toBe(true);
+
+            env.elements.get('teamPassRecordedReplayPaywallEnabled').checked = false;
+            await env.elements.get('team-form').requestSubmit();
+
+            expect(env.state.updateCalls).toHaveLength(1);
+            expect(env.state.updateCalls[0].teamData.teamPassConfig).toEqual({
+                checkoutEnabled: false,
+                recordedReplayPaywallEnabled: false
+            });
         } finally {
             env.cleanup();
         }

--- a/tests/unit/live-game-replay-init.test.js
+++ b/tests/unit/live-game-replay-init.test.js
@@ -256,12 +256,12 @@ function buildModuleSource() {
             'const { MAX_HIGHLIGHT_CLIP_MS, buildHighlightShareUrl, canAccessNativeCameraCapture, createHighlightClipDraft, resolveReplayVideoOptions, shouldReloadVideoPlayback } = deps.liveGameVideo;'
         )
         .replace(
-            /import \{ TEAM_PASS_FEATURES, canAccessPremiumFanFeature, getTeamEntitlementStatus, resolveTeamEntitlementSeasonId \} from '\.\/team-entitlements\.js\?v=\d+';/,
-            'const { TEAM_PASS_FEATURES, canAccessPremiumFanFeature, getTeamEntitlementStatus, resolveTeamEntitlementSeasonId } = deps.teamEntitlements;'
+            /import \{ TEAM_PASS_FEATURES, canAccessPremiumFanFeature, getTeamEntitlementStatus, isRecordedReplayTeamPassGateEnabled, resolveTeamEntitlementSeasonId \} from '\.\/team-entitlements\.js\?v=\d+';/,
+            'const { TEAM_PASS_FEATURES, canAccessPremiumFanFeature, getTeamEntitlementStatus, isRecordedReplayTeamPassGateEnabled, resolveTeamEntitlementSeasonId } = deps.teamEntitlements;'
         )
         .replace(
-            /import \{ TEAM_PASS_FEATURES, canAccessPremiumFanFeature, getTeamEntitlementStatus, resolveTeamEntitlementSeasonId \} from '\.\/team-entitlements\.js\?v=\d+';/,
-            'const { TEAM_PASS_FEATURES, canAccessPremiumFanFeature, getTeamEntitlementStatus, resolveTeamEntitlementSeasonId } = deps.teamEntitlements;'
+            /import \{ TEAM_PASS_FEATURES, canAccessPremiumFanFeature, getTeamEntitlementStatus, isRecordedReplayTeamPassGateEnabled, resolveTeamEntitlementSeasonId \} from '\.\/team-entitlements\.js\?v=\d+';/,
+            'const { TEAM_PASS_FEATURES, canAccessPremiumFanFeature, getTeamEntitlementStatus, isRecordedReplayTeamPassGateEnabled, resolveTeamEntitlementSeasonId } = deps.teamEntitlements;'
         )
         .replace(
             "import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';",
@@ -466,6 +466,7 @@ async function bootReplayPage({ replayEvents }) {
             TEAM_PASS_FEATURES: {},
             canAccessPremiumFanFeature: () => false,
             getTeamEntitlementStatus: () => ({ isActive: false }),
+            isRecordedReplayTeamPassGateEnabled: () => false,
             resolveTeamEntitlementSeasonId: () => null
         },
         firebaseAi: {

--- a/tests/unit/team-entitlements.test.js
+++ b/tests/unit/team-entitlements.test.js
@@ -4,6 +4,7 @@ import {
     TEAM_PASS_FEATURES,
     buildTeamEntitlementId,
     canAccessPremiumFanFeature,
+    isRecordedReplayTeamPassGateEnabled,
     isTeamEntitlementActive,
     resolveTeamEntitlementSeasonId
 } from '../../js/team-entitlements-core.js';
@@ -39,10 +40,22 @@ describe('team entitlement helpers', () => {
         expect(isTeamEntitlementActive(active, { seasonId: '2026', now: '2027-01-01T00:00:00Z' })).toBe(false);
     });
 
+    it('keeps the recorded replay Team Pass gate off unless config enables it', () => {
+        expect(isRecordedReplayTeamPassGateEnabled({ team: {} })).toBe(false);
+        expect(isRecordedReplayTeamPassGateEnabled({
+            team: { teamPassConfig: { recordedReplayPaywallEnabled: true } }
+        })).toBe(true);
+        expect(isRecordedReplayTeamPassGateEnabled({
+            team: { teamPassConfig: { recordedReplayPaywallEnabled: true } },
+            game: { teamPassConfig: { recordedReplayPaywallEnabled: false } }
+        })).toBe(false);
+    });
+
     it('wires live replay video behind the team entitlement helper', () => {
         const liveGame = readRepoFile('js/live-game.js');
         const html = readRepoFile('live-game.html');
 
+        expect(liveGame).toContain('isRecordedReplayTeamPassGateEnabled');
         expect(liveGame).toContain('getTeamEntitlementStatus');
         expect(liveGame).toContain("TEAM_PASS_FEATURES.RECORDED_REPLAY");
         expect(html).toContain('id="video-paywall"');

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -21,15 +21,19 @@ describe('team media entry point', () => {
         const pageJs = readRepoFile('js/team-media.js');
         const rules = readRepoFile('firestore.rules');
 
-        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=2"></script>');
+        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=3"></script>');
         expect(pageHtml).toContain('id="team-media-upload-panel"');
         expect(pageHtml).toContain('id="team-media-admin-panel"');
         expect(pageHtml).toContain('id="bulk-actions"');
+        expect(pageHtml).toContain('Save folder');
+        expect(pageHtml).toContain('Save video link');
         expect(pageJs).toContain("import { checkAuth } from './auth.js?v=13';");
         expect(pageJs).toContain("from './db.js?v=14'");
         expect(pageJs).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
         expect(pageJs).toContain('state.canManage = canManageTeamMedia(user, state.team);');
         expect(pageJs).toContain('uploadTeamMediaPhoto');
+        expect(pageJs).toContain('Create a folder first');
+        expect(pageJs).toContain('getMediaPermissionMessage');
         expect(pageJs).toContain('bulkDeleteTeamMediaItems');
         expect(pageJs).toContain('setTeamMediaAlbumCover');
         expect(pageJs).toContain('download class="rounded-lg');

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -14,11 +14,14 @@ describe('team media page wiring', () => {
         const page = fs.readFileSync(path.join(repoRoot, 'team-media.html'), 'utf8');
         const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
 
-        expect(page).toContain('src="js/team-media.js?v=2"');
+        expect(page).toContain('src="js/team-media.js?v=3"');
+        expect(page).toContain('Save folder');
+        expect(page).toContain('Save video link');
         expect(source).toContain("from './db.js?v=14'");
         expect(source).toContain("import { checkAuth } from './auth.js?v=13';");
         expect(source).toContain('checkAuth(async (user) => {');
         expect(source).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
+        expect(source).toContain('Team media permissions are not enabled');
     });
 
     it('keeps media reads member-scoped and writes admin-scoped', () => {


### PR DESCRIPTION
## Summary
- Keep roster loading players when optional roster metadata reads are denied or unavailable.
- Let team chat fall back to the default team-wide conversation when conversation listing fails.
- Fix Team Media permission handling and make folder/video save actions visible and clearer.
- Make archived replay Team Pass gating off by default, controlled by team/game config, and fix the desktop paywall visibility conflict.
- Add unit and Playwright smoke coverage for the regressions.
- Add CI/CD regression guards so roster/chat/media/replay smoke and Firebase deploy-rule checks run before PR preview and production deploys.

## Root Cause
- Roster treated optional metadata reads as hard blockers before rendering players.
- Chat required conversation listing before default-channel rendering.
- Team Media used unconfigured `primary-*` Tailwind classes on this page and did not distinguish manager permission-rule failures from empty libraries.
- Live replay paywall CSS and entitlement loading made the Team Pass lock appear even when no explicit config enabled it.
- Production deploys already shipped Firestore rules, but PR/deploy gates did not explicitly validate the media rules and targeted regressions before continuing.

## CI/CD Changes
- New `regression-guards` workflow runs on PRs and `master` pushes.
- Dedicated Playwright guard runs `tests/smoke/team-fallback-regressions.spec.js` against a local static server.
- New Firebase rules/deploy guard validates `firebase.json`, media Firestore rule coverage, production rule/index deploy inclusion, and deploy workflow dependencies.
- Preview and production deploy workflows now require regression guards before deploy jobs run.

## Security Review
- No client-side access bypass was added. Firestore rules still enforce media/chat/roster reads and writes.
- Fallbacks only reduce optional UI data dependency; they do not expose additional records.
- Media URLs continue through the safe URL helpers and escaped rendering, with `noopener noreferrer` on opened links.
- Team Pass replay locking is controlled through team/game config editable only through the existing full-access team edit flow.
- The CI/CD guard is static/local only and does not add new secrets or broaden deployment permissions.

## Validation
- `npm run ci:firebase-rules`
- `SMOKE_BASE_URL=http://localhost:8000 npm run test:smoke:team-fallback` - 7 passed
- `TZ=UTC npm run test:unit:ci` - 231 files, 1129 tests passed
- `npx --yes github-actionlint@1.7.12 .github/workflows/ci.yml .github/workflows/deploy-preview.yml .github/workflows/deploy-prod.yml .github/workflows/regression-guards.yml .github/workflows/preview-smoke.yml`
- `git diff --check origin/master...HEAD`
- Local static server responded on `http://localhost:8000/team-media.html`
