### PR TITLE
Default mobile live games to Video

### DIFF
--- a/js/live-game.js
+++ b/js/live-game.js
@@ -557,6 +557,8 @@ function refreshVideoPanel({ force = false } = {}) {
       hasStreamScoreContext
     );
     state.hasVideoStream = Boolean(state.videoPlayback?.hasVideo || shouldShowVideoPanel);
+    const videoTab = document.querySelector('#mobile-tabs [data-tab="video"]');
+    if (videoTab) videoTab.classList.toggle('hidden', !shouldShowVideoPanel);
     renderRecordedReplayTools();
     renderGameMediaHub();
     renderReplayAvailabilityState({ shouldShowVideoPanel });

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -85,6 +85,7 @@ const state = {
   replayStartAt: null,
 
   activeTab: 'plays',
+  hasUserSelectedTab: false,
   unsubscribers: [],
 
   lastStatChange: null,
@@ -309,6 +310,7 @@ function initTabs() {
   els.mobileTabs.forEach(tab => {
     tab.addEventListener('click', () => {
       state.activeTab = tab.dataset.tab;
+      state.hasUserSelectedTab = true;
       updateTabs();
     });
   });
@@ -321,7 +323,8 @@ function updateTabs() {
   const visibility = computePanelVisibility({
     isMobile,
     activeTab: state.activeTab,
-    hasVideoStream: state.hasVideoStream
+    hasVideoStream: state.hasVideoStream,
+    shouldDefaultToVideo: !state.hasUserSelectedTab
   });
   state.activeTab = visibility.activeTab;
 

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -558,7 +558,7 @@ function refreshVideoPanel({ force = false } = {}) {
     );
     state.hasVideoStream = Boolean(state.videoPlayback?.hasVideo || shouldShowVideoPanel);
     const videoTab = document.querySelector('#mobile-tabs [data-tab="video"]');
-    if (videoTab) videoTab.classList.toggle('hidden', !shouldShowVideoPanel);
+    if (videoTab) videoTab.classList.toggle('hidden', !state.hasVideoStream);
     renderRecordedReplayTools();
     renderGameMediaHub();
     renderReplayAvailabilityState({ shouldShowVideoPanel });

--- a/js/live-stream-utils.js
+++ b/js/live-stream-utils.js
@@ -21,7 +21,7 @@ export function normalizeYouTubeEmbedUrl(url) {
     }
 }
 
-export function computePanelVisibility({ isMobile, activeTab, hasVideoStream }) {
+export function computePanelVisibility({ isMobile, activeTab, hasVideoStream, shouldDefaultToVideo = false }) {
     if (!isMobile) {
         return {
             activeTab,
@@ -32,7 +32,9 @@ export function computePanelVisibility({ isMobile, activeTab, hasVideoStream }) 
         };
     }
 
-    const safeActiveTab = activeTab === 'video' && !hasVideoStream ? 'plays' : activeTab;
+    const safeActiveTab = activeTab === 'video' && !hasVideoStream
+        ? 'plays'
+        : shouldDefaultToVideo && hasVideoStream ? 'video' : activeTab;
     return {
         activeTab: safeActiveTab,
         videoHidden: safeActiveTab !== 'video' || !hasVideoStream,

--- a/tests/unit/live-game-replay-init.test.js
+++ b/tests/unit/live-game-replay-init.test.js
@@ -548,6 +548,7 @@ describe('live game replay initialization', () => {
         expect(noReloadBranch).toContain('const shouldShowVideoPanel = Boolean(');
         expect(noReloadBranch).toContain('hasMediaHubContent(state.videoPlayback?.mediaHub)');
         expect(noReloadBranch).toContain('state.videoPlayback?.gameClips?.length');
+        expect(noReloadBranch).toContain('if (videoTab) videoTab.classList.toggle(\'hidden\', !state.hasVideoStream);');
         expect(noReloadBranch).toContain('renderReplayAvailabilityState({ shouldShowVideoPanel });');
         expect(noReloadBranch).not.toContain('renderReplayAvailabilityState();');
     });

--- a/tests/unit/live-stream-utils.test.js
+++ b/tests/unit/live-stream-utils.test.js
@@ -84,4 +84,28 @@ describe('video panel visibility', () => {
         expect(visibility.videoHidden).toBe(true);
         expect(visibility.playsHidden).toBe(false);
     });
+
+    it('defaults mobile to video when stream exists before a manual tab selection', () => {
+        const visibility = computePanelVisibility({
+            isMobile: true,
+            activeTab: 'plays',
+            hasVideoStream: true,
+            shouldDefaultToVideo: true
+        });
+        expect(visibility.activeTab).toBe('video');
+        expect(visibility.videoHidden).toBe(false);
+        expect(visibility.playsHidden).toBe(true);
+    });
+
+    it('keeps a manually selected mobile tab when stream state updates', () => {
+        const visibility = computePanelVisibility({
+            isMobile: true,
+            activeTab: 'chat',
+            hasVideoStream: true,
+            shouldDefaultToVideo: false
+        });
+        expect(visibility.activeTab).toBe('chat');
+        expect(visibility.videoHidden).toBe(true);
+        expect(visibility.chatHidden).toBe(false);
+    });
 });


### PR DESCRIPTION
Closes #1463

## Summary
- Default mobile live-game panel visibility to the Video tab when video-capable content is available and the viewer has not manually selected another tab.
- Track manual mobile tab selection so later video state updates do not pull viewers away from Plays, Stats, or Chat.
- Added focused unit coverage for mobile video defaulting and preserving manual tab selection.

## Tests
- `npx vitest run tests/unit/live-stream-utils.test.js --reporter=verbose`