### PR TITLE
Fix: ICS export uses correct event durations and falls back to type-specific defaults

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -799,7 +799,17 @@
                 if (seen.has(dedupeKey)) return;
                 seen.add(dedupeKey);
                 const start = fmtDate(ev.date);
-                const end = fmtDate(new Date(ev.date.getTime() + 60 * 60 * 1000));
+                let endDate = null;
+                if (ev.end instanceof Date && !isNaN(ev.end)) {
+                    endDate = ev.end;
+                } else {
+                    let durationMs = 60 * 60 * 1000; // Default 1 hour
+                    if (ev.type === 'game') {
+                        durationMs = 2 * 60 * 60 * 1000; // 2 hours for games
+                    }
+                    endDate = new Date(ev.date.getTime() + durationMs);
+                }
+                const end = fmtDate(endDate);
                 lines.push(
                     'BEGIN:VEVENT',
                     `UID:${dedupeKey}@allplays`,

--- a/calendar.html
+++ b/calendar.html
@@ -330,6 +330,7 @@
                                     type: 'practice',
                                     title: occ.title || 'Practice',
                                     date: occ.date instanceof Date ? occ.date : new Date(occ.date),
+                                    end: occ.end || null, // Add this line
                                     location: occ.location || 'TBD',
                                     status: game.status,
                                     isHome: null,
@@ -364,6 +365,7 @@
                                 type: game.type || 'game',
                                 title: game.type === 'practice' ? (game.title || 'Practice') : `vs. ${game.opponent || 'TBD'}`,
                                 date,
+                                end: game.endDate?.toDate ? game.endDate.toDate() : (game.endDate ? new Date(game.endDate) : null), // Add this line
                                 location: game.location || 'TBD',
                                 status: game.status,
                                 isHome: game.isHome,

--- a/js/utils.js
+++ b/js/utils.js
@@ -1377,6 +1377,7 @@ export function buildGlobalCalendarIcsEvent({ team, teamColor, event }) {
     date: eventDate,
     location: event.location || 'TBD',
     status: getCalendarEventStatus(event),
+    end: event?.dtend instanceof Date ? event.dtend : null, // Add this line
     source: 'ics'
   };
 }


### PR DESCRIPTION
Closes #1030

Recovered from a partial issue-fixer run. The agent committed the fix branch successfully, so paulbot is opening the PR from the recorded commit.