### PR TITLE
Add team email draft composer

### DIFF
--- a/docs/team-chat.md
+++ b/docs/team-chat.md
@@ -17,6 +17,7 @@ Goal: Add persistent team chat for anyone who has access to a team (owner, admin
 - Manual refresh button
 - Coach/admin recipient picker for full team, staff-only, or selected roster/community members
 - Lightweight conversations list for the default team-wide channel plus targeted direct/group conversation records
+- Coach/admin-only team email draft composer with eligible roster recipient picker, saved drafts, and reopen/edit support
 
 ### Deferred Features
 - Real-time updates (Firestore onSnapshot) - using manual refresh instead
@@ -47,6 +48,9 @@ Goal: Add persistent team chat for anyone who has access to a team (owner, admin
   - `updatedAt: Timestamp`
 - Targeted conversation messages: `teams/{teamId}/chatConversations/{conversationId}/chatMessages/{messageId}`
   - Same message shape as the default channel, with `conversationId` populated.
+- Email drafts: `teams/{teamId}/emailDrafts/{draftId}`
+  - `subject`, `body`, `recipients[]`, `recipientEmails[]`, `status: "draft"`, author metadata, `createdAt`, and `updatedAt`.
+  - Drafts are saved only; no external email delivery, attachments, replies, or sent history are created.
 
 ### Message Fields
   - `text: string`
@@ -68,7 +72,7 @@ A user can read/post if they have team access:
 - `isGlobalAdmin` (`users.isAdmin == true`), or
 - parent linked to any player on the team (`user.parentOf` contains teamId)
 
-Moderation (delete others' messages):
+Moderation (delete others' messages) and email draft create/edit:
 - Team owner, team admins, or global admin
 
 ## Entry Points

--- a/firestore.rules
+++ b/firestore.rules
@@ -1523,6 +1523,27 @@ service cloud.firestore {
         }
       }
 
+      // Team email drafts are coach/admin-only and never trigger delivery.
+      match /emailDrafts/{draftId} {
+        allow read: if isTeamOwnerOrAdmin(teamId);
+        allow create, update: if isTeamOwnerOrAdmin(teamId) &&
+          request.resource.data.keys().hasAll(['subject', 'body', 'recipients', 'recipientEmails', 'status', 'updatedAt']) &&
+          request.resource.data.keys().hasOnly([
+            'subject', 'body', 'recipients', 'recipientEmails', 'authorId', 'authorEmail',
+            'authorName', 'status', 'createdAt', 'updatedAt'
+          ]) &&
+          request.resource.data.subject is string &&
+          request.resource.data.subject.size() > 0 &&
+          request.resource.data.body is string &&
+          request.resource.data.body.size() > 0 &&
+          request.resource.data.recipients is list &&
+          request.resource.data.recipients.size() > 0 &&
+          request.resource.data.recipientEmails is list &&
+          request.resource.data.recipientEmails.size() > 0 &&
+          request.resource.data.status == 'draft';
+        allow delete: if isTeamOwnerOrAdmin(teamId);
+      }
+
       // Chat messages subcollection
       match /chatMessages/{messageId} {
         // List queries are unfiltered by target metadata in existing clients.

--- a/js/db.js
+++ b/js/db.js
@@ -4505,6 +4505,84 @@ export async function archiveCertificate(teamId, certificateId) {
     await updateCertificate(teamId, certificateId, { status: 'archived' }, { action: 'archived' });
 }
 
+
+function getTeamEmailDraftsRef(teamId) {
+    return collection(db, 'teams', teamId, 'emailDrafts');
+}
+
+function normalizeEmailDraftRecipient(recipient = {}) {
+    const email = String(recipient.email || '').trim().toLowerCase();
+    return {
+        key: String(recipient.key || `email:${email}`).trim(),
+        email,
+        name: String(recipient.name || email).trim(),
+        detail: String(recipient.detail || '').trim()
+    };
+}
+
+function normalizeTeamEmailDraftPayload(draft = {}) {
+    const subject = String(draft.subject || '').trim();
+    const body = String(draft.body || '').trim();
+    const recipients = Array.isArray(draft.recipients)
+        ? draft.recipients.map(normalizeEmailDraftRecipient).filter((recipient) => (
+            recipient.key && /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(recipient.email)
+        ))
+        : [];
+
+    if (recipients.length === 0) throw new Error('Choose at least one recipient before saving.');
+    if (!subject) throw new Error('Enter a subject before saving.');
+    if (!body) throw new Error('Enter a body before saving.');
+
+    return {
+        subject,
+        body,
+        recipients,
+        recipientEmails: recipients.map((recipient) => recipient.email),
+        authorId: draft.authorId || auth.currentUser?.uid || null,
+        authorEmail: draft.authorEmail || auth.currentUser?.email || null,
+        authorName: draft.authorName || null,
+        status: 'draft'
+    };
+}
+
+export async function getTeamEmailDrafts(teamId) {
+    if (!teamId) return [];
+    const draftsRef = getTeamEmailDraftsRef(teamId);
+    try {
+        const snapshot = await getDocs(query(draftsRef, orderBy('updatedAt', 'desc')));
+        return snapshot.docs.map((draftDoc) => ({ id: draftDoc.id, ...draftDoc.data() }));
+    } catch (error) {
+        const snapshot = await getDocs(draftsRef);
+        return snapshot.docs
+            .map((draftDoc) => ({ id: draftDoc.id, ...draftDoc.data() }))
+            .sort((a, b) => {
+                const aTime = a.updatedAt?.toMillis ? a.updatedAt.toMillis() : 0;
+                const bTime = b.updatedAt?.toMillis ? b.updatedAt.toMillis() : 0;
+                return bTime - aTime;
+            });
+    }
+}
+
+export async function saveTeamEmailDraft(teamId, draft, { draftId = null } = {}) {
+    const now = Timestamp.now();
+    const payload = {
+        ...normalizeTeamEmailDraftPayload(draft),
+        updatedAt: now
+    };
+
+    if (draftId) {
+        const draftRef = doc(db, 'teams', teamId, 'emailDrafts', draftId);
+        await setDoc(draftRef, payload, { merge: true });
+        return { id: draftId, ...payload };
+    }
+
+    const draftRef = await addDoc(getTeamEmailDraftsRef(teamId), {
+        ...payload,
+        createdAt: now
+    });
+    return { id: draftRef.id, ...payload, createdAt: now };
+}
+
 function getTeamChatMessagesRef(teamId, conversationId = DEFAULT_TEAM_CONVERSATION_ID) {
     if (isDefaultTeamConversation(conversationId)) {
         return collection(db, 'teams', teamId, 'chatMessages');

--- a/team-chat.html
+++ b/team-chat.html
@@ -75,6 +75,10 @@
                         Photos &amp; Videos
                         <span id="media-gallery-count" class="hidden rounded-full bg-primary-100 px-2 py-0.5 text-xs font-semibold text-primary-700"></span>
                     </button>
+                    <button id="email-drafts-btn"
+                        class="hidden flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-gray-600 hover:text-primary-600 hover:bg-primary-50 rounded-lg transition">
+                        Email Drafts
+                    </button>
                     <button id="refresh-btn"
                         class="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-gray-600 hover:text-primary-600 hover:bg-primary-50 rounded-lg transition">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -207,6 +211,49 @@
         </div>
     </div>
 
+    <div id="email-draft-modal" class="hidden fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50 p-4">
+        <div class="bg-white rounded-2xl shadow-xl max-w-5xl w-full max-h-full overflow-hidden flex flex-col">
+            <div class="flex items-center justify-between px-5 py-4 border-b border-gray-200">
+                <div>
+                    <h3 class="text-lg font-bold text-gray-900">Team Email Drafts</h3>
+                    <p class="text-sm text-gray-500">Compose and save roster email drafts. Email delivery is not enabled yet.</p>
+                </div>
+                <button id="email-draft-close-btn" type="button" class="px-3 py-1.5 text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100 rounded-lg">Close</button>
+            </div>
+            <div class="grid gap-0 md:grid-cols-[280px_1fr] overflow-y-auto">
+                <aside class="border-b md:border-b-0 md:border-r border-gray-200 p-4 bg-gray-50">
+                    <button id="email-draft-new-btn" type="button" class="w-full rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700">New draft</button>
+                    <div class="mt-4 text-xs font-semibold uppercase tracking-wide text-gray-500">Saved Drafts</div>
+                    <div id="email-drafts-list" class="mt-2 space-y-2 text-sm text-gray-600">No drafts yet.</div>
+                </aside>
+                <section class="p-5 space-y-4">
+                    <div id="email-draft-error" class="hidden rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700"></div>
+                    <div>
+                        <label for="email-draft-subject" class="block text-sm font-semibold text-gray-700">Subject</label>
+                        <input id="email-draft-subject" type="text" maxlength="200" class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="Practice update for Friday">
+                    </div>
+                    <div>
+                        <label for="email-draft-body" class="block text-sm font-semibold text-gray-700">Body</label>
+                        <textarea id="email-draft-body" rows="8" maxlength="12000" class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="Write the email body..."></textarea>
+                    </div>
+                    <div>
+                        <div class="flex items-center justify-between gap-3">
+                            <div>
+                                <div class="text-sm font-semibold text-gray-700">Recipients</div>
+                                <div id="email-recipient-summary" class="text-xs text-gray-500">Select at least one eligible roster contact.</div>
+                            </div>
+                            <button id="email-recipient-select-all-btn" type="button" class="text-sm font-medium text-primary-600 hover:text-primary-700">Select all</button>
+                        </div>
+                        <div id="email-recipient-list" class="mt-2 max-h-52 overflow-y-auto rounded-lg border border-gray-200 divide-y divide-gray-100"></div>
+                    </div>
+                    <div class="flex justify-end gap-2">
+                        <button id="email-draft-save-btn" type="button" class="rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700 disabled:opacity-50 disabled:cursor-not-allowed">Save draft</button>
+                    </div>
+                </section>
+            </div>
+        </div>
+    </div>
+
     <div id="media-gallery-modal" class="hidden fixed inset-0 bg-black bg-opacity-60 z-50 p-4">
         <div class="max-w-5xl mx-auto h-full flex items-center justify-center">
             <div class="bg-white rounded-2xl shadow-xl w-full max-h-full overflow-hidden flex flex-col">
@@ -229,7 +276,7 @@
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=14';
-        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=31';
+        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=32';
         import { DEFAULT_TEAM_CONVERSATION_ID, buildDefaultTeamConversation, getConversationDisplayName, isDefaultTeamConversation } from './js/team-chat-conversations.js?v=1';
         import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from './js/team-chat-last-read.js?v=3';
         import {
@@ -401,6 +448,10 @@
         let recipientOptions = [];
         let selectedRecipientTarget = 'full_team';
         let selectedRecipientIds = new Set();
+        let emailDrafts = [];
+        let selectedEmailDraftId = null;
+        let emailRecipientOptions = [];
+        let selectedEmailRecipientKeys = new Set();
         const reactionLongPress = {
             timer: null,
             key: null,
@@ -463,6 +514,8 @@
                 canModerate = canModerateChat(userWithProfile, currentTeam);
                 if (canModerate) {
                     await loadRecipientOptions();
+                    await loadEmailDrafts();
+                    document.getElementById('email-drafts-btn')?.classList.remove('hidden');
                 }
 
                 // Render team navigation banner with appropriate access level
@@ -1062,6 +1115,201 @@
             } catch (error) {
                 console.warn('Failed to load chat recipient options:', error);
                 recipientOptions = [];
+            }
+        }
+
+        function normalizeEmailAddress(value) {
+            return String(value || '').trim().toLowerCase();
+        }
+
+        function isUsableEmail(value) {
+            return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizeEmailAddress(value));
+        }
+
+        function isEmailMessagingEnabled(contact = {}) {
+            return contact.emailMessagingEnabled !== false &&
+                contact.messagingEnabled !== false &&
+                contact.emailEnabled !== false &&
+                contact.optOutEmail !== true &&
+                contact.emailOptOut !== true;
+        }
+
+        function buildEligibleEmailRecipientsFromPlayers(players = []) {
+            const recipients = new Map();
+            players.forEach((player) => {
+                const playerName = player?.name || 'Roster player';
+                const contacts = [
+                    ...(Array.isArray(player?.parents) ? player.parents : []),
+                    ...(Array.isArray(player?.contacts) ? player.contacts : []),
+                    ...(Array.isArray(player?.guardians) ? player.guardians : [])
+                ];
+                contacts.forEach((contact) => {
+                    const email = normalizeEmailAddress(contact?.email);
+                    if (!isUsableEmail(email) || !isEmailMessagingEnabled(contact)) return;
+                    const key = `email:${email}`;
+                    if (!recipients.has(key)) {
+                        recipients.set(key, {
+                            key,
+                            email,
+                            name: contact.name || contact.fullName || contact.parentName || email,
+                            detail: playerName ? `Guardian for ${playerName}` : 'Roster contact'
+                        });
+                    }
+                });
+            });
+            return Array.from(recipients.values()).sort((a, b) => a.name.localeCompare(b.name));
+        }
+
+        async function loadEmailRecipientOptions() {
+            const players = await getPlayers(teamId);
+            emailRecipientOptions = buildEligibleEmailRecipientsFromPlayers(players);
+        }
+
+        async function loadEmailDrafts() {
+            if (!canModerate) return;
+            try {
+                emailDrafts = await getTeamEmailDrafts(teamId);
+            } catch (error) {
+                console.warn('Failed to load email drafts:', error);
+                emailDrafts = [];
+            }
+            renderEmailDraftsList();
+        }
+
+        function openEmailDraftModal(draftId = null) {
+            if (!canModerate) return;
+            document.getElementById('email-draft-modal').classList.remove('hidden');
+            if (emailRecipientOptions.length === 0) {
+                loadEmailRecipientOptions().then(() => {
+                    selectEmailDraft(draftId);
+                }).catch((error) => {
+                    console.warn('Failed to load email recipients:', error);
+                    emailRecipientOptions = [];
+                    selectEmailDraft(draftId);
+                });
+                return;
+            }
+            selectEmailDraft(draftId);
+        }
+
+        function closeEmailDraftModal() {
+            document.getElementById('email-draft-modal').classList.add('hidden');
+            hideEmailDraftError();
+        }
+
+        function selectEmailDraft(draftId = null) {
+            const draft = emailDrafts.find((item) => item.id === draftId) || null;
+            selectedEmailDraftId = draft?.id || null;
+            document.getElementById('email-draft-subject').value = draft?.subject || '';
+            document.getElementById('email-draft-body').value = draft?.body || '';
+            selectedEmailRecipientKeys = new Set((Array.isArray(draft?.recipients) ? draft.recipients : []).map((recipient) => recipient.key || `email:${normalizeEmailAddress(recipient.email)}`));
+            renderEmailDraftsList();
+            renderEmailRecipientPicker();
+            updateEmailDraftSaveState();
+        }
+
+        function renderEmailDraftsList() {
+            const list = document.getElementById('email-drafts-list');
+            if (!list) return;
+            if (emailDrafts.length === 0) {
+                list.innerHTML = '<div class="rounded-lg border border-dashed border-gray-300 bg-white px-3 py-4 text-center text-sm text-gray-500">No drafts yet.</div>';
+                return;
+            }
+            list.innerHTML = emailDrafts.map((draft) => `
+                <button type="button" data-email-draft-id="${escapeHtml(draft.id)}"
+                    class="w-full rounded-lg px-3 py-2 text-left ${draft.id === selectedEmailDraftId ? 'bg-primary-50 text-primary-700' : 'bg-white text-gray-700 hover:bg-gray-100'}">
+                    <span class="block truncate font-semibold">${escapeHtml(draft.subject || 'Untitled draft')}</span>
+                    <span class="block text-xs text-gray-500">${(draft.recipients || []).length} recipient${(draft.recipients || []).length === 1 ? '' : 's'}</span>
+                </button>
+            `).join('');
+        }
+
+        function renderEmailRecipientPicker() {
+            const list = document.getElementById('email-recipient-list');
+            const summary = document.getElementById('email-recipient-summary');
+            if (!list || !summary) return;
+            const selectedCount = selectedEmailRecipientKeys.size;
+            summary.textContent = selectedCount > 0
+                ? `${selectedCount} eligible roster contact${selectedCount === 1 ? '' : 's'} selected.`
+                : 'Select at least one eligible roster contact.';
+            if (emailRecipientOptions.length === 0) {
+                list.innerHTML = '<div class="px-3 py-4 text-sm text-gray-500">No roster contacts have usable email addresses with email messaging enabled.</div>';
+                return;
+            }
+            list.innerHTML = emailRecipientOptions.map((recipient) => `
+                <label class="flex cursor-pointer items-center gap-3 px-3 py-2 hover:bg-gray-50">
+                    <input type="checkbox" data-email-recipient-key="${escapeHtml(recipient.key)}" ${selectedEmailRecipientKeys.has(recipient.key) ? 'checked' : ''}
+                        class="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500">
+                    <span class="min-w-0 flex-1">
+                        <span class="block truncate text-sm font-medium text-gray-800">${escapeHtml(recipient.name)}</span>
+                        <span class="block truncate text-xs text-gray-500">${escapeHtml(recipient.email)} • ${escapeHtml(recipient.detail)}</span>
+                    </span>
+                </label>
+            `).join('');
+        }
+
+        function getSelectedEmailRecipients() {
+            return emailRecipientOptions
+                .filter((recipient) => selectedEmailRecipientKeys.has(recipient.key))
+                .map((recipient) => ({
+                    key: recipient.key,
+                    email: recipient.email,
+                    name: recipient.name,
+                    detail: recipient.detail
+                }));
+        }
+
+        function showEmailDraftError(message) {
+            const error = document.getElementById('email-draft-error');
+            if (!error) return;
+            error.textContent = message;
+            error.classList.remove('hidden');
+        }
+
+        function hideEmailDraftError() {
+            document.getElementById('email-draft-error')?.classList.add('hidden');
+        }
+
+        function updateEmailDraftSaveState() {
+            const saveBtn = document.getElementById('email-draft-save-btn');
+            if (!saveBtn) return;
+            const hasSubject = document.getElementById('email-draft-subject').value.trim().length > 0;
+            const hasBody = document.getElementById('email-draft-body').value.trim().length > 0;
+            saveBtn.disabled = selectedEmailRecipientKeys.size === 0 || !hasSubject || !hasBody;
+        }
+
+        async function saveEmailDraftFromForm() {
+            hideEmailDraftError();
+            const subject = document.getElementById('email-draft-subject').value.trim();
+            const body = document.getElementById('email-draft-body').value.trim();
+            const recipients = getSelectedEmailRecipients();
+            if (recipients.length === 0 || !subject || !body) {
+                showEmailDraftError('Choose at least one recipient, a subject, and a body before saving.');
+                updateEmailDraftSaveState();
+                return;
+            }
+            const saveBtn = document.getElementById('email-draft-save-btn');
+            saveBtn.disabled = true;
+            saveBtn.textContent = 'Saving...';
+            try {
+                const saved = await saveTeamEmailDraft(teamId, {
+                    subject,
+                    body,
+                    recipients,
+                    authorId: currentUser.uid,
+                    authorEmail: currentUser.email || null,
+                    authorName: currentUserProfile?.fullName || null,
+                    status: 'draft'
+                }, { draftId: selectedEmailDraftId });
+                selectedEmailDraftId = saved.id;
+                await loadEmailDrafts();
+                selectEmailDraft(saved.id);
+            } catch (error) {
+                console.error('Error saving email draft:', error);
+                showEmailDraftError(error?.message || 'Failed to save draft. Please try again.');
+            } finally {
+                saveBtn.textContent = 'Save draft';
+                updateEmailDraftSaveState();
             }
         }
 
@@ -2039,6 +2287,34 @@
             document.getElementById('chat-image-input').addEventListener('change', handleImageSelection);
             document.getElementById('media-gallery-btn').addEventListener('click', openMediaGallery);
             document.getElementById('media-gallery-close-btn').addEventListener('click', closeMediaGallery);
+            document.getElementById('email-drafts-btn').addEventListener('click', () => openEmailDraftModal());
+            document.getElementById('email-draft-close-btn').addEventListener('click', closeEmailDraftModal);
+            document.getElementById('email-draft-new-btn').addEventListener('click', () => selectEmailDraft(null));
+            document.getElementById('email-draft-save-btn').addEventListener('click', saveEmailDraftFromForm);
+            document.getElementById('email-drafts-list').addEventListener('click', (event) => {
+                const button = event.target.closest('[data-email-draft-id]');
+                if (!button) return;
+                selectEmailDraft(button.dataset.emailDraftId);
+            });
+            document.getElementById('email-recipient-list').addEventListener('change', (event) => {
+                const key = event.target?.dataset?.emailRecipientKey;
+                if (!key) return;
+                if (event.target.checked) {
+                    selectedEmailRecipientKeys.add(key);
+                } else {
+                    selectedEmailRecipientKeys.delete(key);
+                }
+                renderEmailRecipientPicker();
+                updateEmailDraftSaveState();
+            });
+            document.getElementById('email-recipient-select-all-btn').addEventListener('click', () => {
+                const allSelected = emailRecipientOptions.length > 0 && selectedEmailRecipientKeys.size === emailRecipientOptions.length;
+                selectedEmailRecipientKeys = allSelected ? new Set() : new Set(emailRecipientOptions.map((recipient) => recipient.key));
+                renderEmailRecipientPicker();
+                updateEmailDraftSaveState();
+            });
+            document.getElementById('email-draft-subject').addEventListener('input', updateEmailDraftSaveState);
+            document.getElementById('email-draft-body').addEventListener('input', updateEmailDraftSaveState);
             document.getElementById('conversations-list').addEventListener('click', (event) => {
                 const button = event.target.closest('[data-conversation-id]');
                 if (!button) return;

--- a/tests/smoke/team-fallback-regressions.spec.js
+++ b/tests/smoke/team-fallback-regressions.spec.js
@@ -204,6 +204,10 @@ export async function getChatMessages() {
 export async function postChatMessage() {}
 export async function editChatMessage() {}
 export async function deleteChatMessage() {}
+export async function getTeamEmailDrafts() {
+    return [];
+}
+export async function saveTeamEmailDraft() {}
 export function canAccessTeamChat() {
     return true;
 }

--- a/tests/unit/team-email-drafts.test.js
+++ b/tests/unit/team-email-drafts.test.js
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readRepoFile(relativePath) {
+    return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+describe('team email draft composer', () => {
+    it('wires coach/admin email drafts into team chat', () => {
+        const html = readRepoFile('team-chat.html');
+
+        expect(html).toContain('id="email-drafts-btn"');
+        expect(html).toContain('getTeamEmailDrafts');
+        expect(html).toContain('saveTeamEmailDraft');
+        expect(html).toContain('openEmailDraftModal');
+    });
+
+    it('filters the recipient picker to usable email-enabled roster contacts', () => {
+        const html = readRepoFile('team-chat.html');
+
+        expect(html).toContain('function buildEligibleEmailRecipientsFromPlayers');
+        expect(html).toContain('isUsableEmail(email)');
+        expect(html).toContain('isEmailMessagingEnabled(contact)');
+        expect(html).toContain('No roster contacts have usable email addresses with email messaging enabled.');
+    });
+
+    it('requires recipients, subject, and body before saving', () => {
+        const html = readRepoFile('team-chat.html');
+        const db = readRepoFile('js/db.js');
+
+        expect(html).toContain('Choose at least one recipient, a subject, and a body before saving.');
+        expect(html).toContain('saveBtn.disabled = selectedEmailRecipientKeys.size === 0 || !hasSubject || !hasBody;');
+        expect(db).toContain("if (recipients.length === 0) throw new Error('Choose at least one recipient before saving.');");
+        expect(db).toContain("if (!subject) throw new Error('Enter a subject before saving.');");
+        expect(db).toContain("if (!body) throw new Error('Enter a body before saving.');");
+    });
+
+    it('stores drafts under the team and restricts rules to team managers', () => {
+        const db = readRepoFile('js/db.js');
+        const rules = readRepoFile('firestore.rules');
+
+        expect(db).toContain("collection(db, 'teams', teamId, 'emailDrafts')");
+        expect(rules).toContain('match /emailDrafts/{draftId}');
+        expect(rules).toContain('allow read: if isTeamOwnerOrAdmin(teamId);');
+        expect(rules).toContain('allow create, update: if isTeamOwnerOrAdmin(teamId)');
+    });
+});


### PR DESCRIPTION
Closes #1158

## Summary
- Added a coach/admin-only Team Email Drafts workflow inside team chat.
- Added eligible roster email recipient selection, subject/body validation, saved draft listing, and reopen/edit support.
- Persisted drafts under `teams/{teamId}/emailDrafts` with Firestore rules restricted to team managers.

## Validation
- `npx vitest run tests/unit/team-email-drafts.test.js tests/unit/team-chat-send-media-cleanup.test.js tests/unit/team-chat-conversations.test.js`
- `node --check js/db.js`
- `npm run ci:firebase-rules`
- `node scripts/check-critical-cache-bust.mjs`