### PR TITLE
Social Feed: quick-share composer

### DIFF
--- a/apps/app/src/lib/socialLogic.ts
+++ b/apps/app/src/lib/socialLogic.ts
@@ -31,6 +31,8 @@ export type SocialFeedFilter = 'all' | 'friends' | 'teams' | 'players' | 'highli
 
 export type FriendshipStatus = 'none' | 'pending' | 'accepted' | 'declined' | 'removed' | 'blocked';
 
+export type SocialPostPresetId = 'player' | 'game' | 'photo' | 'practice' | 'achievement';
+
 export type SocialMedia = {
   type: 'image' | 'video';
   url: string;
@@ -106,6 +108,100 @@ export const socialVisibilityOptions: Array<{ id: SocialVisibility; label: strin
   { id: 'household', label: 'Household', detail: 'Visible to linked family only.' },
   { id: 'public_profile', label: 'Public profile', detail: 'Only for opted-in athlete/profile shares.' }
 ];
+
+export const socialPostPresets: Array<{
+  id: SocialPostPresetId;
+  type: SocialPostType;
+  label: string;
+  shortLabel: string;
+  detail: string;
+  prompt: string;
+  defaultVisibility: SocialVisibility;
+  prefersPlayer: boolean;
+  requiresMedia?: boolean;
+  suggestions: string[];
+}> = [
+  {
+    id: 'player',
+    type: 'player_moment',
+    label: 'Player moment',
+    shortLabel: 'Moment',
+    detail: 'Share a quick highlight for one player.',
+    prompt: 'What stood out today?',
+    defaultVisibility: 'friends',
+    prefersPlayer: true,
+    suggestions: [
+      'Proud of the effort today.',
+      'Big improvement this week.',
+      'Great teamwork in a big moment.'
+    ]
+  },
+  {
+    id: 'game',
+    type: 'game_recap',
+    label: 'Game recap',
+    shortLabel: 'Recap',
+    detail: 'Post a short team update after a game.',
+    prompt: 'How did the game go?',
+    defaultVisibility: 'friends_and_team',
+    prefersPlayer: false,
+    suggestions: [
+      'Hard fought game today.',
+      'Great team win today.',
+      'Lots to build on from this one.'
+    ]
+  },
+  {
+    id: 'photo',
+    type: 'team_media',
+    label: 'Photo or video',
+    shortLabel: 'Media',
+    detail: 'Add a photo or video with a caption.',
+    prompt: 'Add a caption for the photo or video.',
+    defaultVisibility: 'friends_and_team',
+    prefersPlayer: false,
+    requiresMedia: true,
+    suggestions: [
+      'Photos from today.',
+      'Team energy was great.',
+      'A few moments worth saving.'
+    ]
+  },
+  {
+    id: 'practice',
+    type: 'practice_packet',
+    label: 'Practice update',
+    shortLabel: 'Practice',
+    detail: 'Call out a packet, drill, or focus area.',
+    prompt: 'What should families know before practice?',
+    defaultVisibility: 'team',
+    prefersPlayer: false,
+    suggestions: [
+      'Practice packet is ready.',
+      'Focus work for the week is posted.',
+      'Good reps coming up at practice.'
+    ]
+  },
+  {
+    id: 'achievement',
+    type: 'achievement',
+    label: 'Achievement',
+    shortLabel: 'Achievement',
+    detail: 'Celebrate a milestone or season best.',
+    prompt: 'What milestone should be celebrated?',
+    defaultVisibility: 'friends',
+    prefersPlayer: true,
+    suggestions: [
+      'Milestone unlocked.',
+      'New season best.',
+      'A moment worth celebrating.'
+    ]
+  }
+];
+
+export function getSocialPostPresetForType(type: SocialPostType) {
+  return socialPostPresets.find((preset) => preset.type === type) || socialPostPresets[0];
+}
 
 export function emptySocialHome(): SocialHomeModel {
   return {

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -64,8 +64,10 @@ import {
 import {
   emptySocialHome,
   filterSocialFeedItems,
+  getSocialPostPresetForType,
   getSocialTypeLabel,
   getSocialVisibilityLabel,
+  socialPostPresets,
   socialFeedFilters,
   socialVisibilityOptions,
   type SocialFeedFilter,
@@ -178,6 +180,20 @@ export function Home({ auth }: { auth: AuthState }) {
   const today = new Date();
   const selectedComposerType = (searchParams.get('type') || 'manual_post') as SocialPostType;
 
+  const openComposer = (type: SocialPostType = 'manual_post') => {
+    const nextParams = new URLSearchParams(searchParams);
+    nextParams.set('section', 'feed');
+    nextParams.set('social', 'create');
+    if (type === 'manual_post') {
+      nextParams.delete('type');
+    } else {
+      nextParams.set('type', type);
+    }
+    setActiveSection('feed');
+    setSearchParams(nextParams, { replace: true });
+    setComposerOpen(true);
+  };
+
   const selectSection = (sectionId: HomeSectionId) => {
     setActiveSection(sectionId);
     const nextParams = new URLSearchParams(searchParams);
@@ -289,7 +305,7 @@ export function Home({ auth }: { auth: AuthState }) {
         </section>
       ) : null}
 
-      {!loading && activeSection === 'today' ? <TodaySection home={home} social={social} socialLoading={socialLoading} onOpenComposer={() => setComposerOpen(true)} /> : null}
+      {!loading && activeSection === 'today' ? <TodaySection home={home} social={social} socialLoading={socialLoading} onOpenComposer={openComposer} /> : null}
       {!loading && activeSection === 'feed' ? (
         <FeedSection
           social={social}
@@ -297,7 +313,7 @@ export function Home({ auth }: { auth: AuthState }) {
           auth={auth}
           home={home}
           onRefresh={() => refreshSocial()}
-          onOpenComposer={() => setComposerOpen(true)}
+          onOpenComposer={openComposer}
           onStatus={setSocialStatus}
         />
       ) : null}
@@ -316,6 +332,7 @@ export function Home({ auth }: { auth: AuthState }) {
 
       {composerOpen ? (
         <SocialComposerModal
+          key={selectedComposerType}
           home={home}
           social={social}
           initialType={selectedComposerType}
@@ -342,7 +359,7 @@ function TodaySection({
   home: ParentHomeModel;
   social: SocialHomeModel;
   socialLoading: boolean;
-  onOpenComposer: () => void;
+  onOpenComposer: (type?: SocialPostType) => void;
 }) {
   const unreadTeams = home.teams
     .filter((team) => Number(team.unreadCount || 0) > 0)
@@ -616,7 +633,7 @@ function AccessCard({ to, icon: Icon, title, detail, tone }: { to: string; icon:
   );
 }
 
-function HomeFeedPreview({ social, loading, onOpenComposer }: { social: SocialHomeModel; loading: boolean; onOpenComposer: () => void }) {
+function HomeFeedPreview({ social, loading, onOpenComposer }: { social: SocialHomeModel; loading: boolean; onOpenComposer: (type?: SocialPostType) => void }) {
   const previewItems = social.feedItems.slice(0, 2);
   return (
     <section className="home-feed-preview app-card overflow-hidden">
@@ -625,7 +642,7 @@ function HomeFeedPreview({ social, loading, onOpenComposer }: { social: SocialHo
           <div className="app-label">Community</div>
           <h2 className="mt-1 app-section-title">Team feed</h2>
         </div>
-        <button type="button" className="ghost-button !min-h-9 !px-3 text-xs" onClick={onOpenComposer}>
+        <button type="button" className="ghost-button !min-h-9 !px-3 text-xs" onClick={() => onOpenComposer('player_moment')}>
           <Plus className="h-4 w-4" aria-hidden="true" />
           Post
         </button>
@@ -692,7 +709,7 @@ function FeedSection({
   auth: AuthState;
   home: ParentHomeModel;
   onRefresh: () => Promise<void> | void;
-  onOpenComposer: () => void;
+  onOpenComposer: (type?: SocialPostType) => void;
   onStatus: (status: { tone: 'error' | 'success'; message: string } | null) => void;
 }) {
   const [filter, setFilter] = useState<SocialFeedFilter>('all');
@@ -711,7 +728,7 @@ function FeedSection({
             <button type="button" className="ghost-button !h-9 !min-h-9 !w-9 !p-0" onClick={() => onRefresh()} disabled={loading} aria-label="Refresh feed" title="Refresh feed">
               {loading ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
             </button>
-            <button type="button" className="primary-button !min-h-9 !px-3 text-xs" onClick={onOpenComposer}>
+            <button type="button" className="primary-button !min-h-9 !px-3 text-xs" onClick={() => onOpenComposer()}>
               <Plus className="h-4 w-4" aria-hidden="true" />
               Post
             </button>
@@ -765,12 +782,21 @@ function FeedSection({
             <section className="rounded-xl border border-primary-100 bg-primary-50 p-3">
               <div className="flex items-center gap-2 text-sm font-black text-primary-900">
                 <Sparkles className="h-4 w-4 text-primary-700" aria-hidden="true" />
-                Shareable ideas
+                Quick shares
               </div>
-              <div className="mt-2 space-y-2 text-xs font-semibold leading-5 text-primary-900/80">
-                <p>Post a game recap after a match report, a player moment from a profile update, or a practice packet reminder before training.</p>
+              <div className="mt-2 grid gap-2">
+                {socialPostPresets.slice(0, 4).map((preset) => (
+                  <button
+                    key={preset.id}
+                    type="button"
+                    className="flex min-h-10 items-center justify-between rounded-lg bg-white px-3 text-left text-xs font-black text-primary-900 ring-1 ring-primary-100 transition hover:ring-primary-300"
+                    onClick={() => onOpenComposer(preset.type)}
+                  >
+                    {preset.label}
+                    <ChevronRight className="h-4 w-4 flex-none text-primary-500" aria-hidden="true" />
+                  </button>
+                ))}
               </div>
-              <button type="button" className="mt-3 w-full rounded-lg bg-primary-600 px-3 py-2 text-xs font-black text-white" onClick={onOpenComposer}>Create a moment</button>
             </section>
           </aside>
         </div>
@@ -1182,37 +1208,64 @@ function SocialComposerModal({
   onClose: () => void;
   onSubmit: (input: CreateSocialPostInput) => Promise<void> | void;
 }) {
-  const [type, setType] = useState<SocialPostType>(initialType);
-  const [visibility, setVisibility] = useState<SocialVisibility>(initialType === 'player_moment' || initialType === 'achievement' ? 'friends' : 'team');
+  const initialPreset = getSocialPostPresetForType(initialType);
+  const [presetId, setPresetId] = useState(initialPreset.id);
+  const activePreset = socialPostPresets.find((preset) => preset.id === presetId) || initialPreset;
+  const type = activePreset.type;
+  const [visibility, setVisibility] = useState<SocialVisibility>(activePreset.defaultVisibility);
   const [teamId, setTeamId] = useState(home.teams[0]?.teamId || '');
-  const [playerKey, setPlayerKey] = useState(home.players[0] ? `${home.players[0].teamId}::${home.players[0].playerId}` : '');
-  const [title, setTitle] = useState('');
+  const [playerKey, setPlayerKey] = useState(initialPreset.prefersPlayer && home.players[0] ? `${home.players[0].teamId}::${home.players[0].playerId}` : '');
   const [caption, setCaption] = useState('');
   const [mediaFile, setMediaFile] = useState<File | null>(null);
+  const [detailsOpen, setDetailsOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [localError, setLocalError] = useState('');
 
-  const selectedTeam = home.teams.find((team) => team.teamId === teamId) || home.teams[0] || null;
-  const selectedPlayer = home.players.find((player) => `${player.teamId}::${player.playerId}` === playerKey) || null;
+  const selectedPlayer = activePreset.prefersPlayer
+    ? home.players.find((player) => `${player.teamId}::${player.playerId}` === playerKey) || home.players[0] || null
+    : home.players.find((player) => `${player.teamId}::${player.playerId}` === playerKey) || null;
+  const selectedTeam = selectedPlayer
+    ? home.teams.find((team) => team.teamId === selectedPlayer.teamId) || home.teams.find((team) => team.teamId === teamId) || home.teams[0] || null
+    : home.teams.find((team) => team.teamId === teamId) || home.teams[0] || null;
   const suggestedTitle = getComposerSuggestedTitle(type, selectedTeam, selectedPlayer);
   const visibleUserIds = visibility === 'friends' || visibility === 'friends_and_team'
     ? social.friends.map((friend) => friend.userId)
     : [];
+  const subjectLabel = selectedPlayer
+    ? `${selectedPlayer.playerName} · ${selectedPlayer.teamName}`
+    : selectedTeam?.teamName || 'Choose team';
+
+  const selectPreset = (nextPresetId: typeof presetId) => {
+    const nextPreset = socialPostPresets.find((preset) => preset.id === nextPresetId);
+    if (!nextPreset) return;
+    setPresetId(nextPreset.id);
+    setVisibility(nextPreset.defaultVisibility);
+    setLocalError('');
+    if (nextPreset.prefersPlayer && !playerKey && home.players[0]) {
+      setPlayerKey(`${home.players[0].teamId}::${home.players[0].playerId}`);
+      setTeamId(home.players[0].teamId);
+    }
+    if (!nextPreset.prefersPlayer) {
+      setPlayerKey('');
+    }
+  };
 
   const handleSubmit = async (event: FormEvent) => {
     event.preventDefault();
     setLocalError('');
     setSubmitting(true);
     try {
-      const media = mediaFile ? [await uploadSocialPostMedia(selectedTeam?.teamId || teamId, mediaFile)] : [];
-      const finalTitle = title.trim() || suggestedTitle;
-      if (!finalTitle) {
-        throw new Error('Add a title before posting.');
+      if (activePreset.requiresMedia && !mediaFile) {
+        throw new Error('Add a photo or video for this share.');
       }
+      if (!caption.trim() && !mediaFile) {
+        throw new Error('Add a short note or attach a photo/video.');
+      }
+      const media = mediaFile ? [await uploadSocialPostMedia(selectedTeam?.teamId || teamId, mediaFile)] : [];
       await onSubmit({
         type,
         visibility,
-        title: finalTitle,
+        title: suggestedTitle,
         detail: getComposerDetail(type, selectedTeam, selectedPlayer),
         caption: caption.trim(),
         teamId: selectedTeam?.teamId || teamId || null,
@@ -1238,76 +1291,114 @@ function SocialComposerModal({
         <div className="flex items-center justify-between gap-3 border-b border-gray-100 px-4 py-3">
           <div>
             <div className="app-label">Share</div>
-            <h2 className="mt-1 app-section-title">Create a moment</h2>
+            <h2 className="mt-1 app-section-title">What happened?</h2>
           </div>
           <button type="button" className="ghost-button !h-9 !min-h-9 !w-9 !p-0" onClick={onClose} aria-label="Close">×</button>
         </div>
-        <div className="max-h-[72dvh] space-y-3 overflow-y-auto p-4">
+        <div className="max-h-[72dvh] space-y-4 overflow-y-auto p-4">
           {localError ? <Status tone="error" message={localError} /> : null}
-          <div className="grid gap-3 sm:grid-cols-2">
-            <label className="block">
-              <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Post type</span>
-              <select value={type} onChange={(event) => setType(event.target.value as SocialPostType)} className="mt-1 min-h-11 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm font-bold outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100">
-                <option value="manual_post">Post</option>
-                <option value="player_moment">Player moment</option>
-                <option value="achievement">Achievement</option>
-                <option value="game_recap">Game recap</option>
-                <option value="team_media">Team media</option>
-                <option value="practice_packet">Practice packet</option>
-                <option value="upcoming_game">Upcoming game</option>
-              </select>
-            </label>
-            <label className="block">
-              <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Audience</span>
-              <select value={visibility} onChange={(event) => setVisibility(event.target.value as SocialVisibility)} className="mt-1 min-h-11 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm font-bold outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100">
-                {socialVisibilityOptions.map((option) => <option key={option.id} value={option.id}>{option.label}</option>)}
-              </select>
-              <span className="mt-1 block text-xs font-semibold text-gray-500">{socialVisibilityOptions.find((option) => option.id === visibility)?.detail}</span>
-            </label>
+
+          <div>
+            <div className="mb-2 text-xs font-black uppercase tracking-[0.04em] text-gray-500">Pick one</div>
+            <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
+              {socialPostPresets.map((preset) => {
+                const active = preset.id === activePreset.id;
+                return (
+                  <button
+                    key={preset.id}
+                    type="button"
+                    className={`min-h-[82px] rounded-xl border p-2 text-left transition ${active ? 'border-primary-300 bg-primary-50 text-primary-950 shadow-sm' : 'border-gray-200 bg-white text-gray-700 hover:border-primary-200'}`}
+                    onClick={() => selectPreset(preset.id)}
+                    aria-pressed={active}
+                  >
+                    <span className={`flex h-8 w-8 items-center justify-center rounded-lg ${active ? 'bg-primary-600 text-white' : 'bg-gray-100 text-gray-700'}`}>
+                      <SocialTypeIcon type={preset.type} />
+                    </span>
+                    <span className="mt-2 block text-xs font-black leading-4">{preset.shortLabel}</span>
+                  </button>
+                );
+              })}
+            </div>
           </div>
 
-          <div className="grid gap-3 sm:grid-cols-2">
-            <label className="block">
-              <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Team</span>
-              <select value={selectedTeam?.teamId || teamId} onChange={(event) => setTeamId(event.target.value)} className="mt-1 min-h-11 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm font-bold outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100">
-                {home.teams.length ? home.teams.map((team) => <option key={team.teamId} value={team.teamId}>{team.teamName}</option>) : <option value="">No team linked</option>}
-              </select>
-            </label>
-            <label className="block">
-              <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Player</span>
-              <select
-                value={playerKey}
-                onChange={(event) => {
-                  const nextKey = event.target.value;
-                  setPlayerKey(nextKey);
-                  const nextPlayer = home.players.find((player) => `${player.teamId}::${player.playerId}` === nextKey);
-                  if (nextPlayer?.teamId) setTeamId(nextPlayer.teamId);
-                }}
-                className="mt-1 min-h-11 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm font-bold outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100"
+          <div className="rounded-xl border border-gray-200 bg-gray-50 p-3">
+            <div className="flex items-start gap-3">
+              <div className="flex h-10 w-10 flex-none items-center justify-center rounded-xl bg-white text-primary-700 ring-1 ring-gray-200">
+                <SocialTypeIcon type={activePreset.type} />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="text-sm font-black text-gray-950">{activePreset.label}</div>
+                <div className="mt-0.5 text-xs font-semibold leading-5 text-gray-600">{activePreset.detail}</div>
+              </div>
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2">
+              <button type="button" className="rounded-full bg-white px-2.5 py-1 text-xs font-black text-gray-700 ring-1 ring-gray-200" onClick={() => setDetailsOpen((value) => !value)}>
+                {subjectLabel}
+              </button>
+              <button type="button" className="rounded-full bg-white px-2.5 py-1 text-xs font-black text-primary-700 ring-1 ring-primary-100" onClick={() => setDetailsOpen((value) => !value)}>
+                {getSocialVisibilityLabel(visibility)}
+              </button>
+            </div>
+          </div>
+
+          {detailsOpen ? (
+            <div className="grid gap-3 rounded-xl border border-gray-200 bg-white p-3 sm:grid-cols-2">
+              <label className="block">
+                <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Audience</span>
+                <select value={visibility} onChange={(event) => setVisibility(event.target.value as SocialVisibility)} className="mt-1 min-h-11 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm font-bold outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100">
+                  {socialVisibilityOptions.map((option) => <option key={option.id} value={option.id}>{option.label}</option>)}
+                </select>
+              </label>
+              <label className="block">
+                <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Team</span>
+                <select value={selectedTeam?.teamId || teamId} onChange={(event) => setTeamId(event.target.value)} className="mt-1 min-h-11 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm font-bold outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100">
+                  {home.teams.length ? home.teams.map((team) => <option key={team.teamId} value={team.teamId}>{team.teamName}</option>) : <option value="">No team linked</option>}
+                </select>
+              </label>
+              <label className="block sm:col-span-2">
+                <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Player</span>
+                <select
+                  value={playerKey}
+                  onChange={(event) => {
+                    const nextKey = event.target.value;
+                    setPlayerKey(nextKey);
+                    const nextPlayer = home.players.find((player) => `${player.teamId}::${player.playerId}` === nextKey);
+                    if (nextPlayer?.teamId) setTeamId(nextPlayer.teamId);
+                  }}
+                  className="mt-1 min-h-11 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm font-bold outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100"
+                >
+                  <option value="">Team post</option>
+                  {home.players.map((player) => <option key={`${player.teamId}-${player.playerId}`} value={`${player.teamId}::${player.playerId}`}>{player.playerName} · {player.teamName}</option>)}
+                </select>
+              </label>
+            </div>
+          ) : null}
+
+          <label className="block">
+            <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Write one short note</span>
+            <textarea value={caption} onChange={(event) => setCaption(event.target.value)} rows={4} placeholder={activePreset.prompt} className="mt-1 w-full resize-none rounded-xl border border-gray-200 bg-white px-3 py-2 text-base font-semibold leading-6 outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100" />
+          </label>
+
+          <div className="flex gap-2 overflow-x-auto pb-1">
+            {activePreset.suggestions.map((suggestion) => (
+              <button
+                key={suggestion}
+                type="button"
+                className="min-h-8 flex-none rounded-full bg-gray-100 px-3 text-xs font-black text-gray-700 transition hover:bg-primary-50 hover:text-primary-800"
+                onClick={() => setCaption(suggestion)}
               >
-                <option value="">Team post</option>
-                {home.players.map((player) => <option key={`${player.teamId}-${player.playerId}`} value={`${player.teamId}::${player.playerId}`}>{player.playerName} · {player.teamName}</option>)}
-              </select>
-            </label>
+                {suggestion}
+              </button>
+            ))}
           </div>
 
-          <label className="block">
-            <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Title</span>
-            <input value={title} onChange={(event) => setTitle(event.target.value)} placeholder={suggestedTitle} className="mt-1 min-h-11 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm font-bold outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100" />
-          </label>
-
-          <label className="block">
-            <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Caption</span>
-            <textarea value={caption} onChange={(event) => setCaption(event.target.value)} rows={4} placeholder="Write the update you want friends or team families to see." className="mt-1 w-full resize-none rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm font-semibold outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100" />
-          </label>
-
-          <label className="flex cursor-pointer items-center gap-3 rounded-xl border border-dashed border-gray-300 bg-gray-50 p-3">
+          <label className={`flex cursor-pointer items-center gap-3 rounded-xl border border-dashed p-3 ${mediaFile ? 'border-primary-300 bg-primary-50' : 'border-gray-300 bg-gray-50'}`}>
             <div className="flex h-10 w-10 flex-none items-center justify-center rounded-xl bg-white text-primary-700 ring-1 ring-gray-200">
               <ImagePlus className="h-5 w-5" aria-hidden="true" />
             </div>
             <span className="min-w-0 flex-1">
-              <span className="block text-sm font-black text-gray-950">{mediaFile ? mediaFile.name : 'Add photo or video'}</span>
-              <span className="mt-0.5 block text-xs font-semibold text-gray-500">Images and videos use the same upload path as team chat.</span>
+              <span className="block text-sm font-black text-gray-950">{mediaFile ? mediaFile.name : activePreset.requiresMedia ? 'Choose photo or video' : 'Add photo or video'}</span>
+              <span className="mt-0.5 block text-xs font-semibold text-gray-500">{mediaFile ? 'Ready to share.' : 'Optional unless this is a media post.'}</span>
             </span>
             <input type="file" accept="image/*,video/*" className="sr-only" onChange={(event) => setMediaFile(event.target.files?.[0] || null)} />
           </label>

--- a/docs/pr-notes/runs/1303-ci-fix-20260524T185056Z/architecture.md
+++ b/docs/pr-notes/runs/1303-ci-fix-20260524T185056Z/architecture.md
@@ -1,0 +1,7 @@
+# Architecture notes
+
+Subagents were unavailable in this environment (sessions_spawn agent allowlist: none), so this role analysis was completed inline.
+
+Root cause: `tests/smoke/app-home-player.spec.js` built app URLs from `baseURL` only. In the static-hosting preview job, app shell tests need to honor `SMOKE_APP_BASE_URL` so the hash route opens the Vite app host instead of the repository/static site root. Neighboring app smoke specs already use this pattern.
+
+Decision: align the Home smoke helper with the existing app smoke URL contract rather than changing product code. This keeps the blast radius limited to the failing smoke spec and preserves the app/runtime architecture.

--- a/docs/pr-notes/runs/1303-ci-fix-20260524T185056Z/code-plan.md
+++ b/docs/pr-notes/runs/1303-ci-fix-20260524T185056Z/code-plan.md
@@ -1,0 +1,7 @@
+# Code plan
+
+Subagents were unavailable in this environment, so this role analysis was completed inline.
+
+Implementation: update only `tests/smoke/app-home-player.spec.js` so `appUrl` uses `process.env.SMOKE_APP_BASE_URL || baseURL`, matching other app smoke specs. No product source change is needed because the CI failure is test URL drift in static-hosting preview.
+
+Risk: low. The helper still falls back to the prior `baseURL` behavior when `SMOKE_APP_BASE_URL` is not set.

--- a/docs/pr-notes/runs/1303-ci-fix-20260524T185056Z/qa.md
+++ b/docs/pr-notes/runs/1303-ci-fix-20260524T185056Z/qa.md
@@ -1,0 +1,10 @@
+# QA notes
+
+Subagents were unavailable in this environment, so this role analysis was completed inline.
+
+Validation target: Home smoke URLs should resolve through `SMOKE_APP_BASE_URL || baseURL`, matching `app-teams.spec.js`. This restores the module-route mocks and expected app shell route for `/home`, `/teams`, and desktop Home workspace cases.
+
+Executed:
+- `npm run app:build` passed.
+- `npx vitest run tests/unit/app-home-player-integration.test.jsx tests/unit/app-home-logic.test.js --reporter=verbose` passed, 9 tests.
+- Targeted Playwright smoke command was attempted, but local browser binaries are missing: Chromium headless shell not installed. CI has the browser dependency, so this is a local environment blocker, not a test assertion failure.

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -3,8 +3,7 @@ import { expect, test } from '@playwright/test';
 test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
 
 function appUrl(baseURL, hashPath) {
-    const appBaseURL = process.env.SMOKE_APP_BASE_URL || baseURL;
-    const url = new URL('/', appBaseURL);
+    const url = new URL('/', baseURL);
     url.hash = hashPath;
     return url.toString();
 }
@@ -12,6 +11,8 @@ function appUrl(baseURL, hashPath) {
 async function mockHomePlayerModules(page) {
     await page.addInitScript(() => {
         window.__playerLoads = [];
+        window.__socialPosts = [];
+        window.__socialUploads = [];
     });
 
     await page.route(/\/src\/lib\/useAuth\.ts(\?.*)?$/, async (route) => {
@@ -208,7 +209,10 @@ async function mockHomePlayerModules(page) {
                         }
                     };
                 }
-                export async function createSocialPost() { return 'post-new'; }
+                export async function createSocialPost(user, input) {
+                    window.__socialPosts.push({ user, input });
+                    return 'post-new';
+                }
                 export async function reactToSocialPost() {}
                 export async function commentOnSocialPost() {}
                 export async function hideSocialPost() {}
@@ -218,8 +222,9 @@ async function mockHomePlayerModules(page) {
                 export async function respondToFriendRequest() {}
                 export async function removeFriend() {}
                 export async function blockFriend() {}
-                export async function uploadSocialPostMedia() {
-                    return { type: 'image', url: 'https://img.example.test/social.png', name: 'social.png', thumbnailUrl: null };
+                export async function uploadSocialPostMedia(teamId, file) {
+                    window.__socialUploads.push({ teamId, name: file?.name || null, type: file?.type || null });
+                    return { type: 'image', url: 'https://img.example.test/social.png', name: file?.name || 'social.png', thumbnailUrl: null };
                 }
             `
         });
@@ -385,11 +390,28 @@ test('home dashboard drills into player detail with section submenus', async ({ 
     await expect(page.locator('a[href="#/teams?selectedTeamId=team-1&from=home"]')).toBeVisible();
 
     await page.getByRole('button', { name: 'Feed' }).click();
-    await expect(page.getByText('Shareable ideas')).toBeVisible();
+    await expect(page.getByText('Quick shares')).toBeVisible();
     await expect(page.getByText('Jamie Friend')).toBeVisible();
     await expect(page.getByText('Great ball movement in the second half.')).toBeVisible();
     await expect(page.locator('a[href="#/players/team-1/player-1"]').first()).toBeVisible();
     await expect(page.locator('a[href="#/home?section=friends"]')).toBeVisible();
+    await page.getByRole('button', { name: 'Player moment' }).click();
+    await expect(page.getByRole('heading', { name: 'What happened?' })).toBeVisible();
+    await expect(page.getByText('Pick one')).toBeVisible();
+    await expect(page.getByText('Write one short note')).toBeVisible();
+    await expect(page.getByText('Proud of the effort today.')).toBeVisible();
+    await expect(page.getByText('Post type')).toHaveCount(0);
+    await expect(page.getByText('Title')).toHaveCount(0);
+    await page.getByRole('button', { name: 'Proud of the effort today.' }).click();
+    await page.getByRole('dialog', { name: 'Create social post' }).getByRole('button', { name: 'Post', exact: true }).click();
+    await expect(page.getByText('Posted to your ALL PLAYS feed.')).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.__socialPosts[0]?.input)).toEqual(expect.objectContaining({
+        type: 'player_moment',
+        title: 'Pat Star moment',
+        caption: 'Proud of the effort today.',
+        teamId: 'team-1',
+        playerIds: ['player-1']
+    }));
 
     await page.locator('.home-section-nav').getByRole('button', { name: 'Friends' }).click();
     await expect(page.getByText('Needs response')).toBeVisible();
@@ -447,6 +469,45 @@ test('home dashboard drills into player detail with section submenus', async ({ 
     await page.getByRole('button', { name: 'Rules', exact: true }).click();
     await expect(page.getByText('Rules and limits')).toBeVisible();
     await expect(page.getByText('PTS: +$1.00 per pts')).toBeVisible();
+});
+
+test('social photo quick share requires media and posts uploaded media payload', async ({ page, baseURL }) => {
+    await mockHomePlayerModules(page);
+    await page.goto(appUrl(baseURL, '/home?section=feed&social=create&type=team_media'), { waitUntil: 'domcontentloaded' });
+
+    const dialog = page.getByRole('dialog', { name: 'Create social post' });
+    await expect(dialog.getByRole('heading', { name: 'What happened?' })).toBeVisible();
+    await expect(dialog.getByText('Photo or video').first()).toBeVisible();
+    await expect(dialog.getByText('Choose photo or video')).toBeVisible();
+    await expect(dialog.getByText('Post type')).toHaveCount(0);
+    await expect(dialog.getByText('Title')).toHaveCount(0);
+
+    await dialog.getByRole('button', { name: 'Post', exact: true }).click();
+    await expect(dialog.getByText('Add a photo or video for this share.')).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.__socialPosts.length)).toBe(0);
+
+    await dialog.locator('input[type="file"]').setInputFiles({
+        name: 'team-photo.png',
+        mimeType: 'image/png',
+        buffer: Buffer.from('image-bytes')
+    });
+    await expect(dialog.getByText('team-photo.png').first()).toBeVisible();
+    await dialog.getByRole('button', { name: 'Post', exact: true }).click();
+
+    await expect(page.getByText('Posted to your ALL PLAYS feed.')).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.__socialUploads[0])).toEqual({
+        teamId: 'team-1',
+        name: 'team-photo.png',
+        type: 'image/png'
+    });
+    await expect.poll(() => page.evaluate(() => window.__socialPosts[0]?.input)).toEqual(expect.objectContaining({
+        type: 'team_media',
+        visibility: 'friends_and_team',
+        title: 'Bears team photo',
+        teamId: 'team-1',
+        playerIds: [],
+        media: [{ type: 'image', url: 'https://img.example.test/social.png', name: 'team-photo.png', thumbnailUrl: null }]
+    }));
 });
 
 test('my teams opens from Home data with selected team, player, and chat routes', async ({ page, baseURL }) => {

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -3,7 +3,8 @@ import { expect, test } from '@playwright/test';
 test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
 
 function appUrl(baseURL, hashPath) {
-    const url = new URL('/', baseURL);
+    const appBaseURL = process.env.SMOKE_APP_BASE_URL || baseURL;
+    const url = new URL('/', appBaseURL);
     url.hash = hashPath;
     return url.toString();
 }

--- a/tests/unit/app-home-player-integration.test.jsx
+++ b/tests/unit/app-home-player-integration.test.jsx
@@ -138,6 +138,17 @@ async function clickButton(container, text) {
     await flush();
 }
 
+async function clickLastButton(container, text) {
+    const buttons = Array.from(container.querySelectorAll('button')).filter((candidate) => candidate.textContent.trim() === text);
+    if (!buttons.length) {
+        throw new Error(`Button not found: ${text}`);
+    }
+    await act(async () => {
+        buttons[buttons.length - 1].dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+}
+
 async function clickLinkByHref(container, href) {
     const link = Array.from(container.querySelectorAll('a')).find((candidate) => candidate.getAttribute('href') === href);
     if (!link) {
@@ -147,6 +158,23 @@ async function clickLinkByHref(container, href) {
         link.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
     });
     await flush();
+}
+
+async function attachComposerFile(container, fileName = 'social.png') {
+    const input = container.querySelector('input[type="file"]');
+    if (!input) {
+        throw new Error('File input not found');
+    }
+    const file = new File(['image-bytes'], fileName, { type: 'image/png' });
+    Object.defineProperty(input, 'files', {
+        configurable: true,
+        value: [file]
+    });
+    await act(async () => {
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flush();
+    return file;
 }
 
 beforeEach(() => {
@@ -403,13 +431,29 @@ describe('React app Home and player drill-in integration', () => {
         expect(teamLink?.getAttribute('aria-label')).toBe('Open Bears in My Teams');
 
         await clickButton(container, 'Feed');
-        await waitForText(container, 'Shareable ideas');
+        await waitForText(container, 'Quick shares');
         expect(container.textContent).toContain('Jamie Friend');
         expect(container.textContent).toContain('Great ball movement in the second half.');
         expect(Array.from(container.querySelectorAll('a')).map((link) => link.getAttribute('href'))).toEqual(expect.arrayContaining([
             '/players/team-1/player-1',
             '/home?section=friends'
         ]));
+        await clickButton(container, 'Player moment');
+        await waitForText(container, 'What happened?');
+        expect(container.textContent).toContain('Pick one');
+        expect(container.textContent).toContain('Write one short note');
+        expect(container.textContent).toContain('Proud of the effort today.');
+        expect(container.textContent).not.toContain('Post type');
+        expect(container.textContent).not.toContain('Title');
+        await clickButton(container, 'Proud of the effort today.');
+        await clickLastButton(container, 'Post');
+        expect(socialMocks.createSocialPost).toHaveBeenCalledWith(auth.user, expect.objectContaining({
+            type: 'player_moment',
+            title: 'Pat Star moment',
+            caption: 'Proud of the effort today.',
+            teamId: 'team-1',
+            playerIds: ['player-1']
+        }));
 
         await clickButton(container, 'Friends');
         await waitForText(container, 'Needs response');
@@ -458,6 +502,65 @@ describe('React app Home and player drill-in integration', () => {
         expect(container.textContent).toContain('PTS: +$1.00 per pts');
         expect(container.textContent).toContain('Max earned per game');
         expect(window.scrollTo).toHaveBeenCalled();
+    });
+
+    it('requires media for photo quick shares and submits a compact media post payload', async () => {
+        const { container } = await renderApp('/home?section=feed&social=create&type=team_media');
+        await waitForText(container, 'What happened?');
+
+        expect(container.textContent).toContain('Photo or video');
+        expect(container.textContent).toContain('Choose photo or video');
+        expect(container.textContent).toContain('Optional unless this is a media post.');
+
+        await clickLastButton(container, 'Post');
+        await waitForText(container, 'Add a photo or video for this share.');
+        expect(socialMocks.uploadSocialPostMedia).not.toHaveBeenCalled();
+        expect(socialMocks.createSocialPost).not.toHaveBeenCalled();
+
+        await attachComposerFile(container, 'team-photo.png');
+        expect(container.textContent).toContain('team-photo.png');
+        await clickLastButton(container, 'Post');
+
+        expect(socialMocks.uploadSocialPostMedia).toHaveBeenCalledWith('team-1', expect.objectContaining({
+            name: 'team-photo.png',
+            type: 'image/png'
+        }));
+        expect(socialMocks.createSocialPost).toHaveBeenCalledWith(auth.user, expect.objectContaining({
+            type: 'team_media',
+            visibility: 'friends_and_team',
+            title: 'Bears team photo',
+            teamId: 'team-1',
+            teamName: 'Bears',
+            playerIds: [],
+            media: [expect.objectContaining({ url: 'https://img.example.test/social.png' })],
+            visibleUserIds: ['friend-1']
+        }));
+    });
+
+    it('keeps advanced audience and subject controls tucked behind composer chips', async () => {
+        const { container } = await renderApp('/home?section=feed&social=create&type=practice_packet');
+        await waitForText(container, 'What happened?');
+
+        expect(container.textContent).toContain('Practice update');
+        expect(container.textContent).toContain('Bears');
+        expect(container.textContent).toContain('Team');
+        expect(container.textContent).not.toContain('Audience');
+
+        await clickButton(container, 'Team');
+        await waitForText(container, 'Audience');
+        expect(container.textContent).toContain('Player');
+
+        await clickButton(container, 'Practice packet is ready.');
+        await clickLastButton(container, 'Post');
+        expect(socialMocks.createSocialPost).toHaveBeenCalledWith(auth.user, expect.objectContaining({
+            type: 'practice_packet',
+            visibility: 'team',
+            title: 'Bears practice packet',
+            caption: 'Practice packet is ready.',
+            teamId: 'team-1',
+            route: '/schedule?teamId=team-1',
+            visibleUserIds: []
+        }));
     });
 
     it('keeps the current player profile subview after saves refresh player data', async () => {

--- a/tests/unit/app-social-logic.test.js
+++ b/tests/unit/app-social-logic.test.js
@@ -5,9 +5,11 @@ import {
     buildFriendshipId,
     buildSocialHomeModel,
     filterSocialFeedItems,
+    getSocialPostPresetForType,
     getSocialTypeLabel,
     mergeSocialFeedItems,
-    normalizeSocialFriend
+    normalizeSocialFriend,
+    socialPostPresets
 } from '../../apps/app/src/lib/socialLogic.ts';
 
 function event(overrides = {}) {
@@ -163,5 +165,48 @@ describe('React app social logic', () => {
             suggestions: 1
         });
         expect(getSocialTypeLabel('game_recap')).toBe('Game recap');
+    });
+
+    it('defines quick-share presets for the social composer instead of exposing raw post fields', () => {
+        expect(socialPostPresets.map((preset) => preset.id)).toEqual([
+            'player',
+            'game',
+            'photo',
+            'practice',
+            'achievement'
+        ]);
+        expect(getSocialPostPresetForType('player_moment')).toMatchObject({
+            label: 'Player moment',
+            defaultVisibility: 'friends',
+            prefersPlayer: true,
+            suggestions: expect.arrayContaining(['Proud of the effort today.'])
+        });
+        expect(getSocialPostPresetForType('team_media')).toMatchObject({
+            label: 'Photo or video',
+            defaultVisibility: 'friends_and_team',
+            requiresMedia: true
+        });
+        expect(getSocialPostPresetForType('manual_post')).toMatchObject({
+            id: 'player',
+            type: 'player_moment'
+        });
+    });
+
+    it('keeps social composer presets complete and aligned to parent-safe defaults', () => {
+        const presetByType = Object.fromEntries(socialPostPresets.map((preset) => [preset.type, preset]));
+
+        expect(Object.keys(presetByType)).toEqual([
+            'player_moment',
+            'game_recap',
+            'team_media',
+            'practice_packet',
+            'achievement'
+        ]);
+        expect(socialPostPresets.every((preset) => preset.prompt && preset.suggestions.length >= 3)).toBe(true);
+        expect(socialPostPresets.filter((preset) => preset.requiresMedia).map((preset) => preset.type)).toEqual(['team_media']);
+        expect(presetByType.player_moment).toMatchObject({ defaultVisibility: 'friends', prefersPlayer: true });
+        expect(presetByType.achievement).toMatchObject({ defaultVisibility: 'friends', prefersPlayer: true });
+        expect(presetByType.game_recap).toMatchObject({ defaultVisibility: 'friends_and_team', prefersPlayer: false });
+        expect(presetByType.practice_packet).toMatchObject({ defaultVisibility: 'team', prefersPlayer: false });
     });
 });


### PR DESCRIPTION
## Summary
- Replaces the social post form with parent-friendly quick-share presets.
- Adds preset metadata for player moments, game recaps, media, practice updates, and achievements.
- Adds unit, integration, and Playwright coverage for preset defaults, compact composer behavior, media-required validation, and social post payloads.

## Stack Notes
This is the clean remaining PR from the React app stack against current `master`. The earlier app/mobile areas from the requested stack are already present on `master`; this PR covers item 9, Social Feed, without dragging in stale legacy-site diffs from the old integration branch.

## Tests
- `npx vitest run tests/unit/app-social-logic.test.js tests/unit/app-home-player-integration.test.jsx --reporter=dot`
- `npm run app:build`
- `npx playwright test tests/smoke/app-home-player.spec.js --config=playwright.smoke.config.js --reporter=line`
