### PR TITLE
Add scoreboard widget copy tools

### DIFF
--- a/apps/app/src/lib/publicActions.ts
+++ b/apps/app/src/lib/publicActions.ts
@@ -11,6 +11,8 @@ export type SharePublicUrlInput = {
 
 export type SharePublicUrlResult = 'shared' | 'copied' | 'failed' | 'cancelled';
 
+export type CopyPublicTextResult = 'copied' | 'failed';
+
 function isNativePluginAvailable(pluginName: string) {
   return Capacitor.isNativePlatform() && Boolean((Capacitor as any).isPluginAvailable?.(pluginName));
 }
@@ -33,6 +35,37 @@ export async function openPublicUrl(url: string) {
   const opened = window.open(url, '_blank', 'noopener,noreferrer');
   if (!opened) {
     window.location.href = url;
+  }
+}
+
+export async function copyPublicText(text: string): Promise<CopyPublicTextResult> {
+  const value = String(text || '');
+  if (!value) return 'failed';
+
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(value);
+      return 'copied';
+    }
+  } catch {
+    // Fall back to the textarea path below for WebViews or blocked clipboard APIs.
+  }
+
+  try {
+    const textarea = document.createElement('textarea');
+    textarea.value = value;
+    textarea.setAttribute('readonly', '');
+    textarea.style.position = 'fixed';
+    textarea.style.left = '-9999px';
+    textarea.style.top = '0';
+    document.body.appendChild(textarea);
+    textarea.focus();
+    textarea.select();
+    const copied = document.execCommand?.('copy') === true;
+    document.body.removeChild(textarea);
+    return copied ? 'copied' : 'failed';
+  } catch {
+    return 'failed';
   }
 }
 

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -126,6 +126,7 @@ export type TeamDetailModel = {
   leaderboards: TeamDetailLeaderboard[];
   trackingSummaries: TeamDetailTrackingSummary[];
   sponsors: TeamDetailSponsor[];
+  canManageTeam: boolean;
   staffPermissions: TeamStaffPermissionsSummary | null;
   counts: {
     games: number;
@@ -404,7 +405,8 @@ export function buildTeamDetailModel({
   const standings = buildStandings(team, games);
   const leaderboards = buildLeaderboards(configs, normalizedPlayers, seasonStatsByPlayerId, team?.sport);
   const trackingSummaries = buildTrackingSummaries(normalizedPlayers, linkedPlayerIds, trackingItems, trackingStatuses);
-  const staffPermissions = hasFullTeamAccess(user, team)
+  const canManageTeam = hasFullTeamAccess(user, team);
+  const staffPermissions = canManageTeam
     ? buildTeamStaffPermissionsViewModel({ ...team, id: teamId }, pendingAdminInvites)
     : null;
 
@@ -441,6 +443,7 @@ export function buildTeamDetailModel({
     leaderboards,
     trackingSummaries,
     sponsors: sponsors.slice(0, 4),
+    canManageTeam,
     staffPermissions,
     counts: {
       games: games.filter((game: any) => game?.type !== 'practice').length,

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -6,6 +6,8 @@ import {
   CalendarDays,
   CheckCircle2,
   ChevronRight,
+  Code2,
+  Copy,
   DollarSign,
   ExternalLink,
   ImageIcon,
@@ -20,7 +22,7 @@ import {
   UserRound,
   Users
 } from 'lucide-react';
-import { openPublicUrl } from '../lib/publicActions';
+import { copyPublicText, openPublicUrl } from '../lib/publicActions';
 import { getEventDetailPath } from '../lib/homeLogic';
 import { loadParentTeamDetail, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer } from '../lib/teamDetailService';
 import type { AuthState } from '../lib/types';
@@ -339,6 +341,7 @@ function MoreTab({ model }: { model: TeamDetailModel }) {
   return (
     <div className="space-y-4">
       {model.staffPermissions ? <StaffPermissionsCard model={model} /> : null}
+      {model.canManageTeam ? <ScoreboardWidgetCard model={model} /> : null}
 
       <section className="app-card p-4">
         <div className="text-sm font-black text-gray-950">Team links</div>
@@ -394,6 +397,79 @@ function MoreTab({ model }: { model: TeamDetailModel }) {
       ) : null}
     </div>
   );
+}
+
+function ScoreboardWidgetCard({ model }: { model: TeamDetailModel }) {
+  const widgetUrl = buildScoreboardWidgetUrl(model.team.id);
+  const embedCode = buildScoreboardWidgetEmbedCode(model.team);
+  const [copyStatus, setCopyStatus] = useState<{ kind: 'embed' | 'link'; success: boolean } | null>(null);
+
+  async function copyValue(kind: 'embed' | 'link', value: string) {
+    const result = await copyPublicText(value);
+    setCopyStatus({ kind, success: result === 'copied' });
+  }
+
+  return (
+    <section className="app-card p-4">
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 flex-none items-center justify-center rounded-xl bg-primary-50 text-primary-700">
+          <Code2 className="h-5 w-5" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-black text-gray-950">Scoreboard widget</div>
+          <div className="mt-1 text-xs font-semibold leading-5 text-gray-500">Copy a read-only public link or iframe embed for this team&apos;s live scoreboard.</div>
+          <label className="mt-3 block text-[11px] font-black uppercase tracking-[0.04em] text-gray-500" htmlFor="scoreboard-widget-embed">Embed code</label>
+          <textarea
+            id="scoreboard-widget-embed"
+            className="mt-1 h-24 w-full resize-none rounded-xl border border-gray-200 bg-gray-50 p-3 font-mono text-xs font-semibold text-gray-700"
+            readOnly
+            value={embedCode}
+          />
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button type="button" className="primary-button !min-h-9 text-xs" onClick={() => copyValue('embed', embedCode)}>
+              <Copy className="h-4 w-4" aria-hidden="true" />
+              Copy Embed Code
+            </button>
+            <button type="button" className="secondary-button !min-h-9 text-xs" onClick={() => copyValue('link', widgetUrl)}>
+              <LinkIcon className="h-4 w-4" aria-hidden="true" />
+              Copy Link
+            </button>
+          </div>
+          {copyStatus ? (
+            <div className={`mt-2 flex items-center gap-2 text-xs font-black ${copyStatus.success ? 'text-emerald-700' : 'text-rose-700'}`} role="status">
+              <CheckCircle2 className="h-4 w-4" aria-hidden="true" />
+              {copyStatus.success
+                ? `${copyStatus.kind === 'embed' ? 'Embed code' : 'Widget link'} copied.`
+                : `Unable to copy ${copyStatus.kind === 'embed' ? 'embed code' : 'widget link'}. Select the field and copy manually.`}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function buildScoreboardWidgetUrl(teamId: string, baseUrl = getPublicBaseUrl()) {
+  const url = new URL('/widget-scoreboard.html', baseUrl);
+  url.searchParams.set('teamId', teamId);
+  return url.toString();
+}
+
+export function buildScoreboardWidgetEmbedCode(team: { id: string; name: string }, baseUrl?: string) {
+  const widgetUrl = buildScoreboardWidgetUrl(team.id, baseUrl);
+  const title = escapeHtmlAttribute(`${team.name || 'Team'} live scoreboard`);
+  return `<iframe src="${escapeHtmlAttribute(widgetUrl)}" title="${title}" style="width: 100%; max-width: 720px; height: 480px; border: 0;" loading="lazy"></iframe>`;
+}
+
+function getPublicBaseUrl() {
+  if (typeof window !== 'undefined' && /^https?:$/i.test(window.location.protocol)) {
+    return window.location.origin;
+  }
+  return 'https://allplays.ai';
+}
+
+function escapeHtmlAttribute(value: string) {
+  return String(value || '').replace(/[&<>"]/g, (char) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[char] || char));
 }
 
 function StaffPermissionsCard({ model }: { model: TeamDetailModel }) {

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -373,6 +373,9 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
             contentType: 'application/javascript',
             body: `
                 export async function openPublicUrl() {}
+                export async function copyPublicText() {
+                    return 'copied';
+                }
                 export async function sharePublicUrl() {
                     return 'shared';
                 }

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -67,6 +67,10 @@ async function mockParentToolsModules(page) {
                 export async function openPublicUrl(url) {
                     window.__openedPublicUrls.push(String(url));
                 }
+                export async function copyPublicText(value) {
+                    window.__copiedText = String(value);
+                    return 'copied';
+                }
                 export async function sharePublicUrl(input) {
                     window.__sharedUrls.push(input);
                     return 'shared';

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -52,6 +52,9 @@ async function mockSearchModules(page) {
                 export async function openPublicUrl(url) {
                     window.__openedPublicUrls.push(String(url));
                 }
+                export async function copyPublicText() {
+                    return 'copied';
+                }
                 export async function sharePublicUrl() {
                     return 'shared';
                 }

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -56,6 +56,9 @@ async function mockTeamsModules(page) {
                 export async function openPublicUrl(url) {
                     window.__openedPublicUrls.push(String(url));
                 }
+                export async function copyPublicText() {
+                    return 'copied';
+                }
                 export async function sharePublicUrl() {
                     return 'shared';
                 }

--- a/tests/unit/app-public-actions.test.js
+++ b/tests/unit/app-public-actions.test.js
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const nativeState = vi.hoisted(() => ({
@@ -106,6 +107,26 @@ describe('React app public URL actions', () => {
 
         expect(result).toBe('copied');
         expect(writeText).toHaveBeenCalledWith('Bears vs Falcons · May 21\nhttps://allplays.ai/game.html#teamId=team-1&gameId=game-1');
+    });
+
+    it('copies public text with clipboard and textarea fallback paths', async () => {
+        const { copyPublicText } = await loadPublicActions();
+        const writeText = vi.fn().mockResolvedValue(undefined);
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: { writeText }
+        });
+
+        await expect(copyPublicText('<iframe src="https://allplays.ai/widget-scoreboard.html?teamId=team-1"></iframe>')).resolves.toBe('copied');
+        expect(writeText).toHaveBeenCalledWith('<iframe src="https://allplays.ai/widget-scoreboard.html?teamId=team-1"></iframe>');
+
+        Object.defineProperty(navigator, 'clipboard', {
+            configurable: true,
+            value: undefined
+        });
+        document.execCommand = vi.fn(() => true);
+        await expect(copyPublicText('https://allplays.ai/widget-scoreboard.html?teamId=team-1')).resolves.toBe('copied');
+        expect(document.execCommand).toHaveBeenCalledWith('copy');
     });
 
     it('falls back to web share for browser builds', async () => {

--- a/tests/unit/app-team-detail-integration.test.jsx
+++ b/tests/unit/app-team-detail-integration.test.jsx
@@ -8,6 +8,7 @@ const teamDetailMocks = vi.hoisted(() => ({
     loadParentTeamDetail: vi.fn()
 }));
 const publicActionMocks = vi.hoisted(() => ({
+    copyPublicText: vi.fn(),
     openPublicUrl: vi.fn()
 }));
 
@@ -16,7 +17,7 @@ vi.mock('../../apps/app/src/lib/teamDetailService.ts', () => ({
 }));
 vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionMocks);
 
-import { TeamDetail } from '../../apps/app/src/pages/TeamDetail.tsx';
+import { buildScoreboardWidgetEmbedCode, buildScoreboardWidgetUrl, TeamDetail } from '../../apps/app/src/pages/TeamDetail.tsx';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -89,6 +90,8 @@ function model() {
             items: [{ id: 'item-1', title: 'Bring ball', description: 'For warmups', isComplete: false }]
         }],
         sponsors: [{ id: 'sponsor-1', name: 'Pizza Place', description: 'After the game', imageUrl: 'https://img.example.test/pizza.png', websiteUrl: 'https://pizza.example.test' }],
+        canManageTeam: false,
+        staffPermissions: null,
         counts: { games: 8, practices: 3, completedGames: 7 }
     };
 }
@@ -149,6 +152,7 @@ beforeEach(() => {
         callback(0);
         return 0;
     };
+    publicActionMocks.copyPublicText.mockResolvedValue('copied');
     teamDetailMocks.loadParentTeamDetail.mockResolvedValue(model());
 });
 
@@ -157,6 +161,11 @@ afterEach(() => {
 });
 
 describe('React app TeamDetail page', () => {
+    it('builds scoreboard widget URL and iframe embed code', () => {
+        expect(buildScoreboardWidgetUrl('team 1/blue', 'https://club.example.test/app/')).toBe('https://club.example.test/widget-scoreboard.html?teamId=team+1%2Fblue');
+        expect(buildScoreboardWidgetEmbedCode({ id: 'team 1/blue', name: 'Bears & Wolves' }, 'https://club.example.test/app/')).toBe('<iframe src="https://club.example.test/widget-scoreboard.html?teamId=team+1%2Fblue" title="Bears &amp; Wolves live scoreboard" style="width: 100%; max-width: 720px; height: 480px; border: 0;" loading="lazy"></iframe>');
+    });
+
     it('loads parent-facing team.html features with team and player photos', async () => {
         const { container } = await renderTeamDetail();
 
@@ -191,6 +200,36 @@ describe('React app TeamDetail page', () => {
         expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://youtube.example.test/watch');
         await clickLink(container, 'Pizza Place');
         expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://pizza.example.test');
+    });
+
+    it('renders scoreboard widget copy tools only for managers', async () => {
+        const managerModel = model();
+        managerModel.canManageTeam = true;
+        managerModel.team.id = 'team 1/blue';
+        managerModel.team.name = 'Bears & Wolves';
+        teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(managerModel);
+
+        const { container } = await renderTeamDetail();
+
+        await clickButton(container, 'More');
+        expect(container.textContent).toContain('Scoreboard widget');
+        const expectedUrl = 'http://localhost:3000/widget-scoreboard.html?teamId=team+1%2Fblue';
+        const expectedEmbed = '<iframe src="http://localhost:3000/widget-scoreboard.html?teamId=team+1%2Fblue" title="Bears &amp; Wolves live scoreboard" style="width: 100%; max-width: 720px; height: 480px; border: 0;" loading="lazy"></iframe>';
+        expect(container.querySelector('#scoreboard-widget-embed').value).toBe(expectedEmbed);
+
+        await clickButton(container, 'Copy Embed Code');
+        expect(publicActionMocks.copyPublicText).toHaveBeenCalledWith(expectedEmbed);
+        expect(container.textContent).toContain('Embed code copied.');
+
+        await clickButton(container, 'Copy Link');
+        expect(publicActionMocks.copyPublicText).toHaveBeenCalledWith(expectedUrl);
+        expect(container.textContent).toContain('Widget link copied.');
+
+        const parentModel = model();
+        teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(parentModel);
+        const hidden = await renderTeamDetail();
+        await clickButton(hidden.container, 'More');
+        expect(hidden.container.textContent).not.toContain('Scoreboard widget');
     });
 
     it('exposes schedule, parent action links, and recent scores', async () => {

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -79,6 +79,7 @@ describe('React app team detail model', () => {
         expect(model.leaderboards[0].leaders[0]).toMatchObject({ playerId: 'player-1', formattedValue: '88' });
         expect(model.trackingSummaries[0].items[0]).toMatchObject({ title: 'Bring ball', isComplete: true });
         expect(model.sponsors[0].imageUrl).toBe('https://img.example.test/pizza.png');
+        expect(model.canManageTeam).toBe(false);
     });
 
     it('normalizes edge cases for linked players, events, streams, registration, and sponsors', () => {
@@ -165,6 +166,7 @@ describe('React app team detail model', () => {
             ]
         });
 
+        expect(adminModel.canManageTeam).toBe(true);
         expect(adminModel.staffPermissions.staff).toEqual([
             { label: 'owner@example.com', role: 'Owner' },
             { label: 'coach@example.com', role: 'Admin' }
@@ -182,6 +184,7 @@ describe('React app team detail model', () => {
             team,
             user: { uid: 'parent-1', email: 'parent@example.com', displayName: 'Parent', roles: ['parent'] }
         });
+        expect(parentModel.canManageTeam).toBe(false);
         expect(parentModel.staffPermissions).toBeNull();
     });
 


### PR DESCRIPTION
Closes #1496

## Summary
- Added a manager-only Scoreboard widget card on React TeamDetail More.
- Builds the public widget URL and iframe embed snippet using the current public origin, matching legacy dimensions and lazy loading.
- Added shared copy-to-clipboard behavior with textarea fallback for web and Capacitor WebViews.

## Validation
- `npx vitest run tests/unit/app-team-detail-integration.test.jsx tests/unit/app-team-detail-service.test.js tests/unit/app-public-actions.test.js --reporter=verbose`
- `npm run app:build`