### PR TITLE
Fix inactive team visibility in app

### DIFF
--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -29,6 +29,7 @@ import {
 import { getApp } from '../../../../js/vendor/firebase-app.js';
 import { getAI, getGenerativeModel, GoogleAIBackend } from '../../../../js/vendor/firebase-ai.js';
 import { resolveImageFirebaseConfig } from '../../../../js/firebase-runtime-config.js';
+import { isTeamActive } from '../../../../js/team-visibility.js';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import {
   DEFAULT_TEAM_CONVERSATION_ID,
@@ -167,10 +168,6 @@ function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = primaryD
 
 function compactString(value: unknown) {
   return String(value || '').trim();
-}
-
-function isActiveTeam(team: Record<string, any> | null | undefined) {
-  return team?.active !== false;
 }
 
 function getProjectId() {
@@ -387,7 +384,7 @@ async function nativeLoadUserTeams(user: AuthUser, profile: Record<string, any>)
     if (team?.id) map.set(team.id, team);
   });
   return [...map.values()]
-    .filter(isActiveTeam)
+    .filter(isTeamActive)
     .sort((a, b) => String(a.name || a.id).localeCompare(String(b.name || b.id)));
 }
 
@@ -431,7 +428,7 @@ export async function loadChatInbox(user: AuthUser | null): Promise<ChatInboxLoa
   }
 
   const userWithProfile = mapUserWithProfile(user, profile);
-  const accessibleTeams = teams.filter((team) => isActiveTeam(team) && canAccessTeamChat(userWithProfile, { ...team, id: team.id }));
+  const accessibleTeams = teams.filter((team) => isTeamActive(team) && canAccessTeamChat(userWithProfile, { ...team, id: team.id }));
   const unreadCounts = await withTimeout(
     Promise.resolve(getUnreadChatCounts(user.uid, accessibleTeams.map((team) => team.id))),
     'Chat unread counts',
@@ -478,7 +475,7 @@ export async function loadChatTeamContext(teamId: string, user: AuthUser | null)
     })
   ]);
 
-  if (!team || !isActiveTeam(team as Record<string, any>)) throw new Error('Team not found.');
+  if (!team || !isTeamActive(team as Record<string, any>)) throw new Error('Team not found.');
   const currentTeam = { ...team, id: teamId };
   const profileData = profile || {};
   const userWithProfile = mapUserWithProfile(user, profileData as Record<string, any>);

--- a/apps/app/src/lib/profileService.ts
+++ b/apps/app/src/lib/profileService.ts
@@ -14,6 +14,7 @@ import {
 import { normalizeTeamNotificationPreferences } from '../../../../js/notification-preferences.js';
 import { resolveImageFirebaseConfig } from '../../../../js/firebase-runtime-config.js';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
+import { isTeamActive } from '../../../../js/team-visibility.js';
 
 const profileTimeoutMs = 8000;
 const primaryDataTimeoutMs = 3000;
@@ -241,7 +242,7 @@ async function nativeRunQuery(collectionId: string, fieldPath: string, op: 'EQUA
 }
 
 function filterActiveTeams(teams: any[]) {
-  return teams.filter((team) => team && team.active !== false && team.archived !== true);
+  return teams.filter(isTeamActive);
 }
 
 async function nativeLoadProfileDocument(userId: string): Promise<ProfileDocument> {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -39,6 +39,7 @@ import { getEventRideshareSummary } from '../../../../js/rideshare-helpers.js';
 import { mergeAssignmentsWithClaims } from '../../../../js/snack-helpers.js';
 import { hasScorekeepingTeamAccess } from '../../../../js/team-access.js';
 import { buildScheduleNotificationTargets, postScheduleNotificationTargets } from '../../../../js/schedule-notifications.js';
+import { isTeamActive } from '../../../../js/team-visibility.js';
 import { loadProfileDocument, saveProfileDocument } from './profileService';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
 import {
@@ -431,10 +432,6 @@ export function buildCancelScheduledGameChatMessage(event: Pick<ParentScheduleEv
   return `⚠️ Game cancelled: ${opponentLabel} on ${formatCancelledGameDate(event.date)}`;
 }
 
-function isActiveTeam(team: Record<string, any> | null | undefined) {
-  return team?.active !== false;
-}
-
 function normalizeEmail(value: unknown) {
   return compactString(value).toLowerCase();
 }
@@ -465,7 +462,7 @@ async function loadStaffTeams(user: AuthUser) {
       ]);
       const teamsById = new Map<string, any>();
       [...visibleTeams, ...coachTeams].filter(Boolean).forEach((team: any) => {
-        if (team?.id && isActiveTeam(team) && isTeamStaff(team, user)) teamsById.set(team.id, team);
+        if (team?.id && isTeamActive(team) && isTeamStaff(team, user)) teamsById.set(team.id, team);
       });
       return [...teamsById.values()];
     },
@@ -478,7 +475,7 @@ async function loadStaffTeams(user: AuthUser) {
       const coachTeams = await Promise.all(coachTeamIds.map((teamId) => nativeGetDocument(`teams/${encodeURIComponent(teamId)}`).catch(() => null)));
       const teamsById = new Map<string, any>();
       [...ownedTeams, ...adminTeams, ...coachTeams].forEach((team) => {
-        if (team?.id && isActiveTeam(team) && team.archived !== true && isTeamStaff(team, user)) teamsById.set(team.id, team);
+        if (team?.id && isTeamActive(team) && isTeamStaff(team, user)) teamsById.set(team.id, team);
       });
       return [...teamsById.values()];
     }
@@ -613,7 +610,7 @@ async function loadTeam(teamId: string) {
     () => Promise.resolve(getTeam(teamId)),
     () => nativeGetDocument(`teams/${encodeURIComponent(teamId)}`)
   );
-  return isActiveTeam(team as Record<string, any> | null) ? team : null;
+  return isTeamActive(team as Record<string, any> | null) ? team : null;
 }
 
 async function loadGames(teamId: string) {

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -1,4 +1,5 @@
 import { getTeams } from '../../../../js/db.js';
+import { isTeamActive } from '../../../../js/team-visibility.js';
 import {
   db,
   collectionGroup,
@@ -39,6 +40,8 @@ export type AppSearchTeam = {
   state?: string | null;
   isPublic?: boolean;
   active?: boolean;
+  archived?: boolean;
+  status?: string | null;
   ownerId?: string | null;
   adminEmails?: string[];
   photoUrl?: string | null;
@@ -240,7 +243,7 @@ export async function loadAppSearchTeams(user: AuthUser | null): Promise<AppSear
   if (homeTeamsResult.status === 'fulfilled' && homeTeamsResult.value) {
     (homeTeamsResult.value.teams || []).forEach((team: any) => {
       if (!team?.teamId) return;
-      if (team.active === false) return;
+      if (!isTeamActive(team)) return;
       const existing = teamsById.get(team.teamId);
       teamsById.set(team.teamId, {
         ...existing,
@@ -252,6 +255,8 @@ export async function loadAppSearchTeams(user: AuthUser | null): Promise<AppSear
         state: existing?.state || '',
         isPublic: existing?.isPublic,
         active: team.active ?? existing?.active,
+        archived: team.archived ?? existing?.archived,
+        status: team.status ?? existing?.status,
         ownerId: existing?.ownerId,
         adminEmails: existing?.adminEmails || [],
         photoUrl: team.photoUrl || existing?.photoUrl || null,
@@ -415,6 +420,8 @@ function normalizeTeams(teams: any[]): AppSearchTeam[] {
       state: cleanString(team?.state),
       isPublic: team?.isPublic,
       active: team?.active,
+      archived: team?.archived,
+      status: cleanString(team?.status),
       ownerId: cleanString(team?.ownerId),
       adminEmails: Array.isArray(team?.adminEmails) ? team.adminEmails : [],
       photoUrl: getFirstUrl(team?.photoUrl, team?.teamPhotoUrl, team?.logoUrl, team?.imageUrl)
@@ -424,7 +431,7 @@ function normalizeTeams(teams: any[]): AppSearchTeam[] {
 
 function canUserDiscoverTeamInAppSearch(team: AppSearchTeam, user: AuthUser | null) {
   if (!team) return false;
-  if (team.active === false) return false;
+  if (!isTeamActive(team)) return false;
   if (team.fromAppAccess) return true;
   if (team.isPublic !== false) return true;
   if (!user) return false;

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -4,6 +4,8 @@ import {
   db,
   collection,
   collectionGroup,
+  doc,
+  getDoc,
   getDocs,
   query,
   where,
@@ -253,28 +255,7 @@ export async function loadAppSearchTeams(user: AuthUser | null): Promise<AppSear
   }
 
   if (homeTeamsResult.status === 'fulfilled' && homeTeamsResult.value) {
-    (homeTeamsResult.value.teams || []).forEach((team: any) => {
-      if (!team?.teamId) return;
-      if (!isTeamActive(team)) return;
-      const existing = teamsById.get(team.teamId);
-      teamsById.set(team.teamId, {
-        ...existing,
-        id: team.teamId,
-        name: team.teamName || existing?.name || 'Team',
-        sport: team.sport || existing?.sport || '',
-        zip: existing?.zip || '',
-        city: existing?.city || '',
-        state: existing?.state || '',
-        isPublic: existing?.isPublic,
-        active: team.active ?? existing?.active,
-        archived: team.archived ?? existing?.archived,
-        status: team.status ?? existing?.status,
-        ownerId: existing?.ownerId,
-        adminEmails: existing?.adminEmails || [],
-        photoUrl: team.photoUrl || existing?.photoUrl || null,
-        fromAppAccess: true
-      });
-    });
+    await mergeParentHomeSearchTeams(teamsById, homeTeamsResult.value.teams || [], user);
   }
 
   if (streamVolunteerTeamsResult.status === 'fulfilled') {
@@ -411,6 +392,69 @@ export function resetAppSearchCacheForTests() {
   cachedTeams = null;
   cachedTeamsLoadedAt = 0;
   cachedTeamsUserKey = '';
+}
+
+async function mergeParentHomeSearchTeams(teamsById: Map<string, AppSearchTeam>, homeTeams: any[], user: AuthUser | null) {
+  const fallbackTeams: any[] = [];
+
+  (Array.isArray(homeTeams) ? homeTeams : []).forEach((team: any) => {
+    const teamId = cleanString(team?.teamId || team?.id);
+    if (!teamId) return;
+    if (!isTeamActive(team)) return;
+
+    const existing = teamsById.get(teamId);
+    if (existing) {
+      teamsById.set(teamId, buildParentHomeSearchTeam(team, existing));
+      return;
+    }
+
+    fallbackTeams.push({ ...team, teamId });
+  });
+
+  if (!fallbackTeams.length) return;
+
+  const snapshots = await Promise.allSettled(
+    fallbackTeams.map((team) => getDoc(doc(db, 'teams', team.teamId)))
+  );
+
+  snapshots.forEach((snapshot: any, index) => {
+    if (snapshot.status !== 'fulfilled') return;
+    const teamDoc = snapshot.value;
+    if (!teamDoc?.exists?.()) return;
+
+    const homeTeam = fallbackTeams[index];
+    const [firestoreTeam] = normalizeTeams([{ id: homeTeam.teamId, ...(typeof teamDoc.data === 'function' ? teamDoc.data() || {} : {}) }]);
+    if (!firestoreTeam || !isTeamActive(firestoreTeam)) return;
+
+    const searchTeam = buildParentHomeSearchTeam(homeTeam, firestoreTeam);
+    if (canUserDiscoverTeamInAppSearch(searchTeam, user)) {
+      teamsById.set(searchTeam.id, searchTeam);
+    }
+  });
+}
+
+function buildParentHomeSearchTeam(homeTeam: any, baseTeam?: AppSearchTeam): AppSearchTeam {
+  const teamId = cleanString(homeTeam?.teamId || homeTeam?.id || baseTeam?.id);
+  return {
+    ...baseTeam,
+    id: teamId,
+    name: cleanString(homeTeam?.teamName || homeTeam?.name) || baseTeam?.name || 'Team',
+    sport: cleanString(homeTeam?.sport) || baseTeam?.sport || '',
+    zip: baseTeam?.zip || '',
+    city: baseTeam?.city || '',
+    state: baseTeam?.state || '',
+    isPublic: baseTeam?.isPublic,
+    active: homeTeam?.active ?? baseTeam?.active,
+    archived: homeTeam?.archived ?? baseTeam?.archived,
+    status: cleanString(homeTeam?.status) || baseTeam?.status,
+    ownerId: baseTeam?.ownerId,
+    adminEmails: baseTeam?.adminEmails || [],
+    photoUrl: getFirstUrl(homeTeam?.photoUrl, baseTeam?.photoUrl),
+    fromAppAccess: true,
+    streamAccessMode: baseTeam?.streamAccessMode,
+    streamVolunteerEmails: baseTeam?.streamVolunteerEmails || [],
+    teamPermissions: baseTeam?.teamPermissions || null
+  };
 }
 
 async function loadStreamVolunteerSearchTeams(user: AuthUser): Promise<AppSearchTeam[]> {

--- a/docs/pr-notes/runs/1492-pr-issue-comment-4581170988-20260530T015811Z/architecture.md
+++ b/docs/pr-notes/runs/1492-pr-issue-comment-4581170988-20260530T015811Z/architecture.md
@@ -1,0 +1,15 @@
+# Architecture
+
+## Decision
+Use a direct Firestore `getDoc(doc(db, 'teams', teamId))` read only for parent-home fallback teams that are not already loaded from the canonical site team list.
+
+## Rationale
+- Preserves the existing site-team discovery path and cache behavior.
+- Adds canonical visibility validation only where fallback data is insufficient.
+- Fails closed on missing or failed document reads to avoid visibility leaks.
+- Reuses `isTeamActive()` and existing app-search authorization checks instead of inventing another lifecycle policy.
+
+## Risk Controls
+- No Firestore rules change required in this patch.
+- Visibility policy remains centralized through `js/team-visibility.js`.
+- Blast radius is limited to `apps/app/src/lib/searchService.ts` parent-home search fallback merging.

--- a/docs/pr-notes/runs/1492-pr-issue-comment-4581170988-20260530T015811Z/code-plan.md
+++ b/docs/pr-notes/runs/1492-pr-issue-comment-4581170988-20260530T015811Z/code-plan.md
@@ -1,0 +1,12 @@
+# Code Plan
+
+## Patch Scope
+- Import `doc` and `getDoc` in `apps/app/src/lib/searchService.ts`.
+- Replace inline parent-home fallback merge with `mergeParentHomeSearchTeams()`.
+- Add `buildParentHomeSearchTeam()` to merge parent-home display fields over canonical team visibility fields.
+- Update app-search unit mocks and tests for direct team document reads.
+
+## Implementation Notes
+- Existing site-list teams are merged without an extra document read.
+- Fallback-only parent-home teams require a canonical team doc read.
+- Missing, failed, inactive, or archived canonical docs are skipped.

--- a/docs/pr-notes/runs/1492-pr-issue-comment-4581170988-20260530T015811Z/qa.md
+++ b/docs/pr-notes/runs/1492-pr-issue-comment-4581170988-20260530T015811Z/qa.md
@@ -1,0 +1,17 @@
+# QA Plan
+
+## Automated Coverage
+- `tests/unit/app-search-service.test.js`
+  - Active private fallback appears after canonical doc validation.
+  - Archived, inactive, and missing-doc fallback teams are excluded.
+  - Existing site-list team merge remains non-duplicating.
+  - Cache/fallback tests mock required visibility reads.
+- Existing coverage retained for `team-visibility` and app schedule service contracts.
+
+## Validation Commands
+- `npx vitest run tests/unit/app-search-service.test.js --reporter=verbose`
+- `npx vitest run tests/unit/team-visibility.test.js tests/unit/app-search-service.test.js tests/unit/app-schedule-service-contracts.test.js --reporter=verbose`
+- `npm run app:build`
+
+## Manual Smoke Recommendation
+Use a parent account linked to one active private team and one archived/inactive team. Confirm app search shows only the active private team and player search only returns players from visible teams.

--- a/docs/pr-notes/runs/1492-pr-issue-comment-4581170988-20260530T015811Z/requirements.md
+++ b/docs/pr-notes/runs/1492-pr-issue-comment-4581170988-20260530T015811Z/requirements.md
@@ -1,0 +1,15 @@
+# Requirements
+
+## Problem
+Parent-home app search fallback can surface teams that are not present in the site team list. If fallback metadata lacks canonical visibility fields, archived or inactive teams can leak into search.
+
+## Acceptance Criteria
+1. Parent-home fallback teams absent from `getTeams()` must be validated against the canonical `teams/{teamId}` document before app search adds them.
+2. Active private parent-home teams remain searchable for the linked parent.
+3. Fallback teams with `archived: true`, `active: false`, or inactive status values are excluded.
+4. Missing or unreadable canonical team documents fail closed and are not added.
+5. Existing site-list teams merge parent-home display data without duplicate results.
+6. Regression tests cover active, archived, inactive, missing-doc, and cache fallback behavior.
+
+## User Impact
+Parents keep access to active private teams they are linked to, while archived or inactive season/team records stay hidden from app search.

--- a/js/team-visibility.js
+++ b/js/team-visibility.js
@@ -1,5 +1,8 @@
 export function isTeamActive(team) {
-    return team?.active !== false;
+    const status = String(team?.status || '').trim().toLowerCase();
+    return team?.active !== false
+        && team?.archived !== true
+        && !['archived', 'inactive', 'disabled'].includes(status);
 }
 
 export function isTeamPublic(team) {

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -8,6 +8,7 @@ const dbMocks = vi.hoisted(() => ({
     getRsvps: vi.fn(),
     getRsvpSummaries: vi.fn(),
     getTeam: vi.fn(),
+    getTeams: vi.fn(),
     updateTeam: vi.fn(),
     getTrackedCalendarEventUids: vi.fn(),
     createRideOffer: vi.fn(),
@@ -154,6 +155,7 @@ beforeEach(() => {
         calendarUrls: ['mock://team-calendar'],
         availabilityPreferences: { noteVisibility: 'team' }
     });
+    dbMocks.getTeams.mockResolvedValue([]);
     dbMocks.getGames.mockResolvedValue([
         {
             id: 'game-1',
@@ -375,6 +377,45 @@ describe('React app schedule service contract integration', () => {
         ]);
         expect(result.events.some((event) => event.childId === 'player-from-user')).toBe(true);
         expect(result.events.some((event) => event.childId === 'player-1')).toBe(false);
+    });
+
+    it('does not surface parent-linked schedules for archived teams', async () => {
+        dbMocks.getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears', archived: true });
+
+        const result = await loadParentSchedule(user());
+
+        expect(dbMocks.getTeam).toHaveBeenCalledWith('team-1');
+        expect(result.children).toEqual([
+            { teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat' },
+            { teamId: 'team-1', teamName: 'Bears', playerId: 'player-2', playerName: 'Sam' }
+        ]);
+        expect(result.events).toEqual([]);
+    });
+
+    it('applies the active-team policy to native REST team fallback reads', async () => {
+        installWindow('capacitor:');
+        dbMocks.getTeam.mockRejectedValue(new Error('web team read unavailable'));
+        authMocks.getNativeAuthIdToken.mockResolvedValue('native-token');
+        vi.stubGlobal('fetch', vi.fn(async () => ({
+            ok: true,
+            json: async () => ({
+                name: 'projects/demo-allplays/databases/(default)/documents/teams/team-1',
+                fields: {
+                    name: { stringValue: 'Bears' },
+                    status: { stringValue: 'archived' }
+                }
+            })
+        })));
+
+        const result = await loadParentSchedule(user());
+
+        expect(fetch).toHaveBeenCalledWith(
+            'https://firestore.googleapis.com/v1/projects/demo-allplays/databases/(default)/documents/teams/team-1',
+            expect.objectContaining({
+                headers: expect.objectContaining({ Authorization: 'Bearer native-token' })
+            })
+        );
+        expect(result.events).toEqual([]);
     });
 
     it('adds a new staff calendar URL and avoids duplicates', async () => {

--- a/tests/unit/app-search-integration.test.jsx
+++ b/tests/unit/app-search-integration.test.jsx
@@ -15,6 +15,8 @@ const homeMocks = vi.hoisted(() => ({
 const firebaseMocks = vi.hoisted(() => ({
     db: {},
     collectionGroup: vi.fn((db, collectionName) => ({ db, collectionName })),
+    doc: vi.fn(),
+    getDoc: vi.fn(),
     getDocs: vi.fn(),
     query: vi.fn((...parts) => ({ parts })),
     where: vi.fn((field, op, value) => ({ type: 'where', field, op, value })),
@@ -161,6 +163,7 @@ beforeEach(() => {
             openActions: 0
         }]
     });
+    firebaseMocks.getDoc.mockResolvedValue({ exists: () => true, data: () => ({}) });
     firebaseMocks.getDocs.mockResolvedValue({
         docs: [
             firestorePlayer('teams/team-1/players/player-1', { name: 'Pat Star', number: '9' }),

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -208,6 +208,8 @@ describe('React app search service', () => {
         dbMocks.getTeams.mockResolvedValue([
             { id: 'team-public', name: 'Public Bears', sport: 'Soccer', isPublic: true },
             { id: 'team-inactive', name: 'Inactive Sharks', sport: 'Soccer', isPublic: true, active: false },
+            { id: 'team-archived', name: 'Archived Sharks', sport: 'Soccer', isPublic: true, archived: true },
+            { id: 'team-status-archived', name: 'Archived Status Sharks', sport: 'Soccer', isPublic: true, status: 'archived' },
             { id: 'team-private', name: 'Private Wolves', sport: 'Basketball', isPublic: false },
             { id: 'team-admin', name: 'Admin Lions', sport: 'Soccer', isPublic: false, adminEmails: ['parent@example.com'] },
             { id: 'team-owner', name: 'Owner Eagles', sport: 'Volleyball', isPublic: false, ownerId: 'user-1' },
@@ -234,6 +236,26 @@ describe('React app search service', () => {
                 eventCount: 0,
                 unreadCount: 0,
                 openActions: 0
+            }, {
+                teamId: 'team-archived-access',
+                teamName: 'Archived Access',
+                sport: 'Soccer',
+                archived: true,
+                players: [],
+                nextEvent: null,
+                eventCount: 0,
+                unreadCount: 0,
+                openActions: 0
+            }, {
+                teamId: 'team-status-archived-access',
+                teamName: 'Archived Status Access',
+                sport: 'Soccer',
+                status: 'archived',
+                players: [],
+                nextEvent: null,
+                eventCount: 0,
+                unreadCount: 0,
+                openActions: 0
             }]
         });
 
@@ -247,7 +269,11 @@ describe('React app search service', () => {
         });
         expect(teams.find((team) => team.id === 'team-private')).toBeUndefined();
         expect(teams.find((team) => team.id === 'team-inactive')).toBeUndefined();
+        expect(teams.find((team) => team.id === 'team-archived')).toBeUndefined();
+        expect(teams.find((team) => team.id === 'team-status-archived')).toBeUndefined();
         expect(teams.find((team) => team.id === 'team-inactive-access')).toBeUndefined();
+        expect(teams.find((team) => team.id === 'team-archived-access')).toBeUndefined();
+        expect(teams.find((team) => team.id === 'team-status-archived-access')).toBeUndefined();
     });
 
     it('caches loaded teams and falls back to app access when public team loading fails', async () => {

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -12,6 +12,8 @@ const firebaseMocks = vi.hoisted(() => ({
     db: {},
     collection: vi.fn((db, collectionName) => ({ db, collectionName })),
     collectionGroup: vi.fn((db, collectionName) => ({ db, collectionName })),
+    doc: vi.fn((db, ...pathSegments) => ({ db, path: pathSegments.join('/') })),
+    getDoc: vi.fn(),
     getDocs: vi.fn(),
     query: vi.fn((...parts) => ({ parts })),
     where: vi.fn((field, op, value) => ({ type: 'where', field, op, value })),
@@ -66,8 +68,17 @@ function firestoreTeam(id, data) {
     };
 }
 
+function firestoreDocument(id, data, exists = true) {
+    return {
+        id,
+        exists: () => exists,
+        data: () => data
+    };
+}
+
 beforeEach(() => {
     vi.clearAllMocks();
+    firebaseMocks.getDoc.mockReset();
     resetAppSearchCacheForTests();
     helpMocks.searchHelpKnowledge.mockReturnValue([]);
 });
@@ -267,7 +278,6 @@ describe('React app search service', () => {
                 openActions: 0
             }]
         });
-
         const teams = await loadAppSearchTeams(auth.user);
 
         expect(teams.map((team) => team.id)).toEqual(['team-admin', 'team-home', 'team-owner', 'team-public']);
@@ -283,6 +293,54 @@ describe('React app search service', () => {
         expect(teams.find((team) => team.id === 'team-inactive-access')).toBeUndefined();
         expect(teams.find((team) => team.id === 'team-archived-access')).toBeUndefined();
         expect(teams.find((team) => team.id === 'team-status-archived-access')).toBeUndefined();
+    });
+
+    it('validates parent home fallback teams against Firestore visibility before adding them', async () => {
+        dbMocks.getTeams.mockResolvedValue([]);
+        homeMocks.loadParentHome.mockResolvedValue({
+            teams: [
+                { teamId: 'team-active-private', teamName: 'Active Private', sport: 'Basketball' },
+                { teamId: 'team-archived-doc', teamName: 'Archived Doc', sport: 'Soccer' },
+                { teamId: 'team-inactive-doc', teamName: 'Inactive Doc', sport: 'Baseball' },
+                { teamId: 'team-missing-doc', teamName: 'Missing Doc', sport: 'Softball' }
+            ]
+        });
+        firebaseMocks.getDoc
+            .mockResolvedValueOnce(firestoreDocument('team-active-private', {
+                name: 'Stored Active Private',
+                sport: 'Basketball',
+                isPublic: false,
+                active: true,
+                archived: false,
+                status: 'active'
+            }))
+            .mockResolvedValueOnce(firestoreDocument('team-archived-doc', {
+                name: 'Stored Archived',
+                sport: 'Soccer',
+                isPublic: false,
+                archived: true
+            }))
+            .mockResolvedValueOnce(firestoreDocument('team-inactive-doc', {
+                name: 'Stored Inactive',
+                sport: 'Baseball',
+                isPublic: false,
+                active: false
+            }))
+            .mockResolvedValueOnce(firestoreDocument('team-missing-doc', {}, false));
+
+        const teams = await loadAppSearchTeams(auth.user);
+
+        expect(firebaseMocks.doc).toHaveBeenCalledWith(firebaseMocks.db, 'teams', 'team-active-private');
+        expect(firebaseMocks.doc).toHaveBeenCalledWith(firebaseMocks.db, 'teams', 'team-archived-doc');
+        expect(firebaseMocks.doc).toHaveBeenCalledWith(firebaseMocks.db, 'teams', 'team-inactive-doc');
+        expect(firebaseMocks.doc).toHaveBeenCalledWith(firebaseMocks.db, 'teams', 'team-missing-doc');
+        expect(teams.map((team) => team.id)).toEqual(['team-active-private']);
+        expect(teams[0]).toMatchObject({
+            id: 'team-active-private',
+            name: 'Active Private',
+            isPublic: false,
+            fromAppAccess: true
+        });
     });
 
     it('loads private selected stream-volunteer teams before checking search access', async () => {
@@ -380,6 +438,12 @@ describe('React app search service', () => {
         homeMocks.loadParentHome.mockResolvedValue({
             teams: [{ teamId: 'team-home', teamName: 'Home Rockets', sport: 'Basketball' }]
         });
+        firebaseMocks.getDoc.mockResolvedValueOnce(firestoreDocument('team-home', {
+            name: 'Home Rockets',
+            sport: 'Basketball',
+            isPublic: false,
+            active: true
+        }));
 
         const first = await loadAppSearchTeams(auth.user);
         const second = await loadAppSearchTeams(auth.user);
@@ -394,6 +458,12 @@ describe('React app search service', () => {
         homeMocks.loadParentHome.mockResolvedValueOnce({
             teams: [{ teamId: 'team-private-access', teamName: 'Private Access', sport: 'Soccer' }]
         });
+        firebaseMocks.getDoc.mockResolvedValueOnce(firestoreDocument('team-private-access', {
+            name: 'Private Access',
+            sport: 'Soccer',
+            isPublic: false,
+            active: true
+        }));
 
         await expect(loadAppSearchTeams(auth.user)).resolves.toMatchObject([
             { id: 'team-private-access', name: 'Private Access', fromAppAccess: true }

--- a/tests/unit/team-visibility.test.js
+++ b/tests/unit/team-visibility.test.js
@@ -16,11 +16,21 @@ describe('team visibility helpers', () => {
         expect(isTeamActive({ id: 't1', active: false })).toBe(false);
     });
 
+    it('treats archived and inactive status markers as inactive', () => {
+        expect(isTeamActive({ id: 't1', archived: true })).toBe(false);
+        expect(isTeamActive({ id: 't2', status: 'archived' })).toBe(false);
+        expect(isTeamActive({ id: 't3', status: 'inactive' })).toBe(false);
+        expect(isTeamActive({ id: 't4', status: 'disabled' })).toBe(false);
+        expect(isTeamActive({ id: 't5', status: 'active' })).toBe(true);
+    });
+
     it('filters inactive teams by default', () => {
         const teams = [
             { id: 'a', active: true },
             { id: 'b', active: false },
-            { id: 'c' }
+            { id: 'c' },
+            { id: 'd', archived: true },
+            { id: 'e', status: 'archived' }
         ];
         expect(filterTeamsByActive(teams)).toEqual([
             { id: 'a', active: true },


### PR DESCRIPTION
Closes #1491

## Summary
- Centralized active team checks on `isTeamActive()` for app schedule, chat, search, and notification-team fallback paths.
- Treats `active: false`, `archived: true`, and inactive `status` markers as hidden from active app surfaces.
- Validates parent-linked teams against active team documents before rendering schedule-derived state.

## Validation
- `npx vitest run tests/unit/team-visibility.test.js tests/unit/app-search-service.test.js tests/unit/app-schedule-service-contracts.test.js --reporter=verbose`
- `npm run app:build`