### PR TITLE
[codex] Post schedule reminders to chat

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1409,8 +1409,63 @@ function buildPreEventReminderPayload({ teamId, gameId, event }) {
   return {
     title: 'Upcoming team event',
     body: bodyParts.join(' '),
-    link
+    link,
+    chatText: [
+      'Schedule reminder: Upcoming team event',
+      ...bodyParts
+    ].join('\n')
   };
+}
+
+function getPreEventReminderChatMessageId(gameId, event) {
+  const dueAt = getReminderDueAt(event);
+  const rawId = [
+    String(gameId || 'event'),
+    dueAt ? dueAt.toISOString() : 'due'
+  ].join('-');
+  const normalizedId = rawId.replace(/[^a-zA-Z0-9_-]/g, '_').slice(0, 180);
+  return `pre-event-reminder-${normalizedId}`;
+}
+
+async function postPreEventReminderChatMessage({ teamId, gameId, event, payload }) {
+  const messageId = getPreEventReminderChatMessageId(gameId, event);
+  const messageRef = firestore.doc(`teams/${teamId}/chatMessages/${messageId}`);
+  const existing = await messageRef.get();
+  if (existing.exists) {
+    return { messageId, created: false };
+  }
+
+  await messageRef.set({
+    text: payload.chatText || payload.body,
+    senderId: 'scheduled-reminder',
+    senderName: 'ALL PLAYS',
+    senderEmail: null,
+    senderPhotoUrl: null,
+    attachments: [],
+    imageUrl: null,
+    imagePath: null,
+    imageName: null,
+    imageType: null,
+    imageSize: null,
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    editedAt: null,
+    deleted: false,
+    ai: false,
+    aiName: null,
+    aiQuestion: null,
+    aiMeta: {
+      type: 'pre-event-reminder',
+      teamId,
+      gameId,
+      link: payload.link
+    },
+    targetType: 'full_team',
+    recipientIds: [],
+    targetRole: null,
+    conversationId: null
+  });
+
+  return { messageId, created: true };
 }
 
 async function markReminderSending(eventRef, claimId, now) {
@@ -1440,6 +1495,8 @@ async function markReminderSent(eventRef, claimId, sendResult) {
     'scheduleNotifications.claimId': claimId,
     'scheduleNotifications.pushSuccessCount': Number(sendResult?.successCount || 0),
     'scheduleNotifications.pushFailureCount': Number(sendResult?.failureCount || 0),
+    'scheduleNotifications.chatMessageId': sendResult?.chatMessageId || null,
+    'scheduleNotifications.chatMessageCreated': sendResult?.chatMessageCreated === true,
     'scheduleNotifications.rsvpEmailCount': Number(sendResult?.rsvpEmailCount || 0)
   });
 }
@@ -1475,6 +1532,7 @@ async function dispatchDuePreEventReminders(now = new Date()) {
 
     try {
       const payload = buildPreEventReminderPayload({ teamId, gameId, event: claimedEvent });
+      const chatResult = await postPreEventReminderChatMessage({ teamId, gameId, event: claimedEvent, payload });
       const sendResult = await sendCategoryNotification({
         teamId,
         gameId,
@@ -1490,9 +1548,18 @@ async function dispatchDuePreEventReminders(now = new Date()) {
       });
       await markReminderSent(eventRef, claimId, {
         ...sendResult,
+        chatMessageId: chatResult.messageId,
+        chatMessageCreated: chatResult.created,
         rsvpEmailCount: emailResult.sentCount
       });
-      results.push({ teamId, gameId, sent: Number(sendResult?.successCount || 0), rsvpEmailCount: emailResult.sentCount });
+      results.push({
+        teamId,
+        gameId,
+        sent: Number(sendResult?.successCount || 0),
+        chatMessageId: chatResult.messageId,
+        chatMessageCreated: chatResult.created,
+        rsvpEmailCount: emailResult.sentCount
+      });
     } catch (error) {
       await markReminderPendingAfterFailure(eventRef, claimId, error);
       console.error('Failed to dispatch pre-event reminder', { teamId, gameId, error });

--- a/functions/index.js
+++ b/functions/index.js
@@ -1388,6 +1388,10 @@ async function postPreEventReminderChatMessage({ teamId, gameId, event, payload 
   return { messageId, created: true };
 }
 
+function isPreEventReminderChatMessage(data) {
+  return data?.aiMeta?.type === 'pre-event-reminder' || data?.senderId === 'scheduled-reminder';
+}
+
 async function markReminderSending(eventRef, claimId, now) {
   return firestore.runTransaction(async (transaction) => {
     const snap = await transaction.get(eventRef);
@@ -1417,6 +1421,9 @@ async function markReminderSent(eventRef, claimId, sendResult) {
     'scheduleNotifications.pushFailureCount': Number(sendResult?.failureCount || 0),
     'scheduleNotifications.chatMessageId': sendResult?.chatMessageId || null,
     'scheduleNotifications.chatMessageCreated': sendResult?.chatMessageCreated === true,
+    'scheduleNotifications.chatMessageError': sendResult?.chatMessageError
+      ? sendResult.chatMessageError
+      : admin.firestore.FieldValue.delete(),
     'scheduleNotifications.rsvpEmailCount': Number(sendResult?.rsvpEmailCount || 0)
   });
 }
@@ -1452,7 +1459,15 @@ async function dispatchDuePreEventReminders(now = new Date()) {
 
     try {
       const payload = buildPreEventReminderPayload({ teamId, gameId, event: claimedEvent });
-      const chatResult = await postPreEventReminderChatMessage({ teamId, gameId, event: claimedEvent, payload });
+      let chatResult = { messageId: null, created: false };
+      let chatMessageError = null;
+      try {
+        chatResult = await postPreEventReminderChatMessage({ teamId, gameId, event: claimedEvent, payload });
+      } catch (chatError) {
+        chatMessageError = chatError;
+        console.error('Failed to write pre-event reminder chat fallback', { teamId, gameId, error: chatError });
+      }
+
       const sendResult = await sendCategoryNotification({
         teamId,
         gameId,
@@ -1470,6 +1485,7 @@ async function dispatchDuePreEventReminders(now = new Date()) {
         ...sendResult,
         chatMessageId: chatResult.messageId,
         chatMessageCreated: chatResult.created,
+        chatMessageError: chatMessageError?.message || null,
         rsvpEmailCount: emailResult.sentCount
       });
       results.push({
@@ -1499,6 +1515,7 @@ exports.notifyTeamChatMessageCreated = functions.firestore
     const text = String(data.text || '').trim();
     const imageUrl = String(data.imageUrl || '').trim();
     if (!text && !imageUrl) return null;
+    if (isPreEventReminderChatMessage(data)) return null;
 
     const teamId = context.params.teamId;
     const actorUid = data.senderId || null;

--- a/tests/smoke/team-fallback-regressions.spec.js
+++ b/tests/smoke/team-fallback-regressions.spec.js
@@ -12,7 +12,7 @@ const AUTH_STUB = `
 export function checkAuth(callback) {
     callback({
         uid: 'user-1',
-        email: 'coach@example.com',
+        email: 'paul@paulsnider.net',
         isAdmin: false,
         parentOf: [{ teamId: 'team-1', playerId: 'player-1' }]
     });
@@ -230,6 +230,11 @@ export async function uploadChatImage() {}
 export async function deleteUploadedChatAttachments() {}
 export async function toggleChatReaction() {}
 `;
+
+const CHAT_DB_REMINDER_STUB = CHAT_DB_STUB
+    .replace("text: 'Hello team'", "text: 'Schedule reminder: Upcoming team event\\nvs. Wildcats is coming up Sat, May 9, 6:00 PM.\\nLocation: Main Gym'")
+    .replace("senderId: 'coach-2'", "senderId: 'scheduled-reminder'")
+    .replace("senderName: 'Coach Lee'", "senderName: 'ALL PLAYS'");
 
 const MEDIA_DB_STUB = `
 ${PERMISSION_ERROR}
@@ -691,6 +696,20 @@ test('team chat falls back to the team-wide channel when conversation listing is
     await expect(page.locator('#messages-container')).toContainText('Hello team');
     await expect(page.locator('#messages-container')).not.toContainText('Loading messages');
     await expect(page.locator('#send-error')).toBeHidden();
+    expect(pageErrors).toEqual([]);
+});
+
+test('team chat renders scheduled reminder fallback messages', async ({ page, baseURL }) => {
+    const pageErrors = await collectPageErrors(page);
+    await routeCommonPageStubs(page);
+    await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: CHAT_DB_REMINDER_STUB }));
+
+    await page.goto(`${baseURL}/team-chat.html?teamId=team-1`, { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#messages-container')).toContainText('Schedule reminder: Upcoming team event');
+    await expect(page.locator('#messages-container')).toContainText('vs. Wildcats is coming up');
+    await expect(page.locator('#messages-container')).toContainText('Location: Main Gym');
+    await expect(page.locator('#messages-container')).toContainText('ALL PLAYS');
     expect(pageErrors).toEqual([]);
 });
 

--- a/tests/unit/pre-event-reminder-dispatcher.test.js
+++ b/tests/unit/pre-event-reminder-dispatcher.test.js
@@ -21,6 +21,15 @@ describe('pre-event reminder dispatcher function', () => {
         expect(functionsSource).toContain("'scheduleNotifications.pushSuccessCount'");
     });
 
+    it('posts due pre-event reminders into team chat as an in-app fallback', () => {
+        expect(functionsSource).toContain('async function postPreEventReminderChatMessage');
+        expect(functionsSource).toContain('teams/${teamId}/chatMessages/${messageId}');
+        expect(functionsSource).toContain('Schedule reminder: Upcoming team event');
+        expect(functionsSource).toContain("type: 'pre-event-reminder'");
+        expect(functionsSource).toContain("'scheduleNotifications.chatMessageId'");
+        expect(functionsSource).toContain('chatMessageCreated');
+    });
+
     it('skips cancelled, deleted, disabled, sent, sending, and past events', () => {
         expect(functionsSource).toContain('notifications.enabled === false');
         expect(functionsSource).toContain('notifications.reminderSent === true');

--- a/tests/unit/pre-event-reminder-dispatcher.test.js
+++ b/tests/unit/pre-event-reminder-dispatcher.test.js
@@ -30,6 +30,26 @@ describe('pre-event reminder dispatcher function', () => {
         expect(functionsSource).toContain('chatMessageCreated');
     });
 
+    it('keeps reminder delivery independent from chat fallback write failures', () => {
+        const dispatchBody = functionsSource.slice(functionsSource.indexOf('async function dispatchDuePreEventReminders'));
+        const chatWriteIndex = dispatchBody.indexOf('postPreEventReminderChatMessage');
+        const chatErrorIndex = dispatchBody.indexOf("console.error('Failed to write pre-event reminder chat fallback'");
+        const pushSendIndex = dispatchBody.indexOf('sendCategoryNotification({');
+        const emailSendIndex = dispatchBody.indexOf('createPublicRsvpEmailDeliveries({');
+
+        expect(chatWriteIndex).toBeGreaterThan(-1);
+        expect(chatErrorIndex).toBeGreaterThan(chatWriteIndex);
+        expect(pushSendIndex).toBeGreaterThan(chatErrorIndex);
+        expect(emailSendIndex).toBeGreaterThan(pushSendIndex);
+        expect(functionsSource).toContain("'scheduleNotifications.chatMessageError'");
+    });
+
+    it('does not route reminder fallback chat docs through live-chat push preferences', () => {
+        expect(functionsSource).toContain('function isPreEventReminderChatMessage');
+        expect(functionsSource).toContain("data?.aiMeta?.type === 'pre-event-reminder'");
+        expect(functionsSource).toContain('if (isPreEventReminderChatMessage(data)) return null;');
+    });
+
     it('skips cancelled, deleted, disabled, sent, sending, and past events', () => {
         expect(functionsSource).toContain('notifications.enabled === false');
         expect(functionsSource).toContain('notifications.reminderSent === true');


### PR DESCRIPTION
## Summary

- Posts due pre-event schedule reminders into the default team chat as an in-app fallback.
- Uses a deterministic chat message id based on event id and reminder due time to avoid duplicate retry spam while still allowing rescheduled reminders.
- Records chat delivery audit fields on `scheduleNotifications`.
- Adds unit coverage for the dispatcher path and Playwright smoke coverage that renders a scheduled reminder message in `team-chat.html` using `[REDACTED_EMAIL]` in the mocked auth identity.

## Why

Browser push and RSVP email can depend on device permission, FCM setup, and mail infrastructure. Chat is already the team-visible communication surface, so timed reminders should leave an in-app record even when external notification channels are not seen.

## Validation

- `npx vitest run tests/unit/pre-event-reminder-dispatcher.test.js tests/unit/schedule-notifications.test.js tests/unit/profile-notification-wiring.test.js --reporter=dot`
- `npx playwright test tests/smoke/team-fallback-regressions.spec.js --config=playwright.smoke.config.js --grep "team chat renders scheduled reminder fallback messages" --reporter=line`
- `npx playwright test tests/smoke/team-fallback-regressions.spec.js --config=playwright.smoke.config.js --reporter=line`
- `npm run ci:firebase-rules`

## Notes

This affects production only after Firebase Functions are deployed. The existing immediate schedule save notifications already post to chat; this PR focuses on timed pre-event reminders.