### PR TITLE
Keep invited admins pending until redemption

### DIFF
--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -29,7 +29,7 @@ const auth: AuthState = {
 };
 
 describe('AppSearchDialog', () => {
-  it('does not close from backdrop mousedown alone but still closes on backdrop click', () => {
+  it('closes from a backdrop mousedown but not from pressing inside the search panel', () => {
     const onClose = vi.fn();
 
     render(
@@ -38,11 +38,11 @@ describe('AppSearchDialog', () => {
       </MemoryRouter>
     );
 
-    const dialog = screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' });
-    fireEvent.mouseDown(dialog);
+    fireEvent.mouseDown(screen.getByTestId('app-search-panel'));
     expect(onClose).not.toHaveBeenCalled();
 
-    fireEvent.click(dialog);
+    const dialog = screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' });
+    fireEvent.mouseDown(dialog);
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -1,0 +1,48 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import { AppSearchDialog } from './AppSearchDialog';
+import type { AuthState } from '../lib/types';
+
+vi.mock('../lib/publicActions', () => ({
+  openPublicUrl: vi.fn(),
+}));
+
+vi.mock('../lib/searchService', () => ({
+  computeAppSearchResults: () => ({ actions: [], teams: [], help: [], players: [], flat: [] }),
+  loadAppSearchTeams: vi.fn(async () => []),
+  searchAppPlayers: vi.fn(async () => []),
+}));
+
+const auth: AuthState = {
+  user: null,
+  profile: null,
+  loading: false,
+  error: null,
+  roles: ['parent'],
+  isParent: true,
+  isCoach: false,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: vi.fn(),
+  signOut: vi.fn(),
+};
+
+describe('AppSearchDialog', () => {
+  it('does not close from backdrop mousedown alone but still closes on backdrop click', () => {
+    const onClose = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' });
+    fireEvent.mouseDown(dialog);
+    expect(onClose).not.toHaveBeenCalled();
+
+    fireEvent.click(dialog);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -181,7 +181,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       aria-modal="true"
       aria-label="Search teams, players, actions, and help"
       onKeyDown={onKeyDown}
-      onMouseDown={(event) => {
+      onClick={(event) => {
         if (event.target === event.currentTarget) onClose();
       }}
     >

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -181,7 +181,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       aria-modal="true"
       aria-label="Search teams, players, actions, and help"
       onKeyDown={onKeyDown}
-      onClick={(event) => {
+      onMouseDown={(event) => {
         if (event.target === event.currentTarget) onClose();
       }}
     >

--- a/edit-team.html
+++ b/edit-team.html
@@ -555,14 +555,14 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers } from './js/db.js?v=33';
+        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes } from './js/db.js?v=33';
         import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth, sendInviteEmail } from './js/auth.js?v=16';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { normalizeYouTubeEmbedUrl } from './js/live-stream-utils.js?v=1';
         import { hasFullTeamAccess, normalizeAdminEmailList, normalizeStreamVolunteerEmailList, normalizeTeamPermissions } from './js/team-access.js?v=3';
-        import { processPendingAdminInvites, buildAdminInviteFollowUp, inviteExistingTeamAdmin } from './js/edit-team-admin-invites.js?v=4';
+        import { processPendingAdminInvites, buildAdminInviteFollowUp, inviteExistingTeamAdmin, loadPendingAdminInviteEmails } from './js/edit-team-admin-invites.js?v=4';
         import { buildRolloverAccessPreview, buildStaffAdminRolloverUpdate } from './js/rollover-access.js?v=1';
         import { buildRosterRolloverPreviewRows } from './js/roster-rollover-preview.js?v=1';
 
@@ -1304,6 +1304,10 @@
                 }
                 streamInput.dispatchEvent(new Event('input')); // trigger detection badge
                 adminEmails = normalizeAdminEmailList(team.adminEmails);
+                pendingAdminInviteEmails = await loadPendingAdminInviteEmails({
+                    teamId: initialTeamId,
+                    getTeamAccessCodes
+                });
                 teamPermissions = normalizeTeamPermissions(team.teamPermissions);
                 await loadConfirmedTeamMembers(initialTeamId);
                 streamVolunteerEmails = normalizeStreamVolunteerEmailList(team.streamVolunteerEmails);

--- a/edit-team.html
+++ b/edit-team.html
@@ -1479,6 +1479,10 @@
                 showAdminStatus('This email is already an admin.', 'error');
                 return;
             }
+            if (pendingAdminInviteEmails.includes(email)) {
+                showAdminStatus('This email already has a pending invite.', 'error');
+                return;
+            }
 
             btn.disabled = true;
             btn.textContent = 'Sending...';
@@ -1488,6 +1492,7 @@
             try {
                 // If we have a team ID (editing existing team), send invite email
                 let showCode = false;
+                let inviteCode = '';
                 if (currentTeamId) {
                     const result = await inviteExistingTeamAdmin({
                         teamId: currentTeamId,
@@ -1496,13 +1501,13 @@
                         addTeamAdminEmail,
                         sendInviteEmail
                     });
-                    const code = typeof result?.code === 'string' ? result.code.trim() : '';
+                    inviteCode = typeof result?.code === 'string' ? result.code.trim() : '';
 
                     if (result.status === 'existing_user') {
                         // User exists - show code for them when available
-                        if (code) {
+                        if (inviteCode) {
                             showAdminStatus(`${email} already has an account. Share this code or link with them:`, 'info');
-                            showAdminCode(code);
+                            showAdminCode(inviteCode);
                             showCode = true;
                         } else {
                             showAdminStatus('No invite code generated. Please try sending the invite again.', 'warning');
@@ -1512,20 +1517,26 @@
                         showAdminStatus(`Invite sent to ${email}! They'll receive an email to join as an admin.`, 'success');
                     } else if (result.status === 'fallback_code') {
                         showAdminStatus(`Could not send email. Share this code or link instead:`, 'warning');
-                        if (code) {
-                            showAdminCode(code);
+                        if (inviteCode) {
+                            showAdminCode(inviteCode);
                             showCode = true;
                         }
                     } else {
                         throw new Error('Unexpected admin invite result');
                     }
                 } else {
-                    pendingAdminInviteEmails.push(email);
+                    pendingAdminInviteEmails = normalizeAdminEmailList([...pendingAdminInviteEmails, email]);
                     showAdminStatus(`Invite for ${email} will be sent when you save this new team.`, 'info');
                 }
 
+                if (currentTeamId && inviteCode) {
+                    pendingAdminInviteEmails = normalizeAdminEmailList([...pendingAdminInviteEmails, email]);
+                }
+
                 // Add to local list and update UI
-                adminEmails = normalizeAdminEmailList([...adminEmails, email]);
+                if (!currentTeamId) {
+                    adminEmails = normalizeAdminEmailList([...adminEmails, email]);
+                }
                 renderAdminList();
                 renderRolloverAccessPreview();
                 input.value = '';

--- a/js/db.js
+++ b/js/db.js
@@ -2988,6 +2988,20 @@ export async function getUserAccessCodes(userId) {
     });
 }
 
+export async function getTeamAccessCodes(teamId) {
+    const normalizedTeamId = String(teamId || '').trim();
+    if (!normalizedTeamId) {
+        return [];
+    }
+
+    const q = query(
+        collection(db, "accessCodes"),
+        where("teamId", "==", normalizedTeamId)
+    );
+    const snapshot = await getDocs(q);
+    return snapshot.docs.map((doc) => ({ id: doc.id, ...doc.data() }));
+}
+
 export async function validateAccessCode(code) {
     const q = query(
         collection(db, "accessCodes"),

--- a/js/edit-team-admin-invites.js
+++ b/js/edit-team-admin-invites.js
@@ -59,6 +59,41 @@ export async function inviteExistingTeamAdmin({
     }
 }
 
+function getExpirationTime(expiresAt) {
+    if (expiresAt == null) return null;
+    if (typeof expiresAt?.toMillis === 'function') return expiresAt.toMillis();
+    if (expiresAt instanceof Date) return expiresAt.getTime();
+    const expiresAtMs = Number(expiresAt);
+    return Number.isFinite(expiresAtMs) ? expiresAtMs : null;
+}
+
+function isPendingAdminInvite(invite) {
+    if (!invite || invite.type !== 'admin_invite') return false;
+    if (invite.used === true || invite.revoked === true || invite.active === false) return false;
+    const status = String(invite.status || '').trim().toLowerCase();
+    if (status && !['active', 'pending'].includes(status)) return false;
+    const expiresAtMs = getExpirationTime(invite.expiresAt);
+    return expiresAtMs == null || Date.now() < expiresAtMs;
+}
+
+export async function loadPendingAdminInviteEmails({
+    teamId,
+    getTeamAccessCodes
+}) {
+    const normalizedTeamId = String(teamId || '').trim();
+    if (!normalizedTeamId || typeof getTeamAccessCodes !== 'function') {
+        return [];
+    }
+
+    const invites = await getTeamAccessCodes(normalizedTeamId);
+    return Array.from(new Set(
+        (Array.isArray(invites) ? invites : [])
+            .filter(isPendingAdminInvite)
+            .map((invite) => String(invite.email || '').trim().toLowerCase())
+            .filter(Boolean)
+    ));
+}
+
 export async function processPendingAdminInvites({
     teamId,
     pendingEmails,

--- a/js/edit-team-admin-invites.js
+++ b/js/edit-team-admin-invites.js
@@ -23,7 +23,6 @@ export async function inviteExistingTeamAdmin({
     const code = parsedCode || null;
 
     if (parsedInviteResult?.existingUser) {
-        await addTeamAdminEmail(teamId, normalizedEmail);
         return {
             email: normalizedEmail,
             status: 'existing_user',
@@ -41,8 +40,6 @@ export async function inviteExistingTeamAdmin({
             reason: 'missing_invite_code'
         };
     }
-
-    await addTeamAdminEmail(teamId, normalizedEmail);
 
     try {
         await sendInviteEmail(normalizedEmail, code, 'admin', { teamName: parsedInviteResult?.teamName || null });

--- a/tests/smoke/admin-invite-redemption.spec.js
+++ b/tests/smoke/admin-invite-redemption.spec.js
@@ -58,6 +58,10 @@ export async function getAllUsers() {
     return [];
 }
 
+export async function getTeamAccessCodes() {
+    return [];
+}
+
 export async function inviteAdmin(teamId, email) {
     window.__lastAdminInvite = { teamId, email };
     return {

--- a/tests/smoke/admin-invite-redemption.spec.js
+++ b/tests/smoke/admin-invite-redemption.spec.js
@@ -281,10 +281,11 @@ async function mockAcceptInviteDependencies(page) {
     await page.route('**/js/utils.js?v=8', (route) => route.fulfill({ status: 200, contentType: 'application/javascript', body: SHARED_UTILS_STUB }));
 }
 
-test('team management exposes the existing-user admin redemption fallback', async ({ page, baseURL }) => {
+test('team management exposes the existing-user admin redemption fallback without granting access before redemption', async ({ page, baseURL }) => {
     await mockEditTeamDependencies(page);
 
     await page.goto(`${baseURL}/edit-team.html?teamId=team-1`, { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#admin-list')).toContainText('owner@example.com');
 
     await page.locator('#add-admin-btn').click();
     await page.locator('#admin-email-input').fill('Coach@Example.com');
@@ -293,16 +294,14 @@ test('team management exposes the existing-user admin redemption fallback', asyn
     await expect(page.locator('#admin-invite-status')).toContainText('already has an account');
     await expect(page.locator('#admin-code-text')).toHaveText('EXIST111');
     await expect(page.locator('#admin-invite-code')).toBeVisible();
-    await expect(page.locator('#admin-list')).toContainText('coach@example.com');
+    await expect(page.locator('#admin-list')).toContainText('owner@example.com');
+    await expect(page.locator('#admin-list')).not.toContainText('coach@example.com');
 
     expect(await page.evaluate(() => window.__lastAdminInvite)).toEqual({
         teamId: 'team-1',
         email: 'coach@example.com'
     });
-    expect(await page.evaluate(() => window.__lastPersistedAdmin)).toEqual({
-        teamId: 'team-1',
-        email: 'coach@example.com'
-    });
+    expect(await page.evaluate(() => window.__lastPersistedAdmin)).toBeUndefined();
 });
 
 test('accept-invite redeems an admin invite into dashboard access', async ({ page, baseURL }) => {

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -53,7 +53,7 @@ describe('React app team detail model', () => {
         const result = await inviteTeamAdminForApp(' team-1 ', ' Coach@Example.com ');
 
         expect(inviteAdmin).toHaveBeenCalledWith('team-1', 'coach@example.com');
-        expect(addTeamAdminEmail).toHaveBeenCalledWith('team-1', 'coach@example.com');
+        expect(addTeamAdminEmail).not.toHaveBeenCalled();
         expect(sendInviteEmail).toHaveBeenCalledWith('coach@example.com', 'CODE 1', 'admin', { teamName: 'Bears' });
         expect(result).toMatchObject({
             email: 'coach@example.com',

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -690,7 +690,7 @@ describe('edit team admin access persistence', () => {
         }
     });
 
-  it('adds a mixed-case admin once in lowercase and keeps next-load access aligned with the saved list', async () => {
+  it('normalizes an invited existing-team admin email without granting access before redemption', async () => {
         const initialState = {
             currentUser: { uid: 'owner-1', email: 'owner@example.com' },
             team: {
@@ -718,8 +718,7 @@ describe('edit team admin access persistence', () => {
 
             expect(env.state.updateCalls).toHaveLength(1);
             expect(env.state.updateCalls[0].teamData.adminEmails).toEqual([
-                'existing@example.com',
-                'newadmin@example.com'
+                'existing@example.com'
             ]);
         } finally {
             env.cleanup();
@@ -730,10 +729,53 @@ describe('edit team admin access persistence', () => {
             currentUser: { uid: 'user-new', email: 'newadmin@example.com' }
         });
         try {
-            expect(reloadEnv.elements.get('page-title').textContent).toBe('Edit Team');
-            expect(reloadEnv.elements.get('admin-list').textContent).toContain('existing@example.com');
-            expect(reloadEnv.elements.get('admin-list').textContent).toContain('newadmin@example.com');
-            expect(reloadEnv.elements.get('admin-list').querySelectorAll('.remove-admin-btn')).toHaveLength(2);
+            expect(reloadEnv.alerts).toContain("You don't have permission to edit this team.");
+            expect(reloadEnv.window.location.href).toBe('http://example.com/dashboard.html');
+        } finally {
+            reloadEnv.cleanup();
+        }
+    });
+
+    it('keeps invited existing-team admins out of the saved admin list until redemption', async () => {
+        const initialState = {
+            currentUser: { uid: 'owner-1', email: 'owner@example.com' },
+            team: {
+                id: 'team-1',
+                ownerId: 'owner-1',
+                name: 'Sharks',
+                description: 'Travel team',
+                sport: 'Basketball',
+                notificationEmail: 'notify@example.com',
+                leagueUrl: '',
+                standingsConfig: { enabled: false, rankingMode: 'points', tiebreakers: [] },
+                zip: '66209',
+                isPublic: true,
+                adminEmails: ['existing@example.com']
+            },
+            updateCalls: []
+        };
+
+        const env = await bootEditTeam(initialState);
+        try {
+            await env.elements.get('add-admin-btn').click();
+            env.elements.get('admin-email-input').value = 'pending@example.com';
+            await env.elements.get('save-admin-btn').click();
+            await env.elements.get('team-form').requestSubmit();
+
+            expect(env.state.updateCalls).toHaveLength(1);
+            expect(env.state.updateCalls[0].teamData.adminEmails).toEqual(['existing@example.com']);
+            expect(env.elements.get('admin-list').textContent).not.toContain('pending@example.com');
+        } finally {
+            env.cleanup();
+        }
+
+        const reloadEnv = await bootEditTeam({
+            ...env.state,
+            currentUser: { uid: 'user-pending', email: 'pending@example.com' }
+        });
+        try {
+            expect(reloadEnv.alerts).toContain("You don't have permission to edit this team.");
+            expect(reloadEnv.window.location.href).toBe('http://example.com/dashboard.html');
         } finally {
             reloadEnv.cleanup();
         }

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -341,8 +341,8 @@ function extractEditTeamModule() {
 
     return match[1]
         .replace(
-            "import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers } from './js/db.js?v=33';",
-            'const { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers } = deps.db;'
+            "import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes } from './js/db.js?v=33';",
+            'const { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes } = deps.db;'
         )
         .replace(
             "import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';",
@@ -369,8 +369,8 @@ function extractEditTeamModule() {
             'const { hasFullTeamAccess, normalizeAdminEmailList, normalizeStreamVolunteerEmailList, normalizeTeamPermissions } = deps.teamAccess;'
         )
         .replace(
-            "import { processPendingAdminInvites, buildAdminInviteFollowUp, inviteExistingTeamAdmin } from './js/edit-team-admin-invites.js?v=4';",
-            'const { processPendingAdminInvites, buildAdminInviteFollowUp, inviteExistingTeamAdmin } = deps.editTeamAdminInvites;'
+            "import { processPendingAdminInvites, buildAdminInviteFollowUp, inviteExistingTeamAdmin, loadPendingAdminInviteEmails } from './js/edit-team-admin-invites.js?v=4';",
+            'const { processPendingAdminInvites, buildAdminInviteFollowUp, inviteExistingTeamAdmin, loadPendingAdminInviteEmails } = deps.editTeamAdminInvites;'
         )
         .replace(
             "import { buildRolloverAccessPreview, buildStaffAdminRolloverUpdate } from './js/rollover-access.js?v=1';",
@@ -451,6 +451,9 @@ async function bootEditTeam(initialState, overrides = {}) {
             async addTeamAdminEmail() {},
             async getAllUsers() {
                 return env.state.users || [];
+            },
+            async getTeamAccessCodes(teamId) {
+                return (env.state.teamAccessCodes || []).filter((code) => code.teamId === teamId);
             }
         },
         utils: {
@@ -497,6 +500,7 @@ async function bootEditTeam(initialState, overrides = {}) {
         rolloverAccess: await import('../../js/rollover-access.js'),
         rosterRolloverPreview: await import('../../js/roster-rollover-preview.js'),
         editTeamAdminInvites: {
+            ...(await import('../../js/edit-team-admin-invites.js')),
             async processPendingAdminInvites() {
                 return { results: [], fallbackCodeCount: 0, failedCount: 0 };
             },
@@ -520,7 +524,7 @@ async function bootEditTeam(initialState, overrides = {}) {
     };
 
     await runEditTeamModule(deps);
-    for (let i = 0; i < 5; i += 1) {
+    for (let i = 0; i < 20; i += 1) {
         await Promise.resolve();
     }
 
@@ -737,6 +741,7 @@ describe('edit team admin access persistence', () => {
     });
 
     it('keeps invited existing-team admins out of the saved admin list until redemption', async () => {
+        const future = Date.now() + 60_000;
         const initialState = {
             currentUser: { uid: 'owner-1', email: 'owner@example.com' },
             team: {
@@ -767,6 +772,30 @@ describe('edit team admin access persistence', () => {
             expect(env.elements.get('admin-list').textContent).not.toContain('pending@example.com');
         } finally {
             env.cleanup();
+        }
+
+        const ownerReloadEnv = await bootEditTeam({
+            ...env.state,
+            currentUser: { uid: 'owner-1', email: 'owner@example.com' },
+            teamAccessCodes: [
+                {
+                    id: 'invite-1',
+                    teamId: 'team-1',
+                    email: 'pending@example.com',
+                    type: 'admin_invite',
+                    used: false,
+                    expiresAt: { toMillis: () => future }
+                }
+            ]
+        });
+        try {
+            await ownerReloadEnv.elements.get('add-admin-btn').click();
+            ownerReloadEnv.elements.get('admin-email-input').value = 'pending@example.com';
+            await ownerReloadEnv.elements.get('save-admin-btn').click();
+
+            expect(ownerReloadEnv.elements.get('admin-invite-status').textContent).toBe('This email already has a pending invite.');
+        } finally {
+            ownerReloadEnv.cleanup();
         }
 
         const reloadEnv = await bootEditTeam({

--- a/tests/unit/edit-team-admin-invites.test.js
+++ b/tests/unit/edit-team-admin-invites.test.js
@@ -7,7 +7,7 @@ import {
 } from '../../js/edit-team-admin-invites.js';
 
 describe('edit team admin invite processing', () => {
-    it('persists invited admin access immediately for existing teams', async () => {
+    it('creates an existing-team admin invite without granting access before redemption', async () => {
         const inviteAdmin = vi.fn().mockResolvedValue({
             code: 'CODE1111',
             teamName: 'Tigers',
@@ -25,9 +25,8 @@ describe('edit team admin invite processing', () => {
         });
 
         expect(inviteAdmin).toHaveBeenCalledWith('team-123', 'coach@example.com');
-        expect(addTeamAdminEmail).toHaveBeenCalledWith('team-123', 'coach@example.com');
+        expect(addTeamAdminEmail).not.toHaveBeenCalled();
         expect(sendInviteEmail).toHaveBeenCalledWith('coach@example.com', 'CODE1111', 'admin', { teamName: 'Tigers' });
-        expect(addTeamAdminEmail.mock.invocationCallOrder[0]).toBeLessThan(sendInviteEmail.mock.invocationCallOrder[0]);
         expect(result).toEqual({
             email: 'coach@example.com',
             status: 'sent',
@@ -36,7 +35,7 @@ describe('edit team admin invite processing', () => {
         });
     });
 
-    it('still persists invited admin access when the invited user already exists', async () => {
+    it('returns an existing-user invite without granting access before redemption', async () => {
         const inviteAdmin = vi.fn().mockResolvedValue({
             code: 'EXIST111',
             teamName: 'Tigers',
@@ -53,7 +52,7 @@ describe('edit team admin invite processing', () => {
             sendInviteEmail
         });
 
-        expect(addTeamAdminEmail).toHaveBeenCalledWith('team-123', 'coach@example.com');
+        expect(addTeamAdminEmail).not.toHaveBeenCalled();
         expect(sendInviteEmail).not.toHaveBeenCalled();
         expect(result).toEqual({
             email: 'coach@example.com',

--- a/tests/unit/edit-team-admin-invites.test.js
+++ b/tests/unit/edit-team-admin-invites.test.js
@@ -3,7 +3,8 @@ import { readFileSync } from 'node:fs';
 import {
     processPendingAdminInvites,
     buildAdminInviteFollowUp,
-    inviteExistingTeamAdmin
+    inviteExistingTeamAdmin,
+    loadPendingAdminInviteEmails
 } from '../../js/edit-team-admin-invites.js';
 
 describe('edit team admin invite processing', () => {
@@ -98,6 +99,26 @@ describe('edit team admin invite processing', () => {
             teamName: 'Tigers',
             reason: 'missing_invite_code'
         });
+    });
+
+    it('hydrates pending invite emails from active team access codes', async () => {
+        const future = Date.now() + 60_000;
+        const getTeamAccessCodes = vi.fn().mockResolvedValue([
+            { email: 'pending@example.com', teamId: 'team-123', type: 'admin_invite', used: false, expiresAt: { toMillis: () => future } },
+            { email: 'PENDING@example.com ', teamId: 'team-123', type: 'admin_invite', used: false, status: 'active', expiresAt: { toMillis: () => future } },
+            { email: 'expired@example.com', teamId: 'team-123', type: 'admin_invite', used: false, expiresAt: { toMillis: () => future - 120_000 } },
+            { email: 'used@example.com', teamId: 'team-123', type: 'admin_invite', used: true, expiresAt: { toMillis: () => future } },
+            { email: 'inactive@example.com', teamId: 'team-123', type: 'admin_invite', used: false, active: false, expiresAt: { toMillis: () => future } },
+            { email: 'wrongtype@example.com', teamId: 'team-123', type: 'standard', used: false, expiresAt: { toMillis: () => future } }
+        ]);
+
+        const emails = await loadPendingAdminInviteEmails({
+            teamId: 'team-123',
+            getTeamAccessCodes
+        });
+
+        expect(getTeamAccessCodes).toHaveBeenCalledWith('team-123');
+        expect(emails).toEqual(['pending@example.com']);
     });
 
     it('processes each pending invite after team creation', async () => {


### PR DESCRIPTION
Closes #1690

## What changed
- stopped existing-team admin invites from writing invited emails into active admin access before invite redemption
- kept invited existing-team emails in pending invite state on the edit form so duplicate invites are blocked without persisting edit access
- updated regression coverage for the legacy edit-team flow and the app invite helper to assert invited admins stay blocked until redemption

## Why
The bug came from treating an invited email like a confirmed admin before the invite code was redeemed. This patch preserves the redemption gate by leaving `team.adminEmails` unchanged until the acceptance flow completes.