### PR TITLE
Load older chat media in gallery

### DIFF
--- a/docs/pr-notes/runs/993-remediator-20260513T071411Z/architecture.md
+++ b/docs/pr-notes/runs/993-remediator-20260513T071411Z/architecture.md
@@ -1,0 +1,13 @@
+# Architecture Notes
+
+## Decision
+Add a small local helper in `team-chat.html` that captures `messages-container.scrollHeight` and `scrollTop`, runs the older-message load, then restores `scrollTop` with the height delta.
+
+## Rationale
+- Keeps pagination logic centralized in `loadMessages(true)`.
+- Matches the existing load-more scroll preservation pattern, while preserving non-zero scroll positions too.
+- Avoids changing Firestore queries, media collection, modal rendering, or realtime chat behavior.
+
+## Risk And Rollback
+- Risk is limited to chat viewport scroll math after prepending older messages.
+- Rollback is removing the helper usage and returning to direct `loadMessages(true)` calls.

--- a/docs/pr-notes/runs/993-remediator-20260513T071411Z/code-plan.md
+++ b/docs/pr-notes/runs/993-remediator-20260513T071411Z/code-plan.md
@@ -1,0 +1,10 @@
+# Code Plan
+
+## Implementation Plan
+- Add `loadOlderMessagesPreservingScroll()` near the existing scroll helpers in `team-chat.html`.
+- The helper will read `messages-container`, store `scrollHeight` and `scrollTop`, await `loadMessages(true)`, then set `scrollTop` to `scrollTopBefore + (scrollHeightAfter - scrollHeightBefore)` when messages were loaded.
+- Replace direct `loadMessages(true)` usage in `loadMediaGalleryHistory()` with the helper.
+- Use the same helper in the load-more button handler to keep behavior consistent and avoid duplicate scroll math.
+
+## Scope Control
+No changes to gallery rendering, media actions, Firestore queries, or realtime listeners.

--- a/docs/pr-notes/runs/993-remediator-20260513T071411Z/qa.md
+++ b/docs/pr-notes/runs/993-remediator-20260513T071411Z/qa.md
@@ -1,0 +1,11 @@
+# QA Notes
+
+## Manual Validation Plan
+1. In team chat with 50+ messages and older media, scroll to a mid-history position, open the media gallery, and confirm the main messages viewport stays at the same reading context while gallery history loads.
+2. Scroll near the top and click Load older messages. Confirm older messages prepend and the viewport remains stable.
+3. Open media gallery in a chat with no additional history. Confirm the gallery opens and summary renders without scroll movement or errors.
+
+## Regression Focus
+- Main message viewport scroll preservation.
+- Media gallery completeness after loading all history.
+- Load-more button behavior and enabled/disabled state.

--- a/docs/pr-notes/runs/993-remediator-20260513T071411Z/requirements.md
+++ b/docs/pr-notes/runs/993-remediator-20260513T071411Z/requirements.md
@@ -1,0 +1,10 @@
+# Requirements Notes
+
+## Acceptance Criteria
+- Opening the media gallery must not move the main chat viewport while older history is loaded to populate gallery media.
+- Each prepended history batch must preserve the reader's relative scroll position by applying the scroll-height delta after render.
+- Existing load-more behavior must continue to load older messages and keep the viewport stable.
+
+## Assumptions
+- Gallery history loading can continue to reuse `loadMessages(true)` for pagination and hydration.
+- The modal gallery's own scroll position is independent from the main chat message viewport.

--- a/team-chat.html
+++ b/team-chat.html
@@ -390,6 +390,7 @@
         let pendingImageFiles = [];
         let pendingMediaPreviewUrls = [];
         let galleryMediaEntries = [];
+        let isLoadingMediaGalleryHistory = false;
         const chatMediaShareFileCache = new Map();
         const chatMediaShareFilePending = new Map();
         let activeReactionPickerMessageId = null;
@@ -492,14 +493,14 @@
         async function loadMessages(loadMore = false) {
             try {
                 if (!loadMore) {
-                    return;
+                    return false;
                 }
 
                 const cursor = olderMessages.length > 0 ? olderMessages[0]._doc : liveOldestDoc;
                 if (!cursor) {
                     hasMoreMessages = false;
                     updateLoadMoreButton();
-                    return;
+                    return false;
                 }
 
                 const newMessages = await getChatMessages(teamId, { limit: 50, startAfterDoc: cursor, conversationId: selectedConversationId });
@@ -518,6 +519,7 @@
 
                 renderMessages();
                 updateLoadMoreButton();
+                return olderBatch.length > 0;
 
             } catch (error) {
                 console.error('Error loading messages:', error);
@@ -529,6 +531,7 @@
                         </button>
                     </div>
                 `;
+                return false;
             }
         }
 
@@ -611,18 +614,8 @@
         function renderMessages() {
             const container = document.getElementById('messages-container');
             const mediaEntries = collectThreadMedia(messages);
-            const mediaCount = document.getElementById('media-gallery-count');
-            const mediaSummary = document.getElementById('media-gallery-summary');
 
-            if (mediaEntries.length > 0) {
-                mediaCount.textContent = String(mediaEntries.length);
-                mediaCount.classList.remove('hidden');
-                mediaSummary.textContent = `${mediaEntries.length} shared item${mediaEntries.length === 1 ? '' : 's'} in this conversation.`;
-            } else {
-                mediaCount.textContent = '';
-                mediaCount.classList.add('hidden');
-                mediaSummary.textContent = 'Browse shared media from this team chat.';
-            }
+            updateMediaGallerySummary(mediaEntries);
 
             if (messages.length === 0) {
                 container.innerHTML = `
@@ -1346,6 +1339,21 @@
             `;
         }
 
+        function updateMediaGallerySummary(mediaEntries) {
+            const mediaCount = document.getElementById('media-gallery-count');
+            const mediaSummary = document.getElementById('media-gallery-summary');
+
+            if (mediaEntries.length > 0) {
+                mediaCount.textContent = String(mediaEntries.length);
+                mediaCount.classList.remove('hidden');
+                mediaSummary.textContent = `${mediaEntries.length} shared item${mediaEntries.length === 1 ? '' : 's'} in this conversation.`;
+            } else {
+                mediaCount.textContent = '';
+                mediaCount.classList.add('hidden');
+                mediaSummary.textContent = 'Browse shared media from this team chat.';
+            }
+        }
+
         function renderMediaGallery(mediaEntries) {
             const grid = document.getElementById('media-gallery-grid');
             galleryMediaEntries = mediaEntries.slice();
@@ -1575,8 +1583,32 @@
             }
         }
 
-        function openMediaGallery() {
+        async function loadMediaGalleryHistory() {
+            if (isLoadingMediaGalleryHistory || !hasMoreMessages) {
+                return;
+            }
+
+            isLoadingMediaGalleryHistory = true;
+            const mediaSummary = document.getElementById('media-gallery-summary');
+            mediaSummary.textContent = 'Loading older shared media…';
+            try {
+                while (hasMoreMessages) {
+                    const loadedMessages = await loadMessages(true);
+                    if (!loadedMessages) {
+                        break;
+                    }
+                }
+            } finally {
+                isLoadingMediaGalleryHistory = false;
+                const mediaEntries = collectThreadMedia(messages);
+                renderMediaGallery(mediaEntries);
+                updateMediaGallerySummary(mediaEntries);
+            }
+        }
+
+        async function openMediaGallery() {
             document.getElementById('media-gallery-modal').classList.remove('hidden');
+            await loadMediaGalleryHistory();
         }
 
         function closeMediaGallery() {

--- a/team-chat.html
+++ b/team-chat.html
@@ -923,6 +923,21 @@
             return container.scrollTop <= threshold;
         }
 
+        async function loadOlderMessagesPreservingScroll() {
+            const container = document.getElementById('messages-container');
+            const scrollHeightBefore = container?.scrollHeight || 0;
+            const scrollTopBefore = container?.scrollTop || 0;
+
+            const loadedMessages = await loadMessages(true);
+
+            if (container && loadedMessages) {
+                const scrollHeightAfter = container.scrollHeight;
+                container.scrollTop = scrollTopBefore + (scrollHeightAfter - scrollHeightBefore);
+            }
+
+            return loadedMessages;
+        }
+
         function showError(message) {
             const errorEl = document.getElementById('send-error');
             errorEl.textContent = message;
@@ -1593,7 +1608,7 @@
             mediaSummary.textContent = 'Loading older shared media…';
             try {
                 while (hasMoreMessages) {
-                    const loadedMessages = await loadMessages(true);
+                    const loadedMessages = await loadOlderMessagesPreservingScroll();
                     if (!loadedMessages) {
                         break;
                     }
@@ -2091,14 +2106,7 @@
                 btn.disabled = true;
                 btn.textContent = 'Loading...';
 
-                const container = document.getElementById('messages-container');
-                const scrollHeightBefore = container.scrollHeight;
-
-                await loadMessages(true);
-
-                // Maintain scroll position
-                const scrollHeightAfter = container.scrollHeight;
-                container.scrollTop = scrollHeightAfter - scrollHeightBefore;
+                await loadOlderMessagesPreservingScroll();
 
                 btn.disabled = false;
                 btn.textContent = 'Load older messages...';

--- a/tests/unit/team-chat-media-gallery-actions.test.js
+++ b/tests/unit/team-chat-media-gallery-actions.test.js
@@ -17,6 +17,16 @@ describe('team chat media gallery actions wiring', () => {
         expect(html).toContain('data-media-action="copy-link"');
     });
 
+    it('loads older chat history before finalizing the gallery contents', () => {
+        const html = readRepoFile('team-chat.html');
+
+        expect(html).toContain('async function loadMediaGalleryHistory()');
+        expect(html).toContain('while (hasMoreMessages)');
+        expect(html).toContain('await loadMessages(true)');
+        expect(html).toContain('async function openMediaGallery()');
+        expect(html).toContain('await loadMediaGalleryHistory()');
+    });
+
     it('wires gallery action handlers for share, save, and copy link fallbacks', () => {
         const html = readRepoFile('team-chat.html');
 


### PR DESCRIPTION
Closes #992

## Summary
- Load older chat history when the Photos & Videos gallery opens so media beyond the initial realtime window is included.
- Refresh the gallery count, summary, and grid after older messages are loaded.
- Added focused coverage to ensure the gallery triggers older history loading.

## Validation
- `npx vitest run tests/unit/team-chat-media-gallery-actions.test.js tests/unit/team-chat-media.test.js`