### PR TITLE
Render Bulk AI reactivate previews

### DIFF
--- a/edit-roster.html
+++ b/edit-roster.html
@@ -2147,7 +2147,7 @@ EXAMPLES:
                             </div>
                         </div>
                     `;
-                } else if (op.action === 'delete') {
+                } else if (op.action === 'delete' || op.action === 'deactivate') {
                     return `
                         <div class="border border-red-300 bg-red-50 rounded-lg p-3" data-index="${index}">
                             <div class="flex justify-between items-start gap-2">
@@ -2156,6 +2156,22 @@ EXAMPLES:
                                     <div class="text-sm">
                                         Player ID: ${op.playerId}<br>
                                         <span class="text-xs text-gray-600">${op.reason || 'Deactivate from active roster (preserve history)'}</span>
+                                    </div>
+                                </div>
+                                <button onclick="removePlayerOperation(${index})"
+                                    class="text-gray-600 hover:text-gray-800 text-sm font-bold">✕</button>
+                            </div>
+                        </div>
+                    `;
+                } else if (op.action === 'reactivate') {
+                    return `
+                        <div class="border border-emerald-300 bg-emerald-50 rounded-lg p-3" data-index="${index}">
+                            <div class="flex justify-between items-start gap-2">
+                                <div class="flex-1">
+                                    <div class="text-xs font-bold text-emerald-700 uppercase mb-1">▶️ Reactivate</div>
+                                    <div class="text-sm">
+                                        Player ID: ${op.playerId}<br>
+                                        <span class="text-xs text-gray-600">${op.reason || 'Reactivate to active roster'}</span>
                                     </div>
                                 </div>
                                 <button onclick="removePlayerOperation(${index})"

--- a/tests/unit/edit-roster-bulk-ai-reactivate.test.js
+++ b/tests/unit/edit-roster-bulk-ai-reactivate.test.js
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readEditRoster() {
+    return readFileSync(new URL('../../edit-roster.html', import.meta.url), 'utf8');
+}
+
+function getRenderProposedChangesSource() {
+    const source = readEditRoster();
+    return source.slice(
+        source.indexOf('function renderProposedChanges()'),
+        source.indexOf('// Update operation when user edits')
+    );
+}
+
+describe('edit roster Bulk AI proposed changes preview', () => {
+    it('renders reactivate operations before they can be applied', () => {
+        const renderSource = getRenderProposedChangesSource();
+
+        expect(renderSource).toContain("op.action === 'reactivate'");
+        expect(renderSource).toContain('▶️ Reactivate');
+        expect(renderSource).toContain('Reactivate to active roster');
+        expect(renderSource).toContain('border-emerald-300 bg-emerald-50');
+        expect(renderSource).toContain('removePlayerOperation(${index})');
+    });
+
+    it('renders explicit deactivate operations as the same reviewable deactivation card as delete operations', () => {
+        const renderSource = getRenderProposedChangesSource();
+
+        expect(renderSource).toContain("op.action === 'delete' || op.action === 'deactivate'");
+        expect(renderSource).toContain('⏸️ Deactivate');
+    });
+});


### PR DESCRIPTION
Closes #1274

## Summary
- Added a dedicated Bulk AI preview card for `reactivate` operations so users can review them before applying changes.
- Render explicit `deactivate` operations with the existing deactivation review card, matching the apply logic.
- Added regression coverage for Bulk AI reactivate/deactivate preview rendering.

## Validation
- `npx vitest run tests/unit/edit-roster-bulk-ai-reactivate.test.js --reporter=verbose`