### PR TITLE
Guard empty selected chat audiences

### DIFF
--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -759,6 +759,11 @@ export async function sendTeamChatMessage({
   selectedRecipientIds: string[];
   onProgress?: (stage: 'uploading' | 'posting') => void;
 }) {
+  if (selectedRecipientTarget === 'individuals'
+    && (selectedRecipientIds || []).map((id) => String(id || '').trim()).filter(Boolean).length === 0) {
+    throw new Error('Choose at least one selected member before sending.');
+  }
+
   const attachments: ChatAttachment[] = [];
   try {
     for (const file of files) {

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -776,6 +776,14 @@ function ChatWindow({
     const files = filePreviews.map((preview) => preview.file);
     if (!trimmed && !files.length) return;
 
+    const hasEmptySelectedAudience = selectedRecipientTarget === 'individuals'
+      && selectedRecipientIds.map((id) => String(id || '').trim()).filter(Boolean).length === 0;
+    if (hasEmptySelectedAudience) {
+      setStatus({ tone: 'error', message: 'Choose at least one selected member before sending.' });
+      setShowAudienceSheet(true);
+      return;
+    }
+
     setSending(true);
     setStatus(null);
     setComposerNotice(files.length ? `Uploading ${files.length} attachment${files.length === 1 ? '' : 's'}...` : 'Sending...');
@@ -1748,6 +1756,7 @@ function AudienceSheet({
         : [...selectedRecipientIds, recipientId]
     );
   };
+  const needsSelectedRecipient = selectedTarget === 'individuals' && selectedRecipientIds.length === 0;
 
   return (
     <Sheet title="Message audience" onClose={onClose}>
@@ -1775,27 +1784,34 @@ function AudienceSheet({
       </div>
 
       {selectedTarget === 'individuals' ? (
-        <div className="mt-4 max-h-72 overflow-y-auto rounded-xl border border-gray-200">
-          {recipientOptions.length ? recipientOptions.map((option) => (
-            <label key={option.id} className="flex cursor-pointer items-center gap-3 border-b border-gray-100 px-3 py-2 last:border-b-0">
-              <input
-                type="checkbox"
-                className="h-4 w-4 rounded border-gray-300 text-primary-600"
-                checked={selectedRecipientIds.includes(option.id)}
-                onChange={() => toggleRecipient(option.id)}
-              />
-              <span className="min-w-0 flex-1">
-                <span className="block truncate text-sm font-black text-gray-800">{option.name}</span>
-                {option.detail ? <span className="block truncate text-xs font-semibold text-gray-500">{option.detail}</span> : null}
-              </span>
-            </label>
-          )) : (
-            <div className="p-3 text-sm font-semibold text-gray-500">No roster or community members are available yet.</div>
-          )}
-        </div>
+        <>
+          <div className="mt-4 max-h-72 overflow-y-auto rounded-xl border border-gray-200">
+            {recipientOptions.length ? recipientOptions.map((option) => (
+              <label key={option.id} className="flex cursor-pointer items-center gap-3 border-b border-gray-100 px-3 py-2 last:border-b-0">
+                <input
+                  type="checkbox"
+                  className="h-4 w-4 rounded border-gray-300 text-primary-600"
+                  checked={selectedRecipientIds.includes(option.id)}
+                  onChange={() => toggleRecipient(option.id)}
+                />
+                <span className="min-w-0 flex-1">
+                  <span className="block truncate text-sm font-black text-gray-800">{option.name}</span>
+                  {option.detail ? <span className="block truncate text-xs font-semibold text-gray-500">{option.detail}</span> : null}
+                </span>
+              </label>
+            )) : (
+              <div className="p-3 text-sm font-semibold text-gray-500">No roster or community members are available yet.</div>
+            )}
+          </div>
+          {needsSelectedRecipient ? (
+            <div className="mt-3 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-bold text-rose-700">
+              Choose at least one selected member, or switch back to Full team.
+            </div>
+          ) : null}
+        </>
       ) : null}
 
-      <button type="button" className="primary-button mt-4 w-full" onClick={onClose}>Done</button>
+      <button type="button" className="primary-button mt-4 w-full" onClick={onClose} disabled={needsSelectedRecipient}>Done</button>
     </Sheet>
   );
 }

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -474,6 +474,24 @@ describe('React app messages integration', () => {
         }));
     });
 
+    it('blocks selected member sends until at least one recipient is checked', async () => {
+        const { container } = await renderMessages('/messages/team-1');
+
+        await click(container, 'Audience: Full team');
+        await click(container, 'Selected members');
+
+        expect(container.textContent).toContain('Choose at least one selected member, or switch back to Full team.');
+        expect(buttonByText(container, 'Done').disabled).toBe(true);
+
+        const textarea = container.querySelector('textarea');
+        await setFieldValue(textarea, 'This should stay targeted.');
+        await click(container, 'Send message');
+
+        expect(container.textContent).toContain('Choose at least one selected member before sending.');
+        expect(container.textContent).toContain('Message audience');
+        expect(chatMocks.sendTeamChatMessage).not.toHaveBeenCalled();
+    });
+
     it('opens photo, video, and link actions from the attachment button', async () => {
         const { container } = await renderMessages('/messages/team-1');
 

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -268,6 +268,28 @@ describe('React app chat recipient service', () => {
         });
     });
 
+    it('rejects empty selected-member targeting before falling back to full team', async () => {
+        const { sendTeamChatMessage } = await import('../../apps/app/src/lib/chatService.ts');
+        await expect(sendTeamChatMessage({
+            teamId: 'team-1',
+            user: {
+                uid: 'user-1',
+                email: 'parent@example.com',
+                displayName: 'Pat Parent'
+            },
+            profile: {},
+            text: 'Private update',
+            files: [],
+            selectedConversation: null,
+            selectedConversationId: 'team',
+            selectedRecipientTarget: 'individuals',
+            selectedRecipientIds: []
+        })).rejects.toThrow('Choose at least one selected member before sending.');
+
+        expect(dbMocks.postChatMessage).not.toHaveBeenCalled();
+        expect(dbMocks.upsertChatConversation).not.toHaveBeenCalled();
+    });
+
     it('cleans uploaded chat media if the message write fails', async () => {
         const photo = new File(['photo'], 'arrival.jpg', { type: 'image/jpeg' });
         const uploadedPhoto = {


### PR DESCRIPTION
Closes #1322

## What changed
- Added inline validation in the message audience sheet when Selected members has zero checked recipients.
- Disabled Done until a selected-member audience includes at least one recipient.
- Blocked composer sends for `selectedRecipientTarget='individuals'` with an empty recipient list and reopened the audience sheet.
- Added a service-layer guard so empty selected-member targeting cannot silently fall back to `full_team` metadata.

## Tests
- `npx vitest run tests/unit/app-chat-messages-integration.test.jsx tests/unit/app-chat-service-recipients.test.js --reporter=verbose`