### PR TITLE
Preserve goal controls unless game selects stat config

### DIFF
--- a/js/live-game-state.js
+++ b/js/live-game-state.js
@@ -80,8 +80,7 @@ export function resolveGoalSportTrackerProfile({ trackerMode = '', game = null, 
   if (mode === 'simple') return goalSportProfile;
 
   const hasExplicitStatTrackerConfig = !!String(game?.statTrackerConfigId || '').trim();
-  const hasResolvedStatTrackerConfig = !!String(config?.id || '').trim();
-  return hasExplicitStatTrackerConfig || hasResolvedStatTrackerConfig ? null : goalSportProfile;
+  return hasExplicitStatTrackerConfig ? null : goalSportProfile;
 }
 
 export function resolveLiveStatColumns({ columns = [], configs = [], game = null, team = null } = {}) {

--- a/js/live-game-state.js
+++ b/js/live-game-state.js
@@ -72,11 +72,13 @@ export function resolvePreferredStatConfigId({ configs = [], team = null } = {})
 }
 
 export function resolveGoalSportTrackerProfile({ trackerMode = '', game = null, team = null, config = null } = {}) {
-  const sport = game?.sport || config?.baseType || team?.sport || '';
+  const mode = String(trackerMode || '').trim().toLowerCase();
+  const sport = mode === 'simple'
+    ? game?.sport || config?.baseType || team?.sport || ''
+    : game?.sport || team?.sport || '';
   const goalSportProfile = getGoalSportProfile({ sport });
   if (!goalSportProfile) return null;
 
-  const mode = String(trackerMode || '').trim().toLowerCase();
   if (mode === 'simple') return goalSportProfile;
 
   const hasExplicitStatTrackerConfig = !!String(game?.statTrackerConfigId || '').trim();

--- a/tests/unit/live-game-state.test.js
+++ b/tests/unit/live-game-state.test.js
@@ -74,12 +74,18 @@ describe('live game state helpers', () => {
     })).toBe('cfg-only');
   });
 
-  it('uses the goal-sport simple tracker only when no stat config is resolved by default', () => {
+  it('keeps goal-sport scoring enabled unless the game explicitly picks a stat config', () => {
     expect(resolveGoalSportTrackerProfile({
       game: { sport: 'Soccer' },
       team: { sport: 'Soccer' },
       config: { id: 'cfg-soccer', baseType: 'Soccer', columns: ['GOALS', 'SHOTS'] }
-    })).toBeNull();
+    })).toMatchObject({ sport: 'soccer', statColumns: ['GOALS'] });
+
+    expect(resolveGoalSportTrackerProfile({
+      game: { sport: 'Soccer' },
+      team: { sport: 'Soccer' },
+      config: { id: 'cfg-basketball', baseType: 'Basketball', columns: ['PTS', 'REB'] }
+    })).toMatchObject({ sport: 'soccer', statColumns: ['GOALS'] });
 
     expect(resolveGoalSportTrackerProfile({
       game: { sport: 'Soccer', statTrackerConfigId: 'cfg-soccer' },

--- a/tests/unit/live-game-state.test.js
+++ b/tests/unit/live-game-state.test.js
@@ -88,6 +88,12 @@ describe('live game state helpers', () => {
     })).toMatchObject({ sport: 'soccer', statColumns: ['GOALS'] });
 
     expect(resolveGoalSportTrackerProfile({
+      game: {},
+      team: { sport: 'Basketball' },
+      config: { id: 'cfg-soccer', baseType: 'Soccer', columns: ['GOALS', 'SHOTS'] }
+    })).toBeNull();
+
+    expect(resolveGoalSportTrackerProfile({
       game: { sport: 'Soccer', statTrackerConfigId: 'cfg-soccer' },
       team: { sport: 'Soccer' },
       config: { baseType: 'Soccer', columns: ['GOALS', 'SHOTS'] }


### PR DESCRIPTION
Closes #1661

## What changed
- updated `resolveGoalSportTrackerProfile` so goal-sport live trackers stay in dedicated goal mode unless the game explicitly sets `statTrackerConfigId`
- stopped treating any merely resolved team config as a reason to suppress the Home Goal/Away Goal workflow
- added a regression test covering both same-sport and unrelated lone-config cases

## Why
Goal-sport games were silently losing their dedicated scoring controls whenever a team had a single saved stat config, even if the game itself had not opted into that config. This keeps the intended fast scorekeeping flow for soccer, lacrosse, hockey, field hockey, and water polo unless the game explicitly chooses stat-tracker mode.