### PR TITLE
Add search help filter regression coverage

### DIFF
--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -13,7 +13,7 @@ import {
   limit
 } from '../../../../js/firebase.js';
 import { loadParentHome } from './homeService';
-import { searchHelpKnowledge } from './helpKnowledgeService';
+import { getSearchHelpRoles as getHelpKnowledgeRoles, searchHelpKnowledge } from './helpKnowledgeService';
 import type { AuthState, AuthUser, UserRole } from './types';
 
 const teamsCacheTtlMs = 10 * 60 * 1000;
@@ -203,7 +203,8 @@ export function computeAppSearchResults({
   queryText,
   auth,
   teams,
-  players
+  players,
+  helpRoleFilter
 }: {
   queryText: string;
   auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatformAdmin'> & Partial<Pick<AuthState, 'roles' | 'isParent' | 'isCoach'>>;
@@ -222,7 +223,7 @@ export function computeAppSearchResults({
   const matchedTeams = tokens.length === 0
     ? teamItems.slice(0, 20)
     : rankSearchItems(teamItems, tokens).slice(0, 20);
-  const matchedHelp = buildAppSearchHelpResults(queryText, auth);
+  const matchedHelp = buildAppSearchHelpResults(queryText, auth, helpRoleFilter);
   const matchedPlayers = players.slice(0, 20);
 
   return {
@@ -358,14 +359,15 @@ export async function searchAppPlayers(queryText: string, teamsById: Map<string,
 
 function buildAppSearchHelpResults(
   queryText: string,
-  auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatformAdmin'> & Partial<Pick<AuthState, 'roles' | 'isParent' | 'isCoach'>>
+  auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatformAdmin'> & Partial<Pick<AuthState, 'roles' | 'isParent' | 'isCoach'>>,
+  helpRoleFilter?: unknown
 ): AppSearchHelp[] {
   const normalized = normalizeSearchQuery(queryText);
   if (normalized.length < 2) return [];
 
   return searchHelpKnowledge({
     query: queryText,
-    roles: getSearchHelpRoles(auth),
+    roles: getSearchHelpQueryRoles(auth, helpRoleFilter),
     limit: 5
   }).map((result) => ({
     id: `help:${result.id}`,
@@ -379,7 +381,15 @@ function buildAppSearchHelpResults(
   }));
 }
 
-function getSearchHelpRoles(auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatformAdmin'> & Partial<Pick<AuthState, 'roles' | 'isParent' | 'isCoach'>>): UserRole[] {
+function getSearchHelpQueryRoles(
+  auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatformAdmin'> & Partial<Pick<AuthState, 'roles' | 'isParent' | 'isCoach'>>,
+  helpRoleFilter?: unknown
+): string[] {
+  if (helpRoleFilter !== undefined) return getHelpKnowledgeRoles(helpRoleFilter);
+  return getSearchHelpAuthRoles(auth);
+}
+
+function getSearchHelpAuthRoles(auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatformAdmin'> & Partial<Pick<AuthState, 'roles' | 'isParent' | 'isCoach'>>): UserRole[] {
   const roles = new Set<UserRole>();
   (auth.roles || auth.user?.roles || []).forEach((role) => roles.add(role));
   if (auth.isAdmin || auth.user?.isAdmin) roles.add('admin');

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -209,6 +209,7 @@ export function computeAppSearchResults({
   auth: Pick<AuthState, 'user' | 'isAdmin' | 'isPlatformAdmin'> & Partial<Pick<AuthState, 'roles' | 'isParent' | 'isCoach'>>;
   teams: AppSearchTeam[];
   players: AppSearchPlayer[];
+  helpRoleFilter?: unknown;
 }) {
   const tokens = splitSearchTokens(queryText);
   const actions = buildAppSearchActions(auth);

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -22,6 +22,7 @@ const firebaseMocks = vi.hoisted(() => ({
 }));
 
 const helpMocks = vi.hoisted(() => ({
+    getSearchHelpRoles: vi.fn((role) => role && role !== 'all' ? [role] : ['admin', 'coach', 'member', 'parent']),
     searchHelpKnowledge: vi.fn()
 }));
 
@@ -262,6 +263,11 @@ describe('React app search service', () => {
             social: results.flat.filter((item) => item.kind === 'social')
         });
 
+        expect(helpMocks.searchHelpKnowledge).toHaveBeenLastCalledWith({
+            query: 'team',
+            roles: ['coach'],
+            limit: 5
+        });
         expect(nonHelpByKind(withRoleFilter)).toEqual(nonHelpByKind(withoutRoleFilter));
         expect(withRoleFilter.teams).toEqual(withoutRoleFilter.teams);
         expect(withRoleFilter.players).toEqual(withoutRoleFilter.players);

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -224,6 +224,49 @@ describe('React app search service', () => {
         expect(results.flat.map((item) => item.kind)).toEqual(['team', 'help', 'player']);
     });
 
+    it('does not let a help role filter change non-help search result categories', () => {
+        helpMocks.searchHelpKnowledge.mockReturnValue([{
+            id: 'team-help',
+            title: 'Team help',
+            file: 'help-coaches.html',
+            url: 'https://allplays.ai/help-coaches.html',
+            roles: ['coach'],
+            summary: 'Coach team help.',
+            snippet: 'Coach team help.',
+            score: 10
+        }]);
+        const baseSearchInput = {
+            queryText: 'team',
+            auth,
+            teams: [
+                { id: 'team-1', name: 'Team Alpha', sport: 'Basketball', zip: '66210', isPublic: true },
+                { id: 'team-2', name: 'Team Beta', sport: 'Soccer', zip: '64114', isPublic: true }
+            ],
+            players: [{
+                id: 'player:team-1:player-1',
+                kind: 'player',
+                title: 'Team Player',
+                subtitle: 'Team Alpha',
+                route: '/players/team-1/player-1',
+                teamId: 'team-1',
+                playerId: 'player-1'
+            }]
+        };
+
+        const withoutRoleFilter = computeAppSearchResults(baseSearchInput);
+        const withRoleFilter = computeAppSearchResults({ ...baseSearchInput, helpRoleFilter: 'coach' });
+        const nonHelpByKind = (results) => ({
+            action: results.flat.filter((item) => item.kind === 'action'),
+            team: results.flat.filter((item) => item.kind === 'team'),
+            player: results.flat.filter((item) => item.kind === 'player'),
+            social: results.flat.filter((item) => item.kind === 'social')
+        });
+
+        expect(nonHelpByKind(withRoleFilter)).toEqual(nonHelpByKind(withoutRoleFilter));
+        expect(withRoleFilter.teams).toEqual(withoutRoleFilter.teams);
+        expect(withRoleFilter.players).toEqual(withoutRoleFilter.players);
+    });
+
     it('loads public/current-site teams and merges private teams from app access', async () => {
         dbMocks.getTeams.mockResolvedValue([
             { id: 'team-public', name: 'Public Bears', sport: 'Soccer', isPublic: true },


### PR DESCRIPTION
Closes #1585

## Summary
- Added focused regression coverage proving non-help app search categories are unchanged when a help role filter is provided.
- Covered action, team, player, and social result categories while keeping the test scoped to search service behavior.
- Typed the search result input to allow a help role filter without affecting non-help result computation.

## Validation
- `npx vitest run tests/unit/app-search-service.test.js --reporter=verbose`
- `npm test`
- `npm run app:build`