### PR TITLE
Mark unused basketball players as DNP

### DIFF
--- a/js/track-finish.js
+++ b/js/track-finish.js
@@ -33,6 +33,18 @@ export function buildNormalizedPlayerStats(playerStats = {}, columns = []) {
     return normalizedStats;
 }
 
+function hasTrackedPlayerActivity(playerStats = {}, normalizedStats = {}, includeTimeMs = false) {
+    const hasStatActivity = Object.entries(normalizedStats || {}).some(([key, value]) => {
+        if (includeTimeMs && String(key).toLowerCase() === 'time') return false;
+        return Number(value) !== 0;
+    });
+
+    if (hasStatActivity) return true;
+    if (!includeTimeMs) return true;
+
+    return (Number(playerStats.time) || 0) > 0;
+}
+
 export function buildAggregatedStatsWrites({ players = [], playerStatsByPlayerId = {}, columns = [], statTrackerConfig = {}, includeTimeMs = false } = {}) {
     const safePlayers = Array.isArray(players) ? players : [];
     const safeStatsByPlayerId = playerStatsByPlayerId && typeof playerStatsByPlayerId === 'object'
@@ -43,6 +55,7 @@ export function buildAggregatedStatsWrites({ players = [], playerStatsByPlayerId
         const playerStats = safeStatsByPlayerId[player.id] || {};
 
         const normalizedStats = buildNormalizedPlayerStats(playerStats, columns);
+        const playerAppeared = hasTrackedPlayerActivity(playerStats, normalizedStats, includeTimeMs);
         // If we are including timeMs, ensure the internal 'time' accumulator is not persisted as a stat.
         if (includeTimeMs && normalizedStats.time !== undefined) {
             delete normalizedStats.time;
@@ -50,20 +63,20 @@ export function buildAggregatedStatsWrites({ players = [], playerStatsByPlayerId
         const { publicStats, privateStats } = splitPlayerStatsByVisibility(statTrackerConfig, normalizedStats);
 
         const playerNumber = player.number ?? player.num ?? '';
-        const publicData = {
+        const baseParticipationData = {
             playerName: player.name,
             playerNumber,
-            participated: true,
-            participationStatus: 'appeared',
+            participated: playerAppeared,
+            participationStatus: playerAppeared ? 'appeared' : 'did-not-appear',
             participationSource: 'standard-tracker-finish',
+            ...(playerAppeared ? {} : { didNotPlay: true })
+        };
+        const publicData = {
+            ...baseParticipationData,
             stats: publicStats
         };
         const privateData = Object.keys(privateStats).length > 0 ? {
-            playerName: player.name,
-            playerNumber,
-            participated: true,
-            participationStatus: 'appeared',
-            participationSource: 'standard-tracker-finish',
+            ...baseParticipationData,
             stats: privateStats
         } : null;
 

--- a/tests/unit/track-finish-batch-limit.test.js
+++ b/tests/unit/track-finish-batch-limit.test.js
@@ -220,7 +220,7 @@ describe('standard tracker finish batch limits', () => {
         ]);
     });
 
-    it('preserves beta basketball finish event clocks, jersey numbers, and playing time', async () => {
+    it('preserves beta basketball finish event clocks, jersey numbers, playing time, and DNP status', async () => {
         const harness = createFirestoreHarness();
 
         await commitStandardTrackerFinishData({
@@ -232,8 +232,14 @@ describe('standard tracker finish batch limits', () => {
             gameId: 'game-1',
             currentUserUid: 'coach-1',
             gameLog: [{ text: 'Ava made a basket', clock: '03:21', period: 'Q4', ts: 99 }],
-            players: [{ id: 'p1', name: 'Ava', num: '23' }],
-            playerStatsByPlayerId: { p1: { pts: 2, fouls: 1, time: 123000 } },
+            players: [
+                { id: 'p1', name: 'Ava', num: '23' },
+                { id: 'p2', name: 'Ben', num: '12' }
+            ],
+            playerStatsByPlayerId: {
+                p1: { pts: 2, fouls: 1, time: 123000 },
+                p2: { pts: 0, fouls: 0, time: 0 }
+            },
             columns: ['PTS', 'FOULS'],
             finalHome: 44,
             finalAway: 40,
@@ -249,9 +255,21 @@ describe('standard tracker finish batch limits', () => {
         expect(harness.batches[1].operations[0].data).toMatchObject({
             playerName: 'Ava',
             playerNumber: '23',
+            participated: true,
+            participationStatus: 'appeared',
             timeMs: 123000,
             stats: expect.objectContaining({ pts: 2, fouls: 1 })
         });
+        expect(harness.batches[1].operations[1].data).toMatchObject({
+            playerName: 'Ben',
+            playerNumber: '12',
+            participated: false,
+            participationStatus: 'did-not-appear',
+            didNotPlay: true,
+            timeMs: 0,
+            stats: { pts: 0, fouls: 0 }
+        });
+        expect(hasPlayerProfileParticipation(harness.batches[1].operations[1].data)).toBe(false);
     });
 
     it('rejects when a secondary aggregated stats batch fails after primary commit', async () => {


### PR DESCRIPTION
Closes #1353

- Mark beta basketball finish roster players with zero tracked time and zero stats as did-not-appear/DNP.
- Preserve legacy standard tracker behavior when playing time is not available.
- Add regression coverage ensuring unused bench players do not count as player profile appearances.