### PR TITLE
Apply goal events to viewer scorer stats

### DIFF
--- a/js/live-game-state.js
+++ b/js/live-game-state.js
@@ -350,7 +350,7 @@ export function applyViewerEventToState(currentState = {}, event = {}) {
   if (event.period) nextState.period = event.period;
   if (event.gameClockMs !== undefined) nextState.gameClockMs = event.gameClockMs;
 
-  if (event.type === 'stat' && event.playerId && event.statKey) {
+  if ((event.type === 'stat' || event.type === 'goal') && event.playerId && event.statKey) {
     if (event.isOpponent) {
       const existing = currentState?.opponentStats?.[event.playerId] || {};
       nextState.opponentStats = { ...currentState?.opponentStats };

--- a/js/live-game-state.js
+++ b/js/live-game-state.js
@@ -293,7 +293,7 @@ export function applyResetEventState(currentState, event) {
   };
 }
 
-export function applyViewerEventToState(currentState = {}, event = {}) {
+export function applyViewerEventToState(currentState = {}, event = {}, options = {}) {
   const nextState = {
     ...currentState,
     events: Array.isArray(currentState?.events) ? currentState.events : [],
@@ -360,8 +360,14 @@ export function applyViewerEventToState(currentState = {}, event = {}) {
         number: event.opponentPlayerNumber || existing.number || '',
         photoUrl: event.opponentPlayerPhoto || existing.photoUrl || ''
       };
-      nextState.opponentStats[event.playerId][event.statKey] =
-        (nextState.opponentStats[event.playerId][event.statKey] || 0) + (event.value || 0);
+      const hasSeededOpponentGoalStat = options.preserveSeededOpponentGoalStats &&
+        event.type === 'goal' &&
+        Number.isFinite(Number(existing[event.statKey])) &&
+        Number(existing[event.statKey]) > 0;
+      if (!hasSeededOpponentGoalStat) {
+        nextState.opponentStats[event.playerId][event.statKey] =
+          (nextState.opponentStats[event.playerId][event.statKey] || 0) + (event.value || 0);
+      }
     } else {
       const existing = currentState?.stats?.[event.playerId] || {};
       nextState.stats = { ...currentState?.stats };

--- a/js/live-game.js
+++ b/js/live-game.js
@@ -1886,7 +1886,7 @@ function resetViewerStateFromGameDoc(gameDoc, placeholder = 'Game reset. Waiting
   renderLineup();
 }
 
-function processNewEvents(events, { announce = true } = {}) {
+function processNewEvents(events, { announce = true, preserveSeededOpponentGoalStats = false } = {}) {
   const newEvents = collectVisibleLiveEventsSequentially(events, {
     seenIds: state.eventIds,
     resetBoundaryMs: state.lastResetAt
@@ -1909,7 +1909,7 @@ function processNewEvents(events, { announce = true } = {}) {
       renderLineup();
       return;
     }
-    const transition = applyViewerEventToState(state, event);
+    const transition = applyViewerEventToState(state, event, { preserveSeededOpponentGoalStats });
     Object.assign(state, transition.state);
 
     if (transition.shouldRenderLineup) {
@@ -1995,7 +1995,10 @@ function startLiveEvents() {
       }
     }
     state.liveEventsFirstLoad = false;
-    processNewEvents(events, { announce: !isInitialLiveEventsLoad });
+    processNewEvents(events, {
+      announce: !isInitialLiveEventsLoad,
+      preserveSeededOpponentGoalStats: isInitialLiveEventsLoad
+    });
   }, (error) => {
     console.warn('Live events subscription failed:', error);
     setConnectionBanner(true, formatFirestoreError(error));

--- a/tests/unit/live-game-state.test.js
+++ b/tests/unit/live-game-state.test.js
@@ -318,10 +318,11 @@ describe('live game state helpers', () => {
     ]);
   });
 
-  it('applies goal events to live viewer state without requiring basketball stat labels', () => {
+  it('applies goal events to live viewer scoreboard and scorer stats', () => {
     const goalEvent = {
       id: 'goal-1',
       type: 'goal',
+      playerId: 'p1',
       statKey: 'goals',
       value: 1,
       teamSide: 'home',
@@ -346,7 +347,13 @@ describe('live game state helpers', () => {
     expect(result.state.awayScore).toBe(0);
     expect(result.state.period).toBe('H1');
     expect(result.state.events).toEqual([goalEvent]);
-    expect(result.state.stats).toEqual({});
+    expect(result.state.stats).toEqual({ p1: { goals: 1 } });
+    expect(result.state.lastStatChange).toEqual({
+      playerId: 'p1',
+      statKey: 'goals',
+      isOpponent: false
+    });
+    expect(result.shouldRenderLineup).toBe(true);
     expect(result.shouldRenderPlayByPlay).toBe(true);
     expect(result.shouldCelebrateScore).toBe(true);
   });

--- a/tests/unit/live-game-state.test.js
+++ b/tests/unit/live-game-state.test.js
@@ -358,6 +358,54 @@ describe('live game state helpers', () => {
     expect(result.shouldCelebrateScore).toBe(true);
   });
 
+  it('preserves seeded opponent goal totals during initial live event replay', () => {
+    const goalEvent = {
+      id: 'away-goal-1',
+      type: 'goal',
+      playerId: 'opp1',
+      statKey: 'goals',
+      value: 1,
+      teamSide: 'away',
+      isOpponent: true,
+      opponentPlayerName: 'Away Striker',
+      opponentPlayerNumber: '9',
+      period: 'H1',
+      homeScore: 0,
+      awayScore: 1
+    };
+
+    const result = applyViewerEventToState({
+      events: [],
+      stats: {},
+      opponentStats: {
+        opp1: {
+          name: 'Away Striker',
+          number: '9',
+          goals: 1
+        }
+      },
+      homeScore: 0,
+      awayScore: 1
+    }, goalEvent, { preserveSeededOpponentGoalStats: true });
+
+    expect(result.state.opponentStats.opp1.goals).toBe(1);
+    expect(result.state.events).toEqual([goalEvent]);
+    expect(result.state.lastStatChange).toEqual({
+      playerId: 'opp1',
+      statKey: 'goals',
+      isOpponent: true
+    });
+    expect(result.shouldRenderLineup).toBe(true);
+    expect(result.shouldCelebrateScore).toBe(true);
+
+    const unseeded = applyViewerEventToState({
+      events: [],
+      stats: {},
+      opponentStats: {}
+    }, goalEvent, { preserveSeededOpponentGoalStats: true });
+    expect(unseeded.state.opponentStats.opp1.goals).toBe(1);
+  });
+
   it('treats football scoring events as scoreboard-changing play-by-play', () => {
     const scoreEvent = {
       id: 'football-score-1',


### PR DESCRIPTION
Closes #1618

## Summary
- Apply live `goal` events with `playerId` and `statKey` to fan viewer stat state, matching existing stat event handling.
- Preserve scoreboard, play-by-play, celebration, and lineup rerender behavior when a scorer goal arrives.
- Updated the live game state regression test so scorer GOALS totals increment from goal events.

## Validation
- `npx vitest run tests/unit/live-game-state.test.js --reporter=verbose`
- `npm test`
- `npm run app:build`