### PR TITLE
Fix scoreboard widget score orientation

### DIFF
--- a/docs/pr-notes/runs/1310-remediator-20260525T000652Z/architecture.md
+++ b/docs/pr-notes/runs/1310-remediator-20260525T000652Z/architecture.md
@@ -1,0 +1,15 @@
+# Architecture Notes
+
+## Decision
+Use `game.isHome` as authoritative only when `typeof game.isHome === 'boolean'`.
+
+## Implementation
+- Keep the existing score ordering calculation for explicit home/away state.
+- Add a `scoreLabel` value in `renderGame`.
+- Render `team - opponent` only for explicit boolean `isHome`.
+- Render neutral `home - away` for missing or non-boolean `isHome`.
+
+## Impact
+- No data model change.
+- No Firebase writes or security rule impact.
+- Blast radius is limited to public scoreboard score caption text.

--- a/docs/pr-notes/runs/1310-remediator-20260525T000652Z/code-plan.md
+++ b/docs/pr-notes/runs/1310-remediator-20260525T000652Z/code-plan.md
@@ -1,0 +1,13 @@
+# Code Plan
+
+## Files
+- `widget-scoreboard.html`
+- `tests/unit/scoreboard-widget.test.js`
+
+## Change Plan
+1. Add `scoreLabel` in `renderGame` using strict boolean detection.
+2. Replace hard-coded `team - opponent` caption with `${scoreLabel}`.
+3. Update static unit assertions to cover strict boolean label logic and neutral fallback label.
+
+## Commit Scope
+Only the review feedback for PR thread `PRRT_kwDOQe-T586Ea8OA` is addressed.

--- a/docs/pr-notes/runs/1310-remediator-20260525T000652Z/qa.md
+++ b/docs/pr-notes/runs/1310-remediator-20260525T000652Z/qa.md
@@ -1,0 +1,17 @@
+# QA Notes
+
+## Regression Coverage
+- Verify source includes strict boolean `isHome` handling for label selection.
+- Verify `team - opponent` is not hard-coded into the rendered score caption.
+- Verify neutral `home - away` label exists for fallback records.
+
+## Test Command
+```bash
+npx vitest run tests/unit/scoreboard-widget.test.js
+```
+
+## Manual Spot Check
+- Load `widget-scoreboard.html?teamId=<teamId>` with completed/live games.
+- Confirm explicit home/away records show `team - opponent`.
+- Confirm missing or non-boolean `isHome` records show `home - away`.
+- Confirm upcoming games still omit scores.

--- a/docs/pr-notes/runs/1310-remediator-20260525T000652Z/requirements.md
+++ b/docs/pr-notes/runs/1310-remediator-20260525T000652Z/requirements.md
@@ -1,0 +1,11 @@
+# Requirements Notes
+
+## Acceptance Criteria
+- Completed or live games still display a score.
+- When `game.isHome` is explicitly `true`, the score is labeled `team - opponent` and uses home score first.
+- When `game.isHome` is explicitly `false`, the score is labeled `team - opponent` and uses away score first.
+- When `game.isHome` is missing or non-boolean, the score uses home/away ordering and a neutral `home - away` label.
+
+## Edge Cases
+- `undefined`, `null`, strings, and numeric values for `isHome` must not imply team/opponent orientation.
+- Upcoming games still hide score output.

--- a/tests/unit/scoreboard-widget.test.js
+++ b/tests/unit/scoreboard-widget.test.js
@@ -30,8 +30,12 @@ describe('scoreboard widget embed', () => {
         expect(source).toContain('function renderGame(game)');
         expect(source).toContain('const teamScore = game.isHome === false ? awayScore : homeScore;');
         expect(source).toContain('const opponentScore = game.isHome === false ? homeScore : awayScore;');
+        expect(source).toContain("const scoreLabel = typeof game.isHome === 'boolean' ? 'team - opponent' : 'home - away';");
         expect(source).toContain('${teamScore} - ${opponentScore}');
+        expect(source).toContain('${scoreLabel}');
         expect(source).toContain('team - opponent');
+        expect(source).toContain('home - away');
+        expect(source).not.toContain('tracking-wide">team - opponent</div>');
         expect(source).not.toContain('${homeScore} - ${awayScore}');
         expect(source).toContain('live-game.html?teamId=${encodeURIComponent(state.teamId)}&gameId=${encodeURIComponent(gameId)}');
         expect(source).toContain('function clearRefreshTimer()');

--- a/tests/unit/scoreboard-widget.test.js
+++ b/tests/unit/scoreboard-widget.test.js
@@ -28,6 +28,11 @@ describe('scoreboard widget embed', () => {
         expect(source).toContain('.filter((game) => game._date && (isLive(game) || game._date >= now || (isCompleted(game) && game._date >= recentCutoff)))');
         expect(source).not.toContain('|| !isCompleted(game) || isLive(game)');
         expect(source).toContain('function renderGame(game)');
+        expect(source).toContain('const teamScore = game.isHome === false ? awayScore : homeScore;');
+        expect(source).toContain('const opponentScore = game.isHome === false ? homeScore : awayScore;');
+        expect(source).toContain('${teamScore} - ${opponentScore}');
+        expect(source).toContain('team - opponent');
+        expect(source).not.toContain('${homeScore} - ${awayScore}');
         expect(source).toContain('live-game.html?teamId=${encodeURIComponent(state.teamId)}&gameId=${encodeURIComponent(gameId)}');
         expect(source).toContain('function clearRefreshTimer()');
         expect(source).toContain("window.addEventListener('pagehide', clearRefreshTimer);");

--- a/widget-scoreboard.html
+++ b/widget-scoreboard.html
@@ -112,6 +112,7 @@
             const awayScore = Number.isFinite(Number(game.awayScore)) ? Number(game.awayScore) : 0;
             const teamScore = game.isHome === false ? awayScore : homeScore;
             const opponentScore = game.isHome === false ? homeScore : awayScore;
+            const scoreLabel = typeof game.isHome === 'boolean' ? 'team - opponent' : 'home - away';
             const showScore = isLive(game) || isCompleted(game);
             return `
                 <article class="p-4 hover:bg-gray-50 transition">
@@ -125,7 +126,7 @@
                             ${game.location ? `<p class="text-xs text-gray-500 truncate mt-1">${escapeHtml(game.location)}</p>` : ''}
                         </div>
                         <div class="flex items-center gap-3 flex-shrink-0">
-                            ${showScore ? `<div class="text-right font-mono"><div class="text-2xl font-black text-gray-900">${teamScore} - ${opponentScore}</div><div class="text-[10px] text-gray-500 uppercase tracking-wide">team - opponent</div></div>` : ''}
+                            ${showScore ? `<div class="text-right font-mono"><div class="text-2xl font-black text-gray-900">${teamScore} - ${opponentScore}</div><div class="text-[10px] text-gray-500 uppercase tracking-wide">${scoreLabel}</div></div>` : ''}
                             ${url ? `<a href="${url}" target="_blank" rel="noopener noreferrer" class="text-xs font-semibold text-primary-600 hover:text-primary-700">Details</a>` : ''}
                         </div>
                     </div>

--- a/widget-scoreboard.html
+++ b/widget-scoreboard.html
@@ -110,6 +110,8 @@
             const liveClass = isLive(game) ? 'bg-red-100 text-red-700' : isCompleted(game) ? 'bg-gray-100 text-gray-700' : 'bg-emerald-100 text-emerald-700';
             const homeScore = Number.isFinite(Number(game.homeScore)) ? Number(game.homeScore) : 0;
             const awayScore = Number.isFinite(Number(game.awayScore)) ? Number(game.awayScore) : 0;
+            const teamScore = game.isHome === false ? awayScore : homeScore;
+            const opponentScore = game.isHome === false ? homeScore : awayScore;
             const showScore = isLive(game) || isCompleted(game);
             return `
                 <article class="p-4 hover:bg-gray-50 transition">
@@ -123,7 +125,7 @@
                             ${game.location ? `<p class="text-xs text-gray-500 truncate mt-1">${escapeHtml(game.location)}</p>` : ''}
                         </div>
                         <div class="flex items-center gap-3 flex-shrink-0">
-                            ${showScore ? `<div class="text-right font-mono"><div class="text-2xl font-black text-gray-900">${homeScore} - ${awayScore}</div><div class="text-[10px] text-gray-500 uppercase tracking-wide">score</div></div>` : ''}
+                            ${showScore ? `<div class="text-right font-mono"><div class="text-2xl font-black text-gray-900">${teamScore} - ${opponentScore}</div><div class="text-[10px] text-gray-500 uppercase tracking-wide">team - opponent</div></div>` : ''}
                             ${url ? `<a href="${url}" target="_blank" rel="noopener noreferrer" class="text-xs font-semibold text-primary-600 hover:text-primary-700">Details</a>` : ''}
                         </div>
                     </div>


### PR DESCRIPTION
Closes #1309

## Summary
- Display scoreboard widget scores in selected-team-first order using `game.isHome`.
- Relabel the score as `team - opponent` to remove home/away ambiguity.
- Added regression coverage asserting the widget no longer renders raw `homeScore - awayScore`.

## Tests
- `npx vitest run tests/unit/scoreboard-widget.test.js --reporter=verbose`