### PR TITLE
Support team email attachments

### DIFF
--- a/docs/pr-notes/runs/1163-ci-fix-20260521T160844Z/architecture.md
+++ b/docs/pr-notes/runs/1163-ci-fix-20260521T160844Z/architecture.md
@@ -1,0 +1,13 @@
+# Architecture Notes
+
+## Acceptance Criteria
+- `js/db.js` changed in the PR must have a matching cache-busted import version change so deployed browsers do not keep using the prior cached module URL.
+- Keep the fix scoped to cache invalidation only.
+
+## Architecture Decisions
+- Bump an existing `db.js` query-string version in a browser entry point instead of changing runtime logic.
+- Avoid touching Firebase rules, functions, or data model code for this CI-only regression.
+
+## Risks And Rollback
+- Risk is limited to forcing reload of the `db.js` module for the updated entry point.
+- Rollback is the single cache-bust import version change if needed.

--- a/docs/pr-notes/runs/1163-ci-fix-20260521T160844Z/code-plan.md
+++ b/docs/pr-notes/runs/1163-ci-fix-20260521T160844Z/code-plan.md
@@ -1,0 +1,9 @@
+# Code Plan
+
+## Root Cause
+- The PR modifies `js/db.js`, but the diff did not include any `db.js?v=<number>` import version change.
+- The cache-bust guard blocks this to prevent stale browser module caches after deploy.
+
+## Implementation Plan
+- Update one existing `./js/db.js?v=22` import in `team.html` to `./js/db.js?v=23`.
+- Re-run the guard locally.

--- a/docs/pr-notes/runs/1163-ci-fix-20260521T160844Z/qa.md
+++ b/docs/pr-notes/runs/1163-ci-fix-20260521T160844Z/qa.md
@@ -1,0 +1,9 @@
+# QA Notes
+
+## QA Plan
+- Re-run `node scripts/check-critical-cache-bust.mjs` with pull request environment variables matching CI.
+- Confirm the script reports `Critical cache-bust guard passed.`
+
+## Regression Risk
+- No functional JavaScript behavior changes are expected because only an import query parameter is bumped.
+- Browser impact is intentional cache invalidation for the changed `js/db.js` dependency.

--- a/firestore.rules
+++ b/firestore.rules
@@ -1523,6 +1523,16 @@ service cloud.firestore {
         }
       }
 
+      // Team email drafts and sent delivery history are coach/admin only.
+      match /emailDrafts/{draftId} {
+        allow read, create, update, delete: if isTeamOwnerOrAdmin(teamId);
+      }
+
+      match /emailSends/{sendId} {
+        allow read, create: if isTeamOwnerOrAdmin(teamId);
+        allow update, delete: if false;
+      }
+
       // Chat messages subcollection
       match /chatMessages/{messageId} {
         // List queries are unfiltered by target metadata in existing clients.

--- a/firestore.rules
+++ b/firestore.rules
@@ -1529,7 +1529,10 @@ service cloud.firestore {
       }
 
       match /emailSends/{sendId} {
-        allow read, create: if isTeamOwnerOrAdmin(teamId);
+        allow read: if isTeamOwnerOrAdmin(teamId);
+        allow create: if isTeamOwnerOrAdmin(teamId) &&
+                        request.resource.data.teamId == teamId &&
+                        request.resource.data.createdBy == request.auth.uid;
         allow update, delete: if false;
       }
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -2300,11 +2300,20 @@ function normalizeTeamEmailAttachmentRecord(attachment) {
   return { name, storagePath, contentType, size };
 }
 
+function isTeamEmailAttachmentPathForTeam(teamId, storagePath) {
+  const cleanTeamId = String(teamId || '').trim();
+  const parts = String(storagePath || '').trim().split('/');
+  return parts.length >= 5 &&
+    parts[0] === 'team-email-attachments' &&
+    parts[1] === cleanTeamId &&
+    parts.slice(2).every(Boolean);
+}
+
 function normalizeTeamEmailAttachmentsForDelivery(teamId, attachments) {
   const rawAttachments = Array.isArray(attachments) ? attachments : [];
   const normalized = rawAttachments.map(normalizeTeamEmailAttachmentRecord).filter(Boolean);
   if (normalized.length !== rawAttachments.length ||
-      normalized.some((attachment) => !attachment.storagePath.startsWith(`team-email-attachments/${teamId}/`))) {
+      normalized.some((attachment) => !isTeamEmailAttachmentPathForTeam(teamId, attachment.storagePath))) {
     throw new Error('Team email attachments must reference files for the same team.');
   }
   const totalBytes = normalized.reduce((sum, attachment) => sum + attachment.size, 0);
@@ -2312,6 +2321,12 @@ function normalizeTeamEmailAttachmentsForDelivery(teamId, attachments) {
     throw new Error('Team email attachments exceed the 20 MB limit.');
   }
   return { attachments: normalized, totalBytes };
+}
+
+function buildTeamEmailMailDocId(teamId, sendId) {
+  const safeTeamId = String(teamId || '').replace(/[^\w.-]+/g, '_').slice(0, 240);
+  const safeSendId = String(sendId || '').replace(/[^\w.-]+/g, '_').slice(0, 240);
+  return `teamEmail_${safeTeamId}_${safeSendId}`;
 }
 
 exports.queueTeamEmailDelivery = functions.firestore
@@ -2346,7 +2361,8 @@ exports.queueTeamEmailDelivery = functions.firestore
       return;
     }
 
-    await firestore.collection('mail').add({
+    const mailRef = firestore.collection('mail').doc(buildTeamEmailMailDocId(teamId, sendId));
+    await mailRef.set({
       to: recipients,
       message: {
         subject,
@@ -2368,6 +2384,7 @@ exports.queueTeamEmailDelivery = functions.firestore
     await snap.ref.set({
       status: 'queued',
       attachmentTotalBytes: totalBytes,
+      mailJobId: mailRef.id,
       queuedAt: admin.firestore.FieldValue.serverTimestamp(),
       updatedAt: admin.firestore.FieldValue.serverTimestamp()
     }, { merge: true });

--- a/functions/index.js
+++ b/functions/index.js
@@ -2288,3 +2288,87 @@ exports.collectTelemetry = functions
       });
     }
   });
+
+const TEAM_EMAIL_ATTACHMENT_LIMIT_BYTES = 20 * 1024 * 1024;
+
+function normalizeTeamEmailAttachmentRecord(attachment) {
+  const name = String(attachment?.name || attachment?.fileName || '').trim();
+  const storagePath = String(attachment?.storagePath || attachment?.path || '').trim();
+  const contentType = String(attachment?.contentType || attachment?.type || 'application/octet-stream').trim();
+  const size = Number(attachment?.size || attachment?.bytes || 0);
+  if (!name || !storagePath || !Number.isFinite(size) || size <= 0) return null;
+  return { name, storagePath, contentType, size };
+}
+
+function normalizeTeamEmailAttachmentsForDelivery(teamId, attachments) {
+  const rawAttachments = Array.isArray(attachments) ? attachments : [];
+  const normalized = rawAttachments.map(normalizeTeamEmailAttachmentRecord).filter(Boolean);
+  if (normalized.length !== rawAttachments.length ||
+      normalized.some((attachment) => !attachment.storagePath.startsWith(`team-email-attachments/${teamId}/`))) {
+    throw new Error('Team email attachments must reference files for the same team.');
+  }
+  const totalBytes = normalized.reduce((sum, attachment) => sum + attachment.size, 0);
+  if (totalBytes > TEAM_EMAIL_ATTACHMENT_LIMIT_BYTES) {
+    throw new Error('Team email attachments exceed the 20 MB limit.');
+  }
+  return { attachments: normalized, totalBytes };
+}
+
+exports.queueTeamEmailDelivery = functions.firestore
+  .document('teams/{teamId}/emailSends/{sendId}')
+  .onCreate(async (snap, context) => {
+    const { teamId, sendId } = context.params;
+    const send = snap.data() || {};
+    const recipients = Array.isArray(send.recipients)
+      ? send.recipients.map((email) => String(email || '').trim()).filter(Boolean)
+      : [];
+    const subject = String(send.subject || '').trim();
+    const body = String(send.body || '').trim();
+    let attachmentSummary;
+    try {
+      attachmentSummary = normalizeTeamEmailAttachmentsForDelivery(teamId, send.attachments);
+    } catch (error) {
+      await snap.ref.set({
+        status: 'failed',
+        failureReason: error?.message || 'Invalid team email attachments.',
+        updatedAt: admin.firestore.FieldValue.serverTimestamp()
+      }, { merge: true });
+      return;
+    }
+    const { attachments, totalBytes } = attachmentSummary;
+
+    if (!recipients.length || !subject || !body) {
+      await snap.ref.set({
+        status: 'failed',
+        failureReason: 'Missing recipients, subject, or body.',
+        updatedAt: admin.firestore.FieldValue.serverTimestamp()
+      }, { merge: true });
+      return;
+    }
+
+    await firestore.collection('mail').add({
+      to: recipients,
+      message: {
+        subject,
+        text: body
+      },
+      createdAt: admin.firestore.FieldValue.serverTimestamp(),
+      metadata: {
+        type: 'team_email',
+        teamId,
+        sendId,
+        draftId: send.draftId || null,
+        attachments,
+        attachmentTotalBytes: totalBytes,
+        createdBy: send.createdBy || null,
+        createdByEmail: send.createdByEmail || null
+      }
+    });
+
+    await snap.ref.set({
+      status: 'queued',
+      attachmentTotalBytes: totalBytes,
+      queuedAt: admin.firestore.FieldValue.serverTimestamp(),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true });
+  });

--- a/js/db.js
+++ b/js/db.js
@@ -106,6 +106,18 @@ import {
     updateOfficiatingSlotResponse
 } from './officiating-utils.js?v=3';
 import { buildOfficiatingNotificationRecord } from './officiating-notifications.js?v=2';
+export {
+    TEAM_EMAIL_ATTACHMENT_LIMIT_BYTES,
+    assertTeamEmailAttachmentLimit,
+    buildTeamEmailDeliveryPayload,
+    deleteTeamEmailAttachment,
+    getTeamEmailAttachmentTotalBytes,
+    getTeamEmailDraft,
+    normalizeTeamEmailAttachments,
+    queueTeamEmailSend,
+    saveTeamEmailDraft,
+    uploadTeamEmailAttachment
+} from './team-email-attachments.js?v=1';
 // import { getAI, getGenerativeModel, GoogleAIBackend } from 'https://www.gstatic.com/firebasejs/12.6.0/firebase-vertexai.js';
 export { collection, getDocs, deleteDoc, query };
 const limitQuery = limit;

--- a/js/team-email-attachments.js
+++ b/js/team-email-attachments.js
@@ -24,6 +24,53 @@ function cleanString(value) {
     return String(value || '').trim();
 }
 
+function normalizeEmail(value) {
+    return cleanString(value).toLowerCase();
+}
+
+function getAttachmentTeamIdFromPath(path) {
+    const parts = cleanString(path).split('/');
+    return parts[0] === 'team-email-attachments' ? cleanString(parts[1]) : '';
+}
+
+function isTeamEmailAttachmentPathForTeam(teamId, path) {
+    const cleanTeamId = cleanString(teamId);
+    const parts = cleanString(path).split('/');
+    return parts.length >= 5 &&
+        parts[0] === 'team-email-attachments' &&
+        parts[1] === cleanTeamId &&
+        parts.slice(2).every(Boolean);
+}
+
+async function assertTeamEmailManagerAccess(teamId, user = auth.currentUser) {
+    const cleanTeamId = cleanString(teamId);
+    if (!cleanTeamId) throw new Error('Missing team for team email action.');
+    if (!user?.uid) throw new Error('Sign in to manage team email.');
+
+    const teamSnap = await getDoc(doc(db, 'teams', cleanTeamId));
+    if (!teamSnap.exists()) throw new Error('Team not found.');
+
+    const team = teamSnap.data() || {};
+    const userEmail = normalizeEmail(user.email);
+    const adminEmails = Array.isArray(team.adminEmails)
+        ? team.adminEmails.map(normalizeEmail)
+        : [];
+    let isGlobalAdmin = user.isAdmin === true;
+    if (!isGlobalAdmin) {
+        try {
+            const userSnap = await getDoc(doc(db, 'users', user.uid));
+            isGlobalAdmin = userSnap.exists() && userSnap.data()?.isAdmin === true;
+        } catch (_) {
+            isGlobalAdmin = false;
+        }
+    }
+
+    if (team.ownerId !== user.uid && !adminEmails.includes(userEmail) && !isGlobalAdmin) {
+        throw new Error('Only team coaches and admins can manage team email.');
+    }
+    return { teamId: cleanTeamId, team };
+}
+
 export function getTeamEmailAttachmentTotalBytes(attachments = []) {
     return (Array.isArray(attachments) ? attachments : []).reduce((total, attachment) => {
         const size = Number(attachment?.size || attachment?.bytes || 0);
@@ -65,33 +112,49 @@ export function normalizeTeamEmailAttachments(attachments = []) {
 }
 
 export async function uploadTeamEmailAttachment(teamId, file, { draftId = 'draft', user = auth.currentUser } = {}) {
-    if (!teamId) throw new Error('Missing team for email attachment.');
     if (!file) throw new Error('Missing email attachment file.');
-    if (!user?.uid) throw new Error('Sign in to attach files to team emails.');
+    const { teamId: cleanTeamId } = await assertTeamEmailManagerAccess(teamId, user);
 
     assertTeamEmailAttachmentLimit([{ size: file.size }]);
 
     const ts = Date.now();
-    const path = `team-email-attachments/${teamId}/${cleanString(draftId) || 'draft'}/${user.uid}/${ts}_${safeFileName(file.name)}`;
-    const storageRef = ref(storage, path);
-    const snapshot = await uploadBytes(storageRef, file);
-    const downloadUrl = await getDownloadURL(snapshot.ref);
+    const path = `team-email-attachments/${cleanTeamId}/${cleanString(draftId) || 'draft'}/${user.uid}/${ts}_${safeFileName(file.name)}`;
+    try {
+        const storageRef = ref(storage, path);
+        const snapshot = await uploadBytes(storageRef, file);
+        const downloadUrl = await getDownloadURL(snapshot.ref);
 
-    return {
-        name: file.name || 'attachment',
-        storagePath: path,
-        contentType: file.type || 'application/octet-stream',
-        size: Number.isFinite(file.size) ? file.size : 0,
-        downloadUrl,
-        uploadedBy: user.uid,
-        uploadedAt: Timestamp.now()
-    };
+        return {
+            name: file.name || 'attachment',
+            storagePath: path,
+            teamId: cleanTeamId,
+            contentType: file.type || 'application/octet-stream',
+            size: Number.isFinite(file.size) ? file.size : 0,
+            downloadUrl,
+            uploadedBy: user.uid,
+            uploadedAt: Timestamp.now()
+        };
+    } catch (error) {
+        console.error('Error uploading team email attachment:', error);
+        throw error;
+    }
 }
 
-export async function deleteTeamEmailAttachment(attachment) {
+export async function deleteTeamEmailAttachment(attachment, { user = auth.currentUser } = {}) {
     const path = cleanString(attachment?.storagePath || attachment?.path);
-    if (!path) return;
-    await deleteObject(ref(storage, path));
+    if (!path) return false;
+    const teamId = cleanString(attachment?.teamId) || getAttachmentTeamIdFromPath(path);
+    await assertTeamEmailManagerAccess(teamId, user);
+    if (!isTeamEmailAttachmentPathForTeam(teamId, path)) {
+        throw new Error('Team email attachment path does not belong to this team.');
+    }
+    try {
+        await deleteObject(ref(storage, path));
+        return true;
+    } catch (error) {
+        console.error('Error deleting team email attachment:', error);
+        throw error;
+    }
 }
 
 export function buildTeamEmailDeliveryPayload({ draft = {}, teamId, sender = auth.currentUser } = {}) {
@@ -112,8 +175,7 @@ export function buildTeamEmailDeliveryPayload({ draft = {}, teamId, sender = aut
 }
 
 export async function saveTeamEmailDraft(teamId, draft = {}, { user = auth.currentUser } = {}) {
-    if (!teamId) throw new Error('Missing team for email draft.');
-    if (!user?.uid) throw new Error('Sign in to save team email drafts.');
+    const { teamId: cleanTeamId } = await assertTeamEmailManagerAccess(teamId, user);
 
     const now = Timestamp.now();
     const attachments = normalizeTeamEmailAttachments(draft.attachments || []);
@@ -128,11 +190,11 @@ export async function saveTeamEmailDraft(teamId, draft = {}, { user = auth.curre
     };
 
     if (draft.id) {
-        await setDoc(doc(db, 'teams', teamId, 'emailDrafts', draft.id), payload, { merge: true });
+        await setDoc(doc(db, 'teams', cleanTeamId, 'emailDrafts', draft.id), payload, { merge: true });
         return draft.id;
     }
 
-    const docRef = await addDoc(collection(db, 'teams', teamId, 'emailDrafts'), {
+    const docRef = await addDoc(collection(db, 'teams', cleanTeamId, 'emailDrafts'), {
         ...payload,
         createdAt: now,
         createdBy: user.uid
@@ -142,15 +204,15 @@ export async function saveTeamEmailDraft(teamId, draft = {}, { user = auth.curre
 
 export async function getTeamEmailDraft(teamId, draftId) {
     if (!teamId || !draftId) return null;
-    const snap = await getDoc(doc(db, 'teams', teamId, 'emailDrafts', draftId));
+    const { teamId: cleanTeamId } = await assertTeamEmailManagerAccess(teamId);
+    const snap = await getDoc(doc(db, 'teams', cleanTeamId, 'emailDrafts', draftId));
     return snap.exists() ? { id: snap.id, ...snap.data() } : null;
 }
 
 export async function queueTeamEmailSend(teamId, draft = {}, { user = auth.currentUser } = {}) {
-    if (!teamId) throw new Error('Missing team for email send.');
-    if (!user?.uid) throw new Error('Sign in to send team emails.');
+    const { teamId: cleanTeamId } = await assertTeamEmailManagerAccess(teamId, user);
 
-    const payload = buildTeamEmailDeliveryPayload({ draft, teamId, sender: user });
-    const sendRef = await addDoc(collection(db, 'teams', teamId, 'emailSends'), payload);
+    const payload = buildTeamEmailDeliveryPayload({ draft, teamId: cleanTeamId, sender: user });
+    const sendRef = await addDoc(collection(db, 'teams', cleanTeamId, 'emailSends'), payload);
     return sendRef.id;
 }

--- a/js/team-email-attachments.js
+++ b/js/team-email-attachments.js
@@ -1,0 +1,156 @@
+import {
+    auth,
+    db,
+    storage,
+    collection,
+    doc,
+    addDoc,
+    setDoc,
+    getDoc,
+    Timestamp,
+    ref,
+    uploadBytes,
+    getDownloadURL,
+    deleteObject
+} from './firebase.js?v=13';
+
+export const TEAM_EMAIL_ATTACHMENT_LIMIT_BYTES = 20 * 1024 * 1024;
+
+function safeFileName(name) {
+    return String(name || 'attachment').trim().replace(/[^\w.\-]+/g, '_') || 'attachment';
+}
+
+function cleanString(value) {
+    return String(value || '').trim();
+}
+
+export function getTeamEmailAttachmentTotalBytes(attachments = []) {
+    return (Array.isArray(attachments) ? attachments : []).reduce((total, attachment) => {
+        const size = Number(attachment?.size || attachment?.bytes || 0);
+        return total + (Number.isFinite(size) && size > 0 ? size : 0);
+    }, 0);
+}
+
+export function assertTeamEmailAttachmentLimit(attachments = []) {
+    const totalBytes = getTeamEmailAttachmentTotalBytes(attachments);
+    if (totalBytes > TEAM_EMAIL_ATTACHMENT_LIMIT_BYTES) {
+        throw new Error('Team email attachments must be 20 MB or smaller in total.');
+    }
+    return totalBytes;
+}
+
+export function normalizeTeamEmailAttachments(attachments = []) {
+    const normalized = (Array.isArray(attachments) ? attachments : [])
+        .map((attachment) => {
+            const name = cleanString(attachment?.name || attachment?.fileName);
+            const path = cleanString(attachment?.path || attachment?.storagePath);
+            const downloadUrl = cleanString(attachment?.downloadUrl || attachment?.url);
+            const contentType = cleanString(attachment?.contentType || attachment?.type) || 'application/octet-stream';
+            const size = Number(attachment?.size || attachment?.bytes || 0);
+            if (!name || !path || !Number.isFinite(size) || size <= 0) return null;
+            return {
+                name,
+                storagePath: path,
+                contentType,
+                size,
+                downloadUrl: downloadUrl || null,
+                uploadedBy: cleanString(attachment?.uploadedBy) || null,
+                uploadedAt: attachment?.uploadedAt || null
+            };
+        })
+        .filter(Boolean);
+
+    assertTeamEmailAttachmentLimit(normalized);
+    return normalized;
+}
+
+export async function uploadTeamEmailAttachment(teamId, file, { draftId = 'draft', user = auth.currentUser } = {}) {
+    if (!teamId) throw new Error('Missing team for email attachment.');
+    if (!file) throw new Error('Missing email attachment file.');
+    if (!user?.uid) throw new Error('Sign in to attach files to team emails.');
+
+    assertTeamEmailAttachmentLimit([{ size: file.size }]);
+
+    const ts = Date.now();
+    const path = `team-email-attachments/${teamId}/${cleanString(draftId) || 'draft'}/${user.uid}/${ts}_${safeFileName(file.name)}`;
+    const storageRef = ref(storage, path);
+    const snapshot = await uploadBytes(storageRef, file);
+    const downloadUrl = await getDownloadURL(snapshot.ref);
+
+    return {
+        name: file.name || 'attachment',
+        storagePath: path,
+        contentType: file.type || 'application/octet-stream',
+        size: Number.isFinite(file.size) ? file.size : 0,
+        downloadUrl,
+        uploadedBy: user.uid,
+        uploadedAt: Timestamp.now()
+    };
+}
+
+export async function deleteTeamEmailAttachment(attachment) {
+    const path = cleanString(attachment?.storagePath || attachment?.path);
+    if (!path) return;
+    await deleteObject(ref(storage, path));
+}
+
+export function buildTeamEmailDeliveryPayload({ draft = {}, teamId, sender = auth.currentUser } = {}) {
+    const attachments = normalizeTeamEmailAttachments(draft.attachments || []);
+    return {
+        teamId,
+        draftId: draft.id || null,
+        recipients: Array.isArray(draft.recipients) ? draft.recipients : [],
+        subject: cleanString(draft.subject),
+        body: cleanString(draft.body),
+        attachments,
+        attachmentTotalBytes: getTeamEmailAttachmentTotalBytes(attachments),
+        createdBy: sender?.uid || draft.createdBy || null,
+        createdByEmail: sender?.email || draft.createdByEmail || null,
+        status: 'queued',
+        createdAt: Timestamp.now()
+    };
+}
+
+export async function saveTeamEmailDraft(teamId, draft = {}, { user = auth.currentUser } = {}) {
+    if (!teamId) throw new Error('Missing team for email draft.');
+    if (!user?.uid) throw new Error('Sign in to save team email drafts.');
+
+    const now = Timestamp.now();
+    const attachments = normalizeTeamEmailAttachments(draft.attachments || []);
+    const payload = {
+        recipients: Array.isArray(draft.recipients) ? draft.recipients : [],
+        subject: cleanString(draft.subject),
+        body: cleanString(draft.body),
+        attachments,
+        attachmentTotalBytes: getTeamEmailAttachmentTotalBytes(attachments),
+        updatedAt: now,
+        updatedBy: user.uid
+    };
+
+    if (draft.id) {
+        await setDoc(doc(db, 'teams', teamId, 'emailDrafts', draft.id), payload, { merge: true });
+        return draft.id;
+    }
+
+    const docRef = await addDoc(collection(db, 'teams', teamId, 'emailDrafts'), {
+        ...payload,
+        createdAt: now,
+        createdBy: user.uid
+    });
+    return docRef.id;
+}
+
+export async function getTeamEmailDraft(teamId, draftId) {
+    if (!teamId || !draftId) return null;
+    const snap = await getDoc(doc(db, 'teams', teamId, 'emailDrafts', draftId));
+    return snap.exists() ? { id: snap.id, ...snap.data() } : null;
+}
+
+export async function queueTeamEmailSend(teamId, draft = {}, { user = auth.currentUser } = {}) {
+    if (!teamId) throw new Error('Missing team for email send.');
+    if (!user?.uid) throw new Error('Sign in to send team emails.');
+
+    const payload = buildTeamEmailDeliveryPayload({ draft, teamId, sender: user });
+    const sendRef = await addDoc(collection(db, 'teams', teamId, 'emailSends'), payload);
+    return sendRef.id;
+}

--- a/storage.rules
+++ b/storage.rules
@@ -57,6 +57,17 @@ service firebase.storage {
       allow update: if false;
     }
 
+    match /team-email-attachments/{teamId}/{draftId}/{userId}/{fileName} {
+      allow get: if isTeamOwnerOrAdmin(teamId);
+      allow list: if false;
+      allow create: if isTeamOwnerOrAdmin(teamId) &&
+        request.auth.uid == userId &&
+        request.resource.size > 0 &&
+        request.resource.size <= 20 * 1024 * 1024;
+      allow delete: if isTeamOwnerOrAdmin(teamId);
+      allow update: if false;
+    }
+
     match /stat-sheets/{fileName=**} {
       allow get, create, delete: if isSignedIn();
       allow list, update: if false;

--- a/team.html
+++ b/team.html
@@ -316,7 +316,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, grantStreamScoreAccess, revokeStreamScoreAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=22';
+        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, grantStreamScoreAccess, revokeStreamScoreAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=23';
         import { normalizeExternalWebsiteUrl, selectRotatingSponsor } from './js/local-attractions.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, escapeHtml, shareOrCopy } from './js/utils.js?v=10';
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';

--- a/tests/unit/team-email-attachments.test.js
+++ b/tests/unit/team-email-attachments.test.js
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readRepoFile(relativePath) {
+    return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+describe('team email attachments', () => {
+    it('enforces the combined 20 MB limit before drafts or sends are persisted', () => {
+        const source = readRepoFile('js/team-email-attachments.js');
+
+        expect(source).toContain('TEAM_EMAIL_ATTACHMENT_LIMIT_BYTES = 20 * 1024 * 1024');
+        expect(source).toContain('assertTeamEmailAttachmentLimit(normalized);');
+        expect(source).toContain('attachmentTotalBytes: getTeamEmailAttachmentTotalBytes(attachments)');
+        expect(source).toContain('saveTeamEmailDraft');
+        expect(source).toContain('queueTeamEmailSend');
+    });
+
+    it('carries storage metadata into delivery jobs and sent history', () => {
+        const source = readRepoFile('functions/index.js');
+
+        expect(source).toContain("document('teams/{teamId}/emailSends/{sendId}')");
+        expect(source).toContain("type: 'team_email'");
+        expect(source).toContain('attachments,');
+        expect(source).toContain('attachmentTotalBytes: totalBytes');
+    });
+
+    it('limits draft/send docs and attachment files to team coaches and admins', () => {
+        const firestoreRules = readRepoFile('firestore.rules');
+        const storageRules = readRepoFile('storage.rules');
+
+        expect(firestoreRules).toContain('match /emailDrafts/{draftId}');
+        expect(firestoreRules).toContain('match /emailSends/{sendId}');
+        expect(firestoreRules).toContain('allow read, create, update, delete: if isTeamOwnerOrAdmin(teamId);');
+        expect(storageRules).toContain('match /team-email-attachments/{teamId}/{draftId}/{userId}/{fileName}');
+        expect(storageRules).toContain('allow get: if isTeamOwnerOrAdmin(teamId);');
+        expect(storageRules).toContain('request.resource.size <= 20 * 1024 * 1024');
+    });
+});

--- a/tests/unit/team-email-attachments.test.js
+++ b/tests/unit/team-email-attachments.test.js
@@ -11,9 +11,21 @@ describe('team email attachments', () => {
 
         expect(source).toContain('TEAM_EMAIL_ATTACHMENT_LIMIT_BYTES = 20 * 1024 * 1024');
         expect(source).toContain('assertTeamEmailAttachmentLimit(normalized);');
+        expect(source).toContain('Number.isFinite(size) && size > 0 ? size : 0');
         expect(source).toContain('attachmentTotalBytes: getTeamEmailAttachmentTotalBytes(attachments)');
         expect(source).toContain('saveTeamEmailDraft');
         expect(source).toContain('queueTeamEmailSend');
+    });
+
+    it('checks manager access before attachment draft and send operations', () => {
+        const source = readRepoFile('js/team-email-attachments.js');
+
+        expect(source).toContain('async function assertTeamEmailManagerAccess(teamId, user = auth.currentUser)');
+        expect(source).toContain('await assertTeamEmailManagerAccess(teamId, user)');
+        expect(source).toContain('await assertTeamEmailManagerAccess(teamId)');
+        expect(source).toContain("console.error('Error uploading team email attachment:', error);");
+        expect(source).toContain("console.error('Error deleting team email attachment:', error);");
+        expect(source).toContain('isTeamEmailAttachmentPathForTeam(teamId, path)');
     });
 
     it('carries storage metadata into delivery jobs and sent history', () => {
@@ -23,6 +35,9 @@ describe('team email attachments', () => {
         expect(source).toContain("type: 'team_email'");
         expect(source).toContain('attachments,');
         expect(source).toContain('attachmentTotalBytes: totalBytes');
+        expect(source).toContain('function isTeamEmailAttachmentPathForTeam(teamId, storagePath)');
+        expect(source).toContain('buildTeamEmailMailDocId(teamId, sendId)');
+        expect(source).toContain('mailJobId: mailRef.id');
     });
 
     it('limits draft/send docs and attachment files to team coaches and admins', () => {
@@ -32,6 +47,8 @@ describe('team email attachments', () => {
         expect(firestoreRules).toContain('match /emailDrafts/{draftId}');
         expect(firestoreRules).toContain('match /emailSends/{sendId}');
         expect(firestoreRules).toContain('allow read, create, update, delete: if isTeamOwnerOrAdmin(teamId);');
+        expect(firestoreRules).toContain('request.resource.data.teamId == teamId');
+        expect(firestoreRules).toContain('request.resource.data.createdBy == request.auth.uid');
         expect(storageRules).toContain('match /team-email-attachments/{teamId}/{draftId}/{userId}/{fileName}');
         expect(storageRules).toContain('allow get: if isTeamOwnerOrAdmin(teamId);');
         expect(storageRules).toContain('request.resource.size <= 20 * 1024 * 1024');


### PR DESCRIPTION
Closes #1160

## Summary
- Added team email attachment helpers for upload, delete, draft persistence, send queueing, metadata normalization, and combined 20 MB enforcement.
- Added a Cloud Function trigger that converts team email send records into mail jobs with secure storage attachment references in metadata.
- Restricted team email draft/send records and attachment storage paths to team owner/admin access.

## Validation
- `npx vitest run tests/unit/team-email-attachments.test.js`
- `node --check functions/index.js`
- `node scripts/check-critical-cache-bust.mjs`
- `npm run ci:firebase-rules`