### PR TITLE
Add family page sharing — read-only public view for grandparents/friends

### DIFF
--- a/family.html
+++ b/family.html
@@ -1,0 +1,847 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-3J13LHWFT3"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+    gtag('config', 'G-3J13LHWFT3');
+  </script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="robots" content="noindex,nofollow">
+  <link rel="icon" type="image/png" href="img/logo_small.png">
+  <title>Family Page - ALL PLAYS</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="css/styles.css">
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          colors: {
+            primary: {
+              50: '#eef2ff',
+              100: '#e0e7ff',
+              500: '#6366f1',
+              600: '#4f46e5',
+              700: '#4338ca',
+              800: '#3730a3',
+              900: '#312e81'
+            }
+          }
+        }
+      }
+    }
+  </script>
+  <script type="module" src="/js/telemetry.js?v=1"></script>
+</head>
+
+<body class="bg-gradient-to-br from-gray-50 to-gray-100 text-gray-900">
+  <div id="header-container"></div>
+
+  <!-- Token invalid / loading states -->
+  <div id="page-error" class="hidden container mx-auto px-4 py-16 text-center">
+    <svg class="w-16 h-16 text-gray-300 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"></path>
+    </svg>
+    <h2 class="text-xl font-bold text-gray-700 mb-2">This link is no longer valid</h2>
+    <p class="text-gray-500 text-sm">The family page link you used has been revoked or does not exist.</p>
+  </div>
+
+  <div id="page-loading" class="container mx-auto px-4 py-16 text-center">
+    <div class="animate-spin rounded-full h-10 w-10 border-b-2 border-primary-600 mx-auto mb-4"></div>
+    <p class="text-gray-500 text-sm">Loading family page...</p>
+  </div>
+
+  <main id="page-main" class="hidden container mx-auto px-4 py-8 md:py-12">
+    <!-- Page Header -->
+    <div class="mb-8 md:mb-10">
+      <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
+        <div>
+          <div class="flex items-center gap-2 mb-1">
+            <span class="text-xs font-semibold text-primary-600 bg-primary-50 border border-primary-200 px-2 py-0.5 rounded-full uppercase tracking-wide">Read Only</span>
+          </div>
+          <h1 id="page-title" class="text-3xl md:text-4xl font-bold bg-gradient-to-r from-primary-600 to-primary-800 bg-clip-text text-transparent">Family Page</h1>
+          <p id="page-subtitle" class="text-gray-500 text-sm mt-1">Schedule, players, and team info — shared with you.</p>
+        </div>
+        <div class="flex items-center gap-2">
+          <button id="download-ics"
+            class="inline-flex items-center gap-2 bg-white text-primary-600 px-4 py-3 rounded-xl border border-primary-200 hover:bg-primary-50 transition font-semibold text-sm">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"></path>
+            </svg>
+            Add to Calendar (.ics)
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-8">
+      <!-- Left Column: Players + Teams -->
+      <div class="lg:col-span-1 space-y-6">
+        <!-- My Players -->
+        <div class="bg-white rounded-2xl shadow-md border border-gray-200 overflow-hidden">
+          <div class="p-4 border-b border-gray-100 bg-gray-50">
+            <h2 class="text-lg font-bold text-gray-900">Players</h2>
+          </div>
+          <div id="players-list" class="p-4 space-y-3">
+            <div class="text-center py-6">
+              <div class="animate-spin rounded-full h-6 w-6 border-b-2 border-primary-600 mx-auto mb-2"></div>
+              <p class="text-sm text-gray-500">Loading...</p>
+            </div>
+          </div>
+        </div>
+
+        <!-- My Teams -->
+        <div class="bg-white rounded-2xl shadow-md border border-gray-200 overflow-hidden">
+          <div class="p-4 border-b border-gray-100 bg-gray-50">
+            <h2 class="text-lg font-bold text-gray-900">Teams</h2>
+          </div>
+          <div id="teams-list" class="p-4 space-y-2">
+            <div class="text-center py-4 text-gray-500 text-sm">Loading...</div>
+          </div>
+        </div>
+
+        <!-- Shared by banner -->
+        <div class="rounded-2xl border border-primary-100 bg-primary-50 p-4 text-sm text-primary-800">
+          <svg class="w-5 h-5 inline-block mr-1 text-primary-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+          </svg>
+          This page is a read-only view. Sign in to get your own parent account with full access including RSVP, team chat, and more.
+        </div>
+      </div>
+
+      <!-- Right Column: Schedule -->
+      <div class="lg:col-span-2">
+        <div class="bg-white rounded-2xl shadow-md border border-gray-200 overflow-hidden min-h-[500px]">
+          <div class="p-6 border-b border-gray-100 bg-gray-50 flex justify-between items-center gap-3">
+            <h2 class="text-xl font-bold text-gray-900">Schedule</h2>
+            <div class="flex items-center gap-2">
+              <div class="flex rounded-lg border border-gray-200 overflow-hidden">
+                <button id="schedule-view-list" onclick="setScheduleView('list')" class="px-2.5 py-1 text-xs font-semibold bg-primary-600 text-white">List</button>
+                <button id="schedule-view-calendar" onclick="setScheduleView('calendar')" class="px-2.5 py-1 text-xs font-semibold bg-white text-gray-600 hover:bg-gray-100">Calendar</button>
+              </div>
+              <select id="player-filter" class="text-xs font-medium bg-white px-2 py-1 rounded border border-gray-200 text-gray-600 focus:outline-none focus:ring-1 focus:ring-primary-500">
+                <option value="">All Players</option>
+              </select>
+            </div>
+          </div>
+          <div class="px-6 py-3 border-b border-gray-100 bg-gray-50">
+            <div class="flex flex-wrap items-center gap-2">
+              <button id="schedule-filter-upcoming-all" onclick="setScheduleFilter('upcoming-all')" class="px-2.5 py-1 text-xs font-semibold rounded-full border border-primary-200 bg-primary-50 text-primary-700">All Upcoming</button>
+              <button id="schedule-filter-upcoming-games" onclick="setScheduleFilter('upcoming-games')" class="px-2.5 py-1 text-xs font-semibold rounded-full border border-gray-200 bg-white text-gray-600 hover:bg-gray-100">Upcoming Games</button>
+              <button id="schedule-filter-upcoming-practices" onclick="setScheduleFilter('upcoming-practices')" class="px-2.5 py-1 text-xs font-semibold rounded-full border border-gray-200 bg-white text-gray-600 hover:bg-gray-100">Upcoming Practices</button>
+              <button id="schedule-filter-past-all" onclick="setScheduleFilter('past-all')" class="px-2.5 py-1 text-xs font-semibold rounded-full border border-gray-200 bg-white text-gray-600 hover:bg-gray-100">Past Events</button>
+            </div>
+          </div>
+          <div id="schedule-calendar-nav" class="hidden px-6 py-3 border-b border-gray-100 bg-white flex items-center justify-center gap-4">
+            <button onclick="navScheduleMonth(-1)" class="px-3 py-1.5 rounded-lg bg-white border border-gray-200 text-gray-600 hover:bg-gray-50 text-sm font-medium">&larr; Prev</button>
+            <span id="schedule-calendar-month-label" class="text-base font-bold text-gray-900"></span>
+            <button onclick="navScheduleMonth(1)" class="px-3 py-1.5 rounded-lg bg-white border border-gray-200 text-gray-600 hover:bg-gray-50 text-sm font-medium">Next &rarr;</button>
+          </div>
+          <div id="schedule-list" class="divide-y divide-gray-100">
+            <div class="text-center py-12">
+              <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-primary-600 mx-auto mb-2"></div>
+              <p class="text-sm text-gray-500">Loading schedule...</p>
+            </div>
+          </div>
+          <div id="schedule-calendar-grid" class="hidden"></div>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <!-- Day modal (calendar click) -->
+  <div id="schedule-day-modal" class="hidden fixed inset-0 z-50">
+    <div class="absolute inset-0 bg-black/50" onclick="closeScheduleDayModal()"></div>
+    <div class="absolute inset-y-0 right-0 w-full max-w-lg bg-white shadow-2xl overflow-y-auto">
+      <div class="sticky top-0 bg-white border-b border-gray-200 px-6 py-4 flex items-center justify-between z-10">
+        <h3 id="schedule-day-modal-title" class="text-lg font-bold text-gray-900"></h3>
+        <button onclick="closeScheduleDayModal()" class="text-gray-400 hover:text-gray-700">
+          <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12"></path>
+          </svg>
+        </button>
+      </div>
+      <div id="schedule-day-modal-content" class="px-6 py-5"></div>
+    </div>
+  </div>
+
+  <div id="footer-container"></div>
+
+  <script type="module">
+    import { getFamilyShareToken, getTeam, getGames, getTrackedCalendarEventUids } from './js/db.js?v=54';
+    import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence, getCalendarEventTrackingId, isTrackedCalendarEvent } from './js/utils.js?v=10';
+
+    renderFooter(document.getElementById('footer-container'));
+
+    const params = new URLSearchParams(window.location.search);
+    const tokenId = params.get('token') || '';
+
+    let allScheduleEvents = [];
+    let scheduleViewFilter = 'upcoming-all';
+    let scheduleViewMode = 'list';
+    let scheduleCalendarMonth = new Date().getMonth();
+    let scheduleCalendarYear = new Date().getFullYear();
+    let activeDayModal = null;
+
+    window.setScheduleView = setScheduleView;
+    window.setScheduleFilter = setScheduleFilter;
+    window.navScheduleMonth = navScheduleMonth;
+    window.openScheduleDayModal = openScheduleDayModal;
+    window.closeScheduleDayModal = closeScheduleDayModal;
+
+    function escapeAttr(value) {
+      return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+    }
+
+    function toDateSafe(value) {
+      if (!value) return null;
+      const d = value?.toDate ? value.toDate() : new Date(value);
+      return Number.isNaN(d?.getTime?.()) ? null : d;
+    }
+
+    async function init() {
+      if (!tokenId) {
+        showError();
+        return;
+      }
+
+      let token;
+      try {
+        token = await getFamilyShareToken(tokenId);
+      } catch (err) {
+        console.error('[family] Failed to load token:', err);
+        showError();
+        return;
+      }
+
+      if (!token || token.active === false) {
+        showError();
+        return;
+      }
+
+      // Render header (no auth user — anonymous view)
+      renderHeader(document.getElementById('header-container'), null);
+
+      // Set title
+      const titleEl = document.getElementById('page-title');
+      const subtitleEl = document.getElementById('page-subtitle');
+      if (token.label) {
+        titleEl.textContent = token.label;
+        subtitleEl.textContent = 'Schedule, players, and team info — shared with you.';
+      }
+
+      document.title = (token.label || 'Family Page') + ' - ALL PLAYS';
+
+      const children = Array.isArray(token.children) ? token.children : [];
+
+      renderPlayers(children);
+      renderTeams(children);
+
+      // Load schedule
+      const events = await buildCombinedSchedule(children);
+      allScheduleEvents = events;
+
+      initPlayerFilter(children);
+      setScheduleFilter('upcoming-all');
+
+      // ICS export
+      document.getElementById('download-ics')?.addEventListener('click', () => {
+        const filterValue = document.getElementById('player-filter')?.value;
+        const eventsToExport = filterValue
+          ? allScheduleEvents.filter(ev => ev.childId === filterValue)
+          : allScheduleEvents;
+        if (!eventsToExport.length) {
+          alert('No events to export.');
+          return;
+        }
+        const ics = buildIcs(eventsToExport);
+        const blob = new Blob([ics], { type: 'text/calendar' });
+        const url = URL.createObjectURL(blob);
+        const link = document.createElement('a');
+        link.href = url;
+        const filename = filterValue
+          ? `${eventsToExport[0]?.childName || 'player'}-schedule.ics`.replace(/[^a-z0-9]+/gi, '-').toLowerCase()
+          : 'family-schedule.ics';
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+      });
+
+      document.getElementById('page-loading').classList.add('hidden');
+      document.getElementById('page-main').classList.remove('hidden');
+    }
+
+    function showError() {
+      document.getElementById('page-loading').classList.add('hidden');
+      document.getElementById('page-error').classList.remove('hidden');
+    }
+
+    function renderPlayers(children) {
+      const container = document.getElementById('players-list');
+      if (!children || children.length === 0) {
+        container.innerHTML = '<div class="text-center py-6 text-gray-500 text-sm">No players.</div>';
+        return;
+      }
+      container.innerHTML = children.map(child => `
+        <div class="rounded-xl border border-gray-200 overflow-hidden">
+          <a href="player.html?teamId=${escapeAttr(child.teamId)}&playerId=${escapeAttr(child.playerId)}"
+             class="flex items-center gap-3 p-3 hover:bg-primary-50 transition group">
+            <div class="h-11 w-11 flex-shrink-0 rounded-full bg-gray-200 overflow-hidden border border-gray-300">
+              ${child.playerPhotoUrl
+                ? `<img src="${escapeHtml(child.playerPhotoUrl)}" class="w-full h-full object-cover" loading="lazy">`
+                : `<div class="w-full h-full flex items-center justify-center text-gray-400 text-xs font-bold">${escapeHtml((child.playerName || '?').charAt(0).toUpperCase())}</div>`
+              }
+            </div>
+            <div class="flex-grow min-w-0">
+              <div class="font-bold text-gray-900 group-hover:text-primary-700 truncate">${escapeHtml(child.playerName || 'Player')}</div>
+              <div class="text-xs text-gray-500 truncate">${escapeHtml(child.teamName || 'Team')}</div>
+            </div>
+            <svg class="w-4 h-4 text-gray-300 group-hover:text-primary-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+            </svg>
+          </a>
+        </div>
+      `).join('');
+    }
+
+    function renderTeams(children) {
+      const container = document.getElementById('teams-list');
+      if (!children || children.length === 0) {
+        container.innerHTML = '<div class="text-center py-4 text-gray-500 text-sm">No teams.</div>';
+        return;
+      }
+      const teamsMap = new Map();
+      children.forEach(child => {
+        if (!teamsMap.has(child.teamId)) {
+          teamsMap.set(child.teamId, { teamId: child.teamId, teamName: child.teamName, playerNames: [] });
+        }
+        if (child.playerName) teamsMap.get(child.teamId).playerNames.push(child.playerName);
+      });
+
+      container.innerHTML = Array.from(teamsMap.values()).map(team => `
+        <a href="team.html#teamId=${escapeAttr(team.teamId)}"
+           class="flex items-center gap-3 p-3 rounded-xl border border-gray-200 hover:bg-primary-50 hover:border-primary-200 transition group">
+          <div class="flex-shrink-0 w-10 h-10 bg-primary-100 rounded-full flex items-center justify-center">
+            <span class="text-primary-700 font-bold text-sm">${escapeHtml((team.teamName || 'T').charAt(0).toUpperCase())}</span>
+          </div>
+          <div class="flex-grow min-w-0">
+            <div class="font-semibold text-gray-900 truncate group-hover:text-primary-700">${escapeHtml(team.teamName || 'Team')}</div>
+            <div class="text-xs text-gray-500 truncate">${escapeHtml(team.playerNames.join(', '))}</div>
+          </div>
+          <svg class="w-4 h-4 text-gray-300 group-hover:text-primary-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+          </svg>
+        </a>
+      `).join('');
+    }
+
+    async function buildCombinedSchedule(children) {
+      if (!children || children.length === 0) return [];
+
+      const byTeam = new Map();
+      for (const child of children) {
+        if (!child.teamId) continue;
+        if (!byTeam.has(child.teamId)) byTeam.set(child.teamId, []);
+        byTeam.get(child.teamId).push(child);
+      }
+
+      const allEvents = [];
+      const batches = await Promise.all(Array.from(byTeam.entries()).map(async ([teamId, teamChildren]) => {
+        const teamEvents = [];
+        let team, dbGames, trackedUids;
+        try {
+          [team, dbGames, trackedUids] = await Promise.all([
+            getTeam(teamId),
+            getGames(teamId),
+            getTrackedCalendarEventUids(teamId)
+          ]);
+          if (!team) return teamEvents;
+        } catch (err) {
+          console.warn('[family] Failed to load team data:', teamId, err);
+          return teamEvents;
+        }
+        if (!Array.isArray(dbGames)) dbGames = [];
+        if (!Array.isArray(trackedUids)) trackedUids = [];
+
+        // DB games (including practice type)
+        for (const game of dbGames) {
+          const isPractice = game.type === 'practice';
+          const type = isPractice ? 'practice' : 'game';
+          const isCancelled = game.status === 'cancelled';
+
+          if (isPractice && game.isSeriesMaster && game.recurrence) {
+            for (const occ of expandRecurrence(game)) {
+              const occDate = occ.date instanceof Date ? occ.date : new Date(occ.date);
+              const occId = `${occ.masterId}__${occ.instanceDate}`;
+              for (const child of teamChildren) {
+                teamEvents.push({
+                  type: 'practice',
+                  date: occDate,
+                  location: occ.location || 'TBD',
+                  opponent: 'TBD',
+                  teamId,
+                  teamName: team.name || child.teamName || '',
+                  id: occId,
+                  isDbGame: true,
+                  childId: child.playerId,
+                  childName: child.playerName,
+                  title: occ.title || null,
+                  status: game.status || 'scheduled',
+                  isCancelled,
+                  isHome: null,
+                  kitColor: null,
+                  arrivalTime: game.arrivalTime || null,
+                  notes: occ.notes || null
+                });
+              }
+            }
+          } else {
+            const date = game.date?.toDate ? game.date.toDate() : new Date(game.date);
+            const id = game.id || game.gameId;
+            for (const child of teamChildren) {
+              teamEvents.push({
+                type,
+                date,
+                location: game.location || 'TBD',
+                opponent: game.opponent || 'TBD',
+                teamId,
+                teamName: team.name || child.teamName || '',
+                id,
+                isDbGame: true,
+                childId: child.playerId,
+                childName: child.playerName,
+                title: game.title || null,
+                status: game.status || 'scheduled',
+                isCancelled,
+                isHome: game.isHome ?? null,
+                kitColor: game.kitColor || null,
+                arrivalTime: game.arrivalTime || null,
+                notes: game.notes || null
+              });
+            }
+          }
+        }
+
+        // ICS calendar events for this team
+        if (team.calendarUrls && team.calendarUrls.length > 0) {
+          const calendarResults = await Promise.all(team.calendarUrls.map(async (calendarUrl) => {
+            try {
+              const calendarEvents = await fetchAndParseCalendar(calendarUrl);
+              return { calendarEvents };
+            } catch (err) {
+              console.error('[family] Error fetching calendar:', calendarUrl, err);
+              return { calendarEvents: [] };
+            }
+          }));
+
+          calendarResults.forEach(({ calendarEvents }) => {
+            calendarEvents.forEach(event => {
+              if (isTrackedCalendarEvent(event, trackedUids)) return;
+              const isCancelled = event.status?.toUpperCase() === 'CANCELLED' || event.summary?.includes('[CANCELED]');
+              const eventDate = event.dtstart;
+              if (!eventDate) return;
+              const hasConflict = dbGames.some(dbGame => {
+                const dbDate = dbGame.date?.toDate ? dbGame.date.toDate() : new Date(dbGame.date);
+                return Math.abs(dbDate - eventDate) < 60000;
+              });
+              if (hasConflict) return;
+              const isPractice = isPracticeEvent(event.summary);
+              const cleanSummary = event.summary?.replace(/\[CANCELED\]\s*/gi, '') || '';
+              const opponent = extractOpponent(cleanSummary, team.name);
+              const location = event.location || 'TBD';
+              const type = isPractice ? 'practice' : 'game';
+              for (const child of teamChildren) {
+                teamEvents.push({
+                  type,
+                  date: eventDate,
+                  location,
+                  opponent,
+                  teamId,
+                  teamName: team.name || child.teamName || '',
+                  id: getCalendarEventTrackingId(event) || null,
+                  calendarEventUid: event.uid || null,
+                  isDbGame: false,
+                  childId: child.playerId,
+                  childName: child.playerName,
+                  isCancelled
+                });
+              }
+            });
+          });
+        }
+
+        return teamEvents;
+      }));
+
+      batches.forEach(batch => allEvents.push(...batch));
+      allEvents.sort((a, b) => a.date - b.date);
+      return allEvents;
+    }
+
+    function initPlayerFilter(children) {
+      const select = document.getElementById('player-filter');
+      if (!select) return;
+      select.innerHTML = `<option value="">All Players</option>` +
+        children.map(child => `<option value="${escapeAttr(child.playerId)}">${escapeHtml(child.playerName || 'Player')}</option>`).join('');
+      select.addEventListener('change', () => renderScheduleFromControls(select.value || ''));
+    }
+
+    function getFilteredScheduleEvents(selectedPlayerId = '') {
+      const now = new Date();
+      const cutoff = new Date(now.getTime() - 3 * 60 * 60 * 1000);
+      let events = selectedPlayerId
+        ? allScheduleEvents.filter(ev => ev.childId === selectedPlayerId)
+        : [...allScheduleEvents];
+      if (scheduleViewFilter === 'upcoming-all') {
+        events = events.filter(ev => new Date(ev.date) >= cutoff);
+        events.sort((a, b) => a.date - b.date);
+      } else if (scheduleViewFilter === 'upcoming-games') {
+        events = events.filter(ev => ev.type === 'game' && new Date(ev.date) >= cutoff);
+        events.sort((a, b) => a.date - b.date);
+      } else if (scheduleViewFilter === 'upcoming-practices') {
+        events = events.filter(ev => ev.type === 'practice' && new Date(ev.date) >= cutoff);
+        events.sort((a, b) => a.date - b.date);
+      } else if (scheduleViewFilter === 'past-all') {
+        events = events.filter(ev => new Date(ev.date) < cutoff);
+        events.sort((a, b) => b.date - a.date);
+      }
+      return events;
+    }
+
+    function renderScheduleFromControls(selectedPlayerId = '') {
+      const playerId = selectedPlayerId || (document.getElementById('player-filter')?.value || '');
+      const events = getFilteredScheduleEvents(playerId);
+      const listEl = document.getElementById('schedule-list');
+      const calEl = document.getElementById('schedule-calendar-grid');
+      const navEl = document.getElementById('schedule-calendar-nav');
+      if (!listEl || !calEl || !navEl) return;
+      if (scheduleViewMode === 'calendar') {
+        listEl.classList.add('hidden');
+        calEl.classList.remove('hidden');
+        navEl.classList.remove('hidden');
+        renderScheduleCalendar(events);
+      } else {
+        calEl.classList.add('hidden');
+        navEl.classList.add('hidden');
+        listEl.classList.remove('hidden');
+        renderScheduleList(events);
+      }
+    }
+
+    function setScheduleView(mode) {
+      scheduleViewMode = mode === 'calendar' ? 'calendar' : 'list';
+      const listBtn = document.getElementById('schedule-view-list');
+      const calBtn = document.getElementById('schedule-view-calendar');
+      if (scheduleViewMode === 'calendar') {
+        const playerId = document.getElementById('player-filter')?.value || '';
+        const events = getCalendarEntries(getFilteredScheduleEvents(playerId));
+        if (events.length > 0) {
+          const hasCurrentMonth = events.some(ev => ev.date.getMonth() === scheduleCalendarMonth && ev.date.getFullYear() === scheduleCalendarYear);
+          if (!hasCurrentMonth) {
+            scheduleCalendarMonth = events[0].date.getMonth();
+            scheduleCalendarYear = events[0].date.getFullYear();
+          }
+        }
+      }
+      if (listBtn && calBtn) {
+        const listActive = scheduleViewMode === 'list';
+        listBtn.className = `px-2.5 py-1 text-xs font-semibold ${listActive ? 'bg-primary-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-100'}`;
+        calBtn.className = `px-2.5 py-1 text-xs font-semibold ${!listActive ? 'bg-primary-600 text-white' : 'bg-white text-gray-600 hover:bg-gray-100'}`;
+      }
+      renderScheduleFromControls();
+    }
+
+    function setScheduleFilter(next) {
+      scheduleViewFilter = next || 'upcoming-all';
+      const ids = ['upcoming-all', 'upcoming-games', 'upcoming-practices', 'past-all'];
+      ids.forEach(id => {
+        const btn = document.getElementById(`schedule-filter-${id}`);
+        if (!btn) return;
+        const active = id === scheduleViewFilter;
+        btn.className = `px-2.5 py-1 text-xs font-semibold rounded-full border ${active ? 'border-primary-200 bg-primary-50 text-primary-700' : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-100'}`;
+      });
+      renderScheduleFromControls();
+    }
+
+    function navScheduleMonth(delta) {
+      scheduleCalendarMonth += delta;
+      if (scheduleCalendarMonth > 11) { scheduleCalendarMonth = 0; scheduleCalendarYear += 1; }
+      else if (scheduleCalendarMonth < 0) { scheduleCalendarMonth = 11; scheduleCalendarYear -= 1; }
+      if (scheduleViewMode === 'calendar') renderScheduleFromControls();
+    }
+
+    function getCalendarEntries(events) {
+      const byKey = new Map();
+      (events || []).forEach(event => {
+        const d = event.date?.toDate ? event.date.toDate() : new Date(event.date);
+        if (!d || Number.isNaN(d.getTime())) return;
+        const key = `${event.teamId || ''}::${event.id || ''}::${d.toISOString()}::${event.type || ''}`;
+        if (!byKey.has(key)) {
+          byKey.set(key, { ...event, date: d, childNames: [], childIds: [] });
+        }
+        const item = byKey.get(key);
+        if (event.childName) item.childNames.push(event.childName);
+        if (event.childId) item.childIds.push(event.childId);
+      });
+      return Array.from(byKey.values()).map(item => ({
+        ...item,
+        childNames: [...new Set(item.childNames)],
+        childIds: [...new Set(item.childIds)]
+      }));
+    }
+
+    function renderScheduleCalendar(events) {
+      const container = document.getElementById('schedule-calendar-grid');
+      const label = document.getElementById('schedule-calendar-month-label');
+      if (!container || !label) return;
+
+      const monthNames = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'];
+      label.textContent = `${monthNames[scheduleCalendarMonth]} ${scheduleCalendarYear}`;
+
+      const monthStart = new Date(scheduleCalendarYear, scheduleCalendarMonth, 1);
+      const monthEnd = new Date(scheduleCalendarYear, scheduleCalendarMonth + 1, 0, 23, 59, 59);
+      const startDow = monthStart.getDay();
+      const daysInMonth = monthEnd.getDate();
+
+      const calendarEvents = getCalendarEntries(events).filter(ev => ev.date >= monthStart && ev.date <= monthEnd);
+      const eventsByDay = {};
+      calendarEvents.forEach(ev => {
+        const day = ev.date.getDate();
+        if (!eventsByDay[day]) eventsByDay[day] = [];
+        eventsByDay[day].push(ev);
+      });
+
+      const totalCells = Math.ceil((startDow + daysInMonth) / 7) * 7;
+      const today = new Date();
+      const isCurrentMonth = today.getMonth() === scheduleCalendarMonth && today.getFullYear() === scheduleCalendarYear;
+
+      let html = `
+        <div class="grid grid-cols-7 border-b border-gray-200 bg-gray-50">
+          ${['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map(d => `<div class="text-center text-xs font-bold text-gray-500 py-2">${d}</div>`).join('')}
+        </div>
+        <div class="grid grid-cols-7">
+      `;
+
+      for (let i = 0; i < totalCells; i++) {
+        const dayNum = i - startDow + 1;
+        const inMonth = dayNum >= 1 && dayNum <= daysInMonth;
+        const dayEvents = inMonth ? (eventsByDay[dayNum] || []) : [];
+        const isToday = isCurrentMonth && inMonth && dayNum === today.getDate();
+        html += `
+          <div class="min-h-[96px] border border-gray-100 p-1.5 ${inMonth ? 'bg-white' : 'bg-gray-50 text-gray-300'} ${isToday ? 'ring-1 ring-primary-300' : ''} ${inMonth && dayEvents.length ? 'cursor-pointer hover:bg-gray-50' : ''}"
+            ${inMonth && dayEvents.length ? `onclick="openScheduleDayModal(${scheduleCalendarYear}, ${scheduleCalendarMonth}, ${dayNum})"` : ''}>
+            ${inMonth ? `<div class="text-xs font-semibold ${isToday ? 'text-primary-700' : 'text-gray-700'}">${dayNum}</div>` : ''}
+            ${inMonth && dayEvents.length ? `
+              <div class="mt-1 space-y-1">
+                ${dayEvents.slice(0, 3).map(ev => `
+                  <div class="text-[10px] px-1 py-0.5 rounded truncate ${ev.type === 'practice' ? 'bg-amber-100 text-amber-800' : 'bg-primary-100 text-primary-800'}">
+                    ${escapeHtml(ev.type === 'practice' ? (ev.title || 'Practice') : `vs. ${ev.opponent || 'TBD'}`)}
+                  </div>
+                `).join('')}
+                ${dayEvents.length > 3 ? `<div class="text-[10px] text-gray-400">+${dayEvents.length - 3} more</div>` : ''}
+              </div>
+            ` : ''}
+          </div>
+        `;
+      }
+      html += '</div>';
+      container.innerHTML = html;
+    }
+
+    function openScheduleDayModal(year, month, day) {
+      const titleEl = document.getElementById('schedule-day-modal-title');
+      const contentEl = document.getElementById('schedule-day-modal-content');
+      const modalEl = document.getElementById('schedule-day-modal');
+      if (!titleEl || !contentEl || !modalEl) return;
+      activeDayModal = { year, month, day };
+
+      const dayStart = new Date(year, month, day);
+      const dayEnd = new Date(year, month, day, 23, 59, 59);
+      const playerId = document.getElementById('player-filter')?.value || '';
+      const getEventsForModal = (sourceEvents) => getCalendarEntries(sourceEvents)
+        .filter(ev => ev.date >= dayStart && ev.date <= dayEnd)
+        .sort((a, b) => a.date - b.date);
+      let events = getEventsForModal(getFilteredScheduleEvents(playerId));
+      if (!events.length) {
+        const fallback = playerId ? allScheduleEvents.filter(ev => ev.childId === playerId) : allScheduleEvents;
+        events = getEventsForModal(fallback);
+      }
+
+      titleEl.textContent = dayStart.toLocaleDateString('en-US', { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
+      if (!events.length) {
+        contentEl.innerHTML = '<p class="text-gray-500 text-center py-8">No events on this day.</p>';
+      } else {
+        contentEl.innerHTML = events.map(ev => renderDayModalEvent(ev)).join('');
+      }
+      modalEl.classList.remove('hidden');
+      document.body.style.overflow = 'hidden';
+    }
+
+    function closeScheduleDayModal() {
+      activeDayModal = null;
+      document.getElementById('schedule-day-modal')?.classList.add('hidden');
+      document.body.style.overflow = '';
+    }
+
+    function renderDayModalEvent(ev) {
+      const timeStr = ev.date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+      const title = ev.type === 'practice' ? (ev.title || 'Practice') : `vs. ${ev.opponent || 'TBD'}`;
+      return `
+        <div class="mb-4 p-4 rounded-lg border border-gray-200 ${ev.isCancelled ? 'opacity-60' : ''}">
+          <div class="text-xs font-semibold uppercase ${ev.type === 'practice' ? 'text-amber-700' : 'text-primary-700'}">${ev.type}</div>
+          <div class="font-bold text-gray-900 ${ev.isCancelled ? 'line-through' : ''}">${escapeHtml(title)}</div>
+          <div class="text-sm text-gray-600 mt-1">${timeStr} · ${escapeHtml(ev.location || 'TBD')}</div>
+          ${ev.type === 'game' && ev.isHome === true ? '<span class="inline-block text-xs bg-blue-100 text-blue-800 px-2 py-0.5 rounded-full font-semibold mt-1 mr-1">HOME</span>' : ''}
+          ${ev.type === 'game' && ev.isHome === false ? '<span class="inline-block text-xs bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full font-semibold mt-1 mr-1">AWAY</span>' : ''}
+          ${ev.kitColor ? `<div class="text-xs text-purple-700 mt-1">Kit: ${escapeHtml(ev.kitColor)}</div>` : ''}
+          ${ev.arrivalTime ? `<div class="text-xs text-amber-700 mt-1">Arrive: ${(() => { const at = ev.arrivalTime?.toDate ? ev.arrivalTime.toDate() : new Date(ev.arrivalTime); return at.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }); })()}</div>` : ''}
+          ${ev.notes ? `<div class="text-xs text-gray-500 mt-1 italic">${escapeHtml(ev.notes)}</div>` : ''}
+          ${ev.childNames?.length ? `<div class="text-xs text-gray-500 mt-1">For ${escapeHtml(ev.childNames.join(', '))}</div>` : ''}
+          ${!ev.isCancelled && ev.isDbGame && ev.type === 'game' ? `
+            <div class="mt-3">
+              <a href="game.html?teamId=${escapeAttr(ev.teamId)}&gameId=${escapeAttr(ev.id)}"
+                 class="inline-flex items-center gap-1 text-sm font-semibold text-primary-600 hover:text-primary-700">
+                View Game Details
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                </svg>
+              </a>
+            </div>
+          ` : ''}
+          ${ev.isCancelled ? '<div class="text-xs text-red-700 mt-1 font-semibold">Cancelled</div>' : ''}
+        </div>
+      `;
+    }
+
+    function renderScheduleList(games) {
+      const container = document.getElementById('schedule-list');
+      if (!games || games.length === 0) {
+        container.innerHTML = `
+          <div class="text-center py-16">
+            <svg class="w-16 h-16 text-gray-300 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+            </svg>
+            <p class="text-gray-500">No events in this filter.</p>
+          </div>
+        `;
+        return;
+      }
+
+      // Deduplicate by event key (same game may appear for multiple children)
+      const byKey = new Map();
+      games.forEach(game => {
+        const d = game.date instanceof Date ? game.date : new Date(game.date);
+        const key = `${game.teamId || ''}::${game.id || ''}::${d.toISOString()}::${game.type || ''}`;
+        if (!byKey.has(key)) {
+          byKey.set(key, { ...game, date: d, childNames: [], childIds: [] });
+        }
+        const item = byKey.get(key);
+        if (game.childName && !item.childNames.includes(game.childName)) item.childNames.push(game.childName);
+        if (game.childId && !item.childIds.includes(game.childId)) item.childIds.push(game.childId);
+      });
+
+      container.innerHTML = Array.from(byKey.values()).map(game => {
+        const gameDate = game.date;
+        const dateStr = gameDate.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
+        const timeStr = gameDate.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+        const typeLabel = game.type === 'practice' ? 'Practice' : 'Game';
+        const typeColor = game.type === 'practice' ? 'bg-amber-100 text-amber-800' : 'bg-primary-100 text-primary-800';
+        const isCancelled = game.isCancelled;
+        const childLabel = game.childNames.join(', ') || game.childName || 'Player';
+        return `
+          <div class="p-6 hover:bg-gray-50 transition flex flex-col sm:flex-row gap-4 sm:items-start ${isCancelled ? 'opacity-60' : ''}">
+            <div class="flex-shrink-0 w-24 text-center sm:text-left">
+              <div class="text-sm font-bold text-gray-900 uppercase ${isCancelled ? 'line-through' : ''}">${dateStr}</div>
+              <div class="text-xs text-gray-500 ${isCancelled ? 'line-through' : ''}">${timeStr}</div>
+            </div>
+            <div class="flex-grow">
+              <div class="flex items-center gap-2 mb-1">
+                <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-bold uppercase tracking-wide ${typeColor}">${typeLabel}</span>
+                ${isCancelled ? '<span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-bold uppercase tracking-wide bg-red-100 text-red-800">Cancelled</span>' : ''}
+                <span class="text-xs text-gray-400 font-medium">For ${escapeHtml(childLabel)}</span>
+              </div>
+              <div class="font-bold text-gray-900 text-lg ${isCancelled ? 'line-through' : ''}">
+                ${game.type === 'practice' ? escapeHtml(game.title || 'Practice') : `vs. ${escapeHtml(game.opponent || 'TBD')}`}
+              </div>
+              <div class="text-sm text-gray-500 flex items-center gap-1 mt-1">
+                <svg class="w-4 h-4 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17.657 16.657L13.414 20.9a1.998 1.998 0 01-2.827 0l-4.244-4.243a8 8 0 1111.314 0z"></path>
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 11a3 3 0 11-6 0 3 3 0 016 0z"></path>
+                </svg>
+                ${escapeHtml(game.location || 'TBD')}
+              </div>
+              ${game.type !== 'practice' && game.isHome === true ? '<span class="inline-block text-xs bg-blue-100 text-blue-800 px-2 py-0.5 rounded-full font-semibold mt-1 mr-1">HOME</span>' : ''}
+              ${game.type !== 'practice' && game.isHome === false ? '<span class="inline-block text-xs bg-gray-100 text-gray-700 px-2 py-0.5 rounded-full font-semibold mt-1 mr-1">AWAY</span>' : ''}
+              ${game.kitColor ? `<div class="text-xs text-purple-700 mt-1">Kit: ${escapeHtml(game.kitColor)}</div>` : ''}
+              ${game.arrivalTime ? `<div class="text-xs text-amber-700 mt-1">Arrive: ${(() => { const at = game.arrivalTime?.toDate ? game.arrivalTime.toDate() : new Date(game.arrivalTime); return at.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' }); })()}</div>` : ''}
+              ${game.notes ? `<div class="text-xs text-gray-500 mt-1 italic">${escapeHtml(game.notes)}</div>` : ''}
+              ${game.teamName ? `<div class="text-xs text-gray-400 mt-1">${escapeHtml(game.teamName)}</div>` : ''}
+            </div>
+            ${!isCancelled && game.isDbGame && game.type === 'game' ? `
+              <div class="flex-shrink-0">
+                <a href="game.html?teamId=${escapeAttr(game.teamId)}&gameId=${escapeAttr(game.id)}"
+                   class="inline-flex items-center gap-1 text-sm font-medium text-primary-600 hover:text-primary-700">
+                  View
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7"></path>
+                  </svg>
+                </a>
+              </div>
+            ` : ''}
+          </div>
+        `;
+      }).join('');
+    }
+
+    // ICS helpers
+    function formatIcsDate(date) {
+      const pad = n => String(n).padStart(2, '0');
+      return `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}T${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}Z`;
+    }
+
+    function buildIcs(events) {
+      const lines = ['BEGIN:VCALENDAR', 'VERSION:2.0', 'PRODID:-//ALL PLAYS//EN'];
+      const escapeIcs = value => String(value || '').replace(/\\/g, '\\\\').replace(/;/g, '\\;').replace(/,/g, '\\,').replace(/\r?\n/g, '\\n');
+      const seen = new Set();
+      events.forEach(event => {
+        const eventKey = `${event.teamId}-${event.id}-${new Date(event.date).getTime()}`;
+        if (seen.has(eventKey)) return;
+        seen.add(eventKey);
+        const date = event.date instanceof Date ? event.date : new Date(event.date);
+        const start = formatIcsDate(date);
+        const end = formatIcsDate(new Date(date.getTime() + 60 * 60 * 1000));
+        const summary = event.type === 'practice' ? `${event.childName} - Practice` : `${event.childName} vs ${event.opponent || 'TBD'}`;
+        lines.push(
+          'BEGIN:VEVENT',
+          `UID:${event.id || eventKey}@allplays`,
+          `DTSTAMP:${formatIcsDate(new Date())}`,
+          `DTSTART:${start}`,
+          `DTEND:${end}`,
+          `SUMMARY:${escapeIcs(summary)}`,
+          `LOCATION:${escapeIcs(event.location || 'TBD')}`,
+          `DESCRIPTION:${escapeIcs(`For ${event.childName}`)}`,
+          'END:VEVENT'
+        );
+      });
+      lines.push('END:VCALENDAR');
+      return lines.join('\r\n');
+    }
+
+    init().catch(err => {
+      console.error('[family] Init failed:', err);
+      showError();
+    });
+  </script>
+</body>
+</html>

--- a/family.html
+++ b/family.html
@@ -172,7 +172,7 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { getFamilyShareToken, getTeam, getGames, getTrackedCalendarEventUids } from './js/db.js?v=54';
+    import { getFamilyShareToken, getTeam, getGames, getTrackedCalendarEventUids } from './js/db.js?v=55';
     import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence, getCalendarEventTrackingId, isTrackedCalendarEvent } from './js/utils.js?v=10';
 
     renderFooter(document.getElementById('footer-container'));
@@ -247,7 +247,8 @@
       renderTeams(children);
 
       // Load schedule
-      const events = await buildCombinedSchedule(children);
+      const extraCalendarUrls = Array.isArray(token.extraCalendarUrls) ? token.extraCalendarUrls : [];
+      const events = await buildCombinedSchedule(children, extraCalendarUrls);
       allScheduleEvents = events;
 
       initPlayerFilter(children);
@@ -346,7 +347,7 @@
       `).join('');
     }
 
-    async function buildCombinedSchedule(children) {
+    async function buildCombinedSchedule(children, extraCalendarUrls = []) {
       if (!children || children.length === 0) return [];
 
       const byTeam = new Map();
@@ -485,6 +486,58 @@
       }));
 
       batches.forEach(batch => allEvents.push(...batch));
+
+      // Extra calendar URLs from the share token (not tied to any specific team)
+      if (extraCalendarUrls && extraCalendarUrls.length > 0) {
+        // Collect all existing DB game timestamps for conflict-checking
+        const dbTimestamps = allEvents
+          .filter(ev => ev.isDbGame)
+          .map(ev => new Date(ev.date).getTime());
+
+        const extraResults = await Promise.all(extraCalendarUrls.map(async (calUrl) => {
+          try {
+            const calendarEvents = await fetchAndParseCalendar(calUrl);
+            return calendarEvents;
+          } catch (err) {
+            console.warn('[family] Error fetching extra calendar:', calUrl, err);
+            return [];
+          }
+        }));
+
+        extraResults.forEach(calendarEvents => {
+          calendarEvents.forEach(event => {
+            const isCancelled = event.status?.toUpperCase() === 'CANCELLED' || event.summary?.includes('[CANCELED]');
+            const eventDate = event.dtstart;
+            if (!eventDate) return;
+            // Skip if conflicts with a DB game within 1 minute
+            const hasConflict = dbTimestamps.some(ts => Math.abs(ts - eventDate.getTime()) < 60000);
+            if (hasConflict) return;
+            const isPractice = isPracticeEvent(event.summary);
+            const cleanSummary = event.summary?.replace(/\[CANCELED\]\s*/gi, '') || '';
+            const type = isPractice ? 'practice' : 'game';
+            // Add one entry per unique child (deduped in renderScheduleList)
+            const uniqueChildren = [...new Map(children.map(c => [c.playerId, c])).values()];
+            for (const child of uniqueChildren) {
+              allEvents.push({
+                type,
+                date: eventDate,
+                location: event.location || 'TBD',
+                opponent: extractOpponent(cleanSummary, ''),
+                teamId: child.teamId || '',
+                teamName: child.teamName || '',
+                id: getCalendarEventTrackingId(event) || null,
+                calendarEventUid: event.uid || null,
+                isDbGame: false,
+                childId: child.playerId,
+                childName: child.playerName,
+                title: isPractice ? (cleanSummary || 'Practice') : null,
+                isCancelled
+              });
+            }
+          });
+        });
+      }
+
       allEvents.sort((a, b) => a.date - b.date);
       return allEvents;
     }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1647,6 +1647,27 @@ service cloud.firestore {
       }
     }
 
+    // Family share tokens — parent-created read-only share links for grandparents/friends.
+    // The tokenId is a 40-char hex string that serves as a bearer credential.
+    match /familyShareTokens/{tokenId} {
+      // Anyone who has the token ID can read it (to validate and load the family page).
+      // Owner can always read their own tokens (including revoked ones).
+      allow get: if resource.data.get('active', false) == true ||
+                    (isSignedIn() && resource.data.ownerUserId == request.auth.uid) ||
+                    isGlobalAdmin();
+      // Only the owner can list their tokens.
+      allow list: if isSignedIn() && request.auth.uid != null;
+      // Owner can create tokens on their own behalf.
+      allow create: if isSignedIn() &&
+                       request.resource.data.ownerUserId == request.auth.uid &&
+                       request.resource.data.active == true &&
+                       isSafeDocumentId(tokenId);
+      // Owner can update (e.g., revoke) their own tokens.
+      allow update: if isSignedIn() && resource.data.ownerUserId == request.auth.uid;
+      allow delete: if isSignedIn() &&
+                       (resource.data.ownerUserId == request.auth.uid || isGlobalAdmin());
+    }
+
     // Deny all other paths
     match /{document=**} {
       allow read, write: if false;

--- a/firestore.rules
+++ b/firestore.rules
@@ -1655,8 +1655,8 @@ service cloud.firestore {
       allow get: if resource.data.get('active', false) == true ||
                     (isSignedIn() && resource.data.ownerUserId == request.auth.uid) ||
                     isGlobalAdmin();
-      // Only the owner can list their tokens.
-      allow list: if isSignedIn() && request.auth.uid != null;
+      // Only the owner can list their own tokens (rule applied per-document).
+      allow list: if isSignedIn() && resource.data.ownerUserId == request.auth.uid;
       // Owner can create tokens on their own behalf.
       allow create: if isSignedIn() &&
                        request.resource.data.ownerUserId == request.auth.uid &&

--- a/js/db.js
+++ b/js/db.js
@@ -6638,7 +6638,7 @@ function generateShareToken() {
     return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
 }
 
-export async function createFamilyShareToken(ownerUserId, children, label) {
+export async function createFamilyShareToken(ownerUserId, children, label, extraCalendarUrls = []) {
     const tokenId = generateShareToken();
     const now = Timestamp.now();
     await setDoc(doc(db, 'familyShareTokens', tokenId), {
@@ -6651,11 +6651,19 @@ export async function createFamilyShareToken(ownerUserId, children, label) {
             playerName: c.playerName || '',
             playerPhotoUrl: c.playerPhotoUrl || null
         })),
+        extraCalendarUrls: (extraCalendarUrls || []).filter(u => typeof u === 'string' && u.trim()),
         createdAt: now,
         updatedAt: now,
         active: true
     });
     return tokenId;
+}
+
+export async function updateFamilyShareTokenCalendars(tokenId, urls) {
+    await updateDoc(doc(db, 'familyShareTokens', tokenId), {
+        extraCalendarUrls: (urls || []).filter(u => typeof u === 'string' && u.trim()),
+        updatedAt: Timestamp.now()
+    });
 }
 
 export async function getFamilyShareToken(tokenId) {

--- a/js/db.js
+++ b/js/db.js
@@ -6629,3 +6629,57 @@ export async function getAssignmentClaims(teamId, gameId) {
     });
     return claims;
 }
+
+// ── Family Share Tokens ──────────────────────────────────────────────────────
+
+function generateShareToken() {
+    const bytes = new Uint8Array(20);
+    crypto.getRandomValues(bytes);
+    return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+}
+
+export async function createFamilyShareToken(ownerUserId, children, label) {
+    const tokenId = generateShareToken();
+    const now = Timestamp.now();
+    await setDoc(doc(db, 'familyShareTokens', tokenId), {
+        ownerUserId,
+        label: label || '',
+        children: (children || []).map(c => ({
+            teamId: c.teamId || '',
+            teamName: c.teamName || '',
+            playerId: c.playerId || '',
+            playerName: c.playerName || '',
+            playerPhotoUrl: c.playerPhotoUrl || null
+        })),
+        createdAt: now,
+        updatedAt: now,
+        active: true
+    });
+    return tokenId;
+}
+
+export async function getFamilyShareToken(tokenId) {
+    if (!tokenId) return null;
+    const snap = await getDoc(doc(db, 'familyShareTokens', tokenId));
+    if (!snap.exists()) return null;
+    return { id: snap.id, ...snap.data() };
+}
+
+export async function listFamilyShareTokens(ownerUserId) {
+    const q = query(
+        collection(db, 'familyShareTokens'),
+        where('ownerUserId', '==', ownerUserId),
+        where('active', '==', true),
+        orderBy('createdAt', 'desc')
+    );
+    const snap = await getDocs(q);
+    return snap.docs.map(d => ({ id: d.id, ...d.data() }));
+}
+
+export async function revokeFamilyShareToken(tokenId) {
+    await updateDoc(doc(db, 'familyShareTokens', tokenId), {
+        active: false,
+        revokedAt: Timestamp.now(),
+        updatedAt: Timestamp.now()
+    });
+}

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -100,10 +100,25 @@
                             New Link
                         </button>
                     </div>
-                    <div id="share-link-form" class="hidden px-4 pt-4 pb-2 border-b border-gray-100 space-y-2">
-                        <label class="block text-xs font-medium text-gray-700">Label (optional)</label>
-                        <input type="text" id="share-link-label" placeholder="e.g. Grandma's link" maxlength="60"
-                            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-primary-500 focus:border-primary-500">
+                    <div id="share-link-form" class="hidden px-4 pt-4 pb-2 border-b border-gray-100 space-y-3">
+                        <div>
+                            <label class="block text-xs font-medium text-gray-700 mb-1">Label (optional)</label>
+                            <input type="text" id="share-link-label" placeholder="e.g. Grandma's link" maxlength="60"
+                                class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-primary-500 focus:border-primary-500">
+                        </div>
+                        <div>
+                            <label class="block text-xs font-medium text-gray-700 mb-1">Extra Calendars (optional)</label>
+                            <p class="text-[11px] text-gray-500 mb-2">Add .ics calendar URLs (league, travel team, etc.) to include in the family page schedule.</p>
+                            <div id="share-form-calendar-list" class="space-y-1 mb-2"></div>
+                            <div class="flex gap-1">
+                                <input type="url" id="share-form-calendar-input" placeholder="https://…/calendar.ics"
+                                    class="flex-grow px-2 py-1.5 border border-gray-300 rounded-lg text-xs focus:ring-primary-500 focus:border-primary-500">
+                                <button id="share-form-calendar-add-btn" type="button"
+                                    class="px-2.5 py-1.5 text-xs font-semibold text-primary-700 bg-primary-50 border border-primary-200 rounded-lg hover:bg-primary-100 transition">
+                                    Add
+                                </button>
+                            </div>
+                        </div>
                         <div class="flex gap-2">
                             <button id="create-share-link-btn"
                                 class="flex-1 bg-primary-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition">
@@ -358,8 +373,9 @@
             inviteCoParentToAthlete,
             createFamilyShareToken,
             listFamilyShareTokens,
-            revokeFamilyShareToken
-        } from './js/db.js?v=54';
+            revokeFamilyShareToken,
+            updateFamilyShareTokenCalendars
+        } from './js/db.js?v=55';
         import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence, getCalendarEventTrackingId, isTrackedCalendarEvent } from './js/utils.js?v=10';
         import {
             getIncentiveRules,
@@ -1119,6 +1135,8 @@
 
         // ── Family Share Links ─────────────────────────────────────────────────
         let familyShareChildren = [];
+        // In-progress calendar URLs for the creation form
+        const shareFormCalendarUrls = [];
 
         function getFamilyPageOrigin() {
             return window.location.origin;
@@ -1126,6 +1144,88 @@
 
         function buildFamilyShareUrl(tokenId) {
             return `${getFamilyPageOrigin()}/family.html?token=${tokenId}`;
+        }
+
+        function renderShareFormCalendarList() {
+            const listEl = document.getElementById('share-form-calendar-list');
+            if (!listEl) return;
+            if (!shareFormCalendarUrls.length) {
+                listEl.innerHTML = '';
+                return;
+            }
+            listEl.innerHTML = shareFormCalendarUrls.map((url, idx) => `
+                <div class="flex items-center gap-1 bg-gray-50 border border-gray-200 rounded px-2 py-1">
+                    <span class="flex-grow text-[11px] text-gray-700 truncate">${escapeHtml(url)}</span>
+                    <button type="button" onclick="removeShareFormCalendarUrl(${idx})"
+                        class="flex-shrink-0 text-gray-400 hover:text-red-600 transition text-sm leading-none">×</button>
+                </div>
+            `).join('');
+        }
+
+        window.removeShareFormCalendarUrl = function(idx) {
+            shareFormCalendarUrls.splice(idx, 1);
+            renderShareFormCalendarList();
+        };
+
+        function renderTokenCalendarList(tokenId, urls) {
+            const listEl = document.getElementById(`token-cal-list-${tokenId}`);
+            if (!listEl) return;
+            if (!urls || !urls.length) {
+                listEl.innerHTML = '<div class="text-[11px] text-gray-400">No extra calendars added.</div>';
+                return;
+            }
+            listEl.innerHTML = urls.map((url, idx) => `
+                <div class="flex items-center gap-1 bg-gray-50 border border-gray-200 rounded px-2 py-1">
+                    <span class="flex-grow text-[11px] text-gray-700 truncate">${escapeHtml(url)}</span>
+                    <button type="button" onclick="removeTokenCalendarUrl('${escapeAttr(tokenId)}', ${idx})"
+                        class="flex-shrink-0 text-gray-400 hover:text-red-600 transition text-sm leading-none">×</button>
+                </div>
+            `).join('');
+        }
+
+        window.removeTokenCalendarUrl = async function(tokenId, idx) {
+            const section = document.getElementById(`token-cal-section-${tokenId}`);
+            const currentUrls = Array.from(section?.querySelectorAll('[data-cal-url]') || [])
+                .map(el => el.getAttribute('data-cal-url'));
+            // Rebuild from DOM before mutation
+            const allUrls = getCurrentTokenCalendarUrls(tokenId);
+            allUrls.splice(idx, 1);
+            await saveTokenCalendarUrls(tokenId, allUrls);
+        };
+
+        window.addTokenCalendarUrl = async function(tokenId) {
+            const input = document.getElementById(`token-cal-input-${tokenId}`);
+            const url = input?.value?.trim();
+            if (!url) return;
+            if (!/^https?:\/\/.+/.test(url)) {
+                alert('Please enter a valid URL starting with http:// or https://');
+                return;
+            }
+            const allUrls = getCurrentTokenCalendarUrls(tokenId);
+            if (allUrls.includes(url)) { input.value = ''; return; }
+            allUrls.push(url);
+            input.value = '';
+            await saveTokenCalendarUrls(tokenId, allUrls);
+        };
+
+        function getCurrentTokenCalendarUrls(tokenId) {
+            const section = document.getElementById(`token-cal-section-${tokenId}`);
+            if (!section) return [];
+            return Array.from(section.querySelectorAll('[data-cal-url]'))
+                .map(el => el.getAttribute('data-cal-url'));
+        }
+
+        async function saveTokenCalendarUrls(tokenId, urls) {
+            const saveBtn = document.getElementById(`token-cal-save-${tokenId}`);
+            if (saveBtn) { saveBtn.disabled = true; saveBtn.textContent = 'Saving…'; }
+            try {
+                await updateFamilyShareTokenCalendars(tokenId, urls);
+                await loadShareLinks();
+            } catch (err) {
+                console.error('[parent-dashboard] Failed to update share link calendars:', err);
+                alert('Could not save: ' + (err?.message || 'Unknown error'));
+                if (saveBtn) { saveBtn.disabled = false; saveBtn.textContent = 'Save'; }
+            }
         }
 
         async function loadShareLinks() {
@@ -1142,28 +1242,67 @@
                     const url = buildFamilyShareUrl(token.id);
                     const createdAt = token.createdAt?.toDate ? token.createdAt.toDate() : new Date(token.createdAt);
                     const dateStr = createdAt.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+                    const extraUrls = Array.isArray(token.extraCalendarUrls) ? token.extraCalendarUrls : [];
+                    const calCount = extraUrls.length;
                     return `
-                        <div class="rounded-xl border border-gray-200 bg-gray-50 px-3 py-2">
-                            <div class="flex items-center justify-between gap-2">
-                                <div class="min-w-0 flex-grow">
-                                    <div class="font-semibold text-gray-900 text-sm truncate">${escapeHtml(token.label || 'Family Page Link')}</div>
-                                    <div class="text-[11px] text-gray-500 mt-0.5">Created ${dateStr}</div>
+                        <div class="rounded-xl border border-gray-200 bg-gray-50">
+                            <div class="px-3 py-2">
+                                <div class="flex items-center justify-between gap-2">
+                                    <div class="min-w-0 flex-grow">
+                                        <div class="font-semibold text-gray-900 text-sm truncate">${escapeHtml(token.label || 'Family Page Link')}</div>
+                                        <div class="text-[11px] text-gray-500 mt-0.5">Created ${dateStr}</div>
+                                    </div>
+                                    <button onclick="revokeShareLink('${escapeAttr(token.id)}')"
+                                        class="text-xs font-semibold text-red-600 hover:text-red-800 px-2 py-1 rounded border border-red-100 bg-white hover:bg-red-50 transition flex-shrink-0">
+                                        Revoke
+                                    </button>
                                 </div>
-                                <button onclick="revokeShareLink('${escapeAttr(token.id)}')"
-                                    class="text-xs font-semibold text-red-600 hover:text-red-800 px-2 py-1 rounded border border-red-100 bg-white hover:bg-red-50 transition flex-shrink-0">
-                                    Revoke
-                                </button>
+                                <div class="mt-2 flex items-center gap-1.5">
+                                    <input readonly value="${escapeHtml(url)}" class="flex-grow text-[11px] text-gray-600 bg-white border border-gray-200 rounded px-2 py-1 truncate">
+                                    <button onclick="copyShareLink('${escapeAttr(url)}', this)"
+                                        class="text-xs font-semibold text-primary-700 bg-primary-50 border border-primary-200 px-2 py-1 rounded hover:bg-primary-100 transition flex-shrink-0">
+                                        Copy
+                                    </button>
+                                    <a href="${escapeHtml(url)}" target="_blank" rel="noopener"
+                                        class="text-xs font-semibold text-gray-600 bg-white border border-gray-200 px-2 py-1 rounded hover:bg-gray-50 transition flex-shrink-0">
+                                        Open
+                                    </a>
+                                </div>
                             </div>
-                            <div class="mt-2 flex items-center gap-1.5">
-                                <input readonly value="${escapeHtml(url)}" class="flex-grow text-[11px] text-gray-600 bg-white border border-gray-200 rounded px-2 py-1 truncate">
-                                <button onclick="copyShareLink('${escapeAttr(url)}', this)"
-                                    class="text-xs font-semibold text-primary-700 bg-primary-50 border border-primary-200 px-2 py-1 rounded hover:bg-primary-100 transition flex-shrink-0">
-                                    Copy
+                            <!-- Extra calendars section -->
+                            <div class="border-t border-gray-100 px-3 py-2" id="token-cal-section-${escapeAttr(token.id)}">
+                                <button type="button" onclick="toggleTokenCalSection('${escapeAttr(token.id)}')"
+                                    class="flex items-center gap-1.5 text-[11px] font-semibold text-gray-600 hover:text-primary-700 transition w-full text-left">
+                                    <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                                    </svg>
+                                    Extra Calendars${calCount ? ` (${calCount})` : ''}
+                                    <svg id="token-cal-chevron-${escapeAttr(token.id)}" class="w-3 h-3 ml-auto transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                                    </svg>
                                 </button>
-                                <a href="${escapeHtml(url)}" target="_blank" rel="noopener"
-                                    class="text-xs font-semibold text-gray-600 bg-white border border-gray-200 px-2 py-1 rounded hover:bg-gray-50 transition flex-shrink-0">
-                                    Open
-                                </a>
+                                <div id="token-cal-body-${escapeAttr(token.id)}" class="hidden mt-2 space-y-1.5">
+                                    <div id="token-cal-list-${escapeAttr(token.id)}" class="space-y-1">
+                                        ${extraUrls.length
+                                            ? extraUrls.map((u, idx) => `
+                                                <div class="flex items-center gap-1 bg-white border border-gray-200 rounded px-2 py-1" data-cal-url="${escapeAttr(u)}">
+                                                    <span class="flex-grow text-[11px] text-gray-700 truncate">${escapeHtml(u)}</span>
+                                                    <button type="button" onclick="removeTokenCalendarUrl('${escapeAttr(token.id)}', ${idx})"
+                                                        class="flex-shrink-0 text-gray-400 hover:text-red-600 transition text-sm leading-none">×</button>
+                                                </div>`).join('')
+                                            : '<div class="text-[11px] text-gray-400">No extra calendars. Add .ics URLs below.</div>'
+                                        }
+                                    </div>
+                                    <div class="flex gap-1">
+                                        <input type="url" id="token-cal-input-${escapeAttr(token.id)}"
+                                            placeholder="https://…/calendar.ics"
+                                            class="flex-grow px-2 py-1 border border-gray-300 rounded text-[11px] focus:ring-primary-500 focus:border-primary-500">
+                                        <button type="button" onclick="addTokenCalendarUrl('${escapeAttr(token.id)}')"
+                                            class="px-2 py-1 text-[11px] font-semibold text-primary-700 bg-primary-50 border border-primary-200 rounded hover:bg-primary-100 transition flex-shrink-0">
+                                            Add
+                                        </button>
+                                    </div>
+                                </div>
                             </div>
                         </div>
                     `;
@@ -1173,6 +1312,14 @@
                 if (listEl) listEl.innerHTML = '<div class="text-xs text-red-500">Unable to load share links.</div>';
             }
         }
+
+        window.toggleTokenCalSection = function(tokenId) {
+            const body = document.getElementById(`token-cal-body-${tokenId}`);
+            const chevron = document.getElementById(`token-cal-chevron-${tokenId}`);
+            if (!body) return;
+            const isHidden = body.classList.toggle('hidden');
+            if (chevron) chevron.style.transform = isHidden ? '' : 'rotate(180deg)';
+        };
 
         window.copyShareLink = function(url, btn) {
             navigator.clipboard.writeText(url).then(() => {
@@ -1207,14 +1354,37 @@
             const createBtn = document.getElementById('create-share-link-btn');
             const form = document.getElementById('share-link-form');
             const statusEl = document.getElementById('share-link-create-status');
+            const calAddBtn = document.getElementById('share-form-calendar-add-btn');
+            const calInput = document.getElementById('share-form-calendar-input');
+
+            calAddBtn?.addEventListener('click', () => {
+                const url = calInput?.value?.trim();
+                if (!url) return;
+                if (!/^https?:\/\/.+/.test(url)) {
+                    alert('Please enter a valid URL starting with http:// or https://');
+                    return;
+                }
+                if (!shareFormCalendarUrls.includes(url)) {
+                    shareFormCalendarUrls.push(url);
+                    renderShareFormCalendarList();
+                }
+                calInput.value = '';
+                calInput.focus();
+            });
+
+            calInput?.addEventListener('keydown', (e) => {
+                if (e.key === 'Enter') { e.preventDefault(); calAddBtn?.click(); }
+            });
 
             newBtn?.addEventListener('click', () => {
                 form?.classList.toggle('hidden');
-                document.getElementById('share-link-label')?.focus();
+                if (!form?.classList.contains('hidden')) document.getElementById('share-link-label')?.focus();
             });
 
             cancelBtn?.addEventListener('click', () => {
                 form?.classList.add('hidden');
+                shareFormCalendarUrls.length = 0;
+                renderShareFormCalendarList();
                 if (statusEl) { statusEl.classList.add('hidden'); statusEl.textContent = ''; }
             });
 
@@ -1226,12 +1396,13 @@
                 createBtn.textContent = 'Creating...';
                 if (statusEl) { statusEl.classList.add('hidden'); statusEl.textContent = ''; }
                 try {
-                    const tokenId = await createFamilyShareToken(currentUserId, familyShareChildren, label);
+                    const tokenId = await createFamilyShareToken(currentUserId, familyShareChildren, label, [...shareFormCalendarUrls]);
                     const url = buildFamilyShareUrl(tokenId);
                     form?.classList.add('hidden');
                     document.getElementById('share-link-label').value = '';
+                    shareFormCalendarUrls.length = 0;
+                    renderShareFormCalendarList();
                     await loadShareLinks();
-                    // Auto-copy the new link
                     try { await navigator.clipboard.writeText(url); } catch (_) {}
                     if (statusEl) {
                         statusEl.className = 'text-xs rounded-lg px-3 py-2 bg-emerald-50 text-emerald-700 border border-emerald-200';

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -85,6 +85,42 @@
                     </div>
                 </div>
 
+                <!-- Share Family Page -->
+                <div class="bg-white rounded-2xl shadow-md border border-gray-200 overflow-hidden">
+                    <div class="p-4 border-b border-gray-100 bg-gray-50 flex items-center justify-between gap-3">
+                        <div>
+                            <h2 class="text-lg font-bold text-gray-900">Share Family Page</h2>
+                            <p class="text-xs text-gray-500 mt-0.5">Let grandparents or friends follow along — no login needed.</p>
+                        </div>
+                        <button id="new-share-link-btn"
+                            class="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-semibold text-primary-700 bg-primary-50 border border-primary-200 rounded-lg hover:bg-primary-100 transition">
+                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4"></path>
+                            </svg>
+                            New Link
+                        </button>
+                    </div>
+                    <div id="share-link-form" class="hidden px-4 pt-4 pb-2 border-b border-gray-100 space-y-2">
+                        <label class="block text-xs font-medium text-gray-700">Label (optional)</label>
+                        <input type="text" id="share-link-label" placeholder="e.g. Grandma's link" maxlength="60"
+                            class="w-full px-3 py-2 border border-gray-300 rounded-lg text-sm focus:ring-primary-500 focus:border-primary-500">
+                        <div class="flex gap-2">
+                            <button id="create-share-link-btn"
+                                class="flex-1 bg-primary-600 text-white py-2 rounded-lg text-sm font-medium hover:bg-primary-700 transition">
+                                Create Link
+                            </button>
+                            <button id="cancel-share-link-btn"
+                                class="px-3 py-2 rounded-lg text-sm font-medium bg-white text-gray-600 border border-gray-200 hover:bg-gray-50 transition">
+                                Cancel
+                            </button>
+                        </div>
+                        <div id="share-link-create-status" class="hidden text-xs rounded-lg px-3 py-2"></div>
+                    </div>
+                    <div id="share-links-list" class="p-4 space-y-2">
+                        <div class="text-xs text-gray-400">Loading...</div>
+                    </div>
+                </div>
+
                 <!-- Coach Invite Info -->
                 <div class="bg-blue-50 rounded-2xl p-6 border border-blue-100">
                     <h3 class="font-semibold text-blue-900 mb-2">Need to add another player?</h3>
@@ -319,8 +355,11 @@
             claimAssignmentSlot,
             releaseAssignmentClaim,
             getAssignmentClaims,
-            inviteCoParentToAthlete
-        } from './js/db.js?v=53';
+            inviteCoParentToAthlete,
+            createFamilyShareToken,
+            listFamilyShareTokens,
+            revokeFamilyShareToken
+        } from './js/db.js?v=54';
         import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence, getCalendarEventTrackingId, isTrackedCalendarEvent } from './js/utils.js?v=10';
         import {
             getIncentiveRules,
@@ -1078,6 +1117,142 @@
             return getScopedPracticePacketRowBase(row, selectedPlayerId);
         }
 
+        // ── Family Share Links ─────────────────────────────────────────────────
+        let familyShareChildren = [];
+
+        function getFamilyPageOrigin() {
+            return window.location.origin;
+        }
+
+        function buildFamilyShareUrl(tokenId) {
+            return `${getFamilyPageOrigin()}/family.html?token=${tokenId}`;
+        }
+
+        async function loadShareLinks() {
+            if (!currentUserId) return;
+            const listEl = document.getElementById('share-links-list');
+            if (!listEl) return;
+            try {
+                const tokens = await listFamilyShareTokens(currentUserId);
+                if (!tokens.length) {
+                    listEl.innerHTML = '<div class="text-xs text-gray-500">No share links yet. Create one to get started.</div>';
+                    return;
+                }
+                listEl.innerHTML = tokens.map(token => {
+                    const url = buildFamilyShareUrl(token.id);
+                    const createdAt = token.createdAt?.toDate ? token.createdAt.toDate() : new Date(token.createdAt);
+                    const dateStr = createdAt.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+                    return `
+                        <div class="rounded-xl border border-gray-200 bg-gray-50 px-3 py-2">
+                            <div class="flex items-center justify-between gap-2">
+                                <div class="min-w-0 flex-grow">
+                                    <div class="font-semibold text-gray-900 text-sm truncate">${escapeHtml(token.label || 'Family Page Link')}</div>
+                                    <div class="text-[11px] text-gray-500 mt-0.5">Created ${dateStr}</div>
+                                </div>
+                                <button onclick="revokeShareLink('${escapeAttr(token.id)}')"
+                                    class="text-xs font-semibold text-red-600 hover:text-red-800 px-2 py-1 rounded border border-red-100 bg-white hover:bg-red-50 transition flex-shrink-0">
+                                    Revoke
+                                </button>
+                            </div>
+                            <div class="mt-2 flex items-center gap-1.5">
+                                <input readonly value="${escapeHtml(url)}" class="flex-grow text-[11px] text-gray-600 bg-white border border-gray-200 rounded px-2 py-1 truncate">
+                                <button onclick="copyShareLink('${escapeAttr(url)}', this)"
+                                    class="text-xs font-semibold text-primary-700 bg-primary-50 border border-primary-200 px-2 py-1 rounded hover:bg-primary-100 transition flex-shrink-0">
+                                    Copy
+                                </button>
+                                <a href="${escapeHtml(url)}" target="_blank" rel="noopener"
+                                    class="text-xs font-semibold text-gray-600 bg-white border border-gray-200 px-2 py-1 rounded hover:bg-gray-50 transition flex-shrink-0">
+                                    Open
+                                </a>
+                            </div>
+                        </div>
+                    `;
+                }).join('');
+            } catch (err) {
+                console.warn('[parent-dashboard] Failed to load share links:', err);
+                if (listEl) listEl.innerHTML = '<div class="text-xs text-red-500">Unable to load share links.</div>';
+            }
+        }
+
+        window.copyShareLink = function(url, btn) {
+            navigator.clipboard.writeText(url).then(() => {
+                const orig = btn.textContent;
+                btn.textContent = 'Copied!';
+                btn.classList.add('text-green-700', 'bg-green-50', 'border-green-200');
+                btn.classList.remove('text-primary-700', 'bg-primary-50', 'border-primary-200');
+                setTimeout(() => {
+                    btn.textContent = orig;
+                    btn.classList.remove('text-green-700', 'bg-green-50', 'border-green-200');
+                    btn.classList.add('text-primary-700', 'bg-primary-50', 'border-primary-200');
+                }, 2000);
+            }).catch(() => {
+                alert('Copy failed. Please copy the link manually.');
+            });
+        };
+
+        window.revokeShareLink = async function(tokenId) {
+            if (!confirm('Revoke this share link? Anyone using it will lose access.')) return;
+            try {
+                await revokeFamilyShareToken(tokenId);
+                await loadShareLinks();
+            } catch (err) {
+                console.error('[parent-dashboard] Failed to revoke share link:', err);
+                alert('Could not revoke link: ' + (err?.message || 'Unknown error'));
+            }
+        };
+
+        function initShareLinkControls() {
+            const newBtn = document.getElementById('new-share-link-btn');
+            const cancelBtn = document.getElementById('cancel-share-link-btn');
+            const createBtn = document.getElementById('create-share-link-btn');
+            const form = document.getElementById('share-link-form');
+            const statusEl = document.getElementById('share-link-create-status');
+
+            newBtn?.addEventListener('click', () => {
+                form?.classList.toggle('hidden');
+                document.getElementById('share-link-label')?.focus();
+            });
+
+            cancelBtn?.addEventListener('click', () => {
+                form?.classList.add('hidden');
+                if (statusEl) { statusEl.classList.add('hidden'); statusEl.textContent = ''; }
+            });
+
+            createBtn?.addEventListener('click', async () => {
+                if (!currentUserId) return;
+                const label = document.getElementById('share-link-label')?.value?.trim() || '';
+                const origText = createBtn.textContent;
+                createBtn.disabled = true;
+                createBtn.textContent = 'Creating...';
+                if (statusEl) { statusEl.classList.add('hidden'); statusEl.textContent = ''; }
+                try {
+                    const tokenId = await createFamilyShareToken(currentUserId, familyShareChildren, label);
+                    const url = buildFamilyShareUrl(tokenId);
+                    form?.classList.add('hidden');
+                    document.getElementById('share-link-label').value = '';
+                    await loadShareLinks();
+                    // Auto-copy the new link
+                    try { await navigator.clipboard.writeText(url); } catch (_) {}
+                    if (statusEl) {
+                        statusEl.className = 'text-xs rounded-lg px-3 py-2 bg-emerald-50 text-emerald-700 border border-emerald-200';
+                        statusEl.textContent = 'Link created and copied to clipboard!';
+                        statusEl.classList.remove('hidden');
+                        setTimeout(() => statusEl.classList.add('hidden'), 4000);
+                    }
+                } catch (err) {
+                    console.error('[parent-dashboard] Failed to create share link:', err);
+                    if (statusEl) {
+                        statusEl.className = 'text-xs rounded-lg px-3 py-2 bg-red-50 text-red-700 border border-red-200';
+                        statusEl.textContent = err?.message || 'Failed to create link.';
+                        statusEl.classList.remove('hidden');
+                    }
+                } finally {
+                    createBtn.disabled = false;
+                    createBtn.textContent = origText;
+                }
+            });
+        }
+
         async function init() {
             try {
                 const user = await requireAuth();
@@ -1089,11 +1264,15 @@
                      renderHeader(document.getElementById('header-container'), updatedUser);
                 });
 
+                initShareLinkControls();
+
                 const [data] = await Promise.all([
                     getParentDashboardData(user.uid),
                     loadRequestAccessOptions(),
                     refreshParentMembershipRequestList(user.uid)
                 ]);
+                familyShareChildren = data.children || [];
+                await loadShareLinks();
                 await loadParentCertificateLinks(data.children);
                 renderPlayers(data.children);
                 teamChildrenByTeamId.clear();

--- a/test-family-sharing.html
+++ b/test-family-sharing.html
@@ -1,0 +1,736 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="robots" content="noindex,nofollow">
+    <title>Family Sharing Test Suite</title>
+    <style>
+        body { font-family: monospace; padding: 20px; background: #f5f5f5; }
+        .test-section { background: white; margin: 20px 0; padding: 20px; border-radius: 8px; }
+        .test-case { margin: 10px 0; padding: 10px; border-left: 4px solid #ccc; }
+        .pass { border-left-color: #22c55e; background: #f0fdf4; }
+        .fail { border-left-color: #ef4444; background: #fef2f2; }
+        .test-name { font-weight: bold; margin-bottom: 5px; }
+        .test-result { font-size: 0.9em; color: #666; }
+        h2 { color: #4338ca; }
+        .summary { background: #e0e7ff; padding: 15px; border-radius: 8px; margin-bottom: 20px; }
+        .summary h3 { margin-top: 0; color: #4338ca; }
+        pre { background: #f8f8f8; padding: 10px; overflow-x: auto; }
+    </style>
+    <script type="module" src="/js/telemetry.js?v=1"></script>
+</head>
+<body>
+    <h1>🧪 Family Sharing Test Suite</h1>
+    <p>Testing: token generation, share URL construction, calendar URL management, schedule filtering, ICS export, deduplication, conflict detection, token validation.</p>
+
+    <div id="test-summary" class="summary">
+        <h3>Test Summary</h3>
+        <p id="summary-text">Running tests...</p>
+    </div>
+
+    <div id="test-results"></div>
+
+    <script>
+        const results = [];
+        const sections = {};
+
+        function test(section, name, fn) {
+            if (!sections[section]) sections[section] = [];
+            try {
+                fn();
+                const r = { name, pass: true, error: null };
+                results.push(r);
+                sections[section].push(r);
+            } catch (e) {
+                const r = { name, pass: false, error: e.message };
+                results.push(r);
+                sections[section].push(r);
+            }
+        }
+
+        function assertEquals(actual, expected, message) {
+            if (actual !== expected) {
+                throw new Error(`${message}\n  Expected: ${JSON.stringify(expected)}\n  Actual:   ${JSON.stringify(actual)}`);
+            }
+        }
+
+        function assertDeepEquals(actual, expected, message) {
+            if (JSON.stringify(actual) !== JSON.stringify(expected)) {
+                throw new Error(`${message}\n  Expected: ${JSON.stringify(expected)}\n  Actual:   ${JSON.stringify(actual)}`);
+            }
+        }
+
+        function assertTrue(value, message) {
+            if (!value) throw new Error(message);
+        }
+
+        function assertFalse(value, message) {
+            if (value) throw new Error(message);
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Inline copies of pure logic under test (no Firebase dependency)
+        // ─────────────────────────────────────────────────────────────────────
+
+        // From js/db.js
+        function generateShareToken() {
+            const bytes = new Uint8Array(20);
+            crypto.getRandomValues(bytes);
+            return Array.from(bytes).map(b => b.toString(16).padStart(2, '0')).join('');
+        }
+
+        function normalizeShareTokenChildren(children) {
+            return (children || []).map(c => ({
+                teamId: c.teamId || '',
+                teamName: c.teamName || '',
+                playerId: c.playerId || '',
+                playerName: c.playerName || '',
+                playerPhotoUrl: c.playerPhotoUrl || null
+            }));
+        }
+
+        function normalizeExtraCalendarUrls(urls) {
+            return (urls || []).filter(u => typeof u === 'string' && u.trim());
+        }
+
+        // From parent-dashboard.html
+        function buildFamilyShareUrl(origin, tokenId) {
+            return `${origin}/family.html?token=${tokenId}`;
+        }
+
+        // Share-form calendar list management (mirrors shareFormCalendarUrls array operations)
+        function addCalendarUrlToList(list, url) {
+            const trimmed = url.trim();
+            if (!trimmed) return false;
+            if (!/^https?:\/\/.+/.test(trimmed)) return false;
+            if (list.includes(trimmed)) return false;
+            list.push(trimmed);
+            return true;
+        }
+
+        function removeCalendarUrlFromList(list, idx) {
+            if (idx < 0 || idx >= list.length) return false;
+            list.splice(idx, 1);
+            return true;
+        }
+
+        // From family.html — schedule filtering
+        function getFilteredScheduleEvents(events, scheduleViewFilter, selectedPlayerId = '') {
+            const now = new Date();
+            const cutoff = new Date(now.getTime() - 3 * 60 * 60 * 1000);
+            let evs = selectedPlayerId
+                ? events.filter(ev => ev.childId === selectedPlayerId)
+                : [...events];
+            if (scheduleViewFilter === 'upcoming-all') {
+                evs = evs.filter(ev => new Date(ev.date) >= cutoff);
+                evs.sort((a, b) => new Date(a.date) - new Date(b.date));
+            } else if (scheduleViewFilter === 'upcoming-games') {
+                evs = evs.filter(ev => ev.type === 'game' && new Date(ev.date) >= cutoff);
+                evs.sort((a, b) => new Date(a.date) - new Date(b.date));
+            } else if (scheduleViewFilter === 'upcoming-practices') {
+                evs = evs.filter(ev => ev.type === 'practice' && new Date(ev.date) >= cutoff);
+                evs.sort((a, b) => new Date(a.date) - new Date(b.date));
+            } else if (scheduleViewFilter === 'past-all') {
+                evs = evs.filter(ev => new Date(ev.date) < cutoff);
+                evs.sort((a, b) => new Date(b.date) - new Date(a.date));
+            }
+            return evs;
+        }
+
+        // From family.html — calendar grid deduplication
+        function getCalendarEntries(events) {
+            const byKey = new Map();
+            (events || []).forEach(event => {
+                const d = new Date(event.date);
+                if (!d || isNaN(d.getTime())) return;
+                const key = `${event.teamId || ''}::${event.id || ''}::${d.toISOString()}::${event.type || ''}`;
+                if (!byKey.has(key)) {
+                    byKey.set(key, { ...event, date: d, childNames: [], childIds: [] });
+                }
+                const item = byKey.get(key);
+                if (event.childName && !item.childNames.includes(event.childName)) item.childNames.push(event.childName);
+                if (event.childId && !item.childIds.includes(event.childId)) item.childIds.push(event.childId);
+            });
+            return Array.from(byKey.values()).map(item => ({
+                ...item,
+                childNames: [...new Set(item.childNames)],
+                childIds: [...new Set(item.childIds)]
+            }));
+        }
+
+        // From family.html — ICS export
+        function formatIcsDate(date) {
+            const pad = n => String(n).padStart(2, '0');
+            return `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}T${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}Z`;
+        }
+
+        function buildIcs(events) {
+            const lines = ['BEGIN:VCALENDAR', 'VERSION:2.0', 'PRODID:-//ALL PLAYS//EN'];
+            const escapeIcs = value => String(value || '').replace(/\\/g, '\\\\').replace(/;/g, '\\;').replace(/,/g, '\\,').replace(/\r?\n/g, '\\n');
+            const seen = new Set();
+            events.forEach(event => {
+                const eventKey = `${event.teamId}-${event.id}-${new Date(event.date).getTime()}`;
+                if (seen.has(eventKey)) return;
+                seen.add(eventKey);
+                const date = event.date instanceof Date ? event.date : new Date(event.date);
+                const start = formatIcsDate(date);
+                const end = formatIcsDate(new Date(date.getTime() + 60 * 60 * 1000));
+                const summary = event.type === 'practice' ? `${event.childName} - Practice` : `${event.childName} vs ${event.opponent || 'TBD'}`;
+                lines.push(
+                    'BEGIN:VEVENT',
+                    `UID:${event.id || eventKey}@allplays`,
+                    `DTSTAMP:${formatIcsDate(new Date())}`,
+                    `DTSTART:${start}`,
+                    `DTEND:${end}`,
+                    `SUMMARY:${escapeIcs(summary)}`,
+                    `LOCATION:${escapeIcs(event.location || 'TBD')}`,
+                    `DESCRIPTION:${escapeIcs(`For ${event.childName}`)}`,
+                    'END:VEVENT'
+                );
+            });
+            lines.push('END:VCALENDAR');
+            return lines.join('\r\n');
+        }
+
+        // From family.html — extra calendar conflict detection
+        function isExtraCalEventConflicting(eventDateMs, dbTimestamps) {
+            return dbTimestamps.some(ts => Math.abs(ts - eventDateMs) < 60000);
+        }
+
+        // Token validation logic from family.html init()
+        function isTokenValid(token) {
+            if (!token) return false;
+            if (token.active === false) return false;
+            return true;
+        }
+
+        // ─────────────────────────────────────────────────────────────────────
+        // SUITE 1: Token generation
+        // ─────────────────────────────────────────────────────────────────────
+
+        test('Token generation', 'generateShareToken returns a 40-char string', () => {
+            const token = generateShareToken();
+            assertEquals(token.length, 40, 'Token should be 40 hex characters (20 bytes)');
+        });
+
+        test('Token generation', 'generateShareToken returns only hex characters', () => {
+            const token = generateShareToken();
+            assertTrue(/^[0-9a-f]+$/.test(token), 'Token should only contain lowercase hex characters');
+        });
+
+        test('Token generation', 'generateShareToken produces unique values', () => {
+            const t1 = generateShareToken();
+            const t2 = generateShareToken();
+            assertTrue(t1 !== t2, 'Two tokens should not be identical');
+        });
+
+        test('Token generation', 'generateShareToken produces different values across 10 calls', () => {
+            const tokens = new Set(Array.from({ length: 10 }, () => generateShareToken()));
+            assertEquals(tokens.size, 10, 'All 10 tokens should be unique');
+        });
+
+        // ─────────────────────────────────────────────────────────────────────
+        // SUITE 2: Token data normalization
+        // ─────────────────────────────────────────────────────────────────────
+
+        test('Token data normalization', 'Children are normalized with all required fields', () => {
+            const normalized = normalizeShareTokenChildren([
+                { teamId: 't1', teamName: 'Eagles', playerId: 'p1', playerName: 'Alex', playerPhotoUrl: 'http://img.png' }
+            ]);
+            assertEquals(normalized.length, 1, 'Should have one child');
+            assertEquals(normalized[0].teamId, 't1', 'teamId should be preserved');
+            assertEquals(normalized[0].teamName, 'Eagles', 'teamName should be preserved');
+            assertEquals(normalized[0].playerId, 'p1', 'playerId should be preserved');
+            assertEquals(normalized[0].playerName, 'Alex', 'playerName should be preserved');
+            assertEquals(normalized[0].playerPhotoUrl, 'http://img.png', 'playerPhotoUrl should be preserved');
+        });
+
+        test('Token data normalization', 'Missing child fields default to empty string', () => {
+            const normalized = normalizeShareTokenChildren([{}]);
+            assertEquals(normalized[0].teamId, '', 'Missing teamId defaults to empty string');
+            assertEquals(normalized[0].teamName, '', 'Missing teamName defaults to empty string');
+            assertEquals(normalized[0].playerId, '', 'Missing playerId defaults to empty string');
+            assertEquals(normalized[0].playerName, '', 'Missing playerName defaults to empty string');
+        });
+
+        test('Token data normalization', 'Missing playerPhotoUrl defaults to null', () => {
+            const normalized = normalizeShareTokenChildren([{ teamId: 't1' }]);
+            assertEquals(normalized[0].playerPhotoUrl, null, 'Missing playerPhotoUrl should default to null');
+        });
+
+        test('Token data normalization', 'null children arg produces empty array', () => {
+            assertDeepEquals(normalizeShareTokenChildren(null), [], 'null children should produce []');
+        });
+
+        test('Token data normalization', 'Multiple children all normalized', () => {
+            const normalized = normalizeShareTokenChildren([
+                { teamId: 't1', playerId: 'p1', playerName: 'Alex' },
+                { teamId: 't2', playerId: 'p2', playerName: 'Jordan' }
+            ]);
+            assertEquals(normalized.length, 2, 'Both children should be in result');
+            assertEquals(normalized[1].playerName, 'Jordan', 'Second child name preserved');
+        });
+
+        test('Token data normalization', 'extraCalendarUrls filters out empty strings', () => {
+            const result = normalizeExtraCalendarUrls(['https://a.com/cal.ics', '', '  ', 'https://b.com/cal.ics']);
+            assertEquals(result.length, 2, 'Empty strings should be filtered out');
+            assertEquals(result[0], 'https://a.com/cal.ics', 'First valid URL preserved');
+            assertEquals(result[1], 'https://b.com/cal.ics', 'Second valid URL preserved');
+        });
+
+        test('Token data normalization', 'null extraCalendarUrls produces empty array', () => {
+            assertDeepEquals(normalizeExtraCalendarUrls(null), [], 'null should produce []');
+        });
+
+        test('Token data normalization', 'non-string values in extraCalendarUrls are filtered out', () => {
+            const result = normalizeExtraCalendarUrls([123, null, 'https://valid.com/cal.ics', undefined]);
+            assertEquals(result.length, 1, 'Only string URLs should survive');
+            assertEquals(result[0], 'https://valid.com/cal.ics', 'Valid URL preserved');
+        });
+
+        // ─────────────────────────────────────────────────────────────────────
+        // SUITE 3: Share URL construction
+        // ─────────────────────────────────────────────────────────────────────
+
+        test('Share URL construction', 'buildFamilyShareUrl produces correct URL', () => {
+            const url = buildFamilyShareUrl('https://allplays.app', 'abc123');
+            assertEquals(url, 'https://allplays.app/family.html?token=abc123', 'URL should include origin, path, and token param');
+        });
+
+        test('Share URL construction', 'token appears in URL query string', () => {
+            const token = generateShareToken();
+            const url = buildFamilyShareUrl('https://allplays.app', token);
+            const parsed = new URL(url);
+            assertEquals(parsed.searchParams.get('token'), token, 'Token should be recoverable from URL');
+        });
+
+        test('Share URL construction', 'path is always /family.html', () => {
+            const url = buildFamilyShareUrl('https://allplays.app', 'tok');
+            assertTrue(new URL(url).pathname === '/family.html', 'Pathname should be /family.html');
+        });
+
+        test('Share URL construction', 'different tokens produce different URLs', () => {
+            const url1 = buildFamilyShareUrl('https://allplays.app', 'token-aaa');
+            const url2 = buildFamilyShareUrl('https://allplays.app', 'token-bbb');
+            assertTrue(url1 !== url2, 'Different tokens produce different URLs');
+        });
+
+        // ─────────────────────────────────────────────────────────────────────
+        // SUITE 4: Calendar URL list management (share form)
+        // ─────────────────────────────────────────────────────────────────────
+
+        test('Calendar URL management', 'addCalendarUrlToList adds a valid URL', () => {
+            const list = [];
+            const added = addCalendarUrlToList(list, 'https://cal.example.com/feed.ics');
+            assertTrue(added, 'Should return true for valid URL');
+            assertEquals(list.length, 1, 'List should have one URL');
+            assertEquals(list[0], 'https://cal.example.com/feed.ics', 'URL should match');
+        });
+
+        test('Calendar URL management', 'addCalendarUrlToList rejects empty string', () => {
+            const list = [];
+            assertFalse(addCalendarUrlToList(list, ''), 'Empty string should be rejected');
+            assertEquals(list.length, 0, 'List should remain empty');
+        });
+
+        test('Calendar URL management', 'addCalendarUrlToList rejects whitespace-only string', () => {
+            const list = [];
+            assertFalse(addCalendarUrlToList(list, '   '), 'Whitespace should be rejected');
+        });
+
+        test('Calendar URL management', 'addCalendarUrlToList rejects non-http URL', () => {
+            const list = [];
+            assertFalse(addCalendarUrlToList(list, 'ftp://bad.com/feed.ics'), 'ftp:// should be rejected');
+            assertFalse(addCalendarUrlToList(list, 'just-a-string'), 'Plain string should be rejected');
+        });
+
+        test('Calendar URL management', 'addCalendarUrlToList rejects duplicate URL', () => {
+            const list = ['https://cal.example.com/feed.ics'];
+            const added = addCalendarUrlToList(list, 'https://cal.example.com/feed.ics');
+            assertFalse(added, 'Duplicate URL should be rejected');
+            assertEquals(list.length, 1, 'List should still have one URL');
+        });
+
+        test('Calendar URL management', 'addCalendarUrlToList trims whitespace from URL', () => {
+            const list = [];
+            addCalendarUrlToList(list, '  https://cal.example.com/feed.ics  ');
+            assertEquals(list[0], 'https://cal.example.com/feed.ics', 'URL should be trimmed');
+        });
+
+        test('Calendar URL management', 'addCalendarUrlToList accepts http:// URLs', () => {
+            const list = [];
+            assertTrue(addCalendarUrlToList(list, 'http://cal.example.com/feed.ics'), 'http:// should be accepted');
+        });
+
+        test('Calendar URL management', 'multiple URLs can be added', () => {
+            const list = [];
+            addCalendarUrlToList(list, 'https://a.com/cal.ics');
+            addCalendarUrlToList(list, 'https://b.com/cal.ics');
+            addCalendarUrlToList(list, 'https://c.com/cal.ics');
+            assertEquals(list.length, 3, 'All three URLs should be in list');
+        });
+
+        test('Calendar URL management', 'removeCalendarUrlFromList removes by index', () => {
+            const list = ['https://a.com', 'https://b.com', 'https://c.com'];
+            removeCalendarUrlFromList(list, 1);
+            assertEquals(list.length, 2, 'List should have two items after removal');
+            assertEquals(list[0], 'https://a.com', 'First item unchanged');
+            assertEquals(list[1], 'https://c.com', 'Second item is now what was third');
+        });
+
+        test('Calendar URL management', 'removeCalendarUrlFromList removes first item', () => {
+            const list = ['https://a.com', 'https://b.com'];
+            removeCalendarUrlFromList(list, 0);
+            assertEquals(list[0], 'https://b.com', 'First item should now be https://b.com');
+        });
+
+        test('Calendar URL management', 'removeCalendarUrlFromList removes last item', () => {
+            const list = ['https://a.com', 'https://b.com'];
+            removeCalendarUrlFromList(list, 1);
+            assertEquals(list.length, 1, 'List should have one item');
+        });
+
+        test('Calendar URL management', 'removeCalendarUrlFromList rejects out-of-bounds index', () => {
+            const list = ['https://a.com'];
+            assertFalse(removeCalendarUrlFromList(list, 5), 'Out-of-bounds index should be rejected');
+            assertEquals(list.length, 1, 'List should be unchanged');
+        });
+
+        test('Calendar URL management', 'removing all items leaves empty list', () => {
+            const list = ['https://a.com'];
+            removeCalendarUrlFromList(list, 0);
+            assertEquals(list.length, 0, 'List should be empty after removing sole item');
+        });
+
+        // ─────────────────────────────────────────────────────────────────────
+        // SUITE 5: Schedule filtering
+        // ─────────────────────────────────────────────────────────────────────
+
+        const HOUR = 60 * 60 * 1000;
+        const now = new Date();
+        const future1 = new Date(now.getTime() + 24 * HOUR);
+        const future2 = new Date(now.getTime() + 48 * HOUR);
+        const past1   = new Date(now.getTime() - 24 * HOUR);
+        const past2   = new Date(now.getTime() - 48 * HOUR);
+
+        const mockEvents = [
+            { id: 'g1', type: 'game',     date: future1, childId: 'p1', childName: 'Alex', teamId: 't1' },
+            { id: 'g2', type: 'game',     date: future2, childId: 'p2', childName: 'Jordan', teamId: 't1' },
+            { id: 'g3', type: 'practice', date: future1, childId: 'p1', childName: 'Alex', teamId: 't1' },
+            { id: 'g4', type: 'practice', date: past1,   childId: 'p1', childName: 'Alex', teamId: 't1' },
+            { id: 'g5', type: 'game',     date: past2,   childId: 'p2', childName: 'Jordan', teamId: 't1' },
+        ];
+
+        test('Schedule filtering', 'upcoming-all shows only future events', () => {
+            const result = getFilteredScheduleEvents(mockEvents, 'upcoming-all');
+            assertTrue(result.every(ev => new Date(ev.date) >= new Date(now.getTime() - 3 * HOUR)), 'All events should be upcoming');
+            assertEquals(result.length, 3, 'Should have 3 upcoming events (2 games + 1 practice)');
+        });
+
+        test('Schedule filtering', 'upcoming-all is sorted ascending by date', () => {
+            const result = getFilteredScheduleEvents(mockEvents, 'upcoming-all');
+            for (let i = 1; i < result.length; i++) {
+                assertTrue(new Date(result[i].date) >= new Date(result[i - 1].date), 'Events should be in ascending date order');
+            }
+        });
+
+        test('Schedule filtering', 'upcoming-games shows only future games', () => {
+            const result = getFilteredScheduleEvents(mockEvents, 'upcoming-games');
+            assertTrue(result.every(ev => ev.type === 'game'), 'All results should be games');
+            assertTrue(result.every(ev => new Date(ev.date) >= new Date(now.getTime() - 3 * HOUR)), 'All games should be upcoming');
+            assertEquals(result.length, 2, 'Should have 2 upcoming games');
+        });
+
+        test('Schedule filtering', 'upcoming-practices shows only future practices', () => {
+            const result = getFilteredScheduleEvents(mockEvents, 'upcoming-practices');
+            assertTrue(result.every(ev => ev.type === 'practice'), 'All results should be practices');
+            assertEquals(result.length, 1, 'Should have 1 upcoming practice');
+        });
+
+        test('Schedule filtering', 'past-all shows only past events', () => {
+            const result = getFilteredScheduleEvents(mockEvents, 'past-all');
+            assertTrue(result.every(ev => new Date(ev.date) < new Date(now.getTime() - 3 * HOUR)), 'All events should be in the past');
+            assertEquals(result.length, 2, 'Should have 2 past events');
+        });
+
+        test('Schedule filtering', 'past-all is sorted descending by date (most recent first)', () => {
+            const result = getFilteredScheduleEvents(mockEvents, 'past-all');
+            for (let i = 1; i < result.length; i++) {
+                assertTrue(new Date(result[i].date) <= new Date(result[i - 1].date), 'Past events should be in descending date order');
+            }
+        });
+
+        test('Schedule filtering', 'player filter narrows to specific child', () => {
+            const result = getFilteredScheduleEvents(mockEvents, 'upcoming-all', 'p1');
+            assertTrue(result.every(ev => ev.childId === 'p1'), 'All events should belong to player p1');
+        });
+
+        test('Schedule filtering', 'player filter returns empty when no match', () => {
+            const result = getFilteredScheduleEvents(mockEvents, 'upcoming-all', 'p99');
+            assertEquals(result.length, 0, 'No events for unknown player');
+        });
+
+        test('Schedule filtering', 'player filter combines with type filter', () => {
+            const result = getFilteredScheduleEvents(mockEvents, 'upcoming-games', 'p1');
+            assertTrue(result.every(ev => ev.childId === 'p1' && ev.type === 'game'), 'Should only have upcoming games for p1');
+        });
+
+        test('Schedule filtering', 'empty event list returns empty array', () => {
+            assertEquals(getFilteredScheduleEvents([], 'upcoming-all').length, 0, 'Empty input produces empty output');
+        });
+
+        // ─────────────────────────────────────────────────────────────────────
+        // SUITE 6: Calendar entry deduplication (getCalendarEntries)
+        // ─────────────────────────────────────────────────────────────────────
+
+        const GAME_DATE = new Date('2025-06-15T14:00:00Z');
+
+        test('Calendar deduplication', 'same game for two children merged into one entry', () => {
+            const events = [
+                { id: 'g1', type: 'game', date: GAME_DATE, teamId: 't1', childId: 'p1', childName: 'Alex', opponent: 'Tigers' },
+                { id: 'g1', type: 'game', date: GAME_DATE, teamId: 't1', childId: 'p2', childName: 'Jordan', opponent: 'Tigers' }
+            ];
+            const entries = getCalendarEntries(events);
+            assertEquals(entries.length, 1, 'Two children on same game should produce one entry');
+            assertEquals(entries[0].childNames.length, 2, 'Entry should list both child names');
+            assertTrue(entries[0].childNames.includes('Alex'), 'Alex should be in childNames');
+            assertTrue(entries[0].childNames.includes('Jordan'), 'Jordan should be in childNames');
+        });
+
+        test('Calendar deduplication', 'childIds are correctly merged', () => {
+            const events = [
+                { id: 'g1', type: 'game', date: GAME_DATE, teamId: 't1', childId: 'p1', childName: 'Alex' },
+                { id: 'g1', type: 'game', date: GAME_DATE, teamId: 't1', childId: 'p2', childName: 'Jordan' }
+            ];
+            const entries = getCalendarEntries(events);
+            assertTrue(entries[0].childIds.includes('p1'), 'p1 should be in childIds');
+            assertTrue(entries[0].childIds.includes('p2'), 'p2 should be in childIds');
+        });
+
+        test('Calendar deduplication', 'different games are not merged', () => {
+            const date2 = new Date('2025-06-16T14:00:00Z');
+            const events = [
+                { id: 'g1', type: 'game', date: GAME_DATE, teamId: 't1', childId: 'p1', childName: 'Alex' },
+                { id: 'g2', type: 'game', date: date2,     teamId: 't1', childId: 'p1', childName: 'Alex' }
+            ];
+            const entries = getCalendarEntries(events);
+            assertEquals(entries.length, 2, 'Different game IDs produce separate entries');
+        });
+
+        test('Calendar deduplication', 'same event for same child not duplicated', () => {
+            const events = [
+                { id: 'g1', type: 'game', date: GAME_DATE, teamId: 't1', childId: 'p1', childName: 'Alex' },
+                { id: 'g1', type: 'game', date: GAME_DATE, teamId: 't1', childId: 'p1', childName: 'Alex' }
+            ];
+            const entries = getCalendarEntries(events);
+            assertEquals(entries.length, 1, 'Same event for same child should not be duplicated');
+            assertEquals(entries[0].childNames.length, 1, 'childNames should not have duplicates');
+        });
+
+        test('Calendar deduplication', 'game and practice at same time are not merged', () => {
+            const events = [
+                { id: 'e1', type: 'game',     date: GAME_DATE, teamId: 't1', childId: 'p1', childName: 'Alex' },
+                { id: 'e1', type: 'practice', date: GAME_DATE, teamId: 't1', childId: 'p1', childName: 'Alex' }
+            ];
+            const entries = getCalendarEntries(events);
+            assertEquals(entries.length, 2, 'Different types with same ID should not merge');
+        });
+
+        test('Calendar deduplication', 'events on different teams are not merged', () => {
+            const events = [
+                { id: 'g1', type: 'game', date: GAME_DATE, teamId: 't1', childId: 'p1', childName: 'Alex' },
+                { id: 'g1', type: 'game', date: GAME_DATE, teamId: 't2', childId: 'p1', childName: 'Alex' }
+            ];
+            const entries = getCalendarEntries(events);
+            assertEquals(entries.length, 2, 'Same game ID on different teams should not merge');
+        });
+
+        test('Calendar deduplication', 'empty event list returns empty array', () => {
+            assertEquals(getCalendarEntries([]).length, 0, 'Empty input produces empty output');
+        });
+
+        // ─────────────────────────────────────────────────────────────────────
+        // SUITE 7: ICS export
+        // ─────────────────────────────────────────────────────────────────────
+
+        test('ICS export', 'output has valid VCALENDAR wrapper', () => {
+            const ics = buildIcs([]);
+            assertTrue(ics.includes('BEGIN:VCALENDAR'), 'Should start with BEGIN:VCALENDAR');
+            assertTrue(ics.includes('END:VCALENDAR'), 'Should end with END:VCALENDAR');
+            assertTrue(ics.includes('VERSION:2.0'), 'Should include VERSION:2.0');
+        });
+
+        test('ICS export', 'game event produces VEVENT block', () => {
+            const events = [{ id: 'g1', type: 'game', date: new Date('2025-06-15T14:00:00Z'), teamId: 't1', childId: 'p1', childName: 'Alex', opponent: 'Tigers', location: 'North Field' }];
+            const ics = buildIcs(events);
+            assertTrue(ics.includes('BEGIN:VEVENT'), 'Should contain VEVENT');
+            assertTrue(ics.includes('END:VEVENT'), 'Should close VEVENT');
+            assertTrue(ics.includes('Alex vs Tigers'), 'Summary should include child name and opponent');
+            assertTrue(ics.includes('North Field'), 'Location should be included');
+        });
+
+        test('ICS export', 'practice event uses correct summary format', () => {
+            const events = [{ id: 'p1', type: 'practice', date: new Date('2025-06-15T14:00:00Z'), teamId: 't1', childId: 'c1', childName: 'Alex', location: 'Gym' }];
+            const ics = buildIcs(events);
+            assertTrue(ics.includes('Alex - Practice'), 'Practice summary should say "<Name> - Practice"');
+        });
+
+        test('ICS export', 'UID includes event id', () => {
+            const events = [{ id: 'game-abc', type: 'game', date: new Date(), teamId: 't1', childId: 'p1', childName: 'Alex', opponent: 'Lions', location: 'Park' }];
+            const ics = buildIcs(events);
+            assertTrue(ics.includes('UID:game-abc@allplays'), 'UID should use event id');
+        });
+
+        test('ICS export', 'same event for two children deduplicated', () => {
+            const date = new Date('2025-06-15T14:00:00Z');
+            const events = [
+                { id: 'g1', type: 'game', date, teamId: 't1', childId: 'p1', childName: 'Alex', opponent: 'Tigers', location: 'Park' },
+                { id: 'g1', type: 'game', date, teamId: 't1', childId: 'p2', childName: 'Jordan', opponent: 'Tigers', location: 'Park' }
+            ];
+            const ics = buildIcs(events);
+            const veventCount = (ics.match(/BEGIN:VEVENT/g) || []).length;
+            assertEquals(veventCount, 1, 'Duplicate events should produce only one VEVENT');
+        });
+
+        test('ICS export', 'multiple distinct events produce multiple VEVENTs', () => {
+            const events = [
+                { id: 'g1', type: 'game',     date: new Date('2025-06-15T14:00:00Z'), teamId: 't1', childId: 'p1', childName: 'Alex', opponent: 'Tigers', location: 'A' },
+                { id: 'g2', type: 'practice', date: new Date('2025-06-16T14:00:00Z'), teamId: 't1', childId: 'p1', childName: 'Alex', opponent: '',        location: 'B' }
+            ];
+            const ics = buildIcs(events);
+            const veventCount = (ics.match(/BEGIN:VEVENT/g) || []).length;
+            assertEquals(veventCount, 2, 'Two distinct events should produce two VEVENTs');
+        });
+
+        test('ICS export', 'semicolons and commas in location are escaped', () => {
+            const events = [{ id: 'g1', type: 'game', date: new Date(), teamId: 't1', childId: 'p1', childName: 'Alex', opponent: 'Lions', location: 'Smith;Park, West' }];
+            const ics = buildIcs(events);
+            assertTrue(ics.includes('Smith\\;Park\\, West'), 'Semicolons and commas should be escaped');
+        });
+
+        test('ICS export', 'empty event list produces calendar wrapper only', () => {
+            const ics = buildIcs([]);
+            assertFalse(ics.includes('BEGIN:VEVENT'), 'No events should mean no VEVENT blocks');
+            assertTrue(ics.includes('END:VCALENDAR'), 'VCALENDAR should still be closed');
+        });
+
+        test('ICS export', 'DTSTART and DTEND are both present', () => {
+            const events = [{ id: 'g1', type: 'game', date: new Date('2025-06-15T14:00:00Z'), teamId: 't1', childId: 'p1', childName: 'Alex', opponent: 'Lions', location: 'Park' }];
+            const ics = buildIcs(events);
+            assertTrue(ics.includes('DTSTART:'), 'DTSTART should be present');
+            assertTrue(ics.includes('DTEND:'), 'DTEND should be present');
+        });
+
+        test('ICS export', 'DTEND is one hour after DTSTART', () => {
+            const date = new Date('2025-06-15T14:00:00Z');
+            const events = [{ id: 'g1', type: 'game', date, teamId: 't1', childId: 'p1', childName: 'Alex', opponent: 'Lions', location: 'Park' }];
+            const ics = buildIcs(events);
+            assertTrue(ics.includes('DTSTART:20250615T140000Z'), 'DTSTART should match game time');
+            assertTrue(ics.includes('DTEND:20250615T150000Z'), 'DTEND should be 1 hour later');
+        });
+
+        // ─────────────────────────────────────────────────────────────────────
+        // SUITE 8: Extra calendar conflict detection
+        // ─────────────────────────────────────────────────────────────────────
+
+        test('Extra calendar conflict detection', 'event within 1 minute of DB game is a conflict', () => {
+            const dbTime = new Date('2025-06-15T14:00:00Z').getTime();
+            const extraTime = new Date('2025-06-15T14:00:30Z').getTime(); // 30 seconds later
+            assertTrue(isExtraCalEventConflicting(extraTime, [dbTime]), 'Event 30s apart should conflict');
+        });
+
+        test('Extra calendar conflict detection', 'event exactly 1 minute apart is still a conflict', () => {
+            const dbTime = new Date('2025-06-15T14:00:00Z').getTime();
+            const extraTime = dbTime + 59999; // just under 1 minute
+            assertTrue(isExtraCalEventConflicting(extraTime, [dbTime]), 'Event < 1 min apart should conflict');
+        });
+
+        test('Extra calendar conflict detection', 'event more than 1 minute apart is not a conflict', () => {
+            const dbTime = new Date('2025-06-15T14:00:00Z').getTime();
+            const extraTime = dbTime + 61000; // 61 seconds later
+            assertFalse(isExtraCalEventConflicting(extraTime, [dbTime]), 'Event 61s apart should not conflict');
+        });
+
+        test('Extra calendar conflict detection', 'event before DB game within 1 minute is a conflict', () => {
+            const dbTime = new Date('2025-06-15T14:00:00Z').getTime();
+            const extraTime = dbTime - 30000; // 30 seconds before
+            assertTrue(isExtraCalEventConflicting(extraTime, [dbTime]), 'Event 30s before should conflict');
+        });
+
+        test('Extra calendar conflict detection', 'no conflict when DB timestamp list is empty', () => {
+            const extraTime = new Date('2025-06-15T14:00:00Z').getTime();
+            assertFalse(isExtraCalEventConflicting(extraTime, []), 'No DB timestamps means no conflict');
+        });
+
+        test('Extra calendar conflict detection', 'conflict detected against any DB timestamp in list', () => {
+            const dbTimes = [
+                new Date('2025-06-15T10:00:00Z').getTime(),
+                new Date('2025-06-15T14:00:00Z').getTime(),
+                new Date('2025-06-15T18:00:00Z').getTime()
+            ];
+            const extraTime = new Date('2025-06-15T14:00:20Z').getTime();
+            assertTrue(isExtraCalEventConflicting(extraTime, dbTimes), 'Should find conflict against second timestamp');
+        });
+
+        test('Extra calendar conflict detection', 'event on different day never conflicts', () => {
+            const dbTime = new Date('2025-06-15T14:00:00Z').getTime();
+            const extraTime = new Date('2025-06-16T14:00:00Z').getTime();
+            assertFalse(isExtraCalEventConflicting(extraTime, [dbTime]), 'Different day should not conflict');
+        });
+
+        // ─────────────────────────────────────────────────────────────────────
+        // SUITE 9: Token validation
+        // ─────────────────────────────────────────────────────────────────────
+
+        test('Token validation', 'null token is invalid', () => {
+            assertFalse(isTokenValid(null), 'null token should be invalid');
+        });
+
+        test('Token validation', 'undefined token is invalid', () => {
+            assertFalse(isTokenValid(undefined), 'undefined token should be invalid');
+        });
+
+        test('Token validation', 'token with active=false is invalid', () => {
+            assertFalse(isTokenValid({ id: 'tok1', active: false, ownerUserId: 'u1' }), 'Revoked token should be invalid');
+        });
+
+        test('Token validation', 'token with active=true is valid', () => {
+            assertTrue(isTokenValid({ id: 'tok1', active: true, ownerUserId: 'u1' }), 'Active token should be valid');
+        });
+
+        test('Token validation', 'token without active field is valid (legacy/new)', () => {
+            assertTrue(isTokenValid({ id: 'tok1', ownerUserId: 'u1' }), 'Token without explicit active field should be valid (not false)');
+        });
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Render results
+        // ─────────────────────────────────────────────────────────────────────
+
+        const passCount = results.filter(r => r.pass).length;
+        const failCount = results.filter(r => !r.pass).length;
+
+        document.getElementById('summary-text').innerHTML =
+            `✅ Passed: <strong>${passCount}</strong> &nbsp;|&nbsp; ❌ Failed: <strong>${failCount}</strong> &nbsp;|&nbsp; Total: <strong>${results.length}</strong>`;
+
+        const container = document.getElementById('test-results');
+        let html = '';
+        Object.entries(sections).forEach(([section, tests]) => {
+            const sPass = tests.filter(r => r.pass).length;
+            const sFail = tests.filter(r => !r.pass).length;
+            html += `<div class="test-section">
+                <h2>${section} &nbsp;<span style="font-size:0.8em;font-weight:normal;color:#666">(${sPass}/${tests.length})</span></h2>`;
+            tests.forEach(result => {
+                const cls = result.pass ? 'pass' : 'fail';
+                const icon = result.pass ? '✅' : '❌';
+                html += `<div class="test-case ${cls}">
+                    <div class="test-name">${icon} ${result.name}</div>
+                    ${result.error ? `<div class="test-result"><pre>${result.error}</pre></div>` : ''}
+                </div>`;
+            });
+            html += '</div>';
+        });
+        container.innerHTML = html;
+    </script>
+</body>
+</html>


### PR DESCRIPTION
- New family.html: public read-only page showing schedule, players, and teams
  with list/calendar views, filters, day modal drill-in, and .ics export.
  Links to existing game.html, player.html, and team.html pages.
  No login required — loaded via a bearer token URL param.

- New /familyShareTokens Firestore collection with full CRUD helpers in db.js:
  createFamilyShareToken, getFamilyShareToken, listFamilyShareTokens,
  revokeFamilyShareToken. Token is a 40-char crypto-random hex string.

- Firestore rules: familyShareTokens — active tokens readable publicly
  (by ID only), owner can list/create/update/delete their own tokens.

- Parent dashboard: new "Share Family Page" card with create-link form
  (optional label), copyable URL, Open button, and Revoke per link.
  Link is auto-copied to clipboard on creation.

https://claude.ai/code/session_01RatbJjuQzYdA3T1Jc7PauL