### PR TITLE
Keep zero-stat DNP players unappeared

### DIFF
--- a/js/track-finish.js
+++ b/js/track-finish.js
@@ -33,16 +33,15 @@ export function buildNormalizedPlayerStats(playerStats = {}, columns = []) {
     return normalizedStats;
 }
 
-function hasTrackedPlayerActivity(playerStats = {}, normalizedStats = {}, includeTimeMs = false, hasPlayerStatsRecord = false) {
+function hasTrackedPlayerActivity(playerStats = {}, normalizedStats = {}, includeTimeMs = false) {
     const hasStatActivity = Object.entries(normalizedStats || {}).some(([key, value]) => {
         if (includeTimeMs && String(key).toLowerCase() === 'time') return false;
         return Number(value) !== 0;
     });
 
     if (hasStatActivity) return true;
-    if (!includeTimeMs) return hasPlayerStatsRecord;
 
-    return (Number(playerStats.time) || 0) > 0;
+    return includeTimeMs && (Number(playerStats.time) || 0) > 0;
 }
 
 export function buildAggregatedStatsWrites({ players = [], playerStatsByPlayerId = {}, columns = [], statTrackerConfig = {}, includeTimeMs = false } = {}) {
@@ -56,7 +55,7 @@ export function buildAggregatedStatsWrites({ players = [], playerStatsByPlayerId
         const playerStats = hasPlayerStatsRecord ? safeStatsByPlayerId[player.id] || {} : {};
 
         const normalizedStats = buildNormalizedPlayerStats(playerStats, columns);
-        const playerAppeared = hasTrackedPlayerActivity(playerStats, normalizedStats, includeTimeMs, hasPlayerStatsRecord);
+        const playerAppeared = hasTrackedPlayerActivity(playerStats, normalizedStats, includeTimeMs);
         // If we are including timeMs, ensure the internal 'time' accumulator is not persisted as a stat.
         if (includeTimeMs && normalizedStats.time !== undefined) {
             delete normalizedStats.time;

--- a/tests/unit/track-finish-batch-limit.test.js
+++ b/tests/unit/track-finish-batch-limit.test.js
@@ -123,7 +123,7 @@ describe('standard tracker finish batch limits', () => {
         ]);
     });
 
-    it('marks untouched standard tracker roster players as did not appear', async () => {
+    it('keeps zero-stat standard tracker records as did not appear on resave', async () => {
         const harness = createFirestoreHarness();
 
         await commitStandardTrackerFinishData({
@@ -168,12 +168,13 @@ describe('standard tracker finish batch limits', () => {
         expect(explicitZeroStatWrite.data).toEqual({
             playerName: 'Cam',
             playerNumber: '11',
-            participated: true,
-            participationStatus: 'appeared',
+            participated: false,
+            participationStatus: 'did-not-appear',
             participationSource: 'standard-tracker-finish',
+            didNotPlay: true,
             stats: { pts: 0, ast: 0 }
         });
-        expect(hasPlayerProfileParticipation(explicitZeroStatWrite.data)).toBe(true);
+        expect(hasPlayerProfileParticipation(explicitZeroStatWrite.data)).toBe(false);
     });
 
     it('writes private player stats to manager-only docs when finishing a standard tracker game', async () => {


### PR DESCRIPTION
Closes #1512

## Summary
- Stop treating the mere presence of a standard tracker aggregated stats record as player activity.
- Keep zero-stat players marked `did-not-appear` with `didNotPlay: true` when a completed game is re-saved.
- Preserve beta basketball time-based appearance behavior.

## Validation
- `npx vitest run tests/unit/track-finish-batch-limit.test.js --reporter=verbose`
- `npm test`
- `npm run app:build`