### PR TITLE
Fix manual balance adjustment credit behavior

### DIFF
--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -441,7 +441,7 @@ export function buildBalanceAdjustmentUpdate({ amount, note, actorId, currentBal
     const priorBalanceCents = Number.isFinite(currentBalance) ? Math.max(0, currentBalance) : 0;
     const paid = Number(currentPaidCents);
     const amountPaidCents = Number.isFinite(paid) ? Math.max(0, paid) : 0;
-    const amountDueCents = Math.max(0, priorBalanceCents + adjustmentCents);
+    const amountDueCents = Math.max(0, priorBalanceCents - adjustmentCents);
     const remainingBalanceCents = Math.max(0, amountDueCents - amountPaidCents);
     const status = normalizeLedgerStatus(amountDueCents, amountPaidCents);
     const ledgerEntry = {
@@ -814,7 +814,8 @@ function renderRecipients(container, countEl, recipients) {
                         </form>
                         <form data-action="adjust" class="rounded-xl border border-gray-200 bg-gray-50 p-3 space-y-2">
                             <div class="text-xs font-bold uppercase tracking-wide text-gray-500">Adjust balance</div>
-                            <input name="amount" type="number" step="0.01" placeholder="-10.00 or 5.00" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Balance adjustment amount">
+                            <input name="amount" type="number" step="0.01" placeholder="20.00 credit or -5.00 charge" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Balance adjustment amount">
+                            <p class="text-xs text-gray-500">Positive amounts credit the account and reduce what is owed. Negative amounts add a charge.</p>
                             <input name="note" type="text" required placeholder="Required reason" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Adjustment reason">
                             <button class="w-full rounded-lg bg-amber-600 px-3 py-2 text-sm font-semibold text-white hover:bg-amber-700">Save adjustment</button>
                         </form>

--- a/tests/unit/team-fees-admin.test.js
+++ b/tests/unit/team-fees-admin.test.js
@@ -2,7 +2,7 @@
 import { readFileSync } from 'node:fs';
 import { JSDOM } from 'jsdom';
 import { describe, it, expect } from 'vitest'; // Import Vitest globals
-import { buildManualPaymentUpdate, buildOnlineRefundRequest, getRecipientRefundableCents, isOnlineRefundEligible, buildOfflineRefundUpdate, buildTeamFeePaymentSummaryRows, serializeTeamFeePaymentSummaryCsv, buildTeamFeePaymentSummaryCsv, escapeCsvValue, registerTeamFeesAdminPageHandlers, normalizeTeamFeeDraft } from '../../js/team-fees-admin.js'; // Adjusted path
+import { buildManualPaymentUpdate, buildBalanceAdjustmentUpdate, buildOnlineRefundRequest, getRecipientRefundableCents, isOnlineRefundEligible, buildOfflineRefundUpdate, buildTeamFeePaymentSummaryRows, serializeTeamFeePaymentSummaryCsv, buildTeamFeePaymentSummaryCsv, escapeCsvValue, registerTeamFeesAdminPageHandlers, normalizeTeamFeeDraft } from '../../js/team-fees-admin.js'; // Adjusted path
 
 describe('team fees admin page routing', () => {
     it('reinitializes when same-page manage links update the hash', () => {
@@ -89,6 +89,15 @@ describe('normalizeTeamFeeDraft', () => {
     });
 });
 
+describe('balance adjustment form copy', () => {
+    it('explains that positive adjustments are credits and negative adjustments are charges', () => {
+        const source = readFileSync(new URL('../../js/team-fees-admin.js', import.meta.url), 'utf8');
+
+        expect(source).toContain('placeholder="20.00 credit or -5.00 charge"');
+        expect(source).toContain('Positive amounts credit the account and reduce what is owed. Negative amounts add a charge.');
+    });
+});
+
 describe('buildManualPaymentUpdate', () => {
     it('should correctly handle missing or invalid currentBalanceCents by defaulting to a high number to prevent premature "paid" status', () => {
         const paymentAmount = '5.00'; // $5.00 payment
@@ -148,6 +157,52 @@ describe('buildManualPaymentUpdate', () => {
         expect(updates.amountPaidCents).toBe(paymentAmountCents); // 500
         expect(updates.remainingBalanceCents).toBe(initialBalanceCents - paymentAmountCents); // 1000 - 500 = 500
         expect(updates.status).toBe('partial');
+    });
+});
+
+describe('buildBalanceAdjustmentUpdate', () => {
+    it('treats positive adjustments as credits that reduce the amount owed', () => {
+        const updates = buildBalanceAdjustmentUpdate({
+            amount: '20.00',
+            note: 'Scholarship credit',
+            actorId: 'admin-1',
+            currentBalanceCents: '15000',
+            currentPaidCents: '0'
+        });
+
+        expect(updates.status).toBe('unpaid');
+        expect(updates.amountDueCents).toBe(13000);
+        expect(updates.remainingBalanceCents).toBe(13000);
+        expect(updates.adjustment).toMatchObject({
+            amountCents: 2000,
+            previousAmountDueCents: 15000,
+            amountDueCents: 13000,
+            note: 'Scholarship credit',
+            adjustedBy: 'admin-1'
+        });
+        expect(updates.ledgerEntries).toEqual([
+            expect.objectContaining({
+                type: 'balance_adjustment',
+                amountCents: 2000,
+                previousAmountDueCents: 15000,
+                amountDueCents: 13000,
+                reason: 'Scholarship credit'
+            })
+        ]);
+    });
+
+    it('treats negative adjustments as charges that increase the amount owed', () => {
+        const updates = buildBalanceAdjustmentUpdate({
+            amount: '-5.00',
+            note: 'Late registration surcharge',
+            actorId: 'admin-1',
+            currentBalanceCents: '15000',
+            currentPaidCents: '0'
+        });
+
+        expect(updates.amountDueCents).toBe(15500);
+        expect(updates.remainingBalanceCents).toBe(15500);
+        expect(updates.adjustment.amountCents).toBe(-500);
     });
 });
 


### PR DESCRIPTION
Closes #1306

## Summary
- Treat positive manual balance adjustments as credits that reduce the amount owed.
- Treat negative manual balance adjustments as charges that increase the amount owed.
- Clarify the admin adjustment form copy so the sign convention matches the workflow guidance.

## Tests
- `npx vitest run tests/unit/team-fees-admin.test.js --reporter=verbose`