### PR TITLE
Add app team media album creation

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -100,9 +100,14 @@ jobs:
 
       - name: Resolve iOS package dependencies
         run: |
+          reset_swiftpm_artifact_cache() {
+            rm -rf "$HOME/Library/Caches/org.swift.swiftpm/artifacts"
+          }
+
           run_with_retry() {
             attempt=1
             delay=20
+            reset_swiftpm_artifact_cache
             until "$@"; do
               if [ "$attempt" -ge 3 ]; then
                 return 1
@@ -110,6 +115,7 @@ jobs:
               echo "Attempt $attempt failed. Retrying in ${delay}s..."
               attempt=$((attempt + 1))
               sleep "$delay"
+              reset_swiftpm_artifact_cache
               delay=$((delay * 2))
             done
           }

--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -2,6 +2,7 @@ import {
   createFamilyShareToken,
   createParentMembershipRequest,
   createRegistrationCheckoutSession,
+  createTeamMediaFolder,
   createTeamMediaLink,
   getPlayers,
   getTeam,
@@ -611,6 +612,12 @@ export async function uploadParentTeamMediaPhoto(teamId: string, folderId: strin
 
 export async function uploadParentTeamMediaFile(teamId: string, folderId: string, file: File) {
   return uploadTeamMediaFile(teamId, folderId, file);
+}
+
+export async function createTeamMediaAlbumForApp(teamId: string, draft: { name: string; visibility?: string }) {
+  const name = compactString(draft?.name);
+  const visibility = draft?.visibility === 'private' ? 'private' : 'team';
+  return createTeamMediaFolder(teamId, { name, visibility });
 }
 
 export async function addParentTeamMediaLink(teamId: string, folderId: string, title: string, url: string) {

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -20,6 +20,7 @@ import {
 import { openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 import {
   addParentTeamMediaLink,
+  createTeamMediaAlbumForApp,
   loadTeamMediaForApp,
   uploadParentTeamMediaFile,
   uploadParentTeamMediaPhoto,
@@ -38,12 +39,15 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const [selectedMediaType, setSelectedMediaType] = useState<MediaTypeFilter>('all');
   const [linkTitle, setLinkTitle] = useState('');
   const [linkUrl, setLinkUrl] = useState('');
+  const [albumName, setAlbumName] = useState('');
+  const [albumVisibility, setAlbumVisibility] = useState<'team' | 'private'>('team');
   const [loading, setLoading] = useState(true);
   const [uploading, setUploading] = useState('');
+  const [creatingAlbum, setCreatingAlbum] = useState(false);
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
 
-  const refresh = async ({ showLoading = model === null }: { showLoading?: boolean } = {}) => {
+  const refresh = async ({ showLoading = model === null, preferredFolderId = '' }: { showLoading?: boolean; preferredFolderId?: string } = {}) => {
     if (!teamId) return;
     if (showLoading) setLoading(true);
     setError('');
@@ -51,6 +55,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
       const nextModel = await loadTeamMediaForApp(auth.user, teamId);
       setModel(nextModel);
       setActiveFolderId((current) => {
+        if (preferredFolderId && nextModel.folders.some((folder) => folder.id === preferredFolderId)) return preferredFolderId;
         if (current && nextModel.folders.some((folder) => folder.id === current)) return current;
         return nextModel.folders[0]?.id || '';
       });
@@ -76,7 +81,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const featured = activeFolder?.items[0] || allItems[0] || null;
 
   const uploadPhoto = async (file: File | null | undefined) => {
-    if (!file || !activeFolder) return;
+    if (!file || !activeFolder || creatingAlbum) return;
     setUploading('photo');
     setError('');
     setMessage('Uploading photo...');
@@ -94,7 +99,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   };
 
   const uploadFile = async (file: File | null | undefined) => {
-    if (!file || !activeFolder) return;
+    if (!file || !activeFolder || creatingAlbum) return;
     setUploading('file');
     setError('');
     setMessage('Uploading file...');
@@ -111,9 +116,28 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
     }
   };
 
+  const createAlbum = async (event: FormEvent) => {
+    event.preventDefault();
+    const name = albumName.trim();
+    if (!name || creatingAlbum) return;
+    setCreatingAlbum(true);
+    setError('');
+    setMessage('');
+    try {
+      const folderId = await createTeamMediaAlbumForApp(teamId, { name, visibility: albumVisibility });
+      setMessage('Album created. You can add photos, files, or links now.');
+      setAlbumName('');
+      await refresh({ showLoading: false, preferredFolderId: String(folderId || '') });
+    } catch (albumError: any) {
+      setError(albumError?.message || 'Unable to create album. Check your connection and permissions, then try again.');
+    } finally {
+      setCreatingAlbum(false);
+    }
+  };
+
   const addLink = async (event: FormEvent) => {
     event.preventDefault();
-    if (!activeFolder) return;
+    if (!activeFolder || creatingAlbum) return;
     setUploading('link');
     setError('');
     setMessage('');
@@ -169,8 +193,8 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
             <h1 className="truncate text-xl font-black leading-tight text-gray-950">{model.team.name || 'Team'} media</h1>
             <p className="mt-0.5 truncate text-xs font-semibold text-gray-600">{model.folders.length} albums - {allItems.length} items</p>
           </div>
-          <button type="button" className="ghost-button !h-9 !min-h-9 !w-9 !flex-none !p-0 sm:!w-auto sm:!px-3 text-xs" onClick={() => refresh({ showLoading: false })} disabled={Boolean(uploading)} aria-label="Refresh media" title="Refresh media">
-            <RefreshCw className={`h-4 w-4 ${uploading ? 'animate-spin' : ''}`} aria-hidden="true" />
+          <button type="button" className="ghost-button !h-9 !min-h-9 !w-9 !flex-none !p-0 sm:!w-auto sm:!px-3 text-xs" onClick={() => refresh({ showLoading: false })} disabled={Boolean(uploading) || creatingAlbum} aria-label="Refresh media" title="Refresh media">
+            <RefreshCw className={`h-4 w-4 ${uploading || creatingAlbum ? 'animate-spin' : ''}`} aria-hidden="true" />
             <span className="hidden sm:inline">Refresh</span>
           </button>
         </div>
@@ -196,6 +220,47 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
       {error ? <Status tone="error" message={error} /> : null}
       {message ? <Status tone="success" message={message} /> : null}
 
+      {model.canManage ? (
+        <section className="app-card p-4">
+          <form className="space-y-3" onSubmit={createAlbum}>
+            <div>
+              <div className="text-sm font-black text-gray-950">Create album</div>
+              <div className="mt-0.5 text-xs font-semibold text-gray-500">{model.folders.length ? 'Add another album for this team.' : 'Start this media library with a team-visible or private album.'}</div>
+            </div>
+            <label className="block text-xs font-black uppercase tracking-wide text-gray-600" htmlFor="team-media-album-name">Album name</label>
+            <input
+              id="team-media-album-name"
+              className="auth-input min-h-11 w-full"
+              value={albumName}
+              onChange={(event) => setAlbumName(event.target.value)}
+              placeholder="Album name"
+              disabled={creatingAlbum}
+              aria-label="Album name"
+            />
+            <label className="block text-xs font-black uppercase tracking-wide text-gray-600" htmlFor="team-media-album-visibility">Visibility</label>
+            <select
+              id="team-media-album-visibility"
+              className="auth-input min-h-11 w-full"
+              value={albumVisibility}
+              onChange={(event) => setAlbumVisibility(event.target.value === 'private' ? 'private' : 'team')}
+              disabled={creatingAlbum}
+              aria-label="Album visibility"
+            >
+              <option value="team">Team-visible</option>
+              <option value="private">Private/admins only</option>
+            </select>
+            <button type="submit" className="primary-button min-h-11 w-full justify-center" disabled={creatingAlbum || !albumName.trim()} aria-disabled={creatingAlbum || !albumName.trim()}>
+              {creatingAlbum ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Plus className="h-4 w-4" aria-hidden="true" />}
+              Create album
+            </button>
+          </form>
+        </section>
+      ) : !model.folders.length ? (
+        <section className="app-card p-4 text-sm font-semibold text-gray-600">
+          No albums are available yet. A coach or team admin can create the first media album.
+        </section>
+      ) : null}
+
       {model.canContribute && activeFolder ? (
         <section className="app-card p-4">
           <div className="flex items-start justify-between gap-3">
@@ -206,11 +271,11 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
             {uploading ? <Loader2 className="h-5 w-5 animate-spin text-primary-600" aria-hidden="true" /> : <Upload className="h-5 w-5 text-primary-600" aria-hidden="true" />}
           </div>
           <div className="mt-3 grid gap-2 sm:grid-cols-2">
-            <button type="button" className="secondary-button justify-center" onClick={() => photoInputRef.current?.click()} disabled={Boolean(uploading)}>
+            <button type="button" className="secondary-button justify-center" onClick={() => photoInputRef.current?.click()} disabled={Boolean(uploading) || creatingAlbum}>
               <ImageIcon className="h-4 w-4" aria-hidden="true" />
               Photo
             </button>
-            <button type="button" className="secondary-button justify-center" onClick={() => fileInputRef.current?.click()} disabled={Boolean(uploading)}>
+            <button type="button" className="secondary-button justify-center" onClick={() => fileInputRef.current?.click()} disabled={Boolean(uploading) || creatingAlbum}>
               <File className="h-4 w-4" aria-hidden="true" />
               File
             </button>
@@ -220,7 +285,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
           <form className="mt-3 grid gap-2 sm:grid-cols-[1fr_1fr_auto]" onSubmit={addLink}>
             <input className="auth-input" value={linkTitle} onChange={(event) => setLinkTitle(event.target.value)} placeholder="Video or link title" />
             <input className="auth-input" value={linkUrl} onChange={(event) => setLinkUrl(event.target.value)} placeholder="https://..." inputMode="url" />
-            <button type="submit" className="primary-button justify-center" disabled={Boolean(uploading) || !linkTitle.trim() || !linkUrl.trim()}>
+            <button type="submit" className="primary-button justify-center" disabled={Boolean(uploading) || creatingAlbum || !linkTitle.trim() || !linkUrl.trim()}>
               {uploading === 'link' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Plus className="h-4 w-4" aria-hidden="true" />}
               Add link
             </button>
@@ -390,7 +455,7 @@ function getMediaDownloadName(item: TeamMediaItem) {
 function Status({ tone, message }: { tone: 'error' | 'success'; message: string }) {
   const Icon = tone === 'error' ? AlertCircle : CheckCircle2;
   return (
-    <div className={`flex items-start gap-2 rounded-xl border p-3 text-sm font-semibold ${tone === 'error' ? 'border-rose-200 bg-rose-50 text-rose-800' : 'border-emerald-200 bg-emerald-50 text-emerald-800'}`}>
+    <div role={tone === 'error' ? 'alert' : 'status'} aria-live={tone === 'error' ? 'assertive' : 'polite'} className={`flex items-start gap-2 rounded-xl border p-3 text-sm font-semibold ${tone === 'error' ? 'border-rose-200 bg-rose-50 text-rose-800' : 'border-emerald-200 bg-emerald-50 text-emerald-800'}`}>
       <Icon className="mt-0.5 h-4 w-4 flex-none" aria-hidden="true" />
       <span>{message}</span>
     </div>

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -223,6 +223,9 @@ async function mockParentToolsModules(page) {
                         }]
                     };
                 }
+                export async function createTeamMediaAlbumForApp() {
+                    return 'folder-2';
+                }
                 export async function uploadParentTeamMediaPhoto(teamId, folderId, file) {
                     window.__mediaUploads.push({ type: 'photo', teamId, folderId, name: file.name });
                     return 'photo-2';

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -9,6 +9,7 @@ const serviceMocks = vi.hoisted(() => ({
     buildParentScheduleIcs: vi.fn(() => 'BEGIN:VCALENDAR\r\nEND:VCALENDAR'),
     createParentFamilyShare: vi.fn(),
     createParentHouseholdMemberInvite: vi.fn(),
+    createTeamMediaAlbumForApp: vi.fn(),
     downloadIcs: vi.fn(),
     getAppleCalendarFeedUrl: vi.fn((url) => `webcal://${url.replace(/^https?:\/\//, '')}`),
     getCalendarEventShareText: vi.fn((event) => `${event.teamName} ${event.title || event.opponent}`),
@@ -133,6 +134,14 @@ async function changeValue(element, value) {
     await flush();
 }
 
+async function changeSelectValue(element, value) {
+    await act(async () => {
+        element.value = value;
+        element.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flush();
+}
+
 beforeEach(() => {
     vi.clearAllMocks();
     window.requestAnimationFrame = (callback) => {
@@ -227,6 +236,7 @@ beforeEach(() => {
     serviceMocks.uploadParentTeamMediaPhoto.mockResolvedValue('photo-2');
     serviceMocks.uploadParentTeamMediaFile.mockResolvedValue('file-1');
     serviceMocks.addParentTeamMediaLink.mockResolvedValue('link-1');
+    serviceMocks.createTeamMediaAlbumForApp.mockResolvedValue('folder-new');
 });
 
 afterEach(() => {
@@ -401,8 +411,6 @@ describe('React app parent tools integration', () => {
         expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
     });
 
-
-
     it('filters team media albums by media type in the app', async () => {
         serviceMocks.loadTeamMediaForApp.mockResolvedValueOnce({
             team: { id: 'team-1', name: 'Bears' },
@@ -455,6 +463,77 @@ describe('React app parent tools integration', () => {
 
         expect(container.textContent).toContain('Videos0');
         expect(container.textContent).toContain('No videos in this album.');
+    });
+
+    it('creates the first team media album and unlocks add-media actions for managers', async () => {
+        serviceMocks.loadTeamMediaForApp
+            .mockResolvedValueOnce({
+                team: { id: 'team-1', name: 'Bears' },
+                canManage: true,
+                canContribute: true,
+                folders: []
+            })
+            .mockResolvedValueOnce({
+                team: { id: 'team-1', name: 'Bears' },
+                canManage: true,
+                canContribute: true,
+                folders: [{
+                    id: 'folder-new',
+                    name: 'Spring photos',
+                    visibility: 'team',
+                    itemCount: 0,
+                    items: []
+                }]
+            });
+        const { container } = await renderParentTools('/teams/team-1/media');
+        await waitForText(container, 'Create album');
+        expect(container.textContent).toContain('Start this media library');
+        expect(container.textContent).toContain('Team-visible');
+        expect(container.textContent).toContain('Private/admins only');
+        const submitButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent.trim().includes('Create album'));
+        expect(submitButton.disabled).toBe(true);
+
+        await changeValue(container.querySelector('#team-media-album-name'), '  Spring photos  ');
+        await changeSelectValue(container.querySelector('#team-media-album-visibility'), 'team');
+        expect(submitButton.disabled).toBe(false);
+        await submitForm(container, 'Create album');
+
+        expect(serviceMocks.createTeamMediaAlbumForApp).toHaveBeenCalledWith('team-1', { name: 'Spring photos', visibility: 'team' });
+        await waitForText(container, 'Album created. You can add photos, files, or links now.');
+        expect(container.textContent).toContain('Add to Spring photos');
+        expect(container.textContent).toContain('Photo');
+        expect(container.textContent).toContain('File');
+        expect(container.textContent).toContain('Add link');
+    });
+
+    it('preserves the album draft and hides create controls from non-managers', async () => {
+        serviceMocks.loadTeamMediaForApp.mockResolvedValue({
+            team: { id: 'team-1', name: 'Bears' },
+            canManage: true,
+            canContribute: true,
+            folders: []
+        });
+        serviceMocks.createTeamMediaAlbumForApp.mockRejectedValueOnce(new Error('permission-denied'));
+        const { container, root } = await renderParentTools('/teams/team-1/media');
+        await waitForText(container, 'Create album');
+        await changeValue(container.querySelector('#team-media-album-name'), 'Private board notes');
+        await changeSelectValue(container.querySelector('#team-media-album-visibility'), 'private');
+        await submitForm(container, 'Create album');
+        await waitForText(container, 'permission-denied');
+        expect(container.querySelector('#team-media-album-name').value).toBe('Private board notes');
+        expect(container.querySelector('#team-media-album-visibility').value).toBe('private');
+
+        await act(async () => root.unmount());
+        document.body.innerHTML = '';
+        serviceMocks.loadTeamMediaForApp.mockResolvedValue({
+            team: { id: 'team-1', name: 'Bears' },
+            canManage: false,
+            canContribute: true,
+            folders: []
+        });
+        const nextRender = await renderParentTools('/teams/team-1/media');
+        await waitForText(nextRender.container, 'No albums are available yet.');
+        expect(nextRender.container.textContent).not.toContain('Create album');
     });
 
     it('loads team media, uploads photos/files, adds links, and opens media items', async () => {

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const dbMocks = vi.hoisted(() => ({
     createFamilyShareToken: vi.fn(),
     createParentMembershipRequest: vi.fn(),
+    createTeamMediaFolder: vi.fn(),
     createTeamMediaLink: vi.fn(),
     db: { _is_mock_db_instance: true }, // Mock db instance for runTransaction
     doc: vi.fn((db, path, ...segments) => ({
@@ -136,6 +137,7 @@ vi.mock('../../js/stripe-service.js', () => stripeMocks);
 import {
     addParentTeamMediaLink,
     buildParentScheduleIcs,
+    createTeamMediaAlbumForApp,
     createParentFamilyShare,
     getAppleCalendarFeedUrl,
     getCertificateUrl,
@@ -653,6 +655,7 @@ describe('React app parent tools service', () => {
         dbMocks.uploadTeamMediaPhoto.mockResolvedValue('photo-2');
         dbMocks.uploadTeamMediaFile.mockResolvedValue('file-1');
         dbMocks.createTeamMediaLink.mockResolvedValue('link-1');
+        dbMocks.createTeamMediaFolder.mockResolvedValue('folder-new');
 
         await expect(loadTeamMediaForApp(user, 'team-1')).resolves.toMatchObject({
             team: { id: 'team-1', name: 'Bears' },
@@ -665,9 +668,11 @@ describe('React app parent tools service', () => {
             }]
         });
 
+        await expect(createTeamMediaAlbumForApp('team-1', { name: '  Spring photos  ', visibility: 'private' })).resolves.toBe('folder-new');
         await uploadParentTeamMediaPhoto('team-1', 'folder-1', photoFile);
         await uploadParentTeamMediaFile('team-1', 'folder-1', docFile);
         await addParentTeamMediaLink('team-1', 'folder-1', 'Replay', 'https://video.example.test/replay');
+        expect(dbMocks.createTeamMediaFolder).toHaveBeenCalledWith('team-1', { name: 'Spring photos', visibility: 'private' });
         expect(dbMocks.uploadTeamMediaPhoto).toHaveBeenCalledWith('team-1', 'folder-1', photoFile);
         expect(dbMocks.uploadTeamMediaFile).toHaveBeenCalledWith('team-1', 'folder-1', docFile);
         expect(dbMocks.createTeamMediaLink).toHaveBeenCalledWith('team-1', 'folder-1', { title: 'Replay', url: 'https://video.example.test/replay' });


### PR DESCRIPTION
Closes #1321

## Summary
- Added React app Team Media album creation backed by the existing legacy `createTeamMediaFolder` behavior.
- Added a manager-only create album panel with name and explicit Team-visible/private visibility controls.
- Refreshes and selects the created album so photo, file, and link actions become available immediately.

## Validation
- `npx vitest run tests/unit/app-parent-tools-service.test.js tests/unit/app-parent-tools-integration.test.jsx --reporter=verbose`
- `npm run app:build`