### PR TITLE
Add failed payment reminder emails for registrations

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -56,6 +56,15 @@ const {
   isVerifiedAccountMergeRequest,
   mergePreferenceObjects
 } = require('./account-merge-core.cjs');
+const {
+  REGISTRATION_PAYMENT_REMINDER_CADENCE_DAYS,
+  buildQueuedReminderAuditEntry,
+  buildRegistrationFailedPaymentReminderState,
+  buildRegistrationPaymentReminderMailDocId,
+  buildRegistrationPaymentReminderMessage,
+  buildRegistrationPaymentRetryUrl,
+  shouldStopRegistrationPaymentReminders
+} = require('./registration-payment-reminders-core.cjs');
 
 if (admin.apps.length === 0) {
   admin.initializeApp();
@@ -175,6 +184,10 @@ function buildRegistrationFormRef({ teamId, formId }) {
   return firestore.doc(`teams/${teamId}/registrationForms/${formId}`);
 }
 
+function buildRegistrationReminderMailRef(mailDocId) {
+  return firestore.collection('mail').doc(mailDocId);
+}
+
 function buildRegistrationCheckoutUrls(appUrl, input) {
   const baseUrl = String(appUrl || 'https://allplays.ai').replace(/\/$/, '');
   const params = new URLSearchParams({
@@ -259,6 +272,156 @@ function buildRegistrationRefFromStripeSession(session = {}) {
     formId: normalizeFirestoreId(metadata.formId, 'formId'),
     registrationId: normalizeFirestoreId(metadata.registrationId, 'registrationId')
   });
+}
+
+function buildRegistrationReminderMailJob({
+  registration = {},
+  form = {},
+  retryUrl = '',
+  reminderLabel,
+  metadata = {}
+} = {}) {
+  const programName = registration.programName || form.programName || form.title || form.name || 'Program registration';
+  const amountDueCents = getRegistrationCheckoutAmountCents(registration);
+  const currency = registration.currency || 'USD';
+  const message = buildRegistrationPaymentReminderMessage({
+    programName,
+    amountDueCents,
+    currency,
+    retryUrl,
+    reminderLabel
+  });
+  return {
+    to: [metadata.recipientEmail],
+    message,
+    createdAt: admin.firestore.FieldValue.serverTimestamp(),
+    metadata: {
+      type: 'registration_failed_payment',
+      teamId: metadata.teamId,
+      formId: metadata.formId,
+      registrationId: metadata.registrationId,
+      reminderKind: metadata.reminderKind,
+      reminderNumber: metadata.reminderNumber,
+      stripeEventId: metadata.stripeEventId || null,
+      retryUrl,
+      amountDueCents,
+      currency
+    }
+  };
+}
+
+function buildRegistrationReminderStopUpdate({ reason = 'resolved', nowIso = '' } = {}) {
+  return {
+    'paymentReminder.status': reason,
+    'paymentReminder.resolvedAt': nowIso,
+    'paymentReminder.nextReminderAt': admin.firestore.FieldValue.delete(),
+    'paymentReminder.lastReminderKind': reason,
+    updatedAt: admin.firestore.FieldValue.serverTimestamp()
+  };
+}
+
+async function queueDueRegistrationFailedPaymentReminders() {
+  const now = new Date();
+  const nowIso = now.toISOString();
+  const { appUrl } = getStripeConfig();
+  const dueSnap = await firestore.collectionGroup('registrations')
+    .where('paymentReminder.nextReminderAt', '<=', nowIso)
+    .limit(50)
+    .get();
+
+  const results = [];
+  for (const docSnap of dueSnap.docs) {
+    const registrationRef = docSnap.ref;
+    let queued = false;
+    await firestore.runTransaction(async (transaction) => {
+      const freshSnap = await transaction.get(registrationRef);
+      if (!freshSnap.exists) return;
+
+      const registration = freshSnap.data() || {};
+      const reminder = registration.paymentReminder || {};
+      const nextReminderAt = String(reminder.nextReminderAt || '').trim();
+      if (!nextReminderAt || nextReminderAt > nowIso) return;
+
+      if (shouldStopRegistrationPaymentReminders(registration)) {
+        transaction.update(registrationRef, buildRegistrationReminderStopUpdate({
+          reason: registration.paymentStatus === 'paid' ? 'paid' : 'closed',
+          nowIso
+        }));
+        return;
+      }
+
+      const recipientEmail = String(reminder.recipientEmail || getRegistrationCustomerEmail(registration) || '').trim().toLowerCase();
+      if (!recipientEmail) {
+        transaction.update(registrationRef, {
+          'paymentReminder.status': 'missing_email',
+          'paymentReminder.lastReminderKind': 'missing_email',
+          'paymentReminder.nextReminderAt': admin.firestore.FieldValue.delete(),
+          updatedAt: admin.firestore.FieldValue.serverTimestamp()
+        });
+        return;
+      }
+
+      const reminderNumber = Math.max(1, Number(reminder.reminderCount || 0) + 1);
+      const registrationInput = {
+        teamId: registration.teamId,
+        formId: registration.formId,
+        registrationId: registration.id || registrationRef.id,
+        checkoutAttemptToken: registration.checkoutAttemptToken || ''
+      };
+      const mailDocId = buildRegistrationPaymentReminderMailDocId({
+        teamId: registration.teamId,
+        formId: registration.formId,
+        registrationId: registration.id || registrationRef.id,
+        eventId: reminder.lastEventId || 'manual',
+        sequence: `followup_${reminderNumber}`
+      });
+      const retryUrl = String(reminder.retryUrl || '').trim() || buildRegistrationPaymentRetryUrl(appUrl, registrationInput);
+      const form = {
+        programName: registration.programName || 'Program registration'
+      };
+      const mailJob = buildRegistrationReminderMailJob({
+        registration,
+        form,
+        retryUrl,
+        reminderLabel: 'Your registration payment is still due.',
+        metadata: {
+          recipientEmail,
+          teamId: registration.teamId,
+          formId: registration.formId,
+          registrationId: registration.id || registrationRef.id,
+          reminderKind: 'followup',
+          reminderNumber,
+          stripeEventId: reminder.lastEventId || null
+        }
+      });
+
+      transaction.set(buildRegistrationReminderMailRef(mailDocId), mailJob);
+      transaction.update(registrationRef, {
+        'paymentReminder.status': 'active',
+        'paymentReminder.recipientEmail': recipientEmail,
+        'paymentReminder.retryUrl': retryUrl,
+        'paymentReminder.reminderCount': reminderNumber,
+        'paymentReminder.lastQueuedAt': nowIso,
+        'paymentReminder.lastMailId': mailDocId,
+        'paymentReminder.lastReminderKind': 'followup',
+        'paymentReminder.lastAudit': buildQueuedReminderAuditEntry({
+          kind: 'followup',
+          eventId: reminder.lastEventId || '',
+          mailDocId,
+          queuedAtIso: nowIso
+        }),
+        'paymentReminder.nextReminderAt': new Date(now.getTime() + REGISTRATION_PAYMENT_REMINDER_CADENCE_DAYS * 24 * 60 * 60 * 1000).toISOString(),
+        updatedAt: admin.firestore.FieldValue.serverTimestamp()
+      });
+      queued = true;
+    });
+
+    if (queued) {
+      results.push(registrationRef.path);
+    }
+  }
+
+  return results;
 }
 
 async function releaseRegistrationCheckoutCapacity(input, statusUpdate = {}) {
@@ -1707,6 +1870,8 @@ exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
     try {
       const session = event.data.object;
       const receivedAt = admin.firestore.FieldValue.serverTimestamp();
+      const queuedAtIso = new Date().toISOString();
+      const { appUrl } = getStripeConfig();
       const eventRef = firestore.doc(`stripeEvents/${event.id}`);
       const registrationRef = buildRegistrationRefFromStripeSession(session);
       const registrationInput = normalizeRegistrationCheckoutCancelInput(session.metadata || {});
@@ -1738,6 +1903,7 @@ exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
             stripeEventId: event.id,
             updatedAt: receivedAt
           }, { merge: true });
+          transaction.update(registrationRef, buildRegistrationReminderStopUpdate({ reason: 'paid', nowIso: queuedAtIso }));
         } else {
           const form = formSnap.data() || {};
           const registration = registrationSnap.data() || {};
@@ -1781,6 +1947,60 @@ exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
             capacityReleasedAt: receivedAt,
             updatedAt: receivedAt
           }, { merge: true });
+
+          if (event.type === 'checkout.session.async_payment_failed') {
+            const recipientEmail = String(getRegistrationCustomerEmail(registration) || '').trim().toLowerCase();
+            if (recipientEmail) {
+              const mailDocId = buildRegistrationPaymentReminderMailDocId({
+                teamId: registrationInput.teamId,
+                formId: registrationInput.formId,
+                registrationId: registrationInput.registrationId,
+                eventId: event.id,
+                sequence: 'initial'
+              });
+              const reminderState = buildRegistrationFailedPaymentReminderState({
+                registration,
+                input: registrationInput,
+                eventId: event.id,
+                appUrl,
+                queuedAtIso,
+                mailDocId
+              });
+              transaction.set(buildRegistrationReminderMailRef(mailDocId), buildRegistrationReminderMailJob({
+                registration,
+                form,
+                retryUrl: reminderState.retryUrl,
+                reminderLabel: 'We could not process your registration payment.',
+                metadata: {
+                  recipientEmail,
+                  teamId: registrationInput.teamId,
+                  formId: registrationInput.formId,
+                  registrationId: registrationInput.registrationId,
+                  reminderKind: 'initial',
+                  reminderNumber: 1,
+                  stripeEventId: event.id
+                }
+              }));
+              transaction.set(registrationRef, {
+                paymentReminder: {
+                  ...reminderState,
+                  recipientEmail
+                }
+              }, { merge: true });
+            } else {
+              transaction.set(registrationRef, {
+                paymentReminder: {
+                  status: 'missing_email',
+                  reminderCount: 0,
+                  lastEventId: event.id,
+                  lastReminderKind: 'missing_email',
+                  lastQueuedAt: queuedAtIso
+                }
+              }, { merge: true });
+            }
+          } else {
+            transaction.update(registrationRef, buildRegistrationReminderStopUpdate({ reason: 'closed', nowIso: queuedAtIso }));
+          }
         }
 
         transaction.set(eventRef, {
@@ -2943,6 +3163,10 @@ async function dispatchDuePreEventReminders(now = new Date()) {
 exports.dispatchDuePreEventReminders = functions.pubsub
   .schedule('every 15 minutes')
   .onRun(() => dispatchDuePreEventReminders());
+
+exports.queueDueRegistrationFailedPaymentReminders = functions.pubsub
+  .schedule('every 6 hours')
+  .onRun(() => queueDueRegistrationFailedPaymentReminders());
 
 exports.notifyTeamChatMessageCreated = functions.firestore
   .document('teams/{teamId}/chatMessages/{messageId}')

--- a/functions/index.js
+++ b/functions/index.js
@@ -149,12 +149,13 @@ function normalizeCheckoutAttemptToken(value, label = 'checkoutAttemptToken') {
 }
 
 function normalizeRegistrationCheckoutInput(data = {}) {
-  const amountCents = Math.round(Number(data.amount ?? data.amountCents ?? 0));
-  const currency = String(data.currency || 'usd').trim().toLowerCase();
-  if (!Number.isFinite(amountCents) || amountCents <= 0) {
+  const hasAmount = data.amount !== undefined || data.amountCents !== undefined;
+  const amountCents = hasAmount ? Math.round(Number(data.amount ?? data.amountCents ?? 0)) : null;
+  const currency = String(data.currency || '').trim().toLowerCase();
+  if (hasAmount && (!Number.isFinite(amountCents) || amountCents <= 0)) {
     throw new Error('A positive checkout amount is required.');
   }
-  if (!/^[a-z]{3}$/.test(currency)) {
+  if (currency && !/^[a-z]{3}$/.test(currency)) {
     throw new Error('A valid checkout currency is required.');
   }
   return {
@@ -163,7 +164,8 @@ function normalizeRegistrationCheckoutInput(data = {}) {
     registrationId: normalizeFirestoreId(data.registrationId, 'registrationId'),
     amountCents,
     currency,
-    checkoutAttemptToken: normalizeCheckoutAttemptToken(data.checkoutAttemptToken)
+    checkoutAttemptToken: normalizeCheckoutAttemptToken(data.checkoutAttemptToken),
+    retryPayment: data.retryPayment === true || String(data.retryPayment || '').trim() === '1'
   };
 }
 
@@ -197,6 +199,9 @@ function buildRegistrationCheckoutUrls(appUrl, input) {
   });
   if (input.checkoutAttemptToken) {
     params.set('checkoutAttemptToken', input.checkoutAttemptToken);
+  }
+  if (input.retryPayment) {
+    params.set('retryPayment', '1');
   }
   return {
     successUrl: `${baseUrl}/registration.html?${params.toString()}&status=success`,
@@ -1772,13 +1777,17 @@ exports.createStripeRegistrationCheckout = functions.https.onCall(async (data) =
   }
 
   const expectedAmountCents = getRegistrationCheckoutAmountCents(registration);
-  if (input.amountCents !== expectedAmountCents) {
+  const amountCents = input.amountCents ?? expectedAmountCents;
+  if (input.amountCents !== null && input.amountCents !== expectedAmountCents) {
     throw new functions.https.HttpsError('failed-precondition', 'Checkout amount does not match the registration fee.');
   }
+  const currency = String(
+    input.currency || registration.feeSnapshot?.currency || registration.currency || form.currency || 'usd'
+  ).trim().toLowerCase() || 'usd';
   if (!registrationCheckoutAttemptMatches(registration, input)) {
     throw new functions.https.HttpsError('failed-precondition', 'Registration checkout attempt does not match.');
   }
-  if (canReuseRegistrationCheckoutSession(registration, input.amountCents, input)) {
+  if (canReuseRegistrationCheckoutSession(registration, amountCents, input)) {
     return { checkoutUrl: registration.checkoutUrl, sessionId: registration.stripeCheckoutSessionId };
   }
 
@@ -1790,8 +1799,8 @@ exports.createStripeRegistrationCheckout = functions.https.onCall(async (data) =
     mode: 'payment',
     line_items: [{
       price_data: {
-        currency: input.currency,
-        unit_amount: input.amountCents,
+        currency,
+        unit_amount: amountCents,
         product_data: {
           name: title
         }
@@ -1814,7 +1823,7 @@ exports.createStripeRegistrationCheckout = functions.https.onCall(async (data) =
     paymentStatus: 'checkout_open',
     stripeCheckoutSessionId: session.id,
     stripePaymentStatus: session.payment_status || 'unpaid',
-    checkoutAmountCents: input.amountCents,
+    checkoutAmountCents: amountCents,
     checkoutAttemptToken: input.checkoutAttemptToken || null,
     checkoutCreatedAt: now,
     updatedAt: now

--- a/functions/registration-payment-reminders-core.cjs
+++ b/functions/registration-payment-reminders-core.cjs
@@ -46,6 +46,21 @@ function escapeHtml(value) {
   }[char]));
 }
 
+function sanitizeHttpUrl(value) {
+  const trimmedValue = String(value || '').trim();
+  if (!trimmedValue) {
+    return '';
+  }
+  try {
+    const parsedUrl = new URL(trimmedValue);
+    return parsedUrl.protocol === 'https:' || parsedUrl.protocol === 'http:'
+      ? parsedUrl.toString()
+      : '';
+  } catch (error) {
+    return '';
+  }
+}
+
 function buildRegistrationPaymentReminderMailDocId({ teamId, formId, registrationId, eventId, sequence = 'initial' } = {}) {
   const parts = [teamId, formId, registrationId, eventId, sequence]
     .map((part) => String(part || '').trim().replace(/[^\w.-]+/g, '_').slice(0, 120))
@@ -71,7 +86,7 @@ function buildRegistrationPaymentReminderMessage({
 } = {}) {
   const safeProgramName = String(programName || 'your registration').trim() || 'your registration';
   const amountLabel = formatRegistrationReminderAmount(amountDueCents, currency);
-  const safeRetryUrl = String(retryUrl || '').trim();
+  const safeRetryUrl = sanitizeHttpUrl(retryUrl);
   return {
     subject: `Payment reminder: ${safeProgramName}`,
     text: [

--- a/functions/registration-payment-reminders-core.cjs
+++ b/functions/registration-payment-reminders-core.cjs
@@ -1,0 +1,157 @@
+const REGISTRATION_PAYMENT_REMINDER_CADENCE_DAYS = 3;
+
+function normalizeFirestoreId(value, label) {
+  const id = String(value || '').trim();
+  if (!id || id.includes('/')) {
+    throw new Error(`${label} is required.`);
+  }
+  return id;
+}
+
+function buildRegistrationPaymentRetryUrl(appUrl, input = {}) {
+  const baseUrl = String(appUrl || 'https://allplays.ai').replace(/\/$/, '');
+  const params = new URLSearchParams({
+    teamId: normalizeFirestoreId(input.teamId, 'teamId'),
+    formId: normalizeFirestoreId(input.formId, 'formId'),
+    registrationId: normalizeFirestoreId(input.registrationId, 'registrationId'),
+    retryPayment: '1'
+  });
+  const checkoutAttemptToken = String(input.checkoutAttemptToken || '').trim();
+  if (checkoutAttemptToken) {
+    params.set('checkoutAttemptToken', checkoutAttemptToken);
+  }
+  return `${baseUrl}/registration.html?${params.toString()}`;
+}
+
+function formatRegistrationReminderAmount(amountCents, currency = 'USD') {
+  const cents = Math.max(0, Math.round(Number(amountCents || 0)));
+  const normalizedCurrency = String(currency || 'USD').trim().toUpperCase() || 'USD';
+  try {
+    return new Intl.NumberFormat('en-US', {
+      style: 'currency',
+      currency: normalizedCurrency
+    }).format(cents / 100);
+  } catch (error) {
+    return `$${(cents / 100).toFixed(2)}`;
+  }
+}
+
+function escapeHtml(value) {
+  return String(value || '').replace(/[&<>"']/g, (char) => ({
+    '&': '&amp;',
+    '<': '&lt;',
+    '>': '&gt;',
+    '"': '&quot;',
+    "'": '&#39;'
+  }[char]));
+}
+
+function buildRegistrationPaymentReminderMailDocId({ teamId, formId, registrationId, eventId, sequence = 'initial' } = {}) {
+  const parts = [teamId, formId, registrationId, eventId, sequence]
+    .map((part) => String(part || '').trim().replace(/[^\w.-]+/g, '_').slice(0, 120))
+    .filter(Boolean);
+  return `registrationPayment_${parts.join('_')}`.slice(0, 500);
+}
+
+function buildQueuedReminderAuditEntry({ kind = 'initial', eventId = '', mailDocId = '', queuedAtIso = '' } = {}) {
+  return {
+    kind,
+    eventId: String(eventId || '').trim() || null,
+    mailDocId: String(mailDocId || '').trim() || null,
+    queuedAt: String(queuedAtIso || '').trim() || null
+  };
+}
+
+function buildRegistrationPaymentReminderMessage({
+  programName = 'your registration',
+  amountDueCents = 0,
+  currency = 'USD',
+  retryUrl = '',
+  reminderLabel = 'We could not process your registration payment.'
+} = {}) {
+  const safeProgramName = String(programName || 'your registration').trim() || 'your registration';
+  const amountLabel = formatRegistrationReminderAmount(amountDueCents, currency);
+  const safeRetryUrl = String(retryUrl || '').trim();
+  return {
+    subject: `Payment reminder: ${safeProgramName}`,
+    text: [
+      reminderLabel,
+      '',
+      `Program: ${safeProgramName}`,
+      `Amount due: ${amountLabel}`,
+      '',
+      safeRetryUrl ? `Retry payment: ${safeRetryUrl}` : '',
+      '',
+      'If your payment has already gone through, you can ignore this email.'
+    ].filter(Boolean).join('\n'),
+    html: `<p>${escapeHtml(reminderLabel)}</p>
+<p><strong>Program:</strong> ${escapeHtml(safeProgramName)}<br />
+<strong>Amount due:</strong> ${escapeHtml(amountLabel)}</p>
+${safeRetryUrl ? `<p><a href="${escapeHtml(safeRetryUrl)}" style="display:inline-block;padding:10px 14px;border-radius:8px;background:#4f46e5;color:#fff;text-decoration:none;font-weight:700;">Retry payment</a></p>` : ''}
+<p>If your payment has already gone through, you can ignore this email.</p>`
+  };
+}
+
+function buildRegistrationFailedPaymentReminderState({
+  registration = {},
+  input = {},
+  eventId = '',
+  appUrl = '',
+  queuedAtIso = '',
+  mailDocId = '',
+  cadenceDays = REGISTRATION_PAYMENT_REMINDER_CADENCE_DAYS
+} = {}) {
+  const amountDueCents = Math.max(0, Math.round(Number(
+    registration.feeSnapshot?.finalAmountDueCents ?? registration.feeAmountCents ?? 0
+  )));
+  const nextReminderAt = new Date(Date.parse(String(queuedAtIso || new Date().toISOString())) + cadenceDays * 24 * 60 * 60 * 1000).toISOString();
+  return {
+    status: 'active',
+    cadenceDays,
+    reminderCount: 1,
+    recipientEmail: String(
+      registration.guardian?.email || registration.guardian?.guardianEmail || registration.guardian?.parentEmail || ''
+    ).trim().toLowerCase() || null,
+    amountDueCents,
+    currency: String(registration.currency || 'USD').trim().toUpperCase() || 'USD',
+    retryUrl: buildRegistrationPaymentRetryUrl(appUrl, {
+      teamId: input.teamId,
+      formId: input.formId,
+      registrationId: input.registrationId,
+      checkoutAttemptToken: input.checkoutAttemptToken || registration.checkoutAttemptToken || ''
+    }),
+    lastEventId: String(eventId || '').trim() || null,
+    firstQueuedAt: queuedAtIso,
+    lastQueuedAt: queuedAtIso,
+    nextReminderAt,
+    lastMailId: String(mailDocId || '').trim() || null,
+    lastReminderKind: 'initial',
+    lastAudit: buildQueuedReminderAuditEntry({
+      kind: 'initial',
+      eventId,
+      mailDocId,
+      queuedAtIso
+    })
+  };
+}
+
+function shouldStopRegistrationPaymentReminders(registration = {}) {
+  const paymentStatus = String(registration.paymentStatus || '').trim().toLowerCase();
+  const status = String(registration.status || '').trim().toLowerCase();
+  return paymentStatus === 'paid' ||
+    paymentStatus === 'checkout_cancelled' ||
+    paymentStatus === 'checkout_canceled' ||
+    paymentStatus === 'checkout_expired' ||
+    ['cancelled', 'canceled', 'closed'].includes(status);
+}
+
+module.exports = {
+  REGISTRATION_PAYMENT_REMINDER_CADENCE_DAYS,
+  buildQueuedReminderAuditEntry,
+  buildRegistrationFailedPaymentReminderState,
+  buildRegistrationPaymentReminderMailDocId,
+  buildRegistrationPaymentReminderMessage,
+  buildRegistrationPaymentRetryUrl,
+  formatRegistrationReminderAmount,
+  shouldStopRegistrationPaymentReminders
+};

--- a/registration.html
+++ b/registration.html
@@ -124,6 +124,9 @@
         const params = new URLSearchParams(window.location.search);
         const teamId = params.get('teamId') || '';
         const formId = params.get('formId') || params.get('id') || '';
+        const retryRegistrationId = params.get('registrationId') || '';
+        const retryCheckoutAttemptToken = params.get('checkoutAttemptToken') || '';
+        const retryPaymentRequested = params.get('retryPayment') === '1' && !!retryRegistrationId;
         let activeForm = null;
 
         const loadingState = document.getElementById('loading-state');
@@ -271,11 +274,13 @@
                 return;
             }
 
-            notice.textContent = paymentNotice;
+            notice.textContent = retryPaymentRequested && onlineCheckoutEnabled
+                ? 'We found your previous registration. Use the button below to retry payment without submitting a new registration.'
+                : paymentNotice;
             if (onlineCheckoutEnabled) {
                 submitButton.classList.add('hidden');
                 payRegistrationButton.classList.remove('hidden');
-                payRegistrationButton.textContent = 'Pay registration with Stripe';
+                payRegistrationButton.textContent = retryPaymentRequested ? 'Retry payment with Stripe' : 'Pay registration with Stripe';
             } else {
                 submitButton.classList.remove('hidden');
                 payRegistrationButton.classList.add('hidden');
@@ -645,6 +650,22 @@
             }
 
             try {
+                if (retryPaymentRequested) {
+                    const checkoutUrl = await initiateStripeCheckout({
+                        teamId,
+                        formId,
+                        registrationId: retryRegistrationId,
+                        checkoutAttemptToken: retryCheckoutAttemptToken,
+                        retryPayment: true
+                    });
+                    if (checkoutUrl) {
+                        window.location.href = checkoutUrl;
+                    } else {
+                        showFormError('Failed to get Stripe checkout URL.');
+                    }
+                    return;
+                }
+
                 const feeSnapshot = submission.feeSnapshot;
                 const amountCents = Math.max(0, Number(feeSnapshot?.finalAmountDueCents || 0));
                 const currency = String(feeSnapshot?.currency || activeForm.currency || 'USD').toLowerCase();
@@ -683,6 +704,9 @@
                     registrationId: result.registrationId,
                     checkoutAttemptToken
                 });
+                if (retryPaymentRequested) {
+                    returnParams.set('retryPayment', '1');
+                }
                 const successUrl = `${window.location.origin}/registration.html?${returnParams.toString()}&status=success`;
                 const cancelUrl = `${window.location.origin}/registration.html?${returnParams.toString()}&status=cancelled`;
 

--- a/tests/unit/registration-flow.test.js
+++ b/tests/unit/registration-flow.test.js
@@ -364,6 +364,13 @@ describe('public registration flow', () => {
         expect(page).toContain(': await submitRegistrationWithoutCapacity(submission);');
         expect(page).toContain('registrationId: result.registrationId');
         expect(page).toContain('let preparedCheckoutRegistration = null;');
+        expect(page).toContain("const retryRegistrationId = params.get('registrationId') || '';");
+        expect(page).toContain("const retryPaymentRequested = params.get('retryPayment') === '1' && !!retryRegistrationId;");
+        expect(page).toContain('Use the button below to retry payment without submitting a new registration.');
+        expect(page).toContain('if (retryPaymentRequested) {');
+        expect(page).toContain('registrationId: retryRegistrationId,');
+        expect(page).toContain('retryPayment: true');
+        expect(page).toContain("returnParams.set('retryPayment', '1');");
         expect(page).toContain('const retryKey = buildCheckoutRetryKey(submission, amountCents, currency);');
         expect(page).toContain('preparedCheckoutRegistration?.retryKey === retryKey');
         expect(page).toContain('preparedCheckoutRegistration = { retryKey, result, checkoutAttemptToken };');
@@ -713,6 +720,10 @@ describe('public registration flow', () => {
         expect(functionsSource).toContain("registrationCapacityReleased: true");
         expect(functionsSource).toContain("product: 'registration'");
         expect(functionsSource).toContain('getRegistrationCheckoutAmountCents(registration)');
+        expect(functionsSource).toContain("if (input.retryPayment) {");
+        expect(functionsSource).toContain("params.set('retryPayment', '1');");
+        expect(functionsSource).toContain('const amountCents = input.amountCents ?? expectedAmountCents;');
+        expect(functionsSource).toContain("const currency = String(");
         expect(functionsSource).toContain("form.paymentSettings?.onlineCheckoutEnabled !== true");
         expect(functionsSource).toContain("checkoutStatus: 'open'");
         expect(functionsSource).toContain("paymentStatus: 'checkout_open'");

--- a/tests/unit/registration-payment-reminders-core.test.js
+++ b/tests/unit/registration-payment-reminders-core.test.js
@@ -1,0 +1,95 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const {
+    REGISTRATION_PAYMENT_REMINDER_CADENCE_DAYS,
+    buildQueuedReminderAuditEntry,
+    buildRegistrationFailedPaymentReminderState,
+    buildRegistrationPaymentReminderMailDocId,
+    buildRegistrationPaymentReminderMessage,
+    buildRegistrationPaymentRetryUrl,
+    shouldStopRegistrationPaymentReminders
+} = require('../../functions/registration-payment-reminders-core.cjs');
+
+describe('registration payment reminder helpers', () => {
+    it('builds a retry URL back to the registration payment flow', () => {
+        expect(buildRegistrationPaymentRetryUrl('https://allplays.ai/', {
+            teamId: 'team_123',
+            formId: 'form_456',
+            registrationId: 'reg_789',
+            checkoutAttemptToken: 'attempt-token-123456'
+        })).toBe('https://allplays.ai/registration.html?teamId=team_123&formId=form_456&registrationId=reg_789&retryPayment=1&checkoutAttemptToken=attempt-token-123456');
+    });
+
+    it('builds failed payment reminder content with the program, amount due, and retry link', () => {
+        const message = buildRegistrationPaymentReminderMessage({
+            programName: 'Summer Skills Camp',
+            amountDueCents: 12500,
+            currency: 'USD',
+            retryUrl: 'https://allplays.ai/registration.html?teamId=team_123&formId=form_456&registrationId=reg_789&retryPayment=1'
+        });
+
+        expect(message.subject).toBe('Payment reminder: Summer Skills Camp');
+        expect(message.text).toContain('Program: Summer Skills Camp');
+        expect(message.text).toContain('Amount due: $125.00');
+        expect(message.text).toContain('Retry payment: https://allplays.ai/registration.html?teamId=team_123&formId=form_456&registrationId=reg_789&retryPayment=1');
+        expect(message.html).toContain('Retry payment');
+        expect(message.html).toContain('Summer Skills Camp');
+    });
+
+    it('creates auditable failed payment reminder state from the webhook event id', () => {
+        const state = buildRegistrationFailedPaymentReminderState({
+            registration: {
+                feeSnapshot: { finalAmountDueCents: 9800 },
+                guardian: { email: 'Parent@Example.com' },
+                checkoutAttemptToken: 'attempt-token-123456',
+                programName: 'Fall Soccer'
+            },
+            input: {
+                teamId: 'team_123',
+                formId: 'form_456',
+                registrationId: 'reg_789',
+                checkoutAttemptToken: 'attempt-token-123456'
+            },
+            eventId: 'evt_123',
+            appUrl: 'https://allplays.ai',
+            queuedAtIso: '2026-06-01T15:23:00.000Z',
+            mailDocId: 'registrationPayment_team_123_form_456_reg_789_evt_123_initial'
+        });
+
+        expect(state).toMatchObject({
+            status: 'active',
+            cadenceDays: REGISTRATION_PAYMENT_REMINDER_CADENCE_DAYS,
+            reminderCount: 1,
+            recipientEmail: 'parent@example.com',
+            amountDueCents: 9800,
+            lastEventId: 'evt_123',
+            lastMailId: 'registrationPayment_team_123_form_456_reg_789_evt_123_initial',
+            lastReminderKind: 'initial'
+        });
+        expect(state.retryUrl).toContain('retryPayment=1');
+        expect(state.nextReminderAt).toBe('2026-06-04T15:23:00.000Z');
+        expect(state.lastAudit).toEqual(buildQueuedReminderAuditEntry({
+            kind: 'initial',
+            eventId: 'evt_123',
+            mailDocId: 'registrationPayment_team_123_form_456_reg_789_evt_123_initial',
+            queuedAtIso: '2026-06-01T15:23:00.000Z'
+        }));
+    });
+
+    it('builds deterministic mail ids and stops reminders once registrations are closed or paid', () => {
+        expect(buildRegistrationPaymentReminderMailDocId({
+            teamId: 'team_123',
+            formId: 'form_456',
+            registrationId: 'reg_789',
+            eventId: 'evt_123',
+            sequence: 'followup_2'
+        })).toBe('registrationPayment_team_123_form_456_reg_789_evt_123_followup_2');
+
+        expect(shouldStopRegistrationPaymentReminders({ paymentStatus: 'paid' })).toBe(true);
+        expect(shouldStopRegistrationPaymentReminders({ paymentStatus: 'checkout_expired' })).toBe(true);
+        expect(shouldStopRegistrationPaymentReminders({ status: 'cancelled' })).toBe(true);
+        expect(shouldStopRegistrationPaymentReminders({ paymentStatus: 'payment_failed', status: 'pending' })).toBe(false);
+    });
+});

--- a/tests/unit/registration-payment-reminders-core.test.js
+++ b/tests/unit/registration-payment-reminders-core.test.js
@@ -34,8 +34,21 @@ describe('registration payment reminder helpers', () => {
         expect(message.text).toContain('Program: Summer Skills Camp');
         expect(message.text).toContain('Amount due: $125.00');
         expect(message.text).toContain('Retry payment: https://allplays.ai/registration.html?teamId=team_123&formId=form_456&registrationId=reg_789&retryPayment=1');
-        expect(message.html).toContain('Retry payment');
+        expect(message.html).toContain('href="https://allplays.ai/registration.html?teamId=team_123&amp;formId=form_456&amp;registrationId=reg_789&amp;retryPayment=1"');
         expect(message.html).toContain('Summer Skills Camp');
+    });
+
+    it('omits retry links that do not use http or https', () => {
+        const message = buildRegistrationPaymentReminderMessage({
+            programName: 'Summer Skills Camp',
+            amountDueCents: 12500,
+            currency: 'USD',
+            retryUrl: 'javascript:alert(1)'
+        });
+
+        expect(message.text).not.toContain('Retry payment:');
+        expect(message.html).not.toContain('href=');
+        expect(message.html).not.toContain('Retry payment');
     });
 
     it('creates auditable failed payment reminder state from the webhook event id', () => {

--- a/tests/unit/registration-payment-reminders-source.test.js
+++ b/tests/unit/registration-payment-reminders-source.test.js
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const source = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+
+describe('registration failed payment reminder wiring', () => {
+    it('queues the initial failed-payment email exactly once per Stripe event id', () => {
+        expect(source).toContain('const eventRef = firestore.doc(`stripeEvents/${event.id}`);');
+        expect(source).toContain("if (event.type === 'checkout.session.async_payment_failed') {");
+        expect(source).toContain("sequence: 'initial'");
+        expect(source).toContain('buildRegistrationPaymentReminderMailDocId({');
+        expect(source).toContain('stripeEventId: event.id');
+        expect(source).toContain('transaction.set(buildRegistrationReminderMailRef(mailDocId), buildRegistrationReminderMailJob({');
+    });
+
+    it('records auditable reminder metadata on the registration and resolves it when paid', () => {
+        expect(source).toContain('paymentReminder: {');
+        expect(source).toContain('buildRegistrationFailedPaymentReminderState({');
+        expect(source).toContain("transaction.update(registrationRef, buildRegistrationReminderStopUpdate({ reason: 'paid', nowIso: queuedAtIso }));");
+        expect(source).toContain("'paymentReminder.nextReminderAt': admin.firestore.FieldValue.delete()");
+    });
+
+    it('schedules follow-up reminders and stops them once the registration is no longer collectible', () => {
+        expect(source).toContain('exports.queueDueRegistrationFailedPaymentReminders = functions.pubsub');
+        expect(source).toContain(".schedule('every 6 hours')");
+        expect(source).toContain(".collectionGroup('registrations')");
+        expect(source).toContain(".where('paymentReminder.nextReminderAt', '<=', nowIso)");
+        expect(source).toContain('shouldStopRegistrationPaymentReminders(registration)');
+        expect(source).toContain("sequence: `followup_${reminderNumber}`");
+    });
+});


### PR DESCRIPTION
Closes #1664

## What changed
- queue an initial failed-payment reminder email when Stripe sends `checkout.session.async_payment_failed` for a registration checkout
- store auditable reminder metadata on the registration, including reminder count, last queued mail job, last Stripe event id, retry URL, and next reminder time
- resolve and stop reminders when the registration is paid, and stop follow-ups for closed or canceled registrations
- add a scheduled function that sends follow-up reminder emails on a fixed cadence while payment is still unresolved
- add focused unit coverage for reminder payloads, reminder state, scheduler wiring, and Stripe-event idempotent queueing by event id

## Why
Allplays already recorded failed Stripe registration outcomes but stopped at status updates. This adds the missing collections workflow so guardians get a retry prompt automatically, admins keep the existing `payment_failed` visibility, and reminder activity is recorded in an auditable way.