### PR TITLE
Send email notification when auto-adding existing parent via invite

### DIFF
--- a/edit-roster.html
+++ b/edit-roster.html
@@ -1558,14 +1558,30 @@
                      // Email was provided - try to send email invite
                      if (result.existingUser) {
                          const codeSection = document.getElementById('existing-user-code-section');
+                         // Always send a notification/invite email even for existing users
+                         let emailSentForExisting = false;
+                         try {
+                             await sendInviteEmail(email, result.code, 'parent', {
+                                 teamName: result.teamName,
+                                 playerName: result.playerName
+                             });
+                             emailSentForExisting = true;
+                         } catch (_emailError) {
+                             console.warn('Could not send notification email to existing parent:', _emailError);
+                         }
                          if (result.autoLinked) {
+                             const noticeMsg = emailSentForExisting
+                                 ? ` A notification email was also sent to ${email}.`
+                                 : '';
                              document.getElementById('invite-existing-message').textContent =
-                                 `${email} already has an ALL PLAYS account, so they were linked to ${currentInvitePlayer.name} automatically.`;
+                                 `${email} already has an ALL PLAYS account, so they were linked to ${currentInvitePlayer.name} automatically.${noticeMsg}`;
                              if (codeSection) codeSection.classList.add('hidden');
                              await loadRoster();
                          } else {
-                             document.getElementById('invite-existing-message').textContent =
-                                 `${email} already has an ALL PLAYS account. Share the code below if automatic linking did not complete.`;
+                             const emailMsg = emailSentForExisting
+                                 ? `An invite email was sent to ${email}. They can also use the code below to confirm their access:`
+                                 : `${email} already has an ALL PLAYS account. Share the code below if automatic linking did not complete.`;
+                             document.getElementById('invite-existing-message').textContent = emailMsg;
                              document.getElementById('existing-user-code').textContent = result.code;
                              if (codeSection) codeSection.classList.remove('hidden');
                          }

--- a/tests/unit/parent-invite-auto-link.test.js
+++ b/tests/unit/parent-invite-auto-link.test.js
@@ -49,4 +49,21 @@ describe('parent invite auto-linking', () => {
         expect(source).toContain("codeSection.classList.add('hidden')");
         expect(source).toContain("from './js/db.js?v=32';");
     });
+
+    it('sends a notification email to existing users even when auto-linked', () => {
+        const source = readFileSync(resolve(process.cwd(), 'edit-roster.html'), 'utf8');
+        // Find the existingUser branch in the invite handler
+        const existingUserIdx = source.indexOf('if (result.existingUser)');
+        expect(existingUserIdx).toBeGreaterThanOrEqual(0);
+        const existingUserBlock = source.slice(existingUserIdx, existingUserIdx + 2000);
+        // sendInviteEmail must be called inside the existingUser branch
+        expect(existingUserBlock).toContain('sendInviteEmail(email, result.code');
+        // Email is attempted before the autoLinked branch check
+        expect(existingUserBlock.indexOf('sendInviteEmail')).toBeLessThan(existingUserBlock.indexOf('if (result.autoLinked)'));
+        // Notification message reflects email sent for auto-linked case
+        expect(existingUserBlock).toContain('emailSentForExisting');
+        expect(existingUserBlock).toContain('A notification email was also sent to');
+        // Non-auto-linked message also reflects email
+        expect(existingUserBlock).toContain('An invite email was sent to');
+    });
 });


### PR DESCRIPTION
When a parent is invited and their email already exists in the system,
the invite flow now:
1. Auto-links them to the player (existing behavior)
2. Still sends a notification email so they know they were added

For both the auto-linked and non-auto-linked existing-user paths,
sendInviteEmail is called before checking the auto-link result.
The UI message reflects whether the email was sent successfully.

https://claude.ai/code/session_01A8gYJVUum4udWVxTmK7wQW