### PR TITLE
Add claimable assignment sign-up (snack duty)

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -2822,15 +2822,32 @@
         });
 
         // ===== ASSIGNMENT ROWS =====
-        function addAssignmentRow(role = '', value = '') {
+        function addAssignmentRow(role = '', value = '', claimable = false) {
             const container = document.getElementById('assignment-rows');
             const row = document.createElement('div');
-            row.className = 'flex gap-2 items-center';
+            row.className = 'flex gap-2 items-start';
+            const isClaimable = claimable === true;
             row.innerHTML = `
-                <input type="text" placeholder="Role (e.g. Snack)" value="${role}" class="assignment-role flex-1 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm">
-                <input type="text" placeholder="Assigned to" value="${value}" class="assignment-value flex-1 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm">
-                <button type="button" class="text-red-400 hover:text-red-600 text-lg font-bold" onclick="this.parentElement.remove()">&times;</button>
+                <div class="flex-1 space-y-1">
+                    <input type="text" placeholder="Role (e.g. Snack)" value="${role}" class="assignment-role w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm">
+                    <input type="text" placeholder="Assigned to" value="${value}" class="assignment-value w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm${isClaimable ? ' hidden' : ''}">
+                    <label class="flex items-center gap-1.5 text-xs text-gray-600 cursor-pointer select-none">
+                        <input type="checkbox" class="assignment-claimable rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"${isClaimable ? ' checked' : ''}>
+                        Let parents sign up
+                    </label>
+                </div>
+                <button type="button" class="mt-2 text-red-400 hover:text-red-600 text-lg font-bold leading-none" onclick="this.parentElement.remove()">&times;</button>
             `;
+            const checkbox = row.querySelector('.assignment-claimable');
+            const valueInput = row.querySelector('.assignment-value');
+            checkbox.addEventListener('change', () => {
+                if (checkbox.checked) {
+                    valueInput.value = '';
+                    valueInput.classList.add('hidden');
+                } else {
+                    valueInput.classList.remove('hidden');
+                }
+            });
             container.appendChild(row);
         }
 
@@ -2955,12 +2972,13 @@
         document.getElementById('add-officiating-slot-btn').addEventListener('click', () => addOfficiatingSlotRow());
 
         function getAssignmentsFromForm() {
-            const rows = document.querySelectorAll('#assignment-rows .flex');
+            const rows = document.querySelectorAll('#assignment-rows > div');
             const assignments = [];
             rows.forEach(row => {
                 const role = row.querySelector('.assignment-role').value.trim();
-                const value = row.querySelector('.assignment-value').value.trim();
-                if (role) assignments.push({ role, value });
+                const claimable = row.querySelector('.assignment-claimable')?.checked === true;
+                const value = claimable ? '' : row.querySelector('.assignment-value').value.trim();
+                if (role) assignments.push({ role, value, claimable });
             });
             return assignments;
         }
@@ -2969,7 +2987,7 @@
             const container = document.getElementById('assignment-rows');
             container.innerHTML = '';
             if (assignments && assignments.length > 0) {
-                assignments.forEach(a => addAssignmentRow(a.role, a.value));
+                assignments.forEach(a => addAssignmentRow(a.role, a.value, a.claimable));
             }
         }
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -1406,7 +1406,6 @@ service cloud.firestore {
                              isRideshareSeatCountUpdateValid(teamId, gameId, offerId, resource.data.status, 'declined');
           }
         }
-      }
 
         // Claimable assignment claims (snack sign-up, etc.)
         match /assignmentClaims/{role} {

--- a/firestore.rules
+++ b/firestore.rules
@@ -1408,6 +1408,23 @@ service cloud.firestore {
         }
       }
 
+        // Claimable assignment claims (snack sign-up, etc.)
+        match /assignmentClaims/{role} {
+          allow read: if isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId);
+          // Parent creates their own claim; document must not already exist (create only, no update).
+          allow create: if isSignedIn() &&
+                           isParentForTeam(teamId) &&
+                           request.resource.data.claimedByUserId == request.auth.uid &&
+                           request.resource.data.claimedByName is string &&
+                           request.resource.data.claimedByName.size() > 0 &&
+                           request.resource.data.claimedByName.size() <= 100;
+          // Owner releases their own claim; admins may release any claim.
+          allow delete: if isSignedIn() &&
+                           (resource.data.claimedByUserId == request.auth.uid ||
+                            isTeamOwnerOrAdmin(teamId));
+        }
+      }
+
       // Tournament brackets subcollection
       match /brackets/{bracketId} {
         allow read: if isTeamOwnerOrAdmin(teamId) ||

--- a/js/db.js
+++ b/js/db.js
@@ -6460,3 +6460,59 @@ export async function getPlayerTrackingStatuses(teamId, playerIds = []) {
     });
     return Array.from(statusesById.values());
 }
+
+// ===== ASSIGNMENT CLAIMS (snack sign-up) =====
+
+/**
+ * Claim an open assignment slot on behalf of the signed-in parent.
+ * Fails if the slot is already claimed by someone else.
+ */
+export async function claimAssignmentSlot(teamId, gameId, role, { name } = {}) {
+    const user = auth.currentUser;
+    if (!user?.uid) throw new Error('You must be signed in to claim a slot.');
+    const trimmedRole = (role || '').toString().trim();
+    if (!trimmedRole) throw new Error('Role is required.');
+    const trimmedName = (name || '').toString().trim();
+    if (!trimmedName) throw new Error('Name is required.');
+
+    const claimRef = doc(db, `teams/${teamId}/games/${gameId}/assignmentClaims`, trimmedRole);
+    const snap = await getDoc(claimRef);
+    if (snap.exists()) throw new Error('This slot has already been claimed.');
+
+    await setDoc(claimRef, {
+        claimedByUserId: user.uid,
+        claimedByName: trimmedName.slice(0, 100),
+        claimedAt: Timestamp.now()
+    });
+}
+
+/**
+ * Release the signed-in parent's claim on an assignment slot.
+ * Admins may release any claim.
+ */
+export async function releaseAssignmentClaim(teamId, gameId, role) {
+    const user = auth.currentUser;
+    if (!user?.uid) throw new Error('You must be signed in to release a claim.');
+    const trimmedRole = (role || '').toString().trim();
+    if (!trimmedRole) throw new Error('Role is required.');
+
+    const claimRef = doc(db, `teams/${teamId}/games/${gameId}/assignmentClaims`, trimmedRole);
+    const snap = await getDoc(claimRef);
+    if (!snap.exists()) return;
+    const claim = snap.data() || {};
+    if (claim.claimedByUserId !== user.uid) throw new Error('You can only release your own claim.');
+    await deleteDoc(claimRef);
+}
+
+/**
+ * Load all assignment claims for a game/event.
+ * Returns a plain object keyed by role name.
+ */
+export async function getAssignmentClaims(teamId, gameId) {
+    const snap = await getDocs(collection(db, `teams/${teamId}/games/${gameId}/assignmentClaims`));
+    const claims = {};
+    snap.forEach((docSnap) => {
+        claims[docSnap.id] = { id: docSnap.id, ...docSnap.data() };
+    });
+    return claims;
+}

--- a/js/db.js
+++ b/js/db.js
@@ -6476,19 +6476,22 @@ export async function claimAssignmentSlot(teamId, gameId, role, { name } = {}) {
     if (!trimmedName) throw new Error('Name is required.');
 
     const claimRef = doc(db, `teams/${teamId}/games/${gameId}/assignmentClaims`, trimmedRole);
-    const snap = await getDoc(claimRef);
-    if (snap.exists()) throw new Error('This slot has already been claimed.');
 
-    await setDoc(claimRef, {
-        claimedByUserId: user.uid,
-        claimedByName: trimmedName.slice(0, 100),
-        claimedAt: Timestamp.now()
+    await runTransaction(db, async (tx) => {
+        const snap = await tx.get(claimRef);
+        if (snap.exists()) throw new Error('This slot has already been claimed.');
+        tx.set(claimRef, {
+            claimedByUserId: user.uid,
+            claimedByName: trimmedName.slice(0, 100),
+            claimedAt: Timestamp.now()
+        });
     });
 }
 
 /**
- * Release the signed-in parent's claim on an assignment slot.
- * Admins may release any claim.
+ * Release a claim on an assignment slot.
+ * Parents may only release their own claim; admins may release any claim
+ * (enforced by Firestore rules).
  */
 export async function releaseAssignmentClaim(teamId, gameId, role) {
     const user = auth.currentUser;
@@ -6499,8 +6502,6 @@ export async function releaseAssignmentClaim(teamId, gameId, role) {
     const claimRef = doc(db, `teams/${teamId}/games/${gameId}/assignmentClaims`, trimmedRole);
     const snap = await getDoc(claimRef);
     if (!snap.exists()) return;
-    const claim = snap.data() || {};
-    if (claim.claimedByUserId !== user.uid) throw new Error('You can only release your own claim.');
     await deleteDoc(claimRef);
 }
 

--- a/js/snack-helpers.js
+++ b/js/snack-helpers.js
@@ -1,0 +1,65 @@
+/**
+ * Helpers for claimable assignment slots (e.g. snack duty).
+ *
+ * An assignment is "claimable" when `claimable: true` and `value` is empty.
+ * Claims are stored as separate documents in the `assignmentClaims` subcollection
+ * keyed by role name (e.g. "Snack"). This keeps the admin-managed assignments
+ * array immutable while allowing parents to self-sign-up.
+ */
+
+export function normalizeAssignment(assignment = {}) {
+    return {
+        ...assignment,
+        role: typeof assignment.role === 'string' ? assignment.role.trim() : '',
+        value: typeof assignment.value === 'string' ? assignment.value.trim() : '',
+        claimable: assignment.claimable === true
+    };
+}
+
+/**
+ * Returns assignments that have the claimable flag set and no pre-filled value.
+ */
+export function getClaimableAssignments(assignments = []) {
+    if (!Array.isArray(assignments)) return [];
+    return assignments
+        .map(normalizeAssignment)
+        .filter((a) => a.claimable && a.role && !a.value);
+}
+
+/**
+ * Returns claimable assignments that have not yet been claimed.
+ * `claims` is a plain object keyed by role name.
+ */
+export function getOpenClaimableAssignments(assignments = [], claims = {}) {
+    return getClaimableAssignments(assignments).filter((a) => !claims[a.role]);
+}
+
+/**
+ * Returns the claim object for a role, or null if unclaimed.
+ */
+export function getClaimForRole(claims = {}, role) {
+    if (!role) return null;
+    return claims[role] || null;
+}
+
+/**
+ * Returns true if the given user has claimed the specified role.
+ */
+export function isClaimedByUser(claims = {}, role, userId) {
+    if (!role || !userId) return false;
+    const claim = claims[role];
+    return !!(claim && claim.claimedByUserId === userId);
+}
+
+/**
+ * Merges admin assignments with live claims for rendering.
+ * Returns an array of assignment display objects:
+ *   { role, value, claimable, claim | null }
+ */
+export function mergeAssignmentsWithClaims(assignments = [], claims = {}) {
+    if (!Array.isArray(assignments)) return [];
+    return assignments.map(normalizeAssignment).map((a) => ({
+        ...a,
+        claim: a.claimable ? (claims[a.role] || null) : null
+    }));
+}

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -282,8 +282,11 @@
             createParentMembershipRequest,
             listMyParentMembershipRequests,
             listParentTeamFeeRecipients,
-            listCertificatesForPlayer
-        } from './js/db.js?v=50';
+            listCertificatesForPlayer,
+            claimAssignmentSlot,
+            releaseAssignmentClaim,
+            getAssignmentClaims
+        } from './js/db.js?v=51';
         import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence, getCalendarEventTrackingId, isTrackedCalendarEvent } from './js/utils.js?v=10';
         import {
             getIncentiveRules,
@@ -313,6 +316,7 @@
         import { resolveRsvpPlayerIdsForSubmission, resolveMyRsvpByChildForGame } from './js/parent-dashboard-rsvp.js?v=5';
         import { createParentDashboardRsvpController } from './js/parent-dashboard-rsvp-controls.js?v=1';
         import { getEventRideshareSummary, getOfferSeatInfo } from './js/rideshare-helpers.js?v=1';
+        import { mergeAssignmentsWithClaims } from './js/snack-helpers.js?v=1';
         import { resolveSelectedRideChildId, getRideOfferUiState, createRideRequestHandlers } from './js/parent-dashboard-rideshare-controls.js?v=1';
         import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';
         import { renderParentTeamFees } from './js/parent-dashboard-fees.js?v=4';
@@ -333,6 +337,7 @@
         let activeDayModal = null;
         const practicePacketSessionMap = new Map();
         const rideshareOffersByEvent = new Map();
+        const assignmentClaimsByEvent = new Map();
         const teamChildrenByTeamId = new Map();
         const selectedRideChildByOffer = new Map();
         const requestablePlayersByTeam = new Map();
@@ -570,6 +575,72 @@
             return event?.isDbGame || event?.type === 'practice';
         }
 
+        function getEventClaimsKey(teamId, eventId) {
+            return `${teamId}::${eventId}`;
+        }
+
+        function getEventAssignmentClaims(teamId, eventId) {
+            return assignmentClaimsByEvent.get(getEventClaimsKey(teamId, eventId)) || {};
+        }
+
+        async function refreshAssignmentClaimsForEvent(teamId, gameId) {
+            const key = getEventClaimsKey(teamId, gameId);
+            try {
+                const claims = await getAssignmentClaims(teamId, gameId);
+                assignmentClaimsByEvent.set(key, claims);
+            } catch (err) {
+                console.warn('Unable to load assignment claims for event:', teamId, gameId, err);
+                assignmentClaimsByEvent.set(key, {});
+            }
+        }
+
+        function renderAssignments(event) {
+            const assignments = Array.isArray(event.assignments) ? event.assignments : [];
+            if (assignments.length === 0) return '';
+            const claims = getEventAssignmentClaims(event.teamId, event.id);
+            const merged = mergeAssignmentsWithClaims(assignments, claims);
+            const badges = merged.map((a) => {
+                if (!a.claimable) {
+                    return `<span class="inline-block bg-gray-100 rounded px-1.5 py-0.5 mr-1 mb-1"><b>${escapeHtml(a.role)}:</b> ${escapeHtml(a.value || 'TBD')}</span>`;
+                }
+                const myOwn = a.claim && a.claim.claimedByUserId === currentUserId;
+                const claimedByOther = a.claim && !myOwn;
+                if (myOwn) {
+                    return `<span class="inline-block bg-green-50 border border-green-200 rounded px-1.5 py-0.5 mr-1 mb-1 text-green-800"><b>${escapeHtml(a.role)}:</b> You &mdash; <button class="underline text-green-700 hover:text-green-900" onclick="handleReleaseAssignmentClaim('${escapeAttr(event.teamId)}','${escapeAttr(event.id)}','${escapeAttr(a.role)}')">Release</button></span>`;
+                }
+                if (claimedByOther) {
+                    return `<span class="inline-block bg-gray-100 rounded px-1.5 py-0.5 mr-1 mb-1"><b>${escapeHtml(a.role)}:</b> ${escapeHtml(a.claim.claimedByName || 'Taken')}</span>`;
+                }
+                return `<span class="inline-block bg-amber-50 border border-amber-200 rounded px-1.5 py-0.5 mr-1 mb-1"><b>${escapeHtml(a.role)}:</b> <button class="underline text-amber-800 hover:text-amber-900 font-semibold" onclick="handleClaimAssignmentSlot('${escapeAttr(event.teamId)}','${escapeAttr(event.id)}','${escapeAttr(a.role)}')">Sign up</button></span>`;
+            }).join('');
+            return `<div class="mt-1 text-xs text-gray-600">${badges}</div>`;
+        }
+
+        async function handleClaimAssignmentSlot(teamId, gameId, role) {
+            try {
+                const name = currentUser?.displayName || currentUser?.email || 'Parent';
+                await claimAssignmentSlot(teamId, gameId, role, { name });
+                await refreshAssignmentClaimsForEvent(teamId, gameId);
+                renderScheduleFromControls();
+                rerenderActiveDayModal();
+            } catch (err) {
+                console.error('Failed to claim assignment slot:', err);
+                alert(`Could not sign up: ${err?.message || err}`);
+            }
+        }
+
+        async function handleReleaseAssignmentClaim(teamId, gameId, role) {
+            try {
+                await releaseAssignmentClaim(teamId, gameId, role);
+                await refreshAssignmentClaimsForEvent(teamId, gameId);
+                renderScheduleFromControls();
+                rerenderActiveDayModal();
+            } catch (err) {
+                console.error('Failed to release assignment claim:', err);
+                alert(`Could not release: ${err?.message || err}`);
+            }
+        }
+
         function resolveChildChoices(teamId) {
             const children = teamChildrenByTeamId.get(teamId) || [];
             return children.filter((child) => child?.playerId).map((child) => ({
@@ -743,6 +814,18 @@
             await Promise.all(uniqueEvents.map(async ({ teamId, gameId, legacyGameId }) => {
                 await refreshRideshareForEvent(teamId, gameId, legacyGameId);
             }));
+        }
+
+        async function hydrateAssignmentClaimsForSchedule(events = []) {
+            const uniqueEvents = Array.from(new Map(
+                (events || [])
+                    .filter((ev) => ev?.isDbGame && !ev?.isCancelled && ev?.teamId && ev?.id)
+                    .filter((ev) => Array.isArray(ev.assignments) && ev.assignments.some((a) => a.claimable))
+                    .map((ev) => [getEventClaimsKey(ev.teamId, ev.id), { teamId: ev.teamId, gameId: ev.id }])
+            ).values());
+            await Promise.all(uniqueEvents.map(({ teamId, gameId }) =>
+                refreshAssignmentClaimsForEvent(teamId, gameId)
+            ));
         }
 
         function toggleRideOfferForm(eventKey) {
@@ -979,7 +1062,10 @@
             if (runId !== parentDashboardHydrationRun) return;
 
             allScheduleEvents = combinedSchedule;
-            await hydrateRideshareOffersForSchedule(allScheduleEvents);
+            await Promise.all([
+                hydrateRideshareOffersForSchedule(allScheduleEvents),
+                hydrateAssignmentClaimsForSchedule(allScheduleEvents)
+            ]);
             if (runId !== parentDashboardHydrationRun) return;
 
             // Fetch my RSVPs for tracked DB events (games + practices).
@@ -1567,7 +1653,7 @@
                             ${ev.kitColor ? `<div class="text-xs text-purple-700 mt-1">Kit: ${escapeHtml(ev.kitColor)}</div>` : ''}
                             ${ev.arrivalTime ? `<div class="text-xs text-amber-700 mt-1">Arrive: ${(() => { const at = ev.arrivalTime?.toDate ? ev.arrivalTime.toDate() : new Date(ev.arrivalTime); return at.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }); })()}</div>` : ''}
                             ${ev.notes ? `<div class="text-xs text-gray-500 mt-1 italic">${escapeHtml(ev.notes)}</div>` : ''}
-                            ${ev.assignments && ev.assignments.length > 0 ? `<div class="mt-1 text-xs text-gray-600">${ev.assignments.map(a => `<span class="inline-block bg-gray-100 rounded px-1.5 py-0.5 mr-1 mb-1"><b>${escapeHtml(a.role)}:</b> ${escapeHtml(a.value || 'TBD')}</span>`).join('')}</div>` : ''}
+                            ${renderAssignments(ev)}
                             ${ev.rsvpSummary ? `<div class="text-xs text-gray-500 mt-1">${formatRsvpSummary(ev.rsvpSummary)}</div>` : ''}
                             ${ev.childNames?.length ? `<div class="text-xs text-gray-500 mt-1">For ${escapeHtml(ev.childNames.join(', '))}</div>` : ''}
                             ${homePacketReady ? `
@@ -2060,7 +2146,7 @@
                         ${game.kitColor ? `<div class="text-xs text-purple-700 mt-1">Kit: ${escapeHtml(game.kitColor)}</div>` : ''}
                         ${game.arrivalTime ? `<div class="text-xs text-amber-700 mt-1">Arrive: ${(() => { const at = game.arrivalTime?.toDate ? game.arrivalTime.toDate() : new Date(game.arrivalTime); return at.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }); })()}</div>` : ''}
                         ${game.notes ? `<div class="text-xs text-gray-500 mt-1 italic">${escapeHtml(game.notes)}</div>` : ''}
-                        ${game.assignments && game.assignments.length > 0 ? `<div class="mt-1 text-xs text-gray-600">${game.assignments.map(a => `<span class="inline-block bg-gray-100 rounded px-1.5 py-0.5 mr-1 mb-1"><b>${escapeHtml(a.role)}:</b> ${escapeHtml(a.value || 'TBD')}</span>`).join('')}</div>` : ''}
+                        ${renderAssignments(game)}
                         ${attendanceRecorded ? `
                             <div class="mt-3 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2">
                                 <div class="text-[11px] font-bold uppercase tracking-wide text-amber-800">Practice Attendance</div>

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -357,6 +357,8 @@
         window.openPracticePacketPreview = openPracticePacketPreview;
         window.closePracticePacketPreview = closePracticePacketPreview;
         window.markPracticePacketComplete = markPracticePacketComplete;
+        window.handleClaimAssignmentSlot = handleClaimAssignmentSlot;
+        window.handleReleaseAssignmentClaim = handleReleaseAssignmentClaim;
         window.toggleRideOfferForm = toggleRideOfferForm;
         window.submitRideOfferFromForm = submitRideOfferFromForm;
         window.updateRideRequestDecision = updateRideRequestDecision;

--- a/tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js
+++ b/tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js
@@ -105,7 +105,7 @@ const location = deps.location;
 const URL = deps.URL;
 const Blob = deps.Blob;
 ` + match[1]
-        .replace(/import\s*\{[\s\S]*?\}\s*from '\.\/js\/db\.js\?v=\d+';/, 'const { getParentDashboardData, redeemParentInvite, getTeam, getTeams, getPlayers, getGames, getTrackedCalendarEventUids, getUnreadChatCounts, getPracticeSessions, getPracticePacketCompletions, upsertPracticePacketCompletion, updateUserProfile, getUserProfile, submitRsvp, submitRsvpForPlayer, getRsvps, getRsvpSummaries, createRideOffer, listRideOffersForEvent, requestRideSpot, updateRideRequestStatus, closeRideOffer, cancelRideRequest, getAggregatedStatsForPlayer, createParentMembershipRequest, listMyParentMembershipRequests, listParentTeamFeeRecipients } = deps.db;')
+        .replace(/import\s*\{[\s\S]*?\}\s*from '\.\/js\/db\.js\?v=\d+';/, 'const { getParentDashboardData, redeemParentInvite, getTeam, getTeams, getPlayers, getGames, getTrackedCalendarEventUids, getUnreadChatCounts, getPracticeSessions, getPracticePacketCompletions, upsertPracticePacketCompletion, updateUserProfile, getUserProfile, submitRsvp, submitRsvpForPlayer, getRsvps, getRsvpSummaries, createRideOffer, listRideOffersForEvent, requestRideSpot, updateRideRequestStatus, closeRideOffer, cancelRideRequest, getAggregatedStatsForPlayer, createParentMembershipRequest, listMyParentMembershipRequests, listParentTeamFeeRecipients, claimAssignmentSlot, releaseAssignmentClaim, getAssignmentClaims } = deps.db;')
         .replace(/import\s*\{[\s\S]*?\}\s*from '\.\/js\/utils\.js\?v=10';/, 'const { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence, getCalendarEventTrackingId, isTrackedCalendarEvent } = deps.utils;')
         .replace(/import\s*\{[\s\S]*?\}\s*from '\.\/js\/parent-incentives\.js\?v=3';/, 'const { getIncentiveRules, saveIncentiveRule: saveIncentiveRuleFn, toggleIncentiveRule: toggleIncentiveRuleFn, retireIncentiveRule: retireIncentiveRuleFn, markGamePaid: markGamePaidFn, unmarkGamePaid: unmarkGamePaidFn, getPaidGames, calculateEarnings, formatCents, getApplicableRulesForGame, getStatOptionsForTeam, renderIncentivesPanel, renderRuleBuilder, getCapSetting, saveCapSetting: saveCapSettingFn } = deps.parentIncentives;')
         .replace("import { requireAuth, checkAuth } from './js/auth.js?v=14';", 'const { requireAuth, checkAuth } = deps.auth;')
@@ -117,6 +117,7 @@ const Blob = deps.Blob;
         .replace("import { resolveRsvpPlayerIdsForSubmission, resolveMyRsvpByChildForGame } from './js/parent-dashboard-rsvp.js?v=5';", 'const { resolveRsvpPlayerIdsForSubmission, resolveMyRsvpByChildForGame } = deps.parentDashboardRsvp;')
         .replace("import { createParentDashboardRsvpController } from './js/parent-dashboard-rsvp-controls.js?v=1';", 'const { createParentDashboardRsvpController } = deps.parentDashboardRsvpControls;')
         .replace("import { getEventRideshareSummary, getOfferSeatInfo } from './js/rideshare-helpers.js?v=1';", 'const { getEventRideshareSummary, getOfferSeatInfo } = deps.rideshareHelpers;')
+        .replace("import { mergeAssignmentsWithClaims } from './js/snack-helpers.js?v=1';", 'const { mergeAssignmentsWithClaims } = deps.snackHelpers;')
         .replace("import { resolveSelectedRideChildId, getRideOfferUiState, createRideRequestHandlers } from './js/parent-dashboard-rideshare-controls.js?v=1';", 'const { resolveSelectedRideChildId, getRideOfferUiState, createRideRequestHandlers } = deps.parentDashboardRideshareControls;')
         .replace("import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';", 'const { applyRsvpHydration } = deps.rsvpHydration;')
         .replace(/import\s*\{\s*renderParentTeamFees\s*\}\s*from '\.\/js\/parent-dashboard-fees\.js\?v=\d+';/, 'const { renderParentTeamFees } = deps.parentDashboardFees;')
@@ -231,7 +232,10 @@ function createDeps(submitRecorder) {
             async getAggregatedStatsForPlayer() { return null; },
             async createParentMembershipRequest() {},
             async listMyParentMembershipRequests() { return []; },
-            async listParentTeamFeeRecipients() { return []; }
+            async listParentTeamFeeRecipients() { return []; },
+            async claimAssignmentSlot() {},
+            async releaseAssignmentClaim() {},
+            async getAssignmentClaims() { return {}; }
         },
         utils: {
             renderHeader() {},
@@ -285,6 +289,9 @@ function createDeps(submitRecorder) {
         rideshareHelpers: {
             getEventRideshareSummary() { return { seatsLeft: 0, requests: 0, isFull: false }; },
             getOfferSeatInfo() { return { seatCountConfirmed: 0, seatCapacity: 0, seatsLeft: 0 }; }
+        },
+        snackHelpers: {
+            mergeAssignmentsWithClaims(assignments) { return (assignments || []).map((a) => ({ ...a, claim: null })); }
         },
         parentDashboardRideshareControls: {
             resolveSelectedRideChildId({ defaultChildId }) { return defaultChildId || ''; },

--- a/tests/unit/snack-helpers.test.js
+++ b/tests/unit/snack-helpers.test.js
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import {
+    normalizeAssignment,
+    getClaimableAssignments,
+    getOpenClaimableAssignments,
+    getClaimForRole,
+    isClaimedByUser,
+    mergeAssignmentsWithClaims
+} from '../../js/snack-helpers.js';
+
+describe('normalizeAssignment', () => {
+    it('sets claimable to false when missing', () => {
+        expect(normalizeAssignment({ role: 'Snack', value: '' }).claimable).toBe(false);
+    });
+
+    it('coerces truthy claimable to boolean true', () => {
+        expect(normalizeAssignment({ role: 'Snack', value: '', claimable: true }).claimable).toBe(true);
+    });
+
+    it('trims role and value', () => {
+        const result = normalizeAssignment({ role: '  Snack  ', value: '  Jane  ', claimable: false });
+        expect(result.role).toBe('Snack');
+        expect(result.value).toBe('Jane');
+    });
+
+    it('handles missing fields gracefully', () => {
+        const result = normalizeAssignment({});
+        expect(result.role).toBe('');
+        expect(result.value).toBe('');
+        expect(result.claimable).toBe(false);
+    });
+});
+
+describe('getClaimableAssignments', () => {
+    it('returns only claimable assignments with no pre-filled value', () => {
+        const assignments = [
+            { role: 'Snack', value: '', claimable: true },
+            { role: 'Setup', value: 'Coach Mike', claimable: true },
+            { role: 'Cleanup', value: '', claimable: false },
+            { role: 'Photographer', value: '', claimable: true }
+        ];
+        const result = getClaimableAssignments(assignments);
+        expect(result.map((a) => a.role)).toEqual(['Snack', 'Photographer']);
+    });
+
+    it('returns empty array for non-array input', () => {
+        expect(getClaimableAssignments(null)).toEqual([]);
+        expect(getClaimableAssignments(undefined)).toEqual([]);
+    });
+
+    it('excludes assignments with empty role', () => {
+        const result = getClaimableAssignments([{ role: '', value: '', claimable: true }]);
+        expect(result).toHaveLength(0);
+    });
+});
+
+describe('getOpenClaimableAssignments', () => {
+    const assignments = [
+        { role: 'Snack', value: '', claimable: true },
+        { role: 'Drinks', value: '', claimable: true }
+    ];
+
+    it('returns all claimable when no claims exist', () => {
+        expect(getOpenClaimableAssignments(assignments, {})).toHaveLength(2);
+    });
+
+    it('excludes roles that have been claimed', () => {
+        const claims = { Snack: { claimedByUserId: 'u1', claimedByName: 'Jane' } };
+        const open = getOpenClaimableAssignments(assignments, claims);
+        expect(open.map((a) => a.role)).toEqual(['Drinks']);
+    });
+
+    it('returns all when claims object is empty', () => {
+        expect(getOpenClaimableAssignments(assignments, {})).toHaveLength(2);
+    });
+});
+
+describe('getClaimForRole', () => {
+    const claims = {
+        Snack: { claimedByUserId: 'u1', claimedByName: 'Jane' }
+    };
+
+    it('returns the claim for a known role', () => {
+        expect(getClaimForRole(claims, 'Snack')).toEqual({ claimedByUserId: 'u1', claimedByName: 'Jane' });
+    });
+
+    it('returns null for an unclaimed role', () => {
+        expect(getClaimForRole(claims, 'Drinks')).toBeNull();
+    });
+
+    it('returns null when role is empty', () => {
+        expect(getClaimForRole(claims, '')).toBeNull();
+    });
+});
+
+describe('isClaimedByUser', () => {
+    const claims = {
+        Snack: { claimedByUserId: 'u1', claimedByName: 'Jane' }
+    };
+
+    it('returns true when user owns the claim', () => {
+        expect(isClaimedByUser(claims, 'Snack', 'u1')).toBe(true);
+    });
+
+    it('returns false when a different user owns the claim', () => {
+        expect(isClaimedByUser(claims, 'Snack', 'u2')).toBe(false);
+    });
+
+    it('returns false when role is unclaimed', () => {
+        expect(isClaimedByUser(claims, 'Drinks', 'u1')).toBe(false);
+    });
+
+    it('returns false when userId is empty', () => {
+        expect(isClaimedByUser(claims, 'Snack', '')).toBe(false);
+    });
+});
+
+describe('mergeAssignmentsWithClaims', () => {
+    it('attaches claim to claimable assignments', () => {
+        const assignments = [
+            { role: 'Snack', value: '', claimable: true },
+            { role: 'Coach Notes', value: 'Coach A', claimable: false }
+        ];
+        const claims = { Snack: { claimedByUserId: 'u1', claimedByName: 'Jane' } };
+        const merged = mergeAssignmentsWithClaims(assignments, claims);
+
+        expect(merged[0].claim).toEqual({ claimedByUserId: 'u1', claimedByName: 'Jane' });
+        expect(merged[1].claim).toBeNull();
+    });
+
+    it('sets claim to null when slot is unclaimed', () => {
+        const assignments = [{ role: 'Snack', value: '', claimable: true }];
+        const merged = mergeAssignmentsWithClaims(assignments, {});
+        expect(merged[0].claim).toBeNull();
+    });
+
+    it('handles non-array input gracefully', () => {
+        expect(mergeAssignmentsWithClaims(null, {})).toEqual([]);
+    });
+});


### PR DESCRIPTION
Admins can mark any assignment slot as "Let parents sign up" in the
schedule editor. Parents see a Sign up / Release button on their
dashboard instead of a static badge. Claims are stored in a separate
assignmentClaims subcollection so the admin-managed assignments array
stays immutable.

- js/snack-helpers.js: pure helpers for normalising, filtering, and
  merging claimable assignments with live claims
- tests/unit/snack-helpers.test.js: 20 unit tests covering all helpers
- js/db.js: claimAssignmentSlot, releaseAssignmentClaim, getAssignmentClaims
- firestore.rules: assignmentClaims subcollection — parents create own
  claim, owner/admin can delete
- edit-schedule.html: claimable checkbox per assignment row; value field
  hidden when claimable is enabled
- parent-dashboard.html: renderAssignments() merges claims with slots,
  hydrateAssignmentClaimsForSchedule() loads claims on schedule hydration
- tests/unit/parent-dashboard-calendar-day-modal-rsvp.test.js: stub the
  two new imports so the module-extraction test continues to pass