### PR TITLE
Enable registrationSource roster imports

### DIFF
--- a/js/edit-roster-registration-import.js
+++ b/js/edit-roster-registration-import.js
@@ -315,7 +315,10 @@ export function isExternallyLinkedRosterTeam(team = {}) {
     return !!(
         team.registrationSourceSnapshot ||
         team.registrationRosterSnapshot ||
-        team.externalRosterPlayers
+        team.externalRosterPlayers ||
+        Array.isArray(team.registrationSource?.rosterPlayers) ||
+        Array.isArray(team.registrationSource?.players) ||
+        Array.isArray(team.registrationSource?.roster)
     );
 }
 

--- a/tests/unit/edit-roster-registration-import.test.js
+++ b/tests/unit/edit-roster-registration-import.test.js
@@ -15,8 +15,12 @@ describe('registration roster import planning', () => {
     it('detects linked roster teams and source roster snapshots', () => {
         expect(isExternallyLinkedRosterTeam({})).toBe(false);
         expect(isExternallyLinkedRosterTeam({ registrationSourceId: 'sports-connect' })).toBe(false);
+        expect(isExternallyLinkedRosterTeam({ registrationSource: { rosterPlayers: [{ id: 'p1' }] } })).toBe(true);
+        expect(isExternallyLinkedRosterTeam({ registrationSource: { players: [{ id: 'p1' }] } })).toBe(true);
+        expect(isExternallyLinkedRosterTeam({ registrationSource: { roster: [{ id: 'p1' }] } })).toBe(true);
         expect(isExternallyLinkedRosterTeam({ externalRosterPlayers: [{ id: 'p1' }] })).toBe(true);
         expect(getRegistrationRosterPlayers({ registrationSourceSnapshot: { rosterPlayers: [{ id: 'p1' }] } })).toEqual([{ id: 'p1' }]);
+        expect(getRegistrationRosterPlayers({ registrationSource: { rosterPlayers: [{ id: 'p2' }] } })).toEqual([{ id: 'p2' }]);
     });
 
     it('plans add and update operations by source plus external player ID while preserving local-only conflicts', () => {


### PR DESCRIPTION
Closes #1299

## Summary
- Treat roster arrays stored under `team.registrationSource` as registration provider data.
- Added regression coverage for `registrationSource.rosterPlayers`, `registrationSource.players`, and `registrationSource.roster` detection.

## Validation
- `npx vitest run tests/unit/edit-roster-registration-import.test.js --reporter=verbose`