### PR TITLE
Add roster import conflict preview

### DIFF
--- a/edit-roster.html
+++ b/edit-roster.html
@@ -732,30 +732,44 @@
             const importButton = document.getElementById('registration-roster-import-btn');
             if (!preview || !importButton || !plan) return;
 
-            const operationRows = plan.operations.map((operation) => {
-                const label = operation.type === 'update' ? 'Update existing player' : 'Add new player';
+            const statusLabels = {
+                add: 'Add',
+                update: 'Update',
+                unchanged: 'Unchanged',
+                conflict: 'Conflict'
+            };
+            const rowHtml = (plan.previewRows || []).map((row) => {
+                const isImportable = row.status === 'add' || row.status === 'update';
+                const isConflict = row.status === 'conflict';
+                const borderClass = isConflict ? 'border-amber-300 bg-amber-50 text-amber-900' : 'border-emerald-200 bg-white';
+                const checkbox = isImportable
+                    ? `<label class="flex items-center gap-2 text-xs font-semibold text-emerald-800"><input type="checkbox" class="registration-roster-import-row rounded border-gray-300" data-operation-id="${escapeHtml(row.id)}" checked> Import this safe row</label>`
+                    : `<span class="text-xs font-semibold ${isConflict ? 'text-amber-800' : 'text-gray-500'}">${isConflict ? 'Skipped until reviewed' : 'No write needed'}</span>`;
+                const conflictText = row.conflict
+                    ? `<div class="text-xs mt-1">Conflicts with existing player ${escapeHtml(row.existingPlayerId || 'unknown')}${row.conflict.contact ? ` by ${escapeHtml(row.conflict.contact)}` : ' by name/number match'}.</div>`
+                    : '';
+
                 return `
-                    <div class="rounded-md border border-emerald-200 bg-white p-3">
-                        <div class="font-semibold text-gray-900">${escapeHtml(label)}: ${escapeHtml(operation.payload.name || 'Unnamed player')}${operation.payload.number ? ` #${escapeHtml(operation.payload.number)}` : ''}</div>
-                        <div class="text-xs text-gray-600 mt-1">Contacts: ${escapeHtml(formatRegistrationContacts(operation.payload))}</div>
-                        <div class="text-xs text-emerald-700 mt-1">Source: ${escapeHtml(operation.payload.sourceMetadata?.sourceType || 'registration')} · ${escapeHtml(operation.payload.sourceMetadata?.externalPlayerId || '')}</div>
+                    <div class="rounded-md border ${borderClass} p-3">
+                        <div class="flex items-start justify-between gap-3">
+                            <div>
+                                <div class="font-semibold">${escapeHtml(statusLabels[row.status] || row.status)}: ${escapeHtml(row.playerName || 'Unnamed player')}${row.number ? ` #${escapeHtml(row.number)}` : ''}</div>
+                                <div class="text-xs text-gray-600 mt-1">Guardians/contacts: ${escapeHtml(formatRegistrationContacts(row))}</div>
+                                <div class="text-xs text-emerald-700 mt-1">Source: ${escapeHtml(row.sourceMetadata?.sourceType || 'registration')} · ${escapeHtml(row.sourceMetadata?.sourceId || 'registration')} · Player ${escapeHtml(row.externalPlayerId || '')}</div>
+                                ${conflictText}
+                            </div>
+                            ${checkbox}
+                        </div>
                     </div>
                 `;
             });
-            const conflictRows = (plan.results.conflicts || []).map((conflict) => `
-                <div class="rounded-md border border-amber-300 bg-amber-50 p-3 text-amber-900">
-                    <div class="font-semibold">Review conflict before import</div>
-                    <div class="text-xs mt-1">External player ${escapeHtml(conflict.externalPlayerId || 'unknown')} likely conflicts with existing player ${escapeHtml(conflict.existingPlayerId || 'unknown')}${conflict.contact ? ` by ${escapeHtml(conflict.contact)}` : ' by name/number match'}.</div>
-                </div>
-            `);
 
             preview.classList.remove('hidden');
             preview.innerHTML = `
                 <div class="rounded-md border border-emerald-200 bg-emerald-100/60 p-3 font-semibold text-emerald-900">
-                    Preview: ${escapeHtml(formatRegistrationRosterImportResults(plan.results))}.
+                    Preview: ${escapeHtml(formatRegistrationRosterImportResults(plan.results))}. Conflicted rows are skipped automatically; uncheck any safe rows you do not want to import.
                 </div>
-                ${operationRows.length ? operationRows.join('') : '<div class="rounded-md border border-gray-200 bg-white p-3 text-gray-600">No importable player changes found.</div>'}
-                ${conflictRows.join('')}
+                ${rowHtml.length ? rowHtml.join('') : '<div class="rounded-md border border-gray-200 bg-white p-3 text-gray-600">No source roster rows found.</div>'}
             `;
             importButton.disabled = plan.operations.length === 0;
             importButton.classList.toggle('opacity-50', importButton.disabled);
@@ -837,7 +851,16 @@
                 button.textContent = 'Importing...';
                 status.textContent = 'Importing previewed roster changes...';
 
-                for (const operation of registrationRosterImportPlan.operations) {
+                const selectedOperationIds = new Set(Array.from(document.querySelectorAll('.registration-roster-import-row:checked')).map((input) => input.dataset.operationId));
+                const selectedOperations = registrationRosterImportPlan.operations.filter((operation) => selectedOperationIds.has(operation.id));
+                if (selectedOperations.length === 0) {
+                    status.textContent = 'No safe rows were selected for import.';
+                    registrationRosterImportPlan = null;
+                    renderRegistrationRosterImportPreview({ operations: [], previewRows: [], results: { added: 0, updated: 0, unchanged: 0, skipped: 0, conflicted: 0 } });
+                    return;
+                }
+
+                for (const operation of selectedOperations) {
                     let playerId = operation.playerId;
                     if (operation.type === 'update') {
                         await updatePlayer(currentTeamId, playerId, operation.payload);
@@ -849,7 +872,7 @@
                     }
                 }
 
-                status.textContent = `Import complete: ${formatRegistrationRosterImportResults(registrationRosterImportPlan.results)}.`;
+                status.textContent = `Import complete: ${selectedOperations.length} selected safe row${selectedOperations.length === 1 ? '' : 's'} applied from preview. ${formatRegistrationRosterImportResults(registrationRosterImportPlan.results)}.`;
                 if (registrationRosterImportPlan.results.conflicted > 0) {
                     status.textContent += ' Conflicts were left unchanged so local-only players are preserved.';
                 }

--- a/js/edit-roster-registration-import.js
+++ b/js/edit-roster-registration-import.js
@@ -264,6 +264,53 @@ function mergeRosterFieldValuesIntoPayload(payload, fieldValues, fields, existin
     };
 }
 
+function comparableImportValue(value) {
+    if (Array.isArray(value)) return value.map(comparableImportValue);
+    if (!value || typeof value !== 'object') return value ?? '';
+
+    return Object.keys(value).sort().reduce((result, key) => {
+        if (key === 'importedAt') return result;
+        result[key] = comparableImportValue(value[key]);
+        return result;
+    }, {});
+}
+
+function buildComparableExistingPlayer(existingPlayer = {}, payload = {}) {
+    return Object.keys(payload).reduce((result, key) => {
+        if (key === 'profile') {
+            result.profile = {
+                ...(existingPlayer.profile || {}),
+                customFields: getRosterProfileValues(existingPlayer)
+            };
+            return result;
+        }
+        result[key] = existingPlayer[key];
+        return result;
+    }, {});
+}
+
+function isUnchangedRegistrationImport(existingPlayer = {}, payload = {}) {
+    if (!existingPlayer?.id) return false;
+    const existingComparable = comparableImportValue(buildComparableExistingPlayer(existingPlayer, payload));
+    const payloadComparable = comparableImportValue(payload);
+    return JSON.stringify(existingComparable) === JSON.stringify(payloadComparable);
+}
+
+function buildPreviewRow({ status, sourcePlayer = {}, payload = null, existingPlayer = null, conflict = null, operationIndex = null } = {}) {
+    return {
+        id: `source-${getExternalPlayerId(sourcePlayer) || operationIndex || status}`,
+        status,
+        externalPlayerId: getExternalPlayerId(sourcePlayer),
+        playerName: payload?.name || getPlayerName(sourcePlayer),
+        number: payload?.number || normalizeString(sourcePlayer.number || sourcePlayer.jerseyNumber || sourcePlayer.jersey || sourcePlayer.uniformNumber),
+        guardians: payload?.guardians || normalizeContacts(sourcePlayer.guardians || sourcePlayer.parents || sourcePlayer.familyContacts),
+        contacts: payload?.contacts || normalizeContacts(sourcePlayer.contacts || sourcePlayer.contactFields),
+        sourceMetadata: payload?.sourceMetadata || null,
+        existingPlayerId: existingPlayer?.id || conflict?.existingPlayerId || null,
+        conflict
+    };
+}
+
 export function isExternallyLinkedRosterTeam(team = {}) {
     return !!(
         team.registrationSourceSnapshot ||
@@ -341,9 +388,11 @@ export function planRegistrationRosterImport({ sourcePlayers = [], existingPlaye
     const seenExternalIds = new Set();
     const existingContactOwners = collectExistingContactOwners(existingPlayers);
     const operations = [];
+    const previewRows = [];
     const results = {
         added: 0,
         updated: 0,
+        unchanged: 0,
         skipped: 0,
         conflicted: 0,
         fieldsImported: 0,
@@ -370,8 +419,10 @@ export function planRegistrationRosterImport({ sourcePlayers = [], existingPlaye
         if (!existing) {
             const conflict = (existingPlayers || []).find((candidate) => isSameLocalPlayer(sourcePlayer, candidate));
             if (conflict) {
+                const conflictDetail = { externalPlayerId, existingPlayerId: conflict.id || null, conflictType: 'name-number' };
                 results.conflicted += 1;
-                results.conflicts.push({ externalPlayerId, existingPlayerId: conflict.id || null });
+                results.conflicts.push(conflictDetail);
+                previewRows.push(buildPreviewRow({ status: 'conflict', sourcePlayer, payload, existingPlayer: conflict, conflict: conflictDetail }));
                 return;
             }
         }
@@ -379,13 +430,15 @@ export function planRegistrationRosterImport({ sourcePlayers = [], existingPlaye
         const sourceContacts = [...(payload.guardians || []), ...(payload.contacts || [])];
         const contactConflict = findContactConflict(sourceContacts, existingContactOwners, existing);
         if (contactConflict) {
-            results.conflicted += 1;
-            results.conflicts.push({
+            const conflictDetail = {
                 externalPlayerId,
                 existingPlayerId: contactConflict.existingPlayerId,
                 conflictType: 'contact',
                 contact: contactConflict.contact
-            });
+            };
+            results.conflicted += 1;
+            results.conflicts.push(conflictDetail);
+            previewRows.push(buildPreviewRow({ status: 'conflict', sourcePlayer, payload, existingPlayer: existing, conflict: conflictDetail }));
             return;
         }
 
@@ -393,20 +446,29 @@ export function planRegistrationRosterImport({ sourcePlayers = [], existingPlaye
         const merged = mergeRosterFieldValuesIntoPayload(payload, fieldValues, fields, existing || {});
 
         if (existing?.id) {
-            operations.push({ type: 'update', playerId: existing.id, payload: merged.payload, privateRosterFields: merged.privateRosterFields });
+            if (isUnchangedRegistrationImport(existing, merged.payload) && !merged.privateRosterFields) {
+                previewRows.push(buildPreviewRow({ status: 'unchanged', sourcePlayer, payload: merged.payload, existingPlayer: existing }));
+                results.unchanged += 1;
+                return;
+            }
+            const operationIndex = operations.length;
+            operations.push({ id: `source-${externalPlayerId}`, type: 'update', playerId: existing.id, payload: merged.payload, privateRosterFields: merged.privateRosterFields });
+            previewRows.push(buildPreviewRow({ status: 'update', sourcePlayer, payload: merged.payload, existingPlayer: existing, operationIndex }));
             results.updated += 1;
             return;
         }
 
-        operations.push({ type: 'add', payload: merged.payload, privateRosterFields: merged.privateRosterFields });
+        const operationIndex = operations.length;
+        operations.push({ id: `source-${externalPlayerId}`, type: 'add', payload: merged.payload, privateRosterFields: merged.privateRosterFields });
+        previewRows.push(buildPreviewRow({ status: 'add', sourcePlayer, payload: merged.payload, operationIndex }));
         results.added += 1;
     });
 
-    return { operations, results };
+    return { operations, previewRows, results };
 }
 
 export function formatRegistrationRosterImportResults(results = {}) {
-    const parts = [`${results.added || 0} added, ${results.updated || 0} updated, ${results.skipped || 0} skipped, ${results.conflicted || 0} conflicted`];
+    const parts = [`${results.added || 0} added, ${results.updated || 0} updated, ${results.unchanged || 0} unchanged, ${results.skipped || 0} skipped, ${results.conflicted || 0} conflicted`];
     if ((results.fieldsImported || 0) > 0 || (results.fieldsSkipped || 0) > 0) {
         parts.push(`${results.fieldsImported || 0} configured field value${(results.fieldsImported || 0) === 1 ? '' : 's'} imported`);
         parts.push(`${results.fieldsSkipped || 0} configured field value${(results.fieldsSkipped || 0) === 1 ? '' : 's'} skipped`);

--- a/tests/unit/edit-roster-registration-import.test.js
+++ b/tests/unit/edit-roster-registration-import.test.js
@@ -63,10 +63,11 @@ describe('registration roster import planning', () => {
         expect(plan.results).toMatchObject({
             added: 1,
             updated: 1,
+            unchanged: 0,
             skipped: 1,
             conflicted: 1
         });
-        expect(plan.results.conflicts).toEqual([{ externalPlayerId: 'ext-2', existingPlayerId: 'player-2' }]);
+        expect(plan.results.conflicts).toEqual([{ externalPlayerId: 'ext-2', existingPlayerId: 'player-2', conflictType: 'name-number' }]);
         expect(plan.operations).toHaveLength(2);
         expect(plan.operations[0]).toMatchObject({
             type: 'update',
@@ -83,6 +84,7 @@ describe('registration roster import planning', () => {
             }
         });
         expect(plan.operations[1]).toMatchObject({
+            id: 'source-ext-3',
             type: 'add',
             payload: {
                 name: 'Jordan Smith',
@@ -92,6 +94,43 @@ describe('registration roster import planning', () => {
                 }
             }
         });
+        expect(plan.previewRows.map((row) => row.status)).toEqual(['update', 'conflict', 'add']);
+    });
+
+    it('labels exact source matches as unchanged and avoids unnecessary writes', () => {
+        const plan = planRegistrationRosterImport({
+            source: { type: 'sports-connect', id: 'league-1' },
+            sourcePlayers: [
+                {
+                    externalPlayerId: 'ext-1',
+                    name: 'Avery Lee',
+                    number: '4',
+                    guardians: [{ name: 'Pat Lee', email: 'pat@example.com', relation: 'Parent' }]
+                }
+            ],
+            existingPlayers: [
+                {
+                    id: 'player-1',
+                    name: 'Avery Lee',
+                    number: '4',
+                    active: true,
+                    guardians: [{ name: 'Pat Lee', email: 'pat@example.com', phone: '', relation: 'Parent' }],
+                    sourceMetadata: { sourceType: 'sports-connect', sourceId: 'league-1', externalPlayerId: 'ext-1', importedAt: '2026-01-01T00:00:00.000Z' }
+                }
+            ]
+        });
+
+        expect(plan.results).toMatchObject({ added: 0, updated: 0, unchanged: 1, skipped: 0, conflicted: 0 });
+        expect(plan.operations).toHaveLength(0);
+        expect(plan.previewRows).toMatchObject([
+            {
+                status: 'unchanged',
+                externalPlayerId: 'ext-1',
+                playerName: 'Avery Lee',
+                existingPlayerId: 'player-1',
+                sourceMetadata: { sourceType: 'sports-connect', sourceId: 'league-1', externalPlayerId: 'ext-1' }
+            }
+        ]);
     });
 
     it('does not update an existing player from a different known source with the same external player ID', () => {
@@ -277,10 +316,10 @@ describe('registration roster import planning', () => {
     });
 
     it('formats import result counts for the UI', () => {
-        expect(formatRegistrationRosterImportResults({ added: 2, updated: 1, skipped: 0, conflicted: 3 }))
-            .toBe('2 added, 1 updated, 0 skipped, 3 conflicted');
-        expect(formatRegistrationRosterImportResults({ added: 1, updated: 0, skipped: 0, conflicted: 0, fieldsImported: 2, fieldsSkipped: 1, fieldSkipReasons: { invalid: 1 } }))
-            .toBe('1 added, 0 updated, 0 skipped, 0 conflicted, 2 configured field values imported, 1 configured field value skipped, skipped: 1 invalid option/date/checkbox');
+        expect(formatRegistrationRosterImportResults({ added: 2, updated: 1, unchanged: 4, skipped: 0, conflicted: 3 }))
+            .toBe('2 added, 1 updated, 4 unchanged, 0 skipped, 3 conflicted');
+        expect(formatRegistrationRosterImportResults({ added: 1, updated: 0, unchanged: 0, skipped: 0, conflicted: 0, fieldsImported: 2, fieldsSkipped: 1, fieldSkipReasons: { invalid: 1 } }))
+            .toBe('1 added, 0 updated, 0 unchanged, 0 skipped, 0 conflicted, 2 configured field values imported, 1 configured field value skipped, skipped: 1 invalid option/date/checkbox');
     });
 });
 
@@ -294,6 +333,9 @@ describe('registration roster import wiring', () => {
         expect(source).toContain("import { formatRegistrationRosterImportResults, getRegistrationRosterPlayers, isExternallyLinkedRosterTeam, planRegistrationRosterImport } from './js/edit-roster-registration-import.js?v=1';");
         expect(source).toContain('planRegistrationRosterImport({');
         expect(source).toContain('renderRegistrationRosterImportPreview');
+        expect(source).toContain('registration-roster-import-row');
+        expect(source).toContain('selectedOperationIds');
+        expect(source).toContain('Conflicted rows are skipped automatically');
         expect(source).toContain('No registration provider data is available yet.');
         expect(source).toContain('fields: rosterFieldDefinitions');
         expect(source).toContain('setPlayerPrivateRosterProfileFields(currentTeamId, playerId, operation.privateRosterFields)');


### PR DESCRIPTION
Closes #922

## Summary
- Adds roster import preview rows for add, update, unchanged, and conflict states.
- Shows normalized player, guardian/contact, source ID, and conflict details before import.
- Lets users uncheck safe add/update rows while conflicted rows remain skipped.
- Preserves source metadata and import audit fields on applied add/update operations.

## Tests
- `npx vitest run tests/unit/edit-roster-registration-import.test.js`