### PR TITLE
Auto-link existing parent invites

### DIFF
--- a/edit-roster.html
+++ b/edit-roster.html
@@ -453,8 +453,8 @@
                     </p>
                     <p id="invite-existing-message" class="text-sm text-gray-500 mb-4"></p>
 
-                    <!-- Code Section for Existing User -->
-                    <div class="bg-blue-50 rounded border border-blue-200 p-3 mt-4">
+                    <!-- Fallback Code Section for Existing User -->
+                    <div id="existing-user-code-section" class="bg-blue-50 rounded border border-blue-200 p-3 mt-4">
                         <p class="text-xs text-blue-700 mb-2">Share this code or link with them to add your player:</p>
                         <div class="flex items-center justify-between bg-white border border-blue-300 rounded px-2 py-1 mb-2">
                             <code id="existing-user-code" class="text-lg font-bold text-blue-700 tracking-widest"></code>
@@ -510,7 +510,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getPlayers, addPlayer, deactivatePlayer, reactivatePlayer, getGames, uploadPlayerPhoto, updatePlayer, setPlayerPrivateRosterProfileFields, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount, listTeamParentMembershipRequests, approveParentMembershipRequest, denyParentMembershipRequest, getRosterFieldDefinitions, saveRosterFieldDefinition, disableRosterFieldDefinition, reorderRosterFieldDefinitions, listTeamRegistrationForms, listTeamRegistrationReviews, approveTeamRegistration, rejectTeamRegistration, extendTeamRegistrationOffer, releaseTeamRegistrationWaitlist, listTeamTrackingItems, createTeamTrackingItem, listTeamTrackingStatuses, setTeamTrackingStatus } from './js/db.js?v=35';
+        import { getTeam, getPlayers, addPlayer, deactivatePlayer, reactivatePlayer, getGames, uploadPlayerPhoto, updatePlayer, setPlayerPrivateRosterProfileFields, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount, listTeamParentMembershipRequests, approveParentMembershipRequest, denyParentMembershipRequest, getRosterFieldDefinitions, saveRosterFieldDefinition, disableRosterFieldDefinition, reorderRosterFieldDefinitions, listTeamRegistrationForms, listTeamRegistrationReviews, approveTeamRegistration, rejectTeamRegistration, extendTeamRegistrationOffer, releaseTeamRegistrationWaitlist, listTeamTrackingItems, createTeamTrackingItem, listTeamTrackingStatuses, setTeamTrackingStatus } from './js/db.js?v=36';
         import { buildRosterFieldDefinitionPayload, collectRosterProfileValues, getRosterProfileValues, normalizeRosterFieldDefinitions, planRosterCsvImport, renderRosterProfileFields, validateRosterProfileValues } from './js/roster-profile-fields.js?v=3';
         import { buildTrackingStatusPayload, mergeTrackingStatusRows, normalizeTrackingItemDraft, summarizeTrackingStatus } from './js/tracking-status-admin.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
@@ -1440,10 +1440,18 @@
                  if (email) {
                      // Email was provided - try to send email invite
                      if (result.existingUser) {
-                         // User already has an account - show different message
-                         document.getElementById('invite-existing-message').textContent =
-                             `${email} already has an ALL PLAYS account. They just need to enter the code below to start following ${currentInvitePlayer.name}.`;
-                         document.getElementById('existing-user-code').textContent = result.code;
+                         const codeSection = document.getElementById('existing-user-code-section');
+                         if (result.autoLinked) {
+                             document.getElementById('invite-existing-message').textContent =
+                                 `${email} already has an ALL PLAYS account, so they were linked to ${currentInvitePlayer.name} automatically.`;
+                             if (codeSection) codeSection.classList.add('hidden');
+                             await loadRoster();
+                         } else {
+                             document.getElementById('invite-existing-message').textContent =
+                                 `${email} already has an ALL PLAYS account. Share the code below if automatic linking did not complete.`;
+                             document.getElementById('existing-user-code').textContent = result.code;
+                             if (codeSection) codeSection.classList.remove('hidden');
+                         }
                          showInviteState('invite-existing-user-state');
                      } else {
                          // New user - send email invite
@@ -1455,6 +1463,8 @@
                              document.getElementById('invite-email-sent-message').textContent =
                                  `We sent an invite to ${email}. They'll receive a link to join and follow ${currentInvitePlayer.name}.`;
                              document.getElementById('fallback-code').textContent = result.code;
+                             const codeSection = document.getElementById('existing-user-code-section');
+                             if (codeSection) codeSection.classList.remove('hidden');
                              showInviteState('invite-email-sent-state');
                          } catch (emailError) {
                              // Email failed - show manual code with error message

--- a/functions/index.js
+++ b/functions/index.js
@@ -185,6 +185,170 @@ function hasTeamAdminAccess({ team, uid, email }) {
   return Boolean(uid && team?.ownerId === uid) || Boolean(normalizedEmail && adminEmails.includes(normalizedEmail));
 }
 
+function normalizeParentInviteEmail(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function isParentInviteExpired(expiresAt) {
+  if (!expiresAt) return false;
+  const millis = typeof expiresAt.toMillis === 'function'
+    ? expiresAt.toMillis()
+    : new Date(expiresAt).getTime();
+  return Number.isFinite(millis) && millis < Date.now();
+}
+
+function validateAutoAcceptParentInviteCode(data = {}) {
+  if (!data || data.type !== 'parent_invite') {
+    throw new functions.https.HttpsError('failed-precondition', 'Not a parent invite code.');
+  }
+  if (data.used || data.revoked === true || data.status === 'removed') {
+    throw new functions.https.HttpsError('failed-precondition', 'Parent invite is no longer available.');
+  }
+  if (isParentInviteExpired(data.expiresAt)) {
+    throw new functions.https.HttpsError('failed-precondition', 'Parent invite has expired.');
+  }
+}
+
+function appendUniqueParentLink(parentOf, link) {
+  const links = Array.isArray(parentOf) ? [...parentOf] : [];
+  const exists = links.some((entry) => entry?.teamId === link.teamId && entry?.playerId === link.playerId);
+  if (!exists) links.push(link);
+  return links;
+}
+
+function appendUniqueValue(values, value) {
+  const nextValues = Array.isArray(values) ? [...values] : [];
+  if (!nextValues.includes(value)) nextValues.push(value);
+  return nextValues;
+}
+
+function buildAutoAcceptedParentLink({ codeData, team, player }) {
+  return {
+    teamId: codeData.teamId,
+    playerId: codeData.playerId,
+    teamName: team?.name || codeData.teamName || null,
+    playerName: player?.name || codeData.playerName || null,
+    playerNumber: player?.number ?? codeData.playerNum ?? null,
+    playerPhotoUrl: player?.photoUrl || null,
+    relation: codeData.relation || null
+  };
+}
+
+exports.autoAcceptParentInviteForExistingUser = functions.https.onCall(async (data, context) => {
+  if (!context.auth?.uid) {
+    throw new functions.https.HttpsError('unauthenticated', 'Sign in before auto-linking a parent invite.');
+  }
+
+  const codeId = normalizeFirestoreId(data?.codeId, 'codeId');
+  const codeRef = firestore.doc(`accessCodes/${codeId}`);
+  const codeSnap = await codeRef.get();
+  if (!codeSnap.exists) {
+    throw new functions.https.HttpsError('not-found', 'Parent invite could not be found.');
+  }
+
+  const codeData = codeSnap.data() || {};
+  validateAutoAcceptParentInviteCode(codeData);
+  const inviteEmail = normalizeParentInviteEmail(codeData.email);
+  if (!inviteEmail) {
+    throw new functions.https.HttpsError('failed-precondition', 'Parent invite has no email to auto-link.');
+  }
+
+  const teamId = normalizeFirestoreId(codeData.teamId, 'teamId');
+  const playerId = normalizeFirestoreId(codeData.playerId, 'playerId');
+  const [teamSnap, playerSnap, actorSnap, userQuerySnap] = await Promise.all([
+    firestore.doc(`teams/${teamId}`).get(),
+    firestore.doc(`teams/${teamId}/players/${playerId}`).get(),
+    firestore.doc(`users/${context.auth.uid}`).get(),
+    firestore.collection('users').where('email', '==', inviteEmail).limit(1).get()
+  ]);
+
+  if (!teamSnap.exists) {
+    throw new functions.https.HttpsError('not-found', 'Team not found.');
+  }
+  if (!playerSnap.exists) {
+    throw new functions.https.HttpsError('not-found', 'Player not found.');
+  }
+  if (userQuerySnap.empty) {
+    return { autoLinked: false, reason: 'no-existing-user' };
+  }
+
+  const team = teamSnap.data() || {};
+  const actor = actorSnap.exists ? actorSnap.data() || {} : {};
+  const actorEmail = context.auth.token?.email || actor.email || '';
+  if (!hasTeamAdminAccess({ team, uid: context.auth.uid, email: actorEmail })) {
+    throw new functions.https.HttpsError('permission-denied', 'Only team owners and admins can auto-link parent invites.');
+  }
+
+  const targetUserDoc = userQuerySnap.docs[0];
+  const userRef = targetUserDoc.ref;
+  const now = admin.firestore.Timestamp.now();
+
+  await firestore.runTransaction(async (transaction) => {
+    const [latestCodeSnap, latestPlayerSnap, latestUserSnap] = await Promise.all([
+      transaction.get(codeRef),
+      transaction.get(firestore.doc(`teams/${teamId}/players/${playerId}`)),
+      transaction.get(userRef)
+    ]);
+
+    if (!latestCodeSnap.exists) {
+      throw new functions.https.HttpsError('not-found', 'Parent invite could not be found.');
+    }
+    if (!latestPlayerSnap.exists) {
+      throw new functions.https.HttpsError('not-found', 'Player not found.');
+    }
+    if (!latestUserSnap.exists) {
+      throw new functions.https.HttpsError('not-found', 'Existing parent user not found.');
+    }
+
+    const latestCodeData = latestCodeSnap.data() || {};
+    validateAutoAcceptParentInviteCode(latestCodeData);
+    if (normalizeParentInviteEmail(latestCodeData.email) !== inviteEmail) {
+      throw new functions.https.HttpsError('failed-precondition', 'Parent invite email changed before auto-linking.');
+    }
+
+    const latestUserData = latestUserSnap.data() || {};
+    if (normalizeParentInviteEmail(latestUserData.email) !== inviteEmail) {
+      throw new functions.https.HttpsError('failed-precondition', 'Existing parent email does not match the invite.');
+    }
+
+    const player = latestPlayerSnap.data() || {};
+    const parentLink = buildAutoAcceptedParentLink({ codeData: latestCodeData, team, player });
+    const playerKey = `${teamId}::${playerId}`;
+    transaction.update(userRef, {
+      parentOf: appendUniqueParentLink(latestUserData.parentOf, parentLink),
+      parentTeamIds: appendUniqueValue(latestUserData.parentTeamIds, teamId),
+      parentPlayerKeys: appendUniqueValue(latestUserData.parentPlayerKeys, playerKey),
+      roles: appendUniqueValue(latestUserData.roles, 'parent')
+    });
+
+    const playerData = latestPlayerSnap.data() || {};
+    const existingParents = Array.isArray(playerData.parents) ? [...playerData.parents] : [];
+    const alreadyLinked = existingParents.some((parent) => parent?.userId === userRef.id);
+    if (!alreadyLinked) {
+      existingParents.push({
+        userId: userRef.id,
+        email: inviteEmail,
+        relation: latestCodeData.relation || null,
+        addedAt: now,
+        status: 'active',
+        source: 'parent_invite'
+      });
+      transaction.update(latestPlayerSnap.ref, { parents: existingParents });
+    }
+
+    transaction.update(codeRef, {
+      used: true,
+      usedBy: userRef.id,
+      usedAt: now,
+      status: 'accepted',
+      autoAccepted: true,
+      autoAcceptedAt: now
+    });
+  });
+
+  return { autoLinked: true, userId: userRef.id };
+});
+
 async function logRsvpTokenRedemptionAttempt({ teamId, payload }) {
   const auditPayload = {
     ...payload,

--- a/js/db.js
+++ b/js/db.js
@@ -3057,6 +3057,83 @@ export async function redeemAdminInviteAtomically(codeId, userId, fallbackEmail 
 // Parent Role Functions
 // ============================================
 
+async function autoAcceptParentInviteForExistingUser(codeRef, existingUser, accessCodeData, team, player) {
+    if (!existingUser?.id) {
+        return false;
+    }
+
+    const userId = existingUser.id;
+    const now = Timestamp.now();
+    const userRef = doc(db, "users", userId);
+    const playerRef = doc(db, `teams/${accessCodeData.teamId}/players`, accessCodeData.playerId);
+
+    await runTransaction(db, async (transaction) => {
+        const [latestCodeSnapshot, playerSnapshot] = await Promise.all([
+            transaction.get(codeRef),
+            transaction.get(playerRef)
+        ]);
+
+        if (!latestCodeSnapshot.exists()) {
+            throw new Error('Parent invite could not be found for auto-linking');
+        }
+
+        const latestCodeData = latestCodeSnapshot.data() || {};
+        if (latestCodeData.type !== 'parent_invite') {
+            throw new Error('Not a parent invite code');
+        }
+        if (latestCodeData.used || latestCodeData.revoked === true || latestCodeData.status === 'removed') {
+            throw new Error('Parent invite is no longer available');
+        }
+        if (isAccessCodeExpired(latestCodeData.expiresAt)) {
+            throw new Error('Parent invite has expired');
+        }
+        if (!playerSnapshot.exists()) {
+            throw new Error('Player not found');
+        }
+
+        transaction.set(userRef, {
+            parentOf: arrayUnion({
+                teamId: accessCodeData.teamId,
+                playerId: accessCodeData.playerId,
+                teamName: team?.name || accessCodeData.teamName || null,
+                playerName: player?.name || accessCodeData.playerName || null,
+                playerNumber: player?.number ?? accessCodeData.playerNum ?? null,
+                playerPhotoUrl: player?.photoUrl || null,
+                relation: accessCodeData.relation || null
+            }),
+            parentTeamIds: arrayUnion(accessCodeData.teamId),
+            parentPlayerKeys: arrayUnion(`${accessCodeData.teamId}::${accessCodeData.playerId}`),
+            roles: arrayUnion('parent')
+        }, { merge: true });
+
+        const existingParents = Array.isArray((playerSnapshot.data() || {}).parents) ? playerSnapshot.data().parents : [];
+        const alreadyLinked = existingParents.some(parent => parent?.userId === userId);
+        if (!alreadyLinked) {
+            transaction.update(playerRef, {
+                parents: arrayUnion({
+                    userId,
+                    email: accessCodeData.email || existingUser.email || 'linked',
+                    relation: accessCodeData.relation || null,
+                    addedAt: now,
+                    status: 'active',
+                    source: 'parent_invite'
+                })
+            });
+        }
+
+        transaction.update(codeRef, {
+            used: true,
+            usedBy: userId,
+            usedAt: now,
+            status: 'accepted',
+            autoAccepted: true,
+            autoAcceptedAt: now
+        });
+    });
+
+    return true;
+}
+
 export async function inviteParent(teamId, playerId, playerNum, parentEmail, relation) {
     const currentUser = auth.currentUser;
     if (!currentUser) {
@@ -3070,6 +3147,7 @@ export async function inviteParent(teamId, playerId, playerNum, parentEmail, rel
     ]);
     const player = players.find(p => p.id === playerId);
 
+    const normalizedParentEmail = String(parentEmail || '').trim().toLowerCase();
     const code = generateAccessCode();
     const accessCodeData = {
         code,
@@ -3080,7 +3158,7 @@ export async function inviteParent(teamId, playerId, playerNum, parentEmail, rel
         playerName: player?.name || null,
         teamName: team?.name || null,
         relation,
-        email: parentEmail || null,
+        email: normalizedParentEmail || null,
         generatedBy: currentUser.uid,
         createdAt: Timestamp.now(),
         // 7 days from now
@@ -3093,8 +3171,12 @@ export async function inviteParent(teamId, playerId, playerNum, parentEmail, rel
 
     // Check if user with this email already exists
     let existingUser = null;
-    if (parentEmail) {
-        existingUser = await getUserByEmail(parentEmail);
+    let autoLinked = false;
+    if (normalizedParentEmail) {
+        existingUser = await getUserByEmail(normalizedParentEmail);
+        if (existingUser) {
+            autoLinked = await autoAcceptParentInviteForExistingUser(docRef, existingUser, accessCodeData, team, player);
+        }
     }
 
     return {
@@ -3102,7 +3184,8 @@ export async function inviteParent(teamId, playerId, playerNum, parentEmail, rel
         code,
         teamName: team?.name || null,
         playerName: player?.name || null,
-        existingUser: !!existingUser
+        existingUser: !!existingUser,
+        autoLinked
     };
 }
 

--- a/js/db.js
+++ b/js/db.js
@@ -26,6 +26,8 @@ import {
     collectionGroup,
     writeBatch,
     runTransaction,
+    functions,
+    httpsCallable,
     ref,
     uploadBytes,
     getDownloadURL,
@@ -3057,81 +3059,10 @@ export async function redeemAdminInviteAtomically(codeId, userId, fallbackEmail 
 // Parent Role Functions
 // ============================================
 
-async function autoAcceptParentInviteForExistingUser(codeRef, existingUser, accessCodeData, team, player) {
-    if (!existingUser?.id) {
-        return false;
-    }
-
-    const userId = existingUser.id;
-    const now = Timestamp.now();
-    const userRef = doc(db, "users", userId);
-    const playerRef = doc(db, `teams/${accessCodeData.teamId}/players`, accessCodeData.playerId);
-
-    await runTransaction(db, async (transaction) => {
-        const [latestCodeSnapshot, playerSnapshot] = await Promise.all([
-            transaction.get(codeRef),
-            transaction.get(playerRef)
-        ]);
-
-        if (!latestCodeSnapshot.exists()) {
-            throw new Error('Parent invite could not be found for auto-linking');
-        }
-
-        const latestCodeData = latestCodeSnapshot.data() || {};
-        if (latestCodeData.type !== 'parent_invite') {
-            throw new Error('Not a parent invite code');
-        }
-        if (latestCodeData.used || latestCodeData.revoked === true || latestCodeData.status === 'removed') {
-            throw new Error('Parent invite is no longer available');
-        }
-        if (isAccessCodeExpired(latestCodeData.expiresAt)) {
-            throw new Error('Parent invite has expired');
-        }
-        if (!playerSnapshot.exists()) {
-            throw new Error('Player not found');
-        }
-
-        transaction.set(userRef, {
-            parentOf: arrayUnion({
-                teamId: accessCodeData.teamId,
-                playerId: accessCodeData.playerId,
-                teamName: team?.name || accessCodeData.teamName || null,
-                playerName: player?.name || accessCodeData.playerName || null,
-                playerNumber: player?.number ?? accessCodeData.playerNum ?? null,
-                playerPhotoUrl: player?.photoUrl || null,
-                relation: accessCodeData.relation || null
-            }),
-            parentTeamIds: arrayUnion(accessCodeData.teamId),
-            parentPlayerKeys: arrayUnion(`${accessCodeData.teamId}::${accessCodeData.playerId}`),
-            roles: arrayUnion('parent')
-        }, { merge: true });
-
-        const existingParents = Array.isArray((playerSnapshot.data() || {}).parents) ? playerSnapshot.data().parents : [];
-        const alreadyLinked = existingParents.some(parent => parent?.userId === userId);
-        if (!alreadyLinked) {
-            transaction.update(playerRef, {
-                parents: arrayUnion({
-                    userId,
-                    email: accessCodeData.email || existingUser.email || 'linked',
-                    relation: accessCodeData.relation || null,
-                    addedAt: now,
-                    status: 'active',
-                    source: 'parent_invite'
-                })
-            });
-        }
-
-        transaction.update(codeRef, {
-            used: true,
-            usedBy: userId,
-            usedAt: now,
-            status: 'accepted',
-            autoAccepted: true,
-            autoAcceptedAt: now
-        });
-    });
-
-    return true;
+async function autoAcceptParentInviteForExistingUser(accessCodeId) {
+    const autoAcceptParentInvite = httpsCallable(functions, 'autoAcceptParentInviteForExistingUser');
+    const result = await autoAcceptParentInvite({ codeId: accessCodeId });
+    return Boolean(result?.data?.autoLinked);
 }
 
 export async function inviteParent(teamId, playerId, playerNum, parentEmail, relation) {
@@ -3175,7 +3106,11 @@ export async function inviteParent(teamId, playerId, playerNum, parentEmail, rel
     if (normalizedParentEmail) {
         existingUser = await getUserByEmail(normalizedParentEmail);
         if (existingUser) {
-            autoLinked = await autoAcceptParentInviteForExistingUser(docRef, existingUser, accessCodeData, team, player);
+            try {
+                autoLinked = await autoAcceptParentInviteForExistingUser(docRef.id);
+            } catch (error) {
+                console.warn(`Could not auto-link existing parent invite: ${error?.message || 'Unknown error'}`);
+            }
         }
     }
 

--- a/tests/unit/parent-invite-auto-link.test.js
+++ b/tests/unit/parent-invite-auto-link.test.js
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+describe('parent invite auto-linking', () => {
+    it('auto-accepts existing parent accounts when inviteParent finds a user', () => {
+        const source = readFileSync(resolve(process.cwd(), 'js/db.js'), 'utf8');
+        const inviteIndex = source.indexOf('export async function inviteParent');
+        expect(inviteIndex).toBeGreaterThanOrEqual(0);
+
+        const inviteSource = source.slice(inviteIndex, inviteIndex + 3200);
+        expect(inviteSource).toContain('existingUser = await getUserByEmail(normalizedParentEmail);');
+        expect(inviteSource).toContain('autoLinked = await autoAcceptParentInviteForExistingUser');
+        expect(inviteSource).toContain('autoLinked');
+    });
+
+    it('links the user, player parents list, and accepted invite atomically', () => {
+        const source = readFileSync(resolve(process.cwd(), 'js/db.js'), 'utf8');
+        const helperIndex = source.indexOf('async function autoAcceptParentInviteForExistingUser');
+        expect(helperIndex).toBeGreaterThanOrEqual(0);
+
+        const helperSource = source.slice(helperIndex, helperIndex + 4200);
+        expect(helperSource).toContain('runTransaction(db, async (transaction) =>');
+        expect(helperSource).toContain('parentOf: arrayUnion');
+        expect(helperSource).toContain('parentTeamIds: arrayUnion(accessCodeData.teamId)');
+        expect(helperSource).toContain('parentPlayerKeys: arrayUnion(`${accessCodeData.teamId}::${accessCodeData.playerId}`)');
+        expect(helperSource).toContain("parents: arrayUnion");
+        expect(helperSource).toContain("status: 'accepted'");
+        expect(helperSource).toContain('autoAccepted: true');
+        expect(helperSource).toContain('alreadyLinked');
+    });
+
+    it('shows auto-linked confirmation instead of code-first instructions in roster UI', () => {
+        const source = readFileSync(resolve(process.cwd(), 'edit-roster.html'), 'utf8');
+        expect(source).toContain('if (result.autoLinked)');
+        expect(source).toContain('were linked to ${currentInvitePlayer.name} automatically');
+        expect(source).toContain("codeSection.classList.add('hidden')");
+        expect(source).toContain("from './js/db.js?v=36';");
+    });
+});

--- a/tests/unit/parent-invite-auto-link.test.js
+++ b/tests/unit/parent-invite-auto-link.test.js
@@ -11,20 +11,32 @@ describe('parent invite auto-linking', () => {
         const inviteSource = source.slice(inviteIndex, inviteIndex + 3200);
         expect(inviteSource).toContain('existingUser = await getUserByEmail(normalizedParentEmail);');
         expect(inviteSource).toContain('autoLinked = await autoAcceptParentInviteForExistingUser');
+        expect(inviteSource).toContain('console.warn(`Could not auto-link existing parent invite:');
         expect(inviteSource).toContain('autoLinked');
     });
 
-    it('links the user, player parents list, and accepted invite atomically', () => {
+    it('uses a callable function for cross-user auto-link writes and keeps the client fallback-safe', () => {
         const source = readFileSync(resolve(process.cwd(), 'js/db.js'), 'utf8');
         const helperIndex = source.indexOf('async function autoAcceptParentInviteForExistingUser');
         expect(helperIndex).toBeGreaterThanOrEqual(0);
 
-        const helperSource = source.slice(helperIndex, helperIndex + 4200);
-        expect(helperSource).toContain('runTransaction(db, async (transaction) =>');
-        expect(helperSource).toContain('parentOf: arrayUnion');
-        expect(helperSource).toContain('parentTeamIds: arrayUnion(accessCodeData.teamId)');
-        expect(helperSource).toContain('parentPlayerKeys: arrayUnion(`${accessCodeData.teamId}::${accessCodeData.playerId}`)');
-        expect(helperSource).toContain("parents: arrayUnion");
+        const helperSource = source.slice(helperIndex, helperIndex + 900);
+        expect(helperSource).toContain("httpsCallable(functions, 'autoAcceptParentInviteForExistingUser')");
+        expect(helperSource).toContain('return Boolean(result?.data?.autoLinked);');
+    });
+
+    it('links the user, player parents list, and accepted invite atomically server-side', () => {
+        const source = readFileSync(resolve(process.cwd(), 'functions/index.js'), 'utf8');
+        const helperIndex = source.indexOf('exports.autoAcceptParentInviteForExistingUser');
+        expect(helperIndex).toBeGreaterThanOrEqual(0);
+
+        const helperSource = source.slice(helperIndex, helperIndex + 6200);
+        expect(helperSource).toContain('firestore.runTransaction(async (transaction) =>');
+        expect(helperSource).toContain('hasTeamAdminAccess({ team, uid: context.auth.uid, email: actorEmail })');
+        expect(helperSource).toContain('parentOf: appendUniqueParentLink');
+        expect(helperSource).toContain('parentTeamIds: appendUniqueValue');
+        expect(helperSource).toContain('parentPlayerKeys: appendUniqueValue');
+        expect(helperSource).toContain('existingParents.push');
         expect(helperSource).toContain("status: 'accepted'");
         expect(helperSource).toContain('autoAccepted: true');
         expect(helperSource).toContain('alreadyLinked');

--- a/workflow-roster.html
+++ b/workflow-roster.html
@@ -367,7 +367,7 @@
 <li>Select <strong>Invite Parent</strong> for an active player.</li>
 <li>Choose relation, enter parent email, then send.</li>
 <li>No email available: Leave email blank to generate a shareable code/link.</li>
-<li>Existing account detected: Share the shown code/link so the parent can connect.</li>
+<li>Existing account detected: The parent is linked automatically; use a generated code/link only if auto-linking cannot complete.</li>
 </ul>
 <p><strong>Invite email enforcement:</strong> When a parent redeems an invite code during signup, the email they use for the new account must match the invite email exactly (case-insensitive, whitespace-normalized). A mismatch is rejected immediately after the activation code validation step — before the Firebase Auth account is created. This prevents parents from accidentally creating accounts under a different email than the one the invite was addressed to. If the parent receives an email mismatch error, they must use the exact email the invite was sent to, or ask the admin to resend the invite to the correct address.</p>
 <p><strong>Invite context preservation:</strong> When a parent follows an invite link and is sent to the signup or login page, the invite code and invite type are carried through automatically in the URL parameters. The activation code field on the signup form is pre-filled with the code from the invite link. The parent does not need to re-enter the invite code manually during signup — the context is preserved through the full authentication flow.</p>


### PR DESCRIPTION
Closes #1137

## Summary
- Auto-links existing ALL PLAYS parent accounts during roster parent invite creation.
- Marks the generated parent invite as accepted/auto-accepted and updates parent profile access plus roster parent visibility atomically.
- Updates roster UI and workflow docs so existing users see an auto-linked confirmation instead of code-first instructions.

## Validation
- `npx vitest run tests/unit/parent-invite-auto-link.test.js --reporter=dot`
- `node scripts/check-critical-cache-bust.mjs`