### PR TITLE
Defer quick share type picker

### DIFF
--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -1229,6 +1229,7 @@ function SocialComposerModal({
   const [caption, setCaption] = useState('');
   const [mediaFile, setMediaFile] = useState<File | null>(null);
   const [detailsOpen, setDetailsOpen] = useState(false);
+  const [typePickerOpen, setTypePickerOpen] = useState(initialType === 'manual_post');
   const [submitting, setSubmitting] = useState(false);
   const [localError, setLocalError] = useState('');
 
@@ -1309,29 +1310,6 @@ function SocialComposerModal({
         <div className="max-h-[72dvh] space-y-4 overflow-y-auto p-4">
           {localError ? <Status tone="error" message={localError} /> : null}
 
-          <div>
-            <div className="mb-2 text-xs font-black uppercase tracking-[0.04em] text-gray-500">Pick one</div>
-            <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
-              {socialPostPresets.map((preset) => {
-                const active = preset.id === activePreset.id;
-                return (
-                  <button
-                    key={preset.id}
-                    type="button"
-                    className={`min-h-[82px] rounded-xl border p-2 text-left transition ${active ? 'border-primary-300 bg-primary-50 text-primary-950 shadow-sm' : 'border-gray-200 bg-white text-gray-700 hover:border-primary-200'}`}
-                    onClick={() => selectPreset(preset.id)}
-                    aria-pressed={active}
-                  >
-                    <span className={`flex h-8 w-8 items-center justify-center rounded-lg ${active ? 'bg-primary-600 text-white' : 'bg-gray-100 text-gray-700'}`}>
-                      <SocialTypeIcon type={preset.type} />
-                    </span>
-                    <span className="mt-2 block text-xs font-black leading-4">{preset.shortLabel}</span>
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-
           <div className="rounded-xl border border-gray-200 bg-gray-50 p-3">
             <div className="flex items-start gap-3">
               <div className="flex h-10 w-10 flex-none items-center justify-center rounded-xl bg-white text-primary-700 ring-1 ring-gray-200">
@@ -1343,6 +1321,9 @@ function SocialComposerModal({
               </div>
             </div>
             <div className="mt-3 flex flex-wrap gap-2">
+              <button type="button" className="rounded-full bg-white px-2.5 py-1 text-xs font-black text-primary-700 ring-1 ring-primary-100" onClick={() => setTypePickerOpen((value) => !value)}>
+                Change share type
+              </button>
               <button type="button" className="rounded-full bg-white px-2.5 py-1 text-xs font-black text-gray-700 ring-1 ring-gray-200" onClick={() => setDetailsOpen((value) => !value)}>
                 {subjectLabel}
               </button>
@@ -1351,6 +1332,31 @@ function SocialComposerModal({
               </button>
             </div>
           </div>
+
+          {typePickerOpen ? (
+            <div>
+              <div className="mb-2 text-xs font-black uppercase tracking-[0.04em] text-gray-500">Pick one</div>
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
+                {socialPostPresets.map((preset) => {
+                  const active = preset.id === activePreset.id;
+                  return (
+                    <button
+                      key={preset.id}
+                      type="button"
+                      className={`min-h-[82px] rounded-xl border p-2 text-left transition ${active ? 'border-primary-300 bg-primary-50 text-primary-950 shadow-sm' : 'border-gray-200 bg-white text-gray-700 hover:border-primary-200'}`}
+                      onClick={() => selectPreset(preset.id)}
+                      aria-pressed={active}
+                    >
+                      <span className={`flex h-8 w-8 items-center justify-center rounded-lg ${active ? 'bg-primary-600 text-white' : 'bg-gray-100 text-gray-700'}`}>
+                        <SocialTypeIcon type={preset.type} />
+                      </span>
+                      <span className="mt-2 block text-xs font-black leading-4">{preset.shortLabel}</span>
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          ) : null}
 
           {detailsOpen ? (
             <div className="grid gap-3 rounded-xl border border-gray-200 bg-white p-3 sm:grid-cols-2">

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -496,6 +496,29 @@ test('home dashboard drills into player detail with section submenus', async ({ 
     await expect(page.getByText('PTS: +$1.00 per pts')).toBeVisible();
 });
 
+test('social quick share defers changing the selected post type', async ({ page, baseURL }) => {
+    await mockHomePlayerModules(page);
+    await page.goto(appUrl(baseURL, '/home?section=feed&social=create&type=game_recap'), { waitUntil: 'domcontentloaded' });
+
+    const dialog = page.getByRole('dialog', { name: 'Create social post' });
+    await expect(dialog.getByRole('heading', { name: 'What happened?' })).toBeVisible();
+    await expect(dialog.getByText('Game recap').first()).toBeVisible();
+    await expect(dialog.getByPlaceholder('How did the game go?')).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Change share type' })).toBeVisible();
+    await expect(dialog.getByText('Pick one')).toHaveCount(0);
+    await expect(dialog.getByRole('button', { name: 'Moment' })).toHaveCount(0);
+
+    await dialog.getByRole('button', { name: 'Change share type' }).click();
+    await expect(dialog.getByText('Pick one')).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Moment' })).toBeVisible();
+
+    await dialog.getByRole('button', { name: 'Media', exact: true }).click();
+    await expect(dialog.getByPlaceholder('Add a caption for the photo or video.')).toBeVisible();
+    await expect(dialog.getByRole('button', { name: 'Photos from today.' })).toBeVisible();
+    await dialog.getByRole('button', { name: 'Post', exact: true }).click();
+    await expect(dialog.getByText('Add a photo or video for this share.')).toBeVisible();
+});
+
 test('social photo quick share requires media and posts uploaded media payload', async ({ page, baseURL }) => {
     await mockHomePlayerModules(page);
     await page.goto(appUrl(baseURL, '/home?section=feed&social=create&type=team_media'), { waitUntil: 'domcontentloaded' });

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -422,7 +422,8 @@ test('home dashboard drills into player detail with section submenus', async ({ 
     await expect(page.locator('a[href="#/home?section=friends"]')).toBeVisible();
     await page.getByRole('button', { name: 'Player moment' }).click();
     await expect(page.getByRole('heading', { name: 'What happened?' })).toBeVisible();
-    await expect(page.getByText('Pick one')).toBeVisible();
+    await expect(page.getByText('Pick one')).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Change share type' })).toBeVisible();
     await expect(page.getByText('Write one short note')).toBeVisible();
     await expect(page.getByText('Proud of the effort today.')).toBeVisible();
     await expect(page.getByText('Post type')).toHaveCount(0);

--- a/tests/unit/app-home-player-integration.test.jsx
+++ b/tests/unit/app-home-player-integration.test.jsx
@@ -492,7 +492,8 @@ describe('React app Home and player drill-in integration', () => {
         ]));
         await clickButton(container, 'Player moment');
         await waitForText(container, 'What happened?');
-        expect(container.textContent).toContain('Pick one');
+        expect(container.textContent).not.toContain('Pick one');
+        expect(container.textContent).toContain('Change share type');
         expect(container.textContent).toContain('Write one short note');
         expect(container.textContent).toContain('Proud of the effort today.');
         expect(container.textContent).not.toContain('Post type');


### PR DESCRIPTION
Closes #1538

## Summary
- Opens Quick Share composer directly on the selected preset summary and note field.
- Moves the full post-type picker behind a `Change share type` control.
- Preserves existing preset switching behavior, including media-required validation.

## Tests
- `npx vitest run tests/unit/app-home-player-integration.test.jsx --reporter=dot`
- `SMOKE_APP_BASE_URL=http://127.0.0.1:5178 npx playwright test tests/smoke/app-home-player.spec.js --config=playwright.smoke.config.js --grep "social quick share defers|social photo quick share" --reporter=line`
- `npm run app:build`