### PR TITLE
Show pool-protection advancement warnings

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -1230,6 +1230,7 @@
                     reason: `Save a final ranking for ${pool?.poolName || 'this pool'} before advancing bracket slots.`,
                     patches: [],
                     previewRows: [],
+                    poolProtectionWarnings: [],
                     requiresOverwriteConfirmation: false
                 };
             }
@@ -1244,8 +1245,10 @@
             if (plan.skipped) return plan.reason || 'Bracket advancement is not ready.';
             if (!plan.patches?.length) return 'Bracket slots already match this final ranking.';
             const slotCount = plan.previewRows?.length || plan.patches.length;
+            const warningCount = plan.poolProtectionWarnings?.length || 0;
+            const warningText = warningCount ? ` ${warningCount} pool-protection warning${warningCount === 1 ? '' : 's'} will be shown.` : '';
             const overwriteText = plan.requiresOverwriteConfirmation ? ' Existing assignments will require confirmation.' : '';
-            return `${slotCount} bracket slot update${slotCount === 1 ? '' : 's'} ready for preview.${overwriteText}`;
+            return `${slotCount} bracket slot update${slotCount === 1 ? '' : 's'} ready for preview.${warningText}${overwriteText}`;
         }
 
         function formatTournamentAdvancementPreviewMessage(pool = {}, plan = {}) {
@@ -1257,13 +1260,16 @@
             const overflowText = previewRows.length > previewLines.length
                 ? `\n• ${previewRows.length - previewLines.length} more slot update${previewRows.length - previewLines.length === 1 ? '' : 's'}`
                 : '';
+            const poolProtectionWarnings = Array.isArray(plan.poolProtectionWarnings) ? plan.poolProtectionWarnings : [];
+            const warningLines = poolProtectionWarnings.map((warning) => `⚠ ${warning.gameId} (${warning.homeSourceLabel || 'Home'} vs ${warning.awaySourceLabel || 'Away'}): ${warning.homeTeamName} vs ${warning.awayTeamName} are both from ${warning.poolName}`);
+            const warningBlock = warningLines.length ? `\n\nPool-protection warnings:\n${warningLines.join('\n')}` : '';
             const fallbackLines = !previewLines.length
                 ? (plan.patches || []).map((patch) => `• ${patch.gameId}`)
                 : [];
             const warning = plan.requiresOverwriteConfirmation
                 ? 'Existing bracket assignments will be overwritten.\n\n'
                 : '';
-            return `${warning}Preview bracket advancement for ${pool.poolName || plan.poolName}:\n\n${[...previewLines, ...fallbackLines].join('\n')}${overflowText}\n\nSave ${plan.patches?.length || 0} tournament game update${(plan.patches?.length || 0) === 1 ? '' : 's'}?`;
+            return `${warning}Preview bracket advancement for ${pool.poolName || plan.poolName}:\n\n${[...previewLines, ...fallbackLines].join('\n')}${overflowText}${warningBlock}\n\nSave ${plan.patches?.length || 0} tournament game update${(plan.patches?.length || 0) === 1 ? '' : 's'}?`;
         }
 
         function closeTournamentStandingsModal() {

--- a/js/tournament-brackets.js
+++ b/js/tournament-brackets.js
@@ -218,6 +218,39 @@ export function collectTournamentPoolSeeds(games = [], poolNameInput) {
     return Array.from(seeds).sort((a, b) => a - b);
 }
 
+function buildPoolProtectionWarningRows(games = [], patches = []) {
+    const gamesById = new Map((games || []).filter((game) => game?.id).map((game) => [game.id, game]));
+
+    return (patches || []).map((patch) => {
+        const game = gamesById.get(patch?.gameId) || {};
+        const tournament = game?.tournament || {};
+        const slotAssignments = tournament.slotAssignments || {};
+        const nextResolved = patch?.tournament?.resolved || {};
+        const homeSource = slotAssignments.home || {};
+        const awaySource = slotAssignments.away || {};
+        if ((normalizeString(homeSource.sourceType) || 'team') !== 'pool_seed') return null;
+        if ((normalizeString(awaySource.sourceType) || 'team') !== 'pool_seed') return null;
+
+        const homePoolName = getTournamentPoolLabel(homeSource, tournament);
+        const awayPoolName = getTournamentPoolLabel(awaySource, tournament);
+        if (!homePoolName || homePoolName !== awayPoolName) return null;
+
+        const homeTeamName = normalizeString(nextResolved.homeTeamName);
+        const awayTeamName = normalizeString(nextResolved.awayTeamName);
+        if (!homeTeamName || !awayTeamName) return null;
+
+        return {
+            gameId: patch.gameId,
+            poolName: homePoolName,
+            homeTeamName,
+            awayTeamName,
+            homeSourceLabel: describeTournamentSource(homeSource, tournament),
+            awaySourceLabel: describeTournamentSource(awaySource, tournament),
+            warning: `${homeTeamName} and ${awayTeamName} both advanced from ${homePoolName}.`
+        };
+    }).filter(Boolean);
+}
+
 function buildTournamentAdvancementPreviewRows(games = [], patches = []) {
     const gamesById = new Map((games || []).filter((game) => game?.id).map((game) => [game.id, game]));
 
@@ -288,6 +321,7 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
             missingSeeds: [],
             patches: [],
             previewRows: [],
+            poolProtectionWarnings: [],
             requiresOverwriteConfirmation: false
         };
     }
@@ -301,6 +335,7 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
             missingSeeds: [],
             patches: [],
             previewRows: [],
+            poolProtectionWarnings: [],
             requiresOverwriteConfirmation: false
         };
     }
@@ -314,6 +349,7 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
             missingSeeds: requiredSeeds,
             patches: [],
             previewRows: [],
+            poolProtectionWarnings: [],
             requiresOverwriteConfirmation: false
         };
     }
@@ -328,6 +364,7 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
             missingSeeds,
             patches: [],
             previewRows: [],
+            poolProtectionWarnings: [],
             requiresOverwriteConfirmation: false
         };
     }
@@ -342,6 +379,7 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
     };
     const patches = collectTournamentAdvancementPatches(games, { poolStandings });
     const previewRows = buildTournamentAdvancementPreviewRows(games, patches);
+    const poolProtectionWarnings = buildPoolProtectionWarningRows(games, patches);
 
     return {
         skipped: false,
@@ -351,6 +389,7 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
         missingSeeds: [],
         patches,
         previewRows,
+        poolProtectionWarnings,
         requiresOverwriteConfirmation: previewRows.some((row) => row.overwritesExistingTeam),
         poolStandings
     };

--- a/tests/unit/edit-schedule-tournament.test.js
+++ b/tests/unit/edit-schedule-tournament.test.js
@@ -72,6 +72,8 @@ describe('edit schedule tournament wiring', () => {
     expect(source).toContain('class="advance-tournament-pool-btn');
     expect(source).toContain('data-advance-tournament-pool');
     expect(source).toContain('formatTournamentAdvancementPreviewMessage');
+    expect(source).toContain('Pool-protection warnings:');
+    expect(source).toContain('poolProtectionWarnings');
     expect(source).toContain('buildFinalizedTournamentAdvancementPlan');
     expect(source).toContain("document.querySelectorAll('.advance-tournament-pool-btn').forEach(btn => {");
     expect(source).toContain('let allTeamGamesCache = {};');

--- a/tests/unit/tournament-brackets.test.js
+++ b/tests/unit/tournament-brackets.test.js
@@ -314,6 +314,111 @@ describe('tournament bracket helpers', () => {
     ]);
   });
 
+
+  it('warns when advancement creates a same-pool initial matchup', () => {
+    const games = [
+      {
+        id: 'gold-semi',
+        competitionType: 'tournament',
+        tournament: {
+          divisionName: '10U Gold',
+          slotAssignments: {
+            home: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 1 },
+            away: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 2 }
+          }
+        }
+      }
+    ];
+
+    const plan = planTournamentPoolAdvancement(games, {
+      poolName: '10U Gold • Pool A',
+      ranking: ['Tigers', 'Lions']
+    });
+
+    expect(plan.skipped).toBe(false);
+    expect(plan.poolProtectionWarnings).toEqual([
+      {
+        gameId: 'gold-semi',
+        poolName: '10U Gold • Pool A',
+        homeTeamName: 'Tigers',
+        awayTeamName: 'Lions',
+        homeSourceLabel: '10U Gold • Pool A #1',
+        awaySourceLabel: '10U Gold • Pool A #2',
+        warning: 'Tigers and Lions both advanced from 10U Gold • Pool A.'
+      }
+    ]);
+  });
+
+  it('does not warn when advancement creates a cross-pool matchup', () => {
+    const games = [
+      {
+        id: 'gold-semi',
+        competitionType: 'tournament',
+        tournament: {
+          divisionName: '10U Gold',
+          slotAssignments: {
+            home: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 1 },
+            away: { sourceType: 'pool_seed', poolName: 'Pool B', seed: 1 }
+          },
+          resolved: {
+            homeLabel: '10U Gold • Pool A #1',
+            awayLabel: '10U Gold • Pool B #1',
+            homeTeamName: null,
+            awayTeamName: null,
+            matchupLabel: '10U Gold • Pool A #1 vs 10U Gold • Pool B #1',
+            ready: false
+          }
+        }
+      }
+    ];
+
+    const plan = planTournamentPoolAdvancement(games, {
+      poolName: '10U Gold • Pool A',
+      ranking: ['Tigers'],
+      poolStandings: {
+        '10U Gold • Pool B': [{ teamName: 'Bears' }]
+      }
+    });
+
+    expect(plan.skipped).toBe(false);
+    expect(plan.poolProtectionWarnings).toEqual([]);
+  });
+
+  it('does not warn for same-named pools in different divisions', () => {
+    const games = [
+      {
+        id: 'gold-semi',
+        competitionType: 'tournament',
+        tournament: {
+          bracketName: 'Gold',
+          slotAssignments: {
+            home: { sourceType: 'pool_seed', divisionName: '10U Gold', poolName: 'Pool A', seed: 1 },
+            away: { sourceType: 'pool_seed', divisionName: '12U Gold', poolName: 'Pool A', seed: 1 }
+          },
+          resolved: {
+            homeLabel: '10U Gold • Pool A #1',
+            awayLabel: '12U Gold • Pool A #1',
+            homeTeamName: null,
+            awayTeamName: null,
+            matchupLabel: '10U Gold • Pool A #1 vs 12U Gold • Pool A #1',
+            ready: false
+          }
+        }
+      }
+    ];
+
+    const plan = planTournamentPoolAdvancement(games, {
+      poolName: '10U Gold • Pool A',
+      ranking: ['Tigers'],
+      poolStandings: {
+        '12U Gold • Pool A': [{ teamName: 'Bears' }]
+      }
+    });
+
+    expect(plan.skipped).toBe(false);
+    expect(plan.poolProtectionWarnings).toEqual([]);
+  });
+
   it('skips pool advancement when a required seed is missing', () => {
     const games = [
       {


### PR DESCRIPTION
Closes #1146

## Summary
- Added pool-protection warning detection to tournament pool advancement plans when initial bracket slots would match teams from the same source pool.
- Surfaced those warnings in the admin advancement preview without blocking or changing the save flow.
- Preserved overwrite confirmation behavior independently from pool-protection warnings.

## Tests
- `npx vitest run tests/unit/tournament-brackets.test.js tests/unit/edit-schedule-tournament.test.js`