### PR TITLE
Add current roster CSV export

### DIFF
--- a/accept-invite.html
+++ b/accept-invite.html
@@ -155,7 +155,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=15';
+        import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=16';
         import { validateAccessCode, redeemParentInvite, redeemHouseholdInvite, redeemAdminInviteAtomically, updateUserProfile, updateTeam, getTeam, getUserProfile, markAccessCodeAsUsed } from './js/db.js?v=33';
         import { createInviteProcessor } from './js/accept-invite-flow.js?v=5';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, ReactNode, Suspense } from 'react';
-import { Navigate, Route, Routes } from 'react-router-dom';
+import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import { AppShell } from './components/AppShell';
 import { useAuth } from './lib/useAuth';
 import type { AuthState } from './lib/types';
@@ -27,6 +27,8 @@ const VerifyPending = lazy(() => import('./pages/VerifyPending').then((module) =
 
 export default function App() {
   const auth = useAuth();
+  const location = useLocation();
+  const shouldDefaultReloadToHome = auth.user && location.pathname === '/teams' && isBrowserReload();
 
   return (
     <Suspense fallback={<LoadingScreen />}>
@@ -43,7 +45,7 @@ export default function App() {
         <Route path="/messages" element={<Protected auth={auth}><Messages auth={auth} /></Protected>} />
         <Route path="/messages/:teamId" element={<Protected auth={auth}><Messages auth={auth} /></Protected>} />
         <Route path="/ai" element={<Protected auth={auth}><PrivateAiChat auth={auth} /></Protected>} />
-        <Route path="/teams" element={<Protected auth={auth}><Teams auth={auth} /></Protected>} />
+        <Route path="/teams" element={shouldDefaultReloadToHome ? <Navigate to="/home" replace /> : <Protected auth={auth}><Teams auth={auth} /></Protected>} />
         <Route path="/teams/:teamId" element={<Protected auth={auth}><TeamDetail auth={auth} /></Protected>} />
         <Route path="/teams/:teamId/fees" element={<Protected auth={auth}><TeamFees auth={auth} /></Protected>} />
         <Route path="/teams/:teamId/fees/:batchId" element={<Protected auth={auth}><TeamFees auth={auth} /></Protected>} />
@@ -61,6 +63,12 @@ export default function App() {
       </Routes>
     </Suspense>
   );
+}
+
+function isBrowserReload() {
+  const navigation = performance.getEntriesByType?.('navigation')?.[0] as PerformanceNavigationTiming | undefined;
+  if (navigation?.type) return navigation.type === 'reload';
+  return (performance as Performance & { navigation?: { type?: number } }).navigation?.type === 1;
 }
 
 function Protected({ auth, children }: { auth: AuthState; children: ReactNode }) {

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useState } from 'react';
+import { lazy, Suspense, useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 import {
@@ -26,6 +26,7 @@ import {
   X
 } from 'lucide-react';
 import { useShellLayout } from '../lib/useShellLayout';
+import { recordUxTiming } from '../lib/uxTiming';
 import type { AuthState, NavItem } from '../lib/types';
 import { RoleBadge } from './Badges';
 
@@ -61,9 +62,19 @@ export function AppShell({ auth, children }: AppShellProps) {
   const { isDesktopWeb } = useShellLayout();
   const navigate = useNavigate();
   const location = useLocation();
+  const routeStartedAtRef = useRef(typeof performance !== 'undefined' ? performance.now() : Date.now());
   const isAiRoute = location.pathname === '/ai';
   const isMobileChatDetail = !isDesktopWeb && location.pathname.startsWith('/messages/') && location.pathname !== '/messages';
   const isDesktopMessages = isDesktopWeb && (location.pathname.startsWith('/messages') || isAiRoute);
+
+  useEffect(() => {
+    const startedAt = routeStartedAtRef.current;
+    const frame = window.requestAnimationFrame(() => {
+      recordUxTiming('route paint', startedAt, { route: `${location.pathname}${location.search}` || '/' });
+      routeStartedAtRef.current = performance.now();
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [location.pathname, location.search]);
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {

--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -18,24 +18,7 @@ import {
   signOut as firebaseSignOut,
   updatePassword,
   verifyPasswordResetCode
-} from '../../../../js/firebase.js';
-import {
-  getTeam,
-  getUserProfile,
-  getUserTeams,
-  listMyParentMembershipRequests,
-  markAccessCodeAsUsed,
-  redeemAdminInviteAtomically,
-  redeemHouseholdInvite,
-  redeemParentInvite,
-  updateTeam,
-  updateUserProfile,
-  validateAccessCode
-} from '../../../../js/db.js';
-import { redeemAdminInviteAcceptance } from '../../../../js/admin-invite.js';
-import { createInviteProcessor } from '../../../../js/accept-invite-flow.js';
-import { executeEmailPasswordSignup } from '../../../../js/signup-flow.js';
-import { mergeApprovedParentMembershipRequests } from '../../../../js/parent-membership-utils.js';
+} from './firebaseAuthRuntime';
 import type { AuthUser, UserRole } from './types';
 
 export const firebaseAuth = auth;
@@ -50,6 +33,43 @@ const signOutCleanupTimeoutMs = 2500;
 const firebaseAuthStorageDb = 'firebaseLocalStorageDb';
 const firebaseAuthStorageStore = 'firebaseLocalStorage';
 const nativeAuthSessionStorageKey = 'allplays-native-auth-session';
+
+type AuthDbModule = typeof import('../../../../js/db.js');
+type AdminInviteModule = typeof import('../../../../js/admin-invite.js');
+type InviteFlowModule = typeof import('../../../../js/accept-invite-flow.js');
+type SignupFlowModule = typeof import('../../../../js/signup-flow.js');
+type ParentMembershipUtilsModule = typeof import('../../../../js/parent-membership-utils.js');
+
+let authDbPromise: Promise<AuthDbModule> | null = null;
+let adminInvitePromise: Promise<AdminInviteModule> | null = null;
+let inviteFlowPromise: Promise<InviteFlowModule> | null = null;
+let signupFlowPromise: Promise<SignupFlowModule> | null = null;
+let parentMembershipUtilsPromise: Promise<ParentMembershipUtilsModule> | null = null;
+
+function loadAuthDb() {
+  authDbPromise ||= import('../../../../js/db.js');
+  return authDbPromise;
+}
+
+function loadAdminInvite() {
+  adminInvitePromise ||= import('../../../../js/admin-invite.js');
+  return adminInvitePromise;
+}
+
+function loadInviteFlow() {
+  inviteFlowPromise ||= import('../../../../js/accept-invite-flow.js');
+  return inviteFlowPromise;
+}
+
+function loadSignupFlow() {
+  signupFlowPromise ||= import('../../../../js/signup-flow.js');
+  return signupFlowPromise;
+}
+
+function loadParentMembershipUtils() {
+  parentMembershipUtilsPromise ||= import('../../../../js/parent-membership-utils.js');
+  return parentMembershipUtilsPromise;
+}
 
 type FirebaseUser = {
   uid: string;
@@ -850,9 +870,10 @@ export async function hydrateFirebaseUser(user: FirebaseUser): Promise<HydratedU
   }
 
   let profile: Record<string, unknown> = {};
+  const dbModule = await loadAuthDb();
   try {
     profile = await withTimeout(
-      Promise.resolve(getUserProfile(user.uid)),
+      Promise.resolve(dbModule.getUserProfile(user.uid)),
       'Profile load timed out.',
       profileHydrationTimeoutMs
     ) || {};
@@ -864,14 +885,15 @@ export async function hydrateFirebaseUser(user: FirebaseUser): Promise<HydratedU
   }
 
   try {
+    const { mergeApprovedParentMembershipRequests } = await loadParentMembershipUtils();
     const approvedRequests = await withTimeout(
-      Promise.resolve(listMyParentMembershipRequests(user.uid)),
+      Promise.resolve(dbModule.listMyParentMembershipRequests(user.uid)),
       'Parent membership sync timed out.',
       profileHydrationTimeoutMs
     );
     const parentRequestSync = mergeApprovedParentMembershipRequests(profile, approvedRequests);
     if (parentRequestSync.changed) {
-      await updateUserProfile(user.uid, parentRequestSync.userUpdate);
+      await dbModule.updateUserProfile(user.uid, parentRequestSync.userUpdate);
       profile = {
         ...profile,
         ...parentRequestSync.userUpdate
@@ -884,7 +906,7 @@ export async function hydrateFirebaseUser(user: FirebaseUser): Promise<HydratedU
   if (!Array.isArray(profile.coachOf) || profile.coachOf.length === 0) {
     try {
       const teams = await withTimeout(
-        Promise.resolve(getUserTeams(user.uid)),
+        Promise.resolve(dbModule.getUserTeams(user.uid)),
         'Team access load timed out.',
         profileHydrationTimeoutMs
       );
@@ -943,6 +965,7 @@ export function getCurrentFirebaseUser(): FirebaseUser | null {
 
 export async function signInWithEmail(email: string, password: string) {
   const normalizedEmail = normalizeEmail(email);
+  const { updateUserProfile } = await loadAuthDb();
 
   if (isNativeRuntime()) {
     const user = await signInWithNativeRestSession(normalizedEmail, password);
@@ -970,20 +993,30 @@ export async function signInWithEmail(email: string, password: string) {
 }
 
 export async function signUpWithEmail(email: string, password: string, activationCode: string) {
+  const [
+    dbModule,
+    { redeemAdminInviteAcceptance },
+    { executeEmailPasswordSignup }
+  ] = await Promise.all([
+    loadAuthDb(),
+    loadAdminInvite(),
+    loadSignupFlow()
+  ]);
+
   return executeEmailPasswordSignup({
     email: email.trim(),
     password,
     activationCode: normalizeCode(activationCode),
     auth,
     dependencies: {
-      validateAccessCode,
+      validateAccessCode: dbModule.validateAccessCode,
       createUserWithEmailAndPassword,
-      redeemParentInvite,
+      redeemParentInvite: dbModule.redeemParentInvite,
       redeemAdminInviteAcceptance,
-      updateUserProfile,
-      markAccessCodeAsUsed,
-      getTeam,
-      getUserProfile,
+      updateUserProfile: dbModule.updateUserProfile,
+      markAccessCodeAsUsed: dbModule.markAccessCodeAsUsed,
+      getTeam: dbModule.getTeam,
+      getUserProfile: dbModule.getUserProfile,
       sendEmailVerification,
       signOut: firebaseSignOut
     }
@@ -1019,9 +1052,10 @@ async function processGoogleResult(result: UserCredential | null, activationCode
   if (!result?.user) {
     return null;
   }
+  const dbModule = await loadAuthDb();
 
   if (!isNewFirebaseUser(result.user)) {
-    await updateUserProfile(result.user.uid, {
+    await dbModule.updateUserProfile(result.user.uid, {
       email: result.user.email || '',
       fullName: result.user.displayName || '',
       photoUrl: result.user.photoURL || '',
@@ -1039,7 +1073,7 @@ async function processGoogleResult(result: UserCredential | null, activationCode
     throw new Error('Activation code is required for new Google accounts.');
   }
 
-  const validation = await validateAccessCode(code);
+  const validation = await dbModule.validateAccessCode(code);
   if (!validation.valid) {
     window.sessionStorage.removeItem(pendingActivationCodeKey);
     await cleanupFailedNewUser(result.user, 'invalid activation code');
@@ -1050,21 +1084,22 @@ async function processGoogleResult(result: UserCredential | null, activationCode
     assertInviteEmailMatches(validation, result.user.email, 'sign up');
 
     if (validation.type === 'parent_invite') {
-      await redeemParentInvite(result.user.uid, validation.data.code);
+      await dbModule.redeemParentInvite(result.user.uid, validation.data.code);
     } else if (validation.type === 'admin_invite') {
+      const { redeemAdminInviteAcceptance } = await loadAdminInvite();
       await redeemAdminInviteAcceptance({
         userId: result.user.uid,
         userEmail: result.user.email,
         teamId: validation.data.teamId,
         codeId: validation.codeId,
-        getTeam,
-        getUserProfile
+        getTeam: dbModule.getTeam,
+        getUserProfile: dbModule.getUserProfile
       });
     } else {
-      await markAccessCodeAsUsed(validation.codeId, result.user.uid);
+      await dbModule.markAccessCodeAsUsed(validation.codeId, result.user.uid);
     }
 
-    await updateUserProfile(result.user.uid, {
+    await dbModule.updateUserProfile(result.user.uid, {
       email: result.user.email || '',
       fullName: result.user.displayName || '',
       photoUrl: result.user.photoURL || '',
@@ -1205,6 +1240,7 @@ export function isEmailLink(url: string) {
 
 export async function completeEmailLink(email: string, url: string) {
   const result = await signInWithEmailLink(auth, email.trim(), url) as UserCredential;
+  const { updateUserProfile } = await loadAuthDb();
   await updateUserProfile(result.user.uid, {
     email: email.trim(),
     lastLogin: new Date(),
@@ -1214,6 +1250,7 @@ export async function completeEmailLink(email: string, url: string) {
 }
 
 export async function setCurrentUserPassword(newPassword: string) {
+  const { updateUserProfile } = await loadAuthDb();
   const user = auth.currentUser;
   if (user) {
     await updatePassword(user, newPassword);
@@ -1246,23 +1283,30 @@ export async function setCurrentUserPassword(newPassword: string) {
   }).catch((error: unknown) => console.warn('[app-auth] Unable to mark native password as set:', error));
 }
 
-export const processInvite = createInviteProcessor({
-  validateAccessCode,
-  redeemParentInvite,
-  redeemHouseholdInvite,
-  redeemAdminInviteAtomically,
-  updateUserProfile,
-  updateTeam,
-  getTeam,
-  getUserProfile,
-  markAccessCodeAsUsed
-});
-
 export async function redeemInviteForUser(userId: string, code: string, authEmail?: string | null) {
   const normalizedCode = normalizeCode(code);
   if (!normalizedCode || normalizedCode.length !== 8) {
     throw new Error('Please enter a valid 8-character invite code.');
   }
+
+  const [
+    dbModule,
+    { createInviteProcessor }
+  ] = await Promise.all([
+    loadAuthDb(),
+    loadInviteFlow()
+  ]);
+  const processInvite = createInviteProcessor({
+    validateAccessCode: dbModule.validateAccessCode,
+    redeemParentInvite: dbModule.redeemParentInvite,
+    redeemHouseholdInvite: dbModule.redeemHouseholdInvite,
+    redeemAdminInviteAtomically: dbModule.redeemAdminInviteAtomically,
+    updateUserProfile: dbModule.updateUserProfile,
+    updateTeam: dbModule.updateTeam,
+    getTeam: dbModule.getTeam,
+    getUserProfile: dbModule.getUserProfile,
+    markAccessCodeAsUsed: dbModule.markAccessCodeAsUsed
+  });
   return processInvite(userId, normalizedCode, authEmail || null);
 }
 

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -138,6 +138,10 @@ export type ChatInboxLoadResult = {
   teams: ChatTeam[];
 };
 
+export type ChatInboxLoadOptions = {
+  includeLastMessages?: boolean;
+};
+
 export type ChatSubscribeResult = {
   unsubscribe: () => void;
 };
@@ -450,8 +454,9 @@ async function getLatestMessagePreview(teamId: string, user: AuthUser, team: Rec
   return getNewestChatMessage(messages);
 }
 
-export async function loadChatInbox(user: AuthUser | null): Promise<ChatInboxLoadResult> {
+export async function loadChatInbox(user: AuthUser | null, options: ChatInboxLoadOptions = {}): Promise<ChatInboxLoadResult> {
   if (!user?.uid) return { teams: [] };
+  const includeLastMessages = options.includeLastMessages !== false;
 
   const profile = await withTimeout(Promise.resolve(getUserProfile(user.uid)), 'Chat profile load').catch(async (error) => {
     if (!isNativeRuntime()) throw error;
@@ -488,7 +493,7 @@ export async function loadChatInbox(user: AuthUser | null): Promise<ChatInboxLoa
     return {
       team,
       canModerate,
-      lastMessage: await getLatestMessagePreview(team.id, userWithProfile, team, canModerate)
+      lastMessage: includeLastMessages ? await getLatestMessagePreview(team.id, userWithProfile, team, canModerate) : null
     };
   }));
 

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -77,6 +77,8 @@ export type ChatConversation = {
   mutedBy?: string[];
   isDefault?: boolean;
   isLegacy?: boolean;
+  updatedAt?: unknown;
+  lastMessageAt?: unknown;
 };
 
 export type ChatAttachment = {
@@ -388,18 +390,64 @@ async function nativeLoadUserTeams(user: AuthUser, profile: Record<string, any>)
     .sort((a, b) => String(a.name || a.id).localeCompare(String(b.name || b.id)));
 }
 
-async function getLatestMessagePreview(teamId: string): Promise<ChatMessage | null> {
+function getMessageTime(message: ChatMessage | null) {
+  return toDate(message?.createdAt)?.getTime() || 0;
+}
+
+function getNewestChatMessage(messages: Array<ChatMessage | null>) {
+  return messages.reduce<ChatMessage | null>((newest, message) => (
+    getMessageTime(message) > getMessageTime(newest) ? message : newest
+  ), null);
+}
+
+async function getLatestConversationMessage(teamId: string, conversationId: string): Promise<ChatMessage | null> {
   try {
-    const [message] = await withTimeout(Promise.resolve(getChatMessages(teamId, { limit: 1 })), `latest chat ${teamId}`, 2500);
+    const [message] = await withTimeout(Promise.resolve(getChatMessages(teamId, { limit: 1, conversationId })), `latest chat ${teamId}/${conversationId}`, 2500);
     return message || null;
   } catch (error) {
     if (!isNativeRuntime()) return null;
-    const [message] = await nativeListCollection(`teams/${encodeURIComponent(teamId)}/chatMessages`, {
+    const path = isDefaultTeamConversation(conversationId)
+      ? `teams/${encodeURIComponent(teamId)}/chatMessages`
+      : `teams/${encodeURIComponent(teamId)}/chatConversations/${encodeURIComponent(conversationId)}/chatMessages`;
+    const [message] = await nativeListCollection(path, {
       orderBy: 'createdAt desc',
       pageSize: 1
     }).catch(() => []);
     return message as ChatMessage || null;
   }
+}
+
+async function getLatestMessagePreview(teamId: string, user: AuthUser, team: Record<string, any>, canModerate: boolean): Promise<ChatMessage | null> {
+  let conversations: ChatConversation[] = [buildDefaultTeamConversation(team)];
+  try {
+    const loadedConversations = await withTimeout(
+      Promise.resolve(getChatConversations(teamId, user, { team, canModerate })),
+      `latest chat conversations ${teamId}`,
+      2500
+    ) as ChatConversation[];
+    conversations = Array.isArray(loadedConversations) && loadedConversations.length
+      ? loadedConversations
+      : [buildDefaultTeamConversation(team)];
+  } catch (error) {
+    if (!isNativeRuntime()) {
+      conversations = [buildDefaultTeamConversation(team)];
+    } else {
+      console.warn('[chat-service] Latest inbox preview limited to team chat:', error);
+    }
+  }
+
+  const recentConversations = conversations
+    .filter((conversation) => conversation?.id)
+    .sort((a, b) => {
+      const aTime = toDate(a.lastMessageAt || a.updatedAt)?.getTime() || 0;
+      const bTime = toDate(b.lastMessageAt || b.updatedAt)?.getTime() || 0;
+      return bTime - aTime;
+    })
+    .slice(0, 8);
+  const messages = await Promise.all(recentConversations.map((conversation) => (
+    getLatestConversationMessage(teamId, conversation.id)
+  )));
+  return getNewestChatMessage(messages);
 }
 
 export async function loadChatInbox(user: AuthUser | null): Promise<ChatInboxLoadResult> {
@@ -435,20 +483,24 @@ export async function loadChatInbox(user: AuthUser | null): Promise<ChatInboxLoa
     3000
   ).catch(() => ({} as Record<string, number>));
 
-  const previews = await Promise.all(accessibleTeams.map(async (team) => ({
-    team,
-    lastMessage: await getLatestMessagePreview(team.id)
-  })));
+  const previews = await Promise.all(accessibleTeams.map(async (team) => {
+    const canModerate = canModerateChat(userWithProfile, { ...team, id: team.id });
+    return {
+      team,
+      canModerate,
+      lastMessage: await getLatestMessagePreview(team.id, userWithProfile, team, canModerate)
+    };
+  }));
 
   return {
-    teams: previews.map(({ team, lastMessage }) => ({
+    teams: previews.map(({ team, canModerate, lastMessage }) => ({
       id: team.id,
       name: team.name || 'Team',
       sport: team.sport || null,
       photoUrl: team.photoUrl || null,
       active: team.active,
       role: getTeamRole(user, team, profile),
-      canModerate: canModerateChat(userWithProfile, { ...team, id: team.id }),
+      canModerate,
       unreadCount: Number(unreadCounts[team.id] || 0),
       lastMessage
     })).sort((a, b) => {

--- a/apps/app/src/lib/firebaseAuthRuntime.ts
+++ b/apps/app/src/lib/firebaseAuthRuntime.ts
@@ -47,6 +47,9 @@ function initializeFirebaseAuth(appInstance: typeof app) {
   if (!isCapacitorNativeRuntime()) {
     return getAuth(appInstance);
   }
+  if (typeof window !== 'undefined' && typeof window.indexedDB?.deleteDatabase !== 'function') {
+    return getAuth(appInstance);
+  }
 
   try {
     return initializeAuth(appInstance, {

--- a/apps/app/src/lib/firebaseAuthRuntime.ts
+++ b/apps/app/src/lib/firebaseAuthRuntime.ts
@@ -1,0 +1,80 @@
+import { getApp, getApps, initializeApp } from '../../../../js/vendor/firebase-app.js';
+import {
+  applyActionCode,
+  confirmPasswordReset,
+  createUserWithEmailAndPassword,
+  getAuth,
+  getRedirectResult,
+  GoogleAuthProvider,
+  indexedDBLocalPersistence,
+  initializeAuth,
+  isSignInWithEmailLink,
+  onAuthStateChanged,
+  sendEmailVerification,
+  sendPasswordResetEmail,
+  signInWithEmailAndPassword,
+  signInWithEmailLink,
+  signInWithPopup,
+  signInWithRedirect,
+  signOut,
+  updatePassword,
+  verifyPasswordResetCode
+} from '../../../../js/vendor/firebase-auth.js';
+import { resolvePrimaryFirebaseConfig } from '../../../../js/firebase-runtime-config.js';
+
+const firebaseConfig = await resolvePrimaryFirebaseConfig();
+const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
+
+function isCapacitorNativeRuntime() {
+  const protocol = typeof window !== 'undefined' ? window.location?.protocol : '';
+  if (protocol === 'capacitor:' || protocol === 'ionic:') {
+    return true;
+  }
+
+  const capacitor = typeof window !== 'undefined' ? (window as any).Capacitor : null;
+  if (!capacitor) {
+    return false;
+  }
+
+  if (typeof capacitor.isNativePlatform === 'function') {
+    return capacitor.isNativePlatform();
+  }
+
+  return capacitor.getPlatform?.() === 'ios' || capacitor.getPlatform?.() === 'android';
+}
+
+function initializeFirebaseAuth(appInstance: typeof app) {
+  if (!isCapacitorNativeRuntime()) {
+    return getAuth(appInstance);
+  }
+
+  try {
+    return initializeAuth(appInstance, {
+      persistence: indexedDBLocalPersistence
+    });
+  } catch (error) {
+    console.warn('[firebase] Native auth initialization fell back to getAuth:', error);
+    return getAuth(appInstance);
+  }
+}
+
+export const auth = initializeFirebaseAuth(app);
+
+export {
+  applyActionCode,
+  confirmPasswordReset,
+  createUserWithEmailAndPassword,
+  getRedirectResult,
+  GoogleAuthProvider,
+  isSignInWithEmailLink,
+  onAuthStateChanged,
+  sendEmailVerification,
+  sendPasswordResetEmail,
+  signInWithEmailAndPassword,
+  signInWithEmailLink,
+  signInWithPopup,
+  signInWithRedirect,
+  signOut,
+  updatePassword,
+  verifyPasswordResetCode
+};

--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -1,17 +1,19 @@
 import { listParentTeamFeeRecipients } from '../../../../js/db.js';
 import { normalizeParentFeeRecord } from '../../../../js/parent-dashboard-fees.js';
 import { loadChatInbox } from './chatService';
+import { startUxTimer } from './uxTiming';
 import {
   buildParentHomeModel,
   type ParentHomeInboxTeam,
   type ParentHomeModel
 } from './homeLogic';
 import { loadCachedAppData } from './appDataCache';
-import { loadParentSchedule, type ParentScheduleLoadResult } from './scheduleService';
+import { loadParentSchedule, type ParentScheduleChild, type ParentScheduleLoadResult } from './scheduleService';
 import type { AuthUser } from './types';
 
 const homeSummaryTtlMs = 45 * 1000;
 const homeSecondaryTtlMs = 30 * 1000;
+const teamsSummaryTtlMs = 30 * 1000;
 
 export async function loadParentHome(user: AuthUser | null): Promise<ParentHomeModel> {
   if (!user?.uid) {
@@ -50,6 +52,42 @@ export async function loadParentHomeSummary(user: AuthUser | null, options: { fo
     inboxTeams: [],
     fees: []
   });
+}
+
+export async function loadParentTeamsSummary(user: AuthUser | null, options: { force?: boolean } = {}): Promise<ParentHomeModel> {
+  if (!user?.uid) {
+    return buildParentHomeModel({ children: [], events: [], inboxTeams: [], fees: [] });
+  }
+
+  return loadCachedAppData(
+    `teams-summary:${user.uid}`,
+    async () => {
+      const timer = startUxTimer('teams summary load');
+      try {
+        const chatInbox = await loadChatInbox(user, { includeLastMessages: false }).catch((error) => {
+          console.warn('[home-service] Unable to load team inbox summary:', error);
+          return { teams: [] };
+        });
+        const children = normalizeChildLinks(user, { parentOf: user.parentOf || [] });
+        const model = buildParentHomeModel({
+          children,
+          events: [],
+          inboxTeams: normalizeInboxTeams(chatInbox.teams || []),
+          fees: []
+        });
+        timer.end({
+          children: children.length,
+          teams: model.teams.length,
+          inboxTeams: chatInbox.teams?.length || 0
+        });
+        return model;
+      } catch (error: any) {
+        timer.end({ error: error?.message || 'Unable to load team summary.' });
+        throw error;
+      }
+    },
+    { ttlMs: teamsSummaryTtlMs, force: options.force }
+  );
 }
 
 export async function loadParentHomeWithSecondaryData(user: AuthUser | null, options: { force?: boolean } = {}): Promise<ParentHomeModel> {
@@ -97,4 +135,32 @@ function normalizeInboxTeams(teams: any[]): ParentHomeInboxTeam[] {
     photoUrl: team.photoUrl || null,
     unreadCount: Number(team.unreadCount || 0)
   }));
+}
+
+function compactString(value: unknown) {
+  return String(value || '').trim();
+}
+
+function normalizeChildLinks(user: AuthUser, profile: Record<string, unknown>): ParentScheduleChild[] {
+  const parentOf = Array.isArray(profile.parentOf) && profile.parentOf.length > 0
+    ? profile.parentOf
+    : Array.isArray(user.parentOf) ? user.parentOf : [];
+
+  const seen = new Set<string>();
+  return parentOf
+    .map((entry: any) => {
+      const teamId = compactString(entry?.teamId);
+      const playerId = compactString(entry?.playerId || entry?.childId);
+      if (!teamId || !playerId) return null;
+      const key = `${teamId}::${playerId}`;
+      if (seen.has(key)) return null;
+      seen.add(key);
+      return {
+        teamId,
+        teamName: compactString(entry?.teamName),
+        playerId,
+        playerName: compactString(entry?.playerName || entry?.childName || entry?.name) || 'Player'
+      };
+    })
+    .filter(Boolean) as ParentScheduleChild[];
 }

--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -83,7 +83,7 @@ export async function loadParentScheduleSummary(user: AuthUser | null, options: 
   if (!user?.uid) return { children: [], events: [] };
   return loadCachedAppData(
     `schedule-summary:${user.uid}`,
-    () => loadParentSchedule(user, { hydrateDetails: false }),
+    () => loadParentSchedule(user, { hydrateDetails: false, expandStaffPlayers: false }),
     { ttlMs: homeSummaryTtlMs, force: options.force }
   );
 }

--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -18,7 +18,7 @@ export async function loadParentHome(user: AuthUser | null): Promise<ParentHomeM
     return buildParentHomeModel({ children: [], events: [], inboxTeams: [], fees: [] });
   }
 
-  const schedule = await loadParentSchedule(user, { hydrateDetails: true });
+  const schedule = await loadParentScheduleSummary(user);
   const [chatInbox, rawFees] = await Promise.all([
     loadChatInbox(user).catch((error) => {
       console.warn('[home-service] Unable to load chat inbox:', error);

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -45,6 +45,7 @@ import { buildScheduleNotificationTargets, postScheduleNotificationTargets } fro
 import { isTeamActive } from '../../../../js/team-visibility.js';
 import { loadProfileDocument, saveProfileDocument } from './profileService';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
+import { startUxTimer } from './uxTiming';
 import {
   getNextRideConfirmedSeatCount,
   getScheduleRideshareSummary,
@@ -87,6 +88,7 @@ import { DEFAULT_TEAM_CONVERSATION_ID } from './chatLogic';
 import type { AuthUser } from './types';
 
 const primaryDataTimeoutMs = 5000;
+const parentScheduleTeamConcurrency = 3;
 
 export type ParentScheduleChild = {
   teamId: string;
@@ -420,6 +422,26 @@ async function readWithNativeFallback<T>(label: string, primary: () => Promise<T
 
 function compactString(value: unknown) {
   return String(value || '').trim();
+}
+
+async function mapWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  mapper: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+  const workerCount = Math.max(1, Math.min(concurrency, items.length));
+
+  await Promise.all(Array.from({ length: workerCount }, async () => {
+    while (nextIndex < items.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      results[currentIndex] = await mapper(items[currentIndex], currentIndex);
+    }
+  }));
+
+  return results;
 }
 
 export function normalizeGameScoreValue(value: unknown) {
@@ -1378,49 +1400,63 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
   if (!user?.uid) {
     return { children: [], events: [] };
   }
+  const timer = startUxTimer('parent schedule service load');
   const hydrateDetails = options.hydrateDetails !== false;
 
-  const profile = await loadProfileDocument(user.uid);
-  const children = normalizeChildLinks(user, profile as Record<string, unknown>);
-  const byTeam = new Map<string, ParentScheduleChild[]>();
-  children.forEach((child) => {
-    if (!byTeam.has(child.teamId)) byTeam.set(child.teamId, []);
-    byTeam.get(child.teamId)?.push(child);
-  });
+  try {
+    const profile = await loadProfileDocument(user.uid);
+    const children = normalizeChildLinks(user, profile as Record<string, unknown>);
+    const byTeam = new Map<string, ParentScheduleChild[]>();
+    children.forEach((child) => {
+      if (!byTeam.has(child.teamId)) byTeam.set(child.teamId, []);
+      byTeam.get(child.teamId)?.push(child);
+    });
 
-  const staffTeams = await loadStaffTeams(user).catch(() => []);
-  await Promise.all(staffTeams.map(async (team: any) => {
-    const teamId = compactString(team?.id);
-    if (!teamId) return;
-    const existingPlayerIds = new Set((byTeam.get(teamId) || []).map((child) => child.playerId));
-    const players = await loadPlayers(teamId).catch(() => []);
-    const staffChildren = (Array.isArray(players) ? players : [])
-      .filter((player: any) => player?.active !== false && compactString(player?.id) && !existingPlayerIds.has(compactString(player.id)))
-      .map((player: any) => ({
-        teamId,
-        teamName: compactString(team?.name) || teamId,
-        playerId: compactString(player.id),
-        playerName: compactString(player.name) || compactString(player.displayName) || 'Player'
-      }));
-    if (staffChildren.length) {
-      byTeam.set(teamId, [...(byTeam.get(teamId) || []), ...staffChildren]);
+    const staffTeams = await loadStaffTeams(user).catch(() => []);
+    await mapWithConcurrency(staffTeams, parentScheduleTeamConcurrency, async (team: any) => {
+      const teamId = compactString(team?.id);
+      if (!teamId) return;
+      const existingPlayerIds = new Set((byTeam.get(teamId) || []).map((child) => child.playerId));
+      const players = await loadPlayers(teamId).catch(() => []);
+      const staffChildren = (Array.isArray(players) ? players : [])
+        .filter((player: any) => player?.active !== false && compactString(player?.id) && !existingPlayerIds.has(compactString(player.id)))
+        .map((player: any) => ({
+          teamId,
+          teamName: compactString(team?.name) || teamId,
+          playerId: compactString(player.id),
+          playerName: compactString(player.name) || compactString(player.displayName) || 'Player'
+        }));
+      if (staffChildren.length) {
+        byTeam.set(teamId, [...(byTeam.get(teamId) || []), ...staffChildren]);
+      }
+    });
+
+    const teamEntries = [...byTeam.entries()];
+    const eventBatches = await mapWithConcurrency(teamEntries, parentScheduleTeamConcurrency, async ([teamId, teamChildren]) => {
+      try {
+        return await buildTeamSchedule(teamId, teamChildren, user);
+      } catch (error) {
+        console.warn('[schedule-service] Failed to load team schedule:', teamId, error);
+        return [];
+      }
+    });
+
+    const events = eventBatches.flat().sort((a, b) => a.date.getTime() - b.date.getTime());
+    if (hydrateDetails) {
+      await hydrateEventDetails(events, user);
     }
-  }));
-
-  const eventBatches = await Promise.all([...byTeam.entries()].map(async ([teamId, teamChildren]) => {
-    try {
-      return await buildTeamSchedule(teamId, teamChildren, user);
-    } catch (error) {
-      console.warn('[schedule-service] Failed to load team schedule:', teamId, error);
-      return [];
-    }
-  }));
-
-  const events = eventBatches.flat().sort((a, b) => a.date.getTime() - b.date.getTime());
-  if (hydrateDetails) {
-    await hydrateEventDetails(events, user);
+    timer.end({
+      hydrateDetails,
+      childLinks: children.length,
+      teams: byTeam.size,
+      staffTeams: staffTeams.length,
+      eventRows: events.length
+    });
+    return { children, events };
+  } catch (error: any) {
+    timer.end({ hydrateDetails, error: error?.message || 'Unable to load parent schedule.' });
+    throw error;
   }
-  return { children, events };
 }
 
 async function nativeSubmitRsvpForPlayer(teamId: string, gameId: string, user: AuthUser, childId: string, response: RsvpResponse, note = '') {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -104,6 +104,7 @@ export type ParentScheduleLoadResult = {
 
 export type ParentScheduleLoadOptions = {
   hydrateDetails?: boolean;
+  expandStaffPlayers?: boolean;
 };
 
 type FirestoreDocument = Record<string, any> & { id: string };
@@ -1402,6 +1403,7 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
   }
   const timer = startUxTimer('parent schedule service load');
   const hydrateDetails = options.hydrateDetails !== false;
+  const expandStaffPlayers = options.expandStaffPlayers !== false;
 
   try {
     const profile = await loadProfileDocument(user.uid);
@@ -1416,13 +1418,25 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
     await mapWithConcurrency(staffTeams, parentScheduleTeamConcurrency, async (team: any) => {
       const teamId = compactString(team?.id);
       if (!teamId) return;
+      const teamName = compactString(team?.name) || teamId;
       const existingPlayerIds = new Set((byTeam.get(teamId) || []).map((child) => child.playerId));
+      if (!expandStaffPlayers) {
+        if (!existingPlayerIds.size) {
+          byTeam.set(teamId, [{
+            teamId,
+            teamName,
+            playerId: `staff-team-${teamId}`,
+            playerName: 'Team schedule'
+          }]);
+        }
+        return;
+      }
       const players = await loadPlayers(teamId).catch(() => []);
       const staffChildren = (Array.isArray(players) ? players : [])
         .filter((player: any) => player?.active !== false && compactString(player?.id) && !existingPlayerIds.has(compactString(player.id)))
         .map((player: any) => ({
           teamId,
-          teamName: compactString(team?.name) || teamId,
+          teamName,
           playerId: compactString(player.id),
           playerName: compactString(player.name) || compactString(player.displayName) || 'Player'
         }));
@@ -1447,6 +1461,7 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
     }
     timer.end({
       hydrateDetails,
+      expandStaffPlayers,
       childLinks: children.length,
       teams: byTeam.size,
       staffTeams: staffTeams.length,
@@ -1454,7 +1469,7 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
     });
     return { children, events };
   } catch (error: any) {
-    timer.end({ hydrateDetails, error: error?.message || 'Unable to load parent schedule.' });
+    timer.end({ hydrateDetails, expandStaffPlayers, error: error?.message || 'Unable to load parent schedule.' });
     throw error;
   }
 }

--- a/apps/app/src/lib/uxTiming.ts
+++ b/apps/app/src/lib/uxTiming.ts
@@ -1,0 +1,16 @@
+export function startUxTimer(label: string) {
+  const startedAt = typeof performance !== 'undefined' ? performance.now() : Date.now();
+  return {
+    end(meta: Record<string, unknown> = {}) {
+      recordUxTiming(label, startedAt, meta);
+    }
+  };
+}
+
+export function recordUxTiming(label: string, startedAt: number, meta: Record<string, unknown> = {}) {
+  const now = typeof performance !== 'undefined' ? performance.now() : Date.now();
+  const durationMs = Math.round(now - startedAt);
+  if (typeof console !== 'undefined') {
+    console.info(`[ux] ${label} ${JSON.stringify({ durationMs, ...meta })}`);
+  }
+}

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -117,7 +117,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
 
       const result = await loadCachedAppData(
         cacheKey,
-        () => loadParentSchedule(auth.user, { hydrateDetails: false }),
+        () => loadParentSchedule(auth.user, { hydrateDetails: false, expandStaffPlayers: false }),
         { ttlMs: scheduleCacheTtlMs, force }
       );
 
@@ -173,6 +173,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
 
   const calendarEntries = useMemo(() => getCalendarScheduleEntries(visibleEvents), [visibleEvents]);
   const listEntries = calendarEntries;
+  const parentLinkedPlayerIds = useMemo(() => new Set(children.map((child) => child.playerId)), [children]);
   const teamOptions = useMemo(() => getParentScheduleTeamOptions(events, children), [children, events]);
   const packetRows = useMemo(() => getPracticePacketRows(visibleEvents), [visibleEvents]);
   const selectedDayEntries = useMemo(() => {
@@ -188,9 +189,9 @@ export function Schedule({ auth }: { auth: AuthState }) {
     total: listEntries.length,
     games: listEntries.filter((event) => event.type === 'game').length,
     practices: listEntries.filter((event) => event.type === 'practice').length,
-    rsvpNeeded: visibleEvents.filter((event) => event.isDbGame && !event.isCancelled && normalizeRsvpResponse(event.myRsvp) === 'not_responded').length,
+    rsvpNeeded: visibleEvents.filter((event) => parentLinkedPlayerIds.has(event.childId) && event.isDbGame && !event.isCancelled && normalizeRsvpResponse(event.myRsvp) === 'not_responded').length,
     packetsReady: packetRows.filter((row) => row.needsAction).length
-  }), [listEntries, packetRows, visibleEvents]);
+  }), [listEntries, packetRows, parentLinkedPlayerIds, visibleEvents]);
   const webInsights = useMemo(() => buildScheduleWebInsights(listEntries), [listEntries]);
   const manageableTeamOptions = useMemo(() => (
     teamOptions.filter((team) => events.some((event) => event.teamId === team.teamId && event.isTeamStaff === true))

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -2,6 +2,8 @@ import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { AlertCircle, CalendarDays, CheckCircle2, ChevronLeft, ChevronRight, ClipboardCheck, Copy, Download, Filter, Link as LinkIcon, ListChecks, MapPin, RefreshCw } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { addTeamCalendarUrl, createScheduleImportGame, createScheduleImportPractice, loadParentSchedule, removeTeamCalendarUrl, type ParentScheduleChild } from '../lib/scheduleService';
+import { getCachedAppData, loadCachedAppData } from '../lib/appDataCache';
+import { startUxTimer } from '../lib/uxTiming';
 import { useShellLayout } from '../lib/useShellLayout';
 import {
   buildScheduleIcs,
@@ -105,11 +107,28 @@ export function Schedule({ auth }: { auth: AuthState }) {
     setLoading(true);
     setError(null);
     setStatusMessage(null);
+    const timer = startUxTimer('schedule summary load');
     try {
-      const result = await loadParentSchedule(auth.user, { hydrateDetails: false });
-      setChildren(result.children);
-      setEvents(result.events);
-      setLoading(false);
+      const cacheKey = 'app-schedule-summary'; // Placeholder for cache key
+      const scheduleCacheTtlMs = 60 * 1000 * 5; // Placeholder for cache TTL (5 minutes)
+      const force = false; // Placeholder for force refresh. Assuming initial refresh is not forced.
+      const cached = getCachedAppData(cacheKey); // Assuming getCachedAppData is available
+      const hasExistingSchedule = events.length > 0; // Check current state
+
+      const result = await loadCachedAppData(
+        cacheKey,
+        () => loadParentSchedule(auth.user, { hydrateDetails: false }),
+        { ttlMs: scheduleCacheTtlMs, force }
+      );
+
+      // Define applyScheduleResult here to access state setters
+      const applyScheduleResult = (data: { children: ParentScheduleChild[]; events: ParentScheduleEvent[]; }) => {
+        setChildren(data.children);
+        setEvents(data.events);
+      };
+      applyScheduleResult(result);
+
+      // Logic from HEAD that adjusts selectedPlayerId, selectedTeamId, and calendarMonth
       if (selectedPlayerId && !result.children.some((child) => child.playerId === selectedPlayerId)) {
         setSelectedPlayerId('');
       }
@@ -121,17 +140,18 @@ export function Schedule({ auth }: { auth: AuthState }) {
         setCalendarMonth(new Date(firstUpcoming.date.getFullYear(), firstUpcoming.date.getMonth(), 1));
       }
 
-      void loadParentSchedule(auth.user)
-        .then((hydratedResult) => {
-          setChildren(hydratedResult.children);
-          setEvents(hydratedResult.events);
-        })
-        .catch((hydrateError: any) => {
-          console.warn('[app-schedule] Unable to hydrate schedule details:', hydrateError);
-        });
+      timer.end({
+        cacheHit: Boolean(cached) && !force,
+        force,
+        children: result.children.length,
+        eventRows: result.events.length,
+        groupedEvents: getCalendarScheduleEntries(result.events).length
+      });
     } catch (loadError: any) {
       setError(loadError?.message || 'Unable to load schedule.');
-      setEvents([]);
+      if (!hasExistingSchedule) setEvents([]);
+      timer.end({ force: false, error: loadError?.message || 'Unable to load schedule.' }); // Use hardcoded false for force in catch
+    } finally {
       setLoading(false);
     }
   };
@@ -152,6 +172,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
   }, [filter, selectedPlayerId, selectedTeamId, timeRange, view]);
 
   const calendarEntries = useMemo(() => getCalendarScheduleEntries(visibleEvents), [visibleEvents]);
+  const listEntries = calendarEntries;
   const teamOptions = useMemo(() => getParentScheduleTeamOptions(events, children), [children, events]);
   const packetRows = useMemo(() => getPracticePacketRows(visibleEvents), [visibleEvents]);
   const selectedDayEntries = useMemo(() => {
@@ -164,13 +185,13 @@ export function Schedule({ auth }: { auth: AuthState }) {
   }, [calendarEntries, selectedDay]);
 
   const counts = useMemo(() => ({
-    total: visibleEvents.length,
-    games: visibleEvents.filter((event) => event.type === 'game').length,
-    practices: visibleEvents.filter((event) => event.type === 'practice').length,
+    total: listEntries.length,
+    games: listEntries.filter((event) => event.type === 'game').length,
+    practices: listEntries.filter((event) => event.type === 'practice').length,
     rsvpNeeded: visibleEvents.filter((event) => event.isDbGame && !event.isCancelled && normalizeRsvpResponse(event.myRsvp) === 'not_responded').length,
     packetsReady: packetRows.filter((row) => row.needsAction).length
-  }), [packetRows, visibleEvents]);
-  const webInsights = useMemo(() => buildScheduleWebInsights(visibleEvents), [visibleEvents]);
+  }), [listEntries, packetRows, visibleEvents]);
+  const webInsights = useMemo(() => buildScheduleWebInsights(listEntries), [listEntries]);
   const manageableTeamOptions = useMemo(() => (
     teamOptions.filter((team) => events.some((event) => event.teamId === team.teamId && event.isTeamStaff === true))
   ), [events, teamOptions]);
@@ -548,7 +569,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
                 setTimeRange('all');
               }}
             />
-            <ScheduleActionQueue events={visibleEvents} />
+            <ScheduleActionQueue events={listEntries} />
           </aside>
         ) : null}
 
@@ -617,13 +638,13 @@ export function Schedule({ auth }: { auth: AuthState }) {
           ) : view === 'packets' ? (
             <PracticePacketsPanel rows={packetRows} />
           ) : view === 'compact' ? (
-            <CompactScheduleList events={visibleEvents} />
+            <CompactScheduleList events={listEntries} />
           ) : (
             <ScheduleList
-              events={visibleEvents}
+              events={listEntries}
               visibleCount={visibleListCount}
               pageSize={listPageSize}
-              onShowMore={() => setVisibleListCount((current) => Math.min(current + listPageSize, visibleEvents.length))}
+              onShowMore={() => setVisibleListCount((current) => Math.min(current + listPageSize, listEntries.length))}
             />
           )}
         </div>
@@ -1143,7 +1164,7 @@ function LoadingSchedule() {
 }
 
 function ScheduleList({ events, visibleCount, pageSize, onShowMore }: {
-  events: ParentScheduleEvent[];
+  events: CalendarScheduleEntry[];
   visibleCount: number;
   pageSize: number;
   onShowMore: () => void;
@@ -1182,7 +1203,7 @@ function ScheduleList({ events, visibleCount, pageSize, onShowMore }: {
   );
 }
 
-function CompactScheduleList({ events }: { events: ParentScheduleEvent[] }) {
+function CompactScheduleList({ events }: { events: CalendarScheduleEntry[] }) {
   if (!events.length) {
     return (
       <div className="app-card p-8 text-center">
@@ -1209,7 +1230,7 @@ function CompactScheduleList({ events }: { events: ParentScheduleEvent[] }) {
               </div>
               <div className="min-w-0">
                 <div className="truncate text-sm font-black text-gray-950">{getScheduleTitle(event)}</div>
-                <div className="mt-0.5 truncate text-xs font-semibold text-gray-500">{event.childName} · {event.teamName} · {event.location || 'TBD'}</div>
+                <div className="mt-0.5 truncate text-xs font-semibold text-gray-500">{getScheduleChildLabel(event)} · {event.teamName} · {event.location || 'TBD'}</div>
               </div>
               <span className={`self-center rounded-full border px-2 py-1 text-[10px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadgeClasses[rsvp]}`}>
                 {rsvpLabels[rsvp]}
@@ -1284,6 +1305,7 @@ function ScheduleEventCard({ event }: {
   const metadataPills = getEventMetadataPills(event);
   const mapHref = getScheduleMapHref(event.location);
   const forecastHref = getScheduleForecastHref(event.location, event.date);
+  const childLabel = getScheduleChildLabel(event);
 
   return (
     <>
@@ -1299,7 +1321,7 @@ function ScheduleEventCard({ event }: {
               <h2 className={`truncate text-[15px] font-black leading-tight text-gray-950 ${event.isCancelled ? 'line-through' : ''}`}>{eventTitle}</h2>
             </div>
             <div className="mt-0.5 truncate text-xs font-bold leading-5 text-gray-600">
-              {event.childName} · {event.teamName}
+              {childLabel} · {event.teamName}
             </div>
             <div className="truncate text-xs font-semibold leading-5 text-gray-500">
               {event.location || 'TBD'}
@@ -1355,7 +1377,7 @@ function ScheduleEventCard({ event }: {
                 ) : null}
               </span>
             </div>
-            <div className="mt-1 text-xs font-semibold text-gray-500">For {event.childName} · {event.teamName}</div>
+            <div className="mt-1 text-xs font-semibold text-gray-500">For {childLabel} · {event.teamName}</div>
 
             {actionPills.length ? (
               <div className="schedule-card-pills mt-3 flex flex-wrap gap-1.5">
@@ -1387,6 +1409,13 @@ function getEventDetailPath(event: ParentScheduleEvent | CalendarScheduleEntry) 
   const params = new URLSearchParams();
   if (event.childId) params.set('childId', event.childId);
   return `/schedule/${encodeURIComponent(event.teamId)}/${encodeURIComponent(event.id)}${params.toString() ? `?${params}` : ''}`;
+}
+
+function getScheduleChildLabel(event: ParentScheduleEvent | CalendarScheduleEntry) {
+  const names = 'childNames' in event && event.childNames.length ? event.childNames : [];
+  if (names.length > 2) return `${names.slice(0, 2).join(', ')} +${names.length - 2}`;
+  if (names.length) return names.join(', ');
+  return event.childName || 'Player';
 }
 
 function getEventPrimaryActionText(event: ParentScheduleEvent, rsvp: RsvpResponse) {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -102,18 +102,17 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const [importingCsv, setImportingCsv] = useState(false);
   const [removingCalendarUrl, setRemovingCalendarUrl] = useState<string | null>(null);
 
-  const refreshSchedule = async () => {
+  const refreshSchedule = async (force = false) => {
     if (!auth.user) return;
     setLoading(true);
     setError(null);
     setStatusMessage(null);
     const timer = startUxTimer('schedule summary load');
+    const hasExistingSchedule = events.length > 0; // Check current state
     try {
-      const cacheKey = 'app-schedule-summary'; // Placeholder for cache key
+      const cacheKey = `app-schedule-summary:${auth.user.uid}`;
       const scheduleCacheTtlMs = 60 * 1000 * 5; // Placeholder for cache TTL (5 minutes)
-      const force = false; // Placeholder for force refresh. Assuming initial refresh is not forced.
       const cached = getCachedAppData(cacheKey); // Assuming getCachedAppData is available
-      const hasExistingSchedule = events.length > 0; // Check current state
 
       const result = await loadCachedAppData(
         cacheKey,
@@ -272,7 +271,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
     }
 
     setCsvPreviewRows(failedRows);
-    await refreshSchedule();
+    await refreshSchedule(true);
     setStatusMessage(failedRows.length
       ? `Imported ${importedCount} row(s); ${failedRows.length} row(s) failed and remain below for retry.`
       : `Imported ${importedCount} schedule row(s) and refreshed the schedule.`);
@@ -296,7 +295,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
       const result = await addTeamCalendarUrl(selectedCalendarTeam.teamId, validation.url, auth.user);
       setCalendarUrl('');
       setStatusMessage(result.added ? 'Calendar link saved. Refreshing schedule…' : 'Calendar link already exists. Refreshing schedule…');
-      await refreshSchedule();
+      await refreshSchedule(true);
       setStatusMessage(result.added ? 'Calendar link saved and schedule refreshed.' : 'Calendar link already exists. Schedule refreshed.');
     } catch (saveError: any) {
       setCalendarUrlError(saveError?.message || 'Unable to save calendar link.');
@@ -385,7 +384,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
             </div>
           </div>
           <div className="flex flex-none gap-1.5">
-            <button type="button" className="ghost-button !h-9 !min-h-9 !w-9 !p-0" onClick={refreshSchedule} disabled={loading} aria-label="Refresh schedule">
+            <button type="button" className="ghost-button !h-9 !min-h-9 !w-9 !p-0" onClick={() => refreshSchedule(true)} disabled={loading} aria-label="Refresh schedule">
               <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />
             </button>
             <button type="button" className="secondary-button !h-9 !min-h-9 !w-9 !p-0" onClick={handleExport} aria-label="Export calendar">
@@ -469,7 +468,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
             </div>
 
             <div className="mt-3 flex flex-wrap gap-2">
-              <button type="button" className="ghost-button !min-h-9 !px-3 !py-2 !text-xs sm:!min-h-10 sm:!text-sm" onClick={refreshSchedule} disabled={loading}>
+              <button type="button" className="ghost-button !min-h-9 !px-3 !py-2 !text-xs sm:!min-h-10 sm:!text-sm" onClick={() => refreshSchedule(true)} disabled={loading}>
                 <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />
                 Refresh
               </button>
@@ -557,7 +556,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
               onPlayerChange={setSelectedPlayerId}
               onTeamChange={setSelectedTeamId}
               onTimeRangeChange={setTimeRange}
-              onRefresh={refreshSchedule}
+              onRefresh={() => refreshSchedule(true)}
               onExport={handleExport}
               advancedControlsOpen={desktopAdvancedControlsOpen}
               onAdvancedControlsOpenChange={setDesktopAdvancedControlsOpen}

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -316,7 +316,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
     try {
       const result = await removeTeamCalendarUrl(selectedCalendarTeam.teamId, url, auth.user);
       setStatusMessage(result.removed ? 'Calendar link removed. Refreshing schedule…' : 'Calendar link was already removed. Refreshing schedule…');
-      await refreshSchedule();
+      await refreshSchedule(true);
       setStatusMessage(result.removed ? 'Calendar link removed and schedule refreshed.' : 'Calendar link was already removed. Schedule refreshed.');
     } catch (removeError: any) {
       setCalendarUrlError(removeError?.message || 'Unable to remove calendar link.');

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -27,7 +27,7 @@ import {
 import { RoleBadge } from '../components/Badges';
 import { PublicTeamSearch } from '../components/PublicTeamSearch';
 import { getEventDetailPath, getPlayerDetailPath, type ParentHomeModel, type ParentHomeTeam } from '../lib/homeLogic';
-import { loadParentHomeSummary } from '../lib/homeService';
+import { loadParentHomeSummary, loadParentTeamsSummary } from '../lib/homeService';
 import { openPublicUrl } from '../lib/publicActions';
 import { useShellLayout } from '../lib/useShellLayout';
 import {
@@ -74,7 +74,16 @@ export function Teams({ auth }: { auth: AuthState }) {
     }
     setError('');
     try {
-      setHome(await loadParentHomeSummary(auth.user, { force: !showLoading }));
+      const fastHome = await loadParentTeamsSummary(auth.user, { force: !showLoading });
+      setHome(fastHome);
+      setLoading(false);
+      setRefreshing(true);
+      try {
+        const enrichedHome = await loadParentHomeSummary(auth.user, { force: !showLoading });
+        setHome((current) => mergeTeamSummary(current, enrichedHome));
+      } catch (enrichError) {
+        console.warn('[teams-page] Unable to enrich team summary:', enrichError);
+      }
     } catch (loadError: any) {
       setError(loadError?.message || 'Unable to load teams.');
       setHome(emptyHome());
@@ -146,6 +155,21 @@ export function Teams({ auth }: { auth: AuthState }) {
       <PublicTeamSearch />
     </div>
   );
+}
+
+function mergeTeamSummary(current: ParentHomeModel, enriched: ParentHomeModel): ParentHomeModel {
+  if (!enriched.teams.length) return current;
+  const currentByTeamId = new Map(current.teams.map((team) => [team.teamId, team]));
+  return {
+    ...enriched,
+    teams: enriched.teams.map((team) => ({
+      ...team,
+      unreadCount: currentByTeamId.get(team.teamId)?.unreadCount || team.unreadCount,
+      role: currentByTeamId.get(team.teamId)?.role || team.role,
+      sport: currentByTeamId.get(team.teamId)?.sport || team.sport,
+      photoUrl: currentByTeamId.get(team.teamId)?.photoUrl || team.photoUrl
+    }))
+  };
 }
 
 function TeamsHeader({ loading, refreshing, teams, teamRoles, onRefresh }: {

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -1058,7 +1058,7 @@
 
         function loadFirebaseModule() {
             if (!firebaseModulePromise) {
-                firebaseModulePromise = import('./js/firebase.js?v=15').catch((error) => {
+                firebaseModulePromise = import('./js/firebase.js?v=16').catch((error) => {
                     firebaseModulePromise = null;
                     throw error;
                 });

--- a/edit-roster.html
+++ b/edit-roster.html
@@ -533,11 +533,11 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getPlayers, addPlayer, deactivatePlayer, reactivatePlayer, getGames, uploadPlayerPhoto, updatePlayer, setPlayerPrivateRosterProfileFields, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount, listTeamParentMembershipRequests, approveParentMembershipRequest, denyParentMembershipRequest, getRosterFieldDefinitions, saveRosterFieldDefinition, disableRosterFieldDefinition, reorderRosterFieldDefinitions, listTeamRegistrationForms, listTeamRegistrationReviews, approveTeamRegistration, rejectTeamRegistration, extendTeamRegistrationOffer, releaseTeamRegistrationWaitlist, listTeamTrackingItems, createTeamTrackingItem, listTeamTrackingStatuses, setTeamTrackingStatus } from './js/db.js?v=33';
+        import { getTeam, getPlayers, addPlayer, deactivatePlayer, reactivatePlayer, getGames, uploadPlayerPhoto, updatePlayer, setPlayerPrivateRosterProfileFields, inviteParent, removeParentFromPlayer, getAllUsers, getUnreadChatCount, listTeamParentMembershipRequests, approveParentMembershipRequest, denyParentMembershipRequest, getRosterFieldDefinitions, saveRosterFieldDefinition, disableRosterFieldDefinition, reorderRosterFieldDefinitions, listTeamRegistrationForms, listTeamRegistrationReviews, approveTeamRegistration, rejectTeamRegistration, extendTeamRegistrationOffer, releaseTeamRegistrationWaitlist, listTeamTrackingItems, createTeamTrackingItem, listTeamTrackingStatuses, setTeamTrackingStatus } from './js/db.js?v=34';
         import { buildRosterFieldDefinitionPayload, collectRosterProfileValues, getRosterProfileValues, normalizeRosterFieldDefinitions, planRosterCsvImport, renderRosterProfileFields, validateRosterProfileValues } from './js/roster-profile-fields.js?v=3';
         import { buildTrackingStatusPayload, mergeTrackingStatusRows, normalizeTrackingItemDraft, summarizeTrackingStatus } from './js/tracking-status-admin.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
-        import { checkAuth, sendInviteEmail } from './js/auth.js?v=14';
+        import { checkAuth, sendInviteEmail } from './js/auth.js?v=15';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { hasFullTeamAccess } from './js/team-access.js';
         import { formatRegistrationRosterImportResults, getRegistrationRosterPlayers, isExternallyLinkedRosterTeam, planRegistrationRosterImport } from './js/edit-roster-registration-import.js?v=1';
@@ -1058,7 +1058,7 @@
 
         function loadFirebaseModule() {
             if (!firebaseModulePromise) {
-                firebaseModulePromise = import('./js/firebase.js?v=16').catch((error) => {
+                firebaseModulePromise = import('./js/firebase.js?v=17').catch((error) => {
                     firebaseModulePromise = null;
                     throw error;
                 });

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -934,7 +934,7 @@
         import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=1';
         import { buildSeasonRecordGameFields, hydrateSeasonRecordFormFields } from './js/edit-schedule-season-record.js?v=1';
         import { normalizeOfficialsDirectory } from './js/officiating-slots.js?v=1';
-        import { Timestamp, deleteField, auth } from "./js/firebase.js?v=15";
+        import { Timestamp, deleteField, auth } from "./js/firebase.js?v=16";
         import { getApp } from './js/vendor/firebase-app.js';
         import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
         import { buildPoolStandingsIndex, collectTournamentAdvancementPatches, collectTournamentPoolSeeds, describeTournamentSource, planTournamentPoolAdvancement } from './js/tournament-brackets.js?v=2';

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -919,10 +919,10 @@
     </div>
 
     <script type="module">
-        import { getTeam, getTeams, getGames, getEvents, addGame, updateGame, updateTeam, deleteGame, addPractice, updateEvent, deleteEvent, getConfigs, addCalendarToTeam, removeCalendarFromTeam, getTrackedCalendarEventUids, cancelOccurrence, updateOccurrence, restoreOccurrence, clearOccurrenceOverride, updateSeries, deleteSeries, getUnreadChatCount, getPracticeSessions, cancelGame, getLatestGameAssignments, postChatMessage, getRsvpBreakdownByPlayer, getPlayers, getRsvps, applyTournamentAdvancementPatches, saveTournamentPoolOverride, clearTournamentPoolOverride, getOfficials, addOfficial, updateOfficial, deleteOfficial, createOfficiatingAssignmentNotificationRecords } from './js/db.js?v=32';
+        import { getTeam, getTeams, getGames, getEvents, addGame, updateGame, updateTeam, deleteGame, addPractice, updateEvent, deleteEvent, getConfigs, addCalendarToTeam, removeCalendarFromTeam, getTrackedCalendarEventUids, cancelOccurrence, updateOccurrence, restoreOccurrence, clearOccurrenceOverride, updateSeries, deleteSeries, getUnreadChatCount, getPracticeSessions, cancelGame, getLatestGameAssignments, postChatMessage, getRsvpBreakdownByPlayer, getPlayers, getRsvps, applyTournamentAdvancementPatches, saveTournamentPoolOverride, clearTournamentPoolOverride, getOfficials, addOfficial, updateOfficial, deleteOfficial, createOfficiatingAssignmentNotificationRecords } from './js/db.js?v=33';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, formatTimeRange, getDefaultEndTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, getCalendarEventStatus, getCalendarEventTrackingId, isTrackedCalendarEvent, generateSeriesId, expandRecurrence, formatRecurrence, shareOrCopy, escapeHtml } from './js/utils.js?v=10';
         import { mergeCalendarImportEvents, validateCalendarImportUrl } from './js/edit-schedule-calendar-import.js?v=1';
-        import { checkAuth } from './js/auth.js?v=15';
+        import { checkAuth } from './js/auth.js?v=16';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { computeOfficiatingCoverageStatus, flagRescheduledOfficiatingSlots, getOfficiatingAssignmentConflictWarnings, normalizeOfficiatingSlots as normalizeAssignmentOfficiatingSlots } from './js/officiating-utils.js?v=3';
         import { buildOfficiatingAssignmentNotificationRecords } from './js/officiating-notifications.js?v=2';
@@ -934,7 +934,7 @@
         import { savePracticeForm } from './js/edit-schedule-practice-submit.js?v=1';
         import { buildSeasonRecordGameFields, hydrateSeasonRecordFormFields } from './js/edit-schedule-season-record.js?v=1';
         import { normalizeOfficialsDirectory } from './js/officiating-slots.js?v=1';
-        import { Timestamp, deleteField, auth } from "./js/firebase.js?v=16";
+        import { Timestamp, deleteField, auth } from "./js/firebase.js?v=17";
         import { getApp } from './js/vendor/firebase-app.js';
         import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
         import { buildPoolStandingsIndex, collectTournamentAdvancementPatches, collectTournamentPoolSeeds, describeTournamentSource, planTournamentPoolAdvancement } from './js/tournament-brackets.js?v=2';

--- a/edit-team.html
+++ b/edit-team.html
@@ -558,7 +558,7 @@
         import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers } from './js/db.js?v=33';
         import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
-        import { checkAuth, sendInviteEmail } from './js/auth.js?v=15';
+        import { checkAuth, sendInviteEmail } from './js/auth.js?v=16';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { normalizeYouTubeEmbedUrl } from './js/live-stream-utils.js?v=1';
         import { hasFullTeamAccess, normalizeAdminEmailList, normalizeStreamVolunteerEmailList, normalizeTeamPermissions } from './js/team-access.js?v=3';

--- a/game.html
+++ b/game.html
@@ -388,12 +388,12 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getUnreadChatCounts, getUserProfile, updateGame, uploadStatSheetPhoto, setCompletedGamePlayerStats, getTeamStatsForGame, setCompletedGameTeamStats } from './js/db.js?v=32';
+        import { getTeam, getGame, getPlayers, getUnreadChatCounts, getUserProfile, updateGame, uploadStatSheetPhoto, setCompletedGamePlayerStats, getTeamStatsForGame, setCompletedGameTeamStats } from './js/db.js?v=33';
         import { generateGameInsights } from './js/post-game-insights.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
-        import { checkAuth } from './js/auth.js?v=15';
-        import { collection, getDocs, query, orderBy } from "./js/firebase.js?v=16";
-        import { db } from './js/firebase.js?v=16';
+        import { checkAuth } from './js/auth.js?v=16';
+        import { collection, getDocs, query, orderBy } from "./js/firebase.js?v=17";
+        import { db } from './js/firebase.js?v=17';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js';
         import { resolveLiveStatConfig } from './js/live-game-state.js?v=3';
         import { splitPlayerStatsByVisibility } from './js/stat-leaderboards.js?v=2';

--- a/game.html
+++ b/game.html
@@ -392,8 +392,8 @@
         import { generateGameInsights } from './js/post-game-insights.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, escapeHtml, shareOrCopy } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=15';
-        import { collection, getDocs, query, orderBy } from "./js/firebase.js?v=15";
-        import { db } from './js/firebase.js?v=15';
+        import { collection, getDocs, query, orderBy } from "./js/firebase.js?v=16";
+        import { db } from './js/firebase.js?v=16';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js';
         import { resolveLiveStatConfig } from './js/live-game-state.js?v=3';
         import { splitPlayerStatsByVisibility } from './js/stat-leaderboards.js?v=2';

--- a/js/admin-invite.js
+++ b/js/admin-invite.js
@@ -1,4 +1,4 @@
-import { redeemAdminInviteAtomicPersistence } from './db.js?v=32';
+import { redeemAdminInviteAtomicPersistence } from './db.js?v=33';
 
 export async function redeemAdminInviteAcceptance({
     userId,

--- a/js/admin.js
+++ b/js/admin.js
@@ -8,7 +8,7 @@ import {
     getTelemetryEventDaily,
     getTelemetrySessions
 } from './db.js?v=32';
-import { db, collection, getDocs, doc, setDoc, updateDoc, serverTimestamp } from './firebase.js?v=15';
+import { db, collection, getDocs, doc, setDoc, updateDoc, serverTimestamp } from './firebase.js?v=16';
 import { renderHeader, renderFooter, escapeHtml } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=15';
 import {

--- a/js/admin.js
+++ b/js/admin.js
@@ -7,10 +7,10 @@ import {
     getTelemetryPageDaily,
     getTelemetryEventDaily,
     getTelemetrySessions
-} from './db.js?v=32';
-import { db, collection, getDocs, doc, setDoc, updateDoc, serverTimestamp } from './firebase.js?v=16';
+} from './db.js?v=33';
+import { db, collection, getDocs, doc, setDoc, updateDoc, serverTimestamp } from './firebase.js?v=17';
 import { renderHeader, renderFooter, escapeHtml } from './utils.js?v=8';
-import { checkAuth } from './auth.js?v=15';
+import { checkAuth } from './auth.js?v=16';
 import {
     adminRegistrationDefaults,
     buildAdminRegistrationFormPayload,
@@ -107,7 +107,7 @@ async function loadGameStats() {
     // Load games from all teams
     const gamesPromises = allTeams.map(async (team) => {
         try {
-            const { getGames } = await import('./db.js?v=32');
+            const { getGames } = await import('./db.js?v=33');
             const games = await getGames(team.id);
             return games.map(g => ({ ...g, teamId: team.id, teamName: team.name }));
         } catch (e) {

--- a/js/auth.js
+++ b/js/auth.js
@@ -14,8 +14,8 @@ import {
     isSignInWithEmailLink,
     signInWithEmailLink,
     updatePassword
-} from './firebase.js?v=16';
-import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, getUserProfile, getUserTeams, getUserByEmail, getTeam, listMyParentMembershipRequests } from './db.js?v=32';
+} from './firebase.js?v=17';
+import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, getUserProfile, getUserTeams, getUserByEmail, getTeam, listMyParentMembershipRequests } from './db.js?v=33';
 import { executeEmailPasswordSignup } from './signup-flow.js?v=3';
 import { redeemAdminInviteAcceptance } from './admin-invite.js?v=4';
 import { mergeApprovedParentMembershipRequests } from './parent-membership-utils.js?v=1';

--- a/js/auth.js
+++ b/js/auth.js
@@ -14,7 +14,7 @@ import {
     isSignInWithEmailLink,
     signInWithEmailLink,
     updatePassword
-} from './firebase.js?v=15';
+} from './firebase.js?v=16';
 import { validateAccessCode, markAccessCodeAsUsed, updateUserProfile, redeemParentInvite, getUserProfile, getUserTeams, getUserByEmail, getTeam, listMyParentMembershipRequests } from './db.js?v=32';
 import { executeEmailPasswordSignup } from './signup-flow.js?v=3';
 import { redeemAdminInviteAcceptance } from './admin-invite.js?v=4';

--- a/js/certificates/assets.js
+++ b/js/certificates/assets.js
@@ -7,7 +7,7 @@ import {
     ref,
     uploadBytes,
     getDownloadURL
-} from '../firebase.js?v=15';
+} from '../firebase.js?v=16';
 
 const MAX_CERTIFICATE_ASSET_BYTES = 5 * 1024 * 1024;
 const ALLOWED_CERTIFICATE_IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/jpg', 'image/webp']);

--- a/js/certificates/assets.js
+++ b/js/certificates/assets.js
@@ -7,7 +7,7 @@ import {
     ref,
     uploadBytes,
     getDownloadURL
-} from '../firebase.js?v=16';
+} from '../firebase.js?v=17';
 
 const MAX_CERTIFICATE_ASSET_BYTES = 5 * 1024 * 1024;
 const ALLOWED_CERTIFICATE_IMAGE_TYPES = new Set(['image/png', 'image/jpeg', 'image/jpg', 'image/webp']);

--- a/js/db.js
+++ b/js/db.js
@@ -32,7 +32,7 @@ import {
     uploadBytes,
     getDownloadURL,
     deleteObject
-} from './firebase.js?v=15';
+} from './firebase.js?v=16';
 import { imageStorage, ensureImageAuth, requireImageAuth } from './firebase-images.js?v=6';
 import { uploadBytesResumable } from './vendor/firebase-storage.js';
 import { buildDrillDiagramUploadPaths } from './drill-upload-paths.js?v=1';

--- a/js/db.js
+++ b/js/db.js
@@ -32,7 +32,7 @@ import {
     uploadBytes,
     getDownloadURL,
     deleteObject
-} from './firebase.js?v=16';
+} from './firebase.js?v=17';
 import { imageStorage, ensureImageAuth, requireImageAuth } from './firebase-images.js?v=6';
 import { uploadBytesResumable } from './vendor/firebase-storage.js';
 import { buildDrillDiagramUploadPaths } from './drill-upload-paths.js?v=1';

--- a/js/family-plan.js
+++ b/js/family-plan.js
@@ -35,7 +35,7 @@ function normalizePlayerLinks(playerLinks = []) {
 
 function loadFirebase(deps = {}) {
     if (deps.firebase) return Promise.resolve(deps.firebase);
-    return import('./firebase.js?v=15');
+    return import('./firebase.js?v=16');
 }
 
 function normalizeAccessLinks(links = []) {

--- a/js/family-plan.js
+++ b/js/family-plan.js
@@ -35,7 +35,7 @@ function normalizePlayerLinks(playerLinks = []) {
 
 function loadFirebase(deps = {}) {
     if (deps.firebase) return Promise.resolve(deps.firebase);
-    return import('./firebase.js?v=16');
+    return import('./firebase.js?v=17');
 }
 
 function normalizeAccessLinks(links = []) {

--- a/js/firebase.js
+++ b/js/firebase.js
@@ -1,4 +1,4 @@
-import { initializeApp } from "./vendor/firebase-app.js";
+import { getApp, getApps, initializeApp } from "./vendor/firebase-app.js";
 import {
     getAuth,
     indexedDBLocalPersistence,
@@ -55,7 +55,7 @@ import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=8";
 
 const firebaseConfig = await resolvePrimaryFirebaseConfig();
 
-const app = initializeApp(firebaseConfig);
+const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
 function isCapacitorNativeRuntime() {
     const protocol = typeof window !== 'undefined' ? window.location?.protocol : '';
     if (protocol === 'capacitor:' || protocol === 'ionic:') {

--- a/js/firebase.js
+++ b/js/firebase.js
@@ -1,4 +1,4 @@
-import { getApp, getApps, initializeApp } from "./vendor/firebase-app.js";
+import { getApps, initializeApp } from "./vendor/firebase-app.js";
 import {
     getAuth,
     indexedDBLocalPersistence,
@@ -55,7 +55,8 @@ import { resolvePrimaryFirebaseConfig } from "./firebase-runtime-config.js?v=8";
 
 const firebaseConfig = await resolvePrimaryFirebaseConfig();
 
-const app = getApps().length ? getApp() : initializeApp(firebaseConfig);
+const existingDefaultApp = getApps().find((candidate) => candidate.name === '[DEFAULT]');
+const app = existingDefaultApp || initializeApp(firebaseConfig);
 function isCapacitorNativeRuntime() {
     const protocol = typeof window !== 'undefined' ? window.location?.protocol : '';
     if (protocol === 'capacitor:' || protocol === 'ionic:') {

--- a/js/global-search.js
+++ b/js/global-search.js
@@ -9,7 +9,7 @@ import {
     where,
     orderBy,
     limit
-} from './firebase.js?v=15';
+} from './firebase.js?v=16';
 
 let cachedTeams = null;
 let cachedTeamsLoadedAt = 0;

--- a/js/global-search.js
+++ b/js/global-search.js
@@ -1,5 +1,5 @@
 import { escapeHtml } from './utils.js?v=8';
-import { getTeams } from './db.js?v=32';
+import { getTeams } from './db.js?v=33';
 import { canUserDiscoverPlayerInSearch, filterSearchableTeams } from './global-search-visibility.js?v=2';
 import {
     db,
@@ -9,7 +9,7 @@ import {
     where,
     orderBy,
     limit
-} from './firebase.js?v=16';
+} from './firebase.js?v=17';
 
 let cachedTeams = null;
 let cachedTeamsLoadedAt = 0;

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -20,7 +20,7 @@ import { getUrlParams, escapeHtml, renderHeader, renderFooter, formatShortDate, 
 import { hasFullTeamAccess } from './team-access.js?v=1';
 import { buildScoreLinkedClipRecord, isScoredPlayEvent, validateGameClipFile } from './game-clips.js?v=1';
 import { computePanelVisibility } from './live-stream-utils.js?v=1';
-import { checkAuth } from './auth.js?v=15';
+import { checkAuth } from './auth.js?v=16';
 import { isViewerChatEnabled } from './live-game-chat.js?v=1';
 import { createPlayAnnouncer } from './live-game-announcer.js?v=1';
 import {

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -1,9 +1,9 @@
 // Mobile-first basketball tracker, now backed by Firebase like track.html.
-import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=32';
-import { db } from './firebase.js?v=16';
+import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=33';
+import { db } from './firebase.js?v=17';
 import { getUrlParams, escapeHtml } from './utils.js?v=9';
-import { checkAuth } from './auth.js?v=15';
-import { writeBatch, doc, setDoc, addDoc, onSnapshot, serverTimestamp } from './firebase.js?v=16';
+import { checkAuth } from './auth.js?v=16';
+import { writeBatch, doc, setDoc, addDoc, onSnapshot, serverTimestamp } from './firebase.js?v=17';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
 import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './live-tracker-notes.js?v=1';

--- a/js/live-tracker.js
+++ b/js/live-tracker.js
@@ -1,9 +1,9 @@
 // Mobile-first basketball tracker, now backed by Firebase like track.html.
 import { getTeam, getTeams, getGame, getPlayers, getConfigs, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, subscribeLiveChat, postLiveChatMessage, setGameLiveStatus } from './db.js?v=32';
-import { db } from './firebase.js?v=15';
+import { db } from './firebase.js?v=16';
 import { getUrlParams, escapeHtml } from './utils.js?v=9';
 import { checkAuth } from './auth.js?v=15';
-import { writeBatch, doc, setDoc, addDoc, onSnapshot, serverTimestamp } from './firebase.js?v=15';
+import { writeBatch, doc, setDoc, addDoc, onSnapshot, serverTimestamp } from './firebase.js?v=16';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
 import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, buildGameNoteLogText } from './live-tracker-notes.js?v=1';

--- a/js/premium-entitlements.js
+++ b/js/premium-entitlements.js
@@ -74,7 +74,7 @@ export function isValidPremiumEntitlementRecord(data, { scope, teamId = '', user
 
 async function loadFirebase(deps = {}) {
     if (deps.firebase) return deps.firebase;
-    return import('./firebase.js?v=16');
+    return import('./firebase.js?v=17');
 }
 
 function dataFromSnapshot(docSnap) {

--- a/js/premium-entitlements.js
+++ b/js/premium-entitlements.js
@@ -74,7 +74,7 @@ export function isValidPremiumEntitlementRecord(data, { scope, teamId = '', user
 
 async function loadFirebase(deps = {}) {
     if (deps.firebase) return deps.firebase;
-    return import('./firebase.js?v=15');
+    return import('./firebase.js?v=16');
 }
 
 function dataFromSnapshot(docSnap) {

--- a/js/schedule-print.js
+++ b/js/schedule-print.js
@@ -1,6 +1,12 @@
 function toDate(value) {
     if (!value) return null;
     if (value instanceof Date) return value;
+    if (typeof value === 'string') {
+        const dateOnly = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
+        if (dateOnly) {
+            return new Date(Number(dateOnly[1]), Number(dateOnly[2]) - 1, Number(dateOnly[3]));
+        }
+    }
     if (typeof value.toDate === 'function') return value.toDate();
     const date = new Date(value);
     return Number.isNaN(date.getTime()) ? null : date;

--- a/js/team-email-attachments.js
+++ b/js/team-email-attachments.js
@@ -12,7 +12,7 @@ import {
     uploadBytes,
     getDownloadURL,
     deleteObject
-} from './firebase.js?v=15';
+} from './firebase.js?v=16';
 
 export const TEAM_EMAIL_ATTACHMENT_LIMIT_BYTES = 20 * 1024 * 1024;
 

--- a/js/team-email-attachments.js
+++ b/js/team-email-attachments.js
@@ -12,7 +12,7 @@ import {
     uploadBytes,
     getDownloadURL,
     deleteObject
-} from './firebase.js?v=16';
+} from './firebase.js?v=17';
 
 export const TEAM_EMAIL_ATTACHMENT_LIMIT_BYTES = 20 * 1024 * 1024;
 

--- a/js/team-entitlements.js
+++ b/js/team-entitlements.js
@@ -1,4 +1,4 @@
-import { db, doc, getDoc } from './firebase.js?v=15';
+import { db, doc, getDoc } from './firebase.js?v=16';
 import {
     TEAM_PASS_TIER,
     buildTeamEntitlementId,

--- a/js/team-entitlements.js
+++ b/js/team-entitlements.js
@@ -1,4 +1,4 @@
-import { db, doc, getDoc } from './firebase.js?v=16';
+import { db, doc, getDoc } from './firebase.js?v=17';
 import {
     TEAM_PASS_TIER,
     buildTeamEntitlementId,

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -565,7 +565,7 @@ export function buildOnlineRefundRequest({ amount, reason, teamId, batchId, reci
 }
 
 export async function submitOnlineTeamFeeRefund(request) {
-    const { getFunctions, httpsCallable } = await import('./firebase.js?v=16');
+    const { getFunctions, httpsCallable } = await import('./firebase.js?v=17');
     const functions = getFunctions();
     const refundTeamFee = httpsCallable(functions, 'refundStripeTeamFeePayment');
     const result = await refundTeamFee(request);
@@ -1140,8 +1140,8 @@ async function initTeamFeesAdminPage() {
     renderFooter(document.getElementById('footer-container'));
 
     const [{ getTeam, getPlayers, getUserProfile, createTeamFeeBatch, getTeamFeeBatch, listTeamFeeBatches, listTeamFeeRecipients, updateTeamFeeRecipient, canModerateChat }, { requireAuth }] = await Promise.all([
-        import('./db.js?v=32'),
-        import('./auth.js?v=12')
+        import('./db.js?v=33'),
+        import('./auth.js?v=13')
     ]);
 
     try {

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -565,7 +565,7 @@ export function buildOnlineRefundRequest({ amount, reason, teamId, batchId, reci
 }
 
 export async function submitOnlineTeamFeeRefund(request) {
-    const { getFunctions, httpsCallable } = await import('./firebase.js?v=15');
+    const { getFunctions, httpsCallable } = await import('./firebase.js?v=16');
     const functions = getFunctions();
     const refundTeamFee = httpsCallable(functions, 'refundStripeTeamFeePayment');
     const result = await refundTeamFee(request);

--- a/js/team-pass.js
+++ b/js/team-pass.js
@@ -1,4 +1,4 @@
-import { auth } from './firebase.js?v=15';
+import { auth } from './firebase.js?v=16';
 import { hasFullTeamAccess } from './team-access.js';
 
 function getFunctionsBaseUrl() {
@@ -117,7 +117,7 @@ function arrayIncludesTeamId(values, teamId) {
 
 function loadFirebase(deps = {}) {
     if (deps.firebase) return deps.firebase;
-    return import('./firebase.js?v=15');
+    return import('./firebase.js?v=16');
 }
 
 function dataFromSnapshot(docSnap) {

--- a/js/team-pass.js
+++ b/js/team-pass.js
@@ -1,4 +1,4 @@
-import { auth } from './firebase.js?v=16';
+import { auth } from './firebase.js?v=17';
 import { hasFullTeamAccess } from './team-access.js';
 
 function getFunctionsBaseUrl() {
@@ -117,7 +117,7 @@ function arrayIncludesTeamId(values, teamId) {
 
 function loadFirebase(deps = {}) {
     if (deps.firebase) return deps.firebase;
-    return import('./firebase.js?v=16');
+    return import('./firebase.js?v=17');
 }
 
 function dataFromSnapshot(docSnap) {

--- a/js/telemetry.js
+++ b/js/telemetry.js
@@ -39,7 +39,7 @@ let firebaseAuthModulePromise = null;
 
 function loadFirebaseAuthModule() {
     if (!firebaseAuthModulePromise) {
-        firebaseAuthModulePromise = import('./firebase.js?v=16')
+        firebaseAuthModulePromise = import('./firebase.js?v=17')
             .then((module) => ({
                 auth: module.auth,
                 onAuthStateChanged: module.onAuthStateChanged

--- a/js/telemetry.js
+++ b/js/telemetry.js
@@ -39,7 +39,7 @@ let firebaseAuthModulePromise = null;
 
 function loadFirebaseAuthModule() {
     if (!firebaseAuthModulePromise) {
-        firebaseAuthModulePromise = import('./firebase.js?v=15')
+        firebaseAuthModulePromise = import('./firebase.js?v=16')
             .then((module) => ({
                 auth: module.auth,
                 onAuthStateChanged: module.onAuthStateChanged

--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -1,9 +1,9 @@
 // Mobile-first basketball tracker, now backed by Firebase like track.html.
-import { getTeam, getGame, getPlayers, getConfigs, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './db.js?v=32';
-import { db } from './firebase.js?v=16';
+import { getTeam, getGame, getPlayers, getConfigs, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './db.js?v=33';
+import { db } from './firebase.js?v=17';
 import { getUrlParams, escapeHtml } from './utils.js?v=8';
-import { checkAuth } from './auth.js?v=15';
-import { writeBatch, doc, setDoc, addDoc } from './firebase.js?v=16';
+import { checkAuth } from './auth.js?v=16';
+import { writeBatch, doc, setDoc, addDoc } from './firebase.js?v=17';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
 import { canApplySubstitution, applySubstitution, resolveFinalScoreForCompletion } from './live-tracker-integrity.js?v=3';

--- a/js/track-basketball.js
+++ b/js/track-basketball.js
@@ -1,9 +1,9 @@
 // Mobile-first basketball tracker, now backed by Firebase like track.html.
 import { getTeam, getGame, getPlayers, getConfigs, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './db.js?v=32';
-import { db } from './firebase.js?v=15';
+import { db } from './firebase.js?v=16';
 import { getUrlParams, escapeHtml } from './utils.js?v=8';
 import { checkAuth } from './auth.js?v=15';
-import { writeBatch, doc, setDoc, addDoc } from './firebase.js?v=15';
+import { writeBatch, doc, setDoc, addDoc } from './firebase.js?v=16';
 import { getAI, getGenerativeModel, GoogleAIBackend } from './vendor/firebase-ai.js';
 import { getApp } from './vendor/firebase-app.js';
 import { canApplySubstitution, applySubstitution, resolveFinalScoreForCompletion } from './live-tracker-integrity.js?v=3';

--- a/js/tracking-items-admin.js
+++ b/js/tracking-items-admin.js
@@ -204,9 +204,9 @@ async function initTrackingItemsAdminPage() {
     renderFooter(document.getElementById('footer-container'));
 
     const [dbModule, authModule, firebaseModule] = await Promise.all([
-        import('./db.js?v=32'),
-        import('./auth.js?v=13'),
-        import('./firebase.js?v=16')
+        import('./db.js?v=33'),
+        import('./auth.js?v=14'),
+        import('./firebase.js?v=17')
     ]);
     const { getTeam, getUserProfile, canModerateChat } = dbModule;
     const { requireAuth } = authModule;

--- a/js/tracking-items-admin.js
+++ b/js/tracking-items-admin.js
@@ -206,7 +206,7 @@ async function initTrackingItemsAdminPage() {
     const [dbModule, authModule, firebaseModule] = await Promise.all([
         import('./db.js?v=32'),
         import('./auth.js?v=13'),
-        import('./firebase.js?v=15')
+        import('./firebase.js?v=16')
     ]);
     const { getTeam, getUserProfile, canModerateChat } = dbModule;
     const { requireAuth } = authModule;

--- a/js/utils.js
+++ b/js/utils.js
@@ -183,7 +183,7 @@ export function renderHeader(container, user) {
 
     // Add logout handler
     navLogout.addEventListener('click', async () => {
-      const { logout } = await import('./auth.js?v=15');
+      const { logout } = await import('./auth.js?v=16');
       await logout();
       window.location.href = 'index.html';
     });

--- a/login.html
+++ b/login.html
@@ -97,7 +97,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=15';
+        import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=16';
         import { getUserProfile } from './js/db.js?v=32';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import { getPostAuthRedirectUrl } from './js/invite-redirect.js?v=1';

--- a/organization-schedule.html
+++ b/organization-schedule.html
@@ -324,8 +324,8 @@
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=10';
         import { checkAuth } from './js/auth.js?v=15';
         import { getTeamAccessInfo } from './js/team-access.js';
-        import { addDoc, collection, db, deleteDoc, doc, getDocs, Timestamp, updateDoc } from './js/firebase.js?v=15';
-        import { functions, httpsCallable } from './js/firebase.js?v=15';
+        import { addDoc, collection, db, deleteDoc, doc, getDocs, Timestamp, updateDoc } from './js/firebase.js?v=16';
+        import { functions, httpsCallable } from './js/firebase.js?v=16';
         import {
             ORGANIZATION_SCHEDULE_WEEKDAYS,
             buildBlackoutDatePayload,

--- a/organization-schedule.html
+++ b/organization-schedule.html
@@ -319,13 +319,13 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { addGame, createOrganizationBlackout, createVenueAvailability, createVenueBlackout, getTeam, getTeams, getUserTeamsWithAccess, listOrganizationScheduleControls } from './js/db.js?v=32';
+        import { addGame, createOrganizationBlackout, createVenueAvailability, createVenueBlackout, getTeam, getTeams, getUserTeamsWithAccess, listOrganizationScheduleControls } from './js/db.js?v=33';
         import { parseCsvText } from './js/schedule-csv-import.js?v=2';
         import { renderHeader, renderFooter, getUrlParams } from './js/utils.js?v=10';
-        import { checkAuth } from './js/auth.js?v=15';
+        import { checkAuth } from './js/auth.js?v=16';
         import { getTeamAccessInfo } from './js/team-access.js';
-        import { addDoc, collection, db, deleteDoc, doc, getDocs, Timestamp, updateDoc } from './js/firebase.js?v=16';
-        import { functions, httpsCallable } from './js/firebase.js?v=16';
+        import { addDoc, collection, db, deleteDoc, doc, getDocs, Timestamp, updateDoc } from './js/firebase.js?v=17';
+        import { functions, httpsCallable } from './js/firebase.js?v=17';
         import {
             ORGANIZATION_SCHEDULE_WEEKDAYS,
             buildBlackoutDatePayload,

--- a/player.html
+++ b/player.html
@@ -236,15 +236,15 @@
     </div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getGames, getConfigs, updatePlayerProfile, updatePlayerPrivateProfile, getPlayerPrivateProfile, uploadPlayerPhoto, getUnreadChatCounts, getUserProfile, getRosterFieldDefinitions } from './js/db.js?v=33';
+        import { getTeam, getGame, getPlayers, getGames, getConfigs, updatePlayerProfile, updatePlayerPrivateProfile, getPlayerPrivateProfile, uploadPlayerPhoto, getUnreadChatCounts, getUserProfile, getRosterFieldDefinitions } from './js/db.js?v=34';
         import { collectRosterProfileValues, getRosterProfileValues, normalizeRosterFieldDefinitions, renderRosterProfileFields, validateRosterProfileValues } from './js/roster-profile-fields.js?v=2';
         import { generatePlayerGameInsights } from './js/post-game-insights.js?v=1';
         import { hasPlayerProfileParticipation, collectPlayerVideoClips } from './js/player-profile-stats.js?v=3';
         import { buildPlayerLeaderboardSnapshot, selectAnalyticsConfig, summarizePlayerTopStats } from './js/stat-leaderboards.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
-        import { checkAuth } from './js/auth.js?v=15';
-        import { collection, getDocs, doc, getDoc, query, orderBy } from "./js/firebase.js?v=16";
-        import { db } from './js/firebase.js?v=16';
+        import { checkAuth } from './js/auth.js?v=16';
+        import { collection, getDocs, doc, getDoc, query, orderBy } from "./js/firebase.js?v=17";
+        import { db } from './js/firebase.js?v=17';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js';
         import { hasFullTeamAccess } from './js/team-access.js';
         import { getVisibleRosterFieldValues } from './js/roster-field-privacy.js';

--- a/player.html
+++ b/player.html
@@ -243,8 +243,8 @@
         import { buildPlayerLeaderboardSnapshot, selectAnalyticsConfig, summarizePlayerTopStats } from './js/stat-leaderboards.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=15';
-        import { collection, getDocs, doc, getDoc, query, orderBy } from "./js/firebase.js?v=15";
-        import { db } from './js/firebase.js?v=15';
+        import { collection, getDocs, doc, getDoc, query, orderBy } from "./js/firebase.js?v=16";
+        import { db } from './js/firebase.js?v=16';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js';
         import { hasFullTeamAccess } from './js/team-access.js';
         import { getVisibleRosterFieldValues } from './js/roster-field-privacy.js';

--- a/public-rsvp.html
+++ b/public-rsvp.html
@@ -70,7 +70,7 @@
     </main>
 
     <script type="module">
-        import { auth } from './js/firebase.js?v=15';
+        import { auth } from './js/firebase.js?v=16';
 
         const params = new URLSearchParams(window.location.search);
         const token = params.get('token') || '';

--- a/public-rsvp.html
+++ b/public-rsvp.html
@@ -70,7 +70,7 @@
     </main>
 
     <script type="module">
-        import { auth } from './js/firebase.js?v=16';
+        import { auth } from './js/firebase.js?v=17';
 
         const params = new URLSearchParams(window.location.search);
         const token = params.get('token') || '';

--- a/registration.html
+++ b/registration.html
@@ -97,7 +97,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { db, doc, getDoc, collection, addDoc, serverTimestamp, runTransaction } from './js/firebase.js?v=16';
+        import { db, doc, getDoc, collection, addDoc, serverTimestamp, runTransaction } from './js/firebase.js?v=17';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import { cancelStripeRegistrationCheckout, initiateStripeCheckout } from './js/stripe-service.js';
         import {

--- a/registration.html
+++ b/registration.html
@@ -97,7 +97,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { db, doc, getDoc, collection, addDoc, serverTimestamp, runTransaction } from './js/firebase.js?v=15';
+        import { db, doc, getDoc, collection, addDoc, serverTimestamp, runTransaction } from './js/firebase.js?v=16';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import { cancelStripeRegistrationCheckout, initiateStripeCheckout } from './js/stripe-service.js';
         import {

--- a/reset-password.html
+++ b/reset-password.html
@@ -110,8 +110,8 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { auth } from './js/firebase.js?v=15';
-        import { verifyPasswordResetCode, confirmPasswordReset, applyActionCode } from "./js/firebase.js?v=15";
+        import { auth } from './js/firebase.js?v=16';
+        import { verifyPasswordResetCode, confirmPasswordReset, applyActionCode } from "./js/firebase.js?v=16";
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 
         renderHeader(document.getElementById('header-container'), null);

--- a/reset-password.html
+++ b/reset-password.html
@@ -110,8 +110,8 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { auth } from './js/firebase.js?v=16';
-        import { verifyPasswordResetCode, confirmPasswordReset, applyActionCode } from "./js/firebase.js?v=16";
+        import { auth } from './js/firebase.js?v=17';
+        import { verifyPasswordResetCode, confirmPasswordReset, applyActionCode } from "./js/firebase.js?v=17";
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 
         renderHeader(document.getElementById('header-container'), null);

--- a/team.html
+++ b/team.html
@@ -324,7 +324,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, grantStreamScoreAccess, revokeStreamScoreAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=33';
+        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, grantStreamScoreAccess, revokeStreamScoreAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=34';
         import { normalizeExternalWebsiteUrl, selectRotatingSponsor } from './js/local-attractions.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, escapeHtml, shareOrCopy } from './js/utils.js?v=10';
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';
@@ -332,9 +332,9 @@
         import { computeTournamentPoolStandings } from './js/tournament-standings.js?v=3';
         import { aggregateSeasonStatsByPlayerId, buildPlayerLeaderboardSnapshot, selectAnalyticsConfig } from './js/stat-leaderboards.js?v=3';
         import { calculateSeasonRecord, listSeasonLabels } from './js/season-record.js';
-        import { checkAuth } from './js/auth.js?v=15';
-        import { collection, getDocs, query, where } from "./js/firebase.js?v=16";
-        import { db } from './js/firebase.js?v=16';
+        import { checkAuth } from './js/auth.js?v=16';
+        import { collection, getDocs, query, where } from "./js/firebase.js?v=17";
+        import { db } from './js/firebase.js?v=17';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js';
         import { getVisibleRosterFieldValues } from './js/roster-field-privacy.js';
         import { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';

--- a/team.html
+++ b/team.html
@@ -333,8 +333,8 @@
         import { aggregateSeasonStatsByPlayerId, buildPlayerLeaderboardSnapshot, selectAnalyticsConfig } from './js/stat-leaderboards.js?v=3';
         import { calculateSeasonRecord, listSeasonLabels } from './js/season-record.js';
         import { checkAuth } from './js/auth.js?v=15';
-        import { collection, getDocs, query, where } from "./js/firebase.js?v=15";
-        import { db } from './js/firebase.js?v=15';
+        import { collection, getDocs, query, where } from "./js/firebase.js?v=16";
+        import { db } from './js/firebase.js?v=16';
         import { renderTeamAdminBanner, getTeamAccessInfo } from './js/team-admin-banner.js';
         import { getVisibleRosterFieldValues } from './js/roster-field-privacy.js';
         import { buildAvailabilityNoteRows, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from './js/availability-preferences.js?v=1';

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -79,6 +79,10 @@ async function mockHomePlayerModules(page) {
                     return loadParentHome(...args);
                 }
 
+                export async function loadParentTeamsSummary(...args) {
+                    return loadParentHome(...args);
+                }
+
                 export async function loadParentHomeWithSecondaryData(...args) {
                     return loadParentHome(...args);
                 }

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -97,6 +97,10 @@ async function mockTeamsModules(page) {
                     return loadParentHome(...args);
                 }
 
+                export async function loadParentTeamsSummary(...args) {
+                    return loadParentHome(...args);
+                }
+
                 export async function loadParentHomeWithSecondaryData(...args) {
                     return loadParentHome(...args);
                 }

--- a/tests/smoke/edit-config-platform-admin.spec.js
+++ b/tests/smoke/edit-config-platform-admin.spec.js
@@ -199,7 +199,7 @@ async function mockDependencies(page) {
     }));
     await page.route('**/js/db.js?v=32', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: DB_STUB }));
     await page.route('**/js/utils.js?v=8', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: UTILS_STUB }));
-    await page.route('**/js/auth.js?v=15', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
+    await page.route('**/js/auth.js?v=*', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: AUTH_STUB }));
     await page.route('**/js/edit-config-access.js?v=2', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: EDIT_CONFIG_ACCESS_STUB }));
     await page.route(/\/js\/team-admin-banner\.js(?:\?v=\d+)?$/, (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: TEAM_ADMIN_BANNER_STUB }));
     await page.route('**/js/stat-leaderboards.js?v=2', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: STAT_LEADERBOARDS_STUB }));

--- a/tests/smoke/team-schedule-calendar.spec.js
+++ b/tests/smoke/team-schedule-calendar.spec.js
@@ -417,7 +417,7 @@ async function mockTeamPageModules(page, scenario) {
         contentType: 'application/javascript',
         body: SEASON_RECORD_STUB
     }));
-    await page.route('**/js/auth.js?v=15', (route) => route.fulfill({
+    await page.route('**/js/auth.js?v=*', (route) => route.fulfill({
         status: 200,
         contentType: 'application/javascript',
         body: AUTH_STUB

--- a/tests/unit/accept-invite-page.test.js
+++ b/tests/unit/accept-invite-page.test.js
@@ -103,7 +103,7 @@ const URLSearchParams = deps.URLSearchParams;
 const setTimeout = deps.setTimeout;
 ` + match[1]
         .replace(
-            "import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=15';",
+            "import { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } from './js/auth.js?v=16';",
             'const { isEmailSignInLink, completeEmailLinkSignIn, checkAuth, getRedirectUrl } = deps.auth;'
         )
         .replace(

--- a/tests/unit/access-code-validation.test.js
+++ b/tests/unit/access-code-validation.test.js
@@ -5,7 +5,7 @@ const collectionMock = vi.fn((database, path) => ({ database, path }));
 const whereMock = vi.fn((field, op, value) => ({ field, op, value }));
 const queryMock = vi.fn((...parts) => parts);
 
-vi.mock('../../js/firebase.js?v=15', () => ({
+vi.mock('../../js/firebase.js?v=16', () => ({
     db: {},
     auth: {},
     storage: {},

--- a/tests/unit/access-code-validation.test.js
+++ b/tests/unit/access-code-validation.test.js
@@ -5,7 +5,7 @@ const collectionMock = vi.fn((database, path) => ({ database, path }));
 const whereMock = vi.fn((field, op, value) => ({ field, op, value }));
 const queryMock = vi.fn((...parts) => parts);
 
-vi.mock('../../js/firebase.js?v=16', () => ({
+vi.mock('../../js/firebase.js?v=17', () => ({
     db: {},
     auth: {},
     storage: {},

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -8,7 +8,7 @@ describe('admin invite signup cache busting', () => {
 
         expect(authSource).toContain("import { executeEmailPasswordSignup } from './signup-flow.js?v=3';");
         expect(authSource).toContain("import { redeemAdminInviteAcceptance } from './admin-invite.js?v=4';");
-        expect(authSource).toContain("from './db.js?v=32';");
+        expect(authSource).toContain("from './db.js?v=33';");
     });
 
     it('pins fresh invite acceptance module versions for admin invite redemption', () => {
@@ -36,7 +36,7 @@ describe('admin invite signup cache busting', () => {
 
         for (const relativePath of authConsumers) {
             const source = readFileSync(resolve(process.cwd(), relativePath), 'utf8');
-            expect(source).toContain('auth.js?v=15');
+            expect(source).toContain('auth.js?v=16');
         }
     });
 });

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -35,6 +35,16 @@ describe('React app auth/profile capability parity', () => {
         expect(appRoutes).not.toContain('if (auth.loading) {');
     });
 
+    it('defaults a browser refresh on My Teams back to Home', () => {
+        const appRoutes = readProjectFile('apps/app/src/App.tsx');
+
+        expectContains(appRoutes, [
+            'location.pathname === \'/teams\'',
+            'isBrowserReload()',
+            'shouldDefaultReloadToHome ? <Navigate to="/home" replace />'
+        ]);
+    });
+
     it('hydrates team media upload grants into app auth users', () => {
         const authService = readProjectFile('apps/app/src/lib/authService.ts');
         const types = readProjectFile('apps/app/src/lib/types.ts');

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -24,7 +24,9 @@ describe('React app auth/profile capability parity', () => {
             'path="/accept-invite"',
             'path="/reset-password"',
             'path="/verify-pending"',
-            'path="/profile"'
+            'path="/profile"',
+            'path="/teams/:teamId/fees"',
+            'path="/teams/:teamId/fees/:batchId"'
         ]);
     });
 

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -189,6 +189,51 @@ describe('React app chat recipient service', () => {
         }));
     });
 
+    it('uses the newest accessible conversation message for inbox previews', async () => {
+        dbMocks.getUserProfile.mockResolvedValue({
+            email: 'parent@example.com',
+            parentOf: [{ teamId: 'team-parent', playerId: 'player-1' }]
+        });
+        dbMocks.getUserTeamsWithAccess.mockResolvedValue([]);
+        dbMocks.getParentTeams.mockResolvedValue([
+            { id: 'team-parent', name: 'Zebras', sport: 'Soccer' }
+        ]);
+        dbMocks.getChatConversations.mockResolvedValue([
+            { id: 'team', type: 'team', name: 'Zebras Team Chat', updatedAt: new Date('2026-05-21T12:00:00Z') },
+            { id: 'direct_user-1__coach-1', type: 'direct', name: 'Coach Morgan', participantIds: ['user-1', 'coach-1'], updatedAt: new Date('2026-05-21T13:00:00Z') }
+        ]);
+        dbMocks.getChatMessages.mockImplementation(async (teamId, options = {}) => {
+            if (options.conversationId === 'direct_user-1__coach-1') {
+                return [{
+                    id: 'direct-last',
+                    text: 'Uniform pickup moved to 6.',
+                    senderName: 'Coach Morgan',
+                    createdAt: new Date('2026-05-21T13:00:00Z')
+                }];
+            }
+            return [{
+                id: 'team-last',
+                text: 'Older team announcement.',
+                senderName: 'Coach Jamie',
+                createdAt: new Date('2026-05-21T12:00:00Z')
+            }];
+        });
+
+        const { loadChatInbox } = await import('../../apps/app/src/lib/chatService.ts');
+        const inbox = await loadChatInbox({
+            uid: 'user-1',
+            email: 'parent@example.com',
+            displayName: 'Pat Parent',
+            roles: ['parent']
+        });
+
+        expect(dbMocks.getChatMessages).toHaveBeenCalledWith('team-parent', { limit: 1, conversationId: 'direct_user-1__coach-1' });
+        expect(inbox.teams[0].lastMessage).toEqual(expect.objectContaining({
+            id: 'direct-last',
+            text: 'Uniform pickup moved to 6.'
+        }));
+    });
+
     it('returns no inbox teams for signed-out users', async () => {
         const { loadChatInbox } = await import('../../apps/app/src/lib/chatService.ts');
 

--- a/tests/unit/app-home-service.test.js
+++ b/tests/unit/app-home-service.test.js
@@ -112,7 +112,7 @@ describe('React app Home service', () => {
 
         const home = await loadParentHome(user);
 
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledWith(user, { hydrateDetails: true });
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledWith(user, { hydrateDetails: false });
         expect(chatMocks.loadChatInbox).toHaveBeenCalledWith(user);
         expect(dbMocks.listParentTeamFeeRecipients).toHaveBeenCalledWith(user.uid, [
             expect.objectContaining({ teamId: 'team-1', playerId: 'player-1' })

--- a/tests/unit/app-home-service.test.js
+++ b/tests/unit/app-home-service.test.js
@@ -214,8 +214,8 @@ describe('React app Home service', () => {
         const summary = await loadParentHomeSummary(user, { force: true });
         const detailed = await loadParentHomeWithSecondaryData(user, { force: true });
 
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledWith(user, { hydrateDetails: false });
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledWith(user, { hydrateDetails: true });
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(1, user, { hydrateDetails: false, expandStaffPlayers: false });
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(2, user, { hydrateDetails: true });
         expect(summary.actionItems.map((item) => item.kind)).toEqual(expect.arrayContaining(['rsvp', 'assignment']));
         expect(detailed.actionItems.map((item) => item.kind)).not.toEqual(expect.arrayContaining(['rsvp', 'assignment']));
         expect(detailed.metrics.rsvpNeeded).toBe(0);

--- a/tests/unit/app-home-service.test.js
+++ b/tests/unit/app-home-service.test.js
@@ -112,7 +112,7 @@ describe('React app Home service', () => {
 
         const home = await loadParentHome(user);
 
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledWith(user, { hydrateDetails: false });
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledWith(user, { hydrateDetails: false, expandStaffPlayers: false });
         expect(chatMocks.loadChatInbox).toHaveBeenCalledWith(user);
         expect(dbMocks.listParentTeamFeeRecipients).toHaveBeenCalledWith(user.uid, [
             expect.objectContaining({ teamId: 'team-1', playerId: 'player-1' })
@@ -178,7 +178,7 @@ describe('React app Home service', () => {
 
         const home = await loadParentHomeSummary(user, { force: true });
 
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledWith(user, { hydrateDetails: false });
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledWith(user, { hydrateDetails: false, expandStaffPlayers: false });
         expect(chatMocks.loadChatInbox).not.toHaveBeenCalled();
         expect(dbMocks.listParentTeamFeeRecipients).not.toHaveBeenCalled();
         expect(home.players).toHaveLength(1);

--- a/tests/unit/app-native-google-auth.test.js
+++ b/tests/unit/app-native-google-auth.test.js
@@ -122,6 +122,15 @@ function installFakeIndexedDb() {
     };
 
     const indexedDB = {
+        deleteDatabase: vi.fn(() => {
+            const request = {
+                error: null,
+                onsuccess: null,
+                onerror: null
+            };
+            queueMicrotask(() => request.onsuccess?.());
+            return request;
+        }),
         open: vi.fn(() => {
             const request = {
                 error: null,

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -186,11 +186,28 @@ describe('React app desktop Schedule controls', () => {
 
         expect(scheduleMocks.addTeamCalendarUrl).toHaveBeenCalledWith('team-1', 'https://example.com/team.ics', auth.user);
         await waitForText(container, 'Calendar link saved and schedule refreshed.');
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(4);
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(1, auth.user, { hydrateDetails: false });
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(2, auth.user);
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(3, auth.user, { hydrateDetails: false });
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(4, auth.user);
+<<<<<<< HEAD
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(2);
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(1, auth.user, { hydrateDetails: false, expandStaffPlayers: false });
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(2, auth.user, { hydrateDetails: false, expandStaffPlayers: false });
+    });
+
+    it('reuses the cached schedule when the route remounts', async () => {
+        const first = await renderSchedule();
+        await waitForText(first.container, 'Main Gym');
+
+        await act(async () => {
+            first.root.unmount();
+        });
+        first.container.remove();
+        scheduleMocks.loadParentSchedule.mockRejectedValue(new Error('network should not be needed'));
+
+        const second = await renderSchedule();
+        await waitForText(second.container, 'Main Gym');
+
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(1);
+        expect(second.container.textContent).not.toContain('Loading schedule');
+
     });
 
     it('shows saved staff calendar links and removes one after confirmation', async () => {

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -231,11 +231,9 @@ describe('React app desktop Schedule controls', () => {
 
         expect(window.confirm).toHaveBeenCalledWith('Remove this external calendar link? Imported events from this feed will disappear after the schedule refreshes.');
         expect(scheduleMocks.removeTeamCalendarUrl).toHaveBeenCalledWith('team-1', 'https://example.com/stale.ics', auth.user);
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(4);
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(1, auth.user, { hydrateDetails: false });
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(2, auth.user);
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(3, auth.user, { hydrateDetails: false });
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(4, auth.user);
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(2);
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(1, auth.user, { hydrateDetails: false, expandStaffPlayers: false });
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(2, auth.user, { hydrateDetails: false, expandStaffPlayers: false });
         await waitForText(container, 'Calendar link removed and schedule refreshed.');
     });
 

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -40,11 +40,7 @@ function event(overrides = {}) {
         teamId: overrides.teamId || 'team-1',
         teamName: overrides.teamName || 'Bears',
         type: overrides.type || 'game',
-<<<<<<< HEAD
         date: overrides.date || futureDate(7 * 24),
-=======
-        date: overrides.date || futureDate(7 * 24),
->>>>>>> deaa7c3b (Fix app review regressions)
         location: overrides.location || 'Main Gym',
         opponent: overrides.opponent || 'Falcons',
         title: overrides.title || null,

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -318,7 +318,8 @@ describe('React app desktop Schedule controls', () => {
             eventType: 'practice',
             title: 'Speed Session'
         }), auth.user);
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(6);
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(3);
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenLastCalledWith(auth.user, { hydrateDetails: false, expandStaffPlayers: false });
         await waitForText(container, 'Imported 2 schedule row(s) and refreshed the schedule.');
     });
 

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -217,6 +217,24 @@ describe('React app desktop Schedule controls', () => {
         await waitForText(container, 'Calendar link removed and schedule refreshed.');
     });
 
+    it('groups duplicate family event rows into one visible schedule card', async () => {
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            children: [
+                { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' },
+                { playerId: 'player-2', playerName: 'Sam', teamId: 'team-1', teamName: 'Bears' }
+            ],
+            events: [
+                event({ childId: 'player-1', childName: 'Pat', eventKey: 'team-1::game-1::player-1' }),
+                event({ childId: 'player-2', childName: 'Sam', eventKey: 'team-1::game-1::player-2' })
+            ]
+        });
+
+        const { container } = await renderSchedule();
+        await waitForText(container, 'Pat, Sam · Bears');
+
+        expect(container.querySelectorAll('.schedule-event-card')).toHaveLength(1);
+    });
+
     it('hides calendar import from parent-only teams and validates .ics input inline', async () => {
         const { container } = await renderSchedule();
         await waitForText(container, 'Main Gym');

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -29,6 +29,10 @@ const auth = {
     }
 };
 
+function futureDate(offsetHours = 24) {
+    return new Date(Date.now() + offsetHours * 60 * 60 * 1000);
+}
+
 function event(overrides = {}) {
     return {
         eventKey: overrides.eventKey || 'team-1::game-1::player-1',
@@ -36,7 +40,11 @@ function event(overrides = {}) {
         teamId: overrides.teamId || 'team-1',
         teamName: overrides.teamName || 'Bears',
         type: overrides.type || 'game',
-        date: overrides.date || new Date('2099-05-28T18:00:00Z'),
+<<<<<<< HEAD
+        date: overrides.date || futureDate(7 * 24),
+=======
+        date: overrides.date || futureDate(7 * 24),
+>>>>>>> deaa7c3b (Fix app review regressions)
         location: overrides.location || 'Main Gym',
         opponent: overrides.opponent || 'Falcons',
         title: overrides.title || null,

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -18,6 +18,7 @@ vi.mock('../../apps/app/src/lib/useShellLayout.ts', () => ({
 }));
 
 import { Schedule } from '../../apps/app/src/pages/Schedule.tsx';
+import { clearAppDataCache } from '../../apps/app/src/lib/appDataCache.ts';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -118,6 +119,7 @@ async function changeSelect(select, value) {
 
 beforeEach(() => {
     vi.clearAllMocks();
+    clearAppDataCache('app-schedule-summary');
     document.body.innerHTML = '';
     scheduleMocks.addTeamCalendarUrl.mockResolvedValue({ added: true, calendarUrls: ['https://example.com/team.ics'] });
     scheduleMocks.createScheduleImportGame.mockResolvedValue('game-new');
@@ -190,7 +192,6 @@ describe('React app desktop Schedule controls', () => {
 
         expect(scheduleMocks.addTeamCalendarUrl).toHaveBeenCalledWith('team-1', 'https://example.com/team.ics', auth.user);
         await waitForText(container, 'Calendar link saved and schedule refreshed.');
-<<<<<<< HEAD
         expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(2);
         expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(1, auth.user, { hydrateDetails: false, expandStaffPlayers: false });
         expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(2, auth.user, { hydrateDetails: false, expandStaffPlayers: false });
@@ -267,6 +268,7 @@ describe('React app desktop Schedule controls', () => {
             ],
             events: [event({ isTeamStaff: true })]
         });
+        clearAppDataCache('app-schedule-summary');
         const staff = await renderSchedule();
         await waitForText(staff.container, 'Add external calendar');
         await clickButton(staff.container, 'Save calendar');
@@ -286,6 +288,7 @@ describe('React app desktop Schedule controls', () => {
             ],
             events: [event({ isTeamStaff: true })]
         });
+        clearAppDataCache('app-schedule-summary');
 
         const { container } = await renderSchedule();
         await waitForText(container, 'Import schedule CSV');

--- a/tests/unit/app-teams-integration.test.jsx
+++ b/tests/unit/app-teams-integration.test.jsx
@@ -6,7 +6,8 @@ import { MemoryRouter, Route, Routes } from '../../apps/app/node_modules/react-r
 
 const homeMocks = vi.hoisted(() => ({
     loadParentHome: vi.fn(),
-    loadParentHomeSummary: vi.fn()
+    loadParentHomeSummary: vi.fn(),
+    loadParentTeamsSummary: vi.fn()
 }));
 const publicActionMocks = vi.hoisted(() => ({
     openPublicUrl: vi.fn()
@@ -113,6 +114,7 @@ beforeEach(() => {
     };
     window.scrollTo = vi.fn();
     homeMocks.loadParentHomeSummary.mockImplementation((...args) => homeMocks.loadParentHome(...args));
+    homeMocks.loadParentTeamsSummary.mockImplementation((...args) => homeMocks.loadParentHome(...args));
     homeMocks.loadParentHome.mockResolvedValue({
         players: [],
         upcomingEvents: [],
@@ -162,6 +164,7 @@ describe('React app Teams page', () => {
     it('renders the same parent and staff/admin teams used by the app inbox', async () => {
         const { container } = await renderTeams('/teams?selectedTeamId=team-staff&from=home');
 
+        expect(homeMocks.loadParentTeamsSummary).toHaveBeenCalledWith(auth.user, { force: false });
         expect(homeMocks.loadParentHomeSummary).toHaveBeenCalledWith(auth.user, { force: false });
         expect(container.textContent).toContain('2 teams ready');
         expect(container.textContent).toContain('Choose a team');
@@ -225,7 +228,7 @@ describe('React app Teams page', () => {
     });
 
     it('refreshes team data without dropping into the loading shell', async () => {
-        homeMocks.loadParentHome
+        homeMocks.loadParentTeamsSummary
             .mockResolvedValueOnce({
                 players: [],
                 teams: [{
@@ -275,6 +278,14 @@ describe('React app Teams page', () => {
                 fees: [],
                 metrics: { players: 0, teams: 2, rsvpNeeded: 0, unreadMessages: 1, packetsReady: 0 }
             });
+        homeMocks.loadParentHomeSummary.mockResolvedValue({
+            players: [],
+            teams: [],
+            upcomingEvents: [],
+            actionItems: [],
+            fees: [],
+            metrics: { players: 0, teams: 0, rsvpNeeded: 0, unreadMessages: 0, packetsReady: 0 }
+        });
 
         const { container } = await renderTeams('/teams');
         await waitForText(container, '1 team ready');
@@ -285,13 +296,13 @@ describe('React app Teams page', () => {
         await flush();
         await waitForText(container, '2 teams ready');
 
-        expect(homeMocks.loadParentHomeSummary).toHaveBeenCalledTimes(2);
+        expect(homeMocks.loadParentTeamsSummary).toHaveBeenCalledTimes(2);
         expect(container.textContent).toContain('Lions');
         expect(container.textContent).not.toContain('Loading teams');
     });
 
     it('uses a website Players resource for teams with multiple linked players', async () => {
-        homeMocks.loadParentHome.mockResolvedValueOnce({
+        const multiTeamModel = {
             players: [],
             teams: [{
                 teamId: 'team-multi',
@@ -311,7 +322,9 @@ describe('React app Teams page', () => {
             actionItems: [],
             fees: [],
             metrics: { players: 2, teams: 1, rsvpNeeded: 0, unreadMessages: 0, packetsReady: 0 }
-        });
+        };
+        homeMocks.loadParentTeamsSummary.mockResolvedValueOnce(multiTeamModel);
+        homeMocks.loadParentHomeSummary.mockResolvedValueOnce(multiTeamModel);
 
         const { container } = await renderTeams('/teams');
         await waitForText(container, 'Multi Bears');
@@ -325,7 +338,7 @@ describe('React app Teams page', () => {
     });
 
     it('shows clear empty and error states instead of a spinner', async () => {
-        homeMocks.loadParentHome.mockRejectedValueOnce(new Error('Team service down'));
+        homeMocks.loadParentTeamsSummary.mockRejectedValueOnce(new Error('Team service down'));
 
         const { container } = await renderTeams('/teams');
 
@@ -335,7 +348,7 @@ describe('React app Teams page', () => {
     });
 
     it('handles signed-in accounts that do not have team access yet', async () => {
-        homeMocks.loadParentHome.mockResolvedValueOnce({
+        const emptyTeamsModel = {
             players: [],
             teams: [],
             upcomingEvents: [],
@@ -348,7 +361,9 @@ describe('React app Teams page', () => {
                 unreadMessages: 0,
                 packetsReady: 0
             }
-        });
+        };
+        homeMocks.loadParentTeamsSummary.mockResolvedValueOnce(emptyTeamsModel);
+        homeMocks.loadParentHomeSummary.mockResolvedValueOnce(emptyTeamsModel);
 
         const { container } = await renderTeams('/teams');
 

--- a/tests/unit/auth-google-admin-invite-cleanup.test.js
+++ b/tests/unit/auth-google-admin-invite-cleanup.test.js
@@ -9,7 +9,7 @@ const updateUserProfileMock = vi.fn();
 const markAccessCodeAsUsedMock = vi.fn();
 const redeemAdminInviteAcceptanceMock = vi.fn();
 
-vi.mock('../../js/firebase.js?v=15', () => ({
+vi.mock('../../js/firebase.js?v=16', () => ({
     auth: { currentUser: null },
     signInWithEmailAndPassword: vi.fn(),
     createUserWithEmailAndPassword: vi.fn(),

--- a/tests/unit/auth-google-admin-invite-cleanup.test.js
+++ b/tests/unit/auth-google-admin-invite-cleanup.test.js
@@ -9,7 +9,7 @@ const updateUserProfileMock = vi.fn();
 const markAccessCodeAsUsedMock = vi.fn();
 const redeemAdminInviteAcceptanceMock = vi.fn();
 
-vi.mock('../../js/firebase.js?v=16', () => ({
+vi.mock('../../js/firebase.js?v=17', () => ({
     auth: { currentUser: null },
     signInWithEmailAndPassword: vi.fn(),
     createUserWithEmailAndPassword: vi.fn(),
@@ -27,7 +27,7 @@ vi.mock('../../js/firebase.js?v=16', () => ({
     updatePassword: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=32', () => ({
+vi.mock('../../js/db.js?v=33', () => ({
     validateAccessCode: validateAccessCodeMock,
     markAccessCodeAsUsed: markAccessCodeAsUsedMock,
     updateUserProfile: updateUserProfileMock,

--- a/tests/unit/auth-google-parent-invite-cleanup.test.js
+++ b/tests/unit/auth-google-parent-invite-cleanup.test.js
@@ -9,7 +9,7 @@ const redeemParentInviteMock = vi.fn();
 const updateUserProfileMock = vi.fn();
 const markAccessCodeAsUsedMock = vi.fn();
 
-vi.mock('../../js/firebase.js?v=15', async (importOriginal) => {
+vi.mock('../../js/firebase.js?v=16', async (importOriginal) => {
     const actual = await importOriginal();
     return {
         ...actual,

--- a/tests/unit/auth-google-parent-invite-cleanup.test.js
+++ b/tests/unit/auth-google-parent-invite-cleanup.test.js
@@ -9,7 +9,7 @@ const redeemParentInviteMock = vi.fn();
 const updateUserProfileMock = vi.fn();
 const markAccessCodeAsUsedMock = vi.fn();
 
-vi.mock('../../js/firebase.js?v=16', async (importOriginal) => {
+vi.mock('../../js/firebase.js?v=17', async (importOriginal) => {
     const actual = await importOriginal();
     return {
         ...actual,
@@ -34,7 +34,7 @@ vi.mock('../../js/firebase.js?v=16', async (importOriginal) => {
     };
 });
 
-vi.mock('../../js/db.js?v=32', () => ({
+vi.mock('../../js/db.js?v=33', () => ({
     validateAccessCode: validateAccessCodeMock,
     markAccessCodeAsUsed: markAccessCodeAsUsedMock,
     updateUserProfile: updateUserProfileMock,

--- a/tests/unit/auth-parent-membership-sync.test.js
+++ b/tests/unit/auth-parent-membership-sync.test.js
@@ -31,8 +31,8 @@ const dbMocks = vi.hoisted(() => ({
     listMyParentMembershipRequests: vi.fn()
 }));
 
-vi.mock('../../js/firebase.js?v=16', () => firebaseMocks);
-vi.mock('../../js/db.js?v=32', () => dbMocks);
+vi.mock('../../js/firebase.js?v=17', () => firebaseMocks);
+vi.mock('../../js/db.js?v=33', () => dbMocks);
 vi.mock('../../js/signup-flow.js?v=3', () => ({
     executeEmailPasswordSignup: vi.fn()
 }));

--- a/tests/unit/auth-parent-membership-sync.test.js
+++ b/tests/unit/auth-parent-membership-sync.test.js
@@ -31,7 +31,7 @@ const dbMocks = vi.hoisted(() => ({
     listMyParentMembershipRequests: vi.fn()
 }));
 
-vi.mock('../../js/firebase.js?v=15', () => firebaseMocks);
+vi.mock('../../js/firebase.js?v=16', () => firebaseMocks);
 vi.mock('../../js/db.js?v=32', () => dbMocks);
 vi.mock('../../js/signup-flow.js?v=3', () => ({
     executeEmailPasswordSignup: vi.fn()

--- a/tests/unit/auth-signup-parent-invite.test.js
+++ b/tests/unit/auth-signup-parent-invite.test.js
@@ -35,7 +35,7 @@ const dbMocks = vi.hoisted(() => ({
     listMyParentMembershipRequests: vi.fn()
 }));
 
-vi.mock('../../js/firebase.js?v=15', () => firebaseMocks);
+vi.mock('../../js/firebase.js?v=16', () => firebaseMocks);
 vi.mock('../../js/db.js?v=32', () => dbMocks);
 
 const { signup, loginWithGoogle, handleGoogleRedirectResult } = await import('../../js/auth.js');

--- a/tests/unit/auth-signup-parent-invite.test.js
+++ b/tests/unit/auth-signup-parent-invite.test.js
@@ -35,8 +35,8 @@ const dbMocks = vi.hoisted(() => ({
     listMyParentMembershipRequests: vi.fn()
 }));
 
-vi.mock('../../js/firebase.js?v=16', () => firebaseMocks);
-vi.mock('../../js/db.js?v=32', () => dbMocks);
+vi.mock('../../js/firebase.js?v=17', () => firebaseMocks);
+vi.mock('../../js/db.js?v=33', () => dbMocks);
 
 const { signup, loginWithGoogle, handleGoogleRedirectResult } = await import('../../js/auth.js');
 

--- a/tests/unit/certificates-assets.test.js
+++ b/tests/unit/certificates-assets.test.js
@@ -14,7 +14,7 @@ vi.mock('../../js/firebase-images.js?v=8', () => ({
     requireImageAuth: mocks.requireImageAuth
 }));
 
-vi.mock('../../js/firebase.js?v=16', () => ({
+vi.mock('../../js/firebase.js?v=17', () => ({
     db: {},
     collection: mocks.collection,
     addDoc: mocks.addDoc,

--- a/tests/unit/certificates-assets.test.js
+++ b/tests/unit/certificates-assets.test.js
@@ -14,7 +14,7 @@ vi.mock('../../js/firebase-images.js?v=8', () => ({
     requireImageAuth: mocks.requireImageAuth
 }));
 
-vi.mock('../../js/firebase.js?v=15', () => ({
+vi.mock('../../js/firebase.js?v=16', () => ({
     db: {},
     collection: mocks.collection,
     addDoc: mocks.addDoc,

--- a/tests/unit/edit-roster-tracking-status.test.js
+++ b/tests/unit/edit-roster-tracking-status.test.js
@@ -22,7 +22,7 @@ describe('edit roster tracking status matrix wiring', () => {
     it('uses rules-compatible tracking item names in the selector and summary', () => {
         const source = readEditRoster();
 
-        expect(source).toContain("from './js/db.js?v=33'");
+        expect(source).toContain("from './js/db.js?v=34'");
         expect(source).toContain("from './js/tracking-status-admin.js?v=2'");
         expect(source).toContain('item.title || item.name || item.id');
         expect(source).toContain("selectedItem.title || selectedItem.name || 'selected item'");

--- a/tests/unit/firebase-default-app.test.js
+++ b/tests/unit/firebase-default-app.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const repoRoot = join(__dirname, '..', '..');
+
+describe('primary Firebase initialization', () => {
+    it('does not treat named Firebase apps as the default app', () => {
+        const source = readFileSync(join(repoRoot, 'js', 'firebase.js'), 'utf8');
+
+        expect(source).toContain("candidate.name === '[DEFAULT]'");
+        expect(source).toContain('existingDefaultApp || initializeApp(firebaseConfig)');
+        expect(source).not.toContain('getApps().length ? getApp() : initializeApp(firebaseConfig)');
+    });
+});

--- a/tests/unit/parent-invite-auto-link.test.js
+++ b/tests/unit/parent-invite-auto-link.test.js
@@ -47,7 +47,7 @@ describe('parent invite auto-linking', () => {
         expect(source).toContain('if (result.autoLinked)');
         expect(source).toContain('were linked to ${currentInvitePlayer.name} automatically');
         expect(source).toContain("codeSection.classList.add('hidden')");
-        expect(source).toContain("from './js/db.js?v=33';");
+        expect(source).toContain("from './js/db.js?v=34';");
     });
 
     it('sends a notification email to existing users even when auto-linked', () => {

--- a/tests/unit/telemetry.test.js
+++ b/tests/unit/telemetry.test.js
@@ -38,7 +38,7 @@ const mockStorage = () => {
 Object.defineProperty(window, 'localStorage', { value: mockStorage() });
 Object.defineProperty(window, 'sessionStorage', { value: mockStorage() });
 
-vi.mock('../../js/firebase.js?v=15', () => {
+vi.mock('../../js/firebase.js?v=16', () => {
     return {
         auth: firebaseMocks.auth,
         onAuthStateChanged: firebaseMocks.onAuthStateChanged

--- a/tests/unit/telemetry.test.js
+++ b/tests/unit/telemetry.test.js
@@ -38,7 +38,7 @@ const mockStorage = () => {
 Object.defineProperty(window, 'localStorage', { value: mockStorage() });
 Object.defineProperty(window, 'sessionStorage', { value: mockStorage() });
 
-vi.mock('../../js/firebase.js?v=16', () => {
+vi.mock('../../js/firebase.js?v=17', () => {
     return {
         auth: firebaseMocks.auth,
         onAuthStateChanged: firebaseMocks.onAuthStateChanged

--- a/track-live.html
+++ b/track-live.html
@@ -667,9 +667,9 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, setGameLiveStatus, subscribeLiveChat, postLiveChatMessage } from './js/db.js?v=32';
-        import { db } from './js/firebase.js?v=16';
-        import { writeBatch, doc, setDoc, addDoc, onSnapshot } from './js/firebase.js?v=16';
+        import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, setGameLiveStatus, subscribeLiveChat, postLiveChatMessage } from './js/db.js?v=33';
+        import { db } from './js/firebase.js?v=17';
+        import { writeBatch, doc, setDoc, addDoc, onSnapshot } from './js/firebase.js?v=17';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { resolveOpponentDisplayName, resolveLiveStatConfig, resolveLiveStatColumns, resolveGoalSportTrackerProfile } from './js/live-game-state.js?v=7';
         import { createFieldState, setPlayerFieldStatus, startFieldClock, pauseFieldClock, getPlayerFieldElapsedMs, getLiveLineup } from './js/live-tracker-field-status.js?v=1';
@@ -680,7 +680,7 @@
         import { applyVolleyballServeOutcome, createVolleyballUndoState, restoreVolleyballUndoState, isVolleyballSport } from './js/live-scorekeeping-volleyball.js?v=2';
 
         import { applyBaseballScorekeepingAction, createBaseballLiveState, getBaseballPeriodLabel, getBaseballSituationSummary, isBaseballScorekeepingSport, parseBaseballPeriodLabel } from './js/live-scorekeeping-baseball.js?v=1';
-        import { checkAuth } from './js/auth.js?v=15';
+        import { checkAuth } from './js/auth.js?v=16';
         import { getApp } from './js/vendor/firebase-app.js';
         import { isVoiceRecognitionSupported, normalizeGameNoteText, appendGameSummaryLine, removeGameSummaryLine, buildGameNoteLogText, buildGoalSportNoteText } from './js/live-tracker-notes.js?v=3';
         import { collectTournamentAdvancementPatches } from './js/tournament-brackets.js?v=1';

--- a/track-live.html
+++ b/track-live.html
@@ -668,8 +668,8 @@
 
     <script type="module">
         import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, collection, getDocs, deleteDoc, query, broadcastLiveEvent, setGameLiveStatus, subscribeLiveChat, postLiveChatMessage } from './js/db.js?v=32';
-        import { db } from './js/firebase.js?v=15';
-        import { writeBatch, doc, setDoc, addDoc, onSnapshot } from './js/firebase.js?v=15';
+        import { db } from './js/firebase.js?v=16';
+        import { writeBatch, doc, setDoc, addDoc, onSnapshot } from './js/firebase.js?v=16';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { resolveOpponentDisplayName, resolveLiveStatConfig, resolveLiveStatColumns, resolveGoalSportTrackerProfile } from './js/live-game-state.js?v=7';
         import { createFieldState, setPlayerFieldStatus, startFieldClock, pauseFieldClock, getPlayerFieldElapsedMs, getLiveLineup } from './js/live-tracker-field-status.js?v=1';

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -199,8 +199,8 @@
 
   <script type="module">
     import { getTeam, getGame, getPlayers, getConfigs, collection, getDocs, deleteDoc, uploadStatSheetPhoto } from './js/db.js?v=32';
-    import { db } from './js/firebase.js?v=15';
-    import { writeBatch, doc, setDoc } from './js/firebase.js?v=15';
+    import { db } from './js/firebase.js?v=16';
+    import { writeBatch, doc, setDoc } from './js/firebase.js?v=16';
     import { renderHeader, renderFooter, getUrlParams, escapeHtml, formatDate } from './js/utils.js?v=8';
     import { checkAuth } from './js/auth.js?v=15';
     import { renderTeamAdminBanner } from './js/team-admin-banner.js';

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -198,11 +198,11 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { getTeam, getGame, getPlayers, getConfigs, collection, getDocs, deleteDoc, uploadStatSheetPhoto } from './js/db.js?v=32';
-    import { db } from './js/firebase.js?v=16';
-    import { writeBatch, doc, setDoc } from './js/firebase.js?v=16';
+    import { getTeam, getGame, getPlayers, getConfigs, collection, getDocs, deleteDoc, uploadStatSheetPhoto } from './js/db.js?v=33';
+    import { db } from './js/firebase.js?v=17';
+    import { writeBatch, doc, setDoc } from './js/firebase.js?v=17';
     import { renderHeader, renderFooter, getUrlParams, escapeHtml, formatDate } from './js/utils.js?v=8';
-    import { checkAuth } from './js/auth.js?v=15';
+    import { checkAuth } from './js/auth.js?v=16';
     import { renderTeamAdminBanner } from './js/team-admin-banner.js';
     import { ensureImageAuth, getImageAuthError } from './js/firebase-images.js?v=7';
     import { validateTrackStatsheetApplyRows, buildTrackStatsheetApplyPlan } from './js/track-statsheet-apply.js?v=2';
@@ -923,7 +923,7 @@ Write the match report now:`;
       try {
         if (summaryText) {
           status.textContent = 'Saving summary…';
-          const { updateGame } = await import('./js/db.js?v=32');
+          const { updateGame } = await import('./js/db.js?v=33');
           await updateGame(currentTeamId, currentGameId, { summary: summaryText });
           status.textContent = 'Summary saved!';
         }

--- a/track.html
+++ b/track.html
@@ -275,8 +275,8 @@
 
     <script type="module">
         import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './js/db.js?v=32';
-        import { db } from './js/firebase.js?v=15';
-        import { writeBatch, doc, setDoc, addDoc } from './js/firebase.js?v=15';
+        import { db } from './js/firebase.js?v=16';
+        import { writeBatch, doc, setDoc, addDoc } from './js/firebase.js?v=16';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=15';
         import { isAISummaryEnabled, applyAISummaryAvailability } from './js/track-ai-summary.js';

--- a/track.html
+++ b/track.html
@@ -274,11 +274,11 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './js/db.js?v=32';
-        import { db } from './js/firebase.js?v=16';
-        import { writeBatch, doc, setDoc, addDoc } from './js/firebase.js?v=16';
+        import { getTeam, getGame, getPlayers, getConfigs, logStatEvent, updatePlayerStats, updateGame, getMyRsvp, collection, getDocs, deleteDoc, query } from './js/db.js?v=33';
+        import { db } from './js/firebase.js?v=17';
+        import { writeBatch, doc, setDoc, addDoc } from './js/firebase.js?v=17';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
-        import { checkAuth } from './js/auth.js?v=15';
+        import { checkAuth } from './js/auth.js?v=16';
         import { isAISummaryEnabled, applyAISummaryAvailability } from './js/track-ai-summary.js';
         import { resolveSummaryRecipient } from './js/live-tracker-email.js?v=1';
         import { hasScorekeepingTeamAccess } from './js/team-access.js?v=2';

--- a/verify-pending.html
+++ b/verify-pending.html
@@ -81,8 +81,8 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { auth } from './js/firebase.js?v=16';
-        import { checkAuth, logout, resendVerificationEmail } from './js/auth.js?v=15';
+        import { auth } from './js/firebase.js?v=17';
+        import { checkAuth, logout, resendVerificationEmail } from './js/auth.js?v=16';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 
         renderHeader(document.getElementById('header-container'), null);

--- a/verify-pending.html
+++ b/verify-pending.html
@@ -81,7 +81,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { auth } from './js/firebase.js?v=15';
+        import { auth } from './js/firebase.js?v=16';
         import { checkAuth, logout, resendVerificationEmail } from './js/auth.js?v=15';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
 


### PR DESCRIPTION
Closes #1531

## Summary
- Adds an Export Roster CSV action to the Current Roster section on edit-roster.html.
- Exports active roster players by default with name, number, active status, guardian/contact summary, and non-admin-only roster profile fields.
- Adds CSV generation helpers with escaping, safe field filtering, active/inactive handling, contact formatting, and dated team-based filenames.

## Validation
- `npx vitest run tests/unit/roster-csv-export.test.js tests/unit/roster-csv-import.test.js --reporter=verbose`
- `npm test`
- `npm run app:build`