### PR TITLE
Add Stripe team fee refunds

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -81,6 +81,29 @@ function buildTeamFeeRecipientRef({ teamId, batchId, recipientId }) {
   return firestore.doc(`teams/${teamId}/feeBatches/${batchId}/feeRecipients/${recipientId}`);
 }
 
+function buildTeamFeeRefundRequestId(input, uid) {
+  const requested = String(input.refundRequestId || '').trim();
+  if (requested) return requested;
+  const suffix = crypto.randomUUID ? crypto.randomUUID() : crypto.randomBytes(16).toString('hex');
+  return `refund_${uid}_${suffix}`.replace(/[^\w.-]+/g, '_').slice(0, 120);
+}
+
+function buildTeamFeeRefundIdempotencyKey(input, refundRequestId) {
+  const hash = crypto.createHash('sha256')
+    .update([input.teamId, input.batchId, input.recipientId, input.amountCents, refundRequestId].join('|'))
+    .digest('hex');
+  return `team_fee_refund_${hash}`;
+}
+
+function hasStripeRefundLedgerEntry(recipient = {}, refundId = '') {
+  if (!refundId) return false;
+  const ledger = Array.isArray(recipient.paymentLedger) ? recipient.paymentLedger : [];
+  return ledger.some((entry) => (
+    (entry?.type === 'stripe_refund' || entry?.type === 'online_refund') &&
+    String(entry.stripeRefundId || '') === refundId
+  ));
+}
+
 function normalizeFirestoreId(value, label) {
   const id = String(value || '').trim();
   if (!id || id.includes('/')) {
@@ -562,6 +585,61 @@ exports.refundStripeTeamFeePayment = functions.https.onCall(async (data, context
     throw new functions.https.HttpsError('failed-precondition', 'Refund amount exceeds the refundable paid amount.');
   }
 
+  const recipientRef = buildTeamFeeRecipientRef(input);
+  const refundRequestId = buildTeamFeeRefundRequestId(input, context.auth.uid);
+  const refundIntentRef = recipientRef.collection('refundIntents').doc(refundRequestId);
+  let existingRefundResult = null;
+  await firestore.runTransaction(async (transaction) => {
+    const latestSnap = await transaction.get(recipientRef);
+    if (!latestSnap.exists) {
+      throw new functions.https.HttpsError('not-found', 'Fee recipient not found.');
+    }
+
+    const latestRecipient = { id: input.recipientId, ...(latestSnap.data() || {}) };
+    if (latestRecipient.teamId !== input.teamId || latestRecipient.batchId !== input.batchId) {
+      throw new functions.https.HttpsError('failed-precondition', 'Fee recipient does not match the requested fee batch.');
+    }
+    if (latestRecipient.paymentProvider !== 'stripe') {
+      throw new functions.https.HttpsError('failed-precondition', 'Only Stripe team fee payments can be refunded online.');
+    }
+
+    const intentSnap = await transaction.get(refundIntentRef);
+    if (intentSnap.exists) {
+      const intent = intentSnap.data() || {};
+      if (intent.status === 'recorded' && intent.stripeRefundId) {
+        existingRefundResult = {
+          refundId: intent.stripeRefundId,
+          status: intent.stripeRefundStatus || 'succeeded',
+          amountCents: Number(intent.amountCents || input.amountCents)
+        };
+        return;
+      }
+      if (Number(intent.amountCents || 0) !== input.amountCents) {
+        throw new functions.https.HttpsError('already-exists', 'Refund request ID already exists for a different amount.');
+      }
+    }
+
+    if (input.amountCents > getTeamFeeRefundableCents(latestRecipient)) {
+      throw new functions.https.HttpsError('failed-precondition', 'Refund amount exceeds the refundable paid amount. The recipient state may have changed.');
+    }
+
+    transaction.set(refundIntentRef, {
+      teamId: input.teamId,
+      batchId: input.batchId,
+      recipientId: input.recipientId,
+      amountCents: input.amountCents,
+      reason: input.reason || '',
+      requestedBy: context.auth.uid,
+      status: 'processing',
+      updatedAt: admin.firestore.FieldValue.serverTimestamp(),
+      createdAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true });
+  });
+
+  if (existingRefundResult) {
+    return existingRefundResult;
+  }
+
   const stripe = createStripeClient();
   let refund;
   try {
@@ -575,43 +653,111 @@ exports.refundStripeTeamFeePayment = functions.https.onCall(async (data, context
         recipientId: input.recipientId,
         refundedBy: context.auth.uid
       }
+    }, {
+      idempotencyKey: buildTeamFeeRefundIdempotencyKey(input, refundRequestId)
     });
   } catch (error) {
     console.warn('Stripe team fee refund failed:', error?.message || error);
+    await refundIntentRef.set({
+      status: 'stripe_failed',
+      errorMessage: error?.message || 'Stripe refund failed.',
+      updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true }).catch(() => {});
     throw new functions.https.HttpsError('failed-precondition', error?.message || 'Stripe refund failed.');
   }
 
-  const recipientRef = buildTeamFeeRecipientRef(input);
-  const refundedAt = admin.firestore.FieldValue.serverTimestamp();
-  await firestore.runTransaction(async (transaction) => {
-    const latestSnap = await transaction.get(recipientRef);
-    if (!latestSnap.exists) {
-      throw new functions.https.HttpsError('not-found', 'Fee recipient not found.');
-    }
-
-    const latestRecipient = { id: input.recipientId, ...(latestSnap.data() || {}) };
-    if (input.amountCents > getTeamFeeRefundableCents(latestRecipient)) {
-      throw new functions.https.HttpsError('failed-precondition', 'Refund amount exceeds the refundable paid amount.');
-    }
-
-    const { ledgerEntries = [], ...update } = buildTeamFeeStripeRefundUpdate({
-      recipient: latestRecipient,
-      refund,
-      amountCents: input.amountCents,
-      actorId: context.auth.uid,
-      reason: input.reason,
-      refundedAt
+  const actualRefundAmount = Math.round(Number(refund.amount || 0));
+  if (actualRefundAmount !== input.amountCents) {
+    console.error('Stripe team fee refund amount mismatch', {
+      requested: input.amountCents,
+      actual: actualRefundAmount,
+      refundId: refund.id || null
     });
-    transaction.set(recipientRef, {
-      ...update,
-      paymentLedger: admin.firestore.FieldValue.arrayUnion(...ledgerEntries)
-    }, { merge: true });
-  });
+    await refundIntentRef.set({
+      status: 'amount_mismatch',
+      stripeRefundId: refund.id || null,
+      stripeRefundAmountCents: actualRefundAmount,
+      stripeRefundStatus: refund.status || null,
+      updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true }).catch(() => {});
+    throw new functions.https.HttpsError('failed-precondition', 'Stripe refund amount mismatch. Contact support.');
+  }
+
+  const stripeRefundStatus = String(refund.status || '').trim().toLowerCase();
+  if (stripeRefundStatus !== 'succeeded') {
+    await refundIntentRef.set({
+      status: `stripe_${stripeRefundStatus || 'pending'}`,
+      stripeRefundId: refund.id || null,
+      stripeRefundAmountCents: actualRefundAmount,
+      stripeRefundStatus: refund.status || null,
+      updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true }).catch(() => {});
+    throw new functions.https.HttpsError('failed-precondition', `Refund status is ${refund.status || 'pending'}. Only succeeded refunds can be recorded immediately.`);
+  }
+
+  const refundedAt = admin.firestore.FieldValue.serverTimestamp();
+  const ledgerRefundedAt = admin.firestore.Timestamp.now();
+  try {
+    await firestore.runTransaction(async (transaction) => {
+      const latestSnap = await transaction.get(recipientRef);
+      if (!latestSnap.exists) {
+        throw new functions.https.HttpsError('not-found', 'Fee recipient not found.');
+      }
+
+      const latestRecipient = { id: input.recipientId, ...(latestSnap.data() || {}) };
+      if (hasStripeRefundLedgerEntry(latestRecipient, refund.id)) {
+        transaction.set(refundIntentRef, {
+          status: 'recorded',
+          stripeRefundId: refund.id || null,
+          stripeRefundAmountCents: actualRefundAmount,
+          stripeRefundStatus: refund.status || null,
+          recordedAt: admin.firestore.FieldValue.serverTimestamp(),
+          updatedAt: admin.firestore.FieldValue.serverTimestamp()
+        }, { merge: true });
+        return;
+      }
+      if (input.amountCents > getTeamFeeRefundableCents(latestRecipient)) {
+        throw new functions.https.HttpsError('failed-precondition', 'Refund amount exceeds the refundable paid amount.');
+      }
+
+      const { ledgerEntries = [], ...update } = buildTeamFeeStripeRefundUpdate({
+        recipient: latestRecipient,
+        refund,
+        amountCents: actualRefundAmount,
+        actorId: context.auth.uid,
+        reason: input.reason,
+        refundedAt,
+        ledgerRefundedAt
+      });
+      transaction.set(recipientRef, {
+        ...update,
+        paymentLedger: admin.firestore.FieldValue.arrayUnion(...ledgerEntries)
+      }, { merge: true });
+      transaction.set(refundIntentRef, {
+        status: 'recorded',
+        stripeRefundId: refund.id || null,
+        stripeRefundAmountCents: actualRefundAmount,
+        stripeRefundStatus: refund.status || null,
+        recordedAt: admin.firestore.FieldValue.serverTimestamp(),
+        updatedAt: admin.firestore.FieldValue.serverTimestamp()
+      }, { merge: true });
+    });
+  } catch (error) {
+    await refundIntentRef.set({
+      status: 'firestore_record_failed',
+      stripeRefundId: refund.id || null,
+      stripeRefundAmountCents: actualRefundAmount,
+      stripeRefundStatus: refund.status || null,
+      errorMessage: error?.message || 'Firestore refund recording failed.',
+      updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true }).catch(() => {});
+    throw error;
+  }
 
   return {
     refundId: refund.id || null,
     status: refund.status || 'pending',
-    amountCents: input.amountCents
+    amountCents: actualRefundAmount
   };
 });
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -11,7 +11,9 @@ const {
 } = require('./team-pass-core.cjs');
 const {
   normalizeTeamFeeCheckoutInput,
+  normalizeTeamFeeRefundInput,
   getTeamFeeBalanceCents,
+  getTeamFeeRefundableCents,
   isTeamFeeCheckoutEligible,
   isEligibleTeamFeePayer,
   buildTeamFeeCheckoutUrls,
@@ -19,7 +21,8 @@ const {
   canReuseTeamFeeCheckoutSession,
   shouldMarkTeamFeePaidFromEvent,
   shouldRecordTeamFeeCheckoutNotPaidFromEvent,
-  buildTeamFeePaidUpdate
+  buildTeamFeePaidUpdate,
+  buildTeamFeeStripeRefundUpdate
 } = require('./team-fees-core.cjs');
 const { createInMemoryRateLimiter } = require('./rate-limit.cjs');
 const { buildPublicGamesIcs, canExposeEmptyPublicFeed, isPublicFanGame } = require('./public-calendar-core.cjs');
@@ -179,8 +182,9 @@ async function getUserForEligibility(uid) {
   return userSnap.exists ? userSnap.data() || {} : {};
 }
 
-function hasTeamAdminAccess({ team, uid, email }) {
-  const normalizedEmail = String(email || '').trim().toLowerCase();
+function hasTeamAdminAccess({ team, user = {}, uid, email }) {
+  if (user?.isAdmin === true) return true;
+  const normalizedEmail = String(email || user?.email || user?.profileEmail || '').trim().toLowerCase();
   const adminEmails = Array.isArray(team?.adminEmails) ? team.adminEmails.map((entry) => String(entry || '').trim().toLowerCase()) : [];
   return Boolean(uid && team?.ownerId === uid) || Boolean(normalizedEmail && adminEmails.includes(normalizedEmail));
 }
@@ -506,6 +510,109 @@ exports.createStripeTeamFeeCheckout = functions.https.onCall(async (data, contex
   }, { merge: true });
 
   return { checkoutUrl: session.url, sessionId: session.id };
+});
+
+exports.refundStripeTeamFeePayment = functions.https.onCall(async (data, context) => {
+  if (!context.auth?.uid) {
+    throw new functions.https.HttpsError('unauthenticated', 'Sign in before refunding a team fee.');
+  }
+
+  let input;
+  try {
+    input = normalizeTeamFeeRefundInput(data || {});
+  } catch (error) {
+    throw new functions.https.HttpsError('invalid-argument', error.message || 'Invalid team fee refund request.');
+  }
+
+  const [teamSnap, recipientSnap, user] = await Promise.all([
+    firestore.doc(`teams/${input.teamId}`).get(),
+    buildTeamFeeRecipientRef(input).get(),
+    getUserForEligibility(context.auth.uid)
+  ]);
+
+  if (!teamSnap.exists) {
+    throw new functions.https.HttpsError('not-found', 'Team not found.');
+  }
+  if (!recipientSnap.exists) {
+    throw new functions.https.HttpsError('not-found', 'Fee recipient not found.');
+  }
+
+  const team = { id: input.teamId, ...(teamSnap.data() || {}) };
+  const email = context.auth.token?.email || user.email || '';
+  if (!hasTeamAdminAccess({ team, user, uid: context.auth.uid, email })) {
+    throw new functions.https.HttpsError('permission-denied', 'Only team admins can issue team fee refunds.');
+  }
+
+  const recipient = { id: input.recipientId, ...(recipientSnap.data() || {}) };
+  if (recipient.teamId !== input.teamId || recipient.batchId !== input.batchId) {
+    throw new functions.https.HttpsError('failed-precondition', 'Fee recipient does not match the requested fee batch.');
+  }
+  if (recipient.paymentProvider !== 'stripe') {
+    throw new functions.https.HttpsError('failed-precondition', 'Only Stripe team fee payments can be refunded online.');
+  }
+
+  const paymentIntentId = String(recipient.stripePaymentIntentId || '').trim();
+  const chargeId = String(recipient.stripeChargeId || recipient.stripeLatestChargeId || '').trim();
+  if (!paymentIntentId && !chargeId) {
+    throw new functions.https.HttpsError('failed-precondition', 'This payment is missing a Stripe payment intent or charge reference.');
+  }
+
+  const refundableCents = getTeamFeeRefundableCents(recipient);
+  if (input.amountCents > refundableCents) {
+    throw new functions.https.HttpsError('failed-precondition', 'Refund amount exceeds the refundable paid amount.');
+  }
+
+  const stripe = createStripeClient();
+  let refund;
+  try {
+    refund = await stripe.refunds.create({
+      amount: input.amountCents,
+      ...(paymentIntentId ? { payment_intent: paymentIntentId } : { charge: chargeId }),
+      metadata: {
+        product: 'team_fee',
+        teamId: input.teamId,
+        batchId: input.batchId,
+        recipientId: input.recipientId,
+        refundedBy: context.auth.uid
+      }
+    });
+  } catch (error) {
+    console.warn('Stripe team fee refund failed:', error?.message || error);
+    throw new functions.https.HttpsError('failed-precondition', error?.message || 'Stripe refund failed.');
+  }
+
+  const recipientRef = buildTeamFeeRecipientRef(input);
+  const refundedAt = admin.firestore.FieldValue.serverTimestamp();
+  await firestore.runTransaction(async (transaction) => {
+    const latestSnap = await transaction.get(recipientRef);
+    if (!latestSnap.exists) {
+      throw new functions.https.HttpsError('not-found', 'Fee recipient not found.');
+    }
+
+    const latestRecipient = { id: input.recipientId, ...(latestSnap.data() || {}) };
+    if (input.amountCents > getTeamFeeRefundableCents(latestRecipient)) {
+      throw new functions.https.HttpsError('failed-precondition', 'Refund amount exceeds the refundable paid amount.');
+    }
+
+    const { ledgerEntries = [], ...update } = buildTeamFeeStripeRefundUpdate({
+      recipient: latestRecipient,
+      refund,
+      amountCents: input.amountCents,
+      actorId: context.auth.uid,
+      reason: input.reason,
+      refundedAt
+    });
+    transaction.set(recipientRef, {
+      ...update,
+      paymentLedger: admin.firestore.FieldValue.arrayUnion(...ledgerEntries)
+    }, { merge: true });
+  });
+
+  return {
+    refundId: refund.id || null,
+    status: refund.status || 'pending',
+    amountCents: input.amountCents
+  };
 });
 
 exports.createStripeRegistrationCheckout = functions.https.onCall(async (data) => {

--- a/functions/team-fees-core.cjs
+++ b/functions/team-fees-core.cjs
@@ -18,12 +18,21 @@ function normalizeTeamFeeRefundInput(data = {}) {
     const input = normalizeTeamFeeCheckoutInput(data);
     const amountCents = Math.round(Number(data.amountCents ?? Number(data.amount || 0) * 100));
     const reason = normalizeString(data.reason || data.note);
+    const refundRequestId = normalizeString(data.refundRequestId || data.idempotencyKey);
 
     if (!Number.isFinite(amountCents) || amountCents <= 0) {
         throw new Error('Refund amount must be greater than $0.');
     }
+    if (refundRequestId && refundRequestId.includes('/')) {
+        throw new Error('Refund request ID is invalid.');
+    }
 
-    return { ...input, amountCents, reason };
+    return {
+        ...input,
+        amountCents,
+        reason,
+        ...(refundRequestId ? { refundRequestId } : {})
+    };
 }
 
 function getTeamFeePaidCents(recipient = {}) {
@@ -53,7 +62,7 @@ function getTeamFeeRefundedCents(recipient = {}) {
 }
 
 function getTeamFeeRefundableCents(recipient = {}) {
-    return Math.max(0, getTeamFeePaidCents(recipient) - getTeamFeeRefundedCents(recipient));
+    return getTeamFeePaidCents(recipient);
 }
 
 function getTeamFeeBalanceCents(recipient = {}) {
@@ -168,7 +177,7 @@ function getTeamFeeStripePaidAmountCents({ recipient = {}, session = {} } = {}) 
     return 0;
 }
 
-function buildTeamFeeStripeRefundUpdate({ recipient = {}, refund = {}, amountCents = 0, actorId = '', reason = '', refundedAt }) {
+function buildTeamFeeStripeRefundUpdate({ recipient = {}, refund = {}, amountCents = 0, actorId = '', reason = '', refundedAt, ledgerRefundedAt = refundedAt }) {
     const refundAmountCents = Math.round(Number(amountCents || refund.amount || 0));
     const previousPaidCents = getTeamFeePaidCents(recipient);
     const previousRefundedCents = getTeamFeeRefundedCents(recipient);
@@ -201,7 +210,7 @@ function buildTeamFeeStripeRefundUpdate({ recipient = {}, refund = {}, amountCen
             stripeChargeId: typeof refund.charge === 'string' ? refund.charge : (recipient.stripeChargeId || null),
             reason: normalizeString(reason),
             refundedBy: actorId || null,
-            refundedAt
+            refundedAt: ledgerRefundedAt
         }]
     };
 }

--- a/functions/team-fees-core.cjs
+++ b/functions/team-fees-core.cjs
@@ -14,6 +14,18 @@ function normalizeTeamFeeCheckoutInput(data = {}) {
     return { teamId, batchId, recipientId };
 }
 
+function normalizeTeamFeeRefundInput(data = {}) {
+    const input = normalizeTeamFeeCheckoutInput(data);
+    const amountCents = Math.round(Number(data.amountCents ?? Number(data.amount || 0) * 100));
+    const reason = normalizeString(data.reason || data.note);
+
+    if (!Number.isFinite(amountCents) || amountCents <= 0) {
+        throw new Error('Refund amount must be greater than $0.');
+    }
+
+    return { ...input, amountCents, reason };
+}
+
 function getTeamFeePaidCents(recipient = {}) {
     const paid = Number(recipient.paidAmountCents ?? recipient.amountPaidCents ?? recipient.totalPaidCents ?? recipient.paidCents ?? 0);
     return Number.isFinite(paid) ? Math.max(0, paid) : 0;
@@ -22,6 +34,26 @@ function getTeamFeePaidCents(recipient = {}) {
 function getTeamFeeTotalCents(recipient = {}) {
     const total = Number(recipient.amountDueCents ?? recipient.balanceDueCents ?? recipient.adjustedAmountCents ?? recipient.amountCents ?? recipient.totalAmountCents ?? 0);
     return Number.isFinite(total) ? Math.max(0, total) : 0;
+}
+
+function getTeamFeeRefundedCents(recipient = {}) {
+    const explicitRefunded = Number(recipient.refundedAmountCents ?? recipient.amountRefundedCents ?? recipient.totalRefundedCents);
+    if (Number.isFinite(explicitRefunded) && explicitRefunded >= 0) {
+        return Math.round(explicitRefunded);
+    }
+
+    const ledger = Array.isArray(recipient.paymentLedger) ? recipient.paymentLedger : Array.isArray(recipient.ledgerEntries) ? recipient.ledgerEntries : [];
+    return ledger.reduce((total, entry) => {
+        if (entry?.type !== 'stripe_refund' && entry?.type !== 'online_refund') return total;
+        const status = normalizeString(entry.status || 'succeeded').toLowerCase();
+        if (status === 'failed' || status === 'canceled' || status === 'cancelled') return total;
+        const amount = Number(entry.refundAmountCents ?? entry.amountCents ?? 0);
+        return total + (Number.isFinite(amount) ? Math.abs(Math.round(amount)) : 0);
+    }, 0);
+}
+
+function getTeamFeeRefundableCents(recipient = {}) {
+    return Math.max(0, getTeamFeePaidCents(recipient) - getTeamFeeRefundedCents(recipient));
 }
 
 function getTeamFeeBalanceCents(recipient = {}) {
@@ -136,6 +168,44 @@ function getTeamFeeStripePaidAmountCents({ recipient = {}, session = {} } = {}) 
     return 0;
 }
 
+function buildTeamFeeStripeRefundUpdate({ recipient = {}, refund = {}, amountCents = 0, actorId = '', reason = '', refundedAt }) {
+    const refundAmountCents = Math.round(Number(amountCents || refund.amount || 0));
+    const previousPaidCents = getTeamFeePaidCents(recipient);
+    const previousRefundedCents = getTeamFeeRefundedCents(recipient);
+    const paidAmountCents = Math.max(0, previousPaidCents - refundAmountCents);
+    const refundedAmountCents = previousRefundedCents + refundAmountCents;
+    const balanceDueCents = Math.max(0, getTeamFeeTotalCents(recipient) - paidAmountCents);
+    const status = paidAmountCents <= 0 ? 'unpaid' : balanceDueCents > 0 ? 'partial' : 'paid';
+    const refundStatus = normalizeString(refund.status || 'pending').toLowerCase() || 'pending';
+
+    return {
+        status,
+        paidAmountCents,
+        amountPaidCents: paidAmountCents,
+        balanceDueCents,
+        remainingBalanceCents: balanceDueCents,
+        refundedAmountCents,
+        amountRefundedCents: refundedAmountCents,
+        lastRefundedAt: refundedAt,
+        updatedAt: refundedAt,
+        paymentProvider: 'stripe',
+        stripeLastRefundId: refund.id || null,
+        stripeLastRefundStatus: refundStatus,
+        ledgerEntries: [{
+            type: 'stripe_refund',
+            amountCents: refundAmountCents,
+            refundAmountCents,
+            status: refundStatus,
+            stripeRefundId: refund.id || null,
+            stripePaymentIntentId: typeof refund.payment_intent === 'string' ? refund.payment_intent : (recipient.stripePaymentIntentId || null),
+            stripeChargeId: typeof refund.charge === 'string' ? refund.charge : (recipient.stripeChargeId || null),
+            reason: normalizeString(reason),
+            refundedBy: actorId || null,
+            refundedAt
+        }]
+    };
+}
+
 function buildTeamFeePaidUpdate({ recipient = {}, session = {}, eventId, receivedAt }) {
     const existingPaidCents = getTeamFeePaidCents(recipient);
     const stripePaidAmountCents = getTeamFeeStripePaidAmountCents({ recipient, session });
@@ -172,9 +242,12 @@ function buildTeamFeePaidUpdate({ recipient = {}, session = {}, eventId, receive
 
 module.exports = {
     normalizeTeamFeeCheckoutInput,
+    normalizeTeamFeeRefundInput,
     getTeamFeePaidCents,
     getTeamFeeTotalCents,
     getTeamFeeBalanceCents,
+    getTeamFeeRefundedCents,
+    getTeamFeeRefundableCents,
     isTeamFeeCheckoutEligible,
     isEligibleTeamFeePayer,
     buildTeamFeeCheckoutUrls,
@@ -183,5 +256,6 @@ module.exports = {
     shouldMarkTeamFeePaidFromEvent,
     shouldRecordTeamFeeCheckoutNotPaidFromEvent,
     getTeamFeeStripePaidAmountCents,
-    buildTeamFeePaidUpdate
+    buildTeamFeePaidUpdate,
+    buildTeamFeeStripeRefundUpdate
 };

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -179,7 +179,7 @@ export function getRecipientRefundedCents(recipient) {
 }
 
 export function getRecipientRefundableCents(recipient) {
-    return Math.max(0, getRecipientPaidCents(recipient) - getRecipientRefundedCents(recipient));
+    return getRecipientPaidCents(recipient);
 }
 
 export function isOnlineRefundEligible(recipient) {
@@ -341,13 +341,17 @@ export function buildOnlineRefundRequest({ amount, reason, teamId, batchId, reci
     if (amountCents === null || amountCents <= 0) {
         throw new Error('Enter a refund amount greater than $0.');
     }
+    const refundRequestId = globalThis.crypto?.randomUUID
+        ? globalThis.crypto.randomUUID()
+        : `refund_${Date.now()}_${Math.random().toString(36).slice(2)}`;
 
     return {
         teamId: normalizeString(teamId),
         batchId: normalizeString(batchId),
         recipientId: normalizeString(recipientId),
         amountCents,
-        reason: normalizeString(reason)
+        reason: normalizeString(reason),
+        refundRequestId
     };
 }
 

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -164,6 +164,30 @@ export function getRecipientPaidCents(recipient) {
     return Number.isFinite(paid) ? Math.max(0, paid) : 0;
 }
 
+export function getRecipientRefundedCents(recipient) {
+    const explicitRefunded = Number(recipient?.refundedAmountCents ?? recipient?.amountRefundedCents ?? recipient?.totalRefundedCents);
+    if (Number.isFinite(explicitRefunded) && explicitRefunded >= 0) return Math.round(explicitRefunded);
+
+    const ledger = Array.isArray(recipient?.paymentLedger) ? recipient.paymentLedger : Array.isArray(recipient?.ledgerEntries) ? recipient.ledgerEntries : [];
+    return ledger.reduce((total, entry) => {
+        if (entry?.type !== 'stripe_refund' && entry?.type !== 'online_refund') return total;
+        const status = normalizeString(entry.status || 'succeeded').toLowerCase();
+        if (status === 'failed' || status === 'canceled' || status === 'cancelled') return total;
+        const amount = Number(entry.refundAmountCents ?? entry.amountCents ?? 0);
+        return total + (Number.isFinite(amount) ? Math.abs(Math.round(amount)) : 0);
+    }, 0);
+}
+
+export function getRecipientRefundableCents(recipient) {
+    return Math.max(0, getRecipientPaidCents(recipient) - getRecipientRefundedCents(recipient));
+}
+
+export function isOnlineRefundEligible(recipient) {
+    return recipient?.paymentProvider === 'stripe'
+        && Boolean(recipient?.stripePaymentIntentId || recipient?.stripeChargeId || recipient?.stripeLatestChargeId)
+        && getRecipientRefundableCents(recipient) > 0;
+}
+
 export function summarizeFeeRecipients(recipients = []) {
     const summary = {
         totalAssignedCents: 0,
@@ -310,6 +334,29 @@ export function buildCancelRecipientUpdate({ note, actorId }) {
         },
         ledgerEntries: [ledgerEntry]
     };
+}
+
+export function buildOnlineRefundRequest({ amount, reason, teamId, batchId, recipientId }) {
+    const amountCents = toFeeCents(amount);
+    if (amountCents === null || amountCents <= 0) {
+        throw new Error('Enter a refund amount greater than $0.');
+    }
+
+    return {
+        teamId: normalizeString(teamId),
+        batchId: normalizeString(batchId),
+        recipientId: normalizeString(recipientId),
+        amountCents,
+        reason: normalizeString(reason)
+    };
+}
+
+export async function submitOnlineTeamFeeRefund(request) {
+    const { getFunctions, httpsCallable } = await import('./firebase.js?v=28');
+    const functions = getFunctions();
+    const refundTeamFee = httpsCallable(functions, 'refundStripeTeamFeePayment');
+    const result = await refundTeamFee(request);
+    return result?.data || {};
 }
 
 export function getRecipientDisplayName(recipient) {
@@ -480,6 +527,8 @@ function renderRecipients(container, countEl, recipients) {
         const balance = formatFeeCurrency(balanceCents);
         const paid = formatFeeCurrency(paidCents);
         const outstanding = formatFeeCurrency(outstandingCents);
+        const refundableCents = getRecipientRefundableCents(recipient);
+        const canRefundOnline = isOnlineRefundEligible(recipient);
         const note = recipient.manualPayment?.note || recipient.adjustment?.note || recipient.canceled?.note || recipient.notes || '';
         return `
             <article class="p-5" data-recipient-id="${escapeHtml(recipient.id)}" data-balance-cents="${balanceCents}" data-paid-cents="${paidCents}" data-status="${escapeHtml(normalizeFeeStatus(recipient.status))}">
@@ -492,7 +541,7 @@ function renderRecipients(container, countEl, recipients) {
                         <div class="mt-1 text-sm text-gray-500">Assigned ${assigned} · Balance ${balance} · Paid ${paid} · Outstanding ${outstanding}</div>
                         ${note ? `<p class="mt-2 text-sm text-gray-600">${escapeHtml(note)}</p>` : ''}
                     </div>
-                    <div class="grid grid-cols-1 md:grid-cols-3 gap-3 w-full lg:max-w-4xl">
+                    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-3 w-full lg:max-w-6xl">
                         <form data-action="paid" class="rounded-xl border border-gray-200 bg-gray-50 p-3 space-y-2">
                             <div class="text-xs font-bold uppercase tracking-wide text-gray-500">Manual payment</div>
                             <input name="amount" type="number" min="0" step="0.01" value="${(outstandingCents / 100).toFixed(2)}" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Payment amount">
@@ -506,6 +555,14 @@ function renderRecipients(container, countEl, recipients) {
                             <input name="note" type="text" required placeholder="Required reason" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Adjustment reason">
                             <button class="w-full rounded-lg bg-amber-600 px-3 py-2 text-sm font-semibold text-white hover:bg-amber-700">Save adjustment</button>
                         </form>
+                        ${canRefundOnline ? `
+                            <form data-action="refund" class="rounded-xl border border-blue-200 bg-blue-50 p-3 space-y-2">
+                                <div class="text-xs font-bold uppercase tracking-wide text-blue-700">Online refund</div>
+                                <input name="amount" type="number" min="0" max="${(refundableCents / 100).toFixed(2)}" step="0.01" value="${(refundableCents / 100).toFixed(2)}" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Refund amount">
+                                <input name="reason" type="text" placeholder="Optional reason" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Refund reason">
+                                <button class="w-full rounded-lg bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-700">Issue refund</button>
+                            </form>
+                        ` : ''}
                         <form data-action="cancel" class="rounded-xl border border-gray-200 bg-gray-50 p-3 space-y-2">
                             <div class="text-xs font-bold uppercase tracking-wide text-gray-500">Cancel recipient</div>
                             <input name="note" type="text" placeholder="Reason" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Cancellation note">
@@ -702,13 +759,17 @@ async function renderManageMode({ container, teamId, batchId, team, user, getTea
         try {
             if (form.dataset.action === 'paid') {
                 updates = buildManualPaymentUpdate({ ...data, actorId: user.uid, currentBalanceCents: article?.dataset?.balanceCents, currentPaidCents: article?.dataset?.paidCents, currentStatus: article?.dataset?.status });
+                await updateTeamFeeRecipient(teamId, batchId, recipientId, updates);
             } else if (form.dataset.action === 'adjust') {
                 updates = buildBalanceAdjustmentUpdate({ ...data, actorId: user.uid, currentBalanceCents: article?.dataset?.balanceCents, currentPaidCents: article?.dataset?.paidCents });
+                await updateTeamFeeRecipient(teamId, batchId, recipientId, updates);
+            } else if (form.dataset.action === 'refund') {
+                await submitOnlineTeamFeeRefund(buildOnlineRefundRequest({ ...data, teamId, batchId, recipientId }));
             } else {
                 updates = buildCancelRecipientUpdate({ ...data, actorId: user.uid });
+                await updateTeamFeeRecipient(teamId, batchId, recipientId, updates);
             }
-            await updateTeamFeeRecipient(teamId, batchId, recipientId, updates);
-            showMessage('Fee recipient updated.', 'success');
+            showMessage(form.dataset.action === 'refund' ? 'Stripe refund submitted.' : 'Fee recipient updated.', 'success');
             await loadBatch();
         } catch (error) {
             showMessage(error?.message || 'Unable to update fee recipient.', 'error');

--- a/team-fees.html
+++ b/team-fees.html
@@ -45,7 +45,7 @@
 
     <div id="footer-container"></div>
 
-    <script type="module" src="./js/team-fees-admin.js?v=6"></script>
+    <script type="module" src="./js/team-fees-admin.js?v=7"></script>
 </body>
 
 </html>

--- a/tests/unit/team-fees-admin.test.js
+++ b/tests/unit/team-fees-admin.test.js
@@ -1,6 +1,6 @@
 // tests/unit/team-fees-admin.test.js
 import { describe, it, expect } from 'vitest'; // Import Vitest globals
-import { buildManualPaymentUpdate } from '../../js/team-fees-admin.js'; // Adjusted path
+import { buildManualPaymentUpdate, buildOnlineRefundRequest, getRecipientRefundableCents, isOnlineRefundEligible } from '../../js/team-fees-admin.js'; // Adjusted path
 
 describe('buildManualPaymentUpdate', () => {
     it('should correctly handle missing or invalid currentBalanceCents by defaulting to a high number to prevent premature "paid" status', () => {
@@ -61,5 +61,37 @@ describe('buildManualPaymentUpdate', () => {
         expect(updates.amountPaidCents).toBe(paymentAmountCents); // 500
         expect(updates.remainingBalanceCents).toBe(initialBalanceCents - paymentAmountCents); // 1000 - 500 = 500
         expect(updates.status).toBe('partial');
+    });
+});
+
+describe('online team fee refunds', () => {
+    it('builds callable refund requests in cents', () => {
+        expect(buildOnlineRefundRequest({
+            teamId: ' team_1 ',
+            batchId: ' batch_1 ',
+            recipientId: ' recipient_1 ',
+            amount: '12.34',
+            reason: ' duplicate payment '
+        })).toEqual({
+            teamId: 'team_1',
+            batchId: 'batch_1',
+            recipientId: 'recipient_1',
+            amountCents: 1234,
+            reason: 'duplicate payment'
+        });
+    });
+
+    it('detects eligible Stripe payments and remaining refundable amount', () => {
+        const recipient = {
+            paymentProvider: 'stripe',
+            stripePaymentIntentId: 'pi_123',
+            amountPaidCents: 10000,
+            refundedAmountCents: 2500
+        };
+
+        expect(getRecipientRefundableCents(recipient)).toBe(7500);
+        expect(isOnlineRefundEligible(recipient)).toBe(true);
+        expect(isOnlineRefundEligible({ ...recipient, stripePaymentIntentId: '', stripeChargeId: '' })).toBe(false);
+        expect(isOnlineRefundEligible({ ...recipient, paymentProvider: 'manual' })).toBe(false);
     });
 });

--- a/tests/unit/team-fees-admin.test.js
+++ b/tests/unit/team-fees-admin.test.js
@@ -66,19 +66,21 @@ describe('buildManualPaymentUpdate', () => {
 
 describe('online team fee refunds', () => {
     it('builds callable refund requests in cents', () => {
-        expect(buildOnlineRefundRequest({
+        const request = buildOnlineRefundRequest({
             teamId: ' team_1 ',
             batchId: ' batch_1 ',
             recipientId: ' recipient_1 ',
             amount: '12.34',
             reason: ' duplicate payment '
-        })).toEqual({
+        });
+        expect(request).toMatchObject({
             teamId: 'team_1',
             batchId: 'batch_1',
             recipientId: 'recipient_1',
             amountCents: 1234,
             reason: 'duplicate payment'
         });
+        expect(request.refundRequestId).toEqual(expect.any(String));
     });
 
     it('detects eligible Stripe payments and remaining refundable amount', () => {
@@ -89,7 +91,7 @@ describe('online team fee refunds', () => {
             refundedAmountCents: 2500
         };
 
-        expect(getRecipientRefundableCents(recipient)).toBe(7500);
+        expect(getRecipientRefundableCents(recipient)).toBe(10000);
         expect(isOnlineRefundEligible(recipient)).toBe(true);
         expect(isOnlineRefundEligible({ ...recipient, stripePaymentIntentId: '', stripeChargeId: '' })).toBe(false);
         expect(isOnlineRefundEligible({ ...recipient, paymentProvider: 'manual' })).toBe(false);

--- a/tests/unit/team-fees-functions.test.js
+++ b/tests/unit/team-fees-functions.test.js
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
 import { describe, expect, it } from 'vitest';
 
 const require = createRequire(import.meta.url);
@@ -180,17 +181,19 @@ describe('team fee checkout function helpers', () => {
             batchId: ' batch_456 ',
             recipientId: ' recipient_789 ',
             amount: '12.34',
-            reason: ' duplicate '
+            reason: ' duplicate ',
+            refundRequestId: ' refund-123 '
         })).toEqual({
             teamId: 'team_123',
             batchId: 'batch_456',
             recipientId: 'recipient_789',
             amountCents: 1234,
-            reason: 'duplicate'
+            reason: 'duplicate',
+            refundRequestId: 'refund-123'
         });
 
         const recipient = {
-            paidAmountCents: 10000,
+            paidAmountCents: 6500,
             paymentLedger: [
                 { type: 'stripe_refund', refundAmountCents: 2500, status: 'succeeded' },
                 { type: 'stripe_refund', amountCents: 1000, status: 'pending' },
@@ -199,6 +202,10 @@ describe('team fee checkout function helpers', () => {
         };
         expect(getTeamFeeRefundedCents(recipient)).toBe(3500);
         expect(getTeamFeeRefundableCents(recipient)).toBe(6500);
+        expect(getTeamFeeRefundableCents({
+            paidAmountCents: 8000,
+            refundedAmountCents: 2000
+        })).toBe(8000);
     });
 
     it('builds Stripe refund ledger updates without over-crediting balances', () => {
@@ -217,7 +224,8 @@ describe('team fee checkout function helpers', () => {
             amountCents: 5000,
             actorId: 'admin_1',
             reason: 'Family requested refund',
-            refundedAt: 'now'
+            refundedAt: 'server-now',
+            ledgerRefundedAt: 'ledger-now'
         });
 
         expect(update).toMatchObject({
@@ -241,8 +249,19 @@ describe('team fee checkout function helpers', () => {
             stripeChargeId: null,
             reason: 'Family requested refund',
             refundedBy: 'admin_1',
-            refundedAt: 'now'
+            refundedAt: 'ledger-now'
         }]);
+    });
+
+    it('guards Stripe refund callable idempotency and recording consistency', () => {
+        const source = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+
+        expect(source).toContain("recipientRef.collection('refundIntents').doc(refundRequestId)");
+        expect(source).toContain('idempotencyKey: buildTeamFeeRefundIdempotencyKey(input, refundRequestId)');
+        expect(source).toContain('const actualRefundAmount = Math.round(Number(refund.amount || 0));');
+        expect(source).toContain("stripeRefundStatus !== 'succeeded'");
+        expect(source).toContain('const ledgerRefundedAt = admin.firestore.Timestamp.now();');
+        expect(source).toContain('hasStripeRefundLedgerEntry(latestRecipient, refund.id)');
     });
 
     it('does not mark the recipient fully paid when the balance grew after checkout creation', () => {

--- a/tests/unit/team-fees-functions.test.js
+++ b/tests/unit/team-fees-functions.test.js
@@ -4,7 +4,10 @@ import { describe, expect, it } from 'vitest';
 const require = createRequire(import.meta.url);
 const {
     normalizeTeamFeeCheckoutInput,
+    normalizeTeamFeeRefundInput,
     getTeamFeeBalanceCents,
+    getTeamFeeRefundedCents,
+    getTeamFeeRefundableCents,
     isTeamFeeCheckoutEligible,
     isEligibleTeamFeePayer,
     buildTeamFeeCheckoutUrls,
@@ -13,7 +16,8 @@ const {
     shouldMarkTeamFeePaidFromEvent,
     shouldRecordTeamFeeCheckoutNotPaidFromEvent,
     getTeamFeeStripePaidAmountCents,
-    buildTeamFeePaidUpdate
+    buildTeamFeePaidUpdate,
+    buildTeamFeeStripeRefundUpdate
 } = require('../../functions/team-fees-core.cjs');
 
 describe('team fee checkout function helpers', () => {
@@ -168,6 +172,77 @@ describe('team fee checkout function helpers', () => {
         });
         expect(update).not.toHaveProperty('paymentMethod');
         expect(update.receiptMetadata).not.toHaveProperty('card');
+    });
+
+    it('normalizes refund input and computes refundable cents', () => {
+        expect(normalizeTeamFeeRefundInput({
+            teamId: ' team_123 ',
+            batchId: ' batch_456 ',
+            recipientId: ' recipient_789 ',
+            amount: '12.34',
+            reason: ' duplicate '
+        })).toEqual({
+            teamId: 'team_123',
+            batchId: 'batch_456',
+            recipientId: 'recipient_789',
+            amountCents: 1234,
+            reason: 'duplicate'
+        });
+
+        const recipient = {
+            paidAmountCents: 10000,
+            paymentLedger: [
+                { type: 'stripe_refund', refundAmountCents: 2500, status: 'succeeded' },
+                { type: 'stripe_refund', amountCents: 1000, status: 'pending' },
+                { type: 'stripe_refund', refundAmountCents: 500, status: 'failed' }
+            ]
+        };
+        expect(getTeamFeeRefundedCents(recipient)).toBe(3500);
+        expect(getTeamFeeRefundableCents(recipient)).toBe(6500);
+    });
+
+    it('builds Stripe refund ledger updates without over-crediting balances', () => {
+        const update = buildTeamFeeStripeRefundUpdate({
+            recipient: {
+                amountCents: 12500,
+                paidAmountCents: 12500,
+                refundedAmountCents: 2500,
+                stripePaymentIntentId: 'pi_123'
+            },
+            refund: {
+                id: 're_123',
+                status: 'succeeded',
+                payment_intent: 'pi_123'
+            },
+            amountCents: 5000,
+            actorId: 'admin_1',
+            reason: 'Family requested refund',
+            refundedAt: 'now'
+        });
+
+        expect(update).toMatchObject({
+            status: 'partial',
+            paidAmountCents: 7500,
+            amountPaidCents: 7500,
+            balanceDueCents: 5000,
+            refundedAmountCents: 7500,
+            amountRefundedCents: 7500,
+            paymentProvider: 'stripe',
+            stripeLastRefundId: 're_123',
+            stripeLastRefundStatus: 'succeeded'
+        });
+        expect(update.ledgerEntries).toEqual([{
+            type: 'stripe_refund',
+            amountCents: 5000,
+            refundAmountCents: 5000,
+            status: 'succeeded',
+            stripeRefundId: 're_123',
+            stripePaymentIntentId: 'pi_123',
+            stripeChargeId: null,
+            reason: 'Family requested refund',
+            refundedBy: 'admin_1',
+            refundedAt: 'now'
+        }]);
     });
 
     it('does not mark the recipient fully paid when the balance grew after checkout creation', () => {


### PR DESCRIPTION
Closes #1168

## Summary
- Added an admin callable Firebase Function to issue Stripe refunds for paid online team fee recipients.
- Validates team admin/global admin access, Stripe payment references, and remaining refundable amount before calling Stripe.
- Records successful/pending Stripe refunds in the existing payment ledger and adjusts paid/refunded/balance fields.
- Added an online refund form to the team fee admin UI for eligible Stripe-paid records.

## Validation
- `npx vitest run tests/unit/team-fees-functions.test.js tests/unit/team-fees-admin.test.js --reporter=dot`
- `node --check functions/index.js`
- `node --check functions/team-fees-core.cjs`
- `git diff --check`