### PR TITLE
Resolve merged PR review follow-ups

### DIFF
--- a/certificates.html
+++ b/certificates.html
@@ -96,7 +96,7 @@
 
     <div id="footer-container"></div>
 
-    <script type="module" src="./js/certificates/studio.js?v=7"></script>
+    <script type="module" src="./js/certificates/studio.js?v=8"></script>
 </body>
 
 </html>

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -909,14 +909,14 @@
         import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=1';
         import { buildSeasonRecordGameFields, hydrateSeasonRecordFormFields } from './js/edit-schedule-season-record.js?v=1';
         import { normalizeOfficialsDirectory } from './js/officiating-slots.js?v=1';
-        import { Timestamp, deleteField } from "./js/firebase.js?v=11";
+        import { Timestamp, deleteField } from "./js/firebase.js?v=12";
         import { getApp } from './js/vendor/firebase-app.js';
         import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
         import { buildPoolStandingsIndex, collectTournamentAdvancementPatches, collectTournamentPoolSeeds, describeTournamentSource, planTournamentPoolAdvancement } from './js/tournament-brackets.js?v=1';
         import { normalizeScheduleNotificationSettings, describeScheduleReminderWindow, buildScheduleNotificationMetadata, buildScheduleChangeMessage, buildScheduleNotificationTargets, postScheduleNotificationTargets, buildRsvpReminderMessage } from './js/schedule-notifications.js?v=4';
         import { buildTournamentPoolStandings, buildTournamentPoolOverrideKey } from './js/tournament-standings.js?v=3';
         import { SCHEDULE_CSV_IMPORT_FIELDS, buildScheduleImportPreview, inferScheduleCsvMapping, normalizeScheduleImportDraft, parseCsvText } from './js/schedule-csv-import.js?v=2';
-        import { buildRegistrationScheduleImportPreview, formatRegistrationImportResults, getRegistrationScheduleEvents, isExternallyLinkedRegistrationTeam, planRegistrationScheduleImport } from './js/edit-schedule-registration-import.js?v=3';
+        import { buildRegistrationScheduleImportPreview, formatRegistrationImportResults, getRegistrationScheduleEvents, isExternallyLinkedRegistrationTeam, planRegistrationScheduleImport } from './js/edit-schedule-registration-import.js?v=4';
 
         renderFooter(document.getElementById('footer-container'));
 

--- a/js/certificates/assets.js
+++ b/js/certificates/assets.js
@@ -1,4 +1,4 @@
-import { imageStorage, requireImageAuth } from '../firebase-images.js?v=4';
+import { imageStorage, requireImageAuth } from '../firebase-images.js?v=6';
 import {
     db,
     collection,
@@ -7,7 +7,7 @@ import {
     ref,
     uploadBytes,
     getDownloadURL
-} from '../firebase.js?v=11';
+} from '../firebase.js?v=12';
 
 const MAX_CERTIFICATE_ASSET_BYTES = 5 * 1024 * 1024;
 const ALLOWED_CERTIFICATE_IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/jpg', 'image/webp']);

--- a/js/certificates/studio.js
+++ b/js/certificates/studio.js
@@ -135,6 +135,20 @@ function hideLoading() {
 function showStudio() {
     document.getElementById('cert-studio')?.classList.remove('hidden');
     document.getElementById('cert-parent-view')?.classList.add('hidden');
+    setCoachActionButtonsVisible(true);
+}
+
+function setCoachActionButtonsVisible(visible) {
+    ['cert-new-run-btn', 'cert-view-saved-btn', 'cert-custom-recipient-btn'].forEach((id) => {
+        document.getElementById(id)?.classList.toggle('hidden', !visible);
+    });
+}
+
+function runCoachCertificateAction(action) {
+    const hasCoachStudioAccess = state.demoMode ||
+        (state.accessInfo?.hasAccess === true && state.accessInfo?.accessLevel !== 'parent');
+    if (!hasCoachStudioAccess || !state.shared) return;
+    action();
 }
 
 function getDefaultCustomColors(team = {}) {
@@ -852,7 +866,7 @@ function bindSetupEvents() {
                 renderSetup();
                 schedulePreviewRender();
 
-                const { uploadCertificateAsset } = await import('./assets.js?v=1');
+                const { uploadCertificateAsset } = await import('./assets.js?v=2');
                 const asset = await uploadCertificateAsset(state.teamId, file, kind, state.user?.uid || null);
                 state.assets.unshift(asset);
                 state.shared[slot] = asset;
@@ -899,7 +913,7 @@ function bindSetupEvents() {
             if (!file) return;
             const index = Number(input.dataset.signatureUpload);
             try {
-                const { uploadSignatureImage } = await import('./assets.js?v=1');
+                const { uploadSignatureImage } = await import('./assets.js?v=2');
                 const result = await uploadSignatureImage(state.user?.uid, file);
                 state.shared.signers[index].signatureStyle = 'image';
                 state.shared.signers[index].signatureImageUrl = result.url;
@@ -2017,6 +2031,7 @@ async function printSelectedDrafts() {
 function renderParentView(certificatesByPlayer = []) {
     hideLoading();
     document.getElementById('cert-studio')?.classList.add('hidden');
+    setCoachActionButtonsVisible(false);
     const container = document.getElementById('cert-parent-view');
     container.classList.remove('hidden');
     const certificates = certificatesByPlayer.flatMap((entry) => entry.certificates.map((cert) => ({ ...cert, playerName: entry.playerName })));
@@ -2042,6 +2057,7 @@ function renderParentView(certificatesByPlayer = []) {
 function renderParentCertificateDetail(certificate) {
     hideLoading();
     document.getElementById('cert-studio')?.classList.add('hidden');
+    setCoachActionButtonsVisible(false);
     const container = document.getElementById('cert-parent-view');
     container.classList.remove('hidden');
 
@@ -2333,9 +2349,9 @@ async function initAuthenticated(params) {
     });
 }
 
-document.getElementById('cert-new-run-btn')?.addEventListener('click', showSetupMode);
-document.getElementById('cert-view-saved-btn')?.addEventListener('click', showSavedWorkMode);
-document.getElementById('cert-custom-recipient-btn')?.addEventListener('click', startCustomCertificate);
+document.getElementById('cert-new-run-btn')?.addEventListener('click', () => runCoachCertificateAction(showSetupMode));
+document.getElementById('cert-view-saved-btn')?.addEventListener('click', () => runCoachCertificateAction(showSavedWorkMode));
+document.getElementById('cert-custom-recipient-btn')?.addEventListener('click', () => runCoachCertificateAction(startCustomCertificate));
 document.getElementById('cert-mobile-preview-btn')?.addEventListener('click', () => {
     document.getElementById(state.mode === 'review' ? 'cert-review-preview' : 'cert-preview')?.scrollIntoView({ behavior: 'smooth' });
 });

--- a/js/edit-schedule-registration-import.js
+++ b/js/edit-schedule-registration-import.js
@@ -72,9 +72,13 @@ function isUnchangedImportedEvent(payload = {}, existingEvent = {}) {
     const existingType = normalizeString(existingEvent.type || 'game').toLowerCase();
     const payloadType = normalizeString(payload.type || 'game').toLowerCase();
     const fields = ['opponent', 'title', 'location', 'notes', 'status', 'isHome'];
-    const fieldMatches = payloadType === existingType && fields.every((field) => normalizeComparableValue(payload[field]) === normalizeComparableValue(existingEvent[field]));
+    const fieldMatches = payloadType === existingType && fields.every((field) => (
+        !Object.prototype.hasOwnProperty.call(payload, field) ||
+        normalizeComparableValue(payload[field]) === normalizeComparableValue(existingEvent[field])
+    ));
     const dateMatches = normalizeComparableValue(payload.date) === normalizeComparableValue(existingEvent.date || existingEvent.start || existingEvent.startTime);
-    const endMatches = normalizeComparableValue(payload.end) === normalizeComparableValue(existingEvent.end || existingEvent.endTime || existingEvent.endsAt);
+    const endMatches = !Object.prototype.hasOwnProperty.call(payload, 'end') ||
+        normalizeComparableValue(payload.end) === normalizeComparableValue(existingEvent.end || existingEvent.endTime || existingEvent.endsAt);
     return fieldMatches && dateMatches && endMatches;
 }
 
@@ -130,7 +134,7 @@ export function buildRegistrationScheduleEventPayload(sourceEvent = {}, { Timest
     } else {
         payload.opponent = opponent || 'TBD';
         payload.title = title || null;
-        payload.isHome = typeof sourceEvent.isHome === 'boolean' ? sourceEvent.isHome : null;
+        if (typeof sourceEvent.isHome === 'boolean') payload.isHome = sourceEvent.isHome;
     }
 
     return payload;

--- a/js/firebase-images.js
+++ b/js/firebase-images.js
@@ -1,7 +1,7 @@
 import { initializeApp, getApps } from "./vendor/firebase-app.js";
 import { getStorage } from "./vendor/firebase-storage.js";
 import { getAuth, signInAnonymously, onAuthStateChanged, setPersistence, browserLocalPersistence } from "./vendor/firebase-auth.js";
-import { resolveImageFirebaseConfig } from "./firebase-runtime-config.js?v=4";
+import { resolveImageFirebaseConfig } from "./firebase-runtime-config.js?v=5";
 
 const imgConfig = resolveImageFirebaseConfig();
 

--- a/js/firebase-runtime-config.js
+++ b/js/firebase-runtime-config.js
@@ -30,11 +30,6 @@ function readWindowGlobal(name) {
     return typeof window !== 'undefined' ? window[name] : undefined;
 }
 
-function isLocalHost() {
-    if (typeof window === 'undefined') return false;
-    return ['localhost', '127.0.0.1', ''].includes(window.location.hostname);
-}
-
 function normalizeFirebaseConfig(rawConfig) {
     if (!rawConfig || typeof rawConfig !== 'object') {
         return null;
@@ -79,9 +74,6 @@ export async function resolvePrimaryFirebaseConfig() {
 
     try {
         const hostedConfig = await fetchFirebaseConfigFromHosting();
-        if (isLocalHost() && hostedConfig.projectId?.startsWith('demo-')) {
-            return { ...DEFAULT_PRIMARY_FIREBASE_CONFIG };
-        }
         return hostedConfig;
     } catch (error) {
         console.warn('Falling back to bundled Firebase config.', error);

--- a/js/firebase.js
+++ b/js/firebase.js
@@ -47,7 +47,7 @@ import {
     runTransaction
 } from "./vendor/firebase-firestore.js";
 import { getStorage, ref, uploadBytes, getDownloadURL, deleteObject } from "./vendor/firebase-storage.js";
-import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=4";
+import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=5";
 
 const firebaseConfig = await resolvePrimaryFirebaseConfig();
 

--- a/tests/smoke/edit-schedule-calendar-cancelled-import.spec.js
+++ b/tests/smoke/edit-schedule-calendar-cancelled-import.spec.js
@@ -302,7 +302,7 @@ async function mockEditScheduleDependencies(page) {
     await page.route('**/js/edit-schedule-cancel-game.js?v=3', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: CANCEL_GAME_STUB }));
     await page.route('**/js/edit-schedule-practice-payload.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: PRACTICE_PAYLOAD_STUB }));
     await page.route('**/js/edit-schedule-practice-submit.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: PRACTICE_SUBMIT_STUB }));
-    await page.route('**/js/firebase.js?v=11', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_STUB }));
+    await page.route('**/js/firebase.js?v=*', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_STUB }));
     await page.route('**/js/vendor/firebase-app.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_APP_STUB }));
     await page.route('**/js/vendor/firebase-ai.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_AI_STUB }));
     await page.route('**/js/tournament-brackets.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TOURNAMENT_STUB }));

--- a/tests/smoke/team-schedule-calendar.spec.js
+++ b/tests/smoke/team-schedule-calendar.spec.js
@@ -400,7 +400,7 @@ async function mockTeamPageModules(page, scenario) {
         contentType: 'application/javascript',
         body: AUTH_STUB
     }));
-    await page.route('**/js/firebase.js?v=11', (route) => route.fulfill({
+    await page.route('**/js/firebase.js?v=*', (route) => route.fulfill({
         status: 200,
         contentType: 'application/javascript',
         body: FIREBASE_STUB

--- a/tests/unit/certificates-assets.test.js
+++ b/tests/unit/certificates-assets.test.js
@@ -9,12 +9,12 @@ const mocks = vi.hoisted(() => ({
     ref: vi.fn()
 }));
 
-vi.mock('../../js/firebase-images.js?v=4', () => ({
+vi.mock('../../js/firebase-images.js?v=6', () => ({
     imageStorage: {},
     requireImageAuth: mocks.requireImageAuth
 }));
 
-vi.mock('../../js/firebase.js?v=11', () => ({
+vi.mock('../../js/firebase.js?v=12', () => ({
     db: {},
     collection: mocks.collection,
     addDoc: mocks.addDoc,

--- a/tests/unit/certificates-workflow.test.js
+++ b/tests/unit/certificates-workflow.test.js
@@ -23,7 +23,7 @@ describe('awards and certificates workflow wiring', () => {
         expect(html).toContain('Start new run');
         expect(html).toContain('View saved work');
         expect(html).toContain('Create one-off certificate');
-        expect(html).toContain('./js/certificates/studio.js?v=7');
+        expect(html).toContain('./js/certificates/studio.js?v=8');
         expect(studio).toContain("from './templates.js?v=2'");
         expect(studio).toContain("from './renderer.js?v=2'");
         expect(studio).toContain("from './aiDescriptions.js?v=4'");
@@ -60,6 +60,8 @@ describe('awards and certificates workflow wiring', () => {
         expect(studio).toContain('cert-parent-png-btn');
         expect(studio).toContain('getParentCertificateLinks');
         expect(studio).toContain('parentPlayerKeys');
+        expect(studio).toContain('setCoachActionButtonsVisible(false)');
+        expect(studio).toContain("runCoachCertificateAction(showSetupMode)");
         expect(studio).toContain('saveDraftsToLocalHistory');
         expect(studio).toContain('startCustomCertificate');
         expect(studio).toContain('selectRecentCompletedGames');

--- a/tests/unit/edit-schedule-registration-import.test.js
+++ b/tests/unit/edit-schedule-registration-import.test.js
@@ -146,6 +146,8 @@ describe('registration schedule import planning', () => {
                     date: new Date('2026-05-02T18:00:00.000Z'),
                     opponent: 'Bears',
                     location: 'Field 2',
+                    status: 'scheduled',
+                    isHome: true,
                     sourceMetadata: { sourceType: 'sports-connect', sourceId: 'league-1', externalEventId: 'ext-same' }
                 },
                 {
@@ -178,7 +180,7 @@ describe('registration schedule import wiring', () => {
         expect(source).toContain('id="registration-schedule-import"');
         expect(source).toContain('id="registration-schedule-import-preview"');
         expect(source).toContain('Import Selected');
-        expect(source).toContain("import { buildRegistrationScheduleImportPreview, formatRegistrationImportResults, getRegistrationScheduleEvents, isExternallyLinkedRegistrationTeam, planRegistrationScheduleImport } from './js/edit-schedule-registration-import.js?v=3';");
+        expect(source).toContain("import { buildRegistrationScheduleImportPreview, formatRegistrationImportResults, getRegistrationScheduleEvents, isExternallyLinkedRegistrationTeam, planRegistrationScheduleImport } from './js/edit-schedule-registration-import.js?v=4';");
         expect(source).toContain('buildRegistrationScheduleImportPreview({');
         expect(source).toContain('registration-schedule-import-choice:checked');
         expect(source).toContain('sourceMetadata?.externalEventId');

--- a/tests/unit/firebase-runtime-config.test.js
+++ b/tests/unit/firebase-runtime-config.test.js
@@ -43,6 +43,29 @@ describe('firebase runtime config', () => {
         expect(globalThis.fetch).toHaveBeenCalledOnce();
     });
 
+    it('keeps hosted demo firebase config when served through local Firebase hosting', async () => {
+        resetGlobals();
+        globalThis.fetch = vi.fn().mockResolvedValue({
+            ok: true,
+            json: async () => ({
+                apiKey: 'demo-key',
+                authDomain: 'demo-allplays.firebaseapp.com',
+                projectId: 'demo-allplays',
+                messagingSenderId: '123',
+                appId: 'demo-app'
+            })
+        });
+
+        const config = await resolvePrimaryFirebaseConfig();
+
+        expect(config).toMatchObject({
+            apiKey: 'demo-key',
+            authDomain: 'demo-allplays.firebaseapp.com',
+            projectId: 'demo-allplays',
+            appId: 'demo-app'
+        });
+    });
+
     it('returns the bundled image firebase config when no inline image config is present', () => {
         resetGlobals();
 


### PR DESCRIPTION
## Summary
- Preserve unchanged registration schedule imports when optional provider fields are absent
- Keep hosted demo Firebase config from local Firebase hosting instead of falling back to production config
- Hide and guard certificate setup actions for parent-only certificate views

## Local checks
- npx vitest run tests/unit/edit-schedule-registration-import.test.js tests/unit/firebase-runtime-config.test.js tests/unit/certificates-workflow.test.js
- node --check js/edit-schedule-registration-import.js && node --check js/firebase-runtime-config.js && node --check js/certificates/studio.js && node --check js/firebase.js && node --check js/firebase-images.js
- GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=master node scripts/check-critical-cache-bust.mjs
- node scripts/validate-firebase-rules-ci.mjs
- git diff --check
- npx playwright test tests/smoke/certificates-workflow.spec.js --config=playwright.smoke.config.js --reporter=line