### PR TITLE
Add team fee batch management links

### DIFF
--- a/js/db.js
+++ b/js/db.js
@@ -3148,6 +3148,13 @@ export async function getTeamFeeBatch(teamId, batchId) {
     return batchSnap.exists() ? { id: batchSnap.id, ...batchSnap.data() } : null;
 }
 
+export async function listTeamFeeBatches(teamId) {
+    if (!teamId) return [];
+    const batchesRef = collection(db, 'teams', teamId, 'feeBatches');
+    const snapshot = await getDocs(query(batchesRef, orderBy('createdAt', 'desc'), limit(25)));
+    return snapshot.docs.map((batchDoc) => ({ id: batchDoc.id, ...batchDoc.data() }));
+}
+
 export async function listTeamFeeRecipients(teamId, batchId) {
     if (!teamId || !batchId) return [];
     const recipientsRef = collection(db, 'teams', teamId, 'feeBatches', batchId, 'feeRecipients');

--- a/js/db.js
+++ b/js/db.js
@@ -30,8 +30,8 @@ import {
     uploadBytes,
     getDownloadURL,
     deleteObject
-} from './firebase.js?v=11';
-import { imageStorage, ensureImageAuth, requireImageAuth } from './firebase-images.js?v=4';
+} from './firebase.js?v=12';
+import { imageStorage, ensureImageAuth, requireImageAuth } from './firebase-images.js?v=5';
 import { uploadBytesResumable } from './vendor/firebase-storage.js';
 import { buildDrillDiagramUploadPaths } from './drill-upload-paths.js?v=1';
 import { isAccessCodeExpired } from './access-code-utils.js?v=1';

--- a/js/firebase-images.js
+++ b/js/firebase-images.js
@@ -1,7 +1,7 @@
 import { initializeApp, getApps } from "./vendor/firebase-app.js";
 import { getStorage } from "./vendor/firebase-storage.js";
 import { getAuth, signInAnonymously, onAuthStateChanged, setPersistence, browserLocalPersistence } from "./vendor/firebase-auth.js";
-import { resolveImageFirebaseConfig } from "./firebase-runtime-config.js?v=5";
+import { resolveImageFirebaseConfig } from "./firebase-runtime-config.js?v=6";
 
 const imgConfig = resolveImageFirebaseConfig();
 

--- a/js/firebase-images.js
+++ b/js/firebase-images.js
@@ -1,7 +1,7 @@
 import { initializeApp, getApps } from "./vendor/firebase-app.js";
 import { getStorage } from "./vendor/firebase-storage.js";
 import { getAuth, signInAnonymously, onAuthStateChanged, setPersistence, browserLocalPersistence } from "./vendor/firebase-auth.js";
-import { resolveImageFirebaseConfig } from "./firebase-runtime-config.js?v=6";
+import { resolveImageFirebaseConfig } from "./firebase-runtime-config.js?v=7";
 
 const imgConfig = resolveImageFirebaseConfig();
 

--- a/js/firebase-runtime-config.js
+++ b/js/firebase-runtime-config.js
@@ -49,7 +49,9 @@ function normalizeFirebaseConfig(rawConfig) {
 }
 
 async function fetchFirebaseConfigFromHosting() {
-    const response = await fetch(FIREBASE_INIT_JSON_URL, { cache: 'no-store' });
+    const baseUrl = (typeof window !== 'undefined' && window.location && window.location.origin) ? window.location.origin : 'http://localhost';
+    const fullUrl = new URL(FIREBASE_INIT_JSON_URL, baseUrl).toString();
+    const response = await fetch(fullUrl, { cache: 'no-store' });
     if (!response.ok) {
         throw new Error(`Firebase config request failed (${response.status})`);
     }

--- a/js/firebase.js
+++ b/js/firebase.js
@@ -47,7 +47,7 @@ import {
     runTransaction
 } from "./vendor/firebase-firestore.js";
 import { getStorage, ref, uploadBytes, getDownloadURL, deleteObject } from "./vendor/firebase-storage.js";
-import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=5";
+import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=6";
 
 const firebaseConfig = await resolvePrimaryFirebaseConfig();
 

--- a/js/firebase.js
+++ b/js/firebase.js
@@ -47,7 +47,7 @@ import {
     runTransaction
 } from "./vendor/firebase-firestore.js";
 import { getStorage, ref, uploadBytes, getDownloadURL, deleteObject } from "./vendor/firebase-storage.js";
-import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=6";
+import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=7";
 
 const firebaseConfig = await resolvePrimaryFirebaseConfig();
 

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -731,7 +731,7 @@ async function initTeamFeesAdminPage() {
     renderFooter(document.getElementById('footer-container'));
 
     const [{ getTeam, getPlayers, getUserProfile, createTeamFeeBatch, getTeamFeeBatch, listTeamFeeBatches, listTeamFeeRecipients, updateTeamFeeRecipient, canModerateChat }, { requireAuth }] = await Promise.all([
-        import('./db.js?v=33'),
+        import('./db.js?v=34'),
         import('./auth.js?v=12')
     ]);
 

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -397,7 +397,7 @@ function renderInvoiceRow(type) {
 }
 
 export function buildTeamFeeBatchManageUrl(teamId, batchId) {
-    return `team-fees.html#teamId=${encodeURIComponent(teamId)}&batchId=${encodeURIComponent(batchId)}`;
+    return `team-fees.html?teamId=${encodeURIComponent(teamId)}&batchId=${encodeURIComponent(batchId)}`;
 }
 
 export function renderCreatedTeamFeeBatchSuccess(teamId, batchId) {

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -338,7 +338,7 @@ function renderRosterOptions(players) {
 
 function showMessage(message, type = 'info') {
     const el = document.getElementById('fee-message');
-    if (!el) return;
+    if (!el) return null;
 
     const colors = type === 'error'
         ? 'border-red-200 bg-red-50 text-red-700'
@@ -349,6 +349,13 @@ function showMessage(message, type = 'info') {
     el.className = `rounded-xl border p-4 text-sm ${colors}`;
     el.textContent = message;
     el.classList.remove('hidden');
+    return el;
+}
+
+function showHtmlMessage(html, type = 'info') {
+    const el = showMessage('', type);
+    if (!el) return;
+    el.innerHTML = html;
 }
 
 function collectFormValues(form) {
@@ -386,6 +393,55 @@ function renderInvoiceRow(type) {
             <input name="installmentAmount" type="number" min="0.01" step="0.01" placeholder="0.00" class="rounded-lg border-gray-300 text-sm" aria-label="Installment amount">
             <button type="button" data-remove-row class="rounded-lg border border-gray-300 px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-white">Remove</button>
         </div>
+    `;
+}
+
+export function buildTeamFeeBatchManageUrl(teamId, batchId) {
+    return `team-fees.html#teamId=${encodeURIComponent(teamId)}&batchId=${encodeURIComponent(batchId)}`;
+}
+
+export function renderCreatedTeamFeeBatchSuccess(teamId, batchId) {
+    const manageUrl = buildTeamFeeBatchManageUrl(teamId, batchId);
+    return `
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <span>Fee batch saved with unpaid recipient records. Batch ID: ${escapeHtml(batchId)}</span>
+            <a href="${escapeHtml(manageUrl)}" class="rounded-lg bg-green-700 px-3 py-2 text-center text-sm font-semibold text-white hover:bg-green-800">Manage this fee</a>
+        </div>
+    `;
+}
+
+export function renderTeamFeeBatchList(batches = [], teamId = '') {
+    if (!batches.length) return '';
+
+    return `
+        <section class="mb-6 rounded-2xl border border-gray-200 bg-white p-5 shadow-sm">
+            <div class="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+                <div>
+                    <h2 class="text-lg font-bold text-gray-900">Existing fee batches</h2>
+                    <p class="text-sm text-gray-500">Open a saved batch to record manual payments, adjustments, or cancellations.</p>
+                </div>
+                <span class="text-xs font-semibold uppercase tracking-wide text-gray-400">Latest 25</span>
+            </div>
+            <div class="mt-4 divide-y divide-gray-100">
+                ${batches.map((batch) => {
+                    const title = batch.title || batch.feeTitle || batch.name || 'Team fee';
+                    const amount = formatFeeCurrency(batch.amountCents ?? batch.totalAmountCents ?? 0);
+                    const recipientCount = Number(batch.recipientCount || 0);
+                    const dueDate = batch.dueDate ? ` · Due ${escapeHtml(batch.dueDate)}` : '';
+                    const status = batch.status ? ` · ${escapeHtml(batch.status)}` : '';
+                    const manageUrl = buildTeamFeeBatchManageUrl(teamId, batch.id);
+                    return `
+                        <a href="${escapeHtml(manageUrl)}" class="flex flex-col gap-2 py-3 hover:bg-gray-50 sm:flex-row sm:items-center sm:justify-between">
+                            <span>
+                                <span class="block font-semibold text-gray-900">${escapeHtml(title)}</span>
+                                <span class="text-sm text-gray-500">${amount} · ${recipientCount} recipient${recipientCount === 1 ? '' : 's'}${dueDate}${status}</span>
+                            </span>
+                            <span class="text-sm font-semibold text-primary-600">Manage</span>
+                        </a>
+                    `;
+                }).join('')}
+            </div>
+        </section>
     `;
 }
 
@@ -466,8 +522,14 @@ function canManageTeamFees(team, user, canModerateChat) {
     return isTeamFeeAdmin(team, user) || canModerateChat(user, team);
 }
 
-async function renderCreateMode({ container, teamId, team, user, getPlayers, createTeamFeeBatch }) {
-    const players = await getPlayers(teamId);
+async function renderCreateMode({ container, teamId, team, user, getPlayers, createTeamFeeBatch, listTeamFeeBatches }) {
+    const [players, existingBatches] = await Promise.all([
+        getPlayers(teamId),
+        listTeamFeeBatches ? listTeamFeeBatches(teamId).catch((error) => {
+            console.warn('[team-fees] Unable to load fee batches:', error);
+            return [];
+        }) : []
+    ]);
     container.innerHTML = `
         <div class="mb-6">
             <a href="dashboard.html" class="text-sm font-semibold text-primary-600 hover:text-primary-700">Back to My Teams</a>
@@ -479,6 +541,8 @@ async function renderCreateMode({ container, teamId, team, user, getPlayers, cre
             <p class="font-bold">${OFFLINE_TEAM_FEE_LABEL}</p>
             <p class="mt-1 text-sm">No credit card, Stripe, checkout, email, push, or SMS workflow is created. This only records unpaid roster fee assignments.</p>
         </div>
+
+        ${renderTeamFeeBatchList(existingBatches, teamId)}
 
         <form id="team-fee-form" class="rounded-2xl border border-gray-200 bg-white p-6 shadow-md">
             <div id="fee-message" class="hidden"></div>
@@ -573,7 +637,7 @@ async function renderCreateMode({ container, teamId, team, user, getPlayers, cre
             form.reset();
             lineItemsList.innerHTML = '';
             installmentsList.innerHTML = '';
-            showMessage(`Fee batch saved with unpaid recipient records. Batch ID: ${batch.id}`, 'success');
+            showHtmlMessage(renderCreatedTeamFeeBatchSuccess(teamId, batch.id), 'success');
         } catch (error) {
             showMessage(error?.message || 'Unable to save fee batch.', 'error');
         } finally {
@@ -666,8 +730,8 @@ async function initTeamFeesAdminPage() {
 
     renderFooter(document.getElementById('footer-container'));
 
-    const [{ getTeam, getPlayers, getUserProfile, createTeamFeeBatch, getTeamFeeBatch, listTeamFeeRecipients, updateTeamFeeRecipient, canModerateChat }, { requireAuth }] = await Promise.all([
-        import('./db.js?v=32'),
+    const [{ getTeam, getPlayers, getUserProfile, createTeamFeeBatch, getTeamFeeBatch, listTeamFeeBatches, listTeamFeeRecipients, updateTeamFeeRecipient, canModerateChat }, { requireAuth }] = await Promise.all([
+        import('./db.js?v=33'),
         import('./auth.js?v=12')
     ]);
 
@@ -711,7 +775,7 @@ async function initTeamFeesAdminPage() {
         if (batchId) {
             await renderManageMode({ container, teamId, batchId, team, user, getTeamFeeBatch, listTeamFeeRecipients, updateTeamFeeRecipient });
         } else {
-            await renderCreateMode({ container, teamId, team, user, getPlayers, createTeamFeeBatch });
+            await renderCreateMode({ container, teamId, team, user, getPlayers, createTeamFeeBatch, listTeamFeeBatches });
         }
     } catch (error) {
         console.error('[team-fees] init failed:', error);

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -397,7 +397,7 @@ function renderInvoiceRow(type) {
 }
 
 export function buildTeamFeeBatchManageUrl(teamId, batchId) {
-    return `team-fees.html?teamId=${encodeURIComponent(teamId)}&batchId=${encodeURIComponent(batchId)}`;
+    return `team-fees.html#teamId=${encodeURIComponent(teamId)}&batchId=${encodeURIComponent(batchId)}`;
 }
 
 export function renderCreatedTeamFeeBatchSuccess(teamId, batchId) {

--- a/team-fees.html
+++ b/team-fees.html
@@ -44,7 +44,7 @@
 
     <div id="footer-container"></div>
 
-    <script type="module" src="./js/team-fees-admin.js?v=5"></script>
+    <script type="module" src="./js/team-fees-admin.js?v=6"></script>
 </body>
 
 </html>

--- a/tests/unit/access-code-validation.test.js
+++ b/tests/unit/access-code-validation.test.js
@@ -5,7 +5,7 @@ const collectionMock = vi.fn((database, path) => ({ database, path }));
 const whereMock = vi.fn((field, op, value) => ({ field, op, value }));
 const queryMock = vi.fn((...parts) => parts);
 
-vi.mock('../../js/firebase.js?v=11', () => ({
+vi.mock('../../js/firebase.js?v=12', () => ({
     db: {},
     auth: {},
     storage: {},
@@ -41,7 +41,7 @@ vi.mock('../../js/firebase.js?v=11', () => ({
     deleteObject: vi.fn()
 }));
 
-vi.mock('../../js/firebase-images.js?v=4', () => ({
+vi.mock('../../js/firebase-images.js?v=5', () => ({
     imageStorage: {},
     ensureImageAuth: vi.fn(),
     requireImageAuth: vi.fn()

--- a/tests/unit/team-fees-admin.test.js
+++ b/tests/unit/team-fees-admin.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     buildBalanceAdjustmentUpdate,
     buildCancelRecipientUpdate,
+    buildTeamFeeBatchManageUrl,
     buildManualPaymentUpdate,
     buildTeamFeeRecipientRecords,
     formatFeeCurrency,
@@ -10,6 +11,8 @@ import {
     isTeamFeeAdmin,
     normalizeTeamFeeDraft,
     parseTeamFeeAmountToCents,
+    renderCreatedTeamFeeBatchSuccess,
+    renderTeamFeeBatchList,
     summarizeFeeRecipients,
     toFeeCents,
     toSignedFeeCents
@@ -106,6 +109,23 @@ describe('team fees admin helpers', () => {
                 installments: []
             })
         ]);
+    });
+
+    it('renders reachable management links for created and existing fee batches', () => {
+        expect(buildTeamFeeBatchManageUrl('team 1', 'batch/1')).toBe('team-fees.html#teamId=team%201&batchId=batch%2F1');
+
+        const success = renderCreatedTeamFeeBatchSuccess('team-1', 'batch-1');
+        expect(success).toContain('Batch ID: batch-1');
+        expect(success).toContain('href="team-fees.html#teamId=team-1&amp;batchId=batch-1"');
+        expect(success).toContain('Manage this fee');
+
+        const list = renderTeamFeeBatchList([
+            { id: 'batch-1', title: 'Season dues', amountCents: 12500, recipientCount: 3, dueDate: '2026-06-01', status: 'open' }
+        ], 'team-1');
+        expect(list).toContain('Existing fee batches');
+        expect(list).toContain('Season dues');
+        expect(list).toContain('$125.00');
+        expect(list).toContain('href="team-fees.html#teamId=team-1&amp;batchId=batch-1"');
     });
 
     it('enforces positive amounts, required fields, recipients, and admin checks', () => {


### PR DESCRIPTION
Closes #962

## Summary
- Added a Team Fees list of existing fee batches when admins open `team-fees.html` with only a `teamId`.
- Added a post-create success link directly to the new batch management view.
- Added focused unit coverage for created and existing batch management links.

## Validation
- `npx vitest run tests/unit/team-fees-admin.test.js`
- `node scripts/check-critical-cache-bust.mjs`