### PR TITLE
Add Stream & Score volunteer duty

### DIFF
--- a/docs/pr-notes/runs/1008-ci-fix-20260513T000805Z/architecture.md
+++ b/docs/pr-notes/runs/1008-ci-fix-20260513T000805Z/architecture.md
@@ -1,0 +1,5 @@
+# Architecture Notes
+
+Root cause is smoke-test fixture drift, not production schedule rendering. `team.html` now imports Stream & Score grant helpers plus player tracking and staff permission modules; the smoke spec route stubs did not provide those exports/modules, so browser module evaluation stopped before schedule rendering populated `#schedule-list`.
+
+Minimal safe fix: update only `tests/smoke/team-schedule-calendar.spec.js` stubs to match the `team.html` import surface. No production code or data model behavior changes.

--- a/docs/pr-notes/runs/1008-ci-fix-20260513T000805Z/code-plan.md
+++ b/docs/pr-notes/runs/1008-ci-fix-20260513T000805Z/code-plan.md
@@ -1,0 +1,5 @@
+# Code Plan
+
+1. Add no-op `grantStreamScoreAccess` and `revokeStreamScoreAccess` exports to the db stub used by `team-schedule-calendar.spec.js`.
+2. Stub `player-tracking-summary.js` and `team-staff-permissions.js` in the same smoke fixture so `team.html` imports resolve without pulling unrelated production modules into this isolated schedule test.
+3. Re-run the affected Playwright smoke spec.

--- a/docs/pr-notes/runs/1008-ci-fix-20260513T000805Z/qa.md
+++ b/docs/pr-notes/runs/1008-ci-fix-20260513T000805Z/qa.md
@@ -1,0 +1,7 @@
+# QA Notes
+
+Failing check: `preview-smoke [preview-smoke]`.
+
+Validation target: `npx playwright test tests/smoke/team-schedule-calendar.spec.js --config=playwright.smoke.config.js --reporter=line`.
+
+Expected result: both team schedule calendar smoke tests pass, confirming the page bootstraps and the practice, duplicate, cancelled, upcoming, and past-event filter assertions execute against rendered schedule rows instead of a blank placeholder.

--- a/js/db.js
+++ b/js/db.js
@@ -954,6 +954,34 @@ export async function revokeScorekeeperAccess(teamId, memberUserId) {
     });
 }
 
+export async function grantStreamScoreAccess(teamId, memberUserId) {
+    const normalizedUserId = String(memberUserId || '').trim();
+    if (!teamId) throw new Error('Missing team for Stream & Score access');
+    if (!normalizedUserId) throw new Error('Team member user ID is required');
+
+    const docRef = doc(db, "teams", teamId);
+    await updateDoc(docRef, {
+        'teamPermissions.scorekeeping.mode': 'selected',
+        'teamPermissions.scorekeeping.memberIds': arrayUnion(normalizedUserId),
+        'teamPermissions.streaming.mode': 'selected',
+        'teamPermissions.streaming.memberIds': arrayUnion(normalizedUserId),
+        updatedAt: Timestamp.now()
+    });
+}
+
+export async function revokeStreamScoreAccess(teamId, memberUserId) {
+    const normalizedUserId = String(memberUserId || '').trim();
+    if (!teamId) throw new Error('Missing team for Stream & Score access');
+    if (!normalizedUserId) throw new Error('Team member user ID is required');
+
+    const docRef = doc(db, "teams", teamId);
+    await updateDoc(docRef, {
+        'teamPermissions.scorekeeping.memberIds': arrayRemove(normalizedUserId),
+        'teamPermissions.streaming.memberIds': arrayRemove(normalizedUserId),
+        updatedAt: Timestamp.now()
+    });
+}
+
 export async function addOfficial(teamId, officialData) {
     const payload = {
         ...normalizeOfficialDraft(officialData),

--- a/js/db.js
+++ b/js/db.js
@@ -960,13 +960,23 @@ export async function grantStreamScoreAccess(teamId, memberUserId) {
     if (!normalizedUserId) throw new Error('Team member user ID is required');
 
     const docRef = doc(db, "teams", teamId);
-    await updateDoc(docRef, {
+    const teamSnap = await getDoc(docRef);
+    const teamData = teamSnap.exists() ? teamSnap.data() : {};
+    const currentStreamingMode = teamData?.teamPermissions?.streaming?.mode;
+
+    const updatePayload = {
         'teamPermissions.scorekeeping.mode': 'selected',
         'teamPermissions.scorekeeping.memberIds': arrayUnion(normalizedUserId),
-        'teamPermissions.streaming.mode': 'selected',
         'teamPermissions.streaming.memberIds': arrayUnion(normalizedUserId),
         updatedAt: Timestamp.now()
-    });
+    };
+
+    // Only force streaming mode to 'selected' if it's not currently 'all_confirmed'
+    if (currentStreamingMode !== 'all_confirmed') {
+        updatePayload['teamPermissions.streaming.mode'] = 'selected';
+    }
+
+    await updateDoc(docRef, updatePayload);
 }
 
 export async function revokeStreamScoreAccess(teamId, memberUserId) {

--- a/js/team-staff-permissions.js
+++ b/js/team-staff-permissions.js
@@ -27,6 +27,11 @@ function getPermissionGrantLabels(permission) {
     return getUniqueLabels(normalized.memberIds);
 }
 
+function getStreamScoreGrantLabels(permissions) {
+    const scorekeeperGrants = new Set(getPermissionGrantLabels(permissions.scorekeeping));
+    return getPermissionGrantLabels(permissions.streaming).filter((memberId) => scorekeeperGrants.has(memberId));
+}
+
 export function buildTeamStaffPermissionsViewModel(team = {}, pendingAdminInvites = []) {
     const adminEmails = uniqueEmails(team.adminEmails);
     const ownerLabel = normalizeEmail(team.ownerEmail) || String(team.ownerId || '').trim();
@@ -59,6 +64,12 @@ export function buildTeamStaffPermissionsViewModel(team = {}, pendingAdminInvite
                 title: 'Scorekeeper',
                 grants: getPermissionGrantLabels(permissions.scorekeeping),
                 emptyText: 'No scorekeeper helpers are assigned yet.'
+            },
+            {
+                key: 'stream-score',
+                title: 'Stream & Score',
+                grants: getStreamScoreGrantLabels(permissions),
+                emptyText: 'No Stream & Score volunteers are assigned yet.'
             },
             {
                 key: 'videographer',
@@ -105,7 +116,7 @@ export function renderTeamStaffPermissionsSection(container, { team = {}, pendin
             <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-4 mb-6">
                 <div>
                     <h2 class="text-2xl font-bold text-gray-900">Team Staff &amp; Permissions</h2>
-                    <p class="text-sm text-gray-500 mt-1">Full staff admin access is separate from scoped game-day helper permissions for scorekeeping, video, and volunteers.</p>
+                    <p class="text-sm text-gray-500 mt-1">Full staff admin access is separate from scoped game-day helper permissions for scorekeeping, Stream &amp; Score, video, and volunteers.</p>
                 </div>
                 <a href="edit-team.html#teamId=${encodeURIComponent(team.id || '')}" class="inline-flex items-center justify-center rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700 transition">Manage staff</a>
             </div>
@@ -117,11 +128,11 @@ export function renderTeamStaffPermissionsSection(container, { team = {}, pendin
                 </div>
                 <div class="rounded-xl border border-emerald-100 bg-emerald-50 p-4">
                     <h3 class="text-sm font-bold text-emerald-900 uppercase tracking-wide mb-2">Admin vs game-day helpers</h3>
-                    <p class="text-sm text-emerald-800">Admins can manage the team. Scoped helpers are intended for specific game-day jobs and do not grant roster, schedule, RSVP, scoring setup, or full team settings access.</p>
+                    <p class="text-sm text-emerald-800">Admins can manage the team. Scoped helpers are intended for specific game-day jobs. Stream &amp; Score grants only scorekeeping plus streaming capability, not roster, schedule, RSVP, scoring setup, or full team settings access.</p>
                 </div>
             </div>
 
-            <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+            <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
                 ${viewModel.helperPermissions.map((permission) => `
                     <div class="rounded-xl border border-gray-200 bg-gray-50 p-4">
                         <h3 class="text-sm font-bold text-gray-900 uppercase tracking-wide mb-3">${escapeHtml(permission.title)}</h3>

--- a/team.html
+++ b/team.html
@@ -316,7 +316,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=20';
+        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, grantStreamScoreAccess, revokeStreamScoreAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=21';
         import { normalizeExternalWebsiteUrl, selectRotatingSponsor } from './js/local-attractions.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, escapeHtml, shareOrCopy } from './js/utils.js?v=10';
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';
@@ -334,7 +334,7 @@
         import { readTeamPremiumEntitlement, renderPremiumGateState } from './js/premium-entitlements.js?v=1';
         import { renderTeamPassCard } from './js/team-pass.js?v=2';
         import { getVisiblePlayerTrackingSummary } from './js/player-tracking-summary.js?v=1';
-        import { renderTeamStaffPermissionsSection } from './js/team-staff-permissions.js?v=1';
+        import { renderTeamStaffPermissionsSection } from './js/team-staff-permissions.js?v=2';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -384,6 +384,7 @@
         window.closeScheduleDayModal = closeScheduleDayModal;
         window.saveAvailabilityPreferences = saveAvailabilityPreferences;
         window.toggleScorekeeperGrant = toggleScorekeeperGrant;
+        window.toggleStreamScoreGrant = toggleStreamScoreGrant;
 
         function canManageTeamAvailability() {
             return !!currentUser && (
@@ -501,12 +502,22 @@
             }
         }
 
-        function getSelectedScorekeeperIds(team) {
-            const scorekeeping = team?.teamPermissions?.scorekeeping || {};
-            if (scorekeeping.mode !== 'selected') return new Set();
-            return new Set((Array.isArray(scorekeeping.memberIds) ? scorekeeping.memberIds : [])
+        function getSelectedPermissionIds(team, kind) {
+            const permission = team?.teamPermissions?.[kind] || {};
+            if (permission.mode !== 'selected') return new Set();
+            return new Set((Array.isArray(permission.memberIds) ? permission.memberIds : [])
                 .map((id) => String(id || '').trim())
                 .filter(Boolean));
+        }
+
+        function getSelectedScorekeeperIds(team) {
+            return getSelectedPermissionIds(team, 'scorekeeping');
+        }
+
+        function getSelectedStreamScoreIds(team) {
+            const scorekeeperIds = getSelectedPermissionIds(team, 'scorekeeping');
+            const streamingIds = getSelectedPermissionIds(team, 'streaming');
+            return new Set(Array.from(scorekeeperIds).filter((id) => streamingIds.has(id)));
         }
 
         function renderScorekeeperGrantControls(team, players = []) {
@@ -519,6 +530,7 @@
             }
 
             const selectedScorekeeperIds = getSelectedScorekeeperIds(team);
+            const selectedStreamScoreIds = getSelectedStreamScoreIds(team);
             const grantTargets = buildScorekeeperGrantTargets(players, currentTeamMemberUsers, currentTeamId);
 
             section.classList.remove('hidden');
@@ -526,26 +538,35 @@
                 <div class="bg-white rounded-2xl shadow-md border border-gray-200 p-6">
                     <div class="flex flex-col md:flex-row md:items-start md:justify-between gap-3 mb-4">
                         <div>
-                            <h2 class="text-xl font-bold text-gray-900">Scorekeeper access</h2>
-                            <p class="text-sm text-gray-500 mt-1">Grant an existing team member scorekeeping access without making them a team admin.</p>
+                            <h2 class="text-xl font-bold text-gray-900">Game-day helper access</h2>
+                            <p class="text-sm text-gray-500 mt-1">Grant an existing team member scorekeeping or Stream &amp; Score duty without making them a team admin.</p>
                         </div>
                     </div>
                     ${grantTargets.length ? `
                         <div class="divide-y divide-gray-100 border border-gray-100 rounded-xl overflow-hidden">
                             ${grantTargets.map((target) => {
-                                const granted = selectedScorekeeperIds.has(target.userId);
+                                const scorekeeperGranted = selectedScorekeeperIds.has(target.userId);
+                                const streamScoreGranted = selectedStreamScoreIds.has(target.userId);
                                 const detail = target.playerNames.length
                                     ? `Linked to ${target.playerNames.join(', ')}.`
                                     : 'Linked team member account.';
+                                const dutyText = streamScoreGranted
+                                    ? `Can stream and score games. ${detail}`
+                                    : (scorekeeperGranted ? `Can score games. ${detail}` : `No game-day helper grant. ${detail}`);
                                 return `
-                                    <div class="flex items-center justify-between gap-3 p-3">
+                                    <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 p-3">
                                         <div class="min-w-0">
                                             <div class="font-semibold text-gray-900 truncate">${escapeHtml(target.name || 'Team member')}</div>
-                                            <div class="text-xs text-gray-500">${escapeHtml(granted ? `Can score games. ${detail}` : `No scorekeeper grant. ${detail}`)}</div>
+                                            <div class="text-xs text-gray-500">${escapeHtml(dutyText)}</div>
                                         </div>
-                                        <button type="button" data-member-user-id="${escapeAttr(target.userId)}" data-granted="${granted ? 'true' : 'false'}" onclick="toggleScorekeeperGrant(this)" class="shrink-0 px-3 py-1.5 text-sm font-semibold rounded-lg border transition ${granted ? 'border-red-200 text-red-700 bg-red-50 hover:bg-red-100' : 'border-primary-200 text-primary-700 bg-primary-50 hover:bg-primary-100'}">
-                                            ${granted ? 'Revoke' : 'Grant'}
-                                        </button>
+                                        <div class="flex flex-wrap gap-2 shrink-0">
+                                            <button type="button" data-member-user-id="${escapeAttr(target.userId)}" data-granted="${scorekeeperGranted ? 'true' : 'false'}" onclick="toggleScorekeeperGrant(this)" class="px-3 py-1.5 text-sm font-semibold rounded-lg border transition ${scorekeeperGranted ? 'border-red-200 text-red-700 bg-red-50 hover:bg-red-100' : 'border-primary-200 text-primary-700 bg-primary-50 hover:bg-primary-100'}">
+                                                ${scorekeeperGranted ? 'Revoke scorekeeper' : 'Grant scorekeeper'}
+                                            </button>
+                                            <button type="button" data-member-user-id="${escapeAttr(target.userId)}" data-granted="${streamScoreGranted ? 'true' : 'false'}" onclick="toggleStreamScoreGrant(this)" class="px-3 py-1.5 text-sm font-semibold rounded-lg border transition ${streamScoreGranted ? 'border-red-200 text-red-700 bg-red-50 hover:bg-red-100' : 'border-emerald-200 text-emerald-700 bg-emerald-50 hover:bg-emerald-100'}">
+                                                ${streamScoreGranted ? 'Revoke Stream & Score' : 'Assign Stream & Score'}
+                                            </button>
+                                        </div>
                                     </div>
                                 `;
                             }).join('')}
@@ -592,6 +613,52 @@
             } catch (err) {
                 button.disabled = false;
                 if (status) status.textContent = `Unable to update scorekeeper access: ${err?.message || err}`;
+            }
+        }
+
+        async function toggleStreamScoreGrant(button) {
+            if (!button || button.disabled || !currentTeamId) return;
+            const memberUserId = String(button.dataset.memberUserId || '').trim();
+            if (!memberUserId) return;
+            const wasGranted = button.dataset.granted === 'true';
+            const status = document.getElementById('team-scorekeeper-status');
+            try {
+                button.disabled = true;
+                if (status) status.textContent = wasGranted ? 'Revoking Stream & Score duty...' : 'Assigning Stream & Score duty...';
+                if (wasGranted) {
+                    await revokeStreamScoreAccess(currentTeamId, memberUserId);
+                } else {
+                    await grantStreamScoreAccess(currentTeamId, memberUserId);
+                }
+                const nextScorekeeperIds = getSelectedScorekeeperIds(currentTeam);
+                const nextStreamingIds = getSelectedPermissionIds(currentTeam, 'streaming');
+                if (wasGranted) {
+                    nextScorekeeperIds.delete(memberUserId);
+                    nextStreamingIds.delete(memberUserId);
+                } else {
+                    nextScorekeeperIds.add(memberUserId);
+                    nextStreamingIds.add(memberUserId);
+                }
+                currentTeam = {
+                    ...currentTeam,
+                    teamPermissions: {
+                        ...(currentTeam?.teamPermissions || {}),
+                        scorekeeping: {
+                            mode: 'selected',
+                            memberIds: Array.from(nextScorekeeperIds)
+                        },
+                        streaming: {
+                            mode: 'selected',
+                            memberIds: Array.from(nextStreamingIds)
+                        }
+                    }
+                };
+                renderScorekeeperGrantControls(currentTeam, currentPlayers);
+                const nextStatus = document.getElementById('team-scorekeeper-status');
+                if (nextStatus) nextStatus.textContent = wasGranted ? 'Stream & Score duty revoked.' : 'Stream & Score duty assigned.';
+            } catch (err) {
+                button.disabled = false;
+                if (status) status.textContent = `Unable to update Stream & Score duty: ${err?.message || err}`;
             }
         }
 

--- a/tests/smoke/team-schedule-calendar.spec.js
+++ b/tests/smoke/team-schedule-calendar.spec.js
@@ -96,6 +96,14 @@ export async function revokeScorekeeperAccess() {
     return undefined;
 }
 
+export async function grantStreamScoreAccess() {
+    return undefined;
+}
+
+export async function revokeStreamScoreAccess() {
+    return undefined;
+}
+
 export async function getRsvps() {
     return [];
 }
@@ -344,6 +352,16 @@ const TEAM_PASS_STUB = `
 export function renderTeamPassCard() {}
 `;
 
+const PLAYER_TRACKING_SUMMARY_STUB = `
+export function getVisiblePlayerTrackingSummary() {
+    return [];
+}
+`;
+
+const TEAM_STAFF_PERMISSIONS_STUB = `
+export function renderTeamStaffPermissionsSection() {}
+`;
+
 const LOCAL_ATTRACTIONS_STUB = `
 export function normalizeExternalWebsiteUrl(value) {
     return value || '';
@@ -444,6 +462,16 @@ async function mockTeamPageModules(page, scenario) {
         status: 200,
         contentType: 'application/javascript',
         body: TEAM_PASS_STUB
+    }));
+    await page.route('**/js/player-tracking-summary.js?v=*', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: PLAYER_TRACKING_SUMMARY_STUB
+    }));
+    await page.route('**/js/team-staff-permissions.js?v=*', (route) => route.fulfill({
+        status: 200,
+        contentType: 'application/javascript',
+        body: TEAM_STAFF_PERMISSIONS_STUB
     }));
 }
 

--- a/tests/unit/team-scorekeeper-grants.test.js
+++ b/tests/unit/team-scorekeeper-grants.test.js
@@ -38,7 +38,8 @@ function loadScorekeeperHelpers() {
                 email: target.email,
                 playerNames: target.playerNames
             })),
-            selectedIds: Array.from(getSelectedScorekeeperIds(context.team))
+            selectedIds: Array.from(getSelectedScorekeeperIds(context.team)),
+            selectedStreamScoreIds: Array.from(getSelectedStreamScoreIds(context.team))
         };
     `);
 }
@@ -50,7 +51,11 @@ describe('team scorekeeper grants', () => {
         expect(source).toContain('id="team-scorekeeper-section"');
         expect(source).toContain('grantScorekeeperAccess');
         expect(source).toContain('revokeScorekeeperAccess');
+        expect(source).toContain('grantStreamScoreAccess');
+        expect(source).toContain('revokeStreamScoreAccess');
         expect(source).toContain('window.toggleScorekeeperGrant = toggleScorekeeperGrant;');
+        expect(source).toContain('window.toggleStreamScoreGrant = toggleStreamScoreGrant;');
+        expect(source).toContain('Assign Stream & Score');
         expect(source).toContain('renderScorekeeperGrantControls(team, players);');
     });
 
@@ -61,7 +66,12 @@ describe('team scorekeeper grants', () => {
             currentUser: { uid: 'coach-1' },
             currentTeamAccessInfo: { hasAccess: true, accessLevel: 'full' },
             player: { name: 'Player', authUid: ' member-1 ' },
-            team: { teamPermissions: { scorekeeping: { mode: 'selected', memberIds: [' member-1 '] } } }
+            team: {
+                teamPermissions: {
+                    scorekeeping: { mode: 'selected', memberIds: [' member-1 '] },
+                    streaming: { mode: 'selected', memberIds: ['member-1'] }
+                }
+            }
         })).toEqual({
             canManageScorekeeperGrants: true,
             memberUserId: 'member-1',
@@ -71,7 +81,8 @@ describe('team scorekeeper grants', () => {
                 email: '',
                 playerNames: ['Player']
             }],
-            selectedIds: ['member-1']
+            selectedIds: ['member-1'],
+            selectedStreamScoreIds: ['member-1']
         });
 
         expect(helpers({

--- a/tests/unit/team-staff-permissions.test.js
+++ b/tests/unit/team-staff-permissions.test.js
@@ -8,8 +8,8 @@ describe('team staff and permissions view model', () => {
             ownerEmail: 'Owner@Example.com',
             adminEmails: [' Coach@Example.com ', 'coach@example.com'],
             teamPermissions: {
-                scorekeeping: { mode: 'selected', memberIds: [' scorekeeper-1 ', 'scorekeeper-1'] },
-                streaming: { mode: 'selected', memberIds: ['video-1'] },
+                scorekeeping: { mode: 'selected', memberIds: [' scorekeeper-1 ', 'stream-score-1', 'scorekeeper-1'] },
+                streaming: { mode: 'selected', memberIds: ['video-1', 'stream-score-1'] },
                 volunteer: { mode: 'selected', memberIds: ['snacks-1'] }
             },
             streamVolunteerEmails: ['video@example.com']
@@ -25,8 +25,9 @@ describe('team staff and permissions view model', () => {
         ]);
         expect(viewModel.pendingInvites).toEqual(['pending@example.com', 'coach@example.com']);
         expect(viewModel.helperPermissions).toEqual([
-            expect.objectContaining({ key: 'scorekeeper', grants: ['scorekeeper-1'] }),
-            expect.objectContaining({ key: 'videographer', grants: ['video-1', 'video@example.com'] }),
+            expect.objectContaining({ key: 'scorekeeper', grants: ['scorekeeper-1', 'stream-score-1'] }),
+            expect.objectContaining({ key: 'stream-score', grants: ['stream-score-1'] }),
+            expect.objectContaining({ key: 'videographer', grants: ['video-1', 'stream-score-1', 'video@example.com'] }),
             expect.objectContaining({ key: 'volunteer', grants: ['snacks-1'] })
         ]);
     });
@@ -60,6 +61,7 @@ describe('team staff and permissions view model', () => {
         expect(container.classList.contains('hidden')).toBe(false);
         expect(container.innerHTML).toContain('No owner, admin staff, or pending admin invites found.');
         expect(container.innerHTML).toContain('No scorekeeper helpers are assigned yet.');
+        expect(container.innerHTML).toContain('No Stream &amp; Score volunteers are assigned yet.');
         expect(container.innerHTML).toContain('No videographer helpers are assigned yet.');
         expect(container.innerHTML).toContain('No general volunteer permissions are assigned yet.');
         expect(container.innerHTML).toContain('Full staff admin access is separate from scoped game-day helper permissions');


### PR DESCRIPTION
Closes #1002

## Summary
- Added a team admin Stream & Score duty assignment from the team helper access panel.
- Reused existing scoped scorekeeping and streaming permissions by granting/removing both selected-member permission lists together.
- Updated staff permissions display to distinguish Stream & Score volunteers from full Staff access, Scorekeeper, Videographer, and Volunteer roles.

## Validation
- `npm test -- --run tests/unit/team-access.test.js tests/unit/team-staff-permissions.test.js tests/unit/team-scorekeeper-grants.test.js`
- `node scripts/check-critical-cache-bust.mjs`
- `git diff --check`