### PR TITLE
Fix rideshare requests for names with apostrophes

### DIFF
--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -513,6 +513,10 @@
                 .replace(/>/g, '&gt;');
         }
 
+        function escapeJsArgAttr(value) {
+            return escapeAttr(JSON.stringify(String(value ?? '')));
+        }
+
         function setParentMembershipRequestStatus(message, tone = 'neutral') {
             const el = document.getElementById('parent-membership-request-status');
             if (!el) return;
@@ -879,7 +883,7 @@
                                                 </select>
                                             ` : ''}
                                             ${canRequest ? `
-                                                <button onclick="requestRideSpotForChild('${escapeAttr(event.teamId)}','${escapeAttr(event.id)}','${escapeAttr(legacyRideEventId)}','${escapeAttr(offerGameId)}','${escapeAttr(offer.id)}','${escapeAttr(selectedChildId)}','${escapeAttr(selectedChildName)}','${escapeAttr(childSelectorId)}')" class="px-2 py-1 text-xs rounded border border-emerald-300 bg-emerald-50 text-emerald-700 font-semibold hover:bg-emerald-100">Request Spot</button>
+                                                <button onclick="requestRideSpotForChild(${escapeJsArgAttr(event.teamId)},${escapeJsArgAttr(event.id)},${escapeJsArgAttr(legacyRideEventId)},${escapeJsArgAttr(offerGameId)},${escapeJsArgAttr(offer.id)},${escapeJsArgAttr(selectedChildId)},${escapeJsArgAttr(selectedChildName)},${escapeJsArgAttr(childSelectorId)})" class="px-2 py-1 text-xs rounded border border-emerald-300 bg-emerald-50 text-emerald-700 font-semibold hover:bg-emerald-100">Request Spot</button>
                                             ` : ''}
                                             ${myRequest ? `
                                                 <button onclick="cancelMyRideRequest('${escapeAttr(event.teamId)}','${escapeAttr(event.id)}','${escapeAttr(legacyRideEventId)}','${escapeAttr(offerGameId)}','${escapeAttr(offer.id)}','${escapeAttr(myRequest.id)}')" class="px-2 py-1 text-xs rounded border border-gray-300 bg-white text-gray-600 font-semibold hover:bg-gray-50">Cancel</button>

--- a/tests/unit/parent-dashboard-rideshare-wiring.test.js
+++ b/tests/unit/parent-dashboard-rideshare-wiring.test.js
@@ -37,4 +37,14 @@ describe('parent dashboard rideshare wiring', () => {
         expect(html).toContain('createRideRequestHandlers({');
         expect(html).toContain('selectedRideChildByOffer');
     });
+
+    it('serializes Request Spot inline arguments as JavaScript strings before HTML escaping', () => {
+        const html = readRepoFile('parent-dashboard.html');
+
+        expect(html).toContain('function escapeJsArgAttr(value)');
+        expect(html).toContain("return escapeAttr(JSON.stringify(String(value ?? '')));");
+        expect(html).toContain('requestRideSpotForChild(${escapeJsArgAttr(event.teamId)},${escapeJsArgAttr(event.id)}');
+        expect(html).toContain('${escapeJsArgAttr(selectedChildName)}');
+        expect(html).not.toContain("'${escapeAttr(selectedChildName)}'");
+    });
 });


### PR DESCRIPTION
Closes #1177

## Summary
- Serialize Request Spot inline handler arguments as JavaScript string literals before HTML attribute escaping.
- Prevent apostrophes in child display names from breaking the generated onclick handler.
- Added unit coverage to guard the parent dashboard rideshare wiring.

## Tests
- `npx vitest run tests/unit/parent-dashboard-rideshare-wiring.test.js tests/unit/parent-dashboard-rideshare-controls.test.js`