### PR TITLE
Fix: Misleading 'Assignments loaded.' message with missing teamId

### DIFF
--- a/officials.html
+++ b/officials.html
@@ -119,6 +119,10 @@
         }
 
         async function refresh() {
+            if (!teamId) {
+                document.getElementById('officials-status').textContent = 'Missing teamId.';
+                return;
+            }
             games = await getGames(teamId);
             renderAssignedGames();
             renderOpenSlots();


### PR DESCRIPTION
Closes #1048

This change addresses a bug in `officials.html` where the status message would incorrectly display 'Assignments loaded.' even when the `teamId` URL parameter was missing. Previously, while an initial 'Missing teamId.' message was set, the `refresh()` function would unconditionally overwrite it.

The fix introduces a check for the `teamId` at the beginning of the `refresh()` function. If `teamId` is not present, the function now exits early after setting the 'Missing teamId.' status, ensuring the correct error message persists and no attempt is made to load assignments.

Manual validation steps:
1. Navigate to `officials.html` without any URL parameters (e.g., `officials.html`).
2. Observe the `#officials-status` element. It should consistently display "Missing teamId."
3. Verify that the assignment sections (`#assigned-games` and `#open-slots`) remain empty.