### PR TITLE
Add admin recent game results dashboard

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -158,6 +158,17 @@
                 </div>
             </div>
 
+            <!-- Recent Game Results -->
+            <div class="bg-white rounded-xl shadow-sm border border-gray-200">
+                <div class="p-4 border-b border-gray-200">
+                    <h3 class="text-lg font-semibold text-gray-900">Recent Game Results</h3>
+                    <p class="text-sm text-gray-500 mt-1">Newest completed or scored games across visible teams.</p>
+                </div>
+                <div id="recent-game-results" class="p-4">
+                    <p class="text-sm text-gray-400">Loading...</p>
+                </div>
+            </div>
+
             <!-- Recent Activity -->
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
                 <div class="bg-white rounded-xl shadow-sm border border-gray-200">

--- a/docs/pr-notes/runs/1340-remediator-20260525T053128Z/architecture.md
+++ b/docs/pr-notes/runs/1340-remediator-20260525T053128Z/architecture.md
@@ -1,0 +1,6 @@
+# Architecture
+
+- Keep result eligibility centralized in `js/admin-game-results.js`.
+- Treat `status === completed` as explicit completion intent.
+- Treat numeric scores as an implicit result only when at least one side is non-zero, because schedule creation defaults new events to `homeScore: 0` and `awayScore: 0`.
+- No data model or dashboard wiring changes are required.

--- a/docs/pr-notes/runs/1340-remediator-20260525T053128Z/code-plan.md
+++ b/docs/pr-notes/runs/1340-remediator-20260525T053128Z/code-plan.md
@@ -1,0 +1,5 @@
+# Code Plan
+
+- Update `hasScore` to require both scores to be numeric and at least one score to be non-zero.
+- Extend `tests/unit/admin-game-results.test.js` with a scheduled 0-0 fixture and assert it is filtered out.
+- Run the focused unit test and commit the scoped changes.

--- a/docs/pr-notes/runs/1340-remediator-20260525T053128Z/qa.md
+++ b/docs/pr-notes/runs/1340-remediator-20260525T053128Z/qa.md
@@ -1,0 +1,5 @@
+# QA
+
+- Add a unit regression case proving scheduled default 0-0 games are excluded.
+- Preserve existing coverage for completed games, scored scheduled games, sorting, formatting, and dashboard wiring.
+- Validate with the focused Vitest file for admin game results.

--- a/docs/pr-notes/runs/1340-remediator-20260525T053128Z/requirements.md
+++ b/docs/pr-notes/runs/1340-remediator-20260525T053128Z/requirements.md
@@ -1,0 +1,6 @@
+# Requirements
+
+- Recent Game Results must show completed games regardless of whether score fields are missing or 0-0.
+- Recent Game Results may show in-progress/imported games with non-zero numeric scores even when status is not completed.
+- Scheduled default 0-0 events must not appear as scored results.
+- Existing visible-team filtering, sorting, formatting, and limit behavior must remain unchanged.

--- a/js/admin-game-results.js
+++ b/js/admin-game-results.js
@@ -1,0 +1,60 @@
+function toDate(value) {
+    if (!value) return null;
+    if (value.toDate) return value.toDate();
+    const parsed = new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function toNumber(value) {
+    if (value === null || value === undefined || value === '') return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+}
+
+function hasScore(game) {
+    return toNumber(game?.homeScore) !== null && toNumber(game?.awayScore) !== null;
+}
+
+function isRecentResultCandidate(game) {
+    const status = String(game?.status || '').toLowerCase();
+    return status === 'completed' || hasScore(game);
+}
+
+function getResultStatus(homeScore, awayScore) {
+    if (homeScore === null || awayScore === null) return 'Played';
+    if (homeScore > awayScore) return 'Win';
+    if (homeScore < awayScore) return 'Loss';
+    return 'Tie';
+}
+
+export function formatGameResult(game = {}) {
+    const homeScore = toNumber(game.homeScore);
+    const awayScore = toNumber(game.awayScore);
+    const score = homeScore !== null && awayScore !== null ? `${homeScore}-${awayScore}` : 'No score';
+    const status = String(game.status || '').toLowerCase() === 'completed'
+        ? getResultStatus(homeScore, awayScore)
+        : 'Scored';
+
+    return { score, status };
+}
+
+export function buildRecentGameResultsRows(games = [], { limit = 10 } = {}) {
+    return games
+        .filter(isRecentResultCandidate)
+        .map((game) => {
+            const date = toDate(game.date);
+            const { score, status } = formatGameResult(game);
+            return {
+                teamId: game.teamId || '',
+                gameId: game.id || game.gameId || '',
+                teamName: game.teamName || 'Unknown team',
+                opponent: game.opponent || 'Opponent',
+                date,
+                dateLabel: date ? date.toLocaleDateString() : 'Unknown date',
+                score,
+                status
+            };
+        })
+        .sort((a, b) => (b.date?.getTime() || 0) - (a.date?.getTime() || 0))
+        .slice(0, limit);
+}

--- a/js/admin-game-results.js
+++ b/js/admin-game-results.js
@@ -12,7 +12,9 @@ function toNumber(value) {
 }
 
 function hasScore(game) {
-    return toNumber(game?.homeScore) !== null && toNumber(game?.awayScore) !== null;
+    const homeScore = toNumber(game?.homeScore);
+    const awayScore = toNumber(game?.awayScore);
+    return homeScore !== null && awayScore !== null && (homeScore !== 0 || awayScore !== 0);
 }
 
 function isRecentResultCandidate(game) {

--- a/js/admin.js
+++ b/js/admin.js
@@ -20,6 +20,7 @@ import {
     getAdminRegistrationShareUrl,
     validateAdminRegistrationFormPayload
 } from './admin-registration-forms.js?v=3';
+import { buildRecentGameResultsRows } from './admin-game-results.js?v=1';
 
 let allTeams = [];
 let allUsers = [];
@@ -198,6 +199,7 @@ function updateDashboard() {
     const scheduledGames = visibleGames.filter(g => g.status === 'scheduled').length;
     document.getElementById('stat-total-games').textContent = visibleGames.length;
     document.getElementById('stat-games-breakdown').textContent = `${completedGames} played, ${scheduledGames} scheduled`;
+    renderRecentGameResults(visibleGames);
 
     // Activity (teams with games in last 7 days)
     const activeTeams = new Set(visibleGames.filter(g => {
@@ -284,6 +286,56 @@ function updateDashboard() {
             ${user.isAdmin ? '<span class="text-xs bg-purple-100 text-purple-700 px-2 py-1 rounded-full font-semibold">Admin</span>' : ''}
         </div>
     `).join('');
+}
+
+function renderRecentGameResults(visibleGames) {
+    const container = document.getElementById('recent-game-results');
+    if (!container) return;
+
+    const rows = buildRecentGameResultsRows(visibleGames, { limit: 10 });
+    if (!rows.length) {
+        container.innerHTML = '<p class="text-sm text-gray-500">No completed or scored game results yet.</p>';
+        return;
+    }
+
+    container.innerHTML = `
+        <div class="overflow-x-auto">
+            <table class="min-w-full divide-y divide-gray-200 text-sm">
+                <thead class="bg-gray-50">
+                    <tr>
+                        <th class="px-3 py-2 text-left font-semibold text-gray-600">Date</th>
+                        <th class="px-3 py-2 text-left font-semibold text-gray-600">Team</th>
+                        <th class="px-3 py-2 text-left font-semibold text-gray-600">Opponent</th>
+                        <th class="px-3 py-2 text-left font-semibold text-gray-600">Score</th>
+                        <th class="px-3 py-2 text-left font-semibold text-gray-600">Status</th>
+                        <th class="px-3 py-2 text-left font-semibold text-gray-600">Report</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-gray-100 bg-white">
+                    ${rows.map(row => {
+                        const reportHref = row.teamId && row.gameId
+                            ? `game.html#teamId=${encodeURIComponent(row.teamId)}&gameId=${encodeURIComponent(row.gameId)}`
+                            : '';
+                        return `
+                            <tr>
+                                <td class="px-3 py-2 text-gray-600 whitespace-nowrap">${escapeHtml(row.dateLabel)}</td>
+                                <td class="px-3 py-2 font-medium text-gray-900">${escapeHtml(row.teamName)}</td>
+                                <td class="px-3 py-2 text-gray-700">${escapeHtml(row.opponent)}</td>
+                                <td class="px-3 py-2 font-semibold text-gray-900 whitespace-nowrap">${escapeHtml(row.score)}</td>
+                                <td class="px-3 py-2 text-gray-700">${escapeHtml(row.status)}</td>
+                                <td class="px-3 py-2 whitespace-nowrap">
+                                    ${reportHref
+                                        ? `<a href="${reportHref}" class="text-indigo-600 hover:text-indigo-800 font-medium">Game Report →</a>`
+                                        : '<span class="text-gray-400">Unavailable</span>'
+                                    }
+                                </td>
+                            </tr>
+                        `;
+                    }).join('')}
+                </tbody>
+            </table>
+        </div>
+    `;
 }
 
 function telemetryDate(value) {

--- a/tests/unit/admin-game-results.test.js
+++ b/tests/unit/admin-game-results.test.js
@@ -10,6 +10,7 @@ describe('admin recent game results', () => {
     it('filters to completed or scored games and sorts newest first', () => {
         const rows = buildRecentGameResultsRows([
             { id: 'scheduled', teamId: 'team-1', teamName: 'Blue', opponent: 'Gold', status: 'scheduled', date: ts('2026-01-03T12:00:00Z') },
+            { id: 'default-score', teamId: 'team-1', teamName: 'Blue', opponent: 'Yellow', status: 'scheduled', homeScore: 0, awayScore: 0, date: ts('2026-01-05T12:00:00Z') },
             { id: 'old', teamId: 'team-2', teamName: 'Red', opponent: 'Green', status: 'completed', homeScore: 1, awayScore: 2, date: ts('2026-01-01T12:00:00Z') },
             { id: 'new', teamId: 'team-3', teamName: 'White', opponent: 'Black', status: 'scheduled', homeScore: 4, awayScore: 3, date: ts('2026-01-04T12:00:00Z') },
             { id: 'middle', teamId: 'team-4', teamName: 'Gray', opponent: 'Orange', status: 'completed', date: ts('2026-01-02T12:00:00Z') }

--- a/tests/unit/admin-game-results.test.js
+++ b/tests/unit/admin-game-results.test.js
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import { buildRecentGameResultsRows, formatGameResult } from '../../js/admin-game-results.js';
+
+function ts(date) {
+    return { toDate: () => new Date(date) };
+}
+
+describe('admin recent game results', () => {
+    it('filters to completed or scored games and sorts newest first', () => {
+        const rows = buildRecentGameResultsRows([
+            { id: 'scheduled', teamId: 'team-1', teamName: 'Blue', opponent: 'Gold', status: 'scheduled', date: ts('2026-01-03T12:00:00Z') },
+            { id: 'old', teamId: 'team-2', teamName: 'Red', opponent: 'Green', status: 'completed', homeScore: 1, awayScore: 2, date: ts('2026-01-01T12:00:00Z') },
+            { id: 'new', teamId: 'team-3', teamName: 'White', opponent: 'Black', status: 'scheduled', homeScore: 4, awayScore: 3, date: ts('2026-01-04T12:00:00Z') },
+            { id: 'middle', teamId: 'team-4', teamName: 'Gray', opponent: 'Orange', status: 'completed', date: ts('2026-01-02T12:00:00Z') }
+        ]);
+
+        expect(rows.map(row => row.gameId)).toEqual(['new', 'middle', 'old']);
+        expect(rows[0]).toMatchObject({ teamName: 'White', opponent: 'Black', score: '4-3', status: 'Scored' });
+        expect(rows[1]).toMatchObject({ score: 'No score', status: 'Played' });
+    });
+
+    it('formats win, loss, tie, and missing scores', () => {
+        expect(formatGameResult({ status: 'completed', homeScore: 5, awayScore: 3 })).toEqual({ score: '5-3', status: 'Win' });
+        expect(formatGameResult({ status: 'completed', homeScore: 2, awayScore: 4 })).toEqual({ score: '2-4', status: 'Loss' });
+        expect(formatGameResult({ status: 'completed', homeScore: 1, awayScore: 1 })).toEqual({ score: '1-1', status: 'Tie' });
+        expect(formatGameResult({ status: 'completed' })).toEqual({ score: 'No score', status: 'Played' });
+    });
+
+    it('wires the admin dashboard container and renderer', () => {
+        const adminHtml = fs.readFileSync('admin.html', 'utf8');
+        const adminJs = fs.readFileSync('js/admin.js', 'utf8');
+
+        expect(adminHtml).toContain('Recent Game Results');
+        expect(adminHtml).toContain('id="recent-game-results"');
+        expect(adminJs).toContain("import { buildRecentGameResultsRows } from './admin-game-results.js?v=1';");
+        expect(adminJs).toContain('renderRecentGameResults(visibleGames);');
+        expect(adminJs).toContain('No completed or scored game results yet.');
+        expect(adminJs).toContain('Game Report →');
+        expect(adminJs).toContain('game.html#teamId=');
+    });
+});


### PR DESCRIPTION
Closes #1336

## Summary
- Added a Recent Game Results card to the admin dashboard.
- Renders newest completed or scored games from the same visible team set used by dashboard counts.
- Shows date, team, opponent, score, result status, and Game Report links, with a clear empty state.

## Tests
- `npx vitest run tests/unit/admin-game-results.test.js tests/unit/admin-dashboard-stats.test.js --reporter=verbose`