### PR TITLE
Add officials summary to admin teams tab

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -225,6 +225,9 @@
                                     class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
                                     Created</th>
                                 <th
+                                    class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                                    Officials</th>
+                                <th
                                     class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">
                                     Actions</th>
                             </tr>

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -3922,6 +3922,12 @@
             });
         }
 
+        function switchTabFromHash() {
+            if (window.location.hash === '#officials') {
+                switchTab('tab-officials');
+            }
+        }
+
         document.getElementById('tab-add-game').addEventListener('click', () => {
             switchTab('tab-add-game');
             if (!editingGameId) prefillAssignments();
@@ -3930,6 +3936,8 @@
         document.getElementById('tab-csv-import').addEventListener('click', () => switchTab('tab-csv-import'));
         document.getElementById('tab-bulk-ai').addEventListener('click', () => switchTab('tab-bulk-ai'));
         document.getElementById('tab-officials').addEventListener('click', () => switchTab('tab-officials'));
+        window.addEventListener('hashchange', switchTabFromHash);
+        switchTabFromHash();
 
         // Recurrence builder toggle
         document.getElementById('practiceRecurring').addEventListener('change', (e) => {

--- a/js/admin-team-officials.js
+++ b/js/admin-team-officials.js
@@ -1,0 +1,64 @@
+import { computeOfficiatingCoverageStatus, normalizeOfficiatingSlots } from './officiating-utils.js?v=3';
+
+function toDate(value) {
+    if (!value) return null;
+    if (typeof value.toDate === 'function') return value.toDate();
+    const parsed = value instanceof Date ? value : new Date(value);
+    return Number.isNaN(parsed.getTime()) ? null : parsed;
+}
+
+function isUpcomingGame(game = {}) {
+    const date = toDate(game.date);
+    const status = String(game.status || '').trim().toLowerCase();
+    return !!date && date.getTime() >= Date.now() && status !== 'cancelled' && status !== 'canceled';
+}
+
+export function buildAdminTeamOfficialsSummary(team = {}, officials = [], games = []) {
+    const officialCount = Array.isArray(officials) ? officials.length : 0;
+    const upcomingGames = (Array.isArray(games) ? games : [])
+        .filter((game) => game?.teamId === team?.id)
+        .filter(isUpcomingGame)
+        .map((game) => ({
+            ...game,
+            normalizedSlots: normalizeOfficiatingSlots(game.officiatingSlots || [])
+        }))
+        .filter((game) => game.normalizedSlots.length > 0);
+
+    const upcomingGameCount = upcomingGames.length;
+    const coveredGameCount = upcomingGames.filter((game) => {
+        const status = game.officiatingCoverageStatus || computeOfficiatingCoverageStatus(game.normalizedSlots);
+        return status === 'covered';
+    }).length;
+    const attentionGameCount = upcomingGameCount - coveredGameCount;
+
+    let badgeTone = 'good';
+    let badgeLabel = officialCount === 1 ? '1 official' : `${officialCount} officials`;
+    if (officialCount === 0) {
+        badgeTone = 'missing';
+        badgeLabel = 'No officials';
+    }
+
+    let detailTone = 'muted';
+    let detailLabel = 'No upcoming officiating slots';
+    if (upcomingGameCount > 0) {
+        if (attentionGameCount > 0) {
+            detailTone = 'warning';
+            const gameLabel = `upcoming game${upcomingGameCount === 1 ? '' : 's'}`;
+            detailLabel = `${attentionGameCount} of ${upcomingGameCount} ${gameLabel} ${upcomingGameCount === 1 ? 'needs' : 'need'} attention`;
+        } else {
+            detailTone = 'good';
+            detailLabel = `${coveredGameCount} upcoming game${coveredGameCount === 1 ? '' : 's'} covered`;
+        }
+    }
+
+    return {
+        officialCount,
+        upcomingGameCount,
+        coveredGameCount,
+        attentionGameCount,
+        badgeTone,
+        badgeLabel,
+        detailTone,
+        detailLabel
+    };
+}

--- a/js/admin.js
+++ b/js/admin.js
@@ -28,10 +28,12 @@ import {
     getOfficialUserSummary,
     matchesOfficialUserSearch
 } from './admin-user-official-links.js?v=1';
+import { buildAdminTeamOfficialsSummary } from './admin-team-officials.js?v=1';
 
 let allTeams = [];
 let allUsers = [];
 let officialUserLookup = new Map();
+let officialsByTeamId = new Map();
 let currentUser = null; // Declare currentUser
 let showInactiveTeams = false;
 let activeRegistrationTeam = null;
@@ -116,12 +118,14 @@ async function loadOfficialUserLinks() {
     const officialEntries = (await Promise.all(allTeams.map(async (team) => {
         try {
             const officials = await getOfficials(team.id);
+            officialsByTeamId.set(team.id, officials);
             return officials.map((official) => ({
                 teamId: team.id,
                 teamName: team.name || 'Team',
                 official
             }));
         } catch (error) {
+            officialsByTeamId.set(team.id, []);
             console.warn('Failed to load officials for admin users view:', team.id, error);
             return [];
         }
@@ -625,9 +629,18 @@ function updateTelemetryDashboard() {
     renderTelemetryEventsTable();
 }
 
+function getOfficialsCellClasses(tone) {
+    if (tone === 'missing') return 'bg-rose-100 text-rose-700';
+    if (tone === 'warning') return 'bg-amber-100 text-amber-700';
+    return 'bg-emerald-100 text-emerald-700';
+}
+
 function renderTeams(teams) {
     const tbody = document.getElementById('teams-table-body');
-    tbody.innerHTML = teams.map(team => `
+    tbody.innerHTML = teams.map(team => {
+        const officialsSummary = buildAdminTeamOfficialsSummary(team, officialsByTeamId.get(team.id) || [], allGames);
+        const manageOfficialsHref = `edit-schedule.html?teamId=${encodeURIComponent(team.id)}#officials`;
+        return `
         <tr>
             <td class="px-6 py-4 whitespace-nowrap">
                 <div class="flex items-center">
@@ -660,13 +673,21 @@ function renderTeams(teams) {
             <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
                 ${team.createdAt?.toDate ? team.createdAt.toDate().toLocaleDateString() : '-'}
             </td>
+            <td class="px-6 py-4 text-sm text-gray-600">
+                <div class="flex flex-col gap-1 min-w-[13rem]">
+                    <span class="inline-flex w-fit items-center rounded-full px-2 py-1 text-xs font-semibold ${getOfficialsCellClasses(officialsSummary.badgeTone)}">${escapeHtml(officialsSummary.badgeLabel)}</span>
+                    <span class="text-xs ${officialsSummary.detailTone === 'warning' ? 'text-amber-700 font-medium' : 'text-gray-500'}">${escapeHtml(officialsSummary.detailLabel)}</span>
+                </div>
+            </td>
             <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
+                <a href="${manageOfficialsHref}" class="text-indigo-600 hover:text-indigo-900 mr-4">Manage Officials</a>
                 <button onclick="window.openRegistrationFormsAdmin(${inlineJsString(team.id)})" class="text-indigo-600 hover:text-indigo-900 mr-4">Registration forms</button>
-                <a href="edit-team.html?teamId=${team.id}" class="text-indigo-600 hover:text-indigo-900 mr-4">Edit</a>
+                <a href="edit-team.html?teamId=${encodeURIComponent(team.id)}" class="text-indigo-600 hover:text-indigo-900 mr-4">Edit</a>
                 <button onclick="window.deleteTeamAdmin(${inlineJsString(team.id)}, ${inlineJsString(team.name)})" class="text-red-600 hover:text-red-900">Deactivate</button>
             </td>
         </tr>
-    `).join('');
+    `;
+    }).join('');
 }
 
 function renderUsers(users) {

--- a/tests/unit/admin-team-officials.test.js
+++ b/tests/unit/admin-team-officials.test.js
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { buildAdminTeamOfficialsSummary } from '../../js/admin-team-officials.js';
+
+function ts(date) {
+    return { toDate: () => new Date(date) };
+}
+
+function readSource(path) {
+    return readFileSync(new URL(`../../${path}`, import.meta.url), 'utf8');
+}
+
+describe('admin team officials summary', () => {
+    it('marks teams without a directory and flags uncovered upcoming games', () => {
+        const summary = buildAdminTeamOfficialsSummary(
+            { id: 'team-1' },
+            [],
+            [
+                {
+                    id: 'game-1',
+                    teamId: 'team-1',
+                    date: ts('2099-05-01T10:00:00Z'),
+                    officiatingSlots: [
+                        { position: 'Referee', officialEmail: 'ref@example.com', status: 'accepted' },
+                        { position: 'AR1', status: 'open' }
+                    ]
+                }
+            ]
+        );
+
+        expect(summary).toMatchObject({
+            officialCount: 0,
+            badgeTone: 'missing',
+            badgeLabel: 'No officials',
+            upcomingGameCount: 1,
+            attentionGameCount: 1,
+            detailTone: 'warning',
+            detailLabel: '1 of 1 upcoming game needs attention'
+        });
+    });
+
+    it('shows covered upcoming games when staffing is complete', () => {
+        const summary = buildAdminTeamOfficialsSummary(
+            { id: 'team-2' },
+            [{ id: 'official-1' }, { id: 'official-2' }],
+            [
+                {
+                    id: 'game-1',
+                    teamId: 'team-2',
+                    date: ts('2099-05-01T10:00:00Z'),
+                    officiatingSlots: [
+                        { position: 'Referee', officialEmail: 'ref@example.com', status: 'accepted' }
+                    ]
+                },
+                {
+                    id: 'game-2',
+                    teamId: 'team-2',
+                    date: ts('2099-05-02T10:00:00Z'),
+                    officiatingCoverageStatus: 'covered',
+                    officiatingSlots: [
+                        { position: 'Referee', officialEmail: 'ref2@example.com', status: 'accepted' }
+                    ]
+                }
+            ]
+        );
+
+        expect(summary).toMatchObject({
+            officialCount: 2,
+            badgeTone: 'good',
+            badgeLabel: '2 officials',
+            upcomingGameCount: 2,
+            coveredGameCount: 2,
+            detailTone: 'good',
+            detailLabel: '2 upcoming games covered'
+        });
+    });
+
+    it('wires the admin teams table and manage officials entrypoint', () => {
+        const adminHtml = readSource('admin.html');
+        const adminJs = readSource('js/admin.js');
+        const helperJs = readSource('js/admin-team-officials.js');
+        const scheduleHtml = readSource('edit-schedule.html');
+
+        expect(adminHtml).toContain('Officials</th>');
+        expect(adminJs).toContain("import { buildAdminTeamOfficialsSummary } from './admin-team-officials.js?v=1';");
+        expect(adminJs).toContain('Manage Officials');
+        expect(adminJs).toContain("edit-schedule.html?teamId=${encodeURIComponent(team.id)}#officials");
+        expect(helperJs).toContain('No officials');
+        expect(scheduleHtml).toContain("if (window.location.hash === '#officials') {");
+        expect(scheduleHtml).toContain('window.addEventListener(\'hashchange\', switchTabFromHash);');
+    });
+});


### PR DESCRIPTION
Closes #1636

## What changed
- added an Officials column to the Admin Teams table with a per-team directory summary and upcoming officiating coverage status
- added a clear Manage Officials action on each team row that routes admins into the existing schedule officials workflow for that team
- added hash-based tab routing in `edit-schedule.html` so the admin entrypoint opens directly on the Officials tab
- added focused unit coverage for the new summary logic and admin wiring

## Why
Admins could not quickly see which teams had officials configured or where upcoming coverage still needed attention. This keeps the change bounded to the existing admin and schedule flows while making missing official setup visible.