### PR TITLE
Load official assignments without team access

### DIFF
--- a/officials.html
+++ b/officials.html
@@ -190,18 +190,25 @@
             currentUser = user;
             renderHeader(document.getElementById('header-container'), user);
             try {
-                [currentTeam, currentUserProfile] = await Promise.all([
-                    getTeam(teamId, { includeInactive: true }),
-                    getUserProfile(user.uid)
-                ]);
+                currentUserProfile = await getUserProfile(user.uid);
+            } catch (error) {
+                console.warn('[officials] Could not load user profile; continuing with assignment-only access.', error);
+                currentUserProfile = null;
+            }
+
+            try {
+                currentTeam = await getTeam(teamId, { includeInactive: true });
                 canClaimOpenSlots = isEligibleOpenSlotParticipant(currentUser, currentUserProfile, currentTeam);
                 if (canClaimOpenSlots) {
                     document.getElementById('officials-intro').textContent = 'Review assigned games, respond to pending assignments, or find open officiating slots.';
                 }
-                await refresh();
             } catch (error) {
-                document.getElementById('officials-status').textContent = error.message || 'Could not load officiating access.';
+                console.warn('[officials] Team details are unavailable; continuing with assignment-only access.', error);
+                currentTeam = null;
+                canClaimOpenSlots = false;
             }
+
+            await refresh();
         }, { skipEmailVerificationCheck: true });
     </script>
 </body>

--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -79,6 +79,15 @@ describe('officiating slots', () => {
         expect(officialsSource).toContain("['pending', 'needs_review'].includes(slot.status)");
     });
 
+    it('loads assigned official games even when private team details are unavailable', () => {
+        const officialsSource = readOfficialsPage();
+
+        expect(officialsSource).not.toContain('[currentTeam, currentUserProfile] = await Promise.all');
+        expect(officialsSource).toContain("console.warn('[officials] Team details are unavailable; continuing with assignment-only access.', error);");
+        expect(officialsSource).toContain('canClaimOpenSlots = false;');
+        expect(officialsSource).toContain('await refresh();');
+    });
+
     it('limits open self-assignment slot claims to eligible team participants', () => {
         const officialsSource = readOfficialsPage();
         const dbSource = readDbSource();


### PR DESCRIPTION
Closes #1276

## Summary
- Stop gating the officials page assignment refresh on a successful private team document read.
- Continue with assignment-only access when team details are unavailable, which keeps assigned officials able to view and respond to games.
- Preserve open-slot claiming only when team/profile access confirms the user is eligible.

## Validation
- `npx vitest run tests/unit/officiating-slots.test.js --reporter=verbose`