### PR TITLE
Add legacy capability launch CTA

### DIFF
--- a/apps/app/src/pages/CapabilityPage.tsx
+++ b/apps/app/src/pages/CapabilityPage.tsx
@@ -25,6 +25,7 @@ export function CapabilityPage() {
         </div>
         <h1 className="mt-3 text-2xl font-black text-gray-950">{capability.title}</h1>
         <p className="mt-2 text-sm font-semibold leading-6 text-gray-600">{capability.summary}</p>
+        <PrimaryCapabilityAction capability={capability} />
         <div className="mt-4 grid gap-3 sm:grid-cols-2">
           <Meta icon={ExternalLink} label="Current site page" value={capability.legacyPath} />
           <Meta icon={Route} label="App route" value={capability.route} />
@@ -56,14 +57,28 @@ export function CapabilityPage() {
           ))}
         </div>
       </section>
-
-      {capability.status === 'native-shell' && capability.route !== `/capabilities/${capability.id}` ? (
-        <Link to={capability.route} className="primary-button w-full justify-center">
-          Open app route
-        </Link>
-      ) : null}
     </div>
   );
+}
+
+function PrimaryCapabilityAction({ capability }: { capability: (typeof capabilities)[number] }) {
+  if (capability.status === 'native-shell' && capability.route !== `/capabilities/${capability.id}`) {
+    return (
+      <Link to={capability.route} className="primary-button mt-4 w-full justify-center">
+        Open app route
+      </Link>
+    );
+  }
+
+  if ((capability.status === 'stub' || capability.status === 'legacy-link') && capability.legacyPath) {
+    return (
+      <a href={`/${capability.legacyPath}`} className="primary-button mt-4 w-full justify-center">
+        Open current page
+      </a>
+    );
+  }
+
+  return null;
 }
 
 function Meta({ icon: Icon, label, value }: { icon: typeof ExternalLink; label: string; value: string }) {

--- a/apps/app/src/pages/CapabilityPage.tsx
+++ b/apps/app/src/pages/CapabilityPage.tsx
@@ -2,6 +2,7 @@ import { Link, Navigate, useParams } from 'react-router-dom';
 import { ArrowLeft, ExternalLink, Layers, Route, ShieldCheck } from 'lucide-react';
 import { CategoryBadge, RoleBadge, StatusBadge } from '../components/Badges';
 import { capabilities } from '../data/capabilities';
+import { openPublicUrl } from '../lib/publicActions';
 
 export function CapabilityPage() {
   const { capabilityId } = useParams();
@@ -71,10 +72,12 @@ function PrimaryCapabilityAction({ capability }: { capability: (typeof capabilit
   }
 
   if ((capability.status === 'stub' || capability.status === 'legacy-link') && capability.legacyPath) {
+    const legacyUrl = new URL(capability.legacyPath, 'https://allplays.ai').toString();
+
     return (
-      <a href={`/${capability.legacyPath}`} className="primary-button mt-4 w-full justify-center">
+      <button type="button" className="primary-button mt-4 w-full justify-center" onClick={() => void openPublicUrl(legacyUrl)}>
         Open current page
-      </a>
+      </button>
     );
   }
 

--- a/docs/pr-notes/runs/1348-remediator-20260525T131458Z/architecture.md
+++ b/docs/pr-notes/runs/1348-remediator-20260525T131458Z/architecture.md
@@ -1,0 +1,13 @@
+# Architecture
+
+## Decision
+
+Route legacy capability CTAs through `openPublicUrl` from `apps/app/src/lib/publicActions.ts` with an absolute `https://allplays.ai/{legacyPath}` URL.
+
+## Why
+
+`openPublicUrl` already centralizes Capacitor Browser handling and web fallback behavior. Using it keeps legacy pages outside the packaged app WebView route context while preserving current hosted legacy page access.
+
+## Risk And Rollback
+
+Blast radius is limited to the `Open current page` CTA for `stub` and `legacy-link` capabilities. Rollback is a single-file revert in `CapabilityPage.tsx` plus test rollback, but that would reintroduce the native broken-link behavior.

--- a/docs/pr-notes/runs/1348-remediator-20260525T131458Z/code-plan.md
+++ b/docs/pr-notes/runs/1348-remediator-20260525T131458Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code Plan
+
+1. Import `openPublicUrl` in `apps/app/src/pages/CapabilityPage.tsx`.
+2. For `stub` and `legacy-link` capability CTAs, build an absolute URL using `new URL(capability.legacyPath, 'https://allplays.ai').toString()`.
+3. Replace the raw relative anchor with a button that invokes `openPublicUrl(legacyUrl)`.
+4. Update unit tests to validate the native-safe opener and unchanged native-shell/future behavior.

--- a/docs/pr-notes/runs/1348-remediator-20260525T131458Z/qa.md
+++ b/docs/pr-notes/runs/1348-remediator-20260525T131458Z/qa.md
@@ -1,0 +1,13 @@
+# QA Plan
+
+## Automated
+
+- Update `tests/unit/app-capability-page.test.jsx` to mock `openPublicUrl`.
+- Verify stub capability `/capabilities/game-plan` calls `openPublicUrl('https://allplays.ai/game-plan.html')` and does not render a raw relative anchor.
+- Verify legacy-link capability `/capabilities/admin` calls `openPublicUrl('https://allplays.ai/admin.html')` and does not render a raw relative anchor.
+- Verify native-shell and future capability behavior remains unchanged.
+
+## Commands
+
+- `npx vitest run tests/unit/app-capability-page.test.jsx --reporter=verbose`
+- `npm run app:build`

--- a/docs/pr-notes/runs/1348-remediator-20260525T131458Z/requirements.md
+++ b/docs/pr-notes/runs/1348-remediator-20260525T131458Z/requirements.md
@@ -1,0 +1,9 @@
+# Requirements
+
+## Acceptance Criteria
+
+1. Stub and legacy-link capability CTAs with `legacyPath` open the hosted public URL, not a packaged WebView-relative path.
+2. Native Capacitor builds use the existing native-aware public URL opener for legacy pages.
+3. Native-shell capabilities continue to use internal React Router links.
+4. Future capabilities and capabilities without a usable legacy path do not render a launch CTA.
+5. Regression tests cover stub and legacy-link examples and protect against raw relative anchors.

--- a/tests/unit/app-capability-page.test.jsx
+++ b/tests/unit/app-capability-page.test.jsx
@@ -1,0 +1,76 @@
+// @vitest-environment jsdom
+import React, { act } from '../../apps/app/node_modules/react/index.js';
+import { afterEach, describe, expect, it } from 'vitest';
+import { createRoot } from '../../apps/app/node_modules/react-dom/client.js';
+import { MemoryRouter, Route, Routes } from '../../apps/app/node_modules/react-router-dom/dist/index.mjs';
+
+import { CapabilityPage } from '../../apps/app/src/pages/CapabilityPage.tsx';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+async function renderCapabilityPage(initialEntry) {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+        root.render(React.createElement(
+            MemoryRouter,
+            { initialEntries: [initialEntry] },
+            React.createElement(
+                Routes,
+                null,
+                React.createElement(Route, { path: '/capabilities/:capabilityId', element: React.createElement(CapabilityPage) }),
+                React.createElement(Route, { path: '/home', element: React.createElement('div', null, 'Home redirect') })
+            )
+        ));
+    });
+
+    return { container, root };
+}
+
+function linkByText(container, text) {
+    const link = Array.from(container.querySelectorAll('a')).find((candidate) => candidate.textContent.includes(text));
+    if (!link) {
+        const labels = Array.from(container.querySelectorAll('a')).map((candidate) => candidate.textContent.trim() || candidate.getAttribute('href') || '(unlabeled)');
+        throw new Error(`Link not found: ${text}. Available links: ${labels.join(', ')}`);
+    }
+    return link;
+}
+
+afterEach(() => {
+    document.body.innerHTML = '';
+});
+
+describe('CapabilityPage launch CTAs', () => {
+    it('shows a primary current page link for stub capabilities with a legacy path', async () => {
+        const { container, root } = await renderCapabilityPage('/capabilities/game-plan');
+
+        expect(container.textContent).toContain('Current site page');
+        expect(container.textContent).toContain('game-plan.html');
+        expect(linkByText(container, 'Open current page').getAttribute('href')).toBe('/game-plan.html');
+        expect(container.textContent).not.toContain('Open app route');
+
+        await act(async () => root.unmount());
+    });
+
+    it('keeps native-shell capabilities on the internal app route CTA', async () => {
+        const { container, root } = await renderCapabilityPage('/capabilities/profile');
+
+        expect(linkByText(container, 'Open app route').getAttribute('href')).toBe('/profile');
+        expect(container.textContent).not.toContain('Open current page');
+
+        await act(async () => root.unmount());
+    });
+
+    it('does not show a primary launch CTA for future capabilities', async () => {
+        const { container, root } = await renderCapabilityPage('/capabilities/organization-schedule');
+
+        expect(container.textContent).toContain('Current site page');
+        expect(container.textContent).toContain('organization-schedule.html');
+        expect(container.textContent).not.toContain('Open current page');
+        expect(container.textContent).not.toContain('Open app route');
+
+        await act(async () => root.unmount());
+    });
+});

--- a/tests/unit/app-capability-page.test.jsx
+++ b/tests/unit/app-capability-page.test.jsx
@@ -1,9 +1,14 @@
 // @vitest-environment jsdom
 import React, { act } from '../../apps/app/node_modules/react/index.js';
-import { afterEach, describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createRoot } from '../../apps/app/node_modules/react-dom/client.js';
 import { MemoryRouter, Route, Routes } from '../../apps/app/node_modules/react-router-dom/dist/index.mjs';
 
+vi.mock('../../apps/app/src/lib/publicActions.ts', () => ({
+    openPublicUrl: vi.fn()
+}));
+
+import { openPublicUrl } from '../../apps/app/src/lib/publicActions.ts';
 import { CapabilityPage } from '../../apps/app/src/pages/CapabilityPage.tsx';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
@@ -38,18 +43,50 @@ function linkByText(container, text) {
     return link;
 }
 
+function buttonByText(container, text) {
+    const button = Array.from(container.querySelectorAll('button')).find((candidate) => candidate.textContent.includes(text));
+    if (!button) {
+        const labels = Array.from(container.querySelectorAll('button')).map((candidate) => candidate.textContent.trim() || '(unlabeled)');
+        throw new Error(`Button not found: ${text}. Available buttons: ${labels.join(', ')}`);
+    }
+    return button;
+}
+
 afterEach(() => {
     document.body.innerHTML = '';
+    vi.clearAllMocks();
 });
 
 describe('CapabilityPage launch CTAs', () => {
-    it('shows a primary current page link for stub capabilities with a legacy path', async () => {
+    it('opens stub capability legacy pages through the native-safe public URL flow', async () => {
         const { container, root } = await renderCapabilityPage('/capabilities/game-plan');
 
         expect(container.textContent).toContain('Current site page');
         expect(container.textContent).toContain('game-plan.html');
-        expect(linkByText(container, 'Open current page').getAttribute('href')).toBe('/game-plan.html');
+        expect(container.querySelector('a[href="/game-plan.html"]')).toBeNull();
         expect(container.textContent).not.toContain('Open app route');
+
+        await act(async () => {
+            buttonByText(container, 'Open current page').click();
+        });
+
+        expect(openPublicUrl).toHaveBeenCalledWith('https://allplays.ai/game-plan.html');
+
+        await act(async () => root.unmount());
+    });
+
+    it('opens legacy-link capability pages through the native-safe public URL flow', async () => {
+        const { container, root } = await renderCapabilityPage('/capabilities/admin');
+
+        expect(container.textContent).toContain('Current site page');
+        expect(container.textContent).toContain('admin.html');
+        expect(container.querySelector('a[href="/admin.html"]')).toBeNull();
+
+        await act(async () => {
+            buttonByText(container, 'Open current page').click();
+        });
+
+        expect(openPublicUrl).toHaveBeenCalledWith('https://allplays.ai/admin.html');
 
         await act(async () => root.unmount());
     });
@@ -59,6 +96,7 @@ describe('CapabilityPage launch CTAs', () => {
 
         expect(linkByText(container, 'Open app route').getAttribute('href')).toBe('/profile');
         expect(container.textContent).not.toContain('Open current page');
+        expect(openPublicUrl).not.toHaveBeenCalled();
 
         await act(async () => root.unmount());
     });
@@ -70,6 +108,7 @@ describe('CapabilityPage launch CTAs', () => {
         expect(container.textContent).toContain('organization-schedule.html');
         expect(container.textContent).not.toContain('Open current page');
         expect(container.textContent).not.toContain('Open app route');
+        expect(openPublicUrl).not.toHaveBeenCalled();
 
         await act(async () => root.unmount());
     });


### PR DESCRIPTION
Closes #1343

## Summary
- Added a primary `Open current page` CTA for stub and legacy-link capabilities with a legacy path.
- Kept native-shell capabilities using the internal `Open app route` CTA.
- Left future capabilities without a primary launch CTA while retaining metadata visibility.

## Tests
- `npx vitest run tests/unit/app-capability-page.test.jsx --reporter=verbose`