### PR TITLE
Show RSVP email recipient preview

### DIFF
--- a/docs/pr-notes/runs/953-ci-fix-20260513T030808Z/architecture.md
+++ b/docs/pr-notes/runs/953-ci-fix-20260513T030808Z/architecture.md
@@ -1,0 +1,7 @@
+# Architecture Notes
+
+The edit-schedule page added imports for RSVP availability helpers: `getPlayers`, `getRsvps`, `buildAvailabilityReminderRecipients`, and `buildAvailabilityReminderEmailPreview`. The smoke tests replace production modules with inline ES module stubs; missing named exports prevent the page module from evaluating, so the schedule render and submit listeners never initialize.
+
+Minimal fix: update only the affected smoke stubs so they match the page's current import contract. No production behavior change is required.
+
+Rollback: revert the test stub additions if the page import surface changes again.

--- a/docs/pr-notes/runs/953-ci-fix-20260513T030808Z/code-plan.md
+++ b/docs/pr-notes/runs/953-ci-fix-20260513T030808Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code Plan
+
+1. Add missing DB stub exports `getPlayers` and `getRsvps` to edit-schedule smoke tests.
+2. Add missing schedule notification stub exports for availability reminder recipients and email preview.
+3. Broaden cancelled import route matchers for schedule notification and tournament standings versioned imports so the page uses test stubs across cache-bust version bumps.
+4. Run targeted Playwright smoke tests.

--- a/docs/pr-notes/runs/953-ci-fix-20260513T030808Z/qa.md
+++ b/docs/pr-notes/runs/953-ci-fix-20260513T030808Z/qa.md
@@ -1,0 +1,5 @@
+# QA Notes
+
+Failing assertions all share the same symptom: `#schedule-list` remains empty and submit does not call `addGame`. That is consistent with a boot-time module import failure, not with calendar merge logic or season record logic.
+
+Validation should run the focused edit-schedule smoke spec and, with a local server for baseURL-backed specs, the cancelled import smoke spec.

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -2215,16 +2215,12 @@
                     currentRsvpReminderContext = null;
                     modal.classList.remove('hidden');
                     try {
-                        const [breakdown, players, rsvps] = await Promise.all([
-                            getRsvpBreakdownByPlayer(currentTeamId, gameId),
-                            getPlayers(currentTeamId, { includeInactive: true }),
-                            getRsvps(currentTeamId, gameId)
-                        ]);
+                        const breakdown = await getRsvpBreakdownByPlayer(currentTeamId, gameId);
                         if (requestToken !== currentRsvpRequestToken) return;
-                        const grouped = breakdown.grouped;
-                        const counts = breakdown.counts;
+                        const { grouped, counts, players, rsvps } = breakdown;
+                        const notRespondedIds = new Set(grouped.not_responded.map((r) => String(r.playerId)));
                         const recipients = buildAvailabilityReminderRecipients(players, rsvps);
-                        const emailPreview = buildAvailabilityReminderEmailPreview(players, rsvps);
+                        const emailPreview = buildAvailabilityReminderEmailPreview(players, rsvps, notRespondedIds);
                         const renderRows = (rows) => rows.length
                             ? rows.map((row) => {
                                 const name = escapeHtml(row.playerName || 'Unknown Player');

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -895,7 +895,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getTeams, getGames, getEvents, addGame, updateGame, updateTeam, deleteGame, addPractice, updateEvent, deleteEvent, getConfigs, addCalendarToTeam, removeCalendarFromTeam, getTrackedCalendarEventUids, cancelOccurrence, updateOccurrence, restoreOccurrence, clearOccurrenceOverride, updateSeries, deleteSeries, getUnreadChatCount, getPracticeSessions, cancelGame, getLatestGameAssignments, postChatMessage, getRsvpBreakdownByPlayer, applyTournamentAdvancementPatches, saveTournamentPoolOverride, clearTournamentPoolOverride, getOfficials, addOfficial, updateOfficial, deleteOfficial, createOfficiatingAssignmentNotificationRecords } from './js/db.js?v=30';
+        import { getTeam, getTeams, getGames, getEvents, addGame, updateGame, updateTeam, deleteGame, addPractice, updateEvent, deleteEvent, getConfigs, addCalendarToTeam, removeCalendarFromTeam, getTrackedCalendarEventUids, cancelOccurrence, updateOccurrence, restoreOccurrence, clearOccurrenceOverride, updateSeries, deleteSeries, getUnreadChatCount, getPracticeSessions, cancelGame, getLatestGameAssignments, postChatMessage, getRsvpBreakdownByPlayer, getPlayers, getRsvps, applyTournamentAdvancementPatches, saveTournamentPoolOverride, clearTournamentPoolOverride, getOfficials, addOfficial, updateOfficial, deleteOfficial, createOfficiatingAssignmentNotificationRecords } from './js/db.js?v=30';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, formatTimeRange, getDefaultEndTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, getCalendarEventStatus, getCalendarEventTrackingId, isTrackedCalendarEvent, generateSeriesId, expandRecurrence, formatRecurrence, shareOrCopy, escapeHtml } from './js/utils.js?v=10';
         import { mergeCalendarImportEvents, validateCalendarImportUrl } from './js/edit-schedule-calendar-import.js?v=1';
         import { checkAuth } from './js/auth.js?v=14';
@@ -913,7 +913,7 @@
         import { getApp } from './js/vendor/firebase-app.js';
         import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
         import { buildPoolStandingsIndex, collectTournamentAdvancementPatches, collectTournamentPoolSeeds, describeTournamentSource, planTournamentPoolAdvancement } from './js/tournament-brackets.js?v=1';
-        import { normalizeScheduleNotificationSettings, describeScheduleReminderWindow, buildScheduleNotificationMetadata, buildScheduleChangeMessage, buildScheduleNotificationTargets, postScheduleNotificationTargets, buildRsvpReminderMessage } from './js/schedule-notifications.js?v=4';
+        import { normalizeScheduleNotificationSettings, describeScheduleReminderWindow, buildScheduleNotificationMetadata, buildScheduleChangeMessage, buildScheduleNotificationTargets, postScheduleNotificationTargets, buildRsvpReminderMessage, buildAvailabilityReminderRecipients, buildAvailabilityReminderEmailPreview } from './js/schedule-notifications.js?v=5';
         import { buildTournamentPoolStandings, buildTournamentPoolOverrideKey } from './js/tournament-standings.js?v=3';
         import { SCHEDULE_CSV_IMPORT_FIELDS, buildScheduleImportPreview, inferScheduleCsvMapping, normalizeScheduleImportDraft, parseCsvText } from './js/schedule-csv-import.js?v=2';
         import { buildRegistrationScheduleImportPreview, formatRegistrationImportResults, getRegistrationScheduleEvents, isExternallyLinkedRegistrationTeam, planRegistrationScheduleImport } from './js/edit-schedule-registration-import.js?v=4';
@@ -2215,10 +2215,16 @@
                     currentRsvpReminderContext = null;
                     modal.classList.remove('hidden');
                     try {
-                        const breakdown = await getRsvpBreakdownByPlayer(currentTeamId, gameId);
+                        const [breakdown, players, rsvps] = await Promise.all([
+                            getRsvpBreakdownByPlayer(currentTeamId, gameId),
+                            getPlayers(currentTeamId, { includeInactive: true }),
+                            getRsvps(currentTeamId, gameId)
+                        ]);
                         if (requestToken !== currentRsvpRequestToken) return;
                         const grouped = breakdown.grouped;
                         const counts = breakdown.counts;
+                        const recipients = buildAvailabilityReminderRecipients(players, rsvps);
+                        const emailPreview = buildAvailabilityReminderEmailPreview(players, rsvps);
                         const renderRows = (rows) => rows.length
                             ? rows.map((row) => {
                                 const name = escapeHtml(row.playerName || 'Unknown Player');
@@ -2227,6 +2233,18 @@
                                 return `<div class="text-sm py-1">${name}${jersey}${note}</div>`;
                             }).join('')
                             : '<p class="text-xs text-gray-400">None</p>';
+                        const renderEmailPreviewRows = (rows) => rows.length
+                            ? rows.map((row) => {
+                                const name = escapeHtml(row.playerName || 'Unknown Player');
+                                const jersey = row.playerNumber ? ` <span class="text-gray-400 text-xs">#${escapeHtml(row.playerNumber)}</span>` : '';
+                                if (row.hasEligibleParentEmail) {
+                                    const emails = row.parentEmails.map((email) => escapeHtml(email)).join(', ');
+                                    return `<div class="rounded border border-indigo-100 bg-indigo-50 px-3 py-2 text-xs"><div class="font-semibold text-indigo-900">${name}${jersey}</div><div class="mt-1 text-indigo-700 break-words">${emails}</div></div>`;
+                                }
+                                return `<div class="rounded border border-amber-200 bg-amber-50 px-3 py-2 text-xs"><div class="font-semibold text-amber-900">${name}${jersey}</div><div class="mt-1 text-amber-700">No eligible parent or guardian email</div></div>`;
+                            }).join('')
+                            : '<p class="text-xs text-gray-400">Everyone has responded. No RSVP email follow-up recipients.</p>';
+                        const emailPreviewSummary = `${emailPreview.eligibleEmailCount} eligible parent/guardian ${emailPreview.eligibleEmailCount === 1 ? 'email' : 'emails'} across ${recipients.playerCount} no-response ${recipients.playerCount === 1 ? 'player' : 'players'}.`;
                         content.innerHTML = `
                             <div class="space-y-4">
                                 <div>
@@ -2244,6 +2262,11 @@
                                 <div>
                                     <h4 class="text-sm font-bold text-gray-700 mb-2">Not Responded (${counts.notResponded})</h4>
                                     ${renderRows(grouped.not_responded)}
+                                </div>
+                                <div class="border-t border-gray-200 pt-4">
+                                    <h4 class="text-sm font-bold text-indigo-700 mb-1">RSVP email recipient preview</h4>
+                                    <p class="text-xs text-gray-500 mb-3">${emailPreviewSummary}</p>
+                                    <div class="space-y-2">${renderEmailPreviewRows(emailPreview.players)}</div>
                                 </div>
                             </div>
                         `;

--- a/js/db.js
+++ b/js/db.js
@@ -5850,7 +5850,8 @@ export async function getRsvpBreakdownByPlayer(teamId, gameId) {
         getRsvps(teamId, gameId)
     ]);
     const fallbackByUser = await buildFallbackPlayerIdsByUser(teamId, rsvps);
-    return buildGameDayRsvpBreakdown({ players, rsvps, fallbackByUser });
+    const breakdown = buildGameDayRsvpBreakdown({ players, rsvps, fallbackByUser });
+    return { ...breakdown, players, rsvps };
 }
 
 export async function getPublicTrackingItems(teamId) {

--- a/js/schedule-notifications.js
+++ b/js/schedule-notifications.js
@@ -251,8 +251,12 @@ export function buildAvailabilityReminderRecipients(players, rsvps) {
     };
 }
 
-export function buildAvailabilityReminderEmailPreview(players, rsvps) {
-    const nonRespondingPlayers = getNonRespondingAvailabilityPlayers(players, rsvps);
+export function buildAvailabilityReminderEmailPreview(players, rsvps, notRespondedIds = null) {
+    const nonRespondingPlayers = notRespondedIds
+        ? (Array.isArray(players) ? players : []).filter(
+            (p) => p?.active !== false && notRespondedIds.has(String(p?.id || ''))
+          )
+        : getNonRespondingAvailabilityPlayers(players, rsvps);
     const playerPreviews = nonRespondingPlayers.map((player) => {
         const parentEmails = uniqueEligibleEmails(
             Array.isArray(player?.parents) ? player.parents.map((parent) => parent?.email) : []

--- a/js/schedule-notifications.js
+++ b/js/schedule-notifications.js
@@ -182,6 +182,11 @@ function uniqueNonEmptyStrings(values) {
         .filter(Boolean)));
 }
 
+function uniqueEligibleEmails(values) {
+    return uniqueNonEmptyStrings(values)
+        .filter((email) => email.includes('@'));
+}
+
 function normalizeRsvpResponse(response) {
     return ['going', 'maybe', 'not_going'].includes(response) ? response : 'not_responded';
 }
@@ -200,7 +205,7 @@ function getPlayerParentUserIds(player) {
     ]);
 }
 
-export function buildAvailabilityReminderRecipients(players, rsvps) {
+function getNonRespondingAvailabilityPlayers(players, rsvps) {
     const activePlayers = (Array.isArray(players) ? players : [])
         .filter((player) => player?.active !== false && String(player?.id || '').trim());
     const playerIdsByParentUserId = new Map();
@@ -220,7 +225,11 @@ export function buildAvailabilityReminderRecipients(players, rsvps) {
         [...rsvpPlayerIds, ...fallbackPlayerIds].forEach((playerId) => respondedPlayerIds.add(playerId));
     });
 
-    const nonRespondingPlayers = activePlayers.filter((player) => !respondedPlayerIds.has(String(player.id)));
+    return activePlayers.filter((player) => !respondedPlayerIds.has(String(player.id)));
+}
+
+export function buildAvailabilityReminderRecipients(players, rsvps) {
+    const nonRespondingPlayers = getNonRespondingAvailabilityPlayers(players, rsvps);
     const playerIds = uniqueNonEmptyStrings(nonRespondingPlayers.map((player) => player.id));
     const parentIds = uniqueNonEmptyStrings(nonRespondingPlayers.flatMap((player) => (
         getPlayerParentUserIds(player)
@@ -239,6 +248,32 @@ export function buildAvailabilityReminderRecipients(players, rsvps) {
         parentEmails,
         playerCount: playerIds.length,
         recipientCount: parentIds.length + rosterDirectRecipientCount
+    };
+}
+
+export function buildAvailabilityReminderEmailPreview(players, rsvps) {
+    const nonRespondingPlayers = getNonRespondingAvailabilityPlayers(players, rsvps);
+    const playerPreviews = nonRespondingPlayers.map((player) => {
+        const parentEmails = uniqueEligibleEmails(
+            Array.isArray(player?.parents) ? player.parents.map((parent) => parent?.email) : []
+        );
+        return {
+            playerId: String(player.id),
+            playerName: player.name || `#${player.number || ''}`.trim() || 'Unknown Player',
+            playerNumber: player.number || '',
+            parentEmails,
+            hasEligibleParentEmail: parentEmails.length > 0
+        };
+    });
+    const eligibleEmails = uniqueEligibleEmails(playerPreviews.flatMap((player) => player.parentEmails));
+
+    return {
+        players: playerPreviews,
+        eligibleEmails,
+        eligibleEmailCount: eligibleEmails.length,
+        missingEmailPlayerIds: playerPreviews
+            .filter((player) => !player.hasEligibleParentEmail)
+            .map((player) => player.playerId)
     };
 }
 

--- a/tests/smoke/edit-schedule-calendar-cancelled-import.spec.js
+++ b/tests/smoke/edit-schedule-calendar-cancelled-import.spec.js
@@ -39,6 +39,8 @@ export async function getLatestGameAssignments() { return {}; }
 export async function postChatMessage() {}
 export async function applyTournamentAdvancementPatches() {}
 export async function getRsvpBreakdownByPlayer() { return {}; }
+export async function getPlayers() { return []; }
+export async function getRsvps() { return []; }
 export async function saveTournamentPoolOverride() {}
 export async function clearTournamentPoolOverride() {}
 export async function getOfficials() { return []; }
@@ -274,6 +276,14 @@ export function buildRsvpReminderMessage() {
 export function describeScheduleReminderWindow() {
     return 'Team default reminder window: 24 hours before event start.';
 }
+
+export function buildAvailabilityReminderRecipients() {
+    return [];
+}
+
+export function buildAvailabilityReminderEmailPreview() {
+    return { recipients: [], subject: '', body: '' };
+}
 `;
 
 const SCHEDULE_CSV_IMPORT_STUB = `
@@ -306,8 +316,8 @@ async function mockEditScheduleDependencies(page) {
     await page.route('**/js/vendor/firebase-app.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_APP_STUB }));
     await page.route('**/js/vendor/firebase-ai.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_AI_STUB }));
     await page.route('**/js/tournament-brackets.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TOURNAMENT_STUB }));
-    await page.route('**/js/schedule-notifications.js?v=4', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: SCHEDULE_NOTIFICATIONS_STUB }));
-    await page.route('**/js/tournament-standings.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TOURNAMENT_STANDINGS_STUB }));
+    await page.route('**/js/schedule-notifications.js?v=*', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: SCHEDULE_NOTIFICATIONS_STUB }));
+    await page.route('**/js/tournament-standings.js?v=*', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TOURNAMENT_STANDINGS_STUB }));
     await page.route('**/js/schedule-csv-import.js?v=2', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: SCHEDULE_CSV_IMPORT_STUB }));
 }
 

--- a/tests/smoke/edit-schedule-calendar-import.spec.js
+++ b/tests/smoke/edit-schedule-calendar-import.spec.js
@@ -70,6 +70,8 @@ export async function getRsvpBreakdownByPlayer() {
         counts: { going: 0, maybe: 0, notGoing: 0, notResponded: 0 }
     };
 }
+export async function getPlayers() { return []; }
+export async function getRsvps() { return []; }
 export async function saveTournamentPoolOverride() {}
 export async function clearTournamentPoolOverride() {}
 export async function getOfficials() { return []; }
@@ -306,6 +308,14 @@ export function buildRsvpReminderMessage() {
 
 export function describeScheduleReminderWindow() {
     return 'Team default reminder window: 24 hours before event start.';
+}
+
+export function buildAvailabilityReminderRecipients() {
+    return [];
+}
+
+export function buildAvailabilityReminderEmailPreview() {
+    return { recipients: [], subject: '', body: '' };
 }
 `,
     '/js/schedule-csv-import.js': `

--- a/tests/unit/edit-schedule-notifications.test.js
+++ b/tests/unit/edit-schedule-notifications.test.js
@@ -71,7 +71,7 @@ describe('edit schedule notification wiring', () => {
         const source = readEditSchedule();
 
         expect(source).toContain('buildAvailabilityReminderRecipients(players, rsvps)');
-        expect(source).toContain('buildAvailabilityReminderEmailPreview(players, rsvps)');
+        expect(source).toContain('buildAvailabilityReminderEmailPreview(players, rsvps, notRespondedIds)');
         expect(source).toContain('RSVP email recipient preview');
         expect(source).toContain('No eligible parent or guardian email');
         expect(source).toContain('eligible parent/guardian');

--- a/tests/unit/edit-schedule-notifications.test.js
+++ b/tests/unit/edit-schedule-notifications.test.js
@@ -59,12 +59,22 @@ describe('edit schedule notification wiring', () => {
     it('wires the schedule notification helper and RSVP reminder action', () => {
         const source = readEditSchedule();
 
-        expect(source).toContain("from './js/schedule-notifications.js?v=4'");
+        expect(source).toContain("from './js/schedule-notifications.js?v=5'");
         expect(source).toContain('describeScheduleReminderWindow');
         expect(source).toContain('await postScheduleNotificationTargets({');
         expect(source).toContain('id="send-rsvp-reminder-btn"');
         expect(source).toContain('await sendRsvpReminder(');
         expect(source).toContain('await maybeNotifyScheduleChange(');
+    });
+
+    it('renders RSVP email recipient preview for no-response players', () => {
+        const source = readEditSchedule();
+
+        expect(source).toContain('buildAvailabilityReminderRecipients(players, rsvps)');
+        expect(source).toContain('buildAvailabilityReminderEmailPreview(players, rsvps)');
+        expect(source).toContain('RSVP email recipient preview');
+        expect(source).toContain('No eligible parent or guardian email');
+        expect(source).toContain('eligible parent/guardian');
     });
 
     it('renders the inherited reminder window from team settings', () => {

--- a/tests/unit/schedule-notifications.test.js
+++ b/tests/unit/schedule-notifications.test.js
@@ -6,6 +6,7 @@ import {
     buildScheduleNotificationTargets,
     postScheduleNotificationTargets,
     buildAvailabilityReminderRecipients,
+    buildAvailabilityReminderEmailPreview,
     buildRsvpReminderMessage,
     buildNextReminderAt,
     buildScheduleNotificationMetadata
@@ -260,6 +261,38 @@ describe('schedule notification helpers', () => {
         expect(recipients.playerIds).toEqual(['p1', 'p2']);
         expect(recipients.parentIds).toEqual(['u2']);
         expect(recipients.recipientCount).toBe(2);
+    });
+
+    it('builds parent email preview for no-response players', () => {
+        const preview = buildAvailabilityReminderEmailPreview([
+            { id: 'p1', name: 'A', parents: [{ userId: 'u1', email: 'one@example.com' }] },
+            { id: 'p2', name: 'B', parents: [{ userId: 'u2', email: 'pending' }] },
+            { id: 'p3', name: 'C', parents: [{ userId: 'u3', email: 'three@example.com' }] }
+        ], [
+            { userId: 'u3', playerIds: ['p3'], response: 'going' }
+        ]);
+
+        expect(preview).toEqual({
+            players: [
+                {
+                    playerId: 'p1',
+                    playerName: 'A',
+                    playerNumber: '',
+                    parentEmails: ['one@example.com'],
+                    hasEligibleParentEmail: true
+                },
+                {
+                    playerId: 'p2',
+                    playerName: 'B',
+                    playerNumber: '',
+                    parentEmails: [],
+                    hasEligibleParentEmail: false
+                }
+            ],
+            eligibleEmails: ['one@example.com'],
+            eligibleEmailCount: 1,
+            missingEmailPlayerIds: ['p2']
+        });
     });
 
     it('builds RSVP reminder messages for the no-response group', () => {


### PR DESCRIPTION
Closes #950

## Summary
- Adds a coach-facing RSVP email recipient preview to the schedule RSVP modal.
- Shows eligible parent/guardian email addresses for no-response players.
- Clearly flags players with no eligible parent or guardian email while preserving the existing team chat reminder flow.

## Tests
- `npx vitest run tests/unit/schedule-notifications.test.js tests/unit/edit-schedule-notifications.test.js`