### PR TITLE
Add printable roster action

### DIFF
--- a/edit-roster.html
+++ b/edit-roster.html
@@ -1586,8 +1586,8 @@
             printRoot.id = 'roster-print-root';
             printRoot.innerHTML = html;
             document.body.appendChild(printRoot);
+            window.addEventListener('afterprint', () => printRoot.remove(), { once: true });
             window.print();
-            window.setTimeout(() => printRoot.remove(), 0);
         }
 
         let currentInvitePlayer = null;

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -313,9 +313,13 @@
                 </section>
 
                 <div class="bg-white rounded-lg shadow-md overflow-hidden">
-                    <div class="p-6 border-b border-gray-200 flex justify-between items-center">
-                        <h2 class="text-xl font-bold">Current Roster</h2>
-                        <span id="team-name-display" class="text-gray-500"></span>
+                    <div class="p-6 border-b border-gray-200 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div>
+                            <h2 class="text-xl font-bold">Current Roster</h2>
+                            <span id="team-name-display" class="text-gray-500"></span>
+                            <p id="roster-print-message" class="mt-1 hidden text-sm text-amber-700"></p>
+                        </div>
+                        <button id="print-roster-btn" type="button" class="rounded-md border border-indigo-300 bg-indigo-50 px-3 py-2 text-sm font-semibold text-indigo-700 hover:bg-indigo-100">Print Roster</button>
                     </div>
                     <div class="px-6 py-3 bg-amber-50 border-b border-amber-100 text-sm text-amber-900">
                         Delete = deactivate from active roster, history preserved.
@@ -528,6 +532,7 @@
         import { hasFullTeamAccess } from './js/team-access.js';
         import { formatRegistrationRosterImportResults, getRegistrationRosterPlayers, isExternallyLinkedRosterTeam, planRegistrationRosterImport } from './js/edit-roster-registration-import.js?v=1';
         import { buildRegistrationReviewCsv, buildRegistrationReviewCsvFilename, getDefaultRegistrationReviewCsvColumnKeys, getRegistrationReviewCsvColumnDefinitions } from './js/registration-review.js?v=4';
+        import { buildRosterPrintHtml } from './js/roster-print.js?v=1';
         import { getApp } from './js/vendor/firebase-app.js';
         import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
 
@@ -549,6 +554,7 @@
         let trackingItems = [];
         let selectedTrackingItemId = '';
         let latestRosterPlayers = [];
+        let latestRosterPrintContactsByPlayerId = new Map();
         let trackingStatusRenderToken = 0;
         function hasAccess(team, user) {
             if (!team || !user) return false;
@@ -601,6 +607,7 @@
             document.getElementById('registration-status-filter').addEventListener('change', () => loadRegistrationReviews());
             document.getElementById('export-registration-csv-btn').addEventListener('click', exportRegistrationReviewsCsv);
             document.getElementById('registration-export-columns').addEventListener('change', handleRegistrationExportColumnChange);
+            document.getElementById('print-roster-btn').addEventListener('click', handlePrintRoster);
             document.getElementById('tracking-item-select').addEventListener('change', (event) => {
                 selectedTrackingItemId = event.target.value;
                 renderTrackingStatusMatrix();
@@ -1353,6 +1360,7 @@
                     existing.push(request);
                     pendingRequestsByPlayerId.set(request.playerId, existing);
                 });
+            latestRosterPrintContactsByPlayerId = parentsByPlayerId;
 
             if (players.length === 0) {
                 tbody.innerHTML = '<tr><td colspan="3" class="px-6 py-4 text-center text-gray-500">No players yet.</td></tr>';
@@ -1548,6 +1556,38 @@
                     }
                 });
             });
+        }
+
+        function handlePrintRoster() {
+            const message = document.getElementById('roster-print-message');
+            if (message) {
+                message.classList.add('hidden');
+                message.textContent = '';
+            }
+
+            const { html, model } = buildRosterPrintHtml({
+                team: currentTeam,
+                players: latestRosterPlayers,
+                fields: rosterFieldDefinitions,
+                contactsByPlayerId: latestRosterPrintContactsByPlayerId,
+                generatedAt: new Date()
+            });
+
+            if (model.activeCount === 0) {
+                if (message) {
+                    message.textContent = 'No active roster players to print.';
+                    message.classList.remove('hidden');
+                }
+                return;
+            }
+
+            document.getElementById('roster-print-root')?.remove();
+            const printRoot = document.createElement('div');
+            printRoot.id = 'roster-print-root';
+            printRoot.innerHTML = html;
+            document.body.appendChild(printRoot);
+            window.print();
+            window.setTimeout(() => printRoot.remove(), 0);
         }
 
         let currentInvitePlayer = null;

--- a/js/roster-print.js
+++ b/js/roster-print.js
@@ -1,0 +1,140 @@
+function escapeHtml(value) {
+    if (value === null || value === undefined) return '';
+    return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#039;');
+}
+
+function getRosterProfileValues(player = {}) {
+    return {
+        ...(player?.rosterFieldValues || {}),
+        ...(player?.customFields || {}),
+        ...(player?.profile?.rosterFields || {}),
+        ...(player?.profile?.customFields || {})
+    };
+}
+
+function isPrintableRosterField(field = {}) {
+    const visibility = String(field.visibility || 'team').trim().toLowerCase();
+    return field.active !== false && !['admin', 'admins', 'private', 'restricted'].includes(visibility);
+}
+
+function formatRosterFieldValue(field = {}, value) {
+    if (value === null || value === undefined || value === '') return '';
+    if (field.type === 'checkbox') return value === true ? 'Yes' : 'No';
+    if (field.type === 'menu') {
+        const option = (field.options || []).find((item) => String(item.value) === String(value));
+        return option?.label || value;
+    }
+    return value;
+}
+
+function parseJerseyNumber(value) {
+    const normalized = String(value ?? '').trim();
+    if (!normalized) return Number.POSITIVE_INFINITY;
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : Number.POSITIVE_INFINITY;
+}
+
+function getContactSummary(player = {}, contactsByPlayerId = {}) {
+    const keyedContacts = contactsByPlayerId instanceof Map
+        ? contactsByPlayerId.get(player.id)
+        : contactsByPlayerId?.[player.id];
+    const contacts = Array.isArray(keyedContacts) ? keyedContacts : [];
+    const playerContacts = Array.isArray(player.parents) ? player.parents : [];
+    const combined = [...contacts, ...playerContacts]
+        .filter((contact) => contact && contact.status !== 'removed')
+        .map((contact) => {
+            const label = contact.name || contact.displayName || contact.fullName || contact.email || 'Contact';
+            const relation = contact.relation || contact.role || '';
+            const email = contact.email && contact.email !== label ? contact.email : '';
+            return [label, relation ? `(${relation})` : '', email].filter(Boolean).join(' ');
+        })
+        .filter(Boolean);
+    return [...new Set(combined)].join('; ');
+}
+
+export function buildRosterPrintViewModel({ team = {}, players = [], fields = [], contactsByPlayerId = {}, generatedAt = new Date() } = {}) {
+    const printableFields = (fields || []).filter(isPrintableRosterField);
+    const activePlayers = (players || [])
+        .filter((player) => player && player.active !== false)
+        .map((player) => {
+            const values = getRosterProfileValues(player);
+            return {
+                id: player.id,
+                number: String(player.number ?? '').trim(),
+                name: String(player.name || 'Unnamed player').trim(),
+                contactSummary: getContactSummary(player, contactsByPlayerId),
+                fields: printableFields
+                    .map((field) => ({
+                        key: field.key,
+                        label: field.label,
+                        value: formatRosterFieldValue(field, values[field.key])
+                    }))
+                    .filter((field) => String(field.value ?? '').trim() !== '')
+            };
+        })
+        .sort((a, b) => parseJerseyNumber(a.number) - parseJerseyNumber(b.number)
+            || a.name.localeCompare(b.name)
+            || String(a.number).localeCompare(String(b.number)));
+
+    return {
+        teamName: team.name || team.teamName || 'Team roster',
+        generatedDate: generatedAt instanceof Date ? generatedAt.toLocaleString() : String(generatedAt || ''),
+        activeCount: activePlayers.length,
+        fields: printableFields.map((field) => ({ key: field.key, label: field.label })),
+        players: activePlayers
+    };
+}
+
+export function buildRosterPrintHtml(options = {}) {
+    const model = buildRosterPrintViewModel(options);
+    const fieldHeaders = model.fields.map((field) => `<th>${escapeHtml(field.label)}</th>`).join('');
+    const rows = model.players.map((player) => {
+        const fieldCells = model.fields.map((field) => {
+            const playerField = player.fields.find((item) => item.key === field.key);
+            return `<td>${escapeHtml(playerField?.value || '')}</td>`;
+        }).join('');
+        return `<tr>
+            <td>${escapeHtml(player.number || '-')}</td>
+            <td>${escapeHtml(player.name)}</td>
+            <td>${escapeHtml(player.contactSummary || 'None listed')}</td>
+            ${fieldCells}
+        </tr>`;
+    }).join('');
+
+    return {
+        model,
+        html: `
+            <style>
+                @media screen { #roster-print-root { display: none; } }
+                @media print {
+                    body > *:not(#roster-print-root) { display: none !important; }
+                    #roster-print-root { display: block !important; color: #111827; font-family: Arial, sans-serif; padding: 24px; }
+                    #roster-print-root table { width: 100%; border-collapse: collapse; margin-top: 16px; }
+                    #roster-print-root th, #roster-print-root td { border: 1px solid #d1d5db; padding: 8px; text-align: left; vertical-align: top; }
+                    #roster-print-root th { background: #f3f4f6; font-size: 12px; text-transform: uppercase; }
+                    #roster-print-root .roster-print-meta { color: #4b5563; font-size: 13px; margin-top: 4px; }
+                }
+            </style>
+            <section aria-label="Printable roster">
+                <h1>${escapeHtml(model.teamName)} Roster</h1>
+                <p class="roster-print-meta">Generated ${escapeHtml(model.generatedDate)} · ${model.activeCount} active player${model.activeCount === 1 ? '' : 's'}</p>
+                <table>
+                    <thead>
+                        <tr>
+                            <th>#</th>
+                            <th>Player</th>
+                            <th>Parent / contact summary</th>
+                            ${fieldHeaders}
+                        </tr>
+                    </thead>
+                    <tbody>${rows}</tbody>
+                </table>
+            </section>
+        `
+    };
+}

--- a/tests/unit/edit-roster-print-wiring.test.js
+++ b/tests/unit/edit-roster-print-wiring.test.js
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const html = readFileSync(resolve('edit-roster.html'), 'utf8');
+
+describe('edit roster print wiring', () => {
+    it('renders a current roster print button and imports the print helper', () => {
+        expect(html).toContain('id="print-roster-btn"');
+        expect(html).toContain('Print Roster');
+        expect(html).toContain("import { buildRosterPrintHtml } from './js/roster-print.js?v=1';");
+    });
+
+    it('clicking print roster builds content before calling window.print and blocks empty rosters', () => {
+        expect(html).toContain("document.getElementById('print-roster-btn').addEventListener('click', handlePrintRoster)");
+        expect(html).toContain('const { html, model } = buildRosterPrintHtml');
+        expect(html).toContain('if (model.activeCount === 0)');
+        expect(html).toContain('No active roster players to print.');
+        expect(html.indexOf('printRoot.innerHTML = html')).toBeLessThan(html.indexOf('window.print();'));
+    });
+});

--- a/tests/unit/roster-print.test.js
+++ b/tests/unit/roster-print.test.js
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { buildRosterPrintHtml, buildRosterPrintViewModel } from '../../js/roster-print.js';
+
+describe('roster print helpers', () => {
+    const fields = [
+        { key: 'grade', label: 'Grade', type: 'menu', options: [{ value: '6', label: 'Sixth' }], visibility: 'team', active: true },
+        { key: 'throwsRight', label: 'Throws Right', type: 'checkbox', visibility: 'public', active: true },
+        { key: 'medicalNote', label: 'Medical Note', type: 'text', visibility: 'admins', active: true }
+    ];
+
+    it('sorts active players by jersey number then name and excludes inactive players', () => {
+        const model = buildRosterPrintViewModel({
+            team: { name: 'Falcons' },
+            fields,
+            players: [
+                { id: 'p3', name: 'Zoe Reed', number: '11', active: true },
+                { id: 'p2', name: 'Avery Lee', number: '2', active: true },
+                { id: 'p4', name: 'Inactive Player', number: '1', active: false },
+                { id: 'p1', name: 'Sam Jones', number: '2', active: true }
+            ],
+            generatedAt: new Date('2026-05-26T20:00:00Z')
+        });
+
+        expect(model.activeCount).toBe(3);
+        expect(model.players.map((player) => player.name)).toEqual(['Avery Lee', 'Sam Jones', 'Zoe Reed']);
+    });
+
+    it('formats printable fields and parent/contact summaries without admin-only fields', () => {
+        const { html, model } = buildRosterPrintHtml({
+            team: { name: 'Falcons' },
+            fields,
+            contactsByPlayerId: new Map([
+                ['p1', [{ name: 'Pat Parent', relation: 'Mother', email: 'pat@example.com' }]]
+            ]),
+            players: [{
+                id: 'p1',
+                name: '<Sam Jones>',
+                number: '7',
+                profile: { customFields: { grade: '6', throwsRight: true, medicalNote: 'Private allergy' } },
+                parents: [{ name: 'Casey Contact', relation: 'Guardian', email: 'casey@example.com' }]
+            }],
+            generatedAt: new Date('2026-05-26T20:00:00Z')
+        });
+
+        expect(model.fields.map((field) => field.label)).toEqual(['Grade', 'Throws Right']);
+        expect(model.players[0].fields).toEqual([
+            { key: 'grade', label: 'Grade', value: 'Sixth' },
+            { key: 'throwsRight', label: 'Throws Right', value: 'Yes' }
+        ]);
+        expect(model.players[0].contactSummary).toContain('Pat Parent (Mother) pat@example.com');
+        expect(model.players[0].contactSummary).toContain('Casey Contact (Guardian) casey@example.com');
+        expect(html).toContain('&lt;Sam Jones&gt;');
+        expect(html).not.toContain('Private allergy');
+        expect(html).not.toContain('Medical Note');
+    });
+});


### PR DESCRIPTION
Closes #1435

## What changed
- Added a Print Roster button to roster management.
- Added a roster print helper that builds sanitized printable roster HTML before invoking `window.print()`.
- Excludes inactive players by default and omits admin/private roster fields from the print layout.
- Includes team name, generated date, active count, jersey number, player name, parent/contact summaries, and visible roster fields.
- Shows an empty-state message instead of printing a blank roster.

## Validation
- `npx vitest run tests/unit/roster-print.test.js tests/unit/edit-roster-print-wiring.test.js tests/unit/roster-csv-import.test.js --reporter=verbose`