### PR TITLE
Add bulk delete for TeamMedia selections

### DIFF
--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -220,6 +220,7 @@ export function AppShell({ auth, children }: AppShellProps) {
                   title="Search (Ctrl+K / Cmd+K)"
                 >
                   <Search className="h-5 w-5" aria-hidden="true" />
+                  <span className="sr-only">Search</span>
                 </button>
                 <button
                   type="button"

--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -21,7 +21,8 @@ import {
   uploadTeamMediaPhoto,
   deleteTeamMediaItem,
   updateTeamMediaItem,
-  moveTeamMediaItems
+  moveTeamMediaItems,
+  bulkDeleteTeamMediaItems
 } from '../../../../js/db.js';
 import { addPendingFamilyMember, readFamilyMembers } from '../../../../js/family-plan.js';
 import { db, doc, collection, getDoc, serverTimestamp, runTransaction } from '../../../../js/firebase.js';
@@ -229,6 +230,13 @@ export async function updateTeamMediaItemForApp(teamId: string, itemId: string, 
 export async function moveTeamMediaItemForApp(teamId: string, itemId: string, targetFolderId: string) {
   if (!teamId || !itemId || !targetFolderId) throw new Error('Missing team, media item, or destination album ID.');
   return moveTeamMediaItems(teamId, [itemId], targetFolderId);
+}
+
+export async function bulkDeleteTeamMediaItemsForApp(teamId: string, itemIds: string[]) {
+  const ids = Array.isArray(itemIds) ? itemIds.map((itemId) => compactString(itemId)).filter(Boolean) : [];
+  if (!teamId) throw new Error('Missing team ID.');
+  if (!ids.length) throw new Error('Select at least one media item to delete.');
+  return bulkDeleteTeamMediaItems(teamId, ids);
 }
 
 export function getLegacyUrl(path: string, params: Record<string, string> = {}, hashParams: Record<string, string> = {}) {

--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -21,8 +21,7 @@ import {
   uploadTeamMediaPhoto,
   deleteTeamMediaItem,
   updateTeamMediaItem,
-  moveTeamMediaItems,
-  bulkDeleteTeamMediaItems
+  moveTeamMediaItems
 } from '../../../../js/db.js';
 import { addPendingFamilyMember, readFamilyMembers } from '../../../../js/family-plan.js';
 import { db, doc, collection, getDoc, serverTimestamp, runTransaction } from '../../../../js/firebase.js';
@@ -232,11 +231,11 @@ export async function moveTeamMediaItemForApp(teamId: string, itemId: string, ta
   return moveTeamMediaItems(teamId, [itemId], targetFolderId);
 }
 
-export async function bulkDeleteTeamMediaItemsForApp(teamId: string, itemIds: string[]) {
-  const ids = Array.isArray(itemIds) ? itemIds.map((itemId) => compactString(itemId)).filter(Boolean) : [];
+export async function bulkDeleteTeamMediaItemsForApp(teamId: string, items: TeamMediaItem[]) {
+  const itemsToDelete = Array.isArray(items) ? items.filter((item) => compactString(item?.id)) : [];
   if (!teamId) throw new Error('Missing team ID.');
-  if (!ids.length) throw new Error('Select at least one media item to delete.');
-  return bulkDeleteTeamMediaItems(teamId, ids);
+  if (!itemsToDelete.length) throw new Error('Select at least one media item to delete.');
+  await Promise.all(itemsToDelete.map((item) => deleteTeamMediaItem(teamId, item)));
 }
 
 export function getLegacyUrl(path: string, params: Record<string, string> = {}, hashParams: Record<string, string> = {}) {

--- a/apps/app/src/pages/TeamMedia.test.tsx
+++ b/apps/app/src/pages/TeamMedia.test.tsx
@@ -135,7 +135,10 @@ describe('TeamMedia bulk delete', () => {
     expect(screen.getByText('2 selected in this view')).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'Delete selected' }));
 
-    expect(parentToolsServiceMocks.bulkDeleteTeamMediaItemsForApp).toHaveBeenCalledWith('team-1', ['photo-1', 'photo-2']);
+    expect(parentToolsServiceMocks.bulkDeleteTeamMediaItemsForApp).toHaveBeenCalledWith('team-1', [
+      expect.objectContaining({ id: 'photo-1', type: 'photo', url: 'https://example.com/photo-1.jpg' }),
+      expect.objectContaining({ id: 'photo-2', type: 'photo', url: 'https://example.com/photo-2.jpg' })
+    ]);
     expect(await screen.findByText('2 media items deleted.')).toBeTruthy();
     expect(screen.getByRole('button', { name: 'Photos0' }).getAttribute('aria-pressed')).toBe('true');
     expect(screen.getByText('No photos in this album.')).toBeTruthy();

--- a/apps/app/src/pages/TeamMedia.test.tsx
+++ b/apps/app/src/pages/TeamMedia.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TeamMedia } from './TeamMedia';
+import type { AuthState } from '../lib/types';
+
+const parentToolsServiceMocks = vi.hoisted(() => ({
+  addParentTeamMediaLink: vi.fn(),
+  bulkDeleteTeamMediaItemsForApp: vi.fn(),
+  createTeamMediaAlbumForApp: vi.fn(),
+  deleteTeamMediaItemForApp: vi.fn(),
+  loadTeamMediaForApp: vi.fn(),
+  moveTeamMediaItemForApp: vi.fn(),
+  updateTeamMediaItemForApp: vi.fn(),
+  uploadParentTeamMediaFile: vi.fn(),
+  uploadParentTeamMediaPhoto: vi.fn()
+}));
+
+vi.mock('../lib/parentToolsService', () => parentToolsServiceMocks);
+vi.mock('../lib/publicActions', () => ({
+  openPublicUrl: vi.fn(),
+  sharePublicUrl: vi.fn().mockResolvedValue('shared')
+}));
+vi.mock('../lib/chatService', () => ({
+  sendTeamChatMessage: vi.fn()
+}));
+vi.mock('../lib/chatLogic', () => ({
+  DEFAULT_TEAM_CONVERSATION_ID: 'team-chat'
+}));
+
+const auth: AuthState = {
+  user: {
+    uid: 'coach-1',
+    email: 'coach@example.com',
+    displayName: 'Coach'
+  } as any,
+  profile: null,
+  loading: false,
+  error: null,
+  roles: ['coach'],
+  isParent: false,
+  isCoach: true,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: vi.fn(),
+  signOut: vi.fn()
+};
+
+function createModel(overrides: Record<string, any> = {}) {
+  return {
+    team: { id: 'team-1', name: 'Bears' },
+    canManage: true,
+    canContribute: false,
+    canPostChat: false,
+    folders: [
+      {
+        id: 'album-1',
+        name: 'Game day',
+        visibility: 'team',
+        itemCount: 3,
+        items: [
+          { id: 'photo-1', title: 'Photo one', type: 'photo', url: 'https://example.com/photo-1.jpg', uploadedBy: 'coach-1' },
+          { id: 'photo-2', title: 'Photo two', type: 'photo', url: 'https://example.com/photo-2.jpg', uploadedBy: 'coach-1' },
+          { id: 'file-1', title: 'Roster PDF', type: 'file', url: 'https://example.com/roster.pdf', uploadedBy: 'coach-1' }
+        ]
+      }
+    ],
+    ...overrides
+  };
+}
+
+function renderTeamMedia(customAuth: AuthState = auth) {
+  return render(
+    <MemoryRouter initialEntries={['/teams/team-1/media']}>
+      <Routes>
+        <Route path="/teams/:teamId/media" element={<TeamMedia auth={customAuth} />} />
+        <Route path="/teams/:teamId" element={<div>Team detail</div>} />
+        <Route path="/teams" element={<div>Teams</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('TeamMedia bulk delete', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    parentToolsServiceMocks.addParentTeamMediaLink.mockReset();
+    parentToolsServiceMocks.bulkDeleteTeamMediaItemsForApp.mockReset();
+    parentToolsServiceMocks.createTeamMediaAlbumForApp.mockReset();
+    parentToolsServiceMocks.deleteTeamMediaItemForApp.mockReset();
+    parentToolsServiceMocks.loadTeamMediaForApp.mockReset();
+    parentToolsServiceMocks.moveTeamMediaItemForApp.mockReset();
+    parentToolsServiceMocks.updateTeamMediaItemForApp.mockReset();
+    parentToolsServiceMocks.uploadParentTeamMediaFile.mockReset();
+    parentToolsServiceMocks.uploadParentTeamMediaPhoto.mockReset();
+    vi.stubGlobal('confirm', vi.fn(() => true));
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn()
+      }
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it('lets a manager select items, bulk delete them, and refresh the same filtered view', async () => {
+    parentToolsServiceMocks.loadTeamMediaForApp
+      .mockResolvedValueOnce(createModel())
+      .mockResolvedValueOnce(createModel({
+        folders: [
+          {
+            id: 'album-1',
+            name: 'Game day',
+            visibility: 'team',
+            itemCount: 1,
+            items: [
+              { id: 'file-1', title: 'Roster PDF', type: 'file', url: 'https://example.com/roster.pdf', uploadedBy: 'coach-1' }
+            ]
+          }
+        ]
+      }));
+    parentToolsServiceMocks.bulkDeleteTeamMediaItemsForApp.mockResolvedValue(undefined);
+
+    renderTeamMedia();
+
+    await screen.findByText('Bears media');
+    fireEvent.click(screen.getByRole('button', { name: 'Photos2' }));
+    fireEvent.click(screen.getByLabelText('Select Photo one'));
+    fireEvent.click(screen.getByLabelText('Select Photo two'));
+
+    expect(screen.getByText('2 selected in this view')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete selected' }));
+
+    expect(parentToolsServiceMocks.bulkDeleteTeamMediaItemsForApp).toHaveBeenCalledWith('team-1', ['photo-1', 'photo-2']);
+    expect(await screen.findByText('2 media items deleted.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Photos0' }).getAttribute('aria-pressed')).toBe('true');
+    expect(screen.getByText('No photos in this album.')).toBeTruthy();
+    expect(screen.getByText('0 selected in this view')).toBeTruthy();
+  });
+
+  it('hides selection controls from non-managers', async () => {
+    parentToolsServiceMocks.loadTeamMediaForApp.mockResolvedValueOnce(createModel({ canManage: false }));
+
+    renderTeamMedia();
+
+    await screen.findByText('Bears media');
+    expect(screen.queryByText('Bulk actions')).toBeNull();
+    expect(screen.queryByLabelText('Select Photo one')).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Delete selected' })).toBeNull();
+  });
+
+  it('keeps the current selection when bulk delete fails', async () => {
+    parentToolsServiceMocks.loadTeamMediaForApp.mockResolvedValueOnce(createModel());
+    parentToolsServiceMocks.bulkDeleteTeamMediaItemsForApp.mockRejectedValue(new Error('Delete failed.'));
+
+    renderTeamMedia();
+
+    await screen.findByText('Bears media');
+    const selectPhotoOne = screen.getByLabelText('Select Photo one') as HTMLInputElement;
+    fireEvent.click(selectPhotoOne);
+    fireEvent.click(screen.getByRole('button', { name: 'Delete selected' }));
+
+    expect(await screen.findByText('Delete failed.')).toBeTruthy();
+    expect(selectPhotoOne.checked).toBe(true);
+    expect(screen.getByText('1 selected in this view')).toBeTruthy();
+  });
+});

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -208,7 +208,8 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const mediaTypeCounts = useMemo(() => getMediaTypeCounts(activeFolder?.items || []), [activeFolder]);
   const filteredItems = useMemo(() => (activeFolder?.items || []).filter((item) => matchesMediaTypeFilter(item, selectedMediaType)), [activeFolder, selectedMediaType]);
   const visibleItemIds = useMemo(() => filteredItems.map((item) => item.id).filter(Boolean), [filteredItems]);
-  const selectedCount = selectedIds.length;
+  const selectedItems = useMemo(() => filteredItems.filter((item) => selectedIds.includes(item.id)), [filteredItems, selectedIds]);
+  const selectedCount = selectedItems.length;
   const selectedMediaTypeLabel = MEDIA_TYPE_FILTERS.find((filter) => filter.id === selectedMediaType)?.label || 'All';
   const emptyStateLabel = selectedMediaType === 'all' ? 'media' : selectedMediaTypeLabel.toLowerCase();
   const featured = activeFolder?.items[0] || allItems[0] || null;
@@ -223,8 +224,8 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   };
 
   const handleBulkDelete = async () => {
-    if (!teamId || !selectedIds.length) return;
-    const deleteCount = selectedIds.length;
+    if (!teamId || !selectedItems.length) return;
+    const deleteCount = selectedItems.length;
     const confirmed = window.confirm(`Are you sure you want to delete ${deleteCount} media item${deleteCount === 1 ? '' : 's'}? This cannot be undone.`);
     if (!confirmed) return;
 
@@ -232,7 +233,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
     setError('');
     setMessage('');
     try {
-      await bulkDeleteTeamMediaItemsForApp(teamId, selectedIds);
+      await bulkDeleteTeamMediaItemsForApp(teamId, selectedItems);
       setSelectedIds([]);
       await refresh({ showLoading: false, preferredFolderId: activeFolder?.id || '' });
       setMessage(`${deleteCount} media item${deleteCount === 1 ? '' : 's'} deleted.`);

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -32,6 +32,7 @@ import {
   uploadParentTeamMediaFile,
   uploadParentTeamMediaPhoto,
   deleteTeamMediaItemForApp,
+  bulkDeleteTeamMediaItemsForApp,
   updateTeamMediaItemForApp,
   moveTeamMediaItemForApp,
   type TeamMediaFolder,
@@ -47,6 +48,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const [model, setModel] = useState<TeamMediaModel | null>(null);
   const [activeFolderId, setActiveFolderId] = useState('');
   const [selectedMediaType, setSelectedMediaType] = useState<MediaTypeFilter>('all');
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
   const [linkTitle, setLinkTitle] = useState('');
   const [linkUrl, setLinkUrl] = useState('');
   const [albumName, setAlbumName] = useState('');
@@ -75,6 +77,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
         if (current && nextModel.folders.some((folder) => folder.id === current)) return current;
         return nextModel.folders[0]?.id || '';
       });
+      setSelectedIds((current) => current.filter((itemId) => nextModel.folders.some((folder) => folder.items.some((item) => item.id === itemId))));
     } catch (loadError: any) {
       setError(loadError?.message || 'Unable to load media.');
       if (showLoading) setModel(null);
@@ -204,9 +207,41 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const allItems = useMemo(() => model?.folders.flatMap((folder) => folder.items.map((item) => ({ ...item, folderName: folder.name || 'Album' }))) || [], [model]);
   const mediaTypeCounts = useMemo(() => getMediaTypeCounts(activeFolder?.items || []), [activeFolder]);
   const filteredItems = useMemo(() => (activeFolder?.items || []).filter((item) => matchesMediaTypeFilter(item, selectedMediaType)), [activeFolder, selectedMediaType]);
+  const visibleItemIds = useMemo(() => filteredItems.map((item) => item.id).filter(Boolean), [filteredItems]);
+  const selectedCount = selectedIds.length;
   const selectedMediaTypeLabel = MEDIA_TYPE_FILTERS.find((filter) => filter.id === selectedMediaType)?.label || 'All';
   const emptyStateLabel = selectedMediaType === 'all' ? 'media' : selectedMediaTypeLabel.toLowerCase();
   const featured = activeFolder?.items[0] || allItems[0] || null;
+
+  useEffect(() => {
+    setSelectedIds((current) => current.filter((itemId) => visibleItemIds.includes(itemId)));
+  }, [visibleItemIds]);
+
+  const toggleItemSelection = (itemId: string, checked: boolean) => {
+    if (!itemId || !model?.canManage) return;
+    setSelectedIds((current) => checked ? current.includes(itemId) ? current : [...current, itemId] : current.filter((selectedId) => selectedId !== itemId));
+  };
+
+  const handleBulkDelete = async () => {
+    if (!teamId || !selectedIds.length) return;
+    const deleteCount = selectedIds.length;
+    const confirmed = window.confirm(`Are you sure you want to delete ${deleteCount} media item${deleteCount === 1 ? '' : 's'}? This cannot be undone.`);
+    if (!confirmed) return;
+
+    setDeletingItemId('__bulk__');
+    setError('');
+    setMessage('');
+    try {
+      await bulkDeleteTeamMediaItemsForApp(teamId, selectedIds);
+      setSelectedIds([]);
+      await refresh({ showLoading: false, preferredFolderId: activeFolder?.id || '' });
+      setMessage(`${deleteCount} media item${deleteCount === 1 ? '' : 's'} deleted.`);
+    } catch (deleteError: any) {
+      setError(deleteError?.message || 'Unable to delete selected media items.');
+    } finally {
+      setDeletingItemId('');
+    }
+  };
 
   const updateUploadQueueItem = (id: string, nextStatus: UploadQueueItem['status'], errorMessage = '') => {
     setUploadQueue((current) => current.map((item) => item.id === id ? { ...item, status: nextStatus, errorMessage } : item));
@@ -399,6 +434,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
               onClick={() => {
                 setActiveFolderId(folder.id);
                 setSelectedMediaType('all');
+                setSelectedIds([]);
               }}
               aria-pressed={activeFolder?.id === folder.id}
             >
@@ -520,7 +556,10 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
               key={filter.id}
               type="button"
               className={`flex min-h-9 flex-none items-center gap-2 rounded-full border px-3 text-xs font-black ${selectedMediaType === filter.id ? 'border-primary-600 bg-primary-600 text-white' : 'border-gray-200 bg-gray-50 text-gray-700'}`}
-              onClick={() => setSelectedMediaType(filter.id)}
+              onClick={() => {
+                setSelectedMediaType(filter.id);
+                setSelectedIds([]);
+              }}
               aria-pressed={selectedMediaType === filter.id}
             >
               {filter.label}
@@ -528,6 +567,26 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
             </button>
           ))}
         </div>
+        {model.canManage ? (
+          <div className="mt-3 rounded-2xl border border-gray-200 bg-gray-50 p-3" aria-label="Selected media actions">
+            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <div className="text-xs font-black uppercase tracking-wide text-gray-600">Bulk actions</div>
+                <div className="text-sm font-semibold text-gray-700">{selectedCount} selected in this view</div>
+              </div>
+              <button
+                type="button"
+                className="ghost-button justify-center text-rose-700 hover:bg-rose-50 disabled:opacity-60"
+                onClick={handleBulkDelete}
+                disabled={!selectedCount || deletingItemId === '__bulk__'}
+                aria-disabled={!selectedCount || deletingItemId === '__bulk__'}
+              >
+                {deletingItemId === '__bulk__' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Trash2 className="h-4 w-4" aria-hidden="true" />}
+                {deletingItemId === '__bulk__' ? 'Deleting selected' : 'Delete selected'}
+              </button>
+            </div>
+          </div>
+        ) : null}
         <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
           {filteredItems.length ? filteredItems.map((item) => (
             <TeamMediaItemCard
@@ -540,9 +599,12 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
               folders={model.folders}
               currentFolderId={activeFolder?.id || ''}
               deleting={deletingItemId === item.id}
+              selectable={model.canManage}
+              selected={selectedIds.includes(item.id)}
               renaming={renamingItemId === item.id}
               moving={movingItemId === item.id}
               posting={postingItemId === item.id}
+              onToggleSelected={toggleItemSelection}
               onRenameItem={handleRenameItem}
               onDeleteItem={handleDeleteItem}
               onMoveItem={handleMoveItem}
@@ -638,9 +700,12 @@ function TeamMediaItemCard({
   folders,
   currentFolderId,
   deleting,
+  selectable,
+  selected,
   renaming,
   moving,
   posting,
+  onToggleSelected,
   onRenameItem,
   onDeleteItem,
   onMoveItem,
@@ -654,9 +719,12 @@ function TeamMediaItemCard({
   folders: TeamMediaFolder[];
   currentFolderId: string;
   deleting: boolean;
+  selectable: boolean;
+  selected: boolean;
   renaming: boolean;
   moving: boolean;
   posting: boolean;
+  onToggleSelected: (itemId: string, checked: boolean) => void;
   onRenameItem: (item: TeamMediaItem, title: string) => Promise<void>;
   onDeleteItem: (item: TeamMediaItem) => void;
   onMoveItem: (item: TeamMediaItem, targetFolderId: string) => Promise<void>;
@@ -738,8 +806,19 @@ function TeamMediaItemCard({
   };
 
   return (
-    <article className="overflow-hidden rounded-xl border border-gray-200 bg-white transition hover:border-primary-200 hover:shadow-app">
-      <div className="aspect-video bg-gray-100">
+    <article className={`overflow-hidden rounded-xl border bg-white transition hover:border-primary-200 hover:shadow-app ${selected ? 'border-primary-500 ring-2 ring-primary-100' : 'border-gray-200'}`}>
+      <div className="relative aspect-video bg-gray-100">
+        {selectable ? (
+          <label className="absolute left-2 top-2 z-10 flex items-center gap-2 rounded-full bg-white/95 px-2 py-1 text-[11px] font-black text-gray-700 shadow-sm">
+            <input
+              type="checkbox"
+              checked={selected}
+              onChange={(event) => onToggleSelected(item.id, event.target.checked)}
+              aria-label={`Select ${title}`}
+            />
+            Select
+          </label>
+        ) : null}
         {isPhoto ? (
           <img src={item.url} alt="" className="h-full w-full object-cover" loading="lazy" />
         ) : (

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -248,6 +248,9 @@ async function mockParentToolsModules(page) {
                     await new Promise((resolve) => setTimeout(resolve, 50));
                     return undefined;
                 }
+                export async function bulkDeleteTeamMediaItemsForApp() {
+                    return undefined;
+                }
                 export async function updateTeamMediaItemForApp() {
                     return undefined;
                 }

--- a/tests/unit/app-search-integration.test.jsx
+++ b/tests/unit/app-search-integration.test.jsx
@@ -188,9 +188,10 @@ afterEach(() => {
 });
 
 describe('React app shell search', () => {
-    it('loads actions and visible teams, searches players, and navigates native results', async () => {
+    it('renders a mobile search trigger with a stable text label and opens search results', async () => {
         const { container } = await renderShell();
 
+        expect(buttonByText(container, 'Search').textContent).toContain('Search');
         await clickButton(container, 'Search');
         await waitForText(container, 'Browse Teams');
         expect(container.textContent).toContain('Bears');

--- a/tests/unit/app-team-media.test.jsx
+++ b/tests/unit/app-team-media.test.jsx
@@ -6,6 +6,7 @@ import { MemoryRouter, Route, Routes } from '../../apps/app/node_modules/react-r
 
 const parentToolsServiceMocks = vi.hoisted(() => ({
   addParentTeamMediaLink: vi.fn(),
+  bulkDeleteTeamMediaItemsForApp: vi.fn(),
   createTeamMediaAlbumForApp: vi.fn(),
   loadTeamMediaForApp: vi.fn(),
   uploadParentTeamMediaFile: vi.fn(),
@@ -129,6 +130,7 @@ function changeFiles(input, files) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  parentToolsServiceMocks.bulkDeleteTeamMediaItemsForApp.mockResolvedValue(undefined);
   parentToolsServiceMocks.updateTeamMediaItemForApp.mockResolvedValue(undefined);
   parentToolsServiceMocks.moveTeamMediaItemForApp.mockResolvedValue(undefined);
   chatServiceMocks.sendTeamChatMessage.mockResolvedValue({ conversationId: 'team', createdConversation: null, wantsAi: false });
@@ -136,6 +138,35 @@ beforeEach(() => {
 
 afterEach(() => {
   document.body.innerHTML = '';
+});
+
+describe('React app TeamMedia bulk delete flow', () => {
+  it('passes full media items to the bulk delete helper so storage objects can be removed', async () => {
+    globalThis.confirm = vi.fn(() => true);
+    const { container, root } = await renderTeamMedia(mediaModel({ canManage: true }));
+
+    click(container.querySelector('[aria-label="Select Tipoff"]'));
+    click(container.querySelector('[aria-label="Select Scouting PDF"]'));
+    const deleteSelectedButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent.includes('Delete selected'));
+    await act(async () => {
+      deleteSelectedButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(parentToolsServiceMocks.bulkDeleteTeamMediaItemsForApp).toHaveBeenCalledWith('team-1', [
+      expect.objectContaining({
+        id: 'owned-photo',
+        type: 'photo',
+        url: 'https://example.test/tipoff.jpg',
+      }),
+      expect.objectContaining({
+        id: 'other-file',
+        type: 'file',
+        url: 'https://example.test/scout.pdf',
+      }),
+    ]);
+
+    await act(async () => root.unmount());
+  });
 });
 
 describe('React app TeamMedia rename flow', () => {


### PR DESCRIPTION
Closes #1671

- add a TeamMedia bulk selection state with manager-only checkboxes and a sticky bulk action bar on the active album view
- wire a new `bulkDeleteTeamMediaItemsForApp` helper to the existing shared `bulkDeleteTeamMediaItems` data-layer helper
- keep album/filter context after delete, clear selection on success, preserve selection on failure, and cover the flow with focused TeamMedia page tests