### PR TITLE
Scope team stat leaders by selected season

### DIFF
--- a/js/stat-leaderboards.js
+++ b/js/stat-leaderboards.js
@@ -1,3 +1,5 @@
+import { inferSeasonLabelFromGame } from './season-record.js';
+
 function slugifyStatId(value) {
   return String(value || '')
     .trim()
@@ -403,6 +405,36 @@ function buildStatLeaderboard(definition, players = [], seasonStatsByPlayerId = 
     leader: leaders[0] || null,
     leaders
   };
+}
+
+export async function aggregateSeasonStatsByPlayerId({
+  games = [],
+  seasonLabel = '',
+  loadGameStats
+} = {}) {
+  if (typeof loadGameStats !== 'function') return {};
+
+  const seasonStatsByPlayerId = {};
+  const completedGames = (Array.isArray(games) ? games : []).filter((game) => {
+    const status = String(game?.status || '').toLowerCase();
+    const liveStatus = String(game?.liveStatus || '').toLowerCase();
+    if (status !== 'completed' && liveStatus !== 'completed') return false;
+    return !seasonLabel || inferSeasonLabelFromGame(game) === seasonLabel;
+  });
+
+  for (const game of completedGames) {
+    const statsByPlayerId = await loadGameStats(game);
+    Object.entries(statsByPlayerId || {}).forEach(([playerId, stats]) => {
+      if (!seasonStatsByPlayerId[playerId]) {
+        seasonStatsByPlayerId[playerId] = {};
+      }
+      Object.entries(stats || {}).forEach(([stat, value]) => {
+        seasonStatsByPlayerId[playerId][stat] = (seasonStatsByPlayerId[playerId][stat] || 0) + (Number(value) || 0);
+      });
+    });
+  }
+
+  return seasonStatsByPlayerId;
 }
 
 export function buildPlayerLeaderboardSnapshot({

--- a/team.html
+++ b/team.html
@@ -330,7 +330,7 @@
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';
         import { computeNativeStandings } from './js/native-standings.js?v=1';
         import { computeTournamentPoolStandings } from './js/tournament-standings.js?v=3';
-        import { buildPlayerLeaderboardSnapshot, selectAnalyticsConfig } from './js/stat-leaderboards.js?v=2';
+        import { aggregateSeasonStatsByPlayerId, buildPlayerLeaderboardSnapshot, selectAnalyticsConfig } from './js/stat-leaderboards.js?v=3';
         import { calculateSeasonRecord, listSeasonLabels } from './js/season-record.js';
         import { checkAuth } from './js/auth.js?v=15';
         import { collection, getDocs, query, where } from "./js/firebase.js?v=15";
@@ -1334,6 +1334,12 @@
             return `${minutes}:${seconds.toString().padStart(2, '0')}`;
         }
 
+        function updateConfiguredTeamLeaderboardSection(snapshot, teamId) {
+            const container = document.getElementById('configured-team-leaderboards-section');
+            if (!container) return;
+            container.innerHTML = renderConfiguredTeamLeaderboards(snapshot, teamId);
+        }
+
         function renderConfiguredTeamLeaderboards(snapshot, teamId) {
             if (!snapshot?.topStats?.length) return '';
 
@@ -1590,28 +1596,36 @@
                     getGames(teamId),
                     getConfigs(teamId)
                 ]);
-                const seasonStatsByPlayerId = {};
                 const completedGames = dbGames.filter(g => g.status === 'completed');
-                for (const game of completedGames) {
-                    const snap = await getDocs(collection(db, `teams/${teamId}/games/${game.id}/aggregatedStats`));
+                const aggregatedStatsByGameId = new Map();
+                async function loadAggregatedStatsForGame(game) {
+                    const gameId = game?.id || game?.gameId;
+                    if (!gameId) return {};
+                    if (aggregatedStatsByGameId.has(gameId)) {
+                        return aggregatedStatsByGameId.get(gameId);
+                    }
+                    const snap = await getDocs(collection(db, `teams/${teamId}/games/${gameId}/aggregatedStats`));
+                    const statsByPlayerId = {};
                     snap.forEach((docSnap) => {
-                        const stats = docSnap.data()?.stats || {};
-                        if (!seasonStatsByPlayerId[docSnap.id]) {
-                            seasonStatsByPlayerId[docSnap.id] = {};
-                        }
-                        Object.entries(stats).forEach(([stat, value]) => {
-                            seasonStatsByPlayerId[docSnap.id][stat] = (seasonStatsByPlayerId[docSnap.id][stat] || 0) + (Number(value) || 0);
-                        });
+                        statsByPlayerId[docSnap.id] = docSnap.data()?.stats || {};
                     });
+                    aggregatedStatsByGameId.set(gameId, statsByPlayerId);
+                    return statsByPlayerId;
                 }
                 const analyticsConfig = selectAnalyticsConfig(configs, team?.sport || '');
-                const leaderboardSnapshot = analyticsConfig
-                    ? buildPlayerLeaderboardSnapshot({
+                async function buildLeaderboardSnapshotForSeason(selectedSeason) {
+                    if (!analyticsConfig) return null;
+                    const seasonStatsByPlayerId = await aggregateSeasonStatsByPlayerId({
+                        games: dbGames,
+                        seasonLabel: selectedSeason,
+                        loadGameStats: loadAggregatedStatsForGame
+                    });
+                    return buildPlayerLeaderboardSnapshot({
                         config: analyticsConfig,
                         players,
                         seasonStatsByPlayerId
-                    })
-                    : null;
+                    });
+                }
 
                 teamGames = dbGames;
                 currentPlayers = players;
@@ -1840,9 +1854,11 @@
 
                 const seasonFilterEl = document.getElementById('season-record-filter');
                 if (seasonFilterEl) {
-                    seasonFilterEl.addEventListener('change', () => {
+                    seasonFilterEl.addEventListener('change', async () => {
                         seasonFilterLabel = seasonFilterEl.value;
                         updateSeasonRecordCard(dbGames, seasonFilterLabel);
+                        const updatedLeaderboardSnapshot = await buildLeaderboardSnapshotForSeason(seasonFilterLabel);
+                        updateConfiguredTeamLeaderboardSection(updatedLeaderboardSnapshot, teamId);
                     });
                 }
 
@@ -1903,6 +1919,7 @@
                     const goalDifferential = totalGoalsFor - totalGoalsAgainst;
 
                     teamAdvancedStatsDiv.innerHTML = `
+                        <div id="configured-team-leaderboards-section"></div>
                         <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
                             <!-- Team Form -->
                             <div class="bg-white rounded-xl p-6 shadow-md border border-gray-200">
@@ -2019,6 +2036,7 @@
                     `;
                 } else {
                     teamAdvancedStatsDiv.innerHTML = `
+                        <div id="configured-team-leaderboards-section"></div>
                         <div class="text-center py-12">
                             <svg class="w-16 h-16 text-gray-300 mx-auto mb-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"></path>
@@ -2029,14 +2047,8 @@
                     `;
                 }
 
-                if (leaderboardSnapshot?.topStats?.length) {
-                    teamAdvancedStatsDiv.innerHTML = `
-                        <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                            ${renderConfiguredTeamLeaderboards(leaderboardSnapshot, teamId)}
-                        </div>
-                        ${teamAdvancedStatsDiv.innerHTML}
-                    `;
-                }
+                const leaderboardSnapshot = await buildLeaderboardSnapshotForSeason(seasonFilterLabel);
+                updateConfiguredTeamLeaderboardSection(leaderboardSnapshot, teamId);
                 }
 
                 await renderPlayerTrackingSection(teamId, players);

--- a/tests/smoke/team-schedule-calendar.spec.js
+++ b/tests/smoke/team-schedule-calendar.spec.js
@@ -233,6 +233,10 @@ export function computeNativeStandings() {
 `;
 
 const STAT_STUB = `
+export async function aggregateSeasonStatsByPlayerId() {
+    return {};
+}
+
 export function buildPlayerLeaderboardSnapshot() {
     return null;
 }
@@ -403,7 +407,7 @@ async function mockTeamPageModules(page, scenario) {
         contentType: 'application/javascript',
         body: NATIVE_STUB
     }));
-    await page.route('**/js/stat-leaderboards.js?v=2', (route) => route.fulfill({
+    await page.route(/\/js\/stat-leaderboards\.js(?:\?v=\d+)?$/, (route) => route.fulfill({
         status: 200,
         contentType: 'application/javascript',
         body: STAT_STUB

--- a/tests/unit/stat-leaderboards.test.js
+++ b/tests/unit/stat-leaderboards.test.js
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  aggregateSeasonStatsByPlayerId,
   buildPlayerLeaderboardSnapshot,
   evaluateDerivedFormula,
   normalizeStatTrackerConfig,
@@ -11,6 +12,47 @@ import {
 } from '../../js/stat-leaderboards.js';
 
 describe('stat leaderboard helpers', () => {
+  it('aggregates team leaderboard stats only for the selected season', async () => {
+    const games = [
+      { id: 'spring-1', status: 'completed', seasonLabel: 'Spring 2026', date: '2026-03-01' },
+      { id: 'fall-1', status: 'completed', seasonLabel: 'Fall 2025', date: '2025-09-01' },
+      { id: 'spring-pending', status: 'scheduled', seasonLabel: 'Spring 2026', date: '2026-03-08' }
+    ];
+    const statsByGame = {
+      'spring-1': { p1: { pts: 12 }, p2: { pts: 8 } },
+      'fall-1': { p1: { pts: 30 }, p2: { pts: 4 } },
+      'spring-pending': { p1: { pts: 99 } }
+    };
+
+    const stats = await aggregateSeasonStatsByPlayerId({
+      games,
+      seasonLabel: 'Spring 2026',
+      loadGameStats: async (game) => statsByGame[game.id]
+    });
+
+    expect(stats).toEqual({
+      p1: { pts: 12 },
+      p2: { pts: 8 }
+    });
+
+    const snapshot = buildPlayerLeaderboardSnapshot({
+      config: {
+        columns: ['PTS'],
+        statDefinitions: [{ label: 'PTS', acronym: 'PTS', topStat: true }]
+      },
+      players: [
+        { id: 'p1', name: 'Ava Cole' },
+        { id: 'p2', name: 'Mia Brooks' }
+      ],
+      seasonStatsByPlayerId: stats
+    });
+
+    expect(snapshot.topStats[0].leader).toEqual(expect.objectContaining({
+      playerId: 'p1',
+      value: 12
+    }));
+  });
+
   it('normalizes legacy column-only configs into typed base stat definitions', () => {
     const normalized = normalizeStatTrackerConfig({
       name: 'Basketball Standard',

--- a/tests/unit/team-stat-leaderboards.test.js
+++ b/tests/unit/team-stat-leaderboards.test.js
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+function readTeamHtml() {
+    return readFileSync(new URL('../../team.html', import.meta.url), 'utf8');
+}
+
+describe('team stat leaderboard season wiring', () => {
+    it('rebuilds configured stat leaderboards when the season selector changes', () => {
+        const source = readTeamHtml();
+
+        expect(source).toContain('aggregateSeasonStatsByPlayerId');
+        expect(source).toContain('seasonFilterEl.addEventListener(\'change\', async () =>');
+        expect(source).toContain('const updatedLeaderboardSnapshot = await buildLeaderboardSnapshotForSeason(seasonFilterLabel);');
+        expect(source).toContain('updateConfiguredTeamLeaderboardSection(updatedLeaderboardSnapshot, teamId);');
+        expect(source).toContain('id="configured-team-leaderboards-section"');
+    });
+});


### PR DESCRIPTION
Closes #1468

## Summary
- Added season-scoped aggregation for team player leaderboard stats using the same season inference helper as the season record card.
- Rebuild and rerender configured stat leaderboards when the season selector changes.
- Added regression coverage for cross-season stat aggregation and team page selector wiring.

## Tests
- `npx vitest run tests/unit/stat-leaderboards.test.js tests/unit/team-stat-leaderboards.test.js tests/unit/season-record.test.js --reporter=verbose`