### PR TITLE
Normalize Team Media photo posts in chat

### DIFF
--- a/js/team-chat-media.js
+++ b/js/team-chat-media.js
@@ -25,10 +25,15 @@ export function isSafeChatMediaUrl(href) {
 }
 
 export function getChatAttachmentKind(input) {
-    const mimeType = String(input?.mimeType || input?.type || '').toLowerCase();
+    const mimeType = String(input?.mimeType || '').toLowerCase();
+    const rawType = String(input?.type || input?.mediaType || '').toLowerCase();
     if (mimeType === 'image' || mimeType === 'video') return mimeType;
     if (mimeType.startsWith('image/')) return 'image';
     if (mimeType.startsWith('video/')) return 'video';
+    if (rawType === 'photo' || rawType === 'image') return 'image';
+    if (rawType === 'video' || rawType === 'video_link') return 'video';
+    if (rawType.startsWith('image/')) return 'image';
+    if (rawType.startsWith('video/')) return 'video';
     return null;
 }
 
@@ -55,8 +60,8 @@ function normalizeChatAttachment(input, { strict = true } = {}) {
         url,
         path: input?.path || null,
         thumbnailUrl: input?.thumbnailUrl || null,
-        name: input?.name || null,
-        mimeType: input?.mimeType || input?.type || null,
+        name: input?.name || input?.title || input?.fileName || null,
+        mimeType: input?.mimeType || input?.type || input?.mediaType || null,
         size,
         uploadedAt: toUploadedAt(input?.uploadedAt)
     };

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -736,6 +736,34 @@ describe('React app messages integration', () => {
         expect(container.textContent).toContain('Media link copied.');
     });
 
+    it('renders team media photo posts inline and includes them in the gallery', async () => {
+        chatMocks.subscribeToTeamChatMessages.mockImplementation((teamId, conversationId, onMessages) => {
+            onMessages([
+                chatMessage({
+                    id: 'msg-team-media',
+                    text: '',
+                    attachments: [
+                        {
+                            type: 'photo',
+                            url: 'https://media.example.test/tipoff.jpg',
+                            title: 'Tipoff'
+                        }
+                    ]
+                })
+            ], { id: 'cursor' });
+            return { unsubscribe: vi.fn() };
+        });
+        const { container } = await renderMessages('/messages/team-1');
+
+        const inlinePhoto = container.querySelector('img[alt="Tipoff"]');
+        expect(inlinePhoto).toBeTruthy();
+        expect(inlinePhoto.getAttribute('src')).toBe('https://media.example.test/tipoff.jpg');
+
+        await click(container, 'Open photos and videos');
+        expect(container.textContent).toContain('Photos & videos');
+        expect(container.textContent).toContain('Tipoff');
+    });
+
     it('routes ALL PLAYS mentions through the existing AI assistant send path', async () => {
         chatMocks.sendTeamChatMessage.mockResolvedValue({ conversationId: 'team', createdConversation: null, wantsAi: true });
         const { container } = await renderMessages('/messages/team-1');

--- a/tests/unit/team-chat-media.test.js
+++ b/tests/unit/team-chat-media.test.js
@@ -4,6 +4,7 @@ import path from 'node:path';
 import {
     MAX_CHAT_MEDIA_SIZE,
     normalizeChatAttachments,
+    getMessageAttachments,
     collectThreadMedia,
     buildChatMediaShareDetails,
     getChatMediaActionState,
@@ -69,6 +70,29 @@ describe('team chat media normalization', () => {
         expect(() => normalizeChatAttachments([
             { url: 'https://cdn.example.com/huge.mp4', type: 'video/mp4', size: MAX_CHAT_MEDIA_SIZE + 1 }
         ])).toThrow(/5MB or smaller/i);
+    });
+
+    it('normalizes team media photo-shaped attachments for message rendering', () => {
+        expect(getMessageAttachments({
+            attachments: [
+                {
+                    type: 'photo',
+                    url: 'https://cdn.example.com/team-photo.jpg',
+                    title: 'Tipoff'
+                }
+            ]
+        })).toEqual([
+            {
+                type: 'image',
+                url: 'https://cdn.example.com/team-photo.jpg',
+                path: null,
+                thumbnailUrl: null,
+                name: 'Tipoff',
+                mimeType: 'photo',
+                size: null,
+                uploadedAt: null
+            }
+        ]);
     });
 });
 


### PR DESCRIPTION
Closes #1651

## What changed
- normalized Team Media-style chat attachments so `photo` and related media aliases render as standard chat images
- preserved Team Media titles/file names when attachment metadata is normalized for Messages and the shared media gallery
- added regression coverage for both helper normalization and the Messages integration path that opens the existing photos and videos gallery

## Why
Team Media-originated photo posts could arrive in a slightly different attachment shape than standard chat uploads, which caused Messages to skip inline rendering and omit them from the gallery. This keeps the fix scoped to attachment normalization and rendering behavior.