### PR TITLE
Add team media file uploads

### DIFF
--- a/docs/pr-notes/runs/995-ci-fix-20260513T001721Z/architecture.md
+++ b/docs/pr-notes/runs/995-ci-fix-20260513T001721Z/architecture.md
@@ -1,0 +1,10 @@
+# Architecture Notes
+
+## Root cause
+The team media page added document/file support and now imports `uploadTeamMediaFile`, `isTeamMediaDocument`, and `isSupportedTeamMediaDocument`. The smoke test module stubs for `db.js` and `team-media-utils.js` were not updated to export those symbols, so the page module fails during import and never runs `checkAuth()`/`render()`.
+
+## Decision
+Keep production behavior unchanged. Update only the affected smoke test stubs so they match the current module contract.
+
+## Risks and rollback
+Low blast radius: test-only change. Rollback is reverting the stub additions if production imports are reverted.

--- a/docs/pr-notes/runs/995-ci-fix-20260513T001721Z/code-plan.md
+++ b/docs/pr-notes/runs/995-ci-fix-20260513T001721Z/code-plan.md
@@ -1,0 +1,9 @@
+# Code Plan
+
+## Minimal change
+Update `tests/smoke/team-fallback-regressions.spec.js` stubs:
+- Add `uploadTeamMediaFile()` to media db stubs.
+- Add `isTeamMediaDocument()` and `isSupportedTeamMediaDocument()` to media utility stubs.
+
+## Scope
+No production code changes. This is CI test drift caused by stale smoke module stubs.

--- a/docs/pr-notes/runs/995-ci-fix-20260513T001721Z/qa.md
+++ b/docs/pr-notes/runs/995-ci-fix-20260513T001721Z/qa.md
@@ -1,0 +1,10 @@
+# QA Notes
+
+## Acceptance criteria
+- Team media smoke tests execute the page module successfully.
+- Permission-denied media reads show the non-staff empty state.
+- Staff management read denial hides management UI and shows the Firestore rules message.
+- Staff with folders sees visible save actions and album options.
+
+## Validation
+Run `npm run test:smoke:team-fallback -- --grep "team media"`.

--- a/docs/pr-notes/runs/995-remediator-20260513T071106Z/architecture.md
+++ b/docs/pr-notes/runs/995-remediator-20260513T071106Z/architecture.md
@@ -1,0 +1,15 @@
+# Architecture
+
+Subagent spawn unavailable in this run, so this is inline role analysis following the orchestrator fallback.
+
+## Architecture Decisions
+- Keep the delete fix in `js/team-media.js` at the event handler boundary. After `deleteTeamMediaItem` succeeds, mutate the module-level cache and call `render()` directly for deterministic UI consistency.
+- Keep MIME fallback logic centralized in `js/team-media-utils.js` inside `isSupportedTeamMediaDocument`.
+- Add extension and generic-MIME constants next to the existing document MIME whitelist.
+
+## Blast Radius
+- Delete behavior changes only for the single item delete button.
+- Upload validation changes only for document/file uploads, not images or video links.
+
+## Rollback
+- Revert the handler change and utility constants/function body if needed.

--- a/docs/pr-notes/runs/995-remediator-20260513T071106Z/code-plan.md
+++ b/docs/pr-notes/runs/995-remediator-20260513T071106Z/code-plan.md
@@ -1,0 +1,21 @@
+# Code Plan
+
+Subagent spawn unavailable in this run, so this is inline role analysis following the orchestrator fallback.
+
+## Implementation Plan
+1. In `js/team-media.js`, replace the single-item delete `persistAndReload` call with a small explicit async path:
+   - guard `state.actionInFlight`
+   - clear alert
+   - await `deleteTeamMediaItem(state.teamId, item)`
+   - filter `state.items` by deleted item id
+   - delete the id from `state.selectedIds`
+   - call `render()` and show success
+   - preserve existing permission/error message handling
+2. In `js/team-media-utils.js`, add document extension and generic MIME constants.
+3. Update `isSupportedTeamMediaDocument` to:
+   - accept exact whitelisted MIME types
+   - fallback to extension only when MIME is blank or generic
+   - reject otherwise.
+
+## Risks And Rollback
+- Scope is limited to two review comments. Revert the two touched functions/constants if behavior regresses.

--- a/docs/pr-notes/runs/995-remediator-20260513T071106Z/qa.md
+++ b/docs/pr-notes/runs/995-remediator-20260513T071106Z/qa.md
@@ -1,0 +1,17 @@
+# QA Plan
+
+Subagent spawn unavailable in this run, so this is inline role analysis following the orchestrator fallback.
+
+## Manual Checks
+- Delete one visible media item and verify it disappears immediately after confirmation and successful delete.
+- Verify a selected deleted item no longer contributes to bulk selection state.
+- Validate `isSupportedTeamMediaDocument` behavior for:
+  - `report.docx` with empty MIME: accepted.
+  - `roster.csv` with `application/octet-stream`: accepted.
+  - `notes.txt` with empty MIME: accepted.
+  - `script.exe` with empty MIME: rejected.
+  - `image.png` with empty MIME: rejected by document validation.
+  - `.docx` with explicit unsupported non-generic MIME like `image/png`: rejected.
+
+## Automation
+- No automated test runner is defined by AGENTS.md/CLAUDE.md. Use syntax/static checks where practical.

--- a/docs/pr-notes/runs/995-remediator-20260513T071106Z/requirements.md
+++ b/docs/pr-notes/runs/995-remediator-20260513T071106Z/requirements.md
@@ -1,0 +1,13 @@
+# Requirements
+
+Subagent spawn unavailable in this run, so this is inline role analysis following the orchestrator fallback.
+
+## Acceptance Criteria
+- Deleting a single media item updates the local `state.items` cache before re-rendering so the item disappears immediately after delete succeeds, independent of Firestore read timing.
+- Selected IDs are cleaned when the deleted item is removed.
+- Supported document uploads accept allowed file extensions when browsers provide a blank or generic MIME type.
+- Explicit non-generic unsupported MIME types remain rejected.
+
+## Risks
+- Extension fallback should be limited to document extensions already implied by the MIME whitelist.
+- UI change should only affect the single-item delete path tied to the review thread.

--- a/firestore.rules
+++ b/firestore.rules
@@ -502,19 +502,34 @@ service cloud.firestore {
               get(folderPath).data.get('visibility', 'team') == 'team');
     }
 
-    function isTeamMediaPhotoCreate(teamId, data) {
+    function isAllowedTeamMediaUploadType(mimeType) {
+      return mimeType.matches('image/.*') ||
+             mimeType in [
+               'application/pdf',
+               'application/msword',
+               'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+               'application/vnd.ms-excel',
+               'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+               'application/vnd.ms-powerpoint',
+               'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+               'text/plain',
+               'text/csv'
+             ];
+    }
+
+    function isTeamMediaUploadCreate(teamId, data) {
       return canAccessTeamChat(teamId) &&
              data.keys().hasAll([
                'folderId', 'title', 'type', 'url', 'storagePath', 'uploadedBy',
                'size', 'mimeType', 'deleted', 'createdAt', 'updatedAt'
              ]) &&
              data.keys().hasOnly([
-               'folderId', 'title', 'type', 'url', 'storagePath', 'uploadedBy',
+               'folderId', 'title', 'fileName', 'type', 'url', 'storagePath', 'uploadedBy',
                'size', 'mimeType', 'order', 'deleted', 'createdAt', 'updatedAt'
              ]) &&
              data.folderId is string &&
              data.folderId.size() > 0 &&
-             data.type == 'photo' &&
+             data.type in ['photo', 'file'] &&
              data.url is string &&
              data.storagePath is string &&
              data.storagePath.matches('team-media/' + teamId + '/' + data.folderId + '/' + request.auth.uid + '/.*') &&
@@ -523,15 +538,16 @@ service cloud.firestore {
              data.size > 0 &&
              data.size <= 10485760 &&
              data.mimeType is string &&
-             data.mimeType.matches('image/.*') &&
+             ((data.type == 'photo' && data.mimeType.matches('image/.*')) ||
+              (data.type == 'file' && isAllowedTeamMediaUploadType(data.mimeType) && !data.mimeType.matches('image/.*'))) &&
              data.deleted == false &&
              data.createdAt == request.time &&
              data.updatedAt == request.time;
     }
 
-    function isOwnTeamMediaPhotoSoftDelete(teamId) {
+    function isOwnTeamMediaUploadSoftDelete(teamId) {
       return canAccessTeamChat(teamId) &&
-             resource.data.type == 'photo' &&
+             resource.data.type in ['photo', 'file'] &&
              resource.data.uploadedBy == request.auth.uid &&
              request.resource.data.diff(resource.data).affectedKeys().hasOnly([
                'deleted', 'deletedAt', 'deletedBy', 'updatedAt'
@@ -924,8 +940,8 @@ service cloud.firestore {
 
       match /mediaItems/{itemId} {
         allow read: if canReadTeamMediaItem(teamId, resource.data);
-        allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaPhotoCreate(teamId, request.resource.data);
-        allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaPhotoSoftDelete(teamId);
+        allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);
+        allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaUploadSoftDelete(teamId);
         allow delete: if isTeamOwnerOrAdmin(teamId);
       }
 

--- a/js/db.js
+++ b/js/db.js
@@ -97,7 +97,7 @@ import {
     summarizeRegistration
 } from './registration-review.js?v=2';
 import { buildTournamentPoolOverrideKey } from './tournament-standings.js?v=1';
-import { buildBulkDeleteUpdates, buildMoveUpdates, buildReorderUpdates, isSafeTeamMediaUrl, normalizeTeamMediaFolderDraft, normalizeAlbumVisibility, sortByMediaOrder } from './team-media-utils.js?v=1';
+import { buildBulkDeleteUpdates, buildMoveUpdates, buildReorderUpdates, isSafeTeamMediaUrl, isSupportedTeamMediaDocument, normalizeTeamMediaFolderDraft, normalizeAlbumVisibility, sortByMediaOrder } from './team-media-utils.js?v=2';
 import { getApp } from './vendor/firebase-app.js';
 import {
     claimOfficiatingSlot,
@@ -654,11 +654,58 @@ export async function uploadTeamMediaPhoto(teamId, folderId, file, options = {})
     return docRef.id;
 }
 
+export async function uploadTeamMediaFile(teamId, folderId, file, options = {}) {
+    const cleanTeamId = String(teamId || '').trim();
+    const cleanFolderId = String(folderId || '').trim();
+    const currentUser = auth.currentUser;
+    if (!cleanTeamId || !cleanFolderId) throw new Error('Choose an album before uploading files.');
+    if (!currentUser?.uid) throw new Error('Sign in before uploading files.');
+    if (!isSupportedTeamMediaDocument(file)) throw new Error('Choose a supported document file.');
+
+    const storagePath = `team-media/${cleanTeamId}/${cleanFolderId}/${currentUser.uid}/${Date.now()}-${sanitizeTeamMediaFileName(file.name)}`;
+    const storageRef = ref(storage, storagePath);
+    const uploadTask = uploadBytesResumable(storageRef, file, { contentType: file.type });
+
+    const snapshot = await new Promise((resolve, reject) => {
+        uploadTask.on('state_changed', (progressSnapshot) => {
+            if (typeof options.onProgress === 'function') {
+                const percent = progressSnapshot.totalBytes > 0
+                    ? Math.round((progressSnapshot.bytesTransferred / progressSnapshot.totalBytes) * 100)
+                    : 0;
+                options.onProgress({
+                    bytesTransferred: progressSnapshot.bytesTransferred,
+                    totalBytes: progressSnapshot.totalBytes,
+                    percent
+                });
+            }
+        }, reject, () => resolve(uploadTask.snapshot));
+    });
+
+    const url = await getDownloadURL(snapshot.ref);
+    const existingItems = await getTeamMediaItems(cleanTeamId, cleanFolderId);
+    const docRef = await addDoc(getTeamMediaItemsRef(cleanTeamId), {
+        folderId: cleanFolderId,
+        title: String(file.name || 'Uploaded file').trim() || 'Uploaded file',
+        fileName: String(file.name || '').trim(),
+        type: 'file',
+        url,
+        storagePath,
+        uploadedBy: currentUser.uid,
+        size: Number(file.size || 0),
+        mimeType: file.type,
+        order: existingItems.length,
+        deleted: false,
+        createdAt: serverTimestamp(),
+        updatedAt: serverTimestamp()
+    });
+    return docRef.id;
+}
+
 export async function deleteTeamMediaItem(teamId, item) {
     const cleanTeamId = String(teamId || '').trim();
     const itemId = String(item?.id || '').trim();
     if (!cleanTeamId || !itemId) throw new Error('Media item is required.');
-    if (item?.type === 'photo' && !item.storagePath) {
+    if (['photo', 'file'].includes(item?.type) && !item.storagePath) {
         console.error('Media object missing file reference:', itemId);
         throw new Error('Cannot delete media: missing file reference');
     }
@@ -676,7 +723,7 @@ export async function deleteTeamMediaItem(teamId, item) {
         updatedAt: serverTimestamp()
     });
 
-    if (item?.type === 'photo') {
+    if (['photo', 'file'].includes(item?.type)) {
         try {
             await deleteObject(ref(storage, item.storagePath));
         } catch (error) {

--- a/js/team-media-utils.js
+++ b/js/team-media-utils.js
@@ -6,6 +6,18 @@ const VIDEO_HOST_PATTERNS = [
     /(^|\.)vimeo\.com$/
 ];
 
+const TEAM_MEDIA_DOCUMENT_TYPES = new Set([
+    'application/pdf',
+    'application/msword',
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    'application/vnd.ms-excel',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/vnd.ms-powerpoint',
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    'text/plain',
+    'text/csv'
+]);
+
 export const TEAM_MEDIA_VISIBILITIES = ['team', 'private'];
 
 function asTrimmedString(value) {
@@ -70,9 +82,17 @@ export function isSupportedTeamMediaImage(file) {
     return Boolean(file && String(file.type || '').startsWith('image/'));
 }
 
+export function isSupportedTeamMediaDocument(file) {
+    return Boolean(file && TEAM_MEDIA_DOCUMENT_TYPES.has(String(file.type || '').toLowerCase()));
+}
+
+export function isTeamMediaDocument(item = {}) {
+    return String(item.type || '').toLowerCase() === 'file';
+}
+
 export function canDeleteTeamMediaItem(user, team, item) {
     if (!user || !item) return false;
-    return canManageTeamMedia(user, team) || (item.type === 'photo' && item.uploadedBy === user.uid);
+    return canManageTeamMedia(user, team) || (['photo', 'file'].includes(item.type) && item.uploadedBy === user.uid);
 }
 
 export function normalizeTeamMediaFolderDraft(draft = {}) {

--- a/js/team-media-utils.js
+++ b/js/team-media-utils.js
@@ -18,6 +18,24 @@ const TEAM_MEDIA_DOCUMENT_TYPES = new Set([
     'text/csv'
 ]);
 
+const TEAM_MEDIA_DOCUMENT_EXTENSIONS = new Set([
+    'pdf',
+    'doc',
+    'docx',
+    'xls',
+    'xlsx',
+    'ppt',
+    'pptx',
+    'txt',
+    'csv'
+]);
+
+const GENERIC_TEAM_MEDIA_DOCUMENT_TYPES = new Set([
+    '',
+    'application/octet-stream',
+    'binary/octet-stream'
+]);
+
 export const TEAM_MEDIA_VISIBILITIES = ['team', 'private'];
 
 function asTrimmedString(value) {
@@ -83,7 +101,14 @@ export function isSupportedTeamMediaImage(file) {
 }
 
 export function isSupportedTeamMediaDocument(file) {
-    return Boolean(file && TEAM_MEDIA_DOCUMENT_TYPES.has(String(file.type || '').toLowerCase()));
+    if (!file) return false;
+
+    const mimeType = String(file.type || '').toLowerCase();
+    if (TEAM_MEDIA_DOCUMENT_TYPES.has(mimeType)) return true;
+    if (!GENERIC_TEAM_MEDIA_DOCUMENT_TYPES.has(mimeType)) return false;
+
+    const extension = String(file.name || '').toLowerCase().match(/\.([a-z0-9]+)$/)?.[1] || '';
+    return TEAM_MEDIA_DOCUMENT_EXTENSIONS.has(extension);
 }
 
 export function isTeamMediaDocument(item = {}) {

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -415,13 +415,27 @@ els.foldersList.addEventListener('click', (event) => {
     }
 });
 
-els.albumDetail.addEventListener('click', (event) => {
+els.albumDetail.addEventListener('click', async (event) => {
     const deleteButton = event.target.closest('[data-item-delete]');
     if (deleteButton) {
         const item = state.items.find((candidate) => candidate.id === deleteButton.dataset.itemDelete);
         if (!canDeleteTeamMediaItem(state.user, state.team, item)) return;
         if (!window.confirm('Delete this media item? This cannot be undone.')) return;
-        persistAndReload(() => deleteTeamMediaItem(state.teamId, item), 'Media item deleted.');
+        if (state.actionInFlight) return;
+        state.actionInFlight = true;
+        clearAlert();
+        try {
+            await deleteTeamMediaItem(state.teamId, item);
+            state.items = state.items.filter((candidate) => candidate.id !== item.id);
+            state.selectedIds.delete(item.id);
+            render();
+            showAlert('Media item deleted.', 'success');
+        } catch (error) {
+            console.error('Team media action failed:', error);
+            showAlert(isPermissionDenied(error) ? getMediaPermissionMessage() : (error.message || 'Unable to save media changes. Refresh and try again.'), 'error');
+        } finally {
+            state.actionInFlight = false;
+        }
         return;
     }
 

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -7,6 +7,7 @@ import {
     updateTeamMediaFolder,
     deleteTeamMediaFolder,
     createTeamMediaLink,
+    uploadTeamMediaFile,
     uploadTeamMediaPhoto,
     deleteTeamMediaItem,
     reorderTeamMediaFolders,
@@ -14,7 +15,7 @@ import {
     moveTeamMediaItems,
     bulkDeleteTeamMediaItems,
     setTeamMediaAlbumCover
-} from './db.js?v=15';
+} from './db.js?v=16';
 import {
     canContributeTeamMedia,
     canDeleteTeamMediaItem,
@@ -24,7 +25,9 @@ import {
     getTeamMediaUploaderName,
     isSafeTeamMediaPhoto,
     isSafeTeamMediaUrl,
+    isSupportedTeamMediaDocument,
     isSupportedTeamMediaImage,
+    isTeamMediaDocument,
     sortByMediaOrder
 } from './team-media-utils.js?v=2';
 
@@ -50,6 +53,10 @@ const els = {
     photoFolder: document.getElementById('photo-folder'),
     photoFiles: document.getElementById('photo-files'),
     uploadProgress: document.getElementById('upload-progress'),
+    fileUploadForm: document.getElementById('file-upload-form'),
+    fileFolder: document.getElementById('file-folder'),
+    mediaFiles: document.getElementById('media-files'),
+    fileUploadProgress: document.getElementById('file-upload-progress'),
     adminPanel: document.getElementById('team-media-admin-panel'),
     bulkActions: document.getElementById('bulk-actions'),
     selectedCount: document.getElementById('selected-count'),
@@ -120,8 +127,9 @@ function renderFolderOptions() {
     const placeholder = `<option value="">${hasFolders ? 'Choose album' : 'Create an album first'}</option>`;
     els.linkFolder.innerHTML = placeholder + options;
     els.photoFolder.innerHTML = placeholder + options;
+    els.fileFolder.innerHTML = placeholder + options;
     els.moveFolder.innerHTML = placeholder + options;
-    [els.linkFolder, els.linkTitle, els.linkUrl, els.linkSubmit].forEach((element) => {
+    [els.linkFolder, els.linkTitle, els.linkUrl, els.linkSubmit, els.photoFolder, els.photoFiles, els.fileFolder, els.mediaFiles].forEach((element) => {
         if (!element) return;
         element.disabled = !hasFolders;
         element.classList.toggle('opacity-50', !hasFolders);
@@ -132,6 +140,14 @@ function renderFolderOptions() {
             ? 'Choose an album, then save the video link.'
             : 'Save an album first. Video links need an album destination.';
     }
+}
+
+function formatFileSize(size) {
+    const bytes = Number(size || 0);
+    if (!Number.isFinite(bytes) || bytes <= 0) return '';
+    if (bytes < 1024) return `${bytes} bytes`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
 function renderBulkActions() {
@@ -197,21 +213,23 @@ function renderAlbumDetail() {
         : `<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">${items.map((item, itemIndex) => {
             const itemUrl = getTeamMediaItemUrl(item);
             const isPhoto = isSafeTeamMediaPhoto(item);
+            const isFile = isTeamMediaDocument(item);
             const canDeleteItem = canDeleteTeamMediaItem(state.user, state.team, item);
-            const title = item.title || item.fileName || (isPhoto ? 'Untitled photo' : 'Untitled video');
+            const title = item.title || item.fileName || (isPhoto ? 'Untitled photo' : isFile ? 'Untitled file' : 'Untitled video');
             const uploadedBy = getTeamMediaUploaderName(item);
             const uploadedAt = formatMediaDate(item.uploadedAt || item.createdAt);
-            const fileDetails = isPhoto ? `${item.mimeType || 'image'}${item.size ? ` · ${Number(item.size || 0).toLocaleString()} bytes` : ''}` : '';
+            const fileDetails = isPhoto || isFile ? [item.mimeType || (isPhoto ? 'image' : 'file'), formatFileSize(item.size)].filter(Boolean).join(' · ') : '';
             const metadata = [uploadedBy ? `Uploaded by ${uploadedBy}` : '', uploadedAt, fileDetails].filter(Boolean).join(' • ');
             return `
                 <div class="flex h-full flex-col gap-3 rounded-xl border border-gray-200 p-4" data-item-id="${escapeHtml(item.id)}">
                     ${isPhoto ? `<a href="${escapeHtml(itemUrl)}" target="_blank" rel="noopener noreferrer" class="block overflow-hidden rounded-lg bg-gray-100"><img src="${escapeHtml(itemUrl)}" alt="${escapeHtml(title)}" loading="lazy" class="h-48 w-full object-cover"></a>` : ''}
+                    ${isFile ? `<a href="${escapeHtml(itemUrl)}" target="_blank" rel="noopener noreferrer" class="flex h-48 items-center justify-center rounded-lg bg-indigo-50 text-center text-indigo-700"><div><div class="text-4xl">📄</div><div class="mt-2 px-4 text-sm font-semibold">${escapeHtml(title)}</div></div></a>` : ''}
                     <div class="flex items-start gap-3">
                         ${state.canManage ? `<input type="checkbox" data-select-item="${escapeHtml(item.id)}" ${state.selectedIds.has(item.id) ? 'checked' : ''} class="mt-1 h-4 w-4 rounded border-gray-300">` : ''}
                         <div class="min-w-0 flex-1">
                             <a href="${escapeHtml(itemUrl)}" target="_blank" rel="noopener noreferrer" class="font-semibold text-indigo-700 hover:text-indigo-900">${escapeHtml(title)}</a>
                             <div class="text-xs text-gray-500">${escapeHtml(metadata || 'Media item')}</div>
-                            ${!isPhoto ? `<div class="break-all text-xs text-gray-500">${escapeHtml(itemUrl)}</div>` : ''}
+                            ${!isPhoto && !isFile ? `<div class="break-all text-xs text-gray-500">${escapeHtml(itemUrl)}</div>` : ''}
                         </div>
                     </div>
                     <div class="mt-auto flex flex-wrap gap-2">
@@ -241,10 +259,10 @@ function renderAlbumDetail() {
 function render() {
     els.title.textContent = state.team?.name ? `${state.team.name} Media` : 'Media Library';
     els.subtitle.textContent = state.canManage
-        ? 'Manage albums, visibility, ordering, photos, and video links.'
+        ? 'Manage albums, visibility, ordering, photos, files, and video links.'
         : state.canContribute
-            ? 'Upload team photos or browse shared video links and highlights.'
-            : 'Team-visible albums with organized photos, video links, and highlights.';
+            ? 'Upload team photos and files or browse shared video links and highlights.'
+            : 'Team-visible albums with organized photos, files, video links, and highlights.';
     els.uploadPanel.classList.toggle('hidden', !state.canContribute);
     els.adminPanel.classList.toggle('hidden', !state.canManage);
     els.backLink.href = state.teamId ? `team.html#teamId=${encodeURIComponent(state.teamId)}` : 'team.html';
@@ -318,6 +336,42 @@ function moveInArray(items, id, direction) {
     if (index < 0 || target < 0 || target >= next.length) return next;
     [next[index], next[target]] = [next[target], next[index]];
     return next;
+}
+
+async function uploadSelectedFiles({ files, folderId, progressEl, validateFile, uploadFile, nounSingular, nounPlural, unsupportedMessage }) {
+    progressEl.innerHTML = files.map((file, index) => `
+        <div data-upload-row="${index}" class="rounded-lg border border-gray-200 p-3">
+            <div class="flex justify-between gap-3"><span>${escapeHtml(file.name)}</span><span data-upload-status="${index}">Waiting</span></div>
+            <div class="mt-2 h-2 rounded-full bg-gray-100"><div data-upload-bar="${index}" class="h-2 rounded-full bg-indigo-600" style="width:0%"></div></div>
+        </div>`).join('');
+
+    let uploadedCount = 0;
+    let failedCount = 0;
+    for (const [index, file] of files.entries()) {
+        const status = progressEl.querySelector(`[data-upload-status="${index}"]`);
+        const bar = progressEl.querySelector(`[data-upload-bar="${index}"]`);
+        try {
+            if (!validateFile(file)) throw new Error(unsupportedMessage);
+            status.textContent = 'Uploading';
+            await uploadFile(state.teamId, folderId, file, {
+                onProgress: ({ percent }) => {
+                    bar.style.width = `${percent}%`;
+                    status.textContent = `${percent}%`;
+                }
+            });
+            uploadedCount += 1;
+            bar.style.width = '100%';
+            status.textContent = 'Uploaded';
+        } catch (error) {
+            failedCount += 1;
+            status.textContent = error.message || 'Failed. Try again.';
+            status.classList.add('text-red-700');
+        }
+    }
+
+    await loadLibrary();
+    showAlert(`${uploadedCount} ${uploadedCount === 1 ? nounSingular : nounPlural} uploaded${failedCount ? `, ${failedCount} failed` : ''}.`, failedCount ? 'error' : 'success');
+    return { uploadedCount, failedCount };
 }
 
 els.foldersList.addEventListener('click', (event) => {
@@ -439,39 +493,44 @@ els.uploadForm.addEventListener('submit', async (event) => {
         return;
     }
 
-    els.uploadProgress.innerHTML = files.map((file, index) => `
-        <div data-upload-row="${index}" class="rounded-lg border border-gray-200 p-3">
-            <div class="flex justify-between gap-3"><span>${escapeHtml(file.name)}</span><span data-upload-status="${index}">Waiting</span></div>
-            <div class="mt-2 h-2 rounded-full bg-gray-100"><div data-upload-bar="${index}" class="h-2 rounded-full bg-indigo-600" style="width:0%"></div></div>
-        </div>`).join('');
+    const { uploadedCount } = await uploadSelectedFiles({
+        files,
+        folderId: els.photoFolder.value,
+        progressEl: els.uploadProgress,
+        validateFile: isSupportedTeamMediaImage,
+        uploadFile: uploadTeamMediaPhoto,
+        nounSingular: 'photo',
+        nounPlural: 'photos',
+        unsupportedMessage: 'Unsupported file type. Choose an image.'
+    });
+    if (uploadedCount > 0) els.photoFiles.value = '';
+});
 
-    let uploadedCount = 0;
-    let failedCount = 0;
-    for (const [index, file] of files.entries()) {
-        const status = els.uploadProgress.querySelector(`[data-upload-status="${index}"]`);
-        const bar = els.uploadProgress.querySelector(`[data-upload-bar="${index}"]`);
-        try {
-            if (!isSupportedTeamMediaImage(file)) throw new Error('Unsupported file type. Choose an image.');
-            status.textContent = 'Uploading';
-            await uploadTeamMediaPhoto(state.teamId, els.photoFolder.value, file, {
-                onProgress: ({ percent }) => {
-                    bar.style.width = `${percent}%`;
-                    status.textContent = `${percent}%`;
-                }
-            });
-            uploadedCount += 1;
-            bar.style.width = '100%';
-            status.textContent = 'Uploaded';
-        } catch (error) {
-            failedCount += 1;
-            status.textContent = error.message || 'Failed. Try again.';
-            status.classList.add('text-red-700');
-        }
+els.fileUploadForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    clearAlert();
+    const files = Array.from(els.mediaFiles.files || []);
+    if (!state.canContribute) return;
+    if (!els.fileFolder.value) {
+        showAlert('Choose an album before uploading files.', 'error');
+        return;
+    }
+    if (files.length === 0) {
+        showAlert('Choose at least one file to upload.', 'error');
+        return;
     }
 
-    await loadLibrary();
-    if (uploadedCount > 0) els.photoFiles.value = '';
-    showAlert(`${uploadedCount} photo${uploadedCount === 1 ? '' : 's'} uploaded${failedCount ? `, ${failedCount} failed` : ''}.`, failedCount ? 'error' : 'success');
+    const { uploadedCount } = await uploadSelectedFiles({
+        files,
+        folderId: els.fileFolder.value,
+        progressEl: els.fileUploadProgress,
+        validateFile: isSupportedTeamMediaDocument,
+        uploadFile: uploadTeamMediaFile,
+        nounSingular: 'file',
+        nounPlural: 'files',
+        unsupportedMessage: 'Unsupported file type. Choose a PDF, Office document, text file, or CSV.'
+    });
+    if (uploadedCount > 0) els.mediaFiles.value = '';
 });
 
 els.moveSelected.addEventListener('click', () => {

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -37,8 +37,8 @@ assertIncludes(firestoreRules, 'function canReadTeamMediaItem(teamId, itemData)'
 assertIncludes(firestoreRules, 'allow read: if canReadTeamMediaFolder(teamId, resource.data);', 'Firestore media folder read rules');
 assertIncludes(firestoreRules, 'allow read: if canReadTeamMediaItem(teamId, resource.data);', 'Firestore media item read rules');
 assertIncludes(firestoreRules, 'allow create, update, delete: if isTeamOwnerOrAdmin(teamId);', 'Firestore media folder write rules');
-assertIncludes(firestoreRules, 'allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaPhotoCreate(teamId, request.resource.data);', 'Firestore media item create rules');
-assertIncludes(firestoreRules, 'allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaPhotoSoftDelete(teamId);', 'Firestore media item update rules');
+assertIncludes(firestoreRules, 'allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);', 'Firestore media item create rules');
+assertIncludes(firestoreRules, 'allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaUploadSoftDelete(teamId);', 'Firestore media item update rules');
 assertIncludes(firestoreRules, 'allow delete: if isTeamOwnerOrAdmin(teamId);', 'Firestore media item delete rules');
 
 assertIncludes(deployProd, 'firestore:rules', 'Production deploy');

--- a/storage.rules
+++ b/storage.rules
@@ -30,6 +30,21 @@ service firebase.storage {
       return isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId);
     }
 
+    function isAllowedTeamMediaUploadType(contentType) {
+      return contentType.matches('image/.*') ||
+        contentType in [
+          'application/pdf',
+          'application/msword',
+          'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+          'application/vnd.ms-excel',
+          'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+          'application/vnd.ms-powerpoint',
+          'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+          'text/plain',
+          'text/csv'
+        ];
+    }
+
     match /team-media/{teamId}/{folderId}/{userId}/{fileName} {
       allow get: if canAccessTeamMedia(teamId);
       allow list: if false;
@@ -37,7 +52,7 @@ service firebase.storage {
         request.auth.uid == userId &&
         request.resource.size > 0 &&
         request.resource.size <= 10 * 1024 * 1024 &&
-        request.resource.contentType.matches('image/.*');
+        isAllowedTeamMediaUploadType(request.resource.contentType);
       allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;
       allow update: if false;
     }

--- a/team-media.html
+++ b/team-media.html
@@ -34,6 +34,14 @@
                 <button class="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2">Upload photos</button>
                 <div id="upload-progress" class="space-y-2 text-sm"></div>
             </form>
+            <form id="file-upload-form" class="mt-5 space-y-3 border-t border-gray-100 pt-5">
+                <h2 class="font-semibold text-gray-900">Upload files</h2>
+                <p class="text-sm text-gray-500">Share PDFs, Office documents, text files, or CSVs with the team.</p>
+                <select id="file-folder" class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" required></select>
+                <input id="media-files" type="file" accept=".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.txt,.csv,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,text/plain,text/csv" multiple class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" required>
+                <button class="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2">Upload files</button>
+                <div id="file-upload-progress" class="space-y-2 text-sm"></div>
+            </form>
         </section>
 
         <section id="team-media-admin-panel" class="hidden mb-6 rounded-xl border border-indigo-100 bg-white p-5 shadow-sm">
@@ -88,6 +96,6 @@
         <section id="album-detail"></section>
     </main>
 
-    <script type="module" src="js/team-media.js?v=3"></script>
+    <script type="module" src="js/team-media.js?v=4"></script>
 </body>
 </html>

--- a/tests/smoke/team-fallback-regressions.spec.js
+++ b/tests/smoke/team-fallback-regressions.spec.js
@@ -247,6 +247,7 @@ export async function updateTeamMediaFolder() {}
 export async function deleteTeamMediaFolder() {}
 export async function createTeamMediaLink() {}
 export async function uploadTeamMediaPhoto() {}
+export async function uploadTeamMediaFile() {}
 export async function deleteTeamMediaItem() {}
 export async function reorderTeamMediaFolders() {}
 export async function reorderTeamMediaItems() {}
@@ -270,6 +271,7 @@ export async function updateTeamMediaFolder() {}
 export async function deleteTeamMediaFolder() {}
 export async function createTeamMediaLink() {}
 export async function uploadTeamMediaPhoto() {}
+export async function uploadTeamMediaFile() {}
 export async function deleteTeamMediaItem() {}
 export async function reorderTeamMediaFolders() {}
 export async function reorderTeamMediaItems() {}
@@ -300,10 +302,16 @@ export function getTeamMediaUploaderName() {
 export function isSafeTeamMediaPhoto() {
     return false;
 }
+export function isTeamMediaDocument() {
+    return false;
+}
 export function isSafeTeamMediaUrl() {
     return true;
 }
 export function isSupportedTeamMediaImage() {
+    return true;
+}
+export function isSupportedTeamMediaDocument() {
     return true;
 }
 export function sortByMediaOrder(items = []) {
@@ -333,10 +341,16 @@ export function getTeamMediaUploaderName() {
 export function isSafeTeamMediaPhoto() {
     return false;
 }
+export function isTeamMediaDocument() {
+    return false;
+}
 export function isSafeTeamMediaUrl() {
     return true;
 }
 export function isSupportedTeamMediaImage() {
+    return true;
+}
+export function isSupportedTeamMediaDocument() {
     return true;
 }
 export function sortByMediaOrder(items = []) {

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -21,19 +21,21 @@ describe('team media entry point', () => {
         const pageJs = readRepoFile('js/team-media.js');
         const rules = readRepoFile('firestore.rules');
 
-        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=3"></script>');
+        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=4"></script>');
         expect(pageHtml).toContain('id="team-media-upload-panel"');
         expect(pageHtml).toContain('id="team-media-admin-panel"');
         expect(pageHtml).toContain('id="bulk-actions"');
         expect(pageHtml).toContain('id="album-detail"');
         expect(pageHtml).toContain('id="folder-visibility"');
         expect(pageHtml).toContain('Add album');
+        expect(pageHtml).toContain('Upload files');
         expect(pageHtml).toContain('Save video link');
         expect(pageJs).toContain("import { checkAuth } from './auth.js?v=14';");
-        expect(pageJs).toContain("from './db.js?v=15'");
+        expect(pageJs).toContain("from './db.js?v=16'");
         expect(pageJs).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
         expect(pageJs).toContain('state.canManage = canManageTeamMedia(user, state.team);');
         expect(pageJs).toContain('uploadTeamMediaPhoto');
+        expect(pageJs).toContain('uploadTeamMediaFile');
         expect(pageJs).toContain('Create an album first');
         expect(pageJs).toContain('getMediaPermissionMessage');
         expect(pageJs).toContain('updateTeamMediaFolder');
@@ -46,7 +48,7 @@ describe('team media entry point', () => {
         expect(rules).toContain('match /mediaFolders/{folderId}');
         expect(rules).toContain('allow read: if canReadTeamMediaFolder(teamId, resource.data);');
         expect(rules).toContain('allow read: if canReadTeamMediaItem(teamId, resource.data);');
-        expect(rules).toContain('allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaPhotoCreate(teamId, request.resource.data);');
-        expect(rules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaPhotoSoftDelete(teamId);');
+        expect(rules).toContain('allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);');
+        expect(rules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaUploadSoftDelete(teamId);');
     });
 });

--- a/tests/unit/team-media-rules.test.js
+++ b/tests/unit/team-media-rules.test.js
@@ -16,8 +16,10 @@ describe('team media Firestore rules', () => {
 
         expect(mediaRules).toContain('allow read: if canReadTeamMediaFolder(teamId, resource.data);');
         expect(mediaRules).toContain('allow read: if canReadTeamMediaItem(teamId, resource.data);');
-        expect(mediaRules).toContain('allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaPhotoCreate(teamId, request.resource.data);');
-        expect(mediaRules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaPhotoSoftDelete(teamId);');
+        expect(mediaRules).toContain('allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);');
+        expect(mediaRules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaUploadSoftDelete(teamId);');
+        expect(rules).toContain("data.type in ['photo', 'file']");
+        expect(rules).toContain('isAllowedTeamMediaUploadType(data.mimeType)');
         expect(mediaRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId);');
     });
 });

--- a/tests/unit/team-media-utils.test.js
+++ b/tests/unit/team-media-utils.test.js
@@ -12,8 +12,10 @@ import {
     getTeamMediaUploaderName,
     isSafeTeamMediaPhoto,
     isSafeTeamMediaUrl,
+    isSupportedTeamMediaDocument,
     isSupportedTeamMediaVideoUrl,
     isSupportedTeamMediaImage,
+    isTeamMediaDocument,
     normalizeAlbumVisibility,
     normalizeSelectedMediaIds,
     normalizeTeamMediaFolderDraft,
@@ -41,11 +43,13 @@ describe('team media management permissions', () => {
         expect(canContributeTeamMedia({ uid: 'other-1', parentTeamIds: ['other-team'] }, team)).toBe(false);
     });
 
-    it('allows owners or admins to moderate all photos and uploaders to delete their own photos', () => {
+    it('allows owners or admins to moderate all uploads and uploaders to delete their own files', () => {
         const team = { id: 'team-1', ownerId: 'coach-1', adminEmails: [] };
         const item = { id: 'photo-1', type: 'photo', uploadedBy: 'parent-1' };
+        const fileItem = { id: 'file-1', type: 'file', uploadedBy: 'parent-1' };
 
         expect(canDeleteTeamMediaItem({ uid: 'parent-1' }, team, item)).toBe(true);
+        expect(canDeleteTeamMediaItem({ uid: 'parent-1' }, team, fileItem)).toBe(true);
         expect(canDeleteTeamMediaItem({ uid: 'parent-2' }, team, item)).toBe(false);
         expect(canDeleteTeamMediaItem({ uid: 'coach-1' }, team, item)).toBe(true);
     });
@@ -163,6 +167,15 @@ describe('team media bulk actions', () => {
         expect(isSupportedTeamMediaImage({ type: 'image/png' })).toBe(true);
         expect(isSupportedTeamMediaImage({ type: 'video/mp4' })).toBe(false);
         expect(isSupportedTeamMediaImage(null)).toBe(false);
+    });
+
+    it('accepts approved document files for team media uploads', () => {
+        expect(isSupportedTeamMediaDocument({ type: 'application/pdf' })).toBe(true);
+        expect(isSupportedTeamMediaDocument({ type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' })).toBe(true);
+        expect(isSupportedTeamMediaDocument({ type: 'text/csv' })).toBe(true);
+        expect(isSupportedTeamMediaDocument({ type: 'video/mp4' })).toBe(false);
+        expect(isSupportedTeamMediaDocument({ type: 'image/png' })).toBe(false);
+        expect(isTeamMediaDocument({ type: 'file' })).toBe(true);
     });
 
     it('sorts by saved order with stable name fallback', () => {

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -14,10 +14,11 @@ describe('team media page wiring', () => {
         const page = fs.readFileSync(path.join(repoRoot, 'team-media.html'), 'utf8');
         const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
 
-        expect(page).toContain('src="js/team-media.js?v=3"');
+        expect(page).toContain('src="js/team-media.js?v=4"');
         expect(page).toContain('Add album');
+        expect(page).toContain('Upload files');
         expect(page).toContain('Save video link');
-        expect(source).toContain("from './db.js?v=15'");
+        expect(source).toContain("from './db.js?v=16'");
         expect(source).toContain("import { checkAuth } from './auth.js?v=14';");
         expect(source).toContain('checkAuth(async (user) => {');
         expect(source).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');
@@ -34,8 +35,8 @@ describe('team media page wiring', () => {
         expect(rules).toContain('match /mediaFolders/{folderId}');
         expect(rules).toContain('allow read: if canReadTeamMediaFolder(teamId, resource.data);');
         expect(rules).toContain('allow read: if canReadTeamMediaItem(teamId, resource.data);');
-        expect(rules).toContain('allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaPhotoCreate(teamId, request.resource.data);');
-        expect(rules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaPhotoSoftDelete(teamId);');
+        expect(rules).toContain('allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);');
+        expect(rules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaUploadSoftDelete(teamId);');
         expect(rules).toContain("folderData.get('visibility', 'team') == 'team'");
         expect(rules).toContain("get(folderPath).data.get('visibility', 'team') == 'team'");
     });
@@ -46,7 +47,8 @@ describe('team media page wiring', () => {
 
         expect(firebaseJson.storage.rules).toBe('storage.rules');
         expect(storageRules).toContain('match /team-media/{teamId}/{folderId}/{userId}/{fileName}');
-        expect(storageRules).toContain("request.resource.contentType.matches('image/.*')");
+        expect(storageRules).toContain('isAllowedTeamMediaUploadType(request.resource.contentType)');
+        expect(storageRules).toContain('application/pdf');
         expect(storageRules).toContain('allow delete: if isTeamOwnerOrAdmin(teamId) || request.auth.uid == userId;');
     });
 });


### PR DESCRIPTION
Closes #994

## What changed
- Added a Team Media file upload form for PDFs, Office documents, text files, and CSVs alongside existing photo uploads.
- Added `uploadTeamMediaFile` storage/Firestore flow with file metadata, rendering, download links, and delete cleanup for uploaded files.
- Expanded Firestore and Storage rules to allow approved document MIME types while preserving team media visibility and uploader ownership controls.
- Updated cache-bust references and team media tests for wiring, permissions, allowed file types, and rules expectations.

## Validation
- `npx vitest run tests/unit/team-media-utils.test.js tests/unit/team-media-rules.test.js tests/unit/team-media-wiring.test.js tests/unit/team-media-page.test.js`
- `node scripts/check-critical-cache-bust.mjs`
- `npm run ci:firebase-rules`
- `node --check js/team-media.js && node --check js/db.js && node --check js/team-media-utils.js`