### PR TITLE
Allow parent key certificate access

### DIFF
--- a/js/team-access.js
+++ b/js/team-access.js
@@ -128,6 +128,20 @@ export function hasScorekeepingTeamAccess(user, team, game = null, rsvp = null) 
  * Determine user's access level for a team.
  * @returns {{ hasAccess: boolean, accessLevel: 'full'|'scorekeep'|'stream'|'stream-score'|'parent'|null, exitUrl: string }}
  */
+function hasParentTeamAccess(user, teamId) {
+  if (!user || !teamId) return false;
+
+  if ((Array.isArray(user.parentOf) ? user.parentOf : []).some((p) => p?.teamId === teamId)) {
+    return true;
+  }
+
+  return (Array.isArray(user.parentPlayerKeys) ? user.parentPlayerKeys : []).some((key) => {
+    const raw = String(key || '');
+    const separatorIndex = raw.indexOf('::');
+    return separatorIndex > 0 && raw.slice(0, separatorIndex) === teamId;
+  });
+}
+
 export function getTeamAccessInfo(user, team, options = {}) {
   if (!user || !team) {
     return { hasAccess: false, accessLevel: null, exitUrl: 'index.html' };
@@ -153,8 +167,7 @@ export function getTeamAccessInfo(user, team, options = {}) {
     return { hasAccess: true, accessLevel: 'stream', exitUrl: teamExitUrl };
   }
 
-  const isParent = (user.parentOf || []).some((p) => p.teamId === team.id);
-  if (isParent) {
+  if (hasParentTeamAccess(user, team.id)) {
     return { hasAccess: true, accessLevel: 'parent', exitUrl: 'parent-dashboard.html' };
   }
 

--- a/tests/unit/team-access.test.js
+++ b/tests/unit/team-access.test.js
@@ -55,6 +55,22 @@ describe('team access helpers', () => {
     });
   });
 
+  it('returns parent access level for users linked only by parent player keys', () => {
+    expect(getTeamAccessInfo({ uid: 'u4', parentPlayerKeys: ['team-1::p1'] }, TEAM)).toEqual({
+      hasAccess: true,
+      accessLevel: 'parent',
+      exitUrl: 'parent-dashboard.html'
+    });
+  });
+
+  it('does not grant parent access from parent player keys for another team', () => {
+    expect(getTeamAccessInfo({ uid: 'u4', parentPlayerKeys: ['team-2::p1'] }, TEAM)).toEqual({
+      hasAccess: false,
+      accessLevel: null,
+      exitUrl: 'index.html'
+    });
+  });
+
   it('grants limited stream access to selected streaming volunteers without full access', () => {
     const team = { ...TEAM, streamAccessMode: 'selected_volunteers', streamVolunteerEmails: [' Video@Example.com '] };
     const game = { id: 'game-1', status: 'scheduled' };


### PR DESCRIPTION
Closes #1232

## Summary
- Updated team access checks to recognize parent links from `users/{uid}.parentPlayerKeys`.
- Preserved legacy `parentOf` access behavior.
- Added unit coverage for parent-key-only access and cross-team denial.

## Tests
- `npx vitest run tests/unit/team-access.test.js`