### PR TITLE
Sync parent memberships on dashboard

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -83,13 +83,28 @@
     <script type="module">
         import { getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=32';
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
-        import { requireAuth as authRequireAuth } from './js/auth.js?v=15';
+        import { checkAuth } from './js/auth.js?v=15';
 
         renderFooter(document.getElementById('footer-container'));
 
+        function requireSyncedAuth() {
+            return new Promise((resolve, reject) => {
+                let unsubscribe = null;
+                unsubscribe = checkAuth((user) => {
+                    if (unsubscribe) unsubscribe();
+                    if (user) {
+                        resolve(user);
+                    } else {
+                        window.location.href = 'login.html';
+                        reject('Not authenticated');
+                    }
+                });
+            });
+        }
+
         async function init() {
             try {
-                const user = await authRequireAuth();
+                const user = await requireSyncedAuth();
 
                 // Load user profile to get isAdmin flag
                 let profile = null;

--- a/dashboard.html
+++ b/dashboard.html
@@ -90,17 +90,17 @@
         function requireSyncedAuth() {
             return new Promise((resolve, reject) => {
                 let unsubscribe = null;
-                let unsubscribePending = false;
+                let cleanupRequestedBeforeSubscribeReturned = false;
                 let settled = false;
 
                 function cleanup() {
                     if (typeof unsubscribe === 'function') {
                         const stop = unsubscribe;
                         unsubscribe = null;
-                        unsubscribePending = false;
+                        cleanupRequestedBeforeSubscribeReturned = false;
                         stop();
                     } else {
-                        unsubscribePending = true;
+                        cleanupRequestedBeforeSubscribeReturned = true;
                     }
                 }
 
@@ -116,7 +116,7 @@
                     }
                 });
 
-                if (unsubscribePending) {
+                if (cleanupRequestedBeforeSubscribeReturned) {
                     cleanup();
                 }
             });

--- a/dashboard.html
+++ b/dashboard.html
@@ -90,8 +90,24 @@
         function requireSyncedAuth() {
             return new Promise((resolve, reject) => {
                 let unsubscribe = null;
+                let unsubscribePending = false;
+                let settled = false;
+
+                function cleanup() {
+                    if (typeof unsubscribe === 'function') {
+                        const stop = unsubscribe;
+                        unsubscribe = null;
+                        unsubscribePending = false;
+                        stop();
+                    } else {
+                        unsubscribePending = true;
+                    }
+                }
+
                 unsubscribe = checkAuth((user) => {
-                    if (unsubscribe) unsubscribe();
+                    if (settled) return;
+                    settled = true;
+                    cleanup();
                     if (user) {
                         resolve(user);
                     } else {
@@ -99,6 +115,10 @@
                         reject('Not authenticated');
                     }
                 });
+
+                if (unsubscribePending) {
+                    cleanup();
+                }
             });
         }
 

--- a/docs/pr-notes/runs/1290-remediator-20260524T190214Z/architecture.md
+++ b/docs/pr-notes/runs/1290-remediator-20260524T190214Z/architecture.md
@@ -1,0 +1,13 @@
+# Architecture
+
+## Decision
+Keep `requireSyncedAuth()` page-local in `dashboard.html` and keep using `checkAuth()` so dashboard benefits from profile enrichment and parent membership sync.
+
+## Cleanup Pattern
+- Track `unsubscribePending` when a synchronous callback fires before `checkAuth()` returns the unsubscribe function.
+- Track `settled` so only the first auth emission resolves or rejects the one-shot wrapper.
+- Centralize listener cleanup in a local `cleanup()` helper.
+
+## Risk And Rollback
+- Risk is limited to dashboard auth initialization.
+- Rollback is the previous `requireSyncedAuth()` implementation, but that restores the listener leak risk.

--- a/docs/pr-notes/runs/1290-remediator-20260524T190214Z/code-plan.md
+++ b/docs/pr-notes/runs/1290-remediator-20260524T190214Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Plan
+
+## Source Change
+- Update `dashboard.html` `requireSyncedAuth()` to defer cleanup when `checkAuth()` invokes the callback before returning `unsubscribe`.
+- Add a `settled` guard to prevent duplicate auth emissions from resolving/rejecting or initializing dashboard state more than once.
+
+## Test Change
+- Update `tests/unit/dashboard-parent-membership-sync.test.js` to evaluate the inline helper with mocked `checkAuth()` callbacks for synchronous authenticated, synchronous unauthenticated, and duplicate emission cases.
+
+## Commit Message
+`Fix dashboard auth unsubscribe race`

--- a/docs/pr-notes/runs/1290-remediator-20260524T190214Z/qa.md
+++ b/docs/pr-notes/runs/1290-remediator-20260524T190214Z/qa.md
@@ -1,0 +1,15 @@
+# QA Plan
+
+## Automated Validation
+- Run the targeted unit test: `npx vitest run tests/unit/dashboard-parent-membership-sync.test.js --reporter=verbose`.
+
+## Regression Coverage
+- Assert dashboard still imports `checkAuth` and calls `requireSyncedAuth()` before loading parent teams.
+- Execute `requireSyncedAuth()` with a synchronous authenticated callback and verify unsubscribe is called once.
+- Execute `requireSyncedAuth()` with a synchronous unauthenticated callback and verify redirect plus unsubscribe.
+- Execute duplicate synchronous emissions and verify the first result wins and unsubscribe is called once.
+
+## Manual Checks If Needed
+- Coach/admin dashboard loads owned/admin teams once.
+- Parent dashboard includes parent-linked teams.
+- Logged-out dashboard redirects to `login.html`.

--- a/docs/pr-notes/runs/1290-remediator-20260524T190214Z/requirements.md
+++ b/docs/pr-notes/runs/1290-remediator-20260524T190214Z/requirements.md
@@ -1,0 +1,12 @@
+# Requirements
+
+## Acceptance Criteria
+- Dashboard auth completes exactly once per page load for authenticated users.
+- Logged-out users redirect to `login.html` exactly once.
+- Parent-linked teams continue to load through the `checkAuth` path before team rendering.
+- If `checkAuth` invokes its callback synchronously before returning the unsubscribe function, the listener is still cleaned up.
+- Duplicate auth emissions after the first settlement do not trigger duplicate dashboard initialization.
+
+## Non-Goals
+- No global auth API changes.
+- No role, Firestore rule, or dashboard layout changes.

--- a/docs/pr-notes/runs/1290-remediator-20260524T201041Z/architecture.md
+++ b/docs/pr-notes/runs/1290-remediator-20260524T201041Z/architecture.md
@@ -1,0 +1,11 @@
+# Architecture
+
+## Decision
+Use a one-shot auth gate that tracks whether cleanup was requested before the unsubscribe function is available.
+
+## Rationale
+Firebase-style auth observers may invoke callbacks synchronously. The dashboard needs the rich `checkAuth` user object, but it only needs the first emission before loading team data. A small pending-cleanup flag keeps the unsubscribe lifecycle deterministic without changing the surrounding page boot flow.
+
+## Risk And Rollback
+- Risk: double cleanup if auth emits multiple times. Mitigation: `settled` guard plus nulling the unsubscribe function before invocation.
+- Rollback: revert the `requireSyncedAuth()` block and associated regression test if auth initialization regresses.

--- a/docs/pr-notes/runs/1290-remediator-20260524T201041Z/code-plan.md
+++ b/docs/pr-notes/runs/1290-remediator-20260524T201041Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code Plan
+
+1. Inspect `dashboard.html` and the dashboard unit test coverage.
+2. Keep `requireSyncedAuth()` as a one-shot promise wrapper around `checkAuth()`.
+3. Make the synchronous-callback unsubscribe handling explicit and readable so the review concern is directly addressed.
+4. Validate with the focused dashboard unit test.

--- a/docs/pr-notes/runs/1290-remediator-20260524T201041Z/qa.md
+++ b/docs/pr-notes/runs/1290-remediator-20260524T201041Z/qa.md
@@ -1,0 +1,10 @@
+# QA Plan
+
+## Automated
+- Run the focused Vitest file: `npx vitest run tests/unit/dashboard-parent-membership-sync.test.js --reporter=verbose`.
+- The test must assert `unsubscribe()` is called once for synchronous authenticated and unauthenticated callbacks.
+- The test must assert duplicate callback emissions after settling do not double-unsubscribe or change the settled result.
+
+## Manual
+- Dashboard should continue to load teams for authenticated users.
+- Anonymous users should redirect to `login.html`.

--- a/docs/pr-notes/runs/1290-remediator-20260524T201041Z/requirements.md
+++ b/docs/pr-notes/runs/1290-remediator-20260524T201041Z/requirements.md
@@ -1,0 +1,10 @@
+# Requirements
+
+## Acceptance Criteria
+- `requireSyncedAuth()` must resolve or reject exactly once for the first auth emission.
+- The auth subscription returned by `checkAuth()` must be unsubscribed even when `checkAuth()` invokes its callback synchronously before returning the unsubscribe function.
+- Unauthenticated users must still redirect to `login.html` and reject with `Not authenticated`.
+- Regression coverage must prove synchronous user, synchronous no-user, and duplicate callback paths do not leak or double-settle.
+
+## Scope
+- Keep the remediation limited to `dashboard.html` auth synchronization and its unit regression coverage.

--- a/tests/unit/dashboard-parent-membership-sync.test.js
+++ b/tests/unit/dashboard-parent-membership-sync.test.js
@@ -1,8 +1,20 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
 
 function readRepoFile(relativePath) {
     return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+function getRequireSyncedAuth() {
+    const html = readRepoFile('dashboard.html');
+    const match = html.match(/function requireSyncedAuth\(\) \{[\s\S]*?\n        \}\n\n        async function init/);
+    if (!match) throw new Error('requireSyncedAuth not found');
+    return match[0].replace(/\n\n        async function init$/, '');
+}
+
+function runRequireSyncedAuth(checkAuth, windowObject = { location: { href: '' } }) {
+    const source = `${getRequireSyncedAuth()}; return requireSyncedAuth();`;
+    return new Function('checkAuth', 'window', source)(checkAuth, windowObject);
 }
 
 describe('dashboard parent membership sync', () => {
@@ -14,5 +26,46 @@ describe('dashboard parent membership sync', () => {
         expect(html).toContain('const user = await requireSyncedAuth();');
         expect(html).toContain('getParentTeams(user.uid)');
         expect(html).not.toContain('requireAuth as authRequireAuth');
+    });
+
+    it('unsubscribes when checkAuth invokes the user callback synchronously', async () => {
+        const user = { uid: 'parent-1' };
+        const unsubscribe = vi.fn();
+        const checkAuth = vi.fn((callback) => {
+            callback(user);
+            return unsubscribe;
+        });
+
+        await expect(runRequireSyncedAuth(checkAuth)).resolves.toBe(user);
+
+        expect(unsubscribe).toHaveBeenCalledTimes(1);
+    });
+
+    it('unsubscribes and redirects when checkAuth synchronously reports no user', async () => {
+        const unsubscribe = vi.fn();
+        const windowObject = { location: { href: '' } };
+        const checkAuth = vi.fn((callback) => {
+            callback(null);
+            return unsubscribe;
+        });
+
+        await expect(runRequireSyncedAuth(checkAuth, windowObject)).rejects.toBe('Not authenticated');
+
+        expect(unsubscribe).toHaveBeenCalledTimes(1);
+        expect(windowObject.location.href).toBe('login.html');
+    });
+
+    it('ignores duplicate auth emissions after settling', async () => {
+        const user = { uid: 'parent-1' };
+        const unsubscribe = vi.fn();
+        const checkAuth = vi.fn((callback) => {
+            callback(user);
+            callback({ uid: 'parent-2' });
+            return unsubscribe;
+        });
+
+        await expect(runRequireSyncedAuth(checkAuth)).resolves.toBe(user);
+
+        expect(unsubscribe).toHaveBeenCalledTimes(1);
     });
 });

--- a/tests/unit/dashboard-parent-membership-sync.test.js
+++ b/tests/unit/dashboard-parent-membership-sync.test.js
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readRepoFile(relativePath) {
+    return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+describe('dashboard parent membership sync', () => {
+    it('uses the rich auth path before loading parent-linked teams', () => {
+        const html = readRepoFile('dashboard.html');
+
+        expect(html).toContain("import { checkAuth } from './js/auth.js?v=15';");
+        expect(html).toContain('function requireSyncedAuth()');
+        expect(html).toContain('const user = await requireSyncedAuth();');
+        expect(html).toContain('getParentTeams(user.uid)');
+        expect(html).not.toContain('requireAuth as authRequireAuth');
+    });
+});


### PR DESCRIPTION
Closes #1289

## Summary
- Updated `dashboard.html` to use the richer `checkAuth` path before loading My Teams.
- This syncs approved parent membership requests into the user profile before `getParentTeams(user.uid)` runs.
- Added regression coverage to ensure the dashboard keeps using the synced auth path.

## Validation
- `npx vitest run tests/unit/dashboard-parent-membership-sync.test.js tests/unit/auth-parent-membership-sync.test.js --reporter=verbose`