### PR TITLE
Fix: Registration button disabled state on 'option-full' error

### DIFF
--- a/registration.html
+++ b/registration.html
@@ -126,7 +126,7 @@
         const formElement = document.getElementById('registration-form');
         const submitButton = document.getElementById('submit-registration');
         const spinner = document.createElement('span');
-        spinner.className = 'spinner-border spinner-border-sm mr-2 hidden';
+                spinner.className = 'inline-block h-4 w-4 mr-2 animate-spin rounded-full border-2 border-solid border-current border-r-transparent align-[-0.125em] motion-reduce:animate-[spin_1.5s_linear_infinite] hidden';
         spinner.setAttribute('role', 'status');
         spinner.setAttribute('aria-hidden', 'true');
         submitButton.prepend(spinner); // Add spinner to the button

--- a/registration.html
+++ b/registration.html
@@ -125,12 +125,20 @@
         const confirmationMessage = document.getElementById('confirmation-message');
         const formElement = document.getElementById('registration-form');
         const submitButton = document.getElementById('submit-registration');
+        const spinner = document.createElement('span');
+        spinner.className = 'spinner-border spinner-border-sm mr-2 hidden';
+        spinner.setAttribute('role', 'status');
+        spinner.setAttribute('aria-hidden', 'true');
+        submitButton.prepend(spinner); // Add spinner to the button
 
         function showError(message) {
             loadingState.classList.add('hidden');
             formElement.classList.add('hidden');
             errorMessage.textContent = message;
             errorMessage.classList.remove('hidden');
+            submitButton.disabled = false; // Re-enable button on error
+            spinner.classList.add('hidden'); // Hide spinner on error
+            submitButton.classList.remove('opacity-60', 'cursor-not-allowed'); // Remove disabled styling
         }
 
         function renderField(container, field, groupName) {
@@ -398,6 +406,8 @@
 
             errorMessage.classList.add('hidden');
             submitButton.disabled = true;
+            spinner.classList.remove('hidden'); // Show spinner
+            submitButton.classList.add('opacity-60', 'cursor-not-allowed'); // Apply disabled styling
 
             const submission = {
                 participant: readGroupValues('participant', activeForm.participantFields),
@@ -413,6 +423,8 @@
                 errorMessage.textContent = validationErrors.join(' ');
                 errorMessage.classList.remove('hidden');
                 submitButton.disabled = false;
+                spinner.classList.add('hidden');
+                submitButton.classList.remove('opacity-60', 'cursor-not-allowed');
                 return;
             }
 
@@ -436,6 +448,8 @@
                     : 'Registration could not be submitted. Please try again.';
                 errorMessage.classList.remove('hidden');
                 submitButton.disabled = false;
+                spinner.classList.add('hidden');
+                submitButton.classList.remove('opacity-60', 'cursor-not-allowed');
             }
         });
 


### PR DESCRIPTION
Closes #1097

This commit addresses the issue where the registration form's submit button remains disabled and the spinner visible after an 'option-full' error.

Upon investigation of the current `registration.html` file, it was found that the spinner element was not consistently managed within the form submission logic. While the `submitButton` itself was correctly referenced and its disabled state was toggled, the associated visual spinner and disabled styling were not.

This change reintroduces the spinner element and integrates its visibility toggling (show/hide) along with the `submitButton`'s disabled state and styling across the form submission event listener and the `showError` utility function. This ensures that the button re-enables and the spinner hides correctly after validation errors or a caught submission error (like 'option-full'), preventing the UI from getting stuck.

This ensures a consistent and responsive user experience during registration, especially when encountering validation feedback.