### PR TITLE
Add team officials modal to admin dashboard

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -287,6 +287,63 @@
             </div>
         </div>
 
+        <div id="officials-admin-modal" class="hidden fixed inset-0 z-50 overflow-y-auto bg-gray-900/50 px-4 py-8">
+            <div class="mx-auto max-w-4xl rounded-xl bg-white shadow-xl">
+                <div class="flex items-start justify-between border-b border-gray-200 p-5">
+                    <div>
+                        <p class="text-sm font-semibold uppercase tracking-wide text-primary-600">Team officials</p>
+                        <h2 class="text-2xl font-bold text-gray-900"><span id="officials-admin-team-name">Team</span> officials</h2>
+                        <p class="mt-1 text-sm text-gray-600">Manage the saved officials directory used by edit-schedule.html for this team.</p>
+                    </div>
+                    <button onclick="window.closeOfficialsAdmin()" class="rounded px-2 py-1 text-gray-500 hover:bg-gray-100" aria-label="Close officials directory">✕</button>
+                </div>
+                <div class="grid gap-6 p-5 lg:grid-cols-2">
+                    <section>
+                        <div class="mb-3 flex items-center justify-between">
+                            <h3 class="font-semibold text-gray-900">Saved officials</h3>
+                            <button onclick="window.startOfficialsAdminEdit()" class="rounded bg-primary-600 px-3 py-2 text-sm font-semibold text-white hover:bg-primary-700">New official</button>
+                        </div>
+                        <div id="officials-admin-list" class="space-y-3">
+                            <p class="text-sm text-gray-500">Select a team to load officials.</p>
+                        </div>
+                    </section>
+
+                    <form id="officials-admin-form" class="hidden space-y-4 rounded border border-gray-200 p-4">
+                        <input type="hidden" id="officials-admin-id">
+                        <div>
+                            <label for="officials-admin-name" class="block text-sm font-medium text-gray-700">Name</label>
+                            <input id="officials-admin-name" required class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Official name">
+                        </div>
+                        <div class="grid gap-4 sm:grid-cols-2">
+                            <div>
+                                <label for="officials-admin-email" class="block text-sm font-medium text-gray-700">Email</label>
+                                <input id="officials-admin-email" type="email" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="name@example.com">
+                            </div>
+                            <div>
+                                <label for="officials-admin-phone" class="block text-sm font-medium text-gray-700">Phone</label>
+                                <input id="officials-admin-phone" type="tel" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="555-123-4567">
+                            </div>
+                        </div>
+                        <div>
+                            <label for="officials-admin-roles" class="block text-sm font-medium text-gray-700">Roles</label>
+                            <input id="officials-admin-roles" required class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Referee, umpire, line judge">
+                            <p class="mt-1 text-xs text-gray-500">Comma-separated officiating roles.</p>
+                        </div>
+                        <div>
+                            <label for="officials-admin-tags" class="block text-sm font-medium text-gray-700">Tags</label>
+                            <input id="officials-admin-tags" class="mt-1 w-full rounded border border-gray-300 p-2" placeholder="Varsity, 12U, experienced">
+                            <p class="mt-1 text-xs text-gray-500">Optional divisions, certifications, or notes.</p>
+                        </div>
+                        <p id="officials-admin-message" class="text-sm text-gray-600"></p>
+                        <div class="flex gap-3">
+                            <button type="submit" id="officials-admin-save-btn" class="flex-1 rounded bg-primary-600 px-4 py-2 font-semibold text-white hover:bg-primary-700">Save official</button>
+                            <button type="button" onclick="window.resetOfficialsAdminForm()" id="officials-admin-cancel-btn" class="hidden rounded bg-gray-100 px-4 py-2 font-semibold text-gray-700 hover:bg-gray-200">Cancel</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
         <div id="registration-forms-modal" class="hidden fixed inset-0 z-50 overflow-y-auto bg-gray-900/50 px-4 py-8">
             <div class="mx-auto max-w-4xl rounded-xl bg-white shadow-xl">
                 <div class="flex items-start justify-between border-b border-gray-200 p-5">

--- a/apps/app/src/lib/useShellLayout.test.tsx
+++ b/apps/app/src/lib/useShellLayout.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useShellLayout } from './useShellLayout';
+
+vi.mock('@capacitor/core', () => ({
+  Capacitor: {
+    isNativePlatform: () => false
+  }
+}));
+
+function HookProbe() {
+  const { isDesktop, isNative, isDesktopWeb } = useShellLayout();
+  return (
+    <div>
+      <span data-testid="desktop">{String(isDesktop)}</span>
+      <span data-testid="native">{String(isNative)}</span>
+      <span data-testid="desktop-web">{String(isDesktopWeb)}</span>
+    </div>
+  );
+}
+
+describe('useShellLayout', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('supports legacy MediaQueryList listeners without crashing', () => {
+    const listeners = new Set<(event: MediaQueryListEvent) => void>();
+    const removeListener = vi.fn((listener: (event: MediaQueryListEvent) => void) => {
+      listeners.delete(listener);
+    });
+    const addListener = vi.fn((listener: (event: MediaQueryListEvent) => void) => {
+      listeners.add(listener);
+    });
+
+    const media = {
+      matches: false,
+      addListener,
+      removeListener
+    };
+
+    vi.stubGlobal('matchMedia', vi.fn(() => media));
+
+    const { unmount } = render(<HookProbe />);
+
+    expect(screen.getByTestId('desktop')).toHaveTextContent('false');
+    expect(screen.getByTestId('native')).toHaveTextContent('false');
+    expect(screen.getByTestId('desktop-web')).toHaveTextContent('false');
+    expect(addListener).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    expect(removeListener).toHaveBeenCalledTimes(1);
+    expect(listeners.size).toBe(0);
+  });
+});

--- a/apps/app/src/lib/useShellLayout.ts
+++ b/apps/app/src/lib/useShellLayout.ts
@@ -3,12 +3,31 @@ import { Capacitor } from '@capacitor/core';
 
 const desktopQuery = '(min-width: 1024px)';
 
+type MediaQueryWithLegacyListeners = MediaQueryList & {
+  addListener?: (listener: (event: MediaQueryListEvent) => void) => void;
+  removeListener?: (listener: (event: MediaQueryListEvent) => void) => void;
+};
+
 function readDesktopMatch() {
   return typeof window !== 'undefined' && typeof window.matchMedia === 'function' && window.matchMedia(desktopQuery).matches;
 }
 
 function readNativeRuntime() {
   return typeof window !== 'undefined' && (Capacitor.isNativePlatform() || window.location.protocol === 'capacitor:');
+}
+
+function subscribeToMediaQuery(media: MediaQueryWithLegacyListeners, listener: (event: MediaQueryListEvent) => void) {
+  if (typeof media.addEventListener === 'function' && typeof media.removeEventListener === 'function') {
+    media.addEventListener('change', listener);
+    return () => media.removeEventListener('change', listener);
+  }
+
+  if (typeof media.addListener === 'function' && typeof media.removeListener === 'function') {
+    media.addListener(listener);
+    return () => media.removeListener(listener);
+  }
+
+  return () => undefined;
 }
 
 export function useShellLayout() {
@@ -21,14 +40,13 @@ export function useShellLayout() {
       setIsNative(readNativeRuntime());
       return undefined;
     }
-    const media = window.matchMedia(desktopQuery);
+    const media = window.matchMedia(desktopQuery) as MediaQueryWithLegacyListeners;
     const updateDesktop = () => setIsDesktop(media.matches);
 
     updateDesktop();
     setIsNative(readNativeRuntime());
 
-    media.addEventListener('change', updateDesktop);
-    return () => media.removeEventListener('change', updateDesktop);
+    return subscribeToMediaQuery(media, updateDesktop);
   }, []);
 
   return {

--- a/js/admin.js
+++ b/js/admin.js
@@ -2,6 +2,9 @@ import {
     getTeams,
     getAllUsers,
     getOfficials,
+    addOfficial,
+    updateOfficial,
+    deleteOfficial,
     deleteTeam,
     getTelemetryEvents,
     getTelemetryDaily,
@@ -36,6 +39,8 @@ let officialUserLookup = new Map();
 let officialsByTeamId = new Map();
 let currentUser = null; // Declare currentUser
 let showInactiveTeams = false;
+let activeOfficialsTeam = null;
+let activeOfficials = [];
 let activeRegistrationTeam = null;
 let activeRegistrationForms = [];
 let activeRegistrationOptions = [];
@@ -43,6 +48,14 @@ let activeRegistrationOptions = [];
 function inlineJsString(value) {
     return escapeHtml(JSON.stringify(String(value || '')));
 }
+
+function splitDirectoryInput(value) {
+    return String(value || '')
+        .split(',')
+        .map((item) => item.trim())
+        .filter(Boolean);
+}
+
 let telemetryState = {
     loaded: false,
     loading: false,
@@ -682,12 +695,169 @@ function renderTeams(teams) {
             <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
                 <a href="${manageOfficialsHref}" class="text-indigo-600 hover:text-indigo-900 mr-4">Manage Officials</a>
                 <button onclick="window.openRegistrationFormsAdmin(${inlineJsString(team.id)})" class="text-indigo-600 hover:text-indigo-900 mr-4">Registration forms</button>
+                <button onclick="window.openOfficialsAdmin(${inlineJsString(team.id)})" class="text-indigo-600 hover:text-indigo-900 mr-4">Officials</button>
                 <a href="edit-team.html?teamId=${encodeURIComponent(team.id)}" class="text-indigo-600 hover:text-indigo-900 mr-4">Edit</a>
                 <button onclick="window.deleteTeamAdmin(${inlineJsString(team.id)}, ${inlineJsString(team.name)})" class="text-red-600 hover:text-red-900">Deactivate</button>
             </td>
         </tr>
     `;
     }).join('');
+}
+
+function resetOfficialsAdminFormState() {
+    document.getElementById('officials-admin-id').value = '';
+    document.getElementById('officials-admin-form').reset();
+    document.getElementById('officials-admin-save-btn').textContent = 'Save official';
+    document.getElementById('officials-admin-cancel-btn').classList.add('hidden');
+    document.getElementById('officials-admin-message').textContent = '';
+}
+
+function renderOfficialsAdminList() {
+    const list = document.getElementById('officials-admin-list');
+    if (!activeOfficials.length) {
+        list.innerHTML = '<p class="text-sm text-gray-500">No officials saved for this team yet.</p>';
+        return;
+    }
+
+    list.innerHTML = activeOfficials.map((official) => {
+        const roles = Array.isArray(official.roles) ? official.roles : [];
+        const tags = Array.isArray(official.tags) ? official.tags : [];
+        const contact = [official.email, official.phone].filter(Boolean).join(' • ');
+        return `
+            <div class="rounded border border-gray-200 p-3">
+                <div class="flex items-start justify-between gap-3">
+                    <div>
+                        <p class="font-semibold text-gray-900">${escapeHtml(official.name || 'Official')}</p>
+                        <p class="text-sm text-gray-600">${escapeHtml(contact || 'No contact saved')}</p>
+                    </div>
+                    <div class="flex gap-2 text-sm">
+                        <button type="button" class="font-medium text-indigo-600 hover:text-indigo-800" data-edit-official-id="${escapeHtml(official.id)}">Edit</button>
+                        <button type="button" class="font-medium text-red-600 hover:text-red-800" data-delete-official-id="${escapeHtml(official.id)}">Remove</button>
+                    </div>
+                </div>
+                <div class="mt-2 flex flex-wrap gap-1">
+                    ${roles.length
+                        ? roles.map((role) => `<span class="inline-block rounded-full bg-indigo-50 px-2 py-0.5 text-xs font-medium text-indigo-700">${escapeHtml(role)}</span>`).join('')
+                        : '<span class="text-xs text-gray-400">No roles saved</span>'}
+                </div>
+                ${tags.length ? `<div class="mt-2 flex flex-wrap gap-1">${tags.map((tag) => `<span class="inline-block rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-700">${escapeHtml(tag)}</span>`).join('')}</div>` : ''}
+            </div>
+        `;
+    }).join('');
+}
+
+async function loadOfficialsForActiveTeam() {
+    const teamId = activeOfficialsTeam?.id;
+    const list = document.getElementById('officials-admin-list');
+    if (!teamId || !list) return;
+
+    list.innerHTML = '<p class="text-sm text-gray-500">Loading officials...</p>';
+    try {
+        activeOfficials = await getOfficials(teamId);
+        renderOfficialsAdminList();
+    } catch (error) {
+        console.error('Error loading officials for admin modal:', error);
+        activeOfficials = [];
+        list.innerHTML = '<p class="text-sm text-red-600">Failed to load officials. Please try again.</p>';
+    }
+}
+
+function getOfficialsAdminDraft() {
+    return {
+        name: document.getElementById('officials-admin-name').value.trim(),
+        email: document.getElementById('officials-admin-email').value.trim(),
+        phone: document.getElementById('officials-admin-phone').value.trim(),
+        roles: splitDirectoryInput(document.getElementById('officials-admin-roles').value),
+        tags: splitDirectoryInput(document.getElementById('officials-admin-tags').value)
+    };
+}
+
+window.openOfficialsAdmin = async function (teamId) {
+    activeOfficialsTeam = allTeams.find((team) => team.id === teamId) || null;
+    if (!activeOfficialsTeam) return;
+
+    document.getElementById('officials-admin-team-name').textContent = activeOfficialsTeam.name || 'Team';
+    document.getElementById('officials-admin-modal').classList.remove('hidden');
+    window.startOfficialsAdminEdit();
+    await loadOfficialsForActiveTeam();
+};
+
+window.closeOfficialsAdmin = function () {
+    document.getElementById('officials-admin-modal').classList.add('hidden');
+};
+
+window.resetOfficialsAdminForm = function () {
+    resetOfficialsAdminFormState();
+};
+
+window.startOfficialsAdminEdit = function (officialId = '') {
+    const official = activeOfficials.find((item) => item.id === officialId) || {};
+    const form = document.getElementById('officials-admin-form');
+    document.getElementById('officials-admin-id').value = official.id || '';
+    document.getElementById('officials-admin-name').value = official.name || '';
+    document.getElementById('officials-admin-email').value = official.email || '';
+    document.getElementById('officials-admin-phone').value = official.phone || '';
+    document.getElementById('officials-admin-roles').value = Array.isArray(official.roles) ? official.roles.join(', ') : '';
+    document.getElementById('officials-admin-tags').value = Array.isArray(official.tags) ? official.tags.join(', ') : '';
+    document.getElementById('officials-admin-save-btn').textContent = official.id ? 'Update official' : 'Save official';
+    document.getElementById('officials-admin-cancel-btn').classList.toggle('hidden', !official.id);
+    document.getElementById('officials-admin-message').textContent = '';
+    form.classList.remove('hidden');
+};
+
+async function saveOfficialsAdmin(event) {
+    event.preventDefault();
+    if (!activeOfficialsTeam) return;
+
+    const teamId = activeOfficialsTeam.id;
+    const officialId = document.getElementById('officials-admin-id').value;
+    const message = document.getElementById('officials-admin-message');
+    const draft = getOfficialsAdminDraft();
+
+    try {
+        if (officialId) {
+            await updateOfficial(teamId, officialId, draft);
+        } else {
+            await addOfficial(teamId, draft);
+        }
+    } catch (error) {
+        console.error('Error saving team official:', error);
+        message.textContent = error.message || 'Failed to save official.';
+        return;
+    }
+
+    message.textContent = officialId ? 'Official updated.' : 'Official saved.';
+    resetOfficialsAdminFormState();
+    document.getElementById('officials-admin-form').classList.remove('hidden');
+    await loadOfficialsForActiveTeam();
+}
+
+async function handleOfficialsAdminListClick(event) {
+    const editId = event.target.dataset.editOfficialId;
+    const deleteId = event.target.dataset.deleteOfficialId;
+
+    if (editId) {
+        window.startOfficialsAdminEdit(editId);
+        return;
+    }
+    if (!deleteId || !activeOfficialsTeam) return;
+
+    const official = activeOfficials.find((item) => item.id === deleteId);
+    if (!confirm(`Remove ${official?.name || 'this official'} from ${activeOfficialsTeam.name || 'this team'}?`)) return;
+
+    const message = document.getElementById('officials-admin-message');
+    try {
+        await deleteOfficial(activeOfficialsTeam.id, deleteId);
+        if (document.getElementById('officials-admin-id').value === deleteId) {
+            resetOfficialsAdminFormState();
+            document.getElementById('officials-admin-form').classList.remove('hidden');
+        }
+        message.textContent = 'Official removed.';
+        await loadOfficialsForActiveTeam();
+    } catch (error) {
+        console.error('Error removing team official:', error);
+        message.textContent = error.message || 'Failed to remove official.';
+    }
 }
 
 function renderUsers(users) {
@@ -1031,6 +1201,8 @@ function setupTabs() {
 }
 
 function setupSearch() {
+    document.getElementById('officials-admin-form').addEventListener('submit', saveOfficialsAdmin);
+    document.getElementById('officials-admin-list').addEventListener('click', handleOfficialsAdminListClick);
     document.getElementById('registration-form-editor').addEventListener('submit', saveRegistrationForm);
 
     const inactiveToggle = document.getElementById('filter-inactive-teams');

--- a/js/admin.js
+++ b/js/admin.js
@@ -753,10 +753,15 @@ async function loadOfficialsForActiveTeam() {
 
     list.innerHTML = '<p class="text-sm text-gray-500">Loading officials...</p>';
     try {
-        activeOfficials = await getOfficials(teamId);
+        const officials = await getOfficials(teamId);
+        if (activeOfficialsTeam?.id !== teamId) return;
+
+        activeOfficials = officials;
         renderOfficialsAdminList();
     } catch (error) {
         console.error('Error loading officials for admin modal:', error);
+        if (activeOfficialsTeam?.id !== teamId) return;
+
         activeOfficials = [];
         list.innerHTML = '<p class="text-sm text-red-600">Failed to load officials. Please try again.</p>';
     }

--- a/tests/unit/admin-officials-directory.test.js
+++ b/tests/unit/admin-officials-directory.test.js
@@ -21,7 +21,9 @@ describe('admin officials directory modal', () => {
         expect(adminJs).toContain('window.closeOfficialsAdmin');
         expect(adminJs).toContain('window.startOfficialsAdminEdit');
         expect(adminJs).toContain('loadOfficialsForActiveTeam()');
-        expect(adminJs).toContain('await getOfficials(teamId);');
+        expect(adminJs).toContain('const officials = await getOfficials(teamId);');
+        expect(adminJs).toContain('if (activeOfficialsTeam?.id !== teamId) return;');
+        expect(adminJs).toContain('activeOfficials = officials;');
         expect(adminJs).toContain('await addOfficial(teamId, draft);');
         expect(adminJs).toContain('await updateOfficial(teamId, officialId, draft);');
         expect(adminJs).toContain('await deleteOfficial(activeOfficialsTeam.id, deleteId);');

--- a/tests/unit/admin-officials-directory.test.js
+++ b/tests/unit/admin-officials-directory.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+
+describe('admin officials directory modal', () => {
+    it('wires the admin teams tab to manage team officials in a modal', () => {
+        const adminHtml = fs.readFileSync('admin.html', 'utf8');
+        const adminJs = fs.readFileSync('js/admin.js', 'utf8');
+
+        expect(adminHtml).toContain('officials-admin-modal');
+        expect(adminHtml).toContain('officials-admin-team-name');
+        expect(adminHtml).toContain('officials-admin-list');
+        expect(adminHtml).toContain('officials-admin-form');
+        expect(adminHtml).toContain('officials-admin-name');
+        expect(adminHtml).toContain('officials-admin-email');
+        expect(adminHtml).toContain('officials-admin-phone');
+        expect(adminHtml).toContain('officials-admin-roles');
+        expect(adminHtml).toContain('officials-admin-tags');
+        expect(adminHtml).toContain('Manage the saved officials directory used by edit-schedule.html for this team.');
+
+        expect(adminJs).toContain('window.openOfficialsAdmin');
+        expect(adminJs).toContain('window.closeOfficialsAdmin');
+        expect(adminJs).toContain('window.startOfficialsAdminEdit');
+        expect(adminJs).toContain('loadOfficialsForActiveTeam()');
+        expect(adminJs).toContain('await getOfficials(teamId);');
+        expect(adminJs).toContain('await addOfficial(teamId, draft);');
+        expect(adminJs).toContain('await updateOfficial(teamId, officialId, draft);');
+        expect(adminJs).toContain('await deleteOfficial(activeOfficialsTeam.id, deleteId);');
+        expect(adminJs).toContain('window.openOfficialsAdmin(${inlineJsString(team.id)})');
+        expect(adminJs).toContain('No officials saved for this team yet.');
+    });
+});


### PR DESCRIPTION
Closes #1637

## What changed
- added a team-specific Officials modal to `admin.html` from the Teams tab actions
- wired `js/admin.js` to load, list, create, edit, and remove officials for the selected team using the existing team officials directory data
- rendered saved contact details, roles, and tags in the modal so admins can manage the same records used by `edit-schedule.html`
- added a focused unit regression test for the new admin officials workflow

## Why
This keeps the scope tight to officials directory CRUD inside the admin dashboard without touching assignment logic or broader officiating workflows.