### PR TITLE
Add game hub lineup publish action

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -1406,6 +1406,7 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onGameCancel
   const isPractice = event.type === 'practice';
   const canUpdateScore = Boolean(!isPractice && event.isDbGame && !event.isCancelled && event.canUpdateScore && auth.user);
   const canCancelGame = Boolean(!isPractice && event.isDbGame && !event.isCancelled && event.canUpdateScore && auth.user);
+  const canPublishLineup = Boolean(!isPractice && event.isDbGame && event.isTeamStaff);
   const hubDestinations = isPractice ? buildPracticeHubDestinations(event) : buildGameHubDestinations(event);
 
   const cancelGame = async () => {
@@ -1477,7 +1478,7 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onGameCancel
 
           {canUpdateScore ? <LiveScoreEditor auth={auth} event={event} onScoreUpdated={onScoreUpdated} /> : null}
 
-          {!isPractice && event.isDbGame && event.canUpdateScore ? (
+          {canPublishLineup ? (
             <GameHubLineupPublishPanel auth={auth} event={event} onGamePlanPublished={onGamePlanPublished} />
           ) : null}
 

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -12,6 +12,7 @@ import {
   loadParentScheduleRideOffers,
   loadStaffRsvpReminderPreview,
   markParentPracticePacketComplete,
+  publishGamePlanForApp,
   releaseParentScheduleAssignmentClaim,
   requestParentScheduleRideSpot,
   sendStaffRsvpReminder,
@@ -26,6 +27,7 @@ import {
   type StaffRsvpReminderSendResult,
   type RideRequestChildInput
 } from '../lib/scheduleService';
+import { getLineupPublishStatus, hasLineupDraft } from '../lib/gameDayLineupPublish';
 import { loadGameReportSections, type GameReportData, type GameReportInsight, type GameReportPlay, type GameReportPlayerRow } from '../lib/gameReportService';
 import { openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 import {
@@ -201,6 +203,14 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
     )));
   }, [decodedEventId, decodedTeamId]);
 
+  const handleGamePlanPublished = useCallback((gamePlan: Record<string, any>) => {
+    setEvents((current) => current.map((event) => (
+      event.teamId === decodedTeamId && event.id === decodedEventId
+        ? { ...event, gamePlan }
+        : event
+    )));
+  }, [decodedEventId, decodedTeamId]);
+
   const canSubmitRsvp = Boolean(selectedEvent?.isDbGame && !selectedEvent.isCancelled && !selectedEvent.availabilityLocked);
 
   const submitRsvp = async (response: Exclude<RsvpResponse, 'not_responded'>) => {
@@ -364,7 +374,7 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
             onAssignmentsChanged={handleAssignmentsChanged}
           />
         ) : null}
-        {activeSection === 'game' ? <GameHubSection auth={auth} event={selectedEvent} childEvents={events} onScoreUpdated={handleScoreUpdated} onGameCancelled={handleGameCancelled} /> : null}
+        {activeSection === 'game' ? <GameHubSection auth={auth} event={selectedEvent} childEvents={events} onScoreUpdated={handleScoreUpdated} onGameCancelled={handleGameCancelled} onGamePlanPublished={handleGamePlanPublished} /> : null}
       </div>
     </div>
   );
@@ -1387,7 +1397,7 @@ function AssignmentCard({ assignment, userId, busy, disabled, onClaim, onRelease
   );
 }
 
-function GameHubSection({ auth, event, childEvents, onScoreUpdated, onGameCancelled }: { auth: AuthState; event: ParentScheduleEvent; childEvents: ParentScheduleEvent[]; onScoreUpdated: (homeScore: number, awayScore: number) => void; onGameCancelled: () => void }) {
+function GameHubSection({ auth, event, childEvents, onScoreUpdated, onGameCancelled, onGamePlanPublished }: { auth: AuthState; event: ParentScheduleEvent; childEvents: ParentScheduleEvent[]; onScoreUpdated: (homeScore: number, awayScore: number) => void; onGameCancelled: () => void; onGamePlanPublished: (gamePlan: Record<string, any>) => void }) {
   const [shareStatus, setShareStatus] = useState<string | null>(null);
   const [cancelStatus, setCancelStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
   const [cancelling, setCancelling] = useState(false);
@@ -1467,6 +1477,10 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onGameCancel
 
           {canUpdateScore ? <LiveScoreEditor auth={auth} event={event} onScoreUpdated={onScoreUpdated} /> : null}
 
+          {!isPractice && event.isDbGame && event.canUpdateScore ? (
+            <GameHubLineupPublishPanel auth={auth} event={event} onGamePlanPublished={onGamePlanPublished} />
+          ) : null}
+
           {canCancelGame ? (
             <div className="mt-3 rounded-2xl border border-rose-200 bg-rose-50 p-3">
               <div className="flex flex-wrap items-center justify-between gap-3">
@@ -1507,6 +1521,60 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onGameCancel
       {cancelStatus ? <Status tone={cancelStatus.tone} message={cancelStatus.message} /> : null}
       {!isPractice ? <GameReportSections event={event} /> : null}
     </section>
+  );
+}
+
+function GameHubLineupPublishPanel({ auth, event, onGamePlanPublished }: { auth: AuthState; event: ParentScheduleEvent; onGamePlanPublished: (gamePlan: Record<string, any>) => void }) {
+  const [publishing, setPublishing] = useState(false);
+  const [status, setStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
+  const hasDraft = hasLineupDraft(event.gamePlan);
+  const canPublish = Boolean(auth.user && hasDraft && !event.isCancelled);
+  const statusCopy = getLineupPublishStatus(event.gamePlan);
+  const disabledCopy = !auth.user
+    ? 'Sign in as a coach or admin to publish the lineup.'
+    : event.isCancelled
+      ? 'Cancelled games cannot publish lineup changes.'
+      : !hasDraft
+        ? 'Save a lineup draft before publishing.'
+        : null;
+
+  const publishLineup = async () => {
+    if (!auth.user || !canPublish) return;
+    setPublishing(true);
+    setStatus(null);
+    try {
+      const result = await publishGamePlanForApp(event, auth.user);
+      onGamePlanPublished(result.gamePlan);
+      const version = Number.parseInt(String(result.gamePlan?.publishedVersion || ''), 10) || 0;
+      setStatus(result.notificationError
+        ? { tone: 'error', message: `Lineup saved${version ? ` as v${version}` : ''}, but team chat notification failed: ${result.notificationError}` }
+        : { tone: 'success', message: `Lineup published${version ? ` as v${version}` : ''}. Team chat notified.` });
+    } catch (error: any) {
+      setStatus({ tone: 'error', message: error?.message || 'Unable to publish lineup.' });
+    } finally {
+      setPublishing(false);
+    }
+  };
+
+  return (
+    <div className="mt-3 rounded-2xl border border-primary-100 bg-primary-50/60 p-3">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-xs font-black uppercase tracking-[0.04em] text-primary-700">Lineup publish</div>
+          <div className="mt-1 text-sm font-semibold text-gray-950">{statusCopy}</div>
+          {disabledCopy ? <div className="mt-1 text-xs font-semibold text-gray-500">{disabledCopy}</div> : null}
+        </div>
+        <button
+          type="button"
+          className="min-h-11 rounded-full bg-primary-600 px-4 text-sm font-black text-white shadow-sm transition hover:bg-primary-700 disabled:opacity-60"
+          onClick={publishLineup}
+          disabled={!canPublish || publishing}
+        >
+          {publishing ? 'Publishing lineup' : 'Publish lineup'}
+        </button>
+      </div>
+      {status ? <div className={`mt-3 text-sm font-semibold ${status.tone === 'success' ? 'text-emerald-700' : 'text-amber-800'}`}>{status.message}</div> : null}
+    </div>
   );
 }
 

--- a/docs/pr-notes/runs/1520-remediator-20260528T173712Z/architecture.md
+++ b/docs/pr-notes/runs/1520-remediator-20260528T173712Z/architecture.md
@@ -1,0 +1,10 @@
+# Architecture
+
+Architecture Decisions
+- Keep scorekeeping and lineup publishing permissions separate in the UI.
+- Continue using `event.canUpdateScore` for score editing and cancellation controls.
+- Gate the lineup publish panel with `event.isTeamStaff === true`, matching the server-side write authority for `gamePlan`.
+
+Risks And Rollback
+- Risk is limited to visibility of one Game hub panel.
+- Rollback is a single conditional/test revert if product decides scorekeepers should receive explicit staff promotion messaging instead.

--- a/docs/pr-notes/runs/1520-remediator-20260528T173712Z/code-plan.md
+++ b/docs/pr-notes/runs/1520-remediator-20260528T173712Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code Plan
+
+Implementation Plan
+- In `ScheduleEventDetail.tsx`, introduce a staff-only `canPublishLineup` condition using `event.isTeamStaff` and render `GameHubLineupPublishPanel` only with that flag.
+- In `tests/unit/app-schedule-more-tab-integration.test.jsx`, update lineup publish setup data for staff tests and add the non-staff scorekeeper regression.
+- Validate with focused unit tests and available app validation commands.

--- a/docs/pr-notes/runs/1520-remediator-20260528T173712Z/qa.md
+++ b/docs/pr-notes/runs/1520-remediator-20260528T173712Z/qa.md
@@ -1,0 +1,5 @@
+# QA Plan
+
+- Add regression coverage where `canUpdateScore: true` and `isTeamStaff: false`; verify live score is visible and lineup publish is hidden.
+- Update existing staff lineup publish tests to set `isTeamStaff: true` explicitly.
+- Run the focused Vitest file, then the unit test suite if feasible.

--- a/docs/pr-notes/runs/1520-remediator-20260528T173712Z/requirements.md
+++ b/docs/pr-notes/runs/1520-remediator-20260528T173712Z/requirements.md
@@ -1,0 +1,10 @@
+# Requirements
+
+Acceptance Criteria
+- Lineup publish panel is visible only to team staff/admin for database-backed games.
+- Non-staff scorekeepers with `canUpdateScore` keep live score controls but do not see staff-only lineup publish controls.
+- Staff with a lineup draft can publish as before; staff without a draft sees the disabled publish action and draft guidance.
+
+Edge Cases
+- Read-only viewers see neither score controls nor lineup publish controls.
+- Cancelled game publish remains disabled inside the staff-only panel if rendered for staff.

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -311,6 +311,19 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
                     return { status: 'cancelled', isCancelled: true };
                 }
 
+                export async function publishGamePlanForApp(event) {
+                    return {
+                        gamePlan: {
+                            ...(event?.gamePlan || {}),
+                            isPublished: true,
+                            publishedVersion: 1,
+                            publishedLineups: event?.gamePlan?.lineups || {},
+                            publishedReadBy: []
+                        },
+                        notificationError: ''
+                    };
+                }
+
                 export async function createParentScheduleRideOffer() {}
                 export async function requestParentScheduleRideSpot() {}
                 export async function cancelParentScheduleRideRequest() {}

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -292,6 +292,19 @@ async function mockScheduleModules(page, options = {}) {
                     return { status: 'cancelled', isCancelled: true };
                 }
 
+                export async function publishGamePlanForApp(event, user) {
+                    const version = Number.parseInt(String(event?.gamePlan?.publishedVersion || ''), 10) || 0;
+                    const gamePlan = {
+                        ...(event?.gamePlan || {}),
+                        isPublished: true,
+                        publishedVersion: version + 1,
+                        publishedLineups: event?.gamePlan?.lineups || {},
+                        publishedReadBy: []
+                    };
+                    window.__scheduleCalls.lineupPublishes = (window.__scheduleCalls.lineupPublishes || []).concat({ eventId: event?.id || null, userId: user?.uid || null });
+                    return { gamePlan, notificationError: '' };
+                }
+
                 export async function loadParentPracticePacket(event, childEvents) {
                     window.__scheduleCalls.packets.push({ action: 'load', eventId: event.id, sessionId: event.practiceSessionId });
                     if (!event.practiceHomePacket) return null;

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -33,7 +33,7 @@ function event(overrides = {}) {
         teamId: overrides.teamId || 'team-1',
         teamName: overrides.teamName || 'Bears',
         type: overrides.type || 'game',
-        date: overrides.date || new Date('2030-05-28T18:00:00Z'),
+        date: overrides.date || new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
         location: overrides.location || 'Main Gym',
         opponent: overrides.opponent || 'Falcons',
         title: overrides.title || null,

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -13,6 +13,7 @@ const scheduleMocks = vi.hoisted(() => ({
     loadParentScheduleAssignments: vi.fn().mockResolvedValue([]),
     loadParentScheduleRideOffers: vi.fn().mockResolvedValue([]),
     markParentPracticePacketComplete: vi.fn(),
+    publishGamePlanForApp: vi.fn(),
     releaseParentScheduleAssignmentClaim: vi.fn(),
     requestParentScheduleRideSpot: vi.fn(),
     setParentScheduleRideOfferStatus: vi.fn(),
@@ -148,6 +149,7 @@ beforeEach(() => {
     vi.clearAllMocks();
     scheduleMocks.loadParentSchedule.mockResolvedValue({ events: [] });
     scheduleMocks.loadParentPracticePacket.mockResolvedValue(null);
+    scheduleMocks.publishGamePlanForApp.mockResolvedValue({ gamePlan: {}, notificationError: null });
     scheduleMocks.updateGameScore.mockResolvedValue({ homeScore: 5, awayScore: 2, scoreUpdatedAt: new Date('2026-05-25T08:00:00Z'), scoreUpdatedBy: 'user-1' });
     scheduleMocks.markParentPracticePacketComplete.mockResolvedValue({
         id: 'user-1__player-1',
@@ -389,6 +391,56 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         expect(container.textContent).toContain('4-2');
         expect(container.textContent).not.toContain('Live score');
         expect(container.textContent).not.toContain('Save score');
+        expect(container.textContent).not.toContain('Lineup publish');
+    });
+
+    it('shows lineup publish status and disables publish when staff has no draft', async () => {
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            events: [event({ canUpdateScore: true, gamePlan: { lineups: {} } })]
+        });
+
+        const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1');
+        await waitForText(container, 'vs. Falcons');
+        await clickButton(container, 'Game');
+        await waitForText(container, 'Lineup publish');
+
+        expect(container.textContent).toContain('No lineup draft is available yet.');
+        expect(container.textContent).toContain('Save a lineup draft before publishing.');
+        expect(buttonByText(container, 'Publish lineup').disabled).toBe(true);
+    });
+
+    it('publishes a lineup draft once and updates the visible status without reloading', async () => {
+        const draftGamePlan = {
+            lineups: { 'H1-keeper': 'p1' },
+            publishedVersion: 1,
+            publishedLineups: { 'H1-keeper': 'p9' }
+        };
+        const publishedGamePlan = {
+            ...draftGamePlan,
+            isPublished: true,
+            publishedVersion: 2,
+            publishedLineups: { 'H1-keeper': 'p1' },
+            publishedReadBy: []
+        };
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            events: [event({ canUpdateScore: true, gamePlan: draftGamePlan })]
+        });
+        scheduleMocks.publishGamePlanForApp.mockResolvedValue({
+            gamePlan: publishedGamePlan,
+            notificationError: 'Chat offline'
+        });
+
+        const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1');
+        await waitForText(container, 'vs. Falcons');
+        await clickButton(container, 'Game');
+        await waitForText(container, 'Published v1. 1 draft assignment unpublished.');
+
+        await clickButton(container, 'Publish lineup');
+
+        expect(scheduleMocks.publishGamePlanForApp).toHaveBeenCalledTimes(1);
+        expect(scheduleMocks.publishGamePlanForApp).toHaveBeenCalledWith(expect.objectContaining({ id: 'game-1' }), auth.user);
+        await waitForText(container, 'Published v2. Current draft matches the published lineup.');
+        expect(container.textContent).toContain('Lineup saved as v2, but team chat notification failed: Chat offline');
     });
 
     it('leaves edited scores visible when saving the live score fails', async () => {

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -394,9 +394,28 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         expect(container.textContent).not.toContain('Lineup publish');
     });
 
+    it('keeps lineup publish controls hidden for non-staff scorekeepers', async () => {
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            events: [event({
+                canUpdateScore: true,
+                isTeamStaff: false,
+                gamePlan: { lineups: { 'H1-keeper': 'p1' } }
+            })]
+        });
+
+        const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1');
+        await waitForText(container, 'vs. Falcons');
+        await clickButton(container, 'Game');
+        await waitForText(container, 'Live score');
+
+        expect(container.textContent).toContain('Live score');
+        expect(container.textContent).not.toContain('Lineup publish');
+        expect(container.textContent).not.toContain('Publish lineup');
+    });
+
     it('shows lineup publish status and disables publish when staff has no draft', async () => {
         scheduleMocks.loadParentSchedule.mockResolvedValue({
-            events: [event({ canUpdateScore: true, gamePlan: { lineups: {} } })]
+            events: [event({ canUpdateScore: true, isTeamStaff: true, gamePlan: { lineups: {} } })]
         });
 
         const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1');
@@ -423,7 +442,7 @@ describe('React app ScheduleEventDetail More tab integration', () => {
             publishedReadBy: []
         };
         scheduleMocks.loadParentSchedule.mockResolvedValue({
-            events: [event({ canUpdateScore: true, gamePlan: draftGamePlan })]
+            events: [event({ canUpdateScore: true, isTeamStaff: true, gamePlan: draftGamePlan })]
         });
         scheduleMocks.publishGamePlanForApp.mockResolvedValue({
             gamePlan: publishedGamePlan,


### PR DESCRIPTION
Closes #1519

## Summary
- Adds a coach/admin-only lineup publish panel to the React game hub.
- Reuses existing publishGamePlanForApp plus lineup publish status helpers.
- Updates local event gamePlan after publish so status changes without reload.
- Surfaces partial success when lineup saves but team chat notification fails.

## Validation
- `npx vitest run tests/unit/app-schedule-more-tab-integration.test.jsx tests/unit/game-day-lineup-publish.test.js --reporter=verbose`
- `npm test`
- `npm run app:build`
- Android Gradle attempted with `./gradlew :app:testDebugUnitTest :app:assembleDebug`, blocked by missing Android SDK / ANDROID_HOME on this host.