### PR TITLE
Support multi-photo team media uploads

### DIFF
--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -166,13 +166,13 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
         } else {
           setMessage(resultMessage);
         }
-        if (photoInputRef.current) photoInputRef.current.value = '';
       } else {
         setMessage('');
         setError(failed > 0 ? 'No photos uploaded. Choose image files that are 10 MB or smaller.' : 'Photo upload failed.');
       }
     } finally {
       setUploading('');
+      if (photoInputRef.current) photoInputRef.current.value = '';
     }
   };
 

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -80,21 +80,43 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const emptyStateLabel = selectedMediaType === 'all' ? 'media' : selectedMediaTypeLabel.toLowerCase();
   const featured = activeFolder?.items[0] || allItems[0] || null;
 
-  const uploadPhoto = async (file: File | null | undefined) => {
-    if (!file || !activeFolder || creatingAlbum) return;
+  const uploadPhotos = async (files: File[]) => {
+    if (!files.length || !activeFolder || creatingAlbum) return;
     setUploading('photo');
     setError('');
-    setMessage('Uploading photo...');
+    setMessage(`Uploading ${files.length} photo${files.length === 1 ? '' : 's'}...`);
+    let uploaded = 0;
+    let failed = 0;
     try {
-      await uploadParentTeamMediaPhoto(teamId, activeFolder.id, file);
-      setMessage('Photo uploaded.');
-      await refresh({ showLoading: false });
-    } catch (uploadError: any) {
-      setError(uploadError?.message || 'Photo upload failed.');
-      setMessage('');
+      for (const file of files) {
+        if (!isSupportedPhotoUpload(file)) {
+          failed += 1;
+          continue;
+        }
+        try {
+          await uploadParentTeamMediaPhoto(teamId, activeFolder.id, file);
+          uploaded += 1;
+        } catch {
+          failed += 1;
+        }
+      }
+
+      if (uploaded > 0) {
+        const resultMessage = getPhotoUploadMessage(uploaded, failed);
+        await refresh({ showLoading: false, preferredFolderId: activeFolder.id });
+        if (failed > 0) {
+          setError(resultMessage);
+          setMessage('');
+        } else {
+          setMessage(resultMessage);
+        }
+        if (photoInputRef.current) photoInputRef.current.value = '';
+      } else {
+        setMessage('');
+        setError(failed > 0 ? 'No photos uploaded. Choose image files that are 10 MB or smaller.' : 'Photo upload failed.');
+      }
     } finally {
       setUploading('');
-      if (photoInputRef.current) photoInputRef.current.value = '';
     }
   };
 
@@ -280,7 +302,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
               File
             </button>
           </div>
-          <input ref={photoInputRef} className="hidden" type="file" accept="image/*" onChange={(event) => uploadPhoto(event.target.files?.[0])} />
+          <input ref={photoInputRef} className="hidden" type="file" accept="image/*" multiple onChange={(event) => uploadPhotos(Array.from(event.target.files || []))} />
           <input ref={fileInputRef} className="hidden" type="file" accept=".pdf,.doc,.docx,.xls,.xlsx,.csv,.txt,.ppt,.pptx" onChange={(event) => uploadFile(event.target.files?.[0])} />
           <form className="mt-3 grid gap-2 sm:grid-cols-[1fr_1fr_auto]" onSubmit={addLink}>
             <input className="auth-input" value={linkTitle} onChange={(event) => setLinkTitle(event.target.value)} placeholder="Video or link title" />
@@ -342,6 +364,17 @@ const MEDIA_TYPE_FILTERS: { id: MediaTypeFilter; label: string }[] = [
   { id: 'videos', label: 'Videos' },
   { id: 'files', label: 'Files' }
 ];
+const MAX_PHOTO_UPLOAD_BYTES = 10 * 1024 * 1024;
+
+function isSupportedPhotoUpload(file: File) {
+  return Boolean(file?.type?.startsWith('image/')) && Number(file.size || 0) > 0 && Number(file.size || 0) <= MAX_PHOTO_UPLOAD_BYTES;
+}
+
+function getPhotoUploadMessage(uploaded: number, failed: number) {
+  const uploadedLabel = `${uploaded} photo${uploaded === 1 ? '' : 's'} uploaded`;
+  if (failed > 0) return `${uploadedLabel}; ${failed} failed.`;
+  return `${uploadedLabel}.`;
+}
 
 function isPhotoMediaItem(item: TeamMediaItem) {
   const type = String(item.type || '').toLowerCase();

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -536,6 +536,53 @@ describe('React app parent tools integration', () => {
         expect(nextRender.container.textContent).not.toContain('Create album');
     });
 
+    it('uploads multiple app team media photos in one batch and refreshes once', async () => {
+        let resolveUpload;
+        const pendingUpload = new Promise((resolve) => {
+            resolveUpload = resolve;
+        });
+        serviceMocks.uploadParentTeamMediaPhoto.mockImplementation(() => pendingUpload);
+        const { container } = await renderParentTools('/teams/team-1/media');
+        await waitForText(container, 'Bears media');
+
+        const photoButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent.trim().includes('Photo'));
+        const photoInput = container.querySelector('input[accept="image/*"]');
+        const firstPhoto = new File(['photo-one'], 'photo-one.jpg', { type: 'image/jpeg' });
+        const secondPhoto = new File(['photo-two'], 'photo-two.png', { type: 'image/png' });
+        expect(photoInput.hasAttribute('multiple')).toBe(true);
+        Object.defineProperty(photoInput, 'files', { value: [firstPhoto, secondPhoto], configurable: true });
+        await act(() => {
+            photoInput.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+        expect(photoButton.disabled).toBe(true);
+        await act(async () => {
+            resolveUpload();
+        });
+        await vi.waitUntil(() => serviceMocks.uploadParentTeamMediaPhoto.mock.calls.length === 2);
+
+        expect(serviceMocks.uploadParentTeamMediaPhoto).toHaveBeenNthCalledWith(1, 'team-1', 'folder-1', firstPhoto);
+        expect(serviceMocks.uploadParentTeamMediaPhoto).toHaveBeenNthCalledWith(2, 'team-1', 'folder-1', secondPhoto);
+        await waitForText(container, '2 photos uploaded.');
+        expect(serviceMocks.loadTeamMediaForApp).toHaveBeenCalledTimes(2);
+    });
+
+    it('reports partial app team media photo failures without blocking valid images', async () => {
+        const { container } = await renderParentTools('/teams/team-1/media');
+        await waitForText(container, 'Bears media');
+
+        const photoInput = container.querySelector('input[accept="image/*"]');
+        const textFile = new File(['not-image'], 'notes.txt', { type: 'text/plain' });
+        const validPhoto = new File(['photo'], 'photo.jpg', { type: 'image/jpeg' });
+        Object.defineProperty(photoInput, 'files', { value: [textFile, validPhoto], configurable: true });
+        await act(async () => {
+            photoInput.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+        await vi.waitUntil(() => serviceMocks.uploadParentTeamMediaPhoto.mock.calls.length === 1);
+
+        expect(serviceMocks.uploadParentTeamMediaPhoto).toHaveBeenCalledWith('team-1', 'folder-1', validPhoto);
+        await waitForText(container, '1 photo uploaded; 1 failed.');
+    });
+
     it('loads team media, uploads photos/files, adds links, and opens media items', async () => {
         const { container } = await renderParentTools('/teams/team-1/media');
         await waitForText(container, 'Bears media');


### PR DESCRIPTION
Closes #1454

## Summary
- Allows the React Team Media photo picker to select multiple images.
- Uploads valid images sequentially to the active album, skips invalid or oversized files, and refreshes the album once after the batch.
- Adds pluralized success and partial-failure batch status.

## Validation
- `npx vitest run tests/unit/app-parent-tools-integration.test.jsx --reporter=verbose`
- `npm run app:build`