### PR TITLE
Load real team fees for checkout

### DIFF
--- a/docs/pr-notes/runs/1438-remediator-20260526T214305Z/architecture.md
+++ b/docs/pr-notes/runs/1438-remediator-20260526T214305Z/architecture.md
@@ -1,0 +1,5 @@
+# Architecture
+
+- Use the signed-in user's profile parent links to build scoped fee-recipient queries by team and player.
+- Constrain direct user-id recipient lookups by linked team when links exist, and add player-specific queries for roster-generated records.
+- Deduplicate snapshots into a single map keyed by document path before normalizing TeamFee records.

--- a/docs/pr-notes/runs/1438-remediator-20260526T214305Z/code-plan.md
+++ b/docs/pr-notes/runs/1438-remediator-20260526T214305Z/code-plan.md
@@ -1,0 +1,5 @@
+# Code Plan
+
+- Add user profile loading for parent link metadata.
+- Build fee recipient queries from linked team/player scope and keep direct-user fallback when links are unavailable.
+- Process only deduplicated documents and filter scoped results to the signed-in parent or linked player keys.

--- a/docs/pr-notes/runs/1438-remediator-20260526T214305Z/qa.md
+++ b/docs/pr-notes/runs/1438-remediator-20260526T214305Z/qa.md
@@ -1,0 +1,5 @@
+# QA
+
+- Add regression coverage for overlapping query results returning the same fee recipient document.
+- Add regression coverage for parent-linked player fee recipients without direct user-id fields.
+- Run the focused TeamFeesComponent Vitest spec.

--- a/docs/pr-notes/runs/1438-remediator-20260526T214305Z/requirements.md
+++ b/docs/pr-notes/runs/1438-remediator-20260526T214305Z/requirements.md
@@ -1,0 +1,5 @@
+# Requirements
+
+- Prevent duplicate fee recipient documents returned by overlapping Firestore queries from producing duplicate or nondeterministic TeamFee entries.
+- Load parent-assigned fee recipients generated from roster assignments, including records with `teamId`/`playerId` or `playerKey` but no direct user-id fields.
+- Keep fallback behavior for accounts without parent link metadata so directly keyed recipient records still load.

--- a/src/app/team-fees/team-fees.component.spec.ts
+++ b/src/app/team-fees/team-fees.component.spec.ts
@@ -7,6 +7,7 @@ const mockAuth = {
   onAuthStateChanged: vi.fn()
 };
 const mockGetDocs = vi.fn();
+const mockGetDoc = vi.fn();
 const mockRecipientsRef = {};
 const mockDb = {};
 
@@ -21,6 +22,8 @@ vi.mock('firebase/auth', () => ({
 
 vi.mock('firebase/firestore', () => ({
   collectionGroup: vi.fn(() => mockRecipientsRef),
+  doc: vi.fn((...args) => ({ args })),
+  getDoc: mockGetDoc,
   getDocs: mockGetDocs,
   getFirestore: vi.fn(() => mockDb),
   query: vi.fn((...args) => ({ args })),
@@ -36,7 +39,7 @@ vi.mock('../shared/services/stripe.service', () => ({
 }));
 
 const { TeamFeesComponent } = await import('./team-fees.component');
-const { collectionGroup, getFirestore, query, where } = await import('firebase/firestore');
+const { collectionGroup, doc, getDoc, getFirestore, query, where } = await import('firebase/firestore');
 
 const template = readFileSync(resolve(process.cwd(), 'src/app/team-fees/team-fees.component.html'), 'utf8');
 
@@ -56,6 +59,7 @@ describe('TeamFeesComponent checkout flow', () => {
     vi.clearAllMocks();
     mockAuth.currentUser = { uid: 'parent-123' };
     mockAuth.onAuthStateChanged.mockReset();
+    mockGetDoc.mockResolvedValue({ exists: () => false, data: () => ({}) });
     mockGetDocs.mockResolvedValue({ docs: [] });
     stripeService = {
       initiateTeamFeeCheckout: vi.fn().mockResolvedValue('https://checkout.stripe.com/team-fee-session')
@@ -110,6 +114,71 @@ describe('TeamFeesComponent checkout flow', () => {
       }
     ]);
     expect(component.isLoadingFees).toBe(false);
+  });
+
+  it('deduplicates overlapping fee recipient query results before mapping fees', async () => {
+    const feeOne = feeDoc('teams/team-real/feeBatches/batch-real/feeRecipients/recipient-real', 'recipient-real', {
+      parentUserId: 'parent-123',
+      title: 'Spring registration',
+      balanceDueCents: 12500,
+      status: 'unpaid'
+    });
+    mockGetDocs
+      .mockResolvedValueOnce({ docs: [feeOne, feeOne] })
+      .mockResolvedValueOnce({ docs: [feeOne] })
+      .mockResolvedValueOnce({ docs: [] });
+
+    await component.ngOnInit();
+
+    expect(component.teamFees).toEqual([
+      {
+        id: 'recipient-real',
+        teamId: 'team-real',
+        batchId: 'batch-real',
+        recipientId: 'recipient-real',
+        name: 'Spring registration',
+        amount: 125,
+        isPaid: false
+      }
+    ]);
+  });
+
+  it('loads parent-assigned fee recipients by linked team and player when records omit user IDs', async () => {
+    mockGetDoc.mockResolvedValue({
+      exists: () => true,
+      data: () => ({ parentOf: [{ teamId: 'team-real', playerId: 'player-real' }] })
+    });
+    const playerFee = feeDoc('teams/team-real/feeBatches/batch-real/feeRecipients/player-real', 'player-real', {
+      teamId: 'team-real',
+      playerId: 'player-real',
+      feeTitle: 'Roster fee',
+      amountCents: 7500,
+      status: 'unpaid'
+    });
+    mockGetDocs
+      .mockResolvedValueOnce({ docs: [] })
+      .mockResolvedValueOnce({ docs: [] })
+      .mockResolvedValueOnce({ docs: [] })
+      .mockResolvedValueOnce({ docs: [playerFee] });
+
+    await component.ngOnInit();
+
+    expect(doc).toHaveBeenCalledWith(mockDb, 'users', 'parent-123');
+    expect(getDoc).toHaveBeenCalled();
+    expect(where).toHaveBeenCalledWith('teamId', '==', 'team-real');
+    expect(where).toHaveBeenCalledWith('playerId', '==', 'player-real');
+    expect(query).toHaveBeenCalledTimes(4);
+    expect(component.teamFees).toEqual([
+      {
+        id: 'player-real',
+        teamId: 'team-real',
+        batchId: 'batch-real',
+        recipientId: 'player-real',
+        name: 'Roster fee',
+        amount: 75,
+        isPaid: false
+      }
+    ]);
   });
 
   it('does not populate hard-coded mock team fees when no user is signed in', async () => {

--- a/src/app/team-fees/team-fees.component.spec.ts
+++ b/src/app/team-fees/team-fees.component.spec.ts
@@ -2,9 +2,33 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const mockAuth = {
+  currentUser: { uid: 'parent-123' },
+  onAuthStateChanged: vi.fn()
+};
+const mockGetDocs = vi.fn();
+const mockRecipientsRef = {};
+const mockDb = {};
+
 vi.mock('@angular/core', () => ({
   Component: () => () => undefined,
   OnInit: class {}
+}));
+
+vi.mock('firebase/auth', () => ({
+  getAuth: vi.fn(() => mockAuth)
+}));
+
+vi.mock('firebase/firestore', () => ({
+  collectionGroup: vi.fn(() => mockRecipientsRef),
+  getDocs: mockGetDocs,
+  getFirestore: vi.fn(() => mockDb),
+  query: vi.fn((...args) => ({ args })),
+  where: vi.fn((field, operator, value) => ({ field, operator, value }))
+}));
+
+vi.mock('../firebase-config', () => ({
+  app: {}
 }));
 
 vi.mock('../shared/services/stripe.service', () => ({
@@ -12,43 +36,125 @@ vi.mock('../shared/services/stripe.service', () => ({
 }));
 
 const { TeamFeesComponent } = await import('./team-fees.component');
+const { collectionGroup, getFirestore, query, where } = await import('firebase/firestore');
 
 const template = readFileSync(resolve(process.cwd(), 'src/app/team-fees/team-fees.component.html'), 'utf8');
+
+function feeDoc(path: string, id: string, data: Record<string, unknown>) {
+  return {
+    id,
+    ref: { path },
+    data: () => data
+  };
+}
 
 describe('TeamFeesComponent checkout flow', () => {
   let stripeService: { initiateTeamFeeCheckout: ReturnType<typeof vi.fn> };
   let component: InstanceType<typeof TeamFeesComponent>;
 
   beforeEach(() => {
+    vi.clearAllMocks();
+    mockAuth.currentUser = { uid: 'parent-123' };
+    mockAuth.onAuthStateChanged.mockReset();
+    mockGetDocs.mockResolvedValue({ docs: [] });
     stripeService = {
       initiateTeamFeeCheckout: vi.fn().mockResolvedValue('https://checkout.stripe.com/team-fee-session')
     };
     component = new TeamFeesComponent(stripeService as never);
   });
 
-  it('renders a Pay Team Fee button only for unpaid fees', () => {
-    component.ngOnInit();
+  it('loads only the signed-in user fee recipient records from Firestore', async () => {
+    const feeOne = feeDoc('teams/team-real/feeBatches/batch-real/feeRecipients/recipient-real', 'recipient-real', {
+      parentUserId: 'parent-123',
+      title: 'Spring registration',
+      balanceDueCents: 12500,
+      status: 'unpaid'
+    });
+    const paidFee = feeDoc('teams/team-real/feeBatches/batch-paid/feeRecipients/recipient-paid', 'recipient-paid', {
+      userId: 'parent-123',
+      feeTitle: 'Uniform fee',
+      amountCents: 5000,
+      status: 'paid'
+    });
+    mockGetDocs
+      .mockResolvedValueOnce({ docs: [feeOne] })
+      .mockResolvedValueOnce({ docs: [feeOne] })
+      .mockResolvedValueOnce({ docs: [paidFee] });
+
+    await component.ngOnInit();
+
+    expect(getFirestore).toHaveBeenCalledWith({});
+    expect(collectionGroup).toHaveBeenCalledWith(mockDb, 'feeRecipients');
+    expect(where).toHaveBeenCalledWith('parentUserId', '==', 'parent-123');
+    expect(where).toHaveBeenCalledWith('accountUserId', '==', 'parent-123');
+    expect(where).toHaveBeenCalledWith('userId', '==', 'parent-123');
+    expect(query).toHaveBeenCalledTimes(3);
+    expect(component.teamFees).toEqual([
+      {
+        id: 'recipient-real',
+        teamId: 'team-real',
+        batchId: 'batch-real',
+        recipientId: 'recipient-real',
+        name: 'Spring registration',
+        amount: 125,
+        isPaid: false
+      },
+      {
+        id: 'recipient-paid',
+        teamId: 'team-real',
+        batchId: 'batch-paid',
+        recipientId: 'recipient-paid',
+        name: 'Uniform fee',
+        amount: 50,
+        isPaid: true
+      }
+    ]);
+    expect(component.isLoadingFees).toBe(false);
+  });
+
+  it('does not populate hard-coded mock team fees when no user is signed in', async () => {
+    mockAuth.currentUser = null;
+    mockAuth.onAuthStateChanged.mockImplementation((next: (user: null) => void) => {
+      next(null);
+      return () => undefined;
+    });
+
+    await component.ngOnInit();
+
+    expect(mockGetDocs).not.toHaveBeenCalled();
+    expect(component.teamFees).toEqual([]);
+    expect(component.paymentErrorMessage).toBeNull();
+  });
+
+  it('renders a Pay Team Fee button only for unpaid fees', async () => {
+    mockGetDocs.mockResolvedValueOnce({
+      docs: [feeDoc('teams/team-real/feeBatches/batch-real/feeRecipients/recipient-real', 'recipient-real', {
+        title: 'Spring registration',
+        balanceDueCents: 12500,
+        status: 'unpaid'
+      })]
+    });
+
+    await component.ngOnInit();
 
     expect(template).toContain('*ngIf="!fee.isPaid"');
     expect(template).toContain('Pay Team Fee');
-    expect(component.teamFees).toEqual([
-      expect.objectContaining({ id: 'fee1', isPaid: false }),
-      expect.objectContaining({ id: 'fee2', isPaid: true }),
-      expect.objectContaining({ id: 'fee3', isPaid: false })
-    ]);
-    expect(component.teamFees.filter((fee) => !fee.isPaid)).toHaveLength(2);
+    expect(component.teamFees.filter((fee) => !fee.isPaid)).toHaveLength(1);
   });
 
-  it('passes teamId, batchId, and recipientId to StripeService before redirecting', async () => {
-    component.ngOnInit();
-    const unpaidFee = component.teamFees.find((fee) => !fee.isPaid);
+  it('passes the selected fee recipient IDs to StripeService before redirecting', async () => {
+    const selectedFee = {
+      id: 'recipient-real',
+      teamId: 'team-real',
+      batchId: 'batch-real',
+      recipientId: 'recipient-real',
+      name: 'Spring registration',
+      amount: 125,
+      isPaid: false
+    };
+    component.teamFees = [selectedFee];
 
     expect(template).toContain('handlePayFee(fee)');
-    expect(unpaidFee).toEqual(expect.objectContaining({
-      teamId: 'teamA',
-      batchId: 'batch1',
-      recipientId: 'recipient1'
-    }));
 
     const originalWindow = globalThis.window;
     Object.defineProperty(globalThis, 'window', {
@@ -56,9 +162,9 @@ describe('TeamFeesComponent checkout flow', () => {
       value: { location: { href: 'https://allplays.test/team-fees' } }
     });
 
-    await component.handlePayFee(unpaidFee!);
+    await component.handlePayFee(selectedFee);
 
-    expect(stripeService.initiateTeamFeeCheckout).toHaveBeenCalledWith('teamA', 'batch1', 'recipient1');
+    expect(stripeService.initiateTeamFeeCheckout).toHaveBeenCalledWith('team-real', 'batch-real', 'recipient-real');
     expect(globalThis.window.location.href).toBe('https://checkout.stripe.com/team-fee-session');
     expect(component.pendingPaymentFeeId).toBeNull();
     expect(component.paymentErrorMessage).toBeNull();
@@ -70,8 +176,8 @@ describe('TeamFeesComponent checkout flow', () => {
   });
 
   it('scopes the initiating payment state to the selected unpaid fee', async () => {
-    component.ngOnInit();
-    const [selectedFee, otherUnpaidFee] = component.teamFees.filter((fee) => !fee.isPaid);
+    const selectedFee = { id: 'recipient-real', teamId: 'team-real', batchId: 'batch-real', recipientId: 'recipient-real', name: 'Registration', amount: 125, isPaid: false };
+    const otherUnpaidFee = { id: 'recipient-other', teamId: 'team-real', batchId: 'batch-other', recipientId: 'recipient-other', name: 'Tournament', amount: 75, isPaid: false };
     let resolveCheckout: (checkoutUrl: string) => void = () => undefined;
     stripeService.initiateTeamFeeCheckout.mockReturnValue(new Promise((resolve) => {
       resolveCheckout = resolve;
@@ -105,8 +211,8 @@ describe('TeamFeesComponent checkout flow', () => {
   });
 
   it('ignores overlapping checkout attempts while another fee payment is pending', async () => {
-    component.ngOnInit();
-    const [selectedFee, otherUnpaidFee] = component.teamFees.filter((fee) => !fee.isPaid);
+    const selectedFee = { id: 'recipient-real', teamId: 'team-real', batchId: 'batch-real', recipientId: 'recipient-real', name: 'Registration', amount: 125, isPaid: false };
+    const otherUnpaidFee = { id: 'recipient-other', teamId: 'team-real', batchId: 'batch-other', recipientId: 'recipient-other', name: 'Tournament', amount: 75, isPaid: false };
     let resolveCheckout: (checkoutUrl: string) => void = () => undefined;
     stripeService.initiateTeamFeeCheckout.mockReturnValue(new Promise((resolve) => {
       resolveCheckout = resolve;
@@ -121,7 +227,7 @@ describe('TeamFeesComponent checkout flow', () => {
     await component.handlePayFee(otherUnpaidFee);
 
     expect(stripeService.initiateTeamFeeCheckout).toHaveBeenCalledTimes(1);
-    expect(stripeService.initiateTeamFeeCheckout).toHaveBeenCalledWith('teamA', 'batch1', 'recipient1');
+    expect(stripeService.initiateTeamFeeCheckout).toHaveBeenCalledWith('team-real', 'batch-real', 'recipient-real');
     expect(component.pendingPaymentFeeId).toBe(selectedFee.id);
     expect(component.isPaymentPending()).toBe(true);
     expect(component.isPaymentLoading(selectedFee.id)).toBe(true);
@@ -140,21 +246,20 @@ describe('TeamFeesComponent checkout flow', () => {
   });
 
   it('resets only the selected fee loading state and shows the existing error on checkout failure', async () => {
-    component.ngOnInit();
-    const [selectedFee, otherUnpaidFee] = component.teamFees.filter((fee) => !fee.isPaid);
+    const selectedFee = { id: 'recipient-real', teamId: 'team-real', batchId: 'batch-real', recipientId: 'recipient-real', name: 'Registration', amount: 125, isPaid: false };
+    const otherUnpaidFee = { id: 'recipient-other', teamId: 'team-real', batchId: 'batch-other', recipientId: 'recipient-other', name: 'Tournament', amount: 75, isPaid: false };
     stripeService.initiateTeamFeeCheckout.mockRejectedValue(new Error('Stripe unavailable'));
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
     await component.handlePayFee(selectedFee);
 
     expect(consoleError).toHaveBeenCalledWith('Failed to initiate payment:', expect.any(Error));
-    expect(stripeService.initiateTeamFeeCheckout).toHaveBeenCalledWith('teamA', 'batch1', 'recipient1');
+    expect(stripeService.initiateTeamFeeCheckout).toHaveBeenCalledWith('team-real', 'batch-real', 'recipient-real');
     expect(component.pendingPaymentFeeId).toBeNull();
     expect(component.isPaymentPending()).toBe(false);
     expect(component.isPaymentLoading(selectedFee.id)).toBe(false);
     expect(component.isPaymentLoading(otherUnpaidFee.id)).toBe(false);
     expect(component.paymentErrorMessage).toBe('Failed to initiate payment. Please try again.');
-    expect(component.teamFees.find((fee) => fee.id === 'fee2')).toEqual(expect.objectContaining({ isPaid: true }));
 
     consoleError.mockRestore();
   });

--- a/src/app/team-fees/team-fees.component.ts
+++ b/src/app/team-fees/team-fees.component.ts
@@ -2,7 +2,7 @@
 import { Component, OnInit } from '@angular/core';
 import { getAuth } from 'firebase/auth';
 import type { User } from 'firebase/auth';
-import { collectionGroup, getDocs, getFirestore, query, where } from 'firebase/firestore';
+import { collectionGroup, doc, getDoc, getDocs, getFirestore, query, where } from 'firebase/firestore';
 import { app } from '../firebase-config';
 import { StripeService } from '../shared/services/stripe.service';
 
@@ -16,6 +16,16 @@ interface TeamFee {
   isPaid: boolean;
 }
 
+type ParentPlayerLink = {
+  teamId?: string;
+  playerId?: string;
+};
+
+type UserProfileData = {
+  parentOf?: ParentPlayerLink[];
+  parentPlayerKeys?: string[];
+};
+
 type FeeRecipientData = {
   title?: string;
   feeTitle?: string;
@@ -28,7 +38,46 @@ type FeeRecipientData = {
   isPaid?: boolean;
   teamId?: string;
   batchId?: string;
+  parentUserId?: string;
+  accountUserId?: string;
+  userId?: string;
+  playerId?: string;
+  childId?: string;
+  playerKey?: string;
 };
+
+
+function getParentPlayerKey(teamId: string, playerId: string): string {
+  return teamId && playerId ? `${teamId}::${playerId}` : '';
+}
+
+function uniqueStrings(values: string[]): string[] {
+  return Array.from(new Set(values.filter(Boolean)));
+}
+
+function getAllowedParentPlayerKeys(profile: UserProfileData): string[] {
+  const profileKeys = Array.isArray(profile.parentPlayerKeys) ? profile.parentPlayerKeys : [];
+  const linkKeys = (Array.isArray(profile.parentOf) ? profile.parentOf : [])
+    .map((link) => getParentPlayerKey(String(link?.teamId || ''), String(link?.playerId || '')));
+  return uniqueStrings([...profileKeys, ...linkKeys]);
+}
+
+function getChildLinks(parentPlayerKeys: string[]): ParentPlayerLink[] {
+  return parentPlayerKeys
+    .map((key) => {
+      const [teamId, playerId] = key.split('::');
+      return { teamId: teamId || '', playerId: playerId || '' };
+    })
+    .filter((link) => link.teamId && link.playerId);
+}
+
+function isAllowedParentFeeRecipient(data: FeeRecipientData, userId: string, parentPlayerKeys: Set<string>): boolean {
+  if ([data.parentUserId, data.accountUserId, data.userId].includes(userId)) return true;
+  const teamId = data.teamId || '';
+  const playerId = data.playerId || data.childId || '';
+  const playerKey = data.playerKey || getParentPlayerKey(teamId, playerId);
+  return parentPlayerKeys.has(playerKey);
+}
 
 function getPathSegment(path: string, segment: string): string {
   const parts = path.split('/');
@@ -107,33 +156,71 @@ export class TeamFeesComponent implements OnInit {
   private async loadFeeRecipientsForUser(userId: string): Promise<TeamFee[]> {
     const db = getFirestore(app);
     const recipientsRef = collectionGroup(db, 'feeRecipients');
-    const snapshots = await Promise.all([
-      getDocs(query(recipientsRef, where('parentUserId', '==', userId))),
-      getDocs(query(recipientsRef, where('accountUserId', '==', userId))),
-      getDocs(query(recipientsRef, where('userId', '==', userId)))
-    ]);
+    const userProfile = await this.loadUserProfile(db, userId);
+    const parentPlayerKeys = new Set(getAllowedParentPlayerKeys(userProfile));
+    const childLinks = getChildLinks(Array.from(parentPlayerKeys));
+    const teamIds = uniqueStrings(childLinks.map((child) => String(child.teamId || '')));
+    const feeQueries = teamIds.length > 0
+      ? [
+          ...teamIds.flatMap((teamId) => [
+            query(recipientsRef, where('teamId', '==', teamId), where('parentUserId', '==', userId)),
+            query(recipientsRef, where('teamId', '==', teamId), where('accountUserId', '==', userId)),
+            query(recipientsRef, where('teamId', '==', teamId), where('userId', '==', userId))
+          ]),
+          ...childLinks.map((child) => query(
+            recipientsRef,
+            where('teamId', '==', child.teamId),
+            where('playerId', '==', child.playerId)
+          ))
+        ]
+      : [
+          query(recipientsRef, where('parentUserId', '==', userId)),
+          query(recipientsRef, where('accountUserId', '==', userId)),
+          query(recipientsRef, where('userId', '==', userId))
+        ];
+    const snapshots = await Promise.all(feeQueries.map((feeQuery) => getDocs(feeQuery)));
+    const uniqueDocs = new Map<string, { id: string; ref: { path: string }; data: () => unknown }>();
     const feesByPath = new Map<string, TeamFee>();
 
     snapshots.forEach((snapshot) => {
       snapshot.docs.forEach((docSnap) => {
-        const data = docSnap.data() as FeeRecipientData;
-        const teamId = data.teamId || getPathSegment(docSnap.ref.path, 'teams');
-        const batchId = data.batchId || getPathSegment(docSnap.ref.path, 'feeBatches');
-        if (!teamId || !batchId) return;
+        if (!uniqueDocs.has(docSnap.ref.path)) {
+          uniqueDocs.set(docSnap.ref.path, docSnap);
+        }
+      });
+    });
 
-        feesByPath.set(docSnap.ref.path, {
-          id: docSnap.id,
-          teamId,
-          batchId,
-          recipientId: docSnap.id,
-          name: data.title || data.feeTitle || data.name || 'Team Fee',
-          amount: normalizeAmount(data),
-          isPaid: isFeePaid(data)
-        });
+    uniqueDocs.forEach((docSnap) => {
+      const data = docSnap.data() as FeeRecipientData;
+      const teamId = data.teamId || getPathSegment(docSnap.ref.path, 'teams');
+      const batchId = data.batchId || getPathSegment(docSnap.ref.path, 'feeBatches');
+      if (!teamId || !batchId) return;
+
+      const normalizedData = { ...data, teamId };
+      if (parentPlayerKeys.size > 0 && !isAllowedParentFeeRecipient(normalizedData, userId, parentPlayerKeys)) return;
+
+      feesByPath.set(docSnap.ref.path, {
+        id: docSnap.id,
+        teamId,
+        batchId,
+        recipientId: docSnap.id,
+        name: data.title || data.feeTitle || data.name || 'Team Fee',
+        amount: normalizeAmount(data),
+        isPaid: isFeePaid(data)
       });
     });
 
     return Array.from(feesByPath.values());
+  }
+
+  private async loadUserProfile(db: ReturnType<typeof getFirestore>, userId: string): Promise<UserProfileData> {
+    try {
+      const userSnap = await getDoc(doc(db, 'users', userId));
+      return userSnap.exists() ? userSnap.data() as UserProfileData : {};
+    } catch (error) {
+      console.warn('Failed to load team fee parent links:', error);
+      return {};
+    }
   }
 
   isPaymentLoading(feeId: string): boolean {

--- a/src/app/team-fees/team-fees.component.ts
+++ b/src/app/team-fees/team-fees.component.ts
@@ -1,5 +1,9 @@
 // src/app/team-fees/team-fees.component.ts
 import { Component, OnInit } from '@angular/core';
+import { getAuth } from 'firebase/auth';
+import type { User } from 'firebase/auth';
+import { collectionGroup, getDocs, getFirestore, query, where } from 'firebase/firestore';
+import { app } from '../firebase-config';
 import { StripeService } from '../shared/services/stripe.service';
 
 interface TeamFee {
@@ -9,8 +13,41 @@ interface TeamFee {
   recipientId: string;
   name: string;
   amount: number;
-  isPaid: boolean; // Assuming this property
-  // ... other fee properties
+  isPaid: boolean;
+}
+
+type FeeRecipientData = {
+  title?: string;
+  feeTitle?: string;
+  name?: string;
+  amount?: number;
+  amountCents?: number;
+  balanceDueCents?: number;
+  status?: string;
+  paid?: boolean;
+  isPaid?: boolean;
+  teamId?: string;
+  batchId?: string;
+};
+
+function getPathSegment(path: string, segment: string): string {
+  const parts = path.split('/');
+  const index = parts.indexOf(segment);
+  return index >= 0 ? parts[index + 1] || '' : '';
+}
+
+function normalizeAmount(data: FeeRecipientData): number {
+  if (typeof data.balanceDueCents === 'number') return data.balanceDueCents / 100;
+  if (typeof data.amountCents === 'number') return data.amountCents / 100;
+  if (typeof data.amount === 'number') return data.amount;
+  return 0;
+}
+
+function isFeePaid(data: FeeRecipientData): boolean {
+  const status = String(data.status || '').toLowerCase();
+  if (status === 'paid') return true;
+  if (data.paid === true || data.isPaid === true) return true;
+  return typeof data.balanceDueCents === 'number' && data.balanceDueCents <= 0;
 }
 
 @Component({
@@ -19,20 +56,84 @@ interface TeamFee {
   styleUrls: ['./team-fees.component.css']
 })
 export class TeamFeesComponent implements OnInit {
-  teamFees: TeamFee[] = []; // Populate this from data service
+  teamFees: TeamFee[] = [];
   pendingPaymentFeeId: string | null = null;
   paymentErrorMessage: string | null = null;
+  isLoadingFees = false;
 
   constructor(private stripeService: StripeService) { }
 
-  ngOnInit(): void {
-    // In a real application, data would be fetched from Firestore or a backend API.
-    // For this demonstration, we populate with mock data.
-    this.teamFees = [
-      { id: 'fee1', teamId: 'teamA', batchId: 'batch1', recipientId: 'recipient1', name: 'Registration Fee', amount: 100, isPaid: false },
-      { id: 'fee2', teamId: 'teamA', batchId: 'batch2', recipientId: 'recipient2', name: 'Uniform Fee', amount: 50, isPaid: true },
-      { id: 'fee3', teamId: 'teamB', batchId: 'batch3', recipientId: 'recipient3', name: 'Tournament Fee', amount: 75, isPaid: false },
-    ];
+  async ngOnInit(): Promise<void> {
+    await this.loadTeamFees();
+  }
+
+  async loadTeamFees(): Promise<void> {
+    this.isLoadingFees = true;
+    this.paymentErrorMessage = null;
+
+    try {
+      const user = await this.getCurrentUser();
+      if (!user) {
+        this.teamFees = [];
+        return;
+      }
+
+      this.teamFees = await this.loadFeeRecipientsForUser(user.uid);
+    } catch (error) {
+      console.error('Failed to load team fees:', error);
+      this.teamFees = [];
+      this.paymentErrorMessage = 'Unable to load team fees. Please try again.';
+    } finally {
+      this.isLoadingFees = false;
+    }
+  }
+
+  private async getCurrentUser(): Promise<User | null> {
+    const auth = getAuth(app);
+    if (auth.currentUser) return auth.currentUser;
+
+    return new Promise((resolve) => {
+      let unsubscribe = () => undefined;
+      unsubscribe = auth.onAuthStateChanged((user) => {
+        unsubscribe();
+        resolve(user);
+      }, () => {
+        unsubscribe();
+        resolve(null);
+      });
+    });
+  }
+
+  private async loadFeeRecipientsForUser(userId: string): Promise<TeamFee[]> {
+    const db = getFirestore(app);
+    const recipientsRef = collectionGroup(db, 'feeRecipients');
+    const snapshots = await Promise.all([
+      getDocs(query(recipientsRef, where('parentUserId', '==', userId))),
+      getDocs(query(recipientsRef, where('accountUserId', '==', userId))),
+      getDocs(query(recipientsRef, where('userId', '==', userId)))
+    ]);
+    const feesByPath = new Map<string, TeamFee>();
+
+    snapshots.forEach((snapshot) => {
+      snapshot.docs.forEach((docSnap) => {
+        const data = docSnap.data() as FeeRecipientData;
+        const teamId = data.teamId || getPathSegment(docSnap.ref.path, 'teams');
+        const batchId = data.batchId || getPathSegment(docSnap.ref.path, 'feeBatches');
+        if (!teamId || !batchId) return;
+
+        feesByPath.set(docSnap.ref.path, {
+          id: docSnap.id,
+          teamId,
+          batchId,
+          recipientId: docSnap.id,
+          name: data.title || data.feeTitle || data.name || 'Team Fee',
+          amount: normalizeAmount(data),
+          isPaid: isFeePaid(data)
+        });
+      });
+    });
+
+    return Array.from(feesByPath.values());
   }
 
   isPaymentLoading(feeId: string): boolean {
@@ -49,11 +150,11 @@ export class TeamFeesComponent implements OnInit {
     }
 
     this.pendingPaymentFeeId = fee.id;
-    this.paymentErrorMessage = null; // Clear previous errors
+    this.paymentErrorMessage = null;
 
     try {
       const checkoutUrl = await this.stripeService.initiateTeamFeeCheckout(fee.teamId, fee.batchId, fee.recipientId);
-      window.location.href = checkoutUrl; // Redirect to Stripe
+      window.location.href = checkoutUrl;
     } catch (error) {
       console.error('Failed to initiate payment:', error);
       this.paymentErrorMessage = 'Failed to initiate payment. Please try again.';


### PR DESCRIPTION
Closes #1437

- Replaced hard-coded Team Fees demo data with Firestore fee recipient loading for the signed-in user.
- Maps real fee recipient records into the component view model, including teamId, batchId, recipientId, amount, and paid status.
- Updated regression coverage to verify no mock fees are populated and checkout uses the selected real fee recipient IDs.

Validation:
- `npx vitest run src/app/team-fees/team-fees.component.spec.ts --reporter=verbose`