### PR TITLE
Add app scorekeeper helper grants

### DIFF
--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -99,6 +99,7 @@ export type TeamStaffPermissionsSummary = {
     grants: string[];
     emptyText: string;
   }>;
+  scorekeepingMode: string;
   scorekeeperGrantTargets: TeamScorekeeperGrantTarget[];
   hasAnyStaff: boolean;
 };
@@ -493,6 +494,7 @@ export function buildTeamDetailModel({
   const staffPermissions = canManageTeam
     ? {
       ...buildTeamStaffPermissionsViewModel({ ...team, id: teamId }, pendingAdminInvites),
+      scorekeepingMode: cleanString(team?.teamPermissions?.scorekeeping?.mode),
       scorekeeperGrantTargets: buildScorekeeperGrantTargets(team, players)
     }
     : null;

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -8,8 +8,10 @@ import {
   getPlayerTrackingStatuses,
   getPublicTrackingItems,
   getTeam,
+  grantScorekeeperAccess,
   inviteAdmin,
-  addTeamAdminEmail
+  addTeamAdminEmail,
+  revokeScorekeeperAccess
 } from '../../../../js/db.js';
 import { sendInviteEmail } from '../../../../js/auth.js';
 import { inviteExistingTeamAdmin } from '../../../../js/edit-team-admin-invites.js';
@@ -32,6 +34,14 @@ export type TeamDetailPlayer = {
   photoUrl: string | null;
   position: string;
   isLinked: boolean;
+};
+
+export type TeamScorekeeperGrantTarget = {
+  userId: string;
+  name: string;
+  email: string;
+  playerNames: string[];
+  isGranted: boolean;
 };
 
 export type TeamDetailEvent = {
@@ -89,6 +99,7 @@ export type TeamStaffPermissionsSummary = {
     grants: string[];
     emptyText: string;
   }>;
+  scorekeeperGrantTargets: TeamScorekeeperGrantTarget[];
   hasAnyStaff: boolean;
 };
 
@@ -364,6 +375,22 @@ export async function inviteTeamAdminForApp(teamId: string, email: string): Prom
   };
 }
 
+export async function grantScorekeeperAccessForApp(teamId: string, memberUserId: string) {
+  const normalizedTeamId = cleanString(teamId);
+  const normalizedUserId = cleanString(memberUserId);
+  if (!normalizedTeamId) throw new Error('Team ID is required.');
+  if (!normalizedUserId) throw new Error('Team member user ID is required.');
+  await grantScorekeeperAccess(normalizedTeamId, normalizedUserId);
+}
+
+export async function revokeScorekeeperAccessForApp(teamId: string, memberUserId: string) {
+  const normalizedTeamId = cleanString(teamId);
+  const normalizedUserId = cleanString(memberUserId);
+  if (!normalizedTeamId) throw new Error('Team ID is required.');
+  if (!normalizedUserId) throw new Error('Team member user ID is required.');
+  await revokeScorekeeperAccess(normalizedTeamId, normalizedUserId);
+}
+
 export function buildAdminAcceptInviteUrl(code: string, baseUrl = getPublicBaseUrl()) {
   const inviteCode = cleanString(code);
   if (!inviteCode) return null;
@@ -464,7 +491,10 @@ export function buildTeamDetailModel({
   const trackingSummaries = buildTrackingSummaries(normalizedPlayers, linkedPlayerIds, trackingItems, trackingStatuses);
   const canManageTeam = hasFullTeamAccess(user, team);
   const staffPermissions = canManageTeam
-    ? buildTeamStaffPermissionsViewModel({ ...team, id: teamId }, pendingAdminInvites)
+    ? {
+      ...buildTeamStaffPermissionsViewModel({ ...team, id: teamId }, pendingAdminInvites),
+      scorekeeperGrantTargets: buildScorekeeperGrantTargets(team, players)
+    }
     : null;
 
   return {
@@ -524,6 +554,65 @@ function normalizePlayers(players: any[], linkedPlayerIds: string[]): TeamDetail
     }))
     .filter((player) => player.id)
     .sort((a, b) => sortByNumberThenName(a, b));
+}
+
+function buildScorekeeperGrantTargets(team: Record<string, any>, players: any[]): TeamScorekeeperGrantTarget[] {
+  const selectedScorekeeperIds = getSelectedPermissionIds(team, 'scorekeeping');
+  const targetsByUserId = new Map<string, Omit<TeamScorekeeperGrantTarget, 'isGranted'>>();
+
+  const addTarget = (userId: any, player: any, source: Record<string, any> = {}) => {
+    const normalizedUserId = cleanString(userId);
+    if (!normalizedUserId) return;
+    const playerName = cleanString(player?.name || player?.playerName);
+    const sourceName = cleanString(source.name || source.displayName || source.fullName || source.email);
+    const sourceEmail = cleanString(source.email).toLowerCase();
+    const existing = targetsByUserId.get(normalizedUserId) || {
+      userId: normalizedUserId,
+      name: sourceName || playerName || 'Team member',
+      email: sourceEmail,
+      playerNames: []
+    };
+    if (playerName && !existing.playerNames.includes(playerName)) existing.playerNames.push(playerName);
+    if (sourceName && (!existing.name || existing.name === playerName || existing.name === 'Team member')) existing.name = sourceName;
+    if (!existing.email && sourceEmail) existing.email = sourceEmail;
+    targetsByUserId.set(normalizedUserId, existing);
+  };
+
+  (Array.isArray(players) ? players : [])
+    .filter((player) => player?.active !== false)
+    .forEach((player) => {
+      getPlayerLinkedUserIds(player).forEach((userId) => addTarget(userId, player));
+      (Array.isArray(player?.parents) ? player.parents : []).forEach((parent: any) => {
+        addTarget(parent?.userId || parent?.uid || parent?.authUid || parent?.accountUserId || parent?.memberUserId, player, parent);
+      });
+    });
+
+  return Array.from(targetsByUserId.values())
+    .map((target) => ({ ...target, isGranted: selectedScorekeeperIds.has(target.userId) }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function getPlayerLinkedUserIds(player: any) {
+  const ids = new Set<string>();
+  [player?.userId, player?.authUid, player?.accountUserId, player?.memberUserId]
+    .map(cleanString)
+    .filter(Boolean)
+    .forEach((id) => ids.add(id));
+  (Array.isArray(player?.parents) ? player.parents : []).forEach((parent: any) => {
+    [parent?.userId, parent?.uid, parent?.authUid, parent?.accountUserId, parent?.memberUserId]
+      .map(cleanString)
+      .filter(Boolean)
+      .forEach((id) => ids.add(id));
+  });
+  return Array.from(ids);
+}
+
+function getSelectedPermissionIds(team: Record<string, any>, kind: string) {
+  const permission = team?.teamPermissions?.[kind] || {};
+  if (permission.mode !== 'selected') return new Set<string>();
+  return new Set((Array.isArray(permission.memberIds) ? permission.memberIds : [])
+    .map(cleanString)
+    .filter(Boolean));
 }
 
 function normalizeEvents(games: any[]) {

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -495,6 +495,7 @@ function StaffPermissionsCard({ model, onInviteSuccess }: { model: TeamDetailMod
     ...summary.pendingInvites.map((inviteEmail) => `${inviteEmail} · Pending admin invite`)
   ];
   const scorekeeperGrantTargets = summary.scorekeeperGrantTargets || [];
+  const isAllConfirmedScorekeeping = summary.scorekeepingMode === 'all_confirmed';
   const existingEmails = getStaffPermissionEmails(summary);
 
   async function submitInvite(event: FormEvent<HTMLFormElement>) {
@@ -608,7 +609,12 @@ function StaffPermissionsCard({ model, onInviteSuccess }: { model: TeamDetailMod
         ) : null}
       </form>
 
-      {scorekeeperGrantTargets.length ? (
+      {isAllConfirmedScorekeeping ? (
+        <div className="mt-4 rounded-xl border border-primary-100 bg-white p-3">
+          <div className="text-[11px] font-black uppercase tracking-[0.04em] text-primary-700">Scorekeeper helper access</div>
+          <p className="mt-2 text-xs font-semibold leading-5 text-gray-600">All confirmed team members can score games, so individual scorekeeper grants are disabled to preserve that team-wide access.</p>
+        </div>
+      ) : scorekeeperGrantTargets.length ? (
         <div className="mt-4 rounded-xl border border-primary-100 bg-white p-3">
           <div className="text-[11px] font-black uppercase tracking-[0.04em] text-primary-700">Scorekeeper helper access</div>
           <p className="mt-2 text-xs font-semibold leading-5 text-gray-600">Grant an existing linked team member scorekeeping duty without making them a full admin or giving roster, schedule, settings, or broader team access.</p>

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -26,7 +26,7 @@ import { copyPublicText, openPublicUrl } from '../lib/publicActions';
 import { getEventDetailPath } from '../lib/homeLogic';
 import { loadStaffRsvpReminderPreview, sendStaffRsvpReminder, type StaffRsvpReminderSendResult } from '../lib/scheduleService';
 import type { ParentScheduleEvent, StaffRsvpReminderPreview } from '../lib/scheduleLogic';
-import { inviteTeamAdminForApp, loadParentTeamDetail, type InviteTeamAdminForAppResult, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer } from '../lib/teamDetailService';
+import { grantScorekeeperAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp, type InviteTeamAdminForAppResult, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer } from '../lib/teamDetailService';
 import type { AuthState } from '../lib/types';
 
 type TeamTab = 'overview' | 'schedule' | 'roster' | 'insights' | 'more';
@@ -486,12 +486,15 @@ function StaffPermissionsCard({ model, onInviteSuccess }: { model: TeamDetailMod
   const [error, setError] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<InviteTeamAdminForAppResult | null>(null);
+  const [grantingUserId, setGrantingUserId] = useState<string | null>(null);
+  const [grantStatus, setGrantStatus] = useState<{ success: boolean; message: string } | null>(null);
   const [copyStatus, setCopyStatus] = useState<{ kind: 'code' | 'link'; success: boolean } | null>(null);
   if (!summary) return null;
   const staffItems = [
     ...summary.staff.map((member) => `${member.label} · ${member.role}`),
     ...summary.pendingInvites.map((inviteEmail) => `${inviteEmail} · Pending admin invite`)
   ];
+  const scorekeeperGrantTargets = summary.scorekeeperGrantTargets || [];
   const existingEmails = getStaffPermissionEmails(summary);
 
   async function submitInvite(event: FormEvent<HTMLFormElement>) {
@@ -530,6 +533,27 @@ function StaffPermissionsCard({ model, onInviteSuccess }: { model: TeamDetailMod
     if (!value) return;
     const copyResult = await copyPublicText(value);
     setCopyStatus({ kind, success: copyResult === 'copied' });
+  }
+
+  async function toggleScorekeeperGrant(memberUserId: string, isGranted: boolean) {
+    if (!memberUserId || grantingUserId) return;
+    setGrantingUserId(memberUserId);
+    setGrantStatus(null);
+    setResult(null);
+    setCopyStatus(null);
+    try {
+      if (isGranted) {
+        await revokeScorekeeperAccessForApp(model.team.id, memberUserId);
+      } else {
+        await grantScorekeeperAccessForApp(model.team.id, memberUserId);
+      }
+      setGrantStatus({ success: true, message: isGranted ? 'Scorekeeper access revoked.' : 'Scorekeeper access granted.' });
+      await onInviteSuccess();
+    } catch (grantError: any) {
+      setGrantStatus({ success: false, message: grantError?.message || 'Unable to update scorekeeper access.' });
+    } finally {
+      setGrantingUserId(null);
+    }
   }
 
   return (
@@ -583,6 +607,32 @@ function StaffPermissionsCard({ model, onInviteSuccess }: { model: TeamDetailMod
           </div>
         ) : null}
       </form>
+
+      {scorekeeperGrantTargets.length ? (
+        <div className="mt-4 rounded-xl border border-primary-100 bg-white p-3">
+          <div className="text-[11px] font-black uppercase tracking-[0.04em] text-primary-700">Scorekeeper helper access</div>
+          <p className="mt-2 text-xs font-semibold leading-5 text-gray-600">Grant an existing linked team member scorekeeping duty without making them a full admin or giving roster, schedule, settings, or broader team access.</p>
+          <div className="mt-3 divide-y divide-gray-100 overflow-hidden rounded-xl border border-gray-100">
+            {scorekeeperGrantTargets.map((target) => {
+              const busy = grantingUserId === target.userId;
+              const detail = target.playerNames.length ? `Linked to ${target.playerNames.join(', ')}.` : 'Linked team member account.';
+              return (
+                <div key={target.userId} className="flex flex-col gap-3 p-3 sm:flex-row sm:items-center sm:justify-between">
+                  <div className="min-w-0">
+                    <div className="truncate text-sm font-black text-gray-950">{target.name || target.email || 'Team member'}</div>
+                    <div className="text-xs font-semibold leading-5 text-gray-500">{target.isGranted ? `Can score games. ${detail}` : `No scorekeeper helper grant. ${detail}`}</div>
+                  </div>
+                  <button type="button" className={`secondary-button !min-h-9 flex-none text-xs ${target.isGranted ? '!border-rose-200 !bg-rose-50 !text-rose-700' : ''}`} disabled={Boolean(grantingUserId)} onClick={() => toggleScorekeeperGrant(target.userId, target.isGranted)}>
+                    {busy ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+                    {target.isGranted ? 'Revoke scorekeeper' : 'Grant scorekeeper'}
+                  </button>
+                </div>
+              );
+            })}
+          </div>
+          {grantStatus ? <div className={`mt-2 text-xs font-black ${grantStatus.success ? 'text-emerald-700' : 'text-rose-700'}`} role="status">{grantStatus.message}</div> : null}
+        </div>
+      ) : null}
 
       <div className="mt-4 grid gap-3 lg:grid-cols-2">
         <div className="rounded-xl border border-indigo-100 bg-indigo-50 p-3">

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -346,6 +346,14 @@ async function mockHomePlayerModules(page) {
                     return { status: 'sent', email: 'coach@example.com' };
                 }
 
+                export async function grantScorekeeperAccessForApp() {
+                    return { success: true };
+                }
+
+                export async function revokeScorekeeperAccessForApp() {
+                    return { success: true };
+                }
+
                 export async function loadParentTeamDetail() {
                     const nextDate = new Date('2100-06-01T18:00:00Z');
                     return {

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -193,6 +193,14 @@ async function mockTeamsModules(page) {
                     return { status: 'sent', email: 'coach@example.com' };
                 }
 
+                export async function grantScorekeeperAccessForApp() {
+                    return { success: true };
+                }
+
+                export async function revokeScorekeeperAccessForApp() {
+                    return { success: true };
+                }
+
                 export async function loadParentTeamDetail(teamId) {
                     if (teamId === 'team-empty') {
                         return {

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -237,6 +237,7 @@ describe('React app team detail model', () => {
             { label: 'coach@example.com', role: 'Admin' }
         ]);
         expect(adminModel.staffPermissions.pendingInvites).toEqual(['pending@example.com']);
+        expect(adminModel.staffPermissions.scorekeepingMode).toBe('selected');
         expect(adminModel.staffPermissions.helperPermissions).toEqual([
             expect.objectContaining({ key: 'scorekeeper', grants: ['scorekeeper-1'] }),
             expect.objectContaining({ key: 'stream-score', grants: ['scorekeeper-1'] }),

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -11,8 +11,10 @@ vi.mock('../../js/db.js', () => ({
     getPlayerTrackingStatuses: vi.fn(),
     getPublicTrackingItems: vi.fn(),
     getTeam: vi.fn(),
+    grantScorekeeperAccess: vi.fn(),
     inviteAdmin: vi.fn(),
-    addTeamAdminEmail: vi.fn()
+    addTeamAdminEmail: vi.fn(),
+    revokeScorekeeperAccess: vi.fn()
 }));
 
 vi.mock('../../js/firebase.js', () => ({
@@ -32,9 +34,9 @@ vi.mock('../../apps/app/src/lib/authService.ts', () => ({
     getNativeAuthIdToken: vi.fn()
 }));
 
-import { buildAdminAcceptInviteUrl, buildTeamDetailModel, inviteTeamAdminForApp, loadParentTeamDetail } from '../../apps/app/src/lib/teamDetailService.ts';
+import { buildAdminAcceptInviteUrl, buildTeamDetailModel, grantScorekeeperAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp } from '../../apps/app/src/lib/teamDetailService.ts';
 import { getDocs } from '../../js/firebase.js';
-import { getAggregatedStatsForGames, getAdSpaceSponsors, getConfigs, getGames, getLocalAttractionSponsors, getPlayers, getTeam, inviteAdmin, addTeamAdminEmail } from '../../js/db.js';
+import { getAggregatedStatsForGames, getAdSpaceSponsors, getConfigs, getGames, getLocalAttractionSponsors, getPlayers, getTeam, grantScorekeeperAccess, inviteAdmin, addTeamAdminEmail, revokeScorekeeperAccess } from '../../js/db.js';
 import { sendInviteEmail } from '../../js/auth.js';
 
 describe('React app team detail model', () => {
@@ -76,6 +78,22 @@ describe('React app team detail model', () => {
         await expect(inviteTeamAdminForApp('', 'coach@example.com')).rejects.toThrow('Team ID is required.');
         await expect(inviteTeamAdminForApp('team-1', '   ')).rejects.toThrow('Admin email is required.');
         expect(inviteAdmin).not.toHaveBeenCalled();
+    });
+
+    it('wraps scorekeeper grant mutations with app validation', async () => {
+        grantScorekeeperAccess.mockResolvedValue(undefined);
+        revokeScorekeeperAccess.mockResolvedValue(undefined);
+
+        await grantScorekeeperAccessForApp(' team-1 ', ' member-1 ');
+        await revokeScorekeeperAccessForApp('team-1', 'member-1');
+
+        expect(grantScorekeeperAccess).toHaveBeenCalledWith('team-1', 'member-1');
+        expect(revokeScorekeeperAccess).toHaveBeenCalledWith('team-1', 'member-1');
+
+        grantScorekeeperAccess.mockClear();
+        await expect(grantScorekeeperAccessForApp('', 'member-1')).rejects.toThrow('Team ID is required.');
+        await expect(grantScorekeeperAccessForApp('team-1', '')).rejects.toThrow('Team member user ID is required.');
+        expect(grantScorekeeperAccess).not.toHaveBeenCalled();
     });
 
     it('projects team.html parent features into the native team model', () => {
@@ -224,6 +242,21 @@ describe('React app team detail model', () => {
             expect.objectContaining({ key: 'stream-score', grants: ['scorekeeper-1'] }),
             expect.objectContaining({ key: 'videographer', grants: ['scorekeeper-1', 'video-1', 'video@example.com'] }),
             expect.objectContaining({ key: 'volunteer', grants: ['snacks-1'] })
+        ]);
+
+        const targetedModel = buildTeamDetailModel({
+            teamId: 'team-1',
+            team,
+            user: { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] },
+            players: [
+                { id: 'player-1', name: 'Pat Star', userId: 'scorekeeper-1' },
+                { id: 'player-2', name: 'Sam Wing', parents: [{ userId: 'parent-1', name: 'Parent One', email: 'parent@example.com' }] },
+                { id: 'inactive', name: 'Inactive', userId: 'inactive-1', active: false }
+            ]
+        });
+        expect(targetedModel.staffPermissions.scorekeeperGrantTargets).toEqual([
+            { userId: 'parent-1', name: 'Parent One', email: 'parent@example.com', playerNames: ['Sam Wing'], isGranted: false },
+            { userId: 'scorekeeper-1', name: 'Pat Star', email: '', playerNames: ['Pat Star'], isGranted: true }
         ]);
 
         const parentModel = buildTeamDetailModel({

--- a/tests/unit/app-team-detail-staff-permissions.test.jsx
+++ b/tests/unit/app-team-detail-staff-permissions.test.jsx
@@ -6,6 +6,8 @@ import { MemoryRouter, Route, Routes } from '../../apps/app/node_modules/react-r
 
 const teamDetailMocks = vi.hoisted(() => ({
     loadParentTeamDetail: vi.fn(),
+    grantScorekeeperAccessForApp: vi.fn(),
+    revokeScorekeeperAccessForApp: vi.fn(),
     inviteTeamAdminForApp: vi.fn()
 }));
 const publicActionMocks = vi.hoisted(() => ({
@@ -126,6 +128,8 @@ beforeEach(() => {
     };
     window.scrollTo = vi.fn();
     publicActionMocks.copyPublicText.mockResolvedValue('copied');
+    teamDetailMocks.grantScorekeeperAccessForApp.mockResolvedValue(undefined);
+    teamDetailMocks.revokeScorekeeperAccessForApp.mockResolvedValue(undefined);
     teamDetailMocks.inviteTeamAdminForApp.mockResolvedValue({
         email: 'newcoach@example.com',
         status: 'sent',
@@ -206,6 +210,49 @@ describe('React app TeamDetail staff permissions overview', () => {
         await clickButton(container, 'Copy link');
         expect(publicActionMocks.copyPublicText).toHaveBeenCalledWith('CODE123');
         expect(publicActionMocks.copyPublicText).toHaveBeenCalledWith('https://allplays.ai/accept-invite?code=CODE123&type=admin');
+    });
+
+    it('grants scorekeeper access to an existing linked team member and refreshes staff state', async () => {
+        const { container } = await renderTeamDetail({
+            staff: [{ label: 'owner@example.com', role: 'Owner' }],
+            pendingInvites: [],
+            helperPermissions: [],
+            scorekeeperGrantTargets: [
+                { userId: 'parent-1', name: 'Parent One', email: 'parent@example.com', playerNames: ['Sam Wing'], isGranted: false }
+            ],
+            hasAnyStaff: true
+        });
+
+        await clickButton(container, 'More');
+
+        expect(container.textContent).toContain('Scorekeeper helper access');
+        expect(container.textContent).toContain('No scorekeeper helper grant. Linked to Sam Wing.');
+        await clickButton(container, 'Grant scorekeeper');
+
+        expect(teamDetailMocks.grantScorekeeperAccessForApp).toHaveBeenCalledWith('team-1', 'parent-1');
+        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledTimes(2);
+        expect(container.textContent).toContain('Scorekeeper access granted.');
+    });
+
+    it('revokes scorekeeper access from an existing linked team member and refreshes staff state', async () => {
+        const { container } = await renderTeamDetail({
+            staff: [{ label: 'owner@example.com', role: 'Owner' }],
+            pendingInvites: [],
+            helperPermissions: [],
+            scorekeeperGrantTargets: [
+                { userId: 'scorekeeper-1', name: 'Score Keeper', email: '', playerNames: ['Pat Star'], isGranted: true }
+            ],
+            hasAnyStaff: true
+        });
+
+        await clickButton(container, 'More');
+
+        expect(container.textContent).toContain('Can score games. Linked to Pat Star.');
+        await clickButton(container, 'Revoke scorekeeper');
+
+        expect(teamDetailMocks.revokeScorekeeperAccessForApp).toHaveBeenCalledWith('team-1', 'scorekeeper-1');
+        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledTimes(2);
+        expect(container.textContent).toContain('Scorekeeper access revoked.');
     });
 
     it('hides staff permissions when the service omits the admin-only payload', async () => {

--- a/tests/unit/app-team-detail-staff-permissions.test.jsx
+++ b/tests/unit/app-team-detail-staff-permissions.test.jsx
@@ -255,6 +255,25 @@ describe('React app TeamDetail staff permissions overview', () => {
         expect(container.textContent).toContain('Scorekeeper access revoked.');
     });
 
+    it('disables individual scorekeeper grants when all confirmed members can score games', async () => {
+        const { container } = await renderTeamDetail({
+            staff: [{ label: 'owner@example.com', role: 'Owner' }],
+            pendingInvites: [],
+            helperPermissions: [],
+            scorekeepingMode: 'all_confirmed',
+            scorekeeperGrantTargets: [
+                { userId: 'parent-1', name: 'Parent One', email: 'parent@example.com', playerNames: ['Sam Wing'], isGranted: false }
+            ],
+            hasAnyStaff: true
+        });
+
+        await clickButton(container, 'More');
+
+        expect(container.textContent).toContain('All confirmed team members can score games');
+        expect(container.textContent).not.toContain('Grant scorekeeper');
+        expect(teamDetailMocks.grantScorekeeperAccessForApp).not.toHaveBeenCalled();
+    });
+
     it('hides staff permissions when the service omits the admin-only payload', async () => {
         const { container } = await renderTeamDetail(null);
 


### PR DESCRIPTION
Closes #1605

## Summary
- Added React app grant/revoke actions for scorekeeper helper access on Team Detail > More.
- Exposed eligible linked roster member targets and current grant state in the team detail model.
- Reused the legacy `grantScorekeeperAccess` and `revokeScorekeeperAccess` db helpers through app service wrappers.

## Validation
- `npx vitest run tests/unit/app-team-detail-service.test.js tests/unit/app-team-detail-staff-permissions.test.jsx --reporter=verbose`
- `npm run app:build`
- Android Gradle validation attempted with `cd android && ./gradlew test :app:assembleDebug`, but this host has no Android SDK configured: missing `ANDROID_HOME` or `android/local.properties`.
- iOS build skipped on Linux host.