### PR TITLE
Load Team Detail RSVP reminders on demand

### DIFF
--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -2126,6 +2126,44 @@ export async function loadStaffRsvpReminderPreview(event: ParentScheduleEvent, u
   return buildStaffRsvpReminderPreview(players, rsvps);
 }
 
+export function createStaffRsvpReminderPreviewLoader() {
+  const playersByTeamId = new Map<string, Promise<any[]>>();
+  const previewByEventKey = new Map<string, Promise<StaffRsvpReminderPreview>>();
+
+  const getPlayersForTeam = (teamId: string) => {
+    const normalizedTeamId = compactString(teamId);
+    if (!normalizedTeamId) return Promise.resolve([]);
+    const existing = playersByTeamId.get(normalizedTeamId);
+    if (existing) return existing;
+    const nextLoad = loadPlayers(normalizedTeamId).catch((error) => {
+      playersByTeamId.delete(normalizedTeamId);
+      throw error;
+    });
+    playersByTeamId.set(normalizedTeamId, nextLoad);
+    return nextLoad;
+  };
+
+  return {
+    async loadPreview(event: ParentScheduleEvent, user: AuthUser | null): Promise<StaffRsvpReminderPreview> {
+      assertStaffRsvpReminderEvent(event, user);
+      const previewKey = `${compactString(event.teamId)}:${compactString(event.id)}`;
+      const existing = previewByEventKey.get(previewKey);
+      if (existing) return existing;
+      const nextLoad = Promise.all([
+        getPlayersForTeam(event.teamId),
+        loadRsvps(event.teamId, event.id)
+      ])
+        .then(([players, rsvps]) => buildStaffRsvpReminderPreview(players, rsvps))
+        .catch((error) => {
+          previewByEventKey.delete(previewKey);
+          throw error;
+        });
+      previewByEventKey.set(previewKey, nextLoad);
+      return nextLoad;
+    }
+  };
+}
+
 async function sendPublicRsvpReminderEmailsNativeSafe(event: ParentScheduleEvent) {
   if (!isNativeRuntime()) {
     return sendPublicRsvpReminderEmails({

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -21,11 +21,12 @@ import {
   Ticket,
   Trophy,
   UserRound,
-  Users
+  Users,
+  Zap
 } from 'lucide-react';
 import { copyPublicText, openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 import { getEventDetailPath } from '../lib/homeLogic';
-import { loadStaffRsvpReminderPreview, sendStaffRsvpReminder, type StaffRsvpReminderSendResult } from '../lib/scheduleService';
+import { createStaffRsvpReminderPreviewLoader, sendStaffRsvpReminder, type StaffRsvpReminderSendResult } from '../lib/scheduleService';
 import type { ParentScheduleEvent, StaffRsvpReminderPreview } from '../lib/scheduleLogic';
 import { buildPublicTeamGamesIcsUrl, canExposePublicFanFeed, grantScorekeeperAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp, saveTeamScheduleNotificationsForApp, type InviteTeamAdminForAppResult, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer } from '../lib/teamDetailService';
 import type { AuthState } from '../lib/types';
@@ -244,6 +245,7 @@ function OverviewTab({ model }: { model: TeamDetailModel }) {
 
 function ScheduleTab({ model, auth }: { model: TeamDetailModel; auth: AuthState }) {
   const events = [...model.upcomingEvents.slice(0, 8), ...model.recentResults.slice(0, 3)];
+  const reminderPreviewLoader = useMemo(() => createStaffRsvpReminderPreviewLoader(), [model.team.id]);
   return (
     <section className="app-card p-4">
       <div className="flex items-center justify-between gap-3">
@@ -254,7 +256,7 @@ function ScheduleTab({ model, auth }: { model: TeamDetailModel; auth: AuthState 
         <Link to={`/schedule?teamId=${encodeURIComponent(model.team.id)}`} className="secondary-button !min-h-9 text-xs">Open</Link>
       </div>
       <div className="mt-3 space-y-2">
-        {events.length ? events.map((event) => <TeamEventRow key={`${event.id}-${event.date.toISOString()}`} event={event} model={model} auth={auth} />) : (
+        {events.length ? events.map((event) => <TeamEventRow key={`${event.id}-${event.date.toISOString()}`} event={event} model={model} auth={auth} reminderPreviewLoader={reminderPreviewLoader} />) : (
           <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">No team events found.</div>
         )}
       </div>
@@ -890,7 +892,7 @@ function SummaryStat({ icon: Icon, label, value }: { icon: LucideIcon; label: st
   );
 }
 
-function TeamEventRow({ event, model, auth }: { event: TeamDetailEvent; model: TeamDetailModel; auth: AuthState }) {
+function TeamEventRow({ event, model, auth, reminderPreviewLoader }: { event: TeamDetailEvent; model: TeamDetailModel; auth: AuthState; reminderPreviewLoader: ReturnType<typeof createStaffRsvpReminderPreviewLoader> }) {
   const childId = '';
   const teamId = model.team.id;
   const eventPath = getEventDetailPath({ teamId, id: event.id, childId });
@@ -916,45 +918,87 @@ function TeamEventRow({ event, model, auth }: { event: TeamDetailEvent; model: T
           <ChevronRight className="h-4 w-4 flex-none text-gray-300" aria-hidden="true" />
         </Link>
       </div>
-      <TeamEventReminderAction event={event} model={model} auth={auth} />
+      <TeamEventReminderAction event={event} model={model} auth={auth} reminderPreviewLoader={reminderPreviewLoader} />
     </div>
   );
 }
 
-function TeamEventReminderAction({ event, model, auth }: { event: TeamDetailEvent; model: TeamDetailModel; auth: AuthState }) {
+function TeamEventReminderAction({ event, model, auth, reminderPreviewLoader }: { event: TeamDetailEvent; model: TeamDetailModel; auth: AuthState; reminderPreviewLoader: ReturnType<typeof createStaffRsvpReminderPreviewLoader> }) {
   const [preview, setPreview] = useState<StaffRsvpReminderPreview | null>(null);
   const [loading, setLoading] = useState(false);
   const [sending, setSending] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [revealed, setRevealed] = useState(false);
   const scheduleEvent = useMemo(() => buildTeamReminderScheduleEvent(event, model), [event, model]);
   const canLoad = Boolean(auth.user && scheduleEvent && model.canManageTeam && event.date.getTime() >= Date.now() && event.status.toLowerCase() !== 'completed');
 
   useEffect(() => {
-    let cancelled = false;
     setPreview(null);
+    setLoading(false);
+    setSending(false);
     setStatus(null);
     setError(null);
-    if (!canLoad || !scheduleEvent || !auth.user) return;
-    setLoading(true);
-    loadStaffRsvpReminderPreview(scheduleEvent, auth.user)
-      .then((nextPreview) => {
-        if (!cancelled) setPreview(nextPreview);
-      })
-      .catch((loadError: any) => {
-        if (!cancelled) setError(loadError?.message || 'Unable to load RSVP reminder preview.');
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [auth.user, canLoad, scheduleEvent]);
+    setRevealed(false);
+  }, [auth.user?.uid, canLoad, scheduleEvent?.eventKey]);
 
   if (!scheduleEvent || !canLoad) return null;
-  if (loading && !preview) return null;
-  if (!preview || preview.missingPlayerCount <= 0) return null;
+
+  const loadPreview = async () => {
+    if (!auth.user || loading || sending) return;
+    setRevealed(true);
+    setLoading(true);
+    setError(null);
+    setStatus(null);
+    try {
+      const nextPreview = await reminderPreviewLoader.loadPreview(scheduleEvent, auth.user);
+      setPreview(nextPreview);
+    } catch (loadError: any) {
+      setError(loadError?.message || 'Unable to load RSVP reminder preview.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!revealed) {
+    return (
+      <div className="mt-3 flex justify-start">
+        <button type="button" className="secondary-button !min-h-9 px-3 text-xs" onClick={loadPreview}>
+          <Zap className="h-3.5 w-3.5" aria-hidden="true" />
+          Review reminder
+        </button>
+      </div>
+    );
+  }
+
+  if (loading && !preview) {
+    return (
+      <div className="mt-3 rounded-xl border border-primary-200 bg-primary-50 p-3 text-xs font-semibold text-gray-600">
+        Loading RSVP reminder preview…
+      </div>
+    );
+  }
+
+  if (error && !preview) {
+    return (
+      <div className="mt-3 rounded-xl border border-rose-200 bg-rose-50 p-3">
+        <div className="text-xs font-bold text-rose-700">{error}</div>
+        <button type="button" className="secondary-button mt-2 !min-h-9 px-3 text-xs" onClick={loadPreview}>
+          Retry reminder preview
+        </button>
+      </div>
+    );
+  }
+
+  if (!preview) return null;
+
+  if (preview.missingPlayerCount <= 0) {
+    return (
+      <div className="mt-3 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-xs font-semibold text-emerald-700">
+        All player RSVPs are in.
+      </div>
+    );
+  }
 
   const sendReminder = async () => {
     if (!auth.user || sending) return;

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -128,7 +128,7 @@ vi.mock('../../js/snack-helpers.js', () => ({
     }))
 }));
 
-import { addTeamCalendarUrl, cancelPracticeOccurrenceForApp, createScheduleImportGame, createScheduleImportPractice, loadParentSchedule, loadParentScheduleEventDetail, parseRecurringPracticeOccurrenceId, removeTeamCalendarUrl } from '../../apps/app/src/lib/scheduleService.ts';
+import { addTeamCalendarUrl, cancelPracticeOccurrenceForApp, createScheduleImportGame, createScheduleImportPractice, createStaffRsvpReminderPreviewLoader, loadParentSchedule, loadParentScheduleEventDetail, parseRecurringPracticeOccurrenceId, removeTeamCalendarUrl } from '../../apps/app/src/lib/scheduleService.ts';
 import { getScheduleForecastHref, getScheduleMapHref } from '../../apps/app/src/lib/scheduleLogic.ts';
 
 function installWindow(protocol = 'http:') {
@@ -612,6 +612,49 @@ describe('React app schedule service contract integration', () => {
                 })
             })
         );
+    });
+
+    it('reuses the team roster across staff RSVP reminder preview loads', async () => {
+        dbMocks.getPlayers.mockResolvedValue([
+            { id: 'player-1', name: 'Pat', active: true, parents: [{ email: 'pat@example.com' }] },
+            { id: 'player-2', name: 'Sam', active: true, parents: [{ email: 'sam@example.com' }] }
+        ]);
+        dbMocks.getRsvps
+            .mockResolvedValueOnce([{ playerId: 'player-1', response: 'going' }])
+            .mockResolvedValueOnce([{ playerId: 'player-2', response: 'going' }]);
+
+        const loader = createStaffRsvpReminderPreviewLoader();
+        const manager = { uid: 'coach-1', email: 'coach@example.com' };
+        const eventBase = {
+            teamId: 'team-1',
+            teamName: 'Bears',
+            type: 'game',
+            date: new Date('2026-05-21T18:00:00Z'),
+            location: 'Main Gym',
+            opponent: 'Falcons',
+            title: 'vs. Falcons',
+            childId: '',
+            childName: '',
+            isDbGame: true,
+            isCancelled: false,
+            status: 'scheduled',
+            homeScore: null,
+            awayScore: null,
+            assignments: [],
+            isTeamStaff: true,
+            isTeamRsvpReminderManager: true
+        };
+
+        const [firstPreview, secondPreview] = await Promise.all([
+            loader.loadPreview({ ...eventBase, id: 'game-1', eventKey: 'team-1:game-1' }, manager),
+            loader.loadPreview({ ...eventBase, id: 'game-2', eventKey: 'team-1:game-2', opponent: 'Tigers', title: 'vs. Tigers' }, manager)
+        ]);
+
+        expect(dbMocks.getPlayers).toHaveBeenCalledTimes(1);
+        expect(dbMocks.getPlayers).toHaveBeenCalledWith('team-1', { includeInactive: true });
+        expect(dbMocks.getRsvps).toHaveBeenCalledTimes(2);
+        expect(firstPreview.missingPlayerCount).toBe(1);
+        expect(secondPreview.missingPlayerCount).toBe(1);
     });
 
     it('fails closed when adding a calendar URL without team staff access', async () => {

--- a/tests/unit/app-team-detail-integration.test.jsx
+++ b/tests/unit/app-team-detail-integration.test.jsx
@@ -16,7 +16,8 @@ const publicActionMocks = vi.hoisted(() => ({
     sharePublicUrl: vi.fn()
 }));
 const scheduleServiceMocks = vi.hoisted(() => ({
-    loadStaffRsvpReminderPreview: vi.fn(),
+    createStaffRsvpReminderPreviewLoader: vi.fn(),
+    loadPreview: vi.fn(),
     sendStaffRsvpReminder: vi.fn()
 }));
 
@@ -27,7 +28,10 @@ vi.mock('../../apps/app/src/lib/teamDetailService.ts', () => ({
     canExposePublicFanFeed: teamDetailMocks.canExposePublicFanFeed
 }));
 vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionMocks);
-vi.mock('../../apps/app/src/lib/scheduleService.ts', () => scheduleServiceMocks);
+vi.mock('../../apps/app/src/lib/scheduleService.ts', () => ({
+    createStaffRsvpReminderPreviewLoader: scheduleServiceMocks.createStaffRsvpReminderPreviewLoader,
+    sendStaffRsvpReminder: scheduleServiceMocks.sendStaffRsvpReminder
+}));
 
 import { buildScoreboardWidgetEmbedCode, buildScoreboardWidgetUrl, TeamDetail } from '../../apps/app/src/pages/TeamDetail.tsx';
 
@@ -195,11 +199,14 @@ beforeEach(() => {
     };
     publicActionMocks.copyPublicText.mockResolvedValue('copied');
     publicActionMocks.sharePublicUrl.mockResolvedValue('copied');
-    scheduleServiceMocks.loadStaffRsvpReminderPreview.mockResolvedValue({
+    scheduleServiceMocks.loadPreview.mockResolvedValue({
         missingPlayerCount: 0,
         eligibleEmailCount: 0,
         eligibleEmails: [],
         players: []
+    });
+    scheduleServiceMocks.createStaffRsvpReminderPreviewLoader.mockReturnValue({
+        loadPreview: scheduleServiceMocks.loadPreview
     });
     scheduleServiceMocks.sendStaffRsvpReminder.mockResolvedValue({
         missingPlayerCount: 0,
@@ -398,7 +405,7 @@ describe('React app TeamDetail page', () => {
         expect(hrefs(container)).toContain('/schedule/team-1/game-final');
     });
 
-    it('lets team managers send an inline RSVP reminder from schedule rows', async () => {
+    it('loads RSVP reminder previews only when a manager opens a specific schedule row action', async () => {
         const managerAuth = {
             ...auth,
             user: { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] },
@@ -408,8 +415,13 @@ describe('React app TeamDetail page', () => {
         };
         const managerModel = model();
         managerModel.canManageTeam = true;
+        managerModel.upcomingEvents = [
+            managerModel.upcomingEvents[0],
+            { id: 'game-2', type: 'game', title: 'at Tigers', date: new Date('2100-06-03T18:00:00Z'), location: 'North Gym', opponent: 'Tigers', status: '', liveStatus: '', visibility: '', isPrivate: false, isPublic: false, shareable: true, publicCalendar: false, homeScore: null, awayScore: null, isCancelled: false }
+        ];
+        managerModel.nextEvent = managerModel.upcomingEvents[0];
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(managerModel);
-        scheduleServiceMocks.loadStaffRsvpReminderPreview.mockResolvedValueOnce({
+        scheduleServiceMocks.loadPreview.mockResolvedValueOnce({
             missingPlayerCount: 3,
             eligibleEmailCount: 4,
             eligibleEmails: ['one@example.test', 'two@example.test', 'three@example.test', 'four@example.test'],
@@ -428,10 +440,16 @@ describe('React app TeamDetail page', () => {
         await clickButton(container, 'Schedule');
         await flush();
 
+        expect(scheduleServiceMocks.loadPreview).not.toHaveBeenCalled();
+        expect(Array.from(container.querySelectorAll('button')).filter((candidate) => candidate.textContent.includes('Review reminder')).length).toBe(2);
+
+        await clickButton(container, 'Review reminder');
+
         expect(container.textContent).toContain('Staff RSVP reminder');
         expect(container.textContent).toContain('3 no-response players');
         expect(container.textContent).toContain('Send reminder (3)');
-        expect(scheduleServiceMocks.loadStaffRsvpReminderPreview).toHaveBeenCalledWith(expect.objectContaining({
+        expect(scheduleServiceMocks.loadPreview).toHaveBeenCalledTimes(1);
+        expect(scheduleServiceMocks.loadPreview).toHaveBeenCalledWith(expect.objectContaining({
             id: 'game-1',
             teamId: 'team-1',
             type: 'game',
@@ -457,7 +475,7 @@ describe('React app TeamDetail page', () => {
         await flush();
 
         expect(container.textContent).not.toContain('Staff RSVP reminder');
-        expect(scheduleServiceMocks.loadStaffRsvpReminderPreview).not.toHaveBeenCalled();
+        expect(scheduleServiceMocks.loadPreview).not.toHaveBeenCalled();
     });
 
     it('renders empty tab states without trapping users in a spinner', async () => {


### PR DESCRIPTION
Closes #1736

## What changed
- stopped Team Detail schedule rows from fetching RSVP reminder previews during initial tab render
- added an on-demand reminder action per eligible row that loads preview data only when a coach/admin opens that row action
- introduced a shared Team Detail preview loader that reuses the team roster across multiple reminder preview requests in the same tab view

## Why
The previous row-mount side effect fetched roster and RSVP data for every visible eligible future event, which created repeated Firestore work before the schedule tab could settle. This change keeps ScheduleEventDetail behavior unchanged while removing the Team Detail eager-load path and sharing roster data when multiple reminders are opened.