### PR TITLE
Preserve Game Plan substitution slots

### DIFF
--- a/.github/workflows/regression-guards.yml
+++ b/.github/workflows/regression-guards.yml
@@ -10,6 +10,9 @@ concurrency:
   group: regression-guards-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   firebase-rules-deploy-guard:
     runs-on: ubuntu-latest

--- a/docs/pr-notes/runs/1239-ci-fix-20260523T111035Z/architecture.md
+++ b/docs/pr-notes/runs/1239-ci-fix-20260523T111035Z/architecture.md
@@ -1,0 +1,10 @@
+# Architecture Notes
+
+## Root cause
+The workflow failure occurred during `actions/checkout@v5`, before application code or the smoke test ran. Checkout could not fetch the PR merge ref because GitHub did not provide usable repository read credentials to the job.
+
+## Minimal change
+Add explicit top-level `permissions: contents: read` to `.github/workflows/regression-guards.yml` so checkout has the read scope it requires.
+
+## Related smoke regression
+Local validation also exposed that `edit-roster.html` eagerly imported Firebase AI modules on page load, which broke the roster fallback smoke test stubs before roster data could render. Lazy-loading the Bulk AI modules only when that tab/action is used preserves page-load behavior and keeps the smoke isolated.

--- a/docs/pr-notes/runs/1239-ci-fix-20260523T111035Z/code-plan.md
+++ b/docs/pr-notes/runs/1239-ci-fix-20260523T111035Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code Plan
+
+## Files
+- `.github/workflows/regression-guards.yml`
+- `edit-roster.html`
+
+## Changes
+1. Add explicit workflow `contents: read` permission for checkout.
+2. Defer Firebase AI imports until Bulk AI is opened or used so normal roster page load does not require AI/Firebase vendor modules.
+
+## Risk
+Low. Workflow permission is read-only. Product change is scoped to Bulk AI module loading and keeps existing Bulk AI behavior behind the same UI path.

--- a/docs/pr-notes/runs/1239-ci-fix-20260523T111035Z/qa.md
+++ b/docs/pr-notes/runs/1239-ci-fix-20260523T111035Z/qa.md
@@ -1,0 +1,9 @@
+# QA Notes
+
+## Validation
+- `git diff --check`
+- Verified PR merge ref exists with `git ls-remote origin refs/pull/1239/merge`
+- Ran `SMOKE_BASE_URL=http://127.0.0.1:4173 npm run test:smoke:team-fallback`
+
+## Expected CI result
+The regression-guards workflow should now pass checkout with explicit repository read permission, then execute the roster/chat/media/replay smoke suite.

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -518,8 +518,6 @@
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { hasFullTeamAccess } from './js/team-access.js';
         import { formatRegistrationRosterImportResults, getRegistrationRosterPlayers, isExternallyLinkedRosterTeam, planRegistrationRosterImport } from './js/edit-roster-registration-import.js?v=1';
-        import { getApp } from './js/vendor/firebase-app.js';
-        import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -1746,11 +1744,33 @@
         // ===== BULK AI UPDATE FUNCTIONALITY =====
 
         let proposedOperations = [];
+        let bulkAiModulesPromise = null;
+        let bulkAiModules = null;
+
+        async function loadBulkAiModules() {
+            if (bulkAiModules) return bulkAiModules;
+            if (!bulkAiModulesPromise) {
+                bulkAiModulesPromise = Promise.all([
+                    import('./js/vendor/firebase-app.js'),
+                    import('./js/vendor/firebase-ai.js')
+                ]).then(([firebaseAppModule, firebaseAiModule]) => {
+                    bulkAiModules = { firebaseAppModule, firebaseAiModule };
+                    return bulkAiModules;
+                }).catch((error) => {
+                    bulkAiModulesPromise = null;
+                    throw error;
+                });
+            }
+            return bulkAiModulesPromise;
+        }
 
         // Tab switching
         document.getElementById('tab-add-player').addEventListener('click', () => activateRosterTab('add-player'));
         document.getElementById('tab-csv-import').addEventListener('click', () => activateRosterTab('csv-import'));
-        document.getElementById('tab-bulk-ai').addEventListener('click', () => activateRosterTab('bulk-ai'));
+        document.getElementById('tab-bulk-ai').addEventListener('click', () => {
+            activateRosterTab('bulk-ai');
+            loadBulkAiModules().catch((error) => console.warn('Unable to preload Bulk AI modules:', error));
+        });
 
         document.getElementById('roster-csv-file').addEventListener('change', async (e) => {
             const file = e.target.files[0];
@@ -1828,6 +1848,10 @@
                     name: p.name,
                     number: p.number || ''
                 }));
+
+                const { firebaseAppModule, firebaseAiModule } = await loadBulkAiModules();
+                const { getApp } = firebaseAppModule;
+                const { getAI, getGenerativeModel, GoogleAIBackend, Schema } = firebaseAiModule;
 
                 // Define JSON schema for structured output
                 const jsonSchema = Schema.object({

--- a/js/game-plan-interop.js
+++ b/js/game-plan-interop.js
@@ -1,7 +1,6 @@
 export function buildRotationPlanFromGamePlan(gamePlan) {
   if (!gamePlan?.lineups || typeof gamePlan.lineups !== 'object') return {};
   const plan = {};
-  const legacyByPeriod = {}; // { period: { posId: { timeNum, playerId } } }
   const numPeriods = Number.parseInt(gamePlan?.numPeriods, 10) || 2;
   const periodPrefix = numPeriods === 4 ? 'Q' : 'H';
 
@@ -15,28 +14,17 @@ export function buildRotationPlanFromGamePlan(gamePlan) {
       return;
     }
 
-    const legacyMatch = /^(\d+)-(\d+)-(.+)$/.exec(key);
+    const legacyMatch = /^(\d+)-(\d+|full)-(.+)$/.exec(key);
     if (!legacyMatch) return;
     const periodNum = Number.parseInt(legacyMatch[1], 10);
-    const timeNum = Number.parseInt(legacyMatch[2], 10);
+    const timeLabel = legacyMatch[2];
     const posId = legacyMatch[3];
     if (!Number.isFinite(periodNum)) return;
 
-    const period = `${periodPrefix}${periodNum}`;
-    if (!legacyByPeriod[period]) legacyByPeriod[period] = {};
-    const existing = legacyByPeriod[period][posId];
-    if (!existing || timeNum > existing.timeNum) {
-      legacyByPeriod[period][posId] = { timeNum, playerId };
-    }
-  });
-
-  Object.entries(legacyByPeriod).forEach(([period, posMap]) => {
+    const basePeriod = `${periodPrefix}${periodNum}`;
+    const period = timeLabel === 'full' ? basePeriod : `${basePeriod} ${timeLabel}'`;
     if (!plan[period]) plan[period] = {};
-    Object.entries(posMap).forEach(([posId, { playerId }]) => {
-      if (!plan[period][posId]) {
-        plan[period][posId] = playerId;
-      }
-    });
+    plan[period][posId] = playerId;
   });
 
   return plan;

--- a/tests/smoke/edit-roster-bulk-ai-reset.spec.js
+++ b/tests/smoke/edit-roster-bulk-ai-reset.spec.js
@@ -93,6 +93,36 @@ const FIREBASE_APP_STUB = `
 export function getApp() {
     return {};
 }
+export function _getProvider() {
+    return { isInitialized: () => false, getImmediate: () => ({}), get: () => Promise.resolve({}), initialize: () => ({}) };
+}
+export function _registerComponent() {}
+export function _removeServiceInstance() {}
+export function registerVersion() {}
+export function _isFirebaseServerApp() { return false; }
+export const SDK_VERSION = 'test';
+`;
+
+const FIREBASE_STUB = `
+export const auth = { currentUser: { uid: 'user-1', email: 'coach@example.com' } };
+export const db = {};
+export const storage = {};
+export function onAuthStateChanged(_auth, callback) { callback(auth.currentUser); return () => {}; }
+export function collection() { return {}; }
+export function doc() { return {}; }
+export function getDoc() { return Promise.resolve({ exists: () => false, data: () => ({}) }); }
+export function getDocs() { return Promise.resolve({ docs: [], empty: true, forEach() {} }); }
+export function setDoc() { return Promise.resolve(); }
+export function updateDoc() { return Promise.resolve(); }
+export function addDoc() { return Promise.resolve({ id: 'doc-1' }); }
+export function deleteDoc() { return Promise.resolve(); }
+export function query() { return {}; }
+export function where() { return {}; }
+export function orderBy() { return {}; }
+export function limit() { return {}; }
+export function onSnapshot(_ref, next) { if (typeof next === 'function') next({ docs: [], empty: true, forEach() {} }); return () => {}; }
+export function serverTimestamp() { return new Date(); }
+export function writeBatch() { return { set() {}, update() {}, delete() {}, commit: () => Promise.resolve() }; }
 `;
 
 const FIREBASE_AI_STUB = `
@@ -142,13 +172,15 @@ export function getGenerativeModel() {
 `;
 
 async function mockEditRosterDependencies(page) {
+    await page.route(/\/js\/telemetry\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: '' }));
+    await page.route(/\/js\/firebase\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_STUB }));
     await page.route(/\/js\/db\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: DB_STUB }));
-    await page.route('**/js/utils.js?v=8', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: UTILS_STUB }));
-    await page.route('**/js/auth.js?v=14', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
-    await page.route('**/js/team-access.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ACCESS_STUB }));
-    await page.route('**/js/team-admin-banner.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ADMIN_BANNER_STUB }));
-    await page.route('**/js/vendor/firebase-app.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_APP_STUB }));
-    await page.route('**/js/vendor/firebase-ai.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_AI_STUB }));
+    await page.route(/\/js\/utils\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: UTILS_STUB }));
+    await page.route(/\/js\/auth\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
+    await page.route(/\/js\/team-access\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ACCESS_STUB }));
+    await page.route(/\/js\/team-admin-banner\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ADMIN_BANNER_STUB }));
+    await page.route(/\/js\/vendor\/firebase-app\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_APP_STUB }));
+    await page.route(/\/js\/vendor\/firebase-ai\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_AI_STUB }));
 }
 
 async function openBulkAiTab(page, baseURL) {

--- a/tests/smoke/team-fallback-regressions.spec.js
+++ b/tests/smoke/team-fallback-regressions.spec.js
@@ -52,8 +52,42 @@ export function hasFullTeamAccess() {
 
 const FIREBASE_APP_STUB = `
 export function getApp() {
-    return {};
+    return { options: { projectId: 'demo-allplays', appId: 'demo-app' }, name: '[DEFAULT]' };
 }
+export function _getProvider() {
+    return { isInitialized: () => false, getImmediate: () => ({}), get: () => Promise.resolve({}), initialize: () => ({}) };
+}
+export function _registerComponent() {}
+export function _removeServiceInstance() {}
+export function registerVersion() {}
+export function _isFirebaseServerApp() { return false; }
+export function getApps() { return [getApp()]; }
+export const SDK_VERSION = 'test';
+export function initializeApp() { return getApp(); }
+`;
+
+const FIREBASE_STUB = `
+export const auth = { currentUser: { uid: 'user-1', email: 'paul@paulsnider.net' } };
+export const db = {};
+export const storage = {};
+export function onAuthStateChanged(_auth, callback) { callback(auth.currentUser); return () => {}; }
+export function collection() { return {}; }
+export function doc() { return {}; }
+export function getDoc() { return Promise.resolve({ exists: () => false, data: () => ({}) }); }
+export function getDocs() { return Promise.resolve({ docs: [], empty: true, forEach() {} }); }
+export function setDoc() { return Promise.resolve(); }
+export function updateDoc() { return Promise.resolve(); }
+export function addDoc() { return Promise.resolve({ id: 'doc-1' }); }
+export function deleteDoc() { return Promise.resolve(); }
+export function query() { return {}; }
+export function where() { return {}; }
+export function orderBy() { return {}; }
+export function limit() { return {}; }
+export function onSnapshot(_ref, next) { if (typeof next === 'function') next({ docs: [], empty: true, forEach() {} }); return () => {}; }
+export function serverTimestamp() { return new Date(); }
+export function writeBatch() { return { set() {}, update() {}, delete() {}, commit: () => Promise.resolve() }; }
+export function getFunctions() { return {}; }
+export function httpsCallable() { return () => Promise.resolve({ data: null }); }
 `;
 
 const FIREBASE_AI_STUB = `
@@ -648,11 +682,13 @@ export function getDefaultLivePeriod() {
 `;
 
 async function routeCommonPageStubs(page) {
-    await page.route('**/js/auth.js?v=14', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
-    await page.route('**/js/utils.js?v=8', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: UTILS_STUB }));
+    await page.route(/\/js\/telemetry\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: '' }));
+    await page.route(/\/js\/firebase\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_STUB }));
+    await page.route(/\/js\/auth\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
+    await page.route(/\/js\/utils\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: UTILS_STUB }));
     await page.route(/\/js\/team-admin-banner\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ADMIN_BANNER_STUB }));
-    await page.route('**/js/vendor/firebase-app.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_APP_STUB }));
-    await page.route('**/js/vendor/firebase-ai.js', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_AI_STUB }));
+    await page.route(/\/js\/vendor\/firebase-app\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_APP_STUB }));
+    await page.route(/\/js\/vendor\/firebase-ai\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: FIREBASE_AI_STUB }));
 }
 
 async function routeLiveGameStubs(page) {

--- a/tests/unit/game-plan-interop.test.js
+++ b/tests/unit/game-plan-interop.test.js
@@ -17,20 +17,22 @@ describe('game plan interop helpers', () => {
     });
   });
 
-  it('consolidates legacy period-time-position keys by keeping the highest timeNum per position', () => {
+  it('preserves legacy period-time-position keys as substitution point labels', () => {
     const plan = buildRotationPlanFromGamePlan({
       numPeriods: 2,
       lineups: {
         '1-7-keeper': 'p1',
-        '1-14-keeper': 'p2',  // higher timeNum — should win for keeper in H1
-        '1-21-keeper': 'p4',  // highest timeNum — wins for keeper in H1
+        '1-14-keeper': 'p2',
+        '1-21-keeper': 'p4',
         '2-7-striker': 'p3'
       }
     });
 
     expect(plan).toEqual({
-      H1: { keeper: 'p4' },
-      H2: { striker: 'p3' }
+      "H1 7'": { keeper: 'p1' },
+      "H1 14'": { keeper: 'p2' },
+      "H1 21'": { keeper: 'p4' },
+      "H2 7'": { striker: 'p3' }
     });
   });
 
@@ -58,24 +60,27 @@ describe('game plan interop helpers', () => {
     });
 
     expect(plan).toEqual({
-      Q1: { pg: 'p1' },
-      Q2: { pg: 'p2' }
+      "Q1 4'": { pg: 'p1' },
+      "Q2 4'": { pg: 'p2' }
     });
   });
 
-  it('prioritizes the latest player assignment (highest timeNum) for legacy data', () => {
+  it('keeps every legacy substitution slot for the same period and position', () => {
     const gamePlan = {
       numPeriods: 2,
       lineups: {
         '1-10-F': 'playerA',
-        '1-20-F': 'playerB',  // higher timeNum — should win
+        '1-20-F': 'playerB',
         '1-5-G': 'playerC',
-        '1-15-G': 'playerD',  // higher timeNum — should win
+        '1-15-G': 'playerD',
       },
     };
 
     expect(buildRotationPlanFromGamePlan(gamePlan)).toEqual({
-      H1: { F: 'playerB', G: 'playerD' },
+      "H1 5'": { G: 'playerC' },
+      "H1 10'": { F: 'playerA' },
+      "H1 15'": { G: 'playerD' },
+      "H1 20'": { F: 'playerB' },
     });
   });
 });


### PR DESCRIPTION
Closes #1238

## Summary
- Preserve legacy Game Plan `period-time-position` lineup keys as Game Day substitution point labels like `H1 7'` instead of collapsing them by period and position.
- Keep all planned assignments for the same period and position so Game Day can render each saved substitution slot.
- Updated interop unit coverage to assert all slots survive import.

## Tests
- `npx vitest run tests/unit/game-plan-interop.test.js tests/unit/game-day-live-substitutions.test.js`