### PR TITLE
Add team email to React messages

### DIFF
--- a/apps/app/src/lib/chatLogic.ts
+++ b/apps/app/src/lib/chatLogic.ts
@@ -218,6 +218,52 @@ export function buildChatAudienceMetadata({
   };
 }
 
+export function buildEmailAudienceMetadata({
+  selectedConversation,
+  selectedConversationId,
+  selectedRecipientTarget,
+  selectedRecipientIds,
+  recipientOptions = []
+}: {
+  selectedConversation?: any;
+  selectedConversationId: string;
+  selectedRecipientTarget: ChatTargetType;
+  selectedRecipientIds: string[];
+  recipientOptions?: ChatRecipientOption[];
+}): ChatAudienceMetadata {
+  if (isStaffConversation(selectedConversation)) {
+    return {
+      targetType: 'staff',
+      recipientIds: [],
+      targetRole: 'staff'
+    };
+  }
+
+  if (selectedConversation && !isDefaultTeamConversation(selectedConversationId)) {
+    const optionIds = new Set(recipientOptions.map((option) => option.id));
+    const participantIds: unknown[] = Array.isArray(selectedConversation.participantIds) ? selectedConversation.participantIds : [];
+    const recipientIds = Array.from(new Set<string>(participantIds.flatMap((id: unknown) => {
+      const raw = String(id || '').trim();
+      if (!raw) return [];
+      if (raw.toLowerCase().startsWith('email:')) return [getRecipientOptionId('email', raw.slice(6))];
+      if (raw.toLowerCase().startsWith('user:')) return [getRecipientOptionId('user', raw.slice(5))];
+      return [raw, getRecipientOptionId('user', raw)];
+    }).filter((id: string) => optionIds.has(id))));
+    return {
+      targetType: 'individuals',
+      recipientIds,
+      targetRole: null
+    };
+  }
+
+  return buildChatAudienceMetadata({
+    selectedConversation,
+    selectedConversationId,
+    selectedRecipientTarget,
+    selectedRecipientIds
+  });
+}
+
 export function getAudienceSummaryText(metadata: ChatAudienceMetadata, recipientOptions: ChatRecipientOption[] = []) {
   if (metadata.targetType === 'staff') {
     return 'Staff only';

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -12,12 +12,14 @@ import {
   getGames,
   getParentTeams,
   getPlayers,
+  getSentTeamEmails,
   getTeam,
   getUnreadChatCounts,
   getUserByEmail,
   getUserProfile,
   getUserTeamsWithAccess,
   postChatMessage,
+  sendTeamEmail,
   subscribeToChatMessages,
   toggleChatReaction,
   updateChatLastRead,
@@ -113,6 +115,20 @@ export type ChatMessage = {
   targetRole?: string | null;
   conversationId?: string | null;
   _doc?: unknown;
+};
+
+export type SentTeamEmail = {
+  id: string;
+  subject?: string | null;
+  senderName?: string | null;
+  senderEmail?: string | null;
+  sentAt?: unknown;
+  recipientCount?: number | null;
+  status?: string | null;
+  delivery?: {
+    status?: string | null;
+    jobCount?: number | null;
+  } | null;
 };
 
 export type ChatInboxLoadResult = {
@@ -836,6 +852,40 @@ export async function sendTeamChatMessage({
     }
     throw error;
   }
+}
+
+export async function sendTeamEmailMessage({
+  teamId,
+  subject,
+  body,
+  targetType = 'full_team',
+  recipientIds = []
+}: {
+  teamId: string;
+  subject: string;
+  body: string;
+  targetType?: ChatTargetType;
+  recipientIds?: string[];
+}) {
+  const trimmedSubject = String(subject || '').trim();
+  const trimmedBody = String(body || '').trim();
+  if (!trimmedSubject || !trimmedBody) {
+    throw new Error('Subject and message are required.');
+  }
+  if (targetType === 'individuals' && recipientIds.map((id) => String(id || '').trim()).filter(Boolean).length === 0) {
+    throw new Error('Choose at least one selected member before sending.');
+  }
+
+  return withTimeout(Promise.resolve(sendTeamEmail(teamId, {
+    subject: trimmedSubject,
+    body: trimmedBody,
+    targetType,
+    recipientIds: targetType === 'individuals' ? recipientIds : []
+  })), 'Team email send');
+}
+
+export async function loadSentTeamEmails(teamId: string, { limit = 25 }: { limit?: number } = {}): Promise<SentTeamEmail[]> {
+  return withTimeout(Promise.resolve(getSentTeamEmails(teamId, { limit })), 'Sent email history') as Promise<SentTeamEmail[]>;
 }
 
 export async function editTeamChatMessage(teamId: string, messageId: string, text: string, conversationId: string) {

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -1880,6 +1880,13 @@ function Composer({
         </button>
       </div>
 
+      {notice ? (
+        <div className="chat-composer-notice" aria-live="polite">
+          {sending ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" /> : <Paperclip className="h-3.5 w-3.5" aria-hidden="true" />}
+          <span className="truncate">{notice}</span>
+        </div>
+      ) : null}
+
       <div className="chat-composer-toolbar">
         <button type="button" className="chat-tool-button" onClick={onAttach} aria-label="Add attachment">
           <Paperclip className="h-4 w-4" aria-hidden="true" />
@@ -1905,12 +1912,6 @@ function Composer({
             <Mail className="h-4 w-4 flex-none" aria-hidden="true" />
             <span className="truncate">Team Email</span>
           </button>
-        ) : null}
-        {notice ? (
-          <div className="chat-composer-notice" aria-live="polite">
-            {sending ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" /> : <Paperclip className="h-3.5 w-3.5" aria-hidden="true" />}
-            <span className="truncate">{notice}</span>
-          </div>
         ) : null}
       </div>
     </form>

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -379,6 +379,7 @@ function ChatWindow({
   const [emailSending, setEmailSending] = useState(false);
   const [emailLoadingHistory, setEmailLoadingHistory] = useState(false);
   const [emailStatus, setEmailStatus] = useState<ChatStatus | null>(null);
+  const [emailHistoryStatus, setEmailHistoryStatus] = useState<ChatStatus | null>(null);
   const [sentEmails, setSentEmails] = useState<SentTeamEmail[]>([]);
   const [linkDraft, setLinkDraft] = useState('');
   const [reactionMessageId, setReactionMessageId] = useState('');
@@ -876,13 +877,16 @@ function ChatWindow({
     }
   };
 
-  const reloadSentEmailHistory = async () => {
+  const reloadSentEmailHistory = async ({ suppressErrorStatus = false } = {}) => {
     if (!canModerate) return;
     setEmailLoadingHistory(true);
     try {
       setSentEmails(await loadSentTeamEmails(teamId, { limit: 25 }));
+      setEmailHistoryStatus(null);
     } catch (historyError: any) {
-      setEmailStatus({ tone: 'error', message: historyError?.message || 'Could not load sent email history.' });
+      if (!suppressErrorStatus) {
+        setEmailHistoryStatus({ tone: 'error', message: historyError?.message || 'Could not load sent email history.' });
+      }
     } finally {
       setEmailLoadingHistory(false);
     }
@@ -892,6 +896,7 @@ function ChatWindow({
     if (!canModerate) return;
     setShowEmailSheet(true);
     setEmailStatus(null);
+    setEmailHistoryStatus(null);
     void reloadSentEmailHistory();
   };
 
@@ -922,7 +927,7 @@ function ChatWindow({
       setEmailSubject('');
       setEmailBody('');
       setEmailStatus({ tone: 'success', message: `Queued ${Number(result?.recipientCount || 0)} recipient${Number(result?.recipientCount || 0) === 1 ? '' : 's'} for backend email delivery.` });
-      await reloadSentEmailHistory();
+      await reloadSentEmailHistory({ suppressErrorStatus: true });
     } catch (sendError: any) {
       setEmailStatus({ tone: 'error', message: sendError?.message || 'Email send failed. Nothing was silently dropped.' });
     } finally {
@@ -1323,6 +1328,7 @@ function ChatWindow({
           sending={emailSending}
           loadingHistory={emailLoadingHistory}
           status={emailStatus}
+          historyStatus={emailHistoryStatus}
           sentEmails={sentEmails}
           audienceSummary={getAudienceSummaryText(emailAudienceMetadata, recipientOptions)}
           audienceMetadata={emailAudienceMetadata}
@@ -1331,6 +1337,7 @@ function ChatWindow({
           onSubmit={handleSendEmail}
           onRefreshHistory={reloadSentEmailHistory}
           onStatusClose={() => setEmailStatus(null)}
+          onHistoryStatusClose={() => setEmailHistoryStatus(null)}
           onClose={() => setShowEmailSheet(false)}
         />
       ) : null}
@@ -1391,6 +1398,7 @@ function TeamEmailSheet({
   sending,
   loadingHistory,
   status,
+  historyStatus,
   sentEmails,
   audienceSummary,
   audienceMetadata,
@@ -1399,6 +1407,7 @@ function TeamEmailSheet({
   onSubmit,
   onRefreshHistory,
   onStatusClose,
+  onHistoryStatusClose,
   onClose
 }: {
   subject: string;
@@ -1406,6 +1415,7 @@ function TeamEmailSheet({
   sending: boolean;
   loadingHistory: boolean;
   status: ChatStatus | null;
+  historyStatus: ChatStatus | null;
   sentEmails: SentTeamEmail[];
   audienceSummary: string;
   audienceMetadata: ChatAudienceMetadata;
@@ -1414,6 +1424,7 @@ function TeamEmailSheet({
   onSubmit: (event?: FormEvent) => void;
   onRefreshHistory: () => void;
   onStatusClose: () => void;
+  onHistoryStatusClose: () => void;
   onClose: () => void;
 }) {
   const missingSelectedRecipients = audienceMetadata.targetType === 'individuals' && audienceMetadata.recipientIds.length === 0;
@@ -1471,6 +1482,7 @@ function TeamEmailSheet({
             Refresh
           </button>
         </div>
+        {historyStatus ? <StatusBanner status={historyStatus} onClose={onHistoryStatusClose} /> : null}
         <div className="mt-3 space-y-2">
           {loadingHistory && sentEmails.length === 0 ? (
             <div className="rounded-xl border border-gray-200 bg-gray-50 px-3 py-3 text-sm font-bold text-gray-500">Loading sent emails...</div>

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -13,6 +13,7 @@ import {
   ImageIcon,
   Link2,
   Loader2,
+  Mail,
   MessageCircle,
   Mic,
   MoreVertical,
@@ -38,19 +39,23 @@ import {
   loadChatRecipientOptions,
   loadChatTeamContext,
   loadOlderTeamChatMessages,
+  loadSentTeamEmails,
   markTeamChatRead,
   sendAllPlaysChatAnswer,
   sendTeamChatMessage,
+  sendTeamEmailMessage,
   subscribeToTeamChatMessages,
   toggleTeamChatReaction,
   type ChatConversation,
   type ChatMessage,
+  type SentTeamEmail,
   type ChatTeam
 } from '../lib/chatService';
 import {
   DEFAULT_TEAM_CONVERSATION_ID,
   MAX_CHAT_MEDIA_SIZE,
   buildChatAudienceMetadata,
+  buildEmailAudienceMetadata,
   buildChatMediaShareDetails,
   chatReactions,
   collectThreadMedia,
@@ -76,6 +81,7 @@ import {
   shouldRetryChatLastReadOnViewReturn,
   shouldUpdateChatLastRead,
   type ChatRecipientOption,
+  type ChatAudienceMetadata,
   type ChatTargetType
 } from '../lib/chatLogic';
 import { sharePublicUrl } from '../lib/publicActions';
@@ -367,6 +373,13 @@ function ChatWindow({
   const [showMediaGallery, setShowMediaGallery] = useState(false);
   const [showAttachSheet, setShowAttachSheet] = useState(false);
   const [showLinkSheet, setShowLinkSheet] = useState(false);
+  const [showEmailSheet, setShowEmailSheet] = useState(false);
+  const [emailSubject, setEmailSubject] = useState('');
+  const [emailBody, setEmailBody] = useState('');
+  const [emailSending, setEmailSending] = useState(false);
+  const [emailLoadingHistory, setEmailLoadingHistory] = useState(false);
+  const [emailStatus, setEmailStatus] = useState<ChatStatus | null>(null);
+  const [sentEmails, setSentEmails] = useState<SentTeamEmail[]>([]);
   const [linkDraft, setLinkDraft] = useState('');
   const [reactionMessageId, setReactionMessageId] = useState('');
   const [actionMessageId, setActionMessageId] = useState('');
@@ -399,6 +412,13 @@ function ChatWindow({
     selectedRecipientTarget,
     selectedRecipientIds
   }), [selectedConversation, selectedConversationId, selectedRecipientIds, selectedRecipientTarget]);
+  const emailAudienceMetadata = useMemo(() => buildEmailAudienceMetadata({
+    selectedConversation,
+    selectedConversationId,
+    selectedRecipientTarget,
+    selectedRecipientIds,
+    recipientOptions
+  }), [recipientOptions, selectedConversation, selectedConversationId, selectedRecipientIds, selectedRecipientTarget]);
   const audienceSummary = useMemo(() => getAudienceSummaryText(audienceMetadata, recipientOptions), [audienceMetadata, recipientOptions]);
   const mediaEntries = useMemo(() => collectThreadMedia(messages), [messages]);
   const teamName = team?.name || inboxTeam?.name || 'Team chat';
@@ -856,6 +876,60 @@ function ChatWindow({
     }
   };
 
+  const reloadSentEmailHistory = async () => {
+    if (!canModerate) return;
+    setEmailLoadingHistory(true);
+    try {
+      setSentEmails(await loadSentTeamEmails(teamId, { limit: 25 }));
+    } catch (historyError: any) {
+      setEmailStatus({ tone: 'error', message: historyError?.message || 'Could not load sent email history.' });
+    } finally {
+      setEmailLoadingHistory(false);
+    }
+  };
+
+  const openEmailSheet = () => {
+    if (!canModerate) return;
+    setShowEmailSheet(true);
+    setEmailStatus(null);
+    void reloadSentEmailHistory();
+  };
+
+  const handleSendEmail = async (event?: FormEvent) => {
+    event?.preventDefault();
+    if (!canModerate || emailSending) return;
+    const subject = emailSubject.trim();
+    const body = emailBody.trim();
+    if (!subject || !body) {
+      setEmailStatus({ tone: 'error', message: 'Subject and message are required.' });
+      return;
+    }
+    if (emailAudienceMetadata.targetType === 'individuals' && emailAudienceMetadata.recipientIds.length === 0) {
+      setEmailStatus({ tone: 'error', message: 'Choose at least one selected member before sending.' });
+      return;
+    }
+
+    setEmailSending(true);
+    setEmailStatus({ tone: 'neutral', message: 'Creating backend mail jobs...' });
+    try {
+      const result = await sendTeamEmailMessage({
+        teamId,
+        subject,
+        body,
+        targetType: emailAudienceMetadata.targetType,
+        recipientIds: emailAudienceMetadata.recipientIds
+      });
+      setEmailSubject('');
+      setEmailBody('');
+      setEmailStatus({ tone: 'success', message: `Queued ${Number(result?.recipientCount || 0)} recipient${Number(result?.recipientCount || 0) === 1 ? '' : 's'} for backend email delivery.` });
+      await reloadSentEmailHistory();
+    } catch (sendError: any) {
+      setEmailStatus({ tone: 'error', message: sendError?.message || 'Email send failed. Nothing was silently dropped.' });
+    } finally {
+      setEmailSending(false);
+    }
+  };
+
   const toggleVoiceCapture = async () => {
     if (voiceListening) {
       stopVoiceCapture();
@@ -1187,6 +1261,7 @@ function ChatWindow({
         voiceListening={voiceListening}
         voiceSupported={voiceSupported}
         canModerate={canModerate && isDefaultTeamConversation(selectedConversationId)}
+        canSendTeamEmail={canModerate}
         audienceSummary={audienceSummary}
         onTextChange={setText}
         onSubmit={handleSend}
@@ -1194,6 +1269,7 @@ function ChatWindow({
         onRemoveFile={removeFile}
         onVoice={toggleVoiceCapture}
         onAudience={() => setShowAudienceSheet(true)}
+        onTeamEmail={openEmailSheet}
         onMention={insertAllPlaysMention}
       />
 
@@ -1237,6 +1313,25 @@ function ChatWindow({
           onChange={setLinkDraft}
           onAdd={addLinkToComposer}
           onClose={() => setShowLinkSheet(false)}
+        />
+      ) : null}
+
+      {showEmailSheet && canModerate ? (
+        <TeamEmailSheet
+          subject={emailSubject}
+          body={emailBody}
+          sending={emailSending}
+          loadingHistory={emailLoadingHistory}
+          status={emailStatus}
+          sentEmails={sentEmails}
+          audienceSummary={getAudienceSummaryText(emailAudienceMetadata, recipientOptions)}
+          audienceMetadata={emailAudienceMetadata}
+          onSubjectChange={setEmailSubject}
+          onBodyChange={setEmailBody}
+          onSubmit={handleSendEmail}
+          onRefreshHistory={reloadSentEmailHistory}
+          onStatusClose={() => setEmailStatus(null)}
+          onClose={() => setShowEmailSheet(false)}
         />
       ) : null}
 
@@ -1288,6 +1383,126 @@ function StatusBanner({ status, onClose }: { status: ChatStatus; onClose: () => 
       </button>
     </div>
   );
+}
+
+function TeamEmailSheet({
+  subject,
+  body,
+  sending,
+  loadingHistory,
+  status,
+  sentEmails,
+  audienceSummary,
+  audienceMetadata,
+  onSubjectChange,
+  onBodyChange,
+  onSubmit,
+  onRefreshHistory,
+  onStatusClose,
+  onClose
+}: {
+  subject: string;
+  body: string;
+  sending: boolean;
+  loadingHistory: boolean;
+  status: ChatStatus | null;
+  sentEmails: SentTeamEmail[];
+  audienceSummary: string;
+  audienceMetadata: ChatAudienceMetadata;
+  onSubjectChange: (value: string) => void;
+  onBodyChange: (value: string) => void;
+  onSubmit: (event?: FormEvent) => void;
+  onRefreshHistory: () => void;
+  onStatusClose: () => void;
+  onClose: () => void;
+}) {
+  const missingSelectedRecipients = audienceMetadata.targetType === 'individuals' && audienceMetadata.recipientIds.length === 0;
+  const canSendEmail = Boolean(subject.trim() && body.trim()) && !missingSelectedRecipients && !sending;
+
+  return (
+    <Sheet title="Team Email" onClose={onClose}>
+      <form className="space-y-3" onSubmit={onSubmit}>
+        <div className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-xs font-bold leading-5 text-amber-800">
+          Sends one backend roster email job. This is separate from chat posting, and delivery jobs are queued.
+        </div>
+        <div className="rounded-xl border border-gray-200 bg-gray-50 px-3 py-2 text-sm font-bold text-gray-700">
+          Audience: {audienceSummary}
+        </div>
+        {missingSelectedRecipients ? (
+          <div className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-bold text-rose-700">
+            Choose at least one selected member before sending email.
+          </div>
+        ) : null}
+        <label className="block">
+          <span className="app-label">Subject</span>
+          <input
+            value={subject}
+            onChange={(event) => onSubjectChange(event.target.value)}
+            className="mt-1 min-h-11 w-full rounded-xl border border-gray-200 px-3 text-sm font-semibold text-gray-900 outline-none focus:border-primary-300 focus:ring-2 focus:ring-primary-100"
+            placeholder="Team update"
+            maxLength={160}
+          />
+        </label>
+        <label className="block">
+          <span className="app-label">Message</span>
+          <textarea
+            value={body}
+            onChange={(event) => onBodyChange(event.target.value)}
+            className="mt-1 min-h-36 w-full rounded-xl border border-gray-200 px-3 py-2 text-sm font-semibold text-gray-900 outline-none focus:border-primary-300 focus:ring-2 focus:ring-primary-100"
+            placeholder="Write the email body..."
+            maxLength={5000}
+          />
+        </label>
+        <button type="submit" className="primary-button w-full" disabled={!canSendEmail}>
+          {sending ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Mail className="h-4 w-4" aria-hidden="true" />}
+          Send email
+        </button>
+        {status ? <StatusBanner status={status} onClose={onStatusClose} /> : null}
+      </form>
+
+      <div className="mt-5 border-t border-gray-100 pt-4">
+        <div className="flex items-center justify-between gap-3">
+          <div>
+            <div className="text-sm font-black text-gray-950">Sent email history</div>
+            <div className="text-xs font-semibold text-gray-500">Latest queued roster emails. Recipient email addresses are hidden.</div>
+          </div>
+          <button type="button" className="ghost-button !h-9 !min-h-9 text-xs" onClick={onRefreshHistory} disabled={loadingHistory}>
+            {loadingHistory ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <RefreshCw className="h-4 w-4" aria-hidden="true" />}
+            Refresh
+          </button>
+        </div>
+        <div className="mt-3 space-y-2">
+          {loadingHistory && sentEmails.length === 0 ? (
+            <div className="rounded-xl border border-gray-200 bg-gray-50 px-3 py-3 text-sm font-bold text-gray-500">Loading sent emails...</div>
+          ) : sentEmails.length === 0 ? (
+            <div className="rounded-xl border border-gray-200 bg-gray-50 px-3 py-3 text-sm font-bold text-gray-500">No sent team emails yet.</div>
+          ) : sentEmails.map((email) => {
+            const delivery = email.delivery || {};
+            const statusLabel = String(delivery.status || email.status || 'queued');
+            return (
+              <div key={email.id} className="rounded-xl border border-gray-200 bg-white px-3 py-2">
+                <div className="flex items-start justify-between gap-3">
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-black text-gray-950">{email.subject || '(No subject)'}</div>
+                    <div className="mt-0.5 text-xs font-semibold text-gray-500">From {email.senderName || 'Team admin'} · {formatEmailSentTime(email.sentAt)}</div>
+                  </div>
+                  <div className="flex-none text-right text-xs font-bold text-gray-500">
+                    {Number(email.recipientCount || 0)} recipients<br />{statusLabel}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </Sheet>
+  );
+}
+
+function formatEmailSentTime(value: unknown) {
+  const day = formatChatDay(value);
+  const time = formatChatTime(value);
+  return [day, time].filter(Boolean).join(' ') || 'Queued';
 }
 
 function MessageList({
@@ -1580,6 +1795,7 @@ function Composer({
   voiceListening,
   voiceSupported,
   canModerate,
+  canSendTeamEmail,
   audienceSummary,
   onTextChange,
   onSubmit,
@@ -1587,6 +1803,7 @@ function Composer({
   onRemoveFile,
   onVoice,
   onAudience,
+  onTeamEmail,
   onMention
 }: {
   teamName: string;
@@ -1598,6 +1815,7 @@ function Composer({
   voiceListening: boolean;
   voiceSupported: boolean;
   canModerate: boolean;
+  canSendTeamEmail: boolean;
   audienceSummary: string;
   onTextChange: (value: string) => void;
   onSubmit: (event?: FormEvent) => void;
@@ -1605,6 +1823,7 @@ function Composer({
   onRemoveFile: (index: number) => void;
   onVoice: () => void;
   onAudience: () => void;
+  onTeamEmail: () => void;
   onMention: () => void;
 }) {
   const canSend = Boolean(text.trim() || filePreviews.length) && !sending && !aiThinking;
@@ -1679,6 +1898,12 @@ function Composer({
           <button type="button" className="chat-audience-pill" onClick={onAudience}>
             <Users className="h-4 w-4 flex-none" aria-hidden="true" />
             <span className="truncate">Audience: {audienceSummary}</span>
+          </button>
+        ) : null}
+        {canSendTeamEmail ? (
+          <button type="button" className="chat-audience-pill" onClick={onTeamEmail} aria-label="Open Team Email">
+            <Mail className="h-4 w-4 flex-none" aria-hidden="true" />
+            <span className="truncate">Team Email</span>
           </button>
         ) : null}
         {notice ? (

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -202,6 +202,14 @@ async function mockMessagesModules(page, options = {}) {
                     window.__chatCalls.reads.push({ userId, teamId });
                 }
 
+                export async function sendTeamEmailMessage() {
+                    return { recipientCount: 1, status: 'queued' };
+                }
+
+                export async function loadSentTeamEmails() {
+                    return [];
+                }
+
                 export async function uploadTeamChatAttachment(teamId, file) {
                     return {
                         id: 'attachment-' + file.name,

--- a/tests/unit/app-chat-logic.test.js
+++ b/tests/unit/app-chat-logic.test.js
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     DEFAULT_TEAM_CONVERSATION_ID,
     buildChatAudienceMetadata,
+    buildEmailAudienceMetadata,
     extractAllPlaysQuestion,
     formatChatMessageHtml,
     getChatMemberDisplayName,
@@ -65,6 +66,37 @@ describe('React app chat logic', () => {
         })).toEqual({
             targetType: 'individuals',
             recipientIds: ['player:one', 'user:two'],
+            targetRole: null
+        });
+    });
+
+    it('maps email audience metadata from conversations and selected members', () => {
+        const recipientOptions = [
+            { id: 'user:coach-1', name: 'Coach Jamie' },
+            { id: 'email:parent@example.com', name: 'Pat Parent' }
+        ];
+
+        expect(buildEmailAudienceMetadata({
+            selectedConversation: { id: 'staff', participantRoles: ['staff'], participantIds: ['coach-1'] },
+            selectedConversationId: 'staff',
+            selectedRecipientTarget: 'full_team',
+            selectedRecipientIds: [],
+            recipientOptions
+        })).toEqual({
+            targetType: 'staff',
+            recipientIds: [],
+            targetRole: 'staff'
+        });
+
+        expect(buildEmailAudienceMetadata({
+            selectedConversation: { id: 'direct', participantIds: ['coach-1', 'email:parent@example.com', 'missing-user'] },
+            selectedConversationId: 'direct',
+            selectedRecipientTarget: 'full_team',
+            selectedRecipientIds: [],
+            recipientOptions
+        })).toEqual({
+            targetType: 'individuals',
+            recipientIds: ['user:coach-1', 'email:parent@example.com'],
             targetRole: null
         });
     });

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -14,9 +14,11 @@ const chatMocks = vi.hoisted(() => ({
     loadChatRecipientOptions: vi.fn(),
     loadChatTeamContext: vi.fn(),
     loadOlderTeamChatMessages: vi.fn(),
+    loadSentTeamEmails: vi.fn(),
     markTeamChatRead: vi.fn(),
     sendAllPlaysChatAnswer: vi.fn(),
     sendTeamChatMessage: vi.fn(),
+    sendTeamEmailMessage: vi.fn(),
     subscribeToTeamChatMessages: vi.fn(),
     toggleTeamChatReaction: vi.fn()
 }));
@@ -291,6 +293,17 @@ beforeEach(() => {
         return { unsubscribe: vi.fn() };
     });
     chatMocks.sendTeamChatMessage.mockResolvedValue({ conversationId: 'team', createdConversation: null, wantsAi: false });
+    chatMocks.sendTeamEmailMessage.mockResolvedValue({ recipientCount: 12, status: 'queued' });
+    chatMocks.loadSentTeamEmails.mockResolvedValue([
+        {
+            id: 'email-1',
+            subject: 'Practice plan',
+            senderName: 'Coach Jamie',
+            sentAt: new Date('2026-05-21T15:00:00Z'),
+            recipientCount: 12,
+            status: 'queued'
+        }
+    ]);
     chatMocks.sendAllPlaysChatAnswer.mockResolvedValue(undefined);
     chatMocks.toggleTeamChatReaction.mockResolvedValue(true);
     chatMocks.editTeamChatMessage.mockResolvedValue(undefined);
@@ -472,6 +485,69 @@ describe('React app messages integration', () => {
             selectedRecipientTarget: 'individuals',
             selectedRecipientIds: ['user:coach-1']
         }));
+    });
+
+    it('shows Team Email only to moderators and queues email with the selected audience', async () => {
+        const { container } = await renderMessages('/messages/team-1');
+
+        await click(container, 'Audience: Full team');
+        await click(container, 'Selected members');
+        const coachCheckbox = Array.from(container.querySelectorAll('label')).find((label) => label.textContent.includes('Coach Jamie'))?.querySelector('input[type="checkbox"]');
+        await act(async () => {
+            coachCheckbox.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+        await flush();
+        await click(container, 'Done');
+        await click(container, 'Team Email');
+
+        expect(chatMocks.loadSentTeamEmails).toHaveBeenCalledWith('team-1', { limit: 25 });
+        expect(container.textContent).toContain('Sends one backend roster email job');
+        expect(container.textContent).toContain('Audience: Coach Jamie (Staff)');
+        expect(container.textContent).toContain('Practice plan');
+        expect(container.textContent).not.toContain('coach@example.com');
+
+        const emailDialog = container.querySelector('[role="dialog"][aria-label="Team Email"]');
+        const subjectInput = emailDialog.querySelector('input[placeholder="Team update"]');
+        const bodyInput = emailDialog.querySelector('textarea[placeholder="Write the email body..."]');
+        await setFieldValue(subjectInput, 'Tournament update');
+        await setFieldValue(bodyInput, 'Arrive at 8:30.');
+        await click(container, 'Send email');
+
+        expect(chatMocks.sendTeamEmailMessage).toHaveBeenCalledWith({
+            teamId: 'team-1',
+            subject: 'Tournament update',
+            body: 'Arrive at 8:30.',
+            targetType: 'individuals',
+            recipientIds: ['user:coach-1']
+        });
+        expect(subjectInput.value).toBe('');
+        expect(bodyInput.value).toBe('');
+        expect(container.textContent).toContain('Queued 12 recipients for backend email delivery.');
+
+        chatMocks.loadChatTeamContext.mockResolvedValueOnce({
+            team: { id: 'team-1', name: 'Bears', sport: 'Basketball' },
+            profile: { fullName: 'Pat Parent', photoUrl: '' },
+            canModerate: false
+        });
+        const parentView = await renderMessages('/messages/team-1');
+        expect(parentView.container.textContent).not.toContain('Team Email');
+    });
+
+    it('keeps Team Email drafts when backend sending fails', async () => {
+        chatMocks.sendTeamEmailMessage.mockRejectedValueOnce(new Error('Callable down'));
+        const { container } = await renderMessages('/messages/team-1');
+
+        await click(container, 'Team Email');
+        const emailDialog = container.querySelector('[role="dialog"][aria-label="Team Email"]');
+        const subjectInput = emailDialog.querySelector('input[placeholder="Team update"]');
+        const bodyInput = emailDialog.querySelector('textarea[placeholder="Write the email body..."]');
+        await setFieldValue(subjectInput, 'Schedule');
+        await setFieldValue(bodyInput, 'Game moved.');
+        await click(container, 'Send email');
+
+        expect(container.textContent).toContain('Callable down');
+        expect(subjectInput.value).toBe('Schedule');
+        expect(bodyInput.value).toBe('Game moved.');
     });
 
     it('blocks selected member sends until at least one recipient is checked', async () => {

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -533,6 +533,66 @@ describe('React app messages integration', () => {
         expect(parentView.container.textContent).not.toContain('Team Email');
     });
 
+    it('preserves Team Email send success when sent history refresh fails', async () => {
+        const { container } = await renderMessages('/messages/team-1');
+
+        await click(container, 'Team Email');
+        chatMocks.loadSentTeamEmails.mockRejectedValueOnce(new Error('History refresh down'));
+        const emailDialog = container.querySelector('[role="dialog"][aria-label="Team Email"]');
+        const subjectInput = emailDialog.querySelector('input[placeholder="Team update"]');
+        const bodyInput = emailDialog.querySelector('textarea[placeholder="Write the email body..."]');
+        await setFieldValue(subjectInput, 'Schedule');
+        await setFieldValue(bodyInput, 'Game moved.');
+        await click(container, 'Send email');
+
+        expect(chatMocks.sendTeamEmailMessage).toHaveBeenCalled();
+        expect(container.textContent).toContain('Queued 12 recipients for backend email delivery.');
+        expect(container.textContent).not.toContain('History refresh down');
+        expect(subjectInput.value).toBe('');
+        expect(bodyInput.value).toBe('');
+    });
+
+    it('keeps Team Email send success separate from stale history load errors', async () => {
+        let rejectInitialHistory;
+        const initialHistoryLoad = new Promise((resolve, reject) => {
+            rejectInitialHistory = reject;
+        });
+        chatMocks.loadSentTeamEmails
+            .mockImplementationOnce(() => initialHistoryLoad)
+            .mockResolvedValueOnce([
+                {
+                    id: 'email-2',
+                    subject: 'Schedule',
+                    senderName: 'Coach Jamie',
+                    sentAt: new Date('2026-05-22T15:00:00Z'),
+                    recipientCount: 12,
+                    status: 'queued'
+                }
+            ]);
+        const { container } = await renderMessages('/messages/team-1');
+
+        await click(container, 'Team Email');
+        const emailDialog = container.querySelector('[role="dialog"][aria-label="Team Email"]');
+        const subjectInput = emailDialog.querySelector('input[placeholder="Team update"]');
+        const bodyInput = emailDialog.querySelector('textarea[placeholder="Write the email body..."]');
+        await setFieldValue(subjectInput, 'Schedule');
+        await setFieldValue(bodyInput, 'Game moved.');
+        await click(container, 'Send email');
+
+        expect(container.textContent).toContain('Queued 12 recipients for backend email delivery.');
+
+        await act(async () => {
+            rejectInitialHistory(new Error('Initial history down'));
+            await initialHistoryLoad.catch(() => undefined);
+        });
+        await flush();
+
+        expect(container.textContent).toContain('Queued 12 recipients for backend email delivery.');
+        expect(container.textContent).toContain('Initial history down');
+        expect(subjectInput.value).toBe('');
+        expect(bodyInput.value).toBe('');
+    });
+
     it('keeps Team Email drafts when backend sending fails', async () => {
         chatMocks.sendTeamEmailMessage.mockRejectedValueOnce(new Error('Callable down'));
         const { container } = await renderMessages('/messages/team-1');

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -14,12 +14,14 @@ const dbMocks = vi.hoisted(() => ({
     getGames: vi.fn(),
     getParentTeams: vi.fn(),
     getPlayers: vi.fn(),
+    getSentTeamEmails: vi.fn(),
     getTeam: vi.fn(),
     getUnreadChatCounts: vi.fn(),
     getUserByEmail: vi.fn(),
     getUserProfile: vi.fn(),
     getUserTeamsWithAccess: vi.fn(),
     postChatMessage: vi.fn(),
+    sendTeamEmail: vi.fn(),
     subscribeToChatMessages: vi.fn(),
     toggleChatReaction: vi.fn(),
     updateChatLastRead: vi.fn(),
@@ -62,6 +64,8 @@ beforeEach(() => {
     dbMocks.canModerateChat.mockImplementation((user, team) => team.id === 'team-coach');
     dbMocks.getUnreadChatCounts.mockResolvedValue({});
     dbMocks.getChatMessages.mockResolvedValue([]);
+    dbMocks.sendTeamEmail.mockResolvedValue({ recipientCount: 8, status: 'queued' });
+    dbMocks.getSentTeamEmails.mockResolvedValue([]);
 });
 
 describe('React app chat recipient service', () => {
@@ -292,6 +296,47 @@ describe('React app chat recipient service', () => {
 
         expect(dbMocks.postChatMessage).not.toHaveBeenCalled();
         expect(dbMocks.upsertChatConversation).not.toHaveBeenCalled();
+    });
+
+    it('sends team email through the backend callable wrapper', async () => {
+        const { sendTeamEmailMessage, loadSentTeamEmails } = await import('../../apps/app/src/lib/chatService.ts');
+
+        await expect(sendTeamEmailMessage({
+            teamId: 'team-1',
+            subject: ' Practice update ',
+            body: ' Bring jerseys ',
+            targetType: 'individuals',
+            recipientIds: ['user:coach-1']
+        })).resolves.toEqual({ recipientCount: 8, status: 'queued' });
+
+        expect(dbMocks.sendTeamEmail).toHaveBeenCalledWith('team-1', {
+            subject: 'Practice update',
+            body: 'Bring jerseys',
+            targetType: 'individuals',
+            recipientIds: ['user:coach-1']
+        });
+
+        await loadSentTeamEmails('team-1', { limit: 10 });
+        expect(dbMocks.getSentTeamEmails).toHaveBeenCalledWith('team-1', { limit: 10 });
+    });
+
+    it('validates team email subject, body, and selected recipients', async () => {
+        const { sendTeamEmailMessage } = await import('../../apps/app/src/lib/chatService.ts');
+
+        await expect(sendTeamEmailMessage({
+            teamId: 'team-1',
+            subject: '   ',
+            body: 'Body',
+            targetType: 'full_team'
+        })).rejects.toThrow('Subject and message are required.');
+        await expect(sendTeamEmailMessage({
+            teamId: 'team-1',
+            subject: 'Subject',
+            body: 'Body',
+            targetType: 'individuals',
+            recipientIds: []
+        })).rejects.toThrow('Choose at least one selected member before sending.');
+        expect(dbMocks.sendTeamEmail).not.toHaveBeenCalled();
     });
 
     it('cleans uploaded chat media if the message write fails', async () => {


### PR DESCRIPTION
Closes #1452

## Summary
- Added coach/admin-only Team Email entry point in React Messages.
- Added service wrappers for `sendTeamEmail` and `getSentTeamEmails`.
- Reused current Messages audience targeting for full team, staff, and selected members.
- Added queued delivery feedback and sent email history without exposing recipient email addresses.

## Validation
- `npx vitest run tests/unit/app-chat-logic.test.js tests/unit/app-chat-service-recipients.test.js tests/unit/app-chat-messages-integration.test.jsx --reporter=verbose`
- `npm run app:build`