### PR TITLE
Fix: Activation code field visibility during signup toggle

### DIFF
--- a/login.html
+++ b/login.html
@@ -106,6 +106,7 @@
         renderFooter(document.getElementById('footer-container'));
 
         let isLogin = true;
+        let isActivationCodeInitiallyHidden = false; // Tracks if the activation code field was hidden due to a URL parameter
 
         const createLoginAuthStateManager = loginPageModule.createLoginAuthStateManager || function createFallbackLoginAuthStateManager() {
             return {
@@ -224,6 +225,7 @@
                     hideActivationCode: true,
                     showInviteBanner: true
                 });
+                isActivationCodeInitiallyHidden = true; // Set flag if invite code was in URL
             } else {
                 showSignupMode();
             }
@@ -264,7 +266,10 @@
             } else {
                 confirmPasswordField.classList.remove('hidden');
                 confirmPasswordInput.setAttribute('required', 'required');
-                activationCodeField.classList.remove('hidden');
+                // Only show activation code field if it wasn't initially hidden due to a URL param
+                if (!isActivationCodeInitiallyHidden) {
+                    activationCodeField.classList.remove('hidden');
+                }
                 activationCodeInput.setAttribute('required', 'required');
                 forgotPasswordLink.classList.add('hidden');
             }

--- a/login.html
+++ b/login.html
@@ -267,10 +267,13 @@
                 confirmPasswordField.classList.remove('hidden');
                 confirmPasswordInput.setAttribute('required', 'required');
                 // Only show activation code field if it wasn't initially hidden due to a URL param
+                // Only show activation code field if it wasn't initially hidden due to a URL param
                 if (!isActivationCodeInitiallyHidden) {
                     activationCodeField.classList.remove('hidden');
+                    activationCodeInput.setAttribute('required', 'required');
+                } else {
+                    activationCodeInput.removeAttribute('required');
                 }
-                activationCodeInput.setAttribute('required', 'required');
                 forgotPasswordLink.classList.add('hidden');
             }
         });


### PR DESCRIPTION
Closes #1112

This commit addresses a UI bug where the activation code field, initially hidden due to an invite code in the URL, would become visible after a user toggled between 'Login' and 'Sign Up' modes.

The fix introduces a flag, `isActivationCodeInitiallyHidden`, which is set to `true` if an invite code is detected in the URL on page load. The 'Sign Up' mode toggle logic now checks this flag and only removes the 'hidden' class from the activation code field if it was not initially hidden by an auto-applied code.

This ensures a consistent user experience for invite-based signups, where the activation code field remains hidden throughout the session when an invite code is auto-applied.