### PR TITLE
Fix: Broken links in Admin Controls workflow documentation

### DIFF
--- a/workflow-admin-ops.html
+++ b/workflow-admin-ops.html
@@ -355,9 +355,9 @@
 </ul>
 <h2 id="related-workflows">Related Workflows</h2>
 <ul class="ml-6 list-disc space-y-1">
-<li><code>getting-started.md</code></li>
-<li><code>team-setup.md</code></li>
-<li><code>schedule.md</code></li>
+<li><a href="workflow-getting-started.html">Getting Started Workflow</a></li>
+<li><a href="workflow-team-setup.html">Team Setup Workflow</a></li>
+<li><a href="workflow-schedule.html">Schedule Workflow</a></li>
 </ul>
 <h2 id="need-more-help">Need More Help</h2>
 <ul class="ml-6 list-disc space-y-1">


### PR DESCRIPTION
Closes #1063

This PR addresses the issue of broken links in the 'Related Workflows' section of the 'Operate Platform Admin Controls' page (`workflow-admin-ops.html`).

Previously, the page displayed `.md` file names within `<code>` tags, which were not functional links and led to 404 errors if a user manually tried to navigate to those paths.

This change converts the non-functional `<code>` references into proper `<a>` tags, linking to the corresponding existing HTML workflow documentation pages:
- `workflow-getting-started.html`
- `workflow-team-setup.html`
- `workflow-schedule.html`

The link text has also been updated for clarity.