### PR TITLE
fix: #1118 Admin 'Delete' button for teams now labeled 'Deactivate'

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -520,7 +520,7 @@ function renderTeams(teams) {
             <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                 <button onclick="window.openRegistrationFormsAdmin(${inlineJsString(team.id)})" class="text-indigo-600 hover:text-indigo-900 mr-4">Registration forms</button>
                 <a href="edit-team.html?teamId=${team.id}" class="text-indigo-600 hover:text-indigo-900 mr-4">Edit</a>
-                <button onclick="window.deleteTeamAdmin(${inlineJsString(team.id)}, ${inlineJsString(team.name)})" class="text-red-600 hover:text-red-900">Delete</button>
+                <button onclick="window.deleteTeamAdmin(${inlineJsString(team.id)}, ${inlineJsString(team.name)})" class="text-red-600 hover:text-red-900">Deactivate</button>
             </td>
         </tr>
     `).join('');


### PR DESCRIPTION
Closes #1118

This PR addresses the functional bug where the admin dashboard's button for managing teams was labeled 'Delete' but performed a deactivation action, leading to user confusion regarding data retention.

The change aligns the UI label with the actual system behavior:
- The 'Delete' button in the admin team management interface has been relabeled to 'Deactivate'.

This ensures clarity for administrators, accurately reflecting that team data will be retained upon clicking the button, consistent with the confirmation message and backend logic.