### PR TITLE
Block certificate publishing during description generation

### DIFF
--- a/js/certificates/studio.js
+++ b/js/certificates/studio.js
@@ -1140,6 +1140,7 @@ async function generateTeamCertificates() {
     } catch (error) {
         console.error('[certificates] generate failed:', error);
         state.descriptionGeneration = null;
+        renderReviewGrid();
         showAlert(error?.message || 'Unable to generate certificates.', 'error');
     } finally {
         state.activeRegenerationPromise = null;

--- a/js/certificates/studio.js
+++ b/js/certificates/studio.js
@@ -1101,29 +1101,33 @@ async function generateTeamCertificates() {
         renderReview();
         showAlert(`Generating descriptions for ${state.drafts.length} certificates. Completed rows will fill in as they finish.`, 'info');
 
-        const recentGames = selectRecentCompletedGames(state.games, state.shared.statsWindow);
-        const totalsByPlayer = state.demoMode
-            ? getDemoData().totalsByPlayer
-            : await getAggregatedStatsForGames(state.teamId, recentGames.map((game) => game.id));
-        const demoDescription = "proved to be a composed and reliable mid-fielder who reads the game exceptionally well. Her smart positioning, hustle in midfield, and support in transition made her a dependable two-way player and a key part of the team's defensive success!";
-        const results = await generateDescriptionsForDrafts({
-            drafts: state.drafts,
-            team: state.team,
-            shared: state.shared,
-            games: state.games,
-            totalsByPlayer,
-            generator: state.demoMode
-                ? async ({ player }) => player.name === 'Vivian Karpuk' ? demoDescription : `${player.name} showed commitment, energy, and a team-first approach throughout the season while making important contributions in key moments.`
-                : generateCertificateDescription,
-            concurrency: state.demoMode ? 3 : 2,
-            onResult: ({ draft, result, completed, total }) => {
-                const currentDraft = state.drafts.find((item) => item.id === draft.id);
-                applyDescriptionResultToDraft(currentDraft, result);
-                updateDescriptionGenerationProgress(completed, total);
-                renderReviewGrid();
-                if (currentDraft?.id === state.selectedDraftId) renderReviewPreview();
-            }
-        });
+        const descriptionRun = (async () => {
+            const recentGames = selectRecentCompletedGames(state.games, state.shared.statsWindow);
+            const totalsByPlayer = state.demoMode
+                ? getDemoData().totalsByPlayer
+                : await getAggregatedStatsForGames(state.teamId, recentGames.map((game) => game.id));
+            const demoDescription = "proved to be a composed and reliable mid-fielder who reads the game exceptionally well. Her smart positioning, hustle in midfield, and support in transition made her a dependable two-way player and a key part of the team's defensive success!";
+            return generateDescriptionsForDrafts({
+                drafts: state.drafts,
+                team: state.team,
+                shared: state.shared,
+                games: state.games,
+                totalsByPlayer,
+                generator: state.demoMode
+                    ? async ({ player }) => player.name === 'Vivian Karpuk' ? demoDescription : `${player.name} showed commitment, energy, and a team-first approach throughout the season while making important contributions in key moments.`
+                    : generateCertificateDescription,
+                concurrency: state.demoMode ? 3 : 2,
+                onResult: ({ draft, result, completed, total }) => {
+                    const currentDraft = state.drafts.find((item) => item.id === draft.id);
+                    applyDescriptionResultToDraft(currentDraft, result);
+                    updateDescriptionGenerationProgress(completed, total);
+                    renderReviewGrid();
+                    if (currentDraft?.id === state.selectedDraftId) renderReviewPreview();
+                }
+            });
+        })();
+        state.activeRegenerationPromise = descriptionRun;
+        const results = await descriptionRun;
 
         state.drafts.forEach((draft) => {
             const result = results.get(draft.id);
@@ -1138,6 +1142,7 @@ async function generateTeamCertificates() {
         state.descriptionGeneration = null;
         showAlert(error?.message || 'Unable to generate certificates.', 'error');
     } finally {
+        state.activeRegenerationPromise = null;
         if (button) {
             button.disabled = false;
             button.textContent = 'Create drafts for selected players';
@@ -1621,6 +1626,10 @@ function renderDescriptionProgress() {
 }
 
 function renderReviewGrid() {
+    const descriptionGenerationActive = Boolean(state.descriptionGeneration?.active);
+    const publishDisabledAttrs = descriptionGenerationActive
+        ? 'disabled aria-disabled="true" title="Descriptions are still generating"'
+        : '';
     const rows = state.drafts.map((draft) => {
         const remaining = DESCRIPTION_MAX_LENGTH - String(draft.description || '').length;
         const pendingDescription = draft.descriptionStatus === 'pending';
@@ -1661,7 +1670,7 @@ function renderReviewGrid() {
                 <div class="flex flex-wrap gap-2">
                     <button id="cert-regenerate-selected-btn" type="button" class="rounded-lg border border-gray-300 px-3 py-2 text-xs font-semibold text-gray-700">Regenerate selected</button>
                     <button id="cert-save-drafts-btn" type="button" class="rounded-lg border border-gray-300 px-3 py-2 text-xs font-semibold text-gray-700">Save progress</button>
-                    <button id="cert-publish-btn" type="button" class="rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-2 text-xs font-semibold text-emerald-700">Publish certificates</button>
+                    <button id="cert-publish-btn" type="button" class="rounded-lg border border-emerald-300 bg-emerald-50 px-3 py-2 text-xs font-semibold text-emerald-700 disabled:cursor-not-allowed disabled:opacity-50" ${publishDisabledAttrs}>Publish certificates</button>
                     <button id="cert-print-btn" type="button" class="rounded-lg bg-primary-600 px-3 py-2 text-xs font-semibold text-white">Print selected</button>
                     <button id="cert-png-btn" type="button" class="rounded-lg border border-gray-300 px-3 py-2 text-xs font-semibold text-gray-700">PNG selected</button>
                     <button id="cert-zip-btn" type="button" class="rounded-lg border border-gray-300 px-3 py-2 text-xs font-semibold text-gray-700">ZIP</button>

--- a/tests/unit/certificates-workflow.test.js
+++ b/tests/unit/certificates-workflow.test.js
@@ -113,6 +113,7 @@ describe('awards and certificates workflow wiring', () => {
         expect(generateBody).toContain('const descriptionRun = (async () =>');
         expect(generateBody).toContain('state.activeRegenerationPromise = descriptionRun;');
         expect(generateBody).toContain('const results = await descriptionRun;');
+        expect(generateBody).toContain("state.descriptionGeneration = null;\n        renderReviewGrid();\n        showAlert(error?.message || 'Unable to generate certificates.', 'error');");
         expect(generateBody).toContain('state.activeRegenerationPromise = null;');
         expect(waitBody).toContain('await state.activeRegenerationPromise;');
         expect(reviewGridBody).toContain('const descriptionGenerationActive = Boolean(state.descriptionGeneration?.active);');

--- a/tests/unit/certificates-workflow.test.js
+++ b/tests/unit/certificates-workflow.test.js
@@ -104,6 +104,23 @@ describe('awards and certificates workflow wiring', () => {
         expect(saveBody).toContain('createCertificate(state.teamId');
     });
 
+    it('blocks publishing while initial certificate descriptions are still generating', () => {
+        const studio = readRepoFile('js/certificates/studio.js');
+        const generateBody = studio.match(/async function generateTeamCertificates\(\) \{[\s\S]*?function renderReview\(\)/)?.[0] || '';
+        const reviewGridBody = studio.match(/function renderReviewGrid\(\) \{[\s\S]*?function bindReviewEvents\(\)/)?.[0] || '';
+        const waitBody = studio.match(/async function waitForActiveRegeneration\(\) \{[\s\S]*?async function runDraftRegeneration/)?.[0] || '';
+
+        expect(generateBody).toContain('const descriptionRun = (async () =>');
+        expect(generateBody).toContain('state.activeRegenerationPromise = descriptionRun;');
+        expect(generateBody).toContain('const results = await descriptionRun;');
+        expect(generateBody).toContain('state.activeRegenerationPromise = null;');
+        expect(waitBody).toContain('await state.activeRegenerationPromise;');
+        expect(reviewGridBody).toContain('const descriptionGenerationActive = Boolean(state.descriptionGeneration?.active);');
+        expect(reviewGridBody).toContain('disabled aria-disabled="true" title="Descriptions are still generating"');
+        expect(reviewGridBody).toContain('<button id="cert-publish-btn"');
+        expect(reviewGridBody).toContain('${publishDisabledAttrs}>Publish certificates</button>');
+    });
+
     it('adds coach and parent navigation without exposing certificates on the public team page', () => {
         const banner = readRepoFile('js/team-admin-banner.js');
         const dashboard = readRepoFile('dashboard.html');


### PR DESCRIPTION
Closes #1548

## Summary
- Track the initial certificate description generation promise so publish/save actions wait for it instead of proceeding with pending drafts.
- Disable the Publish certificates button while descriptions are actively generating.
- Added regression coverage for the initial-generation publishing gate.

## Validation
- `npx vitest run tests/unit/certificates-workflow.test.js --reporter=verbose`
- `npm test`
- `npm run app:build`