### PR TITLE
Add parent household invite workflow

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -187,6 +187,25 @@ service cloud.firestore {
              data.status == 'removed';
     }
 
+    function isHouseholdInvitePayloadValid(data, userId) {
+      return data.keys().hasOnly([
+               'contactName', 'email', 'relation', 'teamAccessIntent', 'status',
+               'organizerUserId', 'playerId', 'playerName', 'teamId', 'teamName',
+               'playerKey', 'invitedAt', 'updatedAt'
+             ]) &&
+             data.keys().hasAll(['contactName', 'email', 'relation', 'teamAccessIntent', 'status', 'organizerUserId', 'playerId', 'teamId', 'playerKey']) &&
+             data.organizerUserId == userId &&
+             data.contactName is string &&
+             data.email is string &&
+             data.relation is string &&
+             data.teamAccessIntent is bool &&
+             data.status == 'pending' &&
+             data.playerId is string &&
+             data.teamId is string &&
+             data.playerKey == data.teamId + "::" + data.playerId &&
+             isParentForPlayer(data.teamId, data.playerId);
+    }
+
     function isTeamFeeRecipientForCurrentParent(data, teamId) {
       let userPath = /databases/$(database)/documents/users/$(request.auth.uid);
       let playerId = data.get('playerId', '');
@@ -689,6 +708,12 @@ service cloud.firestore {
                       isFamilyMembershipRemoval(request.resource.data, userId) &&
                       request.resource.data.diff(resource.data).affectedKeys().hasOnly(['status', 'updatedAt', 'removedAt']);
         allow delete: if false;
+      }
+
+      match /householdInvites/{inviteId} {
+        allow read: if isOwner(userId) || isGlobalAdmin();
+        allow create: if isOwner(userId) && isHouseholdInvitePayloadValid(request.resource.data, userId);
+        allow update, delete: if false;
       }
     }
 

--- a/js/family-plan.js
+++ b/js/family-plan.js
@@ -67,6 +67,92 @@ function statusClasses(status) {
     return 'border-amber-200 bg-amber-50 text-amber-700';
 }
 
+export function normalizeHouseholdInvites(records = []) {
+    return records
+        .filter((record) => record && typeof record === 'object')
+        .map((record, index) => ({
+            id: normalizeString(record.id) || `household-invite-${index}`,
+            contactName: normalizeString(record.contactName || record.displayName || record.name),
+            email: normalizeString(record.email).toLowerCase(),
+            relation: normalizeString(record.relation),
+            status: normalizeStatus(record.status),
+            organizerUserId: normalizeString(record.organizerUserId),
+            playerId: normalizeString(record.playerId),
+            playerName: normalizeString(record.playerName),
+            teamId: normalizeString(record.teamId),
+            teamName: normalizeString(record.teamName),
+            playerKey: normalizeString(record.playerKey),
+            teamAccessIntent: record.teamAccessIntent === true,
+            invitedAt: record.invitedAt || record.createdAt || null,
+            updatedAt: record.updatedAt || null,
+        }))
+        .sort((a, b) => (a.playerName || '').localeCompare(b.playerName || '') || (a.contactName || a.email).localeCompare(b.contactName || b.email));
+}
+
+function normalizeLinkedPlayers(players = []) {
+    return players
+        .filter((player) => player?.teamId && player?.playerId)
+        .map((player) => ({
+            teamId: normalizeString(player.teamId),
+            teamName: normalizeString(player.teamName),
+            playerId: normalizeString(player.playerId),
+            playerName: normalizeString(player.playerName || player.name) || 'Player',
+        }));
+}
+
+export function buildHouseholdInviteMarkup({ invites = [], linkedPlayers = [], validationMessage = '' } = {}) {
+    const normalizedInvites = normalizeHouseholdInvites(invites).filter((invite) => invite.status === 'pending');
+    const normalizedPlayers = normalizeLinkedPlayers(linkedPlayers);
+    const playerOptions = normalizedPlayers.length
+        ? normalizedPlayers.map((player) => `<option value="${escapeHtml(player.teamId)}::${escapeHtml(player.playerId)}">${escapeHtml(player.playerName)}${player.teamName ? ` — ${escapeHtml(player.teamName)}` : ''}</option>`).join('')
+        : '<option value="">No linked players available</option>';
+    const pendingRows = normalizedInvites.length
+        ? normalizedInvites.map((invite) => `
+            <div class="rounded-xl border border-gray-200 bg-white p-3">
+                <div class="flex items-start justify-between gap-3">
+                    <div>
+                        <div class="font-semibold text-gray-900">${escapeHtml(invite.contactName || invite.email || 'Household contact')}</div>
+                        <div class="text-xs text-gray-500 mt-0.5">${escapeHtml(invite.email)}</div>
+                        <div class="text-xs text-gray-600 mt-1">${escapeHtml(invite.relation || 'Relation not specified')} for ${escapeHtml(invite.playerName || 'selected player')}${invite.teamName ? ` · ${escapeHtml(invite.teamName)}` : ''}</div>
+                    </div>
+                    <span class="px-2 py-1 rounded-full border text-[10px] font-semibold uppercase tracking-wide ${statusClasses(invite.status)}">${escapeHtml(invite.status)}</span>
+                </div>
+                ${invite.teamAccessIntent ? '<div class="text-xs text-primary-700 mt-2">Team access requested when invite acceptance is supported.</div>' : ''}
+            </div>
+        `).join('')
+        : '<div class="rounded-xl border border-dashed border-gray-300 bg-gray-50 p-4 text-sm text-gray-600">No pending household player-access invites yet.</div>';
+
+    return `
+        <div class="p-6 border-t border-gray-100 space-y-4">
+            <div>
+                <h3 class="text-lg font-bold text-gray-900">Household player access</h3>
+                <p class="text-xs text-gray-500 mt-1">Create pending invites for contacts who should share access to a specific linked player. Access is not granted until invite acceptance is built.</p>
+            </div>
+            <div class="rounded-xl border border-gray-200 bg-gray-50 p-4 space-y-3">
+                <select id="household-invite-player" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" ${normalizedPlayers.length ? '' : 'disabled'}>
+                    <option value="">Select linked player</option>
+                    ${playerOptions}
+                </select>
+                <div class="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                    <input id="household-invite-name" type="text" placeholder="Contact name" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" ${normalizedPlayers.length ? '' : 'disabled'}>
+                    <input id="household-invite-email" type="email" placeholder="Contact email" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" ${normalizedPlayers.length ? '' : 'disabled'}>
+                </div>
+                <input id="household-invite-relation" type="text" placeholder="Relation, e.g. grandparent, step-parent" class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm" ${normalizedPlayers.length ? '' : 'disabled'}>
+                <label class="flex items-start gap-2 text-xs text-gray-600">
+                    <input id="household-invite-team-access" type="checkbox" class="mt-0.5 rounded border-gray-300 text-primary-600" ${normalizedPlayers.length ? '' : 'disabled'}>
+                    <span>Intend to share team access when household invite acceptance is supported</span>
+                </label>
+                <button id="household-invite-add-btn" class="w-full bg-primary-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition disabled:bg-gray-300 disabled:cursor-not-allowed" ${normalizedPlayers.length ? '' : 'disabled'}>Create pending household invite</button>
+                <div id="household-invite-validation" class="${validationMessage ? '' : 'hidden'} text-xs rounded-lg px-3 py-2 bg-red-50 text-red-700 border border-red-200">${escapeHtml(validationMessage)}</div>
+            </div>
+            <div class="space-y-2">
+                <div class="text-sm font-semibold text-gray-900">Pending household invites</div>
+                ${pendingRows}
+            </div>
+        </div>
+    `;
+}
+
 export function buildFamilyPlanMarkup({ members = [], entitlementState = 'locked', validationMessage = '' } = {}) {
     const normalized = normalizeFamilyMembers(members);
     const counts = getFamilySlotCounts(normalized);
@@ -123,11 +209,55 @@ export function buildFamilyPlanMarkup({ members = [], entitlementState = 'locked
     `;
 }
 
+export function buildFamilyPlanSectionMarkup(state = {}) {
+    return `${buildFamilyPlanMarkup(state)}${buildHouseholdInviteMarkup(state)}`;
+}
+
 export async function readFamilyMembers(userId, { deps = {} } = {}) {
     if (!userId) return [];
     const { db, collection, getDocs } = await loadFirebase(deps);
     const snapshot = await getDocs(collection(db, `users/${userId}/familyMemberships`));
     return normalizeFamilyMembers(snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...dataFromSnapshot(docSnap) })));
+}
+
+export async function readHouseholdInvites(userId, { deps = {} } = {}) {
+    if (!userId) return [];
+    const { db, collection, getDocs } = await loadFirebase(deps);
+    const snapshot = await getDocs(collection(db, `users/${userId}/householdInvites`));
+    return normalizeHouseholdInvites(snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...dataFromSnapshot(docSnap) })));
+}
+
+export async function addPendingHouseholdInvite(userId, invite, { deps = {}, linkedPlayers = [] } = {}) {
+    if (!userId) throw new Error('Missing signed-in user.');
+    const normalizedPlayers = normalizeLinkedPlayers(linkedPlayers);
+    const selectedKey = normalizeString(invite?.playerKey || `${normalizeString(invite?.teamId)}::${normalizeString(invite?.playerId)}`);
+    const selectedPlayer = normalizedPlayers.find((player) => `${player.teamId}::${player.playerId}` === selectedKey);
+    if (!selectedPlayer) throw new Error('Select a player already linked to your parent account.');
+
+    const contactName = normalizeString(invite?.contactName || invite?.displayName || invite?.name);
+    const email = normalizeString(invite?.email).toLowerCase();
+    const relation = normalizeString(invite?.relation);
+    if (!contactName) throw new Error('Enter the household contact name.');
+    if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) throw new Error('Enter a valid email for the household contact.');
+    if (!relation) throw new Error('Enter the household contact relation.');
+
+    const { db, collection, addDoc, serverTimestamp } = await loadFirebase(deps);
+    const timestamp = typeof serverTimestamp === 'function' ? serverTimestamp() : new Date().toISOString();
+    await addDoc(collection(db, `users/${userId}/householdInvites`), {
+        contactName,
+        email,
+        relation,
+        teamAccessIntent: invite?.teamAccessIntent === true,
+        status: 'pending',
+        organizerUserId: userId,
+        playerId: selectedPlayer.playerId,
+        playerName: selectedPlayer.playerName,
+        teamId: selectedPlayer.teamId,
+        teamName: selectedPlayer.teamName,
+        playerKey: `${selectedPlayer.teamId}::${selectedPlayer.playerId}`,
+        invitedAt: timestamp,
+        updatedAt: timestamp,
+    });
 }
 
 export async function addPendingFamilyMember(userId, member, { deps = {}, existingMembers = [] } = {}) {
@@ -171,12 +301,14 @@ export async function removeFamilyMember(userId, memberId, { deps = {} } = {}) {
 }
 
 export async function loadFamilyPlanState(user, { deps = {}, entitlementReader = readAccountPremiumEntitlement } = {}) {
-    const [members, entitlement] = await Promise.all([
+    const [members, invites, entitlement] = await Promise.all([
         readFamilyMembers(user?.uid, { deps }),
+        readHouseholdInvites(user?.uid, { deps }),
         entitlementReader({ user, deps }),
     ]);
     return {
         members,
+        invites,
         entitlementState: entitlement?.state || 'locked',
     };
 }
@@ -186,8 +318,11 @@ export async function renderFamilyPlanSection(container, user, options = {}) {
     const { deps = {}, entitlementReader = readAccountPremiumEntitlement } = options;
 
     try {
-        const state = await loadFamilyPlanState(user, { deps, entitlementReader });
-        container.innerHTML = buildFamilyPlanMarkup(state);
+        const state = {
+            ...(await loadFamilyPlanState(user, { deps, entitlementReader })),
+            linkedPlayers: options.linkedPlayers || []
+        };
+        container.innerHTML = buildFamilyPlanSectionMarkup(state);
 
         const addButton = container.querySelector('#family-plan-add-member-btn');
         const validationEl = container.querySelector('#family-plan-validation');
@@ -229,6 +364,31 @@ export async function renderFamilyPlanSection(container, user, options = {}) {
                 }
                 addButton.disabled = false;
                 addButton.textContent = originalText;
+            }
+        });
+
+        const householdButton = container.querySelector('#household-invite-add-btn');
+        const householdValidationEl = container.querySelector('#household-invite-validation');
+        householdButton?.addEventListener('click', async () => {
+            const originalText = householdButton.textContent;
+            householdButton.disabled = true;
+            householdButton.textContent = 'Saving...';
+            try {
+                await addPendingHouseholdInvite(user.uid, {
+                    playerKey: container.querySelector('#household-invite-player')?.value,
+                    contactName: container.querySelector('#household-invite-name')?.value,
+                    email: container.querySelector('#household-invite-email')?.value,
+                    relation: container.querySelector('#household-invite-relation')?.value,
+                    teamAccessIntent: container.querySelector('#household-invite-team-access')?.checked === true,
+                }, { deps, linkedPlayers: state.linkedPlayers });
+                await renderFamilyPlanSection(container, user, options);
+            } catch (error) {
+                if (householdValidationEl) {
+                    householdValidationEl.textContent = error.message || 'Unable to create household invite.';
+                    householdValidationEl.className = 'text-xs rounded-lg px-3 py-2 bg-red-50 text-red-700 border border-red-200';
+                }
+                householdButton.disabled = false;
+                householdButton.textContent = originalText;
             }
         });
     } catch (error) {

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -315,7 +315,7 @@
         import { resolveSelectedRideChildId, getRideOfferUiState, createRideRequestHandlers } from './js/parent-dashboard-rideshare-controls.js?v=1';
         import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';
         import { renderParentTeamFees } from './js/parent-dashboard-fees.js?v=4';
-        import { renderFamilyPlanSection } from './js/family-plan.js?v=1';
+        import { renderFamilyPlanSection } from './js/family-plan.js?v=2';
         import { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
@@ -894,7 +894,7 @@
                 await ensureParentTeamAccess(user.uid, teamIds);
                 const unreadCounts = await getUnreadChatCounts(user.uid, teamIds);
                 renderTeamChats(data.children, unreadCounts);
-                await renderFamilyPlanSection(document.getElementById('family-plan-card'), user);
+                await renderFamilyPlanSection(document.getElementById('family-plan-card'), user, { linkedPlayers: data.children || [] });
                 await loadParentTeamFees(user.uid, data.children);
                 queueParentDashboardHydration(data.children, user.uid);
 

--- a/tests/unit/family-plan.test.js
+++ b/tests/unit/family-plan.test.js
@@ -1,11 +1,15 @@
 import { readFileSync } from 'node:fs';
 import { describe, expect, it, vi } from 'vitest';
 import {
+    addPendingHouseholdInvite,
     addPendingFamilyMember,
+    buildFamilyPlanSectionMarkup,
     buildFamilyPlanMarkup,
+    buildHouseholdInviteMarkup,
     canAddFamilyMember,
     getFamilySlotCounts,
     loadFamilyPlanState,
+    normalizeHouseholdInvites,
     removeFamilyMember
 } from '../../js/family-plan.js';
 
@@ -75,6 +79,101 @@ describe('family plan helpers', () => {
         }));
     });
 
+    it('renders household invite form and pending invites scoped to linked players', () => {
+        const markup = buildHouseholdInviteMarkup({
+            linkedPlayers: [{ teamId: 'team-1', teamName: 'Tigers', playerId: 'player-1', playerName: 'Sam' }],
+            invites: [{
+                id: 'invite-1',
+                contactName: 'Alex Contact',
+                email: 'alex@example.com',
+                relation: 'Grandparent',
+                status: 'pending',
+                playerId: 'player-1',
+                playerName: 'Sam',
+                teamId: 'team-1',
+                teamName: 'Tigers',
+                teamAccessIntent: true
+            }]
+        });
+
+        expect(markup).toContain('Household player access');
+        expect(markup).toContain('Sam');
+        expect(markup).toContain('Tigers');
+        expect(markup).toContain('Alex Contact');
+        expect(markup).toContain('alex@example.com');
+        expect(markup).toContain('Grandparent');
+        expect(markup).toContain('pending');
+    });
+
+    it('normalizes household invite records without granting access fields', () => {
+        expect(normalizeHouseholdInvites([{ id: 'invite-1', email: ' NEW@EXAMPLE.COM ', status: 'pending', teamAccessIntent: true }])).toEqual([
+            expect.objectContaining({
+                id: 'invite-1',
+                email: 'new@example.com',
+                status: 'pending',
+                teamAccessIntent: true
+            })
+        ]);
+    });
+
+    it('rejects household invites for players outside the linked parent list', async () => {
+        await expect(addPendingHouseholdInvite('user-1', {
+            playerKey: 'team-2::player-2',
+            contactName: 'Alex Contact',
+            email: 'alex@example.com',
+            relation: 'Grandparent'
+        }, {
+            linkedPlayers: [{ teamId: 'team-1', playerId: 'player-1', playerName: 'Sam' }]
+        })).rejects.toThrow('already linked');
+    });
+
+    it('writes a pending household invite for a linked player only', async () => {
+        const addDoc = vi.fn().mockResolvedValue({ id: 'invite-1' });
+        const firebase = {
+            db: {},
+            collection: vi.fn((_db, path) => ({ path })),
+            addDoc,
+            serverTimestamp: () => 'server-now'
+        };
+
+        await addPendingHouseholdInvite('user-1', {
+            playerKey: 'team-1::player-1',
+            contactName: ' Alex Contact ',
+            email: ' ALEX@EXAMPLE.COM ',
+            relation: ' Grandparent ',
+            teamAccessIntent: true
+        }, {
+            deps: { firebase },
+            linkedPlayers: [{ teamId: 'team-1', teamName: 'Tigers', playerId: 'player-1', playerName: 'Sam' }]
+        });
+
+        expect(firebase.collection).toHaveBeenCalledWith({}, 'users/user-1/householdInvites');
+        expect(addDoc).toHaveBeenCalledWith({ path: 'users/user-1/householdInvites' }, expect.objectContaining({
+            contactName: 'Alex Contact',
+            email: 'alex@example.com',
+            relation: 'Grandparent',
+            teamAccessIntent: true,
+            status: 'pending',
+            organizerUserId: 'user-1',
+            playerId: 'player-1',
+            playerName: 'Sam',
+            teamId: 'team-1',
+            teamName: 'Tigers',
+            playerKey: 'team-1::player-1'
+        }));
+    });
+
+    it('combines Family Plan slots and household player-access invites in one section', () => {
+        const markup = buildFamilyPlanSectionMarkup({
+            members: [member('pending', 'pending@example.com')],
+            linkedPlayers: [{ teamId: 'team-1', playerId: 'player-1', playerName: 'Sam' }],
+            invites: []
+        });
+
+        expect(markup).toContain('Family Plan');
+        expect(markup).toContain('Household player access');
+    });
+
     it('marks a family member as removed instead of deleting the record', async () => {
         const updateDoc = vi.fn().mockResolvedValue();
         const firebase = {
@@ -119,5 +218,16 @@ describe('family plan helpers', () => {
         expect(rules).toContain('allow update: if isOwner(userId) &&');
         expect(rules).toContain("affectedKeys().hasOnly(['status', 'updatedAt', 'removedAt'])");
         expect(rules).toContain('allow delete: if false;');
+    });
+
+    it('grants parents create/read access to pending household invites only for linked players', () => {
+        const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+        expect(rules).toContain('match /householdInvites/{inviteId}');
+        expect(rules).toContain('allow read: if isOwner(userId) || isGlobalAdmin();');
+        expect(rules).toContain('allow create: if isOwner(userId) && isHouseholdInvitePayloadValid');
+        expect(rules).toContain('data.status == \'pending\'');
+        expect(rules).toContain('data.playerKey == data.teamId + "::" + data.playerId');
+        expect(rules).toContain('isParentForPlayer(data.teamId, data.playerId)');
+        expect(rules).toContain('allow update, delete: if false;');
     });
 });

--- a/tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js
+++ b/tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js
@@ -121,7 +121,7 @@ const Blob = deps.Blob;
         .replace("import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';", 'const { applyRsvpHydration } = deps.rsvpHydration;')
         .replace(/import\s*\{\s*renderParentTeamFees\s*\}\s*from '\.\/js\/parent-dashboard-fees\.js\?v=\d+';/, 'const { renderParentTeamFees } = deps.parentDashboardFees;')
         .replace("import { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';", 'const { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } = deps.availabilityPreferences;')
-        .replace("import { renderFamilyPlanSection } from './js/family-plan.js?v=1';", 'const { renderFamilyPlanSection } = deps.familyPlan;')
+        .replace(/import\s*\{\s*renderFamilyPlanSection\s*\}\s*from '\.\/js\/family-plan\.js\?v=\d+';/, 'const { renderFamilyPlanSection } = deps.familyPlan;')
         .replace(/\binit\(\);\s*$/, `
 window.__parentDashboardTestHooks = {
     setAllScheduleEvents(value) {


### PR DESCRIPTION
Closes #937

## Summary
- Added a Parent Dashboard household player-access invite form scoped to linked parent players.
- Persisted pending household invite records under the organizer parent without granting player or team access.
- Added Firestore rules and unit coverage to enforce linked-player-only invite creation.

## Validation
- `npx vitest run tests/unit/family-plan.test.js`
- `node scripts/validate-firebase-rules-ci.mjs`
- `node scripts/check-critical-cache-bust.mjs`