### PR TITLE
Persist pool-protection override notes

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -926,7 +926,7 @@
         import { Timestamp, deleteField, auth } from "./js/firebase.js?v=14";
         import { getApp } from './js/vendor/firebase-app.js';
         import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
-        import { buildPoolStandingsIndex, collectTournamentAdvancementPatches, collectTournamentPoolSeeds, describeTournamentSource, planTournamentPoolAdvancement } from './js/tournament-brackets.js?v=1';
+        import { buildPoolStandingsIndex, collectTournamentAdvancementPatches, collectTournamentPoolSeeds, describeTournamentSource, planTournamentPoolAdvancement } from './js/tournament-brackets.js?v=2';
         import { normalizeScheduleNotificationSettings, describeScheduleReminderWindow, buildScheduleNotificationMetadata, buildScheduleChangeMessage, buildScheduleNotificationTargets, postScheduleNotificationTargets, buildRsvpReminderMessage, sendPublicRsvpReminderEmails, buildAvailabilityReminderRecipients, buildAvailabilityReminderEmailPreview } from './js/schedule-notifications.js?v=5';
         import { buildTournamentPoolStandings, buildTournamentPoolOverrideKey } from './js/tournament-standings.js?v=3';
         import { SCHEDULE_CSV_IMPORT_FIELDS, buildScheduleImportPreview, inferScheduleCsvMapping, normalizeScheduleImportDraft, parseCsvText } from './js/schedule-csv-import.js?v=2';
@@ -1126,7 +1126,10 @@
 
             if (!confirm(formatTournamentAdvancementPreviewMessage({ poolName }, plan))) return;
 
-            await applyTournamentAdvancementPatches(currentTeamId, plan.patches, games);
+            const poolProtectionOverride = promptTournamentPoolProtectionOverride(plan);
+            if (plan.requiresPoolProtectionOverride && !poolProtectionOverride) return;
+
+            await applyTournamentAdvancementPatches(currentTeamId, buildTournamentAdvancementPatchesForSave(plan, poolProtectionOverride), games);
             await loadSchedule();
             alert(`Advanced ${poolName} into ${plan.patches.length} tournament game${plan.patches.length === 1 ? '' : 's'}.`);
         }
@@ -1139,10 +1142,12 @@
             const awaySource = tournament.slotAssignments?.away || {};
             const matchupLabel = resolved.matchupLabel || `${describeTournamentSource(homeSource)} vs ${describeTournamentSource(awaySource)}`;
             const bracketBits = [tournament.bracketName, tournament.roundName, tournament.poolName].filter(Boolean).join(' • ');
+            const poolProtectionOverride = tournament.poolProtectionOverride || null;
             return `
                 <div class="mt-2 rounded-md border border-indigo-100 bg-indigo-50 px-3 py-2 text-xs text-indigo-900">
                     ${bracketBits ? `<div class="font-semibold">${escapeHtml(bracketBits)}</div>` : ''}
                     <div>${escapeHtml(matchupLabel)}</div>
+                    ${poolProtectionOverride ? `<div class="mt-1 text-amber-700">Pool-protection conflict intentionally overridden: ${escapeHtml(poolProtectionOverride.note || 'audit note saved')}</div>` : ''}
                 </div>
             `;
         }
@@ -1245,7 +1250,8 @@
             if (!plan.patches?.length) return 'Bracket slots already match this final ranking.';
             const slotCount = plan.previewRows?.length || plan.patches.length;
             const overwriteText = plan.requiresOverwriteConfirmation ? ' Existing assignments will require confirmation.' : '';
-            return `${slotCount} bracket slot update${slotCount === 1 ? '' : 's'} ready for preview.${overwriteText}`;
+            const poolProtectionText = plan.requiresPoolProtectionOverride ? ' Same-pool conflicts require an override note.' : '';
+            return `${slotCount} bracket slot update${slotCount === 1 ? '' : 's'} ready for preview.${overwriteText}${poolProtectionText}`;
         }
 
         function formatTournamentAdvancementPreviewMessage(pool = {}, plan = {}) {
@@ -1260,10 +1266,56 @@
             const fallbackLines = !previewLines.length
                 ? (plan.patches || []).map((patch) => `• ${patch.gameId}`)
                 : [];
+            const poolProtectionConflicts = Array.isArray(plan.poolProtectionConflicts) ? plan.poolProtectionConflicts : [];
+            const poolProtectionLines = poolProtectionConflicts.slice(0, 10).map((conflict) => `• ${conflict.gameId}: ${conflict.homeTeamName || 'TBD'} vs ${conflict.awayTeamName || 'TBD'} both from ${conflict.poolName || 'the same pool'}`);
+            const poolProtectionWarning = poolProtectionLines.length
+                ? `Pool-protection conflicts require an audit note before saving:\n${poolProtectionLines.join('\n')}\n\n`
+                : '';
             const warning = plan.requiresOverwriteConfirmation
                 ? 'Existing bracket assignments will be overwritten.\n\n'
                 : '';
-            return `${warning}Preview bracket advancement for ${pool.poolName || plan.poolName}:\n\n${[...previewLines, ...fallbackLines].join('\n')}${overflowText}\n\nSave ${plan.patches?.length || 0} tournament game update${(plan.patches?.length || 0) === 1 ? '' : 's'}?`;
+            return `${warning}${poolProtectionWarning}Preview bracket advancement for ${pool.poolName || plan.poolName}:\n\n${[...previewLines, ...fallbackLines].join('\n')}${overflowText}\n\nSave ${plan.patches?.length || 0} tournament game update${(plan.patches?.length || 0) === 1 ? '' : 's'}?`;
+        }
+
+        function promptTournamentPoolProtectionOverride(plan = {}) {
+            const conflicts = Array.isArray(plan.poolProtectionConflicts) ? plan.poolProtectionConflicts : [];
+            if (!conflicts.length) return null;
+
+            const conflictSummary = conflicts.slice(0, 5).map((conflict) => `• ${conflict.gameId}: ${conflict.homeTeamName || 'TBD'} vs ${conflict.awayTeamName || 'TBD'} from ${conflict.poolName || 'the same pool'}`).join('\n');
+            while (true) {
+                const noteInput = prompt(`Same-pool bracket conflicts are being overridden. Enter a short audit note before saving.\n\n${conflictSummary}`, 'Approved by tournament director');
+                if (noteInput === null) return null;
+                const note = String(noteInput || '').trim();
+                if (note) {
+                    return {
+                        note,
+                        timestamp: Timestamp.now(),
+                        overriddenBy: {
+                            userId: currentUser?.uid || null,
+                            name: currentUser?.displayName || null,
+                            email: currentUser?.email || null
+                        },
+                        conflicts
+                    };
+                }
+                alert('Enter an audit note to override same-pool bracket conflicts.');
+            }
+        }
+
+        function buildTournamentAdvancementPatchesForSave(plan = {}, poolProtectionOverride = null) {
+            const patches = Array.isArray(plan.patches) ? plan.patches : [];
+            if (!poolProtectionOverride) return patches;
+            const conflictGameIds = new Set((poolProtectionOverride.conflicts || []).map((conflict) => conflict.gameId).filter(Boolean));
+            return patches.map((patch) => {
+                if (!conflictGameIds.has(patch.gameId)) return patch;
+                return {
+                    ...patch,
+                    tournament: {
+                        ...(patch.tournament || {}),
+                        poolProtectionOverride
+                    }
+                };
+            });
         }
 
         function closeTournamentStandingsModal() {
@@ -1405,7 +1457,10 @@
 
             if (!confirm(formatTournamentAdvancementPreviewMessage(pool, plan))) return;
 
-            await applyTournamentAdvancementPatches(currentTeamId, plan.patches, tournamentAdvancementGames);
+            const poolProtectionOverride = promptTournamentPoolProtectionOverride(plan);
+            if (plan.requiresPoolProtectionOverride && !poolProtectionOverride) return;
+
+            await applyTournamentAdvancementPatches(currentTeamId, buildTournamentAdvancementPatchesForSave(plan, poolProtectionOverride), tournamentAdvancementGames);
             await loadSchedule();
             alert(`Advanced ${pool.poolName} into ${plan.patches.length} tournament game${plan.patches.length === 1 ? '' : 's'}.`);
         }

--- a/js/tournament-brackets.js
+++ b/js/tournament-brackets.js
@@ -175,6 +175,99 @@ function resolvedStatesEqual(current = {}, next = {}) {
         && current.ready === next.ready;
 }
 
+function resolveTournamentSourcePoolProtection(source = {}, gamesById, poolStandings, memo, context = {}) {
+    const sourceType = normalizeString(source.sourceType) || 'team';
+    if (sourceType === 'pool_seed') {
+        const sourcePoolName = getTournamentPoolLabel(source, context);
+        const teamName = getPoolSeedTeamName(poolStandings, source, context);
+        return {
+            teamName,
+            sourcePoolName,
+            sourceLabel: describeTournamentSource(source, context),
+            ready: !!teamName
+        };
+    }
+    if (sourceType === 'game_result') {
+        const upstreamId = normalizeString(source.gameId);
+        const upstream = upstreamId ? gamesById.get(upstreamId) : null;
+        if (!upstream) {
+            return {
+                teamName: null,
+                sourcePoolName: null,
+                sourceLabel: describeTournamentSource(source, context),
+                ready: false
+            };
+        }
+
+        const upstreamProtection = resolveTournamentGamePoolProtection(upstream, gamesById, poolStandings, memo);
+        const outcome = normalizeString(source.outcome) || 'winner';
+        const side = outcome === 'loser' ? getTournamentLoser(upstream) : getTournamentWinner(upstream);
+        if (!side) {
+            return {
+                teamName: null,
+                sourcePoolName: null,
+                sourceLabel: describeTournamentSource(source, context),
+                ready: false
+            };
+        }
+        return side === 'home' ? upstreamProtection.home : upstreamProtection.away;
+    }
+
+    const teamName = normalizeString(source.teamName);
+    return {
+        teamName,
+        sourcePoolName: null,
+        sourceLabel: describeTournamentSource(source, context),
+        ready: !!teamName
+    };
+}
+
+function resolveTournamentGamePoolProtection(game = {}, gamesById, poolStandings = {}, memo = new Map()) {
+    const gameId = normalizeString(game.id);
+    if (gameId && memo.has(gameId)) return memo.get(gameId);
+
+    const placeholder = {
+        home: { teamName: null, sourcePoolName: null, sourceLabel: 'TBD', ready: false },
+        away: { teamName: null, sourcePoolName: null, sourceLabel: 'TBD', ready: false }
+    };
+    if (gameId) memo.set(gameId, placeholder);
+
+    const tournament = game?.tournament || {};
+    const slotAssignments = tournament.slotAssignments || {};
+    const resolved = {
+        home: resolveTournamentSourcePoolProtection(slotAssignments.home || {}, gamesById, poolStandings, memo, tournament),
+        away: resolveTournamentSourcePoolProtection(slotAssignments.away || {}, gamesById, poolStandings, memo, tournament)
+    };
+
+    if (gameId) memo.set(gameId, resolved);
+    return resolved;
+}
+
+function collectPoolProtectionConflicts(games = [], poolStandings = {}) {
+    const gamesById = new Map((games || []).filter((game) => game?.id).map((game) => [game.id, game]));
+    const memo = new Map();
+
+    return (games || [])
+        .filter((game) => String(game?.competitionType || '').toLowerCase() === 'tournament' && game?.tournament?.slotAssignments)
+        .map((game) => {
+            const protection = resolveTournamentGamePoolProtection(game, gamesById, poolStandings, memo);
+            const homePool = normalizeString(protection.home?.sourcePoolName);
+            const awayPool = normalizeString(protection.away?.sourcePoolName);
+            const homeTeamName = normalizeString(protection.home?.teamName);
+            const awayTeamName = normalizeString(protection.away?.teamName);
+            if (!homePool || homePool !== awayPool || !homeTeamName || !awayTeamName) return null;
+            return {
+                gameId: game.id,
+                poolName: homePool,
+                homeTeamName,
+                awayTeamName,
+                homeSourceLabel: protection.home?.sourceLabel || 'Home slot',
+                awaySourceLabel: protection.away?.sourceLabel || 'Away slot'
+            };
+        })
+        .filter(Boolean);
+}
+
 export function buildPoolStandingsIndex(games = []) {
     const poolStandings = {};
 
@@ -288,7 +381,9 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
             missingSeeds: [],
             patches: [],
             previewRows: [],
-            requiresOverwriteConfirmation: false
+            requiresOverwriteConfirmation: false,
+            poolProtectionConflicts: [],
+            requiresPoolProtectionOverride: false
         };
     }
 
@@ -301,7 +396,9 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
             missingSeeds: [],
             patches: [],
             previewRows: [],
-            requiresOverwriteConfirmation: false
+            requiresOverwriteConfirmation: false,
+            poolProtectionConflicts: [],
+            requiresPoolProtectionOverride: false
         };
     }
 
@@ -314,7 +411,9 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
             missingSeeds: requiredSeeds,
             patches: [],
             previewRows: [],
-            requiresOverwriteConfirmation: false
+            requiresOverwriteConfirmation: false,
+            poolProtectionConflicts: [],
+            requiresPoolProtectionOverride: false
         };
     }
 
@@ -328,7 +427,9 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
             missingSeeds,
             patches: [],
             previewRows: [],
-            requiresOverwriteConfirmation: false
+            requiresOverwriteConfirmation: false,
+            poolProtectionConflicts: [],
+            requiresPoolProtectionOverride: false
         };
     }
 
@@ -342,6 +443,7 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
     };
     const patches = collectTournamentAdvancementPatches(games, { poolStandings });
     const previewRows = buildTournamentAdvancementPreviewRows(games, patches);
+    const poolProtectionConflicts = collectPoolProtectionConflicts(games, poolStandings);
 
     return {
         skipped: false,
@@ -352,6 +454,8 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
         patches,
         previewRows,
         requiresOverwriteConfirmation: previewRows.some((row) => row.overwritesExistingTeam),
+        poolProtectionConflicts,
+        requiresPoolProtectionOverride: poolProtectionConflicts.length > 0,
         poolStandings
     };
 }

--- a/tests/unit/edit-schedule-tournament.test.js
+++ b/tests/unit/edit-schedule-tournament.test.js
@@ -81,9 +81,22 @@ describe('edit schedule tournament wiring', () => {
     expect(source).toContain('allTeamGamesCache[event.id] = eventRecord;');
     expect(source).toContain('const games = Object.values(allTeamGamesCache).filter((candidate) => candidate?.id);');
     expect(source).toContain('const plan = planTournamentPoolAdvancement(games, {');
-    expect(source).toContain('await applyTournamentAdvancementPatches(currentTeamId, plan.patches, games);');
-    expect(source).toContain('await applyTournamentAdvancementPatches(currentTeamId, plan.patches, tournamentAdvancementGames);');
+    expect(source).toContain('promptTournamentPoolProtectionOverride(plan);');
+    expect(source).toContain('buildTournamentAdvancementPatchesForSave(plan, poolProtectionOverride)');
+    expect(source).toContain('await applyTournamentAdvancementPatches(currentTeamId, buildTournamentAdvancementPatchesForSave(plan, poolProtectionOverride), games);');
+    expect(source).toContain('await applyTournamentAdvancementPatches(currentTeamId, buildTournamentAdvancementPatchesForSave(plan, poolProtectionOverride), tournamentAdvancementGames);');
     expect(source).toContain('Skipped advancement for ${poolName}. ${plan.reason}');
+  });
+
+  it('requires and displays pool-protection override audit notes', () => {
+    const source = readEditSchedule();
+
+    expect(source).toContain('function promptTournamentPoolProtectionOverride(plan = {})');
+    expect(source).toContain('Same-pool bracket conflicts are being overridden. Enter a short audit note before saving.');
+    expect(source).toContain('timestamp: Timestamp.now()');
+    expect(source).toContain('conflicts');
+    expect(source).toContain('Pool-protection conflict intentionally overridden:');
+    expect(source).toContain('Same-pool conflicts require an override note.');
   });
 
   it('wires persistence helpers for saving and clearing pool ranking overrides', () => {

--- a/tests/unit/tournament-brackets.test.js
+++ b/tests/unit/tournament-brackets.test.js
@@ -436,6 +436,77 @@ describe('tournament bracket helpers', () => {
     ]);
   });
 
+  it('flags same-pool bracket advancement conflicts for override audit notes', () => {
+    const games = [
+      {
+        id: 'semi-1',
+        competitionType: 'tournament',
+        tournament: {
+          slotAssignments: {
+            home: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 1 },
+            away: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 2 }
+          }
+        }
+      },
+      {
+        id: 'semi-2',
+        competitionType: 'tournament',
+        tournament: {
+          slotAssignments: {
+            home: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 3 },
+            away: { sourceType: 'pool_seed', poolName: 'Pool B', seed: 1 }
+          }
+        }
+      }
+    ];
+
+    const plan = planTournamentPoolAdvancement(games, {
+      poolName: 'Pool A',
+      ranking: ['Tigers', 'Lions', 'Bears'],
+      poolStandings: {
+        'Pool B': [{ teamName: 'Wolves' }]
+      }
+    });
+
+    expect(plan.requiresPoolProtectionOverride).toBe(true);
+    expect(plan.poolProtectionConflicts).toEqual([
+      {
+        gameId: 'semi-1',
+        poolName: 'Pool A',
+        homeTeamName: 'Tigers',
+        awayTeamName: 'Lions',
+        homeSourceLabel: 'Pool A #1',
+        awaySourceLabel: 'Pool A #2'
+      }
+    ]);
+  });
+
+  it('does not require pool-protection override metadata without same-pool conflicts', () => {
+    const games = [
+      {
+        id: 'semi-1',
+        competitionType: 'tournament',
+        tournament: {
+          slotAssignments: {
+            home: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 1 },
+            away: { sourceType: 'pool_seed', poolName: 'Pool B', seed: 1 }
+          }
+        }
+      }
+    ];
+
+    const plan = planTournamentPoolAdvancement(games, {
+      poolName: 'Pool A',
+      ranking: ['Tigers'],
+      poolStandings: {
+        'Pool B': [{ teamName: 'Wolves' }]
+      }
+    });
+
+    expect(plan.requiresPoolProtectionOverride).toBe(false);
+    expect(plan.poolProtectionConflicts).toEqual([]);
+  });
+
   it('keeps finalized pool-seed slots stable after advancement is saved', () => {
     const games = [
       {


### PR DESCRIPTION
Closes #1148

## Summary
- Detect same-pool bracket advancement conflicts in tournament pool advancement plans.
- Require admins to enter a short audit note before saving same-pool conflict overrides.
- Persist override note, timestamp, admin identity, and conflict details on affected tournament games, then surface the override in the schedule/bracket summary.

## Tests
- `npx vitest run tests/unit/tournament-brackets.test.js tests/unit/edit-schedule-tournament.test.js`