### PR TITLE
Add quick final score submission to officials cards

### DIFF
--- a/apps/app/src/pages/AcceptInvite.test.tsx
+++ b/apps/app/src/pages/AcceptInvite.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AcceptInvite } from './AcceptInvite';
+import type { AuthState } from '../lib/types';
+
+const authServiceMocks = vi.hoisted(() => ({
+    clearPendingInvite: vi.fn(),
+    completeEmailLink: vi.fn(),
+    isEmailLink: vi.fn(() => false),
+    mapLegacyRedirectToAppRoute: vi.fn(() => '/home'),
+    readPendingInvite: vi.fn(() => ({ code: '', type: '' })),
+    redeemInviteForUser: vi.fn(),
+    rememberPendingInvite: vi.fn()
+}));
+
+const inviteRedemptionMocks = vi.hoisted(() => ({
+    getValidatedInviteCode: vi.fn((code: string) => String(code || '').trim().toUpperCase()),
+    normalizeInviteCode: vi.fn((code: string) => String(code || '').trim().toUpperCase()),
+    redeemSignedInInvite: vi.fn()
+}));
+
+vi.mock('../lib/authService', () => authServiceMocks);
+vi.mock('../lib/inviteRedemption', () => inviteRedemptionMocks);
+
+const auth: AuthState = {
+    user: {
+        uid: 'user-1',
+        email: 'parent@example.com',
+        displayName: 'Pat Parent',
+        emailVerified: false,
+        roles: ['parent']
+    },
+    profile: null,
+    loading: false,
+    error: null,
+    roles: ['parent'],
+    isParent: true,
+    isCoach: false,
+    isAdmin: false,
+    isPlatformAdmin: false,
+    refresh: vi.fn().mockResolvedValue(undefined),
+    signOut: vi.fn().mockResolvedValue(undefined)
+};
+
+function renderAcceptInvite() {
+    return render(
+        <MemoryRouter initialEntries={['/accept-invite?code=ABCDEFGH&type=parent']}>
+            <Routes>
+                <Route path="/accept-invite" element={<AcceptInvite auth={auth} />} />
+                <Route path="/home" element={<div>Home route</div>} />
+            </Routes>
+        </MemoryRouter>
+    );
+}
+
+describe('AcceptInvite', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        inviteRedemptionMocks.redeemSignedInInvite.mockResolvedValue({
+            code: 'ABCDEFGH',
+            redirectPath: '/home',
+            message: 'Invite accepted.'
+        });
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    it('shows signed-in invite success before redirecting to the destination route', async () => {
+        renderAcceptInvite();
+
+        expect(await screen.findByText('Invite accepted.')).toBeTruthy();
+        expect(screen.queryByText('Home route')).toBeNull();
+
+        await new Promise((resolve) => setTimeout(resolve, 750));
+
+        expect(await screen.findByText('Home route')).toBeTruthy();
+        expect(inviteRedemptionMocks.redeemSignedInInvite).toHaveBeenCalledWith({
+            userId: 'user-1',
+            code: 'ABCDEFGH',
+            email: 'parent@example.com',
+            refresh: auth.refresh
+        });
+    });
+});

--- a/apps/app/src/pages/AcceptInvite.tsx
+++ b/apps/app/src/pages/AcceptInvite.tsx
@@ -26,6 +26,7 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
   const [email, setEmail] = useState(window.localStorage.getItem('emailForSignIn') || '');
   const [state, setState] = useState<'idle' | 'processing' | 'email-link' | 'success' | 'error'>('idle');
   const [message, setMessage] = useState('');
+  const [pendingRedirectPath, setPendingRedirectPath] = useState('');
   const processedKeyRef = useRef('');
   const redirectTimerRef = useRef<number | null>(null);
 
@@ -33,20 +34,24 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
     return buildInviteAuthUrl(code, inviteType);
   }, [code, inviteType]);
 
-  const scheduleRedirect = (path: string) => {
+  useEffect(() => {
+    if (!pendingRedirectPath) {
+      return undefined;
+    }
+
     if (redirectTimerRef.current !== null) {
       window.clearTimeout(redirectTimerRef.current);
     }
-    redirectTimerRef.current = window.setTimeout(() => navigate(path, { replace: true }), 700);
-  };
 
-  useEffect(() => {
+    redirectTimerRef.current = window.setTimeout(() => navigate(pendingRedirectPath, { replace: true }), 700);
+
     return () => {
       if (redirectTimerRef.current !== null) {
         window.clearTimeout(redirectTimerRef.current);
+        redirectTimerRef.current = null;
       }
     };
-  }, []);
+  }, [navigate, pendingRedirectPath]);
 
   async function redeem(codeToRedeem: string) {
     const normalizedCode = normalizeInviteCode(codeToRedeem);
@@ -74,7 +79,7 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
       });
       setState('success');
       setMessage(result.message);
-      scheduleRedirect(result.redirectPath);
+      setPendingRedirectPath(result.redirectPath);
     } catch (error: any) {
       processedKeyRef.current = '';
       setState('error');
@@ -117,11 +122,11 @@ export function AcceptInvite({ auth }: { auth: AuthState }) {
         clearPendingInvite();
         setState('success');
         setMessage(inviteResult?.message || 'Invite accepted.');
-        scheduleRedirect(mapLegacyRedirectToAppRoute(inviteResult?.redirectUrl));
+        setPendingRedirectPath(mapLegacyRedirectToAppRoute(inviteResult?.redirectUrl));
       } else {
         setState('success');
         setMessage('Signed in successfully.');
-        scheduleRedirect('/home');
+        setPendingRedirectPath('/home');
       }
     } catch (error: any) {
       setState('error');

--- a/edit-schedule.html
+++ b/edit-schedule.html
@@ -3071,6 +3071,7 @@
             `;
             row.dataset.slotId = slot.id || generateOfficiatingSlotId();
             row.dataset.officialUserId = slot.officialUserId || '';
+            row.dataset.submittedResult = slot.submittedResult ? JSON.stringify(slot.submittedResult) : '';
             row.querySelector('.officiating-official').addEventListener('change', (event) => {
                 const selectedOfficial = getDirectoryOfficial(event.target.value);
                 if (selectedOfficial) {
@@ -3113,6 +3114,16 @@
             }
         }
 
+        function parseStoredOfficiatingResult(value) {
+            if (!value) return null;
+            try {
+                return JSON.parse(value);
+            } catch (error) {
+                console.warn('Could not parse stored officiating result from schedule form row:', error);
+                return null;
+            }
+        }
+
         function getOfficiatingSlotsFromForm() {
             const rows = document.querySelectorAll('#officiating-slot-rows .officiating-slot-row');
             const slots = Array.from(rows).map(row => {
@@ -3125,7 +3136,8 @@
                     officialName: row.querySelector('.officiating-name').value.trim() || official?.name || '',
                     officialEmail: (row.querySelector('.officiating-email').value.trim() || official?.email || '').toLowerCase(),
                     officialUserId: row.dataset.officialUserId || '',
-                    status: row.querySelector('.officiating-status').value
+                    status: row.querySelector('.officiating-status').value,
+                    submittedResult: parseStoredOfficiatingResult(row.dataset.submittedResult || '')
                 };
             }).filter(slot => slot.position);
             return normalizeAssignmentOfficiatingSlots(slots);

--- a/js/db.js
+++ b/js/db.js
@@ -107,8 +107,9 @@ import { getApp } from './vendor/firebase-app.js';
 import {
     claimOfficiatingSlot,
     computeOfficiatingCoverageStatus,
-    updateOfficiatingSlotResponse
-} from './officiating-utils.js?v=3';
+    updateOfficiatingSlotResponse,
+    updateOfficiatingSlotResult
+} from './officiating-utils.js?v=4';
 import { buildOfficiatingNotificationRecord } from './officiating-notifications.js?v=2';
 import {
     getTeamEmailAttachmentTotalBytes,
@@ -6488,6 +6489,29 @@ export async function claimOpenOfficiatingSlot(teamId, gameId, slotId, official 
     });
 
     await tryCreateOfficiatingAssignmentNotificationRecords(teamId, notificationRecord ? [notificationRecord] : []);
+}
+
+export async function submitOfficiatingAssignmentResult(teamId, gameId, slotId, result, official = auth.currentUser) {
+    const docRef = getGameDocRef(teamId, gameId);
+    await runTransaction(db, async (transaction) => {
+        const snap = await transaction.get(docRef);
+        if (!snap.exists()) throw new Error('Game not found');
+
+        const game = snap.data() || {};
+        if (String(game.status || '').trim().toLowerCase() === 'cancelled') {
+            throw new Error('Cancelled games cannot accept final results.');
+        }
+
+        const officiatingSlots = updateOfficiatingSlotResult(game.officiatingSlots || [], slotId, result, official, {
+            submittedAt: Timestamp.now()
+        });
+
+        transaction.update(docRef, {
+            officiatingSlots,
+            officiatingCoverageStatus: computeOfficiatingCoverageStatus(officiatingSlots),
+            officiatingUpdatedAt: Timestamp.now()
+        });
+    });
 }
 
 // ============================================

--- a/js/officiating-utils.js
+++ b/js/officiating-utils.js
@@ -303,6 +303,15 @@ export function claimOfficiatingSlot(slots = [], slotId, official = {}) {
     return nextSlots;
 }
 
+function doesOfficialMatchAssignedSlot(slot = {}, official = {}) {
+    const officialUserId = String(official?.uid || '').trim();
+    const officialEmail = normalizeOfficialEmail(official?.email || '');
+    if (!officialUserId && !officialEmail) return false;
+    if (slot.officialUserId && slot.officialUserId === officialUserId) return true;
+    if (slot.officialEmail && slot.officialEmail === officialEmail) return true;
+    return false;
+}
+
 export function updateOfficiatingSlotResult(slots = [], slotId, result = {}, official = {}, options = {}) {
     const submission = validateOfficiatingResultSubmission(result);
     if (!submission.valid) {
@@ -314,6 +323,9 @@ export function updateOfficiatingSlotResult(slots = [], slotId, result = {}, off
         if (slot.id !== slotId) return slot;
         if (slot.status !== 'accepted') {
             throw new Error('Only accepted assignments can submit final results.');
+        }
+        if (!doesOfficialMatchAssignedSlot(slot, official)) {
+            throw new Error('You can only submit a result for your own accepted assignment.');
         }
 
         updated = true;

--- a/js/officiating-utils.js
+++ b/js/officiating-utils.js
@@ -1,5 +1,60 @@
 export const OFFICIATING_ASSIGNMENT_STATUSES = ['pending', 'accepted', 'declined', 'cant_make', 'needs_review', 'open'];
 
+function toWholeNumber(value) {
+    if (value === '' || value === null || value === undefined) return null;
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || !Number.isInteger(numeric) || numeric < 0) return null;
+    return numeric;
+}
+
+export function normalizeOfficiatingResult(result = null) {
+    if (!result || typeof result !== 'object') return null;
+
+    const homeScore = toWholeNumber(result.homeScore);
+    const awayScore = toWholeNumber(result.awayScore);
+    if (homeScore === null || awayScore === null) return null;
+
+    return {
+        homeScore,
+        awayScore,
+        notes: String(result.notes || '').trim(),
+        submittedAt: result.submittedAt || null,
+        submittedByUserId: String(result.submittedByUserId || '').trim(),
+        submittedByEmail: normalizeOfficialEmail(result.submittedByEmail || ''),
+        submittedByName: String(result.submittedByName || '').trim()
+    };
+}
+
+export function hasSubmittedOfficiatingResult(slot = {}) {
+    return !!normalizeOfficiatingResult(slot?.submittedResult || null);
+}
+
+export function validateOfficiatingResultSubmission(result = {}) {
+    const homeScoreProvided = result.homeScore !== '' && result.homeScore !== null && result.homeScore !== undefined;
+    const awayScoreProvided = result.awayScore !== '' && result.awayScore !== null && result.awayScore !== undefined;
+    const homeScore = toWholeNumber(result.homeScore);
+    const awayScore = toWholeNumber(result.awayScore);
+    const errors = [];
+
+    if (!homeScoreProvided) errors.push('Enter a home score.');
+    else if (homeScore === null) errors.push('Home score must be a whole number 0 or greater.');
+
+    if (!awayScoreProvided) errors.push('Enter an away score.');
+    else if (awayScore === null) errors.push('Away score must be a whole number 0 or greater.');
+
+    return {
+        valid: errors.length === 0,
+        errors,
+        value: errors.length === 0
+            ? {
+                homeScore,
+                awayScore,
+                notes: String(result.notes || '').trim()
+            }
+            : null
+    };
+}
+
 export function normalizeOfficialEmail(email) {
     return String(email || '').trim().toLowerCase();
 }
@@ -38,7 +93,8 @@ export function normalizeOfficiatingSlots(slots = []) {
                 selfAssigned: slot?.selfAssigned === true,
                 scheduleReviewRequired,
                 scheduleReviewReason: scheduleReviewRequired ? String(slot?.scheduleReviewReason || 'Game schedule changed').trim() : '',
-                scheduleReviewMarkedAt: scheduleReviewRequired ? (slot?.scheduleReviewMarkedAt || null) : null
+                scheduleReviewMarkedAt: scheduleReviewRequired ? (slot?.scheduleReviewMarkedAt || null) : null,
+                submittedResult: normalizeOfficiatingResult(slot?.submittedResult || null)
             };
         })
         .filter(Boolean);
@@ -244,5 +300,35 @@ export function claimOfficiatingSlot(slots = [], slotId, official = {}) {
     });
 
     if (!claimed) throw new Error('Officiating slot not found');
+    return nextSlots;
+}
+
+export function updateOfficiatingSlotResult(slots = [], slotId, result = {}, official = {}, options = {}) {
+    const submission = validateOfficiatingResultSubmission(result);
+    if (!submission.valid) {
+        throw new Error(submission.errors[0] || 'Enter a valid final score.');
+    }
+
+    let updated = false;
+    const nextSlots = normalizeOfficiatingSlots(slots).map((slot) => {
+        if (slot.id !== slotId) return slot;
+        if (slot.status !== 'accepted') {
+            throw new Error('Only accepted assignments can submit final results.');
+        }
+
+        updated = true;
+        return {
+            ...slot,
+            submittedResult: {
+                ...submission.value,
+                submittedAt: options.submittedAt || new Date().toISOString(),
+                submittedByUserId: String(official?.uid || '').trim(),
+                submittedByEmail: normalizeOfficialEmail(official?.email || ''),
+                submittedByName: String(official?.displayName || official?.name || official?.email || 'Official').trim()
+            }
+        };
+    });
+
+    if (!updated) throw new Error('Officiating slot not found');
     return nextSlots;
 }

--- a/officials.html
+++ b/officials.html
@@ -24,7 +24,7 @@
         <section class="space-y-6">
             <div class="bg-white rounded-lg shadow border border-gray-200">
                 <div class="p-4 border-b border-gray-200">
-                    <h2 class="text-xl font-semibold text-gray-900">My Upcoming Assignments</h2>
+                    <h2 class="text-xl font-semibold text-gray-900">My Assignments</h2>
                 </div>
                 <div id="assigned-games" class="divide-y divide-gray-100"></div>
             </div>
@@ -43,9 +43,9 @@
 
     <script type="module">
         import { checkAuth } from './js/auth.js?v=14';
-        import { getGames, getTeam, getUserProfile, claimOpenOfficiatingSlot, respondToOfficiatingAssignment } from './js/db.js?v=32';
+        import { getGames, getTeam, getUserProfile, claimOpenOfficiatingSlot, respondToOfficiatingAssignment, submitOfficiatingAssignmentResult } from './js/db.js?v=33';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime, escapeHtml } from './js/utils.js?v=10';
-        import { getAssignedOfficiatingSlots, getOpenOfficiatingSlots } from './js/officiating-utils.js?v=3';
+        import { getAssignedOfficiatingSlots, getOpenOfficiatingSlots, hasSubmittedOfficiatingResult, validateOfficiatingResultSubmission } from './js/officiating-utils.js?v=4';
 
         renderFooter(document.getElementById('footer-container'));
 
@@ -67,6 +67,78 @@
             return date && !Number.isNaN(date.getTime()) && date >= new Date() && game.status !== 'cancelled';
         }
 
+        function hasGameStarted(game) {
+            const date = toDate(game.date);
+            return !!(date && !Number.isNaN(date.getTime()) && date < new Date());
+        }
+
+        function isCancelled(game) {
+            return String(game?.status || '').trim().toLowerCase() === 'cancelled';
+        }
+
+        function formatSubmittedAt(value) {
+            const date = toDate(value);
+            if (!date || Number.isNaN(date.getTime())) return 'just now';
+            return `${formatDate(date)} at ${formatTime(date)}`;
+        }
+
+        function renderSubmittedResult(slot) {
+            if (!hasSubmittedOfficiatingResult(slot)) return '';
+            const result = slot.submittedResult;
+            const notes = result.notes ? `<div class="mt-2 text-sm text-gray-700"><span class="font-semibold">Notes:</span> ${escapeHtml(result.notes)}</div>` : '';
+            const submittedBy = result.submittedByName ? ` by ${escapeHtml(result.submittedByName)}` : '';
+            return `
+                <div class="mt-4 rounded-lg border border-green-200 bg-green-50 p-3" data-result-state="submitted">
+                    <div class="flex flex-wrap items-center gap-2">
+                        <span class="inline-flex rounded-full bg-green-600 px-2 py-1 text-xs font-semibold text-white">Result submitted</span>
+                        <span class="text-sm text-green-800">Saved ${escapeHtml(formatSubmittedAt(result.submittedAt))}${submittedBy}.</span>
+                    </div>
+                    <div class="mt-2 text-sm text-gray-900"><span class="font-semibold">Final score:</span> Home ${escapeHtml(String(result.homeScore))} • Away ${escapeHtml(String(result.awayScore))}</div>
+                    ${notes}
+                </div>
+            `;
+        }
+
+        function renderResultForm(game, slot) {
+            if (hasSubmittedOfficiatingResult(slot)) return renderSubmittedResult(slot);
+            if (slot.status !== 'accepted' || !hasGameStarted(game) || isCancelled(game)) return '';
+
+            return `
+                <form class="official-result-form mt-4 rounded-lg border border-gray-200 bg-gray-50 p-4" data-result-form>
+                    <div class="text-sm font-semibold text-gray-900">Quick final score</div>
+                    <p class="mt-1 text-sm text-gray-600">Submit the final score and any post-game notes without leaving this assignment.</p>
+                    <div class="mt-3 grid gap-3 sm:grid-cols-2">
+                        <label class="text-sm font-medium text-gray-700">Home score
+                            <input name="homeScore" type="number" min="0" step="1" inputmode="numeric" class="mt-1 w-full rounded border border-gray-300 px-3 py-2" required>
+                        </label>
+                        <label class="text-sm font-medium text-gray-700">Away score
+                            <input name="awayScore" type="number" min="0" step="1" inputmode="numeric" class="mt-1 w-full rounded border border-gray-300 px-3 py-2" required>
+                        </label>
+                    </div>
+                    <label class="mt-3 block text-sm font-medium text-gray-700">Notes (optional)
+                        <textarea name="notes" rows="3" class="mt-1 w-full rounded border border-gray-300 px-3 py-2" placeholder="Add any post-game notes for the assigner."></textarea>
+                    </label>
+                    <div class="mt-3 hidden rounded border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700" data-result-error></div>
+                    <div class="mt-3 flex flex-wrap items-center gap-3">
+                        <button type="submit" class="official-result-submit rounded bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-700">Submit result</button>
+                        <span class="text-xs text-gray-500">Accepted officials only. Scores must be whole numbers 0 or greater.</span>
+                    </div>
+                </form>
+            `;
+        }
+
+        function renderResponseActions(game, slot) {
+            const hasResultForm = slot.status === 'accepted' && hasGameStarted(game) && !isCancelled(game);
+            if (hasResultForm) return '';
+            if (['pending', 'needs_review'].includes(slot.status)) {
+                return '<button data-action="accepted" class="official-response px-3 py-1 bg-green-100 text-green-700 rounded text-sm hover:bg-green-200">Accept</button><button data-action="declined" class="official-response px-3 py-1 bg-red-100 text-red-700 rounded text-sm hover:bg-red-200">Decline</button>';
+            }
+            if (slot.status === 'accepted' && !hasSubmittedOfficiatingResult(slot)) {
+                return '<button data-action="cant_make" class="official-response px-3 py-1 bg-amber-100 text-amber-700 rounded text-sm hover:bg-amber-200">Can\'t make it</button>';
+            }
+            return '';
+        }
+
         function renderGameMeta(game, slot) {
             return `
                 <div class="text-sm text-gray-500 font-semibold uppercase tracking-wide">${formatDate(game.date)} • ${formatTime(game.date)}</div>
@@ -80,12 +152,18 @@
         function renderAssignedGames() {
             const container = document.getElementById('assigned-games');
             const assigned = [];
-            games.filter(isUpcoming).forEach((game) => {
+            games.forEach((game) => {
                 getAssignedOfficiatingSlots(game, currentUser).forEach((slot) => assigned.push({ game, slot }));
             });
 
+            assigned.sort((a, b) => {
+                const aTime = toDate(a.game.date)?.getTime() || 0;
+                const bTime = toDate(b.game.date)?.getTime() || 0;
+                return bTime - aTime;
+            });
+
             if (!assigned.length) {
-                container.innerHTML = '<div class="p-4 text-sm text-gray-500">No upcoming assignments found for your account.</div>';
+                container.innerHTML = '<div class="p-4 text-sm text-gray-500">No assignments found for your account.</div>';
                 return;
             }
 
@@ -93,10 +171,8 @@
                 <div class="p-4" data-game-id="${game.id}" data-slot-id="${slot.id}">
                     ${renderGameMeta(game, slot)}
                     <div class="mt-2 text-sm"><span class="font-semibold">Status:</span> ${escapeHtml(slot.status.replace(/_/g, ' '))}</div>
-                    <div class="mt-3 flex flex-wrap gap-2">
-                        ${['pending', 'needs_review'].includes(slot.status) ? '<button data-action="accepted" class="official-response px-3 py-1 bg-green-100 text-green-700 rounded text-sm hover:bg-green-200">Accept</button><button data-action="declined" class="official-response px-3 py-1 bg-red-100 text-red-700 rounded text-sm hover:bg-red-200">Decline</button>' : ''}
-                        ${slot.status === 'accepted' ? '<button data-action="cant_make" class="official-response px-3 py-1 bg-amber-100 text-amber-700 rounded text-sm hover:bg-amber-200">Can\'t make it</button>' : ''}
-                    </div>
+                    <div class="mt-3 flex flex-wrap gap-2">${renderResponseActions(game, slot)}</div>
+                    ${renderResultForm(game, slot)}
                 </div>
             `).join('');
         }
@@ -175,6 +251,49 @@
                 await refresh();
             } catch (error) {
                 document.getElementById('officials-status').textContent = error.message || 'Could not save officiating response.';
+            }
+        });
+
+        document.addEventListener('submit', async (event) => {
+            const form = event.target.closest('[data-result-form]');
+            if (!form) return;
+
+            event.preventDefault();
+            const row = form.closest('[data-game-id][data-slot-id]');
+            if (!row) return;
+
+            const errorBox = form.querySelector('[data-result-error]');
+            const submitButton = form.querySelector('.official-result-submit');
+            const formData = new FormData(form);
+            const validation = validateOfficiatingResultSubmission({
+                homeScore: formData.get('homeScore'),
+                awayScore: formData.get('awayScore'),
+                notes: formData.get('notes')
+            });
+
+            if (!validation.valid) {
+                errorBox.textContent = validation.errors[0] || 'Enter a valid final score.';
+                errorBox.classList.remove('hidden');
+                return;
+            }
+
+            errorBox.textContent = '';
+            errorBox.classList.add('hidden');
+
+            try {
+                submitButton.disabled = true;
+                submitButton.textContent = 'Saving...';
+                document.getElementById('officials-status').textContent = 'Saving result...';
+                await submitOfficiatingAssignmentResult(teamId, row.dataset.gameId, row.dataset.slotId, validation.value, currentUser);
+                await refresh();
+                document.getElementById('officials-status').textContent = 'Result saved.';
+            } catch (error) {
+                errorBox.textContent = error.message || 'Could not save the final score. Please try again.';
+                errorBox.classList.remove('hidden');
+                document.getElementById('officials-status').textContent = error.message || 'Could not save the final score. Please try again.';
+            } finally {
+                submitButton.disabled = false;
+                submitButton.textContent = 'Submit result';
             }
         });
 

--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -59,6 +59,8 @@ describe('officiating slots', () => {
         expect(source).toContain('Officiating Slots');
         expect(source).toContain('populateOfficiatingSlots(game.officiatingSlots || [])');
         expect(source).toContain('officiatingSlots: getOfficiatingSlotsFromForm()');
+        expect(source).toContain('submittedResult: parseStoredOfficiatingResult(row.dataset.submittedResult || \'\')');
+        expect(source).toContain("row.dataset.submittedResult = slot.submittedResult ? JSON.stringify(slot.submittedResult) : '';");
         expect(source).toContain('createOfficiatingAssignmentNotificationRecords');
         expect(source).toContain('buildOfficiatingAssignmentNotificationRecords');
         expect(source).toContain('await createScheduleOfficiatingNotificationRecords({');

--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -82,10 +82,28 @@ describe('officiating slots', () => {
     it('loads assigned official games even when private team details are unavailable', () => {
         const officialsSource = readOfficialsPage();
 
+        expect(officialsSource).toContain('My Assignments');
         expect(officialsSource).not.toContain('[currentTeam, currentUserProfile] = await Promise.all');
         expect(officialsSource).toContain("console.warn('[officials] Team details are unavailable; continuing with assignment-only access.', error);");
         expect(officialsSource).toContain('canClaimOpenSlots = false;');
         expect(officialsSource).toContain('await refresh();');
+    });
+
+    it('adds quick final score submission and submitted-result state to accepted official assignments', () => {
+        const officialsSource = readOfficialsPage();
+        const dbSource = readDbSource();
+
+        expect(officialsSource).toContain('submitOfficiatingAssignmentResult');
+        expect(officialsSource).toContain('hasSubmittedOfficiatingResult');
+        expect(officialsSource).toContain('validateOfficiatingResultSubmission');
+        expect(officialsSource).toContain('official-result-form');
+        expect(officialsSource).toContain('Quick final score');
+        expect(officialsSource).toContain('Result submitted');
+        expect(officialsSource).toContain("slot.status !== 'accepted' || !hasGameStarted(game) || isCancelled(game)");
+        expect(officialsSource).toContain("document.getElementById('officials-status').textContent = 'Result saved.';");
+        expect(officialsSource).toContain("'./js/db.js?v=33'");
+        expect(dbSource).toContain('export async function submitOfficiatingAssignmentResult(teamId, gameId, slotId, result, official = auth.currentUser)');
+        expect(dbSource).toContain("throw new Error('Cancelled games cannot accept final results.');");
     });
 
     it('limits open self-assignment slot claims to eligible team participants', () => {
@@ -99,7 +117,6 @@ describe('officiating slots', () => {
         expect(officialsSource).toContain("container.innerHTML = '';");
         expect(officialsSource).toContain('find open officiating slots');
         expect(officialsSource).not.toContain('Open self-assignment slots are only available to team owners, admins, or parents.');
-        expect(officialsSource).toContain("'./js/db.js?v=32'");
         expect(dbSource).toContain('function isEligibleOpenOfficiatingSlotParticipant(team = {}, userProfile = {}, user = {})');
         expect(dbSource).toContain("throw new Error('Only team owners, admins, or parents can claim open officiating slots.');");
         expect(dbSource).toContain('officiatingAuthorizedUserIds: Array.from(officiatingAuthorizedUserIds)');

--- a/tests/unit/officiating-utils.test.js
+++ b/tests/unit/officiating-utils.test.js
@@ -152,6 +152,18 @@ describe('officiating assignment helpers', () => {
     })).toThrow('Only accepted assignments can submit final results.');
   });
 
+  it('rejects result submission when the caller does not match the accepted slot', () => {
+    expect(() => updateOfficiatingSlotResult([
+      { id: 'slot-1', position: 'Referee', officialEmail: 'ref@example.com', officialUserId: 'official-1', status: 'accepted' }
+    ], 'slot-1', {
+      homeScore: 1,
+      awayScore: 0
+    }, {
+      uid: 'official-2',
+      email: 'other@example.com'
+    })).toThrow('You can only submit a result for your own accepted assignment.');
+  });
+
   it('warns when the same official has overlapping or back-to-back assignments', () => {
     const warnings = getOfficiatingAssignmentConflictWarnings({
       id: 'game-new',

--- a/tests/unit/officiating-utils.test.js
+++ b/tests/unit/officiating-utils.test.js
@@ -6,7 +6,10 @@ import {
   getAssignedOfficiatingSlots,
   getOfficiatingAssignmentConflictWarnings,
   getOpenOfficiatingSlots,
+  hasSubmittedOfficiatingResult,
   normalizeOfficiatingSlots,
+  updateOfficiatingSlotResult,
+  validateOfficiatingResultSubmission,
   updateOfficiatingSlotResponse
 } from '../../js/officiating-utils.js';
 
@@ -106,6 +109,47 @@ describe('officiating assignment helpers', () => {
     expect(() => claimOfficiatingSlot([
       { id: 'slot-1', position: 'Referee', officialEmail: 'taken@example.com', status: 'pending' }
     ], 'slot-1', { uid: 'user-1' })).toThrow('already filled');
+  });
+
+  it('validates and stores submitted officiating results for accepted assignments', () => {
+    expect(validateOfficiatingResultSubmission({ homeScore: '', awayScore: '2' })).toMatchObject({
+      valid: false,
+      errors: ['Enter a home score.']
+    });
+
+    const updated = updateOfficiatingSlotResult([
+      { id: 'slot-1', position: 'Referee', officialEmail: 'ref@example.com', status: 'accepted' }
+    ], 'slot-1', {
+      homeScore: '3',
+      awayScore: '1',
+      notes: 'Match ended after regulation.'
+    }, {
+      uid: 'official-1',
+      email: 'Ref@Example.com',
+      displayName: 'Jordan Ref'
+    }, {
+      submittedAt: '2026-06-02T08:50:00.000Z'
+    });
+
+    expect(updated[0].submittedResult).toMatchObject({
+      homeScore: 3,
+      awayScore: 1,
+      notes: 'Match ended after regulation.',
+      submittedAt: '2026-06-02T08:50:00.000Z',
+      submittedByUserId: 'official-1',
+      submittedByEmail: 'ref@example.com',
+      submittedByName: 'Jordan Ref'
+    });
+    expect(hasSubmittedOfficiatingResult(updated[0])).toBe(true);
+  });
+
+  it('rejects result submission for unaccepted assignments', () => {
+    expect(() => updateOfficiatingSlotResult([
+      { id: 'slot-1', position: 'Referee', officialEmail: 'ref@example.com', status: 'pending' }
+    ], 'slot-1', {
+      homeScore: 1,
+      awayScore: 0
+    })).toThrow('Only accepted assignments can submit final results.');
   });
 
   it('warns when the same official has overlapping or back-to-back assignments', () => {


### PR DESCRIPTION
Closes #1719

## What changed
- added a quick post-game result form to accepted officials assignment cards with home score, away score, and optional notes
- persisted submitted results on the assignment slot so the card switches to a saved result view after submit
- added focused validation and error handling for empty, negative, and non-integer score input
- wired a new `submitOfficiatingAssignmentResult` database helper and bumped the officials page cache-bust import
- updated unit coverage for the new submission helpers and officials page wiring

## Why
Officials could accept assignments but had no fast way to submit the final result from the same workflow. This keeps result entry on the assignment card, shows clear save feedback, and preserves the submitted state for later review.