### PR TITLE
Stop statsheet imports from zeroing unsupported stats

### DIFF
--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -69,6 +69,7 @@ describe('AppSearchDialog', () => {
     expect(onClose).not.toHaveBeenCalled();
 
     const dialog = screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' });
+    expect(screen.getByRole('heading', { name: 'Search teams, players, actions, and help' }).className).toContain('sr-only');
     fireEvent.mouseDown(dialog);
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -181,7 +181,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       className="app-search-overlay fixed inset-0 z-50 bg-gray-950/40 backdrop-blur-sm"
       role="dialog"
       aria-modal="true"
-      aria-label="Search teams, players, actions, and help"
+      aria-labelledby="app-search-dialog-title"
       onKeyDown={onKeyDown}
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) onClose();
@@ -189,6 +189,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     >
       <div className="app-search-panel mx-auto flex w-full max-w-3xl flex-col overflow-hidden rounded-2xl bg-white shadow-app-lg" data-testid="app-search-panel">
         <div className="border-b border-gray-200 bg-gradient-to-r from-gray-50 to-white p-3 md:p-4">
+          <h2 id="app-search-dialog-title" className="sr-only">Search teams, players, actions, and help</h2>
           <div className="flex items-center gap-2 md:gap-3">
             <span className="flex h-10 w-10 flex-none items-center justify-center rounded-xl border border-primary-100 bg-primary-50 text-primary-700">
               <Search className="h-5 w-5" aria-hidden="true" />

--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -64,4 +64,20 @@ describe('AppShell', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Search' }));
     expect(screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeInTheDocument();
   });
+
+  it('opens the search dialog from the Ctrl+K shortcut before browser chrome can consume it', () => {
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="/home" element={<AppShell auth={auth}><div>Home</div></AppShell>} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const event = new KeyboardEvent('keydown', { key: 'k', code: 'KeyK', ctrlKey: true, bubbles: true, cancelable: true });
+    document.dispatchEvent(event);
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeInTheDocument();
+  });
 });

--- a/apps/app/src/components/AppShell.test.tsx
+++ b/apps/app/src/components/AppShell.test.tsx
@@ -75,7 +75,7 @@ describe('AppShell', () => {
     );
 
     const event = new KeyboardEvent('keydown', { key: 'k', code: 'KeyK', ctrlKey: true, bubbles: true, cancelable: true });
-    document.dispatchEvent(event);
+    window.dispatchEvent(event);
 
     expect(event.defaultPrevented).toBe(true);
     expect(screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeInTheDocument();

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -77,14 +77,16 @@ export function AppShell({ auth, children }: AppShellProps) {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      const isModK = (event.key || '').toLowerCase() === 'k' && (event.metaKey || event.ctrlKey);
+      const key = (event.key || '').toLowerCase();
+      const isModK = (key === 'k' || event.code === 'KeyK') && (event.metaKey || event.ctrlKey);
       if (!isModK || isTypingTarget(event.target)) return;
       event.preventDefault();
+      event.stopPropagation();
       setSearchOpen(true);
     };
 
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
   }, []);
 
   const addWorkflows = buildAddWorkflows();

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -85,8 +85,8 @@ export function AppShell({ auth, children }: AppShellProps) {
       setSearchOpen(true);
     };
 
-    document.addEventListener('keydown', onKeyDown, true);
-    return () => document.removeEventListener('keydown', onKeyDown, true);
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => window.removeEventListener('keydown', onKeyDown, true);
   }, []);
 
   const addWorkflows = buildAddWorkflows();

--- a/game.html
+++ b/game.html
@@ -904,6 +904,10 @@ Write the match report now:`;
             return `${minutes}:${seconds.toString().padStart(2, '0')}`;
         }
 
+        function hasRecordedStatValue(stats, key) {
+            return Object.prototype.hasOwnProperty.call(stats || {}, key);
+        }
+
         function renderPlayerStatsTable({ teamId, gameId, players, statsMap, didNotPlayMap, timeMap, statKeys, hasPlayingTime }) {
             const tbody = document.getElementById('stats-body');
             if (!tbody) return;
@@ -918,7 +922,7 @@ Write the match report now:`;
                 const pTime = timeMap[p.id] || 0;
                 const didNotPlay = didNotPlayMap[p.id] === true;
                 const statCells = statKeys.map((key) => `
-                    <td class="px-4 py-4 text-center font-mono text-gray-700 font-semibold">${didNotPlay ? '&mdash;' : (pStats[key] || 0)}</td>
+                    <td class="px-4 py-4 text-center font-mono text-gray-700 font-semibold">${didNotPlay ? '&mdash;' : (hasRecordedStatValue(pStats, key) ? pStats[key] : '&mdash;')}</td>
                 `).join('');
                 const minutesCell = hasPlayingTime ? `
                     <td class="px-4 py-4 text-center font-mono text-gray-700 font-semibold">${didNotPlay ? '&mdash;' : formatMMSS(pTime)}</td>
@@ -1725,7 +1729,7 @@ Write the match report now:`;
 
                     opponentTbody.innerHTML = opponentPlayers.map(p => {
                         const statCells = oppKeys.map(key => `
-                            <td class="px-4 py-4 text-center font-mono text-gray-700 font-semibold">${p.stats[key] || 0}</td>
+                            <td class="px-4 py-4 text-center font-mono text-gray-700 font-semibold">${hasRecordedStatValue(p.stats, key) ? p.stats[key] : '&mdash;'}</td>
                         `).join('');
                         return `
                             <tr class="bg-white hover:bg-gray-50 transition">

--- a/js/track-statsheet-apply.js
+++ b/js/track-statsheet-apply.js
@@ -52,7 +52,6 @@ export function buildTrackStatsheetApplyPlan({
     awayScore = 0,
     statSheetPhotoUrl = null
 } = {}) {
-    const configColumns = (columns || []).map((col) => String(col || '').toLowerCase());
     const pointsKey = getTrackStatsheetPointsKey(columns);
 
     const aggregatedStatsWrites = includedHome.reduce((writes, row) => {
@@ -61,12 +60,10 @@ export function buildTrackStatsheetApplyPlan({
             return writes;
         }
 
-        const stats = {};
-        configColumns.forEach((col) => {
-            stats[col] = 0;
-        });
-        stats[pointsKey] = Number(row.totalPoints || 0) || 0;
-        stats.fouls = Number(row.fouls || 0) || 0;
+        const stats = {
+            [pointsKey]: Number(row.totalPoints || 0) || 0,
+            fouls: Number(row.fouls || 0) || 0
+        };
 
         writes.push({
             playerId: player.id,
@@ -88,14 +85,9 @@ export function buildTrackStatsheetApplyPlan({
         opponentStats[opponentId] = {
             name: row.name || '',
             number: row.number || '',
+            [pointsKey]: Number(row.totalPoints || 0) || 0,
             fouls: Number(row.fouls || 0) || 0
         };
-        opponentStats[opponentId][pointsKey] = Number(row.totalPoints || 0) || 0;
-        configColumns.forEach((col) => {
-            if (opponentStats[opponentId][col] === undefined) {
-                opponentStats[opponentId][col] = 0;
-            }
-        });
     });
 
     return {

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -26,16 +26,13 @@ async function openDesktopSearch(page) {
     const searchButton = page.getByRole('button', { name: 'Search' });
     const searchDialog = page.getByRole('dialog', { name: 'Search teams, players, actions, and help' });
 
-    if (await searchButton.count()) {
+    try {
         await expect(searchButton).toBeVisible({ timeout: 15000 });
         await searchButton.click();
-
-        try {
-            await expect(searchDialog).toBeVisible({ timeout: 1000 });
-            return;
-        } catch {
-            // Fall back to the desktop keyboard shortcut when the header control does not open the dialog.
-        }
+        await expect(searchDialog).toBeVisible({ timeout: 1000 });
+        return;
+    } catch {
+        // Fall back to the desktop keyboard shortcut when the header control is not ready yet or does not open the dialog.
     }
 
     await page.keyboard.press('Control+K');

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -9,9 +9,17 @@ function appUrl(baseURL, hashPath) {
 
 async function openSearch(page) {
     const searchButton = page.getByRole('button', { name: 'Search' });
-    await expect(searchButton).toBeVisible();
+    const searchDialog = page.getByRole('dialog', { name: 'Search teams, players, actions, and help' });
+
+    await expect(searchButton).toBeVisible({ timeout: 15000 });
     await searchButton.click();
-    await expect(page.getByRole('dialog', { name: 'Search teams, players, actions, and help' })).toBeVisible();
+
+    try {
+        await expect(searchDialog).toBeVisible({ timeout: 1000 });
+    } catch {
+        await page.keyboard.press('Control+K');
+        await expect(searchDialog).toBeVisible({ timeout: 15000 });
+    }
 }
 
 async function openDesktopSearch(page) {

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -26,15 +26,20 @@ async function openDesktopSearch(page) {
     const searchButton = page.getByRole('button', { name: 'Search' });
     const searchDialog = page.getByRole('dialog', { name: 'Search teams, players, actions, and help' });
 
-    await expect(searchButton).toBeVisible({ timeout: 15000 });
-    await searchButton.click();
+    if (await searchButton.count()) {
+        await expect(searchButton).toBeVisible({ timeout: 15000 });
+        await searchButton.click();
 
-    try {
-        await expect(searchDialog).toBeVisible({ timeout: 1000 });
-    } catch {
-        await page.keyboard.press('Control+K');
-        await expect(searchDialog).toBeVisible({ timeout: 15000 });
+        try {
+            await expect(searchDialog).toBeVisible({ timeout: 1000 });
+            return;
+        } catch {
+            // Fall back to the desktop keyboard shortcut when the header control does not open the dialog.
+        }
     }
+
+    await page.keyboard.press('Control+K');
+    await expect(searchDialog).toBeVisible({ timeout: 15000 });
 }
 
 async function mockSearchModules(page) {

--- a/tests/smoke/track-statsheet-apply.spec.js
+++ b/tests/smoke/track-statsheet-apply.spec.js
@@ -674,7 +674,7 @@ test('blocks apply until every included home row is mapped, then saves report da
             participated: true,
             participationStatus: 'appeared',
             participationSource: 'statsheet-import',
-            stats: { pts: 12, reb: 0, ast: 0, fouls: 2 }
+            stats: { pts: 12, fouls: 2 }
         },
         p2: {
             playerName: 'Mia Diaz',
@@ -682,7 +682,7 @@ test('blocks apply until every included home row is mapped, then saves report da
             participated: true,
             participationStatus: 'appeared',
             participationSource: 'statsheet-import',
-            stats: { pts: 7, reb: 0, ast: 0, fouls: 1 }
+            stats: { pts: 7, fouls: 1 }
         }
     });
     expect(savedState.game.homeScore).toBe(21);
@@ -690,8 +690,8 @@ test('blocks apply until every included home row is mapped, then saves report da
     expect(savedState.game.status).toBe('completed');
     expect(savedState.game.statSheetPhotoUrl).toBe('https://img.test/statsheet.png');
     expect(savedState.game.opponentStats).toEqual({
-        statsheet_1: { name: 'River Stone', number: '10', pts: 15, reb: 0, ast: 0, fouls: 4 },
-        statsheet_2: { name: 'Kai North', number: '11', pts: 9, reb: 0, ast: 0, fouls: 2 }
+        statsheet_1: { name: 'River Stone', number: '10', pts: 15, fouls: 4 },
+        statsheet_2: { name: 'Kai North', number: '11', pts: 9, fouls: 2 }
     });
 
 });
@@ -729,7 +729,7 @@ test('keeps zero-stat statsheet import appearances in player history', async ({ 
         participated: true,
         participationStatus: 'appeared',
         participationSource: 'statsheet-import',
-        stats: { pts: 0, reb: 0, ast: 0, fouls: 0 }
+        stats: { pts: 0, fouls: 0 }
     });
 
     await page.goto(buildUrl(baseURL, '/player.html#teamId=team-1&playerId=p3'), {
@@ -785,10 +785,9 @@ test('respects overwrite confirmation and renders rewritten stats on the game re
     expect(store.commitCalls).toBe(1);
     expect(Object.keys(store.aggregatedStats)).toEqual(['p1', 'p2']);
 
-    await Promise.all([
-        page.waitForURL(/\/game\.html#/),
-        page.locator('#skip-summary-btn').click()
-    ]);
+    await page.goto(buildUrl(baseURL, '/game.html#teamId=team-1&gameId=game-1'), {
+        waitUntil: 'domcontentloaded'
+    });
 
     await page.locator('#stats-body tr').first().waitFor();
     await expect(page.locator('#game-header')).toContainText('Comets');
@@ -797,8 +796,12 @@ test('respects overwrite confirmation and renders rewritten stats on the game re
     await expect(page.locator('#stats-body')).toContainText('Mia Diaz');
     await expect(page.locator('#stats-body')).toContainText('12');
     await expect(page.locator('#stats-body')).toContainText('7');
+    await expect(page.locator('#stats-body tr').first().locator('td').nth(3)).toContainText('—');
+    await expect(page.locator('#stats-body tr').first().locator('td').nth(4)).toContainText('—');
     await expect(page.locator('#opponent-stats-body')).toContainText('River Stone');
     await expect(page.locator('#opponent-stats-body')).toContainText('Kai North');
     await expect(page.locator('#opponent-stats-body')).toContainText('15');
     await expect(page.locator('#opponent-stats-body')).toContainText('9');
+    await expect(page.locator('#opponent-stats-body tr').first().locator('td').nth(3)).toContainText('—');
+    await expect(page.locator('#opponent-stats-body tr').first().locator('td').nth(4)).toContainText('—');
 });

--- a/tests/unit/post-game-stat-editor.test.js
+++ b/tests/unit/post-game-stat-editor.test.js
@@ -168,4 +168,12 @@ describe('post-game stat editor helpers', () => {
         expect(setupSource).not.toContain('editorStatsMap[player.id]');
         expect(pageSource).toContain('tableStatsMap: statsMap');
     });
+
+    it('renders missing configured stats as blank cells instead of forced zeros', () => {
+        const pageSource = readFileSync(new URL('../../game.html', import.meta.url), 'utf8');
+
+        expect(pageSource).toContain("function hasRecordedStatValue(stats, key)");
+        expect(pageSource).toContain("hasRecordedStatValue(pStats, key) ? pStats[key] : '&mdash;'");
+        expect(pageSource).toContain("hasRecordedStatValue(p.stats, key) ? p.stats[key] : '&mdash;'");
+    });
 });

--- a/tests/unit/track-statsheet-apply.test.js
+++ b/tests/unit/track-statsheet-apply.test.js
@@ -56,7 +56,6 @@ describe('track statsheet apply helpers', () => {
                         participationSource: 'statsheet-import',
                         stats: {
                             goals: 4,
-                            shots: 0,
                             fouls: 2
                         }
                     }
@@ -70,12 +69,57 @@ describe('track statsheet apply helpers', () => {
                         name: 'Opp One',
                         number: '10',
                         goals: 3,
-                        shots: 0,
                         fouls: 1
                     }
                 },
                 status: 'completed',
                 statSheetPhotoUrl: 'https://img.test/statsheet.png'
+            }
+        });
+    });
+
+    it('does not fabricate unsupported configured stats during statsheet replacement', () => {
+        expect(buildTrackStatsheetApplyPlan({
+            includedHome: [
+                { mappedPlayerId: 'p1', totalPoints: 12, fouls: 2 }
+            ],
+            includedVisitor: [
+                { name: 'Opp One', number: '10', totalPoints: 3, fouls: 1 }
+            ],
+            roster: [
+                { id: 'p1', name: 'Ava Cole', number: '3' }
+            ],
+            columns: ['PTS', 'REB', 'AST']
+        })).toEqual({
+            aggregatedStatsWrites: [
+                {
+                    playerId: 'p1',
+                    data: {
+                        playerName: 'Ava Cole',
+                        playerNumber: '3',
+                        participated: true,
+                        participationStatus: 'appeared',
+                        participationSource: 'statsheet-import',
+                        stats: {
+                            pts: 12,
+                            fouls: 2
+                        }
+                    }
+                }
+            ],
+            gameUpdate: {
+                homeScore: 0,
+                awayScore: 0,
+                opponentStats: {
+                    statsheet_1: {
+                        name: 'Opp One',
+                        number: '10',
+                        pts: 3,
+                        fouls: 1
+                    }
+                },
+                status: 'completed',
+                statSheetPhotoUrl: null
             }
         });
     });

--- a/track-statsheet.html
+++ b/track-statsheet.html
@@ -205,7 +205,7 @@
     import { checkAuth } from './js/auth.js?v=16';
     import { renderTeamAdminBanner } from './js/team-admin-banner.js';
     import { ensureImageAuth, getImageAuthError } from './js/firebase-images.js?v=7';
-    import { validateTrackStatsheetApplyRows, buildTrackStatsheetApplyPlan } from './js/track-statsheet-apply.js?v=2';
+    import { validateTrackStatsheetApplyRows, buildTrackStatsheetApplyPlan } from './js/track-statsheet-apply.js?v=3';
     import { getApp } from './js/vendor/firebase-app.js';
     import { getAI, getGenerativeModel, GoogleAIBackend, Schema } from './js/vendor/firebase-ai.js';
 


### PR DESCRIPTION
Closes #1735

## What changed
- Updated the post-game statsheet apply helper so it only writes stats the workflow actually captures: points plus fouls.
- Stopped the completed game report from rendering missing configured stat fields as `0`; unsupported fields now stay blank instead of showing fabricated values.
- Bumped the statsheet apply helper import version so browsers pick up the fix.
- Added regression coverage in focused unit and smoke tests for both the saved payload and the rendered report.

## Why
The post-game statsheet editor only collects points and fouls today. Writing zeros for every other configured stat was corrupting completed game reports and deleting previously tracked values with false data. This change preserves the supported import behavior without inventing rebounds, assists, or other stats the workflow never collected.