### PR TITLE
Restrict private chat access to participants

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -813,17 +813,16 @@ service cloud.firestore {
              );
     }
 
-    function canAccessChatConversation(teamId, conversationData) {
+    function canAccessChatConversation(teamId, conversationId, conversationData) {
       let participantIds = conversationData.get('participantIds', []);
-      let participantRoles = conversationData.get('participantRoles', []);
       return canAccessTeamChat(teamId) &&
              (
+               conversationId == 'team' ||
                conversationData.get('type', '') == 'team' ||
                isTeamOwnerOrAdmin(teamId) ||
                request.auth.uid in participantIds ||
                ('user:' + request.auth.uid) in participantIds ||
-               (request.auth.token.email != null && ('email:' + request.auth.token.email.lower()) in participantIds) ||
-               'team' in participantRoles
+               (request.auth.token.email != null && ('email:' + request.auth.token.email.lower()) in participantIds)
              );
     }
 
@@ -1693,32 +1692,32 @@ service cloud.firestore {
       // remains teams/{teamId}/chatMessages for compatibility; targeted threads
       // store messages under their conversation record.
       match /chatConversations/{conversationId} {
-        allow read: if canAccessChatConversation(teamId, resource.data);
+        allow read: if canAccessChatConversation(teamId, conversationId, resource.data);
         allow create: if canAccessTeamChat(teamId) &&
                          isChatConversationPayloadValid(request.resource.data) &&
-                         canAccessChatConversation(teamId, request.resource.data);
-        allow update: if canAccessChatConversation(teamId, resource.data) &&
-                         canAccessChatConversation(teamId, request.resource.data) &&
+                         canAccessChatConversation(teamId, conversationId, request.resource.data);
+        allow update: if canAccessChatConversation(teamId, conversationId, resource.data) &&
+                         canAccessChatConversation(teamId, conversationId, request.resource.data) &&
                          isChatConversationPayloadValid(request.resource.data) &&
                          request.resource.data.diff(resource.data).affectedKeys()
                            .hasOnly(['name', 'participantIds', 'participantRoles', 'lastMessageAt', 'mutedBy', 'updatedAt']);
         allow delete: if isTeamOwnerOrAdmin(teamId);
 
         match /chatMessages/{messageId} {
-          allow read: if canAccessChatConversation(teamId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data);
-          allow create: if canAccessChatConversation(teamId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data) &&
+          allow read: if canAccessChatConversation(teamId, conversationId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data);
+          allow create: if canAccessChatConversation(teamId, conversationId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data) &&
                            request.resource.data.senderId == request.auth.uid;
-          allow update: if canAccessChatConversation(teamId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data) &&
+          allow update: if canAccessChatConversation(teamId, conversationId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data) &&
                            resource.data.senderId == request.auth.uid &&
                            request.resource.data.diff(resource.data).affectedKeys()
                                .hasOnly(['text', 'editedAt']);
-          allow update: if canAccessChatConversation(teamId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data) &&
+          allow update: if canAccessChatConversation(teamId, conversationId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data) &&
                            request.resource.data.diff(resource.data).affectedKeys()
                                .hasOnly(['deleted']) &&
                            request.resource.data.deleted == true &&
                            (resource.data.senderId == request.auth.uid ||
                             isTeamOwnerOrAdmin(teamId));
-          allow update: if canAccessChatConversation(teamId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data) &&
+          allow update: if canAccessChatConversation(teamId, conversationId, get(/databases/$(database)/documents/teams/$(teamId)/chatConversations/$(conversationId)).data) &&
                            (
                              request.resource.data.diff(resource.data).affectedKeys()
                                .hasOnly([

--- a/js/db.js
+++ b/js/db.js
@@ -4748,8 +4748,7 @@ export async function getChatConversations(teamId, user = null, { team = null, c
             ] : []),
             ...(normalizedEmail ? [
                 query(conversationsRef, where('participantIds', 'array-contains', `email:${normalizedEmail}`), orderBy('updatedAt', 'desc'))
-            ] : []),
-            query(conversationsRef, where('participantRoles', 'array-contains', 'team'), orderBy('updatedAt', 'desc'))
+            ] : [])
         ];
     const snapshots = participantQueries.length > 0
         ? await Promise.all(participantQueries.map((conversationQuery) => getDocs(conversationQuery)))

--- a/js/team-chat-conversations.js
+++ b/js/team-chat-conversations.js
@@ -51,12 +51,9 @@ export function isUserInConversation(conversation, user = {}, { canModerate = fa
     if (canModerate) return true;
 
     const participantIds = Array.isArray(conversation.participantIds) ? conversation.participantIds : [];
-    const participantRoles = Array.isArray(conversation.participantRoles) ? conversation.participantRoles : [];
     return participantIds.includes(user?.uid) ||
         (user?.uid && participantIds.includes(`user:${user.uid}`)) ||
-
-        (user?.email && participantIds.includes(`email:${String(user.email).toLowerCase()}`)) ||
-        participantRoles.includes('team');
+        (user?.email && participantIds.includes(`email:${String(user.email).toLowerCase()}`));
 }
 
 export function getConversationDisplayName(conversation, team = {}) {

--- a/team-chat.html
+++ b/team-chat.html
@@ -304,7 +304,7 @@
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=14';
-        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=32';
+        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=35';
         import { DEFAULT_TEAM_CONVERSATION_ID, buildDefaultTeamConversation, getConversationDisplayName, isDefaultTeamConversation } from './js/team-chat-conversations.js?v=1';
         import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from './js/team-chat-last-read.js?v=3';
         import {

--- a/tests/unit/team-chat-conversations.test.js
+++ b/tests/unit/team-chat-conversations.test.js
@@ -60,7 +60,7 @@ describe('team chat conversations', () => {
         expect(db).toContain("where('participantIds', 'array-contains', user.uid)");
         expect(db).toContain("where('participantIds', 'array-contains', `user:${user.uid}`)");
         expect(db).toContain("where('participantIds', 'array-contains', `email:${normalizedEmail}`)");
-        expect(db).toContain("where('participantRoles', 'array-contains', 'team')");
+        expect(db).not.toContain("where('participantRoles', 'array-contains', 'team')");
         expect(rules).not.toContain("'team' in participantRoles");
     });
 });

--- a/tests/unit/team-chat-conversations.test.js
+++ b/tests/unit/team-chat-conversations.test.js
@@ -45,6 +45,8 @@ describe('team chat conversations', () => {
         const mixedCaseUser = { uid: 'u2', email: 'Parent@Example.com' };
         expect(isUserInConversation({ id: 'group-4', type: 'group', participantIds: ['email:parent@example.com'] }, mixedCaseUser)).toBe(true);
         expect(isUserInConversation({ id: 'group-3', type: 'group', participantIds: [] }, user)).toBe(false);
+        expect(isUserInConversation({ id: 'group-5', type: 'group', participantIds: [], participantRoles: ['team'] }, user)).toBe(false);
+        expect(isUserInConversation({ id: 'direct-1', type: 'direct', participantIds: [], participantRoles: ['team'] }, user)).toBe(false);
         expect(isUserInConversation({ id: 'group-3', type: 'group', participantIds: [] }, user, { canModerate: true })).toBe(true);
         expect(isUserInConversation({ id: DEFAULT_TEAM_CONVERSATION_ID, type: 'team' }, user)).toBe(true);
     });
@@ -53,11 +55,12 @@ describe('team chat conversations', () => {
         const rules = readRepoFile('firestore.rules');
         const db = readRepoFile('js/db.js');
 
-        expect(rules).toContain('allow read: if canAccessChatConversation(teamId, resource.data);');
-        expect(rules).toContain('canAccessChatConversation(teamId, request.resource.data) &&');
+        expect(rules).toContain('allow read: if canAccessChatConversation(teamId, conversationId, resource.data);');
+        expect(rules).toContain('canAccessChatConversation(teamId, conversationId, request.resource.data) &&');
         expect(db).toContain("where('participantIds', 'array-contains', user.uid)");
         expect(db).toContain("where('participantIds', 'array-contains', `user:${user.uid}`)");
         expect(db).toContain("where('participantIds', 'array-contains', `email:${normalizedEmail}`)");
         expect(db).toContain("where('participantRoles', 'array-contains', 'team')");
+        expect(rules).not.toContain("'team' in participantRoles");
     });
 });


### PR DESCRIPTION
Closes #1252

## Summary
- Removed `participantRoles: ['team']` as an access grant for direct and group conversations.
- Kept team-wide conversation access limited to conversations with `id: 'team'` or `type: 'team'`.
- Added regression coverage for malformed private conversations that incorrectly include the `team` role.

## Validation
- `npx vitest run tests/unit/team-chat-conversations.test.js --reporter=verbose`