### PR TITLE
Add recurring practice cancellation to app schedule detail

### DIFF
--- a/apps/app/src/lib/scheduleLogic.ts
+++ b/apps/app/src/lib/scheduleLogic.ts
@@ -159,6 +159,7 @@ export type ParentScheduleEvent = {
   practiceSessionId?: string | null;
   practiceHomePacket?: PracticeHomePacket | null;
   practicePacketCompletions?: PracticePacketCompletion[];
+  isTeamAdmin?: boolean;
   isTeamStaff?: boolean;
   isTeamRsvpReminderManager?: boolean;
   calendarUrls?: string[];

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1290,6 +1290,7 @@ function createScheduleEvent(input: {
     practiceSessionId: input.practiceSessionId || null,
     practiceHomePacket: packetSummary ? input.practiceHomePacket : null,
     practicePacketCompletions: [],
+    isTeamAdmin: input.isTeamAdmin === true,
     isTeamStaff: input.isTeamStaff === true,
     isTeamRsvpReminderManager: input.isTeamRsvpReminderManager === true,
     gamePlan: input.gamePlan || null
@@ -1372,6 +1373,7 @@ async function buildTeamSchedule(teamId: string, teamChildren: ParentScheduleChi
             practiceHomePacket: hasHomePacket(session) ? session.homePacketContent : null,
             practiceSessionId: compactString(session?.id) || null,
             availabilityPreferences,
+            isTeamAdmin: isRsvpReminderManager,
             isTeamStaff: isStaff,
             isTeamRsvpReminderManager: isRsvpReminderManager,
             gamePlan: game.gamePlan || null
@@ -1428,6 +1430,7 @@ async function buildTeamSchedule(teamId: string, teamChildren: ParentScheduleChi
           practiceHomePacket: isPractice && hasHomePacket(session) ? session.homePacketContent : null,
           practiceSessionId: isPractice ? compactString(session?.id) || null : null,
           availabilityPreferences,
+          isTeamAdmin: isRsvpReminderManager,
           isTeamStaff: isStaff,
           isTeamRsvpReminderManager: isRsvpReminderManager,
           gamePlan: game.gamePlan || null
@@ -1478,6 +1481,7 @@ async function buildTeamSchedule(teamId: string, teamChildren: ParentScheduleChi
           practiceHomePacket: isPractice && hasHomePacket(session) ? session.homePacketContent : null,
           practiceSessionId: isPractice ? compactString(session?.id) || null : null,
           availabilityPreferences,
+          isTeamAdmin: isRsvpReminderManager,
           isTeamStaff: isStaff,
           isTeamRsvpReminderManager: isRsvpReminderManager
         }));
@@ -1508,6 +1512,7 @@ async function buildTeamSchedule(teamId: string, teamChildren: ParentScheduleChi
           practiceHomePacket: hasHomePacket(session) ? session.homePacketContent : null,
           practiceSessionId: compactString(session?.id) || null,
           availabilityPreferences,
+          isTeamAdmin: isRsvpReminderManager,
           isTeamStaff: isStaff,
           isTeamRsvpReminderManager: isRsvpReminderManager
         }));
@@ -2199,8 +2204,8 @@ export async function cancelPracticeOccurrenceForApp(event: ParentScheduleEvent,
   if (!user?.uid) {
     throw new Error('Sign in before cancelling this practice occurrence.');
   }
-  if (!event.isTeamStaff) {
-    throw new Error('Coach or admin access is required to cancel this practice occurrence.');
+  if (!event.isTeamAdmin) {
+    throw new Error('Team owner or admin access is required to cancel this practice occurrence.');
   }
 
   const occurrence = parseRecurringPracticeOccurrenceId(event.id);

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -24,7 +24,8 @@ import {
   updateGame,
   updateTeam,
   upsertPracticePacketCompletion,
-  postSharedGameCancellationNotification
+  postSharedGameCancellationNotification,
+  cancelOccurrence
 } from '../../../../js/db.js';
 import { sendPublicRsvpReminderEmails } from '../../../../js/schedule-notifications.js';
 import { db, doc, collection, getDocs, runTransaction, increment, serverTimestamp } from '../../../../js/firebase.js';
@@ -179,6 +180,12 @@ export type PlayerScoringStatResult = GameScoreSnapshot & {
 export type CancelScheduledGameResult = {
   cancelled: true;
   notificationError: string | null;
+};
+
+export type CancelPracticeOccurrenceResult = {
+  cancelled: true;
+  masterId: string;
+  instanceDate: string;
 };
 
 export type PublishGamePlanResult = {
@@ -573,6 +580,14 @@ async function readWithNativeFallback<T>(label: string, primary: () => Promise<T
 
 function compactString(value: unknown) {
   return String(value || '').trim();
+}
+
+export function parseRecurringPracticeOccurrenceId(eventId: string) {
+  const normalizedEventId = compactString(eventId);
+  if (!normalizedEventId || !normalizedEventId.includes('__')) return null;
+  const [masterId, instanceDate] = normalizedEventId.split(/__(.+)/).filter(Boolean);
+  if (!masterId || !instanceDate || !/^\d{4}-\d{2}-\d{2}$/.test(instanceDate)) return null;
+  return { masterId, instanceDate };
 }
 
 async function mapWithConcurrency<T, R>(
@@ -2171,6 +2186,47 @@ export async function cancelScheduledGameForApp(event: ParentScheduleEvent, user
   return {
     cancelled: true,
     notificationError
+  };
+}
+
+export async function cancelPracticeOccurrenceForApp(event: ParentScheduleEvent, user: AuthUser | null): Promise<CancelPracticeOccurrenceResult> {
+  if (!event?.teamId || !event?.id || !event.isDbGame || event.type !== 'practice') {
+    throw new Error('A recurring practice occurrence is required before cancelling.');
+  }
+  if (event.isCancelled) {
+    throw new Error('This practice occurrence is already cancelled.');
+  }
+  if (!user?.uid) {
+    throw new Error('Sign in before cancelling this practice occurrence.');
+  }
+  if (!event.isTeamStaff) {
+    throw new Error('Coach or admin access is required to cancel this practice occurrence.');
+  }
+
+  const occurrence = parseRecurringPracticeOccurrenceId(event.id);
+  if (!occurrence) {
+    throw new Error('Only recurring practice occurrences can be cancelled here.');
+  }
+
+  try {
+    await withTimeout(Promise.resolve(cancelOccurrence(event.teamId, occurrence.masterId, occurrence.instanceDate)), 'Practice occurrence cancellation');
+  } catch (error) {
+    if (!isNativeRuntime()) throw error;
+    console.warn('[schedule-service] Falling back to REST practice occurrence cancellation:', error);
+    const path = `teams/${encodeURIComponent(event.teamId)}/games/${encodeURIComponent(occurrence.masterId)}`;
+    const existing = await nativeGetDocument(path);
+    const nextExDates = uniqueNonEmptyStrings([...(Array.isArray(existing?.exDates) ? existing.exDates : []), occurrence.instanceDate]);
+    await nativePatchDocument(path, {
+      exDates: nextExDates,
+      updatedAt: new Date(),
+      updatedBy: user.uid
+    });
+  }
+
+  return {
+    cancelled: true,
+    masterId: occurrence.masterId,
+    instanceDate: occurrence.instanceDate
   };
 }
 

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -3,6 +3,7 @@ import { Link, useParams, useSearchParams } from 'react-router-dom';
 import { AlertCircle, CalendarDays, Car, CheckCircle2, ChevronDown, ChevronLeft, ClipboardCheck, Clock, ExternalLink, FileText, MapPin, Radio, RefreshCw, Share2, Users, Video, type LucideIcon } from 'lucide-react';
 import {
   cancelParentScheduleRideRequest,
+  cancelPracticeOccurrenceForApp,
   cancelScheduledGameForApp,
   claimParentScheduleAssignmentSlot,
   createParentScheduleRideOffer,
@@ -258,6 +259,14 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
     )));
   }, [decodedEventId, decodedTeamId]);
 
+  const handlePracticeOccurrenceCancelled = useCallback(() => {
+    setEvents((current) => current.map((event) => (
+      event.teamId === decodedTeamId && event.id === decodedEventId
+        ? { ...event, status: 'cancelled', isCancelled: true, availabilityLocked: true }
+        : event
+    )));
+  }, [decodedEventId, decodedTeamId]);
+
   const handleGamePlanPublished = useCallback((gamePlan: Record<string, any>) => {
     setEvents((current) => current.map((event) => (
       event.teamId === decodedTeamId && event.id === decodedEventId
@@ -429,7 +438,7 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
             onAssignmentsChanged={handleAssignmentsChanged}
           />
         ) : null}
-        {activeSection === 'game' ? <GameHubSection auth={auth} event={selectedEvent} childEvents={events} onScoreUpdated={handleScoreUpdated} onGameCancelled={handleGameCancelled} onGamePlanPublished={handleGamePlanPublished} /> : null}
+        {activeSection === 'game' ? <GameHubSection auth={auth} event={selectedEvent} childEvents={events} onScoreUpdated={handleScoreUpdated} onGameCancelled={handleGameCancelled} onPracticeOccurrenceCancelled={handlePracticeOccurrenceCancelled} onGamePlanPublished={handleGamePlanPublished} /> : null}
       </div>
     </div>
   );
@@ -1461,7 +1470,7 @@ function AssignmentCard({ assignment, userId, busy, disabled, onClaim, onRelease
   );
 }
 
-function GameHubSection({ auth, event, childEvents, onScoreUpdated, onGameCancelled, onGamePlanPublished }: { auth: AuthState; event: ParentScheduleEvent; childEvents: ParentScheduleEvent[]; onScoreUpdated: (homeScore: number, awayScore: number) => void; onGameCancelled: () => void; onGamePlanPublished: (gamePlan: Record<string, any>) => void }) {
+function GameHubSection({ auth, event, childEvents, onScoreUpdated, onGameCancelled, onPracticeOccurrenceCancelled, onGamePlanPublished }: { auth: AuthState; event: ParentScheduleEvent; childEvents: ParentScheduleEvent[]; onScoreUpdated: (homeScore: number, awayScore: number) => void; onGameCancelled: () => void; onPracticeOccurrenceCancelled: () => void; onGamePlanPublished: (gamePlan: Record<string, any>) => void }) {
   const [shareStatus, setShareStatus] = useState<string | null>(null);
   const [cancelStatus, setCancelStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
   const [cancelling, setCancelling] = useState(false);
@@ -1472,6 +1481,7 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onGameCancel
   const isPractice = event.type === 'practice';
   const canUpdateScore = Boolean(!isPractice && event.isDbGame && !event.isCancelled && event.canUpdateScore && auth.user);
   const canCancelGame = Boolean(!isPractice && event.isDbGame && !event.isCancelled && event.canUpdateScore && auth.user);
+  const canCancelPracticeOccurrence = Boolean(isPractice && event.isDbGame && !event.isCancelled && event.isTeamStaff && auth.user && event.id.includes('__'));
   const canPublishLineup = Boolean(!isPractice && event.isDbGame && event.isTeamStaff);
   const notifiesCounterpartTeam = Boolean(event.opponentTeamId || event.sharedScheduleOpponentTeamId);
   const hubDestinations = isPractice ? buildPracticeHubDestinations(event) : buildGameHubDestinations(event);
@@ -1499,6 +1509,25 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onGameCancel
         : { tone: 'success', message: notifiesCounterpartTeam ? 'Game cancelled and both team chats notified.' : 'Game cancelled and team chat notified.' });
     } catch (error: any) {
       setCancelStatus({ tone: 'error', message: error?.message || 'Unable to cancel game.' });
+    } finally {
+      setCancelling(false);
+    }
+  };
+
+  const cancelPracticeOccurrence = async () => {
+    if (!auth.user) return;
+    const practiceLabel = event.title || 'this practice';
+    const confirmed = window.confirm(`Cancel only ${practiceLabel} on ${formatEventDateLabel(event.date)}? This cancels just this occurrence, not the full recurring series.`);
+    if (!confirmed) return;
+
+    setCancelling(true);
+    setCancelStatus(null);
+    try {
+      await cancelPracticeOccurrenceForApp(event, auth.user);
+      onPracticeOccurrenceCancelled();
+      setCancelStatus({ tone: 'success', message: 'Practice occurrence cancelled for this date only.' });
+    } catch (error: any) {
+      setCancelStatus({ tone: 'error', message: error?.message || 'Unable to cancel practice occurrence.' });
     } finally {
       setCancelling(false);
     }
@@ -1580,6 +1609,25 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onGameCancel
                   disabled={cancelling}
                 >
                   {cancelling ? 'Cancelling game' : 'Cancel game'}
+                </button>
+              </div>
+            </div>
+          ) : null}
+
+          {canCancelPracticeOccurrence ? (
+            <div className="mt-3 rounded-2xl border border-rose-200 bg-rose-50 p-3">
+              <div className="flex flex-wrap items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="text-xs font-black uppercase tracking-[0.04em] text-rose-700">Schedule management</div>
+                  <div className="mt-1 text-sm font-semibold text-rose-900">Cancel only this recurring practice occurrence.</div>
+                </div>
+                <button
+                  type="button"
+                  className="min-h-11 rounded-full bg-rose-600 px-4 text-sm font-black text-white shadow-sm transition hover:bg-rose-700 disabled:opacity-60"
+                  onClick={cancelPracticeOccurrence}
+                  disabled={cancelling}
+                >
+                  {cancelling ? 'Cancelling occurrence' : 'Cancel this occurrence'}
                 </button>
               </div>
             </div>

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -1481,7 +1481,7 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onGameCancel
   const isPractice = event.type === 'practice';
   const canUpdateScore = Boolean(!isPractice && event.isDbGame && !event.isCancelled && event.canUpdateScore && auth.user);
   const canCancelGame = Boolean(!isPractice && event.isDbGame && !event.isCancelled && event.canUpdateScore && auth.user);
-  const canCancelPracticeOccurrence = Boolean(isPractice && event.isDbGame && !event.isCancelled && event.isTeamStaff && auth.user && event.id.includes('__'));
+  const canCancelPracticeOccurrence = Boolean(isPractice && event.isDbGame && !event.isCancelled && event.isTeamAdmin && auth.user && event.id.includes('__'));
   const canPublishLineup = Boolean(!isPractice && event.isDbGame && event.isTeamStaff);
   const notifiesCounterpartTeam = Boolean(event.opponentTeamId || event.sharedScheduleOpponentTeamId);
   const hubDestinations = isPractice ? buildPracticeHubDestinations(event) : buildGameHubDestinations(event);

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -367,6 +367,15 @@ async function mockScheduleModules(page, options = {}) {
                     return { status: 'cancelled', isCancelled: true };
                 }
 
+                export async function cancelPracticeOccurrenceForApp(event, user) {
+                    window.__scheduleCalls.practiceCancellations = (window.__scheduleCalls.practiceCancellations || []).concat({
+                        teamId: event?.teamId || null,
+                        eventId: event?.id || null,
+                        userId: user?.uid || null
+                    });
+                    return { status: 'cancelled', isCancelled: true };
+                }
+
                 export async function loadAutoFilledLineupDraftPreviewForApp(event, user, formationId) {
                     return {
                         formationId,

--- a/tests/unit/app-schedule-event-detail-cancel.test.js
+++ b/tests/unit/app-schedule-event-detail-cancel.test.js
@@ -24,7 +24,7 @@ describe('React app schedule event detail cancellation action', () => {
         const source = readDetailSource();
 
         expect(source).toContain('cancelPracticeOccurrenceForApp');
-        expect(source).toContain("const canCancelPracticeOccurrence = Boolean(isPractice && event.isDbGame && !event.isCancelled && event.isTeamStaff && auth.user && event.id.includes('__'));");
+        expect(source).toContain("const canCancelPracticeOccurrence = Boolean(isPractice && event.isDbGame && !event.isCancelled && event.isTeamAdmin && auth.user && event.id.includes('__'));");
         expect(source).toContain("Cancel only ${practiceLabel} on ${formatEventDateLabel(event.date)}? This cancels just this occurrence, not the full recurring series.`);");
         expect(source).toContain('Practice occurrence cancelled for this date only.');
         expect(source).toContain('Cancel this occurrence');

--- a/tests/unit/app-schedule-event-detail-cancel.test.js
+++ b/tests/unit/app-schedule-event-detail-cancel.test.js
@@ -13,28 +13,34 @@ describe('React app schedule event detail cancellation action', () => {
         expect(source).toContain("const canCancelGame = Boolean(!isPractice && event.isDbGame && !event.isCancelled && event.canUpdateScore && auth.user);");
         expect(source).toContain('Cancel game');
         expect(source).toContain("const notifiesCounterpartTeam = Boolean(event.opponentTeamId || event.sharedScheduleOpponentTeamId);");
-        expect(source).toContain("This marks the game cancelled and notifies ${notifiesCounterpartTeam ? 'both team chats' : 'the team in chat'}.");
+        expect(source).toContain("This marks the game cancelled and notifies ${notifiesCounterpartTeam ? 'both team chats' : 'the team in chat'}.`);");
         expect(source).toContain("{ ...event, status: 'cancelled', isCancelled: true, availabilityLocked: true }");
         expect(source).toContain('Game cancelled, but team chat notification failed:');
-        expect(source).toContain("Game cancelled and both team chats notified.");
-        expect(source).toContain("Cancel this game and notify both team chats.");
+        expect(source).toContain('Game cancelled and both team chats notified.');
+        expect(source).toContain('Cancel this game and notify both team chats.');
+    });
+
+    it('adds recurring practice occurrence cancellation for staff-only schedule detail views', () => {
+        const source = readDetailSource();
+
+        expect(source).toContain('cancelPracticeOccurrenceForApp');
+        expect(source).toContain("const canCancelPracticeOccurrence = Boolean(isPractice && event.isDbGame && !event.isCancelled && event.isTeamStaff && auth.user && event.id.includes('__'));");
+        expect(source).toContain("Cancel only ${practiceLabel} on ${formatEventDateLabel(event.date)}? This cancels just this occurrence, not the full recurring series.`);");
+        expect(source).toContain('Practice occurrence cancelled for this date only.');
+        expect(source).toContain('Cancel this occurrence');
+        expect(source).toContain('Cancel only this recurring practice occurrence.');
     });
 
     it('includes Forecast link logic when a location is present', () => {
         const source = readDetailSource();
-        // Check for import of getScheduleForecastHref
         expect(source).toContain('  getScheduleMapHref,');
-        expect(source).toContain('  getScheduleForecastHref,'); // New import
-
-        // Check for usage in EventDetailsPanel
+        expect(source).toContain('  getScheduleForecastHref,');
         expect(source).toContain('const mapHref = getScheduleMapHref(event.location);');
-        expect(source).toContain('const forecastHref = getScheduleForecastHref(event.location);'); // New variable
-
-        // Check for conditional rendering of both links
-        expect(source).toContain('{(mapHref || forecastHref) ? ('); // Conditional wrapper
-        expect(source).toContain('<a href={mapHref} target="_blank" rel="noreferrer" className="secondary-button min-h-9 flex-1 px-3 py-2 text-xs">'); // Directions link
+        expect(source).toContain('const forecastHref = getScheduleForecastHref(event.location);');
+        expect(source).toContain('{(mapHref || forecastHref) ? (');
+        expect(source).toContain('<a href={mapHref} target="_blank" rel="noreferrer" className="secondary-button min-h-9 flex-1 px-3 py-2 text-xs">');
         expect(source).toContain('Directions');
-        expect(source).toContain('<a href={forecastHref} target="_blank" rel="noreferrer" className="secondary-button min-h-9 flex-1 px-3 py-2 text-xs">'); // Forecast link
+        expect(source).toContain('<a href={forecastHref} target="_blank" rel="noreferrer" className="secondary-button min-h-9 flex-1 px-3 py-2 text-xs">');
         expect(source).toContain('Forecast');
     });
 });

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -14,6 +14,7 @@ const dbMocks = vi.hoisted(() => ({
     updateTeam: vi.fn(),
     addGame: vi.fn(),
     addPractice: vi.fn(),
+    cancelOccurrence: vi.fn(),
     getTrackedCalendarEventUids: vi.fn(),
     createRideOffer: vi.fn(),
     claimAssignmentSlot: vi.fn(),
@@ -120,7 +121,7 @@ vi.mock('../../js/snack-helpers.js', () => ({
     }))
 }));
 
-import { addTeamCalendarUrl, createScheduleImportGame, createScheduleImportPractice, loadParentSchedule, loadParentScheduleEventDetail, removeTeamCalendarUrl } from '../../apps/app/src/lib/scheduleService.ts';
+import { addTeamCalendarUrl, cancelPracticeOccurrenceForApp, createScheduleImportGame, createScheduleImportPractice, loadParentSchedule, loadParentScheduleEventDetail, parseRecurringPracticeOccurrenceId, removeTeamCalendarUrl } from '../../apps/app/src/lib/scheduleService.ts';
 import { getScheduleForecastHref, getScheduleMapHref } from '../../apps/app/src/lib/scheduleLogic.ts';
 
 function installWindow(protocol = 'http:') {
@@ -645,6 +646,57 @@ describe('React app schedule service contract integration', () => {
         await expect(removeTeamCalendarUrl('team-1', 'https://example.com/team.ics', user()))
             .rejects.toThrow('You do not have permission to manage this team schedule.');
         expect(dbMocks.updateTeam).not.toHaveBeenCalled();
+    });
+
+    it('parses recurring practice occurrence ids and rejects non-occurrence ids', () => {
+        expect(parseRecurringPracticeOccurrenceId('practice-master__2026-06-05')).toEqual({
+            masterId: 'practice-master',
+            instanceDate: '2026-06-05'
+        });
+        expect(parseRecurringPracticeOccurrenceId('practice-master')).toBeNull();
+        expect(parseRecurringPracticeOccurrenceId('practice-master__bad-date')).toBeNull();
+    });
+
+    it('cancels a recurring practice occurrence through the legacy recurrence override path', async () => {
+        const coach = { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach' };
+        const event = {
+            teamId: 'team-1',
+            id: 'practice-master__2026-06-05',
+            isDbGame: true,
+            type: 'practice',
+            isCancelled: false,
+            isTeamStaff: true
+        };
+
+        await expect(cancelPracticeOccurrenceForApp(event, coach)).resolves.toEqual({
+            cancelled: true,
+            masterId: 'practice-master',
+            instanceDate: '2026-06-05'
+        });
+
+        expect(dbMocks.cancelOccurrence).toHaveBeenCalledWith('team-1', 'practice-master', '2026-06-05');
+    });
+
+    it('rejects recurring practice occurrence cancellation without staff access or occurrence ids', async () => {
+        const coach = { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach' };
+
+        await expect(cancelPracticeOccurrenceForApp({
+            teamId: 'team-1',
+            id: 'practice-master__2026-06-05',
+            isDbGame: true,
+            type: 'practice',
+            isCancelled: false,
+            isTeamStaff: false
+        }, coach)).rejects.toThrow('Coach or admin access is required to cancel this practice occurrence.');
+
+        await expect(cancelPracticeOccurrenceForApp({
+            teamId: 'team-1',
+            id: 'practice-master',
+            isDbGame: true,
+            type: 'practice',
+            isCancelled: false,
+            isTeamStaff: true
+        }, coach)).rejects.toThrow('Only recurring practice occurrences can be cancelled here.');
     });
 });
 

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -61,6 +61,12 @@ const rsvpMocks = vi.hoisted(() => ({
 vi.mock('../../js/db.js', () => dbMocks);
 vi.mock('../../apps/app/src/lib/profileService.ts', () => profileMocks);
 vi.mock('../../apps/app/src/lib/authService.ts', () => authMocks);
+vi.mock('../../apps/app/src/lib/chatService.ts', () => ({
+    sendTeamChatMessage: vi.fn()
+}));
+vi.mock('../../apps/app/src/lib/chatLogic.ts', () => ({
+    DEFAULT_TEAM_CONVERSATION_ID: 'team'
+}));
 vi.mock('../../js/utils.js', () => utilsMocks);
 vi.mock('../../js/parent-dashboard-practice-sessions.js', () => ({
     filterVisiblePracticeSessions: vi.fn((sessions) => sessions || [])
@@ -665,6 +671,7 @@ describe('React app schedule service contract integration', () => {
             isDbGame: true,
             type: 'practice',
             isCancelled: false,
+            isTeamAdmin: true,
             isTeamStaff: true
         };
 
@@ -686,8 +693,19 @@ describe('React app schedule service contract integration', () => {
             isDbGame: true,
             type: 'practice',
             isCancelled: false,
+            isTeamAdmin: false,
             isTeamStaff: false
-        }, coach)).rejects.toThrow('Coach or admin access is required to cancel this practice occurrence.');
+        }, coach)).rejects.toThrow('Team owner or admin access is required to cancel this practice occurrence.');
+
+        await expect(cancelPracticeOccurrenceForApp({
+            teamId: 'team-1',
+            id: 'practice-master__2026-06-05',
+            isDbGame: true,
+            type: 'practice',
+            isCancelled: false,
+            isTeamAdmin: false,
+            isTeamStaff: true
+        }, coach)).rejects.toThrow('Team owner or admin access is required to cancel this practice occurrence.');
 
         await expect(cancelPracticeOccurrenceForApp({
             teamId: 'team-1',
@@ -695,6 +713,7 @@ describe('React app schedule service contract integration', () => {
             isDbGame: true,
             type: 'practice',
             isCancelled: false,
+            isTeamAdmin: true,
             isTeamStaff: true
         }, coach)).rejects.toThrow('Only recurring practice occurrences can be cancelled here.');
     });


### PR DESCRIPTION
Closes #1708

## What changed
- added a recurring practice occurrence cancellation helper in `scheduleService` that parses `masterId__instanceDate` ids and persists the cancellation through the legacy `cancelOccurrence` recurrence override path
- added a staff-only schedule management action on `ScheduleEventDetail` for recurring practice occurrences with a date-specific confirmation dialog and immediate local cancelled-state refresh
- extended focused unit coverage for the new service helper and the schedule detail UI wiring

## Why
Recurring practice occurrences already render in the new app, but staff could not cancel a single date from the mobile/web detail view. This keeps the fix narrow by reusing the existing recurrence persistence model and the existing schedule detail management pattern.