### PR TITLE
Escape opponent search team fields

### DIFF
--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -1170,15 +1170,21 @@
                     <div class="px-3 py-2 text-gray-500">No teams found. Keep typing to add manually.</div>
                 `;
             } else {
-                opponentResults.innerHTML = matches.map(team => `
-                    <button type="button" class="w-full text-left px-3 py-2 hover:bg-indigo-50 flex items-center gap-2" data-team-id="${team.id}">
-                        ${team.photoUrl ? `<img src="${team.photoUrl}" alt="" class="w-6 h-6 rounded-full object-cover">` : `<div class="w-6 h-6 rounded-full bg-indigo-100 text-indigo-600 text-xs flex items-center justify-center font-semibold">${(team.name || '?')[0]}</div>`}
+                opponentResults.innerHTML = matches.map(team => {
+                    const teamName = team.name || 'Unnamed Team';
+                    const teamSport = team.sport || 'Sport not set';
+                    const teamInitial = teamName[0] || '?';
+                    const teamPhoto = team.photoUrl ? String(team.photoUrl) : '';
+                    return `
+                    <button type="button" class="w-full text-left px-3 py-2 hover:bg-indigo-50 flex items-center gap-2" data-team-id="${escapeHtml(team.id)}">
+                        ${teamPhoto ? `<img src="${escapeHtml(teamPhoto)}" alt="" class="w-6 h-6 rounded-full object-cover">` : `<div class="w-6 h-6 rounded-full bg-indigo-100 text-indigo-600 text-xs flex items-center justify-center font-semibold">${escapeHtml(teamInitial)}</div>`}
                         <div>
-                            <div class="font-medium text-gray-900">${team.name || 'Unnamed Team'}</div>
-                            <div class="text-xs text-gray-500">${team.sport || 'Sport not set'}</div>
+                            <div class="font-medium text-gray-900">${escapeHtml(teamName)}</div>
+                            <div class="text-xs text-gray-500">${escapeHtml(teamSport)}</div>
                         </div>
                     </button>
-                `).join('');
+                `;
+                }).join('');
             }
             opponentResults.classList.remove('hidden');
             opponentResults.querySelectorAll('[data-team-id]').forEach(btn => {

--- a/tests/unit/edit-schedule-opponent-search.test.js
+++ b/tests/unit/edit-schedule-opponent-search.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { escapeHtml } from '../../js/utils.js';
+
+function readEditSchedulePage() {
+    return readFileSync(new URL('../../edit-schedule.html', import.meta.url), 'utf8');
+}
+
+describe('edit schedule opponent search escaping', () => {
+    it('escapes team-controlled values before rendering opponent search results with innerHTML', () => {
+        const source = readEditSchedulePage();
+        const renderStart = source.indexOf('function renderOpponentResults(matches, term) {');
+        const renderEnd = source.indexOf('        checkAuth((user) => {', renderStart);
+
+        expect(renderStart).toBeGreaterThanOrEqual(0);
+        expect(renderEnd).toBeGreaterThan(renderStart);
+
+        const renderBlock = source.slice(renderStart, renderEnd);
+        expect(renderBlock).toContain('const teamName = team.name || \'Unnamed Team\';');
+        expect(renderBlock).toContain('const teamSport = team.sport || \'Sport not set\';');
+        expect(renderBlock).toContain('${escapeHtml(teamName)}');
+        expect(renderBlock).toContain('${escapeHtml(teamSport)}');
+        expect(renderBlock).toContain('${escapeHtml(teamInitial)}');
+        expect(renderBlock).toContain('data-team-id="${escapeHtml(team.id)}"');
+        expect(renderBlock).not.toContain('${team.name || \'Unnamed Team\'}');
+        expect(renderBlock).not.toContain('${team.sport || \'Sport not set\'}');
+    });
+
+    it('converts opponent search payloads to inert text', () => {
+        expect(escapeHtml(`<img src=x onerror=alert('xss')> Falcons`))
+            .toBe('&lt;img src=x onerror=alert(&#039;xss&#039;)&gt; Falcons');
+        expect(escapeHtml('Soccer <script>alert("xss")</script>'))
+            .toBe('Soccer &lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');
+    });
+});


### PR DESCRIPTION
Closes #1406

## Summary
- Escaped opponent search result team names, sports, initials, IDs, and photo URLs before rendering with `innerHTML`.
- Added regression coverage for the opponent search rendering path and XSS-style payload escaping.

## Validation
- `npx vitest run tests/unit/edit-schedule-opponent-search.test.js --reporter=verbose`