### PR TITLE
Add registration installment plan snapshots

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -325,11 +325,29 @@
                             <div class="mb-3 flex items-start justify-between gap-3">
                                 <div>
                                     <h4 class="text-sm font-semibold text-gray-900">Registration options</h4>
-                                    <p class="text-xs text-gray-500">Define capacity and waitlist setup for options. Public checkout behavior is unchanged.</p>
+                                    <p class="text-xs text-gray-500">Define capacity and waitlist setup for options.</p>
                                 </div>
                                 <button type="button" onclick="window.addRegistrationOptionAdmin()" class="rounded bg-gray-100 px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-200">Add option</button>
                             </div>
                             <div id="registration-options-list" class="space-y-3"></div>
+                        </div>
+                        <div class="rounded border border-gray-200 p-3">
+                            <label class="inline-flex items-center gap-2 text-sm font-semibold text-gray-900">
+                                <input id="registration-installments-enabled" type="checkbox" class="rounded border-gray-300">
+                                Offer installment plan
+                            </label>
+                            <div class="mt-3 grid gap-3 sm:grid-cols-3">
+                                <label for="registration-installment-count" class="text-sm font-medium text-gray-700">Installments
+                                    <input id="registration-installment-count" type="number" min="2" max="12" step="1" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="3">
+                                </label>
+                                <label for="registration-installment-first-date" class="text-sm font-medium text-gray-700">First due date
+                                    <input id="registration-installment-first-date" type="date" class="mt-1 w-full rounded border border-gray-300 p-2">
+                                </label>
+                                <label for="registration-installment-interval" class="text-sm font-medium text-gray-700">Days between
+                                    <input id="registration-installment-interval" type="number" min="1" step="1" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="30">
+                                </label>
+                            </div>
+                            <p class="mt-2 text-xs text-gray-500">Parents can choose pay-in-full or this simple equal installment schedule. No payments are charged yet.</p>
                         </div>
                         <div>
                             <label for="registration-waiver" class="block text-sm font-medium text-gray-700">Waiver text</label>

--- a/firestore.rules
+++ b/firestore.rules
@@ -327,6 +327,47 @@ service cloud.firestore {
              option.waitlistEnabled is bool;
     }
 
+    function isRegistrationInstallmentValid(installment) {
+      return installment is map &&
+             installment.keys().hasOnly(['label', 'dueDate', 'amountCents']) &&
+             installment.label is string &&
+             installment.dueDate is string &&
+             installment.amountCents is int &&
+             installment.amountCents >= 0;
+    }
+
+    function isRegistrationScheduleValid(schedule) {
+      return schedule is list &&
+             schedule.size() >= 1 &&
+             schedule.size() <= 12 &&
+             isRegistrationInstallmentValid(schedule[0]) &&
+             (schedule.size() < 2 || isRegistrationInstallmentValid(schedule[1])) &&
+             (schedule.size() < 3 || isRegistrationInstallmentValid(schedule[2])) &&
+             (schedule.size() < 4 || isRegistrationInstallmentValid(schedule[3])) &&
+             (schedule.size() < 5 || isRegistrationInstallmentValid(schedule[4])) &&
+             (schedule.size() < 6 || isRegistrationInstallmentValid(schedule[5])) &&
+             (schedule.size() < 7 || isRegistrationInstallmentValid(schedule[6])) &&
+             (schedule.size() < 8 || isRegistrationInstallmentValid(schedule[7])) &&
+             (schedule.size() < 9 || isRegistrationInstallmentValid(schedule[8])) &&
+             (schedule.size() < 10 || isRegistrationInstallmentValid(schedule[9])) &&
+             (schedule.size() < 11 || isRegistrationInstallmentValid(schedule[10])) &&
+             (schedule.size() < 12 || isRegistrationInstallmentValid(schedule[11]));
+    }
+
+    function isRegistrationPaymentPlanValid(plan) {
+      return plan is map &&
+             plan.keys().hasOnly(['id', 'type', 'title', 'installmentCount', 'totalBalanceDueCents', 'schedule']) &&
+             plan.id in ['pay_full', 'installments'] &&
+             plan.type in ['pay_full', 'installments'] &&
+             plan.id == plan.type &&
+             plan.title is string &&
+             plan.installmentCount is int &&
+             plan.totalBalanceDueCents is int &&
+             plan.totalBalanceDueCents >= 0 &&
+             isRegistrationScheduleValid(plan.schedule) &&
+             plan.installmentCount == plan.schedule.size();
+    }
+
     function isPendingRegistrationPayloadValid(teamId, formId, data) {
       return data.keys().hasOnly([
                'teamId',
@@ -338,6 +379,7 @@ service cloud.firestore {
                'guardian',
                'waiverAccepted',
                'waiverText',
+               'paymentPlan',
                'status',
                'submittedAt',
                'waitlistedAt',
@@ -350,6 +392,7 @@ service cloud.firestore {
              data.waiverAccepted == true &&
              hasOnlyFlatStringValues(data.participant) &&
              hasOnlyFlatStringValues(data.guardian) &&
+             isRegistrationPaymentPlanValid(data.paymentPlan) &&
              (!data.keys().hasAny(['selectedOption']) || isRegistrationSelectedOptionPayloadValid(data.selectedOption)) &&
              (data.status == 'waitlisted' || !data.keys().hasAny(['waitlistedAt'])) &&
              (data.status != 'waitlisted' || data.keys().hasAny(['waitlistedAt'])) &&

--- a/js/admin-registration-forms.js
+++ b/js/admin-registration-forms.js
@@ -31,6 +31,7 @@ export function buildAdminRegistrationFormPayload(input = {}, context = {}) {
     const guardianLabels = parseFieldLabels(input.guardianFieldsText);
     const feeAmount = Number(input.feeAmount || 0);
     const status = input.status === 'published' ? 'published' : 'draft';
+    const installmentPlan = normalizeInstallmentPlan(input.installmentPlan || input);
 
     return {
         teamId: context.teamId || input.teamId || '',
@@ -41,6 +42,7 @@ export function buildAdminRegistrationFormPayload(input = {}, context = {}) {
         season: String(input.season || '').trim(),
         feeAmountCents: Math.max(0, Math.round(feeAmount * 100)),
         currency: 'USD',
+        installmentPlan,
         participantFields: fieldLabelsToDefinitions(
             participantLabels.length ? participantLabels : DEFAULT_PARTICIPANT_LABELS,
             'participant'
@@ -53,6 +55,25 @@ export function buildAdminRegistrationFormPayload(input = {}, context = {}) {
         waiverText: String(input.waiverText || '').trim(),
         status,
         published: status === 'published'
+    };
+}
+
+export function normalizeInstallmentPlan(input = {}) {
+    const enabled = input.installmentPlanEnabled === true || input.enabled === true;
+    if (!enabled) return null;
+
+    const installmentCount = Math.max(2, Math.min(12, Math.floor(Number(input.installmentCount) || 0)));
+    const intervalDays = Math.max(1, Math.min(365, Math.floor(Number(input.intervalDays) || 30)));
+    const firstDueDate = String(input.firstDueDate || '').trim();
+
+    if (!firstDueDate) return null;
+
+    return {
+        enabled: true,
+        title: String(input.title || 'Installment plan').trim() || 'Installment plan',
+        installmentCount,
+        firstDueDate,
+        intervalDays
     };
 }
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -17,7 +17,7 @@ import {
     formatFieldLabels,
     getAdminRegistrationShareUrl,
     validateAdminRegistrationFormPayload
-} from './admin-registration-forms.js?v=2';
+} from './admin-registration-forms.js?v=3';
 
 let allTeams = [];
 let allUsers = [];
@@ -595,6 +595,11 @@ window.startRegistrationFormAdmin = function (formId = '') {
     document.getElementById('registration-program-type').value = form.programType || 'season';
     document.getElementById('registration-season').value = form.season || '';
     document.getElementById('registration-fee').value = Number(form.feeAmountCents || 0) / 100;
+    const installmentPlan = form.installmentPlan || {};
+    document.getElementById('registration-installments-enabled').checked = installmentPlan.enabled === true;
+    document.getElementById('registration-installment-count').value = installmentPlan.installmentCount || '';
+    document.getElementById('registration-installment-first-date').value = installmentPlan.firstDueDate || '';
+    document.getElementById('registration-installment-interval').value = installmentPlan.intervalDays || '';
     document.getElementById('registration-participant-fields').value = formatFieldLabels(form.participantFields, adminRegistrationDefaults.participantLabels);
     document.getElementById('registration-guardian-fields').value = formatFieldLabels(form.guardianFields, adminRegistrationDefaults.guardianLabels);
     activeRegistrationOptions = Array.isArray(form.registrationOptions) ? form.registrationOptions.map(option => ({ ...option })) : [];
@@ -757,6 +762,12 @@ async function saveRegistrationForm(event) {
         participantFieldsText: document.getElementById('registration-participant-fields').value,
         guardianFieldsText: document.getElementById('registration-guardian-fields').value,
         registrationOptions: collectRegistrationOptionsFromEditor(),
+        installmentPlan: {
+            enabled: document.getElementById('registration-installments-enabled').checked,
+            installmentCount: document.getElementById('registration-installment-count').value,
+            firstDueDate: document.getElementById('registration-installment-first-date').value,
+            intervalDays: document.getElementById('registration-installment-interval').value
+        },
         waiverText: document.getElementById('registration-waiver').value,
         status: document.getElementById('registration-status').value
     }, { teamId });

--- a/js/registration-flow.js
+++ b/js/registration-flow.js
@@ -10,6 +10,7 @@ export function normalizeRegistrationForm(form = {}, context = {}) {
         season: String(form.season || '').trim(),
         feeAmountCents,
         currency: String(form.currency || 'USD').trim() || 'USD',
+        installmentPlan: normalizeInstallmentPlan(form.installmentPlan),
         participantFields: normalizeFields(form.participantFields || form.playerFields || []),
         guardianFields: normalizeFields(form.guardianFields || []),
         waiverText: String(form.waiverText || form.waiver || '').trim(),
@@ -17,6 +18,67 @@ export function normalizeRegistrationForm(form = {}, context = {}) {
         published: form.published === true || form.status === 'published',
         registrationOptions: normalizeRegistrationOptions(form.registrationOptions || form.options || [])
     };
+}
+
+export function normalizeInstallmentPlan(plan = null) {
+    if (!plan || plan.enabled !== true) return null;
+
+    const installmentCount = Math.max(2, Math.min(12, Math.floor(Number(plan.installmentCount) || 0)));
+    const intervalDays = Math.max(1, Math.min(365, Math.floor(Number(plan.intervalDays) || 30)));
+    const firstDueDate = String(plan.firstDueDate || '').trim();
+    if (!firstDueDate) return null;
+
+    return {
+        enabled: true,
+        title: String(plan.title || 'Installment plan').trim() || 'Installment plan',
+        installmentCount,
+        firstDueDate,
+        intervalDays
+    };
+}
+
+export function hasInstallmentPlan(form = {}) {
+    return form.installmentPlan?.enabled === true;
+}
+
+export function getPaymentPlanChoices(form = {}) {
+    const payInFull = { id: 'pay_full', type: 'pay_full', title: 'Pay in full' };
+    if (!hasInstallmentPlan(form)) return [payInFull];
+    return [payInFull, { id: 'installments', type: 'installments', title: form.installmentPlan.title || 'Installment plan' }];
+}
+
+export function buildPaymentPlanSnapshot(form = {}, selectedPaymentPlanId = 'pay_full') {
+    const totalBalanceDueCents = Math.max(0, Math.round(Number(form.feeAmountCents) || 0));
+    const useInstallments = selectedPaymentPlanId === 'installments' && hasInstallmentPlan(form);
+    const schedule = useInstallments
+        ? buildInstallmentSchedule(totalBalanceDueCents, form.installmentPlan)
+        : [{ label: 'Pay in full', dueDate: form.installmentPlan?.firstDueDate || '', amountCents: totalBalanceDueCents }];
+
+    return {
+        id: useInstallments ? 'installments' : 'pay_full',
+        type: useInstallments ? 'installments' : 'pay_full',
+        title: useInstallments ? form.installmentPlan.title : 'Pay in full',
+        installmentCount: schedule.length,
+        totalBalanceDueCents,
+        schedule
+    };
+}
+
+export function buildInstallmentSchedule(totalBalanceDueCents = 0, plan = {}) {
+    const count = Math.max(2, Math.min(12, Math.floor(Number(plan.installmentCount) || 2)));
+    const baseAmount = Math.floor(totalBalanceDueCents / count);
+    const remainder = totalBalanceDueCents - (baseAmount * count);
+    const firstDate = parseLocalDate(plan.firstDueDate);
+    const intervalDays = Math.max(1, Math.floor(Number(plan.intervalDays) || 30));
+
+    return Array.from({ length: count }, (_, index) => {
+        const dueDate = firstDate ? addDays(firstDate, intervalDays * index) : null;
+        return {
+            label: `Installment ${index + 1}`,
+            dueDate: dueDate ? formatLocalDate(dueDate) : String(plan.firstDueDate || ''),
+            amountCents: baseAmount + (index === count - 1 ? remainder : 0)
+        };
+    });
 }
 
 export function normalizeFields(fields = []) {
@@ -113,6 +175,10 @@ export function validateRegistrationSubmission(form, submission = {}) {
         errors.push('Please select a registration option.');
     }
 
+    if (hasInstallmentPlan(form) && !getPaymentPlanChoices(form).some(choice => choice.id === submission.selectedPaymentPlanId)) {
+        errors.push('Please select a payment plan.');
+    }
+
     return errors;
 }
 
@@ -124,7 +190,7 @@ function validateRequiredFields(fields, values, groupLabel, errors) {
     });
 }
 
-export function buildPendingRegistrationRecord({ form, participant, guardian, waiverAccepted, now, selectedOption = null, status = 'pending' }) {
+export function buildPendingRegistrationRecord({ form, participant, guardian, waiverAccepted, now, selectedOption = null, selectedPaymentPlanId = 'pay_full', status = 'pending' }) {
     return buildRegistrationRecord({
         form,
         participant,
@@ -132,11 +198,12 @@ export function buildPendingRegistrationRecord({ form, participant, guardian, wa
         waiverAccepted,
         now,
         selectedOption,
+        selectedPaymentPlanId,
         status
     });
 }
 
-export function buildRegistrationRecord({ form, participant, guardian, waiverAccepted, now, selectedOption = null, status = 'pending' }) {
+export function buildRegistrationRecord({ form, participant, guardian, waiverAccepted, now, selectedOption = null, selectedPaymentPlanId = 'pay_full', status = 'pending' }) {
     const record = {
         teamId: form.teamId,
         formId: form.id,
@@ -147,6 +214,7 @@ export function buildRegistrationRecord({ form, participant, guardian, waiverAcc
         guardian,
         waiverAccepted: waiverAccepted === true,
         waiverText: form.waiverText,
+        paymentPlan: buildPaymentPlanSnapshot(form, selectedPaymentPlanId),
         status,
         submittedAt: now,
         source: 'public-registration'
@@ -203,4 +271,20 @@ export function decideRegistrationPlacement({ form, selectedOptionId, counts = {
         selectedOption,
         message: `${selectedOption.title} is full and is not accepting waitlist registrations.`
     };
+}
+
+function parseLocalDate(value = '') {
+    const match = String(value || '').match(/^(\d{4})-(\d{2})-(\d{2})$/);
+    if (!match) return null;
+    return new Date(Date.UTC(Number(match[1]), Number(match[2]) - 1, Number(match[3])));
+}
+
+function addDays(date, days) {
+    const next = new Date(date.getTime());
+    next.setUTCDate(next.getUTCDate() + days);
+    return next;
+}
+
+function formatLocalDate(date) {
+    return date.toISOString().slice(0, 10);
 }

--- a/registration.html
+++ b/registration.html
@@ -44,6 +44,12 @@
                     <div id="registration-options" class="mt-3 grid gap-3"></div>
                 </section>
 
+                <section id="payment-plan-section" class="hidden">
+                    <h2 class="text-xl font-semibold text-gray-900">Payment plan</h2>
+                    <p class="mt-1 text-sm text-gray-600">Choose how you expect to pay. Payments are not charged by this form.</p>
+                    <div id="payment-plan-options" class="mt-3 grid gap-3"></div>
+                </section>
+
                 <section>
                     <h2 class="text-xl font-semibold text-gray-900">Participant details</h2>
                     <div id="participant-fields" class="mt-3 grid gap-4"></div>
@@ -81,10 +87,12 @@
             decideRegistrationPlacement,
             formatFeeAmount,
             getActiveRegistrationOptions,
+            getPaymentPlanChoices,
+            hasInstallmentPlan,
             normalizeRegistrationForm,
             requiresRegistrationOption,
             validateRegistrationSubmission
-        } from './js/registration-flow.js?v=2';
+        } from './js/registration-flow.js?v=3';
 
         renderHeader(document.getElementById('header-container'), null);
         renderFooter(document.getElementById('footer-container'));
@@ -157,6 +165,7 @@
             form.participantFields.forEach(field => renderField(participantContainer, field, 'participant'));
             form.guardianFields.forEach(field => renderField(guardianContainer, field, 'guardian'));
             renderRegistrationOptions(form);
+            renderPaymentPlanChoices(form);
 
             loadingState.classList.add('hidden');
             formElement.classList.remove('hidden');
@@ -195,6 +204,47 @@
                     description.className = 'mt-1 block text-gray-600';
                     description.textContent = option.description;
                     copy.appendChild(description);
+                }
+
+                label.append(input, copy);
+                container.appendChild(label);
+            });
+
+            section.classList.remove('hidden');
+        }
+
+        function renderPaymentPlanChoices(form) {
+            const section = document.getElementById('payment-plan-section');
+            const container = document.getElementById('payment-plan-options');
+            container.innerHTML = '';
+
+            if (!hasInstallmentPlan(form)) {
+                section.classList.add('hidden');
+                return;
+            }
+
+            getPaymentPlanChoices(form).forEach((choice, index) => {
+                const label = document.createElement('label');
+                label.className = 'flex gap-3 rounded border border-gray-200 p-3 text-sm text-gray-700 hover:border-indigo-300';
+                const input = document.createElement('input');
+                input.type = 'radio';
+                input.name = 'paymentPlanId';
+                input.value = choice.id;
+                input.required = true;
+                input.className = 'mt-1 h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500';
+                if (index === 0) input.checked = true;
+
+                const copy = document.createElement('span');
+                const title = document.createElement('span');
+                title.className = 'block font-semibold text-gray-900';
+                title.textContent = choice.title;
+                copy.appendChild(title);
+
+                if (choice.id === 'installments') {
+                    const detail = document.createElement('span');
+                    detail.className = 'mt-1 block text-gray-600';
+                    detail.textContent = `${form.installmentPlan.installmentCount} installments starting ${form.installmentPlan.firstDueDate}`;
+                    copy.appendChild(detail);
                 }
 
                 label.append(input, copy);
@@ -248,6 +298,7 @@
                 participant: readGroupValues('participant', activeForm.participantFields),
                 guardian: readGroupValues('guardian', activeForm.guardianFields),
                 waiverAccepted: document.getElementById('waiver-accepted').checked,
+                selectedPaymentPlanId: formElement.querySelector('input[name="paymentPlanId"]:checked')?.value || 'pay_full',
                 selectedOptionId: formElement.querySelector('input[name="registrationOptionId"]:checked')?.value || ''
             };
             const validationErrors = validateRegistrationSubmission(activeForm, submission);

--- a/tests/unit/admin-registration-forms.test.js
+++ b/tests/unit/admin-registration-forms.test.js
@@ -4,6 +4,7 @@ import {
     buildAdminRegistrationFormPayload,
     fieldLabelsToDefinitions,
     getAdminRegistrationShareUrl,
+    normalizeInstallmentPlan,
     normalizeRegistrationOptions,
     validateAdminRegistrationFormPayload
 } from '../../js/admin-registration-forms.js';
@@ -22,6 +23,7 @@ describe('admin registration form setup', () => {
                 { id: 'division-a', label: 'Division A', capacityLimit: '12', active: true, waitlistEnabled: true },
                 { label: 'Division B', capacityLimit: '', active: false, waitlistEnabled: false }
             ],
+            installmentPlan: { enabled: true, installmentCount: '3', firstDueDate: '2026-06-01', intervalDays: '30' },
             waiverText: 'I accept the risk.',
             status: 'published'
         }, { teamId: 'team-1' });
@@ -35,6 +37,7 @@ describe('admin registration form setup', () => {
             season: 'Spring 2026',
             feeAmountCents: 12550,
             currency: 'USD',
+            installmentPlan: { enabled: true, title: 'Installment plan', installmentCount: 3, firstDueDate: '2026-06-01', intervalDays: 30 },
             waiverText: 'I accept the risk.',
             status: 'published',
             published: true
@@ -49,6 +52,17 @@ describe('admin registration form setup', () => {
             { id: 'option_2', label: 'Division B', capacityLimit: null, active: false, waitlistEnabled: false, sortOrder: 1 }
         ]);
         expect(validateAdminRegistrationFormPayload(payload)).toEqual([]);
+    });
+
+    it('normalizes simple installment plan settings safely', () => {
+        expect(normalizeInstallmentPlan()).toBeNull();
+        expect(normalizeInstallmentPlan({ enabled: true, installmentCount: '24', firstDueDate: '2026-06-01', intervalDays: '0' })).toEqual({
+            enabled: true,
+            title: 'Installment plan',
+            installmentCount: 12,
+            firstDueDate: '2026-06-01',
+            intervalDays: 30
+        });
     });
 
     it('normalizes empty and legacy registration option settings safely', () => {
@@ -107,6 +121,7 @@ describe('admin registration form setup', () => {
         expect(adminPage).toContain('registration-participant-fields');
         expect(adminPage).toContain('registration-guardian-fields');
         expect(adminPage).toContain('registration-options-list');
+        expect(adminPage).toContain('registration-installments-enabled');
         expect(adminPage).toContain('registration-waiver');
         expect(adminPage).toContain('Publish and show link');
         expect(adminJs).toContain('window.openRegistrationFormsAdmin');
@@ -114,6 +129,7 @@ describe('admin registration form setup', () => {
         expect(adminJs).toContain('window.moveRegistrationOptionAdmin');
         expect(adminJs).toContain('window.removeRegistrationOptionAdmin');
         expect(adminJs).toContain('collectRegistrationOptionsFromEditor()');
+        expect(adminJs).toContain("document.getElementById('registration-installment-count')");
         expect(adminJs).toContain('const teamId = activeRegistrationTeam.id;');
         expect(adminJs).toContain('if (activeRegistrationTeam?.id !== teamId) return;');
         expect(adminJs).toContain('teams/${teamId}/registrationForms');

--- a/tests/unit/registration-flow.test.js
+++ b/tests/unit/registration-flow.test.js
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
+    buildInstallmentSchedule,
     buildPendingRegistrationRecord,
     collectFieldValues,
     decideRegistrationPlacement,
     formatFeeAmount,
+    getPaymentPlanChoices,
     normalizeRegistrationForm,
     validateRegistrationSubmission
 } from '../../js/registration-flow.js';
@@ -85,9 +87,60 @@ describe('public registration flow', () => {
             guardian: { email: 'parent@example.com' },
             waiverAccepted: true,
             waiverText: 'Waiver',
+            paymentPlan: {
+                id: 'pay_full',
+                type: 'pay_full',
+                title: 'Pay in full',
+                installmentCount: 1,
+                totalBalanceDueCents: 5000,
+                schedule: [{ label: 'Pay in full', dueDate: '', amountCents: 5000 }]
+            },
             status: 'pending',
             submittedAt: now,
             source: 'public-registration'
+        });
+    });
+
+    it('normalizes installment plans and snapshots selected schedules', () => {
+        const form = normalizeRegistrationForm({
+            programName: 'Clinic',
+            feeAmountCents: 10000,
+            published: true,
+            installmentPlan: { enabled: true, installmentCount: 3, firstDueDate: '2026-06-01', intervalDays: 30 }
+        }, { teamId: 'team-1', formId: 'form-1' });
+
+        expect(getPaymentPlanChoices(form)).toEqual([
+            { id: 'pay_full', type: 'pay_full', title: 'Pay in full' },
+            { id: 'installments', type: 'installments', title: 'Installment plan' }
+        ]);
+        expect(buildInstallmentSchedule(10000, form.installmentPlan)).toEqual([
+            { label: 'Installment 1', dueDate: '2026-06-01', amountCents: 3333 },
+            { label: 'Installment 2', dueDate: '2026-07-01', amountCents: 3333 },
+            { label: 'Installment 3', dueDate: '2026-07-31', amountCents: 3334 }
+        ]);
+        expect(validateRegistrationSubmission(form, { waiverAccepted: true, selectedPaymentPlanId: '' })).toEqual([
+            'Please select a payment plan.'
+        ]);
+
+        const record = buildPendingRegistrationRecord({
+            form,
+            participant: {},
+            guardian: {},
+            waiverAccepted: true,
+            selectedPaymentPlanId: 'installments',
+            now: { sentinel: 'serverTimestamp' }
+        });
+        expect(record.paymentPlan).toEqual({
+            id: 'installments',
+            type: 'installments',
+            title: 'Installment plan',
+            installmentCount: 3,
+            totalBalanceDueCents: 10000,
+            schedule: [
+                { label: 'Installment 1', dueDate: '2026-06-01', amountCents: 3333 },
+                { label: 'Installment 2', dueDate: '2026-07-01', amountCents: 3333 },
+                { label: 'Installment 3', dueDate: '2026-07-31', amountCents: 3334 }
+            ]
         });
     });
 
@@ -190,6 +243,8 @@ describe('public registration flow', () => {
         expect(page).toContain("doc(db, 'teams', teamId, 'registrationForms', formId)");
         expect(page).toContain("collection(db, 'teams', teamId, 'registrationForms', formId, 'registrations')");
         expect(page).toContain('registration-options-section');
+        expect(page).toContain('payment-plan-section');
+        expect(page).toContain('getPaymentPlanChoices');
         expect(page).toContain('runTransaction(db, async (transaction)');
         expect(page).toContain('decideRegistrationPlacement');
         expect(page).toContain('registrationCapacityUpdateId: registrationRef.id');
@@ -207,6 +262,8 @@ describe('public registration flow', () => {
         expect(rules).toContain('isPublishedRegistrationForm(get(formPath).data)');
         expect(rules).toContain("data.status in ['pending', 'waitlisted']");
         expect(rules).toContain("'selectedOption'");
+        expect(rules).toContain("'paymentPlan'");
+        expect(rules).toContain('isRegistrationPaymentPlanValid');
         expect(rules).toContain('isPublicRegistrationCapacityCounterUpdate');
         expect(rules).toContain('registrationCapacityUpdateId');
         expect(rules).toContain('existsAfter(registrationPath)');


### PR DESCRIPTION
Closes #1017

## Summary
- Added admin installment plan configuration for registration forms.
- Added parent-facing pay-in-full versus installment plan selection when a plan is configured.
- Snapshots the selected payment plan, installment schedule, amounts, and total balance due on pending registrations.
- Updated Firestore public registration validation to allow the payment plan snapshot.

## Validation
- `npx vitest run tests/unit/admin-registration-forms.test.js tests/unit/registration-flow.test.js`
- `node scripts/validate-firebase-rules-ci.mjs`