### PR TITLE
Fix team media video link filtering

### DIFF
--- a/js/team-media.js
+++ b/js/team-media.js
@@ -127,7 +127,7 @@ const MEDIA_TYPE_FILTERS = [
 ];
 
 function isVideoMediaItem(item = {}) {
-    return String(item.type || '').toLowerCase() === 'video_link';
+    return String(item.type || '').toLowerCase().replace(/-/g, '_') === 'video_link';
 }
 
 function matchesMediaTypeFilter(item, filterId = 'all') {

--- a/tests/unit/team-media-item-rename.test.js
+++ b/tests/unit/team-media-item-rename.test.js
@@ -221,6 +221,24 @@ describe('team media item renaming', () => {
         expect(editContainerEl.classList.contains('hidden')).toBe(true);
     });
 
+    it('shows saved video-link items under the Videos filter', async () => {
+        mocks.getTeamMediaItems.mockResolvedValue([
+            { id: 'video1', folderId: 'folderA', title: 'Game Clip', type: 'video-link', url: 'https://youtu.be/abc123', uploadedBy: 'user123' }
+        ]);
+
+        const module = await loadModule();
+        await module.loadLibrary();
+
+        const albumDetail = document.getElementById('album-detail');
+        const videosFilter = albumDetail.querySelector('[data-media-type-filter="videos"]');
+        expect(videosFilter?.textContent).toContain('Videos 1');
+
+        videosFilter.click();
+
+        expect(albumDetail.innerHTML).toContain('Game Clip');
+        expect(albumDetail.textContent).not.toContain('No videos in this album.');
+    });
+
     it('ignores duplicate save attempts while a rename is in flight', async () => {
         let resolveRename;
         mocks.updateTeamMediaItem.mockImplementationOnce(() => new Promise((resolve) => {


### PR DESCRIPTION
Closes #1480

- Normalize team media item types before applying the Videos filter so saved `video-link` items are treated as videos.
- Added regression coverage proving saved video links appear and count under the Videos tab instead of showing the empty state.

Validation:
- `npx vitest run tests/unit/team-media-item-rename.test.js --reporter=verbose`