### PR TITLE
Block offline team fee checkout

### DIFF
--- a/functions/team-fees-core.cjs
+++ b/functions/team-fees-core.cjs
@@ -75,7 +75,14 @@ function getTeamFeeBalanceCents(recipient = {}) {
     return Math.max(0, getTeamFeeTotalCents(recipient) - getTeamFeePaidCents(recipient));
 }
 
+function isOnlineTeamFeeCollection(recipient = {}) {
+    const collectionMode = normalizeString(recipient.collectionMode).toLowerCase();
+    return ['online_stripe', 'stripe', 'stripe_checkout', 'online'].includes(collectionMode);
+}
+
 function isTeamFeeCheckoutEligible(recipient = {}) {
+    if (!isOnlineTeamFeeCollection(recipient)) return false;
+
     const status = normalizeString(recipient.status || 'unpaid').toLowerCase();
     if (status === 'paid' || status === 'canceled' || status === 'cancelled') return false;
     return getTeamFeeBalanceCents(recipient) > 0;
@@ -257,6 +264,7 @@ module.exports = {
     getTeamFeeBalanceCents,
     getTeamFeeRefundedCents,
     getTeamFeeRefundableCents,
+    isOnlineTeamFeeCollection,
     isTeamFeeCheckoutEligible,
     isEligibleTeamFeePayer,
     buildTeamFeeCheckoutUrls,

--- a/js/parent-dashboard-fees.js
+++ b/js/parent-dashboard-fees.js
@@ -86,8 +86,13 @@ function isPayActionAllowed(fee) {
     return fee.status === 'unpaid' || fee.status === 'partial' || fee.status === 'partially_paid';
 }
 
+function isOnlineTeamFeeCollection(fee) {
+    const collectionMode = String(fee?.collectionMode || '').trim().toLowerCase();
+    return ['online_stripe', 'stripe', 'stripe_checkout', 'online'].includes(collectionMode);
+}
+
 function canInitiateCheckout(fee) {
-    return isPayActionAllowed(fee) && !fee.checkoutUrl && fee.teamId && fee.batchId && fee.recipientId;
+    return isOnlineTeamFeeCollection(fee) && isPayActionAllowed(fee) && !fee.checkoutUrl && fee.teamId && fee.batchId && fee.recipientId;
 }
 
 function formatCents(value) {
@@ -323,6 +328,7 @@ export function normalizeParentFeeRecord(fee) {
         dueDate: fee?.dueDate || fee?.dueAt || null,
         notes: fee?.notes || fee?.feeNotes || '',
         offlinePaymentInstructions: fee?.offlinePaymentInstructions || fee?.paymentInstructions || '',
+        collectionMode: fee?.collectionMode || '',
         totalAmountCents: getFeeTotalCents(fee),
         paidAmountCents: getFeePaidCents(fee),
         balanceDueCents: getFeeBalanceCents(fee),
@@ -366,7 +372,7 @@ export function renderParentTeamFees(fees) {
         const lineItems = renderInvoiceLineItems(fee);
         const installmentSchedule = renderInstallmentSchedule(fee);
         const receiptActivity = renderReceiptActivity(fee);
-        const payAction = fee.checkoutUrl && isPayActionAllowed(fee)
+        const payAction = isOnlineTeamFeeCollection(fee) && fee.checkoutUrl && isPayActionAllowed(fee)
             ? `<a class="inline-flex items-center justify-center rounded-lg bg-blue-600 px-3 py-2 text-sm font-bold text-white hover:bg-blue-700" href="${escapeHtml(fee.checkoutUrl)}">Pay online</a>`
             : canInitiateCheckout(fee)
                 ? `<button type="button" data-team-fee-checkout="true" data-team-id="${escapeHtml(fee.teamId)}" data-batch-id="${escapeHtml(fee.batchId)}" data-recipient-id="${escapeHtml(fee.recipientId)}" class="inline-flex items-center justify-center rounded-lg bg-blue-600 px-3 py-2 text-sm font-bold text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-70">Pay online</button>`

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -410,7 +410,7 @@
         import { mergeAssignmentsWithClaims } from './js/snack-helpers.js?v=1';
         import { resolveSelectedRideChildId, getRideOfferUiState, createRideRequestHandlers } from './js/parent-dashboard-rideshare-controls.js?v=1';
         import { applyRsvpHydration } from './js/rsvp-hydration.js?v=1';
-        import { handleParentTeamFeeCheckoutClick, renderParentTeamFees } from './js/parent-dashboard-fees.js?v=5';
+        import { handleParentTeamFeeCheckoutClick, renderParentTeamFees } from './js/parent-dashboard-fees.js?v=6';
         import { initiateTeamFeeCheckout } from './js/stripe-service.js?v=1';
         import { renderFamilyPlanSection } from './js/family-plan.js?v=2';
         import { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';

--- a/tests/unit/parent-dashboard-fees.test.js
+++ b/tests/unit/parent-dashboard-fees.test.js
@@ -191,31 +191,41 @@ describe('parent dashboard team fees', () => {
         expect(html).not.toContain('admin-123');
     });
 
-    it('renders Pay online for eligible unpaid or partial fees with or without a stored checkout URL', () => {
+    it('renders Pay online only for Stripe collection fees with an unpaid balance', () => {
         const manualOnlyHtml = renderParentTeamFees([
-            { title: 'Manual collection', teamId: 'team-1', batchId: 'batch-1', id: 'recipient-1', amountCents: 1000 }
+            { title: 'Manual collection', collectionMode: 'offline_manual', teamId: 'team-1', batchId: 'batch-1', id: 'recipient-1', amountCents: 1000 }
+        ]);
+        const manualWithCheckoutUrlHtml = renderParentTeamFees([
+            { title: 'Manual with stale URL', collectionMode: 'offline_manual', amountCents: 1000, checkoutUrl: 'https://pay.example/offline' }
+        ]);
+        const onlineCheckoutHtml = renderParentTeamFees([
+            { title: 'Online collection', collectionMode: 'online_stripe', teamId: 'team-1', batchId: 'batch-1', id: 'recipient-1', amountCents: 1000 }
         ]);
         const checkoutHtml = renderParentTeamFees([
-            { title: 'Online collection', amountCents: 1000, checkoutUrl: 'https://pay.example/checkout' }
+            { title: 'Online collection', collectionMode: 'online_stripe', amountCents: 1000, checkoutUrl: 'https://pay.example/checkout' }
         ]);
         const partialPaymentLinkHtml = renderParentTeamFees([
-            { title: 'Partial collection', amountCents: 2000, paidAmountCents: 1000, status: 'partially_paid', paymentLink: 'https://pay.example/remaining' }
+            { title: 'Partial collection', collectionMode: 'online_stripe', amountCents: 2000, paidAmountCents: 1000, status: 'partially_paid', paymentLink: 'https://pay.example/remaining' }
         ]);
         const paidHtml = renderParentTeamFees([
-            { title: 'Paid collection', amountCents: 1000, balanceDueCents: 0, status: 'paid', checkoutUrl: 'https://pay.example/paid' }
+            { title: 'Paid collection', collectionMode: 'online_stripe', amountCents: 1000, balanceDueCents: 0, status: 'paid', checkoutUrl: 'https://pay.example/paid' }
         ]);
         const adjustedHtml = renderParentTeamFees([
-            { title: 'Adjusted collection', amountCents: 1000, status: 'adjusted', checkoutUrl: 'https://pay.example/adjusted' }
+            { title: 'Adjusted collection', collectionMode: 'online_stripe', amountCents: 1000, status: 'adjusted', checkoutUrl: 'https://pay.example/adjusted' }
         ]);
         const missingContextHtml = renderParentTeamFees([
-            { title: 'No context collection', amountCents: 1000 }
+            { title: 'No context collection', collectionMode: 'online_stripe', amountCents: 1000 }
         ]);
 
-        expect(manualOnlyHtml).toContain('data-team-fee-checkout="true"');
-        expect(manualOnlyHtml).toContain('data-team-id="team-1"');
-        expect(manualOnlyHtml).toContain('data-batch-id="batch-1"');
-        expect(manualOnlyHtml).toContain('data-recipient-id="recipient-1"');
-        expect(manualOnlyHtml).toContain('>Pay online</button>');
+        expect(manualOnlyHtml).not.toContain('Pay online');
+        expect(manualOnlyHtml).not.toContain('data-team-fee-checkout="true"');
+        expect(manualWithCheckoutUrlHtml).not.toContain('Pay online');
+        expect(manualWithCheckoutUrlHtml).not.toContain('https://pay.example/offline');
+        expect(onlineCheckoutHtml).toContain('data-team-fee-checkout="true"');
+        expect(onlineCheckoutHtml).toContain('data-team-id="team-1"');
+        expect(onlineCheckoutHtml).toContain('data-batch-id="batch-1"');
+        expect(onlineCheckoutHtml).toContain('data-recipient-id="recipient-1"');
+        expect(onlineCheckoutHtml).toContain('>Pay online</button>');
         expect(checkoutHtml).toContain('>Pay online</a>');
         expect(checkoutHtml).toContain('https://pay.example/checkout');
         expect(partialPaymentLinkHtml).toContain('>Pay online</a>');

--- a/tests/unit/team-fees-functions.test.js
+++ b/tests/unit/team-fees-functions.test.js
@@ -9,6 +9,7 @@ const {
     getTeamFeeBalanceCents,
     getTeamFeeRefundedCents,
     getTeamFeeRefundableCents,
+    isOnlineTeamFeeCollection,
     isTeamFeeCheckoutEligible,
     isEligibleTeamFeePayer,
     buildTeamFeeCheckoutUrls,
@@ -34,13 +35,18 @@ describe('team fee checkout function helpers', () => {
         });
     });
 
-    it('computes current balance and rejects paid or canceled recipients', () => {
+    it('computes current balance and only allows checkout for online collection recipients', () => {
         expect(getTeamFeeBalanceCents({ amountCents: 12500, paidAmountCents: 2500 })).toBe(10000);
         expect(getTeamFeeBalanceCents({ balanceDueCents: 5000, paidAmountCents: 2500 })).toBe(5000);
-        expect(isTeamFeeCheckoutEligible({ status: 'unpaid', amountCents: 12500 })).toBe(true);
-        expect(isTeamFeeCheckoutEligible({ status: 'paid', amountCents: 12500 })).toBe(false);
-        expect(isTeamFeeCheckoutEligible({ status: 'canceled', amountCents: 12500 })).toBe(false);
-        expect(isTeamFeeCheckoutEligible({ status: 'unpaid', amountCents: 0 })).toBe(false);
+        expect(isOnlineTeamFeeCollection({ collectionMode: 'online_stripe' })).toBe(true);
+        expect(isOnlineTeamFeeCollection({ collectionMode: 'stripe_checkout' })).toBe(true);
+        expect(isOnlineTeamFeeCollection({ collectionMode: 'offline_manual' })).toBe(false);
+        expect(isTeamFeeCheckoutEligible({ collectionMode: 'online_stripe', status: 'unpaid', amountCents: 12500 })).toBe(true);
+        expect(isTeamFeeCheckoutEligible({ collectionMode: 'offline_manual', status: 'unpaid', amountCents: 12500 })).toBe(false);
+        expect(isTeamFeeCheckoutEligible({ status: 'unpaid', amountCents: 12500 })).toBe(false);
+        expect(isTeamFeeCheckoutEligible({ collectionMode: 'online_stripe', status: 'paid', amountCents: 12500 })).toBe(false);
+        expect(isTeamFeeCheckoutEligible({ collectionMode: 'online_stripe', status: 'canceled', amountCents: 12500 })).toBe(false);
+        expect(isTeamFeeCheckoutEligible({ collectionMode: 'online_stripe', status: 'unpaid', amountCents: 0 })).toBe(false);
     });
 
     it('allows owners, admins, linked parents, and direct recipients to pay', () => {


### PR DESCRIPTION
Closes #1384

## Summary
- Hide Pay online actions for team fees unless `collectionMode` explicitly allows Stripe collection.
- Reject backend Stripe checkout creation for offline/manual or unspecified collection modes.
- Added regression coverage for parent dashboard rendering and checkout eligibility.

## Validation
- `npx vitest run tests/unit/parent-dashboard-fees.test.js tests/unit/team-fees-functions.test.js --reporter=verbose`