### PR TITLE
Bind admin invite redemption to invitee email

### DIFF
--- a/accept-invite.html
+++ b/accept-invite.html
@@ -156,7 +156,7 @@
 
     <script type="module">
         import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=15';
-        import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=32';
+        import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=33';
         import { createInviteProcessor } from './js/accept-invite-flow.js?v=5';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 

--- a/js/db.js
+++ b/js/db.js
@@ -3097,6 +3097,15 @@ export async function redeemAdminInviteAtomicPersistence({
             throw new Error('Access code team does not match admin invite target');
         }
 
+        const invitedEmail = String(codeData.email || '').trim().toLowerCase();
+        if (!invitedEmail) {
+            throw new Error('Admin invite is missing invited email');
+        }
+
+        if (normalizedEmail !== invitedEmail) {
+            throw new Error('Admin invite email does not match signed-in user');
+        }
+
         if (codeData.used === true) {
             throw new Error('Access code has already been used');
         }
@@ -3137,6 +3146,13 @@ export async function redeemAdminInviteAtomicPersistence({
             }
             if ((latestCodeData.teamId || null) !== teamId) {
                 throw new Error('Access code team does not match admin invite target');
+            }
+            const latestInvitedEmail = String(latestCodeData.email || '').trim().toLowerCase();
+            if (!latestInvitedEmail) {
+                throw new Error('Admin invite is missing invited email');
+            }
+            if (normalizedEmail !== latestInvitedEmail) {
+                throw new Error('Admin invite email does not match signed-in user');
             }
             if (latestCodeData.used === true) {
                 throw new Error('Access code has already been used');
@@ -3231,6 +3247,15 @@ export async function redeemAdminInviteAtomically(codeId, userId, fallbackEmail 
         const userEmail = (userData.email || authEmail || fallbackEmail || '').toLowerCase().trim();
         if (!userEmail) {
             throw new Error('Unable to determine user email for admin invite');
+        }
+
+        const invitedEmail = String(codeData.email || '').trim().toLowerCase();
+        if (!invitedEmail) {
+            throw new Error('Admin invite is missing invited email');
+        }
+
+        if (userEmail !== invitedEmail) {
+            throw new Error('Admin invite email does not match signed-in user');
         }
 
         transaction.set(teamRef, {

--- a/tests/unit/accept-invite-page.test.js
+++ b/tests/unit/accept-invite-page.test.js
@@ -107,7 +107,7 @@ const setTimeout = deps.setTimeout;
             'const { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } = deps.auth;'
         )
         .replace(
-            "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=32';",
+            "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=33';",
             'const { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } = deps.db;'
         )
         .replace(

--- a/tests/unit/admin-invite-atomic-persistence-guard.test.js
+++ b/tests/unit/admin-invite-atomic-persistence-guard.test.js
@@ -31,4 +31,26 @@ describe('admin invite atomic persistence guard', () => {
         expect(afterFunction).toContain(expirationGuard);
         expect(afterFunction).toContain(latestExpirationGuard);
     });
+
+    it('requires the signed-in email to match the invited admin email', () => {
+        const dbSourcePath = resolve(process.cwd(), 'js/db.js');
+        const source = readFileSync(dbSourcePath, 'utf8');
+
+        const persistenceAnchor = 'export async function redeemAdminInviteAtomicPersistence';
+        const legacyAnchor = 'export async function redeemAdminInviteAtomically';
+        const persistenceIndex = source.indexOf(persistenceAnchor);
+        const legacyIndex = source.indexOf(legacyAnchor);
+        expect(persistenceIndex).toBeGreaterThanOrEqual(0);
+        expect(legacyIndex).toBeGreaterThanOrEqual(0);
+
+        const persistenceFunction = source.slice(persistenceIndex, legacyIndex);
+        const legacyFunction = source.slice(legacyIndex, legacyIndex + 2500);
+
+        expect(persistenceFunction).toContain("const invitedEmail = String(codeData.email || '').trim().toLowerCase();");
+        expect(persistenceFunction).toContain('if (normalizedEmail !== invitedEmail)');
+        expect(persistenceFunction).toContain("const latestInvitedEmail = String(latestCodeData.email || '').trim().toLowerCase();");
+        expect(persistenceFunction).toContain('if (normalizedEmail !== latestInvitedEmail)');
+        expect(legacyFunction).toContain("const invitedEmail = String(codeData.email || '').trim().toLowerCase();");
+        expect(legacyFunction).toContain('if (userEmail !== invitedEmail)');
+    });
 });

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -15,7 +15,7 @@ describe('admin invite signup cache busting', () => {
         const acceptInviteSource = readFileSync(resolve(process.cwd(), 'accept-invite.html'), 'utf8');
 
         expect(acceptInviteSource).toContain(
-            "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=32';"
+            "import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=33';"
         );
         expect(acceptInviteSource).toContain(
             "import { createInviteProcessor } from './js/accept-invite-flow.js?v=5';"


### PR DESCRIPTION
Closes #1493

## Summary
- Require admin invite redemption to compare the signed-in user's normalized email against the email stored on the invite code.
- Fail closed when an admin invite is missing its intended invitee email or the emails do not match.
- Added regression coverage for both admin invite redemption paths and bumped the accept-invite db module cache version.

## Validation
- `npx vitest run tests/unit/admin-invite-atomic-persistence-guard.test.js tests/unit/accept-invite-page.test.js tests/unit/admin-invite-signup-cache-busting.test.js --reporter=verbose`
- `node scripts/check-critical-cache-bust.mjs`