### PR TITLE
Add Sports Connect registration workflow

### DIFF
--- a/edit-team.html
+++ b/edit-team.html
@@ -687,8 +687,21 @@
             });
         }
 
+        function normalizeRegistrationProviderKey(provider) {
+            return String(provider || '').trim().toLowerCase().replace(/[\s_]+/g, '-');
+        }
+
+        function isSportsConnectProvider(provider) {
+            return normalizeRegistrationProviderKey(provider) === 'sports-connect';
+        }
+
+        function getRegistrationProviderDisplayName(provider) {
+            const normalizedProvider = String(provider || '').trim();
+            return isSportsConnectProvider(normalizedProvider) ? 'Sports Connect' : normalizedProvider;
+        }
+
         function getRegistrationProviderId(provider) {
-            return provider.toLowerCase() === 'sports connect' ? 'sports-connect' : '';
+            return isSportsConnectProvider(provider) ? 'sports-connect' : '';
         }
 
         function ensureRegistrationProviderOption(provider) {
@@ -713,7 +726,7 @@
             const externalTeamId = document.getElementById('registrationExternalTeamId').value.trim();
             const lastSyncStatus = document.getElementById('registrationLastSyncStatus').value.trim() || 'Not synced';
             const lastSyncTime = getRegistrationLastSyncTime(source);
-            const isSportsConnect = provider.toLowerCase() === 'sports connect';
+            const isSportsConnect = isSportsConnectProvider(provider);
             let connectionStatus = 'Not configured';
             let helpText = 'Choose Sports Connect and enter a team ID or mapping to store registration metadata.';
 
@@ -737,7 +750,11 @@
             currentRegistrationSource = team.registrationSource && typeof team.registrationSource === 'object'
                 ? { ...team.registrationSource }
                 : null;
-            const provider = getRegistrationSourceValue(team, 'provider') || getRegistrationSourceValue(team, 'providerName');
+            const provider = getRegistrationProviderDisplayName(
+                getRegistrationSourceValue(team, 'provider') ||
+                getRegistrationSourceValue(team, 'providerName') ||
+                getRegistrationSourceValue(team, 'providerId')
+            );
             ensureRegistrationProviderOption(provider);
             document.getElementById('registrationProviderName').value = provider;
             document.getElementById('registrationExternalTeamId').value = getRegistrationSourceValue(team, 'externalTeamId');

--- a/edit-team.html
+++ b/edit-team.html
@@ -438,7 +438,7 @@
                     <div class="flex items-start justify-between gap-3">
                         <div>
                             <h3 class="font-semibold text-blue-900 text-sm">Registration Provider Connection</h3>
-                            <p class="text-xs text-blue-700 mt-1">Configure registration metadata for this team. Sports Connect can be selected now, but no provider login, live sync job, or network fetch runs from these fields.</p>
+                            <p class="text-xs text-blue-700 mt-1">Configure registration metadata for this team. Sports Connect can be selected now. No provider login, sync job, or network call runs from these fields.</p>
                         </div>
                         <button id="clear-registration-provider-btn" type="button" class="shrink-0 px-3 py-1.5 bg-white border border-blue-200 text-blue-700 text-xs font-semibold rounded-lg hover:bg-blue-100 transition">
                             Clear

--- a/edit-team.html
+++ b/edit-team.html
@@ -438,7 +438,7 @@
                     <div class="flex items-start justify-between gap-3">
                         <div>
                             <h3 class="font-semibold text-blue-900 text-sm">Registration Provider Connection</h3>
-                            <p class="text-xs text-blue-700 mt-1">Document the registration source for this team. No provider login, sync job, or network call runs from these fields.</p>
+                            <p class="text-xs text-blue-700 mt-1">Configure registration metadata for this team. Sports Connect can be selected now, but no provider login, live sync job, or network fetch runs from these fields.</p>
                         </div>
                         <button id="clear-registration-provider-btn" type="button" class="shrink-0 px-3 py-1.5 bg-white border border-blue-200 text-blue-700 text-xs font-semibold rounded-lg hover:bg-blue-100 transition">
                             Clear
@@ -446,21 +446,26 @@
                     </div>
                     <div class="grid gap-3 sm:grid-cols-2">
                         <div>
-                            <label class="block text-sm font-medium text-gray-700">Provider Name</label>
-                            <input type="text" id="registrationProviderName"
-                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 border p-2 bg-white"
-                                placeholder="Sports Connect">
+                            <label class="block text-sm font-medium text-gray-700">Registration Provider</label>
+                            <select id="registrationProviderName"
+                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 border p-2 bg-white">
+                                <option value="">No provider configured</option>
+                                <option value="Sports Connect">Sports Connect</option>
+                                <option value="League Apps">League Apps</option>
+                                <option value="Other">Other documented source</option>
+                            </select>
+                            <p class="text-xs text-blue-700 mt-1">Selecting Sports Connect saves metadata only until a connector is added.</p>
                         </div>
                         <div>
-                            <label class="block text-sm font-medium text-gray-700">External Team ID</label>
+                            <label class="block text-sm font-medium text-gray-700">Sports Connect Team ID / External Mapping</label>
                             <input type="text" id="registrationExternalTeamId"
                                 class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 border p-2 bg-white"
-                                placeholder="Provider team identifier">
+                                placeholder="Provider team identifier or mapping key">
                         </div>
                     </div>
                     <div class="grid gap-3 sm:grid-cols-2">
                         <div>
-                            <label class="block text-sm font-medium text-gray-700">Copied Team ID</label>
+                            <label class="block text-sm font-medium text-gray-700">ALL PLAYS Team ID</label>
                             <input type="text" id="registrationCopiedTeamId" readonly
                                 class="mt-1 block w-full rounded-md border-gray-200 bg-white text-gray-600 shadow-sm border p-2"
                                 placeholder="Save this team to generate a Team ID">
@@ -470,6 +475,28 @@
                             <input type="text" id="registrationLastSyncStatus"
                                 class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 border p-2 bg-white"
                                 placeholder="Not synced">
+                        </div>
+                    </div>
+                    <div class="rounded-lg border border-blue-200 bg-white p-3 text-sm text-slate-700 space-y-2">
+                        <div class="grid gap-2 sm:grid-cols-3">
+                            <div>
+                                <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Connection</p>
+                                <p id="registration-connection-status" class="font-medium text-slate-900">Not configured</p>
+                            </div>
+                            <div>
+                                <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Last sync</p>
+                                <p id="registration-sync-status" class="font-medium text-slate-900">Not synced</p>
+                            </div>
+                            <div>
+                                <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Last sync time</p>
+                                <p id="registration-sync-time" class="font-medium text-slate-900">Never</p>
+                            </div>
+                        </div>
+                        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                            <p id="registration-connection-help" class="text-xs text-blue-700">Use the manual entry point to re-import stored roster or schedule data. This does not fetch new Sports Connect data.</p>
+                            <button id="registration-refresh-btn" type="button" class="shrink-0 px-3 py-1.5 bg-blue-600 text-white text-xs font-semibold rounded-lg hover:bg-blue-700 transition">
+                                Manual refresh / re-import
+                            </button>
                         </div>
                     </div>
                 </div>
@@ -641,20 +668,89 @@
             return String(team?.registrationSource?.[key] || team?.registrationProvider?.[key] || '').trim();
         }
 
+        function getRegistrationLastSyncTime(source = {}) {
+            return String(source.lastSyncAt || source.lastSyncedAt || source.lastSyncTime || '').trim();
+        }
+
+        function formatRegistrationSyncTime(value) {
+            if (!value) return 'Never';
+            const parsed = new Date(value);
+            if (Number.isNaN(parsed.getTime())) {
+                return value;
+            }
+            return parsed.toLocaleString(undefined, {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+                hour: 'numeric',
+                minute: '2-digit'
+            });
+        }
+
+        function getRegistrationProviderId(provider) {
+            return provider.toLowerCase() === 'sports connect' ? 'sports-connect' : '';
+        }
+
+        function ensureRegistrationProviderOption(provider) {
+            const normalizedProvider = String(provider || '').trim();
+            if (!normalizedProvider || ['', 'Sports Connect', 'League Apps', 'Other'].includes(normalizedProvider)) {
+                return;
+            }
+            const select = document.getElementById('registrationProviderName');
+            if (typeof document.createElement !== 'function' || typeof select.appendChild !== 'function') {
+                return;
+            }
+            const hasOption = Array.from(select.options || []).some((option) => option.value === normalizedProvider);
+            if (hasOption) return;
+            const option = document.createElement('option');
+            option.value = normalizedProvider;
+            option.textContent = normalizedProvider;
+            select.appendChild(option);
+        }
+
+        function renderRegistrationConnectionStatus(source = {}) {
+            const provider = document.getElementById('registrationProviderName').value.trim();
+            const externalTeamId = document.getElementById('registrationExternalTeamId').value.trim();
+            const lastSyncStatus = document.getElementById('registrationLastSyncStatus').value.trim() || 'Not synced';
+            const lastSyncTime = getRegistrationLastSyncTime(source);
+            const isSportsConnect = provider.toLowerCase() === 'sports connect';
+            let connectionStatus = 'Not configured';
+            let helpText = 'Choose Sports Connect and enter a team ID or mapping to store registration metadata.';
+
+            if (provider && externalTeamId) {
+                connectionStatus = isSportsConnect
+                    ? 'Sports Connect metadata configured, not connected'
+                    : 'Registration metadata configured, not connected';
+                helpText = 'Manual refresh / re-import uses already stored roster or schedule data. It does not contact Sports Connect or another provider.';
+            } else if (provider) {
+                connectionStatus = `${provider} selected, mapping needed`;
+                helpText = 'Enter a provider team ID or external mapping before relying on this metadata.';
+            }
+
+            document.getElementById('registration-connection-status').textContent = connectionStatus;
+            document.getElementById('registration-sync-status').textContent = lastSyncStatus;
+            document.getElementById('registration-sync-time').textContent = formatRegistrationSyncTime(lastSyncTime);
+            document.getElementById('registration-connection-help').textContent = helpText;
+        }
+
         function populateRegistrationProviderFields(team = {}) {
             currentRegistrationSource = team.registrationSource && typeof team.registrationSource === 'object'
                 ? { ...team.registrationSource }
                 : null;
-            document.getElementById('registrationProviderName').value = getRegistrationSourceValue(team, 'provider') || getRegistrationSourceValue(team, 'providerName');
+            const provider = getRegistrationSourceValue(team, 'provider') || getRegistrationSourceValue(team, 'providerName');
+            ensureRegistrationProviderOption(provider);
+            document.getElementById('registrationProviderName').value = provider;
             document.getElementById('registrationExternalTeamId').value = getRegistrationSourceValue(team, 'externalTeamId');
-            document.getElementById('registrationLastSyncStatus').value = getRegistrationSourceValue(team, 'lastSyncStatus') || getRegistrationSourceValue(team, 'syncStatus');
+            document.getElementById('registrationLastSyncStatus').value = getRegistrationSourceValue(team, 'lastSyncStatus') || getRegistrationSourceValue(team, 'syncStatus') || 'Not synced';
             document.getElementById('registrationCopiedTeamId').value = currentTeamId || '';
+            renderRegistrationConnectionStatus(currentRegistrationSource || {});
         }
 
         function clearRegistrationProviderFields() {
             document.getElementById('registrationProviderName').value = '';
             document.getElementById('registrationExternalTeamId').value = '';
             document.getElementById('registrationLastSyncStatus').value = '';
+            renderRegistrationConnectionStatus({});
         }
 
         function buildRegistrationSourcePayload() {
@@ -667,8 +763,11 @@
             return {
                 ...(currentTeamId && currentRegistrationSource ? currentRegistrationSource : {}),
                 provider,
+                providerId: getRegistrationProviderId(provider) || null,
                 externalTeamId,
                 teamId: currentTeamId || null,
+                connectionStatus: provider && externalTeamId ? 'metadata_configured' : 'metadata_incomplete',
+                syncEnabled: false,
                 lastSyncStatus: lastSyncStatus || 'Not synced'
             };
         }
@@ -697,9 +796,11 @@
         function applyRegistrationTeam(record) {
             if (!record) return;
             document.getElementById('name').value = record.externalTeamName;
+            ensureRegistrationProviderOption(record.provider);
             document.getElementById('registrationProviderName').value = record.provider;
             document.getElementById('registrationExternalTeamId').value = record.externalTeamId;
             document.getElementById('registrationLastSyncStatus').value = 'Not synced';
+            renderRegistrationConnectionStatus({});
             if (record.sport) {
                 document.getElementById('sport').value = record.sport;
             }
@@ -1212,6 +1313,13 @@
         });
 
         document.getElementById('clear-registration-provider-btn').addEventListener('click', clearRegistrationProviderFields);
+        ['registrationProviderName', 'registrationExternalTeamId', 'registrationLastSyncStatus'].forEach((id) => {
+            document.getElementById(id).addEventListener('input', () => renderRegistrationConnectionStatus(currentRegistrationSource || {}));
+            document.getElementById(id).addEventListener('change', () => renderRegistrationConnectionStatus(currentRegistrationSource || {}));
+        });
+        document.getElementById('registration-refresh-btn').addEventListener('click', () => {
+            alert('Manual re-import uses registration data already stored on this team. No Sports Connect login, sync job, or network fetch is active yet.');
+        });
 
         document.getElementById('copy-team-id-btn').addEventListener('click', async () => {
             if (!currentTeamId) return;

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -712,7 +712,7 @@ describe('edit team admin access persistence', () => {
                 isPublic: true,
                 adminEmails: [],
                 registrationSource: {
-                    provider: 'Sports Connect',
+                    provider: 'sports-connect',
                     externalTeamId: 'SC-123',
                     sourceId: 'sports-connect',
                     externalTeamName: 'Sharks 12U',
@@ -791,7 +791,7 @@ describe('edit team admin access persistence', () => {
 
         const env = await bootEditTeam(initialState);
         try {
-            env.elements.get('registrationProviderName').value = 'Sports Connect';
+            env.elements.get('registrationProviderName').value = 'sports-connect';
             env.elements.get('registrationExternalTeamId').value = 'SC-987';
             await env.elements.get('registrationProviderName').dispatchEvent(new MockEvent('change'));
 
@@ -804,7 +804,7 @@ describe('edit team admin access persistence', () => {
             await env.elements.get('team-form').requestSubmit();
 
             expect(env.state.updateCalls[0].teamData.registrationSource).toEqual({
-                provider: 'Sports Connect',
+                provider: 'sports-connect',
                 providerId: 'sports-connect',
                 externalTeamId: 'SC-987',
                 teamId: 'team-1',

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -251,6 +251,11 @@ function createEnvironment(initialState, overrides = {}) {
         'registrationExternalTeamId',
         'registrationCopiedTeamId',
         'registrationLastSyncStatus',
+        'registration-connection-status',
+        'registration-sync-status',
+        'registration-sync-time',
+        'registration-connection-help',
+        'registration-refresh-btn',
         'clear-registration-provider-btn',
         'save-admin-btn',
         'cancel-admin-btn',
@@ -714,7 +719,11 @@ describe('edit team admin access persistence', () => {
                     season: 'Spring 2026',
                     division: '12U',
                     teamId: 'team-1',
-                    lastSyncStatus: 'Not synced'
+                    providerId: 'sports-connect',
+                    connectionStatus: 'metadata_configured',
+                    syncEnabled: false,
+                    lastSyncStatus: 'Not synced',
+                    lastSyncAt: '2026-05-10T18:30:00.000Z'
                 }
             },
             updateCalls: []
@@ -726,6 +735,9 @@ describe('edit team admin access persistence', () => {
             expect(env.elements.get('registrationExternalTeamId').value).toBe('SC-123');
             expect(env.elements.get('registrationCopiedTeamId').value).toBe('team-1');
             expect(env.elements.get('registrationLastSyncStatus').value).toBe('Not synced');
+            expect(env.elements.get('registration-connection-status').textContent).toBe('Sports Connect metadata configured, not connected');
+            expect(env.elements.get('registration-sync-status').textContent).toBe('Not synced');
+            expect(env.elements.get('registration-sync-time').textContent).toContain('2026');
 
             env.elements.get('registrationProviderName').value = 'League Apps';
             env.elements.get('registrationExternalTeamId').value = 'LA-456';
@@ -741,7 +753,11 @@ describe('edit team admin access persistence', () => {
                 season: 'Spring 2026',
                 division: '12U',
                 teamId: 'team-1',
-                lastSyncStatus: 'Documented only'
+                providerId: null,
+                connectionStatus: 'metadata_configured',
+                syncEnabled: false,
+                lastSyncStatus: 'Documented only',
+                lastSyncAt: '2026-05-10T18:30:00.000Z'
             });
 
             await env.elements.get('clear-registration-provider-btn').click();
@@ -749,6 +765,53 @@ describe('edit team admin access persistence', () => {
 
             expect(env.state.updateCalls).toHaveLength(2);
             expect(env.state.updateCalls[1].teamData.registrationSource).toBeNull();
+        } finally {
+            env.cleanup();
+        }
+    });
+
+    it('saves Sports Connect metadata as configured but not live synced', async () => {
+        const initialState = {
+            currentUser: { uid: 'owner-1', email: 'owner@example.com' },
+            team: {
+                id: 'team-1',
+                ownerId: 'owner-1',
+                name: 'Sharks',
+                description: 'Travel team',
+                sport: 'Basketball',
+                notificationEmail: 'notify@example.com',
+                leagueUrl: '',
+                standingsConfig: { enabled: false, rankingMode: 'points', tiebreakers: [] },
+                zip: '66209',
+                isPublic: true,
+                adminEmails: []
+            },
+            updateCalls: []
+        };
+
+        const env = await bootEditTeam(initialState);
+        try {
+            env.elements.get('registrationProviderName').value = 'Sports Connect';
+            env.elements.get('registrationExternalTeamId').value = 'SC-987';
+            await env.elements.get('registrationProviderName').dispatchEvent(new MockEvent('change'));
+
+            expect(env.elements.get('registration-connection-status').textContent).toBe('Sports Connect metadata configured, not connected');
+            expect(env.elements.get('registration-connection-help').textContent).toContain('does not contact Sports Connect');
+
+            await env.elements.get('registration-refresh-btn').click();
+            expect(env.alerts.at(-1)).toContain('No Sports Connect login, sync job, or network fetch is active yet');
+
+            await env.elements.get('team-form').requestSubmit();
+
+            expect(env.state.updateCalls[0].teamData.registrationSource).toEqual({
+                provider: 'Sports Connect',
+                providerId: 'sports-connect',
+                externalTeamId: 'SC-987',
+                teamId: 'team-1',
+                connectionStatus: 'metadata_configured',
+                syncEnabled: false,
+                lastSyncStatus: 'Not synced'
+            });
         } finally {
             env.cleanup();
         }


### PR DESCRIPTION
Closes #921

## Summary
- Added Sports Connect as a selectable registration provider on Edit Team.
- Added Team ID / external mapping fields plus connection status, last sync status, last sync time, and a manual refresh / re-import entry point.
- Persist registration metadata with `syncEnabled: false` and copy that clearly states no live connector, login, sync job, or network fetch is active.

## Validation
- `npx vitest run tests/unit/edit-team-admin-access-persistence.test.js`