### PR TITLE
Release capacity after cancelled Stripe checkout

### DIFF
--- a/docs/pr-notes/runs/1358-remediator-20260525T135020Z/architecture.md
+++ b/docs/pr-notes/runs/1358-remediator-20260525T135020Z/architecture.md
@@ -1,0 +1,7 @@
+# Architecture
+
+## Decision
+Guard paid registrations before building or writing caller-supplied cancellation updates in `releaseRegistrationCheckoutCapacity`.
+
+## Risk
+Minimal blast radius: only changes the paid-registration branch in the transaction. It preserves existing behavior for already-released and open non-paid registrations.

--- a/docs/pr-notes/runs/1358-remediator-20260525T135020Z/code-plan.md
+++ b/docs/pr-notes/runs/1358-remediator-20260525T135020Z/code-plan.md
@@ -1,0 +1,5 @@
+# Code Plan
+
+- Move `registrationUpdate` construction below the paid guard.
+- Remove the registration write from the paid branch.
+- Add source-level unit coverage for the guard/write ordering.

--- a/docs/pr-notes/runs/1358-remediator-20260525T135020Z/qa.md
+++ b/docs/pr-notes/runs/1358-remediator-20260525T135020Z/qa.md
@@ -1,0 +1,4 @@
+# QA Plan
+
+- Add a regression assertion that the paid guard returns before any `transaction.set(registrationRef, ...)` in `releaseRegistrationCheckoutCapacity`.
+- Run the affected unit test file.

--- a/docs/pr-notes/runs/1358-remediator-20260525T135020Z/requirements.md
+++ b/docs/pr-notes/runs/1358-remediator-20260525T135020Z/requirements.md
@@ -1,0 +1,6 @@
+# Requirements
+
+## Acceptance Criteria
+- A cancellation request for a registration with `paymentStatus === 'paid'` must not mutate checkout or payment fields.
+- The callable should still return `{ released: false, reason: 'already-paid' }` for paid registrations.
+- Non-paid open checkouts still release capacity and apply the requested cancellation status.

--- a/functions/index.js
+++ b/functions/index.js
@@ -253,15 +253,15 @@ async function releaseRegistrationCheckoutCapacity(input, statusUpdate = {}) {
       throw new functions.https.HttpsError('failed-precondition', 'Registration does not match the requested form.');
     }
 
+    if (registration.paymentStatus === 'paid') {
+      return { released: false, reason: 'already-paid' };
+    }
+
     const registrationUpdate = {
       ...statusUpdate,
       updatedAt: now
     };
 
-    if (registration.paymentStatus === 'paid') {
-      transaction.set(registrationRef, registrationUpdate, { merge: true });
-      return { released: false, reason: 'already-paid' };
-    }
     if (registration.registrationCapacityReleased === true) {
       transaction.set(registrationRef, registrationUpdate, { merge: true });
       return { released: false, reason: 'already-released' };

--- a/functions/index.js
+++ b/functions/index.js
@@ -148,8 +148,20 @@ function normalizeRegistrationCheckoutInput(data = {}) {
   };
 }
 
+function normalizeRegistrationCheckoutCancelInput(data = {}) {
+  return {
+    teamId: normalizeFirestoreId(data.teamId, 'teamId'),
+    formId: normalizeFirestoreId(data.formId, 'formId'),
+    registrationId: normalizeFirestoreId(data.registrationId, 'registrationId')
+  };
+}
+
 function buildRegistrationRef({ teamId, formId, registrationId }) {
   return firestore.doc(`teams/${teamId}/registrationForms/${formId}/registrations/${registrationId}`);
+}
+
+function buildRegistrationFormRef({ teamId, formId }) {
+  return firestore.doc(`teams/${teamId}/registrationForms/${formId}`);
 }
 
 function buildRegistrationCheckoutUrls(appUrl, input) {
@@ -215,6 +227,77 @@ function buildRegistrationRefFromStripeSession(session = {}) {
     teamId: normalizeFirestoreId(metadata.teamId, 'teamId'),
     formId: normalizeFirestoreId(metadata.formId, 'formId'),
     registrationId: normalizeFirestoreId(metadata.registrationId, 'registrationId')
+  });
+}
+
+async function releaseRegistrationCheckoutCapacity(input, statusUpdate = {}) {
+  const formRef = buildRegistrationFormRef(input);
+  const registrationRef = buildRegistrationRef(input);
+  const now = admin.firestore.FieldValue.serverTimestamp();
+
+  return firestore.runTransaction(async (transaction) => {
+    const [formSnap, registrationSnap] = await Promise.all([
+      transaction.get(formRef),
+      transaction.get(registrationRef)
+    ]);
+    if (!formSnap.exists) {
+      throw new functions.https.HttpsError('not-found', 'Registration form not found.');
+    }
+    if (!registrationSnap.exists) {
+      throw new functions.https.HttpsError('not-found', 'Registration not found.');
+    }
+
+    const form = formSnap.data() || {};
+    const registration = registrationSnap.data() || {};
+    if (registration.teamId !== input.teamId || registration.formId !== input.formId) {
+      throw new functions.https.HttpsError('failed-precondition', 'Registration does not match the requested form.');
+    }
+
+    const registrationUpdate = {
+      ...statusUpdate,
+      updatedAt: now
+    };
+
+    if (registration.paymentStatus === 'paid') {
+      transaction.set(registrationRef, registrationUpdate, { merge: true });
+      return { released: false, reason: 'already-paid' };
+    }
+    if (registration.registrationCapacityReleased === true) {
+      transaction.set(registrationRef, registrationUpdate, { merge: true });
+      return { released: false, reason: 'already-released' };
+    }
+    if (registration.checkoutStatus !== 'open' && registration.paymentStatus !== 'checkout_open') {
+      throw new functions.https.HttpsError('failed-precondition', 'Registration checkout is not open.');
+    }
+
+    const selectedOption = registration.selectedOption || {};
+    const countKey = String(selectedOption.countKey || selectedOption.id || '').trim();
+    const counts = form.registrationOptionCounts || {};
+    const optionCounts = countKey ? counts[countKey] || {} : {};
+    const updates = {};
+    let released = false;
+
+    if (countKey && registration.status === 'pending') {
+      updates[`registrationOptionCounts.${countKey}.enrolled`] = Math.max(0, Number(optionCounts.enrolled || 0) - 1);
+      released = true;
+    } else if (countKey && registration.status === 'waitlisted') {
+      updates[`registrationOptionCounts.${countKey}.waitlisted`] = Math.max(0, Number(optionCounts.waitlisted || 0) - 1);
+      released = true;
+    }
+
+    if (released) {
+      updates.registrationCapacityUpdateId = input.registrationId;
+      updates.updatedAt = now;
+      transaction.update(formRef, updates);
+    }
+
+    transaction.set(registrationRef, {
+      ...registrationUpdate,
+      registrationCapacityReleased: true,
+      capacityReleasedAt: now
+    }, { merge: true });
+
+    return { released };
   });
 }
 
@@ -1360,6 +1443,20 @@ exports.createStripeRegistrationCheckout = functions.https.onCall(async (data) =
   return { checkoutUrl: session.url, sessionId: session.id };
 });
 
+exports.cancelStripeRegistrationCheckout = functions.https.onCall(async (data) => {
+  let input;
+  try {
+    input = normalizeRegistrationCheckoutCancelInput(data || {});
+  } catch (error) {
+    throw new functions.https.HttpsError('invalid-argument', error.message || 'Invalid registration checkout cancellation request.');
+  }
+
+  return releaseRegistrationCheckoutCapacity(input, {
+    checkoutStatus: 'cancelled',
+    paymentStatus: 'checkout_cancelled'
+  });
+});
+
 exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
   if (req.method !== 'POST') {
     res.status(405).send('Method not allowed');
@@ -1395,14 +1492,22 @@ exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
       const receivedAt = admin.firestore.FieldValue.serverTimestamp();
       const eventRef = firestore.doc(`stripeEvents/${event.id}`);
       const registrationRef = buildRegistrationRefFromStripeSession(session);
+      const registrationInput = normalizeRegistrationCheckoutCancelInput(session.metadata || {});
+      const formRef = buildRegistrationFormRef(registrationInput);
 
       await firestore.runTransaction(async (transaction) => {
         const eventSnap = await transaction.get(eventRef);
         if (eventSnap.exists) return;
 
-        const registrationSnap = await transaction.get(registrationRef);
+        const [registrationSnap, formSnap] = await Promise.all([
+          transaction.get(registrationRef),
+          transaction.get(formRef)
+        ]);
         if (!registrationSnap.exists) {
           throw new Error('Registration not found for Stripe webhook.');
+        }
+        if (!formSnap.exists) {
+          throw new Error('Registration form not found for Stripe webhook.');
         }
 
         if (shouldMarkRegistrationPaidFromEvent(event)) {
@@ -1417,12 +1522,34 @@ exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
             updatedAt: receivedAt
           }, { merge: true });
         } else {
+          const form = formSnap.data() || {};
+          const registration = registrationSnap.data() || {};
+          const selectedOption = registration.selectedOption || {};
+          const countKey = String(selectedOption.countKey || selectedOption.id || '').trim();
+          const counts = form.registrationOptionCounts || {};
+          const optionCounts = countKey ? counts[countKey] || {} : {};
+          const shouldReleaseCapacity = registration.registrationCapacityReleased !== true && registration.paymentStatus !== 'paid' && countKey;
+          if (shouldReleaseCapacity && registration.status === 'pending') {
+            transaction.update(formRef, {
+              [`registrationOptionCounts.${countKey}.enrolled`]: Math.max(0, Number(optionCounts.enrolled || 0) - 1),
+              registrationCapacityUpdateId: registrationInput.registrationId,
+              updatedAt: receivedAt
+            });
+          } else if (shouldReleaseCapacity && registration.status === 'waitlisted') {
+            transaction.update(formRef, {
+              [`registrationOptionCounts.${countKey}.waitlisted`]: Math.max(0, Number(optionCounts.waitlisted || 0) - 1),
+              registrationCapacityUpdateId: registrationInput.registrationId,
+              updatedAt: receivedAt
+            });
+          }
           transaction.set(registrationRef, {
             checkoutStatus: event.type === 'checkout.session.expired' ? 'expired' : 'payment_failed',
             paymentStatus: event.type === 'checkout.session.expired' ? 'checkout_expired' : 'payment_failed',
             stripeCheckoutSessionId: session.id || null,
             stripePaymentStatus: session.payment_status || 'unpaid',
             stripeEventId: event.id,
+            registrationCapacityReleased: true,
+            capacityReleasedAt: receivedAt,
             updatedAt: receivedAt
           }, { merge: true });
         }

--- a/js/stripe-service.js
+++ b/js/stripe-service.js
@@ -19,6 +19,18 @@ export async function initiateStripeCheckout(params) {
     }
 }
 
+export async function cancelStripeRegistrationCheckout(params) {
+    try {
+        const functions = getFunctions();
+        const cancelCheckoutSession = httpsCallable(functions, 'cancelStripeRegistrationCheckout');
+        const result = await cancelCheckoutSession(params);
+        return result?.data || { released: false };
+    } catch (error) {
+        console.error('StripeService: Error calling cancelStripeRegistrationCheckout:', error);
+        throw error;
+    }
+}
+
 export async function initiateTeamFeeCheckout(params) {
     try {
         const functions = getFunctions();

--- a/registration.html
+++ b/registration.html
@@ -99,7 +99,7 @@
     <script type="module">
         import { db, doc, getDoc, collection, addDoc, serverTimestamp, runTransaction } from './js/firebase.js?v=15';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
-        import { initiateStripeCheckout } from './js/stripe-service.js';
+        import { cancelStripeRegistrationCheckout, initiateStripeCheckout } from './js/stripe-service.js';
         import {
             buildPendingRegistrationRecord,
             calculateRegistrationFeeSnapshot,
@@ -147,6 +147,10 @@
                 confirmationMessage.querySelector('p').textContent = 'Your registration payment was received. The program organizer will follow up with next steps.';
                 confirmationMessage.classList.remove('hidden');
             } else if (stripeStatus === 'cancelled') {
+                const cancelledRegistrationId = urlParams.get('registrationId') || '';
+                if (cancelledRegistrationId) {
+                    void releaseCancelledStripeRegistration(cancelledRegistrationId);
+                }
                 errorMessage.textContent = 'Stripe payment was cancelled. You can try again.';
                 errorMessage.classList.remove('hidden');
             }
@@ -159,6 +163,14 @@
         spinner.setAttribute('role', 'status');
         spinner.setAttribute('aria-hidden', 'true');
         submitButton.prepend(spinner); // Add spinner to the button
+
+        async function releaseCancelledStripeRegistration(registrationId) {
+            try {
+                await cancelStripeRegistrationCheckout({ teamId, formId, registrationId });
+            } catch (error) {
+                console.error('Failed to release cancelled registration checkout:', error);
+            }
+        }
 
         function showError(message) {
             loadingState.classList.add('hidden');

--- a/tests/unit/registration-flow.test.js
+++ b/tests/unit/registration-flow.test.js
@@ -342,6 +342,8 @@ describe('public registration flow', () => {
         expect(page).toContain('return { status: \'pending\', registrationId: registrationRef.id };');
         expect(page).toContain('return { status: placement.status, registrationId: registrationRef.id };');
         expect(page).toContain("paymentLoadingState.classList.add('hidden');");
+        expect(page).toContain('cancelStripeRegistrationCheckout({ teamId, formId, registrationId });');
+        expect(page).toContain('releaseCancelledStripeRegistration(cancelledRegistrationId)');
         expect(page).toContain('runTransaction(db, async (transaction)');
         expect(page).toContain('decideRegistrationPlacement');
         expect(page).toContain('registrationCapacityUpdateId: registrationRef.id');
@@ -587,6 +589,9 @@ describe('public registration flow', () => {
         const functionsSource = fs.readFileSync('functions/index.js', 'utf8');
 
         expect(functionsSource).toContain('exports.createStripeRegistrationCheckout');
+        expect(functionsSource).toContain('exports.cancelStripeRegistrationCheckout');
+        expect(functionsSource).toContain('releaseRegistrationCheckoutCapacity');
+        expect(functionsSource).toContain("registrationCapacityReleased: true");
         expect(functionsSource).toContain("product: 'registration'");
         expect(functionsSource).toContain('getRegistrationCheckoutAmountCents(registration)');
         expect(functionsSource).toContain("form.paymentSettings?.onlineCheckoutEnabled !== true");

--- a/tests/unit/registration-flow.test.js
+++ b/tests/unit/registration-flow.test.js
@@ -599,4 +599,22 @@ describe('public registration flow', () => {
         expect(functionsSource).toContain("paymentStatus: 'checkout_open'");
         expect(functionsSource).toContain('shouldProcessRegistrationCheckoutEvent(event)');
     });
+
+    it('does not write cancellation state before returning for paid registrations', () => {
+        const functionsSource = fs.readFileSync('functions/index.js', 'utf8');
+        const releaseStart = functionsSource.indexOf('async function releaseRegistrationCheckoutCapacity');
+        const releaseEnd = functionsSource.indexOf('async function getUserForEligibility');
+        const releaseBody = functionsSource.slice(releaseStart, releaseEnd);
+        const paidGuardIndex = releaseBody.indexOf("if (registration.paymentStatus === 'paid')");
+        const registrationUpdateIndex = releaseBody.indexOf('const registrationUpdate =');
+        const paidReturnIndex = releaseBody.indexOf("return { released: false, reason: 'already-paid' };");
+        const firstRegistrationWriteAfterPaidGuard = releaseBody.indexOf('transaction.set(registrationRef', paidGuardIndex);
+
+        expect(releaseStart).toBeGreaterThanOrEqual(0);
+        expect(releaseEnd).toBeGreaterThan(releaseStart);
+        expect(paidGuardIndex).toBeGreaterThanOrEqual(0);
+        expect(paidReturnIndex).toBeGreaterThan(paidGuardIndex);
+        expect(registrationUpdateIndex).toBeGreaterThan(paidReturnIndex);
+        expect(firstRegistrationWriteAfterPaidGuard).toBeGreaterThan(registrationUpdateIndex);
+    });
 });

--- a/tests/unit/stripe-service.test.js
+++ b/tests/unit/stripe-service.test.js
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { initiateStripeCheckout, initiateTeamFeeCheckout } from '../../js/stripe-service.js';
+import { cancelStripeRegistrationCheckout, initiateStripeCheckout, initiateTeamFeeCheckout } from '../../js/stripe-service.js';
 
 const mockInnerCallable = vi.fn();
 
@@ -51,6 +51,19 @@ describe('Stripe Service', () => {
 
         await expect(initiateStripeCheckout({ registrationId: 'reg-789' })).rejects.toThrow('Failed to get Stripe checkout URL.');
         expect(httpsCallable).toHaveBeenCalledWith(expect.any(Object), 'createStripeRegistrationCheckout');
+    });
+
+    it('cancels registration checkout and returns release status', async () => {
+        mockInnerCallable.mockResolvedValueOnce({
+            data: { released: true }
+        });
+        const params = { teamId: 'team-1', formId: 'form-1', registrationId: 'reg-123' };
+
+        const result = await cancelStripeRegistrationCheckout(params);
+
+        expect(result).toEqual({ released: true });
+        expect(httpsCallable).toHaveBeenCalledWith(expect.any(Object), 'cancelStripeRegistrationCheckout');
+        expect(mockInnerCallable).toHaveBeenCalledWith(params);
     });
 
     it('initiates team fee checkout and returns a URL', async () => {


### PR DESCRIPTION
Closes #1357

## Summary
- Added a callable cancellation path for Stripe registration checkouts that releases enrolled or waitlisted capacity for unpaid open checkouts.
- Updated the registration page to call the cancellation release when Stripe returns with `status=cancelled`.
- Updated Stripe webhook failure/expiration handling to release capacity idempotently when checkout does not complete.

## Validation
- `npx vitest run tests/unit/stripe-service.test.js tests/unit/registration-flow.test.js --reporter=verbose`
- `node --check functions/index.js`