### PR TITLE
Add Stripe checkout for team fees

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1104,7 +1104,7 @@ service cloud.firestore {
         allow create, update, delete: if isTeamOwnerOrAdmin(teamId);
       }
 
-      // Offline/manual team fee batches. No payment processing data is stored here.
+      // Team fee batches store only safe payment metadata; Stripe secrets and raw payment methods stay server-side.
       match /feeBatches/{batchId} {
         allow read: if isTeamOwnerOrAdmin(teamId);
         allow create, update, delete: if isTeamOwnerOrAdmin(teamId);

--- a/functions/index.js
+++ b/functions/index.js
@@ -16,6 +16,7 @@ const {
   isEligibleTeamFeePayer,
   buildTeamFeeCheckoutUrls,
   buildTeamFeeCheckoutMetadata,
+  canReuseTeamFeeCheckoutSession,
   shouldMarkTeamFeePaidFromEvent,
   shouldRecordTeamFeeCheckoutNotPaidFromEvent,
   buildTeamFeePaidUpdate
@@ -152,12 +153,7 @@ exports.createStripeTeamFeeCheckout = functions.https.onCall(async (data, contex
   }
 
   const amountCents = getTeamFeeBalanceCents(recipient);
-  if (
-    recipient.checkoutUrl &&
-    recipient.stripeCheckoutSessionId &&
-    recipient.checkoutStatus !== 'expired' &&
-    Number(recipient.checkoutAmountCents) === amountCents
-  ) {
+  if (canReuseTeamFeeCheckoutSession(recipient, amountCents)) {
     return { checkoutUrl: recipient.checkoutUrl, sessionId: recipient.stripeCheckoutSessionId };
   }
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -9,6 +9,17 @@ const {
   shouldUnlockTeamPassFromEvent,
   buildTeamPassEntitlement
 } = require('./team-pass-core.cjs');
+const {
+  normalizeTeamFeeCheckoutInput,
+  getTeamFeeBalanceCents,
+  isTeamFeeCheckoutEligible,
+  isEligibleTeamFeePayer,
+  buildTeamFeeCheckoutUrls,
+  buildTeamFeeCheckoutMetadata,
+  shouldMarkTeamFeePaidFromEvent,
+  shouldRecordTeamFeeCheckoutNotPaidFromEvent,
+  buildTeamFeePaidUpdate
+} = require('./team-fees-core.cjs');
 const { createInMemoryRateLimiter } = require('./rate-limit.cjs');
 
 if (admin.apps.length === 0) {
@@ -47,6 +58,10 @@ function buildTeamPassCheckoutUrls(appUrl, teamId) {
     successUrl: `${baseUrl}/team.html?teamId=${encodedTeamId}&teamPass=success`,
     cancelUrl: `${baseUrl}/team.html?teamId=${encodedTeamId}&teamPass=cancelled`
   };
+}
+
+function buildTeamFeeRecipientRef({ teamId, batchId, recipientId }) {
+  return firestore.doc(`teams/${teamId}/feeBatches/${batchId}/feeRecipients/${recipientId}`);
 }
 
 async function getUserForEligibility(uid) {
@@ -97,6 +112,97 @@ exports.createStripeTeamPassCheckout = functions.https.onCall(async (data, conte
   return { checkoutUrl: session.url, sessionId: session.id };
 });
 
+exports.createStripeTeamFeeCheckout = functions.https.onCall(async (data, context) => {
+  if (!context.auth?.uid) {
+    throw new functions.https.HttpsError('unauthenticated', 'Sign in before paying a team fee.');
+  }
+
+  let input;
+  try {
+    input = normalizeTeamFeeCheckoutInput(data || {});
+  } catch (error) {
+    throw new functions.https.HttpsError('invalid-argument', error.message || 'Invalid team fee checkout request.');
+  }
+
+  const teamSnap = await firestore.doc(`teams/${input.teamId}`).get();
+  if (!teamSnap.exists) {
+    throw new functions.https.HttpsError('not-found', 'Team not found.');
+  }
+
+  const recipientRef = buildTeamFeeRecipientRef(input);
+  const recipientSnap = await recipientRef.get();
+  if (!recipientSnap.exists) {
+    throw new functions.https.HttpsError('not-found', 'Fee recipient not found.');
+  }
+
+  const team = { id: input.teamId, ...(teamSnap.data() || {}) };
+  const recipient = { id: input.recipientId, ...(recipientSnap.data() || {}) };
+  if (recipient.teamId !== input.teamId || recipient.batchId !== input.batchId) {
+    throw new functions.https.HttpsError('failed-precondition', 'Fee recipient does not match the requested fee batch.');
+  }
+
+  if (!isTeamFeeCheckoutEligible(recipient)) {
+    throw new functions.https.HttpsError('failed-precondition', 'This team fee is not eligible for online checkout.');
+  }
+
+  const user = await getUserForEligibility(context.auth.uid);
+  const email = context.auth.token?.email || user.email || '';
+  if (!isEligibleTeamFeePayer({ team, user, uid: context.auth.uid, email, recipient })) {
+    throw new functions.https.HttpsError('permission-denied', 'You do not have access to pay this team fee.');
+  }
+
+  const amountCents = getTeamFeeBalanceCents(recipient);
+  if (
+    recipient.checkoutUrl &&
+    recipient.stripeCheckoutSessionId &&
+    recipient.checkoutStatus !== 'expired' &&
+    Number(recipient.checkoutAmountCents) === amountCents
+  ) {
+    return { checkoutUrl: recipient.checkoutUrl, sessionId: recipient.stripeCheckoutSessionId };
+  }
+
+  const stripe = createStripeClient();
+  const { appUrl } = getStripeConfig();
+  const { successUrl, cancelUrl } = buildTeamFeeCheckoutUrls(appUrl, input);
+  const title = recipient.feeTitle || recipient.title || 'Team fee';
+  const playerName = recipient.playerName || recipient.childName || '';
+  const description = playerName ? `${title} for ${playerName}` : title;
+  const session = await stripe.checkout.sessions.create({
+    mode: 'payment',
+    line_items: [{
+      price_data: {
+        currency: 'usd',
+        unit_amount: amountCents,
+        product_data: {
+          name: description
+        }
+      },
+      quantity: 1
+    }],
+    success_url: successUrl,
+    cancel_url: cancelUrl,
+    customer_email: email || recipient.parentEmail || recipient.email || undefined,
+    client_reference_id: `${input.teamId}:${input.batchId}:${input.recipientId}`,
+    metadata: buildTeamFeeCheckoutMetadata({ ...input, payerUid: context.auth.uid })
+  });
+
+  const now = admin.firestore.FieldValue.serverTimestamp();
+  await recipientRef.set({
+    checkoutUrl: session.url,
+    paymentLink: session.url,
+    checkoutStatus: 'open',
+    paymentProvider: 'stripe',
+    stripeCheckoutSessionId: session.id,
+    stripePaymentStatus: session.payment_status || 'unpaid',
+    checkoutAmountCents: amountCents,
+    balanceDueCents: amountCents,
+    checkoutCreatedAt: now,
+    updatedAt: now
+  }, { merge: true });
+
+  return { checkoutUrl: session.url, sessionId: session.id };
+});
+
 exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
   if (req.method !== 'POST') {
     res.status(405).send('Method not allowed');
@@ -124,6 +230,58 @@ exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
     console.warn('Rejected Stripe webhook with invalid signature:', error?.message || error);
     res.status(400).send('Invalid Stripe signature');
     return;
+  }
+
+  if (shouldMarkTeamFeePaidFromEvent(event) || shouldRecordTeamFeeCheckoutNotPaidFromEvent(event)) {
+    try {
+      const session = event.data.object;
+      const { teamId, batchId, recipientId } = session.metadata || {};
+      const receivedAt = admin.firestore.FieldValue.serverTimestamp();
+      const eventRef = firestore.doc(`stripeEvents/${event.id}`);
+      const recipientRef = buildTeamFeeRecipientRef({ teamId, batchId, recipientId });
+
+      await firestore.runTransaction(async (transaction) => {
+        const eventSnap = await transaction.get(eventRef);
+        if (eventSnap.exists) return;
+
+        const recipientSnap = await transaction.get(recipientRef);
+        if (!recipientSnap.exists) {
+          throw new Error('Team fee recipient not found for Stripe webhook.');
+        }
+
+        if (shouldMarkTeamFeePaidFromEvent(event)) {
+          transaction.set(recipientRef, buildTeamFeePaidUpdate({
+            recipient: recipientSnap.data() || {},
+            session,
+            eventId: event.id,
+            receivedAt
+          }), { merge: true });
+        } else {
+          transaction.set(recipientRef, {
+            checkoutStatus: event.type === 'checkout.session.expired' ? 'expired' : 'payment_failed',
+            stripeCheckoutSessionId: session.id || null,
+            stripeEventId: event.id,
+            updatedAt: receivedAt
+          }, { merge: true });
+        }
+
+        transaction.set(eventRef, {
+          provider: 'stripe',
+          product: 'team_fee',
+          type: event.type,
+          checkoutSessionId: session.id || null,
+          recipientPath: recipientRef.path,
+          receivedAt
+        });
+      });
+
+      res.status(200).json({ received: true, teamFeeUpdated: shouldMarkTeamFeePaidFromEvent(event) });
+      return;
+    } catch (error) {
+      console.error('Failed to process Stripe team fee webhook:', error);
+      res.status(500).send('Webhook processing failed');
+      return;
+    }
   }
 
   if (!shouldUnlockTeamPassFromEvent(event)) {

--- a/functions/team-fees-core.cjs
+++ b/functions/team-fees-core.cjs
@@ -1,0 +1,153 @@
+function normalizeString(value) {
+    return String(value || '').trim();
+}
+
+function normalizeTeamFeeCheckoutInput(data = {}) {
+    const teamId = normalizeString(data.teamId);
+    const batchId = normalizeString(data.batchId);
+    const recipientId = normalizeString(data.recipientId || data.feeRecipientId);
+
+    if (!teamId) throw new Error('Team ID is required.');
+    if (!batchId) throw new Error('Fee batch ID is required.');
+    if (!recipientId) throw new Error('Fee recipient ID is required.');
+
+    return { teamId, batchId, recipientId };
+}
+
+function getTeamFeePaidCents(recipient = {}) {
+    const paid = Number(recipient.paidAmountCents ?? recipient.amountPaidCents ?? recipient.totalPaidCents ?? recipient.paidCents ?? 0);
+    return Number.isFinite(paid) ? Math.max(0, paid) : 0;
+}
+
+function getTeamFeeTotalCents(recipient = {}) {
+    const total = Number(recipient.amountDueCents ?? recipient.balanceDueCents ?? recipient.adjustedAmountCents ?? recipient.amountCents ?? recipient.totalAmountCents ?? 0);
+    return Number.isFinite(total) ? Math.max(0, total) : 0;
+}
+
+function getTeamFeeBalanceCents(recipient = {}) {
+    const explicitBalance = recipient.balanceDueCents ?? recipient.remainingBalanceCents;
+    if (explicitBalance !== undefined && explicitBalance !== null && explicitBalance !== '') {
+        const balance = Number(explicitBalance);
+        return Number.isFinite(balance) ? Math.max(0, balance) : 0;
+    }
+
+    return Math.max(0, getTeamFeeTotalCents(recipient) - getTeamFeePaidCents(recipient));
+}
+
+function isTeamFeeCheckoutEligible(recipient = {}) {
+    const status = normalizeString(recipient.status || 'unpaid').toLowerCase();
+    if (status === 'paid' || status === 'canceled' || status === 'cancelled') return false;
+    return getTeamFeeBalanceCents(recipient) > 0;
+}
+
+function isEligibleTeamFeePayer({ team = {}, user = {}, uid = '', email = '', recipient = {} } = {}) {
+    if (!uid) return false;
+    if (team.ownerId && team.ownerId === uid) return true;
+    if (user.isAdmin === true) return true;
+
+    const normalizedEmail = normalizeString(email || user.email || user.profileEmail).toLowerCase();
+    const adminEmails = Array.isArray(team.adminEmails) ? team.adminEmails : [];
+    if (normalizedEmail && adminEmails.some((adminEmail) => normalizeString(adminEmail).toLowerCase() === normalizedEmail)) {
+        return true;
+    }
+
+    if ([recipient.parentUserId, recipient.accountUserId, recipient.userId].some((value) => value && value === uid)) {
+        return true;
+    }
+
+    const teamId = normalizeString(recipient.teamId || team.id);
+    const playerId = normalizeString(recipient.playerId);
+    const playerKey = normalizeString(recipient.playerKey || (teamId && playerId ? `${teamId}::${playerId}` : ''));
+    const parentTeamIds = Array.isArray(user.parentTeamIds) ? user.parentTeamIds : [];
+    const parentPlayerKeys = Array.isArray(user.parentPlayerKeys) ? user.parentPlayerKeys : [];
+
+    return Boolean(
+        (teamId && parentTeamIds.includes(teamId)) ||
+        (playerKey && parentPlayerKeys.includes(playerKey))
+    );
+}
+
+function buildTeamFeeCheckoutUrls(appUrl, { teamId, batchId, recipientId }) {
+    const baseUrl = String(appUrl || 'https://allplays.ai').replace(/\/$/, '');
+    const params = new URLSearchParams({
+        feePayment: '1',
+        teamId,
+        batchId,
+        recipientId
+    });
+    return {
+        successUrl: `${baseUrl}/parent-dashboard.html?${params.toString()}&checkout=success`,
+        cancelUrl: `${baseUrl}/parent-dashboard.html?${params.toString()}&checkout=cancelled`
+    };
+}
+
+function buildTeamFeeCheckoutMetadata({ teamId, batchId, recipientId, payerUid }) {
+    return {
+        product: 'team_fee',
+        teamId,
+        batchId,
+        recipientId,
+        payerUid
+    };
+}
+
+function shouldMarkTeamFeePaidFromEvent(event = {}) {
+    const session = event?.data?.object || {};
+    const metadata = session.metadata || {};
+    return event.type === 'checkout.session.completed' &&
+        session.payment_status === 'paid' &&
+        metadata.product === 'team_fee' &&
+        Boolean(metadata.teamId && metadata.batchId && metadata.recipientId);
+}
+
+function shouldRecordTeamFeeCheckoutNotPaidFromEvent(event = {}) {
+    const session = event?.data?.object || {};
+    const metadata = session.metadata || {};
+    return ['checkout.session.expired', 'checkout.session.async_payment_failed'].includes(event.type) &&
+        metadata.product === 'team_fee' &&
+        Boolean(metadata.teamId && metadata.batchId && metadata.recipientId);
+}
+
+function buildTeamFeePaidUpdate({ recipient = {}, session = {}, eventId, receivedAt }) {
+    const balanceCents = getTeamFeeBalanceCents(recipient);
+    const existingPaidCents = getTeamFeePaidCents(recipient);
+    const paidAmountCents = Math.max(existingPaidCents, existingPaidCents + balanceCents);
+
+    return {
+        status: 'paid',
+        paidAmountCents,
+        amountPaidCents: paidAmountCents,
+        balanceDueCents: 0,
+        checkoutStatus: 'paid',
+        paymentProvider: 'stripe',
+        stripeCheckoutSessionId: session.id || null,
+        stripePaymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : null,
+        stripeCustomerId: typeof session.customer === 'string' ? session.customer : null,
+        stripeEventId: eventId,
+        paidAt: receivedAt,
+        updatedAt: receivedAt,
+        receiptMetadata: {
+            provider: 'stripe',
+            checkoutSessionId: session.id || null,
+            paymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : null,
+            amountPaidCents: paidAmountCents,
+            currency: session.currency || 'usd',
+            receiptEmail: session.customer_details?.email || session.customer_email || null,
+            eventId
+        }
+    };
+}
+
+module.exports = {
+    normalizeTeamFeeCheckoutInput,
+    getTeamFeePaidCents,
+    getTeamFeeTotalCents,
+    getTeamFeeBalanceCents,
+    isTeamFeeCheckoutEligible,
+    isEligibleTeamFeePayer,
+    buildTeamFeeCheckoutUrls,
+    buildTeamFeeCheckoutMetadata,
+    shouldMarkTeamFeePaidFromEvent,
+    shouldRecordTeamFeeCheckoutNotPaidFromEvent,
+    buildTeamFeePaidUpdate
+};

--- a/functions/team-fees-core.cjs
+++ b/functions/team-fees-core.cjs
@@ -91,11 +91,23 @@ function buildTeamFeeCheckoutMetadata({ teamId, batchId, recipientId, payerUid }
     };
 }
 
+function canReuseTeamFeeCheckoutSession(recipient = {}, amountCents = 0) {
+    return Boolean(
+        recipient.checkoutUrl &&
+        recipient.stripeCheckoutSessionId &&
+        recipient.checkoutStatus === 'open' &&
+        Number(recipient.checkoutAmountCents) === Number(amountCents)
+    );
+}
+
 function shouldMarkTeamFeePaidFromEvent(event = {}) {
     const session = event?.data?.object || {};
     const metadata = session.metadata || {};
-    return event.type === 'checkout.session.completed' &&
-        session.payment_status === 'paid' &&
+    const isPaidCheckoutEvent = (
+        (event.type === 'checkout.session.completed' && session.payment_status === 'paid') ||
+        event.type === 'checkout.session.async_payment_succeeded'
+    );
+    return isPaidCheckoutEvent &&
         metadata.product === 'team_fee' &&
         Boolean(metadata.teamId && metadata.batchId && metadata.recipientId);
 }
@@ -108,21 +120,39 @@ function shouldRecordTeamFeeCheckoutNotPaidFromEvent(event = {}) {
         Boolean(metadata.teamId && metadata.batchId && metadata.recipientId);
 }
 
+function getTeamFeeStripePaidAmountCents({ recipient = {}, session = {} } = {}) {
+    const sessionAmount = Number(session.amount_total ?? session.amount_paid ?? session.amount_subtotal);
+    if (Number.isFinite(sessionAmount) && sessionAmount > 0) {
+        return Math.round(sessionAmount);
+    }
+
+    if (recipient.stripeCheckoutSessionId && session.id && recipient.stripeCheckoutSessionId === session.id) {
+        const checkoutAmount = Number(recipient.checkoutAmountCents);
+        if (Number.isFinite(checkoutAmount) && checkoutAmount > 0) {
+            return Math.round(checkoutAmount);
+        }
+    }
+
+    return 0;
+}
+
 function buildTeamFeePaidUpdate({ recipient = {}, session = {}, eventId, receivedAt }) {
-    const balanceCents = getTeamFeeBalanceCents(recipient);
     const existingPaidCents = getTeamFeePaidCents(recipient);
-    const paidAmountCents = Math.max(existingPaidCents, existingPaidCents + balanceCents);
+    const stripePaidAmountCents = getTeamFeeStripePaidAmountCents({ recipient, session });
+    const paidAmountCents = existingPaidCents + stripePaidAmountCents;
+    const balanceDueCents = Math.max(0, getTeamFeeTotalCents(recipient) - paidAmountCents);
 
     return {
-        status: 'paid',
+        status: balanceDueCents > 0 ? 'partial' : 'paid',
         paidAmountCents,
         amountPaidCents: paidAmountCents,
-        balanceDueCents: 0,
+        balanceDueCents,
         checkoutStatus: 'paid',
         paymentProvider: 'stripe',
         stripeCheckoutSessionId: session.id || null,
         stripePaymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : null,
         stripeCustomerId: typeof session.customer === 'string' ? session.customer : null,
+        stripePaymentAmountCents: stripePaidAmountCents,
         stripeEventId: eventId,
         paidAt: receivedAt,
         updatedAt: receivedAt,
@@ -130,7 +160,9 @@ function buildTeamFeePaidUpdate({ recipient = {}, session = {}, eventId, receive
             provider: 'stripe',
             checkoutSessionId: session.id || null,
             paymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : null,
-            amountPaidCents: paidAmountCents,
+            amountPaidCents: stripePaidAmountCents,
+            totalPaidCents: paidAmountCents,
+            balanceDueCents,
             currency: session.currency || 'usd',
             receiptEmail: session.customer_details?.email || session.customer_email || null,
             eventId
@@ -147,7 +179,9 @@ module.exports = {
     isEligibleTeamFeePayer,
     buildTeamFeeCheckoutUrls,
     buildTeamFeeCheckoutMetadata,
+    canReuseTeamFeeCheckoutSession,
     shouldMarkTeamFeePaidFromEvent,
     shouldRecordTeamFeeCheckoutNotPaidFromEvent,
+    getTeamFeeStripePaidAmountCents,
     buildTeamFeePaidUpdate
 };

--- a/tests/unit/team-fees-functions.test.js
+++ b/tests/unit/team-fees-functions.test.js
@@ -1,0 +1,133 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const {
+    normalizeTeamFeeCheckoutInput,
+    getTeamFeeBalanceCents,
+    isTeamFeeCheckoutEligible,
+    isEligibleTeamFeePayer,
+    buildTeamFeeCheckoutUrls,
+    buildTeamFeeCheckoutMetadata,
+    shouldMarkTeamFeePaidFromEvent,
+    shouldRecordTeamFeeCheckoutNotPaidFromEvent,
+    buildTeamFeePaidUpdate
+} = require('../../functions/team-fees-core.cjs');
+
+describe('team fee checkout function helpers', () => {
+    it('normalizes bounded team fee checkout input', () => {
+        expect(normalizeTeamFeeCheckoutInput({
+            teamId: ' team_123 ',
+            batchId: ' batch_456 ',
+            feeRecipientId: ' player_789 '
+        })).toEqual({
+            teamId: 'team_123',
+            batchId: 'batch_456',
+            recipientId: 'player_789'
+        });
+    });
+
+    it('computes current balance and rejects paid or canceled recipients', () => {
+        expect(getTeamFeeBalanceCents({ amountCents: 12500, paidAmountCents: 2500 })).toBe(10000);
+        expect(getTeamFeeBalanceCents({ balanceDueCents: 5000, paidAmountCents: 2500 })).toBe(5000);
+        expect(isTeamFeeCheckoutEligible({ status: 'unpaid', amountCents: 12500 })).toBe(true);
+        expect(isTeamFeeCheckoutEligible({ status: 'paid', amountCents: 12500 })).toBe(false);
+        expect(isTeamFeeCheckoutEligible({ status: 'canceled', amountCents: 12500 })).toBe(false);
+        expect(isTeamFeeCheckoutEligible({ status: 'unpaid', amountCents: 0 })).toBe(false);
+    });
+
+    it('allows owners, admins, linked parents, and direct recipients to pay', () => {
+        const team = {
+            id: 'team_123',
+            ownerId: 'owner_1',
+            adminEmails: ['Coach@Example.com']
+        };
+        const recipient = {
+            teamId: 'team_123',
+            playerId: 'player_1',
+            playerKey: 'team_123::player_1',
+            parentUserId: 'parent_1'
+        };
+
+        expect(isEligibleTeamFeePayer({ team, recipient, uid: 'owner_1' })).toBe(true);
+        expect(isEligibleTeamFeePayer({ team, recipient, uid: 'admin_1', email: 'coach@example.com' })).toBe(true);
+        expect(isEligibleTeamFeePayer({ team, recipient, uid: 'parent_1' })).toBe(true);
+        expect(isEligibleTeamFeePayer({ team, recipient, uid: 'parent_2', user: { parentPlayerKeys: ['team_123::player_1'] } })).toBe(true);
+        expect(isEligibleTeamFeePayer({ team, recipient, uid: 'fan_1', email: 'fan@example.com' })).toBe(false);
+    });
+
+    it('builds parent-dashboard return URLs and safe Stripe metadata', () => {
+        const input = { teamId: 'team_123', batchId: 'batch_456', recipientId: 'player_789' };
+
+        expect(buildTeamFeeCheckoutUrls('https://allplays.example/', input)).toEqual({
+            successUrl: 'https://allplays.example/parent-dashboard.html?feePayment=1&teamId=team_123&batchId=batch_456&recipientId=player_789&checkout=success',
+            cancelUrl: 'https://allplays.example/parent-dashboard.html?feePayment=1&teamId=team_123&batchId=batch_456&recipientId=player_789&checkout=cancelled'
+        });
+        expect(buildTeamFeeCheckoutMetadata({ ...input, payerUid: 'user_123' })).toEqual({
+            product: 'team_fee',
+            teamId: 'team_123',
+            batchId: 'batch_456',
+            recipientId: 'player_789',
+            payerUid: 'user_123'
+        });
+    });
+
+    it('marks only paid completed team fee checkout sessions as paid', () => {
+        const paidSession = {
+            payment_status: 'paid',
+            metadata: {
+                product: 'team_fee',
+                teamId: 'team_123',
+                batchId: 'batch_456',
+                recipientId: 'player_789'
+            }
+        };
+
+        expect(shouldMarkTeamFeePaidFromEvent({ type: 'checkout.session.completed', data: { object: paidSession } })).toBe(true);
+        expect(shouldMarkTeamFeePaidFromEvent({
+            type: 'checkout.session.completed',
+            data: { object: { ...paidSession, payment_status: 'unpaid' } }
+        })).toBe(false);
+        expect(shouldMarkTeamFeePaidFromEvent({ type: 'checkout.session.expired', data: { object: paidSession } })).toBe(false);
+        expect(shouldRecordTeamFeeCheckoutNotPaidFromEvent({ type: 'checkout.session.expired', data: { object: paidSession } })).toBe(true);
+    });
+
+    it('builds paid recipient updates without raw payment method data', () => {
+        const update = buildTeamFeePaidUpdate({
+            recipient: { amountCents: 12500, paidAmountCents: 2500 },
+            eventId: 'evt_123',
+            receivedAt: 'now',
+            session: {
+                id: 'cs_123',
+                payment_intent: 'pi_123',
+                customer: 'cus_123',
+                currency: 'usd',
+                customer_details: { email: 'parent@example.com' }
+            }
+        });
+
+        expect(update).toMatchObject({
+            status: 'paid',
+            paidAmountCents: 12500,
+            amountPaidCents: 12500,
+            balanceDueCents: 0,
+            checkoutStatus: 'paid',
+            paymentProvider: 'stripe',
+            stripeCheckoutSessionId: 'cs_123',
+            stripePaymentIntentId: 'pi_123',
+            stripeCustomerId: 'cus_123',
+            stripeEventId: 'evt_123'
+        });
+        expect(update.receiptMetadata).toEqual({
+            provider: 'stripe',
+            checkoutSessionId: 'cs_123',
+            paymentIntentId: 'pi_123',
+            amountPaidCents: 12500,
+            currency: 'usd',
+            receiptEmail: 'parent@example.com',
+            eventId: 'evt_123'
+        });
+        expect(update).not.toHaveProperty('paymentMethod');
+        expect(update.receiptMetadata).not.toHaveProperty('card');
+    });
+});

--- a/tests/unit/team-fees-functions.test.js
+++ b/tests/unit/team-fees-functions.test.js
@@ -9,8 +9,10 @@ const {
     isEligibleTeamFeePayer,
     buildTeamFeeCheckoutUrls,
     buildTeamFeeCheckoutMetadata,
+    canReuseTeamFeeCheckoutSession,
     shouldMarkTeamFeePaidFromEvent,
     shouldRecordTeamFeeCheckoutNotPaidFromEvent,
+    getTeamFeeStripePaidAmountCents,
     buildTeamFeePaidUpdate
 } = require('../../functions/team-fees-core.cjs');
 
@@ -72,7 +74,21 @@ describe('team fee checkout function helpers', () => {
         });
     });
 
-    it('marks only paid completed team fee checkout sessions as paid', () => {
+    it('reuses only currently open checkout sessions for the same amount', () => {
+        const recipient = {
+            checkoutUrl: 'https://checkout.stripe.test/session',
+            stripeCheckoutSessionId: 'cs_123',
+            checkoutStatus: 'open',
+            checkoutAmountCents: 7500
+        };
+
+        expect(canReuseTeamFeeCheckoutSession(recipient, 7500)).toBe(true);
+        expect(canReuseTeamFeeCheckoutSession({ ...recipient, checkoutStatus: 'payment_failed' }, 7500)).toBe(false);
+        expect(canReuseTeamFeeCheckoutSession({ ...recipient, checkoutStatus: 'expired' }, 7500)).toBe(false);
+        expect(canReuseTeamFeeCheckoutSession({ ...recipient, checkoutAmountCents: 8000 }, 7500)).toBe(false);
+    });
+
+    it('marks paid immediate and async team fee checkout sessions as paid', () => {
         const paidSession = {
             payment_status: 'paid',
             metadata: {
@@ -85,11 +101,30 @@ describe('team fee checkout function helpers', () => {
 
         expect(shouldMarkTeamFeePaidFromEvent({ type: 'checkout.session.completed', data: { object: paidSession } })).toBe(true);
         expect(shouldMarkTeamFeePaidFromEvent({
+            type: 'checkout.session.async_payment_succeeded',
+            data: { object: { ...paidSession, payment_status: 'unpaid' } }
+        })).toBe(true);
+        expect(shouldMarkTeamFeePaidFromEvent({
             type: 'checkout.session.completed',
             data: { object: { ...paidSession, payment_status: 'unpaid' } }
         })).toBe(false);
         expect(shouldMarkTeamFeePaidFromEvent({ type: 'checkout.session.expired', data: { object: paidSession } })).toBe(false);
         expect(shouldRecordTeamFeeCheckoutNotPaidFromEvent({ type: 'checkout.session.expired', data: { object: paidSession } })).toBe(true);
+        expect(shouldRecordTeamFeeCheckoutNotPaidFromEvent({ type: 'checkout.session.async_payment_failed', data: { object: paidSession } })).toBe(true);
+    });
+
+    it('uses immutable Stripe or matching checkout amounts for fee payment accounting', () => {
+        expect(getTeamFeeStripePaidAmountCents({
+            session: { id: 'cs_123', amount_total: 10000 }
+        })).toBe(10000);
+        expect(getTeamFeeStripePaidAmountCents({
+            recipient: { stripeCheckoutSessionId: 'cs_123', checkoutAmountCents: 9000 },
+            session: { id: 'cs_123' }
+        })).toBe(9000);
+        expect(getTeamFeeStripePaidAmountCents({
+            recipient: { stripeCheckoutSessionId: 'cs_other', checkoutAmountCents: 9000 },
+            session: { id: 'cs_123' }
+        })).toBe(0);
     });
 
     it('builds paid recipient updates without raw payment method data', () => {
@@ -101,6 +136,7 @@ describe('team fee checkout function helpers', () => {
                 id: 'cs_123',
                 payment_intent: 'pi_123',
                 customer: 'cus_123',
+                amount_total: 10000,
                 currency: 'usd',
                 customer_details: { email: 'parent@example.com' }
             }
@@ -116,18 +152,48 @@ describe('team fee checkout function helpers', () => {
             stripeCheckoutSessionId: 'cs_123',
             stripePaymentIntentId: 'pi_123',
             stripeCustomerId: 'cus_123',
+            stripePaymentAmountCents: 10000,
             stripeEventId: 'evt_123'
         });
         expect(update.receiptMetadata).toEqual({
             provider: 'stripe',
             checkoutSessionId: 'cs_123',
             paymentIntentId: 'pi_123',
-            amountPaidCents: 12500,
+            amountPaidCents: 10000,
+            totalPaidCents: 12500,
+            balanceDueCents: 0,
             currency: 'usd',
             receiptEmail: 'parent@example.com',
             eventId: 'evt_123'
         });
         expect(update).not.toHaveProperty('paymentMethod');
         expect(update.receiptMetadata).not.toHaveProperty('card');
+    });
+
+    it('does not mark the recipient fully paid when the balance grew after checkout creation', () => {
+        const update = buildTeamFeePaidUpdate({
+            recipient: { amountCents: 15000, paidAmountCents: 2500 },
+            eventId: 'evt_456',
+            receivedAt: 'now',
+            session: {
+                id: 'cs_456',
+                amount_total: 10000,
+                currency: 'usd'
+            }
+        });
+
+        expect(update).toMatchObject({
+            status: 'partial',
+            paidAmountCents: 12500,
+            amountPaidCents: 12500,
+            balanceDueCents: 2500,
+            checkoutStatus: 'paid',
+            stripePaymentAmountCents: 10000
+        });
+        expect(update.receiptMetadata).toMatchObject({
+            amountPaidCents: 10000,
+            totalPaidCents: 12500,
+            balanceDueCents: 2500
+        });
     });
 });


### PR DESCRIPTION
Closes #911

## Summary
- Added a server-side Stripe Checkout creation path for eligible unpaid team fee recipients.
- Stored only safe checkout/payment metadata on fee recipient records, including checkout URL, Stripe session/payment intent IDs, paid amount, balance, and receipt metadata.
- Extended the existing Stripe webhook handler to mark team fee recipients paid only for paid completed checkout sessions, while expired/failed sessions never mark fees paid.

## Validation
- `npx vitest run tests/unit/team-fees-functions.test.js tests/unit/parent-dashboard-fees.test.js tests/unit/team-pass-functions.test.js`
- `node --check functions/index.js && node --check functions/team-fees-core.cjs`