### PR TITLE
Add mobile game cancellation action

### DIFF
--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -37,6 +37,7 @@ import { buildAvailabilityNoteRows, canViewAvailabilityNotes, formatAvailability
 import { getEventRideshareSummary } from '../../../../js/rideshare-helpers.js';
 import { mergeAssignmentsWithClaims } from '../../../../js/snack-helpers.js';
 import { hasScorekeepingTeamAccess } from '../../../../js/team-access.js';
+import { buildScheduleNotificationTargets, postScheduleNotificationTargets } from '../../../../js/schedule-notifications.js';
 import { loadProfileDocument, saveProfileDocument } from './profileService';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import {
@@ -111,6 +112,11 @@ export type GameScoreInput = {
   homeScore: number;
   awayScore: number;
   scoreStreamSessionId?: string | null;
+};
+
+export type CancelScheduledGameResult = {
+  cancelled: true;
+  notificationError: string | null;
 };
 
 function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = primaryDataTimeoutMs): Promise<T> {
@@ -307,6 +313,22 @@ export function normalizeGameScoreValue(value: unknown) {
   const parsed = Number.parseInt(String(value ?? 0), 10);
   if (!Number.isFinite(parsed)) return 0;
   return Math.max(0, parsed);
+}
+
+function formatCancelledGameDate(value: unknown) {
+  const eventDate = normalizeScheduleDate(value);
+  if (!eventDate) return 'date TBD';
+  return eventDate.toLocaleDateString('en-US', {
+    weekday: 'short',
+    month: 'short',
+    day: 'numeric'
+  });
+}
+
+export function buildCancelScheduledGameChatMessage(event: Pick<ParentScheduleEvent, 'opponent' | 'title' | 'date'>) {
+  const opponent = compactString(event.opponent);
+  const opponentLabel = opponent ? `vs. ${opponent}` : compactString(event.title) || 'Game';
+  return `⚠️ Game cancelled: ${opponentLabel} on ${formatCancelledGameDate(event.date)}`;
 }
 
 function isActiveTeam(team: Record<string, any> | null | undefined) {
@@ -1267,6 +1289,60 @@ export async function sendStaffRsvpReminder(event: ParentScheduleEvent, user: Au
   return {
     ...preview,
     emailSentCount
+  };
+}
+
+export async function cancelScheduledGameForApp(event: ParentScheduleEvent, user: AuthUser): Promise<CancelScheduledGameResult> {
+  if (!event?.teamId || !event?.id || !event.isDbGame || event.type !== 'game') {
+    throw new Error('A scheduled game is required before cancelling.');
+  }
+  if (event.isCancelled) {
+    throw new Error('This game is already cancelled.');
+  }
+  if (!user?.uid) {
+    throw new Error('Sign in before cancelling the game.');
+  }
+  if (!event.canUpdateScore) {
+    throw new Error('Coach or admin access is required to cancel this game.');
+  }
+
+  const payload: Record<string, unknown> = {
+    status: 'cancelled',
+    cancelledAt: new Date(),
+    cancelledBy: user.uid
+  };
+
+  try {
+    await withTimeout(Promise.resolve(updateGame(event.teamId, event.id, payload)), 'Game cancellation');
+  } catch (error) {
+    if (!isNativeRuntime()) throw error;
+    console.warn('[schedule-service] Falling back to REST game cancellation:', error);
+    await nativePatchDocument(`teams/${encodeURIComponent(event.teamId)}/games/${encodeURIComponent(event.id)}`, payload);
+  }
+
+  let notificationError: string | null = null;
+  try {
+    const { postChatMessage } = await import('../../../../js/db.js');
+    const targets = buildScheduleNotificationTargets({
+      teamId: event.teamId,
+      title: `vs. ${event.opponent || 'Opponent'}`
+    });
+    const result = await postScheduleNotificationTargets({
+      targets,
+      postChatMessage,
+      senderId: user.uid,
+      senderName: user.displayName || user.email,
+      senderEmail: user.email,
+      buildText: () => buildCancelScheduledGameChatMessage(event)
+    });
+    notificationError = result.failedCount > 0 ? result.errorMessage || 'Team chat notification failed.' : null;
+  } catch (error: any) {
+    notificationError = error?.message || 'Team chat notification failed.';
+  }
+
+  return {
+    cancelled: true,
+    notificationError
   };
 }
 

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -3,6 +3,7 @@ import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { AlertCircle, CalendarDays, Car, CheckCircle2, ChevronDown, ChevronLeft, ClipboardCheck, Clock, ExternalLink, FileText, MapPin, Radio, RefreshCw, Share2, Users, Video, type LucideIcon } from 'lucide-react';
 import {
   cancelParentScheduleRideRequest,
+  cancelScheduledGameForApp,
   claimParentScheduleAssignmentSlot,
   createParentScheduleRideOffer,
   loadParentPracticePacket,
@@ -192,6 +193,14 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
     )));
   }, [decodedEventId, decodedTeamId]);
 
+  const handleGameCancelled = useCallback(() => {
+    setEvents((current) => current.map((event) => (
+      event.teamId === decodedTeamId && event.id === decodedEventId
+        ? { ...event, status: 'cancelled', isCancelled: true, availabilityLocked: true }
+        : event
+    )));
+  }, [decodedEventId, decodedTeamId]);
+
   const canSubmitRsvp = Boolean(selectedEvent?.isDbGame && !selectedEvent.isCancelled && !selectedEvent.availabilityLocked);
 
   const submitRsvp = async (response: Exclude<RsvpResponse, 'not_responded'>) => {
@@ -355,7 +364,7 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
             onAssignmentsChanged={handleAssignmentsChanged}
           />
         ) : null}
-        {activeSection === 'game' ? <GameHubSection auth={auth} event={selectedEvent} childEvents={events} onScoreUpdated={handleScoreUpdated} /> : null}
+        {activeSection === 'game' ? <GameHubSection auth={auth} event={selectedEvent} childEvents={events} onScoreUpdated={handleScoreUpdated} onGameCancelled={handleGameCancelled} /> : null}
       </div>
     </div>
   );
@@ -1378,13 +1387,37 @@ function AssignmentCard({ assignment, userId, busy, disabled, onClaim, onRelease
   );
 }
 
-function GameHubSection({ auth, event, childEvents, onScoreUpdated }: { auth: AuthState; event: ParentScheduleEvent; childEvents: ParentScheduleEvent[]; onScoreUpdated: (homeScore: number, awayScore: number) => void }) {
+function GameHubSection({ auth, event, childEvents, onScoreUpdated, onGameCancelled }: { auth: AuthState; event: ParentScheduleEvent; childEvents: ParentScheduleEvent[]; onScoreUpdated: (homeScore: number, awayScore: number) => void; onGameCancelled: () => void }) {
   const [shareStatus, setShareStatus] = useState<string | null>(null);
+  const [cancelStatus, setCancelStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
+  const [cancelling, setCancelling] = useState(false);
   const statusLabel = getEventStatusLabel(event);
   const scoreLabel = getScoreLabel(event);
   const isPractice = event.type === 'practice';
-  const canUpdateScore = Boolean(!isPractice && event.isDbGame && event.canUpdateScore && auth.user);
+  const canUpdateScore = Boolean(!isPractice && event.isDbGame && !event.isCancelled && event.canUpdateScore && auth.user);
+  const canCancelGame = Boolean(!isPractice && event.isDbGame && !event.isCancelled && event.canUpdateScore && auth.user);
   const hubDestinations = isPractice ? buildPracticeHubDestinations(event) : buildGameHubDestinations(event);
+
+  const cancelGame = async () => {
+    if (!auth.user) return;
+    const opponentLabel = event.opponent || event.title || 'this game';
+    const confirmed = window.confirm(`Cancel ${opponentLabel} on ${formatEventDateLabel(event.date)}? This marks the game cancelled and notifies the team in chat.`);
+    if (!confirmed) return;
+
+    setCancelling(true);
+    setCancelStatus(null);
+    try {
+      const result = await cancelScheduledGameForApp(event, auth.user);
+      onGameCancelled();
+      setCancelStatus(result.notificationError
+        ? { tone: 'error', message: `Game cancelled, but team chat notification failed: ${result.notificationError}` }
+        : { tone: 'success', message: 'Game cancelled and team chat notified.' });
+    } catch (error: any) {
+      setCancelStatus({ tone: 'error', message: error?.message || 'Unable to cancel game.' });
+    } finally {
+      setCancelling(false);
+    }
+  };
 
   const sharePublicDestination = async (destination: { title: string; text: string; url?: string; label: string }) => {
     setShareStatus(null);
@@ -1434,6 +1467,25 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated }: { auth: Au
 
           {canUpdateScore ? <LiveScoreEditor auth={auth} event={event} onScoreUpdated={onScoreUpdated} /> : null}
 
+          {canCancelGame ? (
+            <div className="mt-3 rounded-2xl border border-rose-200 bg-rose-50 p-3">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-xs font-black uppercase tracking-[0.04em] text-rose-700">Schedule management</div>
+                  <div className="mt-1 text-sm font-semibold text-rose-900">Cancel this game and notify the team chat.</div>
+                </div>
+                <button
+                  type="button"
+                  className="min-h-11 rounded-full bg-rose-600 px-4 text-sm font-black text-white shadow-sm transition hover:bg-rose-700 disabled:opacity-60"
+                  onClick={cancelGame}
+                  disabled={cancelling}
+                >
+                  {cancelling ? 'Cancelling game' : 'Cancel game'}
+                </button>
+              </div>
+            </div>
+          ) : null}
+
           <div className="mt-3 grid gap-2 sm:grid-cols-2">
             {hubDestinations.map((destination) => (
               <GameHubDestinationCard
@@ -1452,6 +1504,7 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated }: { auth: Au
       </div>
 
       {shareStatus ? <Status tone={shareStatus.startsWith('Unable') ? 'error' : 'success'} message={shareStatus} /> : null}
+      {cancelStatus ? <Status tone={cancelStatus.tone} message={cancelStatus.message} /> : null}
       {!isPractice ? <GameReportSections event={event} /> : null}
     </section>
   );

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -303,6 +303,10 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
                     };
                 }
 
+                export async function cancelScheduledGameForApp() {
+                    return { status: 'cancelled', isCancelled: true };
+                }
+
                 export async function createParentScheduleRideOffer() {}
                 export async function requestParentScheduleRideSpot() {}
                 export async function cancelParentScheduleRideRequest() {}

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -282,6 +282,11 @@ async function mockScheduleModules(page, options = {}) {
                     return payload;
                 }
 
+                export async function cancelScheduledGameForApp(teamId, gameId, user) {
+                    window.__scheduleCalls.cancellations = (window.__scheduleCalls.cancellations || []).concat({ teamId, gameId, userId: user?.uid || null });
+                    return { status: 'cancelled', isCancelled: true };
+                }
+
                 export async function loadParentPracticePacket(event, childEvents) {
                     window.__scheduleCalls.packets.push({ action: 'load', eventId: event.id, sessionId: event.practiceSessionId });
                     if (!event.practiceHomePacket) return null;

--- a/tests/unit/app-schedule-event-detail-cancel.test.js
+++ b/tests/unit/app-schedule-event-detail-cancel.test.js
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+function readDetailSource() {
+    return readFileSync(new URL('../../apps/app/src/pages/ScheduleEventDetail.tsx', import.meta.url), 'utf8');
+}
+
+describe('React app schedule event detail cancellation action', () => {
+    it('wires a staff-only non-cancelled DB game action through the cancellation service', () => {
+        const source = readDetailSource();
+
+        expect(source).toContain('cancelScheduledGameForApp');
+        expect(source).toContain("const canCancelGame = Boolean(!isPractice && event.isDbGame && !event.isCancelled && event.canUpdateScore && auth.user);");
+        expect(source).toContain('Cancel game');
+        expect(source).toContain('This marks the game cancelled and notifies the team in chat.');
+        expect(source).toContain("{ ...event, status: 'cancelled', isCancelled: true, availabilityLocked: true }");
+        expect(source).toContain('Game cancelled, but team chat notification failed:');
+    });
+});

--- a/tests/unit/app-schedule-score-update.test.js
+++ b/tests/unit/app-schedule-score-update.test.js
@@ -19,7 +19,8 @@ const dbMocks = vi.hoisted(() => ({
     releaseAssignmentClaim: vi.fn(),
     submitRsvpForPlayer: vi.fn(),
     upsertPracticePacketCompletion: vi.fn(),
-    updateGame: vi.fn()
+    updateGame: vi.fn(),
+    postChatMessage: vi.fn()
 }));
 
 vi.mock('../../js/db.js', () => dbMocks);
@@ -62,7 +63,7 @@ vi.mock('../../js/snack-helpers.js', () => ({
     mergeAssignmentsWithClaims: vi.fn((assignments = []) => assignments)
 }));
 
-import { normalizeGameScoreValue, updateGameScore } from '../../apps/app/src/lib/scheduleService.ts';
+import { buildCancelScheduledGameChatMessage, cancelScheduledGameForApp, normalizeGameScoreValue, updateGameScore } from '../../apps/app/src/lib/scheduleService.ts';
 
 const user = {
     uid: 'user-1',
@@ -104,5 +105,94 @@ describe('React app schedule score updates', () => {
         }));
         expect(dbMocks.updateGame.mock.calls[0][2].scoreUpdatedAt).toBeInstanceOf(Date);
         expect(payload).toEqual(dbMocks.updateGame.mock.calls[0][2]);
+    });
+
+    it('writes cancellation metadata and posts the legacy-style team chat notice', async () => {
+        dbMocks.updateGame.mockResolvedValue(undefined);
+        dbMocks.postChatMessage.mockResolvedValue(undefined);
+
+        const result = await cancelScheduledGameForApp({
+            eventKey: 'team-1__game-1__player-1',
+            id: 'game-1',
+            teamId: 'team-1',
+            teamName: 'Bears',
+            type: 'game',
+            date: new Date('2026-05-21T18:00:00Z'),
+            location: 'Main Gym',
+            opponent: 'Falcons',
+            childId: 'player-1',
+            childName: 'Pat',
+            isDbGame: true,
+            isCancelled: false,
+            canUpdateScore: true,
+            assignments: []
+        }, user);
+
+        expect(dbMocks.updateGame).toHaveBeenCalledWith('team-1', 'game-1', expect.objectContaining({
+            status: 'cancelled',
+            cancelledBy: 'user-1'
+        }));
+        expect(dbMocks.updateGame.mock.calls[0][2].cancelledAt).toBeInstanceOf(Date);
+        expect(dbMocks.postChatMessage).toHaveBeenCalledWith('team-1', expect.objectContaining({
+            text: '⚠️ Game cancelled: vs. Falcons on Thu, May 21',
+            senderId: 'user-1',
+            senderName: 'Coach Pat',
+            senderEmail: 'coach@example.com'
+        }));
+        expect(result).toEqual({ cancelled: true, notificationError: null });
+    });
+
+    it('reports chat notification failure without failing the cancellation', async () => {
+        dbMocks.updateGame.mockResolvedValue(undefined);
+        dbMocks.postChatMessage.mockRejectedValue(new Error('chat write failed'));
+
+        const result = await cancelScheduledGameForApp({
+            eventKey: 'team-1__game-1__player-1',
+            id: 'game-1',
+            teamId: 'team-1',
+            teamName: 'Bears',
+            type: 'game',
+            date: new Date('2026-05-21T18:00:00Z'),
+            location: 'Main Gym',
+            opponent: 'Falcons',
+            childId: 'player-1',
+            childName: 'Pat',
+            isDbGame: true,
+            isCancelled: false,
+            canUpdateScore: true,
+            assignments: []
+        }, user);
+
+        expect(dbMocks.updateGame).toHaveBeenCalledTimes(1);
+        expect(result).toEqual({ cancelled: true, notificationError: 'chat write failed' });
+    });
+
+    it('rejects missing cancellation inputs before writing', async () => {
+        await expect(cancelScheduledGameForApp({}, user)).rejects.toThrow('A scheduled game is required before cancelling.');
+        await expect(cancelScheduledGameForApp({
+            eventKey: 'team-1__game-1__player-1',
+            id: 'game-1',
+            teamId: 'team-1',
+            teamName: 'Bears',
+            type: 'game',
+            date: new Date('2026-05-21T18:00:00Z'),
+            location: 'Main Gym',
+            opponent: 'Falcons',
+            childId: 'player-1',
+            childName: 'Pat',
+            isDbGame: true,
+            isCancelled: false,
+            canUpdateScore: true,
+            assignments: []
+        }, {})).rejects.toThrow('Sign in before cancelling the game.');
+        expect(dbMocks.updateGame).not.toHaveBeenCalled();
+    });
+
+    it('builds the cancellation chat text from title when opponent is missing', () => {
+        expect(buildCancelScheduledGameChatMessage({
+            title: 'Championship game',
+            opponent: '',
+            date: new Date('2026-05-21T18:00:00Z')
+        })).toBe('⚠️ Game cancelled: Championship game on Thu, May 21');
     });
 });


### PR DESCRIPTION
Closes #1418

## Summary
- Added a staff-only Cancel game action in the React/mobile Game Hub for active DB games.
- Added schedule cancellation service logic that writes cancelled status metadata, posts the legacy-style team chat notice, and reports non-blocking notification failures.
- Updated local detail state immediately so cancelled guards and badges take over without restart.

## Validation
- `npx vitest run tests/unit/app-schedule-score-update.test.js tests/unit/app-schedule-event-detail-cancel.test.js --reporter=verbose`
- `npm run app:build`