### PR TITLE
Add help results to app search

### DIFF
--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -33,6 +33,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
 
   const teamsById = useMemo(() => new Map(teams.map((team) => [team.id, team])), [teams]);
   const results = useMemo(() => computeAppSearchResults({ queryText: query, auth, teams, players }), [auth, players, query, teams]);
+  const helpResults = results.help ?? [];
 
   useEffect(() => {
     if (!open) return;
@@ -151,7 +152,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       : results.teams.length === 0
         ? 'No matching teams'
         : '';
-  const helpStatus = query.trim().length >= 2 && results.help.length === 0
+  const helpStatus = query.trim().length >= 2 && helpResults.length === 0
     ? 'No matching help articles'
     : '';
   const playersStatus = playersLoading
@@ -229,7 +230,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
 
             <SearchSection
               title="Help"
-              items={results.help}
+              items={helpResults}
               activeIndex={activeIndex}
               offset={results.actions.length + results.teams.length}
               status={helpStatus}
@@ -241,7 +242,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
               title="Players"
               items={results.players}
               activeIndex={activeIndex}
-              offset={results.actions.length + results.teams.length + results.help.length}
+              offset={results.actions.length + results.teams.length + helpResults.length}
               status={playersStatus}
               statusTone={playersError ? 'error' : 'neutral'}
               onOpen={openResult}

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -151,6 +151,9 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       : results.teams.length === 0
         ? 'No matching teams'
         : '';
+  const helpStatus = query.trim().length >= 2 && results.help.length === 0
+    ? 'No matching help articles'
+    : '';
   const playersStatus = playersLoading
     ? 'Searching players...'
     : playersError
@@ -166,7 +169,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       className="app-search-overlay fixed inset-0 z-50 bg-gray-950/40 backdrop-blur-sm"
       role="dialog"
       aria-modal="true"
-      aria-label="Search teams, players, and actions"
+      aria-label="Search teams, players, actions, and help"
       onKeyDown={onKeyDown}
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) onClose();
@@ -184,8 +187,8 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
                 value={query}
                 onChange={(event) => setQuery(event.target.value)}
                 className="min-h-11 w-full rounded-xl border border-gray-200 px-3 text-base font-semibold outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100"
-                placeholder="Search teams, players, actions..."
-                aria-label="Search teams, players, actions"
+                placeholder="Search teams, players, actions, help..."
+                aria-label="Search teams, players, actions, help"
               />
               <div className="mt-2 hidden text-xs font-semibold text-gray-500 sm:block">
                 Use arrow keys to move, Enter to open, Esc to close.
@@ -225,10 +228,20 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
             />
 
             <SearchSection
+              title="Help"
+              items={results.help}
+              activeIndex={activeIndex}
+              offset={results.actions.length + results.teams.length}
+              status={helpStatus}
+              onOpen={openResult}
+              onHover={setActiveIndex}
+            />
+
+            <SearchSection
               title="Players"
               items={results.players}
               activeIndex={activeIndex}
-              offset={results.actions.length + results.teams.length}
+              offset={results.actions.length + results.teams.length + results.help.length}
               status={playersStatus}
               statusTone={playersError ? 'error' : 'neutral'}
               onOpen={openResult}
@@ -311,6 +324,15 @@ function SearchResultRow({ item, active, onOpen, onHover }: {
         <span className="min-w-0">
           <span className="block truncate text-sm font-black text-gray-950">{item.title}</span>
           {item.subtitle ? <span className="mt-0.5 block truncate text-xs font-semibold text-gray-500">{item.subtitle}</span> : null}
+          {item.kind === 'help' && item.roles?.length ? (
+            <span className="mt-2 flex flex-wrap gap-1">
+              {item.roles.slice(0, 3).map((role) => (
+                <span key={role} className="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.04em] text-gray-500">
+                  {role}
+                </span>
+              ))}
+            </span>
+          ) : null}
         </span>
         <span className="flex flex-none items-center gap-2">
           <span className="pt-1 text-[10px] font-extrabold uppercase tracking-[0.04em] text-gray-400">{item.kind}</span>

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -9,14 +9,15 @@ import {
   limit
 } from '../../../../js/firebase.js';
 import { loadParentHome } from './homeService';
-import type { AuthState, AuthUser } from './types';
+import { searchHelpKnowledge } from './helpKnowledgeService';
+import type { AuthState, AuthUser, UserRole } from './types';
 
 const teamsCacheTtlMs = 10 * 60 * 1000;
 
 let cachedTeams: AppSearchTeam[] | null = null;
 let cachedTeamsLoadedAt = 0;
 
-export type AppSearchKind = 'action' | 'team' | 'player' | 'social';
+export type AppSearchKind = 'action' | 'team' | 'player' | 'social' | 'help';
 
 export type AppSearchItem = {
   id: string;
@@ -25,6 +26,8 @@ export type AppSearchItem = {
   subtitle: string;
   route?: string;
   href?: string;
+  roles?: string[];
+  snippet?: string;
 };
 
 export type AppSearchTeam = {
@@ -46,6 +49,13 @@ export type AppSearchPlayer = AppSearchItem & {
   kind: 'player';
   teamId: string;
   playerId: string;
+};
+
+export type AppSearchHelp = AppSearchItem & {
+  kind: 'help';
+  href: string;
+  roles: string[];
+  snippet: string;
 };
 
 export function normalizeSearchQuery(queryText: string) {
@@ -181,7 +191,7 @@ export function computeAppSearchResults({
   players
 }: {
   queryText: string;
-  auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatformAdmin'>;
+  auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatformAdmin'> & Partial<Pick<AuthState, 'roles' | 'isParent' | 'isCoach'>>;
   teams: AppSearchTeam[];
   players: AppSearchPlayer[];
 }) {
@@ -196,12 +206,15 @@ export function computeAppSearchResults({
   const matchedTeams = tokens.length === 0
     ? teamItems.slice(0, 20)
     : rankSearchItems(teamItems, tokens).slice(0, 20);
+  const matchedHelp = buildAppSearchHelpResults(queryText, auth);
+  const matchedPlayers = players.slice(0, 20);
 
   return {
     actions: matchedActions,
     teams: matchedTeams,
-    players: players.slice(0, 20),
-    flat: [...matchedActions, ...matchedTeams, ...players.slice(0, 20)]
+    help: matchedHelp,
+    players: matchedPlayers,
+    flat: [...matchedActions, ...matchedTeams, ...matchedHelp, ...matchedPlayers]
   };
 }
 
@@ -333,6 +346,38 @@ export async function searchAppPlayers(queryText: string, teamsById: Map<string,
     .sort((a, b) => (b.score - a.score) || (a.item.title.length - b.item.title.length))
     .slice(0, 20)
     .map((entry) => entry.item);
+}
+
+function buildAppSearchHelpResults(
+  queryText: string,
+  auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatformAdmin'> & Partial<Pick<AuthState, 'roles' | 'isParent' | 'isCoach'>>
+): AppSearchHelp[] {
+  const normalized = normalizeSearchQuery(queryText);
+  if (normalized.length < 2) return [];
+
+  return searchHelpKnowledge({
+    query: queryText,
+    roles: getSearchHelpRoles(auth),
+    limit: 5
+  }).map((result) => ({
+    id: `help:${result.id}`,
+    kind: 'help' as const,
+    title: result.title,
+    subtitle: result.snippet || result.summary,
+    href: result.url,
+    roles: result.roles,
+    snippet: result.snippet
+  }));
+}
+
+function getSearchHelpRoles(auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatformAdmin'> & Partial<Pick<AuthState, 'roles' | 'isParent' | 'isCoach'>>): UserRole[] {
+  const roles = new Set<UserRole>();
+  (auth.roles || auth.user?.roles || []).forEach((role) => roles.add(role));
+  if (auth.isAdmin || auth.user?.isAdmin) roles.add('admin');
+  if (auth.isPlatformAdmin) roles.add('platformAdmin');
+  if (auth.isParent) roles.add('parent');
+  if (auth.isCoach) roles.add('coach');
+  return [...roles];
 }
 
 export function resetAppSearchCacheForTests() {

--- a/docs/pr-notes/runs/1356-remediator-20260525T135341Z/architecture.md
+++ b/docs/pr-notes/runs/1356-remediator-20260525T135341Z/architecture.md
@@ -1,0 +1,10 @@
+# Architecture
+
+## Architecture Decisions
+- Keep the search service contract as-is for the React app: current TypeScript results include `help`.
+- Add a component-level compatibility fallback so externally mocked or JS-shimmed result payloads without `help` are treated as an empty help result list.
+- Use the fallback only at render/offset/status boundaries. Do not mutate service results.
+
+## Risk And Rollback
+- Risk surface is limited to `AppSearchDialog` rendering and keyboard index offsets.
+- Rollback is the single component fallback plus the shim regression update.

--- a/docs/pr-notes/runs/1356-remediator-20260525T135341Z/code-plan.md
+++ b/docs/pr-notes/runs/1356-remediator-20260525T135341Z/code-plan.md
@@ -1,0 +1,7 @@
+# Code Plan
+
+## Implementation Plan
+- In `AppSearchDialog.tsx`, derive `helpResults` from `results.help ?? []` immediately after computing results.
+- Replace direct `results.help` dereferences in help status, section items, and section offset math with `helpResults`.
+- Update the Playwright smoke search-service shim to omit `help`, preserving the legacy payload shape that triggered the review comment.
+- Validate with focused Vitest tests and, if practical, app build/typecheck.

--- a/docs/pr-notes/runs/1356-remediator-20260525T135341Z/qa.md
+++ b/docs/pr-notes/runs/1356-remediator-20260525T135341Z/qa.md
@@ -1,0 +1,6 @@
+# QA
+
+## QA Plan
+- Run focused unit coverage for app search integration and service behavior: `npx vitest run tests/unit/app-search-integration.test.jsx tests/unit/app-search-service.test.js --reporter=verbose`.
+- Run a focused app build/typecheck if feasible: `npm run app:build`.
+- Regression condition: a smoke-style JS mock may omit `help`; opening search must still render and no runtime error should occur.

--- a/docs/pr-notes/runs/1356-remediator-20260525T135341Z/requirements.md
+++ b/docs/pr-notes/runs/1356-remediator-20260525T135341Z/requirements.md
@@ -1,0 +1,9 @@
+# Requirements
+
+## Acceptance Criteria
+- Opening app search must not throw when `computeAppSearchResults` returns the legacy JS shim shape with `actions`, `teams`, `players`, and `flat` but no `help` array.
+- Help results continue to render when the TypeScript search service returns `help`.
+- Scope is limited to PR review feedback for thread `PRRT_kwDOQe-T586EiBCC`.
+
+## Non-goals
+- No changes to search ranking, routing, Firebase queries, or help knowledge content.

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -118,6 +118,7 @@ async function mockSearchModules(page) {
                     return {
                         actions: matchedActions,
                         teams: matchedTeams,
+                        help: [],
                         players: matchedPlayers,
                         flat: [...matchedActions, ...matchedTeams, ...matchedPlayers]
                     };
@@ -135,7 +136,7 @@ test.describe('app global search', () => {
         await page.goto(appUrl(baseURL, '/home'), { waitUntil: 'domcontentloaded' });
 
         await page.getByRole('button', { name: 'Search' }).click();
-        await expect(page.getByRole('dialog', { name: 'Search teams, players, and actions' })).toBeVisible();
+        await expect(page.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeVisible();
         await expect.poll(async () => {
             const box = await page.getByTestId('app-search-panel').boundingBox();
             return Math.round(box?.y || 0);
@@ -148,7 +149,7 @@ test.describe('app global search', () => {
         await expect(page.getByText('Bears')).toBeVisible();
         await expect(page.getByText('Type at least 2 characters to search players')).toBeVisible();
 
-        await page.getByLabel('Search teams, players, actions').fill('pat');
+        await page.getByLabel('Search teams, players, actions, help').fill('pat');
         await expect(page.getByText('#9 Pat Star')).toBeVisible();
         await expect.poll(() => page.evaluate(() => window.__playerSearchQueries)).toEqual(['pat']);
         await page.getByRole('button', { name: /#9 Pat Star/ }).click();
@@ -161,26 +162,26 @@ test.describe('app global search', () => {
         await page.goto(appUrl(baseURL, '/home'), { waitUntil: 'domcontentloaded' });
 
         await page.getByRole('button', { name: 'Search' }).click();
-        await page.getByLabel('Search teams, players, actions').fill('p');
+        await page.getByLabel('Search teams, players, actions, help').fill('p');
         await expect(page.getByText('Type at least 2 characters to search players')).toBeVisible();
         await expect.poll(() => page.evaluate(() => window.__playerSearchQueries)).toEqual([]);
 
-        await page.getByLabel('Search teams, players, actions').fill('zzzz');
+        await page.getByLabel('Search teams, players, actions, help').fill('zzzz');
         await expect(page.getByText('No matching teams')).toBeVisible();
         await expect(page.getByText('No matching players')).toBeVisible();
         await expect(page.getByText('No results')).toBeVisible();
         await expect.poll(() => page.evaluate(() => window.__playerSearchQueries)).toEqual(['zzzz']);
 
-        await page.getByLabel('Search teams, players, actions').fill('error');
+        await page.getByLabel('Search teams, players, actions, help').fill('error');
         await expect(page.getByText('Player search unavailable for this account.')).toBeVisible();
         await expect.poll(() => page.evaluate(() => window.__playerSearchQueries)).toEqual(['zzzz', 'error']);
 
         await page.keyboard.press('Escape');
-        await expect(page.getByRole('dialog', { name: 'Search teams, players, and actions' })).toBeHidden();
+        await expect(page.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeHidden();
 
         await page.getByRole('button', { name: 'Search' }).click();
         await page.getByRole('button', { name: 'Close search' }).click();
-        await expect(page.getByRole('dialog', { name: 'Search teams, players, and actions' })).toBeHidden();
+        await expect(page.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeHidden();
     });
 });
 
@@ -192,8 +193,8 @@ test.describe('desktop app global search', () => {
         await page.goto(appUrl(baseURL, '/home'), { waitUntil: 'domcontentloaded' });
 
         await page.getByRole('button', { name: 'Search' }).click();
-        await expect(page.getByRole('dialog', { name: 'Search teams, players, and actions' })).toBeVisible();
-        await page.getByLabel('Search teams, players, actions').fill('rock');
+        await expect(page.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeVisible();
+        await page.getByLabel('Search teams, players, actions, help').fill('rock');
         await expect(page.getByRole('button', { name: /Rockets/ })).toBeVisible();
         await page.getByRole('button', { name: /Rockets/ }).click();
         await expect(page).toHaveURL(/#\/teams\/team-2$/);
@@ -208,7 +209,7 @@ test.describe('desktop app global search', () => {
         await page.goto(appUrl(baseURL, '/home'), { waitUntil: 'domcontentloaded' });
 
         await page.getByRole('button', { name: 'Search' }).click();
-        await page.getByLabel('Search teams, players, actions').fill('my');
+        await page.getByLabel('Search teams, players, actions, help').fill('my');
         await expect(page.getByRole('button', { name: /My Teams/ })).toBeVisible();
         await page.keyboard.press('Enter');
         await expect(page).toHaveURL(/#\/teams$/);

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -118,7 +118,6 @@ async function mockSearchModules(page) {
                     return {
                         actions: matchedActions,
                         teams: matchedTeams,
-                        help: [],
                         players: matchedPlayers,
                         flat: [...matchedActions, ...matchedTeams, ...matchedPlayers]
                     };

--- a/tests/unit/app-search-integration.test.jsx
+++ b/tests/unit/app-search-integration.test.jsx
@@ -26,10 +26,15 @@ const publicActionMocks = vi.hoisted(() => ({
     openPublicUrl: vi.fn()
 }));
 
+const helpMocks = vi.hoisted(() => ({
+    searchHelpKnowledge: vi.fn()
+}));
+
 vi.mock('../../js/db.js', () => dbMocks);
 vi.mock('../../js/firebase.js', () => firebaseMocks);
 vi.mock('../../apps/app/src/lib/homeService.ts', () => homeMocks);
 vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionMocks);
+vi.mock('../../apps/app/src/lib/helpKnowledgeService.ts', () => helpMocks);
 
 import { AppShell } from '../../apps/app/src/components/AppShell.tsx';
 import { resetAppSearchCacheForTests } from '../../apps/app/src/lib/searchService.ts';
@@ -121,7 +126,7 @@ async function pressDialogKey(container, key) {
 }
 
 async function fillSearch(container, value) {
-    const input = container.querySelector('input[aria-label="Search teams, players, actions"]');
+    const input = container.querySelector('input[aria-label="Search teams, players, actions, help"]');
     if (!input) throw new Error('Search input not found');
     await act(async () => {
         const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
@@ -162,6 +167,7 @@ beforeEach(() => {
             firestorePlayer('teams/team-private/players/player-2', { name: 'Pat Secret', number: '10' })
         ]
     });
+    helpMocks.searchHelpKnowledge.mockReturnValue([]);
 });
 
 afterEach(() => {
@@ -187,6 +193,31 @@ describe('React app shell search', () => {
 
         await clickButton(container, '#9 Pat Star');
         expect(container.querySelector('[data-testid="route"]').textContent).toBe('/players/team-1/player-1');
+    });
+
+    it('renders help matches and opens help URLs through the public URL adapter', async () => {
+        helpMocks.searchHelpKnowledge.mockReturnValue([{
+            id: 'account-password-reset',
+            title: 'Reset a password',
+            file: 'help-account.html',
+            url: 'https://allplays.ai/help-account.html',
+            roles: ['parent'],
+            summary: 'Recover account access.',
+            snippet: 'Use password reset when a parent cannot sign in.',
+            score: 42
+        }]);
+        const { container } = await renderShell();
+
+        await clickButton(container, 'Search');
+        await fillSearch(container, 'password reset');
+
+        expect(container.textContent).toContain('Help');
+        expect(container.textContent).toContain('Reset a password');
+        expect(container.textContent).toContain('Use password reset when a parent cannot sign in.');
+        expect(container.textContent).toContain('parent');
+
+        await pressDialogKey(container, 'Enter');
+        expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://allplays.ai/help-account.html');
     });
 
     it('opens website-only search actions through the public URL adapter', async () => {

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -18,9 +18,14 @@ const firebaseMocks = vi.hoisted(() => ({
     limit: vi.fn((count) => ({ type: 'limit', count }))
 }));
 
+const helpMocks = vi.hoisted(() => ({
+    searchHelpKnowledge: vi.fn()
+}));
+
 vi.mock('../../js/db.js', () => dbMocks);
 vi.mock('../../js/firebase.js', () => firebaseMocks);
 vi.mock('../../apps/app/src/lib/homeService.ts', () => homeMocks);
+vi.mock('../../apps/app/src/lib/helpKnowledgeService.ts', () => helpMocks);
 
 import {
     buildAppSearchActions,
@@ -55,6 +60,7 @@ function firestorePlayer(path, data) {
 beforeEach(() => {
     vi.clearAllMocks();
     resetAppSearchCacheForTests();
+    helpMocks.searchHelpKnowledge.mockReturnValue([]);
 });
 
 describe('React app search service', () => {
@@ -142,6 +148,59 @@ describe('React app search service', () => {
         expect(defaultResults.actions.map((item) => item.id)).toEqual(['browse-teams', 'dashboard', 'my-teams', 'schedule', 'messages', 'social-feed', 'find-friends', 'create-social-post', 'profile']);
         expect(defaultResults.teams).toHaveLength(20);
         expect(defaultResults.players).toHaveLength(20);
+    });
+
+    it('adds limited help results for meaningful queries without changing app result ordering', () => {
+        helpMocks.searchHelpKnowledge.mockReturnValue([{
+            id: 'account-password-reset',
+            title: 'Reset a password',
+            file: 'help-account.html',
+            url: 'https://allplays.ai/help-account.html',
+            roles: ['parent', 'coach'],
+            summary: 'Recover account access.',
+            snippet: 'Use password reset when a parent or coach cannot sign in.',
+            score: 42
+        }]);
+
+        const shortResults = computeAppSearchResults({
+            queryText: 'p',
+            auth,
+            teams: [{ id: 'team-1', name: 'Panthers', sport: 'Basketball', isPublic: true }],
+            players: []
+        });
+        expect(shortResults.help).toEqual([]);
+        expect(helpMocks.searchHelpKnowledge).not.toHaveBeenCalled();
+
+        const results = computeAppSearchResults({
+            queryText: 'password reset',
+            auth,
+            teams: [{ id: 'team-1', name: 'Password Reset Rockets', sport: 'Basketball', isPublic: true }],
+            players: [{
+                id: 'player:team-1:player-1',
+                kind: 'player',
+                title: 'Reset Runner',
+                subtitle: 'Password Reset Rockets',
+                route: '/players/team-1/player-1',
+                teamId: 'team-1',
+                playerId: 'player-1'
+            }]
+        });
+
+        expect(helpMocks.searchHelpKnowledge).toHaveBeenCalledWith({
+            query: 'password reset',
+            roles: ['parent'],
+            limit: 5
+        });
+        expect(results.help).toEqual([{
+            id: 'help:account-password-reset',
+            kind: 'help',
+            title: 'Reset a password',
+            subtitle: 'Use password reset when a parent or coach cannot sign in.',
+            href: 'https://allplays.ai/help-account.html',
+            roles: ['parent', 'coach'],
+            snippet: 'Use password reset when a parent or coach cannot sign in.'
+        }]);
+        expect(results.flat.map((item) => item.kind)).toEqual(['team', 'help', 'player']);
     });
 
     it('loads public/current-site teams and merges private teams from app access', async () => {


### PR DESCRIPTION
Closes #1355

## Summary
- Added help article results to app search using the existing help knowledge index and role-aware ranking.
- Rendered a Help section with snippets and role chips in the app search dialog.
- Kept one-character queries from showing help results and preserved existing action/team/player ordering.

## Validation
- `npx vitest run tests/unit/app-search-service.test.js tests/unit/app-search-integration.test.jsx --reporter=verbose`
- `npm run app:build`