### PR TITLE
Fix: Live scoreboard scoring run calculation for deductions

### DIFF
--- a/js/live-game.js
+++ b/js/live-game.js
@@ -1817,7 +1817,17 @@ function updateMomentum(event) {
     state.lastRunAnnounced = 0;
   }
 
-  state.scoringRun.points += Math.abs(event.value || 0);
+  const eventValue = event.value || 0;
+  if (eventValue < 0) {
+    // Point deduction for the current scoring team, reset the run.
+    // If it's a deduction for the other team, it will already reset in the `if (state.scoringRun.team !== scoringTeam)` block.
+    state.scoringRun.team = null; // Clear team to ensure it resets next score
+    state.scoringRun.points = 0;
+    state.lastRunAnnounced = 0;
+  } else if (eventValue > 0) {
+    // Only add positive points to the scoring run
+    state.scoringRun.points += eventValue;
+  }
 
   if (state.scoringRun.points >= 5 && state.scoringRun.points !== state.lastRunAnnounced) {
     state.lastRunAnnounced = state.scoringRun.points;


### PR DESCRIPTION
Closes #1056

This PR fixes a functional bug in the live scoreboard's 'Scoring Run' calculation. Previously, `js/live-game.js` used `Math.abs(event.value || 0)` when adding to `state.scoringRun.points`. This meant that point deductions (negative `event.value`) were converted to positive values and incorrectly increased the scoring run counter, misrepresenting game momentum.

The `updateMomentum` function has been updated to:
- Reset the `scoringRun` if a point deduction occurs for the team currently on a run.
- Only add positive `event.value` to the `scoringRun.points`.

This ensures that the 'X-0 Run!' notification accurately reflects only positive, consecutive scoring, providing correct real-time game insights to users.