### PR TITLE
Wire help role filter through app search

### DIFF
--- a/apps/app/src/lib/helpKnowledgeService.ts
+++ b/apps/app/src/lib/helpKnowledgeService.ts
@@ -11,6 +11,8 @@ export type HelpKnowledgeResult = {
   score: number;
 };
 
+export type HelpKnowledgeRoleFilter = string;
+
 type HelpKnowledgeDoc = HelpKnowledgeIndexDoc & {
   id: string;
   title: string;
@@ -78,18 +80,22 @@ export function getHelpKnowledgeDocs(): HelpKnowledgeDoc[] {
 export function searchHelpKnowledge({
   query,
   roles = [],
+  roleFilter = 'all',
   limit = 5
 }: {
   query: string;
   roles?: string[];
+  roleFilter?: HelpKnowledgeRoleFilter;
   limit?: number;
 }): HelpKnowledgeResult[] {
   const cleanQuery = compactText(query);
   const queryTokens = tokenize(cleanQuery);
   const roleTokens = normalizeRoles(roles);
+  const [normalizedRoleFilter] = normalizeRoles([roleFilter]);
   const maxResults = Math.min(Math.max(Number(limit) || 5, 1), 8);
 
   return getHelpKnowledgeDocs()
+    .filter((doc) => roleFilterMatches(doc.roles, normalizedRoleFilter))
     .map((doc) => {
       const score = scoreHelpDoc(doc, cleanQuery, queryTokens, roleTokens);
       return {
@@ -166,6 +172,12 @@ function roleMatches(docRoles: string[], userRoles: string[]) {
   if (!userRoles.length) return false;
   const roles = docRoles.map((role) => role.toLowerCase());
   return roles.includes('all') || userRoles.some((role) => roles.includes(role));
+}
+
+function roleFilterMatches(docRoles: string[], roleFilter: string | undefined) {
+  if (!roleFilter || roleFilter === 'all') return true;
+  const roles = docRoles.map((role) => role.toLowerCase());
+  return roles.includes('all') || roles.includes(roleFilter);
 }
 
 function tokenize(value: string) {

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -13,7 +13,7 @@ import {
   limit
 } from '../../../../js/firebase.js';
 import { loadParentHome } from './homeService';
-import { getSearchHelpRoles as getHelpKnowledgeRoles, searchHelpKnowledge } from './helpKnowledgeService';
+import { searchHelpKnowledge } from './helpKnowledgeService';
 import type { AuthState, AuthUser, UserRole } from './types';
 
 const teamsCacheTtlMs = 10 * 60 * 1000;
@@ -72,6 +72,8 @@ export type AppSearchHelp = AppSearchItem & {
   roles: string[];
   snippet: string;
 };
+
+export type AppSearchHelpRoleFilter = UserRole | 'member' | 'all';
 
 export function normalizeSearchQuery(queryText: string) {
   return String(queryText || '').trim().toLowerCase();
@@ -210,7 +212,7 @@ export function computeAppSearchResults({
   auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatformAdmin'> & Partial<Pick<AuthState, 'roles' | 'isParent' | 'isCoach'>>;
   teams: AppSearchTeam[];
   players: AppSearchPlayer[];
-  helpRoleFilter?: unknown;
+  helpRoleFilter?: AppSearchHelpRoleFilter;
 }) {
   const tokens = splitSearchTokens(queryText);
   const actions = buildAppSearchActions(auth);
@@ -360,14 +362,15 @@ export async function searchAppPlayers(queryText: string, teamsById: Map<string,
 function buildAppSearchHelpResults(
   queryText: string,
   auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatformAdmin'> & Partial<Pick<AuthState, 'roles' | 'isParent' | 'isCoach'>>,
-  helpRoleFilter?: unknown
+  helpRoleFilter: AppSearchHelpRoleFilter = 'all'
 ): AppSearchHelp[] {
   const normalized = normalizeSearchQuery(queryText);
   if (normalized.length < 2) return [];
 
   return searchHelpKnowledge({
     query: queryText,
-    roles: getSearchHelpQueryRoles(auth, helpRoleFilter),
+    roles: getSearchHelpAuthRoles(auth),
+    roleFilter: helpRoleFilter,
     limit: 5
   }).map((result) => ({
     id: `help:${result.id}`,
@@ -379,14 +382,6 @@ function buildAppSearchHelpResults(
     roles: result.roles,
     snippet: result.snippet
   }));
-}
-
-function getSearchHelpQueryRoles(
-  auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatformAdmin'> & Partial<Pick<AuthState, 'roles' | 'isParent' | 'isCoach'>>,
-  helpRoleFilter?: unknown
-): string[] {
-  if (helpRoleFilter !== undefined) return getHelpKnowledgeRoles(helpRoleFilter);
-  return getSearchHelpAuthRoles(auth);
 }
 
 function getSearchHelpAuthRoles(auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatformAdmin'> & Partial<Pick<AuthState, 'roles' | 'isParent' | 'isCoach'>>): UserRole[] {

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -370,7 +370,7 @@ function buildAppSearchHelpResults(
   return searchHelpKnowledge({
     query: queryText,
     roles: getSearchHelpAuthRoles(auth),
-    roleFilter: helpRoleFilter,
+    roleFilter: normalizeAppSearchHelpRoleFilter(helpRoleFilter),
     limit: 5
   }).map((result) => ({
     id: `help:${result.id}`,
@@ -386,12 +386,15 @@ function buildAppSearchHelpResults(
 
 function getSearchHelpAuthRoles(auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatformAdmin'> & Partial<Pick<AuthState, 'roles' | 'isParent' | 'isCoach'>>): UserRole[] {
   const roles = new Set<UserRole>();
-  (auth.roles || auth.user?.roles || []).forEach((role) => roles.add(role));
-  if (auth.isAdmin || auth.user?.isAdmin) roles.add('admin');
-  if (auth.isPlatformAdmin) roles.add('platformAdmin');
+  (auth.roles || auth.user?.roles || []).forEach((role) => roles.add(normalizeAppSearchHelpRoleFilter(role) as UserRole));
+  if (auth.isAdmin || auth.user?.isAdmin || auth.isPlatformAdmin) roles.add('admin');
   if (auth.isParent) roles.add('parent');
   if (auth.isCoach) roles.add('coach');
   return [...roles];
+}
+
+function normalizeAppSearchHelpRoleFilter(role: AppSearchHelpRoleFilter): Exclude<AppSearchHelpRoleFilter, 'platformAdmin'> {
+  return role === 'platformAdmin' ? 'admin' : role;
 }
 
 export function resetAppSearchCacheForTests() {

--- a/tests/unit/app-help-knowledge-service.test.js
+++ b/tests/unit/app-help-knowledge-service.test.js
@@ -33,4 +33,25 @@ describe('app help knowledge service', () => {
         expect(results.map((result) => result.title).join(' ')).toMatch(/Account|Access|Create|Help/i);
         expect(results[0].snippet.length).toBeGreaterThan(40);
     });
+
+    it('filters help search results by All and a specific help role', async () => {
+        const { searchHelpKnowledge } = await import('../../apps/app/src/lib/helpKnowledgeService.ts');
+
+        const allResults = searchHelpKnowledge({
+            query: 'streaming access',
+            roles: ['parent'],
+            roleFilter: 'all',
+            limit: 8
+        });
+        const parentResults = searchHelpKnowledge({
+            query: 'streaming access',
+            roles: ['parent'],
+            roleFilter: 'parent',
+            limit: 8
+        });
+
+        expect(allResults.some((result) => !result.roles.includes('parent') && !result.roles.includes('all'))).toBe(true);
+        expect(parentResults.length).toBeGreaterThan(0);
+        expect(parentResults.every((result) => result.roles.includes('parent') || result.roles.includes('all'))).toBe(true);
+    });
 });

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -210,6 +210,7 @@ describe('React app search service', () => {
         expect(helpMocks.searchHelpKnowledge).toHaveBeenCalledWith({
             query: 'password reset',
             roles: ['parent'],
+            roleFilter: 'all',
             limit: 5
         });
         expect(results.help).toEqual([{
@@ -225,37 +226,47 @@ describe('React app search service', () => {
         expect(results.flat.map((item) => item.kind)).toEqual(['team', 'help', 'player']);
     });
 
-    it('does not let a help role filter change non-help search result categories', () => {
-        helpMocks.searchHelpKnowledge.mockReturnValue([{
-            id: 'team-help',
-            title: 'Team help',
-            file: 'help-coaches.html',
-            url: 'https://allplays.ai/help-coaches.html',
-            roles: ['coach'],
-            summary: 'Coach team help.',
-            snippet: 'Coach team help.',
+    it('passes the optional help role filter only to help search results', () => {
+        const helpDocs = [{
+            id: 'parent-guide',
+            title: 'Parent guide',
+            file: 'help-parent.html',
+            url: 'https://allplays.ai/help-parent.html',
+            roles: ['parent'],
+            summary: 'Help for parents.',
+            snippet: 'Help for parents.',
             score: 10
-        }]);
+        }, {
+            id: 'coach-guide',
+            title: 'Coach guide',
+            file: 'help-coach.html',
+            url: 'https://allplays.ai/help-coach.html',
+            roles: ['coach'],
+            summary: 'Help for coaches.',
+            snippet: 'Help for coaches.',
+            score: 9
+        }];
+        helpMocks.searchHelpKnowledge.mockImplementation(({ roleFilter }) => (
+            roleFilter === 'coach' ? helpDocs.filter((doc) => doc.roles.includes('coach')) : helpDocs
+        ));
+
         const baseSearchInput = {
-            queryText: 'team',
+            queryText: 'guide',
             auth,
-            teams: [
-                { id: 'team-1', name: 'Team Alpha', sport: 'Basketball', zip: '66210', isPublic: true },
-                { id: 'team-2', name: 'Team Beta', sport: 'Soccer', zip: '64114', isPublic: true }
-            ],
+            teams: [{ id: 'team-1', name: 'Guide Bears', sport: 'Basketball', isPublic: true }],
             players: [{
                 id: 'player:team-1:player-1',
                 kind: 'player',
-                title: 'Team Player',
-                subtitle: 'Team Alpha',
+                title: 'Guide Runner',
+                subtitle: 'Guide Bears',
                 route: '/players/team-1/player-1',
                 teamId: 'team-1',
                 playerId: 'player-1'
             }]
         };
 
-        const withoutRoleFilter = computeAppSearchResults(baseSearchInput);
-        const withRoleFilter = computeAppSearchResults({ ...baseSearchInput, helpRoleFilter: 'coach' });
+        const allResults = computeAppSearchResults({ ...baseSearchInput, helpRoleFilter: 'all' });
+        const coachResults = computeAppSearchResults({ ...baseSearchInput, helpRoleFilter: 'coach' });
         const nonHelpByKind = (results) => ({
             action: results.flat.filter((item) => item.kind === 'action'),
             team: results.flat.filter((item) => item.kind === 'team'),
@@ -264,13 +275,17 @@ describe('React app search service', () => {
         });
 
         expect(helpMocks.searchHelpKnowledge).toHaveBeenLastCalledWith({
-            query: 'team',
-            roles: ['coach'],
+            query: 'guide',
+            roles: ['parent'],
+            roleFilter: 'coach',
             limit: 5
         });
-        expect(nonHelpByKind(withRoleFilter)).toEqual(nonHelpByKind(withoutRoleFilter));
-        expect(withRoleFilter.teams).toEqual(withoutRoleFilter.teams);
-        expect(withRoleFilter.players).toEqual(withoutRoleFilter.players);
+        expect(allResults.help.map((item) => item.title)).toEqual(['Parent guide', 'Coach guide']);
+        expect(coachResults.help.map((item) => item.title)).toEqual(['Coach guide']);
+        expect(nonHelpByKind(coachResults)).toEqual(nonHelpByKind(allResults));
+        expect(coachResults.teams.map((item) => item.title)).toEqual(['Guide Bears']);
+        expect(coachResults.players.map((item) => item.title)).toEqual(['Guide Runner']);
+
     });
 
     it('loads public/current-site teams and merges private teams from app access', async () => {

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -288,6 +288,42 @@ describe('React app search service', () => {
 
     });
 
+    it('maps platform admin help searches to admin help docs', () => {
+        const adminDoc = {
+            id: 'admin-guide',
+            title: 'Admin guide',
+            file: 'help-admin.html',
+            url: 'https://allplays.ai/help-admin.html',
+            roles: ['admin'],
+            summary: 'Help for admins.',
+            snippet: 'Help for admins.',
+            score: 10
+        };
+        helpMocks.searchHelpKnowledge.mockImplementation(({ roleFilter }) => (
+            roleFilter === 'admin' ? [adminDoc] : []
+        ));
+
+        const results = computeAppSearchResults({
+            queryText: 'guide',
+            auth: {
+                ...auth,
+                user: { ...auth.user, roles: ['platformAdmin'] },
+                isPlatformAdmin: true
+            },
+            teams: [],
+            players: [],
+            helpRoleFilter: 'platformAdmin'
+        });
+
+        expect(helpMocks.searchHelpKnowledge).toHaveBeenCalledWith({
+            query: 'guide',
+            roles: ['admin'],
+            roleFilter: 'admin',
+            limit: 5
+        });
+        expect(results.help.map((item) => item.title)).toEqual(['Admin guide']);
+    });
+
     it('loads public/current-site teams and merges private teams from app access', async () => {
         dbMocks.getTeams.mockResolvedValue([
             { id: 'team-public', name: 'Public Bears', sport: 'Soccer', isPublic: true },


### PR DESCRIPTION
Closes #1584

## Summary
- Added an optional `helpRoleFilter` parameter to `computeAppSearchResults` without changing existing caller behavior.
- Passed the filter through help result generation and into help knowledge search only.
- Added role-filtered help search behavior so `all` remains unfiltered while specific roles only return matching help docs.

## Validation
- `npx vitest run tests/unit/app-search-service.test.js tests/unit/app-help-knowledge-service.test.js --reporter=verbose`
- `npm run app:build`

Skipped local iOS build on Linux. No native Android files changed.