### PR TITLE
Fix live tracker config fallback

### DIFF
--- a/tests/unit/track-live-live-events.test.js
+++ b/tests/unit/track-live-live-events.test.js
@@ -26,6 +26,8 @@ describe('track-live live event publishing', () => {
     expect(source).toContain('id="goal-note-input"');
     expect(source).toContain("getGoalSportProfile({ game: currentGame, team: currentTeam, config: currentConfig })");
     expect(source).toContain('hasExplicitStatTrackerConfig');
+    expect(source).toContain('hasResolvedStatTrackerConfig');
+    expect(source).toContain('hasExplicitStatTrackerConfig || hasResolvedStatTrackerConfig');
     expect(source).toContain("recordGoalSportGoal('home')");
     expect(source).toContain("recordGoalSportGoal('away')");
     expect(source).toContain("type: 'goal'");

--- a/track-live.html
+++ b/track-live.html
@@ -900,7 +900,8 @@
                     };
                 }
                 const hasExplicitStatTrackerConfig = !!String(currentGame?.statTrackerConfigId || '').trim();
-                currentGoalSportProfile = hasExplicitStatTrackerConfig
+                const hasResolvedStatTrackerConfig = !!String(currentConfig?.id || '').trim();
+                currentGoalSportProfile = hasExplicitStatTrackerConfig || hasResolvedStatTrackerConfig
                     ? null
                     : getGoalSportProfile({ game: currentGame, team: currentTeam, config: currentConfig });
 


### PR DESCRIPTION
## Summary
- Treat a resolved team stat tracker config as authoritative in `track-live.html` even when the game record is missing `statTrackerConfigId`.
- Add a focused regression assertion for the goal-sport wiring test.

## Why
Imported or older soccer games can have `statTrackerConfigId: null`. The tracker was falling into built-in soccer goal-only mode even though the team has a matching Soccer Standard config, which hid the normal stat controls.

## Validation
- `npx vitest run tests/unit/track-live-live-events.test.js`
