### PR TITLE
Allow parent team fee checkout creation

### DIFF
--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -26,6 +26,7 @@ import {
   normalizeParentFeeRecord,
   sortParentFeeRecords
 } from '../../../../js/parent-dashboard-fees.js';
+import { initiateTeamFeeCheckout } from '../../../../js/stripe-service.js';
 import {
   buildPendingRegistrationRecord,
   calculateRegistrationFeeSnapshot,
@@ -83,6 +84,8 @@ export type ParentFeeAppRecord = Record<string, any> & {
   dueLabel: string;
   statusLabel: string;
   canPay: boolean;
+  checkoutInitiatable: boolean;
+  paymentAction: 'checkoutUrl' | 'createCheckout' | '';
   lineItems: Array<Record<string, any>>;
   installments: Array<Record<string, any>>;
   ledgerEntries: Array<Record<string, any>>;
@@ -275,6 +278,19 @@ export async function loadParentFeesForApp(user: AuthUser | null): Promise<Paren
   if (!user?.uid) return [];
   const rawFees = await Promise.resolve(listParentTeamFeeRecipients(user.uid, user.parentOf || []));
   return sortParentFeeRecords(rawFees || []).map((fee: any) => toParentFeeAppRecord(fee));
+}
+
+export async function initiateParentTeamFeeCheckout(teamId: string, batchId: string, recipientId: string): Promise<{ success: true, checkoutUrl: string }> {
+  if (!teamId || !batchId || !recipientId) {
+    throw new Error('Missing required fields for team fee checkout.');
+  }
+
+  const checkoutUrl = await initiateTeamFeeCheckout({ teamId, batchId, recipientId });
+  if (!checkoutUrl) {
+    throw new Error('Failed to get checkout URL.');
+  }
+
+  return { success: true, checkoutUrl };
 }
 
 export async function loadParentCalendarTools(user: AuthUser | null) {
@@ -547,16 +563,40 @@ function normalizeAccessRequest(request: any): ParentAccessRequest {
 function toParentFeeAppRecord(fee: any): ParentFeeAppRecord {
   const normalized = normalizeParentFeeRecord(fee);
   const meta = getParentFeeStatusMeta(normalized.status);
+  const canOpenCheckoutUrl = isParentTeamFeePayActionAllowed(normalized) && Boolean(normalized.checkoutUrl);
+  const checkoutInitiatable = canInitiateParentTeamFeeCheckout(normalized);
   return {
     ...normalized,
     amountLabel: formatParentFeeAmount(normalized),
     dueLabel: formatParentFeeDueDate(normalized.dueDate),
     statusLabel: meta.label,
-    canPay: Boolean(normalized.checkoutUrl && !['paid', 'canceled'].includes(normalized.status) && Number(normalized.balanceDueCents ?? 1) > 0),
+    canPay: canOpenCheckoutUrl || checkoutInitiatable,
+    checkoutInitiatable,
+    paymentAction: canOpenCheckoutUrl ? 'checkoutUrl' : checkoutInitiatable ? 'createCheckout' : '',
     lineItems: getArrayField(normalized, ['lineItems', 'invoiceLineItems', 'invoiceItems', 'items']),
     installments: getArrayField(normalized, ['installments', 'installmentSchedule', 'paymentSchedule', 'scheduledPayments']),
     ledgerEntries: getArrayField(normalized, ['ledgerEntries', 'paymentLedger', 'activity', 'receipts', 'payments', 'adjustments'])
   };
+}
+
+export function isParentTeamFeePayActionAllowed(fee: any) {
+  const status = compactString(fee?.status).toLowerCase();
+  if (status === 'paid' || status === 'canceled' || status === 'cancelled') return false;
+
+  const balanceCents = Number(fee?.balanceDueCents);
+  if (!Number.isFinite(balanceCents) || balanceCents <= 0) return false;
+
+  return status === 'unpaid' || status === 'partial' || status === 'partially_paid';
+}
+
+export function canInitiateParentTeamFeeCheckout(fee: any) {
+  return Boolean(
+    isParentTeamFeePayActionAllowed(fee)
+    && !fee?.checkoutUrl
+    && compactString(fee?.teamId)
+    && compactString(fee?.batchId)
+    && compactString(fee?.recipientId)
+  );
 }
 
 function toRegistrationCard(team: any, form: any): ParentRegistrationCard | null {

--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -586,7 +586,7 @@ export function isParentTeamFeePayActionAllowed(fee: any) {
   const balanceCents = Number(fee?.balanceDueCents);
   if (!Number.isFinite(balanceCents) || balanceCents <= 0) return false;
 
-  return status === 'unpaid' || status === 'partial' || status === 'partially_paid';
+  return true;
 }
 
 export function canInitiateParentTeamFeeCheckout(fee: any) {

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -26,6 +26,7 @@ import {
   getAppleCalendarFeedUrl,
   getGoogleCalendarFeedUrl,
   getPrivateTeamCalendarFeedUrl,
+  initiateParentTeamFeeCheckout,
   loadFamilyShareModel,
   loadParentAccessModel,
   loadParentAccessPlayers,
@@ -260,6 +261,8 @@ function FeesTool({ auth }: { auth: AuthState }) {
   const [filter, setFilter] = useState<'open' | 'all' | 'paid'>('open');
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
+  const [payingFeeId, setPayingFeeId] = useState('');
+  const [feeErrors, setFeeErrors] = useState<Record<string, string>>({});
 
   const refresh = async () => {
     setLoading(true);
@@ -286,6 +289,23 @@ function FeesTool({ auth }: { auth: AuthState }) {
 
   const openCount = fees.filter((fee) => !['paid', 'canceled', 'cancelled'].includes(String(fee.status || '').toLowerCase())).length;
   const balanceCents = visibleFees.reduce((sum, fee) => sum + Number(fee.balanceDueCents ?? fee.amountDueCents ?? 0), 0);
+  const payFee = async (fee: ParentFeeAppRecord) => {
+    const feeKey = getFeeCardKey(fee);
+    setPayingFeeId(feeKey);
+    setFeeErrors((current) => ({ ...current, [feeKey]: '' }));
+    try {
+      if (fee.checkoutUrl) {
+        await openPublicUrl(String(fee.checkoutUrl));
+        return;
+      }
+      const checkout = await initiateParentTeamFeeCheckout(String(fee.teamId || ''), String(fee.batchId || ''), String(fee.recipientId || ''));
+      await openPublicUrl(checkout.checkoutUrl);
+    } catch (payError: any) {
+      setFeeErrors((current) => ({ ...current, [feeKey]: payError?.message || 'Unable to open checkout. Please try again.' }));
+    } finally {
+      setPayingFeeId('');
+    }
+  };
 
   return (
     <div className="space-y-3">
@@ -308,13 +328,20 @@ function FeesTool({ auth }: { auth: AuthState }) {
       {error ? <Status tone="error" message={error} /> : null}
       {loading ? <LoadingBlock label="Loading fees" /> : (
         <div className="grid gap-3 lg:grid-cols-2">
-          {visibleFees.length ? visibleFees.map((fee) => <FeeCard key={`${fee.teamId || 'team'}-${fee.id || fee.title}`} fee={fee} />) : (
+          {visibleFees.length ? visibleFees.map((fee) => {
+            const feeKey = getFeeCardKey(fee);
+            return <FeeCard key={feeKey} fee={fee} onPay={payFee} paying={payingFeeId === feeKey} error={feeErrors[feeKey] || ''} />;
+          }) : (
             <EmptyState icon={DollarSign} title="No fees in this view" detail="Paid and canceled items are available under All." />
           )}
         </div>
       )}
     </div>
   );
+}
+
+function getFeeCardKey(fee: ParentFeeAppRecord) {
+  return `${fee.teamId || 'team'}-${fee.batchId || 'batch'}-${fee.recipientId || fee.id || fee.title || 'fee'}`;
 }
 
 function CalendarTool({ auth }: { auth: AuthState }) {
@@ -647,7 +674,7 @@ function AccessRequestCard({ request }: { request: ParentAccessRequest }) {
   );
 }
 
-function FeeCard({ fee }: { fee: ParentFeeAppRecord }) {
+function FeeCard({ fee, onPay, paying, error }: { fee: ParentFeeAppRecord; onPay: (fee: ParentFeeAppRecord) => void | Promise<void>; paying: boolean; error: string }) {
   return (
     <section className="app-card p-4">
       <div className="flex items-start justify-between gap-3">
@@ -666,11 +693,12 @@ function FeeCard({ fee }: { fee: ParentFeeAppRecord }) {
       {fee.installments.length ? <FeeDetailList title="Installments" rows={fee.installments} /> : null}
       {fee.ledgerEntries.length ? <FeeDetailList title="Payments and adjustments" rows={fee.ledgerEntries} /> : null}
       {fee.canPay ? (
-        <button type="button" className="primary-button mt-3 w-full" onClick={() => openPublicUrl(String(fee.checkoutUrl))}>
-          <ExternalLink className="h-4 w-4" aria-hidden="true" />
-          Pay fee
+        <button type="button" className="primary-button mt-3 w-full" onClick={() => onPay(fee)} disabled={paying}>
+          {paying ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <ExternalLink className="h-4 w-4" aria-hidden="true" />}
+          {paying ? 'Opening checkout' : 'Pay fee'}
         </button>
       ) : null}
+      {error ? <div className="mt-2 rounded-xl border border-rose-100 bg-rose-50 p-3 text-xs font-semibold text-rose-700">{error}</div> : null}
     </section>
   );
 }

--- a/docs/pr-notes/runs/1364-remediator-20260525T150520Z/architecture.md
+++ b/docs/pr-notes/runs/1364-remediator-20260525T150520Z/architecture.md
@@ -1,0 +1,3 @@
+# Architecture
+
+Keep backend checkout eligibility as source of truth. Frontend pay gate should block terminal statuses and non-positive balances only, avoiding a narrower allowlist that strands migrated `adjusted` records. Blast radius is limited to Parent Tools fee action derivation.

--- a/docs/pr-notes/runs/1364-remediator-20260525T150520Z/code-plan.md
+++ b/docs/pr-notes/runs/1364-remediator-20260525T150520Z/code-plan.md
@@ -1,0 +1,3 @@
+# Code Plan
+
+Update `isParentTeamFeePayActionAllowed` to return true after terminal-status and positive-balance checks. Add focused unit assertions for adjusted and open statuses. No UI refactor.

--- a/docs/pr-notes/runs/1364-remediator-20260525T150520Z/qa.md
+++ b/docs/pr-notes/runs/1364-remediator-20260525T150520Z/qa.md
@@ -1,0 +1,3 @@
+# QA
+
+Add regression coverage in `tests/unit/app-parent-tools-service.test.js` for adjusted positive-balance fees with checkout URL, adjusted zero-balance fees, and unknown non-terminal statuses. Validate with the focused Vitest file.

--- a/docs/pr-notes/runs/1364-remediator-20260525T150520Z/requirements.md
+++ b/docs/pr-notes/runs/1364-remediator-20260525T150520Z/requirements.md
@@ -1,0 +1,3 @@
+# Requirements
+
+Adjusted parent fee records with positive balance must remain payable in Parent Tools. Paid/canceled remain blocked. Zero or invalid balances remain blocked. Existing checkout URLs should be opened; otherwise eligible records with identifiers can create checkout.

--- a/docs/pr-notes/runs/1364-remediator-20260525T151303Z/architecture.md
+++ b/docs/pr-notes/runs/1364-remediator-20260525T151303Z/architecture.md
@@ -1,0 +1,5 @@
+# Architecture
+
+- Parent Tools pay gating should align with backend checkout eligibility: exclude terminal statuses only (`paid`, `canceled`, `cancelled`) and require positive remaining balance.
+- Keep the status eligibility rule centralized in `isParentTeamFeePayActionAllowed` so checkout URL and create-checkout paths do not drift.
+- No data model changes are required; this is a client-side eligibility correction for migrated/legacy records.

--- a/docs/pr-notes/runs/1364-remediator-20260525T151303Z/code-plan.md
+++ b/docs/pr-notes/runs/1364-remediator-20260525T151303Z/code-plan.md
@@ -1,0 +1,5 @@
+# Code Plan
+
+- Inspect `apps/app/src/lib/parentToolsService.ts` pay eligibility helpers.
+- Ensure `isParentTeamFeePayActionAllowed` does not exclude `adjusted`; only paid and canceled/cancelled are terminal blockers, plus non-positive balance.
+- Add or preserve regression assertions in `tests/unit/app-parent-tools-service.test.js` for adjusted payable and adjusted zero-balance behavior.

--- a/docs/pr-notes/runs/1364-remediator-20260525T151303Z/qa.md
+++ b/docs/pr-notes/runs/1364-remediator-20260525T151303Z/qa.md
@@ -1,0 +1,5 @@
+# QA
+
+- Run the focused Parent Tools service unit test after the fix: `npx vitest run tests/unit/app-parent-tools-service.test.js --reporter=verbose`.
+- Verify an adjusted positive-balance fee with a checkout URL maps to `canPay: true` and `paymentAction: checkoutUrl`.
+- Verify adjusted zero-balance and terminal paid/canceled fees remain blocked.

--- a/docs/pr-notes/runs/1364-remediator-20260525T151303Z/requirements.md
+++ b/docs/pr-notes/runs/1364-remediator-20260525T151303Z/requirements.md
@@ -1,0 +1,5 @@
+# Requirements
+
+- Acceptance criteria: Parent Tools must show a Pay action for team fee records with status `adjusted` when they have a positive remaining balance and either an existing checkout URL or enough identifiers to initiate checkout.
+- Paid and canceled/cancelled fees remain ineligible. Zero-balance adjusted fees remain ineligible.
+- Regression coverage must assert adjusted positive-balance fees remain payable and zero-balance adjusted fees do not.

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -112,6 +112,9 @@ async function mockParentToolsModules(page) {
                         ledgerEntries: [{ label: 'Adjustment', amountCents: -1000 }]
                     }];
                 }
+                export async function initiateParentTeamFeeCheckout() {
+                    return { success: true, checkoutUrl: 'https://pay.example.test/created-fee' };
+                }
                 export async function loadParentCalendarTools() {
                     return {
                         events: [{ teamId: 'team-1', teamName: 'Bears', title: 'Practice', opponent: '', date: new Date('2100-06-01T18:00:00Z') }],

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -13,6 +13,7 @@ const serviceMocks = vi.hoisted(() => ({
     getCalendarEventShareText: vi.fn((event) => `${event.teamName} ${event.title || event.opponent}`),
     getGoogleCalendarFeedUrl: vi.fn((url) => `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(url)}`),
     getPrivateTeamCalendarFeedUrl: vi.fn(),
+    initiateParentTeamFeeCheckout: vi.fn(),
     loadFamilyShareModel: vi.fn(),
     loadParentAccessModel: vi.fn(),
     loadParentAccessPlayers: vi.fn(),
@@ -173,6 +174,7 @@ beforeEach(() => {
         teams: [{ teamId: 'team-1', teamName: 'Bears', eventCount: 1 }]
     });
     serviceMocks.getPrivateTeamCalendarFeedUrl.mockResolvedValue('https://feed.example.test/team-1.ics');
+    serviceMocks.initiateParentTeamFeeCheckout.mockResolvedValue({ success: true, checkoutUrl: 'https://pay.example.test/created-fee' });
     serviceMocks.loadFamilyShareModel.mockResolvedValue({
         children: [{ teamId: 'team-1', playerId: 'player-1', playerName: 'Pat Star' }],
         tokens: [{ id: 'token-1', label: 'Grandma', url: 'https://allplays.ai/family.html?token=token-1', childCount: 1, extraCalendarUrls: [] }]
@@ -237,6 +239,7 @@ describe('React app parent tools integration', () => {
         expect(container.textContent).toContain('Line items');
         await clickButton(container, 'Pay fee');
         expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://pay.example.test/fee');
+        expect(serviceMocks.initiateParentTeamFeeCheckout).not.toHaveBeenCalled();
 
         await clickButton(container, 'Calendar');
         await waitForText(container, 'Calendar tools');
@@ -274,6 +277,69 @@ describe('React app parent tools integration', () => {
             title: 'Hustle Award',
             url: 'https://allplays.ai/certificates.html#teamId=team-1&certificateId=cert-1'
         }));
+    });
+
+    it('creates a team fee checkout session when no checkout URL exists', async () => {
+        serviceMocks.loadParentFeesForApp.mockResolvedValueOnce([{
+            id: 'fee-2',
+            title: 'Tournament fee',
+            teamId: 'team-1',
+            batchId: 'batch-1',
+            recipientId: 'recipient-1',
+            teamName: 'Bears',
+            playerName: 'Pat Star',
+            status: 'unpaid',
+            amountLabel: '$75',
+            dueLabel: 'Jul 1',
+            statusLabel: 'Open',
+            balanceDueCents: 7500,
+            checkoutUrl: '',
+            canPay: true,
+            checkoutInitiatable: true,
+            paymentAction: 'createCheckout',
+            lineItems: [],
+            installments: [],
+            ledgerEntries: []
+        }]);
+
+        const { container } = await renderParentTools('/parent-tools/fees');
+        await waitForText(container, 'Tournament fee');
+        await clickButton(container, 'Pay fee');
+
+        expect(serviceMocks.initiateParentTeamFeeCheckout).toHaveBeenCalledWith('team-1', 'batch-1', 'recipient-1');
+        expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://pay.example.test/created-fee');
+    });
+
+    it('shows an inline fee checkout error without leaving Parent Tools', async () => {
+        serviceMocks.loadParentFeesForApp.mockResolvedValueOnce([{
+            id: 'fee-3',
+            title: 'Camp fee',
+            teamId: 'team-1',
+            batchId: 'batch-1',
+            recipientId: 'recipient-1',
+            teamName: 'Bears',
+            playerName: 'Pat Star',
+            status: 'partial',
+            amountLabel: '$50',
+            dueLabel: 'Jul 15',
+            statusLabel: 'Open',
+            balanceDueCents: 5000,
+            checkoutUrl: '',
+            canPay: true,
+            checkoutInitiatable: true,
+            paymentAction: 'createCheckout',
+            lineItems: [],
+            installments: [],
+            ledgerEntries: []
+        }]);
+        serviceMocks.initiateParentTeamFeeCheckout.mockRejectedValueOnce(new Error('Stripe session failed.'));
+
+        const { container } = await renderParentTools('/parent-tools/fees');
+        await waitForText(container, 'Camp fee');
+        await clickButton(container, 'Pay fee');
+
+        expect(container.textContent).toContain('Stripe session failed.');
+        expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
     });
 
     it('loads team media, uploads photos/files, adds links, and opens media items', async () => {

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -479,23 +479,35 @@ describe('React app parent tools service', () => {
             { id: 'missing-team', title: 'Missing team', status: 'unpaid', balanceDueCents: 1500, batchId: 'batch-1', recipientId: 'recipient-1' },
             { id: 'paid', title: 'Paid', status: 'paid', balanceDueCents: 1500, teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' },
             { id: 'partial', title: 'Partial', status: 'partial', balanceDueCents: 2500, teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' },
+            { id: 'adjusted', title: 'Adjusted', status: 'adjusted', balanceDueCents: 3000, checkoutUrl: 'https://pay.example.test/adjusted', teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' },
+            { id: 'adjusted-zero', title: 'Adjusted zero', status: 'adjusted', balanceDueCents: 0, checkoutUrl: 'https://pay.example.test/adjusted-zero', teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' },
             { id: 'zero', title: 'Zero', status: 'unpaid', balanceDueCents: 0, teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' }
         ]);
 
         const fees = await loadParentFeesForApp(user);
         const partialFee = fees.find((fee) => fee.id === 'partial');
 
+        const adjustedFee = fees.find((fee) => fee.id === 'adjusted');
+
         expect(partialFee).toMatchObject({
             canPay: true,
             checkoutInitiatable: true,
             paymentAction: 'createCheckout'
         });
+        expect(adjustedFee).toMatchObject({
+            canPay: true,
+            checkoutInitiatable: false,
+            paymentAction: 'checkoutUrl'
+        });
         expect(fees.find((fee) => fee.id === 'missing-team').canPay).toBe(false);
         expect(fees.find((fee) => fee.id === 'paid').canPay).toBe(false);
+        expect(fees.find((fee) => fee.id === 'adjusted-zero').canPay).toBe(false);
         expect(fees.find((fee) => fee.id === 'zero').canPay).toBe(false);
         expect(canInitiateParentTeamFeeCheckout(partialFee)).toBe(true);
         expect(isParentTeamFeePayActionAllowed({ status: 'partially_paid', balanceDueCents: 1 })).toBe(true);
-        expect(isParentTeamFeePayActionAllowed({ status: 'open', balanceDueCents: 1 })).toBe(false);
+        expect(isParentTeamFeePayActionAllowed({ status: 'adjusted', balanceDueCents: 1 })).toBe(true);
+        expect(isParentTeamFeePayActionAllowed({ status: 'open', balanceDueCents: 1 })).toBe(true);
+        expect(isParentTeamFeePayActionAllowed({ status: 'adjusted', balanceDueCents: 0 })).toBe(false);
     });
 
     it('loads schedule tools and builds escaped ICS content', async () => {

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -119,6 +119,10 @@ const scheduleMocks = vi.hoisted(() => ({
     loadParentSchedule: vi.fn()
 }));
 
+const stripeMocks = vi.hoisted(() => ({
+    initiateTeamFeeCheckout: vi.fn()
+}));
+
 vi.mock('../../js/db.js', () => dbMocks);
 vi.mock('../../js/firebase.js', () => firebaseMocks);
 vi.mock('../../js/parent-dashboard-fees.js', () => feeMocks);
@@ -127,6 +131,7 @@ vi.mock('../../js/team-media-utils.js', () => mediaMocks);
 vi.mock('../../apps/app/src/lib/authService.ts', () => authMocks);
 vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionMocks);
 vi.mock('../../apps/app/src/lib/scheduleService.ts', () => scheduleMocks);
+vi.mock('../../js/stripe-service.js', () => stripeMocks);
 
 import {
     addParentTeamMediaLink,
@@ -154,7 +159,10 @@ import {
     updateParentFamilyShareCalendars,
     uploadParentTeamMediaFile,
     uploadParentTeamMediaPhoto,
-    initiateRegistrationCheckout
+    initiateRegistrationCheckout,
+    initiateParentTeamFeeCheckout,
+    canInitiateParentTeamFeeCheckout,
+    isParentTeamFeePayActionAllowed
 } from '../../apps/app/src/lib/parentToolsService.ts';
 
 const user = {
@@ -438,7 +446,7 @@ describe('React app parent tools service', () => {
             {
                 id: 'fee-1',
                 title: 'Dues',
-                status: 'open',
+                status: 'unpaid',
                 amountDueCents: 12000,
                 balanceDueCents: 12000,
                 checkoutUrl: 'https://pay.example.test/open',
@@ -457,11 +465,37 @@ describe('React app parent tools service', () => {
             dueLabel: 'No due date',
             statusLabel: 'Open',
             canPay: true,
+            checkoutInitiatable: false,
+            paymentAction: 'checkoutUrl',
             lineItems: [{ title: 'Season', amountCents: 10000 }],
             installments: [{ label: 'Deposit', amountCents: 5000 }],
             ledgerEntries: [{ label: 'Adjustment', amountCents: -1000 }]
         });
         expect(fees[1].canPay).toBe(false);
+    });
+
+    it('marks unpaid team fees without checkout URLs as initiatable only when identifiers exist', async () => {
+        dbMocks.listParentTeamFeeRecipients.mockResolvedValue([
+            { id: 'missing-team', title: 'Missing team', status: 'unpaid', balanceDueCents: 1500, batchId: 'batch-1', recipientId: 'recipient-1' },
+            { id: 'paid', title: 'Paid', status: 'paid', balanceDueCents: 1500, teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' },
+            { id: 'partial', title: 'Partial', status: 'partial', balanceDueCents: 2500, teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' },
+            { id: 'zero', title: 'Zero', status: 'unpaid', balanceDueCents: 0, teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' }
+        ]);
+
+        const fees = await loadParentFeesForApp(user);
+        const partialFee = fees.find((fee) => fee.id === 'partial');
+
+        expect(partialFee).toMatchObject({
+            canPay: true,
+            checkoutInitiatable: true,
+            paymentAction: 'createCheckout'
+        });
+        expect(fees.find((fee) => fee.id === 'missing-team').canPay).toBe(false);
+        expect(fees.find((fee) => fee.id === 'paid').canPay).toBe(false);
+        expect(fees.find((fee) => fee.id === 'zero').canPay).toBe(false);
+        expect(canInitiateParentTeamFeeCheckout(partialFee)).toBe(true);
+        expect(isParentTeamFeePayActionAllowed({ status: 'partially_paid', balanceDueCents: 1 })).toBe(true);
+        expect(isParentTeamFeePayActionAllowed({ status: 'open', balanceDueCents: 1 })).toBe(false);
     });
 
     it('loads schedule tools and builds escaped ICS content', async () => {
@@ -684,6 +718,23 @@ describe('React app parent tools service', () => {
     it('throws error if checkout URL is not returned from backend', async () => {
         dbMocks.createRegistrationCheckoutSession.mockResolvedValue({ checkoutUrl: null });
         await expect(initiateRegistrationCheckout('t', 'f', 'r', 'o', 'p', 1, 100, 'USD'))
+            .rejects.toThrow('Failed to get checkout URL.');
+    });
+
+    it('initiates Stripe checkout for team fees and requires a returned URL', async () => {
+        stripeMocks.initiateTeamFeeCheckout.mockResolvedValue('https://checkout.stripe.test/team-fee');
+
+        await expect(initiateParentTeamFeeCheckout('team-1', 'batch-1', 'recipient-1')).resolves.toEqual({
+            success: true,
+            checkoutUrl: 'https://checkout.stripe.test/team-fee'
+        });
+        expect(stripeMocks.initiateTeamFeeCheckout).toHaveBeenCalledWith({ teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' });
+
+        await expect(initiateParentTeamFeeCheckout('', 'batch-1', 'recipient-1'))
+            .rejects.toThrow('Missing required fields for team fee checkout.');
+
+        stripeMocks.initiateTeamFeeCheckout.mockResolvedValueOnce('');
+        await expect(initiateParentTeamFeeCheckout('team-1', 'batch-1', 'recipient-1'))
             .rejects.toThrow('Failed to get checkout URL.');
     });
 });


### PR DESCRIPTION
Closes #1361

## Summary
- Added parent app service support for initiating Stripe team fee checkout sessions when no checkout URL exists.
- Updated Parent Tools fee cards to use one Pay fee action for existing checkout URLs or newly-created sessions, with per-card busy and inline error states.
- Added unit coverage for fee eligibility, checkout creation, direct checkout preservation, and recoverable failures.

## Validation
- `npx vitest run tests/unit/app-parent-tools-service.test.js tests/unit/app-parent-tools-integration.test.jsx --reporter=verbose`
- `npm --prefix apps/app run build`