### PR TITLE
Add registration discount previews

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -269,7 +269,7 @@
                     <div>
                         <p class="text-sm font-semibold uppercase tracking-wide text-primary-600">Registration setup</p>
                         <h2 class="text-2xl font-bold text-gray-900"><span id="registration-team-name">Team</span> forms</h2>
-                        <p class="mt-1 text-sm text-gray-600">Create draft or published parent registration links without checkout or roster automation.</p>
+                        <p class="mt-1 text-sm text-gray-600">Create draft or published parent registration links without payment processing or roster automation.</p>
                     </div>
                     <button onclick="window.closeRegistrationFormsAdmin()" class="rounded px-2 py-1 text-gray-500 hover:bg-gray-100" aria-label="Close registration form setup">✕</button>
                 </div>
@@ -325,11 +325,16 @@
                             <div class="mb-3 flex items-start justify-between gap-3">
                                 <div>
                                     <h4 class="text-sm font-semibold text-gray-900">Registration options</h4>
-                                    <p class="text-xs text-gray-500">Define capacity and waitlist setup for options. Public checkout behavior is unchanged.</p>
+                                    <p class="text-xs text-gray-500">Define capacity and waitlist setup for options. Public payment behavior is unchanged.</p>
                                 </div>
                                 <button type="button" onclick="window.addRegistrationOptionAdmin()" class="rounded bg-gray-100 px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-200">Add option</button>
                             </div>
                             <div id="registration-options-list" class="space-y-3"></div>
+                        </div>
+                        <div>
+                            <label for="registration-discount-rules" class="block text-sm font-medium text-gray-700">Discount rules</label>
+                            <textarea id="registration-discount-rules" rows="3" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Early bird before 2026-03-01: $25\nSibling/cart discount 2+: 10%"></textarea>
+                            <p class="mt-1 text-xs text-gray-500">Optional. Supports early-bird deadlines and quantity discounts for public fee previews.</p>
                         </div>
                         <div>
                             <label for="registration-waiver" class="block text-sm font-medium text-gray-700">Waiver text</label>

--- a/docs/pr-notes/runs/1020-remediator-20260513T040807Z/architecture.md
+++ b/docs/pr-notes/runs/1020-remediator-20260513T040807Z/architecture.md
@@ -1,0 +1,13 @@
+# Architecture notes
+
+## Current design
+Payment settings are represented as bounded booleans: `offlinePaymentEnabled` and `onlineCheckoutEnabled`.
+
+## Data flow
+Admin configuration is saved on registration forms, normalized for legacy/malformed values, and snapshotted into public registration records with fee/program context.
+
+## Control posture
+No payment transaction, provider token, PHI, or financial instrument data is introduced. Firestore rules constrain public writes to the expected payment settings shape using allowlists and boolean checks.
+
+## Risk and rollback
+Blast radius is limited to copy/configuration and registration snapshots. If needed, rollback is a branch revert with no data migration because missing settings normalize to disabled.

--- a/docs/pr-notes/runs/1020-remediator-20260513T040807Z/code-plan.md
+++ b/docs/pr-notes/runs/1020-remediator-20260513T040807Z/code-plan.md
@@ -1,0 +1,13 @@
+# Code plan
+
+## Review synthesis
+Amazon Q provided a positive review summary with no blocking issues or requested code changes.
+
+## Implementation decision
+Do not alter payment settings runtime code. Persist the required role-analysis notes for traceability and validate the affected test/rules gates.
+
+## Files intentionally changed
+- `docs/pr-notes/runs/1020-remediator-20260513T040807Z/requirements.md`
+- `docs/pr-notes/runs/1020-remediator-20260513T040807Z/architecture.md`
+- `docs/pr-notes/runs/1020-remediator-20260513T040807Z/qa.md`
+- `docs/pr-notes/runs/1020-remediator-20260513T040807Z/code-plan.md`

--- a/docs/pr-notes/runs/1020-remediator-20260513T040807Z/qa.md
+++ b/docs/pr-notes/runs/1020-remediator-20260513T040807Z/qa.md
@@ -1,0 +1,20 @@
+# QA notes
+
+## Automated validation
+Run focused unit coverage for payment settings and registration flow:
+
+```bash
+npx vitest run tests/unit/admin-registration-forms.test.js tests/unit/registration-flow.test.js --reporter=dot
+```
+
+Run Firestore rules validation when available:
+
+```bash
+npm run ci:firebase-rules
+```
+
+## Manual validation
+1. Admin creates/edits registration forms with offline payment on/off and online checkout on/off.
+2. Public form shows correct copy for offline-only, online-planned-only, both, and neither.
+3. Submission stores only normalized payment settings in the registration snapshot.
+4. UI does not imply live online payment processing is currently available.

--- a/docs/pr-notes/runs/1020-remediator-20260513T040807Z/requirements.md
+++ b/docs/pr-notes/runs/1020-remediator-20260513T040807Z/requirements.md
@@ -1,0 +1,16 @@
+# Requirements notes
+
+## Acceptance criteria
+1. Admin registration setup exposes bounded payment settings for offline payment and future online checkout intent.
+2. Registration form payloads persist normalized boolean payment settings.
+3. Existing forms without payment settings normalize to disabled.
+4. Public registration submissions snapshot bounded payment settings.
+5. Admin and public copy clearly avoid implying live checkout exists today.
+6. Firestore public registration payload validation accepts only the bounded payment settings shape.
+7. Existing unit coverage verifies admin normalization, public normalization, snapshotting, UI hooks, and rules coverage.
+
+## Review finding
+Amazon Q reported no blocking issues. No product requirement change is needed for this remediator pass.
+
+## Non-goals
+Stripe checkout sessions, payment webhooks, payment status mutation, installments, discounts, roster automation, and document upload remain out of scope.

--- a/firestore.rules
+++ b/firestore.rules
@@ -327,6 +327,56 @@ service cloud.firestore {
              option.waitlistEnabled is bool;
     }
 
+
+    function isRegistrationDiscountApplicationValid(discount) {
+      return discount is map &&
+             discount.keys().hasOnly(['id', 'type', 'label', 'amountType', 'amountValue', 'amountCents']) &&
+             discount.id is string &&
+             discount.type in ['early_bird', 'quantity'] &&
+             discount.label is string &&
+             discount.amountType in ['fixed', 'percent'] &&
+             (discount.amountValue is int || discount.amountValue is float) &&
+             discount.amountCents is int &&
+             discount.amountCents >= 0;
+    }
+
+    function areRegistrationDiscountApplicationsValid(discounts) {
+      return discounts is list &&
+             discounts.size() <= 10 &&
+             (discounts.size() < 1 || isRegistrationDiscountApplicationValid(discounts[0])) &&
+             (discounts.size() < 2 || isRegistrationDiscountApplicationValid(discounts[1])) &&
+             (discounts.size() < 3 || isRegistrationDiscountApplicationValid(discounts[2])) &&
+             (discounts.size() < 4 || isRegistrationDiscountApplicationValid(discounts[3])) &&
+             (discounts.size() < 5 || isRegistrationDiscountApplicationValid(discounts[4])) &&
+             (discounts.size() < 6 || isRegistrationDiscountApplicationValid(discounts[5])) &&
+             (discounts.size() < 7 || isRegistrationDiscountApplicationValid(discounts[6])) &&
+             (discounts.size() < 8 || isRegistrationDiscountApplicationValid(discounts[7])) &&
+             (discounts.size() < 9 || isRegistrationDiscountApplicationValid(discounts[8])) &&
+             (discounts.size() < 10 || isRegistrationDiscountApplicationValid(discounts[9]));
+    }
+
+    function isRegistrationFeeSnapshotValid(snapshot) {
+      return snapshot is map &&
+             snapshot.keys().hasOnly([
+               'currency',
+               'quantity',
+               'originalFeeAmountCents',
+               'subtotalAmountCents',
+               'appliedDiscounts',
+               'finalAmountDueCents'
+             ]) &&
+             snapshot.currency is string &&
+             snapshot.quantity is int &&
+             snapshot.quantity >= 1 &&
+             snapshot.originalFeeAmountCents is int &&
+             snapshot.subtotalAmountCents is int &&
+             snapshot.finalAmountDueCents is int &&
+             snapshot.originalFeeAmountCents >= 0 &&
+             snapshot.subtotalAmountCents >= 0 &&
+             snapshot.finalAmountDueCents >= 0 &&
+             areRegistrationDiscountApplicationsValid(snapshot.appliedDiscounts);
+    }
+
     function isPendingRegistrationPayloadValid(teamId, formId, data) {
       return data.keys().hasOnly([
                'teamId',
@@ -342,6 +392,7 @@ service cloud.firestore {
                'submittedAt',
                'waitlistedAt',
                'selectedOption',
+               'feeSnapshot',
                'source'
              ]) &&
              data.teamId == teamId &&
@@ -350,6 +401,8 @@ service cloud.firestore {
              data.waiverAccepted == true &&
              hasOnlyFlatStringValues(data.participant) &&
              hasOnlyFlatStringValues(data.guardian) &&
+             data.keys().hasAny(['feeSnapshot']) &&
+             isRegistrationFeeSnapshotValid(data.feeSnapshot) &&
              (!data.keys().hasAny(['selectedOption']) || isRegistrationSelectedOptionPayloadValid(data.selectedOption)) &&
              (data.status == 'waitlisted' || !data.keys().hasAny(['waitlistedAt'])) &&
              (data.status != 'waitlisted' || data.keys().hasAny(['waitlistedAt'])) &&

--- a/js/admin-registration-forms.js
+++ b/js/admin-registration-forms.js
@@ -50,6 +50,7 @@ export function buildAdminRegistrationFormPayload(input = {}, context = {}) {
             'guardian'
         ),
         registrationOptions: normalizeRegistrationOptions(input.registrationOptions),
+        discountRules: normalizeRegistrationDiscountRules(input.discountRules),
         waiverText: String(input.waiverText || '').trim(),
         status,
         published: status === 'published'
@@ -81,6 +82,87 @@ export function normalizeRegistrationOptions(options = []) {
             id: option.id || `option_${index + 1}`,
             sortOrder: index
         }));
+}
+
+export function normalizeRegistrationDiscountRules(rules = []) {
+    if (!Array.isArray(rules)) return [];
+
+    return rules
+        .map((rule, index) => {
+            const type = normalizeDiscountType(rule?.type);
+            const label = String(rule?.label || '').trim();
+            const amountType = rule?.amountType === 'percent' ? 'percent' : 'fixed';
+            const amountValue = amountType === 'percent'
+                ? Math.min(100, Math.max(0, Number(rule?.amountValue || 0)))
+                : Math.max(0, Math.round(Number(rule?.amountValue || 0) * 100));
+            const earlyBirdDeadline = String(rule?.earlyBirdDeadline || '').trim();
+            const minimumQuantity = Math.max(1, Math.floor(Number(rule?.minimumQuantity || 1)));
+
+            if (!type || !label || amountValue <= 0) return null;
+            if (type === 'early_bird' && !/^\d{4}-\d{2}-\d{2}$/.test(earlyBirdDeadline)) return null;
+
+            return {
+                id: String(rule?.id || '').trim() || `discount_${index + 1}`,
+                type,
+                label,
+                amountType,
+                amountValue,
+                earlyBirdDeadline: type === 'early_bird' ? earlyBirdDeadline : '',
+                minimumQuantity: type === 'quantity' ? minimumQuantity : 1,
+                active: rule?.active !== false,
+                sortOrder: index
+            };
+        })
+        .filter(Boolean);
+}
+
+export function parseRegistrationDiscountRulesText(value = '') {
+    return String(value || '')
+        .split(/\n+/)
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line, index) => {
+            const [rawLabel, rawValue = ''] = line.split(':');
+            const label = String(rawLabel || '').trim();
+            const valueText = rawValue.trim();
+            const percentMatch = valueText.match(/(\d+(?:\.\d+)?)\s*%/);
+            const fixedMatch = valueText.match(/\$?\s*(\d+(?:\.\d+)?)/);
+            const amountType = percentMatch ? 'percent' : 'fixed';
+            const amountValue = Number((percentMatch || fixedMatch || [0, 0])[1] || 0);
+            const dateMatch = line.match(/(\d{4}-\d{2}-\d{2})/);
+            const quantityMatch = line.match(/(\d+)\s*\+/);
+            const lower = line.toLowerCase();
+            const type = lower.includes('early') || dateMatch ? 'early_bird' : 'quantity';
+
+            return {
+                id: `discount_${index + 1}`,
+                type,
+                label: label || (type === 'early_bird' ? 'Early bird discount' : 'Sibling/cart discount'),
+                amountType,
+                amountValue,
+                earlyBirdDeadline: dateMatch ? dateMatch[1] : '',
+                minimumQuantity: quantityMatch ? Number(quantityMatch[1]) : 2,
+                active: true
+            };
+        });
+}
+
+export function formatRegistrationDiscountRulesText(rules = []) {
+    if (!Array.isArray(rules) || rules.length === 0) return '';
+
+    return rules.map((rule) => {
+        const amount = rule.amountType === 'percent' ? `${rule.amountValue}%` : `$${(Number(rule.amountValue || 0) / 100).toFixed(2)}`;
+        if (rule.type === 'early_bird') {
+            return `${rule.label || 'Early bird discount'} before ${rule.earlyBirdDeadline}: ${amount}`;
+        }
+        return `${rule.label || 'Sibling/cart discount'} ${rule.minimumQuantity || 2}+: ${amount}`;
+    }).join('\n');
+}
+
+function normalizeDiscountType(type) {
+    const normalized = String(type || '').toLowerCase().replace(/[ -]/g, '_');
+    if (normalized === 'early_bird' || normalized === 'quantity') return normalized;
+    return '';
 }
 
 export function validateAdminRegistrationFormPayload(payload = {}) {

--- a/js/admin.js
+++ b/js/admin.js
@@ -15,9 +15,11 @@ import {
     adminRegistrationDefaults,
     buildAdminRegistrationFormPayload,
     formatFieldLabels,
+    formatRegistrationDiscountRulesText,
+    parseRegistrationDiscountRulesText,
     getAdminRegistrationShareUrl,
     validateAdminRegistrationFormPayload
-} from './admin-registration-forms.js?v=2';
+} from './admin-registration-forms.js?v=3';
 
 let allTeams = [];
 let allUsers = [];
@@ -597,6 +599,7 @@ window.startRegistrationFormAdmin = function (formId = '') {
     document.getElementById('registration-fee').value = Number(form.feeAmountCents || 0) / 100;
     document.getElementById('registration-participant-fields').value = formatFieldLabels(form.participantFields, adminRegistrationDefaults.participantLabels);
     document.getElementById('registration-guardian-fields').value = formatFieldLabels(form.guardianFields, adminRegistrationDefaults.guardianLabels);
+    document.getElementById('registration-discount-rules').value = formatRegistrationDiscountRulesText(form.discountRules);
     activeRegistrationOptions = Array.isArray(form.registrationOptions) ? form.registrationOptions.map(option => ({ ...option })) : [];
     renderRegistrationOptionsEditor();
     document.getElementById('registration-waiver').value = form.waiverText || '';
@@ -757,6 +760,7 @@ async function saveRegistrationForm(event) {
         participantFieldsText: document.getElementById('registration-participant-fields').value,
         guardianFieldsText: document.getElementById('registration-guardian-fields').value,
         registrationOptions: collectRegistrationOptionsFromEditor(),
+        discountRules: parseRegistrationDiscountRulesText(document.getElementById('registration-discount-rules').value),
         waiverText: document.getElementById('registration-waiver').value,
         status: document.getElementById('registration-status').value
     }, { teamId });

--- a/js/registration-flow.js
+++ b/js/registration-flow.js
@@ -15,6 +15,7 @@ export function normalizeRegistrationForm(form = {}, context = {}) {
         waiverText: String(form.waiverText || form.waiver || '').trim(),
         status: String(form.status || '').trim(),
         published: form.published === true || form.status === 'published',
+        discountRules: normalizeRegistrationDiscountRules(form.discountRules || []),
         registrationOptions: normalizeRegistrationOptions(form.registrationOptions || form.options || [])
     };
 }
@@ -81,6 +82,89 @@ export function normalizeFieldType(type) {
     return 'text';
 }
 
+export function normalizeRegistrationDiscountRules(rules = []) {
+    if (!Array.isArray(rules)) return [];
+
+    return rules
+        .map((rule, index) => {
+            const type = String(rule?.type || '').toLowerCase();
+            const amountType = rule?.amountType === 'percent' ? 'percent' : 'fixed';
+            const amountValue = Math.max(0, Number(rule?.amountValue || 0));
+            const earlyBirdDeadline = String(rule?.earlyBirdDeadline || '').trim();
+            const minimumQuantity = Math.max(1, Math.floor(Number(rule?.minimumQuantity || 1)));
+            if (!['early_bird', 'quantity'].includes(type) || amountValue <= 0) return null;
+
+            return {
+                id: String(rule?.id || `discount_${index + 1}`).trim(),
+                type,
+                label: String(rule?.label || (type === 'early_bird' ? 'Early bird discount' : 'Sibling/cart discount')).trim(),
+                amountType,
+                amountValue,
+                earlyBirdDeadline,
+                minimumQuantity,
+                active: rule?.active !== false
+            };
+        })
+        .filter(Boolean);
+}
+
+export function calculateRegistrationFeeSnapshot(form = {}, options = {}) {
+    const currency = String(form.currency || 'USD').trim() || 'USD';
+    const originalFeeAmountCents = Math.max(0, Math.round(Number(form.feeAmountCents || 0)));
+    const quantity = Math.max(1, Math.floor(Number(options.quantity || 1)));
+    const submittedAt = options.now instanceof Date ? options.now : new Date();
+    const subtotalAmountCents = originalFeeAmountCents * quantity;
+    let remainingAmountCents = subtotalAmountCents;
+    const appliedDiscounts = [];
+
+    normalizeRegistrationDiscountRules(form.discountRules || []).forEach((rule) => {
+        if (!rule.active || !isDiscountRuleEligible(rule, { quantity, now: submittedAt })) return;
+        const discountAmountCents = rule.amountType === 'percent'
+            ? Math.round(remainingAmountCents * (rule.amountValue / 100))
+            : Math.round(rule.amountValue);
+        const appliedAmountCents = Math.min(remainingAmountCents, Math.max(0, discountAmountCents));
+        if (appliedAmountCents <= 0) return;
+        remainingAmountCents -= appliedAmountCents;
+        appliedDiscounts.push({
+            id: rule.id,
+            type: rule.type,
+            label: rule.label,
+            amountType: rule.amountType,
+            amountValue: rule.amountValue,
+            amountCents: appliedAmountCents
+        });
+    });
+
+    return {
+        currency,
+        quantity,
+        originalFeeAmountCents,
+        subtotalAmountCents,
+        appliedDiscounts,
+        finalAmountDueCents: remainingAmountCents
+    };
+}
+
+function isDiscountRuleEligible(rule, { quantity, now }) {
+    if (rule.type === 'quantity') return quantity >= rule.minimumQuantity;
+    if (rule.type === 'early_bird') {
+        const deadline = Date.parse(`${rule.earlyBirdDeadline}T23:59:59.999`);
+        return Number.isFinite(deadline) && now.getTime() <= deadline;
+    }
+    return false;
+}
+
+export function formatFeeSnapshotLines(snapshot = {}) {
+    const lines = [
+        { label: 'Original fee', amountCents: snapshot.subtotalAmountCents ?? snapshot.originalFeeAmountCents ?? 0 }
+    ];
+    (snapshot.appliedDiscounts || []).forEach((discount) => {
+        lines.push({ label: discount.label, amountCents: -Math.abs(Number(discount.amountCents || 0)) });
+    });
+    lines.push({ label: 'Final amount due', amountCents: snapshot.finalAmountDueCents ?? 0, strong: true });
+    return lines;
+}
+
 export function formatFeeAmount(feeAmountCents = 0, currency = 'USD') {
     const amount = Number(feeAmountCents) || 0;
     return new Intl.NumberFormat('en-US', {
@@ -124,7 +208,7 @@ function validateRequiredFields(fields, values, groupLabel, errors) {
     });
 }
 
-export function buildPendingRegistrationRecord({ form, participant, guardian, waiverAccepted, now, selectedOption = null, status = 'pending' }) {
+export function buildPendingRegistrationRecord({ form, participant, guardian, waiverAccepted, now, selectedOption = null, status = 'pending', feeSnapshot = null }) {
     return buildRegistrationRecord({
         form,
         participant,
@@ -132,17 +216,20 @@ export function buildPendingRegistrationRecord({ form, participant, guardian, wa
         waiverAccepted,
         now,
         selectedOption,
-        status
+        status,
+        feeSnapshot
     });
 }
 
-export function buildRegistrationRecord({ form, participant, guardian, waiverAccepted, now, selectedOption = null, status = 'pending' }) {
+export function buildRegistrationRecord({ form, participant, guardian, waiverAccepted, now, selectedOption = null, status = 'pending', feeSnapshot = null }) {
+    const registrationFeeSnapshot = feeSnapshot || calculateRegistrationFeeSnapshot(form, { now: now instanceof Date ? now : new Date() });
     const record = {
         teamId: form.teamId,
         formId: form.id,
         programName: form.programName,
         feeAmountCents: form.feeAmountCents,
         currency: form.currency,
+        feeSnapshot: registrationFeeSnapshot,
         participant,
         guardian,
         waiverAccepted: waiverAccepted === true,

--- a/registration.html
+++ b/registration.html
@@ -35,7 +35,16 @@
                             <dt class="text-sm text-gray-500">Fee</dt>
                             <dd id="program-fee" class="font-semibold text-gray-900"></dd>
                         </div>
+                        <div id="registration-quantity-wrapper" class="hidden rounded border border-gray-200 p-3 sm:col-span-2">
+                            <label for="registration-quantity" class="block text-sm text-gray-500">Participants for fee preview</label>
+                            <input id="registration-quantity" type="number" min="1" step="1" value="1" class="mt-1 w-32 rounded border border-gray-300 p-2">
+                        </div>
                     </dl>
+                </section>
+
+                <section id="fee-summary-section" class="hidden rounded border border-indigo-100 bg-indigo-50 p-4">
+                    <h2 class="text-xl font-semibold text-gray-900">Fee summary</h2>
+                    <div id="fee-summary-lines" class="mt-3 space-y-2 text-sm"></div>
                 </section>
 
                 <section id="registration-options-section" class="hidden">
@@ -77,14 +86,16 @@
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import {
             buildPendingRegistrationRecord,
+            calculateRegistrationFeeSnapshot,
             collectFieldValues,
             decideRegistrationPlacement,
             formatFeeAmount,
+            formatFeeSnapshotLines,
             getActiveRegistrationOptions,
             normalizeRegistrationForm,
             requiresRegistrationOption,
             validateRegistrationSubmission
-        } from './js/registration-flow.js?v=2';
+        } from './js/registration-flow.js?v=3';
 
         renderHeader(document.getElementById('header-container'), null);
         renderFooter(document.getElementById('footer-container'));
@@ -148,6 +159,8 @@
             document.getElementById('program-description').textContent = form.description || 'Complete the required details below.';
             document.getElementById('program-season').textContent = form.season || 'Not specified';
             document.getElementById('program-fee').textContent = formatFeeAmount(form.feeAmountCents, form.currency);
+            document.getElementById('registration-quantity-wrapper').classList.toggle('hidden', !(form.discountRules || []).some(rule => rule.type === 'quantity'));
+            renderFeeSummary(form);
             document.getElementById('waiver-text').textContent = form.waiverText || 'No waiver text was provided.';
 
             const participantContainer = document.getElementById('participant-fields');
@@ -204,6 +217,28 @@
             section.classList.remove('hidden');
         }
 
+        function getRegistrationQuantity() {
+            const quantityInput = document.getElementById('registration-quantity');
+            return Math.max(1, Math.floor(Number(quantityInput?.value || 1)));
+        }
+
+        function renderFeeSummary(form) {
+            const section = document.getElementById('fee-summary-section');
+            const container = document.getElementById('fee-summary-lines');
+            const snapshot = calculateRegistrationFeeSnapshot(form, { quantity: getRegistrationQuantity(), now: new Date() });
+            container.innerHTML = formatFeeSnapshotLines(snapshot).map(line => `
+                <div class="flex justify-between gap-4 ${line.strong ? 'border-t border-indigo-200 pt-2 font-semibold text-gray-900' : 'text-gray-700'}">
+                    <span>${line.label}</span>
+                    <span>${formatFeeAmount(line.amountCents, snapshot.currency)}</span>
+                </div>
+            `).join('');
+            section.classList.remove('hidden');
+        }
+
+        document.getElementById('registration-quantity')?.addEventListener('input', () => {
+            if (activeForm) renderFeeSummary(activeForm);
+        });
+
         function readGroupValues(groupName, fields) {
             return collectFieldValues(fields, Array.from(formElement.querySelectorAll(`[data-group="${groupName}"]`)).reduce((values, input) => {
                 values[input.dataset.fieldId] = input.value;
@@ -248,7 +283,8 @@
                 participant: readGroupValues('participant', activeForm.participantFields),
                 guardian: readGroupValues('guardian', activeForm.guardianFields),
                 waiverAccepted: document.getElementById('waiver-accepted').checked,
-                selectedOptionId: formElement.querySelector('input[name="registrationOptionId"]:checked')?.value || ''
+                selectedOptionId: formElement.querySelector('input[name="registrationOptionId"]:checked')?.value || '',
+                feeSnapshot: calculateRegistrationFeeSnapshot(activeForm, { quantity: getRegistrationQuantity(), now: new Date() })
             };
             const validationErrors = validateRegistrationSubmission(activeForm, submission);
 
@@ -331,6 +367,7 @@
                     ...submission,
                     selectedOption: placement.selectedOption,
                     status: placement.status,
+                    feeSnapshot: calculateRegistrationFeeSnapshot(latestForm, { quantity: submission.feeSnapshot?.quantity || 1, now: new Date() }),
                     now: serverTimestamp()
                 }));
 

--- a/tests/unit/admin-registration-forms.test.js
+++ b/tests/unit/admin-registration-forms.test.js
@@ -3,8 +3,11 @@ import fs from 'node:fs';
 import {
     buildAdminRegistrationFormPayload,
     fieldLabelsToDefinitions,
+    formatRegistrationDiscountRulesText,
     getAdminRegistrationShareUrl,
+    normalizeRegistrationDiscountRules,
     normalizeRegistrationOptions,
+    parseRegistrationDiscountRulesText,
     validateAdminRegistrationFormPayload
 } from '../../js/admin-registration-forms.js';
 
@@ -21,6 +24,10 @@ describe('admin registration form setup', () => {
             registrationOptions: [
                 { id: 'division-a', label: 'Division A', capacityLimit: '12', active: true, waitlistEnabled: true },
                 { label: 'Division B', capacityLimit: '', active: false, waitlistEnabled: false }
+            ],
+            discountRules: [
+                { id: 'early', type: 'early_bird', label: 'Early bird', amountType: 'fixed', amountValue: '25', earlyBirdDeadline: '2026-03-01' },
+                { type: 'quantity', label: 'Sibling discount', amountType: 'percent', amountValue: '10', minimumQuantity: '2' }
             ],
             waiverText: 'I accept the risk.',
             status: 'published'
@@ -48,7 +55,23 @@ describe('admin registration form setup', () => {
             { id: 'division-a', label: 'Division A', capacityLimit: 12, active: true, waitlistEnabled: true, sortOrder: 0 },
             { id: 'option_2', label: 'Division B', capacityLimit: null, active: false, waitlistEnabled: false, sortOrder: 1 }
         ]);
+        expect(payload.discountRules).toEqual([
+            { id: 'early', type: 'early_bird', label: 'Early bird', amountType: 'fixed', amountValue: 2500, earlyBirdDeadline: '2026-03-01', minimumQuantity: 1, active: true, sortOrder: 0 },
+            { id: 'discount_2', type: 'quantity', label: 'Sibling discount', amountType: 'percent', amountValue: 10, earlyBirdDeadline: '', minimumQuantity: 2, active: true, sortOrder: 1 }
+        ]);
         expect(validateAdminRegistrationFormPayload(payload)).toEqual([]);
+    });
+
+    it('parses and formats early-bird and quantity discount rules', () => {
+        const parsed = parseRegistrationDiscountRulesText('Early bird before 2026-03-01: $25\nSibling/cart discount 2+: 10%');
+        const normalized = normalizeRegistrationDiscountRules(parsed);
+
+        expect(normalized).toEqual([
+            { id: 'discount_1', type: 'early_bird', label: 'Early bird before 2026-03-01', amountType: 'fixed', amountValue: 2500, earlyBirdDeadline: '2026-03-01', minimumQuantity: 1, active: true, sortOrder: 0 },
+            { id: 'discount_2', type: 'quantity', label: 'Sibling/cart discount 2+', amountType: 'percent', amountValue: 10, earlyBirdDeadline: '', minimumQuantity: 2, active: true, sortOrder: 1 }
+        ]);
+        expect(formatRegistrationDiscountRulesText(normalized)).toContain('Early bird before 2026-03-01 before 2026-03-01: $25.00');
+        expect(formatRegistrationDiscountRulesText(normalized)).toContain('Sibling/cart discount 2+ 2+: 10%');
     });
 
     it('normalizes empty and legacy registration option settings safely', () => {
@@ -107,6 +130,7 @@ describe('admin registration form setup', () => {
         expect(adminPage).toContain('registration-participant-fields');
         expect(adminPage).toContain('registration-guardian-fields');
         expect(adminPage).toContain('registration-options-list');
+        expect(adminPage).toContain('registration-discount-rules');
         expect(adminPage).toContain('registration-waiver');
         expect(adminPage).toContain('Publish and show link');
         expect(adminJs).toContain('window.openRegistrationFormsAdmin');
@@ -114,6 +138,7 @@ describe('admin registration form setup', () => {
         expect(adminJs).toContain('window.moveRegistrationOptionAdmin');
         expect(adminJs).toContain('window.removeRegistrationOptionAdmin');
         expect(adminJs).toContain('collectRegistrationOptionsFromEditor()');
+        expect(adminJs).toContain('parseRegistrationDiscountRulesText');
         expect(adminJs).toContain('const teamId = activeRegistrationTeam.id;');
         expect(adminJs).toContain('if (activeRegistrationTeam?.id !== teamId) return;');
         expect(adminJs).toContain('teams/${teamId}/registrationForms');

--- a/tests/unit/registration-flow.test.js
+++ b/tests/unit/registration-flow.test.js
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
     buildPendingRegistrationRecord,
+    calculateRegistrationFeeSnapshot,
     collectFieldValues,
     decideRegistrationPlacement,
     formatFeeAmount,
+    formatFeeSnapshotLines,
     normalizeRegistrationForm,
     validateRegistrationSubmission
 } from '../../js/registration-flow.js';
@@ -87,8 +89,49 @@ describe('public registration flow', () => {
             waiverText: 'Waiver',
             status: 'pending',
             submittedAt: now,
-            source: 'public-registration'
+            source: 'public-registration',
+            feeSnapshot: {
+                currency: 'USD',
+                quantity: 1,
+                originalFeeAmountCents: 5000,
+                subtotalAmountCents: 5000,
+                appliedDiscounts: [],
+                finalAmountDueCents: 5000
+            }
         });
+    });
+
+    it('calculates eligible registration discounts for fee previews and snapshots', () => {
+        const form = normalizeRegistrationForm({
+            programName: 'Clinic',
+            feeAmountCents: 10000,
+            currency: 'USD',
+            published: true,
+            discountRules: [
+                { id: 'early', type: 'early_bird', label: 'Early bird', amountType: 'fixed', amountValue: 2500, earlyBirdDeadline: '2026-03-01' },
+                { id: 'siblings', type: 'quantity', label: 'Sibling/cart', amountType: 'percent', amountValue: 10, minimumQuantity: 2 }
+            ]
+        }, { teamId: 'team-1', formId: 'form-1' });
+
+        const snapshot = calculateRegistrationFeeSnapshot(form, { quantity: 2, now: new Date('2026-02-15T12:00:00Z') });
+
+        expect(snapshot).toEqual({
+            currency: 'USD',
+            quantity: 2,
+            originalFeeAmountCents: 10000,
+            subtotalAmountCents: 20000,
+            appliedDiscounts: [
+                { id: 'early', type: 'early_bird', label: 'Early bird', amountType: 'fixed', amountValue: 2500, amountCents: 2500 },
+                { id: 'siblings', type: 'quantity', label: 'Sibling/cart', amountType: 'percent', amountValue: 10, amountCents: 1750 }
+            ],
+            finalAmountDueCents: 15750
+        });
+        expect(formatFeeSnapshotLines(snapshot).map(line => line.label)).toEqual([
+            'Original fee',
+            'Early bird',
+            'Sibling/cart',
+            'Final amount due'
+        ]);
     });
 
     it('requires an active registration option when configured', () => {
@@ -190,6 +233,8 @@ describe('public registration flow', () => {
         expect(page).toContain("doc(db, 'teams', teamId, 'registrationForms', formId)");
         expect(page).toContain("collection(db, 'teams', teamId, 'registrationForms', formId, 'registrations')");
         expect(page).toContain('registration-options-section');
+        expect(page).toContain('fee-summary-section');
+        expect(page).toContain('calculateRegistrationFeeSnapshot');
         expect(page).toContain('runTransaction(db, async (transaction)');
         expect(page).toContain('decideRegistrationPlacement');
         expect(page).toContain('registrationCapacityUpdateId: registrationRef.id');
@@ -207,6 +252,8 @@ describe('public registration flow', () => {
         expect(rules).toContain('isPublishedRegistrationForm(get(formPath).data)');
         expect(rules).toContain("data.status in ['pending', 'waitlisted']");
         expect(rules).toContain("'selectedOption'");
+        expect(rules).toContain("'feeSnapshot'");
+        expect(rules).toContain('isRegistrationFeeSnapshotValid');
         expect(rules).toContain('isPublicRegistrationCapacityCounterUpdate');
         expect(rules).toContain('registrationCapacityUpdateId');
         expect(rules).toContain('existsAfter(registrationPath)');


### PR DESCRIPTION
Closes #1016

## Summary
- Added admin-configured registration discount rules for early-bird and quantity-based sibling/cart discounts.
- Added public fee preview with original fee, applied discounts, and final amount due before submission.
- Snapshots fee details on submitted registrations and tightened Firestore rules to allow only intended fee snapshot fields.

## Validation
- `npx vitest run tests/unit/admin-registration-forms.test.js tests/unit/registration-flow.test.js`
- `node scripts/validate-firebase-rules-ci.mjs`
- `git diff --check`