### PR TITLE
Preserve resumed live tracker game logs

### DIFF
--- a/docs/pr-notes/runs/1189-remediator-20260522T170806Z/architecture.md
+++ b/docs/pr-notes/runs/1189-remediator-20260522T170806Z/architecture.md
@@ -1,0 +1,10 @@
+# Architecture
+
+- Keep the filter localized in `js/live-tracker-resume.js`, where state.log is reconstructed from liveEvents.
+- Do not change live event broadcasting or aggregate stat reconstruction, since reversal events may still be needed to preserve effective totals when aggregate docs are absent.
+- Use both negative value and explicit description prefix to avoid excluding legitimate future stat events accidentally.
+
+## Risks And Rollback
+
+- Risk: filtering only by description could hide valid events; mitigated by also requiring negative value.
+- Rollback: remove the local `isReversalStatBroadcast` guard.

--- a/docs/pr-notes/runs/1189-remediator-20260522T170806Z/code-plan.md
+++ b/docs/pr-notes/runs/1189-remediator-20260522T170806Z/code-plan.md
@@ -1,0 +1,5 @@
+# Code Plan
+
+- Add a small helper in `js/live-tracker-resume.js` to detect reversal stat broadcasts.
+- Call the helper before building log entries in `buildResumeLogFromLiveEvents`.
+- Add a Vitest case in `tests/unit/live-tracker-resume.test.js` for undo/remove exclusion.

--- a/docs/pr-notes/runs/1189-remediator-20260522T170806Z/qa.md
+++ b/docs/pr-notes/runs/1189-remediator-20260522T170806Z/qa.md
@@ -1,0 +1,5 @@
+# QA Plan
+
+- Add a unit regression covering normal stat, undo broadcast, and remove broadcast inputs.
+- Verify reconstructed log contains only the original normal stat entry.
+- Run the focused unit test file for live tracker resume.

--- a/docs/pr-notes/runs/1189-remediator-20260522T170806Z/requirements.md
+++ b/docs/pr-notes/runs/1189-remediator-20260522T170806Z/requirements.md
@@ -1,0 +1,12 @@
+# Requirements
+
+- Resume log reconstruction must include normal stat and note live events only.
+- Undo/remove reversal stat broadcasts must not become removable log entries after resume.
+- A reversal stat broadcast is a stat live event with a negative value and a description beginning with `UNDO ` or `REMOVE `.
+- Existing clock resume behavior and normal stat undo metadata must remain unchanged.
+
+## Acceptance Criteria
+
+- Normal positive stat events are reconstructed with undoData.
+- Note events remain reconstructed.
+- `UNDO ...` and `REMOVE ...` negative stat broadcasts are omitted from reconstructed state.log.

--- a/js/live-tracker-resume.js
+++ b/js/live-tracker-resume.js
@@ -79,6 +79,16 @@ function buildStatUndoDataFromLiveEvent(event) {
     return undoData;
 }
 
+function isReversalStatBroadcast(event) {
+    if (event?.type !== 'stat') return false;
+
+    const value = Number(event?.value || 0);
+    if (!Number.isFinite(value) || value >= 0) return false;
+
+    const text = typeof event?.description === 'string' ? event.description.trim().toUpperCase() : '';
+    return text.startsWith('UNDO ') || text.startsWith('REMOVE ');
+}
+
 export function buildResumeLogFromLiveEvents(liveEvents = [], { now = () => Date.now() } = {}) {
     if (!Array.isArray(liveEvents) || liveEvents.length === 0) return [];
 
@@ -86,6 +96,7 @@ export function buildResumeLogFromLiveEvents(liveEvents = [], { now = () => Date
         .map((event, index) => {
             const type = event?.type;
             if (type !== 'stat' && type !== 'note') return null;
+            if (isReversalStatBroadcast(event)) return null;
 
             const text = typeof event?.description === 'string' ? event.description.trim() : '';
             if (!text) return null;

--- a/js/live-tracker-resume.js
+++ b/js/live-tracker-resume.js
@@ -53,6 +53,70 @@ export function buildPersistedResumeClockState(game) {
     };
 }
 
+function formatResumeLogClock(ms) {
+    const safeMs = Math.max(0, Number(ms) || 0);
+    const totalSeconds = Math.floor(safeMs / 1000);
+    const minutes = Math.floor(totalSeconds / 60).toString().padStart(2, '0');
+    const seconds = (totalSeconds % 60).toString().padStart(2, '0');
+    return `${minutes}:${seconds}`;
+}
+
+function buildStatUndoDataFromLiveEvent(event) {
+    const undoData = {
+        type: 'stat',
+        playerId: event?.playerId || null,
+        statKey: event?.statKey || null,
+        value: Number(event?.value || 0),
+        isOpponent: Boolean(event?.isOpponent)
+    };
+
+    if (Object.prototype.hasOwnProperty.call(event || {}, 'streamRelativeTimestampMs')) {
+        undoData.videoTimestampCaptureActive = event.videoTimestampCaptureActive;
+        undoData.streamRelativeTimestampMs = event.streamRelativeTimestampMs;
+        undoData.videoTimestampUnavailableReason = event.videoTimestampUnavailableReason;
+    }
+
+    return undoData;
+}
+
+export function buildResumeLogFromLiveEvents(liveEvents = [], { now = () => Date.now() } = {}) {
+    if (!Array.isArray(liveEvents) || liveEvents.length === 0) return [];
+
+    return liveEvents
+        .map((event, index) => {
+            const type = event?.type;
+            if (type !== 'stat' && type !== 'note') return null;
+
+            const text = typeof event?.description === 'string' ? event.description.trim() : '';
+            if (!text) return null;
+
+            const createdAtMs = toMillis(event.createdAt);
+            const clock = Number(event?.gameClockMs);
+            const entry = {
+                text,
+                ts: createdAtMs ?? now(),
+                period: typeof event?.period === 'string' ? event.period : '',
+                clock: formatResumeLogClock(Number.isFinite(clock) ? clock : 0),
+                __resumeOrder: index,
+                __resumeCreatedAtMs: createdAtMs
+            };
+
+            if (type === 'stat') {
+                entry.undoData = buildStatUndoDataFromLiveEvent(event);
+            }
+
+            return entry;
+        })
+        .filter(Boolean)
+        .sort((a, b) => {
+            const aTime = Number.isFinite(a.__resumeCreatedAtMs) ? a.__resumeCreatedAtMs : null;
+            const bTime = Number.isFinite(b.__resumeCreatedAtMs) ? b.__resumeCreatedAtMs : null;
+            if (aTime !== null && bTime !== null && aTime !== bTime) return bTime - aTime;
+            return b.__resumeOrder - a.__resumeOrder;
+        })
+        .map(({ __resumeOrder, __resumeCreatedAtMs, ...entry }) => entry);
+}
+
 export function deriveResumeClockState(liveEvents, defaults = { period: 'Q1', clock: 0 }, persistedClockState = null) {
     const fallbackPeriod = defaults?.period || 'Q1';
     const fallbackClock = Number.isFinite(defaults?.clock) ? defaults.clock : 0;

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -9,7 +9,7 @@ import { getApp } from './vendor/firebase-app.js';
 import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './live-tracker-notes.js?v=1';
 import { canApplySubstitution, applySubstitution } from './live-tracker-integrity.js?v=3';
 import { hydrateOpponentStats } from './live-tracker-opponent-stats.js?v=1';
-import { buildPersistedResumeClockState, deriveResumeClockState } from './live-tracker-resume.js?v=3';
+import { buildPersistedResumeClockState, buildResumeLogFromLiveEvents, deriveResumeClockState } from './live-tracker-resume.js?v=4';
 import { restoreLiveLineup } from './live-tracker-lineup.js?v=1';
 import { resolveFinalScore } from './live-tracker-email.js?v=2';
 import { buildLiveResetEvent } from './live-tracker-reset.js?v=1';
@@ -2908,6 +2908,7 @@ async function init() {
     applyPeriodButtons();
 
     const persistedLocalTrackerState = readPersistedLiveTrackerState(window.localStorage, teamId, gameId);
+    let resumedLiveEventLog = [];
     let shouldResume = true;
     const hasOpponentStats = !!(game.opponentStats && Object.keys(game.opponentStats).length > 0);
 
@@ -2994,6 +2995,7 @@ async function init() {
         const hasAggregatedStats = statsSnapshot.size > 0;
         const liveEventsSnapshot = await safeGetDocs(collection(db, `teams/${teamId}/games/${gameId}/liveEvents`), 'liveEvents');
         const liveEvents = liveEventsSnapshot.docs.map(d => d.data());
+        resumedLiveEventLog = buildResumeLogFromLiveEvents(liveEvents);
         const resumedFromPersistedData = hasScores || hasLiveFlag || hasOpponentStats || hasAggregatedStats || liveEvents.length > 0;
         state.scoreLogIsComplete = !resumedFromPersistedData;
         const resumeClockState = deriveResumeClockState(
@@ -3093,6 +3095,12 @@ async function init() {
 
     if (shouldResume && persistedLocalTrackerState) {
       applyPersistedLocalTrackerState(persistedLocalTrackerState);
+    }
+
+    if (shouldResume && state.log.length === 0 && resumedLiveEventLog.length > 0) {
+      state.log = resumedLiveEventLog;
+      state.scoreLogIsComplete = true;
+      persistLocalTrackerState();
     }
 
     if (!state.opp.length) {

--- a/tests/unit/live-tracker-resume.test.js
+++ b/tests/unit/live-tracker-resume.test.js
@@ -197,4 +197,54 @@ describe('live tracker resume game log', () => {
       }
     ]);
   });
+
+  it('excludes undo and remove stat broadcasts from reconstructed log entries', () => {
+    const result = buildResumeLogFromLiveEvents([
+      {
+        type: 'stat',
+        description: '#4 Alex PTS +2',
+        period: 'Q1',
+        gameClockMs: 80000,
+        createdAt: { toMillis: () => 1000 },
+        playerId: 'p1',
+        statKey: 'PTS',
+        value: 2,
+        isOpponent: false
+      },
+      {
+        type: 'stat',
+        description: 'UNDO #4 Alex PTS +2',
+        period: 'Q1',
+        gameClockMs: 78000,
+        createdAt: { toMillis: () => 2000 },
+        playerId: 'p1',
+        statKey: 'PTS',
+        value: -2,
+        isOpponent: false
+      },
+      {
+        type: 'stat',
+        description: 'REMOVE Opponent #12 PTS +3',
+        period: 'Q1',
+        gameClockMs: 76000,
+        createdAt: { toMillis: () => 3000 },
+        playerId: 'opp-12',
+        statKey: 'PTS',
+        value: -3,
+        isOpponent: true
+      }
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      text: '#4 Alex PTS +2',
+      undoData: {
+        type: 'stat',
+        playerId: 'p1',
+        statKey: 'PTS',
+        value: 2,
+        isOpponent: false
+      }
+    });
+  });
 });

--- a/tests/unit/live-tracker-resume.test.js
+++ b/tests/unit/live-tracker-resume.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildPersistedResumeClockState, deriveResumeClockState } from '../../js/live-tracker-resume.js';
+import { buildPersistedResumeClockState, buildResumeLogFromLiveEvents, deriveResumeClockState } from '../../js/live-tracker-resume.js';
 
 describe('live tracker resume clock state', () => {
   it('restores period and clock from latest persisted live event by createdAt', () => {
@@ -116,5 +116,85 @@ describe('live tracker resume clock state', () => {
     expect(result.restored).toBe(true);
     expect(result.period).toBe('Q4');
     expect(result.clock).toBe(10000);
+  });
+});
+
+describe('live tracker resume game log', () => {
+  it('reconstructs persisted live stat events into final-report log entries', () => {
+    const result = buildResumeLogFromLiveEvents([
+      {
+        type: 'stat',
+        description: '#4 Alex PTS +2',
+        period: 'Q1',
+        gameClockMs: 80000,
+        createdAt: { toMillis: () => 1000 },
+        playerId: 'p1',
+        statKey: 'PTS',
+        value: 2,
+        isOpponent: false,
+        streamRelativeTimestampMs: 45000,
+        videoTimestampCaptureActive: true
+      },
+      {
+        type: 'stat',
+        description: 'Opponent #12 PTS +3',
+        period: 'Q1',
+        gameClockMs: 20000,
+        createdAt: { toMillis: () => 2000 },
+        playerId: 'opp-12',
+        statKey: 'PTS',
+        value: 3,
+        isOpponent: true
+      }
+    ]);
+
+    expect(result).toEqual([
+      {
+        text: 'Opponent #12 PTS +3',
+        ts: 2000,
+        period: 'Q1',
+        clock: '00:20',
+        undoData: {
+          type: 'stat',
+          playerId: 'opp-12',
+          statKey: 'PTS',
+          value: 3,
+          isOpponent: true
+        }
+      },
+      {
+        text: '#4 Alex PTS +2',
+        ts: 1000,
+        period: 'Q1',
+        clock: '01:20',
+        undoData: {
+          type: 'stat',
+          playerId: 'p1',
+          statKey: 'PTS',
+          value: 2,
+          isOpponent: false,
+          videoTimestampCaptureActive: true,
+          streamRelativeTimestampMs: 45000,
+          videoTimestampUnavailableReason: undefined
+        }
+      }
+    ]);
+  });
+
+  it('keeps notes but skips non-log live broadcast noise', () => {
+    const result = buildResumeLogFromLiveEvents([
+      { type: 'chat', description: 'Go team', createdAt: { toMillis: () => 1000 } },
+      { type: 'note', description: 'Note: Great defensive possession', period: 'Q2', gameClockMs: 61000, createdAt: { toMillis: () => 2000 } },
+      { type: 'score_reset', description: 'Tracker reset', createdAt: { toMillis: () => 3000 } }
+    ]);
+
+    expect(result).toEqual([
+      {
+        text: 'Note: Great defensive possession',
+        ts: 2000,
+        period: 'Q2',
+        clock: '01:01'
+      }
+    ]);
   });
 });


### PR DESCRIPTION
Closes #1188

## Summary
- Reconstructs final-report log entries from persisted live stat and note broadcasts when resuming a live tracker session without local game log state.
- Preserves stat undo metadata so Save & Complete writes the restored play-by-play into the completed game events collection.
- Adds unit coverage for resumed live-event log reconstruction and filtering of non-log broadcast noise.

## Validation
- `npx vitest run tests/unit/live-tracker-resume.test.js tests/unit/live-tracker-save-complete.test.js tests/unit/live-tracker-integrity.test.js`