### PR TITLE
Enable multi-file uploads in team media

### DIFF
--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -227,7 +227,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
     let uploaded = 0;
     let failed = 0;
     try {
-      await Promise.all(queueItems.map(async (queueItem, index) => {
+      for (const [index, queueItem] of queueItems.entries()) {
         const file = files[index];
         try {
           await uploadParentTeamMediaFile(teamId, activeFolder.id, file);
@@ -237,7 +237,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
           failed += 1;
           updateUploadQueueItem(queueItem.id, 'error', uploadError?.message || 'Upload failed.');
         }
-      }));
+      }
 
       if (uploaded > 0) {
         await refresh({ showLoading: false, preferredFolderId: activeFolder.id });

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
+import { flushSync } from 'react-dom';
 import { Link, Navigate, useParams } from 'react-router-dom';
 import {
   AlertCircle,
@@ -169,7 +170,9 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const uploadPhotos = async (files: File[]) => {
     if (!files.length || !activeFolder || creatingAlbum) return;
     const queueItems = files.map((file, index) => createUploadQueueItem(file, 'photo', index));
-    setUploadQueue((current) => [...queueItems, ...current].slice(0, 12));
+    flushSync(() => {
+      setUploadQueue((current) => [...queueItems, ...current].slice(0, 12));
+    });
     setUploading('photo');
     setError('');
     setMessage(`Uploading ${files.length} photo${files.length === 1 ? '' : 's'}...`);
@@ -215,7 +218,9 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const uploadFiles = async (files: File[]) => {
     if (!files.length || !activeFolder || creatingAlbum) return;
     const queueItems = files.map((file, index) => createUploadQueueItem(file, 'file', index));
-    setUploadQueue((current) => [...queueItems, ...current].slice(0, 12));
+    flushSync(() => {
+      setUploadQueue((current) => [...queueItems, ...current].slice(0, 12));
+    });
     setUploading('file');
     setError('');
     setMessage(`Uploading ${files.length} file${files.length === 1 ? '' : 's'}...`);

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -48,6 +48,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const [albumVisibility, setAlbumVisibility] = useState<'team' | 'private'>('team');
   const [loading, setLoading] = useState(true);
   const [uploading, setUploading] = useState('');
+  const [uploadQueue, setUploadQueue] = useState<UploadQueueItem[]>([]);
   const [creatingAlbum, setCreatingAlbum] = useState(false);
   const [deletingItemId, setDeletingItemId] = useState('');
   const [renamingItemId, setRenamingItemId] = useState('');
@@ -161,26 +162,36 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const emptyStateLabel = selectedMediaType === 'all' ? 'media' : selectedMediaTypeLabel.toLowerCase();
   const featured = activeFolder?.items[0] || allItems[0] || null;
 
+  const updateUploadQueueItem = (id: string, nextStatus: UploadQueueItem['status'], errorMessage = '') => {
+    setUploadQueue((current) => current.map((item) => item.id === id ? { ...item, status: nextStatus, errorMessage } : item));
+  };
+
   const uploadPhotos = async (files: File[]) => {
     if (!files.length || !activeFolder || creatingAlbum) return;
+    const queueItems = files.map((file, index) => createUploadQueueItem(file, 'photo', index));
+    setUploadQueue((current) => [...queueItems, ...current].slice(0, 12));
     setUploading('photo');
     setError('');
     setMessage(`Uploading ${files.length} photo${files.length === 1 ? '' : 's'}...`);
     let uploaded = 0;
     let failed = 0;
     try {
-      for (const file of files) {
+      await Promise.all(queueItems.map(async (queueItem, index) => {
+        const file = files[index];
         if (!isSupportedPhotoUpload(file)) {
           failed += 1;
-          continue;
+          updateUploadQueueItem(queueItem.id, 'error', 'Unsupported image or file exceeds 10 MB.');
+          return;
         }
         try {
           await uploadParentTeamMediaPhoto(teamId, activeFolder.id, file);
           uploaded += 1;
+          updateUploadQueueItem(queueItem.id, 'success');
         } catch {
           failed += 1;
+          updateUploadQueueItem(queueItem.id, 'error', 'Upload failed.');
         }
-      }
+      }));
 
       if (uploaded > 0) {
         const resultMessage = getPhotoUploadMessage(uploaded, failed);
@@ -201,18 +212,41 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
     }
   };
 
-  const uploadFile = async (file: File | null | undefined) => {
-    if (!file || !activeFolder || creatingAlbum) return;
+  const uploadFiles = async (files: File[]) => {
+    if (!files.length || !activeFolder || creatingAlbum) return;
+    const queueItems = files.map((file, index) => createUploadQueueItem(file, 'file', index));
+    setUploadQueue((current) => [...queueItems, ...current].slice(0, 12));
     setUploading('file');
     setError('');
-    setMessage('Uploading file...');
+    setMessage(`Uploading ${files.length} file${files.length === 1 ? '' : 's'}...`);
+    let uploaded = 0;
+    let failed = 0;
     try {
-      await uploadParentTeamMediaFile(teamId, activeFolder.id, file);
-      setMessage('File uploaded.');
-      await refresh({ showLoading: false });
-    } catch (uploadError: any) {
-      setError(uploadError?.message || 'File upload failed.');
-      setMessage('');
+      await Promise.all(queueItems.map(async (queueItem, index) => {
+        const file = files[index];
+        try {
+          await uploadParentTeamMediaFile(teamId, activeFolder.id, file);
+          uploaded += 1;
+          updateUploadQueueItem(queueItem.id, 'success');
+        } catch (uploadError: any) {
+          failed += 1;
+          updateUploadQueueItem(queueItem.id, 'error', uploadError?.message || 'Upload failed.');
+        }
+      }));
+
+      if (uploaded > 0) {
+        await refresh({ showLoading: false, preferredFolderId: activeFolder.id });
+        const resultMessage = getFileUploadMessage(uploaded, failed);
+        if (failed > 0) {
+          setError(resultMessage);
+          setMessage('');
+        } else {
+          setMessage(resultMessage);
+        }
+      } else {
+        setMessage('');
+        setError(failed > 0 ? 'No files uploaded.' : 'File upload failed.');
+      }
     } finally {
       setUploading('');
       if (fileInputRef.current) fileInputRef.current.value = '';
@@ -384,7 +418,28 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
             </button>
           </div>
           <input ref={photoInputRef} className="hidden" type="file" accept="image/*" multiple onChange={(event) => uploadPhotos(Array.from(event.target.files || []))} />
-          <input ref={fileInputRef} className="hidden" type="file" accept=".pdf,.doc,.docx,.xls,.xlsx,.csv,.txt,.ppt,.pptx" onChange={(event) => uploadFile(event.target.files?.[0])} />
+          <input ref={fileInputRef} className="hidden" type="file" accept=".pdf,.doc,.docx,.xls,.xlsx,.csv,.txt,.ppt,.pptx" multiple onChange={(event) => uploadFiles(Array.from(event.target.files || []))} />
+          {uploadQueue.length ? (
+            <div className="mt-3 space-y-2 rounded-2xl border border-gray-200 bg-gray-50 p-3" aria-live="polite" aria-label="Upload progress list">
+              <div className="text-xs font-black uppercase tracking-wide text-gray-600">Upload progress</div>
+              {uploadQueue.map((item) => (
+                <div key={item.id} className="rounded-xl border border-gray-200 bg-white p-2">
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-black text-gray-950">{item.name}</div>
+                      <div className={`text-[11px] font-semibold ${item.status === 'error' ? 'text-rose-700' : item.status === 'success' ? 'text-emerald-700' : 'text-gray-500'}`}>
+                        {item.status === 'uploading' ? 'Uploading…' : item.status === 'success' ? 'Uploaded' : item.errorMessage || 'Upload failed.'}
+                      </div>
+                    </div>
+                    <span className={`rounded-full px-2 py-0.5 text-[10px] font-black uppercase ${item.kind === 'photo' ? 'bg-primary-50 text-primary-700' : 'bg-amber-50 text-amber-700'}`}>{item.kind}</span>
+                  </div>
+                  <div className="mt-2 h-2 overflow-hidden rounded-full bg-gray-100" aria-hidden="true">
+                    <div className={`h-full rounded-full transition-all ${item.status === 'success' ? 'w-full bg-emerald-500' : item.status === 'error' ? 'w-full bg-rose-500' : 'w-2/3 bg-primary-500'}`} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : null}
           <form className="mt-3 grid gap-2 sm:grid-cols-[1fr_1fr_auto]" onSubmit={addLink}>
             <input className="auth-input" value={linkTitle} onChange={(event) => setLinkTitle(event.target.value)} placeholder="Video or link title" />
             <input className="auth-input" value={linkUrl} onChange={(event) => setLinkUrl(event.target.value)} placeholder="https://..." inputMode="url" />
@@ -431,6 +486,13 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
 }
 
 type MediaTypeFilter = 'all' | 'photos' | 'videos' | 'files';
+type UploadQueueItem = {
+  id: string;
+  kind: 'photo' | 'file';
+  name: string;
+  status: 'uploading' | 'success' | 'error';
+  errorMessage: string;
+};
 
 const MEDIA_TYPE_FILTERS: { id: MediaTypeFilter; label: string }[] = [
   { id: 'all', label: 'All' },
@@ -448,6 +510,22 @@ function getPhotoUploadMessage(uploaded: number, failed: number) {
   const uploadedLabel = `${uploaded} photo${uploaded === 1 ? '' : 's'} uploaded`;
   if (failed > 0) return `${uploadedLabel}; ${failed} failed.`;
   return `${uploadedLabel}.`;
+}
+
+function getFileUploadMessage(uploaded: number, failed: number) {
+  const uploadedLabel = `${uploaded} file${uploaded === 1 ? '' : 's'} uploaded`;
+  if (failed > 0) return `${uploadedLabel}; ${failed} failed.`;
+  return `${uploadedLabel}.`;
+}
+
+function createUploadQueueItem(file: File, kind: 'photo' | 'file', index: number): UploadQueueItem {
+  return {
+    id: `${kind}-${file.name || 'upload'}-${file.size || 0}-${index}`,
+    kind,
+    name: file.name || `Untitled ${kind}`,
+    status: 'uploading',
+    errorMessage: ''
+  };
 }
 
 function isPhotoMediaItem(item: TeamMediaItem) {

--- a/tests/unit/app-team-media.test.jsx
+++ b/tests/unit/app-team-media.test.jsx
@@ -200,7 +200,7 @@ describe('React app TeamMedia upload flow', () => {
     await act(async () => root.unmount());
   });
 
-  it('uploads every selected file concurrently and keeps the file picker multi-select enabled', async () => {
+  it('uploads every selected file sequentially and keeps the file picker multi-select enabled', async () => {
     const pendingResolvers = [];
     parentToolsServiceMocks.uploadParentTeamMediaFile.mockImplementation(() => new Promise((resolve) => {
       pendingResolvers.push(resolve);
@@ -218,13 +218,22 @@ describe('React app TeamMedia upload flow', () => {
     changeFiles(fileInput, files);
     await act(async () => {});
 
-    expect(parentToolsServiceMocks.uploadParentTeamMediaFile).toHaveBeenCalledTimes(2);
+    expect(parentToolsServiceMocks.uploadParentTeamMediaFile).toHaveBeenCalledTimes(1);
+    expect(parentToolsServiceMocks.uploadParentTeamMediaFile).toHaveBeenNthCalledWith(1, 'team-1', 'folder-1', files[0]);
     expect(container.textContent).toContain('report.pdf');
     expect(container.textContent).toContain('waiver.docx');
     expect(container.textContent).toContain('Uploading');
 
     await act(async () => {
-      pendingResolvers.forEach((resolve) => resolve(undefined));
+      pendingResolvers[0](undefined);
+    });
+    await act(async () => {});
+
+    expect(parentToolsServiceMocks.uploadParentTeamMediaFile).toHaveBeenCalledTimes(2);
+    expect(parentToolsServiceMocks.uploadParentTeamMediaFile).toHaveBeenNthCalledWith(2, 'team-1', 'folder-1', files[1]);
+
+    await act(async () => {
+      pendingResolvers[1](undefined);
     });
     await act(async () => {});
 

--- a/tests/unit/app-team-media.test.jsx
+++ b/tests/unit/app-team-media.test.jsx
@@ -194,6 +194,7 @@ describe('React app TeamMedia upload flow', () => {
     expect(container.textContent).toContain('Upload progress');
     expect(container.textContent).toContain('tipoff.jpg');
     expect(container.textContent).toContain('bench.png');
+    expect((container.textContent.match(/Uploaded/g) || []).length).toBe(2);
     expect(container.textContent).toContain('2 photos uploaded.');
 
     await act(async () => root.unmount());
@@ -226,6 +227,8 @@ describe('React app TeamMedia upload flow', () => {
       pendingResolvers.forEach((resolve) => resolve(undefined));
     });
     await act(async () => {});
+
+    expect((container.textContent.match(/Uploaded/g) || []).length).toBe(2);
 
     await act(async () => root.unmount());
   });

--- a/tests/unit/app-team-media.test.jsx
+++ b/tests/unit/app-team-media.test.jsx
@@ -105,6 +105,16 @@ function selectValue(select, value) {
   });
 }
 
+function changeFiles(input, files) {
+  act(() => {
+    Object.defineProperty(input, 'files', {
+      configurable: true,
+      value: files,
+    });
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+  });
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   parentToolsServiceMocks.updateTeamMediaItemForApp.mockResolvedValue(undefined);
@@ -158,6 +168,68 @@ describe('React app TeamMedia rename flow', () => {
   });
 });
 
+
+describe('React app TeamMedia upload flow', () => {
+  const uploadableModel = () => mediaModel({
+    canManage: true,
+    canContribute: true,
+  });
+
+  it('uploads every selected photo and renders per-file status rows', async () => {
+    parentToolsServiceMocks.uploadParentTeamMediaPhoto.mockResolvedValue(undefined);
+
+    const { container, root } = await renderTeamMedia(uploadableModel());
+    const photoInput = container.querySelector('input[accept="image/*"]');
+    const files = [
+      new File(['first'], 'tipoff.jpg', { type: 'image/jpeg' }),
+      new File(['second'], 'bench.png', { type: 'image/png' }),
+    ];
+
+    changeFiles(photoInput, files);
+    await act(async () => {});
+
+    expect(parentToolsServiceMocks.uploadParentTeamMediaPhoto).toHaveBeenCalledTimes(2);
+    expect(parentToolsServiceMocks.uploadParentTeamMediaPhoto).toHaveBeenNthCalledWith(1, 'team-1', 'folder-1', files[0]);
+    expect(parentToolsServiceMocks.uploadParentTeamMediaPhoto).toHaveBeenNthCalledWith(2, 'team-1', 'folder-1', files[1]);
+    expect(container.textContent).toContain('Upload progress');
+    expect(container.textContent).toContain('tipoff.jpg');
+    expect(container.textContent).toContain('bench.png');
+    expect(container.textContent).toContain('2 photos uploaded.');
+
+    await act(async () => root.unmount());
+  });
+
+  it('uploads every selected file concurrently and keeps the file picker multi-select enabled', async () => {
+    const pendingResolvers = [];
+    parentToolsServiceMocks.uploadParentTeamMediaFile.mockImplementation(() => new Promise((resolve) => {
+      pendingResolvers.push(resolve);
+    }));
+
+    const { container, root } = await renderTeamMedia(uploadableModel());
+    const fileInput = container.querySelector('input[accept=".pdf,.doc,.docx,.xls,.xlsx,.csv,.txt,.ppt,.pptx"]');
+    const files = [
+      new File(['alpha'], 'report.pdf', { type: 'application/pdf' }),
+      new File(['beta'], 'waiver.docx', { type: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document' }),
+    ];
+
+    expect(fileInput.hasAttribute('multiple')).toBe(true);
+
+    changeFiles(fileInput, files);
+    await act(async () => {});
+
+    expect(parentToolsServiceMocks.uploadParentTeamMediaFile).toHaveBeenCalledTimes(2);
+    expect(container.textContent).toContain('report.pdf');
+    expect(container.textContent).toContain('waiver.docx');
+    expect(container.textContent).toContain('Uploading');
+
+    await act(async () => {
+      pendingResolvers.forEach((resolve) => resolve(undefined));
+    });
+    await act(async () => {});
+
+    await act(async () => root.unmount());
+  });
+});
 
 describe('React app TeamMedia move flow', () => {
   const twoAlbumModel = () => mediaModel({


### PR DESCRIPTION
Closes #1569

## What changed
- updated the React Team Media upload handlers to accept every selected photo or document instead of only the first file
- switched photo and file uploads to concurrent per-file requests using the existing parent tools service calls
- added an in-page upload progress list that shows each file's upload state and final success or failure

## Why
The React app was dropping all but the first selected file, which left it behind legacy behavior. This patch restores multi-select uploads with per-file feedback while keeping the change set small and localized to the existing Team Media page.

## Validation
- `npx vitest run tests/unit/app-team-media.test.jsx --reporter=verbose`
- `npm run app:build`