### PR TITLE
Show full standings tables on public team page

### DIFF
--- a/team.html
+++ b/team.html
@@ -1096,7 +1096,7 @@
 
             return `
                 <div class="space-y-3">
-                    ${renderStandingsTable(leagueSnapshot.rows, leagueSnapshot.match || row, [
+                    ${renderStandingsTable(leagueSnapshot.rows, leagueSnapshot.match || null, [
                         { key: 'team', label: 'Team' },
                         { key: 'w', label: 'W' },
                         { key: 'l', label: 'L' },

--- a/team.html
+++ b/team.html
@@ -1035,6 +1035,44 @@
             `;
         }
 
+        function renderStandingsTable(rows, highlightedRow, columns, emptyMessage) {
+            const safeRows = Array.isArray(rows) ? rows : [];
+            const safeColumns = Array.isArray(columns) ? columns : [];
+
+            if (safeRows.length === 0 || safeColumns.length === 0) {
+                return `<p class="text-sm text-gray-500">${escapeHtml(emptyMessage || 'No standings available')}</p>`;
+            }
+
+            return `
+                <div class="overflow-x-auto rounded-xl border border-gray-200">
+                    <table class="min-w-full divide-y divide-gray-200 text-left">
+                        <thead class="bg-gray-50">
+                            <tr class="text-xs font-semibold uppercase tracking-wide text-gray-500">
+                                ${safeColumns.map((column) => `<th class="px-3 py-2.5">${escapeHtml(column.label)}</th>`).join('')}
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-100 bg-white">
+                            ${safeRows.map((row) => {
+                                const isHighlighted = row === highlightedRow;
+                                return `
+                                    <tr class="${isHighlighted ? 'bg-primary-50/70' : 'bg-white'}">
+                                        ${safeColumns.map((column) => {
+                                            const rawValue = typeof column.value === 'function' ? column.value(row) : row?.[column.key];
+                                            const value = rawValue == null || rawValue === '' ? '—' : rawValue;
+                                            const textClass = column.emphasize || (column.key === 'team' && isHighlighted)
+                                                ? 'font-semibold text-primary-800'
+                                                : (column.key === 'team' ? 'font-medium text-gray-900' : 'text-gray-700');
+                                            return `<td class="px-3 py-2.5 text-sm whitespace-nowrap ${textClass}">${escapeHtml(value)}</td>`;
+                                        }).join('')}
+                                    </tr>
+                                `;
+                            }).join('')}
+                        </tbody>
+                    </table>
+                </div>
+            `;
+        }
+
         function renderLeagueOverviewBody(leagueSnapshot, team) {
             const sourceUrl = team?.leagueUrl ? escapeHtml(team.leagueUrl) : '';
             if (!sourceUrl) {
@@ -1057,12 +1095,19 @@
             }
 
             return `
-                <div class="mb-2">
-                    <div class="text-2xl md:text-3xl font-bold text-gray-900">${escapeHtml(row.record)}</div>
-                    <div class="text-xs text-gray-600">${escapeHtml(row.team)} • PCT ${escapeHtml(row.pct || 'N/A')}</div>
+                <div class="space-y-3">
+                    ${renderStandingsTable(leagueSnapshot.rows, leagueSnapshot.match || row, [
+                        { key: 'team', label: 'Team' },
+                        { key: 'w', label: 'W' },
+                        { key: 'l', label: 'L' },
+                        { key: 't', label: 'T' },
+                        { key: 'pct', label: 'PCT' },
+                        { key: 'pf', label: 'PF' },
+                        { key: 'pa', label: 'PA' },
+                        { key: 'pd', label: 'PD' }
+                    ], 'No standings available')}
+                    <a class="text-xs text-primary-600 hover:underline inline-block" target="_blank" rel="noopener noreferrer" href="${sourceUrl}">Open league page</a>
                 </div>
-                <div class="text-xs text-gray-500">PF ${row.pf} · PA ${row.pa} · PD ${row.pd}</div>
-                <a class="text-xs text-primary-600 hover:underline mt-2 inline-block" target="_blank" rel="noopener noreferrer" href="${sourceUrl}">Open league page</a>
             `;
         }
 
@@ -1103,19 +1148,29 @@
                 return '<p class="text-sm text-gray-500">No completed games yet for native standings</p>';
             }
 
-            const row = snapshot.match;
             const mode = snapshot.config?.rankingMode === 'win_pct' ? 'Win %' : 'Points';
-            const rankLabel = typeof row.rank === 'number' ? `#${row.rank}` : 'N/A';
 
             return `
-                <div class="mb-2">
-                    <div class="text-2xl md:text-3xl font-bold text-gray-900">${escapeHtml(row.record)}</div>
-                    <div class="text-xs text-gray-600">${escapeHtml(row.team)} • ${escapeHtml(rankLabel)} • ${escapeHtml(mode)}</div>
+                <div class="space-y-3">
+                    ${renderStandingsTable(snapshot.rows, snapshot.match, [
+                        { key: 'rank', label: 'Rank', value: (row) => typeof row?.rank === 'number' ? `#${row.rank}` : '—' },
+                        { key: 'team', label: 'Team' },
+                        { key: 'gp', label: 'GP' },
+                        { key: 'w', label: 'W' },
+                        { key: 'l', label: 'L' },
+                        { key: 't', label: 'T' },
+                        { key: 'points', label: mode === 'Win %' ? 'PCT' : 'PTS', value: (row) => mode === 'Win %' ? (Number(row?.winPct) || 0).toFixed(3) : (Number(row?.points) || 0) },
+                        { key: 'pf', label: 'PF' },
+                        { key: 'pa', label: 'PA' },
+                        { key: 'pd', label: 'PD' }
+                    ], 'No completed games yet for native standings')}
+                    <div class="text-xs text-gray-500">
+                        Highlighted row shows the current team.
+                    </div>
+                    <div class="text-xs text-gray-400">
+                        Computed from completed in-app games
+                    </div>
                 </div>
-                <div class="text-xs text-gray-500">
-                    PTS ${Number(row.points) || 0} · PCT ${(Number(row.winPct) || 0).toFixed(3)} · PF ${Number(row.pf) || 0} · PA ${Number(row.pa) || 0} · PD ${Number(row.pd) || 0}
-                </div>
-                <div class="text-xs text-gray-400 mt-2">Computed from completed in-app games</div>
             `;
         }
 

--- a/tests/unit/team-page-standings-render.test.js
+++ b/tests/unit/team-page-standings-render.test.js
@@ -85,6 +85,29 @@ describe('team page league standings rendering', () => {
         expect(html).toContain('Open league page');
     });
 
+    it('does not highlight a fallback row when no standings match is found', () => {
+        const { renderLeagueOverviewBody } = buildLeagueStandingsRenderers();
+        const rows = [
+            { team: 'Wilcox', w: 5, l: 0, t: 0, pct: '1.000', pf: 99, pa: 50, pd: 49 },
+            { team: 'Blue Valley A', w: 4, l: 1, t: 0, pct: '0.800', pf: 65, pa: 43, pd: 22 }
+        ];
+
+        const html = renderLeagueOverviewBody({
+            ok: true,
+            rows,
+            match: null
+        }, {
+            leagueUrl: 'https://example.com/standings'
+        });
+
+        expect(html).toContain('Wilcox');
+        expect(html).toContain('Blue Valley A');
+        expect(html).not.toContain('bg-primary-50/70');
+        expect(html).not.toContain('text-primary-800">Wilcox');
+        expect(html).not.toContain('text-primary-800">Blue Valley A');
+        expect(html).toContain('Open league page');
+    });
+
     it('preserves the fallback message and external link when standings fail to load', () => {
         const { renderLeagueOverviewBody } = buildLeagueStandingsRenderers();
 

--- a/tests/unit/team-page-standings-render.test.js
+++ b/tests/unit/team-page-standings-render.test.js
@@ -5,24 +5,42 @@ function readTeamPage() {
     return readFileSync(new URL('../../team.html', import.meta.url), 'utf8');
 }
 
-function extractFunctionBody(source, signature, nextSignature) {
-    const pattern = new RegExp(`${signature} \\{([\\s\\S]*?)\\n        \\}\\n\\n        ${nextSignature}`);
-    const match = source.match(pattern);
-    expect(match, `${signature} should exist`).toBeTruthy();
-    return match[1];
+function extractFunctionBody(source, signature, nextSignature, expectedFragments = []) {
+    const start = source.indexOf(signature);
+    expect(start, `${signature} should exist`).toBeGreaterThanOrEqual(0);
+
+    const nextStart = source.indexOf(nextSignature, start + signature.length);
+    expect(nextStart, `${nextSignature} should exist after ${signature}`).toBeGreaterThan(start);
+
+    const openBraceIndex = source.indexOf('{', start + signature.length - 1);
+    expect(openBraceIndex, `${signature} should have an opening brace`).toBeGreaterThan(start);
+
+    const functionSource = source.slice(start, nextStart);
+    const closingBraceIndex = functionSource.lastIndexOf('}');
+    expect(closingBraceIndex, `${signature} should have a closing brace before ${nextSignature}`).toBeGreaterThan(0);
+
+    const body = functionSource.slice(openBraceIndex - start + 1, closingBraceIndex);
+    expect(body.trim(), `${signature} should have a non-empty body`).not.toBe('');
+    expectedFragments.forEach((fragment) => {
+        expect(body, `${signature} should include ${fragment}`).toContain(fragment);
+    });
+
+    return body;
 }
 
 function buildLeagueStandingsRenderers() {
     const source = readTeamPage();
     const tableBody = extractFunctionBody(
         source,
-        'function renderStandingsTable\\(rows, highlightedRow, columns, emptyMessage\\)',
-        'function renderLeagueOverviewBody'
+        'function renderStandingsTable(rows, highlightedRow, columns, emptyMessage)',
+        'function renderLeagueOverviewBody',
+        ['safeRows.length === 0', 'bg-primary-50/70']
     );
     const overviewBody = extractFunctionBody(
         source,
-        'function renderLeagueOverviewBody\\(leagueSnapshot, team\\)',
-        'function buildNativeStandingsSnapshot'
+        'function renderLeagueOverviewBody(leagueSnapshot, team)',
+        'function buildNativeStandingsSnapshot',
+        ['Could not load standings', 'renderStandingsTable']
     );
 
     const factory = new Function('escapeHtml', `

--- a/tests/unit/team-page-standings-render.test.js
+++ b/tests/unit/team-page-standings-render.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readTeamPage() {
+    return readFileSync(new URL('../../team.html', import.meta.url), 'utf8');
+}
+
+function extractFunctionBody(source, signature, nextSignature) {
+    const pattern = new RegExp(`${signature} \\{([\\s\\S]*?)\\n        \\}\\n\\n        ${nextSignature}`);
+    const match = source.match(pattern);
+    expect(match, `${signature} should exist`).toBeTruthy();
+    return match[1];
+}
+
+function buildLeagueStandingsRenderers() {
+    const source = readTeamPage();
+    const tableBody = extractFunctionBody(
+        source,
+        'function renderStandingsTable\\(rows, highlightedRow, columns, emptyMessage\\)',
+        'function renderLeagueOverviewBody'
+    );
+    const overviewBody = extractFunctionBody(
+        source,
+        'function renderLeagueOverviewBody\\(leagueSnapshot, team\\)',
+        'function buildNativeStandingsSnapshot'
+    );
+
+    const factory = new Function('escapeHtml', `
+        function renderStandingsTable(rows, highlightedRow, columns, emptyMessage) {
+${tableBody}
+        }
+
+        function renderLeagueOverviewBody(leagueSnapshot, team) {
+${overviewBody}
+        }
+
+        return { renderStandingsTable, renderLeagueOverviewBody };
+    `);
+
+    return factory((value) => String(value ?? ''));
+}
+
+describe('team page league standings rendering', () => {
+    it('renders the full external standings table and highlights the matched team row', () => {
+        const { renderLeagueOverviewBody } = buildLeagueStandingsRenderers();
+        const rows = [
+            { team: 'Wilcox', w: 5, l: 0, t: 0, pct: '1.000', pf: 99, pa: 50, pd: 49 },
+            { team: 'Blue Valley A', w: 4, l: 1, t: 0, pct: '0.800', pf: 65, pa: 43, pd: 22 }
+        ];
+
+        const html = renderLeagueOverviewBody({
+            ok: true,
+            rows,
+            match: rows[1]
+        }, {
+            leagueUrl: 'https://example.com/standings'
+        });
+
+        expect(html).toContain('>Team<');
+        expect(html).toContain('>PCT<');
+        expect(html).toContain('Wilcox');
+        expect(html).toContain('Blue Valley A');
+        expect((html.match(/<tbody[\s\S]*?<tr class=/g) || []).length).toBe(1);
+        expect((html.match(/<tr class="/g) || []).length).toBeGreaterThanOrEqual(2);
+        expect(html).toContain('bg-primary-50/70');
+        expect(html).toContain('text-primary-800">Blue Valley A');
+        expect(html).toContain('Open league page');
+    });
+
+    it('preserves the fallback message and external link when standings fail to load', () => {
+        const { renderLeagueOverviewBody } = buildLeagueStandingsRenderers();
+
+        const html = renderLeagueOverviewBody({
+            ok: false,
+            rows: [],
+            match: null
+        }, {
+            leagueUrl: 'https://example.com/standings'
+        });
+
+        expect(html).toContain('Could not load standings');
+        expect(html).toContain('Open league page');
+        expect(html).not.toContain('<table');
+    });
+});


### PR DESCRIPTION
Closes #1672

## What changed
- replaced the single-row league standings summary on `team.html` with a responsive standings table that renders every parsed external row
- highlight the current team row when the standings matcher finds a team match
- reused the same table renderer for native standings so in-app standings also show full team context instead of only one row
- preserved the existing fallback messaging and external link when standings cannot be loaded or parsed
- added a focused regression test that verifies multi-row rendering, current-team highlighting, and fallback behavior

## Why
Allplays was already fetching and parsing full standings data, but the public team page only exposed a teaser row plus an outbound link. This change surfaces the full comparison table directly on the page so parents, players, and fans can see where the team sits versus rivals without leaving Allplays.