### PR TITLE
Add Private AI starter prompts

### DIFF
--- a/apps/app/src/pages/PrivateAiChat.tsx
+++ b/apps/app/src/pages/PrivateAiChat.tsx
@@ -51,6 +51,13 @@ const suggestedPrompts = [
   'What is my next game?'
 ];
 
+const starterPrompts = [
+  'What do I need to handle today?',
+  'What is my next game?',
+  'Show unread team messages',
+  'Who still needs an RSVP?'
+];
+
 export function PrivateAiChat({ auth }: { auth: AuthState }) {
   const { isDesktopWeb } = useShellLayout();
   const [messages, setMessages] = useState<PrivateAiMessage[]>([]);
@@ -240,11 +247,9 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
     startWebDictation();
   };
 
-  const sendMessage = async (event?: FormEvent) => {
-    event?.preventDefault();
-    if (!auth.user || sending) return;
-    const text = draft.trim();
-    if (!text) return;
+  const sendPrompt = async (text: string) => {
+    const trimmedText = text.trim();
+    if (!auth.user || sending || !trimmedText) return;
 
     setDraft('');
     setSending(true);
@@ -252,14 +257,14 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
     const optimisticUser: PrivateAiMessage = {
       id: `local-user-${Date.now()}`,
       role: 'user',
-      text,
+      text: trimmedText,
       conversationId: activeConversationId,
       createdAt: new Date()
     };
     setMessages((current) => [...current, optimisticUser]);
 
     try {
-      const result = await sendPrivateAiMessage(auth.user, text, activeConversationId);
+      const result = await sendPrivateAiMessage(auth.user, trimmedText, activeConversationId);
       setMessages((current) => [
         ...current.filter((message) => message.id !== optimisticUser.id),
         result.userMessage,
@@ -268,7 +273,7 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
       await refreshConversations(false);
     } catch (error: any) {
       setMessages((current) => current.filter((message) => message.id !== optimisticUser.id));
-      setDraft(text);
+      setDraft(trimmedText);
       setStatus({
         tone: 'error',
         message: error?.message || 'Unable to send message.'
@@ -278,8 +283,13 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
     }
   };
 
+  const sendMessage = (event?: FormEvent) => {
+    event?.preventDefault();
+    void sendPrompt(draft);
+  };
+
   const sendSuggestion = (prompt: string) => {
-    setDraft(prompt);
+    void sendPrompt(prompt);
   };
 
   const startNewConversation = async () => {
@@ -327,6 +337,7 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
       onDraftChange={setDraft}
       onSubmit={sendMessage}
       onToggleDictation={toggleDictation}
+      onStarterPrompt={sendSuggestion}
       dictating={dictating}
       status={status}
       bottomRef={bottomRef}
@@ -374,6 +385,7 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
                     type="button"
                     className="private-ai-prompt-button"
                     onClick={() => sendSuggestion(prompt)}
+                    disabled={sending}
                   >
                     <span>{prompt}</span>
                     <ChevronRight className="h-4 w-4 flex-none" aria-hidden="true" />
@@ -559,6 +571,7 @@ function PrivateAiThread({
   onDraftChange,
   onSubmit,
   onToggleDictation,
+  onStarterPrompt,
   dictating,
   status,
   bottomRef
@@ -570,6 +583,7 @@ function PrivateAiThread({
   onDraftChange: (value: string) => void;
   onSubmit: (event?: FormEvent) => void;
   onToggleDictation: () => void;
+  onStarterPrompt: (prompt: string) => void;
   dictating: boolean;
   status: ChatStatus | null;
   bottomRef: MutableRefObject<HTMLDivElement | null>;
@@ -585,7 +599,7 @@ function PrivateAiThread({
             </div>
           ) : null}
 
-          {!loading && !messages.length ? <PrivateAiWelcome /> : null}
+          {!loading && !messages.length ? <PrivateAiWelcome sending={sending} onStarterPrompt={onStarterPrompt} /> : null}
 
           {!loading ? messages.map((message, index) => (
             <PrivateAiBubble key={message.id} message={message} previous={messages[index - 1] || null} />
@@ -644,7 +658,13 @@ function PrivateAiThread({
   );
 }
 
-function PrivateAiWelcome() {
+function PrivateAiWelcome({
+  sending,
+  onStarterPrompt
+}: {
+  sending: boolean;
+  onStarterPrompt: (prompt: string) => void;
+}) {
   return (
     <div className="private-ai-welcome">
       <div className="flex h-11 w-11 items-center justify-center rounded-2xl bg-primary-50 text-primary-700">
@@ -653,6 +673,20 @@ function PrivateAiWelcome() {
       <div className="mt-3 text-base font-black text-gray-950">What do you need from ALL PLAYS?</div>
       <div className="mt-1 text-sm font-semibold leading-6 text-gray-500">
         Ask about your teams, schedule, messages, fees, player development, coaching ideas, registrations, and profile.
+      </div>
+      <div className="private-ai-starter-prompts" aria-label="Starter prompts">
+        {starterPrompts.map((prompt) => (
+          <button
+            key={prompt}
+            type="button"
+            className="private-ai-starter-prompt"
+            onClick={() => onStarterPrompt(prompt)}
+            disabled={sending}
+          >
+            <span>{prompt}</span>
+            <Send className="h-3.5 w-3.5 flex-none" aria-hidden="true" />
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -1115,9 +1115,45 @@ a {
 
 .private-ai-welcome {
   margin: auto;
-  max-width: 360px;
+  max-width: 420px;
   padding: 28px 18px;
   text-align: center;
+}
+
+.private-ai-starter-prompts {
+  display: grid;
+  gap: 8px;
+  margin-top: 16px;
+}
+
+.private-ai-starter-prompt {
+  display: flex;
+  min-height: 42px;
+  width: 100%;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border: 1px solid #c7d2fe;
+  border-radius: 13px;
+  background: #ffffff;
+  padding: 9px 11px;
+  color: #3730a3;
+  text-align: left;
+  font-size: 0.84rem;
+  font-weight: 900;
+  line-height: 1.25;
+  box-shadow: 0 8px 18px rgba(79, 70, 229, 0.1);
+}
+
+.private-ai-starter-prompt:hover:not(:disabled) {
+  background: #eef2ff;
+  transform: translateY(-1px);
+}
+
+.private-ai-starter-prompt:disabled,
+.private-ai-prompt-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.65;
 }
 
 .private-ai-composer {

--- a/tests/unit/app-private-ai-integration.test.jsx
+++ b/tests/unit/app-private-ai-integration.test.jsx
@@ -158,7 +158,7 @@ describe('private AI chat page', () => {
         expect(container.textContent).toContain('Looked up get_schedule');
     });
 
-    it('renders desktop prompt rail and copies a suggestion into the composer', async () => {
+    it('renders desktop prompt rail and sends a selected suggestion', async () => {
         layoutMocks.isDesktopWeb = true;
         privateAiMocks.loadPrivateAiMessages.mockResolvedValueOnce([]);
 
@@ -170,7 +170,33 @@ describe('private AI chat page', () => {
         const suggestion = Array.from(container.querySelectorAll('button')).find((button) => button.textContent.includes('Who still needs an RSVP?'));
         await click(suggestion);
 
-        expect(container.querySelector('textarea').value).toBe('Who still needs an RSVP?');
+        expect(privateAiMocks.sendPrivateAiMessage).toHaveBeenCalledWith(auth.user, 'Who still needs an RSVP?', 'default');
+        expect(container.querySelector('textarea').value).toBe('');
+    });
+
+    it('renders starter prompts in the empty mobile welcome state', async () => {
+        layoutMocks.isDesktopWeb = false;
+        privateAiMocks.loadPrivateAiMessages.mockResolvedValueOnce([]);
+
+        const { container } = await renderPrivateAi();
+
+        expect(container.querySelector('.messages-two-pane')).toBeFalsy();
+        expect(container.textContent).toContain('What do you need from ALL PLAYS?');
+        expect(container.textContent).toContain('What do I need to handle today?');
+        expect(container.textContent).toContain('What is my next game?');
+        expect(container.textContent).toContain('Show unread team messages');
+        expect(container.textContent).toContain('Who still needs an RSVP?');
+    });
+
+    it('sends a mobile starter prompt through the private AI service', async () => {
+        layoutMocks.isDesktopWeb = false;
+        privateAiMocks.loadPrivateAiMessages.mockResolvedValueOnce([]);
+
+        const { container } = await renderPrivateAi();
+        const starter = Array.from(container.querySelectorAll('.private-ai-starter-prompt')).find((button) => button.textContent.includes('What do I need to handle today?'));
+        await click(starter);
+
+        expect(privateAiMocks.sendPrivateAiMessage).toHaveBeenCalledWith(auth.user, 'What do I need to handle today?', 'default');
     });
 
     it('starts a new conversation and loads that thread', async () => {


### PR DESCRIPTION
Closes #1389

## Summary
- Adds four high-value starter prompts directly to the empty Private AI welcome state on mobile and desktop.
- Routes starter prompt taps through the same send flow as manual messages, including optimistic message handling, sending state, error restoration, and conversation refresh.
- Updates the desktop prompt rail behavior to send selected suggestions instead of only copying text into the composer.

## Tests
- `npx vitest run tests/unit/app-private-ai-integration.test.jsx --reporter=verbose`
- `npm test`