### PR TITLE
Defer advanced fee invoice details

### DIFF
--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -890,29 +890,6 @@ async function renderCreateMode({ container, teamId, team, user, getPlayers, cre
                 </label>
             </div>
 
-            <div class="mt-6 grid gap-4 lg:grid-cols-2">
-                <section class="rounded-2xl border border-gray-200 bg-white p-4">
-                    <div class="flex items-start justify-between gap-3">
-                        <div>
-                            <h2 class="font-bold text-gray-900">Invoice line items <span class="text-sm font-normal text-gray-500">optional</span></h2>
-                            <p class="mt-1 text-sm text-gray-500">Add descriptions and amounts when this fee should look like an invoice. If used, items must total the fee amount.</p>
-                        </div>
-                        <button type="button" id="add-line-item" class="shrink-0 rounded-lg bg-gray-900 px-3 py-2 text-sm font-semibold text-white hover:bg-gray-800">Add item</button>
-                    </div>
-                    <div id="line-items-list" class="mt-4 space-y-3"></div>
-                </section>
-                <section class="rounded-2xl border border-gray-200 bg-white p-4">
-                    <div class="flex items-start justify-between gap-3">
-                        <div>
-                            <h2 class="font-bold text-gray-900">Installment schedule <span class="text-sm font-normal text-gray-500">optional</span></h2>
-                            <p class="mt-1 text-sm text-gray-500">Add due dates and amounts for planned installments. If used, installments must total the fee amount.</p>
-                        </div>
-                        <button type="button" id="add-installment" class="shrink-0 rounded-lg bg-gray-900 px-3 py-2 text-sm font-semibold text-white hover:bg-gray-800">Add installment</button>
-                    </div>
-                    <div id="installments-list" class="mt-4 space-y-3"></div>
-                </section>
-            </div>
-
             <div class="mt-6">
                 <div class="mb-3 flex items-center justify-between gap-3">
                     <h2 class="text-lg font-bold text-gray-900">Recipients</h2>
@@ -920,6 +897,33 @@ async function renderCreateMode({ container, teamId, team, user, getPlayers, cre
                 </div>
                 <div class="grid gap-3 md:grid-cols-2">${renderRosterOptions(players)}</div>
             </div>
+
+            <details id="advanced-invoice-details" class="mt-6 rounded-2xl border border-gray-200 bg-gray-50 p-4">
+                <summary class="cursor-pointer text-lg font-bold text-gray-900">Advanced invoice details <span class="text-sm font-normal text-gray-500">optional</span></summary>
+                <p class="mt-2 text-sm text-gray-500">Add invoice line items or installment schedules only when this fee needs extra detail. If used, each section must total the fee amount.</p>
+                <div class="mt-4 grid gap-4 lg:grid-cols-2">
+                    <section class="rounded-2xl border border-gray-200 bg-white p-4">
+                        <div class="flex items-start justify-between gap-3">
+                            <div>
+                                <h2 class="font-bold text-gray-900">Invoice line items <span class="text-sm font-normal text-gray-500">optional</span></h2>
+                                <p class="mt-1 text-sm text-gray-500">Add descriptions and amounts when this fee should look like an invoice. If used, items must total the fee amount.</p>
+                            </div>
+                            <button type="button" id="add-line-item" class="shrink-0 rounded-lg bg-gray-900 px-3 py-2 text-sm font-semibold text-white hover:bg-gray-800">Add item</button>
+                        </div>
+                        <div id="line-items-list" class="mt-4 space-y-3"></div>
+                    </section>
+                    <section class="rounded-2xl border border-gray-200 bg-white p-4">
+                        <div class="flex items-start justify-between gap-3">
+                            <div>
+                                <h2 class="font-bold text-gray-900">Installment schedule <span class="text-sm font-normal text-gray-500">optional</span></h2>
+                                <p class="mt-1 text-sm text-gray-500">Add due dates and amounts for planned installments. If used, installments must total the fee amount.</p>
+                            </div>
+                            <button type="button" id="add-installment" class="shrink-0 rounded-lg bg-gray-900 px-3 py-2 text-sm font-semibold text-white hover:bg-gray-800">Add installment</button>
+                        </div>
+                        <div id="installments-list" class="mt-4 space-y-3"></div>
+                    </section>
+                </div>
+            </details>
 
             <div class="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-end">
                 <a href="dashboard.html" class="rounded-xl border border-gray-300 px-5 py-3 text-center font-semibold text-gray-700 hover:bg-gray-50">Cancel</a>
@@ -929,6 +933,7 @@ async function renderCreateMode({ container, teamId, team, user, getPlayers, cre
     `;
 
     const form = document.getElementById('team-fee-form');
+    const advancedInvoiceDetails = document.getElementById('advanced-invoice-details');
     const lineItemsList = document.getElementById('line-items-list');
     const installmentsList = document.getElementById('installments-list');
 
@@ -960,6 +965,7 @@ async function renderCreateMode({ container, teamId, team, user, getPlayers, cre
 
             const batch = await createTeamFeeBatch(teamId, draft, recipients, user);
             form.reset();
+            advancedInvoiceDetails.open = false;
             lineItemsList.innerHTML = '';
             installmentsList.innerHTML = '';
             showHtmlMessage(renderCreatedTeamFeeBatchSuccess(teamId, batch.id), 'success');

--- a/tests/unit/team-fees-admin.test.js
+++ b/tests/unit/team-fees-admin.test.js
@@ -1,6 +1,8 @@
 // tests/unit/team-fees-admin.test.js
+import { readFileSync } from 'node:fs';
+import { JSDOM } from 'jsdom';
 import { describe, it, expect } from 'vitest'; // Import Vitest globals
-import { buildManualPaymentUpdate, buildOnlineRefundRequest, getRecipientRefundableCents, isOnlineRefundEligible, buildOfflineRefundUpdate, buildTeamFeePaymentSummaryRows, serializeTeamFeePaymentSummaryCsv, buildTeamFeePaymentSummaryCsv, escapeCsvValue, registerTeamFeesAdminPageHandlers } from '../../js/team-fees-admin.js'; // Adjusted path
+import { buildManualPaymentUpdate, buildOnlineRefundRequest, getRecipientRefundableCents, isOnlineRefundEligible, buildOfflineRefundUpdate, buildTeamFeePaymentSummaryRows, serializeTeamFeePaymentSummaryCsv, buildTeamFeePaymentSummaryCsv, escapeCsvValue, registerTeamFeesAdminPageHandlers, normalizeTeamFeeDraft } from '../../js/team-fees-admin.js'; // Adjusted path
 
 describe('team fees admin page routing', () => {
     it('reinitializes when same-page manage links update the hash', () => {
@@ -13,6 +15,77 @@ describe('team fees admin page routing', () => {
 
         expect(registrations.map(({ eventName }) => eventName)).toEqual(['DOMContentLoaded', 'hashchange']);
         expect(registrations[1].handler).toBe(registrations[0].handler);
+    });
+});
+
+describe('create offline team fee form', () => {
+    it('keeps advanced invoice controls collapsed by default and available after expansion', () => {
+        const source = readFileSync(new URL('../../js/team-fees-admin.js', import.meta.url), 'utf8');
+        const advancedSection = source.match(/<details id="advanced-invoice-details"[\s\S]*?<\/details>/)?.[0];
+
+        expect(advancedSection).toBeTruthy();
+
+        const { document } = new JSDOM(advancedSection).window;
+        const details = document.querySelector('#advanced-invoice-details');
+        const summary = details.querySelector('summary');
+
+        expect(details.hasAttribute('open')).toBe(false);
+        expect(details.open).toBe(false);
+        expect(summary.textContent).toContain('Advanced invoice details');
+        expect(details.querySelector('#add-line-item').textContent).toContain('Add item');
+        expect(details.querySelector('#add-installment').textContent).toContain('Add installment');
+    });
+});
+
+describe('normalizeTeamFeeDraft', () => {
+    const simpleDraft = {
+        title: 'Tournament dues',
+        amount: '25.00',
+        dueDate: '2026-06-01',
+        recipientIds: ['player-1']
+    };
+
+    it('allows a simple offline fee without line items or installments', () => {
+        const draft = normalizeTeamFeeDraft({
+            ...simpleDraft,
+            lineItems: [],
+            installments: []
+        });
+
+        expect(draft).toMatchObject({
+            title: 'Tournament dues',
+            amountCents: 2500,
+            dueDate: '2026-06-01',
+            recipientIds: ['player-1'],
+            lineItems: [],
+            installments: []
+        });
+    });
+
+    it('requires populated line items and installments to match the fee amount', () => {
+        expect(normalizeTeamFeeDraft({
+            ...simpleDraft,
+            lineItems: [{ description: 'Gym rental', amount: '15.00' }, { description: 'Refs', amount: '10.00' }],
+            installments: [{ dueDate: '2026-06-01', amount: '10.00' }, { dueDate: '2026-07-01', amount: '15.00' }]
+        })).toMatchObject({
+            lineItems: [
+                { description: 'Gym rental', amountCents: 1500 },
+                { description: 'Refs', amountCents: 1000 }
+            ],
+            installments: [
+                { dueDate: '2026-06-01', amountCents: 1000 },
+                { dueDate: '2026-07-01', amountCents: 1500 }
+            ]
+        });
+
+        expect(() => normalizeTeamFeeDraft({
+            ...simpleDraft,
+            lineItems: [{ description: 'Gym rental', amount: '10.00' }]
+        })).toThrow('Line items must add up to the total fee amount.');
+        expect(() => normalizeTeamFeeDraft({
+            ...simpleDraft,
+            installments: [{ dueDate: '2026-06-01', amount: '10.00' }]
+        })).toThrow('Installments must add up to the total fee amount.');
     });
 });
 


### PR DESCRIPTION
Closes #1278

## What changed
- Moved optional invoice line items and installment schedule behind a collapsed `Advanced invoice details` disclosure after recipient selection.
- Kept the existing add-row controls and validation behavior available when expanded.
- Added focused coverage for collapsed advanced controls and draft normalization rules.

## Validation
- `npx vitest run tests/unit/team-fees-admin.test.js --reporter=verbose`