### PR TITLE
Filter inactive teams from app surfaces

### DIFF
--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -58,6 +58,7 @@ export type ChatTeam = {
   name: string;
   sport?: string | null;
   photoUrl?: string | null;
+  active?: boolean;
   role: 'Parent' | 'Coach' | 'Admin';
   canModerate: boolean;
   unreadCount: number;
@@ -150,6 +151,10 @@ function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = primaryD
 
 function compactString(value: unknown) {
   return String(value || '').trim();
+}
+
+function isActiveTeam(team: Record<string, any> | null | undefined) {
+  return team?.active !== false;
 }
 
 function getProjectId() {
@@ -365,7 +370,9 @@ async function nativeLoadUserTeams(user: AuthUser, profile: Record<string, any>)
   [...ownedTeams, ...adminTeams, ...parentTeams].forEach((team) => {
     if (team?.id) map.set(team.id, team);
   });
-  return [...map.values()].sort((a, b) => String(a.name || a.id).localeCompare(String(b.name || b.id)));
+  return [...map.values()]
+    .filter(isActiveTeam)
+    .sort((a, b) => String(a.name || a.id).localeCompare(String(b.name || b.id)));
 }
 
 async function getLatestMessagePreview(teamId: string): Promise<ChatMessage | null> {
@@ -408,7 +415,7 @@ export async function loadChatInbox(user: AuthUser | null): Promise<ChatInboxLoa
   }
 
   const userWithProfile = mapUserWithProfile(user, profile);
-  const accessibleTeams = teams.filter((team) => canAccessTeamChat(userWithProfile, { ...team, id: team.id }));
+  const accessibleTeams = teams.filter((team) => isActiveTeam(team) && canAccessTeamChat(userWithProfile, { ...team, id: team.id }));
   const unreadCounts = await withTimeout(
     Promise.resolve(getUnreadChatCounts(user.uid, accessibleTeams.map((team) => team.id))),
     'Chat unread counts',
@@ -426,6 +433,7 @@ export async function loadChatInbox(user: AuthUser | null): Promise<ChatInboxLoa
       name: team.name || 'Team',
       sport: team.sport || null,
       photoUrl: team.photoUrl || null,
+      active: team.active,
       role: getTeamRole(user, team, profile),
       canModerate: canModerateChat(userWithProfile, { ...team, id: team.id }),
       unreadCount: Number(unreadCounts[team.id] || 0),
@@ -454,7 +462,7 @@ export async function loadChatTeamContext(teamId: string, user: AuthUser | null)
     })
   ]);
 
-  if (!team) throw new Error('Team not found.');
+  if (!team || !isActiveTeam(team as Record<string, any>)) throw new Error('Team not found.');
   const currentTeam = { ...team, id: teamId };
   const profileData = profile || {};
   const userWithProfile = mapUserWithProfile(user, profileData as Record<string, any>);

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -258,6 +258,10 @@ function compactString(value: unknown) {
   return String(value || '').trim();
 }
 
+function isActiveTeam(team: Record<string, any> | null | undefined) {
+  return team?.active !== false;
+}
+
 function normalizeChildLinks(user: AuthUser, profile: Record<string, unknown>): ParentScheduleChild[] {
   const parentOf = Array.isArray(profile.parentOf) && profile.parentOf.length > 0
     ? profile.parentOf
@@ -333,11 +337,12 @@ function makeEventKey(teamId: string, id: string, childId: string, date: Date, t
 }
 
 async function loadTeam(teamId: string) {
-  return readWithNativeFallback(
+  const team = await readWithNativeFallback(
     `team ${teamId}`,
     () => Promise.resolve(getTeam(teamId)),
     () => nativeGetDocument(`teams/${encodeURIComponent(teamId)}`)
   );
+  return isActiveTeam(team as Record<string, any> | null) ? team : null;
 }
 
 async function loadGames(teamId: string) {

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -35,6 +35,7 @@ export type AppSearchTeam = {
   city?: string | null;
   state?: string | null;
   isPublic?: boolean;
+  active?: boolean;
   ownerId?: string | null;
   adminEmails?: string[];
   photoUrl?: string | null;
@@ -226,6 +227,7 @@ export async function loadAppSearchTeams(user: AuthUser | null): Promise<AppSear
   if (homeTeamsResult.status === 'fulfilled' && homeTeamsResult.value) {
     (homeTeamsResult.value.teams || []).forEach((team: any) => {
       if (!team?.teamId) return;
+      if (team.active === false) return;
       const existing = teamsById.get(team.teamId);
       teamsById.set(team.teamId, {
         ...existing,
@@ -236,6 +238,7 @@ export async function loadAppSearchTeams(user: AuthUser | null): Promise<AppSear
         city: existing?.city || '',
         state: existing?.state || '',
         isPublic: existing?.isPublic,
+        active: team.active ?? existing?.active,
         ownerId: existing?.ownerId,
         adminEmails: existing?.adminEmails || [],
         photoUrl: team.photoUrl || existing?.photoUrl || null,
@@ -365,6 +368,7 @@ function normalizeTeams(teams: any[]): AppSearchTeam[] {
       city: cleanString(team?.city),
       state: cleanString(team?.state),
       isPublic: team?.isPublic,
+      active: team?.active,
       ownerId: cleanString(team?.ownerId),
       adminEmails: Array.isArray(team?.adminEmails) ? team.adminEmails : [],
       photoUrl: getFirstUrl(team?.photoUrl, team?.teamPhotoUrl, team?.logoUrl, team?.imageUrl)
@@ -374,6 +378,7 @@ function normalizeTeams(teams: any[]): AppSearchTeam[] {
 
 function canUserDiscoverTeamInAppSearch(team: AppSearchTeam, user: AuthUser | null) {
   if (!team) return false;
+  if (team.active === false) return false;
   if (team.fromAppAccess) return true;
   if (team.isPublic !== false) return true;
   if (!user) return false;

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -131,10 +131,12 @@ describe('React app chat recipient service', () => {
         });
         dbMocks.getUserTeamsWithAccess.mockResolvedValue([
             { id: 'team-coach', name: 'Bears', sport: 'Basketball', adminEmails: ['parent@example.com'] },
+            { id: 'team-inactive-admin', name: 'Inactive Admin', sport: 'Soccer', adminEmails: ['parent@example.com'], active: false },
             { id: 'team-denied', name: 'Hidden team', sport: 'Soccer' }
         ]);
         dbMocks.getParentTeams.mockResolvedValue([
-            { id: 'team-parent', name: 'Zebras', sport: 'Soccer' }
+            { id: 'team-parent', name: 'Zebras', sport: 'Soccer' },
+            { id: 'team-inactive-parent', name: 'Inactive Parent', sport: 'Soccer', active: false }
         ]);
         dbMocks.getUnreadChatCounts.mockResolvedValue({
             'team-parent': 2,
@@ -160,6 +162,8 @@ describe('React app chat recipient service', () => {
         expect(dbMocks.getUserTeamsWithAccess).toHaveBeenCalledWith('user-1', 'parent@example.com');
         expect(dbMocks.getParentTeams).toHaveBeenCalledWith('user-1');
         expect(dbMocks.getUnreadChatCounts).toHaveBeenCalledWith('user-1', ['team-coach', 'team-parent']);
+        expect(dbMocks.canAccessTeamChat).not.toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ id: 'team-inactive-admin' }));
+        expect(dbMocks.canAccessTeamChat).not.toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ id: 'team-inactive-parent' }));
         expect(dbMocks.canAccessTeamChat).toHaveBeenCalledWith(expect.objectContaining({
             uid: 'user-1',
             parentOf: [{ teamId: 'team-parent', playerId: 'player-1' }]

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -147,6 +147,7 @@ describe('React app search service', () => {
     it('loads public/current-site teams and merges private teams from app access', async () => {
         dbMocks.getTeams.mockResolvedValue([
             { id: 'team-public', name: 'Public Bears', sport: 'Soccer', isPublic: true },
+            { id: 'team-inactive', name: 'Inactive Sharks', sport: 'Soccer', isPublic: true, active: false },
             { id: 'team-private', name: 'Private Wolves', sport: 'Basketball', isPublic: false },
             { id: 'team-admin', name: 'Admin Lions', sport: 'Soccer', isPublic: false, adminEmails: ['parent@example.com'] },
             { id: 'team-owner', name: 'Owner Eagles', sport: 'Volleyball', isPublic: false, ownerId: 'user-1' },
@@ -158,6 +159,16 @@ describe('React app search service', () => {
                 teamName: 'Home Rockets',
                 sport: 'Basketball',
                 photoUrl: 'https://img.example.test/home.png',
+                players: [],
+                nextEvent: null,
+                eventCount: 0,
+                unreadCount: 0,
+                openActions: 0
+            }, {
+                teamId: 'team-inactive-access',
+                teamName: 'Inactive Access',
+                sport: 'Soccer',
+                active: false,
                 players: [],
                 nextEvent: null,
                 eventCount: 0,
@@ -175,6 +186,8 @@ describe('React app search service', () => {
             photoUrl: 'https://img.example.test/home.png'
         });
         expect(teams.find((team) => team.id === 'team-private')).toBeUndefined();
+        expect(teams.find((team) => team.id === 'team-inactive')).toBeUndefined();
+        expect(teams.find((team) => team.id === 'team-inactive-access')).toBeUndefined();
     });
 
     it('caches loaded teams and falls back to app access when public team loading fails', async () => {


### PR DESCRIPTION
Closes #1333

## Summary
- Filter `active === false` teams from React app chat inbox, native REST chat fallback, and direct chat context loads.
- Filter inactive teams from app search results, including app-access/home merged teams.
- Prevent native REST schedule fallback from loading inactive teams into parent schedules.

## Validation
- `npx vitest run tests/unit/app-search-service.test.js tests/unit/app-chat-service-recipients.test.js --reporter=verbose`
- `npm run app:build`