### PR TITLE
Apply help role filters in app search

### DIFF
--- a/apps/app/src/lib/helpKnowledgeService.ts
+++ b/apps/app/src/lib/helpKnowledgeService.ts
@@ -58,9 +58,9 @@ const stopWords = new Set([
 let helpDocsCache: HelpKnowledgeDoc[] | null = null;
 
 export function getSearchHelpRoles(helpRoleFilter?: unknown): string[] {
-  const [role] = normalizeRoles([helpRoleFilter]);
-  if (!role || role === 'all') return [...searchableHelpRoles];
-  return searchableHelpRoles.includes(role) ? [role] : [...searchableHelpRoles];
+  const role = normalizeRoles([helpRoleFilter]).find((normalizedRole) => searchableHelpRoles.includes(normalizedRole));
+  if (!role) return [...searchableHelpRoles];
+  return [role];
 }
 
 export function getHelpKnowledgeDocs(): HelpKnowledgeDoc[] {

--- a/apps/app/src/lib/helpKnowledgeService.ts
+++ b/apps/app/src/lib/helpKnowledgeService.ts
@@ -95,7 +95,9 @@ export function searchHelpKnowledge({
   const maxResults = Math.min(Math.max(Number(limit) || 5, 1), 8);
 
   return getHelpKnowledgeDocs()
-    .filter((doc) => roleFilterMatches(doc.roles, normalizedRoleFilter))
+    .filter((doc) => normalizedRoleFilter
+      ? roleFilterMatches(doc.roles, normalizedRoleFilter)
+      : (!roleTokens.length || roleMatches(doc.roles, roleTokens)))
     .map((doc) => {
       const score = scoreHelpDoc(doc, cleanQuery, queryTokens, roleTokens);
       return {

--- a/apps/app/src/lib/helpKnowledgeService.ts
+++ b/apps/app/src/lib/helpKnowledgeService.ts
@@ -163,6 +163,7 @@ function buildSnippet(doc: HelpKnowledgeDoc, tokens: string[]) {
 function normalizeRoles(roles: unknown[]) {
   const normalized = roles
     .map((role) => compactText(role).toLowerCase())
+    .flatMap((role) => role === 'platformadmin' || role === 'platform admin' ? ['platformadmin', 'admin'] : [role])
     .map((role) => role === 'administrator' || role === 'admins' || role === 'administrators' ? 'admin' : role)
     .map((role) => role === 'parents' ? 'parent' : role)
     .map((role) => role === 'coaches' ? 'coach' : role)

--- a/apps/app/src/lib/helpKnowledgeService.ts
+++ b/apps/app/src/lib/helpKnowledgeService.ts
@@ -80,7 +80,7 @@ export function getHelpKnowledgeDocs(): HelpKnowledgeDoc[] {
 export function searchHelpKnowledge({
   query,
   roles = [],
-  roleFilter = 'all',
+  roleFilter,
   limit = 5
 }: {
   query: string;

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -73,7 +73,10 @@ export type AppSearchHelp = AppSearchItem & {
   snippet: string;
 };
 
-export type AppSearchHelpRoleFilter = UserRole | 'member' | 'all';
+export type AppSearchHelpRoleFilter = 'All' | UserRole | 'member' | string;
+export type AppSearchHelpRole = UserRole | 'member';
+
+const allSearchHelpRoles: AppSearchHelpRole[] = ['parent', 'coach', 'admin', 'platformAdmin', 'member'];
 
 export function normalizeSearchQuery(queryText: string) {
   return String(queryText || '').trim().toLowerCase();
@@ -367,13 +370,23 @@ function buildAppSearchHelpResults(
   const normalized = normalizeSearchQuery(queryText);
   if (normalized.length < 2) return [];
 
+  const rawHelpRoleFilter = cleanString(helpRoleFilter);
+  const usesDisplayHelpRoleFilter = rawHelpRoleFilter !== '' && rawHelpRoleFilter[0] !== rawHelpRoleFilter[0].toLowerCase();
   const normalizedRoleFilter = normalizeAppSearchHelpRoleFilter(helpRoleFilter);
-  return searchHelpKnowledge({
-    query: queryText,
-    roles: getSearchHelpAuthRoles(auth),
-    roleFilter: normalizedRoleFilter,
-    limit: 5
-  })
+  const helpSearchRequest = usesDisplayHelpRoleFilter
+    ? {
+        query: queryText,
+        roles: getSearchHelpRoles(auth, helpRoleFilter),
+        limit: 5
+      }
+    : {
+        query: queryText,
+        roles: getSearchHelpAuthRoles(auth),
+        roleFilter: normalizedRoleFilter,
+        limit: 5
+      };
+
+  return searchHelpKnowledge(helpSearchRequest)
     .filter((result) => normalizedRoleFilter === 'all' || helpResultMatchesRole(result.roles, normalizedRoleFilter))
     .map((result) => ({
       id: `help:${result.id}`,
@@ -390,15 +403,51 @@ function buildAppSearchHelpResults(
 
 function getSearchHelpAuthRoles(auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatformAdmin'> & Partial<Pick<AuthState, 'roles' | 'isParent' | 'isCoach'>>): UserRole[] {
   const roles = new Set<UserRole>();
-  (auth.roles || auth.user?.roles || []).forEach((role) => roles.add(normalizeAppSearchHelpRoleFilter(role) as UserRole));
+  (auth.roles || auth.user?.roles || []).forEach((role) => {
+    const normalizedRole = normalizeAppSearchHelpRoleFilter(role);
+    if (normalizedRole && normalizedRole !== 'all') roles.add(normalizedRole as UserRole);
+  });
   if (auth.isAdmin || auth.user?.isAdmin || auth.isPlatformAdmin) roles.add('admin');
   if (auth.isParent) roles.add('parent');
   if (auth.isCoach) roles.add('coach');
   return [...roles];
 }
 
-function normalizeAppSearchHelpRoleFilter(role: AppSearchHelpRoleFilter): Exclude<AppSearchHelpRoleFilter, 'platformAdmin'> {
-  return role === 'platformAdmin' ? 'admin' : role;
+export function getSearchHelpRoles(
+  auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatformAdmin'> & Partial<Pick<AuthState, 'roles' | 'isParent' | 'isCoach'>>,
+  helpRoleFilter?: AppSearchHelpRoleFilter
+): AppSearchHelpRole[] {
+  const normalizedFilter = normalizeSearchHelpRole(helpRoleFilter);
+  if (normalizedFilter === 'all') return allSearchHelpRoles;
+  if (normalizedFilter) return [normalizedFilter];
+
+  const roles = new Set<AppSearchHelpRole>();
+  (auth.roles || auth.user?.roles || []).forEach((role) => {
+    const normalizedRole = normalizeSearchHelpRole(role);
+    if (normalizedRole && normalizedRole !== 'all') roles.add(normalizedRole);
+  });
+  if (auth.isAdmin || auth.user?.isAdmin) roles.add('admin');
+  if (auth.isPlatformAdmin) roles.add('platformAdmin');
+  if (auth.isParent) roles.add('parent');
+  if (auth.isCoach) roles.add('coach');
+  return [...roles];
+}
+
+function normalizeAppSearchHelpRoleFilter(role: unknown): Exclude<AppSearchHelpRoleFilter, 'platformAdmin'> | '' {
+  const normalized = normalizeSearchHelpRole(role);
+  return normalized === 'platformAdmin' ? 'admin' : normalized;
+}
+
+function normalizeSearchHelpRole(role: unknown): AppSearchHelpRole | 'all' | '' {
+  const normalized = cleanString(role).toLowerCase();
+  if (!normalized) return '';
+  if (normalized === 'all') return 'all';
+  if (normalized === 'administrator') return 'admin';
+  if (normalized === 'parents') return 'parent';
+  if (normalized === 'coaches') return 'coach';
+  if (normalized === 'platformadmin' || normalized === 'platform admin') return 'platformAdmin';
+  if (normalized === 'parent' || normalized === 'coach' || normalized === 'admin' || normalized === 'member') return normalized;
+  return '';
 }
 
 function helpResultMatchesRole(resultRoles: string[] = [], helpRoleFilter: Exclude<AppSearchHelpRoleFilter, 'platformAdmin'>) {

--- a/tests/unit/app-help-knowledge-service.test.js
+++ b/tests/unit/app-help-knowledge-service.test.js
@@ -17,6 +17,19 @@ describe('app help knowledge service', () => {
         ]));
     });
 
+    it('filters functional workflow help by requested role', async () => {
+        const { searchHelpKnowledge } = await import('../../apps/app/src/lib/helpKnowledgeService.ts');
+        const results = searchHelpKnowledge({
+            query: 'schedule',
+            roles: ['member'],
+            limit: 8
+        });
+
+        expect(results.length).toBeGreaterThan(0);
+        expect(results.every((result) => result.roles.includes('member') || result.roles.includes('all'))).toBe(true);
+        expect(results.map((result) => result.id)).not.toContain('schedule');
+    });
+
     it('finds functional workflow help with source pages and snippets', async () => {
         const { searchHelpKnowledge } = await import('../../apps/app/src/lib/helpKnowledgeService.ts');
         const results = searchHelpKnowledge({

--- a/tests/unit/app-help-knowledge-service.test.js
+++ b/tests/unit/app-help-knowledge-service.test.js
@@ -41,6 +41,13 @@ describe('app help knowledge service', () => {
         expect(results.map((result) => result.id)).toContain('admin-ops');
     });
 
+    it('maps platform admin aliases to the admin help role', async () => {
+        const { getSearchHelpRoles } = await import('../../apps/app/src/lib/helpKnowledgeService.ts');
+
+        expect(getSearchHelpRoles('platformAdmin')).toEqual(['admin']);
+        expect(getSearchHelpRoles('platform admin')).toEqual(['admin']);
+    });
+
     it('finds functional workflow help with source pages and snippets', async () => {
         const { searchHelpKnowledge } = await import('../../apps/app/src/lib/helpKnowledgeService.ts');
         const results = searchHelpKnowledge({

--- a/tests/unit/app-help-knowledge-service.test.js
+++ b/tests/unit/app-help-knowledge-service.test.js
@@ -30,6 +30,17 @@ describe('app help knowledge service', () => {
         expect(results.map((result) => result.id)).not.toContain('schedule');
     });
 
+    it('includes admin workflow help for platform admin role lookups', async () => {
+        const { searchHelpKnowledge } = await import('../../apps/app/src/lib/helpKnowledgeService.ts');
+        const results = searchHelpKnowledge({
+            query: 'platform admin controls',
+            roles: ['platformAdmin'],
+            limit: 5
+        });
+
+        expect(results.map((result) => result.id)).toContain('admin-ops');
+    });
+
     it('finds functional workflow help with source pages and snippets', async () => {
         const { searchHelpKnowledge } = await import('../../apps/app/src/lib/helpKnowledgeService.ts');
         const results = searchHelpKnowledge({

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -34,6 +34,7 @@ vi.mock('../../apps/app/src/lib/helpKnowledgeService.ts', () => helpMocks);
 import {
     buildAppSearchActions,
     computeAppSearchResults,
+    getSearchHelpRoles,
     loadAppSearchTeams,
     resetAppSearchCacheForTests,
     scoreSearchText,
@@ -169,6 +170,61 @@ describe('React app search service', () => {
         expect(defaultResults.actions.map((item) => item.id)).toEqual(['browse-teams', 'dashboard', 'my-teams', 'schedule', 'messages', 'social-feed', 'find-friends', 'create-social-post', 'profile']);
         expect(defaultResults.teams).toHaveLength(20);
         expect(defaultResults.players).toHaveLength(20);
+    });
+
+    it('translates help role filters without affecting non-help search results', () => {
+        expect(getSearchHelpRoles(auth, 'All')).toEqual(['parent', 'coach', 'admin', 'platformAdmin', 'member']);
+        expect(getSearchHelpRoles(auth, 'Coach')).toEqual(['coach']);
+        expect(getSearchHelpRoles(auth, 'Member')).toEqual(['member']);
+        expect(getSearchHelpRoles({ ...auth, roles: ['coach'], isCoach: true, isParent: true })).toEqual(['coach', 'parent']);
+
+        helpMocks.searchHelpKnowledge.mockReturnValue([{
+            id: 'coach-schedule',
+            title: 'Plan Schedule',
+            file: 'workflow-schedule.html',
+            url: 'https://allplays.ai/workflow-schedule.html',
+            roles: ['coach', 'admin'],
+            summary: 'Schedule games and practices.',
+            snippet: 'Coach and admin scheduling guidance.',
+            score: 38
+        }]);
+
+        const teams = [{ id: 'team-1', name: 'Schedule Bears', sport: 'Basketball', isPublic: true }];
+        const players = [{
+            id: 'player:team-1:player-1',
+            kind: 'player',
+            title: 'Schedule Striker',
+            subtitle: 'Schedule Bears',
+            route: '/players/team-1/player-1',
+            teamId: 'team-1',
+            playerId: 'player-1'
+        }];
+        const withoutFilter = computeAppSearchResults({
+            queryText: 'schedule',
+            auth,
+            teams,
+            players
+        });
+        const withCoachFilter = computeAppSearchResults({
+            queryText: 'schedule',
+            auth,
+            teams,
+            players,
+            helpRoleFilter: 'Coach'
+        });
+
+        expect(helpMocks.searchHelpKnowledge).toHaveBeenLastCalledWith({
+            query: 'schedule',
+            roles: ['coach'],
+            limit: 5
+        });
+        expect(withoutFilter.teams).toEqual(withCoachFilter.teams);
+        expect(withoutFilter.players).toEqual(withCoachFilter.players);
+        expect(withoutFilter.actions).toEqual(withCoachFilter.actions);
+        expect(withCoachFilter.help[0]).toMatchObject({
+            id: 'help:coach-schedule',
+            roles: ['coach', 'admin']
+        });
     });
 
     it('adds limited help results for meaningful queries without changing app result ordering', () => {


### PR DESCRIPTION
Closes #1580

## Summary
- Added optional `helpRoleFilter` support to `computeAppSearchResults` and passed it into help result construction.
- Exported and expanded `getSearchHelpRoles` so `All`, specific roles, and `Member` normalize correctly.
- Applied role filtering in `searchHelpKnowledge` so help search results respect the requested role while non-help categories remain unchanged.

## Validation
- `npx vitest run tests/unit/app-search-service.test.js tests/unit/app-help-knowledge-service.test.js --reporter=verbose`
- `npm test -- --reporter=dot`
- `npm run app:build`

Android/iOS native builds were not run because this change only touches shared app search/help logic and no native project files.