### PR TITLE
Make public team search cards actionable on mobile

### DIFF
--- a/apps/app/src/components/PublicTeamSearch.test.tsx
+++ b/apps/app/src/components/PublicTeamSearch.test.tsx
@@ -1,13 +1,19 @@
 // @vitest-environment jsdom
 
 import { describe, it, expect, vi, beforeEach, afterEach, type MockInstance } from 'vitest';
-import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, cleanup, within } from '@testing-library/react';
+import { MemoryRouter, useLocation } from 'react-router-dom';
 import { PublicTeamSearch } from './PublicTeamSearch';
 import { getPublicTeamsByLocation } from '../lib/publicTeamsService';
+import { openPublicUrl } from '../lib/publicActions';
 import { ParentHomeTeam } from '../lib/homeLogic';
 
 vi.mock('../lib/publicTeamsService', () => ({
     getPublicTeamsByLocation: vi.fn() as MockInstance<(locationFilter?: string) => Promise<ParentHomeTeam[]>>,
+}));
+
+vi.mock('../lib/publicActions', () => ({
+    openPublicUrl: vi.fn(),
 }));
 
 const mockTeams: ParentHomeTeam[] = [
@@ -39,11 +45,25 @@ const mockTeams: ParentHomeTeam[] = [
         unreadCount: 0,
         openActions: 0,
         nextEvent: null,
-        appAccess: true,
+        appAccess: false,
         webAccess: true,
         isPublic: true,
     },
 ];
+
+function LocationProbe() {
+    const location = useLocation();
+    return <div data-testid="location-probe">{location.pathname}</div>;
+}
+
+function renderSearch() {
+    return render(
+        <MemoryRouter initialEntries={['/teams']}>
+            <PublicTeamSearch />
+            <LocationProbe />
+        </MemoryRouter>
+    );
+}
 
 describe('PublicTeamSearch', () => {
     afterEach(() => {
@@ -56,7 +76,7 @@ describe('PublicTeamSearch', () => {
     });
 
     it('renders an empty search-first state without loading teams on mount', () => {
-        render(<PublicTeamSearch />);
+        renderSearch();
 
         expect(screen.getByPlaceholderText('Search by city, state, or zip')).toBeTruthy();
         expect(screen.getByRole('button', { name: /Search/i })).toBeTruthy();
@@ -69,7 +89,7 @@ describe('PublicTeamSearch', () => {
 
     it('filters teams by location when search is submitted', async () => {
         (getPublicTeamsByLocation as import('vitest').Mock).mockResolvedValueOnce([mockTeams[0]]);
-        render(<PublicTeamSearch />);
+        renderSearch();
 
         const searchInput = screen.getByPlaceholderText('Search by city, state, or zip') as HTMLInputElement;
         fireEvent.change(searchInput, { target: { value: 'atlanta' } });
@@ -82,7 +102,7 @@ describe('PublicTeamSearch', () => {
     });
 
     it('loads all public teams only when browse all is used', async () => {
-        render(<PublicTeamSearch />);
+        renderSearch();
 
         fireEvent.click(screen.getByRole('button', { name: /Browse all public teams/i }));
 
@@ -93,7 +113,7 @@ describe('PublicTeamSearch', () => {
 
     it('clears a filtered search back to the empty state without browsing all', async () => {
         (getPublicTeamsByLocation as import('vitest').Mock).mockResolvedValueOnce([mockTeams[0]]);
-        render(<PublicTeamSearch />);
+        renderSearch();
 
         const searchInput = screen.getByPlaceholderText('Search by city, state, or zip') as HTMLInputElement;
         fireEvent.change(searchInput, { target: { value: 'atlanta' } });
@@ -112,7 +132,7 @@ describe('PublicTeamSearch', () => {
 
     it('displays an error message if fetching teams fails', async () => {
         (getPublicTeamsByLocation as import('vitest').Mock).mockRejectedValueOnce(new Error('Network error'));
-        render(<PublicTeamSearch />);
+        renderSearch();
 
         fireEvent.click(screen.getByRole('button', { name: /Browse all public teams/i }));
 
@@ -122,7 +142,7 @@ describe('PublicTeamSearch', () => {
 
     it('displays no teams found message when no results are returned', async () => {
         (getPublicTeamsByLocation as import('vitest').Mock).mockResolvedValueOnce([]);
-        render(<PublicTeamSearch />);
+        renderSearch();
 
         fireEvent.change(screen.getByPlaceholderText('Search by city, state, or zip'), { target: { value: 'boston' } });
         fireEvent.click(screen.getByRole('button', { name: /Search/i }));
@@ -135,12 +155,63 @@ describe('PublicTeamSearch', () => {
     });
 
     it('groups teams into separate location sections after browsing all', async () => {
-        render(<PublicTeamSearch />);
+        renderSearch();
 
         fireEvent.click(screen.getByRole('button', { name: /Browse all public teams/i }));
 
         await waitFor(() => expect(screen.getByText('Atlanta United')).toBeTruthy());
         expect(screen.getByText('New York Knicks')).toBeTruthy();
         expect(screen.getAllByRole('heading', { level: 3 }).length).toBe(2);
+    });
+
+    it('routes to the native team page when app access is available', async () => {
+        renderSearch();
+
+        fireEvent.click(screen.getByRole('button', { name: /Browse all public teams/i }));
+
+        await waitFor(() => expect(screen.getByText('Atlanta United')).toBeTruthy());
+        const atlantaCard = screen.getByText('Atlanta United').closest('article');
+        expect(atlantaCard).toBeTruthy();
+
+        fireEvent.click(within(atlantaCard as HTMLElement).getByRole('button', { name: 'View team' }));
+
+        expect(screen.getByTestId('location-probe').textContent).toBe('/teams/team-atl-1');
+        expect(openPublicUrl).not.toHaveBeenCalled();
+    });
+
+    it('opens the website team page when only web access is available', async () => {
+        renderSearch();
+
+        fireEvent.click(screen.getByRole('button', { name: /Browse all public teams/i }));
+
+        await waitFor(() => expect(screen.getByText('New York Knicks')).toBeTruthy());
+        const newYorkCard = screen.getByText('New York Knicks').closest('article');
+        expect(newYorkCard).toBeTruthy();
+
+        fireEvent.click(within(newYorkCard as HTMLElement).getByRole('button', { name: 'View team on website' }));
+
+        expect(openPublicUrl).toHaveBeenCalledWith('https://allplays.ai/team.html#teamId=team-nyc-1');
+        expect(screen.getByTestId('location-probe').textContent).toBe('/teams');
+    });
+
+    it('renders an unavailable state when neither app nor web access exists', async () => {
+        (getPublicTeamsByLocation as import('vitest').Mock).mockResolvedValueOnce([
+            {
+                ...mockTeams[0],
+                teamId: 'team-private-1',
+                teamName: 'Hidden Club',
+                appAccess: false,
+                webAccess: false,
+            },
+        ]);
+        renderSearch();
+
+        fireEvent.click(screen.getByRole('button', { name: /Browse all public teams/i }));
+
+        await waitFor(() => expect(screen.getByText('Hidden Club')).toBeTruthy());
+        const hiddenCard = screen.getByText('Hidden Club').closest('article');
+        expect(hiddenCard).toBeTruthy();
+        expect(within(hiddenCard as HTMLElement).queryByRole('button', { name: /View team/i })).toBeNull();
+        expect(within(hiddenCard as HTMLElement).getByText('Team page is not available in the app yet.')).toBeTruthy();
     });
 });

--- a/apps/app/src/components/PublicTeamSearch.tsx
+++ b/apps/app/src/components/PublicTeamSearch.tsx
@@ -1,15 +1,16 @@
 import { useState, useMemo, useCallback } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Search, XCircle, Loader2, Users } from 'lucide-react';
 import { type ParentHomeTeam } from '../lib/homeLogic';
 import { TeamAvatar, TeamLauncherChip, Status } from '../pages/Teams';
+import { openPublicUrl } from '../lib/publicActions';
 import { getPublicTeamsByLocation } from '../lib/publicTeamsService';
 import { resolveZip } from '../lib/utils';
 
-interface PublicTeamSearchProps {
-  // Add any props if needed, e.g., onTeamSelect, initialLocation
-}
+const PUBLIC_TEAM_WEBSITE_BASE_URL = 'https://allplays.ai/team.html';
 
-export function PublicTeamSearch(props: PublicTeamSearchProps) {
+export function PublicTeamSearch() {
+  const navigate = useNavigate();
   const [locationQuery, setLocationQuery] = useState<string>('');
   const [publicTeams, setPublicTeams] = useState<ParentHomeTeam[]>([]);
   const [loading, setLoading] = useState<boolean>(false);
@@ -48,6 +49,17 @@ export function PublicTeamSearch(props: PublicTeamSearchProps) {
     setActiveSearchLocation(null);
     setHasSearched(false);
   };
+
+  const handleOpenTeam = useCallback(async (team: ParentHomeTeam) => {
+    if (team.appAccess) {
+      navigate(`/teams/${encodeURIComponent(team.teamId)}`);
+      return;
+    }
+
+    if (team.webAccess) {
+      await openPublicUrl(`${PUBLIC_TEAM_WEBSITE_BASE_URL}#teamId=${encodeURIComponent(team.teamId)}`);
+    }
+  }, [navigate]);
 
   const groupedTeams = useMemo(() => {
     const groups: Record<string, ParentHomeTeam[]> = {};
@@ -138,7 +150,7 @@ export function PublicTeamSearch(props: PublicTeamSearchProps) {
               <h3 className="text-lg font-black text-gray-950">{location}</h3>
               <div className="grid gap-2 sm:grid-cols-2">
                 {teams.map(team => (
-                  <PublicTeamCard key={team.teamId} team={team} />
+                  <PublicTeamCard key={team.teamId} team={team} onOpenTeam={handleOpenTeam} />
                 ))}
               </div>
             </div>
@@ -153,22 +165,38 @@ export function PublicTeamSearch(props: PublicTeamSearchProps) {
   );
 }
 
-function PublicTeamCard({ team }: { team: ParentHomeTeam }) {
-  // This is a simplified TeamCard, adapt from existing TeamLauncherRow or create new
+function PublicTeamCard({ team, onOpenTeam }: { team: ParentHomeTeam; onOpenTeam: (team: ParentHomeTeam) => void | Promise<void> }) {
+  const isActionable = Boolean(team.appAccess || team.webAccess);
+  const actionLabel = team.appAccess ? 'View team' : 'View team on website';
+
   return (
-    <article className="flex min-w-0 items-center gap-2 rounded-2xl border border-gray-200 bg-white p-2 shadow-sm">
-      <TeamAvatar name={team.teamName} photoUrl={team.photoUrl} />
-      <span className="min-w-0 flex-1">
-        <span className="truncate text-sm font-black text-gray-950">{team.teamName}</span>
-        <span className="mt-0.5 block truncate text-xs font-semibold text-gray-500">{team.location || 'Location Unknown'}</span>
-        <span className="mt-1 flex min-w-0 flex-wrap gap-1.5">
-          <TeamLauncherChip label={`${team.players.length} player${team.players.length === 1 ? '' : 's'}`} />
+    <article className={`min-w-0 rounded-2xl border bg-white p-3 shadow-sm ${isActionable ? 'border-gray-200' : 'border-gray-200/80 bg-gray-50'}`}>
+      <div className="flex min-w-0 items-center gap-3">
+        <TeamAvatar name={team.teamName} photoUrl={team.photoUrl} />
+        <span className="min-w-0 flex-1">
+          <span className="truncate text-sm font-black text-gray-950">{team.teamName}</span>
+          <span className="mt-0.5 block truncate text-xs font-semibold text-gray-500">{team.location || 'Location Unknown'}</span>
+          <span className="mt-1 flex min-w-0 flex-wrap gap-1.5">
+            <TeamLauncherChip label={`${team.players.length} player${team.players.length === 1 ? '' : 's'}`} />
+          </span>
         </span>
-      </span>
-      {/* Optionally add a link to a public team detail page if it exists */}
-      {/* <Link to={`/public-teams/${encodeURIComponent(team.teamId)}`} className="secondary-button !min-h-10 flex-none text-sm">
-        View Team
-      </Link> */}
+      </div>
+
+      {isActionable ? (
+        <button
+          type="button"
+          className="primary-button mt-3 w-full justify-center !min-h-10 text-sm"
+          onClick={() => {
+            void onOpenTeam(team);
+          }}
+        >
+          {actionLabel}
+        </button>
+      ) : (
+        <div className="mt-3 rounded-xl border border-dashed border-gray-300 bg-white/70 px-3 py-2 text-xs font-semibold text-gray-500">
+          Team page is not available in the app yet.
+        </div>
+      )}
     </article>
   );
 }

--- a/apps/app/src/lib/publicTeamsService.test.ts
+++ b/apps/app/src/lib/publicTeamsService.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({
+    getTeams: vi.fn()
+}));
+
+vi.mock('../../../../js/db.js', () => dbMocks);
+
+import { getPublicTeamsByLocation } from './publicTeamsService';
+
+describe('getPublicTeamsByLocation', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it('defaults public teams without access flags to website access', async () => {
+        dbMocks.getTeams.mockResolvedValue([
+            {
+                id: 'team-legacy-1',
+                name: 'Legacy Legends',
+                city: 'Chicago',
+                state: 'IL'
+            }
+        ]);
+
+        await expect(getPublicTeamsByLocation()).resolves.toEqual([
+            expect.objectContaining({
+                teamId: 'team-legacy-1',
+                teamName: 'Legacy Legends',
+                location: 'Chicago, IL',
+                appAccess: false,
+                webAccess: true,
+                isPublic: true
+            })
+        ]);
+        expect(dbMocks.getTeams).toHaveBeenCalledWith({ publicOnly: true, locationFilter: '' });
+    });
+
+    it('preserves explicit access flags from the public team document', async () => {
+        dbMocks.getTeams.mockResolvedValue([
+            {
+                id: 'team-hidden-1',
+                name: 'Hidden Club',
+                zip: '60601',
+                appAccess: false,
+                webAccess: false
+            }
+        ]);
+
+        await expect(getPublicTeamsByLocation('60601')).resolves.toEqual([
+            expect.objectContaining({
+                teamId: 'team-hidden-1',
+                location: '60601',
+                appAccess: false,
+                webAccess: false
+            })
+        ]);
+        expect(dbMocks.getTeams).toHaveBeenCalledWith({ publicOnly: true, locationFilter: '60601' });
+    });
+});

--- a/apps/app/src/lib/publicTeamsService.ts
+++ b/apps/app/src/lib/publicTeamsService.ts
@@ -17,7 +17,7 @@ export async function getPublicTeamsByLocation(locationFilter?: string): Promise
         photoUrl: team.photoUrl ?? null,
         location: teamLocation(team),
         appAccess: team.appAccess ?? false,
-        webAccess: team.webAccess ?? false,
+        webAccess: team.webAccess ?? true,
         isPublic: true,
         players: [],
         nextEvent: null,


### PR DESCRIPTION
Closes #1706

## What changed
- added a clear mobile CTA to each public team search result
- route directly to the in-app team page when `appAccess` is available
- open the existing public website team page through the external-link adapter when only `webAccess` is available
- show a concise unavailable state when neither destination exists
- added focused component coverage for native navigation, web fallback, and unavailable results

## Why
Public team discovery in the Teams tab was a dead end on mobile. This keeps the change small while restoring a complete follow-through path from search results to a usable destination.