### PR TITLE
Fix team fee online payment eligibility

### DIFF
--- a/docs/pr-notes/runs/1529-remediator-20260528T194610Z/architecture.md
+++ b/docs/pr-notes/runs/1529-remediator-20260528T194610Z/architecture.md
@@ -1,0 +1,6 @@
+# Architecture
+
+- Keep eligibility local to TeamFeesComponent mapping and avoid widening the change.
+- Add a small balance helper that mirrors the callable's getTeamFeeBalanceCents fallback behavior for the fields used by fee recipients.
+- Continue to treat explicit balanceDueCents / remainingBalanceCents as authoritative, matching the server helper.
+- Blast radius is limited to displaying/hiding the parent checkout button; checkout service behavior is unchanged.

--- a/docs/pr-notes/runs/1529-remediator-20260528T194610Z/code-plan.md
+++ b/docs/pr-notes/runs/1529-remediator-20260528T194610Z/code-plan.md
@@ -1,0 +1,6 @@
+# Code Plan
+
+- Extend FeeRecipientData with server-compatible balance/paid amount fields.
+- Add getFeeBalanceCents helper and require balanceCents > 0 in canPayOnline.
+- Update team-fees component spec with a regression test that fails before the eligibility change.
+- Commit only scoped remediation files plus role notes.

--- a/docs/pr-notes/runs/1529-remediator-20260528T194610Z/qa.md
+++ b/docs/pr-notes/runs/1529-remediator-20260528T194610Z/qa.md
@@ -1,0 +1,5 @@
+# QA
+
+- Add regression coverage for online Stripe fee recipients with amountCents = 0 and with paidAmountCents equal to amountCents.
+- Expected result: both remain visible as fee rows but canPayOnline is false, so the template does not expose checkout for them.
+- Validation: run the focused TeamFeesComponent Vitest spec, then repository app validation where feasible.

--- a/docs/pr-notes/runs/1529-remediator-20260528T194610Z/requirements.md
+++ b/docs/pr-notes/runs/1529-remediator-20260528T194610Z/requirements.md
@@ -1,0 +1,6 @@
+# Requirements
+
+- Feedback thread PRRT_kwDOQe-T586FfZeD is actionable.
+- Parent fee checkout affordance must match backend eligibility: online Stripe collection, not paid, not canceled, valid identifiers, and positive remaining balance.
+- A zero amount recipient must not show Pay Team Fee.
+- A recipient with total amount fully covered by paidAmountCents must not show Pay Team Fee when no explicit positive balance remains.

--- a/src/app/team-fees/team-fees.component.html
+++ b/src/app/team-fees/team-fees.component.html
@@ -13,9 +13,10 @@
     <div *ngFor="let fee of teamFees" class="team-fee-item">
       <h3>{{ fee.name }}</h3>
       <p>Amount: {{ fee.amount | currency }}</p>
-      <p>Status: <span [class.paid]="fee.isPaid" [class.unpaid]="!fee.isPaid">{{ fee.isPaid ? 'Paid' : 'Unpaid' }}</span></p>
+      <p>Status: <span [class.paid]="fee.isPaid" [class.unpaid]="!fee.isPaid && fee.status !== 'canceled'">{{ fee.status === 'canceled' ? 'Canceled' : fee.isPaid ? 'Paid' : 'Unpaid' }}</span></p>
+      <p *ngIf="!fee.canPayOnline && !fee.isPaid && fee.status !== 'canceled' && fee.offlinePaymentInstructions" class="offline-payment-instructions">{{ fee.offlinePaymentInstructions }}</p>
 
-      <button *ngIf="!fee.isPaid" (click)="handlePayFee(fee)" [disabled]="isPaymentPending()">
+      <button *ngIf="fee.canPayOnline" (click)="handlePayFee(fee)" [disabled]="isPaymentPending()">
         <span *ngIf="!isPaymentLoading(fee.id)">Pay Team Fee</span>
         <span *ngIf="isPaymentLoading(fee.id)">Initiating Payment...</span>
       </button>

--- a/src/app/team-fees/team-fees.component.spec.ts
+++ b/src/app/team-fees/team-fees.component.spec.ts
@@ -261,6 +261,35 @@ describe('TeamFeesComponent checkout flow', () => {
     });
   });
 
+  it('hides checkout for online Stripe fees without a positive remaining balance', async () => {
+    const zeroAmountFee = feeDoc('teams/team-real/feeBatches/batch-zero/feeRecipients/recipient-zero', 'recipient-zero', {
+      parentUserId: 'parent-123',
+      title: 'Zero registration',
+      amountCents: 0,
+      status: 'unpaid',
+      collectionMode: 'online_stripe'
+    });
+    const fullyPaidFee = feeDoc('teams/team-real/feeBatches/batch-paid/feeRecipients/recipient-paid', 'recipient-paid', {
+      parentUserId: 'parent-123',
+      title: 'Fully paid registration',
+      amountCents: 12500,
+      paidAmountCents: 12500,
+      status: 'unpaid',
+      collectionMode: 'online_stripe'
+    });
+    mockGetDocs
+      .mockResolvedValueOnce({ docs: [zeroAmountFee, fullyPaidFee] })
+      .mockResolvedValueOnce({ docs: [] })
+      .mockResolvedValueOnce({ docs: [] });
+
+    await component.ngOnInit();
+
+    expect(component.teamFees.map((fee) => ({ id: fee.id, canPayOnline: fee.canPayOnline }))).toEqual([
+      { id: 'recipient-zero', canPayOnline: false },
+      { id: 'recipient-paid', canPayOnline: false }
+    ]);
+  });
+
   it('maps unpaid offline manual fees without a pay action and keeps offline instructions', async () => {
     const offlineFee = feeDoc('teams/team-real/feeBatches/batch-real/feeRecipients/recipient-offline', 'recipient-offline', {
       parentUserId: 'parent-123',

--- a/src/app/team-fees/team-fees.component.spec.ts
+++ b/src/app/team-fees/team-fees.component.spec.ts
@@ -101,7 +101,11 @@ describe('TeamFeesComponent checkout flow', () => {
         recipientId: 'recipient-real',
         name: 'Spring registration',
         amount: 125,
-        isPaid: false
+        status: 'unpaid',
+        isPaid: false,
+        collectionMode: '',
+        canPayOnline: false,
+        offlinePaymentInstructions: ''
       },
       {
         id: 'recipient-paid',
@@ -110,7 +114,11 @@ describe('TeamFeesComponent checkout flow', () => {
         recipientId: 'recipient-paid',
         name: 'Uniform fee',
         amount: 50,
-        isPaid: true
+        status: 'paid',
+        isPaid: true,
+        collectionMode: '',
+        canPayOnline: false,
+        offlinePaymentInstructions: ''
       }
     ]);
     expect(component.isLoadingFees).toBe(false);
@@ -138,7 +146,11 @@ describe('TeamFeesComponent checkout flow', () => {
         recipientId: 'recipient-real',
         name: 'Spring registration',
         amount: 125,
-        isPaid: false
+        status: 'unpaid',
+        isPaid: false,
+        collectionMode: '',
+        canPayOnline: false,
+        offlinePaymentInstructions: ''
       }
     ]);
   });
@@ -176,7 +188,11 @@ describe('TeamFeesComponent checkout flow', () => {
         recipientId: 'player-real',
         name: 'Roster fee',
         amount: 75,
-        isPaid: false
+        status: 'unpaid',
+        isPaid: false,
+        collectionMode: '',
+        canPayOnline: false,
+        offlinePaymentInstructions: ''
       }
     ]);
   });
@@ -212,20 +228,101 @@ describe('TeamFeesComponent checkout flow', () => {
     expect(template).toContain('*ngIf="isLoadingFees; else feesReady"');
   });
 
-  it('renders a Pay Team Fee button only for unpaid fees', async () => {
+  it('renders a Pay Team Fee button only for unpaid online Stripe fees', async () => {
     mockGetDocs.mockResolvedValueOnce({
       docs: [feeDoc('teams/team-real/feeBatches/batch-real/feeRecipients/recipient-real', 'recipient-real', {
         title: 'Spring registration',
         balanceDueCents: 12500,
-        status: 'unpaid'
+        status: 'unpaid',
+        collectionMode: 'online_stripe'
       })]
     });
 
     await component.ngOnInit();
 
-    expect(template).toContain('*ngIf="!fee.isPaid"');
+    expect(template).toContain('*ngIf="fee.canPayOnline"');
     expect(template).toContain('Pay Team Fee');
-    expect(component.teamFees.filter((fee) => !fee.isPaid)).toHaveLength(1);
+    expect(component.teamFees.filter((fee) => fee.canPayOnline)).toHaveLength(1);
+
+    const originalWindow = globalThis.window;
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: { location: { href: 'https://allplays.test/team-fees' } }
+    });
+
+    await component.handlePayFee(component.teamFees[0]);
+
+    expect(stripeService.initiateTeamFeeCheckout).toHaveBeenCalledWith('team-real', 'batch-real', 'recipient-real');
+    expect(globalThis.window.location.href).toBe('https://checkout.stripe.com/team-fee-session');
+
+    Object.defineProperty(globalThis, 'window', {
+      configurable: true,
+      value: originalWindow
+    });
+  });
+
+  it('maps unpaid offline manual fees without a pay action and keeps offline instructions', async () => {
+    const offlineFee = feeDoc('teams/team-real/feeBatches/batch-real/feeRecipients/recipient-offline', 'recipient-offline', {
+      parentUserId: 'parent-123',
+      title: 'Cash registration',
+      balanceDueCents: 6500,
+      status: 'unpaid',
+      collectionMode: 'offline_manual',
+      offlinePaymentInstructions: 'Bring cash or check to practice.'
+    });
+    mockGetDocs
+      .mockResolvedValueOnce({ docs: [offlineFee] })
+      .mockResolvedValueOnce({ docs: [] })
+      .mockResolvedValueOnce({ docs: [] });
+
+    await component.ngOnInit();
+
+    expect(template).toContain('offline-payment-instructions');
+    expect(template).toContain('fee.offlinePaymentInstructions');
+    expect(template).toContain('*ngIf="fee.canPayOnline"');
+    expect(component.teamFees).toEqual([
+      {
+        id: 'recipient-offline',
+        teamId: 'team-real',
+        batchId: 'batch-real',
+        recipientId: 'recipient-offline',
+        name: 'Cash registration',
+        amount: 65,
+        status: 'unpaid',
+        isPaid: false,
+        collectionMode: 'offline_manual',
+        canPayOnline: false,
+        offlinePaymentInstructions: 'Bring cash or check to practice.'
+      }
+    ]);
+  });
+
+  it('does not allow paid or canceled fees to start checkout regardless of collection mode', async () => {
+    const paidFee = feeDoc('teams/team-real/feeBatches/batch-paid/feeRecipients/recipient-paid', 'recipient-paid', {
+      parentUserId: 'parent-123',
+      title: 'Paid registration',
+      balanceDueCents: 0,
+      status: 'paid',
+      collectionMode: 'online_stripe'
+    });
+    const canceledFee = feeDoc('teams/team-real/feeBatches/batch-canceled/feeRecipients/recipient-canceled', 'recipient-canceled', {
+      parentUserId: 'parent-123',
+      title: 'Canceled registration',
+      balanceDueCents: 6500,
+      status: 'canceled',
+      collectionMode: 'online_stripe'
+    });
+    mockGetDocs
+      .mockResolvedValueOnce({ docs: [paidFee, canceledFee] })
+      .mockResolvedValueOnce({ docs: [] })
+      .mockResolvedValueOnce({ docs: [] });
+
+    await component.ngOnInit();
+
+    expect(component.teamFees.map((fee) => ({ id: fee.id, status: fee.status, canPayOnline: fee.canPayOnline }))).toEqual([
+      { id: 'recipient-paid', status: 'paid', canPayOnline: false },
+      { id: 'recipient-canceled', status: 'canceled', canPayOnline: false }
+    ]);
   });
 
   it('passes the selected fee recipient IDs to StripeService before redirecting', async () => {
@@ -236,7 +333,11 @@ describe('TeamFeesComponent checkout flow', () => {
       recipientId: 'recipient-real',
       name: 'Spring registration',
       amount: 125,
-      isPaid: false
+      status: 'unpaid',
+      isPaid: false,
+      collectionMode: 'online_stripe',
+      canPayOnline: true,
+      offlinePaymentInstructions: ''
     };
     component.teamFees = [selectedFee];
 
@@ -262,8 +363,8 @@ describe('TeamFeesComponent checkout flow', () => {
   });
 
   it('scopes the initiating payment state to the selected unpaid fee', async () => {
-    const selectedFee = { id: 'recipient-real', teamId: 'team-real', batchId: 'batch-real', recipientId: 'recipient-real', name: 'Registration', amount: 125, isPaid: false };
-    const otherUnpaidFee = { id: 'recipient-other', teamId: 'team-real', batchId: 'batch-other', recipientId: 'recipient-other', name: 'Tournament', amount: 75, isPaid: false };
+    const selectedFee = { id: 'recipient-real', teamId: 'team-real', batchId: 'batch-real', recipientId: 'recipient-real', name: 'Registration', amount: 125, status: 'unpaid', isPaid: false, collectionMode: 'online_stripe', canPayOnline: true, offlinePaymentInstructions: '' };
+    const otherUnpaidFee = { id: 'recipient-other', teamId: 'team-real', batchId: 'batch-other', recipientId: 'recipient-other', name: 'Tournament', amount: 75, status: 'unpaid', isPaid: false, collectionMode: 'online_stripe', canPayOnline: true, offlinePaymentInstructions: '' };
     let resolveCheckout: (checkoutUrl: string) => void = () => undefined;
     stripeService.initiateTeamFeeCheckout.mockReturnValue(new Promise((resolve) => {
       resolveCheckout = resolve;
@@ -297,8 +398,8 @@ describe('TeamFeesComponent checkout flow', () => {
   });
 
   it('ignores overlapping checkout attempts while another fee payment is pending', async () => {
-    const selectedFee = { id: 'recipient-real', teamId: 'team-real', batchId: 'batch-real', recipientId: 'recipient-real', name: 'Registration', amount: 125, isPaid: false };
-    const otherUnpaidFee = { id: 'recipient-other', teamId: 'team-real', batchId: 'batch-other', recipientId: 'recipient-other', name: 'Tournament', amount: 75, isPaid: false };
+    const selectedFee = { id: 'recipient-real', teamId: 'team-real', batchId: 'batch-real', recipientId: 'recipient-real', name: 'Registration', amount: 125, status: 'unpaid', isPaid: false, collectionMode: 'online_stripe', canPayOnline: true, offlinePaymentInstructions: '' };
+    const otherUnpaidFee = { id: 'recipient-other', teamId: 'team-real', batchId: 'batch-other', recipientId: 'recipient-other', name: 'Tournament', amount: 75, status: 'unpaid', isPaid: false, collectionMode: 'online_stripe', canPayOnline: true, offlinePaymentInstructions: '' };
     let resolveCheckout: (checkoutUrl: string) => void = () => undefined;
     stripeService.initiateTeamFeeCheckout.mockReturnValue(new Promise((resolve) => {
       resolveCheckout = resolve;
@@ -332,8 +433,8 @@ describe('TeamFeesComponent checkout flow', () => {
   });
 
   it('resets only the selected fee loading state and shows the existing error on checkout failure', async () => {
-    const selectedFee = { id: 'recipient-real', teamId: 'team-real', batchId: 'batch-real', recipientId: 'recipient-real', name: 'Registration', amount: 125, isPaid: false };
-    const otherUnpaidFee = { id: 'recipient-other', teamId: 'team-real', batchId: 'batch-other', recipientId: 'recipient-other', name: 'Tournament', amount: 75, isPaid: false };
+    const selectedFee = { id: 'recipient-real', teamId: 'team-real', batchId: 'batch-real', recipientId: 'recipient-real', name: 'Registration', amount: 125, status: 'unpaid', isPaid: false, collectionMode: 'online_stripe', canPayOnline: true, offlinePaymentInstructions: '' };
+    const otherUnpaidFee = { id: 'recipient-other', teamId: 'team-real', batchId: 'batch-other', recipientId: 'recipient-other', name: 'Tournament', amount: 75, status: 'unpaid', isPaid: false, collectionMode: 'online_stripe', canPayOnline: true, offlinePaymentInstructions: '' };
     stripeService.initiateTeamFeeCheckout.mockRejectedValue(new Error('Stripe unavailable'));
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 

--- a/src/app/team-fees/team-fees.component.ts
+++ b/src/app/team-fees/team-fees.component.ts
@@ -13,7 +13,11 @@ interface TeamFee {
   recipientId: string;
   name: string;
   amount: number;
+  status: string;
   isPaid: boolean;
+  collectionMode: string;
+  canPayOnline: boolean;
+  offlinePaymentInstructions: string;
 }
 
 type ParentPlayerLink = {
@@ -34,6 +38,11 @@ type FeeRecipientData = {
   amountCents?: number;
   balanceDueCents?: number;
   status?: string;
+  collectionMode?: string;
+  offlinePaymentInstructions?: string;
+  paymentInstructions?: string;
+  manualPaymentInstructions?: string;
+  offlineInstructions?: string;
   paid?: boolean;
   isPaid?: boolean;
   teamId?: string;
@@ -92,11 +101,37 @@ function normalizeAmount(data: FeeRecipientData): number {
   return 0;
 }
 
+function getFeeStatus(data: FeeRecipientData): string {
+  return String(data.status || '').toLowerCase();
+}
+
 function isFeePaid(data: FeeRecipientData): boolean {
-  const status = String(data.status || '').toLowerCase();
+  const status = getFeeStatus(data);
   if (status === 'paid') return true;
   if (data.paid === true || data.isPaid === true) return true;
   return typeof data.balanceDueCents === 'number' && data.balanceDueCents <= 0;
+}
+
+function isFeeCanceled(data: FeeRecipientData): boolean {
+  return ['canceled', 'cancelled'].includes(getFeeStatus(data));
+}
+
+function normalizeCollectionMode(data: FeeRecipientData): string {
+  return String(data.collectionMode || '').toLowerCase();
+}
+
+function isOnlineStripeCollectionMode(collectionMode: string): boolean {
+  return ['online_stripe', 'stripe', 'stripe_checkout', 'online'].includes(collectionMode);
+}
+
+function getOfflinePaymentInstructions(data: FeeRecipientData): string {
+  return String(
+    data.offlinePaymentInstructions
+    || data.paymentInstructions
+    || data.manualPaymentInstructions
+    || data.offlineInstructions
+    || ''
+  ).trim();
 }
 
 @Component({
@@ -199,6 +234,11 @@ export class TeamFeesComponent implements OnInit {
       const normalizedData = { ...data, teamId };
       if (parentPlayerKeys.size > 0 && !isAllowedParentFeeRecipient(normalizedData, userId, parentPlayerKeys)) return;
 
+      const collectionMode = normalizeCollectionMode(data);
+      const isPaid = isFeePaid(data);
+      const isCanceled = isFeeCanceled(data);
+      const canPayOnline = !isPaid && !isCanceled && isOnlineStripeCollectionMode(collectionMode) && Boolean(teamId && batchId && docSnap.id);
+
       feesByPath.set(docSnap.ref.path, {
         id: docSnap.id,
         teamId,
@@ -206,7 +246,11 @@ export class TeamFeesComponent implements OnInit {
         recipientId: docSnap.id,
         name: data.title || data.feeTitle || data.name || 'Team Fee',
         amount: normalizeAmount(data),
-        isPaid: isFeePaid(data)
+        status: isCanceled ? 'canceled' : isPaid ? 'paid' : 'unpaid',
+        isPaid,
+        collectionMode,
+        canPayOnline,
+        offlinePaymentInstructions: getOfflinePaymentInstructions(data)
       });
     });
 
@@ -232,7 +276,7 @@ export class TeamFeesComponent implements OnInit {
   }
 
   async handlePayFee(fee: TeamFee): Promise<void> {
-    if (this.isPaymentPending()) {
+    if (this.isPaymentPending() || !fee.canPayOnline) {
       return;
     }
 

--- a/src/app/team-fees/team-fees.component.ts
+++ b/src/app/team-fees/team-fees.component.ts
@@ -36,7 +36,15 @@ type FeeRecipientData = {
   name?: string;
   amount?: number;
   amountCents?: number;
+  amountDueCents?: number;
+  adjustedAmountCents?: number;
+  totalAmountCents?: number;
   balanceDueCents?: number;
+  remainingBalanceCents?: number;
+  paidAmountCents?: number;
+  amountPaidCents?: number;
+  totalPaidCents?: number;
+  paidCents?: number;
   status?: string;
   collectionMode?: string;
   offlinePaymentInstructions?: string;
@@ -99,6 +107,32 @@ function normalizeAmount(data: FeeRecipientData): number {
   if (typeof data.amountCents === 'number') return data.amountCents / 100;
   if (typeof data.amount === 'number') return data.amount;
   return 0;
+}
+
+function getCentsValue(...values: Array<number | undefined>): number {
+  const value = values.find((candidate) => candidate !== undefined);
+  if (value === undefined) return 0;
+  const cents = Number(value);
+  return Number.isFinite(cents) ? Math.max(0, cents) : 0;
+}
+
+function getFeeBalanceCents(data: FeeRecipientData): number {
+  if (data.balanceDueCents !== undefined) return getCentsValue(data.balanceDueCents);
+  if (data.remainingBalanceCents !== undefined) return getCentsValue(data.remainingBalanceCents);
+
+  const totalCents = getCentsValue(
+    data.amountDueCents,
+    data.adjustedAmountCents,
+    data.amountCents,
+    data.totalAmountCents
+  );
+  const paidCents = getCentsValue(
+    data.paidAmountCents,
+    data.amountPaidCents,
+    data.totalPaidCents,
+    data.paidCents
+  );
+  return Math.max(0, totalCents - paidCents);
 }
 
 function getFeeStatus(data: FeeRecipientData): string {
@@ -237,7 +271,8 @@ export class TeamFeesComponent implements OnInit {
       const collectionMode = normalizeCollectionMode(data);
       const isPaid = isFeePaid(data);
       const isCanceled = isFeeCanceled(data);
-      const canPayOnline = !isPaid && !isCanceled && isOnlineStripeCollectionMode(collectionMode) && Boolean(teamId && batchId && docSnap.id);
+      const balanceCents = getFeeBalanceCents(data);
+      const canPayOnline = !isPaid && !isCanceled && balanceCents > 0 && isOnlineStripeCollectionMode(collectionMode) && Boolean(teamId && batchId && docSnap.id);
 
       feesByPath.set(docSnap.ref.path, {
         id: docSnap.id,


### PR DESCRIPTION
Closes #1528

## Summary
- Map fee recipient collection mode, status, checkout eligibility, and offline payment instructions into the team fees view model.
- Render Pay Team Fee only for unpaid online Stripe-compatible fee records.
- Show offline/manual payment instructions for unpaid offline_manual records and suppress payment for paid or canceled fees.

## Validation
- `npx vitest run src/app/team-fees/team-fees.component.spec.ts --reporter=verbose`
- `npm test`
- `npm run app:build`