### PR TITLE
Add team fee ledger adjustments

### DIFF
--- a/js/db.js
+++ b/js/db.js
@@ -3037,12 +3037,19 @@ export async function updateTeamFeeRecipient(teamId, batchId, recipientId, updat
     }
 
     const recipientRef = doc(db, 'teams', teamId, 'feeBatches', batchId, 'feeRecipients', recipientId);
-    await updateDoc(recipientRef, {
-        ...updates,
+    const { ledgerEntries = [], ...recipientUpdates } = updates;
+    const updatePayload = {
+        ...recipientUpdates,
         teamId,
         batchId,
         updatedAt: serverTimestamp()
-    });
+    };
+
+    if (Array.isArray(ledgerEntries) && ledgerEntries.length > 0) {
+        updatePayload.paymentLedger = arrayUnion(...ledgerEntries);
+    }
+
+    await updateDoc(recipientRef, updatePayload);
 }
 
 export async function createTeamFeeBatch(teamId, feeDraft, recipients = [], user = {}) {

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -225,7 +225,7 @@ export function buildManualPaymentUpdate({ amount, date, note, actorId, currentB
     const balanceCents = Number.isFinite(currentBalance) ? Math.max(0, currentBalance) : paymentAmountCents;
     const priorPaid = Number(currentPaidCents);
     const priorPaidCents = Number.isFinite(priorPaid) ? Math.max(0, priorPaid) : 0;
-    const amountPaidCents = Math.min(balanceCents, priorPaidCents + paymentAmountCents);
+    const amountPaidCents = priorPaidCents + paymentAmountCents;
     const remainingBalanceCents = Math.max(0, balanceCents - amountPaidCents);
     const status = normalizeLedgerStatus(balanceCents, amountPaidCents);
     const noteText = normalizeString(note);

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -6,6 +6,7 @@ export const OFFLINE_TEAM_FEE_INSTRUCTIONS = 'Collect payment outside ALL PLAYS.
 const STATUS_LABELS = {
     paid: 'Paid',
     unpaid: 'Unpaid',
+    partial: 'Partial',
     adjusted: 'Adjusted',
     canceled: 'Canceled'
 };
@@ -52,6 +53,14 @@ export function toFeeCents(value) {
     const normalized = normalizeString(value).replace(/[$,]/g, '');
     const amount = Number(normalized);
     if (!Number.isFinite(amount) || amount < 0) return null;
+    return Math.round(amount * 100);
+}
+
+export function toSignedFeeCents(value) {
+    if (value === null || value === undefined || value === '') return null;
+    const normalized = normalizeString(value).replace(/[$,]/g, '');
+    const amount = Number(normalized);
+    if (!Number.isFinite(amount)) return null;
     return Math.round(amount * 100);
 }
 
@@ -164,6 +173,7 @@ export function summarizeFeeRecipients(recipients = []) {
         totalOutstandingCents: 0,
         counts: {
             paid: 0,
+            partial: 0,
             unpaid: 0,
             adjusted: 0,
             canceled: 0
@@ -180,7 +190,7 @@ export function summarizeFeeRecipients(recipients = []) {
         summary.totalAssignedCents += assignedCents;
         summary.totalPaidCents += paid;
         summary.totalCanceledCents += status === 'canceled' ? assignedCents : 0;
-        summary.totalAdjustedCents += status === 'adjusted' ? Math.max(0, assignedCents - balance) : 0;
+        summary.totalAdjustedCents += status === 'canceled' ? 0 : Math.abs(assignedCents - balance);
         summary.totalOutstandingCents += status === 'paid' || status === 'canceled' ? 0 : Math.max(0, balance - paid);
     });
 
@@ -196,7 +206,15 @@ export function formatFeeCurrency(cents) {
     }).format(amount / 100);
 }
 
-export function buildManualPaymentUpdate({ amount, date, note, actorId, currentBalanceCents, currentPaidCents, currentStatus }) {
+function normalizeLedgerStatus(balanceCents, paidCents) {
+    const balance = Math.max(0, Number(balanceCents) || 0);
+    const paid = Math.max(0, Number(paidCents) || 0);
+    if (balance === 0 || paid >= balance) return 'paid';
+    if (paid > 0) return 'partial';
+    return 'unpaid';
+}
+
+export function buildManualPaymentUpdate({ amount, date, note, actorId, currentBalanceCents, currentPaidCents }) {
     const paymentAmountCents = toFeeCents(amount);
     if (paymentAmountCents === null || paymentAmountCents <= 0) {
         throw new Error('Enter a manual payment amount greater than $0.');
@@ -204,50 +222,93 @@ export function buildManualPaymentUpdate({ amount, date, note, actorId, currentB
     if (!date) throw new Error('Enter a manual payment date.');
 
     const currentBalance = Number(currentBalanceCents);
+    const balanceCents = Number.isFinite(currentBalance) ? Math.max(0, currentBalance) : paymentAmountCents;
     const priorPaid = Number(currentPaidCents);
     const priorPaidCents = Number.isFinite(priorPaid) ? Math.max(0, priorPaid) : 0;
-    const amountPaidCents = priorPaidCents + paymentAmountCents;
-    const isPaidInFull = Number.isFinite(currentBalance) ? amountPaidCents >= Math.max(0, currentBalance) : true;
-    const status = isPaidInFull ? 'paid' : normalizeFeeStatus(currentStatus) === 'adjusted' ? 'adjusted' : 'unpaid';
+    const amountPaidCents = Math.min(balanceCents, priorPaidCents + paymentAmountCents);
+    const remainingBalanceCents = Math.max(0, balanceCents - amountPaidCents);
+    const status = normalizeLedgerStatus(balanceCents, amountPaidCents);
+    const noteText = normalizeString(note);
+    const ledgerEntry = {
+        type: 'offline_payment',
+        amountCents: paymentAmountCents,
+        paymentDate: date,
+        note: noteText,
+        recordedBy: actorId || null
+    };
 
     return {
         status,
         amountPaidCents,
-        paidAt: date,
+        remainingBalanceCents,
+        paidAt: status === 'paid' ? date : null,
         manualPayment: {
             amountPaidCents: paymentAmountCents,
             paidAt: date,
-            note: normalizeString(note),
+            note: noteText,
             recordedBy: actorId || null
-        }
+        },
+        ledgerEntries: [ledgerEntry]
     };
 }
 
-export function buildBalanceAdjustmentUpdate({ amount, note, actorId }) {
-    const amountDueCents = toFeeCents(amount);
-    if (amountDueCents === null) {
-        throw new Error('Enter a valid adjusted balance.');
+export function buildBalanceAdjustmentUpdate({ amount, note, actorId, currentBalanceCents, currentPaidCents }) {
+    const adjustmentCents = toSignedFeeCents(amount);
+    const reason = normalizeString(note);
+    if (adjustmentCents === null || adjustmentCents === 0) {
+        throw new Error('Enter a positive or negative adjustment amount.');
     }
+    if (!reason) throw new Error('Enter an adjustment reason.');
+
+    const currentBalance = Number(currentBalanceCents);
+    const priorBalanceCents = Number.isFinite(currentBalance) ? Math.max(0, currentBalance) : 0;
+    const paid = Number(currentPaidCents);
+    const amountPaidCents = Number.isFinite(paid) ? Math.max(0, paid) : 0;
+    const amountDueCents = Math.max(0, priorBalanceCents + adjustmentCents);
+    const remainingBalanceCents = Math.max(0, amountDueCents - amountPaidCents);
+    const status = normalizeLedgerStatus(amountDueCents, amountPaidCents);
+    const ledgerEntry = {
+        type: 'balance_adjustment',
+        amountCents: adjustmentCents,
+        previousAmountDueCents: priorBalanceCents,
+        amountDueCents,
+        reason,
+        adjustedBy: actorId || null
+    };
 
     return {
-        status: amountDueCents === 0 ? 'paid' : 'adjusted',
+        status,
         amountDueCents,
+        remainingBalanceCents,
         adjustment: {
+            amountCents: adjustmentCents,
+            previousAmountDueCents: priorBalanceCents,
             amountDueCents,
-            note: normalizeString(note),
+            note: reason,
             adjustedBy: actorId || null
-        }
+        },
+        ledgerEntries: [ledgerEntry]
     };
 }
 
 export function buildCancelRecipientUpdate({ note, actorId }) {
+    const reason = normalizeString(note);
+    const ledgerEntry = {
+        type: 'cancellation',
+        amountCents: 0,
+        reason,
+        canceledBy: actorId || null
+    };
+
     return {
         status: 'canceled',
         amountDueCents: 0,
+        remainingBalanceCents: 0,
         canceled: {
-            note: normalizeString(note),
+            note: reason,
             canceledBy: actorId || null
-        }
+        },
+        ledgerEntries: [ledgerEntry]
     };
 }
 
@@ -336,7 +397,7 @@ function renderSummary(container, recipients) {
         ['Adjusted', formatFeeCurrency(summary.totalAdjustedCents)],
         ['Canceled', formatFeeCurrency(summary.totalCanceledCents)],
         ['Outstanding', formatFeeCurrency(summary.totalOutstandingCents)],
-        ['Status counts', `${summary.counts.paid} paid · ${summary.counts.unpaid} unpaid · ${summary.counts.adjusted} adjusted · ${summary.counts.canceled} canceled`]
+        ['Status counts', `${summary.counts.paid} paid · ${summary.counts.partial} partial · ${summary.counts.unpaid} unpaid · ${summary.counts.canceled} canceled`]
     ];
     container.innerHTML = cards.map(([label, value]) => `
         <div class="bg-white rounded-xl border border-gray-200 shadow-sm p-4">
@@ -385,8 +446,8 @@ function renderRecipients(container, countEl, recipients) {
                         </form>
                         <form data-action="adjust" class="rounded-xl border border-gray-200 bg-gray-50 p-3 space-y-2">
                             <div class="text-xs font-bold uppercase tracking-wide text-gray-500">Adjust balance</div>
-                            <input name="amount" type="number" min="0" step="0.01" value="${(getRecipientBalanceCents(recipient) / 100).toFixed(2)}" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Adjusted balance">
-                            <input name="note" type="text" placeholder="Reason" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Adjustment note">
+                            <input name="amount" type="number" step="0.01" placeholder="-10.00 or 5.00" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Balance adjustment amount">
+                            <input name="note" type="text" required placeholder="Required reason" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Adjustment reason">
                             <button class="w-full rounded-lg bg-amber-600 px-3 py-2 text-sm font-semibold text-white hover:bg-amber-700">Save adjustment</button>
                         </form>
                         <form data-action="cancel" class="rounded-xl border border-gray-200 bg-gray-50 p-3 space-y-2">
@@ -578,7 +639,7 @@ async function renderManageMode({ container, teamId, batchId, team, user, getTea
             if (form.dataset.action === 'paid') {
                 updates = buildManualPaymentUpdate({ ...data, actorId: user.uid, currentBalanceCents: article?.dataset?.balanceCents, currentPaidCents: article?.dataset?.paidCents, currentStatus: article?.dataset?.status });
             } else if (form.dataset.action === 'adjust') {
-                updates = buildBalanceAdjustmentUpdate({ ...data, actorId: user.uid });
+                updates = buildBalanceAdjustmentUpdate({ ...data, actorId: user.uid, currentBalanceCents: article?.dataset?.balanceCents, currentPaidCents: article?.dataset?.paidCents });
             } else {
                 updates = buildCancelRecipientUpdate({ ...data, actorId: user.uid });
             }
@@ -606,7 +667,7 @@ async function initTeamFeesAdminPage() {
     renderFooter(document.getElementById('footer-container'));
 
     const [{ getTeam, getPlayers, getUserProfile, createTeamFeeBatch, getTeamFeeBatch, listTeamFeeRecipients, updateTeamFeeRecipient, canModerateChat }, { requireAuth }] = await Promise.all([
-        import('./db.js?v=31'),
+        import('./db.js?v=32'),
         import('./auth.js?v=12')
     ]);
 

--- a/team-fees.html
+++ b/team-fees.html
@@ -44,7 +44,7 @@
 
     <div id="footer-container"></div>
 
-    <script type="module" src="./js/team-fees-admin.js?v=4"></script>
+    <script type="module" src="./js/team-fees-admin.js?v=5"></script>
 </body>
 
 </html>

--- a/tests/unit/parent-dashboard-fees.test.js
+++ b/tests/unit/parent-dashboard-fees.test.js
@@ -36,7 +36,8 @@ describe('parent dashboard team fees', () => {
         const html = renderParentTeamFees([
             { title: 'Paid fee', status: 'paid', amountCents: 1000 },
             { title: 'Unpaid fee', status: 'unpaid', amountCents: 1000 },
-            { title: 'Partial fee', status: 'partially_paid', amountCents: 1000 },
+            { title: 'Partial fee', status: 'partial', amountCents: 1000 },
+            { title: 'Legacy partial fee', status: 'partially_paid', amountCents: 1000 },
             { title: 'Canceled fee', status: 'canceled', amountCents: 1000 },
             { title: 'Adjusted fee', status: 'adjusted', adjustedAmountCents: 500 }
         ]);
@@ -47,6 +48,8 @@ describe('parent dashboard team fees', () => {
         expect(html).toContain('bg-red-100');
         expect(html).toContain('Partially paid');
         expect(html).toContain('bg-blue-100');
+        expect(normalizeParentFeeStatus('partial')).toBe('partial');
+        expect(normalizeParentFeeStatus('partially_paid')).toBe('partially_paid');
         expect(html).toContain('Canceled');
         expect(html).toContain('bg-gray-100');
         expect(html).toContain('Adjusted');

--- a/tests/unit/team-fees-admin.test.js
+++ b/tests/unit/team-fees-admin.test.js
@@ -11,7 +11,8 @@ import {
     normalizeTeamFeeDraft,
     parseTeamFeeAmountToCents,
     summarizeFeeRecipients,
-    toFeeCents
+    toFeeCents,
+    toSignedFeeCents
 } from '../../js/team-fees-admin.js';
 
 describe('team fees admin helpers', () => {
@@ -121,7 +122,7 @@ describe('team fees admin helpers', () => {
         const summary = summarizeFeeRecipients([
             { status: 'paid', amountCents: 5000, amountDueCents: 5000, amountPaidCents: 5000 },
             { status: 'unpaid', amountCents: 7500, amountDueCents: 7500 },
-            { status: 'adjusted', amountCents: 4000, amountDueCents: 2500, amountPaidCents: 500 },
+            { status: 'partial', amountCents: 4000, amountDueCents: 2500, amountPaidCents: 500 },
             { status: 'canceled', amountCents: 3000, amountDueCents: 3000 }
         ]);
 
@@ -133,8 +134,9 @@ describe('team fees admin helpers', () => {
             totalOutstandingCents: 9500,
             counts: {
                 paid: 1,
+                partial: 1,
                 unpaid: 1,
-                adjusted: 1,
+                adjusted: 0,
                 canceled: 1
             }
         });
@@ -147,7 +149,7 @@ describe('team fees admin helpers', () => {
             date: '2026-05-05',
             currentBalanceCents: 5000
         })).toMatchObject({
-            status: 'unpaid',
+            status: 'partial',
             amountPaidCents: 2500
         });
 
@@ -157,7 +159,7 @@ describe('team fees admin helpers', () => {
             currentBalanceCents: 5000,
             currentPaidCents: 2500
         })).toMatchObject({
-            status: 'unpaid',
+            status: 'partial',
             amountPaidCents: 4500
         });
 
@@ -193,6 +195,7 @@ describe('team fees admin helpers', () => {
         })).toMatchObject({
             status: 'paid',
             amountPaidCents: 4250,
+            remainingBalanceCents: 0,
             paidAt: '2026-05-05',
             manualPayment: {
                 amountPaidCents: 4250,
@@ -202,14 +205,22 @@ describe('team fees admin helpers', () => {
             }
         });
 
-        expect(buildBalanceAdjustmentUpdate({ amount: '10', note: 'Sibling discount', actorId: 'coach-1' })).toMatchObject({
-            status: 'adjusted',
-            amountDueCents: 1000,
+        expect(buildBalanceAdjustmentUpdate({ amount: '-10', note: 'Sibling discount', actorId: 'coach-1', currentBalanceCents: 5000, currentPaidCents: 1000 })).toMatchObject({
+            status: 'partial',
+            amountDueCents: 4000,
+            remainingBalanceCents: 3000,
             adjustment: {
-                amountDueCents: 1000,
+                amountCents: -1000,
+                previousAmountDueCents: 5000,
+                amountDueCents: 4000,
                 note: 'Sibling discount',
                 adjustedBy: 'coach-1'
-            }
+            },
+            ledgerEntries: [{
+                type: 'balance_adjustment',
+                amountCents: -1000,
+                reason: 'Sibling discount'
+            }]
         });
 
         expect(buildCancelRecipientUpdate({ note: 'No longer on roster', actorId: 'coach-1' })).toMatchObject({
@@ -225,8 +236,10 @@ describe('team fees admin helpers', () => {
     it('normalizes currency inputs and recipient balances safely', () => {
         expect(toFeeCents('12.345')).toBe(1235);
         expect(toFeeCents('-1')).toBeNull();
+        expect(toSignedFeeCents('-1.50')).toBe(-150);
         expect(getRecipientBalanceCents({ status: 'canceled', amountDueCents: 5000 })).toBe(0);
         expect(getRecipientPaidCents({ status: 'paid', amountDueCents: 2500 })).toBe(2500);
         expect(() => buildManualPaymentUpdate({ amount: '0', date: '2026-05-05' })).toThrow('greater than $0');
+        expect(() => buildBalanceAdjustmentUpdate({ amount: '-5', note: '' })).toThrow('adjustment reason');
     });
 });

--- a/tests/unit/team-fees-admin.test.js
+++ b/tests/unit/team-fees-admin.test.js
@@ -177,12 +177,13 @@ describe('team fees admin helpers', () => {
         });
 
         expect(buildManualPaymentUpdate({
-            amount: '50.00',
+            amount: '75.00',
             date: '2026-05-05',
             currentBalanceCents: 5000
         })).toMatchObject({
             status: 'paid',
-            amountPaidCents: 5000
+            amountPaidCents: 7500,
+            remainingBalanceCents: 0
         });
     });
 


### PR DESCRIPTION
Closes #909

## Summary
- Added offline payment ledger entries for manual payments, balance adjustments, and cancellations.
- Added signed positive/negative balance adjustments with required reasons.
- Updated recipient status calculation to support paid, unpaid, partial, and canceled states with remaining balances.
- Persist ledger entries through `paymentLedger` using `arrayUnion` and updated cache-bust values.

## Validation
- `npx vitest run tests/unit/team-fees-admin.test.js`
- `node scripts/check-critical-cache-bust.mjs`