### PR TITLE
Keep public game reports loading for widget viewers

### DIFF
--- a/game.html
+++ b/game.html
@@ -1269,11 +1269,18 @@ Write the match report now:`;
             document.getElementById('back-link').href = `team.html#teamId=${teamId}`;
 
             try {
+                const playersPromise = getPlayers(teamId, { includeInactive: true }).catch((error) => {
+                    if (error?.code === 'permission-denied') {
+                        console.warn('Failed to load public roster for game report viewer:', error);
+                        return [];
+                    }
+                    throw error;
+                });
                 const [team, game, players] = await Promise.all([
                     // Reports are historical and must resolve soft-deleted teams.
                     getTeam(teamId, { includeInactive: true }),
                     getGame(teamId, gameId),
-                    getPlayers(teamId, { includeInactive: true })
+                    playersPromise
                 ]);
 
                 if (!game) {

--- a/tests/unit/game-auth-reload.test.js
+++ b/tests/unit/game-auth-reload.test.js
@@ -36,4 +36,14 @@ describe('game auth reload', () => {
         expect(opponentHeaderReset).toBeGreaterThan(opponentStatsStart);
         expect(opponentHeaderReset).toBeLessThan(opponentHeaderAppend);
     });
+
+    it('keeps public game reports loading when legacy player docs are denied', () => {
+        const source = readGameHtml();
+
+        expect(source).toContain("const playersPromise = getPlayers(teamId, { includeInactive: true }).catch((error) => {");
+        expect(source).toContain("if (error?.code === 'permission-denied') {");
+        expect(source).toContain("console.warn('Failed to load public roster for game report viewer:', error);");
+        expect(source).toContain('return [];');
+        expect(source).toContain('playersPromise');
+    });
 });


### PR DESCRIPTION
Closes #1716

## What changed
- made `game.html` treat roster loading as optional when Firestore denies public reads on legacy player docs
- kept the page rendering with an empty player list instead of aborting the full load and showing a sign-in prompt
- added a regression unit test covering the public roster permission-denied fallback

## Why
The public scoreboard widget links anonymous viewers into `game.html` for completed games. On teams with legacy sensitive fields still present on public player docs, `getPlayers()` could fail with `permission-denied` and abort the whole page load. This change keeps the public game report accessible even when roster reads are blocked.