### PR TITLE
Mark live tracker zero-stat appearances

### DIFF
--- a/js/live-tracker-finish.js
+++ b/js/live-tracker-finish.js
@@ -113,16 +113,30 @@ export function buildFinishCompletionPlan({
     });
     statsObj.fouls = safeStatsByPlayerId[player.id]?.fouls || 0;
 
+    const playerTimeMs = safeStatsByPlayerId[player.id]?.time || 0;
+    let hasNonZeroStats = false;
+    safeColumns.forEach((col) => {
+      const key = col.toLowerCase();
+      if ((safeStatsByPlayerId[player.id]?.[key] || 0) > 0) {
+        hasNonZeroStats = true;
+      }
+    });
+    if ((safeStatsByPlayerId[player.id]?.fouls || 0) > 0) {
+      hasNonZeroStats = true;
+    }
+
+    const actuallyParticipated = playerTimeMs > 0 || hasNonZeroStats;
+
     return {
       playerId: player.id,
       data: {
         playerName: player.name,
         playerNumber: player.num,
-        participated: true,
-        participationStatus: 'appeared',
+        participated: actuallyParticipated,
+        participationStatus: actuallyParticipated ? 'appeared' : 'did-not-appear',
         participationSource: 'live-tracker-finish',
         stats: statsObj,
-        timeMs: safeStatsByPlayerId[player.id]?.time || 0
+        timeMs: playerTimeMs
       }
     };
   });

--- a/js/live-tracker-finish.js
+++ b/js/live-tracker-finish.js
@@ -118,6 +118,9 @@ export function buildFinishCompletionPlan({
       data: {
         playerName: player.name,
         playerNumber: player.num,
+        participated: true,
+        participationStatus: 'appeared',
+        participationSource: 'live-tracker-finish',
         stats: statsObj,
         timeMs: safeStatsByPlayerId[player.id]?.time || 0
       }

--- a/js/live-tracker-finish.js
+++ b/js/live-tracker-finish.js
@@ -125,7 +125,7 @@ export function buildFinishCompletionPlan({
       hasNonZeroStats = true;
     }
 
-    const actuallyParticipated = playerTimeMs > 0 || hasNonZeroStats;
+        const actuallyParticipated = !!safeStatsByPlayerId[player.id];
 
     return {
       playerId: player.id,

--- a/js/live-tracker-save-complete.js
+++ b/js/live-tracker-save-complete.js
@@ -1,6 +1,6 @@
 import { acquireSingleFlightLock, releaseSingleFlightLock } from './live-tracker-integrity.js?v=3';
 import { resolveSummaryRecipient } from './live-tracker-email.js?v=2';
-import { buildFinishCompletionPlan, executeFinishNavigationPlan } from './live-tracker-finish.js?v=2';
+import { buildFinishCompletionPlan, executeFinishNavigationPlan } from './live-tracker-finish.js?v=3';
 
 function defaultFormatClock(ms) {
   const s = Math.floor(ms / 1000);

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -17,7 +17,7 @@ import { advanceLiveChatUnreadState } from './live-tracker-chat-unread.js?v=2';
 import { buildVideoTimestampMetadata, hasConfiguredLiveStream } from './live-stream-utils.js?v=2';
 import { resolveLiveStatConfig, resolveLiveStatColumns } from './live-game-state.js?v=3';
 import { getDefaultLivePeriod, getSportPeriodLabels } from './live-sport-config.js?v=1';
-import { buildOpponentStatsSnapshotFromEntries } from './live-tracker-finish.js?v=2';
+import { buildOpponentStatsSnapshotFromEntries } from './live-tracker-finish.js?v=3';
 import {
   readPersistedLiveTrackerQueue,
   writePersistedLiveTrackerQueue,

--- a/test-track-zero-stat-player-history.js
+++ b/test-track-zero-stat-player-history.js
@@ -1,3 +1,6 @@
+import { buildFinishCompletionPlan } from './js/live-tracker-finish.js';
+import { hasPlayerProfileParticipation } from './js/player-profile-stats.js';
+
 const results = [];
 
 function test(name, fn) {
@@ -90,6 +93,60 @@ test('zero-stat players get zeroed configured stats', () => {
         writes[0].data.stats,
         { pts: 0, reb: 0, ast: 0 },
         'Scoreless player should still get a zeroed stats object'
+    );
+});
+
+test('standard finish writes zero-stat appearances with player profile participation markers', () => {
+    const plan = buildFinishCompletionPlan({
+        requestedHome: 0,
+        requestedAway: 0,
+        liveHome: 0,
+        liveAway: 0,
+        scoreLogIsComplete: true,
+        log: [],
+        columns: ['PTS', 'REB', 'AST'],
+        roster: [{ id: 'player-b', name: 'Player B', num: '34' }],
+        statsByPlayerId: {
+            'player-b': { pts: 0, reb: 0, ast: 0, fouls: 0, time: 0 }
+        },
+        opponentEntries: []
+    });
+
+    assertDeepEquals(
+        plan.aggregatedStatsWrites[0].data,
+        {
+            playerName: 'Player B',
+            playerNumber: '34',
+            participated: true,
+            participationStatus: 'appeared',
+            participationSource: 'live-tracker-finish',
+            stats: { pts: 0, reb: 0, ast: 0, fouls: 0 },
+            timeMs: 0
+        },
+        'Standard finish zero-stat write should include explicit profile participation markers'
+    );
+    assertEquals(
+        hasPlayerProfileParticipation(plan.aggregatedStatsWrites[0].data),
+        true,
+        'Standard finish zero-stat write should be accepted as a player profile appearance'
+    );
+});
+
+test('standard finish zero-stat aggregate readback stays visible in player history', () => {
+    const aggregateDoc = {
+        playerName: 'Player B',
+        playerNumber: '34',
+        participated: true,
+        participationStatus: 'appeared',
+        participationSource: 'live-tracker-finish',
+        stats: { pts: 0, reb: 0, ast: 0, fouls: 0 },
+        timeMs: 0
+    };
+
+    assertEquals(
+        hasPlayerProfileParticipation(aggregateDoc),
+        true,
+        'Player profile history should include standard finish zero-stat appearances'
     );
 });
 

--- a/tests/unit/live-tracker-finish.test.js
+++ b/tests/unit/live-tracker-finish.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { buildFinishCompletionPlan, prepareFinishPlanForSave } from '../../js/live-tracker-finish.js';
+import { hasPlayerProfileParticipation } from '../../js/player-profile-stats.js';
 
 describe('live tracker finish completion plan', () => {
   it('honors a coach-entered final score when it differs from the live score log totals', () => {
@@ -84,6 +85,9 @@ describe('live tracker finish completion plan', () => {
         data: {
           playerName: 'Alex',
           playerNumber: '4',
+          participated: true,
+          participationStatus: 'appeared',
+          participationSource: 'live-tracker-finish',
           stats: { pts: 2, ast: 1, fouls: 0 },
           timeMs: 123000
         }
@@ -93,6 +97,9 @@ describe('live tracker finish completion plan', () => {
         data: {
           playerName: 'Jamie',
           playerNumber: '7',
+          participated: true,
+          participationStatus: 'appeared',
+          participationSource: 'live-tracker-finish',
           stats: { pts: 3, ast: 0, fouls: 2 },
           timeMs: 118000
         }
@@ -101,6 +108,55 @@ describe('live tracker finish completion plan', () => {
     expect(plan.navigation).toEqual([
       { type: 'redirect', href: 'game.html#teamId=team-1&gameId=game-9', delayMs: 0 }
     ]);
+  });
+
+  it('marks standard live-tracker zero-stat aggregate writes as profile appearances', () => {
+    const plan = buildFinishCompletionPlan({
+      requestedHome: 0,
+      requestedAway: 0,
+      liveHome: 0,
+      liveAway: 0,
+      scoreLogIsComplete: true,
+      log: [],
+      columns: ['PTS', 'REB', 'AST'],
+      roster: [
+        { id: 'p-zero', name: 'Zero Stat', num: '12' }
+      ],
+      statsByPlayerId: {
+        'p-zero': { pts: 0, reb: 0, ast: 0, fouls: 0, time: 0 }
+      },
+      opponentEntries: []
+    });
+
+    expect(plan.aggregatedStatsWrites).toEqual([
+      {
+        playerId: 'p-zero',
+        data: {
+          playerName: 'Zero Stat',
+          playerNumber: '12',
+          participated: true,
+          participationStatus: 'appeared',
+          participationSource: 'live-tracker-finish',
+          stats: { pts: 0, reb: 0, ast: 0, fouls: 0 },
+          timeMs: 0
+        }
+      }
+    ]);
+    expect(hasPlayerProfileParticipation(plan.aggregatedStatsWrites[0].data)).toBe(true);
+  });
+
+  it('keeps standard finish aggregate readback visible in player profile history', () => {
+    const standardFinishAggregateDoc = {
+      playerName: 'Zero Stat',
+      playerNumber: '12',
+      participated: true,
+      participationStatus: 'appeared',
+      participationSource: 'live-tracker-finish',
+      stats: { pts: 0, reb: 0, ast: 0, fouls: 0 },
+      timeMs: 0
+    };
+
+    expect(hasPlayerProfileParticipation(standardFinishAggregateDoc)).toBe(true);
   });
 
   it('preserves video timestamp metadata on persisted scoring events', () => {


### PR DESCRIPTION
Closes #1010

## Summary
- Add explicit participation markers to standard live-tracker aggregate stat writes.
- Cover zero-stat live-tracker readback through player profile participation filtering.
- Bump live-tracker finish import versions so the updated module is loaded.

## Tests
- `node test-track-zero-stat-player-history.js`
- `npx vitest run tests/unit/live-tracker-finish.test.js tests/unit/live-tracker-save-complete.test.js --reporter=dot`