### PR TITLE
Fix auto-fill live lineup sync

### DIFF
--- a/docs/pr-notes/runs/1255-ci-fix-20260523T180905Z/architecture.md
+++ b/docs/pr-notes/runs/1255-ci-fix-20260523T180905Z/architecture.md
@@ -1,0 +1,12 @@
+# Architecture notes
+
+## Acceptance criteria
+- `cache-bust-guard` must not require an authenticated network fetch when GitHub Actions has already checked out the pull request merge commit.
+- The guard must still compare PR changes against the PR base, not just the last commit.
+
+## Decision
+Use the local pull request merge commit parent (`HEAD^1`) as the diff base when available. On `pull_request` events, `actions/checkout` checks out a synthetic merge commit by default; its first parent is the base branch commit and is sufficient for the cache-bust diff.
+
+## Risk and rollback
+- Risk: if a workflow checks out the PR head instead of the merge commit, `HEAD^1`/`HEAD^2` will not both exist. The script should retain the existing fetch path for that case.
+- Rollback: revert the script change and fix workflow credentials/fetch behavior instead.

--- a/docs/pr-notes/runs/1255-ci-fix-20260523T180905Z/code-plan.md
+++ b/docs/pr-notes/runs/1255-ci-fix-20260523T180905Z/code-plan.md
@@ -1,0 +1,9 @@
+# Code plan
+
+## Minimal implementation
+- Add helpers to detect local commit refs and the pull request merge base parent.
+- In `getDiffBase()`, for `pull_request` events, prefer `HEAD^1...HEAD` when `HEAD` has both merge parents.
+- Keep the existing `origin/<base>...HEAD` fetch path as fallback for non-merge checkout modes.
+
+## Files
+- `scripts/check-critical-cache-bust.mjs`

--- a/docs/pr-notes/runs/1255-ci-fix-20260523T180905Z/qa.md
+++ b/docs/pr-notes/runs/1255-ci-fix-20260523T180905Z/qa.md
@@ -1,0 +1,10 @@
+# QA notes
+
+## Validation plan
+- Run the guard normally: `node scripts/check-critical-cache-bust.mjs`.
+- Simulate a pull request environment with `GITHUB_EVENT_NAME=pull_request GITHUB_BASE_REF=master node scripts/check-critical-cache-bust.mjs`.
+- Run the fast unit suite if dependency state allows: `npm test -- --run` or repo-defined `npm test`.
+
+## Expected behavior
+- The guard passes without attempting a network fetch when local PR merge parents exist.
+- Existing cache-bust detection behavior remains unchanged for changed critical files.

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -2774,6 +2774,8 @@ function autoFillStarters() {
   renderLineup();
   renderLive();
   updateSubsButton();
+  persistLocalTrackerState();
+  broadcastLineupUpdate('Lineup auto-filled');
 }
 
 function playerName(id) {

--- a/scripts/check-critical-cache-bust.mjs
+++ b/scripts/check-critical-cache-bust.mjs
@@ -32,8 +32,25 @@ function execGit(args) {
     return execFileSync('git', args, { encoding: 'utf8' }).trim();
 }
 
+function hasCommitRef(ref) {
+    try {
+        execGit(['rev-parse', '--verify', `${ref}^{commit}`]);
+        return true;
+    } catch {
+        return false;
+    }
+}
+
 function isShallowRepository() {
     return execGit(['rev-parse', '--is-shallow-repository']) === 'true';
+}
+
+function getPullRequestMergeBase() {
+    if (!hasCommitRef('HEAD^1') || !hasCommitRef('HEAD^2')) {
+        return null;
+    }
+
+    return 'HEAD^1';
 }
 
 function refreshBaseRef(baseRef) {
@@ -52,6 +69,11 @@ function getDiffBase() {
     const baseRef = process.env.GITHUB_BASE_REF;
 
     if (eventName === 'pull_request' && baseRef) {
+        const mergeBase = getPullRequestMergeBase();
+        if (mergeBase) {
+            return `${mergeBase}...HEAD`;
+        }
+
         refreshBaseRef(baseRef);
         return `origin/${baseRef}...HEAD`;
     }

--- a/tests/unit/live-tracker-integrity.test.js
+++ b/tests/unit/live-tracker-integrity.test.js
@@ -198,4 +198,12 @@ describe('live tracker integrity helpers', () => {
     expect(quickSubBody).toContain('persistLiveLineup();');
     expect(queuedSubBody).toContain('persistLiveLineup();');
   });
+
+  it('persists and broadcasts lineup after auto-fill starters', () => {
+    const liveTrackerSource = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8');
+    const autoFillBody = liveTrackerSource.match(/function autoFillStarters\([\s\S]*?function playerName/)?.[0] || '';
+
+    expect(autoFillBody).toContain('persistLocalTrackerState();');
+    expect(autoFillBody).toContain("broadcastLineupUpdate('Lineup auto-filled');");
+  });
 });


### PR DESCRIPTION
Closes #1254

## Summary
- Persist the live lineup after Auto-fill adds starters.
- Broadcast a lineup event so public live viewers and resume flows receive the same active lineup as the stat keeper.
- Added regression coverage verifying Auto-fill persists locally and broadcasts the lineup update.

## Tests
- `npx vitest run tests/unit/live-tracker-integrity.test.js --reporter=verbose`