### PR TITLE
Fix: Simple goal-sport goals update player stats

### DIFF
--- a/docs/pr-notes/runs/1474-pr-issue-comment-4581183092-20260530T030657Z/architecture.md
+++ b/docs/pr-notes/runs/1474-pr-issue-comment-4581183092-20260530T030657Z/architecture.md
@@ -1,0 +1,15 @@
+# Architecture Role
+
+## Decisions
+- Keep the fix inside the existing static `track-live.html` orchestration path because it owns DOM input, score state, game log, stat buckets, sync scheduling, and live broadcasting.
+- Keep pure scorer resolution in `js/live-scorekeeping-goal-sports.js` and add a side-specific wrapper in the tracker.
+- Validate non-empty scorer input before score mutation. Blank scorer bypasses player stat mutation by design.
+- Roll back scorer stats inside the existing `undoData.type === 'goal'` branch using existing stat buckets and sync functions.
+
+## Blast Radius
+- Limited to goal-sport live scoring and goal undo behavior.
+- No Firestore schema, rule, index, Firebase project, or routing changes.
+- Specialized basketball, baseball, volleyball, and football flows remain untouched.
+
+## Rollback
+- Revert the tracker/test commit. Existing behavior restores but reintroduces invalid scorer attribution and inflated scorer stats after undo.

--- a/docs/pr-notes/runs/1474-pr-issue-comment-4581183092-20260530T030657Z/code-plan.md
+++ b/docs/pr-notes/runs/1474-pr-issue-comment-4581183092-20260530T030657Z/code-plan.md
@@ -1,0 +1,11 @@
+# Code Role
+
+## Implementation Plan
+- Add `resolveGoalSportScorerForSide(teamSide, scorer)` in `track-live.html`.
+- Change `applyRecordedGoalSportScorerStat` to accept an already-resolved player so validation can run before score mutation.
+- In `recordGoalSportGoal`, block non-empty unresolved scorer before `applyGoalSportScore`, score display sync, log entry, note creation, or live broadcast.
+- In goal undo, decrement attributed scorer stats from `gameState.playerStats` or `gameState.opponentStats`, update the stat cell, schedule the proper sync, and emit `broadcastReversedStatEvent`.
+- Update focused unit/string-regression tests for ordering and rollback wiring.
+
+## Conflict Resolution
+- Requirements/QA preferred stronger runtime-style tests, but the nearest existing coverage for `track-live.html` uses static string/ordering assertions. Chosen path: minimal safe patch plus focused static regression assertions, matching current test style without refactoring the large static tracker.

--- a/docs/pr-notes/runs/1474-pr-issue-comment-4581183092-20260530T030657Z/qa.md
+++ b/docs/pr-notes/runs/1474-pr-issue-comment-4581183092-20260530T030657Z/qa.md
@@ -1,0 +1,18 @@
+# QA Role
+
+## Automated Coverage
+- Assert scorer resolution appears before score mutation in `recordGoalSportGoal`.
+- Assert invalid non-empty scorer shows a prompt/focus path and returns before score mutation.
+- Assert scorer stats are rolled back in the goal undo branch, including in-memory stat update, DOM update, persistence sync, and reversed-stat broadcast.
+- Preserve helper coverage for exact name and jersey-number scorer resolution.
+
+## Manual Smoke Plan
+1. Start a goal-sport live tracker game.
+2. Enter an unknown scorer and record a goal. Expected: prompt shown, score/log/live feed/stat unchanged.
+3. Leave scorer blank and record a goal. Expected: team score increments, no player stat mutation.
+4. Enter valid home scorer by name or `#number`, record, then undo. Expected: score and player goals increment then decrement.
+5. Repeat for away/opponent scorer. Expected: away score and opponent goals increment then decrement.
+
+## Regression Guardrails
+- Score and stat values must not go negative on undo.
+- Missing DOM stat cell must not prevent in-memory and persistence sync rollback.

--- a/docs/pr-notes/runs/1474-pr-issue-comment-4581183092-20260530T030657Z/requirements.md
+++ b/docs/pr-notes/runs/1474-pr-issue-comment-4581183092-20260530T030657Z/requirements.md
@@ -1,0 +1,19 @@
+# Requirements Role
+
+## Acceptance Criteria
+- Empty scorer remains allowed and records a team-only goal.
+- Non-empty scorer must resolve to the selected side's roster or opponent player by exact normalized name or jersey number before any score, log, live event, or stat mutation occurs.
+- Valid home scorer increments the home score and the matching player `goals` stat.
+- Valid away scorer increments the away score and the matching opponent player `goals` stat.
+- Undoing a scored goal decrements the score and any attributed scorer `goals` stat without going below zero.
+- Undo emits live state sufficient for parent/fan views to stop showing stale attribution.
+
+## User Impact
+- Coach/scorekeeper gets a fast path for team goals plus guardrails against fat-fingered scorer attribution.
+- Parents/fans see live score and scorer attribution that match the game log.
+- Program/admin reporting avoids inflated player goal totals after undo.
+
+## Non-Goals
+- Fuzzy matching.
+- Post-hoc scorer edit workflows.
+- Changes outside goal-sport live tracking.

--- a/js/live-scorekeeping-goal-sports.js
+++ b/js/live-scorekeeping-goal-sports.js
@@ -6,6 +6,28 @@ function cleanText(value) {
   return String(value || '').replace(/\s+/g, ' ').trim();
 }
 
+function normalizeLookupText(value) {
+  return cleanText(value).toLowerCase();
+}
+
+function normalizeJerseyNumber(value) {
+  return cleanText(value).replace(/^#/, '').toLowerCase();
+}
+
+export function resolveGoalSportScorer(players = [], scorer = '') {
+  const cleanScorer = cleanText(scorer);
+  if (!cleanScorer) return null;
+
+  const scorerName = normalizeLookupText(cleanScorer);
+  const scorerNumber = normalizeJerseyNumber(cleanScorer);
+
+  return (players || []).find((player) => {
+    const playerName = normalizeLookupText(player?.name || player?.displayName || player?.fullName || player?.playerName);
+    const playerNumber = normalizeJerseyNumber(player?.number || player?.playerNumber || player?.jerseyNumber);
+    return (playerName && playerName === scorerName) || (playerNumber && playerNumber === scorerNumber);
+  }) || null;
+}
+
 export function applyGoalSportScore({ homeScore = 0, awayScore = 0 } = {}, teamSide = 'home') {
   const side = normalizeTeamSide(teamSide);
   return {
@@ -22,13 +44,16 @@ export function buildGoalSportEvent({
   gameClockMs = 0,
   homeScore = 0,
   awayScore = 0,
-  createdBy = null
+  createdBy = null,
+  player = null
 } = {}) {
   const side = normalizeTeamSide(teamSide);
   const cleanScorer = cleanText(scorer);
   const cleanNote = cleanText(note);
   const periodLabel = cleanText(period) || 'P1';
   const sideLabel = side === 'away' ? 'Away' : 'Home';
+  const resolvedPlayerName = cleanText(player?.name || player?.displayName || player?.fullName || player?.playerName) || cleanScorer;
+  const resolvedPlayerNumber = cleanText(player?.number || player?.playerNumber || player?.jerseyNumber);
   const scorerText = cleanScorer ? ` by ${cleanScorer}` : '';
   const noteText = cleanNote ? ` — ${cleanNote}` : '';
 
@@ -44,10 +69,11 @@ export function buildGoalSportEvent({
     awayScore: Number(awayScore) || 0,
     scorer: cleanScorer || null,
     note: cleanNote || null,
-    playerName: side === 'home' ? cleanScorer || null : null,
-    playerNumber: '',
-    opponentPlayerName: side === 'away' ? cleanScorer || null : null,
-    opponentPlayerNumber: '',
+    playerId: player?.id || null,
+    playerName: side === 'home' ? resolvedPlayerName || null : null,
+    playerNumber: side === 'home' ? resolvedPlayerNumber : '',
+    opponentPlayerName: side === 'away' ? resolvedPlayerName || null : null,
+    opponentPlayerNumber: side === 'away' ? resolvedPlayerNumber : '',
     description: `${sideLabel} goal${scorerText} (${periodLabel})${noteText}`,
     createdBy
   };

--- a/tests/unit/live-scorekeeping-goal-sports.test.js
+++ b/tests/unit/live-scorekeeping-goal-sports.test.js
@@ -52,11 +52,37 @@ describe('goal sport scorekeeping helpers', () => {
     const html = readFileSync(new URL('../../track-live.html', import.meta.url), 'utf8');
 
     expect(html).toContain('resolveGoalSportScorer');
-    expect(html).toContain('const scorerPlayer = applyRecordedGoalSportScorerStat(teamSide, scorer);');
+    expect(html).toContain('applyRecordedGoalSportScorerStat(teamSide, scorerPlayer);');
     expect(html).toContain('gameState.playerStats');
     expect(html).toContain('schedulePlayerStatsSync(scorerPlayer.id);');
     expect(html).toContain('scheduleOpponentStatsSync();');
     expect(html).toContain('player: scorerPlayer');
+  });
+
+  it('validates scorer text before mutating score state', () => {
+    const html = readFileSync(new URL('../../track-live.html', import.meta.url), 'utf8');
+
+    const validationIndex = html.indexOf('const scorerPlayer = resolveGoalSportScorerForSide(teamSide, scorer);');
+    const scoreMutationIndex = html.indexOf('const nextScore = applyGoalSportScore({ homeScore, awayScore }, teamSide);');
+
+    expect(validationIndex).toBeGreaterThan(-1);
+    expect(scoreMutationIndex).toBeGreaterThan(-1);
+    expect(validationIndex).toBeLessThan(scoreMutationIndex);
+    expect(html).toContain('if (scorer.trim() && !scorerPlayer)');
+    expect(html).toContain('leave scorer blank for a team goal');
+    expect(html).toContain('scorerInput?.focus();');
+  });
+
+  it('rolls back scorer stats when undoing a goal entry', () => {
+    const html = readFileSync(new URL('../../track-live.html', import.meta.url), 'utf8');
+
+    expect(html).toContain("if (undoData && undoData.type === 'goal')");
+    expect(html).toContain('const statKey = undoData.statKey || getGoalSportStatKey();');
+    expect(html).toContain('if (undoData.playerId)');
+    expect(html).toContain('statsBucket[undoData.playerId][statKey] = newVal;');
+    expect(html).toContain('schedulePlayerStatsSync(undoData.playerId);');
+    expect(html).toContain('broadcastReversedStatEvent({');
+    expect(html).toContain('description: `Undo stat: ${entry.text}`');
   });
 
   it('resolves scorer text to roster players by name or jersey number', () => {

--- a/tests/unit/live-scorekeeping-goal-sports.test.js
+++ b/tests/unit/live-scorekeeping-goal-sports.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
-import { applyGoalSportScore, buildGoalSportEvent } from '../../js/live-scorekeeping-goal-sports.js';
+import { readFileSync } from 'node:fs';
+import { applyGoalSportScore, buildGoalSportEvent, resolveGoalSportScorer } from '../../js/live-scorekeeping-goal-sports.js';
 
 describe('goal sport scorekeeping helpers', () => {
   it('increments the selected side by one goal', () => {
@@ -22,7 +23,8 @@ describe('goal sport scorekeeping helpers', () => {
       gameClockMs: 125000,
       homeScore: 1,
       awayScore: 2,
-      createdBy: 'user-1'
+      createdBy: 'user-1',
+      player: { id: 'opp-7', name: 'Alex Kim', number: '11' }
     });
 
     expect(event).toMatchObject({
@@ -34,12 +36,37 @@ describe('goal sport scorekeeping helpers', () => {
       period: 'H2',
       scorer: 'Alex Kim',
       note: 'Header off corner',
+      playerId: 'opp-7',
       playerName: null,
+      playerNumber: '',
       opponentPlayerName: 'Alex Kim',
+      opponentPlayerNumber: '11',
       homeScore: 1,
       awayScore: 2,
       createdBy: 'user-1'
     });
     expect(event.description).toBe('Away goal by Alex Kim (H2) — Header off corner');
+  });
+
+  it('updates scorer player stats when recording a simple goal sport goal', () => {
+    const html = readFileSync(new URL('../../track-live.html', import.meta.url), 'utf8');
+
+    expect(html).toContain('resolveGoalSportScorer');
+    expect(html).toContain('const scorerPlayer = applyRecordedGoalSportScorerStat(teamSide, scorer);');
+    expect(html).toContain('gameState.playerStats');
+    expect(html).toContain('schedulePlayerStatsSync(scorerPlayer.id);');
+    expect(html).toContain('scheduleOpponentStatsSync();');
+    expect(html).toContain('player: scorerPlayer');
+  });
+
+  it('resolves scorer text to roster players by name or jersey number', () => {
+    const players = [
+      { id: 'p1', name: 'Alex Kim', number: '8' },
+      { id: 'p2', name: 'Sam Rivera', number: '11' }
+    ];
+
+    expect(resolveGoalSportScorer(players, ' alex   kim ')?.id).toBe('p1');
+    expect(resolveGoalSportScorer(players, '#11')?.id).toBe('p2');
+    expect(resolveGoalSportScorer(players, 'Unknown')).toBeNull();
   });
 });

--- a/track-live.html
+++ b/track-live.html
@@ -675,7 +675,7 @@
         import { createFieldState, setPlayerFieldStatus, startFieldClock, pauseFieldClock, getPlayerFieldElapsedMs, getLiveLineup } from './js/live-tracker-field-status.js?v=1';
         import { summarizePersistedTrackingState, buildTrackLiveResetUpdate, resolveTrackLiveClockResume, runTrackLiveResetPersistence } from './js/track-live-state.js?v=3';
         import { getDefaultLivePeriod, getSportPeriodLabels, resolveLiveSport, isFootballSport } from './js/live-sport-config.js?v=3';
-        import { applyGoalSportScore, buildGoalSportEvent } from './js/live-scorekeeping-goal-sports.js?v=1';
+        import { applyGoalSportScore, buildGoalSportEvent, resolveGoalSportScorer } from './js/live-scorekeeping-goal-sports.js?v=2';
 
         import { applyVolleyballServeOutcome, createVolleyballUndoState, restoreVolleyballUndoState, isVolleyballSport } from './js/live-scorekeeping-volleyball.js?v=2';
 
@@ -1221,6 +1221,37 @@
             }
         }
 
+        function getGoalSportStatKey() {
+            const goalColumn = currentConfig?.columns?.find((col) => String(col || '').toLowerCase() === 'goals');
+            return goalColumn ? goalColumn.toLowerCase() : 'goals';
+        }
+
+        function applyRecordedGoalSportScorerStat(teamSide, scorer) {
+            const statKey = getGoalSportStatKey();
+            const isOpponent = teamSide === 'away';
+            const scorerPool = isOpponent ? opponentPlayers : players;
+            const scorerPlayer = resolveGoalSportScorer(scorerPool, scorer);
+            if (!scorerPlayer?.id) return null;
+
+            const statsBucket = isOpponent ? gameState.opponentStats : gameState.playerStats;
+            if (!statsBucket[scorerPlayer.id]) {
+                statsBucket[scorerPlayer.id] = {};
+            }
+            const newValue = Number(statsBucket[scorerPlayer.id][statKey] || 0) + 1;
+            statsBucket[scorerPlayer.id][statKey] = newValue;
+
+            const statEl = document.getElementById(`stat-${scorerPlayer.id}-${statKey}`);
+            if (statEl) statEl.textContent = String(newValue);
+
+            if (isOpponent) {
+                scheduleOpponentStatsSync();
+            } else {
+                schedulePlayerStatsSync(scorerPlayer.id);
+            }
+
+            return scorerPlayer;
+        }
+
         async function recordGoalSportGoal(teamSide) {
             if (!currentGoalSportProfile) return;
             if (!gameState.isRunning && gameState.elapsed === 0) {
@@ -1241,6 +1272,7 @@
             }
             updateScoreDisplay();
             scheduleScoreSync();
+            const scorerPlayer = applyRecordedGoalSportScorerStat(teamSide, scorer);
 
             const event = buildGoalSportEvent({
                 teamSide,
@@ -1250,7 +1282,8 @@
                 gameClockMs: gameState.elapsed,
                 homeScore,
                 awayScore,
-                createdBy: currentUser?.uid || null
+                createdBy: currentUser?.uid || null,
+                player: scorerPlayer
             });
             const noteTeamLabel = teamSide === 'away'
                 ? resolveOpponentDisplayName(currentGame)
@@ -1264,8 +1297,11 @@
                 value: 1,
                 scorer: event.scorer,
                 note: event.note,
+                playerId: event.playerId,
                 playerName: event.playerName,
+                playerNumber: event.playerNumber,
                 opponentPlayerName: event.opponentPlayerName,
+                opponentPlayerNumber: event.opponentPlayerNumber,
                 liveNoteId: liveNote?.id || null,
                 liveNoteText: liveNote?.text || null
             });

--- a/track-live.html
+++ b/track-live.html
@@ -1226,11 +1226,15 @@
             return goalColumn ? goalColumn.toLowerCase() : 'goals';
         }
 
-        function applyRecordedGoalSportScorerStat(teamSide, scorer) {
-            const statKey = getGoalSportStatKey();
+        function resolveGoalSportScorerForSide(teamSide, scorer) {
             const isOpponent = teamSide === 'away';
             const scorerPool = isOpponent ? opponentPlayers : players;
-            const scorerPlayer = resolveGoalSportScorer(scorerPool, scorer);
+            return resolveGoalSportScorer(scorerPool, scorer);
+        }
+
+        function applyRecordedGoalSportScorerStat(teamSide, scorerPlayer) {
+            const statKey = getGoalSportStatKey();
+            const isOpponent = teamSide === 'away';
             if (!scorerPlayer?.id) return null;
 
             const statsBucket = isOpponent ? gameState.opponentStats : gameState.playerStats;
@@ -1263,6 +1267,13 @@
             const noteInput = document.getElementById('goal-note-input');
             const scorer = scorerInput?.value || '';
             const note = noteInput?.value || '';
+            const scorerPlayer = resolveGoalSportScorerForSide(teamSide, scorer);
+            if (scorer.trim() && !scorerPlayer) {
+                alert('Enter an exact roster/opponent player name or jersey number, or leave scorer blank for a team goal.');
+                scorerInput?.focus();
+                return;
+            }
+
             const nextScore = applyGoalSportScore({ homeScore, awayScore }, teamSide);
             homeScore = nextScore.homeScore;
             awayScore = nextScore.awayScore;
@@ -1272,7 +1283,7 @@
             }
             updateScoreDisplay();
             scheduleScoreSync();
-            const scorerPlayer = applyRecordedGoalSportScorerStat(teamSide, scorer);
+            applyRecordedGoalSportScorerStat(teamSide, scorerPlayer);
 
             const event = buildGoalSportEvent({
                 teamSide,
@@ -2881,6 +2892,7 @@
             if (undoData && undoData.type === 'goal') {
                 removeLiveNoteRecord(undoData.liveNoteId, undoData.liveNoteText);
                 const goalValue = Number(undoData.value) || 1;
+                const statKey = undoData.statKey || getGoalSportStatKey();
                 if (undoData.teamSide === 'away') {
                     awayScore = Math.max(0, awayScore - goalValue);
                 } else {
@@ -2892,6 +2904,34 @@
                 }
                 updateScoreDisplay();
                 scheduleScoreSync();
+                if (undoData.playerId) {
+                    const isOpponent = !!undoData.isOpponent;
+                    const statsBucket = isOpponent ? gameState.opponentStats : gameState.playerStats;
+                    if (!statsBucket[undoData.playerId]) statsBucket[undoData.playerId] = {};
+                    const currentVal = Number(statsBucket[undoData.playerId][statKey] || 0);
+                    const newVal = Math.max(0, currentVal - goalValue);
+                    const appliedDelta = currentVal - newVal;
+                    statsBucket[undoData.playerId][statKey] = newVal;
+
+                    const statEl = document.getElementById(`stat-${undoData.playerId}-${statKey}`);
+                    if (statEl) statEl.textContent = `${newVal}`;
+
+                    if (isOpponent) {
+                        scheduleOpponentStatsSync();
+                    } else {
+                        schedulePlayerStatsSync(undoData.playerId);
+                    }
+
+                    if (appliedDelta > 0) {
+                        broadcastReversedStatEvent({
+                            playerId: undoData.playerId,
+                            statKey,
+                            value: -appliedDelta,
+                            isOpponent,
+                            description: `Undo stat: ${entry.text}`
+                        });
+                    }
+                }
                 scheduleLiveHasData();
                 broadcastLiveEvent(currentTeamId, currentGameId, {
                     type: 'undo',


### PR DESCRIPTION
Closes #1473

This PR addresses a bug where simple goal-sport goals (e.g., soccer, hockey, lacrosse) were not correctly updating player goal statistics in `gameState.playerStats` or persisting them to final reports.

**Changes made:**
- Introduced `resolveGoalSportScorer` helper to `js/live-scorekeeping-goal-sports.js` to link scorer text (name or jersey number) to a player ID.
- Modified `buildGoalSportEvent` to include `playerId`, `playerName`, and `playerNumber` from the resolved scorer.
- Added `applyRecordedGoalSportScorerStat` function in `track-live.html` to update `gameState.playerStats` or `gameState.opponentStats` and schedule the appropriate sync (`schedulePlayerStatsSync` or `scheduleOpponentStatsSync`).
- Integrated these changes into `recordGoalSportGoal` in `track-live.html` to ensure player stats are incremented and persisted.
- Updated the cache-bust version for `live-scorekeeping-goal-sports.js` to `v=2` in `track-live.html`.

**Verification:**
- Unit tests in `tests/unit/live-scorekeeping-goal-sports.test.js` now include assertions for scorer resolution and stat updates within the `track-live.html` context.
- All unit tests in `live-scorekeeping-goal-sports.test.js` passed successfully.