### PR TITLE
Support batch team media document uploads

### DIFF
--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState, type FormEvent } from 'react';
 import { flushSync } from 'react-dom';
 import { Link, Navigate, useParams } from 'react-router-dom';
+import { isSupportedTeamMediaDocument } from '../../../../js/team-media-utils.js';
 import {
   AlertCircle,
   CheckCircle2,
@@ -229,6 +230,11 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
     try {
       for (const [index, queueItem] of queueItems.entries()) {
         const file = files[index];
+        if (!isSupportedTeamMediaDocument(file)) {
+          failed += 1;
+          updateUploadQueueItem(queueItem.id, 'error', 'Unsupported file or file exceeds 10 MB.');
+          continue;
+        }
         try {
           await uploadParentTeamMediaFile(teamId, activeFolder.id, file);
           uploaded += 1;
@@ -250,11 +256,11 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
         }
       } else {
         setMessage('');
-        setError(failed > 0 ? 'No files uploaded.' : 'File upload failed.');
+        setError(failed > 0 ? 'No files uploaded. Choose supported documents that are 10 MB or smaller.' : 'File upload failed.');
       }
     } finally {
       setUploading('');
-      if (fileInputRef.current) fileInputRef.current.value = '';
+      if (uploaded > 0 && fileInputRef.current) fileInputRef.current.value = '';
     }
   };
 

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -260,7 +260,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
       }
     } finally {
       setUploading('');
-      if (uploaded > 0 && fileInputRef.current) fileInputRef.current.value = '';
+      if (fileInputRef.current) fileInputRef.current.value = '';
     }
   };
 

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -643,6 +643,38 @@ describe('React app parent tools integration', () => {
         await waitForText(container, '1 photo uploaded; 1 failed.');
     });
 
+    it('uploads multiple app team media files in one batch, skips invalid files, and refreshes once', async () => {
+        let resolveUpload;
+        const pendingUpload = new Promise((resolve) => {
+            resolveUpload = resolve;
+        });
+        serviceMocks.uploadParentTeamMediaFile.mockImplementation(() => pendingUpload);
+        const { container } = await renderParentTools('/teams/team-1/media');
+        await waitForText(container, 'Bears media');
+
+        const photoButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent.trim().includes('Photo'));
+        const fileButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent.trim().includes('File'));
+        const fileInput = container.querySelector('input[accept=".pdf,.doc,.docx,.xls,.xlsx,.csv,.txt,.ppt,.pptx"]');
+        const invalidFile = new File(['image'], 'photo.png', { type: 'image/png' });
+        const validFile = new File(['doc'], 'packet.pdf', { type: 'application/pdf' });
+        expect(fileInput.hasAttribute('multiple')).toBe(true);
+        Object.defineProperty(fileInput, 'files', { value: [invalidFile, validFile], configurable: true });
+        await act(async () => {
+            fileInput.dispatchEvent(new Event('change', { bubbles: true }));
+        });
+        await vi.waitUntil(() => serviceMocks.uploadParentTeamMediaFile.mock.calls.length === 1);
+        expect(photoButton.disabled).toBe(true);
+        expect(fileButton.disabled).toBe(true);
+
+        expect(serviceMocks.uploadParentTeamMediaFile).toHaveBeenCalledWith('team-1', 'folder-1', validFile);
+        await act(async () => {
+            resolveUpload();
+        });
+        expect(serviceMocks.loadTeamMediaForApp).toHaveBeenCalledTimes(2);
+        await waitForText(container, '1 file uploaded; 1 failed.');
+        expect(container.textContent).toContain('Unsupported file or file exceeds 10 MB.');
+    });
+
     it('loads team media, uploads photos/files, adds links, and opens media items', async () => {
         const { container } = await renderParentTools('/teams/team-1/media');
         await waitForText(container, 'Bears media');

--- a/tests/unit/app-team-media.test.jsx
+++ b/tests/unit/app-team-media.test.jsx
@@ -241,6 +241,25 @@ describe('React app TeamMedia upload flow', () => {
 
     await act(async () => root.unmount());
   });
+
+  it('skips invalid files, uploads remaining valid documents, and reports partial failure', async () => {
+    parentToolsServiceMocks.uploadParentTeamMediaFile.mockResolvedValue(undefined);
+
+    const { container, root } = await renderTeamMedia(uploadableModel());
+    const fileInput = container.querySelector('input[accept=".pdf,.doc,.docx,.xls,.xlsx,.csv,.txt,.ppt,.pptx"]');
+    const invalidFile = new File(['image'], 'photo.png', { type: 'image/png' });
+    const validFile = new File(['alpha'], 'report.pdf', { type: 'application/pdf' });
+
+    changeFiles(fileInput, [invalidFile, validFile]);
+    await act(async () => {});
+
+    expect(parentToolsServiceMocks.uploadParentTeamMediaFile).toHaveBeenCalledTimes(1);
+    expect(parentToolsServiceMocks.uploadParentTeamMediaFile).toHaveBeenCalledWith('team-1', 'folder-1', validFile);
+    expect(container.textContent).toContain('Unsupported file or file exceeds 10 MB.');
+    expect(container.textContent).toContain('1 file uploaded; 1 failed.');
+
+    await act(async () => root.unmount());
+  });
 });
 
 describe('React app TeamMedia move flow', () => {

--- a/tests/unit/app-team-media.test.jsx
+++ b/tests/unit/app-team-media.test.jsx
@@ -260,6 +260,28 @@ describe('React app TeamMedia upload flow', () => {
 
     await act(async () => root.unmount());
   });
+
+  it('clears the file picker after failed uploads so the same selection can be retried', async () => {
+    parentToolsServiceMocks.uploadParentTeamMediaFile.mockRejectedValue(new Error('storage/retry'));
+
+    const { container, root } = await renderTeamMedia(uploadableModel());
+    const fileInput = container.querySelector('input[accept=".pdf,.doc,.docx,.xls,.xlsx,.csv,.txt,.ppt,.pptx"]');
+    const file = new File(['alpha'], 'report.pdf', { type: 'application/pdf' });
+
+    Object.defineProperty(fileInput, 'value', {
+      configurable: true,
+      writable: true,
+      value: 'C\\fakepath\\report.pdf',
+    });
+    changeFiles(fileInput, [file]);
+    await act(async () => {});
+
+    expect(parentToolsServiceMocks.uploadParentTeamMediaFile).toHaveBeenCalledWith('team-1', 'folder-1', file);
+    expect(fileInput.value).toBe('');
+    expect(container.textContent).toContain('No files uploaded. Choose supported documents that are 10 MB or smaller.');
+
+    await act(async () => root.unmount());
+  });
 });
 
 describe('React app TeamMedia move flow', () => {


### PR DESCRIPTION
Closes #1545

## What changed
- validated each selected Team Media document in the React app before upload so unsupported or oversized files fail individually without blocking valid files
- kept the existing sequential batch file upload flow, but now refresh the active album once after successful uploads and preserve the file selection when a batch fully fails
- added focused unit and integration coverage for multi-file document selection, partial failure feedback, disabled upload actions during upload, and single-refresh batch behavior

## Why
The React Team Media File action already supported batch selection, but it did not mirror legacy document validation behavior. This patch brings document uploads in line with the expected UX by giving clear per-file failures while still uploading the valid files in the same batch.