### PR TITLE
Route signed-out invite links directly to login

### DIFF
--- a/accept-invite.html
+++ b/accept-invite.html
@@ -74,6 +74,25 @@
                 </form>
             </div>
 
+            <!-- Signed-out invite link state -->
+            <div id="invite-link-state" class="hidden text-center">
+                <h1 class="text-2xl font-bold mb-4">Join Your Team</h1>
+                <p class="text-gray-600 text-sm mb-4">
+                    We found your invite link. Sign in or create an account to finish joining this team.
+                </p>
+                <p class="text-xs text-gray-500 mb-4">
+                    Invite code: <span id="invite-code-confirmation" class="font-mono font-semibold tracking-widest"></span>
+                </p>
+                <a id="continue-invite-link" href="login.html"
+                    class="block w-full bg-indigo-600 text-white py-2 px-4 rounded-md hover:bg-indigo-700 transition">
+                    Sign in or create account to join team
+                </a>
+                <button type="button" id="enter-different-code-btn"
+                    class="mt-3 text-sm text-indigo-600 hover:underline">
+                    Enter a different code
+                </button>
+            </div>
+
             <!-- Manual Code Entry State (fallback) -->
             <div id="manual-code-state" class="hidden">
                 <h1 class="text-2xl font-bold mb-4 text-center">Enter Invite Code</h1>
@@ -147,24 +166,40 @@
         const urlParams = new URLSearchParams(window.location.search);
         const inviteCode = urlParams.get('code') || window.localStorage.getItem('inviteCode');
         const inviteType = urlParams.get('type') || window.localStorage.getItem('inviteType') || 'parent';
+        const normalizedInviteCode = String(inviteCode || '').trim().toUpperCase();
+        const normalizedInviteType = String(inviteType || 'parent').trim().toLowerCase();
+
+        function getLoginUrlForInvite(code = normalizedInviteCode, type = normalizedInviteType) {
+            const loginParams = new URLSearchParams();
+            loginParams.set('code', String(code).trim().toUpperCase());
+            loginParams.set('type', String(type || 'parent').trim().toLowerCase());
+            return `login.html?${loginParams.toString()}`;
+        }
 
         const signupLink = document.getElementById('signup-link');
-        if (signupLink && inviteCode) {
-            const signupParams = new URLSearchParams();
-            signupParams.set('code', String(inviteCode).trim().toUpperCase());
-            signupParams.set('type', String(inviteType).trim().toLowerCase());
-            signupLink.href = `login.html?${signupParams.toString()}`;
+        if (signupLink && normalizedInviteCode) {
+            signupLink.href = getLoginUrlForInvite();
+        }
+
+        const continueInviteLink = document.getElementById('continue-invite-link');
+        const inviteCodeConfirmation = document.getElementById('invite-code-confirmation');
+        if (continueInviteLink && normalizedInviteCode) {
+            continueInviteLink.href = getLoginUrlForInvite();
+        }
+        if (inviteCodeConfirmation && normalizedInviteCode) {
+            inviteCodeConfirmation.textContent = normalizedInviteCode;
         }
 
         // State elements
         const loadingState = document.getElementById('loading-state');
         const emailRequiredState = document.getElementById('email-required-state');
+        const inviteLinkState = document.getElementById('invite-link-state');
         const manualCodeState = document.getElementById('manual-code-state');
         const successState = document.getElementById('success-state');
         const errorState = document.getElementById('error-state');
 
         function showState(state) {
-            [loadingState, emailRequiredState, manualCodeState, successState, errorState].forEach(s => s.classList.add('hidden'));
+            [loadingState, emailRequiredState, inviteLinkState, manualCodeState, successState, errorState].forEach(s => s.classList.add('hidden'));
             state.classList.remove('hidden');
         }
 
@@ -285,9 +320,8 @@
                         // User is logged in but no invite code
                         showState(manualCodeState);
                     } else if (inviteCode) {
-                        // Has invite code but not logged in - show manual entry
-                        showState(manualCodeState);
-                        document.getElementById('code-input').value = inviteCode;
+                        // Has invite code but not logged in - continue account access first
+                        showState(inviteLinkState);
                     } else {
                         // No invite code, not logged in
                         showState(manualCodeState);
@@ -363,7 +397,7 @@
             checkAuth(async (user) => {
                 if (!user) {
                     // Not logged in - redirect to login with the code
-                    window.location.href = `login.html?code=${code}&type=${encodeURIComponent(inviteType)}`;
+                    window.location.href = getLoginUrlForInvite(code, inviteType);
                     return;
                 }
 
@@ -384,6 +418,12 @@
 
         // Handle "try manual code" button
         document.getElementById('try-manual-code-btn').addEventListener('click', () => {
+            showState(manualCodeState);
+        });
+
+        // Handle signed-out invite link fallback
+        document.getElementById('enter-different-code-btn').addEventListener('click', () => {
+            document.getElementById('code-input').value = '';
             showState(manualCodeState);
         });
 

--- a/tests/unit/accept-invite-page.test.js
+++ b/tests/unit/accept-invite-page.test.js
@@ -144,6 +144,7 @@ function createEnvironment({ href, storage } = {}) {
         'footer-container',
         'loading-state',
         'email-required-state',
+        'invite-link-state',
         'manual-code-state',
         'success-state',
         'error-state',
@@ -158,6 +159,9 @@ function createEnvironment({ href, storage } = {}) {
         'success-message',
         'error-message',
         'try-manual-code-btn',
+        'enter-different-code-btn',
+        'continue-invite-link',
+        'invite-code-confirmation',
         'signup-link'
     ];
 
@@ -294,14 +298,17 @@ describe('accept-invite page parent flow', () => {
         expect(window.location.href).toBe('http://example.com/parent-dashboard.html');
     });
 
-    it('preserves the invite context on the signed-out signup link', async () => {
+    it('shows the link-first continue state for signed-out parent invite links', async () => {
         const loggedOut = await bootAcceptInvite({
             href: 'http://example.com/accept-invite.html?code=ab12cd34&type=parent',
             authUser: null
         });
 
-        expect(loggedOut.elements.get('signup-link').href).toBe('login.html?code=AB12CD34&type=parent');
-        expect(loggedOut.elements.get('code-input').value).toBe('ab12cd34');
+        expect(loggedOut.elements.get('invite-link-state').classList.contains('hidden')).toBe(false);
+        expect(loggedOut.elements.get('manual-code-state').classList.contains('hidden')).toBe(true);
+        expect(loggedOut.elements.get('invite-code-confirmation').textContent).toBe('AB12CD34');
+        expect(loggedOut.elements.get('continue-invite-link').href).toBe('login.html?code=AB12CD34&type=parent');
+        expect(loggedOut.elements.get('code-input').value).toBe('');
     });
 
     it('uppercases the manual code for login redirect and redeems exactly once after the user returns authenticated', async () => {
@@ -369,7 +376,17 @@ describe('accept-invite page admin flow', () => {
         expect(window.location.href).toBe('http://example.com/dashboard.html');
     });
 
-    it('preserves the admin invite type when a signed-out user submits a manual code', async () => {
+    it('preserves the admin invite type on the signed-out continue link', async () => {
+        const loggedOut = await bootAcceptInvite({
+            href: 'http://example.com/accept-invite.html?code=exist111&type=admin',
+            authUser: null
+        });
+
+        expect(loggedOut.elements.get('invite-link-state').classList.contains('hidden')).toBe(false);
+        expect(loggedOut.elements.get('continue-invite-link').href).toBe('login.html?code=EXIST111&type=admin');
+    });
+
+    it('preserves the admin invite type when a signed-out user submits a different manual code', async () => {
         const loggedOut = await bootAcceptInvite({
             href: 'http://example.com/accept-invite.html?code=exist111&type=admin',
             authUser: null,
@@ -385,9 +402,11 @@ describe('accept-invite page admin flow', () => {
             }
         });
 
+        await loggedOut.elements.get('enter-different-code-btn').dispatchEvent(new MockEvent('click'));
+        loggedOut.elements.get('code-input').value = 'new11122';
         await loggedOut.elements.get('code-form').dispatchEvent(new MockEvent('submit'));
 
-        expect(loggedOut.window.location.href).toBe('http://example.com/login.html?code=EXIST111&type=admin');
+        expect(loggedOut.window.location.href).toBe('http://example.com/login.html?code=NEW11122&type=admin');
     });
 
     it('completes cross-device email-link admin redemption after the user confirms their email', async () => {


### PR DESCRIPTION
Closes #1012

## Summary
- Added a signed-out invite-link continue state on `accept-invite.html` when a code is already present.
- Routes the primary CTA to `login.html` with normalized invite code and type preserved.
- Keeps manual code entry available behind an `Enter a different code` affordance.

## Tests
- `npm test -- tests/unit/accept-invite-page.test.js`