### PR TITLE
Chunk finish flow Firestore writes

### DIFF
--- a/docs/pr-notes/runs/1140-ci-fix-20260520T140925Z/architecture.md
+++ b/docs/pr-notes/runs/1140-ci-fix-20260520T140925Z/architecture.md
@@ -1,0 +1,13 @@
+# Architecture notes
+
+## Acceptance Criteria
+- Stored live tracker finish plans can be replayed into Firestore using the current chunked commit path.
+- Test expectations match the intentional commit order: event batches, aggregated stat batches, then the game update batch.
+
+## Architecture Decisions
+- `commitFinishPlan` already separates writes to avoid Firestore batch limits: live event writes are committed in event chunks, aggregated stats are committed in stats chunks, and the game document update commits last.
+- The failing assertion is stale test drift from the previous single-batch ordering, not a production write bug.
+
+## Risks And Rollback
+- Risk is limited to unit-test expectation coverage. No runtime code change is required.
+- Rollback is reverting the test expectation change if the product intentionally returns to single-batch or stats-first ordering.

--- a/docs/pr-notes/runs/1140-ci-fix-20260520T140925Z/code-plan.md
+++ b/docs/pr-notes/runs/1140-ci-fix-20260520T140925Z/code-plan.md
@@ -1,0 +1,8 @@
+# Code plan
+
+## Implementation Plan
+- Update `tests/unit/live-tracker-save-complete.test.js` so the stored finalization replay assertion expects the current event-write then aggregated-stats write order.
+- Do not change `js/live-tracker-save-complete.js`; batch splitting/order is already validated by `tests/unit/live-tracker-finish-batch-limit.test.js`.
+
+## Minimality
+- Scope is one assertion reorder in the failing unit test plus required PR notes.

--- a/docs/pr-notes/runs/1140-ci-fix-20260520T140925Z/qa.md
+++ b/docs/pr-notes/runs/1140-ci-fix-20260520T140925Z/qa.md
@@ -1,0 +1,9 @@
+# QA notes
+
+## QA Plan
+- Run `npx vitest run tests/unit/live-tracker-save-complete.test.js` to verify the replay workflow assertion.
+- Run `npx vitest run tests/unit/live-tracker-finish-batch-limit.test.js` to confirm chunked commit ordering and batch-limit behavior remain covered.
+
+## Expected Behavior
+- Replayed finish plans should enqueue event writes before aggregated stats writes because `commitFinishPlan` now commits event batches before stats batches.
+- The game update remains a separate final update commit.

--- a/js/live-tracker-save-complete.js
+++ b/js/live-tracker-save-complete.js
@@ -3,6 +3,7 @@ import { resolveSummaryRecipient } from './live-tracker-email.js?v=2';
 import { buildFinishCompletionPlan, executeFinishNavigationPlan } from './live-tracker-finish.js?v=3';
 
 export const LIVE_TRACKER_MAX_PRIMARY_BATCH_WRITES = 500;
+export const LIVE_TRACKER_MAX_EVENT_BATCH_WRITES = 500;
 export const LIVE_TRACKER_MAX_AGGREGATED_STATS_BATCH_WRITES = 450;
 
 function defaultFormatClock(ms) {
@@ -10,10 +11,6 @@ function defaultFormatClock(ms) {
   const m = Math.floor(s / 60).toString().padStart(2, '0');
   const sec = (s % 60).toString().padStart(2, '0');
   return `${m}:${sec}`;
-}
-
-export function buildLiveTrackerFinishBatchLimitError(eventWriteCount, maxPrimaryBatchWrites = LIVE_TRACKER_MAX_PRIMARY_BATCH_WRITES) {
-  return new Error(`Game has ${eventWriteCount} live log entries. Finish requires chunked event persistence before it can safely exceed Firestore's ${maxPrimaryBatchWrites}-write batch limit.`);
 }
 
 export function addFinishPlanWritesToBatch({
@@ -32,6 +29,21 @@ export function addFinishPlanWritesToBatch({
 
   const gameRef = createDocRef(db, `teams/${currentTeamId}/games`, currentGameId);
   batch.update(gameRef, finishPlan.gameUpdate);
+}
+
+export function addEventWritesToBatch({
+  eventWrites = [],
+  batch,
+  db,
+  currentTeamId,
+  currentGameId,
+  createCollectionRef,
+  createDocRef
+} = {}) {
+  eventWrites.forEach(({ data }) => {
+    const eventRef = createDocRef(createCollectionRef(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
+    batch.set(eventRef, data);
+  });
 }
 
 export function addAggregatedStatsWritesToBatch({
@@ -61,19 +73,33 @@ export async function commitFinishPlan({
   createCollectionRef,
   createDocRef,
   maxPrimaryBatchWrites = LIVE_TRACKER_MAX_PRIMARY_BATCH_WRITES,
+  maxEventBatchWrites = LIVE_TRACKER_MAX_EVENT_BATCH_WRITES,
   maxAggregatedStatsBatchWrites = LIVE_TRACKER_MAX_AGGREGATED_STATS_BATCH_WRITES,
   beforePrimaryCommit = null
 } = {}) {
   const eventWrites = finishPlan?.eventWrites || [];
   const aggregatedStatsWrites = finishPlan?.aggregatedStatsWrites || [];
-  const primaryBatchWriteCount = eventWrites.length + 1;
-
-  if (primaryBatchWriteCount > maxPrimaryBatchWrites) {
-    throw buildLiveTrackerFinishBatchLimitError(eventWrites.length, maxPrimaryBatchWrites);
-  }
+  const legacyPrimaryBatchWriteCount = eventWrites.length + 1;
 
   if (typeof beforePrimaryCommit === 'function') {
     await beforePrimaryCommit({ finishPlan });
+  }
+
+  const eventBatchSizes = [];
+  for (let i = 0; i < eventWrites.length; i += maxEventBatchWrites) {
+    const eventBatch = createBatch(db);
+    const eventChunk = eventWrites.slice(i, i + maxEventBatchWrites);
+    addEventWritesToBatch({
+      eventWrites: eventChunk,
+      batch: eventBatch,
+      db,
+      currentTeamId,
+      currentGameId,
+      createCollectionRef,
+      createDocRef
+    });
+    eventBatchSizes.push(eventChunk.length);
+    await eventBatch.commit();
   }
 
   const aggregatedStatsBatchSizes = [];
@@ -92,20 +118,15 @@ export async function commitFinishPlan({
     await statsBatch.commit();
   }
 
-  const primaryBatch = createBatch(db);
-  addFinishPlanWritesToBatch({
-    finishPlan,
-    batch: primaryBatch,
-    db,
-    currentTeamId,
-    currentGameId,
-    createCollectionRef,
-    createDocRef
-  });
-  await primaryBatch.commit();
+  const gameUpdateBatch = createBatch(db);
+  const gameRef = createDocRef(db, `teams/${currentTeamId}/games`, currentGameId);
+  gameUpdateBatch.update(gameRef, finishPlan.gameUpdate);
+  await gameUpdateBatch.commit();
 
   return {
-    primaryBatchWriteCount,
+    primaryBatchWriteCount: legacyPrimaryBatchWriteCount,
+    eventBatchSizes,
+    gameUpdateBatchSize: 1,
     aggregatedStatsBatchSizes,
     aggregatedStatsWriteCount: aggregatedStatsWrites.length
   };

--- a/js/live-tracker-save-complete.js
+++ b/js/live-tracker-save-complete.js
@@ -6,6 +6,10 @@ export const LIVE_TRACKER_MAX_PRIMARY_BATCH_WRITES = 500;
 export const LIVE_TRACKER_MAX_EVENT_BATCH_WRITES = 500;
 export const LIVE_TRACKER_MAX_AGGREGATED_STATS_BATCH_WRITES = 450;
 
+export function buildLiveTrackerFinishEventDocumentId(index) {
+  return `finish-log-${String(Number(index || 0) + 1).padStart(6, '0')}`;
+}
+
 function defaultFormatClock(ms) {
   const s = Math.floor(ms / 1000);
   const m = Math.floor(s / 60).toString().padStart(2, '0');
@@ -22,8 +26,12 @@ export function addFinishPlanWritesToBatch({
   createCollectionRef,
   createDocRef
 } = {}) {
-  (finishPlan?.eventWrites || []).forEach(({ data }) => {
-    const eventRef = createDocRef(createCollectionRef(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
+  (finishPlan?.eventWrites || []).forEach(({ data }, index) => {
+    const eventRef = createDocRef(
+      db,
+      `teams/${currentTeamId}/games/${currentGameId}/events`,
+      buildLiveTrackerFinishEventDocumentId(index)
+    );
     batch.set(eventRef, data);
   });
 
@@ -38,10 +46,15 @@ export function addEventWritesToBatch({
   currentTeamId,
   currentGameId,
   createCollectionRef,
-  createDocRef
+  createDocRef,
+  startIndex = 0
 } = {}) {
-  eventWrites.forEach(({ data }) => {
-    const eventRef = createDocRef(createCollectionRef(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
+  eventWrites.forEach(({ data }, index) => {
+    const eventRef = createDocRef(
+      db,
+      `teams/${currentTeamId}/games/${currentGameId}/events`,
+      buildLiveTrackerFinishEventDocumentId(startIndex + index)
+    );
     batch.set(eventRef, data);
   });
 }
@@ -96,7 +109,8 @@ export async function commitFinishPlan({
       currentTeamId,
       currentGameId,
       createCollectionRef,
-      createDocRef
+      createDocRef,
+      startIndex: i
     });
     eventBatchSizes.push(eventChunk.length);
     await eventBatch.commit();

--- a/js/track-finish.js
+++ b/js/track-finish.js
@@ -4,6 +4,10 @@ export const STANDARD_TRACKER_MAX_PRIMARY_BATCH_WRITES = 500;
 export const STANDARD_TRACKER_MAX_EVENT_BATCH_WRITES = 500;
 export const STANDARD_TRACKER_MAX_AGGREGATED_STATS_BATCH_WRITES = 450;
 
+export function buildFinishEventDocumentId(index) {
+    return `finish-log-${String(Number(index || 0) + 1).padStart(6, '0')}`;
+}
+
 export function buildNormalizedPlayerStats(playerStats = {}, columns = []) {
     const playerStatsByLowerKey = {};
     const normalizedStats = {};
@@ -111,12 +115,12 @@ export async function commitStandardTrackerFinishData({
         eventBatchWriteCount = 0;
     }
 
-    for (const entry of safeGameLog) {
+    for (const [eventIndex, entry] of safeGameLog.entries()) {
         if (eventBatchWriteCount >= maxEventBatchWrites) {
             await commitEventBatch();
         }
         ensureEventBatch();
-        const eventRef = doc(collection(db, `teams/${teamId}/games/${gameId}/events`));
+        const eventRef = doc(db, `teams/${teamId}/games/${gameId}/events`, buildFinishEventDocumentId(eventIndex));
         eventBatch.set(eventRef, {
             text: entry.text,
             gameTime: entry.time,

--- a/js/track-finish.js
+++ b/js/track-finish.js
@@ -1,6 +1,7 @@
 import { splitPlayerStatsByVisibility } from './stat-leaderboards.js?v=2';
 
 export const STANDARD_TRACKER_MAX_PRIMARY_BATCH_WRITES = 500;
+export const STANDARD_TRACKER_MAX_EVENT_BATCH_WRITES = 500;
 export const STANDARD_TRACKER_MAX_AGGREGATED_STATS_BATCH_WRITES = 450;
 
 export function buildNormalizedPlayerStats(playerStats = {}, columns = []) {
@@ -26,10 +27,6 @@ export function buildNormalizedPlayerStats(playerStats = {}, columns = []) {
     });
 
     return normalizedStats;
-}
-
-export function buildFinishBatchLimitError(gameLogLength, maxPrimaryBatchWrites = STANDARD_TRACKER_MAX_PRIMARY_BATCH_WRITES) {
-    return new Error(`Game has ${gameLogLength} logged events. Finish requires chunked event persistence before it can safely exceed Firestore's ${maxPrimaryBatchWrites}-write batch limit.`);
 }
 
 export function buildAggregatedStatsWrites({ players = [], playerStatsByPlayerId = {}, columns = [], statTrackerConfig = {} } = {}) {
@@ -84,16 +81,11 @@ export async function commitStandardTrackerFinishData({
     summary = '',
     opponentStats = {},
     maxPrimaryBatchWrites = STANDARD_TRACKER_MAX_PRIMARY_BATCH_WRITES,
+    maxEventBatchWrites = STANDARD_TRACKER_MAX_EVENT_BATCH_WRITES,
     maxAggregatedStatsBatchWrites = STANDARD_TRACKER_MAX_AGGREGATED_STATS_BATCH_WRITES
 } = {}) {
     const safeGameLog = Array.isArray(gameLog) ? gameLog : [];
-    const primaryBatchWriteCount = safeGameLog.length + 1;
-
-    if (primaryBatchWriteCount > maxPrimaryBatchWrites) {
-        throw buildFinishBatchLimitError(safeGameLog.length, maxPrimaryBatchWrites);
-    }
-
-    const primaryBatch = writeBatch(db);
+    const legacyPrimaryBatchWriteCount = safeGameLog.length + 1;
     const aggregatedStatsWrites = buildAggregatedStatsWrites({
         players,
         playerStatsByPlayerId,
@@ -101,9 +93,31 @@ export async function commitStandardTrackerFinishData({
         statTrackerConfig
     });
 
-    safeGameLog.forEach((entry) => {
+    const eventBatchSizes = [];
+    let eventBatch = null;
+    let eventBatchWriteCount = 0;
+
+    function ensureEventBatch() {
+        if (!eventBatch) {
+            eventBatch = writeBatch(db);
+        }
+    }
+
+    async function commitEventBatch() {
+        if (!eventBatch || eventBatchWriteCount === 0) return;
+        eventBatchSizes.push(eventBatchWriteCount);
+        await eventBatch.commit();
+        eventBatch = null;
+        eventBatchWriteCount = 0;
+    }
+
+    for (const entry of safeGameLog) {
+        if (eventBatchWriteCount >= maxEventBatchWrites) {
+            await commitEventBatch();
+        }
+        ensureEventBatch();
         const eventRef = doc(collection(db, `teams/${teamId}/games/${gameId}/events`));
-        primaryBatch.set(eventRef, {
+        eventBatch.set(eventRef, {
             text: entry.text,
             gameTime: entry.time,
             period: entry.period,
@@ -115,18 +129,9 @@ export async function commitStandardTrackerFinishData({
             isOpponent: entry.undoData?.isOpponent || false,
             createdBy: currentUserUid
         });
-    });
-
-    const gameRef = doc(db, `teams/${teamId}/games`, gameId);
-    primaryBatch.update(gameRef, {
-        homeScore: finalHome,
-        awayScore: finalAway,
-        summary,
-        status: 'completed',
-        opponentStats
-    });
-
-    await primaryBatch.commit();
+        eventBatchWriteCount += 1;
+    }
+    await commitEventBatch();
 
     const aggregatedStatsBatchSizes = [];
     let statsBatch = null;
@@ -165,8 +170,21 @@ export async function commitStandardTrackerFinishData({
     }
     await commitStatsBatch();
 
+    const gameUpdateBatch = writeBatch(db);
+    const gameRef = doc(db, `teams/${teamId}/games`, gameId);
+    gameUpdateBatch.update(gameRef, {
+        homeScore: finalHome,
+        awayScore: finalAway,
+        summary,
+        status: 'completed',
+        opponentStats
+    });
+    await gameUpdateBatch.commit();
+
     return {
-        primaryBatchWriteCount,
+        primaryBatchWriteCount: legacyPrimaryBatchWriteCount,
+        eventBatchSizes,
+        gameUpdateBatchSize: 1,
         aggregatedStatsBatchSizes,
         aggregatedStatsWriteCount: aggregatedStatsBatchSizes.reduce((total, size) => total + size, 0)
     };

--- a/test-track-finish-batch-limit.js
+++ b/test-track-finish-batch-limit.js
@@ -23,36 +23,36 @@ function assertDeepEquals(actual, expected, label) {
     }
 }
 
-function buildFinishWritePlan(gameLogEntries, aggregatedStatsWrites, maxAggregatedStatsBatchWrites = 450) {
-    const primaryBatchWriteCount = gameLogEntries.length + 1;
-    const canCommitPrimaryBatch = primaryBatchWriteCount <= 500;
-    const aggregatedStatsBatchSizes = [];
+function buildFinishWritePlan(gameLogEntries, aggregatedStatsWrites, maxEventBatchWrites = 500, maxAggregatedStatsBatchWrites = 450) {
+    const eventBatchSizes = [];
+    for (let i = 0; i < gameLogEntries.length; i += maxEventBatchWrites) {
+        eventBatchSizes.push(gameLogEntries.slice(i, i + maxEventBatchWrites).length);
+    }
 
-    if (canCommitPrimaryBatch) {
-        for (let i = 0; i < aggregatedStatsWrites.length; i += maxAggregatedStatsBatchWrites) {
-            aggregatedStatsBatchSizes.push(
-                aggregatedStatsWrites.slice(i, i + maxAggregatedStatsBatchWrites).length
-            );
-        }
+    const aggregatedStatsBatchSizes = [];
+    for (let i = 0; i < aggregatedStatsWrites.length; i += maxAggregatedStatsBatchWrites) {
+        aggregatedStatsBatchSizes.push(
+            aggregatedStatsWrites.slice(i, i + maxAggregatedStatsBatchWrites).length
+        );
     }
 
     return {
-        primaryBatchWriteCount,
-        canCommitPrimaryBatch,
-        aggregatedStatsBatchSizes
+        eventBatchSizes,
+        aggregatedStatsBatchSizes,
+        gameUpdateBatchSize: 1
     };
 }
 
-test('keeps roster-wide aggregated stats writes out of the primary finish batch', () => {
+test('keeps roster-wide aggregated stats writes out of event finish batches', () => {
     const plan = buildFinishWritePlan(
         new Array(490).fill({}),
         new Array(25).fill({})
     );
 
-    assertEquals(
-        plan.primaryBatchWriteCount,
-        491,
-        'Primary finish batch should only contain game-log writes plus the final game update'
+    assertDeepEquals(
+        plan.eventBatchSizes,
+        [490],
+        'Event writes should be committed separately from stats and final game update'
     );
     assertDeepEquals(
         plan.aggregatedStatsBatchSizes,
@@ -67,10 +67,10 @@ test('chunks aggregated stats writes into sub-500 secondary batches', () => {
         new Array(905).fill({})
     );
 
-    assertEquals(
-        plan.canCommitPrimaryBatch,
-        true,
-        'Primary batch should remain commit-safe at 499 event writes plus the game update'
+    assertDeepEquals(
+        plan.eventBatchSizes,
+        [499],
+        'Event batch should remain commit-safe at 499 event writes'
     );
     assertDeepEquals(
         plan.aggregatedStatsBatchSizes,
@@ -84,26 +84,26 @@ test('chunks aggregated stats writes into sub-500 secondary batches', () => {
     });
 });
 
-test('fails cleanly before writing secondary batches when the primary batch would overflow', () => {
+test('chunks event writes when event count exceeds Firestore batch limit', () => {
     const plan = buildFinishWritePlan(
-        new Array(500).fill({}),
+        new Array(1001).fill({}),
         new Array(25).fill({})
     );
 
-    assertEquals(
-        plan.primaryBatchWriteCount,
-        501,
-        '500 event writes plus the final game update should exceed Firestore batch limits'
-    );
-    assertEquals(
-        plan.canCommitPrimaryBatch,
-        false,
-        'Primary batch should be rejected before any secondary aggregated stats batches are committed'
+    assertDeepEquals(
+        plan.eventBatchSizes,
+        [500, 500, 1],
+        'Event writes over 500 should be split across multiple batches'
     );
     assertDeepEquals(
         plan.aggregatedStatsBatchSizes,
-        [],
-        'No secondary aggregated stats batches should be planned when the primary batch is already unsafe'
+        [25],
+        'Aggregated stats should still be planned after event chunking'
+    );
+    assertEquals(
+        plan.gameUpdateBatchSize,
+        1,
+        'Final game completion update should be committed in its own batch'
     );
 });
 

--- a/tests/unit/live-tracker-finish-batch-limit.test.js
+++ b/tests/unit/live-tracker-finish-batch-limit.test.js
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
 import { commitFinishPlan } from '../../js/live-tracker-save-complete.js';
 
 function createFirestoreHarness({ commitFailuresByBatchIndex = {} } = {}) {
@@ -89,21 +90,26 @@ describe('live broadcast tracker finish batch limits', () => {
             aggregatedStatsCount: 25
         });
 
-        expect(result.primaryBatchWriteCount).toBe(491);
+        expect(result.eventBatchSizes).toEqual([490]);
         expect(result.aggregatedStatsBatchSizes).toEqual([25]);
-        expect(harness.batches).toHaveLength(2);
+        expect(result.gameUpdateBatchSize).toBe(1);
+        expect(harness.batches).toHaveLength(3);
 
-        const [statsBatch, primaryBatch] = harness.batches;
+        const [eventBatch, statsBatch, gameUpdateBatch] = harness.batches;
+        expect(eventBatch.commitCount).toBe(1);
+        expect(eventBatch.operations).toHaveLength(490);
+        expect(eventBatch.operations.every((op) => op.type === 'set')).toBe(true);
+        expect(eventBatch.operations.some((op) => op.ref.path.includes('/aggregatedStats/'))).toBe(false);
+
         expect(statsBatch.commitCount).toBe(1);
         expect(statsBatch.operations).toHaveLength(25);
         expect(statsBatch.operations.every((op) => op.type === 'set')).toBe(true);
         expect(statsBatch.operations.every((op) => op.ref.path.includes('/aggregatedStats/'))).toBe(true);
 
-        expect(primaryBatch.commitCount).toBe(1);
-        expect(primaryBatch.operations).toHaveLength(491);
-        expect(primaryBatch.operations.filter((op) => op.type === 'set')).toHaveLength(490);
-        expect(primaryBatch.operations.filter((op) => op.type === 'update')).toHaveLength(1);
-        expect(primaryBatch.operations.some((op) => op.ref.path.includes('/aggregatedStats/'))).toBe(false);
+        expect(gameUpdateBatch.commitCount).toBe(1);
+        expect(gameUpdateBatch.operations).toEqual([
+            expect.objectContaining({ type: 'update', ref: { path: 'teams/team-1/games/game-1' } })
+        ]);
     });
 
     it('chunks large aggregated stats into secondary batches', async () => {
@@ -112,34 +118,31 @@ describe('live broadcast tracker finish batch limits', () => {
             aggregatedStatsCount: 905
         });
 
-        expect(result.primaryBatchWriteCount).toBe(500);
+        expect(result.eventBatchSizes).toEqual([499]);
         expect(result.aggregatedStatsBatchSizes).toEqual([450, 450, 5]);
-        expect(harness.batches).toHaveLength(4);
-        expect(harness.batches.slice(0, 3).map((batch) => batch.operations.length)).toEqual([450, 450, 5]);
-        expect(harness.batches[3].operations).toHaveLength(500);
+        expect(harness.batches).toHaveLength(5);
+        expect(harness.batches.map((batch) => batch.operations.length)).toEqual([499, 450, 450, 5, 1]);
     });
 
-    it('rejects before any commit when the primary finish batch would overflow', async () => {
-        const harness = createFirestoreHarness();
+    it('chunks more than 500 live log entries instead of rejecting the finish', async () => {
+        const { harness, result } = await runCommit({
+            eventCount: 1001,
+            aggregatedStatsCount: 25
+        });
 
-        await expect(commitFinishPlan({
-            finishPlan: buildFinishPlan({ eventCount: 500, aggregatedStatsCount: 25 }),
-            db: harness.db,
-            currentTeamId: 'team-1',
-            currentGameId: 'game-1',
-            createBatch: harness.writeBatch,
-            createCollectionRef: harness.collection,
-            createDocRef: harness.doc
-        })).rejects.toThrow("Game has 500 live log entries. Finish requires chunked event persistence before it can safely exceed Firestore's 500-write batch limit.");
-
-        expect(harness.batches).toHaveLength(0);
+        expect(result.eventBatchSizes).toEqual([500, 500, 1]);
+        expect(result.aggregatedStatsBatchSizes).toEqual([25]);
+        expect(harness.batches.map((batch) => batch.operations.length)).toEqual([500, 500, 1, 25, 1]);
+        expect(harness.batches.at(-1).operations).toEqual([
+            expect.objectContaining({ type: 'update', data: expect.objectContaining({ status: 'completed' }) })
+        ]);
     });
 
     it('rejects when a secondary aggregated stats batch fails before primary commit', async () => {
         const statsBatchFailure = new Error('Secondary aggregated stats batch failed');
         const harness = createFirestoreHarness({
             commitFailuresByBatchIndex: {
-                1: statsBatchFailure
+                2: statsBatchFailure
             }
         });
 
@@ -149,11 +152,27 @@ describe('live broadcast tracker finish batch limits', () => {
             harness
         })).rejects.toBe(statsBatchFailure);
 
-        expect(harness.batches).toHaveLength(2);
+        expect(harness.batches).toHaveLength(3);
         expect(harness.batches[0].commitCount).toBe(1);
         expect(harness.batches[1].commitCount).toBe(1);
-        expect(harness.batches[0].operations).toHaveLength(450);
+        expect(harness.batches[2].commitCount).toBe(1);
+        expect(harness.batches[0].operations).toHaveLength(499);
         expect(harness.batches[1].operations).toHaveLength(450);
+        expect(harness.batches[2].operations).toHaveLength(450);
         expect(harness.batches.some((batch) => batch.operations.some((op) => op.type === 'update'))).toBe(false);
+    });
+
+    it('chunks the legacy track-live.html finish writes before completing the game', () => {
+        const source = readFileSync(new URL('../../track-live.html', import.meta.url), 'utf8');
+        const finishSubmitIndex = source.indexOf("finishForm.addEventListener('submit'");
+        const eventLoopIndex = source.indexOf('for (const entry of gameState.gameLog)', finishSubmitIndex);
+        const statsLoopIndex = source.indexOf('for (const [playerId, stats] of Object.entries(gameState.playerStats))', eventLoopIndex);
+        const finalUpdateIndex = source.indexOf("status: 'completed'", statsLoopIndex);
+
+        expect(source).toContain('const maxBatchWrites = 500;');
+        expect(source).toContain('await commitBatchIfNeeded(true);');
+        expect(eventLoopIndex).toBeGreaterThan(finishSubmitIndex);
+        expect(statsLoopIndex).toBeGreaterThan(eventLoopIndex);
+        expect(finalUpdateIndex).toBeGreaterThan(statsLoopIndex);
     });
 });

--- a/tests/unit/live-tracker-finish-batch-limit.test.js
+++ b/tests/unit/live-tracker-finish-batch-limit.test.js
@@ -133,6 +133,10 @@ describe('live broadcast tracker finish batch limits', () => {
         expect(result.eventBatchSizes).toEqual([500, 500, 1]);
         expect(result.aggregatedStatsBatchSizes).toEqual([25]);
         expect(harness.batches.map((batch) => batch.operations.length)).toEqual([500, 500, 1, 25, 1]);
+        expect(harness.batches[0].operations[0].ref.path).toBe('teams/team-1/games/game-1/events/finish-log-000001');
+        expect(harness.batches[0].operations[499].ref.path).toBe('teams/team-1/games/game-1/events/finish-log-000500');
+        expect(harness.batches[1].operations[0].ref.path).toBe('teams/team-1/games/game-1/events/finish-log-000501');
+        expect(harness.batches[2].operations[0].ref.path).toBe('teams/team-1/games/game-1/events/finish-log-001001');
         expect(harness.batches.at(-1).operations).toEqual([
             expect.objectContaining({ type: 'update', data: expect.objectContaining({ status: 'completed' }) })
         ]);
@@ -165,11 +169,12 @@ describe('live broadcast tracker finish batch limits', () => {
     it('chunks the legacy track-live.html finish writes before completing the game', () => {
         const source = readFileSync(new URL('../../track-live.html', import.meta.url), 'utf8');
         const finishSubmitIndex = source.indexOf("finishForm.addEventListener('submit'");
-        const eventLoopIndex = source.indexOf('for (const entry of gameState.gameLog)', finishSubmitIndex);
+        const eventLoopIndex = source.indexOf('for (const [eventIndex, entry] of gameState.gameLog.entries())', finishSubmitIndex);
         const statsLoopIndex = source.indexOf('for (const [playerId, stats] of Object.entries(gameState.playerStats))', eventLoopIndex);
         const finalUpdateIndex = source.indexOf("status: 'completed'", statsLoopIndex);
 
         expect(source).toContain('const maxBatchWrites = 500;');
+        expect(source).toContain("const eventId = `finish-log-${String(eventIndex + 1).padStart(6, '0')}`;");
         expect(source).toContain('await commitBatchIfNeeded(true);');
         expect(eventLoopIndex).toBeGreaterThan(finishSubmitIndex);
         expect(statsLoopIndex).toBeGreaterThan(eventLoopIndex);

--- a/tests/unit/live-tracker-save-complete.test.js
+++ b/tests/unit/live-tracker-save-complete.test.js
@@ -294,7 +294,7 @@ describe('live tracker save-and-complete workflow', () => {
     expect(harness.batch.commit).toHaveBeenCalledTimes(1);
     expect(harness.setCalls).toEqual([
       {
-        ref: { kind: 'auto-doc', path: 'teams/team-1/games/game-9/events/AUTO_ID' },
+        ref: { kind: 'doc', path: 'teams/team-1/games/game-9/events/finish-log-000001' },
         data: { text: 'Home layup', gameTime: '01:20' }
       },
       {

--- a/tests/unit/live-tracker-save-complete.test.js
+++ b/tests/unit/live-tracker-save-complete.test.js
@@ -294,12 +294,12 @@ describe('live tracker save-and-complete workflow', () => {
     expect(harness.batch.commit).toHaveBeenCalledTimes(1);
     expect(harness.setCalls).toEqual([
       {
-        ref: { kind: 'doc', path: 'teams/team-1/games/game-9/aggregatedStats/p1' },
-        data: { playerName: 'Alex', stats: { pts: 2 }, timeMs: 1000 }
-      },
-      {
         ref: { kind: 'auto-doc', path: 'teams/team-1/games/game-9/events/AUTO_ID' },
         data: { text: 'Home layup', gameTime: '01:20' }
+      },
+      {
+        ref: { kind: 'doc', path: 'teams/team-1/games/game-9/aggregatedStats/p1' },
+        data: { playerName: 'Alex', stats: { pts: 2 }, timeMs: 1000 }
       }
     ]);
     expect(harness.updateCalls).toEqual([

--- a/tests/unit/track-finish-batch-limit.test.js
+++ b/tests/unit/track-finish-batch-limit.test.js
@@ -211,6 +211,10 @@ describe('standard tracker finish batch limits', () => {
         expect(result.eventBatchSizes).toEqual([500, 500, 1]);
         expect(result.aggregatedStatsBatchSizes).toEqual([12]);
         expect(harness.batches.map((batch) => batch.operations.length)).toEqual([500, 500, 1, 12, 1]);
+        expect(harness.batches[0].operations[0].ref.path).toBe('teams/team-1/games/game-1/events/finish-log-000001');
+        expect(harness.batches[0].operations[499].ref.path).toBe('teams/team-1/games/game-1/events/finish-log-000500');
+        expect(harness.batches[1].operations[0].ref.path).toBe('teams/team-1/games/game-1/events/finish-log-000501');
+        expect(harness.batches[2].operations[0].ref.path).toBe('teams/team-1/games/game-1/events/finish-log-001001');
         expect(harness.batches.at(-1).operations).toEqual([
             expect.objectContaining({ type: 'update', data: expect.objectContaining({ status: 'completed' }) })
         ]);

--- a/tests/unit/track-finish-batch-limit.test.js
+++ b/tests/unit/track-finish-batch-limit.test.js
@@ -96,27 +96,31 @@ async function runFinishSave({ eventCount, rosterCount }) {
 }
 
 describe('standard tracker finish batch limits', () => {
-    it('commits 499 game logs plus final update and chunks 905 aggregated stat writes', async () => {
+    it('chunks game logs and aggregated stat writes before final game update', async () => {
         const { harness, result } = await runFinishSave({
             eventCount: 499,
             rosterCount: 905
         });
 
-        expect(result.primaryBatchWriteCount).toBe(500);
+        expect(result.eventBatchSizes).toEqual([499]);
         expect(result.aggregatedStatsBatchSizes).toEqual([450, 450, 5]);
-        expect(harness.batches).toHaveLength(4);
+        expect(result.gameUpdateBatchSize).toBe(1);
+        expect(harness.batches).toHaveLength(5);
 
-        const [primaryBatch, ...secondaryBatches] = harness.batches;
-        expect(primaryBatch.commitCount).toBe(1);
-        expect(primaryBatch.operations).toHaveLength(500);
-        expect(primaryBatch.operations.filter((op) => op.type === 'set')).toHaveLength(499);
-        expect(primaryBatch.operations.filter((op) => op.type === 'update')).toHaveLength(1);
+        const [eventBatch, ...secondaryBatches] = harness.batches;
+        const gameUpdateBatch = secondaryBatches.pop();
+        expect(eventBatch.commitCount).toBe(1);
+        expect(eventBatch.operations).toHaveLength(499);
+        expect(eventBatch.operations.every((op) => op.type === 'set')).toBe(true);
 
         expect(secondaryBatches.map((batch) => batch.operations.length)).toEqual([450, 450, 5]);
         secondaryBatches.forEach((batch) => {
             expect(batch.commitCount).toBe(1);
             expect(batch.operations.every((op) => op.type === 'set')).toBe(true);
         });
+        expect(gameUpdateBatch.operations).toEqual([
+            expect.objectContaining({ type: 'update', ref: { path: 'teams/team-1/games/game-1' } })
+        ]);
     });
 
     it('writes zero-stat roster players as player profile appearances', async () => {
@@ -143,7 +147,7 @@ describe('standard tracker finish batch limits', () => {
             opponentStats: {}
         });
 
-        const statsBatch = harness.batches[1];
+        const statsBatch = harness.batches[0];
         const zeroStatWrite = statsBatch.operations.find((op) => op.ref.path === 'teams/team-1/games/game-1/aggregatedStats/p2');
 
         expect(zeroStatWrite.data).toEqual({
@@ -185,7 +189,7 @@ describe('standard tracker finish batch limits', () => {
             opponentStats: {}
         });
 
-        const statsBatch = harness.batches[1];
+        const statsBatch = harness.batches[0];
         expect(statsBatch.operations).toEqual([
             expect.objectContaining({
                 ref: { path: 'teams/team-1/games/game-1/aggregatedStats/p1' },
@@ -198,28 +202,18 @@ describe('standard tracker finish batch limits', () => {
         ]);
     });
 
-    it('rejects 500 game logs plus final update before any batch commit', async () => {
-        const harness = createFirestoreHarness();
+    it('chunks more than 500 game logs instead of rejecting the finish', async () => {
+        const { harness, result } = await runFinishSave({
+            eventCount: 1001,
+            rosterCount: 12
+        });
 
-        await expect(commitStandardTrackerFinishData({
-            db: harness.db,
-            writeBatch: harness.writeBatch,
-            doc: harness.doc,
-            collection: harness.collection,
-            teamId: 'team-1',
-            gameId: 'game-1',
-            currentUserUid: 'coach-1',
-            gameLog: buildGameLog(500),
-            players: buildRoster(905),
-            playerStatsByPlayerId: {},
-            columns: ['PTS'],
-            finalHome: 12,
-            finalAway: 10,
-            summary: 'Should not save.',
-            opponentStats: {}
-        })).rejects.toThrow("Game has 500 logged events. Finish requires chunked event persistence before it can safely exceed Firestore's 500-write batch limit.");
-
-        expect(harness.batches).toHaveLength(0);
+        expect(result.eventBatchSizes).toEqual([500, 500, 1]);
+        expect(result.aggregatedStatsBatchSizes).toEqual([12]);
+        expect(harness.batches.map((batch) => batch.operations.length)).toEqual([500, 500, 1, 12, 1]);
+        expect(harness.batches.at(-1).operations).toEqual([
+            expect.objectContaining({ type: 'update', data: expect.objectContaining({ status: 'completed' }) })
+        ]);
     });
 
     it('rejects when a secondary aggregated stats batch fails after primary commit', async () => {
@@ -252,10 +246,10 @@ describe('standard tracker finish batch limits', () => {
         expect(harness.batches[0].commitCount).toBe(1);
         expect(harness.batches[1].commitCount).toBe(1);
         expect(harness.batches[2].commitCount).toBe(1);
-        expect(harness.batches[0].operations).toHaveLength(500);
+        expect(harness.batches[0].operations).toHaveLength(499);
         expect(harness.batches[1].operations).toHaveLength(450);
         expect(harness.batches[2].operations).toHaveLength(450);
-        expect(harness.batches[3]).toBeUndefined();
+        expect(harness.batches.some((batch) => batch.operations.some((op) => op.type === 'update'))).toBe(false);
     });
 
     it('wires the production track.html submit path through the tested finish helper before success-only side effects', () => {

--- a/track-live.html
+++ b/track-live.html
@@ -3247,9 +3247,10 @@ Write the match report now:`;
                 };
 
                 // 1. Write all game log events in chunks under Firestore's batch limit
-                for (const entry of gameState.gameLog) {
+                for (const [eventIndex, entry] of gameState.gameLog.entries()) {
                     await commitBatchIfNeeded();
-                    const eventRef = doc(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
+                    const eventId = `finish-log-${String(eventIndex + 1).padStart(6, '0')}`;
+                    const eventRef = doc(db, `teams/${currentTeamId}/games/${currentGameId}/events`, eventId);
                     batch.set(eventRef, {
                         text: entry.text,
                         gameTime: entry.time,

--- a/track-live.html
+++ b/track-live.html
@@ -3234,11 +3234,21 @@ Write the match report now:`;
             const sendEmail = document.getElementById('sendEmailCheckbox').checked;
 
             try {
-                // Create a batch write for all data
-                const batch = writeBatch(db);
+                const maxBatchWrites = 500;
+                let batch = writeBatch(db);
+                let batchWriteCount = 0;
 
-                // 1. Write all game log events
-                gameState.gameLog.forEach(entry => {
+                const commitBatchIfNeeded = async (force = false) => {
+                    if (batchWriteCount === 0) return;
+                    if (!force && batchWriteCount < maxBatchWrites) return;
+                    await batch.commit();
+                    batch = writeBatch(db);
+                    batchWriteCount = 0;
+                };
+
+                // 1. Write all game log events in chunks under Firestore's batch limit
+                for (const entry of gameState.gameLog) {
+                    await commitBatchIfNeeded();
                     const eventRef = doc(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
                     batch.set(eventRef, {
                         text: entry.text,
@@ -3252,12 +3262,15 @@ Write the match report now:`;
                         isOpponent: entry.undoData?.isOpponent || false,
                         createdBy: currentUser.uid
                     });
-                });
+                    batchWriteCount += 1;
+                }
+                await commitBatchIfNeeded(true);
 
-                // 2. Write aggregated stats for each player
-                Object.entries(gameState.playerStats).forEach(([playerId, stats]) => {
+                // 2. Write aggregated stats for each player in chunks
+                for (const [playerId, stats] of Object.entries(gameState.playerStats)) {
                     const player = players.find(p => p.id === playerId);
                     if (player) {
+                        await commitBatchIfNeeded();
                         const timeMs = getPlayerFieldElapsedMs(
                             gameState.playerFieldStatus,
                             playerId,
@@ -3270,11 +3283,14 @@ Write the match report now:`;
                             stats: stats,
                             timeMs
                         });
+                        batchWriteCount += 1;
                     }
-                });
+                }
+                await commitBatchIfNeeded(true);
 
-                // 3. Update game document with final data
+                // 3. Update game document with final data after detail writes finish
                 const gameRef = doc(db, `teams/${currentTeamId}/games`, currentGameId);
+                batch = writeBatch(db);
                 batch.update(gameRef, {
                     homeScore: finalHome,
                     awayScore: finalAway,
@@ -3284,8 +3300,6 @@ Write the match report now:`;
                     ...(gameState.isBaseballScorekeeping ? { liveBaseballState: gameState.baseballState } : {}),
                     ...(isFootballTrackingConfig() ? { liveFootballState: gameState.footballState } : {})
                 });
-
-                // Commit all writes in a single batch
                 await batch.commit();
                 console.log('Game data saved successfully');
 


### PR DESCRIPTION
Closes #1139

## Summary
- Chunked standard tracker finish event writes so games with more than 500 events can complete.
- Chunked mobile live tracker finish event writes and moved the final game completion update into its own last batch.
- Updated legacy track-live finish flow to chunk event and aggregated stat writes before marking the game completed.

## Tests
- `npx vitest run tests/unit/track-finish-batch-limit.test.js tests/unit/live-tracker-finish-batch-limit.test.js --reporter=dot`
- `node test-track-finish-batch-limit.js`