### PR TITLE
Add in-app help portal with role-filtered search

### DIFF
--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -9,6 +9,7 @@ const AcceptInvite = lazy(() => import('./pages/AcceptInvite').then((module) => 
 const CapabilityPage = lazy(() => import('./pages/CapabilityPage').then((module) => ({ default: module.CapabilityPage })));
 const GameDetail = lazy(() => import('./pages/GameDetail').then((module) => ({ default: module.GameDetail })));
 const HelpArticle = lazy(() => import('./pages/HelpArticle').then((module) => ({ default: module.HelpArticle })));
+const HelpPortal = lazy(() => import('./pages/HelpPortal').then((module) => ({ default: module.HelpPortal })));
 const Home = lazy(() => import('./pages/Home').then((module) => ({ default: module.Home })));
 const Messages = lazy(() => import('./pages/Messages').then((module) => ({ default: module.Messages })));
 const ParentTools = lazy(() => import('./pages/ParentTools').then((module) => ({ default: module.ParentTools })));
@@ -58,6 +59,7 @@ export default function App() {
         <Route path="/players/:teamId/:playerId" element={<Protected auth={auth}><PlayerDetail auth={auth} /></Protected>} />
         <Route path="/players/:playerId" element={<Protected auth={auth}><PlayerDetail auth={auth} /></Protected>} />
         <Route path="/games/:gameId" element={<Protected auth={auth}><GameDetail auth={auth} /></Protected>} />
+        <Route path="/help" element={<Protected auth={auth}><HelpPortal /></Protected>} />
         <Route path="/help/:helpId" element={<Protected auth={auth}><HelpArticle /></Protected>} />
         <Route path="/profile" element={<Protected auth={auth}><Profile auth={auth} /></Protected>} />
         <Route path="/capabilities/:capabilityId" element={<Protected auth={auth}><CapabilityPage /></Protected>} />

--- a/apps/app/src/data/capabilities.ts
+++ b/apps/app/src/data/capabilities.ts
@@ -66,7 +66,7 @@ export const capabilities: Capability[] = [
   capability('widget-scoreboard', 'Scoreboard widget', 'widget-scoreboard.html', 'Public', 'Public scoreboard widget, team games, team link, and read-only embed.', ['Scoreboard widget', 'Team games', 'Team link', 'Read-only embed']),
   capability('changelog', 'Changelog', 'changelog.html', 'Help', 'Release notes and product updates.', ['Release notes', 'Product updates']),
 
-  capability('help', 'Help portal', 'help.html', 'Help', 'Workflow search, role filters, and help routing.', ['Workflow search', 'Role filters', 'Help routing']),
+  capability('help', 'Help portal', 'help.html', 'Help', 'Workflow search, role filters, and help routing.', ['Workflow search', 'Role filters', 'Help routing'], '/help', 'native-shell'),
   capability('help-account', 'Account help', 'help-account.html', 'Help', 'Account help, access help, and role ownership.', ['Account help', 'Access help', 'Role ownership']),
   capability('help-team-operations', 'Team operations help', 'help-team-operations.html', 'Help', 'Team operations, roster, and schedule help.', ['Team operations', 'Roster help', 'Schedule help']),
   capability('help-game-operations', 'Game operations help', 'help-game-operations.html', 'Help', 'Game operations, tracking, and postgame help.', ['Game operations', 'Tracking help', 'Postgame help']),

--- a/apps/app/src/lib/helpKnowledgeService.ts
+++ b/apps/app/src/lib/helpKnowledgeService.ts
@@ -88,13 +88,14 @@ export function searchHelpKnowledge({
   roleFilter?: HelpKnowledgeRoleFilter;
   limit?: number;
 }): HelpKnowledgeResult[] {
+  const docs = getHelpKnowledgeDocs();
   const cleanQuery = compactText(query);
   const queryTokens = tokenize(cleanQuery);
   const roleTokens = normalizeRoles(roles);
   const [normalizedRoleFilter] = normalizeRoles([roleFilter]);
-  const maxResults = Math.min(Math.max(Number(limit) || 5, 1), 8);
+  const maxResults = Math.min(Math.max(Number(limit) || 5, 1), Math.max(docs.length, 1));
 
-  return getHelpKnowledgeDocs()
+  return docs
     .filter((doc) => normalizedRoleFilter
       ? roleFilterMatches(doc.roles, normalizedRoleFilter)
       : (!roleTokens.length || roleMatches(doc.roles, roleTokens)))

--- a/apps/app/src/pages/HelpArticle.tsx
+++ b/apps/app/src/pages/HelpArticle.tsx
@@ -1,16 +1,18 @@
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { ArrowLeft, Home, Search } from 'lucide-react';
 import { getHelpKnowledgeDocs } from '../lib/helpKnowledgeService';
 
 export function HelpArticle() {
   const { helpId = '' } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
+  const helpPortalState = normalizeHelpPortalState(location.state);
   const helpDoc = getHelpKnowledgeDocs().find((doc) => doc.id === helpId);
 
   if (!helpDoc) {
     return (
       <div className="space-y-4">
-        <BackButton />
+        <BackButton helpPortalState={helpPortalState} />
         <section className="app-card p-5 text-center">
           <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-primary-50 text-primary-700">
             <Search className="h-5 w-5" aria-hidden="true" />
@@ -20,9 +22,19 @@ export function HelpArticle() {
             This help article is not packaged in the app yet. Try another search result or head back home.
           </p>
           <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:justify-center">
-            <button type="button" className="primary-button justify-center" onClick={() => navigate(-1)}>
-              Back to search
-            </button>
+            {helpPortalState.fromHelpPortal ? (
+              <button
+                type="button"
+                className="primary-button justify-center"
+                onClick={() => navigate('/help', { state: helpPortalState })}
+              >
+                Back to Help Portal
+              </button>
+            ) : (
+              <button type="button" className="primary-button justify-center" onClick={() => navigate(-1)}>
+                Back to search
+              </button>
+            )}
             <Link to="/home" className="ghost-button justify-center">
               <Home className="h-4 w-4" aria-hidden="true" />
               Home
@@ -37,7 +49,7 @@ export function HelpArticle() {
 
   return (
     <div className="space-y-4">
-      <BackButton />
+      <BackButton helpPortalState={helpPortalState} />
 
       <article className="app-card overflow-hidden">
         <header className="border-b border-gray-200 bg-gradient-to-r from-primary-50 to-white p-5">
@@ -65,15 +77,33 @@ export function HelpArticle() {
   );
 }
 
-function BackButton() {
+function BackButton({ helpPortalState }: { helpPortalState: ReturnType<typeof normalizeHelpPortalState> }) {
   const navigate = useNavigate();
 
+  const handleBack = () => {
+    if (helpPortalState.fromHelpPortal) {
+      navigate('/help', { state: helpPortalState });
+      return;
+    }
+    navigate(-1);
+  };
+
   return (
-    <button type="button" className="ghost-button" onClick={() => navigate(-1)}>
+    <button type="button" className="ghost-button" onClick={handleBack}>
       <ArrowLeft className="h-4 w-4" aria-hidden="true" />
-      Back
+      {helpPortalState.fromHelpPortal ? 'Back to Help Portal' : 'Back'}
     </button>
   );
+}
+
+function normalizeHelpPortalState(state: unknown) {
+  const candidate = state as { fromHelpPortal?: boolean; helpQuery?: string; helpRoleFilter?: string } | null;
+
+  return {
+    fromHelpPortal: candidate?.fromHelpPortal === true,
+    helpQuery: typeof candidate?.helpQuery === 'string' ? candidate.helpQuery : '',
+    helpRoleFilter: typeof candidate?.helpRoleFilter === 'string' ? candidate.helpRoleFilter : 'all'
+  };
 }
 
 function buildArticleParagraphs(text: string, title: string, summary: string) {

--- a/apps/app/src/pages/HelpPortal.tsx
+++ b/apps/app/src/pages/HelpPortal.tsx
@@ -1,0 +1,176 @@
+import { useMemo, useState } from 'react';
+import { Link, useLocation } from 'react-router-dom';
+import { LifeBuoy, Search } from 'lucide-react';
+import { getHelpKnowledgeDocs, searchHelpKnowledge } from '../lib/helpKnowledgeService';
+
+type HelpPortalRoleFilter = 'all' | 'parent' | 'coach' | 'admin' | 'member';
+
+type HelpPortalListItem = {
+  id: string;
+  title: string;
+  summary: string;
+  roles: string[];
+};
+
+const helpRoleOptions: Array<{ value: HelpPortalRoleFilter; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'parent', label: 'Parent' },
+  { value: 'coach', label: 'Coach' },
+  { value: 'admin', label: 'Admin' },
+  { value: 'member', label: 'Member' }
+];
+
+export function HelpPortal() {
+  const location = useLocation();
+  const initialState = normalizePortalState(location.state);
+  const [query, setQuery] = useState(initialState.helpQuery);
+  const [roleFilter, setRoleFilter] = useState<HelpPortalRoleFilter>(initialState.helpRoleFilter);
+  const helpDocs = useMemo(() => getHelpKnowledgeDocs(), []);
+
+  const visibleDocs = useMemo<HelpPortalListItem[]>(() => {
+    const trimmedQuery = query.trim();
+    if (!trimmedQuery) {
+      return helpDocs.filter((doc) => roleFilterMatches(doc.roles, roleFilter));
+    }
+
+    return searchHelpKnowledge({
+      query: trimmedQuery,
+      roleFilter,
+      limit: helpDocs.length
+    }).map((doc) => ({
+      id: doc.id,
+      title: doc.title,
+      summary: doc.summary,
+      roles: doc.roles
+    }));
+  }, [helpDocs, query, roleFilter]);
+
+  const selectedRoleLabel = helpRoleOptions.find((option) => option.value === roleFilter)?.label || 'All';
+  const hasFilters = Boolean(query.trim()) || roleFilter !== 'all';
+
+  return (
+    <div className="space-y-4">
+      <section className="app-card overflow-hidden">
+        <div className="border-b border-gray-200 bg-gradient-to-r from-primary-50 to-white p-5">
+          <div className="flex items-start gap-3">
+            <div className="flex h-12 w-12 flex-none items-center justify-center rounded-2xl bg-white text-primary-700 shadow-sm ring-1 ring-primary-100">
+              <LifeBuoy className="h-5 w-5" aria-hidden="true" />
+            </div>
+            <div>
+              <div className="text-xs font-extrabold uppercase tracking-[0.04em] text-primary-700">Help portal</div>
+              <h1 className="mt-2 text-2xl font-black text-gray-950">Find guides without leaving the app</h1>
+              <p className="mt-2 text-sm font-semibold leading-6 text-gray-600">
+                Search packaged help content, filter it by role, and open articles directly in ALL PLAYS.
+              </p>
+            </div>
+          </div>
+
+          <div className="mt-4 grid gap-3 md:grid-cols-[minmax(0,1fr)_auto] md:items-end">
+            <label className="block">
+              <span className="mb-1 block text-[11px] font-extrabold uppercase tracking-[0.04em] text-gray-500">Search help</span>
+              <span className="relative block">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-gray-400" aria-hidden="true" />
+                <input
+                  value={query}
+                  onChange={(event) => setQuery(event.target.value)}
+                  placeholder="Search help articles"
+                  aria-label="Search help articles"
+                  className="min-h-11 w-full rounded-xl border border-gray-200 bg-white pl-10 pr-3 text-sm font-semibold outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100"
+                />
+              </span>
+            </label>
+
+            <div>
+              <div className="mb-1 text-[11px] font-extrabold uppercase tracking-[0.04em] text-gray-500">Role filter</div>
+              <div className="flex flex-wrap gap-1.5" aria-label="Filter help by role">
+                {helpRoleOptions.map((option) => (
+                  <button
+                    key={option.value}
+                    type="button"
+                    className={`rounded-full border px-3 py-1 text-xs font-extrabold transition ${
+                      roleFilter === option.value
+                        ? 'border-primary-300 bg-primary-50 text-primary-700'
+                        : 'border-gray-200 bg-white text-gray-600 hover:bg-gray-50'
+                    }`}
+                    aria-pressed={roleFilter === option.value}
+                    onClick={() => setRoleFilter(option.value)}
+                  >
+                    {option.label}
+                  </button>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div className="border-b border-gray-100 px-5 py-3 text-sm font-semibold text-gray-500">
+          {visibleDocs.length} article{visibleDocs.length === 1 ? '' : 's'}
+          {roleFilter !== 'all' ? ` for ${selectedRoleLabel}` : ''}
+          {query.trim() ? ` matching “${query.trim()}”` : ''}
+        </div>
+
+        <div className="p-5">
+          {visibleDocs.length ? (
+            <div className="space-y-3">
+              {visibleDocs.map((doc) => (
+                <Link
+                  key={doc.id}
+                  to={`/help/${doc.id}`}
+                  state={{ fromHelpPortal: true, helpQuery: query, helpRoleFilter: roleFilter }}
+                  className="block rounded-2xl border border-gray-200 bg-white p-4 transition hover:border-primary-200 hover:bg-primary-50/40"
+                >
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0">
+                      <h2 className="text-base font-black text-gray-950">{doc.title}</h2>
+                      <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">{doc.summary}</p>
+                      {doc.roles.length ? (
+                        <div className="mt-3 flex flex-wrap gap-1.5" aria-label={`${doc.title} roles`}>
+                          {doc.roles.map((role) => (
+                            <span key={role} className="rounded-full bg-gray-100 px-2.5 py-1 text-[10px] font-extrabold uppercase tracking-[0.04em] text-gray-500">
+                              {role}
+                            </span>
+                          ))}
+                        </div>
+                      ) : null}
+                    </div>
+                    <span className="text-xs font-extrabold uppercase tracking-[0.04em] text-primary-700">Open</span>
+                  </div>
+                </Link>
+              ))}
+            </div>
+          ) : (
+            <div className="rounded-2xl border border-dashed border-gray-300 bg-gray-50 px-4 py-8 text-center">
+              <div className="mx-auto flex h-12 w-12 items-center justify-center rounded-2xl bg-white text-primary-700 shadow-sm ring-1 ring-gray-200">
+                <Search className="h-5 w-5" aria-hidden="true" />
+              </div>
+              <h2 className="mt-3 text-lg font-black text-gray-950">No help articles match this filter</h2>
+              <p className="mt-2 text-sm font-semibold leading-6 text-gray-600">
+                {hasFilters
+                  ? `Try a different search term or switch the role filter from ${selectedRoleLabel}.`
+                  : 'Try another search term or role filter.'}
+              </p>
+            </div>
+          )}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+function normalizePortalState(state: unknown) {
+  const candidate = state as { helpQuery?: string; helpRoleFilter?: HelpPortalRoleFilter } | null;
+  return {
+    helpQuery: typeof candidate?.helpQuery === 'string' ? candidate.helpQuery : '',
+    helpRoleFilter: isRoleFilter(candidate?.helpRoleFilter) ? candidate.helpRoleFilter : 'all'
+  };
+}
+
+function isRoleFilter(value: unknown): value is HelpPortalRoleFilter {
+  return helpRoleOptions.some((option) => option.value === value);
+}
+
+function roleFilterMatches(roles: string[], roleFilter: HelpPortalRoleFilter) {
+  if (roleFilter === 'all') return true;
+  const normalizedRoles = roles.map((role) => role.toLowerCase());
+  return normalizedRoles.includes('all') || normalizedRoles.includes(roleFilter);
+}

--- a/tests/unit/app-capability-page.test.jsx
+++ b/tests/unit/app-capability-page.test.jsx
@@ -101,6 +101,16 @@ describe('CapabilityPage launch CTAs', () => {
         await act(async () => root.unmount());
     });
 
+    it('routes the help capability to the in-app help portal', async () => {
+        const { container, root } = await renderCapabilityPage('/capabilities/help');
+
+        expect(linkByText(container, 'Open app route').getAttribute('href')).toBe('/help');
+        expect(container.textContent).not.toContain('Open current page');
+        expect(openPublicUrl).not.toHaveBeenCalled();
+
+        await act(async () => root.unmount());
+    });
+
     it('does not show a primary launch CTA for future capabilities', async () => {
         const { container, root } = await renderCapabilityPage('/capabilities/organization-schedule');
 

--- a/tests/unit/app-help-article.test.jsx
+++ b/tests/unit/app-help-article.test.jsx
@@ -65,10 +65,14 @@ describe('HelpArticle', () => {
         await act(async () => root.unmount());
     });
 
-    it('is registered as a protected app route', () => {
+    it('is registered as protected help portal routes', () => {
         const appSource = readFileSync('apps/app/src/App.tsx', 'utf8');
 
-        expect(appSource).toContain("const HelpArticle = lazy(() => import('./pages/HelpArticle').then((module) => ({ default: module.HelpArticle })));");
+        expect(appSource).toContain("const HelpPortal = lazy(() => import('./pages/HelpPortal').then((module) => ({ default: module.HelpPortal })));"
+        );
+        expect(appSource).toContain("const HelpArticle = lazy(() => import('./pages/HelpArticle').then((module) => ({ default: module.HelpArticle })));"
+        );
+        expect(appSource).toContain('<Route path="/help" element={<Protected auth={auth}><HelpPortal /></Protected>} />');
         expect(appSource).toContain('<Route path="/help/:helpId" element={<Protected auth={auth}><HelpArticle /></Protected>} />');
     });
 

--- a/tests/unit/app-help-knowledge-service.test.js
+++ b/tests/unit/app-help-knowledge-service.test.js
@@ -85,4 +85,26 @@ describe('app help knowledge service', () => {
         expect(parentResults.length).toBeGreaterThan(0);
         expect(parentResults.every((result) => result.roles.includes('parent') || result.roles.includes('all'))).toBe(true);
     });
+
+    it('supports portal-sized result sets and role-filter narrowing for each portal role', async () => {
+        const { getHelpKnowledgeDocs, searchHelpKnowledge } = await import('../../apps/app/src/lib/helpKnowledgeService.ts');
+        const docs = getHelpKnowledgeDocs();
+
+        expect(searchHelpKnowledge({
+            query: '',
+            roleFilter: 'all',
+            limit: docs.length
+        })).toHaveLength(docs.length);
+
+        ['all', 'parent', 'coach', 'admin', 'member'].forEach((roleFilter) => {
+            const results = searchHelpKnowledge({
+                query: 'schedule',
+                roleFilter,
+                limit: docs.length
+            });
+
+            expect(results.length).toBeGreaterThan(0);
+            expect(results.every((result) => roleFilter === 'all' || result.roles.includes('all') || result.roles.includes(roleFilter))).toBe(true);
+        });
+    });
 });

--- a/tests/unit/app-help-portal.test.jsx
+++ b/tests/unit/app-help-portal.test.jsx
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import React, { act } from '../../apps/app/node_modules/react/index.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createRoot } from '../../apps/app/node_modules/react-dom/client.js';
+import { MemoryRouter, Route, Routes } from '../../apps/app/node_modules/react-router-dom/dist/index.mjs';
+
+const helpMocks = vi.hoisted(() => ({
+    getHelpKnowledgeDocs: vi.fn(),
+    searchHelpKnowledge: vi.fn()
+}));
+
+vi.mock('../../apps/app/src/lib/helpKnowledgeService.ts', () => helpMocks);
+
+import { HelpArticle } from '../../apps/app/src/pages/HelpArticle.tsx';
+import { HelpPortal } from '../../apps/app/src/pages/HelpPortal.tsx';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const docs = [
+    {
+        id: 'all-guide',
+        title: 'ALL PLAYS basics',
+        file: 'help.html',
+        url: 'https://allplays.ai/help.html',
+        roles: ['all'],
+        summary: 'General help for everyone.',
+        text: 'ALL PLAYS basics General help for everyone. Start here for account setup and common app tasks.'
+    },
+    {
+        id: 'coach-schedule',
+        title: 'Coach schedule tools',
+        file: 'help-team-operations.html',
+        url: 'https://allplays.ai/help-team-operations.html',
+        roles: ['coach'],
+        summary: 'Manage practices and game day timing.',
+        text: 'Coach schedule tools Manage practices and game day timing. Schedule practices, games, and reminders.'
+    },
+    {
+        id: 'parent-fees',
+        title: 'Parent fee guide',
+        file: 'help-account.html',
+        url: 'https://allplays.ai/help-account.html',
+        roles: ['parent'],
+        summary: 'Pay and track team fees.',
+        text: 'Parent fee guide Pay and track team fees. Review balances and payment links.'
+    }
+];
+
+async function renderHelp(initialEntry = '/help') {
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    await act(async () => {
+        root.render(React.createElement(
+            MemoryRouter,
+            { initialEntries: [initialEntry] },
+            React.createElement(
+                Routes,
+                null,
+                React.createElement(Route, { path: '/help', element: React.createElement(HelpPortal) }),
+                React.createElement(Route, { path: '/help/:helpId', element: React.createElement(HelpArticle) })
+            )
+        ));
+    });
+
+    return { container, root };
+}
+
+async function setInputValue(input, value) {
+    await act(async () => {
+        const setter = Object.getOwnPropertyDescriptor(window.HTMLInputElement.prototype, 'value')?.set;
+        setter.call(input, value);
+        input.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: value }));
+    });
+}
+
+async function clickElement(element) {
+    await act(async () => {
+        element.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+    });
+}
+
+afterEach(() => {
+    document.body.innerHTML = '';
+    vi.clearAllMocks();
+});
+
+describe('HelpPortal', () => {
+    it('renders a dedicated help landing page with search, role filters, and packaged article cards', async () => {
+        helpMocks.getHelpKnowledgeDocs.mockReturnValue(docs);
+        helpMocks.searchHelpKnowledge.mockReturnValue([docs[1]]);
+
+        const { container, root } = await renderHelp();
+
+        expect(container.querySelector('input[aria-label="Search help articles"]')).toBeTruthy();
+        expect(container.textContent).toContain('Role filter');
+        expect(container.textContent).toContain('ALL PLAYS basics');
+        expect(container.textContent).toContain('Coach schedule tools');
+        expect(container.textContent).toContain('Parent fee guide');
+
+        await act(async () => root.unmount());
+    });
+
+    it('updates the rendered help list inline when the role filter and query change', async () => {
+        helpMocks.getHelpKnowledgeDocs.mockReturnValue(docs);
+        helpMocks.searchHelpKnowledge.mockImplementation(({ query, roleFilter }) => {
+            if (query === 'schedule' && roleFilter === 'coach') return [docs[1]];
+            return [];
+        });
+
+        const { container, root } = await renderHelp();
+
+        expect(container.textContent).toContain('Parent fee guide');
+        await clickElement(Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Coach'));
+        expect(container.textContent).toContain('Coach schedule tools');
+        expect(container.textContent).toContain('ALL PLAYS basics');
+        expect(container.textContent).not.toContain('Parent fee guide');
+
+        const input = container.querySelector('input[aria-label="Search help articles"]');
+        await setInputValue(input, 'schedule');
+
+        expect(helpMocks.searchHelpKnowledge).toHaveBeenCalledWith({
+            query: 'schedule',
+            roleFilter: 'coach',
+            limit: docs.length
+        });
+        expect(container.textContent).toContain('Coach schedule tools');
+        expect(container.textContent).not.toContain('Parent fee guide');
+        expect(container.querySelector('a[href="/help/coach-schedule"]')).toBeTruthy();
+
+        await act(async () => root.unmount());
+    });
+
+    it('opens help results in-app and preserves the portal return path', async () => {
+        helpMocks.getHelpKnowledgeDocs.mockReturnValue(docs);
+        helpMocks.searchHelpKnowledge.mockImplementation(({ query }) => query === 'schedule' ? [docs[1]] : []);
+
+        const { container, root } = await renderHelp();
+
+        await clickElement(Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Coach'));
+        await setInputValue(container.querySelector('input[aria-label="Search help articles"]'), 'schedule');
+        await clickElement(container.querySelector('a[href="/help/coach-schedule"]'));
+
+        expect(container.textContent).toContain('Coach schedule tools');
+        expect(container.textContent).toContain('Manage practices and game day timing.');
+        expect(container.textContent).toContain('Back to Help Portal');
+
+        await clickElement(Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Back to Help Portal'));
+        expect(container.querySelector('input[aria-label="Search help articles"]')?.value).toBe('schedule');
+        expect(Array.from(container.querySelectorAll('button')).find((button) => button.textContent === 'Coach')?.getAttribute('aria-pressed')).toBe('true');
+
+        await act(async () => root.unmount());
+    });
+});


### PR DESCRIPTION
Closes #1669

## What changed
- added a protected `/help` route in the React app and created a dedicated `HelpPortal` page with an always-visible search field and role filter chips
- wired help article cards to navigate in-app to `/help/:helpId` and updated `HelpArticle` to return users to the portal when they came from help browsing
- changed the `help` capability to use the native `/help` route instead of the legacy external link fallback
- expanded help knowledge search so the portal can request the full packaged result set instead of the old modal-sized cap
- added focused regression coverage for the portal flow, capability routing, and help knowledge filtering

## Why
The app already had packaged help articles and searchable help metadata, but users could only discover them through the global search modal or the legacy `help.html` handoff. This adds the missing first-class in-app help landing experience without changing native iOS or Android wrappers.