### PR TITLE
Fix standard tracker DNP participation

### DIFF
--- a/js/track-finish.js
+++ b/js/track-finish.js
@@ -33,14 +33,14 @@ export function buildNormalizedPlayerStats(playerStats = {}, columns = []) {
     return normalizedStats;
 }
 
-function hasTrackedPlayerActivity(playerStats = {}, normalizedStats = {}, includeTimeMs = false) {
+function hasTrackedPlayerActivity(playerStats = {}, normalizedStats = {}, includeTimeMs = false, hasPlayerStatsRecord = false) {
     const hasStatActivity = Object.entries(normalizedStats || {}).some(([key, value]) => {
         if (includeTimeMs && String(key).toLowerCase() === 'time') return false;
         return Number(value) !== 0;
     });
 
     if (hasStatActivity) return true;
-    if (!includeTimeMs) return true;
+    if (!includeTimeMs) return hasPlayerStatsRecord;
 
     return (Number(playerStats.time) || 0) > 0;
 }
@@ -52,10 +52,11 @@ export function buildAggregatedStatsWrites({ players = [], playerStatsByPlayerId
         : {};
 
     return safePlayers.map((player) => {
-        const playerStats = safeStatsByPlayerId[player.id] || {};
+        const hasPlayerStatsRecord = Object.prototype.hasOwnProperty.call(safeStatsByPlayerId, player.id);
+        const playerStats = hasPlayerStatsRecord ? safeStatsByPlayerId[player.id] || {} : {};
 
         const normalizedStats = buildNormalizedPlayerStats(playerStats, columns);
-        const playerAppeared = hasTrackedPlayerActivity(playerStats, normalizedStats, includeTimeMs);
+        const playerAppeared = hasTrackedPlayerActivity(playerStats, normalizedStats, includeTimeMs, hasPlayerStatsRecord);
         // If we are including timeMs, ensure the internal 'time' accumulator is not persisted as a stat.
         if (includeTimeMs && normalizedStats.time !== undefined) {
             delete normalizedStats.time;

--- a/tests/unit/track-finish-batch-limit.test.js
+++ b/tests/unit/track-finish-batch-limit.test.js
@@ -123,7 +123,7 @@ describe('standard tracker finish batch limits', () => {
         ]);
     });
 
-    it('writes zero-stat roster players as player profile appearances', async () => {
+    it('marks untouched standard tracker roster players as did not appear', async () => {
         const harness = createFirestoreHarness();
 
         await commitStandardTrackerFinishData({
@@ -137,9 +137,13 @@ describe('standard tracker finish batch limits', () => {
             gameLog: [],
             players: [
                 { id: 'p1', name: 'Ava', number: '3' },
-                { id: 'p2', name: 'Ben', number: '8' }
+                { id: 'p2', name: 'Ben', number: '8' },
+                { id: 'p3', name: 'Cam', number: '11' }
             ],
-            playerStatsByPlayerId: { p1: { pts: 6, ast: 1 } },
+            playerStatsByPlayerId: {
+                p1: { pts: 6, ast: 1 },
+                p3: { pts: 0, ast: 0 }
+            },
             columns: ['PTS', 'AST'],
             finalHome: 6,
             finalAway: 4,
@@ -148,17 +152,28 @@ describe('standard tracker finish batch limits', () => {
         });
 
         const statsBatch = harness.batches[0];
-        const zeroStatWrite = statsBatch.operations.find((op) => op.ref.path === 'teams/team-1/games/game-1/aggregatedStats/p2');
+        const untouchedWrite = statsBatch.operations.find((op) => op.ref.path === 'teams/team-1/games/game-1/aggregatedStats/p2');
+        const explicitZeroStatWrite = statsBatch.operations.find((op) => op.ref.path === 'teams/team-1/games/game-1/aggregatedStats/p3');
 
-        expect(zeroStatWrite.data).toEqual({
+        expect(untouchedWrite.data).toEqual({
             playerName: 'Ben',
             playerNumber: '8',
+            participated: false,
+            participationStatus: 'did-not-appear',
+            participationSource: 'standard-tracker-finish',
+            didNotPlay: true,
+            stats: { pts: 0, ast: 0 }
+        });
+        expect(hasPlayerProfileParticipation(untouchedWrite.data)).toBe(false);
+        expect(explicitZeroStatWrite.data).toEqual({
+            playerName: 'Cam',
+            playerNumber: '11',
             participated: true,
             participationStatus: 'appeared',
             participationSource: 'standard-tracker-finish',
             stats: { pts: 0, ast: 0 }
         });
-        expect(hasPlayerProfileParticipation(zeroStatWrite.data)).toBe(true);
+        expect(hasPlayerProfileParticipation(explicitZeroStatWrite.data)).toBe(true);
     });
 
     it('writes private player stats to manager-only docs when finishing a standard tracker game', async () => {


### PR DESCRIPTION
Closes #1433

- Treat roster players with no standard tracker stats record as did not appear instead of participated.
- Preserve explicit zero-stat appearance behavior when a player has a stats record with all zero values.
- Added regression coverage for untouched roster players and explicit zero-stat entries.

Validation:
- `npx vitest run tests/unit/track-finish-batch-limit.test.js tests/unit/player-profile-stats.test.js --reporter=verbose`