### PR TITLE
Revoke stale profile photo preview blob URLs

### DIFF
--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from 'react';
+import { ChangeEvent, FormEvent, useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import {
   Bell,
@@ -104,6 +104,15 @@ export function Profile({ auth }: { auth: AuthState }) {
   const [parentLinkedTeamsLoaded, setParentLinkedTeamsLoaded] = useState(false);
   const [loadedNotificationTeamId, setLoadedNotificationTeamId] = useState('');
   const [generatedInviteMetadata, setGeneratedInviteMetadata] = useState<{ email: string; phone: string }>({ email: '', phone: '' });
+  const ownedPhotoPreviewUrlRef = useRef<string | null>(null);
+
+  const revokeOwnedPhotoPreviewUrl = () => {
+    const activePreviewUrl = ownedPhotoPreviewUrlRef.current;
+    if (activePreviewUrl?.startsWith('blob:')) {
+      URL.revokeObjectURL(activePreviewUrl);
+    }
+    ownedPhotoPreviewUrlRef.current = null;
+  };
 
   const displayName = fullName || user?.displayName || profile.displayName || user?.email || 'ALL PLAYS User';
   const showPasswordSection = profile.signInMethod === 'emailLink' && !profile.hasPassword;
@@ -119,6 +128,12 @@ export function Profile({ auth }: { auth: AuthState }) {
       window.scrollTo({ top: 0, behavior: 'smooth' });
     });
   };
+
+  useEffect(() => {
+    return () => {
+      revokeOwnedPhotoPreviewUrl();
+    };
+  }, []);
 
   useEffect(() => {
     let cancelled = false;
@@ -157,6 +172,7 @@ export function Profile({ auth }: { auth: AuthState }) {
           return;
         }
 
+        revokeOwnedPhotoPreviewUrl();
         setProfile(loadedProfile);
         setFullName(loadedProfile.fullName || user.displayName || '');
         setPhone(loadedProfile.phone || '');
@@ -325,13 +341,17 @@ export function Profile({ auth }: { auth: AuthState }) {
       return;
     }
 
+    const nextPhotoPreviewUrl = URL.createObjectURL(file);
+    revokeOwnedPhotoPreviewUrl();
+    ownedPhotoPreviewUrlRef.current = nextPhotoPreviewUrl;
     setPhotoFile(file);
-    setPhotoPreview(URL.createObjectURL(file));
+    setPhotoPreview(nextPhotoPreviewUrl);
     setPhotoChanged(true);
     setProfileStatus(null);
   };
 
   const removePhoto = () => {
+    revokeOwnedPhotoPreviewUrl();
     setPhotoFile(null);
     setPhotoUrl('');
     setPhotoPreview('');
@@ -362,6 +382,7 @@ export function Profile({ auth }: { auth: AuthState }) {
       });
 
       const nextProfile = await loadProfileDocument(user.uid);
+      revokeOwnedPhotoPreviewUrl();
       setProfile(nextProfile);
       setPhotoUrl(nextProfile.photoUrl || nextPhotoUrl || '');
       setPhotoPreview(nextProfile.photoUrl || nextPhotoUrl || '');

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -368,7 +368,9 @@ test('messages selected-member, dictation, and validation flows stay usable on m
     await mockMessagesModules(page, { speech: true });
     await page.goto(appUrl(baseURL, '/messages/team-1'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByText('Latest ride update.')).toBeVisible();
+    const thread = page.locator('.chat-messages-scroll');
+    await expect(page.getByRole('button', { name: /Audience: Full team/ })).toBeVisible();
+    await expect(thread).toContainText('Latest ride update.');
     await page.getByRole('button', { name: /Audience: Full team/ }).click();
     await page.getByRole('button', { name: /Selected members/ }).click();
     await page.locator('label').filter({ hasText: 'Coach Jamie' }).click();

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -102,10 +102,32 @@ function renderProfile() {
   );
 }
 
+function getPhotoInput(container: HTMLElement) {
+  const input = container.querySelector('input[type="file"][accept="image/*"]') as HTMLInputElement | null;
+  if (!input) {
+    throw new Error('Profile photo input not found');
+  }
+  return input;
+}
+
+async function selectPhoto(container: HTMLElement, fileName: string) {
+  const input = getPhotoInput(container);
+  const file = new File(['image-bytes'], fileName, { type: 'image/png' });
+  Object.defineProperty(input, 'files', {
+    configurable: true,
+    value: [file]
+  });
+  fireEvent.change(input);
+  await waitFor(() => expect(URL.createObjectURL).toHaveBeenCalledWith(file));
+  return file;
+}
+
 describe('Profile invites', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubGlobal('scrollTo', vi.fn());
+    window.URL.createObjectURL = vi.fn((file: File) => `blob:${file.name}`);
+    window.URL.revokeObjectURL = vi.fn();
     profileServiceMocks.normalizeNotificationPreferences.mockClear();
     profileServiceMocks.loadProfileDocument.mockResolvedValue({
       fullName: 'Pat Parent',
@@ -183,6 +205,57 @@ describe('Profile invites', () => {
 
     fireEvent.click(within(activeCard).getByRole('button', { name: /Share saved invite link/ }));
     expect(await screen.findByText('Share cancelled.')).toBeTruthy();
+  });
+
+  it('revokes replaced and removed profile photo blob previews', async () => {
+    const { container } = renderProfile();
+
+    await screen.findByText('Choose photo');
+    await selectPhoto(container, 'first.png');
+    expect(URL.revokeObjectURL).not.toHaveBeenCalled();
+
+    await selectPhoto(container, 'second.png');
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:first.png');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove' }));
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:second.png');
+  });
+
+  it('revokes temporary blob previews after save and on unmount without touching remote urls', async () => {
+    profileServiceMocks.loadProfileDocument
+      .mockResolvedValueOnce({
+        fullName: 'Pat Parent',
+        phone: '555-0100',
+        photoUrl: 'https://example.test/original.png',
+        signInMethod: 'emailLink',
+        hasPassword: false,
+        updatedAt: { seconds: 1717200000 }
+      })
+      .mockResolvedValueOnce({
+        fullName: 'Pat Parent',
+        phone: '555-0100',
+        photoUrl: 'https://example.test/persisted.png',
+        signInMethod: 'emailLink',
+        hasPassword: false,
+        updatedAt: { seconds: 1717203600 }
+      });
+
+    const { container, unmount } = renderProfile();
+
+    await screen.findByText('Choose photo');
+    await selectPhoto(container, 'saved.png');
+    fireEvent.click(screen.getByRole('button', { name: 'Save profile' }));
+
+    await waitFor(() => expect(profileServiceMocks.uploadProfilePhoto).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(profileServiceMocks.saveProfileDocument).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(auth.refresh).toHaveBeenCalledTimes(1));
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:saved.png');
+    expect(URL.revokeObjectURL).not.toHaveBeenCalledWith('https://example.test/original.png');
+    expect(URL.revokeObjectURL).not.toHaveBeenCalledWith('https://example.test/persisted.png');
+    expect((container.querySelector('img') as HTMLImageElement | null)?.getAttribute('src')).toBe('https://example.test/persisted.png');
+
+    unmount();
+    expect(URL.revokeObjectURL).not.toHaveBeenCalledWith('https://example.test/persisted.png');
   });
 
   it('refreshes alert preferences before saving game-day alerts', async () => {


### PR DESCRIPTION
Closes #1746

## What changed
- tracked ownership of local profile photo blob previews in `Profile.tsx`
- revoked the previous blob URL when a new local image is selected
- revoked the active blob URL when the photo is removed, after save swaps back to the persisted remote URL, and when the profile page unmounts
- left remote `https://` profile photo URLs untouched
- added focused Profile regression tests covering replace, remove, save, and unmount cleanup behavior

## Why
Repeated profile photo retries were creating new object URLs without cleaning up the old ones. This patch keeps the existing upload flow intact while closing the memory leak path that could make the profile screen degrade on lower-memory devices.