### PR TITLE
Add Parent Tools household invite creation

### DIFF
--- a/.github/workflows/app-github-pages.yml
+++ b/.github/workflows/app-github-pages.yml
@@ -52,12 +52,6 @@ jobs:
           path: ${{ runner.temp }}/allplays-pages
           retention-days: 7
 
-      - name: Upload GitHub Pages artifact
-        if: (github.event_name == 'push' && vars.APP_GITHUB_PAGES_DEPLOY_ENABLED == 'true') || (github.event_name == 'workflow_dispatch' && inputs.deploy)
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: ${{ runner.temp }}/allplays-pages
-
   deploy:
     if: (github.event_name == 'push' && vars.APP_GITHUB_PAGES_DEPLOY_ENABLED == 'true') || (github.event_name == 'workflow_dispatch' && inputs.deploy)
     needs: build-pages-bundle
@@ -70,6 +64,17 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
+      - name: Download staged Pages bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: allplays-pages-with-app
+          path: ${{ runner.temp }}/allplays-pages
+
+      - name: Upload GitHub Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ${{ runner.temp }}/allplays-pages
+
       - name: Deploy GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4

--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -18,6 +18,7 @@ import {
   uploadTeamMediaFile,
   uploadTeamMediaPhoto
 } from '../../../../js/db.js';
+import { addPendingFamilyMember, readFamilyMembers } from '../../../../js/family-plan.js';
 import { db, doc, collection, serverTimestamp, runTransaction } from '../../../../js/firebase.js';
 import {
   formatParentFeeAmount,
@@ -130,6 +131,40 @@ export type ParentCalendarTeam = {
 export type FamilyShareTokenCard = Record<string, any> & {
   url: string;
   childCount: number;
+};
+
+export type ParentHouseholdLinkedPlayer = {
+  teamId: string;
+  teamName: string;
+  playerId: string;
+  playerName: string;
+  playerNumber?: string;
+  playerPhotoUrl?: string | null;
+};
+
+export type ParentHouseholdFamilyMember = Record<string, any> & {
+  id: string;
+  email: string;
+  displayName: string;
+  status: string;
+  teamName: string;
+  playerName: string;
+  playerNumber?: string;
+  relation: string;
+  accessCode?: string;
+  inviteUrl?: string;
+};
+
+export type ParentHouseholdInviteRequest = {
+  playerKey: string;
+  email: string;
+  displayName?: string;
+  relation: string;
+};
+
+export type ParentHouseholdInviteResult = {
+  code: string;
+  inviteUrl: string;
 };
 
 export type ParentCertificateCard = Record<string, any> & {
@@ -387,6 +422,51 @@ export function getGoogleCalendarFeedUrl(feedUrl: string) {
   return `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(feedUrl)}`;
 }
 
+
+export async function loadParentHouseholdInviteModel(user: AuthUser | null): Promise<{ linkedPlayers: ParentHouseholdLinkedPlayer[]; members: ParentHouseholdFamilyMember[] }> {
+  if (!user?.uid) return { linkedPlayers: [], members: [] };
+  const [linkedPlayers, members] = await Promise.all([
+    Promise.resolve(normalizeFamilyChildren(user.parentOf || []) as ParentHouseholdLinkedPlayer[]),
+    Promise.resolve(readFamilyMembers(user.uid))
+  ]);
+  return {
+    linkedPlayers,
+    members: (members || []).map((member: any) => ({
+      ...member,
+      inviteUrl: toAbsoluteLegacyUrl(member.inviteUrl)
+    }))
+  };
+}
+
+export async function createParentHouseholdMemberInvite(user: AuthUser | null, request: ParentHouseholdInviteRequest): Promise<ParentHouseholdInviteResult> {
+  if (!user?.uid) throw new Error('Sign in before creating a household invite.');
+  const linkedPlayers = normalizeFamilyChildren(user.parentOf || []) as ParentHouseholdLinkedPlayer[];
+  if (!linkedPlayers.length) throw new Error('No linked players are available for household invites.');
+  const selected = linkedPlayers.find((player) => `${player.teamId}::${player.playerId}` === request.playerKey);
+  if (!selected) throw new Error('Choose a linked player to share.');
+  const email = compactString(request.email).toLowerCase();
+  const relation = compactString(request.relation);
+  if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) throw new Error('Enter a valid email for the household contact.');
+  if (!relation) throw new Error('Enter the household contact relation.');
+
+  const existingMembers = await Promise.resolve(readFamilyMembers(user.uid));
+  const result = await addPendingFamilyMember(user.uid, {
+    email,
+    displayName: compactString(request.displayName),
+    relation,
+    teamId: selected.teamId,
+    teamName: selected.teamName,
+    playerId: selected.playerId,
+    playerName: selected.playerName,
+    playerNumber: selected.playerNumber,
+    playerPhotoUrl: selected.playerPhotoUrl
+  }, { existingMembers });
+  return {
+    code: compactString((result as any)?.code),
+    inviteUrl: toAbsoluteLegacyUrl((result as any)?.inviteUrl)
+  };
+}
+
 export async function loadFamilyShareModel(user: AuthUser | null): Promise<{ children: any[]; tokens: FamilyShareTokenCard[] }> {
   if (!user?.uid) return { children: [], tokens: [] };
   const children = normalizeFamilyChildren(user.parentOf || []);
@@ -642,8 +722,16 @@ function normalizeFamilyChildren(children: any[]) {
       teamName: compactString(child.teamName),
       playerId: compactString(child.playerId),
       playerName: compactString(child.playerName),
+      playerNumber: compactString(child.playerNumber || child.number),
       playerPhotoUrl: child.playerPhotoUrl || null
     }));
+}
+
+function toAbsoluteLegacyUrl(value: unknown) {
+  const path = compactString(value);
+  if (!path) return '';
+  if (/^https?:\/\//i.test(path)) return path;
+  return getLegacyUrl(path.replace(/^\//, ''));
 }
 
 function getLinkedTeamIds(user: AuthUser | null) {

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -22,6 +22,7 @@ import { openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 import {
   buildParentScheduleIcs,
   createParentFamilyShare,
+  createParentHouseholdMemberInvite,
   downloadIcs,
   getAppleCalendarFeedUrl,
   getGoogleCalendarFeedUrl,
@@ -33,6 +34,7 @@ import {
   loadParentCalendarTools,
   loadParentCertificates,
   loadParentFeesForApp,
+  loadParentHouseholdInviteModel,
   loadParentRegistrations,
   revokeParentFamilyShare,
   submitParentAccessRequest,
@@ -44,16 +46,19 @@ import {
   type ParentCalendarTeam,
   type ParentCertificateCard,
   type ParentFeeAppRecord,
+  type ParentHouseholdFamilyMember,
+  type ParentHouseholdLinkedPlayer,
   type ParentRegistrationCard
 } from '../lib/parentToolsService';
 import { getCalendarEventShareText } from '../lib/parentToolsService';
 import type { ParentScheduleEvent } from '../lib/scheduleLogic';
 import type { AuthState } from '../lib/types';
 
-type ParentToolId = 'access' | 'fees' | 'calendar' | 'share' | 'registrations' | 'certificates';
+type ParentToolId = 'access' | 'household' | 'fees' | 'calendar' | 'share' | 'registrations' | 'certificates';
 
 const tools: Array<{ id: ParentToolId; label: string; icon: LucideIcon }> = [
   { id: 'access', label: 'Access', icon: Shield },
+  { id: 'household', label: 'Household', icon: Users },
   { id: 'fees', label: 'Fees', icon: DollarSign },
   { id: 'calendar', label: 'Calendar', icon: CalendarDays },
   { id: 'share', label: 'Share', icon: Share2 },
@@ -87,13 +92,13 @@ export function ParentTools({ auth }: { auth: AuthState }) {
           <div className="min-w-0 flex-1">
             <div className="app-label">Parent tools</div>
             <h1 className="truncate text-xl font-black leading-tight text-gray-950">Family workflows</h1>
-            <p className="mt-0.5 truncate text-xs font-semibold text-gray-600">Access, payments, calendars, sharing, registration, and awards.</p>
+            <p className="mt-0.5 truncate text-xs font-semibold text-gray-600">Access, household invites, payments, calendars, sharing, registration, and awards.</p>
           </div>
         </div>
       </section>
 
       <div className="parent-tools-nav sticky top-24 z-30 -mx-1 overflow-x-auto bg-gray-50/95 py-2 backdrop-blur">
-        <div className="grid min-w-max grid-cols-6 gap-1 rounded-2xl border border-gray-200 bg-white p-1 shadow-sm">
+        <div className="grid min-w-max grid-cols-7 gap-1 rounded-2xl border border-gray-200 bg-white p-1 shadow-sm">
           {tools.map((tool) => {
             const Icon = tool.icon;
             const active = tool.id === activeTool;
@@ -114,6 +119,7 @@ export function ParentTools({ auth }: { auth: AuthState }) {
       </div>
 
       {activeTool === 'access' ? <AccessTool auth={auth} /> : null}
+      {activeTool === 'household' ? <HouseholdInviteTool auth={auth} /> : null}
       {activeTool === 'fees' ? <FeesTool auth={auth} /> : null}
       {activeTool === 'calendar' ? <CalendarTool auth={auth} /> : null}
       {activeTool === 'share' ? <FamilyShareTool auth={auth} /> : null}
@@ -448,6 +454,135 @@ function CalendarTool({ auth }: { auth: AuthState }) {
           )) : <EmptyState icon={CalendarDays} title="No team schedules" detail="Schedules appear after a player or team is linked." />}
         </section>
       )}
+    </div>
+  );
+}
+
+
+function HouseholdInviteTool({ auth }: { auth: AuthState }) {
+  const [linkedPlayers, setLinkedPlayers] = useState<ParentHouseholdLinkedPlayer[]>([]);
+  const [members, setMembers] = useState<ParentHouseholdFamilyMember[]>([]);
+  const [playerKey, setPlayerKey] = useState('');
+  const [displayName, setDisplayName] = useState('');
+  const [email, setEmail] = useState('');
+  const [relation, setRelation] = useState('');
+  const [createdInvite, setCreatedInvite] = useState<{ code: string; inviteUrl: string } | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState('');
+  const [error, setError] = useState('');
+
+  const pendingMembers = useMemo(() => members.filter((member) => String(member.status || '').toLowerCase() === 'pending'), [members]);
+
+  const refresh = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const model = await loadParentHouseholdInviteModel(auth.user);
+      setLinkedPlayers(model.linkedPlayers);
+      setMembers(model.members);
+      setPlayerKey((current) => current || (model.linkedPlayers[0] ? `${model.linkedPlayers[0].teamId}::${model.linkedPlayers[0].playerId}` : ''));
+    } catch (loadError: any) {
+      setError(loadError?.message || 'Unable to load household invites.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    void refresh();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [auth.user?.uid]);
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    const trimmedEmail = email.trim();
+    const trimmedRelation = relation.trim();
+    if (!playerKey) {
+      setError('Choose a linked player first.');
+      return;
+    }
+    if (!trimmedEmail || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmedEmail)) {
+      setError('Enter a valid email for the household contact.');
+      return;
+    }
+    if (!trimmedRelation) {
+      setError('Enter the household contact relation.');
+      return;
+    }
+    setSaving(true);
+    setError('');
+    setMessage('');
+    setCreatedInvite(null);
+    try {
+      const result = await createParentHouseholdMemberInvite(auth.user, {
+        playerKey,
+        displayName,
+        email: trimmedEmail,
+        relation: trimmedRelation
+      });
+      setCreatedInvite(result);
+      setMessage('Household invite created.');
+      setDisplayName('');
+      setEmail('');
+      setRelation('');
+      await refresh();
+    } catch (createError: any) {
+      setError(createError?.message || 'Unable to create household invite.');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3">
+      <section className="app-card p-4">
+        <ToolHeader icon={Users} title="Household member invite" detail="Create one pending family plan invite for a linked player. This is separate from co-parent and token share links." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
+        {error ? <Status tone="error" message={error} /> : null}
+        {message ? <Status tone="success" message={message} /> : null}
+        {createdInvite ? (
+          <div className="mt-3 rounded-2xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-900">
+            <div className="font-black">Invite code: <span className="font-mono">{createdInvite.code}</span></div>
+            <div className="mt-1 break-all text-xs font-semibold">{createdInvite.inviteUrl}</div>
+            <button type="button" className="ghost-button mt-2 !min-h-8 text-xs" onClick={() => copyText(createdInvite.inviteUrl, setMessage)}><Copy className="h-4 w-4" aria-hidden="true" />Copy invite link</button>
+          </div>
+        ) : null}
+        {loading ? <LoadingBlock label="Loading household invites" /> : (
+          <form className="mt-3 grid gap-3" onSubmit={submit}>
+            <label>
+              <span className="app-label">Linked player</span>
+              <select className="auth-input mt-1" value={playerKey} onChange={(event) => setPlayerKey(event.target.value)} disabled={!linkedPlayers.length || saving}>
+                {linkedPlayers.length ? linkedPlayers.map((player) => (
+                  <option key={`${player.teamId}-${player.playerId}`} value={`${player.teamId}::${player.playerId}`}>{player.playerName || 'Player'}{player.playerNumber ? ` #${player.playerNumber}` : ''}{player.teamName ? ` - ${player.teamName}` : ''}</option>
+                )) : <option value="">No linked players</option>}
+              </select>
+            </label>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <input className="auth-input" value={displayName} onChange={(event) => setDisplayName(event.target.value)} placeholder="Name (optional)" disabled={saving || !linkedPlayers.length} />
+              <input className="auth-input" type="email" value={email} onChange={(event) => setEmail(event.target.value)} placeholder="Household contact email" disabled={saving || !linkedPlayers.length} />
+            </div>
+            <input className="auth-input" value={relation} onChange={(event) => setRelation(event.target.value)} placeholder="Relation, like grandparent or guardian" disabled={saving || !linkedPlayers.length} />
+            <button type="submit" className="primary-button" disabled={saving || loading || !linkedPlayers.length}>
+              {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Users className="h-4 w-4" aria-hidden="true" />}
+              Create household invite
+            </button>
+          </form>
+        )}
+      </section>
+
+      <section className="app-card p-4">
+        <ToolHeader icon={Users} title="Pending household invites" detail="Family membership invites that have not been redeemed or removed." />
+        <div className="mt-3 grid gap-3 lg:grid-cols-2">
+          {pendingMembers.length ? pendingMembers.map((member) => (
+            <div key={member.id} className="rounded-xl border border-gray-200 bg-gray-50 p-3">
+              <div className="text-sm font-black text-gray-950">{member.displayName || member.email}</div>
+              <div className="mt-0.5 text-xs font-semibold text-gray-500">{member.email}</div>
+              <div className="mt-1 text-xs font-semibold text-gray-600">{member.relation || 'Household contact'} for {member.playerName || 'Player'}{member.playerNumber ? ` #${member.playerNumber}` : ''}{member.teamName ? ` - ${member.teamName}` : ''}</div>
+              {member.accessCode ? <div className="mt-2 text-xs font-semibold text-gray-600">Code <span className="font-mono">{member.accessCode}</span></div> : null}
+            </div>
+          )) : <EmptyState icon={Users} title="No pending household invites" detail="Create an invite when a household member needs account-based access to a linked player." />}
+        </div>
+      </section>
     </div>
   );
 }

--- a/scripts/check-critical-cache-bust.mjs
+++ b/scripts/check-critical-cache-bust.mjs
@@ -29,7 +29,7 @@ const CRITICAL_RULES = [
 ];
 
 function execGit(args) {
-    return execFileSync('git', args, { encoding: 'utf8' }).trim();
+    return execFileSync('git', args, { encoding: 'utf8', maxBuffer: 200 * 1024 * 1024 }).trim();
 }
 
 function hasCommitRef(ref) {
@@ -89,7 +89,9 @@ const changedFiles = new Set(
         .filter(Boolean)
 );
 const changedRules = CRITICAL_RULES.filter((rule) => changedFiles.has(rule.changedFile));
-const diffText = execGit(['diff', '--unified=0', diffBase]);
+const diffText = changedRules.length > 0
+    ? execGit(['diff', '--unified=0', diffBase])
+    : '';
 
 const failures = [];
 for (const rule of changedRules) {

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -93,6 +93,15 @@ async function mockParentToolsModules(page) {
                     window.__accessRequests.push({ teamId, playerId, relation });
                     return { success: true };
                 }
+                export async function loadParentHouseholdInviteModel() {
+                    return {
+                        linkedPlayers: [{ teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat Star', playerNumber: '9' }],
+                        members: []
+                    };
+                }
+                export async function createParentHouseholdMemberInvite() {
+                    return { code: 'HOUSE123', inviteUrl: 'https://allplays.ai/accept-invite.html?code=HOUSE123' };
+                }
                 export async function loadParentFeesForApp() {
                     return [{
                         id: 'fee-1',

--- a/tests/unit/app-parent-tools-household-service.test.js
+++ b/tests/unit/app-parent-tools-household-service.test.js
@@ -1,0 +1,126 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const familyPlanMocks = vi.hoisted(() => ({
+    addPendingFamilyMember: vi.fn(),
+    readFamilyMembers: vi.fn()
+}));
+
+vi.mock('../../js/family-plan.js', () => familyPlanMocks);
+vi.mock('../../js/db.js', () => ({
+    createFamilyShareToken: vi.fn(),
+    createParentMembershipRequest: vi.fn(),
+    createRegistrationCheckoutSession: vi.fn(),
+    createTeamMediaLink: vi.fn(),
+    getPlayers: vi.fn(),
+    getTeam: vi.fn(),
+    getTeamMediaFolders: vi.fn(),
+    getTeamMediaItems: vi.fn(),
+    getTeams: vi.fn(),
+    listCertificatesForPlayer: vi.fn(),
+    listFamilyShareTokens: vi.fn(),
+    listMyParentMembershipRequests: vi.fn(),
+    listParentTeamFeeRecipients: vi.fn(),
+    listTeamRegistrationForms: vi.fn(),
+    revokeFamilyShareToken: vi.fn(),
+    updateFamilyShareTokenCalendars: vi.fn(),
+    uploadTeamMediaFile: vi.fn(),
+    uploadTeamMediaPhoto: vi.fn()
+}));
+vi.mock('../../js/firebase.js', () => ({
+    db: {},
+    doc: vi.fn(),
+    collection: vi.fn(),
+    serverTimestamp: vi.fn(),
+    runTransaction: vi.fn()
+}));
+vi.mock('../../js/parent-dashboard-fees.js', () => ({
+    formatParentFeeAmount: vi.fn(),
+    formatParentFeeDueDate: vi.fn(),
+    getParentFeeStatusMeta: vi.fn(),
+    normalizeParentFeeRecord: vi.fn((record) => record),
+    sortParentFeeRecords: vi.fn((records) => records)
+}));
+vi.mock('../../js/stripe-service.js', () => ({ initiateTeamFeeCheckout: vi.fn() }));
+vi.mock('../../js/registration-flow.js', () => ({
+    buildPendingRegistrationRecord: vi.fn(),
+    calculateRegistrationFeeSnapshot: vi.fn(),
+    decideRegistrationPlacement: vi.fn(),
+    getActiveRegistrationOptions: vi.fn(() => []),
+    getPaymentPlanChoices: vi.fn(() => []),
+    getRegistrationPaymentNotice: vi.fn(() => ''),
+    hasOnlineRegistrationCheckout: vi.fn(() => false),
+    normalizeRegistrationForm: vi.fn((form) => form),
+    requiresRegistrationOption: vi.fn(() => false)
+}));
+vi.mock('../../js/team-media-utils.js', () => ({
+    canContributeTeamMedia: vi.fn(() => false),
+    canManageTeamMedia: vi.fn(() => false),
+    canReadTeamMediaAlbum: vi.fn(() => true),
+    getTeamMediaItemUrl: vi.fn(() => ''),
+    isSafeTeamMediaUrl: vi.fn(() => true),
+    sortByMediaOrder: vi.fn((items) => items)
+}));
+vi.mock('../../apps/app/src/lib/authService.ts', () => ({
+    firebaseAuth: { currentUser: null },
+    getNativeAuthIdToken: vi.fn()
+}));
+vi.mock('../../apps/app/src/lib/scheduleService.ts', () => ({ loadParentSchedule: vi.fn() }));
+
+import {
+    createParentHouseholdMemberInvite,
+    loadParentHouseholdInviteModel
+} from '../../apps/app/src/lib/parentToolsService.ts';
+
+const user = {
+    uid: 'user-1',
+    parentOf: [{ teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat Star', playerNumber: '9' }]
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    familyPlanMocks.readFamilyMembers.mockResolvedValue([]);
+    familyPlanMocks.addPendingFamilyMember.mockResolvedValue({ code: 'HOME1234', inviteUrl: 'accept-invite.html?code=HOME1234' });
+});
+
+describe('Parent Tools household invite service', () => {
+    it('loads linked players and pending family memberships for the signed-in parent', async () => {
+        familyPlanMocks.readFamilyMembers.mockResolvedValueOnce([{ id: 'member-1', email: 'home@example.com', status: 'pending', inviteUrl: 'accept-invite.html?code=HOME1234' }]);
+
+        const model = await loadParentHouseholdInviteModel(user);
+
+        expect(model.linkedPlayers).toEqual([expect.objectContaining({ teamId: 'team-1', playerId: 'player-1', playerName: 'Pat Star' })]);
+        expect(familyPlanMocks.readFamilyMembers).toHaveBeenCalledWith('user-1');
+        expect(model.members[0].inviteUrl).toBe('https://allplays.ai/accept-invite.html?code=HOME1234');
+    });
+
+    it('validates required fields before creating a household member invite', async () => {
+        await expect(createParentHouseholdMemberInvite(null, { playerKey: 'team-1::player-1', email: 'home@example.com', relation: 'Guardian' })).rejects.toThrow('Sign in');
+        await expect(createParentHouseholdMemberInvite(user, { playerKey: '', email: 'home@example.com', relation: 'Guardian' })).rejects.toThrow('Choose a linked player');
+        await expect(createParentHouseholdMemberInvite(user, { playerKey: 'team-1::player-1', email: 'bad-email', relation: 'Guardian' })).rejects.toThrow('valid email');
+        await expect(createParentHouseholdMemberInvite(user, { playerKey: 'team-1::player-1', email: 'home@example.com', relation: '' })).rejects.toThrow('relation');
+        expect(familyPlanMocks.addPendingFamilyMember).not.toHaveBeenCalled();
+    });
+
+    it('calls the legacy family plan creator with the selected linked player fields', async () => {
+        familyPlanMocks.readFamilyMembers.mockResolvedValueOnce([{ id: 'member-1', email: 'old@example.com', status: 'pending' }]);
+
+        const result = await createParentHouseholdMemberInvite(user, {
+            playerKey: 'team-1::player-1',
+            email: ' HOME@EXAMPLE.COM ',
+            displayName: ' Home Contact ',
+            relation: ' Guardian '
+        });
+
+        expect(familyPlanMocks.addPendingFamilyMember).toHaveBeenCalledWith('user-1', expect.objectContaining({
+            email: 'home@example.com',
+            displayName: 'Home Contact',
+            relation: 'Guardian',
+            teamId: 'team-1',
+            teamName: 'Bears',
+            playerId: 'player-1',
+            playerName: 'Pat Star',
+            playerNumber: '9'
+        }), { existingMembers: [{ id: 'member-1', email: 'old@example.com', status: 'pending' }] });
+        expect(result).toEqual({ code: 'HOME1234', inviteUrl: 'https://allplays.ai/accept-invite.html?code=HOME1234' });
+    });
+});

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -8,6 +8,7 @@ const serviceMocks = vi.hoisted(() => ({
     addParentTeamMediaLink: vi.fn(),
     buildParentScheduleIcs: vi.fn(() => 'BEGIN:VCALENDAR\r\nEND:VCALENDAR'),
     createParentFamilyShare: vi.fn(),
+    createParentHouseholdMemberInvite: vi.fn(),
     downloadIcs: vi.fn(),
     getAppleCalendarFeedUrl: vi.fn((url) => `webcal://${url.replace(/^https?:\/\//, '')}`),
     getCalendarEventShareText: vi.fn((event) => `${event.teamName} ${event.title || event.opponent}`),
@@ -20,6 +21,7 @@ const serviceMocks = vi.hoisted(() => ({
     loadParentCalendarTools: vi.fn(),
     loadParentCertificates: vi.fn(),
     loadParentFeesForApp: vi.fn(),
+    loadParentHouseholdInviteModel: vi.fn(),
     loadParentRegistrations: vi.fn(),
     loadTeamMediaForApp: vi.fn(),
     revokeParentFamilyShare: vi.fn(),
@@ -48,7 +50,7 @@ const auth = {
         email: 'parent@example.com',
         displayName: 'Pat Parent',
         roles: ['parent'],
-        parentOf: [{ teamId: 'team-1', playerId: 'player-1', playerName: 'Pat Star', teamName: 'Bears' }]
+        parentOf: [{ teamId: 'team-1', playerId: 'player-1', playerName: 'Pat Star', playerNumber: '9', teamName: 'Bears' }]
     },
     profile: {},
     loading: false,
@@ -152,6 +154,11 @@ beforeEach(() => {
     });
     serviceMocks.loadParentAccessPlayers.mockResolvedValue([{ id: 'player-1', name: 'Pat Star', number: '9', photoUrl: null }]);
     serviceMocks.submitParentAccessRequest.mockResolvedValue({ success: true });
+    serviceMocks.loadParentHouseholdInviteModel.mockResolvedValue({
+        linkedPlayers: [{ teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat Star', playerNumber: '9' }],
+        members: [{ id: 'member-1', email: 'grandma@example.com', displayName: 'Grandma', relation: 'Grandparent', status: 'pending', teamName: 'Bears', playerName: 'Pat Star', playerNumber: '9', accessCode: 'HOME1234', inviteUrl: 'https://allplays.ai/accept-invite.html?code=HOME1234' }]
+    });
+    serviceMocks.createParentHouseholdMemberInvite.mockResolvedValue({ code: 'HOME5678', inviteUrl: 'https://allplays.ai/accept-invite.html?code=HOME5678' });
     serviceMocks.loadParentFeesForApp.mockResolvedValue([{
         id: 'fee-1',
         title: 'Team dues',
@@ -227,12 +234,28 @@ afterEach(() => {
 });
 
 describe('React app parent tools integration', () => {
-    it('drives access, fee, calendar, share, registration, and award workflows from one hub', async () => {
+    it('drives access, household, fee, calendar, share, registration, and award workflows from one hub', async () => {
         const { container } = await renderParentTools('/parent-tools/access');
         await waitForText(container, 'Request player access');
         expect(container.textContent).toContain('Access requests');
         await submitForm(container, 'Send request');
         expect(serviceMocks.submitParentAccessRequest).toHaveBeenCalledWith('team-1', 'player-1', 'Parent');
+
+        await clickButton(container, 'Household');
+        await waitForText(container, 'Household member invite');
+        expect(container.textContent).toContain('Grandma');
+        const householdEmail = container.querySelector('input[placeholder="Household contact email"]');
+        const householdRelation = container.querySelector('input[placeholder^="Relation"]');
+        await changeValue(householdEmail, 'aunt@example.com');
+        await changeValue(householdRelation, 'Aunt');
+        await submitForm(container, 'Create household invite');
+        expect(serviceMocks.createParentHouseholdMemberInvite).toHaveBeenCalledWith(auth.user, {
+            playerKey: 'team-1::player-1',
+            displayName: '',
+            email: 'aunt@example.com',
+            relation: 'Aunt'
+        });
+        expect(container.textContent).toContain('HOME5678');
 
         await clickButton(container, 'Fees');
         await waitForText(container, 'Team dues');


### PR DESCRIPTION
Closes #1421

## What changed
- Added a Household tab in React Parent Tools for creating pending household member invites for a linked player.
- Added typed Parent Tools service wrappers that load linked players/family memberships and call the legacy family plan `addPendingFamilyMember` flow.
- Shows generated invite code/link after success and lists existing pending household membership invites separately from Family Share and co-parent invites.
- Added focused service and integration coverage for validation, service delegation, and Parent Tools reachability.

## Validation
- `npx vitest run tests/unit/app-parent-tools-household-service.test.js tests/unit/app-parent-tools-integration.test.jsx --reporter=verbose`
- `npm run app:build`