### PR TITLE
Allow denied parent request resubmission

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1242,6 +1242,20 @@ service cloud.firestore {
                              request.resource.data.teamId == resource.data.teamId &&
                              request.resource.data.createdAt == resource.data.createdAt &&
                              request.resource.data.status in ['approved', 'denied']
+                           ) ||
+                           (
+                             resource.data.status == 'denied' &&
+                             resource.data.requesterUserId == request.auth.uid &&
+                             requestId == request.auth.uid + "__" + request.resource.data.playerId &&
+                             request.resource.data.requesterUserId == request.auth.uid &&
+                             request.resource.data.playerId == resource.data.playerId &&
+                             request.resource.data.teamId == resource.data.teamId &&
+                             request.resource.data.createdAt == resource.data.createdAt &&
+                             request.resource.data.status == 'pending' &&
+                             request.resource.data.decidedAt == null &&
+                             request.resource.data.decidedBy == null &&
+                             request.resource.data.decidedByName == null &&
+                             request.resource.data.decisionNote == null
                            )
                          );
 

--- a/tests/unit/parent-membership-request-wiring.test.js
+++ b/tests/unit/parent-membership-request-wiring.test.js
@@ -41,6 +41,17 @@ describe('parent membership request wiring', () => {
         expect(rules).toContain('isTeamOwnerOrAdmin(teamId)');
     });
 
+    it('allows requesters to resubmit denied membership requests safely', () => {
+        const rules = readRepoFile('firestore.rules');
+
+        expect(rules).toContain("resource.data.status == 'denied'");
+        expect(rules).toContain('resource.data.requesterUserId == request.auth.uid');
+        expect(rules).toContain('requestId == request.auth.uid + "__" + request.resource.data.playerId');
+        expect(rules).toContain('request.resource.data.createdAt == resource.data.createdAt');
+        expect(rules).toContain('request.resource.data.decidedAt == null');
+        expect(rules).toContain('request.resource.data.decisionNote == null');
+    });
+
     it('defines the parent membership request collection-group index', () => {
         const indexes = readRepoFile('firestore.indexes.json');
 


### PR DESCRIPTION
Closes #1172

## Summary
- Allows parent requesters to resubmit an existing denied membership request by moving it back to pending.
- Preserves immutable request ownership, team, player, and createdAt fields during resubmission.
- Requires prior decision fields to be cleared when the requester resubmits.

## Validation
- `npx vitest run tests/unit/parent-membership-request-wiring.test.js`
- `npm run ci:firebase-rules`