### PR TITLE
Restrict admin team deactivation to owners

### DIFF
--- a/js/admin.js
+++ b/js/admin.js
@@ -82,6 +82,17 @@ function getVisibleTeams() {
     return showInactiveTeams ? allTeams : allTeams.filter(isTeamActive);
 }
 
+function canCurrentUserDeactivateTeam(team) {
+    if (!currentUser || !team) return false;
+    if (team.ownerId && currentUser.uid) {
+        return team.ownerId === currentUser.uid;
+    }
+    if (team.ownerEmail && currentUser.email) {
+        return team.ownerEmail.trim().toLowerCase() === currentUser.email.trim().toLowerCase();
+    }
+    return false;
+}
+
 checkAuth(async (user) => {
     if (!user) {
         window.location.href = 'login.html';
@@ -697,7 +708,9 @@ function renderTeams(teams) {
                 <button onclick="window.openRegistrationFormsAdmin(${inlineJsString(team.id)})" class="text-indigo-600 hover:text-indigo-900 mr-4">Registration forms</button>
                 <button onclick="window.openOfficialsAdmin(${inlineJsString(team.id)})" class="text-indigo-600 hover:text-indigo-900 mr-4">Officials</button>
                 <a href="edit-team.html?teamId=${encodeURIComponent(team.id)}" class="text-indigo-600 hover:text-indigo-900 mr-4">Edit</a>
-                <button onclick="window.deleteTeamAdmin(${inlineJsString(team.id)}, ${inlineJsString(team.name)})" class="text-red-600 hover:text-red-900">Deactivate</button>
+                ${canCurrentUserDeactivateTeam(team)
+        ? `<button onclick="window.deleteTeamAdmin(${inlineJsString(team.id)}, ${inlineJsString(team.name)})" class="text-red-600 hover:text-red-900">Deactivate</button>`
+        : '<span class="text-xs font-medium text-gray-400">Owner only</span>'}
             </td>
         </tr>
     `;
@@ -911,6 +924,12 @@ function renderUsers(users) {
 }
 
 window.deleteTeamAdmin = async function (teamId, teamName) {
+    const team = allTeams.find((entry) => entry.id === teamId) || null;
+    if (!canCurrentUserDeactivateTeam(team)) {
+        alert('Team deactivation is only available to the team owner in the dashboard workflow.');
+        return;
+    }
+
     if (confirm(`ADMIN ACTION: Deactivate team "${teamName}"? Team data will be retained.`)) {
         try {
             await deleteTeam(teamId);

--- a/tests/unit/admin-team-deactivation-access.test.js
+++ b/tests/unit/admin-team-deactivation-access.test.js
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+
+describe('admin team deactivation access', () => {
+    it('keeps team deactivation owner-only in the admin teams table', () => {
+        const adminJs = fs.readFileSync('js/admin.js', 'utf8');
+
+        expect(adminJs).toContain('function canCurrentUserDeactivateTeam(team) {');
+        expect(adminJs).toContain('team.ownerId === currentUser.uid');
+        expect(adminJs).toContain("team.ownerEmail.trim().toLowerCase() === currentUser.email.trim().toLowerCase()");
+        expect(adminJs).toContain('>Owner only<');
+        expect(adminJs).toContain('if (!canCurrentUserDeactivateTeam(team)) {');
+        expect(adminJs).toContain('Team deactivation is only available to the team owner in the dashboard workflow.');
+    });
+});


### PR DESCRIPTION
Closes #1750

## What changed
- added an owner check in `js/admin.js` so the Admin Teams tab only renders the **Deactivate** action for the current team owner
- added a runtime guard in `window.deleteTeamAdmin()` so non-owner admins cannot trigger team deactivation even if they invoke the handler directly
- added a focused regression test covering the owner-only admin deactivation wiring

## Why
The admin console was exposing a destructive team deactivation path to any platform admin, which bypassed the documented owner-controlled dashboard workflow. This patch keeps the admin view aligned with that workflow while preserving the existing owner deactivation path.