### PR TITLE
Add background check registration settings

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -368,6 +368,15 @@
                             <textarea id="registration-discount-rules" rows="3" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Early bird before 2026-03-01: $25\nSibling/cart discount 2+: 10%"></textarea>
                             <p class="mt-1 text-xs text-gray-500">Optional. Supports early-bird deadlines and quantity discounts for public fee previews.</p>
                         </div>
+                        <div class="rounded border border-amber-200 bg-amber-50 p-3">
+                            <label class="inline-flex items-start gap-2 text-sm font-semibold text-gray-900">
+                                <input id="registration-background-check-required" type="checkbox" class="mt-1 rounded border-gray-300 text-amber-600 focus:ring-amber-500">
+                                <span>Require volunteer background check</span>
+                            </label>
+                            <label for="registration-background-check-instructions" class="mt-3 block text-sm font-medium text-gray-700">Volunteer instructions</label>
+                            <textarea id="registration-background-check-instructions" rows="3" class="mt-1 w-full rounded border border-amber-200 p-2" placeholder="Explain who must complete screening, timing, and where to find next steps."></textarea>
+                            <p class="mt-1 text-xs text-gray-600">Optional policy metadata only. This does not create screening submissions, charge fees, or change access.</p>
+                        </div>
                         <div>
                             <label for="registration-waiver" class="block text-sm font-medium text-gray-700">Waiver text</label>
                             <textarea id="registration-waiver" rows="4" required class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Waiver and acknowledgement text parents must accept"></textarea>

--- a/js/admin-registration-forms.js
+++ b/js/admin-registration-forms.js
@@ -58,9 +58,20 @@ export function buildAdminRegistrationFormPayload(input = {}, context = {}) {
         registrationOptions: normalizeRegistrationOptions(input.registrationOptions),
         paymentSettings: normalizePaymentSettings(input.paymentSettings),
         discountRules: normalizeRegistrationDiscountRules(input.discountRules),
+        backgroundCheck: normalizeBackgroundCheck(input.backgroundCheck),
         waiverText: String(input.waiverText || '').trim(),
         status,
         published: status === 'published'
+    };
+}
+
+export function normalizeBackgroundCheck(settings = {}) {
+    const required = settings?.required === true;
+    const instructions = String(settings?.instructions || '').trim();
+
+    return {
+        required,
+        instructions: required ? instructions : ''
     };
 }
 

--- a/js/admin.js
+++ b/js/admin.js
@@ -671,6 +671,8 @@ window.startRegistrationFormAdmin = function (formId = '') {
     document.getElementById('registration-offline-payment').checked = form.paymentSettings?.offlinePaymentEnabled === true;
     document.getElementById('registration-online-checkout').checked = form.paymentSettings?.onlineCheckoutEnabled === true;
     document.getElementById('registration-discount-rules').value = formatRegistrationDiscountRulesText(form.discountRules);
+    document.getElementById('registration-background-check-required').checked = form.backgroundCheck?.required === true;
+    document.getElementById('registration-background-check-instructions').value = form.backgroundCheck?.instructions || '';
     activeRegistrationOptions = Array.isArray(form.registrationOptions) ? form.registrationOptions.map(option => ({ ...option })) : [];
     renderRegistrationOptionsEditor();
     document.getElementById('registration-waiver').value = form.waiverText || '';
@@ -842,6 +844,10 @@ async function saveRegistrationForm(event) {
             intervalDays: document.getElementById('registration-installment-interval').value
         },
         discountRules: parseRegistrationDiscountRulesText(document.getElementById('registration-discount-rules').value),
+        backgroundCheck: {
+            required: document.getElementById('registration-background-check-required').checked,
+            instructions: document.getElementById('registration-background-check-instructions').value
+        },
         waiverText: document.getElementById('registration-waiver').value,
         status: document.getElementById('registration-status').value
     }, { teamId });

--- a/tests/unit/admin-registration-forms.test.js
+++ b/tests/unit/admin-registration-forms.test.js
@@ -5,6 +5,7 @@ import {
     fieldLabelsToDefinitions,
     formatRegistrationDiscountRulesText,
     getAdminRegistrationShareUrl,
+    normalizeBackgroundCheck,
     normalizePaymentSettings,
     normalizeInstallmentPlan,
     normalizeRegistrationDiscountRules,
@@ -29,6 +30,7 @@ describe('admin registration form setup', () => {
             ],
             paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: true },
             installmentPlan: { enabled: true, installmentCount: '3', firstDueDate: '2026-06-01', intervalDays: '30' },
+            backgroundCheck: { required: true, instructions: 'Coaches must complete screening before practices.' },
             discountRules: [
                 { id: 'early', type: 'early_bird', label: 'Early bird', amountType: 'fixed', amountValue: '25', earlyBirdDeadline: '2026-03-01' },
                 { type: 'quantity', label: 'Sibling discount', amountType: 'percent', amountValue: '10', minimumQuantity: '2' }
@@ -48,6 +50,7 @@ describe('admin registration form setup', () => {
             currency: 'USD',
             paymentSettings: { offlinePaymentEnabled: true, onlineCheckoutEnabled: true },
             installmentPlan: { enabled: true, title: 'Installment plan', installmentCount: 3, firstDueDate: '2026-06-01', intervalDays: 30 },
+            backgroundCheck: { required: true, instructions: 'Coaches must complete screening before practices.' },
             waiverText: 'I accept the risk.',
             status: 'published',
             published: true
@@ -66,6 +69,18 @@ describe('admin registration form setup', () => {
             { id: 'discount_2', type: 'quantity', label: 'Sibling discount', amountType: 'percent', amountValue: 10, earlyBirdDeadline: '', minimumQuantity: 2, active: true, sortOrder: 1 }
         ]);
         expect(validateAdminRegistrationFormPayload(payload)).toEqual([]);
+    });
+
+    it('normalizes background-check policy metadata safely', () => {
+        expect(normalizeBackgroundCheck()).toEqual({ required: false, instructions: '' });
+        expect(normalizeBackgroundCheck({ required: true, instructions: '  Complete screening before volunteering.  ' })).toEqual({
+            required: true,
+            instructions: 'Complete screening before volunteering.'
+        });
+        expect(normalizeBackgroundCheck({ required: false, instructions: 'Ignored when disabled' })).toEqual({
+            required: false,
+            instructions: ''
+        });
     });
 
     it('normalizes checkout and payment settings to bounded booleans', () => {
@@ -126,6 +141,7 @@ describe('admin registration form setup', () => {
 
         expect(payload.status).toBe('draft');
         expect(payload.published).toBe(false);
+        expect(payload.backgroundCheck).toEqual({ required: false, instructions: '' });
         expect(validateAdminRegistrationFormPayload(payload)).toEqual([
             'Title is required.',
             'Waiver text is required.'
@@ -160,6 +176,8 @@ describe('admin registration form setup', () => {
         expect(adminPage).toContain('Online payment processing is not available yet');
         expect(adminPage).toContain('registration-installments-enabled');
         expect(adminPage).toContain('registration-discount-rules');
+        expect(adminPage).toContain('registration-background-check-required');
+        expect(adminPage).toContain('registration-background-check-instructions');
         expect(adminPage).toContain('registration-waiver');
         expect(adminPage).toContain('Publish and show link');
         expect(adminJs).toContain('window.openRegistrationFormsAdmin');
@@ -170,6 +188,8 @@ describe('admin registration form setup', () => {
         expect(adminJs).toContain('offlinePaymentEnabled: document.getElementById');
         expect(adminJs).toContain("document.getElementById('registration-installment-count')");
         expect(adminJs).toContain('parseRegistrationDiscountRulesText');
+        expect(adminJs).toContain("document.getElementById('registration-background-check-required')");
+        expect(adminJs).toContain("document.getElementById('registration-background-check-instructions')");
         expect(adminJs).toContain('const teamId = activeRegistrationTeam.id;');
         expect(adminJs).toContain('if (activeRegistrationTeam?.id !== teamId) return;');
         expect(adminJs).toContain('teams/${teamId}/registrationForms');


### PR DESCRIPTION
Closes #1217

## Summary
- Added a background-check section to the admin registration form editor.
- Saved a normalized `backgroundCheck` configuration object with `required` and `instructions` fields on registration form records.
- Preserved legacy form behavior by defaulting missing background-check settings to disabled.

## Validation
- `npx vitest run tests/unit/admin-registration-forms.test.js --reporter=dot`