### PR TITLE
Add standalone Profile push enable action

### DIFF
--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -311,6 +311,25 @@ export function Profile({ auth }: { auth: AuthState }) {
     }
   };
 
+  const enablePushOnDevice = async () => {
+    if (!user) {
+      setNotificationStatus({ message: 'Sign in before enabling push notifications.', tone: 'error' });
+      return;
+    }
+
+    setBusy('push-device');
+    setNotificationStatus(null);
+
+    try {
+      await enablePushNotificationsForUser(user.uid);
+      setNotificationStatus({ message: 'Push is enabled on this device.', tone: 'success' });
+    } catch (error: any) {
+      setNotificationStatus({ message: error?.message || 'Failed to enable push on this device.', tone: 'error' });
+    } finally {
+      setBusy('');
+    }
+  };
+
   const turnOnGameDayAlerts = async () => {
     if (!user || !selectedTeamId) {
       setNotificationStatus({ message: 'Select a team first.', tone: 'error' });
@@ -546,6 +565,14 @@ export function Profile({ auth }: { auth: AuthState }) {
               ))}
             </select>
           </label>
+          <div className="rounded-2xl border border-gray-200 bg-white p-3">
+            <div className="text-sm font-black text-gray-900">Device push</div>
+            <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">Register this device for push notifications without changing team alert preferences.</p>
+            <button type="button" className="secondary-button mt-3" onClick={enablePushOnDevice} disabled={busy === 'push-device' || !user}>
+              {busy === 'push-device' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Upload className="h-4 w-4" aria-hidden="true" />}
+              Enable push on this device
+            </button>
+          </div>
           <div className="rounded-2xl border border-primary-100 bg-primary-50 p-3">
             <div className="text-sm font-black text-primary-900">Game-day alerts</div>
             <p className="mt-1 text-sm font-semibold leading-6 text-primary-800">One tap enables push on this device and turns on schedule changes and live score updates for the selected team.</p>

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -208,6 +208,8 @@ describe('React app auth/profile capability parity', () => {
             'Choose photo',
             'Remove',
             'Notification preferences',
+            'Enable push on this device',
+            'Register this device for push notifications without changing team alert preferences.',
             'Turn on game-day alerts',
             'Customize alerts',
             'Live Chat',
@@ -231,6 +233,24 @@ describe('React app auth/profile capability parity', () => {
             'loadProfileAccessCodes',
             'nativeUploadProfilePhoto'
         ]);
+    });
+
+    it('registers push for the current Profile device without saving alert preferences', () => {
+        const profilePage = readProjectFile('apps/app/src/pages/Profile.tsx');
+        const handlerStart = profilePage.indexOf('const enablePushOnDevice = async () => {');
+        const handlerEnd = profilePage.indexOf('  const turnOnGameDayAlerts = async () => {');
+        const enablePushOnDevice = profilePage.slice(handlerStart, handlerEnd);
+
+        expect(handlerStart).toBeGreaterThanOrEqual(0);
+        expectContains(enablePushOnDevice, [
+            "setBusy('push-device')",
+            'await enablePushNotificationsForUser(user.uid);',
+            'Push is enabled on this device.',
+            'Failed to enable push on this device.'
+        ]);
+        expect(enablePushOnDevice).not.toContain('saveNotificationPreferences');
+        expect(enablePushOnDevice).not.toContain('setNotificationPreferences');
+        expect(profilePage).toContain("disabled={busy === 'push-device' || !user}");
     });
 
     it('reloads current team preferences before turning on game-day alerts', () => {

--- a/tests/unit/app-teams-integration.test.jsx
+++ b/tests/unit/app-teams-integration.test.jsx
@@ -20,6 +20,8 @@ import { Teams } from '../../apps/app/src/pages/Teams.tsx';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
+const mountedRoots = new Set();
+
 const auth = {
     user: {
         uid: 'user-1',
@@ -43,6 +45,7 @@ async function renderTeams(initialEntry = '/teams') {
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);
+    mountedRoots.add(root);
 
     await act(async () => {
         root.render(React.createElement(
@@ -156,7 +159,11 @@ beforeEach(() => {
     });
 });
 
-afterEach(() => {
+afterEach(async () => {
+    await act(async () => {
+        mountedRoots.forEach((root) => root.unmount());
+    });
+    mountedRoots.clear();
     document.body.innerHTML = '';
 });
 


### PR DESCRIPTION
Closes #1607

## Summary
- Adds a standalone Profile Alerts action to enable push on the current device.
- Calls `enablePushNotificationsForUser(user.uid)` without saving or mutating alert preferences.
- Shows loading, success, and error state through the existing notification status area.

## Validation
- `npx vitest run tests/unit/app-auth-profile-capabilities.test.js --reporter=verbose` passed.
- `npm run app:build` passed.
- `npm test` passed: 331 files, 1946 tests.
- `./gradlew :app:assembleDebug` was attempted but blocked by missing Android SDK location / `ANDROID_HOME` on this host. iOS build skipped on Linux.