### PR TITLE
FEAT: Implement Delete Individual Media Item in React Team Media

### DIFF
--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -17,7 +17,8 @@ import {
   revokeFamilyShareToken,
   updateFamilyShareTokenCalendars,
   uploadTeamMediaFile,
-  uploadTeamMediaPhoto
+  uploadTeamMediaPhoto,
+  deleteTeamMediaItem
 } from '../../../../js/db.js';
 import { addPendingFamilyMember, readFamilyMembers } from '../../../../js/family-plan.js';
 import { db, doc, collection, serverTimestamp, runTransaction } from '../../../../js/firebase.js';
@@ -207,6 +208,11 @@ export type TeamMediaModel = {
   canContribute: boolean;
   folders: TeamMediaFolder[];
 };
+
+export async function deleteTeamMediaItemForApp(teamId: string, item: TeamMediaItem) {
+  if (!teamId || !item?.id) throw new Error('Missing team or media item ID.');
+  await deleteTeamMediaItem(teamId, item);
+}
 
 export function getLegacyUrl(path: string, params: Record<string, string> = {}, hashParams: Record<string, string> = {}) {
   const url = new URL(path, legacyOrigin);

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -46,6 +46,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const [loading, setLoading] = useState(true);
   const [uploading, setUploading] = useState('');
   const [creatingAlbum, setCreatingAlbum] = useState(false);
+  const [deletingItemId, setDeletingItemId] = useState('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
 
@@ -75,17 +76,17 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
       return;
     }
 
-    setLoading(true); // Indicate loading while deleting
+    setDeletingItemId(item.id);
     setError('');
     setMessage('');
     try {
       await deleteTeamMediaItemForApp(teamId, item);
       setMessage('Media item deleted.');
-      await refresh({ showLoading: false }); // Refresh to remove the item from UI
+      await refresh({ showLoading: false });
     } catch (deleteError: any) {
       setError(deleteError?.message || 'Unable to delete media item.');
     } finally {
-      setLoading(false);
+      setDeletingItemId('');
     }
   };
 
@@ -339,7 +340,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
         </div>
         <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {filteredItems.length ? filteredItems.map((item) => (
-            <TeamMediaItemCard key={item.id} item={item} onStatus={(tone, msg) => tone === 'error' ? setError(msg) : setMessage(msg)} canManage={model.canManage} onDeleteItem={handleDeleteItem} />
+            <TeamMediaItemCard key={item.id} item={item} onStatus={(tone, msg) => tone === 'error' ? setError(msg) : setMessage(msg)} canManage={model.canManage} currentUserId={auth.user?.uid || ''} deleting={deletingItemId === item.id} onDeleteItem={handleDeleteItem} />
           )) : (
             <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">No {emptyStateLabel} in this album.</div>
           )}
@@ -391,16 +392,21 @@ function TeamMediaItemCard({
   item,
   onStatus,
   canManage,
+  currentUserId,
+  deleting,
   onDeleteItem
 }: {
   item: TeamMediaItem;
   onStatus: (tone: 'error' | 'success', message: string) => void;
   canManage: boolean;
+  currentUserId: string;
+  deleting: boolean;
   onDeleteItem: (item: TeamMediaItem) => void;
 }) {
   const Icon = getItemIcon(item);
   const isPhoto = item.type === 'photo';
   const title = item.title || 'Team media';
+  const canDelete = canManage || (['photo', 'file'].includes(String(item.type || '').toLowerCase()) && item.uploadedBy === currentUserId);
 
   const copyLink = async () => {
     try {
@@ -466,10 +472,10 @@ function TeamMediaItemCard({
             <Copy className="h-3.5 w-3.5" aria-hidden="true" />
             Copy
           </button>
-          {canManage && (
-            <button type="button" className="ghost-button !h-8 !min-h-8 !px-2 !text-xs text-rose-700 hover:bg-rose-50" onClick={() => onDeleteItem(item)} aria-label={`Delete ${title}`}>
-              <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
-              Delete
+          {canDelete && (
+            <button type="button" className="ghost-button !h-8 !min-h-8 !px-2 !text-xs text-rose-700 hover:bg-rose-50 disabled:opacity-60" onClick={() => onDeleteItem(item)} disabled={deleting} aria-label={`Delete ${title}`}>
+              {deleting ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" /> : <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />}
+              {deleting ? 'Deleting' : 'Delete'}
             </button>
           )}
         </div>

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -14,6 +14,7 @@ import {
   Plus,
   RefreshCw,
   Share2,
+  Trash2,
   Upload,
   Video
 } from 'lucide-react';
@@ -24,6 +25,7 @@ import {
   loadTeamMediaForApp,
   uploadParentTeamMediaFile,
   uploadParentTeamMediaPhoto,
+  deleteTeamMediaItemForApp,
   type TeamMediaFolder,
   type TeamMediaItem,
   type TeamMediaModel
@@ -64,6 +66,26 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
       if (showLoading) setModel(null);
     } finally {
       if (showLoading) setLoading(false);
+    }
+  };
+
+  const handleDeleteItem = async (item: TeamMediaItem) => {
+    if (!teamId || !item?.id) return;
+    if (!window.confirm(`Are you sure you want to delete ${item.title || 'this media item'}? This cannot be undone.`)) {
+      return;
+    }
+
+    setLoading(true); // Indicate loading while deleting
+    setError('');
+    setMessage('');
+    try {
+      await deleteTeamMediaItemForApp(teamId, item);
+      setMessage('Media item deleted.');
+      await refresh({ showLoading: false }); // Refresh to remove the item from UI
+    } catch (deleteError: any) {
+      setError(deleteError?.message || 'Unable to delete media item.');
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -317,14 +339,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
         </div>
         <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {filteredItems.length ? filteredItems.map((item) => (
-            <MediaItemCard
-              key={item.id}
-              item={item}
-              onStatus={(tone, statusMessage) => {
-                setError(tone === 'error' ? statusMessage : '');
-                setMessage(tone === 'success' ? statusMessage : '');
-              }}
-            />
+            <TeamMediaItemCard key={item.id} item={item} onStatus={(tone, msg) => tone === 'error' ? setError(msg) : setMessage(msg)} canManage={model.canManage} onDeleteItem={handleDeleteItem} />
           )) : (
             <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">No {emptyStateLabel} in this album.</div>
           )}
@@ -372,7 +387,17 @@ function getMediaTypeCounts(items: TeamMediaItem[]) {
   };
 }
 
-function MediaItemCard({ item, onStatus }: { item: TeamMediaItem; onStatus: (tone: 'error' | 'success', message: string) => void }) {
+function TeamMediaItemCard({
+  item,
+  onStatus,
+  canManage,
+  onDeleteItem
+}: {
+  item: TeamMediaItem;
+  onStatus: (tone: 'error' | 'success', message: string) => void;
+  canManage: boolean;
+  onDeleteItem: (item: TeamMediaItem) => void;
+}) {
   const Icon = getItemIcon(item);
   const isPhoto = item.type === 'photo';
   const title = item.title || 'Team media';
@@ -441,6 +466,12 @@ function MediaItemCard({ item, onStatus }: { item: TeamMediaItem; onStatus: (ton
             <Copy className="h-3.5 w-3.5" aria-hidden="true" />
             Copy
           </button>
+          {canManage && (
+            <button type="button" className="ghost-button !h-8 !min-h-8 !px-2 !text-xs text-rose-700 hover:bg-rose-50" onClick={() => onDeleteItem(item)} aria-label={`Delete ${title}`}>
+              <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+              Delete
+            </button>
+          )}
         </div>
       </div>
     </article>

--- a/docs/pr-notes/runs/1477-remediator-20260528T051706Z/architecture.md
+++ b/docs/pr-notes/runs/1477-remediator-20260528T051706Z/architecture.md
@@ -1,0 +1,10 @@
+# Architecture role notes
+
+## Architecture decisions
+- Keep the change local to `TeamMedia.tsx`; no service contract change is required because `TeamMediaItem` already preserves `uploadedBy` via object spread.
+- Add a page-level `deletingItemId` state instead of reusing global `loading` so delete refreshes can be non-blocking.
+- Compute per-item delete visibility in the card from `canManage`, `currentUserId`, item `type`, and `uploadedBy`, mirroring the legacy `canDeleteTeamMediaItem` owner rule for photos/files.
+
+## Risks and rollback
+- Risk: duplicating the permission predicate can drift from `team-media-utils.js`. This is acceptable for a scoped PR remediation, but future cleanup should expose a shared app-safe helper if more React media permissions are added.
+- Rollback: revert this commit; the prior page-wide delete behavior and manager-only delete visibility return.

--- a/docs/pr-notes/runs/1477-remediator-20260528T051706Z/code-plan.md
+++ b/docs/pr-notes/runs/1477-remediator-20260528T051706Z/code-plan.md
@@ -1,0 +1,8 @@
+# Code role notes
+
+## Implementation plan
+- In `TeamMedia.tsx`, replace delete-time `setLoading(true/false)` with `deletingItemId` state.
+- Pass `currentUserId` and per-card `deleting` to `TeamMediaItemCard`.
+- In `TeamMediaItemCard`, render delete when `canManage` is true or when the current user owns a photo/file item.
+- Disable only the matching delete button and show an inline spinner/text while that item is deleting.
+- In `tests/smoke/app-parent-tools.spec.js`, add `uploadedBy` to the mocked photo, capture delete calls, and assert owner delete plus non-blocking UI.

--- a/docs/pr-notes/runs/1477-remediator-20260528T051706Z/qa.md
+++ b/docs/pr-notes/runs/1477-remediator-20260528T051706Z/qa.md
@@ -1,0 +1,11 @@
+# QA role notes
+
+## QA plan
+- Extend the existing Playwright parent tools media flow because it already mounts the React route with mocked parent permissions.
+- Mock an uploaded photo with `uploadedBy: 'user-1'` and `canManage: false` to prove a contributor owner sees the delete control.
+- Click the owner delete control, accept confirmation, assert the delete service receives the team/item pair.
+- While the mocked delete promise is in flight, assert the album button remains enabled to catch regressions where global page `loading` disables/replaces the full UI.
+
+## Validation commands
+- `npm --prefix apps/app run build`
+- `npx playwright test tests/smoke/app-parent-tools.spec.js --config=playwright.smoke.config.js --reporter=line`

--- a/docs/pr-notes/runs/1477-remediator-20260528T051706Z/requirements.md
+++ b/docs/pr-notes/runs/1477-remediator-20260528T051706Z/requirements.md
@@ -1,0 +1,11 @@
+# Requirements role notes
+
+## Acceptance criteria
+- Non-manager contributors who uploaded a team media photo or file can see and use the delete control for their own item.
+- Delete visibility stays aligned with the existing permission model: managers can delete, upload owners can delete photos/files, unrelated contributors cannot.
+- Deleting one media item must not replace the whole Team Media page with the global loading state.
+- While delete is in progress, only the target item delete action needs disabled/loading feedback; navigation, album controls, filters, and other actions remain available.
+
+## Feedback classification
+- PRRT_kwDOQe-T586FJOnF is actionable: owner delete control is missing in the React media page.
+- PRRT_kwDOQe-T586FJNsu is informational but valid: global loading during delete creates avoidable page-wide blocking, so remediate with granular delete state.

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -18,6 +18,7 @@ async function mockParentToolsModules(page) {
         window.__familyCreates = [];
         window.__mediaUploads = [];
         window.__mediaLinks = [];
+        window.__mediaDeletes = [];
         Object.defineProperty(navigator, 'clipboard', {
             configurable: true,
             value: {
@@ -223,7 +224,7 @@ async function mockParentToolsModules(page) {
                             name: 'Game photos',
                             visibility: 'team',
                             itemCount: 1,
-                            items: [{ id: 'photo-1', title: 'Tipoff', type: 'photo', url: 'https://img.example.test/tipoff.jpg' }]
+                            items: [{ id: 'photo-1', title: 'Tipoff', type: 'photo', uploadedBy: 'user-1', url: 'https://img.example.test/tipoff.jpg' }]
                         }]
                     };
                 }
@@ -242,7 +243,9 @@ async function mockParentToolsModules(page) {
                     window.__mediaLinks.push({ teamId, folderId, title, url });
                     return 'link-1';
                 }
-                export async function deleteTeamMediaItemForApp() {
+                export async function deleteTeamMediaItemForApp(teamId, item) {
+                    window.__mediaDeletes.push({ teamId, itemId: item.id });
+                    await new Promise((resolve) => setTimeout(resolve, 50));
                     return undefined;
                 }
             `
@@ -320,7 +323,12 @@ test('team media route supports photo upload, file upload, link add, and media o
     await page.getByRole('button', { name: /Add link/ }).click();
     await expect.poll(() => page.evaluate(() => window.__mediaLinks.at(-1))).toEqual({ teamId: 'team-1', folderId: 'folder-1', title: 'Replay', url: 'https://video.example.test/replay' });
 
-    await page.getByRole('button', { name: /Tipoff/ }).click();
+    await page.getByRole('button', { name: 'Open Tipoff' }).click();
     await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://img.example.test/tipoff.jpg');
+
+    page.once('dialog', (dialog) => dialog.accept());
+    await page.getByRole('button', { name: /Delete Tipoff/ }).click();
+    await expect(page.getByRole('button', { name: /Game photos/ })).toBeEnabled();
+    await expect.poll(() => page.evaluate(() => window.__mediaDeletes.at(-1))).toEqual({ teamId: 'team-1', itemId: 'photo-1' });
     await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
 });

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -238,6 +238,9 @@ async function mockParentToolsModules(page) {
                     window.__mediaLinks.push({ teamId, folderId, title, url });
                     return 'link-1';
                 }
+                export async function deleteTeamMediaItemForApp() {
+                    return undefined;
+                }
             `
         });
     });

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -30,6 +30,7 @@ const dbMocks = vi.hoisted(() => ({
     updateFamilyShareTokenCalendars: vi.fn(),
     uploadTeamMediaFile: vi.fn(),
     uploadTeamMediaPhoto: vi.fn(),
+    deleteTeamMediaItem: vi.fn(),
     createRegistrationCheckoutSession: vi.fn()
 }));
 
@@ -161,6 +162,7 @@ import {
     updateParentFamilyShareCalendars,
     uploadParentTeamMediaFile,
     uploadParentTeamMediaPhoto,
+    deleteTeamMediaItemForApp,
     initiateRegistrationCheckout,
     initiateParentTeamFeeCheckout,
     canInitiateParentTeamFeeCheckout,
@@ -757,5 +759,33 @@ describe('React app parent tools service', () => {
         stripeMocks.initiateTeamFeeCheckout.mockResolvedValueOnce('');
         await expect(initiateParentTeamFeeCheckout('team-1', 'batch-1', 'recipient-1'))
             .rejects.toThrow('Failed to get checkout URL.');
+    });
+
+    describe('deleteTeamMediaItemForApp', () => {
+        it('correctly calls deleteTeamMediaItem with teamId and item', async () => {
+            const teamId = 'test-team';
+            const item = { id: 'media-item-1', title: 'Test Photo', type: 'photo', storagePath: 'photos/test.jpg' };
+            dbMocks.deleteTeamMediaItem.mockResolvedValueOnce(true);
+
+            await expect(deleteTeamMediaItemForApp(teamId, item)).resolves.toBeUndefined();
+            expect(dbMocks.deleteTeamMediaItem).toHaveBeenCalledWith(teamId, item);
+        });
+
+        it('throws an error if teamId or itemId are missing', async () => {
+            const item = { id: 'media-item-1', title: 'Test Photo', type: 'photo', storagePath: 'photos/test.jpg' };
+            await expect(deleteTeamMediaItemForApp('', item)).rejects.toThrow('Missing team or media item ID.');
+            await expect(deleteTeamMediaItemForApp('team-id', { id: '', title: 'Test Photo', type: 'photo' })).rejects.toThrow('Missing team or media item ID.');
+            expect(dbMocks.deleteTeamMediaItem).not.toHaveBeenCalled();
+        });
+
+        it('propagates errors from deleteTeamMediaItem', async () => {
+            const teamId = 'test-team';
+            const item = { id: 'media-item-1', title: 'Test Photo', type: 'photo', storagePath: 'photos/test.jpg' };
+            const mockError = new Error('Firestore delete failed');
+            dbMocks.deleteTeamMediaItem.mockRejectedValueOnce(mockError);
+
+            await expect(deleteTeamMediaItemForApp(teamId, item)).rejects.toThrow('Firestore delete failed');
+            expect(dbMocks.deleteTeamMediaItem).toHaveBeenCalledWith(teamId, item);
+        });
     });
 });


### PR DESCRIPTION
Closes #1476

This PR implements the ability to delete individual media items (photos, files, links) from a team media album within the React web app.

Changes include:
- Added `deleteTeamMediaItemForApp` function to `apps/app/src/lib/parentToolsService.ts` to expose backend deletion logic.
- Modified `apps/app/src/pages/TeamMedia.tsx` to include a "Delete" button on each media item card, visible only to authorized users.
- Implemented a confirmation dialog before deletion and state updates to remove the item from the UI.
- Added unit tests in `tests/unit/app-parent-tools-service.test.js` to verify the new deletion logic and error handling.