### PR TITLE
Fix postgame controls after slow auth

### DIFF
--- a/game.html
+++ b/game.html
@@ -408,6 +408,7 @@
         let authResolved = false;
         let gameLoaded = false;
         let gameLoadedForAuthenticatedUser = false;
+        let gameLoadPromise = null;
 
         const authTimeout = setTimeout(() => {
             if (authResolved || gameLoaded) return;
@@ -1243,6 +1244,15 @@ Write the match report now:`;
         }
 
         async function loadGame({ forceAuthenticatedReload = false } = {}) {
+            if (gameLoadPromise) {
+                await gameLoadPromise;
+                if (forceAuthenticatedReload && !gameLoadedForAuthenticatedUser) {
+                    return loadGame({ forceAuthenticatedReload: true });
+                }
+                return;
+            }
+
+            gameLoadPromise = (async () => {
             if (gameLoaded && (!forceAuthenticatedReload || gameLoadedForAuthenticatedUser)) return;
             gameLoaded = true;
             gameLoadedForAuthenticatedUser = !!currentUser;
@@ -1799,6 +1809,13 @@ Write the match report now:`;
                         </div>
                     `;
                 }
+            }
+            })();
+
+            try {
+                return await gameLoadPromise;
+            } finally {
+                gameLoadPromise = null;
             }
         }
     </script>

--- a/game.html
+++ b/game.html
@@ -407,6 +407,7 @@
         let canEditStats = false;
         let authResolved = false;
         let gameLoaded = false;
+        let gameLoadedForAuthenticatedUser = false;
 
         const authTimeout = setTimeout(() => {
             if (authResolved || gameLoaded) return;
@@ -418,9 +419,10 @@
             authResolved = true;
             clearTimeout(authTimeout);
             // Allow viewing without login - user can be null
+            const shouldRefreshPermissions = gameLoaded && !gameLoadedForAuthenticatedUser && !!user;
             currentUser = user;
             renderHeader(document.getElementById('header-container'), user);
-            loadGame();
+            loadGame({ forceAuthenticatedReload: shouldRefreshPermissions });
         });
 
         renderFooter(document.getElementById('footer-container'));
@@ -1240,9 +1242,13 @@ Write the match report now:`;
             saveNextBtn?.addEventListener('click', () => saveCurrent('next'));
         }
 
-        async function loadGame() {
-            if (gameLoaded) return;
+        async function loadGame({ forceAuthenticatedReload = false } = {}) {
+            if (gameLoaded && (!forceAuthenticatedReload || gameLoadedForAuthenticatedUser)) return;
             gameLoaded = true;
+            gameLoadedForAuthenticatedUser = !!currentUser;
+            canManageStatSheet = false;
+            canEditSummary = false;
+            canEditStats = false;
             const { teamId, gameId } = getUrlParams();
             if (!teamId || !gameId) {
                 window.location.href = 'index.html';
@@ -1675,6 +1681,10 @@ Write the match report now:`;
                     });
 
                     // Render header
+                    opponentHeaderRow.innerHTML = `
+                        <th class="px-4 py-4 text-left">#</th>
+                        <th class="px-4 py-4 text-left">Player</th>
+                    `;
                     oppKeys.forEach(key => {
                         const th = document.createElement('th');
                         th.className = "px-4 py-4 text-center";

--- a/tests/unit/game-auth-reload.test.js
+++ b/tests/unit/game-auth-reload.test.js
@@ -18,8 +18,12 @@ describe('game auth reload', () => {
         const source = readGameHtml();
 
         expect(source).toContain('async function loadGame({ forceAuthenticatedReload = false } = {})');
+        expect(source).toContain('let gameLoadPromise = null;');
+        expect(source).toContain('if (gameLoadPromise) {');
+        expect(source).toContain('await gameLoadPromise;');
         expect(source).toContain('if (gameLoaded && (!forceAuthenticatedReload || gameLoadedForAuthenticatedUser)) return;');
         expect(source).toContain('gameLoadedForAuthenticatedUser = !!currentUser;');
+        expect(source).toContain('gameLoadPromise = null;');
     });
 
     it('resets opponent stat headers before an authenticated reload re-renders the report', () => {

--- a/tests/unit/game-auth-reload.test.js
+++ b/tests/unit/game-auth-reload.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readGameHtml() {
+    return readFileSync(new URL('../../game.html', import.meta.url), 'utf8');
+}
+
+describe('game auth reload', () => {
+    it('forces one authenticated reload after the public auth timeout fallback loads the report', () => {
+        const source = readGameHtml();
+
+        expect(source).toContain('let gameLoadedForAuthenticatedUser = false;');
+        expect(source).toContain('const shouldRefreshPermissions = gameLoaded && !gameLoadedForAuthenticatedUser && !!user;');
+        expect(source).toContain('loadGame({ forceAuthenticatedReload: shouldRefreshPermissions });');
+    });
+
+    it('keeps the normal single-load guard after authenticated state has rendered', () => {
+        const source = readGameHtml();
+
+        expect(source).toContain('async function loadGame({ forceAuthenticatedReload = false } = {})');
+        expect(source).toContain('if (gameLoaded && (!forceAuthenticatedReload || gameLoadedForAuthenticatedUser)) return;');
+        expect(source).toContain('gameLoadedForAuthenticatedUser = !!currentUser;');
+    });
+
+    it('resets opponent stat headers before an authenticated reload re-renders the report', () => {
+        const source = readGameHtml();
+        const opponentStatsStart = source.indexOf('if (game.opponentStats && Object.keys(game.opponentStats).length > 0)');
+        const opponentHeaderReset = source.indexOf('opponentHeaderRow.innerHTML = `', opponentStatsStart);
+        const opponentHeaderAppend = source.indexOf('oppKeys.forEach(key => {', opponentStatsStart);
+
+        expect(opponentStatsStart).toBeGreaterThan(-1);
+        expect(opponentHeaderReset).toBeGreaterThan(opponentStatsStart);
+        expect(opponentHeaderReset).toBeLessThan(opponentHeaderAppend);
+    });
+});


### PR DESCRIPTION
Closes #1179

## Summary
- Allows `game.html` to perform one authenticated reload when the 3-second public fallback rendered before Firebase auth resolved.
- Resets postgame permission flags before each load so Coach/Admin controls are recomputed from the resolved user.
- Resets opponent stat headers before a reload to avoid duplicate dynamic columns.

## Tests
- `npx vitest run tests/unit/game-auth-reload.test.js tests/unit/game-statsheet-controls.test.js --reporter=dot`