### PR TITLE
Restrict athlete profile media reads

### DIFF
--- a/storage.rules
+++ b/storage.rules
@@ -72,12 +72,9 @@ service firebase.storage {
 
     function canReadAthleteProfileMedia(userId, profileId) {
       let profilePath = /databases/(default)/documents/athleteProfiles/$(profileId);
-      return isSignedIn() &&
-        (
-          request.auth.uid == userId ||
-          (firestore.exists(profilePath) &&
-           firestore.get(profilePath).data.get('privacy', 'private') == 'public')
-        );
+      return (isSignedIn() && request.auth.uid == userId) ||
+        (firestore.exists(profilePath) &&
+         firestore.get(profilePath).data.get('privacy', 'private') == 'public');
     }
 
     match /team-media/{teamId}/{folderId}/{userId}/{fileName} {

--- a/storage.rules
+++ b/storage.rules
@@ -70,6 +70,16 @@ service firebase.storage {
         contentType.matches('video/.*');
     }
 
+    function canReadAthleteProfileMedia(userId, profileId) {
+      let profilePath = /databases/(default)/documents/athleteProfiles/$(profileId);
+      return isSignedIn() &&
+        (
+          request.auth.uid == userId ||
+          (firestore.exists(profilePath) &&
+           firestore.get(profilePath).data.get('privacy', 'private') == 'public')
+        );
+    }
+
     match /team-media/{teamId}/{folderId}/{userId}/{fileName} {
       allow get: if canAccessTeamMedia(teamId);
       allow list: if false;
@@ -104,7 +114,7 @@ service firebase.storage {
     }
 
     match /athlete-profile-media/{userId}/{profileId}/{fileName} {
-      allow get: if isSignedIn();
+      allow get: if canReadAthleteProfileMedia(userId, profileId);
       allow list: if false;
       allow create: if isSignedIn() &&
         request.auth.uid == userId &&

--- a/tests/unit/athlete-profile-storage-rules.test.js
+++ b/tests/unit/athlete-profile-storage-rules.test.js
@@ -27,7 +27,7 @@ function canGetAthleteProfileMedia({ authUid, userId, profilePrivacy = 'private'
     const isOwner = authUid === userId;
     const isPublicProfile = profileExists && profilePrivacy === 'public';
 
-    return signedIn && (isOwner || isPublicProfile);
+    return (signedIn && isOwner) || isPublicProfile;
 }
 
 function canDeleteAthleteProfileMedia({ authUid, userId }) {
@@ -102,6 +102,20 @@ describe('athlete profile Storage rules', () => {
             userId: 'parent-1',
             profilePrivacy: 'public',
             profileExists: false
+        })).toBe(false);
+    });
+
+    it('allows logged-out viewers to read media for public athlete profiles only', () => {
+        expect(canGetAthleteProfileMedia({
+            authUid: null,
+            userId: 'parent-1',
+            profilePrivacy: 'public'
+        })).toBe(true);
+
+        expect(canGetAthleteProfileMedia({
+            authUid: null,
+            userId: 'parent-1',
+            profilePrivacy: 'private'
         })).toBe(false);
     });
 

--- a/tests/unit/athlete-profile-storage-rules.test.js
+++ b/tests/unit/athlete-profile-storage-rules.test.js
@@ -22,6 +22,14 @@ function canCreateAthleteProfileMedia({ authUid, userId, size, contentType }) {
     return signedIn && pathOwnerAllowed && hasAllowedSize && hasAllowedContentType;
 }
 
+function canGetAthleteProfileMedia({ authUid, userId, profilePrivacy = 'private', profileExists = true }) {
+    const signedIn = authUid !== null;
+    const isOwner = authUid === userId;
+    const isPublicProfile = profileExists && profilePrivacy === 'public';
+
+    return signedIn && (isOwner || isPublicProfile);
+}
+
 function canDeleteAthleteProfileMedia({ authUid, userId }) {
     const signedIn = authUid !== null;
     const deleteRuleStart = mediaRules.indexOf('allow delete:');
@@ -34,8 +42,9 @@ function canDeleteAthleteProfileMedia({ authUid, userId }) {
 }
 
 describe('athlete profile Storage rules', () => {
-    it('allows signed-in profile owners to upload image/video media within limits', () => {
-        expect(mediaRules).toContain('allow get: if isSignedIn();');
+    it('allows profile owners to read and upload image/video media within limits', () => {
+        expect(rules).toContain('function canReadAthleteProfileMedia(userId, profileId)');
+        expect(mediaRules).toContain('allow get: if canReadAthleteProfileMedia(userId, profileId);');
         expect(mediaRules).toContain('allow list: if false;');
         expect(mediaRules).toContain('allow create: if isSignedIn() &&');
         expect(mediaRules).toContain('request.auth.uid == userId');
@@ -45,6 +54,11 @@ describe('athlete profile Storage rules', () => {
         expect(mediaRules).toContain('allow delete: if isSignedIn() && request.auth.uid == userId;');
         expect(mediaRules).toContain('allow update: if false;');
 
+        expect(canGetAthleteProfileMedia({
+            authUid: 'parent-1',
+            userId: 'parent-1'
+        })).toBe(true);
+
         expect(canCreateAthleteProfileMedia({
             authUid: 'parent-1',
             userId: 'parent-1',
@@ -53,7 +67,16 @@ describe('athlete profile Storage rules', () => {
         })).toBe(true);
     });
 
-    it('denies profile media uploads and deletes for another user path', () => {
+    it('denies unrelated signed-in users from reading private profile media', () => {
+        expect(rules).toContain("firestore.exists(profilePath)");
+        expect(rules).toContain("firestore.get(profilePath).data.get('privacy', 'private') == 'public'");
+
+        expect(canGetAthleteProfileMedia({
+            authUid: 'parent-2',
+            userId: 'parent-1',
+            profilePrivacy: 'private'
+        })).toBe(false);
+
         expect(canCreateAthleteProfileMedia({
             authUid: 'parent-2',
             userId: 'parent-1',
@@ -64,6 +87,21 @@ describe('athlete profile Storage rules', () => {
         expect(canDeleteAthleteProfileMedia({
             authUid: 'parent-2',
             userId: 'parent-1'
+        })).toBe(false);
+    });
+
+    it('allows public athlete profile media reads for non-owners', () => {
+        expect(canGetAthleteProfileMedia({
+            authUid: 'viewer-1',
+            userId: 'parent-1',
+            profilePrivacy: 'public'
+        })).toBe(true);
+
+        expect(canGetAthleteProfileMedia({
+            authUid: 'viewer-1',
+            userId: 'parent-1',
+            profilePrivacy: 'public',
+            profileExists: false
         })).toBe(false);
     });
 


### PR DESCRIPTION
Closes #1761

## What changed
- tightened `athlete-profile-media` Storage reads so files are no longer readable by any signed-in user
- added a dedicated Storage helper that allows reads only for the profile owner or when the linked `athleteProfiles/{profileId}` document is public
- updated the focused unit test to cover owner access, denial for unrelated signed-in users on private profiles, and allowed reads for public profiles

## Why
The previous Storage rule allowed any authenticated user to fetch athlete profile media directly if they had a path or durable URL. This change aligns Storage access with the Firestore privacy model so private athlete media stays private while public profile rendering still works.