### PR TITLE
Restrict public team browsing

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -28,6 +28,15 @@ service cloud.firestore {
               isGlobalAdmin());
     }
 
+    function canReadTeamDocument(data) {
+      return data.isPublic == true ||
+             (isSignedIn() &&
+              (data.ownerId == request.auth.uid ||
+               (request.auth.token.email != null &&
+                request.auth.token.email.lower() in data.get('adminEmails', [])) ||
+               isGlobalAdmin()));
+    }
+
     function isSafeDocumentId(documentId) {
       return documentId is string &&
              documentId.size() > 0 &&
@@ -1050,9 +1059,9 @@ service cloud.firestore {
       allow write: if false;
     }
 
-    // Teams - only owner or admins can modify
+    // Teams - only public teams are readable by anonymous browse/listing paths.
     match /teams/{teamId} {
-      allow read: if true;  // Public teams for browsing
+      allow read: if canReadTeamDocument(resource.data);
       allow create: if isSignedIn() && request.resource.data.ownerId == request.auth.uid;
       allow update: if isTeamOwnerOrAdmin(teamId);
       allow delete: if isGlobalAdmin();

--- a/firestore.rules
+++ b/firestore.rules
@@ -29,7 +29,7 @@ service cloud.firestore {
     }
 
     function canReadTeamDocument(data) {
-      return data.isPublic == true ||
+      return (data.isPublic is bool && data.isPublic == true) ||
              (isSignedIn() &&
               (data.ownerId == request.auth.uid ||
                (request.auth.token.email != null &&

--- a/js/db.js
+++ b/js/db.js
@@ -480,9 +480,13 @@ import { resolveZip } from './utils.js?v=9'; // Import resolveZip
 // Teams
 export async function getTeams(options = {}) {
     const includeInactive = !!options.includeInactive;
+    const includePrivate = options.includePrivate === true || includeInactive;
     const locationFilter = String(options.locationFilter || '').trim().toLowerCase();
 
-    const q = query(collection(db, "teams"), orderBy("name"));
+    const teamsRef = collection(db, "teams");
+    const q = includePrivate
+        ? query(teamsRef, orderBy("name"))
+        : query(teamsRef, where("isPublic", "==", true), orderBy("name"));
     let teams = (await getDocs(q)).docs.map(doc => ({ id: doc.id, ...doc.data() }));
 
     // Apply location filter if provided

--- a/js/db.js
+++ b/js/db.js
@@ -482,14 +482,34 @@ import { resolveZip } from './utils.js?v=9'; // Import resolveZip
 // Teams
 export async function getTeams(options = {}) {
     const includeInactive = !!options.includeInactive;
+    const publicOnly = options.publicOnly === true;
     const includePrivate = options.includePrivate === true || includeInactive;
     const locationFilter = String(options.locationFilter || '').trim().toLowerCase();
 
     const teamsRef = collection(db, "teams");
-    const q = includePrivate
-        ? query(teamsRef, orderBy("name"))
-        : query(teamsRef, where("isPublic", "==", true), orderBy("name"));
-    let teams = (await getDocs(q)).docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    let teams = [];
+    if (includePrivate) {
+        teams = (await getDocs(query(teamsRef, orderBy("name")))).docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    } else if (publicOnly) {
+        teams = (await getDocs(query(teamsRef, where("isPublic", "==", true), orderBy("name")))).docs.map(doc => ({ id: doc.id, ...doc.data() }));
+    } else {
+        const currentUser = auth.currentUser;
+        const currentUserEmail = String(currentUser?.email || '').trim().toLowerCase();
+        const teamSnapshots = await Promise.all([
+            getDocs(query(teamsRef, where("isPublic", "==", true), orderBy("name"))),
+            currentUser?.uid
+                ? getDocs(query(teamsRef, where("ownerId", "==", currentUser.uid)))
+                : Promise.resolve({ docs: [] }),
+            currentUserEmail
+                ? getDocs(query(teamsRef, where("adminEmails", "array-contains", currentUserEmail)))
+                : Promise.resolve({ docs: [] })
+        ]);
+        const teamsById = new Map();
+        teamSnapshots.forEach((snapshot) => {
+            snapshot.docs.forEach(doc => teamsById.set(doc.id, { id: doc.id, ...doc.data() }));
+        });
+        teams = Array.from(teamsById.values()).sort((a, b) => String(a.name || '').localeCompare(String(b.name || '')));
+    }
 
     // Apply location filter if provided
     if (locationFilter) {

--- a/organization-schedule.html
+++ b/organization-schedule.html
@@ -925,7 +925,7 @@
             }
 
             accessibleTeams = currentUser.isAdmin === true
-                ? await getTeams()
+                ? await getTeams({ includePrivate: true })
                 : await getUserTeamsWithAccess(currentUser.uid, currentUser.email);
             organizationTeams = getOrganizationTeams({
                 accessibleTeams,

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -597,7 +597,7 @@
         }
 
         async function loadRequestAccessOptions() {
-            publicRequestTeams = (await getTeams()).filter((team) => team?.isPublic !== false);
+            publicRequestTeams = (await getTeams({ publicOnly: true })).filter((team) => team?.isPublic === true);
             populateRequestTeamOptions();
             await handleRequestTeamSelection();
         }

--- a/teams.html
+++ b/teams.html
@@ -102,7 +102,7 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { getTeams } from './js/db.js?v=32';
+    import { getTeams } from './js/db.js?v=33';
     import { renderHeader, renderFooter, escapeHtml, getSafeImageUrl, resolveZip } from './js/utils.js?v=9';
     import { checkAuth } from './js/auth.js?v=15';
 
@@ -133,10 +133,10 @@
       const container = document.getElementById('teams-list');
       setSearchPending(true);
       try {
-        const allTeams = await getTeams(locationFilter ? { locationFilter } : {});
-        // Filter out private teams (isPublic === false)
-        // Default isPublic to true if undefined
-        const teams = allTeams.filter(t => t.isPublic !== false);
+        const allTeams = await getTeams(locationFilter ? { locationFilter, publicOnly: true } : { publicOnly: true });
+        // Defense in depth: the query only requests public teams, and this keeps
+        // private teams hidden if a stale helper or local test double returns one.
+        const teams = allTeams.filter(t => t.isPublic === true);
 
         if (teams.length === 0) {
           const emptyMessage = locationFilter

--- a/tests/smoke/teams-location-search.spec.js
+++ b/tests/smoke/teams-location-search.spec.js
@@ -62,19 +62,19 @@ test('browse teams location search submits filters and clear restores all teams'
 
     await expect(page.getByText('Alpha Soccer')).toBeVisible();
     await expect(page.getByText('Kansas City Current')).toBeVisible();
-    await expect.poll(() => page.evaluate(() => window.__teamSearchCalls)).toEqual([{}]);
+    await expect.poll(() => page.evaluate(() => window.__teamSearchCalls)).toEqual([{ publicOnly: true }]);
 
     await page.locator('#location-search-input').fill('Kansas');
     await page.locator('#search-button').click();
 
     await expect(page.getByText('Kansas City Current')).toBeVisible();
     await expect(page.getByText('Alpha Soccer')).toHaveCount(0);
-    await expect.poll(() => page.evaluate(() => window.__teamSearchCalls.at(-1))).toEqual({ locationFilter: 'Kansas' });
+    await expect.poll(() => page.evaluate(() => window.__teamSearchCalls.at(-1))).toEqual({ locationFilter: 'Kansas', publicOnly: true });
     expect(new URL(page.url()).pathname).toMatch(/\/teams\.html$/);
 
     await page.locator('#clear-search-button').click();
 
     await expect(page.getByText('Alpha Soccer')).toBeVisible();
     await expect(page.getByText('Kansas City Current')).toBeVisible();
-    await expect.poll(() => page.evaluate(() => window.__teamSearchCalls.at(-1))).toEqual({});
+    await expect.poll(() => page.evaluate(() => window.__teamSearchCalls.at(-1))).toEqual({ publicOnly: true });
 });

--- a/tests/unit/organization-schedule.test.js
+++ b/tests/unit/organization-schedule.test.js
@@ -349,7 +349,7 @@ describe('organization schedule helpers', () => {
 
         expect(source).toContain('getTeam, getTeams, getUserTeamsWithAccess, listOrganizationScheduleControls');
         expect(source).toContain('accessibleTeams = currentUser.isAdmin === true');
-        expect(source).toContain('? await getTeams()');
+        expect(source).toContain('? await getTeams({ includePrivate: true })');
         expect(source).toContain(': await getUserTeamsWithAccess(currentUser.uid, currentUser.email);');
     });
 

--- a/tests/unit/teams-html-escaping.test.js
+++ b/tests/unit/teams-html-escaping.test.js
@@ -30,7 +30,7 @@ describe('teams page HTML escaping', () => {
         expect(source).toContain("searchForm.addEventListener('submit'");
         expect(source).toContain('event.preventDefault();');
         expect(source).toContain('await loadTeams(getLocationSearchValue());');
-        expect(source).toContain('getTeams(locationFilter ? { locationFilter } : {})');
+        expect(source).toContain('getTeams(locationFilter ? { locationFilter, publicOnly: true } : { publicOnly: true })');
         expect(source).toContain("clearSearchButton.addEventListener('click'");
         expect(source).toContain("locationSearchInput.value = '';");
     });

--- a/tests/unit/teams-public-visibility.test.js
+++ b/tests/unit/teams-public-visibility.test.js
@@ -6,11 +6,15 @@ function readRepoFile(path) {
 }
 
 describe('public teams visibility', () => {
-    it('requests only explicit public teams by default from the teams helper', () => {
+    it('keeps public team browsing opt-in and preserves accessible private teams by default', () => {
         const source = readRepoFile('js/db.js');
 
+        expect(source).toContain('const publicOnly = options.publicOnly === true;');
         expect(source).toContain('const includePrivate = options.includePrivate === true || includeInactive;');
-        expect(source).toContain('where("isPublic", "==", true), orderBy("name")');
+        expect(source).toContain('} else if (publicOnly) {');
+        expect(source).toContain('getDocs(query(teamsRef, where("ownerId", "==", currentUser.uid)))');
+        expect(source).toContain('getDocs(query(teamsRef, where("adminEmails", "array-contains", currentUserEmail)))');
+        expect(source).not.toContain('const q = includePrivate');
     });
 
     it('wires Browse Teams to the public-only helper path and keeps a defensive client filter', () => {
@@ -26,7 +30,7 @@ describe('public teams visibility', () => {
         const rules = readRepoFile('firestore.rules');
 
         expect(rules).toContain('function canReadTeamDocument(data)');
-        expect(rules).toContain('return data.isPublic == true ||');
+        expect(rules).toContain('return (data.isPublic is bool && data.isPublic == true) ||');
         expect(rules).toContain('allow read: if canReadTeamDocument(resource.data);');
         expect(rules).not.toContain('allow read: if true;  // Public teams for browsing');
     });

--- a/tests/unit/teams-public-visibility.test.js
+++ b/tests/unit/teams-public-visibility.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readRepoFile(path) {
+    return readFileSync(new URL(`../../${path}`, import.meta.url), 'utf8');
+}
+
+describe('public teams visibility', () => {
+    it('requests only explicit public teams by default from the teams helper', () => {
+        const source = readRepoFile('js/db.js');
+
+        expect(source).toContain('const includePrivate = options.includePrivate === true || includeInactive;');
+        expect(source).toContain('where("isPublic", "==", true), orderBy("name")');
+    });
+
+    it('wires Browse Teams to the public-only helper path and keeps a defensive client filter', () => {
+        const source = readRepoFile('teams.html');
+
+        expect(source).toContain("import { getTeams } from './js/db.js?v=33';");
+        expect(source).toContain('getTeams(locationFilter ? { locationFilter, publicOnly: true } : { publicOnly: true })');
+        expect(source).toContain('allTeams.filter(t => t.isPublic === true)');
+        expect(source).not.toContain('getTeams(locationFilter ? { locationFilter } : {})');
+    });
+
+    it('does not allow anonymous reads of private team documents in Firestore rules', () => {
+        const rules = readRepoFile('firestore.rules');
+
+        expect(rules).toContain('function canReadTeamDocument(data)');
+        expect(rules).toContain('return data.isPublic == true ||');
+        expect(rules).toContain('allow read: if canReadTeamDocument(resource.data);');
+        expect(rules).not.toContain('allow read: if true;  // Public teams for browsing');
+    });
+});


### PR DESCRIPTION
Closes #1153

## Summary
- Updated `getTeams()` to request only explicit public teams by default.
- Updated Browse Teams to use the public-only path and bumped the `js/db.js` cache-bust import.
- Tightened Firestore team document reads so anonymous users cannot read private teams directly.
- Added focused unit coverage for the public Browse Teams query, defensive filtering, cache-bust wiring, and rules guard.

## Validation
- `npx vitest run tests/unit/teams-public-visibility.test.js tests/unit/teams-html-escaping.test.js`
- `node scripts/check-critical-cache-bust.mjs`
- `npm run ci:firebase-rules`