### PR TITLE
Fix older certificate run share links

### DIFF
--- a/certificates.html
+++ b/certificates.html
@@ -97,7 +97,7 @@
 
     <div id="footer-container"></div>
 
-    <script type="module" src="./js/certificates/studio.js?v=8"></script>
+    <script type="module" src="./js/certificates/studio.js?v=9"></script>
 </body>
 
 </html>

--- a/js/certificates/studio.js
+++ b/js/certificates/studio.js
@@ -11,6 +11,7 @@ import {
     setCertificateDefaults,
     listCertificateAssets,
     listCertificateBatches,
+    getCertificateBatch,
     listCertificates,
     listCertificatesForPlayer,
     createCertificateBatch,
@@ -20,7 +21,7 @@ import {
     getCertificate,
     canAccessCertificates,
     canViewSavedCertificate
-} from '../db.js?v=32';
+} from '../db.js?v=33';
 import { renderHeader, renderFooter, escapeHtml, shareOrCopy } from '../utils.js?v=8';
 import { renderTeamAdminBanner, getTeamAccessInfo } from '../team-admin-banner.js?v=4';
 import { TEMPLATES } from './templates.js?v=2';
@@ -1528,7 +1529,20 @@ async function loadCertificatesForSavedBatch(batch) {
 }
 
 async function openSavedBatch(batchId) {
-    const batch = state.savedBatches.find((item) => item.id === batchId);
+    let batch = state.savedBatches.find((item) => item.id === batchId);
+    if (!batch && !state.demoMode && !state.certificatePersistenceUnavailable) {
+        try {
+            batch = await getCertificateBatch(state.teamId, batchId);
+            if (batch) {
+                upsertSavedBatch(batch);
+            }
+        } catch (error) {
+            if (!isPermissionError(error)) throw error;
+            state.certificatePersistenceUnavailable = true;
+            showAlert('Saved certificate data could not be loaded. You can still create, edit, export, and print certificates.', 'warning');
+            return;
+        }
+    }
     if (!batch) {
         showAlert('Saved run could not be found.', 'warning');
         return;

--- a/js/db.js
+++ b/js/db.js
@@ -4742,6 +4742,12 @@ export async function updateCertificateBatch(teamId, batchId, data = {}) {
     await writeCertificateBatchAudit(teamId, batchId, { action: data.status === 'published' ? 'published' : 'updated' });
 }
 
+export async function getCertificateBatch(teamId, batchId) {
+    if (!teamId || !batchId) return null;
+    const snap = await getDoc(doc(db, 'teams', teamId, 'certificateBatches', batchId));
+    return snap.exists() ? { id: snap.id, ...snap.data() } : null;
+}
+
 export async function listCertificateBatches(teamId, options = {}) {
     if (!teamId) return [];
     const batchesRef = collection(db, 'teams', teamId, 'certificateBatches');

--- a/tests/unit/certificates-workflow.test.js
+++ b/tests/unit/certificates-workflow.test.js
@@ -23,7 +23,7 @@ describe('awards and certificates workflow wiring', () => {
         expect(html).toContain('Start new run');
         expect(html).toContain('View saved work');
         expect(html).toContain('Create one-off certificate');
-        expect(html).toContain('./js/certificates/studio.js?v=8');
+        expect(html).toContain('./js/certificates/studio.js?v=9');
         expect(studio).toContain("from './templates.js?v=2'");
         expect(studio).toContain("from './renderer.js?v=2'");
         expect(studio).toContain("from './aiDescriptions.js?v=4'");
@@ -53,7 +53,7 @@ describe('awards and certificates workflow wiring', () => {
         expect(studio).toContain('certificateLimit = 6');
         expect(studio).toContain('Showing ${visible.length} of ${items.length}');
         expect(studio).toContain('openSavedBatch');
-        expect(studio).toContain('getCertificateBatch(state.teamId, batchId)');
+        expect(studio).toContain('await getCertificateBatch(state.teamId, batchId)');
         expect(studio).toContain('upsertSavedBatch(batch);');
         expect(studio).toContain('openSavedCertificate');
         expect(studio).toContain("params.get('certificateId')");

--- a/tests/unit/certificates-workflow.test.js
+++ b/tests/unit/certificates-workflow.test.js
@@ -27,7 +27,7 @@ describe('awards and certificates workflow wiring', () => {
         expect(studio).toContain("from './templates.js?v=2'");
         expect(studio).toContain("from './renderer.js?v=2'");
         expect(studio).toContain("from './aiDescriptions.js?v=4'");
-        expect(studio).toContain("from '../db.js?v=32'");
+        expect(studio).toContain("from '../db.js?v=33'");
 
         expect(studio).toContain('Create drafts for selected players');
         expect(studio).toContain('Saved work');
@@ -53,6 +53,8 @@ describe('awards and certificates workflow wiring', () => {
         expect(studio).toContain('certificateLimit = 6');
         expect(studio).toContain('Showing ${visible.length} of ${items.length}');
         expect(studio).toContain('openSavedBatch');
+        expect(studio).toContain('getCertificateBatch(state.teamId, batchId)');
+        expect(studio).toContain('upsertSavedBatch(batch);');
         expect(studio).toContain('openSavedCertificate');
         expect(studio).toContain("params.get('certificateId')");
         expect(studio).toContain("params.get('batchId')");
@@ -145,6 +147,7 @@ describe('awards and certificates workflow wiring', () => {
             'getCertificateDefaults',
             'setCertificateDefaults',
             'createCertificateBatch',
+            'getCertificateBatch',
             'listCertificateBatches',
             'createCertificate',
             'updateCertificate',


### PR DESCRIPTION
Closes #1665

## What changed
- added a direct `getCertificateBatch` Firestore helper for certificate batch lookups by id
- updated the certificates studio to fall back to that direct lookup when a shared `batchId` is not in the initially loaded recent batch list
- kept the loaded saved-run cache in sync after a direct batch fetch and bumped the `db.js` cache-bust import version
- extended the certificates workflow regression test to cover the new batch deep-link fallback wiring

## Why
Shared saved-run links were only resolving against the most recent loaded batches. Once a team had more than 100 newer runs, older shared links incorrectly showed "Saved run could not be found." even though the batch still existed in Firestore. This change makes batch deep links reopen the specific saved run regardless of recency.