### PR TITLE
Preserve stat configs in shared schedule sync

### DIFF
--- a/js/shared-schedule-sync.js
+++ b/js/shared-schedule-sync.js
@@ -39,7 +39,6 @@ export function buildMirroredGamePayload({
     date: sourceGame.date || null,
     opponent: sourceTeam.name || sourceGame.opponent || 'Opponent',
     location: sourceGame.location || '',
-    statTrackerConfigId: sourceGame.statTrackerConfigId || null,
     opponentTeamId: sourceTeamId || null,
     opponentTeamName: sourceTeam.name || sourceGame.opponent || null,
     opponentTeamPhoto: sourceTeam.photoUrl || null,

--- a/tests/unit/shared-schedule-sync.test.js
+++ b/tests/unit/shared-schedule-sync.test.js
@@ -88,10 +88,29 @@ describe('shared schedule sync helpers', () => {
     expect(payload.assignments).toEqual([{ role: 'Clock', value: 'Alex' }]);
     expect(payload.date).toBe('2026-03-12T18:00:00Z');
     expect(payload.arrivalTime).toBe('2026-03-12T17:15:00Z');
+    expect(payload).not.toHaveProperty('statTrackerConfigId');
     expect(payload.tournament).toEqual(tournament);
     expect(payload.tournament).not.toBe(tournament);
     expect(payload.tournament.slotAssignments).not.toBe(tournament.slotAssignments);
     expect(payload.tournament.resolved).not.toBe(tournament.resolved);
+  });
+
+
+  it('does not mirror team-scoped stat tracker config ids across shared schedules', () => {
+    const payload = buildMirroredGamePayload({
+      sourceTeamId: 'team-alpha',
+      sourceTeam: { name: 'Alpha FC' },
+      sourceGameId: 'game-123',
+      sourceGame: {
+        type: 'game',
+        date: '2026-03-12T18:00:00Z',
+        opponentTeamId: 'team-bravo',
+        statTrackerConfigId: 'alpha-config'
+      },
+      sharedScheduleId: 'shared_team-alpha_game-123'
+    });
+
+    expect(payload).not.toHaveProperty('statTrackerConfigId');
   });
 
   it('records source metadata needed to keep the counterpart game in sync', () => {


### PR DESCRIPTION
Closes #934

## Summary
- Stop copying team-scoped `statTrackerConfigId` values into mirrored shared schedule payloads.
- Add regression coverage proving shared schedule mirrors do not propagate another team's stat tracker config ID.

## Validation
- `npm exec -- vitest run tests/unit/shared-schedule-sync.test.js`