### PR TITLE
Add app CI and agent guidance

### DIFF
--- a/.amazonq/rules/allplays.md
+++ b/.amazonq/rules/allplays.md
@@ -1,0 +1,9 @@
+# ALL PLAYS Repository Rules
+
+- Treat this as a hybrid repo: legacy static HTML/ES modules at the root, plus a React/TypeScript Capacitor app in `apps/app`.
+- Do not duplicate app feature logic separately for web, iOS, and Android. Put shared behavior in `apps/app/src`, with thin Capacitor adapters for native capabilities.
+- Keep Firebase Auth, Firestore, and Storage security enforced by rules and existing access helpers; do not bypass access checks client-side.
+- For React app changes, run or request `npm run app:build`, focused Vitest coverage in `tests/unit`, and focused Playwright smoke coverage in `tests/smoke/app-*.spec.js`.
+- For legacy page changes, preserve existing root HTML/JS patterns and add unit or smoke tests for changed flows.
+- GitHub Pages deployment publishes the root site and the React app under `/app/` using `scripts/stage-pages-bundle.mjs`.
+- Do not commit service account keys, signing certificates, provisioning profiles, or private secrets. Public Firebase client config is expected.

--- a/.github/workflows/app-github-pages.yml
+++ b/.github/workflows/app-github-pages.yml
@@ -43,52 +43,7 @@ jobs:
         run: npm run app:build
 
       - name: Stage GitHub Pages bundle
-        run: |
-          set -euo pipefail
-          site_dir="$RUNNER_TEMP/allplays-pages"
-          rm -rf "$site_dir"
-          mkdir -p "$site_dir"
-
-          rsync -a ./ "$site_dir"/ \
-            --exclude='.git/' \
-            --exclude='.github/' \
-            --exclude='.firebase/' \
-            --exclude='.claude/' \
-            --exclude='.playwright-mcp/' \
-            --exclude='.ralph/' \
-            --exclude='.zenflow/' \
-            --exclude='node_modules/' \
-            --exclude='apps/' \
-            --exclude='android/' \
-            --exclude='ios/' \
-            --exclude='functions/' \
-            --exclude='tests/' \
-            --exclude='test-results/' \
-            --exclude='scripts/' \
-            --exclude='src/' \
-            --exclude='_migration/' \
-            --exclude='_project-docs/' \
-            --exclude='_temp/' \
-            --exclude='spec/' \
-            --exclude='docs/' \
-            --exclude='*.md' \
-            --exclude='package.json' \
-            --exclude='package-lock.json' \
-            --exclude='capacitor.config.json' \
-            --exclude='firebase.json' \
-            --exclude='firestore.rules' \
-            --exclude='firestore.indexes.json' \
-            --exclude='storage.rules'
-
-          rm -rf "$site_dir/app"
-          mkdir -p "$site_dir/app"
-          test -d apps/app/dist || { echo "Build output not found at apps/app/dist"; exit 1; }
-          cp -R apps/app/dist/. "$site_dir/app/"
-          touch "$site_dir/.nojekyll"
-
-          echo "Staged legacy site root plus React app at /app/"
-          test -f "$site_dir/index.html"
-          test -f "$site_dir/app/index.html"
+        run: node scripts/stage-pages-bundle.mjs "$RUNNER_TEMP/allplays-pages"
 
       - name: Upload app Pages bundle artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 22
 
       - name: Validate critical cache-bust updates
         run: node scripts/check-critical-cache-bust.mjs
@@ -41,7 +41,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -90,7 +90,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -98,6 +98,17 @@ jobs:
 
       - name: Install app dependencies
         run: npm ci --prefix apps/app
+
+      - name: Build React app
+        run: npm run app:build
+
+      - name: Stage Firebase preview bundle
+        run: |
+          site_dir="$RUNNER_TEMP/firebase-preview-site"
+          config_file="$GITHUB_WORKSPACE/.firebase-preview.generated.json"
+          node scripts/stage-pages-bundle.mjs "$site_dir"
+          node scripts/write-firebase-hosting-config.mjs "$site_dir" "$config_file"
+          echo "FIREBASE_PREVIEW_CONFIG=$config_file" >> "$GITHUB_ENV"
 
       - name: Configure Firebase service account
         run: |
@@ -139,7 +150,7 @@ jobs:
         run: |
           set -euo pipefail
           log_file="$RUNNER_TEMP/firebase-preview-deploy.log"
-          npx firebase-tools@14.25.0 hosting:channel:deploy pr-${{ github.event.pull_request.number }} --project game-flow-c6311 --expires 7d --non-interactive | tee "$log_file"
+          npx firebase-tools@14.25.0 hosting:channel:deploy pr-${{ github.event.pull_request.number }} --project game-flow-c6311 --config "$FIREBASE_PREVIEW_CONFIG" --expires 7d --non-interactive | tee "$log_file"
           preview_url="$(grep -Eo 'https://[^ ]+' "$log_file" | tail -n1)"
           if [ -z "$preview_url" ]; then
             echo "Failed to extract preview URL from Firebase deploy output." >&2

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -84,7 +84,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -92,6 +92,17 @@ jobs:
 
       - name: Install app dependencies
         run: npm ci --prefix apps/app
+
+      - name: Build React app
+        run: npm run app:build
+
+      - name: Stage Firebase production bundle
+        run: |
+          site_dir="$RUNNER_TEMP/firebase-prod-site"
+          config_file="$GITHUB_WORKSPACE/.firebase-prod.generated.json"
+          node scripts/stage-pages-bundle.mjs "$site_dir"
+          node scripts/write-firebase-hosting-config.mjs "$site_dir" "$config_file"
+          echo "FIREBASE_PROD_CONFIG=$config_file" >> "$GITHUB_ENV"
 
       - name: Install Functions dependencies
         run: npm ci --prefix functions
@@ -103,4 +114,4 @@ jobs:
           echo "GOOGLE_APPLICATION_CREDENTIALS=$credentials_file" >> "$GITHUB_ENV"
 
       - name: Deploy Firebase production
-        run: npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,functions --project game-flow-c6311 --non-interactive
+        run: npx firebase-tools@14.25.0 deploy --only hosting,firestore:rules,firestore:indexes,functions --project game-flow-c6311 --config "$FIREBASE_PROD_CONFIG" --non-interactive

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -45,7 +45,7 @@ jobs:
         uses: actions/setup-java@v5
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -98,9 +98,44 @@ jobs:
       - name: Sync iOS project
         run: npx cap sync ios
 
+      - name: Resolve iOS package dependencies
+        run: |
+          run_with_retry() {
+            attempt=1
+            delay=20
+            until "$@"; do
+              if [ "$attempt" -ge 3 ]; then
+                return 1
+              fi
+              echo "Attempt $attempt failed. Retrying in ${delay}s..."
+              attempt=$((attempt + 1))
+              sleep "$delay"
+              delay=$((delay * 2))
+            done
+          }
+
+          run_with_retry xcodebuild \
+            -resolvePackageDependencies \
+            -project ios/App/App.xcodeproj \
+            -scheme App
+
       - name: Build iOS simulator app
         run: |
-          xcodebuild \
+          run_with_retry() {
+            attempt=1
+            delay=20
+            until "$@"; do
+              if [ "$attempt" -ge 3 ]; then
+                return 1
+              fi
+              echo "Attempt $attempt failed. Retrying in ${delay}s..."
+              attempt=$((attempt + 1))
+              sleep "$delay"
+              delay=$((delay * 2))
+            done
+          }
+
+          run_with_retry xcodebuild \
             -project ios/App/App.xcodeproj \
             -scheme App \
             -configuration Debug \

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -1,0 +1,110 @@
+name: mobile-build
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/mobile-build.yml"
+      - "apps/app/**"
+      - "android/**"
+      - "ios/**"
+      - "capacitor.config.json"
+      - "package.json"
+      - "package-lock.json"
+  push:
+    branches:
+      - master
+    paths:
+      - ".github/workflows/mobile-build.yml"
+      - "apps/app/**"
+      - "android/**"
+      - "ios/**"
+      - "capacitor.config.json"
+      - "package.json"
+      - "package-lock.json"
+  workflow_dispatch:
+
+concurrency:
+  group: mobile-build-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  android-debug:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install app dependencies
+        run: npm ci --prefix apps/app
+
+      - name: Build React app
+        run: npm run app:build
+
+      - name: Sync Android project
+        run: npx cap sync android
+
+      - name: Build Android debug APK
+        working-directory: android
+        run: ./gradlew :app:assembleDebug --stacktrace
+
+      - name: Upload Android debug APK
+        uses: actions/upload-artifact@v4
+        with:
+          name: allplays-android-debug
+          path: android/app/build/outputs/apk/debug/*.apk
+          retention-days: 7
+
+  ios-simulator:
+    runs-on: macos-15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install app dependencies
+        run: npm ci --prefix apps/app
+
+      - name: Build React app
+        run: npm run app:build
+
+      - name: Sync iOS project
+        run: npx cap sync ios
+
+      - name: Build iOS simulator app
+        run: |
+          xcodebuild \
+            -project ios/App/App.xcodeproj \
+            -scheme App \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            CODE_SIGNING_ALLOWED=NO \
+            build

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -4,7 +4,6 @@ on:
   workflow_run:
     workflows:
       - deploy-prod
-      - app-github-pages
     types:
       - completed
 

--- a/.github/workflows/post-deploy-smoke.yml
+++ b/.github/workflows/post-deploy-smoke.yml
@@ -4,6 +4,7 @@ on:
   workflow_run:
     workflows:
       - deploy-prod
+      - app-github-pages
     types:
       - completed
 
@@ -25,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -41,6 +42,7 @@ jobs:
         run: npx playwright test --config=playwright.smoke.config.js --reporter=line
         env:
           SMOKE_BASE_URL: https://allplays.ai
+          SMOKE_APP_BOOT_URL: https://allplays.ai/app/
           SMOKE_SUITE: production
           SMOKE_TEAM_ID: ${{ vars.SMOKE_TEAM_ID }}
           SMOKE_GAME_ID: ${{ vars.SMOKE_GAME_ID }}

--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/regression-guards.yml
+++ b/.github/workflows/regression-guards.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 22
 
       - name: Validate Firebase rules and deploy gates
         run: npm run ci:firebase-rules
@@ -39,7 +39,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
 
       - name: Install dependencies

--- a/.github/workflows/scheduled-prod-smoke.yml
+++ b/.github/workflows/scheduled-prod-smoke.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v5
         with:
-          node-version: 24
+          node-version: 22
           cache: npm
 
       - name: Install dependencies
@@ -38,6 +38,7 @@ jobs:
         run: npx playwright test --config=playwright.smoke.config.js --reporter=line
         env:
           SMOKE_BASE_URL: https://allplays.ai
+          SMOKE_APP_BOOT_URL: https://allplays.ai/app/
           SMOKE_SUITE: production
           SMOKE_TEAM_ID: ${{ vars.SMOKE_TEAM_ID }}
           SMOKE_GAME_ID: ${{ vars.SMOKE_GAME_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ _project-docs/
 
 # Firebase - NEVER commit these
 .firebaserc
+.firebase-*.generated.json
 firebase-debug.log
 firebase-debug.*.log
 firestore-debug.log

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,20 +4,32 @@
 - Root HTML pages (e.g., `index.html`, `dashboard.html`, `track.html`) are entry points for screens and flows.
 - Shared frontend logic lives in `js/` as ES modules (e.g., `js/auth.js`, `js/db.js`, `js/utils.js`).
 - Global styling is in `css/`, images and logos in `img/`.
+- The React/TypeScript app lives in `apps/app/` and is packaged for web at `/app/` plus iOS/Android through Capacitor.
+- Native Capacitor shells live in `ios/` and `android/`; keep native edits thin and put shared app logic in `apps/app/src/`.
 - Product specs and feature notes are kept in `spec/` and `_project-docs/`.
 - Firebase configuration and rules are in `firebase.json`, `firestore.rules`, and `firestore.indexes.json`.
 
 ## Build, Test, and Development Commands
-This is a static site; run any local static server from repo root:
+Legacy HTML site:
 - `python3 -m http.server` — quick local server on port 8000.
 - `npx http-server .` — alternative Node-based server.
-Open `http://localhost:8000` (or the printed port) and navigate to the HTML page you’re working on.
+
+React/Capacitor app:
+- `npm run app:dev` — Vite dev server for `apps/app` on port 5174.
+- `npm run app:build` — TypeScript check and Vite production build.
+- `npm run mobile:sync` — build the React app and sync Capacitor assets/plugins.
+- `npm run mobile:build:ios` — local iOS simulator build.
+- `npm run mobile:build:android` — local Android debug build.
+
+Open legacy pages at `http://localhost:8000`. Open the app locally at `http://localhost:5174`.
 
 ## Coding Style & Naming Conventions
-- Indentation: 4 spaces; use semicolons and ES module imports.
+- Legacy HTML/JS indentation: 4 spaces; use semicolons and ES module imports.
+- React app indentation follows the existing `apps/app` TypeScript/JSX style; keep shared behavior in reusable `apps/app/src/lib` helpers.
 - Naming: `camelCase` for variables/functions, `PascalCase` for classes (when used).
 - Keep DOM IDs and data keys consistent with HTML names (e.g., `admin-email` ↔ `#admin-email`).
 - Prefer small, focused functions in `js/` modules; reuse helpers in `js/utils.js`.
+- Do not duplicate feature logic separately for web, iOS, and Android. Put app feature behavior in `apps/app/src/` and use Capacitor adapters only for native capabilities.
 
 ## Testing Guidelines
 
@@ -43,6 +55,7 @@ The repo has two automated test tiers:
 
 ### What to write for each change
 - **New JS module:** unit test covering the exported functions and error branches.
+- **New React app helper:** unit test in `tests/unit/` and focused Playwright smoke when it changes a user flow.
 - **New static HTML page:** unit test checking structure, data attributes, JS wiring, and internal link targets; smoke test checking boot, key selectors, and interactive behaviors.
 - **Bug fix:** add a regression unit test that fails before the fix and passes after.
 - **UI flow change:** update or extend the relevant smoke spec.
@@ -61,3 +74,5 @@ HTML test pages in the repo root (`test-foul-tracking.html`, `test-pr-changes.ht
 - Admin access is controlled by the `isAdmin` field in Firestore; don’t bypass it client-side.
 - Update Firebase web config in `js/firebase.js` and `js/firebase-images.js` when changing projects.
 - Ensure Auth authorized domains include local dev and the deployed host.
+- Public Firebase config in app/native bundles is expected; do not commit service account keys, private API keys, provisioning profiles, or signing certificates.
+- GitHub Pages deployment uses `.github/workflows/app-github-pages.yml` and `scripts/stage-pages-bundle.mjs` to publish the legacy site root plus the React build under `/app/`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,28 +4,38 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-ALL PLAYS is a sports team management and live stat tracking web application. It's a static HTML + JavaScript app using Firebase as the backend, hosted on GitHub Pages.
+ALL PLAYS is a sports team management and live stat tracking product. The legacy website is static HTML + JavaScript using Firebase as the backend. The new ALL PLAYS app is a React/TypeScript + Capacitor app in `apps/app`, hosted on the website at `/app/` and packaged for iOS/Android.
 
 **Key Features:** Team management, roster management, live game stat tracking, game replays, team chat, parent dashboards, AI-powered game summaries.
 
 ## Tech Stack
 
-- **Frontend:** HTML5, JavaScript (ES Modules), Tailwind CSS (CDN)
+- **Legacy frontend:** HTML5, JavaScript (ES Modules), Tailwind CSS (CDN)
+- **App frontend:** React, TypeScript, Vite, Tailwind, Capacitor
 - **Backend:** Firebase (Auth, Firestore, Storage, Vertex AI/GenAI)
-- **Hosting:** GitHub Pages (static)
-- **No build step** - Direct ES module imports in browser
+- **Hosting:** GitHub Pages for `allplays.ai`; Firebase Hosting preview channels for PRs
+- **Native:** Capacitor iOS and Android projects in `ios/` and `android/`
 
 ## Local Development
 
 ```bash
-# Option 1: Python
+# Legacy static site
 python3 -m http.server 8000
 
-# Option 2: Node
+# Legacy static site alternative
 npx http-server .
+
+# React/Capacitor app
+npm run app:dev
+npm run app:build
+
+# Native sync/build checks
+npm run mobile:sync
+npm run mobile:build:ios
+npm run mobile:build:android
 ```
 
-Open `http://localhost:8000` in your browser.
+Open legacy pages at `http://localhost:8000`. Open the React app at `http://localhost:5174`.
 
 ## Testing
 
@@ -53,6 +63,7 @@ Playwright tests against a live static server. Cover page boot, interactive flow
 
 ### What to write
 - **New JS module** → unit test for exported functions.
+- **New React app helper** → unit test in `tests/unit/` and focused app smoke coverage when it changes a route or user flow.
 - **New static page** → unit test (structure + JS wiring) + smoke spec (boot + interactions).
 - **Bug fix** → regression unit test that fails before the fix.
 
@@ -75,6 +86,15 @@ Playwright tests against a live static server. Cover page boot, interactive flow
 - `drill-constants.js` - Practice drill library data (categories, skill levels)
 - `global-search.js` - Cross-entity search functionality
 - `vendor/` - Firebase SDK bundles (ES Module format): app, auth, firestore, storage, ai
+
+### React/Capacitor App (`apps/app/`)
+- `src/pages/` - App routes for auth, home, schedule, messages, teams, player details, profile, private AI, and parent tools
+- `src/components/` - Shared app shell, navigation, cards, and form UI
+- `src/lib/` - Shared app data services, Firebase adapters, native adapters, and feature helpers
+- `vite.config.ts` - Uses `base: './'` so the production build works under `/app/`
+- `capacitor.config.json` - Uses `apps/app/dist` as the native WebView bundle
+
+Keep app feature logic shared across web/iOS/Android. Use thin Capacitor adapters for native auth, push, share, media, and dictation behavior.
 
 ### Two Firebase Projects
 1. **Main project** (`game-flow-c6311`): Auth, Firestore, business logic
@@ -158,7 +178,8 @@ See `AGENTS.md` for commit message style (short, imperative, sentence-case) and 
 4. **Activation codes:** Required for signup (no open registration)
 5. **Public API keys:** Firebase keys are public; security is via Firestore rules
 6. **Mobile-first:** Tracker pages optimized for phone screens
-7. **Vanilla JS:** No React/Vue - direct DOM manipulation with querySelector
+7. **Legacy pages:** Use vanilla JS and direct DOM manipulation
+8. **React app:** Follow the existing `apps/app` component and helper patterns; avoid forking feature logic by platform
 
 ## Deployment
 
@@ -170,4 +191,8 @@ firebase deploy --only firestore:rules
 firebase deploy --only hosting
 ```
 
-GitHub Pages: Push to master branch, enable Pages in repo settings.
+GitHub Pages: `.github/workflows/app-github-pages.yml` stages the legacy root site plus the React app under `/app/` with `scripts/stage-pages-bundle.mjs`.
+
+Firebase previews: `.github/workflows/deploy-preview.yml` deploys a staged preview bundle so PR preview URLs include `/app/`.
+
+Production smoke: `post-deploy-smoke` and `scheduled-prod-smoke` check the legacy site plus the deployed `/app/` boot route.

--- a/apps/app/AGENTS.md
+++ b/apps/app/AGENTS.md
@@ -1,0 +1,28 @@
+# App Guidelines
+
+## Scope
+- This directory contains the React/TypeScript ALL PLAYS app used for web at `/app/` and for iOS/Android through Capacitor.
+- Shared app behavior belongs in `src/lib/`; native-specific work should stay in thin Capacitor adapters.
+- Keep the web, iOS, and Android experiences on the same React routes instead of forking feature logic per platform.
+
+## Commands
+- `npm run app:dev` from the repo root starts the Vite app on port 5174.
+- `npm run app:build` from the repo root runs TypeScript and Vite production build.
+- `npm run mobile:sync` from the repo root builds and syncs Capacitor.
+- `npm run mobile:build:ios` and `npm run mobile:build:android` run local native build checks.
+
+## Testing
+- Put app unit tests in root `tests/unit/`, importing app helpers from `apps/app/src/`.
+- Put app Playwright flows in root `tests/smoke/app-*.spec.js`.
+- For user-facing app changes, run the targeted unit tests, `npm run app:build`, and the relevant app smoke spec with `SMOKE_APP_BASE_URL`.
+- Production boot coverage for `https://allplays.ai/app/` lives in `tests/smoke/app-production-bootstrap.spec.js`.
+
+## UX And Implementation
+- Keep mobile-first layouts compact and parent-focused, but make desktop browser layouts comfortable when the app is hosted at `/app/`.
+- Prefer existing app components, route patterns, and visual tokens over new one-off UI styles.
+- Do not import full legacy HTML pages into the React app. Reuse portable data contracts and helper logic instead.
+- Keep native permissions, Google auth, push, sharing, media upload, and dictation behind small adapter functions.
+
+## Deployment
+- Vite uses relative assets (`base: './'`) so the build works under `/app/`.
+- GitHub Pages and Firebase preview/prod workflows stage the root static site plus `apps/app/dist` through `scripts/stage-pages-bundle.mjs`.

--- a/docs/pr-notes/runs/1316-remediator-20260525T002331Z/architecture.md
+++ b/docs/pr-notes/runs/1316-remediator-20260525T002331Z/architecture.md
@@ -1,0 +1,11 @@
+# Architecture
+
+## Decision
+Keep `post-deploy-smoke` tied only to `deploy-prod`, because `workflow_run` observes whole workflow success and cannot prove that the conditional `app-github-pages` deploy job actually ran.
+
+## Risk Surface
+- Current risk: `app-github-pages` can build successfully while deployment is skipped, then production smoke checks stale `https://allplays.ai` content.
+- Proposed risk: Pages-specific deploys will not automatically trigger this production smoke unless covered by a future deploy-confirmed workflow.
+
+## Minimal Change
+Edit only `.github/workflows/post-deploy-smoke.yml` and remove `app-github-pages` from the trigger list.

--- a/docs/pr-notes/runs/1316-remediator-20260525T002331Z/code-plan.md
+++ b/docs/pr-notes/runs/1316-remediator-20260525T002331Z/code-plan.md
@@ -1,0 +1,13 @@
+# Code Plan
+
+## Implementation Plan
+1. Edit `.github/workflows/post-deploy-smoke.yml`.
+2. Remove `app-github-pages` from `on.workflow_run.workflows`.
+3. Leave the existing `deploy-prod` trigger, branch guard, checkout SHA, and production smoke command unchanged.
+
+## Validation Commands
+- `npm test`
+- `git diff --check`
+
+## Rollback
+Revert this commit if a deploy-confirmed GitHub Pages smoke trigger is implemented separately.

--- a/docs/pr-notes/runs/1316-remediator-20260525T002331Z/qa.md
+++ b/docs/pr-notes/runs/1316-remediator-20260525T002331Z/qa.md
@@ -1,0 +1,10 @@
+# QA Plan
+
+## Validation
+- Inspect `.github/workflows/post-deploy-smoke.yml` and confirm `workflow_run.workflows` contains `deploy-prod` only.
+- Inspect `.github/workflows/app-github-pages.yml` and confirm deploy remains conditional, so it is not safe as a whole-workflow trigger.
+- Run the relevant fast test gate from repo guidance: `npm test`.
+
+## Negative Checks
+- A successful `app-github-pages` build-only run should not trigger `post-deploy-smoke`.
+- A failed or cancelled `deploy-prod` run should continue to be blocked by the existing job `if` guard.

--- a/docs/pr-notes/runs/1316-remediator-20260525T002331Z/requirements.md
+++ b/docs/pr-notes/runs/1316-remediator-20260525T002331Z/requirements.md
@@ -1,0 +1,9 @@
+# Requirements
+
+## Acceptance Criteria
+- `post-deploy-smoke` runs after a successful `deploy-prod` workflow on `master`.
+- `post-deploy-smoke` does not run after `app-github-pages` succeeds without a real Pages deployment.
+- Production smoke failures remain attributable to real production deploys or scheduled production monitoring, not stale production content.
+
+## Exact Expected Change
+Remove `app-github-pages` from `.github/workflows/post-deploy-smoke.yml` `workflow_run.workflows` unless a deploy-confirmed signal exists. No product behavior changes.

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test:smoke": "playwright test --config=playwright.smoke.config.js",
     "test:smoke:team-fallback": "playwright test tests/smoke/team-fallback-regressions.spec.js --config=playwright.smoke.config.js --reporter=line",
     "ci:firebase-rules": "node scripts/validate-firebase-rules-ci.mjs",
+    "stage:pages": "node scripts/stage-pages-bundle.mjs",
     "app:build-help-index": "node scripts/build-app-help-knowledge-index.mjs",
     "serve:firebase": "firebase emulators:start --only hosting --project demo-allplays",
     "app:dev": "npm --prefix apps/app run dev",

--- a/scripts/stage-pages-bundle.mjs
+++ b/scripts/stage-pages-bundle.mjs
@@ -1,0 +1,134 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const defaultRootDir = path.resolve(scriptDir, '..');
+
+const excludedDirectories = new Set([
+    '.amazonq',
+    '.claude',
+    '.firebase',
+    '.git',
+    '.github',
+    '.playwright-mcp',
+    '.ralph',
+    '.zenflow',
+    '_migration',
+    '_project-docs',
+    '_temp',
+    'android',
+    'apps',
+    'docs',
+    'functions',
+    'ios',
+    'node_modules',
+    'scripts',
+    'spec',
+    'src',
+    'test-results',
+    'tests'
+]);
+
+const excludedFiles = new Set([
+    'capacitor.config.json',
+    'firebase.json',
+    'firestore.indexes.json',
+    'firestore.rules',
+    'package-lock.json',
+    'package.json',
+    'storage.rules'
+]);
+
+function toRelativePath(rootDir, filePath) {
+    return path.relative(rootDir, filePath).split(path.sep).join('/');
+}
+
+function shouldExclude(rootDir, sourcePath, entry) {
+    const relativePath = toRelativePath(rootDir, sourcePath);
+    const parts = relativePath.split('/').filter(Boolean);
+
+    if (entry.name.startsWith('.')) {
+        return true;
+    }
+
+    if (parts.some((part) => excludedDirectories.has(part))) {
+        return true;
+    }
+
+    if (entry.isFile()) {
+        return excludedFiles.has(entry.name) || entry.name.endsWith('.md');
+    }
+
+    return false;
+}
+
+function copyPublicRoot(rootDir, destinationDir, currentDir = rootDir) {
+    for (const entry of fs.readdirSync(currentDir, { withFileTypes: true })) {
+        const sourcePath = path.join(currentDir, entry.name);
+        if (shouldExclude(rootDir, sourcePath, entry)) {
+            continue;
+        }
+
+        const relativePath = path.relative(rootDir, sourcePath);
+        const destinationPath = path.join(destinationDir, relativePath);
+
+        if (entry.isDirectory()) {
+            fs.mkdirSync(destinationPath, { recursive: true });
+            copyPublicRoot(rootDir, destinationDir, sourcePath);
+        } else if (entry.isFile()) {
+            fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+            fs.copyFileSync(sourcePath, destinationPath);
+        } else if (entry.isSymbolicLink()) {
+            const linkTarget = fs.readlinkSync(sourcePath);
+            fs.mkdirSync(path.dirname(destinationPath), { recursive: true });
+            fs.symlinkSync(linkTarget, destinationPath);
+        }
+    }
+}
+
+export function stagePagesBundle(destinationDir, { rootDir = defaultRootDir } = {}) {
+    if (!destinationDir) {
+        throw new Error('Destination directory is required.');
+    }
+
+    const resolvedRoot = path.resolve(rootDir);
+    const resolvedDestination = path.resolve(destinationDir);
+    const appDistDir = path.join(resolvedRoot, 'apps', 'app', 'dist');
+    const appDestinationDir = path.join(resolvedDestination, 'app');
+
+    if (!fs.existsSync(appDistDir)) {
+        throw new Error('Build output not found at apps/app/dist');
+    }
+
+    fs.rmSync(resolvedDestination, { recursive: true, force: true });
+    fs.mkdirSync(resolvedDestination, { recursive: true });
+
+    copyPublicRoot(resolvedRoot, resolvedDestination);
+
+    fs.rmSync(appDestinationDir, { recursive: true, force: true });
+    fs.mkdirSync(appDestinationDir, { recursive: true });
+    fs.cpSync(appDistDir, appDestinationDir, { recursive: true });
+    fs.writeFileSync(path.join(resolvedDestination, '.nojekyll'), '');
+
+    const rootIndexPath = path.join(resolvedDestination, 'index.html');
+    const appIndexPath = path.join(appDestinationDir, 'index.html');
+    if (!fs.existsSync(rootIndexPath)) {
+        throw new Error('Staged root index.html was not found.');
+    }
+    if (!fs.existsSync(appIndexPath)) {
+        throw new Error('Staged app index.html was not found.');
+    }
+
+    return {
+        destinationDir: resolvedDestination,
+        rootIndexPath,
+        appIndexPath
+    };
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+    const destinationDir = process.argv[2];
+    const result = stagePagesBundle(destinationDir);
+    console.log(`Staged legacy site root plus React app at /app/: ${result.destinationDir}`);
+}

--- a/scripts/write-firebase-hosting-config.mjs
+++ b/scripts/write-firebase-hosting-config.mjs
@@ -1,0 +1,35 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url));
+const defaultRootDir = path.resolve(scriptDir, '..');
+
+export function writeFirebaseHostingConfig(publicDir, outputFile, { rootDir = defaultRootDir } = {}) {
+    if (!publicDir) {
+        throw new Error('Hosting public directory is required.');
+    }
+    if (!outputFile) {
+        throw new Error('Output config path is required.');
+    }
+
+    const firebaseConfigPath = path.join(rootDir, 'firebase.json');
+    const config = JSON.parse(fs.readFileSync(firebaseConfigPath, 'utf8'));
+
+    config.hosting = {
+        ...config.hosting,
+        public: path.resolve(publicDir)
+    };
+
+    const resolvedOutputFile = path.resolve(outputFile);
+    fs.mkdirSync(path.dirname(resolvedOutputFile), { recursive: true });
+    fs.writeFileSync(resolvedOutputFile, `${JSON.stringify(config, null, 2)}\n`);
+
+    return resolvedOutputFile;
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+    const [publicDir, outputFile] = process.argv.slice(2);
+    const resolvedOutputFile = writeFirebaseHostingConfig(publicDir, outputFile);
+    console.log(`Wrote Firebase hosting config: ${resolvedOutputFile}`);
+}

--- a/tests/smoke/app-production-bootstrap.spec.js
+++ b/tests/smoke/app-production-bootstrap.spec.js
@@ -1,0 +1,40 @@
+import { expect, test } from '@playwright/test';
+
+const appBootUrl = process.env.SMOKE_APP_BOOT_URL || '';
+test.skip(!appBootUrl, 'SMOKE_APP_BOOT_URL is required for production app boot smoke tests');
+
+function appUrl(hashPath = '/auth') {
+    const url = new URL(appBootUrl);
+    if (!url.pathname.endsWith('/')) {
+        url.pathname = `${url.pathname}/`;
+    }
+    url.hash = hashPath;
+    return url.toString();
+}
+
+test('production React app boots from deployed /app bundle', async ({ page }) => {
+    const fatalErrors = [];
+    const failedAssets = [];
+
+    page.on('pageerror', (error) => {
+        fatalErrors.push(error.message);
+    });
+
+    page.on('requestfailed', (request) => {
+        if (['document', 'script', 'stylesheet'].includes(request.resourceType())) {
+            failedAssets.push(`${request.method()} ${request.url()} ${request.failure()?.errorText || ''}`.trim());
+        }
+    });
+
+    await page.goto(appUrl('/auth'), { waitUntil: 'domcontentloaded' });
+
+    await expect(page).toHaveTitle(/ALL PLAYS APP/i);
+    await expect(page.locator('#root')).not.toBeEmpty();
+    await expect(page.getByRole('heading', { name: 'Sign in' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Continue with Google' })).toBeVisible();
+    await expect(page.locator('input[type="email"]')).toBeVisible();
+    await expect(page.locator('input[type="password"]')).toBeVisible();
+
+    expect(fatalErrors).toEqual([]);
+    expect(failedAssets).toEqual([]);
+});

--- a/tests/unit/pages-bundle-staging.test.js
+++ b/tests/unit/pages-bundle-staging.test.js
@@ -1,0 +1,86 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { stagePagesBundle } from '../../scripts/stage-pages-bundle.mjs';
+import { writeFirebaseHostingConfig } from '../../scripts/write-firebase-hosting-config.mjs';
+
+const tempDirs = [];
+
+function makeTempDir() {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'allplays-pages-bundle-'));
+    tempDirs.push(dir);
+    return dir;
+}
+
+function writeFile(filePath, contents = '') {
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, contents);
+}
+
+afterEach(() => {
+    while (tempDirs.length) {
+        fs.rmSync(tempDirs.pop(), { recursive: true, force: true });
+    }
+});
+
+describe('pages bundle staging', () => {
+    it('stages the legacy root and React app without publishing source or config files', () => {
+        const rootDir = makeTempDir();
+        const destinationDir = path.join(makeTempDir(), 'site');
+
+        writeFile(path.join(rootDir, 'index.html'), '<h1>ALL PLAYS</h1>');
+        writeFile(path.join(rootDir, 'css', 'site.css'), 'body {}');
+        writeFile(path.join(rootDir, 'js', 'site.js'), 'export const ok = true;');
+        writeFile(path.join(rootDir, 'CNAME'), 'allplays.ai');
+        writeFile(path.join(rootDir, 'package.json'), '{}');
+        writeFile(path.join(rootDir, 'firebase.json'), '{}');
+        writeFile(path.join(rootDir, '.firebaserc'), '{}');
+        writeFile(path.join(rootDir, 'README.md'), '# private docs');
+        writeFile(path.join(rootDir, 'apps', 'app', 'src', 'main.tsx'), 'source');
+        writeFile(path.join(rootDir, 'apps', 'app', 'dist', 'index.html'), '<div id="root"></div>');
+        writeFile(path.join(rootDir, 'apps', 'app', 'dist', 'assets', 'index.js'), 'console.log("app");');
+        writeFile(path.join(rootDir, 'tests', 'unit', 'example.test.js'), 'test');
+
+        const result = stagePagesBundle(destinationDir, { rootDir });
+
+        expect(fs.existsSync(result.rootIndexPath)).toBe(true);
+        expect(fs.existsSync(result.appIndexPath)).toBe(true);
+        expect(fs.existsSync(path.join(destinationDir, 'css', 'site.css'))).toBe(true);
+        expect(fs.existsSync(path.join(destinationDir, 'js', 'site.js'))).toBe(true);
+        expect(fs.existsSync(path.join(destinationDir, 'CNAME'))).toBe(true);
+        expect(fs.existsSync(path.join(destinationDir, 'app', 'assets', 'index.js'))).toBe(true);
+        expect(fs.existsSync(path.join(destinationDir, '.nojekyll'))).toBe(true);
+
+        expect(fs.existsSync(path.join(destinationDir, 'package.json'))).toBe(false);
+        expect(fs.existsSync(path.join(destinationDir, 'firebase.json'))).toBe(false);
+        expect(fs.existsSync(path.join(destinationDir, '.firebaserc'))).toBe(false);
+        expect(fs.existsSync(path.join(destinationDir, 'README.md'))).toBe(false);
+        expect(fs.existsSync(path.join(destinationDir, 'apps', 'app', 'src', 'main.tsx'))).toBe(false);
+        expect(fs.existsSync(path.join(destinationDir, 'tests', 'unit', 'example.test.js'))).toBe(false);
+    });
+
+    it('writes a Firebase config that points hosting at the staged bundle', () => {
+        const rootDir = makeTempDir();
+        const publicDir = path.join(makeTempDir(), 'site');
+        const outputFile = path.join(rootDir, '.firebase-generated.json');
+
+        writeFile(path.join(rootDir, 'firebase.json'), JSON.stringify({
+            hosting: {
+                public: '.',
+                rewrites: [{ source: '**', destination: '/index.html' }]
+            },
+            firestore: {
+                rules: 'firestore.rules'
+            }
+        }));
+
+        const resolvedOutputFile = writeFirebaseHostingConfig(publicDir, outputFile, { rootDir });
+        const config = JSON.parse(fs.readFileSync(resolvedOutputFile, 'utf8'));
+
+        expect(config.hosting.public).toBe(path.resolve(publicDir));
+        expect(config.hosting.rewrites).toEqual([{ source: '**', destination: '/index.html' }]);
+        expect(config.firestore.rules).toBe('firestore.rules');
+    });
+});


### PR DESCRIPTION
## Summary
- add shared staging scripts so GitHub Pages, Firebase previews, and Firebase production deploys publish the legacy root plus React app under `/app/`
- add production `/app/` boot smoke coverage and mobile iOS/Android build workflow
- update Codex/Claude/Amazon Q guidance for the React/TypeScript Capacitor app and deployment model
- standardize workflow Node setup on Node 22

## Tests
- ruby YAML parse for `.github/workflows/*.yml`
- `npx vitest run tests/unit/pages-bundle-staging.test.js --reporter=dot`
- `npm run test:unit:ci`
- `npm run app:build`
- `node scripts/stage-pages-bundle.mjs /tmp/allplays-pages-stage-test`
- `SMOKE_APP_BOOT_URL=https://allplays.ai/app/ npx playwright test tests/smoke/app-production-bootstrap.spec.js --config=playwright.smoke.config.js --reporter=line`
- `npm run ci:firebase-rules`

## Notes
- Did not run local native builds because Capacitor sync rewrites tracked native public assets; the new `mobile-build` workflow runs clean Android and iOS builds in CI.