### PR TITLE
Fix recurring RSVP cutoff override time

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -135,7 +135,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvpSummaries, getRsvps } from './js/db.js?v=29';
+        import { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvpSummaries, getRsvps } from './js/db.js?v=33';
         import { renderHeader, renderFooter, escapeHtml, formatDate, formatTime, fetchAndParseCalendar, expandRecurrence, buildGlobalCalendarIcsEvent, isTrackedCalendarEvent } from './js/utils.js?v=12';
         import { mergeGlobalCalendarIcsEvents } from './js/calendar-ics-sync.js?v=1';
         import { requireAuth, checkAuth } from './js/auth.js?v=14';

--- a/js/availability-cutoff-date.js
+++ b/js/availability-cutoff-date.js
@@ -1,0 +1,53 @@
+function normalizeDateValue(value) {
+    if (!value) return null;
+    if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;
+    if (typeof value.toDate === 'function') {
+        const date = value.toDate();
+        return date instanceof Date && !Number.isNaN(date.getTime()) ? date : null;
+    }
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function parseStartTime(value) {
+    const time = typeof value === 'string' ? value.trim() : '';
+    const match = /^(\d{1,2}):(\d{2})$/.exec(time);
+    if (!match) return null;
+
+    const hours = Number(match[1]);
+    const minutes = Number(match[2]);
+    if (!Number.isInteger(hours) || !Number.isInteger(minutes)) return null;
+    if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null;
+
+    return { hours, minutes };
+}
+
+function getOccurrenceStartTime(game, instanceDate) {
+    const override = instanceDate && game?.overrides && typeof game.overrides === 'object'
+        ? game.overrides[instanceDate]
+        : null;
+    return override?.startTime || game?.startTime || null;
+}
+
+export function resolveAvailabilityCutoffEventDate(game, instanceDate) {
+    const baseDate = normalizeDateValue(game?.date);
+    if (!baseDate) return null;
+
+    if (!instanceDate) {
+        return baseDate;
+    }
+
+    const occurrenceDate = new Date(`${instanceDate}T00:00:00`);
+    if (Number.isNaN(occurrenceDate.getTime())) {
+        return baseDate;
+    }
+
+    const startTime = parseStartTime(getOccurrenceStartTime(game, instanceDate));
+    if (startTime) {
+        occurrenceDate.setHours(startTime.hours, startTime.minutes, 0, 0);
+    } else {
+        occurrenceDate.setHours(baseDate.getHours(), baseDate.getMinutes(), baseDate.getSeconds(), baseDate.getMilliseconds());
+    }
+
+    return occurrenceDate;
+}

--- a/js/db.js
+++ b/js/db.js
@@ -45,6 +45,7 @@ import { buildCoachOverrideRsvpDocId, shouldDeleteLegacyRsvpForOverride } from '
 import { computeEffectiveRsvpSummary } from './rsvp-summary.js?v=1';
 import { buildGameDayRsvpBreakdown } from './game-day-rsvp-breakdown.js?v=1';
 import { isAvailabilityLocked, normalizeAvailabilityPreferences } from './availability-preferences.js?v=1';
+import { resolveAvailabilityCutoffEventDate } from './availability-cutoff-date.js?v=1';
 import { normalizeChatAttachments } from './team-chat-media.js';
 import {
     DEFAULT_TEAM_CONVERSATION_ID,
@@ -5489,16 +5490,7 @@ async function getEventDateForAvailabilityCutoff(teamId, gameId) {
     const gameRef = doc(db, `teams/${teamId}/games`, masterId || gameId);
     const snap = await getDoc(gameRef);
     if (!snap.exists()) return null;
-    const game = snap.data();
-    const baseDate = game.date?.toDate ? game.date.toDate() : new Date(game.date);
-    if (instanceDate && !Number.isNaN(baseDate.getTime())) {
-        const occurrenceDate = new Date(`${instanceDate}T00:00:00`);
-        if (!Number.isNaN(occurrenceDate.getTime())) {
-            occurrenceDate.setHours(baseDate.getHours(), baseDate.getMinutes(), baseDate.getSeconds(), baseDate.getMilliseconds());
-            return occurrenceDate;
-        }
-    }
-    return baseDate;
+    return resolveAvailabilityCutoffEventDate(snap.data(), instanceDate);
 }
 
 async function assertAvailabilityOpen(teamId, gameId) {

--- a/tests/unit/availability-cutoff-date.test.js
+++ b/tests/unit/availability-cutoff-date.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { resolveAvailabilityCutoffEventDate } from '../../js/availability-cutoff-date.js';
+
+describe('resolveAvailabilityCutoffEventDate', () => {
+    it('uses an overridden recurring occurrence start time for cutoff checks', () => {
+        const eventDate = resolveAvailabilityCutoffEventDate({
+            date: new Date('2026-06-10T10:00:00'),
+            startTime: '10:00',
+            overrides: {
+                '2026-06-17': { startTime: '18:00' }
+            }
+        }, '2026-06-17');
+
+        expect(eventDate).toBeInstanceOf(Date);
+        expect(eventDate.getFullYear()).toBe(2026);
+        expect(eventDate.getMonth()).toBe(5);
+        expect(eventDate.getDate()).toBe(17);
+        expect(eventDate.getHours()).toBe(18);
+        expect(eventDate.getMinutes()).toBe(0);
+    });
+
+    it('falls back to the series start time when the occurrence is not overridden', () => {
+        const eventDate = resolveAvailabilityCutoffEventDate({
+            date: new Date('2026-06-10T10:00:00'),
+            startTime: '10:00',
+            overrides: {}
+        }, '2026-06-17');
+
+        expect(eventDate.getFullYear()).toBe(2026);
+        expect(eventDate.getMonth()).toBe(5);
+        expect(eventDate.getDate()).toBe(17);
+        expect(eventDate.getHours()).toBe(10);
+        expect(eventDate.getMinutes()).toBe(0);
+    });
+});

--- a/tests/unit/calendar-day-modal-rsvp.test.js
+++ b/tests/unit/calendar-day-modal-rsvp.test.js
@@ -88,7 +88,7 @@ const URL = deps.URL;
 const Blob = deps.Blob;
 ` + match[1]
         .replace(
-            "import { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvpSummaries, getRsvps } from './js/db.js?v=29';",
+            "import { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvpSummaries, getRsvps } from './js/db.js?v=33';",
             'const { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvpSummaries, getRsvps } = deps.db;'
         )
         .replace(


### PR DESCRIPTION
Closes #1026

## Summary
- Added a focused availability cutoff date resolver that applies per-occurrence `overrides[instanceDate].startTime` before evaluating RSVP lock state.
- Wired `assertAvailabilityOpen` through the resolver so recurring occurrence RSVP submissions match the UI-expanded occurrence time.
- Bumped affected `db.js` cache-bust imports for parent dashboard and calendar RSVP flows.

## Validation
- `npx vitest run tests/unit/availability-cutoff-date.test.js tests/unit/calendar-day-modal-rsvp.test.js --reporter=dot`
- `node scripts/check-critical-cache-bust.mjs`