### PR TITLE
Guard edit config access for writable admins

### DIFF
--- a/edit-config.html
+++ b/edit-config.html
@@ -148,7 +148,7 @@
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=14';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
-        import { getEditConfigAccessDecision } from './js/edit-config-access.js?v=1';
+        import { getEditConfigAccessDecision } from './js/edit-config-access.js?v=2';
 
         renderFooter(document.getElementById('footer-container'));
 

--- a/js/edit-config-access.js
+++ b/js/edit-config-access.js
@@ -1,5 +1,17 @@
 import { getTeamAccessInfo } from './team-access.js';
 
+function hasRulesCompatibleConfigWriteAccess(user, team) {
+    if (!user || !team) return false;
+    if (team.ownerId === user.uid || user.isAdmin === true) return true;
+
+    const authEmail = String(user.email || '').toLowerCase();
+    return Boolean(
+        authEmail &&
+        Array.isArray(team.adminEmails) &&
+        team.adminEmails.includes(authEmail)
+    );
+}
+
 export function getEditConfigAccessDecision(user, team, teamId) {
     if (!team) {
         return {
@@ -16,7 +28,7 @@ export function getEditConfigAccessDecision(user, team, teamId) {
     const accessInfo = getTeamAccessInfo(user, normalizedTeam);
 
     return {
-        allowed: accessInfo.accessLevel === 'full',
+        allowed: accessInfo.accessLevel === 'full' && hasRulesCompatibleConfigWriteAccess(user, normalizedTeam),
         exitUrl: accessInfo.exitUrl,
         team: normalizedTeam
     };

--- a/tests/smoke/edit-config-platform-admin.spec.js
+++ b/tests/smoke/edit-config-platform-admin.spec.js
@@ -196,7 +196,7 @@ async function mockDependencies(page) {
     await page.route('**/js/db.js?v=29', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: DB_STUB }));
     await page.route('**/js/utils.js?v=8', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: UTILS_STUB }));
     await page.route('**/js/auth.js?v=14', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
-    await page.route('**/js/edit-config-access.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: EDIT_CONFIG_ACCESS_STUB }));
+    await page.route('**/js/edit-config-access.js?v=2', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: EDIT_CONFIG_ACCESS_STUB }));
     await page.route('**/js/team-admin-banner.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ADMIN_BANNER_STUB }));
     await page.route('**/js/stat-leaderboards.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: STAT_LEADERBOARDS_STUB }));
     await page.route('**/js/stat-config-presets.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: STAT_CONFIG_PRESETS_STUB }));

--- a/tests/unit/edit-config-access.test.js
+++ b/tests/unit/edit-config-access.test.js
@@ -16,6 +16,35 @@ describe('edit config access decision', () => {
         });
     });
 
+    it('allows rules-compatible team admins to manage stats configs', () => {
+        expect(getEditConfigAccessDecision({ uid: 'coach-1', email: 'Coach@Example.com' }, TEAM, TEAM.id)).toEqual({
+            allowed: true,
+            exitUrl: 'dashboard.html',
+            team: TEAM
+        });
+    });
+
+    it('denies legacy-normalized admin emails that Firestore would reject for config writes', () => {
+        const legacyTeam = {
+            ...TEAM,
+            adminEmails: [' Coach@Example.com ']
+        };
+
+        expect(getEditConfigAccessDecision({ uid: 'coach-1', email: 'coach@example.com' }, legacyTeam, TEAM.id)).toEqual({
+            allowed: false,
+            exitUrl: 'dashboard.html',
+            team: legacyTeam
+        });
+    });
+
+    it('denies profile-email-only admin access that Firestore would reject for config writes', () => {
+        expect(getEditConfigAccessDecision({ uid: 'coach-1', profileEmail: 'coach@example.com' }, TEAM, TEAM.id)).toEqual({
+            allowed: false,
+            exitUrl: 'dashboard.html',
+            team: TEAM
+        });
+    });
+
     it('denies parent-only access for stats config page', () => {
         expect(
             getEditConfigAccessDecision(

--- a/tests/unit/team-management-access-wiring.test.js
+++ b/tests/unit/team-management-access-wiring.test.js
@@ -32,7 +32,7 @@ describe('team management page access wiring', () => {
 
     it('uses shared full-access helper in edit config page', () => {
         const html = readRepoFile('edit-config.html');
-        expect(html).toContain("from './js/edit-config-access.js?v=1'");
+        expect(html).toContain("from './js/edit-config-access.js?v=2'");
         expect(html).toContain('getEditConfigAccessDecision(');
     });
 });


### PR DESCRIPTION
Closes #943

- Added an edit-config-specific write access guard that only allows owners, platform admins, or team admins whose auth email matches the raw Firestore `adminEmails` membership check.
- Prevents legacy/case-variant admin records from entering the editable stats config workflow when Firestore would deny the save.
- Updated cache-bust wiring and targeted access tests.