### PR TITLE
Fix team fee manage hash routing

### DIFF
--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -1021,6 +1021,13 @@ async function initTeamFeesAdminPage() {
     }
 }
 
+export function registerTeamFeesAdminPageHandlers(win = typeof window !== 'undefined' ? window : null) {
+    if (!win?.addEventListener) return;
+
+    win.addEventListener('DOMContentLoaded', initTeamFeesAdminPage);
+    win.addEventListener('hashchange', initTeamFeesAdminPage);
+}
+
 if (typeof window !== 'undefined') {
-    window.addEventListener('DOMContentLoaded', initTeamFeesAdminPage);
+    registerTeamFeesAdminPageHandlers(window);
 }

--- a/tests/unit/team-fees-admin.test.js
+++ b/tests/unit/team-fees-admin.test.js
@@ -1,6 +1,20 @@
 // tests/unit/team-fees-admin.test.js
 import { describe, it, expect } from 'vitest'; // Import Vitest globals
-import { buildManualPaymentUpdate, buildOnlineRefundRequest, getRecipientRefundableCents, isOnlineRefundEligible, buildOfflineRefundUpdate } from '../../js/team-fees-admin.js'; // Adjusted path
+import { buildManualPaymentUpdate, buildOnlineRefundRequest, getRecipientRefundableCents, isOnlineRefundEligible, buildOfflineRefundUpdate, registerTeamFeesAdminPageHandlers } from '../../js/team-fees-admin.js'; // Adjusted path
+
+describe('team fees admin page routing', () => {
+    it('reinitializes when same-page manage links update the hash', () => {
+        const registrations = [];
+        const fakeWindow = {
+            addEventListener: (eventName, handler) => registrations.push({ eventName, handler })
+        };
+
+        registerTeamFeesAdminPageHandlers(fakeWindow);
+
+        expect(registrations.map(({ eventName }) => eventName)).toEqual(['DOMContentLoaded', 'hashchange']);
+        expect(registrations[1].handler).toBe(registrations[0].handler);
+    });
+});
 
 describe('buildManualPaymentUpdate', () => {
     it('should correctly handle missing or invalid currentBalanceCents by defaulting to a high number to prevent premature "paid" status', () => {


### PR DESCRIPTION
Closes #1213

## Summary
- Added a `hashchange` listener for the team fees admin page so same-page Manage links reinitialize the page controller.
- Covered the page routing registration with a focused unit test.

## Validation
- `npx vitest run tests/unit/team-fees-admin.test.js`