### PR TITLE
Prioritize unpaid team fees

### DIFF
--- a/src/app/team-fees/team-fees.component.spec.ts
+++ b/src/app/team-fees/team-fees.component.spec.ts
@@ -354,6 +354,50 @@ describe('TeamFeesComponent checkout flow', () => {
     ]);
   });
 
+  it('orders actionable unpaid fees before completed and canceled fees', async () => {
+    const paidFee = feeDoc('teams/team-real/feeBatches/batch-paid/feeRecipients/recipient-paid', 'recipient-paid', {
+      parentUserId: 'parent-123',
+      title: 'Paid registration',
+      balanceDueCents: 0,
+      status: 'paid',
+      collectionMode: 'online_stripe'
+    });
+    const canceledFee = feeDoc('teams/team-real/feeBatches/batch-canceled/feeRecipients/recipient-canceled', 'recipient-canceled', {
+      parentUserId: 'parent-123',
+      title: 'Canceled registration',
+      balanceDueCents: 6500,
+      status: 'canceled',
+      collectionMode: 'online_stripe'
+    });
+    const offlineFee = feeDoc('teams/team-real/feeBatches/batch-offline/feeRecipients/recipient-offline', 'recipient-offline', {
+      parentUserId: 'parent-123',
+      title: 'Cash registration',
+      balanceDueCents: 6500,
+      status: 'unpaid',
+      collectionMode: 'offline_manual'
+    });
+    const onlineFee = feeDoc('teams/team-real/feeBatches/batch-online/feeRecipients/recipient-online', 'recipient-online', {
+      parentUserId: 'parent-123',
+      title: 'Online registration',
+      balanceDueCents: 12500,
+      status: 'unpaid',
+      collectionMode: 'online_stripe'
+    });
+    mockGetDocs
+      .mockResolvedValueOnce({ docs: [paidFee, canceledFee, offlineFee, onlineFee] })
+      .mockResolvedValueOnce({ docs: [] })
+      .mockResolvedValueOnce({ docs: [] });
+
+    await component.ngOnInit();
+
+    expect(component.teamFees.map((fee) => ({ id: fee.id, status: fee.status, canPayOnline: fee.canPayOnline }))).toEqual([
+      { id: 'recipient-online', status: 'unpaid', canPayOnline: true },
+      { id: 'recipient-offline', status: 'unpaid', canPayOnline: false },
+      { id: 'recipient-paid', status: 'paid', canPayOnline: false },
+      { id: 'recipient-canceled', status: 'canceled', canPayOnline: false }
+    ]);
+  });
+
   it('passes the selected fee recipient IDs to StripeService before redirecting', async () => {
     const selectedFee = {
       id: 'recipient-real',

--- a/src/app/team-fees/team-fees.component.ts
+++ b/src/app/team-fees/team-fees.component.ts
@@ -168,6 +168,16 @@ function getOfflinePaymentInstructions(data: FeeRecipientData): string {
   ).trim();
 }
 
+function getTeamFeeDisplayPriority(fee: TeamFee): number {
+  if (fee.canPayOnline) return 0;
+  if (fee.status === 'unpaid') return 1;
+  return 2;
+}
+
+function sortTeamFeesForDisplay(fees: TeamFee[]): TeamFee[] {
+  return [...fees].sort((feeA, feeB) => getTeamFeeDisplayPriority(feeA) - getTeamFeeDisplayPriority(feeB));
+}
+
 @Component({
   selector: 'app-team-fees',
   templateUrl: './team-fees.component.html',
@@ -289,7 +299,7 @@ export class TeamFeesComponent implements OnInit {
       });
     });
 
-    return Array.from(feesByPath.values());
+    return sortTeamFeesForDisplay(Array.from(feesByPath.values()));
   }
 
   private async loadUserProfile(db: ReturnType<typeof getFirestore>, userId: string): Promise<UserProfileData> {


### PR DESCRIPTION
Closes #1552

## Summary
- Sort team fees so unpaid online-payable fees render first, unpaid offline/manual fees render next, and paid/canceled fees remain visible after active balances.
- Preserve existing checkout gating so only unpaid online Stripe fees with a positive balance show the Pay Team Fee action.
- Add regression coverage for mixed fee statuses and collection modes.

## Validation
- `npx vitest run src/app/team-fees/team-fees.component.spec.ts --reporter=verbose`
- `npm test`
- `npm run app:build`
- `./gradlew :app:assembleDebug` attempted, blocked by missing Android SDK configuration: `ANDROID_HOME` or `android/local.properties` `sdk.dir` is not set.
- Flutter not installed on this host; iOS build skipped on Linux.