### PR TITLE
Add offline refund controls to Team Fees

### DIFF
--- a/apps/app/src/lib/teamFeesService.ts
+++ b/apps/app/src/lib/teamFeesService.ts
@@ -50,6 +50,21 @@ export type TeamFeeBalanceAdjustmentInput = {
   currentPaidCents?: string | number | null;
 };
 
+export type OfflineTeamFeeRefundInput = {
+  refundType?: string;
+  amount?: string | number;
+  method?: string;
+  note?: string;
+  actorId?: string;
+  currentBalanceCents?: string | number | null;
+  currentPaidCents?: string | number | null;
+};
+
+const REFUND_METHOD_LABELS: Record<string, string> = {
+  cash: 'Cash',
+  check: 'Check'
+};
+
 export function toFeeCents(value: string | number | null | undefined) {
   const normalized = String(value ?? '').replace(/[$,]/g, '').trim();
   if (!normalized) return null;
@@ -152,6 +167,62 @@ export function buildBalanceAdjustmentUpdate({ amount, note, actorId, currentBal
   };
 }
 
+export function buildOfflineTeamFeeRefundUpdate({ refundType = 'full', amount, method, note, actorId, currentBalanceCents, currentPaidCents }: OfflineTeamFeeRefundInput) {
+  const priorPaid = Number(currentPaidCents);
+  const priorPaidCents = Number.isFinite(priorPaid) ? Math.max(0, priorPaid) : 0;
+  if (priorPaidCents <= 0) {
+    throw new Error('Only recipients with recorded payments can be refunded.');
+  }
+
+  const normalizedType = normalizeString(refundType).toLowerCase() === 'partial' ? 'partial' : 'full';
+  const refundAmountCents = normalizedType === 'full' ? priorPaidCents : toFeeCents(amount);
+  if (refundAmountCents === null || refundAmountCents <= 0) {
+    throw new Error('Enter a refund amount greater than $0.');
+  }
+  if (refundAmountCents > priorPaidCents) {
+    throw new Error('Refund amount cannot exceed the recorded paid amount.');
+  }
+
+  const refundMethod = normalizeString(method).toLowerCase();
+  if (!Object.prototype.hasOwnProperty.call(REFUND_METHOD_LABELS, refundMethod)) {
+    throw new Error('Select cash or check as the refund method.');
+  }
+
+  const adminNote = normalizeString(note);
+  if (!adminNote) throw new Error('Enter an admin note for the refund.');
+
+  const currentBalance = Number(currentBalanceCents);
+  const balanceCents = Number.isFinite(currentBalance) ? Math.max(0, currentBalance) : 0;
+  const amountPaidCents = Math.max(0, priorPaidCents - refundAmountCents);
+  const remainingBalanceCents = Math.max(0, balanceCents - amountPaidCents);
+  const status = normalizeLedgerStatus(balanceCents, amountPaidCents);
+  const ledgerEntry = {
+    type: 'offline_refund',
+    amountCents: -refundAmountCents,
+    refundAmountCents,
+    refundType: normalizedType,
+    refundMethod,
+    methodLabel: REFUND_METHOD_LABELS[refundMethod],
+    note: adminNote,
+    recordedBy: actorId || null
+  };
+
+  return {
+    status,
+    amountPaidCents,
+    remainingBalanceCents,
+    ...(status === 'paid' ? {} : { paidAt: null }),
+    refunded: {
+      amountCents: refundAmountCents,
+      refundType: normalizedType,
+      refundMethod,
+      note: adminNote,
+      recordedBy: actorId || null
+    },
+    ledgerEntries: [ledgerEntry]
+  };
+}
+
 export async function loadTeamFeeManagementModel(teamId: string, batchId: string | undefined, user: AuthUser | null): Promise<TeamFeeManagementModel> {
   if (!teamId) throw new Error('Missing team context.');
   const team = await Promise.resolve(getTeam(teamId));
@@ -223,6 +294,34 @@ export async function recordTeamFeeBalanceAdjustment({ teamId, batchId, recipien
 
   const updates = buildBalanceAdjustmentUpdate({
     amount,
+    note,
+    actorId: user?.uid,
+    currentBalanceCents: recipient.amountDueCents,
+    currentPaidCents: recipient.amountPaidCents
+  });
+
+  await Promise.resolve(updateTeamFeeRecipient(teamId, batchId, recipient.id, updates));
+  return updates;
+}
+
+export async function recordOfflineTeamFeeRefund({ teamId, batchId, recipient, refundType, amount, method, note, user }: {
+  teamId: string;
+  batchId: string;
+  recipient: TeamFeeRecipientSummary;
+  refundType: string;
+  amount?: string;
+  method: string;
+  note: string;
+  user: AuthUser | null;
+}) {
+  if (!teamId || !batchId || !recipient?.id) throw new Error('Missing fee recipient context.');
+  const team = await Promise.resolve(getTeam(teamId));
+  if (!hasFullTeamAccess(user, team)) throw new Error('You do not have access to record team fee refunds.');
+
+  const updates = buildOfflineTeamFeeRefundUpdate({
+    refundType,
+    amount,
+    method,
     note,
     actorId: user?.uid,
     currentBalanceCents: recipient.amountDueCents,

--- a/apps/app/src/pages/TeamFees.test.tsx
+++ b/apps/app/src/pages/TeamFees.test.tsx
@@ -8,7 +8,8 @@ import type { AuthState } from '../lib/types';
 const teamFeesServiceMocks = vi.hoisted(() => ({
   loadTeamFeeManagementModel: vi.fn(),
   recordOfflineTeamFeePayment: vi.fn(),
-  recordTeamFeeBalanceAdjustment: vi.fn()
+  recordTeamFeeBalanceAdjustment: vi.fn(),
+  recordOfflineTeamFeeRefund: vi.fn()
 }));
 
 vi.mock('../lib/teamFeesService', () => teamFeesServiceMocks);
@@ -51,9 +52,11 @@ describe('TeamFees recipient queue', () => {
     vi.clearAllMocks();
     teamFeesServiceMocks.recordOfflineTeamFeePayment.mockReset();
     teamFeesServiceMocks.recordTeamFeeBalanceAdjustment.mockReset();
+    teamFeesServiceMocks.recordOfflineTeamFeeRefund.mockReset();
     teamFeesServiceMocks.loadTeamFeeManagementModel.mockReset();
     teamFeesServiceMocks.recordOfflineTeamFeePayment.mockResolvedValue(undefined);
     teamFeesServiceMocks.recordTeamFeeBalanceAdjustment.mockResolvedValue(undefined);
+    teamFeesServiceMocks.recordOfflineTeamFeeRefund.mockResolvedValue(undefined);
     teamFeesServiceMocks.loadTeamFeeManagementModel.mockResolvedValue({
       team: { id: 'team-1', name: 'Bears' },
       batches: [{ id: 'batch-1', title: 'Spring dues', dueDate: '2026-06-01', amountCents: 10000, status: 'open' }],
@@ -106,6 +109,7 @@ describe('TeamFees recipient queue', () => {
     expect(within(queue).queryByText('Paid Player')).toBeNull();
     expect(within(queue).getAllByRole('button', { name: 'Record payment' })).toHaveLength(2);
     expect(within(queue).getAllByRole('button', { name: 'Save adjustment' })).toHaveLength(2);
+    expect(within(queue).getByRole('button', { name: 'Record refund' })).toBeTruthy();
     expect(screen.getByDisplayValue('100.00')).toBeTruthy();
     expect(screen.getByDisplayValue('75.00')).toBeTruthy();
     expect(screen.getAllByText('Positive credits reduce what is owed. Negative charges increase it.')).toHaveLength(3);
@@ -123,7 +127,83 @@ describe('TeamFees recipient queue', () => {
     expect(within(reviewCard).queryByRole('button', { name: 'Record payment' })).toBeNull();
     expect(within(reviewCard).queryByText('Record offline payment')).toBeNull();
     expect(within(reviewCard).getByRole('button', { name: 'Save adjustment' })).toBeTruthy();
+    expect(within(reviewCard).getByRole('button', { name: 'Record refund' })).toBeTruthy();
     expect(within(reviewCard).getByText('Positive credits reduce what is owed. Negative charges increase it.')).toBeTruthy();
+  });
+
+  it('submits a recipient refund and refreshes the totals in place', async () => {
+    teamFeesServiceMocks.loadTeamFeeManagementModel
+      .mockResolvedValueOnce({
+        team: { id: 'team-1', name: 'Bears' },
+        batches: [{ id: 'batch-1', title: 'Spring dues', dueDate: '2026-06-01', amountCents: 10000, status: 'open' }],
+        selectedBatch: { id: 'batch-1', title: 'Spring dues', dueDate: '2026-06-01', amountCents: 10000, status: 'open' },
+        canManageFees: true,
+        recipients: [{
+          id: 'recipient-1',
+          playerName: 'Pat Star',
+          parentName: 'Pat Parent',
+          parentEmail: 'pat@example.com',
+          status: 'paid',
+          amountDueCents: 10000,
+          amountPaidCents: 10000,
+          remainingBalanceCents: 0,
+          paymentLedger: []
+        }]
+      })
+      .mockResolvedValueOnce({
+        team: { id: 'team-1', name: 'Bears' },
+        batches: [{ id: 'batch-1', title: 'Spring dues', dueDate: '2026-06-01', amountCents: 10000, status: 'open' }],
+        selectedBatch: { id: 'batch-1', title: 'Spring dues', dueDate: '2026-06-01', amountCents: 10000, status: 'open' },
+        canManageFees: true,
+        recipients: [{
+          id: 'recipient-1',
+          playerName: 'Pat Star',
+          parentName: 'Pat Parent',
+          parentEmail: 'pat@example.com',
+          status: 'partial',
+          amountDueCents: 10000,
+          amountPaidCents: 7500,
+          remainingBalanceCents: 2500,
+          paymentLedger: [{ type: 'offline_refund' }]
+        }]
+      });
+
+    renderTeamFees();
+
+    const refundTrigger = await screen.findByRole('button', { name: 'Record refund' });
+    fireEvent.click(refundTrigger);
+    fireEvent.change(screen.getByDisplayValue('Full refund'), { target: { value: 'partial' } });
+    fireEvent.change(screen.getByPlaceholderText('100.00'), { target: { value: '25.00' } });
+    fireEvent.change(screen.getByDisplayValue('Select method'), { target: { value: 'cash' } });
+    fireEvent.change(screen.getByPlaceholderText('Why this was refunded and how it was handled'), { target: { value: 'Refunded at the field' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Submit refund' }));
+
+    expect(await screen.findByText('Recorded partial refund for Pat Star.')).toBeTruthy();
+    expect(teamFeesServiceMocks.recordOfflineTeamFeeRefund).toHaveBeenCalledWith(expect.objectContaining({
+      teamId: 'team-1',
+      batchId: 'batch-1',
+      refundType: 'partial',
+      amount: '25.00',
+      method: 'cash',
+      note: 'Refunded at the field'
+    }));
+    expect((await screen.findAllByText('$25.00')).length).toBeGreaterThan(0);
+  });
+
+  it('keeps the refund form open and shows validation errors when a refund is invalid', async () => {
+    teamFeesServiceMocks.recordOfflineTeamFeeRefund.mockRejectedValue(new Error('Select cash or check as the refund method.'));
+
+    renderTeamFees();
+
+    const recipientCard = (await screen.findByText('Partial Player')).closest('section');
+    if (!recipientCard) throw new Error('Recipient card not found');
+
+    fireEvent.click(within(recipientCard).getByRole('button', { name: 'Record refund' }));
+    fireEvent.change(within(recipientCard).getByPlaceholderText('Why this was refunded and how it was handled'), { target: { value: 'Need to fix overcollection' } });
+    fireEvent.click(within(recipientCard).getByRole('button', { name: 'Submit refund' }));
+
+    expect(await screen.findByText('Select cash or check as the refund method.')).toBeTruthy();
+    expect(within(recipientCard).getByRole('button', { name: 'Submit refund' })).toBeTruthy();
   });
 
   it('submits one recipient adjustment and refreshes the totals in place', async () => {
@@ -196,10 +276,10 @@ describe('TeamFees recipient queue', () => {
 
     fireEvent.click(within(recipientCard).getByRole('button', { name: 'Record payment' }));
 
-    expect(await within(recipientCard).findByRole('button', { name: 'Recording...' })).toBeDisabled();
-    expect(within(recipientCard).getByRole('button', { name: 'Save adjustment' })).toBeDisabled();
-    expect(within(recipientCard).getByDisplayValue('100.00')).toBeDisabled();
-    expect(within(recipientCard).getByPlaceholderText('25.00 or -10.00')).toBeDisabled();
+    expect((await within(recipientCard).findByRole('button', { name: 'Recording...' })).hasAttribute('disabled')).toBe(true);
+    expect(within(recipientCard).getByRole('button', { name: 'Save adjustment' }).hasAttribute('disabled')).toBe(true);
+    expect(within(recipientCard).getByDisplayValue('100.00').hasAttribute('disabled')).toBe(true);
+    expect(within(recipientCard).getByPlaceholderText('25.00 or -10.00').hasAttribute('disabled')).toBe(true);
 
     await act(async () => {
       resolvePayment?.();

--- a/apps/app/src/pages/TeamFees.tsx
+++ b/apps/app/src/pages/TeamFees.tsx
@@ -4,11 +4,28 @@ import { CheckCircle2, DollarSign, Loader2, RefreshCw, Shield } from 'lucide-rea
 import {
   loadTeamFeeManagementModel,
   recordOfflineTeamFeePayment,
+  recordOfflineTeamFeeRefund,
   recordTeamFeeBalanceAdjustment,
   type TeamFeeManagementModel,
   type TeamFeeRecipientSummary
 } from '../lib/teamFeesService';
 import type { AuthState } from '../lib/types';
+
+type RecipientFormState = {
+  paymentAmount: string;
+  paymentDate: string;
+  paymentNote: string;
+  paymentError: string;
+  adjustmentAmount: string;
+  adjustmentReason: string;
+  adjustmentError: string;
+  refundOpen: boolean;
+  refundType: 'full' | 'partial';
+  refundAmount: string;
+  refundMethod: string;
+  refundNote: string;
+  refundError: string;
+};
 
 function formatMoney(cents: number) {
   return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format((Number(cents) || 0) / 100);
@@ -30,7 +47,7 @@ export function TeamFees({ auth }: { auth: AuthState }) {
   const [submittingId, setSubmittingId] = useState('');
   const [error, setError] = useState('');
   const [success, setSuccess] = useState('');
-  const [formByRecipient, setFormByRecipient] = useState<Record<string, { paymentAmount: string; paymentDate: string; paymentNote: string; paymentError: string; adjustmentAmount: string; adjustmentReason: string; adjustmentError: string }>>({});
+  const [formByRecipient, setFormByRecipient] = useState<Record<string, RecipientFormState>>({});
 
   const selectedBatchId = model?.selectedBatch?.id || '';
 
@@ -78,23 +95,15 @@ export function TeamFees({ auth }: { auth: AuthState }) {
     [recipients]
   );
 
-  const isRecipientSubmitting = (recipientId: string) => submittingId === `payment:${recipientId}` || submittingId === `adjustment:${recipientId}`;
+  const isRecipientSubmitting = (recipientId: string) => submittingId === `payment:${recipientId}` || submittingId === `adjustment:${recipientId}` || submittingId === `refund:${recipientId}`;
 
   if (!teamId) return <Navigate to="/teams" replace />;
 
-  const updateForm = (recipientId: string, patch: Partial<{ paymentAmount: string; paymentDate: string; paymentNote: string; paymentError: string; adjustmentAmount: string; adjustmentReason: string; adjustmentError: string }>) => {
+  const updateForm = (recipientId: string, patch: Partial<RecipientFormState>) => {
     setFormByRecipient((current) => ({
       ...current,
       [recipientId]: {
-        ...(current[recipientId] || {
-          paymentAmount: '',
-          paymentDate: todayIsoDate(),
-          paymentNote: '',
-          paymentError: '',
-          adjustmentAmount: '',
-          adjustmentReason: '',
-          adjustmentError: ''
-        }),
+        ...(current[recipientId] || buildRecipientFormState()),
         ...patch
       }
     }));
@@ -102,15 +111,7 @@ export function TeamFees({ auth }: { auth: AuthState }) {
 
   const submitPayment = async (event: FormEvent<HTMLFormElement>, recipient: TeamFeeRecipientSummary) => {
     event.preventDefault();
-    const form = formByRecipient[recipient.id] || {
-      paymentAmount: centsToAmount(recipient.remainingBalanceCents),
-      paymentDate: todayIsoDate(),
-      paymentNote: '',
-      paymentError: '',
-      adjustmentAmount: '',
-      adjustmentReason: '',
-      adjustmentError: ''
-    };
+    const form = formByRecipient[recipient.id] || buildRecipientFormState(recipient);
     updateForm(recipient.id, { paymentError: '' });
     setSuccess('');
     setSubmittingId(`payment:${recipient.id}`);
@@ -135,15 +136,7 @@ export function TeamFees({ auth }: { auth: AuthState }) {
 
   const submitAdjustment = async (event: FormEvent<HTMLFormElement>, recipient: TeamFeeRecipientSummary) => {
     event.preventDefault();
-    const form = formByRecipient[recipient.id] || {
-      paymentAmount: centsToAmount(recipient.remainingBalanceCents),
-      paymentDate: todayIsoDate(),
-      paymentNote: '',
-      paymentError: '',
-      adjustmentAmount: '',
-      adjustmentReason: '',
-      adjustmentError: ''
-    };
+    const form = formByRecipient[recipient.id] || buildRecipientFormState(recipient);
     updateForm(recipient.id, { adjustmentError: '' });
     setSuccess('');
     setSubmittingId(`adjustment:${recipient.id}`);
@@ -165,6 +158,33 @@ export function TeamFees({ auth }: { auth: AuthState }) {
     }
   };
 
+  const submitRefund = async (event: FormEvent<HTMLFormElement>, recipient: TeamFeeRecipientSummary) => {
+    event.preventDefault();
+    const form = formByRecipient[recipient.id] || buildRecipientFormState(recipient);
+    updateForm(recipient.id, { refundError: '' });
+    setSuccess('');
+    setSubmittingId(`refund:${recipient.id}`);
+    try {
+      const refundAmount = form.refundType === 'full' ? centsToAmount(recipient.amountPaidCents) : form.refundAmount;
+      await recordOfflineTeamFeeRefund({
+        teamId,
+        batchId: selectedBatchId,
+        recipient,
+        refundType: form.refundType,
+        amount: refundAmount,
+        method: form.refundMethod,
+        note: form.refundNote,
+        user: auth.user
+      });
+      setSuccess(`Recorded ${form.refundType} refund for ${recipient.playerName}.`);
+      await refresh();
+    } catch (submitError: any) {
+      updateForm(recipient.id, { refundError: submitError?.message || 'Unable to record refund.' });
+    } finally {
+      setSubmittingId('');
+    }
+  };
+
   if (loading) {
     return (
       <section className="app-card p-5 text-center">
@@ -180,7 +200,7 @@ export function TeamFees({ auth }: { auth: AuthState }) {
   }
 
   if (!model.canManageFees) {
-    return <StatusCard title="Admin access required" message="Only team owners, team admins, and global admins can record offline team fee payments or adjust balances." backTo={`/teams/${encodeURIComponent(teamId)}`} />;
+    return <StatusCard title="Admin access required" message="Only team owners, team admins, and global admins can record offline team fee payments, refunds, or balance adjustments." backTo={`/teams/${encodeURIComponent(teamId)}`} />;
   }
 
   return (
@@ -190,7 +210,7 @@ export function TeamFees({ auth }: { auth: AuthState }) {
           <div>
             <div className="flex items-center gap-2 text-xs font-black uppercase tracking-[0.06em] text-primary-700"><DollarSign className="h-4 w-4" aria-hidden="true" /> Team fees</div>
             <h1 className="mt-1 text-2xl font-black text-gray-950">Manage fee balances</h1>
-            <p className="mt-1 text-sm font-semibold text-gray-600">{model.team.name}: record offline payments and apply one signed balance adjustment with a required reason for each recipient.</p>
+            <p className="mt-1 text-sm font-semibold text-gray-600">{model.team.name}: record offline payments, offline refunds, and one signed balance adjustment with a required reason for each recipient.</p>
           </div>
           <button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading}>
             <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" /> Refresh
@@ -226,15 +246,7 @@ export function TeamFees({ auth }: { auth: AuthState }) {
         </div>
         <div className="grid gap-3 lg:grid-cols-2">
           {actionableRecipients.length ? actionableRecipients.map((recipient) => {
-            const form = formByRecipient[recipient.id] || {
-              paymentAmount: centsToAmount(recipient.remainingBalanceCents),
-              paymentDate: todayIsoDate(),
-              paymentNote: '',
-              paymentError: '',
-              adjustmentAmount: '',
-              adjustmentReason: '',
-              adjustmentError: ''
-            };
+            const form = formByRecipient[recipient.id] || buildRecipientFormState(recipient);
             const recipientSubmitting = isRecipientSubmitting(recipient.id);
             return (
               <section key={recipient.id} className="app-card p-4">
@@ -284,6 +296,15 @@ export function TeamFees({ auth }: { auth: AuthState }) {
                   {form.adjustmentError ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-2 text-xs font-bold text-rose-700">{form.adjustmentError}</div> : null}
                   <button type="submit" className="secondary-button w-full justify-center" disabled={recipientSubmitting}>{submittingId === `adjustment:${recipient.id}` ? 'Saving...' : 'Save adjustment'}</button>
                 </form>
+
+                <RefundSection
+                  recipient={recipient}
+                  form={form}
+                  submittingId={submittingId}
+                  recipientSubmitting={recipientSubmitting}
+                  updateForm={updateForm}
+                  submitRefund={submitRefund}
+                />
               </section>
             );
           }) : recipients.length ? (
@@ -304,15 +325,7 @@ export function TeamFees({ auth }: { auth: AuthState }) {
           <p className="mt-2 text-xs font-semibold text-gray-500">Fully paid recipients stay available for review without editable payment controls.</p>
           <div className="mt-4 grid gap-3 lg:grid-cols-2">
             {paidRecipients.map((recipient) => {
-              const form = formByRecipient[recipient.id] || {
-                paymentAmount: centsToAmount(recipient.remainingBalanceCents),
-                paymentDate: todayIsoDate(),
-                paymentNote: '',
-                paymentError: '',
-                adjustmentAmount: '',
-                adjustmentReason: '',
-                adjustmentError: ''
-              };
+              const form = formByRecipient[recipient.id] || buildRecipientFormState(recipient);
               const recipientSubmitting = isRecipientSubmitting(recipient.id);
               return (
               <section key={recipient.id} className="rounded-2xl border border-gray-200 bg-gray-50 p-4">
@@ -345,6 +358,16 @@ export function TeamFees({ auth }: { auth: AuthState }) {
                   {form.adjustmentError ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-2 text-xs font-bold text-rose-700">{form.adjustmentError}</div> : null}
                   <button type="submit" className="secondary-button w-full justify-center" disabled={recipientSubmitting}>{submittingId === `adjustment:${recipient.id}` ? 'Saving...' : 'Save adjustment'}</button>
                 </form>
+
+                <RefundSection
+                  recipient={recipient}
+                  form={form}
+                  submittingId={submittingId}
+                  recipientSubmitting={recipientSubmitting}
+                  updateForm={updateForm}
+                  submitRefund={submitRefund}
+                  className="mt-4"
+                />
               </section>
               );
             })}
@@ -356,24 +379,34 @@ export function TeamFees({ auth }: { auth: AuthState }) {
         <section className="app-card p-5 text-center">
           <DollarSign className="mx-auto h-8 w-8 text-gray-400" aria-hidden="true" />
           <div className="mt-3 text-sm font-black text-gray-950">No fee recipients</div>
-          <p className="mt-1 text-xs font-semibold text-gray-500">Create fee batches in the full website manager, then record offline payments or adjustments here.</p>
+          <p className="mt-1 text-xs font-semibold text-gray-500">Create fee batches in the full website manager, then record offline payments, refunds, or adjustments here.</p>
         </section>
       ) : null}
     </div>
   );
 }
 
-function seedRecipientForms(current: Record<string, { paymentAmount: string; paymentDate: string; paymentNote: string; paymentError: string; adjustmentAmount: string; adjustmentReason: string; adjustmentError: string }>, recipients: TeamFeeRecipientSummary[]) {
-  return recipients.reduce<Record<string, { paymentAmount: string; paymentDate: string; paymentNote: string; paymentError: string; adjustmentAmount: string; adjustmentReason: string; adjustmentError: string }>>((next, recipient) => {
-    next[recipient.id] = current[recipient.id] || {
-      paymentAmount: centsToAmount(recipient.remainingBalanceCents),
-      paymentDate: todayIsoDate(),
-      paymentNote: '',
-      paymentError: '',
-      adjustmentAmount: '',
-      adjustmentReason: '',
-      adjustmentError: ''
-    };
+function buildRecipientFormState(recipient?: TeamFeeRecipientSummary): RecipientFormState {
+  return {
+    paymentAmount: centsToAmount(recipient?.remainingBalanceCents ?? 0),
+    paymentDate: todayIsoDate(),
+    paymentNote: '',
+    paymentError: '',
+    adjustmentAmount: '',
+    adjustmentReason: '',
+    adjustmentError: '',
+    refundOpen: false,
+    refundType: 'full',
+    refundAmount: centsToAmount(recipient?.amountPaidCents ?? 0),
+    refundMethod: '',
+    refundNote: '',
+    refundError: ''
+  };
+}
+
+function seedRecipientForms(current: Record<string, RecipientFormState>, recipients: TeamFeeRecipientSummary[]) {
+  return recipients.reduce<Record<string, RecipientFormState>>((next, recipient) => {
+    next[recipient.id] = current[recipient.id] || buildRecipientFormState(recipient);
     return next;
   }, {});
 }
@@ -406,4 +439,92 @@ function StatusCard({ title, message, backTo }: { title: string; message: string
       </div>
     </section>
   );
+}
+
+function RefundSection({
+  recipient,
+  form,
+  submittingId,
+  recipientSubmitting,
+  updateForm,
+  submitRefund,
+  className = 'mt-4'
+}: {
+  recipient: TeamFeeRecipientSummary;
+  form: RecipientFormState;
+  submittingId: string;
+  recipientSubmitting: boolean;
+  updateForm: (recipientId: string, patch: Partial<RecipientFormState>) => void;
+  submitRefund: (event: FormEvent<HTMLFormElement>, recipient: TeamFeeRecipientSummary) => Promise<void>;
+  className?: string;
+}) {
+  if (recipient.status === 'canceled' || recipient.amountPaidCents <= 0) return null;
+
+  const maxRefundLabel = formatMoney(recipient.amountPaidCents);
+  const previewError = form.refundOpen && form.refundType === 'partial'
+    ? getPartialRefundPreviewError(form.refundAmount, recipient)
+    : '';
+
+  return (
+    <section className={`${className} rounded-2xl border border-gray-200 bg-white p-3`}>
+      <div className="flex items-center justify-between gap-3">
+        <div>
+          <div className="text-xs font-black uppercase tracking-[0.06em] text-gray-500">Offline refund</div>
+          <p className="mt-1 text-xs font-semibold text-gray-500">Refund up to {maxRefundLabel} by cash or check. This records the ledger change only.</p>
+        </div>
+        <button
+          type="button"
+          className="secondary-button !min-h-9 text-xs"
+          disabled={recipientSubmitting}
+          onClick={() => updateForm(recipient.id, { refundOpen: !form.refundOpen, refundError: '' })}
+        >
+          {form.refundOpen ? 'Cancel refund' : 'Record refund'}
+        </button>
+      </div>
+
+      {form.refundOpen ? (
+        <form className="mt-3 space-y-3" onSubmit={(event) => submitRefund(event, recipient)}>
+          <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Refund type
+            <select className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" value={form.refundType} onChange={(event) => updateForm(recipient.id, { refundType: event.target.value as 'full' | 'partial', refundError: '' })} disabled={recipientSubmitting}>
+              <option value="full">Full refund</option>
+              <option value="partial">Partial refund</option>
+            </select>
+          </label>
+
+          {form.refundType === 'partial' ? (
+            <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Refund amount
+              <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" inputMode="decimal" placeholder={centsToAmount(recipient.amountPaidCents)} value={form.refundAmount} onChange={(event) => updateForm(recipient.id, { refundAmount: event.target.value, refundError: '' })} disabled={recipientSubmitting} />
+            </label>
+          ) : null}
+
+          <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Refund method
+            <select className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" value={form.refundMethod} onChange={(event) => updateForm(recipient.id, { refundMethod: event.target.value, refundError: '' })} disabled={recipientSubmitting}>
+              <option value="">Select method</option>
+              <option value="cash">Cash</option>
+              <option value="check">Check</option>
+            </select>
+          </label>
+
+          <label className="block text-xs font-black uppercase tracking-[0.06em] text-gray-500">Admin note
+            <input className="mt-1 w-full rounded-2xl border border-gray-200 bg-white px-3 py-3 text-sm font-bold text-gray-900" placeholder="Why this was refunded and how it was handled" value={form.refundNote} onChange={(event) => updateForm(recipient.id, { refundNote: event.target.value, refundError: '' })} disabled={recipientSubmitting} />
+          </label>
+
+          {previewError ? <div className="rounded-xl border border-amber-200 bg-amber-50 p-2 text-xs font-bold text-amber-700">{previewError}</div> : null}
+          {form.refundError ? <div className="rounded-xl border border-rose-200 bg-rose-50 p-2 text-xs font-bold text-rose-700">{form.refundError}</div> : null}
+          <button type="submit" className="secondary-button w-full justify-center" disabled={recipientSubmitting || Boolean(previewError)}>{submittingId === `refund:${recipient.id}` ? 'Recording refund...' : 'Submit refund'}</button>
+        </form>
+      ) : null}
+    </section>
+  );
+}
+
+function getPartialRefundPreviewError(amount: string, recipient: TeamFeeRecipientSummary) {
+  const refundAmountCents = Number(String(amount || '').replace(/[$,]/g, '').trim());
+  if (!String(amount || '').trim() || !Number.isFinite(refundAmountCents) || refundAmountCents <= 0) {
+    return 'Enter a refund amount greater than $0.';
+  }
+  if (Math.round(refundAmountCents * 100) > recipient.amountPaidCents) {
+    return 'Refund amount cannot exceed the recorded paid amount.';
+  }
+  return '';
 }

--- a/tests/unit/app-team-fees-service.test.ts
+++ b/tests/unit/app-team-fees-service.test.ts
@@ -14,9 +14,11 @@ vi.mock('../../js/team-access.js', () => ({
 
 import {
     buildBalanceAdjustmentUpdate,
+    buildOfflineTeamFeeRefundUpdate,
     buildManualPaymentUpdate,
     loadTeamFeeManagementModel,
     recordOfflineTeamFeePayment,
+    recordOfflineTeamFeeRefund,
     recordTeamFeeBalanceAdjustment
 } from '../../apps/app/src/lib/teamFeesService.ts';
 
@@ -128,6 +130,90 @@ describe('React app team fee offline payment service', () => {
         expect(() => buildBalanceAdjustmentUpdate({ amount: '0', note: 'No-op' })).toThrow('positive or negative adjustment');
         expect(() => buildBalanceAdjustmentUpdate({ amount: '', note: 'No-op' })).toThrow('positive or negative adjustment');
         expect(() => buildBalanceAdjustmentUpdate({ amount: '5.00', note: '' })).toThrow('adjustment reason');
+    });
+
+    it('builds partial offline refunds with the legacy ledger shape', () => {
+        const update = buildOfflineTeamFeeRefundUpdate({
+            refundType: 'partial',
+            amount: '15.00',
+            method: 'check',
+            note: 'Parent returned duplicate cash payment',
+            actorId: 'coach-1',
+            currentBalanceCents: 10000,
+            currentPaidCents: 8000
+        });
+
+        expect(update).toMatchObject({
+            status: 'partial',
+            amountPaidCents: 6500,
+            remainingBalanceCents: 3500,
+            paidAt: null,
+            refunded: {
+                amountCents: 1500,
+                refundType: 'partial',
+                refundMethod: 'check',
+                note: 'Parent returned duplicate cash payment',
+                recordedBy: 'coach-1'
+            }
+        });
+        expect(update.ledgerEntries).toEqual([
+            expect.objectContaining({
+                type: 'offline_refund',
+                amountCents: -1500,
+                refundAmountCents: 1500,
+                refundType: 'partial',
+                refundMethod: 'check',
+                methodLabel: 'Check'
+            })
+        ]);
+    });
+
+    it('builds full offline refunds back to unpaid', () => {
+        const update = buildOfflineTeamFeeRefundUpdate({
+            refundType: 'full',
+            method: 'cash',
+            note: 'Cash refund at practice',
+            currentBalanceCents: 10000,
+            currentPaidCents: 10000
+        });
+
+        expect(update.status).toBe('unpaid');
+        expect(update.amountPaidCents).toBe(0);
+        expect(update.remainingBalanceCents).toBe(10000);
+        expect(update.paidAt).toBeNull();
+    });
+
+    it('rejects invalid offline refund input', () => {
+        expect(() => buildOfflineTeamFeeRefundUpdate({
+            refundType: 'partial',
+            amount: '0',
+            method: 'cash',
+            note: 'Zero refund',
+            currentBalanceCents: 10000,
+            currentPaidCents: 5000
+        })).toThrow('greater than $0');
+        expect(() => buildOfflineTeamFeeRefundUpdate({
+            refundType: 'partial',
+            amount: '60.00',
+            method: 'cash',
+            note: 'Too much',
+            currentBalanceCents: 10000,
+            currentPaidCents: 5000
+        })).toThrow('cannot exceed');
+        expect(() => buildOfflineTeamFeeRefundUpdate({
+            refundType: 'full',
+            method: '',
+            note: 'Missing method',
+            currentBalanceCents: 10000,
+            currentPaidCents: 5000
+        })).toThrow('Select cash or check');
+        expect(() => buildOfflineTeamFeeRefundUpdate({
+            refundType: 'full',
+            method: 'cash',
+            note: '',
+            currentBalanceCents: 10000,
+            currentPaidCents: 5000
+        })).toThrow('admin note');
     });
 
     it('loads batches and recipients only for fee managers', async () => {
@@ -246,6 +332,40 @@ describe('React app team fee offline payment service', () => {
         }));
     });
 
+    it('writes offline refunds to the existing recipient document', async () => {
+        dbMocks.getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears', ownerId: 'coach-1' });
+        dbMocks.updateTeamFeeRecipient.mockResolvedValue(undefined);
+
+        await recordOfflineTeamFeeRefund({
+            teamId: 'team-1',
+            batchId: 'batch-1',
+            recipient: {
+                id: 'recipient-1',
+                playerName: 'Pat Star',
+                parentName: '',
+                parentEmail: '',
+                status: 'paid',
+                amountDueCents: 10000,
+                amountPaidCents: 10000,
+                remainingBalanceCents: 0,
+                paymentLedger: []
+            },
+            refundType: 'partial',
+            amount: '25.00',
+            method: 'cash',
+            note: 'Refunded at the field',
+            user: { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: [] }
+        });
+
+        expect(dbMocks.updateTeamFeeRecipient).toHaveBeenCalledWith('team-1', 'batch-1', 'recipient-1', expect.objectContaining({
+            status: 'partial',
+            amountPaidCents: 7500,
+            remainingBalanceCents: 2500,
+            refunded: expect.objectContaining({ amountCents: 2500, refundMethod: 'cash', note: 'Refunded at the field' }),
+            ledgerEntries: [expect.objectContaining({ type: 'offline_refund', amountCents: -2500, refundAmountCents: 2500 })]
+        }));
+    });
+
     it('blocks non-managers from recording offline payments or adjustments', async () => {
         dbMocks.getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears', ownerId: 'coach-1' });
 
@@ -277,6 +397,37 @@ describe('React app team fee offline payment service', () => {
             note: 'Scholarship',
             user: { uid: 'parent-1', email: 'parent@example.com', displayName: 'Parent', roles: [] }
         })).rejects.toThrow('do not have access');
+        await expect(recordOfflineTeamFeeRefund({
+            teamId: 'team-1',
+            batchId: 'batch-1',
+            recipient: { ...recipient, status: 'partial', amountPaidCents: 5000, remainingBalanceCents: 5000 },
+            refundType: 'full',
+            method: 'cash',
+            note: 'Requested by parent',
+            user: { uid: 'parent-1', email: 'parent@example.com', displayName: 'Parent', roles: [] }
+        })).rejects.toThrow('do not have access');
         expect(dbMocks.updateTeamFeeRecipient).not.toHaveBeenCalled();
+    });
+
+    it('rejects refund submissions with missing fee context', async () => {
+        await expect(recordOfflineTeamFeeRefund({
+            teamId: '',
+            batchId: 'batch-1',
+            recipient: {
+                id: 'recipient-1',
+                playerName: 'Pat Star',
+                parentName: '',
+                parentEmail: '',
+                status: 'partial',
+                amountDueCents: 10000,
+                amountPaidCents: 5000,
+                remainingBalanceCents: 5000,
+                paymentLedger: []
+            },
+            refundType: 'full',
+            method: 'cash',
+            note: 'Missing team context',
+            user: { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: [] }
+        })).rejects.toThrow('Missing fee recipient context');
     });
 });


### PR DESCRIPTION
Closes #1677

## What changed
- added an offline refund update builder and `recordOfflineTeamFeeRefund` service wrapper in the React app fee service
- added recipient-level offline refund controls to the Team Fees page for paid and partially paid recipients
- enforced legacy refund validation in the new app flow: full or partial refund, cash/check method required, and admin note required
- refreshed recipient totals and status after refund submission so paid, partial, and outstanding values update immediately
- extended focused unit and component coverage for refund math, validation, access control, and UI submission behavior

## Why
The React Team Fees manager could record payments and balance adjustments, but it could not record offline refunds that reduce paid amounts and append an `offline_refund` ledger entry. This closes that parity gap with the legacy fee manager without adding native wrapper-specific logic.