### PR TITLE
Fix basketball finish batch chunking

### DIFF
--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -8,6 +8,7 @@ import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai
 import { getApp } from './vendor/firebase-app.js';
 import { canApplySubstitution, applySubstitution, resolveFinalScoreForCompletion } from './live-tracker-integrity.js?v=3';
 import { resolveFinalScore, resolveSummaryRecipient } from './live-tracker-email.js?v=2';
+import { commitStandardTrackerFinishData } from './track-finish.js?v=2';
 import { hasScorekeepingTeamAccess } from './team-access.js?v=2';
 
 let currentTeamId = null;
@@ -656,44 +657,7 @@ async function saveAndComplete() {
   const sendEmail = els.finishSendEmail?.checked;
 
   try {
-    const batch = writeBatch(db);
-
-    // 1. Write all game log events
-    state.log.forEach(entry => {
-      const eventRef = doc(collection(db, `teams/${currentTeamId}/games/${currentGameId}/events`));
-      batch.set(eventRef, {
-        text: entry.text,
-        gameTime: entry.clock,
-        period: entry.period,
-        timestamp: entry.ts || Date.now(),
-        type: entry.undoData?.type || 'game_log',
-        playerId: entry.undoData?.playerId || null,
-        statKey: entry.undoData?.statKey || null,
-        value: entry.undoData?.value || null,
-        isOpponent: entry.undoData?.isOpponent || false,
-        createdBy: currentUser.uid
-      });
-    });
-
-    // 2. Write aggregated stats for each player
-    roster.forEach(player => {
-      const statsObj = {};
-      (currentConfig?.columns || []).forEach(col => {
-        const key = col.toLowerCase();
-        statsObj[key] = state.stats[player.id]?.[key] || 0;
-      });
-      // Always include fouls
-      statsObj.fouls = state.stats[player.id]?.fouls || 0;
-      const statsRef = doc(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`, player.id);
-      batch.set(statsRef, {
-        playerName: player.name,
-        playerNumber: player.num,
-        stats: statsObj,
-        timeMs: state.stats[player.id]?.time || 0
-      });
-    });
-
-    // 3. Build opponentStats in same shape as track.html
+    // 1. Build opponentStats in same shape as track.html
     const opponentStats = {};
     state.opp.forEach(opp => {
       opponentStats[opp.id] = {
@@ -708,17 +672,26 @@ async function saveAndComplete() {
       opponentStats[opp.id].fouls = opp.stats?.fouls || 0;
     });
 
-    // 4. Update game doc
-    const gameRef = doc(db, `teams/${currentTeamId}/games`, currentGameId);
-    batch.update(gameRef, {
-      homeScore: finalHome,
-      awayScore: finalAway,
+    // 2. Persist events, aggregated stats, and the completed game update in chunks.
+    await commitStandardTrackerFinishData({
+      db,
+      writeBatch,
+      doc,
+      collection,
+      teamId: currentTeamId,
+      gameId: currentGameId,
+      currentUserUid: currentUser.uid,
+      gameLog: state.log,
+      players: roster,
+      playerStatsByPlayerId: state.stats,
+      columns: currentConfig?.columns || [],
+      statTrackerConfig: currentConfig,
+      finalHome,
+      finalAway,
       summary,
-      status: 'completed',
-      opponentStats
+      opponentStats,
+      includeTimeMs: true
     });
-
-    await batch.commit();
     isFinishing = true;
 
     if (sendEmail) {

--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -9,6 +9,7 @@ import { getApp } from './vendor/firebase-app.js';
 import { canApplySubstitution, applySubstitution, resolveFinalScoreForCompletion } from './live-tracker-integrity.js?v=3';
 import { resolveFinalScore, resolveSummaryRecipient } from './live-tracker-email.js?v=2';
 import { commitStandardTrackerFinishData } from './track-finish.js?v=2';
+import { getPrivatePlayerStatIds } from './stat-leaderboards.js?v=2';
 import { hasScorekeepingTeamAccess } from './team-access.js?v=2';
 
 let currentTeamId = null;
@@ -757,6 +758,8 @@ async function startStop() {
         await Promise.all(eventsSnap.docs.map(d => deleteDoc(d.ref)));
         const statsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/aggregatedStats`));
         await Promise.all(statsSnap.docs.map(d => deleteDoc(d.ref)));
+        const privateStatsSnap = await getDocs(collection(db, `teams/${currentTeamId}/games/${currentGameId}/privatePlayerStats`));
+        await Promise.all(privateStatsSnap.docs.map(d => deleteDoc(d.ref)));
         // Reset game doc scores/opponent stats to avoid mixing old data
         await updateGame(currentTeamId, currentGameId, { homeScore: 0, awayScore: 0, opponentStats: {} });
       }
@@ -1384,6 +1387,16 @@ async function init() {
       if (typeof d.data().timeMs === 'number') {
         state.stats[d.id].time = d.data().timeMs;
       }
+    });
+
+    const privateStatsSnapshot = currentConfig
+        ? await getDocs(collection(db, `teams/${teamId}/games/${gameId}/privatePlayerStats`))
+        : { forEach: () => {} }; // Dummy object if no config to avoid errors
+
+    privateStatsSnapshot.forEach(d => {
+        if (!state.stats[d.id]) state.stats[d.id] = statDefaults(currentConfig.columns);
+        const existing = d.data().stats || {};
+        Object.assign(state.stats[d.id], existing);
     });
 
     // Recalculate home score if needed based on points column

--- a/js/track-finish.js
+++ b/js/track-finish.js
@@ -43,6 +43,10 @@ export function buildAggregatedStatsWrites({ players = [], playerStatsByPlayerId
         const playerStats = safeStatsByPlayerId[player.id] || {};
 
         const normalizedStats = buildNormalizedPlayerStats(playerStats, columns);
+        // If we are including timeMs, ensure the internal 'time' accumulator is not persisted as a stat.
+        if (includeTimeMs && normalizedStats.time !== undefined) {
+            delete normalizedStats.time;
+        }
         const { publicStats, privateStats } = splitPlayerStatsByVisibility(statTrackerConfig, normalizedStats);
 
         const playerNumber = player.number ?? player.num ?? '';

--- a/js/track-finish.js
+++ b/js/track-finish.js
@@ -33,7 +33,7 @@ export function buildNormalizedPlayerStats(playerStats = {}, columns = []) {
     return normalizedStats;
 }
 
-export function buildAggregatedStatsWrites({ players = [], playerStatsByPlayerId = {}, columns = [], statTrackerConfig = {} } = {}) {
+export function buildAggregatedStatsWrites({ players = [], playerStatsByPlayerId = {}, columns = [], statTrackerConfig = {}, includeTimeMs = false } = {}) {
     const safePlayers = Array.isArray(players) ? players : [];
     const safeStatsByPlayerId = playerStatsByPlayerId && typeof playerStatsByPlayerId === 'object'
         ? playerStatsByPlayerId
@@ -45,24 +45,35 @@ export function buildAggregatedStatsWrites({ players = [], playerStatsByPlayerId
         const normalizedStats = buildNormalizedPlayerStats(playerStats, columns);
         const { publicStats, privateStats } = splitPlayerStatsByVisibility(statTrackerConfig, normalizedStats);
 
+        const playerNumber = player.number ?? player.num ?? '';
+        const publicData = {
+            playerName: player.name,
+            playerNumber,
+            participated: true,
+            participationStatus: 'appeared',
+            participationSource: 'standard-tracker-finish',
+            stats: publicStats
+        };
+        const privateData = Object.keys(privateStats).length > 0 ? {
+            playerName: player.name,
+            playerNumber,
+            participated: true,
+            participationStatus: 'appeared',
+            participationSource: 'standard-tracker-finish',
+            stats: privateStats
+        } : null;
+
+        if (includeTimeMs) {
+            publicData.timeMs = Number(playerStats.time) || 0;
+            if (privateData) {
+                privateData.timeMs = Number(playerStats.time) || 0;
+            }
+        }
+
         return {
             playerId: player.id,
-            publicData: {
-                playerName: player.name,
-                playerNumber: player.number,
-                participated: true,
-                participationStatus: 'appeared',
-                participationSource: 'standard-tracker-finish',
-                stats: publicStats
-            },
-            privateData: Object.keys(privateStats).length > 0 ? {
-                playerName: player.name,
-                playerNumber: player.number,
-                participated: true,
-                participationStatus: 'appeared',
-                participationSource: 'standard-tracker-finish',
-                stats: privateStats
-            } : null
+            publicData,
+            privateData
         };
     });
 }
@@ -86,7 +97,8 @@ export async function commitStandardTrackerFinishData({
     opponentStats = {},
     maxPrimaryBatchWrites = STANDARD_TRACKER_MAX_PRIMARY_BATCH_WRITES,
     maxEventBatchWrites = STANDARD_TRACKER_MAX_EVENT_BATCH_WRITES,
-    maxAggregatedStatsBatchWrites = STANDARD_TRACKER_MAX_AGGREGATED_STATS_BATCH_WRITES
+    maxAggregatedStatsBatchWrites = STANDARD_TRACKER_MAX_AGGREGATED_STATS_BATCH_WRITES,
+    includeTimeMs = false
 } = {}) {
     const safeGameLog = Array.isArray(gameLog) ? gameLog : [];
     const legacyPrimaryBatchWriteCount = safeGameLog.length + 1;
@@ -94,7 +106,8 @@ export async function commitStandardTrackerFinishData({
         players,
         playerStatsByPlayerId,
         columns,
-        statTrackerConfig
+        statTrackerConfig,
+        includeTimeMs
     });
 
     const eventBatchSizes = [];
@@ -123,9 +136,9 @@ export async function commitStandardTrackerFinishData({
         const eventRef = doc(db, `teams/${teamId}/games/${gameId}/events`, buildFinishEventDocumentId(eventIndex));
         eventBatch.set(eventRef, {
             text: entry.text,
-            gameTime: entry.time,
+            gameTime: entry.time ?? entry.clock,
             period: entry.period,
-            timestamp: entry.timestamp || Date.now(),
+            timestamp: entry.timestamp || entry.ts || Date.now(),
             type: entry.undoData?.type || 'game_log',
             playerId: entry.undoData?.playerId || null,
             statKey: entry.undoData?.statKey || null,

--- a/tests/unit/track-finish-batch-limit.test.js
+++ b/tests/unit/track-finish-batch-limit.test.js
@@ -220,6 +220,40 @@ describe('standard tracker finish batch limits', () => {
         ]);
     });
 
+    it('preserves beta basketball finish event clocks, jersey numbers, and playing time', async () => {
+        const harness = createFirestoreHarness();
+
+        await commitStandardTrackerFinishData({
+            db: harness.db,
+            writeBatch: harness.writeBatch,
+            doc: harness.doc,
+            collection: harness.collection,
+            teamId: 'team-1',
+            gameId: 'game-1',
+            currentUserUid: 'coach-1',
+            gameLog: [{ text: 'Ava made a basket', clock: '03:21', period: 'Q4', ts: 99 }],
+            players: [{ id: 'p1', name: 'Ava', num: '23' }],
+            playerStatsByPlayerId: { p1: { pts: 2, fouls: 1, time: 123000 } },
+            columns: ['PTS', 'FOULS'],
+            finalHome: 44,
+            finalAway: 40,
+            summary: 'Finished cleanly.',
+            opponentStats: {},
+            includeTimeMs: true
+        });
+
+        expect(harness.batches[0].operations[0].data).toMatchObject({
+            gameTime: '03:21',
+            timestamp: 99
+        });
+        expect(harness.batches[1].operations[0].data).toMatchObject({
+            playerName: 'Ava',
+            playerNumber: '23',
+            timeMs: 123000,
+            stats: expect.objectContaining({ pts: 2, fouls: 1 })
+        });
+    });
+
     it('rejects when a secondary aggregated stats batch fails after primary commit', async () => {
         const statsBatchFailure = new Error('Secondary aggregated stats batch failed');
         const harness = createFirestoreHarness({
@@ -254,6 +288,19 @@ describe('standard tracker finish batch limits', () => {
         expect(harness.batches[1].operations).toHaveLength(450);
         expect(harness.batches[2].operations).toHaveLength(450);
         expect(harness.batches.some((batch) => batch.operations.some((op) => op.type === 'update'))).toBe(false);
+    });
+
+    it('wires the beta basketball tracker finish path through the tested finish helper', () => {
+        const source = readFileSync(new URL('../../js/track-basketball.js', import.meta.url), 'utf8');
+        const saveAndCompleteIndex = source.indexOf('async function saveAndComplete()');
+        const helperAwaitIndex = source.indexOf('await commitStandardTrackerFinishData({', saveAndCompleteIndex);
+        const catchIndex = source.indexOf('} catch (error) {', helperAwaitIndex);
+
+        expect(source).toContain("import { commitStandardTrackerFinishData } from './track-finish.js?v=2';");
+        expect(helperAwaitIndex).toBeGreaterThan(saveAndCompleteIndex);
+        expect(source.indexOf('includeTimeMs: true', helperAwaitIndex)).toBeGreaterThan(helperAwaitIndex);
+        expect(source.indexOf('const batch = writeBatch(db);', saveAndCompleteIndex)).toBe(-1);
+        expect(catchIndex).toBeGreaterThan(helperAwaitIndex);
     });
 
     it('wires the production track.html submit path through the tested finish helper before success-only side effects', () => {


### PR DESCRIPTION
Closes #1317

## Summary
- Routes the beta basketball Save & Complete flow through the existing chunked finish helper.
- Preserves beta basketball event clocks, jersey numbers, and playing time when writing finish data.
- Adds regression coverage for long finish logs and basketball-specific finish wiring.

## Tests
- `npx vitest run tests/unit/track-finish-batch-limit.test.js tests/unit/live-tracker-finish-batch-limit.test.js --reporter=verbose`