### PR TITLE
Allow stream volunteers in app search

### DIFF
--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -1,6 +1,7 @@
 import { getTeams } from '../../../../js/db.js';
 import {
   db,
+  collection,
   collectionGroup,
   getDocs,
   query,
@@ -234,9 +235,10 @@ export async function loadAppSearchTeams(user: AuthUser | null): Promise<AppSear
     return cachedTeams;
   }
 
-  const [siteTeamsResult, homeTeamsResult] = await Promise.allSettled([
+  const [siteTeamsResult, homeTeamsResult, streamVolunteerTeamsResult] = await Promise.allSettled([
     Promise.resolve(getTeams()),
-    user ? loadParentHome(user) : Promise.resolve(null)
+    user ? loadParentHome(user) : Promise.resolve(null),
+    user ? loadStreamVolunteerSearchTeams(user) : Promise.resolve([])
   ]);
 
   const teamsById = new Map<string, AppSearchTeam>();
@@ -270,12 +272,20 @@ export async function loadAppSearchTeams(user: AuthUser | null): Promise<AppSear
     });
   }
 
+  if (streamVolunteerTeamsResult.status === 'fulfilled') {
+    normalizeTeams(streamVolunteerTeamsResult.value).forEach((team) => {
+      if (canUserDiscoverTeamInAppSearch(team, user)) teamsById.set(team.id, team);
+    });
+  }
+
   if (!teamsById.size) {
     const firstError = siteTeamsResult.status === 'rejected'
       ? siteTeamsResult.reason
       : homeTeamsResult.status === 'rejected'
         ? homeTeamsResult.reason
-        : null;
+        : streamVolunteerTeamsResult.status === 'rejected'
+          ? streamVolunteerTeamsResult.reason
+          : null;
     if (firstError) throw firstError;
   }
 
@@ -398,6 +408,45 @@ export function resetAppSearchCacheForTests() {
   cachedTeamsUserKey = '';
 }
 
+async function loadStreamVolunteerSearchTeams(user: AuthUser): Promise<AppSearchTeam[]> {
+  const uid = cleanString(user.uid);
+  const email = cleanString(user.email).toLowerCase();
+  if (!uid && !email) return [];
+
+  const teamsRef = collection(db, 'teams');
+  const teamQueries = [];
+  if (uid) {
+    teamQueries.push(getDocs(query(
+      teamsRef,
+      where('teamPermissions.streaming.memberIds', 'array-contains', uid)
+    )));
+  }
+  if (email) {
+    teamQueries.push(getDocs(query(
+      teamsRef,
+      where('streamVolunteerEmails', 'array-contains', email)
+    )));
+  }
+
+  const snapshots = await Promise.allSettled(teamQueries);
+  const rejected = snapshots.filter((snapshot) => snapshot.status === 'rejected').map((snapshot: any) => snapshot.reason).filter(Boolean);
+  const hasFulfilled = snapshots.some((snapshot) => snapshot.status === 'fulfilled');
+
+  if (!hasFulfilled && rejected.length) {
+    throw rejected[0];
+  }
+
+  const teamsById = new Map<string, any>();
+  snapshots.forEach((snapshot: any) => {
+    if (snapshot.status !== 'fulfilled') return;
+    (snapshot.value?.docs || []).forEach((doc: any) => {
+      teamsById.set(doc.id, { id: doc.id, ...(typeof doc.data === 'function' ? doc.data() || {} : {}) });
+    });
+  });
+
+  return normalizeTeams(Array.from(teamsById.values()));
+}
+
 function rankSearchItems<T extends AppSearchItem>(items: T[], tokens: string[]) {
   return items
     .map((item) => ({ item, score: scoreSearchText(`${item.title} ${item.subtitle}`, tokens) }))
@@ -456,7 +505,7 @@ function canUserDiscoverTeamViaSelectedStreaming(team: AppSearchTeam, user: Auth
   const streamingMode = normalizeAccessMode(team.teamPermissions?.streaming?.mode);
   if (streamingMode === 'selected') {
     const memberIds = Array.isArray(team.teamPermissions?.streaming?.memberIds)
-      ? team.teamPermissions?.streaming?.memberIds || []
+      ? team.teamPermissions.streaming.memberIds
       : [];
     if (memberIds.map((entry) => cleanString(entry)).filter(Boolean).includes(cleanString(user.uid))) {
       return true;

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -16,6 +16,7 @@ const teamsCacheTtlMs = 10 * 60 * 1000;
 
 let cachedTeams: AppSearchTeam[] | null = null;
 let cachedTeamsLoadedAt = 0;
+let cachedTeamsUserKey = '';
 
 export type AppSearchKind = 'action' | 'team' | 'player' | 'social' | 'help';
 
@@ -43,6 +44,14 @@ export type AppSearchTeam = {
   adminEmails?: string[];
   photoUrl?: string | null;
   fromAppAccess?: boolean;
+  streamAccessMode?: string | null;
+  streamVolunteerEmails?: string[];
+  teamPermissions?: {
+    streaming?: {
+      mode?: string | null;
+      memberIds?: string[];
+    } | null;
+  } | null;
 };
 
 export type AppSearchPlayer = AppSearchItem & {
@@ -220,7 +229,8 @@ export function computeAppSearchResults({
 
 export async function loadAppSearchTeams(user: AuthUser | null): Promise<AppSearchTeam[]> {
   const now = Date.now();
-  if (cachedTeams && now - cachedTeamsLoadedAt < teamsCacheTtlMs) {
+  const userCacheKey = getAppSearchUserCacheKey(user);
+  if (cachedTeams && cachedTeamsUserKey === userCacheKey && now - cachedTeamsLoadedAt < teamsCacheTtlMs) {
     return cachedTeams;
   }
 
@@ -272,6 +282,7 @@ export async function loadAppSearchTeams(user: AuthUser | null): Promise<AppSear
   cachedTeams = Array.from(teamsById.values())
     .sort((a, b) => a.name.localeCompare(b.name));
   cachedTeamsLoadedAt = now;
+  cachedTeamsUserKey = userCacheKey;
   return cachedTeams;
 }
 
@@ -384,6 +395,7 @@ function getSearchHelpRoles(auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatfo
 export function resetAppSearchCacheForTests() {
   cachedTeams = null;
   cachedTeamsLoadedAt = 0;
+  cachedTeamsUserKey = '';
 }
 
 function rankSearchItems<T extends AppSearchItem>(items: T[], tokens: string[]) {
@@ -417,7 +429,10 @@ function normalizeTeams(teams: any[]): AppSearchTeam[] {
       active: team?.active,
       ownerId: cleanString(team?.ownerId),
       adminEmails: Array.isArray(team?.adminEmails) ? team.adminEmails : [],
-      photoUrl: getFirstUrl(team?.photoUrl, team?.teamPhotoUrl, team?.logoUrl, team?.imageUrl)
+      photoUrl: getFirstUrl(team?.photoUrl, team?.teamPhotoUrl, team?.logoUrl, team?.imageUrl),
+      streamAccessMode: cleanString(team?.streamAccessMode),
+      streamVolunteerEmails: Array.isArray(team?.streamVolunteerEmails) ? team.streamVolunteerEmails : [],
+      teamPermissions: normalizeSearchTeamPermissions(team?.teamPermissions)
     }))
     .filter((team) => team.id);
 }
@@ -433,7 +448,50 @@ function canUserDiscoverTeamInAppSearch(team: AppSearchTeam, user: AuthUser | nu
   const email = cleanString(user.email).toLowerCase();
   const adminEmails = (team.adminEmails || []).map((entry) => cleanString(entry).toLowerCase()).filter(Boolean);
   if (email && adminEmails.includes(email)) return true;
+  if (canUserDiscoverTeamViaSelectedStreaming(team, user, email)) return true;
   return Array.isArray(user.parentOf) && user.parentOf.some((link: any) => cleanString(link?.teamId) === team.id);
+}
+
+function canUserDiscoverTeamViaSelectedStreaming(team: AppSearchTeam, user: AuthUser, email: string) {
+  const streamingMode = normalizeAccessMode(team.teamPermissions?.streaming?.mode);
+  if (streamingMode === 'selected') {
+    const memberIds = Array.isArray(team.teamPermissions?.streaming?.memberIds)
+      ? team.teamPermissions?.streaming?.memberIds || []
+      : [];
+    if (memberIds.map((entry) => cleanString(entry)).filter(Boolean).includes(cleanString(user.uid))) {
+      return true;
+    }
+  }
+
+  const legacyMode = normalizeAccessMode(team.streamAccessMode);
+  if ((legacyMode === 'selected' || legacyMode === 'selected_volunteers') && email) {
+    const volunteerEmails = (team.streamVolunteerEmails || [])
+      .map((entry) => cleanString(entry).toLowerCase())
+      .filter(Boolean);
+    return volunteerEmails.includes(email);
+  }
+
+  return false;
+}
+
+function normalizeSearchTeamPermissions(teamPermissions: any) {
+  const streaming = teamPermissions?.streaming;
+  if (!streaming || typeof streaming !== 'object') return null;
+  return {
+    streaming: {
+      mode: cleanString(streaming.mode),
+      memberIds: Array.isArray(streaming.memberIds) ? streaming.memberIds : []
+    }
+  };
+}
+
+function normalizeAccessMode(value: unknown) {
+  return cleanString(value).toLowerCase();
+}
+
+function getAppSearchUserCacheKey(user: AuthUser | null) {
+  if (!user) return 'signed-out';
+  return `${cleanString(user.uid)}:${cleanString(user.email).toLowerCase()}`;
 }
 
 function canUserDiscoverPlayerInAppSearch(teamId: string, teamsById: Map<string, AppSearchTeam>, user: AuthUser | null) {

--- a/docs/pr-notes/runs/1472-remediator-20260528T061102Z/architecture.md
+++ b/docs/pr-notes/runs/1472-remediator-20260528T061102Z/architecture.md
@@ -1,0 +1,13 @@
+# Architecture role notes
+
+## Decision
+Add a narrow supplemental Firestore team lookup in `loadAppSearchTeams` for signed-in users instead of broad `getTeams({ includePrivate: true })`.
+
+## Rationale
+- Keeps blast radius small: only targeted queries for the signed-in user's uid and email.
+- Preserves existing public/owner/admin-email `getTeams()` behavior and parent-home merge.
+- Avoids relying on broad private team reads, which may fail under Firestore rules and would expand data exposure.
+
+## Risks and rollback
+- Requires Firestore indexes/rules to support targeted array membership queries on teams. If unsupported locally, the search still falls back to existing sources unless all sources fail.
+- Rollback is one commit revert, returning to existing behavior.

--- a/docs/pr-notes/runs/1472-remediator-20260528T061102Z/code-plan.md
+++ b/docs/pr-notes/runs/1472-remediator-20260528T061102Z/code-plan.md
@@ -1,0 +1,8 @@
+# Code role notes
+
+## Implementation plan
+1. Import `collection` from the Firebase adapter in `searchService.ts`.
+2. Add `loadStreamVolunteerSearchTeams(user)` that queries `teams` by `teamPermissions.streaming.memberIds array-contains user.uid` and `streamVolunteerEmails array-contains normalized email`.
+3. Merge normalized supplemental teams through the same `canUserDiscoverTeamInAppSearch` gate.
+4. Replace the redundant ternary branch with direct `team.teamPermissions.streaming.memberIds` after the `Array.isArray` guard.
+5. Extend `app-search-service.test.js` mocks and add a regression test proving private stream-volunteer teams are loaded even when `getTeams()` omits them.

--- a/docs/pr-notes/runs/1472-remediator-20260528T061102Z/qa.md
+++ b/docs/pr-notes/runs/1472-remediator-20260528T061102Z/qa.md
@@ -1,0 +1,7 @@
+# QA role notes
+
+## Test plan
+- Unit test `loadAppSearchTeams` with `getTeams()` returning only public/default teams while supplemental Firestore queries return private selected-stream teams.
+- Assert uid and email stream-volunteer teams are included, hidden teams are excluded, and Firestore query constraints include member uid and normalized email.
+- Run targeted Vitest file first, then the repository unit suite if feasible.
+- Run app build for TypeScript/Vite validation. Android/iOS native builds are not required for this search-service-only change; iOS is skipped on Linux.

--- a/docs/pr-notes/runs/1472-remediator-20260528T061102Z/requirements.md
+++ b/docs/pr-notes/runs/1472-remediator-20260528T061102Z/requirements.md
@@ -1,0 +1,12 @@
+# Requirements role notes
+
+## Acceptance criteria
+- Selected streaming volunteers can discover private teams in app search when they match `teamPermissions.streaming.memberIds` by uid.
+- Legacy selected stream volunteers can discover private teams in app search when they match `streamVolunteerEmails` by normalized email.
+- Ineligible users and signed-out users cannot discover those private teams or their players.
+- The redundant `|| []` fallback after an `Array.isArray` guard is removed.
+- Tests cover the private-team loading path that would fail when `getTeams()` does not return private stream-volunteer teams.
+
+## Feedback classification
+- `PRRT_kwDOQe-T586FG5WQ`: actionable, code cleanup in selected-stream member id handling.
+- `PRRT_kwDOQe-T586FG655`: actionable despite informational label, because the current loader can miss private stream-volunteer teams before the access check.

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -250,6 +250,57 @@ describe('React app search service', () => {
         expect(teams.find((team) => team.id === 'team-inactive-access')).toBeUndefined();
     });
 
+    it('lets selected stream volunteers discover private teams by uid or legacy email only', async () => {
+        dbMocks.getTeams.mockResolvedValue([
+            {
+                id: 'team-stream-member',
+                name: 'Stream Member Bears',
+                sport: 'Soccer',
+                isPublic: false,
+                teamPermissions: {
+                    streaming: {
+                        mode: 'selected',
+                        memberIds: ['user-1']
+                    }
+                }
+            },
+            {
+                id: 'team-stream-email',
+                name: 'Stream Email Wolves',
+                sport: 'Basketball',
+                isPublic: false,
+                streamAccessMode: 'selected_volunteers',
+                streamVolunteerEmails: ['Parent@Example.com']
+            },
+            {
+                id: 'team-stream-hidden',
+                name: 'Stream Hidden Hawks',
+                sport: 'Baseball',
+                isPublic: false,
+                teamPermissions: {
+                    streaming: {
+                        mode: 'selected',
+                        memberIds: ['other-user']
+                    }
+                },
+                streamAccessMode: 'selected_volunteers',
+                streamVolunteerEmails: ['other@example.com']
+            }
+        ]);
+        homeMocks.loadParentHome.mockResolvedValue({ teams: [] });
+
+        const teams = await loadAppSearchTeams(auth.user);
+
+        expect(teams.map((team) => team.id)).toEqual(['team-stream-email', 'team-stream-member']);
+
+        const unrelatedUser = { ...auth.user, uid: 'unrelated-user', email: 'unrelated@example.com', parentOf: [] };
+        const unrelatedTeams = await loadAppSearchTeams(unrelatedUser);
+        expect(unrelatedTeams).toEqual([]);
+
+        const signedOutTeams = await loadAppSearchTeams(null);
+        expect(signedOutTeams).toEqual([]);
+    });
+
     it('caches loaded teams and falls back to app access when public team loading fails', async () => {
         dbMocks.getTeams.mockResolvedValue([
             { id: 'team-1', name: 'Bears', sport: 'Soccer', isPublic: true }
@@ -314,6 +365,44 @@ describe('React app search service', () => {
             teamId: 'team-1',
             playerId: 'player-1'
         }]);
+    });
+
+    it('returns players from private selected-stream teams for eligible users only', async () => {
+        const streamTeam = {
+            id: 'team-stream',
+            name: 'Stream Wolves',
+            sport: 'Basketball',
+            isPublic: false,
+            teamPermissions: {
+                streaming: {
+                    mode: 'selected',
+                    memberIds: ['user-1']
+                }
+            }
+        };
+        const visibleTeams = new Map([
+            ['team-stream', streamTeam]
+        ]);
+        firebaseMocks.getDocs.mockResolvedValue({
+            docs: [
+                firestorePlayer('teams/team-stream/players/player-1', { name: 'Pat Stream', number: '7' })
+            ]
+        });
+
+        const players = await searchAppPlayers('pat', visibleTeams, auth.user);
+        expect(players).toEqual([{
+            id: 'player:team-stream:player-1',
+            kind: 'player',
+            title: '#7 Pat Stream',
+            subtitle: 'Stream Wolves',
+            route: '/players/team-stream/player-1',
+            teamId: 'team-stream',
+            playerId: 'player-1'
+        }]);
+
+        const unrelatedUser = { ...auth.user, uid: 'unrelated-user', email: 'unrelated@example.com', parentOf: [] };
+        const unrelatedPlayers = await searchAppPlayers('pat', visibleTeams, unrelatedUser);
+        expect(unrelatedPlayers).toEqual([]);
     });
 
     it('searches player jersey numbers and encodes player routes', async () => {

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -10,6 +10,7 @@ const homeMocks = vi.hoisted(() => ({
 
 const firebaseMocks = vi.hoisted(() => ({
     db: {},
+    collection: vi.fn((db, collectionName) => ({ db, collectionName })),
     collectionGroup: vi.fn((db, collectionName) => ({ db, collectionName })),
     getDocs: vi.fn(),
     query: vi.fn((...parts) => ({ parts })),
@@ -53,6 +54,14 @@ function firestorePlayer(path, data) {
     return {
         id: path.split('/').pop(),
         ref: { path },
+        data: () => data
+    };
+}
+
+function firestoreTeam(id, data) {
+    return {
+        id,
+        ref: { path: `teams/${id}` },
         data: () => data
     };
 }
@@ -248,6 +257,43 @@ describe('React app search service', () => {
         expect(teams.find((team) => team.id === 'team-private')).toBeUndefined();
         expect(teams.find((team) => team.id === 'team-inactive')).toBeUndefined();
         expect(teams.find((team) => team.id === 'team-inactive-access')).toBeUndefined();
+    });
+
+    it('loads private selected stream-volunteer teams before checking search access', async () => {
+        dbMocks.getTeams.mockResolvedValue([
+            { id: 'team-public', name: 'Public Bears', sport: 'Soccer', isPublic: true }
+        ]);
+        homeMocks.loadParentHome.mockResolvedValue({ teams: [] });
+        firebaseMocks.getDocs
+            .mockResolvedValueOnce({
+                docs: [firestoreTeam('team-stream-member', {
+                    name: 'Stream Member Bears',
+                    sport: 'Soccer',
+                    isPublic: false,
+                    teamPermissions: {
+                        streaming: {
+                            mode: 'selected',
+                            memberIds: ['user-1']
+                        }
+                    }
+                })]
+            })
+            .mockResolvedValueOnce({
+                docs: [firestoreTeam('team-stream-email', {
+                    name: 'Stream Email Wolves',
+                    sport: 'Basketball',
+                    isPublic: false,
+                    streamAccessMode: 'selected_volunteers',
+                    streamVolunteerEmails: ['parent@example.com']
+                })]
+            });
+
+        const teams = await loadAppSearchTeams(auth.user);
+
+        expect(firebaseMocks.collection).toHaveBeenCalledWith(firebaseMocks.db, 'teams');
+        expect(firebaseMocks.where).toHaveBeenCalledWith('teamPermissions.streaming.memberIds', 'array-contains', 'user-1');
+        expect(firebaseMocks.where).toHaveBeenCalledWith('streamVolunteerEmails', 'array-contains', 'parent@example.com');
+        expect(teams.map((team) => team.id)).toEqual(['team-public', 'team-stream-email', 'team-stream-member']);
     });
 
     it('lets selected stream volunteers discover private teams by uid or legacy email only', async () => {


### PR DESCRIPTION
Closes #1471

## Summary
- Added selected streaming access checks to React app search team discoverability.
- Normalized legacy stream volunteer email fields and `teamPermissions.streaming` member fields for search visibility only.
- Kept player search gated through the same team discoverability path so private stream-volunteer players appear only for eligible users.

## Validation
- `npx vitest run tests/unit/app-search-service.test.js --reporter=verbose`
- `npm run app:build`