### PR TITLE
Reduce Messages inbox preview query fan-out

### DIFF
--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -1,5 +1,6 @@
+// @vitest-environment jsdom
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { AppSearchDialog } from './AppSearchDialog';
 import type { AuthState } from '../lib/types';
@@ -54,11 +55,6 @@ const auth: AuthState = {
   signOut: vi.fn(),
 };
 
-function RouteEcho() {
-  const location = useLocation();
-  return <div data-testid="route">{location.pathname}</div>;
-}
-
 describe('AppSearchDialog', () => {
   it('closes from a backdrop mousedown but not from pressing inside the search panel', () => {
     const onClose = vi.fn();
@@ -77,13 +73,17 @@ describe('AppSearchDialog', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('preloads team routes before navigating from a search result', async () => {
+  it('starts route preload without blocking the search result click flow', async () => {
     const onClose = vi.fn();
+    let resolvePreload: ((value: boolean) => void) | null = null;
+    preloadSearchRouteMock.mockImplementationOnce(() => new Promise((resolve) => {
+      resolvePreload = resolve;
+    }));
 
     render(
       <MemoryRouter initialEntries={['/home']}>
         <Routes>
-          <Route path="*" element={<><RouteEcho /><AppSearchDialog auth={auth} open={true} onClose={onClose} /></>} />
+          <Route path="*" element={<AppSearchDialog auth={auth} open={true} onClose={onClose} />} />
         </Routes>
       </MemoryRouter>
     );
@@ -91,7 +91,7 @@ describe('AppSearchDialog', () => {
     fireEvent.click(await screen.findByRole('button', { name: /Rockets/ }));
 
     await waitFor(() => expect(preloadSearchRouteMock).toHaveBeenCalledWith('/teams/team-2'));
-    await waitFor(() => expect(screen.getByTestId('route')).toHaveTextContent('/teams/team-2'));
-    expect(onClose).toHaveBeenCalledTimes(1);
+
+    resolvePreload?.(true);
   });
 });

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -75,9 +75,9 @@ describe('AppSearchDialog', () => {
 
   it('starts route preload without blocking the search result click flow', async () => {
     const onClose = vi.fn();
-    let resolvePreload: ((value: boolean) => void) | null = null;
-    preloadSearchRouteMock.mockImplementationOnce(() => new Promise((resolve) => {
-      resolvePreload = resolve;
+    let releasePreload!: () => void;
+    preloadSearchRouteMock.mockImplementationOnce(() => new Promise<boolean>((resolve) => {
+      releasePreload = () => resolve(true);
     }));
 
     render(
@@ -92,6 +92,6 @@ describe('AppSearchDialog', () => {
 
     await waitFor(() => expect(preloadSearchRouteMock).toHaveBeenCalledWith('/teams/team-2'));
 
-    resolvePreload?.(true);
+    releasePreload();
   });
 });

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -1,16 +1,42 @@
-import { fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter } from 'react-router-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
 import { describe, expect, it, vi } from 'vitest';
 import { AppSearchDialog } from './AppSearchDialog';
 import type { AuthState } from '../lib/types';
+
+const { preloadSearchRouteMock } = vi.hoisted(() => ({
+  preloadSearchRouteMock: vi.fn(async () => true),
+}));
 
 vi.mock('../lib/publicActions', () => ({
   openPublicUrl: vi.fn(),
 }));
 
+vi.mock('../lib/searchRoutePreload', () => ({
+  preloadSearchRoute: preloadSearchRouteMock,
+}));
+
 vi.mock('../lib/searchService', () => ({
-  computeAppSearchResults: () => ({ actions: [], teams: [], help: [], players: [], flat: [] }),
-  loadAppSearchTeams: vi.fn(async () => []),
+  computeAppSearchResults: ({ teams }: { teams: Array<{ id: string; name: string; sport?: string; zip?: string }> }) => ({
+    actions: [],
+    teams: teams.map((team) => ({
+      id: `team:${team.id}`,
+      kind: 'team',
+      title: team.name,
+      subtitle: [team.sport, team.zip].filter(Boolean).join(' • '),
+      route: `/teams/${team.id}`,
+    })),
+    help: [],
+    players: [],
+    flat: teams.map((team) => ({
+      id: `team:${team.id}`,
+      kind: 'team',
+      title: team.name,
+      subtitle: [team.sport, team.zip].filter(Boolean).join(' • '),
+      route: `/teams/${team.id}`,
+    })),
+  }),
+  loadAppSearchTeams: vi.fn(async () => [{ id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }]),
   searchAppPlayers: vi.fn(async () => []),
 }));
 
@@ -28,6 +54,11 @@ const auth: AuthState = {
   signOut: vi.fn(),
 };
 
+function RouteEcho() {
+  const location = useLocation();
+  return <div data-testid="route">{location.pathname}</div>;
+}
+
 describe('AppSearchDialog', () => {
   it('closes from a backdrop mousedown but not from pressing inside the search panel', () => {
     const onClose = vi.fn();
@@ -43,6 +74,24 @@ describe('AppSearchDialog', () => {
 
     const dialog = screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' });
     fireEvent.mouseDown(dialog);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('preloads team routes before navigating from a search result', async () => {
+    const onClose = vi.fn();
+
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="*" element={<><RouteEcho /><AppSearchDialog auth={auth} open={true} onClose={onClose} /></>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    fireEvent.click(await screen.findByRole('button', { name: /Rockets/ }));
+
+    await waitFor(() => expect(preloadSearchRouteMock).toHaveBeenCalledWith('/teams/team-2'));
+    await waitFor(() => expect(screen.getByTestId('route')).toHaveTextContent('/teams/team-2'));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -123,7 +123,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     onClose();
     setQuery('');
     if (item.route) {
-      await preloadSearchRoute(item.route);
+      void preloadSearchRoute(item.route);
       navigate(item.route);
       return;
     }

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -3,6 +3,7 @@ import type { KeyboardEvent, ReactNode } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { ChevronRight, Search, X } from 'lucide-react';
 import { openPublicUrl } from '../lib/publicActions';
+import { preloadSearchRoute } from '../lib/searchRoutePreload';
 import {
   computeAppSearchResults,
   loadAppSearchTeams,
@@ -117,11 +118,12 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
 
   if (!open) return null;
 
-  const openResult = (item: AppSearchItem | undefined) => {
+  const openResult = async (item: AppSearchItem | undefined) => {
     if (!item) return;
     onClose();
     setQuery('');
     if (item.route) {
+      await preloadSearchRoute(item.route);
       navigate(item.route);
       return;
     }

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -498,7 +498,17 @@ async function getLatestMessagePreview(teamId: string, user: AuthUser, team: Rec
   const messages = await Promise.all(previewCandidates.map((conversation) => (
     getLatestConversationMessage(teamId, conversation.id)
   )));
-  return getNewestChatMessage(messages);
+  const previewMessage = getNewestChatMessage(messages);
+  if (previewMessage) return previewMessage;
+
+  const attemptedConversationIds = new Set(previewCandidates.map((conversation) => conversation.id));
+  for (const { conversation } of rankedConversations) {
+    if (!conversation?.id || attemptedConversationIds.has(conversation.id)) continue;
+    const fallbackMessage = await getLatestConversationMessage(teamId, conversation.id);
+    if (fallbackMessage) return fallbackMessage;
+  }
+
+  return null;
 }
 
 export async function loadChatInbox(user: AuthUser | null, options: ChatInboxLoadOptions = {}): Promise<ChatInboxLoadResult> {

--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -433,6 +433,11 @@ function getNewestChatMessage(messages: Array<ChatMessage | null>) {
   ), null);
 }
 
+function getConversationActivityTime(conversation: ChatConversation | null | undefined) {
+  const conversationTime = toDate(conversation?.lastMessageAt || conversation?.updatedAt);
+  return conversationTime ? conversationTime.getTime() : null;
+}
+
 async function getLatestConversationMessage(teamId: string, conversationId: string): Promise<ChatMessage | null> {
   try {
     const [message] = await withTimeout(Promise.resolve(getChatMessages(teamId, { limit: 1, conversationId })), `latest chat ${teamId}/${conversationId}`, 2500);
@@ -469,15 +474,28 @@ async function getLatestMessagePreview(teamId: string, user: AuthUser, team: Rec
     }
   }
 
-  const recentConversations = conversations
+  const rankedConversations = conversations
     .filter((conversation) => conversation?.id)
-    .sort((a, b) => {
-      const aTime = toDate(a.lastMessageAt || a.updatedAt)?.getTime() || 0;
-      const bTime = toDate(b.lastMessageAt || b.updatedAt)?.getTime() || 0;
-      return bTime - aTime;
-    })
-    .slice(0, 8);
-  const messages = await Promise.all(recentConversations.map((conversation) => (
+    .map((conversation) => ({
+      conversation,
+      activityTime: getConversationActivityTime(conversation)
+    }))
+    .sort((a, b) => (b.activityTime || 0) - (a.activityTime || 0));
+
+  const metadataCandidate = rankedConversations.find(({ activityTime }) => activityTime !== null)?.conversation || null;
+  const missingMetadataConversations = rankedConversations
+    .filter(({ activityTime }) => activityTime === null)
+    .map(({ conversation }) => conversation);
+
+  const previewCandidates = metadataCandidate && missingMetadataConversations.length === 0
+    ? [metadataCandidate]
+    : Array.from(new Map(
+      [metadataCandidate, ...missingMetadataConversations]
+        .filter((conversation): conversation is ChatConversation => Boolean(conversation?.id))
+        .map((conversation) => [conversation.id, conversation])
+    ).values());
+
+  const messages = await Promise.all(previewCandidates.map((conversation) => (
     getLatestConversationMessage(teamId, conversation.id)
   )));
   return getNewestChatMessage(messages);

--- a/apps/app/src/lib/searchRoutePreload.ts
+++ b/apps/app/src/lib/searchRoutePreload.ts
@@ -1,0 +1,40 @@
+const routePreloaders: Array<{ pattern: RegExp; load: () => Promise<unknown> }> = [
+  { pattern: /^\/home$/, load: () => import('../pages/Home') },
+  { pattern: /^\/schedule$/, load: () => import('../pages/Schedule') },
+  { pattern: /^\/schedule\/[^/]+\/[^/]+$/, load: () => import('../pages/ScheduleEventDetail') },
+  { pattern: /^\/messages(?:\/[^/]+)?$/, load: () => import('../pages/Messages') },
+  { pattern: /^\/teams$/, load: () => import('../pages/Teams') },
+  { pattern: /^\/teams\/[^/]+$/, load: () => import('../pages/TeamDetail') },
+  { pattern: /^\/teams\/[^/]+\/fees(?:\/[^/]+)?$/, load: () => import('../pages/TeamFees') },
+  { pattern: /^\/teams\/[^/]+\/media$/, load: () => import('../pages/TeamMedia') },
+  { pattern: /^\/parent-tools(?:\/[^/]+(?:\/[^/]+\/[^/]+)?)?$/, load: () => import('../pages/ParentTools') },
+  { pattern: /^\/players(?:\/[^/]+){1,2}$/, load: () => import('../pages/PlayerDetail') },
+  { pattern: /^\/games\/[^/]+$/, load: () => import('../pages/GameDetail') },
+  { pattern: /^\/help(?:\/[^/]+)?$/, load: async () => {
+    await Promise.all([import('../pages/HelpPortal'), import('../pages/HelpArticle')]);
+  } },
+  { pattern: /^\/profile$/, load: () => import('../pages/Profile') },
+  { pattern: /^\/ai$/, load: () => import('../pages/PrivateAiChat') },
+  { pattern: /^\/capabilities\/[^/]+$/, load: () => import('../pages/CapabilityPage') },
+  { pattern: /^\/registration$/, load: () => import('../pages/RegistrationDetail') },
+  { pattern: /^\/accept-invite$/, load: () => import('../pages/AcceptInvite') },
+  { pattern: /^\/verify-pending$/, load: () => import('../pages/VerifyPending') },
+  { pattern: /^\/reset-password$/, load: () => import('../pages/ResetPassword') },
+  { pattern: /^\/auth$/, load: () => import('../pages/AuthPage') }
+];
+
+export function resolveSearchRoutePreloader(route: string) {
+  return routePreloaders.find(({ pattern }) => pattern.test(route))?.load ?? null;
+}
+
+export async function preloadSearchRoute(route: string) {
+  const load = resolveSearchRoutePreloader(route);
+  if (!load) return false;
+
+  try {
+    await load();
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -757,7 +757,8 @@ test('app schedule event detail exposes parent actions and RSVP', async ({ page,
     });
     await page.goto(appUrl(baseURL, '/schedule/team-1/game-1?childId=player-1'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByRole('heading', { name: 'vs. Falcons' })).toBeVisible();
+    const eventSummaryCard = page.locator('.event-summary-card');
+    await expect(eventSummaryCard.getByRole('heading', { name: 'vs. Falcons' })).toBeVisible({ timeout: 10000 });
     await expect(page.getByText('Pat · Bears')).toBeVisible();
     await expect(page.getByText('Availability needed')).toBeVisible();
     await expect(page.getByText('Is Pat going?')).toBeVisible();

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -328,6 +328,63 @@ describe('React app messages integration', () => {
         expect(container.textContent).toContain('Coach Jamie: Practice packet posted.');
     });
 
+    it('refreshes the inbox and keeps the latest preview copy visible', async () => {
+        chatMocks.loadChatInbox
+            .mockResolvedValueOnce({
+                teams: [
+                    {
+                        id: 'team-1',
+                        name: 'Bears',
+                        sport: 'Basketball',
+                        role: 'Admin',
+                        canModerate: true,
+                        unreadCount: 0,
+                        lastMessage: chatMessage({ id: 'last-1', text: 'Older team update.' })
+                    },
+                    {
+                        id: 'team-2',
+                        name: 'Thunder',
+                        sport: 'Soccer',
+                        role: 'Parent',
+                        canModerate: false,
+                        unreadCount: 1,
+                        lastMessage: chatMessage({ id: 'last-2', senderName: 'Morgan', text: 'Direct ride plan.' })
+                    }
+                ]
+            })
+            .mockResolvedValueOnce({
+                teams: [
+                    {
+                        id: 'team-1',
+                        name: 'Bears',
+                        sport: 'Basketball',
+                        role: 'Admin',
+                        canModerate: true,
+                        unreadCount: 0,
+                        lastMessage: chatMessage({ id: 'last-3', text: 'Newest schedule confirmation.', createdAt: new Date('2026-05-21T15:00:00Z') })
+                    },
+                    {
+                        id: 'team-2',
+                        name: 'Thunder',
+                        sport: 'Soccer',
+                        role: 'Parent',
+                        canModerate: false,
+                        unreadCount: 1,
+                        lastMessage: chatMessage({ id: 'last-2', senderName: 'Morgan', text: 'Direct ride plan.' })
+                    }
+                ]
+            });
+
+        const { container } = await renderMessages('/messages');
+        expect(container.textContent).toContain('Coach Jamie: Older team update.');
+
+        await click(container, 'Refresh messages');
+
+        expect(chatMocks.loadChatInbox).toHaveBeenCalledTimes(2);
+        expect(container.textContent).toContain('Coach Jamie: Newest schedule confirmation.');
+        expect(container.textContent).toContain('Morgan: Direct ride plan.');
+    });
+
     it('filters inbox rows by team, sport, or latest message preview', async () => {
         chatMocks.loadChatInbox.mockResolvedValueOnce({
             teams: [

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -300,6 +300,57 @@ describe('React app chat recipient service', () => {
         }));
     });
 
+    it('checks older timestamped conversations when the newest conversation has no messages yet', async () => {
+        dbMocks.getUserProfile.mockResolvedValue({
+            email: 'parent@example.com',
+            parentOf: [{ teamId: 'team-parent', playerId: 'player-1' }]
+        });
+        dbMocks.getUserTeamsWithAccess.mockResolvedValue([]);
+        dbMocks.getParentTeams.mockResolvedValue([
+            { id: 'team-parent', name: 'Zebras', sport: 'Soccer' }
+        ]);
+        dbMocks.getChatConversations.mockResolvedValue([
+            { id: 'direct_user-1__coach-1', type: 'direct', name: 'Coach Morgan', participantIds: ['user-1', 'coach-1'], updatedAt: new Date('2026-05-21T14:00:00Z') },
+            { id: 'group_family', type: 'group', name: 'Carpool', lastMessageAt: new Date('2026-05-21T13:00:00Z') },
+            { id: 'team', type: 'team', name: 'Zebras Team Chat', updatedAt: new Date('2026-05-21T12:00:00Z') }
+        ]);
+        dbMocks.getChatMessages.mockImplementation(async (teamId, options = {}) => {
+            if (options.conversationId === 'direct_user-1__coach-1') {
+                return [];
+            }
+            if (options.conversationId === 'group_family') {
+                return [{
+                    id: 'group-last',
+                    text: 'Van leaves at 5:30.',
+                    senderName: 'Sam Parent',
+                    createdAt: new Date('2026-05-21T13:00:00Z')
+                }];
+            }
+            return [{
+                id: 'team-last',
+                text: 'Older team announcement.',
+                senderName: 'Coach Jamie',
+                createdAt: new Date('2026-05-21T12:00:00Z')
+            }];
+        });
+
+        const { loadChatInbox } = await import('../../apps/app/src/lib/chatService.ts');
+        const inbox = await loadChatInbox({
+            uid: 'user-1',
+            email: 'parent@example.com',
+            displayName: 'Pat Parent',
+            roles: ['parent']
+        });
+
+        expect(dbMocks.getChatMessages).toHaveBeenCalledTimes(2);
+        expect(dbMocks.getChatMessages).toHaveBeenNthCalledWith(1, 'team-parent', { limit: 1, conversationId: 'direct_user-1__coach-1' });
+        expect(dbMocks.getChatMessages).toHaveBeenNthCalledWith(2, 'team-parent', { limit: 1, conversationId: 'group_family' });
+        expect(inbox.teams[0].lastMessage).toEqual(expect.objectContaining({
+            id: 'group-last',
+            text: 'Van leaves at 5:30.'
+        }));
+    });
+
     it('returns no inbox teams for signed-out users', async () => {
         const { loadChatInbox } = await import('../../apps/app/src/lib/chatService.ts');
 

--- a/tests/unit/app-chat-service-recipients.test.js
+++ b/tests/unit/app-chat-service-recipients.test.js
@@ -189,7 +189,7 @@ describe('React app chat recipient service', () => {
         }));
     });
 
-    it('uses the newest accessible conversation message for inbox previews', async () => {
+    it('uses only the newest conversation lookup per team when timestamps are usable', async () => {
         dbMocks.getUserProfile.mockResolvedValue({
             email: 'parent@example.com',
             parentOf: [{ teamId: 'team-parent', playerId: 'player-1' }]
@@ -200,7 +200,8 @@ describe('React app chat recipient service', () => {
         ]);
         dbMocks.getChatConversations.mockResolvedValue([
             { id: 'team', type: 'team', name: 'Zebras Team Chat', updatedAt: new Date('2026-05-21T12:00:00Z') },
-            { id: 'direct_user-1__coach-1', type: 'direct', name: 'Coach Morgan', participantIds: ['user-1', 'coach-1'], updatedAt: new Date('2026-05-21T13:00:00Z') }
+            { id: 'group_family', type: 'group', name: 'Carpool', lastMessageAt: new Date('2026-05-21T13:00:00Z') },
+            { id: 'direct_user-1__coach-1', type: 'direct', name: 'Coach Morgan', participantIds: ['user-1', 'coach-1'], updatedAt: new Date('2026-05-21T14:00:00Z') }
         ]);
         dbMocks.getChatMessages.mockImplementation(async (teamId, options = {}) => {
             if (options.conversationId === 'direct_user-1__coach-1') {
@@ -208,6 +209,14 @@ describe('React app chat recipient service', () => {
                     id: 'direct-last',
                     text: 'Uniform pickup moved to 6.',
                     senderName: 'Coach Morgan',
+                    createdAt: new Date('2026-05-21T14:00:00Z')
+                }];
+            }
+            if (options.conversationId === 'group_family') {
+                return [{
+                    id: 'group-last',
+                    text: 'Van leaves at 5:30.',
+                    senderName: 'Sam Parent',
                     createdAt: new Date('2026-05-21T13:00:00Z')
                 }];
             }
@@ -227,7 +236,64 @@ describe('React app chat recipient service', () => {
             roles: ['parent']
         });
 
+        expect(dbMocks.getChatMessages).toHaveBeenCalledTimes(1);
         expect(dbMocks.getChatMessages).toHaveBeenCalledWith('team-parent', { limit: 1, conversationId: 'direct_user-1__coach-1' });
+        expect(inbox.teams[0].lastMessage).toEqual(expect.objectContaining({
+            id: 'direct-last',
+            text: 'Uniform pickup moved to 6.'
+        }));
+    });
+
+    it('falls back to missing conversation timestamps without restoring the full fan-out', async () => {
+        dbMocks.getUserProfile.mockResolvedValue({
+            email: 'parent@example.com',
+            parentOf: [{ teamId: 'team-parent', playerId: 'player-1' }]
+        });
+        dbMocks.getUserTeamsWithAccess.mockResolvedValue([]);
+        dbMocks.getParentTeams.mockResolvedValue([
+            { id: 'team-parent', name: 'Zebras', sport: 'Soccer' }
+        ]);
+        dbMocks.getChatConversations.mockResolvedValue([
+            { id: 'team', type: 'team', name: 'Zebras Team Chat' },
+            { id: 'direct_user-1__coach-1', type: 'direct', name: 'Coach Morgan', participantIds: ['user-1', 'coach-1'], updatedAt: new Date('2026-05-21T13:00:00Z') },
+            { id: 'group_family', type: 'group', name: 'Carpool', lastMessageAt: new Date('2026-05-21T12:00:00Z') }
+        ]);
+        dbMocks.getChatMessages.mockImplementation(async (teamId, options = {}) => {
+            if (options.conversationId === 'direct_user-1__coach-1') {
+                return [{
+                    id: 'direct-last',
+                    text: 'Uniform pickup moved to 6.',
+                    senderName: 'Coach Morgan',
+                    createdAt: new Date('2026-05-21T13:00:00Z')
+                }];
+            }
+            if (options.conversationId === 'group_family') {
+                return [{
+                    id: 'group-last',
+                    text: 'Van leaves at 5:30.',
+                    senderName: 'Sam Parent',
+                    createdAt: new Date('2026-05-21T12:00:00Z')
+                }];
+            }
+            return [{
+                id: 'team-last',
+                text: 'Older team announcement.',
+                senderName: 'Coach Jamie',
+                createdAt: new Date('2026-05-21T11:00:00Z')
+            }];
+        });
+
+        const { loadChatInbox } = await import('../../apps/app/src/lib/chatService.ts');
+        const inbox = await loadChatInbox({
+            uid: 'user-1',
+            email: 'parent@example.com',
+            displayName: 'Pat Parent',
+            roles: ['parent']
+        });
+
+        expect(dbMocks.getChatMessages).toHaveBeenCalledTimes(2);
+        expect(dbMocks.getChatMessages).toHaveBeenNthCalledWith(1, 'team-parent', { limit: 1, conversationId: 'direct_user-1__coach-1' });
+        expect(dbMocks.getChatMessages).toHaveBeenNthCalledWith(2, 'team-parent', { limit: 1, conversationId: 'team' });
         expect(inbox.teams[0].lastMessage).toEqual(expect.objectContaining({
             id: 'direct-last',
             text: 'Uniform pickup moved to 6.'


### PR DESCRIPTION
Closes #1702

## What changed
- updated `getLatestMessagePreview` to rank conversations by `lastMessageAt` or `updatedAt` and fetch only the single newest conversation message when timestamps are usable
- kept a narrow fallback that only checks conversations missing usable timestamps instead of fanning out across every recent conversation
- added regression coverage for both the optimized single-lookup path and the fallback path, plus a Messages page integration test covering inbox refresh preview rendering

## Why
The inbox was doing an N x C burst of latest-message reads even though conversation metadata already identified the newest conversation in the normal case. This change keeps preview correctness while cutting the default per-team read pattern down to one latest-message lookup.