### PR TITLE
Fix Game Day lineup planner interop

### DIFF
--- a/docs/pr-notes/runs/1284-ci-fix-20260524T100813Z/architecture.md
+++ b/docs/pr-notes/runs/1284-ci-fix-20260524T100813Z/architecture.md
@@ -1,0 +1,11 @@
+# Architecture Notes
+
+## Acceptance Criteria
+- `game-plan.html` continues to normalize saved game plan lineups through `normalizeLineupsForGamePlanPlanner` when loading a game.
+- Unit harness mirrors the browser module scope closely enough to execute `loadGame` without undefined imported helpers.
+
+## Architecture Decision
+The production code is already correct: `game-plan.html` imports `normalizeLineupsForGamePlanPlanner` from `js/game-plan-interop.js`. The failure is test drift caused by extracting `loadGame` into a `new Function` harness without injecting that imported symbol.
+
+## Risk And Rollback
+Risk is limited to the unit test harness. Rollback is reverting the test import and dependency injection if a better harness abstraction replaces the source extraction approach.

--- a/docs/pr-notes/runs/1284-ci-fix-20260524T100813Z/code-plan.md
+++ b/docs/pr-notes/runs/1284-ci-fix-20260524T100813Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code Plan
+
+## Root Cause
+`game-plan-switching.test.js` extracts `loadGame` from `game-plan.html` and executes it in a synthetic `new Function` scope. PR code added a call to imported helper `normalizeLineupsForGamePlanPlanner`, but the test harness did not provide that symbol.
+
+## Implementation Plan
+- Import `normalizeLineupsForGamePlanPlanner` in the test file.
+- Add it to the harness dependency object.
+- Bind it inside the synthetic function before evaluating `loadGame`.
+
+## Scope
+Only the failing unit test harness changes. No production behavior changes.

--- a/docs/pr-notes/runs/1284-ci-fix-20260524T100813Z/qa.md
+++ b/docs/pr-notes/runs/1284-ci-fix-20260524T100813Z/qa.md
@@ -1,0 +1,8 @@
+# QA Notes
+
+## QA Plan
+- Run the focused failing unit file: `npx vitest run tests/unit/game-plan-switching.test.js --reporter=verbose`.
+- Confirm all six game switching tests pass, including lineup clearing, auto-save cancellation, calendar read-only handling, regular DB save enablement, and shared game notice.
+
+## Result
+Focused unit test passed: 6/6 tests green.

--- a/docs/pr-notes/runs/1284-remediator-20260524T201340Z/architecture.md
+++ b/docs/pr-notes/runs/1284-remediator-20260524T201340Z/architecture.md
@@ -1,0 +1,5 @@
+# Architecture
+
+- `game-plan.html` imports and calls `normalizeLineupsForGamePlanPlanner` during `loadGame` to normalize persisted lineup keys.
+- The switching test extracts `loadGame` with `new Function(...)`, so the harness must explicitly bind imported module helpers into the generated function scope.
+- Current branch already injects `normalizeLineupsForGamePlanPlanner` from `deps` into the harness, matching the existing dependency injection pattern for DOM, render, formatting, and autosave collaborators.

--- a/docs/pr-notes/runs/1284-remediator-20260524T201340Z/code-plan.md
+++ b/docs/pr-notes/runs/1284-remediator-20260524T201340Z/code-plan.md
@@ -1,0 +1,5 @@
+# Code Plan
+
+- Inspect `game-plan.html` and `tests/unit/game-plan-switching.test.js` for the unresolved helper dependency.
+- Confirm the harness imports `normalizeLineupsForGamePlanPlanner`, exposes it on `deps`, and binds it inside the generated `new Function` scope before evaluating extracted `loadGame`.
+- If missing, add that injection only. If present, classify the review item as already satisfied by the current branch and commit the required remediation notes.

--- a/docs/pr-notes/runs/1284-remediator-20260524T201340Z/qa.md
+++ b/docs/pr-notes/runs/1284-remediator-20260524T201340Z/qa.md
@@ -1,0 +1,5 @@
+# QA
+
+- Run targeted unit coverage: `npx vitest run tests/unit/game-plan-switching.test.js --reporter=verbose`.
+- Passing criteria: the switching suite executes all assertions and does not fail before assertions with a missing helper reference.
+- Regression surface: game switching state reset, autosave cancellation, save-state handling for calendar/shared games, and lineup normalization dependency wiring.

--- a/docs/pr-notes/runs/1284-remediator-20260524T201340Z/requirements.md
+++ b/docs/pr-notes/runs/1284-remediator-20260524T201340Z/requirements.md
@@ -1,0 +1,5 @@
+# Requirements
+
+- Address review thread `PRRT_kwDOQe-T586EXee2` by ensuring the `loadGame` unit-test harness provides every dependency referenced by the extracted `loadGame` body.
+- Preserve production behavior in `game-plan.html`; no unrelated UI or planner behavior changes.
+- Validation must prove `tests/unit/game-plan-switching.test.js` runs without `ReferenceError: normalizeLineupsForGamePlanPlanner is not defined`.

--- a/game-plan.html
+++ b/game-plan.html
@@ -290,6 +290,7 @@
         import { getTeamAccessInfo } from './js/team-access.js';
         import { createAutoSaveController } from './js/game-plan-autosave.js?v=1';
         import { buildGamePlanIntervals } from './js/game-plan-intervals.js?v=1';
+        import { normalizeLineupsForGamePlanPlanner } from './js/game-plan-interop.js?v=1';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -593,10 +594,10 @@
             gamePlan = game.gamePlan
                 ? {
                     ...baseGamePlan,
-                    ...game.gamePlan,
-                    lineups: { ...(game.gamePlan.lineups || {}) }
+                    ...game.gamePlan
                 }
                 : baseGamePlan;
+            gamePlan.lineups = normalizeLineupsForGamePlanPlanner(gamePlan);
 
             recentAssignments.clear();
             intervalsCache = [];

--- a/js/game-plan-interop.js
+++ b/js/game-plan-interop.js
@@ -1,3 +1,52 @@
+import { buildGamePlanIntervals } from './game-plan-intervals.js';
+
+function parseCurrentShapeKey(key) {
+  const match = /^([HQ])(\d+)(?: (\d+)')?-(.+)$/.exec(key);
+  if (!match) return null;
+  return {
+    periodNum: Number.parseInt(match[2], 10),
+    time: match[3] ? Number.parseInt(match[3], 10) : null,
+    posId: match[4]
+  };
+}
+
+function plannerKeyForCurrentShapeKey(key, intervals) {
+  const parsed = parseCurrentShapeKey(key);
+  if (!parsed || !Number.isFinite(parsed.periodNum)) return null;
+
+  const periodIntervals = intervals.filter(interval => interval.period === parsed.periodNum);
+  if (periodIntervals.length === 0) return null;
+
+  const interval = parsed.time == null
+    ? periodIntervals[0]
+    : periodIntervals.find(candidate => Number(candidate.time) === parsed.time);
+
+  return interval ? `${interval.key}-${parsed.posId}` : null;
+}
+
+export function normalizeLineupsForGamePlanPlanner(gamePlan) {
+  if (!gamePlan?.lineups || typeof gamePlan.lineups !== 'object') return {};
+
+  const intervals = buildGamePlanIntervals(gamePlan);
+  const normalized = {};
+  const legacyAndOtherEntries = [];
+
+  Object.entries(gamePlan.lineups).forEach(([key, playerId]) => {
+    const plannerKey = plannerKeyForCurrentShapeKey(key, intervals);
+    if (plannerKey) {
+      normalized[plannerKey] = playerId;
+    } else {
+      legacyAndOtherEntries.push([key, playerId]);
+    }
+  });
+
+  legacyAndOtherEntries.forEach(([key, playerId]) => {
+    normalized[key] = playerId;
+  });
+
+  return normalized;
+}
+
 export function buildRotationPlanFromGamePlan(gamePlan) {
   if (!gamePlan?.lineups || typeof gamePlan.lineups !== 'object') return {};
   const plan = {};

--- a/tests/unit/game-plan-interop.test.js
+++ b/tests/unit/game-plan-interop.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { buildRotationPlanFromGamePlan } from '../../js/game-plan-interop.js';
+import {
+  buildRotationPlanFromGamePlan,
+  normalizeLineupsForGamePlanPlanner
+} from '../../js/game-plan-interop.js';
 
 describe('game plan interop helpers', () => {
   it('reads current game-day lineups shape', () => {
@@ -47,6 +50,54 @@ describe('game plan interop helpers', () => {
     expect(plan).toEqual({
       "H1 7'": { keeper: 'p1' },
       "H1 14'": { keeper: 'p2' }
+    });
+  });
+
+  it('maps Game Day half lineup keys into planner interval keys', () => {
+    const lineups = normalizeLineupsForGamePlanPlanner({
+      numPeriods: 2,
+      periodDuration: 25,
+      subTimes: [7, 14, 21],
+      lineups: {
+        'H1-keeper': 'p1',
+        'H2-striker': 'p2'
+      }
+    });
+
+    expect(lineups).toEqual({
+      '1-7-keeper': 'p1',
+      '2-7-striker': 'p2'
+    });
+  });
+
+  it('lets existing planner keys override older Game Day keys for the same cell', () => {
+    const lineups = normalizeLineupsForGamePlanPlanner({
+      numPeriods: 2,
+      periodDuration: 25,
+      subTimes: [7, 14, 21],
+      lineups: {
+        'H1-keeper': 'old-player',
+        '1-7-keeper': 'new-player'
+      }
+    });
+
+    expect(lineups).toEqual({
+      '1-7-keeper': 'new-player'
+    });
+  });
+
+  it('maps saved Game Day substitution labels into matching planner interval keys', () => {
+    const lineups = normalizeLineupsForGamePlanPlanner({
+      numPeriods: 2,
+      periodDuration: 25,
+      subTimes: [7, 14, 21],
+      lineups: {
+        "H1 14'-keeper": 'p2'
+      }
+    });
+
+    expect(lineups).toEqual({
+      '1-14-keeper': 'p2'
     });
   });
 

--- a/tests/unit/game-plan-switching.test.js
+++ b/tests/unit/game-plan-switching.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
+import { normalizeLineupsForGamePlanPlanner } from '../../js/game-plan-interop.js';
 
 function readGamePlanPage() {
     return readFileSync(new URL('../../game-plan.html', import.meta.url), 'utf8');
@@ -109,6 +110,7 @@ function buildHarness(overrides = {}) {
         console: {
             error: vi.fn()
         },
+        normalizeLineupsForGamePlanPlanner,
         ...overrides
     };
 
@@ -133,6 +135,7 @@ function buildHarness(overrides = {}) {
         const updatePlanSummary = deps.updatePlanSummary;
         const autoSave = deps.autoSave;
         const console = deps.console;
+        const normalizeLineupsForGamePlanPlanner = deps.normalizeLineupsForGamePlanPlanner;
 
         ${createDefaultGamePlanSource}
 

--- a/tests/unit/game-plan-switching.test.js
+++ b/tests/unit/game-plan-switching.test.js
@@ -223,6 +223,27 @@ describe('game plan game switching', () => {
         expect(harness.getState().currentGameId).toBe('game-b');
     });
 
+    it('normalizes saved lineup keys through the loadGame harness dependency', async () => {
+        const { harness } = buildHarness();
+
+        await harness.loadGame({
+            id: 'game-a',
+            opponent: 'Sharks',
+            date: '2026-04-04T19:00:00.000Z',
+            gamePlan: {
+                numPeriods: 2,
+                periodDuration: 25,
+                subTimes: [7, 14, 21],
+                formationId: 'soccer-9v9',
+                lineups: { "H1 7'-keeper": 'player-1' }
+            }
+        });
+
+        expect(harness.getState().gamePlan.lineups).toEqual({
+            '1-7-keeper': 'player-1'
+        });
+    });
+
     it('cancels any pending auto-save when switching games', async () => {
         const { harness, deps } = buildHarness();
 


### PR DESCRIPTION
Closes #1283

## Summary
- Normalize Game Day lineup keys like `H1-keeper` into Game Plan planner interval keys like `1-7-keeper` when loading the planner.
- Preserve planner interval edits over older Game Day period keys for the same cell so later Game Plan saves win.
- Added regression coverage for current-shape keys, conflict override behavior, and saved substitution labels.

## Validation
- `npx vitest run tests/unit/game-plan-interop.test.js tests/unit/game-plan-playing-time-summary.test.js --reporter=verbose`