### PR TITLE
Harden Team Media team chat posting

### DIFF
--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -820,7 +820,7 @@ export async function sendTeamChatMessage({
   profile,
   text,
   files = [],
-  existingAttachments = [],
+  attachments: sharedAttachments = [],
   selectedConversation,
   selectedConversationId,
   selectedRecipientTarget,
@@ -833,7 +833,7 @@ export async function sendTeamChatMessage({
   profile: Record<string, any>;
   text: string;
   files?: File[];
-  existingAttachments?: ChatAttachment[];
+  attachments?: ChatAttachment[];
   selectedConversation?: ChatConversation | null;
   selectedConversationId: string;
   selectedRecipientTarget: ChatTargetType;
@@ -847,15 +847,14 @@ export async function sendTeamChatMessage({
   }
 
   const uploadedAttachments: ChatAttachment[] = [];
-  const attachments: ChatAttachment[] = [...existingAttachments];
   try {
     for (const file of files) {
       onProgress?.('uploading');
-      const uploadedAttachment = await uploadTeamChatAttachment(teamId, file);
-      uploadedAttachments.push(uploadedAttachment);
-      attachments.push(uploadedAttachment);
+      uploadedAttachments.push(await uploadTeamChatAttachment(teamId, file));
     }
     onProgress?.('posting');
+
+    const attachments = [...sharedAttachments, ...uploadedAttachments];
 
     const targetMetadata = buildChatAudienceMetadata({
       selectedConversation,

--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -9,6 +9,7 @@ import {
   getTeamMediaFolders,
   getTeamMediaItems,
   getTeams,
+  canAccessTeamChat,
   listCertificatesForPlayer,
   listFamilyShareTokens,
   listMyParentMembershipRequests,
@@ -47,7 +48,6 @@ import {
   canContributeTeamMedia,
   canManageTeamMedia,
   canReadTeamMediaAlbum,
-  canAccessTeamChat,
   getTeamMediaItemUrl,
   isSafeTeamMediaUrl,
   sortByMediaOrder

--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -47,6 +47,7 @@ import {
   canContributeTeamMedia,
   canManageTeamMedia,
   canReadTeamMediaAlbum,
+  canAccessTeamChat,
   getTeamMediaItemUrl,
   isSafeTeamMediaUrl,
   sortByMediaOrder
@@ -209,6 +210,7 @@ export type TeamMediaModel = {
   team: Record<string, any>;
   canManage: boolean;
   canContribute: boolean;
+  canPostChat: boolean;
   folders: TeamMediaFolder[];
 };
 
@@ -661,8 +663,10 @@ export async function loadTeamMediaForApp(user: AuthUser | null, teamId: string)
   const team = await Promise.resolve(getTeam(teamId));
   if (!team) throw new Error('Team not found.');
   const appUser = user ? { ...user, parentOf: user.parentOf || [] } : null;
-  const canManage = canManageTeamMedia(appUser, { ...team, id: teamId });
-  const canContribute = canContributeTeamMedia(appUser, { ...team, id: teamId });
+  const teamWithId = { ...team, id: teamId };
+  const canManage = canManageTeamMedia(appUser, teamWithId);
+  const canContribute = canContributeTeamMedia(appUser, teamWithId);
+  const canPostChat = canAccessTeamChat(appUser, teamWithId);
   const folders = await Promise.resolve(getTeamMediaFolders(teamId, { includePrivate: canManage }));
   const visibleFolders = (folders || [])
     .filter((folder: any) => canManage || canReadTeamMediaAlbum(folder, false));
@@ -682,9 +686,10 @@ export async function loadTeamMediaForApp(user: AuthUser | null, teamId: string)
   });
 
   return {
-    team: { ...team, id: teamId },
+    team: teamWithId,
     canManage,
     canContribute,
+    canPostChat,
     folders: folderCards
   };
 }

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -532,7 +532,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
               item={item}
               onStatus={(tone, msg) => tone === 'error' ? setError(msg) : setMessage(msg)}
               canManage={model.canManage}
-              canPostToChat={model.canContribute && Boolean(auth.user)}
+              canPostToChat={model.canPostChat && Boolean(auth.user)}
               currentUserId={auth.user?.uid || ''}
               folders={model.folders}
               currentFolderId={activeFolder?.id || ''}

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -59,6 +59,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const [renamingItemId, setRenamingItemId] = useState('');
   const [movingItemId, setMovingItemId] = useState('');
   const [postingItemId, setPostingItemId] = useState('');
+  const postingItemIdRef = useRef('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
 
@@ -156,8 +157,9 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   };
 
   const handlePostItemToChat = async (item: TeamMediaItem, caption = '') => {
-    if (!teamId || !auth.user || !item?.id || postingItemId) return false;
+    if (!teamId || !auth.user || !item?.id || postingItemIdRef.current) return false;
 
+    postingItemIdRef.current = item.id;
     setPostingItemId(item.id);
     setError('');
     setMessage('');
@@ -188,6 +190,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
       setError(postError?.message || 'Unable to post photo to team chat. Try again.');
       return false;
     } finally {
+      postingItemIdRef.current = '';
       setPostingItemId('');
     }
   };
@@ -532,7 +535,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
               item={item}
               onStatus={(tone, msg) => tone === 'error' ? setError(msg) : setMessage(msg)}
               canManage={model.canManage}
-              canPostToChat={model.canPostChat && Boolean(auth.user)}
+              canPostToChat={model.canPostChat && model.canContribute && Boolean(auth.user)}
               currentUserId={auth.user?.uid || ''}
               folders={model.folders}
               currentFolderId={activeFolder?.id || ''}
@@ -843,7 +846,7 @@ function TeamMediaItemCard({
             <div className="mt-2 flex gap-2">
               <button type="button" className="primary-button !h-8 !min-h-8 !px-2 !text-xs" onClick={postToTeamChat} disabled={posting}>
                 {posting ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" /> : <MessageCircle className="h-3.5 w-3.5" aria-hidden="true" />}
-                Send to chat
+                {posting ? 'Posting' : 'Send to chat'}
               </button>
               <button type="button" className="ghost-button !h-8 !min-h-8 !px-2 !text-xs" onClick={() => setIsPosting(false)} disabled={posting}>Cancel</button>
             </div>

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -58,9 +58,9 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const [deletingItemId, setDeletingItemId] = useState('');
   const [renamingItemId, setRenamingItemId] = useState('');
   const [movingItemId, setMovingItemId] = useState('');
+  const [postingItemId, setPostingItemId] = useState('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
-  const [postingItemId, setPostingItemId] = useState('');
 
   const refresh = async ({ showLoading = model === null, preferredFolderId = '' }: { showLoading?: boolean; preferredFolderId?: string } = {}) => {
     if (!teamId) return;
@@ -152,6 +152,43 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
       setError(moveError?.message || 'Unable to move media item.');
     } finally {
       setMovingItemId('');
+    }
+  };
+
+  const handlePostItemToChat = async (item: TeamMediaItem, caption = '') => {
+    if (!teamId || !auth.user || !item?.id || postingItemId) return false;
+
+    setPostingItemId(item.id);
+    setError('');
+    setMessage('');
+    try {
+      const attachment: ChatAttachment = {
+        type: 'image',
+        url: item.url,
+        name: item.title || 'Team media photo',
+        mimeType: null,
+        size: null,
+        path: null,
+        thumbnailUrl: item.url
+      };
+      await sendTeamChatMessage({
+        teamId,
+        user: auth.user,
+        profile: auth.profile || {},
+        text: caption.trim(),
+        attachments: [attachment],
+        selectedConversation: null,
+        selectedConversationId: DEFAULT_TEAM_CONVERSATION_ID,
+        selectedRecipientTarget: 'full_team',
+        selectedRecipientIds: []
+      });
+      setMessage('Photo posted to team chat.');
+      return true;
+    } catch (postError: any) {
+      setError(postError?.message || 'Unable to post photo to team chat. Try again.');
+      return false;
+    } finally {
+      setPostingItemId('');
     }
   };
 
@@ -490,39 +527,24 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
         </div>
         <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {filteredItems.length ? filteredItems.map((item) => (
-            <TeamMediaItemCard key={item.id} item={item} onStatus={(tone, msg) => tone === 'error' ? setError(msg) : setMessage(msg)} canManage={model.canManage} currentUserId={auth.user?.uid || ''} folders={model.folders} currentFolderId={activeFolder?.id || ''} deleting={deletingItemId === item.id} renaming={renamingItemId === item.id} moving={movingItemId === item.id} posting={postingItemId === item.id} onRenameItem={handleRenameItem} onDeleteItem={handleDeleteItem} onMoveItem={handleMoveItem} onPostToTeamChat={async (item, caption) => {
-              if (!teamId || !auth.user) return;
-              setPostingItemId(item.id);
-              setError('');
-              setMessage('');
-              try {
-                const existingAttachment: ChatAttachment = {
-                  type: 'image',
-                  url: item.url,
-                  name: item.title || 'Team media photo',
-                  mimeType: null,
-                  path: null,
-                  size: null,
-                  thumbnailUrl: item.url,
-                };
-                await sendTeamChatMessage({
-                  teamId,
-                  user: auth.user,
-                  profile: auth.profile || {},
-                  text: caption.trim(),
-                  existingAttachments: [existingAttachment],
-                  selectedConversationId: DEFAULT_TEAM_CONVERSATION_ID,
-                  selectedRecipientTarget: 'full_team',
-                  selectedRecipientIds: [],
-                });
-                setMessage('Photo posted to team chat.');
-              } catch (postError: any) {
-                setError(postError?.message || 'Unable to post photo to team chat.');
-                throw postError;
-              } finally {
-                setPostingItemId('');
-              }
-            }} />
+            <TeamMediaItemCard
+              key={item.id}
+              item={item}
+              onStatus={(tone, msg) => tone === 'error' ? setError(msg) : setMessage(msg)}
+              canManage={model.canManage}
+              canPostToChat={model.canContribute && Boolean(auth.user)}
+              currentUserId={auth.user?.uid || ''}
+              folders={model.folders}
+              currentFolderId={activeFolder?.id || ''}
+              deleting={deletingItemId === item.id}
+              renaming={renamingItemId === item.id}
+              moving={movingItemId === item.id}
+              posting={postingItemId === item.id}
+              onRenameItem={handleRenameItem}
+              onDeleteItem={handleDeleteItem}
+              onMoveItem={handleMoveItem}
+              onPostToChat={handlePostItemToChat}
+            />
           )) : (
             <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">No {emptyStateLabel} in this album.</div>
           )}
@@ -608,6 +630,7 @@ function TeamMediaItemCard({
   item,
   onStatus,
   canManage,
+  canPostToChat,
   currentUserId,
   folders,
   currentFolderId,
@@ -618,11 +641,12 @@ function TeamMediaItemCard({
   onRenameItem,
   onDeleteItem,
   onMoveItem,
-  onPostToTeamChat
+  onPostToChat
 }: {
   item: TeamMediaItem;
   onStatus: (tone: 'error' | 'success', message: string) => void;
   canManage: boolean;
+  canPostToChat: boolean;
   currentUserId: string;
   folders: TeamMediaFolder[];
   currentFolderId: string;
@@ -633,7 +657,7 @@ function TeamMediaItemCard({
   onRenameItem: (item: TeamMediaItem, title: string) => Promise<void>;
   onDeleteItem: (item: TeamMediaItem) => void;
   onMoveItem: (item: TeamMediaItem, targetFolderId: string) => Promise<void>;
-  onPostToTeamChat: (item: TeamMediaItem, caption: string) => Promise<void>;
+  onPostToChat: (item: TeamMediaItem, caption: string) => Promise<boolean>;
 }) {
   const Icon = getItemIcon(item);
   const isPhoto = isPhotoMediaItem(item);
@@ -648,7 +672,7 @@ function TeamMediaItemCard({
   const selectedMoveFolderId = moveFolderId && moveFolderId !== currentFolderId ? moveFolderId : '';
   const canRename = canManage || item.uploadedBy === currentUserId;
   const canDelete = canManage || (['photo', 'file'].includes(String(item.type || '').toLowerCase()) && item.uploadedBy === currentUserId);
-  const canPostToTeamChat = canManage && isPhoto && Boolean(item.url);
+  const canPostToTeamChat = canPostToChat && isPhoto && Boolean(item.url);
 
   const startRename = () => {
     setDraftTitle(title);
@@ -672,7 +696,9 @@ function TeamMediaItemCard({
   };
 
   const postToTeamChat = async () => {
-    await onPostToTeamChat(item, postCaption);
+    if (posting) return;
+    const posted = await onPostToChat(item, postCaption);
+    if (!posted) return;
     setPostCaption('');
     setIsPosting(false);
   };

--- a/tests/unit/app-parent-tools-household-service.test.js
+++ b/tests/unit/app-parent-tools-household-service.test.js
@@ -20,6 +20,7 @@ vi.mock('../../js/db.js', () => ({
     getTeamMediaFolders: vi.fn(),
     getTeamMediaItems: vi.fn(),
     getTeams: vi.fn(),
+    canAccessTeamChat: vi.fn(() => false),
     listCertificatesForPlayer: vi.fn(),
     listFamilyShareTokens: vi.fn(),
     listMyParentMembershipRequests: vi.fn(),

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -21,6 +21,7 @@ const dbMocks = vi.hoisted(() => ({
     getTeamMediaFolders: vi.fn(),
     getTeamMediaItems: vi.fn(),
     getTeams: vi.fn(),
+    canAccessTeamChat: vi.fn(() => true),
     listCertificatesForPlayer: vi.fn(),
     listFamilyShareTokens: vi.fn(),
     listMyParentMembershipRequests: vi.fn(),
@@ -714,6 +715,7 @@ describe('React app parent tools service', () => {
             team: { id: 'team-1', name: 'Bears' },
             canManage: false,
             canContribute: true,
+            canPostChat: true,
             folders: [{
                 id: 'folder-1',
                 itemCount: 1,
@@ -725,6 +727,7 @@ describe('React app parent tools service', () => {
         await uploadParentTeamMediaPhoto('team-1', 'folder-1', photoFile);
         await uploadParentTeamMediaFile('team-1', 'folder-1', docFile);
         await addParentTeamMediaLink('team-1', 'folder-1', 'Replay', 'https://video.example.test/replay');
+        expect(dbMocks.canAccessTeamChat).toHaveBeenCalledWith(expect.objectContaining({ uid: 'user-1' }), { id: 'team-1', name: 'Bears' });
         expect(dbMocks.createTeamMediaFolder).toHaveBeenCalledWith('team-1', { name: 'Spring photos', visibility: 'private' });
         expect(dbMocks.uploadTeamMediaPhoto).toHaveBeenCalledWith('team-1', 'folder-1', photoFile);
         expect(dbMocks.uploadTeamMediaFile).toHaveBeenCalledWith('team-1', 'folder-1', docFile);

--- a/tests/unit/app-team-media.test.jsx
+++ b/tests/unit/app-team-media.test.jsx
@@ -60,6 +60,7 @@ const mediaModel = (overrides = {}) => ({
   team: { id: 'team-1', name: 'Bears' },
   canManage: false,
   canContribute: false,
+  canPostChat: false,
   folders: [{
     id: 'folder-1',
     name: 'Game media',
@@ -300,7 +301,16 @@ describe('React app TeamMedia team chat posting', () => {
   const postableModel = (overrides = {}) => mediaModel({
     canManage: true,
     canContribute: true,
+    canPostChat: true,
     ...overrides,
+  });
+
+  it('hides photo chat posting when the viewer can upload media but cannot access team chat', async () => {
+    const { container, root } = await renderTeamMedia(postableModel({ canPostChat: false }));
+
+    expect(container.querySelector('[aria-label="Post Tipoff to team chat"]')).toBeNull();
+
+    await act(async () => root.unmount());
   });
 
   it('shows the post action only for photo media when contributors can post to team chat', async () => {

--- a/tests/unit/app-team-media.test.jsx
+++ b/tests/unit/app-team-media.test.jsx
@@ -386,6 +386,7 @@ describe('React app TeamMedia team chat posting', () => {
 
     expect(chatServiceMocks.sendTeamChatMessage).toHaveBeenCalledTimes(1);
     expect(sendButton.disabled).toBe(true);
+    expect(sendButton.textContent).toContain('Posting');
     expect(container.textContent).toContain('Posting');
 
     await act(async () => {

--- a/tests/unit/app-team-media.test.jsx
+++ b/tests/unit/app-team-media.test.jsx
@@ -130,11 +130,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   parentToolsServiceMocks.updateTeamMediaItemForApp.mockResolvedValue(undefined);
   parentToolsServiceMocks.moveTeamMediaItemForApp.mockResolvedValue(undefined);
-  chatServiceMocks.sendTeamChatMessage.mockResolvedValue({
-    conversationId: 'team-main',
-    createdConversation: null,
-    wantsAi: false,
-  });
+  chatServiceMocks.sendTeamChatMessage.mockResolvedValue({ conversationId: 'team', createdConversation: null, wantsAi: false });
 });
 
 afterEach(() => {
@@ -300,10 +296,15 @@ describe('React app TeamMedia upload flow', () => {
   });
 });
 
-describe('React app TeamMedia post to team chat flow', () => {
-  it('shows the post action for any media item classified as a photo when managers can post to team chat', async () => {
-    const managerModel = mediaModel({
-      canManage: true,
+describe('React app TeamMedia team chat posting', () => {
+  const postableModel = (overrides = {}) => mediaModel({
+    canManage: true,
+    canContribute: true,
+    ...overrides,
+  });
+
+  it('shows the post action only for photo media when contributors can post to team chat', async () => {
+    const managerModel = postableModel({
       folders: [{
         id: 'folder-1',
         name: 'Game media',
@@ -324,15 +325,14 @@ describe('React app TeamMedia post to team chat flow', () => {
 
     await act(async () => root.unmount());
 
-    const nonManagerModel = mediaModel({ canManage: false });
-    const rendered = await renderTeamMedia(nonManagerModel);
+    const rendered = await renderTeamMedia(postableModel({ canContribute: false }));
     expect(rendered.container.querySelector('[aria-label="Post Tipoff to team chat"]')).toBeNull();
 
     await act(async () => rendered.root.unmount());
   });
 
   it('sends the selected photo URL to the default team conversation with an optional caption', async () => {
-    const { container, root } = await renderTeamMedia(mediaModel({ canManage: true }));
+    const { container, root } = await renderTeamMedia(postableModel());
 
     click(container.querySelector('[aria-label="Post Tipoff to team chat"]'));
     inputValue(container.querySelector('[aria-label="Caption for team chat"]'), '  Great start  ');
@@ -347,13 +347,65 @@ describe('React app TeamMedia post to team chat flow', () => {
     expect(sendCall.selectedConversationId).toBe('team');
     expect(sendCall.selectedRecipientTarget).toBe('full_team');
     expect(sendCall.selectedRecipientIds).toEqual([]);
-    expect(sendCall.existingAttachments).toEqual([expect.objectContaining({
+    expect(sendCall.attachments).toEqual([expect.objectContaining({
       type: 'image',
       url: 'https://example.test/tipoff.jpg',
       name: 'Tipoff',
     })]);
     expect(container.textContent).toContain('Photo posted to team chat.');
     expect(container.querySelector('[aria-label="Caption for team chat"]')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('disables photo chat posting while the send is in flight and prevents duplicate submits', async () => {
+    let resolveSend;
+    chatServiceMocks.sendTeamChatMessage.mockImplementation(() => new Promise((resolve) => {
+      resolveSend = resolve;
+    }));
+
+    const { container, root } = await renderTeamMedia(postableModel());
+
+    click(container.querySelector('[aria-label="Post Tipoff to team chat"]'));
+    const sendButton = [...container.querySelectorAll('button')].find((button) => button.textContent.includes('Send to chat'));
+
+    await act(async () => {
+      sendButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      sendButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(chatServiceMocks.sendTeamChatMessage).toHaveBeenCalledTimes(1);
+    expect(sendButton.disabled).toBe(true);
+    expect(container.textContent).toContain('Posting');
+
+    await act(async () => {
+      resolveSend({ conversationId: 'team', createdConversation: null, wantsAi: false });
+    });
+    await act(async () => {});
+
+    expect(container.textContent).toContain('Photo posted to team chat.');
+    expect(container.querySelector('[aria-label="Caption for team chat"]')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('shows a retryable error when chat posting fails without mutating the media item', async () => {
+    chatServiceMocks.sendTeamChatMessage.mockRejectedValue(new Error('Chat offline'));
+
+    const { container, root } = await renderTeamMedia(postableModel());
+
+    click(container.querySelector('[aria-label="Post Tipoff to team chat"]'));
+    await act(async () => {
+      const buttons = [...container.querySelectorAll('button')];
+      buttons.find((button) => button.textContent.includes('Send to chat')).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.textContent).toContain('Chat offline');
+    expect(container.querySelector('[aria-label="Caption for team chat"]')).not.toBeNull();
+    expect(container.textContent).toContain('Tipoff');
+    expect(parentToolsServiceMocks.updateTeamMediaItemForApp).not.toHaveBeenCalled();
+    expect(parentToolsServiceMocks.moveTeamMediaItemForApp).not.toHaveBeenCalled();
+    expect(parentToolsServiceMocks.deleteTeamMediaItemForApp).not.toHaveBeenCalled();
 
     await act(async () => root.unmount());
   });


### PR DESCRIPTION
Closes #1652

## What changed
- added a Team Media photo action to post directly into the default team chat using the existing chat attachment model
- disabled the Team Media post action while a photo is in flight so duplicate submissions cannot be sent
- surfaced chat-posting failures back in Team Media so users can retry without the album item being renamed, moved, deleted, or otherwise mutated
- extended Team Media regression coverage for both in-flight disablement and failure handling

## Why
This slice adds the reliability polish for Team Media chat posting without changing album data behavior or expanding the broader media workflow. It keeps failures local to the posting action and preserves the underlying album item for a safe retry.