### PR TITLE
Drain due pre-event reminder backlog per scheduler run

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -66,6 +66,12 @@ const {
   shouldStopRegistrationPaymentReminders
 } = require('./registration-payment-reminders-core.cjs');
 const { validateAccessCodeCandidates } = require('./access-code-validation.cjs');
+const {
+  PRE_EVENT_REMINDER_QUERY_PAGE_SIZE,
+  PRE_EVENT_REMINDER_MAX_PAGES_PER_RUN,
+  PRE_EVENT_REMINDER_MAX_RUNTIME_MS,
+  drainDueReminderPages
+} = require('./pre-event-reminder-dispatcher-core.cjs');
 
 if (admin.apps.length === 0) {
   admin.initializeApp();
@@ -3143,71 +3149,85 @@ async function markReminderPendingAfterFailure(eventRef, claimId, error) {
 }
 
 async function dispatchDuePreEventReminders(now = new Date()) {
-  const dueIso = now.toISOString();
-  const dueSnap = await firestore
-    .collectionGroup('games')
-    .where('scheduleNotifications.nextReminderAt', '<=', dueIso)
-    .limit(50)
-    .get();
-
-  const results = [];
-  for (const docSnap of dueSnap.docs) {
-    const eventRef = docSnap.ref;
-    const teamRef = eventRef.parent?.parent;
-    const teamId = teamRef?.id;
-    const gameId = eventRef.id;
-    if (!teamId) continue;
-
-    const claimId = `pre-event-${Date.now()}-${Math.random().toString(36).slice(2)}`;
-    const claimedEvent = await markReminderSending(eventRef, claimId, now);
-    if (!claimedEvent) continue;
-
-    try {
-      const payload = buildPreEventReminderPayload({ teamId, gameId, event: claimedEvent });
-      let chatResult = { messageId: null, created: false };
-      let chatMessageError = null;
-      try {
-        chatResult = await postPreEventReminderChatMessage({ teamId, gameId, event: claimedEvent, payload });
-      } catch (chatError) {
-        chatMessageError = chatError;
-        console.error('Failed to write pre-event reminder chat fallback', { teamId, gameId, error: chatError });
+  const drainSummary = await drainDueReminderPages({
+    now,
+    maxPages: PRE_EVENT_REMINDER_MAX_PAGES_PER_RUN,
+    maxRuntimeMs: PRE_EVENT_REMINDER_MAX_RUNTIME_MS,
+    loadPage: async ({ dueIso, cursor, limit }) => {
+      let query = firestore
+        .collectionGroup('games')
+        .where('scheduleNotifications.nextReminderAt', '<=', dueIso)
+        .orderBy('scheduleNotifications.nextReminderAt')
+        .limit(limit || PRE_EVENT_REMINDER_QUERY_PAGE_SIZE);
+      if (cursor) {
+        query = query.startAfter(cursor);
       }
+      const dueSnap = await query.get();
+      return {
+        docs: dueSnap.docs,
+        nextCursor: dueSnap.docs[dueSnap.docs.length - 1] || null
+      };
+    },
+    processReminder: async (docSnap) => {
+      const eventRef = docSnap.ref;
+      const teamRef = eventRef.parent?.parent;
+      const teamId = teamRef?.id;
+      const gameId = eventRef.id;
+      if (!teamId) return null;
 
-      const sendResult = await sendCategoryNotification({
-        teamId,
-        gameId,
-        eventId: gameId,
-        category: 'schedule',
-        title: payload.title,
-        body: payload.body,
-        linkOverride: payload.link
-      });
-      const emailResult = await createPublicRsvpEmailDeliveries({
-        teamId,
-        gameId,
-        actorUid: 'scheduled-reminder'
-      });
-      await markReminderSent(eventRef, claimId, {
-        ...sendResult,
-        chatMessageId: chatResult.messageId,
-        chatMessageCreated: chatResult.created,
-        chatMessageError: chatMessageError?.message || null,
-        rsvpEmailCount: emailResult.sentCount
-      });
-      results.push({
-        teamId,
-        gameId,
-        sent: Number(sendResult?.successCount || 0),
-        chatMessageId: chatResult.messageId,
-        chatMessageCreated: chatResult.created,
-        rsvpEmailCount: emailResult.sentCount
-      });
-    } catch (error) {
-      await markReminderPendingAfterFailure(eventRef, claimId, error);
-      console.error('Failed to dispatch pre-event reminder', { teamId, gameId, error });
+      const claimId = `pre-event-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+      const claimedEvent = await markReminderSending(eventRef, claimId, now);
+      if (!claimedEvent) return null;
+
+      try {
+        const payload = buildPreEventReminderPayload({ teamId, gameId, event: claimedEvent });
+        let chatResult = { messageId: null, created: false };
+        let chatMessageError = null;
+        try {
+          chatResult = await postPreEventReminderChatMessage({ teamId, gameId, event: claimedEvent, payload });
+        } catch (chatError) {
+          chatMessageError = chatError;
+          console.error('Failed to write pre-event reminder chat fallback', { teamId, gameId, error: chatError });
+        }
+
+        const sendResult = await sendCategoryNotification({
+          teamId,
+          gameId,
+          eventId: gameId,
+          category: 'schedule',
+          title: payload.title,
+          body: payload.body,
+          linkOverride: payload.link
+        });
+        const emailResult = await createPublicRsvpEmailDeliveries({
+          teamId,
+          gameId,
+          actorUid: 'scheduled-reminder'
+        });
+        await markReminderSent(eventRef, claimId, {
+          ...sendResult,
+          chatMessageId: chatResult.messageId,
+          chatMessageCreated: chatResult.created,
+          chatMessageError: chatMessageError?.message || null,
+          rsvpEmailCount: emailResult.sentCount
+        });
+        return {
+          teamId,
+          gameId,
+          sent: Number(sendResult?.successCount || 0),
+          chatMessageId: chatResult.messageId,
+          chatMessageCreated: chatResult.created,
+          rsvpEmailCount: emailResult.sentCount
+        };
+      } catch (error) {
+        await markReminderPendingAfterFailure(eventRef, claimId, error);
+        console.error('Failed to dispatch pre-event reminder', { teamId, gameId, error });
+        return null;
+      }
     }
-  }
-  return results;
+  });
+
+  return drainSummary.results.filter(Boolean);
 }
 
 exports.dispatchDuePreEventReminders = functions.pubsub

--- a/functions/pre-event-reminder-dispatcher-core.cjs
+++ b/functions/pre-event-reminder-dispatcher-core.cjs
@@ -1,0 +1,81 @@
+const PRE_EVENT_REMINDER_QUERY_PAGE_SIZE = 50;
+const PRE_EVENT_REMINDER_MAX_PAGES_PER_RUN = 10;
+const PRE_EVENT_REMINDER_MAX_RUNTIME_MS = 8 * 60 * 1000;
+
+async function drainDueReminderPages({
+  loadPage,
+  processReminder,
+  now = new Date(),
+  maxPages = PRE_EVENT_REMINDER_MAX_PAGES_PER_RUN,
+  maxRuntimeMs = PRE_EVENT_REMINDER_MAX_RUNTIME_MS
+} = {}) {
+  if (typeof loadPage !== 'function') {
+    throw new Error('loadPage is required.');
+  }
+  if (typeof processReminder !== 'function') {
+    throw new Error('processReminder is required.');
+  }
+
+  const safeStartedAtMs = Date.now();
+  const dueIso = now instanceof Date ? now.toISOString() : new Date(now || Date.now()).toISOString();
+  const summary = {
+    dueIso,
+    pagesAttempted: 0,
+    stoppedBecause: 'drained',
+    lastCursor: null,
+    results: []
+  };
+
+  let cursor = null;
+  let hitPageCap = true;
+  while (summary.pagesAttempted < maxPages) {
+    if ((Date.now() - safeStartedAtMs) >= maxRuntimeMs) {
+      summary.stoppedBecause = 'maxRuntimeMs';
+      break;
+    }
+
+    const page = await loadPage({
+      dueIso,
+      limit: PRE_EVENT_REMINDER_QUERY_PAGE_SIZE,
+      cursor
+    }) || {};
+    const docs = Array.isArray(page.docs) ? page.docs : [];
+    summary.pagesAttempted += 1;
+
+    if (!docs.length) {
+      summary.lastCursor = cursor;
+      hitPageCap = false;
+      break;
+    }
+
+    for (const doc of docs) {
+      if ((Date.now() - safeStartedAtMs) >= maxRuntimeMs) {
+        summary.stoppedBecause = 'maxRuntimeMs';
+        return summary;
+      }
+      const result = await processReminder(doc, { dueIso, page: summary.pagesAttempted });
+      summary.results.push(result);
+    }
+
+    cursor = page.nextCursor || docs[docs.length - 1] || null;
+    summary.lastCursor = cursor;
+
+    if (docs.length < PRE_EVENT_REMINDER_QUERY_PAGE_SIZE) {
+      hitPageCap = false;
+      break;
+    }
+  }
+
+  if (hitPageCap && summary.pagesAttempted >= maxPages && summary.stoppedBecause === 'drained') {
+    summary.stoppedBecause = 'maxPages';
+  }
+
+  return summary;
+}
+
+module.exports = {
+  PRE_EVENT_REMINDER_QUERY_PAGE_SIZE,
+  PRE_EVENT_REMINDER_MAX_PAGES_PER_RUN,
+  PRE_EVENT_REMINDER_MAX_RUNTIME_MS,
+  drainDueReminderPages
+};

--- a/tests/unit/pre-event-reminder-dispatcher.test.js
+++ b/tests/unit/pre-event-reminder-dispatcher.test.js
@@ -1,15 +1,37 @@
-import { describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
+import { describe, expect, it, vi } from 'vitest';
 import { readFileSync } from 'node:fs';
+
+const require = createRequire(import.meta.url);
+const {
+    PRE_EVENT_REMINDER_QUERY_PAGE_SIZE,
+    drainDueReminderPages
+} = require('../../functions/pre-event-reminder-dispatcher-core.cjs');
 
 const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
 
+function createDoc(id, dueIso, status = 'pending') {
+    return {
+        id,
+        dueIso,
+        scheduleNotifications: {
+            nextReminderAt: dueIso,
+            reminderStatus: status
+        }
+    };
+}
+
 describe('pre-event reminder dispatcher function', () => {
-    it('registers a bounded scheduled dispatcher for due reminders', () => {
+    it('registers a bounded scheduled dispatcher that drains ordered pages of due reminders', () => {
         expect(functionsSource).toContain('exports.dispatchDuePreEventReminders = functions.pubsub');
         expect(functionsSource).toContain(".schedule('every 15 minutes')");
         expect(functionsSource).toContain(".collectionGroup('games')");
         expect(functionsSource).toContain(".where('scheduleNotifications.nextReminderAt', '<=', dueIso)");
-        expect(functionsSource).toContain('.limit(50)');
+        expect(functionsSource).toContain(".orderBy('scheduleNotifications.nextReminderAt')");
+        expect(functionsSource).toContain('drainDueReminderPages({');
+        expect(functionsSource).toContain('PRE_EVENT_REMINDER_MAX_PAGES_PER_RUN');
+        expect(functionsSource).toContain('PRE_EVENT_REMINDER_MAX_RUNTIME_MS');
+        expect(functionsSource).not.toContain(".where('scheduleNotifications.nextReminderAt', '<=', dueIso)\n    .limit(50)\n    .get();");
     });
 
     it('uses a transaction claim before sending and records sent audit state', () => {
@@ -59,5 +81,100 @@ describe('pre-event reminder dispatcher function', () => {
         expect(functionsSource).toContain("status === 'canceled'");
         expect(functionsSource).toContain('eventDate <= now');
         expect(functionsSource).toContain('event?.deleted === true');
+    });
+});
+
+describe('drainDueReminderPages', () => {
+    it('drains 120 due docs across three ordered pages in one invocation', async () => {
+        const dueIso = '2026-06-03T09:00:00.000Z';
+        const docs = Array.from({ length: 120 }, (_, index) => createDoc(
+            `game-${String(index + 1).padStart(3, '0')}`,
+            dueIso,
+            'pending'
+        ));
+        const processedIds = [];
+        const loadPage = vi.fn(async ({ cursor, limit }) => {
+            const startIndex = cursor ? docs.findIndex((doc) => doc.id === cursor.id) + 1 : 0;
+            const pageDocs = docs.slice(startIndex, startIndex + limit);
+            return {
+                docs: pageDocs,
+                nextCursor: pageDocs[pageDocs.length - 1] || null
+            };
+        });
+
+        const summary = await drainDueReminderPages({
+            now: new Date(dueIso),
+            loadPage,
+            processReminder: async (doc) => {
+                processedIds.push(doc.id);
+                return doc.id;
+            }
+        });
+
+        expect(loadPage).toHaveBeenCalledTimes(3);
+        expect(summary.stoppedBecause).toBe('drained');
+        expect(processedIds).toHaveLength(120);
+        expect(processedIds).toEqual(docs.map((doc) => doc.id));
+        expect(loadPage.mock.calls[0][0]).toMatchObject({ limit: PRE_EVENT_REMINDER_QUERY_PAGE_SIZE, cursor: null });
+        expect(loadPage.mock.calls[1][0].cursor.id).toBe('game-050');
+        expect(loadPage.mock.calls[2][0].cursor.id).toBe('game-100');
+    });
+
+    it('preserves skip semantics for already claimed or sent docs on later pages', async () => {
+        const dueIso = '2026-06-03T09:00:00.000Z';
+        const docs = [
+            ...Array.from({ length: 50 }, (_, index) => createDoc(`game-a-${index + 1}`, dueIso)),
+            createDoc('game-b-1', dueIso, 'sending'),
+            createDoc('game-b-2', dueIso, 'sent'),
+            ...Array.from({ length: 18 }, (_, index) => createDoc(`game-b-${index + 3}`, dueIso))
+        ];
+        const sendAttemptIds = [];
+
+        const summary = await drainDueReminderPages({
+            now: new Date(dueIso),
+            loadPage: async ({ cursor, limit }) => {
+                const startIndex = cursor ? docs.findIndex((doc) => doc.id === cursor.id) + 1 : 0;
+                const pageDocs = docs.slice(startIndex, startIndex + limit);
+                return {
+                    docs: pageDocs,
+                    nextCursor: pageDocs[pageDocs.length - 1] || null
+                };
+            },
+            processReminder: async (doc) => {
+                if (doc.scheduleNotifications.reminderStatus === 'sending' || doc.scheduleNotifications.reminderStatus === 'sent') {
+                    return null;
+                }
+                sendAttemptIds.push(doc.id);
+                return doc.id;
+            }
+        });
+
+        expect(summary.stoppedBecause).toBe('drained');
+        expect(sendAttemptIds).toHaveLength(68);
+        expect(sendAttemptIds).not.toContain('game-b-1');
+        expect(sendAttemptIds).not.toContain('game-b-2');
+        expect(new Set(sendAttemptIds).size).toBe(sendAttemptIds.length);
+    });
+
+    it('stops cleanly when it hits the configured page guard', async () => {
+        const dueIso = '2026-06-03T09:00:00.000Z';
+        const docs = Array.from({ length: 130 }, (_, index) => createDoc(`game-${index + 1}`, dueIso));
+
+        const summary = await drainDueReminderPages({
+            now: new Date(dueIso),
+            maxPages: 2,
+            loadPage: async ({ cursor, limit }) => {
+                const startIndex = cursor ? docs.findIndex((doc) => doc.id === cursor.id) + 1 : 0;
+                const pageDocs = docs.slice(startIndex, startIndex + limit);
+                return {
+                    docs: pageDocs,
+                    nextCursor: pageDocs[pageDocs.length - 1] || null
+                };
+            },
+            processReminder: async (doc) => doc.id
+        });
+
+        expect(summary.stoppedBecause).toBe('maxPages');
+        expect(summary.results).toHaveLength(100);
     });
 });


### PR DESCRIPTION
Closes #1773

## What changed
- extracted bounded pre-event reminder drain logic into a shared helper with explicit page-size, max-pages, and max-runtime guards
- updated `dispatchDuePreEventReminders` to page through due `games` docs in ascending `scheduleNotifications.nextReminderAt` order during a single invocation instead of stopping after the first 50 docs
- kept the existing claim-before-send flow and sent-state audit updates intact while filtering the drained results back to successful reminder sends
- expanded unit coverage to verify multi-page draining, guard behavior, and skip semantics for reminders already marked `sending` or `sent`

## Why
The old scheduler only fetched one `.limit(50)` page every 15 minutes, so large reminder windows could back up for multiple cron cycles. This change keeps each Firestore query bounded while letting one run drain a larger due backlog safely and deterministically.