### PR TITLE
[codex] Add baseball and softball support

### DIFF
--- a/drills.html
+++ b/drills.html
@@ -618,6 +618,7 @@
         import { requireAuth } from './js/auth.js?v=9';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js?v=3';
         import { DRILL_TYPES, DRILL_LEVELS, DRILL_TYPE_COLORS, getAllSkillTags } from './js/drill-constants.js?v=1';
+        import { getStarterDrillById, getStarterDrills } from './js/practice-starter-drills.js?v=1';
         import { mergeUniqueDrills, linkifySafeText, parseMarkdown } from './js/drills-issue28-helpers.js?v=3';
         import { appendLivePracticeNote } from './js/drills-live-practice-notes.js?v=1';
         import { getAI, getGenerativeModel, GoogleAIBackend } from './js/vendor/firebase-ai.js';
@@ -1509,11 +1510,12 @@ ${JSON.stringify({
 
                 if (state.libTab === 'community') {
                     const opts = getCommunityLibraryFilters();
+                    const starterDrills = getStarterDrills(state.team?.sport || 'Soccer', opts);
                     const [result, published] = await Promise.all([
                         getDrills(opts),
                         getPublishedDrills({ ...opts, limitCount: 60 })
                     ]);
-                    drills = mergeUniqueDrills(result.drills, published);
+                    drills = mergeUniqueDrills(starterDrills, mergeUniqueDrills(result.drills, published));
                     state.libLastDoc = result.lastDoc;
                     state.aiDrillContext = {
                         ...(state.aiDrillContext || {}),
@@ -1528,7 +1530,7 @@ ${JSON.stringify({
                 } else if (state.libTab === 'favorites') {
                     if (state.favoriteIds.size === 0) { drills = []; }
                     else {
-                        const fetches = [...state.favoriteIds].map(id => getDrill(id));
+                        const fetches = [...state.favoriteIds].map(id => resolveDrillById(id));
                         drills = (await Promise.all(fetches)).filter(Boolean);
                     }
                 }
@@ -1610,6 +1612,7 @@ ${JSON.stringify({
                 return state.aiDrillUniverse;
             }
             const sport = state.team?.sport || 'Soccer';
+            const starterDrills = getStarterDrills(sport);
             const community = [];
             let cursor = null;
             let guard = 0;
@@ -1627,7 +1630,7 @@ ${JSON.stringify({
                 console.warn('Failed loading team drills for AI index:', err);
             }
 
-            const merged = [...community, ...teamDrills];
+            const merged = [...starterDrills, ...community, ...teamDrills];
             const byId = new Map();
             merged.forEach(d => {
                 if (!d?.id) return;
@@ -1789,9 +1792,15 @@ ${JSON.stringify({
         }
 
         // ==================== DRILL DETAIL ====================
+        async function resolveDrillById(drillId) {
+            const starter = getStarterDrillById(drillId);
+            if (starter) return starter;
+            return getDrill(drillId);
+        }
+
         window._openDrill = async function(drillId) {
             try {
-                const drill = await getDrill(drillId);
+                const drill = await resolveDrillById(drillId);
                 if (!drill) return;
                 state.currentDetailDrill = drill;
                 const tc = getTypeClass(drill.type);
@@ -1799,7 +1808,7 @@ ${JSON.stringify({
                 document.getElementById('detail-type-badge').textContent = drill.type || 'Drill';
                 document.getElementById('detail-source-label').textContent = drill.source === 'community'
                     ? 'Community Drill'
-                    : (drill.publishedToCommunity ? 'Published Team Drill' : 'Custom Drill');
+                    : (drill.source === 'starter' ? 'Starter Drill' : (drill.publishedToCommunity ? 'Published Team Drill' : 'Custom Drill'));
 
             // Fav button
             const isFav = state.favoriteIds.has(drill.id);

--- a/edit-config.html
+++ b/edit-config.html
@@ -59,9 +59,11 @@
                         </div>
                         <div>
                             <label class="block text-sm font-medium text-gray-700">Quick Templates</label>
-                            <div class="flex gap-2 mt-1">
+                            <div class="flex flex-wrap gap-2 mt-1">
                                 <button type="button" id="basketball-template" class="flex-1 px-3 py-2 bg-orange-100 text-orange-700 rounded text-sm hover:bg-orange-200">Basketball</button>
                                 <button type="button" id="soccer-template" class="flex-1 px-3 py-2 bg-green-100 text-green-700 rounded text-sm hover:bg-green-200">Soccer</button>
+                                <button type="button" id="baseball-template" class="flex-1 px-3 py-2 bg-blue-100 text-blue-700 rounded text-sm hover:bg-blue-200">Baseball</button>
+                                <button type="button" id="softball-template" class="flex-1 px-3 py-2 bg-pink-100 text-pink-700 rounded text-sm hover:bg-pink-200">Softball</button>
                             </div>
                         </div>
                         <div>
@@ -70,6 +72,8 @@
                                 class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2">
                                 <option value="Basketball">Basketball</option>
                                 <option value="Soccer">Soccer</option>
+                                <option value="Baseball">Baseball</option>
+                                <option value="Softball">Softball</option>
                                 <option value="Custom">Custom</option>
                             </select>
                         </div>
@@ -77,7 +81,7 @@
                             <label class="block text-sm font-medium text-gray-700">Columns (comma separated)</label>
                             <input type="text" id="columns" placeholder="PTS, REB, AST, STL, BLK" required
                                 class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2">
-                            <p class="text-xs text-gray-500 mt-1">Max 5 columns recommended for mobile.</p>
+                            <p class="text-xs text-gray-500 mt-1">5 to 6 columns recommended for mobile.</p>
                         </div>
                         <button type="submit"
                             class="w-full bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700 transition">Create
@@ -109,6 +113,7 @@
         import { checkAuth } from './js/auth.js?v=9';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { hasFullTeamAccess } from './js/team-access.js';
+        import { getSportStatTemplate } from './js/sport-templates.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -155,16 +160,19 @@
             loadConfigs();
 
             // Template buttons
-            document.getElementById('basketball-template').addEventListener('click', () => {
-                document.getElementById('configName').value = 'Basketball Standard';
-                document.getElementById('baseType').value = 'Basketball';
-                document.getElementById('columns').value = 'PTS, REB, AST, STL, TO';
-            });
-
-            document.getElementById('soccer-template').addEventListener('click', () => {
-                document.getElementById('configName').value = 'Soccer Standard';
-                document.getElementById('baseType').value = 'Soccer';
-                document.getElementById('columns').value = 'GOALS, SHOTS, PASSES, BLOCKS, HUSTLE';
+            [
+                ['basketball-template', 'Basketball'],
+                ['soccer-template', 'Soccer'],
+                ['baseball-template', 'Baseball'],
+                ['softball-template', 'Softball']
+            ].forEach(([buttonId, sport]) => {
+                document.getElementById(buttonId).addEventListener('click', () => {
+                    const template = getSportStatTemplate(sport);
+                    if (!template) return;
+                    document.getElementById('configName').value = template.name;
+                    document.getElementById('baseType').value = template.baseType;
+                    document.getElementById('columns').value = template.columns.join(', ');
+                });
             });
         }
 

--- a/edit-team.html
+++ b/edit-team.html
@@ -68,6 +68,8 @@
                         <option value="">Select a sport...</option>
                         <option value="Basketball">Basketball — PTS/REB/AST/STL/TO template</option>
                         <option value="Soccer">Soccer — GOALS/SHOTS/PASSES/BLOCKS/HUSTLE template</option>
+                        <option value="Baseball">Baseball — AB/H/R/RBI/BB/FP template</option>
+                        <option value="Softball">Softball — AB/H/R/RBI/BB/FP template</option>
                     </select>
                     <p class="text-xs text-gray-500 mt-1">Only sports with built-in stat tracker templates are listed.
                     </p>
@@ -247,6 +249,7 @@
         import { normalizeYouTubeEmbedUrl } from './js/live-stream-utils.js?v=1';
         import { hasFullTeamAccess } from './js/team-access.js';
         import { processPendingAdminInvites, buildAdminInviteFollowUp } from './js/edit-team-admin-invites.js?v=3';
+        import { getSportStatTemplate } from './js/sport-templates.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -663,32 +666,16 @@
                     console.log('Created team with ID:', newTeamId);
                     console.log('Team sport:', teamData.sport);
 
-                    // Auto-create standard config based on sport
-                    const sportValue = teamData.sport;
-                    const sport = sportValue ? sportValue.toLowerCase() : '';
-                    console.log('Sport value (lowercase):', sport);
-
-                    let configName = '';
-                    let columns = [];
-
-                    if (sport === 'basketball') {
-                        configName = 'Basketball Standard';
-                        columns = ['PTS', 'REB', 'AST', 'STL', 'TO'];
-                        console.log('Basketball config:', configName, columns);
-                    } else if (sport === 'soccer') {
-                        configName = 'Soccer Standard';
-                        columns = ['GOALS', 'SHOTS', 'PASSES', 'BLOCKS', 'HUSTLE'];
-                        console.log('Soccer config:', configName, columns);
-                    }
+                    const sportTemplate = getSportStatTemplate(teamData.sport);
 
                     // Create the config if we have a template for this sport
-                    if (configName && columns.length > 0) {
-                        console.log('Creating config...', { name: configName, baseType: sport, columns });
+                    if (sportTemplate) {
+                        console.log('Creating config...', sportTemplate);
                         try {
                             const configId = await addConfig(newTeamId, {
-                                name: configName,
-                                baseType: sport,
-                                columns: columns
+                                name: sportTemplate.name,
+                                baseType: sportTemplate.baseType,
+                                columns: sportTemplate.columns
                             });
                             console.log('Config created successfully with ID:', configId);
                         } catch (configError) {
@@ -696,7 +683,7 @@
                             alert('Team created but failed to create default config: ' + configError.message);
                         }
                     } else {
-                        console.log('No template for sport:', sport);
+                        console.log('No template for sport:', teamData.sport);
                     }
 
                     let pendingInviteSummary = {

--- a/game-day.html
+++ b/game-day.html
@@ -67,6 +67,9 @@
         .basketball-court { background: #c68642; }
         .basketball-court::before { background: rgba(255,255,255,0.2); }
         .basketball-court::after { border-color: rgba(255,255,255,0.2); }
+        .diamond-field { background: #3f7f47; }
+        .diamond-field::before,
+        .diamond-field::after { display: none; }
     </style>
 </head>
 <body class="bg-gray-50 min-h-screen">
@@ -198,6 +201,8 @@
                         <option value="">— Select formation —</option>
                         <option value="soccer-9v9">Soccer 9v9</option>
                         <option value="basketball-5v5">Basketball 5v5</option>
+                        <option value="baseball-9">Baseball 9</option>
+                        <option value="softball-10">Softball 10</option>
                     </select>
                 </div>
 
@@ -515,6 +520,41 @@
                     { id: 'pf', name: 'Power Forward' },
                     { id: 'c', name: 'Center' }
                 ]
+            },
+            'baseball-9': {
+                name: 'Baseball 9',
+                numPeriods: 7,
+                periodPrefix: 'I',
+                diamond: true,
+                positions: [
+                    { id: 'p', name: 'Pitcher' },
+                    { id: 'c', name: 'Catcher' },
+                    { id: '1b', name: 'First Base' },
+                    { id: '2b', name: 'Second Base' },
+                    { id: '3b', name: 'Third Base' },
+                    { id: 'ss', name: 'Shortstop' },
+                    { id: 'lf', name: 'Left Field' },
+                    { id: 'cf', name: 'Center Field' },
+                    { id: 'rf', name: 'Right Field' }
+                ]
+            },
+            'softball-10': {
+                name: 'Softball 10',
+                numPeriods: 7,
+                periodPrefix: 'I',
+                diamond: true,
+                positions: [
+                    { id: 'p', name: 'Pitcher' },
+                    { id: 'c', name: 'Catcher' },
+                    { id: '1b', name: 'First Base' },
+                    { id: '2b', name: 'Second Base' },
+                    { id: '3b', name: 'Third Base' },
+                    { id: 'ss', name: 'Shortstop' },
+                    { id: 'lf', name: 'Left Field' },
+                    { id: 'lcf', name: 'Left Center' },
+                    { id: 'rcf', name: 'Right Center' },
+                    { id: 'rf', name: 'Right Field' }
+                ]
             }
         };
 
@@ -551,6 +591,29 @@
                 'sf': { left: 78, top: 42 },
                 'pf': { left: 28, top: 67 },
                 'c':  { left: 72, top: 67 },
+            },
+            'baseball-9': {
+                'p':  { left: 50, top: 50 },
+                'c':  { left: 50, top: 86 },
+                '1b': { left: 76, top: 58 },
+                '2b': { left: 62, top: 34 },
+                '3b': { left: 24, top: 58 },
+                'ss': { left: 38, top: 34 },
+                'lf': { left: 20, top: 15 },
+                'cf': { left: 50, top: 10 },
+                'rf': { left: 80, top: 15 },
+            },
+            'softball-10': {
+                'p':   { left: 50, top: 50 },
+                'c':   { left: 50, top: 86 },
+                '1b':  { left: 76, top: 58 },
+                '2b':  { left: 62, top: 34 },
+                '3b':  { left: 24, top: 58 },
+                'ss':  { left: 38, top: 34 },
+                'lf':  { left: 18, top: 16 },
+                'lcf': { left: 40, top: 10 },
+                'rcf': { left: 60, top: 10 },
+                'rf':  { left: 82, top: 16 },
             }
         };
 
@@ -1630,6 +1693,9 @@ Assistant:`;
         function getPeriods(formationId) {
             const f = FORMATIONS[formationId];
             if (!f) return ['H1', 'H2'];
+            if (f.periodPrefix) {
+                return Array.from({ length: f.numPeriods || 2 }, (_, index) => `${f.periodPrefix}${index + 1}`);
+            }
             const n = f.numPeriods || 2;
             if (n === 4) return ['Q1', 'Q2', 'Q3', 'Q4'];
             return ['H1', 'H2'];
@@ -1883,6 +1949,7 @@ Respond ONLY with valid JSON.`;
                 const gamePlan = {
                     formationId: state.formationId,
                     numPeriods: FORMATIONS[state.formationId].numPeriods || 2,
+                    battingOrder: Array.isArray(state.gamePlan?.battingOrder) ? state.gamePlan.battingOrder : [],
                     lineups: flattenRotationPlan(state.rotationPlan)
                 };
                 await updateGame(state.teamId, state.gameId, { gamePlan });
@@ -2020,9 +2087,10 @@ Respond ONLY with valid JSON.`;
 
             const isSoccer = state.formationId.startsWith('soccer');
             const isBasketball = state.formationId.startsWith('basketball');
+            const isDiamond = !!formation.diamond;
 
             // Field background class
-            const fieldClass = isBasketball ? 'basketball-court' : '';
+            const fieldClass = isBasketball ? 'basketball-court' : (isDiamond ? 'diamond-field' : '');
 
             // Build player blocks HTML
             const playerBlocks = formation.positions.map(pos => {
@@ -2065,10 +2133,15 @@ Respond ONLY with valid JSON.`;
                 <div class="field-line" style="left:10%;right:10%;top:5%;height:1px"></div>
                 <div class="field-line" style="left:35%;right:35%;top:78%;height:1px"></div>
             ` : '';
+            const diamondMarkings = isDiamond ? `
+                <div class="field-line" style="left:50%;top:86%;width:1px;height:46%;transform:rotate(45deg);transform-origin:top;background:rgba(255,255,255,0.35)"></div>
+                <div class="field-line" style="left:50%;top:86%;width:1px;height:46%;transform:rotate(-45deg);transform-origin:top;background:rgba(255,255,255,0.35)"></div>
+                <div class="field-line" style="left:50%;top:46%;width:44%;height:1px;transform:translateX(-50%) rotate(45deg);background:rgba(255,255,255,0.35)"></div>
+            ` : '';
 
             container.innerHTML = `
                 <div class="field-diagram ${fieldClass}" style="height:260px">
-                    ${soccerMarkings}${basketballMarkings}
+                    ${soccerMarkings}${basketballMarkings}${diamondMarkings}
                     ${playerBlocks}
                     <!-- bench players -->
                 </div>

--- a/game-plan.html
+++ b/game-plan.html
@@ -148,6 +148,22 @@
                                 <p class="text-sm text-gray-600">5 court positions + bench</p>
                             </div>
                         </div>
+                        <div class="formation-card cursor-pointer border-2 border-gray-300 rounded-xl p-6 hover:border-primary-500 hover:bg-primary-50 transition"
+                             data-formation="baseball-9">
+                            <div class="text-center">
+                                <div class="text-4xl mb-3">Diamond</div>
+                                <h3 class="text-xl font-bold text-gray-900 mb-2">Baseball 9</h3>
+                                <p class="text-sm text-gray-600">9 defensive positions + batting order</p>
+                            </div>
+                        </div>
+                        <div class="formation-card cursor-pointer border-2 border-gray-300 rounded-xl p-6 hover:border-primary-500 hover:bg-primary-50 transition"
+                             data-formation="softball-10">
+                            <div class="text-center">
+                                <div class="text-4xl mb-3">Diamond</div>
+                                <h3 class="text-xl font-bold text-gray-900 mb-2">Softball 10</h3>
+                                <p class="text-sm text-gray-600">10 defensive positions + batting order</p>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -162,20 +178,20 @@
 
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
                         <div>
-                            <label class="block text-sm font-semibold text-gray-700 mb-2">Number of Periods</label>
-                            <input type="number" id="num-periods" min="2" max="4" value="2"
+                            <label id="num-periods-label" class="block text-sm font-semibold text-gray-700 mb-2">Number of Periods</label>
+                            <input type="number" id="num-periods" min="2" max="9" value="2"
                                    class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500">
-                            <p class="text-xs text-gray-500 mt-1">Typically 2 halves or 4 quarters</p>
+                            <p id="num-periods-help" class="text-xs text-gray-500 mt-1">Typically 2 halves or 4 quarters</p>
                         </div>
-                        <div>
-                            <label class="block text-sm font-semibold text-gray-700 mb-2">Minutes per Period</label>
+                        <div id="period-duration-field">
+                            <label id="period-duration-label" class="block text-sm font-semibold text-gray-700 mb-2">Minutes per Period</label>
                             <input type="number" id="period-duration" min="5" max="45" value="25"
                                    class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500">
                         </div>
                     </div>
 
                     <div id="sub-times-config" class="mb-6">
-                        <label class="block text-sm font-semibold text-gray-700 mb-3">Substitution Times (minutes into each period)</label>
+                        <label id="sub-times-label" class="block text-sm font-semibold text-gray-700 mb-3">Substitution Times (minutes into each period)</label>
                         <div class="flex gap-2 mb-2">
                             <input type="text" id="sub-times-input" placeholder="e.g., 7,14,21"
                                    class="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500">
@@ -184,7 +200,7 @@
                             </button>
                         </div>
                         <div id="sub-times-display" class="flex flex-wrap gap-2"></div>
-                        <p class="text-xs text-gray-500 mt-2">Enter comma-separated minutes (e.g., 7,14,21 for subs at those times)</p>
+                        <p id="sub-times-help" class="text-xs text-gray-500 mt-2">Enter comma-separated minutes (e.g., 7,14,21 for subs at those times)</p>
                     </div>
 
                     <div class="flex gap-3">
@@ -214,9 +230,9 @@
                     <div id="plan-summary" class="mb-6 hidden">
                         <div class="bg-primary-50 border border-primary-200 rounded-xl p-4 flex flex-wrap items-center gap-4">
                             <div class="text-sm text-gray-700"><span class="font-semibold">Formation:</span> <span id="plan-summary-formation">—</span></div>
-                            <div class="text-sm text-gray-700"><span class="font-semibold">Periods:</span> <span id="plan-summary-periods">—</span></div>
-                            <div class="text-sm text-gray-700"><span class="font-semibold">Minutes/Period:</span> <span id="plan-summary-duration">—</span></div>
-                            <div class="text-sm text-gray-700"><span class="font-semibold">Sub times:</span> <span id="plan-summary-subs">—</span></div>
+                            <div class="text-sm text-gray-700"><span id="plan-summary-periods-label" class="font-semibold">Periods:</span> <span id="plan-summary-periods">—</span></div>
+                            <div id="plan-summary-duration-wrap" class="text-sm text-gray-700"><span class="font-semibold">Minutes/Period:</span> <span id="plan-summary-duration">—</span></div>
+                            <div class="text-sm text-gray-700"><span id="plan-summary-subs-label" class="font-semibold">Sub times:</span> <span id="plan-summary-subs">—</span></div>
                         </div>
                     </div>
 
@@ -235,6 +251,21 @@
                                 </table>
                             </div>
                         </div>
+                    </div>
+
+                    <!-- Batting Order -->
+                    <div id="batting-order-section" class="hidden bg-gradient-to-br from-amber-50 to-white rounded-xl p-6 border border-amber-200 mb-8">
+                        <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3 mb-4">
+                            <div>
+                                <h3 class="text-lg font-bold text-gray-900">Batting Order</h3>
+                                <p class="text-sm text-gray-600">Set the lineup once; defensive assignments stay inning-by-inning above.</p>
+                            </div>
+                            <div class="flex gap-2">
+                                <button type="button" onclick="autoFillBattingOrder()" class="px-3 py-2 bg-amber-100 text-amber-800 rounded-lg text-sm font-semibold hover:bg-amber-200">Fill by roster</button>
+                                <button type="button" onclick="clearBattingOrder()" class="px-3 py-2 bg-white text-gray-700 border border-gray-200 rounded-lg text-sm font-semibold hover:bg-gray-50">Clear</button>
+                            </div>
+                        </div>
+                        <div id="batting-order-list" class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3"></div>
                     </div>
 
                     <!-- Available Players Pool -->
@@ -263,7 +294,7 @@
 
     <script type="module">
         import { getTeam, getPlayers, getGames, getGame, updateGame, getTrackedCalendarEventUids, getEvents } from './js/db.js?v=14';
-        import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent } from './js/utils.js?v=8';
+        import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=9';
         import { getTeamAccessInfo } from './js/team-access.js';
 
@@ -273,6 +304,9 @@
         const FORMATIONS = {
             'soccer-9v9': {
                 name: 'Soccer 9v9',
+                numPeriods: 2,
+                periodDuration: 25,
+                subTimes: [7, 14, 21],
                 positions: [
                     { id: 'keeper', name: 'Keeper' },
                     { id: 'right-defense', name: 'Right - Defense' },
@@ -287,12 +321,54 @@
             },
             'basketball-5v5': {
                 name: 'Basketball 5v5',
+                numPeriods: 4,
+                periodDuration: 8,
+                subTimes: [4],
                 positions: [
                     { id: 'pg', name: 'Point Guard (PG)' },
                     { id: 'sg', name: 'Shooting Guard (SG)' },
                     { id: 'sf', name: 'Small Forward (SF)' },
                     { id: 'pf', name: 'Power Forward (PF)' },
                     { id: 'c', name: 'Center (C)' }
+                ]
+            },
+            'baseball-9': {
+                name: 'Baseball 9',
+                numPeriods: 7,
+                periodDuration: 1,
+                subTimes: [1],
+                periodPrefix: 'I',
+                diamond: true,
+                positions: [
+                    { id: 'p', name: 'Pitcher (P)' },
+                    { id: 'c', name: 'Catcher (C)' },
+                    { id: '1b', name: 'First Base (1B)' },
+                    { id: '2b', name: 'Second Base (2B)' },
+                    { id: '3b', name: 'Third Base (3B)' },
+                    { id: 'ss', name: 'Shortstop (SS)' },
+                    { id: 'lf', name: 'Left Field (LF)' },
+                    { id: 'cf', name: 'Center Field (CF)' },
+                    { id: 'rf', name: 'Right Field (RF)' }
+                ]
+            },
+            'softball-10': {
+                name: 'Softball 10',
+                numPeriods: 7,
+                periodDuration: 1,
+                subTimes: [1],
+                periodPrefix: 'I',
+                diamond: true,
+                positions: [
+                    { id: 'p', name: 'Pitcher (P)' },
+                    { id: 'c', name: 'Catcher (C)' },
+                    { id: '1b', name: 'First Base (1B)' },
+                    { id: '2b', name: 'Second Base (2B)' },
+                    { id: '3b', name: 'Third Base (3B)' },
+                    { id: 'ss', name: 'Shortstop (SS)' },
+                    { id: 'lf', name: 'Left Field (LF)' },
+                    { id: 'lcf', name: 'Left Center (LCF)' },
+                    { id: 'rcf', name: 'Right Center (RCF)' },
+                    { id: 'rf', name: 'Right Field (RF)' }
                 ]
             }
         };
@@ -311,13 +387,18 @@
         let plannerInitialized = false;
 
         // Game plan state
-        let gamePlan = {
-            numPeriods: 2,
-            periodDuration: 25,
-            subTimes: [7, 14, 21],
-            formationId: null,
-            lineups: {} // { 'period-time': { positionId: playerId } }
-        };
+        function createEmptyGamePlan() {
+            return {
+                numPeriods: 2,
+                periodDuration: 25,
+                subTimes: [7, 14, 21],
+                formationId: null,
+                lineups: {},
+                battingOrder: []
+            };
+        }
+
+        let gamePlan = createEmptyGamePlan();
 
         let draggedPlayerId = null;
 
@@ -458,6 +539,7 @@
         async function loadGame(game) {
             currentGameId = game.id;
             currentGame = game;
+            gamePlan = createEmptyGamePlan();
 
             const date = game.date.toDate ? game.date.toDate() : new Date(game.date);
 
@@ -471,20 +553,19 @@
             // Load existing game plan if it exists
             if (game.gamePlan) {
                 gamePlan = { ...gamePlan, ...game.gamePlan };
+                gamePlan.battingOrder = Array.isArray(gamePlan.battingOrder) ? gamePlan.battingOrder : [];
             } else {
                 // Set defaults based on team sport
                 if (currentTeam.sport) {
                     const sport = currentTeam.sport.toLowerCase();
                     if (sport === 'basketball') {
-                        gamePlan.numPeriods = 4;
-                        gamePlan.periodDuration = 8;
-                        gamePlan.subTimes = [4];
-                        gamePlan.formationId = 'basketball-5v5';
+                        applyFormationDefaults('basketball-5v5');
                     } else if (sport === 'soccer') {
-                        gamePlan.numPeriods = 2;
-                        gamePlan.periodDuration = 25;
-                        gamePlan.subTimes = [7, 14, 21];
-                        gamePlan.formationId = 'soccer-9v9';
+                        applyFormationDefaults('soccer-9v9');
+                    } else if (sport === 'baseball') {
+                        applyFormationDefaults('baseball-9');
+                    } else if (sport === 'softball') {
+                        applyFormationDefaults('softball-10');
                     }
                 }
             }
@@ -500,6 +581,7 @@
             document.getElementById('num-periods').value = gamePlan.numPeriods;
             document.getElementById('period-duration').value = gamePlan.periodDuration;
             document.getElementById('sub-times-input').value = gamePlan.subTimes.join(',');
+            updatePeriodConfigControls();
             renderSubTimesDisplay();
 
             const hasPlan = gamePlan.formationId && (gamePlan.subTimes || []).length > 0;
@@ -514,6 +596,7 @@
                 document.getElementById('step-lineup').classList.remove('hidden');
                 renderPlayerPool();
                 renderSubMatrix();
+                renderBattingOrder();
                 renderPlayingTimeSummary();
                 updatePlanSummary();
             } else {
@@ -521,6 +604,7 @@
                 document.getElementById('step-formation').classList.remove('hidden');
                 document.getElementById('step-periods').classList.add('hidden');
                 document.getElementById('step-lineup').classList.add('hidden');
+                renderBattingOrder();
             }
         }
 
@@ -564,8 +648,49 @@
             }
         }
 
+        function getFormation() {
+            return FORMATIONS[gamePlan.formationId] || null;
+        }
+
+        function isDiamondPlan() {
+            return !!getFormation()?.diamond;
+        }
+
+        function applyFormationDefaults(formationId) {
+            const formation = FORMATIONS[formationId];
+            if (!formation) return;
+            gamePlan.formationId = formationId;
+            gamePlan.numPeriods = formation.numPeriods || gamePlan.numPeriods || 2;
+            gamePlan.periodDuration = formation.periodDuration || gamePlan.periodDuration || 25;
+            gamePlan.subTimes = Array.isArray(formation.subTimes) ? [...formation.subTimes] : (gamePlan.subTimes || []);
+            if (formation.diamond && !Array.isArray(gamePlan.battingOrder)) {
+                gamePlan.battingOrder = [];
+            }
+            document.getElementById('num-periods').value = gamePlan.numPeriods;
+            document.getElementById('period-duration').value = gamePlan.periodDuration;
+            document.getElementById('sub-times-input').value = gamePlan.subTimes.join(',');
+            updatePeriodConfigControls();
+            renderSubTimesDisplay();
+        }
+
+        function updatePeriodConfigControls() {
+            const diamond = isDiamondPlan();
+            document.getElementById('num-periods-label').textContent = diamond ? 'Number of Innings' : 'Number of Periods';
+            document.getElementById('num-periods-help').textContent = diamond ? 'Default is 7 innings' : 'Typically 2 halves or 4 quarters';
+            document.getElementById('period-duration-field').classList.toggle('hidden', diamond);
+            document.getElementById('sub-times-config').classList.toggle('hidden', diamond);
+            document.getElementById('sub-times-label').textContent = diamond ? 'Defensive Slots' : 'Substitution Times (minutes into each period)';
+            document.getElementById('sub-times-help').textContent = diamond
+                ? 'One defensive assignment column is planned for each inning.'
+                : 'Enter comma-separated minutes (e.g., 7,14,21 for subs at those times)';
+        }
+
         function renderSubTimesDisplay() {
             const display = document.getElementById('sub-times-display');
+            if (isDiamondPlan()) {
+                display.innerHTML = '<span class="inline-flex items-center gap-1 px-3 py-1 bg-amber-100 text-amber-800 rounded-full text-sm font-semibold">One defensive lineup per inning</span>';
+                return;
+            }
             display.innerHTML = gamePlan.subTimes.map(time => `
                 <span class="inline-flex items-center gap-1 px-3 py-1 bg-primary-100 text-primary-700 rounded-full text-sm font-semibold">
                     ${time} min
@@ -576,34 +701,49 @@
         function updatePlanSummary() {
             const summary = document.getElementById('plan-summary');
             if (!summary) return;
-            const formation = FORMATIONS[gamePlan.formationId];
+            const formation = getFormation();
+            const diamond = isDiamondPlan();
             const subTimesText = (gamePlan.subTimes && gamePlan.subTimes.length > 0)
                 ? gamePlan.subTimes.join(', ')
                 : '—';
             document.getElementById('plan-summary-formation').textContent = formation ? formation.name : 'Not set';
+            document.getElementById('plan-summary-periods-label').textContent = diamond ? 'Innings:' : 'Periods:';
             document.getElementById('plan-summary-periods').textContent = gamePlan.numPeriods || '—';
+            document.getElementById('plan-summary-duration-wrap').classList.toggle('hidden', diamond);
             document.getElementById('plan-summary-duration').textContent = gamePlan.periodDuration || '—';
-            document.getElementById('plan-summary-subs').textContent = subTimesText;
+            document.getElementById('plan-summary-subs-label').textContent = diamond ? 'Defense:' : 'Sub times:';
+            document.getElementById('plan-summary-subs').textContent = diamond ? 'Inning-by-inning' : subTimesText;
 
-            const ready = formation && subTimesText !== '—';
+            const ready = formation && (diamond || subTimesText !== '—');
             summary.classList.toggle('hidden', !ready);
         }
 
         function renderSubMatrix() {
             if (!gamePlan.formationId) return;
 
-            const formation = FORMATIONS[gamePlan.formationId];
+            const formation = getFormation();
             const header = document.getElementById('sub-matrix-header');
             const body = document.getElementById('sub-matrix-body');
+            const diamond = isDiamondPlan();
 
             // Build header with all time intervals
             const intervals = [];
             for (let period = 1; period <= gamePlan.numPeriods; period++) {
-                const periodName = gamePlan.numPeriods === 2 ? `H${period}` : `Q${period}`;
-                const periodLabel = gamePlan.numPeriods === 2 ? `Half ${period}` : `Quarter ${period}`;
-                gamePlan.subTimes.forEach(time => {
-                    intervals.push({ period, periodName, periodLabel, time, key: `${period}-${time}` });
-                });
+                if (diamond) {
+                    intervals.push({
+                        period,
+                        periodName: `${formation.periodPrefix || 'I'}${period}`,
+                        periodLabel: `Inning ${period}`,
+                        time: 1,
+                        key: `${period}-1`
+                    });
+                } else {
+                    const periodName = gamePlan.numPeriods === 2 ? `H${period}` : `Q${period}`;
+                    const periodLabel = gamePlan.numPeriods === 2 ? `Half ${period}` : `Quarter ${period}`;
+                    gamePlan.subTimes.forEach(time => {
+                        intervals.push({ period, periodName, periodLabel, time, key: `${period}-${time}` });
+                    });
+                }
             }
             intervalsCache = intervals;
 
@@ -612,7 +752,7 @@
                 ${intervals.map(int => `
                     <th class="px-4 py-3 text-center text-xs font-bold text-gray-700 uppercase tracking-wider whitespace-nowrap">
                         <div class="flex items-center justify-center gap-2">
-                            <span>${int.periodName}: ${int.time}'</span>
+                            <span>${diamond ? int.periodName : `${int.periodName}: ${int.time}'`}</span>
                             <button class="push-forward-btn text-gray-500 hover:text-primary-700 text-lg leading-none"
                                     title="Push assignments to next interval"
                                     data-interval="${int.key}">⇢</button>
@@ -812,8 +952,87 @@
             });
         }
 
+        function sortedPlayersForPlanning() {
+            return [...players].sort((a, b) => {
+                const aNum = Number.parseInt(a.number, 10);
+                const bNum = Number.parseInt(b.number, 10);
+                if (Number.isFinite(aNum) && Number.isFinite(bNum) && aNum !== bNum) return aNum - bNum;
+                return (a.name || '').localeCompare(b.name || '');
+            });
+        }
+
+        function normalizeBattingOrder(includeEmpty = true) {
+            const existing = Array.isArray(gamePlan.battingOrder) ? gamePlan.battingOrder : [];
+            const playerIds = new Set(players.map(p => p.id));
+            const bySlot = new Map();
+            existing.forEach((row, index) => {
+                const slot = Number.parseInt(row?.slot, 10) || index + 1;
+                const playerId = playerIds.has(row?.playerId) ? row.playerId : '';
+                bySlot.set(slot, playerId);
+            });
+            const slotCount = Math.max(players.length, bySlot.size, 1);
+            const rows = Array.from({ length: slotCount }, (_, index) => ({
+                slot: index + 1,
+                playerId: bySlot.get(index + 1) || ''
+            }));
+            return includeEmpty ? rows : rows.filter(row => row.playerId);
+        }
+
+        function renderBattingOrder() {
+            const section = document.getElementById('batting-order-section');
+            const list = document.getElementById('batting-order-list');
+            if (!section || !list) return;
+            const show = isDiamondPlan();
+            section.classList.toggle('hidden', !show);
+            if (!show) return;
+
+            gamePlan.battingOrder = normalizeBattingOrder(true);
+            const options = sortedPlayersForPlanning().map(player =>
+                `<option value="${escapeHtml(player.id)}">#${escapeHtml(player.number || '?')} ${escapeHtml(player.name || 'Unnamed')}</option>`
+            ).join('');
+
+            list.innerHTML = gamePlan.battingOrder.map(row => `
+                <label class="flex items-center gap-3 bg-white border border-amber-100 rounded-lg p-3">
+                    <span class="w-8 h-8 rounded-full bg-amber-100 text-amber-800 flex items-center justify-center text-sm font-bold">${row.slot}</span>
+                    <select class="flex-1 border border-gray-200 rounded-md px-3 py-2 text-sm"
+                        onchange="updateBattingOrderSlot(${row.slot}, this.value)">
+                        <option value="">Select player...</option>
+                        ${options}
+                    </select>
+                </label>
+            `).join('');
+
+            const selects = list.querySelectorAll('select');
+            gamePlan.battingOrder.forEach((row, index) => {
+                if (selects[index]) selects[index].value = row.playerId || '';
+            });
+        }
+
+        window.updateBattingOrderSlot = function(slot, playerId) {
+            const nextSlot = Number.parseInt(slot, 10);
+            gamePlan.battingOrder = normalizeBattingOrder(true).map(row => {
+                if (row.slot === nextSlot) return { ...row, playerId };
+                if (playerId && row.playerId === playerId) return { ...row, playerId: '' };
+                return row;
+            });
+            renderBattingOrder();
+        };
+
+        window.autoFillBattingOrder = function() {
+            gamePlan.battingOrder = sortedPlayersForPlanning().map((player, index) => ({
+                slot: index + 1,
+                playerId: player.id
+            }));
+            renderBattingOrder();
+        };
+
+        window.clearBattingOrder = function() {
+            gamePlan.battingOrder = normalizeBattingOrder(true).map(row => ({ ...row, playerId: '' }));
+            renderBattingOrder();
+        };
+
         function getBenchPlayersForInterval(intervalKey) {
-            const formation = FORMATIONS[gamePlan.formationId];
+            const formation = getFormation();
             const assignedPlayerIds = new Set();
 
             // Get all players assigned in this interval
@@ -833,7 +1052,7 @@
             if (!gamePlan.formationId) return;
 
             const summaryDiv = document.getElementById('playing-time-summary');
-            const formation = FORMATIONS[gamePlan.formationId];
+            const formation = getFormation();
             if (!formation) {
                 summaryDiv.innerHTML = '<div class="text-sm text-gray-500">Select a formation to see playing time.</div>';
                 return;
@@ -850,9 +1069,11 @@
             });
 
             // Count intervals each player is in
-            const intervalsPerPeriod = Math.max(1, gamePlan.subTimes.length || 0);
-            const minutesPerInterval = gamePlan.periodDuration / intervalsPerPeriod;
-            const intervalTimes = intervalsPerPeriod === 1 ? ['full'] : gamePlan.subTimes;
+            const diamond = isDiamondPlan();
+            const intervalsPerPeriod = diamond ? 1 : Math.max(1, gamePlan.subTimes.length || 0);
+            const minutesPerInterval = diamond ? 1 : gamePlan.periodDuration / intervalsPerPeriod;
+            const intervalTimes = diamond ? [1] : ((gamePlan.subTimes && gamePlan.subTimes.length) ? gamePlan.subTimes : ['full']);
+            const unitLabel = diamond ? 'innings' : 'minutes';
 
             for (let period = 1; period <= gamePlan.numPeriods; period++) {
                 intervalTimes.forEach(time => {
@@ -868,7 +1089,7 @@
                 });
             }
 
-            const totalPlayerMinutes = gamePlan.numPeriods * gamePlan.periodDuration * formation.positions.length;
+            const totalPlayerMinutes = gamePlan.numPeriods * minutesPerInterval * formation.positions.length * intervalsPerPeriod;
             const targetTime = totalPlayerMinutes / players.length;
 
             summaryDiv.innerHTML = players
@@ -905,7 +1126,7 @@
                                 </div>
                                 <div class="text-right">
                                 <div class="text-2xl font-bold text-${statusColor}-600">${minutes}</div>
-                                    <div class="text-xs text-gray-600">minutes vs target ${targetTime.toFixed(0)}</div>
+                                    <div class="text-xs text-gray-600">${unitLabel} vs target ${targetTime.toFixed(0)}</div>
                                 </div>
                             </div>
                             <div class="w-full bg-gray-200 rounded-full h-3 overflow-hidden">
@@ -925,7 +1146,7 @@
         };
 
         function playerAssignedInInterval(playerId, intervalKey) {
-            const formation = FORMATIONS[gamePlan.formationId];
+            const formation = getFormation();
             let found = false;
             formation.positions.forEach(pos => {
                 const checkKey = `${intervalKey}-${pos.id}`;
@@ -940,7 +1161,7 @@
             const idx = intervalsCache.findIndex(int => int.key === intervalKey);
             if (idx === -1 || idx === intervalsCache.length - 1) return;
             const nextInterval = intervalsCache[idx + 1];
-            const formation = FORMATIONS[gamePlan.formationId];
+            const formation = getFormation();
 
             formation.positions.forEach(pos => {
                 const sourceKey = `${intervalKey}-${pos.id}`;
@@ -989,7 +1210,12 @@
         // Formation selection (Step 1 -> Step 2)
         document.querySelectorAll('.formation-card').forEach(card => {
             card.addEventListener('click', () => {
-                gamePlan.formationId = card.dataset.formation;
+                const nextFormationId = card.dataset.formation;
+                const formationChanged = gamePlan.formationId && gamePlan.formationId !== nextFormationId;
+                applyFormationDefaults(nextFormationId);
+                if (formationChanged) {
+                    gamePlan.lineups = {};
+                }
 
                 document.getElementById('step-formation').classList.add('hidden');
                 document.getElementById('step-periods').classList.remove('hidden');
@@ -1007,12 +1233,17 @@
         // From Step 2 (Periods) to Step 3 (Lineup)
         document.getElementById('next-to-lineup')?.addEventListener('click', () => {
             gamePlan.numPeriods = parseInt(document.getElementById('num-periods').value);
-            gamePlan.periodDuration = parseInt(document.getElementById('period-duration').value);
+            gamePlan.periodDuration = isDiamondPlan() ? 1 : parseInt(document.getElementById('period-duration').value);
+            if (isDiamondPlan()) {
+                gamePlan.subTimes = [1];
+            }
 
             document.getElementById('step-periods').classList.add('hidden');
             document.getElementById('step-lineup').classList.remove('hidden');
 
+            renderPlayerPool();
             renderSubMatrix();
+            renderBattingOrder();
             renderPlayingTimeSummary();
             updatePlanSummary();
         });
@@ -1028,6 +1259,7 @@
         // Save game plan
         document.getElementById('save-plan-btn')?.addEventListener('click', async () => {
             try {
+                gamePlan.battingOrder = isDiamondPlan() ? normalizeBattingOrder(false) : [];
                 await updateGame(currentTeamId, currentGameId, { gamePlan });
                 alert('Game plan saved successfully!');
             } catch (error) {

--- a/js/drill-constants.js
+++ b/js/drill-constants.js
@@ -19,6 +19,28 @@ export const DRILL_SKILLS = {
         "First Touch": ["ground control", "aerial control", "turning with ball", "one-touch control"],
         "Fitness": ["speed", "agility", "endurance"],
         "Other": ["ice breaker", "strength building"]
+    },
+    Baseball: {
+        "Throwing": ["throwing", "catching", "partner catch", "long toss"],
+        "Fielding": ["ground balls", "fly balls", "fielding play", "throws to first", "communication"],
+        "Hitting": ["tee work", "soft toss", "contact", "bunting", "bat path"],
+        "Base Running": ["base running", "leads", "rounding bases", "sliding"],
+        "Team Defense": ["cutoffs", "relays", "situations", "backups"],
+        "Pitching": ["pitching basics", "accuracy", "balance"],
+        "Catching": ["blocking", "receiving", "throws to second"],
+        "Fitness": ["speed", "agility", "core"],
+        "Other": ["teamwork", "focus"]
+    },
+    Softball: {
+        "Throwing": ["throwing", "catching", "partner catch", "long toss"],
+        "Fielding": ["ground balls", "fly balls", "fielding play", "throws to first", "communication"],
+        "Hitting": ["tee work", "soft toss", "contact", "bunting", "bat path"],
+        "Base Running": ["base running", "leads", "rounding bases", "sliding"],
+        "Team Defense": ["cutoffs", "relays", "situations", "backups"],
+        "Pitching": ["pitching basics", "accuracy", "balance"],
+        "Catching": ["blocking", "receiving", "throws to second"],
+        "Fitness": ["speed", "agility", "core"],
+        "Other": ["teamwork", "focus"]
     }
 };
 

--- a/js/game-plan-interop.js
+++ b/js/game-plan-interop.js
@@ -3,10 +3,13 @@ export function buildRotationPlanFromGamePlan(gamePlan) {
   const plan = {};
   const legacyByPeriodPos = {};
   const numPeriods = Number.parseInt(gamePlan?.numPeriods, 10) || 2;
-  const periodPrefix = numPeriods === 4 ? 'Q' : 'H';
+  const formationId = String(gamePlan?.formationId || '').toLowerCase();
+  const periodPrefix = formationId.startsWith('baseball') || formationId.startsWith('softball')
+    ? 'I'
+    : (numPeriods === 4 ? 'Q' : 'H');
 
   Object.entries(gamePlan.lineups).forEach(([key, playerId]) => {
-    const currentMatch = /^([HQ]\d+)-(.+)$/.exec(key);
+    const currentMatch = /^([HQI]\d+)-(.+)$/.exec(key);
     if (currentMatch) {
       const period = currentMatch[1];
       const posId = currentMatch[2];

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -145,6 +145,10 @@ const mentionState = { active: false, atPos: null };
 const statKeyMap = {
   PTS: 'pts',
   POINTS: 'pts',
+  GOALS: 'goals',
+  R: 'r',
+  RUN: 'r',
+  RUNS: 'r',
   REB: 'reb',
   AST: 'ast',
   STL: 'stl',
@@ -156,6 +160,11 @@ const statKeyMap = {
   FOULS: 'fouls',
   FLS: 'fouls'
 };
+
+function isScoringStatKey(statKey) {
+  const key = String(statKey || '').toLowerCase();
+  return key === 'pts' || key === 'points' || key === 'goals' || key === 'r' || key === 'run' || key === 'runs';
+}
 
 function q(selector) {
   return document.querySelector(selector);
@@ -356,7 +365,7 @@ function renderPlayByPlay(event, isNew = false) {
         ${event.playerName ? `<p class="text-sand/60 text-sm">#${escapeHtml(event.playerNumber || '')} ${escapeHtml(event.playerName)}</p>` : ''}
         ${event.isOpponent && (event.opponentPlayerName || event.opponentPlayerNumber) ? `<p class="text-sand/60 text-sm">${opponentLabel}</p>` : ''}
       </div>
-      ${event.statKey === 'pts' && event.value ? `
+      ${isScoringStatKey(event.statKey) && event.value ? `
         <span class="text-2xl font-bold ${event.value === 3 ? 'text-gold' : 'text-teal'}">+${event.value}</span>
       ` : ''}
     </div>
@@ -852,11 +861,12 @@ function processNewEvents(events) {
       renderLineup();
     }
 
-    renderScoreboard(event.type === 'stat' && event.statKey === 'pts');
+    const isScoringStat = event.type === 'stat' && isScoringStatKey(event.statKey);
+    renderScoreboard(isScoringStat);
     renderPlayByPlay(event, true);
     renderStats();
 
-    if (event.type === 'stat' && event.statKey === 'pts') {
+    if (isScoringStat) {
       showScoreCelebration(event);
       updateMomentum(event);
     } else {
@@ -1260,13 +1270,19 @@ async function generateAiResponse(question) {
 
 function buildAiPrompt(question) {
   const recentEvents = state.events.slice(-20).map(ev => `${ev.period || ''} ${formatClock(ev.gameClockMs || 0)} - ${ev.description}`).join('\n');
+  const columns = normalizeLiveStatColumns(state.statColumns).slice(0, 4);
   const statLines = state.players.map(p => {
     const stats = state.stats[p.id] || {};
-    return `#${p.num || ''} ${p.name}: ${stats.pts || 0} PTS, ${stats.reb || 0} REB, ${stats.ast || 0} AST`;
+    const statText = columns.map((col) => {
+      const key = statKeyMap[col] || col.toLowerCase();
+      return `${col}:${stats[key] || 0}`;
+    }).join(', ');
+    return `#${p.num || ''} ${p.name}: ${statText || 'No stats'}`;
   }).join('\n');
   const chatContext = state.chatMessages.slice(-10).map(m => `${m.senderName || 'Fan'}: ${m.text}`).join('\n');
 
-  return `You are ALL PLAYS, a helpful game assistant for a live basketball broadcast.\n\nCurrent score: ${state.homeScore} - ${state.awayScore}\nPeriod: ${state.period}\nClock: ${formatClock(state.gameClockMs)}\n\nRecent plays:\n${recentEvents || 'No events yet.'}\n\nPlayer stats:\n${statLines || 'No stats yet.'}\n\nRecent chat:\n${chatContext || 'No chat yet.'}\n\nQuestion: ${question}\n\nRespond in a concise, friendly broadcast tone.`;
+  const sport = state.team?.sport || state.game?.sport || 'sports';
+  return `You are ALL PLAYS, a helpful game assistant for a live ${sport} broadcast.\n\nCurrent score: ${state.homeScore} - ${state.awayScore}\nPeriod: ${state.period}\nClock: ${formatClock(state.gameClockMs)}\n\nRecent plays:\n${recentEvents || 'No events yet.'}\n\nPlayer stats:\n${statLines || 'No stats yet.'}\n\nRecent chat:\n${chatContext || 'No chat yet.'}\n\nQuestion: ${question}\n\nRespond in a concise, friendly broadcast tone.`;
 }
 
 function showAiThinking() {

--- a/js/live-tracker-integrity.js
+++ b/js/live-tracker-integrity.js
@@ -1,6 +1,6 @@
 function isPointsKey(statKey) {
   const key = (statKey || '').toString().toUpperCase();
-  return key === 'PTS' || key === 'POINTS' || key === 'GOALS';
+  return key === 'PTS' || key === 'POINTS' || key === 'GOALS' || key === 'R' || key === 'RUN' || key === 'RUNS';
 }
 
 export function hasUniquePlayerIds(ids = []) {

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -1,4 +1,4 @@
-// Mobile-first basketball tracker, now backed by Firebase like track.html.
+// Mobile-first live tracker, backed by Firebase like track.html.
 import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=14';
 import { db } from './firebase.js?v=9';
 import { getUrlParams, escapeHtml } from './utils.js?v=9';
@@ -15,7 +15,7 @@ import { resolveSummaryRecipient } from './live-tracker-email.js?v=1';
 import { buildLiveResetEvent } from './live-tracker-reset.js?v=1';
 import { advanceLiveChatUnreadState } from './live-tracker-chat-unread.js?v=2';
 import { resolveLiveStatConfig, resolveLiveStatColumns } from './live-game-state.js?v=3';
-import { getDefaultLivePeriod, getSportPeriodLabels } from './live-sport-config.js?v=1';
+import { getDefaultLivePeriod, getSportPeriodLabels, resolveLiveSport } from './live-sport-config.js?v=1';
 
 let currentTeamId = null;
 let currentGameId = null;
@@ -193,6 +193,7 @@ const els = {
   clock: q('#clock-mobile'),
   fairness: q('#fairness-mobile'),
   onCourtCount: q('#on-court-count-mobile'),
+  lineupLimitLabel: q('#lineup-limit-label'),
   startStop: q('#start-stop'),
   undoMini: q('#undo-mini'),
   preTab: q('#pre-game-tab'),
@@ -313,13 +314,26 @@ function renderHeader() {
   updateClockUI();
 }
 
+function getActivePlayerLimit() {
+  const sport = resolveLiveSport({ game: currentGame, team: currentTeam, config: currentConfig }).toLowerCase();
+  if (sport === 'baseball') return 9;
+  if (sport === 'softball') return 10;
+  return 5;
+}
+
+function updateLineupLabels() {
+  const limit = getActivePlayerLimit();
+  if (els.lineupLimitLabel) els.lineupLimitLabel.textContent = `Pick starters (max ${limit})`;
+  if (els.autoFill) els.autoFill.textContent = `Auto-fill ${limit}`;
+}
+
 function updateClockUI() {
   els.periodChip.textContent = `${state.period} · ${formatClock(state.clock)}`;
   els.clock.textContent = formatClock(state.clock);
 }
 
 function renderLineup() {
-  els.onCourtCount.textContent = `${state.onCourt.length}/5`;
+  els.onCourtCount.textContent = `${state.onCourt.length}/${getActivePlayerLimit()}`;
   els.lineupStarters.innerHTML = state.onCourt.map(id => playerChip(id, true)).join('');
   const bench = state.bench.map(id => playerChip(id, false)).join('');
   els.lineupBench.innerHTML = bench || '<div class="col-span-5 text-[10px] text-slate-500">No bench set</div>';
@@ -379,7 +393,7 @@ function liveCard(id) {
 
   const btnHtml = cols.map(col => {
     const key = col.toLowerCase();
-    if (isPointsColumn(col)) {
+    if (isMultiValueScoreColumn(col)) {
       return `${statBtn(id, key, 2, '+2')} ${statBtn(id, key, 3, '+3')} ${statBtn(id, key, 1, '+1')}`;
     }
     return statBtn(id, key, 1, col);
@@ -447,7 +461,7 @@ function renderOpponents() {
 
     const oppBtns = cols.map(col => {
       const key = col.toLowerCase();
-      if (isPointsColumn(col)) {
+      if (isMultiValueScoreColumn(col)) {
         return `${oppBtn(o.id, key, 2, '+2')} ${oppBtn(o.id, key, 3, '+3')} ${oppBtn(o.id, key, 1, '+1')}`;
       }
       return oppBtn(o.id, key, 1, col);
@@ -1561,7 +1575,12 @@ function formatClock(ms) {
 
 function isPointsColumn(colOrKey) {
   const u = (colOrKey || '').toString().toUpperCase();
-  return u === 'PTS' || u === 'POINTS' || u === 'GOALS';
+  return u === 'PTS' || u === 'POINTS' || u === 'GOALS' || u === 'R' || u === 'RUN' || u === 'RUNS';
+}
+
+function isMultiValueScoreColumn(colOrKey) {
+  const u = (colOrKey || '').toString().toUpperCase();
+  return u === 'PTS' || u === 'POINTS';
 }
 
 async function startStop() {
@@ -1693,13 +1712,14 @@ function setPeriod(p) {
 }
 
 function applyPeriodButtons() {
-  const labels = getSportPeriodLabels({ game: currentGame, team: currentTeam, config: currentConfig }).slice(0, 5);
+  const labels = getSportPeriodLabels({ game: currentGame, team: currentTeam, config: currentConfig });
   const fallbackLabel = labels[0] || getDefaultLivePeriod({ game: currentGame, team: currentTeam, config: currentConfig });
-  document.querySelectorAll('.period-btn').forEach((button, index) => {
-    const label = labels[index] || fallbackLabel;
-    button.dataset.period = label;
-    button.textContent = label;
-  });
+  const container = document.getElementById('period-buttons');
+  if (!container) return;
+  container.innerHTML = labels.map((label) => {
+    const active = label === (state.period || fallbackLabel);
+    return `<button class="pill px-2 py-1.5 ${active ? 'bg-teal text-ink border-teal font-bold' : 'bg-white border-slate/10 font-semibold'} border period-btn" data-period="${escapeHtml(label)}">${escapeHtml(label)}</button>`;
+  }).join('');
 }
 
 function addStat(id, key, delta) {
@@ -2072,7 +2092,7 @@ function handleLineupClick(e) {
     state.bench.push(id);
     addLog(`#${getNum(id)} ${playerName(id)} removed from court`);
   } else {
-    if (state.onCourt.length >= 5) return;
+    if (state.onCourt.length >= getActivePlayerLimit()) return;
     state.onCourt.push(id);
     state.bench = state.bench.filter(p => p !== id);
     addLog(`#${getNum(id)} ${playerName(id)} added to court`);
@@ -2109,13 +2129,13 @@ function setSubMode(mode) {
 function updateSubHint() {
   if (state.queueMode) {
     if (!state.pendingOut) {
-      els.subHint.textContent = 'Tap player on court, then tap replacement';
+      els.subHint.textContent = 'Tap active player, then tap replacement';
     } else {
       els.subHint.textContent = 'Now tap bench player to complete swap';
     }
   } else {
     if (!state.pendingOut) {
-      els.subHint.textContent = 'Tap player on court, then tap replacement';
+      els.subHint.textContent = 'Tap active player, then tap replacement';
     } else {
       els.subHint.textContent = 'Now tap bench player to swap in';
     }
@@ -2172,7 +2192,7 @@ function renderSubPlayers() {
       ${avatarHtml(p, 'h-5 w-5', 'text-[9px]')}
       <span class="truncate">#${escapeHtml(p?.num || '')} ${escapeHtml(p?.name || '')}</span>
     </button>`;
-  }).join('') || '<div class="text-xs text-slate-500 text-center py-2">No players on court</div>';
+  }).join('') || '<div class="text-xs text-slate-500 text-center py-2">No active players</div>';
 
   // Render bench players
   els.subIn.innerHTML = state.bench.map(id => {
@@ -2252,7 +2272,7 @@ function applyQueue(closeModal = true) {
 }
 
 function subIn(id) {
-  if (state.onCourt.length >= 5) return;
+  if (state.onCourt.length >= getActivePlayerLimit()) return;
   state.onCourt.push(id);
   state.bench = state.bench.filter(p => p !== id);
   renderLineup();
@@ -2288,7 +2308,7 @@ function renderQueue() {
 }
 
 function autoFillStarters() {
-  const needed = 5 - state.onCourt.length;
+  const needed = getActivePlayerLimit() - state.onCourt.length;
   if (needed <= 0) return;
   const add = state.bench.slice(0, needed);
   state.onCourt = [...state.onCourt, ...add];
@@ -2426,6 +2446,7 @@ async function init() {
     setVoiceNoteButtonLabel(false);
     setVoiceNoteHint(false);
     applyPeriodButtons();
+    updateLineupLabels();
 
     let shouldResume = true;
     const hasOpponentStats = !!(game.opponentStats && Object.keys(game.opponentStats).length > 0);
@@ -2455,7 +2476,7 @@ async function init() {
             liveResetAt: resetAt,
             liveClockMs: 0,
             liveClockRunning: false,
-            liveClockPeriod: 'Q1',
+            liveClockPeriod: state.period,
             liveClockUpdatedAt: resetAt,
             liveLineup: { onCourt: [], bench: roster.map(r => r.id) },
             // Preserve opponent fields
@@ -2471,7 +2492,7 @@ async function init() {
         }
         currentGame.liveClockMs = 0;
         currentGame.liveClockRunning = false;
-        currentGame.liveClockPeriod = 'Q1';
+        currentGame.liveClockPeriod = state.period;
         currentGame.liveClockUpdatedAt = resetAt;
         const deletions = [
           ...eventsSnapshot.docs.map(d => deleteDoc(d.ref)),

--- a/js/practice-starter-drills.js
+++ b/js/practice-starter-drills.js
@@ -1,0 +1,124 @@
+const SHARED_DIAMOND_DRILLS = [
+    {
+        slug: 'throwing-ladder',
+        title: 'Partner Throwing Ladder',
+        type: 'Warm-up',
+        level: 'All',
+        skills: ['throwing', 'catching', 'partner catch'],
+        duration: 10,
+        players: '2+',
+        cones: 0,
+        description: 'Pairs build throwing rhythm by stepping back after clean catches and stepping in after misses.',
+        instructions: 'Pair players 20 feet apart. Each pair makes five clean throws before taking two steps back. Keep throws chest-high, reset feet before throwing, and finish with five accurate short throws.'
+    },
+    {
+        slug: 'grounders-to-first',
+        title: 'Grounders and Throws to First',
+        type: 'Technical',
+        level: 'Basic',
+        skills: ['ground balls', 'throws to first', 'fielding play'],
+        duration: 15,
+        players: '4+',
+        cones: 2,
+        description: 'Players field routine ground balls and make controlled throws to first base.',
+        instructions: 'Set one line at shortstop depth and one first-base target. Roll grounders at game pace. Field out front, funnel to throwing hand, make one strong throw, then rotate.'
+    },
+    {
+        slug: 'fly-ball-communication',
+        title: 'Fly Ball Communication',
+        type: 'Technical',
+        level: 'Basic',
+        skills: ['fly balls', 'communication', 'fielding play'],
+        duration: 12,
+        players: '3+',
+        cones: 4,
+        description: 'Small groups practice calling the ball early and yielding to the player with the best angle.',
+        instructions: 'Place players in a shallow outfield triangle. Toss pop flies between them. The catching player calls three times, other players peel away and back up.'
+    },
+    {
+        slug: 'base-running-turns',
+        title: 'Base Running Turns',
+        type: 'Physical',
+        level: 'All',
+        skills: ['base running', 'rounding bases', 'speed'],
+        duration: 10,
+        players: '4+',
+        cones: 4,
+        description: 'Players practice aggressive but controlled turns through first and second.',
+        instructions: 'Start at home. Players run through first, round first, then round first and second on later reps. Emphasize touching the inside corner, eyes up, and slowing under control.'
+    },
+    {
+        slug: 'tee-contact-zones',
+        title: 'Tee Contact Zones',
+        type: 'Technical',
+        level: 'All',
+        skills: ['tee work', 'contact', 'bat path'],
+        duration: 15,
+        players: '2+',
+        cones: 0,
+        description: 'Hitters work inside, middle, and outside contact points from a tee.',
+        instructions: 'Set the tee at three plate locations. Hit five balls from each spot. Players should drive through the ball, keep balance, and reset between swings.'
+    },
+    {
+        slug: 'situational-outs',
+        title: 'Situational Outs',
+        type: 'Game',
+        level: 'Intermediate',
+        skills: ['situations', 'cutoffs', 'team defense', 'fielding play'],
+        duration: 18,
+        players: '8+',
+        cones: 0,
+        description: 'Defense gets a simple situation before each ball and makes the high-percentage out.',
+        instructions: 'Call a base/out situation before each rep. Put the ball in play by rolling or hitting it softly. Players call the play, make the throw, and reset quickly.'
+    }
+];
+
+function normalizeSport(value) {
+    return String(value || '').trim().toLowerCase();
+}
+
+function buildSportDrill(sport, drill) {
+    return {
+        id: `starter-${sport.toLowerCase()}-${drill.slug}`,
+        source: 'starter',
+        sport,
+        title: drill.title,
+        type: drill.type,
+        level: drill.level,
+        ageGroup: 'All',
+        skills: drill.skills,
+        description: drill.description,
+        instructions: drill.instructions,
+        setup: {
+            duration: drill.duration,
+            players: drill.players,
+            cones: drill.cones,
+            balls: 'Baseballs or softballs'
+        }
+    };
+}
+
+export const PRACTICE_STARTER_DRILLS = [
+    ...SHARED_DIAMOND_DRILLS.map(drill => buildSportDrill('Baseball', drill)),
+    ...SHARED_DIAMOND_DRILLS.map(drill => buildSportDrill('Softball', drill))
+];
+
+export function getStarterDrills(sport, filters = {}) {
+    const targetSport = normalizeSport(sport);
+    const term = filters.searchText ? String(filters.searchText).toLowerCase() : '';
+    return PRACTICE_STARTER_DRILLS.filter(drill => {
+        if (targetSport && normalizeSport(drill.sport) !== targetSport) return false;
+        if (filters.type && drill.type !== filters.type) return false;
+        if (filters.level && drill.level !== filters.level) return false;
+        if (filters.skill && !drill.skills.includes(filters.skill)) return false;
+        if (term) {
+            const haystack = `${drill.title} ${drill.description} ${drill.skills.join(' ')}`.toLowerCase();
+            if (!haystack.includes(term)) return false;
+        }
+        return true;
+    });
+}
+
+export function getStarterDrillById(id) {
+    return PRACTICE_STARTER_DRILLS.find(drill => drill.id === id) || null;
+}

--- a/js/sport-templates.js
+++ b/js/sport-templates.js
@@ -1,0 +1,40 @@
+export const SPORT_STAT_TEMPLATES = {
+    Basketball: {
+        sport: 'Basketball',
+        name: 'Basketball Standard',
+        baseType: 'Basketball',
+        columns: ['PTS', 'REB', 'AST', 'STL', 'TO']
+    },
+    Soccer: {
+        sport: 'Soccer',
+        name: 'Soccer Standard',
+        baseType: 'Soccer',
+        columns: ['GOALS', 'SHOTS', 'PASSES', 'BLOCKS', 'HUSTLE']
+    },
+    Baseball: {
+        sport: 'Baseball',
+        name: 'Baseball Standard',
+        baseType: 'Baseball',
+        columns: ['AB', 'H', 'R', 'RBI', 'BB', 'FP']
+    },
+    Softball: {
+        sport: 'Softball',
+        name: 'Softball Standard',
+        baseType: 'Softball',
+        columns: ['AB', 'H', 'R', 'RBI', 'BB', 'FP']
+    }
+};
+
+function normalizeSport(value) {
+    return String(value || '').trim().toLowerCase();
+}
+
+export function getSportStatTemplate(sport) {
+    const normalized = normalizeSport(sport);
+    return Object.values(SPORT_STAT_TEMPLATES).find(template => normalizeSport(template.sport) === normalized) || null;
+}
+
+export function getSportTemplateOptions() {
+    return Object.values(SPORT_STAT_TEMPLATES);
+}
+

--- a/live-tracker.html
+++ b/live-tracker.html
@@ -83,17 +83,16 @@
         </div>
       </div>
       <!-- Periods row (compact) -->
-      <div class="grid grid-cols-4 gap-1 text-center text-[11px]">
+      <div id="period-buttons" class="grid grid-cols-4 gap-1 text-center text-[11px]">
         <button class="pill px-2 py-1.5 bg-teal text-ink border border-teal period-btn font-bold" data-period="Q1">Q1</button>
         <button class="pill px-2 py-1.5 bg-white border border-slate/10 period-btn font-semibold" data-period="Q2">Q2</button>
         <button class="pill px-2 py-1.5 bg-white border border-slate/10 period-btn font-semibold" data-period="Q3">Q3</button>
         <button class="pill px-2 py-1.5 bg-white border border-slate/10 period-btn font-semibold" data-period="Q4">Q4</button>
       </div>
       <!-- Actions row -->
-      <div class="grid grid-cols-3 gap-2 text-center text-[11px]">
-        <button class="pill px-2 py-1.5 bg-white border border-slate/10 period-btn font-semibold" data-period="OT">OT</button>
+      <div class="grid grid-cols-2 gap-2 text-center text-[11px]">
         <button class="pill px-2 py-1.5 bg-purple-600 text-white border border-purple-700 font-bold" id="sub-open">Subs</button>
-        <button class="pill px-2 py-1.5 bg-white border border-slate/10 font-semibold" id="full-line-swap">Swap 5</button>
+        <button class="pill px-2 py-1.5 bg-white border border-slate/10 font-semibold" id="full-line-swap">Swap active</button>
       </div>
       <!-- Quick apply queue button (only visible when queue exists) -->
       <div id="queue-quick-apply" class="hidden rounded-xl bg-teal/10 border border-teal p-2">
@@ -103,7 +102,7 @@
         </div>
       </div>
       <div class="flex items-center justify-between text-xs text-white bg-slate rounded-xl px-3 py-2">
-        <span class="font-semibold">On court: <span id="on-court-count-mobile">0/5</span></span>
+        <span class="font-semibold">Active: <span id="on-court-count-mobile">0/5</span></span>
         <span id="fairness-mobile" class="pill px-2 py-1 bg-white/10 text-white font-semibold text-xs">Needs data</span>
         <span class="font-mono" id="clock-mobile">00:00</span>
       </div>
@@ -112,7 +111,7 @@
     <!-- Lineup -->
     <section id="panel-lineup" class="card mx-3 p-3 rounded-2xl shadow-lg space-y-3 hidden">
       <div class="flex items-center justify-between text-sm font-semibold">
-        <span>Pick starters (max 5)</span>
+        <span id="lineup-limit-label">Pick starters</span>
         <button id="clear-lineup-mobile" class="text-xs underline">Clear</button>
       </div>
       <div id="lineup-starters" class="grid grid-cols-5 gap-2 text-center text-xs"></div>
@@ -127,9 +126,9 @@
       <div id="starter-helper" class="hidden rounded-xl bg-sand border border-slate/10 p-2 text-xs space-y-1">
         <div class="flex items-center justify-between">
           <span class="font-semibold text-ink">Add starters</span>
-          <button id="auto-fill-mobile" class="pill px-2 py-1 bg-teal text-ink font-semibold">Auto-fill 5</button>
+          <button id="auto-fill-mobile" class="pill px-2 py-1 bg-teal text-ink font-semibold">Auto-fill</button>
         </div>
-        <p class="text-slate-600">Tap below to move players on court.</p>
+        <p class="text-slate-600">Tap below to move players into the active group.</p>
       </div>
       <div id="live-players" class="grid grid-cols-2 gap-2"></div>
       <button id="toggle-bench-mobile" class="w-full text-xs font-semibold pill px-3 py-2 bg-white border border-slate/10">Bench / Add starters</button>
@@ -334,7 +333,7 @@
       </div>
 
       <div class="space-y-2">
-        <div id="sub-hint-mobile" class="text-xs text-center py-2 rounded-lg bg-sand text-slate-600 font-medium">Tap player on court, then tap replacement</div>
+        <div id="sub-hint-mobile" class="text-xs text-center py-2 rounded-lg bg-sand text-slate-600 font-medium">Tap active player, then tap replacement</div>
         <div class="grid grid-cols-2 gap-2">
           <button id="save-queue-later" class="hidden pill px-3 py-2 bg-white border-2 border-teal text-teal font-bold text-sm">Save for Later</button>
           <button id="confirm-sub-mobile" class="w-full pill px-4 py-3 bg-teal text-ink font-bold text-sm" disabled>Make Swap</button>

--- a/spec/baseball-softball-support/design.md
+++ b/spec/baseball-softball-support/design.md
@@ -1,0 +1,77 @@
+# Baseball and Softball Support Design
+
+## Overview
+
+This feature adds baseball and softball as first-class sports using the existing multi-sport architecture. The core design choice is passive tracking: the product should feel useful on the sideline without turning into a formal scorebook.
+
+The implementation should reuse existing patterns:
+
+- Team creation auto-creates one `statTrackerConfigs` document.
+- `edit-config.html` provides quick stat templates.
+- Standard tracking remains config-driven through `track.html`.
+- Live period labels are resolved by `js/live-sport-config.js`.
+- Game planning extends the existing formation model.
+- Practice planning extends existing drill taxonomies and starter content.
+
+## Sport Templates
+
+Baseball and softball use the same initial stat columns:
+
+`AB, H, R, RBI, BB, FP`
+
+`FP` means fielding play. It is intentionally broad so a passive scorekeeper can credit a defensive out, strong throw, catch, or other notable fielding contribution without choosing a formal scorebook code.
+
+## Tracking Model
+
+No new pitch-level tracker is introduced in this release. Baseball and softball games use:
+
+- Existing standard stat tracker for player stats and score save/complete.
+- Existing live tracker/event model where available.
+- Inning labels from `getSportPeriodLabels()`.
+- Existing config columns for stat tables and reports.
+
+This keeps the blast radius low and preserves the current save paths.
+
+## Game Planning
+
+Add two formations:
+
+- `baseball-9`: P, C, 1B, 2B, 3B, SS, LF, CF, RF
+- `softball-10`: P, C, 1B, 2B, 3B, SS, LF, LCF, RCF, RF
+
+For baseball and softball plans, default period labels should be seven innings. The planner also stores a `battingOrder` array on the game plan:
+
+```js
+{
+  battingOrder: [
+    { slot: 1, playerId: "..." },
+    { slot: 2, playerId: "..." }
+  ]
+}
+```
+
+The existing defensive lineup grid remains the source for inning/position assignments.
+
+## Practice Planning
+
+Add baseball and softball taxonomies to the drill constants and seed a small built-in library that uses the current drill schema. Starter drills should cover:
+
+- Warm-up throwing and catching
+- Ground balls and throws to first
+- Fly balls and communication
+- Base running
+- Tee/soft toss hitting
+- Team defense or situational scrimmage
+
+The same seed content can be used for both sports with sport-specific labels where helpful.
+
+## Risks
+
+- Existing game planning code is page-local, so adding batting order needs focused edits and tests.
+- Generic stat tracking may not satisfy users expecting formal scorebook behavior. The requirement explicitly avoids that for this release.
+- Practice drill AI prompts should remain useful when the sport is not soccer; templates and taxonomies reduce empty-state risk.
+
+## Rollback
+
+Rollback is limited to removing baseball/softball options and templates from team/config pages, reverting game-planning formation additions, and removing the added drill taxonomy/seed content. No data migration is required.
+

--- a/spec/baseball-softball-support/requirements.md
+++ b/spec/baseball-softball-support/requirements.md
@@ -1,0 +1,91 @@
+# Baseball and Softball Support Requirements
+
+## Introduction
+
+Add first-class baseball and softball support for newly created teams. The first release should feel native across team setup, stat templates, game tracking, live viewing, game planning, and practice planning while staying passive enough for a parent or coach to use from the sideline.
+
+The feature intentionally avoids full pitch-by-pitch scoring. Users should be able to record inning-level context, runs, simple hitting stats, and basic fielding plays without needing to document every pitch, count, or substitution in real time.
+
+## User Stories
+
+- **US-1:** As a coach creating a new baseball or softball team, I want the correct sport option and a default stat template so that I can schedule and track games without manual config setup.
+- **US-2:** As a scorekeeper, I want a passive baseball/softball tracker so that I can record key offensive and fielding outcomes without managing pitch counts.
+- **US-3:** As a family member watching a live game, I want innings and baseball/softball stats to appear correctly so that the live view makes sense for the sport.
+- **US-4:** As a coach planning a game, I want baseball and softball field templates plus batting order planning so that I can prepare defense and lineup together.
+- **US-5:** As a coach planning practice, I want baseball/softball drill categories and starter templates so that practice planning starts from sport-relevant work.
+
+## Requirements
+
+### 1. New-Team Sport Setup
+
+1.1 The system shall list `Baseball` and `Softball` as selectable sports when creating a new team.
+
+1.2 When a new baseball team is created, the system shall auto-create a default stat tracker config named `Baseball Standard`.
+
+1.3 When a new softball team is created, the system shall auto-create a default stat tracker config named `Softball Standard`.
+
+1.4 The default baseball and softball configs shall include offensive and fielding columns suitable for passive tracking.
+
+1.5 The system shall not attempt to migrate existing baseball or softball teams in this release.
+
+### 2. Stat Templates
+
+2.1 The baseball and softball templates shall support core hitting stats: `AB`, `H`, `R`, `RBI`, and `BB`.
+
+2.2 The baseball and softball templates shall support at least one fielding-play stat so a scorekeeper can capture defensive contribution without full scorebook detail.
+
+2.3 The templates shall use the same stat config storage model as the existing basketball and soccer templates.
+
+2.4 The edit-config page shall provide quick templates for baseball and softball.
+
+### 3. Passive Game Tracking
+
+3.1 The standard game tracker shall load baseball and softball stat configs without routing users into basketball-specific beta/photo trackers.
+
+3.2 The live tracker shall use inning period labels for baseball and softball: `T1/B1` through `T7/B7`.
+
+3.3 Baseball and softball tracking shall avoid required pitch-by-pitch input, ball/strike counts, or pitch sequencing.
+
+3.4 The system shall allow users to record team/player stats and final scores using existing save/complete flows.
+
+3.5 Fielding play capture shall be available through the configured stat columns rather than a full defensive scoring workflow.
+
+### 4. Live Game Viewing
+
+4.1 Live game display shall show inning labels instead of basketball quarter labels for baseball and softball.
+
+4.2 Live event descriptions and stat tables shall use the configured baseball/softball columns.
+
+4.3 Replay and live status flows shall continue to work with baseball/softball games using the existing live event model.
+
+### 5. Game Planning
+
+5.1 Game planning shall include a `Baseball 9` formation with standard defensive positions.
+
+5.2 Game planning shall include a `Softball 10` formation with a tenth fielder position.
+
+5.3 Baseball and softball game plans shall support 7 innings by default.
+
+5.4 Baseball and softball game plans shall include batting order planning in addition to defensive position assignments.
+
+5.5 Batting order planning shall be persisted with the game plan data.
+
+### 6. Practice Planning
+
+6.1 The drill taxonomy shall include baseball and softball skill categories.
+
+6.2 Practice planning shall expose baseball/softball starter drill templates.
+
+6.3 Baseball/softball practice drill support shall use the existing drill schema and team sport filtering.
+
+6.4 Starter templates shall prioritize youth-coach friendly drills that are easy to run without specialized equipment.
+
+## Out of Scope
+
+- Existing team migration.
+- Full pitch-by-pitch scorekeeping.
+- Pitch count management.
+- Umpire/scorebook rule adjudication.
+- Advanced baseball analytics.
+- League-specific lineup legality enforcement.
+

--- a/spec/baseball-softball-support/tasks.md
+++ b/spec/baseball-softball-support/tasks.md
@@ -1,0 +1,38 @@
+# Baseball and Softball Support Tasks
+
+## Phase 1: Spec and Template Foundation
+
+- [x] Create requirements, design, tasks, and validation log under `spec/baseball-softball-support/`.
+- [x] Add baseball and softball sport options to team creation.
+- [x] Auto-create baseball and softball standard configs for new teams.
+- [x] Add quick templates to `edit-config.html`.
+- [x] Add tests or static checks for default template values.
+
+## Phase 2: Tracking and Live Support
+
+- [x] Verify standard tracker loads baseball/softball configs without basketball-only routing.
+- [x] Ensure baseball/softball live period labels resolve to `T1/B1` through `T7/B7`.
+- [x] Add focused tests for sport period defaults if missing.
+- [x] Confirm live viewer stat rendering remains config-driven.
+
+## Phase 3: Game Planning
+
+- [x] Add `Baseball 9` and `Softball 10` formations.
+- [x] Default baseball/softball plans to seven innings.
+- [x] Add batting order planning UI.
+- [x] Persist batting order with game plans.
+- [x] Add focused game-planning tests for formation and batting order helpers.
+
+## Phase 4: Practice Planning
+
+- [x] Add baseball and softball drill skill taxonomies.
+- [x] Add starter drill templates for baseball and softball.
+- [x] Verify practice planner filters by team sport.
+- [x] Add focused tests for taxonomy/template availability.
+
+## Phase 5: Validation
+
+- [x] Run unit tests.
+- [x] Start a local static server.
+- [x] Manually inspect team creation, edit config, game planning, standard tracking, live view, and practice planning pages.
+- [x] Record results in `validation-log.md`.

--- a/spec/baseball-softball-support/validation-log.md
+++ b/spec/baseball-softball-support/validation-log.md
@@ -1,0 +1,24 @@
+# Baseball and Softball Support Validation Log
+
+## Manual Test Plan
+
+- Create a new baseball team and confirm `Baseball Standard` config appears with `AB, H, R, RBI, BB, FP`.
+- Create a new softball team and confirm `Softball Standard` config appears with `AB, H, R, RBI, BB, FP`.
+- Open `edit-config.html` and confirm baseball/softball quick templates populate name, base sport, and columns.
+- Create a baseball/softball game, open standard tracking, record stats, update score, and save/complete.
+- Open live tracking/live viewer for a baseball/softball game and confirm inning labels render as `T1/B1` style labels.
+- Open `game-plan.html`, choose `Baseball 9` and `Softball 10`, assign defensive positions, set batting order, save, reload, and confirm persistence.
+- Open `drills.html` for baseball and softball teams and confirm sport-relevant drill categories and starter drills appear.
+
+## Results
+
+### 2026-05-10
+
+- Added focused unit coverage for sport stat templates, baseball/softball inning labels, run-score finalization, game-plan interop, and practice starter drills.
+- Ran `npx vitest run tests/unit/live-tracker-integrity.test.js tests/unit/sport-templates.test.js tests/unit/live-sport-config.test.js tests/unit/game-plan-interop.test.js tests/unit/practice-starter-drills.test.js`: 5 files passed, 25 tests passed.
+- Ran `npm test`: 81 files passed, 399 tests passed.
+- Ran `git diff --check` with no whitespace errors.
+- Used local static server at `http://localhost:8000` to confirm edited pages return 200: `edit-team.html`, `edit-config.html`, `track.html`, `track-live.html`, `live-tracker.html`, `live-game.html`, `game-plan.html`, `game-day.html`, and `drills.html`.
+- Confirmed static page content includes baseball/softball config templates, game-plan formations, batting order UI, starter drill import, and dynamic period selector wiring.
+- Double-check fixed run scoring in live final-score reconciliation and removed basketball-only multi-point buttons from run/goal tracking paths.
+- Authenticated Firebase-backed create/save flows still need real-account manual verification.

--- a/tests/unit/game-plan-interop.test.js
+++ b/tests/unit/game-plan-interop.test.js
@@ -47,4 +47,29 @@ describe('game plan interop helpers', () => {
       Q2: { pg: 'p2' }
     });
   });
+
+  it('uses inning prefixes for baseball and softball legacy plans', () => {
+    const baseballPlan = buildRotationPlanFromGamePlan({
+      formationId: 'baseball-9',
+      numPeriods: 7,
+      lineups: {
+        '1-1-p': 'p1',
+        '2-1-ss': 'p2'
+      }
+    });
+    expect(baseballPlan).toEqual({
+      I1: { p: 'p1' },
+      I2: { ss: 'p2' }
+    });
+
+    const softballPlan = buildRotationPlanFromGamePlan({
+      formationId: 'softball-10',
+      lineups: {
+        'I1-lcf': 'p3'
+      }
+    });
+    expect(softballPlan).toEqual({
+      I1: { lcf: 'p3' }
+    });
+  });
 });

--- a/tests/unit/live-tracker-integrity.test.js
+++ b/tests/unit/live-tracker-integrity.test.js
@@ -61,6 +61,30 @@ describe('live tracker integrity helpers', () => {
     expect(result.derived.away).toBe(2);
   });
 
+  it('counts run stats as scoring events for diamond sports', () => {
+    const log = [
+      { undoData: { type: 'stat', statKey: 'R', value: 1, isOpponent: false } },
+      { undoData: { type: 'stat', statKey: 'runs', value: 2, isOpponent: true } },
+      { undoData: { type: 'stat', statKey: 'H', value: 1, isOpponent: false } }
+    ];
+
+    expect(reconcileFinalScoreFromLog({
+      requestedHome: 0,
+      requestedAway: 0,
+      log
+    })).toMatchObject({
+      home: 1,
+      away: 2,
+      mismatch: true
+    });
+
+    expect(canTrustScoreLogForFinalization({
+      liveHome: 1,
+      liveAway: 2,
+      log
+    })).toBe(true);
+  });
+
   it('keeps requested final score when already aligned to event-derived score', () => {
     const log = [
       { undoData: { type: 'stat', statKey: 'PTS', value: 2, isOpponent: false } },

--- a/tests/unit/practice-starter-drills.test.js
+++ b/tests/unit/practice-starter-drills.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { getAllSkillTags } from '../../js/drill-constants.js';
+import { getStarterDrillById, getStarterDrills } from '../../js/practice-starter-drills.js';
+
+describe('baseball and softball practice starter drills', () => {
+    it('exposes baseball and softball skills', () => {
+        expect(getAllSkillTags('Baseball')).toContain('fielding play');
+        expect(getAllSkillTags('Softball')).toContain('base running');
+    });
+
+    it('returns sport-filtered starter drills', () => {
+        const baseball = getStarterDrills('Baseball');
+        const softball = getStarterDrills('Softball');
+        expect(baseball.length).toBeGreaterThanOrEqual(6);
+        expect(softball.length).toBe(baseball.length);
+        expect(baseball.every(drill => drill.sport === 'Baseball')).toBe(true);
+    });
+
+    it('supports starter drill lookup by id', () => {
+        const [drill] = getStarterDrills('Baseball', { skill: 'fielding play' });
+        expect(getStarterDrillById(drill.id)).toMatchObject({
+            id: drill.id,
+            source: 'starter'
+        });
+    });
+});
+

--- a/tests/unit/sport-templates.test.js
+++ b/tests/unit/sport-templates.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { getSportStatTemplate, getSportTemplateOptions } from '../../js/sport-templates.js';
+
+describe('sport stat templates', () => {
+    it('includes baseball and softball templates with passive fielding play', () => {
+        expect(getSportStatTemplate('Baseball')).toMatchObject({
+            name: 'Baseball Standard',
+            baseType: 'Baseball',
+            columns: ['AB', 'H', 'R', 'RBI', 'BB', 'FP']
+        });
+        expect(getSportStatTemplate('softball')).toMatchObject({
+            name: 'Softball Standard',
+            baseType: 'Softball',
+            columns: ['AB', 'H', 'R', 'RBI', 'BB', 'FP']
+        });
+    });
+
+    it('keeps existing basketball and soccer templates available', () => {
+        expect(getSportTemplateOptions().map(template => template.sport)).toEqual([
+            'Basketball',
+            'Soccer',
+            'Baseball',
+            'Softball'
+        ]);
+    });
+});
+

--- a/track-live.html
+++ b/track-live.html
@@ -291,7 +291,7 @@
             </div>
 
             <!-- Period Selector -->
-            <div class="flex justify-center gap-1 mb-2">
+            <div id="period-selector" class="flex flex-wrap justify-center gap-1 mb-2">
                 <button
                     class="period-btn period-active px-3 py-1 rounded text-xs"
                     data-period="Q1">Q1</button>
@@ -700,13 +700,7 @@
                     };
                 }
 
-                const periodLabels = getSportPeriodLabels({ team: currentTeam, config: currentConfig }).slice(0, 5);
-                const periodButtons = document.querySelectorAll('.period-btn');
-                periodButtons.forEach((btn, index) => {
-                    const label = periodLabels[index] || periodLabels[0];
-                    btn.dataset.period = label;
-                    btn.textContent = label;
-                });
+                const periodLabels = renderPeriodSelector();
                 gameState.currentPeriod = periodLabels[0] || getDefaultLivePeriod({ team: currentTeam, config: currentConfig });
 
                 // Load existing aggregated stats from Firestore into gameState
@@ -717,9 +711,12 @@
 
                 // Also load existing scores from aggregated stats
                 let totalHomePoints = 0;
+                const scoreKey = (currentConfig.columns || [])
+                    .map(col => col.toLowerCase())
+                    .find(key => ['pts', 'points', 'goals', 'r', 'run', 'runs'].includes(key)) || 'pts';
                 players.forEach(p => {
                     if (gameState.playerStats[p.id]) {
-                        const pts = gameState.playerStats[p.id].pts || gameState.playerStats[p.id].points || 0;
+                        const pts = gameState.playerStats[p.id][scoreKey] || 0;
                         totalHomePoints += pts;
                     }
                 });
@@ -751,16 +748,8 @@
                 // Add period button listeners
                 document.querySelectorAll('.period-btn').forEach(btn => {
                     btn.addEventListener('click', () => {
-                        // Update UI
-                        document.querySelectorAll('.period-btn').forEach(b => {
-                            b.classList.remove('period-active');
-                            b.classList.add('period-inactive');
-                        });
-                        btn.classList.remove('period-inactive');
-                        btn.classList.add('period-active');
-
-                        // Update state
                         gameState.currentPeriod = btn.dataset.period;
+                        setPeriodButtonState(gameState.currentPeriod);
                         addLogEntry(`Period changed to ${gameState.currentPeriod}`);
                     });
                 });
@@ -774,6 +763,38 @@
         function updateScoreDisplay() {
             document.getElementById('home-score').textContent = homeScore;
             document.getElementById('away-score').textContent = awayScore;
+        }
+
+        function isScoringStatKey(statKey) {
+            return ['pts', 'points', 'goals', 'r', 'run', 'runs'].includes(String(statKey || '').toLowerCase());
+        }
+
+        function isMultiValueScoreStatKey(statKey) {
+            return ['pts', 'points'].includes(String(statKey || '').toLowerCase());
+        }
+
+        function renderPeriodSelector() {
+            const labels = getSportPeriodLabels({ game: currentGame, team: currentTeam, config: currentConfig });
+            const selector = document.getElementById('period-selector');
+            if (!selector) return labels;
+            const active = labels[0] || getDefaultLivePeriod({ game: currentGame, team: currentTeam, config: currentConfig });
+            selector.innerHTML = labels.map(label => `
+                <button class="period-btn period-inactive px-3 py-1 rounded text-xs"
+                    data-period="${escapeHtml(label)}">${escapeHtml(label)}</button>
+            `).join('');
+            setPeriodButtonState(active);
+            return labels;
+        }
+
+        function setPeriodButtonState(period) {
+            document.querySelectorAll('.period-btn').forEach(b => {
+                b.classList.remove('period-active');
+                b.classList.add('period-inactive');
+                if (b.dataset.period === period) {
+                    b.classList.remove('period-inactive');
+                    b.classList.add('period-active');
+                }
+            });
         }
 
         function formatFieldTime(ms) {
@@ -957,7 +978,7 @@
             let headersHTML = '<th class="player-name text-left p-1">Player</th>';
             headersHTML += '<th class="stat-cell-wide p-1">Status</th>';
             currentConfig.columns.forEach(col => {
-                const isPoints = col.toUpperCase() === 'PTS' || col.toUpperCase() === 'POINTS' || col.toUpperCase() === 'GOALS';
+                const isPoints = isMultiValueScoreStatKey(col);
                 headersHTML += `<th class="${isPoints ? 'stat-cell-wide' : 'stat-cell'} p-1">${col}</th>`;
             });
             thead.innerHTML = headersHTML;
@@ -992,7 +1013,7 @@
                 </td>`;
 
                 currentConfig.columns.forEach(col => {
-                    const isPoints = col.toUpperCase() === 'PTS' || col.toUpperCase() === 'POINTS' || col.toUpperCase() === 'GOALS';
+                    const isPoints = isMultiValueScoreStatKey(col);
                     const statKey = col.toLowerCase();
 
                     if (isPoints) {
@@ -1037,7 +1058,7 @@
             let headersHTML = '<th class="player-name text-left p-1">Player</th>';
             headersHTML += '<th class="stat-cell-wide p-1">Status</th>';
             currentConfig.columns.forEach(col => {
-                const isPoints = col.toUpperCase() === 'PTS' || col.toUpperCase() === 'POINTS' || col.toUpperCase() === 'GOALS';
+                const isPoints = isMultiValueScoreStatKey(col);
                 headersHTML += `<th class="${isPoints ? 'stat-cell-wide' : 'stat-cell'} p-1">${col}</th>`;
             });
             thead.innerHTML = headersHTML;
@@ -1054,7 +1075,7 @@
                 </td>`;
 
                 currentConfig.columns.forEach(col => {
-                    const isPoints = col.toUpperCase() === 'PTS' || col.toUpperCase() === 'POINTS' || col.toUpperCase() === 'GOALS';
+                    const isPoints = isMultiValueScoreStatKey(col);
                     const statKey = col.toLowerCase();
                     const existingVal = gameState.opponentStats[opp.id]?.[statKey] || 0;
 
@@ -1228,7 +1249,7 @@
             const newVal = currentVal + value;
             statEl.textContent = newVal;
 
-            const isPoints = statKey === 'pts' || statKey === 'points' || statKey === 'goals';
+            const isPoints = isScoringStatKey(statKey);
 
             if (isOpponent) {
                 gameState.opponentStats[playerId][statKey] = newVal;
@@ -1316,9 +1337,9 @@
             if (currentVal === 0) return;
 
             let value = 1;
-            const isPoints = statKey === 'pts' || statKey === 'points' || statKey === 'goals';
+            const isPoints = isScoringStatKey(statKey);
 
-            if (isPoints && currentVal >= 3) {
+            if (isMultiValueScoreStatKey(statKey) && currentVal >= 3) {
                 value = confirm('Remove 3 points?') ? 3 : confirm('Remove 2 points?') ? 2 : 1;
             }
 
@@ -1772,7 +1793,7 @@
             if (undoData && undoData.type === 'stat') {
                 const { playerId, statKey, value, isOpponent } = undoData;
                 const statEl = document.getElementById(`stat-${playerId}-${statKey}`);
-                const isPoints = statKey === 'pts' || statKey === 'points' || statKey === 'goals';
+                const isPoints = isScoringStatKey(statKey);
                 const parsedValue = Number(value) || 0;
 
                 if (isOpponent) {

--- a/track.html
+++ b/track.html
@@ -128,7 +128,7 @@
             </div>
 
             <!-- Period Selector -->
-            <div class="flex justify-center gap-1 mb-2">
+            <div id="period-selector" class="flex flex-wrap justify-center gap-1 mb-2">
                 <button
                     class="period-btn bg-white text-blue-600 border-2 border-blue-600 px-3 py-1 rounded text-xs font-bold"
                     data-period="Q1">Q1</button>
@@ -280,6 +280,7 @@
         import { checkAuth } from './js/auth.js?v=9';
         import { isAISummaryEnabled, applyAISummaryAvailability } from './js/track-ai-summary.js';
         import { getApp } from './js/vendor/firebase-app.js';
+        import { getDefaultLivePeriod, getSportPeriodLabels } from './js/live-sport-config.js?v=1';
         // Note: firebase-ai will be lazy-loaded when AI summary is requested
 
         renderFooter(document.getElementById('footer-container'));
@@ -396,9 +397,12 @@
                 if (!currentConfig) {
                     currentConfig = {
                         name: 'Default',
+                        baseType: team?.sport || 'Basketball',
                         columns: ['PTS', 'REB', 'AST', 'STL', 'TO']
                     };
                 }
+                gameState.currentPeriod = getDefaultLivePeriod({ game, team, config: currentConfig });
+                renderPeriodSelector();
 
                 // Load existing aggregated stats from Firestore into gameState
                 const statsSnapshot = await getDocs(collection(db, `teams/${teamId}/games/${gameId}/aggregatedStats`));
@@ -408,9 +412,12 @@
 
                 // Also load existing scores from aggregated stats
                 let totalHomePoints = 0;
+                const scoreKey = (currentConfig.columns || [])
+                    .map(col => col.toLowerCase())
+                    .find(key => ['pts', 'points', 'goals', 'r', 'run', 'runs'].includes(key)) || 'pts';
                 players.forEach(p => {
                     if (gameState.playerStats[p.id]) {
-                        const pts = gameState.playerStats[p.id].pts || gameState.playerStats[p.id].points || 0;
+                        const pts = gameState.playerStats[p.id][scoreKey] || 0;
                         totalHomePoints += pts;
                     }
                 });
@@ -437,22 +444,7 @@
                 // Add initial history state for back button handling
                 history.pushState({ trackingPage: true }, '', window.location.href);
 
-                // Add period button listeners
-                document.querySelectorAll('.period-btn').forEach(btn => {
-                    btn.addEventListener('click', () => {
-                        // Update UI
-                        document.querySelectorAll('.period-btn').forEach(b => {
-                            b.classList.remove('bg-blue-600', 'text-white', 'border-blue-600', 'font-bold');
-                            b.classList.add('bg-white', 'text-gray-600', 'border-gray-300');
-                        });
-                        btn.classList.remove('bg-white', 'text-gray-600', 'border-gray-300');
-                        btn.classList.add('bg-blue-600', 'text-white', 'border-blue-600', 'font-bold');
-
-                        // Update state
-                        gameState.currentPeriod = btn.dataset.period;
-                        addLogEntry(`Period changed to ${gameState.currentPeriod}`);
-                    });
-                });
+                attachPeriodButtonListeners();
 
             } catch (error) {
                 console.error(error);
@@ -460,9 +452,54 @@
             }
         }
 
+        function getPeriodLabels() {
+            return getSportPeriodLabels({ game: currentGame, team: currentTeam, config: currentConfig });
+        }
+
+        function renderPeriodSelector() {
+            const selector = document.getElementById('period-selector');
+            if (!selector) return;
+            const labels = getPeriodLabels();
+            const active = gameState.currentPeriod || labels[0] || 'Q1';
+            selector.innerHTML = labels.map(label => `
+                <button class="period-btn bg-white text-gray-600 border border-gray-300 px-3 py-1 rounded text-xs"
+                    data-period="${escapeHtml(label)}">${escapeHtml(label)}</button>
+            `).join('');
+            setPeriodButtonState(active);
+        }
+
+        function setPeriodButtonState(period) {
+            document.querySelectorAll('.period-btn').forEach(b => {
+                b.classList.remove('bg-blue-600', 'text-white', 'border-blue-600', 'border-2', 'font-bold');
+                b.classList.add('bg-white', 'text-gray-600', 'border-gray-300', 'border');
+                if (b.dataset.period === period) {
+                    b.classList.remove('bg-white', 'text-gray-600', 'border-gray-300', 'border');
+                    b.classList.add('bg-blue-600', 'text-white', 'border-blue-600', 'border-2', 'font-bold');
+                }
+            });
+        }
+
+        function attachPeriodButtonListeners() {
+            document.querySelectorAll('.period-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    gameState.currentPeriod = btn.dataset.period;
+                    setPeriodButtonState(gameState.currentPeriod);
+                    addLogEntry(`Period changed to ${gameState.currentPeriod}`);
+                });
+            });
+        }
+
         function updateScoreDisplay() {
             document.getElementById('home-score').textContent = homeScore;
             document.getElementById('away-score').textContent = awayScore;
+        }
+
+        function isScoringStatKey(statKey) {
+            return ['pts', 'points', 'goals', 'r', 'run', 'runs'].includes(String(statKey || '').toLowerCase());
+        }
+
+        function isMultiValueScoreStatKey(statKey) {
+            return ['pts', 'points'].includes(String(statKey || '').toLowerCase());
         }
 
         function renderStatsTable() {
@@ -647,7 +684,7 @@
             const newVal = currentVal + value;
             statEl.textContent = newVal;
 
-            const isPoints = statKey === 'pts' || statKey === 'points' || statKey === 'goals';
+            const isPoints = isScoringStatKey(statKey);
 
             if (isOpponent) {
                 gameState.opponentStats[playerId][statKey] = newVal;
@@ -699,9 +736,9 @@
             if (currentVal === 0) return;
 
             let value = 1;
-            const isPoints = statKey === 'pts' || statKey === 'points' || statKey === 'goals';
+            const isPoints = isScoringStatKey(statKey);
 
-            if (isPoints && currentVal >= 3) {
+            if (isMultiValueScoreStatKey(statKey) && currentVal >= 3) {
                 value = confirm('Remove 3 points?') ? 3 : confirm('Remove 2 points?') ? 2 : 1;
             }
 
@@ -936,7 +973,7 @@
                 const newVal = Math.max(0, currentVal - value);
                 statEl.textContent = newVal;
 
-                const isPoints = statKey === 'pts' || statKey === 'points' || statKey === 'goals';
+                const isPoints = isScoringStatKey(statKey);
 
                 if (isOpponent) {
                     // Update in-memory opponent stats


### PR DESCRIPTION
## Summary
- Add spec-driven baseball/softball requirements, design, task list, and validation log.
- Add Baseball and Softball sport templates with passive stats: `AB`, `H`, `R`, `RBI`, `BB`, `FP`.
- Wire templates into team creation, stat config creation, standard tracking, live tracking, live viewing, game planning, game day planning, and practice drills.
- Add diamond game-planning formations, seven-inning defaults, batting order planning, run scoring support, and starter baseball/softball drills.

## Impact
Baseball and softball teams can now start with built-in templates and use the existing site flows without needing pitch-by-pitch tracking. The implementation keeps sideline tracking passive while supporting fielding play and runs as score events.

## Validation
- `npx vitest run tests/unit/live-tracker-integrity.test.js tests/unit/sport-templates.test.js tests/unit/live-sport-config.test.js tests/unit/game-plan-interop.test.js tests/unit/practice-starter-drills.test.js`
- `npm test` passed: 81 files, 399 tests
- `node --check` on changed JS modules
- `git diff --check`
- Local static checks on `http://localhost:8000` for `/`, `edit-team.html`, `edit-config.html`, `track.html`, `track-live.html`, `live-tracker.html`, `live-game.html`, `game-plan.html`, `game-day.html`, and `drills.html`

## Manual Follow-Up
Authenticated Firebase create/save flows still need real-account verification in the browser.