### PR TITLE
Add help role filter translation

### DIFF
--- a/apps/app/src/lib/helpKnowledgeService.ts
+++ b/apps/app/src/lib/helpKnowledgeService.ts
@@ -21,6 +21,7 @@ type HelpKnowledgeDoc = HelpKnowledgeIndexDoc & {
   text: string;
 };
 
+const searchableHelpRoles = ['admin', 'coach', 'member', 'parent'];
 const allPlaysOrigin = 'https://allplays.ai/';
 const stopWords = new Set([
   'about',
@@ -53,6 +54,12 @@ const stopWords = new Set([
 ]);
 
 let helpDocsCache: HelpKnowledgeDoc[] | null = null;
+
+export function getSearchHelpRoles(helpRoleFilter?: unknown): string[] {
+  const [role] = normalizeRoles([helpRoleFilter]);
+  if (!role || role === 'all') return [...searchableHelpRoles];
+  return searchableHelpRoles.includes(role) ? [role] : [...searchableHelpRoles];
+}
 
 export function getHelpKnowledgeDocs(): HelpKnowledgeDoc[] {
   if (helpDocsCache) return helpDocsCache;
@@ -148,7 +155,7 @@ function buildSnippet(doc: HelpKnowledgeDoc, tokens: string[]) {
 function normalizeRoles(roles: unknown[]) {
   const normalized = roles
     .map((role) => compactText(role).toLowerCase())
-    .map((role) => role === 'administrator' ? 'admin' : role)
+    .map((role) => role === 'administrator' || role === 'admins' || role === 'administrators' ? 'admin' : role)
     .map((role) => role === 'parents' ? 'parent' : role)
     .map((role) => role === 'coaches' ? 'coach' : role)
     .filter(Boolean);

--- a/tests/unit/help-knowledge-service.test.js
+++ b/tests/unit/help-knowledge-service.test.js
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { getSearchHelpRoles } from '../../apps/app/src/lib/helpKnowledgeService.ts';
+
+describe('help knowledge service role filters', () => {
+    const allSearchableRoles = ['admin', 'coach', 'member', 'parent'];
+
+    it('returns all searchable help roles for all or empty filter values', () => {
+        expect(getSearchHelpRoles()).toEqual(allSearchableRoles);
+        expect(getSearchHelpRoles(null)).toEqual(allSearchableRoles);
+        expect(getSearchHelpRoles('')).toEqual(allSearchableRoles);
+        expect(getSearchHelpRoles('All')).toEqual(allSearchableRoles);
+    });
+
+    it('returns only the selected supported help role filter', () => {
+        expect(getSearchHelpRoles('parent')).toEqual(['parent']);
+        expect(getSearchHelpRoles('Coaches')).toEqual(['coach']);
+        expect(getSearchHelpRoles('administrator')).toEqual(['admin']);
+        expect(getSearchHelpRoles('member')).toEqual(['member']);
+    });
+});


### PR DESCRIPTION
Closes #1583

## Summary
- Added `getSearchHelpRoles` to translate optional help role filters into searchable help role sets.
- Treats `All`, undefined, null, and empty values as all searchable help roles.
- Covers specific supported role filters with focused unit tests.

## Validation
- `npx vitest run tests/unit/help-knowledge-service.test.js --reporter=verbose`
- `npm run app:build`