### PR TITLE
Add tournament bracket team link

### DIFF
--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -82,6 +82,7 @@ export type TeamDetailModel = {
     description: string;
     zip: string;
     leagueUrl: string | null;
+    bracketUrl: string | null;
     streamUrl: string | null;
     websiteUrl: string;
     mediaUrl: string;
@@ -335,6 +336,7 @@ export function buildTeamDetailModel({
       description: cleanString(team?.description),
       zip: cleanString(team?.zip),
       leagueUrl: getFirstUrl(team?.leagueUrl),
+      bracketUrl: getFirstUrl(team?.bracketUrl),
       streamUrl: getStreamUrl(team),
       websiteUrl: getPublicHashUrl('team.html', teamId),
       mediaUrl: getPublicHashUrl('team-media.html', teamId),

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -346,6 +346,7 @@ function MoreTab({ model }: { model: TeamDetailModel }) {
           <InternalAction icon={DollarSign} label="My fees" detail="Balances, checkout links, installments, and history." to="/parent-tools/fees" />
           <InternalAction icon={Ticket} label="Registrations" detail="Open published team registration forms." to="/parent-tools/registrations" />
           {model.team.streamUrl ? <ExternalAction icon={Radio} label="Watch stream" detail="Open the configured team stream." href={model.team.streamUrl} /> : null}
+          {model.team.bracketUrl ? <ExternalAction icon={Trophy} label="Tournament bracket" detail="Open official bracket." href={model.team.bracketUrl} /> : null}
           {model.team.leagueUrl ? <ExternalAction icon={Trophy} label="League page" detail="Open standings or league registration source." href={model.team.leagueUrl} /> : null}
         </div>
       </section>

--- a/edit-team.html
+++ b/edit-team.html
@@ -168,6 +168,14 @@
                     <p class="text-xs text-gray-500 mt-1">Used to display external league standings (W/L/T) on the team page.</p>
                 </div>
 
+                <div>
+                    <label class="block text-sm font-medium text-gray-700">Tournament Bracket Link (optional)</label>
+                    <input type="url" id="bracketUrl"
+                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 border p-2"
+                        placeholder="https://tourneymachine.com/.../bracket/...">
+                    <p class="text-xs text-gray-500 mt-1">Shown to parents as an official tournament bracket link on the team page.</p>
+                </div>
+
                 <div class="rounded-lg border border-gray-200 p-4 space-y-3">
                     <div class="flex items-start">
                         <div class="flex items-center h-5">
@@ -1260,6 +1268,7 @@
                 document.getElementById('teamColorSecondary').value = getTeamColorValue(team, 'secondary', '#d32f3a');
                 document.getElementById('notificationEmail').value = team.notificationEmail || '';
                 document.getElementById('leagueUrl').value = team.leagueUrl || '';
+                document.getElementById('bracketUrl').value = team.bracketUrl || '';
                 document.getElementById('standingsEnabled').checked = team.standingsConfig?.enabled === true;
                 document.getElementById('standingsRankingMode').value = team.standingsConfig?.rankingMode === 'win_pct' ? 'win_pct' : 'points';
                 document.getElementById('standingsPointWin').value = String(parseStandingsNumber(team.standingsConfig?.points?.win, 3));
@@ -1733,6 +1742,7 @@
                     sport: document.getElementById('sport').value,
                     notificationEmail: document.getElementById('notificationEmail').value,
                     leagueUrl: document.getElementById('leagueUrl').value.trim(),
+                    bracketUrl: document.getElementById('bracketUrl').value.trim(),
                     standingsConfig: {
                         enabled: document.getElementById('standingsEnabled').checked,
                         rankingMode: document.getElementById('standingsRankingMode').value === 'win_pct' ? 'win_pct' : 'points',

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -184,6 +184,7 @@ async function mockTeamsModules(page) {
                                 description: '',
                                 zip: '',
                                 leagueUrl: null,
+                                bracketUrl: null,
                                 streamUrl: null,
                                 websiteUrl: 'https://allplays.ai/team.html#teamId=team-empty',
                                 mediaUrl: 'https://allplays.ai/team-media.html#teamId=team-empty',
@@ -213,6 +214,7 @@ async function mockTeamsModules(page) {
                             description: 'Parent-facing team page',
                             zip: '66210',
                             leagueUrl: 'https://league.example.test/standings',
+                            bracketUrl: 'https://bracket.example.test/official',
                             streamUrl: 'https://youtube.example.test/watch',
                             websiteUrl: 'https://allplays.ai/team.html#teamId=team-1',
                             mediaUrl: 'https://allplays.ai/team-media.html#teamId=team-1',
@@ -340,11 +342,15 @@ test.describe('mobile My Teams', () => {
         await expect(page.getByText('Website team page')).toBeVisible();
         await expect(page.getByText('Media albums')).toBeVisible();
         await expect(page.getByText('Watch stream')).toBeVisible();
+        await expect(page.getByText('Tournament bracket')).toBeVisible();
+        await expect(page.getByText('Open official bracket.')).toBeVisible();
         await expect(page.getByText('League page')).toBeVisible();
         await expect(page.getByText('Sports Connect')).toBeVisible();
         await expect(page.getByText('Pizza Place')).toBeVisible();
         await page.getByRole('link', { name: /Watch stream/ }).click();
         await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://youtube.example.test/watch');
+        await page.getByRole('link', { name: /Tournament bracket/ }).click();
+        await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://bracket.example.test/official');
         await page.getByRole('link', { name: /Pizza Place/ }).click();
         await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://pizza.example.test');
         await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
@@ -367,6 +373,7 @@ test.describe('mobile My Teams', () => {
         await expect(page.getByText('Leaderboards appear after public stat configs and completed tracked games exist.')).toBeVisible();
         await page.getByRole('button', { name: /More/ }).click();
         await expect(page.getByText('Team links')).toBeVisible();
+        await expect(page.getByText('Tournament bracket')).toHaveCount(0);
         await expect(page.getByText('Loading team')).toHaveCount(0);
     });
 });

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -28,6 +28,7 @@ describe('React app team detail model', () => {
                 sport: 'Basketball',
                 photoUrl: 'https://img.example.test/team.png',
                 leagueUrl: 'https://league.example.test',
+                bracketUrl: 'https://bracket.example.test/path',
                 standingsConfig: { enabled: true },
                 registrationSource: { provider: 'Sports Connect', externalTeamId: 'EXT-1' }
             },
@@ -57,6 +58,7 @@ describe('React app team detail model', () => {
         });
 
         expect(model.team.photoUrl).toBe('https://img.example.test/team.png');
+        expect(model.team.bracketUrl).toBe('https://bracket.example.test/path');
         expect(model.team.registrationProvider.map((row) => row.value)).toContain('Sports Connect');
         expect(model.players.find((player) => player.id === 'player-1').photoUrl).toBe('https://img.example.test/player.png');
         expect(model.linkedPlayers.map((player) => player.id)).toEqual(['player-1']);

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -198,6 +198,7 @@ function createEnvironment(initialState, overrides = {}) {
         'teamColorSecondary',
         'notificationEmail',
         'leagueUrl',
+        'bracketUrl',
         'standingsEnabled',
         'standingsRankingMode',
         'standingsPointWin',
@@ -561,6 +562,7 @@ describe('edit team admin access persistence', () => {
             env.elements.get('description').value = 'First season';
             env.elements.get('sport').value = 'Basketball';
             env.elements.get('zip').value = '66209';
+            env.elements.get('bracketUrl').value = 'https://example.com/bracket';
             expect(env.elements.get('advanced-team-setup').open).toBe(false);
 
             await env.elements.get('team-form').requestSubmit();
@@ -585,6 +587,7 @@ describe('edit team admin access persistence', () => {
                     streaming: { mode: 'all_confirmed', memberIds: [] },
                     videography: { mode: 'selected', memberIds: [] }
                 },
+                bracketUrl: 'https://example.com/bracket',
                 streamAccessMode: 'admins',
                 streamVolunteerEmails: [],
                 defaultAssignments: [],
@@ -611,6 +614,7 @@ describe('edit team admin access persistence', () => {
                 sport: 'Soccer',
                 notificationEmail: 'notify@example.com',
                 leagueUrl: 'https://example.com/league',
+                bracketUrl: 'https://example.com/bracket',
                 standingsConfig: {
                     enabled: true,
                     rankingMode: 'points',
@@ -633,6 +637,7 @@ describe('edit team admin access persistence', () => {
             expect(env.elements.get('teamColorPrimary').value).toBe('#111111');
             expect(env.elements.get('notificationEmail').value).toBe('notify@example.com');
             expect(env.elements.get('leagueUrl').value).toBe('https://example.com/league');
+            expect(env.elements.get('bracketUrl').value).toBe('https://example.com/bracket');
             expect(env.elements.get('standingsEnabled').checked).toBe(true);
             expect(env.elements.get('standingsPointWin').value).toBe('5');
         } finally {


### PR DESCRIPTION
Closes #1291

## What changed
- Added an optional Tournament Bracket Link field to the team edit form.
- Persisted `bracketUrl` alongside existing team link fields.
- Exposed `bracketUrl` through the parent team detail model.
- Added a conditional parent-visible `Tournament bracket` action in the Team Detail More tab.
- Updated unit and smoke coverage for bracket URL load/save/model/UI behavior.

## Validation
- Passed: `npx vitest run tests/unit/edit-team-admin-access-persistence.test.js tests/unit/app-team-detail-service.test.js --reporter=verbose`
- Attempted: `npx playwright test tests/smoke/app-teams.spec.js`, blocked because Playwright Chromium is not installed in this lane image.
- Attempted: `npm --prefix apps/app run build`, blocked by existing missing `@capgo/capacitor-speech-recognition` module/type dependency.