### PR TITLE
fix: #1042 Display custom opponent player names on game reopen

### DIFF
--- a/track.html
+++ b/track.html
@@ -395,6 +395,14 @@
                     });
                 }
 
+                // Synchronize opponentPlayers array with loaded gameState.opponentStats
+                // This ensures the UI reflects saved opponent names, and handles dynamically added players.
+                opponentPlayers = Object.entries(gameState.opponentStats).map(([id, stats]) => ({
+                    id: id,
+                    name: stats.name || '',
+                    notes: '' // Notes are not stored in gameState.opponentStats directly upon initialization/load, so keep empty.
+                }));
+
                 document.getElementById('game-title').textContent = `vs. ${escapeHtml(game.opponent)}`;
                 document.getElementById('game-meta').textContent = escapeHtml(team.name);
                 homeScore = game.homeScore || 0;


### PR DESCRIPTION
Closes #1042

This PR addresses a functional bug where custom opponent player names were not displayed in the 'Opponent Stats' table when revisiting a game tracking page, even though the names were correctly saved in `gameState.opponentStats`.

The `opponentPlayers` array, which drives the UI rendering, was not being synchronized with the loaded `gameState.opponentStats` after game data was fetched. This led to empty input fields for opponent player names, requiring users to re-enter them.

The fix involves:
- Synchronizing the `opponentPlayers` array with the `name` and `id` from `gameState.opponentStats` immediately after `gameState.opponentStats` is loaded or initialized in the `init()` function.

This ensures that the `renderOpponentTable()` function uses the correct, previously saved opponent player names when rendering the UI, providing a consistent user experience and preventing perceived data loss.