### PR TITLE
Add parent fee detail view

### DIFF
--- a/js/parent-dashboard-fees.js
+++ b/js/parent-dashboard-fees.js
@@ -79,7 +79,7 @@ function isPayActionAllowed(fee) {
 
     const balanceCents = Number(fee.balanceDueCents);
     if (Number.isFinite(balanceCents)) return balanceCents > 0;
-    return fee.status === 'unpaid' || fee.status === 'partial' || fee.status === 'partially_paid' || fee.status === 'adjusted';
+    return fee.status === 'unpaid' || fee.status === 'partial' || fee.status === 'partially_paid';
 }
 
 function formatCents(value) {

--- a/js/parent-dashboard-fees.js
+++ b/js/parent-dashboard-fees.js
@@ -18,6 +18,16 @@ const STATUS_META = {
         label: 'Adjusted',
         badgeClass: 'bg-amber-100 text-amber-800 border-amber-200',
         accentClass: 'border-l-amber-500'
+    },
+    partial: {
+        label: 'Partially paid',
+        badgeClass: 'bg-blue-100 text-blue-800 border-blue-200',
+        accentClass: 'border-l-blue-500'
+    },
+    partially_paid: {
+        label: 'Partially paid',
+        badgeClass: 'bg-blue-100 text-blue-800 border-blue-200',
+        accentClass: 'border-l-blue-500'
     }
 };
 
@@ -37,11 +47,39 @@ function getFeeInstallments(fee) {
 }
 
 function getFeeBalanceCents(fee) {
-    return getFirstDefined(fee?.balanceDueCents, fee?.remainingBalanceCents, fee?.amountDueCents);
+    const explicitBalance = getFirstDefined(fee?.balanceDueCents, fee?.remainingBalanceCents, fee?.amountDueCents);
+    if (explicitBalance !== undefined) return explicitBalance;
+
+    const totalCents = getFeeTotalCents(fee);
+    const paidCents = getFeePaidCents(fee);
+    if (totalCents === undefined || paidCents === undefined) return undefined;
+    return Math.max(0, Number(totalCents) - Number(paidCents));
+}
+
+function getFeeTotalCents(fee) {
+    return getFirstDefined(fee?.totalAmountCents, fee?.totalCents, fee?.adjustedAmountCents, fee?.amountCents, fee?.amountDueCents, fee?.amount);
+}
+
+function getFeePaidCents(fee) {
+    return getFirstDefined(fee?.paidAmountCents, fee?.amountPaidCents, fee?.totalPaidCents, fee?.paidCents);
 }
 
 function getFeeCheckoutUrl(fee) {
     return getFirstDefined(fee?.checkoutUrl, fee?.checkoutURL, fee?.paymentLink, fee?.paymentLinkUrl, fee?.paymentUrl);
+}
+
+function getFeeLedgerEntries(fee) {
+    const rawEntries = getFirstDefined(fee?.ledgerEntries, fee?.paymentLedger, fee?.activity, fee?.receipts, fee?.payments, fee?.adjustments);
+    return Array.isArray(rawEntries) ? rawEntries.filter(Boolean) : [];
+}
+
+function isPayActionAllowed(fee) {
+    if (!fee?.checkoutUrl) return false;
+    if (fee.status === 'paid' || fee.status === 'canceled') return false;
+
+    const balanceCents = Number(fee.balanceDueCents);
+    if (Number.isFinite(balanceCents)) return balanceCents > 0;
+    return fee.status === 'unpaid' || fee.status === 'partial' || fee.status === 'partially_paid' || fee.status === 'adjusted';
 }
 
 function formatCents(value) {
@@ -131,6 +169,41 @@ function renderInstallmentSchedule(fee) {
     `;
 }
 
+function renderReceiptActivity(fee) {
+    const entries = getFeeLedgerEntries(fee);
+    if (!entries.length) return '';
+
+    const rows = entries.map((entry, index) => {
+        const label = getFirstDefined(entry?.label, entry?.title, entry?.type, entry?.kind, `Activity ${index + 1}`);
+        const dateValue = getFirstDefined(entry?.date, entry?.postedAt, entry?.createdAt, entry?.paidAt, entry?.adjustedAt);
+        const amount = formatCents(getFirstDefined(entry?.amountCents, entry?.paidAmountCents, entry?.adjustmentAmountCents, entry?.totalCents));
+        const note = getFirstDefined(entry?.note, entry?.memo, entry?.description, entry?.receiptNumber, entry?.reference);
+        const status = getFirstDefined(entry?.status, entry?.paymentStatus);
+        const details = [
+            dateValue ? formatParentFeeDueDate(dateValue) : '',
+            status ? String(status) : '',
+            note ? String(note) : ''
+        ].filter(Boolean).join(' · ');
+
+        return `
+            <div class="flex items-start justify-between gap-3 py-2 border-t border-gray-100 first:border-t-0">
+                <div>
+                    <div class="font-medium text-gray-900 capitalize">${escapeHtml(label)}</div>
+                    ${details ? `<div class="text-xs text-gray-500 mt-0.5">${escapeHtml(details)}</div>` : ''}
+                </div>
+                <div class="font-semibold text-gray-900 whitespace-nowrap">${escapeHtml(amount || 'Amount not set')}</div>
+            </div>
+        `;
+    }).join('');
+
+    return `
+        <div class="mt-4 rounded-lg border border-gray-200 bg-white p-3">
+            <div class="text-xs uppercase tracking-wide text-gray-500 font-semibold mb-1">Receipts & activity</div>
+            ${rows}
+        </div>
+    `;
+}
+
 function escapeHtml(value) {
     return String(value ?? '')
         .replace(/&/g, '&amp;')
@@ -163,7 +236,7 @@ export function getParentFeeStatusMeta(status) {
 }
 
 export function formatParentFeeAmount(fee) {
-    const raw = fee?.amountDueCents ?? fee?.adjustedAmountCents ?? fee?.amountCents ?? fee?.amount;
+    const raw = getFeeTotalCents(fee);
     return formatCents(raw) || 'Amount not set';
 }
 
@@ -187,6 +260,8 @@ export function normalizeParentFeeRecord(fee) {
         dueDate: fee?.dueDate || fee?.dueAt || null,
         notes: fee?.notes || fee?.feeNotes || '',
         offlinePaymentInstructions: fee?.offlinePaymentInstructions || fee?.paymentInstructions || '',
+        totalAmountCents: getFeeTotalCents(fee),
+        paidAmountCents: getFeePaidCents(fee),
         balanceDueCents: getFeeBalanceCents(fee),
         checkoutUrl: getFeeCheckoutUrl(fee)
     };
@@ -216,12 +291,16 @@ export function renderParentTeamFees(fees) {
         const instructions = fee.offlinePaymentInstructions
             ? `<p class="text-sm text-gray-700 mt-2"><span class="font-semibold">Offline payment:</span> ${escapeHtml(fee.offlinePaymentInstructions)}</p>`
             : '';
+        const paid = fee.paidAmountCents !== undefined && fee.paidAmountCents !== null
+            ? `<div class="rounded-lg bg-gray-50 border border-gray-100 px-3 py-2"><div class="text-xs uppercase tracking-wide text-gray-500 font-semibold">Paid</div><div class="font-bold text-gray-900">${escapeHtml(formatCents(fee.paidAmountCents) || 'Amount not set')}</div></div>`
+            : '';
         const balance = fee.balanceDueCents !== undefined && fee.balanceDueCents !== null
-            ? `<div class="rounded-lg bg-gray-50 border border-gray-100 px-3 py-2"><div class="text-xs uppercase tracking-wide text-gray-500 font-semibold">Balance</div><div class="font-bold text-gray-900">${escapeHtml(formatCents(fee.balanceDueCents) || 'Amount not set')}</div></div>`
+            ? `<div class="rounded-lg bg-gray-50 border border-gray-100 px-3 py-2"><div class="text-xs uppercase tracking-wide text-gray-500 font-semibold">Remaining balance</div><div class="font-bold text-gray-900">${escapeHtml(formatCents(fee.balanceDueCents) || 'Amount not set')}</div></div>`
             : '';
         const lineItems = renderInvoiceLineItems(fee);
         const installmentSchedule = renderInstallmentSchedule(fee);
-        const payLink = fee.checkoutUrl
+        const receiptActivity = renderReceiptActivity(fee);
+        const payLink = isPayActionAllowed(fee)
             ? `<a class="inline-flex items-center justify-center rounded-lg bg-blue-600 px-3 py-2 text-sm font-bold text-white hover:bg-blue-700" href="${escapeHtml(fee.checkoutUrl)}">Pay</a>`
             : '';
 
@@ -242,17 +321,24 @@ export function renderParentTeamFees(fees) {
                 </div>
                 <div class="mt-4 grid grid-cols-1 sm:grid-cols-2 gap-3 text-sm">
                     <div class="rounded-lg bg-gray-50 border border-gray-100 px-3 py-2">
-                        <div class="text-xs uppercase tracking-wide text-gray-500 font-semibold">Amount owed</div>
+                        <div class="text-xs uppercase tracking-wide text-gray-500 font-semibold">Total amount</div>
                         <div class="font-bold text-gray-900">${formatParentFeeAmount(fee)}</div>
                     </div>
                     <div class="rounded-lg bg-gray-50 border border-gray-100 px-3 py-2">
                         <div class="text-xs uppercase tracking-wide text-gray-500 font-semibold">Due date</div>
                         <div class="font-bold text-gray-900">${escapeHtml(formatParentFeeDueDate(fee.dueDate))}</div>
                     </div>
+                    ${paid}
                     ${balance}
                 </div>
-                ${lineItems}
-                ${installmentSchedule}
+                <details class="mt-4 rounded-lg border border-gray-200 bg-gray-50 p-3">
+                    <summary class="cursor-pointer text-sm font-bold text-blue-700 hover:text-blue-800">View fee details</summary>
+                    <div class="mt-3 text-sm text-gray-700">
+                        ${lineItems || '<div class="rounded-lg border border-gray-200 bg-white p-3 text-sm text-gray-500">No line items recorded.</div>'}
+                        ${installmentSchedule}
+                        ${receiptActivity}
+                    </div>
+                </details>
                 ${notes}
                 ${instructions}
             </div>

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -314,7 +314,7 @@
         import { getEventRideshareSummary, getOfferSeatInfo } from './js/rideshare-helpers.js?v=1';
         import { resolveSelectedRideChildId, getRideOfferUiState, createRideRequestHandlers } from './js/parent-dashboard-rideshare-controls.js?v=1';
         import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';
-        import { renderParentTeamFees } from './js/parent-dashboard-fees.js?v=3';
+        import { renderParentTeamFees } from './js/parent-dashboard-fees.js?v=4';
         import { renderFamilyPlanSection } from './js/family-plan.js?v=1';
         import { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';
 

--- a/tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js
+++ b/tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js
@@ -119,7 +119,7 @@ const Blob = deps.Blob;
         .replace("import { getEventRideshareSummary, getOfferSeatInfo } from './js/rideshare-helpers.js?v=1';", 'const { getEventRideshareSummary, getOfferSeatInfo } = deps.rideshareHelpers;')
         .replace("import { resolveSelectedRideChildId, getRideOfferUiState, createRideRequestHandlers } from './js/parent-dashboard-rideshare-controls.js?v=1';", 'const { resolveSelectedRideChildId, getRideOfferUiState, createRideRequestHandlers } = deps.parentDashboardRideshareControls;')
         .replace("import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';", 'const { applyRsvpHydration } = deps.rsvpHydration;')
-        .replace("import { renderParentTeamFees } from './js/parent-dashboard-fees.js?v=3';", 'const { renderParentTeamFees } = deps.parentDashboardFees;')
+        .replace(/import\s*\{\s*renderParentTeamFees\s*\}\s*from '\.\/js\/parent-dashboard-fees\.js\?v=\d+';/, 'const { renderParentTeamFees } = deps.parentDashboardFees;')
         .replace("import { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';", 'const { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } = deps.availabilityPreferences;')
         .replace("import { renderFamilyPlanSection } from './js/family-plan.js?v=1';", 'const { renderFamilyPlanSection } = deps.familyPlan;')
         .replace(/\binit\(\);\s*$/, `

--- a/tests/unit/parent-dashboard-fees.test.js
+++ b/tests/unit/parent-dashboard-fees.test.js
@@ -32,10 +32,11 @@ describe('parent dashboard team fees', () => {
         expect(html).toContain('border-l-red-500');
     });
 
-    it('normalizes paid, unpaid, canceled, and adjusted status styling', () => {
+    it('normalizes paid, unpaid, partial, canceled, and adjusted status styling', () => {
         const html = renderParentTeamFees([
             { title: 'Paid fee', status: 'paid', amountCents: 1000 },
             { title: 'Unpaid fee', status: 'unpaid', amountCents: 1000 },
+            { title: 'Partial fee', status: 'partially_paid', amountCents: 1000 },
             { title: 'Canceled fee', status: 'canceled', amountCents: 1000 },
             { title: 'Adjusted fee', status: 'adjusted', adjustedAmountCents: 500 }
         ]);
@@ -44,6 +45,8 @@ describe('parent dashboard team fees', () => {
         expect(html).toContain('bg-green-100');
         expect(html).toContain('Unpaid');
         expect(html).toContain('bg-red-100');
+        expect(html).toContain('Partially paid');
+        expect(html).toContain('bg-blue-100');
         expect(html).toContain('Canceled');
         expect(html).toContain('bg-gray-100');
         expect(html).toContain('Adjusted');
@@ -80,12 +83,12 @@ describe('parent dashboard team fees', () => {
         }
     });
 
-    it('renders invoice line items, balances, and installment schedules', () => {
+    it('renders a fee detail view with totals, balances, line items, installments, and receipts', () => {
         const html = renderParentTeamFees([
             {
                 title: 'Spring team invoice',
                 amountCents: 30000,
-                balanceDueCents: 20000,
+                paidAmountCents: 10000,
                 lineItems: [
                     { description: 'Uniform kit', quantity: 1, amountCents: 12500 },
                     { name: 'Tournament entry', amountCents: 17500, dueDate: '2026-06-15' }
@@ -93,22 +96,33 @@ describe('parent dashboard team fees', () => {
                 installmentSchedule: [
                     { label: 'Deposit', dueDate: '2026-06-01', amountCents: 10000, paid: true },
                     { label: 'Final payment', dueDate: '2026-07-01', amountCents: 20000, status: 'unpaid' }
+                ],
+                ledgerEntries: [
+                    { type: 'payment', paidAt: '2026-06-01', amountCents: 10000, receiptNumber: 'Receipt #101', status: 'posted' }
                 ]
             }
         ]);
 
+        expect(html).toContain('View fee details');
+        expect(html).toContain('Total amount');
+        expect(html).toContain('$300.00');
+        expect(html).toContain('Paid');
+        expect(html).toContain('$100.00');
         expect(html).toContain('Invoice line items');
         expect(html).toContain('Uniform kit');
         expect(html).toContain('Qty 1');
         expect(html).toContain('Tournament entry');
         expect(html).toContain('Due Jun 15, 2026');
-        expect(html).toContain('Balance');
+        expect(html).toContain('Remaining balance');
         expect(html).toContain('$200.00');
         expect(html).toContain('Installment schedule');
         expect(html).toContain('Deposit');
         expect(html).toContain('Final payment');
         expect(html).toContain('Paid');
         expect(html).toContain('Unpaid');
+        expect(html).toContain('Receipts & activity');
+        expect(html).toContain('payment');
+        expect(html).toContain('Receipt #101');
     });
 
     it('falls back to populated fee aliases when primary arrays are empty', () => {
@@ -133,16 +147,25 @@ describe('parent dashboard team fees', () => {
         expect(html).toContain('Due Jun 10, 2026');
     });
 
-    it('only renders a Pay action when a checkout or payment link exists', () => {
+    it('only renders a Pay action for unpaid or partially paid fees with a checkout or payment link', () => {
         const manualOnlyHtml = renderParentTeamFees([
             { title: 'Manual collection', amountCents: 1000 }
         ]);
         const checkoutHtml = renderParentTeamFees([
             { title: 'Online collection', amountCents: 1000, checkoutUrl: 'https://pay.example/checkout' }
         ]);
+        const partialPaymentLinkHtml = renderParentTeamFees([
+            { title: 'Partial collection', amountCents: 2000, paidAmountCents: 1000, status: 'partially_paid', paymentLink: 'https://pay.example/remaining' }
+        ]);
+        const paidHtml = renderParentTeamFees([
+            { title: 'Paid collection', amountCents: 1000, balanceDueCents: 0, status: 'paid', checkoutUrl: 'https://pay.example/paid' }
+        ]);
 
         expect(manualOnlyHtml).not.toContain('>Pay</a>');
         expect(checkoutHtml).toContain('>Pay</a>');
         expect(checkoutHtml).toContain('https://pay.example/checkout');
+        expect(partialPaymentLinkHtml).toContain('>Pay</a>');
+        expect(partialPaymentLinkHtml).toContain('https://pay.example/remaining');
+        expect(paidHtml).not.toContain('>Pay</a>');
     });
 });

--- a/tests/unit/parent-dashboard-fees.test.js
+++ b/tests/unit/parent-dashboard-fees.test.js
@@ -160,6 +160,9 @@ describe('parent dashboard team fees', () => {
         const paidHtml = renderParentTeamFees([
             { title: 'Paid collection', amountCents: 1000, balanceDueCents: 0, status: 'paid', checkoutUrl: 'https://pay.example/paid' }
         ]);
+        const adjustedHtml = renderParentTeamFees([
+            { title: 'Adjusted collection', amountCents: 1000, status: 'adjusted', checkoutUrl: 'https://pay.example/adjusted' }
+        ]);
 
         expect(manualOnlyHtml).not.toContain('>Pay</a>');
         expect(checkoutHtml).toContain('>Pay</a>');
@@ -167,5 +170,6 @@ describe('parent dashboard team fees', () => {
         expect(partialPaymentLinkHtml).toContain('>Pay</a>');
         expect(partialPaymentLinkHtml).toContain('https://pay.example/remaining');
         expect(paidHtml).not.toContain('>Pay</a>');
+        expect(adjustedHtml).not.toContain('>Pay</a>');
     });
 });


### PR DESCRIPTION
Closes #910

## Summary
- Adds an expandable parent fee detail view from the dashboard fee list.
- Shows total, paid amount, remaining balance, line items, installment schedule, and read-only receipt/activity entries.
- Restricts the Pay action to unpaid or partially paid fees with an existing checkout/payment link.

## Validation
- `node scripts/check-critical-cache-bust.mjs`
- `npx vitest run tests/unit/parent-dashboard-fees.test.js`