### PR TITLE
Feat: Expose non-responded player IDs in RSVP summary

### DIFF
--- a/js/rsvp-summary.js
+++ b/js/rsvp-summary.js
@@ -53,10 +53,11 @@ export function computeEffectiveRsvpSummary({
     normalizeResponse,
     resolvePlayerIds
 }) {
-    const summary = { going: 0, maybe: 0, notGoing: 0, notResponded: 0, total: 0 };
+    const summary = { going: 0, maybe: 0, notGoing: 0, notResponded: 0, total: 0, notRespondedPlayerIds: [] };
     if (!Array.isArray(rsvps) || !(activeRosterIds instanceof Set) || activeRosterIds.size === 0) {
         summary.total = activeRosterIds instanceof Set ? activeRosterIds.size : 0;
         summary.notResponded = summary.total;
+        summary.notRespondedPlayerIds = Array.from(activeRosterIds);
         return summary;
     }
 
@@ -75,7 +76,10 @@ export function computeEffectiveRsvpSummary({
     });
 
     summary.total = activeRosterIds.size;
-    const respondedCount = summary.going + summary.maybe + summary.notGoing;
-    summary.notResponded = Math.max(0, summary.total - respondedCount);
+    const respondedPlayerIds = new Set(latestByPlayer.keys());
+    summary.notRespondedPlayerIds = Array.from(activeRosterIds).filter(
+        (playerId) => !respondedPlayerIds.has(playerId)
+    );
+    summary.notResponded = summary.notRespondedPlayerIds.length;
     return summary;
 }

--- a/js/rsvp-summary.js
+++ b/js/rsvp-summary.js
@@ -57,7 +57,7 @@ export function computeEffectiveRsvpSummary({
     if (!Array.isArray(rsvps) || !(activeRosterIds instanceof Set) || activeRosterIds.size === 0) {
         summary.total = activeRosterIds instanceof Set ? activeRosterIds.size : 0;
         summary.notResponded = summary.total;
-        summary.notRespondedPlayerIds = Array.from(activeRosterIds);
+        summary.notRespondedPlayerIds = activeRosterIds instanceof Set ? Array.from(activeRosterIds) : [];
         return summary;
     }
 
@@ -76,7 +76,12 @@ export function computeEffectiveRsvpSummary({
     });
 
     summary.total = activeRosterIds.size;
-    const respondedPlayerIds = new Set(latestByPlayer.keys());
+    const respondedPlayerIds = new Set();
+    latestByPlayer.forEach((entry) => {
+        if (entry.responseKey !== 'not_responded') {
+            respondedPlayerIds.add(entry.playerId);
+        }
+    });
     summary.notRespondedPlayerIds = Array.from(activeRosterIds).filter(
         (playerId) => !respondedPlayerIds.has(playerId)
     );

--- a/js/rsvp-summary.test.js
+++ b/js/rsvp-summary.test.js
@@ -1,0 +1,133 @@
+import { expect } from 'chai';
+import { computeEffectiveRsvpSummary, selectLatestRsvpByPlayer } from './rsvp-summary.js';
+
+describe('rsvp-summary', () => {
+    describe('selectLatestRsvpByPlayer', () => {
+        const mockRsvps = [
+            { playerId: 'player1', response: 'going', respondedAt: new Date('2026-01-01T10:00:00Z'), userId: 'user1' },
+            { playerId: 'player2', response: 'not_going', respondedAt: new Date('2026-01-01T11:00:00Z'), userId: 'user2' },
+            { playerId: 'player1', response: 'maybe', respondedAt: new Date('2026-01-01T12:00:00Z'), userId: 'user1' }, // Later RSVP for player1
+        ];
+
+        const fallbackByUser = {};
+        const normalizeResponse = (response) => response;
+        const resolvePlayerIds = (rsvp) => [rsvp.playerId];
+
+        it('should return the latest RSVP for each player', () => {
+            const latestByPlayer = selectLatestRsvpByPlayer({
+                rsvps: mockRsvps,
+                fallbackByUser,
+                normalizeResponse,
+                resolvePlayerIds,
+                includePlayerId: () => true,
+            });
+
+            expect(latestByPlayer.size).to.equal(2);
+            expect(latestByPlayer.get('player1').responseKey).to.equal('maybe');
+            expect(latestByPlayer.get('player2').responseKey).to.equal('not_going');
+        });
+
+        it('should filter by includePlayerId function', () => {
+            const latestByPlayer = selectLatestRsvpByPlayer({
+                rsvps: mockRsvps,
+                fallbackByUser,
+                normalizeResponse,
+                resolvePlayerIds,
+                includePlayerId: (playerId) => playerId === 'player1',
+            });
+
+            expect(latestByPlayer.size).to.equal(1);
+            expect(latestByPlayer.get('player1').responseKey).to.equal('maybe');
+        });
+    });
+
+    describe('computeEffectiveRsvpSummary', () => {
+        const normalizeResponse = (response) => response;
+        const resolvePlayerIds = (rsvp) => [rsvp.playerId];
+        const fallbackByUser = {};
+
+        it('should return an empty summary for no active roster', () => {
+            const summary = computeEffectiveRsvpSummary({
+                rsvps: [],
+                activeRosterIds: new Set(),
+                fallbackByUser,
+                normalizeResponse,
+                resolvePlayerIds,
+            });
+            expect(summary).to.deep.equal({ going: 0, maybe: 0, notGoing: 0, notResponded: 0, total: 0, notRespondedPlayerIds: [] });
+        });
+
+        it('should correctly summarize RSVPs with all players responded', () => {
+            const rsvps = [
+                { playerId: 'player1', response: 'going', respondedAt: new Date() },
+                { playerId: 'player2', response: 'not_going', respondedAt: new Date() },
+                { playerId: 'player3', response: 'maybe', respondedAt: new Date() },
+            ];
+            const activeRosterIds = new Set(['player1', 'player2', 'player3']);
+
+            const summary = computeEffectiveRsvpSummary({
+                rsvps,
+                activeRosterIds,
+                fallbackByUser,
+                normalizeResponse,
+                resolvePlayerIds,
+            });
+
+            expect(summary).to.deep.equal({
+                going: 1,
+                maybe: 1,
+                notGoing: 1,
+                notResponded: 0,
+                total: 3,
+                notRespondedPlayerIds: [],
+            });
+        });
+
+        it('should correctly identify non-responded players', () => {
+            const rsvps = [
+                { playerId: 'player1', response: 'going', respondedAt: new Date() },
+                { playerId: 'player3', response: 'maybe', respondedAt: new Date() },
+            ];
+            const activeRosterIds = new Set(['player1', 'player2', 'player3', 'player4']);
+
+            const summary = computeEffectiveRsvpSummary({
+                rsvps,
+                activeRosterIds,
+                fallbackByUser,
+                normalizeResponse,
+                resolvePlayerIds,
+            });
+
+            expect(summary).to.deep.equal({
+                going: 1,
+                maybe: 1,
+                notGoing: 0,
+                notResponded: 2,
+                total: 4,
+                notRespondedPlayerIds: ['player2', 'player4'],
+            });
+        });
+
+        it('should handle no RSVPs for active roster', () => {
+            const rsvps = [];
+            const activeRosterIds = new Set(['player1', 'player2']);
+
+            const summary = computeEffectiveRsvpSummary({
+                rsvps,
+                activeRosterIds,
+                fallbackByUser,
+                normalizeResponse,
+                resolvePlayerIds,
+            });
+
+            expect(summary).to.deep.equal({
+                going: 0,
+                maybe: 0,
+                notGoing: 0,
+                notResponded: 2,
+                total: 2,
+                notRespondedPlayerIds: ['player1', 'player2'],
+            });
+        });
+    });
+});

--- a/tests/unit/rsvp-summary.test.js
+++ b/tests/unit/rsvp-summary.test.js
@@ -41,6 +41,7 @@ describe('effective RSVP summary', () => {
             maybe: 0,
             notGoing: 1,
             notResponded: 0,
+            notRespondedPlayerIds: [],
             total: 2
         });
     });
@@ -77,6 +78,7 @@ describe('effective RSVP summary', () => {
             maybe: 2,
             notGoing: 0,
             notResponded: 0,
+            notRespondedPlayerIds: [],
             total: 2
         });
     });


### PR DESCRIPTION
Closes #1110

This change augments the `computeEffectiveRsvpSummary` function to directly provide a list of player IDs who have not yet responded, making it easier for coaches to follow up. The `notRespondedPlayerIds` array is now included in the summary object.