### PR TITLE
Add simple live goal tracker choice

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -796,6 +796,14 @@
                     </span>
                     Live Broadcast Tracker
                 </button>
+                <button id="basketball-tracker-live-simple"
+                    class="hidden w-full px-4 py-3 bg-emerald-100 text-emerald-800 rounded-lg hover:bg-emerald-200 transition font-semibold flex items-center justify-center gap-2">
+                    <span class="inline-flex items-center gap-1 bg-emerald-600 text-white text-[10px] font-bold px-2 py-0.5 rounded-full">
+                        <span class="w-1.5 h-1.5 bg-white rounded-full animate-pulse"></span>
+                        LIVE
+                    </span>
+                    Live Broadcast Simple
+                </button>
                 <button id="basketball-tracker-photo"
                     class="w-full px-4 py-3 bg-amber-100 text-amber-800 rounded-lg hover:bg-amber-200 transition font-semibold">
                     Photo Score Sheet
@@ -909,6 +917,7 @@
         import { buildOfficiatingAssignmentNotificationRecords } from './js/officiating-notifications.js?v=2';
         import { getTeamAccessInfo } from './js/team-access.js';
         import { resolvePreferredStatConfigId } from './js/live-game-state.js?v=3';
+        import { getGoalSportProfile } from './js/live-sport-config.js?v=3';
         import { cancelScheduledGame } from './js/edit-schedule-cancel-game.js?v=3';
         import { applyPracticeRecurrenceFields } from './js/edit-schedule-practice-payload.js?v=1';
         import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=1';
@@ -2458,6 +2467,7 @@
         let allTeamGamesCache = {};
         let pendingTrackGameId = null;
         let pendingTrackIsBasketball = false;
+        let pendingTrackSupportsSimpleLive = false;
 
         // Helper function to check if a stat config is for basketball
         function isBasketballConfig(configId) {
@@ -2479,36 +2489,57 @@
             return isBasketballConfig(game.statTrackerConfigId);
         }
 
+        function getStatConfigForGame(game) {
+            const configId = String(game?.statTrackerConfigId || '').trim();
+            if (!configId) return null;
+            return allConfigs.find(config => String(config.id || '').trim() === configId) || null;
+        }
+
+        function isGoalSportForGame(game) {
+            if (!game || isBasketballForGame(game)) return false;
+            const config = getStatConfigForGame(game);
+            const sport = game?.sport || config?.baseType || currentTeam?.sport || '';
+            return !!getGoalSportProfile({ sport });
+        }
+
         function closeBasketballTrackerModal() {
             document.getElementById('basketball-tracker-modal')?.classList.add('hidden');
             pendingTrackGameId = null;
             pendingTrackIsBasketball = false;
+            pendingTrackSupportsSimpleLive = false;
         }
 
-        function configureTrackerChoiceModal(isBasketball) {
+        function configureTrackerChoiceModal(isBasketball, supportsSimpleLive) {
             const description = document.getElementById('tracker-choice-description');
             const betaBtn = document.getElementById('basketball-tracker-beta');
+            const simpleBtn = document.getElementById('basketball-tracker-live-simple');
             const photoBtn = document.getElementById('basketball-tracker-photo');
             if (description) {
-                description.textContent = isBasketball
-                    ? 'This game uses a Basketball stat config. Which tracker do you want?'
-                    : 'Choose a tracker for this game.';
+                if (isBasketball) {
+                    description.textContent = 'This game uses a Basketball stat config. Which tracker do you want?';
+                } else if (supportsSimpleLive) {
+                    description.textContent = 'Choose full stat broadcasting or simple goal broadcasting for this game.';
+                } else {
+                    description.textContent = 'Choose a tracker for this game.';
+                }
             }
             if (betaBtn) betaBtn.classList.toggle('hidden', !isBasketball);
+            if (simpleBtn) simpleBtn.classList.toggle('hidden', !supportsSimpleLive);
             if (photoBtn) photoBtn.classList.toggle('hidden', !isBasketball);
         }
 
-        function openTrackerChoiceModal(gameId, isBasketball) {
+        function openTrackerChoiceModal(gameId, isBasketball, supportsSimpleLive = false) {
             pendingTrackGameId = gameId;
             pendingTrackIsBasketball = !!isBasketball;
-            configureTrackerChoiceModal(pendingTrackIsBasketball);
+            pendingTrackSupportsSimpleLive = !!supportsSimpleLive;
+            configureTrackerChoiceModal(pendingTrackIsBasketball, pendingTrackSupportsSimpleLive);
             document.getElementById('basketball-tracker-modal')?.classList.remove('hidden');
         }
 
         function handleTrackClick(gameId) {
             const game = gamesCache[gameId];
             if (!game) return;
-            openTrackerChoiceModal(gameId, isBasketballForGame(game));
+            openTrackerChoiceModal(gameId, isBasketballForGame(game), isGoalSportForGame(game));
         }
 
         function renderDbGame(game) {
@@ -3640,7 +3671,11 @@
                     calendarEventUid: getCalendarEventTrackingId(calendarEvent)
                 });
 
-                openTrackerChoiceModal(gameId, isBasketballConfig(configId));
+                const trackingGame = {
+                    statTrackerConfigId: configId || null,
+                    sport: currentTeam?.sport || ''
+                };
+                openTrackerChoiceModal(gameId, isBasketballConfig(configId), isGoalSportForGame(trackingGame));
             } catch (error) {
                 console.error('Error tracking game:', error);
                 alert('Error tracking game: ' + error.message);
@@ -4762,6 +4797,12 @@ PARSING RULES:
             } else {
                 window.location.href = `track-live.html?v=2#teamId=${currentTeamId}&gameId=${gameId}`;
             }
+        });
+        document.getElementById('basketball-tracker-live-simple')?.addEventListener('click', () => {
+            if (!pendingTrackGameId || !pendingTrackSupportsSimpleLive) return closeBasketballTrackerModal();
+            const gameId = pendingTrackGameId;
+            closeBasketballTrackerModal();
+            window.location.href = `track-live.html?v=2#teamId=${currentTeamId}&gameId=${gameId}&trackerMode=simple`;
         });
         document.getElementById('basketball-tracker-photo')?.addEventListener('click', () => {
             if (!pendingTrackGameId) return closeBasketballTrackerModal();

--- a/js/live-game-state.js
+++ b/js/live-game-state.js
@@ -71,6 +71,19 @@ export function resolvePreferredStatConfigId({ configs = [], team = null } = {})
   return String(config?.id || '').trim() || null;
 }
 
+export function resolveGoalSportTrackerProfile({ trackerMode = '', game = null, team = null, config = null } = {}) {
+  const sport = game?.sport || config?.baseType || team?.sport || '';
+  const goalSportProfile = getGoalSportProfile({ sport });
+  if (!goalSportProfile) return null;
+
+  const mode = String(trackerMode || '').trim().toLowerCase();
+  if (mode === 'simple') return goalSportProfile;
+
+  const hasExplicitStatTrackerConfig = !!String(game?.statTrackerConfigId || '').trim();
+  const hasResolvedStatTrackerConfig = !!String(config?.id || '').trim();
+  return hasExplicitStatTrackerConfig || hasResolvedStatTrackerConfig ? null : goalSportProfile;
+}
+
 export function resolveLiveStatColumns({ columns = [], configs = [], game = null, team = null } = {}) {
   const directColumns = normalizeLiveStatColumns(columns);
   if (Array.isArray(columns) && columns.length) return directColumns;

--- a/js/live-tracker-notes.js
+++ b/js/live-tracker-notes.js
@@ -19,3 +19,11 @@ export function buildGameNoteLogText(noteText, type = 'text') {
   if (!note) return '';
   return type === 'voice' ? `Voice note: ${note}` : `Note: ${note}`;
 }
+
+export function buildGoalSportNoteText(teamLabel, noteText) {
+  const note = normalizeGameNoteText(noteText);
+  if (!note) return '';
+  const label = normalizeGameNoteText(teamLabel);
+  if (!label) return `Goal: ${note}`;
+  return `${label} goal: ${note}`;
+}

--- a/js/live-tracker-notes.js
+++ b/js/live-tracker-notes.js
@@ -14,6 +14,18 @@ export function appendGameSummaryLine(existingSummary, noteText) {
   return summary ? `${summary}\n${note}` : note;
 }
 
+export function removeGameSummaryLine(existingSummary, noteText) {
+  const note = normalizeGameNoteText(noteText);
+  if (!note) return normalizeGameNoteText(existingSummary);
+
+  const lines = String(existingSummary || '').split('\n');
+  const index = lines.map(normalizeGameNoteText).lastIndexOf(note);
+  if (index === -1) return normalizeGameNoteText(existingSummary);
+
+  lines.splice(index, 1);
+  return lines.map(normalizeGameNoteText).filter(Boolean).join('\n');
+}
+
 export function buildGameNoteLogText(noteText, type = 'text') {
   const note = normalizeGameNoteText(noteText);
   if (!note) return '';

--- a/tests/unit/edit-schedule-basketball-routing.test.js
+++ b/tests/unit/edit-schedule-basketball-routing.test.js
@@ -20,6 +20,29 @@ ${match[1]}
     return createHelper({ allConfigs, currentTeam });
 }
 
+function buildTrackerRoutingHelpers({ allConfigs, currentTeam }) {
+    const source = readEditSchedule();
+    const match = source.match(/function isBasketballConfig\(configId\) \{([\s\S]*?)\n        \}\n\n        function closeBasketballTrackerModal/);
+    expect(match, 'tracker routing helpers should exist').toBeTruthy();
+
+    const createHelpers = new Function('deps', `
+        const { allConfigs, currentTeam, getGoalSportProfile } = deps;
+        ${match[0].replace('\n\n        function closeBasketballTrackerModal', '')}
+        return { isBasketballConfig, isBasketballForGame, getStatConfigForGame, isGoalSportForGame };
+    `);
+
+    return createHelpers({
+        allConfigs,
+        currentTeam,
+        getGoalSportProfile: ({ sport }) => {
+            const normalized = String(sport || '').trim().toLowerCase();
+            return ['soccer', 'hockey', 'lacrosse', 'field hockey', 'water polo'].includes(normalized)
+                ? { sport: normalized }
+                : null;
+        }
+    });
+}
+
 describe('edit schedule basketball tracker routing', () => {
     it('falls back to the team sport when a referenced config has no baseType', () => {
         const isBasketballConfig = buildIsBasketballConfig({
@@ -37,5 +60,36 @@ describe('edit schedule basketball tracker routing', () => {
         });
 
         expect(isBasketballConfig('config-2')).toBe(false);
+    });
+
+    it('offers simple live only for non-basketball goal sports', () => {
+        const helpers = buildTrackerRoutingHelpers({
+            allConfigs: [
+                { id: 'soccer-config', baseType: 'Soccer' },
+                { id: 'basketball-config', baseType: 'Basketball' },
+                { id: 'baseball-config', baseType: 'Baseball' }
+            ],
+            currentTeam: { sport: 'Soccer' }
+        });
+
+        expect(helpers.isGoalSportForGame({ statTrackerConfigId: 'soccer-config' })).toBe(true);
+        expect(helpers.isGoalSportForGame({ statTrackerConfigId: null })).toBe(true);
+        expect(helpers.isGoalSportForGame({ statTrackerConfigId: 'basketball-config' })).toBe(false);
+        expect(helpers.isGoalSportForGame({ statTrackerConfigId: 'baseball-config' })).toBe(false);
+    });
+
+    it('wires full and simple live broadcast choices without changing the full tracker route', () => {
+        const source = readEditSchedule();
+
+        expect(source).toContain('id="basketball-tracker-live-simple"');
+        expect(source).toContain('Live Broadcast Simple');
+        expect(source).toContain("import { getGoalSportProfile } from './js/live-sport-config.js?v=3';");
+        expect(source).toContain("const simpleBtn = document.getElementById('basketball-tracker-live-simple');");
+        expect(source).toContain("if (simpleBtn) simpleBtn.classList.toggle('hidden', !supportsSimpleLive);");
+        expect(source).toContain('openTrackerChoiceModal(gameId, isBasketballForGame(game), isGoalSportForGame(game));');
+        expect(source).toContain('const trackingGame = {');
+        expect(source).toContain('openTrackerChoiceModal(gameId, isBasketballConfig(configId), isGoalSportForGame(trackingGame));');
+        expect(source).toContain('window.location.href = `track-live.html?v=2#teamId=${currentTeamId}&gameId=${gameId}`;');
+        expect(source).toContain('window.location.href = `track-live.html?v=2#teamId=${currentTeamId}&gameId=${gameId}&trackerMode=simple`;');
     });
 });

--- a/tests/unit/live-game-state.test.js
+++ b/tests/unit/live-game-state.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { resolveOpponentDisplayName, normalizeLiveStatColumns, resolveLiveStatConfig, resolvePreferredStatConfigId, resolveLiveStatColumns, renderOpponentStatsCards, applyResetEventState, applyViewerEventToState, shouldResetViewerFromGameDoc, isLiveEventVisibleForResetBoundary, collectVisibleLiveEventsSequentially } from '../../js/live-game-state.js';
+import { resolveOpponentDisplayName, normalizeLiveStatColumns, resolveLiveStatConfig, resolvePreferredStatConfigId, resolveLiveStatColumns, resolveGoalSportTrackerProfile, renderOpponentStatsCards, applyResetEventState, applyViewerEventToState, shouldResetViewerFromGameDoc, isLiveEventVisibleForResetBoundary, collectVisibleLiveEventsSequentially } from '../../js/live-game-state.js';
 
 describe('live game state helpers', () => {
   it('prefers linked opponent team name when opponent is missing', () => {
@@ -72,6 +72,56 @@ describe('live game state helpers', () => {
       ],
       team: { sport: 'Soccer' }
     })).toBe('cfg-only');
+  });
+
+  it('uses the goal-sport simple tracker only when no stat config is resolved by default', () => {
+    expect(resolveGoalSportTrackerProfile({
+      game: { sport: 'Soccer' },
+      team: { sport: 'Soccer' },
+      config: { id: 'cfg-soccer', baseType: 'Soccer', columns: ['GOALS', 'SHOTS'] }
+    })).toBeNull();
+
+    expect(resolveGoalSportTrackerProfile({
+      game: { sport: 'Soccer', statTrackerConfigId: 'cfg-soccer' },
+      team: { sport: 'Soccer' },
+      config: { baseType: 'Soccer', columns: ['GOALS', 'SHOTS'] }
+    })).toBeNull();
+
+    expect(resolveGoalSportTrackerProfile({
+      game: { sport: 'Soccer' },
+      team: { sport: 'Soccer' },
+      config: { name: 'Default', baseType: 'Soccer', columns: ['GOALS'] }
+    })).toMatchObject({ sport: 'soccer', statColumns: ['GOALS'] });
+  });
+
+  it('lets trackerMode=simple force goal-sport scoring without affecting non-goal sports', () => {
+    expect(resolveGoalSportTrackerProfile({
+      trackerMode: 'simple',
+      game: { sport: 'Soccer' },
+      team: { sport: 'Soccer' },
+      config: { id: 'cfg-soccer', baseType: 'Soccer', columns: ['GOALS', 'SHOTS'] }
+    })).toMatchObject({ sport: 'soccer', statColumns: ['GOALS'] });
+
+    expect(resolveGoalSportTrackerProfile({
+      trackerMode: ' SIMPLE ',
+      game: { sport: 'Hockey' },
+      team: { sport: 'Hockey' },
+      config: { id: 'cfg-hockey', baseType: 'Hockey', columns: ['GOALS', 'SAVES'] }
+    })).toMatchObject({ sport: 'hockey' });
+
+    expect(resolveGoalSportTrackerProfile({
+      trackerMode: 'simple',
+      game: { sport: 'Basketball' },
+      team: { sport: 'Basketball' },
+      config: { id: 'cfg-basketball', baseType: 'Basketball', columns: ['PTS'] }
+    })).toBeNull();
+
+    expect(resolveGoalSportTrackerProfile({
+      trackerMode: 'simple',
+      game: {},
+      team: { sport: 'Soccer' },
+      config: { id: 'cfg-baseball', baseType: 'Baseball', columns: ['RUNS'] }
+    })).toBeNull();
   });
 
   it('renders persisted opponent identity and injects FLS when config omits fouls', () => {

--- a/tests/unit/live-tracker-notes.test.js
+++ b/tests/unit/live-tracker-notes.test.js
@@ -3,6 +3,7 @@ import {
   isVoiceRecognitionSupported,
   normalizeGameNoteText,
   appendGameSummaryLine,
+  removeGameSummaryLine,
   buildGameNoteLogText,
   buildGoalSportNoteText
 } from '../../js/live-tracker-notes.js';
@@ -30,6 +31,15 @@ describe('live tracker note helpers', () => {
 
   it('does not append empty note lines', () => {
     expect(appendGameSummaryLine('First note', '   ')).toBe('First note');
+  });
+
+  it('removes the last matching summary line', () => {
+    expect(removeGameSummaryLine('Goal A\nGoal B\nGoal A', 'Goal A')).toBe('Goal A\nGoal B');
+  });
+
+  it('leaves summaries unchanged when a matching line is not found', () => {
+    expect(removeGameSummaryLine('Goal A\nGoal B', 'Goal C')).toBe('Goal A\nGoal B');
+    expect(removeGameSummaryLine('Goal A\nGoal B', '   ')).toBe('Goal A\nGoal B');
   });
 
   it('formats text note log entries', () => {

--- a/tests/unit/live-tracker-notes.test.js
+++ b/tests/unit/live-tracker-notes.test.js
@@ -3,7 +3,8 @@ import {
   isVoiceRecognitionSupported,
   normalizeGameNoteText,
   appendGameSummaryLine,
-  buildGameNoteLogText
+  buildGameNoteLogText,
+  buildGoalSportNoteText
 } from '../../js/live-tracker-notes.js';
 
 describe('live tracker note helpers', () => {
@@ -37,5 +38,11 @@ describe('live tracker note helpers', () => {
 
   it('formats voice note log entries', () => {
     expect(buildGameNoteLogText('Great closeout by 12', 'voice')).toBe('Voice note: Great closeout by 12');
+  });
+
+  it('formats simple goal tracker notes with scoring context', () => {
+    expect(buildGoalSportNoteText('Jr KC Current', ' Header off corner ')).toBe('Jr KC Current goal: Header off corner');
+    expect(buildGoalSportNoteText('', 'Set piece')).toBe('Goal: Set piece');
+    expect(buildGoalSportNoteText('Jr KC Current', '   ')).toBe('');
   });
 });

--- a/tests/unit/track-live-live-events.test.js
+++ b/tests/unit/track-live-live-events.test.js
@@ -27,8 +27,9 @@ describe('track-live live event publishing', () => {
     expect(source).toContain('id="live-notes-list"');
     expect(source).toContain('resolveGoalSportTrackerProfile');
     expect(source).toContain("from './js/live-game-state.js?v=7'");
-    expect(source).toContain("from './js/live-tracker-notes.js?v=2'");
+    expect(source).toContain("from './js/live-tracker-notes.js?v=3'");
     expect(source).toContain('buildGoalSportNoteText');
+    expect(source).toContain('removeGameSummaryLine');
     expect(source).toContain('const { teamId, gameId, trackerMode } = getUrlParams();');
     expect(source).toContain('trackerMode,');
     expect(source).toContain('game: currentGame,');
@@ -40,7 +41,10 @@ describe('track-live live event publishing', () => {
     expect(source).toContain('statKey: event.statKey');
     expect(source).toContain('isOpponent: event.isOpponent');
     expect(source).toContain('buildGoalSportEvent({');
-    expect(source).toContain("addLiveNoteRecord(buildGoalSportNoteText(noteTeamLabel, event.note), 'goal');");
+    expect(source).toContain("const liveNote = addLiveNoteRecord(buildGoalSportNoteText(noteTeamLabel, event.note), 'goal');");
+    expect(source).toContain('liveNoteId: liveNote?.id || null');
+    expect(source).toContain('liveNoteText: liveNote?.text || null');
+    expect(source).toContain('removeLiveNoteRecord(undoData.liveNoteId, undoData.liveNoteText);');
     expect(source).toContain('function renderLiveNotes()');
   });
 

--- a/tests/unit/track-live-live-events.test.js
+++ b/tests/unit/track-live-live-events.test.js
@@ -24,16 +24,24 @@ describe('track-live live event publishing', () => {
     expect(source).toContain('id="goal-sport-controls"');
     expect(source).toContain('id="goal-scorer-input"');
     expect(source).toContain('id="goal-note-input"');
-    expect(source).toContain("getGoalSportProfile({ game: currentGame, team: currentTeam, config: currentConfig })");
-    expect(source).toContain('hasExplicitStatTrackerConfig');
-    expect(source).toContain('hasResolvedStatTrackerConfig');
-    expect(source).toContain('hasExplicitStatTrackerConfig || hasResolvedStatTrackerConfig');
+    expect(source).toContain('id="live-notes-list"');
+    expect(source).toContain('resolveGoalSportTrackerProfile');
+    expect(source).toContain("from './js/live-game-state.js?v=7'");
+    expect(source).toContain("from './js/live-tracker-notes.js?v=2'");
+    expect(source).toContain('buildGoalSportNoteText');
+    expect(source).toContain('const { teamId, gameId, trackerMode } = getUrlParams();');
+    expect(source).toContain('trackerMode,');
+    expect(source).toContain('game: currentGame,');
+    expect(source).toContain('team: currentTeam,');
+    expect(source).toContain('config: currentConfig');
     expect(source).toContain("recordGoalSportGoal('home')");
     expect(source).toContain("recordGoalSportGoal('away')");
     expect(source).toContain("type: 'goal'");
     expect(source).toContain('statKey: event.statKey');
     expect(source).toContain('isOpponent: event.isOpponent');
     expect(source).toContain('buildGoalSportEvent({');
+    expect(source).toContain("addLiveNoteRecord(buildGoalSportNoteText(noteTeamLabel, event.note), 'goal');");
+    expect(source).toContain('function renderLiveNotes()');
   });
 
   it('includes bounded football play logging with down-distance context', () => {

--- a/track-live.html
+++ b/track-live.html
@@ -554,6 +554,9 @@
                 <button id="live-note-add"
                     class="px-3 py-2 rounded bg-teal text-ink text-xs font-semibold hover:bg-teal/80">Add</button>
             </div>
+            <div id="live-notes-list" class="space-y-1">
+                <div class="p-2 bg-slate/60 rounded text-sand/50 text-xs">No live notes yet</div>
+            </div>
         </div>
 
         <!-- Game Log -->
@@ -668,10 +671,10 @@
         import { db } from './js/firebase.js?v=11';
         import { writeBatch, doc, setDoc, addDoc, onSnapshot } from './js/firebase.js?v=11';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
-        import { resolveOpponentDisplayName, resolveLiveStatConfig, resolveLiveStatColumns } from './js/live-game-state.js?v=6';
+        import { resolveOpponentDisplayName, resolveLiveStatConfig, resolveLiveStatColumns, resolveGoalSportTrackerProfile } from './js/live-game-state.js?v=7';
         import { createFieldState, setPlayerFieldStatus, startFieldClock, pauseFieldClock, getPlayerFieldElapsedMs, getLiveLineup } from './js/live-tracker-field-status.js?v=1';
         import { summarizePersistedTrackingState, buildTrackLiveResetUpdate, resolveTrackLiveClockResume, runTrackLiveResetPersistence } from './js/track-live-state.js?v=2';
-        import { getDefaultLivePeriod, getGoalSportProfile, getSportPeriodLabels, resolveLiveSport, isFootballSport } from './js/live-sport-config.js?v=3';
+        import { getDefaultLivePeriod, getSportPeriodLabels, resolveLiveSport, isFootballSport } from './js/live-sport-config.js?v=3';
         import { applyGoalSportScore, buildGoalSportEvent } from './js/live-scorekeeping-goal-sports.js?v=1';
 
         import { applyVolleyballServeOutcome, createVolleyballUndoState, restoreVolleyballUndoState, isVolleyballSport } from './js/live-scorekeeping-volleyball.js?v=2';
@@ -679,7 +682,7 @@
         import { applyBaseballScorekeepingAction, createBaseballLiveState, getBaseballPeriodLabel, getBaseballSituationSummary, isBaseballScorekeepingSport, parseBaseballPeriodLabel } from './js/live-scorekeeping-baseball.js?v=1';
         import { checkAuth } from './js/auth.js?v=14';
         import { getApp } from './js/vendor/firebase-app.js';
-        import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './js/live-tracker-notes.js?v=1';
+        import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText, buildGoalSportNoteText } from './js/live-tracker-notes.js?v=2';
         import { collectTournamentAdvancementPatches } from './js/tournament-brackets.js?v=1';
         // Note: firebase-ai will be lazy-loaded when AI summary is requested
 
@@ -735,6 +738,7 @@
             voiceListening: false,
             activeVoiceRecognition: null,
             gameLog: [],
+            liveNotes: [],
             playerStats: {}, // In-memory player stats (replaces real-time DB writes)
             opponentStats: {},
             currentPeriod: getDefaultLivePeriod(),
@@ -815,7 +819,7 @@
         });
 
         async function init() {
-            const { teamId, gameId } = getUrlParams();
+            const { teamId, gameId, trackerMode } = getUrlParams();
             console.log('Track init - teamId:', teamId, 'gameId:', gameId);
             if (!teamId || !gameId) {
                 console.error('Missing teamId or gameId');
@@ -899,11 +903,12 @@
                         })
                     };
                 }
-                const hasExplicitStatTrackerConfig = !!String(currentGame?.statTrackerConfigId || '').trim();
-                const hasResolvedStatTrackerConfig = !!String(currentConfig?.id || '').trim();
-                currentGoalSportProfile = hasExplicitStatTrackerConfig || hasResolvedStatTrackerConfig
-                    ? null
-                    : getGoalSportProfile({ game: currentGame, team: currentTeam, config: currentConfig });
+                currentGoalSportProfile = resolveGoalSportTrackerProfile({
+                    trackerMode,
+                    game: currentGame,
+                    team: currentTeam,
+                    config: currentConfig
+                });
 
 
                 const volleyballMode = isVolleyballGame();
@@ -1258,6 +1263,10 @@
                 playerName: event.playerName,
                 opponentPlayerName: event.opponentPlayerName
             });
+            const noteTeamLabel = teamSide === 'away'
+                ? resolveOpponentDisplayName(currentGame)
+                : currentTeam?.name || 'Home';
+            addLiveNoteRecord(buildGoalSportNoteText(noteTeamLabel, event.note), 'goal');
             broadcastLiveEvent(currentTeamId, currentGameId, event).catch(console.warn);
             scheduleLiveHasData();
 
@@ -1941,17 +1950,33 @@
             setVoiceNoteHint(false);
         }
 
-        async function appendGameNote(text, type = 'text') {
+        function addLiveNoteRecord(text, type = 'text') {
             const clean = normalizeGameNoteText(text);
             if (!clean) return false;
-            const logText = buildGameNoteLogText(clean, type);
-            if (!logText) return false;
 
             const summaryField = document.getElementById('gameSummary');
             if (summaryField) {
                 summaryField.value = appendGameSummaryLine(summaryField.value, clean);
             }
 
+            gameState.liveNotes.unshift({
+                text: clean,
+                type,
+                period: gameState.currentPeriod,
+                time: getGameTime(),
+                timestamp: Date.now()
+            });
+            renderLiveNotes();
+            return true;
+        }
+
+        async function appendGameNote(text, type = 'text') {
+            const clean = normalizeGameNoteText(text);
+            if (!clean) return false;
+            const logText = buildGameNoteLogText(clean, type);
+            if (!logText) return false;
+
+            addLiveNoteRecord(clean, type);
             await addLogEntry(logText, { type: 'note', note: clean, noteType: type });
             if (gameState.isRunning) {
                 broadcastLiveEvent(currentTeamId, currentGameId, {
@@ -1967,6 +1992,28 @@
                 }).catch(console.warn);
             }
             return true;
+        }
+
+        function renderLiveNotes() {
+            const notesList = document.getElementById('live-notes-list');
+            if (!notesList) return;
+            if (!gameState.liveNotes.length) {
+                notesList.innerHTML = '<div class="p-2 bg-slate/60 rounded text-sand/50 text-xs">No live notes yet</div>';
+                return;
+            }
+
+            notesList.innerHTML = gameState.liveNotes.map((entry) => {
+                const label = entry.type === 'voice' ? 'Voice' : (entry.type === 'goal' ? 'Goal' : 'Note');
+                return `
+                    <div class="p-2 bg-slate/60 rounded border-l-2 border-teal/60">
+                        <div class="flex items-center justify-between gap-2 text-[11px] text-teal">
+                            <span>${escapeHtml(label)}</span>
+                            <span>${escapeHtml(entry.period || 'Q1')} ${escapeHtml(entry.time || '0:00')}</span>
+                        </div>
+                        <div class="text-xs text-sand break-words">${escapeHtml(entry.text)}</div>
+                    </div>
+                `;
+            }).join('');
         }
 
         function addManualGameNote() {
@@ -2232,6 +2279,7 @@
 
                             gameState.playerStats = {};
                             gameState.gameLog = [];
+                            gameState.liveNotes = [];
                             gameState.playerFieldStatus = createFieldState(players);
                             homeScore = 0;
                             awayScore = 0;
@@ -2309,6 +2357,7 @@
 
                             updateScoreDisplay();
                             renderGameLog();
+                            renderLiveNotes();
                             renderBaseballScorekeeping();
                             if (!gameState.isBaseballScorekeeping && !isFootballTrackingConfig()) {
                                 renderStatsTable();
@@ -2386,6 +2435,7 @@
                 gameState.currentPeriod = getDefaultLivePeriod({ team: currentTeam, config: currentConfig, game: currentGame });
                 liveState.lastClockSyncAt = 0;
                 gameState.gameLog = [];
+                gameState.liveNotes = [];
                 gameState.playerStats = {}; // Clear in-memory player stats
                 gameState.playerFieldStatus = createFieldState(players);
                 opponentPlayers.forEach((opp) => {
@@ -2431,6 +2481,7 @@
                 }
                 updateScoreDisplay();
                 renderGameLog();
+                renderLiveNotes();
                 renderBaseballScorekeeping();
                 if (!gameState.isBaseballScorekeeping && !isFootballTrackingConfig()) {
                     renderStatsTable();

--- a/track-live.html
+++ b/track-live.html
@@ -682,7 +682,7 @@
         import { applyBaseballScorekeepingAction, createBaseballLiveState, getBaseballPeriodLabel, getBaseballSituationSummary, isBaseballScorekeepingSport, parseBaseballPeriodLabel } from './js/live-scorekeeping-baseball.js?v=1';
         import { checkAuth } from './js/auth.js?v=14';
         import { getApp } from './js/vendor/firebase-app.js';
-        import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText, buildGoalSportNoteText } from './js/live-tracker-notes.js?v=2';
+        import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, removeGameSummaryLine, buildGameNoteLogText, buildGoalSportNoteText } from './js/live-tracker-notes.js?v=3';
         import { collectTournamentAdvancementPatches } from './js/tournament-brackets.js?v=1';
         // Note: firebase-ai will be lazy-loaded when AI summary is requested
 
@@ -1252,6 +1252,10 @@
                 awayScore,
                 createdBy: currentUser?.uid || null
             });
+            const noteTeamLabel = teamSide === 'away'
+                ? resolveOpponentDisplayName(currentGame)
+                : currentTeam?.name || 'Home';
+            const liveNote = addLiveNoteRecord(buildGoalSportNoteText(noteTeamLabel, event.note), 'goal');
             await addLogEntry(event.description, {
                 type: 'goal',
                 statKey: event.statKey,
@@ -1261,12 +1265,10 @@
                 scorer: event.scorer,
                 note: event.note,
                 playerName: event.playerName,
-                opponentPlayerName: event.opponentPlayerName
+                opponentPlayerName: event.opponentPlayerName,
+                liveNoteId: liveNote?.id || null,
+                liveNoteText: liveNote?.text || null
             });
-            const noteTeamLabel = teamSide === 'away'
-                ? resolveOpponentDisplayName(currentGame)
-                : currentTeam?.name || 'Home';
-            addLiveNoteRecord(buildGoalSportNoteText(noteTeamLabel, event.note), 'goal');
             broadcastLiveEvent(currentTeamId, currentGameId, event).catch(console.warn);
             scheduleLiveHasData();
 
@@ -1952,22 +1954,46 @@
 
         function addLiveNoteRecord(text, type = 'text') {
             const clean = normalizeGameNoteText(text);
-            if (!clean) return false;
+            if (!clean) return null;
 
             const summaryField = document.getElementById('gameSummary');
             if (summaryField) {
                 summaryField.value = appendGameSummaryLine(summaryField.value, clean);
             }
 
-            gameState.liveNotes.unshift({
+            const entry = {
+                id: `note-${Date.now()}-${Math.random().toString(36).slice(2)}`,
                 text: clean,
                 type,
                 period: gameState.currentPeriod,
                 time: getGameTime(),
                 timestamp: Date.now()
-            });
+            };
+            gameState.liveNotes.unshift(entry);
             renderLiveNotes();
-            return true;
+            return entry;
+        }
+
+        function removeLiveNoteRecord(noteId, noteText) {
+            const clean = normalizeGameNoteText(noteText);
+            const beforeCount = gameState.liveNotes.length;
+            if (noteId) {
+                gameState.liveNotes = gameState.liveNotes.filter((entry) => entry.id !== noteId);
+            } else if (clean) {
+                const index = gameState.liveNotes.findIndex((entry) => normalizeGameNoteText(entry.text) === clean);
+                if (index !== -1) {
+                    gameState.liveNotes.splice(index, 1);
+                }
+            }
+
+            if (gameState.liveNotes.length !== beforeCount) {
+                renderLiveNotes();
+            }
+
+            const summaryField = document.getElementById('gameSummary');
+            if (summaryField && clean) {
+                summaryField.value = removeGameSummaryLine(summaryField.value, clean);
+            }
         }
 
         async function appendGameNote(text, type = 'text') {
@@ -2822,6 +2848,7 @@
             }
 
             if (undoData && undoData.type === 'goal') {
+                removeLiveNoteRecord(undoData.liveNoteId, undoData.liveNoteText);
                 const goalValue = Number(undoData.value) || 1;
                 if (undoData.teamSide === 'away') {
                     awayScore = Math.max(0, awayScore - goalValue);


### PR DESCRIPTION
## Summary
- Add a `Live Broadcast Simple` choice for goal-sport games in the schedule tracker chooser.
- Keep the existing `Live Broadcast Tracker` route unchanged for full stat broadcasting.
- Add `trackerMode=simple` support in `track-live.html` through a tested `resolveGoalSportTrackerProfile` helper.

## Why
Goal sports now default to the full live stat tracker when a team stat config is resolved. Coaches still need an explicit way to choose the simple live goal broadcast mode when they want score/clock/goals without the full stat grid.

## User impact
For non-basketball goal sports like soccer, hockey, lacrosse, field hockey, and water polo, the Track modal shows both live choices:
- `Live Broadcast Tracker`: full stat tracker
- `Live Broadcast Simple`: existing simple goal broadcast mode

Basketball, baseball, volleyball, football, and other non-goal sports do not get the simple goal option.

## Validation
- `npx vitest run tests/unit/live-game-state.test.js tests/unit/track-live-live-events.test.js tests/unit/edit-schedule-basketball-routing.test.js`
- `npm run test:unit`
