### PR TITLE
Fix: Prevent selection of full, non-waitlisted registration options

### DIFF
--- a/js/registration-flow.js
+++ b/js/registration-flow.js
@@ -175,11 +175,11 @@ export function getActiveRegistrationOptions(form = {}, registrationOptionCounts
 }
 
 export function requiresRegistrationOption(form = {}) {
-    return getActiveRegistrationOptions(form).length > 0;
+    return getActiveRegistrationOptions(form, form.registrationOptionCounts || {}).length > 0;
 }
 
 export function getRegistrationOptionById(form = {}, optionId = '') {
-    return getActiveRegistrationOptions(form).find(option => option.id === optionId) || null;
+    return getActiveRegistrationOptions(form, form.registrationOptionCounts || {}).find(option => option.id === optionId) || null;
 }
 
 export function normalizeFieldType(type) {

--- a/js/registration-flow.js
+++ b/js/registration-flow.js
@@ -1,4 +1,5 @@
 export function normalizeRegistrationForm(form = {}, context = {}) {
+    const registrationOptionCounts = form.registrationOptionCounts || {};
     const programName = String(form.programName || form.title || form.name || '').trim();
     const feeAmountCents = Number.isFinite(Number(form.feeAmountCents)) ? Number(form.feeAmountCents) : 0;
 
@@ -18,7 +19,8 @@ export function normalizeRegistrationForm(form = {}, context = {}) {
         published: form.published === true || form.status === 'published',
         paymentSettings: normalizePaymentSettings(form.paymentSettings),
         discountRules: normalizeRegistrationDiscountRules(form.discountRules || []),
-        registrationOptions: normalizeRegistrationOptions(form.registrationOptions || form.options || [])
+        registrationOptions: normalizeRegistrationOptions(form.registrationOptions || form.options || [], registrationOptionCounts),
+        registrationOptionCounts
     };
 }
 
@@ -122,7 +124,7 @@ export function normalizeFields(fields = []) {
         .filter(field => field.id && field.label);
 }
 
-export function normalizeRegistrationOptions(options = []) {
+export function normalizeRegistrationOptions(options = [], registrationOptionCounts = {}) {
     if (!Array.isArray(options)) return [];
 
     return options
@@ -150,8 +152,26 @@ export function buildRegistrationOptionCountKey(optionId = '') {
     return key || 'option';
 }
 
-export function getActiveRegistrationOptions(form = {}) {
-    return (form.registrationOptions || []).filter(option => option.active !== false);
+export function getActiveRegistrationOptions(form = {}, registrationOptionCounts = {}) {
+    return (form.registrationOptions || []).filter(option => {
+        if (!option.active) return false; // Must be active
+
+        const counts = registrationOptionCounts[option.countKey] || registrationOptionCounts[option.id] || {};
+        const enrolledCount = Number(counts.enrolled || 0);
+
+        // If no capacity limit, or if capacity limit not reached, option is available
+        if (!option.capacityLimit || enrolledCount < option.capacityLimit) {
+            return true;
+        }
+
+        // If capacity limit reached, but waitlist is enabled, option is available (for waitlist)
+        if (option.waitlistEnabled) {
+            return true;
+        }
+
+        // Otherwise, option is full and not waitlisted, so it's not active for new registrations
+        return false;
+    });
 }
 
 export function requiresRegistrationOption(form = {}) {

--- a/registration.html
+++ b/registration.html
@@ -227,7 +227,7 @@
                     selectedOptionId: option.id,
                     counts: form.registrationOptionCounts || {}
                 });
-                if (placement.status !== 'blocked') {
+                if (placement.status === 'pending') {
                     initialCheckedOptionId = option.id;
                     break;
                 }
@@ -237,7 +237,7 @@
             }
 
             options.forEach((option) => {
-                const optionCounts = form.registrationOptionCounts[option.countKey] || form.registrationOptionCounts[option.id] || {};
+                const optionCounts = (form.registrationOptionCounts || {})[option.countKey] || (form.registrationOptionCounts || {})[option.id] || {};
                 const enrolledCount = Number(optionCounts.enrolled || 0);
                 const hasCapacity = !option.capacityLimit || enrolledCount < option.capacityLimit;
                 const isFullAndNoWaitlist = !hasCapacity && !option.waitlistEnabled;

--- a/registration.html
+++ b/registration.html
@@ -110,7 +110,7 @@
             normalizeRegistrationForm,
             requiresRegistrationOption,
             validateRegistrationSubmission
-        } from './js/registration-flow.js?v=3';
+        } from './js/registration-flow.js?v=4';
 
         renderHeader(document.getElementById('header-container'), null);
         renderFooter(document.getElementById('footer-container'));
@@ -211,7 +211,7 @@
         function renderRegistrationOptions(form) {
             const section = document.getElementById('registration-options-section');
             const container = document.getElementById('registration-options');
-            const options = getActiveRegistrationOptions(form);
+            const options = getActiveRegistrationOptions(form, form.registrationOptionCounts || {});
             container.innerHTML = '';
 
             if (options.length === 0) {
@@ -219,16 +219,48 @@
                 return;
             }
 
-            options.forEach((option, index) => {
+            // Determine initial checked option, prioritizing one with capacity
+            let initialCheckedOptionId = '';
+            for (const option of options) {
+                const placement = decideRegistrationPlacement({
+                    form: form,
+                    selectedOptionId: option.id,
+                    counts: form.registrationOptionCounts || {}
+                });
+                if (placement.status !== 'blocked') {
+                    initialCheckedOptionId = option.id;
+                    break;
+                }
+            }
+            if (!initialCheckedOptionId && options.length > 0) {
+                initialCheckedOptionId = options[0].id; // Fallback to first option if none have capacity
+            }
+
+            options.forEach((option) => {
+                const optionCounts = form.registrationOptionCounts[option.countKey] || form.registrationOptionCounts[option.id] || {};
+                const enrolledCount = Number(optionCounts.enrolled || 0);
+                const hasCapacity = !option.capacityLimit || enrolledCount < option.capacityLimit;
+                const isFullAndNoWaitlist = !hasCapacity && !option.waitlistEnabled;
+
+                if (isFullAndNoWaitlist) return; // Should already be filtered, but double-check
+
                 const label = document.createElement('label');
-                label.className = 'flex gap-3 rounded border border-gray-200 p-3 text-sm text-gray-700 hover:border-indigo-300';
+                // Dynamically adjust classes based on option status
+                label.className = `flex gap-3 rounded border p-3 text-sm ${hasCapacity ? 'border-gray-200 text-gray-700 hover:border-indigo-300' : 'border-orange-200 bg-orange-50 text-orange-800'}`;
+
                 const input = document.createElement('input');
                 input.type = 'radio';
                 input.name = 'registrationOptionId';
                 input.value = option.id;
                 input.required = true;
-                input.className = 'mt-1 h-4 w-4 border-gray-300 text-indigo-600 focus:ring-indigo-500';
-                if (index === 0) input.checked = true;
+                // Disable if full and waitlist not enabled (should be filtered out, but defensive)
+                input.disabled = isFullAndNoWaitlist;
+                input.className = `mt-1 h-4 w-4 ${hasCapacity ? 'border-gray-300 text-indigo-600 focus:ring-indigo-500' : 'border-orange-300'}`;
+
+                // Set checked state based on initialCheckedOptionId
+                if (option.id === initialCheckedOptionId) {
+                    input.checked = true;
+                }
 
                 const copy = document.createElement('span');
                 const title = document.createElement('span');
@@ -241,6 +273,20 @@
                     description.className = 'mt-1 block text-gray-600';
                     description.textContent = option.description;
                     copy.appendChild(description);
+                }
+
+                // Add status indicator
+                if (!hasCapacity && option.waitlistEnabled) {
+                    const statusIndicator = document.createElement('span');
+                    statusIndicator.className = 'mt-1 block text-xs font-medium text-orange-600';
+                    statusIndicator.textContent = '(Full - Waitlist Available)';
+                    copy.appendChild(statusIndicator);
+                } else if (!hasCapacity && !option.waitlistEnabled) {
+                    // This case should ideally not be reached due to getActiveRegistrationOptions filtering
+                    const statusIndicator = document.createElement('span');
+                    statusIndicator.className = 'mt-1 block text-xs font-medium text-red-600';
+                    statusIndicator.textContent = '(Full)';
+                    copy.appendChild(statusIndicator);
                 }
 
                 label.append(input, copy);


### PR DESCRIPTION
Closes #1066

This PR addresses an issue where the registration form allowed users to select options that were at full capacity and did not permit waitlisting, leading to submission failures and a poor user experience.

**Changes Made:**
- The `getActiveRegistrationOptions` function in `js/registration-flow.js` was enhanced to filter out options that are full and do not have waitlisting enabled, ensuring only truly available (or waitlistable) options are presented.
- The `renderRegistrationOptions` function in `registration.html` was updated to display clearer UI feedback, marking options as "(Full - Waitlist Available)" when applicable, and prioritizing available options for initial selection.
- The cache-bust version for `registration-flow.js` was incremented in `registration.html`.

These changes ensure that users only see and can select registration options that are genuinely available, either for direct registration or for waitlisting.