### PR TITLE
Label fouled-out players in tracker

### DIFF
--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -195,7 +195,7 @@ function liveCard(id) {
   // Foul pill with warning colors
   const fouls = s.fouls || 0;
   const foulBgClass = fouls >= 5 ? 'bg-red-600 text-white' : fouls >= 4 ? 'bg-amber-500 text-white' : 'bg-sand';
-  const foulWarning = fouls >= 5 ? ' ⚠️' : fouls >= 4 ? ' ⚠️' : '';
+  const foulWarning = fouls >= 5 ? ' FOULED OUT!' : fouls >= 4 ? ' ⚠️' : '';
   const foulPill = `<div class="${foulBgClass} rounded-lg py-1">FLS <span class="font-display text-sm">${fouls}${foulWarning}</span></div>`;
 
   const btnHtml = cols.map(col => {
@@ -262,7 +262,7 @@ function renderOpponents() {
     // Add fouls to quick stats display
     const fouls = s.fouls || 0;
     const foulBgClass = fouls >= 5 ? 'bg-red-600 text-white' : fouls >= 4 ? 'bg-amber-500 text-white' : '';
-    const foulWarning = fouls >= 5 ? ' ⚠️' : fouls >= 4 ? ' ⚠️' : '';
+    const foulWarning = fouls >= 5 ? ' FOULED OUT!' : fouls >= 4 ? ' ⚠️' : '';
     const foulDisplay = foulBgClass ? `<span class="${foulBgClass} px-1 rounded">FLS ${fouls}${foulWarning}</span>` : `FLS ${fouls}`;
     const quickLineWithFouls = quickLine ? `${quickLine} · ${foulDisplay}` : foulDisplay;
 

--- a/tests/unit/live-tracker-foul-warning.test.js
+++ b/tests/unit/live-tracker-foul-warning.test.js
@@ -1,11 +1,14 @@
 import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 
-const source = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8');
+const liveTrackerSource = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8');
+const basketballTrackerSource = readFileSync(new URL('../../js/track-basketball.js', import.meta.url), 'utf8');
 
-describe('live tracker foul warnings', () => {
+describe('tracker foul warnings', () => {
     it('labels 5+ fouls as fouled out instead of only showing a warning icon', () => {
-        expect(source).toContain("fouls >= 5 ? ' FOULED OUT!'");
-        expect(source).not.toContain("fouls >= 5 ? ' ⚠️'");
+        for (const source of [liveTrackerSource, basketballTrackerSource]) {
+            expect(source).toContain("fouls >= 5 ? ' FOULED OUT!'");
+            expect(source).not.toContain("fouls >= 5 ? ' ⚠️'");
+        }
     });
 });


### PR DESCRIPTION
Closes #1280

- Updated the basketball tracker foul display to show `FOULED OUT!` at 5+ fouls for live player cards and opponent quick stats.
- Extended the existing foul-warning regression test to cover both `live-tracker.js` and `track-basketball.js` so 5+ fouls cannot regress to the warning icon-only state.

Validation:
- `npx vitest run tests/unit/live-tracker-foul-warning.test.js --reporter=verbose`