### PR TITLE
Fix: Officials page displays error on assignment load failure

### DIFF
--- a/officials.html
+++ b/officials.html
@@ -144,10 +144,14 @@
                 document.getElementById('officials-status').textContent = 'Missing teamId.';
                 return;
             }
-            games = await getGames(teamId);
-            renderAssignedGames();
-            renderOpenSlots();
-            document.getElementById('officials-status').textContent = 'Assignments loaded.';
+            try {
+                games = await getGames(teamId);
+                renderAssignedGames();
+                renderOpenSlots();
+                document.getElementById('officials-status').textContent = 'Assignments loaded.';
+            } catch (error) {
+                document.getElementById('officials-status').textContent = error.message || 'Error loading assignments. Please try again.';
+            }
         }
 
         document.addEventListener('click', async (event) => {


### PR DESCRIPTION
Closes #1089

This PR addresses a bug where the 'Officials' page would get stuck on 'Loading assignments...' indefinitely if the initial data fetch for assignments (via `getGames(teamId)`) failed. 

The `refresh()` function has been updated to include a `try-catch` block around the `getGames(teamId)` call. In case of a failure, the `#officials-status` div will now display an informative error message: 'Error loading assignments. Please try again.', providing better user feedback.