### PR TITLE
Open help search results in app

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -5,6 +5,7 @@ import { AuthPage } from './pages/AuthPage';
 import { AcceptInvite } from './pages/AcceptInvite';
 import { CapabilityPage } from './pages/CapabilityPage';
 import { GameDetail } from './pages/GameDetail';
+import { HelpArticle } from './pages/HelpArticle';
 import { Home } from './pages/Home';
 import { Messages } from './pages/Messages';
 import { ParentTools } from './pages/ParentTools';
@@ -47,6 +48,7 @@ export default function App() {
       <Route path="/players/:teamId/:playerId" element={<Protected auth={auth}><PlayerDetail auth={auth} /></Protected>} />
       <Route path="/players/:playerId" element={<Protected auth={auth}><PlayerDetail auth={auth} /></Protected>} />
       <Route path="/games/:gameId" element={<Protected auth={auth}><GameDetail auth={auth} /></Protected>} />
+      <Route path="/help/:helpId" element={<Protected auth={auth}><HelpArticle /></Protected>} />
       <Route path="/profile" element={<Protected auth={auth}><Profile auth={auth} /></Protected>} />
       <Route path="/capabilities/:capabilityId" element={<Protected auth={auth}><CapabilityPage /></Protected>} />
       <Route path="*" element={<Navigate to={auth.user ? '/home' : '/auth'} replace />} />

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -364,6 +364,7 @@ function buildAppSearchHelpResults(
     kind: 'help' as const,
     title: result.title,
     subtitle: result.snippet || result.summary,
+    route: `/help/${encodeURIComponent(result.id)}`,
     href: result.url,
     roles: result.roles,
     snippet: result.snippet

--- a/apps/app/src/pages/HelpArticle.tsx
+++ b/apps/app/src/pages/HelpArticle.tsx
@@ -1,0 +1,105 @@
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { ArrowLeft, Home, Search } from 'lucide-react';
+import { getHelpKnowledgeDocs } from '../lib/helpKnowledgeService';
+
+export function HelpArticle() {
+  const { helpId = '' } = useParams();
+  const navigate = useNavigate();
+  const helpDoc = getHelpKnowledgeDocs().find((doc) => doc.id === helpId);
+
+  if (!helpDoc) {
+    return (
+      <div className="space-y-4">
+        <BackButton />
+        <section className="app-card p-5 text-center">
+          <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-primary-50 text-primary-700">
+            <Search className="h-5 w-5" aria-hidden="true" />
+          </div>
+          <h1 className="mt-3 text-2xl font-black text-gray-950">Help article not found</h1>
+          <p className="mt-2 text-sm font-semibold leading-6 text-gray-600">
+            This help article is not packaged in the app yet. Try another search result or head back home.
+          </p>
+          <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:justify-center">
+            <button type="button" className="primary-button justify-center" onClick={() => navigate(-1)}>
+              Back to search
+            </button>
+            <Link to="/home" className="ghost-button justify-center">
+              <Home className="h-4 w-4" aria-hidden="true" />
+              Home
+            </Link>
+          </div>
+        </section>
+      </div>
+    );
+  }
+
+  const paragraphs = buildArticleParagraphs(helpDoc.text, helpDoc.title, helpDoc.summary);
+
+  return (
+    <div className="space-y-4">
+      <BackButton />
+
+      <article className="app-card overflow-hidden">
+        <header className="border-b border-gray-200 bg-gradient-to-r from-primary-50 to-white p-5">
+          <div className="text-xs font-extrabold uppercase tracking-[0.04em] text-primary-700">Help article</div>
+          <h1 className="mt-2 text-2xl font-black text-gray-950">{helpDoc.title}</h1>
+          <p className="mt-2 text-sm font-semibold leading-6 text-gray-600">{helpDoc.summary}</p>
+          {helpDoc.roles.length ? (
+            <div className="mt-3 flex flex-wrap gap-2" aria-label="Help roles">
+              {helpDoc.roles.map((role) => (
+                <span key={role} className="rounded-full bg-white px-3 py-1 text-[11px] font-extrabold uppercase tracking-[0.04em] text-gray-600 shadow-sm ring-1 ring-gray-200">
+                  {role}
+                </span>
+              ))}
+            </div>
+          ) : null}
+        </header>
+
+        <div className="space-y-4 p-5 text-sm font-semibold leading-7 text-gray-700">
+          {paragraphs.map((paragraph, index) => (
+            <p key={`${paragraph.slice(0, 24)}-${index}`}>{paragraph}</p>
+          ))}
+        </div>
+      </article>
+    </div>
+  );
+}
+
+function BackButton() {
+  const navigate = useNavigate();
+
+  return (
+    <button type="button" className="ghost-button" onClick={() => navigate(-1)}>
+      <ArrowLeft className="h-4 w-4" aria-hidden="true" />
+      Back
+    </button>
+  );
+}
+
+function buildArticleParagraphs(text: string, title: string, summary: string) {
+  const titlePattern = escapeRegExp(title);
+  const summaryPattern = escapeRegExp(summary);
+  const cleaned = String(text || '')
+    .replace(new RegExp(`^${titlePattern}\\s+${summaryPattern}\\s*`, 'i'), '')
+    .replace(/Help\s+-\s+[^←]+←\s+Back to Help Portal\s*/i, '')
+    .replace(new RegExp(`^${titlePattern}\\s+${summaryPattern}\\s*`, 'i'), '')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  const chunks = cleaned
+    .split(/(?<=[.!?])\s+/)
+    .map((chunk) => chunk.trim())
+    .filter(Boolean);
+
+  if (!chunks.length) return [summary];
+
+  const paragraphs: string[] = [];
+  for (let index = 0; index < chunks.length; index += 2) {
+    paragraphs.push(chunks.slice(index, index + 2).join(' '));
+  }
+  return paragraphs.slice(0, 24);
+}
+
+function escapeRegExp(value: string) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/tests/unit/app-help-article.test.jsx
+++ b/tests/unit/app-help-article.test.jsx
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'node:fs';
+import React, { act } from '../../apps/app/node_modules/react/index.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createRoot } from '../../apps/app/node_modules/react-dom/client.js';
+import { MemoryRouter, Route, Routes } from '../../apps/app/node_modules/react-router-dom/dist/index.mjs';
+
+const helpMocks = vi.hoisted(() => ({
+    getHelpKnowledgeDocs: vi.fn()
+}));
+
+vi.mock('../../apps/app/src/lib/helpKnowledgeService.ts', () => helpMocks);
+
+import { HelpArticle } from '../../apps/app/src/pages/HelpArticle.tsx';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+async function renderHelpArticle(initialEntry) {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+        root.render(React.createElement(
+            MemoryRouter,
+            { initialEntries: [initialEntry] },
+            React.createElement(
+                Routes,
+                null,
+                React.createElement(Route, { path: '/help/:helpId', element: React.createElement(HelpArticle) }),
+                React.createElement(Route, { path: '/home', element: React.createElement('div', null, 'Home route') })
+            )
+        ));
+    });
+
+    return { container, root };
+}
+
+afterEach(() => {
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+});
+
+describe('HelpArticle', () => {
+    it('renders a packaged help article from the app knowledge index', async () => {
+        helpMocks.getHelpKnowledgeDocs.mockReturnValue([{
+            id: 'account-password-reset',
+            title: 'Reset a password',
+            file: 'help-account.html',
+            url: 'https://allplays.ai/help-account.html',
+            roles: ['parent', 'coach'],
+            summary: 'Recover account access.',
+            text: 'Reset a password Recover account access. Help - Account and Access ← Back to Help Portal Use password reset when a parent cannot sign in. Complete the email reset link flow.'
+        }]);
+
+        const { container, root } = await renderHelpArticle('/help/account-password-reset');
+
+        expect(container.textContent).toContain('Reset a password');
+        expect(container.textContent).toContain('Recover account access.');
+        expect(container.textContent).toContain('parent');
+        expect(container.textContent).toContain('coach');
+        expect(container.textContent).toContain('Use password reset when a parent cannot sign in.');
+        expect(container.querySelector('a[href="https://allplays.ai/help-account.html"]')).toBeNull();
+
+        await act(async () => root.unmount());
+    });
+
+    it('is registered as a protected app route', () => {
+        const appSource = readFileSync('apps/app/src/App.tsx', 'utf8');
+
+        expect(appSource).toContain("import { HelpArticle } from './pages/HelpArticle';");
+        expect(appSource).toContain('<Route path="/help/:helpId" element={<Protected auth={auth}><HelpArticle /></Protected>} />');
+    });
+
+    it('shows a friendly not-found state for unknown help ids', async () => {
+        helpMocks.getHelpKnowledgeDocs.mockReturnValue([]);
+
+        const { container, root } = await renderHelpArticle('/help/missing-article');
+
+        expect(container.textContent).toContain('Help article not found');
+        expect(container.textContent).toContain('This help article is not packaged in the app yet.');
+        expect(container.textContent).toContain('Back to search');
+        expect(container.querySelector('a[href="/home"]')).toBeTruthy();
+
+        await act(async () => root.unmount());
+    });
+});

--- a/tests/unit/app-search-integration.test.jsx
+++ b/tests/unit/app-search-integration.test.jsx
@@ -195,7 +195,7 @@ describe('React app shell search', () => {
         expect(container.querySelector('[data-testid="route"]').textContent).toBe('/players/team-1/player-1');
     });
 
-    it('renders help matches and opens help URLs through the public URL adapter', async () => {
+    it('renders help matches and opens help articles inside the app', async () => {
         helpMocks.searchHelpKnowledge.mockReturnValue([{
             id: 'account-password-reset',
             title: 'Reset a password',
@@ -217,7 +217,8 @@ describe('React app shell search', () => {
         expect(container.textContent).toContain('parent');
 
         await pressDialogKey(container, 'Enter');
-        expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://allplays.ai/help-account.html');
+        expect(container.querySelector('[data-testid="route"]').textContent).toBe('/help/account-password-reset');
+        expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
     });
 
     it('opens website-only search actions through the public URL adapter', async () => {

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -196,6 +196,7 @@ describe('React app search service', () => {
             kind: 'help',
             title: 'Reset a password',
             subtitle: 'Use password reset when a parent or coach cannot sign in.',
+            route: '/help/account-password-reset',
             href: 'https://allplays.ai/help-account.html',
             roles: ['parent', 'coach'],
             snippet: 'Use password reset when a parent or coach cannot sign in.'


### PR DESCRIPTION
Closes #1407

## Summary
- Added a protected `/help/:helpId` React route that renders packaged help article content from the in-app help knowledge index.
- Updated Help search results to navigate in-app while preserving the legacy public URL as fallback metadata.
- Updated search integration coverage and added HelpArticle coverage for found, not-found, and protected route registration states.

## Validation
- `npx vitest run tests/unit/app-search-service.test.js tests/unit/app-search-integration.test.jsx tests/unit/app-help-article.test.jsx --reporter=verbose`
- `npm run app:build`