### PR TITLE
Publish organization draft schedule slots

### DIFF
--- a/docs/pr-notes/runs/1484-pr-issue-comment-4581157363-20260530T013844Z/architecture.md
+++ b/docs/pr-notes/runs/1484-pr-issue-comment-4581157363-20260530T013844Z/architecture.md
@@ -1,0 +1,22 @@
+# Architecture
+
+## Current State
+`publishOrganizationScheduleDraft` is a Firebase callable that uses the Admin SDK to write paired game documents under both home and away teams. Because Admin SDK bypasses Firestore rules, this callable is the authorization boundary.
+
+## Decision
+Keep the callable as the bulk publish write path, but enforce authorization in this order:
+1. Require authenticated callable context.
+2. Validate organization ID, schedule ID, draft slots, and slot limit.
+3. Fetch caller user and organization team.
+4. Require organization admin access with `hasTeamAdminAccess`.
+5. Fetch all unique home and away teams.
+6. Require every referenced team to exist and remain in the organization owner boundary.
+7. Require `hasTeamAdminAccess` for every unique referenced team.
+8. Only then create timestamp, batch, refs, and writes.
+
+## Blast Radius
+- Without this gate: an organization admin could write games into teams they do not administer if team IDs are supplied.
+- With this gate: writes are constrained to teams where the caller is owner, admin email match, or global admin.
+
+## Rollback
+Revert the single commit. Existing organization boundary checks remain adjacent, so rollback scope is limited to the additional per-team authorization guard and source regression assertions.

--- a/docs/pr-notes/runs/1484-pr-issue-comment-4581157363-20260530T013844Z/code-plan.md
+++ b/docs/pr-notes/runs/1484-pr-issue-comment-4581157363-20260530T013844Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code Plan
+
+## Patch
+- Add a per-team `hasTeamAdminAccess` gate in `functions/index.js` inside `publishOrganizationScheduleDraft`.
+- Place it after team existence and organization-boundary validation, before `admin.firestore.Timestamp.now()`, `firestore.batch()`, and all `batch.set` calls.
+- Throw `permission-denied` with a clear team-admin message.
+- Update `tests/unit/organization-schedule.test.js` to assert the guard, message, and ordering before batch creation.
+
+## Files
+- `functions/index.js`
+- `tests/unit/organization-schedule.test.js`
+- `docs/pr-notes/runs/1484-pr-issue-comment-4581157363-20260530T013844Z/*`

--- a/docs/pr-notes/runs/1484-pr-issue-comment-4581157363-20260530T013844Z/qa.md
+++ b/docs/pr-notes/runs/1484-pr-issue-comment-4581157363-20260530T013844Z/qa.md
@@ -1,0 +1,21 @@
+# QA Plan
+
+## Risk Guardrails
+- Unauthorized teams must block all writes before `firestore.batch()` is created.
+- The guard must check every unique home and away team.
+- Global admin behavior must continue to pass through `hasTeamAdminAccess`.
+- Existing invalid draft, missing team, same-team, and organization-boundary errors must remain intact.
+
+## Automated Validation
+Run:
+```bash
+npx vitest run tests/unit/organization-schedule.test.js --reporter=verbose
+node --check functions/index.js
+git diff --check
+```
+
+## Manual Regression Targets
+1. Authorized org admin who is also team admin for all participating teams publishes successfully.
+2. Org admin missing admin access on any home/away team gets `permission-denied` and zero created games.
+3. Global admin can still publish valid drafts.
+4. Publish with no generated draft slots remains blocked in the UI before callable invocation.

--- a/docs/pr-notes/runs/1484-pr-issue-comment-4581157363-20260530T013844Z/requirements.md
+++ b/docs/pr-notes/runs/1484-pr-issue-comment-4581157363-20260530T013844Z/requirements.md
@@ -1,0 +1,23 @@
+# Requirements
+
+## Problem
+Organization draft schedule publishing must not create games for teams unless the publisher has admin access to every home and away team included in the draft. This protects teams from unauthorized schedule changes while preserving fast publishing for legitimate organization schedulers.
+
+## Acceptance Criteria
+1. Authenticated organization admins can publish valid draft slots only when they also pass team admin access for every participating home and away team.
+2. If access is missing for any participating team, the callable returns `permission-denied` before any schedule game writes are prepared.
+3. The UI must not report success when authorization fails.
+4. Existing no-draft blocking remains: “Generate at least one draft slot before publishing.”
+5. Successful publishes preserve opponent, venue, date, home/away status, notes, shared schedule linkage, and audit fields for coaches and parents.
+6. Global admins remain authorized through the existing `hasTeamAdminAccess` behavior.
+
+## Non-Goals
+- Redesign role models or delegated league scheduler permissions.
+- Add a pre-publish permission audit screen.
+- Change draft generation, venues, blackout logic, CSV import, or notification behavior.
+
+## Edge Cases
+- A large draft with one unauthorized team fails fully, with no partial publish state.
+- Team admin for home teams but not away teams fails.
+- Deleted or inaccessible referenced teams fail cleanly.
+- Duplicate team IDs are checked once via the unique team ID set.

--- a/functions/index.js
+++ b/functions/index.js
@@ -313,6 +313,167 @@ function hasTeamAdminAccess({ team, user = {}, uid, email }) {
   return Boolean(uid && team?.ownerId === uid) || Boolean(normalizedEmail && adminEmails.includes(normalizedEmail));
 }
 
+function normalizeOrganizationDraftSlot(slot = {}) {
+  const homeTeamId = String(slot.homeTeamId || '').trim();
+  const awayTeamId = String(slot.awayTeamId || '').trim();
+  const startsAt = new Date(slot.startsAt);
+  if (!homeTeamId || !awayTeamId || homeTeamId === awayTeamId) {
+    throw new functions.https.HttpsError('invalid-argument', 'Each draft slot must include different home and away teams.');
+  }
+  if (Number.isNaN(startsAt.getTime())) {
+    throw new functions.https.HttpsError('invalid-argument', 'Each draft slot must include a valid start date.');
+  }
+  return {
+    homeTeamId,
+    awayTeamId,
+    startsAt,
+    venueName: String(slot.venueName || '').trim(),
+    notes: String(slot.notes || '').trim() || null
+  };
+}
+
+function buildOrganizationDraftGamePayload({
+  homeTeamId,
+  awayTeamId,
+  homeTeam,
+  awayTeam,
+  sourceGameId,
+  counterpartGameId,
+  startsAt,
+  venueName,
+  notes,
+  scheduleId,
+  organizationId,
+  uid,
+  now,
+  isMirror = false
+}) {
+  const sharedScheduleId = `shared_${homeTeamId}_${sourceGameId}`;
+  const opponentTeam = isMirror ? homeTeam : awayTeam;
+  return {
+    type: 'game',
+    status: 'scheduled',
+    date: admin.firestore.Timestamp.fromDate(startsAt),
+    opponent: opponentTeam.name || 'Opponent',
+    opponentTeamId: isMirror ? homeTeamId : awayTeamId,
+    opponentTeamName: opponentTeam.name || null,
+    opponentTeamPhoto: opponentTeam.photoUrl || null,
+    location: venueName,
+    arrivalTime: null,
+    notes,
+    isHome: !isMirror,
+    homeScore: 0,
+    awayScore: 0,
+    createdAt: now,
+    createdVia: 'organizationScheduleDraftPublish',
+    organizationScheduleDraft: {
+      organizationId,
+      scheduleId,
+      publishedBy: uid,
+      publishedAt: now
+    },
+    sharedScheduleId,
+    sharedScheduleSourceTeamId: homeTeamId,
+    sharedScheduleOpponentTeamId: isMirror ? homeTeamId : awayTeamId,
+    sharedScheduleOpponentGameId: isMirror ? sourceGameId : counterpartGameId
+  };
+}
+
+exports.publishOrganizationScheduleDraft = functions.https.onCall(async (data, context) => {
+  if (!context.auth) {
+    throw new functions.https.HttpsError('unauthenticated', 'The function must be called while authenticated.');
+  }
+
+  const organizationId = String(data?.organizationId || '').trim();
+  const scheduleId = String(data?.scheduleId || '').trim();
+  const draftSlots = Array.isArray(data?.draftSlots) ? data.draftSlots.map(normalizeOrganizationDraftSlot) : [];
+  if (!organizationId || !scheduleId) {
+    throw new functions.https.HttpsError('invalid-argument', 'organizationId and scheduleId are required.');
+  }
+  if (draftSlots.length === 0) {
+    throw new functions.https.HttpsError('invalid-argument', 'At least one draft slot is required to publish.');
+  }
+  if (draftSlots.length > 200) {
+    throw new functions.https.HttpsError('invalid-argument', 'Draft publishing is limited to 200 slots at a time.');
+  }
+
+  const uid = context.auth.uid;
+  const callerEmail = String(context.auth.token?.email || '').trim().toLowerCase();
+  const [userSnap, organizationSnap] = await Promise.all([
+    firestore.doc(`users/${uid}`).get(),
+    firestore.doc(`teams/${organizationId}`).get()
+  ]);
+  if (!organizationSnap.exists) {
+    throw new functions.https.HttpsError('not-found', 'Organization team was not found.');
+  }
+
+  const user = userSnap.exists ? userSnap.data() || {} : {};
+  const organizationTeam = organizationSnap.data() || {};
+  if (!hasTeamAdminAccess({ team: organizationTeam, user, uid, email: callerEmail })) {
+    throw new functions.https.HttpsError('permission-denied', 'Only organization admins can publish draft schedules.');
+  }
+
+  const teamIds = Array.from(new Set(draftSlots.flatMap((slot) => [slot.homeTeamId, slot.awayTeamId])));
+  const teamSnaps = await Promise.all(teamIds.map((teamId) => firestore.doc(`teams/${teamId}`).get()));
+  const teamsById = new Map(teamSnaps
+    .filter((snap) => snap.exists)
+    .map((snap) => [snap.id, snap.data() || {}]));
+  if (teamsById.size !== teamIds.length) {
+    throw new functions.https.HttpsError('invalid-argument', 'Every draft slot team must exist.');
+  }
+
+  const organizationOwnerId = String(organizationTeam.ownerId || '').trim();
+  if (organizationOwnerId) {
+    const outsideOrganization = teamIds.find((teamId) => String(teamsById.get(teamId)?.ownerId || '').trim() !== organizationOwnerId);
+    if (outsideOrganization) {
+      throw new functions.https.HttpsError('permission-denied', 'Draft slots can only include teams in the current organization.');
+    }
+  }
+
+  const now = admin.firestore.Timestamp.now();
+  const batch = firestore.batch();
+  draftSlots.forEach((slot) => {
+    const sourceRef = firestore.collection(`teams/${slot.homeTeamId}/games`).doc();
+    const mirrorRef = firestore.collection(`teams/${slot.awayTeamId}/games`).doc();
+    const homeTeam = teamsById.get(slot.homeTeamId);
+    const awayTeam = teamsById.get(slot.awayTeamId);
+
+    batch.set(sourceRef, buildOrganizationDraftGamePayload({
+      ...slot,
+      homeTeam,
+      awayTeam,
+      sourceGameId: sourceRef.id,
+      counterpartGameId: mirrorRef.id,
+      scheduleId,
+      organizationId,
+      uid,
+      now
+    }));
+    batch.set(mirrorRef, buildOrganizationDraftGamePayload({
+      ...slot,
+      homeTeam,
+      awayTeam,
+      sourceGameId: sourceRef.id,
+      counterpartGameId: mirrorRef.id,
+      scheduleId,
+      organizationId,
+      uid,
+      now,
+      isMirror: true
+    }));
+  });
+
+  await batch.commit();
+  functions.logger.info('Published organization schedule draft', {
+    uid,
+    organizationId,
+    scheduleId,
+    publishedCount: draftSlots.length,
+    teamCount: teamIds.length
+  });
+  return { status: 'success', publishedCount: draftSlots.length, message: 'Draft slots published to team schedules.' };
+});
+
 function normalizeParentInviteEmail(value) {
   return String(value || '').trim().toLowerCase();
 }

--- a/functions/index.js
+++ b/functions/index.js
@@ -430,6 +430,16 @@ exports.publishOrganizationScheduleDraft = functions.https.onCall(async (data, c
     }
   }
 
+  const inaccessibleTeamId = teamIds.find((teamId) => !hasTeamAdminAccess({
+    team: teamsById.get(teamId),
+    user,
+    uid,
+    email: callerEmail
+  }));
+  if (inaccessibleTeamId) {
+    throw new functions.https.HttpsError('permission-denied', 'Only team admins can publish draft slots to every selected team.');
+  }
+
   const now = admin.firestore.Timestamp.now();
   const batch = firestore.batch();
   draftSlots.forEach((slot) => {

--- a/organization-schedule.html
+++ b/organization-schedule.html
@@ -1297,6 +1297,10 @@
                 setAlert('Organization context missing. Cannot publish schedule.');
                 return;
             }
+            if (!Array.isArray(draftGeneratorState.draftSlots) || draftGeneratorState.draftSlots.length === 0) {
+                setAlert('Generate at least one draft slot before publishing.');
+                return;
+            }
 
             try {
                 setButtonBusy(publishDraftScheduleBtn, 'Publishing…', true);
@@ -1304,13 +1308,14 @@
                 const publishCallable = httpsCallable(functions, 'publishOrganizationScheduleDraft');
                 const result = await publishCallable({
                     organizationId: anchorTeam.id,
-                    scheduleId: anchorTeam.id // Placeholder for now, can be refined later
+                    scheduleId: `draft-${Date.now()}`,
+                    draftSlots: draftGeneratorState.draftSlots
                 });
 
                 console.log('Publish function result:', result.data);
 
                 successAlert.className = 'rounded-xl border border-emerald-200 bg-emerald-50 px-4 py-4 text-sm text-emerald-800';
-                successAlert.textContent = `Organization schedule draft publishing request logged successfully. Message: ${result.data.message}`;
+                successAlert.textContent = `Published ${result.data.publishedCount || draftGeneratorState.draftSlots.length} draft schedule slot${(result.data.publishedCount || draftGeneratorState.draftSlots.length) === 1 ? '' : 's'} to team schedules.`;
 
             } catch (error) {
                 console.error('Error publishing organization schedule draft:', error);

--- a/tests/unit/organization-schedule.test.js
+++ b/tests/unit/organization-schedule.test.js
@@ -336,6 +336,23 @@ describe('organization schedule helpers', () => {
         expect(source).toContain('localStorage.setItem(`organizationScheduleDraft:${anchorTeam?.id || \'unknown\'}`');
     });
 
+    it('publishes generated draft slots instead of logging a placeholder request', () => {
+        const html = readFileSync(new URL('../../organization-schedule.html', import.meta.url), 'utf8');
+        const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+
+        expect(html).toContain('draftSlots: draftGeneratorState.draftSlots');
+        expect(html).toContain('Generate at least one draft slot before publishing.');
+        expect(html).toContain('Published ${result.data.publishedCount || draftGeneratorState.draftSlots.length} draft schedule slot');
+        expect(html).not.toContain('Organization schedule draft publishing request logged successfully');
+
+        expect(functionsSource).toContain('exports.publishOrganizationScheduleDraft = functions.https.onCall');
+        expect(functionsSource).toContain('const draftSlots = Array.isArray(data?.draftSlots) ? data.draftSlots.map(normalizeOrganizationDraftSlot) : [];');
+        expect(functionsSource).toContain("firestore.collection(`teams/${slot.homeTeamId}/games`).doc()");
+        expect(functionsSource).toContain("firestore.collection(`teams/${slot.awayTeamId}/games`).doc()");
+        expect(functionsSource).toContain("createdVia: 'organizationScheduleDraftPublish'");
+        expect(functionsSource).toContain("message: 'Draft slots published to team schedules.'");
+    });
+
     it('caps organization schedule CSV imports before preview and import', () => {
         const source = readFileSync(new URL('../../organization-schedule.html', import.meta.url), 'utf8');
 

--- a/tests/unit/organization-schedule.test.js
+++ b/tests/unit/organization-schedule.test.js
@@ -347,6 +347,10 @@ describe('organization schedule helpers', () => {
 
         expect(functionsSource).toContain('exports.publishOrganizationScheduleDraft = functions.https.onCall');
         expect(functionsSource).toContain('const draftSlots = Array.isArray(data?.draftSlots) ? data.draftSlots.map(normalizeOrganizationDraftSlot) : [];');
+        expect(functionsSource).toContain("const inaccessibleTeamId = teamIds.find((teamId) => !hasTeamAdminAccess({");
+        expect(functionsSource).toContain('team: teamsById.get(teamId),');
+        expect(functionsSource).toContain("Only team admins can publish draft slots to every selected team.");
+        expect(functionsSource.indexOf('const inaccessibleTeamId = teamIds.find')).toBeLessThan(functionsSource.indexOf('const batch = firestore.batch();'));
         expect(functionsSource).toContain("firestore.collection(`teams/${slot.homeTeamId}/games`).doc()");
         expect(functionsSource).toContain("firestore.collection(`teams/${slot.awayTeamId}/games`).doc()");
         expect(functionsSource).toContain("createdVia: 'organizationScheduleDraftPublish'");


### PR DESCRIPTION
Closes #1483

- Sends generated draft slots from the organization schedule UI to the publish callable.
- Implements `publishOrganizationScheduleDraft` to validate admin access, validate draft teams, and write games to both home and away team schedules with shared schedule metadata.
- Adds regression coverage to prevent the placeholder success/log-only behavior from returning.

Validation:
- `npx vitest run tests/unit/organization-schedule.test.js --reporter=verbose`
- `node --check functions/index.js`