### PR TITLE
Add team media photo post to team chat

### DIFF
--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -820,6 +820,7 @@ export async function sendTeamChatMessage({
   profile,
   text,
   files = [],
+  existingAttachments = [],
   selectedConversation,
   selectedConversationId,
   selectedRecipientTarget,
@@ -832,6 +833,7 @@ export async function sendTeamChatMessage({
   profile: Record<string, any>;
   text: string;
   files?: File[];
+  existingAttachments?: ChatAttachment[];
   selectedConversation?: ChatConversation | null;
   selectedConversationId: string;
   selectedRecipientTarget: ChatTargetType;
@@ -844,11 +846,14 @@ export async function sendTeamChatMessage({
     throw new Error('Choose at least one selected member before sending.');
   }
 
-  const attachments: ChatAttachment[] = [];
+  const uploadedAttachments: ChatAttachment[] = [];
+  const attachments: ChatAttachment[] = [...existingAttachments];
   try {
     for (const file of files) {
       onProgress?.('uploading');
-      attachments.push(await uploadTeamChatAttachment(teamId, file));
+      const uploadedAttachment = await uploadTeamChatAttachment(teamId, file);
+      uploadedAttachments.push(uploadedAttachment);
+      attachments.push(uploadedAttachment);
     }
     onProgress?.('posting');
 
@@ -900,9 +905,9 @@ export async function sendTeamChatMessage({
       wantsAi: hasAllPlaysMention(text)
     };
   } catch (error) {
-    if (attachments.length > 0) {
+    if (uploadedAttachments.length > 0) {
       try {
-        await deleteUploadedChatAttachments(attachments);
+        await deleteUploadedChatAttachments(uploadedAttachments);
       } catch (cleanupError) {
         console.error('Failed to clean up uploaded chat attachments:', cleanupError);
       }

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -636,7 +636,7 @@ function TeamMediaItemCard({
   onPostToTeamChat: (item: TeamMediaItem, caption: string) => Promise<void>;
 }) {
   const Icon = getItemIcon(item);
-  const isPhoto = item.type === 'photo';
+  const isPhoto = isPhotoMediaItem(item);
   const title = item.title || 'Team media';
   const [isRenaming, setIsRenaming] = useState(false);
   const [isPosting, setIsPosting] = useState(false);

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -14,6 +14,7 @@ import {
   ImageIcon,
   LinkIcon,
   Loader2,
+  MessageCircle,
   Plus,
   RefreshCw,
   Share2,
@@ -22,6 +23,8 @@ import {
   Video
 } from 'lucide-react';
 import { openPublicUrl, sharePublicUrl } from '../lib/publicActions';
+import { sendTeamChatMessage, type ChatAttachment } from '../lib/chatService';
+import { DEFAULT_TEAM_CONVERSATION_ID } from '../lib/chatLogic';
 import {
   addParentTeamMediaLink,
   createTeamMediaAlbumForApp,
@@ -57,6 +60,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const [movingItemId, setMovingItemId] = useState('');
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
+  const [postingItemId, setPostingItemId] = useState('');
 
   const refresh = async ({ showLoading = model === null, preferredFolderId = '' }: { showLoading?: boolean; preferredFolderId?: string } = {}) => {
     if (!teamId) return;
@@ -486,7 +490,39 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
         </div>
         <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {filteredItems.length ? filteredItems.map((item) => (
-            <TeamMediaItemCard key={item.id} item={item} onStatus={(tone, msg) => tone === 'error' ? setError(msg) : setMessage(msg)} canManage={model.canManage} currentUserId={auth.user?.uid || ''} folders={model.folders} currentFolderId={activeFolder?.id || ''} deleting={deletingItemId === item.id} renaming={renamingItemId === item.id} moving={movingItemId === item.id} onRenameItem={handleRenameItem} onDeleteItem={handleDeleteItem} onMoveItem={handleMoveItem} />
+            <TeamMediaItemCard key={item.id} item={item} onStatus={(tone, msg) => tone === 'error' ? setError(msg) : setMessage(msg)} canManage={model.canManage} currentUserId={auth.user?.uid || ''} folders={model.folders} currentFolderId={activeFolder?.id || ''} deleting={deletingItemId === item.id} renaming={renamingItemId === item.id} moving={movingItemId === item.id} posting={postingItemId === item.id} onRenameItem={handleRenameItem} onDeleteItem={handleDeleteItem} onMoveItem={handleMoveItem} onPostToTeamChat={async (item, caption) => {
+              if (!teamId || !auth.user) return;
+              setPostingItemId(item.id);
+              setError('');
+              setMessage('');
+              try {
+                const existingAttachment: ChatAttachment = {
+                  type: 'image',
+                  url: item.url,
+                  name: item.title || 'Team media photo',
+                  mimeType: null,
+                  path: null,
+                  size: null,
+                  thumbnailUrl: item.url,
+                };
+                await sendTeamChatMessage({
+                  teamId,
+                  user: auth.user,
+                  profile: auth.profile || {},
+                  text: caption.trim(),
+                  existingAttachments: [existingAttachment],
+                  selectedConversationId: DEFAULT_TEAM_CONVERSATION_ID,
+                  selectedRecipientTarget: 'full_team',
+                  selectedRecipientIds: [],
+                });
+                setMessage('Photo posted to team chat.');
+              } catch (postError: any) {
+                setError(postError?.message || 'Unable to post photo to team chat.');
+                throw postError;
+              } finally {
+                setPostingItemId('');
+              }
+            }} />
           )) : (
             <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">No {emptyStateLabel} in this album.</div>
           )}
@@ -578,9 +614,11 @@ function TeamMediaItemCard({
   deleting,
   renaming,
   moving,
+  posting,
   onRenameItem,
   onDeleteItem,
-  onMoveItem
+  onMoveItem,
+  onPostToTeamChat
 }: {
   item: TeamMediaItem;
   onStatus: (tone: 'error' | 'success', message: string) => void;
@@ -591,21 +629,26 @@ function TeamMediaItemCard({
   deleting: boolean;
   renaming: boolean;
   moving: boolean;
+  posting: boolean;
   onRenameItem: (item: TeamMediaItem, title: string) => Promise<void>;
   onDeleteItem: (item: TeamMediaItem) => void;
   onMoveItem: (item: TeamMediaItem, targetFolderId: string) => Promise<void>;
+  onPostToTeamChat: (item: TeamMediaItem, caption: string) => Promise<void>;
 }) {
   const Icon = getItemIcon(item);
   const isPhoto = item.type === 'photo';
   const title = item.title || 'Team media';
   const [isRenaming, setIsRenaming] = useState(false);
+  const [isPosting, setIsPosting] = useState(false);
   const [draftTitle, setDraftTitle] = useState(title);
+  const [postCaption, setPostCaption] = useState('');
   const [moveFolderId, setMoveFolderId] = useState('');
   const alternateFolders = folders.filter((folder) => folder.id && folder.id !== currentFolderId);
   const canMove = canManage && alternateFolders.length > 0;
   const selectedMoveFolderId = moveFolderId && moveFolderId !== currentFolderId ? moveFolderId : '';
   const canRename = canManage || item.uploadedBy === currentUserId;
   const canDelete = canManage || (['photo', 'file'].includes(String(item.type || '').toLowerCase()) && item.uploadedBy === currentUserId);
+  const canPostToTeamChat = canManage && isPhoto && Boolean(item.url);
 
   const startRename = () => {
     setDraftTitle(title);
@@ -626,6 +669,12 @@ function TeamMediaItemCard({
     if (!selectedMoveFolderId || moving) return;
     await onMoveItem(item, selectedMoveFolderId);
     setMoveFolderId('');
+  };
+
+  const postToTeamChat = async () => {
+    await onPostToTeamChat(item, postCaption);
+    setPostCaption('');
+    setIsPosting(false);
   };
 
   const copyLink = async () => {
@@ -718,6 +767,12 @@ function TeamMediaItemCard({
               Rename
             </button>
           )}
+          {canPostToTeamChat && (
+            <button type="button" className="ghost-button !h-8 !min-h-8 !px-2 !text-xs" onClick={() => setIsPosting((current) => !current)} disabled={posting} aria-label={`Post ${title} to team chat`}>
+              {posting ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" /> : <MessageCircle className="h-3.5 w-3.5" aria-hidden="true" />}
+              Post to team chat
+            </button>
+          )}
           {canMove && (
             <div className="flex w-full flex-wrap items-center gap-2 rounded-xl border border-gray-100 bg-gray-50 p-2">
               <label className="sr-only" htmlFor={`move-media-${item.id}`}>Move media item to album</label>
@@ -747,6 +802,27 @@ function TeamMediaItemCard({
             </button>
           )}
         </div>
+        {isPosting ? (
+          <div className="mt-3 rounded-xl border border-primary-100 bg-primary-50 p-2">
+            <label className="sr-only" htmlFor={`post-media-caption-${item.id}`}>Caption for team chat</label>
+            <input
+              id={`post-media-caption-${item.id}`}
+              className="auth-input min-h-10 w-full bg-white"
+              value={postCaption}
+              onChange={(event) => setPostCaption(event.target.value)}
+              disabled={posting}
+              placeholder="Add an optional caption"
+              aria-label="Caption for team chat"
+            />
+            <div className="mt-2 flex gap-2">
+              <button type="button" className="primary-button !h-8 !min-h-8 !px-2 !text-xs" onClick={postToTeamChat} disabled={posting}>
+                {posting ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" /> : <MessageCircle className="h-3.5 w-3.5" aria-hidden="true" />}
+                Send to chat
+              </button>
+              <button type="button" className="ghost-button !h-8 !min-h-8 !px-2 !text-xs" onClick={() => setIsPosting(false)} disabled={posting}>Cancel</button>
+            </div>
+          </div>
+        ) : null}
       </div>
     </article>
   );

--- a/tests/unit/app-team-media.test.jsx
+++ b/tests/unit/app-team-media.test.jsx
@@ -301,11 +301,25 @@ describe('React app TeamMedia upload flow', () => {
 });
 
 describe('React app TeamMedia post to team chat flow', () => {
-  it('shows the post action only for photo items when managers can post to team chat', async () => {
-    const managerModel = mediaModel({ canManage: true });
+  it('shows the post action for any media item classified as a photo when managers can post to team chat', async () => {
+    const managerModel = mediaModel({
+      canManage: true,
+      folders: [{
+        id: 'folder-1',
+        name: 'Game media',
+        visibility: 'team',
+        itemCount: 3,
+        items: [
+          { id: 'owned-photo', title: 'Tipoff', type: 'photo', url: 'https://example.test/tipoff.jpg', uploadedBy: 'user-1' },
+          { id: 'uploaded-image', title: 'Warmups', type: 'image', url: 'https://example.test/warmups.jpg', uploadedBy: 'user-2' },
+          { id: 'other-file', title: 'Scouting PDF', type: 'file', url: 'https://example.test/scout.pdf', uploadedBy: 'user-2' },
+        ],
+      }],
+    });
     const { container, root } = await renderTeamMedia(managerModel);
 
     expect(container.querySelector('[aria-label="Post Tipoff to team chat"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Post Warmups to team chat"]')).not.toBeNull();
     expect(container.querySelector('[aria-label="Post Scouting PDF to team chat"]')).toBeNull();
 
     await act(async () => root.unmount());

--- a/tests/unit/app-team-media.test.jsx
+++ b/tests/unit/app-team-media.test.jsx
@@ -20,8 +20,19 @@ const publicActionsMocks = vi.hoisted(() => ({
   sharePublicUrl: vi.fn().mockResolvedValue('shared'),
 }));
 
+const chatServiceMocks = vi.hoisted(() => ({
+  sendTeamChatMessage: vi.fn(),
+}));
+
 vi.mock('../../apps/app/src/lib/parentToolsService.ts', () => parentToolsServiceMocks);
 vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionsMocks);
+vi.mock('../../apps/app/src/lib/chatService.ts', async () => {
+  const actual = await vi.importActual('../../apps/app/src/lib/chatService.ts');
+  return {
+    ...actual,
+    sendTeamChatMessage: chatServiceMocks.sendTeamChatMessage,
+  };
+});
 
 import { TeamMedia } from '../../apps/app/src/pages/TeamMedia.tsx';
 
@@ -119,6 +130,11 @@ beforeEach(() => {
   vi.clearAllMocks();
   parentToolsServiceMocks.updateTeamMediaItemForApp.mockResolvedValue(undefined);
   parentToolsServiceMocks.moveTeamMediaItemForApp.mockResolvedValue(undefined);
+  chatServiceMocks.sendTeamChatMessage.mockResolvedValue({
+    conversationId: 'team-main',
+    createdConversation: null,
+    wantsAi: false,
+  });
 });
 
 afterEach(() => {
@@ -279,6 +295,51 @@ describe('React app TeamMedia upload flow', () => {
     expect(parentToolsServiceMocks.uploadParentTeamMediaFile).toHaveBeenCalledWith('team-1', 'folder-1', file);
     expect(fileInput.value).toBe('');
     expect(container.textContent).toContain('No files uploaded. Choose supported documents that are 10 MB or smaller.');
+
+    await act(async () => root.unmount());
+  });
+});
+
+describe('React app TeamMedia post to team chat flow', () => {
+  it('shows the post action only for photo items when managers can post to team chat', async () => {
+    const managerModel = mediaModel({ canManage: true });
+    const { container, root } = await renderTeamMedia(managerModel);
+
+    expect(container.querySelector('[aria-label="Post Tipoff to team chat"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Post Scouting PDF to team chat"]')).toBeNull();
+
+    await act(async () => root.unmount());
+
+    const nonManagerModel = mediaModel({ canManage: false });
+    const rendered = await renderTeamMedia(nonManagerModel);
+    expect(rendered.container.querySelector('[aria-label="Post Tipoff to team chat"]')).toBeNull();
+
+    await act(async () => rendered.root.unmount());
+  });
+
+  it('sends the selected photo URL to the default team conversation with an optional caption', async () => {
+    const { container, root } = await renderTeamMedia(mediaModel({ canManage: true }));
+
+    click(container.querySelector('[aria-label="Post Tipoff to team chat"]'));
+    inputValue(container.querySelector('[aria-label="Caption for team chat"]'), '  Great start  ');
+    await act(async () => {
+      const buttons = [...container.querySelectorAll('button')];
+      buttons.find((button) => button.textContent.includes('Send to chat')).dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    const sendCall = chatServiceMocks.sendTeamChatMessage.mock.calls[0][0];
+    expect(sendCall.teamId).toBe('team-1');
+    expect(sendCall.text).toBe('Great start');
+    expect(sendCall.selectedConversationId).toBe('team');
+    expect(sendCall.selectedRecipientTarget).toBe('full_team');
+    expect(sendCall.selectedRecipientIds).toEqual([]);
+    expect(sendCall.existingAttachments).toEqual([expect.objectContaining({
+      type: 'image',
+      url: 'https://example.test/tipoff.jpg',
+      name: 'Tipoff',
+    })]);
+    expect(container.textContent).toContain('Photo posted to team chat.');
+    expect(container.querySelector('[aria-label="Caption for team chat"]')).toBeNull();
 
     await act(async () => root.unmount());
   });


### PR DESCRIPTION
Closes #1650

## What changed
- added a visible **Post to team chat** action on Team Media photo cards for team managers
- added a lightweight inline post flow with an optional caption and send/cancel controls
- reused the existing photo URL as a chat image attachment instead of re-uploading bytes
- extended the shared team chat send path to accept pre-existing attachments while only cleaning up newly uploaded files on failure
- added regression coverage for the new Team Media chat-post flow

## Why
This wires the happy-path Team Media photo action into the existing default team chat flow with the smallest safe change set. It gives coaches and admins a direct album-to-chat path without mutating the media item itself or duplicating uploaded media.