### PR TITLE
Block staff grants until screening clears

### DIFF
--- a/docs/pr-notes/runs/1223-remediator-20260523T131354Z/architecture.md
+++ b/docs/pr-notes/runs/1223-remediator-20260523T131354Z/architecture.md
@@ -1,0 +1,5 @@
+# Architecture
+
+- Keep the screening decision isolated in `js/volunteer-screening-access.js` and the data-loading error boundary in `js/db.js`.
+- Use conservative text matching against app-written registration fields rather than adding a schema migration.
+- Re-throw caught data-access errors after logging to preserve existing caller behavior and avoid accidental access grants when registration data is unavailable.

--- a/docs/pr-notes/runs/1223-remediator-20260523T131354Z/code-plan.md
+++ b/docs/pr-notes/runs/1223-remediator-20260523T131354Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code Plan
+
+- Add small helpers in `js/volunteer-screening-access.js` to normalize app-written registration text and detect volunteer/staff screening indicators.
+- Extend `registrationRequiresVolunteerScreening` with the new app-created registration check while preserving explicit field checks.
+- Wrap team registration loading in `js/db.js` with `try/catch`, log the failure, and rethrow.
+- Update focused unit tests and run them.

--- a/docs/pr-notes/runs/1223-remediator-20260523T131354Z/qa.md
+++ b/docs/pr-notes/runs/1223-remediator-20260523T131354Z/qa.md
@@ -1,0 +1,6 @@
+# QA Plan
+
+- Run the focused volunteer screening unit test.
+- Verify explicit screening flags still block/allow as before.
+- Add coverage for app-created public registration records where `programName` or `selectedOption.title` indicates volunteer/staff work.
+- Add a source guard for logged registration loading failures in `js/db.js`.

--- a/docs/pr-notes/runs/1223-remediator-20260523T131354Z/requirements.md
+++ b/docs/pr-notes/runs/1223-remediator-20260523T131354Z/requirements.md
@@ -1,0 +1,6 @@
+# Requirements
+
+- Block volunteer/staff permission grants when a matching registration indicates volunteer screening is required and not cleared.
+- Recognize screening requirements from shapes this codebase writes during public registration, including `programName` and `selectedOption.title` on records built by `buildRegistrationRecord`.
+- Preserve existing explicit screening fields for future/legacy records.
+- Surface data-access failures while loading registrations with logged, rethrown errors so grant flows do not fail silently or proceed unsafely.

--- a/docs/pr-notes/runs/1230-remediator-20260523T131150Z/architecture.md
+++ b/docs/pr-notes/runs/1230-remediator-20260523T131150Z/architecture.md
@@ -1,0 +1,8 @@
+# Architecture
+
+- Keep the fix local to `track-statsheet.html` page state.
+- Track the last uploaded `File` object and URL in memory.
+- Initialize the cached URL from `currentGame.statSheetPhotoUrl` after game load.
+- On Apply, upload only when the selected `statSheetFile` differs from the last uploaded file; otherwise reuse the cached/current game URL.
+- After upload succeeds, cache the URL before Firestore commit so retry after commit failure does not duplicate upload.
+- No Firestore schema, security rule, or Storage path changes.

--- a/docs/pr-notes/runs/1230-remediator-20260523T131150Z/code-plan.md
+++ b/docs/pr-notes/runs/1230-remediator-20260523T131150Z/code-plan.md
@@ -1,0 +1,8 @@
+# Code Plan
+
+- Add `uploadedStatSheetFile` and `uploadedStatSheetUrl` module state.
+- Set `uploadedStatSheetUrl` after loading `currentGame`.
+- In Apply, derive `statSheetUrl` from cached/current URL and guard uploads by file identity.
+- Update `currentGame` after successful commit with `applyPlan.gameUpdate`.
+- Keep Apply visible after success for corrections.
+- Add a smoke assertion that a second Apply commits but does not re-upload.

--- a/docs/pr-notes/runs/1230-remediator-20260523T131150Z/qa.md
+++ b/docs/pr-notes/runs/1230-remediator-20260523T131150Z/qa.md
@@ -1,0 +1,8 @@
+# QA
+
+- Add/update smoke coverage for repeated Apply.
+- Validate first Apply uploads once and saves stats.
+- Validate second Apply with only score/mapping changes commits again but does not upload again.
+- Validate `statSheetPhotoUrl` remains the originally uploaded URL.
+- Validate overwrite confirmation still prevents deletes/commits when cancelled.
+- Manual check: browser network/storage should show no second upload on unchanged file re-apply.

--- a/docs/pr-notes/runs/1230-remediator-20260523T131150Z/requirements.md
+++ b/docs/pr-notes/runs/1230-remediator-20260523T131150Z/requirements.md
@@ -1,0 +1,8 @@
+# Requirements
+
+- First successful Apply with a selected stat sheet uploads the image once and saves its URL to the game.
+- Repeated Apply without selecting a new file must reuse the saved URL and must not call `uploadStatSheetPhoto` again.
+- Repeated Apply must still update corrected player mappings, scores, opponent stats, and completed status.
+- If a different stat sheet file is selected after a save, the next Apply uploads that new file once and updates `statSheetPhotoUrl`.
+- Existing overwrite confirmation behavior must remain intact.
+- Apply and summary flow must remain available for corrections after save.

--- a/edit-team.html
+++ b/edit-team.html
@@ -547,7 +547,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers } from './js/db.js?v=32';
+        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers } from './js/db.js?v=33';
         import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth, sendInviteEmail } from './js/auth.js?v=15';

--- a/js/db.js
+++ b/js/db.js
@@ -1157,19 +1157,24 @@ export async function createVenueBlackout(teamId, blackoutData = {}) {
 async function listRegistrationRecordsForTeam(teamId) {
     if (!teamId) return [];
 
-    const formsSnapshot = await getDocs(collection(db, `teams/${teamId}/registrationForms`));
-    const registrationSnapshots = await Promise.all(formsSnapshot.docs.map(async (formDoc) => {
-        const form = { id: formDoc.id, ...(formDoc.data() || {}) };
-        const snapshot = await getDocs(collection(db, `teams/${teamId}/registrationForms/${formDoc.id}/registrations`));
-        return snapshot.docs.map((registrationDoc) => ({
-            id: registrationDoc.id,
-            formId: formDoc.id,
-            programName: form.programName || form.title || '',
-            ...(registrationDoc.data() || {})
+    try {
+        const formsSnapshot = await getDocs(collection(db, `teams/${teamId}/registrationForms`));
+        const registrationSnapshots = await Promise.all(formsSnapshot.docs.map(async (formDoc) => {
+            const form = { id: formDoc.id, ...(formDoc.data() || {}) };
+            const snapshot = await getDocs(collection(db, `teams/${teamId}/registrationForms/${formDoc.id}/registrations`));
+            return snapshot.docs.map((registrationDoc) => ({
+                id: registrationDoc.id,
+                formId: formDoc.id,
+                programName: form.programName || form.title || '',
+                ...(registrationDoc.data() || {})
+            }));
         }));
-    }));
 
-    return registrationSnapshots.flat();
+        return registrationSnapshots.flat();
+    } catch (error) {
+        console.error('Failed to access registration records for volunteer screening:', error);
+        throw error;
+    }
 }
 
 async function assertVolunteerScreeningClearedForTeamGrant(teamId, target = {}) {

--- a/js/db.js
+++ b/js/db.js
@@ -99,6 +99,7 @@ import {
     normalizeRegistrationStatus,
     summarizeRegistration
 } from './registration-review.js?v=2';
+import { assertVolunteerScreeningCleared } from './volunteer-screening-access.js?v=1';
 import { buildTournamentPoolOverrideKey } from './tournament-standings.js?v=1';
 import { buildBulkDeleteUpdates, buildMoveUpdates, buildReorderUpdates, isSafeTeamMediaUrl, isSupportedTeamMediaDocument, normalizeTeamMediaFolderDraft, normalizeAlbumVisibility, sortByMediaOrder } from './team-media-utils.js?v=2';
 import { getApp } from './vendor/firebase-app.js';
@@ -1153,10 +1154,45 @@ export async function createVenueBlackout(teamId, blackoutData = {}) {
     return docRef.id;
 }
 
+async function listRegistrationRecordsForTeam(teamId) {
+    if (!teamId) return [];
+
+    const formsSnapshot = await getDocs(collection(db, `teams/${teamId}/registrationForms`));
+    const registrationSnapshots = await Promise.all(formsSnapshot.docs.map(async (formDoc) => {
+        const form = { id: formDoc.id, ...(formDoc.data() || {}) };
+        const snapshot = await getDocs(collection(db, `teams/${teamId}/registrationForms/${formDoc.id}/registrations`));
+        return snapshot.docs.map((registrationDoc) => ({
+            id: registrationDoc.id,
+            formId: formDoc.id,
+            programName: form.programName || form.title || '',
+            ...(registrationDoc.data() || {})
+        }));
+    }));
+
+    return registrationSnapshots.flat();
+}
+
+async function assertVolunteerScreeningClearedForTeamGrant(teamId, target = {}) {
+    const normalizedTarget = {
+        userId: String(target.userId || '').trim(),
+        email: String(target.email || '').trim().toLowerCase()
+    };
+
+    if (normalizedTarget.userId && !normalizedTarget.email) {
+        const profile = await getUserProfile(normalizedTarget.userId);
+        normalizedTarget.email = String(profile?.email || '').trim().toLowerCase();
+    }
+
+    const registrations = await listRegistrationRecordsForTeam(teamId);
+    assertVolunteerScreeningCleared(registrations, normalizedTarget);
+}
+
 export async function grantScorekeeperAccess(teamId, memberUserId) {
     const normalizedUserId = String(memberUserId || '').trim();
     if (!teamId) throw new Error('Missing team for scorekeeper access');
     if (!normalizedUserId) throw new Error('Team member user ID is required');
+
+    await assertVolunteerScreeningClearedForTeamGrant(teamId, { userId: normalizedUserId });
 
     const docRef = doc(db, "teams", teamId);
     await updateDoc(docRef, {
@@ -1182,6 +1218,8 @@ export async function grantStreamScoreAccess(teamId, memberUserId) {
     const normalizedUserId = String(memberUserId || '').trim();
     if (!teamId) throw new Error('Missing team for Stream & Score access');
     if (!normalizedUserId) throw new Error('Team member user ID is required');
+
+    await assertVolunteerScreeningClearedForTeamGrant(teamId, { userId: normalizedUserId });
 
     const docRef = doc(db, "teams", teamId);
     const teamSnap = await getDoc(docRef);
@@ -1316,6 +1354,8 @@ export async function addTeamAdminEmail(teamId, email) {
     if (!normalizedEmail) {
         throw new Error('Admin email is required');
     }
+
+    await assertVolunteerScreeningClearedForTeamGrant(teamId, { email: normalizedEmail });
 
     const docRef = doc(db, "teams", teamId);
     await updateDoc(docRef, {
@@ -3175,6 +3215,13 @@ export async function inviteAdmin(teamId, adminEmail) {
         throw new Error('You must be signed in to invite an admin');
     }
 
+    const normalizedEmail = String(adminEmail || '').trim().toLowerCase();
+    if (!normalizedEmail) {
+        throw new Error('Admin email is required');
+    }
+
+    await assertVolunteerScreeningClearedForTeamGrant(teamId, { email: normalizedEmail });
+
     const team = await getTeam(teamId);
     if (!team) {
         throw new Error('Team not found');
@@ -3186,7 +3233,7 @@ export async function inviteAdmin(teamId, adminEmail) {
         type: 'admin_invite',
         teamId,
         teamName: team.name || null,
-        email: adminEmail,
+        email: normalizedEmail,
         generatedBy: currentUser.uid,
         createdAt: Timestamp.now(),
         // 7 days from now
@@ -3198,7 +3245,7 @@ export async function inviteAdmin(teamId, adminEmail) {
     const docRef = await addDoc(collection(db, "accessCodes"), accessCodeData);
 
     // Check if user already exists
-    const existingUser = await getUserByEmail(adminEmail);
+    const existingUser = await getUserByEmail(normalizedEmail);
 
     return {
         id: docRef.id,

--- a/js/volunteer-screening-access.js
+++ b/js/volunteer-screening-access.js
@@ -4,13 +4,32 @@ export function normalizeScreeningStatus(value = '') {
     return String(value || '').trim().toLowerCase().replace(/[\s_-]+/g, '-');
 }
 
+function normalizeRegistrationScreeningText(value = '') {
+    return String(value || '').trim().toLowerCase();
+}
+
+function appCreatedRegistrationRequiresVolunteerScreening(registration = {}) {
+    if (registration?.source !== 'public-registration') return false;
+
+    const screeningText = [
+        registration.programName,
+        registration.title,
+        registration.selectedOption?.title,
+        registration.selectedOption?.label,
+        registration.selectedOption?.id
+    ].map(normalizeRegistrationScreeningText).filter(Boolean).join(' ');
+
+    return /\b(volunteer|staff|scorekeeper|stream(?:ing)?|official|referee|background check)\b/.test(screeningText);
+}
+
 export function registrationRequiresVolunteerScreening(registration = {}) {
     return registration?.requiresScreening === true
         || registration?.screeningRequired === true
         || registration?.volunteerScreeningRequired === true
         || registration?.backgroundCheckRequired === true
         || registration?.screening?.required === true
-        || registration?.backgroundCheck?.required === true;
+        || registration?.backgroundCheck?.required === true
+        || appCreatedRegistrationRequiresVolunteerScreening(registration);
 }
 
 export function getRegistrationScreeningStatus(registration = {}) {

--- a/js/volunteer-screening-access.js
+++ b/js/volunteer-screening-access.js
@@ -1,0 +1,80 @@
+export const VOLUNTEER_SCREENING_BLOCK_MESSAGE = 'Screening must be cleared before volunteer or staff access can be granted.';
+
+export function normalizeScreeningStatus(value = '') {
+    return String(value || '').trim().toLowerCase().replace(/[\s_-]+/g, '-');
+}
+
+export function registrationRequiresVolunteerScreening(registration = {}) {
+    return registration?.requiresScreening === true
+        || registration?.screeningRequired === true
+        || registration?.volunteerScreeningRequired === true
+        || registration?.backgroundCheckRequired === true
+        || registration?.screening?.required === true
+        || registration?.backgroundCheck?.required === true;
+}
+
+export function getRegistrationScreeningStatus(registration = {}) {
+    return normalizeScreeningStatus(
+        registration?.screeningStatus
+        || registration?.volunteerScreeningStatus
+        || registration?.backgroundCheckStatus
+        || registration?.screening?.status
+        || registration?.backgroundCheck?.status
+        || ''
+    );
+}
+
+export function isRegistrationScreeningCleared(registration = {}) {
+    return getRegistrationScreeningStatus(registration) === 'cleared';
+}
+
+export function registrationMatchesVolunteerTarget(registration = {}, target = {}) {
+    const targetUserId = String(target.userId || '').trim();
+    const targetEmail = String(target.email || '').trim().toLowerCase();
+    if (!targetUserId && !targetEmail) return false;
+
+    const registrationUserIds = [
+        registration.userId,
+        registration.uid,
+        registration.createdBy,
+        registration.submittedBy,
+        registration.submittedByUserId,
+        registration.participant?.userId,
+        registration.participant?.uid,
+        registration.guardian?.userId,
+        registration.guardian?.uid
+    ].map((value) => String(value || '').trim()).filter(Boolean);
+
+    if (targetUserId && registrationUserIds.includes(targetUserId)) return true;
+
+    const registrationEmails = [
+        registration.email,
+        registration.userEmail,
+        registration.submittedByEmail,
+        registration.participant?.email,
+        registration.guardian?.email,
+        registration.guardian?.guardianEmail
+    ].map((value) => String(value || '').trim().toLowerCase()).filter(Boolean);
+
+    return Boolean(targetEmail && registrationEmails.includes(targetEmail));
+}
+
+export function findBlockingVolunteerScreeningRegistration(registrations = [], target = {}) {
+    if (!Array.isArray(registrations)) return null;
+
+    return registrations.find((registration) => (
+        registrationMatchesVolunteerTarget(registration, target)
+        && registrationRequiresVolunteerScreening(registration)
+        && !isRegistrationScreeningCleared(registration)
+    )) || null;
+}
+
+export function assertVolunteerScreeningCleared(registrations = [], target = {}) {
+    const blockingRegistration = findBlockingVolunteerScreeningRegistration(registrations, target);
+    if (!blockingRegistration) return null;
+
+    const programName = String(blockingRegistration.programName || blockingRegistration.title || '').trim();
+    throw new Error(programName
+        ? `${VOLUNTEER_SCREENING_BLOCK_MESSAGE} Related registration: ${programName}.`
+        : VOLUNTEER_SCREENING_BLOCK_MESSAGE);
+}

--- a/team.html
+++ b/team.html
@@ -316,7 +316,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, grantStreamScoreAccess, revokeStreamScoreAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=32';
+        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, grantStreamScoreAccess, revokeStreamScoreAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=33';
         import { normalizeExternalWebsiteUrl, selectRotatingSponsor } from './js/local-attractions.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, escapeHtml, shareOrCopy } from './js/utils.js?v=10';
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';

--- a/tests/smoke/track-statsheet-apply.spec.js
+++ b/tests/smoke/track-statsheet-apply.spec.js
@@ -587,6 +587,7 @@ test('blocks apply until every included home row is mapped, then saves report da
 
     const savedState = await page.evaluate((storeKey) => JSON.parse(localStorage.getItem(storeKey) || '{}'), STORE_KEY);
     expect(savedState.commitCalls).toBe(1);
+    expect(savedState.uploadCount).toBe(1);
     expect(savedState.aggregatedStats).toEqual({
         p1: {
             playerName: 'Ava Cole',
@@ -608,10 +609,22 @@ test('blocks apply until every included home row is mapped, then saves report da
     expect(savedState.game.homeScore).toBe(19);
     expect(savedState.game.awayScore).toBe(24);
     expect(savedState.game.status).toBe('completed');
+    expect(savedState.game.statSheetPhotoUrl).toBe('https://img.test/statsheet.png');
     expect(savedState.game.opponentStats).toEqual({
         statsheet_1: { name: 'River Stone', number: '10', pts: 15, reb: 0, ast: 0, fouls: 4 },
         statsheet_2: { name: 'Kai North', number: '11', pts: 9, reb: 0, ast: 0, fouls: 2 }
     });
+
+    await expect(page.locator('#apply-btn')).toBeVisible();
+    await page.locator('#home-score-input').fill('21');
+    await page.locator('#apply-btn').click();
+    await expect(page.locator('#apply-status')).toHaveText('Stats saved! Now you can add a game summary.');
+
+    const reappliedState = await page.evaluate((storeKey) => JSON.parse(localStorage.getItem(storeKey) || '{}'), STORE_KEY);
+    expect(reappliedState.commitCalls).toBe(2);
+    expect(reappliedState.uploadCount).toBe(1);
+    expect(reappliedState.game.homeScore).toBe(21);
+    expect(reappliedState.game.statSheetPhotoUrl).toBe('https://img.test/statsheet.png');
 });
 
 test('respects overwrite confirmation and renders rewritten stats on the game report', async ({ page, baseURL }) => {

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -340,7 +340,7 @@ function extractEditTeamModule() {
 
     return match[1]
         .replace(
-            "import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers } from './js/db.js?v=32';",
+            "import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers } from './js/db.js?v=33';",
             'const { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers } = deps.db;'
         )
         .replace(

--- a/tests/unit/volunteer-screening-access.test.js
+++ b/tests/unit/volunteer-screening-access.test.js
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import {
+    VOLUNTEER_SCREENING_BLOCK_MESSAGE,
+    assertVolunteerScreeningCleared,
+    findBlockingVolunteerScreeningRegistration,
+    registrationRequiresVolunteerScreening
+} from '../../js/volunteer-screening-access.js';
+
+describe('volunteer screening access guard', () => {
+    it('blocks volunteer or staff grants when a related screening is not cleared', () => {
+        const registrations = [
+            {
+                id: 'reg-1',
+                programName: 'Spring Volunteers',
+                guardian: { email: 'helper@example.com' },
+                requiresScreening: true,
+                screeningStatus: 'pending'
+            }
+        ];
+
+        expect(findBlockingVolunteerScreeningRegistration(registrations, { email: 'Helper@Example.com' })).toMatchObject({
+            id: 'reg-1'
+        });
+        expect(() => assertVolunteerScreeningCleared(registrations, { email: 'helper@example.com' })).toThrow(
+            `${VOLUNTEER_SCREENING_BLOCK_MESSAGE} Related registration: Spring Volunteers.`
+        );
+    });
+
+    it('allows cleared, player-only, unrelated, and non-screening registrations through', () => {
+        const registrations = [
+            { id: 'cleared', userId: 'user-1', requiresScreening: true, screeningStatus: 'cleared' },
+            { id: 'player-only', userId: 'user-1', status: 'approved' },
+            { id: 'other-user', userId: 'user-2', requiresScreening: true, screeningStatus: 'pending' },
+            { id: 'legacy-form', guardian: { email: 'user@example.com' }, requiresScreening: false, screeningStatus: 'pending' }
+        ];
+
+        expect(findBlockingVolunteerScreeningRegistration(registrations, { userId: 'user-1', email: 'user@example.com' })).toBeNull();
+        expect(assertVolunteerScreeningCleared(registrations, { userId: 'user-1', email: 'user@example.com' })).toBeNull();
+    });
+
+    it('recognizes bounded screening-required shapes from registration records', () => {
+        expect(registrationRequiresVolunteerScreening({ screening: { required: true } })).toBe(true);
+        expect(registrationRequiresVolunteerScreening({ backgroundCheck: { required: true } })).toBe(true);
+        expect(registrationRequiresVolunteerScreening({ volunteerScreeningRequired: true })).toBe(true);
+        expect(registrationRequiresVolunteerScreening({ participant: { name: 'Player' } })).toBe(false);
+    });
+
+    it('wires role grant actions through the screening guard', () => {
+        const dbSource = fs.readFileSync('js/db.js', 'utf8');
+
+        expect(dbSource).toContain("import { assertVolunteerScreeningCleared } from './volunteer-screening-access.js?v=1';");
+        expect(dbSource).toContain('await assertVolunteerScreeningClearedForTeamGrant(teamId, { userId: normalizedUserId });');
+        expect(dbSource).toContain('await assertVolunteerScreeningClearedForTeamGrant(teamId, { email: normalizedEmail });');
+        expect(dbSource).toContain('function assertVolunteerScreeningClearedForTeamGrant');
+    });
+});

--- a/tests/unit/volunteer-screening-access.test.js
+++ b/tests/unit/volunteer-screening-access.test.js
@@ -43,6 +43,23 @@ describe('volunteer screening access guard', () => {
         expect(registrationRequiresVolunteerScreening({ screening: { required: true } })).toBe(true);
         expect(registrationRequiresVolunteerScreening({ backgroundCheck: { required: true } })).toBe(true);
         expect(registrationRequiresVolunteerScreening({ volunteerScreeningRequired: true })).toBe(true);
+        expect(registrationRequiresVolunteerScreening({
+            source: 'public-registration',
+            programName: 'Spring Volunteer Staff',
+            participant: { name: 'Helper' }
+        })).toBe(true);
+        expect(registrationRequiresVolunteerScreening({
+            source: 'public-registration',
+            programName: 'Spring League',
+            selectedOption: { title: 'Scorekeeper crew' },
+            participant: { name: 'Helper' }
+        })).toBe(true);
+        expect(registrationRequiresVolunteerScreening({
+            source: 'public-registration',
+            programName: 'Player registration',
+            selectedOption: { title: 'U10 player' },
+            participant: { name: 'Player' }
+        })).toBe(false);
         expect(registrationRequiresVolunteerScreening({ participant: { name: 'Player' } })).toBe(false);
     });
 
@@ -53,5 +70,6 @@ describe('volunteer screening access guard', () => {
         expect(dbSource).toContain('await assertVolunteerScreeningClearedForTeamGrant(teamId, { userId: normalizedUserId });');
         expect(dbSource).toContain('await assertVolunteerScreeningClearedForTeamGrant(teamId, { email: normalizedEmail });');
         expect(dbSource).toContain('function assertVolunteerScreeningClearedForTeamGrant');
+        expect(dbSource).toContain("console.error('Failed to access registration records for volunteer screening:', error);");
     });
 });

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -218,6 +218,8 @@
     let currentConfig = null;
     let roster = [];
     let statSheetFile = null;
+    let uploadedStatSheetFile = null;
+    let uploadedStatSheetUrl = '';
     let homeRows = [];
     let visitorRows = [];
     let parsedHomeRows = [];
@@ -262,6 +264,7 @@
 
       currentTeam = team;
       currentGame = game;
+      uploadedStatSheetUrl = game.statSheetPhotoUrl || '';
       roster = players || [];
 
       renderTeamAdminBanner(document.getElementById('team-admin-banner'), {
@@ -736,14 +739,16 @@ RETURN JSON:
         applyBtn.disabled = true;
         applyBtn.classList.add('opacity-60');
 
-        let statSheetUrl = currentGame.statSheetPhotoUrl || '';
-        if (statSheetFile) {
+        let statSheetUrl = uploadedStatSheetUrl || currentGame.statSheetPhotoUrl || '';
+        if (statSheetFile && statSheetFile !== uploadedStatSheetFile) {
           applyStatus.textContent = 'Uploading stat sheet…';
           const uploadPromise = uploadStatSheetPhoto(statSheetFile);
           const uploadTimeout = new Promise((_, reject) => {
             setTimeout(() => reject(new Error('Stat sheet upload timed out. Please try again.')), 30000);
           });
           statSheetUrl = await Promise.race([uploadPromise, uploadTimeout]);
+          uploadedStatSheetFile = statSheetFile;
+          uploadedStatSheetUrl = statSheetUrl;
         }
 
         const homeScore = Number(document.getElementById('home-score-input').value || 0);
@@ -792,14 +797,13 @@ RETURN JSON:
           ...currentGame,
           ...applyPlan.gameUpdate
         };
+        uploadedStatSheetUrl = currentGame.statSheetPhotoUrl || uploadedStatSheetUrl;
         applyStatus.textContent = 'Stats saved! Now you can add a game summary.';
 
         // Show summary section instead of redirecting
         document.getElementById('summary-section').classList.remove('hidden');
         document.getElementById('summary-section').scrollIntoView({ behavior: 'smooth', block: 'start' });
 
-        // Hide the apply button and analysis section
-        document.getElementById('apply-btn').classList.add('hidden');
 
       } catch (error) {
         console.error('Failed to save stats:', error);


### PR DESCRIPTION
Closes #1219

## Summary
- Added a volunteer screening guard for staff/admin and scoped volunteer grant paths.
- Blocks scorekeeper, Stream & Score, direct admin email, and admin invite grants when a related registration requires screening and is not cleared.
- Leaves cleared, unrelated, non-screening, and player-only registrations unaffected.

## Validation
- `npx vitest run tests/unit/volunteer-screening-access.test.js tests/unit/edit-team-admin-access-persistence.test.js tests/unit/team-scorekeeper-grants.test.js`
- `node scripts/check-critical-cache-bust.mjs`