### PR TITLE
Add team staff permissions overview

### DIFF
--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -295,6 +295,23 @@ async function loadTeamConfigs(teamId: string) {
   ).catch(() => []);
 }
 
+function getExpirationTime(expiresAt: any): number | null {
+  if (expiresAt == null) return null;
+  if (typeof expiresAt?.toMillis === 'function') return expiresAt.toMillis();
+  if (expiresAt instanceof Date) return expiresAt.getTime();
+  const expiresAtMs = Number(expiresAt);
+  return Number.isFinite(expiresAtMs) ? expiresAtMs : null;
+}
+
+function isPendingAdminInvite(invite: any) {
+  if (invite?.type !== 'admin_invite') return false;
+  if (invite.used === true || invite.revoked === true || invite.active === false) return false;
+  const status = cleanString(invite.status).toLowerCase();
+  if (status && !['active', 'pending'].includes(status)) return false;
+  const expiresAtMs = getExpirationTime(invite.expiresAt);
+  return expiresAtMs == null || Date.now() < expiresAtMs;
+}
+
 async function loadPendingAdminInvites(teamId: string) {
   return readWithNativeFallback(
     `pending admin invites ${teamId}`,
@@ -304,7 +321,7 @@ async function loadPendingAdminInvites(teamId: string) {
     },
     async () => nativeRunQuery('accessCodes', 'teamId', 'EQUAL', teamId)
   ).then((invites: any[]) => (Array.isArray(invites) ? invites : [])
-    .filter((invite) => invite?.type === 'admin_invite' && invite?.used !== true));
+    .filter(isPendingAdminInvite));
 }
 
 export async function loadParentTeamDetail(teamId: string, user: AuthUser | null): Promise<TeamDetailModel> {

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -9,10 +9,13 @@ import {
   getPublicTrackingItems,
   getTeam
 } from '../../../../js/db.js';
+import { collection, db, getDocs, query, where } from '../../../../js/firebase.js';
 import { calculateSeasonRecord, listSeasonLabels } from '../../../../js/season-record.js';
 import { computeNativeStandings } from '../../../../js/native-standings.js';
 import { buildPlayerLeaderboardSnapshot, selectAnalyticsConfig } from '../../../../js/stat-leaderboards.js';
 import { getVisiblePlayerTrackingSummary } from '../../../../js/player-tracking-summary.js';
+import { hasFullTeamAccess } from '../../../../js/team-access.js';
+import { buildTeamStaffPermissionsViewModel } from '../../../../js/team-staff-permissions.js';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import type { AuthUser } from './types';
 
@@ -73,6 +76,18 @@ export type TeamDetailSponsor = {
   websiteUrl: string | null;
 };
 
+export type TeamStaffPermissionsSummary = {
+  staff: Array<{ label: string; role: string }>;
+  pendingInvites: string[];
+  helperPermissions: Array<{
+    key: string;
+    title: string;
+    grants: string[];
+    emptyText: string;
+  }>;
+  hasAnyStaff: boolean;
+};
+
 export type TeamDetailModel = {
   team: {
     id: string;
@@ -85,6 +100,7 @@ export type TeamDetailModel = {
     bracketUrl: string | null;
     streamUrl: string | null;
     websiteUrl: string;
+    editTeamUrl: string;
     mediaUrl: string;
     registrationProvider: Array<{ label: string; value: string }>;
   };
@@ -110,6 +126,7 @@ export type TeamDetailModel = {
   leaderboards: TeamDetailLeaderboard[];
   trackingSummaries: TeamDetailTrackingSummary[];
   sponsors: TeamDetailSponsor[];
+  staffPermissions: TeamStaffPermissionsSummary | null;
   counts: {
     games: number;
     practices: number;
@@ -153,9 +170,13 @@ async function getNativeHeaders() {
   };
 }
 
-async function nativeFirestoreRequest(path: string) {
+async function nativeFirestoreRequest(path: string, init: RequestInit = {}) {
   const response = await withTimeout(fetch(`${getFirestoreBaseUrl()}${path}`, {
-    headers: await getNativeHeaders()
+    ...init,
+    headers: {
+      ...(await getNativeHeaders()),
+      ...(init.headers || {})
+    }
   }), 'Firestore REST request');
   const payload = await response.json().catch(() => ({}));
   if (!response.ok) {
@@ -210,6 +231,28 @@ async function nativeListCollection(path: string) {
     .filter(Boolean) as FirestoreDocument[];
 }
 
+async function nativeRunQuery(collectionId: string, fieldPath: string, op: 'EQUAL' | 'ARRAY_CONTAINS', value: string) {
+  const payload = await nativeFirestoreRequest(':runQuery', {
+    method: 'POST',
+    body: JSON.stringify({
+      structuredQuery: {
+        from: [{ collectionId }],
+        where: {
+          fieldFilter: {
+            field: { fieldPath },
+            op,
+            value: { stringValue: value }
+          }
+        }
+      }
+    })
+  });
+
+  return Array.isArray(payload)
+    ? payload.map((entry: any) => decodeFirestoreDocument(entry.document)).filter(Boolean) as FirestoreDocument[]
+    : [];
+}
+
 async function readWithNativeFallback<T>(label: string, primary: () => Promise<T>, fallback: () => Promise<T>): Promise<T> {
   try {
     return await withTimeout(Promise.resolve(primary()), label);
@@ -252,6 +295,18 @@ async function loadTeamConfigs(teamId: string) {
   ).catch(() => []);
 }
 
+async function loadPendingAdminInvites(teamId: string) {
+  return readWithNativeFallback(
+    `pending admin invites ${teamId}`,
+    async () => {
+      const snapshot = await getDocs(query(collection(db, 'accessCodes'), where('teamId', '==', teamId)));
+      return snapshot.docs.map((docSnap: any) => ({ id: docSnap.id, ...(docSnap.data() || {}) }));
+    },
+    async () => nativeRunQuery('accessCodes', 'teamId', 'EQUAL', teamId)
+  ).then((invites: any[]) => (Array.isArray(invites) ? invites : [])
+    .filter((invite) => invite?.type === 'admin_invite' && invite?.used !== true));
+}
+
 export async function loadParentTeamDetail(teamId: string, user: AuthUser | null): Promise<TeamDetailModel> {
   const [team, players, games, configs] = await Promise.all([
     loadTeamDocument(teamId),
@@ -261,6 +316,9 @@ export async function loadParentTeamDetail(teamId: string, user: AuthUser | null
   ]);
 
   if (!team) throw new Error('Team not found.');
+
+  const canManageTeam = hasFullTeamAccess(user, team);
+  const pendingAdminInvites = canManageTeam ? await loadPendingAdminInvites(teamId).catch(() => []) : [];
 
   const linkedPlayerIds = getLinkedPlayerIds(user, teamId, players);
   const completedGameIds = (Array.isArray(games) ? games : [])
@@ -287,7 +345,8 @@ export async function loadParentTeamDetail(teamId: string, user: AuthUser | null
     seasonStatsByPlayerId,
     trackingItems,
     trackingStatuses,
-    sponsors: [...normalizeSponsorList(adSponsors), ...normalizeSponsorList(localSponsors)]
+    sponsors: [...normalizeSponsorList(adSponsors), ...normalizeSponsorList(localSponsors)],
+    pendingAdminInvites
   });
 }
 
@@ -302,7 +361,8 @@ export function buildTeamDetailModel({
   seasonStatsByPlayerId = {},
   trackingItems = [],
   trackingStatuses = [],
-  sponsors = []
+  sponsors = [],
+  pendingAdminInvites = []
 }: {
   teamId: string;
   team: Record<string, any>;
@@ -315,6 +375,7 @@ export function buildTeamDetailModel({
   trackingItems?: any[];
   trackingStatuses?: any[];
   sponsors?: TeamDetailSponsor[];
+  pendingAdminInvites?: any[];
 }): TeamDetailModel {
   const normalizedPlayers = normalizePlayers(players, linkedPlayerIds);
   const normalizedEvents = normalizeEvents(games);
@@ -326,6 +387,9 @@ export function buildTeamDetailModel({
   const standings = buildStandings(team, games);
   const leaderboards = buildLeaderboards(configs, normalizedPlayers, seasonStatsByPlayerId, team?.sport);
   const trackingSummaries = buildTrackingSummaries(normalizedPlayers, linkedPlayerIds, trackingItems, trackingStatuses);
+  const staffPermissions = hasFullTeamAccess(user, team)
+    ? buildTeamStaffPermissionsViewModel({ ...team, id: teamId }, pendingAdminInvites)
+    : null;
 
   return {
     team: {
@@ -339,6 +403,7 @@ export function buildTeamDetailModel({
       bracketUrl: getFirstUrl(team?.bracketUrl),
       streamUrl: getStreamUrl(team),
       websiteUrl: getPublicHashUrl('team.html', teamId),
+      editTeamUrl: getPublicHashUrl('edit-team.html', teamId),
       mediaUrl: getPublicHashUrl('team-media.html', teamId),
       registrationProvider: getRegistrationProviderDetails(team, teamId)
     },
@@ -359,6 +424,7 @@ export function buildTeamDetailModel({
     leaderboards,
     trackingSummaries,
     sponsors: sponsors.slice(0, 4),
+    staffPermissions,
     counts: {
       games: games.filter((game: any) => game?.type !== 'practice').length,
       practices: games.filter((game: any) => game?.type === 'practice').length,

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -338,6 +338,8 @@ function InsightsTab({ model }: { model: TeamDetailModel }) {
 function MoreTab({ model }: { model: TeamDetailModel }) {
   return (
     <div className="space-y-4">
+      {model.staffPermissions ? <StaffPermissionsCard model={model} /> : null}
+
       <section className="app-card p-4">
         <div className="text-sm font-black text-gray-950">Team links</div>
         <div className="mt-3 grid gap-2 sm:grid-cols-2">
@@ -390,6 +392,62 @@ function MoreTab({ model }: { model: TeamDetailModel }) {
           </div>
         </section>
       ) : null}
+    </div>
+  );
+}
+
+function StaffPermissionsCard({ model }: { model: TeamDetailModel }) {
+  const summary = model.staffPermissions;
+  if (!summary) return null;
+  const staffItems = [
+    ...summary.staff.map((member) => `${member.label} · ${member.role}`),
+    ...summary.pendingInvites.map((email) => `${email} · Pending admin invite`)
+  ];
+
+  return (
+    <section className="app-card p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-sm font-black text-gray-950">Team Staff &amp; Permissions</div>
+          <div className="mt-1 text-xs font-semibold leading-5 text-gray-500">Full admins can manage the team. Scoped helpers only cover game-day jobs like scorekeeping, Stream &amp; Score, video, and volunteer tasks.</div>
+        </div>
+        <button type="button" className="ghost-button !min-h-9 flex-none text-xs" onClick={() => openPublicUrl(model.team.editTeamUrl)}>
+          Manage staff
+          <ExternalLink className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+
+      <div className="mt-4 grid gap-3 lg:grid-cols-2">
+        <div className="rounded-xl border border-indigo-100 bg-indigo-50 p-3">
+          <div className="text-[11px] font-black uppercase tracking-[0.04em] text-indigo-700">Owner, admins, and invites</div>
+          <PillList items={staffItems} emptyText="No owner, admin staff, or pending admin invites found." tone="border-indigo-200 bg-white text-indigo-800" />
+        </div>
+        <div className="rounded-xl border border-emerald-100 bg-emerald-50 p-3">
+          <div className="text-[11px] font-black uppercase tracking-[0.04em] text-emerald-700">Admin vs game-day helpers</div>
+          <p className="mt-2 text-xs font-semibold leading-5 text-emerald-800">Stream &amp; Score means scorekeeping plus streaming capability. It does not grant roster, schedule, RSVP, scoring setup, or full team settings access.</p>
+        </div>
+      </div>
+
+      <div className="mt-3 grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        {summary.helperPermissions.map((permission) => (
+          <div key={permission.key} className="rounded-xl border border-gray-200 bg-gray-50 p-3">
+            <div className="text-[11px] font-black uppercase tracking-[0.04em] text-gray-700">{permission.title}</div>
+            <PillList items={permission.grants} emptyText={permission.emptyText} />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function PillList({ items, emptyText, tone = 'border-gray-200 bg-white text-gray-700' }: { items: string[]; emptyText: string; tone?: string }) {
+  if (!items.length) {
+    return <div className="mt-2 rounded-lg border border-dashed border-gray-300 bg-white/70 p-3 text-xs font-semibold italic text-gray-500">{emptyText}</div>;
+  }
+
+  return (
+    <div className="mt-2 flex flex-wrap gap-2">
+      {items.map((item) => <span key={item} className={`rounded-full border px-2.5 py-1 text-xs font-black ${tone}`}>{item}</span>)}
     </div>
   );
 }

--- a/docs/pr-notes/runs/1398-remediator-20260526T055303Z/architecture.md
+++ b/docs/pr-notes/runs/1398-remediator-20260526T055303Z/architecture.md
@@ -1,0 +1,5 @@
+# Architecture
+
+- Keep filtering local to `loadPendingAdminInvites` so the Staff & Permissions view model receives only displayable pending invite records.
+- Support Firestore timestamp shapes already used by access-code validation: `toMillis()`, `Date`, and numeric milliseconds.
+- No schema or query/index changes; blast radius is limited to the React team detail service pending-invite read path.

--- a/docs/pr-notes/runs/1398-remediator-20260526T055303Z/code-plan.md
+++ b/docs/pr-notes/runs/1398-remediator-20260526T055303Z/code-plan.md
@@ -1,0 +1,5 @@
+# Code Plan
+
+- Add small invite-expiration and pending-invite predicate helpers in `apps/app/src/lib/teamDetailService.ts`.
+- Replace the loose `type === admin_invite && used !== true` filter with the stricter predicate.
+- Extend the existing pending-admin-invites unit test to verify stale/non-active invites are filtered out.

--- a/docs/pr-notes/runs/1398-remediator-20260526T055303Z/qa.md
+++ b/docs/pr-notes/runs/1398-remediator-20260526T055303Z/qa.md
@@ -1,0 +1,4 @@
+# QA
+
+- Add regression coverage in `tests/unit/app-team-detail-service.test.js` for future, expired, revoked, inactive, cancelled-status, used, and non-admin invite records.
+- Run targeted Vitest file: `npx vitest run tests/unit/app-team-detail-service.test.js --reporter=verbose`.

--- a/docs/pr-notes/runs/1398-remediator-20260526T055303Z/requirements.md
+++ b/docs/pr-notes/runs/1398-remediator-20260526T055303Z/requirements.md
@@ -1,0 +1,6 @@
+# Requirements
+
+- Staff & Permissions pending admin invites must include only unused `admin_invite` records for the current team that are still valid.
+- Expired invites must be excluded because redemption rejects them after the 7-day validity window.
+- Non-active invites, including revoked, explicitly inactive, or cancelled/non-pending statuses, must not appear.
+- Parent/non-manager users must not trigger invite loading.

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -193,8 +193,18 @@ describe('React app team detail model', () => {
         getAggregatedStatsForGames.mockResolvedValue({});
         getAdSpaceSponsors.mockResolvedValue([]);
         getLocalAttractionSponsors.mockResolvedValue([]);
+        const future = Date.now() + 60_000;
+        const past = Date.now() - 60_000;
         getDocs.mockResolvedValue({
-            docs: [{ id: 'invite-1', data: () => ({ email: 'pending@example.com', teamId: 'team-1', type: 'admin_invite', used: false }) }]
+            docs: [
+                { id: 'invite-1', data: () => ({ email: 'pending@example.com', teamId: 'team-1', type: 'admin_invite', used: false, expiresAt: { toMillis: () => future } }) },
+                { id: 'invite-2', data: () => ({ email: 'expired@example.com', teamId: 'team-1', type: 'admin_invite', used: false, expiresAt: { toMillis: () => past } }) },
+                { id: 'invite-3', data: () => ({ email: 'revoked@example.com', teamId: 'team-1', type: 'admin_invite', used: false, revoked: true, expiresAt: { toMillis: () => future } }) },
+                { id: 'invite-4', data: () => ({ email: 'inactive@example.com', teamId: 'team-1', type: 'admin_invite', used: false, active: false, expiresAt: { toMillis: () => future } }) },
+                { id: 'invite-5', data: () => ({ email: 'cancelled@example.com', teamId: 'team-1', type: 'admin_invite', used: false, status: 'cancelled', expiresAt: { toMillis: () => future } }) },
+                { id: 'invite-6', data: () => ({ email: 'used@example.com', teamId: 'team-1', type: 'admin_invite', used: true, expiresAt: { toMillis: () => future } }) },
+                { id: 'invite-7', data: () => ({ email: 'standard@example.com', teamId: 'team-1', type: 'standard', used: false, expiresAt: { toMillis: () => future } }) }
+            ]
         });
 
         const adminModel = await loadParentTeamDetail('team-1', { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] });

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { describe, expect, it, vi } from 'vitest';
 
 vi.mock('../../js/db.js', () => ({
@@ -12,12 +13,22 @@ vi.mock('../../js/db.js', () => ({
     getTeam: vi.fn()
 }));
 
+vi.mock('../../js/firebase.js', () => ({
+    collection: vi.fn((db, name) => ({ db, name })),
+    db: {},
+    getDocs: vi.fn(),
+    query: vi.fn((...parts) => parts),
+    where: vi.fn((field, op, value) => ({ field, op, value }))
+}));
+
 vi.mock('../../apps/app/src/lib/authService.ts', () => ({
     firebaseAuth: { app: { options: { projectId: 'demo-allplays' } } },
     getNativeAuthIdToken: vi.fn()
 }));
 
-import { buildTeamDetailModel } from '../../apps/app/src/lib/teamDetailService.ts';
+import { buildTeamDetailModel, loadParentTeamDetail } from '../../apps/app/src/lib/teamDetailService.ts';
+import { getDocs } from '../../js/firebase.js';
+import { getAggregatedStatsForGames, getAdSpaceSponsors, getConfigs, getGames, getLocalAttractionSponsors, getPlayers, getTeam } from '../../js/db.js';
 
 describe('React app team detail model', () => {
     it('projects team.html parent features into the native team model', () => {
@@ -115,6 +126,7 @@ describe('React app team detail model', () => {
         expect(model.team.photoUrl).toBe('https://img.example.test/logo.png');
         expect(model.team.streamUrl).toBe('https://twitch.tv/allplayslive');
         expect(model.team.websiteUrl).toBe('https://allplays.ai/team.html#teamId=team%2Fwith+slash');
+        expect(model.team.editTeamUrl).toBe('https://allplays.ai/edit-team.html#teamId=team%2Fwith+slash');
         expect(model.team.mediaUrl).toBe('https://allplays.ai/team-media.html#teamId=team%2Fwith+slash');
         expect(model.team.registrationProvider).toEqual([
             { label: 'Provider', value: 'League Apps' },
@@ -128,5 +140,70 @@ describe('React app team detail model', () => {
         expect(model.recentResults.map((event) => event.id)).toEqual(['scored-past', 'final-game']);
         expect(model.counts).toMatchObject({ games: 4, practices: 1, completedGames: 1 });
         expect(model.sponsors.map((sponsor) => sponsor.id)).toEqual(['s1', 's2', 's3', 's4']);
+    });
+
+    it('adds staff permissions only for users with full team access', () => {
+        const team = {
+            ownerId: 'owner-1',
+            ownerEmail: 'Owner@Example.com',
+            adminEmails: [' Coach@Example.com ', 'coach@example.com'],
+            teamPermissions: {
+                scorekeeping: { mode: 'selected', memberIds: ['scorekeeper-1', 'scorekeeper-1'] },
+                streaming: { mode: 'selected', memberIds: ['scorekeeper-1', 'video-1'] },
+                volunteer: { mode: 'selected', memberIds: ['snacks-1'] }
+            },
+            streamVolunteerEmails: ['video@example.com']
+        };
+
+        const adminModel = buildTeamDetailModel({
+            teamId: 'team-1',
+            team,
+            user: { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] },
+            pendingAdminInvites: [
+                { email: 'pending@example.com', type: 'admin_invite', used: false },
+                { email: 'used@example.com', type: 'admin_invite', used: true }
+            ]
+        });
+
+        expect(adminModel.staffPermissions.staff).toEqual([
+            { label: 'owner@example.com', role: 'Owner' },
+            { label: 'coach@example.com', role: 'Admin' }
+        ]);
+        expect(adminModel.staffPermissions.pendingInvites).toEqual(['pending@example.com']);
+        expect(adminModel.staffPermissions.helperPermissions).toEqual([
+            expect.objectContaining({ key: 'scorekeeper', grants: ['scorekeeper-1'] }),
+            expect.objectContaining({ key: 'stream-score', grants: ['scorekeeper-1'] }),
+            expect.objectContaining({ key: 'videographer', grants: ['scorekeeper-1', 'video-1', 'video@example.com'] }),
+            expect.objectContaining({ key: 'volunteer', grants: ['snacks-1'] })
+        ]);
+
+        const parentModel = buildTeamDetailModel({
+            teamId: 'team-1',
+            team,
+            user: { uid: 'parent-1', email: 'parent@example.com', displayName: 'Parent', roles: ['parent'] }
+        });
+        expect(parentModel.staffPermissions).toBeNull();
+    });
+
+    it('loads pending admin invites for team admins but not parent members', async () => {
+        getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears', ownerId: 'owner-1', adminEmails: ['coach@example.com'] });
+        getPlayers.mockResolvedValue([]);
+        getGames.mockResolvedValue([]);
+        getConfigs.mockResolvedValue([]);
+        getAggregatedStatsForGames.mockResolvedValue({});
+        getAdSpaceSponsors.mockResolvedValue([]);
+        getLocalAttractionSponsors.mockResolvedValue([]);
+        getDocs.mockResolvedValue({
+            docs: [{ id: 'invite-1', data: () => ({ email: 'pending@example.com', teamId: 'team-1', type: 'admin_invite', used: false }) }]
+        });
+
+        const adminModel = await loadParentTeamDetail('team-1', { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] });
+        expect(adminModel.staffPermissions.pendingInvites).toEqual(['pending@example.com']);
+        expect(getDocs).toHaveBeenCalledTimes(1);
+
+        getDocs.mockClear();
+        const parentModel = await loadParentTeamDetail('team-1', { uid: 'parent-1', email: 'parent@example.com', displayName: 'Parent', roles: ['parent'] });
+        expect(parentModel.staffPermissions).toBeNull();
+        expect(getDocs).not.toHaveBeenCalled();
     });
 });

--- a/tests/unit/app-team-detail-staff-permissions.test.jsx
+++ b/tests/unit/app-team-detail-staff-permissions.test.jsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+import React, { act } from '../../apps/app/node_modules/react/index.js';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createRoot } from '../../apps/app/node_modules/react-dom/client.js';
+import { MemoryRouter, Route, Routes } from '../../apps/app/node_modules/react-router-dom/dist/index.mjs';
+
+const teamDetailMocks = vi.hoisted(() => ({
+    loadParentTeamDetail: vi.fn()
+}));
+const publicActionMocks = vi.hoisted(() => ({
+    openPublicUrl: vi.fn()
+}));
+
+vi.mock('../../apps/app/src/lib/teamDetailService.ts', () => teamDetailMocks);
+vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionMocks);
+
+import { TeamDetail } from '../../apps/app/src/pages/TeamDetail.tsx';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const auth = {
+    user: { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] },
+    profile: {},
+    loading: false,
+    error: null,
+    roles: ['coach'],
+    isParent: false,
+    isCoach: true,
+    isAdmin: false,
+    isPlatformAdmin: false,
+    refresh: async () => {},
+    signOut: async () => {}
+};
+
+function makeModel(staffPermissions) {
+    return {
+        team: {
+            id: 'team-1',
+            name: 'Bears',
+            sport: 'Basketball',
+            photoUrl: null,
+            description: '',
+            zip: '',
+            leagueUrl: null,
+            bracketUrl: null,
+            streamUrl: null,
+            websiteUrl: 'https://allplays.ai/team.html#teamId=team-1',
+            editTeamUrl: 'https://allplays.ai/edit-team.html#teamId=team-1',
+            mediaUrl: 'https://allplays.ai/team-media.html#teamId=team-1',
+            registrationProvider: []
+        },
+        players: [],
+        linkedPlayers: [],
+        upcomingEvents: [],
+        recentResults: [],
+        nextEvent: null,
+        record: { label: '2026', wins: 0, losses: 0, ties: 0, gamesPlayed: 0, winPercentage: null },
+        standings: { enabled: false, label: 'No standings configured', rows: [], currentRow: null },
+        leaderboards: [],
+        trackingSummaries: [],
+        sponsors: [],
+        staffPermissions,
+        counts: { games: 0, practices: 0, completedGames: 0 }
+    };
+}
+
+async function renderTeamDetail(staffPermissions) {
+    teamDetailMocks.loadParentTeamDetail.mockResolvedValue(makeModel(staffPermissions));
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+        root.render(React.createElement(
+            MemoryRouter,
+            { initialEntries: ['/teams/team-1'] },
+            React.createElement(
+                Routes,
+                null,
+                React.createElement(Route, { path: '/teams/:teamId', element: React.createElement(TeamDetail, { auth }) })
+            )
+        ));
+    });
+    await flush();
+    return { container, root };
+}
+
+async function flush() {
+    await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+    });
+}
+
+async function clickButton(container, text) {
+    const button = Array.from(container.querySelectorAll('button')).find((candidate) => candidate.textContent.includes(text));
+    if (!button) throw new Error(`Button not found: ${text}`);
+    await act(async () => {
+        button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+    await flush();
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    window.requestAnimationFrame = (callback) => {
+        callback(0);
+        return 0;
+    };
+    window.scrollTo = vi.fn();
+});
+
+describe('React app TeamDetail staff permissions overview', () => {
+    it('renders staff, pending invites, helper empty states, and manage fallback for admins', async () => {
+        const { container } = await renderTeamDetail({
+            staff: [{ label: 'owner@example.com', role: 'Owner' }, { label: 'coach@example.com', role: 'Admin' }],
+            pendingInvites: ['pending@example.com'],
+            helperPermissions: [
+                { key: 'scorekeeper', title: 'Scorekeeper', grants: ['scorekeeper-1'], emptyText: 'No scorekeeper helpers are assigned yet.' },
+                { key: 'stream-score', title: 'Stream & Score', grants: [], emptyText: 'No Stream & Score volunteers are assigned yet.' },
+                { key: 'videographer', title: 'Videographer', grants: ['video@example.com'], emptyText: 'No videographer helpers are assigned yet.' },
+                { key: 'volunteer', title: 'Volunteer', grants: [], emptyText: 'No general volunteer permissions are assigned yet.' }
+            ],
+            hasAnyStaff: true
+        });
+
+        await clickButton(container, 'More');
+
+        expect(container.textContent).toContain('Team Staff & Permissions');
+        expect(container.textContent).toContain('owner@example.com · Owner');
+        expect(container.textContent).toContain('pending@example.com · Pending admin invite');
+        expect(container.textContent).toContain('scorekeeper-1');
+        expect(container.textContent).toContain('No Stream & Score volunteers are assigned yet.');
+        expect(container.textContent).toContain('No general volunteer permissions are assigned yet.');
+
+        await clickButton(container, 'Manage staff');
+        expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://allplays.ai/edit-team.html#teamId=team-1');
+    });
+
+    it('hides staff permissions when the service omits the admin-only payload', async () => {
+        const { container } = await renderTeamDetail(null);
+
+        await clickButton(container, 'More');
+
+        expect(container.textContent).not.toContain('Team Staff & Permissions');
+        expect(container.textContent).not.toContain('owner@example.com');
+    });
+});


### PR DESCRIPTION
Closes #1397

## Summary
- Adds an admin-only Staff & Permissions card to React TeamDetail > More.
- Extends the team detail model with owner/admin staff, pending admin invites, scoped helper groups, and an edit-team fallback link.
- Reuses the legacy staff permissions view-model logic and keeps the section hidden for non-admin users.

## Validation
- `npx vitest run tests/unit/app-team-detail-service.test.js tests/unit/app-team-detail-staff-permissions.test.jsx tests/unit/team-staff-permissions.test.js --reporter=verbose`
- `npm run app:build`