### PR TITLE
Fix team chat mention picker targeting

### DIFF
--- a/team-chat.html
+++ b/team-chat.html
@@ -2059,7 +2059,9 @@
             }
 
             const query = value.slice(atPos + 1, cursorPos);
-            if (query.includes(' ') || query.length > 20) {
+            const normalizedQuery = query.toLowerCase();
+            const supportedMention = 'all plays';
+            if (query.length > supportedMention.length || !supportedMention.startsWith(normalizedQuery)) {
                 hideMentionMenu();
                 return;
             }

--- a/tests/unit/team-chat-mentions.test.js
+++ b/tests/unit/team-chat-mentions.test.js
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readTeamChat() {
+    return readFileSync(new URL('../../team-chat.html', import.meta.url), 'utf8');
+}
+
+describe('team chat mention picker', () => {
+    it('only opens for the supported ALL PLAYS mention target', () => {
+        const html = readTeamChat();
+
+        expect(html).toContain("const supportedMention = 'all plays';");
+        expect(html).toContain('const normalizedQuery = query.toLowerCase();');
+        expect(html).toContain('!supportedMention.startsWith(normalizedQuery)');
+        expect(html).not.toContain("if (query.includes(' ') || query.length > 20)");
+    });
+
+    it('still inserts only the explicit ALL PLAYS assistant mention', () => {
+        const html = readTeamChat();
+
+        expect(html).toContain("const mentionText = '@ALL PLAYS ';");
+        expect(html).toContain("document.getElementById('mention-allplays').addEventListener('click', insertMention);");
+    });
+});


### PR DESCRIPTION
Closes #1314

- Limit the team chat mention picker to the supported `@ALL PLAYS` assistant mention.
- Prevent unsupported targeted mentions like `@Sam` from opening the picker and being replaced with `@ALL PLAYS`.
- Add regression coverage for the mention picker guard and explicit ALL PLAYS insertion path.

Validation:
- `npx vitest run tests/unit/team-chat-mentions.test.js --reporter=verbose`