### PR TITLE
Add registration schedule re-import preview

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -916,7 +916,7 @@
         import { normalizeScheduleNotificationSettings, describeScheduleReminderWindow, buildScheduleNotificationMetadata, buildScheduleChangeMessage, buildScheduleNotificationTargets, postScheduleNotificationTargets, buildRsvpReminderMessage } from './js/schedule-notifications.js?v=4';
         import { buildTournamentPoolStandings, buildTournamentPoolOverrideKey } from './js/tournament-standings.js?v=3';
         import { SCHEDULE_CSV_IMPORT_FIELDS, buildScheduleImportPreview, inferScheduleCsvMapping, normalizeScheduleImportDraft, parseCsvText } from './js/schedule-csv-import.js?v=2';
-        import { buildRegistrationScheduleImportPreview, formatRegistrationImportResults, getRegistrationScheduleEvents, isExternallyLinkedRegistrationTeam, planRegistrationScheduleImport } from './js/edit-schedule-registration-import.js?v=2';
+        import { buildRegistrationScheduleImportPreview, formatRegistrationImportResults, getRegistrationScheduleEvents, isExternallyLinkedRegistrationTeam, planRegistrationScheduleImport } from './js/edit-schedule-registration-import.js?v=3';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -1752,7 +1752,13 @@
                 return;
             }
 
-            status.textContent = `${sourceEvents.length} source event${sourceEvents.length === 1 ? '' : 's'} ready to review.`;
+            const lastImport = team.registrationScheduleImportStatus || {};
+            const lastImportedAt = lastImport.importedAt || team.registrationScheduleLastImportedAt;
+            const lastImportedDate = lastImportedAt?.toDate ? lastImportedAt.toDate() : (lastImportedAt ? new Date(lastImportedAt) : null);
+            const lastImportText = lastImportedDate && !Number.isNaN(lastImportedDate.getTime())
+                ? ` Last import: ${formatShortDate(lastImportedDate)} ${formatTime(lastImportedDate)}.`
+                : '';
+            status.textContent = `${sourceEvents.length} source event${sourceEvents.length === 1 ? '' : 's'} ready to review.${lastImportText}`;
             button.disabled = true;
             preview.innerHTML = '<p class="text-sm text-emerald-700">Loading existing schedule conflicts...</p>';
             try {
@@ -1784,6 +1790,8 @@
             const actionClasses = {
                 add: 'bg-green-100 text-green-800',
                 update: 'bg-blue-100 text-blue-800',
+                unchanged: 'bg-gray-100 text-gray-700',
+                duplicate: 'bg-purple-100 text-purple-800',
                 conflict: 'bg-amber-100 text-amber-800',
                 skipped: 'bg-gray-100 text-gray-700'
             };
@@ -1859,6 +1867,24 @@
                         await updateGame(currentTeamId, operation.eventId, operation.payload);
                     }
                 }
+
+                const importMetadata = {
+                    importedAt: Timestamp.now ? Timestamp.now() : new Date().toISOString(),
+                    source: getRegistrationSourceDescriptor(currentTeam),
+                    selectedCount: selectedSourceEvents.length,
+                    results: plan.results
+                };
+                await updateTeam(currentTeamId, {
+                    registrationScheduleImportStatus: importMetadata,
+                    registrationScheduleLastImportedAt: importMetadata.importedAt,
+                    registrationScheduleLastImportResults: plan.results
+                });
+                currentTeam = {
+                    ...currentTeam,
+                    registrationScheduleImportStatus: importMetadata,
+                    registrationScheduleLastImportedAt: importMetadata.importedAt,
+                    registrationScheduleLastImportResults: plan.results
+                };
 
                 status.textContent = `Import complete: ${formatRegistrationImportResults(plan.results)}.`;
                 await renderRegistrationScheduleImport(currentTeam);

--- a/js/edit-schedule-registration-import.js
+++ b/js/edit-schedule-registration-import.js
@@ -34,6 +34,19 @@ function getExistingExternalEventId(event = {}) {
     );
 }
 
+function getSourceKey(source = {}) {
+    return `${normalizeString(source.sourceType || source.type || source.provider || source.name || 'registration').toLowerCase()}::${normalizeString(source.sourceId || source.id || source.providerId || source.registrationSourceId || 'registration').toLowerCase()}`;
+}
+
+function getExistingSourceKey(event = {}) {
+    const metadata = event.sourceMetadata || event.registrationSource || {};
+    return getSourceKey(metadata);
+}
+
+function getExternalEventKey(externalEventId, source = {}) {
+    return `${getSourceKey(source)}::${normalizeString(externalEventId).toLowerCase()}`;
+}
+
 function getComparableTitle(event = {}) {
     return normalizeString(event.opponent || event.title).toLowerCase();
 }
@@ -45,6 +58,24 @@ function isSameLocalEvent(sourceEvent, existingEvent) {
 
     const sourceTitle = normalizeString(sourceEvent.opponent || sourceEvent.title || sourceEvent.summary).toLowerCase();
     return sourceTitle && sourceTitle === getComparableTitle(existingEvent);
+}
+
+function normalizeComparableValue(value) {
+    if (value?.toDate) return normalizeComparableValue(value.toDate());
+    const date = toDate(value);
+    if (date && (value instanceof Date || typeof value === 'string' || value?.toDate)) return date.toISOString();
+    if (value === null || typeof value === 'undefined') return '';
+    return String(value).trim();
+}
+
+function isUnchangedImportedEvent(payload = {}, existingEvent = {}) {
+    const existingType = normalizeString(existingEvent.type || 'game').toLowerCase();
+    const payloadType = normalizeString(payload.type || 'game').toLowerCase();
+    const fields = ['opponent', 'title', 'location', 'notes', 'status', 'isHome'];
+    const fieldMatches = payloadType === existingType && fields.every((field) => normalizeComparableValue(payload[field]) === normalizeComparableValue(existingEvent[field]));
+    const dateMatches = normalizeComparableValue(payload.date) === normalizeComparableValue(existingEvent.date || existingEvent.start || existingEvent.startTime);
+    const endMatches = normalizeComparableValue(payload.end) === normalizeComparableValue(existingEvent.end || existingEvent.endTime || existingEvent.endsAt);
+    return fieldMatches && dateMatches && endMatches;
 }
 
 export function isExternallyLinkedRegistrationTeam(team = {}) {
@@ -77,7 +108,7 @@ export function buildRegistrationScheduleEventPayload(sourceEvent = {}, { Timest
     const rawType = normalizeString(sourceEvent.type || sourceEvent.eventType).toLowerCase();
     const isPractice = rawType === 'practice';
     const toTimestamp = (date) => Timestamp?.fromDate ? Timestamp.fromDate(date) : date;
-    const title = normalizeString(sourceEvent.title || sourceEvent.summary || (isPractice ? 'Practice' : 'Game'));
+    const title = normalizeString(sourceEvent.title || sourceEvent.summary || (isPractice ? 'Practice' : ''));
     const opponent = normalizeString(sourceEvent.opponent || sourceEvent.awayTeam || sourceEvent.homeTeam || title || 'TBD');
     const endDate = toDate(sourceEvent.end || sourceEvent.endTime || sourceEvent.endsAt);
 
@@ -106,24 +137,51 @@ export function buildRegistrationScheduleEventPayload(sourceEvent = {}, { Timest
 }
 
 export function buildRegistrationScheduleImportPreview({ sourceEvents = [], existingEvents = [], Timestamp, source = {} } = {}) {
+    const sourceKey = getSourceKey(source);
     const existingByExternalId = new Map();
     (existingEvents || []).forEach((event) => {
         const externalEventId = getExistingExternalEventId(event);
-        if (externalEventId) existingByExternalId.set(externalEventId, event);
+        if (!externalEventId) return;
+        existingByExternalId.set(getExternalEventKey(externalEventId, event.sourceMetadata || event.registrationSource || source), event);
+        if (!event.sourceMetadata?.sourceType && !event.sourceMetadata?.sourceId && !event.registrationSource?.sourceType && !event.registrationSource?.sourceId) {
+            existingByExternalId.set(getExternalEventKey(externalEventId, source), event);
+        }
     });
 
     const seenExternalIds = new Set();
     return (sourceEvents || []).map((sourceEvent, index) => {
         const externalEventId = getExternalEventId(sourceEvent);
+        const eventKey = getExternalEventKey(externalEventId, source);
         const payload = buildRegistrationScheduleEventPayload(sourceEvent, { Timestamp, source });
-        if (!externalEventId || seenExternalIds.has(externalEventId) || !payload) {
-            return { index, sourceEvent, payload, externalEventId, action: 'skipped', selectable: false, reason: 'Missing or duplicate source event id/date' };
+        if (!externalEventId || !payload) {
+            return { index, sourceEvent, payload, externalEventId, action: 'skipped', selectable: false, reason: 'Missing source event id or date' };
         }
-        seenExternalIds.add(externalEventId);
+        if (seenExternalIds.has(eventKey)) {
+            return { index, sourceEvent, payload, externalEventId, action: 'duplicate', selectable: false, reason: 'Duplicate source event in the registration snapshot' };
+        }
+        seenExternalIds.add(eventKey);
 
-        const existing = existingByExternalId.get(externalEventId);
+        const existing = existingByExternalId.get(eventKey);
         if (existing?.id) {
-            return { index, sourceEvent, payload, externalEventId, action: 'update', selectable: true, existingEventId: existing.id, reason: 'Matches an imported event' };
+            const unchanged = isUnchangedImportedEvent(payload, existing);
+            return {
+                index,
+                sourceEvent,
+                payload,
+                externalEventId,
+                action: unchanged ? 'unchanged' : 'update',
+                selectable: !unchanged,
+                existingEventId: existing.id,
+                reason: unchanged ? 'Already matches the imported event' : 'Matches an imported event with changes'
+            };
+        }
+
+        const conflictingImportedEvent = (existingEvents || []).find((candidate) => {
+            const candidateExternalEventId = getExistingExternalEventId(candidate);
+            return candidateExternalEventId === externalEventId && getExistingSourceKey(candidate) !== sourceKey;
+        });
+        if (conflictingImportedEvent) {
+            return { index, sourceEvent, payload, externalEventId, action: 'conflict', selectable: false, existingEventId: conflictingImportedEvent.id || null, reason: 'Source event id is already linked to a different registration source' };
         }
 
         const conflict = (existingEvents || []).find((candidate) => !getExistingExternalEventId(candidate) && isSameLocalEvent(sourceEvent, candidate));
@@ -140,6 +198,8 @@ export function planRegistrationScheduleImport({ sourceEvents = [], existingEven
     const results = {
         added: 0,
         updated: 0,
+        unchanged: 0,
+        duplicates: 0,
         skipped: 0,
         conflicted: 0,
         conflicts: []
@@ -148,6 +208,14 @@ export function planRegistrationScheduleImport({ sourceEvents = [], existingEven
     buildRegistrationScheduleImportPreview({ sourceEvents, existingEvents, Timestamp, source }).forEach((row) => {
         if (row.action === 'skipped') {
             results.skipped += 1;
+            return;
+        }
+        if (row.action === 'duplicate') {
+            results.duplicates += 1;
+            return;
+        }
+        if (row.action === 'unchanged') {
+            results.unchanged += 1;
             return;
         }
         if (row.action === 'conflict') {
@@ -172,5 +240,5 @@ export function planRegistrationScheduleImport({ sourceEvents = [], existingEven
 }
 
 export function formatRegistrationImportResults(results = {}) {
-    return `${results.added || 0} added, ${results.updated || 0} updated, ${results.skipped || 0} skipped, ${results.conflicted || 0} conflicted`;
+    return `${results.added || 0} added, ${results.updated || 0} updated, ${results.unchanged || 0} unchanged, ${results.duplicates || 0} duplicate, ${results.skipped || 0} skipped, ${results.conflicted || 0} conflicted`;
 }

--- a/tests/unit/edit-schedule-registration-import.test.js
+++ b/tests/unit/edit-schedule-registration-import.test.js
@@ -75,7 +75,8 @@ describe('registration schedule import planning', () => {
         expect(plan.results).toMatchObject({
             added: 1,
             updated: 1,
-            skipped: 1,
+            duplicates: 1,
+            skipped: 0,
             conflicted: 1
         });
         expect(plan.results.conflicts).toEqual([{ externalEventId: 'ext-2', existingEventId: 'game-2' }]);
@@ -105,10 +106,25 @@ describe('registration schedule import planning', () => {
         });
     });
 
-    it('builds preview rows for selectable imports and local conflicts', () => {
+    it('builds preview rows for selectable imports, unchanged entries, duplicates, and local conflicts', () => {
         const rows = buildRegistrationScheduleImportPreview({
             Timestamp,
+            source: { type: 'sports-connect', id: 'league-1' },
             sourceEvents: [
+                {
+                    externalEventId: 'ext-new',
+                    type: 'practice',
+                    start: '2026-05-01T18:00:00.000Z',
+                    title: 'Practice',
+                    location: 'Gym'
+                },
+                {
+                    externalEventId: 'ext-same',
+                    type: 'game',
+                    start: '2026-05-02T18:00:00.000Z',
+                    opponent: 'Bears',
+                    location: 'Field 2'
+                },
                 {
                     externalEventId: 'ext-new',
                     type: 'practice',
@@ -119,15 +135,23 @@ describe('registration schedule import planning', () => {
                 {
                     externalEventId: 'ext-conflict',
                     type: 'game',
-                    start: '2026-05-02T18:00:00.000Z',
+                    start: '2026-05-03T18:00:00.000Z',
                     opponent: 'Bears'
                 }
             ],
             existingEvents: [
                 {
-                    id: 'game-2',
+                    id: 'game-same',
                     type: 'game',
                     date: new Date('2026-05-02T18:00:00.000Z'),
+                    opponent: 'Bears',
+                    location: 'Field 2',
+                    sourceMetadata: { sourceType: 'sports-connect', sourceId: 'league-1', externalEventId: 'ext-same' }
+                },
+                {
+                    id: 'game-2',
+                    type: 'game',
+                    date: new Date('2026-05-03T18:00:00.000Z'),
                     opponent: 'Bears'
                 }
             ]
@@ -135,13 +159,15 @@ describe('registration schedule import planning', () => {
 
         expect(rows).toEqual([
             expect.objectContaining({ action: 'add', selectable: true, payload: expect.objectContaining({ type: 'practice', title: 'Practice', location: 'Gym' }) }),
+            expect.objectContaining({ action: 'unchanged', selectable: false, existingEventId: 'game-same' }),
+            expect.objectContaining({ action: 'duplicate', selectable: false }),
             expect.objectContaining({ action: 'conflict', selectable: false, existingEventId: 'game-2' })
         ]);
     });
 
     it('formats import result counts for the UI', () => {
-        expect(formatRegistrationImportResults({ added: 2, updated: 1, skipped: 0, conflicted: 3 }))
-            .toBe('2 added, 1 updated, 0 skipped, 3 conflicted');
+        expect(formatRegistrationImportResults({ added: 2, updated: 1, unchanged: 4, duplicates: 1, skipped: 0, conflicted: 3 }))
+            .toBe('2 added, 1 updated, 4 unchanged, 1 duplicate, 0 skipped, 3 conflicted');
     });
 });
 
@@ -152,9 +178,11 @@ describe('registration schedule import wiring', () => {
         expect(source).toContain('id="registration-schedule-import"');
         expect(source).toContain('id="registration-schedule-import-preview"');
         expect(source).toContain('Import Selected');
-        expect(source).toContain("import { buildRegistrationScheduleImportPreview, formatRegistrationImportResults, getRegistrationScheduleEvents, isExternallyLinkedRegistrationTeam, planRegistrationScheduleImport } from './js/edit-schedule-registration-import.js?v=2';");
+        expect(source).toContain("import { buildRegistrationScheduleImportPreview, formatRegistrationImportResults, getRegistrationScheduleEvents, isExternallyLinkedRegistrationTeam, planRegistrationScheduleImport } from './js/edit-schedule-registration-import.js?v=3';");
         expect(source).toContain('buildRegistrationScheduleImportPreview({');
         expect(source).toContain('registration-schedule-import-choice:checked');
         expect(source).toContain('sourceMetadata?.externalEventId');
+        expect(source).toContain('registrationScheduleImportStatus');
+        expect(source).toContain('registrationScheduleLastImportedAt');
     });
 });


### PR DESCRIPTION
Closes #923

## Summary
- Adds registration schedule preview labels for add, update, unchanged, duplicate, and conflict states.
- Applies only selected non-conflicting registration schedule changes while leaving conflicts untouched.
- Stores registration source metadata on imported events and persists visible last import metadata on the team.

## Tests
- `npx vitest run tests/unit/edit-schedule-registration-import.test.js`