### PR TITLE
Deduplicate family share extra calendar events

### DIFF
--- a/family.html
+++ b/family.html
@@ -577,6 +577,7 @@
                 teamName: child.teamName || '',
                 id: getCalendarEventTrackingId(event) || null,
                 calendarEventUid: event.uid || null,
+                sourceCalendarUrl: calUrl,
                 isDbGame: false,
                 isShareExtraCalendar: true,
                 childId: child.playerId,
@@ -689,7 +690,17 @@
       const date = rawDate?.toDate ? rawDate.toDate() : new Date(rawDate);
       const isoDate = Number.isNaN(date?.getTime?.()) ? '' : date.toISOString();
       const teamId = event?.isShareExtraCalendar ? '' : (event?.teamId || '');
-      return `${teamId}::${event?.id || ''}::${isoDate}::${event?.type || ''}`;
+      const trackingId = event?.id || '';
+      const fallbackIdentity = trackingId
+        ? ''
+        : [
+            event?.calendarEventUid || '',
+            event?.sourceCalendarUrl || '',
+            event?.title || '',
+            event?.opponent || '',
+            event?.location || ''
+          ].join('::');
+      return `${teamId}::${trackingId || fallbackIdentity}::${isoDate}::${event?.type || ''}`;
     }
 
     function getCalendarEntries(events) {

--- a/family.html
+++ b/family.html
@@ -578,6 +578,7 @@
                 id: getCalendarEventTrackingId(event) || null,
                 calendarEventUid: event.uid || null,
                 isDbGame: false,
+                isShareExtraCalendar: true,
                 childId: child.playerId,
                 childName: child.playerName,
                 title: isPractice ? (cleanSummary || 'Practice') : null,
@@ -684,18 +685,27 @@
       if (scheduleViewMode === 'calendar') renderScheduleFromControls();
     }
 
+    function getScheduleEventDedupKey(event, rawDate = event?.date) {
+      const date = rawDate?.toDate ? rawDate.toDate() : new Date(rawDate);
+      const isoDate = Number.isNaN(date?.getTime?.()) ? '' : date.toISOString();
+      const teamId = event?.isShareExtraCalendar ? '' : (event?.teamId || '');
+      return `${teamId}::${event?.id || ''}::${isoDate}::${event?.type || ''}`;
+    }
+
     function getCalendarEntries(events) {
       const byKey = new Map();
       (events || []).forEach(event => {
         const d = event.date?.toDate ? event.date.toDate() : new Date(event.date);
         if (!d || Number.isNaN(d.getTime())) return;
-        const key = `${event.teamId || ''}::${event.id || ''}::${d.toISOString()}::${event.type || ''}`;
+        const key = getScheduleEventDedupKey(event, d);
         if (!byKey.has(key)) {
           byKey.set(key, { ...event, date: d, childNames: [], childIds: [] });
         }
         const item = byKey.get(key);
-        if (event.childName) item.childNames.push(event.childName);
-        if (event.childId) item.childIds.push(event.childId);
+        const childNames = Array.isArray(event.childNames) ? event.childNames : (event.childName ? [event.childName] : []);
+        const childIds = Array.isArray(event.childIds) ? event.childIds : (event.childId ? [event.childId] : []);
+        item.childNames.push(...childNames);
+        item.childIds.push(...childIds);
       });
       return Array.from(byKey.values()).map(item => ({
         ...item,
@@ -846,13 +856,19 @@
       const byKey = new Map();
       games.forEach(game => {
         const d = game.date instanceof Date ? game.date : new Date(game.date);
-        const key = `${game.teamId || ''}::${game.id || ''}::${d.toISOString()}::${game.type || ''}`;
+        const key = getScheduleEventDedupKey(game, d);
         if (!byKey.has(key)) {
           byKey.set(key, { ...game, date: d, childNames: [], childIds: [] });
         }
         const item = byKey.get(key);
-        if (game.childName && !item.childNames.includes(game.childName)) item.childNames.push(game.childName);
-        if (game.childId && !item.childIds.includes(game.childId)) item.childIds.push(game.childId);
+        const childNames = Array.isArray(game.childNames) ? game.childNames : (game.childName ? [game.childName] : []);
+        const childIds = Array.isArray(game.childIds) ? game.childIds : (game.childId ? [game.childId] : []);
+        childNames.forEach(childName => {
+          if (childName && !item.childNames.includes(childName)) item.childNames.push(childName);
+        });
+        childIds.forEach(childId => {
+          if (childId && !item.childIds.includes(childId)) item.childIds.push(childId);
+        });
       });
 
       container.innerHTML = Array.from(byKey.values()).map(game => {
@@ -917,24 +933,35 @@
     function buildIcs(events) {
       const lines = ['BEGIN:VCALENDAR', 'VERSION:2.0', 'PRODID:-//ALL PLAYS//EN'];
       const escapeIcs = value => String(value || '').replace(/\\/g, '\\\\').replace(/;/g, '\\;').replace(/,/g, '\\,').replace(/\r?\n/g, '\\n');
-      const seen = new Set();
+      const byKey = new Map();
       events.forEach(event => {
-        const eventKey = `${event.teamId}-${event.id}-${new Date(event.date).getTime()}`;
-        if (seen.has(eventKey)) return;
-        seen.add(eventKey);
+        const date = event.date instanceof Date ? event.date : new Date(event.date);
+        const eventKey = getScheduleEventDedupKey(event, date);
+        if (!byKey.has(eventKey)) {
+          byKey.set(eventKey, { ...event, date, childNames: [], childIds: [] });
+        }
+        const item = byKey.get(eventKey);
+        const childNames = Array.isArray(event.childNames) ? event.childNames : (event.childName ? [event.childName] : []);
+        const childIds = Array.isArray(event.childIds) ? event.childIds : (event.childId ? [event.childId] : []);
+        item.childNames.push(...childNames);
+        item.childIds.push(...childIds);
+      });
+      Array.from(byKey.values()).forEach(event => {
         const date = event.date instanceof Date ? event.date : new Date(event.date);
         const start = formatIcsDate(date);
         const end = formatIcsDate(new Date(date.getTime() + 60 * 60 * 1000));
-        const summary = event.type === 'practice' ? `${event.childName} - Practice` : `${event.childName} vs ${event.opponent || 'TBD'}`;
+        const childLabel = [...new Set(event.childNames || [])].join(', ') || event.childName || 'Family';
+        const summary = event.type === 'practice' ? `${childLabel} - Practice` : `${childLabel} vs ${event.opponent || 'TBD'}`;
+        const eventKey = getScheduleEventDedupKey(event, date);
         lines.push(
           'BEGIN:VEVENT',
-          `UID:${event.id || eventKey}@allplays`,
+          `UID:${event.id || `${eventKey}@allplays`}`,
           `DTSTAMP:${formatIcsDate(new Date())}`,
           `DTSTART:${start}`,
           `DTEND:${end}`,
           `SUMMARY:${escapeIcs(summary)}`,
           `LOCATION:${escapeIcs(event.location || 'TBD')}`,
-          `DESCRIPTION:${escapeIcs(`For ${event.childName}`)}`,
+          `DESCRIPTION:${escapeIcs(`For ${childLabel}`)}`,
           'END:VEVENT'
         );
       });

--- a/tests/unit/family-extra-calendar-dedup.test.js
+++ b/tests/unit/family-extra-calendar-dedup.test.js
@@ -1,0 +1,143 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+function readFamilyPageSource() {
+    return readFileSync(new URL('../../family.html', import.meta.url), 'utf8');
+}
+
+function extractFunction(source, name) {
+    const start = source.indexOf(`function ${name}`);
+    if (start === -1) {
+        throw new Error(`Function ${name} not found`);
+    }
+
+    const bodyStart = source.indexOf('{', start);
+    let depth = 0;
+
+    for (let index = bodyStart; index < source.length; index += 1) {
+        const char = source[index];
+        if (char === '{') depth += 1;
+        if (char === '}') depth -= 1;
+        if (depth === 0) {
+            return source.slice(start, index + 1);
+        }
+    }
+
+    throw new Error(`Function ${name} did not terminate`);
+}
+
+function createFamilyHooks() {
+    const source = readFamilyPageSource();
+    const getScheduleEventDedupKeySource = extractFunction(source, 'getScheduleEventDedupKey');
+    const getCalendarEntriesSource = extractFunction(source, 'getCalendarEntries');
+    const formatIcsDateSource = extractFunction(source, 'formatIcsDate');
+    const buildIcsSource = extractFunction(source, 'buildIcs');
+
+    return new Function(`
+${getScheduleEventDedupKeySource}
+${getCalendarEntriesSource}
+${formatIcsDateSource}
+${buildIcsSource}
+return { getScheduleEventDedupKey, getCalendarEntries, buildIcs };
+`)();
+}
+
+describe('family page extra calendar deduplication', () => {
+    it('collapses share-token extra calendar events across shared children on different teams', () => {
+        const { getCalendarEntries } = createFamilyHooks();
+        const sharedDate = new Date('2026-06-15T18:00:00Z');
+
+        const entries = getCalendarEntries([
+            {
+                teamId: 'team-1',
+                id: 'calendar-event-1',
+                type: 'game',
+                date: sharedDate,
+                childId: 'child-1',
+                childName: 'Avery',
+                isShareExtraCalendar: true
+            },
+            {
+                teamId: 'team-2',
+                id: 'calendar-event-1',
+                type: 'game',
+                date: new Date(sharedDate),
+                childId: 'child-2',
+                childName: 'Blake',
+                isShareExtraCalendar: true
+            }
+        ]);
+
+        expect(entries).toHaveLength(1);
+        expect(entries[0].childNames).toEqual(['Avery', 'Blake']);
+        expect(entries[0].childIds).toEqual(['child-1', 'child-2']);
+    });
+
+    it('keeps team-scoped events distinct when they are not share-token extra calendars', () => {
+        const { getCalendarEntries } = createFamilyHooks();
+        const sharedDate = new Date('2026-06-15T18:00:00Z');
+
+        const entries = getCalendarEntries([
+            {
+                teamId: 'team-1',
+                id: 'calendar-event-1',
+                type: 'game',
+                date: sharedDate,
+                childId: 'child-1',
+                childName: 'Avery'
+            },
+            {
+                teamId: 'team-2',
+                id: 'calendar-event-1',
+                type: 'game',
+                date: new Date(sharedDate),
+                childId: 'child-2',
+                childName: 'Blake'
+            }
+        ]);
+
+        expect(entries).toHaveLength(2);
+    });
+
+    it('deduplicates exported ICS events and preserves all child names', () => {
+        const { buildIcs } = createFamilyHooks();
+        const sharedDate = new Date('2026-06-15T18:00:00Z');
+
+        const ics = buildIcs([
+            {
+                teamId: 'team-1',
+                id: 'calendar-event-1',
+                type: 'game',
+                date: sharedDate,
+                opponent: 'Lions',
+                location: 'North Field',
+                childId: 'child-1',
+                childName: 'Avery',
+                isShareExtraCalendar: true
+            },
+            {
+                teamId: 'team-2',
+                id: 'calendar-event-1',
+                type: 'game',
+                date: new Date(sharedDate),
+                opponent: 'Lions',
+                location: 'North Field',
+                childId: 'child-2',
+                childName: 'Blake',
+                isShareExtraCalendar: true
+            }
+        ]);
+
+        expect(ics.match(/BEGIN:VEVENT/g)).toHaveLength(1);
+        expect(ics).toContain('SUMMARY:Avery\\, Blake vs Lions');
+        expect(ics).toContain('DESCRIPTION:For Avery\\, Blake');
+    });
+
+    it('marks share-token extra calendar events and reuses the shared dedup helper in list rendering', () => {
+        const source = readFamilyPageSource();
+
+        expect(source).toContain('isShareExtraCalendar: true');
+        expect(source).toContain('const key = getScheduleEventDedupKey(game, d);');
+        expect(source).toContain('const key = getScheduleEventDedupKey(event, d);');
+    });
+});

--- a/tests/unit/family-extra-calendar-dedup.test.js
+++ b/tests/unit/family-extra-calendar-dedup.test.js
@@ -133,10 +133,51 @@ describe('family page extra calendar deduplication', () => {
         expect(ics).toContain('DESCRIPTION:For Avery\\, Blake');
     });
 
+    it('keeps share-token extra calendar events from different sources distinct when tracking ids are missing', () => {
+        const { getCalendarEntries, buildIcs } = createFamilyHooks();
+        const sharedDate = new Date('2026-06-15T18:00:00Z');
+        const events = [
+            {
+                type: 'practice',
+                date: sharedDate,
+                location: 'North Field',
+                teamId: 'team-1',
+                teamName: 'Falcons',
+                id: null,
+                calendarEventUid: null,
+                sourceCalendarUrl: 'https://calendar.example.com/one.ics',
+                isDbGame: false,
+                isShareExtraCalendar: true,
+                childId: 'child-1',
+                childName: 'Avery',
+                title: 'Summer Practice'
+            },
+            {
+                type: 'practice',
+                date: new Date(sharedDate),
+                location: 'North Field',
+                teamId: 'team-2',
+                teamName: 'Falcons',
+                id: null,
+                calendarEventUid: null,
+                sourceCalendarUrl: 'https://calendar.example.com/two.ics',
+                isDbGame: false,
+                isShareExtraCalendar: true,
+                childId: 'child-2',
+                childName: 'Blake',
+                title: 'Summer Practice'
+            }
+        ];
+
+        expect(getCalendarEntries(events)).toHaveLength(2);
+        expect(buildIcs(events).match(/BEGIN:VEVENT/g)).toHaveLength(2);
+    });
+
     it('marks share-token extra calendar events and reuses the shared dedup helper in list rendering', () => {
         const source = readFamilyPageSource();
 
         expect(source).toContain('isShareExtraCalendar: true');
+        expect(source).toContain('sourceCalendarUrl: calUrl');
         expect(source).toContain('const key = getScheduleEventDedupKey(game, d);');
         expect(source).toContain('const key = getScheduleEventDedupKey(event, d);');
     });


### PR DESCRIPTION
Closes #1732

## What changed
- marked share-token extra calendar events so family-page deduplication treats them as family-wide entries instead of team-scoped duplicates
- reused a shared deduplication key for calendar view, list view, and ICS export
- aggregated child names/ids while collapsing duplicate extra-calendar events so the shared schedule still shows which children the event applies to
- added a focused regression test covering cross-team duplicate collapse and ICS export behavior

## Why
A single extra calendar event was being added once per shared child, and the existing dedupe key included `teamId`, so households with children on different teams saw the same event repeated. This change keeps those share-token calendar events visible once on the family page while preserving child attribution.