### PR TITLE
Simplify first team creation

### DIFF
--- a/edit-team.html
+++ b/edit-team.html
@@ -107,6 +107,33 @@
                     </p>
                 </div>
 
+                <div>
+                    <label class="block text-sm font-medium text-gray-700">ZIP Code</label>
+                    <input type="text" id="zip" inputmode="numeric" maxlength="10"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2"
+                        placeholder="e.g., 66209" title="Enter 5 digits or ZIP+4">
+                    <p class="text-xs text-gray-500 mt-1">Used to group teams by location (city, state).</p>
+                </div>
+
+                <div class="flex items-start">
+                    <div class="flex items-center h-5">
+                        <input id="isPublic" type="checkbox"
+                            class="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded" checked>
+                    </div>
+                    <div class="ml-3 text-sm">
+                        <label for="isPublic" class="font-medium text-gray-700">Public Team</label>
+                        <p class="text-gray-500">If unchecked, this team will be hidden from the "Browse Teams" list but
+                            can still be accessed via direct link.</p>
+                    </div>
+                </div>
+
+                <details id="advanced-team-setup" class="rounded-lg border border-slate-200 bg-slate-50 p-4">
+                    <summary class="cursor-pointer select-none text-sm font-semibold text-slate-900 hover:text-indigo-700">
+                        Advanced team setup
+                        <span class="ml-2 font-normal text-slate-500">Colors, standings, streaming, access, registration, photo, and default assignments</span>
+                    </summary>
+                    <div class="mt-4 space-y-6">
+
                 <div class="rounded-lg border border-gray-200 bg-gray-50 p-4">
                     <div class="mb-3">
                         <h3 class="text-sm font-semibold text-gray-900">Team Colors</h3>
@@ -124,14 +151,6 @@
                                 class="mt-1 h-10 w-full cursor-pointer rounded-md border border-gray-300 bg-white p-1">
                         </label>
                     </div>
-                </div>
-
-                <div>
-                    <label class="block text-sm font-medium text-gray-700">ZIP Code</label>
-                    <input type="text" id="zip" inputmode="numeric" maxlength="10"
-                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2"
-                        placeholder="e.g., 66209" title="Enter 5 digits or ZIP+4">
-                    <p class="text-xs text-gray-500 mt-1">Used to group teams by location (city, state).</p>
                 </div>
 
                 <div>
@@ -271,18 +290,6 @@
                             <label for="teamPassRecordedReplayPaywallEnabled" class="font-medium text-amber-900">Require Team Pass for Archived Replays</label>
                             <p class="text-amber-700">When enabled, completed game replay videos are locked unless this team has an active Team Pass for the season.</p>
                         </div>
-                    </div>
-                </div>
-
-                <div class="flex items-start">
-                    <div class="flex items-center h-5">
-                        <input id="isPublic" type="checkbox"
-                            class="focus:ring-indigo-500 h-4 w-4 text-indigo-600 border-gray-300 rounded" checked>
-                    </div>
-                    <div class="ml-3 text-sm">
-                        <label for="isPublic" class="font-medium text-gray-700">Public Team</label>
-                        <p class="text-gray-500">If unchecked, this team will be hidden from the "Browse Teams" list but
-                            can still be accessed via direct link.</p>
                     </div>
                 </div>
 
@@ -523,6 +530,9 @@
                     <button type="button" id="add-default-assignment-btn" class="text-sm text-indigo-600 hover:text-indigo-800 font-medium">+ Add Role</button>
                 </div>
 
+                    </div>
+                </details>
+
                 <div class="flex justify-end space-x-4 pt-4 border-t">
                     <a href="dashboard.html"
                         class="px-4 py-2 border border-gray-300 rounded-md text-sm font-medium text-gray-700 hover:bg-gray-50">Cancel</a>
@@ -557,6 +567,14 @@
         let currentUserProfile = null;
         let adminEmails = [];
         let streamVolunteerEmails = [];
+
+        function syncAdvancedTeamSetupDisclosure() {
+            const advancedSetup = document.getElementById('advanced-team-setup');
+            if (advancedSetup) {
+                advancedSetup.open = !!initialTeamId;
+            }
+        }
+        syncAdvancedTeamSetupDisclosure();
         let pendingAdminInviteEmails = [];
         let confirmedTeamMembers = [];
         let teamPermissions = normalizeTeamPermissions();

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -190,6 +190,7 @@ function createEnvironment(initialState, overrides = {}) {
         'registration-empty-state',
         'registration-import-help',
         'team-form',
+        'advanced-team-setup',
         'name',
         'description',
         'sport',
@@ -278,6 +279,13 @@ function createEnvironment(initialState, overrides = {}) {
     elements.get('access-rollover-panel').classList.add('hidden');
     elements.get('rollover-staff-review').classList.add('hidden');
     elements.get('save-btn').textContent = 'Save Team';
+    elements.get('advanced-team-setup').open = false;
+    elements.get('teamColorPrimary').value = '#5ec9c5';
+    elements.get('teamColorSecondary').value = '#d32f3a';
+    elements.get('standingsPointWin').value = '3';
+    elements.get('standingsPointTie').value = '1';
+    elements.get('standingsPointLoss').value = '0';
+    elements.get('isPublic').checked = true;
     elements.get('streamAccessMode').value = 'admins';
     elements.get('photo-upload').files = [];
 
@@ -519,6 +527,119 @@ async function bootEditTeam(initialState, overrides = {}) {
 }
 
 describe('edit team admin access persistence', () => {
+    it('defers advanced setup controls behind a collapsed create-mode disclosure', async () => {
+        const html = readFileSync(new URL('../../edit-team.html', import.meta.url), 'utf8');
+        const advancedIndex = html.indexOf('id="advanced-team-setup"');
+        expect(advancedIndex).toBeGreaterThan(-1);
+        expect(html.indexOf('id="zip"')).toBeLessThan(advancedIndex);
+        expect(html.indexOf('id="isPublic"')).toBeLessThan(advancedIndex);
+        expect(html.indexOf('id="teamColorPrimary"')).toBeGreaterThan(advancedIndex);
+        expect(html.indexOf('id="registrationProviderName"')).toBeGreaterThan(advancedIndex);
+
+        const createEnv = await bootEditTeam({
+            currentUser: { uid: 'owner-1', email: 'owner@example.com' },
+            createCalls: [],
+            updateCalls: []
+        }, { href: 'http://example.com/edit-team.html' });
+        try {
+            expect(createEnv.elements.get('advanced-team-setup').open).toBe(false);
+        } finally {
+            createEnv.cleanup();
+        }
+    });
+
+    it('saves the simple create path with safe advanced defaults', async () => {
+        const initialState = {
+            currentUser: { uid: 'owner-1', email: 'owner@example.com' },
+            createCalls: [],
+            updateCalls: []
+        };
+
+        const env = await bootEditTeam(initialState, { href: 'http://example.com/edit-team.html' });
+        try {
+            env.elements.get('name').value = 'Spring Sharks';
+            env.elements.get('description').value = 'First season';
+            env.elements.get('sport').value = 'Basketball';
+            env.elements.get('zip').value = '66209';
+            expect(env.elements.get('advanced-team-setup').open).toBe(false);
+
+            await env.elements.get('team-form').requestSubmit();
+
+            expect(env.state.createCalls).toHaveLength(1);
+            expect(env.state.createCalls[0].teamData).toMatchObject({
+                name: 'Spring Sharks',
+                description: 'First season',
+                sport: 'Basketball',
+                zip: '66209',
+                isPublic: true,
+                colors: { primary: '#5ec9c5', secondary: '#d32f3a' },
+                standingsConfig: {
+                    enabled: false,
+                    rankingMode: 'points',
+                    points: { win: 3, tie: 1, loss: 0 },
+                    maxGoalDiff: null
+                },
+                teamPassConfig: { recordedReplayPaywallEnabled: false },
+                teamPermissions: {
+                    scorekeeping: { mode: 'all_confirmed', memberIds: [] },
+                    streaming: { mode: 'all_confirmed', memberIds: [] },
+                    videography: { mode: 'selected', memberIds: [] }
+                },
+                streamAccessMode: 'admins',
+                streamVolunteerEmails: [],
+                defaultAssignments: [],
+                twitchChannel: null,
+                streamEmbedUrl: null,
+                youtubeEmbedUrl: null,
+                ownerId: 'owner-1',
+                ownerEmail: 'owner@example.com'
+            });
+            expect(env.state.createCalls[0].teamData.registrationSource).toBeNull();
+        } finally {
+            env.cleanup();
+        }
+    });
+
+    it('keeps advanced setup open when editing an existing team', async () => {
+        const initialState = {
+            currentUser: { uid: 'owner-1', email: 'owner@example.com' },
+            team: {
+                id: 'team-1',
+                ownerId: 'owner-1',
+                name: 'Sharks',
+                description: 'Travel team',
+                sport: 'Soccer',
+                notificationEmail: 'notify@example.com',
+                leagueUrl: 'https://example.com/league',
+                standingsConfig: {
+                    enabled: true,
+                    rankingMode: 'points',
+                    points: { win: 5, tie: 2, loss: 1 },
+                    maxGoalDiff: 3,
+                    twoTeamTiebreakers: ['wins'],
+                    multiTeamTiebreakers: ['goals_for']
+                },
+                colors: { primary: '#111111', secondary: '#eeeeee' },
+                zip: '66209',
+                isPublic: true,
+                adminEmails: []
+            },
+            updateCalls: []
+        };
+
+        const env = await bootEditTeam(initialState);
+        try {
+            expect(env.elements.get('advanced-team-setup').open).toBe(true);
+            expect(env.elements.get('teamColorPrimary').value).toBe('#111111');
+            expect(env.elements.get('notificationEmail').value).toBe('notify@example.com');
+            expect(env.elements.get('leagueUrl').value).toBe('https://example.com/league');
+            expect(env.elements.get('standingsEnabled').checked).toBe(true);
+            expect(env.elements.get('standingsPointWin').value).toBe('5');
+        } finally {
+            env.cleanup();
+        }
+    });
+
     it('persists a normalized admin list after removing an admin and blocks the removed admin on the next load', async () => {
         const initialState = {
             currentUser: { uid: 'owner-1', email: 'owner@example.com' },


### PR DESCRIPTION
Closes #1186

## Summary
- Moves ZIP and public team onto the simple create path before advanced setup.
- Defers colors, standings, streaming, access, registration, photo, and default assignments behind a collapsed Advanced team setup disclosure for new teams.
- Keeps the advanced setup open and populated for existing team edits.

## Tests
- `npx vitest run tests/unit/edit-team-admin-access-persistence.test.js`