### PR TITLE
Mask numeric telemetry identifiers

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -529,8 +529,11 @@ function normalizeTelemetryObject(value, depth = 0) {
 
     if (rawValue === null || rawValue === undefined) {
       normalized[cleanKey] = null;
-    } else if (typeof rawValue === 'boolean' || typeof rawValue === 'number') {
+    } else if (typeof rawValue === 'boolean') {
       normalized[cleanKey] = rawValue;
+    } else if (typeof rawValue === 'number') {
+      const sanitizedNumber = normalizeTelemetryString(rawValue, 240);
+      normalized[cleanKey] = sanitizedNumber === String(rawValue) ? rawValue : sanitizedNumber;
     } else if (Array.isArray(rawValue)) {
       normalized[cleanKey] = rawValue
         .slice(0, 10)

--- a/js/telemetry-utils.js
+++ b/js/telemetry-utils.js
@@ -45,7 +45,19 @@ export function sanitizeTelemetryProperties(properties = {}, depth = 0) {
             // large metrics like transferSize or engagementMs.
             const asString = String(value);
             const maskedPhone = asString.replace(/\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]?\d{4}\b/g, '[phone]');
-            clean[cleanKey] = maskedPhone !== asString ? maskedPhone : value;
+            if (maskedPhone !== asString) {
+                clean[cleanKey] = maskedPhone;
+            } else {
+                // If not a phone, check for general sensitive numbers (5 or more digits)
+                // This will catch playerId: 123456789 but not loadMs: 240
+                const maskedNumber = asString.replace(/\b\d{5,}\b/g, '[number]');
+                if (maskedNumber !== asString) {
+                    clean[cleanKey] = maskedNumber;
+                } else {
+                    // Otherwise, preserve the original numeric value
+                    clean[cleanKey] = value;
+                }
+            }
         } else if (Array.isArray(value)) {
             clean[cleanKey] = value.slice(0, 10).map((item) => sanitizeTelemetryText(item, 60));
         } else if (typeof value === 'object') {

--- a/js/telemetry-utils.js
+++ b/js/telemetry-utils.js
@@ -37,8 +37,11 @@ export function sanitizeTelemetryProperties(properties = {}, depth = 0) {
 
         if (value === null || value === undefined) {
             clean[cleanKey] = null;
-        } else if (typeof value === 'boolean' || typeof value === 'number') {
+        } else if (typeof value === 'boolean') {
             clean[cleanKey] = value;
+        } else if (typeof value === 'number') {
+            const sanitizedNumber = sanitizeTelemetryText(value, 160);
+            clean[cleanKey] = sanitizedNumber === String(value) ? value : sanitizedNumber;
         } else if (Array.isArray(value)) {
             clean[cleanKey] = value.slice(0, 10).map((item) => sanitizeTelemetryText(item, 60));
         } else if (typeof value === 'object') {

--- a/js/telemetry-utils.js
+++ b/js/telemetry-utils.js
@@ -40,8 +40,12 @@ export function sanitizeTelemetryProperties(properties = {}, depth = 0) {
         } else if (typeof value === 'boolean') {
             clean[cleanKey] = value;
         } else if (typeof value === 'number') {
-            const sanitizedNumber = sanitizeTelemetryText(value, 160);
-            clean[cleanKey] = sanitizedNumber === String(value) ? value : sanitizedNumber;
+            // Only mask phone-pattern numbers; preserve all other numeric metrics as-is.
+            // Running the full sanitizeTelemetryText (\b\d{5,}\b) would corrupt legitimate
+            // large metrics like transferSize or engagementMs.
+            const asString = String(value);
+            const maskedPhone = asString.replace(/\b(?:\+?1[-.\s]?)?(?:\(?\d{3}\)?[-.\s]?)\d{3}[-.\s]?\d{4}\b/g, '[phone]');
+            clean[cleanKey] = maskedPhone !== asString ? maskedPhone : value;
         } else if (Array.isArray(value)) {
             clean[cleanKey] = value.slice(0, 10).map((item) => sanitizeTelemetryText(item, 60));
         } else if (typeof value === 'object') {

--- a/tests/unit/telemetry-utils.test.js
+++ b/tests/unit/telemetry-utils.test.js
@@ -28,6 +28,18 @@ describe('telemetry privacy utilities', () => {
         expect(properties.nested.email).toBe('[email]');
     });
 
+    it('masks sensitive numeric property values without string coercion by callers', () => {
+        const properties = sanitizeTelemetryProperties({
+            phone: 5551234567,
+            playerId: 123456789,
+            loadMs: 240
+        });
+
+        expect(properties.phone).toBe('[phone]');
+        expect(properties.playerId).toBe('[number]');
+        expect(properties.loadMs).toBe(240);
+    });
+
     it('keeps telemetry keys bounded and machine-friendly', () => {
         expect(sanitizeTelemetryKey('bad key.with spaces and dots')).toBe('bad_key_with_spaces_and_dots');
         expect(sanitizeTelemetryKey('many words '.repeat(20))).toHaveLength(60);


### PR DESCRIPTION
Closes #988

## Summary
- Mask numeric telemetry property values that match existing phone or long identifier patterns before client submission.
- Apply the same numeric masking path in the server telemetry normalizer for defense in depth.
- Preserve short numeric metrics, such as timing values, as numbers.

## Tests
- `npx vitest run tests/unit/telemetry-utils.test.js`