### PR TITLE
Align team chat mention help

### DIFF
--- a/help-watch-chat.html
+++ b/help-watch-chat.html
@@ -33,11 +33,11 @@
       </article>
 
       <article class="bg-white rounded-xl border border-slate-200 p-5">
-        <h2 class="text-xl font-bold">Tagging and Mentions</h2>
+        <h2 class="text-xl font-bold">Assistant Mentions and Recipients</h2>
         <ul class="mt-3 list-disc list-inside text-sm text-slate-700 space-y-1">
-          <li><strong>Parent/Coach/Admin:</strong> Mention/tag in chat when recipient attention is required.</li>
-          <li><strong>Coach/Admin:</strong> Use targeted mentions for assignments and game-day actions.</li>
-          <li><strong>Parent:</strong> Use mentions for availability and coordination updates.</li>
+          <li><strong>Parent/Coach/Admin:</strong> Type <code>@</code> to mention <strong>@ALL PLAYS</strong> when asking the assistant for help in chat.</li>
+          <li><strong>Coach/Admin:</strong> Use the recipient picker, not @ mentions, to limit operational updates to staff or selected members.</li>
+          <li><strong>Parent:</strong> Use the recipient picker for targeted availability and coordination updates when available.</li>
         </ul>
       </article>
     </section>

--- a/js/help-center.js
+++ b/js/help-center.js
@@ -372,30 +372,30 @@ const HELP_GUIDES = [
     },
     {
         id: 'team-chat-tagging',
-        title: 'Tag people in chat',
+        title: 'Use chat recipients and @ALL PLAYS',
         category: 'watch-chat',
         roles: ['parent', 'coach', 'administrator'],
-        tags: ['tag', 'mention', 'chat', 'notifications', '@'],
-        summary: 'Mention the right people in chat without over-notifying the entire team.',
+        tags: ['recipient', 'mention', 'chat', 'notifications', '@ALL PLAYS'],
+        summary: 'Use the recipient picker for targeted chat delivery and @ALL PLAYS only for assistant help.',
         prerequisites: [
             'Team chat is enabled and you can send messages.',
-            'You know who should be notified for the message context.'
+            'You know who should receive the message or whether you need assistant help.'
         ],
         steps: [
             'Open `team-chat.html#teamId={teamId}`.',
-            'Start typing your message and include a mention format supported by chat UI.',
-            'Tag only the people or groups that need action.',
-            'Send the message and confirm mention formatting renders correctly.',
-            'Watch for replies/acknowledgments from tagged recipients.',
+            'Use the recipient picker to choose Full team, Staff only, or Selected members before sending targeted operational messages.',
+            'Type `@` and select `@ALL PLAYS` only when you want the assistant to answer a question in chat.',
+            'Send the message and confirm the selected recipient audience or @ALL PLAYS assistant mention renders correctly.',
+            'Watch for replies/acknowledgments from the selected recipients.',
             'If message is urgent, follow up with a clear action + deadline in same thread.'
         ],
         commonErrors: [
-            'Tag does not link/notify: check exact mention formatting expected by current chat implementation.',
-            'Too many people notified: narrow tags to responsible individuals.',
-            'No response from tagged users: verify they have notification permissions enabled.'
+            '@Name does not link/notify: person and group @ mentions are not supported in team chat; use the recipient picker instead.',
+            'Too many people notified: narrow the recipient picker to staff or selected members.',
+            'No response from selected recipients: verify they have notification permissions enabled.'
         ],
         edgeCases: [
-            'In mixed parent/coach chats, avoid tagging minors directly where policy requires parent-only comms.',
+            'In mixed parent/coach chats, avoid targeting minors directly where policy requires parent-only comms.',
             'For repeated announcements, use one canonical message and reference it instead of retagging everyone.'
         ],
         relatedGuideIds: ['team-chat-basics', 'plan-game'],

--- a/tests/unit/help-center.test.js
+++ b/tests/unit/help-center.test.js
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
 import {
     normalizeHelpRole,
     getHelpGuidesForRole,
@@ -8,6 +9,10 @@ import {
     resolveGuideLinks,
     getHelpCategoriesForRole
 } from '../../js/help-center.js';
+
+function readRepoFile(relativePath) {
+    return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
 
 describe('help center deep workflow coverage', () => {
     it('normalizes role aliases and defaults unknown to member', () => {
@@ -60,5 +65,24 @@ describe('help center deep workflow coverage', () => {
         const parentCategories = getHelpCategoriesForRole('parent').map((category) => category.id);
         expect(parentCategories.includes('team-setup')).toBe(false);
         expect(parentCategories.includes('watch-chat')).toBe(true);
+    });
+
+    it('keeps team chat mention help aligned with supported assistant mentions', () => {
+        const guide = getGuideById('coach', 'team-chat-tagging');
+        const helpPage = readRepoFile('help-watch-chat.html');
+        const guideText = [
+            guide.title,
+            guide.summary,
+            ...guide.steps,
+            ...guide.commonErrors
+        ].join(' ');
+
+        expect(guideText).toContain('@ALL PLAYS');
+        expect(guideText).toContain('recipient picker');
+        expect(guideText).toContain('person and group @ mentions are not supported');
+        expect(guideText).not.toMatch(/Tag people in chat|Tag only the people|targeted mentions/i);
+        expect(helpPage).toContain('@ALL PLAYS');
+        expect(helpPage).toContain('Use the recipient picker, not @ mentions');
+        expect(helpPage).not.toContain('Use targeted mentions');
     });
 });


### PR DESCRIPTION
Closes #1182

## Summary
- Updated Watch and Chat help copy to describe the supported @ALL PLAYS assistant mention.
- Redirected targeted chat guidance to the existing recipient picker instead of unsupported person/group @ mentions.
- Added unit coverage to keep help-center guidance and the static help page aligned with supported chat behavior.

## Tests
- `npx vitest run tests/unit/help-center.test.js --reporter=dot`