### PR TITLE
Show official status in admin users tab

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -242,8 +242,15 @@
             <div class="bg-white rounded-xl shadow-sm border border-gray-200 overflow-hidden">
                 <div class="p-4 border-b border-gray-200 flex justify-between items-center">
                     <h2 class="text-lg font-semibold text-gray-900">All Users</h2>
-                    <input type="text" id="search-users" placeholder="Search users..."
-                        class="px-3 py-1 border border-gray-300 rounded-md text-sm">
+                    <div class="flex items-center gap-3">
+                        <select id="filter-users-official-status" class="px-3 py-1 border border-gray-300 rounded-md text-sm">
+                            <option value="all">All users</option>
+                            <option value="officials">Officials only</option>
+                            <option value="non-officials">Non-officials only</option>
+                        </select>
+                        <input type="text" id="search-users" placeholder="Search users, officials, or teams..."
+                            class="px-3 py-1 border border-gray-300 rounded-md text-sm">
+                    </div>
                 </div>
                 <div class="overflow-x-auto">
                     <table class="min-w-full divide-y divide-gray-200">
@@ -258,6 +265,9 @@
                                 <th
                                     class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                                     Phone</th>
+                                <th
+                                    class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    Official</th>
                                 <th
                                     class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                                     Last Active</th>

--- a/js/admin-user-official-links.js
+++ b/js/admin-user-official-links.js
@@ -1,0 +1,80 @@
+export function normalizeOfficialLinkEmail(email) {
+    return String(email || '').trim().toLowerCase();
+}
+
+export function buildOfficialUserLookup(officialEntries = []) {
+    const lookup = new Map();
+
+    officialEntries.forEach((entry) => {
+        const email = normalizeOfficialLinkEmail(entry?.official?.email);
+        if (!email) return;
+
+        const existing = lookup.get(email) || {
+            email,
+            teamIds: new Set(),
+            teamNames: new Set(),
+            officialNames: new Set()
+        };
+
+        if (entry?.teamId) existing.teamIds.add(String(entry.teamId));
+        if (entry?.teamName) existing.teamNames.add(String(entry.teamName).trim());
+
+        const officialName = String(entry?.official?.name || entry?.official?.displayName || '').trim();
+        if (officialName) existing.officialNames.add(officialName);
+
+        lookup.set(email, existing);
+    });
+
+    return new Map(Array.from(lookup.entries()).map(([email, summary]) => [email, {
+        email,
+        teamIds: Array.from(summary.teamIds),
+        teamNames: Array.from(summary.teamNames).sort((a, b) => a.localeCompare(b)),
+        officialNames: Array.from(summary.officialNames).sort((a, b) => a.localeCompare(b))
+    }]));
+}
+
+export function getOfficialUserSummary(user = {}, lookup = new Map()) {
+    const email = normalizeOfficialLinkEmail(user?.email);
+    if (!email) return null;
+
+    const summary = lookup.get(email);
+    if (!summary) return null;
+
+    return {
+        ...summary,
+        teamCount: Array.isArray(summary.teamIds) ? summary.teamIds.length : 0
+    };
+}
+
+export function formatOfficialUserSummary(summary) {
+    if (!summary) return '';
+
+    const teamNames = Array.isArray(summary.teamNames) ? summary.teamNames : [];
+    if (!teamNames.length) {
+        return summary.teamCount === 1 ? '1 team' : `${summary.teamCount} teams`;
+    }
+
+    if (teamNames.length <= 2) {
+        return `${summary.teamCount === 1 ? '1 team' : `${summary.teamCount} teams`}: ${teamNames.join(', ')}`;
+    }
+
+    return `${summary.teamCount} teams: ${teamNames.slice(0, 2).join(', ')} +${teamNames.length - 2} more`;
+}
+
+export function matchesOfficialUserSearch(user = {}, summary = null, term = '') {
+    const normalizedTerm = String(term || '').trim().toLowerCase();
+    if (!normalizedTerm) return true;
+
+    const haystack = [
+        user?.email,
+        user?.fullName,
+        user?.phone,
+        summary ? 'official' : '',
+        ...(summary?.teamNames || []),
+        ...(summary?.officialNames || [])
+    ]
+        .map((value) => String(value || '').toLowerCase())
+        .join(' ');
+
+    return haystack.includes(normalizedTerm);
+}

--- a/js/admin-user-official-links.js
+++ b/js/admin-user-official-links.js
@@ -2,15 +2,31 @@ export function normalizeOfficialLinkEmail(email) {
     return String(email || '').trim().toLowerCase();
 }
 
+export function normalizeOfficialLinkPhone(phone) {
+    const digits = String(phone || '').replace(/\D/g, '');
+    if (digits.length === 11 && digits.startsWith('1')) {
+        return digits.slice(1);
+    }
+    return digits;
+}
+
+function getOfficialLookupKeys(official = {}) {
+    return [
+        normalizeOfficialLinkEmail(official.email),
+        normalizeOfficialLinkPhone(official.phone)
+    ].filter(Boolean);
+}
+
 export function buildOfficialUserLookup(officialEntries = []) {
     const lookup = new Map();
 
     officialEntries.forEach((entry) => {
-        const email = normalizeOfficialLinkEmail(entry?.official?.email);
-        if (!email) return;
+        const lookupKeys = getOfficialLookupKeys(entry?.official);
+        if (!lookupKeys.length) return;
 
-        const existing = lookup.get(email) || {
-            email,
+        const existing = lookupKeys.map((key) => lookup.get(key)).find(Boolean) || {
+            email: normalizeOfficialLinkEmail(entry?.official?.email) || null,
+            phone: normalizeOfficialLinkPhone(entry?.official?.phone) || null,
             teamIds: new Set(),
             teamNames: new Set(),
             officialNames: new Set()
@@ -22,11 +38,12 @@ export function buildOfficialUserLookup(officialEntries = []) {
         const officialName = String(entry?.official?.name || entry?.official?.displayName || '').trim();
         if (officialName) existing.officialNames.add(officialName);
 
-        lookup.set(email, existing);
+        lookupKeys.forEach((key) => lookup.set(key, existing));
     });
 
-    return new Map(Array.from(lookup.entries()).map(([email, summary]) => [email, {
-        email,
+    return new Map(Array.from(lookup.entries()).map(([key, summary]) => [key, {
+        email: summary.email,
+        phone: summary.phone,
         teamIds: Array.from(summary.teamIds),
         teamNames: Array.from(summary.teamNames).sort((a, b) => a.localeCompare(b)),
         officialNames: Array.from(summary.officialNames).sort((a, b) => a.localeCompare(b))
@@ -35,9 +52,8 @@ export function buildOfficialUserLookup(officialEntries = []) {
 
 export function getOfficialUserSummary(user = {}, lookup = new Map()) {
     const email = normalizeOfficialLinkEmail(user?.email);
-    if (!email) return null;
-
-    const summary = lookup.get(email);
+    const phone = normalizeOfficialLinkPhone(user?.phone);
+    const summary = (email && lookup.get(email)) || (phone && lookup.get(phone)) || null;
     if (!summary) return null;
 
     return {

--- a/js/admin.js
+++ b/js/admin.js
@@ -1,6 +1,7 @@
 import {
     getTeams,
     getAllUsers,
+    getOfficials,
     deleteTeam,
     getTelemetryEvents,
     getTelemetryDaily,
@@ -21,9 +22,16 @@ import {
     validateAdminRegistrationFormPayload
 } from './admin-registration-forms.js?v=3';
 import { buildRecentGameResultsRows } from './admin-game-results.js?v=1';
+import {
+    buildOfficialUserLookup,
+    formatOfficialUserSummary,
+    getOfficialUserSummary,
+    matchesOfficialUserSearch
+} from './admin-user-official-links.js?v=1';
 
 let allTeams = [];
 let allUsers = [];
+let officialUserLookup = new Map();
 let currentUser = null; // Declare currentUser
 let showInactiveTeams = false;
 let activeRegistrationTeam = null;
@@ -88,7 +96,8 @@ async function loadData() {
         // Load game stats for all teams and telemetry in parallel after core data is available.
         await Promise.all([
             loadGameStats(),
-            loadTelemetryData({ silent: true })
+            loadTelemetryData({ silent: true }),
+            loadOfficialUserLinks()
         ]);
 
         updateDashboard();
@@ -102,6 +111,24 @@ async function loadData() {
 }
 
 let allGames = [];
+
+async function loadOfficialUserLinks() {
+    const officialEntries = (await Promise.all(allTeams.map(async (team) => {
+        try {
+            const officials = await getOfficials(team.id);
+            return officials.map((official) => ({
+                teamId: team.id,
+                teamName: team.name || 'Team',
+                official
+            }));
+        } catch (error) {
+            console.warn('Failed to load officials for admin users view:', team.id, error);
+            return [];
+        }
+    }))).flat();
+
+    officialUserLookup = buildOfficialUserLookup(officialEntries);
+}
 
 async function loadGameStats() {
     // Load games from all teams
@@ -645,6 +672,8 @@ function renderTeams(teams) {
 function renderUsers(users) {
     const tbody = document.getElementById('users-table-body');
     tbody.innerHTML = users.map(u => {
+        const officialSummary = getOfficialUserSummary(u, officialUserLookup);
+        const officialSummaryText = formatOfficialUserSummary(officialSummary);
         // Determine verification status:
         // - emailVerificationRequired=true + not verified → unverified (red)
         // - emailVerificationRequired not set → signed up via Google/OAuth (inherently verified)
@@ -658,13 +687,21 @@ function renderUsers(users) {
         return `
         <tr>
             <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
-                ${escapeHtml(u.email || '-')}
+                <div class="flex items-center gap-2">
+                    <span>${escapeHtml(u.email || '-')}</span>
+                    ${officialSummary ? '<span class="inline-flex items-center rounded-full bg-emerald-100 px-2 py-0.5 text-xs font-semibold text-emerald-700">Official</span>' : ''}
+                </div>
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                 ${escapeHtml(u.fullName || '-')}
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                 ${escapeHtml(u.phone || '-')}
+            </td>
+            <td class="px-6 py-4 text-sm text-gray-500">
+                ${officialSummary
+                ? `<div class="text-sm text-gray-700">${escapeHtml(officialSummaryText)}</div>`
+                : '<span class="text-gray-400">-</span>'}
             </td>
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                 ${u.updatedAt?.toDate ? u.updatedAt.toDate().toLocaleDateString() : '-'}
@@ -993,14 +1030,20 @@ function setupSearch() {
         renderTeams(filtered);
     });
 
-    document.getElementById('search-users').addEventListener('input', (e) => {
-        const term = e.target.value.toLowerCase();
-        const filtered = allUsers.filter(u =>
-            (u.email || '').toLowerCase().includes(term) ||
-            (u.fullName || '').toLowerCase().includes(term)
-        );
+    const filterUsers = () => {
+        const term = (document.getElementById('search-users')?.value || '').toLowerCase();
+        const officialFilter = document.getElementById('filter-users-official-status')?.value || 'all';
+        const filtered = allUsers.filter((u) => {
+            const officialSummary = getOfficialUserSummary(u, officialUserLookup);
+            if (officialFilter === 'officials' && !officialSummary) return false;
+            if (officialFilter === 'non-officials' && officialSummary) return false;
+            return matchesOfficialUserSearch(u, officialSummary, term);
+        });
         renderUsers(filtered);
-    });
+    };
+
+    document.getElementById('search-users').addEventListener('input', filterUsers);
+    document.getElementById('filter-users-official-status')?.addEventListener('change', filterUsers);
 
     const telemetryRange = document.getElementById('telemetry-range');
     const telemetryRefresh = document.getElementById('telemetry-refresh');

--- a/tests/unit/admin-user-official-links.test.js
+++ b/tests/unit/admin-user-official-links.test.js
@@ -35,6 +35,7 @@ describe('admin users official links', () => {
 
         expect(summary).toEqual({
             email: 'ref@one.com',
+            phone: null,
             teamIds: ['team-1', 'team-2'],
             teamNames: ['Blue Jays', 'Storm'],
             officialNames: ['Robin Ref'],
@@ -44,6 +45,28 @@ describe('admin users official links', () => {
         expect(matchesOfficialUserSearch({ fullName: 'Robin Ref' }, summary, 'storm')).toBe(true);
         expect(matchesOfficialUserSearch({ fullName: 'Robin Ref' }, summary, 'official')).toBe(true);
         expect(matchesOfficialUserSearch({ fullName: 'Robin Ref' }, summary, 'wolves')).toBe(false);
+    });
+
+    it('matches phone-only officials by normalized phone number', () => {
+        const lookup = buildOfficialUserLookup([
+            {
+                teamId: 'team-4',
+                teamName: 'Falcons',
+                official: { phone: '+1 (555) 123-4567', name: 'Pat Phone' }
+            }
+        ]);
+
+        const summary = getOfficialUserSummary({ phone: '5551234567' }, lookup);
+
+        expect(summary).toEqual({
+            email: null,
+            phone: '5551234567',
+            teamIds: ['team-4'],
+            teamNames: ['Falcons'],
+            officialNames: ['Pat Phone'],
+            teamCount: 1
+        });
+        expect(formatOfficialUserSummary(summary)).toBe('1 team: Falcons');
     });
 
     it('wires the admin users tab to show and filter official-linked users', () => {

--- a/tests/unit/admin-user-official-links.test.js
+++ b/tests/unit/admin-user-official-links.test.js
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import {
+    buildOfficialUserLookup,
+    formatOfficialUserSummary,
+    getOfficialUserSummary,
+    matchesOfficialUserSearch
+} from '../../js/admin-user-official-links.js';
+
+function readSource(path) {
+    return readFileSync(new URL(`../../${path}`, import.meta.url), 'utf8');
+}
+
+describe('admin users official links', () => {
+    it('groups official directory matches by normalized email and team context', () => {
+        const lookup = buildOfficialUserLookup([
+            {
+                teamId: 'team-1',
+                teamName: 'Blue Jays',
+                official: { email: 'Ref@One.com', name: 'Robin Ref' }
+            },
+            {
+                teamId: 'team-2',
+                teamName: 'Storm',
+                official: { email: 'ref@one.com', name: 'Robin Ref' }
+            },
+            {
+                teamId: 'team-3',
+                teamName: 'Wolves',
+                official: { email: 'other@example.com', name: 'Other Official' }
+            }
+        ]);
+
+        const summary = getOfficialUserSummary({ email: 'REF@one.com' }, lookup);
+
+        expect(summary).toEqual({
+            email: 'ref@one.com',
+            teamIds: ['team-1', 'team-2'],
+            teamNames: ['Blue Jays', 'Storm'],
+            officialNames: ['Robin Ref'],
+            teamCount: 2
+        });
+        expect(formatOfficialUserSummary(summary)).toBe('2 teams: Blue Jays, Storm');
+        expect(matchesOfficialUserSearch({ fullName: 'Robin Ref' }, summary, 'storm')).toBe(true);
+        expect(matchesOfficialUserSearch({ fullName: 'Robin Ref' }, summary, 'official')).toBe(true);
+        expect(matchesOfficialUserSearch({ fullName: 'Robin Ref' }, summary, 'wolves')).toBe(false);
+    });
+
+    it('wires the admin users tab to show and filter official-linked users', () => {
+        const adminHtml = readSource('admin.html');
+        const adminJs = readSource('js/admin.js');
+
+        expect(adminHtml).toContain('id="filter-users-official-status"');
+        expect(adminHtml).toContain('Officials only');
+        expect(adminHtml).toContain('Search users, officials, or teams...');
+        expect(adminHtml).toContain('Official</th>');
+
+        expect(adminJs).toContain('getOfficials');
+        expect(adminJs).toContain('loadOfficialUserLinks()');
+        expect(adminJs).toContain('buildOfficialUserLookup');
+        expect(adminJs).toContain('formatOfficialUserSummary');
+        expect(adminJs).toContain('matchesOfficialUserSearch');
+        expect(adminJs).toContain("officialFilter === 'officials'");
+        expect(adminJs).toContain('inline-flex items-center rounded-full bg-emerald-100');
+    });
+});


### PR DESCRIPTION
Closes #1638

## What changed
- load each team's officials directory into the admin users view and match official records to users by normalized email
- show an `Official` indicator on matching user rows with team-count and team-name context
- add Users tab filtering for officials vs non-officials and extend search so admins can find users by official/team context
- add focused regression coverage for official-link aggregation and admin users tab wiring

## Why
Admins could not quickly tell which user accounts were already tied to officials directories. This makes official-linked accounts discoverable directly from the Users tab without adding assignment management there.