### PR TITLE
Add live game chat to React GameDetail

### DIFF
--- a/apps/app/src/data/mockData.ts
+++ b/apps/app/src/data/mockData.ts
@@ -82,6 +82,8 @@ export const mockGames: Game[] = [
     rideshare: { seatsLeft: 2, requests: 1 },
     assignments: ['Snacks: Open', 'Scorebook: Jamie'],
     status: 'live',
+    date: '2026-06-03T10:30:00Z',
+    liveStatus: 'live',
     liveEvents: [
       { id: 'game-1-event-1', type: 'score', period: 'Q1', gameClockMs: 320000, description: '#9 Kevin scored 2 points' },
       { id: 'game-1-event-2', type: 'rebound', period: 'Q1', gameClockMs: 301000, description: '#12 Paul defensive rebound' }
@@ -115,7 +117,8 @@ export const mockGames: Game[] = [
     availability: 'maybe',
     rideshare: { seatsLeft: 4, requests: 0 },
     assignments: ['Clock: Assigned', 'Video: Open'],
-    status: 'upcoming'
+    status: 'upcoming',
+    date: '2026-06-10T19:15:00Z'
   }
 ];
 

--- a/apps/app/src/lib/liveGameChatService.test.ts
+++ b/apps/app/src/lib/liveGameChatService.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({
+    postLiveChatMessage: vi.fn(),
+    subscribeLiveChat: vi.fn(() => vi.fn())
+}));
+
+const legacyChatMocks = vi.hoisted(() => ({
+    isViewerChatEnabled: vi.fn()
+}));
+
+vi.mock('../../../../js/db.js', () => dbMocks);
+vi.mock('../../../../js/live-game-chat.js', () => legacyChatMocks);
+
+import { postLiveChatMessage, subscribeLiveChat } from '../../../../js/db.js';
+import { buildLiveGameChatPayload, canUseLiveGameChat, sendLiveGameChatMessage, subscribeToLiveGameChat } from './liveGameChatService';
+
+describe('liveGameChatService', () => {
+    it('uses the legacy viewer chat gate for live, same-day, and replay decisions', () => {
+        vi.mocked(legacyChatMocks.isViewerChatEnabled)
+            .mockReturnValueOnce(true)
+            .mockReturnValueOnce(true)
+            .mockReturnValueOnce(false);
+
+        expect(canUseLiveGameChat({ status: 'live' }, { now: new Date('2026-06-03T12:00:00Z') })).toBe(true);
+        expect(canUseLiveGameChat({ date: '2026-06-03T09:00:00Z' }, { now: new Date('2026-06-03T12:00:00Z') })).toBe(true);
+        expect(canUseLiveGameChat({ date: '2026-06-03T09:00:00Z' }, { isReplay: true, now: new Date('2026-06-03T12:00:00Z') })).toBe(false);
+
+        expect(legacyChatMocks.isViewerChatEnabled).toHaveBeenNthCalledWith(1, { status: 'live', liveStatus: 'live' }, { now: new Date('2026-06-03T12:00:00Z') });
+        expect(legacyChatMocks.isViewerChatEnabled).toHaveBeenNthCalledWith(2, { date: '2026-06-03T09:00:00Z', liveStatus: null }, { now: new Date('2026-06-03T12:00:00Z') });
+        expect(legacyChatMocks.isViewerChatEnabled).toHaveBeenNthCalledWith(3, { date: '2026-06-03T09:00:00Z', liveStatus: null }, { isReplay: true, now: new Date('2026-06-03T12:00:00Z') });
+    });
+
+    it('builds signed-in and anonymous live chat payloads', () => {
+        expect(buildLiveGameChatPayload({
+            text: ' Let\'s go ',
+            user: { uid: 'user-1', displayName: 'Coach Kim', email: 'coach@example.com', roles: [] }
+        })).toEqual({
+            text: 'Let\'s go',
+            senderId: 'user-1',
+            senderName: 'Coach Kim',
+            senderPhotoUrl: null,
+            isAnonymous: false
+        });
+
+        expect(buildLiveGameChatPayload({
+            text: 'Nice play',
+            anonymousDisplayName: 'Grandma Pat'
+        })).toEqual({
+            text: 'Nice play',
+            senderId: null,
+            senderName: 'Grandma Pat',
+            senderPhotoUrl: null,
+            isAnonymous: true
+        });
+
+        expect(() => buildLiveGameChatPayload({ text: '   ', anonymousDisplayName: 'Pat' })).toThrow('Enter a message');
+        expect(() => buildLiveGameChatPayload({ text: 'Hi', anonymousDisplayName: '   ' })).toThrow('Add a display name');
+    });
+
+    it('subscribes and posts through the legacy live chat data layer', async () => {
+        const callback = vi.fn();
+        const unsubscribe = vi.fn();
+        vi.mocked(subscribeLiveChat).mockReturnValue(unsubscribe as never);
+
+        expect(subscribeToLiveGameChat('team-1', 'game-1', callback)).toBe(unsubscribe);
+        expect(subscribeLiveChat).toHaveBeenCalledWith('team-1', 'game-1', { limit: 100 }, callback, undefined);
+
+        const payload = await sendLiveGameChatMessage('team-1', 'game-1', {
+            text: 'Defense!',
+            anonymousDisplayName: 'Pat'
+        });
+
+        expect(payload).toMatchObject({ senderName: 'Pat', isAnonymous: true, text: 'Defense!' });
+        expect(postLiveChatMessage).toHaveBeenCalledWith('team-1', 'game-1', payload);
+    });
+});

--- a/apps/app/src/lib/liveGameChatService.ts
+++ b/apps/app/src/lib/liveGameChatService.ts
@@ -1,0 +1,98 @@
+import { postLiveChatMessage, subscribeLiveChat } from '../../../../js/db.js';
+import { isViewerChatEnabled } from '../../../../js/live-game-chat.js';
+import type { AuthUser } from './types';
+
+export type LiveGameChatMessage = {
+    id: string;
+    text?: string | null;
+    senderId?: string | null;
+    senderName?: string | null;
+    senderPhotoUrl?: string | null;
+    isAnonymous?: boolean;
+    createdAt?: unknown;
+};
+
+export type LiveGameChatEligibilityGame = {
+    date?: Date | string | { toDate: () => Date } | null;
+    liveStatus?: string | null;
+    status?: string | null;
+};
+
+export type LiveGameChatPayload = {
+    text: string;
+    senderId: string | null;
+    senderName: string;
+    senderPhotoUrl: string | null;
+    isAnonymous: boolean;
+};
+
+function compactString(value: unknown): string {
+    return typeof value === 'string' ? value.trim() : '';
+}
+
+export function canUseLiveGameChat(game: LiveGameChatEligibilityGame | null | undefined, options?: { isReplay?: boolean; now?: Date }) {
+    return isViewerChatEnabled({
+        ...game,
+        liveStatus: game?.liveStatus || (game?.status === 'live' ? 'live' : null)
+    }, options);
+}
+
+export function getLiveGameChatNotice(game: LiveGameChatEligibilityGame | null | undefined, options?: { isReplay?: boolean; now?: Date }) {
+    if (options?.isReplay) {
+        return 'Live chat is closed during replay.';
+    }
+    if (canUseLiveGameChat(game, options)) {
+        return null;
+    }
+    return 'Live chat opens on game day and closes after the live window ends.';
+}
+
+export function buildLiveGameChatPayload(input: {
+    text: string;
+    user?: AuthUser | null;
+    anonymousDisplayName?: string | null;
+}): LiveGameChatPayload {
+    const text = compactString(input.text);
+    if (!text) {
+        throw new Error('Enter a message before sending.');
+    }
+
+    const user = input.user || null;
+    const anonymousDisplayName = compactString(input.anonymousDisplayName);
+    const senderName = compactString(user?.displayName) || compactString(user?.email) || anonymousDisplayName;
+
+    if (!senderName) {
+        throw new Error('Add a display name before sending.');
+    }
+
+    return {
+        text,
+        senderId: user?.uid || null,
+        senderName,
+        senderPhotoUrl: compactString(user?.photoUrl) || null,
+        isAnonymous: !user
+    };
+}
+
+export function subscribeToLiveGameChat(
+    teamId: string,
+    gameId: string,
+    callback: (messages: LiveGameChatMessage[]) => void,
+    onError?: (error: unknown) => void
+) {
+    return subscribeLiveChat(teamId, gameId, { limit: 100 }, callback, onError);
+}
+
+export async function sendLiveGameChatMessage(
+    teamId: string,
+    gameId: string,
+    input: {
+        text: string;
+        user?: AuthUser | null;
+        anonymousDisplayName?: string | null;
+    }
+) {
+    const payload = buildLiveGameChatPayload(input);
+    await postLiveChatMessage(teamId, gameId, payload);
+    return payload;
+}

--- a/apps/app/src/lib/types.ts
+++ b/apps/app/src/lib/types.ts
@@ -107,6 +107,8 @@ export interface Game {
   };
   assignments: string[];
   status: 'upcoming' | 'past' | 'live';
+  date?: Date | string;
+  liveStatus?: string;
   liveEvents?: LiveGameEvent[];
 }
 

--- a/apps/app/src/pages/GameDetail.test.tsx
+++ b/apps/app/src/pages/GameDetail.test.tsx
@@ -12,6 +12,7 @@ const liveGameChatMocks = vi.hoisted(() => ({
 vi.mock('../lib/liveGameChatService', () => liveGameChatMocks);
 
 import { GameDetail } from './GameDetail';
+import { mockGames } from '../data/mockData';
 import type { AuthState } from '../lib/types';
 
 const auth: AuthState = {
@@ -95,6 +96,38 @@ describe('GameDetail play-by-play audio', () => {
         anonymousDisplayName: 'Pat Parent'
       });
     });
+  });
+
+  it('does not resubscribe when the game object is recreated with the same ids', () => {
+    const unsubscribe = vi.fn();
+    const originalGame = mockGames[0];
+
+    liveGameChatMocks.subscribeToLiveGameChat.mockReturnValue(unsubscribe);
+
+    try {
+      const view = renderGameDetail();
+
+      expect(liveGameChatMocks.subscribeToLiveGameChat).toHaveBeenCalledTimes(1);
+
+      mockGames[0] = {
+        ...originalGame,
+        liveEvents: [...(originalGame.liveEvents || [])]
+      };
+
+      view.rerender(
+        <MemoryRouter initialEntries={['/games/game-1']}>
+          <Routes>
+            <Route path="/games/:gameId" element={<GameDetail auth={auth} />} />
+            <Route path="/schedule" element={<div>Schedule</div>} />
+          </Routes>
+        </MemoryRouter>
+      );
+
+      expect(liveGameChatMocks.subscribeToLiveGameChat).toHaveBeenCalledTimes(1);
+      expect(unsubscribe).not.toHaveBeenCalled();
+    } finally {
+      mockGames[0] = originalGame;
+    }
   });
 
   it('shows the locked notice and disables the composer when live chat is closed', () => {

--- a/apps/app/src/pages/GameDetail.test.tsx
+++ b/apps/app/src/pages/GameDetail.test.tsx
@@ -1,6 +1,16 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const liveGameChatMocks = vi.hoisted(() => ({
+  canUseLiveGameChat: vi.fn(),
+  getLiveGameChatNotice: vi.fn(),
+  sendLiveGameChatMessage: vi.fn(),
+  subscribeToLiveGameChat: vi.fn(() => vi.fn())
+}));
+
+vi.mock('../lib/liveGameChatService', () => liveGameChatMocks);
+
 import { GameDetail } from './GameDetail';
 import type { AuthState } from '../lib/types';
 
@@ -31,6 +41,15 @@ function renderGameDetail(path = '/games/game-1') {
 
 describe('GameDetail play-by-play audio', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
+    liveGameChatMocks.canUseLiveGameChat.mockReturnValue(true);
+    liveGameChatMocks.getLiveGameChatNotice.mockReturnValue(null);
+    liveGameChatMocks.subscribeToLiveGameChat.mockImplementation((...args: any[]) => {
+      const callback = args[2] as (messages: Array<{ id: string; senderName: string; text: string }>) => void;
+      callback([{ id: 'chat-1', senderName: 'Jamie', text: 'Let\'s go Bears!' }]);
+      return vi.fn();
+    });
+    liveGameChatMocks.sendLiveGameChatMessage.mockResolvedValue(undefined);
     localStorage.clear();
     vi.stubGlobal('speechSynthesis', { speak: vi.fn(), cancel: vi.fn() });
     vi.stubGlobal('SpeechSynthesisUtterance', vi.fn(function MockUtterance(this: SpeechSynthesisUtterance, text: string) {
@@ -44,6 +63,9 @@ describe('GameDetail play-by-play audio', () => {
     expect(screen.getByRole('button', { name: 'Enable play-by-play audio announcements' })).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'Live play by play' })).toBeInTheDocument();
     expect(screen.getByText('#9 Kevin scored 2 points')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Live chat' })).toBeInTheDocument();
+    expect(liveGameChatMocks.subscribeToLiveGameChat).toHaveBeenCalledWith('team-bears', 'game-1', expect.any(Function), expect.any(Function));
+    expect(screen.getByText("Let's go Bears!")).toBeInTheDocument();
   });
 
   it('announces displayed game events once when enabled', () => {
@@ -57,5 +79,32 @@ describe('GameDetail play-by-play audio', () => {
     expect(SpeechSynthesisUtterance).toHaveBeenCalledWith('Q1. #9 Kevin scored 2 points');
     expect(SpeechSynthesisUtterance).toHaveBeenCalledWith('Q1. #12 Paul defensive rebound');
     expect(localStorage.getItem('allplaysPlayAnnouncerEnabled')).toBe('true');
+  });
+
+  it('sends anonymous live chat messages from the game detail panel', async () => {
+    renderGameDetail();
+
+    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Pat Parent' } });
+    fireEvent.change(screen.getByLabelText('Message'), { target: { value: 'Great hustle!' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+
+    await waitFor(() => {
+      expect(liveGameChatMocks.sendLiveGameChatMessage).toHaveBeenCalledWith('team-bears', 'game-1', {
+        text: 'Great hustle!',
+        user: null,
+        anonymousDisplayName: 'Pat Parent'
+      });
+    });
+  });
+
+  it('shows the locked notice and disables the composer when live chat is closed', () => {
+    liveGameChatMocks.canUseLiveGameChat.mockReturnValue(false);
+    liveGameChatMocks.getLiveGameChatNotice.mockReturnValue('Live chat opens on game day and closes after the live window ends.');
+
+    renderGameDetail('/games/game-2');
+
+    expect(screen.getByText('Live chat opens on game day and closes after the live window ends.')).toBeInTheDocument();
+    expect(screen.getByLabelText('Message')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled();
   });
 });

--- a/apps/app/src/pages/GameDetail.tsx
+++ b/apps/app/src/pages/GameDetail.tsx
@@ -53,7 +53,7 @@ export function GameDetail({ auth }: { auth: AuthState }) {
       setChatError('Live chat is temporarily unavailable.');
       setChatReady(true);
     });
-  }, [game]);
+  }, [game?.id, game?.teamId]);
 
   if (!game) {
     return <Navigate to="/schedule" replace />;

--- a/apps/app/src/pages/GameDetail.tsx
+++ b/apps/app/src/pages/GameDetail.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import { Link, Navigate, useParams } from 'react-router-dom';
 import { BarChart3, Brain, Car, ClipboardCheck, FileText, ListTree, MessageCircleReply, Radio, Share2, Shield, Trophy, Users } from 'lucide-react';
 import { LiveGameAnnouncerToggle } from '../components/LiveGameAnnouncerToggle';
 import { mockGames, mockPlayers, mockTeams } from '../data/mockData';
+import { canUseLiveGameChat, getLiveGameChatNotice, sendLiveGameChatMessage, subscribeToLiveGameChat, type LiveGameChatMessage } from '../lib/liveGameChatService';
 import { applyWalk, createBaseballLiveState, type BaseballBases, type BaseballLiveState } from '../lib/sportScoring/baseballScorekeepingService';
 import { createPlayAnnouncer } from '../lib/liveGameAnnouncerService';
 import type { AuthState } from '../lib/types';
@@ -17,6 +18,12 @@ export function GameDetail({ auth }: { auth: AuthState }) {
   const liveEvents = game?.liveEvents || [];
   const announcer = useMemo(() => createPlayAnnouncer(), []);
   const [announcementsEnabled, setAnnouncementsEnabled] = useState(() => announcer.isEnabled());
+  const [chatMessages, setChatMessages] = useState<LiveGameChatMessage[]>([]);
+  const [chatDraft, setChatDraft] = useState('');
+  const [anonymousDisplayName, setAnonymousDisplayName] = useState('');
+  const [chatError, setChatError] = useState<string | null>(null);
+  const [chatSending, setChatSending] = useState(false);
+  const [chatReady, setChatReady] = useState(false);
 
   useEffect(() => {
     if (!game) return;
@@ -33,11 +40,53 @@ export function GameDetail({ auth }: { auth: AuthState }) {
     };
   }, [announcer, announcementsEnabled, game, liveEvents]);
 
+  useEffect(() => {
+    if (!game) return;
+
+    setChatReady(false);
+    setChatError(null);
+
+    return subscribeToLiveGameChat(game.teamId, game.id, (messages) => {
+      setChatMessages(messages);
+      setChatReady(true);
+    }, () => {
+      setChatError('Live chat is temporarily unavailable.');
+      setChatReady(true);
+    });
+  }, [game]);
+
   if (!game) {
     return <Navigate to="/schedule" replace />;
   }
 
-  const players = mockPlayers.filter((player) => game.playerIds.includes(player.id));
+  const currentGame = game;
+  const players = mockPlayers.filter((player) => currentGame.playerIds.includes(player.id));
+  const liveChatEnabled = canUseLiveGameChat(currentGame, { isReplay: currentGame.status === 'past' });
+  const liveChatNotice = getLiveGameChatNotice(currentGame, { isReplay: currentGame.status === 'past' });
+
+  async function handleChatSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+
+    if (!liveChatEnabled) {
+      setChatError(liveChatNotice || 'Live chat is unavailable right now.');
+      return;
+    }
+
+    setChatError(null);
+    setChatSending(true);
+    try {
+      await sendLiveGameChatMessage(currentGame.teamId, currentGame.id, {
+        text: chatDraft,
+        user: auth.user,
+        anonymousDisplayName
+      });
+      setChatDraft('');
+    } catch (error) {
+      setChatError(error instanceof Error ? error.message : 'Unable to send message.');
+    } finally {
+      setChatSending(false);
+    }
+  }
 
   function toggleBase(base: keyof BaseballBases) {
     setBaseballState((current) => ({
@@ -91,6 +140,74 @@ export function GameDetail({ auth }: { auth: AuthState }) {
           </div>
         </section>
       ) : null}
+
+      <section className="app-card p-4" aria-labelledby="live-game-chat-heading">
+        <div className="flex items-start justify-between gap-3">
+          <div>
+            <div className="app-label">Game day chat</div>
+            <h2 id="live-game-chat-heading" className="mt-1 text-lg font-black text-gray-950">Live chat</h2>
+          </div>
+          <div className="rounded-full bg-primary-50 px-3 py-1 text-[11px] font-black uppercase tracking-wide text-primary-700">
+            {liveChatEnabled ? 'Open' : 'Locked'}
+          </div>
+        </div>
+
+        {liveChatNotice ? (
+          <div className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-semibold text-amber-900">
+            {liveChatNotice}
+          </div>
+        ) : null}
+
+        <div className="mt-3 space-y-2" data-testid="live-game-chat-thread">
+          {chatMessages.length > 0 ? chatMessages.map((message) => (
+            <div key={message.id} className="rounded-2xl border border-gray-200 bg-gray-50 p-3">
+              <div className="text-xs font-black uppercase tracking-wide text-gray-500">{message.senderName || 'Fan'}</div>
+              <div className="mt-1 text-sm font-semibold text-gray-700">{message.text || ''}</div>
+            </div>
+          )) : (
+            <div className="rounded-2xl border border-dashed border-gray-200 bg-gray-50 px-3 py-4 text-sm font-semibold text-gray-500">
+              {chatReady ? 'No live game chat messages yet.' : 'Connecting to live game chat...'}
+            </div>
+          )}
+        </div>
+
+        <form className="mt-3 space-y-3" onSubmit={handleChatSubmit}>
+          {!auth.user ? (
+            <label className="block">
+              <span className="mb-1 block text-xs font-black uppercase tracking-wide text-gray-500">Display name</span>
+              <input
+                type="text"
+                aria-label="Display name"
+                className="auth-input"
+                value={anonymousDisplayName}
+                onChange={(event) => setAnonymousDisplayName(event.target.value)}
+                placeholder="Your first name"
+                disabled={chatSending}
+              />
+            </label>
+          ) : null}
+
+          <label className="block">
+            <span className="mb-1 block text-xs font-black uppercase tracking-wide text-gray-500">Message</span>
+            <textarea
+              aria-label="Message"
+              className="auth-input min-h-24"
+              value={chatDraft}
+              onChange={(event) => setChatDraft(event.target.value)}
+              placeholder={liveChatEnabled ? 'Send encouragement, updates, or reactions.' : 'Live chat is locked right now.'}
+              disabled={chatSending || !liveChatEnabled}
+            />
+          </label>
+
+          {chatError ? <div className="text-sm font-semibold text-rose-700">{chatError}</div> : null}
+
+          <div className="flex justify-end">
+            <button type="submit" className="primary-button" disabled={chatSending || !liveChatEnabled}>
+              {chatSending ? 'Sending...' : 'Send message'}
+            </button>
+          </div>
+        </form>
+      </section>
 
       {auth.isCoach || auth.isAdmin ? (
         <section className="app-card p-4">


### PR DESCRIPTION
Closes #1775

## What changed
- added a small `liveGameChatService` wrapper in the React app that reuses the legacy `subscribeLiveChat`, `postLiveChatMessage`, and viewer chat gating logic
- embedded a live game chat panel directly in `GameDetail` with real-time message subscription, locked-state messaging, anonymous display-name capture, and send handling
- extended focused tests to cover the new service wrapper plus GameDetail subscription, send, and locked-composer behavior

## Why
The React GameDetail route had play-by-play and a team messages link, but no game-scoped live chat parity with the legacy live-game experience. This patch closes that gap with the smallest shared React implementation so web and Capacitor shells inherit the same behavior.