### PR TITLE
feat(app): Add external .ics calendar link to app schedule

### DIFF
--- a/apps/app/src/lib/scheduleLogic.ts
+++ b/apps/app/src/lib/scheduleLogic.ts
@@ -201,6 +201,18 @@ export type ParentScheduleFilterOptions = {
   now?: Date;
 };
 
+
+export function validateExternalCalendarUrl(value: unknown) {
+  const normalizedUrl = String(value || '').trim();
+  if (!normalizedUrl) {
+    return { valid: false, url: '', error: 'Enter a calendar .ics URL.' };
+  }
+  if (!normalizedUrl.toLowerCase().includes('.ics')) {
+    return { valid: false, url: '', error: 'Calendar URL must be an .ics link.' };
+  }
+  return { valid: true, url: normalizedUrl, error: null };
+}
+
 export function normalizeScheduleDate(value: unknown): Date | null {
   if (!value) return null;
   if (value instanceof Date) return Number.isNaN(value.getTime()) ? null : value;

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -19,7 +19,7 @@ import {
   releaseAssignmentClaim,
   submitRsvpForPlayer,
   updateGame,
-  postChatMessage,
+  updateTeam,
   upsertPracticePacketCompletion
 } from '../../../../js/db.js';
 import { sendPublicRsvpReminderEmails } from '../../../../js/schedule-notifications.js';
@@ -51,6 +51,7 @@ import {
   normalizeRideRequestStatus,
   normalizeRsvpResponse,
   normalizeScheduleDate,
+  validateExternalCalendarUrl,
   buildStaffRsvpReminderMetadata,
   buildStaffRsvpReminderMessage,
   buildStaffRsvpReminderPreview,
@@ -482,6 +483,46 @@ async function loadStaffTeams(user: AuthUser) {
       return [...teamsById.values()];
     }
   );
+}
+
+async function saveTeamCalendarUrls(teamId: string, calendarUrls: string[]) {
+  if (isNativeRuntime()) {
+    await nativePatchDocument(`teams/${encodeURIComponent(teamId)}`, { calendarUrls });
+    return;
+  }
+  await updateTeam(teamId, { calendarUrls });
+}
+
+export async function addTeamCalendarUrl(teamId: string, url: string, user: AuthUser | null) {
+  const normalizedTeamId = compactString(teamId);
+  if (!normalizedTeamId) {
+    throw new Error('Team is required.');
+  }
+  if (!user?.uid) {
+    throw new Error('You need to sign in before adding a calendar.');
+  }
+
+  const validation = validateExternalCalendarUrl(url);
+  if (!validation.valid) {
+    throw new Error(validation.error || 'Enter a valid .ics calendar URL.');
+  }
+
+  const team = await loadTeam(normalizedTeamId);
+  const teamWithId = team ? { ...team, id: team.id || normalizedTeamId } : null;
+  if (!teamWithId || !isTeamStaff(teamWithId, user)) {
+    throw new Error('You do not have permission to manage this team schedule.');
+  }
+
+  const existingUrls = Array.isArray(teamWithId.calendarUrls)
+    ? teamWithId.calendarUrls.map(compactString).filter(Boolean)
+    : [];
+  if (existingUrls.includes(validation.url)) {
+    return { calendarUrls: existingUrls, added: false };
+  }
+
+  const calendarUrls = [...existingUrls, validation.url];
+  await saveTeamCalendarUrls(normalizedTeamId, calendarUrls);
+  return { calendarUrls, added: true };
 }
 
 async function loadPlayers(teamId: string) {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -1,7 +1,7 @@
-import { useEffect, useMemo, useState } from 'react';
-import { AlertCircle, CalendarDays, CheckCircle2, ChevronLeft, ChevronRight, ClipboardCheck, Copy, Download, Filter, ListChecks, MapPin, RefreshCw } from 'lucide-react';
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { AlertCircle, CalendarDays, CheckCircle2, ChevronLeft, ChevronRight, ClipboardCheck, Copy, Download, Filter, Link as LinkIcon, ListChecks, MapPin, RefreshCw } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import { loadParentSchedule, type ParentScheduleChild } from '../lib/scheduleService';
+import { addTeamCalendarUrl, loadParentSchedule, type ParentScheduleChild } from '../lib/scheduleService';
 import { useShellLayout } from '../lib/useShellLayout';
 import {
   buildScheduleIcs,
@@ -15,6 +15,7 @@ import {
   getScheduleTitle,
   getScheduleMapHref,
   normalizeRsvpResponse,
+  validateExternalCalendarUrl,
   type CalendarScheduleEntry,
   type ParentScheduleEvent,
   type ParentScheduleFilter,
@@ -78,6 +79,9 @@ export function Schedule({ auth }: { auth: AuthState }) {
   });
   const [selectedDay, setSelectedDay] = useState<Date | null>(null);
   const [desktopAdvancedControlsOpen, setDesktopAdvancedControlsOpen] = useState(false);
+  const [calendarUrl, setCalendarUrl] = useState('');
+  const [calendarUrlError, setCalendarUrlError] = useState<string | null>(null);
+  const [savingCalendarUrl, setSavingCalendarUrl] = useState(false);
 
   const refreshSchedule = async () => {
     if (!auth.user) return;
@@ -141,6 +145,41 @@ export function Schedule({ auth }: { auth: AuthState }) {
     packetsReady: packetRows.filter((row) => row.needsAction).length
   }), [packetRows, visibleEvents]);
   const webInsights = useMemo(() => buildScheduleWebInsights(visibleEvents), [visibleEvents]);
+  const manageableTeamOptions = useMemo(() => (
+    teamOptions.filter((team) => events.some((event) => event.teamId === team.teamId && event.isTeamStaff === true))
+  ), [events, teamOptions]);
+  const selectedCalendarTeam = useMemo(() => {
+    if (selectedTeamId) {
+      return manageableTeamOptions.find((team) => team.teamId === selectedTeamId) || null;
+    }
+    return manageableTeamOptions.length === 1 ? manageableTeamOptions[0] : null;
+  }, [manageableTeamOptions, selectedTeamId]);
+
+  const handleAddCalendarUrl = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!selectedCalendarTeam || !auth.user) return;
+    const validation = validateExternalCalendarUrl(calendarUrl);
+    if (!validation.valid) {
+      setCalendarUrlError(validation.error || 'Enter a valid .ics calendar URL.');
+      return;
+    }
+
+    setSavingCalendarUrl(true);
+    setCalendarUrlError(null);
+    setStatusMessage(null);
+    setError(null);
+    try {
+      const result = await addTeamCalendarUrl(selectedCalendarTeam.teamId, validation.url, auth.user);
+      setCalendarUrl('');
+      setStatusMessage(result.added ? 'Calendar link saved. Refreshing schedule…' : 'Calendar link already exists. Refreshing schedule…');
+      await refreshSchedule();
+      setStatusMessage(result.added ? 'Calendar link saved and schedule refreshed.' : 'Calendar link already exists. Schedule refreshed.');
+    } catch (saveError: any) {
+      setCalendarUrlError(saveError?.message || 'Unable to save calendar link.');
+    } finally {
+      setSavingCalendarUrl(false);
+    }
+  };
 
   const handleExport = () => {
     const exportEvents = filterParentScheduleEvents(events, {
@@ -404,6 +443,20 @@ export function Schedule({ auth }: { auth: AuthState }) {
             </div>
           ) : null}
 
+          {selectedCalendarTeam ? (
+            <CalendarSourcePanel
+              teamName={selectedCalendarTeam.teamName}
+              calendarUrl={calendarUrl}
+              error={calendarUrlError}
+              saving={savingCalendarUrl}
+              onCalendarUrlChange={(value) => {
+                setCalendarUrl(value);
+                if (calendarUrlError) setCalendarUrlError(null);
+              }}
+              onSubmit={handleAddCalendarUrl}
+            />
+          ) : null}
+
           {statusMessage ? <Status tone="success" message={statusMessage} /> : null}
           {error ? <Status tone="error" message={error} /> : null}
 
@@ -434,6 +487,49 @@ export function Schedule({ auth }: { auth: AuthState }) {
         </div>
       </div>
     </div>
+  );
+}
+
+function CalendarSourcePanel({ teamName, calendarUrl, error, saving, onCalendarUrlChange, onSubmit }: {
+  teamName: string;
+  calendarUrl: string;
+  error: string | null;
+  saving: boolean;
+  onCalendarUrlChange: (value: string) => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+}) {
+  return (
+    <section className="app-card p-4" aria-label="Calendar source">
+      <div className="flex items-start gap-3">
+        <div className="flex h-9 w-9 flex-none items-center justify-center rounded-xl bg-primary-50 text-primary-700">
+          <LinkIcon className="h-4 w-4" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="app-label">Staff schedule tools</div>
+          <h2 className="mt-1 text-base font-black text-gray-950">Add external calendar</h2>
+          <p className="mt-1 text-xs font-semibold leading-5 text-gray-500">Paste one .ics link for {teamName}. Imported events appear after the schedule refreshes.</p>
+        </div>
+      </div>
+      <form className="mt-3 space-y-2 sm:flex sm:items-start sm:gap-2 sm:space-y-0" onSubmit={onSubmit}>
+        <label className="block min-w-0 flex-1">
+          <span className="sr-only">External .ics calendar URL</span>
+          <input
+            className="auth-input min-h-10 !px-3 !py-2 text-sm font-semibold"
+            type="url"
+            inputMode="url"
+            placeholder="https://example.com/team.ics"
+            value={calendarUrl}
+            onChange={(event) => onCalendarUrlChange(event.target.value)}
+            aria-label="External .ics calendar URL"
+            aria-invalid={error ? 'true' : 'false'}
+          />
+        </label>
+        <button type="submit" className="primary-button w-full sm:w-auto" disabled={saving}>
+          {saving ? 'Saving…' : 'Save calendar'}
+        </button>
+      </form>
+      {error ? <div className="mt-2 text-xs font-bold text-rose-600" role="alert">{error}</div> : null}
+    </section>
   );
 }
 

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -275,6 +275,10 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
             status: 200,
             contentType: 'application/javascript',
             body: `
+                export async function addTeamCalendarUrl(teamId, url) {
+                    return { calendarUrls: [url], added: true };
+                }
+
                 export async function loadParentSchedule() {
                     return { children: [], events: [] };
                 }

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -228,6 +228,11 @@ async function mockScheduleModules(page, options = {}) {
                     };
                 }
 
+                export async function addTeamCalendarUrl(teamId, url) {
+                    window.__scheduleCalls.calendarUrls = (window.__scheduleCalls.calendarUrls || []).concat({ teamId, url });
+                    return { calendarUrls: [url], added: true };
+                }
+
                 export async function loadParentSchedule() {
                     if (${JSON.stringify(scheduleLoadError)}) {
                         throw new Error(${JSON.stringify(scheduleLoadError)});

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -5,6 +5,7 @@ import { createRoot } from '../../apps/app/node_modules/react-dom/client.js';
 import { MemoryRouter } from '../../apps/app/node_modules/react-router-dom/dist/index.mjs';
 
 const scheduleMocks = vi.hoisted(() => ({
+    addTeamCalendarUrl: vi.fn(),
     loadParentSchedule: vi.fn()
 }));
 
@@ -92,6 +93,15 @@ async function clickButton(container, text) {
     });
 }
 
+
+async function changeInput(input, value) {
+    await act(async () => {
+        const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value').set;
+        setter.call(input, value);
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+}
+
 async function changeSelect(select, value) {
     await act(async () => {
         select.value = value;
@@ -102,6 +112,7 @@ async function changeSelect(select, value) {
 beforeEach(() => {
     vi.clearAllMocks();
     document.body.innerHTML = '';
+    scheduleMocks.addTeamCalendarUrl.mockResolvedValue({ added: true, calendarUrls: ['https://example.com/team.ics'] });
     scheduleMocks.loadParentSchedule.mockResolvedValue({
         children: [
             { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' },
@@ -148,4 +159,46 @@ describe('React app desktop Schedule controls', () => {
         expect(selectByLabel(container, 'Team').value).toBe('team-1');
         expect(selectByLabel(container, 'Player').value).toBe('player-2');
     });
+
+    it('shows staff-only calendar import and refreshes after save', async () => {
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            children: [
+                { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+            ],
+            events: [event({ isTeamStaff: true })]
+        });
+
+        const { container } = await renderSchedule();
+        await waitForText(container, 'Add external calendar');
+
+        const input = container.querySelector('input[aria-label="External .ics calendar URL"]');
+        expect(input).toBeTruthy();
+
+        await changeInput(input, 'https://example.com/team.ics');
+        await clickButton(container, 'Save calendar');
+
+        expect(scheduleMocks.addTeamCalendarUrl).toHaveBeenCalledWith('team-1', 'https://example.com/team.ics', auth.user);
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(2);
+        await waitForText(container, 'Calendar link saved and schedule refreshed.');
+    });
+
+    it('hides calendar import from parent-only teams and validates .ics input inline', async () => {
+        const { container } = await renderSchedule();
+        await waitForText(container, 'Main Gym');
+        expect(container.textContent).not.toContain('Add external calendar');
+
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            children: [
+                { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+            ],
+            events: [event({ isTeamStaff: true })]
+        });
+        const staff = await renderSchedule();
+        await waitForText(staff.container, 'Add external calendar');
+        await clickButton(staff.container, 'Save calendar');
+
+        expect(staff.container.textContent).toContain('Enter a calendar .ics URL.');
+        expect(scheduleMocks.addTeamCalendarUrl).not.toHaveBeenCalled();
+    });
+
 });

--- a/tests/unit/app-schedule-logic.test.js
+++ b/tests/unit/app-schedule-logic.test.js
@@ -16,7 +16,8 @@ import {
     getScheduleRideshareSummary,
     isScheduleAssignmentClaimedByUser,
     isScheduleAssignmentOpen,
-    normalizeScheduleAssignment
+    normalizeScheduleAssignment,
+    validateExternalCalendarUrl
 } from '../../apps/app/src/lib/scheduleLogic';
 
 function event(overrides = {}) {
@@ -43,6 +44,17 @@ function event(overrides = {}) {
 }
 
 describe('React app parent schedule logic', () => {
+
+    it('validates external calendar .ics URLs like legacy schedule import', () => {
+        expect(validateExternalCalendarUrl('')).toMatchObject({ valid: false, error: 'Enter a calendar .ics URL.' });
+        expect(validateExternalCalendarUrl('https://example.com/calendar')).toMatchObject({ valid: false, error: 'Calendar URL must be an .ics link.' });
+        expect(validateExternalCalendarUrl('  https://example.com/team.ics?token=abc  ')).toEqual({
+            valid: true,
+            url: 'https://example.com/team.ics?token=abc',
+            error: null
+        });
+    });
+
     it('matches parent-dashboard upcoming and past filter behavior with a three-hour cutoff', () => {
         const now = new Date('2026-05-20T12:00:00Z');
         const events = [

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -8,6 +8,7 @@ const dbMocks = vi.hoisted(() => ({
     getRsvps: vi.fn(),
     getRsvpSummaries: vi.fn(),
     getTeam: vi.fn(),
+    updateTeam: vi.fn(),
     getTrackedCalendarEventUids: vi.fn(),
     createRideOffer: vi.fn(),
     claimAssignmentSlot: vi.fn(),
@@ -114,7 +115,7 @@ vi.mock('../../js/snack-helpers.js', () => ({
     }))
 }));
 
-import { loadParentSchedule } from '../../apps/app/src/lib/scheduleService.ts';
+import { addTeamCalendarUrl, loadParentSchedule } from '../../apps/app/src/lib/scheduleService.ts';
 
 function installWindow(protocol = 'http:') {
     vi.stubGlobal('window', {
@@ -375,4 +376,47 @@ describe('React app schedule service contract integration', () => {
         expect(result.events.some((event) => event.childId === 'player-from-user')).toBe(true);
         expect(result.events.some((event) => event.childId === 'player-1')).toBe(false);
     });
+
+    it('adds a new staff calendar URL and avoids duplicates', async () => {
+        dbMocks.getTeam.mockResolvedValue({
+            id: 'team-1',
+            name: 'Bears',
+            ownerId: 'user-1',
+            calendarUrls: ['https://example.com/existing.ics']
+        });
+
+        const added = await addTeamCalendarUrl('team-1', '  https://example.com/new.ics  ', user());
+
+        expect(added).toEqual({
+            added: true,
+            calendarUrls: ['https://example.com/existing.ics', 'https://example.com/new.ics']
+        });
+        expect(dbMocks.updateTeam).toHaveBeenCalledWith('team-1', {
+            calendarUrls: ['https://example.com/existing.ics', 'https://example.com/new.ics']
+        });
+
+        dbMocks.updateTeam.mockClear();
+        const duplicate = await addTeamCalendarUrl('team-1', 'https://example.com/existing.ics', user());
+
+        expect(duplicate).toEqual({
+            added: false,
+            calendarUrls: ['https://example.com/existing.ics']
+        });
+        expect(dbMocks.updateTeam).not.toHaveBeenCalled();
+    });
+
+    it('fails closed when adding a calendar URL without team staff access', async () => {
+        dbMocks.getTeam.mockResolvedValue({
+            id: 'team-1',
+            name: 'Bears',
+            ownerId: 'owner-2',
+            adminEmails: [],
+            calendarUrls: []
+        });
+
+        await expect(addTeamCalendarUrl('team-1', 'https://example.com/team.ics', user()))
+            .rejects.toThrow('You do not have permission to manage this team schedule.');
+        expect(dbMocks.updateTeam).not.toHaveBeenCalled();
+    });
+
 });


### PR DESCRIPTION
Closes #1450

This PR implements the ability for coaches and admins to add external .ics calendar links directly from the app schedule experience.

**Changes:**
- Added `validateExternalCalendarUrl` helper in `scheduleLogic.ts` for .ics URL validation.
- Implemented `addTeamCalendarUrl` in `scheduleService.ts` to save new, non-duplicate .ics URLs to a team's `calendarUrls` array, with appropriate permission checks.
- Integrated a new `CalendarSourcePanel` component into `Schedule.tsx`, visible only to team staff. This panel allows users to input and save .ics URLs, displaying loading, success, and error states, and automatically refreshing the schedule upon successful save.

**Verification:**
- Unit tests added for URL validation and `addTeamCalendarUrl` service function.
- Unit tests updated for `app-schedule-desktop-controls.test.jsx` to cover the display and functionality of the new calendar import UI for staff and its hidden state for non-staff.
- `npm run app:build` passed successfully.