### PR TITLE
Block IPv4-mapped private calendar addresses

### DIFF
--- a/docs/pr-notes/runs/1294-remediator-20260525T001945Z/architecture.md
+++ b/docs/pr-notes/runs/1294-remediator-20260525T001945Z/architecture.md
@@ -1,0 +1,10 @@
+# Architecture
+
+Decision: keep the patch local and minimal. Update `getIpv4MappedAddress` in both current validators so it recognizes expanded IPv4-mapped IPv6 addresses structurally, including zero-padded zero hextets, then delegates classification to the existing IPv4 private-address logic.
+
+The helper accepts:
+- `::ffff:<ipv4>` and `::ffff:<hex>:<hex>`
+- `0:0:0:0:0:ffff:<ipv4>` and zero-padded equivalents
+- `0000:0000:0000:0000:0000:ffff:<hex>:<hex>`
+
+Risk: duplicated validator logic can drift. Mitigation in this scoped remediation is identical targeted changes and tests in both affected test tiers. A larger shared-helper refactor is intentionally out of scope for this review fix.

--- a/docs/pr-notes/runs/1294-remediator-20260525T001945Z/code-plan.md
+++ b/docs/pr-notes/runs/1294-remediator-20260525T001945Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code Plan
+
+1. Replace prefix-only mapped IPv6 detection in `functions/utils/security-utils.js` and `functions/utils/ip-address-validation.js` with a parser that accepts compressed mapped forms and expanded zero-padded mapped prefixes.
+2. Preserve existing IPv4 conversion and delegate the embedded IPv4 back to `isPrivateIpAddress`.
+3. Add regression tests in `tests/unit/is-private-ip-address.test.js` and `functions/test/ssrf.test.js`.
+4. Run targeted tests and commit the scoped remediation.

--- a/docs/pr-notes/runs/1294-remediator-20260525T001945Z/qa.md
+++ b/docs/pr-notes/runs/1294-remediator-20260525T001945Z/qa.md
@@ -1,0 +1,15 @@
+# QA
+
+Plan:
+
+1. Add unit coverage for zero-padded expanded IPv4-mapped IPv6 private addresses.
+2. Add unit coverage for zero-padded expanded public mapped IPv4 addresses to avoid overblocking.
+3. Add SSRF/security utility coverage proving `assertPublicHost` rejects a direct zero-padded expanded mapped loopback address.
+4. Run targeted tests for the affected unit file and the functions SSRF test.
+
+Commands:
+
+```bash
+npx vitest run tests/unit/is-private-ip-address.test.js --reporter=verbose
+node --test functions/test/ssrf.test.js
+```

--- a/docs/pr-notes/runs/1294-remediator-20260525T001945Z/requirements.md
+++ b/docs/pr-notes/runs/1294-remediator-20260525T001945Z/requirements.md
@@ -1,0 +1,11 @@
+# Requirements
+
+Acceptance criteria for PR #1294 remediation:
+
+1. Zero-padded expanded IPv4-mapped IPv6 literals such as `0000:0000:0000:0000:0000:ffff:7f00:0001` are classified by their embedded IPv4 address.
+2. Private, loopback, unspecified, and link-local embedded IPv4 addresses remain blocked in compressed, expanded, and zero-padded mapped forms.
+3. Public embedded IPv4 addresses remain allowed.
+4. Invalid IP inputs remain fail-closed.
+5. `assertPublicHost` rejects direct zero-padded mapped private hosts before any fetch path is used.
+
+Non-goals: no calendar UX changes, no fetch/redirect redesign, no broad IPv6 validator rewrite beyond mapped-address recognition.

--- a/functions/test/ssrf.test.js
+++ b/functions/test/ssrf.test.js
@@ -28,7 +28,10 @@ test('isPrivateIpAddress correctly identifies private IPs', () => {
   assert.strictEqual(isPrivateIpAddress('::ffff:10.0.0.1'), true, 'IPv4-mapped IPv6 RFC1918 should be private');
   assert.strictEqual(isPrivateIpAddress('::ffff:192.168.1.1'), true, 'IPv4-mapped IPv6 RFC1918 should be private');
   assert.strictEqual(isPrivateIpAddress('::ffff:169.254.169.254'), true, 'IPv4-mapped IPv6 link-local should be private');
+  assert.strictEqual(isPrivateIpAddress('0000:0000:0000:0000:0000:ffff:7f00:0001'), true, 'zero-padded IPv4-mapped IPv6 loopback should be private');
+  assert.strictEqual(isPrivateIpAddress('0000:0000:0000:0000:0000:ffff:0a00:0001'), true, 'zero-padded IPv4-mapped IPv6 RFC1918 should be private');
   assert.strictEqual(isPrivateIpAddress('::ffff:8.8.8.8'), false, 'IPv4-mapped IPv6 public address should be public');
+  assert.strictEqual(isPrivateIpAddress('0000:0000:0000:0000:0000:ffff:0808:0808'), false, 'zero-padded IPv4-mapped IPv6 public address should be public');
 });
 
 test('assertPublicHost prevents blocked hosts and private IPs', async () => {
@@ -39,6 +42,7 @@ test('assertPublicHost prevents blocked hosts and private IPs', async () => {
 
   await assert.rejects(assertPublicHost('::ffff:127.0.0.1'), { message: 'Blocked host address' }, 'IPv4-mapped IPv6 loopback should be blocked');
   await assert.rejects(assertPublicHost('::ffff:169.254.169.254'), { message: 'Blocked host address' }, 'IPv4-mapped IPv6 link-local should be blocked');
+  await assert.rejects(assertPublicHost('0000:0000:0000:0000:0000:ffff:7f00:0001'), { message: 'Blocked host address' }, 'zero-padded IPv4-mapped IPv6 loopback should be blocked');
 
   const publicIp = await assertPublicHost('8.8.8.8');
   assert.deepStrictEqual(publicIp, ['8.8.8.8'], 'public IP should be allowed');

--- a/functions/test/ssrf.test.js
+++ b/functions/test/ssrf.test.js
@@ -23,6 +23,12 @@ test('isPrivateIpAddress correctly identifies private IPs', () => {
   assert.strictEqual(isPrivateIpAddress('fc00::1'), true, 'fc00::1 should be private (IPv6 ULA)');
   assert.strictEqual(isPrivateIpAddress('fd00::1'), true, 'fd00::1 should be private (IPv6 ULA)');
   assert.strictEqual(isPrivateIpAddress('2001:0db8::1'), false, '2001:0db8::1 should be public');
+
+  assert.strictEqual(isPrivateIpAddress('::ffff:127.0.0.1'), true, 'IPv4-mapped IPv6 loopback should be private');
+  assert.strictEqual(isPrivateIpAddress('::ffff:10.0.0.1'), true, 'IPv4-mapped IPv6 RFC1918 should be private');
+  assert.strictEqual(isPrivateIpAddress('::ffff:192.168.1.1'), true, 'IPv4-mapped IPv6 RFC1918 should be private');
+  assert.strictEqual(isPrivateIpAddress('::ffff:169.254.169.254'), true, 'IPv4-mapped IPv6 link-local should be private');
+  assert.strictEqual(isPrivateIpAddress('::ffff:8.8.8.8'), false, 'IPv4-mapped IPv6 public address should be public');
 });
 
 test('assertPublicHost prevents blocked hosts and private IPs', async () => {
@@ -30,6 +36,9 @@ test('assertPublicHost prevents blocked hosts and private IPs', async () => {
   await assert.rejects(assertPublicHost('127.0.0.1'), { message: 'Blocked host' }, '127.0.0.1 should be blocked');
   await assert.rejects(assertPublicHost('192.168.1.1'), { message: 'Blocked host address' }, 'private IP should be blocked');
   await assert.rejects(assertPublicHost('evil.local'), { message: 'Blocked host' }, '.local should be blocked');
+
+  await assert.rejects(assertPublicHost('::ffff:127.0.0.1'), { message: 'Blocked host address' }, 'IPv4-mapped IPv6 loopback should be blocked');
+  await assert.rejects(assertPublicHost('::ffff:169.254.169.254'), { message: 'Blocked host address' }, 'IPv4-mapped IPv6 link-local should be blocked');
 
   const publicIp = await assertPublicHost('8.8.8.8');
   assert.deepStrictEqual(publicIp, ['8.8.8.8'], 'public IP should be allowed');
@@ -152,3 +161,4 @@ test('SSRF vulnerability via DNS Rebinding prevention in fetchWithTimeout', asyn
     dns.lookup = originalDnsLookup;
     _setClientModulesForTesting(null, null); // Restore original modules
   }
+});

--- a/functions/utils/ip-address-validation.js
+++ b/functions/utils/ip-address-validation.js
@@ -1,5 +1,33 @@
 const net = require('node:net');
 
+function getIpv4MappedAddress(ip) {
+  const normalized = ip.toLowerCase();
+  const mappedPrefixes = ['::ffff:', '0:0:0:0:0:ffff:'];
+  const prefix = mappedPrefixes.find((candidate) => normalized.startsWith(candidate));
+  if (!prefix) {
+    return null;
+  }
+
+  const embedded = normalized.slice(prefix.length);
+  if (net.isIP(embedded) === 4) {
+    return embedded;
+  }
+
+  const hextets = embedded.split(':');
+  if (hextets.length !== 2 || hextets.some((part) => !/^[0-9a-f]{1,4}$/.test(part))) {
+    return null;
+  }
+
+  const first = Number.parseInt(hextets[0], 16);
+  const second = Number.parseInt(hextets[1], 16);
+  return [
+    (first >> 8) & 255,
+    first & 255,
+    (second >> 8) & 255,
+    second & 255,
+  ].join('.');
+}
+
 function isPrivateIpAddress(ip) {
   const ipVersion = net.isIP(ip);
   if (!ipVersion) {
@@ -16,6 +44,11 @@ function isPrivateIpAddress(ip) {
     if (parts[0] === 192 && parts[1] === 168) return true;
     if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true;
     return false;
+  }
+
+  const mappedIpv4Address = getIpv4MappedAddress(ip);
+  if (mappedIpv4Address) {
+    return isPrivateIpAddress(mappedIpv4Address);
   }
 
   const normalized = ip.toLowerCase();

--- a/functions/utils/ip-address-validation.js
+++ b/functions/utils/ip-address-validation.js
@@ -2,13 +2,26 @@ const net = require('node:net');
 
 function getIpv4MappedAddress(ip) {
   const normalized = ip.toLowerCase();
-  const mappedPrefixes = ['::ffff:', '0:0:0:0:0:ffff:'];
-  const prefix = mappedPrefixes.find((candidate) => normalized.startsWith(candidate));
-  if (!prefix) {
+  let embedded = null;
+
+  if (normalized.startsWith('::ffff:')) {
+    embedded = normalized.slice('::ffff:'.length);
+  } else {
+    const parts = normalized.split(':');
+    if (
+      (parts.length === 7 || parts.length === 8) &&
+      parts.slice(0, 5).every((part) => /^[0-9a-f]{1,4}$/.test(part) && Number.parseInt(part, 16) === 0) &&
+      /^[0-9a-f]{1,4}$/.test(parts[5]) &&
+      Number.parseInt(parts[5], 16) === 0xffff
+    ) {
+      embedded = parts.slice(6).join(':');
+    }
+  }
+
+  if (!embedded) {
     return null;
   }
 
-  const embedded = normalized.slice(prefix.length);
   if (net.isIP(embedded) === 4) {
     return embedded;
   }

--- a/functions/utils/security-utils.js
+++ b/functions/utils/security-utils.js
@@ -5,13 +5,26 @@ const net = require('node:net');
 
 function getIpv4MappedAddress(ip) {
   const normalized = ip.toLowerCase();
-  const mappedPrefixes = ['::ffff:', '0:0:0:0:0:ffff:'];
-  const prefix = mappedPrefixes.find((candidate) => normalized.startsWith(candidate));
-  if (!prefix) {
+  let embedded = null;
+
+  if (normalized.startsWith('::ffff:')) {
+    embedded = normalized.slice('::ffff:'.length);
+  } else {
+    const parts = normalized.split(':');
+    if (
+      (parts.length === 7 || parts.length === 8) &&
+      parts.slice(0, 5).every((part) => /^[0-9a-f]{1,4}$/.test(part) && Number.parseInt(part, 16) === 0) &&
+      /^[0-9a-f]{1,4}$/.test(parts[5]) &&
+      Number.parseInt(parts[5], 16) === 0xffff
+    ) {
+      embedded = parts.slice(6).join(':');
+    }
+  }
+
+  if (!embedded) {
     return null;
   }
 
-  const embedded = normalized.slice(prefix.length);
   if (net.isIP(embedded) === 4) {
     return embedded;
   }

--- a/functions/utils/security-utils.js
+++ b/functions/utils/security-utils.js
@@ -3,6 +3,34 @@ const https = require('node:https');
 const dns = require('node:dns').promises;
 const net = require('node:net');
 
+function getIpv4MappedAddress(ip) {
+  const normalized = ip.toLowerCase();
+  const mappedPrefixes = ['::ffff:', '0:0:0:0:0:ffff:'];
+  const prefix = mappedPrefixes.find((candidate) => normalized.startsWith(candidate));
+  if (!prefix) {
+    return null;
+  }
+
+  const embedded = normalized.slice(prefix.length);
+  if (net.isIP(embedded) === 4) {
+    return embedded;
+  }
+
+  const hextets = embedded.split(':');
+  if (hextets.length !== 2 || hextets.some((part) => !/^[0-9a-f]{1,4}$/.test(part))) {
+    return null;
+  }
+
+  const first = Number.parseInt(hextets[0], 16);
+  const second = Number.parseInt(hextets[1], 16);
+  return [
+    (first >> 8) & 255,
+    first & 255,
+    (second >> 8) & 255,
+    second & 255,
+  ].join('.');
+}
+
 let _http = require('node:http');
 let _https = require('node:https');
 
@@ -27,6 +55,11 @@ function isPrivateIpAddress(ip) {
     if (parts[0] === 192 && parts[1] === 168) return true;
     if (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) return true;
     return false;
+  }
+
+  const mappedIpv4Address = getIpv4MappedAddress(ip);
+  if (mappedIpv4Address) {
+    return isPrivateIpAddress(mappedIpv4Address);
   }
 
   const normalized = ip.toLowerCase();

--- a/tests/unit/is-private-ip-address.test.js
+++ b/tests/unit/is-private-ip-address.test.js
@@ -71,6 +71,15 @@ describe('isPrivateIpAddress', () => {
     expect(isPrivateIpAddress('feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff')).toBe(true);
   });
 
+  it('should validate IPv4-mapped IPv6 addresses by embedded IPv4 address', () => {
+    expect(isPrivateIpAddress('::ffff:127.0.0.1')).toBe(true);
+    expect(isPrivateIpAddress('::ffff:10.0.0.1')).toBe(true);
+    expect(isPrivateIpAddress('::ffff:192.168.1.1')).toBe(true);
+    expect(isPrivateIpAddress('::ffff:169.254.169.254')).toBe(true);
+    expect(isPrivateIpAddress('::ffff:7f00:1')).toBe(true);
+    expect(isPrivateIpAddress('::ffff:8.8.8.8')).toBe(false);
+  });
+
   // Invalid IP addresses
   it('should return true for invalid IP addresses', () => {
     expect(isPrivateIpAddress('invalid-ip')).toBe(true);

--- a/tests/unit/is-private-ip-address.test.js
+++ b/tests/unit/is-private-ip-address.test.js
@@ -77,7 +77,13 @@ describe('isPrivateIpAddress', () => {
     expect(isPrivateIpAddress('::ffff:192.168.1.1')).toBe(true);
     expect(isPrivateIpAddress('::ffff:169.254.169.254')).toBe(true);
     expect(isPrivateIpAddress('::ffff:7f00:1')).toBe(true);
+    expect(isPrivateIpAddress('0:0:0:0:0:ffff:7f00:1')).toBe(true);
+    expect(isPrivateIpAddress('0000:0000:0000:0000:0000:ffff:7f00:0001')).toBe(true);
+    expect(isPrivateIpAddress('0000:0000:0000:0000:0000:ffff:0a00:0001')).toBe(true);
+    expect(isPrivateIpAddress('0000:0000:0000:0000:0000:ffff:c0a8:0101')).toBe(true);
+    expect(isPrivateIpAddress('0000:0000:0000:0000:0000:FFFF:7F00:0001')).toBe(true);
     expect(isPrivateIpAddress('::ffff:8.8.8.8')).toBe(false);
+    expect(isPrivateIpAddress('0000:0000:0000:0000:0000:ffff:0808:0808')).toBe(false);
   });
 
   // Invalid IP addresses


### PR DESCRIPTION
Closes #1293

## Summary
- Reject IPv4-mapped IPv6 addresses when the embedded IPv4 address is private, loopback, unspecified, or link-local.
- Preserve public IPv4-mapped IPv6 addresses as allowed.
- Added regression coverage for calendar SSRF validation and the shared IP validation helper.

## Validation
- `node --test functions/test/ssrf.test.js`
- `npx vitest run tests/unit/is-private-ip-address.test.js --reporter=verbose`