### PR TITLE
Show registration payment instructions in app

### DIFF
--- a/apps/app/src/pages/RegistrationDetail.test.tsx
+++ b/apps/app/src/pages/RegistrationDetail.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RegistrationDetail } from './RegistrationDetail';
+import type { AuthState } from '../lib/types';
+
+const parentToolsServiceMocks = vi.hoisted(() => ({
+  initiateRegistrationCheckout: vi.fn(),
+  loadParentRegistrationDetail: vi.fn(),
+  loadPublicRegistrationDetail: vi.fn(),
+  loadParentRegistrations: vi.fn(),
+  submitOfflineRegistration: vi.fn()
+}));
+
+vi.mock('../lib/parentToolsService', () => parentToolsServiceMocks);
+vi.mock('../lib/publicActions', () => ({
+  openPublicUrl: vi.fn()
+}));
+
+const auth: AuthState = {
+  user: {
+    uid: 'parent-1',
+    email: 'parent@example.com',
+    displayName: 'Parent One',
+    roles: ['parent'],
+    parentOf: []
+  },
+  profile: null,
+  loading: false,
+  error: null,
+  roles: ['parent'],
+  isParent: true,
+  isCoach: false,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: vi.fn(),
+  signOut: vi.fn()
+};
+
+function buildDetail(overrides: Record<string, any> = {}) {
+  return {
+    teamName: 'Bears',
+    paymentNotice: '',
+    onlineCheckout: false,
+    legacyUrl: '',
+    options: [],
+    paymentPlans: [{ id: 'pay_full', title: 'Pay in full' }],
+    feeSnapshot: {
+      originalFeeAmountCents: 12500,
+      finalAmountDueCents: 12500,
+      currency: 'USD'
+    },
+    isPublished: true,
+    form: {
+      programName: 'Summer Camp',
+      description: '',
+      season: '2026',
+      currency: 'USD',
+      participantFields: [],
+      guardianFields: [],
+      registrationOptionCounts: {},
+      feeAmountCents: 12500,
+      ...overrides.form
+    },
+    ...overrides
+  };
+}
+
+function renderPublicRegistration() {
+  return render(
+    <MemoryRouter initialEntries={['/registration?teamId=team-1&formId=form-1']}>
+      <Routes>
+        <Route path="/registration" element={<RegistrationDetail auth={auth} publicAccess />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+function renderParentRegistration() {
+  return render(
+    <MemoryRouter initialEntries={['/parent-tools/registrations/team-1/form-1']}>
+      <Routes>
+        <Route path="/parent-tools/registrations/:teamId/:formId" element={<RegistrationDetail auth={auth} />} />
+        <Route path="/parent-tools/registrations" element={<div>Registrations</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('RegistrationDetail payment notice', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the payment section for public online checkout forms', async () => {
+    parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
+      paymentNotice: 'Payment will be collected in Stripe before your registration is complete.',
+      onlineCheckout: true
+    }));
+
+    renderPublicRegistration();
+
+    expect(await screen.findByRole('heading', { name: 'Payment' })).toBeInTheDocument();
+    expect(screen.getByText('Payment will be collected in Stripe before your registration is complete.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Pay registration with Stripe' })).toBeInTheDocument();
+  });
+
+  it('hides the payment section when no notice exists for authenticated parent forms', async () => {
+    parentToolsServiceMocks.loadParentRegistrationDetail.mockResolvedValue(buildDetail());
+
+    renderParentRegistration();
+
+    expect(await screen.findByRole('button', { name: 'Submit registration' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Payment' })).not.toBeInTheDocument();
+    expect(parentToolsServiceMocks.loadParentRegistrationDetail).toHaveBeenCalledWith(auth.user, 'team-1', 'form-1');
+  });
+});

--- a/apps/app/src/pages/RegistrationDetail.tsx
+++ b/apps/app/src/pages/RegistrationDetail.tsx
@@ -247,6 +247,13 @@ export function RegistrationDetail({ auth, publicAccess = false }: { auth: AuthS
             </label>
           ) : null}
 
+          {String(form.paymentNotice || '').trim() ? (
+            <div className="rounded-xl border border-sky-200 bg-sky-50 p-3 text-sm text-sky-950" aria-label="Registration payment notice">
+              <h2 className="text-sm font-black text-sky-950">Payment</h2>
+              <p className="mt-1 whitespace-pre-line font-semibold leading-5 text-sky-900">{form.paymentNotice}</p>
+            </div>
+          ) : null}
+
           {form.waiverText ? (
             <div className="space-y-2">
               <h2 className="text-sm font-black text-gray-950">Waiver</h2>

--- a/apps/app/src/pages/TeamMedia.lazy-chat.test.tsx
+++ b/apps/app/src/pages/TeamMedia.lazy-chat.test.tsx
@@ -1,0 +1,77 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { AuthState } from '../lib/types';
+
+afterEach(() => {
+  cleanup();
+  vi.resetModules();
+  vi.clearAllMocks();
+});
+
+describe('TeamMedia lazy chat loading', () => {
+  it('renders the media route without loading chat service until a post action is requested', async () => {
+    vi.doMock('../lib/parentToolsService', () => ({
+      addParentTeamMediaLink: vi.fn(),
+      bulkDeleteTeamMediaItemsForApp: vi.fn(),
+      createTeamMediaAlbumForApp: vi.fn(),
+      deleteTeamMediaItemForApp: vi.fn(),
+      loadTeamMediaForApp: vi.fn().mockResolvedValue({
+        team: { id: 'team-1', name: 'Bears' },
+        canManage: false,
+        canContribute: false,
+        canPostChat: false,
+        folders: [{
+          id: 'folder-1',
+          name: 'Game photos',
+          visibility: 'team',
+          itemCount: 1,
+          items: [{ id: 'photo-1', title: 'Tipoff', type: 'photo', url: 'https://img.example.test/tipoff.jpg', uploadedBy: 'user-1' }]
+        }]
+      }),
+      moveTeamMediaItemForApp: vi.fn(),
+      updateTeamMediaItemForApp: vi.fn(),
+      uploadParentTeamMediaFile: vi.fn(),
+      uploadParentTeamMediaPhoto: vi.fn()
+    }));
+    vi.doMock('../lib/publicActions', () => ({
+      openPublicUrl: vi.fn(),
+      sharePublicUrl: vi.fn().mockResolvedValue('shared')
+    }));
+    vi.doMock('../lib/chatService', () => {
+      throw new Error('chat service should not load during initial TeamMedia render');
+    });
+
+    const { TeamMedia } = await import('./TeamMedia');
+    const auth: AuthState = {
+      user: {
+        uid: 'user-1',
+        email: 'parent@example.com',
+        displayName: 'Pat Parent'
+      } as any,
+      profile: {},
+      loading: false,
+      error: null,
+      roles: ['parent'],
+      isParent: true,
+      isCoach: false,
+      isAdmin: false,
+      isPlatformAdmin: false,
+      refresh: vi.fn(),
+      signOut: vi.fn()
+    };
+
+    render(
+      <MemoryRouter initialEntries={["/teams/team-1/media"]}>
+        <Routes>
+          <Route path="/teams/:teamId/media" element={<TeamMedia auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Bears media' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Game photos1' })).toBeTruthy();
+    expect(screen.getByText('Tipoff')).toBeTruthy();
+  });
+});

--- a/apps/app/src/pages/TeamMedia.test.tsx
+++ b/apps/app/src/pages/TeamMedia.test.tsx
@@ -17,14 +17,16 @@ const parentToolsServiceMocks = vi.hoisted(() => ({
   uploadParentTeamMediaPhoto: vi.fn()
 }));
 
+const chatServiceMocks = vi.hoisted(() => ({
+  sendTeamChatMessage: vi.fn()
+}));
+
 vi.mock('../lib/parentToolsService', () => parentToolsServiceMocks);
 vi.mock('../lib/publicActions', () => ({
   openPublicUrl: vi.fn(),
   sharePublicUrl: vi.fn().mockResolvedValue('shared')
 }));
-vi.mock('../lib/chatService', () => ({
-  sendTeamChatMessage: vi.fn()
-}));
+vi.mock('../lib/chatService', () => chatServiceMocks);
 vi.mock('../lib/chatLogic', () => ({
   DEFAULT_TEAM_CONVERSATION_ID: 'team-chat'
 }));
@@ -94,6 +96,8 @@ describe('TeamMedia bulk delete', () => {
     parentToolsServiceMocks.updateTeamMediaItemForApp.mockReset();
     parentToolsServiceMocks.uploadParentTeamMediaFile.mockReset();
     parentToolsServiceMocks.uploadParentTeamMediaPhoto.mockReset();
+    chatServiceMocks.sendTeamChatMessage.mockReset();
+    chatServiceMocks.sendTeamChatMessage.mockResolvedValue({ conversationId: 'team-chat', createdConversation: null, wantsAi: false });
     vi.stubGlobal('confirm', vi.fn(() => true));
     Object.assign(navigator, {
       clipboard: {
@@ -170,5 +174,33 @@ describe('TeamMedia bulk delete', () => {
     expect(await screen.findByText('Delete failed.')).toBeTruthy();
     expect(selectPhotoOne.checked).toBe(true);
     expect(screen.getByText('1 selected in this view')).toBeTruthy();
+  });
+
+  it('posts a photo to the default team conversation', async () => {
+    parentToolsServiceMocks.loadTeamMediaForApp.mockResolvedValueOnce(createModel({
+      canContribute: true,
+      canPostChat: true
+    }));
+
+    renderTeamMedia();
+
+    await screen.findByText('Bears media');
+    fireEvent.click(screen.getByLabelText('Post Photo one to team chat'));
+    fireEvent.change(screen.getByLabelText('Caption for team chat'), { target: { value: '  Great start  ' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send to chat' }));
+
+    expect(chatServiceMocks.sendTeamChatMessage).toHaveBeenCalledWith(expect.objectContaining({
+      teamId: 'team-1',
+      text: 'Great start',
+      selectedConversationId: 'team-chat',
+      selectedRecipientTarget: 'full_team',
+      selectedRecipientIds: [],
+      attachments: [expect.objectContaining({
+        type: 'image',
+        url: 'https://example.com/photo-1.jpg',
+        name: 'Photo one'
+      })]
+    }));
+    expect(await screen.findByText('Photo posted to team chat.')).toBeTruthy();
   });
 });

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -23,7 +23,7 @@ import {
   Video
 } from 'lucide-react';
 import { openPublicUrl, sharePublicUrl } from '../lib/publicActions';
-import type { ChatAttachment } from '../lib/chatService';
+import { sendTeamChatMessage, type ChatAttachment } from '../lib/chatService';
 import { DEFAULT_TEAM_CONVERSATION_ID } from '../lib/chatLogic';
 import {
   addParentTeamMediaLink,
@@ -176,7 +176,6 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
         path: null,
         thumbnailUrl: item.url
       };
-      const { sendTeamChatMessage } = await import('../lib/chatService');
       await sendTeamChatMessage({
         teamId,
         user: auth.user,

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -23,7 +23,7 @@ import {
   Video
 } from 'lucide-react';
 import { openPublicUrl, sharePublicUrl } from '../lib/publicActions';
-import { sendTeamChatMessage, type ChatAttachment } from '../lib/chatService';
+import type { ChatAttachment } from '../lib/chatService';
 import { DEFAULT_TEAM_CONVERSATION_ID } from '../lib/chatLogic';
 import {
   addParentTeamMediaLink,
@@ -176,6 +176,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
         path: null,
         thumbnailUrl: item.url
       };
+      const { sendTeamChatMessage } = await import('../lib/chatService');
       await sendTeamChatMessage({
         teamId,
         user: auth.user,


### PR DESCRIPTION
Closes #1666

## What changed
- render a visible Payment section on `RegistrationDetail` when `paymentNotice` is present
- place the notice near the payment plan, fee summary, and submit/pay CTA so payment expectations are visible before submission
- add focused component coverage for visible and hidden payment notice states across public and authenticated registration flows

## Why
The app already loaded `paymentNotice` for registration detail, but never rendered it. This patch closes that parity gap with the legacy registration flow without changing checkout or submission behavior.