### PR TITLE
Fix certificate print centering: use full page dimensions

### DIFF
--- a/css/certificates.css
+++ b/css/certificates.css
@@ -984,7 +984,7 @@
 @media print {
     @page {
         size: letter landscape;
-        margin: 0.25in;
+        margin: 0;
     }
 
     body.cert-printing {
@@ -1004,9 +1004,8 @@
         display: flex;
         align-items: center;
         justify-content: center;
-        width: 10.5in;
-        height: 8in;
-        margin: 0 auto;
+        width: 11in;
+        height: 8.5in;
         break-after: page;
         page-break-after: always;
     }

--- a/css/certificates.css
+++ b/css/certificates.css
@@ -987,6 +987,11 @@
         margin: 0.25in;
     }
 
+    body.cert-printing {
+        margin: 0 !important;
+        padding: 0 !important;
+    }
+
     body.cert-printing > *:not(#cert-print-root) {
         display: none !important;
     }
@@ -1001,6 +1006,7 @@
         justify-content: center;
         width: 10.5in;
         height: 8in;
+        margin: 0 auto;
         break-after: page;
         page-break-after: always;
     }


### PR DESCRIPTION
## Summary

- Browsers commonly ignore `@page` CSS margins, so the 0.25in margin was not being applied — the content area was the full 11in × 8.5in page
- The certificate sheet was sized to 10.5in × 8in and rendered from the top-left corner, making the image appear left-aligned with unequal top/bottom spacing
- Fix: set `@page { margin: 0 }` and the sheet to the full landscape dimensions (11in × 8.5in), letting flexbox center the image within the full page
- Image `max-width: 10.5in` / `max-height: 8in` constraints preserve a natural inset from the page edges
- Also zero out `body.cert-printing` margin/padding to eliminate any browser default body margin

## Test plan

- [ ] Click Print on a certificate — image should be horizontally and vertically centered on the page with no manual printer margin adjustments needed
- [ ] Printer margin settings should be left at default (zero) and centering should still work
- [ ] Multi-certificate print should page-break correctly between certificates

https://claude.ai/code/session_01EPhyE4EwYSpsw9C3kPFvmr