### PR TITLE
Retry calendar imports across validated IPs

### DIFF
--- a/functions/test/ssrf.test.js
+++ b/functions/test/ssrf.test.js
@@ -48,23 +48,24 @@ test('assertPublicHost prevents blocked hosts and private IPs', async () => {
   assert.deepStrictEqual(publicIp, ['8.8.8.8'], 'public IP should be allowed');
 });
 
-test('SSRF vulnerability via DNS Rebinding prevention in fetchWithTimeout', async (t) => {
+test('fetchWithTimeout uses validated IPs and falls back across failures', async () => {
   const originalDnsLookup = dns.lookup;
   const originalSetClientModules = _setClientModulesForTesting;
 
   try {
     const publicIp = '203.0.113.1';
+    const fallbackPublicIp = '198.51.100.2';
     const privateIp = '192.168.1.1';
     const maliciousHost = 'attacker.com';
     const maliciousUrl = `https://${maliciousHost}/evil_feed.ics`;
 
-    let requestOptionsUsed = null;
+    const requestOptionsUsed = [];
 
     // Mock http and https modules to capture request options
     const mockHttp = {
       request: (options, callback) => {
-        requestOptionsUsed = options;
-        assert.strictEqual(options.host, publicIp, 'HTTP request should connect to the pre-validated public IP');
+        requestOptionsUsed.push(options);
+        assert.ok([publicIp, fallbackPublicIp].includes(options.host), 'HTTP request should connect only to validated public IPs');
         assert.strictEqual(options.headers['Host'], maliciousHost, 'HTTP request should use original hostname in Host header');
         const mockResponse = new http.IncomingMessage(new net.Socket());
         mockResponse.statusCode = 200;
@@ -81,15 +82,23 @@ test('SSRF vulnerability via DNS Rebinding prevention in fetchWithTimeout', asyn
     };
     const mockHttps = {
       request: (options, callback) => {
-        requestOptionsUsed = options;
-        assert.strictEqual(options.host, publicIp, 'HTTPS request should connect to the pre-validated public IP');
+        requestOptionsUsed.push(options);
+        assert.ok([publicIp, fallbackPublicIp].includes(options.host), 'HTTPS request should connect only to validated public IPs');
         assert.strictEqual(options.servername, maliciousHost, 'HTTPS request should use original hostname for SNI');
         assert.strictEqual(options.headers['Host'], maliciousHost, 'HTTPS request should use original hostname in Host header');
+        const mockRequest = new http.ClientRequest(options);
+
+        if (options.host === publicIp) {
+          setImmediate(() => {
+            mockRequest.emit('error', new Error('connect ECONNREFUSED'));
+          });
+          return mockRequest;
+        }
+
         const mockResponse = new http.IncomingMessage(new net.Socket());
         mockResponse.statusCode = 200;
         mockResponse.statusMessage = 'OK';
         mockResponse.headers = { 'content-type': 'text/calendar' };
-        const mockRequest = new http.ClientRequest(options);
         setImmediate(() => {
           callback(mockResponse);
           mockResponse.emit('data', 'BEGIN:VCALENDAR\nSUMMARY:Test Event\nEND:VCALENDAR');
@@ -104,7 +113,10 @@ test('SSRF vulnerability via DNS Rebinding prevention in fetchWithTimeout', asyn
     // Mock dns.lookup to initially return a public IP
     dns.lookup = async (hostname, options) => {
       if (hostname === maliciousHost) {
-        return [{ address: publicIp, family: 4 }];
+        return [
+          { address: publicIp, family: 4 },
+          { address: fallbackPublicIp, family: 4 },
+        ];
       }
       return originalDnsLookup(hostname, options);
     };
@@ -113,7 +125,7 @@ test('SSRF vulnerability via DNS Rebinding prevention in fetchWithTimeout', asyn
     const { url: normalizedUrl, hostname, publicIps } = await normalizeTargetUrl(maliciousUrl);
 
     // Verify initial validation passed and public IP was resolved
-    assert.deepStrictEqual(publicIps, [publicIp], 'normalizeTargetUrl should return the public IP after initial DNS lookup');
+    assert.deepStrictEqual(publicIps, [publicIp, fallbackPublicIp], 'normalizeTargetUrl should return all validated public IPs after initial DNS lookup');
     assert.strictEqual(hostname, maliciousHost, 'hostname should be preserved');
 
 
@@ -129,16 +141,17 @@ test('SSRF vulnerability via DNS Rebinding prevention in fetchWithTimeout', asyn
     const response = await fetchWithTimeout(normalizedUrl, hostname, publicIps);
 
     // Assert that https.request was indeed called with the public IP
-    assert.ok(requestOptionsUsed, 'https.request should have been called');
+    assert.strictEqual(requestOptionsUsed.length, 2, 'https.request should retry the next validated IP after a connection failure');
+    assert.deepStrictEqual(requestOptionsUsed.map((options) => options.host), [publicIp, fallbackPublicIp], 'https.request should try validated IPs in resolution order');
     assert.ok(response.ok, 'fetchWithTimeout should return ok response');
     const icsText = await response.text();
     assert.ok(icsText.includes('BEGIN:VCALENDAR'), 'ICS text should be present');
 
     // Test redirect handling: fetchWithTimeout should reject redirects
     // Re-configure mocks for redirect test
-    requestOptionsUsed = null;
+    requestOptionsUsed.length = 0;
     mockHttps.request = (options, callback) => {
-      requestOptionsUsed = options;
+      requestOptionsUsed.push(options);
       assert.strictEqual(options.host, publicIp, 'HTTPS request for redirect should connect to pre-validated IP');
 
       const mockResponse = new http.IncomingMessage(new net.Socket());

--- a/functions/test/ssrf.test.js
+++ b/functions/test/ssrf.test.js
@@ -4,8 +4,15 @@ import { promises as dns } from 'node:dns';
 import * as https from 'node:https';
 import * as http from 'node:http';
 import * as net from 'node:net';
+import { EventEmitter } from 'node:events';
 import * as securityUtils from '../utils/security-utils.js';
 const { fetchWithTimeout, normalizeTargetUrl, assertPublicHost, isPrivateIpAddress, _setClientModulesForTesting } = securityUtils;
+
+function createMockRequest() {
+  const mockRequest = new EventEmitter();
+  mockRequest.end = () => {};
+  return mockRequest;
+}
 
 test('isPrivateIpAddress correctly identifies private IPs', () => {
   assert.strictEqual(isPrivateIpAddress('10.0.0.1'), true, '10.0.0.1 should be private');
@@ -71,7 +78,7 @@ test('fetchWithTimeout uses validated IPs and falls back across failures', async
         mockResponse.statusCode = 200;
         mockResponse.statusMessage = 'OK';
         mockResponse.headers = { 'content-type': 'text/calendar' };
-        const mockRequest = new http.ClientRequest(options);
+        const mockRequest = createMockRequest();
         setImmediate(() => {
           callback(mockResponse);
           mockResponse.emit('data', 'BEGIN:VCALENDAR\nSUMMARY:Test Event\nEND:VCALENDAR');
@@ -86,7 +93,7 @@ test('fetchWithTimeout uses validated IPs and falls back across failures', async
         assert.ok([publicIp, fallbackPublicIp].includes(options.host), 'HTTPS request should connect only to validated public IPs');
         assert.strictEqual(options.servername, maliciousHost, 'HTTPS request should use original hostname for SNI');
         assert.strictEqual(options.headers['Host'], maliciousHost, 'HTTPS request should use original hostname in Host header');
-        const mockRequest = new http.ClientRequest(options);
+        const mockRequest = createMockRequest();
 
         if (options.host === publicIp) {
           setImmediate(() => {
@@ -159,7 +166,7 @@ test('fetchWithTimeout uses validated IPs and falls back across failures', async
       mockResponse.statusMessage = 'Found';
       mockResponse.headers = { 'location': 'https://new.example.com/redirected.ics' };
 
-      const mockRequest = new http.ClientRequest(options);
+      const mockRequest = createMockRequest();
       setImmediate(() => {
         callback(mockResponse);
         mockResponse.emit('end');

--- a/functions/utils/security-utils.js
+++ b/functions/utils/security-utils.js
@@ -157,8 +157,9 @@ async function normalizeTargetUrl(rawUrl) {
 
 async function fetchWithTimeout(url, originalHostname, publicIps, timeoutMs = 12000) {
   const controller = new AbortController();
+  let timeoutId = null;
   const timeoutPromise = new Promise((_, reject) => {
-    const timeoutId = setTimeout(() => {
+    timeoutId = setTimeout(() => {
       controller.abort();
       reject(new Error('Calendar request timed out'));
     }, timeoutMs);
@@ -172,57 +173,75 @@ async function fetchWithTimeout(url, originalHostname, publicIps, timeoutMs = 12
   if (!publicIps || publicIps.length === 0) {
     throw new Error('No public IPs provided for fetch connection after validation.');
   }
-  const targetIp = publicIps[0];
 
-  const requestOptions = {
-    method: 'GET',
-    headers: {
-      'User-Agent': 'allplays-calendar-fetch/1.0',
-      'Accept': 'text/calendar,text/plain,*/*',
-      'Host': originalHostname,
-    },
-    signal: controller.signal,
-    host: targetIp,
-    port: parsedUrl.port || (isHttps ? 443 : 80),
-    path: parsedUrl.pathname + parsedUrl.search + parsedUrl.hash,
-    servername: originalHostname,
-    maxRedirects: 0,
+  const fetchAttempt = async (targetIp) => new Promise((resolve, reject) => {
+    const requestOptions = {
+      method: 'GET',
+      headers: {
+        'User-Agent': 'allplays-calendar-fetch/1.0',
+        'Accept': 'text/calendar,text/plain,*/*',
+        'Host': originalHostname,
+      },
+      signal: controller.signal,
+      host: targetIp,
+      port: parsedUrl.port || (isHttps ? 443 : 80),
+      path: parsedUrl.pathname + parsedUrl.search + parsedUrl.hash,
+      servername: originalHostname,
+      maxRedirects: 0,
+    };
+
+    const req = clientModule.request(requestOptions, (res) => {
+      if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+        return resolve({
+          ok: false,
+          status: res.statusCode,
+          statusText: res.statusMessage,
+          text: () => Promise.resolve(`Redirect to ${res.headers.location}`),
+        });
+      }
+
+      let data = '';
+      res.on('data', (chunk) => {
+        data += chunk;
+      });
+      res.on('end', () => {
+        resolve({
+          ok: res.statusCode >= 200 && res.statusCode < 300,
+          status: res.statusCode,
+          statusText: res.statusMessage,
+          text: () => Promise.resolve(data),
+        });
+      });
+    });
+
+    req.on('error', (err) => {
+      reject(new Error(`Calendar fetch failed: ${err.message || 'Unknown network error'}`));
+    });
+
+    req.end();
+  });
+
+  const fetchAllAttempts = async () => {
+    let lastError = null;
+
+    for (const targetIp of publicIps) {
+      try {
+        return await fetchAttempt(targetIp);
+      } catch (error) {
+        if (controller.signal.aborted) {
+          throw error;
+        }
+        lastError = error;
+      }
+    }
+
+    throw lastError || new Error('Calendar fetch failed: Unknown network error');
   };
 
-  return Promise.race([
-    new Promise((resolve, reject) => {
-      const req = clientModule.request(requestOptions, (res) => {
-        if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-          return resolve({
-            ok: false,
-            status: res.statusCode,
-            statusText: res.statusMessage,
-            text: () => Promise.resolve(`Redirect to ${res.headers.location}`),
-          });
-        }
-
-        let data = '';
-        res.on('data', (chunk) => {
-          data += chunk;
-        });
-        res.on('end', () => {
-          resolve({
-            ok: res.statusCode >= 200 && res.statusCode < 300,
-            status: res.statusCode,
-            statusText: res.statusMessage,
-            text: () => Promise.resolve(data),
-          });
-        });
-      });
-
-      req.on('error', (err) => {
-        reject(new Error(`Calendar fetch failed: ${err.message || 'Unknown network error'}`));
-      });
-
-      req.end();
-    }),
-    timeoutPromise,
-  ]).finally(() => {
+  return Promise.race([fetchAllAttempts(), timeoutPromise]).finally(() => {
+    if (timeoutId) {
+      clearTimeout(timeoutId);
+    }
   });
 }
 


### PR DESCRIPTION
Closes #1757

## What changed
- updated `fetchWithTimeout` to try each validated public IP in resolution order instead of hard-coding the first address only
- preserved the existing SSRF protections by continuing to connect only to pre-validated public IPs while keeping the original hostname for Host header and SNI
- added a regression test that fails the first connection attempt and verifies the fetch succeeds on the next validated IP

## Why
Some calendar hosts resolve to multiple public addresses. If the first address is unreachable from the Cloud Function but a later validated address works, imports should still succeed instead of failing immediately.