### PR TITLE
[codex] Fix public teams query

### DIFF
--- a/js/db.js
+++ b/js/db.js
@@ -508,12 +508,14 @@ export async function getTeams(options = {}) {
     if (includePrivate) {
         teams = (await getDocs(query(teamsRef, orderBy("name")))).docs.map(doc => ({ id: doc.id, ...doc.data() }));
     } else if (publicOnly) {
-        teams = (await getDocs(query(teamsRef, where("isPublic", "==", true), orderBy("name")))).docs.map(doc => ({ id: doc.id, ...doc.data() }));
+        teams = (await getDocs(query(teamsRef, where("isPublic", "==", true)))).docs
+            .map(doc => ({ id: doc.id, ...doc.data() }))
+            .sort((a, b) => String(a.name || '').localeCompare(String(b.name || '')));
     } else {
         const currentUser = auth.currentUser;
         const currentUserEmail = String(currentUser?.email || '').trim().toLowerCase();
         const teamSnapshots = await Promise.all([
-            getDocs(query(teamsRef, where("isPublic", "==", true), orderBy("name"))),
+            getDocs(query(teamsRef, where("isPublic", "==", true))),
             currentUser?.uid
                 ? getDocs(query(teamsRef, where("ownerId", "==", currentUser.uid)))
                 : Promise.resolve({ docs: [] }),

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -377,7 +377,7 @@
             listFamilyShareTokens,
             revokeFamilyShareToken,
             updateFamilyShareTokenCalendars
-        } from './js/db.js?v=33';
+        } from './js/db.js?v=34';
         import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence, getCalendarEventTrackingId, isTrackedCalendarEvent } from './js/utils.js?v=10';
         import {
             getIncentiveRules,

--- a/teams.html
+++ b/teams.html
@@ -102,7 +102,7 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { getTeams } from './js/db.js?v=32';
+    import { getTeams } from './js/db.js?v=34';
     import { renderHeader, renderFooter, escapeHtml, getSafeImageUrl, resolveZip } from './js/utils.js?v=9';
     import { checkAuth } from './js/auth.js?v=15';
 

--- a/tests/unit/family-plan.test.js
+++ b/tests/unit/family-plan.test.js
@@ -374,6 +374,6 @@ describe('family plan helpers', () => {
         expect(html).toContain('function updateShareLinkControlsReady()');
         expect(html).toContain('Link created and copied to clipboard.');
         expect(html).toContain('id="retry-share-links-btn"');
-        expect(html).toContain("from './js/db.js?v=33'");
+        expect(html).toContain("from './js/db.js?v=34'");
     });
 });

--- a/tests/unit/teams-public-visibility.test.js
+++ b/tests/unit/teams-public-visibility.test.js
@@ -12,6 +12,9 @@ describe('public teams visibility', () => {
         expect(source).toContain('const publicOnly = options.publicOnly === true;');
         expect(source).toContain('const includePrivate = options.includePrivate === true || includeInactive;');
         expect(source).toContain('} else if (publicOnly) {');
+        expect(source).toContain('getDocs(query(teamsRef, where("isPublic", "==", true)))');
+        expect(source).toContain('.sort((a, b) => String(a.name || \'\').localeCompare(String(b.name || \'\')))');
+        expect(source).not.toContain('where("isPublic", "==", true), orderBy("name")');
         expect(source).toContain('getDocs(query(teamsRef, where("ownerId", "==", currentUser.uid)))');
         expect(source).toContain('getDocs(query(teamsRef, where("adminEmails", "array-contains", currentUserEmail)))');
         expect(source).not.toContain('const q = includePrivate');
@@ -20,7 +23,7 @@ describe('public teams visibility', () => {
     it('wires Browse Teams to the public-only helper path and keeps a defensive client filter', () => {
         const source = readRepoFile('teams.html');
 
-        expect(source).toContain("import { getTeams } from './js/db.js?v=32';");
+        expect(source).toContain("import { getTeams } from './js/db.js?v=34';");
         expect(source).toContain('getTeams(locationFilter ? { locationFilter, publicOnly: true } : { publicOnly: true })');
         expect(source).toContain('allTeams.filter(t => t.isPublic === true)');
         expect(source).not.toContain('getTeams(locationFilter ? { locationFilter } : {})');


### PR DESCRIPTION
## Summary
- Remove the composite-index `where(isPublic) + orderBy(name)` query from public team reads.
- Keep the same alphabetical behavior by sorting public team results client-side.
- Add regression coverage so the composite query does not come back.

## Root Cause
Live testing the Family Page workflow showed Parent Dashboard hydration was blocked before share links loaded. The console reported a missing Firestore composite index for `teams(isPublic, name)`, triggered by `getTeams({ publicOnly: true })` in the Request Team Access options.

## Validation
- `npx vitest run tests/unit/teams-public-visibility.test.js tests/unit/family-plan.test.js`
- Live Playwright probe reproduced the production blocker before this fix: Parent Dashboard stayed on loading and logged the missing Firestore index error.