### PR TITLE
Add native sharing to profile invite links

### DIFF
--- a/apps/app/src/pages/Profile.test.tsx
+++ b/apps/app/src/pages/Profile.test.tsx
@@ -1,0 +1,157 @@
+// @vitest-environment jsdom
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Profile } from './Profile';
+import type { AuthState } from '../lib/types';
+
+const profileServiceMocks = vi.hoisted(() => ({
+  createProfileAccessCode: vi.fn(),
+  loadParentTeams: vi.fn(),
+  loadNotificationPreferences: vi.fn(),
+  loadNotificationTeams: vi.fn(),
+  loadProfileAccessCodes: vi.fn(),
+  loadProfileDocument: vi.fn(),
+  normalizeNotificationPreferences: vi.fn(),
+  requestAccountMerge: vi.fn(),
+  saveNotificationPreferences: vi.fn(),
+  saveProfileDocument: vi.fn(),
+  uploadProfilePhoto: vi.fn()
+}));
+
+const publicActionsMocks = vi.hoisted(() => ({
+  sharePublicUrl: vi.fn()
+}));
+
+vi.mock('../lib/profileService', () => profileServiceMocks);
+vi.mock('../lib/publicActions', () => publicActionsMocks);
+vi.mock('../lib/pushService', () => ({
+  enablePushNotificationsForUser: vi.fn()
+}));
+vi.mock('../lib/useShellLayout', () => ({
+  useShellLayout: () => ({ isDesktopWeb: false })
+}));
+vi.mock('../lib/authService', () => ({
+  describeAuthError: (error: any) => error?.message || 'Authentication failed.',
+  reloadCurrentUser: vi.fn(),
+  resendVerificationEmail: vi.fn(),
+  sendResetEmail: vi.fn(),
+  setCurrentUserPassword: vi.fn()
+}));
+
+const auth: AuthState = {
+  user: {
+    uid: 'user-1',
+    email: 'parent@example.com',
+    displayName: 'Pat Parent',
+    emailVerified: false,
+    roles: ['parent'],
+    parentOf: []
+  },
+  profile: null,
+  loading: false,
+  error: null,
+  roles: ['parent'],
+  isParent: true,
+  isCoach: false,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: vi.fn().mockResolvedValue(undefined),
+  signOut: vi.fn().mockResolvedValue(undefined)
+};
+
+function renderProfile() {
+  return render(
+    <MemoryRouter>
+      <Profile auth={auth} />
+    </MemoryRouter>
+  );
+}
+
+describe('Profile invites', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal('scrollTo', vi.fn());
+    profileServiceMocks.normalizeNotificationPreferences.mockImplementation((preferences?: any) => ({
+      liveChat: preferences?.liveChat !== false,
+      liveScore: preferences?.liveScore === true,
+      schedule: preferences?.schedule !== false
+    }));
+    profileServiceMocks.loadProfileDocument.mockResolvedValue({
+      fullName: 'Pat Parent',
+      phone: '555-0100',
+      photoUrl: '',
+      signInMethod: 'emailLink',
+      hasPassword: false,
+      updatedAt: { seconds: 1717200000 }
+    });
+    profileServiceMocks.loadNotificationTeams.mockResolvedValue([]);
+    profileServiceMocks.loadNotificationPreferences.mockResolvedValue({ liveChat: true, liveScore: false, schedule: true });
+    profileServiceMocks.loadParentTeams.mockResolvedValue([]);
+    profileServiceMocks.requestAccountMerge.mockResolvedValue(undefined);
+    profileServiceMocks.saveNotificationPreferences.mockResolvedValue({ liveChat: true, liveScore: false, schedule: true });
+    profileServiceMocks.saveProfileDocument.mockResolvedValue(undefined);
+    profileServiceMocks.uploadProfilePhoto.mockResolvedValue('https://example.test/avatar.png');
+    profileServiceMocks.createProfileAccessCode.mockResolvedValue('NEWMVP42');
+    profileServiceMocks.loadProfileAccessCodes.mockResolvedValue([
+      { id: 'code-1', code: 'ACTIVE123', email: 'coach@example.com', phone: '', used: false, createdAt: { seconds: 1717200000 } },
+      { id: 'code-2', code: 'USED1234', email: 'used@example.com', phone: '', used: true, createdAt: { seconds: 1717113600 }, usedAt: { seconds: 1717200000 } }
+    ]);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('shares a generated invite link with invite metadata before any copy fallback', async () => {
+    publicActionsMocks.sharePublicUrl.mockResolvedValue('shared');
+    renderProfile();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Invites' }));
+    fireEvent.change(screen.getByLabelText('Invite email label'), { target: { value: 'coach@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Generate invite link' }));
+
+    await screen.findByText('Generated invite link');
+    fireEvent.click(screen.getByRole('button', { name: 'Share invite link' }));
+
+    await waitFor(() => expect(publicActionsMocks.sharePublicUrl).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'ALL PLAYS invite for coach@example.com',
+      text: 'Use this ALL PLAYS invite link for coach@example.com.',
+      url: expect.stringContaining('/login.html?code=NEWMVP42'),
+      clipboardText: expect.stringContaining('/login.html?code=NEWMVP42')
+    })));
+    expect(screen.getByText('Share sheet opened.')).toBeInTheDocument();
+  });
+
+  it('shows active invite share actions, hides them for used codes, and surfaces copied and cancelled statuses', async () => {
+    publicActionsMocks.sharePublicUrl.mockResolvedValueOnce('copied').mockResolvedValueOnce('cancelled');
+    renderProfile();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Invites' }));
+
+    const shareButtons = await screen.findAllByRole('button', { name: /Share invite link/ });
+    expect(shareButtons).toHaveLength(1);
+    const copyLinkButtons = screen.getAllByRole('button', { name: /Copy invite link/ });
+    expect(copyLinkButtons).toHaveLength(1);
+    const copyCodeButtons = screen.getAllByRole('button', { name: /Copy invite code/ });
+    expect(copyCodeButtons).toHaveLength(2);
+
+    const activeCard = shareButtons[0].closest('div.rounded-xl') as HTMLElement | null;
+    const usedCard = screen.getByLabelText('Copy invite code USED1234').closest('div.rounded-xl') as HTMLElement | null;
+    if (!activeCard || !usedCard) {
+      throw new Error('Expected invite cards to render');
+    }
+
+    expect(within(activeCard).getByRole('button', { name: /Share invite link/ })).toBeInTheDocument();
+    expect(within(activeCard).getByRole('button', { name: /Copy invite link/ })).toBeInTheDocument();
+    expect(within(usedCard).queryByRole('button', { name: /Share invite link/ })).not.toBeInTheDocument();
+    expect(within(usedCard).queryByRole('button', { name: /Copy invite link/ })).not.toBeInTheDocument();
+
+    fireEvent.click(within(activeCard).getByRole('button', { name: /Share invite link/ }));
+    expect(await screen.findByText('Link copied.')).toBeInTheDocument();
+
+    fireEvent.click(within(activeCard).getByRole('button', { name: /Share invite link/ }));
+    expect(await screen.findByText('Share cancelled.')).toBeInTheDocument();
+  });
+});

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -999,18 +999,18 @@ function AccessCodeCard({ code, onCopy, onShare }: { code: AccessCodeRecord; onC
           <span className={`rounded-full px-2 py-1 text-[11px] font-black uppercase tracking-[0.04em] ${code.used ? 'bg-gray-200 text-gray-700' : 'bg-emerald-100 text-emerald-700'}`}>{code.used ? 'Used' : 'Active'}</span>
         </div>
         <div className="flex flex-wrap gap-2">
-          <button type="button" className="ghost-button !min-h-9 !px-3 !py-1.5" onClick={() => onCopy(code.code, 'Code copied.')} aria-label={`Copy invite code ${code.code}`}>
+          <button type="button" className="ghost-button !min-h-9 !px-3 !py-1.5" onClick={() => onCopy(code.code, 'Code copied.')} aria-label={`Copy saved invite code ${code.code}`}>
             <Copy className="h-4 w-4" aria-hidden="true" />
             <span className="text-xs font-black">Copy code</span>
           </button>
           {!code.used ? (
-            <button type="button" className="ghost-button !min-h-9 !px-3 !py-1.5" onClick={() => onShare(code.code, { email: code.email, phone: code.phone })} aria-label={`Share invite link for ${code.code}`}>
+            <button type="button" className="ghost-button !min-h-9 !px-3 !py-1.5" onClick={() => onShare(code.code, { email: code.email, phone: code.phone })} aria-label={`Share saved invite link for ${code.code}`}>
               <Share2 className="h-4 w-4" aria-hidden="true" />
               <span className="text-xs font-black">Share link</span>
             </button>
           ) : null}
           {!code.used ? (
-            <button type="button" className="ghost-button !min-h-9 !px-3 !py-1.5" onClick={() => onCopy(signupLink, 'Link copied.')} aria-label={`Copy invite link for ${code.code}`}>
+            <button type="button" className="ghost-button !min-h-9 !px-3 !py-1.5" onClick={() => onCopy(signupLink, 'Link copied.')} aria-label={`Copy saved invite link for ${code.code}`}>
               <Link2 className="h-4 w-4" aria-hidden="true" />
               <span className="text-xs font-black">Copy link</span>
             </button>

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -16,6 +16,7 @@ import {
   RefreshCw,
   Save,
   Send,
+  Share2,
   ShieldCheck,
   Trash2,
   Upload,
@@ -37,6 +38,7 @@ import {
   uploadProfilePhoto
 } from '../lib/profileService';
 import { enablePushNotificationsForUser } from '../lib/pushService';
+import { sharePublicUrl } from '../lib/publicActions';
 import { useShellLayout } from '../lib/useShellLayout';
 import type { AccessCodeRecord, NotificationPreferences, NotificationTeam, ProfileDocument } from '../lib/profileService';
 import type { AuthState } from '../lib/types';
@@ -94,13 +96,14 @@ export function Profile({ auth }: { auth: AuthState }) {
   const [passwordStatus, setPasswordStatus] = useState<Status | null>(null);
   const [inviteStatus, setInviteStatus] = useState<Status | null>(null);
   const [accountMergeStatus, setAccountMergeStatus] = useState<Status | null>(null);
-  const [copyStatus, setCopyStatus] = useState('');
+  const [inviteActionStatus, setInviteActionStatus] = useState('');
   const [inviteHistoryExpanded, setInviteHistoryExpanded] = useState(false);
   const [activeProfileSection, setActiveProfileSection] = useState<ProfileSectionId>('account');
   const [notificationTeamsLoaded, setNotificationTeamsLoaded] = useState(false);
   const [accessCodesLoaded, setAccessCodesLoaded] = useState(false);
   const [parentLinkedTeamsLoaded, setParentLinkedTeamsLoaded] = useState(false);
   const [loadedNotificationTeamId, setLoadedNotificationTeamId] = useState('');
+  const [generatedInviteMetadata, setGeneratedInviteMetadata] = useState<{ email: string; phone: string }>({ email: '', phone: '' });
 
   const displayName = fullName || user?.displayName || profile.displayName || user?.email || 'ALL PLAYS User';
   const showPasswordSection = profile.signInMethod === 'emailLink' && !profile.hasPassword;
@@ -136,6 +139,7 @@ export function Profile({ auth }: { auth: AuthState }) {
       setLoadedNotificationTeamId('');
       setSelectedTeamId('');
       setAccessCodes([]);
+      setInviteActionStatus('');
       setAccessCodesLoaded(false);
       setParentLinkedTeams([]);
       setParentLinkedTeamsLoaded(false);
@@ -526,10 +530,14 @@ export function Profile({ auth }: { auth: AuthState }) {
 
     setBusy('invite');
     setInviteStatus(null);
+    setInviteActionStatus('');
 
     try {
-      const code = await createProfileAccessCode(user.uid, inviteEmail.trim(), invitePhone.trim());
+      const nextInviteEmail = inviteEmail.trim();
+      const nextInvitePhone = invitePhone.trim();
+      const code = await createProfileAccessCode(user.uid, nextInviteEmail, nextInvitePhone);
       setGeneratedCode(code);
+      setGeneratedInviteMetadata({ email: nextInviteEmail, phone: nextInvitePhone });
       setInviteEmail('');
       setInvitePhone('');
       setAccessCodes(await loadProfileAccessCodes(user.uid));
@@ -583,12 +591,29 @@ export function Profile({ auth }: { auth: AuthState }) {
   const copyText = async (text: string, label: string) => {
     try {
       await navigator.clipboard.writeText(text);
-      setCopyStatus(label);
-      window.setTimeout(() => setCopyStatus(''), 1800);
+      setInviteActionStatus(label);
+      window.setTimeout(() => setInviteActionStatus(''), 1800);
     } catch {
-      setCopyStatus('Copy failed');
-      window.setTimeout(() => setCopyStatus(''), 1800);
+      setInviteActionStatus('Copy failed');
+      window.setTimeout(() => setInviteActionStatus(''), 1800);
     }
+  };
+
+  const shareInviteLink = async (code: string, metadata?: { email?: string | null; phone?: string | null }) => {
+    const result = await sharePublicUrl(buildInviteShareInput(code, metadata));
+    if (result === 'shared') {
+      setInviteActionStatus('Share sheet opened.');
+      return;
+    }
+    if (result === 'copied') {
+      setInviteActionStatus('Link copied.');
+      return;
+    }
+    if (result === 'cancelled') {
+      setInviteActionStatus('Share cancelled.');
+      return;
+    }
+    setInviteActionStatus('Unable to share invite link.');
   };
 
   const handleSignOut = async () => {
@@ -911,17 +936,21 @@ export function Profile({ auth }: { auth: AuthState }) {
           <div className="mt-4 rounded-xl border border-emerald-200 bg-emerald-50 p-3">
             <div className="text-xs font-extrabold uppercase tracking-[0.04em] text-emerald-700">Generated invite link</div>
             <div className="mt-2 flex flex-wrap items-center gap-2">
-              <button type="button" className="primary-button" onClick={() => copyText(signupLink, 'Link copied')}>
+              <button type="button" className="primary-button" onClick={() => shareInviteLink(generatedCode, generatedInviteMetadata)}>
+                <Share2 className="h-4 w-4" aria-hidden="true" />
+                Share invite link
+              </button>
+              <button type="button" className="ghost-button" onClick={() => copyText(signupLink, 'Link copied.')}>
                 <Link2 className="h-4 w-4" aria-hidden="true" />
                 Copy invite link
               </button>
               <span className="break-all rounded-lg bg-white px-3 py-2 text-sm font-bold text-gray-700">{signupLink}</span>
-              {copyStatus ? <span className="text-sm font-black text-emerald-700">{copyStatus}</span> : null}
             </div>
+            {inviteActionStatus ? <div className="mt-2 text-sm font-black text-emerald-700">{inviteActionStatus}</div> : null}
             <div className="mt-3 flex flex-wrap items-center gap-2 text-sm font-bold text-gray-600">
               <span>Fallback code</span>
               <code className="rounded-lg bg-white px-3 py-1.5 text-lg font-black tracking-widest text-gray-950">{generatedCode}</code>
-              <button type="button" className="ghost-button" onClick={() => copyText(generatedCode, 'Code copied')}>
+              <button type="button" className="ghost-button" onClick={() => copyText(generatedCode, 'Code copied.')}>
                 <Copy className="h-4 w-4" aria-hidden="true" />
                 Copy code
               </button>
@@ -931,11 +960,13 @@ export function Profile({ auth }: { auth: AuthState }) {
 
         <div className="mt-4 space-y-2">
           {accessCodes.length ? visibleAccessCodes.map((code) => (
-            <AccessCodeCard key={code.id} code={code} onCopy={copyText} />
+            <AccessCodeCard key={code.id} code={code} onCopy={copyText} onShare={shareInviteLink} />
           )) : (
             <div className="rounded-xl border border-gray-200 bg-gray-50 p-3 text-sm font-semibold text-gray-500">No codes generated yet.</div>
           )}
         </div>
+
+        {!generatedCode && inviteActionStatus ? <div className="mt-3 text-sm font-black text-emerald-700">{inviteActionStatus}</div> : null}
 
         {accessCodes.length > collapsedInviteCount ? (
           <button type="button" className="ghost-button mt-3 w-full justify-center" onClick={() => setInviteHistoryExpanded((current) => !current)}>
@@ -958,7 +989,7 @@ function PreferenceToggle({ label, checked, onChange }: { label: string; checked
   );
 }
 
-function AccessCodeCard({ code, onCopy }: { code: AccessCodeRecord; onCopy: (text: string, label: string) => void }) {
+function AccessCodeCard({ code, onCopy, onShare }: { code: AccessCodeRecord; onCopy: (text: string, label: string) => void; onShare: (code: string, metadata?: { email?: string | null; phone?: string | null }) => void }) {
   const signupLink = buildSignupLink(code.code);
   return (
     <div className={`rounded-xl border p-3 ${code.used ? 'border-gray-200 bg-gray-50' : 'border-primary-200 bg-white'}`}>
@@ -967,13 +998,21 @@ function AccessCodeCard({ code, onCopy }: { code: AccessCodeRecord; onCopy: (tex
           <code className="rounded-lg bg-primary-50 px-3 py-1.5 text-lg font-black tracking-widest text-primary-900">{code.code}</code>
           <span className={`rounded-full px-2 py-1 text-[11px] font-black uppercase tracking-[0.04em] ${code.used ? 'bg-gray-200 text-gray-700' : 'bg-emerald-100 text-emerald-700'}`}>{code.used ? 'Used' : 'Active'}</span>
         </div>
-        <div className="flex gap-2">
-          <button type="button" className="ghost-button !min-h-9 !px-3 !py-1.5" onClick={() => onCopy(code.code, 'Code copied')}>
+        <div className="flex flex-wrap gap-2">
+          <button type="button" className="ghost-button !min-h-9 !px-3 !py-1.5" onClick={() => onCopy(code.code, 'Code copied.')} aria-label={`Copy invite code ${code.code}`}>
             <Copy className="h-4 w-4" aria-hidden="true" />
+            <span className="text-xs font-black">Copy code</span>
           </button>
           {!code.used ? (
-            <button type="button" className="ghost-button !min-h-9 !px-3 !py-1.5" onClick={() => onCopy(signupLink, 'Link copied')}>
+            <button type="button" className="ghost-button !min-h-9 !px-3 !py-1.5" onClick={() => onShare(code.code, { email: code.email, phone: code.phone })} aria-label={`Share invite link for ${code.code}`}>
+              <Share2 className="h-4 w-4" aria-hidden="true" />
+              <span className="text-xs font-black">Share link</span>
+            </button>
+          ) : null}
+          {!code.used ? (
+            <button type="button" className="ghost-button !min-h-9 !px-3 !py-1.5" onClick={() => onCopy(signupLink, 'Link copied.')} aria-label={`Copy invite link for ${code.code}`}>
               <Link2 className="h-4 w-4" aria-hidden="true" />
+              <span className="text-xs font-black">Copy link</span>
             </button>
           ) : null}
         </div>
@@ -1029,6 +1068,18 @@ function toDate(value: any): Date | null {
 function buildSignupLink(code: string) {
   const origin = window.location.protocol === 'capacitor:' ? 'https://allplays.ai' : window.location.origin;
   return `${origin}/login.html?code=${encodeURIComponent(code)}`;
+}
+
+function buildInviteShareInput(code: string, metadata?: { email?: string | null; phone?: string | null }) {
+  const recipientDetails = [metadata?.email, metadata?.phone].map((value) => String(value || '').trim()).filter(Boolean);
+  const recipientLabel = recipientDetails.join(' • ');
+  const signupLink = buildSignupLink(code);
+  return {
+    title: recipientLabel ? `ALL PLAYS invite for ${recipientLabel}` : 'ALL PLAYS invite link',
+    text: recipientLabel ? `Use this ALL PLAYS invite link for ${recipientLabel}.` : 'Use this ALL PLAYS invite link to join ALL PLAYS.',
+    url: signupLink,
+    clipboardText: signupLink
+  };
 }
 
 function normalizeEmail(value: string | null | undefined) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,10 @@
       "devDependencies": {
         "@capacitor/cli": "^8.3.4",
         "@playwright/test": "^1.59.1",
+        "@testing-library/react": "^16.3.2",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
+        "react-router-dom": "^7.16.0",
         "vitest": "^4.0.18"
       }
     },
@@ -70,6 +74,43 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "license": "MIT"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@bramus/specificity": {
       "version": "2.4.2",
@@ -2057,6 +2098,63 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
@@ -2253,6 +2351,17 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -2431,6 +2540,20 @@
         "node": ">=18"
       }
     },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -2505,6 +2628,25 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/elementtree": {
       "version": "0.1.7",
@@ -2861,6 +3003,14 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/jsdom": {
       "version": "29.1.1",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.1.1.tgz",
@@ -2943,6 +3093,17 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -3252,6 +3413,36 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -3307,6 +3498,77 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-router": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.16.0.tgz",
+      "integrity": "sha512-wArC8lVyJb3+jM9OpDyW6hLCizACWkvQR/sSGqSs+o5uEXEtGlqdZ4v8hENR3Jad6i+LRkK93q/+bQAcvl6V1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.16.0.tgz",
+      "integrity": "sha512-kMUAbimWB5FVbF4Bce4bJsiKJWLIUHq/mEG8+CFDnCSgltptBiG5nguducmsJeGKytlCvQud9Qhzpn49iduTlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.16.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/readable-stream": {
@@ -3446,6 +3708,13 @@
         "node": ">=v12.22.7"
       }
     },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
@@ -3458,6 +3727,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,10 @@
   "devDependencies": {
     "@capacitor/cli": "^8.3.4",
     "@playwright/test": "^1.59.1",
+    "@testing-library/react": "^16.3.2",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
+    "react-router-dom": "^7.16.0",
     "vitest": "^4.0.18"
   },
   "dependencies": {

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -38,6 +38,7 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
             push: 0,
             accessCodes: []
         };
+        window.__appShareCalls = [];
     }, { mockUser: user, mockEmailLink: emailLink });
 
     await page.route(/\/src\/lib\/useAuth\.ts(\?.*)?$/, async (route) => {
@@ -407,7 +408,8 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
                 export async function copyPublicText() {
                     return 'copied';
                 }
-                export async function sharePublicUrl() {
+                export async function sharePublicUrl(input) {
+                    window.__appShareCalls.push(input);
                     return 'shared';
                 }
             `
@@ -524,9 +526,12 @@ test('profile exposes account, notification, invite, verification, password, upl
     await expect(page.getByText('Advanced: add recipient label')).toBeVisible();
     await page.getByRole('button', { name: 'Generate invite link' }).click();
     await expect(page.getByText('Generated invite link')).toBeVisible();
-    const copyInviteLink = page.getByRole('button', { name: 'Copy invite link' });
-    await expect(copyInviteLink).toBeVisible();
-    await expect(copyInviteLink).toHaveClass(/primary-button/);
+    const shareInviteLink = page.getByRole('button', { name: 'Share invite link' });
+    await expect(shareInviteLink).toBeVisible();
+    await expect(shareInviteLink).toHaveClass(/primary-button/);
+    await expect(page.getByRole('button', { name: 'Copy invite link' })).toBeVisible();
+    await shareInviteLink.click();
+    await expect(page.getByText('Share sheet opened.')).toBeVisible();
     await expect(page.getByText('Fallback code')).toBeVisible();
     await expect(page.getByText('NEWMVP42', { exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Copy code' })).toBeVisible();
@@ -548,6 +553,7 @@ test('profile exposes account, notification, invite, verification, password, upl
         push: window.__appProfileCalls.push,
         notificationSaves: window.__appProfileCalls.notificationSaves,
         accessCodes: window.__appProfileCalls.accessCodes,
+        shares: window.__appShareCalls,
         password: window.__appAuthCalls.setCurrentUserPassword,
         reset: window.__appAuthCalls.sendResetEmail,
         signOut: window.__appAuthCalls.signOut
@@ -559,6 +565,12 @@ test('profile exposes account, notification, invite, verification, password, upl
             { userId: 'user-1', teamId: 'team-1', preferences: { liveChat: false, liveScore: true, schedule: true } }
         ],
         accessCodes: [{ userId: 'user-1', email: '', phone: '' }],
+        shares: [expect.objectContaining({
+            title: 'ALL PLAYS invite link',
+            text: 'Use this ALL PLAYS invite link to join ALL PLAYS.',
+            url: expect.stringContaining('/login.html?code=NEWMVP42'),
+            clipboardText: expect.stringContaining('/login.html?code=NEWMVP42')
+        })],
         password: ['new-password'],
         reset: ['parent@example.com'],
         signOut: 1

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -7,6 +7,13 @@ function appUrl(baseURL, hashPath) {
     return url.toString();
 }
 
+async function openSearch(page) {
+    const searchButton = page.getByRole('button', { name: 'Search' });
+    await expect(searchButton).toBeVisible();
+    await searchButton.click();
+    await expect(page.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeVisible();
+}
+
 async function mockSearchModules(page) {
     await page.addInitScript(() => {
         window.__openedPublicUrls = [];
@@ -162,8 +169,7 @@ test.describe('app global search', () => {
         await mockSearchModules(page);
         await page.goto(appUrl(baseURL, '/home'), { waitUntil: 'domcontentloaded' });
 
-        await page.getByRole('button', { name: 'Search' }).click();
-        await expect(page.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeVisible();
+        await openSearch(page);
         await expect.poll(async () => {
             const box = await page.getByTestId('app-search-panel').boundingBox();
             return Math.round(box?.y || 0);
@@ -188,7 +194,7 @@ test.describe('app global search', () => {
         await mockSearchModules(page);
         await page.goto(appUrl(baseURL, '/home'), { waitUntil: 'domcontentloaded' });
 
-        await page.getByRole('button', { name: 'Search' }).click();
+        await openSearch(page);
         await page.getByLabel('Search teams, players, actions, help').fill('p');
         await expect(page.getByText('Type at least 2 characters to search players')).toBeVisible();
         await expect.poll(() => page.evaluate(() => window.__playerSearchQueries)).toEqual([]);
@@ -206,7 +212,7 @@ test.describe('app global search', () => {
         await page.keyboard.press('Escape');
         await expect(page.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeHidden();
 
-        await page.getByRole('button', { name: 'Search' }).click();
+        await openSearch(page);
         await page.getByRole('button', { name: 'Close search' }).click();
         await expect(page.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeHidden();
     });
@@ -216,8 +222,7 @@ test.describe('desktop app global search', () => {
     test.use({ viewport: { width: 1440, height: 900 }, hasTouch: false });
 
     async function openDesktopSearch(page) {
-        await page.getByRole('button', { name: 'Search' }).click();
-        await expect(page.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeVisible();
+        await openSearch(page);
     }
 
     test('desktop search supports native navigation and website actions', async ({ page, baseURL }) => {

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
 // @vitest-environment jsdom
+import React from 'react';
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -1,10 +1,10 @@
+import React from 'react';
 // @vitest-environment jsdom
-import '@testing-library/jest-dom/vitest';
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { Profile } from './Profile';
-import type { AuthState } from '../lib/types';
+import { Profile } from '../../apps/app/src/pages/Profile';
+import type { AuthState } from '../../apps/app/src/lib/types';
 
 const profileServiceMocks = vi.hoisted(() => ({
   createProfileAccessCode: vi.fn(),
@@ -24,15 +24,15 @@ const publicActionsMocks = vi.hoisted(() => ({
   sharePublicUrl: vi.fn()
 }));
 
-vi.mock('../lib/profileService', () => profileServiceMocks);
-vi.mock('../lib/publicActions', () => publicActionsMocks);
-vi.mock('../lib/pushService', () => ({
+vi.mock('../../apps/app/src/lib/profileService', () => profileServiceMocks);
+vi.mock('../../apps/app/src/lib/publicActions', () => publicActionsMocks);
+vi.mock('../../apps/app/src/lib/pushService', () => ({
   enablePushNotificationsForUser: vi.fn()
 }));
-vi.mock('../lib/useShellLayout', () => ({
+vi.mock('../../apps/app/src/lib/useShellLayout', () => ({
   useShellLayout: () => ({ isDesktopWeb: false })
 }));
-vi.mock('../lib/authService', () => ({
+vi.mock('../../apps/app/src/lib/authService', () => ({
   describeAuthError: (error: any) => error?.message || 'Authentication failed.',
   reloadCurrentUser: vi.fn(),
   resendVerificationEmail: vi.fn(),
@@ -121,7 +121,7 @@ describe('Profile invites', () => {
       url: expect.stringContaining('/login.html?code=NEWMVP42'),
       clipboardText: expect.stringContaining('/login.html?code=NEWMVP42')
     })));
-    expect(screen.getByText('Share sheet opened.')).toBeInTheDocument();
+    expect(screen.getByText('Share sheet opened.')).toBeTruthy();
   });
 
   it('shows active invite share actions, hides them for used codes, and surfaces copied and cancelled statuses', async () => {
@@ -143,15 +143,15 @@ describe('Profile invites', () => {
       throw new Error('Expected invite cards to render');
     }
 
-    expect(within(activeCard).getByRole('button', { name: /Share invite link/ })).toBeInTheDocument();
-    expect(within(activeCard).getByRole('button', { name: /Copy invite link/ })).toBeInTheDocument();
-    expect(within(usedCard).queryByRole('button', { name: /Share invite link/ })).not.toBeInTheDocument();
-    expect(within(usedCard).queryByRole('button', { name: /Copy invite link/ })).not.toBeInTheDocument();
+    expect(within(activeCard).getByRole('button', { name: /Share invite link/ })).toBeTruthy();
+    expect(within(activeCard).getByRole('button', { name: /Copy invite link/ })).toBeTruthy();
+    expect(within(usedCard).queryByRole('button', { name: /Share invite link/ })).toBeNull();
+    expect(within(usedCard).queryByRole('button', { name: /Copy invite link/ })).toBeNull();
 
     fireEvent.click(within(activeCard).getByRole('button', { name: /Share invite link/ }));
-    expect(await screen.findByText('Link copied.')).toBeInTheDocument();
+    expect(await screen.findByText('Link copied.')).toBeTruthy();
 
     fireEvent.click(within(activeCard).getByRole('button', { name: /Share invite link/ }));
-    expect(await screen.findByText('Share cancelled.')).toBeInTheDocument();
+    expect(await screen.findByText('Share cancelled.')).toBeTruthy();
   });
 });

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -130,28 +130,28 @@ describe('Profile invites', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: 'Invites' }));
 
-    const shareButtons = await screen.findAllByRole('button', { name: /Share invite link/ });
+    const shareButtons = await screen.findAllByRole('button', { name: /Share saved invite link/ });
     expect(shareButtons).toHaveLength(1);
-    const copyLinkButtons = screen.getAllByRole('button', { name: /Copy invite link/ });
+    const copyLinkButtons = screen.getAllByRole('button', { name: /Copy saved invite link/ });
     expect(copyLinkButtons).toHaveLength(1);
-    const copyCodeButtons = screen.getAllByRole('button', { name: /Copy invite code/ });
+    const copyCodeButtons = screen.getAllByRole('button', { name: /Copy saved invite code/ });
     expect(copyCodeButtons).toHaveLength(2);
 
     const activeCard = shareButtons[0].closest('div.rounded-xl') as HTMLElement | null;
-    const usedCard = screen.getByLabelText('Copy invite code USED1234').closest('div.rounded-xl') as HTMLElement | null;
+    const usedCard = screen.getByLabelText('Copy saved invite code USED1234').closest('div.rounded-xl') as HTMLElement | null;
     if (!activeCard || !usedCard) {
       throw new Error('Expected invite cards to render');
     }
 
-    expect(within(activeCard).getByRole('button', { name: /Share invite link/ })).toBeTruthy();
-    expect(within(activeCard).getByRole('button', { name: /Copy invite link/ })).toBeTruthy();
-    expect(within(usedCard).queryByRole('button', { name: /Share invite link/ })).toBeNull();
-    expect(within(usedCard).queryByRole('button', { name: /Copy invite link/ })).toBeNull();
+    expect(within(activeCard).getByRole('button', { name: /Share saved invite link/ })).toBeTruthy();
+    expect(within(activeCard).getByRole('button', { name: /Copy saved invite link/ })).toBeTruthy();
+    expect(within(usedCard).queryByRole('button', { name: /Share saved invite link/ })).toBeNull();
+    expect(within(usedCard).queryByRole('button', { name: /Copy saved invite link/ })).toBeNull();
 
-    fireEvent.click(within(activeCard).getByRole('button', { name: /Share invite link/ }));
+    fireEvent.click(within(activeCard).getByRole('button', { name: /Share saved invite link/ }));
     expect(await screen.findByText('Link copied.')).toBeTruthy();
 
-    fireEvent.click(within(activeCard).getByRole('button', { name: /Share invite link/ }));
+    fireEvent.click(within(activeCard).getByRole('button', { name: /Share saved invite link/ }));
     expect(await screen.findByText('Share cancelled.')).toBeTruthy();
   });
 });

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
-import React from 'react';
-import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import React from '../../apps/app/node_modules/react/index.js';
+import { cleanup, fireEvent, render, screen, waitFor, within } from '../../apps/app/node_modules/@testing-library/react/dist/index.js';
+import { MemoryRouter } from '../../apps/app/node_modules/react-router-dom/dist/index.mjs';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Profile } from '../../apps/app/src/pages/Profile';
 import type { AuthState } from '../../apps/app/src/lib/types';


### PR DESCRIPTION
Closes #1696

## What changed
- replaced the post-generation primary Profile invite action with **Share invite link** backed by `sharePublicUrl`
- kept **Copy invite link** and **Copy code** as fallbacks for generated invites
- added share and copy-link actions to active invite history cards while leaving used codes without a share-link action
- mapped share results to clear status text for shared, copied fallback, cancelled, and failed outcomes
- added focused Profile invite tests and updated the profile smoke coverage to assert the share path

## Why
The mobile Profile invite flow only exposed clipboard actions, which made onboarding from the Capacitor app feel unfinished. This wires Profile into the existing native/web share helper so mobile users get the expected share sheet while preserving manual copy options.