### PR TITLE
Fix type-less invite login redirects

### DIFF
--- a/js/login-page.js
+++ b/js/login-page.js
@@ -66,7 +66,7 @@ export function createLoginRedirectCoordinator({
         ? urlParams.get('type').trim().toLowerCase()
         : '';
     const shouldRedeemInviteFromLogin = Boolean(urlCodeParam) &&
-        (urlInviteType === 'parent' || urlInviteType === 'admin');
+        (!urlInviteType || urlInviteType === 'parent' || urlInviteType === 'admin');
     let inviteRedemptionOverride = null;
 
     function getPostAuthRedirect(userWithRoles, shouldRedeemInvite = false) {

--- a/login.html
+++ b/login.html
@@ -100,7 +100,7 @@
         import { getUserProfile } from './js/db.js?v=29';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import { getPostAuthRedirectUrl } from './js/invite-redirect.js?v=1';
-        import * as loginPageModule from './js/login-page.js?v=2';
+        import * as loginPageModule from './js/login-page.js?v=3';
 
         renderFooter(document.getElementById('footer-container'));
 

--- a/tests/smoke/login-invite-redirect.spec.js
+++ b/tests/smoke/login-invite-redirect.spec.js
@@ -104,7 +104,7 @@ async function mockInviteLoginModules(page, options = {}) {
     });
 }
 
-test('email/password login from an invite link redirects existing parents to accept-invite', async ({ page, baseURL }) => {
+test('email/password login from a type-less invite link redirects existing users to accept-invite', async ({ page, baseURL }) => {
     await mockInviteLoginModules(page, {
         profile: {
             parentOf: [{ teamId: 'team-1' }]
@@ -112,7 +112,7 @@ test('email/password login from an invite link redirects existing parents to acc
         defaultRedirect: 'parent-dashboard.html'
     });
 
-    await page.goto(buildUrl(baseURL, '/login.html?code=ab12cd34&type=parent'), {
+    await page.goto(buildUrl(baseURL, '/login.html?code=ab12cd34'), {
         waitUntil: 'domcontentloaded'
     });
 
@@ -124,7 +124,7 @@ test('email/password login from an invite link redirects existing parents to acc
     await page.locator('#password').fill('secret123');
     await page.locator('#login-form').dispatchEvent('submit');
 
-    await expect(page).toHaveURL(/\/accept-invite\.html\?code=AB12CD34&type=parent$/);
+    await expect(page).toHaveURL(/\/accept-invite\.html\?code=AB12CD34$/);
 });
 
 test('google redirect login mode keeps existing admin invites on accept-invite', async ({ page, baseURL }) => {

--- a/tests/unit/login-page-cache-busting.test.js
+++ b/tests/unit/login-page-cache-busting.test.js
@@ -7,7 +7,7 @@ describe('login page cache busting', () => {
         const source = readFileSync(resolve(process.cwd(), 'login.html'), 'utf8');
 
         expect(source).toContain(
-            "import * as loginPageModule from './js/login-page.js?v=2';"
+            "import * as loginPageModule from './js/login-page.js?v=3';"
         );
     });
 });

--- a/tests/unit/login-page.test.js
+++ b/tests/unit/login-page.test.js
@@ -69,6 +69,17 @@ describe('login page redirect coordination', () => {
             .toBe('accept-invite.html?code=AB12CD34&type=admin');
     });
 
+    it('redeems type-less 8-character invite links after login', () => {
+        const { coordinator } = createCoordinator({
+            search: '?code=ab12cd34',
+            defaultRedirect: 'dashboard.html'
+        });
+
+        expect(coordinator.shouldRedeemInviteFromLogin).toBe(true);
+        expect(coordinator.getPostAuthRedirect({ uid: 'user-1' }, coordinator.shouldRedeemInviteFromLogin))
+            .toBe('accept-invite.html?code=AB12CD34');
+    });
+
     it('does not redeem invite redirects when the invite code is missing', () => {
         const { coordinator } = createCoordinator({
             search: '?type=parent',


### PR DESCRIPTION
Closes #960

## Summary
- Treat invite login links with a code but no type as redeemable after login.
- Preserve typed parent/admin invite behavior and omit type when it was absent.
- Bumped the login-page module cache version so browsers load the fixed coordinator.

## Validation
- `npm run test:unit -- tests/unit/login-page.test.js tests/unit/invite-redirect.test.js tests/unit/login-page-cache-busting.test.js`
- `npx playwright test tests/smoke/login-invite-redirect.spec.js --config=playwright.smoke.config.js --reporter=line`