### PR TITLE
Fix post-game stat editor save state

### DIFF
--- a/game.html
+++ b/game.html
@@ -1078,6 +1078,7 @@ Write the match report now:`;
             game,
             players,
             statsMap,
+            tableStatsMap = statsMap,
             didNotPlayMap,
             timeMap,
             resolvedConfig,
@@ -1193,8 +1194,8 @@ Write the match report now:`;
                         statTrackerConfig: resolvedConfig
                     });
                     const { publicStats } = splitPlayerStatsByVisibility(resolvedConfig || {}, payload.stats || {});
-                    statsMap[player.id] = publicStats;
-                    editorStatsMap[player.id] = { ...(payload.stats || {}) };
+                    tableStatsMap[player.id] = publicStats;
+                    statsMap[player.id] = { ...(payload.stats || {}) };
                     didNotPlayMap[player.id] = payload.didNotPlay === true;
                     pendingDidNotPlayMap[player.id] = payload.didNotPlay === true;
                     timeMap[player.id] = payload.timeMs || 0;
@@ -1575,6 +1576,7 @@ Write the match report now:`;
                     game,
                     players,
                     statsMap: editorStatsMap,
+                    tableStatsMap: statsMap,
                     didNotPlayMap,
                     timeMap,
                     resolvedConfig,

--- a/tests/unit/post-game-stat-editor.test.js
+++ b/tests/unit/post-game-stat-editor.test.js
@@ -155,4 +155,17 @@ describe('post-game stat editor helpers', () => {
         expect(pageSource).toContain('setCompletedGameTeamStats');
         expect(pageSource).toContain('getTeamStatsForGame');
     });
+
+    it('keeps completed-game player save updates scoped to injected stat maps', () => {
+        const pageSource = readFileSync(new URL('../../game.html', import.meta.url), 'utf8');
+        const setupStart = pageSource.indexOf('function setupPostGameStatEditor({');
+        const setupEnd = pageSource.indexOf('function setupStatSheetControls', setupStart);
+        const setupSource = pageSource.slice(setupStart, setupEnd);
+
+        expect(setupSource).toContain('tableStatsMap = statsMap');
+        expect(setupSource).toContain('tableStatsMap[player.id] = publicStats;');
+        expect(setupSource).toContain('statsMap[player.id] = { ...(payload.stats || {}) };');
+        expect(setupSource).not.toContain('editorStatsMap[player.id]');
+        expect(pageSource).toContain('tableStatsMap: statsMap');
+    });
 });


### PR DESCRIPTION
Closes #1184

## Summary
- Removed the out-of-scope `editorStatsMap` reference from the completed-game player stat save path.
- Added an injected public table stats map so saves refresh the visible table while keeping editor stats current.
- Added unit coverage to guard the page wiring and scoped save updates.

## Validation
- `npx vitest run tests/unit/post-game-stat-editor.test.js`