### PR TITLE
Use server time for live reset boundaries

### DIFF
--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -3,7 +3,7 @@ import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collect
 import { db } from './firebase.js?v=13';
 import { getUrlParams, escapeHtml } from './utils.js?v=9';
 import { checkAuth } from './auth.js?v=15';
-import { writeBatch, doc, setDoc, addDoc, onSnapshot } from './firebase.js?v=13';
+import { writeBatch, doc, setDoc, addDoc, onSnapshot, serverTimestamp } from './firebase.js?v=13';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
 import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './live-tracker-notes.js?v=1';
@@ -2939,7 +2939,7 @@ async function init() {
             opponentStats: {},
             liveStatus: 'scheduled',
             liveHasData: false,
-            liveResetAt: resetAt,
+            liveResetAt: serverTimestamp(),
             liveClockMs: 0,
             liveClockRunning: false,
             liveClockPeriod: 'Q1',

--- a/js/track-live-state.js
+++ b/js/track-live-state.js
@@ -1,3 +1,4 @@
+import { serverTimestamp } from './vendor/firebase-firestore.js';
 import { getDefaultLivePeriod, isFootballSport } from './live-sport-config.js';
 
 export function summarizePersistedTrackingState({
@@ -29,7 +30,7 @@ export function buildTrackLiveResetUpdate({
   currentConfig = null,
   period,
   liveLineup = { onCourt: [], bench: [] },
-  liveResetAt = Date.now()
+  liveResetAt = serverTimestamp()
 } = {}) {
   const onCourt = Array.isArray(liveLineup?.onCourt) ? [...liveLineup.onCourt] : [];
   const bench = Array.isArray(liveLineup?.bench) ? [...liveLineup.bench] : [];

--- a/tests/unit/live-tracker-start-over.test.js
+++ b/tests/unit/live-tracker-start-over.test.js
@@ -190,7 +190,7 @@ function buildModuleSource(source = readFileSync(new URL('../../js/live-tracker.
   rewritten = replaceImport(
     rewritten,
     /import\s*\{(?=[\s\S]*\bdb\b)[\s\S]*?\}\s*from\s*['"]\.\/firebase\.js(?:\?v=[^'"]+)?['"];?\s*/,
-    'const { db, writeBatch, doc, setDoc, addDoc, onSnapshot } = deps.firebase;'
+    'const { db, writeBatch, doc, setDoc, addDoc, onSnapshot, serverTimestamp } = deps.firebase;'
   );
   rewritten = replaceNamedImportByModulePath(
     rewritten,
@@ -400,7 +400,8 @@ async function bootLiveTracker({ game, snapshots }) {
       doc: (...parts) => ({ path: parts.join('/') }),
       setDoc: async () => {},
       addDoc: async () => {},
-      onSnapshot: () => () => {}
+      onSnapshot: () => () => {},
+      serverTimestamp: () => ({ _methodName: 'serverTimestamp' })
     },
     utils: {
       getUrlParams: () => ({ teamId: 'team-1', gameId: 'game-1' }),
@@ -609,7 +610,7 @@ describe('live tracker start over reset flow', () => {
         opponentTeamName: 'Lions Academy',
         opponentTeamPhoto: 'https://example.com/lions.png'
       });
-      expect(resetUpdate.liveResetAt).toEqual(expect.any(Number));
+      expect(resetUpdate.liveResetAt?._methodName).toBe('serverTimestamp');
       expect(resetUpdate.liveClockUpdatedAt).toEqual(expect.any(Number));
 
       expect(page.els.scoreLine.textContent).toBe('0 — 0');

--- a/tests/unit/track-live-state.test.js
+++ b/tests/unit/track-live-state.test.js
@@ -84,11 +84,20 @@ describe('track live state helpers', () => {
     expect(payload.opponentTeamId).toBe('');
     expect(payload.opponentTeamName).toBe('');
     expect(payload.opponentTeamPhoto).toBe('');
-    expect(payload.liveResetAt).toEqual(expect.any(Number));
+    expect(payload.liveResetAt?._methodName).toBe('serverTimestamp');
     expect(payload.liveLineup).toEqual({ onCourt: ['p1'], bench: ['p2'] });
 
     input.onCourt.push('p3');
     expect(payload.liveLineup.onCourt).toEqual(['p1']);
+  });
+
+  it('preserves an explicit reset boundary when provided', () => {
+    const payload = buildTrackLiveResetUpdate({
+      currentGame: {},
+      liveResetAt: 1700000000000
+    });
+
+    expect(payload.liveResetAt).toBe(1700000000000);
   });
 
   it('includes default football game state for football resets only', () => {

--- a/track-live.html
+++ b/track-live.html
@@ -673,7 +673,7 @@
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { resolveOpponentDisplayName, resolveLiveStatConfig, resolveLiveStatColumns, resolveGoalSportTrackerProfile } from './js/live-game-state.js?v=7';
         import { createFieldState, setPlayerFieldStatus, startFieldClock, pauseFieldClock, getPlayerFieldElapsedMs, getLiveLineup } from './js/live-tracker-field-status.js?v=1';
-        import { summarizePersistedTrackingState, buildTrackLiveResetUpdate, resolveTrackLiveClockResume, runTrackLiveResetPersistence } from './js/track-live-state.js?v=2';
+        import { summarizePersistedTrackingState, buildTrackLiveResetUpdate, resolveTrackLiveClockResume, runTrackLiveResetPersistence } from './js/track-live-state.js?v=3';
         import { getDefaultLivePeriod, getSportPeriodLabels, resolveLiveSport, isFootballSport } from './js/live-sport-config.js?v=3';
         import { applyGoalSportScore, buildGoalSportEvent } from './js/live-scorekeeping-goal-sports.js?v=1';
 


### PR DESCRIPTION
Closes #1131

## Summary
- Changed tracker reset payloads to persist `liveResetAt` with Firestore `serverTimestamp()` instead of the scorer browser clock.
- Updated the basketball live tracker start-over path to use the same server-clock reset boundary.
- Added focused unit coverage confirming reset boundaries use server timestamps while preserving explicit overrides.

## Tests
- `npx vitest run tests/unit/track-live-state.test.js tests/unit/live-tracker-start-over.test.js`