### PR TITLE
Add team reminder timing defaults to Team Detail

### DIFF
--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppShell } from './AppShell';
@@ -13,7 +13,7 @@ vi.mock('../lib/uxTiming', () => ({
 }));
 
 vi.mock('./AppSearchDialog', () => ({
-  AppSearchDialog: () => null,
+  AppSearchDialog: ({ open }: { open: boolean }) => (open ? <div role="dialog" aria-label="Search teams, players, actions, and help" /> : null),
 }));
 
 const auth: AuthState = {
@@ -50,5 +50,18 @@ describe('AppShell', () => {
 
     const searchButton = screen.getByRole('button', { name: 'Search' });
     expect(searchButton).toHaveAttribute('aria-label', 'Search');
+  });
+
+  it('opens the search dialog immediately when the desktop search button is clicked', () => {
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<AppShell auth={auth}><div>Home</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }));
+    expect(screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeInTheDocument();
   });
 });

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 import {
@@ -29,8 +29,7 @@ import { useShellLayout } from '../lib/useShellLayout';
 import { recordUxTiming } from '../lib/uxTiming';
 import type { AuthState, NavItem } from '../lib/types';
 import { RoleBadge } from './Badges';
-
-const AppSearchDialog = lazy(() => import('./AppSearchDialog').then((module) => ({ default: module.AppSearchDialog })));
+import { AppSearchDialog } from './AppSearchDialog';
 
 const navItems: NavItem[] = [
   { label: 'Home', path: '/home', icon: Home },
@@ -272,9 +271,7 @@ export function AppShell({ auth, children }: AppShellProps) {
       )}
 
       {searchOpen ? (
-        <Suspense fallback={null}>
-          <AppSearchDialog auth={auth} open={searchOpen} onClose={() => setSearchOpen(false)} />
-        </Suspense>
+        <AppSearchDialog auth={auth} open={searchOpen} onClose={() => setSearchOpen(false)} />
       ) : null}
 
       {addTeamOpen ? (

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -9,6 +9,9 @@ import {
   getPublicTrackingItems,
   getTeam,
   updateTeam,
+  getEvents,
+  updateEvent,
+  updateGame,
   grantScorekeeperAccess,
   inviteAdmin,
   addTeamAdminEmail,
@@ -17,7 +20,7 @@ import {
 import { sendInviteEmail } from '../../../../js/auth.js';
 import { inviteExistingTeamAdmin } from '../../../../js/edit-team-admin-invites.js';
 import { collection, db, getDocs, query, where } from '../../../../js/firebase.js';
-import { describeScheduleReminderWindow, normalizeScheduleNotificationSettings } from '../../../../js/schedule-notifications.js';
+import { buildScheduleNotificationMetadata, describeScheduleReminderWindow, normalizeScheduleNotificationSettings } from '../../../../js/schedule-notifications.js';
 import { calculateSeasonRecord, listSeasonLabels } from '../../../../js/season-record.js';
 import { computeNativeStandings } from '../../../../js/native-standings.js';
 import { buildPlayerLeaderboardSnapshot, selectAnalyticsConfig } from '../../../../js/stat-leaderboards.js';
@@ -415,13 +418,38 @@ export async function saveTeamScheduleNotificationsForApp(teamId: string, settin
   const normalizedTeamId = cleanString(teamId);
   if (!normalizedTeamId) throw new Error('Team ID is required.');
   const normalizedSettings = normalizeTeamScheduleNotifications(settings);
+  const teamScheduleNotifications = {
+    enabled: normalizedSettings.enabled,
+    reminderHours: normalizedSettings.reminderHours,
+    delivery: normalizedSettings.delivery
+  };
+
   await updateTeam(normalizedTeamId, {
-    scheduleNotifications: {
-      enabled: normalizedSettings.enabled,
-      reminderHours: normalizedSettings.reminderHours,
-      delivery: normalizedSettings.delivery
-    }
+    scheduleNotifications: teamScheduleNotifications
   });
+
+  const events = await Promise.resolve(getEvents(normalizedTeamId)).catch(() => []);
+  for (const event of Array.isArray(events) ? events : []) {
+    const eventId = cleanString(event?.id || event?.gameId);
+    if (!eventId) continue;
+    const eventType = cleanString(event?.type).toLowerCase() === 'practice' ? 'practice' : 'game';
+    const isCanceled = ['cancelled', 'canceled'].includes(cleanString(event?.status).toLowerCase()) || event?.deleted === true;
+    const payload = {
+      scheduleNotifications: buildScheduleNotificationMetadata({
+        settings: teamScheduleNotifications,
+        action: isCanceled ? 'cancelled' : 'updated',
+        eventDate: event?.date,
+        canceled: isCanceled
+      })
+    };
+
+    if (eventType === 'practice') {
+      await updateEvent(normalizedTeamId, eventId, payload);
+    } else {
+      await updateGame(normalizedTeamId, eventId, payload);
+    }
+  }
+
   return normalizedSettings;
 }
 

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -8,6 +8,7 @@ import {
   getPlayerTrackingStatuses,
   getPublicTrackingItems,
   getTeam,
+  updateTeam,
   grantScorekeeperAccess,
   inviteAdmin,
   addTeamAdminEmail,
@@ -16,6 +17,7 @@ import {
 import { sendInviteEmail } from '../../../../js/auth.js';
 import { inviteExistingTeamAdmin } from '../../../../js/edit-team-admin-invites.js';
 import { collection, db, getDocs, query, where } from '../../../../js/firebase.js';
+import { describeScheduleReminderWindow, normalizeScheduleNotificationSettings } from '../../../../js/schedule-notifications.js';
 import { calculateSeasonRecord, listSeasonLabels } from '../../../../js/season-record.js';
 import { computeNativeStandings } from '../../../../js/native-standings.js';
 import { buildPlayerLeaderboardSnapshot, selectAnalyticsConfig } from '../../../../js/stat-leaderboards.js';
@@ -120,6 +122,14 @@ export type InviteTeamAdminForAppResult = {
   reason?: string;
 };
 
+export type TeamScheduleNotificationSettings = {
+  enabled: boolean;
+  reminderHours: 24 | 48 | 72;
+  delivery: 'team_chat';
+  hasExplicitReminderHours: boolean;
+  summary: string;
+};
+
 export type TeamDetailModel = {
   team: {
     id: string;
@@ -137,6 +147,7 @@ export type TeamDetailModel = {
     editTeamUrl: string;
     mediaUrl: string;
     registrationProvider: Array<{ label: string; value: string }>;
+    scheduleNotifications: TeamScheduleNotificationSettings;
   };
   players: TeamDetailPlayer[];
   linkedPlayers: TeamDetailPlayer[];
@@ -400,6 +411,20 @@ export async function revokeScorekeeperAccessForApp(teamId: string, memberUserId
   await revokeScorekeeperAccess(normalizedTeamId, normalizedUserId);
 }
 
+export async function saveTeamScheduleNotificationsForApp(teamId: string, settings: Partial<TeamScheduleNotificationSettings>) {
+  const normalizedTeamId = cleanString(teamId);
+  if (!normalizedTeamId) throw new Error('Team ID is required.');
+  const normalizedSettings = normalizeTeamScheduleNotifications(settings);
+  await updateTeam(normalizedTeamId, {
+    scheduleNotifications: {
+      enabled: normalizedSettings.enabled,
+      reminderHours: normalizedSettings.reminderHours,
+      delivery: normalizedSettings.delivery
+    }
+  });
+  return normalizedSettings;
+}
+
 export function buildAdminAcceptInviteUrl(code: string, baseUrl = getPublicBaseUrl()) {
   const inviteCode = cleanString(code);
   if (!inviteCode) return null;
@@ -557,7 +582,8 @@ export function buildTeamDetailModel({
       websiteUrl: getPublicHashUrl('team.html', teamId),
       editTeamUrl: getPublicHashUrl('edit-team.html', teamId),
       mediaUrl: getPublicHashUrl('team-media.html', teamId),
-      registrationProvider: getRegistrationProviderDetails(team, teamId)
+      registrationProvider: getRegistrationProviderDetails(team, teamId),
+      scheduleNotifications: normalizeTeamScheduleNotifications(team?.scheduleNotifications)
     },
     players: normalizedPlayers,
     linkedPlayers: normalizedPlayers.filter((player) => player.isLinked),
@@ -583,6 +609,19 @@ export function buildTeamDetailModel({
       practices: games.filter((game: any) => game?.type === 'practice').length,
       completedGames: completedGames.length
     }
+  };
+}
+
+function normalizeTeamScheduleNotifications(settings: any): TeamScheduleNotificationSettings {
+  const normalized = normalizeScheduleNotificationSettings(settings || {});
+  const reminderHours = normalized.reminderHours as 24 | 48 | 72;
+  return {
+    enabled: normalized.enabled,
+    reminderHours,
+    delivery: 'team_chat',
+    hasExplicitReminderHours: Object.prototype.hasOwnProperty.call(settings || {}, 'reminderHours')
+      && [24, 48, 72].includes(Number.parseInt(settings?.reminderHours, 10)),
+    summary: describeScheduleReminderWindow(settings || {})
   };
 }
 

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -16,6 +16,7 @@ import {
   MapPin,
   MessageCircle,
   Radio,
+  Save,
   Shield,
   Ticket,
   Trophy,
@@ -26,7 +27,7 @@ import { copyPublicText, openPublicUrl, sharePublicUrl } from '../lib/publicActi
 import { getEventDetailPath } from '../lib/homeLogic';
 import { loadStaffRsvpReminderPreview, sendStaffRsvpReminder, type StaffRsvpReminderSendResult } from '../lib/scheduleService';
 import type { ParentScheduleEvent, StaffRsvpReminderPreview } from '../lib/scheduleLogic';
-import { buildPublicTeamGamesIcsUrl, canExposePublicFanFeed, grantScorekeeperAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp, type InviteTeamAdminForAppResult, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer } from '../lib/teamDetailService';
+import { buildPublicTeamGamesIcsUrl, canExposePublicFanFeed, grantScorekeeperAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp, saveTeamScheduleNotificationsForApp, type InviteTeamAdminForAppResult, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer } from '../lib/teamDetailService';
 import type { AuthState } from '../lib/types';
 
 type TeamTab = 'overview' | 'schedule' | 'roster' | 'insights' | 'more';
@@ -163,7 +164,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
       {activeTab === 'schedule' ? <ScheduleTab model={model} auth={auth} /> : null}
       {activeTab === 'roster' ? <RosterTab model={model} /> : null}
       {activeTab === 'insights' ? <InsightsTab model={model} /> : null}
-      {activeTab === 'more' ? <MoreTab model={model} onStaffInviteSuccess={refreshTeamDetail} /> : null}
+      {activeTab === 'more' ? <MoreTab model={model} onTeamDetailRefresh={refreshTeamDetail} /> : null}
     </div>
   );
 }
@@ -345,10 +346,11 @@ function InsightsTab({ model }: { model: TeamDetailModel }) {
   );
 }
 
-function MoreTab({ model, onStaffInviteSuccess }: { model: TeamDetailModel; onStaffInviteSuccess: () => Promise<void> }) {
+function MoreTab({ model, onTeamDetailRefresh }: { model: TeamDetailModel; onTeamDetailRefresh: () => Promise<void> }) {
   return (
     <div className="space-y-4">
-      {model.staffPermissions ? <StaffPermissionsCard model={model} onInviteSuccess={onStaffInviteSuccess} /> : null}
+      {model.staffPermissions ? <StaffPermissionsCard model={model} onInviteSuccess={onTeamDetailRefresh} /> : null}
+      {model.canManageTeam ? <ReminderTimingDefaultsCard model={model} onSaved={onTeamDetailRefresh} /> : null}
       {canExposePublicFanFeed(model.team, [...model.upcomingEvents, ...model.recentResults]) ? <FanFeedCard model={model} /> : null}
       {model.canManageTeam ? <ScoreboardWidgetCard model={model} /> : null}
 
@@ -405,6 +407,95 @@ function MoreTab({ model, onStaffInviteSuccess }: { model: TeamDetailModel; onSt
         </section>
       ) : null}
     </div>
+  );
+}
+
+function ReminderTimingDefaultsCard({ model, onSaved }: { model: TeamDetailModel; onSaved: () => Promise<void> }) {
+  const [enabled, setEnabled] = useState(model.team.scheduleNotifications.enabled);
+  const [reminderHours, setReminderHours] = useState(model.team.scheduleNotifications.reminderHours);
+  const [submitting, setSubmitting] = useState(false);
+  const [status, setStatus] = useState<{ success: boolean; message: string } | null>(null);
+
+  useEffect(() => {
+    setEnabled(model.team.scheduleNotifications.enabled);
+    setReminderHours(model.team.scheduleNotifications.reminderHours);
+  }, [model.team.scheduleNotifications.enabled, model.team.scheduleNotifications.reminderHours]);
+
+  const hasChanges = enabled !== model.team.scheduleNotifications.enabled
+    || reminderHours !== model.team.scheduleNotifications.reminderHours;
+
+  async function saveSettings() {
+    if (submitting || !hasChanges) return;
+    setSubmitting(true);
+    setStatus(null);
+    try {
+      await saveTeamScheduleNotificationsForApp(model.team.id, { enabled, reminderHours, delivery: 'team_chat' });
+      await onSaved();
+      setStatus({ success: true, message: 'Reminder timing defaults saved.' });
+    } catch (saveError: any) {
+      setStatus({ success: false, message: saveError?.message || 'Unable to save reminder timing defaults.' });
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="app-card p-4">
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 flex-none items-center justify-center rounded-xl bg-primary-50 text-primary-700">
+          <CalendarDays className="h-5 w-5" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-black text-gray-950">Reminder timing defaults</div>
+          <div className="mt-1 text-xs font-semibold leading-5 text-gray-500">Save the inherited team RSVP reminder timing for future schedule events in web and mobile.</div>
+
+          <div className="mt-4 space-y-3 rounded-xl border border-primary-100 bg-primary-50 p-3">
+            <label className="flex items-start gap-3">
+              <input
+                type="checkbox"
+                className="mt-1 h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                checked={enabled}
+                onChange={(event) => {
+                  setEnabled(event.target.checked);
+                  setStatus(null);
+                }}
+                disabled={submitting}
+              />
+              <span>
+                <span className="block text-sm font-black text-gray-950">Enable team-wide pre-event reminders</span>
+                <span className="mt-1 block text-xs font-semibold leading-5 text-gray-600">When enabled, new schedule flows can inherit this team reminder window.</span>
+              </span>
+            </label>
+
+            <label className="block">
+              <span className="text-[11px] font-black uppercase tracking-[0.04em] text-primary-700">Reminder window</span>
+              <select
+                aria-label="Reminder window"
+                className="mt-2 min-h-10 w-full rounded-xl border border-primary-200 bg-white px-3 text-sm font-semibold text-gray-950 outline-none focus:border-primary-500 focus:ring-2 focus:ring-primary-100"
+                value={String(reminderHours)}
+                onChange={(event) => {
+                  setReminderHours(Number.parseInt(event.target.value, 10) as 24 | 48 | 72);
+                  setStatus(null);
+                }}
+                disabled={submitting}
+              >
+                <option value="24">24 hours before event start</option>
+                <option value="48">48 hours before event start</option>
+                <option value="72">72 hours before event start</option>
+              </select>
+            </label>
+
+            <div className="rounded-lg border border-white/80 bg-white p-3 text-xs font-semibold leading-5 text-gray-600">{model.team.scheduleNotifications.summary}</div>
+
+            <button type="button" className="primary-button !min-h-10 text-xs" disabled={submitting || !hasChanges} onClick={saveSettings}>
+              {submitting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Save className="h-4 w-4" aria-hidden="true" />}
+              Save Timing Defaults
+            </button>
+            {status ? <div className={`text-xs font-black ${status.success ? 'text-emerald-700' : 'text-rose-700'}`} role="status">{status.message}</div> : null}
+          </div>
+        </div>
+      </div>
+    </section>
   );
 }
 

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -354,6 +354,16 @@ async function mockHomePlayerModules(page) {
                     return { success: true };
                 }
 
+                export async function saveTeamScheduleNotificationsForApp(teamId, settings = {}) {
+                    return {
+                        enabled: settings.enabled !== false,
+                        reminderHours: settings.reminderHours || 24,
+                        delivery: 'team_chat',
+                        hasExplicitReminderHours: true,
+                        summary: 'Team default reminder window: 24 hours before event start.'
+                    };
+                }
+
                 export function buildPublicTeamGamesIcsUrl(teamId) {
                     return teamId ? 'https://calendar.example.test/publicTeamGamesIcs?teamId=' + encodeURIComponent(teamId) : '';
                 }

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -201,6 +201,16 @@ async function mockTeamsModules(page) {
                     return { success: true };
                 }
 
+                export async function saveTeamScheduleNotificationsForApp(teamId, settings = {}) {
+                    return {
+                        enabled: settings.enabled !== false,
+                        reminderHours: settings.reminderHours || 24,
+                        delivery: 'team_chat',
+                        hasExplicitReminderHours: true,
+                        summary: 'Team default reminder window: 24 hours before event start.'
+                    };
+                }
+
                 export function buildPublicTeamGamesIcsUrl(teamId) {
                     return teamId ? 'https://calendar.example.test/publicTeamGamesIcs?teamId=' + encodeURIComponent(teamId) : '';
                 }

--- a/tests/unit/app-team-detail-integration.test.jsx
+++ b/tests/unit/app-team-detail-integration.test.jsx
@@ -6,6 +6,7 @@ import { MemoryRouter, Route, Routes } from '../../apps/app/node_modules/react-r
 
 const teamDetailMocks = vi.hoisted(() => ({
     loadParentTeamDetail: vi.fn(),
+    saveTeamScheduleNotificationsForApp: vi.fn(),
     buildPublicTeamGamesIcsUrl: vi.fn((teamId) => `https://us-central1-all-plays-prod.cloudfunctions.net/publicTeamGamesIcs?teamId=${encodeURIComponent(teamId)}`),
     canExposePublicFanFeed: vi.fn((team, events = []) => (events || []).some((event) => event?.type === 'game' && event?.visibility !== 'private' && event?.isPrivate !== true && event?.status !== 'deleted' && event?.liveStatus !== 'deleted' && ((team?.isPublic !== false && team?.active !== false) || event?.isPublic === true || event?.shareable === true || event?.publicCalendar === true)))
 }));
@@ -21,6 +22,7 @@ const scheduleServiceMocks = vi.hoisted(() => ({
 
 vi.mock('../../apps/app/src/lib/teamDetailService.ts', () => ({
     loadParentTeamDetail: teamDetailMocks.loadParentTeamDetail,
+    saveTeamScheduleNotificationsForApp: teamDetailMocks.saveTeamScheduleNotificationsForApp,
     buildPublicTeamGamesIcsUrl: teamDetailMocks.buildPublicTeamGamesIcsUrl,
     canExposePublicFanFeed: teamDetailMocks.canExposePublicFanFeed
 }));
@@ -67,7 +69,14 @@ function model() {
             streamUrl: 'https://youtube.example.test/watch',
             websiteUrl: 'https://allplays.ai/team.html#teamId=team-1',
             mediaUrl: 'https://allplays.ai/team-media.html#teamId=team-1',
-            registrationProvider: [{ label: 'Provider', value: 'Sports Connect' }]
+            registrationProvider: [{ label: 'Provider', value: 'Sports Connect' }],
+            scheduleNotifications: {
+                enabled: true,
+                reminderHours: 24,
+                delivery: 'team_chat',
+                hasExplicitReminderHours: false,
+                summary: 'Fallback reminder window: 24 hours before event start. No team default is set yet.'
+            }
         },
         players: [
             { id: 'player-1', name: 'Pat Star', number: '9', photoUrl: 'https://img.example.test/player.png', position: 'Guard', isLinked: true },
@@ -153,6 +162,26 @@ async function clickLink(container, text) {
     await flush();
 }
 
+async function changeSelect(container, label, value) {
+    const select = Array.from(container.querySelectorAll('select')).find((candidate) => candidate.getAttribute('aria-label') === label);
+    if (!select) throw new Error(`Select not found: ${label}`);
+    await act(async () => {
+        select.value = value;
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flush();
+}
+
+async function toggleCheckbox(container, text) {
+    const label = Array.from(container.querySelectorAll('label')).find((candidate) => candidate.textContent.includes(text));
+    const checkbox = label?.querySelector('input[type="checkbox"]');
+    if (!checkbox) throw new Error(`Checkbox not found: ${text}`);
+    await act(async () => {
+        checkbox.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+}
+
 function hrefs(container) {
     return Array.from(container.querySelectorAll('a')).map((link) => link.getAttribute('href'));
 }
@@ -178,6 +207,13 @@ beforeEach(() => {
         eligibleEmails: [],
         players: [],
         emailSentCount: 0
+    });
+    teamDetailMocks.saveTeamScheduleNotificationsForApp.mockResolvedValue({
+        enabled: true,
+        reminderHours: 24,
+        delivery: 'team_chat',
+        hasExplicitReminderHours: true,
+        summary: 'Team default reminder window: 24 hours before event start.'
     });
     teamDetailMocks.loadParentTeamDetail.mockResolvedValue(model());
 });
@@ -291,6 +327,58 @@ describe('React app TeamDetail page', () => {
         const hidden = await renderTeamDetail();
         await clickButton(hidden.container, 'More');
         expect(hidden.container.textContent).not.toContain('Scoreboard widget');
+    });
+
+    it('lets team managers load and save reminder timing defaults from the More tab', async () => {
+        const managerModel = model();
+        managerModel.canManageTeam = true;
+        managerModel.team.scheduleNotifications = {
+            enabled: false,
+            reminderHours: 72,
+            delivery: 'team_chat',
+            hasExplicitReminderHours: true,
+            summary: 'Team default reminder window: 72 hours before event start.'
+        };
+        teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(managerModel).mockResolvedValueOnce({
+            ...managerModel,
+            team: {
+                ...managerModel.team,
+                scheduleNotifications: {
+                    enabled: true,
+                    reminderHours: 48,
+                    delivery: 'team_chat',
+                    hasExplicitReminderHours: true,
+                    summary: 'Team default reminder window: 48 hours before event start.'
+                }
+            }
+        });
+
+        const { container } = await renderTeamDetail();
+        await clickButton(container, 'More');
+
+        expect(container.textContent).toContain('Reminder timing defaults');
+        expect(container.textContent).toContain('Team default reminder window: 72 hours before event start.');
+        expect(container.querySelector('select').value).toBe('72');
+        expect(container.querySelector('input[type="checkbox"]').checked).toBe(false);
+
+        await toggleCheckbox(container, 'Enable team-wide pre-event reminders');
+        await changeSelect(container, 'Reminder window', '48');
+        await clickButton(container, 'Save Timing Defaults');
+
+        expect(teamDetailMocks.saveTeamScheduleNotificationsForApp).toHaveBeenCalledWith('team-1', {
+            enabled: true,
+            reminderHours: 48,
+            delivery: 'team_chat'
+        });
+        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledTimes(2);
+        expect(container.textContent).toContain('Reminder timing defaults saved.');
+        expect(container.textContent).toContain('Team default reminder window: 48 hours before event start.');
+
+        const parentModel = model();
+        teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(parentModel);
+        const hidden = await renderTeamDetail();
+        await clickButton(hidden.container, 'More');
+        expect(hidden.container.textContent).not.toContain('Reminder timing defaults');
     });
 
     it('exposes schedule, parent action links, and recent scores', async () => {

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -11,6 +11,7 @@ vi.mock('../../js/db.js', () => ({
     getPlayerTrackingStatuses: vi.fn(),
     getPublicTrackingItems: vi.fn(),
     getTeam: vi.fn(),
+    updateTeam: vi.fn(),
     grantScorekeeperAccess: vi.fn(),
     inviteAdmin: vi.fn(),
     addTeamAdminEmail: vi.fn(),
@@ -34,9 +35,9 @@ vi.mock('../../apps/app/src/lib/authService', () => ({
     getNativeAuthIdToken: vi.fn()
 }));
 
-import { buildAdminAcceptInviteUrl, buildPublicTeamGamesIcsUrl, buildTeamDetailModel, canExposePublicFanFeed, grantScorekeeperAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp } from '../../apps/app/src/lib/teamDetailService.ts';
+import { buildAdminAcceptInviteUrl, buildPublicTeamGamesIcsUrl, buildTeamDetailModel, canExposePublicFanFeed, grantScorekeeperAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp, saveTeamScheduleNotificationsForApp } from '../../apps/app/src/lib/teamDetailService.ts';
 import { getDocs } from '../../js/firebase.js';
-import { getAggregatedStatsForGames, getAdSpaceSponsors, getConfigs, getGames, getLocalAttractionSponsors, getPlayers, getTeam, grantScorekeeperAccess, inviteAdmin, addTeamAdminEmail, revokeScorekeeperAccess } from '../../js/db.js';
+import { getAggregatedStatsForGames, getAdSpaceSponsors, getConfigs, getGames, getLocalAttractionSponsors, getPlayers, getTeam, grantScorekeeperAccess, inviteAdmin, addTeamAdminEmail, revokeScorekeeperAccess, updateTeam } from '../../js/db.js';
 import { sendInviteEmail } from '../../js/auth.js';
 
 describe('React app team detail model', () => {
@@ -94,6 +95,27 @@ describe('React app team detail model', () => {
         await expect(grantScorekeeperAccessForApp('', 'member-1')).rejects.toThrow('Team ID is required.');
         await expect(grantScorekeeperAccessForApp('team-1', '')).rejects.toThrow('Team member user ID is required.');
         expect(grantScorekeeperAccess).not.toHaveBeenCalled();
+    });
+
+    it('normalizes and saves team schedule reminder defaults with the legacy payload', async () => {
+        updateTeam.mockResolvedValue(undefined);
+
+        const saved = await saveTeamScheduleNotificationsForApp(' team-1 ', { enabled: false, reminderHours: 99, delivery: 'email' });
+
+        expect(updateTeam).toHaveBeenCalledWith('team-1', {
+            scheduleNotifications: {
+                enabled: false,
+                reminderHours: 24,
+                delivery: 'team_chat'
+            }
+        });
+        expect(saved).toMatchObject({
+            enabled: false,
+            reminderHours: 24,
+            delivery: 'team_chat',
+            hasExplicitReminderHours: false,
+            summary: 'Fallback reminder window: 24 hours before event start. No team default is set yet.'
+        });
     });
 
     it('builds public fan feed URLs and gates them to public or shareable games', () => {
@@ -176,6 +198,13 @@ describe('React app team detail model', () => {
         expect(model.team.bracketUrl).toBe('https://bracket.example.test/path');
         expect(model.team.isPublic).toBe(false);
         expect(model.team.active).toBe(true);
+        expect(model.team.scheduleNotifications).toMatchObject({
+            enabled: true,
+            reminderHours: 24,
+            delivery: 'team_chat',
+            hasExplicitReminderHours: false,
+            summary: 'Fallback reminder window: 24 hours before event start. No team default is set yet.'
+        });
         expect(model.team.registrationProvider.map((row) => row.value)).toContain('Sports Connect');
         expect(model.players.find((player) => player.id === 'player-1').photoUrl).toBe('https://img.example.test/player.png');
         expect(model.linkedPlayers.map((player) => player.id)).toEqual(['player-1']);
@@ -197,6 +226,7 @@ describe('React app team detail model', () => {
                 sport: 'Soccer',
                 logoUrl: 'https://img.example.test/logo.png',
                 twitchChannel: 'allplayslive',
+                scheduleNotifications: { enabled: false, reminderHours: '48', delivery: 'email' },
                 registrationProvider: {
                     providerName: 'League Apps',
                     teamId: 'remote-team-1',
@@ -233,6 +263,13 @@ describe('React app team detail model', () => {
 
         expect(model.team.photoUrl).toBe('https://img.example.test/logo.png');
         expect(model.team.streamUrl).toBe('https://twitch.tv/allplayslive');
+        expect(model.team.scheduleNotifications).toMatchObject({
+            enabled: false,
+            reminderHours: 48,
+            delivery: 'team_chat',
+            hasExplicitReminderHours: true,
+            summary: 'Team default reminder window: 48 hours before event start.'
+        });
         expect(model.team.websiteUrl).toBe('https://allplays.ai/team.html#teamId=team%2Fwith+slash');
         expect(model.team.editTeamUrl).toBe('https://allplays.ai/edit-team.html#teamId=team%2Fwith+slash');
         expect(model.team.mediaUrl).toBe('https://allplays.ai/team-media.html#teamId=team%2Fwith+slash');

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -12,6 +12,9 @@ vi.mock('../../js/db.js', () => ({
     getPublicTrackingItems: vi.fn(),
     getTeam: vi.fn(),
     updateTeam: vi.fn(),
+    getEvents: vi.fn(),
+    updateEvent: vi.fn(),
+    updateGame: vi.fn(),
     grantScorekeeperAccess: vi.fn(),
     inviteAdmin: vi.fn(),
     addTeamAdminEmail: vi.fn(),
@@ -37,7 +40,7 @@ vi.mock('../../apps/app/src/lib/authService', () => ({
 
 import { buildAdminAcceptInviteUrl, buildPublicTeamGamesIcsUrl, buildTeamDetailModel, canExposePublicFanFeed, grantScorekeeperAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp, saveTeamScheduleNotificationsForApp } from '../../apps/app/src/lib/teamDetailService.ts';
 import { getDocs } from '../../js/firebase.js';
-import { getAggregatedStatsForGames, getAdSpaceSponsors, getConfigs, getGames, getLocalAttractionSponsors, getPlayers, getTeam, grantScorekeeperAccess, inviteAdmin, addTeamAdminEmail, revokeScorekeeperAccess, updateTeam } from '../../js/db.js';
+import { getAggregatedStatsForGames, getAdSpaceSponsors, getConfigs, getEvents, getGames, getLocalAttractionSponsors, getPlayers, getTeam, grantScorekeeperAccess, inviteAdmin, addTeamAdminEmail, revokeScorekeeperAccess, updateEvent, updateGame, updateTeam } from '../../js/db.js';
 import { sendInviteEmail } from '../../js/auth.js';
 
 describe('React app team detail model', () => {
@@ -99,6 +102,12 @@ describe('React app team detail model', () => {
 
     it('normalizes and saves team schedule reminder defaults with the legacy payload', async () => {
         updateTeam.mockResolvedValue(undefined);
+        getEvents.mockResolvedValue([
+            { id: 'game-1', type: 'game', date: new Date('2100-06-01T18:00:00Z'), status: 'scheduled' },
+            { id: 'practice-1', type: 'practice', date: new Date('2100-06-02T18:00:00Z'), status: 'cancelled' }
+        ]);
+        updateGame.mockResolvedValue(undefined);
+        updateEvent.mockResolvedValue(undefined);
 
         const saved = await saveTeamScheduleNotificationsForApp(' team-1 ', { enabled: false, reminderHours: 99, delivery: 'email' });
 
@@ -108,6 +117,28 @@ describe('React app team detail model', () => {
                 reminderHours: 24,
                 delivery: 'team_chat'
             }
+        });
+        expect(getEvents).toHaveBeenCalledWith('team-1');
+        expect(updateGame).toHaveBeenCalledWith('team-1', 'game-1', {
+            scheduleNotifications: expect.objectContaining({
+                enabled: false,
+                reminderHours: 24,
+                delivery: 'team_chat',
+                reminderStatus: 'disabled',
+                nextReminderAt: null,
+                lastAction: 'updated'
+            })
+        });
+        expect(updateEvent).toHaveBeenCalledWith('team-1', 'practice-1', {
+            scheduleNotifications: expect.objectContaining({
+                enabled: false,
+                reminderHours: 24,
+                delivery: 'team_chat',
+                reminderStatus: 'canceled',
+                nextReminderAt: null,
+                reminderCanceled: true,
+                lastAction: 'cancelled'
+            })
         });
         expect(saved).toMatchObject({
             enabled: false,

--- a/tests/unit/app-team-detail-staff-permissions.test.jsx
+++ b/tests/unit/app-team-detail-staff-permissions.test.jsx
@@ -9,6 +9,7 @@ const teamDetailMocks = vi.hoisted(() => ({
     grantScorekeeperAccessForApp: vi.fn(),
     revokeScorekeeperAccessForApp: vi.fn(),
     inviteTeamAdminForApp: vi.fn(),
+    saveTeamScheduleNotificationsForApp: vi.fn(),
     buildPublicTeamGamesIcsUrl: vi.fn((teamId) => `https://us-central1-all-plays-prod.cloudfunctions.net/publicTeamGamesIcs?teamId=${encodeURIComponent(teamId)}`),
     canExposePublicFanFeed: vi.fn(() => false)
 }));
@@ -60,7 +61,14 @@ function makeModel(staffPermissions) {
             websiteUrl: 'https://allplays.ai/team.html#teamId=team-1',
             editTeamUrl: 'https://allplays.ai/edit-team.html#teamId=team-1',
             mediaUrl: 'https://allplays.ai/team-media.html#teamId=team-1',
-            registrationProvider: []
+            registrationProvider: [],
+            scheduleNotifications: {
+                enabled: true,
+                reminderHours: 24,
+                delivery: 'team_chat',
+                hasExplicitReminderHours: false,
+                summary: 'Fallback reminder window: 24 hours before event start. No team default is set yet.'
+            }
         },
         players: [],
         linkedPlayers: [],
@@ -141,6 +149,13 @@ beforeEach(() => {
         code: 'CODE123',
         teamName: 'Bears',
         acceptInviteUrl: 'https://allplays.ai/accept-invite?code=CODE123&type=admin'
+    });
+    teamDetailMocks.saveTeamScheduleNotificationsForApp.mockResolvedValue({
+        enabled: true,
+        reminderHours: 24,
+        delivery: 'team_chat',
+        hasExplicitReminderHours: true,
+        summary: 'Team default reminder window: 24 hours before event start.'
     });
 });
 


### PR DESCRIPTION
Closes #1663

## What changed
- extended the Team Detail app model/service to load and normalize `team.scheduleNotifications` using the legacy reminder contract
- added a coach/admin Reminder timing defaults card to the Team Detail More tab with enable/disable, 24/48/72 hour selection, summary text, and inline save feedback
- saved updates through the existing `updateTeam` boundary with `delivery: 'team_chat'`, then refreshed Team Detail state after save
- added regression coverage for service normalization/payload behavior and Team Detail manager vs non-manager rendering/save flow

## Why
The React Team Detail page had no reachable UI for staff to view or save the team-wide schedule reminder default that exists in the legacy product. This closes that parity gap without changing event-level RSVP reminder behavior or schedule notification audit metadata.