### PR TITLE
Fix: Consistent email casing in isUserInConversation

### DIFF
--- a/js/team-chat-conversations.js
+++ b/js/team-chat-conversations.js
@@ -54,7 +54,7 @@ export function isUserInConversation(conversation, user = {}, { canModerate = fa
     const participantRoles = Array.isArray(conversation.participantRoles) ? conversation.participantRoles : [];
     return participantIds.includes(user?.uid) ||
         (user?.uid && participantIds.includes(`user:${user.uid}`)) ||
-        (user?.email && participantIds.includes(`email:${user.email}`)) ||
+
         (user?.email && participantIds.includes(`email:${String(user.email).toLowerCase()}`)) ||
         participantRoles.includes('team');
 }

--- a/tests/unit/team-chat-conversations.test.js
+++ b/tests/unit/team-chat-conversations.test.js
@@ -42,6 +42,8 @@ describe('team chat conversations', () => {
 
         expect(isUserInConversation({ id: 'group-1', type: 'group', participantIds: ['user:u1'] }, user)).toBe(true);
         expect(isUserInConversation({ id: 'group-2', type: 'group', participantIds: ['email:parent@example.com'] }, user)).toBe(true);
+        const mixedCaseUser = { uid: 'u2', email: 'Parent@Example.com' };
+        expect(isUserInConversation({ id: 'group-4', type: 'group', participantIds: ['email:parent@example.com'] }, mixedCaseUser)).toBe(true);
         expect(isUserInConversation({ id: 'group-3', type: 'group', participantIds: [] }, user)).toBe(false);
         expect(isUserInConversation({ id: 'group-3', type: 'group', participantIds: [] }, user, { canModerate: true })).toBe(true);
         expect(isUserInConversation({ id: DEFAULT_TEAM_CONVERSATION_ID, type: 'team' }, user)).toBe(true);


### PR DESCRIPTION
Closes #1069

This PR addresses the inconsistent email casing check in `isUserInConversation`.
Previously, the function first attempted to match `user.email` with its original casing, which could fail due to `normalizeConversationParticipantIds` storing email participant IDs in lowercase.
The redundant check using the original casing of `user.email` has been removed. The function now consistently normalizes `user.email` to lowercase before comparison, aligning with the stored format and ensuring robust access validation.

A new test case has been added to cover scenarios with mixed-case emails, verifying the fix.