### PR TITLE
Allow accepted officials to submit final scores

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -622,10 +622,15 @@ service cloud.firestore {
     // Chat access: team owner, team admins, global admins, or any parent linked to the team
     function isOfficialGameUpdate() {
       return request.resource.data.diff(resource.data).affectedKeys().hasOnly([
+        'homeScore',
+        'awayScore',
         'officiatingSlots',
         'officiatingCoverageStatus',
-        'officiatingUpdatedAt'
-      ]);
+        'officiatingUpdatedAt',
+        'scoreUpdatedAt',
+        'scoreUpdatedBy'
+      ]) &&
+      isScoreMetadataAttributionValid();
     }
 
     function isOfficialForGame() {

--- a/js/db.js
+++ b/js/db.js
@@ -6512,8 +6512,8 @@ export async function submitOfficiatingAssignmentResult(teamId, gameId, slotId, 
         }
 
         transaction.update(docRef, {
-            homeScore: officiatingResult.homeScore,
-            awayScore: officiatingResult.awayScore,
+            homeScore: Number.isFinite(officiatingResult.homeScore) ? officiatingResult.homeScore : 0,
+            awayScore: Number.isFinite(officiatingResult.awayScore) ? officiatingResult.awayScore : 0,
             officiatingSlots,
             officiatingCoverageStatus: computeOfficiatingCoverageStatus(officiatingSlots),
             officiatingUpdatedAt: Timestamp.now(),

--- a/js/db.js
+++ b/js/db.js
@@ -6505,11 +6505,20 @@ export async function submitOfficiatingAssignmentResult(teamId, gameId, slotId, 
         const officiatingSlots = updateOfficiatingSlotResult(game.officiatingSlots || [], slotId, result, official, {
             submittedAt: Timestamp.now()
         });
+        const updatedSlot = officiatingSlots.find((slot) => slot.id === slotId) || null;
+        const officiatingResult = updatedSlot?.submittedResult || null;
+        if (!officiatingResult) {
+            throw new Error('Final result submission could not be recorded.');
+        }
 
         transaction.update(docRef, {
+            homeScore: officiatingResult.homeScore,
+            awayScore: officiatingResult.awayScore,
             officiatingSlots,
             officiatingCoverageStatus: computeOfficiatingCoverageStatus(officiatingSlots),
-            officiatingUpdatedAt: Timestamp.now()
+            officiatingUpdatedAt: Timestamp.now(),
+            scoreUpdatedAt: Timestamp.now(),
+            scoreUpdatedBy: String(official?.uid || '').trim()
         });
     });
 }

--- a/officials.html
+++ b/officials.html
@@ -43,7 +43,7 @@
 
     <script type="module">
         import { checkAuth } from './js/auth.js?v=14';
-        import { getGames, getTeam, getUserProfile, claimOpenOfficiatingSlot, respondToOfficiatingAssignment, submitOfficiatingAssignmentResult } from './js/db.js?v=33';
+        import { getGames, getTeam, getUserProfile, claimOpenOfficiatingSlot, respondToOfficiatingAssignment, submitOfficiatingAssignmentResult } from './js/db.js?v=34';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatTime, escapeHtml } from './js/utils.js?v=10';
         import { getAssignedOfficiatingSlots, getOpenOfficiatingSlots, hasSubmittedOfficiatingResult, validateOfficiatingResultSubmission } from './js/officiating-utils.js?v=4';
 

--- a/tests/unit/officiating-result-submission.test.js
+++ b/tests/unit/officiating-result-submission.test.js
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+
+import { updateOfficiatingSlotResult } from '../../js/officiating-utils.js';
+
+describe('updateOfficiatingSlotResult', () => {
+    const acceptedSlot = {
+        id: 'slot-1',
+        position: 'Referee',
+        officialUserId: 'official-1',
+        officialEmail: 'official@example.com',
+        officialName: 'Alex Official',
+        status: 'accepted'
+    };
+
+    it('stores final score attribution for the accepted assigned official', () => {
+        const slots = updateOfficiatingSlotResult([
+            acceptedSlot
+        ], 'slot-1', {
+            homeScore: 42,
+            awayScore: 35,
+            notes: 'Close finish'
+        }, {
+            uid: 'official-1',
+            email: 'official@example.com',
+            displayName: 'Alex Official'
+        }, {
+            submittedAt: '2026-06-02T09:30:00.000Z'
+        });
+
+        expect(slots[0].submittedResult).toEqual({
+            homeScore: 42,
+            awayScore: 35,
+            notes: 'Close finish',
+            submittedAt: '2026-06-02T09:30:00.000Z',
+            submittedByUserId: 'official-1',
+            submittedByEmail: 'official@example.com',
+            submittedByName: 'Alex Official'
+        });
+    });
+
+    it('rejects non-accepted assignments from submitting results', () => {
+        expect(() => updateOfficiatingSlotResult([
+            { ...acceptedSlot, status: 'pending' }
+        ], 'slot-1', {
+            homeScore: 42,
+            awayScore: 35
+        }, {
+            uid: 'official-1',
+            email: 'official@example.com'
+        })).toThrow('Only accepted assignments can submit final results.');
+    });
+
+    it('rejects other officials from submitting results for the slot', () => {
+        expect(() => updateOfficiatingSlotResult([
+            acceptedSlot
+        ], 'slot-1', {
+            homeScore: 42,
+            awayScore: 35
+        }, {
+            uid: 'official-2',
+            email: 'other@example.com'
+        })).toThrow('You can only submit a result for your own accepted assignment.');
+    });
+});

--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -106,8 +106,8 @@ describe('officiating slots', () => {
         expect(officialsSource).toContain("'./js/db.js?v=34'");
         expect(dbSource).toContain('export async function submitOfficiatingAssignmentResult(teamId, gameId, slotId, result, official = auth.currentUser)');
         expect(dbSource).toContain("throw new Error('Cancelled games cannot accept final results.');");
-        expect(dbSource).toContain('homeScore: officiatingResult.homeScore');
-        expect(dbSource).toContain('awayScore: officiatingResult.awayScore');
+        expect(dbSource).toContain('homeScore: Number.isFinite(officiatingResult.homeScore) ? officiatingResult.homeScore : 0');
+        expect(dbSource).toContain('awayScore: Number.isFinite(officiatingResult.awayScore) ? officiatingResult.awayScore : 0');
         expect(dbSource).toContain("scoreUpdatedBy: String(official?.uid || '').trim()");
         expect(readFirestoreRules()).toContain("'homeScore'");
         expect(readFirestoreRules()).toContain("'awayScore'");

--- a/tests/unit/officiating-slots.test.js
+++ b/tests/unit/officiating-slots.test.js
@@ -103,9 +103,15 @@ describe('officiating slots', () => {
         expect(officialsSource).toContain('Result submitted');
         expect(officialsSource).toContain("slot.status !== 'accepted' || !hasGameStarted(game) || isCancelled(game)");
         expect(officialsSource).toContain("document.getElementById('officials-status').textContent = 'Result saved.';");
-        expect(officialsSource).toContain("'./js/db.js?v=33'");
+        expect(officialsSource).toContain("'./js/db.js?v=34'");
         expect(dbSource).toContain('export async function submitOfficiatingAssignmentResult(teamId, gameId, slotId, result, official = auth.currentUser)');
         expect(dbSource).toContain("throw new Error('Cancelled games cannot accept final results.');");
+        expect(dbSource).toContain('homeScore: officiatingResult.homeScore');
+        expect(dbSource).toContain('awayScore: officiatingResult.awayScore');
+        expect(dbSource).toContain("scoreUpdatedBy: String(official?.uid || '').trim()");
+        expect(readFirestoreRules()).toContain("'homeScore'");
+        expect(readFirestoreRules()).toContain("'awayScore'");
+        expect(readFirestoreRules()).toContain("'scoreUpdatedBy'");
     });
 
     it('limits open self-assignment slot claims to eligible team participants', () => {


### PR DESCRIPTION
Closes #1718

## What changed
- updated the officiating result submission transaction to write the game's final `homeScore` and `awayScore` alongside the slot-level submitted result attribution
- expanded Firestore's official game update path so authorized officials can write the tightly scoped score/result fields, while preserving existing scorekeeper and admin paths
- added regression coverage for accepted-official result submission, including rejection of pending and wrong-official submissions, and updated the wiring assertions for the officials page

## Why
Accepted assigned officials could already record a submitted result on their slot, but that path did not update the scheduled game's final score fields. This patch keeps the writable surface narrow while making the officiating submission path actually finalize the game score and retain attribution.