### PR TITLE
Simplify Certificates landing page, prioritize 'Start new run'

### DIFF
--- a/certificates.html
+++ b/certificates.html
@@ -55,9 +55,9 @@
                     <p id="cert-page-subtitle" class="mt-2 text-gray-600">Set up the certificate, choose players, create drafts, edit, then print.</p>
                 </div>
                 <div class="flex flex-wrap gap-2">
-                    <button id="cert-new-run-btn" type="button" class="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50">Start new run</button>
+                    <button id="cert-new-run-btn" type="button" class="rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-primary-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-600">Start new run</button>
                     <button id="cert-view-saved-btn" type="button" class="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-50">View saved work</button>
-                    <button id="cert-custom-recipient-btn" type="button" class="rounded-lg border border-primary-200 bg-primary-50 px-4 py-2 text-sm font-semibold text-primary-700 hover:bg-primary-100">Create one-off certificate</button>
+                    <button id="cert-custom-recipient-btn" type="button" class="rounded-lg border border-gray-300 bg-white px-4 py-2 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50">Create one-off certificate</button>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
Closes #1106

This PR simplifies the Certificates landing page by updating the visual hierarchy of the action buttons. The 'Start new run' button is now prominently styled as the primary call to action, guiding users to the most common workflow.

The 'Create one-off certificate' button, which previously used primary styling, has been restyled to a neutral appearance, aligning it with 'View saved work' as a secondary option. This change reduces cognitive load for coaches and admins by streamlining the initial decision point.

**Acceptance Criteria Verification:**
1.  **'Start new run' button prioritized:** The button now uses primary `bg-primary-600` styling with `text-white` to clearly stand out.
2.  **'View saved work' de-emphasized:** This button retains its neutral styling.
3.  **'Create one-off certificate' de-emphasized:** This button's styling has been changed from primary to neutral, making it a secondary choice and removing competition for primary attention.

**Testing Expectation:**
*   Verify that a user can easily identify and initiate the 'Start new run' workflow without distraction.
*   Confirm that 'View saved work' and 'Create one-off certificate' are still accessible and functional in their new placement/styling.