### PR TITLE
Hide empty postgame report tabs

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -84,6 +84,41 @@ const gameReportSections: Array<{ id: GameReportSectionId; label: string }> = [
   { id: 'media', label: 'Media' }
 ];
 
+const liveReportStatuses = new Set(['live', 'in_progress', 'in-progress', 'halftime']);
+
+function hasOpponentReportData(report: GameReportData) {
+  return report.opponentRows.length > 0 && report.opponentStatKeys.length > 0;
+}
+
+function hasInsightReportData(report: GameReportData) {
+  return report.teamInsights.length > 0 || report.playerInsightRows.length > 0;
+}
+
+function hasMediaReportData(report: GameReportData) {
+  return (report.highlightClips?.length || 0) > 0
+    || Boolean(report.statSheetPhotoUrl)
+    || (report.teamStatKeys?.length || 0) > 0;
+}
+
+function shouldShowPlayByPlaySection(report: GameReportData) {
+  const liveStatus = String(report.game?.liveStatus || report.game?.status || '').trim().toLowerCase();
+  return report.plays.length > 0 || liveReportStatuses.has(liveStatus);
+}
+
+function getVisibleGameReportSections(report: GameReportData | null) {
+  if (!report) {
+    return gameReportSections.filter((section) => section.id === 'summary' || section.id === 'players' || section.id === 'plays');
+  }
+  return gameReportSections.filter((section) => {
+    if (section.id === 'summary' || section.id === 'players') return true;
+    if (section.id === 'plays') return shouldShowPlayByPlaySection(report);
+    if (section.id === 'opponent') return hasOpponentReportData(report);
+    if (section.id === 'insights') return hasInsightReportData(report);
+    if (section.id === 'media') return hasMediaReportData(report);
+    return false;
+  });
+}
+
 const hubIconComponents: Record<ScheduleHubIcon, LucideIcon> = {
   video: Video,
   radio: Radio,
@@ -2083,6 +2118,7 @@ function GameReportSections({ event }: { event: ParentScheduleEvent }) {
   const [report, setReport] = useState<GameReportData | null>(null);
   const [loadingReport, setLoadingReport] = useState(true);
   const [reportError, setReportError] = useState<string | null>(null);
+  const visibleReportSections = useMemo(() => getVisibleGameReportSections(report), [report]);
 
   const refreshReport = useCallback(async (showLoading = true) => {
     if (showLoading) setLoadingReport(true);
@@ -2111,6 +2147,19 @@ function GameReportSections({ event }: { event: ParentScheduleEvent }) {
     return () => window.clearInterval(intervalId);
   }, [activeReportSection, refreshReport]);
 
+  useEffect(() => {
+    const handleFocus = () => {
+      void refreshReport(false);
+    };
+    window.addEventListener('focus', handleFocus);
+    return () => window.removeEventListener('focus', handleFocus);
+  }, [refreshReport]);
+
+  useEffect(() => {
+    if (visibleReportSections.some((section) => section.id === activeReportSection)) return;
+    setActiveReportSection('summary');
+  }, [activeReportSection, visibleReportSections]);
+
   return (
     <div className="app-card overflow-hidden p-0">
       <div className="border-b border-gray-100 px-3 py-3 sm:px-4">
@@ -2125,7 +2174,7 @@ function GameReportSections({ event }: { event: ParentScheduleEvent }) {
 
       <div className="border-b border-gray-100 px-2 py-2">
         <div className="flex gap-1 overflow-x-auto pb-0.5">
-          {gameReportSections.map((section) => {
+          {visibleReportSections.map((section) => {
             const active = section.id === activeReportSection;
             return (
               <button

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -94,10 +94,21 @@ function hasInsightReportData(report: GameReportData) {
   return report.teamInsights.length > 0 || report.playerInsightRows.length > 0;
 }
 
+function hasRecordedTeamStatValue(report: GameReportData, key: string) {
+  const teamStats = report.teamStats || {};
+  if (!Object.prototype.hasOwnProperty.call(teamStats, key)) return false;
+  const value = teamStats[key];
+  return value !== null && value !== undefined && String(value).trim() !== '';
+}
+
+function getRecordedTeamStatKeys(report: GameReportData) {
+  return (report.teamStatKeys || []).filter((key) => hasRecordedTeamStatValue(report, key));
+}
+
 function hasMediaReportData(report: GameReportData) {
   return (report.highlightClips?.length || 0) > 0
     || Boolean(report.statSheetPhotoUrl)
-    || (report.teamStatKeys?.length || 0) > 0;
+    || getRecordedTeamStatKeys(report).length > 0;
 }
 
 function shouldShowPlayByPlaySection(report: GameReportData) {
@@ -2387,7 +2398,7 @@ function OpponentStatsSection({ report }: { report: GameReportData }) {
 
 function ReportMediaSection({ report }: { report: GameReportData }) {
   const highlightClips = report.highlightClips || [];
-  const teamStatKeys = report.teamStatKeys || [];
+  const teamStatKeys = getRecordedTeamStatKeys(report);
   const hasTeamStats = teamStatKeys.length > 0;
   const hasMedia = highlightClips.length > 0 || Boolean(report.statSheetPhotoUrl) || hasTeamStats;
   if (!hasMedia) {

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -94,6 +94,11 @@ function report(overrides = {}) {
         opponentRows: [],
         opponentStatKeys: [],
         opponentStatLabels: {},
+        teamStatKeys: [],
+        teamStatLabels: {},
+        teamStats: {},
+        statSheetPhotoUrl: '',
+        highlightClips: [],
         teamInsights: [],
         playerInsightRows: [],
         emptyInsightsMessage: 'No insights yet.',
@@ -328,7 +333,12 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         scheduleMocks.loadParentSchedule.mockResolvedValue({
             events: [event({ liveStatus: 'completed', homeScore: 4, awayScore: 2 })]
         });
-        reportMocks.loadGameReportSections.mockResolvedValue(report({ plays: [] }));
+        reportMocks.loadGameReportSections.mockResolvedValue(report({
+            plays: [],
+            teamStatKeys: ['shots'],
+            teamStatLabels: { shots: 'Shots' },
+            teamStats: {}
+        }));
 
         const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1');
         await waitForText(container, 'vs. Falcons');

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -142,6 +142,12 @@ function buttonByText(container, text) {
     return button;
 }
 
+function queryButtonByText(container, text) {
+    return Array.from(container.querySelectorAll('button')).find((candidate) => (
+        candidate.textContent.trim() === text || candidate.getAttribute('aria-label') === text
+    )) || null;
+}
+
 async function clickButton(container, text) {
     await act(async () => {
         buttonByText(container, text).dispatchEvent(new MouseEvent('click', { bubbles: true }));
@@ -316,6 +322,87 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         expect(shareCall.title).toBe('Bears vs. Falcons match report');
         expect(shareCall.url).toBe('https://allplays.ai/game.html#teamId=team-1&gameId=game-1');
         expect(shareCall.clipboardText).toContain('https://allplays.ai/game.html#teamId=team-1&gameId=game-1');
+    });
+
+    it('hides empty optional postgame report tabs for completed games', async () => {
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            events: [event({ liveStatus: 'completed', homeScore: 4, awayScore: 2 })]
+        });
+        reportMocks.loadGameReportSections.mockResolvedValue(report({ plays: [] }));
+
+        const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1');
+        await waitForText(container, 'vs. Falcons');
+        await clickButton(container, 'Game');
+        await waitForText(container, 'Report sections');
+        await waitForText(container, 'Match Summary');
+
+        expect(queryButtonByText(container, 'Summary')).not.toBeNull();
+        expect(queryButtonByText(container, 'Players')).not.toBeNull();
+        expect(queryButtonByText(container, 'Plays')).toBeNull();
+        expect(queryButtonByText(container, 'Opponent')).toBeNull();
+        expect(queryButtonByText(container, 'Insights')).toBeNull();
+        expect(queryButtonByText(container, 'Media')).toBeNull();
+    });
+
+    it('shows optional postgame report tabs only when their data exists', async () => {
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            events: [event({ liveStatus: 'completed', homeScore: 4, awayScore: 2 })]
+        });
+        reportMocks.loadGameReportSections.mockResolvedValue(report({
+            opponentRows: [{ id: 'opp-1', name: 'Jordan', number: '12', stats: { pts: 9 } }],
+            opponentStatKeys: ['pts'],
+            opponentStatLabels: { pts: 'PTS' },
+            highlightClips: [{
+                title: 'Late goal',
+                description: 'Late goal',
+                period: 'Q4',
+                gameTime: '01:20',
+                startMs: 1000,
+                endMs: 3000,
+                url: 'https://example.com/highlight'
+            }]
+        }));
+
+        const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1');
+        await waitForText(container, 'vs. Falcons');
+        await clickButton(container, 'Game');
+        await waitForText(container, 'Report sections');
+        await waitForText(container, 'Match Summary');
+
+        expect(queryButtonByText(container, 'Opponent')).not.toBeNull();
+        expect(queryButtonByText(container, 'Media')).not.toBeNull();
+        expect(queryButtonByText(container, 'Insights')).toBeNull();
+    });
+
+    it('falls back to Summary when a refreshed report removes the active optional tab', async () => {
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            events: [event({ liveStatus: 'completed', homeScore: 4, awayScore: 2 })]
+        });
+        reportMocks.loadGameReportSections
+            .mockResolvedValueOnce(report({
+                opponentRows: [{ id: 'opp-1', name: 'Jordan', number: '12', stats: { pts: 9 } }],
+                opponentStatKeys: ['pts'],
+                opponentStatLabels: { pts: 'PTS' }
+            }))
+            .mockResolvedValueOnce(report());
+
+        const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1');
+        await waitForText(container, 'vs. Falcons');
+        await clickButton(container, 'Game');
+        await waitForText(container, 'Report sections');
+        await waitForText(container, 'Opponent');
+
+        await clickButton(container, 'Opponent');
+        await waitForText(container, 'Jordan');
+
+        await act(async () => {
+            window.dispatchEvent(new Event('focus'));
+            await Promise.resolve();
+        });
+        await waitForText(container, 'Match Summary');
+
+        expect(queryButtonByText(container, 'Opponent')).toBeNull();
+        expect(container.textContent).not.toContain('Jordan');
     });
 
     it('renders the live period and clock chip beside the score for live games', async () => {


### PR DESCRIPTION
Closes #1649

## What changed
- gate Schedule Event Detail postgame report tabs off the loaded report data instead of rendering all six tabs up front
- always keep Summary and Players visible, keep Plays only when the game is live or has logged events, and only show Opponent, Insights, and Media when those sections actually have data
- fall back to Summary if a refreshed report removes the currently selected optional tab

## Why
This keeps the completed-game review path focused on useful sections first and avoids sending coaches or parents into empty optional tabs before those sections have data.

## Validation
- ran `npx vitest run tests/unit/app-schedule-more-tab-integration.test.jsx --reporter=verbose`