### PR TITLE
Add venue availability controls

### DIFF
--- a/docs/pr-notes/runs/973-remediator-20260511T231131Z/architecture.md
+++ b/docs/pr-notes/runs/973-remediator-20260511T231131Z/architecture.md
@@ -1,0 +1,10 @@
+# Architecture Decisions
+
+- Enforce field allowlists at the database boundary in `js/db.js`, closest to Firestore writes, so callers cannot inject arbitrary document fields.
+- Preserve server-controlled fields by setting `scope`, `createdAt`, and `updatedAt` after selecting allowed user fields.
+- Guard venue-control form submission in `organization-schedule.html` using current access state before building and writing payloads.
+- Disable venue-control inputs when general schedule initialization is blocked to keep UI state consistent with authorization state.
+
+## Risks And Rollback
+- Risk: omitted legitimate fields could hide intended data. Mitigation: allowlist includes the fields emitted by existing payload builders.
+- Rollback: revert this remediation commit if schedule control writes regress.

--- a/docs/pr-notes/runs/973-remediator-20260511T231131Z/code-plan.md
+++ b/docs/pr-notes/runs/973-remediator-20260511T231131Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code Plan
+
+1. In `js/db.js`, replace user-data spreads with local `allowedFields` objects for venue availability, organization blackouts, and venue blackouts.
+2. In `organization-schedule.html`, add a helper that confirms `anchorTeam`, full access, and enough organization teams before venue-control writes.
+3. Extend `disableScheduleInputs()` to disable venue-control forms and refresh control when init is blocked.
+4. Run a minimal syntax check with `node --check` for changed JavaScript-bearing files, then commit.

--- a/docs/pr-notes/runs/973-remediator-20260511T231131Z/qa.md
+++ b/docs/pr-notes/runs/973-remediator-20260511T231131Z/qa.md
@@ -1,0 +1,7 @@
+# QA Plan
+
+- Static inspection: verify `createVenueAvailability`, `createOrganizationBlackout`, and `createVenueBlackout` no longer spread caller-provided objects into Firestore writes.
+- Static inspection: verify venue-control submit handlers check access state before calling create functions.
+- Manual browser plan if exercised: open `organization-schedule.html#teamId=<team>` as full-access user and confirm saving availability and blackouts still works; open with missing/unauthorized/single-team state and confirm controls are inactive and no write is attempted.
+
+No automated test runner is defined for this static site.

--- a/docs/pr-notes/runs/973-remediator-20260511T231131Z/requirements.md
+++ b/docs/pr-notes/runs/973-remediator-20260511T231131Z/requirements.md
@@ -1,0 +1,11 @@
+# Requirements
+
+## Acceptance Criteria
+- Venue availability creation writes only expected scheduling-control fields plus server-managed timestamps.
+- Organization blackout creation writes only expected blackout fields plus fixed `scope: 'organization'` and timestamps.
+- Venue blackout creation writes only expected blackout fields plus fixed `scope: 'venue'` and timestamps.
+- Venue availability and blackout submit handlers do not write when schedule initialization is blocked due to missing team, insufficient access, or an organization grouping with fewer than two teams.
+
+## Assumptions
+- Existing payload builder validation remains the source of field-level value validation.
+- This remediation is scoped to review feedback only, with no broader schedule-control redesign.

--- a/firestore.rules
+++ b/firestore.rules
@@ -971,6 +971,18 @@ service cloud.firestore {
         allow read, create, update, delete: if isTeamOwnerOrAdmin(teamId);
       }
 
+      match /venueAvailability/{availabilityId} {
+        allow read, create, update, delete: if isTeamOwnerOrAdmin(teamId);
+      }
+
+      match /organizationBlackouts/{blackoutId} {
+        allow read, create, update, delete: if isTeamOwnerOrAdmin(teamId);
+      }
+
+      match /venueBlackouts/{blackoutId} {
+        allow read, create, update, delete: if isTeamOwnerOrAdmin(teamId);
+      }
+
       match /entitlements/{entitlementId} {
         // Public fan pages may read safe team-pass state, but raw billing/provider
         // metadata stays limited to team admins.

--- a/js/db.js
+++ b/js/db.js
@@ -893,20 +893,33 @@ export async function listOrganizationScheduleControls(teamId) {
     };
 }
 
-export async function createVenueAvailability(teamId, availabilityData) {
+export async function createVenueAvailability(teamId, availabilityData = {}) {
     if (!teamId) throw new Error('Missing team for venue availability');
+    const allowedFields = {
+        venueName: availabilityData.venueName,
+        subVenueName: availabilityData.subVenueName,
+        dayOfWeek: availabilityData.dayOfWeek,
+        startTime: availabilityData.startTime,
+        endTime: availabilityData.endTime,
+        notes: availabilityData.notes
+    };
     const docRef = await addDoc(collection(db, `teams/${teamId}/venueAvailability`), {
-        ...availabilityData,
+        ...allowedFields,
         createdAt: Timestamp.now(),
         updatedAt: Timestamp.now()
     });
     return docRef.id;
 }
 
-export async function createOrganizationBlackout(teamId, blackoutData) {
+export async function createOrganizationBlackout(teamId, blackoutData = {}) {
     if (!teamId) throw new Error('Missing team for organization blackout');
+    const allowedFields = {
+        startDate: blackoutData.startDate,
+        endDate: blackoutData.endDate,
+        reason: blackoutData.reason
+    };
     const docRef = await addDoc(collection(db, `teams/${teamId}/organizationBlackouts`), {
-        ...blackoutData,
+        ...allowedFields,
         scope: 'organization',
         createdAt: Timestamp.now(),
         updatedAt: Timestamp.now()
@@ -914,10 +927,17 @@ export async function createOrganizationBlackout(teamId, blackoutData) {
     return docRef.id;
 }
 
-export async function createVenueBlackout(teamId, blackoutData) {
+export async function createVenueBlackout(teamId, blackoutData = {}) {
     if (!teamId) throw new Error('Missing team for venue blackout');
+    const allowedFields = {
+        venueName: blackoutData.venueName,
+        subVenueName: blackoutData.subVenueName,
+        startDate: blackoutData.startDate,
+        endDate: blackoutData.endDate,
+        reason: blackoutData.reason
+    };
     const docRef = await addDoc(collection(db, `teams/${teamId}/venueBlackouts`), {
-        ...blackoutData,
+        ...allowedFields,
         scope: 'venue',
         createdAt: Timestamp.now(),
         updatedAt: Timestamp.now()

--- a/js/db.js
+++ b/js/db.js
@@ -863,6 +863,68 @@ export async function saveTeamAvailabilityPreferences(teamId, preferences) {
     return normalized;
 }
 
+function mapSnapshotWithIds(snapshot) {
+    return snapshot.docs.map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }));
+}
+
+function sortByFields(records, fields) {
+    return [...records].sort((a, b) => {
+        for (const field of fields) {
+            const comparison = String(a?.[field] || '').localeCompare(String(b?.[field] || ''));
+            if (comparison !== 0) return comparison;
+        }
+        return 0;
+    });
+}
+
+export async function listOrganizationScheduleControls(teamId) {
+    if (!teamId) throw new Error('Missing team for organization schedule controls');
+
+    const [availabilitySnapshot, organizationBlackoutsSnapshot, venueBlackoutsSnapshot] = await Promise.all([
+        getDocs(collection(db, `teams/${teamId}/venueAvailability`)),
+        getDocs(collection(db, `teams/${teamId}/organizationBlackouts`)),
+        getDocs(collection(db, `teams/${teamId}/venueBlackouts`))
+    ]);
+
+    return {
+        availability: sortByFields(mapSnapshotWithIds(availabilitySnapshot), ['dayOfWeek', 'startTime', 'venueName']),
+        organizationBlackouts: sortByFields(mapSnapshotWithIds(organizationBlackoutsSnapshot), ['startDate', 'endDate']),
+        venueBlackouts: sortByFields(mapSnapshotWithIds(venueBlackoutsSnapshot), ['startDate', 'endDate', 'venueName'])
+    };
+}
+
+export async function createVenueAvailability(teamId, availabilityData) {
+    if (!teamId) throw new Error('Missing team for venue availability');
+    const docRef = await addDoc(collection(db, `teams/${teamId}/venueAvailability`), {
+        ...availabilityData,
+        createdAt: Timestamp.now(),
+        updatedAt: Timestamp.now()
+    });
+    return docRef.id;
+}
+
+export async function createOrganizationBlackout(teamId, blackoutData) {
+    if (!teamId) throw new Error('Missing team for organization blackout');
+    const docRef = await addDoc(collection(db, `teams/${teamId}/organizationBlackouts`), {
+        ...blackoutData,
+        scope: 'organization',
+        createdAt: Timestamp.now(),
+        updatedAt: Timestamp.now()
+    });
+    return docRef.id;
+}
+
+export async function createVenueBlackout(teamId, blackoutData) {
+    if (!teamId) throw new Error('Missing team for venue blackout');
+    const docRef = await addDoc(collection(db, `teams/${teamId}/venueBlackouts`), {
+        ...blackoutData,
+        scope: 'venue',
+        createdAt: Timestamp.now(),
+        updatedAt: Timestamp.now()
+    });
+    return docRef.id;
+}
+
 export async function grantScorekeeperAccess(teamId, memberUserId) {
     const normalizedUserId = String(memberUserId || '').trim();
     if (!teamId) throw new Error('Missing team for scorekeeper access');

--- a/js/organization-schedule.js
+++ b/js/organization-schedule.js
@@ -18,6 +18,125 @@ const ORGANIZATION_SCHEDULE_CSV_HEADER_ALIASES = {
     notes: ['notes', 'comments', 'details']
 };
 
+export const ORGANIZATION_SCHEDULE_WEEKDAYS = [
+    { value: 'monday', label: 'Monday' },
+    { value: 'tuesday', label: 'Tuesday' },
+    { value: 'wednesday', label: 'Wednesday' },
+    { value: 'thursday', label: 'Thursday' },
+    { value: 'friday', label: 'Friday' },
+    { value: 'saturday', label: 'Saturday' },
+    { value: 'sunday', label: 'Sunday' }
+];
+
+const ORGANIZATION_SCHEDULE_WEEKDAY_VALUES = new Set(ORGANIZATION_SCHEDULE_WEEKDAYS.map((day) => day.value));
+const TIME_VALUE_PATTERN = /^\d{2}:\d{2}$/;
+const DATE_VALUE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+
+function normalizeTextValue(value) {
+    return String(value || '').trim();
+}
+
+function normalizeDateValue(value) {
+    return normalizeTextValue(value);
+}
+
+function isValidTimeValue(value) {
+    return TIME_VALUE_PATTERN.test(String(value || ''));
+}
+
+function isValidDateValue(value) {
+    return DATE_VALUE_PATTERN.test(String(value || ''));
+}
+
+function compareTimeValues(startTime, endTime) {
+    return String(startTime || '').localeCompare(String(endTime || ''));
+}
+
+export function getOrganizationScheduleWeekdayLabel(value) {
+    return ORGANIZATION_SCHEDULE_WEEKDAYS.find((day) => day.value === value)?.label || String(value || '');
+}
+
+export function buildVenueAvailabilityPayload({
+    venueName = '',
+    subVenueName = '',
+    dayOfWeek = '',
+    startTime = '',
+    endTime = '',
+    notes = ''
+} = {}) {
+    const payload = {
+        venueName: normalizeTextValue(venueName),
+        subVenueName: normalizeTextValue(subVenueName) || null,
+        dayOfWeek: normalizeTextValue(dayOfWeek).toLowerCase(),
+        startTime: normalizeTextValue(startTime),
+        endTime: normalizeTextValue(endTime),
+        notes: normalizeTextValue(notes) || null
+    };
+
+    if (!payload.venueName) {
+        throw new Error('Venue or sub-venue name is required.');
+    }
+    if (!ORGANIZATION_SCHEDULE_WEEKDAY_VALUES.has(payload.dayOfWeek)) {
+        throw new Error('Choose an available day.');
+    }
+    if (!isValidTimeValue(payload.startTime) || !isValidTimeValue(payload.endTime)) {
+        throw new Error('Enter a start and end time for the availability window.');
+    }
+    if (compareTimeValues(payload.startTime, payload.endTime) >= 0) {
+        throw new Error('Availability end time must be after the start time.');
+    }
+
+    return payload;
+}
+
+export function buildBlackoutDatePayload({
+    scope = 'organization',
+    venueName = '',
+    subVenueName = '',
+    startDate = '',
+    endDate = '',
+    reason = ''
+} = {}) {
+    const normalizedScope = normalizeTextValue(scope) === 'venue' ? 'venue' : 'organization';
+    const payload = {
+        scope: normalizedScope,
+        venueName: normalizeTextValue(venueName) || null,
+        subVenueName: normalizeTextValue(subVenueName) || null,
+        startDate: normalizeDateValue(startDate),
+        endDate: normalizeDateValue(endDate),
+        reason: normalizeTextValue(reason) || null
+    };
+
+    if (payload.scope === 'venue' && !payload.venueName) {
+        throw new Error('Venue or sub-venue name is required for venue-specific blackouts.');
+    }
+    if (!isValidDateValue(payload.startDate) || !isValidDateValue(payload.endDate)) {
+        throw new Error('Enter a start and end date for the blackout.');
+    }
+    if (payload.endDate < payload.startDate) {
+        throw new Error('Blackout end date cannot be before the start date.');
+    }
+
+    return payload;
+}
+
+export function formatVenueAvailabilityRecord(record = {}) {
+    const venue = [record.venueName, record.subVenueName].filter(Boolean).join(' / ');
+    const day = getOrganizationScheduleWeekdayLabel(record.dayOfWeek);
+    const window = [record.startTime, record.endTime].filter(Boolean).join('–');
+    return [venue || 'Venue', day, window].filter(Boolean).join(' · ');
+}
+
+export function formatBlackoutDateRecord(record = {}) {
+    const scope = record.scope === 'venue'
+        ? [record.venueName, record.subVenueName].filter(Boolean).join(' / ') || 'Venue blackout'
+        : 'Organization-wide blackout';
+    const range = record.startDate === record.endDate
+        ? record.startDate
+        : `${record.startDate || 'Start'} through ${record.endDate || 'End'}`;
+    return `${scope} · ${range}`;
+}
+
 function normalizeTeamList(teams) {
     return (Array.isArray(teams) ? teams : [])
         .filter((team) => team && team.id)

--- a/organization-schedule.html
+++ b/organization-schedule.html
@@ -275,6 +275,7 @@
         const venueControlsList = document.getElementById('venue-controls-list');
         const saveAvailabilityButton = document.getElementById('save-venue-availability-btn');
         const saveBlackoutButton = document.getElementById('save-blackout-date-btn');
+        const refreshVenueControlsButton = document.getElementById('refresh-venue-controls-btn');
 
         function setButtonBusy(button, busyText, busy) {
             if (!button) return;
@@ -363,6 +364,19 @@
             bulkPanel.classList.add('hidden');
             singleTab.disabled = true;
             bulkTab.disabled = true;
+            refreshVenueControlsButton.disabled = true;
+            availabilityForm.querySelectorAll('input, select, button').forEach((control) => {
+                control.disabled = true;
+            });
+            blackoutForm.querySelectorAll('input, select, button').forEach((control) => {
+                control.disabled = true;
+            });
+        }
+
+        function canManageVenueControls() {
+            if (!currentUser || !anchorTeam?.id || organizationTeams.length < 2) return false;
+            const accessInfo = getTeamAccessInfo(currentUser, anchorTeam);
+            return accessInfo.hasAccess && accessInfo.accessLevel === 'full';
         }
 
         function downloadCsvFile(filename, text) {
@@ -570,11 +584,15 @@
 
 
 
-        document.getElementById('refresh-venue-controls-btn').addEventListener('click', refreshVenueControls);
+        refreshVenueControlsButton.addEventListener('click', refreshVenueControls);
 
         availabilityForm.addEventListener('submit', async (event) => {
             event.preventDefault();
             setAlert('');
+            if (!canManageVenueControls()) {
+                setAlert('Venue scheduling controls are not available for this team.');
+                return;
+            }
             try {
                 setButtonBusy(saveAvailabilityButton, 'Saving…', true);
                 const payload = buildVenueAvailabilityPayload({
@@ -598,6 +616,10 @@
         blackoutForm.addEventListener('submit', async (event) => {
             event.preventDefault();
             setAlert('');
+            if (!canManageVenueControls()) {
+                setAlert('Venue scheduling controls are not available for this team.');
+                return;
+            }
             try {
                 setButtonBusy(saveBlackoutButton, 'Saving…', true);
                 const payload = buildBlackoutDatePayload({

--- a/organization-schedule.html
+++ b/organization-schedule.html
@@ -34,6 +34,88 @@
             <div id="organization-access-alert" class="hidden rounded-xl border px-4 py-3 text-sm"></div>
             <div id="organization-success" class="hidden rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-4 text-sm text-emerald-800"></div>
 
+            <section class="rounded-2xl bg-white p-6 shadow-md">
+                <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                    <div>
+                        <h2 class="text-xl font-bold text-gray-900">Venue availability and blackouts</h2>
+                        <p class="mt-2 text-sm text-gray-600">Define usable venue windows and blackout dates before building generated schedules.</p>
+                    </div>
+                    <button id="refresh-venue-controls-btn" type="button" class="rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50">Refresh</button>
+                </div>
+
+                <div class="mt-5 grid gap-5 lg:grid-cols-2">
+                    <form id="venue-availability-form" class="space-y-3 rounded-xl border border-gray-200 bg-gray-50 p-4">
+                        <h3 class="font-semibold text-gray-900">Add available window</h3>
+                        <div>
+                            <label for="availability-venue-name" class="block text-sm font-medium text-gray-700">Venue</label>
+                            <input id="availability-venue-name" type="text" required placeholder="Main Field" class="mt-1 block w-full rounded-md border border-gray-300 p-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        </div>
+                        <div>
+                            <label for="availability-sub-venue-name" class="block text-sm font-medium text-gray-700">Sub-venue <span class="font-normal text-gray-500">optional</span></label>
+                            <input id="availability-sub-venue-name" type="text" placeholder="Court 1" class="mt-1 block w-full rounded-md border border-gray-300 p-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        </div>
+                        <div class="grid gap-3 sm:grid-cols-3">
+                            <div>
+                                <label for="availability-day" class="block text-sm font-medium text-gray-700">Day</label>
+                                <select id="availability-day" required class="mt-1 block w-full rounded-md border border-gray-300 p-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500"></select>
+                            </div>
+                            <div>
+                                <label for="availability-start-time" class="block text-sm font-medium text-gray-700">Start</label>
+                                <input id="availability-start-time" type="time" required class="mt-1 block w-full rounded-md border border-gray-300 p-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                            </div>
+                            <div>
+                                <label for="availability-end-time" class="block text-sm font-medium text-gray-700">End</label>
+                                <input id="availability-end-time" type="time" required class="mt-1 block w-full rounded-md border border-gray-300 p-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                            </div>
+                        </div>
+                        <div>
+                            <label for="availability-notes" class="block text-sm font-medium text-gray-700">Notes <span class="font-normal text-gray-500">optional</span></label>
+                            <input id="availability-notes" type="text" placeholder="Lights available after 6 PM" class="mt-1 block w-full rounded-md border border-gray-300 p-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        </div>
+                        <button id="save-venue-availability-btn" type="submit" class="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700">Add availability</button>
+                    </form>
+
+                    <form id="blackout-date-form" class="space-y-3 rounded-xl border border-gray-200 bg-gray-50 p-4">
+                        <h3 class="font-semibold text-gray-900">Add blackout date</h3>
+                        <div>
+                            <label for="blackout-scope" class="block text-sm font-medium text-gray-700">Blackout scope</label>
+                            <select id="blackout-scope" class="mt-1 block w-full rounded-md border border-gray-300 p-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                                <option value="organization">Organization-wide</option>
+                                <option value="venue">Venue-specific</option>
+                            </select>
+                        </div>
+                        <div>
+                            <label for="blackout-venue-name" class="block text-sm font-medium text-gray-700">Venue <span class="font-normal text-gray-500">required for venue-specific</span></label>
+                            <input id="blackout-venue-name" type="text" placeholder="Main Field" class="mt-1 block w-full rounded-md border border-gray-300 p-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        </div>
+                        <div>
+                            <label for="blackout-sub-venue-name" class="block text-sm font-medium text-gray-700">Sub-venue <span class="font-normal text-gray-500">optional</span></label>
+                            <input id="blackout-sub-venue-name" type="text" placeholder="Court 1" class="mt-1 block w-full rounded-md border border-gray-300 p-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        </div>
+                        <div class="grid gap-3 sm:grid-cols-2">
+                            <div>
+                                <label for="blackout-start-date" class="block text-sm font-medium text-gray-700">Start date</label>
+                                <input id="blackout-start-date" type="date" required class="mt-1 block w-full rounded-md border border-gray-300 p-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                            </div>
+                            <div>
+                                <label for="blackout-end-date" class="block text-sm font-medium text-gray-700">End date</label>
+                                <input id="blackout-end-date" type="date" required class="mt-1 block w-full rounded-md border border-gray-300 p-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                            </div>
+                        </div>
+                        <div>
+                            <label for="blackout-reason" class="block text-sm font-medium text-gray-700">Reason <span class="font-normal text-gray-500">optional</span></label>
+                            <input id="blackout-reason" type="text" placeholder="Tournament, maintenance, holiday" class="mt-1 block w-full rounded-md border border-gray-300 p-2 text-sm shadow-sm focus:border-indigo-500 focus:ring-indigo-500">
+                        </div>
+                        <button id="save-blackout-date-btn" type="submit" class="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700">Add blackout</button>
+                    </form>
+                </div>
+
+                <div class="mt-6">
+                    <h3 class="font-semibold text-gray-900">Review saved scheduling controls</h3>
+                    <div id="venue-controls-list" class="mt-3 space-y-3 text-sm"></div>
+                </div>
+            </section>
+
             <div class="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
                 <section class="rounded-2xl bg-white p-6 shadow-md">
                     <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
@@ -140,20 +222,25 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { addGame, getTeam, getTeams, getUserTeamsWithAccess } from './js/db.js?v=30';
+        import { addGame, createOrganizationBlackout, createVenueAvailability, createVenueBlackout, getTeam, getTeams, getUserTeamsWithAccess, listOrganizationScheduleControls } from './js/db.js?v=31';
         import { parseCsvText } from './js/schedule-csv-import.js?v=2';
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=10';
         import { checkAuth } from './js/auth.js?v=14';
         import { getTeamAccessInfo } from './js/team-access.js';
         import { Timestamp } from './js/firebase.js?v=11';
         import {
+            ORGANIZATION_SCHEDULE_WEEKDAYS,
+            buildBlackoutDatePayload,
             buildOrganizationScheduleCsvTemplate,
             buildOrganizationScheduleImportPreview,
             buildOrganizationSharedGamePayload,
+            buildVenueAvailabilityPayload,
+            formatBlackoutDateRecord,
+            formatVenueAvailabilityRecord,
             getOrganizationTeams,
             inferOrganizationScheduleCsvMapping,
             validateOrganizationMatchup
-        } from './js/organization-schedule.js?v=2';
+        } from './js/organization-schedule.js?v=3';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -182,7 +269,80 @@
         let organizationTeams = [];
         let accessibleTeams = [];
         let organizationCsvState = { fileName: '', preview: null };
+        const availabilityForm = document.getElementById('venue-availability-form');
+        const blackoutForm = document.getElementById('blackout-date-form');
+        const availabilityDaySelect = document.getElementById('availability-day');
+        const venueControlsList = document.getElementById('venue-controls-list');
+        const saveAvailabilityButton = document.getElementById('save-venue-availability-btn');
+        const saveBlackoutButton = document.getElementById('save-blackout-date-btn');
 
+        function setButtonBusy(button, busyText, busy) {
+            if (!button) return;
+            if (busy) {
+                button.dataset.defaultText = button.textContent;
+                button.disabled = true;
+                button.textContent = busyText;
+            } else {
+                button.disabled = false;
+                button.textContent = button.dataset.defaultText || button.textContent;
+            }
+        }
+
+        function renderVenueControlGroup(title, records, formatter) {
+            const section = document.createElement('section');
+            section.className = 'rounded-xl border border-gray-200 bg-white p-4';
+
+            const heading = document.createElement('h4');
+            heading.className = 'font-semibold text-gray-900';
+            heading.textContent = `${title} (${records.length})`;
+            section.appendChild(heading);
+
+            if (records.length === 0) {
+                const empty = document.createElement('p');
+                empty.className = 'mt-2 text-gray-500';
+                empty.textContent = 'No records saved yet.';
+                section.appendChild(empty);
+                return section;
+            }
+
+            const list = document.createElement('ul');
+            list.className = 'mt-3 space-y-2';
+            records.forEach((record) => {
+                const item = document.createElement('li');
+                item.className = 'rounded-lg border border-gray-100 bg-gray-50 px-3 py-2';
+
+                const titleEl = document.createElement('div');
+                titleEl.className = 'font-medium text-gray-900';
+                titleEl.textContent = formatter(record);
+                item.appendChild(titleEl);
+
+                if (record.notes || record.reason) {
+                    const note = document.createElement('div');
+                    note.className = 'mt-1 text-xs text-gray-600';
+                    note.textContent = record.notes || record.reason;
+                    item.appendChild(note);
+                }
+                list.appendChild(item);
+            });
+            section.appendChild(list);
+            return section;
+        }
+
+        async function refreshVenueControls() {
+            if (!anchorTeam?.id) return;
+            venueControlsList.textContent = 'Loading scheduling controls…';
+            try {
+                const controls = await listOrganizationScheduleControls(anchorTeam.id);
+                venueControlsList.replaceChildren(
+                    renderVenueControlGroup('Availability windows', controls.availability || [], formatVenueAvailabilityRecord),
+                    renderVenueControlGroup('Organization blackouts', controls.organizationBlackouts || [], formatBlackoutDateRecord),
+                    renderVenueControlGroup('Venue blackouts', controls.venueBlackouts || [], formatBlackoutDateRecord)
+                );
+            } catch (error) {
+                console.error('Unable to load venue controls:', error);
+                venueControlsList.textContent = `Unable to load scheduling controls: ${error.message}`;
+            }
+        }
 
         function showScheduleMode(mode) {
             const isBulk = mode === 'bulk';
@@ -398,10 +558,69 @@
 
             renderTeamOptions(homeTeamSelect, organizationTeams, anchorTeam.id);
             renderTeamOptions(awayTeamSelect, organizationTeams, organizationTeams.find((team) => team.id !== anchorTeam.id)?.id || organizationTeams[0]?.id);
+            availabilityDaySelect.replaceChildren(...ORGANIZATION_SCHEDULE_WEEKDAYS.map((day) => {
+                const option = document.createElement('option');
+                option.value = day.value;
+                option.textContent = day.label;
+                return option;
+            }));
             resetOrganizationCsvState();
+            await refreshVenueControls();
         }
 
 
+
+        document.getElementById('refresh-venue-controls-btn').addEventListener('click', refreshVenueControls);
+
+        availabilityForm.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            setAlert('');
+            try {
+                setButtonBusy(saveAvailabilityButton, 'Saving…', true);
+                const payload = buildVenueAvailabilityPayload({
+                    venueName: document.getElementById('availability-venue-name').value,
+                    subVenueName: document.getElementById('availability-sub-venue-name').value,
+                    dayOfWeek: document.getElementById('availability-day').value,
+                    startTime: document.getElementById('availability-start-time').value,
+                    endTime: document.getElementById('availability-end-time').value,
+                    notes: document.getElementById('availability-notes').value
+                });
+                await createVenueAvailability(anchorTeam.id, payload);
+                availabilityForm.reset();
+                await refreshVenueControls();
+            } catch (error) {
+                setAlert(error.message);
+            } finally {
+                setButtonBusy(saveAvailabilityButton, 'Saving…', false);
+            }
+        });
+
+        blackoutForm.addEventListener('submit', async (event) => {
+            event.preventDefault();
+            setAlert('');
+            try {
+                setButtonBusy(saveBlackoutButton, 'Saving…', true);
+                const payload = buildBlackoutDatePayload({
+                    scope: document.getElementById('blackout-scope').value,
+                    venueName: document.getElementById('blackout-venue-name').value,
+                    subVenueName: document.getElementById('blackout-sub-venue-name').value,
+                    startDate: document.getElementById('blackout-start-date').value,
+                    endDate: document.getElementById('blackout-end-date').value,
+                    reason: document.getElementById('blackout-reason').value
+                });
+                if (payload.scope === 'venue') {
+                    await createVenueBlackout(anchorTeam.id, payload);
+                } else {
+                    await createOrganizationBlackout(anchorTeam.id, payload);
+                }
+                blackoutForm.reset();
+                await refreshVenueControls();
+            } catch (error) {
+                setAlert(error.message);
+            } finally {
+                setButtonBusy(saveBlackoutButton, 'Saving…', false);
+            }
+        });
 
         singleTab.addEventListener('click', () => showScheduleMode('single'));
         bulkTab.addEventListener('click', () => showScheduleMode('bulk'));

--- a/tests/unit/organization-schedule.test.js
+++ b/tests/unit/organization-schedule.test.js
@@ -1,15 +1,96 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import {
+    buildBlackoutDatePayload,
     buildOrganizationScheduleCsvTemplate,
     buildOrganizationScheduleImportPreview,
     buildOrganizationSharedGamePayload,
+    buildVenueAvailabilityPayload,
+    formatBlackoutDateRecord,
+    formatVenueAvailabilityRecord,
     getOrganizationTeams,
     inferOrganizationScheduleCsvMapping,
     validateOrganizationMatchup
 } from '../../js/organization-schedule.js';
 
 describe('organization schedule helpers', () => {
+
+    it('validates venue availability time windows before saving', () => {
+        expect(buildVenueAvailabilityPayload({
+            venueName: 'Main Field',
+            subVenueName: 'North',
+            dayOfWeek: 'monday',
+            startTime: '18:00',
+            endTime: '20:00',
+            notes: 'Lights available'
+        })).toEqual({
+            venueName: 'Main Field',
+            subVenueName: 'North',
+            dayOfWeek: 'monday',
+            startTime: '18:00',
+            endTime: '20:00',
+            notes: 'Lights available'
+        });
+
+        expect(() => buildVenueAvailabilityPayload({
+            venueName: 'Main Field',
+            dayOfWeek: 'monday',
+            startTime: '',
+            endTime: '20:00'
+        })).toThrow('Enter a start and end time for the availability window.');
+
+        expect(() => buildVenueAvailabilityPayload({
+            venueName: 'Main Field',
+            dayOfWeek: 'monday',
+            startTime: '20:00',
+            endTime: '18:00'
+        })).toThrow('Availability end time must be after the start time.');
+    });
+
+    it('validates blackout date ranges before saving', () => {
+        expect(buildBlackoutDatePayload({
+            scope: 'organization',
+            startDate: '2026-07-04',
+            endDate: '2026-07-05',
+            reason: 'Holiday'
+        })).toEqual({
+            scope: 'organization',
+            venueName: null,
+            subVenueName: null,
+            startDate: '2026-07-04',
+            endDate: '2026-07-05',
+            reason: 'Holiday'
+        });
+
+        expect(() => buildBlackoutDatePayload({
+            scope: 'venue',
+            startDate: '2026-07-05',
+            endDate: '2026-07-04'
+        })).toThrow('Venue or sub-venue name is required for venue-specific blackouts.');
+
+        expect(() => buildBlackoutDatePayload({
+            scope: 'organization',
+            startDate: '2026-07-05',
+            endDate: '2026-07-04'
+        })).toThrow('Blackout end date cannot be before the start date.');
+    });
+
+    it('formats venue controls for the review list', () => {
+        expect(formatVenueAvailabilityRecord({
+            venueName: 'Main Field',
+            subVenueName: 'North',
+            dayOfWeek: 'monday',
+            startTime: '18:00',
+            endTime: '20:00'
+        })).toBe('Main Field / North · Monday · 18:00–20:00');
+
+        expect(formatBlackoutDateRecord({
+            scope: 'venue',
+            venueName: 'Main Field',
+            startDate: '2026-07-04',
+            endDate: '2026-07-05'
+        })).toBe('Main Field · 2026-07-04 through 2026-07-05');
+    });
     const accessibleTeams = [
         { id: 'team-1', name: 'Alpha', ownerId: 'org-1', photoUrl: 'alpha.png' },
         { id: 'team-2', name: 'Bravo', ownerId: 'org-1', photoUrl: 'bravo.png' },
@@ -159,7 +240,7 @@ describe('organization schedule helpers', () => {
     it('loads all active teams for platform admins before organization filtering', () => {
         const source = readFileSync(new URL('../../organization-schedule.html', import.meta.url), 'utf8');
 
-        expect(source).toContain('import { addGame, getTeam, getTeams, getUserTeamsWithAccess }');
+        expect(source).toContain('getTeam, getTeams, getUserTeamsWithAccess, listOrganizationScheduleControls');
         expect(source).toContain('accessibleTeams = currentUser.isAdmin === true');
         expect(source).toContain('? await getTeams()');
         expect(source).toContain(': await getUserTeamsWithAccess(currentUser.uid, currentUser.email);');
@@ -180,4 +261,23 @@ describe('organization schedule helpers', () => {
         expect(source).toContain("const homeLink = document.createElement('a');");
         expect(source).not.toContain('successAlert.innerHTML =');
     });
+    it('wires venue availability and blackout controls on the organization schedule page', () => {
+        const source = readFileSync(new URL('../../organization-schedule.html', import.meta.url), 'utf8');
+
+        expect(source).toContain('id="venue-availability-form"');
+        expect(source).toContain('id="blackout-date-form"');
+        expect(source).toContain('id="venue-controls-list"');
+        expect(source).toContain('buildVenueAvailabilityPayload');
+        expect(source).toContain('buildBlackoutDatePayload');
+        expect(source).toContain('listOrganizationScheduleControls');
+    });
+
+    it('allows team admins to manage venue schedule control collections', () => {
+        const source = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+
+        expect(source).toContain('match /venueAvailability/{availabilityId}');
+        expect(source).toContain('match /organizationBlackouts/{blackoutId}');
+        expect(source).toContain('match /venueBlackouts/{blackoutId}');
+    });
+
 });


### PR DESCRIPTION
Closes #970

## Summary
- Added organization schedule controls for venue availability windows, organization-wide blackouts, and venue-specific blackouts.
- Added validation for empty/invalid time windows and blackout date ranges where the end is before the start.
- Persisted controls under team-scoped Firestore collections with team-admin-only rules and rendered saved records in review lists.

## Validation
- `npm exec vitest run tests/unit/organization-schedule.test.js -- --reporter=dot`
- `node scripts/check-critical-cache-bust.mjs`
- `npm run ci:firebase-rules`