### PR TITLE
Avoid duplicate calendar game reads

### DIFF
--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -12,7 +12,6 @@ import {
   getTeams,
   addGame,
   addPractice,
-  getTrackedCalendarEventUids,
   createRideOffer,
   claimAssignmentSlot,
   requestRideSpot,
@@ -1001,6 +1000,12 @@ function makeEventKey(teamId: string, id: string, childId: string, date: Date, t
   return `${teamId}::${id}::${childId}::${date.toISOString()}::${type}`;
 }
 
+function getTrackedCalendarEventUidsFromLoadedGames(games: any[] = []) {
+  return (Array.isArray(games) ? games : [])
+    .map((game) => compactString(game?.calendarEventUid))
+    .filter(Boolean);
+}
+
 async function loadTeam(teamId: string) {
   const team = await readWithNativeFallback(
     `team ${teamId}`,
@@ -1320,13 +1325,13 @@ function createScheduleEvent(input: {
 
 async function buildTeamSchedule(teamId: string, teamChildren: ParentScheduleChild[], user: AuthUser) {
   const events: ParentScheduleEvent[] = [];
-  const [team, dbGames, trackedUids, practiceSessions] = await Promise.all([
+  const [team, dbGames, practiceSessions] = await Promise.all([
     loadTeam(teamId),
     loadGames(teamId),
-    getTrackedCalendarEventUids(teamId).catch(() => []),
     loadPracticeSessions(teamId)
   ]);
   if (!team) return events;
+  const trackedUids = getTrackedCalendarEventUidsFromLoadedGames(dbGames || []);
 
   const teamName = compactString(team.name) || teamId;
   const teamWithId = { ...team, id: team.id || teamId };

--- a/calendar.html
+++ b/calendar.html
@@ -141,7 +141,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvpSummaries, getRsvps } from './js/db.js?v=32';
+        import { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvpSummaries, getRsvps } from './js/db.js?v=33';
         import { renderHeader, renderFooter, escapeHtml, formatDate, formatTime, fetchAndParseCalendar, expandRecurrence, buildGlobalCalendarIcsEvent, isTrackedCalendarEvent } from './js/utils.js?v=13';
         import { mergeGlobalCalendarIcsEvents } from './js/calendar-ics-sync.js?v=1';
         import { requireAuth, checkAuth } from './js/auth.js?v=15';
@@ -404,7 +404,7 @@
                     // Load ICS calendar events
                     const calendarUrls = Array.isArray(team.calendarUrls) ? team.calendarUrls : [];
                     if (calendarUrls.length > 0) {
-                        const trackedUids = await getTrackedCalendarEventUids(team.id);
+                        const trackedUids = await getTrackedCalendarEventUids(team.id, games);
                         for (const calUrl of calendarUrls) {
                             try {
                                 const icsEvents = await fetchAndParseCalendar(calUrl);

--- a/js/db.js
+++ b/js/db.js
@@ -2872,11 +2872,15 @@ export async function removeCalendarFromTeam(teamId, calendarUrl) {
     await updateTeam(teamId, { calendarUrls });
 }
 
-export async function getTrackedCalendarEventUids(teamId) {
-    const games = await getGames(teamId);
+export function getTrackedCalendarEventUidsFromGames(games = []) {
     return games
         .filter(game => game.calendarEventUid)
         .map(game => game.calendarEventUid);
+}
+
+export async function getTrackedCalendarEventUids(teamId, preloadedGames = null) {
+    const games = Array.isArray(preloadedGames) ? preloadedGames : await getGames(teamId);
+    return getTrackedCalendarEventUidsFromGames(games);
 }
 
 // Access Codes

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -324,6 +324,8 @@ describe('React app schedule service contract integration', () => {
         expect(profileMocks.loadProfileDocument).toHaveBeenCalledWith('user-1');
         expect(dbMocks.getTeam).toHaveBeenCalledWith('team-1');
         expect(dbMocks.getGames).toHaveBeenCalledWith('team-1');
+        expect(dbMocks.getGames).toHaveBeenCalledTimes(1);
+        expect(dbMocks.getTrackedCalendarEventUids).not.toHaveBeenCalled();
         expect(dbMocks.getPracticeSessions).toHaveBeenCalledWith('team-1');
         expect(utilsMocks.fetchAndParseCalendar).toHaveBeenCalledWith('mock://team-calendar');
         expect(dbMocks.getRsvpSummaries).toHaveBeenCalledWith('team-1', expect.arrayContaining(['game-1', 'practice-1', 'final-1']));

--- a/tests/unit/calendar-day-modal-rsvp.test.js
+++ b/tests/unit/calendar-day-modal-rsvp.test.js
@@ -88,7 +88,7 @@ const URL = deps.URL;
 const Blob = deps.Blob;
 ` + match[1]
         .replace(
-            "import { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvpSummaries, getRsvps } from './js/db.js?v=32';",
+            "import { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvpSummaries, getRsvps } from './js/db.js?v=33';",
             'const { getUserTeamsWithAccess, getParentTeams, getGames, getTeam, getTrackedCalendarEventUids, getUserProfile, submitRsvp, submitRsvpForPlayer, getMyRsvp, getRsvpSummaries, getRsvps } = deps.db;'
         )
         .replace(

--- a/tests/unit/calendar-shared-sync.test.js
+++ b/tests/unit/calendar-shared-sync.test.js
@@ -6,6 +6,13 @@ function readCalendarPage() {
 }
 
 describe('global calendar ICS sync helper', () => {
+    it('reuses the loaded game list when resolving tracked calendar UIDs', () => {
+        const source = readCalendarPage();
+
+        expect(source).toContain('const games = await getGames(team.id);');
+        expect(source).toContain('const trackedUids = await getTrackedCalendarEventUids(team.id, games);');
+    });
+
     it('suppresses tracked ICS events while keeping distinct same-slot imports', async () => {
         const { mergeGlobalCalendarIcsEvents } = await import('../../js/calendar-ics-sync.js');
 


### PR DESCRIPTION
Closes #1760

## Summary
- reuse already-loaded games when resolving tracked ICS calendar UIDs in the React schedule service
- pass preloaded games into the legacy calendar tracked UID helper
- add focused regressions for app and legacy calendar wiring

## Tests
- npx vitest run tests/unit/app-schedule-service-contracts.test.js tests/unit/calendar-shared-sync.test.js --reporter=verbose

## Local build note
- npm run app:build currently fails before this change because @capacitor/camera is declared but not installed in this workspace node_modules.