### PR TITLE
Simplify profile invite link creation

### DIFF
--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -381,11 +381,6 @@ export function Profile({ auth }: { auth: AuthState }) {
       return;
     }
 
-    if (!inviteEmail.trim() && !invitePhone.trim()) {
-      setInviteStatus({ message: 'Enter an email or phone number.', tone: 'error' });
-      return;
-    }
-
     setBusy('invite');
     setInviteStatus(null);
 
@@ -648,14 +643,18 @@ export function Profile({ auth }: { auth: AuthState }) {
         </div>
 
         <form className="mt-4 space-y-3" onSubmit={createInviteCode}>
-          <div className="grid gap-3 sm:grid-cols-2">
-            <input className="auth-input" type="email" value={inviteEmail} onChange={(event) => setInviteEmail(event.target.value)} placeholder="coach@example.com" />
-            <input className="auth-input" type="tel" value={invitePhone} onChange={(event) => setInvitePhone(event.target.value)} placeholder="(555) 123-4567" />
-          </div>
+          <details className="rounded-xl border border-gray-200 bg-gray-50 p-3">
+            <summary className="cursor-pointer text-sm font-black text-gray-700">Advanced: add recipient label</summary>
+            <p className="mt-2 text-xs font-semibold leading-5 text-gray-500">Optional only. Use these fields to annotate invite history; the app does not send the invite.</p>
+            <div className="mt-3 grid gap-3 sm:grid-cols-2">
+              <input className="auth-input" type="email" value={inviteEmail} onChange={(event) => setInviteEmail(event.target.value)} placeholder="coach@example.com" aria-label="Invite email label" />
+              <input className="auth-input" type="tel" value={invitePhone} onChange={(event) => setInvitePhone(event.target.value)} placeholder="(555) 123-4567" aria-label="Invite phone label" />
+            </div>
+          </details>
           <div className="flex flex-wrap items-center gap-2">
             <button type="submit" className="primary-button" disabled={busy === 'invite'}>
-              {busy === 'invite' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <KeyRound className="h-4 w-4" aria-hidden="true" />}
-              Generate code
+              {busy === 'invite' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Link2 className="h-4 w-4" aria-hidden="true" />}
+              Generate invite link
             </button>
             <StatusMessage status={inviteStatus} />
           </div>
@@ -663,18 +662,22 @@ export function Profile({ auth }: { auth: AuthState }) {
 
         {generatedCode ? (
           <div className="mt-4 rounded-xl border border-emerald-200 bg-emerald-50 p-3">
-            <div className="text-xs font-extrabold uppercase tracking-[0.04em] text-emerald-700">Generated code</div>
+            <div className="text-xs font-extrabold uppercase tracking-[0.04em] text-emerald-700">Generated invite link</div>
             <div className="mt-2 flex flex-wrap items-center gap-2">
-              <code className="rounded-lg bg-white px-4 py-2 text-2xl font-black tracking-widest text-gray-950">{generatedCode}</code>
-              <button type="button" className="secondary-button" onClick={() => copyText(generatedCode, 'Code copied')}>
-                <Copy className="h-4 w-4" aria-hidden="true" />
-                Copy
-              </button>
-              <button type="button" className="secondary-button" onClick={() => copyText(signupLink, 'Link copied')}>
+              <button type="button" className="primary-button" onClick={() => copyText(signupLink, 'Link copied')}>
                 <Link2 className="h-4 w-4" aria-hidden="true" />
-                Copy link
+                Copy invite link
               </button>
+              <span className="break-all rounded-lg bg-white px-3 py-2 text-sm font-bold text-gray-700">{signupLink}</span>
               {copyStatus ? <span className="text-sm font-black text-emerald-700">{copyStatus}</span> : null}
+            </div>
+            <div className="mt-3 flex flex-wrap items-center gap-2 text-sm font-bold text-gray-600">
+              <span>Fallback code</span>
+              <code className="rounded-lg bg-white px-3 py-1.5 text-lg font-black tracking-widest text-gray-950">{generatedCode}</code>
+              <button type="button" className="ghost-button" onClick={() => copyText(generatedCode, 'Code copied')}>
+                <Copy className="h-4 w-4" aria-hidden="true" />
+                Copy code
+              </button>
             </div>
           </div>
         ) : null}

--- a/docs/pr-notes/runs/1312-ci-fix-20260525T002613Z/architecture.md
+++ b/docs/pr-notes/runs/1312-ci-fix-20260525T002613Z/architecture.md
@@ -1,0 +1,10 @@
+# Architecture notes
+
+## Root cause
+The React profile page invite UI changed its user-facing copy from "Generate code" to "Generate invite link", while the capability parity unit test still asserted the older token. The implementation already exposes the invite-link generation capability.
+
+## Minimal change
+Update the unit parity assertion to match the current React profile UI copy. No runtime architecture or data model change is required.
+
+## Risk and rollback
+Risk is limited to test coverage wording. Rollback is reverting the one-line test assertion change if product copy intentionally returns to "Generate code".

--- a/docs/pr-notes/runs/1312-ci-fix-20260525T002613Z/code-plan.md
+++ b/docs/pr-notes/runs/1312-ci-fix-20260525T002613Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code plan
+
+## Files
+- `tests/unit/app-auth-profile-capabilities.test.js`
+
+## Plan
+1. Locate the profile capability parity assertion for invite code generation.
+2. Replace the stale expected token `Generate code` with the current UI text `Generate invite link`.
+3. Run targeted unit validation and full unit tests.
+
+## Notes
+Role subagent attempts timed out, so implementation proceeded from direct repository inspection and local test evidence.

--- a/docs/pr-notes/runs/1312-ci-fix-20260525T002613Z/qa.md
+++ b/docs/pr-notes/runs/1312-ci-fix-20260525T002613Z/qa.md
@@ -1,0 +1,11 @@
+# QA notes
+
+## Validation scope
+Run the affected parity unit test first, then the full unit suite because CI failure is in the unit-tests job.
+
+## Commands
+- `npx vitest run tests/unit/app-auth-profile-capabilities.test.js --reporter=verbose`
+- `npm test`
+
+## Expected result
+All profile capability parity assertions pass, including invite code/link coverage. Full unit suite remains green.

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -458,9 +458,15 @@ test('profile exposes account, notification, invite, verification, password, upl
     await page.getByRole('button', { name: 'Invites' }).click();
     await expect(page.getByText('Invite codes')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Show 1 more' })).toBeVisible();
-    await page.getByPlaceholder('coach@example.com').fill('newcoach@example.com');
-    await page.getByRole('button', { name: 'Generate code' }).click();
+    await expect(page.getByText('Advanced: add recipient label')).toBeVisible();
+    await page.getByRole('button', { name: 'Generate invite link' }).click();
+    await expect(page.getByText('Generated invite link')).toBeVisible();
+    const copyInviteLink = page.getByRole('button', { name: 'Copy invite link' });
+    await expect(copyInviteLink).toBeVisible();
+    await expect(copyInviteLink).toHaveClass(/primary-button/);
+    await expect(page.getByText('Fallback code')).toBeVisible();
     await expect(page.getByText('NEWMVP42')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Copy code' })).toBeVisible();
 
     await page.getByRole('button', { name: 'Security' }).click();
     await expect(page.getByText('Email not verified')).toBeVisible();
@@ -485,6 +491,7 @@ test('profile exposes account, notification, invite, verification, password, upl
     }))).toMatchObject({
         uploads: [{ name: 'avatar.png', type: 'image/png' }],
         push: 1,
+        accessCodes: [{ userId: 'user-1', email: '', phone: '' }],
         password: ['new-password'],
         reset: ['parent@example.com'],
         signOut: 1

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -465,7 +465,7 @@ test('profile exposes account, notification, invite, verification, password, upl
     await expect(copyInviteLink).toBeVisible();
     await expect(copyInviteLink).toHaveClass(/primary-button/);
     await expect(page.getByText('Fallback code')).toBeVisible();
-    await expect(page.getByText('NEWMVP42')).toBeVisible();
+    await expect(page.getByText('NEWMVP42', { exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Copy code' })).toBeVisible();
 
     await page.getByRole('button', { name: 'Security' }).click();

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -187,7 +187,7 @@ describe('React app auth/profile capability parity', () => {
             'Email not verified',
             'Set a password',
             'Send password reset',
-            'Generate code',
+            'Generate invite link',
             'Show fewer codes',
             'Sign out'
         ]);


### PR DESCRIPTION
Closes #1311

## Summary
- Allows Profile > Invites to generate an invite link without email or phone.
- Moves optional recipient email/phone labels behind an Advanced disclosure.
- Makes Copy invite link the primary generated action while keeping the raw code visible as fallback.

## Tests
- Updated `tests/smoke/app-auth-profile.spec.js` for empty email/phone invite generation and primary copy-link UI.
- `git diff --check` passed.
- Targeted Playwright smoke run was blocked by missing local Playwright Chromium install.
- App build was blocked by existing missing `@capgo/capacitor-speech-recognition` module/types.