### PR TITLE
Add media type filters to team albums

### DIFF
--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -35,6 +35,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [model, setModel] = useState<TeamMediaModel | null>(null);
   const [activeFolderId, setActiveFolderId] = useState('');
+  const [selectedMediaType, setSelectedMediaType] = useState<MediaTypeFilter>('all');
   const [linkTitle, setLinkTitle] = useState('');
   const [linkUrl, setLinkUrl] = useState('');
   const [loading, setLoading] = useState(true);
@@ -68,6 +69,10 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
 
   const activeFolder = useMemo(() => model?.folders.find((folder) => folder.id === activeFolderId) || model?.folders[0] || null, [activeFolderId, model]);
   const allItems = useMemo(() => model?.folders.flatMap((folder) => folder.items.map((item) => ({ ...item, folderName: folder.name || 'Album' }))) || [], [model]);
+  const mediaTypeCounts = useMemo(() => getMediaTypeCounts(activeFolder?.items || []), [activeFolder]);
+  const filteredItems = useMemo(() => (activeFolder?.items || []).filter((item) => matchesMediaTypeFilter(item, selectedMediaType)), [activeFolder, selectedMediaType]);
+  const selectedMediaTypeLabel = MEDIA_TYPE_FILTERS.find((filter) => filter.id === selectedMediaType)?.label || 'All';
+  const emptyStateLabel = selectedMediaType === 'all' ? 'media' : selectedMediaTypeLabel.toLowerCase();
   const featured = activeFolder?.items[0] || allItems[0] || null;
 
   const uploadPhoto = async (file: File | null | undefined) => {
@@ -175,7 +180,10 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
               key={folder.id}
               type="button"
               className={`flex min-h-9 flex-none items-center gap-2 rounded-full border px-3 text-xs font-black ${activeFolder?.id === folder.id ? 'border-primary-600 bg-primary-600 text-white' : 'border-gray-200 bg-gray-50 text-gray-700'}`}
-              onClick={() => setActiveFolderId(folder.id)}
+              onClick={() => {
+                setActiveFolderId(folder.id);
+                setSelectedMediaType('all');
+              }}
               aria-pressed={activeFolder?.id === folder.id}
             >
               {folder.name || 'Album'}
@@ -228,8 +236,22 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
           </div>
           {activeFolder?.visibility ? <span className="rounded-full bg-gray-100 px-2 py-0.5 text-[10px] font-black uppercase text-gray-700">{activeFolder.visibility}</span> : null}
         </div>
+        <div className="mt-3 flex gap-1.5 overflow-x-auto" aria-label="Media type filters">
+          {MEDIA_TYPE_FILTERS.map((filter) => (
+            <button
+              key={filter.id}
+              type="button"
+              className={`flex min-h-9 flex-none items-center gap-2 rounded-full border px-3 text-xs font-black ${selectedMediaType === filter.id ? 'border-primary-600 bg-primary-600 text-white' : 'border-gray-200 bg-gray-50 text-gray-700'}`}
+              onClick={() => setSelectedMediaType(filter.id)}
+              aria-pressed={selectedMediaType === filter.id}
+            >
+              {filter.label}
+              <span className={`rounded-full px-1.5 py-0.5 text-[10px] ${selectedMediaType === filter.id ? 'bg-white/20 text-white' : 'bg-white text-gray-600'}`}>{mediaTypeCounts[filter.id]}</span>
+            </button>
+          ))}
+        </div>
         <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-          {activeFolder?.items.length ? activeFolder.items.map((item) => (
+          {filteredItems.length ? filteredItems.map((item) => (
             <MediaItemCard
               key={item.id}
               item={item}
@@ -239,12 +261,50 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
               }}
             />
           )) : (
-            <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">No media in this album yet.</div>
+            <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">No {emptyStateLabel} in this album.</div>
           )}
         </div>
       </section>
     </div>
   );
+}
+
+type MediaTypeFilter = 'all' | 'photos' | 'videos' | 'files';
+
+const MEDIA_TYPE_FILTERS: { id: MediaTypeFilter; label: string }[] = [
+  { id: 'all', label: 'All' },
+  { id: 'photos', label: 'Photos' },
+  { id: 'videos', label: 'Videos' },
+  { id: 'files', label: 'Files' }
+];
+
+function isPhotoMediaItem(item: TeamMediaItem) {
+  const type = String(item.type || '').toLowerCase();
+  return type === 'photo' || type.includes('image');
+}
+
+function isVideoMediaItem(item: TeamMediaItem) {
+  return String(item.type || '').toLowerCase() === 'video_link';
+}
+
+function isFileMediaItem(item: TeamMediaItem) {
+  return String(item.type || '').toLowerCase() === 'file';
+}
+
+function matchesMediaTypeFilter(item: TeamMediaItem, filter: MediaTypeFilter) {
+  if (filter === 'photos') return isPhotoMediaItem(item);
+  if (filter === 'videos') return isVideoMediaItem(item);
+  if (filter === 'files') return isFileMediaItem(item);
+  return true;
+}
+
+function getMediaTypeCounts(items: TeamMediaItem[]) {
+  return {
+    all: items.length,
+    photos: items.filter((item) => matchesMediaTypeFilter(item, 'photos')).length,
+    videos: items.filter((item) => matchesMediaTypeFilter(item, 'videos')).length,
+    files: items.filter((item) => matchesMediaTypeFilter(item, 'files')).length
+  };
 }
 
 function MediaItemCard({ item, onStatus }: { item: TeamMediaItem; onStatus: (tone: 'error' | 'success', message: string) => void }) {

--- a/docs/pr-notes/runs/1411-remediator-20260526T100305Z/architecture.md
+++ b/docs/pr-notes/runs/1411-remediator-20260526T100305Z/architecture.md
@@ -1,0 +1,62 @@
+## Current-State Read
+
+PR #1411 adds media-type filter chips to legacy `js/team-media.js`. The review issue is valid: the item reorder click handler builds its reorder list from `getFilteredItems(getItemsForFolder(...))` when a filter is active.
+
+`reorderTeamMediaItems(teamId, itemIds)` writes `order = index` for only the provided IDs. If the caller sends only photos/videos/files, hidden sibling items keep prior `order` values. That can create duplicate `order` values and unstable `sortByMediaOrder(...)` results after switching back to **All** or reloading.
+
+## Proposed Design
+
+Use filtering only for rendering.
+
+Minimal decision:
+
+- Keep `getFilteredItems(...)` for display counts, empty states, and card rendering.
+- In the reorder handler, compute reorder against `getItemsForFolder(folderId)` without the media-type filter.
+- Pass the full reordered folder item ID list to `reorderTeamMediaItems(...)`.
+
+Recommended minimal handler shape:
+
+```js
+const items = getItemsForFolder(itemButton.dataset.folderId);
+const reordered = moveInArray(items, itemButton.dataset.itemId, itemButton.dataset.itemMove);
+persistAndReload(
+    () => reorderTeamMediaItems(state.teamId, reordered.map((item) => item.id)),
+    'Item order saved.'
+);
+```
+
+This restores the original persistence contract: item ordering is album-scoped, not filter-scoped.
+
+## Files And Modules Touched
+
+Required:
+
+- `js/team-media.js`
+  - Change the reorder click handler to use the full folder list.
+  - No Firestore schema, rules, or storage changes.
+
+Recommended test coverage if updating tests:
+
+- `tests/unit/team-media-page.test.js`
+  - Add/adjust coverage proving filtered views do not send partial reorder IDs.
+
+## Data/State Impacts
+
+- No data model change.
+- No migration required.
+- Existing duplicate/unstable `order` values caused by prior filtered reorders may remain until a full album reorder writes all item orders again.
+- Future reorders should preserve a single deterministic order sequence across all media types in the album.
+
+## Security/Permissions Impacts
+
+- No permission boundary change.
+- Existing `state.canManage` guard remains the control for reorder actions.
+- No Firebase rules changes required.
+- No additional reads/writes beyond the existing reorder batch pattern.
+
+## Failure Modes And Mitigations
+
+- **Filtered reorder feels visually odd:** With a filter active, an item may move relative to hidden siblings, so the visible filtered order might not change as expected. Mitigation: acceptable for minimal fix, or optionally hide/disable reorder buttons unless filter is **All**.
+- **Existing duplicate order data remains:** Prior bad writes may have already created duplicate orders. Mitigation: any full album reorder normalizes all provided IDs back to `0..n`.
+- **Regression risk:** Low. This reverts reorder persistence to the pre-filter album-level behavior while preserving filter rendering.
+- **Rollback:** Revert the `js/team-media.js` handler change. No schema or data rollback required.

--- a/docs/pr-notes/runs/1411-remediator-20260526T100305Z/code-plan.md
+++ b/docs/pr-notes/runs/1411-remediator-20260526T100305Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Plan
+
+The dedicated code-plan role timed out, so implementation uses the completed requirements, architecture, and QA findings.
+
+## Plan
+
+1. Locate the legacy item move handler in `js/team-media.js`.
+2. Replace filtered reorder source with the full folder item sequence.
+3. Add/update a regression assertion in `tests/unit/team-media-page.test.js` proving filtered subset reorder is not used for persistence.
+4. Run the targeted Vitest files.
+5. Commit scoped changes only.

--- a/docs/pr-notes/runs/1411-remediator-20260526T100305Z/qa.md
+++ b/docs/pr-notes/runs/1411-remediator-20260526T100305Z/qa.md
@@ -1,0 +1,20 @@
+# QA Plan
+
+## Regression Coverage
+
+Add a unit-level source assertion in `tests/unit/team-media-page.test.js` that the item move handler uses `getItemsForFolder(itemButton.dataset.folderId)` directly and does not use `getFilteredItems(getItemsForFolder(...))` for persistence.
+
+## Manual Scenario
+
+1. Open a mixed-media album as a manager.
+2. Select Videos.
+3. Move a video up or down.
+4. Switch back to All.
+5. Confirm photos, videos, and files remain in one deterministic order without dropped IDs or duplicate order collisions.
+
+## Test Commands
+
+```bash
+npx vitest run tests/unit/team-media-page.test.js --reporter=verbose
+npx vitest run tests/unit/team-media-page.test.js tests/unit/app-parent-tools-integration.test.jsx --reporter=verbose
+```

--- a/docs/pr-notes/runs/1411-remediator-20260526T100305Z/requirements.md
+++ b/docs/pr-notes/runs/1411-remediator-20260526T100305Z/requirements.md
@@ -1,0 +1,35 @@
+# Requirements
+
+## Problem Statement
+When a media type filter is active in the ALL PLAYS team media interface, reordering operations apply only to the currently filtered subset of items. This leads to data inconsistencies, duplicate entries, and an unstable order for the full list of media items. This creates confusion for users, corrupts the intended media sequence, and degrades the operational reliability of team media management.
+
+## User Segments Impacted
+*   **Coaches:** Directly impacted when attempting to organize team media for practice plans, game highlights, or sharing with the team. Inconsistent ordering disrupts workflow, wastes time, and leads to incorrect content sequencing.
+*   **Parents:** Indirectly impacted if media they've contributed or expect to see in a specific order appears out of sequence or duplicated, leading to frustration and reduced trust in the platform's ability to reliably manage content.
+*   **Admins/Program Managers:** Responsible for overall data integrity and user experience. They will encounter issues when auditing or managing media across teams, leading to increased support requests and operational toil.
+
+## Acceptance Criteria
+1.  **Reorder Consistency (Unfiltered View):** When a user reorders media items while *no* media type filter is active, the order change MUST persist correctly across all media items in the database and be reflected consistently upon subsequent visits.
+2.  **Reorder Consistency (Filtered View - Coach/Admin):** When a user reorders media items while a *single or multiple* media type filter is active (e.g., "videos only"), the reordering operation MUST apply to the *entire, unfiltered list* of media items. The visual change in order within the filtered view MUST correctly represent the new position of those items relative to the complete media collection.
+    *   **Coach Perspective:** "I want to drag my important highlight video to the top, and know it will always be at the top, regardless of whether I'm looking at 'All Media' or just 'Videos'."
+3.  **No Duplicate or Lost Items:** After any reordering operation, regardless of filter state, no media items MUST be duplicated, and no existing media items MUST be lost from the collection.
+4.  **Stable Ordering:** The relative order of media items *not visible* in a currently active filter MUST remain unchanged during a reorder operation on filtered items.
+    *   **Parent Perspective:** "If a coach reorders videos, my photos shouldn't randomly jump around."
+5.  **UI Reflection:** Any reorder performed while a filter is active MUST be immediately and accurately reflected if the user clears the filter or switches to a different filter view.
+6.  **Error Handling (Operational Reliability):** In cases where reordering fails (e.g., network error, backend issue), the system MUST provide clear feedback to the user, and the media order MUST revert to its last stable state or clearly indicate the failure.
+
+## Non-Goals
+*   Changes to the visual presentation or styling of media items.
+*   The introduction of new media filtering capabilities (e.g., filtering by date, user, or tags).
+*   Any changes to media upload, deletion, or metadata editing functionality.
+
+## Edge Cases
+*   **Empty Filtered Set:** Reordering attempts when the active filter results in no visible media items. The system should gracefully handle this without error and make no changes to the overall order.
+*   **Single Item Filtered Set:** Reordering attempts when the active filter results in only one visible media item. No reorder operation should occur, and the system should make no changes to the overall order.
+*   **Max Items Reordered:** Performance and stability when reordering a very large number of media items within a filtered view (if applicable, define "very large").
+*   **Concurrent Editing:** While the core bug is client-side, consider if backend reordering mechanisms are robust to multiple users attempting to reorder the same media list concurrently.
+
+## Open Questions
+*   Is there a specific technical constraint in the existing `getFilteredItems` implementation that prevents it from returning the full item set for reordering purposes?
+*   What is the acceptable latency for a reorder operation to reflect the change across all items, especially if the media list is very long?
+*   Are there any existing integration tests that specifically cover media reordering in filtered and unfiltered states, which could be expanded or remediated?

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -578,7 +578,7 @@ els.albumDetail.addEventListener('click', async (event) => {
 
     const itemButton = event.target.closest('[data-item-move]');
     if (itemButton) {
-        const items = getFilteredItems(getItemsForFolder(itemButton.dataset.folderId));
+        const items = getItemsForFolder(itemButton.dataset.folderId);
         const reordered = moveInArray(items, itemButton.dataset.itemId, itemButton.dataset.itemMove);
         persistAndReload(() => reorderTeamMediaItems(state.teamId, reordered.map((item) => item.id)), 'Item order saved.');
     }

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -41,6 +41,7 @@ const state = {
     folders: [],
     items: [],
     selectedFolderId: '',
+    selectedMediaType: 'all',
     selectedIds: new Set(),
     actionInFlight: false
 };
@@ -116,6 +117,41 @@ function getItemsForFolder(folderId) {
     return sortByMediaOrder(state.items
         .filter((item) => item.folderId === folderId)
         .filter((item) => isSafeTeamMediaUrl(getTeamMediaItemUrl(item))));
+}
+
+const MEDIA_TYPE_FILTERS = [
+    { id: 'all', label: 'All' },
+    { id: 'photos', label: 'Photos' },
+    { id: 'videos', label: 'Videos' },
+    { id: 'files', label: 'Files' }
+];
+
+function isVideoMediaItem(item = {}) {
+    return String(item.type || '').toLowerCase() === 'video_link';
+}
+
+function matchesMediaTypeFilter(item, filterId = 'all') {
+    if (filterId === 'photos') return isSafeTeamMediaPhoto(item);
+    if (filterId === 'videos') return isVideoMediaItem(item);
+    if (filterId === 'files') return isTeamMediaDocument(item);
+    return true;
+}
+
+function getMediaTypeCounts(items = []) {
+    return {
+        all: items.length,
+        photos: items.filter((item) => matchesMediaTypeFilter(item, 'photos')).length,
+        videos: items.filter((item) => matchesMediaTypeFilter(item, 'videos')).length,
+        files: items.filter((item) => matchesMediaTypeFilter(item, 'files')).length
+    };
+}
+
+function getFilteredItems(items = []) {
+    return items.filter((item) => matchesMediaTypeFilter(item, state.selectedMediaType));
+}
+
+function getSelectedMediaTypeLabel() {
+    return MEDIA_TYPE_FILTERS.find((filter) => filter.id === state.selectedMediaType)?.label || 'All';
 }
 
 function getVisibilityLabel(folder) {
@@ -209,9 +245,17 @@ function renderAlbumDetail() {
     }
 
     const items = getItemsForFolder(folder.id);
-    const itemRows = items.length === 0
-        ? '<div class="rounded-xl border border-dashed border-gray-200 p-4 text-sm text-gray-500">No media in this album.</div>'
-        : `<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">${items.map((item, itemIndex) => {
+    const counts = getMediaTypeCounts(items);
+    const filteredItems = getFilteredItems(items);
+    const selectedMediaTypeLabel = getSelectedMediaTypeLabel();
+    const emptyStateLabel = state.selectedMediaType === 'all' ? 'media' : selectedMediaTypeLabel.toLowerCase();
+    const filterTabs = MEDIA_TYPE_FILTERS.map((filter) => {
+        const selected = filter.id === state.selectedMediaType;
+        return `<button type="button" data-media-type-filter="${escapeHtml(filter.id)}" aria-pressed="${selected ? 'true' : 'false'}" class="inline-flex items-center gap-2 rounded-full border px-3 py-1.5 text-xs font-semibold ${selected ? 'border-indigo-600 bg-indigo-600 text-white' : 'border-gray-200 bg-gray-50 text-gray-700 hover:bg-gray-100'}">${escapeHtml(filter.label)} <span class="rounded-full ${selected ? 'bg-white/20 text-white' : 'bg-white text-gray-600'} px-1.5 py-0.5 text-[10px]">${counts[filter.id]}</span></button>`;
+    }).join('');
+    const itemRows = filteredItems.length === 0
+        ? `<div class="rounded-xl border border-dashed border-gray-200 p-4 text-sm text-gray-500">No ${escapeHtml(emptyStateLabel)} in this album.</div>`
+        : `<div class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">${filteredItems.map((item, itemIndex) => {
             const itemUrl = getTeamMediaItemUrl(item);
             const isPhoto = isSafeTeamMediaPhoto(item);
             const isFile = isTeamMediaDocument(item);
@@ -244,7 +288,7 @@ function renderAlbumDetail() {
                         <a href="${escapeHtml(itemUrl)}" download class="rounded-lg border border-indigo-200 px-3 py-1 text-xs font-semibold text-indigo-700 hover:bg-indigo-50">Download</a>
                         ${state.canManage && isPhoto ? `<button type="button" data-set-cover="${escapeHtml(item.id)}" data-folder-id="${escapeHtml(folder.id)}" class="rounded-lg border border-indigo-200 px-3 py-1 text-xs font-semibold text-indigo-700 hover:bg-indigo-50">Set cover</button>` : ''}
                         ${state.canManage ? `<button type="button" data-item-move="up" data-item-id="${escapeHtml(item.id)}" data-folder-id="${escapeHtml(folder.id)}" ${itemIndex === 0 ? 'disabled' : ''} class="rounded-lg border px-3 py-1 text-xs font-semibold disabled:opacity-40">Up</button>
-                        <button type="button" data-item-move="down" data-item-id="${escapeHtml(item.id)}" data-folder-id="${escapeHtml(folder.id)}" ${itemIndex === items.length - 1 ? 'disabled' : ''} class="rounded-lg border px-3 py-1 text-xs font-semibold disabled:opacity-40">Down</button>` : ''}
+                        <button type="button" data-item-move="down" data-item-id="${escapeHtml(item.id)}" data-folder-id="${escapeHtml(folder.id)}" ${itemIndex === filteredItems.length - 1 ? 'disabled' : ''} class="rounded-lg border px-3 py-1 text-xs font-semibold disabled:opacity-40">Down</button>` : ''}
                         ${canDeleteItem ? `<button type="button" data-item-delete="${escapeHtml(item.id)}" class="rounded-lg border border-red-200 px-3 py-1 text-xs font-semibold text-red-700 hover:bg-red-50">Delete</button>` : ''}
                     </div>
                 </div>`;
@@ -259,6 +303,7 @@ function renderAlbumDetail() {
                         <p class="text-sm text-gray-500">${items.length} item${items.length === 1 ? '' : 's'} · ${escapeHtml(getVisibilityLabel(folder))}</p>
                     </div>
                 </div>
+                <div class="mt-4 flex flex-wrap gap-2" aria-label="Media type filters">${filterTabs}</div>
             </header>
             <div class="space-y-3 p-5">${itemRows}</div>
         </article>`;
@@ -426,6 +471,14 @@ els.foldersList.addEventListener('click', (event) => {
 });
 
 els.albumDetail.addEventListener('click', async (event) => {
+    const filterButton = event.target.closest('[data-media-type-filter]');
+    if (filterButton) {
+        state.selectedMediaType = filterButton.dataset.mediaTypeFilter || 'all';
+        state.selectedIds.clear();
+        render();
+        return;
+    }
+
     const deleteButton = event.target.closest('[data-item-delete]');
     if (deleteButton) {
         const item = state.items.find((candidate) => candidate.id === deleteButton.dataset.itemDelete);
@@ -525,7 +578,7 @@ els.albumDetail.addEventListener('click', async (event) => {
 
     const itemButton = event.target.closest('[data-item-move]');
     if (itemButton) {
-        const items = getItemsForFolder(itemButton.dataset.folderId);
+        const items = getFilteredItems(getItemsForFolder(itemButton.dataset.folderId));
         const reordered = moveInArray(items, itemButton.dataset.itemId, itemButton.dataset.itemMove);
         persistAndReload(() => reorderTeamMediaItems(state.teamId, reordered.map((item) => item.id)), 'Item order saved.');
     }

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -342,6 +342,62 @@ describe('React app parent tools integration', () => {
         expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
     });
 
+
+
+    it('filters team media albums by media type in the app', async () => {
+        serviceMocks.loadTeamMediaForApp.mockResolvedValueOnce({
+            team: { id: 'team-1', name: 'Bears' },
+            canManage: false,
+            canContribute: false,
+            folders: [{
+                id: 'folder-1',
+                name: 'Game media',
+                visibility: 'team',
+                itemCount: 3,
+                items: [
+                    { id: 'photo-1', title: 'Tipoff', type: 'photo', url: 'https://img.example.test/tipoff.jpg' },
+                    { id: 'video-1', title: 'Replay', type: 'video_link', url: 'https://youtube.com/watch?v=abc' },
+                    { id: 'file-1', title: 'Packet', type: 'file', url: 'https://docs.example.test/packet.pdf' }
+                ]
+            }]
+        });
+
+        const { container } = await renderParentTools('/teams/team-1/media');
+        await waitForText(container, 'Game media');
+        expect(container.textContent).toContain('All3');
+        expect(container.textContent).toContain('Photos1');
+        expect(container.textContent).toContain('Videos1');
+        expect(container.textContent).toContain('Files1');
+
+        await clickButton(container, 'Videos');
+
+        expect(container.textContent).toContain('Replay');
+        expect(container.textContent).not.toContain('Tipoff');
+        expect(container.textContent).not.toContain('Packet');
+    });
+
+    it('shows an empty state when the selected app media type has no matches', async () => {
+        serviceMocks.loadTeamMediaForApp.mockResolvedValueOnce({
+            team: { id: 'team-1', name: 'Bears' },
+            canManage: false,
+            canContribute: false,
+            folders: [{
+                id: 'folder-1',
+                name: 'Photos only',
+                visibility: 'team',
+                itemCount: 1,
+                items: [{ id: 'photo-1', title: 'Tipoff', type: 'photo', url: 'https://img.example.test/tipoff.jpg' }]
+            }]
+        });
+
+        const { container } = await renderParentTools('/teams/team-1/media');
+        await waitForText(container, 'Photos only');
+        await clickButton(container, 'Videos');
+
+        expect(container.textContent).toContain('Videos0');
+        expect(container.textContent).toContain('No videos in this album.');
+    });
+
     it('loads team media, uploads photos/files, adds links, and opens media items', async () => {
         const { container } = await renderParentTools('/teams/team-1/media');
         await waitForText(container, 'Bears media');

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -45,6 +45,13 @@ describe('team media entry point', () => {
         expect(pageJs).toContain('canReadTeamMediaAlbum');
         expect(pageJs).toContain('bulkDeleteTeamMediaItems');
         expect(pageJs).toContain('setTeamMediaAlbumCover');
+        expect(pageJs).toContain('MEDIA_TYPE_FILTERS');
+        expect(pageJs).toContain("{ id: 'videos', label: 'Videos' }");
+        expect(pageJs).toContain('data-media-type-filter');
+        expect(pageJs).toContain('aria-label="Media type filters"');
+        expect(pageJs).toContain('getMediaTypeCounts');
+        expect(pageJs).toContain('matchesMediaTypeFilter(item, state.selectedMediaType)');
+        expect(pageJs).toContain('No ${escapeHtml(emptyStateLabel)} in this album.');
         expect(pageJs).toContain('download class="rounded-lg');
         expect(pageJs).toContain('data-set-cover');
         expect(rules).toContain('match /mediaFolders/{folderId}');


### PR DESCRIPTION
Closes #1408

## Summary
- Add All, Photos, Videos, and Files filter chips with counts to legacy Team Media album details.
- Filter visible album cards by media type without changing stored order, visibility, permissions, or item actions.
- Add matching filter chips, counts, and empty states to the React app TeamMedia route.

## Tests
- `npx vitest run tests/unit/team-media-page.test.js tests/unit/app-parent-tools-integration.test.jsx --reporter=verbose`