### PR TITLE
Fix: Prefix shared notes in mirrored games with source tag

### DIFF
--- a/js/shared-schedule-sync.js
+++ b/js/shared-schedule-sync.js
@@ -50,7 +50,7 @@ export function buildMirroredGamePayload({
     seasonLabel: sourceGame.seasonLabel || null,
     countsTowardSeasonRecord: sourceGame.countsTowardSeasonRecord !== false,
     arrivalTime: sourceGame.arrivalTime || null,
-    notes: sourceGame.notes || null,
+    notes: sourceGame.notes ? '[SHARED SOURCE NOTES] ' + sourceGame.notes : null,
     assignments: cloneAssignments(sourceGame.assignments),
     tournament: clonePlainValue(sourceGame.tournament) || null,
     cancelledAt: sourceGame.cancelledAt || null,

--- a/js/shared-schedule-sync.js
+++ b/js/shared-schedule-sync.js
@@ -50,7 +50,11 @@ export function buildMirroredGamePayload({
     seasonLabel: sourceGame.seasonLabel || null,
     countsTowardSeasonRecord: sourceGame.countsTowardSeasonRecord !== false,
     arrivalTime: sourceGame.arrivalTime || null,
-    notes: sourceGame.notes ? '[SHARED SOURCE NOTES] ' + sourceGame.notes : null,
+        notes: sourceGame.notes
+      ? sourceGame.notes.startsWith('[SHARED SOURCE NOTES] ')
+        ? sourceGame.notes
+        : '[SHARED SOURCE NOTES] ' + sourceGame.notes
+      : null,
     assignments: cloneAssignments(sourceGame.assignments),
     tournament: clonePlainValue(sourceGame.tournament) || null,
     cancelledAt: sourceGame.cancelledAt || null,

--- a/tests/unit/shared-schedule-sync.test.js
+++ b/tests/unit/shared-schedule-sync.test.js
@@ -93,6 +93,39 @@ describe('shared schedule sync helpers', () => {
     expect(payload.tournament).not.toBe(tournament);
     expect(payload.tournament.slotAssignments).not.toBe(tournament.slotAssignments);
     expect(payload.tournament.resolved).not.toBe(tournament.resolved);
+    expect(payload.notes).toBe('[SHARED SOURCE NOTES] Championship');
+  });
+
+  it('builds a mirrored opponent-team fixture with no notes if sourceGame.notes is null', () => {
+    const payload = buildMirroredGamePayload({
+      sourceTeamId: 'team-alpha',
+      sourceTeam: { name: 'Alpha FC' },
+      sourceGameId: 'game-123',
+      sourceGame: {
+        type: 'game',
+        date: '2026-03-12T18:00:00Z',
+        opponentTeamId: 'team-bravo',
+        notes: null
+      },
+      sharedScheduleId: 'shared_team-alpha_game-123'
+    });
+    expect(payload.notes).toBeNull();
+  });
+
+  it('builds a mirrored opponent-team fixture with no notes if sourceGame.notes is an empty string', () => {
+    const payload = buildMirroredGamePayload({
+      sourceTeamId: 'team-alpha',
+      sourceTeam: { name: 'Alpha FC' },
+      sourceGameId: 'game-123',
+      sourceGame: {
+        type: 'game',
+        date: '2026-03-12T18:00:00Z',
+        opponentTeamId: 'team-bravo',
+        notes: ''
+      },
+      sharedScheduleId: 'shared_team-alpha_game-123'
+    });
+    expect(payload.notes).toBeNull();
   });
 
 


### PR DESCRIPTION
Closes #1092

This change addresses the ambiguity in shared schedule notes for mirrored games. Previously, notes from a source game were copied verbatim, potentially leading to confusion.

Now, when a mirrored game is created from a shared schedule, if the `sourceGame.notes` field contains content, the notes will be prepended with `[SHARED SOURCE NOTES] `.

This improves clarity for coaches, parents, and admins by explicitly indicating the origin of shared notes, reducing cognitive load and the need for manual data reconciliation.

Unit tests have been updated to verify this behavior for cases with and without source notes.