### PR TITLE
Fix #1058: Allow granular config access for stream and parent roles

### DIFF
--- a/edit-config.html
+++ b/edit-config.html
@@ -381,7 +381,7 @@
             }
             currentTeamId = teamId;
 
-            const accessDecision = getEditConfigAccessDecision(currentUser, await getTeam(teamId), teamId);
+            const accessDecision = getEditConfigAccessDecision(currentUser, await getTeam(teamId), teamId, 'stat_settings');
             if (!accessDecision.allowed) {
                 alert('Team not found or access denied.');
                 window.location.href = accessDecision.exitUrl || 'dashboard.html';

--- a/js/edit-config-access.js
+++ b/js/edit-config-access.js
@@ -12,7 +12,7 @@ function hasRulesCompatibleConfigWriteAccess(user, team) {
     );
 }
 
-export function getEditConfigAccessDecision(user, team, teamId) {
+export function getEditConfigAccessDecision(user, team, teamId, configType = 'stat_settings') {
     if (!team) {
         return {
             allowed: false,
@@ -27,8 +27,26 @@ export function getEditConfigAccessDecision(user, team, teamId) {
     };
     const accessInfo = getTeamAccessInfo(user, normalizedTeam);
 
+    let allowed = false;
+
+    if (accessInfo.accessLevel === 'full') {
+        // Full access users can edit any config type, subject to rules-compatible write access
+        allowed = hasRulesCompatibleConfigWriteAccess(user, normalizedTeam);
+    } else if (configType === 'stream_settings' && accessInfo.accessLevel === 'stream') {
+        // Stream users can edit stream settings (no additional write access rules needed)
+        allowed = true;
+    } else if (configType === 'child_profile' && accessInfo.accessLevel === 'parent') {
+        // Parent users can edit child profiles (no additional write access rules needed)
+        allowed = true;
+    } else {
+        // For 'stat_settings' (or any other configType not explicitly handled),
+        // only full access is allowed, subject to rules-compatible write access.
+        // This covers the default 'stat_settings' if no specific rules apply earlier.
+        allowed = accessInfo.accessLevel === 'full' && hasRulesCompatibleConfigWriteAccess(user, normalizedTeam);
+    }
+
     return {
-        allowed: accessInfo.accessLevel === 'full' && hasRulesCompatibleConfigWriteAccess(user, normalizedTeam),
+        allowed: allowed,
         exitUrl: accessInfo.exitUrl,
         team: normalizedTeam
     };

--- a/js/team-access.js
+++ b/js/team-access.js
@@ -48,8 +48,22 @@ function hasConfirmedRsvp(rsvp) {
  * Stream access never implies full team management access.
  */
 export function hasStreamTeamAccess(user, team, game = null, rsvp = null) {
-  if (!user || !team || !isScheduledGame(game)) return false;
-  if (hasFullTeamAccess(user, team)) return true;
+  if (!user || !team) return false; // Basic checks first
+
+  if (hasFullTeamAccess(user, team)) return true; // Full access short-circuits
+
+  // For team-level stream configuration access (no specific game context required),
+  // check if the user is a selected stream volunteer for the team.
+  const isSelectedTeamStreamVolunteer = (String(team.streamAccessMode || '').trim().toLowerCase() === 'selected_volunteers' || String(team.streamAccessMode || '').trim().toLowerCase() === 'selected') &&
+                                        Boolean(getNormalizedUserEmail(user) && normalizeStreamVolunteerEmailList(team.streamVolunteerEmails).includes(getNormalizedUserEmail(user)));
+
+  if (!game && isSelectedTeamStreamVolunteer) {
+      return true; // Grant team-level stream access if no game and is a selected volunteer
+  }
+
+  // If a game is provided, or if we need further checks, proceed with game-specific logic.
+  // If no game is present here, and it's not a selected volunteer, then no stream access.
+  if (!isScheduledGame(game)) return false;
 
   if (team.teamPermissions?.streaming) {
     const permissions = normalizeTeamPermissions(team.teamPermissions);

--- a/js/team-access.js
+++ b/js/team-access.js
@@ -52,17 +52,23 @@ export function hasStreamTeamAccess(user, team, game = null, rsvp = null) {
 
   if (hasFullTeamAccess(user, team)) return true; // Full access short-circuits
 
-  // For team-level stream configuration access (no specific game context required),
-  // check if the user is a selected stream volunteer for the team.
-  const isSelectedTeamStreamVolunteer = (String(team.streamAccessMode || '').trim().toLowerCase() === 'selected_volunteers' || String(team.streamAccessMode || '').trim().toLowerCase() === 'selected') &&
-                                        Boolean(getNormalizedUserEmail(user) && normalizeStreamVolunteerEmailList(team.streamVolunteerEmails).includes(getNormalizedUserEmail(user)));
-
-  if (!game && isSelectedTeamStreamVolunteer) {
-      return true; // Grant team-level stream access if no game and is a selected volunteer
+  // Case 1: No game context provided. This is where the config access check happens.
+  if (!game) {
+    if (team.teamPermissions?.streaming) {
+      const permissions = normalizeTeamPermissions(team.teamPermissions);
+      const streaming = permissions.streaming;
+      // If stream access mode is 'selected' and the user's UID is in the memberIds,
+      // grant access *for config purposes*.
+      if (streaming.mode === 'selected' && normalizeMemberIdList(streaming.memberIds).includes(String(user.uid || '').trim())) {
+        return true;
+      }
+    }
+    // For all other cases when no game is present, and it's not the specific config access path above,
+    // we should NOT grant stream access.
+    return false;
   }
 
-  // If a game is provided, or if we need further checks, proceed with game-specific logic.
-  // If no game is present here, and it's not a selected volunteer, then no stream access.
+  // Case 2: A game context is provided. Proceed with game-specific stream access logic.
   if (!isScheduledGame(game)) return false;
 
   if (team.teamPermissions?.streaming) {

--- a/js/team-access.js
+++ b/js/team-access.js
@@ -63,6 +63,14 @@ export function hasStreamTeamAccess(user, team, game = null, rsvp = null) {
         return true;
       }
     }
+    // Check for legacy streamAccessMode config when no game is present
+    const mode = String(team.streamAccessMode || '').trim().toLowerCase(); // Initialize mode here for config checks
+    if (mode === 'selected_volunteers' || mode === 'selected') {
+        const normalizedEmail = getNormalizedUserEmail(user);
+        const streamVolunteerEmails = normalizeStreamVolunteerEmailList(team.streamVolunteerEmails);
+        return Boolean(normalizedEmail && streamVolunteerEmails.includes(normalizedEmail));
+    }
+
     // For all other cases when no game is present, and it's not the specific config access path above,
     // we should NOT grant stream access.
     return false;

--- a/tests/unit/edit-config-access.test.js
+++ b/tests/unit/edit-config-access.test.js
@@ -4,12 +4,20 @@ import { getEditConfigAccessDecision } from '../../js/edit-config-access.js';
 const TEAM = {
     id: 'team-1',
     ownerId: 'owner-1',
-    adminEmails: ['coach@example.com']
+    adminEmails: ['coach@example.com'],
+    streamAccessMode: 'selected_volunteers', // For stream access
+    streamVolunteerEmails: ['streamer@example.com'] // For stream access
 };
+
+// Mock user data
+const PARENT_USER = { uid: 'parent-1', parentOf: [{ teamId: TEAM.id, playerId: 'child-1' }], email: 'parent@example.com' };
+const STREAM_USER = { uid: 'streamer-1', email: 'streamer@example.com' };
+const REGULAR_USER = { uid: 'member-1', email: 'member@example.com' };
+
 
 describe('edit config access decision', () => {
     it('allows platform admins to manage stats configs', () => {
-        expect(getEditConfigAccessDecision({ uid: 'admin-1', isAdmin: true }, TEAM, TEAM.id)).toEqual({
+        expect(getEditConfigAccessDecision({ uid: 'admin-1', isAdmin: true }, TEAM, TEAM.id, 'stat_settings')).toEqual({
             allowed: true,
             exitUrl: 'dashboard.html',
             team: TEAM
@@ -17,7 +25,7 @@ describe('edit config access decision', () => {
     });
 
     it('allows rules-compatible team admins to manage stats configs', () => {
-        expect(getEditConfigAccessDecision({ uid: 'coach-1', email: 'Coach@Example.com' }, TEAM, TEAM.id)).toEqual({
+        expect(getEditConfigAccessDecision({ uid: 'coach-1', email: 'Coach@Example.com' }, TEAM, TEAM.id, 'stat_settings')).toEqual({
             allowed: true,
             exitUrl: 'dashboard.html',
             team: TEAM
@@ -30,7 +38,7 @@ describe('edit config access decision', () => {
             adminEmails: [' Coach@Example.com ']
         };
 
-        expect(getEditConfigAccessDecision({ uid: 'coach-1', email: 'coach@example.com' }, legacyTeam, TEAM.id)).toEqual({
+        expect(getEditConfigAccessDecision({ uid: 'coach-1', email: 'coach@example.com' }, legacyTeam, TEAM.id, 'stat_settings')).toEqual({
             allowed: false,
             exitUrl: 'dashboard.html',
             team: legacyTeam
@@ -38,17 +46,17 @@ describe('edit config access decision', () => {
     });
 
     it('denies profile-email-only admin access that Firestore would reject for config writes', () => {
-        expect(getEditConfigAccessDecision({ uid: 'coach-1', profileEmail: 'coach@example.com' }, TEAM, TEAM.id)).toEqual({
+        expect(getEditConfigAccessDecision({ uid: 'coach-1', profileEmail: 'coach@example.com' }, TEAM, TEAM.id, 'stat_settings')).toEqual({
             allowed: false,
             exitUrl: 'dashboard.html',
             team: TEAM
         });
     });
 
-    it('denies parent-only access for stats config page', () => {
+    it('denies parent-only access for stats config page (default configType)', () => {
         expect(
             getEditConfigAccessDecision(
-                { uid: 'parent-1', parentOf: [{ teamId: TEAM.id, playerId: 'player-1' }] },
+                PARENT_USER,
                 TEAM,
                 TEAM.id
             )
@@ -60,10 +68,44 @@ describe('edit config access decision', () => {
     });
 
     it('denies access when the team cannot be resolved', () => {
-        expect(getEditConfigAccessDecision({ uid: 'admin-1', isAdmin: true }, null, 'missing-team')).toEqual({
+        expect(getEditConfigAccessDecision({ uid: 'admin-1', isAdmin: true }, null, 'missing-team', 'stat_settings')).toEqual({
             allowed: false,
             exitUrl: 'dashboard.html',
             team: null
+        });
+    });
+
+    it('allows stream users to manage stream settings', () => {
+        // hasStreamTeamAccess will be true for STREAM_USER based on TEAM config
+        expect(getEditConfigAccessDecision(STREAM_USER, TEAM, TEAM.id, 'stream_settings')).toEqual({
+            allowed: true,
+            exitUrl: `team.html#teamId=${TEAM.id}`,
+            team: TEAM
+        });
+    });
+
+    it('denies stream users from managing stat settings', () => {
+        expect(getEditConfigAccessDecision(STREAM_USER, TEAM, TEAM.id, 'stat_settings')).toEqual({
+            allowed: false,
+            exitUrl: `team.html#teamId=${TEAM.id}`,
+            team: TEAM
+        });
+    });
+
+    it('allows parent users to manage child profiles', () => {
+        // getTeamAccessInfo will return accessLevel: 'parent' for PARENT_USER
+        expect(getEditConfigAccessDecision(PARENT_USER, TEAM, TEAM.id, 'child_profile')).toEqual({
+            allowed: true,
+            exitUrl: 'parent-dashboard.html',
+            team: TEAM
+        });
+    });
+
+    it('denies parent users from managing stat settings', () => {
+        expect(getEditConfigAccessDecision(PARENT_USER, TEAM, TEAM.id, 'stat_settings')).toEqual({
+            allowed: false,
+            exitUrl: 'parent-dashboard.html',
+            team: TEAM
         });
     });
 });


### PR DESCRIPTION
Closes #1058

This PR addresses the issue where 'stream' and 'parent' roles were unable to edit configurations relevant to their responsibilities due to an overly restrictive access check.

Changes include:
- **`js/edit-config-access.js`**: Modified `getEditConfigAccessDecision` to accept a `configType` parameter. It now grants granular access:
    - Users with 'full' access can edit any configuration type (e.g., `'stat_settings'`, `'stream_settings'`, `'child_profile'`).
    - Users with 'stream' access can edit configurations of type `'stream_settings'`.
    - Users with 'parent' access can edit configurations of type `'child_profile'`.
- **`js/team-access.js`**: Updated `hasStreamTeamAccess` to properly identify team-level stream volunteers for config purposes, even when a specific game context is not present. This ensures that `getTeamAccessInfo` can correctly assign the 'stream' access level for relevant config edits.
- **`edit-config.html`**: The call to `getEditConfigAccessDecision` was updated to explicitly pass `'stat_settings'` as the `configType`, maintaining existing behavior for stat configurations.
- **`tests/unit/edit-config-access.test.js`**: New unit tests were added to validate the granular access for 'stream' and 'parent' roles with their respective `configType`s, and all tests now pass.