### PR TITLE
Load schedule detail without full parent schedule reload

### DIFF
--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -112,6 +112,11 @@ export type ParentScheduleLoadOptions = {
   expandStaffPlayers?: boolean;
 };
 
+export type ParentScheduleEventDetailLoadOptions = ParentScheduleLoadOptions & {
+  teamId: string;
+  eventId: string;
+};
+
 type FirestoreDocument = Record<string, any> & { id: string };
 
 export type StaffRsvpReminderSendResult = StaffRsvpReminderPreview & {
@@ -1598,6 +1603,94 @@ async function hydrateEventDetails(events: ParentScheduleEvent[], user: AuthUser
   return events;
 }
 
+async function buildParentScheduleTeamChildren(user: AuthUser, profile: Record<string, unknown>, options: ParentScheduleLoadOptions = {}) {
+  const expandStaffPlayers = options.expandStaffPlayers !== false;
+  const children = normalizeChildLinks(user, profile as Record<string, unknown>);
+  const byTeam = new Map<string, ParentScheduleChild[]>();
+  children.forEach((child) => {
+    if (!byTeam.has(child.teamId)) byTeam.set(child.teamId, []);
+    byTeam.get(child.teamId)?.push(child);
+  });
+
+  const staffTeams = await loadStaffTeams(user).catch(() => []);
+  await mapWithConcurrency(staffTeams, parentScheduleTeamConcurrency, async (team: any) => {
+    const teamId = compactString(team?.id);
+    if (!teamId) return;
+    const teamName = compactString(team?.name) || teamId;
+    const existingPlayerIds = new Set((byTeam.get(teamId) || []).map((child) => child.playerId));
+    if (!expandStaffPlayers) {
+      if (!existingPlayerIds.size) {
+        byTeam.set(teamId, [{
+          teamId,
+          teamName,
+          playerId: `staff-team-${teamId}`,
+          playerName: 'Team schedule'
+        }]);
+      }
+      return;
+    }
+    const players = await loadPlayers(teamId).catch(() => []);
+    const staffChildren = (Array.isArray(players) ? players : [])
+      .filter((player: any) => player?.active !== false && compactString(player?.id) && !existingPlayerIds.has(compactString(player.id)))
+      .map((player: any) => ({
+        teamId,
+        teamName,
+        playerId: compactString(player.id),
+        playerName: compactString(player.name) || compactString(player.displayName) || 'Player'
+      }));
+    if (staffChildren.length) {
+      byTeam.set(teamId, [...(byTeam.get(teamId) || []), ...staffChildren]);
+    }
+  });
+
+  return { children, byTeam, staffTeams };
+}
+
+export async function loadParentScheduleEventDetail(user: AuthUser | null, options: ParentScheduleEventDetailLoadOptions): Promise<ParentScheduleLoadResult> {
+  const requestedTeamId = compactString(options?.teamId);
+  const requestedEventId = compactString(options?.eventId);
+
+  if (!user?.uid || !requestedTeamId || !requestedEventId) {
+    return { children: [], events: [] };
+  }
+
+  const timer = startUxTimer('parent schedule event detail load');
+  const hydrateDetails = options.hydrateDetails !== false;
+  const expandStaffPlayers = options.expandStaffPlayers !== false;
+
+  try {
+    const profile = await loadProfileDocument(user.uid);
+    const { children, byTeam, staffTeams } = await buildParentScheduleTeamChildren(user, profile as Record<string, unknown>, { expandStaffPlayers });
+    const teamChildren = byTeam.get(requestedTeamId) || [];
+
+    if (!teamChildren.length) {
+      timer.end({ hydrateDetails, expandStaffPlayers, teamId: requestedTeamId, eventId: requestedEventId, childLinks: children.length, teams: byTeam.size, staffTeams: staffTeams.length, eventRows: 0 });
+      return { children, events: [] };
+    }
+
+    const teamEvents = await buildTeamSchedule(requestedTeamId, teamChildren, user);
+    const events = teamEvents.filter((event) => event.id === requestedEventId);
+    if (hydrateDetails && events.length) {
+      await hydrateEventDetails(events, user);
+    }
+    timer.end({
+      hydrateDetails,
+      expandStaffPlayers,
+      teamId: requestedTeamId,
+      eventId: requestedEventId,
+      childLinks: children.length,
+      teams: byTeam.size,
+      staffTeams: staffTeams.length,
+      teamEventRows: teamEvents.length,
+      eventRows: events.length
+    });
+    return { children, events };
+  } catch (error: any) {
+    timer.end({ hydrateDetails, expandStaffPlayers, teamId: requestedTeamId, eventId: requestedEventId, error: error?.message || 'Unable to load schedule event detail.' });
+    throw error;
+  }
+}
+
 export async function loadParentSchedule(user: AuthUser | null, options: ParentScheduleLoadOptions = {}): Promise<ParentScheduleLoadResult> {
   if (!user?.uid) {
     return { children: [], events: [] };
@@ -1608,43 +1701,7 @@ export async function loadParentSchedule(user: AuthUser | null, options: ParentS
 
   try {
     const profile = await loadProfileDocument(user.uid);
-    const children = normalizeChildLinks(user, profile as Record<string, unknown>);
-    const byTeam = new Map<string, ParentScheduleChild[]>();
-    children.forEach((child) => {
-      if (!byTeam.has(child.teamId)) byTeam.set(child.teamId, []);
-      byTeam.get(child.teamId)?.push(child);
-    });
-
-    const staffTeams = await loadStaffTeams(user).catch(() => []);
-    await mapWithConcurrency(staffTeams, parentScheduleTeamConcurrency, async (team: any) => {
-      const teamId = compactString(team?.id);
-      if (!teamId) return;
-      const teamName = compactString(team?.name) || teamId;
-      const existingPlayerIds = new Set((byTeam.get(teamId) || []).map((child) => child.playerId));
-      if (!expandStaffPlayers) {
-        if (!existingPlayerIds.size) {
-          byTeam.set(teamId, [{
-            teamId,
-            teamName,
-            playerId: `staff-team-${teamId}`,
-            playerName: 'Team schedule'
-          }]);
-        }
-        return;
-      }
-      const players = await loadPlayers(teamId).catch(() => []);
-      const staffChildren = (Array.isArray(players) ? players : [])
-        .filter((player: any) => player?.active !== false && compactString(player?.id) && !existingPlayerIds.has(compactString(player.id)))
-        .map((player: any) => ({
-          teamId,
-          teamName,
-          playerId: compactString(player.id),
-          playerName: compactString(player.name) || compactString(player.displayName) || 'Player'
-        }));
-      if (staffChildren.length) {
-        byTeam.set(teamId, [...(byTeam.get(teamId) || []), ...staffChildren]);
-      }
-    });
+    const { children, byTeam, staffTeams } = await buildParentScheduleTeamChildren(user, profile as Record<string, unknown>, { expandStaffPlayers });
 
     const teamEntries = [...byTeam.entries()];
     const eventBatches = await mapWithConcurrency(teamEntries, parentScheduleTeamConcurrency, async ([teamId, teamChildren]) => {

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -7,7 +7,7 @@ import {
   claimParentScheduleAssignmentSlot,
   createParentScheduleRideOffer,
   loadParentPracticePacket,
-  loadParentSchedule,
+  loadParentScheduleEventDetail,
   loadParentScheduleAssignments,
   loadParentScheduleRideOffers,
   loadStaffRsvpReminderPreview,
@@ -198,11 +198,10 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
     setError(null);
     setStatusMessage(null);
     try {
-      const result = await loadParentSchedule(auth.user);
-      const matching = result.events.filter((event) => event.teamId === decodedTeamId && event.id === decodedEventId);
-      setEvents(matching);
-      if (!selectedChildId && matching[0]?.childId) {
-        setSelectedChildId(matching[0].childId);
+      const result = await loadParentScheduleEventDetail(auth.user, { teamId: decodedTeamId, eventId: decodedEventId });
+      setEvents(result.events);
+      if (!selectedChildId && result.events[0]?.childId) {
+        setSelectedChildId(result.events[0].childId);
       }
     } catch (loadError: any) {
       setError(loadError?.message || 'Unable to load event details.');

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -327,6 +327,14 @@ async function mockScheduleModules(page, options = {}) {
                     };
                 }
 
+                export async function loadParentScheduleEventDetail(user, { teamId, eventId }) {
+                    const result = await loadParentSchedule(user);
+                    return {
+                        ...result,
+                        events: result.events.filter((event) => event.teamId === teamId && event.id === eventId)
+                    };
+                }
+
                 export async function submitParentScheduleRsvp(event, user, response, note = '') {
                     window.__scheduleCalls.rsvps.push({ eventKey: event.eventKey, childId: event.childId, userId: user.uid, response, note });
                     return { going: 2, maybe: 0, notGoing: 0, notResponded: 0 };

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -10,8 +10,10 @@ const scheduleMocks = vi.hoisted(() => ({
     createParentScheduleRideOffer: vi.fn(),
     loadParentPracticePacket: vi.fn(),
     loadParentSchedule: vi.fn(),
+    loadParentScheduleEventDetail: vi.fn(),
     loadParentScheduleAssignments: vi.fn().mockResolvedValue([]),
     loadParentScheduleRideOffers: vi.fn().mockResolvedValue([]),
+    loadHomeScoringPlayers: vi.fn().mockResolvedValue([]),
     loadAutoFilledLineupDraftPreviewForApp: vi.fn(),
     markParentPracticePacketComplete: vi.fn(),
     publishGamePlanForApp: vi.fn(),
@@ -28,6 +30,7 @@ const scheduleMocks = vi.hoisted(() => ({
         isFull: false
     })),
     publishLiveScoreUpdateEvent: vi.fn(),
+    recordPlayerScoringStat: vi.fn(),
     saveScheduledGameLineupDraftForApp: vi.fn(),
     updateGameScore: vi.fn(),
     updateParentScheduleRideRequestStatus: vi.fn()
@@ -162,6 +165,7 @@ async function clickButton(container, text) {
 beforeEach(() => {
     vi.clearAllMocks();
     scheduleMocks.loadParentSchedule.mockResolvedValue({ events: [] });
+    scheduleMocks.loadParentScheduleEventDetail.mockImplementation(async () => scheduleMocks.loadParentSchedule());
     scheduleMocks.loadParentPracticePacket.mockResolvedValue(null);
     scheduleMocks.publishGamePlanForApp.mockResolvedValue({ gamePlan: {}, notificationError: null });
     scheduleMocks.loadAutoFilledLineupDraftPreviewForApp.mockResolvedValue({
@@ -246,6 +250,26 @@ describe('React app ScheduleEventDetail More tab integration', () => {
                 })
             ]
         });
+        scheduleMocks.loadParentScheduleEventDetail.mockResolvedValue({
+            events: [
+                event({
+                    id: 'practice-1',
+                    type: 'practice',
+                    title: 'Practice',
+                    location: 'North Field',
+                    practiceSessionId: 'session-1',
+                    practiceHomePacket: {
+                        totalMinutes: 20,
+                        blocks: [
+                            { type: 'Drill', duration: 10, drillTitle: 'Ball Mastery', description: 'Touches at home.' },
+                            { type: 'Drill', duration: 10, drillTitle: 'Passing Wall', description: 'Two-touch passing.' }
+                        ]
+                    },
+                    practiceHomePacketSummary: '2 drills · 20 min',
+                    notes: 'Bring water'
+                })
+            ]
+        });
         scheduleMocks.loadParentPracticePacket.mockResolvedValue({
             sessionId: 'session-1',
             teamId: 'team-1',
@@ -300,7 +324,7 @@ describe('React app ScheduleEventDetail More tab integration', () => {
     });
 
     it('renders the completed game More tab with replay and report actions wired to public URLs', async () => {
-        scheduleMocks.loadParentSchedule.mockResolvedValue({
+        scheduleMocks.loadParentScheduleEventDetail.mockResolvedValue({
             events: [
                 event({
                     liveStatus: 'completed',
@@ -313,6 +337,8 @@ describe('React app ScheduleEventDetail More tab integration', () => {
 
         const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1');
         await waitForText(container, 'vs. Falcons');
+        expect(scheduleMocks.loadParentScheduleEventDetail).toHaveBeenCalledWith(auth.user, { teamId: 'team-1', eventId: 'game-1' });
+        expect(scheduleMocks.loadParentSchedule).not.toHaveBeenCalled();
         await clickButton(container, 'Game');
         await waitForText(container, 'Game hub');
 

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -2,8 +2,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const dbMocks = vi.hoisted(() => ({
     getAssignmentClaims: vi.fn(),
+    getGame: vi.fn(),
     getGames: vi.fn(),
     getPracticePacketCompletions: vi.fn(),
+    getPracticeSessionByEvent: vi.fn(),
     getPracticeSessions: vi.fn(),
     getRsvps: vi.fn(),
     getRsvpSummaries: vi.fn(),
@@ -118,7 +120,7 @@ vi.mock('../../js/snack-helpers.js', () => ({
     }))
 }));
 
-import { addTeamCalendarUrl, createScheduleImportGame, createScheduleImportPractice, loadParentSchedule, removeTeamCalendarUrl } from '../../apps/app/src/lib/scheduleService.ts';
+import { addTeamCalendarUrl, createScheduleImportGame, createScheduleImportPractice, loadParentSchedule, loadParentScheduleEventDetail, removeTeamCalendarUrl } from '../../apps/app/src/lib/scheduleService.ts';
 import { getScheduleForecastHref, getScheduleMapHref } from '../../apps/app/src/lib/scheduleLogic.ts';
 
 function installWindow(protocol = 'http:') {
@@ -158,6 +160,7 @@ beforeEach(() => {
         calendarUrls: ['mock://team-calendar'],
         availabilityPreferences: { noteVisibility: 'team' }
     });
+    dbMocks.getGame.mockResolvedValue(null);
     dbMocks.getTeams.mockResolvedValue([]);
     dbMocks.getGames.mockResolvedValue([
         {
@@ -230,6 +233,7 @@ beforeEach(() => {
             }
         }
     ]);
+    dbMocks.getPracticeSessionByEvent.mockResolvedValue(null);
     dbMocks.getTrackedCalendarEventUids.mockResolvedValue([]);
     utilsMocks.fetchAndParseCalendar.mockResolvedValue([
         {
@@ -380,6 +384,34 @@ describe('React app schedule service contract integration', () => {
             sourceLabel: 'Imported calendar',
             opponent: 'Eagles',
             location: 'Imported Field'
+        });
+    });
+
+    it('loads schedule event detail without hydrating unrelated events', async () => {
+        const result = await loadParentScheduleEventDetail(user(), { teamId: 'team-1', eventId: 'game-1' });
+
+        expect(dbMocks.getTeam).toHaveBeenCalledWith('team-1');
+        expect(dbMocks.getGames).toHaveBeenCalledWith('team-1');
+        expect(dbMocks.getPracticeSessions).toHaveBeenCalledWith('team-1');
+        expect(utilsMocks.fetchAndParseCalendar).toHaveBeenCalledWith('mock://team-calendar');
+        expect(dbMocks.getRsvpSummaries).toHaveBeenCalledWith('team-1', ['game-1']);
+        expect(dbMocks.getRsvps).toHaveBeenCalledTimes(1);
+        expect(dbMocks.getRsvps).toHaveBeenCalledWith('team-1', 'game-1');
+        expect(dbMocks.listRideOffersForEvent).toHaveBeenCalledTimes(1);
+        expect(dbMocks.listRideOffersForEvent).toHaveBeenCalledWith('team-1', 'game-1', { fallbackGameIds: [] });
+        expect(dbMocks.getAssignmentClaims).toHaveBeenCalledTimes(1);
+        expect(dbMocks.getAssignmentClaims).toHaveBeenCalledWith('team-1', 'game-1');
+
+        expect(result.events).toHaveLength(2);
+        expect(result.events.every((event) => event.id === 'game-1')).toBe(true);
+        expect(result.events.find((event) => event.childId === 'player-1')).toMatchObject({
+            myRsvp: 'going',
+            myRsvpNote: 'Needs a ride home',
+            rideshareSummary: { offerCount: 1, seatsLeft: 2, requests: 1, pending: 1, confirmed: 0, isFull: false }
+        });
+        expect(result.events.find((event) => event.childId === 'player-2')).toMatchObject({
+            myRsvp: 'maybe',
+            myRsvpNote: 'Late arrival'
         });
     });
 


### PR DESCRIPTION
Closes #1695

## What changed
- added a focused `loadParentScheduleEventDetail()` service path that builds schedule data for only the requested team and hydrates RSVP, rideshare, and assignments only for the requested event id
- updated `ScheduleEventDetail` to use the focused loader instead of calling the full parent schedule loader and filtering afterward
- extended the existing unit and smoke coverage to verify the detail route uses the focused loader and only hydrates the targeted event

## Why
Opening one schedule event was previously paying the cost of the full parent schedule graph, then narrowing to a single event in the page. This change keeps the existing schedule list behavior intact while making the detail route fetch only the event detail data it actually needs.