### PR TITLE
Add inline invite redemption to Parent Tools

### DIFF
--- a/apps/app/src/lib/inviteRedemption.test.ts
+++ b/apps/app/src/lib/inviteRedemption.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const authServiceMocks = vi.hoisted(() => ({
+    clearPendingInvite: vi.fn(),
+    mapLegacyRedirectToAppRoute: vi.fn(() => '/home'),
+    redeemInviteForUser: vi.fn()
+}));
+
+vi.mock('./authService', () => authServiceMocks);
+
+import { getValidatedInviteCode, normalizeInviteCode, redeemSignedInInvite } from './inviteRedemption';
+
+describe('inviteRedemption', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('normalizes invite codes before redemption', async () => {
+        authServiceMocks.redeemInviteForUser.mockResolvedValue({ message: 'Invite accepted.', redirectUrl: 'parent-dashboard.html' });
+        const refresh = vi.fn().mockResolvedValue(undefined);
+
+        await expect(redeemSignedInInvite({
+            userId: 'parent-1',
+            code: ' ab12cd34 ',
+            email: 'parent@example.com',
+            refresh
+        })).resolves.toMatchObject({ code: 'AB12CD34', redirectPath: '/home', message: 'Invite accepted.' });
+
+        expect(authServiceMocks.redeemInviteForUser).toHaveBeenCalledWith('parent-1', 'AB12CD34', 'parent@example.com');
+        expect(refresh).toHaveBeenCalledTimes(1);
+        expect(authServiceMocks.clearPendingInvite).toHaveBeenCalledTimes(1);
+    });
+
+    it('rejects invalid invite codes before network work', async () => {
+        expect(normalizeInviteCode(' ab12cd34 ')).toBe('AB12CD34');
+        expect(() => getValidatedInviteCode('abc123')).toThrow('Please enter a valid 8-character invite code.');
+        await expect(redeemSignedInInvite({ userId: 'parent-1', code: 'short' })).rejects.toThrow('Please enter a valid 8-character invite code.');
+        expect(authServiceMocks.redeemInviteForUser).not.toHaveBeenCalled();
+    });
+});

--- a/apps/app/src/lib/inviteRedemption.ts
+++ b/apps/app/src/lib/inviteRedemption.ts
@@ -1,0 +1,35 @@
+import { clearPendingInvite, mapLegacyRedirectToAppRoute, redeemInviteForUser } from './authService';
+
+export type SignedInInviteRedemptionOptions = {
+    userId: string;
+    code: string;
+    email?: string | null;
+    refresh?: () => Promise<unknown>;
+};
+
+export function normalizeInviteCode(code: string | null | undefined) {
+    return String(code || '').trim().toUpperCase();
+}
+
+export function getValidatedInviteCode(code: string | null | undefined) {
+    const normalizedCode = normalizeInviteCode(code);
+    if (normalizedCode.length !== 8) {
+        throw new Error('Please enter a valid 8-character invite code.');
+    }
+    return normalizedCode;
+}
+
+export async function redeemSignedInInvite({ userId, code, email, refresh }: SignedInInviteRedemptionOptions) {
+    const normalizedCode = getValidatedInviteCode(code);
+    const result = await redeemInviteForUser(userId, normalizedCode, email);
+    if (refresh) {
+        await refresh();
+    }
+    clearPendingInvite();
+    return {
+        code: normalizedCode,
+        redirectPath: mapLegacyRedirectToAppRoute(result?.redirectUrl),
+        message: result?.message || 'Invite accepted.',
+        result
+    };
+}

--- a/apps/app/src/pages/AcceptInvite.tsx
+++ b/apps/app/src/pages/AcceptInvite.tsx
@@ -12,6 +12,7 @@ import {
   redeemInviteForUser,
   rememberPendingInvite
 } from '../lib/authService';
+import { getValidatedInviteCode, normalizeInviteCode, redeemSignedInInvite } from '../lib/inviteRedemption';
 import type { AuthState } from '../lib/types';
 
 export function AcceptInvite({ auth }: { auth: AuthState }) {
@@ -48,14 +49,13 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
   }, []);
 
   async function redeem(codeToRedeem: string) {
+    const normalizedCode = normalizeInviteCode(codeToRedeem);
     if (!auth.user) {
-      const normalizedCode = codeToRedeem.trim().toUpperCase();
       rememberPendingInvite(normalizedCode, inviteType);
       navigate(`${buildInviteAuthUrl(normalizedCode, inviteType)}&mode=login`);
       return;
     }
 
-    const normalizedCode = codeToRedeem.trim().toUpperCase();
     const key = `${auth.user.uid}:${normalizedCode}`;
     if (processedKeyRef.current === key) {
       return;
@@ -66,12 +66,15 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
     setMessage('Processing invite...');
 
     try {
-      const result = await redeemInviteForUser(auth.user.uid, normalizedCode, auth.user.email);
-      await auth.refresh();
-      clearPendingInvite();
+      const result = await redeemSignedInInvite({
+        userId: auth.user.uid,
+        code: normalizedCode,
+        email: auth.user.email,
+        refresh: auth.refresh
+      });
       setState('success');
-      setMessage(result?.message || 'Invite accepted.');
-      scheduleRedirect(mapLegacyRedirectToAppRoute(result?.redirectUrl));
+      setMessage(result.message);
+      scheduleRedirect(result.redirectPath);
     } catch (error: any) {
       processedKeyRef.current = '';
       setState('error');
@@ -92,13 +95,12 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
 
   const handleManualSubmit = async (event: FormEvent) => {
     event.preventDefault();
-    const normalizedCode = manualCode.trim().toUpperCase();
-    if (!normalizedCode || normalizedCode.length !== 8) {
+    try {
+      await redeem(getValidatedInviteCode(manualCode));
+    } catch (error: any) {
       setState('error');
-      setMessage('Please enter a valid 8-character invite code.');
-      return;
+      setMessage(error?.message || 'Please enter a valid 8-character invite code.');
     }
-    await redeem(normalizedCode);
   };
 
   const handleEmailLink = async (event: FormEvent) => {

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ParentTools } from './ParentTools';
+import type { AuthState } from '../lib/types';
+
+const parentToolsServiceMocks = vi.hoisted(() => ({
+    buildParentScheduleIcs: vi.fn(),
+    createParentFamilyShare: vi.fn(),
+    createParentHouseholdMemberInvite: vi.fn(),
+    downloadIcs: vi.fn(),
+    getAppleCalendarFeedUrl: vi.fn(),
+    getCalendarEventShareText: vi.fn(),
+    getGoogleCalendarFeedUrl: vi.fn(),
+    getPrivateTeamCalendarFeedUrl: vi.fn(),
+    initiateParentTeamFeeCheckout: vi.fn(),
+    loadFamilyShareModel: vi.fn(),
+    loadParentAccessModel: vi.fn(),
+    loadParentAccessPlayers: vi.fn(),
+    loadParentCalendarTools: vi.fn(),
+    loadParentCertificates: vi.fn(),
+    loadParentFeesForApp: vi.fn(),
+    loadParentHouseholdInviteModel: vi.fn(),
+    loadParentRegistrations: vi.fn(),
+    revokeParentFamilyShare: vi.fn(),
+    submitParentAccessRequest: vi.fn(),
+    updateParentFamilyShareCalendars: vi.fn()
+}));
+
+const inviteRedemptionMocks = vi.hoisted(() => ({
+    redeemSignedInInvite: vi.fn()
+}));
+
+vi.mock('../lib/parentToolsService', () => parentToolsServiceMocks);
+vi.mock('../lib/inviteRedemption', () => inviteRedemptionMocks);
+vi.mock('../lib/publicActions', () => ({
+    openPublicUrl: vi.fn(),
+    sharePublicUrl: vi.fn()
+}));
+
+const auth: AuthState = {
+    user: {
+        uid: 'parent-1',
+        email: 'parent@example.com',
+        displayName: 'Parent One',
+        roles: ['parent'],
+        parentOf: []
+    },
+    profile: null,
+    loading: false,
+    error: null,
+    roles: ['parent'],
+    isParent: true,
+    isCoach: false,
+    isAdmin: false,
+    isPlatformAdmin: false,
+    refresh: vi.fn().mockResolvedValue(null),
+    signOut: vi.fn().mockResolvedValue(undefined)
+};
+
+function renderParentTools() {
+    return render(
+        <MemoryRouter initialEntries={['/parent-tools/access']}>
+            <Routes>
+                <Route path="/parent-tools/:toolId" element={<ParentTools auth={auth} />} />
+                <Route path="/accept-invite" element={<div>Accept invite route</div>} />
+            </Routes>
+        </MemoryRouter>
+    );
+}
+
+describe('ParentTools access', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        parentToolsServiceMocks.loadParentAccessModel.mockResolvedValue({
+            teams: [{ id: 'team-1', name: 'Bears', sport: 'Soccer' }],
+            requests: []
+        });
+        parentToolsServiceMocks.loadParentAccessPlayers.mockResolvedValue([
+            { id: 'player-1', name: 'Sam Player', number: '12' }
+        ]);
+        parentToolsServiceMocks.submitParentAccessRequest.mockResolvedValue(undefined);
+        inviteRedemptionMocks.redeemSignedInInvite.mockResolvedValue({
+            code: 'AB12CD34',
+            redirectPath: '/home',
+            message: 'Invite accepted.'
+        });
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('redeems an invite inline and stays on parent tools', async () => {
+        renderParentTools();
+
+        await screen.findByText('Request player access');
+        fireEvent.change(screen.getByPlaceholderText('XXXXXXXX'), { target: { value: 'ab12cd34' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Redeem code' }));
+
+        expect(await screen.findByText('Invite accepted.')).toBeTruthy();
+        expect(inviteRedemptionMocks.redeemSignedInInvite).toHaveBeenCalledWith({
+            userId: 'parent-1',
+            code: 'AB12CD34',
+            email: 'parent@example.com',
+            refresh: auth.refresh
+        });
+        expect(screen.queryByText('Accept invite route')).toBeNull();
+        expect(screen.getByRole('button', { name: 'Redeem code' })).toBeTruthy();
+    });
+
+    it('shows inline redeem errors without breaking the request form', async () => {
+        inviteRedemptionMocks.redeemSignedInInvite.mockRejectedValue(new Error('Invite code expired.'));
+        renderParentTools();
+
+        await screen.findByText('Request player access');
+        fireEvent.change(screen.getByPlaceholderText('XXXXXXXX'), { target: { value: 'expired1' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Redeem code' }));
+
+        expect(await screen.findByText('Invite code expired.')).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Send request' })).toBeTruthy();
+    });
+
+    it('still submits request access after the redeem panel is added', async () => {
+        renderParentTools();
+
+        await screen.findByText('Request player access');
+        await screen.findByRole('option', { name: '#12 Sam Player' });
+        const submitButton = screen.getByRole('button', { name: 'Send request' });
+        expect(submitButton.hasAttribute('disabled')).toBe(false);
+        fireEvent.click(submitButton);
+
+        expect(await screen.findByText('Access request sent.')).toBeTruthy();
+        expect(parentToolsServiceMocks.submitParentAccessRequest).toHaveBeenCalledWith('team-1', 'player-1', 'Parent');
+
+        const requestsSection = screen.getByText('Access requests').closest('section');
+        expect(requestsSection).toBeTruthy();
+        if (!requestsSection) throw new Error('Requests section not found');
+        expect(within(requestsSection).getByText('No requests yet')).toBeTruthy();
+    });
+});

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -11,6 +11,7 @@ import {
   DollarSign,
   Download,
   ExternalLink,
+  KeyRound,
   Loader2,
   RefreshCw,
   Share2,
@@ -19,6 +20,7 @@ import {
   Users
 } from 'lucide-react';
 import { openPublicUrl, sharePublicUrl } from '../lib/publicActions';
+import { redeemSignedInInvite } from '../lib/inviteRedemption';
 import {
   buildParentScheduleIcs,
   createParentFamilyShare,
@@ -139,18 +141,24 @@ function AccessTool({ auth }: { auth: AuthState }) {
   const [loading, setLoading] = useState(true);
   const [loadingPlayers, setLoadingPlayers] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [redeemCode, setRedeemCode] = useState('');
+  const [redeeming, setRedeeming] = useState(false);
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
+
+  const loadAccessModel = async () => {
+    const model = await loadParentAccessModel(auth.user);
+    setTeams(model.teams);
+    setRequests(model.requests);
+    setSelectedTeamId((current) => current || model.teams[0]?.id || '');
+  };
 
   const refresh = async () => {
     setLoading(true);
     setError('');
     setMessage('');
     try {
-      const model = await loadParentAccessModel(auth.user);
-      setTeams(model.teams);
-      setRequests(model.requests);
-      setSelectedTeamId((current) => current || model.teams[0]?.id || '');
+      await loadAccessModel();
     } catch (loadError: any) {
       setError(loadError?.message || 'Unable to load team access.');
     } finally {
@@ -188,6 +196,33 @@ function AccessTool({ auth }: { auth: AuthState }) {
     };
   }, [selectedTeamId]);
 
+  const redeem = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!auth.user?.uid) {
+      setError('Sign in to redeem an invite code.');
+      return;
+    }
+
+    setRedeeming(true);
+    setError('');
+    setMessage('');
+    try {
+      const result = await redeemSignedInInvite({
+        userId: auth.user.uid,
+        code: redeemCode,
+        email: auth.user.email,
+        refresh: auth.refresh
+      });
+      await loadAccessModel();
+      setRedeemCode('');
+      setMessage(result.message);
+    } catch (redeemError: any) {
+      setError(redeemError?.message || 'Unable to redeem this invite code.');
+    } finally {
+      setRedeeming(false);
+    }
+  };
+
   const submit = async (event: FormEvent) => {
     event.preventDefault();
     if (!selectedTeamId || !selectedPlayerId) {
@@ -200,8 +235,7 @@ function AccessTool({ auth }: { auth: AuthState }) {
     try {
       await submitParentAccessRequest(selectedTeamId, selectedPlayerId, relation);
       setMessage('Access request sent.');
-      const model = await loadParentAccessModel(auth.user);
-      setRequests(model.requests);
+      await loadAccessModel();
     } catch (submitError: any) {
       setError(submitError?.message || 'Unable to send access request.');
     } finally {
@@ -212,49 +246,71 @@ function AccessTool({ auth }: { auth: AuthState }) {
   return (
     <div className="space-y-3">
       <section className="app-card p-4">
-        <ToolHeader icon={Shield} title="Request player access" detail="Use this when you do not have an invite code." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
+        <ToolHeader icon={Shield} title="Request player access" detail="Use this when you do not have an invite code." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading || redeeming}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
         {error ? <Status tone="error" message={error} /> : null}
         {message ? <Status tone="success" message={message} /> : null}
         {loading ? <LoadingBlock label="Loading teams" /> : (
-          <form className="mt-3 grid gap-3 lg:grid-cols-[1fr_1fr_auto]" onSubmit={submit}>
-            <label className="min-w-0">
-              <span className="app-label">Team</span>
-              <select className="auth-input mt-1" value={selectedTeamId} onChange={(event) => setSelectedTeamId(event.target.value)}>
-                {teams.length ? teams.map((team) => (
-                  <option key={team.id} value={team.id}>{team.name}{team.sport ? ` - ${team.sport}` : ''}</option>
-                )) : <option value="">No public teams</option>}
-              </select>
-            </label>
-            <label className="min-w-0">
-              <span className="app-label">Player</span>
-              <select className="auth-input mt-1" value={selectedPlayerId} onChange={(event) => setSelectedPlayerId(event.target.value)} disabled={!selectedTeamId || loadingPlayers}>
-                {loadingPlayers ? <option value="">Loading players...</option> : players.length ? players.map((player) => (
-                  <option key={player.id} value={player.id}>{player.number ? `#${player.number} ` : ''}{player.name}</option>
-                )) : <option value="">No players found</option>}
-              </select>
-            </label>
-            <label className="min-w-0">
-              <span className="app-label">Relationship</span>
-              <select className="auth-input mt-1" value={relation} onChange={(event) => setRelation(event.target.value)}>
-                <option value="Parent">Parent</option>
-                <option value="Guardian">Guardian</option>
-                <option value="Grandparent">Grandparent</option>
-                <option value="Family">Family</option>
-              </select>
-            </label>
-            <button type="submit" className="primary-button lg:col-span-3" disabled={saving || loadingPlayers || !selectedTeamId || !selectedPlayerId}>
-              {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Shield className="h-4 w-4" aria-hidden="true" />}
-              Send request
-            </button>
-          </form>
+          <>
+            <form className="mt-3 rounded-2xl border border-primary-100 bg-primary-50/60 p-3" onSubmit={redeem}>
+              <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+                <label className="min-w-0 flex-1">
+                  <span className="app-label">Invite code</span>
+                  <input
+                    className="auth-input mt-1 text-center font-mono uppercase tracking-[0.3em]"
+                    value={redeemCode}
+                    onChange={(event) => setRedeemCode(event.target.value.toUpperCase())}
+                    maxLength={8}
+                    placeholder="XXXXXXXX"
+                    disabled={redeeming || saving}
+                  />
+                </label>
+                <button type="submit" className="primary-button sm:min-w-[10rem]" disabled={redeeming || saving}>
+                  {redeeming ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <KeyRound className="h-4 w-4" aria-hidden="true" />}
+                  {redeeming ? 'Redeeming...' : 'Redeem code'}
+                </button>
+              </div>
+              <p className="mt-2 text-xs font-semibold text-gray-600">Already have an 8-character player invite? Redeem it here and stay in Parent Tools.</p>
+            </form>
+            <form className="mt-3 grid gap-3 lg:grid-cols-[1fr_1fr_auto]" onSubmit={submit}>
+              <label className="min-w-0">
+                <span className="app-label">Team</span>
+                <select className="auth-input mt-1" value={selectedTeamId} onChange={(event) => setSelectedTeamId(event.target.value)}>
+                  {teams.length ? teams.map((team) => (
+                    <option key={team.id} value={team.id}>{team.name}{team.sport ? ` - ${team.sport}` : ''}</option>
+                  )) : <option value="">No public teams</option>}
+                </select>
+              </label>
+              <label className="min-w-0">
+                <span className="app-label">Player</span>
+                <select className="auth-input mt-1" value={selectedPlayerId} onChange={(event) => setSelectedPlayerId(event.target.value)} disabled={!selectedTeamId || loadingPlayers}>
+                  {loadingPlayers ? <option value="">Loading players...</option> : players.length ? players.map((player) => (
+                    <option key={player.id} value={player.id}>{player.number ? `#${player.number} ` : ''}{player.name}</option>
+                  )) : <option value="">No players found</option>}
+                </select>
+              </label>
+              <label className="min-w-0">
+                <span className="app-label">Relationship</span>
+                <select className="auth-input mt-1" value={relation} onChange={(event) => setRelation(event.target.value)}>
+                  <option value="Parent">Parent</option>
+                  <option value="Guardian">Guardian</option>
+                  <option value="Grandparent">Grandparent</option>
+                  <option value="Family">Family</option>
+                </select>
+              </label>
+              <button type="submit" className="primary-button lg:col-span-3" disabled={saving || redeeming || loadingPlayers || !selectedTeamId || !selectedPlayerId}>
+                {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Shield className="h-4 w-4" aria-hidden="true" />}
+                Send request
+              </button>
+            </form>
+          </>
         )}
       </section>
 
       <section className="app-card p-4">
-        <ToolHeader icon={Users} title="Access requests" detail="Pending and decided requests from your account." action={<Link to="/accept-invite" className="secondary-button !min-h-9 text-xs">Accept invite</Link>} />
+        <ToolHeader icon={Users} title="Access requests" detail="Pending and decided requests from your account." action={<Link to="/accept-invite" className="secondary-button !min-h-9 text-xs">Open full invite flow</Link>} />
         <div className="mt-3 grid gap-2 md:grid-cols-2">
           {requests.length ? requests.map((request) => <AccessRequestCard key={request.id || `${request.teamId}-${request.playerId}`} request={request} />) : (
-            <EmptyState icon={Shield} title="No requests yet" detail="Invite codes can still be redeemed from Accept invite." />
+            <EmptyState icon={Shield} title="No requests yet" detail="Invite codes can be redeemed here, or you can open the full invite flow." />
           )}
         </div>
       </section>


### PR DESCRIPTION
Closes #1673

## What changed
- extracted signed-in invite redemption into a shared `inviteRedemption` helper so `AcceptInvite` and `ParentTools` use the same code normalization, validation, refresh, and success handling
- added an inline 8-character invite-code form to `ParentTools` access with loading, success, and error states while keeping the existing request-access flow in place
- refreshed parent access data after successful redemption so the parent tools session updates without redirecting to `/accept-invite`
- added focused Vitest coverage for the shared helper and the Parent Tools access route

## Why
Parents already had manual invite redemption in the standalone Accept Invite flow, but not inside Parent Tools. This patch restores the legacy side-by-side experience with the smallest shared implementation, while preserving the separate auth-oriented invite route for signed-out or broader invite flows.