### PR TITLE
Restrict officiating slot self-assignment

### DIFF
--- a/docs/pr-notes/runs/933-remediator-20260511T061313Z/architecture.md
+++ b/docs/pr-notes/runs/933-remediator-20260511T061313Z/architecture.md
@@ -1,0 +1,9 @@
+# Architecture
+
+- The server-authoritative Firestore rule must remain the source of truth for direct writes.
+- Since `playerTeamIds` has no writer, keeping it in either client or rules creates a broken policy branch and misleading UI copy.
+- Minimal safe remediation is to remove that unsupported branch rather than broadening rules to all signed-in users.
+- Future roster-member self-assignment should add a populated, rules-verifiable membership index before reintroducing roster-member language.
+
+## Risks And Rollback
+- Scope narrows the advertised policy to actually enforceable roles. Rollback is reverting this commit if a populated roster-member identity field is later added.

--- a/docs/pr-notes/runs/933-remediator-20260511T061313Z/code-plan.md
+++ b/docs/pr-notes/runs/933-remediator-20260511T061313Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code Plan
+
+1. Remove `playerTeamIds` eligibility checks from `officials.html`, `js/db.js`, and `firestore.rules`.
+2. Update user-facing copy and thrown error text to list only supported eligible roles.
+3. Update `tests/unit/officiating-slots.test.js` string assertions.
+4. Run targeted unit test and commit scoped changes.

--- a/docs/pr-notes/runs/933-remediator-20260511T061313Z/qa.md
+++ b/docs/pr-notes/runs/933-remediator-20260511T061313Z/qa.md
@@ -1,0 +1,5 @@
+# QA Plan
+
+- Run the targeted officiating unit guard: `npx vitest run tests/unit/officiating-slots.test.js`.
+- Verify source guards no longer contain `playerTeamIds` for open officiating slot claim eligibility.
+- Manual follow-up for PR: sign in as owner/admin/parent and verify open slot claim remains visible and claim succeeds; sign in as unrelated user and verify open slots are hidden and direct update is denied.

--- a/docs/pr-notes/runs/933-remediator-20260511T061313Z/requirements.md
+++ b/docs/pr-notes/runs/933-remediator-20260511T061313Z/requirements.md
@@ -1,0 +1,12 @@
+# Requirements
+
+- Address PR review feedback by removing officiating self-assignment eligibility dependence on `users/{uid}.playerTeamIds`, because the field is not populated anywhere in the app.
+- Preserve current working access paths: team owner, team admin email, global admin, and confirmed parent team membership via `parentTeamIds`.
+- Keep unauthorized users from adding themselves to officiating authorization arrays through direct Firestore writes.
+- Update guard tests so they no longer encode the unsupported `playerTeamIds` policy.
+
+## Acceptance Criteria
+- `js/db.js` no longer grants claim eligibility from `userProfile.playerTeamIds`.
+- `firestore.rules` no longer grants open slot claim updates from `playerTeamIds`.
+- `officials.html` copy and UI gate match the supported eligible participant set.
+- Unit guard for officiating slots passes.

--- a/firestore.rules
+++ b/firestore.rules
@@ -442,12 +442,8 @@ service cloud.firestore {
     }
 
     function canClaimOpenOfficiatingSlot(teamId) {
-      let userPath = /databases/$(database)/documents/users/$(request.auth.uid);
       return isTeamOwnerOrAdmin(teamId) ||
-             isParentForTeam(teamId) ||
-             (isSignedIn() &&
-              exists(userPath) &&
-              teamId in get(userPath).data.get('playerTeamIds', []));
+             isParentForTeam(teamId);
     }
 
     function isOpenOfficiatingSelfAssignmentUpdate(teamId) {

--- a/firestore.rules
+++ b/firestore.rules
@@ -441,8 +441,17 @@ service cloud.firestore {
              );
     }
 
-    function isOpenOfficiatingSelfAssignmentUpdate() {
-      return isSignedIn() &&
+    function canClaimOpenOfficiatingSlot(teamId) {
+      let userPath = /databases/$(database)/documents/users/$(request.auth.uid);
+      return isTeamOwnerOrAdmin(teamId) ||
+             isParentForTeam(teamId) ||
+             (isSignedIn() &&
+              exists(userPath) &&
+              teamId in get(userPath).data.get('playerTeamIds', []));
+    }
+
+    function isOpenOfficiatingSelfAssignmentUpdate(teamId) {
+      return canClaimOpenOfficiatingSlot(teamId) &&
              resource.data.get('officiatingSelfAssignmentEnabled', false) == true &&
              request.resource.data.get('officiatingSelfAssignmentEnabled', false) == true &&
              request.resource.data.diff(resource.data).affectedKeys().hasOnly([
@@ -1018,7 +1027,7 @@ service cloud.firestore {
                         (isOfficialForGame() && isOfficialGameUpdate()) ||
                         isScorekeepingGameUpdate(teamId, gameId) ||
                         isVideographyGameUpdate(teamId, gameId);
-        allow update: if isOpenOfficiatingSelfAssignmentUpdate();
+        allow update: if isOpenOfficiatingSelfAssignmentUpdate(teamId);
 
         // Events subcollection
         match /events/{eventId} {

--- a/js/db.js
+++ b/js/db.js
@@ -5164,7 +5164,27 @@ export async function respondToOfficiatingAssignment(teamId, gameId, slotId, sta
     await tryCreateOfficiatingAssignmentNotificationRecords(teamId, notificationRecord ? [notificationRecord] : []);
 }
 
+function isEligibleOpenOfficiatingSlotParticipant(team = {}, userProfile = {}, user = {}) {
+    const uid = String(user?.uid || '').trim();
+    const email = String(user?.email || '').trim().toLowerCase();
+    if (!uid) return false;
+    if (team.ownerId === uid) return true;
+    if (email && Array.isArray(team.adminEmails) && team.adminEmails.map((adminEmail) => String(adminEmail || '').trim().toLowerCase()).includes(email)) return true;
+    if (userProfile?.isAdmin === true) return true;
+    if (Array.isArray(userProfile?.parentTeamIds) && userProfile.parentTeamIds.includes(team.id)) return true;
+    if (Array.isArray(userProfile?.playerTeamIds) && userProfile.playerTeamIds.includes(team.id)) return true;
+    return false;
+}
+
 export async function claimOpenOfficiatingSlot(teamId, gameId, slotId, official = auth.currentUser) {
+    const [team, userProfile] = await Promise.all([
+        getTeam(teamId, { includeInactive: true }),
+        official?.uid ? getUserProfile(official.uid) : Promise.resolve(null)
+    ]);
+    if (!isEligibleOpenOfficiatingSlotParticipant(team || {}, userProfile || {}, official || {})) {
+        throw new Error('Only team owners, admins, parents, or roster members can claim open officiating slots.');
+    }
+
     const docRef = getGameDocRef(teamId, gameId);
     let notificationRecord = null;
     await runTransaction(db, async (transaction) => {

--- a/js/db.js
+++ b/js/db.js
@@ -5172,7 +5172,6 @@ function isEligibleOpenOfficiatingSlotParticipant(team = {}, userProfile = {}, u
     if (email && Array.isArray(team.adminEmails) && team.adminEmails.map((adminEmail) => String(adminEmail || '').trim().toLowerCase()).includes(email)) return true;
     if (userProfile?.isAdmin === true) return true;
     if (Array.isArray(userProfile?.parentTeamIds) && userProfile.parentTeamIds.includes(team.id)) return true;
-    if (Array.isArray(userProfile?.playerTeamIds) && userProfile.playerTeamIds.includes(team.id)) return true;
     return false;
 }
 
@@ -5182,7 +5181,7 @@ export async function claimOpenOfficiatingSlot(teamId, gameId, slotId, official 
         official?.uid ? getUserProfile(official.uid) : Promise.resolve(null)
     ]);
     if (!isEligibleOpenOfficiatingSlotParticipant(team || {}, userProfile || {}, official || {})) {
-        throw new Error('Only team owners, admins, parents, or roster members can claim open officiating slots.');
+        throw new Error('Only team owners, admins, or parents can claim open officiating slots.');
     }
 
     const docRef = getGameDocRef(teamId, gameId);

--- a/officials.html
+++ b/officials.html
@@ -110,14 +110,13 @@
             if (normalizeEmail(user.email) && Array.isArray(team.adminEmails) && team.adminEmails.map(normalizeEmail).includes(normalizeEmail(user.email))) return true;
             if (userProfile?.isAdmin === true) return true;
             if (Array.isArray(userProfile?.parentTeamIds) && userProfile.parentTeamIds.includes(team.id)) return true;
-            if (Array.isArray(userProfile?.playerTeamIds) && userProfile.playerTeamIds.includes(team.id)) return true;
             return false;
         }
 
         function renderOpenSlots() {
             const container = document.getElementById('open-slots');
             if (!canClaimOpenSlots) {
-                container.innerHTML = '<div class="p-4 text-sm text-gray-500">Open self-assignment slots are only available to team owners, admins, parents, or roster members.</div>';
+                container.innerHTML = '<div class="p-4 text-sm text-gray-500">Open self-assignment slots are only available to team owners, admins, or parents.</div>';
                 return;
             }
 

--- a/officials.html
+++ b/officials.html
@@ -42,7 +42,7 @@
 
     <script type="module">
         import { checkAuth } from './js/auth.js?v=14';
-        import { getGames, claimOpenOfficiatingSlot, respondToOfficiatingAssignment } from './js/db.js?v=31';
+        import { getGames, getTeam, getUserProfile, claimOpenOfficiatingSlot, respondToOfficiatingAssignment } from './js/db.js?v=32';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime, escapeHtml } from './js/utils.js?v=10';
         import { getAssignedOfficiatingSlots, getOpenOfficiatingSlots } from './js/officiating-utils.js?v=3';
 
@@ -51,6 +51,9 @@
         const params = getUrlParams();
         const teamId = params.teamId;
         let currentUser = null;
+        let currentTeam = null;
+        let currentUserProfile = null;
+        let canClaimOpenSlots = false;
         let games = [];
 
         function toDate(value) {
@@ -97,8 +100,27 @@
             `).join('');
         }
 
+        function normalizeEmail(email) {
+            return String(email || '').trim().toLowerCase();
+        }
+
+        function isEligibleOpenSlotParticipant(user, userProfile, team) {
+            if (!user?.uid || !team) return false;
+            if (team.ownerId === user.uid) return true;
+            if (normalizeEmail(user.email) && Array.isArray(team.adminEmails) && team.adminEmails.map(normalizeEmail).includes(normalizeEmail(user.email))) return true;
+            if (userProfile?.isAdmin === true) return true;
+            if (Array.isArray(userProfile?.parentTeamIds) && userProfile.parentTeamIds.includes(team.id)) return true;
+            if (Array.isArray(userProfile?.playerTeamIds) && userProfile.playerTeamIds.includes(team.id)) return true;
+            return false;
+        }
+
         function renderOpenSlots() {
             const container = document.getElementById('open-slots');
+            if (!canClaimOpenSlots) {
+                container.innerHTML = '<div class="p-4 text-sm text-gray-500">Open self-assignment slots are only available to team owners, admins, parents, or roster members.</div>';
+                return;
+            }
+
             const openSlots = [];
             games.filter(isUpcoming).forEach((game) => {
                 getOpenOfficiatingSlots(game).forEach((slot) => openSlots.push({ game, slot }));
@@ -145,7 +167,7 @@
             }
         });
 
-        checkAuth((user) => {
+        checkAuth(async (user) => {
             if (!user) {
                 window.location.href = 'login.html';
                 return;
@@ -156,7 +178,16 @@
             }
             currentUser = user;
             renderHeader(document.getElementById('header-container'), user);
-            refresh();
+            try {
+                [currentTeam, currentUserProfile] = await Promise.all([
+                    getTeam(teamId, { includeInactive: true }),
+                    getUserProfile(user.uid)
+                ]);
+                canClaimOpenSlots = isEligibleOpenSlotParticipant(currentUser, currentUserProfile, currentTeam);
+                await refresh();
+            } catch (error) {
+                document.getElementById('officials-status').textContent = error.message || 'Could not load officiating access.';
+            }
         }, { skipEmailVerificationCheck: true });
     </script>
 </body>

--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -79,19 +79,26 @@ describe('officiating slots', () => {
         expect(officialsSource).toContain("['pending', 'needs_review'].includes(slot.status)");
     });
 
-    it('allows signed-in officials to claim open self-assignment slots through Firestore rules', () => {
+    it('limits open self-assignment slot claims to eligible team participants', () => {
+        const officialsSource = readOfficialsPage();
         const dbSource = readDbSource();
         const rules = readFirestoreRules();
 
-        expect(dbSource).toContain('export async function claimOpenOfficiatingSlot(teamId, gameId, slotId, official = auth.currentUser)');
+        expect(officialsSource).toContain('canClaimOpenSlots = isEligibleOpenSlotParticipant(currentUser, currentUserProfile, currentTeam);');
+        expect(officialsSource).toContain('Open self-assignment slots are only available to team owners, admins, parents, or roster members.');
+        expect(officialsSource).toContain("'./js/db.js?v=32'");
+        expect(dbSource).toContain('function isEligibleOpenOfficiatingSlotParticipant(team = {}, userProfile = {}, user = {})');
+        expect(dbSource).toContain("throw new Error('Only team owners, admins, parents, or roster members can claim open officiating slots.');");
         expect(dbSource).toContain('officiatingAuthorizedUserIds: Array.from(officiatingAuthorizedUserIds)');
         expect(dbSource).toContain('officiatingAuthorizedEmails: Array.from(officiatingAuthorizedEmails)');
-        expect(rules).toContain('function isOpenOfficiatingSelfAssignmentUpdate()');
-        expect(rules).toContain("resource.data.get('officiatingSelfAssignmentEnabled', false) == true");
+        expect(rules).toContain('function canClaimOpenOfficiatingSlot(teamId)');
+        expect(rules).toContain('isParentForTeam(teamId)');
+        expect(rules).toContain("teamId in get(userPath).data.get('playerTeamIds', [])");
+        expect(rules).toContain('function isOpenOfficiatingSelfAssignmentUpdate(teamId)');
+        expect(rules).toContain('return canClaimOpenOfficiatingSlot(teamId) &&');
         expect(rules).toContain('function isOnlyAddingCurrentOfficialAuthorization()');
         expect(rules).toContain("nextUserIds.hasOnly(previousUserIds + [request.auth.uid])");
         expect(rules).toContain("nextEmails.hasOnly(previousEmails + [callerEmail])");
-        expect(rules).toContain("'officiatingAuthorizedUserIds'");
-        expect(rules).toContain('allow update: if isOpenOfficiatingSelfAssignmentUpdate();');
+        expect(rules).toContain('allow update: if isOpenOfficiatingSelfAssignmentUpdate(teamId);');
     });
 });

--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -85,15 +85,15 @@ describe('officiating slots', () => {
         const rules = readFirestoreRules();
 
         expect(officialsSource).toContain('canClaimOpenSlots = isEligibleOpenSlotParticipant(currentUser, currentUserProfile, currentTeam);');
-        expect(officialsSource).toContain('Open self-assignment slots are only available to team owners, admins, parents, or roster members.');
+        expect(officialsSource).toContain('Open self-assignment slots are only available to team owners, admins, or parents.');
         expect(officialsSource).toContain("'./js/db.js?v=32'");
         expect(dbSource).toContain('function isEligibleOpenOfficiatingSlotParticipant(team = {}, userProfile = {}, user = {})');
-        expect(dbSource).toContain("throw new Error('Only team owners, admins, parents, or roster members can claim open officiating slots.');");
+        expect(dbSource).toContain("throw new Error('Only team owners, admins, or parents can claim open officiating slots.');");
         expect(dbSource).toContain('officiatingAuthorizedUserIds: Array.from(officiatingAuthorizedUserIds)');
         expect(dbSource).toContain('officiatingAuthorizedEmails: Array.from(officiatingAuthorizedEmails)');
         expect(rules).toContain('function canClaimOpenOfficiatingSlot(teamId)');
         expect(rules).toContain('isParentForTeam(teamId)');
-        expect(rules).toContain("teamId in get(userPath).data.get('playerTeamIds', [])");
+        expect(rules).not.toContain('playerTeamIds');
         expect(rules).toContain('function isOpenOfficiatingSelfAssignmentUpdate(teamId)');
         expect(rules).toContain('return canClaimOpenOfficiatingSlot(teamId) &&');
         expect(rules).toContain('function isOnlyAddingCurrentOfficialAuthorization()');


### PR DESCRIPTION
Closes #932

## Summary
- Restricts open officiating slot self-assignment to eligible team participants: team owners, admins, parents, roster members, or global admins.
- Hides open claim controls on `officials.html` for ineligible signed-in users.
- Adds Firestore rules enforcement so outsiders cannot claim a slot by writing their own officiating authorization fields.
- Updates the `db.js` cache-bust value on the affected officials page import.

## Validation
- `npm test -- --run tests/unit/officiating-slots.test.js`
- `node scripts/check-critical-cache-bust.mjs`
- `npm run ci:firebase-rules`