### PR TITLE
Add Team Detail fan feed share action

### DIFF
--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -441,7 +441,7 @@ export function canExposePublicFanFeed(team: Partial<TeamDetailModel['team']> = 
     if (event.isPrivate === true) return false;
     if (cleanString(event.status).toLowerCase() === 'deleted') return false;
     if (cleanString(event.liveStatus).toLowerCase() === 'deleted') return false;
-    return (team.isPublic !== false && team.active !== false) || isShareableFanFeedEvent(event);
+    return (team.isPublic === true && team.active !== false) || isShareableFanFeedEvent(event);
   });
 }
 
@@ -549,7 +549,7 @@ export function buildTeamDetailModel({
       photoUrl: getFirstUrl(team?.photoUrl, team?.teamPhotoUrl, team?.logoUrl, team?.imageUrl),
       description: cleanString(team?.description),
       zip: cleanString(team?.zip),
-      isPublic: team?.isPublic !== false,
+      isPublic: team?.isPublic === true,
       active: team?.active !== false,
       leagueUrl: getFirstUrl(team?.leagueUrl),
       bracketUrl: getFirstUrl(team?.bracketUrl),

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -52,6 +52,12 @@ export type TeamDetailEvent = {
   location: string;
   opponent: string;
   status: string;
+  liveStatus: string;
+  visibility: string;
+  isPrivate: boolean;
+  isPublic: boolean;
+  shareable: boolean;
+  publicCalendar: boolean;
   homeScore: number | null;
   awayScore: number | null;
   isCancelled: boolean;
@@ -122,6 +128,8 @@ export type TeamDetailModel = {
     photoUrl: string | null;
     description: string;
     zip: string;
+    isPublic: boolean;
+    active: boolean;
     leagueUrl: string | null;
     bracketUrl: string | null;
     streamUrl: string | null;
@@ -403,6 +411,40 @@ export function buildAdminAcceptInviteUrl(code: string, baseUrl = getPublicBaseU
   return url.toString();
 }
 
+export function buildPublicTeamGamesIcsUrl(teamId: string) {
+  const normalizedTeamId = cleanString(teamId);
+  if (!normalizedTeamId) return '';
+  const configured = (window as any).__ALLPLAYS_CONFIG__?.publicTeamGamesIcsFunctionUrl || (window as any).ALLPLAYS_PUBLIC_GAMES_ICS_URL;
+  const fallback = (window as any).__ALLPLAYS_CONFIG__?.calendarFetchFunctionUrl || (window as any).ALLPLAYS_CALENDAR_FUNCTION_URL;
+  const baseUrl = typeof configured === 'string' && configured.trim()
+    ? configured.trim()
+    : typeof fallback === 'string' && fallback.includes('fetchCalendarIcs')
+      ? fallback.replace('fetchCalendarIcs', 'publicTeamGamesIcs')
+      : 'https://us-central1-all-plays-prod.cloudfunctions.net/publicTeamGamesIcs';
+  const separator = baseUrl.includes('?') ? '&' : '?';
+  return `${baseUrl}${separator}teamId=${encodeURIComponent(normalizedTeamId)}`;
+}
+
+export function isShareableFanFeedEvent(event: Partial<TeamDetailEvent> = {}) {
+  const visibility = cleanString(event.visibility).toLowerCase();
+  if (visibility === 'private' || event.isPrivate === true) return false;
+  return visibility === 'public'
+    || event.isPublic === true
+    || event.shareable === true
+    || event.publicCalendar === true;
+}
+
+export function canExposePublicFanFeed(team: Partial<TeamDetailModel['team']> = {}, events: Array<Partial<TeamDetailEvent>> = []) {
+  return (events || []).some((event) => {
+    if (cleanString(event.type || 'game').toLowerCase() !== 'game') return false;
+    if (cleanString(event.visibility).toLowerCase() === 'private') return false;
+    if (event.isPrivate === true) return false;
+    if (cleanString(event.status).toLowerCase() === 'deleted') return false;
+    if (cleanString(event.liveStatus).toLowerCase() === 'deleted') return false;
+    return (team.isPublic !== false && team.active !== false) || isShareableFanFeedEvent(event);
+  });
+}
+
 function getPublicBaseUrl() {
   if (typeof window !== 'undefined' && /^https?:$/i.test(window.location.protocol)) {
     return window.location.origin;
@@ -507,6 +549,8 @@ export function buildTeamDetailModel({
       photoUrl: getFirstUrl(team?.photoUrl, team?.teamPhotoUrl, team?.logoUrl, team?.imageUrl),
       description: cleanString(team?.description),
       zip: cleanString(team?.zip),
+      isPublic: team?.isPublic !== false,
+      active: team?.active !== false,
       leagueUrl: getFirstUrl(team?.leagueUrl),
       bracketUrl: getFirstUrl(team?.bracketUrl),
       streamUrl: getStreamUrl(team),
@@ -631,6 +675,12 @@ function normalizeEvents(games: any[]) {
         location: cleanString(game?.location) || 'TBD',
         opponent: cleanString(game?.opponent) || 'TBD',
         status: cleanString(game?.status || game?.liveStatus),
+        liveStatus: cleanString(game?.liveStatus),
+        visibility: cleanString(game?.visibility),
+        isPrivate: game?.isPrivate === true || game?.private === true,
+        isPublic: game?.isPublic === true || game?.public === true,
+        shareable: game?.shareable === true || game?.isShareable === true,
+        publicCalendar: game?.publicCalendar === true,
         homeScore: toNullableNumber(game?.homeScore),
         awayScore: toNullableNumber(game?.awayScore),
         isCancelled: cleanString(game?.status).toLowerCase() === 'cancelled'

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -22,11 +22,11 @@ import {
   UserRound,
   Users
 } from 'lucide-react';
-import { copyPublicText, openPublicUrl } from '../lib/publicActions';
+import { copyPublicText, openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 import { getEventDetailPath } from '../lib/homeLogic';
 import { loadStaffRsvpReminderPreview, sendStaffRsvpReminder, type StaffRsvpReminderSendResult } from '../lib/scheduleService';
 import type { ParentScheduleEvent, StaffRsvpReminderPreview } from '../lib/scheduleLogic';
-import { grantScorekeeperAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp, type InviteTeamAdminForAppResult, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer } from '../lib/teamDetailService';
+import { buildPublicTeamGamesIcsUrl, canExposePublicFanFeed, grantScorekeeperAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp, type InviteTeamAdminForAppResult, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer } from '../lib/teamDetailService';
 import type { AuthState } from '../lib/types';
 
 type TeamTab = 'overview' | 'schedule' | 'roster' | 'insights' | 'more';
@@ -349,6 +349,7 @@ function MoreTab({ model, onStaffInviteSuccess }: { model: TeamDetailModel; onSt
   return (
     <div className="space-y-4">
       {model.staffPermissions ? <StaffPermissionsCard model={model} onInviteSuccess={onStaffInviteSuccess} /> : null}
+      {canExposePublicFanFeed(model.team, [...model.upcomingEvents, ...model.recentResults]) ? <FanFeedCard model={model} /> : null}
       {model.canManageTeam ? <ScoreboardWidgetCard model={model} /> : null}
 
       <section className="app-card p-4">
@@ -404,6 +405,48 @@ function MoreTab({ model, onStaffInviteSuccess }: { model: TeamDetailModel; onSt
         </section>
       ) : null}
     </div>
+  );
+}
+
+function FanFeedCard({ model }: { model: TeamDetailModel }) {
+  const feedUrl = buildPublicTeamGamesIcsUrl(model.team.id);
+  const [status, setStatus] = useState<{ success: boolean; message: string } | null>(null);
+
+  async function shareFanFeed() {
+    const result = await sharePublicUrl({
+      title: `${model.team.name} fan feed`,
+      text: `${model.team.name} public games calendar feed`,
+      url: feedUrl,
+      clipboardText: feedUrl
+    });
+    if (result === 'shared') {
+      setStatus({ success: true, message: 'Fan feed share sheet opened.' });
+    } else if (result === 'copied') {
+      setStatus({ success: true, message: 'Fan feed link copied.' });
+    } else {
+      setStatus({ success: false, message: 'Unable to share the fan feed from this device.' });
+    }
+  }
+
+  return (
+    <section className="app-card p-4">
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 flex-none items-center justify-center rounded-xl bg-primary-50 text-primary-700">
+          <CalendarDays className="h-5 w-5" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-black text-gray-950">Fan Feed</div>
+          <div className="mt-1 text-xs font-semibold leading-5 text-gray-500">Share a public games-only calendar link for fans. Practices, private notes, RSVPs, and assignments stay out of this feed.</div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button type="button" className="primary-button !min-h-9 text-xs" onClick={shareFanFeed}>
+              <LinkIcon className="h-4 w-4" aria-hidden="true" />
+              Copy or Share Fan Feed
+            </button>
+          </div>
+          {status ? <div className={`mt-2 text-xs font-black ${status.success ? 'text-emerald-700' : 'text-rose-700'}`} role="status">{status.message}</div> : null}
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -354,6 +354,22 @@ async function mockHomePlayerModules(page) {
                     return { success: true };
                 }
 
+                export function buildPublicTeamGamesIcsUrl(teamId) {
+                    return teamId ? 'https://calendar.example.test/publicTeamGamesIcs?teamId=' + encodeURIComponent(teamId) : '';
+                }
+
+                export function canExposePublicFanFeed(team = {}, events = []) {
+                    return (events || []).some((event) => event?.type === 'game'
+                        && event?.visibility !== 'private'
+                        && event?.isPrivate !== true
+                        && event?.status !== 'deleted'
+                        && event?.liveStatus !== 'deleted'
+                        && ((team?.isPublic !== false && team?.active !== false)
+                            || event?.isPublic === true
+                            || event?.shareable === true
+                            || event?.publicCalendar === true));
+                }
+
                 export async function loadParentTeamDetail() {
                     const nextDate = new Date('2100-06-01T18:00:00Z');
                     return {

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -201,6 +201,22 @@ async function mockTeamsModules(page) {
                     return { success: true };
                 }
 
+                export function buildPublicTeamGamesIcsUrl(teamId) {
+                    return teamId ? 'https://calendar.example.test/publicTeamGamesIcs?teamId=' + encodeURIComponent(teamId) : '';
+                }
+
+                export function canExposePublicFanFeed(team = {}, events = []) {
+                    return (events || []).some((event) => event?.type === 'game'
+                        && event?.visibility !== 'private'
+                        && event?.isPrivate !== true
+                        && event?.status !== 'deleted'
+                        && event?.liveStatus !== 'deleted'
+                        && ((team?.isPublic !== false && team?.active !== false)
+                            || event?.isPublic === true
+                            || event?.shareable === true
+                            || event?.publicCalendar === true));
+                }
+
                 export async function loadParentTeamDetail(teamId) {
                     if (teamId === 'team-empty') {
                         return {

--- a/tests/unit/app-team-detail-integration.test.jsx
+++ b/tests/unit/app-team-detail-integration.test.jsx
@@ -5,11 +5,14 @@ import { createRoot } from '../../apps/app/node_modules/react-dom/client.js';
 import { MemoryRouter, Route, Routes } from '../../apps/app/node_modules/react-router-dom/dist/index.mjs';
 
 const teamDetailMocks = vi.hoisted(() => ({
-    loadParentTeamDetail: vi.fn()
+    loadParentTeamDetail: vi.fn(),
+    buildPublicTeamGamesIcsUrl: vi.fn((teamId) => `https://us-central1-all-plays-prod.cloudfunctions.net/publicTeamGamesIcs?teamId=${encodeURIComponent(teamId)}`),
+    canExposePublicFanFeed: vi.fn((team, events = []) => (events || []).some((event) => event?.type === 'game' && event?.visibility !== 'private' && event?.isPrivate !== true && event?.status !== 'deleted' && event?.liveStatus !== 'deleted' && ((team?.isPublic !== false && team?.active !== false) || event?.isPublic === true || event?.shareable === true || event?.publicCalendar === true)))
 }));
 const publicActionMocks = vi.hoisted(() => ({
     copyPublicText: vi.fn(),
-    openPublicUrl: vi.fn()
+    openPublicUrl: vi.fn(),
+    sharePublicUrl: vi.fn()
 }));
 const scheduleServiceMocks = vi.hoisted(() => ({
     loadStaffRsvpReminderPreview: vi.fn(),
@@ -17,7 +20,9 @@ const scheduleServiceMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../../apps/app/src/lib/teamDetailService.ts', () => ({
-    loadParentTeamDetail: teamDetailMocks.loadParentTeamDetail
+    loadParentTeamDetail: teamDetailMocks.loadParentTeamDetail,
+    buildPublicTeamGamesIcsUrl: teamDetailMocks.buildPublicTeamGamesIcsUrl,
+    canExposePublicFanFeed: teamDetailMocks.canExposePublicFanFeed
 }));
 vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionMocks);
 vi.mock('../../apps/app/src/lib/scheduleService.ts', () => scheduleServiceMocks);
@@ -56,6 +61,8 @@ function model() {
             photoUrl: 'https://img.example.test/team.png',
             description: 'Fast, parent-friendly team page.',
             zip: '66210',
+            isPublic: true,
+            active: true,
             leagueUrl: 'https://league.example.test/standings',
             streamUrl: 'https://youtube.example.test/watch',
             websiteUrl: 'https://allplays.ai/team.html#teamId=team-1',
@@ -70,12 +77,12 @@ function model() {
             { id: 'player-1', name: 'Pat Star', number: '9', photoUrl: 'https://img.example.test/player.png', position: 'Guard', isLinked: true }
         ],
         upcomingEvents: [
-            { id: 'game-1', type: 'game', title: 'vs. Falcons', date: nextDate, location: 'Main Gym', opponent: 'Falcons', status: '', homeScore: null, awayScore: null, isCancelled: false }
+            { id: 'game-1', type: 'game', title: 'vs. Falcons', date: nextDate, location: 'Main Gym', opponent: 'Falcons', status: '', liveStatus: '', visibility: '', isPrivate: false, isPublic: false, shareable: true, publicCalendar: false, homeScore: null, awayScore: null, isCancelled: false }
         ],
         recentResults: [
-            { id: 'game-final', type: 'game', title: 'vs. Wolves', date: new Date('2026-05-01T18:00:00Z'), location: 'Main Gym', opponent: 'Wolves', status: 'completed', homeScore: 42, awayScore: 35, isCancelled: false }
+            { id: 'game-final', type: 'game', title: 'vs. Wolves', date: new Date('2026-05-01T18:00:00Z'), location: 'Main Gym', opponent: 'Wolves', status: 'completed', liveStatus: '', visibility: '', isPrivate: false, isPublic: false, shareable: false, publicCalendar: false, homeScore: 42, awayScore: 35, isCancelled: false }
         ],
-        nextEvent: { id: 'game-1', type: 'game', title: 'vs. Falcons', date: nextDate, location: 'Main Gym', opponent: 'Falcons', status: '', homeScore: null, awayScore: null, isCancelled: false },
+        nextEvent: { id: 'game-1', type: 'game', title: 'vs. Falcons', date: nextDate, location: 'Main Gym', opponent: 'Falcons', status: '', liveStatus: '', visibility: '', isPrivate: false, isPublic: false, shareable: true, publicCalendar: false, homeScore: null, awayScore: null, isCancelled: false },
         record: { label: '2100', wins: 4, losses: 2, ties: 1, gamesPlayed: 7, winPercentage: 64.3 },
         standings: {
             enabled: true,
@@ -158,6 +165,7 @@ beforeEach(() => {
         return 0;
     };
     publicActionMocks.copyPublicText.mockResolvedValue('copied');
+    publicActionMocks.sharePublicUrl.mockResolvedValue('copied');
     scheduleServiceMocks.loadStaffRsvpReminderPreview.mockResolvedValue({
         missingPlayerCount: 0,
         eligibleEmailCount: 0,
@@ -218,6 +226,41 @@ describe('React app TeamDetail page', () => {
         expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://youtube.example.test/watch');
         await clickLink(container, 'Pizza Place');
         expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://pizza.example.test');
+    });
+
+    it('renders and shares the public fan feed when at least one game is public or shareable', async () => {
+        const fanModel = model();
+        fanModel.team.id = 'team 1/blue';
+        fanModel.team.name = 'Bears & Wolves';
+        teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(fanModel);
+
+        const { container } = await renderTeamDetail();
+
+        await clickButton(container, 'More');
+        expect(container.textContent).toContain('Fan Feed');
+        expect(container.textContent).toContain('public games-only calendar link for fans');
+
+        await clickButton(container, 'Copy or Share Fan Feed');
+        expect(publicActionMocks.sharePublicUrl).toHaveBeenCalledWith({
+            title: 'Bears & Wolves fan feed',
+            text: 'Bears & Wolves public games calendar feed',
+            url: 'https://us-central1-all-plays-prod.cloudfunctions.net/publicTeamGamesIcs?teamId=team%201%2Fblue',
+            clipboardText: 'https://us-central1-all-plays-prod.cloudfunctions.net/publicTeamGamesIcs?teamId=team%201%2Fblue'
+        });
+        expect(container.textContent).toContain('Fan feed link copied.');
+
+        const hiddenModel = model();
+        hiddenModel.team.isPublic = false;
+        hiddenModel.upcomingEvents = [
+            { id: 'private-game', type: 'game', title: 'vs. Tigers', date: new Date('2100-06-03T18:00:00Z'), location: 'Gym', opponent: 'Tigers', status: '', liveStatus: '', visibility: 'private', isPrivate: true, isPublic: false, shareable: false, publicCalendar: false, homeScore: null, awayScore: null, isCancelled: false },
+            { id: 'practice-1', type: 'practice', title: 'Practice', date: new Date('2100-06-04T18:00:00Z'), location: 'Gym', opponent: '', status: '', liveStatus: '', visibility: '', isPrivate: false, isPublic: true, shareable: false, publicCalendar: false, homeScore: null, awayScore: null, isCancelled: false }
+        ];
+        hiddenModel.recentResults = [];
+        hiddenModel.nextEvent = hiddenModel.upcomingEvents[0];
+        teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(hiddenModel);
+        const hidden = await renderTeamDetail();
+        await clickButton(hidden.container, 'More');
+        expect(hidden.container.textContent).not.toContain('Fan Feed');
     });
 
     it('renders scoreboard widget copy tools only for managers', async () => {

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -29,7 +29,7 @@ vi.mock('../../js/auth.js', () => ({
     sendInviteEmail: vi.fn()
 }));
 
-vi.mock('../../apps/app/src/lib/authService.ts', () => ({
+vi.mock('../../apps/app/src/lib/authService', () => ({
     firebaseAuth: { app: { options: { projectId: 'demo-allplays' } } },
     getNativeAuthIdToken: vi.fn()
 }));
@@ -112,6 +112,12 @@ describe('React app team detail model', () => {
             ]
         )).toBe(true);
         expect(canExposePublicFanFeed(
+            { active: true },
+            [
+                { id: 'legacy-private-game', type: 'game', visibility: '', isPrivate: false, shareable: false, publicCalendar: false, status: 'scheduled', liveStatus: '' }
+            ]
+        )).toBe(false);
+        expect(canExposePublicFanFeed(
             { isPublic: false, active: true },
             [
                 { id: 'private-game', type: 'game', visibility: 'private', isPrivate: true, shareable: false, status: 'scheduled', liveStatus: '' },
@@ -168,7 +174,7 @@ describe('React app team detail model', () => {
 
         expect(model.team.photoUrl).toBe('https://img.example.test/team.png');
         expect(model.team.bracketUrl).toBe('https://bracket.example.test/path');
-        expect(model.team.isPublic).toBe(true);
+        expect(model.team.isPublic).toBe(false);
         expect(model.team.active).toBe(true);
         expect(model.team.registrationProvider.map((row) => row.value)).toContain('Sports Connect');
         expect(model.players.find((player) => player.id === 'player-1').photoUrl).toBe('https://img.example.test/player.png');

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -34,7 +34,7 @@ vi.mock('../../apps/app/src/lib/authService.ts', () => ({
     getNativeAuthIdToken: vi.fn()
 }));
 
-import { buildAdminAcceptInviteUrl, buildTeamDetailModel, grantScorekeeperAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp } from '../../apps/app/src/lib/teamDetailService.ts';
+import { buildAdminAcceptInviteUrl, buildPublicTeamGamesIcsUrl, buildTeamDetailModel, canExposePublicFanFeed, grantScorekeeperAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp } from '../../apps/app/src/lib/teamDetailService.ts';
 import { getDocs } from '../../js/firebase.js';
 import { getAggregatedStatsForGames, getAdSpaceSponsors, getConfigs, getGames, getLocalAttractionSponsors, getPlayers, getTeam, grantScorekeeperAccess, inviteAdmin, addTeamAdminEmail, revokeScorekeeperAccess } from '../../js/db.js';
 import { sendInviteEmail } from '../../js/auth.js';
@@ -96,6 +96,39 @@ describe('React app team detail model', () => {
         expect(grantScorekeeperAccess).not.toHaveBeenCalled();
     });
 
+    it('builds public fan feed URLs and gates them to public or shareable games', () => {
+        window.__ALLPLAYS_CONFIG__ = {
+            publicTeamGamesIcsFunctionUrl: 'https://calendar.example.test/publicTeamGamesIcs',
+            calendarFetchFunctionUrl: 'https://calendar.example.test/fetchCalendarIcs'
+        };
+
+        expect(buildPublicTeamGamesIcsUrl('team 1/blue')).toBe('https://calendar.example.test/publicTeamGamesIcs?teamId=team%201%2Fblue');
+        expect(buildPublicTeamGamesIcsUrl('')).toBe('');
+        expect(canExposePublicFanFeed(
+            { isPublic: false, active: true },
+            [
+                { id: 'shareable-game', type: 'game', shareable: true, isPrivate: false, visibility: '', status: 'scheduled', liveStatus: '' },
+                { id: 'practice-1', type: 'practice', isPublic: true, status: 'scheduled', liveStatus: '' }
+            ]
+        )).toBe(true);
+        expect(canExposePublicFanFeed(
+            { isPublic: false, active: true },
+            [
+                { id: 'private-game', type: 'game', visibility: 'private', isPrivate: true, shareable: false, status: 'scheduled', liveStatus: '' },
+                { id: 'deleted-game', type: 'game', isPublic: true, status: 'deleted', liveStatus: '' },
+                { id: 'practice-2', type: 'practice', isPublic: true, status: 'scheduled', liveStatus: '' }
+            ]
+        )).toBe(false);
+        expect(canExposePublicFanFeed(
+            { isPublic: true, active: true },
+            [
+                { id: 'public-team-game', type: 'game', visibility: '', isPrivate: false, status: 'scheduled', liveStatus: '' }
+            ]
+        )).toBe(true);
+
+        delete window.__ALLPLAYS_CONFIG__;
+    });
+
     it('projects team.html parent features into the native team model', () => {
         const model = buildTeamDetailModel({
             teamId: 'team-1',
@@ -113,7 +146,7 @@ describe('React app team detail model', () => {
                 { id: 'player-2', name: 'Sam Wing', number: '12' }
             ],
             games: [
-                { id: 'game-1', opponent: 'Falcons', date: new Date('2100-06-01T18:00:00Z'), status: 'scheduled', homeScore: null, awayScore: null },
+                { id: 'game-1', opponent: 'Falcons', date: new Date('2100-06-01T18:00:00Z'), status: 'scheduled', homeScore: null, awayScore: null, shareable: true },
                 { id: 'game-2', opponent: 'Wolves', date: new Date('2026-05-01T18:00:00Z'), status: 'completed', homeScore: 42, awayScore: 35, isHome: true },
                 { id: 'practice-1', type: 'practice', title: 'Practice', date: new Date('2100-06-02T18:00:00Z') }
             ],
@@ -135,11 +168,14 @@ describe('React app team detail model', () => {
 
         expect(model.team.photoUrl).toBe('https://img.example.test/team.png');
         expect(model.team.bracketUrl).toBe('https://bracket.example.test/path');
+        expect(model.team.isPublic).toBe(true);
+        expect(model.team.active).toBe(true);
         expect(model.team.registrationProvider.map((row) => row.value)).toContain('Sports Connect');
         expect(model.players.find((player) => player.id === 'player-1').photoUrl).toBe('https://img.example.test/player.png');
         expect(model.linkedPlayers.map((player) => player.id)).toEqual(['player-1']);
         expect(model.record).toMatchObject({ wins: 1, losses: 0, ties: 0, gamesPlayed: 1 });
         expect(model.upcomingEvents.map((event) => event.id)).toEqual(['game-1', 'practice-1']);
+        expect(model.upcomingEvents[0]).toMatchObject({ shareable: true, isPrivate: false, publicCalendar: false, liveStatus: '' });
         expect(model.standings.currentRow.record).toBe('1-0');
         expect(model.leaderboards[0].leaders[0]).toMatchObject({ playerId: 'player-1', formattedValue: '88' });
         expect(model.trackingSummaries[0].items[0]).toMatchObject({ title: 'Bring ball', isComplete: true });

--- a/tests/unit/app-team-detail-staff-permissions.test.jsx
+++ b/tests/unit/app-team-detail-staff-permissions.test.jsx
@@ -8,11 +8,14 @@ const teamDetailMocks = vi.hoisted(() => ({
     loadParentTeamDetail: vi.fn(),
     grantScorekeeperAccessForApp: vi.fn(),
     revokeScorekeeperAccessForApp: vi.fn(),
-    inviteTeamAdminForApp: vi.fn()
+    inviteTeamAdminForApp: vi.fn(),
+    buildPublicTeamGamesIcsUrl: vi.fn((teamId) => `https://us-central1-all-plays-prod.cloudfunctions.net/publicTeamGamesIcs?teamId=${encodeURIComponent(teamId)}`),
+    canExposePublicFanFeed: vi.fn(() => false)
 }));
 const publicActionMocks = vi.hoisted(() => ({
     copyPublicText: vi.fn(),
-    openPublicUrl: vi.fn()
+    openPublicUrl: vi.fn(),
+    sharePublicUrl: vi.fn()
 }));
 
 vi.mock('../../apps/app/src/lib/teamDetailService.ts', () => teamDetailMocks);
@@ -49,6 +52,8 @@ function makeModel(staffPermissions) {
             photoUrl: null,
             description: '',
             zip: '',
+            isPublic: true,
+            active: true,
             leagueUrl: null,
             bracketUrl: null,
             streamUrl: null,


### PR DESCRIPTION
Closes #1659

## What changed
- added public fan-feed eligibility and URL helpers to `teamDetailService` so Team Detail can detect public/shareable games safely
- extended Team Detail event normalization with the minimal visibility fields needed to hide the action for private, deleted, or practice-only schedules
- added a Fan Feed card to the Team Detail More tab that uses existing share/copy behavior and inline status feedback
- added focused Team Detail service and integration coverage for gating and share behavior

## Why
The React Team Detail screen was missing the legacy fan-facing public games calendar action. This restores that parity with a small, app-native control without exposing private schedule data or expanding the broader calendar UI scope.