### PR TITLE
Make public team discovery search-first

### DIFF
--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -1,0 +1,54 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { AppShell } from './AppShell';
+import type { AuthState } from '../lib/types';
+
+vi.mock('../lib/useShellLayout', () => ({
+  useShellLayout: () => ({ isDesktopWeb: true }),
+}));
+
+vi.mock('../lib/uxTiming', () => ({
+  recordUxTiming: vi.fn(),
+}));
+
+vi.mock('./AppSearchDialog', () => ({
+  AppSearchDialog: () => null,
+}));
+
+const auth: AuthState = {
+  user: null,
+  profile: null,
+  loading: false,
+  error: null,
+  roles: ['parent'],
+  isParent: true,
+  isCoach: false,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: vi.fn(),
+  signOut: vi.fn(),
+};
+
+describe('AppShell', () => {
+  beforeEach(() => {
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(0);
+      return 1;
+    });
+    vi.stubGlobal('cancelAnimationFrame', vi.fn());
+  });
+
+  it('adds an explicit accessible label to the desktop search button', () => {
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<AppShell auth={auth}><div>Home</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const searchButton = screen.getByRole('button', { name: 'Search' });
+    expect(searchButton).toHaveAttribute('aria-label', 'Search');
+  });
+});

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -134,6 +134,7 @@ export function AppShell({ auth, children }: AppShellProps) {
                   type="button"
                   className="ghost-button !h-10 !min-h-10"
                   onClick={() => setSearchOpen(true)}
+                  aria-label="Search"
                   title="Search (Ctrl+K / Cmd+K)"
                 >
                   <Search className="h-5 w-5" aria-hidden="true" />

--- a/apps/app/src/components/PublicTeamSearch.test.tsx
+++ b/apps/app/src/components/PublicTeamSearch.test.tsx
@@ -1,165 +1,146 @@
-import { describe, it, expect, vi, beforeEach, type MockInstance } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
 import { PublicTeamSearch } from './PublicTeamSearch';
 import { getPublicTeamsByLocation } from '../lib/publicTeamsService';
 import { ParentHomeTeam } from '../lib/homeLogic';
 
-// Mock the service call
 vi.mock('../lib/publicTeamsService', () => ({
-  getPublicTeamsByLocation: vi.fn() as MockInstance<(locationFilter?: string) => Promise<ParentHomeTeam[]>>,
+    getPublicTeamsByLocation: vi.fn() as MockInstance<(locationFilter?: string) => Promise<ParentHomeTeam[]>>,
 }));
 
-// Mock team data
 const mockTeams: ParentHomeTeam[] = [
-  {
-    teamId: 'team-atl-1',
-    teamName: 'Atlanta United',
-    photoUrl: '',
-    role: 'Fan',
-    sport: 'Soccer',
-    location: 'Atlanta, GA',
-    players: [],
-    eventCount: 0,
-    unreadCount: 0,
-    openActions: 0,
-    nextEvent: null,
-    appAccess: true,
-    webAccess: true,
-    isPublic: true,
-  },
-  {
-    teamId: 'team-nyc-1',
-    teamName: 'New York Knicks',
-    photoUrl: '',
-    role: 'Fan',
-    sport: 'Basketball',
-    location: 'New York, NY',
-    players: [],
-    eventCount: 0,
-    unreadCount: 0,
-    openActions: 0,
-    nextEvent: null,
-    appAccess: true,
-    webAccess: true,
-    isPublic: true,
-  },
+    {
+        teamId: 'team-atl-1',
+        teamName: 'Atlanta United',
+        photoUrl: '',
+        role: 'Fan',
+        sport: 'Soccer',
+        location: 'Atlanta, GA',
+        players: [],
+        eventCount: 0,
+        unreadCount: 0,
+        openActions: 0,
+        nextEvent: null,
+        appAccess: true,
+        webAccess: true,
+        isPublic: true,
+    },
+    {
+        teamId: 'team-nyc-1',
+        teamName: 'New York Knicks',
+        photoUrl: '',
+        role: 'Fan',
+        sport: 'Basketball',
+        location: 'New York, NY',
+        players: [],
+        eventCount: 0,
+        unreadCount: 0,
+        openActions: 0,
+        nextEvent: null,
+        appAccess: true,
+        webAccess: true,
+        isPublic: true,
+    },
 ];
 
 describe('PublicTeamSearch', () => {
-  beforeEach(() => {
-    // Reset mocks before each test
-    vi.clearAllMocks();
-    // Default mock for tests that don't specify mockResolvedValueOnce
-    (getPublicTeamsByLocation as import('vitest').Mock).mockResolvedValue(mockTeams);
-  });
-
-  it('renders the search input and buttons', async () => {
-    // Ensure initial render also uses the default mock
-    (getPublicTeamsByLocation as import('vitest').Mock).mockResolvedValueOnce(mockTeams);
-    render(<PublicTeamSearch />);
-    expect(screen.getByPlaceholderText('Search by city, state, or zip')).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /Search/i })).toBeInTheDocument();
-    // Clear button only appears after a search or query is entered
-    expect(screen.queryByRole('button', { name: /Clear/i })).not.toBeInTheDocument();
-
-    // Wait for initial load to complete
-    await waitFor(() => expect(screen.queryByText('Loading public teams')).not.toBeInTheDocument());
-  });
-
-  it('loads all public teams on initial render', async () => {
-    // Mock for this specific test's initial render
-    (getPublicTeamsByLocation as import('vitest').Mock).mockResolvedValueOnce(mockTeams);
-    render(<PublicTeamSearch />);
-    expect(screen.getByText('Loading public teams')).toBeInTheDocument();
-    await waitFor(() => expect(getPublicTeamsByLocation).toHaveBeenCalledWith(undefined));
-    await waitFor(() => expect(screen.getByText('Atlanta United')).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByText('New York Knicks')).toBeInTheDocument());
-  });
-
-  it('filters teams by location when search button is clicked', async () => {
-    // Mock initial load to return all teams
-    (getPublicTeamsByLocation as import('vitest').Mock).mockResolvedValueOnce(mockTeams);
-    render(<PublicTeamSearch />);
-
-    // Wait for initial load and assert all teams are present
-    await waitFor(() => expect(getPublicTeamsByLocation).toHaveBeenCalledWith(undefined));
-    await waitFor(() => expect(screen.getByText('Atlanta United')).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByText('New York Knicks')).toBeInTheDocument());
-
-    const searchInput = screen.getByPlaceholderText('Search by city, state, or zip');
-    fireEvent.change(searchInput, { target: { value: 'atlanta' } });
-
-    // Mock the next call (the search call) to return only Atlanta teams
-    (getPublicTeamsByLocation as import('vitest').Mock).mockResolvedValueOnce([mockTeams[0]]);
-    fireEvent.click(screen.getByRole('button', { name: /Search/i }));
-
-    // After search, assert only Atlanta team is present
-    await waitFor(() => expect(getPublicTeamsByLocation).toHaveBeenCalledWith('atlanta'));
-    await waitFor(() => expect(screen.getByText('Atlanta United')).toBeInTheDocument());
-    await waitFor(() => expect(screen.queryByText('New York Knicks')).not.toBeInTheDocument());
-  });
-
-  it('clears the search and shows all teams when clear button is clicked', async () => {
-    // Mock initial load to return all teams
-    (getPublicTeamsByLocation as import('vitest').Mock).mockResolvedValueOnce(mockTeams);
-    render(<PublicTeamSearch />);
-
-    // Initial load confirmation
-    await waitFor(() => expect(getPublicTeamsByLocation).toHaveBeenCalledWith(undefined));
-    await waitFor(() => expect(screen.getByText('Atlanta United')).toBeInTheDocument());
-    await waitFor(() => expect(screen.getByText('New York Knicks')).toBeInTheDocument());
-
-    const searchInput = screen.getByPlaceholderText('Search by city, state, or zip');
-    fireEvent.change(searchInput, { target: { value: 'atlanta' } });
-
-    // Mock search call to return only Atlanta teams
-    (getPublicTeamsByLocation as import('vitest').Mock).mockResolvedValueOnce([mockTeams[0]]);
-    fireEvent.click(screen.getByRole('button', { name: /Search/i }));
-
-    // After search, only Atlanta should be visible
-    await waitFor(() => expect(getPublicTeamsByLocation).toHaveBeenCalledWith('atlanta'));
-    await waitFor(() => expect(screen.getByText('Atlanta United')).toBeInTheDocument());
-    await waitFor(() => expect(screen.queryByText('New York Knicks')).not.toBeInTheDocument());
-
-    // Now, mock the service to return all teams when clear is called
-    (getPublicTeamsByLocation as import('vitest').Mock).mockResolvedValueOnce(mockTeams);
-
-    // Click clear button
-    fireEvent.click(screen.getByRole('button', { name: /Clear/i }));
-
-    // After clear, all teams should be visible
-    await waitFor(() => expect(getPublicTeamsByLocation).toHaveBeenCalledWith(undefined));
-    await waitFor(() => {
-      expect(screen.getByText('Atlanta United')).toBeInTheDocument();
-      expect(screen.getByText('New York Knicks')).toBeInTheDocument();
+    afterEach(() => {
+        cleanup();
     });
-    expect(searchInput).toHaveValue(''); // Verify input is cleared
-  });
 
-  it('displays an error message if fetching teams fails', async () => {
-    (getPublicTeamsByLocation as import('vitest').Mock).mockRejectedValueOnce(new Error('Network error'));
-    render(<PublicTeamSearch />);
+    beforeEach(() => {
+        vi.clearAllMocks();
+        (getPublicTeamsByLocation as import('vitest').Mock).mockResolvedValue(mockTeams);
+    });
 
-    await waitFor(() => expect(screen.getByText('Network error')).toBeInTheDocument());
-    expect(screen.queryByText('Atlanta United')).not.toBeInTheDocument();
-  });
+    it('renders an empty search-first state without loading teams on mount', () => {
+        render(<PublicTeamSearch />);
 
-  it('displays no teams found message when no results', async () => {
-    (getPublicTeamsByLocation as import('vitest').Mock).mockResolvedValueOnce([]);
-    render(<PublicTeamSearch />);
+        expect(screen.getByPlaceholderText('Search by city, state, or zip')).toBeTruthy();
+        expect(screen.getByRole('button', { name: /Search/i })).toBeTruthy();
+        expect(screen.getByRole('button', { name: /Browse all public teams/i })).toBeTruthy();
+        expect(screen.getByText('Search for public teams near you')).toBeTruthy();
+        expect(screen.queryByRole('button', { name: /Clear/i })).toBeNull();
+        expect(screen.queryByText('Atlanta United')).toBeNull();
+        expect(getPublicTeamsByLocation).not.toHaveBeenCalled();
+    });
 
-    await waitFor(() => expect(screen.getByText(/No public teams found/i)).toBeInTheDocument());
-    expect(screen.queryByText('Atlanta United')).not.toBeInTheDocument();
-  });
+    it('filters teams by location when search is submitted', async () => {
+        (getPublicTeamsByLocation as import('vitest').Mock).mockResolvedValueOnce([mockTeams[0]]);
+        render(<PublicTeamSearch />);
 
-  it('groups teams by resolved location', async () => {
-    // Mock for this specific test's initial render
-    (getPublicTeamsByLocation as import('vitest').Mock).mockResolvedValueOnce(mockTeams);
-    render(<PublicTeamSearch />);
-    await waitFor(() => expect(screen.queryByText('Loading public teams')).not.toBeInTheDocument());
+        const searchInput = screen.getByPlaceholderText('Search by city, state, or zip') as HTMLInputElement;
+        fireEvent.change(searchInput, { target: { value: 'atlanta' } });
+        fireEvent.click(screen.getByRole('button', { name: /Search/i }));
 
-    expect(screen.getByText('Atlanta, GA')).toBeInTheDocument();
-    expect(screen.getByText('New York, NY')).toBeInTheDocument();
-    expect(screen.getAllByText(/player/).length).toBe(2); // One for each team card
-  });
+        await waitFor(() => expect(getPublicTeamsByLocation).toHaveBeenCalledWith('atlanta'));
+        expect(screen.getByText('Atlanta United')).toBeTruthy();
+        expect(screen.queryByText('New York Knicks')).toBeNull();
+        expect(screen.getByRole('button', { name: /Clear/i })).toBeTruthy();
+    });
+
+    it('loads all public teams only when browse all is used', async () => {
+        render(<PublicTeamSearch />);
+
+        fireEvent.click(screen.getByRole('button', { name: /Browse all public teams/i }));
+
+        await waitFor(() => expect(getPublicTeamsByLocation).toHaveBeenCalledWith(undefined));
+        expect(screen.getByText('Atlanta United')).toBeTruthy();
+        expect(screen.getByText('New York Knicks')).toBeTruthy();
+    });
+
+    it('clears a filtered search back to the empty state without browsing all', async () => {
+        (getPublicTeamsByLocation as import('vitest').Mock).mockResolvedValueOnce([mockTeams[0]]);
+        render(<PublicTeamSearch />);
+
+        const searchInput = screen.getByPlaceholderText('Search by city, state, or zip') as HTMLInputElement;
+        fireEvent.change(searchInput, { target: { value: 'atlanta' } });
+        fireEvent.click(screen.getByRole('button', { name: /Search/i }));
+
+        await waitFor(() => expect(getPublicTeamsByLocation).toHaveBeenCalledTimes(1));
+        expect(screen.getByText('Atlanta United')).toBeTruthy();
+
+        fireEvent.click(screen.getByRole('button', { name: /Clear/i }));
+
+        expect(searchInput.value).toBe('');
+        expect(screen.getByText('Search for public teams near you')).toBeTruthy();
+        expect(screen.queryByText('Atlanta United')).toBeNull();
+        expect(getPublicTeamsByLocation).toHaveBeenCalledTimes(1);
+    });
+
+    it('displays an error message if fetching teams fails', async () => {
+        (getPublicTeamsByLocation as import('vitest').Mock).mockRejectedValueOnce(new Error('Network error'));
+        render(<PublicTeamSearch />);
+
+        fireEvent.click(screen.getByRole('button', { name: /Browse all public teams/i }));
+
+        await waitFor(() => expect(screen.getByText('Network error')).toBeTruthy());
+        expect(screen.queryByText('Atlanta United')).toBeNull();
+    });
+
+    it('displays no teams found message when no results are returned', async () => {
+        (getPublicTeamsByLocation as import('vitest').Mock).mockResolvedValueOnce([]);
+        render(<PublicTeamSearch />);
+
+        fireEvent.change(screen.getByPlaceholderText('Search by city, state, or zip'), { target: { value: 'boston' } });
+        fireEvent.click(screen.getByRole('button', { name: /Search/i }));
+
+        await waitFor(() => {
+            const message = screen.getByText(/No public teams found/i);
+            expect(message.textContent).toContain('for "boston"');
+        });
+        expect(screen.queryByText('Atlanta United')).toBeNull();
+    });
+
+    it('groups teams into separate location sections after browsing all', async () => {
+        render(<PublicTeamSearch />);
+
+        fireEvent.click(screen.getByRole('button', { name: /Browse all public teams/i }));
+
+        await waitFor(() => expect(screen.getByText('Atlanta United')).toBeTruthy());
+        expect(screen.getByText('New York Knicks')).toBeTruthy();
+        expect(screen.getAllByRole('heading', { level: 3 }).length).toBe(2);
+    });
 });

--- a/apps/app/src/components/PublicTeamSearch.tsx
+++ b/apps/app/src/components/PublicTeamSearch.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useEffect, useCallback } from 'react';
+import { useState, useMemo, useCallback } from 'react';
 import { Search, XCircle, Loader2, Users } from 'lucide-react';
 import { type ParentHomeTeam } from '../lib/homeLogic';
 import { TeamAvatar, TeamLauncherChip, Status } from '../pages/Teams';
@@ -15,10 +15,12 @@ export function PublicTeamSearch(props: PublicTeamSearchProps) {
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string>('');
   const [activeSearchLocation, setActiveSearchLocation] = useState<string | null>(null);
+  const [hasSearched, setHasSearched] = useState<boolean>(false);
 
   const fetchPublicTeams = useCallback(async (location?: string) => {
     setLoading(true);
     setError('');
+    setHasSearched(true);
     try {
       const teams = await getPublicTeamsByLocation(location);
       setPublicTeams(teams);
@@ -31,18 +33,20 @@ export function PublicTeamSearch(props: PublicTeamSearchProps) {
     }
   }, []);
 
-  useEffect(() => {
-    // Load all public teams on initial mount
-    void fetchPublicTeams();
-  }, [fetchPublicTeams]);
-
   const handleSearch = () => {
-    void fetchPublicTeams(locationQuery);
+    void fetchPublicTeams(locationQuery.trim() || undefined);
+  };
+
+  const handleBrowseAll = () => {
+    void fetchPublicTeams();
   };
 
   const handleClear = () => {
     setLocationQuery('');
-    void fetchPublicTeams(); // Fetch all public teams
+    setPublicTeams([]);
+    setError('');
+    setActiveSearchLocation(null);
+    setHasSearched(false);
   };
 
   const groupedTeams = useMemo(() => {
@@ -105,11 +109,25 @@ export function PublicTeamSearch(props: PublicTeamSearchProps) {
         ) : null}
       </div>
 
-      {loading && !publicTeams.length ? (
+      {!hasSearched && !loading ? (
+        <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 p-6 text-center">
+          <Users className="mx-auto h-8 w-8 text-gray-400" aria-hidden="true" />
+          <div className="mt-3 text-sm font-black text-gray-900">Search for public teams near you</div>
+          <div className="mt-1 text-xs font-semibold text-gray-500">Enter a city, state, or zip code to find nearby teams.</div>
+          <button
+            type="button"
+            className="ghost-button mt-4 !min-h-10 !px-3 text-sm"
+            onClick={handleBrowseAll}
+            disabled={loading}
+          >
+            Browse all public teams
+          </button>
+        </div>
+      ) : loading && !publicTeams.length ? (
         <div className="app-card p-6 text-center">
           <Loader2 className="mx-auto h-8 w-8 animate-spin text-primary-600" aria-hidden="true" />
           <div className="mt-3 text-sm font-black text-gray-900">Loading public teams</div>
-          <div className="mt-1 text-xs font-semibold text-gray-500">Fetching teams across all regions.</div>
+          <div className="mt-1 text-xs font-semibold text-gray-500">{activeSearchLocation ? `Searching for teams near "${activeSearchLocation}".` : 'Browsing teams across all regions.'}</div>
         </div>
       ) : error ? (
         <Status tone="error" message={error} />
@@ -128,7 +146,7 @@ export function PublicTeamSearch(props: PublicTeamSearchProps) {
         </div>
       ) : (
         <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500 text-center">
-          No public teams found {activeSearchLocation ? `for "${activeSearchLocation}"` : ''}. Try a different location or clear your search.
+          No public teams found {activeSearchLocation ? `for "${activeSearchLocation}"` : ''}. Try a different location or browse all public teams.
         </div>
       )}
     </section>


### PR DESCRIPTION
Closes #1629

## What changed
- removed the automatic unfiltered public-team fetch from `PublicTeamSearch` initial render
- added an empty search-first state with a secondary **Browse all public teams** action
- changed **Clear** to reset the component back to the neutral prompt instead of reloading the full catalog
- updated the component tests to cover search-first, explicit browse-all, and clear-reset behavior

## Why
The teams page was dropping users into a full public catalog before they expressed intent. This keeps the common path focused on city/state/zip search while preserving full browsing as an explicit secondary action.

## Validation
- `npx vitest run apps/app/src/components/PublicTeamSearch.test.tsx --reporter=verbose`