### PR TITLE
Add AI schedule import drafts

### DIFF
--- a/apps/app/src/lib/scheduleAiImport.test.ts
+++ b/apps/app/src/lib/scheduleAiImport.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const aiMocks = vi.hoisted(() => {
+  const generateContent = vi.fn();
+  const getGenerativeModel = vi.fn(() => ({ generateContent }));
+  const makeSchema = (type: string, extra: Record<string, unknown> = {}) => ({ type, ...extra, toJSON: () => ({ type, ...extra }) });
+  return {
+    generateContent,
+    getGenerativeModel,
+    Schema: {
+      object: vi.fn((config: any) => makeSchema('object', config)),
+      array: vi.fn((config: any) => makeSchema('array', config)),
+      string: vi.fn((config?: any) => makeSchema('string', config)),
+      boolean: vi.fn((config?: any) => makeSchema('boolean', config))
+    }
+  };
+});
+
+vi.mock('../../../../js/vendor/firebase-app.js', () => ({
+  getApp: vi.fn(() => ({}))
+}));
+
+vi.mock('../../../../js/vendor/firebase-ai.js', () => ({
+  getAI: vi.fn(() => ({})),
+  getGenerativeModel: aiMocks.getGenerativeModel,
+  GoogleAIBackend: vi.fn(),
+  Schema: aiMocks.Schema
+}));
+
+import {
+  buildScheduleAiImportPrompt,
+  generateScheduleAiImportRows,
+  normalizeScheduleAiImportResponse
+} from './scheduleAiImport';
+
+describe('scheduleAiImport', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('builds a prompt with team context, current games, and image/text instructions', () => {
+    const prompt = buildScheduleAiImportPrompt({
+      teamName: 'U10 Bears',
+      text: 'only home games',
+      imageFile: { name: 'schedule.png' } as File,
+      currentGames: [{ id: 'g1', date: '2026-06-01T18:00:00', opponent: 'Rockets', location: 'Field 1' }],
+      now: new Date('2026-05-31T12:00:00Z')
+    });
+
+    expect(prompt).toContain('Team: U10 Bears');
+    expect(prompt).toContain('Current games in DB: 1');
+    expect(prompt).toContain('Rockets');
+    expect(prompt).toContain('schedule is attached as an image');
+    expect(prompt).toContain('only home games');
+    expect(prompt).toContain('Only create operations with action "add"');
+  });
+
+  it('normalizes valid add-game operations into import preview rows', () => {
+    const result = normalizeScheduleAiImportResponse({
+      operations: [{
+        action: 'add',
+        game: {
+          date: '2026-06-05T18:30:00',
+          opponent: 'Falcons',
+          location: 'Main Field',
+          isHome: true,
+          arrivalTime: '2026-06-05T18:00:00',
+          notes: 'Wear blue',
+          assignments: [{ role: 'snack', value: 'Lee family' }]
+        },
+        reason: 'read from line 1'
+      }]
+    }, { teamName: 'Bears' });
+
+    expect(result.errors).toEqual([]);
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0].normalized).toMatchObject({
+      eventType: 'game',
+      startsAt: '2026-06-05T18:30',
+      opponent: 'Falcons',
+      location: 'Main Field',
+      isHome: true,
+      arrivalTime: '2026-06-05T18:00'
+    });
+    expect(result.rows[0].normalized.notes).toContain('snack: Lee family');
+    expect(result.rows[0].errors).toEqual([]);
+  });
+
+  it('returns actionable errors for malformed or empty AI responses', () => {
+    expect(normalizeScheduleAiImportResponse({ nope: [] }).errors[0]).toContain('operations array');
+    expect(normalizeScheduleAiImportResponse({ operations: [] }).errors[0]).toContain('did not find any games');
+  });
+
+  it('generates rows through Firebase AI without persisting them', async () => {
+    aiMocks.generateContent.mockResolvedValue({
+      response: {
+        text: () => JSON.stringify({
+          operations: [{ action: 'add', game: { date: '2026-06-06T10:00:00', opponent: 'Tigers' } }]
+        })
+      }
+    });
+
+    const result = await generateScheduleAiImportRows({
+      teamName: 'Bears',
+      text: 'Sat 10am vs Tigers',
+      now: new Date('2026-05-31T12:00:00Z')
+    });
+
+    expect(aiMocks.getGenerativeModel).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({
+      model: 'gemini-2.5-flash',
+      generationConfig: expect.objectContaining({ responseMimeType: 'application/json' })
+    }));
+    expect(aiMocks.generateContent).toHaveBeenCalledWith([expect.stringContaining('Sat 10am vs Tigers')]);
+    expect(result.rows[0].normalized.opponent).toBe('Tigers');
+  });
+
+  it('does not call AI when both text and image are empty', async () => {
+    const result = await generateScheduleAiImportRows({ teamName: 'Bears', text: '   ' });
+
+    expect(result.rows).toEqual([]);
+    expect(result.errors[0]).toContain('Paste schedule text or upload');
+    expect(aiMocks.generateContent).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/lib/scheduleAiImport.ts
+++ b/apps/app/src/lib/scheduleAiImport.ts
@@ -1,0 +1,252 @@
+import { getApp } from '../../../../js/vendor/firebase-app.js';
+import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from '../../../../js/vendor/firebase-ai.js';
+import { normalizeScheduleImportDraft, type ScheduleCsvImportPreviewRow } from './scheduleCsvImport';
+
+export type ScheduleAiImportCurrentGame = {
+  id?: string;
+  date?: string | Date | null;
+  opponent?: string | null;
+  location?: string | null;
+  status?: string | null;
+};
+
+export type ScheduleAiImportInput = {
+  teamName: string;
+  text?: string;
+  imageFile?: File | null;
+  currentGames?: ScheduleAiImportCurrentGame[];
+  now?: Date;
+};
+
+export type ScheduleAiImportResult = {
+  rows: ScheduleCsvImportPreviewRow[];
+  errors: string[];
+};
+
+type ScheduleAiOperation = {
+  action?: string;
+  game?: Record<string, unknown>;
+  reason?: string;
+};
+
+const maxContextGames = 30;
+
+export async function generateScheduleAiImportRows(input: ScheduleAiImportInput): Promise<ScheduleAiImportResult> {
+  const text = compactText(input.text || '');
+  const imageFile = input.imageFile || null;
+  if (!text && !imageFile) {
+    return { rows: [], errors: ['Paste schedule text or upload a schedule image before using AI import.'] };
+  }
+
+  try {
+    const model = getScheduleAiImportModel();
+    const promptParts: any[] = [buildScheduleAiImportPrompt({ ...input, text })];
+    if (imageFile) {
+      promptParts.push(await fileToGenerativePart(imageFile));
+    }
+
+    const result = await model.generateContent(promptParts);
+    const responseText = compactText(result?.response?.text?.() || '');
+    const response = JSON.parse(responseText || '{}');
+    return normalizeScheduleAiImportResponse(response, input);
+  } catch (error: any) {
+    return {
+      rows: [],
+      errors: [error?.message ? `AI could not parse the schedule: ${error.message}` : 'AI could not parse the schedule. Try clearer text or a sharper image.']
+    };
+  }
+}
+
+export function buildScheduleAiImportPrompt(input: ScheduleAiImportInput): string {
+  const teamName = compactText(input.teamName) || 'the selected team';
+  const now = input.now || new Date();
+  const currentGames = (input.currentGames || []).slice(0, maxContextGames).map((game) => ({
+    id: compactText(game.id || ''),
+    date: normalizeContextDate(game.date),
+    opponent: compactText(game.opponent || ''),
+    location: compactText(game.location || ''),
+    status: compactText(game.status || 'scheduled')
+  }));
+  const text = compactText(input.text || '');
+  const hasImage = Boolean(input.imageFile);
+
+  return `Parse this youth sports schedule into add-game draft rows for review in ALL PLAYS.
+
+CONTEXT:
+- Today: ${now.toISOString().split('T')[0]}
+- Team: ${teamName}
+- Current games in DB: ${currentGames.length}
+- Current games JSON: ${JSON.stringify(currentGames)}
+
+INPUT:
+${hasImage ? '- The schedule is attached as an image. Extract visible game rows from the image.' : '- Schedule text is pasted below.'}
+${text ? `- Pasted schedule text or instructions:\n${text}` : '- No extra text instructions were provided.'}
+
+OUTPUT RULES:
+1. Return strict JSON only with an operations array.
+2. Only create operations with action "add". Do not update or delete existing games.
+3. Each operation must include a game object with date, opponent, location, isHome, arrivalTime, notes, assignments, and status when known.
+4. Convert dates to ISO 8601 local datetime strings like YYYY-MM-DDTHH:mm:ss. Use year ${now.getFullYear()} for future dates and ${now.getFullYear() + 1} for dates that have already passed.
+5. Opponent is the team that is not "${teamName}". Skip rows where you cannot identify a real game opponent.
+6. Use isHome true for home, false for away, and null/omit when unknown.
+7. Put uncertainty, filters used, assignment details, and skipped-row explanations in notes or reason.
+8. If no games are found, return {"operations":[]}.
+
+JSON shape:
+{"operations":[{"action":"add","game":{"date":"2026-06-01T18:00:00","opponent":"Rockets","location":"Field 1","isHome":true,"arrivalTime":"2026-06-01T17:30:00","notes":"Snack: Lee family","assignments":[{"role":"snack","value":"Lee family"}],"status":"scheduled"},"reason":"read from schedule row"}]}`;
+}
+
+export function normalizeScheduleAiImportResponse(response: unknown, input: Partial<Pick<ScheduleAiImportInput, 'teamName' | 'currentGames'>> = {}): ScheduleAiImportResult {
+  const operations = Array.isArray((response as any)?.operations) ? (response as any).operations as ScheduleAiOperation[] : [];
+  if (!Array.isArray((response as any)?.operations)) {
+    return { rows: [], errors: ['AI response did not include an operations array.'] };
+  }
+
+  const rows = operations
+    .filter((operation) => compactText(operation?.action || '').toLowerCase() === 'add' && operation.game)
+    .map((operation, index) => {
+      const draft = buildDraftFromAiGame(operation.game || {}, operation.reason);
+      const preview = normalizeScheduleImportDraft(draft, {
+        rowNumber: index + 1,
+        teamName: input.teamName || ''
+      }) as ScheduleCsvImportPreviewRow;
+      const conflictErrors = findCurrentGameConflictErrors(preview, input.currentGames || []);
+      return {
+        ...preview,
+        errors: [...preview.errors, ...conflictErrors]
+      };
+    });
+
+  if (!rows.length) {
+    return { rows: [], errors: ['AI did not find any games to import. Try adding more schedule details or a clearer image.'] };
+  }
+
+  return { rows, errors: [] };
+}
+
+export function buildScheduleAiImportSchema() {
+  return Schema.object({
+    properties: {
+      operations: Schema.array({
+        items: Schema.object({
+          properties: {
+            action: Schema.string(),
+            game: Schema.object({
+              properties: {
+                date: Schema.string(),
+                opponent: Schema.string(),
+                location: Schema.string(),
+                isHome: Schema.boolean({ nullable: true }),
+                arrivalTime: Schema.string(),
+                notes: Schema.string(),
+                assignments: Schema.array({
+                  items: Schema.object({
+                    properties: {
+                      role: Schema.string(),
+                      value: Schema.string()
+                    }
+                  })
+                }),
+                status: Schema.string()
+              },
+              optionalProperties: ['location', 'isHome', 'arrivalTime', 'notes', 'assignments', 'status']
+            }),
+            reason: Schema.string()
+          },
+          optionalProperties: ['game', 'reason']
+        })
+      })
+    }
+  });
+}
+
+function getScheduleAiImportModel() {
+  const firebaseApp = getApp();
+  const ai = getAI(firebaseApp, { backend: new GoogleAIBackend() });
+  return getGenerativeModel(ai, {
+    model: 'gemini-2.5-flash',
+    generationConfig: {
+      responseMimeType: 'application/json',
+      responseSchema: buildScheduleAiImportSchema()
+    }
+  });
+}
+
+async function fileToGenerativePart(file: File) {
+  const data = await fileToBase64(file);
+  return {
+    inlineData: {
+      data,
+      mimeType: file.type || 'image/png'
+    }
+  };
+}
+
+async function fileToBase64(file: File): Promise<string> {
+  if (typeof FileReader !== 'undefined') {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => resolve(String(reader.result || '').split(',')[1] || '');
+      reader.onerror = () => reject(new Error('Could not read the schedule image.'));
+      reader.readAsDataURL(file);
+    });
+  }
+
+  const buffer = await file.arrayBuffer();
+  let binary = '';
+  const bytes = new Uint8Array(buffer);
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary);
+}
+
+function buildDraftFromAiGame(game: Record<string, unknown>, reason?: string) {
+  const assignments = Array.isArray(game.assignments)
+    ? game.assignments
+        .map((item: any) => `${compactText(item?.role || 'Assignment')}: ${compactText(item?.value || '')}`)
+        .filter((item: string) => !item.endsWith(':'))
+    : [];
+  const noteParts = [compactText(game.notes), ...assignments, compactText(reason)].filter(Boolean);
+
+  return {
+    eventType: 'game',
+    startsAt: compactText(game.date || game.startsAt || ''),
+    endsAt: '',
+    opponent: compactText(game.opponent || ''),
+    title: '',
+    location: compactText(game.location || ''),
+    arrivalTime: compactText(game.arrivalTime || ''),
+    isHome: game.isHome === true ? 'home' : game.isHome === false ? 'away' : '',
+    notes: Array.from(new Set(noteParts)).join('\n')
+  };
+}
+
+function findCurrentGameConflictErrors(row: ScheduleCsvImportPreviewRow, currentGames: ScheduleAiImportCurrentGame[]): string[] {
+  const startsAt = row.normalized.startsAt ? new Date(row.normalized.startsAt) : null;
+  if (!startsAt || Number.isNaN(startsAt.getTime())) return [];
+  const rowOpponent = compactText(row.normalized.opponent || '').toLowerCase();
+
+  const conflict = currentGames.find((game) => {
+    const gameDate = normalizeContextDate(game.date);
+    if (!gameDate) return false;
+    const existing = new Date(gameDate);
+    if (Number.isNaN(existing.getTime())) return false;
+    const sameOpponent = rowOpponent && compactText(game.opponent || '').toLowerCase() === rowOpponent;
+    const hoursApart = Math.abs(existing.getTime() - startsAt.getTime()) / (60 * 60 * 1000);
+    return sameOpponent && hoursApart <= 24;
+  });
+
+  return conflict ? [`Possible duplicate/conflict with existing game vs ${compactText(conflict.opponent || 'opponent')} within 24 hours.`] : [];
+}
+
+function normalizeContextDate(value: unknown): string {
+  if (!value) return '';
+  if (value instanceof Date) return value.toISOString();
+  if (typeof (value as any)?.toDate === 'function') return (value as any).toDate().toISOString();
+  return compactText(value);
+}
+
+function compactText(value: unknown): string {
+  return String(value ?? '').replace(/\s+/g, ' ').trim();
+}

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -109,6 +109,13 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const [importingCsv, setImportingCsv] = useState(false);
   const [removingCalendarUrl, setRemovingCalendarUrl] = useState<string | null>(null);
 
+  const clearAiPreview = () => {
+    if (scheduleImportPreviewSource === 'ai') {
+      setCsvPreviewRows([]);
+      setScheduleImportPreviewSource(null);
+    }
+  };
+
   const refreshSchedule = async (force = false) => {
     if (!auth.user) return;
     setLoading(true);
@@ -248,6 +255,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
 
   const handleAiImageChange = (file: File | null) => {
     setAiImportErrors([]);
+    clearAiPreview();
     setAiScheduleImage(file);
     setAiScheduleImageName(file?.name || '');
   };
@@ -257,10 +265,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
     setAiScheduleImage(null);
     setAiScheduleImageName('');
     setAiImportErrors([]);
-    if (scheduleImportPreviewSource === 'ai') {
-      setCsvPreviewRows([]);
-      setScheduleImportPreviewSource(null);
-    }
+    clearAiPreview();
   };
 
   const handleAiGeneratePreview = async () => {
@@ -677,6 +682,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
               importing={importingCsv}
               onTextChange={(value) => {
                 setAiScheduleText(value);
+                clearAiPreview();
                 if (aiImportErrors.length) setAiImportErrors([]);
               }}
               onImageChange={handleAiImageChange}

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { AlertCircle, CalendarDays, CheckCircle2, ChevronLeft, ChevronRight, ClipboardCheck, Copy, Download, Filter, Link as LinkIcon, ListChecks, MapPin, RefreshCw } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { addTeamCalendarUrl, createScheduleImportGame, createScheduleImportPractice, loadParentSchedule, removeTeamCalendarUrl, type ParentScheduleChild } from '../lib/scheduleService';
+import { generateScheduleAiImportRows } from '../lib/scheduleAiImport';
 import { getCachedAppData, loadCachedAppData } from '../lib/appDataCache';
 import { startUxTimer } from '../lib/uxTiming';
 import { useShellLayout } from '../lib/useShellLayout';
@@ -97,8 +98,14 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const [csvRows, setCsvRows] = useState<Array<Record<string, string>>>([]);
   const [csvMapping, setCsvMapping] = useState<ScheduleCsvImportMapping>({});
   const [csvPreviewRows, setCsvPreviewRows] = useState<ScheduleCsvImportPreviewRow[]>([]);
+  const [scheduleImportPreviewSource, setScheduleImportPreviewSource] = useState<'csv' | 'ai' | null>(null);
   const [csvImportErrors, setCsvImportErrors] = useState<string[]>([]);
   const [csvFileName, setCsvFileName] = useState('');
+  const [aiScheduleText, setAiScheduleText] = useState('');
+  const [aiScheduleImage, setAiScheduleImage] = useState<File | null>(null);
+  const [aiScheduleImageName, setAiScheduleImageName] = useState('');
+  const [aiImportErrors, setAiImportErrors] = useState<string[]>([]);
+  const [processingAiImport, setProcessingAiImport] = useState(false);
   const [importingCsv, setImportingCsv] = useState(false);
   const [removingCalendarUrl, setRemovingCalendarUrl] = useState<string | null>(null);
 
@@ -205,6 +212,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const handleCsvFileChange = async (file: File | null) => {
     setCsvImportErrors([]);
     setCsvPreviewRows([]);
+    setScheduleImportPreviewSource(null);
     if (!file) return;
     try {
       const parsed = parseCsvText(await file.text());
@@ -225,6 +233,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
     });
     setCsvImportErrors(preview.errors);
     setCsvPreviewRows(preview.rows);
+    setScheduleImportPreviewSource(preview.rows.length ? 'csv' : null);
   };
 
   const handleCsvClear = () => {
@@ -234,13 +243,68 @@ export function Schedule({ auth }: { auth: AuthState }) {
     setCsvPreviewRows([]);
     setCsvImportErrors([]);
     setCsvFileName('');
+    setScheduleImportPreviewSource(null);
+  };
+
+  const handleAiImageChange = (file: File | null) => {
+    setAiImportErrors([]);
+    setAiScheduleImage(file);
+    setAiScheduleImageName(file?.name || '');
+  };
+
+  const handleAiClear = () => {
+    setAiScheduleText('');
+    setAiScheduleImage(null);
+    setAiScheduleImageName('');
+    setAiImportErrors([]);
+    if (scheduleImportPreviewSource === 'ai') {
+      setCsvPreviewRows([]);
+      setScheduleImportPreviewSource(null);
+    }
+  };
+
+  const handleAiGeneratePreview = async () => {
+    if (!selectedCalendarTeam || processingAiImport) return;
+    setAiImportErrors([]);
+    setCsvImportErrors([]);
+    setCsvPreviewRows([]);
+    setScheduleImportPreviewSource(null);
+    setStatusMessage(null);
+    setError(null);
+    const currentGames = events
+      .filter((event) => event.teamId === selectedCalendarTeam.teamId && event.type === 'game' && event.isDbGame)
+      .map((event) => ({
+        id: event.id,
+        date: event.date,
+        opponent: event.opponent,
+        location: event.location,
+        status: event.isCancelled ? 'cancelled' : 'scheduled'
+      }));
+
+    setProcessingAiImport(true);
+    try {
+      const result = await generateScheduleAiImportRows({
+        teamName: selectedCalendarTeam.teamName,
+        text: aiScheduleText,
+        imageFile: aiScheduleImage,
+        currentGames
+      });
+      setAiImportErrors(result.errors);
+      setCsvPreviewRows(result.rows);
+      setScheduleImportPreviewSource(result.rows.length ? 'ai' : null);
+      if (result.rows.length) {
+        setStatusMessage(`AI generated ${result.rows.length} draft game row(s). Review them below before importing.`);
+      }
+    } finally {
+      setProcessingAiImport(false);
+    }
   };
 
   const handleCsvImport = async () => {
     if (!selectedCalendarTeam || !auth.user || importingCsv) return;
     const invalidRows = csvPreviewRows.filter((row) => row.errors.length > 0);
     if (!csvPreviewRows.length) {
-      setCsvImportErrors(['Preview the CSV before importing.']);
+      setCsvImportErrors(['Preview rows before importing.']);
       return;
     }
     if (invalidRows.length > 0) {
@@ -603,11 +667,28 @@ export function Schedule({ auth }: { auth: AuthState }) {
               onSubmit={handleAddCalendarUrl}
               onRemove={handleRemoveCalendarUrl}
             />
+            <ScheduleAiImportPanel
+              teamName={selectedCalendarTeam.teamName}
+              text={aiScheduleText}
+              imageName={aiScheduleImageName}
+              previewRows={scheduleImportPreviewSource === 'ai' ? csvPreviewRows : []}
+              errors={aiImportErrors}
+              processing={processingAiImport}
+              importing={importingCsv}
+              onTextChange={(value) => {
+                setAiScheduleText(value);
+                if (aiImportErrors.length) setAiImportErrors([]);
+              }}
+              onImageChange={handleAiImageChange}
+              onGeneratePreview={handleAiGeneratePreview}
+              onImport={handleCsvImport}
+              onClear={handleAiClear}
+            />
             <ScheduleCsvImportPanel
               teamName={selectedCalendarTeam.teamName}
               headers={csvHeaders}
               mapping={csvMapping}
-              previewRows={csvPreviewRows}
+              previewRows={scheduleImportPreviewSource === 'csv' ? csvPreviewRows : []}
               errors={csvImportErrors}
               fileName={csvFileName}
               importing={importingCsv}
@@ -650,6 +731,88 @@ export function Schedule({ auth }: { auth: AuthState }) {
         </div>
       </div>
     </div>
+  );
+}
+
+function ScheduleAiImportPanel({ teamName, text, imageName, previewRows, errors, processing, importing, onTextChange, onImageChange, onGeneratePreview, onImport, onClear }: {
+  teamName: string;
+  text: string;
+  imageName: string;
+  previewRows: ScheduleCsvImportPreviewRow[];
+  errors: string[];
+  processing: boolean;
+  importing: boolean;
+  onTextChange: (value: string) => void;
+  onImageChange: (file: File | null) => void;
+  onGeneratePreview: () => void;
+  onImport: () => void;
+  onClear: () => void;
+}) {
+  const invalidCount = previewRows.filter((row) => row.errors.length > 0).length;
+  return (
+    <section className="app-card p-4" aria-label="AI schedule import">
+      <div className="flex items-start gap-3">
+        <div className="flex h-9 w-9 flex-none items-center justify-center rounded-xl bg-violet-50 text-violet-700">
+          <ClipboardCheck className="h-4 w-4" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="app-label">Staff schedule tools</div>
+          <h2 className="mt-1 text-base font-black text-gray-950">Draft schedule with AI</h2>
+          <p className="mt-1 text-xs font-semibold leading-5 text-gray-500">Paste schedule text or upload one image for {teamName}. AI drafts game rows only; nothing is saved until you review and import.</p>
+        </div>
+      </div>
+
+      <div className="mt-3 space-y-3">
+        <label className="block">
+          <span className="text-xs font-black uppercase tracking-[0.08em] text-gray-500">Schedule text or instructions</span>
+          <textarea
+            className="auth-input mt-1 min-h-28 !px-3 !py-2 text-sm font-semibold"
+            placeholder="Paste schedule lines, or add instructions like 'only home games' when uploading an image."
+            value={text}
+            onChange={(event) => onTextChange(event.target.value)}
+            aria-label="Schedule text or AI instructions"
+          />
+        </label>
+
+        <label className="block">
+          <span className="text-xs font-black uppercase tracking-[0.08em] text-gray-500">Schedule image</span>
+          <input
+            className="auth-input mt-1 min-h-10 !px-3 !py-2 text-sm font-semibold"
+            type="file"
+            accept="image/png,image/jpeg,image/webp,image/heic,image/heif"
+            aria-label="Schedule image"
+            onChange={(event) => onImageChange(event.target.files?.[0] || null)}
+          />
+        </label>
+        {imageName ? <div className="text-xs font-bold text-gray-500">Loaded {imageName}</div> : null}
+
+        {errors.length ? (
+          <div className="rounded-xl border border-rose-200 bg-rose-50 p-3 text-xs font-bold text-rose-700" role="alert">
+            {errors.map((item) => <div key={item}>{item}</div>)}
+          </div>
+        ) : null}
+
+        {previewRows.length ? (
+          <div className="space-y-2">
+            <div className="text-xs font-black uppercase tracking-[0.08em] text-gray-500">AI draft preview {previewRows.length} row(s){invalidCount ? `, ${invalidCount} needs review` : ''}</div>
+            {previewRows.map((row) => (
+              <div key={row.rowNumber} className={`rounded-xl border p-3 text-sm ${row.errors.length ? 'border-rose-200 bg-rose-50' : 'border-violet-200 bg-violet-50'}`}>
+                <div className="font-black text-gray-900">Draft {row.rowNumber}: Game vs {row.normalized.opponent || 'opponent TBD'}</div>
+                <div className="mt-1 text-xs font-semibold text-gray-600">{row.normalized.startsAt || 'Start TBD'} · {row.normalized.location || 'Location TBD'}</div>
+                {row.normalized.notes ? <div className="mt-1 text-xs font-semibold text-gray-600 whitespace-pre-line">{row.normalized.notes}</div> : null}
+                {row.errors.length ? <ul className="mt-2 list-disc pl-4 text-xs font-bold text-rose-700">{row.errors.map((item) => <li key={item}>{item}</li>)}</ul> : null}
+              </div>
+            ))}
+          </div>
+        ) : null}
+
+        <div className="flex flex-wrap gap-2">
+          <button type="button" className="secondary-button" onClick={onGeneratePreview} disabled={processing || importing}>{processing ? 'Processing…' : 'Generate draft rows'}</button>
+          <button type="button" className="primary-button" onClick={onImport} disabled={!previewRows.length || invalidCount > 0 || processing || importing}>{importing ? 'Importing…' : 'Import reviewed rows'}</button>
+          <button type="button" className="secondary-button" onClick={onClear} disabled={processing || importing}>Clear AI input</button>
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -9,10 +9,14 @@ const scheduleMocks = vi.hoisted(() => ({
     createScheduleImportGame: vi.fn(),
     createScheduleImportPractice: vi.fn(),
     loadParentSchedule: vi.fn(),
-    removeTeamCalendarUrl: vi.fn()
+    removeTeamCalendarUrl: vi.fn(),
+    generateScheduleAiImportRows: vi.fn()
 }));
 
 vi.mock('../../apps/app/src/lib/scheduleService.ts', () => scheduleMocks);
+vi.mock('../../apps/app/src/lib/scheduleAiImport.ts', () => ({
+    generateScheduleAiImportRows: scheduleMocks.generateScheduleAiImportRows
+}));
 vi.mock('../../apps/app/src/lib/useShellLayout.ts', () => ({
     useShellLayout: () => ({ isDesktopWeb: true, isNative: false, isMobileWeb: false })
 }));
@@ -110,6 +114,14 @@ async function changeInput(input, value) {
     });
 }
 
+async function changeTextarea(textarea, value) {
+    await act(async () => {
+        const setter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value').set;
+        setter.call(textarea, value);
+        textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+}
+
 async function changeSelect(select, value) {
     await act(async () => {
         select.value = value;
@@ -125,6 +137,7 @@ beforeEach(() => {
     scheduleMocks.createScheduleImportGame.mockResolvedValue('game-new');
     scheduleMocks.createScheduleImportPractice.mockResolvedValue('practice-new');
     scheduleMocks.removeTeamCalendarUrl.mockResolvedValue({ removed: true, calendarUrls: [] });
+    scheduleMocks.generateScheduleAiImportRows.mockResolvedValue({ rows: [], errors: [] });
     vi.spyOn(window, 'confirm').mockReturnValue(true);
     scheduleMocks.loadParentSchedule.mockResolvedValue({
         children: [
@@ -321,6 +334,61 @@ describe('React app desktop Schedule controls', () => {
         expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(3);
         expect(scheduleMocks.loadParentSchedule).toHaveBeenLastCalledWith(auth.user, { hydrateDetails: false, expandStaffPlayers: false });
         await waitForText(container, 'Imported 2 schedule row(s) and refreshed the schedule.');
+    });
+
+    it('previews and imports staff AI schedule rows without showing the tool to parents', async () => {
+        const parentOnly = await renderSchedule();
+        await waitForText(parentOnly.container, 'Main Gym');
+        expect(parentOnly.container.textContent).not.toContain('Draft schedule with AI');
+
+        const aiRow = {
+            rowNumber: 1,
+            draft: {},
+            normalized: {
+                rowNumber: 1,
+                eventType: 'game',
+                startsAt: '2026-04-02T18:30',
+                endsAt: null,
+                opponent: 'Tigers',
+                title: null,
+                location: 'Field 1',
+                arrivalTime: null,
+                isHome: true,
+                notes: 'AI extracted from pasted text'
+            },
+            errors: []
+        };
+        scheduleMocks.generateScheduleAiImportRows.mockResolvedValue({ rows: [aiRow], errors: [] });
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            children: [
+                { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+            ],
+            events: [event({ isTeamStaff: true })]
+        });
+        clearAppDataCache('app-schedule-summary');
+
+        const { container } = await renderSchedule();
+        await waitForText(container, 'Draft schedule with AI');
+        const textarea = container.querySelector('textarea[aria-label="Schedule text or AI instructions"]');
+        expect(textarea).toBeTruthy();
+
+        await changeTextarea(textarea, '4/2 6:30 PM vs Tigers at Field 1');
+        await clickButton(container, 'Generate draft rows');
+        await waitForText(container, 'AI draft preview 1 row(s)');
+        expect(scheduleMocks.generateScheduleAiImportRows).toHaveBeenCalledWith(expect.objectContaining({
+            teamName: 'Bears',
+            text: '4/2 6:30 PM vs Tigers at Field 1',
+            imageFile: null,
+            currentGames: [expect.objectContaining({ opponent: 'Falcons', location: 'Main Gym' })]
+        }));
+        expect(container.textContent).toContain('Game vs Tigers');
+
+        await clickButton(container, 'Import reviewed rows');
+        expect(scheduleMocks.createScheduleImportGame).toHaveBeenCalledWith('team-1', expect.objectContaining({
+            eventType: 'game',
+            opponent: 'Tigers'
+        }), auth.user);
+        await waitForText(container, 'Imported 1 schedule row(s) and refreshed the schedule.');
     });
 
     it('blocks CSV import when preview contains invalid rows', async () => {

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -391,6 +391,48 @@ describe('React app desktop Schedule controls', () => {
         await waitForText(container, 'Imported 1 schedule row(s) and refreshed the schedule.');
     });
 
+    it('clears stale AI preview rows when the source text changes', async () => {
+        const aiRow = {
+            rowNumber: 1,
+            draft: {},
+            normalized: {
+                rowNumber: 1,
+                eventType: 'game',
+                startsAt: '2026-04-02T18:30',
+                endsAt: null,
+                opponent: 'Tigers',
+                title: null,
+                location: 'Field 1',
+                arrivalTime: null,
+                isHome: true,
+                notes: 'AI extracted from pasted text'
+            },
+            errors: []
+        };
+        scheduleMocks.generateScheduleAiImportRows.mockResolvedValue({ rows: [aiRow], errors: [] });
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            children: [
+                { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+            ],
+            events: [event({ isTeamStaff: true })]
+        });
+
+        const { container } = await renderSchedule();
+        await waitForText(container, 'Draft schedule with AI');
+        const textarea = container.querySelector('textarea[aria-label="Schedule text or AI instructions"]');
+
+        await changeTextarea(textarea, '4/2 6:30 PM vs Tigers at Field 1');
+        await clickButton(container, 'Generate draft rows');
+        await waitForText(container, 'AI draft preview 1 row(s)');
+        expect(buttonByText(container, 'Import reviewed rows').disabled).toBe(false);
+
+        await changeTextarea(textarea, '4/3 7:00 PM vs Hawks at Field 2');
+
+        expect(container.textContent).not.toContain('AI draft preview 1 row(s)');
+        expect(container.textContent).not.toContain('Game vs Tigers');
+        expect(buttonByText(container, 'Import reviewed rows').disabled).toBe(true);
+    });
+
     it('blocks CSV import when preview contains invalid rows', async () => {
         scheduleMocks.loadParentSchedule.mockResolvedValue({
             children: [


### PR DESCRIPTION
Closes #1621

## Summary
- Added a Firebase AI schedule parser that accepts pasted schedule text and optional image input, returns add-game preview rows, and handles malformed/no-row AI responses safely.
- Added a staff-only AI import panel on the React Schedule page next to existing calendar and CSV tools.
- Reused the existing preview/import path so generated rows are not persisted until reviewed and imported.

## Validation
- `npx vitest run apps/app/src/lib/scheduleAiImport.test.ts --reporter=verbose`
- `npx vitest run tests/unit/app-schedule-desktop-controls.test.jsx apps/app/src/lib/scheduleAiImport.test.ts --reporter=verbose`
- `npm test -- --reporter=dot`
- `npm run app:build`

Android native build was not run because this change is React/shared app code only; iOS build skipped on Linux host.