### PR TITLE
Block tracking cancelled games

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -2665,14 +2665,24 @@
             document.getElementById('basketball-tracker-modal')?.classList.remove('hidden');
         }
 
+        function isCancelledGame(game) {
+            const status = String(game?.status || '').toLowerCase();
+            return status === 'cancelled' || status === 'canceled';
+        }
+
         function handleTrackClick(gameId) {
             const game = gamesCache[gameId];
             if (!game) return;
+            if (isCancelledGame(game)) {
+                alert('Cancelled games cannot be tracked. Restore or reschedule the game before tracking.');
+                return;
+            }
             openTrackerChoiceModal(gameId, isBasketballForGame(game), isGoalSportForGame(game));
         }
 
         function renderDbGame(game) {
             const isCompleted = game.status === 'completed';
+            const isCancelled = isCancelledGame(game);
             // Cache game data for later retrieval
             gamesCache[game.id] = game;
             return `
@@ -2698,21 +2708,21 @@
                         ${renderOfficiatingSummary(game.officiatingSlots)}
                         ${game.assignments && game.assignments.length > 0 ? `<div class="mt-1 text-xs text-gray-600">${game.assignments.map(a => `<span class="inline-block bg-gray-100 rounded px-1.5 py-0.5 mr-1 mb-1"><b>${escapeHtml(a.role)}:</b> ${escapeHtml(a.value || 'TBD')}</span>`).join('')}</div>` : ''}
                         ${isCompleted ? `<span class="inline-block bg-green-100 text-green-800 text-xs px-2 py-1 rounded-full font-semibold mt-2">Final: ${game.homeScore}-${game.awayScore}</span>` : ''}
-                        ${game.status === 'cancelled' ? '<div class="mt-1"><span class="inline-block bg-red-100 text-red-800 text-xs px-2 py-1 rounded-full font-semibold">CANCELLED</span></div>' : ''}
+                        ${isCancelled ? '<div class="mt-1"><span class="inline-block bg-red-100 text-red-800 text-xs px-2 py-1 rounded-full font-semibold">CANCELLED</span></div>' : ''}
                         ${game.rsvpSummary ? `<div class="text-xs text-gray-500 mt-1">${game.rsvpSummary.going || 0} going · ${game.rsvpSummary.maybe || 0} maybe · ${game.rsvpSummary.notGoing || 0} can't go · ${game.rsvpSummary.notResponded || 0} no response</div>` : ''}
                     </div>
                     <div class="flex flex-wrap gap-2">
                         <button data-game-id="${game.id}" class="edit-game-btn px-3 py-1 bg-blue-100 text-blue-700 rounded text-sm hover:bg-blue-200">Edit</button>
                         ${game.competitionType === 'tournament' && game.tournament?.poolName ? `<button data-game-id="${game.id}" class="advance-tournament-pool-btn px-3 py-1 bg-violet-100 text-violet-700 rounded text-sm hover:bg-violet-200">Advance Pool</button>` : ''}
-                        ${!isCompleted ? `<button data-game-id="${game.id}" class="track-game-btn px-3 py-1 bg-indigo-100 text-indigo-700 rounded text-sm hover:bg-indigo-200">Track</button>` : ''}
+                        ${!isCompleted && !isCancelled ? `<button data-game-id="${game.id}" class="track-game-btn px-3 py-1 bg-indigo-100 text-indigo-700 rounded text-sm hover:bg-indigo-200">Track</button>` : ''}
                         ${!isCompleted ? `<a href="live-game.html?teamId=${currentTeamId}&gameId=${game.id}" class="px-3 py-1 ${game.liveStatus === 'live' ? 'bg-red-100 text-red-700 hover:bg-red-200' : 'bg-slate-100 text-slate-700 hover:bg-slate-200'} rounded text-sm">${game.liveStatus === 'live' ? 'Live Now' : 'View Live'}</a>` : ''}
                         ${!isCompleted ? `<button data-live-link="${game.id}" class="copy-live-link-btn px-3 py-1 bg-rose-100 text-rose-700 rounded text-sm hover:bg-rose-200">Share</button>` : ''}
                         ${isCompleted ? `<a href="game.html#teamId=${currentTeamId}&gameId=${game.id}" class="px-3 py-1 bg-green-100 text-green-700 rounded text-sm hover:bg-green-200">Report</a>` : ''}
                         ${game.liveStatus === 'completed' ? `<a href="live-game.html?teamId=${currentTeamId}&gameId=${game.id}&replay=true" class="px-3 py-1 bg-teal-100 text-teal-700 rounded text-sm hover:bg-teal-200">Watch Replay</a>` : ''}
                         <a href="game-plan.html#teamId=${currentTeamId}&gameId=${game.id}" class="px-3 py-1 bg-primary-100 text-primary-700 rounded text-sm hover:bg-primary-200">Game Plan</a>
-                        ${game.status !== 'cancelled' ? `<a href="game-day.html?teamId=${currentTeamId}&gameId=${game.id}" class="px-3 py-1 bg-orange-100 text-orange-700 rounded text-sm hover:bg-orange-200">Command Center</a>` : ''}
+                        ${!isCancelled ? `<a href="game-day.html?teamId=${currentTeamId}&gameId=${game.id}" class="px-3 py-1 bg-orange-100 text-orange-700 rounded text-sm hover:bg-orange-200">Command Center</a>` : ''}
                         <button data-game-id="${game.id}" data-event-doc-id="${game.id}" data-event-type="game" data-event-title="${escapeHtml(`vs. ${game.opponent || 'TBD'}`)}" data-event-date="${(game.date?.toDate ? game.date.toDate() : new Date(game.date)).toISOString()}" class="view-rsvps-btn px-3 py-1 bg-green-100 text-green-700 rounded text-sm hover:bg-green-200">RSVPs</button>
-                        ${game.status !== 'cancelled' ? `<button data-game-id="${game.id}" class="cancel-game-btn px-3 py-1 border border-orange-300 text-orange-600 rounded text-sm hover:bg-orange-50">Cancel</button>` : '<span class="px-3 py-1 bg-red-100 text-red-700 rounded text-sm font-semibold">Cancelled</span>'}
+                        ${!isCancelled ? `<button data-game-id="${game.id}" class="cancel-game-btn px-3 py-1 border border-orange-300 text-orange-600 rounded text-sm hover:bg-orange-50">Cancel</button>` : '<span class="px-3 py-1 bg-red-100 text-red-700 rounded text-sm font-semibold">Cancelled</span>'}
                         <button data-id="${game.id}" class="px-3 py-1 border border-red-300 text-red-600 rounded text-sm hover:bg-red-50 delete-btn">Delete</button>
                     </div>
                 </div>

--- a/tests/unit/edit-schedule-cancelled-row-render.test.js
+++ b/tests/unit/edit-schedule-cancelled-row-render.test.js
@@ -23,11 +23,12 @@ function buildRenderDbGame(overrides = {}) {
         mapLink: () => '',
         renderTournamentSummary: () => '',
         renderOfficiatingSummary: () => '',
+        isCancelledGame: (game) => ['cancelled', 'canceled'].includes(String(game?.status || '').toLowerCase()),
         ...overrides
     };
 
     const createRenderer = new Function('deps', `
-        const { gamesCache, currentTeamId, formatDate, formatTime, escapeHtml, mapLink, renderTournamentSummary, renderOfficiatingSummary } = deps;
+        const { gamesCache, currentTeamId, formatDate, formatTime, escapeHtml, mapLink, renderTournamentSummary, renderOfficiatingSummary, isCancelledGame } = deps;
         return function(game) {
 ${body}
         };
@@ -55,8 +56,27 @@ describe('edit schedule game row rendering', () => {
         });
         expect(html).toContain('CANCELLED');
         expect(html).toContain('>Cancelled</span>');
+        expect(html).not.toContain('Track</button>');
+        expect(html).not.toContain('track-game-btn');
         expect(html).not.toContain('Command Center');
         expect(html).not.toContain('cancel-game-btn');
+    });
+
+    it('treats American-spelled canceled games as untrackable too', () => {
+        const { renderDbGame } = buildRenderDbGame();
+
+        const html = renderDbGame({
+            id: 'game-canceled',
+            opponent: 'Tigers',
+            location: 'Main Gym',
+            date: '2026-03-10T18:00:00.000Z',
+            status: 'canceled',
+            liveStatus: 'scheduled'
+        });
+
+        expect(html).toContain('CANCELLED');
+        expect(html).not.toContain('track-game-btn');
+        expect(html).not.toContain('Command Center');
     });
 
     it('uses liveStatus to label active broadcasts as Live Now', () => {

--- a/tests/unit/track-cancelled-game-guard.test.js
+++ b/tests/unit/track-cancelled-game-guard.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readTrackPage() {
+    return readFileSync(new URL('../../track.html', import.meta.url), 'utf8');
+}
+
+describe('standard tracker cancelled game guard', () => {
+    it('blocks cancelled games during tracker initialization', () => {
+        const source = readTrackPage();
+
+        expect(source).toContain('function isCancelledGame(game)');
+        expect(source).toContain("return status === 'cancelled' || status === 'canceled';");
+        expect(source).toContain('if (isCancelledGame(game))');
+        expect(source).toContain('Cancelled games cannot be tracked. Restore or reschedule the game before tracking.');
+        expect(source).toContain('window.location.href = `edit-schedule.html#teamId=${teamId}`;');
+    });
+
+    it('re-checks cancellation before Save & Complete writes completed status', () => {
+        const source = readTrackPage();
+        const latestGameGuardIndex = source.indexOf('const latestGame = await getGame(currentTeamId, currentGameId);');
+        const finishWriteIndex = source.indexOf('await commitStandardTrackerFinishData({');
+
+        expect(latestGameGuardIndex).toBeGreaterThan(-1);
+        expect(finishWriteIndex).toBeGreaterThan(-1);
+        expect(latestGameGuardIndex).toBeLessThan(finishWriteIndex);
+        expect(source).toContain('if (isCancelledGame(latestGame || currentGame))');
+        expect(source).toContain('Cancelled games cannot be completed. Restore or reschedule the game before saving stats.');
+    });
+});

--- a/track.html
+++ b/track.html
@@ -327,6 +327,11 @@
             init();
         });
 
+        function isCancelledGame(game) {
+            const status = String(game?.status || '').toLowerCase();
+            return status === 'cancelled' || status === 'canceled';
+        }
+
         async function init() {
             const { teamId, gameId } = getUrlParams();
             console.log('Track init - teamId:', teamId, 'gameId:', gameId);
@@ -354,9 +359,15 @@
                     return;
                 }
 
-                // Practices cannot be tracked - redirect to schedule
+                // Practices and cancelled games cannot be tracked - redirect to schedule
                 if (game.type === 'practice') {
                     alert('Practice events cannot be tracked. Use game tracking for games only.');
+                    window.location.href = `edit-schedule.html#teamId=${teamId}`;
+                    return;
+                }
+
+                if (isCancelledGame(game)) {
+                    alert('Cancelled games cannot be tracked. Restore or reschedule the game before tracking.');
                     window.location.href = `edit-schedule.html#teamId=${teamId}`;
                     return;
                 }
@@ -1247,6 +1258,13 @@ Write the match report now:`;
             const sendEmail = document.getElementById('sendEmailCheckbox').checked;
 
             try {
+                const latestGame = await getGame(currentTeamId, currentGameId);
+                if (isCancelledGame(latestGame || currentGame)) {
+                    alert('Cancelled games cannot be completed. Restore or reschedule the game before saving stats.');
+                    window.location.href = `edit-schedule.html#teamId=${currentTeamId}`;
+                    return;
+                }
+
                 await commitStandardTrackerFinishData({
                     db,
                     writeBatch,


### PR DESCRIPTION
Closes #1224

## Summary
- Hide the Track action for cancelled/canceled games in the schedule list.
- Guard Track clicks so stale schedule rows cannot open the tracker for cancelled games.
- Block direct tracker loads and re-check cancellation before Save & Complete writes completed stats.

## Tests
- `npx vitest run tests/unit/edit-schedule-cancelled-row-render.test.js tests/unit/track-cancelled-game-guard.test.js --reporter=dot`