### PR TITLE
Add organization draft slot generator

### DIFF
--- a/docs/pr-notes/runs/987-ci-fix-20260512T040845Z/architecture.md
+++ b/docs/pr-notes/runs/987-ci-fix-20260512T040845Z/architecture.md
@@ -1,0 +1,16 @@
+# Architecture Notes
+
+## Current State
+- PR #987 cache-busted page imports to newer versions, including `js/auth.js?v=15` and `js/team-access.js?v=3`.
+- The admin invite smoke spec still mocked older exact versions, so Playwright allowed real modules to load instead of the intended stubs.
+- `js/accept-invite-flow.js` also built the admin success message only from `redeemResult.teamName`, falling back to `the team` even when the fetched team had a name.
+
+## Decision
+- Keep the production flow and data model unchanged.
+- Make the smoke mocks version-tolerant for auth and team-access ES module imports.
+- Harden admin invite success text to use fetched `team.name` when the atomic redeem result does not include `teamName`.
+
+## Impact
+- No Firestore rules, data shape, or permission expansion.
+- Existing post-redemption `hasFullTeamAccess` guard remains fail-closed.
+- Blast radius is limited to smoke test routing and admin invite display fallback text.

--- a/docs/pr-notes/runs/987-ci-fix-20260512T040845Z/code-plan.md
+++ b/docs/pr-notes/runs/987-ci-fix-20260512T040845Z/code-plan.md
@@ -1,0 +1,16 @@
+# Code Plan
+
+## Patch
+- Update admin invite smoke mocks to match `auth.js` and `team-access.js` with optional numeric cache-bust query strings.
+- Update admin invite success text to fall back to fetched `team.name` when `redeemAdminInviteAtomically` does not return `teamName`.
+
+## Files
+- `tests/smoke/admin-invite-redemption.spec.js`
+- `js/accept-invite-flow.js`
+
+## Validation
+- Run the focused Playwright smoke spec for admin invite redemption.
+- Run targeted invite-related unit tests if the repo has the needed test dependencies installed.
+
+## Commit Message
+- `fix:address-ci-failure: update admin invite smoke mocks`

--- a/docs/pr-notes/runs/987-ci-fix-20260512T040845Z/qa.md
+++ b/docs/pr-notes/runs/987-ci-fix-20260512T040845Z/qa.md
@@ -1,0 +1,16 @@
+# QA Notes
+
+## Root Cause Hypothesis
+- The failing preview-smoke checks are caused by stale route stubs in `tests/smoke/admin-invite-redemption.spec.js`.
+- `auth.js` and `team-access.js` imports were cache-busted in page code, but the smoke spec matched exact older versions.
+- That prevented the intended mocked admin invite path from running and left the DOM with empty or generic status text.
+
+## Focused Validation
+- Run the targeted smoke spec:
+  - `npx playwright test --config=playwright.smoke.config.js tests/smoke/admin-invite-redemption.spec.js --reporter=line`
+- Run relevant unit coverage if available:
+  - `npx vitest run tests/unit/admin-invite.test.js tests/unit/edit-team-admin-invites.test.js tests/unit/admin-invite-signup-cache-busting.test.js tests/unit/accept-invite-page.test.js`
+
+## Regression Risk
+- Low for production behavior. The test change only makes mocks tolerant of cache-bust version increments.
+- Low for UI text. The source change only improves the fallback display name after successful admin redemption and access validation.

--- a/js/accept-invite-flow.js
+++ b/js/accept-invite-flow.js
@@ -81,7 +81,7 @@ export async function processInviteCode(userId, code, deps, authEmail = null) {
 
         return {
             success: true,
-            message: `You've been added as an admin of ${redeemResult.teamName || 'the team'}!`,
+            message: `You've been added as an admin of ${redeemResult.teamName || team?.name || 'the team'}!`,
             redirectUrl: 'dashboard.html'
         };
     }

--- a/js/organization-schedule.js
+++ b/js/organization-schedule.js
@@ -18,6 +18,8 @@ const ORGANIZATION_SCHEDULE_CSV_HEADER_ALIASES = {
     notes: ['notes', 'comments', 'details']
 };
 
+const DATE_ONLY_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
 function normalizeTeamList(teams) {
     return (Array.isArray(teams) ? teams : [])
         .filter((team) => team && team.id)
@@ -99,6 +101,152 @@ function matchOrganizationTeam(teamName, label, organizationIndex, accessibleInd
 function readMappedValue(row, headerName) {
     if (!headerName) return '';
     return String(row?.[headerName] || '').trim();
+}
+
+function normalizeDateKey(value) {
+    if (!value) return '';
+    if (value instanceof Date && !Number.isNaN(value.getTime())) {
+        return value.toISOString().slice(0, 10);
+    }
+    const text = String(value).trim();
+    if (DATE_ONLY_PATTERN.test(text)) return text;
+    const parsed = new Date(text);
+    return Number.isNaN(parsed.getTime()) ? '' : parsed.toISOString().slice(0, 10);
+}
+
+function parseLocalDateTime(dateKey, timeText) {
+    if (!DATE_ONLY_PATTERN.test(dateKey) || !/^\d{2}:\d{2}$/.test(String(timeText || '').trim())) {
+        return null;
+    }
+    const parsed = new Date(`${dateKey}T${String(timeText).trim()}:00`);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function addMinutes(date, minutes) {
+    return new Date(date.getTime() + (Number(minutes) || 0) * 60000);
+}
+
+function buildTeamPairs(teams = []) {
+    const normalizedTeams = normalizeTeamList(teams);
+    const pairs = [];
+    normalizedTeams.forEach((homeTeam, homeIndex) => {
+        normalizedTeams.slice(homeIndex + 1).forEach((awayTeam) => {
+            pairs.push({ homeTeam, awayTeam });
+        });
+    });
+    return pairs;
+}
+
+function hasDateOverlap(dateKey, blackoutDates = []) {
+    return new Set((Array.isArray(blackoutDates) ? blackoutDates : [])
+        .map(normalizeDateKey)
+        .filter(Boolean))
+        .has(dateKey);
+}
+
+function normalizeAvailabilityWindows(venues = [], seasonStart = '', seasonEnd = '', durationMinutes = 60) {
+    const startKey = normalizeDateKey(seasonStart);
+    const endKey = normalizeDateKey(seasonEnd);
+
+    return (Array.isArray(venues) ? venues : []).flatMap((venue) => {
+        const venueName = String(venue?.name || venue?.venueName || '').trim();
+        const windows = Array.isArray(venue?.availability) ? venue.availability : [];
+
+        return windows.map((window) => {
+            const dateKey = normalizeDateKey(window?.date);
+            const startsAt = parseLocalDateTime(dateKey, window?.startTime);
+            const endsAt = parseLocalDateTime(dateKey, window?.endTime);
+            return {
+                venueName,
+                dateKey,
+                startsAt,
+                endsAt,
+                blackout: hasDateOverlap(dateKey, venue?.blackoutDates),
+                valid: !!venueName && !!startsAt && !!endsAt && addMinutes(startsAt, durationMinutes) <= endsAt
+            };
+        }).filter((window) => {
+            if (!window.dateKey || !window.valid) return false;
+            if (startKey && window.dateKey < startKey) return false;
+            if (endKey && window.dateKey > endKey) return false;
+            return true;
+        });
+    }).sort((left, right) => left.startsAt - right.startsAt || left.venueName.localeCompare(right.venueName));
+}
+
+export function buildOrganizationScheduleDraftSlots({
+    selectedTeams = [],
+    seasonStart = '',
+    seasonEnd = '',
+    venues = [],
+    organizationBlackoutDates = [],
+    durationMinutes = 60
+} = {}) {
+    const teams = normalizeTeamList(selectedTeams);
+    const duration = Math.max(1, Number(durationMinutes) || 60);
+    const pairs = buildTeamPairs(teams);
+    const remainingPairs = [...pairs];
+    const conflicts = [];
+    const teamSlotCounts = new Map(teams.map((team) => [team.id, 0]));
+
+    const windows = normalizeAvailabilityWindows(venues, seasonStart, seasonEnd, duration);
+    const usableWindows = windows.filter((window) => {
+        if (hasDateOverlap(window.dateKey, organizationBlackoutDates)) {
+            conflicts.push({ type: 'organization-blackout', date: window.dateKey, venueName: window.venueName });
+            return false;
+        }
+        if (window.blackout) {
+            conflicts.push({ type: 'venue-blackout', date: window.dateKey, venueName: window.venueName });
+            return false;
+        }
+        return true;
+    });
+
+    const draftSlots = [];
+    usableWindows.forEach((window) => {
+        let cursor = new Date(window.startsAt);
+        while (remainingPairs.length > 0 && addMinutes(cursor, duration) <= window.endsAt) {
+            const pair = remainingPairs.shift();
+            const endsAt = addMinutes(cursor, duration);
+            draftSlots.push({
+                id: `draft-${draftSlots.length + 1}`,
+                homeTeamId: pair.homeTeam.id,
+                homeTeamName: pair.homeTeam.name,
+                awayTeamId: pair.awayTeam.id,
+                awayTeamName: pair.awayTeam.name,
+                venueName: window.venueName,
+                startsAt: cursor.toISOString(),
+                endsAt: endsAt.toISOString(),
+                durationMinutes: duration,
+                notes: ''
+            });
+            teamSlotCounts.set(pair.homeTeam.id, (teamSlotCounts.get(pair.homeTeam.id) || 0) + 1);
+            teamSlotCounts.set(pair.awayTeam.id, (teamSlotCounts.get(pair.awayTeam.id) || 0) + 1);
+            cursor = endsAt;
+        }
+    });
+
+    remainingPairs.forEach((pair) => {
+        conflicts.push({
+            type: 'unscheduled-matchup',
+            homeTeamId: pair.homeTeam.id,
+            awayTeamId: pair.awayTeam.id,
+            message: `${pair.homeTeam.name} vs ${pair.awayTeam.name} could not be placed in saved availability.`
+        });
+    });
+
+    return {
+        draftSlots,
+        conflicts,
+        unassignedTeams: teams.filter((team) => (teamSlotCounts.get(team.id) || 0) === 0),
+        generatedSlotCounts: {
+            total: draftSlots.length,
+            byVenue: draftSlots.reduce((counts, slot) => {
+                counts[slot.venueName] = (counts[slot.venueName] || 0) + 1;
+                return counts;
+            }, {}),
+            byTeam: Object.fromEntries(teamSlotCounts)
+        }
+    };
 }
 
 export function getOrganizationTeams({ accessibleTeams = [], organizationOwnerId = null } = {}) {

--- a/organization-schedule.html
+++ b/organization-schedule.html
@@ -44,6 +44,7 @@
                         <div class="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1 text-sm font-semibold" role="tablist" aria-label="Organization schedule mode">
                             <button id="single-matchup-tab" type="button" class="rounded-md bg-white px-3 py-1.5 text-indigo-700 shadow-sm" aria-selected="true">Single Matchup</button>
                             <button id="bulk-import-tab" type="button" class="rounded-md px-3 py-1.5 text-gray-600 hover:text-gray-900" aria-selected="false">Bulk Import</button>
+                            <button id="draft-generator-tab" type="button" class="rounded-md px-3 py-1.5 text-gray-600 hover:text-gray-900" aria-selected="false">Draft Generator</button>
                         </div>
                     </div>
 
@@ -117,6 +118,50 @@
                             <button id="import-organization-csv-btn" type="button" disabled class="inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 disabled:cursor-not-allowed disabled:bg-gray-300">Import Validated Games</button>
                         </div>
                     </div>
+
+                    <div id="organization-draft-generator-panel" class="hidden mt-6 space-y-5 border-t border-gray-100 pt-6">
+                        <div>
+                            <h3 class="text-lg font-bold text-gray-900">Generate Draft Schedule Slots</h3>
+                            <p class="mt-2 text-sm text-gray-600">Create editable draft slots from selected teams, saved venue availability windows, and blackout dates. Drafts are not published to team schedules.</p>
+                        </div>
+                        <div>
+                            <label for="draft-team-ids" class="block text-sm font-medium text-gray-700">Division / Teams</label>
+                            <select id="draft-team-ids" multiple size="6" class="mt-1 block w-full rounded-md border border-gray-300 p-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500"></select>
+                            <p class="mt-1 text-xs text-gray-500">Select the teams to include in this bounded draft generation pass.</p>
+                        </div>
+                        <div class="grid gap-4 md:grid-cols-3">
+                            <div>
+                                <label for="draft-season-start" class="block text-sm font-medium text-gray-700">Season Start</label>
+                                <input id="draft-season-start" type="date" class="mt-1 block w-full rounded-md border border-gray-300 p-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                            </div>
+                            <div>
+                                <label for="draft-season-end" class="block text-sm font-medium text-gray-700">Season End</label>
+                                <input id="draft-season-end" type="date" class="mt-1 block w-full rounded-md border border-gray-300 p-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                            </div>
+                            <div>
+                                <label for="draft-game-duration" class="block text-sm font-medium text-gray-700">Game Duration</label>
+                                <input id="draft-game-duration" type="number" min="1" value="60" class="mt-1 block w-full rounded-md border border-gray-300 p-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                            </div>
+                        </div>
+                        <div>
+                            <label for="draft-venue-availability" class="block text-sm font-medium text-gray-700">Allowed Venues & Saved Availability</label>
+                            <textarea id="draft-venue-availability" rows="7" class="mt-1 block w-full rounded-md border border-gray-300 p-2 font-mono text-xs shadow-sm focus:border-indigo-500 focus:ring-indigo-500" placeholder='[{"name":"Main Field","availability":[{"date":"2026-08-15","startTime":"09:00","endTime":"12:00"}],"blackoutDates":["2026-08-22"]}]'></textarea>
+                        </div>
+                        <div>
+                            <label for="draft-organization-blackouts" class="block text-sm font-medium text-gray-700">Organization Blackout Dates</label>
+                            <input id="draft-organization-blackouts" type="text" placeholder="2026-08-29, 2026-09-05" class="mt-1 block w-full rounded-md border border-gray-300 p-2 shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        </div>
+                        <div class="flex items-center justify-between gap-3 border-t border-gray-100 pt-4">
+                            <p class="text-xs text-gray-500">Review conflicts, unassigned teams, and slot counts before saving the draft.</p>
+                            <button id="generate-draft-slots-btn" type="button" class="inline-flex items-center justify-center rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700">Generate Draft Slots</button>
+                        </div>
+                        <div id="draft-generator-errors" class="hidden rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800"></div>
+                        <div id="draft-review-summary" class="hidden rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700"></div>
+                        <div id="draft-slot-list" class="space-y-2"></div>
+                        <div class="flex justify-end border-t border-gray-100 pt-4">
+                            <button id="save-draft-slots-btn" type="button" disabled class="inline-flex items-center justify-center rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700 disabled:cursor-not-allowed disabled:bg-gray-300">Save Draft</button>
+                        </div>
+                    </div>
                 </section>
 
                 <aside class="rounded-2xl bg-white p-6 shadow-md">
@@ -148,12 +193,13 @@
         import { Timestamp } from './js/firebase.js?v=11';
         import {
             buildOrganizationScheduleCsvTemplate,
+            buildOrganizationScheduleDraftSlots,
             buildOrganizationScheduleImportPreview,
             buildOrganizationSharedGamePayload,
             getOrganizationTeams,
             inferOrganizationScheduleCsvMapping,
             validateOrganizationMatchup
-        } from './js/organization-schedule.js?v=2';
+        } from './js/organization-schedule.js?v=3';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -162,7 +208,9 @@
         const form = document.getElementById('organization-game-form');
         const singleTab = document.getElementById('single-matchup-tab');
         const bulkTab = document.getElementById('bulk-import-tab');
+        const draftTab = document.getElementById('draft-generator-tab');
         const bulkPanel = document.getElementById('organization-bulk-import-panel');
+        const draftPanel = document.getElementById('organization-draft-generator-panel');
         const csvInput = document.getElementById('organization-schedule-csv-input');
         const csvFileMeta = document.getElementById('organization-csv-file-meta');
         const csvErrors = document.getElementById('organization-csv-errors');
@@ -175,6 +223,11 @@
         const backLink = document.getElementById('back-to-team-schedule');
         const organizationNameEl = document.getElementById('organization-context-name');
         const organizationDetailEl = document.getElementById('organization-context-detail');
+        const draftTeamSelect = document.getElementById('draft-team-ids');
+        const draftErrors = document.getElementById('draft-generator-errors');
+        const draftReviewSummary = document.getElementById('draft-review-summary');
+        const draftSlotList = document.getElementById('draft-slot-list');
+        const saveDraftButton = document.getElementById('save-draft-slots-btn');
         const ORGANIZATION_CSV_IMPORT_ROW_LIMIT = 500;
 
         let currentUser = null;
@@ -182,27 +235,36 @@
         let organizationTeams = [];
         let accessibleTeams = [];
         let organizationCsvState = { fileName: '', preview: null };
+        let draftGeneratorState = { draftSlots: [], conflicts: [], unassignedTeams: [], generatedSlotCounts: null };
 
 
         function showScheduleMode(mode) {
             const isBulk = mode === 'bulk';
-            form.classList.toggle('hidden', isBulk);
+            const isDraft = mode === 'draft';
+            form.classList.toggle('hidden', isDraft || isBulk);
             bulkPanel.classList.toggle('hidden', !isBulk);
-            singleTab.className = isBulk
+            draftPanel.classList.toggle('hidden', !isDraft);
+            singleTab.className = isDraft || isBulk
                 ? 'rounded-md px-3 py-1.5 text-gray-600 hover:text-gray-900'
                 : 'rounded-md bg-white px-3 py-1.5 text-indigo-700 shadow-sm';
             bulkTab.className = isBulk
                 ? 'rounded-md bg-white px-3 py-1.5 text-indigo-700 shadow-sm'
                 : 'rounded-md px-3 py-1.5 text-gray-600 hover:text-gray-900';
-            singleTab.setAttribute('aria-selected', String(!isBulk));
+            draftTab.className = isDraft
+                ? 'rounded-md bg-white px-3 py-1.5 text-indigo-700 shadow-sm'
+                : 'rounded-md px-3 py-1.5 text-gray-600 hover:text-gray-900';
+            singleTab.setAttribute('aria-selected', String(!isBulk && !isDraft));
             bulkTab.setAttribute('aria-selected', String(isBulk));
+            draftTab.setAttribute('aria-selected', String(isDraft));
         }
 
         function disableScheduleInputs() {
             form.classList.add('hidden');
             bulkPanel.classList.add('hidden');
+            draftPanel.classList.add('hidden');
             singleTab.disabled = true;
             bulkTab.disabled = true;
+            draftTab.disabled = true;
         }
 
         function downloadCsvFile(filename, text) {
@@ -297,6 +359,109 @@
             csvPreviewList.replaceChildren();
             showOrganizationCsvErrors([]);
             importCsvButton.disabled = true;
+        }
+
+        function showDraftGeneratorErrors(errors = []) {
+            if (!errors.length) {
+                draftErrors.className = 'hidden rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800';
+                draftErrors.replaceChildren();
+                return;
+            }
+            draftErrors.className = 'rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-800';
+            const list = document.createElement('ul');
+            list.className = 'list-disc space-y-1 pl-5';
+            errors.forEach((error) => {
+                const item = document.createElement('li');
+                item.textContent = error;
+                list.appendChild(item);
+            });
+            draftErrors.replaceChildren(list);
+        }
+
+        function parseDraftVenues() {
+            const text = document.getElementById('draft-venue-availability').value.trim();
+            if (!text) return [];
+            const parsed = JSON.parse(text);
+            return Array.isArray(parsed) ? parsed : [];
+        }
+
+        function getSelectedDraftTeams() {
+            const selectedIds = Array.from(draftTeamSelect.selectedOptions).map((option) => option.value);
+            return organizationTeams.filter((team) => selectedIds.includes(team.id));
+        }
+
+        function getDraftOrganizationBlackouts() {
+            return document.getElementById('draft-organization-blackouts').value
+                .split(',')
+                .map((value) => value.trim())
+                .filter(Boolean);
+        }
+
+        function resetDraftGeneratorState() {
+            draftGeneratorState = { draftSlots: [], conflicts: [], unassignedTeams: [], generatedSlotCounts: null };
+            draftReviewSummary.className = 'hidden rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700';
+            draftReviewSummary.textContent = '';
+            draftSlotList.replaceChildren();
+            showDraftGeneratorErrors([]);
+            saveDraftButton.disabled = true;
+        }
+
+        function renderDraftReview() {
+            draftSlotList.replaceChildren();
+            const { draftSlots, conflicts, unassignedTeams, generatedSlotCounts } = draftGeneratorState;
+            draftReviewSummary.className = 'rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-sm text-gray-700';
+            const venueCounts = Object.entries(generatedSlotCounts?.byVenue || {})
+                .map(([venue, count]) => `${venue}: ${count}`)
+                .join(', ') || 'No venues';
+            draftReviewSummary.textContent = `${draftSlots.length} generated slot(s). ${conflicts.length} conflict(s). ${unassignedTeams.length} unassigned team(s). Counts by venue: ${venueCounts}.`;
+
+            if (conflicts.length || unassignedTeams.length) {
+                showDraftGeneratorErrors([
+                    ...conflicts.map((conflict) => conflict.message || `${conflict.type} on ${conflict.date || 'unscheduled date'}${conflict.venueName ? ` at ${conflict.venueName}` : ''}.`),
+                    ...unassignedTeams.map((team) => `${team.name} has no generated draft slot.`)
+                ]);
+            } else {
+                showDraftGeneratorErrors([]);
+            }
+
+            draftSlots.forEach((slot, index) => {
+                const card = document.createElement('div');
+                card.className = 'rounded-lg border border-gray-200 bg-white p-3 text-sm';
+
+                const grid = document.createElement('div');
+                grid.className = 'grid gap-2 md:grid-cols-[1fr_1fr_1fr_auto]';
+
+                const matchup = document.createElement('input');
+                matchup.value = `${slot.homeTeamName} vs ${slot.awayTeamName}`;
+                matchup.className = 'rounded-md border border-gray-300 p-2';
+                matchup.addEventListener('input', () => { slot.notes = matchup.value; });
+
+                const start = document.createElement('input');
+                start.type = 'datetime-local';
+                start.value = slot.startsAt.slice(0, 16);
+                start.className = 'rounded-md border border-gray-300 p-2';
+                start.addEventListener('change', () => { slot.startsAt = new Date(start.value).toISOString(); });
+
+                const venue = document.createElement('input');
+                venue.value = slot.venueName;
+                venue.className = 'rounded-md border border-gray-300 p-2';
+                venue.addEventListener('input', () => { slot.venueName = venue.value.trim(); });
+
+                const removeButton = document.createElement('button');
+                removeButton.type = 'button';
+                removeButton.className = 'rounded-md border border-red-200 bg-red-50 px-3 py-2 font-semibold text-red-700 hover:bg-red-100';
+                removeButton.textContent = 'Remove';
+                removeButton.addEventListener('click', () => {
+                    draftGeneratorState.draftSlots.splice(index, 1);
+                    renderDraftReview();
+                });
+
+                grid.append(matchup, start, venue, removeButton);
+                card.appendChild(grid);
+                draftSlotList.appendChild(card);
+            });
+
+            saveDraftButton.disabled = draftSlots.length === 0;
         }
 
         function setAlert(message, variant = 'error') {
@@ -398,13 +563,60 @@
 
             renderTeamOptions(homeTeamSelect, organizationTeams, anchorTeam.id);
             renderTeamOptions(awayTeamSelect, organizationTeams, organizationTeams.find((team) => team.id !== anchorTeam.id)?.id || organizationTeams[0]?.id);
+            renderTeamOptions(draftTeamSelect, organizationTeams, anchorTeam.id);
+            Array.from(draftTeamSelect.options).forEach((option) => { option.selected = true; });
             resetOrganizationCsvState();
+            resetDraftGeneratorState();
         }
 
 
 
         singleTab.addEventListener('click', () => showScheduleMode('single'));
         bulkTab.addEventListener('click', () => showScheduleMode('bulk'));
+        draftTab.addEventListener('click', () => showScheduleMode('draft'));
+
+        document.getElementById('generate-draft-slots-btn').addEventListener('click', () => {
+            try {
+                const selectedTeams = getSelectedDraftTeams();
+                if (selectedTeams.length < 2) {
+                    showDraftGeneratorErrors(['Select at least two teams for draft generation.']);
+                    return;
+                }
+                const venues = parseDraftVenues();
+                if (venues.length === 0) {
+                    showDraftGeneratorErrors(['Add at least one allowed venue with saved availability windows.']);
+                    return;
+                }
+
+                draftGeneratorState = buildOrganizationScheduleDraftSlots({
+                    selectedTeams,
+                    seasonStart: document.getElementById('draft-season-start').value,
+                    seasonEnd: document.getElementById('draft-season-end').value,
+                    venues,
+                    organizationBlackoutDates: getDraftOrganizationBlackouts(),
+                    durationMinutes: document.getElementById('draft-game-duration').value
+                });
+                renderDraftReview();
+            } catch (error) {
+                console.error('Draft generation failed:', error);
+                showDraftGeneratorErrors(['Could not generate draft slots. Check that venue availability is valid JSON.']);
+            }
+        });
+
+        saveDraftButton.addEventListener('click', () => {
+            const draft = {
+                savedAt: new Date().toISOString(),
+                savedBy: currentUser?.uid || null,
+                anchorTeamId: anchorTeam?.id || null,
+                slots: draftGeneratorState.draftSlots,
+                conflicts: draftGeneratorState.conflicts,
+                unassignedTeams: draftGeneratorState.unassignedTeams,
+                generatedSlotCounts: draftGeneratorState.generatedSlotCounts
+            };
+            localStorage.setItem(`organizationScheduleDraft:${anchorTeam?.id || 'unknown'}`, JSON.stringify(draft));
+            successAlert.className = 'rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-4 text-sm text-emerald-800';
+            successAlert.textContent = `Saved ${draft.slots.length} draft schedule slot${draft.slots.length === 1 ? '' : 's'} for review. Nothing was published to team schedules.`;
+        });
 
         document.getElementById('download-organization-schedule-template').addEventListener('click', () => {
             downloadCsvFile('allplays-organization-schedule-template.csv', buildOrganizationScheduleCsvTemplate());

--- a/tests/smoke/admin-invite-redemption.spec.js
+++ b/tests/smoke/admin-invite-redemption.spec.js
@@ -258,16 +258,16 @@ async function mockEditTeamDependencies(page) {
     await mockExternalResources(page);
     await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: EDIT_TEAM_DB_STUB }));
     await page.route('**/js/utils.js?v=8', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: EDIT_TEAM_UTILS_STUB }));
-    await page.route('**/js/auth.js?v=14', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: EDIT_TEAM_AUTH_STUB }));
+    await page.route(/\/js\/auth\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: EDIT_TEAM_AUTH_STUB }));
     await page.route('**/js/team-admin-banner.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ADMIN_BANNER_STUB }));
     await page.route('**/js/live-stream-utils.js?v=1', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: LIVE_STREAM_UTILS_STUB }));
-    await page.route('**/js/team-access.js?v=2', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ACCESS_STUB }));
+    await page.route(/\/js\/team-access\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ACCESS_STUB }));
 }
 
 async function mockAcceptInviteDependencies(page) {
     await mockExternalResources(page);
     await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: ACCEPT_INVITE_DB_STUB }));
-    await page.route('**/js/auth.js?v=14', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: ACCEPT_INVITE_AUTH_STUB }));
+    await page.route(/\/js\/auth\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: ACCEPT_INVITE_AUTH_STUB }));
     await page.route('**/js/utils.js?v=8', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: SHARED_UTILS_STUB }));
 }
 

--- a/tests/unit/organization-schedule.test.js
+++ b/tests/unit/organization-schedule.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import {
     buildOrganizationScheduleCsvTemplate,
+    buildOrganizationScheduleDraftSlots,
     buildOrganizationScheduleImportPreview,
     buildOrganizationSharedGamePayload,
     getOrganizationTeams,
@@ -122,6 +123,67 @@ describe('organization schedule helpers', () => {
         });
     });
 
+    it('generates editable draft slots only inside availability and blackout rules', () => {
+        const draft = buildOrganizationScheduleDraftSlots({
+            selectedTeams: accessibleTeams.slice(0, 2),
+            seasonStart: '2026-08-01',
+            seasonEnd: '2026-08-31',
+            durationMinutes: 60,
+            organizationBlackoutDates: ['2026-08-16'],
+            venues: [
+                {
+                    name: 'Main Field',
+                    availability: [
+                        { date: '2026-08-15', startTime: '09:00', endTime: '11:00' },
+                        { date: '2026-08-16', startTime: '09:00', endTime: '11:00' },
+                        { date: '2026-08-22', startTime: '09:00', endTime: '11:00' }
+                    ],
+                    blackoutDates: ['2026-08-22']
+                }
+            ]
+        });
+
+        expect(draft.draftSlots).toHaveLength(1);
+        expect(draft.draftSlots[0]).toMatchObject({
+            homeTeamId: 'team-1',
+            awayTeamId: 'team-2',
+            venueName: 'Main Field',
+            durationMinutes: 60
+        });
+        expect(draft.draftSlots[0].startsAt).toBe(new Date('2026-08-15T09:00:00').toISOString());
+        expect(draft.conflicts).toEqual(expect.arrayContaining([
+            expect.objectContaining({ type: 'organization-blackout', date: '2026-08-16' }),
+            expect.objectContaining({ type: 'venue-blackout', date: '2026-08-22' })
+        ]));
+        expect(draft.unassignedTeams).toHaveLength(0);
+        expect(draft.generatedSlotCounts).toMatchObject({
+            total: 1,
+            byVenue: { 'Main Field': 1 },
+            byTeam: { 'team-1': 1, 'team-2': 1 }
+        });
+    });
+
+    it('reports unassigned teams and unscheduled conflicts when slots run out', () => {
+        const draft = buildOrganizationScheduleDraftSlots({
+            selectedTeams: accessibleTeams,
+            seasonStart: '2026-08-01',
+            seasonEnd: '2026-08-31',
+            durationMinutes: 60,
+            venues: [{
+                name: 'Main Field',
+                availability: [{ date: '2026-08-15', startTime: '09:00', endTime: '10:00' }],
+                blackoutDates: []
+            }]
+        });
+
+        expect(draft.draftSlots).toHaveLength(1);
+        expect(draft.unassignedTeams).toEqual([accessibleTeams[2]]);
+        expect(draft.conflicts).toEqual(expect.arrayContaining([
+            expect.objectContaining({ type: 'unscheduled-matchup', homeTeamId: 'team-1', awayTeamId: 'team-3' }),
+            expect.objectContaining({ type: 'unscheduled-matchup', homeTeamId: 'team-2', awayTeamId: 'team-3' })
+        ]));
+    });
+
     it('exposes the organization schedule entry point from team schedule', () => {
         const source = readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
 
@@ -146,6 +208,19 @@ describe('organization schedule helpers', () => {
         expect(source).toContain('id="organization-schedule-csv-input"');
         expect(source).toContain('buildOrganizationScheduleImportPreview');
         expect(source).toContain('createdVia: \'organizationScheduleCsvImport\'');
+    });
+
+    it('wires the organization draft generator review and save workflow', () => {
+        const source = readFileSync(new URL('../../organization-schedule.html', import.meta.url), 'utf8');
+
+        expect(source).toContain('id="draft-generator-tab"');
+        expect(source).toContain('id="draft-team-ids"');
+        expect(source).toContain('id="draft-venue-availability"');
+        expect(source).toContain('id="draft-organization-blackouts"');
+        expect(source).toContain('buildOrganizationScheduleDraftSlots');
+        expect(source).toContain('renderDraftReview');
+        expect(source).toContain('draftGeneratorState.draftSlots.splice(index, 1);');
+        expect(source).toContain('localStorage.setItem(`organizationScheduleDraft:${anchorTeam?.id || \'unknown\'}`');
     });
 
     it('caps organization schedule CSV imports before preview and import', () => {


### PR DESCRIPTION
Closes #971

## Summary
- Added a draft generator tab to organization scheduling for selecting teams, season dates, allowed venue availability, blackouts, and game duration.
- Generated draft slots stay within availability windows, skip organization and venue blackout dates, and show conflicts, unassigned teams, and slot counts before saving.
- Added manual draft slot edit/remove controls and local draft saving without publishing to team schedules.

## Tests
- `npx vitest run tests/unit/organization-schedule.test.js`