### PR TITLE
Fix Google invite login redemption

### DIFF
--- a/js/login-page.js
+++ b/js/login-page.js
@@ -55,6 +55,18 @@ export function shouldInitializeSignupMode({ windowObject = window, urlCodeParam
     return String(windowObject.location.hash || '').toLowerCase() === '#signup';
 }
 
+export function getGoogleAuthModeForLoginPage({ isLogin = true, urlCodeParam = null } = {}) {
+    if (isLogin) {
+        return 'login';
+    }
+
+    if (urlCodeParam && urlCodeParam.length === 8) {
+        return 'invite';
+    }
+
+    return 'signup';
+}
+
 export function createLoginRedirectCoordinator({
     windowObject = window,
     getRedirectUrl,
@@ -77,7 +89,8 @@ export function createLoginRedirectCoordinator({
     function getGoogleRedirectUrl(userWithRoles) {
         const googleAuthMode = windowObject.sessionStorage.getItem('postGoogleAuthMode');
         windowObject.sessionStorage.removeItem('postGoogleAuthMode');
-        const shouldRedeemInvite = shouldRedeemInviteFromLogin && googleAuthMode === 'login';
+        const shouldRedeemInvite = shouldRedeemInviteFromLogin &&
+            (googleAuthMode === 'login' || googleAuthMode === 'invite');
         inviteRedemptionOverride = shouldRedeemInvite;
         return getPostAuthRedirect(userWithRoles, shouldRedeemInvite);
     }

--- a/login.html
+++ b/login.html
@@ -101,7 +101,7 @@
         import { getUserProfile } from './js/db.js?v=32';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import { getPostAuthRedirectUrl } from './js/invite-redirect.js?v=1';
-        import * as loginPageModule from './js/login-page.js?v=3';
+        import * as loginPageModule from './js/login-page.js?v=4';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -322,7 +322,8 @@
             errorDiv.classList.add('hidden');
 
             try {
-                window.sessionStorage.setItem('postGoogleAuthMode', isLogin ? 'login' : 'signup');
+                const googleAuthMode = loginPageModule.getGoogleAuthModeForLoginPage({ isLogin, urlCodeParam });
+                window.sessionStorage.setItem('postGoogleAuthMode', googleAuthMode);
                 // If in signup mode, validate activation code before starting auth
                 let activationCode = null;
                 if (!isLogin) {
@@ -340,7 +341,8 @@
                     console.log('[Login Page] Popup succeeded, redirecting...');
                     const profile = await getUserProfile(result.user.uid);
                     const userWithRoles = { ...result.user, ...profile };
-                    const shouldRedeemInvite = shouldRedeemInviteFromLogin && isLogin;
+                    const shouldRedeemInvite = shouldRedeemInviteFromLogin &&
+                        (googleAuthMode === 'login' || googleAuthMode === 'invite');
                     window.location.href = redirectCoordinator.getPostAuthRedirect(userWithRoles, shouldRedeemInvite);
                 }
                 // If result is null, redirect flow was triggered - page will reload

--- a/tests/unit/login-page-cache-busting.test.js
+++ b/tests/unit/login-page-cache-busting.test.js
@@ -7,7 +7,7 @@ describe('login page cache busting', () => {
         const source = readFileSync(resolve(process.cwd(), 'login.html'), 'utf8');
 
         expect(source).toContain(
-            "import * as loginPageModule from './js/login-page.js?v=3';"
+            "import * as loginPageModule from './js/login-page.js?v=4';"
         );
     });
 });

--- a/tests/unit/login-page.test.js
+++ b/tests/unit/login-page.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { createLoginRedirectCoordinator, createLoginAuthStateManager, shouldInitializeSignupMode } from '../../js/login-page.js';
+import { createLoginRedirectCoordinator, createLoginAuthStateManager, shouldInitializeSignupMode, getGoogleAuthModeForLoginPage } from '../../js/login-page.js';
 
 function createCoordinator({
     search = '?code=ab12cd34&type=parent',
@@ -57,6 +57,20 @@ describe('login page initial mode', () => {
     });
 });
 
+describe('login page Google mode selection', () => {
+    it('stores invite mode for invite links that initialize signup UI', () => {
+        expect(getGoogleAuthModeForLoginPage({ isLogin: false, urlCodeParam: 'ab12cd34' })).toBe('invite');
+    });
+
+    it('stores signup mode for ordinary signup Google auth', () => {
+        expect(getGoogleAuthModeForLoginPage({ isLogin: false })).toBe('signup');
+    });
+
+    it('stores login mode when the user is in login UI', () => {
+        expect(getGoogleAuthModeForLoginPage({ isLogin: true, urlCodeParam: 'ab12cd34' })).toBe('login');
+    });
+});
+
 describe('login page redirect coordination', () => {
     it('treats invite type values case-insensitively when code is present', () => {
         const { coordinator } = createCoordinator({
@@ -98,7 +112,16 @@ describe('login page redirect coordination', () => {
         expect(windowObject.sessionStorage.removeItem).toHaveBeenCalledWith('postGoogleAuthMode');
     });
 
-    it('does not let auth auto-redirect redeem the invite after a Google signup return', () => {
+    it('redeems the invite after Google auth from an invite-prefilled signup page', () => {
+        const { coordinator, windowObject } = createCoordinator({ postGoogleAuthMode: 'invite' });
+        const user = { parentOf: [{ teamId: 'team-1' }] };
+
+        expect(coordinator.getGoogleRedirectUrl(user)).toBe('accept-invite.html?code=AB12CD34&type=parent');
+        expect(coordinator.getAutoRedirectUrl(user)).toBe('accept-invite.html?code=AB12CD34&type=parent');
+        expect(windowObject.sessionStorage.removeItem).toHaveBeenCalledWith('postGoogleAuthMode');
+    });
+
+    it('does not let auth auto-redirect redeem the invite after an ordinary Google signup return', () => {
         const { coordinator } = createCoordinator({ postGoogleAuthMode: 'signup' });
         const user = { parentOf: [{ teamId: 'team-1' }] };
 


### PR DESCRIPTION
Closes #1201

## Summary
- Treat Google auth launched from invite-prefilled signup mode as an invite redemption flow.
- Preserve ordinary public signup behavior so non-invite Google signups still avoid invite redemption.
- Bumped the login-page module cache-bust import and updated coverage for the new invite Google mode.

## Validation
- `npx vitest run tests/unit/login-page.test.js tests/unit/login-page-cache-busting.test.js tests/unit/invite-redirect.test.js`