### PR TITLE
Fix game plan timestamp intervals

### DIFF
--- a/game-plan.html
+++ b/game-plan.html
@@ -289,6 +289,7 @@
         import { checkAuth } from './js/auth.js?v=15';
         import { getTeamAccessInfo } from './js/team-access.js';
         import { createAutoSaveController } from './js/game-plan-autosave.js?v=1';
+        import { buildGamePlanIntervals } from './js/game-plan-intervals.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -739,15 +740,8 @@
             const header = document.getElementById('sub-matrix-header');
             const body = document.getElementById('sub-matrix-body');
 
-            // Build header with all time intervals
-            const intervals = [];
-            for (let period = 1; period <= gamePlan.numPeriods; period++) {
-                const periodName = gamePlan.numPeriods === 2 ? `H${period}` : `Q${period}`;
-                const periodLabel = gamePlan.numPeriods === 2 ? `Half ${period}` : `Quarter ${period}`;
-                gamePlan.subTimes.forEach(time => {
-                    intervals.push({ period, periodName, periodLabel, time, key: `${period}-${time}` });
-                });
-            }
+            // Build header with all playable time intervals.
+            const intervals = buildGamePlanIntervals(gamePlan);
             intervalsCache = intervals;
 
             header.innerHTML = `
@@ -755,7 +749,7 @@
                 ${intervals.map(int => `
                     <th class="px-4 py-3 text-center text-xs font-bold text-gray-700 uppercase tracking-wider whitespace-nowrap">
                         <div class="flex items-center justify-center gap-2">
-                            <span>${int.periodName}: ${int.time}'</span>
+                            <span>${int.periodName}: ${int.label}</span>
                             <button class="push-forward-btn text-gray-500 hover:text-primary-700 text-lg leading-none"
                                     title="Push assignments to next interval"
                                     data-interval="${int.key}">⇢</button>
@@ -993,24 +987,16 @@
                 playingTime[p.id] = 0;
             });
 
-            // Count intervals each player is in
-            const intervalsPerPeriod = Math.max(1, gamePlan.subTimes.length || 0);
-            const minutesPerInterval = gamePlan.periodDuration / intervalsPerPeriod;
-            const intervalTimes = gamePlan.subTimes.length > 0 ? gamePlan.subTimes : ['full'];
-
-            for (let period = 1; period <= gamePlan.numPeriods; period++) {
-                intervalTimes.forEach(time => {
-                    const intervalKey = `${period}-${time}`;
-
-                    formation.positions.forEach(pos => {
-                        const cellKey = `${intervalKey}-${pos.id}`;
-                        const playerId = gamePlan.lineups[cellKey];
-                        if (playerId) {
-                            playingTime[playerId] += minutesPerInterval;
-                        }
-                    });
+            // Count actual minutes for each timestamp-derived interval.
+            buildGamePlanIntervals(gamePlan).forEach(interval => {
+                formation.positions.forEach(pos => {
+                    const cellKey = `${interval.key}-${pos.id}`;
+                    const playerId = gamePlan.lineups[cellKey];
+                    if (playerId) {
+                        playingTime[playerId] += interval.duration;
+                    }
                 });
-            }
+            });
 
             const totalPlayerMinutes = gamePlan.numPeriods * gamePlan.periodDuration * formation.positions.length;
             const targetTime = totalPlayerMinutes / players.length;

--- a/js/game-plan-intervals.js
+++ b/js/game-plan-intervals.js
@@ -1,0 +1,52 @@
+export function buildGamePlanIntervals(gamePlan) {
+    const numPeriods = Number(gamePlan?.numPeriods) || 0;
+    const periodDuration = Number(gamePlan?.periodDuration) || 0;
+    const rawSubTimes = Array.isArray(gamePlan?.subTimes) ? gamePlan.subTimes : [];
+    const boundaries = [...new Set(rawSubTimes
+        .map(time => Number(time))
+        .filter(time => Number.isFinite(time) && time > 0 && time < periodDuration))]
+        .sort((a, b) => a - b);
+
+    if (periodDuration > 0) {
+        boundaries.push(periodDuration);
+    }
+
+    const intervals = [];
+    for (let period = 1; period <= numPeriods; period++) {
+        const periodName = numPeriods === 2 ? `H${period}` : `Q${period}`;
+        const periodLabel = numPeriods === 2 ? `Half ${period}` : `Quarter ${period}`;
+        let start = 0;
+
+        if (boundaries.length === 0) {
+            intervals.push({
+                period,
+                periodName,
+                periodLabel,
+                start: 0,
+                end: periodDuration,
+                duration: periodDuration,
+                time: 'full',
+                label: 'Full',
+                key: `${period}-full`
+            });
+            continue;
+        }
+
+        boundaries.forEach(end => {
+            intervals.push({
+                period,
+                periodName,
+                periodLabel,
+                start,
+                end,
+                duration: end - start,
+                time: end,
+                label: `${start}-${end}'`,
+                key: `${period}-${end}`
+            });
+            start = end;
+        });
+    }
+
+    return intervals;
+}

--- a/tests/unit/game-plan-playing-time-summary.test.js
+++ b/tests/unit/game-plan-playing-time-summary.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
+import { buildGamePlanIntervals } from '../../js/game-plan-intervals.js';
 
 function readGamePlanPage() {
     return readFileSync(new URL('../../game-plan.html', import.meta.url), 'utf8');
@@ -82,6 +83,7 @@ function buildHarness(overrides = {}) {
         },
         document,
         gamePlan: null,
+        buildGamePlanIntervals,
         ...overrides
     };
 
@@ -90,6 +92,7 @@ function buildHarness(overrides = {}) {
         let gamePlan = deps.gamePlan;
         const FORMATIONS = deps.FORMATIONS;
         const document = deps.document;
+        const buildGamePlanIntervals = deps.buildGamePlanIntervals;
         let intervalsCache = [];
         const recentAssignments = new Map();
         let draggedPlayerId = null;
@@ -125,7 +128,7 @@ ${renderPlayingTimeSummaryBody}
     return createHarness(deps);
 }
 
-describe('game plan single-sub-time playing time summary', () => {
+describe('game plan timestamp interval playing time summary', () => {
     it('counts basketball default summary minutes from saved quarter-time lineup keys', () => {
         const harness = buildHarness();
         const gamePlan = harness.createDefaultGamePlan('Basketball');
@@ -135,7 +138,7 @@ describe('game plan single-sub-time playing time summary', () => {
         harness.renderPlayingTimeSummary();
 
         const summaryHtml = harness.getDocument().getElementById('playing-time-summary').innerHTML;
-        expect(extractMinutesForPlayer(summaryHtml, 'Jordan')).toBe(8);
+        expect(extractMinutesForPlayer(summaryHtml, 'Jordan')).toBe(4);
         expect(extractMinutesForPlayer(summaryHtml, 'Casey')).toBe(0);
     });
 
@@ -159,6 +162,51 @@ describe('game plan single-sub-time playing time summary', () => {
         const summaryHtml = harness.getDocument().getElementById('playing-time-summary').innerHTML;
 
         expect(matrixHtml).toContain('data-cell-key="2-12-keeper"');
-        expect(extractMinutesForPlayer(summaryHtml, 'Jordan')).toBe(24);
+        expect(matrixHtml).toContain('data-cell-key="2-24-keeper"');
+        expect(extractMinutesForPlayer(summaryHtml, 'Jordan')).toBe(12);
+    });
+
+    it('creates initial and final real-time soccer segments from substitution timestamps', () => {
+        const intervals = buildGamePlanIntervals({
+            numPeriods: 2,
+            periodDuration: 25,
+            subTimes: [7, 14, 21]
+        });
+
+        expect(intervals.filter(interval => interval.period === 1).map(interval => ({
+            key: interval.key,
+            label: interval.label,
+            duration: interval.duration
+        }))).toEqual([
+            { key: '1-7', label: "0-7'", duration: 7 },
+            { key: '1-14', label: "7-14'", duration: 7 },
+            { key: '1-21', label: "14-21'", duration: 7 },
+            { key: '1-25', label: "21-25'", duration: 4 }
+        ]);
+    });
+
+    it('counts default soccer assignment minutes by actual segment length', () => {
+        const harness = buildHarness({
+            gamePlan: {
+                numPeriods: 2,
+                periodDuration: 25,
+                subTimes: [7, 14, 21],
+                formationId: 'soccer-9v9',
+                lineups: {
+                    '1-7-keeper': 'p1',
+                    '1-25-keeper': 'p2'
+                }
+            }
+        });
+
+        harness.renderSubMatrix();
+        harness.renderPlayingTimeSummary();
+
+        const matrixHtml = harness.getDocument().getElementById('sub-matrix-body').innerHTML;
+        const summaryHtml = harness.getDocument().getElementById('playing-time-summary').innerHTML;
+
+        expect(matrixHtml).toContain('data-cell-key="1-25-keeper"');
+        expect(extractMinutesForPlayer(summaryHtml, 'Jordan')).toBe(7);
+        expect(extractMinutesForPlayer(summaryHtml, 'Casey')).toBe(4);
     });
 });


### PR DESCRIPTION
Closes #1175

## Summary
- Treat substitution times as timestamp boundaries instead of equal-length slots.
- Render all playable intervals, including the final segment after the last substitution.
- Calculate Playing Time Summary minutes from actual interval durations.

## Validation
- `npx vitest run tests/unit/game-plan-playing-time-summary.test.js --reporter=dot`