### PR TITLE
Show registration fee breakdown

### DIFF
--- a/apps/app/src/pages/RegistrationDetail.tsx
+++ b/apps/app/src/pages/RegistrationDetail.tsx
@@ -7,6 +7,7 @@ import type { ParentRegistrationCard, ParentRegistrationDetailModel } from '../l
 import {
   calculateRegistrationFeeSnapshot,
   decideRegistrationPlacement,
+  formatFeeSnapshotLines,
   getActiveRegistrationOptions,
   getPaymentPlanChoices,
   requiresRegistrationOption
@@ -14,6 +15,7 @@ import {
 import type { AuthState } from '../lib/types';
 
 type FieldErrors = Record<string, string>;
+type FeeSummaryLine = { label: string; amountCents: number; strong?: boolean };
 
 export function RegistrationDetail({ auth }: { auth: AuthState }) {
   const { teamId = '', formId = '' } = useParams();
@@ -73,7 +75,8 @@ export function RegistrationDetail({ auth }: { auth: AuthState }) {
     if (!form || !requiresRegistrationOption(form) || !selectedOptionId) return null;
     return decideRegistrationPlacement({ form, selectedOptionId, counts: form.registrationOptionCounts || {} });
   }, [form, selectedOptionId]);
-  const feeSnapshot = useMemo(() => form ? (form.feeSnapshot || calculateRegistrationFeeSnapshot(form, { quantity, now: new Date() })) : null, [form, quantity]);
+  const displayFeeSnapshot = useMemo(() => form ? calculateRegistrationFeeSnapshot(form, { quantity, now: new Date() }) : null, [form, quantity]);
+  const displayFeeLines = useMemo<FeeSummaryLine[]>(() => displayFeeSnapshot ? formatFeeSnapshotLines(displayFeeSnapshot) : [], [displayFeeSnapshot]);
 
   const updateParticipant = (fieldId: string, value: string) => setParticipant((current) => ({ ...current, [fieldId]: value }));
   const updateGuardian = (fieldId: string, value: string) => setGuardian((current) => ({ ...current, [fieldId]: value }));
@@ -231,7 +234,19 @@ export function RegistrationDetail({ auth }: { auth: AuthState }) {
             </div>
           ) : null}
 
-          {feeSnapshot ? <div className="rounded-xl border border-gray-200 bg-gray-50 p-3 text-sm font-black text-gray-900">Total due: {formatMoney(feeSnapshot.finalAmountDueCents, form.currency)}</div> : null}
+          {displayFeeSnapshot ? (
+            <div className="rounded-xl border border-gray-200 bg-gray-50 p-3 text-sm text-gray-900" aria-label="Registration fee summary">
+              <div className="mb-2 text-xs font-black uppercase tracking-wide text-gray-500">Fee summary</div>
+              <div className="grid gap-1.5">
+                {displayFeeLines.map((line, index) => (
+                  <div key={`${line.label}-${index}`} className={`flex items-center justify-between gap-3 ${line.strong ? 'border-t border-gray-200 pt-2 text-base font-black text-gray-950' : 'font-semibold text-gray-700'}`}>
+                    <span>{line.label}</span>
+                    <span className="tabular-nums">{formatMoney(line.amountCents, displayFeeSnapshot.currency || form.currency)}</span>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null}
 
           <button type="button" className="primary-button" onClick={submit} disabled={saving || Boolean(message)}>
             {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Send className="h-4 w-4" aria-hidden="true" />}

--- a/apps/app/src/pages/RegistrationDetail.tsx
+++ b/apps/app/src/pages/RegistrationDetail.tsx
@@ -297,6 +297,7 @@ async function loadRegistrationForm(user: any, teamId: string, formId: string): 
         description: detail.form.description || '',
         season: detail.form.season || '',
         currency: detail.form.currency || 'USD',
+        feeAmountCents: detail.form.feeAmountCents ?? detail.feeSnapshot?.originalFeeAmountCents ?? detail.feeSnapshot?.finalAmountDueCents ?? 0,
         feeLabel: detail.feeSnapshot?.finalAmountDueCents ? formatMoney(detail.feeSnapshot.finalAmountDueCents, detail.form.currency) : '',
         paymentNotice: detail.paymentNotice || '',
         onlineCheckout: detail.onlineCheckout,

--- a/tests/unit/app-registration-detail.test.jsx
+++ b/tests/unit/app-registration-detail.test.jsx
@@ -28,7 +28,19 @@ const registrationFlowMocks = vi.hoisted(() => ({
     selectedOption: params.selectedOptionId ? { id: params.selectedOptionId, countKey: params.selectedOptionId } : null,
     nextCounts: { enrolled: 1, waitlisted: 0 },
   })),
-  calculateRegistrationFeeSnapshot: vi.fn(() => ({ finalAmountDueCents: 10000, currency: 'USD' })),
+  calculateRegistrationFeeSnapshot: vi.fn((form = {}, options = {}) => {
+    const quantity = Math.max(1, Number(options.quantity || 1));
+    const originalFeeAmountCents = Number(form.feeAmountCents || 10000);
+    const subtotalAmountCents = originalFeeAmountCents * quantity;
+    const appliedDiscounts = quantity >= 2 ? [{ id: 'sibling', label: 'Sibling discount', amountCents: 2500 }] : [];
+    const finalAmountDueCents = subtotalAmountCents - appliedDiscounts.reduce((sum, discount) => sum + discount.amountCents, 0);
+    return { originalFeeAmountCents, subtotalAmountCents, appliedDiscounts, finalAmountDueCents, currency: form.currency || 'USD' };
+  }),
+  formatFeeSnapshotLines: vi.fn((snapshot = {}) => ([
+    { label: 'Original fee', amountCents: snapshot.subtotalAmountCents ?? snapshot.originalFeeAmountCents ?? 0 },
+    ...(snapshot.appliedDiscounts || []).map((discount) => ({ label: discount.label, amountCents: -Math.abs(Number(discount.amountCents || 0)) })),
+    { label: 'Final amount due', amountCents: snapshot.finalAmountDueCents ?? 0, strong: true },
+  ])),
   getPaymentPlanChoices: vi.fn(() => ([{ id: 'pay_full', title: 'Pay in full' }])),
   getActiveRegistrationOptions: vi.fn(() => ([{ id: 'opt-1', title: 'Option 1', capacityLimit: 10 }])),
   requiresRegistrationOption: vi.fn(() => true),
@@ -109,9 +121,16 @@ async function changeInputValue(container, labelText, value) {
   if (!input) throw new Error(`Input with label "${labelText}" not found.`);
   await act(async () => {
     if (input.type === 'checkbox') {
-      input.checked = value;
+      const checkedSetter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'checked')?.set;
+      checkedSetter?.call(input, value);
     } else {
-      input.value = value;
+      const prototype = input instanceof window.HTMLSelectElement
+        ? window.HTMLSelectElement.prototype
+        : input instanceof window.HTMLTextAreaElement
+          ? window.HTMLTextAreaElement.prototype
+          : window.HTMLInputElement.prototype;
+      const valueSetter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
+      valueSetter?.call(input, value);
     }
     input.dispatchEvent(new Event('input', { bubbles: true }));
     input.dispatchEvent(new Event('change', { bubbles: true }));
@@ -481,6 +500,54 @@ describe('RegistrationDetail page', () => {
       'USD'
     );
     expect(publicActionsMocks.openPublicUrl).toHaveBeenCalledWith('https://checkout.stripe.com/c/pay-reg-1');
+  });
+
+  it('renders fee summary rows and updates them when quantity changes', async () => {
+    const { container } = await renderRegistrationDetail();
+    await waitForText(container, 'Summer Camp');
+
+    expect(container.textContent).toContain('Fee summary');
+    expect(container.textContent).toContain('Original fee');
+    expect(container.textContent).toContain('$100.00');
+    expect(container.textContent).toContain('Final amount due');
+
+    await changeInputValue(container, 'Quantity', '2');
+
+    expect(container.textContent).toContain('Sibling discount');
+    expect(container.textContent).toContain('-$25.00');
+    expect(container.textContent).toContain('$175.00');
+  });
+
+  it('does not let a loaded fee snapshot freeze the displayed quantity total', async () => {
+    parentToolsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
+      {
+        id: 'form-1',
+        teamId: 'team-1',
+        teamName: 'Bears',
+        programName: 'Summer Camp',
+        season: 'Summer',
+        currency: 'USD',
+        feeAmountCents: 10000,
+        feeSnapshot: { originalFeeAmountCents: 10000, subtotalAmountCents: 10000, appliedDiscounts: [], finalAmountDueCents: 10000, currency: 'USD' },
+        onlineCheckout: false,
+        options: [{ id: 'opt-1', title: 'Option 1' }],
+        registrationOptionCounts: { 'opt-1': { enrolled: 0, waitlisted: 0 } },
+        participantFields: [{ id: 'name', label: 'Participant Name', type: 'text', required: true }],
+        guardianFields: [{ id: 'name', label: 'Guardian Name', type: 'text', required: true }],
+        waiverText: 'I agree to the terms and conditions.',
+      },
+    ]);
+
+    const { container } = await renderRegistrationDetail();
+    await waitForText(container, 'Summer Camp');
+    await changeInputValue(container, 'Quantity', '3');
+
+    expect(registrationFlowMocks.calculateRegistrationFeeSnapshot).toHaveBeenLastCalledWith(
+      expect.objectContaining({ feeSnapshot: expect.objectContaining({ finalAmountDueCents: 10000 }) }),
+      expect.objectContaining({ quantity: 3, now: expect.any(Date) })
+    );
+    expect(container.textContent).toContain('Sibling discount');
+    expect(container.textContent).toContain('$275.00');
   });
 
   it('uses the server-returned registration fee for checkout', async () => {


### PR DESCRIPTION
Closes #1393

## Summary
- Replaced the one-line registration total with a compact fee summary card.
- Recalculate displayed fee rows from the current quantity so discounts update live.
- Keep submit and checkout fee snapshot behavior unchanged.

## Validation
- `npx vitest run tests/unit/app-registration-detail.test.jsx --reporter=verbose`
- `npm run app:build`