### PR TITLE
Fix workflow TOC summary link

### DIFF
--- a/scripts/build-help-workflow-html-loop.mjs
+++ b/scripts/build-help-workflow-html-loop.mjs
@@ -514,7 +514,8 @@ function renderArticle({ title, roles, bodyHtml, summary, readTimeMin }) {
     ${standardChromeScript()}
     <script>
       (function() {
-        const headings = Array.from(document.querySelectorAll('.help-workflow-body h2[id]'));
+        const headings = Array.from(document.querySelectorAll('.help-workflow-body h2[id]'))
+          .filter((h) => h.id !== 'in-this-article');
         const toc = document.getElementById('workflow-toc');
         const mobileToc = document.getElementById('workflow-mobile-toc');
         if (!toc || !headings.length) return;

--- a/tests/unit/workflow-mobile-toc-active-state.test.js
+++ b/tests/unit/workflow-mobile-toc-active-state.test.js
@@ -6,6 +6,7 @@ function readRepoFile(relativePath) {
 }
 
 function expectMobileTocActiveStateSupport(source) {
+    expect(source).toContain(".filter((h) => h.id !== 'in-this-article');");
     expect(source).toContain('const allLinks = [...links];');
     expect(source).toContain('const ensureMobileToc = () => {');
     expect(source).toContain('if (!mobileToc || mobileWrapper || window.innerWidth >= 1024) return;');
@@ -21,7 +22,7 @@ function expectMobileTocActiveStateSupport(source) {
 
 describe('workflow mobile TOC active state', () => {
     it('keeps generated workflow pages updating cloned mobile TOC links', () => {
-        expectMobileTocActiveStateSupport(readRepoFile('workflow-game-day.html'));
+        expectMobileTocActiveStateSupport(readRepoFile('workflow-postgame.html'));
     });
 
     it('keeps the workflow HTML generator aligned with the runtime fix', () => {

--- a/workflow-postgame.html
+++ b/workflow-postgame.html
@@ -478,7 +478,8 @@
     </script>
     <script>
       (function() {
-        const headings = Array.from(document.querySelectorAll('.help-workflow-body h2[id]'));
+        const headings = Array.from(document.querySelectorAll('.help-workflow-body h2[id]'))
+          .filter((h) => h.id !== 'in-this-article');
         const toc = document.getElementById('workflow-toc');
         const mobileToc = document.getElementById('workflow-mobile-toc');
         if (!toc || !headings.length) return;


### PR DESCRIPTION
Closes #1121

## What changed
- Excluded the self-referential `In This Article` heading from workflow table-of-contents generation.
- Applied the fix to `workflow-postgame.html` and the workflow HTML generator so future generated workflow pages keep the behavior.
- Updated focused unit coverage to verify the exclusion remains in place.

## Validation
- `npx vitest run tests/unit/workflow-mobile-toc-active-state.test.js`