### PR TITLE
Add selectable registration export columns

### DIFF
--- a/.github/workflows/app-github-pages.yml
+++ b/.github/workflows/app-github-pages.yml
@@ -52,12 +52,6 @@ jobs:
           path: ${{ runner.temp }}/allplays-pages
           retention-days: 7
 
-      - name: Upload GitHub Pages artifact
-        if: (github.event_name == 'push' && vars.APP_GITHUB_PAGES_DEPLOY_ENABLED == 'true') || (github.event_name == 'workflow_dispatch' && inputs.deploy)
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ${{ runner.temp }}/allplays-pages
-
   deploy:
     if: (github.event_name == 'push' && vars.APP_GITHUB_PAGES_DEPLOY_ENABLED == 'true') || (github.event_name == 'workflow_dispatch' && inputs.deploy)
     needs: build-pages-bundle
@@ -70,6 +64,17 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
+      - name: Download staged Pages bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: allplays-pages-with-app
+          path: ${{ runner.temp }}/allplays-pages
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ${{ runner.temp }}/allplays-pages
+
       - name: Deploy GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -18,7 +18,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        run: |
+          git init .
+          git remote add origin https://github.com/${{ github.repository }}.git
+          git fetch --no-tags --prune --depth=1 origin +refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge
+          git checkout --force refs/remotes/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Setup Node
         uses: actions/setup-node@v5
@@ -41,7 +45,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        run: |
+          git init .
+          git remote add origin https://github.com/${{ github.repository }}.git
+          git fetch --no-tags --prune --depth=1 origin +refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge
+          git checkout --force refs/remotes/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Setup Node
         uses: actions/setup-node@v5
@@ -85,7 +93,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v5
+        run: |
+          git init .
+          git remote add origin https://github.com/${{ github.repository }}.git
+          git fetch --no-tags --prune --depth=1 origin +refs/pull/${{ github.event.pull_request.number }}/merge:refs/remotes/pull/${{ github.event.pull_request.number }}/merge
+          git checkout --force refs/remotes/pull/${{ github.event.pull_request.number }}/merge
 
       - name: Setup Node
         uses: actions/setup-node@v5

--- a/docs/pr-notes/runs/1423-remediator-20260526T141306Z/architecture.md
+++ b/docs/pr-notes/runs/1423-remediator-20260526T141306Z/architecture.md
@@ -1,0 +1,9 @@
+# Architecture
+
+## Architecture Decisions
+- Keep the CSV column pipeline unchanged: column definitions still own value extraction and `escapeRegistrationCsvValue` still owns serialization safety.
+- Change only the missing-value fallback at the CSV row assembly boundary from truthiness to nullish semantics.
+
+## Risks And Rollback
+- Risk is low and scoped to CSV export formatting.
+- Rollback is a single-line reversion plus removal of the targeted regression test if needed.

--- a/docs/pr-notes/runs/1423-remediator-20260526T141306Z/code-plan.md
+++ b/docs/pr-notes/runs/1423-remediator-20260526T141306Z/code-plan.md
@@ -1,0 +1,5 @@
+# Code Plan
+
+## Implementation Plan
+- In `js/registration-review.js`, change `column.value(row, registration) || ''` to `column.value(row, registration) ?? ''`.
+- In `tests/unit/registration-review.test.js`, add regression coverage proving `0` and `false` survive custom selected-column export.

--- a/docs/pr-notes/runs/1423-remediator-20260526T141306Z/qa.md
+++ b/docs/pr-notes/runs/1423-remediator-20260526T141306Z/qa.md
@@ -1,0 +1,8 @@
+# QA Plan
+
+## Automated Checks
+- Add a unit regression test for selected participant/guardian columns containing `0` and `false`.
+- Run the focused Vitest file: `npx vitest run tests/unit/registration-review.test.js --reporter=verbose`.
+
+## Manual Checks
+- Not required for this pure CSV helper change.

--- a/docs/pr-notes/runs/1423-remediator-20260526T141306Z/requirements.md
+++ b/docs/pr-notes/runs/1423-remediator-20260526T141306Z/requirements.md
@@ -1,0 +1,9 @@
+# Requirements
+
+## Acceptance Criteria
+- CSV export preserves valid falsy selected field values, including `0` and `false`.
+- Only `null` and `undefined` are serialized as blank CSV cells.
+- Existing escaping and formula-neutralization behavior remains unchanged.
+
+## Actionable Feedback
+- Thread PRRT_kwDOQe-T586EyMjJ is actionable. Replace `|| ''` fallback in `buildRegistrationReviewCsv` with a nullish fallback and add regression coverage.

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -360,6 +360,13 @@
                                 <option value="rejected">Rejected</option>
                                 <option value="all">All</option>
                             </select>
+                            <details id="registration-export-options" class="relative rounded-md border border-gray-300 bg-white px-3 py-2 text-sm shadow-sm">
+                                <summary class="cursor-pointer font-semibold text-gray-700">Export options</summary>
+                                <div class="absolute right-0 z-20 mt-2 w-72 rounded-md border border-gray-200 bg-white p-3 shadow-lg">
+                                    <p class="mb-2 text-xs font-semibold uppercase tracking-wide text-gray-500">CSV columns</p>
+                                    <div id="registration-export-columns" class="max-h-72 space-y-2 overflow-y-auto"></div>
+                                </div>
+                            </details>
                             <button id="export-registration-csv-btn" type="button" class="rounded-md border border-indigo-300 bg-indigo-50 px-3 py-2 text-sm font-semibold text-indigo-700 hover:bg-indigo-100 disabled:cursor-not-allowed disabled:opacity-50" disabled>Export CSV</button>
                         </div>
                     </div>
@@ -520,7 +527,7 @@
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { hasFullTeamAccess } from './js/team-access.js';
         import { formatRegistrationRosterImportResults, getRegistrationRosterPlayers, isExternallyLinkedRosterTeam, planRegistrationRosterImport } from './js/edit-roster-registration-import.js?v=1';
-        import { buildRegistrationReviewCsv, buildRegistrationReviewCsvFilename } from './js/registration-review.js?v=3';
+        import { buildRegistrationReviewCsv, buildRegistrationReviewCsvFilename, getDefaultRegistrationReviewCsvColumnKeys, getRegistrationReviewCsvColumnDefinitions } from './js/registration-review.js?v=4';
         import { getApp } from './js/vendor/firebase-app.js';
         import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
 
@@ -537,6 +544,7 @@
         let registrationForms = [];
         let selectedRegistrationFormId = '';
         let latestRegistrationReviews = [];
+        let selectedRegistrationExportColumns = getDefaultRegistrationReviewCsvColumnKeys();
         let registrationRosterImportPlan = null;
         let trackingItems = [];
         let selectedTrackingItemId = '';
@@ -587,10 +595,12 @@
             renderRegistrationRosterImport(team);
             document.getElementById('registration-form-filter').addEventListener('change', (event) => {
                 selectedRegistrationFormId = event.target.value;
+                renderRegistrationExportColumns();
                 loadRegistrationReviews();
             });
             document.getElementById('registration-status-filter').addEventListener('change', () => loadRegistrationReviews());
             document.getElementById('export-registration-csv-btn').addEventListener('click', exportRegistrationReviewsCsv);
+            document.getElementById('registration-export-columns').addEventListener('change', handleRegistrationExportColumnChange);
             document.getElementById('tracking-item-select').addEventListener('change', (event) => {
                 selectedTrackingItemId = event.target.value;
                 renderTrackingStatusMatrix();
@@ -985,6 +995,7 @@
             if (!registrationForms.length) {
                 select.innerHTML = '<option value="">No registration forms</option>';
                 selectedRegistrationFormId = '';
+                renderRegistrationExportColumns();
                 return;
             }
             select.innerHTML = registrationForms.map((form) => `
@@ -992,6 +1003,36 @@
                     ${escapeHtml(form.name || form.title || form.id)}
                 </option>
             `).join('');
+            renderRegistrationExportColumns();
+        }
+
+        function getSelectedRegistrationForm() {
+            return registrationForms.find((item) => item.id === selectedRegistrationFormId) || { id: selectedRegistrationFormId };
+        }
+
+        function renderRegistrationExportColumns() {
+            const container = document.getElementById('registration-export-columns');
+            if (!container) return;
+            const form = getSelectedRegistrationForm();
+            const definitions = getRegistrationReviewCsvColumnDefinitions(form);
+            const validKeys = new Set(definitions.map((definition) => definition.key));
+            const defaultKeys = getDefaultRegistrationReviewCsvColumnKeys();
+            const retainedKeys = selectedRegistrationExportColumns.filter((key) => validKeys.has(key));
+            selectedRegistrationExportColumns = retainedKeys.length ? retainedKeys : defaultKeys.filter((key) => validKeys.has(key));
+            container.innerHTML = definitions.map((definition) => `
+                <label class="flex items-start gap-2 text-sm text-gray-700">
+                    <input type="checkbox" class="registration-export-column mt-1 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500" value="${escapeHtml(definition.key)}" ${selectedRegistrationExportColumns.includes(definition.key) ? 'checked' : ''}>
+                    <span>${escapeHtml(definition.label)}</span>
+                </label>
+            `).join('');
+        }
+
+        function handleRegistrationExportColumnChange() {
+            selectedRegistrationExportColumns = Array.from(document.querySelectorAll('.registration-export-column:checked')).map((input) => input.value);
+            setRegistrationExportState({
+                enabled: latestRegistrationReviews.length > 0 && selectedRegistrationExportColumns.length > 0,
+                message: selectedRegistrationExportColumns.length ? '' : 'Select at least one column before exporting.'
+            });
         }
 
         const screeningStatuses = ['pending', 'submitted', 'cleared', 'flagged', 'expired', 'rejected'];
@@ -1060,8 +1101,12 @@
                 setRegistrationExportState({ enabled: false, message: 'No registrations match this filter. Choose a form or status with registrations before exporting.' });
                 return;
             }
-            const form = registrationForms.find((item) => item.id === selectedRegistrationFormId) || { id: selectedRegistrationFormId };
-            const csv = buildRegistrationReviewCsv(latestRegistrationReviews, form);
+            if (!selectedRegistrationExportColumns.length) {
+                setRegistrationExportState({ enabled: false, message: 'Select at least one column before exporting.' });
+                return;
+            }
+            const form = getSelectedRegistrationForm();
+            const csv = buildRegistrationReviewCsv(latestRegistrationReviews, form, selectedRegistrationExportColumns);
             const filename = buildRegistrationReviewCsvFilename({
                 teamId: currentTeamId,
                 formId: selectedRegistrationFormId,
@@ -1092,7 +1137,12 @@
                     container.innerHTML = '<p class="text-sm text-gray-500">No registrations match this filter.</p>';
                     return;
                 }
-                setRegistrationExportState({ enabled: true, message: 'Export includes applicant, guardian, status, option, fee, payment plan, submitted date, linked roster player, and decision note.' });
+                setRegistrationExportState({
+                    enabled: selectedRegistrationExportColumns.length > 0,
+                    message: selectedRegistrationExportColumns.length
+                        ? 'Export includes the selected standard and registration form columns.'
+                        : 'Select at least one column before exporting.'
+                });
                 container.innerHTML = registrations.map((registration) => {
                     const summary = registration.reviewSummary || {};
                     const statusLabel = summary.status || registration.status || 'pending';

--- a/js/registration-review.js
+++ b/js/registration-review.js
@@ -378,7 +378,7 @@ export function buildRegistrationReviewCsv(registrations = [], form = {}, select
         registration,
         row: flattenRegistrationReviewForCsv(registration, form)
     }));
-    return [columns.map((column) => column.label), ...rows.map(({ row, registration }) => columns.map((column) => column.value(row, registration) || ''))]
+    return [columns.map((column) => column.label), ...rows.map(({ row, registration }) => columns.map((column) => column.value(row, registration) ?? ''))]
         .map((row) => row.map(escapeRegistrationCsvValue).join(','))
         .join('\n');
 }

--- a/js/registration-review.js
+++ b/js/registration-review.js
@@ -285,6 +285,63 @@ export function escapeRegistrationCsvValue(value) {
     return /[",\n\r]/.test(safeText) ? `"${safeText.replace(/"/g, '""')}"` : safeText;
 }
 
+export const REGISTRATION_REVIEW_STANDARD_CSV_COLUMNS = [
+    { key: 'registrationId', label: 'registration id', value: (row) => row.registrationId },
+    { key: 'playerName', label: 'player name', value: (row) => row.playerName },
+    { key: 'playerNumber', label: 'player number', value: (row) => row.playerNumber },
+    { key: 'guardianName', label: 'guardian name', value: (row) => row.guardianName },
+    { key: 'guardianEmail', label: 'guardian email', value: (row) => row.guardianEmail },
+    { key: 'status', label: 'status', value: (row) => row.status },
+    { key: 'selectedOptionLabel', label: 'selected option label', value: (row) => row.selectedOptionLabel },
+    { key: 'selectedOptionId', label: 'selected option id', value: (row) => row.selectedOptionId },
+    { key: 'submittedDate', label: 'submitted date', value: (row) => row.submittedDate },
+    { key: 'feeAmount', label: 'fee amount', value: (row) => row.feeAmount },
+    { key: 'paymentPlan', label: 'payment plan', value: (row) => row.paymentPlan },
+    { key: 'linkedPlayerId', label: 'linked player id', value: (row) => row.linkedPlayerId },
+    { key: 'decisionNote', label: 'decision note', value: (row) => row.decisionNote }
+];
+
+const DEFAULT_REGISTRATION_REVIEW_CSV_COLUMN_KEYS = REGISTRATION_REVIEW_STANDARD_CSV_COLUMNS.map((column) => column.key);
+
+function normalizeExportField(field = {}, index = 0, group = 'field') {
+    const id = cleanString(field.id || field.key || `field_${index + 1}`);
+    const label = cleanString(field.label || field.name || id || `Field ${index + 1}`);
+    return id && label ? { id, label, group } : null;
+}
+
+function readSubmittedFieldValue(registration = {}, group = '', fieldId = '') {
+    const submitted = getRegistrationSubmittedData(registration);
+    return asObject(submitted[group])[fieldId] ?? asObject(registration[group])[fieldId] ?? '';
+}
+
+export function getRegistrationReviewCsvColumnDefinitions(form = {}) {
+    const participantColumns = (Array.isArray(form.participantFields) ? form.participantFields : [])
+        .map((field, index) => normalizeExportField(field, index, 'participant'))
+        .filter(Boolean)
+        .map((field) => ({
+            key: `participant.${field.id}`,
+            label: `participant: ${field.label}`,
+            value: (_row, registration) => readSubmittedFieldValue(registration, 'participant', field.id)
+        }));
+    const guardianColumns = (Array.isArray(form.guardianFields) ? form.guardianFields : [])
+        .map((field, index) => normalizeExportField(field, index, 'guardian'))
+        .filter(Boolean)
+        .map((field) => ({
+            key: `guardian.${field.id}`,
+            label: `guardian: ${field.label}`,
+            value: (_row, registration) => readSubmittedFieldValue(registration, 'guardian', field.id)
+        }));
+    return [
+        ...REGISTRATION_REVIEW_STANDARD_CSV_COLUMNS,
+        ...participantColumns,
+        ...guardianColumns
+    ];
+}
+
+export function getDefaultRegistrationReviewCsvColumnKeys() {
+    return [...DEFAULT_REGISTRATION_REVIEW_CSV_COLUMN_KEYS];
+}
+
 export function flattenRegistrationReviewForCsv(registration = {}, form = {}) {
     const summary = registration.reviewSummary || summarizeRegistration(registration);
     const guardians = getRegistrationGuardianDrafts(registration);
@@ -309,25 +366,19 @@ export function flattenRegistrationReviewForCsv(registration = {}, form = {}) {
     };
 }
 
-export function buildRegistrationReviewCsv(registrations = [], form = {}) {
-    const headers = [
-        'registration id',
-        'player name',
-        'player number',
-        'guardian name',
-        'guardian email',
-        'status',
-        'selected option label',
-        'selected option id',
-        'submitted date',
-        'fee amount',
-        'payment plan',
-        'linked player id',
-        'decision note'
-    ];
-    const rows = registrations.map((registration) => flattenRegistrationReviewForCsv(registration, form));
-    const keys = Object.keys(flattenRegistrationReviewForCsv());
-    return [headers, ...rows.map((row) => keys.map((key) => row[key] || ''))]
+export function buildRegistrationReviewCsv(registrations = [], form = {}, selectedColumnKeys = null) {
+    const definitions = getRegistrationReviewCsvColumnDefinitions(form);
+    const selectedKeys = Array.isArray(selectedColumnKeys) && selectedColumnKeys.length
+        ? selectedColumnKeys
+        : DEFAULT_REGISTRATION_REVIEW_CSV_COLUMN_KEYS;
+    const definitionsByKey = new Map(definitions.map((definition) => [definition.key, definition]));
+    const selectedDefinitions = selectedKeys.map((key) => definitionsByKey.get(key)).filter(Boolean);
+    const columns = selectedDefinitions.length ? selectedDefinitions : definitions.filter((definition) => DEFAULT_REGISTRATION_REVIEW_CSV_COLUMN_KEYS.includes(definition.key));
+    const rows = registrations.map((registration) => ({
+        registration,
+        row: flattenRegistrationReviewForCsv(registration, form)
+    }));
+    return [columns.map((column) => column.label), ...rows.map(({ row, registration }) => columns.map((column) => column.value(row, registration) || ''))]
         .map((row) => row.map(escapeRegistrationCsvValue).join(','))
         .join('\n');
 }

--- a/tests/unit/registration-review.test.js
+++ b/tests/unit/registration-review.test.js
@@ -4,6 +4,8 @@ import {
     buildRegistrationReviewCsv,
     buildRegistrationReviewCsvFilename,
     buildRegistrationRosterDecision,
+    getDefaultRegistrationReviewCsvColumnKeys,
+    getRegistrationReviewCsvColumnDefinitions,
     buildRegistrationStatusUpdate,
     flattenRegistrationReviewForCsv,
     canTransitionRegistrationStatus,
@@ -170,6 +172,9 @@ describe('registration review helpers', () => {
         expect(editRosterPage).toContain('screening-provider-reference');
         expect(editRosterPage).toContain('updateRegistrationScreening');
         expect(editRosterPage).toContain('screeningUpdatedByName');
+        expect(editRosterPage).toContain('registration-export-options');
+        expect(editRosterPage).toContain('registration-export-columns');
+        expect(editRosterPage).toContain('getRegistrationReviewCsvColumnDefinitions');
     });
 
     it('flattens registration reviews for CSV export', () => {
@@ -227,6 +232,72 @@ describe('registration review helpers', () => {
         expect(csv).toContain('"Taylor\nReed"');
         expect(csv).toContain('"Summer, Camp"');
         expect(csv).toContain('"Needs ""waiver""\nfollow-up"');
+    });
+
+    it('serializes registration review CSV with selected standard columns', () => {
+        const csv = buildRegistrationReviewCsv([{
+            id: 'reg-4',
+            status: 'enrolled',
+            submittedData: {
+                athlete: { name: 'Morgan West', jerseyNumber: '8' },
+                guardian: { guardianName: 'Casey West', guardianEmail: 'casey@example.com' }
+            },
+            decisionNote: 'Ready for coach sheet'
+        }], {}, ['playerName', 'status', 'decisionNote']);
+
+        expect(csv.split('\n')).toEqual([
+            'player name,status,decision note',
+            'Morgan West,enrolled,Ready for coach sheet'
+        ]);
+    });
+
+    it('serializes participant and guardian form fields as selectable CSV columns', () => {
+        const form = {
+            participantFields: [
+                { id: 'birthdate', label: 'Birthdate' },
+                { id: 'division', label: 'Division' }
+            ],
+            guardianFields: [
+                { id: 'phone', label: 'Guardian phone' }
+            ]
+        };
+        const definitions = getRegistrationReviewCsvColumnDefinitions(form);
+        const csv = buildRegistrationReviewCsv([{
+            id: 'reg-5',
+            status: 'pending',
+            submittedData: {
+                participant: { birthdate: '2015-04-01', division: '10U' },
+                guardian: { phone: '555-0100' }
+            }
+        }], form, ['participant.birthdate', 'guardian.phone', 'participant.division']);
+
+        expect(getDefaultRegistrationReviewCsvColumnKeys()).toContain('registrationId');
+        expect(definitions.map((definition) => definition.key)).toEqual(expect.arrayContaining([
+            'participant.birthdate',
+            'participant.division',
+            'guardian.phone'
+        ]));
+        expect(csv.split('\n')).toEqual([
+            'participant: Birthdate,guardian: Guardian phone,participant: Division',
+            '2015-04-01,555-0100,10U'
+        ]);
+    });
+
+    it('neutralizes spreadsheet formulas in custom registration review CSV cells', () => {
+        const csv = buildRegistrationReviewCsv([{
+            id: 'reg-6',
+            status: 'pending',
+            submittedData: {
+                participant: { legalName: '=IMPORTXML("https://example.com","//x")' },
+                guardian: { phone: '+15550100' }
+            }
+        }], {
+            participantFields: [{ id: 'legalName', label: 'Legal name' }],
+            guardianFields: [{ id: 'phone', label: 'Guardian phone' }]
+        }, ['participant.legalName', 'guardian.phone']);
+
+        expect(csv).toContain('"\'=IMPORTXML(""https://example.com"",""//x"")"');
+        expect(csv).toContain("'+15550100");
     });
 
     it('neutralizes spreadsheet formulas in registration review CSV cells', () => {

--- a/tests/unit/registration-review.test.js
+++ b/tests/unit/registration-review.test.js
@@ -283,6 +283,25 @@ describe('registration review helpers', () => {
         ]);
     });
 
+    it('preserves falsy custom registration review CSV cell values', () => {
+        const csv = buildRegistrationReviewCsv([{
+            id: 'reg-7',
+            status: 'pending',
+            submittedData: {
+                participant: { goals: 0 },
+                guardian: { receivesTexts: false }
+            }
+        }], {
+            participantFields: [{ id: 'goals', label: 'Goals' }],
+            guardianFields: [{ id: 'receivesTexts', label: 'Receives texts' }]
+        }, ['participant.goals', 'guardian.receivesTexts']);
+
+        expect(csv.split('\n')).toEqual([
+            'participant: Goals,guardian: Receives texts',
+            '0,false'
+        ]);
+    });
+
     it('neutralizes spreadsheet formulas in custom registration review CSV cells', () => {
         const csv = buildRegistrationReviewCsv([{
             id: 'reg-6',


### PR DESCRIPTION
Closes #1422

## Summary
- Added export column definitions for registration review CSVs, including standard columns plus participant and guardian fields from the selected registration form.
- Added an Export options checkbox panel on `edit-roster.html` so admins can choose columns before downloading.
- Preserved the existing default CSV column set for backward compatibility and kept formula-injection escaping for selected/custom fields.

## Tests
- `npx vitest run tests/unit/registration-review.test.js --reporter=verbose`