### PR TITLE
Hide private team games from homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -653,7 +653,7 @@
   <script type="module">
     import { checkAuth, getRedirectUrl } from './js/auth.js?v=14';
     import { renderHeader, formatDate, formatTime } from './js/utils.js?v=8';
-    import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=32';
+    import { getUpcomingLiveGames, getLiveGamesNow, getRecentLiveTrackedGames } from './js/db.js?v=33';
     import { initHomepage } from './js/homepage.js?v=3';
 
     initHomepage({

--- a/js/db.js
+++ b/js/db.js
@@ -85,7 +85,7 @@ import {
     filterTeamsByActive,
     shouldIncludeTeamInLiveOrUpcoming,
     shouldIncludeTeamInReplay
-} from './team-visibility.js?v=1';
+} from './team-visibility.js?v=2';
 import { normalizeStatTrackerConfig, splitPlayerStatsByVisibility } from './stat-leaderboards.js?v=2';
 import { buildPublishedBracketView } from './bracket-management.js?v=1';
 import { buildRolloverPlayerCopy } from './team-rollover.js?v=1';

--- a/js/team-visibility.js
+++ b/js/team-visibility.js
@@ -2,6 +2,10 @@ export function isTeamActive(team) {
     return team?.active !== false;
 }
 
+export function isTeamPublic(team) {
+    return team?.isPublic === true;
+}
+
 export function filterTeamsByActive(teams, includeInactive = false) {
     const safeTeams = Array.isArray(teams) ? teams : [];
     if (includeInactive) return safeTeams;
@@ -9,10 +13,10 @@ export function filterTeamsByActive(teams, includeInactive = false) {
 }
 
 export function shouldIncludeTeamInLiveOrUpcoming(team) {
-    return isTeamActive(team);
+    return isTeamActive(team) && isTeamPublic(team);
 }
 
-// Policy choice: keep completed replay history visible even if a team is inactive.
-export function shouldIncludeTeamInReplay(_team) {
-    return true;
+// Policy choice: keep completed replay history visible even if a public team is inactive.
+export function shouldIncludeTeamInReplay(team) {
+    return isTeamPublic(team);
 }

--- a/tests/unit/team-visibility.test.js
+++ b/tests/unit/team-visibility.test.js
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
     isTeamActive,
+    isTeamPublic,
     filterTeamsByActive,
     shouldIncludeTeamInLiveOrUpcoming,
     shouldIncludeTeamInReplay
@@ -32,12 +33,25 @@ describe('team visibility helpers', () => {
         expect(filterTeamsByActive(teams, true)).toEqual(teams);
     });
 
-    it('excludes inactive teams from upcoming/live cards', () => {
-        expect(shouldIncludeTeamInLiveOrUpcoming({ id: 'a', active: true })).toBe(true);
-        expect(shouldIncludeTeamInLiveOrUpcoming({ id: 'b', active: false })).toBe(false);
+    it('only treats explicitly public teams as public', () => {
+        expect(isTeamPublic({ id: 'a', isPublic: true })).toBe(true);
+        expect(isTeamPublic({ id: 'b', isPublic: false })).toBe(false);
+        expect(isTeamPublic({ id: 'c' })).toBe(false);
     });
 
-    it('keeps replay cards for inactive teams to preserve historical context', () => {
-        expect(shouldIncludeTeamInReplay({ id: 'a', active: false })).toBe(true);
+    it('excludes inactive and private teams from upcoming/live cards', () => {
+        expect(shouldIncludeTeamInLiveOrUpcoming({ id: 'a', active: true, isPublic: true })).toBe(true);
+        expect(shouldIncludeTeamInLiveOrUpcoming({ id: 'b', active: false, isPublic: true })).toBe(false);
+        expect(shouldIncludeTeamInLiveOrUpcoming({ id: 'c', active: true, isPublic: false })).toBe(false);
+        expect(shouldIncludeTeamInLiveOrUpcoming({ id: 'd', active: true })).toBe(false);
+    });
+
+    it('keeps replay cards for inactive public teams to preserve historical context', () => {
+        expect(shouldIncludeTeamInReplay({ id: 'a', active: false, isPublic: true })).toBe(true);
+    });
+
+    it('excludes private teams from replay cards', () => {
+        expect(shouldIncludeTeamInReplay({ id: 'a', active: true, isPublic: false })).toBe(false);
+        expect(shouldIncludeTeamInReplay({ id: 'b', active: true })).toBe(false);
     });
 });


### PR DESCRIPTION
Closes #1198

## Summary
- Require homepage live/upcoming and replay team visibility checks to include only teams with `isPublic === true`.
- Preserve inactive public replay visibility while excluding private or missing-visibility teams.
- Bumped homepage/db cache-bust imports for the changed browser modules.

## Validation
- `npx vitest run tests/unit/team-visibility.test.js tests/unit/db-homepage-shared-games.test.js`
- `node scripts/check-critical-cache-bust.mjs`