### PR TITLE
Fix tracking item creation payload

### DIFF
--- a/edit-roster.html
+++ b/edit-roster.html
@@ -519,9 +519,9 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getPlayers, addPlayer, deactivatePlayer, reactivatePlayer, getGames, uploadPlayerPhoto, updatePlayer, setPlayerPrivateRosterProfileFields, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount, listTeamParentMembershipRequests, approveParentMembershipRequest, denyParentMembershipRequest, getRosterFieldDefinitions, saveRosterFieldDefinition, disableRosterFieldDefinition, reorderRosterFieldDefinitions, listTeamRegistrationForms, listTeamRegistrationReviews, approveTeamRegistration, rejectTeamRegistration, extendTeamRegistrationOffer, releaseTeamRegistrationWaitlist, listTeamTrackingItems, createTeamTrackingItem, listTeamTrackingStatuses, setTeamTrackingStatus } from './js/db.js?v=32';
+        import { getTeam, getPlayers, addPlayer, deactivatePlayer, reactivatePlayer, getGames, uploadPlayerPhoto, updatePlayer, setPlayerPrivateRosterProfileFields, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount, listTeamParentMembershipRequests, approveParentMembershipRequest, denyParentMembershipRequest, getRosterFieldDefinitions, saveRosterFieldDefinition, disableRosterFieldDefinition, reorderRosterFieldDefinitions, listTeamRegistrationForms, listTeamRegistrationReviews, approveTeamRegistration, rejectTeamRegistration, extendTeamRegistrationOffer, releaseTeamRegistrationWaitlist, listTeamTrackingItems, createTeamTrackingItem, listTeamTrackingStatuses, setTeamTrackingStatus } from './js/db.js?v=33';
         import { buildRosterFieldDefinitionPayload, collectRosterProfileValues, getRosterProfileValues, normalizeRosterFieldDefinitions, planRosterCsvImport, renderRosterProfileFields, validateRosterProfileValues } from './js/roster-profile-fields.js?v=3';
-        import { buildTrackingStatusPayload, mergeTrackingStatusRows, normalizeTrackingItemDraft, summarizeTrackingStatus } from './js/tracking-status-admin.js?v=1';
+        import { buildTrackingStatusPayload, mergeTrackingStatusRows, normalizeTrackingItemDraft, summarizeTrackingStatus } from './js/tracking-status-admin.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth, sendInviteEmail } from './js/auth.js?v=14';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
@@ -628,7 +628,7 @@
                 return;
             }
             select.innerHTML = trackingItems.map((item) => `
-                <option value="${escapeHtml(item.id)}" ${item.id === selectedTrackingItemId ? 'selected' : ''}>${escapeHtml(item.title || item.id)}</option>
+                <option value="${escapeHtml(item.id)}" ${item.id === selectedTrackingItemId ? 'selected' : ''}>${escapeHtml(item.title || item.name || item.id)}</option>
             `).join('');
         }
 
@@ -671,7 +671,7 @@
             }
             const rows = mergeTrackingStatusRows(rosterPlayers, statuses);
             const summary = summarizeTrackingStatus(rows);
-            summaryEl.textContent = `${summary.complete} of ${summary.total} complete for ${selectedItem.title || 'selected item'} (${summary.incomplete} incomplete).`;
+            summaryEl.textContent = `${summary.complete} of ${summary.total} complete for ${selectedItem.title || selectedItem.name || 'selected item'} (${summary.incomplete} incomplete).`;
 
             if (rows.length === 0) {
                 container.innerHTML = '<p class="text-sm text-gray-500">No active roster players to track.</p>';

--- a/js/db.js
+++ b/js/db.js
@@ -1622,20 +1622,42 @@ export async function listTeamTrackingItems(teamId) {
     const itemsRef = collection(db, `teams/${teamId}/trackingItems`);
     const snapshot = await getDocs(itemsRef);
     return snapshot.docs
-        .map((docSnap) => ({ id: docSnap.id, ...docSnap.data() }))
-        .filter((item) => item.active !== false && item.scope === 'players')
+        .map((docSnap) => {
+            const data = docSnap.data();
+            return {
+                id: docSnap.id,
+                ...data,
+                title: data.title || data.name || ''
+            };
+        })
+        .filter((item) => item.active !== false && item.archived !== true && (!item.status || item.status === 'active') && (!item.scope || item.scope === 'players'))
         .sort((a, b) => String(a.title || '').localeCompare(String(b.title || '')));
 }
 
-export async function createTeamTrackingItem(teamId, itemData) {
+export async function createTeamTrackingItem(teamId, itemData = {}) {
+    const currentUserId = auth.currentUser?.uid;
+    if (!currentUserId) {
+        throw new Error('You must be signed in to create tracking items');
+    }
+
+    const name = String(itemData.name || itemData.title || '').trim();
+    if (!name) {
+        throw new Error('Tracking item title is required');
+    }
+
     const itemsRef = collection(db, `teams/${teamId}/trackingItems`);
     const docRef = await addDoc(itemsRef, {
-        ...itemData,
         teamId,
-        scope: 'players',
-        active: itemData.active !== false,
+        name,
+        description: itemData.description || '',
+        visibility: itemData.visibility || 'private',
+        status: 'active',
+        active: true,
+        archived: false,
         createdAt: serverTimestamp(),
-        updatedAt: serverTimestamp()
+        createdBy: currentUserId,
+        updatedAt: serverTimestamp(),
+        updatedBy: currentUserId
     });
     return docRef.id;
 }

--- a/js/tracking-status-admin.js
+++ b/js/tracking-status-admin.js
@@ -5,9 +5,11 @@ export function normalizeTrackingItemDraft(draft = {}) {
     }
 
     return {
-        title,
-        scope: 'players',
-        active: true
+        name: title,
+        visibility: 'private',
+        status: 'active',
+        active: true,
+        archived: false
     };
 }
 

--- a/tests/unit/db-tracking-items.test.js
+++ b/tests/unit/db-tracking-items.test.js
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readDbSource() {
+    return readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+}
+
+function getFunctionSource(source, functionName) {
+    const start = source.indexOf(`export async function ${functionName}`);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const nextExport = source.indexOf('\nexport async function ', start + 1);
+    return source.slice(start, nextExport === -1 ? source.length : nextExport);
+}
+
+describe('team tracking item db helpers', () => {
+    it('creates tracking items with the Firestore rules-approved schema and audit fields', () => {
+        const source = readDbSource();
+        const createSource = getFunctionSource(source, 'createTeamTrackingItem');
+
+        expect(createSource).toContain('const currentUserId = auth.currentUser?.uid;');
+        expect(createSource).toContain("throw new Error('You must be signed in to create tracking items');");
+        expect(createSource).toContain('name,');
+        expect(createSource).toContain("visibility: itemData.visibility || 'private'");
+        expect(createSource).toContain("status: 'active'");
+        expect(createSource).toContain('active: true');
+        expect(createSource).toContain('archived: false');
+        expect(createSource).toContain('createdBy: currentUserId');
+        expect(createSource).toContain('updatedBy: currentUserId');
+        expect(createSource).not.toContain('scope:');
+        expect(createSource).not.toContain('...itemData');
+    });
+
+    it('lists both legacy player-scoped and rules-compliant active tracking items', () => {
+        const source = readDbSource();
+        const listSource = getFunctionSource(source, 'listTeamTrackingItems');
+
+        expect(listSource).toContain("title: data.title || data.name || ''");
+        expect(listSource).toContain('item.active !== false');
+        expect(listSource).toContain('item.archived !== true');
+        expect(listSource).toContain("(!item.status || item.status === 'active')");
+        expect(listSource).toContain("(!item.scope || item.scope === 'players')");
+    });
+});

--- a/tests/unit/edit-roster-tracking-status.test.js
+++ b/tests/unit/edit-roster-tracking-status.test.js
@@ -19,6 +19,15 @@ describe('edit roster tracking status matrix wiring', () => {
         expect(source).toContain('await setTeamTrackingStatus(currentTeamId, trackingItemId, player.id, payload);');
     });
 
+    it('uses rules-compatible tracking item names in the selector and summary', () => {
+        const source = readEditRoster();
+
+        expect(source).toContain("from './js/db.js?v=33'");
+        expect(source).toContain("from './js/tracking-status-admin.js?v=2'");
+        expect(source).toContain('item.title || item.name || item.id');
+        expect(source).toContain("selectedItem.title || selectedItem.name || 'selected item'");
+    });
+
     it('escapes roster player values before inserting them into the table HTML', () => {
         const source = readEditRoster();
         const rosterRender = source.slice(source.indexOf('tbody.innerHTML = players.map(p => {'), source.indexOf("document.querySelectorAll('.deactivate-btn')"));

--- a/tests/unit/parent-invite-auto-link.test.js
+++ b/tests/unit/parent-invite-auto-link.test.js
@@ -47,7 +47,7 @@ describe('parent invite auto-linking', () => {
         expect(source).toContain('if (result.autoLinked)');
         expect(source).toContain('were linked to ${currentInvitePlayer.name} automatically');
         expect(source).toContain("codeSection.classList.add('hidden')");
-        expect(source).toContain("from './js/db.js?v=32';");
+        expect(source).toContain("from './js/db.js?v=33';");
     });
 
     it('sends a notification email to existing users even when auto-linked', () => {

--- a/tests/unit/tracking-status-admin.test.js
+++ b/tests/unit/tracking-status-admin.test.js
@@ -8,11 +8,13 @@ import {
 } from '../../js/tracking-status-admin.js';
 
 describe('tracking status admin helpers', () => {
-    it('normalizes player-scoped tracking items', () => {
+    it('normalizes tracking items to the Firestore rules schema', () => {
         expect(normalizeTrackingItemDraft({ title: ' Medical release ' })).toEqual({
-            title: 'Medical release',
-            scope: 'players',
-            active: true
+            name: 'Medical release',
+            visibility: 'private',
+            status: 'active',
+            active: true,
+            archived: false
         });
         expect(() => normalizeTrackingItemDraft({ title: '   ' })).toThrow('Tracking item title');
     });


### PR DESCRIPTION
Closes #1439

## Summary
- Normalize new tracking item drafts to the Firestore rules-approved schema using `name`, `visibility`, `status`, `active`, and `archived`.
- Create tracking items with required audit fields from the signed-in user and omit rejected fields like `title` and `scope`.
- Keep the edit roster selector compatible with both legacy `title` items and new `name` items.

## Tests
- `npx vitest run tests/unit/tracking-status-admin.test.js tests/unit/db-tracking-items.test.js tests/unit/edit-roster-tracking-status.test.js --reporter=verbose`
- `node scripts/check-critical-cache-bust.mjs`