### PR TITLE
Keep sensitive player fields private

### DIFF
--- a/js/db.js
+++ b/js/db.js
@@ -4088,6 +4088,7 @@ export async function getParentDashboardData(userId) {
 export async function updatePlayerProfile(teamId, playerId, data) {
     // Restricted update for parents.
     // SECURITY: sensitive fields must never live on the public player doc.
+    assertNoSensitivePlayerFields(data || {});
     const now = Timestamp.now();
 
     // Public player doc: allow photoUrl and non-sensitive roster profile fields.
@@ -4104,8 +4105,9 @@ export async function updatePlayerProfile(teamId, playerId, data) {
             updatedAt: now
         });
     }
+}
 
-    // Private profile doc: emergencyContact / medicalInfo only.
+export async function updatePlayerPrivateProfile(teamId, playerId, data) {
     const privateUpdate = {};
     if (Object.prototype.hasOwnProperty.call(data, 'emergencyContact')) {
         privateUpdate.emergencyContact = data.emergencyContact || null;
@@ -4114,7 +4116,7 @@ export async function updatePlayerProfile(teamId, playerId, data) {
         privateUpdate.medicalInfo = data.medicalInfo || '';
     }
     if (Object.keys(privateUpdate).length > 0) {
-        privateUpdate.updatedAt = now;
+        privateUpdate.updatedAt = Timestamp.now();
         const ref = doc(db, `teams/${teamId}/players/${playerId}/private/profile`);
         await setDoc(ref, privateUpdate, { merge: true });
     }

--- a/player.html
+++ b/player.html
@@ -236,7 +236,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getGames, getConfigs, updatePlayerProfile, getPlayerPrivateProfile, uploadPlayerPhoto, getUnreadChatCounts, getUserProfile, getRosterFieldDefinitions } from './js/db.js?v=32';
+        import { getTeam, getGame, getPlayers, getGames, getConfigs, updatePlayerProfile, updatePlayerPrivateProfile, getPlayerPrivateProfile, uploadPlayerPhoto, getUnreadChatCounts, getUserProfile, getRosterFieldDefinitions } from './js/db.js?v=33';
         import { collectRosterProfileValues, getRosterProfileValues, normalizeRosterFieldDefinitions, renderRosterProfileFields, validateRosterProfileValues } from './js/roster-profile-fields.js?v=2';
         import { generatePlayerGameInsights } from './js/post-game-insights.js?v=1';
         import { hasPlayerProfileParticipation, collectPlayerVideoClips } from './js/player-profile-stats.js?v=3';
@@ -1262,8 +1262,19 @@
                     privateProfileLoadFailed,
                     privateFieldsDirty
                 });
+                const { emergencyContact, medicalInfo, ...publicData } = data;
+                const privateData = {};
+                if (Object.prototype.hasOwnProperty.call(data, 'emergencyContact')) {
+                    privateData.emergencyContact = emergencyContact;
+                }
+                if (Object.prototype.hasOwnProperty.call(data, 'medicalInfo')) {
+                    privateData.medicalInfo = medicalInfo;
+                }
 
-                await updatePlayerProfile(currentTeamId, currentPlayer.id, data);
+                await updatePlayerProfile(currentTeamId, currentPlayer.id, publicData);
+                if (Object.keys(privateData).length > 0) {
+                    await updatePlayerPrivateProfile(currentTeamId, currentPlayer.id, privateData);
+                }
                 
                 alert('Profile updated!');
                 location.reload();

--- a/tests/unit/player-private-profile-edit.test.js
+++ b/tests/unit/player-private-profile-edit.test.js
@@ -65,15 +65,20 @@ function buildPlayerProfileUpdatePayload(overrides = {}) {
     });
 }
 
-function buildUpdatePlayerProfile() {
+function buildDbProfileUpdateHelpers() {
     const source = readDbSource();
-    const fnSource = extractFunction(source, 'export async function updatePlayerProfile(')
+    const assertFnSource = extractFunction(source, 'function assertNoSensitivePlayerFields(');
+    const publicFnSource = extractFunction(source, 'export async function updatePlayerProfile(')
         .replace('export async function updatePlayerProfile', 'async function updatePlayerProfile');
+    const privateFnSource = extractFunction(source, 'export async function updatePlayerPrivateProfile(')
+        .replace('export async function updatePlayerPrivateProfile', 'async function updatePlayerPrivateProfile');
 
     const factory = new Function('deps', `
         const { Timestamp, updateDoc, doc, db, setDoc } = deps;
-        ${fnSource}
-        return updatePlayerProfile;
+        ${assertFnSource}
+        ${publicFnSource}
+        ${privateFnSource}
+        return { updatePlayerProfile, updatePlayerPrivateProfile };
     `);
 
     const deps = {
@@ -88,7 +93,7 @@ function buildUpdatePlayerProfile() {
 
     return {
         deps,
-        updatePlayerProfile: factory(deps)
+        ...factory(deps)
     };
 }
 
@@ -143,7 +148,7 @@ describe('player private-profile edit payload', () => {
     });
 });
 
-describe('updatePlayerProfile private doc writes', () => {
+describe('player profile private doc writes', () => {
     it('keeps standard sensitive roster fields out of the public player document helper', () => {
         const source = readDbSource();
         const fnSource = extractFunction(source, 'function assertNoSensitivePlayerFields(');
@@ -158,8 +163,17 @@ describe('updatePlayerProfile private doc writes', () => {
         })).toThrow('Do not write sensitive fields to public player doc');
     });
 
+    it('rejects sensitive fields passed to the public player document helper', async () => {
+        const { updatePlayerProfile } = buildDbProfileUpdateHelpers();
+
+        await expect(updatePlayerProfile('team-1', 'player-1', {
+            emergencyContact: { name: 'Pat Parent', phone: '555-0100' },
+            medicalInfo: 'Asthma inhaler'
+        })).rejects.toThrow('Do not write sensitive fields to public player doc');
+    });
+
     it('skips the private profile document when only photoUrl is present', async () => {
-        const { deps, updatePlayerProfile } = buildUpdatePlayerProfile();
+        const { deps, updatePlayerProfile } = buildDbProfileUpdateHelpers();
 
         await updatePlayerProfile('team-1', 'player-1', {
             photoUrl: 'https://img.example/player.jpg'
@@ -167,5 +181,34 @@ describe('updatePlayerProfile private doc writes', () => {
 
         expect(deps.updateDoc).toHaveBeenCalledTimes(1);
         expect(deps.setDoc).not.toHaveBeenCalled();
+    });
+
+    it('writes emergency contact and medical info through the private profile helper', async () => {
+        const { deps, updatePlayerPrivateProfile } = buildDbProfileUpdateHelpers();
+
+        await updatePlayerPrivateProfile('team-1', 'player-1', {
+            emergencyContact: { name: 'Pat Parent', phone: '555-0100' },
+            medicalInfo: 'Asthma inhaler'
+        });
+
+        expect(deps.updateDoc).not.toHaveBeenCalled();
+        expect(deps.setDoc).toHaveBeenCalledWith(
+            'teams/team-1/players/player-1/private/profile',
+            {
+                emergencyContact: { name: 'Pat Parent', phone: '555-0100' },
+                medicalInfo: 'Asthma inhaler',
+                updatedAt: 'ts-now'
+            },
+            { merge: true }
+        );
+    });
+
+    it('wires the edit form to split public and private profile saves', () => {
+        const source = readPlayerPage();
+
+        expect(source).toContain('updatePlayerPrivateProfile');
+        expect(source).toContain('const { emergencyContact, medicalInfo, ...publicData } = data;');
+        expect(source).toContain('await updatePlayerProfile(currentTeamId, currentPlayer.id, publicData);');
+        expect(source).toContain('await updatePlayerPrivateProfile(currentTeamId, currentPlayer.id, privateData);');
     });
 });


### PR DESCRIPTION
Closes #1249

- Split player profile saves so public fields continue through `updatePlayerProfile`.
- Added `updatePlayerPrivateProfile` for emergency contact and medical info writes to `teams/{teamId}/players/{playerId}/private/profile`.
- Added regression coverage proving sensitive fields are rejected from the public player helper and written only through the private helper.

Validation:
- `npx vitest run tests/unit/player-private-profile-edit.test.js --reporter=verbose`
- `node scripts/check-critical-cache-bust.mjs`