### PR TITLE
Fix selected player chat recipients

### DIFF
--- a/team-chat.html
+++ b/team-chat.html
@@ -1189,20 +1189,37 @@
             return option.detail ? `${option.name} (${option.detail})` : option.name;
         }
 
+        function getPlayerGuardianRecipientIds(player = {}) {
+            const contacts = [
+                ...(Array.isArray(player?.parents) ? player.parents : []),
+                ...(Array.isArray(player?.contacts) ? player.contacts : []),
+                ...(Array.isArray(player?.guardians) ? player.guardians : [])
+            ];
+            return Array.from(new Set(contacts.flatMap((contact) => {
+                const parentKey = contact?.userId || contact?.email || '';
+                if (!parentKey) return [];
+                return [getRecipientOptionId(contact.userId ? 'user' : 'email', parentKey)];
+            })));
+        }
+
         async function loadRecipientOptions() {
             try {
                 const players = await getPlayers(teamId);
                 const options = [];
                 players.forEach((player) => {
                     if (!player?.id) return;
+                    const guardianRecipientIds = getPlayerGuardianRecipientIds(player);
                     const number = player.number !== undefined && player.number !== null && String(player.number).trim() !== ''
                         ? `#${player.number}`
                         : 'Roster';
-                    options.push({
-                        id: getRecipientOptionId('player', player.id),
-                        name: player.name || `Player ${player.id.slice(0, 6)}`,
-                        detail: number
-                    });
+                    if (guardianRecipientIds.length > 0) {
+                        options.push({
+                            id: getRecipientOptionId('player', player.id),
+                            recipientIds: guardianRecipientIds,
+                            name: player.name || `Player ${player.id.slice(0, 6)}`,
+                            detail: `${number} family`
+                        });
+                    }
                     (Array.isArray(player.parents) ? player.parents : []).forEach((parent) => {
                         const parentKey = parent?.userId || parent?.email || '';
                         if (!parentKey) return;
@@ -1617,9 +1634,16 @@
                 };
             }
             if (selectedRecipientTarget === 'individuals' && selectedRecipientIds.size > 0) {
+                const selectedOptionsById = new Map(recipientOptions.map((option) => [option.id, option]));
+                const recipientIds = Array.from(new Set(Array.from(selectedRecipientIds).flatMap((id) => {
+                    const option = selectedOptionsById.get(id);
+                    return Array.isArray(option?.recipientIds) && option.recipientIds.length > 0
+                        ? option.recipientIds
+                        : [id];
+                }))).sort();
                 return {
                     targetType: 'individuals',
-                    recipientIds: Array.from(selectedRecipientIds).sort(),
+                    recipientIds,
                     targetRole: null
                 };
             }

--- a/team-chat.html
+++ b/team-chat.html
@@ -1220,13 +1220,17 @@
                             detail: `${number} family`
                         });
                     }
-                    (Array.isArray(player.parents) ? player.parents : []).forEach((parent) => {
-                        const parentKey = parent?.userId || parent?.email || '';
-                        if (!parentKey) return;
-                        const parentName = parent.name || parent.fullName || parent.email || 'Guardian';
+                    [
+                        ...(Array.isArray(player.parents) ? player.parents : []),
+                        ...(Array.isArray(player.contacts) ? player.contacts : []),
+                        ...(Array.isArray(player.guardians) ? player.guardians : [])
+                    ].forEach((contact) => {
+                        const contactKey = contact?.userId || contact?.email || '';
+                        if (!contactKey) return;
+                        const contactName = contact.name || contact.fullName || contact.email || 'Guardian';
                         options.push({
-                            id: getRecipientOptionId(parent.userId ? 'user' : 'email', parentKey),
-                            name: parentName,
+                            id: getRecipientOptionId(contact.userId ? 'user' : 'email', contactKey),
+                            name: contactName,
                             detail: player.name ? `Guardian for ${player.name}` : 'Guardian'
                         });
                     });

--- a/tests/unit/team-chat-recipient-targets.test.js
+++ b/tests/unit/team-chat-recipient-targets.test.js
@@ -22,11 +22,15 @@ describe('team chat recipient targets', () => {
 
         expect(html).toContain('await loadRecipientOptions();');
         expect(html).toContain('const players = await getPlayers(teamId);');
+        expect(html).toContain('function getPlayerGuardianRecipientIds(player = {})');
+        expect(html).toContain('const guardianRecipientIds = getPlayerGuardianRecipientIds(player);');
+        expect(html).toContain('recipientIds: guardianRecipientIds');
+        expect(html).toContain('return Array.isArray(option?.recipientIds) && option.recipientIds.length > 0');
         expect(html).toContain('Array.isArray(player.parents)');
         expect(html).toContain('...buildRecipientTargetMetadata()');
         expect(html).toContain("targetType: 'staff'");
         expect(html).toContain("targetType: 'full_team'");
-        expect(html).toContain('recipientIds: Array.from(selectedRecipientIds).sort()');
+        expect(html).toContain('const recipientIds = Array.from(new Set(Array.from(selectedRecipientIds).flatMap((id) => {');
         expect(html).toContain('function buildEmailTargetMetadata()');
         expect(html).toContain("participantRoles.includes('staff')");
         expect(html).toContain('const targetMetadata = buildEmailTargetMetadata();');

--- a/tests/unit/team-chat-recipient-targets.test.js
+++ b/tests/unit/team-chat-recipient-targets.test.js
@@ -25,6 +25,9 @@ describe('team chat recipient targets', () => {
         expect(html).toContain('function getPlayerGuardianRecipientIds(player = {})');
         expect(html).toContain('const guardianRecipientIds = getPlayerGuardianRecipientIds(player);');
         expect(html).toContain('recipientIds: guardianRecipientIds');
+        expect(html).toContain('...(Array.isArray(player.contacts) ? player.contacts : [])');
+        expect(html).toContain('...(Array.isArray(player.guardians) ? player.guardians : [])');
+        expect(html).toContain('const contactKey = contact?.userId || contact?.email ||');
         expect(html).toContain('return Array.isArray(option?.recipientIds) && option.recipientIds.length > 0');
         expect(html).toContain('Array.isArray(player.parents)');
         expect(html).toContain('...buildRecipientTargetMetadata()');


### PR DESCRIPTION
Closes #1609

## Summary
- Resolve selected-player chat recipients to linked guardian `user:<uid>` or `email:<email>` IDs before creating targeted conversations.
- Only show player-family recipient rows when the player has at least one readable linked guardian/contact recipient.
- Add regression coverage asserting player selections expand to guardian recipient IDs instead of persisting unreadable `player:<id>` participants.

## Validation
- `npx vitest run tests/unit/team-chat-recipient-targets.test.js tests/unit/team-chat-conversations.test.js --reporter=verbose`
- `npm test`
- `npm run app:build`