### PR TITLE
Add printable schedule range view

### DIFF
--- a/calendar.html
+++ b/calendar.html
@@ -95,7 +95,10 @@
                 </select>
 
                 <!-- Export -->
-                <button id="export-ics-btn" onclick="exportIcs()" class="ml-auto inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-primary-600 bg-primary-50 rounded-lg hover:bg-primary-100 transition border border-primary-200">
+                <button id="print-schedule" onclick="printCurrentSchedule()" class="ml-auto inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-gray-700 bg-white rounded-lg hover:bg-gray-50 transition border border-gray-200">
+                    Print Schedule
+                </button>
+                <button id="export-ics-btn" onclick="exportIcs()" class="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-primary-600 bg-primary-50 rounded-lg hover:bg-primary-100 transition border border-primary-200">
                     <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16v1a3 3 0 003 3h10a3 3 0 003-3v-1m-4-4l-4 4m0 0l-4-4m4 4V4"></path></svg>
                     .ics Export
                 </button>
@@ -142,6 +145,7 @@
         import { buildLinkedPlayersByTeam, resolveCalendarRsvpSubmission } from './js/calendar-rsvp.js?v=1';
         import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';
         import { buildAvailabilityNoteRows, canViewAvailabilityNotes, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';
+        import { printSchedule, promptSchedulePrintOptions } from './js/schedule-print.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -164,6 +168,7 @@
         window.setTimeRange = setTimeRange;
         window.setTypeFilter = setTypeFilter;
         window.applyFilters = applyFilters;
+        window.printCurrentSchedule = printCurrentSchedule;
         window.navMonth = navMonth;
         window.exportIcs = exportIcs;
         window.openDayDetail = openDayDetail;
@@ -777,6 +782,19 @@
             if (calendarMonth > 11) { calendarMonth = 0; calendarYear++; }
             if (calendarMonth < 0) { calendarMonth = 11; calendarYear--; }
             render();
+        }
+
+        function printCurrentSchedule() {
+            const options = promptSchedulePrintOptions();
+            if (!options) return;
+            const selectedTeam = currentTeamFilter
+                ? allEvents.find((event) => event.teamId === currentTeamFilter)?.teamName
+                : 'All teams';
+            printSchedule(filteredEvents, {
+                ...options,
+                title: `${selectedTeam || 'All teams'} schedule`,
+                teamName: selectedTeam || ''
+            });
         }
 
         // ===== ICS EXPORT =====

--- a/css/styles.css
+++ b/css/styles.css
@@ -8,3 +8,61 @@ body {
     backdrop-filter: blur(10px);
     border: 1px solid rgba(255, 255, 255, 0.2);
 }
+.schedule-print-container {
+    display: none;
+}
+
+@media print {
+    body > *:not(.schedule-print-container) {
+        display: none !important;
+    }
+
+    .schedule-print-container {
+        display: block;
+        color: #111827;
+        font-family: Arial, sans-serif;
+        padding: 24px;
+    }
+
+    .schedule-print-bw,
+    .schedule-print-bw * {
+        background: #fff !important;
+        color: #000 !important;
+        box-shadow: none !important;
+        text-shadow: none !important;
+    }
+
+    .schedule-print-header {
+        border-bottom: 2px solid currentColor;
+        margin-bottom: 16px;
+        padding-bottom: 8px;
+    }
+
+    .schedule-print-header h1 {
+        font-size: 24px;
+        margin: 0 0 4px;
+    }
+
+    .schedule-print-header p {
+        margin: 0;
+    }
+
+    .schedule-print-table {
+        border-collapse: collapse;
+        width: 100%;
+    }
+
+    .schedule-print-table th,
+    .schedule-print-table td {
+        border: 1px solid #d1d5db;
+        font-size: 12px;
+        padding: 8px;
+        text-align: left;
+        vertical-align: top;
+    }
+
+    .schedule-print-table th {
+        background: #f3f4f6;
+        font-weight: 700;
+    }
+}

--- a/docs/pr-notes/runs/1231-remediator-20260523T050844Z/architecture.md
+++ b/docs/pr-notes/runs/1231-remediator-20260523T050844Z/architecture.md
@@ -1,0 +1,16 @@
+# Architecture
+
+## Decision
+Centralize CSV formula-injection mitigation in `escapeCsvValue()` in `js/team-fees-admin.js`. This keeps the blast radius small and protects all current and future payment-summary fields that use the serializer.
+
+## Scope
+- Update `escapeCsvValue()` only for sanitization behavior.
+- Add focused unit coverage for direct formula markers, whitespace bypasses, pipe markers, and existing escaping regression cases.
+
+## Impacts
+- No persisted data changes.
+- No Firebase rules, schema, routing, permissions, or UI changes.
+- Exported formula-like values gain a leading apostrophe before normal CSV escaping.
+
+## Risks and rollback
+False positives on legitimate leading `-` or `|` text are acceptable for spreadsheet safety. Rollback is a single helper/test revert with no data cleanup.

--- a/docs/pr-notes/runs/1231-remediator-20260523T050844Z/code-plan.md
+++ b/docs/pr-notes/runs/1231-remediator-20260523T050844Z/code-plan.md
@@ -1,0 +1,9 @@
+# Code Plan
+
+The code-planning subagent timed out, so this inline implementation plan is used.
+
+1. Inspect `js/team-fees-admin.js` and existing unit tests.
+2. Update `escapeCsvValue()` to prefix an apostrophe when the first non-whitespace character is one of `=`, `+`, `-`, `@`, or `|`.
+3. Preserve current null handling and CSV quoting behavior.
+4. Add focused unit tests for formula markers, whitespace bypasses, pipe markers, safe values, and combined sanitization plus escaping.
+5. Run the affected unit test command available in the repo.

--- a/docs/pr-notes/runs/1231-remediator-20260523T050844Z/qa.md
+++ b/docs/pr-notes/runs/1231-remediator-20260523T050844Z/qa.md
@@ -1,0 +1,14 @@
+# QA Plan
+
+## Automated coverage
+- `escapeCsvValue()` neutralizes leading `=`, `+`, `-`, `@`, and `|`.
+- Leading whitespace before dangerous markers is neutralized.
+- Dangerous values containing commas and quotes are both neutralized and CSV-escaped correctly.
+- Safe values and empty/null/undefined values remain unchanged.
+- Serialization-level test proves dangerous row fields are neutralized in final CSV output.
+
+## Command gate
+Run the affected unit tests for `tests/unit/team-fees-admin.test.js`.
+
+## Manual check
+Export a payment summary containing dangerous recipient/note/reference values and confirm spreadsheet apps treat them as text, while normal commas, quotes, multiline notes, amounts, dates, and statuses remain aligned.

--- a/docs/pr-notes/runs/1231-remediator-20260523T050844Z/requirements.md
+++ b/docs/pr-notes/runs/1231-remediator-20260523T050844Z/requirements.md
@@ -1,0 +1,15 @@
+# Requirements
+
+## Acceptance criteria
+- Prefix a single quote to exported CSV cells whose first non-whitespace character is `=`, `+`, `-`, `@`, or `|`.
+- Apply sanitization through `escapeCsvValue()` so every CSV cell uses the same policy.
+- Preserve original text after the safe prefix; do not strip or mutate payload content.
+- Keep existing CSV escaping behavior for commas, quotes, CR, and LF.
+- Serialize empty, null, and undefined values as empty cells without a prefix.
+- Leave safe values unchanged.
+
+## Edge cases
+- Formula values: `=1+1`, `+SUM(A1:A2)`, `-10+20`, `@HYPERLINK(...)`, `|cmd`.
+- Leading spaces/tabs before formula markers.
+- Dangerous values that also require CSV quoting, such as formulas containing commas or quotes.
+- Multiline notes beginning with formula markers.

--- a/js/schedule-print.js
+++ b/js/schedule-print.js
@@ -1,0 +1,163 @@
+function toDate(value) {
+    if (!value) return null;
+    if (value instanceof Date) return value;
+    if (typeof value.toDate === 'function') return value.toDate();
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function startOfDay(value) {
+    const date = toDate(value);
+    if (!date) return null;
+    date.setHours(0, 0, 0, 0);
+    return date;
+}
+
+function endOfDay(value) {
+    const date = toDate(value);
+    if (!date) return null;
+    date.setHours(23, 59, 59, 999);
+    return date;
+}
+
+function escapeHtml(value) {
+    return String(value ?? '')
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}
+
+function formatDate(value) {
+    const date = toDate(value);
+    if (!date) return 'TBD';
+    return date.toLocaleDateString('en-US', {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric'
+    });
+}
+
+function formatTime(value) {
+    const date = toDate(value);
+    if (!date) return 'TBD';
+    return date.toLocaleTimeString('en-US', {
+        hour: 'numeric',
+        minute: '2-digit'
+    });
+}
+
+function resolveEventType(event) {
+    if (event?.isPractice || event?.type === 'practice') return 'practice';
+    return 'game';
+}
+
+function resolveTitle(event) {
+    if (event?.title) return event.title;
+    if (event?.opponent) return event.isPractice ? event.opponent : `vs. ${event.opponent}`;
+    return resolveEventType(event) === 'practice' ? 'Practice' : 'Game';
+}
+
+export function filterScheduleEventsForPrint(events, options = {}) {
+    const rangeStart = startOfDay(options.startDate);
+    const rangeEnd = endOfDay(options.endDate);
+    const eventType = options.eventType || 'all';
+
+    if (!rangeStart || !rangeEnd || rangeStart > rangeEnd) return [];
+
+    return (events || [])
+        .filter((event) => {
+            const eventDate = toDate(event?.date || event?.dtstart);
+            if (!eventDate || eventDate < rangeStart || eventDate > rangeEnd) return false;
+            if (eventType !== 'all' && resolveEventType(event) !== eventType) return false;
+            return true;
+        })
+        .sort((a, b) => toDate(a.date || a.dtstart) - toDate(b.date || b.dtstart));
+}
+
+export function promptSchedulePrintOptions(defaults = {}) {
+    const today = new Date();
+    const defaultStart = defaults.startDate || today.toISOString().slice(0, 10);
+    const monthEnd = new Date(today.getFullYear(), today.getMonth() + 1, 0);
+    const defaultEnd = defaults.endDate || monthEnd.toISOString().slice(0, 10);
+    const startDate = window.prompt('Print schedule start date (YYYY-MM-DD)', defaultStart);
+    if (!startDate) return null;
+    const endDate = window.prompt('Print schedule end date (YYYY-MM-DD)', defaultEnd);
+    if (!endDate) return null;
+    const blackAndWhite = window.confirm('Print in black and white?');
+    return { startDate, endDate, blackAndWhite };
+}
+
+export function renderSchedulePrintContainer(events, options = {}) {
+    const container = document.createElement('section');
+    container.id = 'schedule-print-container';
+    container.className = `schedule-print-container${options.blackAndWhite ? ' schedule-print-bw' : ''}`;
+    container.setAttribute('aria-hidden', 'true');
+
+    const title = options.title || 'Schedule';
+    const rangeLabel = `${formatDate(options.startDate)} - ${formatDate(options.endDate)}`;
+    const rows = (events || []).map((event) => {
+        const eventDate = toDate(event.date || event.dtstart);
+        const eventEnd = toDate(event.end || event.endDate);
+        const type = resolveEventType(event);
+        const timeLabel = eventEnd ? `${formatTime(eventDate)} - ${formatTime(eventEnd)}` : formatTime(eventDate);
+        return `
+            <tr>
+                <td>${escapeHtml(formatDate(eventDate))}</td>
+                <td>${escapeHtml(timeLabel)}</td>
+                <td>${escapeHtml(resolveTitle(event))}</td>
+                <td>${escapeHtml(event.location || 'TBD')}</td>
+                <td>${escapeHtml(type === 'practice' ? 'Practice' : 'Game')}</td>
+                <td>${escapeHtml(event.teamName || options.teamName || '')}</td>
+            </tr>
+        `;
+    }).join('');
+
+    container.innerHTML = `
+        <div class="schedule-print-page">
+            <header class="schedule-print-header">
+                <h1>${escapeHtml(title)}</h1>
+                <p>${escapeHtml(rangeLabel)}</p>
+            </header>
+            <table class="schedule-print-table">
+                <thead>
+                    <tr>
+                        <th>Date</th>
+                        <th>Time</th>
+                        <th>Event</th>
+                        <th>Location</th>
+                        <th>Type</th>
+                        <th>Team</th>
+                    </tr>
+                </thead>
+                <tbody>${rows}</tbody>
+            </table>
+        </div>
+    `;
+
+    return container;
+}
+
+export function printSchedule(events, options = {}) {
+    const printableEvents = filterScheduleEventsForPrint(events, options);
+    if (printableEvents.length === 0) {
+        window.alert(options.noEventsMessage || 'No schedule events match that print range.');
+        return { printed: false, count: 0 };
+    }
+
+    const existing = document.getElementById('schedule-print-container');
+    if (existing) existing.remove();
+
+    const container = renderSchedulePrintContainer(printableEvents, options);
+    document.body.appendChild(container);
+
+    const cleanup = () => {
+        container.remove();
+        window.removeEventListener('afterprint', cleanup);
+    };
+    window.addEventListener('afterprint', cleanup, { once: true });
+    window.print();
+    return { printed: true, count: printableEvents.length, cleanup };
+}

--- a/team.html
+++ b/team.html
@@ -200,10 +200,14 @@
                                 class="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-primary-600 bg-primary-50 rounded-lg hover:bg-primary-100 transition border border-primary-200">
                                 <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                     <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2"
-                                        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z">
+                                        d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 002 2z">
                                     </path>
                                 </svg>
                                 .ics
+                            </button>
+                            <button id="print-schedule"
+                                class="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-gray-700 bg-white rounded-lg hover:bg-gray-50 transition border border-gray-200">
+                                Print Schedule
                             </button>
                             <button id="sync-calendar"
                                 class="inline-flex items-center gap-1 px-3 py-1.5 text-xs font-medium text-emerald-700 bg-emerald-50 rounded-lg hover:bg-emerald-100 transition border border-emerald-200">
@@ -335,6 +339,7 @@
         import { renderTeamPassCard } from './js/team-pass.js?v=2';
         import { getVisiblePlayerTrackingSummary } from './js/player-tracking-summary.js?v=1';
         import { renderTeamStaffPermissionsSection } from './js/team-staff-permissions.js?v=2';
+        import { printSchedule, promptSchedulePrintOptions } from './js/schedule-print.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -2900,6 +2905,16 @@
             link.click();
             document.body.removeChild(link);
             URL.revokeObjectURL(url);
+        });
+
+        document.getElementById('print-schedule')?.addEventListener('click', () => {
+            const options = promptSchedulePrintOptions();
+            if (!options) return;
+            printSchedule(getFilteredScheduleEvents(), {
+                ...options,
+                title: `${currentTeam?.name || 'Team'} schedule`,
+                teamName: currentTeam?.name || 'Team'
+            });
         });
 
         document.getElementById('sync-calendar')?.addEventListener('click', openSyncCalendarModal);

--- a/tests/smoke/team-schedule-calendar.spec.js
+++ b/tests/smoke/team-schedule-calendar.spec.js
@@ -545,6 +545,85 @@ test('team schedule calendar shows only practices in the dedicated practice filt
     await expect(page.locator('#schedule-day-modal-content')).not.toContainText('Rivals FC');
 });
 
+test('team schedule print uses the selected range and black-and-white layout', async ({ page, baseURL }) => {
+    const now = new Date();
+    const inRangeGameDate = addDays(now, 7, 18);
+    const inRangePracticeDate = addDays(now, 10, 17);
+    const outOfRangeDate = addDays(now, 45, 18);
+    const scenario = {
+        team: {
+            name: 'Team A',
+            sport: 'Soccer',
+            calendarUrls: []
+        },
+        games: [
+            {
+                id: 'game-1',
+                opponent: 'Rivals FC',
+                location: 'Field 1',
+                type: 'game',
+                status: 'scheduled',
+                date: makeIso(inRangeGameDate)
+            },
+            {
+                id: 'practice-1',
+                title: 'Practice',
+                location: 'Gym 1',
+                type: 'practice',
+                status: 'scheduled',
+                date: makeIso(inRangePracticeDate)
+            },
+            {
+                id: 'game-2',
+                opponent: 'Late FC',
+                location: 'Field 2',
+                type: 'game',
+                status: 'scheduled',
+                date: makeIso(outOfRangeDate)
+            }
+        ],
+        trackedUids: [],
+        calendarEvents: []
+    };
+
+    await page.addInitScript(() => {
+        window.__printCalls = 0;
+        window.print = () => {
+            window.__printCalls += 1;
+        };
+    });
+    await mockTeamPageModules(page, scenario);
+    await page.goto(buildUrl(baseURL, '/team.html#teamId=team-a'), { waitUntil: 'domcontentloaded' });
+
+    await expect(page.locator('#team-header')).toContainText('Team A');
+    await page.locator('#show-practices').check();
+    await page.locator('#schedule-filter-all-upcoming').click();
+
+    const dialogValues = [
+        inRangeGameDate.toISOString().slice(0, 10),
+        inRangePracticeDate.toISOString().slice(0, 10),
+        true
+    ];
+    page.on('dialog', async (dialog) => {
+        const value = dialogValues.shift();
+        if (dialog.type() === 'confirm') {
+            await (value ? dialog.accept() : dialog.dismiss());
+            return;
+        }
+        await dialog.accept(String(value));
+    });
+
+    await page.locator('#print-schedule').scrollIntoViewIfNeeded();
+    await page.locator('#print-schedule').click({ force: true });
+
+    await expect.poll(() => page.evaluate(() => window.__printCalls)).toBe(1);
+    await expect(page.locator('#schedule-print-container')).toHaveClass(/schedule-print-bw/);
+    await expect(page.locator('#schedule-print-container tbody tr')).toHaveCount(2);
+    await expect(page.locator('#schedule-print-container')).toContainText('Rivals FC');
+    await expect(page.locator('#schedule-print-container')).toContainText('Practice');
+    await expect(page.locator('#schedule-print-container')).not.toContainText('Late FC');
+});
+
 test('team schedule keeps tracked duplicates and cancelled items out of the wrong filter buckets', async ({ page, baseURL }) => {
     const now = new Date();
     const completedDate = addDays(now, -5, 18);

--- a/tests/unit/calendar-day-modal-rsvp.test.js
+++ b/tests/unit/calendar-day-modal-rsvp.test.js
@@ -115,6 +115,10 @@ const Blob = deps.Blob;
             "import { buildAvailabilityNoteRows, canViewAvailabilityNotes, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';",
             'const { buildAvailabilityNoteRows, canViewAvailabilityNotes, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } = deps.availabilityPreferences;'
         )
+        .replace(
+            "import { printSchedule, promptSchedulePrintOptions } from './js/schedule-print.js?v=1';",
+            'const { printSchedule, promptSchedulePrintOptions } = deps.schedulePrint;'
+        )
         .replace(/\binit\(\);\s*$/, 'await init();');
 }
 
@@ -390,6 +394,10 @@ function createDeps(submitRecorder, overrides = {}) {
                     }
                 });
             }
+        },
+        schedulePrint: {
+            printSchedule() {},
+            promptSchedulePrintOptions() { return null; }
         },
         eventDate,
         initialSummary,

--- a/tests/unit/team-schedule-filter.test.js
+++ b/tests/unit/team-schedule-filter.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
+import { filterScheduleEventsForPrint } from '../../js/schedule-print.js';
 
 function loadGetFilteredScheduleEvents() {
     const source = readFileSync(new URL('../../team.html', import.meta.url), 'utf8');
@@ -94,6 +95,23 @@ describe('team schedule filtering', () => {
         });
 
         expect(result.map((event) => event.opponent)).toEqual(['Rivals', 'Practice']);
+    });
+
+    it('filters printable schedule events by date range and event type', () => {
+        const events = [
+            { date: '2026-05-01T18:00:00Z', type: 'game', opponent: 'Early' },
+            { date: '2026-05-10T18:00:00Z', type: 'practice', title: 'Practice' },
+            { date: '2026-05-12T18:00:00Z', type: 'game', opponent: 'In Range' },
+            { date: '2026-06-01T18:00:00Z', type: 'game', opponent: 'Late' }
+        ];
+
+        const games = filterScheduleEventsForPrint(events, {
+            startDate: '2026-05-08',
+            endDate: '2026-05-31',
+            eventType: 'game'
+        });
+
+        expect(games.map((event) => event.opponent)).toEqual(['In Range']);
     });
 
     it('wires the team availability filter and RSVP controls into team.html', () => {


### PR DESCRIPTION
Closes #1226

## Summary
- Added Print Schedule actions to team schedule and global calendar toolbars.
- Added a reusable schedule print helper with date-range filtering, black-and-white print mode, no-events guard, and print-only table output.
- Added unit coverage for print filtering and smoke coverage for the team print flow with window.print stubbed.

## Validation
- `npx vitest run tests/unit/team-schedule-filter.test.js tests/unit/calendar-day-modal-rsvp.test.js --reporter=dot`
- `SMOKE_BASE_URL=http://127.0.0.1:8000 npx playwright test tests/smoke/team-schedule-calendar.spec.js --config=playwright.smoke.config.js --reporter=line`