### PR TITLE
Fix recurring practice occurrence ids

### DIFF
--- a/js/utils.js
+++ b/js/utils.js
@@ -1639,7 +1639,7 @@ export function expandRecurrence(master, windowDays = 180) {
       // Build the occurrence object
       const occurrence = {
         ...master,
-        id: master.id, // Keep master ID for reference
+        id: `${master.id}__${isoDate}`,
         masterId: master.id,
         instanceDate: isoDate,
         isInstance: true,

--- a/tests/unit/recurrence-expand.test.js
+++ b/tests/unit/recurrence-expand.test.js
@@ -6,6 +6,33 @@ describe('expandRecurrence interval guardrails', () => {
     vi.useRealTimers();
   });
 
+  it('sets occurrence id to masterId and instanceDate while preserving masterId', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-10T12:00:00Z'));
+
+    const master = {
+      id: 'series-practice-rsvp',
+      isSeriesMaster: true,
+      date: new Date('2026-01-05T18:00:00Z'),
+      recurrence: {
+        freq: 'weekly',
+        interval: 1,
+        byDays: ['MO'],
+        count: 3
+      }
+    };
+
+    const occurrences = expandRecurrence(master, 30);
+
+    expect(occurrences.map((occ) => occ.id)).toEqual([
+      'series-practice-rsvp__2026-01-05',
+      'series-practice-rsvp__2026-01-12',
+      'series-practice-rsvp__2026-01-19'
+    ]);
+    expect(new Set(occurrences.map((occ) => occ.id)).size).toBe(occurrences.length);
+    expect(occurrences.every((occ) => occ.masterId === master.id)).toBe(true);
+  });
+
   it('honors daily interval in matching and does not double-advance', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-01-10T12:00:00Z'));


### PR DESCRIPTION
Closes #1566

## Summary
- Set expanded recurring occurrence `id` values to `masterId__instanceDate`.
- Preserve `masterId` as the original series master id for downstream references.
- Added regression coverage asserting occurrence ids are unique and formatted from the master id plus instance date.

## Validation
- `npx vitest run tests/unit/recurrence-expand.test.js --reporter=verbose`
- `npm test`
- `npm run app:build`