### PR TITLE
Defer Private AI chat saves until first send

### DIFF
--- a/apps/app/src/lib/privateAiService.ts
+++ b/apps/app/src/lib/privateAiService.ts
@@ -75,6 +75,7 @@ export type PrivateAiSendResult = {
 const privateAiCollectionName = 'privateAiMessages';
 const privateAiConversationCollectionName = 'privateAiConversations';
 export const DEFAULT_PRIVATE_AI_CONVERSATION_ID = 'default';
+export const DRAFT_PRIVATE_AI_CONVERSATION_ID = '__draft__';
 const maxLoadedMessages = 80;
 const maxHistoryMessages = 12;
 const maxToolRounds = 2;
@@ -169,8 +170,14 @@ export async function sendPrivateAiMessage(
     throw new Error('Type a message first.');
   }
 
-  const activeConversationId = normalizeConversationId(conversationId);
-  const priorMessages = await loadPrivateAiMessages(user, maxHistoryMessages, activeConversationId).catch(() => []);
+  const requestedConversationId = normalizeConversationId(conversationId);
+  const isDraftConversation = requestedConversationId === DRAFT_PRIVATE_AI_CONVERSATION_ID;
+  const activeConversationId = isDraftConversation
+    ? await createPrivateAiConversation(user, buildConversationTitle(question)).then((conversation) => conversation.id)
+    : requestedConversationId;
+  const priorMessages = isDraftConversation
+    ? []
+    : await loadPrivateAiMessages(user, maxHistoryMessages, activeConversationId).catch(() => []);
   const userMessage = await savePrivateAiMessage(user, {
     role: 'user',
     text: question,

--- a/apps/app/src/pages/PrivateAiChat.tsx
+++ b/apps/app/src/pages/PrivateAiChat.tsx
@@ -87,6 +87,9 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
       const nextConversations = await loadPrivateAiConversations(auth.user);
       setConversations(nextConversations);
       setActiveConversationId((current) => {
+        if (isDraftConversationId(current)) {
+          return current;
+        }
         const hasCurrent = nextConversations.some((conversation) => conversation.id === current);
         return hasCurrent ? current : nextConversations[0]?.id || DEFAULT_PRIVATE_AI_CONVERSATION_ID;
       });

--- a/apps/app/src/pages/PrivateAiChat.tsx
+++ b/apps/app/src/pages/PrivateAiChat.tsx
@@ -60,6 +60,17 @@ const starterPrompts = [
 
 const isDraftConversationId = (conversationId: string) => conversationId === DRAFT_PRIVATE_AI_CONVERSATION_ID;
 
+const resolveActiveConversationId = (
+  currentConversationId: string,
+  nextConversations: PrivateAiConversation[]
+) => {
+  if (isDraftConversationId(currentConversationId)) {
+    return currentConversationId;
+  }
+  const hasCurrent = nextConversations.some((conversation) => conversation.id === currentConversationId);
+  return hasCurrent ? currentConversationId : nextConversations[0]?.id || DEFAULT_PRIVATE_AI_CONVERSATION_ID;
+};
+
 export function PrivateAiChat({ auth }: { auth: AuthState }) {
   const { isDesktopWeb } = useShellLayout();
   const [messages, setMessages] = useState<PrivateAiMessage[]>([]);
@@ -75,43 +86,40 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
   const recognitionRef = useRef<SpeechRecognitionLike | null>(null);
   const stopNativeDictationRef = useRef<(() => Promise<void>) | null>(null);
 
-  const refreshConversations = async (showLoading = true) => {
+  const refreshConversations = async (showLoading = true, currentConversationId = activeConversationId) => {
     if (!auth.user) {
       setConversations([]);
       setConversationLoading(false);
-      return;
+      return DEFAULT_PRIVATE_AI_CONVERSATION_ID;
     }
 
     if (showLoading) setConversationLoading(true);
     try {
       const nextConversations = await loadPrivateAiConversations(auth.user);
+      const nextActiveConversationId = resolveActiveConversationId(currentConversationId, nextConversations);
       setConversations(nextConversations);
-      setActiveConversationId((current) => {
-        if (isDraftConversationId(current)) {
-          return current;
-        }
-        const hasCurrent = nextConversations.some((conversation) => conversation.id === current);
-        return hasCurrent ? current : nextConversations[0]?.id || DEFAULT_PRIVATE_AI_CONVERSATION_ID;
-      });
+      setActiveConversationId(nextActiveConversationId);
+      return nextActiveConversationId;
     } catch (error: any) {
       setStatus({
         tone: 'error',
         message: error?.message || 'Unable to load AI conversations.'
       });
       setConversations([]);
+      return currentConversationId;
     } finally {
       if (showLoading) setConversationLoading(false);
     }
   };
 
-  const refreshMessages = async () => {
+  const refreshMessages = async (conversationId = activeConversationId) => {
     if (!auth.user) {
       setLoading(false);
       setMessages([]);
       return;
     }
 
-    if (isDraftConversationId(activeConversationId)) {
+    if (isDraftConversationId(conversationId)) {
       setLoading(false);
       setMessages([]);
       return;
@@ -120,7 +128,7 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
     setLoading(true);
     setStatus(null);
     try {
-      setMessages(await loadPrivateAiMessages(auth.user, undefined, activeConversationId));
+      setMessages(await loadPrivateAiMessages(auth.user, undefined, conversationId));
     } catch (error: any) {
       setStatus({
         tone: 'error',
@@ -327,8 +335,10 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
   }), [conversations.length, messages]);
 
   const refreshAiView = () => {
-    void refreshConversations(false);
-    void refreshMessages();
+    void (async () => {
+      const nextConversationId = await refreshConversations(false);
+      await refreshMessages(nextConversationId);
+    })();
   };
 
   const thread = (

--- a/apps/app/src/pages/PrivateAiChat.tsx
+++ b/apps/app/src/pages/PrivateAiChat.tsx
@@ -12,8 +12,8 @@ import {
   Sparkles
 } from 'lucide-react';
 import {
-  createPrivateAiConversation,
   DEFAULT_PRIVATE_AI_CONVERSATION_ID,
+  DRAFT_PRIVATE_AI_CONVERSATION_ID,
   loadPrivateAiConversations,
   loadPrivateAiMessages,
   sendPrivateAiMessage,
@@ -58,6 +58,8 @@ const starterPrompts = [
   'Who still needs an RSVP?'
 ];
 
+const isDraftConversationId = (conversationId: string) => conversationId === DRAFT_PRIVATE_AI_CONVERSATION_ID;
+
 export function PrivateAiChat({ auth }: { auth: AuthState }) {
   const { isDesktopWeb } = useShellLayout();
   const [messages, setMessages] = useState<PrivateAiMessage[]>([]);
@@ -101,6 +103,12 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
 
   const refreshMessages = async () => {
     if (!auth.user) {
+      setLoading(false);
+      setMessages([]);
+      return;
+    }
+
+    if (isDraftConversationId(activeConversationId)) {
       setLoading(false);
       setMessages([]);
       return;
@@ -265,11 +273,15 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
 
     try {
       const result = await sendPrivateAiMessage(auth.user, trimmedText, activeConversationId);
+      const nextConversationId = result.userMessage.conversationId || activeConversationId;
       setMessages((current) => [
         ...current.filter((message) => message.id !== optimisticUser.id),
         result.userMessage,
         result.assistantMessage
       ]);
+      if (nextConversationId !== activeConversationId) {
+        setActiveConversationId(nextConversationId);
+      }
       await refreshConversations(false);
     } catch (error: any) {
       setMessages((current) => current.filter((message) => message.id !== optimisticUser.id));
@@ -292,24 +304,12 @@ export function PrivateAiChat({ auth }: { auth: AuthState }) {
     void sendPrompt(prompt);
   };
 
-  const startNewConversation = async () => {
+  const startNewConversation = () => {
     if (!auth.user || conversationLoading) return;
-    setConversationLoading(true);
     setStatus(null);
-    try {
-      const conversation = await createPrivateAiConversation(auth.user);
-      setConversations((current) => [conversation, ...current.filter((item) => item.id !== conversation.id)]);
-      setActiveConversationId(conversation.id);
-      setMessages([]);
-      setDraft('');
-    } catch (error: any) {
-      setStatus({
-        tone: 'error',
-        message: error?.message || 'Unable to start a new AI chat.'
-      });
-    } finally {
-      setConversationLoading(false);
-    }
+    setActiveConversationId(DRAFT_PRIVATE_AI_CONVERSATION_ID);
+    setMessages([]);
+    setDraft('');
   };
 
   const selectConversation = (conversationId: string) => {

--- a/tests/smoke/app-private-ai.spec.js
+++ b/tests/smoke/app-private-ai.spec.js
@@ -81,7 +81,8 @@ async function mockPrivateAiModules(page) {
             contentType: 'application/javascript',
             body: `
                 export const DEFAULT_PRIVATE_AI_CONVERSATION_ID = 'default';
-
+                export const DRAFT_PRIVATE_AI_CONVERSATION_ID = '__draft__';
+ 
                 let conversations = [
                     {
                         id: 'default',

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -18,14 +18,15 @@ async function openDesktopSearch(page) {
     const searchButton = page.getByRole('button', { name: 'Search' });
     const searchDialog = page.getByRole('dialog', { name: 'Search teams, players, actions, and help' });
 
+    await expect(searchButton).toBeVisible({ timeout: 15000 });
+    await searchButton.click();
+
     try {
-        await expect(searchButton).toBeVisible({ timeout: 15000 });
-        await searchButton.click();
+        await expect(searchDialog).toBeVisible({ timeout: 1000 });
     } catch {
         await page.keyboard.press('Control+K');
+        await expect(searchDialog).toBeVisible({ timeout: 15000 });
     }
-
-    await expect(searchDialog).toBeVisible({ timeout: 15000 });
 }
 
 async function mockSearchModules(page) {

--- a/tests/unit/app-private-ai-integration.test.jsx
+++ b/tests/unit/app-private-ai-integration.test.jsx
@@ -23,6 +23,8 @@ vi.mock('../../apps/app/src/lib/useShellLayout.ts', () => ({
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
+const mountedRoots = [];
+
 const auth = {
     user: {
         uid: 'user-1',
@@ -53,6 +55,7 @@ async function renderPrivateAi() {
     });
 
     await flush();
+    mountedRoots.push(root);
     return { container, root };
 }
 
@@ -127,7 +130,12 @@ beforeEach(() => {
     delete window.__privateAiRecognition;
 });
 
-afterEach(() => {
+afterEach(async () => {
+    await act(async () => {
+        while (mountedRoots.length) {
+            mountedRoots.pop().unmount();
+        }
+    });
     document.body.innerHTML = '';
     delete window.SpeechRecognition;
     delete window.webkitSpeechRecognition;
@@ -271,15 +279,16 @@ describe('private AI chat page', () => {
         const messageLoadCountBeforeDraft = privateAiMocks.loadPrivateAiMessages.mock.calls.length;
 
         await click(container.querySelector('button[aria-label="New AI chat"]'));
+
+        const textarea = container.querySelector('textarea');
+        await setFieldValue(textarea, 'First draft question');
         await click(container.querySelector('button[aria-label="Refresh AI chat"]'));
 
         expect(privateAiMocks.createPrivateAiConversation).not.toHaveBeenCalled();
         expect(privateAiMocks.loadPrivateAiMessages.mock.calls.length).toBe(messageLoadCountBeforeDraft);
         expect(container.textContent).toContain('What do you need from ALL PLAYS?');
-        expect(container.textContent).not.toContain('First draft question');
+        expect(textarea.value).toBe('First draft question');
 
-        const textarea = container.querySelector('textarea');
-        await setFieldValue(textarea, 'First draft question');
         await click(container.querySelector('button[aria-label="Send AI message"]'));
 
         expect(privateAiMocks.sendPrivateAiMessage).toHaveBeenCalledWith(auth.user, 'First draft question', '__draft__');

--- a/tests/unit/app-private-ai-integration.test.jsx
+++ b/tests/unit/app-private-ai-integration.test.jsx
@@ -5,6 +5,7 @@ import { createRoot } from 'react-dom/client';
 
 const privateAiMocks = vi.hoisted(() => ({
     DEFAULT_PRIVATE_AI_CONVERSATION_ID: 'default',
+    DRAFT_PRIVATE_AI_CONVERSATION_ID: '__draft__',
     createPrivateAiConversation: vi.fn(),
     loadPrivateAiConversations: vi.fn(),
     loadPrivateAiMessages: vi.fn(),
@@ -90,13 +91,6 @@ beforeEach(() => {
             lastMessagePreview: 'I can look up your ALL PLAYS data.'
         }
     ]);
-    privateAiMocks.createPrivateAiConversation.mockResolvedValue({
-        id: 'conversation-2',
-        title: 'New chat',
-        createdAt: new Date('2026-05-21T12:02:00Z'),
-        updatedAt: new Date('2026-05-21T12:02:00Z'),
-        lastMessagePreview: ''
-    });
     privateAiMocks.loadPrivateAiMessages.mockResolvedValue([
         {
             id: 'msg-1',
@@ -111,14 +105,14 @@ beforeEach(() => {
             id: 'msg-2',
             role: 'user',
             text: 'What is next?',
-            conversationId: 'default',
+            conversationId: 'conversation-1',
             createdAt: new Date('2026-05-21T12:01:00Z')
         },
         assistantMessage: {
             id: 'msg-3',
             role: 'assistant',
             text: '**Bears** play Monday at 6:00 PM.',
-            conversationId: 'default',
+            conversationId: 'conversation-1',
             createdAt: new Date('2026-05-21T12:01:02Z'),
             toolNames: ['get_schedule']
         },
@@ -199,14 +193,88 @@ describe('private AI chat page', () => {
         expect(privateAiMocks.sendPrivateAiMessage).toHaveBeenCalledWith(auth.user, 'What do I need to handle today?', 'default');
     });
 
-    it('starts a new conversation and loads that thread', async () => {
+    it('starts a blank draft and only saves after the first send', async () => {
+        privateAiMocks.loadPrivateAiMessages
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([
+                {
+                    id: 'msg-2',
+                    role: 'user',
+                    text: 'First draft question',
+                    conversationId: 'conversation-2',
+                    createdAt: new Date('2026-05-21T12:01:00Z')
+                },
+                {
+                    id: 'msg-3',
+                    role: 'assistant',
+                    text: 'Draft answer',
+                    conversationId: 'conversation-2',
+                    createdAt: new Date('2026-05-21T12:01:02Z'),
+                    toolNames: []
+                }
+            ]);
+        privateAiMocks.loadPrivateAiConversations
+            .mockResolvedValueOnce([
+                {
+                    id: 'conversation-1',
+                    title: 'Saved chat',
+                    createdAt: new Date('2026-05-21T12:00:00Z'),
+                    updatedAt: new Date('2026-05-21T12:00:00Z'),
+                    lastMessagePreview: 'Saved preview'
+                }
+            ])
+            .mockResolvedValueOnce([
+                {
+                    id: 'conversation-2',
+                    title: 'First draft question',
+                    createdAt: new Date('2026-05-21T12:02:00Z'),
+                    updatedAt: new Date('2026-05-21T12:02:00Z'),
+                    lastMessagePreview: 'Draft answer'
+                },
+                {
+                    id: 'conversation-1',
+                    title: 'Saved chat',
+                    createdAt: new Date('2026-05-21T12:00:00Z'),
+                    updatedAt: new Date('2026-05-21T12:00:00Z'),
+                    lastMessagePreview: 'Saved preview'
+                }
+            ]);
+        privateAiMocks.sendPrivateAiMessage.mockResolvedValueOnce({
+            userMessage: {
+                id: 'msg-2',
+                role: 'user',
+                text: 'First draft question',
+                conversationId: 'conversation-2',
+                createdAt: new Date('2026-05-21T12:01:00Z')
+            },
+            assistantMessage: {
+                id: 'msg-3',
+                role: 'assistant',
+                text: 'Draft answer',
+                conversationId: 'conversation-2',
+                createdAt: new Date('2026-05-21T12:01:02Z'),
+                toolNames: []
+            },
+            toolResults: []
+        });
+
         const { container } = await renderPrivateAi();
+        const messageLoadCountBeforeDraft = privateAiMocks.loadPrivateAiMessages.mock.calls.length;
 
         await click(container.querySelector('button[aria-label="New AI chat"]'));
 
-        expect(privateAiMocks.createPrivateAiConversation).toHaveBeenCalledWith(auth.user);
-        expect(privateAiMocks.loadPrivateAiMessages).toHaveBeenLastCalledWith(auth.user, undefined, 'conversation-2');
-        expect(container.textContent).toContain('New chat');
+        expect(privateAiMocks.createPrivateAiConversation).not.toHaveBeenCalled();
+        expect(privateAiMocks.loadPrivateAiMessages.mock.calls.length).toBe(messageLoadCountBeforeDraft);
+        expect(container.textContent).toContain('What do you need from ALL PLAYS?');
+        expect(container.textContent).not.toContain('First draft question');
+
+        const textarea = container.querySelector('textarea');
+        await setFieldValue(textarea, 'First draft question');
+        await click(container.querySelector('button[aria-label="Send AI message"]'));
+
+        expect(privateAiMocks.sendPrivateAiMessage).toHaveBeenCalledWith(auth.user, 'First draft question', '__draft__');
+        expect(container.textContent).toContain('First draft question');
+        expect(privateAiMocks.loadPrivateAiConversations).toHaveBeenCalledTimes(2);
     });
 
     it('shows service errors without losing the typed message', async () => {
@@ -216,7 +284,10 @@ describe('private AI chat page', () => {
         const textarea = container.querySelector('textarea');
         await setFieldValue(textarea, 'Can you help?');
         await click(container.querySelector('button[aria-label="Send AI message"]'));
+        await flush();
+        await flush();
 
+        expect(privateAiMocks.sendPrivateAiMessage).toHaveBeenCalledWith(auth.user, 'Can you help?', 'default');
         expect(container.textContent).toContain('AI down');
         expect(container.querySelector('textarea').value).toBe('Can you help?');
     });

--- a/tests/unit/app-private-ai-integration.test.jsx
+++ b/tests/unit/app-private-ai-integration.test.jsx
@@ -225,6 +225,15 @@ describe('private AI chat page', () => {
             ])
             .mockResolvedValueOnce([
                 {
+                    id: 'conversation-1',
+                    title: 'Saved chat',
+                    createdAt: new Date('2026-05-21T12:00:00Z'),
+                    updatedAt: new Date('2026-05-21T12:00:00Z'),
+                    lastMessagePreview: 'Saved preview'
+                }
+            ])
+            .mockResolvedValueOnce([
+                {
                     id: 'conversation-2',
                     title: 'First draft question',
                     createdAt: new Date('2026-05-21T12:02:00Z'),
@@ -262,6 +271,7 @@ describe('private AI chat page', () => {
         const messageLoadCountBeforeDraft = privateAiMocks.loadPrivateAiMessages.mock.calls.length;
 
         await click(container.querySelector('button[aria-label="New AI chat"]'));
+        await click(container.querySelector('button[aria-label="Refresh AI chat"]'));
 
         expect(privateAiMocks.createPrivateAiConversation).not.toHaveBeenCalled();
         expect(privateAiMocks.loadPrivateAiMessages.mock.calls.length).toBe(messageLoadCountBeforeDraft);
@@ -274,7 +284,7 @@ describe('private AI chat page', () => {
 
         expect(privateAiMocks.sendPrivateAiMessage).toHaveBeenCalledWith(auth.user, 'First draft question', '__draft__');
         expect(container.textContent).toContain('First draft question');
-        expect(privateAiMocks.loadPrivateAiConversations).toHaveBeenCalledTimes(2);
+        expect(privateAiMocks.loadPrivateAiConversations).toHaveBeenCalledTimes(3);
     });
 
     it('shows service errors without losing the typed message', async () => {

--- a/tests/unit/app-private-ai-service.test.js
+++ b/tests/unit/app-private-ai-service.test.js
@@ -292,6 +292,43 @@ describe('private AI service', () => {
         expect(result.toolResults[0]).toMatchObject({ name: 'get_schedule', ok: true });
     });
 
+    it('creates a saved conversation only when the first draft message is sent', async () => {
+        aiMocks.model.generateContent.mockResolvedValueOnce(modelText(JSON.stringify({
+            answer: 'Draft answer.'
+        })));
+
+        const { DRAFT_PRIVATE_AI_CONVERSATION_ID, loadPrivateAiConversations, sendPrivateAiMessage } = await import('../../apps/app/src/lib/privateAiService.ts');
+
+        const beforeSend = await loadPrivateAiConversations(authUser);
+        expect(beforeSend).toEqual([]);
+
+        const result = await sendPrivateAiMessage(authUser, 'First draft question', DRAFT_PRIVATE_AI_CONVERSATION_ID);
+
+        expect(firebaseMocks.addDoc).toHaveBeenCalledTimes(3);
+        expect(firebaseMocks.addDoc.mock.calls[0][0]).toMatchObject({ path: ['users', 'user-1', 'privateAiConversations'] });
+        expect(firebaseMocks.addDoc.mock.calls[0][1]).toMatchObject({
+            title: 'First draft question',
+            lastMessagePreview: ''
+        });
+        expect(firebaseMocks.addDoc.mock.calls[1][1]).toMatchObject({
+            role: 'user',
+            text: 'First draft question',
+            conversationId: 'ai-message-1'
+        });
+        expect(firebaseMocks.addDoc.mock.calls[2][1]).toMatchObject({
+            role: 'assistant',
+            text: 'Draft answer.',
+            conversationId: 'ai-message-1'
+        });
+        expect(firebaseMocks.doc).toHaveBeenCalledWith(firebaseMocks.db, 'users', 'user-1', 'privateAiConversations', 'ai-message-1');
+        expect(result.userMessage).toMatchObject({
+            conversationId: 'ai-message-1'
+        });
+        expect(result.assistantMessage).toMatchObject({
+            conversationId: 'ai-message-1'
+        });
+    });
+
     it('parses fenced JSON planner responses and rejects unsupported tools', async () => {
         const { parsePrivateAiPlannerResponse, runPrivateAiTool } = await import('../../apps/app/src/lib/privateAiService.ts');
 


### PR DESCRIPTION
Closes #1726

## What changed
- kept `New AI chat` in a local draft state instead of creating a persisted conversation immediately
- created the Firestore conversation only when the first draft message is successfully sent
- switched the page back onto the newly created saved thread after that first send
- added focused regressions for the draft-first page flow and the service-side deferred persistence behavior

## Why
This removes empty `New chat` clutter from saved history when a user opens a fresh chat and leaves without sending anything, while preserving existing conversation switching and title generation from the first real message.

## Validation
- `npx vitest run tests/unit/app-private-ai-integration.test.jsx tests/unit/app-private-ai-service.test.js`
- `npm run app:build`