### PR TITLE
Reject oversized team media uploads

### DIFF
--- a/js/db.js
+++ b/js/db.js
@@ -102,7 +102,7 @@ import {
 } from './registration-review.js?v=2';
 import { assertVolunteerScreeningCleared } from './volunteer-screening-access.js?v=1';
 import { buildTournamentPoolOverrideKey } from './tournament-standings.js?v=1';
-import { buildBulkDeleteUpdates, buildMoveUpdates, buildReorderUpdates, isSafeTeamMediaUrl, isSupportedTeamMediaDocument, normalizeTeamMediaFolderDraft, normalizeAlbumVisibility, sortByMediaOrder } from './team-media-utils.js?v=2';
+import { buildBulkDeleteUpdates, buildMoveUpdates, buildReorderUpdates, isSafeTeamMediaUrl, isSupportedTeamMediaDocument, isSupportedTeamMediaImage, normalizeTeamMediaFolderDraft, normalizeAlbumVisibility, sortByMediaOrder } from './team-media-utils.js?v=3';
 import { getApp } from './vendor/firebase-app.js';
 import {
     claimOfficiatingSlot,
@@ -693,7 +693,7 @@ export async function uploadTeamMediaPhoto(teamId, folderId, file, options = {})
     const currentUser = auth.currentUser;
     if (!cleanTeamId || !cleanFolderId) throw new Error('Choose an album before uploading photos.');
     if (!currentUser?.uid) throw new Error('Sign in before uploading photos.');
-    if (!file || !String(file.type || '').startsWith('image/')) throw new Error('Choose a supported image file.');
+    if (!isSupportedTeamMediaImage(file)) throw new Error('Choose an image file that is 10 MB or smaller.');
 
     const storagePath = `team-media/${cleanTeamId}/${cleanFolderId}/${currentUser.uid}/${Date.now()}-${sanitizeTeamMediaFileName(file.name)}`;
     const storageRef = ref(storage, storagePath);
@@ -739,7 +739,7 @@ export async function uploadTeamMediaFile(teamId, folderId, file, options = {}) 
     const currentUser = auth.currentUser;
     if (!cleanTeamId || !cleanFolderId) throw new Error('Choose an album before uploading files.');
     if (!currentUser?.uid) throw new Error('Sign in before uploading files.');
-    if (!isSupportedTeamMediaDocument(file)) throw new Error('Choose a supported document file.');
+    if (!isSupportedTeamMediaDocument(file)) throw new Error('Choose a supported document file that is 10 MB or smaller.');
 
     const storagePath = `team-media/${cleanTeamId}/${cleanFolderId}/${currentUser.uid}/${Date.now()}-${sanitizeTeamMediaFileName(file.name)}`;
     const storageRef = ref(storage, storagePath);

--- a/js/team-media-utils.js
+++ b/js/team-media-utils.js
@@ -36,6 +36,7 @@ const GENERIC_TEAM_MEDIA_DOCUMENT_TYPES = new Set([
     'binary/octet-stream'
 ]);
 
+export const TEAM_MEDIA_MAX_FILE_SIZE_BYTES = 10 * 1024 * 1024;
 export const TEAM_MEDIA_VISIBILITIES = ['team', 'private'];
 
 function asTrimmedString(value) {
@@ -96,12 +97,16 @@ export function isSupportedTeamMediaVideoUrl(value) {
     return Boolean(getSafeVideoUrl(value));
 }
 
+function isAllowedTeamMediaFileSize(file) {
+    return Number(file?.size || 0) > 0 && Number(file.size) <= TEAM_MEDIA_MAX_FILE_SIZE_BYTES;
+}
+
 export function isSupportedTeamMediaImage(file) {
-    return Boolean(file && String(file.type || '').startsWith('image/'));
+    return Boolean(file && isAllowedTeamMediaFileSize(file) && String(file.type || '').startsWith('image/'));
 }
 
 export function isSupportedTeamMediaDocument(file) {
-    if (!file) return false;
+    if (!file || !isAllowedTeamMediaFileSize(file)) return false;
 
     const mimeType = String(file.type || '').toLowerCase();
     if (TEAM_MEDIA_DOCUMENT_TYPES.has(mimeType)) return true;

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -16,7 +16,7 @@ import {
     bulkDeleteTeamMediaItems,
     setTeamMediaAlbumCover,
     updateTeamMediaItem // Add this new import
-} from './db.js?v=32';
+} from './db.js?v=33';
 import {
     canContributeTeamMedia,
     canDeleteTeamMediaItem,
@@ -30,7 +30,7 @@ import {
     isSupportedTeamMediaImage,
     isTeamMediaDocument,
     sortByMediaOrder
-} from './team-media-utils.js?v=2';
+} from './team-media-utils.js?v=3';
 
 const state = {
     teamId: '',
@@ -591,7 +591,7 @@ els.uploadForm.addEventListener('submit', async (event) => {
         uploadFile: uploadTeamMediaPhoto,
         nounSingular: 'photo',
         nounPlural: 'photos',
-        unsupportedMessage: 'Unsupported file type. Choose an image.'
+        unsupportedMessage: 'Choose an image file that is 10 MB or smaller.'
     });
     if (uploadedCount > 0) els.photoFiles.value = '';
 });
@@ -618,7 +618,7 @@ els.fileUploadForm.addEventListener('submit', async (event) => {
         uploadFile: uploadTeamMediaFile,
         nounSingular: 'file',
         nounPlural: 'files',
-        unsupportedMessage: 'Unsupported file type. Choose a PDF, Office document, text file, or CSV.'
+        unsupportedMessage: 'Choose a supported document file that is 10 MB or smaller.'
     });
     if (uploadedCount > 0) els.mediaFiles.value = '';
 });

--- a/team-media.html
+++ b/team-media.html
@@ -28,7 +28,7 @@
         <section id="team-media-upload-panel" class="hidden mb-6 rounded-xl border border-indigo-100 bg-white p-5 shadow-sm">
             <form id="photo-upload-form" class="space-y-3">
                 <h2 class="font-semibold text-gray-900">Upload photos</h2>
-                <p class="text-sm text-gray-500">Choose an album and add one or more image files.</p>
+                <p class="text-sm text-gray-500">Choose an album and add one or more image files up to 10 MB each.</p>
                 <select id="photo-folder" class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" required></select>
                 <input id="photo-files" type="file" accept="image/*" multiple class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" required>
                 <button class="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2">Upload photos</button>
@@ -36,7 +36,7 @@
             </form>
             <form id="file-upload-form" class="mt-5 space-y-3 border-t border-gray-100 pt-5">
                 <h2 class="font-semibold text-gray-900">Upload files</h2>
-                <p class="text-sm text-gray-500">Share PDFs, Office documents, text files, or CSVs with the team.</p>
+                <p class="text-sm text-gray-500">Share PDFs, Office documents, text files, or CSVs up to 10 MB each with the team.</p>
                 <select id="file-folder" class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" required></select>
                 <input id="media-files" type="file" accept=".pdf,.doc,.docx,.xls,.xlsx,.ppt,.pptx,.txt,.csv,application/pdf,application/msword,application/vnd.openxmlformats-officedocument.wordprocessingml.document,application/vnd.ms-excel,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,application/vnd.ms-powerpoint,application/vnd.openxmlformats-officedocument.presentationml.presentation,text/plain,text/csv" multiple class="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm" required>
                 <button class="rounded-lg bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-600 focus:ring-offset-2">Upload files</button>
@@ -96,6 +96,6 @@
         <section id="album-detail"></section>
     </main>
 
-    <script type="module" src="js/team-media.js?v=4"></script>
+    <script type="module" src="js/team-media.js?v=5"></script>
 </body>
 </html>

--- a/tests/unit/team-media-item-rename.test.js
+++ b/tests/unit/team-media-item-rename.test.js
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
     checkAuth: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=32', () => {
+vi.mock('../../js/db.js?v=33', () => {
     return {
         getTeam: mocks.getTeam,
         getTeamMediaFolders: mocks.getTeamMediaFolders,

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -21,7 +21,7 @@ describe('team media entry point', () => {
         const pageJs = readRepoFile('js/team-media.js');
         const rules = readRepoFile('firestore.rules');
 
-        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=4"></script>');
+        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=5"></script>');
         expect(pageHtml).toContain('id="team-media-upload-panel"');
         expect(pageHtml).toContain('id="team-media-admin-panel"');
         expect(pageHtml).toContain('id="bulk-actions"');
@@ -29,6 +29,8 @@ describe('team media entry point', () => {
         expect(pageHtml).toContain('id="folder-visibility"');
         expect(pageHtml).toContain('Add album');
         expect(pageHtml).toContain('Upload files');
+        expect(pageHtml).toContain('image files up to 10 MB each');
+        expect(pageHtml).toContain('CSVs up to 10 MB each');
         expect(pageHtml).toContain('Save video link');
         expect(pageJs).toContain("import { checkAuth } from './auth.js?v=14';");
         expect(pageJs).toMatch(/from '\.\/db\.js\?v=\d+';/);

--- a/tests/unit/team-media-utils.test.js
+++ b/tests/unit/team-media-utils.test.js
@@ -12,6 +12,7 @@ import {
     getTeamMediaUploaderName,
     isSafeTeamMediaPhoto,
     isSafeTeamMediaUrl,
+    TEAM_MEDIA_MAX_FILE_SIZE_BYTES,
     isSupportedTeamMediaDocument,
     isSupportedTeamMediaVideoUrl,
     isSupportedTeamMediaImage,
@@ -162,19 +163,23 @@ describe('team media bulk actions', () => {
         expect(getTeamMediaUploaderName(item)).toBe('Coach Pat');
     });
 
-    it('accepts only image files for team album uploads', () => {
-        expect(isSupportedTeamMediaImage({ type: 'image/jpeg' })).toBe(true);
-        expect(isSupportedTeamMediaImage({ type: 'image/png' })).toBe(true);
-        expect(isSupportedTeamMediaImage({ type: 'video/mp4' })).toBe(false);
+    it('accepts only image files up to the team media backend size limit', () => {
+        expect(isSupportedTeamMediaImage({ type: 'image/jpeg', size: TEAM_MEDIA_MAX_FILE_SIZE_BYTES })).toBe(true);
+        expect(isSupportedTeamMediaImage({ type: 'image/png', size: 1 })).toBe(true);
+        expect(isSupportedTeamMediaImage({ type: 'image/jpeg', size: TEAM_MEDIA_MAX_FILE_SIZE_BYTES + 1 })).toBe(false);
+        expect(isSupportedTeamMediaImage({ type: 'image/jpeg', size: 0 })).toBe(false);
+        expect(isSupportedTeamMediaImage({ type: 'video/mp4', size: 1 })).toBe(false);
         expect(isSupportedTeamMediaImage(null)).toBe(false);
     });
 
-    it('accepts approved document files for team media uploads', () => {
-        expect(isSupportedTeamMediaDocument({ type: 'application/pdf' })).toBe(true);
-        expect(isSupportedTeamMediaDocument({ type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' })).toBe(true);
-        expect(isSupportedTeamMediaDocument({ type: 'text/csv' })).toBe(true);
-        expect(isSupportedTeamMediaDocument({ type: 'video/mp4' })).toBe(false);
-        expect(isSupportedTeamMediaDocument({ type: 'image/png' })).toBe(false);
+    it('accepts approved document files up to the team media backend size limit', () => {
+        expect(isSupportedTeamMediaDocument({ type: 'application/pdf', size: TEAM_MEDIA_MAX_FILE_SIZE_BYTES })).toBe(true);
+        expect(isSupportedTeamMediaDocument({ type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document', size: 1 })).toBe(true);
+        expect(isSupportedTeamMediaDocument({ type: 'text/csv', size: 1 })).toBe(true);
+        expect(isSupportedTeamMediaDocument({ type: 'application/pdf', size: TEAM_MEDIA_MAX_FILE_SIZE_BYTES + 1 })).toBe(false);
+        expect(isSupportedTeamMediaDocument({ type: 'application/pdf', size: 0 })).toBe(false);
+        expect(isSupportedTeamMediaDocument({ type: 'video/mp4', size: 1 })).toBe(false);
+        expect(isSupportedTeamMediaDocument({ type: 'image/png', size: 1 })).toBe(false);
         expect(isTeamMediaDocument({ type: 'file' })).toBe(true);
     });
 

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -14,11 +14,11 @@ describe('team media page wiring', () => {
         const page = fs.readFileSync(path.join(repoRoot, 'team-media.html'), 'utf8');
         const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
 
-        expect(page).toContain('src="js/team-media.js?v=4"');
+        expect(page).toContain('src="js/team-media.js?v=5"');
         expect(page).toContain('Add album');
         expect(page).toContain('Upload files');
         expect(page).toContain('Save video link');
-        expect(source).toContain("from './db.js?v=32'");
+        expect(source).toContain("from './db.js?v=33'");
         expect(source).toContain("import { checkAuth } from './auth.js?v=14';");
         expect(source).toContain('checkAuth(async (user) => {');
         expect(source).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');


### PR DESCRIPTION
Closes #1344

## Summary
- Added the Firestore-backed 10 MB media size limit to Team Media image and document validation.
- Reject oversized or empty files before Firebase Storage upload with clear user-facing 10 MB messages.
- Updated Team Media copy and cache-bust imports so users receive the new validation.

## Validation
- `npx vitest run tests/unit/team-media-utils.test.js tests/unit/team-media-page.test.js tests/unit/team-media-wiring.test.js tests/unit/team-media-item-rename.test.js --reporter=verbose`
- `node scripts/check-critical-cache-bust.mjs`