### PR TITLE
Use device locale for team chat dictation

### DIFF
--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -998,6 +998,7 @@ function ChatWindow({
     }
 
     setStatus(null);
+    const dictationLanguage = typeof navigator !== 'undefined' ? navigator.language || 'en-US' : 'en-US';
 
     if (voiceRecognition.isNativeRuntime()) {
       try {
@@ -1041,7 +1042,7 @@ function ChatWindow({
         });
         voiceListenerHandlesRef.current = [partialHandle, stateHandle, errorHandle];
         const result = await voiceRecognition.start({
-          language: 'en-US',
+          language: dictationLanguage,
           maxResults: 1,
           partialResults: true,
           addPunctuation: true,
@@ -1070,7 +1071,7 @@ function ChatWindow({
       return;
     }
     const recognition = new BrowserSpeechRecognition();
-    recognition.lang = 'en-US';
+    recognition.lang = dictationLanguage;
     recognition.interimResults = true;
     recognition.continuous = false;
     recognition.onresult = (speechEvent: any) => {

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -215,18 +215,22 @@ test.describe('app global search', () => {
 test.describe('desktop app global search', () => {
     test.use({ viewport: { width: 1440, height: 900 }, hasTouch: false });
 
+    async function openDesktopSearch(page) {
+        await page.getByRole('button', { name: 'Search' }).click();
+        await expect(page.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeVisible();
+    }
+
     test('desktop search supports native navigation and website actions', async ({ page, baseURL }) => {
         await mockSearchModules(page);
         await page.goto(appUrl(baseURL, '/home'), { waitUntil: 'domcontentloaded' });
 
-        await page.getByRole('button', { name: 'Search' }).click();
-        await expect(page.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeVisible();
+        await openDesktopSearch(page);
         await page.getByLabel('Search teams, players, actions, help').fill('rock');
         await expect(page.getByRole('button', { name: /Rockets/ })).toBeVisible();
         await page.getByRole('button', { name: /Rockets/ }).click();
         await expect(page).toHaveURL(/#\/teams\/team-2$/);
 
-        await page.getByRole('button', { name: 'Search' }).click();
+        await openDesktopSearch(page);
         await page.getByRole('button', { name: /Browse Teams/ }).click();
         await expect.poll(() => page.evaluate(() => window.__openedPublicUrls)).toEqual(['https://allplays.ai/teams.html']);
     });
@@ -235,7 +239,7 @@ test.describe('desktop app global search', () => {
         await mockSearchModules(page);
         await page.goto(appUrl(baseURL, '/home'), { waitUntil: 'domcontentloaded' });
 
-        await page.getByRole('button', { name: 'Search' }).click();
+        await openDesktopSearch(page);
         await page.getByLabel('Search teams, players, actions, help').fill('live tracker');
         await expect(page.getByRole('button', { name: /Track Live Games with the Live Tracker/ })).toBeVisible();
         await expect(page.getByRole('button', { name: /Watch Live Games and Replays/ })).toBeVisible();
@@ -253,13 +257,13 @@ test.describe('desktop app global search', () => {
         await mockSearchModules(page);
         await page.goto(appUrl(baseURL, '/home'), { waitUntil: 'domcontentloaded' });
 
-        await page.getByRole('button', { name: 'Search' }).click();
+        await openDesktopSearch(page);
         await page.getByLabel('Search teams, players, actions, help').fill('my');
         await expect(page.getByRole('button', { name: /My Teams/ })).toBeVisible();
         await page.keyboard.press('Enter');
         await expect(page).toHaveURL(/#\/teams$/);
 
-        await page.getByRole('button', { name: 'Search' }).click();
+        await openDesktopSearch(page);
         await page.keyboard.press('ArrowDown');
         await page.keyboard.press('ArrowDown');
         await page.keyboard.press('Enter');

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -241,6 +241,10 @@ beforeEach(() => {
             writeText: vi.fn(async () => {})
         }
     });
+    Object.defineProperty(navigator, 'language', {
+        configurable: true,
+        value: 'en-US'
+    });
     window.requestAnimationFrame = (callback) => {
         callback(0);
         return 0;
@@ -850,7 +854,7 @@ describe('React app messages integration', () => {
         expect(container.querySelector('button[aria-label="Voice to text"]')).toBeNull();
     });
 
-    it('uses browser speech dictation to fill the composer and return to the compact toolbar state', async () => {
+    it('uses the browser locale for web voice dictation and returns to the compact toolbar state', async () => {
         let recognitionInstance;
         class MockSpeechRecognition {
             constructor() {
@@ -862,6 +866,10 @@ describe('React app messages integration', () => {
             }
         }
 
+        Object.defineProperty(navigator, 'language', {
+            configurable: true,
+            value: 'es-MX'
+        });
         voiceMocks.hasBrowserSupport.mockReturnValue(true);
         Object.defineProperty(window, 'webkitSpeechRecognition', {
             configurable: true,
@@ -871,6 +879,7 @@ describe('React app messages integration', () => {
         const { container } = await renderMessages('/messages/team-1');
 
         await click(container, 'Voice to text');
+        expect(recognitionInstance.lang).toBe('es-MX');
         expect(recognitionInstance.start).toHaveBeenCalled();
         expect(container.textContent).toContain('Listening...');
 
@@ -895,7 +904,41 @@ describe('React app messages integration', () => {
         expect(container.textContent).not.toContain('Listening...');
     });
 
-    it('keeps native dictation listening when iOS resolves start without a result payload', async () => {
+    it('falls back to en-US for browser voice dictation when navigator.language is empty', async () => {
+        let recognitionInstance;
+        class MockSpeechRecognition {
+            constructor() {
+                recognitionInstance = this;
+                this.start = vi.fn();
+                this.stop = vi.fn(() => {
+                    this.onend?.();
+                });
+            }
+        }
+
+        Object.defineProperty(navigator, 'language', {
+            configurable: true,
+            value: ''
+        });
+        voiceMocks.hasBrowserSupport.mockReturnValue(true);
+        Object.defineProperty(window, 'webkitSpeechRecognition', {
+            configurable: true,
+            value: MockSpeechRecognition
+        });
+
+        const { container } = await renderMessages('/messages/team-1');
+
+        await click(container, 'Voice to text');
+
+        expect(recognitionInstance.lang).toBe('en-US');
+        expect(recognitionInstance.start).toHaveBeenCalled();
+    });
+
+    it('passes the device locale to native dictation and keeps listening when iOS resolves start without a result payload', async () => {
+        Object.defineProperty(navigator, 'language', {
+            configurable: true,
+            value: 'fr-CA'
+        });
         nativeMocks.isNativePlatform = true;
         voiceMocks.start.mockResolvedValue(undefined);
         const { container } = await renderMessages('/messages/team-1');
@@ -904,6 +947,7 @@ describe('React app messages integration', () => {
         await click(container, 'Voice to text');
 
         expect(voiceMocks.start).toHaveBeenCalledWith(expect.objectContaining({
+            language: 'fr-CA',
             partialResults: true
         }));
         expect(container.textContent).toContain('Listening...');
@@ -917,5 +961,21 @@ describe('React app messages integration', () => {
         const textarea = container.querySelector('textarea');
         expect(textarea.value).toBe('Leaving now');
         expect(container.querySelector('button[aria-label="Stop voice input"]')).toBeTruthy();
+    });
+
+    it('falls back to en-US for native dictation when navigator.language is empty', async () => {
+        Object.defineProperty(navigator, 'language', {
+            configurable: true,
+            value: ''
+        });
+        nativeMocks.isNativePlatform = true;
+        voiceMocks.start.mockResolvedValue(undefined);
+        const { container } = await renderMessages('/messages/team-1');
+
+        await click(container, 'Voice to text');
+
+        expect(voiceMocks.start).toHaveBeenCalledWith(expect.objectContaining({
+            language: 'en-US'
+        }));
     });
 });


### PR DESCRIPTION
Closes #1688

## What changed
- Updated team chat voice dictation in `apps/app/src/pages/Messages.tsx` to use `navigator.language` when available for both browser and native speech recognition.
- Kept `en-US` as the fallback only when the device/browser locale is missing or empty.
- Added focused regression coverage in `tests/unit/app-chat-messages-integration.test.jsx` for both browser and native dictation paths, including locale and fallback behavior.

## Why
Team chat dictation was hard-coded to `en-US`, which caused avoidable misrecognition for users whose device language is different. This keeps the mic flow one tap to start and one tap to stop while aligning dictation with the user device locale by default.