### PR TITLE
Make telemetry issues visible first

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -408,11 +408,23 @@
                             <option value="interaction_submit">Form submits</option>
                             <option value="scroll_depth">Scroll depth</option>
                             <option value="js_error">JS errors</option>
+                            <option value="js_unhandled_rejection">Unhandled rejections</option>
+                            <option value="interaction_rage_click">Rage clicks</option>
                         </select>
                         <button id="telemetry-refresh" class="px-4 py-2 bg-primary-600 text-white rounded-md text-sm font-medium hover:bg-primary-700">Refresh</button>
                     </div>
                 </div>
                 <p id="telemetry-status" class="text-xs text-gray-500 mt-3">Loading telemetry...</p>
+            </div>
+
+            <div class="bg-white rounded-xl shadow-sm border border-red-100 overflow-hidden">
+                <div class="p-4 border-b border-red-100 bg-red-50/60">
+                    <h3 class="text-lg font-semibold text-gray-900">Needs attention</h3>
+                    <p class="text-sm text-gray-500">JS errors, unhandled rejections, and rage clicks for the selected range.</p>
+                </div>
+                <div id="telemetry-needs-attention" class="p-4 space-y-4">
+                    <p class="text-gray-400 text-sm">Loading...</p>
+                </div>
             </div>
 
             <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-6 gap-4">

--- a/js/admin.js
+++ b/js/admin.js
@@ -392,18 +392,22 @@ function renderTopTelemetryEvents() {
     `, 'No event telemetry has been recorded for this range.');
 }
 
+function getTelemetryIssueCounts() {
+    const issueCounts = new Map(telemetryIssueEvents.map(({ name }) => [name, 0]));
+    telemetryState.eventDaily.forEach((row) => {
+        if (!issueCounts.has(row.name)) return;
+        issueCounts.set(row.name, issueCounts.get(row.name) + Number(row.count || 0));
+    });
+    return issueCounts;
+}
+
 function renderTelemetryNeedsAttention() {
     const element = document.getElementById('telemetry-needs-attention');
     if (!element) return;
 
-    const issueCounts = new Map(telemetryIssueEvents.map(({ name }) => [name, 0]));
+    const issueCounts = getTelemetryIssueCounts();
     const issueEvents = telemetryState.events.filter((event) => issueCounts.has(event.name));
-
-    issueEvents.forEach((event) => {
-        issueCounts.set(event.name, issueCounts.get(event.name) + 1);
-    });
-
-    const totalIssues = issueEvents.length;
+    const totalIssues = Array.from(issueCounts.values()).reduce((sum, count) => sum + count, 0);
     const countCards = telemetryIssueEvents.map(({ name, label }) => `
         <div class="rounded-lg border border-gray-200 p-4">
             <p class="text-xs font-semibold text-gray-500 uppercase">${escapeHtml(label)}</p>
@@ -433,7 +437,7 @@ function renderTelemetryNeedsAttention() {
                 </div>
             `;
         })
-        .join('');
+        .join('') || '<p class="text-sm text-gray-500">No recent raw examples loaded for this range.</p>';
 
     element.innerHTML = `
         <div class="grid grid-cols-1 md:grid-cols-3 gap-3">${countCards}</div>

--- a/js/admin.js
+++ b/js/admin.js
@@ -44,6 +44,12 @@ let telemetryState = {
     sessions: []
 };
 
+const telemetryIssueEvents = [
+    { name: 'js_error', label: 'JS errors' },
+    { name: 'js_unhandled_rejection', label: 'Unhandled rejections' },
+    { name: 'interaction_rage_click', label: 'Rage clicks' }
+];
+
 function isTeamActive(team) {
     return team?.active !== false;
 }
@@ -386,6 +392,58 @@ function renderTopTelemetryEvents() {
     `, 'No event telemetry has been recorded for this range.');
 }
 
+function renderTelemetryNeedsAttention() {
+    const element = document.getElementById('telemetry-needs-attention');
+    if (!element) return;
+
+    const issueCounts = new Map(telemetryIssueEvents.map(({ name }) => [name, 0]));
+    const issueEvents = telemetryState.events.filter((event) => issueCounts.has(event.name));
+
+    issueEvents.forEach((event) => {
+        issueCounts.set(event.name, issueCounts.get(event.name) + 1);
+    });
+
+    const totalIssues = issueEvents.length;
+    const countCards = telemetryIssueEvents.map(({ name, label }) => `
+        <div class="rounded-lg border border-gray-200 p-4">
+            <p class="text-xs font-semibold text-gray-500 uppercase">${escapeHtml(label)}</p>
+            <p class="text-2xl font-bold text-gray-900 mt-1">${telemetryNumber(issueCounts.get(name))}</p>
+        </div>
+    `).join('');
+
+    if (!totalIssues) {
+        element.innerHTML = `
+            <div class="grid grid-cols-1 md:grid-cols-3 gap-3">${countCards}</div>
+            <p class="text-sm text-gray-500">No errors or rage clicks recorded for this range.</p>
+        `;
+        return;
+    }
+
+    const recentRows = issueEvents
+        .slice(0, 5)
+        .map((event) => {
+            const createdAt = telemetryDate(event.createdAt) || telemetryDate(event.clientTimestamp);
+            return `
+                <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-1 border-b border-gray-100 pb-2 last:border-0">
+                    <div class="min-w-0">
+                        <p class="text-sm font-medium text-gray-900 truncate">${escapeHtml(event.name || '-')} · ${escapeHtml(event.pagePath || '-')}</p>
+                        <p class="text-xs text-gray-500 truncate">Target: ${escapeHtml(getTelemetryTarget(event))}</p>
+                    </div>
+                    <span class="text-xs text-gray-500 whitespace-nowrap">${createdAt ? createdAt.toLocaleString() : '-'}</span>
+                </div>
+            `;
+        })
+        .join('');
+
+    element.innerHTML = `
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-3">${countCards}</div>
+        <div>
+            <p class="text-xs font-semibold text-gray-500 uppercase mb-2">Recent examples</p>
+            <div class="space-y-2">${recentRows}</div>
+        </div>
+    `;
+}
+
 function renderRecentTelemetrySessions() {
     const cutoff = Date.now() - telemetryState.days * 24 * 60 * 60 * 1000;
     const sessions = telemetryState.sessions
@@ -451,6 +509,7 @@ function updateTelemetryDashboard() {
         renderMetric('telemetry-known-users', 0);
         renderMetric('telemetry-errors', 0);
         renderEmptyTelemetry('telemetry-daily-trend', errorMessage);
+        renderEmptyTelemetry('telemetry-needs-attention', errorMessage);
         renderEmptyTelemetry('telemetry-top-pages', errorMessage);
         renderEmptyTelemetry('telemetry-top-events', errorMessage);
         renderEmptyTelemetry('telemetry-recent-sessions', errorMessage);
@@ -475,6 +534,7 @@ function updateTelemetryDashboard() {
     renderMetric('telemetry-known-users', knownUsers.size);
     renderMetric('telemetry-errors', sumBy(telemetryState.daily, 'errors'));
 
+    renderTelemetryNeedsAttention();
     renderTelemetryTrend();
     renderTopTelemetryPages();
     renderTopTelemetryEvents();

--- a/tests/unit/admin-telemetry-issues.test.js
+++ b/tests/unit/admin-telemetry-issues.test.js
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import { JSDOM } from 'jsdom';
+
+describe('admin telemetry issue-first view', () => {
+    it('shows issue signals first and includes drill-down filter options', () => {
+        const adminHtml = fs.readFileSync('admin.html', 'utf8');
+        const dom = new JSDOM(adminHtml);
+
+        const needsAttention = dom.window.document.querySelector('#telemetry-needs-attention');
+        expect(needsAttention).toBeTruthy();
+        expect(adminHtml.indexOf('id="telemetry-needs-attention"')).toBeLessThan(adminHtml.indexOf('id="telemetry-total-events"'));
+
+        const filterValues = Array.from(dom.window.document.querySelectorAll('#telemetry-event-filter option'))
+            .map((option) => option.value);
+        expect(filterValues).toContain('js_error');
+        expect(filterValues).toContain('js_unhandled_rejection');
+        expect(filterValues).toContain('interaction_rage_click');
+    });
+
+    it('renders issue counts, recent examples, and the empty state from telemetryState events', () => {
+        const adminJs = fs.readFileSync('js/admin.js', 'utf8');
+
+        expect(adminJs).toContain("{ name: 'js_error', label: 'JS errors' }");
+        expect(adminJs).toContain("{ name: 'js_unhandled_rejection', label: 'Unhandled rejections' }");
+        expect(adminJs).toContain("{ name: 'interaction_rage_click', label: 'Rage clicks' }");
+        expect(adminJs).toContain('function renderTelemetryNeedsAttention()');
+        expect(adminJs).toContain('const issueEvents = telemetryState.events.filter((event) => issueCounts.has(event.name));');
+        expect(adminJs).toContain('No errors or rage clicks recorded for this range.');
+        expect(adminJs).toContain('renderTelemetryNeedsAttention();');
+    });
+});

--- a/tests/unit/admin-telemetry-issues.test.js
+++ b/tests/unit/admin-telemetry-issues.test.js
@@ -18,13 +18,16 @@ describe('admin telemetry issue-first view', () => {
         expect(filterValues).toContain('interaction_rage_click');
     });
 
-    it('renders issue counts, recent examples, and the empty state from telemetryState events', () => {
+    it('renders issue counts from aggregate telemetry and recent examples from raw events', () => {
         const adminJs = fs.readFileSync('js/admin.js', 'utf8');
 
         expect(adminJs).toContain("{ name: 'js_error', label: 'JS errors' }");
         expect(adminJs).toContain("{ name: 'js_unhandled_rejection', label: 'Unhandled rejections' }");
         expect(adminJs).toContain("{ name: 'interaction_rage_click', label: 'Rage clicks' }");
         expect(adminJs).toContain('function renderTelemetryNeedsAttention()');
+        expect(adminJs).toContain('function getTelemetryIssueCounts()');
+        expect(adminJs).toContain('telemetryState.eventDaily.forEach((row) => {');
+        expect(adminJs).toContain('const totalIssues = Array.from(issueCounts.values()).reduce((sum, count) => sum + count, 0);');
         expect(adminJs).toContain('const issueEvents = telemetryState.events.filter((event) => issueCounts.has(event.name));');
         expect(adminJs).toContain('No errors or rage clicks recorded for this range.');
         expect(adminJs).toContain('renderTelemetryNeedsAttention();');


### PR DESCRIPTION
Closes #1128

## Summary
- Adds a prominent Needs attention telemetry section above broad metrics.
- Surfaces counts and recent examples for JS errors, unhandled rejections, and rage clicks from the loaded telemetry state.
- Adds admin event filter options for unhandled rejections and rage clicks.

## Validation
- `npx vitest run tests/unit/admin-telemetry-issues.test.js tests/unit/admin-dashboard-stats.test.js`