### PR TITLE
Preserve invite context for signup

### DIFF
--- a/accept-invite.html
+++ b/accept-invite.html
@@ -93,7 +93,7 @@
                     </button>
                 </form>
                 <p class="text-xs text-gray-500 mt-4 text-center">
-                    Need to create an account? <a href="login.html" class="text-indigo-600 hover:underline">Sign up here</a> with your invite code.
+                    Need to create an account? <a href="login.html" id="signup-link" class="text-indigo-600 hover:underline">Sign up here</a> with your invite code.
                 </p>
             </div>
 
@@ -146,6 +146,14 @@
         const urlParams = new URLSearchParams(window.location.search);
         const inviteCode = urlParams.get('code') || window.localStorage.getItem('inviteCode');
         const inviteType = urlParams.get('type') || window.localStorage.getItem('inviteType') || 'parent';
+
+        const signupLink = document.getElementById('signup-link');
+        if (signupLink && inviteCode) {
+            const signupParams = new URLSearchParams();
+            signupParams.set('code', String(inviteCode).trim().toUpperCase());
+            signupParams.set('type', String(inviteType).trim().toLowerCase());
+            signupLink.href = `login.html?${signupParams.toString()}`;
+        }
 
         // State elements
         const loadingState = document.getElementById('loading-state');

--- a/tests/unit/accept-invite-page.test.js
+++ b/tests/unit/accept-invite-page.test.js
@@ -157,7 +157,8 @@ function createEnvironment({ href, storage } = {}) {
         'submit-code-btn',
         'success-message',
         'error-message',
-        'try-manual-code-btn'
+        'try-manual-code-btn',
+        'signup-link'
     ];
 
     const elements = new Map(ids.map((id) => [id, new MockElement(id)]));
@@ -291,6 +292,16 @@ describe('accept-invite page parent flow', () => {
         expect(elements.get('success-message').textContent).toContain("#22");
         expect(elements.get('success-message').textContent).toContain('Tigers');
         expect(window.location.href).toBe('http://example.com/parent-dashboard.html');
+    });
+
+    it('preserves the invite context on the signed-out signup link', async () => {
+        const loggedOut = await bootAcceptInvite({
+            href: 'http://example.com/accept-invite.html?code=ab12cd34&type=parent',
+            authUser: null
+        });
+
+        expect(loggedOut.elements.get('signup-link').href).toBe('login.html?code=AB12CD34&type=parent');
+        expect(loggedOut.elements.get('code-input').value).toBe('ab12cd34');
     });
 
     it('uppercases the manual code for login redirect and redeems exactly once after the user returns authenticated', async () => {


### PR DESCRIPTION
Closes #924

## Summary
- Updated the accept-invite signup CTA to carry the current invite code and type into `login.html`.
- Normalizes the code/type before building the signup URL so `login.html` can auto-apply the activation code.
- Added unit coverage for the signed-out signup link preserving invite context.

## Validation
- `npm test -- --run tests/unit/accept-invite-page.test.js tests/unit/login-page.test.js`