### PR TITLE
Scope team fee checkout loading state

### DIFF
--- a/docs/pr-notes/runs/1287-remediator-20260524T190408Z/architecture.md
+++ b/docs/pr-notes/runs/1287-remediator-20260524T190408Z/architecture.md
@@ -1,0 +1,10 @@
+# Architecture
+
+Decision: keep the single `pendingPaymentFeeId` as the checkout lock and selected-fee loading indicator.
+
+Implementation:
+- Add a component-level pending predicate based on `pendingPaymentFeeId !== null`.
+- Guard `handlePayFee` before mutating state so overlapping calls return immediately.
+- Disable all Pay buttons while any checkout is pending, while `isPaymentLoading(fee.id)` continues to scope the loading label to the selected fee.
+
+Risk and rollback: minimal component-only change. Roll back by reverting this commit.

--- a/docs/pr-notes/runs/1287-remediator-20260524T190408Z/code-plan.md
+++ b/docs/pr-notes/runs/1287-remediator-20260524T190408Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code Plan
+
+1. Add `isPaymentPending()` helper to `TeamFeesComponent`.
+2. Early-return from `handlePayFee` if `isPaymentPending()` is true.
+3. Change the Pay button disabled binding to `isPaymentPending()`.
+4. Update unit tests for the overlap guard and disabled binding.

--- a/docs/pr-notes/runs/1287-remediator-20260524T190408Z/qa.md
+++ b/docs/pr-notes/runs/1287-remediator-20260524T190408Z/qa.md
@@ -1,0 +1,8 @@
+# QA
+
+Regression tests:
+- Verify the template disables buttons using the global pending predicate while preserving scoped loading label checks.
+- Verify overlapping `handlePayFee` calls result in a single Stripe checkout invocation and keep the first fee pending until the first promise resolves.
+- Verify error path still clears pending state and surfaces the existing error message.
+
+Validation command: `npx vitest run src/app/team-fees/team-fees.component.spec.ts --reporter=verbose`.

--- a/docs/pr-notes/runs/1287-remediator-20260524T190408Z/requirements.md
+++ b/docs/pr-notes/runs/1287-remediator-20260524T190408Z/requirements.md
@@ -1,0 +1,8 @@
+# Requirements
+
+Acceptance criteria:
+- Only one team-fee checkout request may be in flight at a time.
+- A second click while any checkout is pending must not call Stripe again.
+- The selected fee still shows scoped loading text.
+- Other unpaid fee buttons are disabled during the pending checkout without showing the selected fee loading label.
+- On success or failure, pending state clears and existing error behavior is preserved.

--- a/src/app/team-fees/team-fees.component.html
+++ b/src/app/team-fees/team-fees.component.html
@@ -10,7 +10,7 @@
     <p>Amount: {{ fee.amount | currency }}</p>
     <p>Status: <span [class.paid]="fee.isPaid" [class.unpaid]="!fee.isPaid">{{ fee.isPaid ? 'Paid' : 'Unpaid' }}</span></p>
 
-    <button *ngIf="!fee.isPaid" (click)="handlePayFee(fee)" [disabled]="isPaymentLoading(fee.id)">
+    <button *ngIf="!fee.isPaid" (click)="handlePayFee(fee)" [disabled]="isPaymentPending()">
       <span *ngIf="!isPaymentLoading(fee.id)">Pay Team Fee</span>
       <span *ngIf="isPaymentLoading(fee.id)">Initiating Payment...</span>
     </button>

--- a/src/app/team-fees/team-fees.component.html
+++ b/src/app/team-fees/team-fees.component.html
@@ -10,9 +10,9 @@
     <p>Amount: {{ fee.amount | currency }}</p>
     <p>Status: <span [class.paid]="fee.isPaid" [class.unpaid]="!fee.isPaid">{{ fee.isPaid ? 'Paid' : 'Unpaid' }}</span></p>
 
-    <button *ngIf="!fee.isPaid" (click)="handlePayFee(fee.teamId, fee.batchId, fee.recipientId)" [disabled]="isLoadingPayment">
-      <span *ngIf="!isLoadingPayment">Pay Team Fee</span>
-      <span *ngIf="isLoadingPayment">Initiating Payment...</span>
+    <button *ngIf="!fee.isPaid" (click)="handlePayFee(fee)" [disabled]="isPaymentLoading(fee.id)">
+      <span *ngIf="!isPaymentLoading(fee.id)">Pay Team Fee</span>
+      <span *ngIf="isPaymentLoading(fee.id)">Initiating Payment...</span>
     </button>
   </div>
 </div>

--- a/src/app/team-fees/team-fees.component.spec.ts
+++ b/src/app/team-fees/team-fees.component.spec.ts
@@ -82,12 +82,13 @@ describe('TeamFeesComponent checkout flow', () => {
       value: { location: { href: 'https://allplays.test/team-fees' } }
     });
 
-    expect(template).toContain('[disabled]="isPaymentLoading(fee.id)"');
+    expect(template).toContain('[disabled]="isPaymentPending()"');
     expect(template).toContain('*ngIf="isPaymentLoading(fee.id)"');
 
     const checkoutPromise = component.handlePayFee(selectedFee);
 
     expect(component.pendingPaymentFeeId).toBe(selectedFee.id);
+    expect(component.isPaymentPending()).toBe(true);
     expect(component.isPaymentLoading(selectedFee.id)).toBe(true);
     expect(component.isPaymentLoading(otherUnpaidFee.id)).toBe(false);
 
@@ -96,6 +97,41 @@ describe('TeamFeesComponent checkout flow', () => {
 
     expect(component.pendingPaymentFeeId).toBeNull();
     expect(component.paymentErrorMessage).toBeNull();
+
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: originalWindow
+    });
+  });
+
+  it('ignores overlapping checkout attempts while another fee payment is pending', async () => {
+    component.ngOnInit();
+    const [selectedFee, otherUnpaidFee] = component.teamFees.filter((fee) => !fee.isPaid);
+    let resolveCheckout: (checkoutUrl: string) => void = () => undefined;
+    stripeService.initiateTeamFeeCheckout.mockReturnValue(new Promise((resolve) => {
+      resolveCheckout = resolve;
+    }));
+    const originalWindow = globalThis.window;
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: { location: { href: 'https://allplays.test/team-fees' } }
+    });
+
+    const checkoutPromise = component.handlePayFee(selectedFee);
+    await component.handlePayFee(otherUnpaidFee);
+
+    expect(stripeService.initiateTeamFeeCheckout).toHaveBeenCalledTimes(1);
+    expect(stripeService.initiateTeamFeeCheckout).toHaveBeenCalledWith('teamA', 'batch1', 'recipient1');
+    expect(component.pendingPaymentFeeId).toBe(selectedFee.id);
+    expect(component.isPaymentPending()).toBe(true);
+    expect(component.isPaymentLoading(selectedFee.id)).toBe(true);
+    expect(component.isPaymentLoading(otherUnpaidFee.id)).toBe(false);
+
+    resolveCheckout('https://checkout.stripe.com/team-fee-session');
+    await checkoutPromise;
+
+    expect(component.pendingPaymentFeeId).toBeNull();
+    expect(component.isPaymentPending()).toBe(false);
 
     Object.defineProperty(globalThis, 'window', {
       configurable: true,
@@ -114,6 +150,7 @@ describe('TeamFeesComponent checkout flow', () => {
     expect(consoleError).toHaveBeenCalledWith('Failed to initiate payment:', expect.any(Error));
     expect(stripeService.initiateTeamFeeCheckout).toHaveBeenCalledWith('teamA', 'batch1', 'recipient1');
     expect(component.pendingPaymentFeeId).toBeNull();
+    expect(component.isPaymentPending()).toBe(false);
     expect(component.isPaymentLoading(selectedFee.id)).toBe(false);
     expect(component.isPaymentLoading(otherUnpaidFee.id)).toBe(false);
     expect(component.paymentErrorMessage).toBe('Failed to initiate payment. Please try again.');

--- a/src/app/team-fees/team-fees.component.spec.ts
+++ b/src/app/team-fees/team-fees.component.spec.ts
@@ -43,7 +43,7 @@ describe('TeamFeesComponent checkout flow', () => {
     component.ngOnInit();
     const unpaidFee = component.teamFees.find((fee) => !fee.isPaid);
 
-    expect(template).toContain('handlePayFee(fee.teamId, fee.batchId, fee.recipientId)');
+    expect(template).toContain('handlePayFee(fee)');
     expect(unpaidFee).toEqual(expect.objectContaining({
       teamId: 'teamA',
       batchId: 'batch1',
@@ -56,16 +56,69 @@ describe('TeamFeesComponent checkout flow', () => {
       value: { location: { href: 'https://allplays.test/team-fees' } }
     });
 
-    await component.handlePayFee(unpaidFee!.teamId, unpaidFee!.batchId, unpaidFee!.recipientId);
+    await component.handlePayFee(unpaidFee!);
 
     expect(stripeService.initiateTeamFeeCheckout).toHaveBeenCalledWith('teamA', 'batch1', 'recipient1');
     expect(globalThis.window.location.href).toBe('https://checkout.stripe.com/team-fee-session');
-    expect(component.isLoadingPayment).toBe(false);
+    expect(component.pendingPaymentFeeId).toBeNull();
     expect(component.paymentErrorMessage).toBeNull();
 
     Object.defineProperty(globalThis, 'window', {
       configurable: true,
       value: originalWindow
     });
+  });
+
+  it('scopes the initiating payment state to the selected unpaid fee', async () => {
+    component.ngOnInit();
+    const [selectedFee, otherUnpaidFee] = component.teamFees.filter((fee) => !fee.isPaid);
+    let resolveCheckout: (checkoutUrl: string) => void = () => undefined;
+    stripeService.initiateTeamFeeCheckout.mockReturnValue(new Promise((resolve) => {
+      resolveCheckout = resolve;
+    }));
+    const originalWindow = globalThis.window;
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: { location: { href: 'https://allplays.test/team-fees' } }
+    });
+
+    expect(template).toContain('[disabled]="isPaymentLoading(fee.id)"');
+    expect(template).toContain('*ngIf="isPaymentLoading(fee.id)"');
+
+    const checkoutPromise = component.handlePayFee(selectedFee);
+
+    expect(component.pendingPaymentFeeId).toBe(selectedFee.id);
+    expect(component.isPaymentLoading(selectedFee.id)).toBe(true);
+    expect(component.isPaymentLoading(otherUnpaidFee.id)).toBe(false);
+
+    resolveCheckout('https://checkout.stripe.com/team-fee-session');
+    await checkoutPromise;
+
+    expect(component.pendingPaymentFeeId).toBeNull();
+    expect(component.paymentErrorMessage).toBeNull();
+
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: originalWindow
+    });
+  });
+
+  it('resets only the selected fee loading state and shows the existing error on checkout failure', async () => {
+    component.ngOnInit();
+    const [selectedFee, otherUnpaidFee] = component.teamFees.filter((fee) => !fee.isPaid);
+    stripeService.initiateTeamFeeCheckout.mockRejectedValue(new Error('Stripe unavailable'));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await component.handlePayFee(selectedFee);
+
+    expect(consoleError).toHaveBeenCalledWith('Failed to initiate payment:', expect.any(Error));
+    expect(stripeService.initiateTeamFeeCheckout).toHaveBeenCalledWith('teamA', 'batch1', 'recipient1');
+    expect(component.pendingPaymentFeeId).toBeNull();
+    expect(component.isPaymentLoading(selectedFee.id)).toBe(false);
+    expect(component.isPaymentLoading(otherUnpaidFee.id)).toBe(false);
+    expect(component.paymentErrorMessage).toBe('Failed to initiate payment. Please try again.');
+    expect(component.teamFees.find((fee) => fee.id === 'fee2')).toEqual(expect.objectContaining({ isPaid: true }));
+
+    consoleError.mockRestore();
   });
 });

--- a/src/app/team-fees/team-fees.component.ts
+++ b/src/app/team-fees/team-fees.component.ts
@@ -20,7 +20,7 @@ interface TeamFee {
 })
 export class TeamFeesComponent implements OnInit {
   teamFees: TeamFee[] = []; // Populate this from data service
-  isLoadingPayment: boolean = false;
+  pendingPaymentFeeId: string | null = null;
   paymentErrorMessage: string | null = null;
 
   constructor(private stripeService: StripeService) { }
@@ -35,18 +35,22 @@ export class TeamFeesComponent implements OnInit {
     ];
   }
 
-  async handlePayFee(teamId: string, batchId: string, recipientId: string): Promise<void> {
-    this.isLoadingPayment = true;
+  isPaymentLoading(feeId: string): boolean {
+    return this.pendingPaymentFeeId === feeId;
+  }
+
+  async handlePayFee(fee: TeamFee): Promise<void> {
+    this.pendingPaymentFeeId = fee.id;
     this.paymentErrorMessage = null; // Clear previous errors
 
     try {
-      const checkoutUrl = await this.stripeService.initiateTeamFeeCheckout(teamId, batchId, recipientId);
+      const checkoutUrl = await this.stripeService.initiateTeamFeeCheckout(fee.teamId, fee.batchId, fee.recipientId);
       window.location.href = checkoutUrl; // Redirect to Stripe
     } catch (error) {
       console.error('Failed to initiate payment:', error);
       this.paymentErrorMessage = 'Failed to initiate payment. Please try again.';
     } finally {
-      this.isLoadingPayment = false;
+      this.pendingPaymentFeeId = null;
     }
   }
 }

--- a/src/app/team-fees/team-fees.component.ts
+++ b/src/app/team-fees/team-fees.component.ts
@@ -39,7 +39,15 @@ export class TeamFeesComponent implements OnInit {
     return this.pendingPaymentFeeId === feeId;
   }
 
+  isPaymentPending(): boolean {
+    return this.pendingPaymentFeeId !== null;
+  }
+
   async handlePayFee(fee: TeamFee): Promise<void> {
+    if (this.isPaymentPending()) {
+      return;
+    }
+
     this.pendingPaymentFeeId = fee.id;
     this.paymentErrorMessage = null; // Clear previous errors
 


### PR DESCRIPTION
Closes #1286

## Summary
- Track pending team fee checkout by selected fee id instead of one global loading flag.
- Disable and label only the selected unpaid fee while checkout is being initiated.
- Added regression coverage for multiple unpaid fees, scoped loading, checkout failure reset, and existing Stripe checkout arguments.