### PR TITLE
Exclude cancelled events from upcoming schedule

### DIFF
--- a/docs/pr-notes/runs/1302-ci-fix-20260524T180041Z/architecture.md
+++ b/docs/pr-notes/runs/1302-ci-fix-20260524T180041Z/architecture.md
@@ -1,0 +1,13 @@
+# Architecture notes
+
+## Acceptance Criteria
+- Upcoming schedule filters exclude cancelled calendar imports so future cancellation notices do not appear as actionable upcoming rows.
+- Rendering coverage for cancelled imported rows remains, using the past-events view where cancelled items are intentionally visible.
+
+## Architecture Decisions
+- Treat the preview-smoke failure as test drift, consistent with the branch's `isUpcomingScheduleEvent()` cancellation guard and the team schedule filter unit contract.
+- Do not change production schedule filtering for this CI fix.
+
+## Risks And Rollback
+- Risk: losing action-suppression coverage for cancelled rows. Mitigation: preserve it in the past-events smoke test.
+- Rollback: revert the smoke expectation changes if product decides future cancellations should remain visible in upcoming lists.

--- a/docs/pr-notes/runs/1302-ci-fix-20260524T180041Z/code-plan.md
+++ b/docs/pr-notes/runs/1302-ci-fix-20260524T180041Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code plan
+
+## Implementation Plan
+- Update `tests/smoke/edit-schedule-calendar-import.spec.js` so the upcoming filter expects cancelled imports to be absent.
+- Update `tests/smoke/edit-schedule-calendar-cancelled-import.spec.js` so cancelled row rendering and hidden action assertions run after switching to Past Events.
+- No production code changes are required for this CI classifier.

--- a/docs/pr-notes/runs/1302-ci-fix-20260524T180041Z/qa.md
+++ b/docs/pr-notes/runs/1302-ci-fix-20260524T180041Z/qa.md
@@ -1,0 +1,11 @@
+# QA notes
+
+## QA Plan
+- Run targeted smoke specs that failed in preview-smoke.
+- Run the cancellation unit test for helper-level cancellation detection.
+
+## Negative Coverage
+- Tracked calendar imports stay suppressed.
+- Time-conflicting calendar imports stay suppressed.
+- Cancelled imports are absent from default upcoming filters.
+- Past cancelled rows still show cancellation styling and hide Track / Plan Practice actions.

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -2185,26 +2185,31 @@
             // Sort by date
             allEvents.sort((a, b) => a.date - b.date);
 
-            const hiddenPracticeCount = allEvents.filter(event => event.isPractice && !event.isCancelled).length;
-            console.log('Aggregated events', { total: allEvents.length, hiddenPracticeCount, showPractices });
-
             const now = new Date();
             const cutoff = new Date(now.getTime() - 3 * 60 * 60 * 1000);
+            const isCancelledScheduleEvent = (event) => {
+                const status = String(event?.status || '').toLowerCase();
+                return event?.isCancelled === true || status === 'cancelled' || status === 'canceled';
+            };
+            const isUpcomingScheduleEvent = (event) => event.date >= cutoff && !isCancelledScheduleEvent(event);
+
+            const hiddenPracticeCount = allEvents.filter(event => event.isPractice && !isCancelledScheduleEvent(event)).length;
+            console.log('Aggregated events', { total: allEvents.length, hiddenPracticeCount, showPractices });
 
             // Filter by practice checkbox + schedule view
             const forcePracticeVisibility = scheduleViewFilter === 'upcoming-practices';
             let filteredEvents = allEvents.filter(event => {
-                if (event.isPractice && !event.isCancelled && !showPractices && !forcePracticeVisibility) return false;
+                if (event.isPractice && !isCancelledScheduleEvent(event) && !showPractices && !forcePracticeVisibility) return false;
                 return true;
             });
             if (scheduleViewFilter === 'upcoming-all') {
-                filteredEvents = filteredEvents.filter(event => event.date >= cutoff);
+                filteredEvents = filteredEvents.filter(event => isUpcomingScheduleEvent(event));
                 filteredEvents.sort((a, b) => a.date - b.date);
             } else if (scheduleViewFilter === 'upcoming-games') {
-                filteredEvents = filteredEvents.filter(event => !event.isPractice && event.date >= cutoff);
+                filteredEvents = filteredEvents.filter(event => !event.isPractice && isUpcomingScheduleEvent(event));
                 filteredEvents.sort((a, b) => a.date - b.date);
             } else if (scheduleViewFilter === 'upcoming-practices') {
-                filteredEvents = filteredEvents.filter(event => event.isPractice && event.date >= cutoff);
+                filteredEvents = filteredEvents.filter(event => event.isPractice && isUpcomingScheduleEvent(event));
                 filteredEvents.sort((a, b) => a.date - b.date);
             } else if (scheduleViewFilter === 'past-all') {
                 filteredEvents = filteredEvents.filter(event => event.date < cutoff);

--- a/tests/smoke/edit-schedule-calendar-cancelled-import.spec.js
+++ b/tests/smoke/edit-schedule-calendar-cancelled-import.spec.js
@@ -51,7 +51,7 @@ export async function createOfficiatingAssignmentNotificationRecords() { return 
 `;
 
 const UTILS_STUB = `
-function futureDate(daysFromNow, hour, minute) {
+function relativeDate(daysFromNow, hour, minute) {
     const date = new Date();
     date.setUTCDate(date.getUTCDate() + daysFromNow);
     date.setUTCHours(hour, minute, 0, 0);
@@ -61,7 +61,7 @@ function futureDate(daysFromNow, hour, minute) {
 const calendarEvents = [
     {
         uid: 'cancelled-game-1',
-        dtstart: futureDate(7, 18, 0),
+        dtstart: relativeDate(-7, 18, 0),
         summary: 'Wildcats vs Cancelled Lions',
         location: 'Field 1',
         status: 'CANCELLED',
@@ -69,7 +69,7 @@ const calendarEvents = [
     },
     {
         uid: 'cancelled-practice-1',
-        dtstart: futureDate(8, 17, 30),
+        dtstart: relativeDate(-8, 17, 30),
         summary: '[CANCELED] Team Practice',
         location: 'Main Gym',
         isPractice: true
@@ -329,12 +329,16 @@ async function mockEditScheduleDependencies(page) {
     await page.route('**/js/schedule-csv-import.js?v=2', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: SCHEDULE_CSV_IMPORT_STUB }));
 }
 
-test('cancelled imported calendar events stay visible but hide track and plan actions', async ({ page, baseURL }) => {
+test('past cancelled imported calendar events stay visible but hide track and plan actions', async ({ page, baseURL }) => {
     await mockEditScheduleDependencies(page);
     const issues = createBootIssueCollector(page, { baseURL });
 
     await page.goto(buildUrl(baseURL, '/edit-schedule.html#teamId=team-1'), { waitUntil: 'domcontentloaded' });
     await expect(page.locator('#schedule-list')).toBeVisible();
+    await expect(page.locator('#schedule-list')).not.toContainText('Cancelled Lions');
+    await expect(page.locator('#schedule-list')).not.toContainText('Team Practice');
+
+    await page.getByRole('button', { name: 'Past Events' }).click();
 
     const cancelledGameRow = page.locator('#schedule-list > div', { hasText: 'Cancelled Lions' });
     const cancelledPracticeRow = page.locator('#schedule-list > div', { hasText: 'Team Practice' });

--- a/tests/smoke/edit-schedule-calendar-import.spec.js
+++ b/tests/smoke/edit-schedule-calendar-import.spec.js
@@ -494,7 +494,7 @@ test.describe('edit schedule imported calendar rows', () => {
         expect(params.get('eventTitle')).toBe('Evening Practice');
     });
 
-    test('suppresses tracked and conflicting imports while rendering cancelled rows without actions', async ({ page }) => {
+    test('suppresses tracked, conflicting, and cancelled imports from upcoming schedule filters', async ({ page }) => {
         await page.addInitScript((state) => {
             window.__editScheduleTestState = state;
             window.HTMLElement.prototype.scrollIntoView = function scrollIntoView() {};
@@ -540,14 +540,11 @@ test.describe('edit schedule imported calendar rows', () => {
         await page.goto(`${serverOrigin}/edit-schedule.html#teamId=team-1`, { waitUntil: 'domcontentloaded' });
 
         const scheduleList = page.locator('#schedule-list');
-        await expect(scheduleList).toContainText('Storm');
-        await expect(scheduleList).toContainText('Cancelled');
+        await expect(scheduleList).toContainText('Existing Opponent');
+        await expect(scheduleList).not.toContainText('Storm');
+        await expect(scheduleList).not.toContainText('Cancelled');
         await expect(scheduleList).not.toContainText('Tigers');
         await expect(scheduleList).not.toContainText('Bears');
-
-        const cancelledRow = scheduleList.locator('div').filter({ hasText: 'Storm' }).first();
-        await expect(cancelledRow).not.toContainText('Track');
-        await expect(cancelledRow).not.toContainText('Plan Practice');
     });
 });
 

--- a/tests/unit/edit-schedule-calendar-cancellation.test.js
+++ b/tests/unit/edit-schedule-calendar-cancellation.test.js
@@ -26,4 +26,14 @@ describe('edit schedule calendar cancellation handling', () => {
 
         expect(helperSource).toContain("replace(/\\[(?:CANCELED|CANCELLED)\\]\\s*/gi, '')");
     });
+
+    it('excludes cancelled calendar and DB events from upcoming schedule filters', () => {
+        const source = readEditSchedule();
+
+        expect(source).toContain("return event?.isCancelled === true || status === 'cancelled' || status === 'canceled';");
+        expect(source).toContain('const isUpcomingScheduleEvent = (event) => event.date >= cutoff && !isCancelledScheduleEvent(event);');
+        expect(source).toContain("filteredEvents = filteredEvents.filter(event => isUpcomingScheduleEvent(event));");
+        expect(source).toContain("filteredEvents = filteredEvents.filter(event => !event.isPractice && isUpcomingScheduleEvent(event));");
+        expect(source).toContain("filteredEvents = filteredEvents.filter(event => event.isPractice && isUpcomingScheduleEvent(event));");
+    });
 });


### PR DESCRIPTION
Closes #1301

- Exclude cancelled calendar events and DB events from All Upcoming, Upcoming Games, and Upcoming Practices filters.
- Centralize the upcoming-filter cancellation check across `isCancelled`, `cancelled`, and `canceled` status values.
- Add regression coverage for the edit schedule cancellation filtering wiring.

Validation:
- `npx vitest run tests/unit/edit-schedule-calendar-cancellation.test.js --reporter=verbose`