### PR TITLE
Add app schedule CSV import

### DIFF
--- a/apps/app/src/lib/scheduleCsvImport.ts
+++ b/apps/app/src/lib/scheduleCsvImport.ts
@@ -1,0 +1,38 @@
+import {
+  SCHEDULE_CSV_IMPORT_FIELDS,
+  buildScheduleImportPreview,
+  inferScheduleCsvMapping,
+  normalizeScheduleImportDraft,
+  parseCsvText,
+  validateScheduleCsvMapping
+} from '../../../../js/schedule-csv-import.js';
+
+export type ScheduleCsvImportFieldKey = 'startDateTime' | 'date' | 'startTime' | 'endTime' | 'eventType' | 'opponent' | 'title' | 'location' | 'arrivalTime' | 'isHome' | 'notes';
+export type ScheduleCsvImportMapping = Partial<Record<ScheduleCsvImportFieldKey, string>>;
+export type ScheduleCsvImportNormalizedRow = {
+  rowNumber: number;
+  eventType: 'game' | 'practice';
+  startsAt: string;
+  endsAt: string | null;
+  opponent: string | null;
+  title: string | null;
+  location: string | null;
+  arrivalTime: string | null;
+  isHome: boolean | null;
+  notes: string | null;
+};
+export type ScheduleCsvImportPreviewRow = {
+  rowNumber: number;
+  draft: Record<string, string>;
+  normalized: ScheduleCsvImportNormalizedRow;
+  errors: string[];
+};
+
+export {
+  SCHEDULE_CSV_IMPORT_FIELDS,
+  buildScheduleImportPreview,
+  inferScheduleCsvMapping,
+  normalizeScheduleImportDraft,
+  parseCsvText,
+  validateScheduleCsvMapping
+};

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -8,6 +8,8 @@ import {
   getRsvpSummaries,
   getTeam,
   getTeams,
+  addGame,
+  addPractice,
   getTrackedCalendarEventUids,
   createRideOffer,
   claimAssignmentSlot,
@@ -491,6 +493,122 @@ async function saveTeamCalendarUrls(teamId: string, calendarUrls: string[]) {
     return;
   }
   await updateTeam(teamId, { calendarUrls });
+}
+
+
+export type ScheduleImportNormalizedRow = {
+  rowNumber?: number;
+  eventType: 'game' | 'practice';
+  startsAt: string;
+  endsAt?: string | null;
+  opponent?: string | null;
+  title?: string | null;
+  location?: string | null;
+  arrivalTime?: string | null;
+  isHome?: boolean | null;
+  notes?: string | null;
+};
+
+function requireScheduleImportStaff(teamId: string, user: AuthUser | null) {
+  if (!user?.uid) {
+    throw new Error('You need to sign in before importing schedule rows.');
+  }
+  return loadTeam(teamId).then((team) => {
+    const teamWithId = team ? { ...team, id: team.id || teamId } : null;
+    if (!teamWithId || !isTeamStaff(teamWithId, user)) {
+      throw new Error('You do not have permission to manage this team schedule.');
+    }
+    return teamWithId;
+  });
+}
+
+function parseScheduleImportDate(value: string | null | undefined, label: string) {
+  const date = new Date(String(value || ''));
+  if (Number.isNaN(date.getTime())) {
+    throw new Error(`${label} is invalid.`);
+  }
+  return date;
+}
+
+function buildScheduleImportGamePayload(row: ScheduleImportNormalizedRow, user: AuthUser) {
+  const startDate = parseScheduleImportDate(row.startsAt, 'Start time');
+  return {
+    type: 'game',
+    date: startDate,
+    end: row.endsAt ? parseScheduleImportDate(row.endsAt, 'End time') : null,
+    opponent: compactString(row.opponent),
+    title: null,
+    location: compactString(row.location),
+    isHome: row.isHome === null || row.isHome === undefined ? null : row.isHome === true,
+    arrivalTime: row.arrivalTime ? parseScheduleImportDate(row.arrivalTime, 'Arrival time') : null,
+    notes: compactString(row.notes),
+    assignments: [],
+    status: 'scheduled',
+    homeScore: 0,
+    awayScore: 0,
+    competitionType: 'league',
+    countsTowardSeasonRecord: true,
+    statTrackerConfigId: null,
+    createdBy: user.uid
+  };
+}
+
+function buildScheduleImportPracticePayload(row: ScheduleImportNormalizedRow, user: AuthUser) {
+  const startDate = parseScheduleImportDate(row.startsAt, 'Start time');
+  return {
+    type: 'practice',
+    title: compactString(row.title) || 'Practice',
+    date: startDate,
+    end: row.endsAt ? parseScheduleImportDate(row.endsAt, 'End time') : null,
+    opponent: null,
+    location: compactString(row.location),
+    arrivalTime: row.arrivalTime ? parseScheduleImportDate(row.arrivalTime, 'Arrival time') : null,
+    notes: compactString(row.notes),
+    status: 'scheduled',
+    homeScore: 0,
+    awayScore: 0,
+    statTrackerConfigId: null,
+    createdBy: user.uid
+  };
+}
+
+export async function createScheduleImportGame(teamId: string, row: ScheduleImportNormalizedRow, user: AuthUser | null) {
+  const normalizedTeamId = compactString(teamId);
+  if (!normalizedTeamId) throw new Error('Team is required.');
+  await requireScheduleImportStaff(normalizedTeamId, user);
+  const payload = buildScheduleImportGamePayload(row, user as AuthUser);
+  if (!payload.opponent) throw new Error('Game rows require an opponent.');
+
+  try {
+    return await withTimeout(Promise.resolve(addGame(normalizedTeamId, payload)), 'Schedule import game create');
+  } catch (error) {
+    if (!isNativeRuntime()) throw error;
+    console.warn('[schedule-service] Falling back to REST schedule import game create:', error);
+    const doc = await nativeCreateDocument(`teams/${encodeURIComponent(normalizedTeamId)}/games`, {
+      ...payload,
+      createdAt: new Date()
+    });
+    return doc?.id || '';
+  }
+}
+
+export async function createScheduleImportPractice(teamId: string, row: ScheduleImportNormalizedRow, user: AuthUser | null) {
+  const normalizedTeamId = compactString(teamId);
+  if (!normalizedTeamId) throw new Error('Team is required.');
+  await requireScheduleImportStaff(normalizedTeamId, user);
+  const payload = buildScheduleImportPracticePayload(row, user as AuthUser);
+
+  try {
+    return await withTimeout(Promise.resolve(addPractice(normalizedTeamId, payload)), 'Schedule import practice create');
+  } catch (error) {
+    if (!isNativeRuntime()) throw error;
+    console.warn('[schedule-service] Falling back to REST schedule import practice create:', error);
+    const doc = await nativeCreateDocument(`teams/${encodeURIComponent(normalizedTeamId)}/games`, {
+      ...payload,
+      createdAt: new Date()
+    });
+    return doc?.id || '';
+  }
 }
 
 export async function addTeamCalendarUrl(teamId: string, url: string, user: AuthUser | null) {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { AlertCircle, CalendarDays, CheckCircle2, ChevronLeft, ChevronRight, ClipboardCheck, Copy, Download, Filter, Link as LinkIcon, ListChecks, MapPin, RefreshCw } from 'lucide-react';
 import { Link } from 'react-router-dom';
-import { addTeamCalendarUrl, loadParentSchedule, type ParentScheduleChild } from '../lib/scheduleService';
+import { addTeamCalendarUrl, createScheduleImportGame, createScheduleImportPractice, loadParentSchedule, type ParentScheduleChild } from '../lib/scheduleService';
 import { useShellLayout } from '../lib/useShellLayout';
 import {
   buildScheduleIcs,
@@ -25,6 +25,14 @@ import {
   type ScheduleTimeRange,
   type ScheduleViewMode
 } from '../lib/scheduleLogic';
+import {
+  SCHEDULE_CSV_IMPORT_FIELDS,
+  buildScheduleImportPreview,
+  inferScheduleCsvMapping,
+  parseCsvText,
+  type ScheduleCsvImportMapping,
+  type ScheduleCsvImportPreviewRow
+} from '../lib/scheduleCsvImport';
 import type { AuthState } from '../lib/types';
 
 const filterOptions: Array<{ value: ParentScheduleFilter; label: string }> = [
@@ -82,6 +90,13 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const [calendarUrl, setCalendarUrl] = useState('');
   const [calendarUrlError, setCalendarUrlError] = useState<string | null>(null);
   const [savingCalendarUrl, setSavingCalendarUrl] = useState(false);
+  const [csvHeaders, setCsvHeaders] = useState<string[]>([]);
+  const [csvRows, setCsvRows] = useState<Array<Record<string, string>>>([]);
+  const [csvMapping, setCsvMapping] = useState<ScheduleCsvImportMapping>({});
+  const [csvPreviewRows, setCsvPreviewRows] = useState<ScheduleCsvImportPreviewRow[]>([]);
+  const [csvImportErrors, setCsvImportErrors] = useState<string[]>([]);
+  const [csvFileName, setCsvFileName] = useState('');
+  const [importingCsv, setImportingCsv] = useState(false);
 
   const refreshSchedule = async () => {
     if (!auth.user) return;
@@ -154,6 +169,82 @@ export function Schedule({ auth }: { auth: AuthState }) {
     }
     return manageableTeamOptions.length === 1 ? manageableTeamOptions[0] : null;
   }, [manageableTeamOptions, selectedTeamId]);
+
+  const handleCsvFileChange = async (file: File | null) => {
+    setCsvImportErrors([]);
+    setCsvPreviewRows([]);
+    if (!file) return;
+    try {
+      const parsed = parseCsvText(await file.text());
+      setCsvHeaders(parsed.headers);
+      setCsvRows(parsed.rows);
+      setCsvMapping(inferScheduleCsvMapping(parsed.headers));
+      setCsvFileName(file.name);
+    } catch (csvError: any) {
+      setCsvImportErrors([csvError?.message || 'Could not read the CSV file.']);
+    }
+  };
+
+  const handleCsvPreview = () => {
+    const preview = buildScheduleImportPreview({
+      rows: csvRows,
+      mapping: csvMapping,
+      teamName: selectedCalendarTeam?.teamName || ''
+    });
+    setCsvImportErrors(preview.errors);
+    setCsvPreviewRows(preview.rows);
+  };
+
+  const handleCsvClear = () => {
+    setCsvHeaders([]);
+    setCsvRows([]);
+    setCsvMapping({});
+    setCsvPreviewRows([]);
+    setCsvImportErrors([]);
+    setCsvFileName('');
+  };
+
+  const handleCsvImport = async () => {
+    if (!selectedCalendarTeam || !auth.user || importingCsv) return;
+    const invalidRows = csvPreviewRows.filter((row) => row.errors.length > 0);
+    if (!csvPreviewRows.length) {
+      setCsvImportErrors(['Preview the CSV before importing.']);
+      return;
+    }
+    if (invalidRows.length > 0) {
+      setCsvImportErrors(['Fix invalid rows before importing.']);
+      return;
+    }
+
+    setImportingCsv(true);
+    setCsvImportErrors([]);
+    setStatusMessage(null);
+    setError(null);
+    const failedRows: ScheduleCsvImportPreviewRow[] = [];
+    let importedCount = 0;
+    for (const row of csvPreviewRows) {
+      try {
+        if (row.normalized.eventType === 'game') {
+          await createScheduleImportGame(selectedCalendarTeam.teamId, row.normalized, auth.user);
+        } else {
+          await createScheduleImportPractice(selectedCalendarTeam.teamId, row.normalized, auth.user);
+        }
+        importedCount += 1;
+      } catch (importError: any) {
+        failedRows.push({
+          ...row,
+          errors: [importError?.message || 'Import failed for this row.']
+        });
+      }
+    }
+
+    setCsvPreviewRows(failedRows);
+    await refreshSchedule();
+    setStatusMessage(failedRows.length
+      ? `Imported ${importedCount} row(s); ${failedRows.length} row(s) failed and remain below for retry.`
+      : `Imported ${importedCount} schedule row(s) and refreshed the schedule.`);
+    setImportingCsv(false);
+  };
 
   const handleAddCalendarUrl = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -444,6 +535,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
           ) : null}
 
           {selectedCalendarTeam ? (
+            <>
             <CalendarSourcePanel
               teamName={selectedCalendarTeam.teamName}
               calendarUrl={calendarUrl}
@@ -455,6 +547,21 @@ export function Schedule({ auth }: { auth: AuthState }) {
               }}
               onSubmit={handleAddCalendarUrl}
             />
+            <ScheduleCsvImportPanel
+              teamName={selectedCalendarTeam.teamName}
+              headers={csvHeaders}
+              mapping={csvMapping}
+              previewRows={csvPreviewRows}
+              errors={csvImportErrors}
+              fileName={csvFileName}
+              importing={importingCsv}
+              onFileChange={handleCsvFileChange}
+              onMappingChange={(field, value) => setCsvMapping((current) => ({ ...current, [field]: value || undefined }))}
+              onPreview={handleCsvPreview}
+              onImport={handleCsvImport}
+              onClear={handleCsvClear}
+            />
+            </>
           ) : null}
 
           {statusMessage ? <Status tone="success" message={statusMessage} /> : null}
@@ -487,6 +594,95 @@ export function Schedule({ auth }: { auth: AuthState }) {
         </div>
       </div>
     </div>
+  );
+}
+
+function ScheduleCsvImportPanel({ teamName, headers, mapping, previewRows, errors, fileName, importing, onFileChange, onMappingChange, onPreview, onImport, onClear }: {
+  teamName: string;
+  headers: string[];
+  mapping: ScheduleCsvImportMapping;
+  previewRows: ScheduleCsvImportPreviewRow[];
+  errors: string[];
+  fileName: string;
+  importing: boolean;
+  onFileChange: (file: File | null) => void;
+  onMappingChange: (field: keyof ScheduleCsvImportMapping, value: string) => void;
+  onPreview: () => void;
+  onImport: () => void;
+  onClear: () => void;
+}) {
+  const invalidCount = previewRows.filter((row) => row.errors.length > 0).length;
+  return (
+    <section className="app-card p-4" aria-label="CSV schedule import">
+      <div className="flex items-start gap-3">
+        <div className="flex h-9 w-9 flex-none items-center justify-center rounded-xl bg-emerald-50 text-emerald-700">
+          <ClipboardCheck className="h-4 w-4" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="app-label">Staff schedule tools</div>
+          <h2 className="mt-1 text-base font-black text-gray-950">Import schedule CSV</h2>
+          <p className="mt-1 text-xs font-semibold leading-5 text-gray-500">Upload a UTF-8 CSV for {teamName}, confirm column mapping, preview rows, then import games and practices.</p>
+        </div>
+      </div>
+
+      <div className="mt-3 space-y-3">
+        <label className="block">
+          <span className="text-xs font-black uppercase tracking-[0.08em] text-gray-500">CSV file</span>
+          <input
+            className="auth-input mt-1 min-h-10 !px-3 !py-2 text-sm font-semibold"
+            type="file"
+            accept=".csv,text/csv"
+            aria-label="Schedule CSV file"
+            onChange={(event) => onFileChange(event.target.files?.[0] || null)}
+          />
+        </label>
+        {fileName ? <div className="text-xs font-bold text-gray-500">Loaded {fileName}</div> : null}
+
+        {headers.length ? (
+          <div className="grid gap-2 sm:grid-cols-2">
+            {SCHEDULE_CSV_IMPORT_FIELDS.map((field: { key: string; label: string }) => (
+              <label key={field.key} className="block">
+                <span className="text-xs font-bold text-gray-600">{field.label}</span>
+                <select
+                  className="auth-input mt-1 min-h-10 !px-3 !py-2 text-sm font-semibold"
+                  aria-label={`CSV mapping ${field.label}`}
+                  value={mapping[field.key as keyof ScheduleCsvImportMapping] || ''}
+                  onChange={(event) => onMappingChange(field.key as keyof ScheduleCsvImportMapping, event.target.value)}
+                >
+                  <option value="">Not mapped</option>
+                  {headers.map((header) => <option key={header} value={header}>{header}</option>)}
+                </select>
+              </label>
+            ))}
+          </div>
+        ) : null}
+
+        {errors.length ? (
+          <div className="rounded-xl border border-rose-200 bg-rose-50 p-3 text-xs font-bold text-rose-700" role="alert">
+            {errors.map((item) => <div key={item}>{item}</div>)}
+          </div>
+        ) : null}
+
+        {previewRows.length ? (
+          <div className="space-y-2">
+            <div className="text-xs font-black uppercase tracking-[0.08em] text-gray-500">Preview {previewRows.length} row(s){invalidCount ? `, ${invalidCount} invalid` : ''}</div>
+            {previewRows.map((row) => (
+              <div key={row.rowNumber} className={`rounded-xl border p-3 text-sm ${row.errors.length ? 'border-rose-200 bg-rose-50' : 'border-emerald-200 bg-emerald-50'}`}>
+                <div className="font-black text-gray-900">Row {row.rowNumber}: {row.normalized.eventType === 'game' ? `Game vs ${row.normalized.opponent || 'opponent TBD'}` : row.normalized.title || 'Practice'}</div>
+                <div className="mt-1 text-xs font-semibold text-gray-600">{row.normalized.startsAt || 'Start TBD'} · {row.normalized.location || 'Location TBD'}</div>
+                {row.errors.length ? <ul className="mt-2 list-disc pl-4 text-xs font-bold text-rose-700">{row.errors.map((item) => <li key={item}>{item}</li>)}</ul> : null}
+              </div>
+            ))}
+          </div>
+        ) : null}
+
+        <div className="flex flex-wrap gap-2">
+          <button type="button" className="secondary-button" onClick={onPreview} disabled={!headers.length || importing}>Preview rows</button>
+          <button type="button" className="primary-button" onClick={onImport} disabled={!previewRows.length || invalidCount > 0 || importing}>{importing ? 'Importing…' : 'Import rows'}</button>
+          <button type="button" className="secondary-button" onClick={onClear} disabled={importing}>Clear</button>
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -279,6 +279,14 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
                     return { calendarUrls: [url], added: true };
                 }
 
+                export async function createScheduleImportGame() {
+                    return 'imported-game';
+                }
+
+                export async function createScheduleImportPractice() {
+                    return 'imported-practice';
+                }
+
                 export async function loadParentSchedule() {
                     return { children: [], events: [] };
                 }

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -254,6 +254,16 @@ async function mockScheduleModules(page, options = {}) {
                     return { calendarUrls: [url], added: true };
                 }
 
+                export async function createScheduleImportGame(teamId, row, user) {
+                    window.__scheduleCalls.csvImports = (window.__scheduleCalls.csvImports || []).concat({ type: 'game', teamId, row, userId: user?.uid || null });
+                    return 'imported-game';
+                }
+
+                export async function createScheduleImportPractice(teamId, row, user) {
+                    window.__scheduleCalls.csvImports = (window.__scheduleCalls.csvImports || []).concat({ type: 'practice', teamId, row, userId: user?.uid || null });
+                    return 'imported-practice';
+                }
+
                 export async function loadParentSchedule() {
                     if (${JSON.stringify(scheduleLoadError)}) {
                         throw new Error(${JSON.stringify(scheduleLoadError)});

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -6,6 +6,8 @@ import { MemoryRouter } from '../../apps/app/node_modules/react-router-dom/dist/
 
 const scheduleMocks = vi.hoisted(() => ({
     addTeamCalendarUrl: vi.fn(),
+    createScheduleImportGame: vi.fn(),
+    createScheduleImportPractice: vi.fn(),
     loadParentSchedule: vi.fn()
 }));
 
@@ -113,6 +115,8 @@ beforeEach(() => {
     vi.clearAllMocks();
     document.body.innerHTML = '';
     scheduleMocks.addTeamCalendarUrl.mockResolvedValue({ added: true, calendarUrls: ['https://example.com/team.ics'] });
+    scheduleMocks.createScheduleImportGame.mockResolvedValue('game-new');
+    scheduleMocks.createScheduleImportPractice.mockResolvedValue('practice-new');
     scheduleMocks.loadParentSchedule.mockResolvedValue({
         children: [
             { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' },
@@ -199,6 +203,112 @@ describe('React app desktop Schedule controls', () => {
 
         expect(staff.container.textContent).toContain('Enter a calendar .ics URL.');
         expect(scheduleMocks.addTeamCalendarUrl).not.toHaveBeenCalled();
+    });
+
+    it('previews and imports staff CSV schedule rows while hiding import from parents', async () => {
+        const parentOnly = await renderSchedule();
+        await waitForText(parentOnly.container, 'Main Gym');
+        expect(parentOnly.container.textContent).not.toContain('Import schedule CSV');
+
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            children: [
+                { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+            ],
+            events: [event({ isTeamStaff: true })]
+        });
+
+        const { container } = await renderSchedule();
+        await waitForText(container, 'Import schedule CSV');
+        const input = container.querySelector('input[aria-label="Schedule CSV file"]');
+        const file = new File([
+            'Type,Date,Start,End,Opponent,Title,Location\n',
+            'Game,4/2/2026,6:30 PM,8:00 PM,Tigers,,Field 1\n',
+            'Practice,4/4/2026,7:00 AM,8:30 AM,,Speed Session,Field 2'
+        ], 'schedule.csv', { type: 'text/csv' });
+
+        await act(async () => {
+            Object.defineProperty(input, 'files', { value: [file], configurable: true });
+            input.dispatchEvent(new Event('change', { bubbles: true }));
+            await Promise.resolve();
+        });
+
+        await clickButton(container, 'Preview rows');
+        await waitForText(container, 'Game vs Tigers');
+        expect(container.textContent).toContain('Speed Session');
+
+        await clickButton(container, 'Import rows');
+        expect(scheduleMocks.createScheduleImportGame).toHaveBeenCalledWith('team-1', expect.objectContaining({
+            eventType: 'game',
+            opponent: 'Tigers'
+        }), auth.user);
+        expect(scheduleMocks.createScheduleImportPractice).toHaveBeenCalledWith('team-1', expect.objectContaining({
+            eventType: 'practice',
+            title: 'Speed Session'
+        }), auth.user);
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(3);
+        await waitForText(container, 'Imported 2 schedule row(s) and refreshed the schedule.');
+    });
+
+    it('blocks CSV import when preview contains invalid rows', async () => {
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            children: [
+                { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+            ],
+            events: [event({ isTeamStaff: true })]
+        });
+
+        const { container } = await renderSchedule();
+        await waitForText(container, 'Import schedule CSV');
+        const input = container.querySelector('input[aria-label="Schedule CSV file"]');
+        const file = new File([
+            'Type,Date,Start,Opponent\n',
+            'Game,4/2/2026,not-a-time,'
+        ], 'bad-schedule.csv', { type: 'text/csv' });
+
+        await act(async () => {
+            Object.defineProperty(input, 'files', { value: [file], configurable: true });
+            input.dispatchEvent(new Event('change', { bubbles: true }));
+            await Promise.resolve();
+        });
+
+        await clickButton(container, 'Preview rows');
+        await waitForText(container, 'Start time is invalid.');
+        expect(buttonByText(container, 'Import rows').disabled).toBe(true);
+        expect(scheduleMocks.createScheduleImportGame).not.toHaveBeenCalled();
+    });
+
+    it('leaves failed CSV rows available after a partial import failure', async () => {
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            children: [
+                { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+            ],
+            events: [event({ isTeamStaff: true })]
+        });
+        scheduleMocks.createScheduleImportGame.mockRejectedValueOnce(new Error('Firestore write failed'));
+
+        const { container } = await renderSchedule();
+        await waitForText(container, 'Import schedule CSV');
+        const input = container.querySelector('input[aria-label="Schedule CSV file"]');
+        const file = new File([
+            'Type,Date,Start,Opponent,Location\n',
+            'Game,4/2/2026,6:30 PM,Tigers,Field 1\n',
+            'Practice,4/4/2026,7:00 AM,,Field 2'
+        ], 'partial-schedule.csv', { type: 'text/csv' });
+
+        await act(async () => {
+            Object.defineProperty(input, 'files', { value: [file], configurable: true });
+            input.dispatchEvent(new Event('change', { bubbles: true }));
+            await Promise.resolve();
+        });
+
+        await clickButton(container, 'Preview rows');
+        await waitForText(container, 'Game vs Tigers');
+        await clickButton(container, 'Import rows');
+
+        await waitForText(container, 'Imported 1 row(s); 1 row(s) failed and remain below for retry.');
+        expect(container.textContent).toContain('Firestore write failed');
+        expect(container.textContent).toContain('Game vs Tigers');
+        expect(container.textContent).not.toContain('Row 3: Practice');
     });
 
 });

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -9,6 +9,8 @@ const dbMocks = vi.hoisted(() => ({
     getRsvpSummaries: vi.fn(),
     getTeam: vi.fn(),
     updateTeam: vi.fn(),
+    addGame: vi.fn(),
+    addPractice: vi.fn(),
     getTrackedCalendarEventUids: vi.fn(),
     createRideOffer: vi.fn(),
     claimAssignmentSlot: vi.fn(),
@@ -115,7 +117,7 @@ vi.mock('../../js/snack-helpers.js', () => ({
     }))
 }));
 
-import { addTeamCalendarUrl, loadParentSchedule } from '../../apps/app/src/lib/scheduleService.ts';
+import { addTeamCalendarUrl, createScheduleImportGame, createScheduleImportPractice, loadParentSchedule } from '../../apps/app/src/lib/scheduleService.ts';
 
 function installWindow(protocol = 'http:') {
     vi.stubGlobal('window', {
@@ -417,6 +419,67 @@ describe('React app schedule service contract integration', () => {
         await expect(addTeamCalendarUrl('team-1', 'https://example.com/team.ics', user()))
             .rejects.toThrow('You do not have permission to manage this team schedule.');
         expect(dbMocks.updateTeam).not.toHaveBeenCalled();
+    });
+
+    it('creates CSV import games and practices only for staff users', async () => {
+        dbMocks.getTeam.mockResolvedValue({
+            id: 'team-1',
+            name: 'Bears',
+            ownerId: 'coach-1',
+            adminEmails: []
+        });
+        dbMocks.addGame.mockResolvedValue('game-new');
+        dbMocks.addPractice.mockResolvedValue('practice-new');
+        const coach = { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach' };
+
+        await expect(createScheduleImportGame('team-1', {
+            eventType: 'game',
+            startsAt: '2026-04-02T18:30',
+            endsAt: '2026-04-02T20:00',
+            opponent: 'Tigers',
+            location: 'Field 1',
+            arrivalTime: '2026-04-02T17:45',
+            isHome: false,
+            notes: 'Bring white kit'
+        }, coach)).resolves.toBe('game-new');
+
+        expect(dbMocks.addGame).toHaveBeenCalledWith('team-1', expect.objectContaining({
+            type: 'game',
+            opponent: 'Tigers',
+            location: 'Field 1',
+            isHome: false,
+            status: 'scheduled',
+            homeScore: 0,
+            awayScore: 0,
+            createdBy: 'coach-1'
+        }));
+        expect(dbMocks.addGame.mock.calls[0][1].date).toBeInstanceOf(Date);
+        expect(dbMocks.addGame.mock.calls[0][1].arrivalTime).toBeInstanceOf(Date);
+
+        await expect(createScheduleImportPractice('team-1', {
+            eventType: 'practice',
+            startsAt: '2026-04-04T07:00',
+            endsAt: '2026-04-04T08:30',
+            title: 'Speed Session',
+            location: 'Field 2',
+            arrivalTime: null,
+            notes: 'Bring water'
+        }, coach)).resolves.toBe('practice-new');
+
+        expect(dbMocks.addPractice).toHaveBeenCalledWith('team-1', expect.objectContaining({
+            type: 'practice',
+            title: 'Speed Session',
+            opponent: null,
+            status: 'scheduled',
+            createdBy: 'coach-1'
+        }));
+
+        dbMocks.getTeam.mockResolvedValue({ id: 'team-1', ownerId: 'other-user', adminEmails: [] });
+        await expect(createScheduleImportGame('team-1', {
+            eventType: 'game',
+            startsAt: '2026-04-02T18:30',
+            opponent: 'Tigers'
+        }, { uid: 'parent-1', email: 'parent@example.com' })).rejects.toThrow('permission');
     });
 
 });


### PR DESCRIPTION
Closes #1537

## What changed
- Added a staff-only CSV schedule import panel to the React Schedule page.
- Reused the legacy CSV parser/mapping/preview helpers through a typed app wrapper.
- Added app schedule service methods to create imported games and practices with staff permission checks and native REST fallback.
- Preserved failed rows after partial import failure so staff can retry only failures.

## Validation
- `npx vitest run tests/unit/app-schedule-service-contracts.test.js tests/unit/app-schedule-desktop-controls.test.jsx tests/unit/schedule-csv-import.test.js --reporter=verbose`
- `npm run app:build`
- Android Gradle `:app:assembleDebug` attempted but blocked locally because Android SDK location is not configured (`ANDROID_HOME`/`android/local.properties`).
- iOS build skipped on Linux host.