### PR TITLE
Show team fee loading state

### DIFF
--- a/src/app/team-fees/team-fees.component.html
+++ b/src/app/team-fees/team-fees.component.html
@@ -4,18 +4,24 @@
 
 <div *ngIf="paymentErrorMessage" class="error-message">{{ paymentErrorMessage }}</div>
 
-<div *ngIf="teamFees.length > 0; else noFees">
-  <div *ngFor="let fee of teamFees" class="team-fee-item">
-    <h3>{{ fee.name }}</h3>
-    <p>Amount: {{ fee.amount | currency }}</p>
-    <p>Status: <span [class.paid]="fee.isPaid" [class.unpaid]="!fee.isPaid">{{ fee.isPaid ? 'Paid' : 'Unpaid' }}</span></p>
-
-    <button *ngIf="!fee.isPaid" (click)="handlePayFee(fee)" [disabled]="isPaymentPending()">
-      <span *ngIf="!isPaymentLoading(fee.id)">Pay Team Fee</span>
-      <span *ngIf="isPaymentLoading(fee.id)">Initiating Payment...</span>
-    </button>
-  </div>
+<div *ngIf="isLoadingFees; else feesReady">
+  <p>Loading team fees...</p>
 </div>
+
+<ng-template #feesReady>
+  <div *ngIf="teamFees.length > 0; else noFees">
+    <div *ngFor="let fee of teamFees" class="team-fee-item">
+      <h3>{{ fee.name }}</h3>
+      <p>Amount: {{ fee.amount | currency }}</p>
+      <p>Status: <span [class.paid]="fee.isPaid" [class.unpaid]="!fee.isPaid">{{ fee.isPaid ? 'Paid' : 'Unpaid' }}</span></p>
+
+      <button *ngIf="!fee.isPaid" (click)="handlePayFee(fee)" [disabled]="isPaymentPending()">
+        <span *ngIf="!isPaymentLoading(fee.id)">Pay Team Fee</span>
+        <span *ngIf="isPaymentLoading(fee.id)">Initiating Payment...</span>
+      </button>
+    </div>
+  </div>
+</ng-template>
 
 <ng-template #noFees>
   <p>No team fees to display.</p>

--- a/src/app/team-fees/team-fees.component.spec.ts
+++ b/src/app/team-fees/team-fees.component.spec.ts
@@ -195,6 +195,23 @@ describe('TeamFeesComponent checkout flow', () => {
     expect(component.paymentErrorMessage).toBeNull();
   });
 
+  it('gates the no-fees empty state behind completed fee loading', () => {
+    expect(template).toContain('*ngIf="isLoadingFees; else feesReady"');
+    expect(template).toContain('<ng-template #feesReady>');
+    expect(template).toContain('*ngIf="teamFees.length > 0; else noFees"');
+    expect(template.indexOf('else feesReady')).toBeLessThan(template.indexOf('else noFees'));
+  });
+
+  it('represents loading instead of the empty state while fees are still loading', () => {
+    component.isLoadingFees = true;
+    component.teamFees = [];
+
+    expect(component.isLoadingFees).toBe(true);
+    expect(component.teamFees).toHaveLength(0);
+    expect(template).toContain('Loading team fees...');
+    expect(template).toContain('*ngIf="isLoadingFees; else feesReady"');
+  });
+
   it('renders a Pay Team Fee button only for unpaid fees', async () => {
     mockGetDocs.mockResolvedValueOnce({
       docs: [feeDoc('teams/team-real/feeBatches/batch-real/feeRecipients/recipient-real', 'recipient-real', {


### PR DESCRIPTION
Closes #1455

## Summary
- Show a loading message while team fees are still loading.
- Defer the empty fee state until loading is complete.
- Added targeted regression coverage for the template loading gate and loading-with-empty-fees behavior.

## Tests
- `npx vitest run src/app/team-fees/team-fees.component.spec.ts --reporter=verbose`