### PR TITLE
Require pool protection override for advancement

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -1125,6 +1125,7 @@
             }
 
             if (!confirm(formatTournamentAdvancementPreviewMessage({ poolName }, plan))) return;
+            if (plan.requiresPoolProtectionOverride && !confirm(formatTournamentPoolProtectionOverrideMessage(plan))) return;
 
             await applyTournamentAdvancementPatches(currentTeamId, plan.patches, games);
             await loadSchedule();
@@ -1245,7 +1246,8 @@
             if (!plan.patches?.length) return 'Bracket slots already match this final ranking.';
             const slotCount = plan.previewRows?.length || plan.patches.length;
             const overwriteText = plan.requiresOverwriteConfirmation ? ' Existing assignments will require confirmation.' : '';
-            return `${slotCount} bracket slot update${slotCount === 1 ? '' : 's'} ready for preview.${overwriteText}`;
+            const poolProtectionText = plan.requiresPoolProtectionOverride ? ' Same-pool conflicts require override confirmation.' : '';
+            return `${slotCount} bracket slot update${slotCount === 1 ? '' : 's'} ready for preview.${overwriteText}${poolProtectionText}`;
         }
 
         function formatTournamentAdvancementPreviewMessage(pool = {}, plan = {}) {
@@ -1260,10 +1262,25 @@
             const fallbackLines = !previewLines.length
                 ? (plan.patches || []).map((patch) => `• ${patch.gameId}`)
                 : [];
-            const warning = plan.requiresOverwriteConfirmation
+            const overwriteWarning = plan.requiresOverwriteConfirmation
                 ? 'Existing bracket assignments will be overwritten.\n\n'
                 : '';
-            return `${warning}Preview bracket advancement for ${pool.poolName || plan.poolName}:\n\n${[...previewLines, ...fallbackLines].join('\n')}${overflowText}\n\nSave ${plan.patches?.length || 0} tournament game update${(plan.patches?.length || 0) === 1 ? '' : 's'}?`;
+            const poolProtectionWarning = plan.requiresPoolProtectionOverride
+                ? 'Same-pool matchups were detected and will require a separate override confirmation before saving.\n\n'
+                : '';
+            return `${overwriteWarning}${poolProtectionWarning}Preview bracket advancement for ${pool.poolName || plan.poolName}:\n\n${[...previewLines, ...fallbackLines].join('\n')}${overflowText}\n\nSave ${plan.patches?.length || 0} tournament game update${(plan.patches?.length || 0) === 1 ? '' : 's'}?`;
+        }
+
+        function formatTournamentPoolProtectionOverrideMessage(plan = {}) {
+            const conflicts = Array.isArray(plan.poolProtectionConflicts) ? plan.poolProtectionConflicts : [];
+            const conflictLines = conflicts.slice(0, 20).map((conflict) => {
+                const matchup = conflict.matchupLabel || `${conflict.homeTeamName || 'TBD'} vs ${conflict.awayTeamName || 'TBD'}`;
+                return `• ${conflict.gameId}: ${matchup} from ${conflict.poolName || 'the same pool'}`;
+            });
+            const overflowText = conflicts.length > conflictLines.length
+                ? `\n• ${conflicts.length - conflictLines.length} more same-pool matchup${conflicts.length - conflictLines.length === 1 ? '' : 's'}`
+                : '';
+            return `Pool-protection conflict detected. These same-pool matchup${conflicts.length === 1 ? '' : 's'} will be saved only if you intentionally override the protection warning:\n\n${conflictLines.join('\n')}${overflowText}\n\nOverride pool protection and continue saving?`;
         }
 
         function closeTournamentStandingsModal() {
@@ -1404,6 +1421,7 @@
             }
 
             if (!confirm(formatTournamentAdvancementPreviewMessage(pool, plan))) return;
+            if (plan.requiresPoolProtectionOverride && !confirm(formatTournamentPoolProtectionOverrideMessage(plan))) return;
 
             await applyTournamentAdvancementPatches(currentTeamId, plan.patches, tournamentAdvancementGames);
             await loadSchedule();
@@ -1442,7 +1460,7 @@
                                             <div class="text-sm font-semibold text-gray-900">${escapeHtml(pool.poolName)}</div>
                                             <div class="text-xs text-gray-500">${pool.gameCount} completed pool game${pool.gameCount === 1 ? '' : 's'}</div>
                                             ${pool.isOverridden && pool.override ? `<div class="text-xs text-amber-700 mt-1">${escapeHtml(formatTournamentOverrideAudit(pool.override))}</div>` : '<div class="text-xs text-gray-500 mt-1">Using computed standings</div>'}
-                                            <div class="text-xs ${advancementPlan.skipped ? 'text-slate-500' : (advancementPlan.requiresOverwriteConfirmation ? 'text-amber-700' : 'text-emerald-700')} mt-1">${escapeHtml(formatTournamentAdvancementStatus(advancementPlan))}</div>
+                                            <div class="text-xs ${advancementPlan.skipped ? 'text-slate-500' : ((advancementPlan.requiresOverwriteConfirmation || advancementPlan.requiresPoolProtectionOverride) ? 'text-amber-700' : 'text-emerald-700')} mt-1">${escapeHtml(formatTournamentAdvancementStatus(advancementPlan))}</div>
                                         </div>
                                         <div class="flex flex-col gap-2">
                                             <button type="button" data-edit-tournament-pool="${escapeHtml(poolKey)}" class="px-3 py-1.5 rounded bg-indigo-100 text-indigo-700 text-sm font-medium hover:bg-indigo-200">Edit final ranking</button>

--- a/js/tournament-brackets.js
+++ b/js/tournament-brackets.js
@@ -166,6 +166,91 @@ export function resolveTournamentGame(game = {}, gamesByIdInput, poolStandings =
     return resolved;
 }
 
+
+function resolveGameResultSlotSource(gamesById, source, poolStandings, memo, context = {}) {
+    const upstreamId = normalizeString(source.gameId);
+    if (!upstreamId) return { teamName: null, sourcePoolName: null, ready: false };
+    const upstream = gamesById.get(upstreamId);
+    if (!upstream) return { teamName: null, sourcePoolName: null, ready: false };
+
+    const upstreamResolved = resolveTournamentGameSources(upstream, gamesById, poolStandings, memo);
+    const outcome = normalizeString(source.outcome) || 'winner';
+    const side = outcome === 'loser' ? getTournamentLoser(upstream) : getTournamentWinner(upstream);
+    if (!side) return { teamName: null, sourcePoolName: null, ready: false };
+
+    return side === 'home' ? upstreamResolved.home : upstreamResolved.away;
+}
+
+function resolveTournamentSourceWithPool(source = {}, gamesById, poolStandings, memo, context = {}) {
+    const sourceType = normalizeString(source.sourceType) || 'team';
+    if (sourceType === 'pool_seed') {
+        const teamName = getPoolSeedTeamName(poolStandings, source, context);
+        return {
+            teamName,
+            sourcePoolName: getTournamentPoolLabel(source, context),
+            ready: !!teamName
+        };
+    }
+    if (sourceType === 'game_result') {
+        return resolveGameResultSlotSource(gamesById, source, poolStandings, memo, context);
+    }
+    return {
+        teamName: normalizeString(source.teamName),
+        sourcePoolName: null,
+        ready: !!normalizeString(source.teamName)
+    };
+}
+
+function resolveTournamentGameSources(game = {}, gamesByIdInput, poolStandings = {}, memo = new Map()) {
+    const gameId = normalizeString(game.id);
+    if (gameId && memo.has(gameId)) return memo.get(gameId);
+
+    const placeholder = {
+        home: { teamName: null, sourcePoolName: null, ready: false },
+        away: { teamName: null, sourcePoolName: null, ready: false }
+    };
+    if (gameId) memo.set(gameId, placeholder);
+
+    const tournament = game?.tournament || {};
+    const slotAssignments = tournament.slotAssignments || {};
+    const gamesById = gamesByIdInput instanceof Map
+        ? gamesByIdInput
+        : new Map(Array.isArray(gamesByIdInput) ? gamesByIdInput.map((item) => [item.id, item]) : []);
+    const resolved = {
+        home: resolveTournamentSourceWithPool(slotAssignments.home || {}, gamesById, poolStandings, memo, tournament),
+        away: resolveTournamentSourceWithPool(slotAssignments.away || {}, gamesById, poolStandings, memo, tournament)
+    };
+
+    if (gameId) memo.set(gameId, resolved);
+    return resolved;
+}
+
+function collectPoolProtectionConflicts(games = [], poolStandings = {}, gameIds = null) {
+    const eligibleGameIds = gameIds instanceof Set ? gameIds : null;
+    const gamesById = new Map((games || []).filter((game) => game?.id).map((game) => [game.id, game]));
+    const memo = new Map();
+
+    return (games || [])
+        .filter((game) => String(game?.competitionType || '').toLowerCase() === 'tournament' && game?.tournament?.slotAssignments)
+        .filter((game) => !eligibleGameIds || eligibleGameIds.has(game.id))
+        .map((game) => {
+            const sources = resolveTournamentGameSources(game, gamesById, poolStandings, memo);
+            const homePoolName = normalizeString(sources.home?.sourcePoolName);
+            const awayPoolName = normalizeString(sources.away?.sourcePoolName);
+            const homeTeamName = normalizeString(sources.home?.teamName);
+            const awayTeamName = normalizeString(sources.away?.teamName);
+            if (!homePoolName || homePoolName !== awayPoolName || !homeTeamName || !awayTeamName) return null;
+            return {
+                gameId: game.id,
+                poolName: homePoolName,
+                homeTeamName,
+                awayTeamName,
+                matchupLabel: `${homeTeamName} vs ${awayTeamName}`
+            };
+        })
+        .filter(Boolean);
+}
+
 function resolvedStatesEqual(current = {}, next = {}) {
     return current.homeLabel === next.homeLabel
         && current.awayLabel === next.awayLabel
@@ -288,7 +373,9 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
             missingSeeds: [],
             patches: [],
             previewRows: [],
-            requiresOverwriteConfirmation: false
+            requiresOverwriteConfirmation: false,
+            requiresPoolProtectionOverride: false,
+            poolProtectionConflicts: []
         };
     }
 
@@ -301,7 +388,9 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
             missingSeeds: [],
             patches: [],
             previewRows: [],
-            requiresOverwriteConfirmation: false
+            requiresOverwriteConfirmation: false,
+            requiresPoolProtectionOverride: false,
+            poolProtectionConflicts: []
         };
     }
 
@@ -314,7 +403,9 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
             missingSeeds: requiredSeeds,
             patches: [],
             previewRows: [],
-            requiresOverwriteConfirmation: false
+            requiresOverwriteConfirmation: false,
+            requiresPoolProtectionOverride: false,
+            poolProtectionConflicts: []
         };
     }
 
@@ -328,7 +419,9 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
             missingSeeds,
             patches: [],
             previewRows: [],
-            requiresOverwriteConfirmation: false
+            requiresOverwriteConfirmation: false,
+            requiresPoolProtectionOverride: false,
+            poolProtectionConflicts: []
         };
     }
 
@@ -342,6 +435,7 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
     };
     const patches = collectTournamentAdvancementPatches(games, { poolStandings });
     const previewRows = buildTournamentAdvancementPreviewRows(games, patches);
+    const poolProtectionConflicts = collectPoolProtectionConflicts(games, poolStandings, new Set(patches.map((patch) => patch.gameId)));
 
     return {
         skipped: false,
@@ -352,6 +446,8 @@ export function planTournamentPoolAdvancement(games = [], options = {}) {
         patches,
         previewRows,
         requiresOverwriteConfirmation: previewRows.some((row) => row.overwritesExistingTeam),
+        requiresPoolProtectionOverride: poolProtectionConflicts.length > 0,
+        poolProtectionConflicts,
         poolStandings
     };
 }

--- a/tests/unit/edit-schedule-tournament.test.js
+++ b/tests/unit/edit-schedule-tournament.test.js
@@ -72,6 +72,9 @@ describe('edit schedule tournament wiring', () => {
     expect(source).toContain('class="advance-tournament-pool-btn');
     expect(source).toContain('data-advance-tournament-pool');
     expect(source).toContain('formatTournamentAdvancementPreviewMessage');
+    expect(source).toContain('formatTournamentPoolProtectionOverrideMessage');
+    expect(source).toContain('plan.requiresPoolProtectionOverride && !confirm(formatTournamentPoolProtectionOverrideMessage(plan))');
+    expect(source).toContain('Same-pool matchups were detected and will require a separate override confirmation before saving.');
     expect(source).toContain('buildFinalizedTournamentAdvancementPlan');
     expect(source).toContain("document.querySelectorAll('.advance-tournament-pool-btn').forEach(btn => {");
     expect(source).toContain('let allTeamGamesCache = {};');

--- a/tests/unit/tournament-brackets.test.js
+++ b/tests/unit/tournament-brackets.test.js
@@ -436,6 +436,124 @@ describe('tournament bracket helpers', () => {
     ]);
   });
 
+
+  it('requires pool-protection override when advancement creates same-pool matchup', () => {
+    const games = [
+      {
+        id: 'semi-1',
+        competitionType: 'tournament',
+        tournament: {
+          slotAssignments: {
+            home: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 1 },
+            away: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 2 }
+          },
+          resolved: {
+            homeLabel: 'Pool A #1',
+            awayLabel: 'Pool A #2',
+            homeTeamName: null,
+            awayTeamName: null,
+            matchupLabel: 'Pool A #1 vs Pool A #2',
+            ready: false
+          }
+        }
+      }
+    ];
+
+    const plan = planTournamentPoolAdvancement(games, {
+      poolName: 'Pool A',
+      ranking: ['Tigers', 'Lions']
+    });
+
+    expect(plan.skipped).toBe(false);
+    expect(plan.requiresPoolProtectionOverride).toBe(true);
+    expect(plan.poolProtectionConflicts).toEqual([
+      {
+        gameId: 'semi-1',
+        poolName: 'Pool A',
+        homeTeamName: 'Tigers',
+        awayTeamName: 'Lions',
+        matchupLabel: 'Tigers vs Lions'
+      }
+    ]);
+  });
+
+  it('does not require pool-protection override for cross-pool matchups', () => {
+    const games = [
+      {
+        id: 'semi-1',
+        competitionType: 'tournament',
+        tournament: {
+          slotAssignments: {
+            home: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 1 },
+            away: { sourceType: 'pool_seed', poolName: 'Pool B', seed: 1 }
+          },
+          resolved: {
+            homeLabel: 'Pool A #1',
+            awayLabel: 'Bears',
+            homeTeamName: null,
+            awayTeamName: 'Bears',
+            matchupLabel: 'Pool A #1 vs Bears',
+            ready: false
+          }
+        }
+      }
+    ];
+
+    const plan = planTournamentPoolAdvancement(games, {
+      poolName: 'Pool A',
+      ranking: ['Tigers']
+    });
+
+    expect(plan.skipped).toBe(false);
+    expect(plan.requiresPoolProtectionOverride).toBe(false);
+    expect(plan.poolProtectionConflicts).toEqual([]);
+  });
+
+  it('carries source pools through game-result slots for pool-protection conflicts', () => {
+    const games = [
+      {
+        id: 'semi-1',
+        competitionType: 'tournament',
+        status: 'completed',
+        homeScore: 2,
+        awayScore: 1,
+        tournament: {
+          slotAssignments: {
+            home: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 1 },
+            away: { sourceType: 'pool_seed', poolName: 'Pool B', seed: 1 }
+          }
+        }
+      },
+      {
+        id: 'final-1',
+        competitionType: 'tournament',
+        tournament: {
+          slotAssignments: {
+            home: { sourceType: 'game_result', gameId: 'semi-1', outcome: 'winner' },
+            away: { sourceType: 'pool_seed', poolName: 'Pool A', seed: 2 }
+          }
+        }
+      }
+    ];
+
+    const plan = planTournamentPoolAdvancement(games, {
+      poolName: 'Pool A',
+      ranking: ['Tigers', 'Lions'],
+      poolStandings: {
+        'Pool B': [{ teamName: 'Bears' }]
+      }
+    });
+
+    expect(plan.requiresPoolProtectionOverride).toBe(true);
+    expect(plan.poolProtectionConflicts).toEqual([
+      expect.objectContaining({
+        gameId: 'final-1',
+        poolName: 'Pool A',
+        matchupLabel: 'Tigers vs Lions'
+      })
+    ]);
+  });
+
   it('keeps finalized pool-seed slots stable after advancement is saved', () => {
     const games = [
       {


### PR DESCRIPTION
Closes #1147

## Summary
- Detect same-pool matchups created by bracket advancement, including through upstream game-result slots.
- Add a separate pool-protection override confirmation that names the affected matchup or matchups before saving.
- Preserve the existing overwrite preview confirmation, so admins must satisfy both confirmations when both risks exist.

## Tests
- `npx vitest run tests/unit/tournament-brackets.test.js tests/unit/edit-schedule-tournament.test.js --reporter=dot`