### PR TITLE
feat: Implement UI to initiate Stripe checkout for team fees

### DIFF
--- a/src/app/firebase-config.ts
+++ b/src/app/firebase-config.ts
@@ -8,12 +8,12 @@ import { initializeApp, FirebaseApp } from 'firebase/app';
 
 // TODO: Replace with actual Firebase project configuration
 const firebaseConfig = {
-  apiKey: "YOUR_API_KEY",
-  authDomain: "YOUR_AUTH_DOMAIN",
-  projectId: "YOUR_PROJECT_ID",
-  storageBucket: "YOUR_STORAGE_BUCKET",
-  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
-  appId: "YOUR_APP_ID"
+  apiKey: process.env['FIREBASE_API_KEY'] || '',
+  authDomain: process.env['FIREBASE_AUTH_DOMAIN'] || '',
+  projectId: process.env['FIREBASE_PROJECT_ID'] || '',
+  storageBucket: process.env['FIREBASE_STORAGE_BUCKET'] || '',
+  messagingSenderId: process.env['FIREBASE_MESSAGING_SENDER_ID'] || '',
+  appId: process.env['FIREBASE_APP_ID'] || ''
 };
 
 export const app: FirebaseApp = initializeApp(firebaseConfig);

--- a/src/app/firebase-config.ts
+++ b/src/app/firebase-config.ts
@@ -1,0 +1,24 @@
+
+// This is a placeholder for Firebase initialization.
+// In a real Angular application, 'app' would be initialized using initializeApp.
+// For this task, we are providing a mock/placeholder to allow compilation.
+
+import { initializeApp, FirebaseApp } from 'firebase/app';
+// import { getFunctions } from 'firebase/functions'; // Not needed here directly
+
+// TODO: Replace with actual Firebase project configuration
+const firebaseConfig = {
+  apiKey: "YOUR_API_KEY",
+  authDomain: "YOUR_AUTH_DOMAIN",
+  projectId: "YOUR_PROJECT_ID",
+  storageBucket: "YOUR_STORAGE_BUCKET",
+  messagingSenderId: "YOUR_MESSAGING_SENDER_ID",
+  appId: "YOUR_APP_ID"
+};
+
+export const app: FirebaseApp = initializeApp(firebaseConfig);
+
+// If using Firebase Emulator Suite, uncomment and configure:
+// import { connectFunctionsEmulator } from 'firebase/functions';
+// const functions = getFunctions(app);
+// connectFunctionsEmulator(functions, 'localhost', 5001); // Default for local functions

--- a/src/app/shared/services/stripe.service.ts
+++ b/src/app/shared/services/stripe.service.ts
@@ -1,0 +1,31 @@
+
+// src/app/shared/services/stripe.service.ts
+import { Injectable } from '@angular/core';
+import { getFunctions, httpsCallable } from 'firebase/functions';
+import { app } from '../../app/firebase-config'; // Adjusted path
+
+@Injectable({
+  providedIn: 'root'
+})
+export class StripeService {
+
+  constructor() { }
+
+  async initiateTeamFeeCheckout(teamId: string, teamFeeId: string): Promise<string> {
+    const functions = getFunctions(app);
+    const createCheckoutSession = httpsCallable(functions, 'createStripeTeamFeeCheckout');
+
+    try {
+      const result = await createCheckoutSession({ teamId, teamFeeId });
+      const data = result.data as { checkoutUrl?: string };
+      if (data.checkoutUrl) {
+        return data.checkoutUrl;
+      } else {
+        throw new Error('Stripe checkout URL not returned from function.');
+      }
+    } catch (error) {
+      console.error('Error initiating Stripe checkout:', error);
+      throw error;
+    }
+  }
+}

--- a/src/app/team-fees/team-fees.component.css
+++ b/src/app/team-fees/team-fees.component.css
@@ -1,0 +1,51 @@
+
+/* src/app/team-fees/team-fees.component.css */
+.team-fee-item {
+  border: 1px solid #ccc;
+  padding: 15px;
+  margin-bottom: 10px;
+  border-radius: 5px;
+}
+
+.team-fee-item h3 {
+  margin-top: 0;
+  color: #333;
+}
+
+.team-fee-item p {
+  margin-bottom: 5px;
+}
+
+.paid {
+  color: green;
+  font-weight: bold;
+}
+
+.unpaid {
+  color: red;
+  font-weight: bold;
+}
+
+.error-message {
+  color: #a00;
+  background-color: #ffe0e0;
+  border: 1px solid #a00;
+  padding: 10px;
+  margin-bottom: 15px;
+  border-radius: 5px;
+}
+
+button {
+  background-color: #4CAF50; /* Green */
+  color: white;
+  padding: 10px 15px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 16px;
+}
+
+button:disabled {
+  background-color: #cccccc;
+  cursor: not-allowed;
+}

--- a/src/app/team-fees/team-fees.component.html
+++ b/src/app/team-fees/team-fees.component.html
@@ -1,0 +1,22 @@
+
+<!-- src/app/team-fees/team-fees.component.html -->
+<h2>Team Fees</h2>
+
+<div *ngIf="paymentErrorMessage" class="error-message">{{ paymentErrorMessage }}</div>
+
+<div *ngIf="teamFees.length > 0; else noFees">
+  <div *ngFor="let fee of teamFees" class="team-fee-item">
+    <h3>{{ fee.name }}</h3>
+    <p>Amount: {{ fee.amount | currency }}</p>
+    <p>Status: <span [class.paid]="fee.isPaid" [class.unpaid]="!fee.isPaid">{{ fee.isPaid ? 'Paid' : 'Unpaid' }}</span></p>
+
+    <button *ngIf="!fee.isPaid" (click)="handlePayFee(fee.teamId, fee.id)" [disabled]="isLoadingPayment">
+      <span *ngIf="!isLoadingPayment">Pay Team Fee</span>
+      <span *ngIf="isLoadingPayment">Initiating Payment...</span>
+    </button>
+  </div>
+</div>
+
+<ng-template #noFees>
+  <p>No team fees to display.</p>
+</ng-template>

--- a/src/app/team-fees/team-fees.component.ts
+++ b/src/app/team-fees/team-fees.component.ts
@@ -1,0 +1,51 @@
+
+// src/app/team-fees/team-fees.component.ts
+import { Component, OnInit } from '@angular/core';
+import { StripeService } from '../../app/shared/services/stripe.service'; // Adjusted path
+
+interface TeamFee {
+  id: string;
+  teamId: string;
+  name: string;
+  amount: number;
+  isPaid: boolean; // Assuming this property
+  // ... other fee properties
+}
+
+@Component({
+  selector: 'app-team-fees',
+  templateUrl: './team-fees.component.html',
+  styleUrls: ['./team-fees.component.css']
+})
+export class TeamFeesComponent implements OnInit {
+  teamFees: TeamFee[] = []; // Populate this from data service
+  isLoadingPayment: boolean = false;
+  paymentErrorMessage: string | null = null;
+
+  constructor(private stripeService: StripeService) { }
+
+  ngOnInit(): void {
+    // In a real application, data would be fetched from Firestore or a backend API.
+    // For this demonstration, we populate with mock data.
+    this.teamFees = [
+      { id: 'fee1', teamId: 'teamA', name: 'Registration Fee', amount: 100, isPaid: false },
+      { id: 'fee2', teamId: 'teamA', name: 'Uniform Fee', amount: 50, isPaid: true },
+      { id: 'fee3', teamId: 'teamB', name: 'Tournament Fee', amount: 75, isPaid: false },
+    ];
+  }
+
+  async handlePayFee(teamId: string, teamFeeId: string): Promise<void> {
+    this.isLoadingPayment = true;
+    this.paymentErrorMessage = null; // Clear previous errors
+
+    try {
+      const checkoutUrl = await this.stripeService.initiateTeamFeeCheckout(teamId, teamFeeId);
+      window.location.href = checkoutUrl; // Redirect to Stripe
+    } catch (error) {
+      console.error('Failed to initiate payment:', error);
+      this.paymentErrorMessage = 'Failed to initiate payment. Please try again.';
+    } finally {
+      this.isLoadingPayment = false;
+    }
+  }
+}


### PR DESCRIPTION
Closes #1078

Adds a "Pay Team Fee" button in the team fees section that, when clicked,
invokes the `createStripeTeamFeeCheckout` Firebase Function and redirects
the user to the Stripe checkout page. Includes basic loading and error states.

- Created `src/app/firebase-config.ts` as a placeholder for Firebase app initialization.
- Created `src/app/shared/services/stripe.service.ts` to include
  `initiateTeamFeeCheckout` method for calling the Firebase Function.
- Created `src/app/team-fees/team-fees.component.ts` and its template
  (`team-fees.component.html`) to display the payment button and handle
  the payment initiation flow.
- Created `src/app/team-fees/team-fees.component.css` for basic styling.