### PR TITLE
Add Team Media item move action

### DIFF
--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -19,7 +19,8 @@ import {
   uploadTeamMediaFile,
   uploadTeamMediaPhoto,
   deleteTeamMediaItem,
-  updateTeamMediaItem
+  updateTeamMediaItem,
+  moveTeamMediaItems
 } from '../../../../js/db.js';
 import { addPendingFamilyMember, readFamilyMembers } from '../../../../js/family-plan.js';
 import { db, doc, collection, getDoc, serverTimestamp, runTransaction } from '../../../../js/firebase.js';
@@ -221,6 +222,11 @@ export async function updateTeamMediaItemForApp(teamId: string, itemId: string, 
   if (!teamId || !itemId) throw new Error('Missing team or media item ID.');
   if (!cleanTitle) throw new Error('Media item title cannot be empty.');
   return updateTeamMediaItem(teamId, itemId, { title: cleanTitle });
+}
+
+export async function moveTeamMediaItemForApp(teamId: string, itemId: string, targetFolderId: string) {
+  if (!teamId || !itemId || !targetFolderId) throw new Error('Missing team, media item, or destination album ID.');
+  return moveTeamMediaItems(teamId, [itemId], targetFolderId);
 }
 
 export function getLegacyUrl(path: string, params: Record<string, string> = {}, hashParams: Record<string, string> = {}) {

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -28,6 +28,7 @@ import {
   uploadParentTeamMediaPhoto,
   deleteTeamMediaItemForApp,
   updateTeamMediaItemForApp,
+  moveTeamMediaItemForApp,
   type TeamMediaFolder,
   type TeamMediaItem,
   type TeamMediaModel
@@ -50,6 +51,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const [creatingAlbum, setCreatingAlbum] = useState(false);
   const [deletingItemId, setDeletingItemId] = useState('');
   const [renamingItemId, setRenamingItemId] = useState('');
+  const [movingItemId, setMovingItemId] = useState('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
 
@@ -120,6 +122,29 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
       setError(deleteError?.message || 'Unable to delete media item.');
     } finally {
       setDeletingItemId('');
+    }
+  };
+
+  const handleMoveItem = async (item: TeamMediaItem, targetFolderId: string) => {
+    if (!teamId || !item?.id) return;
+    if (!targetFolderId || targetFolderId === activeFolder?.id) {
+      setError('Choose a different album to move this item.');
+      setMessage('');
+      return;
+    }
+
+    setMovingItemId(item.id);
+    setError('');
+    setMessage('');
+    try {
+      await moveTeamMediaItemForApp(teamId, item.id, targetFolderId);
+      await refresh({ showLoading: false, preferredFolderId: targetFolderId });
+      const destinationName = model?.folders.find((folder) => folder.id === targetFolderId)?.name || 'the selected album';
+      setMessage(`Media item moved to ${destinationName}.`);
+    } catch (moveError: any) {
+      setError(moveError?.message || 'Unable to move media item.');
+    } finally {
+      setMovingItemId('');
     }
   };
 
@@ -395,7 +420,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
         </div>
         <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {filteredItems.length ? filteredItems.map((item) => (
-            <TeamMediaItemCard key={item.id} item={item} onStatus={(tone, msg) => tone === 'error' ? setError(msg) : setMessage(msg)} canManage={model.canManage} currentUserId={auth.user?.uid || ''} deleting={deletingItemId === item.id} renaming={renamingItemId === item.id} onRenameItem={handleRenameItem} onDeleteItem={handleDeleteItem} />
+            <TeamMediaItemCard key={item.id} item={item} onStatus={(tone, msg) => tone === 'error' ? setError(msg) : setMessage(msg)} canManage={model.canManage} currentUserId={auth.user?.uid || ''} folders={model.folders} currentFolderId={activeFolder?.id || ''} deleting={deletingItemId === item.id} renaming={renamingItemId === item.id} moving={movingItemId === item.id} onRenameItem={handleRenameItem} onDeleteItem={handleDeleteItem} onMoveItem={handleMoveItem} />
           )) : (
             <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">No {emptyStateLabel} in this album.</div>
           )}
@@ -459,25 +484,37 @@ function TeamMediaItemCard({
   onStatus,
   canManage,
   currentUserId,
+  folders,
+  currentFolderId,
   deleting,
   renaming,
+  moving,
   onRenameItem,
-  onDeleteItem
+  onDeleteItem,
+  onMoveItem
 }: {
   item: TeamMediaItem;
   onStatus: (tone: 'error' | 'success', message: string) => void;
   canManage: boolean;
   currentUserId: string;
+  folders: TeamMediaFolder[];
+  currentFolderId: string;
   deleting: boolean;
   renaming: boolean;
+  moving: boolean;
   onRenameItem: (item: TeamMediaItem, title: string) => Promise<void>;
   onDeleteItem: (item: TeamMediaItem) => void;
+  onMoveItem: (item: TeamMediaItem, targetFolderId: string) => Promise<void>;
 }) {
   const Icon = getItemIcon(item);
   const isPhoto = item.type === 'photo';
   const title = item.title || 'Team media';
   const [isRenaming, setIsRenaming] = useState(false);
   const [draftTitle, setDraftTitle] = useState(title);
+  const [moveFolderId, setMoveFolderId] = useState('');
+  const alternateFolders = folders.filter((folder) => folder.id && folder.id !== currentFolderId);
+  const canMove = canManage && alternateFolders.length > 0;
+  const selectedMoveFolderId = moveFolderId && moveFolderId !== currentFolderId ? moveFolderId : '';
   const canRename = canManage || item.uploadedBy === currentUserId;
   const canDelete = canManage || (['photo', 'file'].includes(String(item.type || '').toLowerCase()) && item.uploadedBy === currentUserId);
 
@@ -494,6 +531,12 @@ function TeamMediaItemCard({
     }
     await onRenameItem(item, cleanTitle);
     setIsRenaming(false);
+  };
+
+  const moveItem = async () => {
+    if (!selectedMoveFolderId || moving) return;
+    await onMoveItem(item, selectedMoveFolderId);
+    setMoveFolderId('');
   };
 
   const copyLink = async () => {
@@ -585,6 +628,28 @@ function TeamMediaItemCard({
               <Edit3 className="h-3.5 w-3.5" aria-hidden="true" />
               Rename
             </button>
+          )}
+          {canMove && (
+            <div className="flex w-full flex-wrap items-center gap-2 rounded-xl border border-gray-100 bg-gray-50 p-2">
+              <label className="sr-only" htmlFor={`move-media-${item.id}`}>Move media item to album</label>
+              <select
+                id={`move-media-${item.id}`}
+                className="auth-input min-h-8 flex-1 py-1 text-xs"
+                value={selectedMoveFolderId}
+                onChange={(event) => setMoveFolderId(event.target.value)}
+                disabled={moving}
+                aria-label={`Move ${title} to album`}
+              >
+                <option value="">Move to album...</option>
+                {alternateFolders.map((folder) => (
+                  <option key={folder.id} value={folder.id}>{folder.name || 'Album'}</option>
+                ))}
+              </select>
+              <button type="button" className="primary-button !h-8 !min-h-8 !px-2 !text-xs" onClick={moveItem} disabled={moving || !selectedMoveFolderId} aria-label={`Move ${title}`}>
+                {moving ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" /> : null}
+                {moving ? 'Moving' : 'Move'}
+              </button>
+            </div>
           )}
           {canDelete && (
             <button type="button" className="ghost-button !h-8 !min-h-8 !px-2 !text-xs text-rose-700 hover:bg-rose-50 disabled:opacity-60" onClick={() => onDeleteItem(item)} disabled={deleting} aria-label={`Delete ${title}`}>

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -251,6 +251,9 @@ async function mockParentToolsModules(page) {
                 export async function updateTeamMediaItemForApp() {
                     return undefined;
                 }
+                export async function moveTeamMediaItemForApp() {
+                    return undefined;
+                }
             `
         });
     });

--- a/tests/unit/app-parent-tools-household-service.test.js
+++ b/tests/unit/app-parent-tools-household-service.test.js
@@ -5,6 +5,10 @@ const familyPlanMocks = vi.hoisted(() => ({
     readFamilyMembers: vi.fn()
 }));
 
+const dbMocks = vi.hoisted(() => ({
+    moveTeamMediaItems: vi.fn()
+}));
+
 vi.mock('../../js/family-plan.js', () => familyPlanMocks);
 vi.mock('../../js/db.js', () => ({
     createFamilyShareToken: vi.fn(),
@@ -24,7 +28,10 @@ vi.mock('../../js/db.js', () => ({
     revokeFamilyShareToken: vi.fn(),
     updateFamilyShareTokenCalendars: vi.fn(),
     uploadTeamMediaFile: vi.fn(),
-    uploadTeamMediaPhoto: vi.fn()
+    uploadTeamMediaPhoto: vi.fn(),
+    deleteTeamMediaItem: vi.fn(),
+    updateTeamMediaItem: vi.fn(),
+    moveTeamMediaItems: dbMocks.moveTeamMediaItems
 }));
 vi.mock('../../js/firebase.js', () => ({
     db: {},
@@ -68,7 +75,8 @@ vi.mock('../../apps/app/src/lib/scheduleService.ts', () => ({ loadParentSchedule
 
 import {
     createParentHouseholdMemberInvite,
-    loadParentHouseholdInviteModel
+    loadParentHouseholdInviteModel,
+    moveTeamMediaItemForApp
 } from '../../apps/app/src/lib/parentToolsService.ts';
 
 const user = {
@@ -80,6 +88,7 @@ beforeEach(() => {
     vi.clearAllMocks();
     familyPlanMocks.readFamilyMembers.mockResolvedValue([]);
     familyPlanMocks.addPendingFamilyMember.mockResolvedValue({ code: 'HOME1234', inviteUrl: 'accept-invite.html?code=HOME1234' });
+    dbMocks.moveTeamMediaItems.mockResolvedValue(undefined);
 });
 
 describe('Parent Tools household invite service', () => {
@@ -122,5 +131,21 @@ describe('Parent Tools household invite service', () => {
             playerNumber: '9'
         }), { existingMembers: [{ id: 'member-1', email: 'old@example.com', status: 'pending' }] });
         expect(result).toEqual({ code: 'HOME1234', inviteUrl: 'https://allplays.ai/accept-invite.html?code=HOME1234' });
+    });
+});
+
+
+describe('React app team media move service', () => {
+    it('moves one media item through the legacy move helper', async () => {
+        await moveTeamMediaItemForApp('team-1', 'item-1', 'folder-2');
+
+        expect(dbMocks.moveTeamMediaItems).toHaveBeenCalledWith('team-1', ['item-1'], 'folder-2');
+    });
+
+    it('rejects missing move identifiers before calling the legacy helper', async () => {
+        await expect(moveTeamMediaItemForApp('', 'item-1', 'folder-2')).rejects.toThrow('Missing team, media item, or destination album ID.');
+        await expect(moveTeamMediaItemForApp('team-1', '', 'folder-2')).rejects.toThrow('Missing team, media item, or destination album ID.');
+        await expect(moveTeamMediaItemForApp('team-1', 'item-1', '')).rejects.toThrow('Missing team, media item, or destination album ID.');
+        expect(dbMocks.moveTeamMediaItems).not.toHaveBeenCalled();
     });
 });

--- a/tests/unit/app-team-media.test.jsx
+++ b/tests/unit/app-team-media.test.jsx
@@ -12,6 +12,7 @@ const parentToolsServiceMocks = vi.hoisted(() => ({
   uploadParentTeamMediaPhoto: vi.fn(),
   deleteTeamMediaItemForApp: vi.fn(),
   updateTeamMediaItemForApp: vi.fn(),
+  moveTeamMediaItemForApp: vi.fn(),
 }));
 
 const publicActionsMocks = vi.hoisted(() => ({
@@ -96,9 +97,18 @@ function inputValue(input, value) {
   });
 }
 
+function selectValue(select, value) {
+  act(() => {
+    const setter = Object.getOwnPropertyDescriptor(window.HTMLSelectElement.prototype, 'value').set;
+    setter.call(select, value);
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   parentToolsServiceMocks.updateTeamMediaItemForApp.mockResolvedValue(undefined);
+  parentToolsServiceMocks.moveTeamMediaItemForApp.mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -143,6 +153,87 @@ describe('React app TeamMedia rename flow', () => {
     expect(parentToolsServiceMocks.updateTeamMediaItemForApp).not.toHaveBeenCalled();
     expect(container.textContent).toContain('Tipoff');
     expect(container.textContent).toContain('Media item title cannot be empty.');
+
+    await act(async () => root.unmount());
+  });
+});
+
+
+describe('React app TeamMedia move flow', () => {
+  const twoAlbumModel = () => mediaModel({
+    canManage: true,
+    canContribute: true,
+    folders: [
+      {
+        id: 'folder-1',
+        name: 'Album A',
+        visibility: 'team',
+        itemCount: 1,
+        items: [{ id: 'owned-photo', title: 'Tipoff', type: 'photo', url: 'https://example.test/tipoff.jpg', uploadedBy: 'user-1' }],
+      },
+      {
+        id: 'folder-2',
+        name: 'Album B',
+        visibility: 'team',
+        itemCount: 0,
+        items: [],
+      },
+    ],
+  });
+
+  it('shows Move only to managers when another album exists', async () => {
+    const { container, root } = await renderTeamMedia(twoAlbumModel());
+
+    expect(container.querySelector('[aria-label="Move Tipoff to album"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Move Tipoff"]')).not.toBeNull();
+
+    await act(async () => root.unmount());
+
+    const nonManager = twoAlbumModel();
+    nonManager.canManage = false;
+    const rendered = await renderTeamMedia(nonManager);
+    expect(rendered.container.querySelector('[aria-label="Move Tipoff to album"]')).toBeNull();
+
+    await act(async () => rendered.root.unmount());
+  });
+
+  it('does not show Move when there is no alternate album', async () => {
+    const model = twoAlbumModel();
+    model.folders = model.folders.slice(0, 1);
+    const { container, root } = await renderTeamMedia(model);
+
+    expect(container.querySelector('[aria-label="Move Tipoff to album"]')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('disables submit until a different album is selected and refreshes to the destination after move', async () => {
+    const initialModel = twoAlbumModel();
+    const movedModel = twoAlbumModel();
+    movedModel.folders = [
+      { ...initialModel.folders[0], itemCount: 0, items: [] },
+      { ...initialModel.folders[1], itemCount: 1, items: initialModel.folders[0].items },
+    ];
+    parentToolsServiceMocks.loadTeamMediaForApp
+      .mockResolvedValueOnce(initialModel)
+      .mockResolvedValueOnce(movedModel);
+
+    const { container, root } = await renderTeamMedia(initialModel);
+
+    const moveButton = container.querySelector('[aria-label="Move Tipoff"]');
+    expect(moveButton.disabled).toBe(true);
+
+    selectValue(container.querySelector('[aria-label="Move Tipoff to album"]'), 'folder-2');
+    expect(moveButton.disabled).toBe(false);
+
+    await act(async () => {
+      moveButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(parentToolsServiceMocks.moveTeamMediaItemForApp).toHaveBeenCalledWith('team-1', 'owned-photo', 'folder-2');
+    expect(container.textContent).toContain('Media item moved to Album B.');
+    expect(container.textContent).toContain('Album B');
+    expect(container.textContent).toContain('Tipoff');
 
     await act(async () => root.unmount());
   });


### PR DESCRIPTION
Closes #1602

## Summary
- Added an app-facing `moveTeamMediaItemForApp` helper that delegates single-item moves to the existing legacy move semantics.
- Added a manager-only Move control on React Team Media cards when another album exists.
- Refreshes into the destination album after a successful move and shows confirmation feedback.

## Validation
- `npx vitest run tests/unit/app-team-media.test.jsx tests/unit/app-parent-tools-household-service.test.js --reporter=verbose`
- `npm run app:build`
- `npm test`

## Notes
- No native iOS or Android code changed. iOS build skipped on Linux; native wrapper validation should run in CI/macOS if required.