### PR TITLE
Filter paid recipients from Team Fees queue

### DIFF
--- a/apps/app/src/pages/TeamFees.test.tsx
+++ b/apps/app/src/pages/TeamFees.test.tsx
@@ -1,0 +1,116 @@
+import { render, screen, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TeamFees } from './TeamFees';
+import type { AuthState } from '../lib/types';
+
+const teamFeesServiceMocks = vi.hoisted(() => ({
+  loadTeamFeeManagementModel: vi.fn(),
+  recordOfflineTeamFeePayment: vi.fn()
+}));
+
+vi.mock('../lib/teamFeesService', () => teamFeesServiceMocks);
+
+const auth: AuthState = {
+  user: {
+    uid: 'coach-1',
+    email: 'coach@example.com',
+    displayName: 'Coach'
+  } as any,
+  profile: null,
+  loading: false,
+  error: null,
+  roles: ['coach'],
+  isParent: false,
+  isCoach: true,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: vi.fn(),
+  signOut: vi.fn()
+};
+
+function renderTeamFees() {
+  return render(
+    <MemoryRouter initialEntries={['/teams/team-1/fees/batch-1']}>
+      <Routes>
+        <Route path="/teams/:teamId/fees/:batchId" element={<TeamFees auth={auth} />} />
+        <Route path="/teams/:teamId" element={<div>Team detail</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('TeamFees recipient queue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    teamFeesServiceMocks.recordOfflineTeamFeePayment.mockResolvedValue(undefined);
+    teamFeesServiceMocks.loadTeamFeeManagementModel.mockResolvedValue({
+      team: { id: 'team-1', name: 'Bears' },
+      batches: [{ id: 'batch-1', title: 'Spring dues', dueDate: '2026-06-01', amountCents: 10000, status: 'open' }],
+      selectedBatch: { id: 'batch-1', title: 'Spring dues', dueDate: '2026-06-01', amountCents: 10000, status: 'open' },
+      canManageFees: true,
+      recipients: [
+        {
+          id: 'unpaid-1',
+          playerName: 'Unpaid Player',
+          parentName: 'Una Parent',
+          parentEmail: 'una@example.com',
+          status: 'unpaid',
+          amountDueCents: 10000,
+          amountPaidCents: 0,
+          remainingBalanceCents: 10000,
+          paymentLedger: []
+        },
+        {
+          id: 'partial-1',
+          playerName: 'Partial Player',
+          parentName: 'Part Parent',
+          parentEmail: 'part@example.com',
+          status: 'partial',
+          amountDueCents: 10000,
+          amountPaidCents: 2500,
+          remainingBalanceCents: 7500,
+          paymentLedger: [{ type: 'offline_payment' }]
+        },
+        {
+          id: 'paid-1',
+          playerName: 'Paid Player',
+          parentName: 'Pay Parent',
+          parentEmail: 'pay@example.com',
+          status: 'paid',
+          amountDueCents: 10000,
+          amountPaidCents: 10000,
+          remainingBalanceCents: 0,
+          paymentLedger: [{ type: 'offline_payment' }]
+        }
+      ]
+    });
+  });
+
+  it('shows only unpaid and partial recipients in the default payment queue', async () => {
+    renderTeamFees();
+
+    const queue = await screen.findByLabelText('Actionable recipients');
+    expect(within(queue).getByText('Unpaid Player')).toBeInTheDocument();
+    expect(within(queue).getByText('Partial Player')).toBeInTheDocument();
+    expect(within(queue).queryByText('Paid Player')).not.toBeInTheDocument();
+    expect(within(queue).getAllByRole('button', { name: 'Record payment' })).toHaveLength(2);
+    expect(screen.getByDisplayValue('100.00')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('75.00')).toBeInTheDocument();
+  });
+
+  it('renders paid recipients in a secondary review area without payment controls', async () => {
+    renderTeamFees();
+
+    const paidSection = await screen.findByText('Paid recipients (1)');
+    const reviewCard = paidSection.closest('details');
+    expect(reviewCard).not.toBeNull();
+    if (!reviewCard) throw new Error('Paid recipients details not found');
+
+    expect(within(reviewCard).getByText('Paid Player')).toBeInTheDocument();
+    expect(within(reviewCard).queryByRole('button', { name: 'Record payment' })).not.toBeInTheDocument();
+    expect(within(reviewCard).queryByLabelText('Payment amount')).not.toBeInTheDocument();
+    expect(within(reviewCard).queryByLabelText('Payment date')).not.toBeInTheDocument();
+    expect(within(reviewCard).queryByLabelText('Note')).not.toBeInTheDocument();
+  });
+});

--- a/apps/app/src/pages/TeamFees.tsx
+++ b/apps/app/src/pages/TeamFees.tsx
@@ -57,14 +57,25 @@ export function TeamFees({ auth }: { auth: AuthState }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth.user?.uid, teamId, batchId]);
 
+  const recipients = model?.recipients || [];
+
   const totals = useMemo(() => {
-    const recipients = model?.recipients || [];
     return {
       due: recipients.reduce((sum, recipient) => sum + recipient.amountDueCents, 0),
       paid: recipients.reduce((sum, recipient) => sum + recipient.amountPaidCents, 0),
       balance: recipients.reduce((sum, recipient) => sum + recipient.remainingBalanceCents, 0)
     };
-  }, [model?.recipients]);
+  }, [recipients]);
+
+  const actionableRecipients = useMemo(
+    () => recipients.filter((recipient) => recipient.remainingBalanceCents > 0),
+    [recipients]
+  );
+
+  const paidRecipients = useMemo(
+    () => recipients.filter((recipient) => recipient.remainingBalanceCents <= 0),
+    [recipients]
+  );
 
   if (!teamId) return <Navigate to="/teams" replace />;
 
@@ -154,50 +165,92 @@ export function TeamFees({ auth }: { auth: AuthState }) {
 
       {success ? <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-3 text-sm font-bold text-emerald-800"><CheckCircle2 className="mr-2 inline h-4 w-4" aria-hidden="true" />{success}</div> : null}
 
-      <div className="grid gap-3 lg:grid-cols-2">
-        {model.recipients.length ? model.recipients.map((recipient) => {
-          const form = formByRecipient[recipient.id] || { amount: centsToAmount(recipient.remainingBalanceCents), date: todayIsoDate(), note: '', error: '' };
-          return (
-            <section key={recipient.id} className="app-card p-4">
-              <div className="flex items-start justify-between gap-3">
-                <div>
-                  <h2 className="text-lg font-black text-gray-950">{recipient.playerName}</h2>
-                  <p className="mt-1 text-xs font-semibold text-gray-500">{[recipient.parentName, recipient.parentEmail].filter(Boolean).join(' · ') || 'Fee recipient'}</p>
+      <section className="space-y-3" aria-labelledby="actionable-recipients-heading">
+        <div>
+          <h2 id="actionable-recipients-heading" className="text-sm font-black uppercase tracking-[0.06em] text-gray-500">Actionable recipients</h2>
+          <p className="mt-1 text-xs font-semibold text-gray-500">Only recipients with an outstanding balance appear in the payment queue.</p>
+        </div>
+        <div className="grid gap-3 lg:grid-cols-2">
+          {actionableRecipients.length ? actionableRecipients.map((recipient) => {
+            const form = formByRecipient[recipient.id] || { amount: centsToAmount(recipient.remainingBalanceCents), date: todayIsoDate(), note: '', error: '' };
+            return (
+              <section key={recipient.id} className="app-card p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h3 className="text-lg font-black text-gray-950">{recipient.playerName}</h3>
+                    <p className="mt-1 text-xs font-semibold text-gray-500">{[recipient.parentName, recipient.parentEmail].filter(Boolean).join(' · ') || 'Fee recipient'}</p>
+                  </div>
+                  <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-black uppercase text-gray-700">{recipient.status}</span>
                 </div>
-                <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-black uppercase text-gray-700">{recipient.status}</span>
-              </div>
 
-              <div className="mt-3 grid grid-cols-3 gap-2 text-center">
-                <Metric label="Paid" value={formatMoney(recipient.amountPaidCents)} />
-                <Metric label="Balance" value={formatMoney(recipient.remainingBalanceCents)} urgent={recipient.remainingBalanceCents > 0} />
-                <Metric label="Ledger" value={String(recipient.paymentLedger.length)} />
-              </div>
-
-              <form className="mt-4 space-y-3" onSubmit={(event) => submitPayment(event, recipient)}>
-                <div className="grid gap-3 sm:grid-cols-2">
-                  <label className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Payment amount
-                    <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" inputMode="decimal" value={form.amount} onChange={(event) => updateForm(recipient.id, { amount: event.target.value })} />
-                  </label>
-                  <label className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Payment date
-                    <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" type="date" value={form.date} onChange={(event) => updateForm(recipient.id, { date: event.target.value })} />
-                  </label>
+                <div className="mt-3 grid grid-cols-3 gap-2 text-center">
+                  <Metric label="Paid" value={formatMoney(recipient.amountPaidCents)} />
+                  <Metric label="Balance" value={formatMoney(recipient.remainingBalanceCents)} urgent={recipient.remainingBalanceCents > 0} />
+                  <Metric label="Ledger" value={String(recipient.paymentLedger.length)} />
                 </div>
-                <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Note
-                  <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" placeholder="Cash, check #, Venmo note..." value={form.note} onChange={(event) => updateForm(recipient.id, { note: event.target.value })} />
-                </label>
-                {form.error ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-2 text-xs font-bold text-rose-700">{form.error}</div> : null}
-                <button type="submit" className="primary-button w-full" disabled={submittingId === recipient.id}>{submittingId === recipient.id ? 'Recording...' : 'Mark paid'}</button>
-              </form>
+
+                <form className="mt-4 space-y-3" onSubmit={(event) => submitPayment(event, recipient)}>
+                  <div className="grid gap-3 sm:grid-cols-2">
+                    <label className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Payment amount
+                      <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" inputMode="decimal" value={form.amount} onChange={(event) => updateForm(recipient.id, { amount: event.target.value })} />
+                    </label>
+                    <label className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Payment date
+                      <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" type="date" value={form.date} onChange={(event) => updateForm(recipient.id, { date: event.target.value })} />
+                    </label>
+                  </div>
+                  <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Note
+                    <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" placeholder="Cash, check #, Venmo note..." value={form.note} onChange={(event) => updateForm(recipient.id, { note: event.target.value })} />
+                  </label>
+                  {form.error ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-2 text-xs font-bold text-rose-700">{form.error}</div> : null}
+                  <button type="submit" className="primary-button w-full" disabled={submittingId === recipient.id}>{submittingId === recipient.id ? 'Recording...' : 'Record payment'}</button>
+                </form>
+              </section>
+            );
+          }) : recipients.length ? (
+            <section className="app-card p-5 text-center lg:col-span-2">
+              <DollarSign className="mx-auto h-8 w-8 text-gray-400" aria-hidden="true" />
+              <div className="mt-3 text-sm font-black text-gray-950">No outstanding balances</div>
+              <p className="mt-1 text-xs font-semibold text-gray-500">Everyone in this fee batch is fully paid. Review paid recipients below.</p>
             </section>
-          );
-        }) : (
-          <section className="app-card p-5 text-center lg:col-span-2">
-            <DollarSign className="mx-auto h-8 w-8 text-gray-400" aria-hidden="true" />
-            <div className="mt-3 text-sm font-black text-gray-950">No fee recipients</div>
-            <p className="mt-1 text-xs font-semibold text-gray-500">Create fee batches in the full website manager, then record offline payments here.</p>
-          </section>
-        )}
-      </div>
+          ) : null}
+        </div>
+      </section>
+
+      {paidRecipients.length ? (
+        <details className="app-card p-4">
+          <summary className="cursor-pointer list-none text-sm font-black text-gray-950">
+            Paid recipients ({paidRecipients.length})
+          </summary>
+          <p className="mt-2 text-xs font-semibold text-gray-500">Fully paid recipients stay available for review without editable payment controls.</p>
+          <div className="mt-4 grid gap-3 lg:grid-cols-2">
+            {paidRecipients.map((recipient) => (
+              <section key={recipient.id} className="rounded-2xl border border-gray-200 bg-gray-50 p-4">
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <h3 className="text-lg font-black text-gray-950">{recipient.playerName}</h3>
+                    <p className="mt-1 text-xs font-semibold text-gray-500">{[recipient.parentName, recipient.parentEmail].filter(Boolean).join(' · ') || 'Fee recipient'}</p>
+                  </div>
+                  <span className="rounded-full bg-emerald-100 px-2.5 py-1 text-xs font-black uppercase text-emerald-700">{recipient.status}</span>
+                </div>
+
+                <div className="mt-3 grid grid-cols-3 gap-2 text-center">
+                  <Metric label="Paid" value={formatMoney(recipient.amountPaidCents)} />
+                  <Metric label="Balance" value={formatMoney(recipient.remainingBalanceCents)} />
+                  <Metric label="Ledger" value={String(recipient.paymentLedger.length)} />
+                </div>
+              </section>
+            ))}
+          </div>
+        </details>
+      ) : null}
+
+      {!recipients.length ? (
+        <section className="app-card p-5 text-center">
+          <DollarSign className="mx-auto h-8 w-8 text-gray-400" aria-hidden="true" />
+          <div className="mt-3 text-sm font-black text-gray-950">No fee recipients</div>
+          <p className="mt-1 text-xs font-semibold text-gray-500">Create fee batches in the full website manager, then record offline payments here.</p>
+        </section>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
Closes #1635

## What changed
- split the mobile Team Fees recipient list into an actionable queue and a secondary paid-recipient review section
- show payment forms only for recipients with a remaining balance greater than $0, still prefilled to the current remaining balance
- renamed the primary action from `Mark paid` to `Record payment` so partial payments are not mislabeled
- rendered fully paid recipients in a collapsed `Paid recipients` section without editable amount/date/note fields or a submit button
- added a focused TeamFees component regression test covering both the actionable queue and the paid review area

## Why
Paid recipients were appearing in the default offline payment queue with a `0.00` amount and a misleading `Mark paid` affordance. This keeps the common reconciliation path focused on unpaid and partial balances while preserving read-only visibility into already-paid recipients.