### PR TITLE
Allow athlete profile media uploads

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -65,6 +65,11 @@ service firebase.storage {
         ];
     }
 
+    function isAllowedAthleteProfileMediaUploadType(contentType) {
+      return contentType.matches('image/.*') ||
+        contentType.matches('video/.*');
+    }
+
     match /team-media/{teamId}/{folderId}/{userId}/{fileName} {
       allow get: if canAccessTeamMedia(teamId);
       allow list: if false;
@@ -96,6 +101,17 @@ service firebase.storage {
     match /game-clips/{fileName=**} {
       allow get, create, delete: if isSignedIn();
       allow list, update: if false;
+    }
+
+    match /athlete-profile-media/{userId}/{profileId}/{fileName} {
+      allow get: if isSignedIn();
+      allow list: if false;
+      allow create: if isSignedIn() &&
+        request.resource.size > 0 &&
+        request.resource.size <= 100 * 1024 * 1024 &&
+        isAllowedAthleteProfileMediaUploadType(request.resource.contentType);
+      allow delete: if isSignedIn();
+      allow update: if false;
     }
   }
 }

--- a/storage.rules
+++ b/storage.rules
@@ -107,10 +107,11 @@ service firebase.storage {
       allow get: if isSignedIn();
       allow list: if false;
       allow create: if isSignedIn() &&
+        request.auth.uid == userId &&
         request.resource.size > 0 &&
         request.resource.size <= 100 * 1024 * 1024 &&
         isAllowedAthleteProfileMediaUploadType(request.resource.contentType);
-      allow delete: if isSignedIn();
+      allow delete: if isSignedIn() && request.auth.uid == userId;
       allow update: if false;
     }
   }

--- a/tests/unit/athlete-profile-storage-rules.test.js
+++ b/tests/unit/athlete-profile-storage-rules.test.js
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const rules = readFileSync(new URL('../../storage.rules', import.meta.url), 'utf8');
+
+describe('athlete profile Storage rules', () => {
+    it('allows signed-in profile media uploads with image/video limits', () => {
+        const mediaRulesStart = rules.indexOf('match /athlete-profile-media/{userId}/{profileId}/{fileName}');
+        expect(mediaRulesStart).toBeGreaterThan(-1);
+
+        const mediaRulesEnd = rules.indexOf('match /', mediaRulesStart + 1);
+        const mediaRules = rules.slice(mediaRulesStart, mediaRulesEnd === -1 ? undefined : mediaRulesEnd);
+
+        expect(mediaRules).toContain('allow get: if isSignedIn();');
+        expect(mediaRules).toContain('allow list: if false;');
+        expect(mediaRules).toContain('allow create: if isSignedIn() &&');
+        expect(mediaRules).toContain('request.resource.size > 0');
+        expect(mediaRules).toContain('request.resource.size <= 100 * 1024 * 1024');
+        expect(mediaRules).toContain('isAllowedAthleteProfileMediaUploadType(request.resource.contentType);');
+        expect(mediaRules).toContain('allow delete: if isSignedIn();');
+        expect(mediaRules).toContain('allow update: if false;');
+    });
+
+    it('restricts athlete profile uploads to image and video content types', () => {
+        expect(rules).toContain('function isAllowedAthleteProfileMediaUploadType(contentType)');
+        expect(rules).toContain("contentType.matches('image/.*')");
+        expect(rules).toContain("contentType.matches('video/.*')");
+    });
+});

--- a/tests/unit/athlete-profile-storage-rules.test.js
+++ b/tests/unit/athlete-profile-storage-rules.test.js
@@ -2,23 +2,69 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 
 const rules = readFileSync(new URL('../../storage.rules', import.meta.url), 'utf8');
+const mediaRules = extractAthleteProfileMediaRules();
+
+function extractAthleteProfileMediaRules() {
+    const mediaRulesStart = rules.indexOf('match /athlete-profile-media/{userId}/{profileId}/{fileName}');
+    expect(mediaRulesStart).toBeGreaterThan(-1);
+
+    const mediaRulesEnd = rules.indexOf('match /', mediaRulesStart + 1);
+    return rules.slice(mediaRulesStart, mediaRulesEnd === -1 ? undefined : mediaRulesEnd);
+}
+
+function canCreateAthleteProfileMedia({ authUid, userId, size, contentType }) {
+    const signedIn = authUid !== null;
+    const requiresPathOwner = mediaRules.includes('request.auth.uid == userId');
+    const pathOwnerAllowed = !requiresPathOwner || authUid === userId;
+    const hasAllowedSize = size > 0 && size <= 100 * 1024 * 1024;
+    const hasAllowedContentType = contentType.startsWith('image/') || contentType.startsWith('video/');
+
+    return signedIn && pathOwnerAllowed && hasAllowedSize && hasAllowedContentType;
+}
+
+function canDeleteAthleteProfileMedia({ authUid, userId }) {
+    const signedIn = authUid !== null;
+    const deleteRuleStart = mediaRules.indexOf('allow delete:');
+    const deleteRuleEnd = mediaRules.indexOf(';', deleteRuleStart);
+    const deleteRule = mediaRules.slice(deleteRuleStart, deleteRuleEnd);
+    const requiresPathOwner = deleteRule.includes('request.auth.uid == userId');
+    const pathOwnerAllowed = !requiresPathOwner || authUid === userId;
+
+    return signedIn && pathOwnerAllowed;
+}
 
 describe('athlete profile Storage rules', () => {
-    it('allows signed-in profile media uploads with image/video limits', () => {
-        const mediaRulesStart = rules.indexOf('match /athlete-profile-media/{userId}/{profileId}/{fileName}');
-        expect(mediaRulesStart).toBeGreaterThan(-1);
-
-        const mediaRulesEnd = rules.indexOf('match /', mediaRulesStart + 1);
-        const mediaRules = rules.slice(mediaRulesStart, mediaRulesEnd === -1 ? undefined : mediaRulesEnd);
-
+    it('allows signed-in profile owners to upload image/video media within limits', () => {
         expect(mediaRules).toContain('allow get: if isSignedIn();');
         expect(mediaRules).toContain('allow list: if false;');
         expect(mediaRules).toContain('allow create: if isSignedIn() &&');
+        expect(mediaRules).toContain('request.auth.uid == userId');
         expect(mediaRules).toContain('request.resource.size > 0');
         expect(mediaRules).toContain('request.resource.size <= 100 * 1024 * 1024');
         expect(mediaRules).toContain('isAllowedAthleteProfileMediaUploadType(request.resource.contentType);');
-        expect(mediaRules).toContain('allow delete: if isSignedIn();');
+        expect(mediaRules).toContain('allow delete: if isSignedIn() && request.auth.uid == userId;');
         expect(mediaRules).toContain('allow update: if false;');
+
+        expect(canCreateAthleteProfileMedia({
+            authUid: 'parent-1',
+            userId: 'parent-1',
+            size: 1024,
+            contentType: 'image/png'
+        })).toBe(true);
+    });
+
+    it('denies profile media uploads and deletes for another user path', () => {
+        expect(canCreateAthleteProfileMedia({
+            authUid: 'parent-2',
+            userId: 'parent-1',
+            size: 1024,
+            contentType: 'video/mp4'
+        })).toBe(false);
+
+        expect(canDeleteAthleteProfileMedia({
+            authUid: 'parent-2',
+            userId: 'parent-1'
+        })).toBe(false);
     });
 
     it('restricts athlete profile uploads to image and video content types', () => {


### PR DESCRIPTION
Closes #1613

## Summary
- Added Firebase Storage rules for `athlete-profile-media/{userId}/{profileId}/{fileName}` uploads.
- Limited creates to signed-in image-storage users, non-empty files, image/video MIME types, and the documented 100 MB cap.
- Added regression coverage to ensure athlete profile Storage rules remain present and constrained.

## Validation
- `npx vitest run tests/unit/athlete-profile-storage-rules.test.js --reporter=verbose`
- `npm run ci:firebase-rules`
- `npm test`
- `npm run app:build`