### PR TITLE
Add player profile no-game smoke coverage

### DIFF
--- a/tests/smoke/helpers/boot-path.js
+++ b/tests/smoke/helpers/boot-path.js
@@ -131,7 +131,17 @@ export function createBootIssueCollector(page, options = {}) {
 }
 
 export async function assertPageBootsWithoutFatalErrors(page, options) {
-    const { baseURL, path, titlePatterns, readySelectors = [], forbiddenTexts = [] } = options;
+    const {
+        baseURL,
+        path,
+        titlePatterns,
+        readySelectors = [],
+        requiredSelectors = [],
+        forbiddenTexts = [],
+        expectedAttributes = [],
+        tabChecks = [],
+        hiddenSelectors = []
+    } = options;
     const issues = createBootIssueCollector(page, options);
 
     await page.goto(buildUrl(baseURL, path), { waitUntil: 'domcontentloaded' });
@@ -149,6 +159,23 @@ export async function assertPageBootsWithoutFatalErrors(page, options) {
                 page.locator(selector).first().waitFor({ state: 'attached', timeout: 10000 })
             )
         );
+    }
+
+    for (const selector of requiredSelectors) {
+        await page.locator(selector).first().waitFor({ state: 'attached', timeout: 10000 });
+    }
+
+    for (const { selector, attribute, value } of expectedAttributes) {
+        await expect(page.locator(selector).first()).toHaveAttribute(attribute, value);
+    }
+
+    for (const { tab, content } of tabChecks) {
+        await page.locator(tab).click();
+        await expect(page.locator(content).first()).toBeVisible();
+    }
+
+    for (const selector of hiddenSelectors) {
+        await expect(page.locator(selector).first()).toBeHidden();
     }
 
     const bodyText = await page.locator('body').innerText();

--- a/tests/smoke/page-registry.js
+++ b/tests/smoke/page-registry.js
@@ -41,6 +41,24 @@ function buildOptionalCorePages({ teamId, gameId, playerId }) {
         );
     }
 
+    if (playerId) {
+        pages.push({
+            name: 'player details without game context',
+            path: `/player.html#teamId=${teamId}&playerId=${playerId}`,
+            titlePatterns: [/Player Details - ALL PLAYS/i],
+            requiredSelectors: ['#player-header', '#season-overview', '#game-stats'],
+            forbiddenTexts: [/Player not found/i, /Error loading player details/i],
+            expectedAttributes: [
+                { selector: '#back-link', attribute: 'href', value: `team.html#teamId=${teamId}` }
+            ],
+            tabChecks: [
+                { tab: '#tab-season', content: '#content-season' },
+                { tab: '#tab-games', content: '#content-games' }
+            ],
+            hiddenSelectors: ['#player-game-insights-section']
+        });
+    }
+
     if (gameId && playerId) {
         pages.push({
             name: 'player details',

--- a/tests/smoke/static-hosting-bootstrap.spec.js
+++ b/tests/smoke/static-hosting-bootstrap.spec.js
@@ -25,10 +25,7 @@ test.describe('public smoke pages', () => {
         test(`${definition.name} renders`, async ({ page, baseURL }) => {
             await assertPageBootsWithoutFatalErrors(page, {
                 baseURL,
-                path: definition.path,
-                titlePatterns: definition.titlePatterns,
-                readySelectors: definition.readySelectors,
-                forbiddenTexts: definition.forbiddenTexts
+                ...definition
             });
         });
     }
@@ -39,10 +36,7 @@ test.describe('preview boot smoke pages', () => {
         test(`${definition.name} boots without fatal runtime errors`, async ({ page, baseURL }) => {
             await assertPageBootsWithoutFatalErrors(page, {
                 baseURL,
-                path: definition.path,
-                titlePatterns: definition.titlePatterns,
-                readySelectors: definition.readySelectors,
-                forbiddenTexts: definition.forbiddenTexts
+                ...definition
             });
         });
     }
@@ -59,10 +53,7 @@ test.describe('authenticated smoke pages', () => {
             await test.step(definition.name, async () => {
                 await assertPageBootsWithoutFatalErrors(page, {
                     baseURL,
-                    path: definition.path,
-                    titlePatterns: definition.titlePatterns,
-                    readySelectors: definition.readySelectors,
-                    forbiddenTexts: definition.forbiddenTexts
+                    ...definition
                 });
             });
         }


### PR DESCRIPTION
Closes #966

## Summary
- Added smoke registry coverage for `player.html` with `teamId` and `playerId` only, omitting `gameId`.
- Extended the boot helper to support required selectors, fallback link assertions, tab usability checks, and hidden-section assertions.
- Passed smoke definition metadata through the static bootstrap spec so scenario-specific assertions run.

## Validation
- `SMOKE_PLAYER_ID=test-player npx playwright test tests/smoke/static-hosting-bootstrap.spec.js --config=playwright.smoke.config.js --list`
- `node --input-type=module` registry assertion for the no-game player smoke page
- `SMOKE_BASE_URL=http://127.0.0.1:4173 npx playwright test tests/smoke/static-hosting-bootstrap.spec.js --config=playwright.smoke.config.js --grep "homepage renders" --reporter=line`
- `git diff --check`