### PR TITLE
Cache visited Parent Tools tabs

### DIFF
--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -217,4 +217,41 @@ describe('ParentTools access', () => {
         expect(await screen.findByText('Summer Camp')).toBeTruthy();
         expect(parentToolsServiceMocks.loadParentRegistrations).toHaveBeenCalledTimes(2);
     });
+
+    it('refreshes cached tool data after access changes update parent links', async () => {
+        parentToolsServiceMocks.loadParentRegistrations
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([
+                {
+                    id: 'form-1',
+                    teamId: 'team-1',
+                    teamName: 'Bears',
+                    programName: 'Summer Camp',
+                    description: 'Skills week',
+                    season: 'Summer',
+                    feeLabel: '$75.00',
+                    paymentNotice: '',
+                    onlineCheckout: true,
+                    options: [],
+                    url: 'https://allplays.ai/registration.html?teamId=team-1&formId=form-1'
+                }
+            ]);
+
+        renderParentTools();
+
+        await screen.findByText('Request player access');
+        fireEvent.click(screen.getByRole('button', { name: 'Register' }));
+        await screen.findByText('No open registrations');
+        expect(parentToolsServiceMocks.loadParentRegistrations).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Access' }));
+        await screen.findByText('Request player access');
+        fireEvent.change(screen.getByPlaceholderText('XXXXXXXX'), { target: { value: 'ab12cd34' } });
+        fireEvent.click(screen.getByRole('button', { name: 'Redeem code' }));
+        expect(await screen.findByText('Invite accepted.')).toBeTruthy();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Register' }));
+        expect(await screen.findByText('Summer Camp')).toBeTruthy();
+        expect(parentToolsServiceMocks.loadParentRegistrations).toHaveBeenCalledTimes(2);
+    });
 });

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -139,4 +139,82 @@ describe('ParentTools access', () => {
         if (!requestsSection) throw new Error('Requests section not found');
         expect(within(requestsSection).getByText('No requests yet')).toBeTruthy();
     });
+
+    it('reuses loaded tab data on revisit and only refreshes when requested', async () => {
+        parentToolsServiceMocks.loadParentFeesForApp.mockResolvedValue([
+            {
+                id: 'fee-1',
+                title: 'Team dues',
+                teamId: 'team-1',
+                teamName: 'Bears',
+                playerName: 'Sam Player',
+                status: 'open',
+                amountLabel: '$100',
+                dueLabel: 'Today',
+                statusLabel: 'Open',
+                balanceDueCents: 10000,
+                canPay: false,
+                lineItems: [],
+                installments: [],
+                ledgerEntries: []
+            }
+        ]);
+        parentToolsServiceMocks.loadParentRegistrations.mockResolvedValue([
+            {
+                id: 'form-1',
+                teamId: 'team-1',
+                teamName: 'Bears',
+                programName: 'Summer Camp',
+                description: 'Skills week',
+                season: 'Summer',
+                feeLabel: '$75.00',
+                paymentNotice: '',
+                onlineCheckout: true,
+                options: [],
+                url: 'https://allplays.ai/registration.html?teamId=team-1&formId=form-1'
+            }
+        ]);
+        parentToolsServiceMocks.loadParentCertificates.mockResolvedValue([
+            {
+                id: 'cert-1',
+                teamId: 'team-1',
+                teamName: 'Bears',
+                playerId: 'player-1',
+                playerName: 'Sam Player',
+                title: 'Hustle Award',
+                narrative: 'Great effort.',
+                url: 'https://allplays.ai/certificates.html#cert-1'
+            }
+        ]);
+
+        renderParentTools();
+
+        await screen.findByText('Request player access');
+        fireEvent.click(screen.getByRole('button', { name: 'Fees' }));
+        await screen.findByText('Team dues');
+        expect(parentToolsServiceMocks.loadParentAccessModel).toHaveBeenCalledTimes(1);
+        expect(parentToolsServiceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(1);
+        expect(parentToolsServiceMocks.loadParentFeesForApp).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Access' }));
+        await screen.findByText('Request player access');
+        expect(parentToolsServiceMocks.loadParentAccessModel).toHaveBeenCalledTimes(1);
+        expect(parentToolsServiceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Register' }));
+        await screen.findByText('Summer Camp');
+        expect(parentToolsServiceMocks.loadParentRegistrations).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Awards' }));
+        await screen.findByText('Hustle Award');
+        expect(parentToolsServiceMocks.loadParentCertificates).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Register' }));
+        await screen.findByText('Summer Camp');
+        expect(parentToolsServiceMocks.loadParentRegistrations).toHaveBeenCalledTimes(1);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Refresh' }));
+        expect(await screen.findByText('Summer Camp')).toBeTruthy();
+        expect(parentToolsServiceMocks.loadParentRegistrations).toHaveBeenCalledTimes(2);
+    });
 });

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type FormEvent } from 'react';
+import { useEffect, useMemo, useState, type FormEvent, type ReactNode } from 'react';
 import { Link, Navigate, useNavigate, useParams } from 'react-router-dom';
 import type { LucideIcon } from 'lucide-react';
 import {
@@ -74,6 +74,12 @@ export function ParentTools({ auth }: { auth: AuthState }) {
   const { toolId = 'access' } = useParams();
   const navigate = useNavigate();
   const activeTool = validToolIds.has(toolId as ParentToolId) ? toolId as ParentToolId : null;
+  const [visitedTools, setVisitedTools] = useState<ParentToolId[]>(() => activeTool ? [activeTool] : ['access']);
+
+  useEffect(() => {
+    if (!activeTool) return;
+    setVisitedTools((current) => (current.includes(activeTool) ? current : [...current, activeTool]));
+  }, [activeTool]);
 
   if (!activeTool) return <Navigate to="/parent-tools/access" replace />;
 
@@ -120,15 +126,20 @@ export function ParentTools({ auth }: { auth: AuthState }) {
         </div>
       </div>
 
-      {activeTool === 'access' ? <AccessTool auth={auth} /> : null}
-      {activeTool === 'household' ? <HouseholdInviteTool auth={auth} /> : null}
-      {activeTool === 'fees' ? <FeesTool auth={auth} /> : null}
-      {activeTool === 'calendar' ? <CalendarTool auth={auth} /> : null}
-      {activeTool === 'share' ? <FamilyShareTool auth={auth} /> : null}
-      {activeTool === 'registrations' ? <RegistrationsTool auth={auth} /> : null}
-      {activeTool === 'certificates' ? <CertificatesTool auth={auth} /> : null}
+      <KeepAliveTool active={activeTool === 'access'} mounted={visitedTools.includes('access')}><AccessTool auth={auth} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'household'} mounted={visitedTools.includes('household')}><HouseholdInviteTool auth={auth} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'fees'} mounted={visitedTools.includes('fees')}><FeesTool auth={auth} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'calendar'} mounted={visitedTools.includes('calendar')}><CalendarTool auth={auth} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'share'} mounted={visitedTools.includes('share')}><FamilyShareTool auth={auth} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'registrations'} mounted={visitedTools.includes('registrations')}><RegistrationsTool auth={auth} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'certificates'} mounted={visitedTools.includes('certificates')}><CertificatesTool auth={auth} /></KeepAliveTool>
     </div>
   );
+}
+
+function KeepAliveTool({ active, mounted, children }: { active: boolean; mounted: boolean; children: ReactNode }) {
+  if (!mounted) return null;
+  return <div hidden={!active}>{children}</div>;
 }
 
 function AccessTool({ auth }: { auth: AuthState }) {

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -75,6 +75,7 @@ export function ParentTools({ auth }: { auth: AuthState }) {
   const navigate = useNavigate();
   const activeTool = validToolIds.has(toolId as ParentToolId) ? toolId as ParentToolId : null;
   const [visitedTools, setVisitedTools] = useState<ParentToolId[]>(() => activeTool ? [activeTool] : ['access']);
+  const [accessRefreshVersion, setAccessRefreshVersion] = useState(0);
 
   useEffect(() => {
     if (!activeTool) return;
@@ -88,6 +89,10 @@ export function ParentTools({ auth }: { auth: AuthState }) {
     window.requestAnimationFrame(() => {
       window.scrollTo({ top: 0, behavior: 'smooth' });
     });
+  };
+
+  const handleAccessChanged = () => {
+    setAccessRefreshVersion((current) => current + 1);
   };
 
   return (
@@ -126,13 +131,13 @@ export function ParentTools({ auth }: { auth: AuthState }) {
         </div>
       </div>
 
-      <KeepAliveTool active={activeTool === 'access'} mounted={visitedTools.includes('access')}><AccessTool auth={auth} /></KeepAliveTool>
-      <KeepAliveTool active={activeTool === 'household'} mounted={visitedTools.includes('household')}><HouseholdInviteTool auth={auth} /></KeepAliveTool>
-      <KeepAliveTool active={activeTool === 'fees'} mounted={visitedTools.includes('fees')}><FeesTool auth={auth} /></KeepAliveTool>
-      <KeepAliveTool active={activeTool === 'calendar'} mounted={visitedTools.includes('calendar')}><CalendarTool auth={auth} /></KeepAliveTool>
-      <KeepAliveTool active={activeTool === 'share'} mounted={visitedTools.includes('share')}><FamilyShareTool auth={auth} /></KeepAliveTool>
-      <KeepAliveTool active={activeTool === 'registrations'} mounted={visitedTools.includes('registrations')}><RegistrationsTool auth={auth} /></KeepAliveTool>
-      <KeepAliveTool active={activeTool === 'certificates'} mounted={visitedTools.includes('certificates')}><CertificatesTool auth={auth} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'access'} mounted={visitedTools.includes('access')}><AccessTool auth={auth} onAccessChanged={handleAccessChanged} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'household'} mounted={visitedTools.includes('household')}><HouseholdInviteTool auth={auth} refreshVersion={accessRefreshVersion} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'fees'} mounted={visitedTools.includes('fees')}><FeesTool auth={auth} refreshVersion={accessRefreshVersion} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'calendar'} mounted={visitedTools.includes('calendar')}><CalendarTool auth={auth} refreshVersion={accessRefreshVersion} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'share'} mounted={visitedTools.includes('share')}><FamilyShareTool auth={auth} refreshVersion={accessRefreshVersion} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'registrations'} mounted={visitedTools.includes('registrations')}><RegistrationsTool auth={auth} refreshVersion={accessRefreshVersion} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'certificates'} mounted={visitedTools.includes('certificates')}><CertificatesTool auth={auth} refreshVersion={accessRefreshVersion} /></KeepAliveTool>
     </div>
   );
 }
@@ -142,7 +147,7 @@ function KeepAliveTool({ active, mounted, children }: { active: boolean; mounted
   return <div hidden={!active}>{children}</div>;
 }
 
-function AccessTool({ auth }: { auth: AuthState }) {
+function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChanged: () => void }) {
   const [teams, setTeams] = useState<ParentAccessTeam[]>([]);
   const [requests, setRequests] = useState<ParentAccessRequest[]>([]);
   const [players, setPlayers] = useState<ParentAccessPlayer[]>([]);
@@ -225,6 +230,7 @@ function AccessTool({ auth }: { auth: AuthState }) {
         refresh: auth.refresh
       });
       await loadAccessModel();
+      onAccessChanged();
       setRedeemCode('');
       setMessage(result.message);
     } catch (redeemError: any) {
@@ -247,6 +253,7 @@ function AccessTool({ auth }: { auth: AuthState }) {
       await submitParentAccessRequest(selectedTeamId, selectedPlayerId, relation);
       setMessage('Access request sent.');
       await loadAccessModel();
+      onAccessChanged();
     } catch (submitError: any) {
       setError(submitError?.message || 'Unable to send access request.');
     } finally {
@@ -329,7 +336,7 @@ function AccessTool({ auth }: { auth: AuthState }) {
   );
 }
 
-function FeesTool({ auth }: { auth: AuthState }) {
+function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
   const [fees, setFees] = useState<ParentFeeAppRecord[]>([]);
   const [filter, setFilter] = useState<'open' | 'all' | 'paid'>('open');
   const [loading, setLoading] = useState(true);
@@ -352,7 +359,7 @@ function FeesTool({ auth }: { auth: AuthState }) {
   useEffect(() => {
     void refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [auth.user?.uid]);
+  }, [auth.user?.uid, refreshVersion]);
 
   const visibleFees = useMemo(() => fees.filter((fee) => {
     if (filter === 'all') return true;
@@ -417,7 +424,7 @@ function getFeeCardKey(fee: ParentFeeAppRecord) {
   return `${fee.teamId || 'team'}-${fee.batchId || 'batch'}-${fee.recipientId || fee.id || fee.title || 'fee'}`;
 }
 
-function CalendarTool({ auth }: { auth: AuthState }) {
+function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
   const [events, setEvents] = useState<ParentScheduleEvent[]>([]);
   const [teams, setTeams] = useState<ParentCalendarTeam[]>([]);
   const [loading, setLoading] = useState(true);
@@ -443,7 +450,7 @@ function CalendarTool({ auth }: { auth: AuthState }) {
   useEffect(() => {
     void refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [auth.user?.uid]);
+  }, [auth.user?.uid, refreshVersion]);
 
   const download = () => {
     if (!events.length) {
@@ -526,7 +533,7 @@ function CalendarTool({ auth }: { auth: AuthState }) {
 }
 
 
-function HouseholdInviteTool({ auth }: { auth: AuthState }) {
+function HouseholdInviteTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
   const [linkedPlayers, setLinkedPlayers] = useState<ParentHouseholdLinkedPlayer[]>([]);
   const [members, setMembers] = useState<ParentHouseholdFamilyMember[]>([]);
   const [playerKey, setPlayerKey] = useState('');
@@ -559,7 +566,7 @@ function HouseholdInviteTool({ auth }: { auth: AuthState }) {
   useEffect(() => {
     void refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [auth.user?.uid]);
+  }, [auth.user?.uid, refreshVersion]);
 
   const submit = async (event: FormEvent) => {
     event.preventDefault();
@@ -654,7 +661,7 @@ function HouseholdInviteTool({ auth }: { auth: AuthState }) {
   );
 }
 
-function FamilyShareTool({ auth }: { auth: AuthState }) {
+function FamilyShareTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
   const [tokens, setTokens] = useState<FamilyShareTokenCard[]>([]);
   const [children, setChildren] = useState<any[]>([]);
   const [label, setLabel] = useState('');
@@ -683,7 +690,7 @@ function FamilyShareTool({ auth }: { auth: AuthState }) {
   useEffect(() => {
     void refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [auth.user?.uid]);
+  }, [auth.user?.uid, refreshVersion]);
 
   const create = async (event: FormEvent) => {
     event.preventDefault();
@@ -797,7 +804,7 @@ function FamilyShareTool({ auth }: { auth: AuthState }) {
   );
 }
 
-function RegistrationsTool({ auth }: { auth: AuthState }) {
+function RegistrationsTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
   const [cards, setCards] = useState<ParentRegistrationCard[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -817,7 +824,7 @@ function RegistrationsTool({ auth }: { auth: AuthState }) {
   useEffect(() => {
     void refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [auth.user?.uid]);
+  }, [auth.user?.uid, refreshVersion]);
 
   return (
     <div className="space-y-3">
@@ -836,7 +843,7 @@ function RegistrationsTool({ auth }: { auth: AuthState }) {
   );
 }
 
-function CertificatesTool({ auth }: { auth: AuthState }) {
+function CertificatesTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: number }) {
   const [cards, setCards] = useState<ParentCertificateCard[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -856,7 +863,7 @@ function CertificatesTool({ auth }: { auth: AuthState }) {
   useEffect(() => {
     void refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [auth.user?.uid]);
+  }, [auth.user?.uid, refreshVersion]);
 
   return (
     <div className="space-y-3">

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -325,6 +325,45 @@ describe('React app parent tools integration', () => {
         }));
     });
 
+    it('keeps previously opened parent tool tabs warm until a tab refresh is requested', async () => {
+        const { container } = await renderParentTools('/parent-tools/access');
+        await waitForText(container, 'Request player access');
+        expect(serviceMocks.loadParentAccessModel).toHaveBeenCalledTimes(1);
+        expect(serviceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(1);
+
+        await clickButton(container, 'Fees');
+        await waitForText(container, 'Team dues');
+        expect(serviceMocks.loadParentFeesForApp).toHaveBeenCalledTimes(1);
+
+        await clickButton(container, 'Access');
+        await waitForText(container, 'Request player access');
+        expect(serviceMocks.loadParentAccessModel).toHaveBeenCalledTimes(1);
+        expect(serviceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(1);
+
+        await clickButton(container, 'Register');
+        await waitForText(container, 'Summer Camp');
+        expect(serviceMocks.loadParentRegistrations).toHaveBeenCalledTimes(1);
+
+        await clickButton(container, 'Awards');
+        await waitForText(container, 'Hustle Award');
+        expect(serviceMocks.loadParentCertificates).toHaveBeenCalledTimes(1);
+
+        await clickButton(container, 'Register');
+        await waitForText(container, 'Summer Camp');
+        expect(serviceMocks.loadParentRegistrations).toHaveBeenCalledTimes(1);
+        expect(container.textContent).not.toContain('Loading registrations');
+
+        const refreshButton = Array.from(container.querySelectorAll('button')).find((button) => button.textContent.trim().includes('Refresh') && !button.closest('[hidden]'));
+        if (!refreshButton) throw new Error('Visible refresh button not found');
+        await act(async () => {
+            refreshButton.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+        });
+        await flush();
+        await waitForText(container, 'Summer Camp');
+        expect(serviceMocks.loadParentRegistrations).toHaveBeenCalledTimes(2);
+        expect(serviceMocks.loadParentFeesForApp).toHaveBeenCalledTimes(1);
+    });
+
     it('requires confirmation before revoking a family share link', async () => {
         const { container } = await renderParentTools('/parent-tools/share');
         await waitForText(container, 'Grandma');


### PR DESCRIPTION
Closes #1704

## Summary
- cache visited Parent Tools tab data by user and tool so tab revisits render from memory instead of remounting and refetching
- preserve explicit refresh and mutation invalidation paths for tools that change data
- add coverage for revisit cache behavior in ParentTools and app integration tests

## Tests
- npm --prefix apps/app test -- ParentTools.test.tsx --reporter=verbose
- npm test -- tests/unit/app-parent-tools-integration.test.jsx --reporter=verbose
