### PR TITLE
Add native profile photo capture on mobile

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -12,6 +12,7 @@ dependencies {
     implementation project(':capacitor-firebase-authentication')
     implementation project(':capacitor-firebase-messaging')
     implementation project(':capacitor-browser')
+    implementation project(':capacitor-camera')
     implementation project(':capacitor-share')
     implementation project(':capgo-capacitor-speech-recognition')
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -38,6 +38,7 @@
     <!-- Permissions -->
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
 </manifest>

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -11,6 +11,9 @@ project(':capacitor-firebase-messaging').projectDir = new File('../node_modules/
 include ':capacitor-browser'
 project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/browser/android')
 
+include ':capacitor-camera'
+project(':capacitor-camera').projectDir = new File('../node_modules/@capacitor/camera/android')
+
 include ':capacitor-share'
 project(':capacitor-share').projectDir = new File('../node_modules/@capacitor/share/android')
 

--- a/apps/app/package-lock.json
+++ b/apps/app/package-lock.json
@@ -11,6 +11,7 @@
         "@capacitor-firebase/authentication": "^8.2.0",
         "@capacitor-firebase/messaging": "^8.2.0",
         "@capacitor/browser": "^8.0.3",
+        "@capacitor/camera": "^8.2.0",
         "@capacitor/core": "^8.3.4",
         "@capacitor/share": "^8.0.1",
         "@capgo/capacitor-speech-recognition": "^8.1.3",
@@ -714,6 +715,15 @@
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/@capacitor/browser/-/browser-8.0.3.tgz",
       "integrity": "sha512-WJWPHEPbweiFoHYmVlCbZf5yrqJ2Rchx2Xvbmd+3Lf+Zkpq3nXBThThY2CF69lYEg1NINGF9BcHThIOEU1gZlQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/camera": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/camera/-/camera-8.2.0.tgz",
+      "integrity": "sha512-hYfrT6xpL936qoEkIpJzSnb0fQCaTkOux1cXzGBfH8QLOGqr6gSLiWZlZz/fqMPmMKJMNRBqlTQkj5fuMhVZog==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -13,6 +13,7 @@
     "@capacitor-firebase/authentication": "^8.2.0",
     "@capacitor-firebase/messaging": "^8.2.0",
     "@capacitor/browser": "^8.0.3",
+    "@capacitor/camera": "^8.2.0",
     "@capacitor/core": "^8.3.4",
     "@capacitor/share": "^8.0.1",
     "@capgo/capacitor-speech-recognition": "^8.1.3",

--- a/apps/app/src/lib/profileService.ts
+++ b/apps/app/src/lib/profileService.ts
@@ -1,4 +1,11 @@
 import {
+  Camera,
+  CameraResultType,
+  CameraSource,
+  type CameraPhoto
+} from '@capacitor/camera';
+import { Capacitor } from '@capacitor/core';
+import {
   createAccessCode,
   createAccountMergeRequest,
   generateAccessCode,
@@ -54,6 +61,18 @@ export type AccessCodeRecord = {
   usedAt?: unknown;
 };
 
+export type ProfilePhotoSource = 'camera' | 'photos';
+
+export class ProfilePhotoAcquireError extends Error {
+  code: 'permission-denied' | 'cancelled' | 'unavailable' | 'failed';
+
+  constructor(code: 'permission-denied' | 'cancelled' | 'unavailable' | 'failed', message: string) {
+    super(message);
+    this.name = 'ProfilePhotoAcquireError';
+    this.code = code;
+  }
+}
+
 export type NotificationDeviceTokenInput = {
   token: string;
   platform?: string;
@@ -100,6 +119,83 @@ function getFirestoreBaseUrl() {
 
 function isNativeRuntime() {
   return window.location.protocol === 'capacitor:';
+}
+
+function isNativeCameraAvailable() {
+  return Capacitor.isNativePlatform() && Boolean((Capacitor as any).isPluginAvailable?.('Camera'));
+}
+
+function inferPhotoMimeType(photo: CameraPhoto, fallbackBlob?: Blob) {
+  const format = String(photo.format || '').trim().toLowerCase();
+  if (format) {
+    return format === 'jpg' ? 'image/jpeg' : `image/${format}`;
+  }
+  if (fallbackBlob?.type) {
+    return fallbackBlob.type;
+  }
+  return 'image/jpeg';
+}
+
+function buildPhotoFileName(source: ProfilePhotoSource, photo: CameraPhoto, mimeType: string) {
+  const extension = mimeType.split('/')[1] || 'jpg';
+  const baseName = source === 'camera' ? 'profile-camera' : 'profile-library';
+  return `${baseName}-${Date.now()}.${extension.replace(/[^a-z0-9]+/gi, '') || 'jpg'}`;
+}
+
+function isPermissionDeniedError(error: unknown) {
+  const message = String((error as any)?.message || error || '').toLowerCase();
+  return message.includes('permission') || message.includes('denied') || message.includes('not authorized');
+}
+
+function isCancellationError(error: unknown) {
+  const message = String((error as any)?.message || error || '').toLowerCase();
+  return message.includes('cancel') || message.includes('user denied') || message.includes('no image picked');
+}
+
+export async function acquireProfilePhoto(source: ProfilePhotoSource): Promise<File> {
+  if (!isNativeRuntime()) {
+    throw new ProfilePhotoAcquireError('unavailable', 'Native profile photo capture is only available in the mobile app.');
+  }
+
+  if (!isNativeCameraAvailable()) {
+    throw new ProfilePhotoAcquireError('unavailable', 'Camera access is not available on this device yet.');
+  }
+
+  try {
+    const photo = await Camera.getPhoto({
+      quality: 85,
+      resultType: CameraResultType.Uri,
+      source: source === 'camera' ? CameraSource.Camera : CameraSource.Photos,
+      correctOrientation: true
+    });
+
+    if (!photo.webPath) {
+      throw new ProfilePhotoAcquireError('failed', 'Photo data was unavailable after selection.');
+    }
+
+    const response = await fetch(photo.webPath);
+    if (!response.ok) {
+      throw new ProfilePhotoAcquireError('failed', `Photo data could not be loaded (${response.status}).`);
+    }
+
+    const blob = await response.blob();
+    const mimeType = inferPhotoMimeType(photo, blob);
+    return new File([blob], buildPhotoFileName(source, photo, mimeType), {
+      type: mimeType,
+      lastModified: Date.now()
+    });
+  } catch (error) {
+    if (error instanceof ProfilePhotoAcquireError) {
+      throw error;
+    }
+    if (isCancellationError(error)) {
+      throw new ProfilePhotoAcquireError('cancelled', 'Photo selection was cancelled.');
+    }
+    if (isPermissionDeniedError(error)) {
+      throw new ProfilePhotoAcquireError('permission-denied', 'Photo access permission was denied.');
+    }
+    throw new ProfilePhotoAcquireError('failed', String((error as any)?.message || 'Photo selection failed.'));
+  }
 }
 
 async function getNativeHeaders() {

--- a/apps/app/src/lib/profileService.ts
+++ b/apps/app/src/lib/profileService.ts
@@ -118,7 +118,7 @@ function getFirestoreBaseUrl() {
 }
 
 function isNativeRuntime() {
-  return window.location.protocol === 'capacitor:';
+  return Capacitor.isNativePlatform() || window.location.protocol === 'capacitor:';
 }
 
 function isNativeCameraAvailable() {

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -25,6 +25,7 @@ import {
 } from 'lucide-react';
 import { describeAuthError, reloadCurrentUser, resendVerificationEmail, sendResetEmail, setCurrentUserPassword } from '../lib/authService';
 import {
+  acquireProfilePhoto,
   createProfileAccessCode,
   loadParentTeams,
   loadNotificationPreferences,
@@ -41,6 +42,7 @@ import { enablePushNotificationsForUser } from '../lib/pushService';
 import { sharePublicUrl } from '../lib/publicActions';
 import { useShellLayout } from '../lib/useShellLayout';
 import type { AccessCodeRecord, NotificationPreferences, NotificationTeam, ProfileDocument } from '../lib/profileService';
+import type { ProfilePhotoSource } from '../lib/profileService';
 import type { AuthState } from '../lib/types';
 
 type Tone = 'neutral' | 'success' | 'error';
@@ -67,7 +69,7 @@ const profileSections: Array<{ id: ProfileSectionId; label: string }> = [
 
 export function Profile({ auth }: { auth: AuthState }) {
   const navigate = useNavigate();
-  const { isDesktopWeb } = useShellLayout();
+  const { isDesktopWeb, isNative } = useShellLayout();
   const user = auth.user;
   const [profile, setProfile] = useState<ProfileDocument>({});
   const [fullName, setFullName] = useState('');
@@ -76,6 +78,7 @@ export function Profile({ auth }: { auth: AuthState }) {
   const [photoPreview, setPhotoPreview] = useState('');
   const [photoFile, setPhotoFile] = useState<File | null>(null);
   const [photoChanged, setPhotoChanged] = useState(false);
+  const [photoChooserOpen, setPhotoChooserOpen] = useState(false);
   const [notificationTeams, setNotificationTeams] = useState<NotificationTeam[]>([]);
   const [selectedTeamId, setSelectedTeamId] = useState('');
   const [notificationPreferences, setNotificationPreferences] = useState<NotificationPreferences>(emptyPreferences);
@@ -105,6 +108,7 @@ export function Profile({ auth }: { auth: AuthState }) {
   const [loadedNotificationTeamId, setLoadedNotificationTeamId] = useState('');
   const [generatedInviteMetadata, setGeneratedInviteMetadata] = useState<{ email: string; phone: string }>({ email: '', phone: '' });
   const ownedPhotoPreviewUrlRef = useRef<string | null>(null);
+  const photoInputRef = useRef<HTMLInputElement | null>(null);
 
   const revokeOwnedPhotoPreviewUrl = () => {
     const activePreviewUrl = ownedPhotoPreviewUrlRef.current;
@@ -329,15 +333,13 @@ export function Profile({ auth }: { auth: AuthState }) {
     };
   }, [accountMergeExpanded, parentLinkedTeamsLoaded, user]);
 
-  const handlePhotoChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0];
+  const applySelectedPhoto = (file: File) => {
     if (!file) {
       return;
     }
 
     if (!file.type.startsWith('image/')) {
       setProfileStatus({ message: 'Choose an image file.', tone: 'error' });
-      event.target.value = '';
       return;
     }
 
@@ -350,12 +352,51 @@ export function Profile({ auth }: { auth: AuthState }) {
     setProfileStatus(null);
   };
 
+  const handlePhotoChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      applySelectedPhoto(file);
+    }
+    event.target.value = '';
+  };
+
+  const handleNativePhotoChoice = async (source: ProfilePhotoSource) => {
+    setBusy('photo-acquire');
+    setProfileStatus(null);
+
+    try {
+      const file = await acquireProfilePhoto(source);
+      applySelectedPhoto(file);
+      setPhotoChooserOpen(false);
+    } catch (error: any) {
+      if (error?.code === 'cancelled') {
+        setPhotoChooserOpen(false);
+        return;
+      }
+      if (error?.code === 'unavailable' && source === 'photos') {
+        photoInputRef.current?.click();
+        setPhotoChooserOpen(false);
+        return;
+      }
+      const message = error?.code === 'permission-denied'
+        ? source === 'camera'
+          ? 'Camera permission was denied. Allow camera access to take a new profile photo.'
+          : 'Photo permission was denied. Allow photo library access to choose a profile photo.'
+        : error?.message || 'Profile photo could not be updated right now.';
+      setProfileStatus({ message, tone: 'error' });
+      setPhotoChooserOpen(false);
+    } finally {
+      setBusy('');
+    }
+  };
+
   const removePhoto = () => {
     revokeOwnedPhotoPreviewUrl();
     setPhotoFile(null);
     setPhotoUrl('');
     setPhotoPreview('');
     setPhotoChanged(true);
+    setProfileStatus(null);
   };
 
   const saveProfile = async (event: FormEvent) => {
@@ -702,11 +743,21 @@ export function Profile({ auth }: { auth: AuthState }) {
 
         <form className="mt-4 space-y-4" onSubmit={saveProfile}>
           <div className="flex flex-wrap items-center gap-3">
-            <label className="secondary-button cursor-pointer">
-              <ImagePlus className="h-4 w-4" aria-hidden="true" />
-              Choose photo
-              <input type="file" accept="image/*" className="sr-only" onChange={handlePhotoChange} />
-            </label>
+            {isNative ? (
+              <>
+                <button type="button" className="secondary-button" onClick={() => setPhotoChooserOpen(true)} disabled={busy === 'photo-acquire'}>
+                  {busy === 'photo-acquire' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <ImagePlus className="h-4 w-4" aria-hidden="true" />}
+                  Choose photo
+                </button>
+                <input ref={photoInputRef} type="file" accept="image/*" className="sr-only" onChange={handlePhotoChange} tabIndex={-1} aria-hidden="true" />
+              </>
+            ) : (
+              <label className="secondary-button cursor-pointer">
+                <ImagePlus className="h-4 w-4" aria-hidden="true" />
+                Choose photo
+                <input ref={photoInputRef} type="file" accept="image/*" className="sr-only" onChange={handlePhotoChange} />
+              </label>
+            )}
             {photoPreview ? (
               <button type="button" className="ghost-button" onClick={removePhoto}>
                 <Trash2 className="h-4 w-4" aria-hidden="true" />
@@ -997,6 +1048,27 @@ export function Profile({ auth }: { auth: AuthState }) {
           </button>
         ) : null}
       </section>
+      ) : null}
+
+      {photoChooserOpen ? (
+        <div className="fixed inset-0 z-50 flex items-end bg-gray-950/40 p-0 sm:items-center sm:justify-center sm:p-4" role="dialog" aria-modal="true" aria-labelledby="profile-photo-chooser-title">
+          <button type="button" className="absolute inset-0 h-full w-full cursor-default" onClick={() => setPhotoChooserOpen(false)} aria-label="Close photo options" />
+          <section className="relative w-full rounded-t-3xl bg-white p-4 shadow-2xl sm:max-w-sm sm:rounded-2xl">
+            <div className="app-label">Profile photo</div>
+            <h2 id="profile-photo-chooser-title" className="mt-1 text-lg font-black text-gray-950">Choose how to update your photo</h2>
+            <div className="mt-4 space-y-2">
+              <button type="button" className="primary-button w-full justify-center" onClick={() => handleNativePhotoChoice('camera')} disabled={busy === 'photo-acquire'}>
+                Take photo
+              </button>
+              <button type="button" className="secondary-button w-full justify-center" onClick={() => handleNativePhotoChoice('photos')} disabled={busy === 'photo-acquire'}>
+                Choose existing photo
+              </button>
+              <button type="button" className="ghost-button w-full justify-center" onClick={() => setPhotoChooserOpen(false)} disabled={busy === 'photo-acquire'}>
+                Cancel
+              </button>
+            </div>
+          </section>
+        </div>
       ) : null}
     </div>
   );

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
         .package(name: "CapacitorFirebaseAuthentication", path: "../../../node_modules/@capacitor-firebase/authentication"),
         .package(name: "CapacitorFirebaseMessaging", path: "../../../node_modules/@capacitor-firebase/messaging"),
         .package(name: "CapacitorBrowser", path: "../../../node_modules/@capacitor/browser"),
+        .package(name: "CapacitorCamera", path: "../../../node_modules/@capacitor/camera"),
         .package(name: "CapacitorShare", path: "../../../node_modules/@capacitor/share"),
         .package(name: "CapgoCapacitorSpeechRecognition", path: "../../../node_modules/@capgo/capacitor-speech-recognition")
     ],
@@ -27,6 +28,7 @@ let package = Package(
                 .product(name: "CapacitorFirebaseAuthentication", package: "CapacitorFirebaseAuthentication"),
                 .product(name: "CapacitorFirebaseMessaging", package: "CapacitorFirebaseMessaging"),
                 .product(name: "CapacitorBrowser", package: "CapacitorBrowser"),
+                .product(name: "CapacitorCamera", package: "CapacitorCamera"),
                 .product(name: "CapacitorShare", package: "CapacitorShare"),
                 .product(name: "CapgoCapacitorSpeechRecognition", package: "CapgoCapacitorSpeechRecognition")
             ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@capacitor-firebase/messaging": "^8.2.0",
         "@capacitor/android": "^8.3.4",
         "@capacitor/browser": "^8.0.3",
+        "@capacitor/camera": "^8.2.0",
         "@capacitor/core": "^8.3.4",
         "@capacitor/ios": "^8.3.4",
         "@capacitor/share": "^8.0.1",
@@ -187,6 +188,15 @@
       "version": "8.0.3",
       "resolved": "https://registry.npmjs.org/@capacitor/browser/-/browser-8.0.3.tgz",
       "integrity": "sha512-WJWPHEPbweiFoHYmVlCbZf5yrqJ2Rchx2Xvbmd+3Lf+Zkpq3nXBThThY2CF69lYEg1NINGF9BcHThIOEU1gZlQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
+    "node_modules/@capacitor/camera": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/@capacitor/camera/-/camera-8.2.0.tgz",
+      "integrity": "sha512-hYfrT6xpL936qoEkIpJzSnb0fQCaTkOux1cXzGBfH8QLOGqr6gSLiWZlZz/fqMPmMKJMNRBqlTQkj5fuMhVZog==",
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@capacitor-firebase/messaging": "^8.2.0",
     "@capacitor/android": "^8.3.4",
     "@capacitor/browser": "^8.0.3",
+    "@capacitor/camera": "^8.2.0",
     "@capacitor/core": "^8.3.4",
     "@capacitor/ios": "^8.3.4",
     "@capacitor/share": "^8.0.1",

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -218,6 +218,10 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
                     };
                 }
 
+                export async function acquireProfilePhoto() {
+                    return new File(['native-photo'], 'native-camera.jpg', { type: 'image/jpeg' });
+                }
+
                 export async function saveProfileDocument(userId, profile) {
                     window.__appProfileCalls.saves.push({ userId, profile });
                 }

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -245,6 +245,9 @@ describe('React app auth/profile capability parity', () => {
         const profilePage = readProjectFile('apps/app/src/pages/Profile.tsx');
         const profileService = readProjectFile('apps/app/src/lib/profileService.ts');
         const androidManifest = readProjectFile('android/app/src/main/AndroidManifest.xml');
+        const androidSettings = readProjectFile('android/capacitor.settings.gradle');
+        const androidCapacitorBuild = readProjectFile('android/app/capacitor.build.gradle');
+        const iosCapAppPackage = readProjectFile('ios/App/CapApp-SPM/Package.swift');
 
         expectContains(rootPackage, ['"@capacitor/camera":']);
         expectContains(rootPackageLock, ['"node_modules/@capacitor/camera"']);
@@ -252,6 +255,7 @@ describe('React app auth/profile capability parity', () => {
         expectContains(appPackageLock, ['"node_modules/@capacitor/camera"']);
         expectContains(profileService, [
             "from '@capacitor/camera'",
+            'Capacitor.isNativePlatform() || window.location.protocol === \'capacitor:\'',
             'Camera.getPhoto',
             'CameraResultType.Uri',
             'CameraSource.Camera',
@@ -264,6 +268,15 @@ describe('React app auth/profile capability parity', () => {
             'Choose existing photo'
         ]);
         expectContains(androidManifest, ['android.permission.CAMERA']);
+        expectContains(androidSettings, [
+            "include ':capacitor-camera'",
+            "project(':capacitor-camera').projectDir = new File('../node_modules/@capacitor/camera/android')"
+        ]);
+        expectContains(androidCapacitorBuild, ["implementation project(':capacitor-camera')"]);
+        expectContains(iosCapAppPackage, [
+            '.package(name: "CapacitorCamera", path: "../../../node_modules/@capacitor/camera")',
+            '.product(name: "CapacitorCamera", package: "CapacitorCamera")'
+        ]);
     });
 
     it('registers push for the current Profile device without saving alert preferences', () => {

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -232,8 +232,38 @@ describe('React app auth/profile capability parity', () => {
             'saveNotificationDeviceToken',
             'createProfileAccessCode',
             'loadProfileAccessCodes',
-            'nativeUploadProfilePhoto'
+            'nativeUploadProfilePhoto',
+            'acquireProfilePhoto'
         ]);
+    });
+
+    it('keeps native profile photo capture wired to the Camera plugin dependency and Android permission', () => {
+        const rootPackage = readProjectFile('package.json');
+        const rootPackageLock = readProjectFile('package-lock.json');
+        const appPackage = readProjectFile('apps/app/package.json');
+        const appPackageLock = readProjectFile('apps/app/package-lock.json');
+        const profilePage = readProjectFile('apps/app/src/pages/Profile.tsx');
+        const profileService = readProjectFile('apps/app/src/lib/profileService.ts');
+        const androidManifest = readProjectFile('android/app/src/main/AndroidManifest.xml');
+
+        expectContains(rootPackage, ['"@capacitor/camera":']);
+        expectContains(rootPackageLock, ['"node_modules/@capacitor/camera"']);
+        expectContains(appPackage, ['"@capacitor/camera":']);
+        expectContains(appPackageLock, ['"node_modules/@capacitor/camera"']);
+        expectContains(profileService, [
+            "from '@capacitor/camera'",
+            'Camera.getPhoto',
+            'CameraResultType.Uri',
+            'CameraSource.Camera',
+            'CameraSource.Photos'
+        ]);
+        expectContains(profilePage, [
+            "handleNativePhotoChoice('camera')",
+            "handleNativePhotoChoice('photos')",
+            'Take photo',
+            'Choose existing photo'
+        ]);
+        expectContains(androidManifest, ['android.permission.CAMERA']);
     });
 
     it('registers push for the current Profile device without saving alert preferences', () => {

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -7,6 +7,7 @@ import { Profile } from '../../apps/app/src/pages/Profile';
 import type { AuthState } from '../../apps/app/src/lib/types';
 
 const profileServiceMocks = vi.hoisted(() => ({
+  acquireProfilePhoto: vi.fn(),
   createProfileAccessCode: vi.fn(),
   loadParentTeams: vi.fn(),
   loadNotificationPreferences: vi.fn(),
@@ -32,11 +33,16 @@ const pushServiceMocks = vi.hoisted(() => ({
   enablePushNotificationsForUser: vi.fn()
 }));
 
+const shellLayoutState = vi.hoisted(() => ({
+  isDesktopWeb: false,
+  isNative: false
+}));
+
 vi.mock('../../apps/app/src/lib/profileService', () => profileServiceMocks);
 vi.mock('../../apps/app/src/lib/publicActions', () => publicActionsMocks);
 vi.mock('../../apps/app/src/lib/pushService', () => pushServiceMocks);
 vi.mock('../../apps/app/src/lib/useShellLayout', () => ({
-  useShellLayout: () => ({ isDesktopWeb: false })
+  useShellLayout: () => shellLayoutState
 }));
 vi.mock('lucide-react', () => {
   const createIcon = (name: string) => (props: Record<string, unknown>) => React.createElement('svg', { ...props, 'data-icon': name });
@@ -138,6 +144,7 @@ describe('Profile invites', () => {
       updatedAt: { seconds: 1717200000 }
     });
     profileServiceMocks.loadNotificationTeams.mockResolvedValue([]);
+    profileServiceMocks.acquireProfilePhoto.mockResolvedValue(new File(['native-photo'], 'native-camera.jpg', { type: 'image/jpeg' }));
     pushServiceMocks.enablePushNotificationsForUser.mockResolvedValue(undefined);
     profileServiceMocks.loadNotificationPreferences.mockResolvedValue({ liveChat: true, liveScore: false, schedule: true });
     profileServiceMocks.loadParentTeams.mockResolvedValue([]);
@@ -150,6 +157,8 @@ describe('Profile invites', () => {
       { id: 'code-1', code: 'ACTIVE123', email: 'coach@example.com', phone: '', used: false, createdAt: { seconds: 1717200000 } },
       { id: 'code-2', code: 'USED1234', email: 'used@example.com', phone: '', used: true, createdAt: { seconds: 1717113600 }, usedAt: { seconds: 1717200000 } }
     ]);
+    shellLayoutState.isDesktopWeb = false;
+    shellLayoutState.isNative = false;
   });
 
   afterEach(() => {
@@ -283,5 +292,50 @@ describe('Profile invites', () => {
       schedule: true
     });
     expect(await screen.findByText('Game-day alerts are on for this team.')).toBeTruthy();
+  });
+
+  it('uses the native chooser to capture a profile photo before saving', async () => {
+    shellLayoutState.isNative = true;
+    const { container } = renderProfile();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Choose photo' }));
+    expect(screen.getByRole('button', { name: 'Take photo' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Choose existing photo' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Take photo' }));
+
+    await waitFor(() => expect(profileServiceMocks.acquireProfilePhoto).toHaveBeenCalledWith('camera'));
+    await waitFor(() => expect(URL.createObjectURL).toHaveBeenCalled());
+    expect((container.querySelector('img') as HTMLImageElement | null)?.getAttribute('src')).toBe('blob:native-camera.jpg');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save profile' }));
+
+    await waitFor(() => expect(profileServiceMocks.uploadProfilePhoto).toHaveBeenCalledTimes(1));
+    expect((container.querySelector('img') as HTMLImageElement | null)?.getAttribute('src')).toBe('https://example.test/avatar.png');
+  });
+
+  it('shows an inline error and preserves the current photo when native camera permission is denied', async () => {
+    shellLayoutState.isNative = true;
+    profileServiceMocks.loadProfileDocument.mockResolvedValue({
+      fullName: 'Pat Parent',
+      phone: '555-0100',
+      photoUrl: 'https://example.test/original.png',
+      signInMethod: 'emailLink',
+      hasPassword: false,
+      updatedAt: { seconds: 1717200000 }
+    });
+    profileServiceMocks.acquireProfilePhoto.mockRejectedValue({ code: 'permission-denied', message: 'Denied' });
+
+    const { container } = renderProfile();
+
+    await screen.findByRole('button', { name: 'Choose photo' });
+    expect((container.querySelector('img') as HTMLImageElement | null)?.getAttribute('src')).toBe('https://example.test/original.png');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Choose photo' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Take photo' }));
+
+    expect(await screen.findByText('Camera permission was denied. Allow camera access to take a new profile photo.')).toBeTruthy();
+    expect((container.querySelector('img') as HTMLImageElement | null)?.getAttribute('src')).toBe('https://example.test/original.png');
+    expect(profileServiceMocks.uploadProfilePhoto).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #1748

## What changed
- added a native profile photo acquisition helper using `@capacitor/camera` so the mobile app can return a `File` into the existing preview and upload flow
- updated the `/profile` account card to show a native chooser with **Take photo** and **Choose existing photo** actions while keeping the web file-input path intact
- added inline permission-denied handling so the current photo stays unchanged when camera or library access is blocked
- wired Android camera permission support and added the Capacitor camera dependency
- added focused regression coverage for the native chooser path and denied-permission behavior

## Why
The profile page only supported a hidden web file input, which made native photo updates clunky and prevented in-app camera capture. This keeps the current save/upload pipeline but gives iOS and Android users a fast native photo flow from the profile screen.