### PR TITLE
Reuse cached Home schedule during secondary refresh

### DIFF
--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -8,7 +8,12 @@ import {
   type ParentHomeModel
 } from './homeLogic';
 import { loadCachedAppData } from './appDataCache';
-import { loadParentSchedule, type ParentScheduleChild, type ParentScheduleLoadResult } from './scheduleService';
+import {
+  hydrateParentScheduleDetails,
+  loadParentSchedule,
+  type ParentScheduleChild,
+  type ParentScheduleLoadResult
+} from './scheduleService';
 import type { AuthUser } from './types';
 
 const homeSummaryTtlMs = 45 * 1000;
@@ -41,17 +46,32 @@ export async function loadParentHome(user: AuthUser | null): Promise<ParentHomeM
 }
 
 export async function loadParentHomeSummary(user: AuthUser | null, options: { force?: boolean } = {}): Promise<ParentHomeModel> {
+  const summary = await loadParentHomeSummaryBootstrap(user, options);
+  return summary.home;
+}
+
+export async function loadParentHomeSummaryBootstrap(
+  user: AuthUser | null,
+  options: { force?: boolean } = {}
+): Promise<{ home: ParentHomeModel; schedule: ParentScheduleLoadResult }> {
   if (!user?.uid) {
-    return buildParentHomeModel({ children: [], events: [], inboxTeams: [], fees: [] });
+    const schedule = { children: [], events: [] };
+    return {
+      home: buildParentHomeModel({ children: [], events: [], inboxTeams: [], fees: [] }),
+      schedule
+    };
   }
 
   const schedule = await loadParentScheduleSummary(user, options);
-  return buildParentHomeModel({
-    children: schedule.children,
-    events: schedule.events,
-    inboxTeams: [],
-    fees: []
-  });
+  return {
+    home: buildParentHomeModel({
+      children: schedule.children,
+      events: schedule.events,
+      inboxTeams: [],
+      fees: []
+    }),
+    schedule
+  };
 }
 
 export async function loadParentTeamsSummary(user: AuthUser | null, options: { force?: boolean } = {}): Promise<ParentHomeModel> {
@@ -90,14 +110,18 @@ export async function loadParentTeamsSummary(user: AuthUser | null, options: { f
   );
 }
 
-export async function loadParentHomeWithSecondaryData(user: AuthUser | null, options: { force?: boolean } = {}): Promise<ParentHomeModel> {
+export async function loadParentHomeWithSecondaryData(
+  user: AuthUser | null,
+  options: { force?: boolean; schedule?: ParentScheduleLoadResult } = {}
+): Promise<ParentHomeModel> {
   if (!user?.uid) {
     return buildParentHomeModel({ children: [], events: [], inboxTeams: [], fees: [] });
   }
 
   const cacheKey = `home-secondary:${user.uid}`;
   return loadCachedAppData(cacheKey, async () => {
-    const schedule = await loadParentSchedule(user, { hydrateDetails: true });
+    const schedule = options.schedule || await loadParentScheduleSummary(user, { force: options.force });
+    await hydrateParentScheduleDetails(schedule, user);
     const [chatInbox, rawFees] = await Promise.all([
       loadChatInbox(user).catch((error) => {
         console.warn('[home-service] Unable to load chat inbox:', error);

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1725,6 +1725,14 @@ async function hydrateEventDetails(events: ParentScheduleEvent[], user: AuthUser
   return events;
 }
 
+export async function hydrateParentScheduleDetails(schedule: ParentScheduleLoadResult, user: AuthUser | null): Promise<ParentScheduleLoadResult> {
+  if (!user?.uid || !schedule.events.length) {
+    return schedule;
+  }
+  await hydrateEventDetails(schedule.events, user);
+  return schedule;
+}
+
 async function buildParentScheduleTeamChildren(user: AuthUser, profile: Record<string, unknown>, options: ParentScheduleLoadOptions = {}) {
   const expandStaffPlayers = options.expandStaffPlayers !== false;
   const children = normalizeChildLinks(user, profile as Record<string, unknown>);

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -26,7 +26,7 @@ import {
   Users,
   type LucideIcon
 } from 'lucide-react';
-import { loadParentHomeSummary, loadParentHomeWithSecondaryData } from '../lib/homeService';
+import { loadParentHomeSummaryBootstrap, loadParentHomeWithSecondaryData } from '../lib/homeService';
 import {
   blockFriend,
   commentOnSocialPost,
@@ -146,11 +146,11 @@ export function Home({ auth }: { auth: AuthState }) {
     setError('');
     setSocialStatus(null);
     try {
-      const nextHome = await loadParentHomeSummary(auth.user, { force });
+      const { home: nextHome, schedule } = await loadParentHomeSummaryBootstrap(auth.user, { force });
       setHome(nextHome);
       setLoading(false);
 
-      void loadParentHomeWithSecondaryData(auth.user, { force })
+      void loadParentHomeWithSecondaryData(auth.user, { force, schedule })
         .then(async (secondaryHome) => {
           setHome(secondaryHome);
           setSocial(await loadSocialHome(auth.user, secondaryHome));

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -312,6 +312,10 @@ async function mockAppModules(page, { user = null, emailLink = false } = {}) {
                     return { children: [], events: [] };
                 }
 
+                export async function hydrateParentScheduleDetails(schedule) {
+                    return schedule;
+                }
+
                 export async function loadParentPracticePacket() {
                     return null;
                 }

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -79,6 +79,11 @@ async function mockHomePlayerModules(page) {
                     return loadParentHome(...args);
                 }
 
+                export async function loadParentHomeSummaryBootstrap(...args) {
+                    const home = await loadParentHome(...args);
+                    return { home, schedule: [] };
+                }
+
                 export async function loadParentTeamsSummary(...args) {
                     return loadParentHome(...args);
                 }

--- a/tests/smoke/app-private-ai.spec.js
+++ b/tests/smoke/app-private-ai.spec.js
@@ -51,6 +51,11 @@ async function mockPrivateAiModules(page) {
                     return loadParentHome(...args);
                 }
 
+                export async function loadParentHomeSummaryBootstrap(...args) {
+                    const home = await loadParentHome(...args);
+                    return { home, schedule: [] };
+                }
+
                 export async function loadParentHomeWithSecondaryData(...args) {
                     return loadParentHome(...args);
                 }

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -327,6 +327,10 @@ async function mockScheduleModules(page, options = {}) {
                     };
                 }
 
+                export async function hydrateParentScheduleDetails(schedule) {
+                    return schedule;
+                }
+
                 export async function loadParentScheduleEventDetail(user, { teamId, eventId }) {
                     const result = await loadParentSchedule(user);
                     return {

--- a/tests/unit/app-home-player-integration.test.jsx
+++ b/tests/unit/app-home-player-integration.test.jsx
@@ -7,6 +7,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 const homeMocks = vi.hoisted(() => ({
     loadParentHome: vi.fn(),
     loadParentHomeSummary: vi.fn(),
+    loadParentHomeSummaryBootstrap: vi.fn(),
     loadParentHomeWithSecondaryData: vi.fn()
 }));
 
@@ -223,6 +224,10 @@ beforeEach(() => {
     window.URL.revokeObjectURL = vi.fn();
     window.scrollTo = vi.fn();
     homeMocks.loadParentHomeSummary.mockImplementation((user) => homeMocks.loadParentHome(user));
+    homeMocks.loadParentHomeSummaryBootstrap.mockImplementation(async (user) => ({
+        home: await homeMocks.loadParentHome(user),
+        schedule: { children: [], events: [] }
+    }));
     homeMocks.loadParentHomeWithSecondaryData.mockImplementation((user) => homeMocks.loadParentHome(user));
 
     const nextEvent = event({ id: 'game-next', opponent: 'Falcons' });

--- a/tests/unit/app-home-service.test.js
+++ b/tests/unit/app-home-service.test.js
@@ -3,7 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { clearAppDataCache } from '../../apps/app/src/lib/appDataCache.ts';
 
 const scheduleMocks = vi.hoisted(() => ({
-    loadParentSchedule: vi.fn()
+    loadParentSchedule: vi.fn(),
+    hydrateParentScheduleDetails: vi.fn((schedule) => Promise.resolve(schedule))
 }));
 
 const chatMocks = vi.hoisted(() => ({
@@ -191,7 +192,7 @@ describe('React app Home service', () => {
         expect(home.fees).toEqual([]);
     });
 
-    it('loads detailed schedule data for the secondary Home refresh', async () => {
+    it('reuses one base schedule load across summary and secondary Home refresh', async () => {
         scheduleMocks.loadParentSchedule.mockImplementation((_, options = {}) => Promise.resolve({
             children: [
                 {
@@ -201,24 +202,26 @@ describe('React app Home service', () => {
                     playerName: 'Pat Star'
                 }
             ],
-            events: [event(options.hydrateDetails === false ? {
+            events: [event({
                 assignments: [{ role: 'Snacks', claimable: true }],
                 myRsvp: 'not_responded'
-            } : {
-                assignments: [{ role: 'Snacks', claimable: true, claim: { claimedByUserId: 'other-parent' } }],
-                myRsvp: 'going'
             })]
         }));
-        const { loadParentHomeSummary, loadParentHomeWithSecondaryData } = await import('../../apps/app/src/lib/homeService.ts');
+        const { loadParentHomeSummaryBootstrap, loadParentHomeWithSecondaryData } = await import('../../apps/app/src/lib/homeService.ts');
 
-        const summary = await loadParentHomeSummary(user, { force: true });
-        const detailed = await loadParentHomeWithSecondaryData(user, { force: true });
+        const summary = await loadParentHomeSummaryBootstrap(user, { force: true });
+        const detailed = await loadParentHomeWithSecondaryData(user, { force: true, schedule: summary.schedule });
 
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(1, user, { hydrateDetails: false, expandStaffPlayers: false });
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(2, user, { hydrateDetails: true });
-        expect(summary.actionItems.map((item) => item.kind)).toEqual(expect.arrayContaining(['rsvp', 'assignment']));
-        expect(detailed.actionItems.map((item) => item.kind)).not.toEqual(expect.arrayContaining(['rsvp', 'assignment']));
-        expect(detailed.metrics.rsvpNeeded).toBe(0);
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(1);
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledWith(user, { hydrateDetails: false, expandStaffPlayers: false });
+        expect(scheduleMocks.hydrateParentScheduleDetails).toHaveBeenCalledTimes(1);
+        expect(scheduleMocks.hydrateParentScheduleDetails).toHaveBeenCalledWith(expect.objectContaining({
+            children: [expect.objectContaining({ teamId: 'team-1', playerId: 'player-1' })],
+            events: [expect.objectContaining({ id: 'game-1' })]
+        }), user);
+        expect(summary.home.actionItems.map((item) => item.kind)).toEqual(expect.arrayContaining(['rsvp', 'assignment']));
+        expect(detailed.actionItems.map((item) => item.kind)).toEqual(expect.arrayContaining(['rsvp', 'assignment']));
+        expect(detailed.metrics.rsvpNeeded).toBe(1);
     });
 
     it('returns an empty model without touching Firebase when signed out', async () => {


### PR DESCRIPTION
Closes #1769

## What changed
- added a Home bootstrap path that returns both the fast Home model and the already-fetched parent schedule
- changed the secondary Home refresh to reuse that schedule and hydrate it in place instead of rebuilding the full parent schedule a second time
- exposed a schedule-service helper for hydrating existing parent schedule results and updated Home regression coverage

## Why
Home was doing one schedule-backed pass for the fast render and then immediately doing a second full parent schedule traversal for secondary enrichment. This keeps the fast first render, preserves the secondary enrichment path, and removes the duplicate base schedule rebuild on open and refresh.

## Validation
- `npx vitest run tests/unit/app-home-service.test.js tests/unit/app-home-player-integration.test.jsx --reporter=verbose`