### PR TITLE
Add account merge request action to app profile

### DIFF
--- a/apps/app/src/lib/profileService.test.ts
+++ b/apps/app/src/lib/profileService.test.ts
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({
+    createAccessCode: vi.fn(),
+    createAccountMergeRequest: vi.fn(),
+    generateAccessCode: vi.fn(() => 'CODE1234'),
+    getNotificationPreferencesForTeam: vi.fn(),
+    getParentTeams: vi.fn(),
+    getUserAccessCodes: vi.fn(),
+    getUserProfile: vi.fn(),
+    getUserTeamsWithAccess: vi.fn(),
+    saveNotificationPreferencesForTeam: vi.fn(),
+    updateUserProfile: vi.fn(),
+    upsertNotificationDeviceToken: vi.fn(),
+    uploadUserPhoto: vi.fn()
+}));
+
+vi.mock('../../../../js/db.js', () => dbMocks);
+vi.mock('../../../../js/notification-preferences.js', () => ({
+    normalizeTeamNotificationPreferences: vi.fn((preferences) => ({
+        liveChat: Boolean(preferences?.liveChat),
+        liveScore: Boolean(preferences?.liveScore),
+        schedule: Boolean(preferences?.schedule)
+    }))
+}));
+vi.mock('../../../../js/firebase-runtime-config.js', () => ({
+    resolveImageFirebaseConfig: vi.fn(() => ({ apiKey: 'key', storageBucket: 'bucket' }))
+}));
+vi.mock('./authService', () => ({
+    firebaseAuth: { app: { options: { projectId: 'demo-project' } } },
+    getNativeAuthIdToken: vi.fn()
+}));
+vi.mock('../../../../js/team-visibility.js', () => ({
+    isTeamActive: vi.fn(() => true)
+}));
+
+import { requestAccountMerge } from './profileService';
+
+describe('requestAccountMerge', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('normalizes emails and calls createAccountMergeRequest', async () => {
+        dbMocks.createAccountMergeRequest.mockResolvedValue('merge-1');
+
+        await expect(requestAccountMerge('user-1', ' Parent@Example.com ', ' Child@Example.com ')).resolves.toBe('merge-1');
+
+        expect(dbMocks.createAccountMergeRequest).toHaveBeenCalledWith('user-1', {
+            primaryEmail: 'parent@example.com',
+            secondaryEmail: 'child@example.com'
+        });
+    });
+});

--- a/apps/app/src/lib/profileService.ts
+++ b/apps/app/src/lib/profileService.ts
@@ -1,5 +1,6 @@
 import {
   createAccessCode,
+  createAccountMergeRequest,
   generateAccessCode,
   getNotificationPreferencesForTeam,
   getParentTeams,
@@ -275,6 +276,19 @@ async function nativeLoadNotificationTeams(userId: string, email?: string | null
   return [...map.values()].sort((a, b) => String(a.name || a.id).localeCompare(String(b.name || b.id)));
 }
 
+async function nativeLoadParentTeams(userId: string): Promise<NotificationTeam[]> {
+  const profile = await nativeLoadProfileDocument(userId).catch(() => ({}));
+  const parentTeamIds = [...new Set((Array.isArray((profile as any).parentOf) ? (profile as any).parentOf : [])
+    .map((link: any) => link?.teamId)
+    .filter(Boolean))] as string[];
+  const parentTeams = await Promise.all(parentTeamIds.map((teamId) => nativeGetDocument(`teams/${encodeURIComponent(teamId)}`).catch(() => null)));
+
+  return filterActiveTeams(parentTeams)
+    .filter((team: any) => team?.id)
+    .map((team: any) => ({ id: team.id, name: team.name || team.id }))
+    .sort((a, b) => String(a.name || a.id).localeCompare(String(b.name || b.id)));
+}
+
 async function nativeLoadNotificationPreferences(userId: string, teamId: string) {
   return normalizeNotificationPreferences(await nativeGetDocument(`users/${encodeURIComponent(userId)}/notificationPreferences/${encodeURIComponent(teamId)}`) as Partial<NotificationPreferences> | null);
 }
@@ -329,6 +343,29 @@ async function nativeCreateAccessCode(userId: string, email: string, phone: stri
       }
     })
   });
+}
+
+async function nativeCreateAccountMergeRequest(userId: string, primaryEmail: string, secondaryEmail: string) {
+  const payload = {
+    requestedBy: userId,
+    primaryEmail,
+    secondaryEmail,
+    status: 'pending_verification',
+    createdAt: new Date(),
+    updatedAt: new Date()
+  };
+
+  const response = await nativeFirestoreRequest(`/users/${encodeURIComponent(userId)}/accountMergeRequests`, {
+    method: 'POST',
+    body: JSON.stringify({
+      fields: Object.keys(payload).reduce<Record<string, Record<string, unknown>>>((acc, key) => {
+        acc[key] = encodeFirestoreValue((payload as Record<string, unknown>)[key]);
+        return acc;
+      }, {})
+    })
+  });
+
+  return String(response?.name || '').split('/').pop() || '';
 }
 
 async function nativeLoadAccessCodes(userId: string): Promise<AccessCodeRecord[]> {
@@ -524,6 +561,16 @@ export async function loadNotificationTeams(userId: string, email?: string | nul
   return [...map.values()].sort((a, b) => String(a.name || a.id).localeCompare(String(b.name || b.id)));
 }
 
+export async function loadParentTeams(userId: string): Promise<NotificationTeam[]> {
+  try {
+    const teams = await withTimeout(Promise.resolve(getParentTeams(userId)), 'Parent team load', primaryDataTimeoutMs);
+    return (teams || []).filter((team: NotificationTeam | null | undefined) => Boolean(team?.id));
+  } catch (error) {
+    console.warn('[profile-service] Falling back to REST parent team load:', error);
+    return nativeLoadParentTeams(userId);
+  }
+}
+
 export async function loadNotificationPreferences(userId: string, teamId: string) {
   try {
     return normalizeNotificationPreferences(await withTimeout(
@@ -572,6 +619,29 @@ export async function createProfileAccessCode(userId: string, email: string, pho
     await nativeCreateAccessCode(userId, email, phone, code);
   }
   return code;
+}
+
+export async function requestAccountMerge(userId: string, primaryEmail: string, secondaryEmail: string) {
+  const normalizedPrimaryEmail = String(primaryEmail || '').trim().toLowerCase();
+  const normalizedSecondaryEmail = String(secondaryEmail || '').trim().toLowerCase();
+
+  if (!normalizedPrimaryEmail || !normalizedSecondaryEmail) {
+    throw new Error('Both account emails are required');
+  }
+
+  try {
+    return await withTimeout(
+      Promise.resolve(createAccountMergeRequest(userId, {
+        primaryEmail: normalizedPrimaryEmail,
+        secondaryEmail: normalizedSecondaryEmail
+      })),
+      'Account merge request',
+      primaryDataTimeoutMs
+    );
+  } catch (error) {
+    console.warn('[profile-service] Falling back to REST account merge request:', error);
+    return nativeCreateAccountMergeRequest(userId, normalizedPrimaryEmail, normalizedSecondaryEmail);
+  }
 }
 
 export async function loadProfileAccessCodes(userId: string): Promise<AccessCodeRecord[]> {

--- a/apps/app/src/pages/Profile.test.tsx
+++ b/apps/app/src/pages/Profile.test.tsx
@@ -1,0 +1,134 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Profile } from './Profile';
+import type { AuthState } from '../lib/types';
+
+const profileServiceMocks = vi.hoisted(() => ({
+    createProfileAccessCode: vi.fn(),
+    loadNotificationPreferences: vi.fn(),
+    loadNotificationTeams: vi.fn(),
+    loadParentTeams: vi.fn(),
+    loadProfileAccessCodes: vi.fn(),
+    loadProfileDocument: vi.fn(),
+    normalizeNotificationPreferences: vi.fn(() => ({ liveChat: false, liveScore: false, schedule: false })),
+    requestAccountMerge: vi.fn(),
+    saveNotificationPreferences: vi.fn(),
+    saveProfileDocument: vi.fn(),
+    uploadProfilePhoto: vi.fn()
+}));
+
+vi.mock('../lib/profileService', () => profileServiceMocks);
+vi.mock('../lib/authService', () => ({
+    describeAuthError: vi.fn(() => 'auth error'),
+    reloadCurrentUser: vi.fn(),
+    resendVerificationEmail: vi.fn(),
+    sendResetEmail: vi.fn(),
+    setCurrentUserPassword: vi.fn()
+}));
+vi.mock('../lib/pushService', () => ({
+    enablePushNotificationsForUser: vi.fn()
+}));
+vi.mock('../lib/useShellLayout', () => ({
+    useShellLayout: vi.fn(() => ({ isDesktopWeb: false }))
+}));
+
+const auth: AuthState = {
+    user: {
+        uid: 'user-1',
+        email: 'parent@example.com',
+        displayName: 'Parent User',
+        emailVerified: true
+    } as any,
+    profile: null,
+    loading: false,
+    error: null,
+    roles: ['parent'],
+    isParent: true,
+    isCoach: false,
+    isAdmin: false,
+    isPlatformAdmin: false,
+    refresh: vi.fn(),
+    signOut: vi.fn()
+};
+
+function renderProfile() {
+    return render(
+        <MemoryRouter>
+            <Profile auth={auth} />
+        </MemoryRouter>
+    );
+}
+
+describe('Profile account merge', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.stubGlobal('scrollTo', vi.fn());
+        vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+            callback(0);
+            return 0;
+        });
+        profileServiceMocks.loadProfileDocument.mockResolvedValue({ fullName: 'Parent User', signInMethod: 'password', hasPassword: true });
+        profileServiceMocks.loadNotificationTeams.mockResolvedValue([]);
+        profileServiceMocks.loadNotificationPreferences.mockResolvedValue({ liveChat: false, liveScore: false, schedule: false });
+        profileServiceMocks.loadProfileAccessCodes.mockResolvedValue([]);
+        profileServiceMocks.requestAccountMerge.mockResolvedValue('merge-1');
+    });
+
+    it('shows the merge entry point for parent-linked users', async () => {
+        profileServiceMocks.loadParentTeams.mockResolvedValue([{ id: 'team-1', name: 'Bears' }]);
+
+        renderProfile();
+
+        expect(await screen.findByRole('button', { name: 'Merge another account' })).toBeInTheDocument();
+    });
+
+    it('hides the merge entry point for users without parent-linked teams', async () => {
+        profileServiceMocks.loadParentTeams.mockResolvedValue([]);
+
+        renderProfile();
+
+        await waitFor(() => {
+            expect(profileServiceMocks.loadParentTeams).toHaveBeenCalledWith('user-1');
+        });
+        expect(screen.queryByRole('button', { name: 'Merge another account' })).not.toBeInTheDocument();
+    });
+
+    it('rejects invalid and same-account emails without calling the merge service', async () => {
+        profileServiceMocks.loadParentTeams.mockResolvedValue([{ id: 'team-1', name: 'Bears' }]);
+
+        renderProfile();
+
+        fireEvent.click(await screen.findByRole('button', { name: 'Merge another account' }));
+
+        fireEvent.click(screen.getByRole('button', { name: 'Request merge' }));
+        expect(await screen.findByText('Enter the email address for the other account.')).toBeInTheDocument();
+
+        fireEvent.change(screen.getByLabelText('Secondary account email'), { target: { value: 'not-an-email' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Request merge' }));
+        expect(await screen.findByText('Enter a valid email address.')).toBeInTheDocument();
+
+        fireEvent.change(screen.getByLabelText('Secondary account email'), { target: { value: 'parent@example.com' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Request merge' }));
+        expect(await screen.findByText('Enter a different email than the account you are signed in with.')).toBeInTheDocument();
+        expect(profileServiceMocks.requestAccountMerge).not.toHaveBeenCalled();
+    });
+
+    it('submits a valid merge request, clears the field, and shows pending verification', async () => {
+        profileServiceMocks.loadParentTeams.mockResolvedValue([{ id: 'team-1', name: 'Bears' }]);
+
+        renderProfile();
+
+        fireEvent.click(await screen.findByRole('button', { name: 'Merge another account' }));
+
+        const input = screen.getByLabelText('Secondary account email') as HTMLInputElement;
+        fireEvent.change(input, { target: { value: 'child@example.com' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Request merge' }));
+
+        await waitFor(() => {
+            expect(profileServiceMocks.requestAccountMerge).toHaveBeenCalledWith('user-1', 'parent@example.com', 'child@example.com');
+        });
+        expect(await screen.findByText('Merge request pending verification. We will verify the other email before moving any account data.')).toBeInTheDocument();
+        expect(input.value).toBe('');
+    });
+});

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -25,11 +25,13 @@ import {
 import { describeAuthError, reloadCurrentUser, resendVerificationEmail, sendResetEmail, setCurrentUserPassword } from '../lib/authService';
 import {
   createProfileAccessCode,
+  loadParentTeams,
   loadNotificationPreferences,
   loadNotificationTeams,
   loadProfileAccessCodes,
   loadProfileDocument,
   normalizeNotificationPreferences,
+  requestAccountMerge,
   saveNotificationPreferences,
   saveProfileDocument,
   uploadProfilePhoto
@@ -79,6 +81,9 @@ export function Profile({ auth }: { auth: AuthState }) {
   const [inviteEmail, setInviteEmail] = useState('');
   const [invitePhone, setInvitePhone] = useState('');
   const [generatedCode, setGeneratedCode] = useState('');
+  const [parentLinkedTeams, setParentLinkedTeams] = useState<NotificationTeam[]>([]);
+  const [accountMergeExpanded, setAccountMergeExpanded] = useState(false);
+  const [accountMergeEmail, setAccountMergeEmail] = useState('');
   const [newPassword, setNewPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [loading, setLoading] = useState(true);
@@ -88,6 +93,7 @@ export function Profile({ auth }: { auth: AuthState }) {
   const [notificationStatus, setNotificationStatus] = useState<Status | null>(null);
   const [passwordStatus, setPasswordStatus] = useState<Status | null>(null);
   const [inviteStatus, setInviteStatus] = useState<Status | null>(null);
+  const [accountMergeStatus, setAccountMergeStatus] = useState<Status | null>(null);
   const [copyStatus, setCopyStatus] = useState('');
   const [inviteHistoryExpanded, setInviteHistoryExpanded] = useState(false);
   const [activeProfileSection, setActiveProfileSection] = useState<ProfileSectionId>('account');
@@ -98,6 +104,7 @@ export function Profile({ auth }: { auth: AuthState }) {
   const signupLink = generatedCode ? buildSignupLink(generatedCode) : '';
   const visibleAccessCodes = inviteHistoryExpanded ? accessCodes : accessCodes.slice(0, collapsedInviteCount);
   const hiddenAccessCodeCount = Math.max(0, accessCodes.length - visibleAccessCodes.length);
+  const canRequestAccountMerge = parentLinkedTeams.length > 0;
 
   const selectProfileSection = (sectionId: ProfileSectionId) => {
     setActiveProfileSection(sectionId);
@@ -118,9 +125,10 @@ export function Profile({ auth }: { auth: AuthState }) {
       setProfileStatus(null);
       setNotificationStatus(null);
       setInviteStatus(null);
+      setAccountMergeStatus(null);
 
       try {
-        const [loadedProfile, teams, codes] = await Promise.all([
+        const [loadedProfile, teams, codes, parentTeams] = await Promise.all([
           loadProfileDocument(user.uid).catch((error) => {
             console.warn('[profile] Unable to load profile:', error);
             setProfileStatus({ message: 'Profile details could not be loaded yet.', tone: 'error' });
@@ -134,6 +142,11 @@ export function Profile({ auth }: { auth: AuthState }) {
           loadProfileAccessCodes(user.uid).catch((error) => {
             console.warn('[profile] Unable to load access codes:', error);
             setInviteStatus({ message: 'Unable to load invite history.', tone: 'error' });
+            return [];
+          }),
+          loadParentTeams(user.uid).catch((error) => {
+            console.warn('[profile] Unable to load parent-linked teams:', error);
+            setAccountMergeStatus({ message: 'Unable to load account merge options right now.', tone: 'error' });
             return [];
           })
         ]);
@@ -150,6 +163,9 @@ export function Profile({ auth }: { auth: AuthState }) {
         setPhotoFile(null);
         setPhotoChanged(false);
         setNotificationTeams(teams);
+        setParentLinkedTeams(parentTeams);
+        setAccountMergeExpanded(false);
+        setAccountMergeEmail('');
         setSelectedTeamId((current) => {
           if (current && teams.some((team) => team.id === current)) {
             return current;
@@ -432,6 +448,43 @@ export function Profile({ auth }: { auth: AuthState }) {
     }
   };
 
+  const submitAccountMerge = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!user?.uid) {
+      return;
+    }
+
+    const secondaryEmail = normalizeEmail(accountMergeEmail);
+    const primaryEmail = normalizeEmail(user.email);
+
+    if (!secondaryEmail) {
+      setAccountMergeStatus({ message: 'Enter the email address for the other account.', tone: 'error' });
+      return;
+    }
+    if (!isValidEmail(secondaryEmail)) {
+      setAccountMergeStatus({ message: 'Enter a valid email address.', tone: 'error' });
+      return;
+    }
+    if (secondaryEmail === primaryEmail) {
+      setAccountMergeStatus({ message: 'Enter a different email than the account you are signed in with.', tone: 'error' });
+      return;
+    }
+
+    setBusy('account-merge');
+    setAccountMergeStatus({ message: 'Preparing merge request...', tone: 'neutral' });
+
+    try {
+      await requestAccountMerge(user.uid, primaryEmail, secondaryEmail);
+      setAccountMergeEmail('');
+      setAccountMergeStatus({ message: 'Merge request pending verification. We will verify the other email before moving any account data.', tone: 'success' });
+    } catch (error) {
+      console.error('[profile] Unable to request account merge:', error);
+      setAccountMergeStatus({ message: 'Unable to request merge right now. Please try again.', tone: 'error' });
+    } finally {
+      setBusy('');
+    }
+  };
+
   const copyText = async (text: string, label: string) => {
     try {
       await navigator.clipboard.writeText(text);
@@ -544,6 +597,53 @@ export function Profile({ auth }: { auth: AuthState }) {
             <StatusMessage status={profileStatus} />
           </div>
         </form>
+
+        {canRequestAccountMerge ? (
+          <div className="mt-6 border-t border-gray-200 pt-6">
+            <div className="flex items-start justify-between gap-4">
+              <div>
+                <h3 className="text-base font-black text-gray-900">Merge another account</h3>
+                <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">Request a merge for another ALL PLAYS account you own. We will verify that email before any account data moves.</p>
+              </div>
+              {!accountMergeExpanded ? (
+                <button
+                  type="button"
+                  className="secondary-button shrink-0"
+                  onClick={() => {
+                    setAccountMergeExpanded(true);
+                    setAccountMergeStatus(null);
+                  }}
+                >
+                  Merge another account
+                </button>
+              ) : null}
+            </div>
+
+            {accountMergeExpanded ? (
+              <form className="mt-4 space-y-3 rounded-2xl border border-gray-200 bg-gray-50 p-4" onSubmit={submitAccountMerge} noValidate>
+                <label className="block">
+                  <span className="mb-1.5 block text-xs font-extrabold uppercase tracking-[0.04em] text-gray-500">Secondary account email</span>
+                  <input
+                    className="auth-input"
+                    type="email"
+                    aria-label="Secondary account email"
+                    value={accountMergeEmail}
+                    onChange={(event) => setAccountMergeEmail(event.target.value)}
+                    placeholder="other-email@example.com"
+                    autoComplete="email"
+                  />
+                </label>
+                <div className="flex flex-wrap items-center gap-2">
+                  <button type="submit" className="primary-button" disabled={busy === 'account-merge'}>
+                    {busy === 'account-merge' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Link2 className="h-4 w-4" aria-hidden="true" />}
+                    Request merge
+                  </button>
+                  <StatusMessage status={accountMergeStatus} />
+                </div>
+              </form>
+            ) : null}
+          </div>
+        ) : null}
       </section>
       ) : null}
 
@@ -830,6 +930,14 @@ function toDate(value: any): Date | null {
 function buildSignupLink(code: string) {
   const origin = window.location.protocol === 'capacitor:' ? 'https://allplays.ai' : window.location.origin;
   return `${origin}/login.html?code=${encodeURIComponent(code)}`;
+}
+
+function normalizeEmail(value: string | null | undefined) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function isValidEmail(email: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }
 
 function formatProfileSaveError(error: any) {

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -254,6 +254,16 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
                         { id: 'code-4', code: 'MNOP3456', email: '', phone: '', used: false, createdAt: { seconds: 1716940800 } }
                     ];
                 }
+
+                export async function loadParentTeams() {
+                    return [
+                        { id: 'team-1', name: 'Blue Team' }
+                    ];
+                }
+
+                export async function requestAccountMerge() {
+                    return;
+                }
             `
         });
     });


### PR DESCRIPTION
Closes #1542

## What changed
- added a parent-linked account merge entry point to the React Profile account section, hidden behind a collapsed "Merge another account" action
- added inline validation for blank, malformed, and same-account secondary emails, plus pending-verification success and error states
- added `loadParentTeams` and `requestAccountMerge` helpers in `profileService`, including normalized email handling and native Firestore REST fallback support
- added focused regression tests for the new service wrapper and Profile merge flow visibility, validation, and successful submission

## Why
The legacy profile page already lets linked parents request an account merge, but the React Profile route used by web/app/iOS/Android had no reachable entry point or service call. This closes that parity gap without changing unrelated profile, invite, notification, or security flows.

## Validation
- `npm test -- --run src/lib/profileService.test.ts src/pages/Profile.test.tsx`
- `npm run build`