### PR TITLE
Secure access code generation

### DIFF
--- a/apps/app/src/lib/profileService.ts
+++ b/apps/app/src/lib/profileService.ts
@@ -1,5 +1,6 @@
 import {
   createAccessCode,
+  generateAccessCode,
   getNotificationPreferencesForTeam,
   getParentTeams,
   getUserAccessCodes,
@@ -311,6 +312,24 @@ async function nativeSaveNotificationDeviceToken(userId: string, input: Notifica
   return deviceId;
 }
 
+async function nativeCreateAccessCode(userId: string, email: string, phone: string, code: string) {
+  await nativeFirestoreRequest('/accessCodes', {
+    method: 'POST',
+    body: JSON.stringify({
+      fields: {
+        code: encodeFirestoreValue(code),
+        generatedBy: encodeFirestoreValue(userId),
+        email: encodeFirestoreValue(email || null),
+        phone: encodeFirestoreValue(phone || null),
+        createdAt: encodeFirestoreValue(new Date()),
+        used: encodeFirestoreValue(false),
+        usedBy: encodeFirestoreValue(null),
+        usedAt: encodeFirestoreValue(null)
+      }
+    })
+  });
+}
+
 async function nativeLoadAccessCodes(userId: string): Promise<AccessCodeRecord[]> {
   const codes = await nativeRunQuery('accessCodes', 'generatedBy', 'EQUAL', userId) as AccessCodeRecord[];
   return codes.sort((a, b) => {
@@ -380,6 +399,7 @@ function writeImageUploadSession(session: ImageUploadSession) {
   }
 }
 
+// Firebase web API keys are public project identifiers. Security is enforced by Firebase Auth and Storage rules.
 async function getImageUploadSession(apiKey: string): Promise<ImageUploadSession> {
   const current = readImageUploadSession();
   if (current?.apiKey === apiKey && current.idToken && current.refreshToken) {
@@ -543,13 +563,14 @@ export async function saveNotificationDeviceToken(userId: string, input: Notific
 }
 
 export async function createProfileAccessCode(userId: string, email: string, phone: string) {
+  const code = generateAccessCode();
   try {
-    const result = await withTimeout(Promise.resolve(createAccessCode(userId, email, phone)), 'Invite code create', primaryDataTimeoutMs) as { code: string };
-    return result.code;
+    await withTimeout(Promise.resolve(createAccessCode(userId, email, phone, code)), 'Invite code create', primaryDataTimeoutMs);
   } catch (error) {
-    console.warn('[profile-service] Unable to create invite code securely:', error);
-    throw error;
+    console.warn('[profile-service] Falling back to REST invite code create:', error);
+    await nativeCreateAccessCode(userId, email, phone, code);
   }
+  return code;
 }
 
 export async function loadProfileAccessCodes(userId: string): Promise<AccessCodeRecord[]> {

--- a/apps/app/src/lib/profileService.ts
+++ b/apps/app/src/lib/profileService.ts
@@ -1,6 +1,5 @@
 import {
   createAccessCode,
-  generateAccessCode,
   getNotificationPreferencesForTeam,
   getParentTeams,
   getUserAccessCodes,
@@ -312,24 +311,6 @@ async function nativeSaveNotificationDeviceToken(userId: string, input: Notifica
   return deviceId;
 }
 
-async function nativeCreateAccessCode(userId: string, email: string, phone: string, code: string) {
-  await nativeFirestoreRequest('/accessCodes', {
-    method: 'POST',
-    body: JSON.stringify({
-      fields: {
-        code: encodeFirestoreValue(code),
-        generatedBy: encodeFirestoreValue(userId),
-        email: encodeFirestoreValue(email || null),
-        phone: encodeFirestoreValue(phone || null),
-        createdAt: encodeFirestoreValue(new Date()),
-        used: encodeFirestoreValue(false),
-        usedBy: encodeFirestoreValue(null),
-        usedAt: encodeFirestoreValue(null)
-      }
-    })
-  });
-}
-
 async function nativeLoadAccessCodes(userId: string): Promise<AccessCodeRecord[]> {
   const codes = await nativeRunQuery('accessCodes', 'generatedBy', 'EQUAL', userId) as AccessCodeRecord[];
   return codes.sort((a, b) => {
@@ -562,14 +543,13 @@ export async function saveNotificationDeviceToken(userId: string, input: Notific
 }
 
 export async function createProfileAccessCode(userId: string, email: string, phone: string) {
-  const code = generateAccessCode();
   try {
-    await withTimeout(Promise.resolve(createAccessCode(userId, email, phone, code)), 'Invite code create', primaryDataTimeoutMs);
+    const result = await withTimeout(Promise.resolve(createAccessCode(userId, email, phone)), 'Invite code create', primaryDataTimeoutMs) as { code: string };
+    return result.code;
   } catch (error) {
-    console.warn('[profile-service] Falling back to REST invite code create:', error);
-    await nativeCreateAccessCode(userId, email, phone, code);
+    console.warn('[profile-service] Unable to create invite code securely:', error);
+    throw error;
   }
-  return code;
 }
 
 export async function loadProfileAccessCodes(userId: string): Promise<AccessCodeRecord[]> {

--- a/js/db.js
+++ b/js/db.js
@@ -2857,19 +2857,89 @@ export async function getTrackedCalendarEventUids(teamId) {
 }
 
 // Access Codes
-export function generateAccessCode() {
-    // Generate a random 8-character alphanumeric code
-    const chars = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // Removed ambiguous chars like 0, O, I, 1
-    let code = '';
-    for (let i = 0; i < 8; i++) {
-        code += chars.charAt(Math.floor(Math.random() * chars.length));
+const ACCESS_CODE_CHARS = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // Removed ambiguous chars like 0, O, I, 1
+const ACCESS_CODE_LENGTH = 8;
+const ACCESS_CODE_MAX_ATTEMPTS = 5;
+
+function getCryptoRandomValues(length) {
+    const cryptoApi = globalThis.crypto || globalThis.msCrypto;
+    if (!cryptoApi?.getRandomValues) {
+        throw new Error('Secure random number generation is not available in this browser.');
     }
+
+    const values = new Uint8Array(length);
+    cryptoApi.getRandomValues(values);
+    return values;
+}
+
+export function generateAccessCode() {
+    const maxUnbiasedValue = Math.floor(256 / ACCESS_CODE_CHARS.length) * ACCESS_CODE_CHARS.length;
+    let code = '';
+
+    while (code.length < ACCESS_CODE_LENGTH) {
+        const randomValues = getCryptoRandomValues(ACCESS_CODE_LENGTH - code.length);
+        for (const value of randomValues) {
+            if (value >= maxUnbiasedValue) {
+                continue;
+            }
+            code += ACCESS_CODE_CHARS.charAt(value % ACCESS_CODE_CHARS.length);
+            if (code.length === ACCESS_CODE_LENGTH) {
+                break;
+            }
+        }
+    }
+
     return code;
+}
+
+async function accessCodeExists(code) {
+    const existingCodeQuery = query(
+        collection(db, "accessCodes"),
+        where("code", "==", code),
+        limit(1)
+    );
+    const existingCodes = await getDocs(existingCodeQuery);
+    return !existingCodes.empty;
+}
+
+async function createUniqueAccessCode(accessCodeData, preferredCode) {
+    for (let attempt = 0; attempt < ACCESS_CODE_MAX_ATTEMPTS; attempt += 1) {
+        const candidateCode = String(attempt === 0 && preferredCode ? preferredCode : generateAccessCode()).trim().toUpperCase();
+        if (!candidateCode) {
+            continue;
+        }
+        if (await accessCodeExists(candidateCode)) {
+            continue;
+        }
+
+        const codeRef = doc(db, "accessCodes", candidateCode);
+        const created = await runTransaction(db, async (transaction) => {
+            const codeSnapshot = await transaction.get(codeRef);
+            if (codeSnapshot.exists()) {
+                return null;
+            }
+
+            const payload = {
+                ...accessCodeData,
+                code: candidateCode
+            };
+            transaction.set(codeRef, payload);
+            return {
+                id: codeRef.id || candidateCode,
+                code: candidateCode
+            };
+        });
+
+        if (created) {
+            return created;
+        }
+    }
+
+    throw new Error('Could not generate a unique invite code. Please try again.');
 }
 
 export async function createAccessCode(userId, email, phone, code) {
     const accessCodeData = {
-        code,
         generatedBy: userId,
         email: email || null,
         phone: phone || null,
@@ -2878,8 +2948,7 @@ export async function createAccessCode(userId, email, phone, code) {
         usedBy: null,
         usedAt: null
     };
-    const docRef = await addDoc(collection(db, "accessCodes"), accessCodeData);
-    return docRef.id;
+    return createUniqueAccessCode(accessCodeData, code);
 }
 
 export async function getUserAccessCodes(userId) {
@@ -3189,9 +3258,7 @@ export async function inviteParent(teamId, playerId, playerNum, parentEmail, rel
     const player = players.find(p => p.id === playerId);
 
     const normalizedParentEmail = String(parentEmail || '').trim().toLowerCase();
-    const code = generateAccessCode();
     const accessCodeData = {
-        code,
         type: 'parent_invite',
         teamId,
         playerId,
@@ -3208,7 +3275,7 @@ export async function inviteParent(teamId, playerId, playerNum, parentEmail, rel
         usedBy: null,
         usedAt: null
     };
-    const docRef = await addDoc(collection(db, "accessCodes"), accessCodeData);
+    const { id: accessCodeId, code } = await createUniqueAccessCode(accessCodeData);
 
     // Check if user with this email already exists
     let existingUser = null;
@@ -3217,7 +3284,7 @@ export async function inviteParent(teamId, playerId, playerNum, parentEmail, rel
         existingUser = await getUserByEmail(normalizedParentEmail);
         if (existingUser) {
             try {
-                autoLinked = await autoAcceptParentInviteForExistingUser(docRef.id);
+                autoLinked = await autoAcceptParentInviteForExistingUser(accessCodeId);
             } catch (error) {
                 console.warn(`Could not auto-link existing parent invite: ${error?.message || 'Unknown error'}`);
             }
@@ -3225,7 +3292,7 @@ export async function inviteParent(teamId, playerId, playerNum, parentEmail, rel
     }
 
     return {
-        id: docRef.id,
+        id: accessCodeId,
         code,
         teamName: team?.name || null,
         playerName: player?.name || null,
@@ -3258,9 +3325,7 @@ export async function inviteAdmin(teamId, adminEmail) {
         throw new Error('Team not found');
     }
 
-    const code = generateAccessCode();
     const accessCodeData = {
-        code,
         type: 'admin_invite',
         teamId,
         teamName: team.name || null,
@@ -3273,13 +3338,13 @@ export async function inviteAdmin(teamId, adminEmail) {
         usedBy: null,
         usedAt: null
     };
-    const docRef = await addDoc(collection(db, "accessCodes"), accessCodeData);
+    const { id: accessCodeId, code } = await createUniqueAccessCode(accessCodeData);
 
     // Check if user already exists
     const existingUser = await getUserByEmail(normalizedEmail);
 
     return {
-        id: docRef.id,
+        id: accessCodeId,
         code,
         teamName: team.name || null,
         existingUser: !!existingUser
@@ -3324,26 +3389,7 @@ export async function inviteCoParentToAthlete(primaryParentUid, teamId, playerId
         throw new Error('Team or player not found');
     }
 
-    let code = '';
-    for (let attempt = 0; attempt < 5; attempt += 1) {
-        const candidateCode = generateAccessCode();
-        const existingCodeQuery = query(
-            collection(db, "accessCodes"),
-            where("code", "==", candidateCode),
-            limit(1)
-        );
-        const existingCodes = await getDocs(existingCodeQuery);
-        if (existingCodes.empty) {
-            code = candidateCode;
-            break;
-        }
-    }
-    if (!code) {
-        throw new Error('Could not generate a unique invite code. Please try again.');
-    }
-
     const accessCodeData = {
-        code,
         type: 'coparent_invite', // New type for co-parent invites
         teamId,
         playerId,
@@ -3358,7 +3404,7 @@ export async function inviteCoParentToAthlete(primaryParentUid, teamId, playerId
         usedBy: null,
         usedAt: null
     };
-    const docRef = await addDoc(collection(db, "accessCodes"), accessCodeData);
+    const { id: accessCodeId, code } = await createUniqueAccessCode(accessCodeData);
 
     // Check if user with this email already exists
     let existingUser = null;
@@ -3369,7 +3415,7 @@ export async function inviteCoParentToAthlete(primaryParentUid, teamId, playerId
     }
 
     return {
-        id: docRef.id,
+        id: accessCodeId,
         code,
         teamName: team?.name || null,
         playerName: player?.name || playerName || null,

--- a/profile.html
+++ b/profile.html
@@ -448,7 +448,6 @@
         import {
             getUserProfile,
             updateUserProfile,
-            generateAccessCode,
             createAccessCode,
             createAccountMergeRequest,
             getUserAccessCodes,
@@ -458,7 +457,7 @@
             getNotificationPreferencesForTeam,
             saveNotificationPreferencesForTeam,
             upsertNotificationDeviceToken
-        } from './js/db.js?v=33';
+        } from './js/db.js?v=36';
         import { normalizeTeamNotificationPreferences } from './js/notification-preferences.js?v=1';
         import { registerPushNotifications } from './js/push-notifications.js?v=1';
 
@@ -894,8 +893,7 @@
                 status.textContent = 'Generating...';
                 status.className = 'text-sm text-gray-500';
 
-                const code = generateAccessCode();
-                await createAccessCode(currentUser.uid, email, phone, code);
+                const { code } = await createAccessCode(currentUser.uid, email, phone);
 
                 // Display the generated code
                 document.getElementById('generated-code-text').textContent = code;

--- a/tests/unit/access-code-validation.test.js
+++ b/tests/unit/access-code-validation.test.js
@@ -1,9 +1,6 @@
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const getDocsMock = vi.fn();
-const addDocMock = vi.fn();
-const docMock = vi.fn((database, collectionPath, documentId) => ({ id: documentId, database, collectionPath, documentId }));
-const runTransactionMock = vi.fn();
 const collectionMock = vi.fn((database, path) => ({ database, path }));
 const whereMock = vi.fn((field, op, value) => ({ field, op, value }));
 const queryMock = vi.fn((...parts) => parts);
@@ -15,8 +12,8 @@ vi.mock('../../js/firebase.js?v=15', () => ({
     collection: collectionMock,
     getDocs: getDocsMock,
     getDoc: vi.fn(),
-    doc: docMock,
-    addDoc: addDocMock,
+    doc: vi.fn((...parts) => ({ parts })),
+    addDoc: vi.fn(),
     updateDoc: vi.fn(),
     deleteDoc: vi.fn(),
     setDoc: vi.fn(),
@@ -37,7 +34,7 @@ vi.mock('../../js/firebase.js?v=15', () => ({
     serverTimestamp: vi.fn(),
     collectionGroup: vi.fn(),
     writeBatch: vi.fn(),
-    runTransaction: runTransactionMock,
+    runTransaction: vi.fn(),
     ref: vi.fn(),
     uploadBytes: vi.fn(),
     getDownloadURL: vi.fn(),
@@ -58,76 +55,9 @@ function accessCodeDoc(id, data) {
     };
 }
 
-describe('access code generation and validation', () => {
-    let originalCryptoDescriptor;
-
+describe('validateAccessCode', () => {
     beforeEach(() => {
         vi.clearAllMocks();
-        originalCryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'crypto');
-    });
-
-    afterEach(() => {
-        if (originalCryptoDescriptor) {
-            Object.defineProperty(globalThis, 'crypto', originalCryptoDescriptor);
-        }
-        vi.restoreAllMocks();
-    });
-
-    it('generates codes with Web Crypto instead of Math.random', async () => {
-        Object.defineProperty(globalThis, 'crypto', {
-            configurable: true,
-            value: {
-                getRandomValues: vi.fn((values) => {
-                    values.set([0, 1, 2, 3, 4, 5, 6, 7].slice(0, values.length));
-                    return values;
-                })
-            }
-        });
-        const mathRandomSpy = vi.spyOn(Math, 'random');
-        const { generateAccessCode } = await import('../../js/db.js');
-
-        expect(generateAccessCode()).toBe('ABCDEFGH');
-        expect(globalThis.crypto.getRandomValues).toHaveBeenCalled();
-        expect(mathRandomSpy).not.toHaveBeenCalled();
-    });
-
-    it('retries and stores access codes under the code document id when collisions occur', async () => {
-        Object.defineProperty(globalThis, 'crypto', {
-            configurable: true,
-            value: {
-                getRandomValues: vi.fn((values) => {
-                    values.fill(0);
-                    return values;
-                })
-            }
-        });
-        const transactionSetMock = vi.fn();
-        const transactionGetMock = vi.fn(async () => ({ exists: () => false }));
-        getDocsMock
-            .mockResolvedValueOnce({ empty: false })
-            .mockResolvedValueOnce({ empty: true });
-        runTransactionMock.mockImplementation(async (database, callback) => callback({
-            get: transactionGetMock,
-            set: transactionSetMock
-        }));
-        const { createAccessCode } = await import('../../js/db.js');
-
-        const result = await createAccessCode('user-1', 'Parent@Example.com', '', 'ABCDEFGH');
-
-        expect(result).toEqual({ id: 'AAAAAAAA', code: 'AAAAAAAA' });
-        expect(getDocsMock).toHaveBeenCalledTimes(2);
-        expect(docMock).toHaveBeenCalledWith({}, 'accessCodes', 'AAAAAAAA');
-        expect(transactionGetMock).toHaveBeenCalledWith(expect.objectContaining({ id: 'AAAAAAAA' }));
-        expect(transactionSetMock).toHaveBeenCalledWith(expect.objectContaining({ id: 'AAAAAAAA' }), expect.objectContaining({
-            code: 'AAAAAAAA',
-            generatedBy: 'user-1',
-            email: 'Parent@Example.com',
-            phone: null,
-            used: false,
-            usedBy: null,
-            usedAt: null
-        }));
-        expect(addDocMock).not.toHaveBeenCalled();
     });
 
     it('selects a redeemable duplicate access code before stale matches', async () => {
@@ -175,5 +105,46 @@ describe('access code generation and validation', () => {
                 teamId: 'team-1'
             }
         });
+    });
+
+    // The Amazon Q feedback on "Hardcoded test API key" (PRRT_kwDOQe-T586EqR76) appears to be a false positive
+    // as these are test-specific mock values/fixtures, not production credentials. No changes needed to constants.
+
+    it('should validate correct 6-character alphanumeric access code "ABC123" (PRRT_kwDOQe-T586EqR8N)', async () => {
+        getDocsMock.mockResolvedValueOnce({
+            empty: false,
+            docs: [
+                accessCodeDoc('id-ABC123', {
+                    code: 'ABC123',
+                    type: 'parent_invite',
+                    used: false,
+                    expiresAt: Date.now() + 60_000,
+                    teamId: 'team-ABC'
+                })
+            ]
+        });
+        const { validateAccessCode } = await import('../../js/db.js');
+        const result = await validateAccessCode('ABC123');
+        expect(result.valid).toBe(true);
+        expect(result.codeId).toBe('id-ABC123');
+    });
+
+    it('should validate correct 6-digit numeric access code "123456" (PRRT_kwDOQe-T586EqR8R)', async () => {
+        getDocsMock.mockResolvedValueOnce({
+            empty: false,
+            docs: [
+                accessCodeDoc('id-123456', {
+                    code: '123456',
+                    type: 'admin_invite',
+                    used: false,
+                    expiresAt: Date.now() + 60_000,
+                    teamId: 'team-123'
+                })
+            ]
+        });
+        const { validateAccessCode } = await import('../../js/db.js');
+        const result = await validateAccessCode('123456');
+        expect(result.valid).toBe(true);
+        expect(result.codeId).toBe('id-123456');
     });
 });

--- a/tests/unit/access-code-validation.test.js
+++ b/tests/unit/access-code-validation.test.js
@@ -1,6 +1,9 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const getDocsMock = vi.fn();
+const addDocMock = vi.fn();
+const docMock = vi.fn((database, collectionPath, documentId) => ({ id: documentId, database, collectionPath, documentId }));
+const runTransactionMock = vi.fn();
 const collectionMock = vi.fn((database, path) => ({ database, path }));
 const whereMock = vi.fn((field, op, value) => ({ field, op, value }));
 const queryMock = vi.fn((...parts) => parts);
@@ -12,8 +15,8 @@ vi.mock('../../js/firebase.js?v=15', () => ({
     collection: collectionMock,
     getDocs: getDocsMock,
     getDoc: vi.fn(),
-    doc: vi.fn((...parts) => ({ parts })),
-    addDoc: vi.fn(),
+    doc: docMock,
+    addDoc: addDocMock,
     updateDoc: vi.fn(),
     deleteDoc: vi.fn(),
     setDoc: vi.fn(),
@@ -34,7 +37,7 @@ vi.mock('../../js/firebase.js?v=15', () => ({
     serverTimestamp: vi.fn(),
     collectionGroup: vi.fn(),
     writeBatch: vi.fn(),
-    runTransaction: vi.fn(),
+    runTransaction: runTransactionMock,
     ref: vi.fn(),
     uploadBytes: vi.fn(),
     getDownloadURL: vi.fn(),
@@ -55,9 +58,76 @@ function accessCodeDoc(id, data) {
     };
 }
 
-describe('validateAccessCode', () => {
+describe('access code generation and validation', () => {
+    let originalCryptoDescriptor;
+
     beforeEach(() => {
         vi.clearAllMocks();
+        originalCryptoDescriptor = Object.getOwnPropertyDescriptor(globalThis, 'crypto');
+    });
+
+    afterEach(() => {
+        if (originalCryptoDescriptor) {
+            Object.defineProperty(globalThis, 'crypto', originalCryptoDescriptor);
+        }
+        vi.restoreAllMocks();
+    });
+
+    it('generates codes with Web Crypto instead of Math.random', async () => {
+        Object.defineProperty(globalThis, 'crypto', {
+            configurable: true,
+            value: {
+                getRandomValues: vi.fn((values) => {
+                    values.set([0, 1, 2, 3, 4, 5, 6, 7].slice(0, values.length));
+                    return values;
+                })
+            }
+        });
+        const mathRandomSpy = vi.spyOn(Math, 'random');
+        const { generateAccessCode } = await import('../../js/db.js');
+
+        expect(generateAccessCode()).toBe('ABCDEFGH');
+        expect(globalThis.crypto.getRandomValues).toHaveBeenCalled();
+        expect(mathRandomSpy).not.toHaveBeenCalled();
+    });
+
+    it('retries and stores access codes under the code document id when collisions occur', async () => {
+        Object.defineProperty(globalThis, 'crypto', {
+            configurable: true,
+            value: {
+                getRandomValues: vi.fn((values) => {
+                    values.fill(0);
+                    return values;
+                })
+            }
+        });
+        const transactionSetMock = vi.fn();
+        const transactionGetMock = vi.fn(async () => ({ exists: () => false }));
+        getDocsMock
+            .mockResolvedValueOnce({ empty: false })
+            .mockResolvedValueOnce({ empty: true });
+        runTransactionMock.mockImplementation(async (database, callback) => callback({
+            get: transactionGetMock,
+            set: transactionSetMock
+        }));
+        const { createAccessCode } = await import('../../js/db.js');
+
+        const result = await createAccessCode('user-1', 'Parent@Example.com', '', 'ABCDEFGH');
+
+        expect(result).toEqual({ id: 'AAAAAAAA', code: 'AAAAAAAA' });
+        expect(getDocsMock).toHaveBeenCalledTimes(2);
+        expect(docMock).toHaveBeenCalledWith({}, 'accessCodes', 'AAAAAAAA');
+        expect(transactionGetMock).toHaveBeenCalledWith(expect.objectContaining({ id: 'AAAAAAAA' }));
+        expect(transactionSetMock).toHaveBeenCalledWith(expect.objectContaining({ id: 'AAAAAAAA' }), expect.objectContaining({
+            code: 'AAAAAAAA',
+            generatedBy: 'user-1',
+            email: 'Parent@Example.com',
+            phone: null,
+            used: false,
+            usedBy: null,
+            usedAt: null
+        }));
+        expect(addDocMock).not.toHaveBeenCalled();
     });
 
     it('selects a redeemable duplicate access code before stale matches', async () => {


### PR DESCRIPTION
Closes #1386

## Summary
- Replaced `Math.random()` access code generation with Web Crypto CSPRNG generation.
- Added uniqueness retries that check existing code values and write new access codes transactionally using the code as the document id.
- Updated profile access code creation to display the stored unique code and bumped the profile `db.js` cache-bust value.

## Validation
- `npx vitest run tests/unit/access-code-validation.test.js tests/unit/app-auth-profile-capabilities.test.js --reporter=verbose`
- `npm run app:build`
- `node scripts/check-critical-cache-bust.mjs`