### PR TITLE
Fix game report event timestamps

### DIFF
--- a/game.html
+++ b/game.html
@@ -397,7 +397,7 @@
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js';
         import { resolveLiveStatConfig } from './js/live-game-state.js?v=3';
         import { splitPlayerStatsByVisibility } from './js/stat-leaderboards.js?v=2';
-        import { resolveReportStatColumns, resolveOpponentReportStatColumns } from './js/game-report-stats.js?v=1';
+        import { formatGameReportEventTimestamp, resolveReportStatColumns, resolveOpponentReportStatColumns } from './js/game-report-stats.js?v=2';
         import { resolvePostGameStatFields, resolvePostGameTeamStatFields, resolvePostGameEditorDidNotPlay, buildCompletedGamePlayerStatsPayload, buildCompletedGameTeamStatsPayload, getPostGameEditorNextIndex } from './js/post-game-stat-editor.js?v=3';
         import { buildHighlightShareUrl, normalizeGameRecapHighlightClips } from './js/live-game-video.js?v=3';
 
@@ -1768,7 +1768,7 @@ Write the match report now:`;
                     gameLogDiv.innerHTML = `
                         <div class="space-y-2">
                             ${events.map((event, index) => {
-                        const timestamp = event.timestamp ? new Date(event.timestamp.seconds * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '';
+                        const timestamp = formatGameReportEventTimestamp(event.timestamp);
                         const period = event.period || 'Q1';
                         const gameTime = event.gameTime || '';
                         return `

--- a/js/game-report-stats.js
+++ b/js/game-report-stats.js
@@ -77,6 +77,26 @@ export function resolveReportStatColumns({ statsMap = {}, resolvedConfig = null 
   return { statKeys, statLabels };
 }
 
+export function formatGameReportEventTimestamp(timestamp) {
+  if (!timestamp) return '';
+
+  let date = null;
+
+  if (typeof timestamp === 'number') {
+    date = new Date(timestamp);
+  } else if (timestamp instanceof Date) {
+    date = timestamp;
+  } else if (typeof timestamp.toDate === 'function') {
+    date = timestamp.toDate();
+  } else if (typeof timestamp.seconds === 'number') {
+    date = new Date(timestamp.seconds * 1000);
+  }
+
+  if (!date || Number.isNaN(date.getTime())) return '';
+
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+}
+
 export function resolveOpponentReportStatColumns({ opponentStats = {}, resolvedConfig = null } = {}) {
   const metadataKeys = new Set(['name', 'number', 'notes', 'photoUrl']);
   let oppKeys = [];

--- a/tests/unit/game-report-stats.test.js
+++ b/tests/unit/game-report-stats.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { buildConfiguredStatFields, resolveReportStatColumns, resolveOpponentReportStatColumns } from '../../js/game-report-stats.js';
+import { buildConfiguredStatFields, formatGameReportEventTimestamp, resolveReportStatColumns, resolveOpponentReportStatColumns } from '../../js/game-report-stats.js';
 
 describe('game report stat helpers', () => {
   it('keeps soccer config labels even when no aggregated stats docs exist', () => {
@@ -97,5 +97,26 @@ describe('game report stat helpers', () => {
     expect(buildConfiguredStatFields(['GOALS'], [{ pts: 1 }])).toEqual([
       { fieldName: 'pts', label: 'GOALS' }
     ]);
+  });
+
+  it('formats numeric tracker event timestamps without Invalid Date', () => {
+    const timestamp = Date.UTC(2026, 0, 1, 15, 30, 0);
+
+    expect(formatGameReportEventTimestamp(timestamp)).toBe(
+      new Date(timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    );
+  });
+
+  it('formats Firestore Timestamp event timestamps', () => {
+    const timestamp = { seconds: Date.UTC(2026, 0, 1, 15, 30, 0) / 1000 };
+
+    expect(formatGameReportEventTimestamp(timestamp)).toBe(
+      new Date(timestamp.seconds * 1000).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+    );
+  });
+
+  it('omits invalid event timestamps instead of rendering Invalid Date', () => {
+    expect(formatGameReportEventTimestamp({ seconds: undefined })).toBe('');
+    expect(formatGameReportEventTimestamp('not-a-date')).toBe('');
   });
 });


### PR DESCRIPTION
Closes #1447

- Added a shared game report timestamp formatter that supports tracker numeric millisecond timestamps and Firestore Timestamp objects.
- Updated the Play-by-Play report rendering to use the formatter so tracker-created events no longer show Invalid Date.
- Added regression coverage for numeric timestamps, Firestore timestamps, and invalid timestamp inputs.

Validation:
- `npx vitest run tests/unit/game-report-stats.test.js --reporter=verbose`