### PR TITLE
Fix(calendar): Ensure ICS export uses actual event end times

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -802,9 +802,23 @@
                 seen.add(dedupeKey);
                 const start = fmtDate(ev.date);
                 let endDate = null;
-                if (ev.end instanceof Date && !isNaN(ev.end)) {
-                    endDate = ev.end;
-                } else {
+                // Attempt to resolve ev.end into a valid Date object if it exists
+                if (ev.end) {
+                    let potentialDate = ev.end;
+                    if (!(potentialDate instanceof Date)) {
+                        if (typeof potentialDate === 'string') {
+                            potentialDate = new Date(potentialDate);
+                        } else if (typeof potentialDate === 'object' && potentialDate !== null && typeof potentialDate.toDate === 'function') {
+                            potentialDate = potentialDate.toDate(); // Assume Firebase Timestamp-like
+                        }
+                    }
+                    if (potentialDate instanceof Date && !isNaN(potentialDate)) {
+                        endDate = potentialDate;
+                    }
+                }
+
+                // If endDate is still not a valid Date, apply default duration
+                if (!(endDate instanceof Date) || isNaN(endDate)) {
                     let durationMs = 60 * 60 * 1000; // Default 1 hour
                     if (ev.type === 'game') {
                         durationMs = 2 * 60 * 60 * 1000; // 2 hours for games


### PR DESCRIPTION
Closes #1034

This change addresses a bug in the calendar's ICS export functionality where all events were assigned a hardcoded 1-hour duration, regardless of their actual length.

The `exportIcs` function in `calendar.html` was modified to more robustly handle event end times (`ev.end`). Previously, if `ev.end` was not strictly a `Date` object (e.g., a string or Firebase Timestamp), it would fall back to a default duration. The updated logic now attempts to convert `ev.end` to a valid `Date` object from various formats before resorting to default durations (1 hour for practices, 2 hours for games). This ensures that actual event end times, when provided, are correctly reflected in the exported ICS file.