### PR TITLE
Add native team fee balance adjustments in app

### DIFF
--- a/apps/app/src/lib/teamFeesService.ts
+++ b/apps/app/src/lib/teamFeesService.ts
@@ -42,7 +42,23 @@ export type ManualTeamFeePaymentInput = {
   currentPaidCents?: string | number | null;
 };
 
+export type TeamFeeBalanceAdjustmentInput = {
+  amount: string | number;
+  note?: string;
+  actorId?: string;
+  currentBalanceCents?: string | number | null;
+  currentPaidCents?: string | number | null;
+};
+
 export function toFeeCents(value: string | number | null | undefined) {
+  const normalized = String(value ?? '').replace(/[$,]/g, '').trim();
+  if (!normalized) return null;
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed)) return null;
+  return Math.round(parsed * 100);
+}
+
+function toSignedFeeCents(value: string | number | null | undefined) {
   const normalized = String(value ?? '').replace(/[$,]/g, '').trim();
   if (!normalized) return null;
   const parsed = Number(normalized);
@@ -97,6 +113,45 @@ export function buildManualPaymentUpdate({ amount, date, note, actorId, currentB
   };
 }
 
+export function buildBalanceAdjustmentUpdate({ amount, note, actorId, currentBalanceCents, currentPaidCents }: TeamFeeBalanceAdjustmentInput) {
+  const adjustmentCents = toSignedFeeCents(amount);
+  const reason = normalizeString(note);
+  if (adjustmentCents === null || adjustmentCents === 0) {
+    throw new Error('Enter a positive or negative adjustment amount.');
+  }
+  if (!reason) throw new Error('Enter an adjustment reason.');
+
+  const currentBalance = Number(currentBalanceCents);
+  const priorBalanceCents = Number.isFinite(currentBalance) ? Math.max(0, currentBalance) : 0;
+  const paid = Number(currentPaidCents);
+  const amountPaidCents = Number.isFinite(paid) ? Math.max(0, paid) : 0;
+  const amountDueCents = Math.max(0, priorBalanceCents - adjustmentCents);
+  const remainingBalanceCents = Math.max(0, amountDueCents - amountPaidCents);
+  const status = normalizeLedgerStatus(amountDueCents, amountPaidCents);
+  const ledgerEntry = {
+    type: 'balance_adjustment',
+    amountCents: adjustmentCents,
+    previousAmountDueCents: priorBalanceCents,
+    amountDueCents,
+    reason,
+    adjustedBy: actorId || null
+  };
+
+  return {
+    status,
+    amountDueCents,
+    remainingBalanceCents,
+    adjustment: {
+      amountCents: adjustmentCents,
+      previousAmountDueCents: priorBalanceCents,
+      amountDueCents,
+      note: reason,
+      adjustedBy: actorId || null
+    },
+    ledgerEntries: [ledgerEntry]
+  };
+}
+
 export async function loadTeamFeeManagementModel(teamId: string, batchId: string | undefined, user: AuthUser | null): Promise<TeamFeeManagementModel> {
   if (!teamId) throw new Error('Missing team context.');
   const team = await Promise.resolve(getTeam(teamId));
@@ -144,6 +199,30 @@ export async function recordOfflineTeamFeePayment({ teamId, batchId, recipient, 
   const updates = buildManualPaymentUpdate({
     amount,
     date,
+    note,
+    actorId: user?.uid,
+    currentBalanceCents: recipient.amountDueCents,
+    currentPaidCents: recipient.amountPaidCents
+  });
+
+  await Promise.resolve(updateTeamFeeRecipient(teamId, batchId, recipient.id, updates));
+  return updates;
+}
+
+export async function recordTeamFeeBalanceAdjustment({ teamId, batchId, recipient, amount, note, user }: {
+  teamId: string;
+  batchId: string;
+  recipient: TeamFeeRecipientSummary;
+  amount: string;
+  note: string;
+  user: AuthUser | null;
+}) {
+  if (!teamId || !batchId || !recipient?.id) throw new Error('Missing fee recipient context.');
+  const team = await Promise.resolve(getTeam(teamId));
+  if (!hasFullTeamAccess(user, team)) throw new Error('You do not have access to adjust team fee balances.');
+
+  const updates = buildBalanceAdjustmentUpdate({
+    amount,
     note,
     actorId: user?.uid,
     currentBalanceCents: recipient.amountDueCents,

--- a/apps/app/src/pages/TeamFees.test.tsx
+++ b/apps/app/src/pages/TeamFees.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TeamFees } from './TeamFees';
@@ -179,6 +179,32 @@ describe('TeamFees recipient queue', () => {
       note: 'Scholarship credit'
     }));
     expect((await screen.findAllByText('$75.00')).length).toBeGreaterThan(0);
+  });
+
+  it('disables both payment and adjustment controls while a recipient payment is submitting', async () => {
+    let resolvePayment: (() => void) | null = null;
+    teamFeesServiceMocks.recordOfflineTeamFeePayment.mockImplementation(
+      () => new Promise<void>((resolve) => {
+        resolvePayment = resolve;
+      })
+    );
+
+    renderTeamFees();
+
+    const recipientCard = (await screen.findByText('Unpaid Player')).closest('section');
+    if (!recipientCard) throw new Error('Recipient card not found');
+
+    fireEvent.click(within(recipientCard).getByRole('button', { name: 'Record payment' }));
+
+    expect(await within(recipientCard).findByRole('button', { name: 'Recording...' })).toBeDisabled();
+    expect(within(recipientCard).getByRole('button', { name: 'Save adjustment' })).toBeDisabled();
+    expect(within(recipientCard).getByDisplayValue('100.00')).toBeDisabled();
+    expect(within(recipientCard).getByPlaceholderText('25.00 or -10.00')).toBeDisabled();
+
+    await act(async () => {
+      resolvePayment?.();
+      await Promise.resolve();
+    });
   });
 
   it('shows the access guard instead of rendering adjustment controls for unauthorized users', async () => {

--- a/apps/app/src/pages/TeamFees.test.tsx
+++ b/apps/app/src/pages/TeamFees.test.tsx
@@ -1,12 +1,14 @@
-import { render, screen, within } from '@testing-library/react';
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { TeamFees } from './TeamFees';
 import type { AuthState } from '../lib/types';
 
 const teamFeesServiceMocks = vi.hoisted(() => ({
   loadTeamFeeManagementModel: vi.fn(),
-  recordOfflineTeamFeePayment: vi.fn()
+  recordOfflineTeamFeePayment: vi.fn(),
+  recordTeamFeeBalanceAdjustment: vi.fn()
 }));
 
 vi.mock('../lib/teamFeesService', () => teamFeesServiceMocks);
@@ -41,9 +43,17 @@ function renderTeamFees() {
 }
 
 describe('TeamFees recipient queue', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    teamFeesServiceMocks.recordOfflineTeamFeePayment.mockReset();
+    teamFeesServiceMocks.recordTeamFeeBalanceAdjustment.mockReset();
+    teamFeesServiceMocks.loadTeamFeeManagementModel.mockReset();
     teamFeesServiceMocks.recordOfflineTeamFeePayment.mockResolvedValue(undefined);
+    teamFeesServiceMocks.recordTeamFeeBalanceAdjustment.mockResolvedValue(undefined);
     teamFeesServiceMocks.loadTeamFeeManagementModel.mockResolvedValue({
       team: { id: 'team-1', name: 'Bears' },
       batches: [{ id: 'batch-1', title: 'Spring dues', dueDate: '2026-06-01', amountCents: 10000, status: 'open' }],
@@ -91,15 +101,17 @@ describe('TeamFees recipient queue', () => {
     renderTeamFees();
 
     const queue = await screen.findByLabelText('Actionable recipients');
-    expect(within(queue).getByText('Unpaid Player')).toBeInTheDocument();
-    expect(within(queue).getByText('Partial Player')).toBeInTheDocument();
-    expect(within(queue).queryByText('Paid Player')).not.toBeInTheDocument();
+    expect(within(queue).getByText('Unpaid Player')).toBeTruthy();
+    expect(within(queue).getByText('Partial Player')).toBeTruthy();
+    expect(within(queue).queryByText('Paid Player')).toBeNull();
     expect(within(queue).getAllByRole('button', { name: 'Record payment' })).toHaveLength(2);
-    expect(screen.getByDisplayValue('100.00')).toBeInTheDocument();
-    expect(screen.getByDisplayValue('75.00')).toBeInTheDocument();
+    expect(within(queue).getAllByRole('button', { name: 'Save adjustment' })).toHaveLength(2);
+    expect(screen.getByDisplayValue('100.00')).toBeTruthy();
+    expect(screen.getByDisplayValue('75.00')).toBeTruthy();
+    expect(screen.getAllByText('Positive credits reduce what is owed. Negative charges increase it.')).toHaveLength(3);
   });
 
-  it('renders paid recipients in a secondary review area without payment controls', async () => {
+  it('renders paid recipients in a secondary review area with adjustment-only controls', async () => {
     renderTeamFees();
 
     const paidSection = await screen.findByText('Paid recipients (1)');
@@ -107,10 +119,80 @@ describe('TeamFees recipient queue', () => {
     expect(reviewCard).not.toBeNull();
     if (!reviewCard) throw new Error('Paid recipients details not found');
 
-    expect(within(reviewCard).getByText('Paid Player')).toBeInTheDocument();
-    expect(within(reviewCard).queryByRole('button', { name: 'Record payment' })).not.toBeInTheDocument();
-    expect(within(reviewCard).queryByLabelText('Payment amount')).not.toBeInTheDocument();
-    expect(within(reviewCard).queryByLabelText('Payment date')).not.toBeInTheDocument();
-    expect(within(reviewCard).queryByLabelText('Note')).not.toBeInTheDocument();
+    expect(within(reviewCard).getByText('Paid Player')).toBeTruthy();
+    expect(within(reviewCard).queryByRole('button', { name: 'Record payment' })).toBeNull();
+    expect(within(reviewCard).queryByText('Record offline payment')).toBeNull();
+    expect(within(reviewCard).getByRole('button', { name: 'Save adjustment' })).toBeTruthy();
+    expect(within(reviewCard).getByText('Positive credits reduce what is owed. Negative charges increase it.')).toBeTruthy();
+  });
+
+  it('submits one recipient adjustment and refreshes the totals in place', async () => {
+    teamFeesServiceMocks.loadTeamFeeManagementModel
+      .mockResolvedValueOnce({
+        team: { id: 'team-1', name: 'Bears' },
+        batches: [{ id: 'batch-1', title: 'Spring dues', dueDate: '2026-06-01', amountCents: 10000, status: 'open' }],
+        selectedBatch: { id: 'batch-1', title: 'Spring dues', dueDate: '2026-06-01', amountCents: 10000, status: 'open' },
+        canManageFees: true,
+        recipients: [{
+          id: 'recipient-1',
+          playerName: 'Pat Star',
+          parentName: 'Pat Parent',
+          parentEmail: 'pat@example.com',
+          status: 'unpaid',
+          amountDueCents: 10000,
+          amountPaidCents: 0,
+          remainingBalanceCents: 10000,
+          paymentLedger: []
+        }]
+      })
+      .mockResolvedValueOnce({
+        team: { id: 'team-1', name: 'Bears' },
+        batches: [{ id: 'batch-1', title: 'Spring dues', dueDate: '2026-06-01', amountCents: 10000, status: 'open' }],
+        selectedBatch: { id: 'batch-1', title: 'Spring dues', dueDate: '2026-06-01', amountCents: 10000, status: 'open' },
+        canManageFees: true,
+        recipients: [{
+          id: 'recipient-1',
+          playerName: 'Pat Star',
+          parentName: 'Pat Parent',
+          parentEmail: 'pat@example.com',
+          status: 'unpaid',
+          amountDueCents: 7500,
+          amountPaidCents: 0,
+          remainingBalanceCents: 7500,
+          paymentLedger: [{ type: 'balance_adjustment', reason: 'Scholarship credit' }]
+        }]
+      });
+
+    renderTeamFees();
+
+    const recipientCard = (await screen.findByText('Pat Star')).closest('section');
+    if (!recipientCard) throw new Error('Recipient card not found');
+    fireEvent.change(within(recipientCard).getByPlaceholderText('25.00 or -10.00'), { target: { value: '25.00' } });
+    fireEvent.change(within(recipientCard).getByPlaceholderText('Scholarship credit, late fee, correction...'), { target: { value: 'Scholarship credit' } });
+    fireEvent.click(within(recipientCard).getByRole('button', { name: 'Save adjustment' }));
+
+    expect(await screen.findByText('Adjusted Pat Star by +$25.00.')).toBeTruthy();
+    expect(teamFeesServiceMocks.recordTeamFeeBalanceAdjustment).toHaveBeenCalledWith(expect.objectContaining({
+      teamId: 'team-1',
+      batchId: 'batch-1',
+      amount: '25.00',
+      note: 'Scholarship credit'
+    }));
+    expect((await screen.findAllByText('$75.00')).length).toBeGreaterThan(0);
+  });
+
+  it('shows the access guard instead of rendering adjustment controls for unauthorized users', async () => {
+    teamFeesServiceMocks.loadTeamFeeManagementModel.mockResolvedValue({
+      team: { id: 'team-1', name: 'Bears' },
+      batches: [],
+      selectedBatch: null,
+      canManageFees: false,
+      recipients: []
+    });
+
+    renderTeamFees();
+
+    expect(await screen.findByText('Admin access required')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Save adjustment' })).toBeNull();
   });
 });

--- a/apps/app/src/pages/TeamFees.tsx
+++ b/apps/app/src/pages/TeamFees.tsx
@@ -78,6 +78,8 @@ export function TeamFees({ auth }: { auth: AuthState }) {
     [recipients]
   );
 
+  const isRecipientSubmitting = (recipientId: string) => submittingId === `payment:${recipientId}` || submittingId === `adjustment:${recipientId}`;
+
   if (!teamId) return <Navigate to="/teams" replace />;
 
   const updateForm = (recipientId: string, patch: Partial<{ paymentAmount: string; paymentDate: string; paymentNote: string; paymentError: string; adjustmentAmount: string; adjustmentReason: string; adjustmentError: string }>) => {
@@ -233,6 +235,7 @@ export function TeamFees({ auth }: { auth: AuthState }) {
               adjustmentReason: '',
               adjustmentError: ''
             };
+            const recipientSubmitting = isRecipientSubmitting(recipient.id);
             return (
               <section key={recipient.id} className="app-card p-4">
                 <div className="flex items-start justify-between gap-3">
@@ -254,17 +257,17 @@ export function TeamFees({ auth }: { auth: AuthState }) {
                   <div className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Record offline payment</div>
                   <div className="grid gap-3 sm:grid-cols-2">
                     <label className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Payment amount
-                      <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" inputMode="decimal" value={form.paymentAmount} onChange={(event) => updateForm(recipient.id, { paymentAmount: event.target.value })} />
+                      <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" inputMode="decimal" value={form.paymentAmount} onChange={(event) => updateForm(recipient.id, { paymentAmount: event.target.value })} disabled={recipientSubmitting} />
                     </label>
                     <label className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Payment date
-                      <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" type="date" value={form.paymentDate} onChange={(event) => updateForm(recipient.id, { paymentDate: event.target.value })} />
+                      <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" type="date" value={form.paymentDate} onChange={(event) => updateForm(recipient.id, { paymentDate: event.target.value })} disabled={recipientSubmitting} />
                     </label>
                   </div>
                   <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Payment note
-                    <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" placeholder="Cash, check #, Venmo note..." value={form.paymentNote} onChange={(event) => updateForm(recipient.id, { paymentNote: event.target.value })} />
+                    <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" placeholder="Cash, check #, Venmo note..." value={form.paymentNote} onChange={(event) => updateForm(recipient.id, { paymentNote: event.target.value })} disabled={recipientSubmitting} />
                   </label>
                   {form.paymentError ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-2 text-xs font-bold text-rose-700">{form.paymentError}</div> : null}
-                  <button type="submit" className="primary-button w-full" disabled={submittingId === `payment:${recipient.id}`}>{submittingId === `payment:${recipient.id}` ? 'Recording...' : 'Record payment'}</button>
+                  <button type="submit" className="primary-button w-full" disabled={recipientSubmitting}>{submittingId === `payment:${recipient.id}` ? 'Recording...' : 'Record payment'}</button>
                 </form>
 
                 <form className="mt-4 space-y-3 rounded-2xl border border-gray-200 bg-gray-50 p-3" onSubmit={(event) => submitAdjustment(event, recipient)}>
@@ -273,13 +276,13 @@ export function TeamFees({ auth }: { auth: AuthState }) {
                     <p className="mt-1 text-xs font-semibold text-gray-500">Positive credits reduce what is owed. Negative charges increase it.</p>
                   </div>
                   <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Signed amount
-                    <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" inputMode="decimal" placeholder="25.00 or -10.00" value={form.adjustmentAmount} onChange={(event) => updateForm(recipient.id, { adjustmentAmount: event.target.value })} />
+                    <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" inputMode="decimal" placeholder="25.00 or -10.00" value={form.adjustmentAmount} onChange={(event) => updateForm(recipient.id, { adjustmentAmount: event.target.value })} disabled={recipientSubmitting} />
                   </label>
                   <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Reason
-                    <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" placeholder="Scholarship credit, late fee, correction..." value={form.adjustmentReason} onChange={(event) => updateForm(recipient.id, { adjustmentReason: event.target.value })} />
+                    <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" placeholder="Scholarship credit, late fee, correction..." value={form.adjustmentReason} onChange={(event) => updateForm(recipient.id, { adjustmentReason: event.target.value })} disabled={recipientSubmitting} />
                   </label>
                   {form.adjustmentError ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-2 text-xs font-bold text-rose-700">{form.adjustmentError}</div> : null}
-                  <button type="submit" className="secondary-button w-full justify-center" disabled={submittingId === `adjustment:${recipient.id}`}>{submittingId === `adjustment:${recipient.id}` ? 'Saving...' : 'Save adjustment'}</button>
+                  <button type="submit" className="secondary-button w-full justify-center" disabled={recipientSubmitting}>{submittingId === `adjustment:${recipient.id}` ? 'Saving...' : 'Save adjustment'}</button>
                 </form>
               </section>
             );
@@ -310,6 +313,7 @@ export function TeamFees({ auth }: { auth: AuthState }) {
                 adjustmentReason: '',
                 adjustmentError: ''
               };
+              const recipientSubmitting = isRecipientSubmitting(recipient.id);
               return (
               <section key={recipient.id} className="rounded-2xl border border-gray-200 bg-gray-50 p-4">
                 <div className="flex items-start justify-between gap-3">
@@ -333,13 +337,13 @@ export function TeamFees({ auth }: { auth: AuthState }) {
                     <p className="mt-1 text-xs font-semibold text-gray-500">Positive credits reduce what is owed. Negative charges increase it.</p>
                   </div>
                   <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Signed amount
-                    <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" inputMode="decimal" placeholder="25.00 or -10.00" value={form.adjustmentAmount} onChange={(event) => updateForm(recipient.id, { adjustmentAmount: event.target.value })} />
+                    <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" inputMode="decimal" placeholder="25.00 or -10.00" value={form.adjustmentAmount} onChange={(event) => updateForm(recipient.id, { adjustmentAmount: event.target.value })} disabled={recipientSubmitting} />
                   </label>
                   <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Reason
-                    <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" placeholder="Scholarship credit, late fee, correction..." value={form.adjustmentReason} onChange={(event) => updateForm(recipient.id, { adjustmentReason: event.target.value })} />
+                    <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" placeholder="Scholarship credit, late fee, correction..." value={form.adjustmentReason} onChange={(event) => updateForm(recipient.id, { adjustmentReason: event.target.value })} disabled={recipientSubmitting} />
                   </label>
                   {form.adjustmentError ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-2 text-xs font-bold text-rose-700">{form.adjustmentError}</div> : null}
-                  <button type="submit" className="secondary-button w-full justify-center" disabled={submittingId === `adjustment:${recipient.id}`}>{submittingId === `adjustment:${recipient.id}` ? 'Saving...' : 'Save adjustment'}</button>
+                  <button type="submit" className="secondary-button w-full justify-center" disabled={recipientSubmitting}>{submittingId === `adjustment:${recipient.id}` ? 'Saving...' : 'Save adjustment'}</button>
                 </form>
               </section>
               );

--- a/apps/app/src/pages/TeamFees.tsx
+++ b/apps/app/src/pages/TeamFees.tsx
@@ -4,6 +4,7 @@ import { CheckCircle2, DollarSign, Loader2, RefreshCw, Shield } from 'lucide-rea
 import {
   loadTeamFeeManagementModel,
   recordOfflineTeamFeePayment,
+  recordTeamFeeBalanceAdjustment,
   type TeamFeeManagementModel,
   type TeamFeeRecipientSummary
 } from '../lib/teamFeesService';
@@ -29,7 +30,7 @@ export function TeamFees({ auth }: { auth: AuthState }) {
   const [submittingId, setSubmittingId] = useState('');
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
-  const [formByRecipient, setFormByRecipient] = useState<Record<string, { amount: string; date: string; note: string; error: string }>>({});
+  const [formByRecipient, setFormByRecipient] = useState<Record<string, { paymentAmount: string; paymentDate: string; paymentNote: string; paymentError: string; adjustmentAmount: string; adjustmentReason: string; adjustmentError: string }>>({});
 
   const selectedBatchId = model?.selectedBatch?.id || '';
 
@@ -79,33 +80,84 @@ export function TeamFees({ auth }: { auth: AuthState }) {
 
   if (!teamId) return <Navigate to="/teams" replace />;
 
-  const updateForm = (recipientId: string, patch: Partial<{ amount: string; date: string; note: string; error: string }>) => {
+  const updateForm = (recipientId: string, patch: Partial<{ paymentAmount: string; paymentDate: string; paymentNote: string; paymentError: string; adjustmentAmount: string; adjustmentReason: string; adjustmentError: string }>) => {
     setFormByRecipient((current) => ({
       ...current,
-      [recipientId]: { ...(current[recipientId] || { amount: '', date: todayIsoDate(), note: '', error: '' }), ...patch }
+      [recipientId]: {
+        ...(current[recipientId] || {
+          paymentAmount: '',
+          paymentDate: todayIsoDate(),
+          paymentNote: '',
+          paymentError: '',
+          adjustmentAmount: '',
+          adjustmentReason: '',
+          adjustmentError: ''
+        }),
+        ...patch
+      }
     }));
   };
 
   const submitPayment = async (event: FormEvent<HTMLFormElement>, recipient: TeamFeeRecipientSummary) => {
     event.preventDefault();
-    const form = formByRecipient[recipient.id] || { amount: centsToAmount(recipient.remainingBalanceCents), date: todayIsoDate(), note: '', error: '' };
-    updateForm(recipient.id, { error: '' });
+    const form = formByRecipient[recipient.id] || {
+      paymentAmount: centsToAmount(recipient.remainingBalanceCents),
+      paymentDate: todayIsoDate(),
+      paymentNote: '',
+      paymentError: '',
+      adjustmentAmount: '',
+      adjustmentReason: '',
+      adjustmentError: ''
+    };
+    updateForm(recipient.id, { paymentError: '' });
     setSuccess('');
-    setSubmittingId(recipient.id);
+    setSubmittingId(`payment:${recipient.id}`);
     try {
       await recordOfflineTeamFeePayment({
         teamId,
         batchId: selectedBatchId,
         recipient,
-        amount: form.amount,
-        date: form.date,
-        note: form.note,
+        amount: form.paymentAmount,
+        date: form.paymentDate,
+        note: form.paymentNote,
         user: auth.user
       });
-      setSuccess(`Recorded ${formatMoney(Number(form.amount) * 100)} for ${recipient.playerName}.`);
+      setSuccess(`Recorded ${formatMoney(Number(form.paymentAmount) * 100)} for ${recipient.playerName}.`);
       await refresh();
     } catch (submitError: any) {
-      updateForm(recipient.id, { error: submitError?.message || 'Unable to record payment.' });
+      updateForm(recipient.id, { paymentError: submitError?.message || 'Unable to record payment.' });
+    } finally {
+      setSubmittingId('');
+    }
+  };
+
+  const submitAdjustment = async (event: FormEvent<HTMLFormElement>, recipient: TeamFeeRecipientSummary) => {
+    event.preventDefault();
+    const form = formByRecipient[recipient.id] || {
+      paymentAmount: centsToAmount(recipient.remainingBalanceCents),
+      paymentDate: todayIsoDate(),
+      paymentNote: '',
+      paymentError: '',
+      adjustmentAmount: '',
+      adjustmentReason: '',
+      adjustmentError: ''
+    };
+    updateForm(recipient.id, { adjustmentError: '' });
+    setSuccess('');
+    setSubmittingId(`adjustment:${recipient.id}`);
+    try {
+      await recordTeamFeeBalanceAdjustment({
+        teamId,
+        batchId: selectedBatchId,
+        recipient,
+        amount: form.adjustmentAmount,
+        note: form.adjustmentReason,
+        user: auth.user
+      });
+      setSuccess(`Adjusted ${recipient.playerName} by ${formatSignedMoney(form.adjustmentAmount)}.`);
+      await refresh();
+    } catch (submitError: any) {
+      updateForm(recipient.id, { adjustmentError: submitError?.message || 'Unable to save adjustment.' });
     } finally {
       setSubmittingId('');
     }
@@ -126,7 +178,7 @@ export function TeamFees({ auth }: { auth: AuthState }) {
   }
 
   if (!model.canManageFees) {
-    return <StatusCard title="Admin access required" message="Only team owners, team admins, and global admins can record offline team fee payments." backTo={`/teams/${encodeURIComponent(teamId)}`} />;
+    return <StatusCard title="Admin access required" message="Only team owners, team admins, and global admins can record offline team fee payments or adjust balances." backTo={`/teams/${encodeURIComponent(teamId)}`} />;
   }
 
   return (
@@ -135,8 +187,8 @@ export function TeamFees({ auth }: { auth: AuthState }) {
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div>
             <div className="flex items-center gap-2 text-xs font-black uppercase tracking-[0.06em] text-primary-700"><DollarSign className="h-4 w-4" aria-hidden="true" /> Team fees</div>
-            <h1 className="mt-1 text-2xl font-black text-gray-950">Record offline payment</h1>
-            <p className="mt-1 text-sm font-semibold text-gray-600">{model.team.name}: record cash, check, or other offline payments against existing fee recipients.</p>
+            <h1 className="mt-1 text-2xl font-black text-gray-950">Manage fee balances</h1>
+            <p className="mt-1 text-sm font-semibold text-gray-600">{model.team.name}: record offline payments and apply one signed balance adjustment with a required reason for each recipient.</p>
           </div>
           <button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading}>
             <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" /> Refresh
@@ -172,7 +224,15 @@ export function TeamFees({ auth }: { auth: AuthState }) {
         </div>
         <div className="grid gap-3 lg:grid-cols-2">
           {actionableRecipients.length ? actionableRecipients.map((recipient) => {
-            const form = formByRecipient[recipient.id] || { amount: centsToAmount(recipient.remainingBalanceCents), date: todayIsoDate(), note: '', error: '' };
+            const form = formByRecipient[recipient.id] || {
+              paymentAmount: centsToAmount(recipient.remainingBalanceCents),
+              paymentDate: todayIsoDate(),
+              paymentNote: '',
+              paymentError: '',
+              adjustmentAmount: '',
+              adjustmentReason: '',
+              adjustmentError: ''
+            };
             return (
               <section key={recipient.id} className="app-card p-4">
                 <div className="flex items-start justify-between gap-3">
@@ -183,26 +243,43 @@ export function TeamFees({ auth }: { auth: AuthState }) {
                   <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-black uppercase text-gray-700">{recipient.status}</span>
                 </div>
 
-                <div className="mt-3 grid grid-cols-3 gap-2 text-center">
+                <div className="mt-3 grid grid-cols-2 gap-2 text-center sm:grid-cols-4">
+                  <Metric label="Status" value={recipient.status} />
+                  <Metric label="Amount due" value={formatMoney(recipient.amountDueCents)} />
                   <Metric label="Paid" value={formatMoney(recipient.amountPaidCents)} />
-                  <Metric label="Balance" value={formatMoney(recipient.remainingBalanceCents)} urgent={recipient.remainingBalanceCents > 0} />
-                  <Metric label="Ledger" value={String(recipient.paymentLedger.length)} />
+                  <Metric label="Outstanding" value={formatMoney(recipient.remainingBalanceCents)} urgent={recipient.remainingBalanceCents > 0} />
                 </div>
 
                 <form className="mt-4 space-y-3" onSubmit={(event) => submitPayment(event, recipient)}>
+                  <div className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Record offline payment</div>
                   <div className="grid gap-3 sm:grid-cols-2">
                     <label className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Payment amount
-                      <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" inputMode="decimal" value={form.amount} onChange={(event) => updateForm(recipient.id, { amount: event.target.value })} />
+                      <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" inputMode="decimal" value={form.paymentAmount} onChange={(event) => updateForm(recipient.id, { paymentAmount: event.target.value })} />
                     </label>
                     <label className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Payment date
-                      <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" type="date" value={form.date} onChange={(event) => updateForm(recipient.id, { date: event.target.value })} />
+                      <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" type="date" value={form.paymentDate} onChange={(event) => updateForm(recipient.id, { paymentDate: event.target.value })} />
                     </label>
                   </div>
-                  <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Note
-                    <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" placeholder="Cash, check #, Venmo note..." value={form.note} onChange={(event) => updateForm(recipient.id, { note: event.target.value })} />
+                  <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Payment note
+                    <input className="mt-1 w-full rounded-2xl border border-gray-200 px-3 py-3 text-sm font-bold text-gray-900" placeholder="Cash, check #, Venmo note..." value={form.paymentNote} onChange={(event) => updateForm(recipient.id, { paymentNote: event.target.value })} />
                   </label>
-                  {form.error ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-2 text-xs font-bold text-rose-700">{form.error}</div> : null}
-                  <button type="submit" className="primary-button w-full" disabled={submittingId === recipient.id}>{submittingId === recipient.id ? 'Recording...' : 'Record payment'}</button>
+                  {form.paymentError ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-2 text-xs font-bold text-rose-700">{form.paymentError}</div> : null}
+                  <button type="submit" className="primary-button w-full" disabled={submittingId === `payment:${recipient.id}`}>{submittingId === `payment:${recipient.id}` ? 'Recording...' : 'Record payment'}</button>
+                </form>
+
+                <form className="mt-4 space-y-3 rounded-2xl border border-gray-200 bg-gray-50 p-3" onSubmit={(event) => submitAdjustment(event, recipient)}>
+                  <div>
+                    <div className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Adjust balance</div>
+                    <p className="mt-1 text-xs font-semibold text-gray-500">Positive credits reduce what is owed. Negative charges increase it.</p>
+                  </div>
+                  <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Signed amount
+                    <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" inputMode="decimal" placeholder="25.00 or -10.00" value={form.adjustmentAmount} onChange={(event) => updateForm(recipient.id, { adjustmentAmount: event.target.value })} />
+                  </label>
+                  <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Reason
+                    <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" placeholder="Scholarship credit, late fee, correction..." value={form.adjustmentReason} onChange={(event) => updateForm(recipient.id, { adjustmentReason: event.target.value })} />
+                  </label>
+                  {form.adjustmentError ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-2 text-xs font-bold text-rose-700">{form.adjustmentError}</div> : null}
+                  <button type="submit" className="secondary-button w-full justify-center" disabled={submittingId === `adjustment:${recipient.id}`}>{submittingId === `adjustment:${recipient.id}` ? 'Saving...' : 'Save adjustment'}</button>
                 </form>
               </section>
             );
@@ -223,7 +300,17 @@ export function TeamFees({ auth }: { auth: AuthState }) {
           </summary>
           <p className="mt-2 text-xs font-semibold text-gray-500">Fully paid recipients stay available for review without editable payment controls.</p>
           <div className="mt-4 grid gap-3 lg:grid-cols-2">
-            {paidRecipients.map((recipient) => (
+            {paidRecipients.map((recipient) => {
+              const form = formByRecipient[recipient.id] || {
+                paymentAmount: centsToAmount(recipient.remainingBalanceCents),
+                paymentDate: todayIsoDate(),
+                paymentNote: '',
+                paymentError: '',
+                adjustmentAmount: '',
+                adjustmentReason: '',
+                adjustmentError: ''
+              };
+              return (
               <section key={recipient.id} className="rounded-2xl border border-gray-200 bg-gray-50 p-4">
                 <div className="flex items-start justify-between gap-3">
                   <div>
@@ -233,13 +320,30 @@ export function TeamFees({ auth }: { auth: AuthState }) {
                   <span className="rounded-full bg-emerald-100 px-2.5 py-1 text-xs font-black uppercase text-emerald-700">{recipient.status}</span>
                 </div>
 
-                <div className="mt-3 grid grid-cols-3 gap-2 text-center">
+                <div className="mt-3 grid grid-cols-2 gap-2 text-center sm:grid-cols-4">
+                  <Metric label="Status" value={recipient.status} />
+                  <Metric label="Amount due" value={formatMoney(recipient.amountDueCents)} />
                   <Metric label="Paid" value={formatMoney(recipient.amountPaidCents)} />
-                  <Metric label="Balance" value={formatMoney(recipient.remainingBalanceCents)} />
-                  <Metric label="Ledger" value={String(recipient.paymentLedger.length)} />
+                  <Metric label="Outstanding" value={formatMoney(recipient.remainingBalanceCents)} />
                 </div>
+
+                <form className="mt-4 space-y-3 rounded-2xl border border-gray-200 bg-white p-3" onSubmit={(event) => submitAdjustment(event, recipient)}>
+                  <div>
+                    <div className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Adjust balance</div>
+                    <p className="mt-1 text-xs font-semibold text-gray-500">Positive credits reduce what is owed. Negative charges increase it.</p>
+                  </div>
+                  <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Signed amount
+                    <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" inputMode="decimal" placeholder="25.00 or -10.00" value={form.adjustmentAmount} onChange={(event) => updateForm(recipient.id, { adjustmentAmount: event.target.value })} />
+                  </label>
+                  <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Reason
+                    <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" placeholder="Scholarship credit, late fee, correction..." value={form.adjustmentReason} onChange={(event) => updateForm(recipient.id, { adjustmentReason: event.target.value })} />
+                  </label>
+                  {form.adjustmentError ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-2 text-xs font-bold text-rose-700">{form.adjustmentError}</div> : null}
+                  <button type="submit" className="secondary-button w-full justify-center" disabled={submittingId === `adjustment:${recipient.id}`}>{submittingId === `adjustment:${recipient.id}` ? 'Saving...' : 'Save adjustment'}</button>
+                </form>
               </section>
-            ))}
+              );
+            })}
           </div>
         </details>
       ) : null}
@@ -248,23 +352,32 @@ export function TeamFees({ auth }: { auth: AuthState }) {
         <section className="app-card p-5 text-center">
           <DollarSign className="mx-auto h-8 w-8 text-gray-400" aria-hidden="true" />
           <div className="mt-3 text-sm font-black text-gray-950">No fee recipients</div>
-          <p className="mt-1 text-xs font-semibold text-gray-500">Create fee batches in the full website manager, then record offline payments here.</p>
+          <p className="mt-1 text-xs font-semibold text-gray-500">Create fee batches in the full website manager, then record offline payments or adjustments here.</p>
         </section>
       ) : null}
     </div>
   );
 }
 
-function seedRecipientForms(current: Record<string, { amount: string; date: string; note: string; error: string }>, recipients: TeamFeeRecipientSummary[]) {
-  return recipients.reduce<Record<string, { amount: string; date: string; note: string; error: string }>>((next, recipient) => {
+function seedRecipientForms(current: Record<string, { paymentAmount: string; paymentDate: string; paymentNote: string; paymentError: string; adjustmentAmount: string; adjustmentReason: string; adjustmentError: string }>, recipients: TeamFeeRecipientSummary[]) {
+  return recipients.reduce<Record<string, { paymentAmount: string; paymentDate: string; paymentNote: string; paymentError: string; adjustmentAmount: string; adjustmentReason: string; adjustmentError: string }>>((next, recipient) => {
     next[recipient.id] = current[recipient.id] || {
-      amount: centsToAmount(recipient.remainingBalanceCents),
-      date: todayIsoDate(),
-      note: '',
-      error: ''
+      paymentAmount: centsToAmount(recipient.remainingBalanceCents),
+      paymentDate: todayIsoDate(),
+      paymentNote: '',
+      paymentError: '',
+      adjustmentAmount: '',
+      adjustmentReason: '',
+      adjustmentError: ''
     };
     return next;
   }, {});
+}
+
+function formatSignedMoney(value: string) {
+  const amount = Number(String(value || '').replace(/[$,]/g, '').trim());
+  if (!Number.isFinite(amount)) return String(value || '').trim();
+  return `${amount >= 0 ? '+' : '-'}${formatMoney(Math.round(Math.abs(amount) * 100))}`;
 }
 
 function Metric({ label, value, urgent = false }: { label: string; value: string; urgent?: boolean }) {

--- a/tests/unit/app-team-fees-service.test.ts
+++ b/tests/unit/app-team-fees-service.test.ts
@@ -13,9 +13,11 @@ vi.mock('../../js/team-access.js', () => ({
 }));
 
 import {
+    buildBalanceAdjustmentUpdate,
     buildManualPaymentUpdate,
     loadTeamFeeManagementModel,
-    recordOfflineTeamFeePayment
+    recordOfflineTeamFeePayment,
+    recordTeamFeeBalanceAdjustment
 } from '../../apps/app/src/lib/teamFeesService.ts';
 
 describe('React app team fee offline payment service', () => {
@@ -73,6 +75,59 @@ describe('React app team fee offline payment service', () => {
         expect(() => buildManualPaymentUpdate({ amount: '0', date: '2026-05-28' })).toThrow('greater than $0');
         expect(() => buildManualPaymentUpdate({ amount: '-1.00', date: '2026-05-28' })).toThrow('greater than $0');
         expect(() => buildManualPaymentUpdate({ amount: '5.00', date: '' })).toThrow('payment date');
+    });
+
+    it('treats positive adjustments as credits that reduce the amount owed', () => {
+        const update = buildBalanceAdjustmentUpdate({
+            amount: '20.00',
+            note: 'Scholarship credit',
+            actorId: 'coach-1',
+            currentBalanceCents: 15000,
+            currentPaidCents: 2500
+        });
+
+        expect(update).toMatchObject({
+            status: 'partial',
+            amountDueCents: 13000,
+            remainingBalanceCents: 10500,
+            adjustment: {
+                amountCents: 2000,
+                previousAmountDueCents: 15000,
+                amountDueCents: 13000,
+                note: 'Scholarship credit',
+                adjustedBy: 'coach-1'
+            }
+        });
+        expect(update.ledgerEntries).toEqual([
+            expect.objectContaining({
+                type: 'balance_adjustment',
+                amountCents: 2000,
+                previousAmountDueCents: 15000,
+                amountDueCents: 13000,
+                reason: 'Scholarship credit'
+            })
+        ]);
+    });
+
+    it('treats negative adjustments as charges that increase the amount owed', () => {
+        const update = buildBalanceAdjustmentUpdate({
+            amount: '-5.00',
+            note: 'Late fee',
+            actorId: 'coach-1',
+            currentBalanceCents: 15000,
+            currentPaidCents: 0
+        });
+
+        expect(update.status).toBe('unpaid');
+        expect(update.amountDueCents).toBe(15500);
+        expect(update.remainingBalanceCents).toBe(15500);
+        expect(update.adjustment.amountCents).toBe(-500);
+    });
+
+    it('rejects zero adjustments and missing reasons', () => {
+        expect(() => buildBalanceAdjustmentUpdate({ amount: '0', note: 'No-op' })).toThrow('positive or negative adjustment');
+        expect(() => buildBalanceAdjustmentUpdate({ amount: '', note: 'No-op' })).toThrow('positive or negative adjustment');
+        expect(() => buildBalanceAdjustmentUpdate({ amount: '5.00', note: '' })).toThrow('adjustment reason');
     });
 
     it('loads batches and recipients only for fee managers', async () => {
@@ -159,10 +214,11 @@ describe('React app team fee offline payment service', () => {
         }));
     });
 
-    it('blocks non-managers from recording offline payments', async () => {
+    it('writes balance adjustments to the existing recipient document', async () => {
         dbMocks.getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears', ownerId: 'coach-1' });
+        dbMocks.updateTeamFeeRecipient.mockResolvedValue(undefined);
 
-        await expect(recordOfflineTeamFeePayment({
+        await recordTeamFeeBalanceAdjustment({
             teamId: 'team-1',
             batchId: 'batch-1',
             recipient: {
@@ -170,14 +226,55 @@ describe('React app team fee offline payment service', () => {
                 playerName: 'Pat Star',
                 parentName: '',
                 parentEmail: '',
-                status: 'unpaid',
+                status: 'paid',
                 amountDueCents: 10000,
-                amountPaidCents: 0,
-                remainingBalanceCents: 10000,
+                amountPaidCents: 10000,
+                remainingBalanceCents: 0,
                 paymentLedger: []
             },
+            amount: '-10.00',
+            note: 'Late fee',
+            user: { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: [] }
+        });
+
+        expect(dbMocks.updateTeamFeeRecipient).toHaveBeenCalledWith('team-1', 'batch-1', 'recipient-1', expect.objectContaining({
+            status: 'partial',
+            amountDueCents: 11000,
+            remainingBalanceCents: 1000,
+            adjustment: expect.objectContaining({ amountCents: -1000, note: 'Late fee' }),
+            ledgerEntries: [expect.objectContaining({ type: 'balance_adjustment', amountCents: -1000, reason: 'Late fee' })]
+        }));
+    });
+
+    it('blocks non-managers from recording offline payments or adjustments', async () => {
+        dbMocks.getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears', ownerId: 'coach-1' });
+
+        const recipient = {
+            id: 'recipient-1',
+            playerName: 'Pat Star',
+            parentName: '',
+            parentEmail: '',
+            status: 'unpaid',
+            amountDueCents: 10000,
+            amountPaidCents: 0,
+            remainingBalanceCents: 10000,
+            paymentLedger: []
+        };
+
+        await expect(recordOfflineTeamFeePayment({
+            teamId: 'team-1',
+            batchId: 'batch-1',
+            recipient,
             amount: '10.00',
             date: '2026-05-28',
+            user: { uid: 'parent-1', email: 'parent@example.com', displayName: 'Parent', roles: [] }
+        })).rejects.toThrow('do not have access');
+        await expect(recordTeamFeeBalanceAdjustment({
+            teamId: 'team-1',
+            batchId: 'batch-1',
+            recipient,
+            amount: '10.00',
+            note: 'Scholarship',
             user: { uid: 'parent-1', email: 'parent@example.com', displayName: 'Parent', roles: [] }
         })).rejects.toThrow('do not have access');
         expect(dbMocks.updateTeamFeeRecipient).not.toHaveBeenCalled();


### PR DESCRIPTION
Closes #1540

## What changed
- added native team fee balance adjustment support to the React app team fees screen
- ported the legacy `buildBalanceAdjustmentUpdate` semantics into `teamFeesService` so signed credits and charges update `amountDueCents`, `remainingBalanceCents`, `status`, and append a `balance_adjustment` ledger entry
- added authorized coach/admin submission flow and in-place refresh messaging for recipient balance updates
- extended focused service and page tests to cover adjustment math, persistence, authorized UI behavior, refresh after submit, and unauthorized access blocking

## Why
The app already supported adjacent fee management work, but coaches and admins still had to fall back to the legacy web page for manual recipient balance adjustments. This closes that parity gap with the smallest app-local patch and preserves legacy calculation behavior.