### PR TITLE
Show offline fee instructions in parent app

### DIFF
--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -83,6 +83,10 @@ export type ParentFeeAppRecord = Record<string, any> & {
   amountLabel: string;
   dueLabel: string;
   statusLabel: string;
+  notes?: string;
+  feeNotes?: string;
+  offlinePaymentInstructions?: string;
+  paymentInstructions?: string;
   canPay: boolean;
   checkoutInitiatable: boolean;
   paymentAction: 'checkoutUrl' | 'createCheckout' | '';

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -674,7 +674,23 @@ function AccessRequestCard({ request }: { request: ParentAccessRequest }) {
   );
 }
 
+function getFeeMessage(...values: Array<unknown>): string {
+  return values.map((value) => String(value || '').trim()).find(Boolean) || '';
+}
+
+function FeeMessageBlock({ title, message }: { title: string; message: string }) {
+  return (
+    <div className="mt-3 rounded-xl border border-blue-100 bg-blue-50 p-3 text-xs font-semibold leading-5 text-blue-900">
+      <div className="font-black uppercase tracking-[0.04em] text-blue-700">{title}</div>
+      <div className="mt-1 whitespace-pre-wrap break-words">{message}</div>
+    </div>
+  );
+}
+
 function FeeCard({ fee, onPay, paying, error }: { fee: ParentFeeAppRecord; onPay: (fee: ParentFeeAppRecord) => void | Promise<void>; paying: boolean; error: string }) {
+  const notes = getFeeMessage(fee.notes, fee.feeNotes);
+  const offlinePaymentInstructions = getFeeMessage(fee.offlinePaymentInstructions, fee.paymentInstructions);
+
   return (
     <section className="app-card p-4">
       <div className="flex items-start justify-between gap-3">
@@ -692,6 +708,8 @@ function FeeCard({ fee, onPay, paying, error }: { fee: ParentFeeAppRecord; onPay
       {fee.lineItems.length ? <FeeDetailList title="Line items" rows={fee.lineItems} /> : null}
       {fee.installments.length ? <FeeDetailList title="Installments" rows={fee.installments} /> : null}
       {fee.ledgerEntries.length ? <FeeDetailList title="Payments and adjustments" rows={fee.ledgerEntries} /> : null}
+      {notes ? <FeeMessageBlock title="Notes" message={notes} /> : null}
+      {offlinePaymentInstructions ? <FeeMessageBlock title="Offline payment" message={offlinePaymentInstructions} /> : null}
       {fee.canPay ? (
         <button type="button" className="primary-button mt-3 w-full" onClick={() => onPay(fee)} disabled={paying}>
           {paying ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <ExternalLink className="h-4 w-4" aria-hidden="true" />}

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -279,9 +279,45 @@ describe('React app parent tools integration', () => {
         }));
     });
 
-    it('creates a team fee checkout session when no checkout URL exists', async () => {
+    it('renders fee notes and offline payment guidance without changing checkout', async () => {
         serviceMocks.loadParentFeesForApp.mockResolvedValueOnce([{
             id: 'fee-2',
+            title: 'Tournament fee',
+            teamId: 'team-1',
+            teamName: 'Bears',
+            playerName: 'Pat Star',
+            status: 'unpaid',
+            amountLabel: '$75',
+            dueLabel: 'Jul 1',
+            statusLabel: 'Open',
+            balanceDueCents: 7500,
+            checkoutUrl: 'https://pay.example.test/tournament',
+            notes: 'Uniform deposit is included.',
+            paymentInstructions: 'Bring a check payable to Bears Booster Club.',
+            canPay: true,
+            checkoutInitiatable: false,
+            paymentAction: 'checkoutUrl',
+            lineItems: [],
+            installments: [],
+            ledgerEntries: []
+        }]);
+
+        const { container } = await renderParentTools('/parent-tools/fees');
+        await waitForText(container, 'Tournament fee');
+
+        expect(container.textContent).toContain('Notes');
+        expect(container.textContent).toContain('Uniform deposit is included.');
+        expect(container.textContent).toContain('Offline payment');
+        expect(container.textContent).toContain('Bring a check payable to Bears Booster Club.');
+
+        await clickButton(container, 'Pay fee');
+        expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://pay.example.test/tournament');
+        expect(serviceMocks.initiateParentTeamFeeCheckout).not.toHaveBeenCalled();
+    });
+
+    it('creates a team fee checkout session when no checkout URL exists', async () => {
+        serviceMocks.loadParentFeesForApp.mockResolvedValueOnce([{
+            id: 'fee-3',
             title: 'Tournament fee',
             teamId: 'team-1',
             batchId: 'batch-1',
@@ -312,7 +348,7 @@ describe('React app parent tools integration', () => {
 
     it('shows an inline fee checkout error without leaving Parent Tools', async () => {
         serviceMocks.loadParentFeesForApp.mockResolvedValueOnce([{
-            id: 'fee-3',
+            id: 'fee-4',
             title: 'Camp fee',
             teamId: 'team-1',
             batchId: 'batch-1',

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -450,6 +450,8 @@ describe('React app parent tools service', () => {
                 amountDueCents: 12000,
                 balanceDueCents: 12000,
                 checkoutUrl: 'https://pay.example.test/open',
+                notes: 'Bring jersey deposit form.',
+                offlinePaymentInstructions: 'Cash or check accepted at practice.',
                 lineItems: [{ title: 'Season', amountCents: 10000 }],
                 installments: [{ label: 'Deposit', amountCents: 5000 }],
                 ledgerEntries: [{ label: 'Adjustment', amountCents: -1000 }]
@@ -464,6 +466,8 @@ describe('React app parent tools service', () => {
             amountLabel: '$120',
             dueLabel: 'No due date',
             statusLabel: 'Open',
+            notes: 'Bring jersey deposit form.',
+            offlinePaymentInstructions: 'Cash or check accepted at practice.',
             canPay: true,
             checkoutInitiatable: false,
             paymentAction: 'checkoutUrl',


### PR DESCRIPTION
Closes #1401

## Summary
- Render parent fee notes and offline payment instructions on React parent fee cards when present.
- Support legacy aliases for notes and payment instructions without changing checkout eligibility or payment behavior.
- Add focused regression coverage for fee message rendering and preserved fee fields.

## Validation
- `npx vitest run tests/unit/app-parent-tools-integration.test.jsx tests/unit/app-parent-tools-service.test.js --reporter=verbose`
- `npm run app:build`