### PR TITLE
Hide single payment plan selector

### DIFF
--- a/apps/app/src/pages/RegistrationDetail.tsx
+++ b/apps/app/src/pages/RegistrationDetail.tsx
@@ -70,7 +70,8 @@ export function RegistrationDetail({ auth }: { auth: AuthState }) {
   }, [auth.user?.uid, teamId, formId, reloadKey]);
 
   const activeOptions: any[] = useMemo(() => form ? ((Array.isArray(form.options) && form.options.length) ? form.options : getActiveRegistrationOptions(form, form.registrationOptionCounts || {})) : [], [form]);
-  const paymentPlanChoices: any[] = useMemo(() => form ? (form.paymentPlans || getPaymentPlanChoices(form)) : [], [form]);
+  const paymentPlanChoices: any[] = useMemo(() => form ? ((Array.isArray(form.paymentPlans) && form.paymentPlans.length) ? form.paymentPlans : getPaymentPlanChoices(form)) : [], [form]);
+  const showPaymentPlanSelector = paymentPlanChoices.length > 1;
   const selectedOption = activeOptions.find((option) => option.id === selectedOptionId) || null;
   const placement = useMemo(() => {
     if (!form || !requiresRegistrationOption(form) || !selectedOptionId) return null;
@@ -219,13 +220,15 @@ export function RegistrationDetail({ auth }: { auth: AuthState }) {
             </label>
           ) : null}
 
-          <label className="min-w-0">
-            <span className="app-label">Payment plan</span>
-            <select className="auth-input mt-1" data-payment-plan value={selectedPaymentPlanId} onChange={(event) => setSelectedPaymentPlanId(event.target.value)} disabled={saving}>
-              {paymentPlanChoices.map((plan) => <option key={plan.id} value={plan.id}>{plan.title}</option>)}
-            </select>
-            {fieldErrors.paymentPlan ? <InlineError message={fieldErrors.paymentPlan} /> : null}
-          </label>
+          {showPaymentPlanSelector ? (
+            <label className="min-w-0">
+              <span className="app-label">Payment plan</span>
+              <select className="auth-input mt-1" data-payment-plan value={selectedPaymentPlanId} onChange={(event) => setSelectedPaymentPlanId(event.target.value)} disabled={saving}>
+                {paymentPlanChoices.map((plan) => <option key={plan.id} value={plan.id}>{plan.title}</option>)}
+              </select>
+              {fieldErrors.paymentPlan ? <InlineError message={fieldErrors.paymentPlan} /> : null}
+            </label>
+          ) : null}
 
           {form.waiverText ? (
             <div className="space-y-2">

--- a/tests/unit/app-registration-detail.test.jsx
+++ b/tests/unit/app-registration-detail.test.jsx
@@ -218,6 +218,69 @@ describe('RegistrationDetail page', () => {
     await waitForText(container, 'Registration submitted. Your registration is pending review.');
   });
 
+  it('hides the payment plan selector for a single pay-in-full plan and submits the default', async () => {
+    const { container } = await renderRegistrationDetail();
+    await waitForText(container, 'Summer Camp');
+
+    expect(container.querySelector('[data-payment-plan]')).toBeNull();
+    expect(container.textContent).not.toContain('Payment plan');
+
+    await changeInputValue(container, 'Participant Name', 'Test Participant');
+    await changeInputValue(container, 'Guardian Name', 'Test Guardian');
+    await changeInputValue(container, 'I accept the waiver.', true);
+    await changeInputValue(container, 'Registration option', 'opt-1');
+    await clickButton(container, 'Submit registration');
+
+    expect(parentToolsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
+      'team-1',
+      'form-1',
+      expect.objectContaining({
+        selectedPaymentPlanId: 'pay_full',
+      })
+    );
+  });
+
+  it('shows the payment plan selector for multiple choices and submits the selected plan', async () => {
+    parentToolsServiceMocks.loadParentRegistrations.mockResolvedValueOnce([
+      {
+        id: 'form-1',
+        teamId: 'team-1',
+        teamName: 'Bears',
+        programName: 'Summer Camp',
+        season: 'Summer',
+        onlineCheckout: false,
+        paymentPlans: [
+          { id: 'pay_full', title: 'Pay in full' },
+          { id: 'installments', title: 'Installment plan' },
+        ],
+        options: [{ id: 'opt-1', title: 'Option 1' }],
+        registrationOptionCounts: { 'opt-1': { enrolled: 0, waitlisted: 0 } },
+        participantFields: [{ id: 'name', label: 'Participant Name', type: 'text', required: true }],
+        guardianFields: [{ id: 'name', label: 'Guardian Name', type: 'text', required: true }],
+      },
+    ]);
+
+    const { container } = await renderRegistrationDetail();
+    await waitForText(container, 'Summer Camp');
+
+    expect(container.querySelector('[data-payment-plan]')).not.toBeNull();
+    expect(container.textContent).toContain('Payment plan');
+
+    await changeInputValue(container, 'Participant Name', 'Test Participant');
+    await changeInputValue(container, 'Guardian Name', 'Test Guardian');
+    await changeInputValue(container, 'Registration option', 'opt-1');
+    await changeInputValue(container, 'Payment plan', 'installments');
+    await clickButton(container, 'Submit registration');
+
+    expect(parentToolsServiceMocks.submitOfflineRegistration).toHaveBeenCalledWith(
+      'team-1',
+      'form-1',
+      expect.objectContaining({
+        selectedPaymentPlanId: 'installments',
+      })
+    );
+  });
+
   it('shows an error if required fields are missing', async () => {
     const { container } = await renderRegistrationDetail();
     await waitForText(container, 'Summer Camp');


### PR DESCRIPTION
Closes #1489

## Summary
- Hide the RegistrationDetail payment plan selector when only one payment plan is available.
- Keep the default `pay_full` payment plan applied for hidden single-plan submissions.
- Preserve the selector and selected plan submission when multiple payment plans are available.

## Tests
- `npx vitest run tests/unit/app-registration-detail.test.jsx --reporter=verbose`