### PR TITLE
Add team fee checkout payload regression tests

### DIFF
--- a/src/app/shared/services/stripe.service.spec.ts
+++ b/src/app/shared/services/stripe.service.spec.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockCallable = vi.fn();
+const mockHttpsCallable = vi.fn(() => mockCallable);
+const mockFunctions = {};
+
+vi.mock('@angular/core', () => ({
+  Injectable: () => () => undefined
+}));
+
+vi.mock('firebase/functions', () => ({
+  getFunctions: vi.fn(() => mockFunctions),
+  httpsCallable: mockHttpsCallable
+}));
+
+vi.mock('../../firebase-config', () => ({
+  app: {}
+}));
+
+const { StripeService } = await import('./stripe.service');
+const { getFunctions, httpsCallable } = await import('firebase/functions');
+
+describe('StripeService team fee checkout', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('calls createStripeTeamFeeCheckout with teamId, batchId, and recipientId', async () => {
+    mockCallable.mockResolvedValueOnce({
+      data: { checkoutUrl: 'https://checkout.stripe.com/team-fee-session' }
+    });
+
+    const service = new StripeService();
+    const checkoutUrl = await service.initiateTeamFeeCheckout('team-123', 'batch-456', 'recipient-789');
+
+    expect(checkoutUrl).toBe('https://checkout.stripe.com/team-fee-session');
+    expect(getFunctions).toHaveBeenCalledWith({});
+    expect(httpsCallable).toHaveBeenCalledWith(mockFunctions, 'createStripeTeamFeeCheckout');
+    expect(mockCallable).toHaveBeenCalledWith({
+      teamId: 'team-123',
+      batchId: 'batch-456',
+      recipientId: 'recipient-789'
+    });
+  });
+
+  it('surfaces an error when checkoutUrl is missing without changing location', async () => {
+    const originalLocation = globalThis.location;
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: { href: 'https://allplays.test/team-fees' }
+    });
+    mockCallable.mockResolvedValueOnce({ data: {} });
+
+    const service = new StripeService();
+
+    await expect(service.initiateTeamFeeCheckout('team-123', 'batch-456', 'recipient-789'))
+      .rejects.toThrow('Stripe checkout URL not returned from function.');
+    expect(globalThis.location.href).toBe('https://allplays.test/team-fees');
+
+    Object.defineProperty(globalThis, 'location', {
+      configurable: true,
+      value: originalLocation
+    });
+  });
+});

--- a/src/app/shared/services/stripe.service.ts
+++ b/src/app/shared/services/stripe.service.ts
@@ -1,8 +1,7 @@
-
 // src/app/shared/services/stripe.service.ts
 import { Injectable } from '@angular/core';
 import { getFunctions, httpsCallable } from 'firebase/functions';
-import { app } from '../../app/firebase-config'; // Adjusted path
+import { app } from '../../firebase-config';
 
 @Injectable({
   providedIn: 'root'
@@ -11,12 +10,12 @@ export class StripeService {
 
   constructor() { }
 
-  async initiateTeamFeeCheckout(teamId: string, teamFeeId: string): Promise<string> {
+  async initiateTeamFeeCheckout(teamId: string, batchId: string, recipientId: string): Promise<string> {
     const functions = getFunctions(app);
     const createCheckoutSession = httpsCallable(functions, 'createStripeTeamFeeCheckout');
 
     try {
-      const result = await createCheckoutSession({ teamId, teamFeeId });
+      const result = await createCheckoutSession({ teamId, batchId, recipientId });
       const data = result.data as { checkoutUrl?: string };
       if (data.checkoutUrl) {
         return data.checkoutUrl;

--- a/src/app/team-fees/team-fees.component.html
+++ b/src/app/team-fees/team-fees.component.html
@@ -10,7 +10,7 @@
     <p>Amount: {{ fee.amount | currency }}</p>
     <p>Status: <span [class.paid]="fee.isPaid" [class.unpaid]="!fee.isPaid">{{ fee.isPaid ? 'Paid' : 'Unpaid' }}</span></p>
 
-    <button *ngIf="!fee.isPaid" (click)="handlePayFee(fee.teamId, fee.id)" [disabled]="isLoadingPayment">
+    <button *ngIf="!fee.isPaid" (click)="handlePayFee(fee.teamId, fee.batchId, fee.recipientId)" [disabled]="isLoadingPayment">
       <span *ngIf="!isLoadingPayment">Pay Team Fee</span>
       <span *ngIf="isLoadingPayment">Initiating Payment...</span>
     </button>

--- a/src/app/team-fees/team-fees.component.spec.ts
+++ b/src/app/team-fees/team-fees.component.spec.ts
@@ -1,0 +1,71 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@angular/core', () => ({
+  Component: () => () => undefined,
+  OnInit: class {}
+}));
+
+vi.mock('../shared/services/stripe.service', () => ({
+  StripeService: class {}
+}));
+
+const { TeamFeesComponent } = await import('./team-fees.component');
+
+const template = readFileSync(resolve(process.cwd(), 'src/app/team-fees/team-fees.component.html'), 'utf8');
+
+describe('TeamFeesComponent checkout flow', () => {
+  let stripeService: { initiateTeamFeeCheckout: ReturnType<typeof vi.fn> };
+  let component: InstanceType<typeof TeamFeesComponent>;
+
+  beforeEach(() => {
+    stripeService = {
+      initiateTeamFeeCheckout: vi.fn().mockResolvedValue('https://checkout.stripe.com/team-fee-session')
+    };
+    component = new TeamFeesComponent(stripeService as never);
+  });
+
+  it('renders a Pay Team Fee button only for unpaid fees', () => {
+    component.ngOnInit();
+
+    expect(template).toContain('*ngIf="!fee.isPaid"');
+    expect(template).toContain('Pay Team Fee');
+    expect(component.teamFees).toEqual([
+      expect.objectContaining({ id: 'fee1', isPaid: false }),
+      expect.objectContaining({ id: 'fee2', isPaid: true }),
+      expect.objectContaining({ id: 'fee3', isPaid: false })
+    ]);
+    expect(component.teamFees.filter((fee) => !fee.isPaid)).toHaveLength(2);
+  });
+
+  it('passes teamId, batchId, and recipientId to StripeService before redirecting', async () => {
+    component.ngOnInit();
+    const unpaidFee = component.teamFees.find((fee) => !fee.isPaid);
+
+    expect(template).toContain('handlePayFee(fee.teamId, fee.batchId, fee.recipientId)');
+    expect(unpaidFee).toEqual(expect.objectContaining({
+      teamId: 'teamA',
+      batchId: 'batch1',
+      recipientId: 'recipient1'
+    }));
+
+    const originalWindow = globalThis.window;
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: { location: { href: 'https://allplays.test/team-fees' } }
+    });
+
+    await component.handlePayFee(unpaidFee!.teamId, unpaidFee!.batchId, unpaidFee!.recipientId);
+
+    expect(stripeService.initiateTeamFeeCheckout).toHaveBeenCalledWith('teamA', 'batch1', 'recipient1');
+    expect(globalThis.window.location.href).toBe('https://checkout.stripe.com/team-fee-session');
+    expect(component.isLoadingPayment).toBe(false);
+    expect(component.paymentErrorMessage).toBeNull();
+
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: originalWindow
+    });
+  });
+});

--- a/src/app/team-fees/team-fees.component.ts
+++ b/src/app/team-fees/team-fees.component.ts
@@ -1,11 +1,12 @@
-
 // src/app/team-fees/team-fees.component.ts
 import { Component, OnInit } from '@angular/core';
-import { StripeService } from '../../app/shared/services/stripe.service'; // Adjusted path
+import { StripeService } from '../shared/services/stripe.service';
 
 interface TeamFee {
   id: string;
   teamId: string;
+  batchId: string;
+  recipientId: string;
   name: string;
   amount: number;
   isPaid: boolean; // Assuming this property
@@ -28,18 +29,18 @@ export class TeamFeesComponent implements OnInit {
     // In a real application, data would be fetched from Firestore or a backend API.
     // For this demonstration, we populate with mock data.
     this.teamFees = [
-      { id: 'fee1', teamId: 'teamA', name: 'Registration Fee', amount: 100, isPaid: false },
-      { id: 'fee2', teamId: 'teamA', name: 'Uniform Fee', amount: 50, isPaid: true },
-      { id: 'fee3', teamId: 'teamB', name: 'Tournament Fee', amount: 75, isPaid: false },
+      { id: 'fee1', teamId: 'teamA', batchId: 'batch1', recipientId: 'recipient1', name: 'Registration Fee', amount: 100, isPaid: false },
+      { id: 'fee2', teamId: 'teamA', batchId: 'batch2', recipientId: 'recipient2', name: 'Uniform Fee', amount: 50, isPaid: true },
+      { id: 'fee3', teamId: 'teamB', batchId: 'batch3', recipientId: 'recipient3', name: 'Tournament Fee', amount: 75, isPaid: false },
     ];
   }
 
-  async handlePayFee(teamId: string, teamFeeId: string): Promise<void> {
+  async handlePayFee(teamId: string, batchId: string, recipientId: string): Promise<void> {
     this.isLoadingPayment = true;
     this.paymentErrorMessage = null; // Clear previous errors
 
     try {
-      const checkoutUrl = await this.stripeService.initiateTeamFeeCheckout(teamId, teamFeeId);
+      const checkoutUrl = await this.stripeService.initiateTeamFeeCheckout(teamId, batchId, recipientId);
       window.location.href = checkoutUrl; // Redirect to Stripe
     } catch (error) {
       console.error('Failed to initiate payment:', error);


### PR DESCRIPTION
Closes #1268

## Summary
- Added TeamFeesComponent regression coverage for unpaid fee Pay Team Fee wiring and redirect behavior.
- Added StripeService regression coverage for the createStripeTeamFeeCheckout payload contract and missing checkoutUrl errors.
- Updated the Angular Team Fees checkout path to pass backend-required teamId, batchId, and recipientId values.

## Validation
- `npx vitest run src/app/team-fees/team-fees.component.spec.ts src/app/shared/services/stripe.service.spec.ts --reporter=verbose`