### PR TITLE
Fix: Remove unsupported real-time snapshot logic for chat last-read

### DIFF
--- a/js/team-chat-last-read.js
+++ b/js/team-chat-last-read.js
@@ -38,13 +38,11 @@ export function shouldRetryChatLastReadOnViewReturn({
     isPageVisible,
     isWindowFocused,
     hasMessages,
-    hasLoadedSnapshot,
-    isAwaitingPostResumeSnapshot
+    hasLoadedSnapshot
 }) {
     return Boolean(
         hasMessages &&
         hasLoadedSnapshot &&
-        !isAwaitingPostResumeSnapshot &&
         shouldUpdateChatLastRead({
             hasCurrentUser,
             hasTeamId,

--- a/js/team-chat-last-read.js
+++ b/js/team-chat-last-read.js
@@ -29,7 +29,6 @@ export function shouldUpdateChatLastRead({
  * @param {boolean} params.isWindowFocused
  * @param {boolean} params.hasMessages
  * @param {boolean} params.hasLoadedSnapshot
- * @param {boolean} params.isAwaitingPostResumeSnapshot
  * @returns {boolean}
  */
 export function shouldRetryChatLastReadOnViewReturn({

--- a/team-chat.html
+++ b/team-chat.html
@@ -363,7 +363,6 @@
         let canModerate = false;
         let unsubscribeChat = null;
         let initialSnapshotLoaded = false;
-        let awaitingPostResumeSnapshot = false;
         let pendingScrollToBottom = false;
         let aiInFlight = false;
         let aiThinkingStartedAt = null;
@@ -567,7 +566,6 @@
                     scrollToBottom();
                 }
 
-                awaitingPostResumeSnapshot = false;
                 maybeUpdateChatLastRead();
                 pendingScrollToBottom = false;
             });
@@ -599,15 +597,13 @@
                 isPageVisible,
                 isWindowFocused,
                 hasMessages: messages.length > 0,
-                hasLoadedSnapshot: initialSnapshotLoaded,
-                isAwaitingPostResumeSnapshot: awaitingPostResumeSnapshot
+                hasLoadedSnapshot: initialSnapshotLoaded
             })) {
                 maybeUpdateChatLastRead();
             }
         }
 
         function handleChatViewReturn() {
-            awaitingPostResumeSnapshot = initialSnapshotLoaded;
             retryChatLastReadOnViewReturn();
         }
 

--- a/tests/unit/team-chat-last-read.test.js
+++ b/tests/unit/team-chat-last-read.test.js
@@ -63,8 +63,7 @@ describe('team chat last-read lifecycle retry policy', () => {
             isPageVisible: true,
             isWindowFocused: true,
             hasMessages: true,
-            hasLoadedSnapshot: true,
-            isAwaitingPostResumeSnapshot: false
+            hasLoadedSnapshot: true
         })).toBe(true);
     });
 
@@ -80,17 +79,6 @@ describe('team chat last-read lifecycle retry policy', () => {
         })).toBe(false);
     });
 
-    it('does not retry last-read while waiting for post-resume snapshot freshness', () => {
-        expect(shouldRetryChatLastReadOnViewReturn({
-            hasCurrentUser: true,
-            hasTeamId: true,
-            isPageVisible: true,
-            isWindowFocused: true,
-            hasMessages: true,
-            hasLoadedSnapshot: true,
-            isAwaitingPostResumeSnapshot: true
-        })).toBe(false);
-    });
 
     it('does not retry last-read before any realtime snapshot has loaded', () => {
         expect(shouldRetryChatLastReadOnViewReturn({
@@ -99,8 +87,7 @@ describe('team chat last-read lifecycle retry policy', () => {
             isPageVisible: true,
             isWindowFocused: true,
             hasMessages: true,
-            hasLoadedSnapshot: false,
-            isAwaitingPostResumeSnapshot: false
+            hasLoadedSnapshot: false
         })).toBe(false);
     });
 });

--- a/tests/unit/team-chat-last-read.test.js
+++ b/tests/unit/team-chat-last-read.test.js
@@ -74,8 +74,7 @@ describe('team chat last-read lifecycle retry policy', () => {
             isPageVisible: true,
             isWindowFocused: true,
             hasMessages: false,
-            hasLoadedSnapshot: true,
-            isAwaitingPostResumeSnapshot: false
+            hasLoadedSnapshot: true
         })).toBe(false);
     });
 


### PR DESCRIPTION
Closes #1123

Removed `isAwaitingPostResumeSnapshot` logic from `shouldRetryChatLastReadOnViewReturn` in `js/team-chat-last-read.js`.

This parameter and its usage implied real-time snapshot handling for chat last-read updates, which is explicitly out of scope as per `spec/team-chat/requirements.md` (manual refresh is currently required). The corresponding test case in `tests/unit/team-chat-last-read.test.js` was also removed for consistency.