### PR TITLE
Confirm family share link revokes

### DIFF
--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -593,6 +593,7 @@ function FamilyShareTool({ auth }: { auth: AuthState }) {
   const [label, setLabel] = useState('');
   const [calendarText, setCalendarText] = useState('');
   const [editingTokenId, setEditingTokenId] = useState('');
+  const [pendingRevokeToken, setPendingRevokeToken] = useState<FamilyShareTokenCard | null>(null);
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [message, setMessage] = useState('');
@@ -648,6 +649,7 @@ function FamilyShareTool({ auth }: { auth: AuthState }) {
       setError(revokeError?.message || 'Unable to revoke family link.');
     } finally {
       setSaving(false);
+      setPendingRevokeToken(null);
     }
   };
 
@@ -700,12 +702,30 @@ function FamilyShareTool({ auth }: { auth: AuthState }) {
               onCancel={() => setEditingTokenId('')}
               onCopy={(text) => copyText(text, setMessage)}
               onShare={() => sharePublicUrl({ title: 'ALL PLAYS family page', text: token.label || 'Family schedule', url: token.url })}
-              onRevoke={() => revoke(token.id)}
+              onRevoke={() => setPendingRevokeToken(token)}
               onSaveCalendars={saveCalendars}
             />
           )) : <EmptyState icon={Share2} title="No family links" detail="Create a link when someone needs schedule access without a full account." />}
         </div>
       )}
+
+      {pendingRevokeToken ? (
+        <div className="fixed inset-0 z-50 flex items-end justify-center bg-gray-950/40 px-4 py-5 sm:items-center" role="presentation">
+          <div className="w-full max-w-sm rounded-2xl bg-white p-4 shadow-2xl" role="dialog" aria-modal="true" aria-labelledby="family-share-revoke-title">
+            <h3 id="family-share-revoke-title" className="text-base font-black text-gray-950">Revoke this share link?</h3>
+            <p className="mt-2 text-sm font-semibold leading-6 text-gray-600">
+              Anyone using the family share link{pendingRevokeToken.label ? ` for ${pendingRevokeToken.label}` : ''} will lose access.
+            </p>
+            <div className="mt-4 grid grid-cols-2 gap-2">
+              <button type="button" className="secondary-button justify-center text-xs" onClick={() => setPendingRevokeToken(null)} disabled={saving}>Cancel</button>
+              <button type="button" className="primary-button justify-center text-xs !bg-rose-600 hover:!bg-rose-700" onClick={() => revoke(pendingRevokeToken.id)} disabled={saving}>
+                {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+                Revoke link
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -111,6 +111,15 @@ async function clickButton(container, text) {
     await flush();
 }
 
+async function clickButtonWithin(container, text) {
+    const button = Array.from(container.querySelectorAll('button')).find((candidate) => candidate.textContent.trim().includes(text));
+    if (!button) throw new Error(`Button not found: ${text}`);
+    await act(async () => {
+        button.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+    await flush();
+}
+
 async function submitForm(container, text) {
     const button = Array.from(container.querySelectorAll('button')).find((candidate) => candidate.textContent.trim().includes(text));
     if (!button) throw new Error(`Submit button not found: ${text}`);
@@ -290,6 +299,10 @@ describe('React app parent tools integration', () => {
         await submitForm(container, 'Create share link');
         expect(serviceMocks.createParentFamilyShare).toHaveBeenCalledWith(auth.user, 'Grandpa', []);
         await clickButton(container, 'Revoke');
+        expect(serviceMocks.revokeParentFamilyShare).not.toHaveBeenCalled();
+        const confirmDialog = container.querySelector('[role="dialog"]');
+        expect(confirmDialog?.textContent).toContain('Anyone using the family share link for Grandma will lose access.');
+        await clickButtonWithin(confirmDialog, 'Revoke link');
         expect(serviceMocks.revokeParentFamilyShare).toHaveBeenCalledWith('token-1');
 
         await clickButton(container, 'Register');
@@ -310,6 +323,53 @@ describe('React app parent tools integration', () => {
             title: 'Hustle Award',
             url: 'https://allplays.ai/certificates.html#teamId=team-1&certificateId=cert-1'
         }));
+    });
+
+    it('requires confirmation before revoking a family share link', async () => {
+        const { container } = await renderParentTools('/parent-tools/share');
+        await waitForText(container, 'Grandma');
+
+        await clickButton(container, 'Revoke');
+
+        expect(serviceMocks.revokeParentFamilyShare).not.toHaveBeenCalled();
+        const confirmDialog = container.querySelector('[role="dialog"]');
+        expect(confirmDialog?.textContent).toContain('Anyone using the family share link for Grandma will lose access.');
+
+        await clickButtonWithin(confirmDialog, 'Cancel');
+
+        expect(serviceMocks.revokeParentFamilyShare).not.toHaveBeenCalled();
+        expect(container.querySelector('[role="dialog"]')).toBeNull();
+    });
+
+    it('only revokes a family share link after confirmation', async () => {
+        const { container } = await renderParentTools('/parent-tools/share');
+        await waitForText(container, 'Grandma');
+
+        await clickButton(container, 'Revoke');
+        const confirmDialog = container.querySelector('[role="dialog"]');
+        await clickButtonWithin(confirmDialog, 'Revoke link');
+
+        expect(serviceMocks.revokeParentFamilyShare).toHaveBeenCalledWith('token-1');
+        await waitForText(container, 'Family link revoked.');
+    });
+
+    it('keeps revoke disabled for already revoked family share links', async () => {
+        serviceMocks.loadFamilyShareModel.mockResolvedValueOnce({
+            children: [{ teamId: 'team-1', playerId: 'player-1', playerName: 'Pat Star' }],
+            tokens: [{ id: 'token-1', label: 'Grandma', url: 'https://allplays.ai/family.html?token=token-1', childCount: 1, extraCalendarUrls: [], revoked: true }]
+        });
+        const { container } = await renderParentTools('/parent-tools/share');
+        await waitForText(container, 'Revoked');
+
+        const revokeButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent.trim() === 'Revoke');
+        expect(revokeButton?.disabled).toBe(true);
+        await act(async () => {
+            revokeButton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+        });
+        await flush();
+
+        expect(container.querySelector('[role="dialog"]')).toBeNull();
+        expect(serviceMocks.revokeParentFamilyShare).not.toHaveBeenCalled();
     });
 
     it('renders fee notes and offline payment guidance without changing checkout', async () => {


### PR DESCRIPTION
Closes #1600

## What changed
- Added an accessible mobile-friendly confirmation dialog before revoking active family share links.
- Kept already-revoked links disabled and prevented them from opening confirmation.
- Added regression coverage for cancel, confirmed revoke, and disabled revoked-token behavior.

## Validation
- `npx vitest run tests/unit/app-parent-tools-integration.test.jsx --reporter=verbose`
- `npm test -- --reporter=dot`
- `npm run app:build`
- Android `./gradlew :app:assembleDebug` attempted, but local Android SDK is not configured (`ANDROID_HOME` / `android/local.properties` missing). iOS build skipped on Linux.