### PR TITLE
Add Stream & Score game-day entry

### DIFF
--- a/game-day.html
+++ b/game-day.html
@@ -2581,7 +2581,7 @@ Respond ONLY with valid JSON.`;
                 exitUrl: accessInfo.exitUrl
             });
             const gameTitle = state.game?.opponent ? `vs ${escapeHtml(state.game.opponent)}` : 'Scheduled event';
-            const streamStatus = state.game?.managedStreamReady
+            const streamStatus = state.game?.broadcastSession?.managedStreamReady
                 ? 'Broadcast setup is marked ready for this game.'
                 : 'Broadcast setup has not been marked ready yet.';
             const streamProviderAction = externalUrl

--- a/game-day.html
+++ b/game-day.html
@@ -965,8 +965,12 @@
                     ? await getMyRsvp(teamId, resolvedGameId, state.user.uid).catch(() => null)
                     : null;
                 const accessInfo = getTeamAccessInfo(state.user, { ...team, id: teamId }, { game, rsvp: scopedRsvp });
-                if (!accessInfo.hasAccess || !['full', 'scorekeep', 'stream'].includes(accessInfo.accessLevel)) {
+                if (!accessInfo.hasAccess || !['full', 'scorekeep', 'stream', 'stream-score'].includes(accessInfo.accessLevel)) {
                     window.location.href = `team.html#teamId=${teamId}&message=Game+Day+is+for+coaches,+admins,+approved+scorekeepers,+and+approved+streaming+volunteers+only`;
+                    return;
+                }
+                if (accessInfo.accessLevel === 'stream-score') {
+                    renderLimitedStreamAndScoreAccess(accessInfo);
                     return;
                 }
                 if (accessInfo.accessLevel === 'scorekeep') {
@@ -2559,6 +2563,61 @@ Respond ONLY with valid JSON.`;
                     <div class="flex flex-col sm:flex-row gap-3">
                         <a href="${watchUrl}" class="inline-flex items-center justify-center rounded-lg bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-gray-800">Open live viewer</a>
                         ${streamButton}
+                    </div>
+                </section>`;
+            document.getElementById('footer-container')?.before(main);
+        }
+
+        function renderLimitedStreamAndScoreAccess(accessInfo) {
+            hideLoading();
+            const externalUrl = getStreamExternalUrl(state.team);
+            const trackerUrl = getScorekeepingTrackerUrl();
+            const liveGameUrl = `live-game.html#teamId=${encodeURIComponent(state.teamId)}&gameId=${encodeURIComponent(state.gameId)}`;
+            renderTeamAdminBanner(document.getElementById('banner-container'), {
+                team: state.team,
+                teamId: state.teamId,
+                active: 'gameday',
+                accessLevel: accessInfo.accessLevel,
+                exitUrl: accessInfo.exitUrl
+            });
+            const gameTitle = state.game?.opponent ? `vs ${escapeHtml(state.game.opponent)}` : 'Scheduled event';
+            const streamStatus = state.game?.managedStreamReady
+                ? 'Broadcast setup is marked ready for this game.'
+                : 'Broadcast setup has not been marked ready yet.';
+            const streamProviderAction = externalUrl
+                ? `<a href="${escapeHtml(externalUrl)}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center rounded-lg border border-indigo-200 px-4 py-2 text-sm font-semibold text-indigo-700 hover:bg-indigo-50">Open stream provider ↗</a>`
+                : '<div class="rounded-lg bg-amber-50 border border-amber-200 px-4 py-3 text-sm text-amber-800">No saved team stream URL yet. Ask a coach/admin to add the YouTube or Twitch URL in team settings.</div>';
+            document.getElementById('game-subbanner')?.classList.add('hidden');
+            document.getElementById('pre-game-view')?.classList.add('hidden');
+            document.getElementById('game-day-view')?.classList.add('hidden');
+            document.getElementById('wrap-up-view')?.classList.add('hidden');
+            const main = document.createElement('main');
+            main.className = 'max-w-3xl mx-auto px-4 py-8';
+            main.innerHTML = `
+                <section class="bg-white rounded-2xl shadow-sm border border-gray-200 p-6 space-y-5">
+                    <div>
+                        <div class="text-xs font-semibold uppercase tracking-wide text-primary-600">Stream &amp; Score</div>
+                        <h1 class="text-2xl font-bold text-gray-900 mt-1">${gameTitle}</h1>
+                        <p class="text-sm text-gray-600 mt-2">Use this mobile game-day workspace when you are handling both scorekeeping and stream setup for the same scheduled game.</p>
+                    </div>
+                    <a href="${trackerUrl}" class="flex w-full items-center justify-center rounded-xl bg-primary-600 px-4 py-3 text-base font-semibold text-white hover:bg-primary-700">Open Stream &amp; Score workspace</a>
+                    <div class="grid gap-4 sm:grid-cols-2">
+                        <div class="rounded-xl border border-emerald-200 bg-emerald-50 p-4">
+                            <div class="text-xs font-semibold uppercase tracking-wide text-emerald-700">Scoring</div>
+                            <p class="mt-2 text-sm text-emerald-900">Open the scorekeeper to start or continue live stats for this game.</p>
+                            <a href="${trackerUrl}" class="mt-3 inline-flex items-center justify-center rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white hover:bg-emerald-700">Open scorekeeper</a>
+                        </div>
+                        <div class="rounded-xl border border-indigo-200 bg-indigo-50 p-4">
+                            <div class="text-xs font-semibold uppercase tracking-wide text-indigo-700">Stream setup/status</div>
+                            <p class="mt-2 text-sm text-indigo-900">${streamStatus}</p>
+                            <div class="mt-3 flex flex-col gap-2">
+                                <a href="${liveGameUrl}" class="inline-flex items-center justify-center rounded-lg bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-gray-800">Open broadcast setup</a>
+                                ${streamProviderAction}
+                            </div>
+                        </div>
+                    </div>
+                    <div class="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+                        Current streaming support uses external provider/setup tools. ALL PLAYS can capture setup/status metadata here, but this is not yet a native managed broadcast or server-side stream pipeline.
                     </div>
                 </section>`;
             document.getElementById('footer-container')?.before(main);

--- a/js/team-access.js
+++ b/js/team-access.js
@@ -98,7 +98,7 @@ export function hasScorekeepingTeamAccess(user, team, game = null, rsvp = null) 
 
 /**
  * Determine user's access level for a team.
- * @returns {{ hasAccess: boolean, accessLevel: 'full'|'scorekeep'|'stream'|'parent'|null, exitUrl: string }}
+ * @returns {{ hasAccess: boolean, accessLevel: 'full'|'scorekeep'|'stream'|'stream-score'|'parent'|null, exitUrl: string }}
  */
 export function getTeamAccessInfo(user, team, options = {}) {
   if (!user || !team) {
@@ -109,13 +109,19 @@ export function getTeamAccessInfo(user, team, options = {}) {
     return { hasAccess: true, accessLevel: 'full', exitUrl: 'dashboard.html' };
   }
 
-  if (hasScorekeepingTeamAccess(user, team, options.game, options.rsvp)) {
-    const teamExitUrl = team.id ? `team.html#teamId=${team.id}` : 'team.html';
+  const teamExitUrl = team.id ? `team.html#teamId=${team.id}` : 'team.html';
+  const canScorekeep = hasScorekeepingTeamAccess(user, team, options.game, options.rsvp);
+  const canStream = hasStreamTeamAccess(user, team, options.game, options.rsvp);
+
+  if (canScorekeep && canStream) {
+    return { hasAccess: true, accessLevel: 'stream-score', exitUrl: teamExitUrl };
+  }
+
+  if (canScorekeep) {
     return { hasAccess: true, accessLevel: 'scorekeep', exitUrl: teamExitUrl };
   }
 
-  if (hasStreamTeamAccess(user, team, options.game, options.rsvp)) {
-    const teamExitUrl = team.id ? `team.html#teamId=${team.id}` : 'team.html';
+  if (canStream) {
     return { hasAccess: true, accessLevel: 'stream', exitUrl: teamExitUrl };
   }
 

--- a/tests/unit/scorekeeping-access-wiring.test.js
+++ b/tests/unit/scorekeeping-access-wiring.test.js
@@ -6,7 +6,9 @@ describe('scorekeeping access wiring', () => {
     it('wires Game Day to limited scorekeeping access instead of full admin only', () => {
         const source = readFileSync(resolve(process.cwd(), 'game-day.html'), 'utf8');
 
-        expect(source).toContain("['full', 'scorekeep', 'stream'].includes(accessInfo.accessLevel)");
+        expect(source).toContain("['full', 'scorekeep', 'stream', 'stream-score'].includes(accessInfo.accessLevel)");
+        expect(source).toContain("accessInfo.accessLevel === 'stream-score'");
+        expect(source).toContain('renderLimitedStreamAndScoreAccess(accessInfo)');
         expect(source).toContain("accessInfo.accessLevel === 'scorekeep'");
         expect(source).toContain('renderLimitedScorekeepingAccess(accessInfo)');
         expect(source).toContain('Roster management, schedule editing, team settings, and other coach/admin controls remain restricted.');

--- a/tests/unit/team-access.test.js
+++ b/tests/unit/team-access.test.js
@@ -139,6 +139,25 @@ describe('team access helpers', () => {
     });
   });
 
+  it('returns combined stream and score access for volunteers with both permissions', () => {
+    const team = {
+      ...TEAM,
+      teamPermissions: {
+        scorekeeping: { mode: 'selected', memberIds: ['dual-volunteer'] },
+        streaming: { mode: 'selected', memberIds: ['dual-volunteer'] }
+      }
+    };
+    const game = { id: 'game-1', status: 'scheduled' };
+
+    expect(hasScorekeepingTeamAccess({ uid: 'dual-volunteer' }, team, game)).toBe(true);
+    expect(hasStreamTeamAccess({ uid: 'dual-volunteer' }, team, game)).toBe(true);
+    expect(getTeamAccessInfo({ uid: 'dual-volunteer' }, team, { game })).toEqual({
+      hasAccess: true,
+      accessLevel: 'stream-score',
+      exitUrl: 'team.html#teamId=team-1'
+    });
+  });
+
   it('denies selected scorekeeper access to admin-only management when the game is cancelled', () => {
     const team = {
       ...TEAM,


### PR DESCRIPTION
Closes #1003

## Summary
- Adds a combined `stream-score` access level for volunteers with both scorekeeping and streaming permission.
- Routes those volunteers to a mobile Stream & Score game-day workspace with game context, scoring access, stream setup/status, and external-provider guidance.
- Preserves existing scorekeeper-only and streamer-only game-day entry flows.

## Validation
- `npx vitest run tests/unit/team-access.test.js tests/unit/scorekeeping-access-wiring.test.js tests/unit/scorekeeping-access.test.js`