### PR TITLE
Add team email send history

### DIFF
--- a/docs/pr-notes/runs/1162-ci-fix-20260521T161147Z/architecture.md
+++ b/docs/pr-notes/runs/1162-ci-fix-20260521T161147Z/architecture.md
@@ -1,0 +1,14 @@
+# Architecture Notes
+
+## Acceptance Criteria
+- Team chat still renders the default team-wide conversation when conversation listing is denied.
+- Team chat scheduled reminder fallback messages render through the same realtime subscription path.
+- Smoke stubs stay aligned with the production `team-chat.html` module import surface.
+
+## Architecture Decisions
+- No production architecture change needed. The fallback path in `team-chat.html` already catches `getChatConversations()` permission failures and builds the default team conversation from the loaded team.
+- The failure is test drift: `team-chat.html` imports the new team email history helpers from `js/db.js`, but the smoke test DB stub does not export them, so the page module never initializes.
+
+## Risks And Rollback
+- Risk is limited to smoke test coverage. Adding no-op stub exports preserves current assertions and does not change app behavior.
+- Rollback is reverting the test stub additions.

--- a/docs/pr-notes/runs/1162-ci-fix-20260521T161147Z/code-plan.md
+++ b/docs/pr-notes/runs/1162-ci-fix-20260521T161147Z/code-plan.md
@@ -1,0 +1,9 @@
+# Code Plan
+
+## Root Cause
+`team-chat.html` now imports `sendTeamEmail` and `getSentTeamEmails` from `./js/db.js?v=32`. The smoke test replaces `js/db.js` with `CHAT_DB_STUB`, but that stub lacks those exports. Browser module import fails before initialization, so the DOM stays at the static `Team-wide` button and `Loading messages...` state.
+
+## Implementation Plan
+- Add no-op `sendTeamEmail` and `getSentTeamEmails` exports to `CHAT_DB_STUB` in `tests/smoke/team-fallback-regressions.spec.js`.
+- Keep production code unchanged.
+- Validate with targeted smoke grep, then full team fallback smoke suite if feasible.

--- a/docs/pr-notes/runs/1162-ci-fix-20260521T161147Z/qa.md
+++ b/docs/pr-notes/runs/1162-ci-fix-20260521T161147Z/qa.md
@@ -1,0 +1,12 @@
+# QA Notes
+
+## QA Plan
+- Re-run the two failing team-chat fallback smoke tests locally.
+- Re-run the full `test:smoke:team-fallback` suite if time allows because the same stub file backs adjacent media/replay guards.
+
+## Expected Coverage
+- Conversation listing denied: verifies fallback default conversation label and message rendering.
+- Scheduled reminder fallback: verifies reminder text and ALL PLAYS sender render after realtime callback.
+
+## Risk Focus
+- Missing stub exports can stop the page module before app initialization, leaving static HTML and loading state. Assertions should prove the page reaches rendered fallback state and page errors remain empty.

--- a/firestore.rules
+++ b/firestore.rules
@@ -1577,6 +1577,11 @@ service cloud.firestore {
                          );
       }
 
+      match /teamEmails/{messageId} {
+        allow read: if isTeamOwnerOrAdmin(teamId);
+        allow create, update, delete: if false;
+      }
+
       // First-class team messaging conversations. The default team-wide channel
       // remains teams/{teamId}/chatMessages for compatibility; targeted threads
       // store messages under their conversation record.

--- a/functions/index.js
+++ b/functions/index.js
@@ -35,6 +35,11 @@ const {
   validateRsvpTokenRedemption,
   buildRsvpTokenAuditPayload
 } = require('./rsvp-token-core.cjs');
+const {
+  normalizeText,
+  resolveTeamEmailRecipients,
+  buildTeamEmailMailJob
+} = require('./team-email-core.cjs');
 
 if (admin.apps.length === 0) {
   admin.initializeApp();
@@ -1770,6 +1775,162 @@ exports.notifyTeamChatMessageCreated = functions.firestore
       actorUid
     });
   });
+
+async function requireTeamEmailSender(teamId, context) {
+  if (!context.auth?.uid) {
+    throw new functions.https.HttpsError('unauthenticated', 'Sign in to send team email.');
+  }
+  const [teamSnap, userSnap] = await Promise.all([
+    firestore.doc(`teams/${teamId}`).get(),
+    firestore.doc(`users/${context.auth.uid}`).get()
+  ]);
+  if (!teamSnap.exists) {
+    throw new functions.https.HttpsError('not-found', 'Team not found.');
+  }
+  const team = teamSnap.data() || {};
+  const user = userSnap.exists ? userSnap.data() || {} : {};
+  const callerEmail = String(context.auth.token?.email || '').trim().toLowerCase();
+  const adminEmails = Array.isArray(team.adminEmails)
+    ? team.adminEmails.map((email) => String(email || '').trim().toLowerCase())
+    : [];
+  const canSend = team.ownerId === context.auth.uid ||
+    adminEmails.includes(callerEmail) ||
+    user.isAdmin === true;
+  if (!canSend) {
+    throw new functions.https.HttpsError('permission-denied', 'Only team coaches and admins can send team email.');
+  }
+  return { team, user, callerEmail };
+}
+
+exports.sendTeamEmail = functions.https.onCall(async (data, context) => {
+  const teamId = normalizeText(data?.teamId, 160);
+  const draftId = normalizeText(data?.draftId, 160);
+  let subject = normalizeText(data?.subject, 160);
+  let body = normalizeText(data?.body, 20000);
+  let targetType = ['full_team', 'staff', 'individuals'].includes(data?.targetType) ? data.targetType : 'full_team';
+  let recipientIds = Array.isArray(data?.recipientIds) ? data.recipientIds : [];
+
+  if (!teamId) {
+    throw new functions.https.HttpsError('invalid-argument', 'Team is required.');
+  }
+
+  const { team, user } = await requireTeamEmailSender(teamId, context);
+  if (draftId) {
+    const draftSnap = await firestore.doc(`teams/${teamId}/teamEmailDrafts/${draftId}`).get();
+    if (!draftSnap.exists) {
+      throw new functions.https.HttpsError('not-found', 'Email draft not found.');
+    }
+    const draft = draftSnap.data() || {};
+    subject = subject || normalizeText(draft.subject, 160);
+    body = body || normalizeText(draft.body, 20000);
+    targetType = ['full_team', 'staff', 'individuals'].includes(draft.targetType) ? draft.targetType : targetType;
+    recipientIds = Array.isArray(draft.recipientIds) && draft.recipientIds.length > 0 ? draft.recipientIds : recipientIds;
+  }
+
+  if (!subject || !body) {
+    throw new functions.https.HttpsError('invalid-argument', 'Subject and message are required.');
+  }
+  if (targetType === 'individuals' && recipientIds.length === 0) {
+    throw new functions.https.HttpsError('invalid-argument', 'Select at least one recipient.');
+  }
+
+  const [playersSnap, ownerSnap] = await Promise.all([
+    firestore.collection(`teams/${teamId}/players`).get(),
+    team.ownerId ? firestore.doc(`users/${team.ownerId}`).get() : Promise.resolve(null)
+  ]);
+  const players = playersSnap.docs.map((docSnap) => ({ id: docSnap.id, ...(docSnap.data() || {}) }));
+  const ownerUser = ownerSnap?.exists ? ownerSnap.data() || {} : null;
+  const recipients = resolveTeamEmailRecipients({ targetType, recipientIds, players, team, ownerUser });
+  if (recipients.length === 0) {
+    throw new functions.https.HttpsError('failed-precondition', 'No email-enabled recipients were found for that audience.');
+  }
+
+  const now = admin.firestore.FieldValue.serverTimestamp();
+  const messageRef = firestore.collection(`teams/${teamId}/teamEmails`).doc();
+  const mailJobs = recipients.map((recipient) => ({
+    ref: firestore.collection('mail').doc(),
+    recipient,
+    payload: buildTeamEmailMailJob({
+      email: recipient.email,
+      subject,
+      body,
+      teamId,
+      messageId: messageRef.id,
+      senderUid: context.auth.uid
+    })
+  }));
+  const messagePayload = {
+    subject,
+    body,
+    status: 'sent',
+    immutable: true,
+    targetType,
+    draftId: draftId || null,
+    recipientCount: recipients.length,
+    recipientSummary: recipients.map((recipient) => ({
+      playerIds: recipient.playerIds,
+      userIds: recipient.userIds,
+      roles: recipient.roles
+    })),
+    senderId: context.auth.uid,
+    senderName: user.fullName || context.auth.token?.name || null,
+    senderEmail: context.auth.token?.email || null,
+    sentAt: now,
+    createdAt: now,
+    delivery: {
+      provider: 'firestore-mail',
+      status: 'queued',
+      jobCount: mailJobs.length,
+      jobIds: mailJobs.map((job) => job.ref.id)
+    }
+  };
+
+  const chunks = [];
+  for (let i = 0; i < mailJobs.length; i += 400) {
+    chunks.push(mailJobs.slice(i, i + 400));
+  }
+  const firstBatch = firestore.batch();
+  firstBatch.set(messageRef, messagePayload);
+  if (draftId) {
+    firstBatch.set(firestore.doc(`teams/${teamId}/teamEmailDrafts/${draftId}`), {
+      status: 'sent',
+      sentMessageId: messageRef.id,
+      sentAt: now,
+      updatedAt: now
+    }, { merge: true });
+  }
+  chunks.shift().forEach((job) => {
+    firstBatch.set(job.ref, {
+      ...job.payload,
+      createdAt: now
+    });
+  });
+  await firstBatch.commit();
+  try {
+    for (const chunk of chunks) {
+      const batch = firestore.batch();
+      chunk.forEach((job) => batch.set(job.ref, { ...job.payload, createdAt: now }));
+      await batch.commit();
+    }
+  } catch (error) {
+    await messageRef.set({
+      status: 'partial_failed',
+      delivery: {
+        ...messagePayload.delivery,
+        status: 'partial_failed',
+        errorMessage: String(error?.message || 'Some mail jobs could not be queued.')
+      }
+    }, { merge: true });
+    throw new functions.https.HttpsError('internal', 'Some email delivery jobs could not be queued. Check sent history for partial failure details.');
+  }
+
+  return {
+    messageId: messageRef.id,
+    status: 'sent',
+    recipientCount: recipients.length,
+    delivery: messagePayload.delivery
+  };
+});
 
 exports.notifyGameUpdated = functions.firestore
   .document('teams/{teamId}/games/{gameId}')

--- a/functions/team-email-core.cjs
+++ b/functions/team-email-core.cjs
@@ -1,0 +1,140 @@
+function normalizeText(value, maxLength = 2000) {
+  const text = String(value || '').trim();
+  return text.length > maxLength ? text.slice(0, maxLength) : text;
+}
+
+function normalizeEmail(value) {
+  const email = String(value || '').trim().toLowerCase();
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? email : '';
+}
+
+function isEmailEnabledContact(contact = {}) {
+  return contact.emailEnabled !== false &&
+    contact.receiveEmail !== false &&
+    contact.receivesEmail !== false &&
+    contact.notificationsEnabled !== false &&
+    contact.unsubscribed !== true;
+}
+
+function addRecipient(recipientsByEmail, email, metadata = {}) {
+  const normalizedEmail = normalizeEmail(email);
+  if (!normalizedEmail) return;
+  if (!recipientsByEmail.has(normalizedEmail)) {
+    recipientsByEmail.set(normalizedEmail, {
+      email: normalizedEmail,
+      playerIds: new Set(),
+      userIds: new Set(),
+      roles: new Set()
+    });
+  }
+  const recipient = recipientsByEmail.get(normalizedEmail);
+  if (metadata.playerId) recipient.playerIds.add(String(metadata.playerId));
+  if (metadata.userId) recipient.userIds.add(String(metadata.userId));
+  if (metadata.role) recipient.roles.add(String(metadata.role));
+}
+
+function addPlayerContacts(recipientsByEmail, player = {}) {
+  if (player.active === false) return;
+  const playerId = player.id || player.playerId || '';
+  if (isEmailEnabledContact(player)) {
+    addRecipient(recipientsByEmail, player.email, { playerId, userId: player.userId, role: 'player' });
+  }
+  const contacts = [
+    ...(Array.isArray(player.parents) ? player.parents : []),
+    ...(Array.isArray(player.guardians) ? player.guardians : []),
+    ...(Array.isArray(player.familyContacts) ? player.familyContacts : [])
+  ];
+  contacts.forEach((contact) => {
+    if (!isEmailEnabledContact(contact)) return;
+    addRecipient(recipientsByEmail, contact.email, { playerId, userId: contact.userId, role: 'guardian' });
+  });
+}
+
+function serializeRecipients(recipientsByEmail) {
+  return Array.from(recipientsByEmail.values()).map((recipient) => ({
+    email: recipient.email,
+    playerIds: Array.from(recipient.playerIds).sort(),
+    userIds: Array.from(recipient.userIds).sort(),
+    roles: Array.from(recipient.roles).sort()
+  })).sort((a, b) => a.email.localeCompare(b.email));
+}
+
+function resolveTeamEmailRecipients({ targetType = 'full_team', recipientIds = [], players = [], team = {}, ownerUser = null } = {}) {
+  const recipientsByEmail = new Map();
+  const selectedIds = new Set((Array.isArray(recipientIds) ? recipientIds : [])
+    .map((id) => String(id || '').trim())
+    .filter(Boolean));
+  const activePlayers = players.filter((player) => player && player.active !== false);
+
+  if (targetType === 'staff') {
+    (Array.isArray(team.adminEmails) ? team.adminEmails : []).forEach((email) => {
+      addRecipient(recipientsByEmail, email, { role: 'staff' });
+    });
+    if (ownerUser?.email) {
+      addRecipient(recipientsByEmail, ownerUser.email, { userId: team.ownerId, role: 'owner' });
+    }
+    return serializeRecipients(recipientsByEmail);
+  }
+
+  if (targetType === 'individuals' && selectedIds.size > 0) {
+    activePlayers.forEach((player) => {
+      const playerId = String(player.id || player.playerId || '');
+      const playerSelected = selectedIds.has(`player:${playerId}`) || selectedIds.has(playerId);
+      const matchingContacts = [];
+      const contacts = [
+        ...(Array.isArray(player.parents) ? player.parents : []),
+        ...(Array.isArray(player.guardians) ? player.guardians : []),
+        ...(Array.isArray(player.familyContacts) ? player.familyContacts : [])
+      ];
+      contacts.forEach((contact) => {
+        const userId = contact?.userId ? `user:${contact.userId}` : '';
+        const email = contact?.email ? `email:${normalizeEmail(contact.email)}` : '';
+        if (playerSelected || selectedIds.has(userId) || selectedIds.has(email)) {
+          matchingContacts.push(contact);
+        }
+      });
+      if (playerSelected) {
+        addPlayerContacts(recipientsByEmail, player);
+      } else {
+        matchingContacts.forEach((contact) => {
+          if (!isEmailEnabledContact(contact)) return;
+          addRecipient(recipientsByEmail, contact.email, { playerId, userId: contact.userId, role: 'guardian' });
+        });
+      }
+    });
+    return serializeRecipients(recipientsByEmail);
+  }
+
+  activePlayers.forEach((player) => addPlayerContacts(recipientsByEmail, player));
+  return serializeRecipients(recipientsByEmail);
+}
+
+function buildTeamEmailMailJob({ email, subject, body, teamId, messageId, senderUid }) {
+  const safeBody = normalizeText(body, 20000);
+  const html = safeBody
+    .split(/\n{2,}/)
+    .map((paragraph) => `<p>${paragraph.replace(/[&<>]/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;' }[char])).replace(/\n/g, '<br>')}</p>`)
+    .join('');
+  return {
+    to: [email],
+    message: {
+      subject,
+      text: safeBody,
+      html
+    },
+    metadata: {
+      teamId,
+      teamEmailMessageId: messageId,
+      type: 'team_email',
+      senderUid
+    }
+  };
+}
+
+module.exports = {
+  normalizeText,
+  normalizeEmail,
+  isEmailEnabledContact,
+  resolveTeamEmailRecipients,
+  buildTeamEmailMailJob
+};

--- a/functions/team-email-core.cjs
+++ b/functions/team-email-core.cjs
@@ -8,6 +8,24 @@ function normalizeEmail(value) {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) ? email : '';
 }
 
+function normalizeRecipientSelector(value) {
+  const raw = String(value || '').trim();
+  if (!raw) return '';
+  const separatorIndex = raw.indexOf(':');
+  if (separatorIndex < 0) return raw;
+  const kind = raw.slice(0, separatorIndex).trim().toLowerCase();
+  const id = raw.slice(separatorIndex + 1).trim();
+  if (!id) return '';
+  if (kind === 'email') {
+    const email = normalizeEmail(id);
+    return email ? `email:${email}` : '';
+  }
+  if (kind === 'player' || kind === 'user') {
+    return `${kind}:${id}`;
+  }
+  return raw;
+}
+
 function isEmailEnabledContact(contact = {}) {
   return contact.emailEnabled !== false &&
     contact.receiveEmail !== false &&
@@ -62,7 +80,7 @@ function serializeRecipients(recipientsByEmail) {
 function resolveTeamEmailRecipients({ targetType = 'full_team', recipientIds = [], players = [], team = {}, ownerUser = null } = {}) {
   const recipientsByEmail = new Map();
   const selectedIds = new Set((Array.isArray(recipientIds) ? recipientIds : [])
-    .map((id) => String(id || '').trim())
+    .map(normalizeRecipientSelector)
     .filter(Boolean));
   const activePlayers = players.filter((player) => player && player.active !== false);
 
@@ -79,7 +97,8 @@ function resolveTeamEmailRecipients({ targetType = 'full_team', recipientIds = [
   if (targetType === 'individuals' && selectedIds.size > 0) {
     activePlayers.forEach((player) => {
       const playerId = String(player.id || player.playerId || '');
-      const playerSelected = selectedIds.has(`player:${playerId}`) || selectedIds.has(playerId);
+      const playerSelector = normalizeRecipientSelector(`player:${playerId}`);
+      const playerSelected = selectedIds.has(playerSelector) || selectedIds.has(playerId);
       const matchingContacts = [];
       const contacts = [
         ...(Array.isArray(player.parents) ? player.parents : []),
@@ -87,8 +106,8 @@ function resolveTeamEmailRecipients({ targetType = 'full_team', recipientIds = [
         ...(Array.isArray(player.familyContacts) ? player.familyContacts : [])
       ];
       contacts.forEach((contact) => {
-        const userId = contact?.userId ? `user:${contact.userId}` : '';
-        const email = contact?.email ? `email:${normalizeEmail(contact.email)}` : '';
+        const userId = contact?.userId ? normalizeRecipientSelector(`user:${contact.userId}`) : '';
+        const email = contact?.email ? normalizeRecipientSelector(`email:${contact.email}`) : '';
         if (playerSelected || selectedIds.has(userId) || selectedIds.has(email)) {
           matchingContacts.push(contact);
         }

--- a/functions/test/team-email-core.test.cjs
+++ b/functions/test/team-email-core.test.cjs
@@ -1,0 +1,68 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { resolveTeamEmailRecipients, buildTeamEmailMailJob } = require('../team-email-core.cjs');
+
+test('resolveTeamEmailRecipients deduplicates enabled roster contacts without leaking disabled contacts', () => {
+  const recipients = resolveTeamEmailRecipients({
+    targetType: 'full_team',
+    players: [
+      {
+        id: 'p1',
+        active: true,
+        parents: [
+          { email: ' Mom@Example.com ', userId: 'u1' },
+          { email: 'skip@example.com', emailEnabled: false }
+        ]
+      },
+      {
+        id: 'p2',
+        active: true,
+        guardians: [{ email: 'mom@example.com', userId: 'u1' }]
+      },
+      {
+        id: 'p3',
+        active: false,
+        parents: [{ email: 'inactive@example.com' }]
+      }
+    ]
+  });
+
+  assert.equal(recipients.length, 1);
+  assert.deepEqual(recipients[0], {
+    email: 'mom@example.com',
+    playerIds: ['p1', 'p2'],
+    userIds: ['u1'],
+    roles: ['guardian']
+  });
+});
+
+test('resolveTeamEmailRecipients limits individual sends to selected recipients', () => {
+  const recipients = resolveTeamEmailRecipients({
+    targetType: 'individuals',
+    recipientIds: ['player:p2', 'email:extra@example.com'],
+    players: [
+      { id: 'p1', parents: [{ email: 'one@example.com' }] },
+      { id: 'p2', parents: [{ email: 'two@example.com' }] },
+      { id: 'p3', parents: [{ email: 'extra@example.com' }] }
+    ]
+  });
+
+  assert.deepEqual(recipients.map((recipient) => recipient.email), ['extra@example.com', 'two@example.com']);
+});
+
+test('buildTeamEmailMailJob keeps recipient email only in backend mail job', () => {
+  const job = buildTeamEmailMailJob({
+    email: 'parent@example.com',
+    subject: 'Practice update',
+    body: 'Line 1\nLine 2',
+    teamId: 'team1',
+    messageId: 'message1',
+    senderUid: 'coach1'
+  });
+
+  assert.deepEqual(job.to, ['parent@example.com']);
+  assert.equal(job.message.subject, 'Practice update');
+  assert.equal(job.metadata.type, 'team_email');
+  assert.equal(job.metadata.teamEmailMessageId, 'message1');
+  assert.match(job.message.html, /Line 1<br>Line 2/);
+});

--- a/functions/test/team-email-core.test.cjs
+++ b/functions/test/team-email-core.test.cjs
@@ -39,7 +39,7 @@ test('resolveTeamEmailRecipients deduplicates enabled roster contacts without le
 test('resolveTeamEmailRecipients limits individual sends to selected recipients', () => {
   const recipients = resolveTeamEmailRecipients({
     targetType: 'individuals',
-    recipientIds: ['player:p2', 'email:extra@example.com'],
+    recipientIds: ['player:p2', ' email:Extra@Example.com '],
     players: [
       { id: 'p1', parents: [{ email: 'one@example.com' }] },
       { id: 'p2', parents: [{ email: 'two@example.com' }] },

--- a/js/db.js
+++ b/js/db.js
@@ -31,9 +31,7 @@ import {
     ref,
     uploadBytes,
     getDownloadURL,
-    deleteObject,
-    functions,
-    httpsCallable
+    deleteObject
 } from './firebase.js?v=13';
 import { imageStorage, ensureImageAuth, requireImageAuth } from './firebase-images.js?v=6';
 import { uploadBytesResumable } from './vendor/firebase-storage.js';

--- a/js/db.js
+++ b/js/db.js
@@ -29,7 +29,9 @@ import {
     ref,
     uploadBytes,
     getDownloadURL,
-    deleteObject
+    deleteObject,
+    functions,
+    httpsCallable
 } from './firebase.js?v=13';
 import { imageStorage, ensureImageAuth, requireImageAuth } from './firebase-images.js?v=6';
 import { uploadBytesResumable } from './vendor/firebase-storage.js';
@@ -4615,6 +4617,29 @@ export function subscribeToChatMessages(teamId, { limit = 50, conversationId = D
         const oldestDoc = snapshot.docs.length ? snapshot.docs[snapshot.docs.length - 1] : null;
         onMessages(docs, oldestDoc);
     });
+}
+
+export async function sendTeamEmail(teamId, {
+    subject,
+    body,
+    targetType = 'full_team',
+    recipientIds = []
+} = {}) {
+    const callable = httpsCallable(functions, 'sendTeamEmail');
+    const result = await callable({
+        teamId,
+        subject,
+        body,
+        targetType,
+        recipientIds
+    });
+    return result.data;
+}
+
+export async function getSentTeamEmails(teamId, { limit = 25 } = {}) {
+    const emailsRef = collection(db, 'teams', teamId, 'teamEmails');
+    const snapshot = await getDocs(query(emailsRef, orderBy('sentAt', 'desc'), limitQuery(limit)));
+    return snapshot.docs.map((d) => ({ id: d.id, ...d.data(), _doc: d }));
 }
 
 /**

--- a/team-chat.html
+++ b/team-chat.html
@@ -1055,7 +1055,11 @@
         }
 
         function getRecipientOptionId(kind, value) {
-            return `${kind}:${String(value || '').trim()}`;
+            const normalizedKind = String(kind || '').trim().toLowerCase();
+            const normalizedValue = normalizedKind === 'email'
+                ? String(value || '').trim().toLowerCase()
+                : String(value || '').trim();
+            return `${normalizedKind}:${normalizedValue}`;
         }
 
         function getRecipientOptionLabel(option) {
@@ -1197,6 +1201,44 @@
             };
         }
 
+        function getConversationEmailRecipientIds(conversation = {}) {
+            const optionIds = new Set(recipientOptions.map((option) => option.id));
+            const ids = Array.isArray(conversation.participantIds) ? conversation.participantIds : [];
+            return Array.from(new Set(ids.flatMap((id) => {
+                const raw = String(id || '').trim();
+                if (!raw) return [];
+                if (raw.toLowerCase().startsWith('email:')) {
+                    return [getRecipientOptionId('email', raw.slice(6))];
+                }
+                if (raw.toLowerCase().startsWith('user:')) {
+                    return [getRecipientOptionId('user', raw.slice(5))];
+                }
+                return [raw, getRecipientOptionId('user', raw)];
+            }).filter((id) => optionIds.has(id))));
+        }
+
+        function buildEmailTargetMetadata() {
+            const activeConversation = getSelectedConversation();
+            if (activeConversation && !isDefaultTeamConversation(selectedConversationId)) {
+                const participantRoles = Array.isArray(activeConversation.participantRoles)
+                    ? activeConversation.participantRoles.map((role) => String(role || '').trim().toLowerCase())
+                    : [];
+                if (participantRoles.includes('staff')) {
+                    return {
+                        targetType: 'staff',
+                        recipientIds: [],
+                        targetRole: 'staff'
+                    };
+                }
+                return {
+                    targetType: 'individuals',
+                    recipientIds: getConversationEmailRecipientIds(activeConversation),
+                    targetRole: null
+                };
+            }
+            return buildRecipientTargetMetadata();
+        }
+
         function getRecipientSummaryText() {
             const target = buildRecipientTargetMetadata();
             if (target.targetType === 'staff') {
@@ -1314,7 +1356,7 @@
                 setEmailStatus('Subject and message are required.', 'error');
                 return;
             }
-            const targetMetadata = buildRecipientTargetMetadata();
+            const targetMetadata = buildEmailTargetMetadata();
             if (targetMetadata.targetType === 'individuals' && targetMetadata.recipientIds.length === 0) {
                 setEmailStatus('Select at least one recipient.', 'error');
                 return;

--- a/team-chat.html
+++ b/team-chat.html
@@ -75,6 +75,10 @@
                         Photos &amp; Videos
                         <span id="media-gallery-count" class="hidden rounded-full bg-primary-100 px-2 py-0.5 text-xs font-semibold text-primary-700"></span>
                     </button>
+                    <button id="email-panel-btn"
+                        class="hidden flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-gray-600 hover:text-primary-600 hover:bg-primary-50 rounded-lg transition">
+                        Team Email
+                    </button>
                     <button id="refresh-btn"
                         class="flex items-center gap-2 px-3 py-1.5 text-sm font-medium text-gray-600 hover:text-primary-600 hover:bg-primary-50 rounded-lg transition">
                         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -90,6 +94,30 @@
                 <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">Conversations</div>
                 <div id="conversations-list" class="flex gap-2 overflow-x-auto pb-1">
                     <button type="button" class="rounded-full bg-primary-600 px-3 py-1.5 text-sm font-medium text-white">Team-wide</button>
+                </div>
+            </div>
+
+            <div id="email-panel" class="hidden border-b border-gray-100 bg-white p-4 space-y-4">
+                <div class="rounded-xl border border-blue-100 bg-blue-50 p-3 text-sm text-blue-900">
+                    Send a backend email to roster contacts with email enabled. Sent messages are immutable and recipient email addresses are not shown here.
+                </div>
+                <div class="grid gap-3">
+                    <label class="block">
+                        <span class="text-xs font-semibold uppercase tracking-wide text-gray-500">Subject</span>
+                        <input id="email-subject" type="text" maxlength="160" class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="Practice update">
+                    </label>
+                    <label class="block">
+                        <span class="text-xs font-semibold uppercase tracking-wide text-gray-500">Message</span>
+                        <textarea id="email-body" rows="5" maxlength="20000" class="mt-1 w-full rounded-lg border border-gray-300 px-3 py-2 text-sm focus:border-primary-500 focus:outline-none focus:ring-2 focus:ring-primary-500" placeholder="Write the email message..."></textarea>
+                    </label>
+                    <div class="flex items-center justify-between gap-3">
+                        <div id="email-status" class="text-sm text-gray-600"></div>
+                        <button id="email-send-btn" type="button" class="rounded-lg bg-primary-600 px-4 py-2 text-sm font-semibold text-white hover:bg-primary-700 disabled:opacity-50">Send email</button>
+                    </div>
+                </div>
+                <div>
+                    <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">Sent email history</div>
+                    <div id="email-history" class="space-y-2 text-sm text-gray-600">No sent emails yet.</div>
                 </div>
             </div>
 
@@ -229,7 +257,7 @@
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=14';
-        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=31';
+        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=32';
         import { DEFAULT_TEAM_CONVERSATION_ID, buildDefaultTeamConversation, getConversationDisplayName, isDefaultTeamConversation } from './js/team-chat-conversations.js?v=1';
         import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from './js/team-chat-last-read.js?v=3';
         import {
@@ -476,6 +504,10 @@
                     exitUrl
                 });
                 await loadConversations();
+                if (canModerate) {
+                    document.getElementById('email-panel-btn')?.classList.remove('hidden');
+                    loadSentEmailHistory();
+                }
 
                 // Load messages (real-time)
                 startRealtimeUpdates();
@@ -1221,6 +1253,92 @@
                     </span>
                 </label>
             `).join('');
+        }
+
+        function renderEmailHistory(items = []) {
+            const container = document.getElementById('email-history');
+            if (!container) return;
+            if (!items.length) {
+                container.innerHTML = '<div class="rounded-lg border border-gray-200 px-3 py-2 text-gray-500">No sent emails yet.</div>';
+                return;
+            }
+            container.innerHTML = items.map((item) => {
+                const sentAt = item.sentAt?.toDate ? item.sentAt.toDate() : null;
+                const sentLabel = sentAt ? sentAt.toLocaleString([], { dateStyle: 'medium', timeStyle: 'short' }) : 'Queued';
+                const delivery = item.delivery || {};
+                const status = delivery.status || item.status || 'queued';
+                const jobCount = delivery.jobCount ?? item.recipientCount ?? 0;
+                return `
+                    <div class="rounded-lg border border-gray-200 bg-gray-50 px-3 py-2">
+                        <div class="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
+                            <div class="min-w-0">
+                                <div class="truncate font-semibold text-gray-900">${escapeHtml(item.subject || '(No subject)')}</div>
+                                <div class="text-xs text-gray-500">From ${escapeHtml(item.senderName || item.senderEmail || 'Team admin')} • ${escapeHtml(sentLabel)}</div>
+                            </div>
+                            <div class="text-xs text-gray-500 sm:text-right">
+                                ${Number(item.recipientCount || 0)} recipients • ${escapeHtml(status)} • ${Number(jobCount)} jobs
+                            </div>
+                        </div>
+                    </div>
+                `;
+            }).join('');
+        }
+
+        async function loadSentEmailHistory() {
+            if (!canModerate) return;
+            try {
+                renderEmailHistory(await getSentTeamEmails(teamId, { limit: 25 }));
+            } catch (error) {
+                console.warn('Failed to load sent email history:', error);
+                const container = document.getElementById('email-history');
+                if (container) {
+                    container.innerHTML = '<div class="rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-red-700">Could not load sent email history.</div>';
+                }
+            }
+        }
+
+        function setEmailStatus(message, tone = 'muted') {
+            const status = document.getElementById('email-status');
+            if (!status) return;
+            status.textContent = message || '';
+            status.className = `text-sm ${tone === 'error' ? 'text-red-600' : tone === 'success' ? 'text-green-700' : 'text-gray-600'}`;
+        }
+
+        async function sendEmailMessage() {
+            const subjectInput = document.getElementById('email-subject');
+            const bodyInput = document.getElementById('email-body');
+            const button = document.getElementById('email-send-btn');
+            const subject = subjectInput.value.trim();
+            const body = bodyInput.value.trim();
+            if (!subject || !body) {
+                setEmailStatus('Subject and message are required.', 'error');
+                return;
+            }
+            const targetMetadata = buildRecipientTargetMetadata();
+            if (targetMetadata.targetType === 'individuals' && targetMetadata.recipientIds.length === 0) {
+                setEmailStatus('Select at least one recipient.', 'error');
+                return;
+            }
+            button.disabled = true;
+            button.textContent = 'Sending...';
+            setEmailStatus('Creating backend mail jobs...');
+            try {
+                const result = await sendTeamEmail(teamId, {
+                    subject,
+                    body,
+                    ...targetMetadata
+                });
+                subjectInput.value = '';
+                bodyInput.value = '';
+                setEmailStatus(`Sent to ${result.recipientCount || 0} recipients. Delivery jobs queued.`, 'success');
+                await loadSentEmailHistory();
+            } catch (error) {
+                console.error('Error sending team email:', error);
+                setEmailStatus(error?.message || 'Email send failed. Nothing was silently dropped.', 'error');
+            } finally {
+                button.disabled = false;
+                button.textContent = 'Send email';
+            }
         }
 
         function updateComposerState() {
@@ -2039,6 +2157,14 @@
             document.getElementById('chat-image-input').addEventListener('change', handleImageSelection);
             document.getElementById('media-gallery-btn').addEventListener('click', openMediaGallery);
             document.getElementById('media-gallery-close-btn').addEventListener('click', closeMediaGallery);
+            document.getElementById('email-panel-btn').addEventListener('click', () => {
+                const panel = document.getElementById('email-panel');
+                panel.classList.toggle('hidden');
+                if (!panel.classList.contains('hidden')) {
+                    loadSentEmailHistory();
+                }
+            });
+            document.getElementById('email-send-btn').addEventListener('click', sendEmailMessage);
             document.getElementById('conversations-list').addEventListener('click', (event) => {
                 const button = event.target.closest('[data-conversation-id]');
                 if (!button) return;

--- a/tests/smoke/team-fallback-regressions.spec.js
+++ b/tests/smoke/team-fallback-regressions.spec.js
@@ -211,6 +211,12 @@ export function canModerateChat() {
     return false;
 }
 export async function updateChatLastRead() {}
+export async function sendTeamEmail() {
+    return { id: 'email-1', recipientCount: 1 };
+}
+export async function getSentTeamEmails() {
+    return [];
+}
 export function subscribeToChatMessages(teamId, options, onMessages) {
     setTimeout(() => {
         onMessages([

--- a/tests/unit/team-chat-recipient-targets.test.js
+++ b/tests/unit/team-chat-recipient-targets.test.js
@@ -27,6 +27,9 @@ describe('team chat recipient targets', () => {
         expect(html).toContain("targetType: 'staff'");
         expect(html).toContain("targetType: 'full_team'");
         expect(html).toContain('recipientIds: Array.from(selectedRecipientIds).sort()');
+        expect(html).toContain('function buildEmailTargetMetadata()');
+        expect(html).toContain("participantRoles.includes('staff')");
+        expect(html).toContain('const targetMetadata = buildEmailTargetMetadata();');
     });
 
     it('persists normalized target metadata from postChatMessage', () => {


### PR DESCRIPTION
Closes #1159

## Summary
- Added a callable backend send path that resolves email-enabled roster/staff recipients server-side, creates Firestore mail jobs, and records immutable sent team email history without exposing recipient email addresses in the UI.
- Added sent email history UI on Team Chat for coaches/admins with sender, recipient count, timestamp, delivery status, and job count metadata.
- Added focused tests for recipient resolution, disabled-contact filtering, deduplication, and backend mail job payloads.

## Validation
- `node --test functions/test/team-email-core.test.cjs`
- `node --check functions/index.js`
- `node --check js/db.js`
- `node scripts/validate-firebase-rules-ci.mjs`
- `git diff --check`