### PR TITLE
Add stat setup visibility controls

### DIFF
--- a/docs/pr-notes/runs/985-remediator-20260512T031356Z/architecture.md
+++ b/docs/pr-notes/runs/985-remediator-20260512T031356Z/architecture.md
@@ -1,0 +1,7 @@
+# Architecture
+
+## Decision
+Add immediate validation inside `addOrUpdateStatDefinitionLine()` in `edit-config.html`, directly after reading the stat helper control values and before building/appending the definition line.
+
+## Blast Radius
+Scoped to the manager-facing stat definition helper only. The existing save-time validation in `validateStatDefinitionsForPublicLeaderboards()` remains unchanged to protect manually edited textarea content.

--- a/docs/pr-notes/runs/985-remediator-20260512T031356Z/code-plan.md
+++ b/docs/pr-notes/runs/985-remediator-20260512T031356Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code Plan
+
+- Edit `edit-config.html` only.
+- Add a guard in `addOrUpdateStatDefinitionLine()` after `visibility`, `scope`, and `topStat` are read.
+- If `topStat` is true and either visibility is not `public` or scope is not `player`, alert the existing validation message and return before mutating the textarea.
+- Leave existing submission validation untouched.

--- a/docs/pr-notes/runs/985-remediator-20260512T031356Z/qa.md
+++ b/docs/pr-notes/runs/985-remediator-20260512T031356Z/qa.md
@@ -1,0 +1,6 @@
+# QA Plan
+
+- In `edit-config.html`, choose Public leaderboard Top Stat with visibility `private` and scope `player`; click Add/Update and confirm an alert appears and the textarea is unchanged.
+- Choose Public leaderboard Top Stat with visibility `public` and scope `team`; click Add/Update and confirm an alert appears and the textarea is unchanged.
+- Choose Public leaderboard Top Stat with visibility `public` and scope `player`; click Add/Update and confirm the line is added with `topStat=true`.
+- Confirm save-time validation still rejects invalid definitions typed directly into the textarea.

--- a/docs/pr-notes/runs/985-remediator-20260512T031356Z/requirements.md
+++ b/docs/pr-notes/runs/985-remediator-20260512T031356Z/requirements.md
@@ -1,0 +1,6 @@
+# Requirements
+
+## Acceptance Criteria
+- When a manager checks Public leaderboard Top Stat in the stat definition helper, the helper must reject the definition before adding or updating the textarea unless visibility is `public` and scope is `player`.
+- Invalid Top Stat entries must show a clear alert explaining the required public/player combination.
+- Existing form-submit validation remains in place as a safety net for pasted or manually edited definitions.

--- a/edit-config.html
+++ b/edit-config.html
@@ -269,6 +269,11 @@
             const scope = document.getElementById('statDefinitionScope').value;
             const topStat = document.getElementById('statDefinitionTopStat').checked;
 
+            if (topStat && (visibility !== 'public' || scope !== 'player')) {
+                alert(`${label} cannot be a Top Stat unless visibility is public and scope is player.`);
+                return;
+            }
+
             if (formula) attributes.push(`formula=${formula}`);
             if (group) attributes.push(`group=${group}`);
             attributes.push(`visibility=${visibility}`);

--- a/edit-config.html
+++ b/edit-config.html
@@ -113,6 +113,63 @@
                                 class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 font-mono text-sm"></textarea>
                             <p class="text-xs text-gray-500 mt-1">Use this area to review and adjust stat groups, top stats, privacy, formulas, precision, and ranking direction before saving.</p>
                         </div>
+                        <div class="rounded-lg border border-gray-200 bg-gray-50 p-3 space-y-3">
+                            <div>
+                                <h3 class="text-sm font-semibold text-gray-800">Stat Setup Controls</h3>
+                                <p class="text-xs text-gray-500 mt-1">Add or update one stat definition at a time with explicit visibility and scope.</p>
+                            </div>
+                            <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+                                <label class="block text-xs font-medium text-gray-700">Display Label
+                                    <input type="text" id="statDefinitionLabel" placeholder="e.g. Deflections"
+                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm">
+                                </label>
+                                <label class="block text-xs font-medium text-gray-700">Stat ID
+                                    <input type="text" id="statDefinitionId" placeholder="e.g. deflections"
+                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm">
+                                </label>
+                                <label class="block text-xs font-medium text-gray-700">Visibility
+                                    <select id="statDefinitionVisibility" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm">
+                                        <option value="public">Public</option>
+                                        <option value="private">Private</option>
+                                    </select>
+                                </label>
+                                <label class="block text-xs font-medium text-gray-700">Scope
+                                    <select id="statDefinitionScope" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm">
+                                        <option value="player">Player</option>
+                                        <option value="team">Team</option>
+                                    </select>
+                                </label>
+                                <label class="block text-xs font-medium text-gray-700">Group
+                                    <input type="text" id="statDefinitionGroup" placeholder="General"
+                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm">
+                                </label>
+                                <label class="block text-xs font-medium text-gray-700">Formula
+                                    <input type="text" id="statDefinitionFormula" placeholder="Optional, e.g. AST/TO"
+                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm">
+                                </label>
+                                <label class="block text-xs font-medium text-gray-700">Format
+                                    <select id="statDefinitionFormat" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm">
+                                        <option value="number">Number</option>
+                                        <option value="percentage">Percentage</option>
+                                    </select>
+                                </label>
+                                <label class="block text-xs font-medium text-gray-700">Precision
+                                    <input type="number" min="0" id="statDefinitionPrecision" placeholder="0"
+                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm">
+                                </label>
+                                <label class="block text-xs font-medium text-gray-700">Ranking Order
+                                    <select id="statDefinitionRankingOrder" class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm">
+                                        <option value="desc">High to low</option>
+                                        <option value="asc">Low to high</option>
+                                    </select>
+                                </label>
+                            </div>
+                            <label class="inline-flex items-center gap-2 text-xs font-medium text-gray-700">
+                                <input type="checkbox" id="statDefinitionTopStat" class="rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+                                Public leaderboard Top Stat
+                            </label>
+                            <button type="button" id="add-stat-definition-btn" class="w-full px-3 py-2 bg-white border border-indigo-200 text-indigo-700 rounded-md text-sm hover:bg-indigo-50">Add or Update Stat Definition</button>
+                        </div>
                         <div class="flex gap-2">
                             <button type="submit" id="save-config-btn"
                                 class="flex-1 bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700 transition">Create Config</button>
@@ -144,7 +201,7 @@
 
     <script type="module">
         import { getTeam, getUserTeams, getConfigs, createConfig, updateConfig, deleteConfig, resetTeamStatConfigs, getUnreadChatCount } from './js/db.js?v=29';
-        import { parseAdvancedStatDefinitions } from './js/stat-leaderboards.js?v=1';
+        import { parseAdvancedStatDefinitions, validateStatDefinitionsForPublicLeaderboards } from './js/stat-leaderboards.js?v=2';
         import { getStatConfigPresetOptions, getStatConfigPresetById, serializeAdvancedStatDefinitions } from './js/stat-config-presets.js?v=1';
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=14';
@@ -186,6 +243,52 @@
             const columns = columnsStr.split(',').map(s => s.trim()).filter(s => s.length > 0);
             const statDefinitions = parseAdvancedStatDefinitions(advancedStatDefinitionsStr);
             return { name, baseType, columns, statDefinitions };
+        }
+
+        function getStatDefinitionLineId(line = '') {
+            const [head] = String(line || '').split('|');
+            const [labelPart, idPart] = head.split('=').map((segment) => segment.trim());
+            return (idPart || labelPart || '').trim().toLowerCase().replace(/[^a-z0-9_]+/g, '');
+        }
+
+        function addOrUpdateStatDefinitionLine() {
+            const label = document.getElementById('statDefinitionLabel').value.trim();
+            const id = document.getElementById('statDefinitionId').value.trim();
+            if (!label || !id) {
+                alert('Add a stat label and stat ID first.');
+                return;
+            }
+
+            const attributes = [];
+            const formula = document.getElementById('statDefinitionFormula').value.trim();
+            const group = document.getElementById('statDefinitionGroup').value.trim();
+            const format = document.getElementById('statDefinitionFormat').value;
+            const precision = document.getElementById('statDefinitionPrecision').value.trim();
+            const rankingOrder = document.getElementById('statDefinitionRankingOrder').value;
+            const visibility = document.getElementById('statDefinitionVisibility').value;
+            const scope = document.getElementById('statDefinitionScope').value;
+            const topStat = document.getElementById('statDefinitionTopStat').checked;
+
+            if (formula) attributes.push(`formula=${formula}`);
+            if (group) attributes.push(`group=${group}`);
+            attributes.push(`visibility=${visibility}`);
+            attributes.push(`scope=${scope}`);
+            if (format !== 'number') attributes.push(`format=${format}`);
+            if (precision) attributes.push(`precision=${precision}`);
+            if (rankingOrder !== 'desc') attributes.push(`rankingOrder=${rankingOrder}`);
+            if (topStat) attributes.push('topStat=true');
+
+            const line = `${label}=${id}${attributes.length ? `|${attributes.join('|')}` : ''}`;
+            const textarea = document.getElementById('advancedStatDefinitions');
+            const normalizedId = getStatDefinitionLineId(line);
+            const lines = textarea.value.split('\n').map((entry) => entry.trim()).filter(Boolean);
+            const existingIndex = lines.findIndex((entry) => getStatDefinitionLineId(entry) === normalizedId);
+            if (existingIndex >= 0) {
+                lines[existingIndex] = line;
+            } else {
+                lines.push(line);
+            }
+            textarea.value = lines.join('\n');
         }
 
         function resetFormState() {
@@ -322,6 +425,8 @@
                 resetFormState();
             });
 
+            document.getElementById('add-stat-definition-btn').addEventListener('click', addOrUpdateStatDefinitionLine);
+
             document.getElementById('reset-configs-btn').addEventListener('click', async () => {
                 if (!confirm('Reset Stats Setup? This deletes all team stat schemas that are not assigned to games and returns you to the initial setup state.')) {
                     return;
@@ -410,6 +515,12 @@
 
             if (columns.length === 0) {
                 alert('Please add at least one column.');
+                return;
+            }
+
+            const leaderboardValidation = validateStatDefinitionsForPublicLeaderboards(statDefinitions);
+            if (!leaderboardValidation.valid) {
+                alert(leaderboardValidation.errors.join('\n'));
                 return;
             }
 

--- a/js/stat-leaderboards.js
+++ b/js/stat-leaderboards.js
@@ -145,6 +145,22 @@ export function parseAdvancedStatDefinitions(text = '') {
     });
 }
 
+export function validateStatDefinitionsForPublicLeaderboards(statDefinitions = []) {
+  const invalidTopStats = (Array.isArray(statDefinitions) ? statDefinitions : [])
+    .filter((definition) => definition?.topStat && (definition.scope !== 'player' || definition.visibility !== 'public'));
+
+  if (!invalidTopStats.length) {
+    return { valid: true, errors: [] };
+  }
+
+  return {
+    valid: false,
+    errors: invalidTopStats.map((definition) => (
+      `${definition.label || definition.id || 'Stat'} cannot be a Top Stat unless visibility is public and scope is player.`
+    ))
+  };
+}
+
 export function normalizeStatTrackerConfig(config = {}) {
   const columns = (Array.isArray(config.columns) ? config.columns : [])
     .map((column) => normalizeLabel(column))

--- a/tests/unit/stat-leaderboards.test.js
+++ b/tests/unit/stat-leaderboards.test.js
@@ -5,7 +5,8 @@ import {
   evaluateDerivedFormula,
   normalizeStatTrackerConfig,
   parseAdvancedStatDefinitions,
-  summarizePlayerTopStats
+  summarizePlayerTopStats,
+  validateStatDefinitionsForPublicLeaderboards
 } from '../../js/stat-leaderboards.js';
 
 describe('stat leaderboard helpers', () => {
@@ -77,6 +78,18 @@ Deflections=deflections|scope=team|visibility=private|group=Defense
         type: 'base'
       })
     ]);
+  });
+
+  it('prevents private or team-scoped stats from being public leaderboard top stats', () => {
+    const definitions = parseAdvancedStatDefinitions(`
+Hustle=hustle|visibility=private|scope=team|topStat=true
+PTS=pts|visibility=public|scope=player|topStat=true
+    `);
+
+    expect(validateStatDefinitionsForPublicLeaderboards(definitions)).toEqual({
+      valid: false,
+      errors: ['Hustle cannot be a Top Stat unless visibility is public and scope is player.']
+    });
   });
 
   it('builds grouped public leaderboards with derived metrics and ranking direction', () => {


### PR DESCRIPTION
Closes #982

## Summary
- Added explicit manager-facing stat setup controls for visibility, scope, format, precision, ranking, formula, group, and Top Stat selection.
- Preserved the existing advanced textarea workflow while allowing add/update of structured stat definition lines.
- Added validation to block non-public-player stats from being marked as public leaderboard Top Stats.

## Tests
- `npx vitest run tests/unit/stat-leaderboards.test.js --reporter=dot`