### PR TITLE
Add athlete profile headshot uploads

### DIFF
--- a/apps/app/src/lib/playerService.ts
+++ b/apps/app/src/lib/playerService.ts
@@ -6,6 +6,7 @@ import {
   getPlayers,
   getPublicTrackingItems,
   getTeam,
+  deleteAthleteProfileMediaByPath,
   inviteCoParentToAthlete,
   listAthleteProfilesForParent,
   listCertificatesForPlayer,
@@ -327,14 +328,26 @@ export async function saveParentAthleteProfileDraft({
   assertLinkedParent(user, teamId, playerId);
   const seasonKey = buildParentSeasonKey(teamId, playerId);
   const workingProfileId = profileId || createLocalId('profile');
-  const profilePhoto = profilePhotoFile
-    ? await uploadAthleteProfileMedia(user!.uid, workingProfileId, profilePhotoFile, { kind: 'profile-photo' })
-    : (resetProfilePhoto ? null : draft.profilePhoto);
-  const saved = await saveAthleteProfile(user!.uid, {
-    ...draft,
-    profilePhoto,
-    selectedSeasonKeys: [seasonKey]
-  }, { profileId: workingProfileId });
+  let uploadedProfilePhoto: Record<string, any> | null = null;
+  if (profilePhotoFile) {
+    validateImageFile(profilePhotoFile);
+    uploadedProfilePhoto = await uploadAthleteProfileMedia(user!.uid, workingProfileId, profilePhotoFile, { kind: 'profile-photo' });
+  }
+  const profilePhoto = uploadedProfilePhoto || (resetProfilePhoto ? null : draft.profilePhoto);
+
+  let saved;
+  try {
+    saved = await saveAthleteProfile(user!.uid, {
+      ...draft,
+      profilePhoto,
+      selectedSeasonKeys: [seasonKey]
+    }, { profileId: workingProfileId });
+  } catch (error) {
+    if (uploadedProfilePhoto?.storagePath) {
+      await deleteAthleteProfileMediaByPath(uploadedProfilePhoto.storagePath).catch(() => undefined);
+    }
+    throw error;
+  }
   return {
     profile: saved,
     shareUrl: buildAthleteProfileShareUrl(getLegacyOrigin(), saved.id),

--- a/apps/app/src/lib/playerService.ts
+++ b/apps/app/src/lib/playerService.ts
@@ -11,6 +11,7 @@ import {
   listCertificatesForPlayer,
   saveAthleteProfile,
   updatePlayerProfile,
+  uploadAthleteProfileMedia,
   uploadPlayerPhoto
 } from '../../../../js/db.js';
 import {
@@ -311,25 +312,41 @@ export async function saveParentAthleteProfileDraft({
   teamId,
   playerId,
   draft,
-  profileId
+  profileId,
+  profilePhotoFile,
+  resetProfilePhoto = false
 }: {
   user: AuthUser | null;
   teamId: string;
   playerId: string;
   draft: Record<string, any>;
   profileId?: string | null;
+  profilePhotoFile?: File | null;
+  resetProfilePhoto?: boolean;
 }) {
   assertLinkedParent(user, teamId, playerId);
   const seasonKey = buildParentSeasonKey(teamId, playerId);
+  const workingProfileId = profileId || createLocalId('profile');
+  const profilePhoto = profilePhotoFile
+    ? await uploadAthleteProfileMedia(user!.uid, workingProfileId, profilePhotoFile, { kind: 'profile-photo' })
+    : (resetProfilePhoto ? null : draft.profilePhoto);
   const saved = await saveAthleteProfile(user!.uid, {
     ...draft,
+    profilePhoto,
     selectedSeasonKeys: [seasonKey]
-  }, profileId ? { profileId } : {});
+  }, { profileId: workingProfileId });
   return {
     profile: saved,
     shareUrl: buildAthleteProfileShareUrl(getLegacyOrigin(), saved.id),
     builderUrl: buildLegacyUrl('athlete-profile-builder.html', { teamId, playerId, profileId: saved.id })
   };
+}
+
+function createLocalId(prefix: string) {
+  if (globalThis.crypto?.randomUUID) {
+    return `${prefix}_${globalThis.crypto.randomUUID()}`;
+  }
+  return `${prefix}_${Date.now()}_${Math.random().toString(36).slice(2, 10)}`;
 }
 
 function normalizePrivateProfile(profile: any): ParentPlayerPrivateProfile | null {

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -537,9 +537,29 @@ function AthleteProfileBuilderCard({ data, auth, onChanged }: { data: ParentPlay
   const [saving, setSaving] = useState(false);
   const [status, setStatus] = useState<{ tone: 'error' | 'success'; message: string } | null>(null);
   const [shareUrl, setShareUrl] = useState(data.athleteProfile.shareUrl || '');
+  const [headshotFile, setHeadshotFile] = useState<File | null>(null);
+  const [headshotError, setHeadshotError] = useState('');
+  const [resetHeadshot, setResetHeadshot] = useState(false);
+  const existingHeadshotUrl = existing?.profilePhotoUrl || '';
+  const linkedHeadshotUrl = data.player.photoUrl || '';
+  const headshotPreviewUrl = useMemo(() => {
+    if (headshotFile) return URL.createObjectURL(headshotFile);
+    if (resetHeadshot) return linkedHeadshotUrl;
+    return existingHeadshotUrl || linkedHeadshotUrl;
+  }, [existingHeadshotUrl, headshotFile, linkedHeadshotUrl, resetHeadshot]);
+  const headshotLabel = headshotFile
+    ? 'New headshot selected. Save to publish it.'
+    : (existingHeadshotUrl && !resetHeadshot ? 'Custom athlete profile headshot' : 'Using linked season photo');
+
+  useEffect(() => {
+    return () => {
+      if (headshotPreviewUrl.startsWith('blob:')) URL.revokeObjectURL(headshotPreviewUrl);
+    };
+  }, [headshotPreviewUrl]);
 
   const submit = async (event: FormEvent) => {
     event.preventDefault();
+    if (headshotError) return;
     setSaving(true);
     setStatus(null);
     try {
@@ -560,8 +580,12 @@ function AthleteProfileBuilderCard({ data, auth, onChanged }: { data: ParentPlay
             sizeBytes: existing.profilePhotoSizeBytes,
             uploadedAtMs: existing.profilePhotoUploadedAtMs
           } : null
-        }
+        },
+        profilePhotoFile: headshotFile,
+        resetProfilePhoto: resetHeadshot
       });
+      setHeadshotFile(null);
+      setResetHeadshot(false);
       setShareUrl(result.shareUrl);
       setStatus({ tone: 'success', message: 'Athlete profile saved.' });
       await onChanged();
@@ -580,13 +604,58 @@ function AthleteProfileBuilderCard({ data, auth, onChanged }: { data: ParentPlay
             <Sparkles className="h-4 w-4 flex-none" aria-hidden="true" />
             <span className="truncate">Athlete Profile Builder</span>
           </div>
-          <p className="mt-1 text-xs font-semibold leading-5 text-gray-500">Native quick edit for the parent-managed public profile. Use Full builder below for headshot and highlight uploads.</p>
+          <p className="mt-1 text-xs font-semibold leading-5 text-gray-500">Native quick edit for the parent-managed public profile, including the public headshot.</p>
         </div>
         {status?.tone === 'success' ? (
           <span className="flex-none rounded-full border border-emerald-200 bg-emerald-50 px-2.5 py-1 text-[11px] font-black uppercase tracking-[0.04em] text-emerald-700">Saved</span>
         ) : null}
       </div>
       <form className="mt-4 space-y-3" onSubmit={submit}>
+        <div className="rounded-2xl border border-gray-200 bg-gray-50 p-3">
+          <div className="flex items-center gap-3">
+            <div className="flex h-16 w-16 flex-none items-center justify-center overflow-hidden rounded-2xl bg-white text-sm font-black text-primary-700">
+              {headshotPreviewUrl ? <img src={headshotPreviewUrl} alt="Athlete profile headshot preview" className="h-full w-full object-cover" /> : getInitials(name || data.child.playerName || 'Athlete')}
+            </div>
+            <div className="min-w-0 flex-1">
+              <div className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Public headshot</div>
+              <p className="mt-1 text-sm font-semibold text-gray-700">{headshotLabel}</p>
+              {headshotFile ? <p className="mt-1 text-xs font-semibold text-primary-700">{headshotFile.name}</p> : null}
+            </div>
+          </div>
+          <div className="mt-3 grid gap-2 sm:grid-cols-2">
+            <label className="secondary-button justify-center">
+              <span>Choose headshot</span>
+              <input
+                type="file"
+                accept="image/*"
+                className="sr-only"
+                onChange={(event) => {
+                  const file = event.currentTarget.files?.[0] || null;
+                  if (file && !String(file.type || '').startsWith('image/')) {
+                    setHeadshotFile(null);
+                    setHeadshotError('Choose an image file for the athlete headshot.');
+                    return;
+                  }
+                  setHeadshotFile(file);
+                  setResetHeadshot(false);
+                  setHeadshotError('');
+                }}
+              />
+            </label>
+            <button
+              type="button"
+              className="secondary-button justify-center"
+              onClick={() => {
+                setHeadshotFile(null);
+                setResetHeadshot(true);
+                setHeadshotError('');
+              }}
+            >
+              Use linked season photo
+            </button>
+          </div>
+          {headshotError ? <p className="mt-2 text-xs font-bold text-rose-600">{headshotError}</p> : null}
+        </div>
         <div className="athlete-profile-grid grid gap-3 sm:grid-cols-2">
           <TextField label="Athlete name" value={name} onChange={setName} placeholder="Athlete name" />
           <TextField label="Headline" value={headline} onChange={setHeadline} placeholder="2028 Guard" />

--- a/docs/pr-notes/runs/1338-remediator-20260525T053649Z/architecture.md
+++ b/docs/pr-notes/runs/1338-remediator-20260525T053649Z/architecture.md
@@ -1,0 +1,7 @@
+# Architecture
+
+Decisions:
+- Reuse existing local `validateImageFile` to preserve control equivalence with player photos.
+- Import and call `deleteAthleteProfileMediaByPath` from `js/db.js` for rollback because `uploadAthleteProfileMedia` returns `storagePath`.
+- Wrap only the `saveAthleteProfile` call after a successful profile-photo upload, so validation/upload failures are not treated as rollback cases.
+- Cleanup failure is best-effort and should not mask the original profile save failure.

--- a/docs/pr-notes/runs/1338-remediator-20260525T053649Z/code-plan.md
+++ b/docs/pr-notes/runs/1338-remediator-20260525T053649Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Plan
+
+Implementation:
+1. Add `deleteAthleteProfileMediaByPath` to `playerService.ts` db imports.
+2. Validate `profilePhotoFile` before upload in `saveParentAthleteProfileDraft`.
+3. Track the uploaded profile photo metadata and delete by `storagePath` in a catch block if `saveAthleteProfile` throws.
+4. Extend `tests/unit/app-player-service.test.js` mocks and add focused tests for validation and rollback.
+
+Risks and rollback:
+- Risk is limited to parent athlete profile saves with newly uploaded headshots.
+- Rollback is reverting this commit; no data migration involved.

--- a/docs/pr-notes/runs/1338-remediator-20260525T053649Z/qa.md
+++ b/docs/pr-notes/runs/1338-remediator-20260525T053649Z/qa.md
@@ -1,0 +1,9 @@
+# QA Plan
+
+Regression tests:
+- Invalid headshot file rejects before upload and does not call `uploadAthleteProfileMedia`.
+- Save failure after successful headshot upload calls `deleteAthleteProfileMediaByPath` with the uploaded storage path and rethrows the save failure.
+- Existing headshot upload/reset test continues to prove current happy paths.
+
+Validation command:
+- `npx vitest run tests/unit/app-player-service.test.js --reporter=verbose`

--- a/docs/pr-notes/runs/1338-remediator-20260525T053649Z/requirements.md
+++ b/docs/pr-notes/runs/1338-remediator-20260525T053649Z/requirements.md
@@ -1,0 +1,7 @@
+# Requirements
+
+Acceptance criteria:
+- Profile headshot uploads through `saveParentAthleteProfileDraft` must enforce the same image-only, non-empty, and <=10 MB validation used by parent player photo uploads.
+- If a new profile headshot uploads successfully but `saveAthleteProfile` fails, the uploaded media object must be deleted by storage path before the original save error is rethrown.
+- Existing reset/no-photo behavior must remain unchanged.
+- Scope is limited to PR review feedback in `apps/app/src/lib/playerService.ts` and direct unit coverage.

--- a/tests/unit/app-home-player-integration.test.jsx
+++ b/tests/unit/app-home-player-integration.test.jsx
@@ -160,6 +160,23 @@ async function clickLinkByHref(container, href) {
     await flush();
 }
 
+async function attachAthleteHeadshotFile(container, fileName = 'headshot.png', type = 'image/png') {
+    const input = container.querySelector('.athlete-profile-editor input[type="file"]');
+    if (!input) {
+        throw new Error('Athlete headshot input not found');
+    }
+    const file = new File(['headshot-bytes'], fileName, { type });
+    Object.defineProperty(input, 'files', {
+        configurable: true,
+        value: [file]
+    });
+    await act(async () => {
+        input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flush();
+    return file;
+}
+
 async function attachComposerFile(container, fileName = 'social.png') {
     const input = container.querySelector('input[type="file"]');
     if (!input) {
@@ -183,6 +200,8 @@ beforeEach(() => {
         callback(0);
         return 0;
     };
+    window.URL.createObjectURL = vi.fn((file) => `blob:${file.name}`);
+    window.URL.revokeObjectURL = vi.fn();
     window.scrollTo = vi.fn();
 
     const nextEvent = event({ id: 'game-next', opponent: 'Falcons' });
@@ -352,7 +371,7 @@ beforeEach(() => {
 
     playerMocks.loadParentPlayerDetail.mockResolvedValue({
         child: { teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat Star' },
-        player: { id: 'player-1', name: 'Pat Star', teamId: 'team-1', teamName: 'Bears', number: '9', photoUrl: '' },
+        player: { id: 'player-1', name: 'Pat Star', teamId: 'team-1', teamName: 'Bears', number: '9', photoUrl: 'https://example.test/linked-season.jpg' },
         team: { id: 'team-1', name: 'Bears', sport: 'basketball' },
         events: [statEvent, nextEvent, practice],
         nextEvent,
@@ -389,7 +408,18 @@ beforeEach(() => {
             unpaidCents: 1200
         },
         athleteProfile: {
-            profile: { id: 'profile-1', athlete: { name: 'Pat Star', headline: '2028 Guard' }, bio: { position: 'Guard' }, privacy: 'public', seasons: [{ teamId: 'team-1', playerId: 'player-1' }] },
+            profile: {
+                id: 'profile-1',
+                athlete: { name: 'Pat Star', headline: '2028 Guard' },
+                bio: { position: 'Guard' },
+                privacy: 'public',
+                seasons: [{ teamId: 'team-1', playerId: 'player-1' }],
+                profilePhotoUrl: 'https://example.test/custom-headshot.jpg',
+                profilePhotoPath: 'athlete-profile-media/user-1/profile-1/custom.jpg',
+                profilePhotoMimeType: 'image/jpeg',
+                profilePhotoSizeBytes: 42,
+                profilePhotoUploadedAtMs: 1234
+            },
             shareUrl: 'https://allplays.ai/athlete-profile.html?profileId=profile-1',
             builderUrl: 'https://allplays.ai/athlete-profile-builder.html?teamId=team-1&playerId=player-1&profileId=profile-1'
         }
@@ -572,19 +602,33 @@ describe('React app Home and player drill-in integration', () => {
         await waitForText(container, 'Athlete Profile Builder');
         expect(buttonByText(container, 'Athlete Profile').getAttribute('aria-pressed')).toBe('true');
 
+        expect(container.textContent).toContain('Custom athlete profile headshot');
+        await attachAthleteHeadshotFile(container, 'new-headshot.png');
+        expect(container.textContent).toContain('New headshot selected. Save to publish it.');
         await clickButton(container, 'Save Athlete Profile');
         await waitForText(container, 'Saved');
         expect(playerMocks.saveParentAthleteProfileDraft).toHaveBeenCalledWith(expect.objectContaining({
             user: auth.user,
             teamId: 'team-1',
             playerId: 'player-1',
-            profileId: 'profile-1'
+            profileId: 'profile-1',
+            profilePhotoFile: expect.objectContaining({ name: 'new-headshot.png', type: 'image/png' }),
+            resetProfilePhoto: false
         }));
         expect(playerMocks.loadParentPlayerDetail).toHaveBeenCalledTimes(2);
         expect(buttonByText(container, 'Athlete Profile').getAttribute('aria-pressed')).toBe('true');
         expect(container.textContent).toContain('Athlete Profile Builder');
         expect(container.textContent).not.toContain('Parents can update the player photo');
         expect(container.textContent).not.toContain('Loading player');
+
+        await attachAthleteHeadshotFile(container, 'notes.txt', 'text/plain');
+        await waitForText(container, 'Choose an image file for the athlete headshot.');
+        await clickButton(container, 'Use linked season photo');
+        await clickButton(container, 'Save Athlete Profile');
+        expect(playerMocks.saveParentAthleteProfileDraft).toHaveBeenLastCalledWith(expect.objectContaining({
+            profilePhotoFile: null,
+            resetProfilePhoto: true
+        }));
 
         await clickButton(container, 'Incentives');
         await waitForText(container, 'Incentive wallet');

--- a/tests/unit/app-player-service.test.js
+++ b/tests/unit/app-player-service.test.js
@@ -13,6 +13,7 @@ const dbMocks = vi.hoisted(() => ({
     listCertificatesForPlayer: vi.fn(),
     saveAthleteProfile: vi.fn(),
     updatePlayerProfile: vi.fn(),
+    uploadAthleteProfileMedia: vi.fn(),
     uploadPlayerPhoto: vi.fn()
 }));
 
@@ -156,6 +157,14 @@ beforeEach(() => {
     dbMocks.inviteCoParentToAthlete.mockResolvedValue({ id: 'invite-1', code: 'ABC12345', teamName: 'Bears', playerName: 'Pat Star', existingUser: false });
     dbMocks.saveAthleteProfile.mockResolvedValue({ id: 'profile-1', athlete: { name: 'Pat Star' }, privacy: 'public' });
     dbMocks.updatePlayerProfile.mockResolvedValue(undefined);
+    dbMocks.uploadAthleteProfileMedia.mockResolvedValue({
+        url: 'https://example.test/headshot.jpg',
+        storagePath: 'athlete-profile-media/user-1/profile-1/headshot.jpg',
+        mimeType: 'image/jpeg',
+        sizeBytes: 8,
+        uploadedAtMs: 1234,
+        mediaType: 'image'
+    });
     dbMocks.uploadPlayerPhoto.mockResolvedValue('https://example.test/new-photo.jpg');
     dbMocks.getPublicTrackingItems.mockResolvedValue([{ id: 'item-1', title: 'Bring ball' }]);
     dbMocks.getPlayerTrackingStatuses.mockResolvedValue([{ playerId: 'player-1', itemId: 'item-1', status: 'complete' }]);
@@ -344,6 +353,51 @@ describe('React app parent player detail service', () => {
             selectedSeasonKeys: ['team-1::player-1']
         }, { profileId: 'profile-1' });
         expect(savedProfile.shareUrl).toBe('https://allplays.ai/athlete-profile.html?profileId=profile-1');
+    });
+
+    it('uploads athlete profile headshots before saving and supports linked-photo reset', async () => {
+        const file = new File(['headshot'], 'headshot.jpg', { type: 'image/jpeg' });
+
+        await saveParentAthleteProfileDraft({
+            user: user(),
+            teamId: 'team-1',
+            playerId: 'player-1',
+            profileId: 'profile-1',
+            profilePhotoFile: file,
+            draft: {
+                athlete: { name: 'Pat Star' },
+                bio: {},
+                privacy: 'public',
+                clips: [],
+                profilePhoto: { url: 'https://example.test/old.jpg' }
+            }
+        });
+
+        expect(dbMocks.uploadAthleteProfileMedia).toHaveBeenCalledWith('user-1', 'profile-1', file, { kind: 'profile-photo' });
+        expect(dbMocks.saveAthleteProfile).toHaveBeenLastCalledWith('user-1', expect.objectContaining({
+            profilePhoto: expect.objectContaining({ url: 'https://example.test/headshot.jpg' }),
+            selectedSeasonKeys: ['team-1::player-1']
+        }), { profileId: 'profile-1' });
+
+        await saveParentAthleteProfileDraft({
+            user: user(),
+            teamId: 'team-1',
+            playerId: 'player-1',
+            profileId: 'profile-1',
+            resetProfilePhoto: true,
+            draft: {
+                athlete: { name: 'Pat Star' },
+                bio: {},
+                privacy: 'public',
+                clips: [],
+                profilePhoto: { url: 'https://example.test/old.jpg' }
+            }
+        });
+
+        expect(dbMocks.saveAthleteProfile).toHaveBeenLastCalledWith('user-1', expect.objectContaining({
+            profilePhoto: null,
+            selectedSeasonKeys: ['team-1::player-1']
+        }), { profileId: 'profile-1' });
     });
 
     it('saves incentive rules under the parent account', async () => {

--- a/tests/unit/app-player-service.test.js
+++ b/tests/unit/app-player-service.test.js
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const dbMocks = vi.hoisted(() => ({
+    deleteAthleteProfileMediaByPath: vi.fn(),
     getAggregatedStatsForPlayer: vi.fn(),
     getGames: vi.fn(),
     getPlayerPrivateProfile: vi.fn(),
@@ -156,6 +157,7 @@ beforeEach(() => {
     }]);
     dbMocks.inviteCoParentToAthlete.mockResolvedValue({ id: 'invite-1', code: 'ABC12345', teamName: 'Bears', playerName: 'Pat Star', existingUser: false });
     dbMocks.saveAthleteProfile.mockResolvedValue({ id: 'profile-1', athlete: { name: 'Pat Star' }, privacy: 'public' });
+    dbMocks.deleteAthleteProfileMediaByPath.mockResolvedValue(undefined);
     dbMocks.updatePlayerProfile.mockResolvedValue(undefined);
     dbMocks.uploadAthleteProfileMedia.mockResolvedValue({
         url: 'https://example.test/headshot.jpg',
@@ -398,6 +400,49 @@ describe('React app parent player detail service', () => {
             profilePhoto: null,
             selectedSeasonKeys: ['team-1::player-1']
         }), { profileId: 'profile-1' });
+    });
+
+    it('rejects invalid athlete profile headshots before upload', async () => {
+        const file = new File(['not image'], 'headshot.txt', { type: 'text/plain' });
+
+        await expect(saveParentAthleteProfileDraft({
+            user: user(),
+            teamId: 'team-1',
+            playerId: 'player-1',
+            profileId: 'profile-1',
+            profilePhotoFile: file,
+            draft: {
+                athlete: { name: 'Pat Star' },
+                bio: {},
+                privacy: 'public',
+                clips: []
+            }
+        })).rejects.toThrow('Player photos must be image files.');
+
+        expect(dbMocks.uploadAthleteProfileMedia).not.toHaveBeenCalled();
+        expect(dbMocks.saveAthleteProfile).not.toHaveBeenCalled();
+    });
+
+    it('cleans up uploaded athlete profile headshots when saving the profile fails', async () => {
+        const file = new File(['headshot'], 'headshot.jpg', { type: 'image/jpeg' });
+        dbMocks.saveAthleteProfile.mockRejectedValueOnce(new Error('profile save failed'));
+
+        await expect(saveParentAthleteProfileDraft({
+            user: user(),
+            teamId: 'team-1',
+            playerId: 'player-1',
+            profileId: 'profile-1',
+            profilePhotoFile: file,
+            draft: {
+                athlete: { name: 'Pat Star' },
+                bio: {},
+                privacy: 'public',
+                clips: []
+            }
+        })).rejects.toThrow('profile save failed');
+
+        expect(dbMocks.uploadAthleteProfileMedia).toHaveBeenCalledWith('user-1', 'profile-1', file, { kind: 'profile-photo' });
+        expect(dbMocks.deleteAthleteProfileMediaByPath).toHaveBeenCalledWith('athlete-profile-media/user-1/profile-1/headshot.jpg');
     });
 
     it('saves incentive rules under the parent account', async () => {


### PR DESCRIPTION
Closes #1335

## Summary
- Added in-app Athlete Profile headshot preview, image picker, pending-save state, and linked season photo reset control.
- Wired React saves through athlete profile media upload with `kind: profile-photo`, preserving existing metadata when unchanged and saving `null` on reset.
- Added focused service and integration coverage for upload, reset, non-image validation, and save wiring.

## Validation
- `npx vitest run tests/unit/app-player-service.test.js tests/unit/app-home-player-integration.test.jsx --reporter=verbose`
- `npm run app:build`