### PR TITLE
Resume running live tracker clocks

### DIFF
--- a/docs/pr-notes/runs/1342-remediator-20260525T055935Z/architecture.md
+++ b/docs/pr-notes/runs/1342-remediator-20260525T055935Z/architecture.md
@@ -1,0 +1,12 @@
+# Architecture
+
+## Decision
+Keep `deriveResumeClockState` responsible for visible running-clock restoration, and add a small pure helper that derives the elapsed lineup time separately.
+
+## Rationale
+The clock and lineup stat totals have different sources of authority on same-device resume. The persisted game document is authoritative for clock continuity, while the local tracker snapshot is authoritative for player stat time already accumulated on that browser.
+
+## Implementation shape
+- `deriveResumeClockState` exposes the persisted clock update timestamp and evaluation timestamp.
+- `buildResumeLineupElapsedMs` returns full elapsed time when no local snapshot exists.
+- When a local snapshot exists, it returns only elapsed time after the local snapshot `savedAt`; invalid local timestamps return zero to avoid double-counting.

--- a/docs/pr-notes/runs/1342-remediator-20260525T055935Z/code-plan.md
+++ b/docs/pr-notes/runs/1342-remediator-20260525T055935Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code Plan
+
+1. Add a pure `buildResumeLineupElapsedMs` helper in `js/live-tracker-resume.js`.
+2. Import and use the helper in `js/live-tracker.js` where elapsed time is applied to active lineup stats.
+3. Use `liveState.restoredLocalTrackerStateAt` to avoid applying elapsed time already represented in the local snapshot.
+4. Add focused unit tests in `tests/unit/live-tracker-resume.test.js`.

--- a/docs/pr-notes/runs/1342-remediator-20260525T055935Z/qa.md
+++ b/docs/pr-notes/runs/1342-remediator-20260525T055935Z/qa.md
@@ -1,0 +1,12 @@
+# QA
+
+## Automated coverage
+- Running persisted clock still restores visible clock with elapsed wall-clock time.
+- No local snapshot credits active lineup with full persisted running elapsed time.
+- Same-device snapshot only credits elapsed time after local `savedAt`.
+- Current local snapshot credits zero extra lineup time.
+- Invalid local snapshot timestamp credits zero extra lineup time.
+- Paused clock credits zero elapsed time.
+
+## Targeted command
+- `npx vitest run tests/unit/live-tracker-resume.test.js --reporter=verbose`

--- a/docs/pr-notes/runs/1342-remediator-20260525T055935Z/requirements.md
+++ b/docs/pr-notes/runs/1342-remediator-20260525T055935Z/requirements.md
@@ -1,0 +1,13 @@
+# Requirements
+
+## Acceptance criteria
+- Same-browser resume must not double-count active lineup time already captured in the local tracker snapshot.
+- Running-clock display may still advance using persisted game-clock elapsed time.
+- Active lineup time should only receive elapsed time after the local snapshot `savedAt`, clamped to zero.
+- No-local-snapshot/cross-device resume should keep existing behavior and credit active lineup time from persisted running-clock elapsed time.
+- Paused games must not add lineup elapsed time.
+
+## Non-goals
+- No redesign of tracker persistence.
+- No Firestore schema/rules changes.
+- No lineup, substitution, fairness, or opponent-stat behavior changes.

--- a/js/live-tracker-resume.js
+++ b/js/live-tracker-resume.js
@@ -47,6 +47,8 @@ export function buildPersistedResumeClockState(game) {
     return {
         liveClockPeriod: game?.liveClockPeriod,
         liveClockMs: game?.liveClockMs,
+        liveClockRunning: game?.liveClockRunning,
+        liveClockUpdatedAt: game?.liveClockUpdatedAt,
         period: game?.period,
         gameClockMs: game?.gameClockMs,
         clock: game?.clock
@@ -128,7 +130,7 @@ export function buildResumeLogFromLiveEvents(liveEvents = [], { now = () => Date
         .map(({ __resumeOrder, __resumeCreatedAtMs, ...entry }) => entry);
 }
 
-export function deriveResumeClockState(liveEvents, defaults = { period: 'Q1', clock: 0 }, persistedClockState = null) {
+export function deriveResumeClockState(liveEvents, defaults = { period: 'Q1', clock: 0 }, persistedClockState = null, { now = () => Date.now() } = {}) {
     const fallbackPeriod = defaults?.period || 'Q1';
     const fallbackClock = Number.isFinite(defaults?.clock) ? defaults.clock : 0;
     const persistedPeriod = [
@@ -140,16 +142,34 @@ export function deriveResumeClockState(liveEvents, defaults = { period: 'Q1', cl
         persistedClockState?.gameClockMs ??
         persistedClockState?.clock
     );
+    const persistedUpdatedAtMs = toMillis(persistedClockState?.liveClockUpdatedAt);
+    const persistedRunning = persistedClockState?.liveClockRunning === true;
+    const elapsedWhileRunningMs = (
+        persistedRunning &&
+        Number.isFinite(persistedUpdatedAtMs)
+    )
+        ? Math.max(0, now() - persistedUpdatedAtMs)
+        : 0;
     const persistedState = (
         persistedPeriod &&
         Number.isFinite(persistedClock) &&
         persistedClock >= 0
     )
-        ? { period: persistedPeriod, clock: persistedClock, restored: true }
+        ? {
+            period: persistedPeriod,
+            clock: persistedClock + elapsedWhileRunningMs,
+            restored: true,
+            running: persistedRunning,
+            elapsedWhileRunningMs
+        }
         : null;
 
+    if (persistedState?.running) {
+        return persistedState;
+    }
+
     if (!Array.isArray(liveEvents) || liveEvents.length === 0) {
-        return persistedState || { period: fallbackPeriod, clock: fallbackClock, restored: false };
+        return persistedState || { period: fallbackPeriod, clock: fallbackClock, restored: false, running: false, elapsedWhileRunningMs: 0 };
     }
 
     const candidates = liveEvents
@@ -168,7 +188,7 @@ export function deriveResumeClockState(liveEvents, defaults = { period: 'Q1', cl
         .filter(Boolean);
 
     if (!candidates.length) {
-        return persistedState || { period: fallbackPeriod, clock: fallbackClock, restored: false };
+        return persistedState || { period: fallbackPeriod, clock: fallbackClock, restored: false, running: false, elapsedWhileRunningMs: 0 };
     }
 
     const withTimestamp = candidates.filter(item => Number.isFinite(item.createdAtMs));

--- a/js/live-tracker-resume.js
+++ b/js/live-tracker-resume.js
@@ -130,6 +130,26 @@ export function buildResumeLogFromLiveEvents(liveEvents = [], { now = () => Date
         .map(({ __resumeOrder, __resumeCreatedAtMs, ...entry }) => entry);
 }
 
+export function buildResumeLineupElapsedMs(resumeClockState, { localStateSavedAt = null } = {}) {
+    const elapsedWhileRunningMs = Math.max(0, Number(resumeClockState?.elapsedWhileRunningMs) || 0);
+    if (!elapsedWhileRunningMs) return 0;
+
+    if (localStateSavedAt == null) return elapsedWhileRunningMs;
+
+    const localSavedAtMs = toMillis(localStateSavedAt);
+    if (!Number.isFinite(localSavedAtMs)) return 0;
+
+    const resumeEvaluatedAtMs = Number(resumeClockState?.resumeEvaluatedAtMs);
+    if (!Number.isFinite(resumeEvaluatedAtMs)) return 0;
+
+    const persistedUpdatedAtMs = Number(resumeClockState?.persistedUpdatedAtMs);
+    const elapsedStartMs = Number.isFinite(persistedUpdatedAtMs)
+        ? Math.max(persistedUpdatedAtMs, localSavedAtMs)
+        : localSavedAtMs;
+
+    return Math.max(0, resumeEvaluatedAtMs - elapsedStartMs);
+}
+
 export function deriveResumeClockState(liveEvents, defaults = { period: 'Q1', clock: 0 }, persistedClockState = null, { now = () => Date.now() } = {}) {
     const fallbackPeriod = defaults?.period || 'Q1';
     const fallbackClock = Number.isFinite(defaults?.clock) ? defaults.clock : 0;
@@ -144,11 +164,12 @@ export function deriveResumeClockState(liveEvents, defaults = { period: 'Q1', cl
     );
     const persistedUpdatedAtMs = toMillis(persistedClockState?.liveClockUpdatedAt);
     const persistedRunning = persistedClockState?.liveClockRunning === true;
+    const resumeEvaluatedAtMs = now();
     const elapsedWhileRunningMs = (
         persistedRunning &&
         Number.isFinite(persistedUpdatedAtMs)
     )
-        ? Math.max(0, now() - persistedUpdatedAtMs)
+        ? Math.max(0, resumeEvaluatedAtMs - persistedUpdatedAtMs)
         : 0;
     const persistedState = (
         persistedPeriod &&
@@ -160,7 +181,9 @@ export function deriveResumeClockState(liveEvents, defaults = { period: 'Q1', cl
             clock: persistedClock + elapsedWhileRunningMs,
             restored: true,
             running: persistedRunning,
-            elapsedWhileRunningMs
+            elapsedWhileRunningMs,
+            persistedUpdatedAtMs,
+            resumeEvaluatedAtMs
         }
         : null;
 

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -9,7 +9,7 @@ import { getApp } from './vendor/firebase-app.js';
 import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './live-tracker-notes.js?v=1';
 import { canApplySubstitution, applySubstitution } from './live-tracker-integrity.js?v=3';
 import { hydrateOpponentStats } from './live-tracker-opponent-stats.js?v=1';
-import { buildPersistedResumeClockState, buildResumeLogFromLiveEvents, deriveResumeClockState } from './live-tracker-resume.js?v=5';
+import { buildPersistedResumeClockState, buildResumeLineupElapsedMs, buildResumeLogFromLiveEvents, deriveResumeClockState } from './live-tracker-resume.js?v=6';
 import { restoreLiveLineup } from './live-tracker-lineup.js?v=1';
 import { resolveFinalScore } from './live-tracker-email.js?v=2';
 import { buildLiveResetEvent } from './live-tracker-reset.js?v=1';
@@ -3129,7 +3129,9 @@ async function init() {
     if (shouldResume && resumeClockState?.restored) {
       state.period = resumeClockState.period;
       state.clock = resumeClockState.clock;
-      addElapsedPlayingTimeToActiveLineup(resumeClockState.elapsedWhileRunningMs);
+      addElapsedPlayingTimeToActiveLineup(buildResumeLineupElapsedMs(resumeClockState, {
+        localStateSavedAt: liveState.restoredLocalTrackerState ? liveState.restoredLocalTrackerStateAt : null
+      }));
     }
 
     if (shouldResume && state.log.length === 0 && resumedLiveEventLog.length > 0) {

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -9,7 +9,7 @@ import { getApp } from './vendor/firebase-app.js';
 import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './live-tracker-notes.js?v=1';
 import { canApplySubstitution, applySubstitution } from './live-tracker-integrity.js?v=3';
 import { hydrateOpponentStats } from './live-tracker-opponent-stats.js?v=1';
-import { buildPersistedResumeClockState, buildResumeLogFromLiveEvents, deriveResumeClockState } from './live-tracker-resume.js?v=4';
+import { buildPersistedResumeClockState, buildResumeLogFromLiveEvents, deriveResumeClockState } from './live-tracker-resume.js?v=5';
 import { restoreLiveLineup } from './live-tracker-lineup.js?v=1';
 import { resolveFinalScore } from './live-tracker-email.js?v=2';
 import { buildLiveResetEvent } from './live-tracker-reset.js?v=1';
@@ -2092,6 +2092,32 @@ async function startStop() {
   persistLocalTrackerState();
 }
 
+function addElapsedPlayingTimeToActiveLineup(elapsedMs) {
+  const safeElapsed = Math.max(0, Number(elapsedMs) || 0);
+  if (!safeElapsed) return;
+  state.onCourt.forEach(id => {
+    if (!state.stats[id]) state.stats[id] = statDefaults(currentConfig.columns);
+    state.stats[id].time += safeElapsed;
+  });
+}
+
+function resumeRunningClock() {
+  if (state.running) return;
+  state.running = true;
+  if (els.startStop) {
+    els.startStop.textContent = 'Pause';
+    els.startStop.classList.remove('bg-emerald-600', 'border-emerald-700');
+    els.startStop.classList.add('bg-red-600', 'border-red-700');
+  }
+  if (state.tick) clearInterval(state.tick);
+  state.lastTick = performance.now();
+  state.tick = setInterval(tick, 500);
+  liveState.lastClockSyncAt = Date.now();
+  addLog('Game clock resumed after reconnect');
+  syncClockToGameDoc();
+  persistLocalTrackerState();
+}
+
 function tick() {
   if (!state.running) return;
   const now = performance.now();
@@ -2911,6 +2937,7 @@ async function init() {
 
     const persistedLocalTrackerState = readPersistedLiveTrackerState(window.localStorage, teamId, gameId);
     let resumedLiveEventLog = [];
+    let resumeClockState = null;
     let shouldResume = true;
     const hasOpponentStats = !!(game.opponentStats && Object.keys(game.opponentStats).length > 0);
 
@@ -3000,7 +3027,7 @@ async function init() {
         resumedLiveEventLog = buildResumeLogFromLiveEvents(liveEvents);
         const resumedFromPersistedData = hasScores || hasLiveFlag || hasOpponentStats || hasAggregatedStats || liveEvents.length > 0;
         state.scoreLogIsComplete = !resumedFromPersistedData;
-        const resumeClockState = deriveResumeClockState(
+        resumeClockState = deriveResumeClockState(
           liveEvents,
           { period: state.period, clock: state.clock },
           buildPersistedResumeClockState(currentGame)
@@ -3099,6 +3126,12 @@ async function init() {
       applyPersistedLocalTrackerState(persistedLocalTrackerState);
     }
 
+    if (shouldResume && resumeClockState?.restored) {
+      state.period = resumeClockState.period;
+      state.clock = resumeClockState.clock;
+      addElapsedPlayingTimeToActiveLineup(resumeClockState.elapsedWhileRunningMs);
+    }
+
     if (shouldResume && state.log.length === 0 && resumedLiveEventLog.length > 0) {
       state.log = resumedLiveEventLog;
       state.scoreLogIsComplete = true;
@@ -3134,6 +3167,9 @@ async function init() {
       .catch(err => console.warn('Failed to sync initial lineup:', err));
     if (currentGame.liveStatus === 'live') {
       await startLiveBroadcast();
+    }
+    if (shouldResume && resumeClockState?.running) {
+      resumeRunningClock();
     }
     if (liveState.eventQueue.length > 0 && window.navigator?.onLine !== false) {
       scheduleRetry({ resetBackoff: true });

--- a/tests/unit/live-tracker-resume.test.js
+++ b/tests/unit/live-tracker-resume.test.js
@@ -70,6 +70,48 @@ describe('live tracker resume clock state', () => {
     expect(result.clock).toBe(187000);
   });
 
+  it('restores a running persisted game clock with elapsed wall-clock time', () => {
+    const result = deriveResumeClockState(
+      [
+        { period: 'Q2', gameClockMs: 61000, createdAt: { toMillis: () => 1000 } }
+      ],
+      { period: 'Q1', clock: 0 },
+      buildPersistedResumeClockState({
+        liveClockPeriod: 'Q2',
+        liveClockMs: 65000,
+        liveClockRunning: true,
+        liveClockUpdatedAt: { toMillis: () => 10000 }
+      }),
+      { now: () => 25000 }
+    );
+
+    expect(result.restored).toBe(true);
+    expect(result.running).toBe(true);
+    expect(result.period).toBe('Q2');
+    expect(result.clock).toBe(80000);
+    expect(result.elapsedWhileRunningMs).toBe(15000);
+  });
+
+  it('does not add elapsed wall-clock time for a paused persisted game clock', () => {
+    const result = deriveResumeClockState(
+      [],
+      { period: 'Q1', clock: 0 },
+      buildPersistedResumeClockState({
+        liveClockPeriod: 'Q2',
+        liveClockMs: 65000,
+        liveClockRunning: false,
+        liveClockUpdatedAt: { toMillis: () => 10000 }
+      }),
+      { now: () => 25000 }
+    );
+
+    expect(result.restored).toBe(true);
+    expect(result.running).toBe(false);
+    expect(result.period).toBe('Q2');
+    expect(result.clock).toBe(65000);
+    expect(result.elapsedWhileRunningMs).toBe(0);
+  });
+
   it('restores using period/clock progression when timestamps are unavailable', () => {
     const result = deriveResumeClockState([
       { period: 'Q1', gameClockMs: 30000 },


### PR DESCRIPTION
Closes #1341

## Summary
- Restore persisted running live-clock state, including elapsed wall-clock time since the last sync.
- Restart the local tracker tick on resume so the UI shows Pause and the clock keeps advancing.
- Add elapsed resume time to active player playing-time totals.

## Validation
- `npx vitest run tests/unit/live-tracker-resume.test.js tests/unit/live-tracker-start-over.test.js tests/unit/live-tracker-opponent-stats.test.js tests/unit/live-tracker-retry-queue.test.js --reporter=verbose`