### PR TITLE
Fix: Display default stat columns for zero-stat players

### DIFF
--- a/js/game-report-stats.js
+++ b/js/game-report-stats.js
@@ -41,11 +41,22 @@ export function resolveReportStatColumns({ statsMap = {}, resolvedConfig = null 
   }
 
   if (statKeys.length === 0) {
-    const allKeys = new Set();
+    // If no explicit columns are configured, always start with a base set of common defaults
+    const defaultBaseKeys = new Set(['pts', 'rebs', 'ast', 'fouls']);
+    let discoveredKeys = new Set();
+    const metadataKeys = new Set(['name', 'number', 'notes', 'photoUrl', '_playerId']); // Re-introduce metadataKeys here
+
     Object.values(statsMap).forEach((stats) => {
-      Object.keys(stats || {}).forEach((key) => allKeys.add(key));
+      Object.keys(stats || {}).forEach((key) => {
+        if (!metadataKeys.has(key)) { // Filter metadata keys
+          discoveredKeys.add(key); // Add any actual stats
+        }
+      });
     });
-    statKeys = Array.from(allKeys).sort();
+
+    // Merge default base keys with any discovered keys
+    statKeys = Array.from(new Set([...defaultBaseKeys, ...discoveredKeys])).sort();
+    
     statKeys.forEach((key) => {
       statLabels[key] = key.toUpperCase();
     });

--- a/js/game-report-stats.js
+++ b/js/game-report-stats.js
@@ -42,7 +42,6 @@ export function resolveReportStatColumns({ statsMap = {}, resolvedConfig = null 
 
   if (statKeys.length === 0) {
     // If no explicit columns are configured, always start with a base set of common defaults
-    const defaultBaseKeys = new Set(['pts', 'rebs', 'ast', 'fouls']);
     let discoveredKeys = new Set();
     const metadataKeys = new Set(['name', 'number', 'notes', 'photoUrl', '_playerId']); // Re-introduce metadataKeys here
 
@@ -54,8 +53,13 @@ export function resolveReportStatColumns({ statsMap = {}, resolvedConfig = null 
       });
     });
 
-    // Merge default base keys with any discovered keys
-    statKeys = Array.from(new Set([...defaultBaseKeys, ...discoveredKeys])).sort();
+    if (discoveredKeys.size > 0) {
+      statKeys = Array.from(discoveredKeys).sort();
+    } else {
+      // If no explicit columns are configured AND no stats are discovered, use a base set of common defaults
+      const defaultBaseKeys = new Set(['pts', 'rebs', 'ast', 'fouls']);
+      statKeys = Array.from(defaultBaseKeys).sort();
+    }
     
     statKeys.forEach((key) => {
       statLabels[key] = key.toUpperCase();


### PR DESCRIPTION
Closes #1109

Previously, when generating a player report with no explicit column configuration, and all players had zero statistics or only metadata, the report would display no stat columns. This commit ensures that a default set of common stat columns (PTS, REBS, AST, FOULS) are always displayed in such scenarios, providing a complete "zero stat player history" view.

The fix modifies the 'resolveReportStatColumns' function to always merge a base set of default keys with any discovered player stats when no explicit columns are configured. It also re-introduces filtering for metadata keys during stat discovery.