### PR TITLE
[codex] Add site usage telemetry

### DIFF
--- a/accept-invite.html
+++ b/accept-invite.html
@@ -38,6 +38,7 @@
             }
         }
     </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gray-50 flex flex-col min-h-screen">

--- a/admin.html
+++ b/admin.html
@@ -38,6 +38,7 @@
             }
         }
     </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gray-100 text-gray-900">
@@ -59,6 +60,8 @@
                 class="px-4 py-2 font-medium text-gray-500 hover:text-gray-700 focus:outline-none">Teams</button>
             <button id="tab-users"
                 class="px-4 py-2 font-medium text-gray-500 hover:text-gray-700 focus:outline-none">Users</button>
+            <button id="tab-telemetry"
+                class="px-4 py-2 font-medium text-gray-500 hover:text-gray-700 focus:outline-none">Telemetry</button>
         </div>
 
         <!-- Dashboard View -->
@@ -254,6 +257,129 @@
                         </thead>
                         <tbody class="bg-white divide-y divide-gray-200" id="users-table-body">
                             <!-- Rows injected here -->
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+        </div>
+
+        <!-- Telemetry View -->
+        <div id="view-telemetry" class="hidden space-y-6">
+            <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-4">
+                <div class="flex flex-col lg:flex-row lg:items-center lg:justify-between gap-4">
+                    <div>
+                        <h2 class="text-lg font-semibold text-gray-900">Site Usage Telemetry</h2>
+                        <p class="text-sm text-gray-500">First-party autocapture across pages, clicks, forms, scroll depth, sessions, and errors.</p>
+                    </div>
+                    <div class="flex flex-wrap items-center gap-3">
+                        <select id="telemetry-range" class="px-3 py-2 border border-gray-300 rounded-md text-sm">
+                            <option value="1">Last 24 hours</option>
+                            <option value="7" selected>Last 7 days</option>
+                            <option value="30">Last 30 days</option>
+                        </select>
+                        <select id="telemetry-event-filter" class="px-3 py-2 border border-gray-300 rounded-md text-sm">
+                            <option value="">All events</option>
+                            <option value="page_view">Page views</option>
+                            <option value="interaction_click">Clicks</option>
+                            <option value="interaction_change">Form changes</option>
+                            <option value="interaction_submit">Form submits</option>
+                            <option value="scroll_depth">Scroll depth</option>
+                            <option value="js_error">JS errors</option>
+                        </select>
+                        <button id="telemetry-refresh" class="px-4 py-2 bg-primary-600 text-white rounded-md text-sm font-medium hover:bg-primary-700">Refresh</button>
+                    </div>
+                </div>
+                <p id="telemetry-status" class="text-xs text-gray-500 mt-3">Loading telemetry...</p>
+            </div>
+
+            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-6 gap-4">
+                <div class="bg-white p-5 rounded-xl shadow-sm border border-gray-200">
+                    <p class="text-xs font-semibold text-gray-500 uppercase">Events</p>
+                    <p id="telemetry-total-events" class="text-3xl font-bold text-gray-900 mt-2">-</p>
+                </div>
+                <div class="bg-white p-5 rounded-xl shadow-sm border border-gray-200">
+                    <p class="text-xs font-semibold text-gray-500 uppercase">Page Views</p>
+                    <p id="telemetry-page-views" class="text-3xl font-bold text-gray-900 mt-2">-</p>
+                </div>
+                <div class="bg-white p-5 rounded-xl shadow-sm border border-gray-200">
+                    <p class="text-xs font-semibold text-gray-500 uppercase">Interactions</p>
+                    <p id="telemetry-interactions" class="text-3xl font-bold text-gray-900 mt-2">-</p>
+                </div>
+                <div class="bg-white p-5 rounded-xl shadow-sm border border-gray-200">
+                    <p class="text-xs font-semibold text-gray-500 uppercase">Sessions</p>
+                    <p id="telemetry-sessions" class="text-3xl font-bold text-gray-900 mt-2">-</p>
+                </div>
+                <div class="bg-white p-5 rounded-xl shadow-sm border border-gray-200">
+                    <p class="text-xs font-semibold text-gray-500 uppercase">Known Users</p>
+                    <p id="telemetry-known-users" class="text-3xl font-bold text-gray-900 mt-2">-</p>
+                </div>
+                <div class="bg-white p-5 rounded-xl shadow-sm border border-gray-200">
+                    <p class="text-xs font-semibold text-gray-500 uppercase">Errors</p>
+                    <p id="telemetry-errors" class="text-3xl font-bold text-gray-900 mt-2">-</p>
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 xl:grid-cols-3 gap-6">
+                <div class="bg-white rounded-xl shadow-sm border border-gray-200 xl:col-span-2">
+                    <div class="p-4 border-b border-gray-200">
+                        <h3 class="text-lg font-semibold text-gray-900">Daily Trend</h3>
+                    </div>
+                    <div id="telemetry-daily-trend" class="p-4 space-y-3">
+                        <p class="text-gray-400 text-sm">Loading...</p>
+                    </div>
+                </div>
+
+                <div class="bg-white rounded-xl shadow-sm border border-gray-200">
+                    <div class="p-4 border-b border-gray-200">
+                        <h3 class="text-lg font-semibold text-gray-900">Top Events</h3>
+                    </div>
+                    <div id="telemetry-top-events" class="p-4 space-y-3 max-h-80 overflow-y-auto">
+                        <p class="text-gray-400 text-sm">Loading...</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="grid grid-cols-1 xl:grid-cols-2 gap-6">
+                <div class="bg-white rounded-xl shadow-sm border border-gray-200">
+                    <div class="p-4 border-b border-gray-200">
+                        <h3 class="text-lg font-semibold text-gray-900">Top Pages</h3>
+                    </div>
+                    <div id="telemetry-top-pages" class="p-4 space-y-3 max-h-96 overflow-y-auto">
+                        <p class="text-gray-400 text-sm">Loading...</p>
+                    </div>
+                </div>
+
+                <div class="bg-white rounded-xl shadow-sm border border-gray-200">
+                    <div class="p-4 border-b border-gray-200">
+                        <h3 class="text-lg font-semibold text-gray-900">Recent Sessions</h3>
+                    </div>
+                    <div id="telemetry-recent-sessions" class="p-4 space-y-3 max-h-96 overflow-y-auto">
+                        <p class="text-gray-400 text-sm">Loading...</p>
+                    </div>
+                </div>
+            </div>
+
+            <div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
+                <div class="p-4 border-b border-gray-200 flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+                    <h3 class="text-lg font-semibold text-gray-900">Recent Events</h3>
+                    <input id="telemetry-page-filter" type="text" placeholder="Filter by page..."
+                        class="px-3 py-2 border border-gray-300 rounded-md text-sm">
+                </div>
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Time</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Event</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Page</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Target</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">User</th>
+                            </tr>
+                        </thead>
+                        <tbody id="telemetry-events-table" class="bg-white divide-y divide-gray-200">
+                            <tr>
+                                <td colspan="5" class="px-6 py-4 text-sm text-gray-400">Loading...</td>
+                            </tr>
                         </tbody>
                     </table>
                 </div>

--- a/beta/cheer/track-cheer-mobile.html
+++ b/beta/cheer/track-cheer-mobile.html
@@ -49,6 +49,7 @@
     .stat-btn { touch-action: manipulation; }
     .grid-cols-auto { grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
   </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="min-h-screen text-ink font-body">
   <header class="px-4 py-3 text-white flex items-center justify-between">

--- a/beta/sub-tracker-prototype.html
+++ b/beta/sub-tracker-prototype.html
@@ -30,6 +30,7 @@
         .sub-step-1 .player-card.on-court { cursor: pointer; }
         .sub-step-2 .player-card.on-bench { cursor: pointer; }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="bg-gray-50 min-h-screen">
 

--- a/beta/track-basketball-mobile-mock.html
+++ b/beta/track-basketball-mobile-mock.html
@@ -46,6 +46,7 @@
     .stat-btn { touch-action: manipulation; }
     .grid-cols-auto { grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); }
   </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="min-h-screen text-ink font-body">
   <header class="px-4 py-3 text-white flex items-center justify-between">

--- a/beta/track-basketball-mock.html
+++ b/beta/track-basketball-mock.html
@@ -62,6 +62,7 @@
             touch-action: manipulation;
         }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="min-h-screen">
     <header class="text-white px-6 py-4 flex items-center justify-between">

--- a/calendar.html
+++ b/calendar.html
@@ -45,6 +45,7 @@
         .cal-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin: 1px; cursor: pointer; }
         .cal-cell:hover { background: #f3f4f6; cursor: pointer; }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gradient-to-br from-gray-50 to-gray-100 text-gray-900">

--- a/dashboard.html
+++ b/dashboard.html
@@ -38,6 +38,7 @@
             }
         }
     </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gradient-to-br from-gray-50 to-gray-100 text-gray-900">

--- a/drills.html
+++ b/drills.html
@@ -92,6 +92,7 @@
             box-shadow: inset 0 0 0 2px rgba(59, 130, 246, 0.45);
         }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gray-50 text-gray-900">

--- a/edit-config.html
+++ b/edit-config.html
@@ -38,6 +38,7 @@
             }
         }
     </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gray-50 text-gray-900">

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -38,6 +38,7 @@
             }
         }
     </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gray-50 text-gray-900">

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -38,6 +38,7 @@
             }
         }
     </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gray-50 text-gray-900">

--- a/edit-team.html
+++ b/edit-team.html
@@ -38,6 +38,7 @@
             }
         }
     </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gray-50 text-gray-900">

--- a/firestore.rules
+++ b/firestore.rules
@@ -214,6 +214,33 @@ service cloud.firestore {
                               );
     }
 
+    // First-party product telemetry. Clients send events through the Cloud Function,
+    // and only global admins can inspect the resulting datasets.
+    match /telemetryEvents/{eventId} {
+      allow read: if isGlobalAdmin();
+      allow write: if false;
+    }
+
+    match /telemetryDaily/{dateId} {
+      allow read: if isGlobalAdmin();
+      allow write: if false;
+    }
+
+    match /telemetryPagesDaily/{pageId} {
+      allow read: if isGlobalAdmin();
+      allow write: if false;
+    }
+
+    match /telemetryEventsDaily/{eventId} {
+      allow read: if isGlobalAdmin();
+      allow write: if false;
+    }
+
+    match /telemetrySessions/{sessionId} {
+      allow read: if isGlobalAdmin();
+      allow write: if false;
+    }
+
     // Teams - only owner or admins can modify
     match /teams/{teamId} {
       allow read: if true;  // Public teams for browsing

--- a/functions/index.js
+++ b/functions/index.js
@@ -1,6 +1,11 @@
 const functions = require('firebase-functions');
+const admin = require('firebase-admin');
 const dns = require('node:dns').promises;
 const net = require('node:net');
+
+if (!admin.apps.length) {
+  admin.initializeApp();
+}
 
 function normalizeIcsText(text) {
   const marker = 'BEGIN:VCALENDAR';
@@ -146,15 +151,191 @@ function isAllowedOrigin(origin) {
   return allowedOriginSet.has(origin);
 }
 
-function writeCorsHeaders(req, res) {
+function writeCorsHeaders(req, res, methods = 'GET,OPTIONS') {
   const origin = req.headers.origin;
   if (origin && allowedOriginSet.has(origin)) {
     res.set('Access-Control-Allow-Origin', origin);
     res.set('Vary', 'Origin');
   }
-  res.set('Access-Control-Allow-Methods', 'GET,OPTIONS');
+  res.set('Access-Control-Allow-Methods', methods);
   res.set('Access-Control-Allow-Headers', 'Content-Type');
   res.set('Cache-Control', 'no-store');
+}
+
+function normalizeTelemetryString(value, maxLength = 160) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .replace(/\s+/g, ' ')
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[email]')
+    .replace(/\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]?\d{4}\b/g, '[phone]')
+    .replace(/\b\d{5,}\b/g, '[number]')
+    .replace(/\b[A-Za-z0-9_-]{18,}\b/g, '[token]')
+    .trim()
+    .slice(0, maxLength);
+}
+
+function normalizeTelemetryKey(value, maxLength = 80) {
+  return normalizeTelemetryString(value, maxLength)
+    .replace(/[^\w:-]/g, '_')
+    .slice(0, maxLength);
+}
+
+function normalizeTelemetryObject(value, depth = 0) {
+  if (!value || typeof value !== 'object' || Array.isArray(value) || depth > 2) {
+    return {};
+  }
+
+  const normalized = {};
+  for (const [key, rawValue] of Object.entries(value).slice(0, 40)) {
+    const cleanKey = normalizeTelemetryKey(key, 60);
+    if (!cleanKey) continue;
+
+    if (rawValue === null || rawValue === undefined) {
+      normalized[cleanKey] = null;
+    } else if (typeof rawValue === 'boolean' || typeof rawValue === 'number') {
+      normalized[cleanKey] = rawValue;
+    } else if (Array.isArray(rawValue)) {
+      normalized[cleanKey] = rawValue
+        .slice(0, 10)
+        .map((item) => normalizeTelemetryString(item, 80));
+    } else if (typeof rawValue === 'object') {
+      normalized[cleanKey] = normalizeTelemetryObject(rawValue, depth + 1);
+    } else {
+      normalized[cleanKey] = normalizeTelemetryString(rawValue, 240);
+    }
+  }
+  return normalized;
+}
+
+function normalizeTelemetryPath(value) {
+  const path = normalizeTelemetryString(value || '/', 220);
+  if (!path || path[0] !== '/') return '/';
+  return path.split('?')[0].split('#')[0] || '/';
+}
+
+function parseTelemetryBody(req) {
+  if (req.body && typeof req.body === 'object' && !Buffer.isBuffer(req.body)) {
+    return req.body;
+  }
+
+  if (typeof req.body === 'string') {
+    return JSON.parse(req.body);
+  }
+
+  if (Buffer.isBuffer(req.body)) {
+    return JSON.parse(req.body.toString('utf8'));
+  }
+
+  throw new Error('Invalid JSON body');
+}
+
+function normalizeTelemetryEvent(rawEvent, receivedAt) {
+  if (!rawEvent || typeof rawEvent !== 'object') {
+    return null;
+  }
+
+  const name = normalizeTelemetryKey(rawEvent.name, 80);
+  const sessionId = normalizeTelemetryKey(rawEvent.sessionId, 120);
+  const visitorId = normalizeTelemetryKey(rawEvent.visitorId, 120);
+
+  if (!name || !sessionId || !visitorId) {
+    return null;
+  }
+
+  const clientTimestamp = Number.isNaN(Date.parse(rawEvent.clientTimestamp))
+    ? receivedAt.toISOString()
+    : new Date(rawEvent.clientTimestamp).toISOString();
+
+  return {
+    id: normalizeTelemetryKey(rawEvent.id, 120) || `${sessionId}_${receivedAt.getTime()}`,
+    name,
+    version: normalizeTelemetryString(rawEvent.version, 24),
+    sessionId,
+    visitorId,
+    userId: rawEvent.userId ? normalizeTelemetryKey(rawEvent.userId, 128) : null,
+    signedIn: rawEvent.signedIn === true,
+    clientTimestamp,
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    receivedAt: receivedAt.toISOString(),
+    pagePath: normalizeTelemetryPath(rawEvent.pagePath),
+    pageTitle: normalizeTelemetryString(rawEvent.pageTitle, 140),
+    queryKeys: Array.isArray(rawEvent.queryKeys)
+      ? rawEvent.queryKeys.slice(0, 20).map((key) => normalizeTelemetryKey(key, 60)).filter(Boolean)
+      : [],
+    referrer: normalizeTelemetryString(rawEvent.referrer, 160),
+    viewport: normalizeTelemetryObject(rawEvent.viewport),
+    screen: normalizeTelemetryObject(rawEvent.screen),
+    timezone: normalizeTelemetryString(rawEvent.timezone, 80),
+    language: normalizeTelemetryString(rawEvent.language, 32),
+    userAgent: normalizeTelemetryString(rawEvent.userAgent, 260),
+    properties: normalizeTelemetryObject(rawEvent.properties)
+  };
+}
+
+function telemetryDocId(value) {
+  return normalizeTelemetryKey(value, 140) || 'unknown';
+}
+
+function getDateKey(date) {
+  return date.toISOString().slice(0, 10);
+}
+
+function applyTelemetryAggregateWrites(batch, event, dateKey) {
+  const db = admin.firestore();
+  const increment = admin.firestore.FieldValue.increment;
+  const serverTimestamp = admin.firestore.FieldValue.serverTimestamp;
+  const isPageView = event.name === 'page_view';
+  const isInteraction = event.name.startsWith('interaction_');
+  const isError = event.name.startsWith('js_');
+
+  batch.set(db.collection('telemetryDaily').doc(dateKey), {
+    date: dateKey,
+    totalEvents: increment(1),
+    pageViews: increment(isPageView ? 1 : 0),
+    interactions: increment(isInteraction ? 1 : 0),
+    errors: increment(isError ? 1 : 0),
+    signedInEvents: increment(event.signedIn ? 1 : 0),
+    updatedAt: serverTimestamp()
+  }, { merge: true });
+
+  const pageDocId = `${dateKey}_${telemetryDocId(event.pagePath)}`;
+  batch.set(db.collection('telemetryPagesDaily').doc(pageDocId), {
+    date: dateKey,
+    pagePath: event.pagePath,
+    totalEvents: increment(1),
+    pageViews: increment(isPageView ? 1 : 0),
+    interactions: increment(isInteraction ? 1 : 0),
+    errors: increment(isError ? 1 : 0),
+    updatedAt: serverTimestamp()
+  }, { merge: true });
+
+  const eventDocId = `${dateKey}_${telemetryDocId(event.name)}`;
+  batch.set(db.collection('telemetryEventsDaily').doc(eventDocId), {
+    date: dateKey,
+    name: event.name,
+    count: increment(1),
+    updatedAt: serverTimestamp()
+  }, { merge: true });
+
+  const sessionUpdate = {
+    sessionId: event.sessionId,
+    visitorId: event.visitorId,
+    userId: event.userId || null,
+    signedIn: event.signedIn,
+    lastPage: event.pagePath,
+    lastEventName: event.name,
+    eventCount: increment(1),
+    pageViews: increment(isPageView ? 1 : 0),
+    interactions: increment(isInteraction ? 1 : 0),
+    errors: increment(isError ? 1 : 0),
+    updatedAt: serverTimestamp()
+  };
+
+  if (isPageView) {
+    sessionUpdate.entryPage = event.pagePath;
+  }
+
+  batch.set(db.collection('telemetrySessions').doc(event.sessionId), sessionUpdate, { merge: true });
 }
 
 const calendarServiceAccount =
@@ -219,6 +400,71 @@ exports.fetchCalendarIcs = functions
       res.status(400).json({
         ok: false,
         error: error?.message || 'Unknown error'
+      });
+    }
+  });
+
+exports.collectTelemetry = functions
+  .runWith({ timeoutSeconds: 15, memory: '256MB' })
+  .https
+  .onRequest(async (req, res) => {
+    writeCorsHeaders(req, res, 'POST,OPTIONS');
+
+    if (!isAllowedOrigin(req.headers.origin)) {
+      res.status(403).json({ ok: false, error: 'Origin not allowed' });
+      return;
+    }
+
+    if (req.method === 'OPTIONS') {
+      res.status(204).send('');
+      return;
+    }
+
+    if (req.method !== 'POST') {
+      res.status(405).json({ ok: false, error: 'Method not allowed' });
+      return;
+    }
+
+    const rawSize = Number(req.headers['content-length'] || 0);
+    if (rawSize > 64 * 1024) {
+      res.status(413).json({ ok: false, error: 'Telemetry payload too large' });
+      return;
+    }
+
+    try {
+      const payload = parseTelemetryBody(req);
+      const rawEvents = Array.isArray(payload?.events) ? payload.events.slice(0, 25) : [];
+      if (!rawEvents.length) {
+        res.status(400).json({ ok: false, error: 'No telemetry events provided' });
+        return;
+      }
+
+      const receivedAt = new Date();
+      const dateKey = getDateKey(receivedAt);
+      const events = rawEvents
+        .map((event) => normalizeTelemetryEvent(event, receivedAt))
+        .filter(Boolean);
+
+      if (!events.length) {
+        res.status(400).json({ ok: false, error: 'No valid telemetry events provided' });
+        return;
+      }
+
+      const db = admin.firestore();
+      const batch = db.batch();
+      events.forEach((event) => {
+        const eventRef = db.collection('telemetryEvents').doc(event.id);
+        batch.set(eventRef, event, { merge: false });
+        applyTelemetryAggregateWrites(batch, event, dateKey);
+      });
+
+      await batch.commit();
+      res.status(204).send('');
+    } catch (error) {
+      console.error('Telemetry collection failed:', error);
+      res.status(400).json({
+        ok: false,
+        error: error?.message || 'Telemetry collection failed'
       });
     }
   });

--- a/functions/index.js
+++ b/functions/index.js
@@ -180,6 +180,19 @@ function normalizeTelemetryKey(value, maxLength = 80) {
     .slice(0, maxLength);
 }
 
+function normalizeTelemetryIdentifier(value, maxLength = 120) {
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .trim()
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '')
+    .replace(/\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]?\d{4}\b/g, '')
+    .replace(/\s+/g, '_')
+    .replace(/[^\w:-]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .slice(0, maxLength);
+}
+
 function normalizeTelemetryObject(value, depth = 0) {
   if (!value || typeof value !== 'object' || Array.isArray(value) || depth > 2) {
     return {};
@@ -235,8 +248,8 @@ function normalizeTelemetryEvent(rawEvent, receivedAt) {
   }
 
   const name = normalizeTelemetryKey(rawEvent.name, 80);
-  const sessionId = normalizeTelemetryKey(rawEvent.sessionId, 120);
-  const visitorId = normalizeTelemetryKey(rawEvent.visitorId, 120);
+  const sessionId = normalizeTelemetryIdentifier(rawEvent.sessionId, 120);
+  const visitorId = normalizeTelemetryIdentifier(rawEvent.visitorId, 120);
 
   if (!name || !sessionId || !visitorId) {
     return null;
@@ -247,12 +260,12 @@ function normalizeTelemetryEvent(rawEvent, receivedAt) {
     : new Date(rawEvent.clientTimestamp).toISOString();
 
   return {
-    id: normalizeTelemetryKey(rawEvent.id, 120) || `${sessionId}_${receivedAt.getTime()}`,
+    id: normalizeTelemetryIdentifier(rawEvent.id, 120) || `${sessionId}_${receivedAt.getTime()}`,
     name,
     version: normalizeTelemetryString(rawEvent.version, 24),
     sessionId,
     visitorId,
-    userId: rawEvent.userId ? normalizeTelemetryKey(rawEvent.userId, 128) : null,
+    userId: rawEvent.userId ? normalizeTelemetryIdentifier(rawEvent.userId, 128) : null,
     signedIn: rawEvent.signedIn === true,
     clientTimestamp,
     createdAt: admin.firestore.FieldValue.serverTimestamp(),

--- a/functions/index.js
+++ b/functions/index.js
@@ -151,6 +151,10 @@ function isAllowedOrigin(origin) {
   return allowedOriginSet.has(origin);
 }
 
+function isAllowedTelemetryOrigin(origin) {
+  return !!origin && allowedOriginSet.has(origin);
+}
+
 function writeCorsHeaders(req, res, methods = 'GET,OPTIONS') {
   const origin = req.headers.origin;
   if (origin && allowedOriginSet.has(origin)) {
@@ -158,7 +162,7 @@ function writeCorsHeaders(req, res, methods = 'GET,OPTIONS') {
     res.set('Vary', 'Origin');
   }
   res.set('Access-Control-Allow-Methods', methods);
-  res.set('Access-Control-Allow-Headers', 'Content-Type');
+  res.set('Access-Control-Allow-Headers', 'Authorization, Content-Type');
   res.set('Cache-Control', 'no-store');
 }
 
@@ -238,18 +242,40 @@ function parseTelemetryBody(req) {
     return req.body;
   }
 
-  if (typeof req.body === 'string') {
-    return JSON.parse(req.body);
-  }
+  try {
+    if (typeof req.body === 'string') {
+      return JSON.parse(req.body);
+    }
 
-  if (Buffer.isBuffer(req.body)) {
-    return JSON.parse(req.body.toString('utf8'));
+    if (Buffer.isBuffer(req.body)) {
+      return JSON.parse(req.body.toString('utf8'));
+    }
+  } catch (error) {
+    throw new Error('Invalid JSON body');
   }
 
   throw new Error('Invalid JSON body');
 }
 
-function normalizeTelemetryEvent(rawEvent, receivedAt) {
+function getTelemetryBearerToken(req, payload) {
+  const authHeader = req.headers.authorization || '';
+  const match = typeof authHeader === 'string' ? authHeader.match(/^Bearer\s+(.+)$/i) : null;
+  if (match?.[1]) return match[1].trim();
+  return typeof payload?.authToken === 'string' ? payload.authToken.trim() : '';
+}
+
+async function verifyTelemetryAuth(req, payload) {
+  const token = getTelemetryBearerToken(req, payload);
+  if (!token) return null;
+
+  try {
+    return await admin.auth().verifyIdToken(token);
+  } catch (error) {
+    throw new Error('Invalid telemetry auth token');
+  }
+}
+
+function normalizeTelemetryEvent(rawEvent, receivedAt, authUid = null) {
   if (!rawEvent || typeof rawEvent !== 'object') {
     return null;
   }
@@ -272,8 +298,8 @@ function normalizeTelemetryEvent(rawEvent, receivedAt) {
     version: normalizeTelemetryString(rawEvent.version, 24),
     sessionId,
     visitorId,
-    userId: rawEvent.userId ? normalizeTelemetryIdentifier(rawEvent.userId, 128) : null,
-    signedIn: rawEvent.signedIn === true,
+    userId: authUid || null,
+    signedIn: !!authUid && rawEvent.signedIn === true,
     clientTimestamp,
     createdAt: admin.firestore.FieldValue.serverTimestamp(),
     receivedAt: receivedAt.toISOString(),
@@ -358,6 +384,39 @@ function applyTelemetryAggregateWrites(batch, event, dateKey) {
   batch.set(db.collection('telemetrySessions').doc(event.sessionId), sessionUpdate, { merge: true });
 }
 
+const MAX_TELEMETRY_EVENTS_PER_REQUEST = 25;
+const TELEMETRY_WRITES_PER_EVENT = 5;
+const FIRESTORE_WRITE_SAFETY_LIMIT = 450;
+
+async function commitTelemetryEvent(db, event, dateKey) {
+  const eventRef = db.collection('telemetryEvents').doc(event.id);
+  return db.runTransaction(async (transaction) => {
+    const existing = await transaction.get(eventRef);
+    if (existing.exists) {
+      return false;
+    }
+
+    transaction.create(eventRef, event);
+    applyTelemetryAggregateWrites(transaction, event, dateKey);
+    return true;
+  });
+}
+
+async function commitTelemetryEvents(db, events, dateKey) {
+  const maxEventsPerChunk = Math.max(1, Math.floor(FIRESTORE_WRITE_SAFETY_LIMIT / TELEMETRY_WRITES_PER_EVENT));
+  let stored = 0;
+  let duplicates = 0;
+
+  for (let i = 0; i < events.length; i += maxEventsPerChunk) {
+    const chunk = events.slice(i, i + maxEventsPerChunk);
+    const results = await Promise.all(chunk.map((event) => commitTelemetryEvent(db, event, dateKey)));
+    stored += results.filter(Boolean).length;
+    duplicates += results.filter((result) => !result).length;
+  }
+
+  return { stored, duplicates };
+}
+
 const calendarServiceAccount =
   functions.config()?.calendar?.service_account ||
   process.env.CALENDAR_FETCH_SERVICE_ACCOUNT ||
@@ -430,7 +489,7 @@ exports.collectTelemetry = functions
   .onRequest(async (req, res) => {
     writeCorsHeaders(req, res, 'POST,OPTIONS');
 
-    if (!isAllowedOrigin(req.headers.origin)) {
+    if (!isAllowedTelemetryOrigin(req.headers.origin)) {
       res.status(403).json({ ok: false, error: 'Origin not allowed' });
       return;
     }
@@ -453,7 +512,10 @@ exports.collectTelemetry = functions
 
     try {
       const payload = parseTelemetryBody(req);
-      const rawEvents = Array.isArray(payload?.events) ? payload.events.slice(0, 25) : [];
+      const verifiedAuth = await verifyTelemetryAuth(req, payload);
+      const rawEvents = Array.isArray(payload?.events)
+        ? payload.events.slice(0, MAX_TELEMETRY_EVENTS_PER_REQUEST)
+        : [];
       if (!rawEvents.length) {
         res.status(400).json({ ok: false, error: 'No telemetry events provided' });
         return;
@@ -462,7 +524,7 @@ exports.collectTelemetry = functions
       const receivedAt = new Date();
       const dateKey = getDateKey(receivedAt);
       const events = rawEvents
-        .map((event) => normalizeTelemetryEvent(event, receivedAt))
+        .map((event) => normalizeTelemetryEvent(event, receivedAt, verifiedAuth?.uid || null))
         .filter(Boolean);
 
       if (!events.length) {
@@ -471,14 +533,7 @@ exports.collectTelemetry = functions
       }
 
       const db = admin.firestore();
-      const batch = db.batch();
-      events.forEach((event) => {
-        const eventRef = db.collection('telemetryEvents').doc(event.id);
-        batch.set(eventRef, event, { merge: false });
-        applyTelemetryAggregateWrites(batch, event, dateKey);
-      });
-
-      await batch.commit();
+      await commitTelemetryEvents(db, events, dateKey);
       res.status(204).send('');
     } catch (error) {
       console.error('Telemetry collection failed:', error);

--- a/functions/index.js
+++ b/functions/index.js
@@ -175,8 +175,15 @@ function normalizeTelemetryString(value, maxLength = 160) {
 }
 
 function normalizeTelemetryKey(value, maxLength = 80) {
-  return normalizeTelemetryString(value, maxLength)
+  if (value === null || value === undefined) return '';
+  return String(value)
+    .trim()
+    .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '')
+    .replace(/\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]?\d{4}\b/g, '')
+    .replace(/\s+/g, '_')
     .replace(/[^\w:-]/g, '_')
+    .replace(/_+/g, '_')
+    .replace(/^_+|_+$/g, '')
     .slice(0, maxLength);
 }
 

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -6,46 +6,42 @@
     "": {
       "name": "allplays-functions",
       "dependencies": {
+        "firebase-admin": "^12.7.0",
         "firebase-functions": "^5.1.1"
       },
       "engines": {
-        "node": "18"
+        "node": "20"
       }
     },
     "node_modules/@fastify/busboy": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-3.2.0.tgz",
       "integrity": "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@firebase/app-check-interop-types": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.2.tgz",
       "integrity": "sha512-LMs47Vinv2HBMZi49C09dJxp0QT5LwDzFaVGf/+ITHe3BlIhUiLNttkATSXplc89A2lAaeTqjgqVkiRfUGyQiQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/app-types": {
       "version": "0.9.2",
       "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.2.tgz",
       "integrity": "sha512-oMEZ1TDlBz479lmABwWsWjzHwheQKiAgnuKxE0pz0IXCVx7/rtlkx1fQ6GfgK24WCrxDKMplZrT50Kh04iMbXQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/auth-interop-types": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.3.tgz",
       "integrity": "sha512-Fc9wuJGgxoxQeavybiuwgyi+0rssr76b+nHpj+eGhXFYAdudMWyfBHvFL/I5fEHniUM/UQdFzi9VXJK2iZF7FQ==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@firebase/component": {
       "version": "0.6.9",
       "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.6.9.tgz",
       "integrity": "sha512-gm8EUEJE/fEac86AvHn8Z/QW8BvR56TBw3hMW0O838J/1mThYQXAIQBgUv75EqlCZfdawpWLrKt1uXvp9ciK3Q==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/util": "1.10.0",
         "tslib": "^2.1.0"
@@ -56,7 +52,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.0.8.tgz",
       "integrity": "sha512-dzXALZeBI1U5TXt6619cv0+tgEhJiwlUtQ55WNZY7vGAjv7Q1QioV969iYwt1AQQ0ovHnEW0YW9TiBfefLvErg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app-check-interop-types": "0.3.2",
         "@firebase/auth-interop-types": "0.2.3",
@@ -72,7 +67,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-1.0.8.tgz",
       "integrity": "sha512-OpeWZoPE3sGIRPBKYnW9wLad25RaWbGyk7fFQe4xnJQKRzlynWeFBSRRAoLE2Old01WXwskUiucNqUUVlFsceg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/component": "0.6.9",
         "@firebase/database": "1.0.8",
@@ -87,7 +81,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.5.tgz",
       "integrity": "sha512-fTlqCNwFYyq/C6W7AJ5OCuq5CeZuBEsEwptnVxlNPkWCo5cTTyukzAHRSO/jaQcItz33FfYrrFk1SJofcu2AaQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@firebase/app-types": "0.9.2",
         "@firebase/util": "1.10.0"
@@ -98,7 +91,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.4.2.tgz",
       "integrity": "sha512-Q1VuA5M1Gjqrwom6I6NUU4lQXdo9IAQieXlujeHZWvRt1b7qQ0KwBaNAjgxG27jgF9/mUwsNmO8ptBCGVYhB0A==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -108,7 +100,6 @@
       "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.10.0.tgz",
       "integrity": "sha512-xKtx4A668icQqoANRxyDLBLz51TAbDP9KRfpbKGxiCAW346d0BeJe5vN6/hKxxmWwnZ0mautyv39JxviwwQMOQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -119,7 +110,6 @@
       "integrity": "sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.3.0",
         "fast-deep-equal": "^3.1.1",
@@ -137,7 +127,6 @@
       "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "arrify": "^2.0.0",
         "extend": "^3.0.2"
@@ -152,7 +141,6 @@
       "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=14.0.0"
       }
@@ -163,7 +151,6 @@
       "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -174,7 +161,6 @@
       "integrity": "sha512-n2FjE7NAOYyshogdc7KQOl/VZb4sneqPjWouSyia9CMDdMhRX5+RIbqalNmC7LOLzuLAN89VlF2HvG8na9G+zQ==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@google-cloud/paginator": "^5.0.0",
         "@google-cloud/projectify": "^4.0.0",
@@ -202,7 +188,6 @@
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -213,7 +198,6 @@
       "integrity": "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@grpc/proto-loader": "^0.8.0",
         "@js-sdsl/ordered-map": "^4.4.2"
@@ -228,7 +212,6 @@
       "integrity": "sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -248,7 +231,6 @@
       "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "lodash.camelcase": "^4.3.0",
         "long": "^5.0.0",
@@ -268,7 +250,6 @@
       "integrity": "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/js-sdsl"
@@ -280,7 +261,6 @@
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -355,7 +335,6 @@
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 10"
       }
@@ -375,8 +354,7 @@
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
@@ -430,7 +408,6 @@
       "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
       "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/ms": "*",
         "@types/node": "*"
@@ -441,15 +418,13 @@
       "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
       "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/node": {
       "version": "22.19.13",
@@ -478,7 +453,6 @@
       "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/caseless": "*",
         "@types/node": "*",
@@ -510,8 +484,7 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",
@@ -519,7 +492,6 @@
       "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "event-target-shim": "^5.0.0"
       },
@@ -546,7 +518,6 @@
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 14"
       }
@@ -557,7 +528,6 @@
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -568,7 +538,6 @@
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -591,7 +560,6 @@
       "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -602,7 +570,6 @@
       "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "retry": "0.13.1"
       }
@@ -612,8 +579,7 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -634,8 +600,7 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
@@ -643,7 +608,6 @@
       "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -676,8 +640,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
-      "license": "BSD-3-Clause",
-      "peer": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -723,7 +686,6 @@
       "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
       "license": "ISC",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
@@ -739,7 +701,6 @@
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -752,8 +713,7 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -761,7 +721,6 @@
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -837,7 +796,6 @@
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -881,7 +839,6 @@
       "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.4.1",
         "inherits": "^2.0.3",
@@ -894,7 +851,6 @@
       "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
       "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
@@ -910,8 +866,7 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -928,7 +883,6 @@
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -969,7 +923,6 @@
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "es-errors": "^1.3.0",
         "get-intrinsic": "^1.2.6",
@@ -986,7 +939,6 @@
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -1012,7 +964,6 @@
       "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -1068,15 +1019,13 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/farmhash-modern": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/farmhash-modern/-/farmhash-modern-1.1.0.tgz",
       "integrity": "sha512-6ypT4XfgqJk/F3Yuv4SX26I3doUjt0GTG4a+JgWxXQpxXzTBq8fPUeGHfcYMMDPHJHm3yPOSjaeBwBGAHWXCdA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18.0.0"
       }
@@ -1086,8 +1035,7 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/fast-xml-builder": {
       "version": "1.0.0",
@@ -1100,8 +1048,7 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/fast-xml-parser": {
       "version": "5.4.1",
@@ -1115,7 +1062,6 @@
       ],
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "fast-xml-builder": "^1.0.0",
         "strnum": "^2.1.2"
@@ -1129,7 +1075,6 @@
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
       "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "websocket-driver": ">=0.5.1"
       },
@@ -1160,7 +1105,6 @@
       "resolved": "https://registry.npmjs.org/firebase-admin/-/firebase-admin-12.7.0.tgz",
       "integrity": "sha512-raFIrOyTqREbyXsNkSHyciQLfv8AUZazehPaQS1lZBSCDYW74FYXU0nQZa3qHI4K+hawohlDbywZ4+qce9YNxA==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@fastify/busboy": "^3.0.0",
         "@firebase/database-compat": "1.0.8",
@@ -1208,7 +1152,6 @@
       "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -1253,8 +1196,7 @@
       "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
       "integrity": "sha512-dsKNQNdj6xA3T+QlADDA7mOSlX0qiMINjn0cgr+eGHGsbSHzTabcIogz2+p/iqP1Xs6EP/sS2SbqH+brGTbq0g==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/gaxios": {
       "version": "6.7.1",
@@ -1262,7 +1204,6 @@
       "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
@@ -1284,7 +1225,6 @@
       ],
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -1295,7 +1235,6 @@
       "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "gaxios": "^6.1.1",
         "google-logging-utils": "^0.0.2",
@@ -1311,7 +1250,6 @@
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "license": "ISC",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
       }
@@ -1359,7 +1297,6 @@
       "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
@@ -1378,7 +1315,6 @@
       "integrity": "sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@grpc/grpc-js": "^1.10.9",
         "@grpc/proto-loader": "^0.7.13",
@@ -1407,7 +1343,6 @@
       ],
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -1418,7 +1353,6 @@
       "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -1441,7 +1375,6 @@
       "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "gaxios": "^6.0.0",
         "jws": "^4.0.0"
@@ -1468,7 +1401,6 @@
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "has-symbols": "^1.0.3"
       },
@@ -1506,8 +1438,7 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -1533,8 +1464,7 @@
       "version": "0.5.10",
       "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
       "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/http-proxy-agent": {
       "version": "5.0.0",
@@ -1542,7 +1472,6 @@
       "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@tootallnate/once": "2",
         "agent-base": "6",
@@ -1558,7 +1487,6 @@
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -1572,7 +1500,6 @@
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1590,8 +1517,7 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
@@ -1599,7 +1525,6 @@
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "4"
@@ -1614,7 +1539,6 @@
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1632,8 +1556,7 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
@@ -1668,7 +1591,6 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -1679,7 +1601,6 @@
       "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       },
@@ -1692,7 +1613,6 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-4.15.9.tgz",
       "integrity": "sha512-1vUQX+IdDMVPj4k8kOxgUqlcK518yluMuGZwqlr44FS1ppZB/5GWh4rZG89erpOBOJjU/OBsnCVFfapsRz6nEA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -1703,7 +1623,6 @@
       "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "bignumber.js": "^9.0.0"
       }
@@ -1713,7 +1632,6 @@
       "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.3.tgz",
       "integrity": "sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jws": "^4.0.1",
         "lodash.includes": "^4.3.0",
@@ -1735,15 +1653,13 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jwa": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
       "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "buffer-equal-constant-time": "^1.0.1",
         "ecdsa-sig-formatter": "1.0.11",
@@ -1755,7 +1671,6 @@
       "resolved": "https://registry.npmjs.org/jwks-rsa/-/jwks-rsa-3.2.2.tgz",
       "integrity": "sha512-BqTyEDV+lS8F2trk3A+qJnxV5Q9EqKCBJOPti3W97r7qTympCZjb7h2X6f2kc+0K3rsSTY1/6YG2eaXKoj497w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/jsonwebtoken": "^9.0.4",
         "debug": "^4.3.4",
@@ -1772,7 +1687,6 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -1789,15 +1703,13 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/jws": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
       "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "jwa": "^2.0.1",
         "safe-buffer": "^5.0.1"
@@ -1806,72 +1718,62 @@
     "node_modules/limiter": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/limiter/-/limiter-1.1.5.tgz",
-      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA==",
-      "peer": true
+      "integrity": "sha512-FWWMIEOxz3GwUI4Ts/IvgVy6LPvoMPgjMdQ185nN6psJyBJ4yOpzqm695/h5umdLJg2vW3GR5iG11MAkR2AzJA=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
       "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.includes": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
       "integrity": "sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isboolean": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
       "integrity": "sha512-Bz5mupy2SVbPHURB98VAcw+aHh4vRV5IPNhILUCsOzRmsTmSQ17jIuqopAentWoehktxGd9e/hbIXq980/1QJg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isinteger": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
       "integrity": "sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isnumber": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
       "integrity": "sha512-QYqzpfwO3/CWf3XP+Z+tkQsfaLL/EnUlXWVkIk5FUPc4sBdTehEqZONuyRt2P67PXAk+NXmTBcc97zw9t1FQrw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isplainobject": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
       "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.isstring": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
       "integrity": "sha512-0wJxfxH1wgO3GrbuP+dTTk7op+6L41QCXbGINEmD+ny/G/eCqGzxyCsh7159S+mgDDcoarnBw6PC1PS5+wUGgw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash.once": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
       "integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/long": {
       "version": "5.3.2",
@@ -1884,7 +1786,6 @@
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -1897,7 +1798,6 @@
       "resolved": "https://registry.npmjs.org/lru-memoizer/-/lru-memoizer-2.3.0.tgz",
       "integrity": "sha512-GXn7gyHAMhO13WSKrIiNfztwxodVsP8IoZ3XfrJV4yH2x0/OeTO/FIaAHTY5YekdGgW94njfuKmyyt1E0mR6Ug==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
         "lru-cache": "6.0.0"
@@ -1945,7 +1845,6 @@
       "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -1995,7 +1894,6 @@
       "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -2012,11 +1910,10 @@
       }
     },
     "node_modules/node-forge": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.3.3.tgz",
-      "integrity": "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.4.0.tgz",
+      "integrity": "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ==",
       "license": "(BSD-3-Clause OR GPL-2.0)",
-      "peer": true,
       "engines": {
         "node": ">= 6.13.0"
       }
@@ -2036,7 +1933,6 @@
       "integrity": "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 6"
       }
@@ -2071,7 +1967,6 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -2082,7 +1977,6 @@
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
@@ -2114,7 +2008,6 @@
       "integrity": "sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "protobufjs": "^7.2.5"
       },
@@ -2204,7 +2097,6 @@
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -2220,7 +2112,6 @@
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2231,7 +2122,6 @@
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">= 4"
       }
@@ -2242,7 +2132,6 @@
       "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@types/request": "^2.48.8",
         "extend": "^3.0.2",
@@ -2283,7 +2172,6 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "license": "ISC",
-      "peer": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -2441,7 +2329,6 @@
       "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "stubs": "^3.0.0"
       }
@@ -2451,8 +2338,7 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -2460,7 +2346,6 @@
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -2471,7 +2356,6 @@
       "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "emoji-regex": "^8.0.0",
         "is-fullwidth-code-point": "^3.0.0",
@@ -2487,7 +2371,6 @@
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1"
       },
@@ -2506,16 +2389,14 @@
         }
       ],
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/stubs": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
       "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/teeny-request": {
       "version": "9.0.0",
@@ -2523,7 +2404,6 @@
       "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
       "license": "Apache-2.0",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "http-proxy-agent": "^5.0.0",
         "https-proxy-agent": "^5.0.0",
@@ -2541,7 +2421,6 @@
       "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "debug": "4"
       },
@@ -2555,7 +2434,6 @@
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2574,7 +2452,6 @@
       "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "agent-base": "6",
         "debug": "4"
@@ -2588,8 +2465,7 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/teeny-request/node_modules/uuid": {
       "version": "9.0.1",
@@ -2601,7 +2477,6 @@
       ],
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -2620,15 +2495,13 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -2663,8 +2536,7 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -2679,12 +2551,12 @@
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
       "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
-      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -2703,15 +2575,13 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/websocket-driver": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
       "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",
@@ -2726,7 +2596,6 @@
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
       "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -2737,7 +2606,6 @@
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -2749,7 +2617,6 @@
       "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
@@ -2767,8 +2634,7 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC",
-      "optional": true,
-      "peer": true
+      "optional": true
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -2776,7 +2642,6 @@
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "license": "ISC",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       }
@@ -2785,8 +2650,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",
@@ -2794,7 +2658,6 @@
       "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "cliui": "^8.0.1",
         "escalade": "^3.1.1",
@@ -2814,7 +2677,6 @@
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -2825,7 +2687,6 @@
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },

--- a/functions/package.json
+++ b/functions/package.json
@@ -11,6 +11,7 @@
     "logs": "firebase functions:log"
   },
   "dependencies": {
+    "firebase-admin": "^12.7.0",
     "firebase-functions": "^5.1.1"
   }
 }

--- a/game-day.html
+++ b/game-day.html
@@ -71,6 +71,7 @@
         .diamond-field::before,
         .diamond-field::after { display: none; }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="bg-gray-50 min-h-screen">
 

--- a/game-plan.html
+++ b/game-plan.html
@@ -72,6 +72,7 @@
             50% { box-shadow: 0 0 0 6px rgba(245, 158, 11, 0.2); }
         }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gradient-to-br from-gray-50 to-gray-100 text-gray-900">

--- a/game.html
+++ b/game.html
@@ -38,6 +38,7 @@
             }
         }
     </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gradient-to-br from-gray-50 to-gray-100 text-gray-900">

--- a/help-account.html
+++ b/help-account.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Help - Account and Access</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="bg-slate-50 text-slate-900 min-h-screen">
   <main class="max-w-6xl mx-auto px-4 py-8">

--- a/help-game-operations.html
+++ b/help-game-operations.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Help - Game Operations</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="bg-slate-50 text-slate-900 min-h-screen">
   <main class="max-w-6xl mx-auto px-4 py-8">

--- a/help-page-reference.html
+++ b/help-page-reference.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Help - File-by-File Page Reference</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="bg-slate-50 text-slate-900 min-h-screen">
   <main class="max-w-7xl mx-auto px-4 py-8">

--- a/help-team-operations.html
+++ b/help-team-operations.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Help - Team Operations</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="bg-slate-50 text-slate-900 min-h-screen">
   <main class="max-w-6xl mx-auto px-4 py-8">

--- a/help-watch-chat.html
+++ b/help-watch-chat.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Help - Watch and Chat</title>
   <script src="https://cdn.tailwindcss.com"></script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="bg-slate-50 text-slate-900 min-h-screen">
   <main class="max-w-6xl mx-auto px-4 py-8">

--- a/help.html
+++ b/help.html
@@ -123,6 +123,7 @@
         }
       }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="text-gray-900 min-h-screen flex flex-col">
     <div id="header-container"></div>

--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
       }
     }
   </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gradient-to-br from-gray-50 to-gray-100 text-gray-900 antialiased">

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,4 +1,13 @@
-import { getTeams, getAllUsers, deleteTeam } from './db.js?v=14';
+import {
+    getTeams,
+    getAllUsers,
+    deleteTeam,
+    getTelemetryEvents,
+    getTelemetryDaily,
+    getTelemetryPageDaily,
+    getTelemetryEventDaily,
+    getTelemetrySessions
+} from './db.js?v=14';
 import { renderHeader, renderFooter, escapeHtml } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=10';
 
@@ -6,6 +15,16 @@ let allTeams = [];
 let allUsers = [];
 let currentUser = null; // Declare currentUser
 let showInactiveTeams = false;
+let telemetryState = {
+    loaded: false,
+    loading: false,
+    days: 7,
+    events: [],
+    daily: [],
+    pages: [],
+    eventDaily: [],
+    sessions: []
+};
 
 function isTeamActive(team) {
     return team?.active !== false;
@@ -41,12 +60,16 @@ async function loadData() {
         allTeams = teams;
         allUsers = users;
 
-        // Load game stats for all teams
-        await loadGameStats();
+        // Load game stats for all teams and telemetry in parallel after core data is available.
+        await Promise.all([
+            loadGameStats(),
+            loadTelemetryData({ silent: true })
+        ]);
 
         updateDashboard();
         renderTeams(getVisibleTeams());
         renderUsers(allUsers);
+        updateTelemetryDashboard();
     } catch (error) {
         console.error('Error loading admin data:', error);
         alert('Failed to load data');
@@ -68,6 +91,55 @@ async function loadGameStats() {
     });
     const gamesArrays = await Promise.all(gamesPromises);
     allGames = gamesArrays.flat();
+}
+
+function getTelemetryRangeDays() {
+    const select = document.getElementById('telemetry-range');
+    return Number(select?.value || telemetryState.days || 7);
+}
+
+async function loadTelemetryData({ silent = false } = {}) {
+    if (telemetryState.loading) return;
+
+    telemetryState.loading = true;
+    telemetryState.days = getTelemetryRangeDays();
+    const status = document.getElementById('telemetry-status');
+    if (status && !silent) {
+        status.textContent = 'Loading telemetry...';
+    }
+
+    try {
+        const days = telemetryState.days;
+        const maxEvents = days <= 1 ? 1000 : days <= 7 ? 2000 : 5000;
+        const [events, daily, pages, eventDaily, sessions] = await Promise.all([
+            getTelemetryEvents({ days, maxEvents }),
+            getTelemetryDaily({ days }),
+            getTelemetryPageDaily({ days }),
+            getTelemetryEventDaily({ days }),
+            getTelemetrySessions({ maxSessions: 300 })
+        ]);
+
+        telemetryState = {
+            loaded: true,
+            loading: false,
+            days,
+            events,
+            daily,
+            pages,
+            eventDaily,
+            sessions
+        };
+        if (status) {
+            status.textContent = `Loaded ${events.length.toLocaleString()} recent raw events plus aggregate summaries.`;
+        }
+    } catch (error) {
+        console.error('Error loading telemetry:', error);
+        telemetryState.loading = false;
+        telemetryState.loaded = false;
+        if (status) {
+            status.textContent = `Telemetry could not be loaded: ${error.message}`;
+        }
+    }
 }
 
 function updateDashboard() {
@@ -179,6 +251,191 @@ function updateDashboard() {
     `).join('');
 }
 
+function telemetryDate(value) {
+    if (!value) return null;
+    if (value.toDate) return value.toDate();
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function telemetryNumber(value) {
+    return Number(value || 0).toLocaleString();
+}
+
+function sumBy(items, key) {
+    return items.reduce((sum, item) => sum + Number(item[key] || 0), 0);
+}
+
+function groupTelemetry(items, key, countKey = 'count') {
+    const grouped = new Map();
+    items.forEach((item) => {
+        const groupKey = item[key] || 'Unknown';
+        const current = grouped.get(groupKey) || { key: groupKey, count: 0, item };
+        current.count += Number(item[countKey] || 0);
+        grouped.set(groupKey, current);
+    });
+    return Array.from(grouped.values()).sort((a, b) => b.count - a.count);
+}
+
+function getFilteredTelemetryEvents() {
+    const eventFilter = document.getElementById('telemetry-event-filter')?.value || '';
+    const pageFilter = (document.getElementById('telemetry-page-filter')?.value || '').toLowerCase();
+    return telemetryState.events.filter((event) => {
+        const eventMatches = !eventFilter || event.name === eventFilter;
+        const pageMatches = !pageFilter || (event.pagePath || '').toLowerCase().includes(pageFilter);
+        return eventMatches && pageMatches;
+    });
+}
+
+function getTelemetryTarget(event) {
+    const props = event.properties || {};
+    return props.telemetryName || props.label || props.elementId || props.formId || props.tagName || '-';
+}
+
+function renderMetric(id, value) {
+    const element = document.getElementById(id);
+    if (element) element.textContent = telemetryNumber(value);
+}
+
+function renderEmptyTelemetry(id, message = 'No telemetry yet.') {
+    const element = document.getElementById(id);
+    if (element) {
+        element.innerHTML = `<p class="text-gray-400 text-sm">${escapeHtml(message)}</p>`;
+    }
+}
+
+function renderTelemetryList(id, rows, renderer, emptyMessage) {
+    const element = document.getElementById(id);
+    if (!element) return;
+    if (!rows.length) {
+        renderEmptyTelemetry(id, emptyMessage);
+        return;
+    }
+    element.innerHTML = rows.map(renderer).join('');
+}
+
+function renderTelemetryTrend() {
+    const rows = [...telemetryState.daily].sort((a, b) => (a.date || '').localeCompare(b.date || ''));
+    const maxEvents = Math.max(...rows.map((row) => Number(row.totalEvents || 0)), 1);
+    renderTelemetryList('telemetry-daily-trend', rows, (row) => {
+        const total = Number(row.totalEvents || 0);
+        const width = Math.max(4, Math.round((total / maxEvents) * 100));
+        return `
+            <div>
+                <div class="flex items-center justify-between text-xs text-gray-500 mb-1">
+                    <span>${escapeHtml(row.date || '-')}</span>
+                    <span>${telemetryNumber(total)} events · ${telemetryNumber(row.pageViews)} views</span>
+                </div>
+                <div class="h-3 bg-gray-100 rounded-full overflow-hidden">
+                    <div class="h-full bg-primary-600 rounded-full" style="width: ${width}%"></div>
+                </div>
+            </div>
+        `;
+    }, 'No daily telemetry has been recorded for this range.');
+}
+
+function renderTopTelemetryPages() {
+    const grouped = groupTelemetry(telemetryState.pages, 'pagePath', 'pageViews').slice(0, 20);
+    renderTelemetryList('telemetry-top-pages', grouped, ({ key, count, item }) => `
+        <div class="flex items-center justify-between gap-3 border-b border-gray-100 pb-2 last:border-0">
+            <div class="min-w-0">
+                <p class="font-medium text-gray-900 truncate">${escapeHtml(key)}</p>
+                <p class="text-xs text-gray-500">${telemetryNumber(item.interactions)} interactions · ${telemetryNumber(item.errors)} errors</p>
+            </div>
+            <span class="text-sm font-semibold text-gray-900">${telemetryNumber(count)}</span>
+        </div>
+    `, 'No page telemetry has been recorded for this range.');
+}
+
+function renderTopTelemetryEvents() {
+    const grouped = groupTelemetry(telemetryState.eventDaily, 'name', 'count').slice(0, 20);
+    renderTelemetryList('telemetry-top-events', grouped, ({ key, count }) => `
+        <div class="flex items-center justify-between gap-3 border-b border-gray-100 pb-2 last:border-0">
+            <span class="text-sm font-medium text-gray-800 truncate">${escapeHtml(key)}</span>
+            <span class="text-sm font-semibold text-gray-900">${telemetryNumber(count)}</span>
+        </div>
+    `, 'No event telemetry has been recorded for this range.');
+}
+
+function renderRecentTelemetrySessions() {
+    const cutoff = Date.now() - telemetryState.days * 24 * 60 * 60 * 1000;
+    const sessions = telemetryState.sessions
+        .filter((session) => {
+            const updatedAt = telemetryDate(session.updatedAt);
+            return !updatedAt || updatedAt.getTime() >= cutoff;
+        })
+        .slice(0, 25);
+
+    renderTelemetryList('telemetry-recent-sessions', sessions, (session) => {
+        const updatedAt = telemetryDate(session.updatedAt);
+        return `
+            <div class="border-b border-gray-100 pb-3 last:border-0">
+                <div class="flex items-center justify-between gap-3">
+                    <p class="font-medium text-gray-900 truncate">${escapeHtml(session.lastPage || session.entryPage || '-')}</p>
+                    <span class="text-xs text-gray-500 whitespace-nowrap">${updatedAt ? updatedAt.toLocaleString() : '-'}</span>
+                </div>
+                <p class="text-xs text-gray-500 mt-1">${telemetryNumber(session.eventCount)} events · ${telemetryNumber(session.pageViews)} views · ${telemetryNumber(session.interactions)} interactions</p>
+                <p class="text-xs text-gray-400 mt-1 truncate">${escapeHtml(session.userId ? `User ${session.userId}` : `Visitor ${session.visitorId || '-'}`)}</p>
+            </div>
+        `;
+    }, 'No recent sessions have been recorded for this range.');
+}
+
+function renderTelemetryEventsTable() {
+    const tbody = document.getElementById('telemetry-events-table');
+    if (!tbody) return;
+
+    const events = getFilteredTelemetryEvents().slice(0, 150);
+    if (!events.length) {
+        tbody.innerHTML = `
+            <tr>
+                <td colspan="5" class="px-6 py-4 text-sm text-gray-400">No events match the current filters.</td>
+            </tr>
+        `;
+        return;
+    }
+
+    tbody.innerHTML = events.map((event) => {
+        const createdAt = telemetryDate(event.createdAt) || telemetryDate(event.clientTimestamp);
+        return `
+            <tr>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">${createdAt ? createdAt.toLocaleString() : '-'}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">${escapeHtml(event.name || '-')}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">${escapeHtml(event.pagePath || '-')}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">${escapeHtml(getTelemetryTarget(event))}</td>
+                <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">${event.userId ? 'Signed in' : 'Anonymous'}</td>
+            </tr>
+        `;
+    }).join('');
+}
+
+function updateTelemetryDashboard() {
+    if (!telemetryState.loaded) {
+        renderMetric('telemetry-total-events', 0);
+        renderMetric('telemetry-page-views', 0);
+        renderMetric('telemetry-interactions', 0);
+        renderMetric('telemetry-sessions', 0);
+        renderMetric('telemetry-known-users', 0);
+        renderMetric('telemetry-errors', 0);
+        return;
+    }
+
+    const knownUsers = new Set(telemetryState.events.map((event) => event.userId).filter(Boolean));
+
+    renderMetric('telemetry-total-events', sumBy(telemetryState.daily, 'totalEvents'));
+    renderMetric('telemetry-page-views', sumBy(telemetryState.daily, 'pageViews'));
+    renderMetric('telemetry-interactions', sumBy(telemetryState.daily, 'interactions'));
+    renderMetric('telemetry-sessions', telemetryState.sessions.length);
+    renderMetric('telemetry-known-users', knownUsers.size);
+    renderMetric('telemetry-errors', sumBy(telemetryState.daily, 'errors'));
+
+    renderTelemetryTrend();
+    renderTopTelemetryPages();
+    renderTopTelemetryEvents();
+    renderRecentTelemetrySessions();
+    renderTelemetryEventsTable();
+}
+
 function renderTeams(teams) {
     const tbody = document.getElementById('teams-table-body');
     tbody.innerHTML = teams.map(team => `
@@ -271,7 +528,7 @@ window.deleteTeamAdmin = async function (teamId, teamName) {
 };
 
 function setupTabs() {
-    const tabs = ['dashboard', 'teams', 'users'];
+    const tabs = ['dashboard', 'teams', 'users', 'telemetry'];
     tabs.forEach(tab => {
         document.getElementById(`tab-${tab}`).addEventListener('click', () => {
             // Update tab styles
@@ -288,6 +545,10 @@ function setupTabs() {
                     view.classList.add('hidden');
                 }
             });
+
+            if (tab === 'telemetry' && !telemetryState.loaded && !telemetryState.loading) {
+                loadTelemetryData().then(updateTelemetryDashboard);
+            }
         });
     });
 }
@@ -319,6 +580,24 @@ function setupSearch() {
         );
         renderUsers(filtered);
     });
+
+    const telemetryRange = document.getElementById('telemetry-range');
+    const telemetryRefresh = document.getElementById('telemetry-refresh');
+    const telemetryEventFilter = document.getElementById('telemetry-event-filter');
+    const telemetryPageFilter = document.getElementById('telemetry-page-filter');
+
+    telemetryRange?.addEventListener('change', async () => {
+        await loadTelemetryData();
+        updateTelemetryDashboard();
+    });
+
+    telemetryRefresh?.addEventListener('click', async () => {
+        await loadTelemetryData();
+        updateTelemetryDashboard();
+    });
+
+    telemetryEventFilter?.addEventListener('change', renderTelemetryEventsTable);
+    telemetryPageFilter?.addEventListener('input', renderTelemetryEventsTable);
 }
 
 function getTeamOwnerEmail(team) {

--- a/js/admin.js
+++ b/js/admin.js
@@ -18,6 +18,7 @@ let showInactiveTeams = false;
 let telemetryState = {
     loaded: false,
     loading: false,
+    error: null,
     days: 7,
     events: [],
     daily: [],
@@ -134,8 +135,17 @@ async function loadTelemetryData({ silent = false } = {}) {
         }
     } catch (error) {
         console.error('Error loading telemetry:', error);
-        telemetryState.loading = false;
-        telemetryState.loaded = false;
+        telemetryState = {
+            ...telemetryState,
+            loading: false,
+            loaded: false,
+            error: error.message || 'Telemetry could not be loaded',
+            events: [],
+            daily: [],
+            pages: [],
+            eventDaily: [],
+            sessions: []
+        };
         if (status) {
             status.textContent = `Telemetry could not be loaded: ${error.message}`;
         }
@@ -411,12 +421,29 @@ function renderTelemetryEventsTable() {
 
 function updateTelemetryDashboard() {
     if (!telemetryState.loaded) {
+        const errorMessage = telemetryState.error
+            ? `Telemetry could not be loaded: ${telemetryState.error}`
+            : 'No telemetry has been loaded yet.';
+
         renderMetric('telemetry-total-events', 0);
         renderMetric('telemetry-page-views', 0);
         renderMetric('telemetry-interactions', 0);
         renderMetric('telemetry-sessions', 0);
         renderMetric('telemetry-known-users', 0);
         renderMetric('telemetry-errors', 0);
+        renderEmptyTelemetry('telemetry-daily-trend', errorMessage);
+        renderEmptyTelemetry('telemetry-top-pages', errorMessage);
+        renderEmptyTelemetry('telemetry-top-events', errorMessage);
+        renderEmptyTelemetry('telemetry-recent-sessions', errorMessage);
+
+        const tbody = document.getElementById('telemetry-events-table');
+        if (tbody) {
+            tbody.innerHTML = `
+                <tr>
+                    <td colspan="5" class="px-6 py-4 text-sm text-gray-400">${escapeHtml(errorMessage)}</td>
+                </tr>
+            `;
+        }
         return;
     }
 

--- a/js/db.js
+++ b/js/db.js
@@ -69,6 +69,73 @@ const CHAT_REACTIONS = [
 ];
 const CHAT_REACTION_KEYS = new Set(CHAT_REACTIONS.map(r => r.key));
 
+function daysAgoDate(days) {
+    const safeDays = Number.isFinite(days) ? Math.max(1, days) : 7;
+    return new Date(Date.now() - safeDays * 24 * 60 * 60 * 1000);
+}
+
+function toDateKey(date) {
+    return date.toISOString().slice(0, 10);
+}
+
+function mapSnapshot(snapshot) {
+    return snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+}
+
+export async function getTelemetryEvents({ days = 7, maxEvents = 1500 } = {}) {
+    const startDate = Timestamp.fromDate(daysAgoDate(days));
+    const safeLimit = Math.min(Math.max(Number(maxEvents) || 1500, 100), 5000);
+    const q = query(
+        collection(db, 'telemetryEvents'),
+        where('createdAt', '>=', startDate),
+        orderBy('createdAt', 'desc'),
+        limitQuery(safeLimit)
+    );
+    return mapSnapshot(await getDocs(q));
+}
+
+export async function getTelemetryDaily({ days = 30 } = {}) {
+    const startKey = toDateKey(daysAgoDate(days));
+    const q = query(
+        collection(db, 'telemetryDaily'),
+        where('date', '>=', startKey),
+        orderBy('date', 'desc'),
+        limitQuery(Math.min(Math.max(days + 2, 7), 60))
+    );
+    return mapSnapshot(await getDocs(q));
+}
+
+export async function getTelemetryPageDaily({ days = 30, maxPages = 500 } = {}) {
+    const startKey = toDateKey(daysAgoDate(days));
+    const q = query(
+        collection(db, 'telemetryPagesDaily'),
+        where('date', '>=', startKey),
+        orderBy('date', 'desc'),
+        limitQuery(Math.min(Math.max(Number(maxPages) || 500, 50), 1000))
+    );
+    return mapSnapshot(await getDocs(q));
+}
+
+export async function getTelemetryEventDaily({ days = 30, maxEvents = 500 } = {}) {
+    const startKey = toDateKey(daysAgoDate(days));
+    const q = query(
+        collection(db, 'telemetryEventsDaily'),
+        where('date', '>=', startKey),
+        orderBy('date', 'desc'),
+        limitQuery(Math.min(Math.max(Number(maxEvents) || 500, 50), 1000))
+    );
+    return mapSnapshot(await getDocs(q));
+}
+
+export async function getTelemetrySessions({ maxSessions = 200 } = {}) {
+    const q = query(
+        collection(db, 'telemetrySessions'),
+        orderBy('updatedAt', 'desc'),
+        limitQuery(Math.min(Math.max(Number(maxSessions) || 200, 50), 500))
+    );
+    return mapSnapshot(await getDocs(q));
+}
+
 export async function uploadTeamPhoto(file) {
     console.log('Starting photo upload...', {
         fileName: file.name,

--- a/js/telemetry-utils.js
+++ b/js/telemetry-utils.js
@@ -14,7 +14,15 @@ export function sanitizeTelemetryText(value, maxLength = DEFAULT_TEXT_LIMIT) {
 }
 
 export function sanitizeTelemetryKey(value, maxLength = 60) {
-    return sanitizeTelemetryText(value, maxLength).replace(/[^\w:-]/g, '_').slice(0, maxLength);
+    if (value === null || value === undefined) return '';
+    return String(value)
+        .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '')
+        .replace(/\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]?\d{4}\b/g, '')
+        .replace(/\s+/g, '_')
+        .replace(/[^\w:-]/g, '_')
+        .replace(/_+/g, '_')
+        .replace(/^_+|_+$/g, '')
+        .slice(0, maxLength);
 }
 
 export function sanitizeTelemetryProperties(properties = {}, depth = 0) {

--- a/js/telemetry-utils.js
+++ b/js/telemetry-utils.js
@@ -1,0 +1,43 @@
+const DEFAULT_TEXT_LIMIT = 80;
+const DEFAULT_PROPERTY_LIMIT = 40;
+
+export function sanitizeTelemetryText(value, maxLength = DEFAULT_TEXT_LIMIT) {
+    if (value === null || value === undefined) return '';
+    return String(value)
+        .replace(/\s+/g, ' ')
+        .replace(/[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}/gi, '[email]')
+        .replace(/\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]?\d{4}\b/g, '[phone]')
+        .replace(/\b\d{5,}\b/g, '[number]')
+        .replace(/\b[A-Za-z0-9_-]{18,}\b/g, '[token]')
+        .trim()
+        .slice(0, maxLength);
+}
+
+export function sanitizeTelemetryKey(value, maxLength = 60) {
+    return sanitizeTelemetryText(value, maxLength).replace(/[^\w:-]/g, '_').slice(0, maxLength);
+}
+
+export function sanitizeTelemetryProperties(properties = {}, depth = 0) {
+    if (!properties || typeof properties !== 'object' || Array.isArray(properties) || depth > 2) {
+        return {};
+    }
+
+    const clean = {};
+    Object.entries(properties).slice(0, DEFAULT_PROPERTY_LIMIT).forEach(([key, value]) => {
+        const cleanKey = sanitizeTelemetryKey(key);
+        if (!cleanKey) return;
+
+        if (value === null || value === undefined) {
+            clean[cleanKey] = null;
+        } else if (typeof value === 'boolean' || typeof value === 'number') {
+            clean[cleanKey] = value;
+        } else if (Array.isArray(value)) {
+            clean[cleanKey] = value.slice(0, 10).map((item) => sanitizeTelemetryText(item, 60));
+        } else if (typeof value === 'object') {
+            clean[cleanKey] = sanitizeTelemetryProperties(value, depth + 1);
+        } else {
+            clean[cleanKey] = sanitizeTelemetryText(value, 160);
+        }
+    });
+    return clean;
+}

--- a/js/telemetry.js
+++ b/js/telemetry.js
@@ -201,20 +201,21 @@ function shouldIgnoreElement(element) {
 
 function getElementText(element) {
     const explicitLabel = element.getAttribute('data-telemetry-label');
-    if (explicitLabel) return explicitLabel;
+    if (explicitLabel) return sanitizeTelemetryText(explicitLabel, 80);
 
     const ariaLabel = element.getAttribute('aria-label');
-    if (ariaLabel) return ariaLabel;
+    if (ariaLabel) return sanitizeTelemetryText(ariaLabel, 80);
 
+    let text = '';
     if (element instanceof HTMLInputElement) {
-        return element.labels?.[0]?.textContent || element.placeholder || element.name || element.id || element.type;
+        text = element.labels?.[0]?.textContent || element.placeholder || element.name || element.id || element.type;
+    } else if (element instanceof HTMLSelectElement || element instanceof HTMLTextAreaElement) {
+        text = element.labels?.[0]?.textContent || element.placeholder || element.name || element.id || element.tagName.toLowerCase();
+    } else {
+        text = element.textContent || element.getAttribute('title') || element.getAttribute('alt') || '';
     }
 
-    if (element instanceof HTMLSelectElement || element instanceof HTMLTextAreaElement) {
-        return element.labels?.[0]?.textContent || element.placeholder || element.name || element.id || element.tagName.toLowerCase();
-    }
-
-    return element.textContent || element.getAttribute('title') || element.getAttribute('alt') || '';
+    return sanitizeTelemetryText(text, 80);
 }
 
 function getHrefPath(element) {
@@ -318,8 +319,10 @@ export function captureTelemetryEvent(name, properties = {}, options = {}) {
 }
 
 async function sendEvents(events, keepalive = false) {
+    const authToken = await getAuthToken();
     const payload = JSON.stringify({
         sentAt: new Date().toISOString(),
+        authToken,
         events
     });
 
@@ -328,12 +331,28 @@ async function sendEvents(events, keepalive = false) {
         if (navigator.sendBeacon(endpoint, blob)) return;
     }
 
+    const headers = { 'Content-Type': 'application/json' };
+    if (authToken) {
+        headers.Authorization = `Bearer ${authToken}`;
+    }
+
     await fetch(endpoint, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers,
         body: payload,
         keepalive
     });
+}
+
+async function getAuthToken() {
+    const user = auth.currentUser;
+    if (!user?.getIdToken) return null;
+
+    try {
+        return await user.getIdToken();
+    } catch (error) {
+        return null;
+    }
 }
 
 function flush(keepalive = false) {
@@ -387,23 +406,27 @@ function handleClick(event) {
         targetYPercent: rect.height ? Math.round(((event.clientY - rect.top) / rect.height) * 100) : null
     });
 
-    trackRageClick(event);
+    trackRageClick(event, element);
 }
 
-function trackRageClick(event) {
+function trackRageClick(event, element) {
     const now = Date.now();
     recentClicks = recentClicks
         .filter((click) => now - click.time < 1200)
-        .concat([{ time: now, x: event.clientX, y: event.clientY }])
-        .slice(-5);
+        .slice(-4);
+    recentClicks.push({ time: now, x: event.clientX, y: event.clientY });
 
-    const clustered = recentClicks.filter((click) =>
-        Math.abs(click.x - event.clientX) < 30 && Math.abs(click.y - event.clientY) < 30
-    );
+    let clusteredClickCount = 0;
+    recentClicks.forEach((click) => {
+        if (Math.abs(click.x - event.clientX) < 30 && Math.abs(click.y - event.clientY) < 30) {
+            clusteredClickCount += 1;
+        }
+    });
 
-    if (clustered.length >= 3) {
+    if (clusteredClickCount >= 3) {
         captureTelemetryEvent('interaction_rage_click', {
-            clickCount: clustered.length,
+            ...describeElement(element),
+            clickCount: clusteredClickCount,
             x: event.clientX,
             y: event.clientY
         });

--- a/js/telemetry.js
+++ b/js/telemetry.js
@@ -11,6 +11,7 @@ const MAX_QUEUE_SIZE = 40;
 const MAX_BATCH_SIZE = 15;
 const FLUSH_INTERVAL_MS = 5000;
 const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
+const SESSION_TOUCH_INTERVAL_MS = 60 * 1000;
 const SCROLL_MILESTONES = [25, 50, 75, 90, 100];
 const GLOBAL_KEY = '__allplaysTelemetry';
 const SESSION_KEY = 'allplays.telemetry.session';
@@ -32,6 +33,9 @@ let historyTrackingInitialized = false;
 let globalListenersInitialized = false;
 let localStorageAvailable = null;
 let sessionStorageAvailable = null;
+let visitorIdCache = null;
+let sessionCache = null;
+let lastSessionStorageWrite = 0;
 
 function canUseStorage(storage, kind) {
     if (kind === 'local' && localStorageAvailable !== null) return localStorageAvailable;
@@ -80,22 +84,37 @@ function setSessionStorageValue(key, value) {
 }
 
 function getVisitorId() {
+    if (visitorIdCache) return visitorIdCache;
+
     const existing = getLocalStorageValue(VISITOR_KEY);
-    if (existing) return existing;
-    const visitorId = randomId('visitor');
-    setLocalStorageValue(VISITOR_KEY, visitorId);
-    return visitorId;
+    visitorIdCache = existing || randomId('visitor');
+    if (!existing) {
+        setLocalStorageValue(VISITOR_KEY, visitorIdCache);
+    }
+    return visitorIdCache;
 }
 
 function getSessionId() {
-    const existing = getSessionStorageValue(SESSION_KEY);
     const now = Date.now();
+
+    if (sessionCache?.id && now - sessionCache.lastSeen < SESSION_TIMEOUT_MS) {
+        sessionCache.lastSeen = now;
+        if (now - lastSessionStorageWrite >= SESSION_TOUCH_INTERVAL_MS) {
+            setSessionStorageValue(SESSION_KEY, JSON.stringify(sessionCache));
+            lastSessionStorageWrite = now;
+        }
+        return sessionCache.id;
+    }
+
+    const existing = getSessionStorageValue(SESSION_KEY);
     if (existing) {
         try {
             const parsed = JSON.parse(existing);
             if (parsed?.id && parsed?.lastSeen && now - parsed.lastSeen < SESSION_TIMEOUT_MS) {
                 parsed.lastSeen = now;
-                setSessionStorageValue(SESSION_KEY, JSON.stringify(parsed));
+                sessionCache = parsed;
+                setSessionStorageValue(SESSION_KEY, JSON.stringify(sessionCache));
+                lastSessionStorageWrite = now;
                 return parsed.id;
             }
         } catch (error) {
@@ -103,9 +122,10 @@ function getSessionId() {
         }
     }
 
-    const session = { id: randomId('session'), startedAt: now, lastSeen: now };
-    setSessionStorageValue(SESSION_KEY, JSON.stringify(session));
-    return session.id;
+    sessionCache = { id: randomId('session'), startedAt: now, lastSeen: now };
+    setSessionStorageValue(SESSION_KEY, JSON.stringify(sessionCache));
+    lastSessionStorageWrite = now;
+    return sessionCache.id;
 }
 
 function resolveEndpoint() {
@@ -274,10 +294,18 @@ function enqueue(event) {
         queue = queue.slice(queue.length - MAX_QUEUE_SIZE);
     }
     if (queue.length >= MAX_BATCH_SIZE) {
-        flush();
-    } else if (!flushTimer) {
-        flushTimer = window.setTimeout(flush, FLUSH_INTERVAL_MS);
+        scheduleFlush(0);
+    } else {
+        scheduleFlush(FLUSH_INTERVAL_MS);
     }
+}
+
+function scheduleFlush(delayMs) {
+    if (flushTimer) {
+        if (delayMs !== 0) return;
+        window.clearTimeout(flushTimer);
+    }
+    flushTimer = window.setTimeout(flush, delayMs);
 }
 
 export function captureTelemetryEvent(name, properties = {}, options = {}) {
@@ -319,6 +347,10 @@ function flush(keepalive = false) {
     sendEvents(events, keepalive).catch(() => {
         queue = events.concat(queue).slice(0, MAX_QUEUE_SIZE);
     });
+
+    if (!keepalive && queue.length > 0) {
+        scheduleFlush(queue.length >= MAX_BATCH_SIZE ? 0 : FLUSH_INTERVAL_MS);
+    }
 }
 
 function capturePageView() {

--- a/js/telemetry.js
+++ b/js/telemetry.js
@@ -1,0 +1,556 @@
+import { auth, onAuthStateChanged } from './firebase.js?v=9';
+import {
+    sanitizeTelemetryKey,
+    sanitizeTelemetryProperties,
+    sanitizeTelemetryText
+} from './telemetry-utils.js?v=1';
+
+const TELEMETRY_VERSION = '1.0.0';
+const DEFAULT_ENDPOINT = 'https://us-central1-game-flow-c6311.cloudfunctions.net/collectTelemetry';
+const MAX_QUEUE_SIZE = 40;
+const MAX_BATCH_SIZE = 15;
+const FLUSH_INTERVAL_MS = 5000;
+const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
+const SCROLL_MILESTONES = [25, 50, 75, 90, 100];
+const GLOBAL_KEY = '__allplaysTelemetry';
+const SESSION_KEY = 'allplays.telemetry.session';
+const VISITOR_KEY = 'allplays.telemetry.visitor';
+const OPT_OUT_KEY = 'allplays.telemetry.optOut';
+
+let endpoint = null;
+let enabled = false;
+let queue = [];
+let flushTimer = null;
+let userContext = { userId: null, signedIn: false };
+let pageStartedAt = Date.now();
+let lastScrollCheck = 0;
+let capturedScrollMilestones = new Set();
+let recentClicks = [];
+let hasSentPageLeave = false;
+let authContextInitialized = false;
+let historyTrackingInitialized = false;
+let globalListenersInitialized = false;
+let localStorageAvailable = null;
+let sessionStorageAvailable = null;
+
+function canUseStorage(storage, kind) {
+    if (kind === 'local' && localStorageAvailable !== null) return localStorageAvailable;
+    if (kind === 'session' && sessionStorageAvailable !== null) return sessionStorageAvailable;
+
+    let available = false;
+    try {
+        const key = '__allplays_storage_test__';
+        storage.setItem(key, '1');
+        storage.removeItem(key);
+        available = true;
+    } catch (error) {
+        available = false;
+    }
+
+    if (kind === 'local') localStorageAvailable = available;
+    if (kind === 'session') sessionStorageAvailable = available;
+    return available;
+}
+
+function randomId(prefix) {
+    if (window.crypto?.randomUUID) {
+        return `${prefix}_${window.crypto.randomUUID()}`;
+    }
+    return `${prefix}_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 10)}`;
+}
+
+function getLocalStorageValue(key) {
+    if (!canUseStorage(window.localStorage, 'local')) return null;
+    return window.localStorage.getItem(key);
+}
+
+function setLocalStorageValue(key, value) {
+    if (!canUseStorage(window.localStorage, 'local')) return;
+    window.localStorage.setItem(key, value);
+}
+
+function getSessionStorageValue(key) {
+    if (!canUseStorage(window.sessionStorage, 'session')) return null;
+    return window.sessionStorage.getItem(key);
+}
+
+function setSessionStorageValue(key, value) {
+    if (!canUseStorage(window.sessionStorage, 'session')) return;
+    window.sessionStorage.setItem(key, value);
+}
+
+function getVisitorId() {
+    const existing = getLocalStorageValue(VISITOR_KEY);
+    if (existing) return existing;
+    const visitorId = randomId('visitor');
+    setLocalStorageValue(VISITOR_KEY, visitorId);
+    return visitorId;
+}
+
+function getSessionId() {
+    const existing = getSessionStorageValue(SESSION_KEY);
+    const now = Date.now();
+    if (existing) {
+        try {
+            const parsed = JSON.parse(existing);
+            if (parsed?.id && parsed?.lastSeen && now - parsed.lastSeen < SESSION_TIMEOUT_MS) {
+                parsed.lastSeen = now;
+                setSessionStorageValue(SESSION_KEY, JSON.stringify(parsed));
+                return parsed.id;
+            }
+        } catch (error) {
+            // Fall through and create a fresh session.
+        }
+    }
+
+    const session = { id: randomId('session'), startedAt: now, lastSeen: now };
+    setSessionStorageValue(SESSION_KEY, JSON.stringify(session));
+    return session.id;
+}
+
+function resolveEndpoint() {
+    const config = window.__ALLPLAYS_CONFIG__ || {};
+    const configuredEndpoint = config.telemetryEndpoint || window.ALLPLAYS_TELEMETRY_ENDPOINT;
+    if (typeof configuredEndpoint === 'string' && configuredEndpoint.trim()) {
+        return configuredEndpoint.trim();
+    }
+
+    const metaEndpoint = document.querySelector('meta[name="allplays-telemetry-endpoint"]')?.content;
+    if (typeof metaEndpoint === 'string' && metaEndpoint.trim()) {
+        return metaEndpoint.trim();
+    }
+
+    return DEFAULT_ENDPOINT;
+}
+
+function isLocalDevelopment() {
+    return ['localhost', '127.0.0.1', '0.0.0.0', ''].includes(window.location.hostname);
+}
+
+function isTelemetryEnabled() {
+    const params = new URLSearchParams(window.location.search);
+    if (params.get('telemetry') === '0') return false;
+    if (params.get('telemetry') === '1') return true;
+    if (getLocalStorageValue(OPT_OUT_KEY) === '1') return false;
+
+    const config = window.__ALLPLAYS_CONFIG__ || {};
+    if (config.telemetryEnabled === false || window.ALLPLAYS_TELEMETRY_ENABLED === false) {
+        return false;
+    }
+
+    return !isLocalDevelopment() || config.telemetryEnabled === true || window.ALLPLAYS_TELEMETRY_ENABLED === true;
+}
+
+function getSafePath(url = window.location.href) {
+    try {
+        const parsed = new URL(url, window.location.origin);
+        return parsed.pathname || '/';
+    } catch (error) {
+        return window.location.pathname || '/';
+    }
+}
+
+function getQueryKeys() {
+    return Array.from(new URLSearchParams(window.location.search).keys())
+        .map((key) => sanitizeTelemetryKey(key))
+        .filter(Boolean)
+        .slice(0, 20);
+}
+
+function getSafeReferrer() {
+    if (!document.referrer) return '';
+    try {
+        const referrer = new URL(document.referrer);
+        if (referrer.origin !== window.location.origin) {
+            return referrer.hostname;
+        }
+        return referrer.pathname || '/';
+    } catch (error) {
+        return '';
+    }
+}
+
+function closestTrackableElement(target) {
+    if (!(target instanceof Element)) return null;
+    return target.closest('[data-telemetry-name], button, a, input, select, textarea, label, summary, [role="button"], [role="link"], [contenteditable="true"]');
+}
+
+function shouldIgnoreElement(element) {
+    return !!element?.closest?.('[data-telemetry-ignore], [data-no-telemetry]');
+}
+
+function getElementText(element) {
+    const explicitLabel = element.getAttribute('data-telemetry-label');
+    if (explicitLabel) return explicitLabel;
+
+    const ariaLabel = element.getAttribute('aria-label');
+    if (ariaLabel) return ariaLabel;
+
+    if (element instanceof HTMLInputElement) {
+        return element.labels?.[0]?.textContent || element.placeholder || element.name || element.id || element.type;
+    }
+
+    if (element instanceof HTMLSelectElement || element instanceof HTMLTextAreaElement) {
+        return element.labels?.[0]?.textContent || element.placeholder || element.name || element.id || element.tagName.toLowerCase();
+    }
+
+    return element.textContent || element.getAttribute('title') || element.getAttribute('alt') || '';
+}
+
+function getHrefPath(element) {
+    const href = element.getAttribute('href');
+    if (!href) return '';
+    try {
+        const url = new URL(href, window.location.origin);
+        if (url.origin !== window.location.origin) {
+            return url.hostname;
+        }
+        return url.pathname || '/';
+    } catch (error) {
+        return sanitizeTelemetryText(href, 80);
+    }
+}
+
+function describeElement(element) {
+    if (!element) return {};
+    const tagName = element.tagName.toLowerCase();
+    const classes = Array.from(element.classList || [])
+        .filter((className) => !className.includes(':'))
+        .slice(0, 5)
+        .map((className) => sanitizeTelemetryKey(className));
+
+    const dataName = element.getAttribute('data-telemetry-name') || element.getAttribute('data-analytics-name');
+    const form = element.closest('form');
+
+    return sanitizeTelemetryProperties({
+        telemetryName: dataName || '',
+        tagName,
+        elementId: element.id || '',
+        elementClasses: classes,
+        role: element.getAttribute('role') || '',
+        type: element.getAttribute('type') || '',
+        name: element.getAttribute('name') || '',
+        label: getElementText(element),
+        href: tagName === 'a' ? getHrefPath(element) : '',
+        formId: form?.id || '',
+        formName: form?.getAttribute('name') || ''
+    });
+}
+
+function buildBaseEvent(name, properties = {}) {
+    const now = Date.now();
+    return {
+        id: randomId('event'),
+        name: sanitizeTelemetryKey(name) || 'unknown',
+        version: TELEMETRY_VERSION,
+        sessionId: getSessionId(),
+        visitorId: getVisitorId(),
+        userId: userContext.userId,
+        signedIn: userContext.signedIn,
+        clientTimestamp: new Date(now).toISOString(),
+        pagePath: getSafePath(),
+        pageTitle: sanitizeTelemetryText(document.title, 120),
+        queryKeys: getQueryKeys(),
+        referrer: getSafeReferrer(),
+        viewport: {
+            width: window.innerWidth || 0,
+            height: window.innerHeight || 0
+        },
+        screen: {
+            width: window.screen?.width || 0,
+            height: window.screen?.height || 0
+        },
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || '',
+        language: navigator.language || '',
+        userAgent: sanitizeTelemetryText(navigator.userAgent || '', 240),
+        properties: sanitizeTelemetryProperties(properties)
+    };
+}
+
+function enqueue(event) {
+    if (!enabled || !endpoint || !event) return;
+    queue.push(event);
+    if (queue.length > MAX_QUEUE_SIZE) {
+        queue = queue.slice(queue.length - MAX_QUEUE_SIZE);
+    }
+    if (queue.length >= MAX_BATCH_SIZE) {
+        flush();
+    } else if (!flushTimer) {
+        flushTimer = window.setTimeout(flush, FLUSH_INTERVAL_MS);
+    }
+}
+
+export function captureTelemetryEvent(name, properties = {}, options = {}) {
+    const event = buildBaseEvent(name, properties);
+    enqueue(event);
+    if (options.flush) {
+        flush(options.keepalive === true);
+    }
+    return event;
+}
+
+async function sendEvents(events, keepalive = false) {
+    const payload = JSON.stringify({
+        sentAt: new Date().toISOString(),
+        events
+    });
+
+    if (keepalive && navigator.sendBeacon) {
+        const blob = new Blob([payload], { type: 'application/json' });
+        if (navigator.sendBeacon(endpoint, blob)) return;
+    }
+
+    await fetch(endpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: payload,
+        keepalive
+    });
+}
+
+function flush(keepalive = false) {
+    if (flushTimer) {
+        window.clearTimeout(flushTimer);
+        flushTimer = null;
+    }
+    if (!enabled || !endpoint || queue.length === 0) return;
+
+    const events = queue.splice(0, MAX_BATCH_SIZE);
+    sendEvents(events, keepalive).catch(() => {
+        queue = events.concat(queue).slice(0, MAX_QUEUE_SIZE);
+    });
+}
+
+function capturePageView() {
+    hasSentPageLeave = false;
+    pageStartedAt = Date.now();
+    capturedScrollMilestones = new Set();
+    captureTelemetryEvent('page_view', {
+        hashPresent: !!window.location.hash,
+        navigationType: performance.getEntriesByType?.('navigation')?.[0]?.type || ''
+    });
+}
+
+function capturePerformance() {
+    const navigation = performance.getEntriesByType?.('navigation')?.[0];
+    if (!navigation) return;
+
+    captureTelemetryEvent('page_performance', {
+        domContentLoadedMs: Math.round(navigation.domContentLoadedEventEnd),
+        loadMs: Math.round(navigation.loadEventEnd),
+        transferSize: navigation.transferSize || 0
+    });
+}
+
+function handleClick(event) {
+    const element = closestTrackableElement(event.target);
+    if (!element || shouldIgnoreElement(element)) return;
+
+    const rect = element.getBoundingClientRect();
+    captureTelemetryEvent('interaction_click', {
+        ...describeElement(element),
+        button: event.button,
+        modifierKey: event.metaKey || event.ctrlKey || event.shiftKey || event.altKey,
+        targetXPercent: rect.width ? Math.round(((event.clientX - rect.left) / rect.width) * 100) : null,
+        targetYPercent: rect.height ? Math.round(((event.clientY - rect.top) / rect.height) * 100) : null
+    });
+
+    trackRageClick(event);
+}
+
+function trackRageClick(event) {
+    const now = Date.now();
+    recentClicks = recentClicks
+        .filter((click) => now - click.time < 1200)
+        .concat([{ time: now, x: event.clientX, y: event.clientY }])
+        .slice(-5);
+
+    const clustered = recentClicks.filter((click) =>
+        Math.abs(click.x - event.clientX) < 30 && Math.abs(click.y - event.clientY) < 30
+    );
+
+    if (clustered.length >= 3) {
+        captureTelemetryEvent('interaction_rage_click', {
+            clickCount: clustered.length,
+            x: event.clientX,
+            y: event.clientY
+        });
+        recentClicks = [];
+    }
+}
+
+function handleChange(event) {
+    const element = closestTrackableElement(event.target);
+    if (!element || shouldIgnoreElement(element)) return;
+    if (!(element instanceof HTMLInputElement || element instanceof HTMLSelectElement || element instanceof HTMLTextAreaElement)) return;
+
+    const properties = describeElement(element);
+    properties.hasValue = element.type === 'checkbox' || element.type === 'radio'
+        ? element.checked
+        : !!element.value;
+    properties.valueLengthBucket = element.value ? Math.min(100, Math.ceil(element.value.length / 10) * 10) : 0;
+    if (element instanceof HTMLInputElement && element.type === 'file') {
+        properties.fileCount = element.files?.length || 0;
+    }
+
+    captureTelemetryEvent('interaction_change', properties);
+}
+
+function handleSubmit(event) {
+    const form = event.target;
+    if (!(form instanceof HTMLFormElement) || shouldIgnoreElement(form)) return;
+
+    captureTelemetryEvent('interaction_submit', {
+        formId: form.id || '',
+        formName: form.getAttribute('name') || '',
+        method: form.getAttribute('method') || 'get',
+        action: form.getAttribute('action') ? getSafePath(form.getAttribute('action')) : '',
+        fieldCount: form.querySelectorAll('input, select, textarea').length
+    });
+}
+
+function handleScroll() {
+    const now = Date.now();
+    if (now - lastScrollCheck < 500) return;
+    lastScrollCheck = now;
+
+    const scrollTop = window.scrollY || document.documentElement.scrollTop || 0;
+    const scrollable = Math.max(1, document.documentElement.scrollHeight - window.innerHeight);
+    const depth = Math.min(100, Math.round((scrollTop / scrollable) * 100));
+    const nextMilestone = SCROLL_MILESTONES.find((milestone) => depth >= milestone && !capturedScrollMilestones.has(milestone));
+
+    if (nextMilestone) {
+        capturedScrollMilestones.add(nextMilestone);
+        captureTelemetryEvent('scroll_depth', { depthPercent: nextMilestone });
+    }
+}
+
+function capturePageLeave() {
+    if (hasSentPageLeave) return;
+    hasSentPageLeave = true;
+    captureTelemetryEvent('page_leave', {
+        engagementMs: Date.now() - pageStartedAt,
+        visibilityState: document.visibilityState
+    }, { flush: true, keepalive: true });
+}
+
+function setupAuthContext() {
+    if (authContextInitialized) return;
+    authContextInitialized = true;
+
+    onAuthStateChanged(auth, (user) => {
+        userContext = {
+            userId: user?.uid || null,
+            signedIn: !!user
+        };
+        if (user) {
+            captureTelemetryEvent('auth_context', { signedIn: true });
+        }
+    });
+}
+
+function setupHistoryTracking() {
+    if (historyTrackingInitialized) return;
+    historyTrackingInitialized = true;
+
+    const originalPushState = history.pushState;
+    const originalReplaceState = history.replaceState;
+
+    history.pushState = function (...args) {
+        const result = originalPushState.apply(this, args);
+        window.dispatchEvent(new Event('allplays:navigation'));
+        return result;
+    };
+
+    history.replaceState = function (...args) {
+        const result = originalReplaceState.apply(this, args);
+        window.dispatchEvent(new Event('allplays:navigation'));
+        return result;
+    };
+
+    window.addEventListener('popstate', capturePageView);
+    window.addEventListener('hashchange', capturePageView);
+    window.addEventListener('allplays:navigation', capturePageView);
+}
+
+function setupGlobalListeners() {
+    if (globalListenersInitialized) return;
+    globalListenersInitialized = true;
+
+    document.addEventListener('click', handleClick, true);
+    document.addEventListener('change', handleChange, true);
+    document.addEventListener('submit', handleSubmit, true);
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    window.addEventListener('pagehide', capturePageLeave);
+    document.addEventListener('visibilitychange', () => {
+        captureTelemetryEvent('visibility_change', { visibilityState: document.visibilityState });
+        if (document.visibilityState === 'hidden') {
+            capturePageLeave();
+        }
+    });
+    window.addEventListener('error', (event) => {
+        captureTelemetryEvent('js_error', {
+            message: event.message || '',
+            source: getSafePath(event.filename || ''),
+            line: event.lineno || 0,
+            column: event.colno || 0
+        }, { flush: true });
+    });
+    window.addEventListener('unhandledrejection', (event) => {
+        captureTelemetryEvent('js_unhandled_rejection', {
+            reason: event.reason?.message || event.reason || ''
+        }, { flush: true });
+    });
+}
+
+function exposeApi() {
+    window.AllPlaysTelemetry = {
+        capture: captureTelemetryEvent,
+        flush,
+        optOut() {
+            setLocalStorageValue(OPT_OUT_KEY, '1');
+            enabled = false;
+            queue = [];
+        },
+        optIn() {
+            setLocalStorageValue(OPT_OUT_KEY, '0');
+            enabled = true;
+            endpoint = resolveEndpoint();
+            setupAuthContext();
+            setupHistoryTracking();
+            setupGlobalListeners();
+            capturePageView();
+        },
+        getSessionId,
+        getVisitorId
+    };
+}
+
+function startTelemetry() {
+    if (window[GLOBAL_KEY]?.started) return;
+
+    window[GLOBAL_KEY] = { started: true };
+    endpoint = resolveEndpoint();
+    enabled = isTelemetryEnabled();
+    exposeApi();
+
+    if (!enabled || !endpoint) return;
+
+    setupAuthContext();
+    setupHistoryTracking();
+    setupGlobalListeners();
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', capturePageView, { once: true });
+    } else {
+        capturePageView();
+    }
+
+    window.addEventListener('load', () => {
+        window.setTimeout(capturePerformance, 0);
+    }, { once: true });
+}
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+    startTelemetry();
+}

--- a/js/utils.js
+++ b/js/utils.js
@@ -192,6 +192,14 @@ export function renderHeader(container, user) {
   updateNav('desktop');
   updateNav('mobile');
 
+  // Keep telemetry available on new pages that use the shared header but miss
+  // the global module tag.
+  try {
+    import('./telemetry.js?v=1').catch((e) => console.warn('[Telemetry] Failed to load:', e));
+  } catch (e) {
+    console.warn('[Telemetry] Failed to initialize:', e);
+  }
+
   // Global search: injected into the shared header in one place.
   // Lazy-import to avoid adding weight to initial render and to avoid circular deps.
   try {

--- a/live-game.html
+++ b/live-game.html
@@ -185,6 +185,7 @@
     }
     .event-slide { animation: slide-in 0.25s ease-out; }
   </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-ink text-sand min-h-screen font-body">

--- a/live-tracker.html
+++ b/live-tracker.html
@@ -48,6 +48,7 @@
     @keyframes pulse-live { 0%, 100% { opacity: 1; } 50% { opacity: 0.5; } }
     .live-pulse { animation: pulse-live 1.5s ease-in-out infinite; }
   </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="min-h-screen text-ink font-body">
   <header class="px-4 py-3 text-white flex items-center justify-between">

--- a/login.html
+++ b/login.html
@@ -38,6 +38,7 @@
             }
         }
     </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gray-50 flex flex-col min-h-screen">

--- a/mockups/game-day-command-center.html
+++ b/mockups/game-day-command-center.html
@@ -37,6 +37,7 @@
         .vpane{animation:fadein .2s ease}
         .ycard{color:#fbbf24;font-weight:700}
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="bg-gray-50 min-h-screen">
 

--- a/mockups/practice-command-center.html
+++ b/mockups/practice-command-center.html
@@ -57,6 +57,7 @@
         .attendance-btn.active-late { background: #78350f; border-color: #f59e0b; color: #fde68a; }
         .attendance-btn.active-absent { background: #7f1d1d; border-color: #ef4444; color: #fecaca; }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="bg-gray-50 min-h-screen">
 

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -38,6 +38,7 @@
             }
         }
     </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gradient-to-br from-gray-50 to-gray-100 text-gray-900">

--- a/player.html
+++ b/player.html
@@ -38,6 +38,7 @@
             }
         }
     </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gradient-to-br from-gray-50 to-gray-100 text-gray-900">

--- a/profile.html
+++ b/profile.html
@@ -38,6 +38,7 @@
             }
         }
     </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gray-50 text-gray-900">

--- a/reset-password.html
+++ b/reset-password.html
@@ -38,6 +38,7 @@
             }
         }
     </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gray-50 flex flex-col min-h-screen">

--- a/team-chat.html
+++ b/team-chat.html
@@ -48,6 +48,7 @@
             }
         }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gray-50 text-gray-900">

--- a/team.html
+++ b/team.html
@@ -38,6 +38,7 @@
             }
         }
     </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gradient-to-br from-gray-50 to-gray-100 text-gray-900">

--- a/teams.html
+++ b/teams.html
@@ -44,6 +44,7 @@
       }
     }
   </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gradient-to-br from-gray-50 to-gray-100 text-gray-900">

--- a/test-fix-recurring-rsvp.html
+++ b/test-fix-recurring-rsvp.html
@@ -19,6 +19,7 @@
         .summary .pass-count { color: #16a34a; font-weight: bold; }
         .summary .fail-count { color: #dc2626; font-weight: bold; }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body>
     <h1>🧪 Test Suite: Recurring Practice RSVP Fix</h1>

--- a/test-fix-schedule-drills.html
+++ b/test-fix-schedule-drills.html
@@ -19,6 +19,7 @@
         .summary .pass-count { color: #16a34a; font-weight: bold; }
         .summary .fail-count { color: #dc2626; font-weight: bold; }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body>
     <h1>🧪 Test Suite: Schedule Buffer, Drill Markdown, Photo Fix</h1>

--- a/test-foul-tracking.html
+++ b/test-foul-tracking.html
@@ -18,6 +18,7 @@
         .summary { background: #e0e7ff; padding: 15px; border-radius: 8px; margin-bottom: 20px; }
         .summary h3 { margin-top: 0; color: #4338ca; }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body>
     <h1>🧪 Foul Tracking & Score Undo Test Suite</h1>

--- a/test-game-day.html
+++ b/test-game-day.html
@@ -17,6 +17,7 @@
         .summary-pass { color: #16a34a; font-weight: bold; }
         .summary-fail { color: #dc2626; font-weight: bold; }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body>
     <h1>🧪 Test Suite — Game Day Command Center</h1>

--- a/test-pr-changes.html
+++ b/test-pr-changes.html
@@ -16,6 +16,7 @@
         h2 { color: #4338ca; }
         pre { background: #f8f8f8; padding: 10px; overflow-x: auto; }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body>
     <h1>🧪 PR Test Suite</h1>

--- a/test-statsheet-mapping.html
+++ b/test-statsheet-mapping.html
@@ -11,6 +11,7 @@
     .pass { border-left-color: #22c55e; background: #f0fdf4; }
     .fail { border-left-color: #ef4444; background: #fef2f2; }
   </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="bg-gray-50 text-gray-900">
   <main class="max-w-3xl mx-auto px-4 py-8">

--- a/test-track-live.html
+++ b/test-track-live.html
@@ -20,6 +20,7 @@
         .summary.has-fail { background: #fee2e2; color: #991b1b; }
         #loading { color: #666; padding: 20px; }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body>
     <h1>🧪 Test Suite — track-live.html Live Broadcasting</h1>

--- a/test-youtube-stream.html
+++ b/test-youtube-stream.html
@@ -19,6 +19,7 @@
         .summary.all-pass { background: #dcfce7; color: #15803d; }
         .summary.has-fail { background: #fee2e2; color: #991b1b; }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body>
     <h1>🧪 Stream URL Parser Test Suite</h1>

--- a/tests/unit/telemetry-utils.test.js
+++ b/tests/unit/telemetry-utils.test.js
@@ -31,5 +31,8 @@ describe('telemetry privacy utilities', () => {
     it('keeps telemetry keys bounded and machine-friendly', () => {
         expect(sanitizeTelemetryKey('bad key.with spaces and dots')).toBe('bad_key_with_spaces_and_dots');
         expect(sanitizeTelemetryKey('many words '.repeat(20))).toHaveLength(60);
+        expect(sanitizeTelemetryKey('domContentLoadedMs')).toBe('domContentLoadedMs');
+        expect(sanitizeTelemetryKey('local_smoke_test_123456789')).toBe('local_smoke_test_123456789');
+        expect(sanitizeTelemetryKey('coach@example.com')).toBe('');
     });
 });

--- a/tests/unit/telemetry-utils.test.js
+++ b/tests/unit/telemetry-utils.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import {
+    sanitizeTelemetryKey,
+    sanitizeTelemetryProperties,
+    sanitizeTelemetryText
+} from '../../js/telemetry-utils.js';
+
+describe('telemetry privacy utilities', () => {
+    it('masks common personal data patterns before telemetry is sent', () => {
+        const text = sanitizeTelemetryText('Email coach@example.com or call 555-123-4567 with code abcdefghijklmnopqrstuvwxyz');
+
+        expect(text).toContain('[email]');
+        expect(text).toContain('[phone]');
+        expect(text).toContain('[token]');
+        expect(text).not.toContain('coach@example.com');
+        expect(text).not.toContain('555-123-4567');
+    });
+
+    it('normalizes object keys and strips unsafe text from nested properties', () => {
+        const properties = sanitizeTelemetryProperties({
+            'label text': 'Pay for player 123456789',
+            nested: {
+                email: 'parent@example.com'
+            }
+        });
+
+        expect(properties.label_text).toBe('Pay for player [number]');
+        expect(properties.nested.email).toBe('[email]');
+    });
+
+    it('keeps telemetry keys bounded and machine-friendly', () => {
+        expect(sanitizeTelemetryKey('bad key.with spaces and dots')).toBe('bad_key_with_spaces_and_dots');
+        expect(sanitizeTelemetryKey('many words '.repeat(20))).toHaveLength(60);
+    });
+});

--- a/track-basketball.html
+++ b/track-basketball.html
@@ -46,6 +46,7 @@
     .stat-btn { touch-action: manipulation; }
     .grid-cols-auto { grid-template-columns: repeat(auto-fit, minmax(120px, 1fr)); }
   </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="min-h-screen text-ink font-body">
   <header class="px-4 py-3 text-white flex items-center justify-between">

--- a/track-live.html
+++ b/track-live.html
@@ -252,6 +252,7 @@
             color: rgba(247, 245, 237, 0.85);
         }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-ink text-sand min-h-screen font-body">

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -38,6 +38,7 @@
       }
     }
   </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gray-50 text-gray-900">

--- a/track.html
+++ b/track.html
@@ -103,6 +103,7 @@
             background: #1d4ed8;
         }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gray-50 text-gray-900">

--- a/verify-pending.html
+++ b/verify-pending.html
@@ -38,6 +38,7 @@
             }
         }
     </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 
 <body class="bg-gray-50 flex flex-col min-h-screen">

--- a/workflow-admin-ops.html
+++ b/workflow-admin-ops.html
@@ -261,6 +261,7 @@
         }
       }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>

--- a/workflow-choose-home-dashboard.html
+++ b/workflow-choose-home-dashboard.html
@@ -261,6 +261,7 @@
         }
       }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>

--- a/workflow-communication.html
+++ b/workflow-communication.html
@@ -261,6 +261,7 @@
         }
       }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>

--- a/workflow-game-day.html
+++ b/workflow-game-day.html
@@ -261,6 +261,7 @@
         }
       }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>

--- a/workflow-getting-started.html
+++ b/workflow-getting-started.html
@@ -261,6 +261,7 @@
         }
       }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>

--- a/workflow-join-team.html
+++ b/workflow-join-team.html
@@ -261,6 +261,7 @@
         }
       }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>

--- a/workflow-live-watch-replay.html
+++ b/workflow-live-watch-replay.html
@@ -261,6 +261,7 @@
         }
       }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>

--- a/workflow-postgame.html
+++ b/workflow-postgame.html
@@ -261,6 +261,7 @@
         }
       }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>

--- a/workflow-roster.html
+++ b/workflow-roster.html
@@ -261,6 +261,7 @@
         }
       }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>

--- a/workflow-schedule.html
+++ b/workflow-schedule.html
@@ -261,6 +261,7 @@
         }
       }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>

--- a/workflow-team-setup.html
+++ b/workflow-team-setup.html
@@ -261,6 +261,7 @@
         }
       }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>

--- a/workflow-track-game.html
+++ b/workflow-track-game.html
@@ -261,6 +261,7 @@
         }
       }
     </style>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>


### PR DESCRIPTION
## What changed
- Added a first-party telemetry module loaded across every HTML entry point and through the shared header fallback.
- Captures page views, page leaves, clicks, form changes/submits, scroll-depth milestones, visibility changes, JS errors, page performance, and custom events via `window.AllPlaysTelemetry.capture(...)`.
- Added privacy masking before data leaves the browser: no form values are sent, query values are stripped, and email/phone/token-like text is redacted.
- Added `collectTelemetry` Firebase Function ingestion with schema normalization, raw event writes, and daily/page/event/session aggregates in Firestore.
- Locked telemetry reads to global admins in Firestore rules.
- Added a new Admin Dashboard `Telemetry` tab for totals, trends, top pages, top events, recent sessions, and raw event exploration.

## Research rationale
I reviewed open-source and hosted options including PostHog, OpenReplay, rrweb, and Matomo. PostHog has mature JS autocapture for interactions, navigation, form changes, rage clicks, errors, and web vitals, but it requires a PostHog project token/backend to use its UI. OpenReplay and rrweb are strong for full session replay, but they are heavier than needed for an in-app usage dashboard. Matomo supports page/event tracking, but it still needs a Matomo server and would not give this app an integrated Firestore-backed admin explorer.

For this Firebase static site, the best fit is first-party delegated autocapture with a Firebase Function collector: it keeps ownership of raw interaction data, avoids adding a third-party project credential, and supports the requested in-app admin dashboards immediately.

References:
- PostHog autocapture docs: https://posthog.com/docs/product-analytics/autocapture
- PostHog JS SDK docs: https://posthog.com/docs/libraries/js
- OpenReplay GitHub: https://github.com/openreplay/openreplay
- rrweb GitHub: https://github.com/rrweb-io/rrweb
- Matomo JS tracking docs: https://developer.matomo.org/guides/tracking-javascript

## Validation
- `node --check functions/index.js`
- `node --check js/admin.js`
- `node --check js/telemetry.js`
- `node --check js/telemetry-utils.js`
- `git diff --check`
- `npm test` (82 files, 402 tests)
- Local static server smoke checks for `index.html`, `admin.html`, and `js/telemetry.js`
- Playwright smoke test intercepting telemetry POSTs verified `page_view`, `interaction_click`, custom capture, and PII masking