### PR TITLE
Add registration payment settings

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -269,7 +269,7 @@
                     <div>
                         <p class="text-sm font-semibold uppercase tracking-wide text-primary-600">Registration setup</p>
                         <h2 class="text-2xl font-bold text-gray-900"><span id="registration-team-name">Team</span> forms</h2>
-                        <p class="mt-1 text-sm text-gray-600">Create draft or published parent registration links without checkout or roster automation.</p>
+                        <p class="mt-1 text-sm text-gray-600">Create draft or published parent registration links with optional payment settings. Online payment processing is not enabled yet.</p>
                     </div>
                     <button onclick="window.closeRegistrationFormsAdmin()" class="rounded px-2 py-1 text-gray-500 hover:bg-gray-100" aria-label="Close registration form setup">✕</button>
                 </div>
@@ -312,6 +312,20 @@
                                 <input id="registration-fee" type="number" min="0" step="0.01" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="125.00">
                             </div>
                         </div>
+                        <div class="rounded border border-indigo-100 bg-indigo-50 p-3">
+                            <h4 class="text-sm font-semibold text-gray-900">Checkout and payment settings</h4>
+                            <p class="mt-1 text-xs text-gray-600">Choose what this form should support. Online checkout is saved as intent only until backend processing lands.</p>
+                            <div class="mt-3 grid gap-3 text-sm text-gray-700 sm:grid-cols-2">
+                                <label class="flex items-start gap-2 rounded border border-indigo-100 bg-white p-3">
+                                    <input id="registration-offline-payment" type="checkbox" class="mt-1 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+                                    <span><span class="font-medium text-gray-900">Accept offline payment</span><span class="block text-xs text-gray-500">Parents submit registration and the organizer follows up with payment instructions.</span></span>
+                                </label>
+                                <label class="flex items-start gap-2 rounded border border-indigo-100 bg-white p-3">
+                                    <input id="registration-online-checkout" type="checkbox" class="mt-1 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+                                    <span><span class="font-medium text-gray-900">Plan for online checkout</span><span class="block text-xs text-gray-500">Saved for future checkout. Online payment processing is not available yet.</span></span>
+                                </label>
+                            </div>
+                        </div>
                         <div>
                             <label for="registration-participant-fields" class="block text-sm font-medium text-gray-700">Participant fields</label>
                             <textarea id="registration-participant-fields" rows="3" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Participant name&#10;Birthdate"></textarea>
@@ -325,7 +339,7 @@
                             <div class="mb-3 flex items-start justify-between gap-3">
                                 <div>
                                     <h4 class="text-sm font-semibold text-gray-900">Registration options</h4>
-                                    <p class="text-xs text-gray-500">Define capacity and waitlist setup for options. Public checkout behavior is unchanged.</p>
+                                    <p class="text-xs text-gray-500">Define capacity and waitlist setup for options. Payment behavior is controlled by the checkout and payment settings above.</p>
                                 </div>
                                 <button type="button" onclick="window.addRegistrationOptionAdmin()" class="rounded bg-gray-100 px-3 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-200">Add option</button>
                             </div>

--- a/docs/parent-role.md
+++ b/docs/parent-role.md
@@ -51,7 +51,7 @@
 ## Public Registration Forms
 - Coaches/admins manage published registration form documents at `teams/{teamId}/registrationForms/{formId}`.
 - `registration.html` reads only published forms by direct link and writes new records under `teams/{teamId}/registrationForms/{formId}/registrations/{registrationId}` with `status: 'pending'`.
-- Public submissions are intentionally limited to form field values, explicit waiver acceptance, fee/program snapshot data, and submission metadata. Online payments, document upload, discounting, and auto-roster placement remain separate follow-up flows.
+- Public submissions are intentionally limited to form field values, explicit waiver acceptance, fee/program/payment settings snapshot data, and submission metadata. Admins can mark forms for offline payment or future online checkout; online payment processing, document upload, discounting, and auto-roster placement remain separate follow-up flows.
 
 ## Testing Ideas
 - Parent signup with valid/invalid code; cannot sign up without code.

--- a/firestore.rules
+++ b/firestore.rules
@@ -316,6 +316,13 @@ service cloud.firestore {
              (data.get('options', []) is list && data.get('options', []).size() > 0);
     }
 
+    function isRegistrationPaymentSettingsPayloadValid(settings) {
+      return settings is map &&
+             settings.keys().hasOnly(['offlinePaymentEnabled', 'onlineCheckoutEnabled']) &&
+             settings.offlinePaymentEnabled is bool &&
+             settings.onlineCheckoutEnabled is bool;
+    }
+
     function isRegistrationSelectedOptionPayloadValid(option) {
       return option is map &&
              option.keys().hasOnly(['id', 'countKey', 'title', 'feeAmountCents', 'capacityLimit', 'waitlistEnabled']) &&
@@ -334,6 +341,7 @@ service cloud.firestore {
                'programName',
                'feeAmountCents',
                'currency',
+               'paymentSettings',
                'participant',
                'guardian',
                'waiverAccepted',
@@ -350,6 +358,7 @@ service cloud.firestore {
              data.waiverAccepted == true &&
              hasOnlyFlatStringValues(data.participant) &&
              hasOnlyFlatStringValues(data.guardian) &&
+             isRegistrationPaymentSettingsPayloadValid(data.paymentSettings) &&
              (!data.keys().hasAny(['selectedOption']) || isRegistrationSelectedOptionPayloadValid(data.selectedOption)) &&
              (data.status == 'waitlisted' || !data.keys().hasAny(['waitlistedAt'])) &&
              (data.status != 'waitlisted' || data.keys().hasAny(['waitlistedAt'])) &&

--- a/js/admin-registration-forms.js
+++ b/js/admin-registration-forms.js
@@ -1,5 +1,9 @@
 const DEFAULT_PARTICIPANT_LABELS = ['Participant name', 'Birthdate'];
 const DEFAULT_GUARDIAN_LABELS = ['Guardian name', 'Guardian email', 'Guardian phone'];
+const DEFAULT_PAYMENT_SETTINGS = {
+    offlinePaymentEnabled: false,
+    onlineCheckoutEnabled: false
+};
 
 export function fieldLabelsToDefinitions(labels = [], prefix = 'field') {
     return labels
@@ -50,9 +54,17 @@ export function buildAdminRegistrationFormPayload(input = {}, context = {}) {
             'guardian'
         ),
         registrationOptions: normalizeRegistrationOptions(input.registrationOptions),
+        paymentSettings: normalizePaymentSettings(input.paymentSettings),
         waiverText: String(input.waiverText || '').trim(),
         status,
         published: status === 'published'
+    };
+}
+
+export function normalizePaymentSettings(settings = {}) {
+    return {
+        offlinePaymentEnabled: settings?.offlinePaymentEnabled === true,
+        onlineCheckoutEnabled: settings?.onlineCheckoutEnabled === true
     };
 }
 
@@ -112,5 +124,6 @@ function inferFieldType(label) {
 
 export const adminRegistrationDefaults = {
     participantLabels: DEFAULT_PARTICIPANT_LABELS,
-    guardianLabels: DEFAULT_GUARDIAN_LABELS
+    guardianLabels: DEFAULT_GUARDIAN_LABELS,
+    paymentSettings: DEFAULT_PAYMENT_SETTINGS
 };

--- a/js/admin.js
+++ b/js/admin.js
@@ -17,7 +17,7 @@ import {
     formatFieldLabels,
     getAdminRegistrationShareUrl,
     validateAdminRegistrationFormPayload
-} from './admin-registration-forms.js?v=2';
+} from './admin-registration-forms.js?v=3';
 
 let allTeams = [];
 let allUsers = [];
@@ -597,6 +597,8 @@ window.startRegistrationFormAdmin = function (formId = '') {
     document.getElementById('registration-fee').value = Number(form.feeAmountCents || 0) / 100;
     document.getElementById('registration-participant-fields').value = formatFieldLabels(form.participantFields, adminRegistrationDefaults.participantLabels);
     document.getElementById('registration-guardian-fields').value = formatFieldLabels(form.guardianFields, adminRegistrationDefaults.guardianLabels);
+    document.getElementById('registration-offline-payment').checked = form.paymentSettings?.offlinePaymentEnabled === true;
+    document.getElementById('registration-online-checkout').checked = form.paymentSettings?.onlineCheckoutEnabled === true;
     activeRegistrationOptions = Array.isArray(form.registrationOptions) ? form.registrationOptions.map(option => ({ ...option })) : [];
     renderRegistrationOptionsEditor();
     document.getElementById('registration-waiver').value = form.waiverText || '';
@@ -757,6 +759,10 @@ async function saveRegistrationForm(event) {
         participantFieldsText: document.getElementById('registration-participant-fields').value,
         guardianFieldsText: document.getElementById('registration-guardian-fields').value,
         registrationOptions: collectRegistrationOptionsFromEditor(),
+        paymentSettings: {
+            offlinePaymentEnabled: document.getElementById('registration-offline-payment').checked,
+            onlineCheckoutEnabled: document.getElementById('registration-online-checkout').checked
+        },
         waiverText: document.getElementById('registration-waiver').value,
         status: document.getElementById('registration-status').value
     }, { teamId });

--- a/js/registration-flow.js
+++ b/js/registration-flow.js
@@ -15,8 +15,34 @@ export function normalizeRegistrationForm(form = {}, context = {}) {
         waiverText: String(form.waiverText || form.waiver || '').trim(),
         status: String(form.status || '').trim(),
         published: form.published === true || form.status === 'published',
+        paymentSettings: normalizePaymentSettings(form.paymentSettings),
         registrationOptions: normalizeRegistrationOptions(form.registrationOptions || form.options || [])
     };
+}
+
+export function normalizePaymentSettings(settings = {}) {
+    return {
+        offlinePaymentEnabled: settings?.offlinePaymentEnabled === true,
+        onlineCheckoutEnabled: settings?.onlineCheckoutEnabled === true
+    };
+}
+
+export function hasRegistrationPaymentSettings(form = {}) {
+    return form.paymentSettings?.offlinePaymentEnabled === true || form.paymentSettings?.onlineCheckoutEnabled === true;
+}
+
+export function getRegistrationPaymentNotice(form = {}) {
+    const settings = form.paymentSettings || {};
+    if (settings.offlinePaymentEnabled && settings.onlineCheckoutEnabled) {
+        return 'Offline payment is accepted for this registration. Online checkout is planned, but online payment processing is not available yet.';
+    }
+    if (settings.offlinePaymentEnabled) {
+        return 'Offline payment is accepted for this registration. The organizer will share payment instructions after review.';
+    }
+    if (settings.onlineCheckoutEnabled) {
+        return 'Online checkout is planned for this registration, but online payment processing is not available yet.';
+    }
+    return '';
 }
 
 export function normalizeFields(fields = []) {
@@ -143,6 +169,7 @@ export function buildRegistrationRecord({ form, participant, guardian, waiverAcc
         programName: form.programName,
         feeAmountCents: form.feeAmountCents,
         currency: form.currency,
+        paymentSettings: normalizePaymentSettings(form.paymentSettings),
         participant,
         guardian,
         waiverAccepted: waiverAccepted === true,

--- a/registration.html
+++ b/registration.html
@@ -38,6 +38,11 @@
                     </dl>
                 </section>
 
+                <section id="registration-payment-section" class="hidden rounded border border-indigo-100 bg-indigo-50 p-4">
+                    <h2 class="text-xl font-semibold text-gray-900">Payment</h2>
+                    <p id="registration-payment-notice" class="mt-1 text-sm text-gray-700"></p>
+                </section>
+
                 <section id="registration-options-section" class="hidden">
                     <h2 class="text-xl font-semibold text-gray-900">Registration option</h2>
                     <p class="mt-1 text-sm text-gray-600">Choose the option that fits this participant.</p>
@@ -81,10 +86,12 @@
             decideRegistrationPlacement,
             formatFeeAmount,
             getActiveRegistrationOptions,
+            getRegistrationPaymentNotice,
+            hasRegistrationPaymentSettings,
             normalizeRegistrationForm,
             requiresRegistrationOption,
             validateRegistrationSubmission
-        } from './js/registration-flow.js?v=2';
+        } from './js/registration-flow.js?v=3';
 
         renderHeader(document.getElementById('header-container'), null);
         renderFooter(document.getElementById('footer-container'));
@@ -156,10 +163,27 @@
             guardianContainer.innerHTML = '';
             form.participantFields.forEach(field => renderField(participantContainer, field, 'participant'));
             form.guardianFields.forEach(field => renderField(guardianContainer, field, 'guardian'));
+            renderRegistrationPaymentSettings(form);
             renderRegistrationOptions(form);
 
             loadingState.classList.add('hidden');
             formElement.classList.remove('hidden');
+        }
+
+        function renderRegistrationPaymentSettings(form) {
+            const section = document.getElementById('registration-payment-section');
+            const notice = document.getElementById('registration-payment-notice');
+            const paymentNotice = getRegistrationPaymentNotice(form);
+            if (!hasRegistrationPaymentSettings(form) || !paymentNotice) {
+                section.classList.add('hidden');
+                notice.textContent = '';
+                submitButton.textContent = 'Submit registration';
+                return;
+            }
+
+            notice.textContent = paymentNotice;
+            submitButton.textContent = 'Submit registration';
+            section.classList.remove('hidden');
         }
 
         function renderRegistrationOptions(form) {
@@ -268,6 +292,8 @@
                 if (result.status === 'waitlisted') {
                     confirmationMessage.querySelector('h1').textContent = 'Registration waitlisted';
                     confirmationMessage.querySelector('p').textContent = 'This option is currently full, so your registration has been added to the waitlist.';
+                } else if (hasRegistrationPaymentSettings(activeForm)) {
+                    confirmationMessage.querySelector('p').textContent = getRegistrationPaymentNotice(activeForm) || 'The program organizer will follow up with next steps.';
                 }
                 confirmationMessage.classList.remove('hidden');
             } catch (error) {

--- a/tests/unit/admin-registration-forms.test.js
+++ b/tests/unit/admin-registration-forms.test.js
@@ -4,6 +4,7 @@ import {
     buildAdminRegistrationFormPayload,
     fieldLabelsToDefinitions,
     getAdminRegistrationShareUrl,
+    normalizePaymentSettings,
     normalizeRegistrationOptions,
     validateAdminRegistrationFormPayload
 } from '../../js/admin-registration-forms.js';
@@ -22,6 +23,7 @@ describe('admin registration form setup', () => {
                 { id: 'division-a', label: 'Division A', capacityLimit: '12', active: true, waitlistEnabled: true },
                 { label: 'Division B', capacityLimit: '', active: false, waitlistEnabled: false }
             ],
+            paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: true },
             waiverText: 'I accept the risk.',
             status: 'published'
         }, { teamId: 'team-1' });
@@ -35,6 +37,7 @@ describe('admin registration form setup', () => {
             season: 'Spring 2026',
             feeAmountCents: 12550,
             currency: 'USD',
+            paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: true },
             waiverText: 'I accept the risk.',
             status: 'published',
             published: true
@@ -49,6 +52,14 @@ describe('admin registration form setup', () => {
             { id: 'option_2', label: 'Division B', capacityLimit: null, active: false, waitlistEnabled: false, sortOrder: 1 }
         ]);
         expect(validateAdminRegistrationFormPayload(payload)).toEqual([]);
+    });
+
+    it('normalizes checkout and payment settings to bounded booleans', () => {
+        expect(normalizePaymentSettings()).toEqual({ offlinePaymentEnabled: false, onlineCheckoutEnabled: false });
+        expect(normalizePaymentSettings({ offlinePaymentEnabled: true, onlineCheckoutEnabled: 'yes' })).toEqual({
+            offlinePaymentEnabled: true,
+            onlineCheckoutEnabled: false
+        });
     });
 
     it('normalizes empty and legacy registration option settings safely', () => {
@@ -107,6 +118,9 @@ describe('admin registration form setup', () => {
         expect(adminPage).toContain('registration-participant-fields');
         expect(adminPage).toContain('registration-guardian-fields');
         expect(adminPage).toContain('registration-options-list');
+        expect(adminPage).toContain('registration-offline-payment');
+        expect(adminPage).toContain('registration-online-checkout');
+        expect(adminPage).toContain('Online payment processing is not available yet');
         expect(adminPage).toContain('registration-waiver');
         expect(adminPage).toContain('Publish and show link');
         expect(adminJs).toContain('window.openRegistrationFormsAdmin');
@@ -114,6 +128,7 @@ describe('admin registration form setup', () => {
         expect(adminJs).toContain('window.moveRegistrationOptionAdmin');
         expect(adminJs).toContain('window.removeRegistrationOptionAdmin');
         expect(adminJs).toContain('collectRegistrationOptionsFromEditor()');
+        expect(adminJs).toContain('offlinePaymentEnabled: document.getElementById');
         expect(adminJs).toContain('const teamId = activeRegistrationTeam.id;');
         expect(adminJs).toContain('if (activeRegistrationTeam?.id !== teamId) return;');
         expect(adminJs).toContain('teams/${teamId}/registrationForms');

--- a/tests/unit/registration-flow.test.js
+++ b/tests/unit/registration-flow.test.js
@@ -4,6 +4,8 @@ import {
     collectFieldValues,
     decideRegistrationPlacement,
     formatFeeAmount,
+    getRegistrationPaymentNotice,
+    hasRegistrationPaymentSettings,
     normalizeRegistrationForm,
     validateRegistrationSubmission
 } from '../../js/registration-flow.js';
@@ -15,6 +17,7 @@ describe('public registration flow', () => {
             name: 'Spring Soccer',
             season: 'Spring 2026',
             feeAmountCents: 12500,
+            paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: true },
             playerFields: [{ key: 'firstName', name: 'First name', required: true }],
             guardianFields: [{ id: 'email', label: 'Email', type: 'email', required: true }],
             waiver: 'I accept the risk.',
@@ -27,11 +30,15 @@ describe('public registration flow', () => {
             programName: 'Spring Soccer',
             season: 'Spring 2026',
             feeAmountCents: 12500,
+            paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: true },
             published: true,
             waiverText: 'I accept the risk.'
         });
         expect(form.participantFields[0]).toMatchObject({ id: 'firstName', label: 'First name', required: true });
         expect(form.guardianFields[0]).toMatchObject({ id: 'email', type: 'email' });
+        expect(form.paymentSettings).toEqual({ offlinePaymentEnabled: true, onlineCheckoutEnabled: true });
+        expect(hasRegistrationPaymentSettings(form)).toBe(true);
+        expect(getRegistrationPaymentNotice(form)).toContain('Online checkout is planned');
         expect(formatFeeAmount(form.feeAmountCents, form.currency)).toBe('$125.00');
     });
 
@@ -64,6 +71,7 @@ describe('public registration flow', () => {
         const form = normalizeRegistrationForm({
             programName: 'Clinic',
             feeAmountCents: 5000,
+            paymentSettings: { offlinePaymentEnabled: true },
             published: true,
             waiverText: 'Waiver'
         }, { teamId: 'team-1', formId: 'form-1' });
@@ -81,6 +89,7 @@ describe('public registration flow', () => {
             programName: 'Clinic',
             feeAmountCents: 5000,
             currency: 'USD',
+            paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: false },
             participant: { playerName: 'Sam' },
             guardian: { email: 'parent@example.com' },
             waiverAccepted: true,
@@ -190,6 +199,8 @@ describe('public registration flow', () => {
         expect(page).toContain("doc(db, 'teams', teamId, 'registrationForms', formId)");
         expect(page).toContain("collection(db, 'teams', teamId, 'registrationForms', formId, 'registrations')");
         expect(page).toContain('registration-options-section');
+        expect(page).toContain('registration-payment-section');
+        expect(page).toContain('getRegistrationPaymentNotice');
         expect(page).toContain('runTransaction(db, async (transaction)');
         expect(page).toContain('decideRegistrationPlacement');
         expect(page).toContain('registrationCapacityUpdateId: registrationRef.id');
@@ -206,7 +217,9 @@ describe('public registration flow', () => {
         expect(rules).toContain('function registrationFormPath(teamId, formId)');
         expect(rules).toContain('isPublishedRegistrationForm(get(formPath).data)');
         expect(rules).toContain("data.status in ['pending', 'waitlisted']");
+        expect(rules).toContain("'paymentSettings'");
         expect(rules).toContain("'selectedOption'");
+        expect(rules).toContain('isRegistrationPaymentSettingsPayloadValid');
         expect(rules).toContain('isPublicRegistrationCapacityCounterUpdate');
         expect(rules).toContain('registrationCapacityUpdateId');
         expect(rules).toContain('existsAfter(registrationPath)');


### PR DESCRIPTION
Closes #1015

## Summary
- Added admin registration checkout/payment settings for offline payment and future online checkout intent.
- Persisted bounded payment settings on registration form payloads and public registration snapshots.
- Updated public/admin copy to describe offline payment and clearly mark online payment processing as unavailable until backend support lands.

## Validation
- `npx vitest run tests/unit/admin-registration-forms.test.js tests/unit/registration-flow.test.js`
- `npm run ci:firebase-rules`