### PR TITLE
Add default game assignments feature for teams

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -120,6 +120,17 @@
             <p id="team-reminder-settings-summary" class="mt-3 text-sm text-gray-600"></p>
         </div>
 
+        <div id="bulk-assignments-panel" class="mb-6 bg-white border border-gray-200 rounded-lg p-4 shadow-sm hidden">
+            <div class="flex items-start justify-between gap-4">
+                <div>
+                    <h3 class="font-semibold text-gray-900">Default Game Assignments</h3>
+                    <p id="bulk-assignments-description" class="text-sm text-gray-600"></p>
+                </div>
+                <button id="bulk-apply-assignments-btn" type="button" class="shrink-0 bg-indigo-600 text-white text-sm px-4 py-2 rounded-md hover:bg-indigo-700 transition">Apply to All Upcoming Games</button>
+            </div>
+            <p id="bulk-assignments-result" class="mt-2 text-sm text-green-700 hidden"></p>
+        </div>
+
         <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
             <!-- Add Game Form -->
             <div class="lg:col-span-1">
@@ -1503,6 +1514,20 @@
             return normalizeScheduleNotificationSettings(currentTeam?.scheduleNotifications || {});
         }
 
+        function renderBulkAssignmentsPanel(team) {
+            const defaults = team?.defaultAssignments || [];
+            const panel = document.getElementById('bulk-assignments-panel');
+            const desc = document.getElementById('bulk-assignments-description');
+            if (!panel || !desc) return;
+            if (defaults.length === 0) {
+                panel.classList.add('hidden');
+                return;
+            }
+            panel.classList.remove('hidden');
+            const roleList = defaults.map(a => a.role).join(', ');
+            desc.textContent = `Configured roles: ${roleList}. Adds these as claimable slots to upcoming games that have no assignments yet.`;
+        }
+
         function renderTeamScheduleNotificationSettings(team) {
             const rawSettings = team?.scheduleNotifications || {};
             const settings = normalizeScheduleNotificationSettings(rawSettings);
@@ -1666,6 +1691,7 @@
 
             currentTeam = team;
             renderTeamScheduleNotificationSettings(team);
+            renderBulkAssignmentsPanel(team);
             renderRegistrationScheduleImport(team);
             setupOpponentSearch();
             document.getElementById('team-name-display').textContent = team.name;
@@ -3096,9 +3122,14 @@
             populateOfficiatingSlots([]);
         }
 
-        // Pre-populate assignments for new games from the latest game
+        // Pre-populate assignments for new games from team defaults or latest game
         async function prefillAssignments() {
-            if (editingGameId) return; // Don't prefill when editing
+            if (editingGameId) return;
+            const defaults = currentTeam?.defaultAssignments;
+            if (defaults && defaults.length > 0) {
+                populateAssignments(defaults.map(a => ({ role: a.role, value: '', claimable: true })));
+                return;
+            }
             try {
                 const latest = await getLatestGameAssignments(currentTeamId);
                 if (latest && latest.length > 0) {
@@ -3667,6 +3698,41 @@
                 alert('Schedule reminder settings saved.');
             } catch (error) {
                 alert('Error saving reminder settings: ' + error.message);
+            }
+        });
+
+        document.getElementById('bulk-apply-assignments-btn').addEventListener('click', async () => {
+            const defaults = currentTeam?.defaultAssignments || [];
+            if (defaults.length === 0) return;
+            const roleList = defaults.map(a => a.role).join(', ');
+            if (!confirm(`Add "${roleList}" as claimable assignment slots to all upcoming games that have no assignments yet?`)) return;
+
+            const btn = document.getElementById('bulk-apply-assignments-btn');
+            const resultEl = document.getElementById('bulk-assignments-result');
+            btn.disabled = true;
+            btn.textContent = 'Applying...';
+            resultEl.classList.add('hidden');
+
+            try {
+                const now = new Date();
+                const events = Object.values(gamesCache);
+                const upcoming = events.filter(g => {
+                    const d = g.date?.toDate ? g.date.toDate() : new Date(g.date);
+                    return g.type === 'game' && d >= now && (!g.assignments || g.assignments.length === 0);
+                });
+
+                await Promise.all(upcoming.map(g =>
+                    updateGame(currentTeamId, g.id, { assignments: defaults.map(a => ({ role: a.role, value: '', claimable: true })) })
+                ));
+
+                resultEl.textContent = `Updated ${upcoming.length} upcoming game${upcoming.length === 1 ? '' : 's'}.`;
+                resultEl.classList.remove('hidden');
+                await loadSchedule();
+            } catch (error) {
+                alert('Error applying assignments: ' + error.message);
+            } finally {
+                btn.disabled = false;
+                btn.textContent = 'Apply to All Upcoming Games';
             }
         });
 

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -3715,7 +3715,7 @@
 
             try {
                 const now = new Date();
-                const events = Object.values(gamesCache);
+                const events = Object.values(allTeamGamesCache);
                 const upcoming = events.filter(g => {
                     const d = g.date?.toDate ? g.date.toDate() : new Date(g.date);
                     return g.type === 'game' && d >= now && (!g.assignments || g.assignments.length === 0);

--- a/edit-team.html
+++ b/edit-team.html
@@ -642,7 +642,7 @@
             const row = document.createElement('div');
             row.className = 'flex gap-2 items-center';
             row.innerHTML = `
-                <input type="text" placeholder="Role (e.g. Snack)" value="${role}" class="default-assignment-role flex-1 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm">
+                <input type="text" placeholder="Role (e.g. Snack)" value="${escapeHtml(role)}" class="default-assignment-role flex-1 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm">
                 <button type="button" class="text-red-400 hover:text-red-600 text-lg font-bold leading-none" onclick="this.parentElement.remove()">&times;</button>
             `;
             container.appendChild(row);

--- a/edit-team.html
+++ b/edit-team.html
@@ -514,6 +514,15 @@
                     </div>
                 </div>
 
+                <div class="rounded-lg border border-gray-200 p-4 space-y-3">
+                    <div>
+                        <label class="block text-sm font-semibold text-gray-700">Default Game Assignments</label>
+                        <p class="text-xs text-gray-500 mt-0.5">These roles auto-fill on every new game. Parents can claim open slots from their dashboard.</p>
+                    </div>
+                    <div id="default-assignment-rows" class="space-y-2"></div>
+                    <button type="button" id="add-default-assignment-btn" class="text-sm text-indigo-600 hover:text-indigo-800 font-medium">+ Add Role</button>
+                </div>
+
                 <div class="flex justify-end space-x-4 pt-4 border-t">
                     <a href="dashboard.html"
                         class="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">Cancel</a>
@@ -627,6 +636,31 @@
                 team.recordedReplayTeamPassRequired
             ].find((value) => typeof value === 'boolean') === true;
         }
+
+        function addDefaultAssignmentRow(role = '') {
+            const container = document.getElementById('default-assignment-rows');
+            const row = document.createElement('div');
+            row.className = 'flex gap-2 items-center';
+            row.innerHTML = `
+                <input type="text" placeholder="Role (e.g. Snack)" value="${role}" class="default-assignment-role flex-1 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2 text-sm">
+                <button type="button" class="text-red-400 hover:text-red-600 text-lg font-bold leading-none" onclick="this.parentElement.remove()">&times;</button>
+            `;
+            container.appendChild(row);
+        }
+
+        function getDefaultAssignmentsFromForm() {
+            return Array.from(document.querySelectorAll('#default-assignment-rows .default-assignment-role'))
+                .map(input => input.value.trim())
+                .filter(Boolean)
+                .map(role => ({ role, value: '', claimable: true }));
+        }
+
+        function populateDefaultAssignments(assignments) {
+            document.getElementById('default-assignment-rows').innerHTML = '';
+            (assignments || []).forEach(a => addDefaultAssignmentRow(a.role || ''));
+        }
+
+        document.getElementById('add-default-assignment-btn').addEventListener('click', () => addDefaultAssignmentRow());
 
         async function copyTextToClipboard(value) {
             if (navigator.clipboard?.writeText) {
@@ -1255,6 +1289,7 @@
                 syncStreamVolunteerPanel();
                 updateTeamIdPanel(initialTeamId);
                 populateRegistrationProviderFields(team);
+                populateDefaultAssignments(team.defaultAssignments || []);
 
                 if (team.photoUrl) {
                     currentPhotoUrl = team.photoUrl;
@@ -1717,6 +1752,7 @@
                     teamPermissions: normalizeTeamPermissions(teamPermissions),
                     streamAccessMode: document.getElementById('streamAccessMode').value,
                     streamVolunteerEmails: normalizedStreamVolunteerEmails,
+                    defaultAssignments: getDefaultAssignmentsFromForm(),
                     ...((() => {
                         const sr = parseStreamUrl(document.getElementById('streamUrl').value);
                         return {

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -263,7 +263,9 @@ function createEnvironment(initialState, overrides = {}) {
         'manage-schedule-btn',
         'photo-preview',
         'photo-upload',
-        'save-btn'
+        'save-btn',
+        'add-default-assignment-btn',
+        'default-assignment-rows'
     ];
 
     const elements = new Map(ids.map((id) => [id, new MockElement(id)]));


### PR DESCRIPTION
## Summary
Adds a new "Default Game Assignments" feature that allows team admins to configure default assignment roles that automatically populate on new games and can be bulk-applied to upcoming games without assignments.

## Key Changes

**edit-team.html:**
- Added "Default Game Assignments" section in team settings with UI to add/remove default roles
- Implemented `addDefaultAssignmentRow()`, `getDefaultAssignmentsFromForm()`, and `populateDefaultAssignments()` functions to manage the form
- Integrated default assignments into team save flow via `getDefaultAssignmentsFromForm()`
- Loads existing default assignments when team data is populated

**edit-schedule.html:**
- Added "Default Game Assignments" panel that displays configured roles and provides "Apply to All Upcoming Games" button
- Implemented `renderBulkAssignmentsPanel()` to show/hide the panel based on whether defaults are configured
- Modified `prefillAssignments()` to prioritize default assignments over latest game assignments when creating new games
- Added click handler for bulk apply button that:
  - Filters upcoming games with no existing assignments
  - Applies default assignments as claimable slots to all matching games
  - Shows confirmation dialog and result feedback
  - Reloads schedule after applying

## Implementation Details

- Default assignments are stored as objects with `role`, `value`, and `claimable` properties
- The bulk apply feature respects game dates (only applies to games >= current time)
- Assignments are marked as `claimable: true` to allow parents to claim slots from their dashboard
- UI provides clear feedback with disabled state during bulk operations and success/error messaging
- Panel is hidden when no defaults are configured, reducing visual clutter

https://claude.ai/code/session_01BP1enjGdtD1gvWaBA36esL