### PR TITLE
Honor team help role filters

### DIFF
--- a/help.html
+++ b/help.html
@@ -288,6 +288,19 @@
 
         function escapeHtml(v){return String(v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');}
 
+        function applyRoleFromUrl() {
+            const requestedRole = new URLSearchParams(window.location.search).get('role');
+            if (!requestedRole) {
+                return;
+            }
+
+            const requestedRoleKey = requestedRole.trim().toLowerCase();
+            const matchingOption = Array.from(roleSelect.options).find((option) => option.value.toLowerCase() === requestedRoleKey);
+            if (matchingOption) {
+                roleSelect.value = matchingOption.value;
+            }
+        }
+
         function render() {
             const q = (searchInput.value || '').toLowerCase().trim();
             const role = roleSelect.value;
@@ -318,6 +331,7 @@
             summary.textContent = filtered.length + ' of ' + manifest.length + ' workflows';
         }
 
+        applyRoleFromUrl();
         searchInput.addEventListener('input', render);
         roleSelect.addEventListener('change', render);
         render();

--- a/tests/smoke/help-center.spec.js
+++ b/tests/smoke/help-center.spec.js
@@ -67,7 +67,8 @@ test('help center supports workflow discovery and page-reference navigation', as
     await expect(page.locator('#help-grid')).not.toHaveClass(/hidden/);
     await expect(page.getByRole('link', { name: 'View file-by-file page reference' })).toBeVisible();
 
-    await page.locator('#help-role').selectOption('Coach');
+    await page.goto(buildUrl(baseURL, '/help.html?context=team&teamId=team-123&role=coach'), { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#help-role')).toHaveValue('Coach');
     const coachResults = filterManifest(manifest, { role: 'Coach' });
     await expect(page.locator('#help-grid article')).toHaveCount(coachResults.length);
     await expect(page.locator('#help-summary')).toHaveText(`${coachResults.length} of ${manifest.length} workflows`);

--- a/tests/unit/help-navigation-wiring.test.js
+++ b/tests/unit/help-navigation-wiring.test.js
@@ -25,6 +25,13 @@ describe('help navigation wiring', () => {
         expect(bannerJs).toContain("label: 'Help'");
     });
 
+    it('applies team help role query parameters before rendering workflows', () => {
+        const helpHtml = readRepoFile('help.html');
+        expect(helpHtml).toContain("new URLSearchParams(window.location.search).get('role')");
+        expect(helpHtml).toContain('option.value.toLowerCase() === requestedRoleKey');
+        expect(helpHtml).toMatch(/applyRoleFromUrl\(\);\s*searchInput\.addEventListener/);
+    });
+
     it('renders multi-page help portal links', () => {
         const helpHtml = readRepoFile('help.html');
         expect(helpHtml).toContain('href="workflow-getting-started.html"');


### PR DESCRIPTION
Closes #990

## Summary
- Read the Help Center `role` query parameter before the initial render.
- Match role values case-insensitively so team banner links like `role=coach` select the `Coach` filter.
- Added unit and smoke coverage for role-aware Help Center entry.

## Validation
- Passed: `npx vitest run tests/unit/help-navigation-wiring.test.js --reporter=dot`
- Blocked: `npx playwright test tests/smoke/help-center.spec.js --config=playwright.smoke.config.js --reporter=line` because the Playwright Chromium executable is not installed in this workspace.