### PR TITLE
Add TeamDetail videographer grant controls

### DIFF
--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -13,9 +13,11 @@ import {
   updateEvent,
   updateGame,
   grantScorekeeperAccess,
+  grantVideographerAccess,
   inviteAdmin,
   addTeamAdminEmail,
-  revokeScorekeeperAccess
+  revokeScorekeeperAccess,
+  revokeVideographerAccess
 } from '../../../../js/db.js';
 import { sendInviteEmail } from '../../../../js/auth.js';
 import { inviteExistingTeamAdmin } from '../../../../js/edit-team-admin-invites.js';
@@ -112,6 +114,7 @@ export type TeamStaffPermissionsSummary = {
   }>;
   scorekeepingMode: string;
   scorekeeperGrantTargets: TeamScorekeeperGrantTarget[];
+  videographerGrantTargets: TeamScorekeeperGrantTarget[];
   hasAnyStaff: boolean;
 };
 
@@ -414,6 +417,22 @@ export async function revokeScorekeeperAccessForApp(teamId: string, memberUserId
   await revokeScorekeeperAccess(normalizedTeamId, normalizedUserId);
 }
 
+export async function grantVideographerAccessForApp(teamId: string, memberUserId: string) {
+  const normalizedTeamId = cleanString(teamId);
+  const normalizedUserId = cleanString(memberUserId);
+  if (!normalizedTeamId) throw new Error('Team ID is required.');
+  if (!normalizedUserId) throw new Error('Team member user ID is required.');
+  await grantVideographerAccess(normalizedTeamId, normalizedUserId);
+}
+
+export async function revokeVideographerAccessForApp(teamId: string, memberUserId: string) {
+  const normalizedTeamId = cleanString(teamId);
+  const normalizedUserId = cleanString(memberUserId);
+  if (!normalizedTeamId) throw new Error('Team ID is required.');
+  if (!normalizedUserId) throw new Error('Team member user ID is required.');
+  await revokeVideographerAccess(normalizedTeamId, normalizedUserId);
+}
+
 export async function saveTeamScheduleNotificationsForApp(teamId: string, settings: Partial<TeamScheduleNotificationSettings>) {
   const normalizedTeamId = cleanString(teamId);
   if (!normalizedTeamId) throw new Error('Team ID is required.');
@@ -590,7 +609,8 @@ export function buildTeamDetailModel({
     ? {
       ...buildTeamStaffPermissionsViewModel({ ...team, id: teamId }, pendingAdminInvites),
       scorekeepingMode: cleanString(team?.teamPermissions?.scorekeeping?.mode),
-      scorekeeperGrantTargets: buildScorekeeperGrantTargets(team, players)
+      scorekeeperGrantTargets: buildPermissionGrantTargets(team, players, 'scorekeeping'),
+      videographerGrantTargets: buildPermissionGrantTargets(team, players, 'videography')
     }
     : null;
 
@@ -669,8 +689,8 @@ function normalizePlayers(players: any[], linkedPlayerIds: string[]): TeamDetail
     .sort((a, b) => sortByNumberThenName(a, b));
 }
 
-function buildScorekeeperGrantTargets(team: Record<string, any>, players: any[]): TeamScorekeeperGrantTarget[] {
-  const selectedScorekeeperIds = getSelectedPermissionIds(team, 'scorekeeping');
+function buildPermissionGrantTargets(team: Record<string, any>, players: any[], permissionKey: string): TeamScorekeeperGrantTarget[] {
+  const selectedPermissionIds = getSelectedPermissionIds(team, permissionKey);
   const targetsByUserId = new Map<string, Omit<TeamScorekeeperGrantTarget, 'isGranted'>>();
 
   const addTarget = (userId: any, player: any, source: Record<string, any> = {}) => {
@@ -701,7 +721,7 @@ function buildScorekeeperGrantTargets(team: Record<string, any>, players: any[])
     });
 
   return Array.from(targetsByUserId.values())
-    .map((target) => ({ ...target, isGranted: selectedScorekeeperIds.has(target.userId) }))
+    .map((target) => ({ ...target, isGranted: selectedPermissionIds.has(target.userId) }))
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -8,6 +8,7 @@ import {
   getPlayerTrackingStatuses,
   getPublicTrackingItems,
   getTeam,
+  getAllUsers,
   updateTeam,
   getEvents,
   updateEvent,
@@ -536,6 +537,7 @@ export async function loadParentTeamDetail(teamId: string, user: AuthUser | null
 
   const canManageTeam = hasFullTeamAccess(user, team);
   const pendingAdminInvites = canManageTeam ? await loadPendingAdminInvites(teamId).catch(() => []) : [];
+  const confirmedTeamMembers = canManageTeam ? await Promise.resolve(getAllUsers()).catch(() => []) : [];
 
   const linkedPlayerIds = getLinkedPlayerIds(user, teamId, players);
   const completedGameIds = (Array.isArray(games) ? games : [])
@@ -563,7 +565,8 @@ export async function loadParentTeamDetail(teamId: string, user: AuthUser | null
     trackingItems,
     trackingStatuses,
     sponsors: [...normalizeSponsorList(adSponsors), ...normalizeSponsorList(localSponsors)],
-    pendingAdminInvites
+    pendingAdminInvites,
+    confirmedTeamMembers
   });
 }
 
@@ -579,7 +582,8 @@ export function buildTeamDetailModel({
   trackingItems = [],
   trackingStatuses = [],
   sponsors = [],
-  pendingAdminInvites = []
+  pendingAdminInvites = [],
+  confirmedTeamMembers = []
 }: {
   teamId: string;
   team: Record<string, any>;
@@ -593,6 +597,7 @@ export function buildTeamDetailModel({
   trackingStatuses?: any[];
   sponsors?: TeamDetailSponsor[];
   pendingAdminInvites?: any[];
+  confirmedTeamMembers?: any[];
 }): TeamDetailModel {
   const normalizedPlayers = normalizePlayers(players, linkedPlayerIds);
   const normalizedEvents = normalizeEvents(games);
@@ -609,8 +614,8 @@ export function buildTeamDetailModel({
     ? {
       ...buildTeamStaffPermissionsViewModel({ ...team, id: teamId }, pendingAdminInvites),
       scorekeepingMode: cleanString(team?.teamPermissions?.scorekeeping?.mode),
-      scorekeeperGrantTargets: buildPermissionGrantTargets(team, players, 'scorekeeping'),
-      videographerGrantTargets: buildPermissionGrantTargets(team, players, 'videography')
+      scorekeeperGrantTargets: buildPermissionGrantTargets(team, players, 'scorekeeping', confirmedTeamMembers, teamId),
+      videographerGrantTargets: buildPermissionGrantTargets(team, players, 'videography', confirmedTeamMembers, teamId)
     }
     : null;
 
@@ -689,7 +694,7 @@ function normalizePlayers(players: any[], linkedPlayerIds: string[]): TeamDetail
     .sort((a, b) => sortByNumberThenName(a, b));
 }
 
-function buildPermissionGrantTargets(team: Record<string, any>, players: any[], permissionKey: string): TeamScorekeeperGrantTarget[] {
+function buildPermissionGrantTargets(team: Record<string, any>, players: any[], permissionKey: string, confirmedTeamMembers: any[] = [], teamId = ''): TeamScorekeeperGrantTarget[] {
   const selectedPermissionIds = getSelectedPermissionIds(team, permissionKey);
   const targetsByUserId = new Map<string, Omit<TeamScorekeeperGrantTarget, 'isGranted'>>();
 
@@ -711,14 +716,24 @@ function buildPermissionGrantTargets(team: Record<string, any>, players: any[], 
     targetsByUserId.set(normalizedUserId, existing);
   };
 
-  (Array.isArray(players) ? players : [])
-    .filter((player) => player?.active !== false)
-    .forEach((player) => {
-      getPlayerLinkedUserIds(player).forEach((userId) => addTarget(userId, player));
-      (Array.isArray(player?.parents) ? player.parents : []).forEach((parent: any) => {
-        addTarget(parent?.userId || parent?.uid || parent?.authUid || parent?.accountUserId || parent?.memberUserId, player, parent);
-      });
+  const activePlayers = (Array.isArray(players) ? players : []).filter((player) => player?.active !== false);
+  const playersById = new Map(activePlayers.map((player) => [cleanString(player?.id || player?.playerId), player]));
+
+  activePlayers.forEach((player) => {
+    getPlayerLinkedUserIds(player).forEach((userId) => addTarget(userId, player));
+    (Array.isArray(player?.parents) ? player.parents : []).forEach((parent: any) => {
+      addTarget(parent?.userId || parent?.uid || parent?.authUid || parent?.accountUserId || parent?.memberUserId, player, parent);
     });
+  });
+
+  (Array.isArray(confirmedTeamMembers) ? confirmedTeamMembers : []).forEach((member) => {
+    const parentLinks = (Array.isArray(member?.parentOf) ? member.parentOf : [])
+      .filter((link: any) => cleanString(link?.teamId) === teamId);
+    parentLinks.forEach((link: any) => {
+      const player = playersById.get(cleanString(link?.playerId));
+      if (player) addTarget(member?.id || member?.uid, player, member);
+    });
+  });
 
   return Array.from(targetsByUserId.values())
     .map((target) => ({ ...target, isGranted: selectedPermissionIds.has(target.userId) }))

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -28,7 +28,7 @@ import { copyPublicText, openPublicUrl, sharePublicUrl } from '../lib/publicActi
 import { getEventDetailPath } from '../lib/homeLogic';
 import { createStaffRsvpReminderPreviewLoader, sendStaffRsvpReminder, type StaffRsvpReminderSendResult } from '../lib/scheduleService';
 import type { ParentScheduleEvent, StaffRsvpReminderPreview } from '../lib/scheduleLogic';
-import { buildPublicTeamGamesIcsUrl, canExposePublicFanFeed, grantScorekeeperAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp, saveTeamScheduleNotificationsForApp, type InviteTeamAdminForAppResult, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer } from '../lib/teamDetailService';
+import { buildPublicTeamGamesIcsUrl, canExposePublicFanFeed, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp, type InviteTeamAdminForAppResult, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer, type TeamScorekeeperGrantTarget } from '../lib/teamDetailService';
 import type { AuthState } from '../lib/types';
 
 type TeamTab = 'overview' | 'schedule' | 'roster' | 'insights' | 'more';
@@ -631,6 +631,7 @@ function StaffPermissionsCard({ model, onInviteSuccess }: { model: TeamDetailMod
     ...summary.pendingInvites.map((inviteEmail) => `${inviteEmail} · Pending admin invite`)
   ];
   const scorekeeperGrantTargets = summary.scorekeeperGrantTargets || [];
+  const videographerGrantTargets = summary.videographerGrantTargets || [];
   const isAllConfirmedScorekeeping = summary.scorekeepingMode === 'all_confirmed';
   const existingEmails = getStaffPermissionEmails(summary);
 
@@ -688,6 +689,27 @@ function StaffPermissionsCard({ model, onInviteSuccess }: { model: TeamDetailMod
       await onInviteSuccess();
     } catch (grantError: any) {
       setGrantStatus({ success: false, message: grantError?.message || 'Unable to update scorekeeper access.' });
+    } finally {
+      setGrantingUserId(null);
+    }
+  }
+
+  async function toggleVideographerGrant(memberUserId: string, isGranted: boolean) {
+    if (!memberUserId || grantingUserId) return;
+    setGrantingUserId(memberUserId);
+    setGrantStatus(null);
+    setResult(null);
+    setCopyStatus(null);
+    try {
+      if (isGranted) {
+        await revokeVideographerAccessForApp(model.team.id, memberUserId);
+      } else {
+        await grantVideographerAccessForApp(model.team.id, memberUserId);
+      }
+      setGrantStatus({ success: true, message: isGranted ? 'Videographer access revoked.' : 'Videographer access granted.' });
+      await onInviteSuccess();
+    } catch (grantError: any) {
+      setGrantStatus({ success: false, message: grantError?.message || 'Unable to update videographer access.' });
     } finally {
       setGrantingUserId(null);
     }
@@ -751,30 +773,34 @@ function StaffPermissionsCard({ model, onInviteSuccess }: { model: TeamDetailMod
           <p className="mt-2 text-xs font-semibold leading-5 text-gray-600">All confirmed team members can score games, so individual scorekeeper grants are disabled to preserve that team-wide access.</p>
         </div>
       ) : scorekeeperGrantTargets.length ? (
-        <div className="mt-4 rounded-xl border border-primary-100 bg-white p-3">
-          <div className="text-[11px] font-black uppercase tracking-[0.04em] text-primary-700">Scorekeeper helper access</div>
-          <p className="mt-2 text-xs font-semibold leading-5 text-gray-600">Grant an existing linked team member scorekeeping duty without making them a full admin or giving roster, schedule, settings, or broader team access.</p>
-          <div className="mt-3 divide-y divide-gray-100 overflow-hidden rounded-xl border border-gray-100">
-            {scorekeeperGrantTargets.map((target) => {
-              const busy = grantingUserId === target.userId;
-              const detail = target.playerNames.length ? `Linked to ${target.playerNames.join(', ')}.` : 'Linked team member account.';
-              return (
-                <div key={target.userId} className="flex flex-col gap-3 p-3 sm:flex-row sm:items-center sm:justify-between">
-                  <div className="min-w-0">
-                    <div className="truncate text-sm font-black text-gray-950">{target.name || target.email || 'Team member'}</div>
-                    <div className="text-xs font-semibold leading-5 text-gray-500">{target.isGranted ? `Can score games. ${detail}` : `No scorekeeper helper grant. ${detail}`}</div>
-                  </div>
-                  <button type="button" className={`secondary-button !min-h-9 flex-none text-xs ${target.isGranted ? '!border-rose-200 !bg-rose-50 !text-rose-700' : ''}`} disabled={Boolean(grantingUserId)} onClick={() => toggleScorekeeperGrant(target.userId, target.isGranted)}>
-                    {busy ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
-                    {target.isGranted ? 'Revoke scorekeeper' : 'Grant scorekeeper'}
-                  </button>
-                </div>
-              );
-            })}
-          </div>
-          {grantStatus ? <div className={`mt-2 text-xs font-black ${grantStatus.success ? 'text-emerald-700' : 'text-rose-700'}`} role="status">{grantStatus.message}</div> : null}
-        </div>
+        <PermissionGrantPanel
+          title="Scorekeeper helper access"
+          description="Grant an existing linked team member scorekeeping duty without making them a full admin or giving roster, schedule, settings, or broader team access."
+          targets={scorekeeperGrantTargets}
+          grantingUserId={grantingUserId}
+          onToggle={toggleScorekeeperGrant}
+          grantedText="Can score games."
+          emptyText="No scorekeeper helper grant."
+          grantLabel="Grant scorekeeper"
+          revokeLabel="Revoke scorekeeper"
+        />
       ) : null}
+
+      {videographerGrantTargets.length ? (
+        <PermissionGrantPanel
+          title="Videographer access"
+          description="Grant an existing linked team member live-game camera and media capture access only. This does not grant roster, schedule, RSVP, or full team admin rights."
+          targets={videographerGrantTargets}
+          grantingUserId={grantingUserId}
+          onToggle={toggleVideographerGrant}
+          grantedText="Can capture live-game camera and media."
+          emptyText="No videographer helper grant."
+          grantLabel="Grant videographer"
+          revokeLabel="Revoke videographer"
+        />
+      ) : null}
+
+      {grantStatus ? <div className={`mt-2 text-xs font-black ${grantStatus.success ? 'text-emerald-700' : 'text-rose-700'}`} role="status">{grantStatus.message}</div> : null}
 
       <div className="mt-4 grid gap-3 lg:grid-cols-2">
         <div className="rounded-xl border border-indigo-100 bg-indigo-50 p-3">
@@ -796,6 +822,53 @@ function StaffPermissionsCard({ model, onInviteSuccess }: { model: TeamDetailMod
         ))}
       </div>
     </section>
+  );
+}
+
+function PermissionGrantPanel({
+  title,
+  description,
+  targets,
+  grantingUserId,
+  onToggle,
+  grantedText,
+  emptyText,
+  grantLabel,
+  revokeLabel
+}: {
+  title: string;
+  description: string;
+  targets: TeamScorekeeperGrantTarget[];
+  grantingUserId: string | null;
+  onToggle: (memberUserId: string, isGranted: boolean) => Promise<void>;
+  grantedText: string;
+  emptyText: string;
+  grantLabel: string;
+  revokeLabel: string;
+}) {
+  return (
+    <div className="mt-4 rounded-xl border border-primary-100 bg-white p-3">
+      <div className="text-[11px] font-black uppercase tracking-[0.04em] text-primary-700">{title}</div>
+      <p className="mt-2 text-xs font-semibold leading-5 text-gray-600">{description}</p>
+      <div className="mt-3 divide-y divide-gray-100 overflow-hidden rounded-xl border border-gray-100">
+        {targets.map((target) => {
+          const busy = grantingUserId === target.userId;
+          const detail = target.playerNames.length ? `Linked to ${target.playerNames.join(', ')}.` : 'Linked team member account.';
+          return (
+            <div key={target.userId} className="flex flex-col gap-3 p-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="min-w-0">
+                <div className="truncate text-sm font-black text-gray-950">{target.name || target.email || 'Team member'}</div>
+                <div className="text-xs font-semibold leading-5 text-gray-500">{target.isGranted ? `${grantedText} ${detail}` : `${emptyText} ${detail}`}</div>
+              </div>
+              <button type="button" className={`secondary-button !min-h-9 flex-none text-xs ${target.isGranted ? '!border-rose-200 !bg-rose-50 !text-rose-700' : ''}`} disabled={Boolean(grantingUserId)} onClick={() => onToggle(target.userId, target.isGranted)}>
+                {busy ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+                {target.isGranted ? revokeLabel : grantLabel}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 

--- a/js/db.js
+++ b/js/db.js
@@ -1297,6 +1297,33 @@ export async function revokeScorekeeperAccess(teamId, memberUserId) {
     });
 }
 
+export async function grantVideographerAccess(teamId, memberUserId) {
+    const normalizedUserId = String(memberUserId || '').trim();
+    if (!teamId) throw new Error('Missing team for videographer access');
+    if (!normalizedUserId) throw new Error('Team member user ID is required');
+
+    await assertVolunteerScreeningClearedForTeamGrant(teamId, { userId: normalizedUserId });
+
+    const docRef = doc(db, "teams", teamId);
+    await updateDoc(docRef, {
+        'teamPermissions.videography.mode': 'selected',
+        'teamPermissions.videography.memberIds': arrayUnion(normalizedUserId),
+        updatedAt: Timestamp.now()
+    });
+}
+
+export async function revokeVideographerAccess(teamId, memberUserId) {
+    const normalizedUserId = String(memberUserId || '').trim();
+    if (!teamId) throw new Error('Missing team for videographer access');
+    if (!normalizedUserId) throw new Error('Team member user ID is required');
+
+    const docRef = doc(db, "teams", teamId);
+    await updateDoc(docRef, {
+        'teamPermissions.videography.memberIds': arrayRemove(normalizedUserId),
+        updatedAt: Timestamp.now()
+    });
+}
+
 export async function grantStreamScoreAccess(teamId, memberUserId) {
     const normalizedUserId = String(memberUserId || '').trim();
     if (!teamId) throw new Error('Missing team for Stream & Score access');

--- a/js/team-staff-permissions.js
+++ b/js/team-staff-permissions.js
@@ -74,7 +74,7 @@ export function buildTeamStaffPermissionsViewModel(team = {}, pendingAdminInvite
             {
                 key: 'videographer',
                 title: 'Videographer',
-                grants: getUniqueLabels([...getPermissionGrantLabels(permissions.streaming), ...legacyVideoGrants]),
+                grants: getUniqueLabels([...getPermissionGrantLabels(permissions.videography), ...legacyVideoGrants]),
                 emptyText: 'No videographer helpers are assigned yet.'
             },
             {

--- a/team.html
+++ b/team.html
@@ -324,7 +324,7 @@
     </div>
 
     <script type="module">
-        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, grantStreamScoreAccess, revokeStreamScoreAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=34';
+        import { getTeam, getPlayers, getGames, getConfigs, getTrackedCalendarEventUids, getUnreadChatCounts, getUserProfile, getAllUsers, saveTeamAvailabilityPreferences, grantScorekeeperAccess, revokeScorekeeperAccess, grantStreamScoreAccess, revokeStreamScoreAccess, getRsvps, getRsvpSummaries, submitRsvp, getMyRsvp, getLocalAttractionSponsors, getAdSpaceSponsors, postChatMessage, getPublicTrackingItems, getPlayerTrackingStatuses } from './js/db.js?v=35';
         import { normalizeExternalWebsiteUrl, selectRotatingSponsor } from './js/local-attractions.js?v=2';
         import { renderHeader, renderFooter, getUrlParams, formatDate, formatShortDate, formatTime, fetchAndParseCalendar, extractOpponent, isPracticeEvent, isTrackedCalendarEvent, escapeHtml, shareOrCopy } from './js/utils.js?v=11';
         import { fetchLeagueStandings } from './js/league-standings.js?v=1';

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -359,6 +359,14 @@ async function mockHomePlayerModules(page) {
                     return { success: true };
                 }
 
+                export async function grantVideographerAccessForApp() {
+                    return { success: true };
+                }
+
+                export async function revokeVideographerAccessForApp() {
+                    return { success: true };
+                }
+
                 export async function saveTeamScheduleNotificationsForApp(teamId, settings = {}) {
                     return {
                         enabled: settings.enabled !== false,

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -747,10 +747,9 @@ test('Android-sized schedule smoke covers practice packet and More workflow with
     await page.goto(appUrl(baseURL, '/schedule/team-1/practice-1?childId=player-1'), { waitUntil: 'domcontentloaded' });
 
     await expect(page.getByRole('heading', { name: 'Practice' })).toBeVisible();
-    await expect(page.getByRole('button', { name: /Practice packet ready/ })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'More, packet ready' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Practice packet ready, review packet' })).toBeVisible();
 
-    await page.getByRole('button', { name: /Practice packet ready/ }).click();
+    await page.getByRole('button', { name: 'Practice packet ready, review packet' }).click();
     await expect(page.getByRole('heading', { name: 'Practice hub' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Packet ready' })).toBeVisible();
     await expect(page.getByText('Ball Mastery')).toBeVisible();
@@ -885,9 +884,8 @@ test('app practice more tab uses hub cards and shares event details without a li
     await page.goto(appUrl(baseURL, '/schedule/team-1/practice-1?childId=player-1'), { waitUntil: 'domcontentloaded' });
 
     await expect(page.getByRole('heading', { name: 'Practice' })).toBeVisible();
-    await expect(page.getByRole('button', { name: /Practice packet ready/ })).toBeVisible();
-    await expect(page.getByRole('button', { name: 'More, packet ready' })).toBeVisible();
-    await page.getByRole('button', { name: /Practice packet ready/ }).click();
+    await expect(page.getByRole('button', { name: 'Practice packet ready, review packet' })).toBeVisible();
+    await page.getByRole('button', { name: 'Practice packet ready, review packet' }).click();
     await expect(page.getByRole('heading', { name: 'Practice hub' })).toBeVisible();
     const practiceHub = page.locator('.app-card').filter({ has: page.getByRole('heading', { name: 'Practice hub' }) });
     await expect(page.getByText('2 drills · 20 min · Main Gym')).toBeVisible();

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -194,6 +194,83 @@ async function mockSearchModules(page) {
             `
         });
     });
+
+    await page.route(/\/src\/lib\/teamDetailService\.ts(\?.*)?$/, async (route) => {
+        await route.fulfill({
+            status: 200,
+            contentType: 'application/javascript',
+            body: `
+                export async function inviteTeamAdminForApp() {
+                    return { status: 'sent', email: 'coach@example.com' };
+                }
+
+                export async function grantScorekeeperAccessForApp() {
+                    return { success: true };
+                }
+
+                export async function revokeScorekeeperAccessForApp() {
+                    return { success: true };
+                }
+
+                export async function grantVideographerAccessForApp() {
+                    return { success: true };
+                }
+
+                export async function revokeVideographerAccessForApp() {
+                    return { success: true };
+                }
+
+                export async function saveTeamScheduleNotificationsForApp(teamId, settings = {}) {
+                    return {
+                        enabled: settings.enabled !== false,
+                        reminderHours: settings.reminderHours || 24,
+                        delivery: 'team_chat',
+                        hasExplicitReminderHours: true,
+                        summary: 'Team default reminder window: 24 hours before event start.'
+                    };
+                }
+
+                export function buildPublicTeamGamesIcsUrl(teamId) {
+                    return teamId ? 'https://calendar.example.test/publicTeamGamesIcs?teamId=' + encodeURIComponent(teamId) : '';
+                }
+
+                export function canExposePublicFanFeed(team = {}, events = []) {
+                    return (events || []).some((event) => event?.type === 'game');
+                }
+
+                export async function loadParentTeamDetail(teamId) {
+                    const isRockets = teamId === 'team-2';
+                    return {
+                        team: {
+                            id: teamId,
+                            name: isRockets ? 'Rockets' : 'Bears',
+                            sport: isRockets ? 'Soccer' : 'Basketball',
+                            photoUrl: null,
+                            description: 'Parent-facing team page',
+                            zip: isRockets ? '64114' : '66210',
+                            leagueUrl: null,
+                            bracketUrl: null,
+                            streamUrl: null,
+                            websiteUrl: 'https://allplays.ai/team.html#teamId=' + encodeURIComponent(teamId),
+                            mediaUrl: 'https://allplays.ai/team-media.html#teamId=' + encodeURIComponent(teamId),
+                            registrationProvider: []
+                        },
+                        players: [],
+                        linkedPlayers: [],
+                        upcomingEvents: [],
+                        recentResults: [],
+                        nextEvent: null,
+                        record: { label: '2100', wins: 0, losses: 0, ties: 0, gamesPlayed: 0, winPercentage: null },
+                        standings: { enabled: false, label: 'No standings configured', rows: [], currentRow: null },
+                        leaderboards: [],
+                        trackingSummaries: [],
+                        sponsors: [],
+                        counts: { games: 0, practices: 0, completedGames: 0 }
+                    };
+                }
+            `
+        });
+    });
 }
 
 test.describe('app global search', () => {

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -32,19 +32,16 @@ async function openDesktopSearch(page) {
     const searchButton = page.getByRole('button', { name: 'Search' });
     const searchDialog = page.getByRole('dialog', { name: 'Search teams, players, actions, and help' });
 
+    await expect(searchButton).toBeVisible({ timeout: 15000 });
     await expect(async () => {
         await page.keyboard.press('Control+K');
-        if (await searchDialog.isVisible().catch(() => false)) {
-            return;
-        }
 
-        if (await searchButton.isVisible().catch(() => false)) {
+        try {
+            await expect(searchDialog).toBeVisible({ timeout: 1000 });
+        } catch {
             await searchButton.click();
             await expect(searchDialog).toBeVisible({ timeout: 1000 });
-            return;
         }
-
-        throw new Error('Desktop search controls not ready');
     }).toPass({ timeout: 15000 });
 }
 

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -201,6 +201,14 @@ async function mockTeamsModules(page) {
                     return { success: true };
                 }
 
+                export async function grantVideographerAccessForApp() {
+                    return { success: true };
+                }
+
+                export async function revokeVideographerAccessForApp() {
+                    return { success: true };
+                }
+
                 export async function saveTeamScheduleNotificationsForApp(teamId, settings = {}) {
                     return {
                         enabled: settings.enabled !== false,

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -16,9 +16,11 @@ vi.mock('../../js/db.js', () => ({
     updateEvent: vi.fn(),
     updateGame: vi.fn(),
     grantScorekeeperAccess: vi.fn(),
+    grantVideographerAccess: vi.fn(),
     inviteAdmin: vi.fn(),
     addTeamAdminEmail: vi.fn(),
-    revokeScorekeeperAccess: vi.fn()
+    revokeScorekeeperAccess: vi.fn(),
+    revokeVideographerAccess: vi.fn()
 }));
 
 vi.mock('../../js/firebase.js', () => ({
@@ -38,9 +40,9 @@ vi.mock('../../apps/app/src/lib/authService', () => ({
     getNativeAuthIdToken: vi.fn()
 }));
 
-import { buildAdminAcceptInviteUrl, buildPublicTeamGamesIcsUrl, buildTeamDetailModel, canExposePublicFanFeed, grantScorekeeperAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp, saveTeamScheduleNotificationsForApp } from '../../apps/app/src/lib/teamDetailService.ts';
+import { buildAdminAcceptInviteUrl, buildPublicTeamGamesIcsUrl, buildTeamDetailModel, canExposePublicFanFeed, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp } from '../../apps/app/src/lib/teamDetailService.ts';
 import { collection, getDocs, query, where } from '../../js/firebase.js';
-import { getAggregatedStatsForGames, getAdSpaceSponsors, getConfigs, getEvents, getGames, getLocalAttractionSponsors, getPlayers, getTeam, grantScorekeeperAccess, inviteAdmin, addTeamAdminEmail, revokeScorekeeperAccess, updateEvent, updateGame, updateTeam } from '../../js/db.js';
+import { getAggregatedStatsForGames, getAdSpaceSponsors, getConfigs, getEvents, getGames, getLocalAttractionSponsors, getPlayers, getTeam, grantScorekeeperAccess, grantVideographerAccess, inviteAdmin, addTeamAdminEmail, revokeScorekeeperAccess, revokeVideographerAccess, updateEvent, updateGame, updateTeam } from '../../js/db.js';
 import { sendInviteEmail } from '../../js/auth.js';
 
 describe('React app team detail model', () => {
@@ -87,17 +89,27 @@ describe('React app team detail model', () => {
     it('wraps scorekeeper grant mutations with app validation', async () => {
         grantScorekeeperAccess.mockResolvedValue(undefined);
         revokeScorekeeperAccess.mockResolvedValue(undefined);
+        grantVideographerAccess.mockResolvedValue(undefined);
+        revokeVideographerAccess.mockResolvedValue(undefined);
 
         await grantScorekeeperAccessForApp(' team-1 ', ' member-1 ');
         await revokeScorekeeperAccessForApp('team-1', 'member-1');
+        await grantVideographerAccessForApp(' team-1 ', ' member-2 ');
+        await revokeVideographerAccessForApp('team-1', 'member-2');
 
         expect(grantScorekeeperAccess).toHaveBeenCalledWith('team-1', 'member-1');
         expect(revokeScorekeeperAccess).toHaveBeenCalledWith('team-1', 'member-1');
+        expect(grantVideographerAccess).toHaveBeenCalledWith('team-1', 'member-2');
+        expect(revokeVideographerAccess).toHaveBeenCalledWith('team-1', 'member-2');
 
         grantScorekeeperAccess.mockClear();
+        grantVideographerAccess.mockClear();
         await expect(grantScorekeeperAccessForApp('', 'member-1')).rejects.toThrow('Team ID is required.');
         await expect(grantScorekeeperAccessForApp('team-1', '')).rejects.toThrow('Team member user ID is required.');
+        await expect(grantVideographerAccessForApp('', 'member-1')).rejects.toThrow('Team ID is required.');
+        await expect(grantVideographerAccessForApp('team-1', '')).rejects.toThrow('Team member user ID is required.');
         expect(grantScorekeeperAccess).not.toHaveBeenCalled();
+        expect(grantVideographerAccess).not.toHaveBeenCalled();
     });
 
     it('normalizes and saves team schedule reminder defaults with the legacy payload', async () => {
@@ -326,6 +338,7 @@ describe('React app team detail model', () => {
             teamPermissions: {
                 scorekeeping: { mode: 'selected', memberIds: ['scorekeeper-1', 'scorekeeper-1'] },
                 streaming: { mode: 'selected', memberIds: ['scorekeeper-1', 'video-1'] },
+                videography: { mode: 'selected', memberIds: ['video-1', 'video-1'] },
                 volunteer: { mode: 'selected', memberIds: ['snacks-1'] }
             },
             streamVolunteerEmails: ['video@example.com']
@@ -351,7 +364,7 @@ describe('React app team detail model', () => {
         expect(adminModel.staffPermissions.helperPermissions).toEqual([
             expect.objectContaining({ key: 'scorekeeper', grants: ['scorekeeper-1'] }),
             expect.objectContaining({ key: 'stream-score', grants: ['scorekeeper-1'] }),
-            expect.objectContaining({ key: 'videographer', grants: ['scorekeeper-1', 'video-1', 'video@example.com'] }),
+            expect.objectContaining({ key: 'videographer', grants: ['video-1', 'video@example.com'] }),
             expect.objectContaining({ key: 'volunteer', grants: ['snacks-1'] })
         ]);
 
@@ -368,6 +381,10 @@ describe('React app team detail model', () => {
         expect(targetedModel.staffPermissions.scorekeeperGrantTargets).toEqual([
             { userId: 'parent-1', name: 'Parent One', email: 'parent@example.com', playerNames: ['Sam Wing'], isGranted: false },
             { userId: 'scorekeeper-1', name: 'Pat Star', email: '', playerNames: ['Pat Star'], isGranted: true }
+        ]);
+        expect(targetedModel.staffPermissions.videographerGrantTargets).toEqual([
+            { userId: 'parent-1', name: 'Parent One', email: 'parent@example.com', playerNames: ['Sam Wing'], isGranted: false },
+            { userId: 'scorekeeper-1', name: 'Pat Star', email: '', playerNames: ['Pat Star'], isGranted: false }
         ]);
 
         const parentModel = buildTeamDetailModel({

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -1,6 +1,16 @@
 // @vitest-environment jsdom
 import { describe, expect, it, vi } from 'vitest';
 
+vi.mock('@capacitor/core', () => ({
+    Capacitor: {
+        isNativePlatform: () => false
+    }
+}), { virtual: true });
+
+vi.mock('@capacitor-firebase/authentication', () => ({
+    FirebaseAuthentication: {}
+}), { virtual: true });
+
 vi.mock('../../js/db.js', () => ({
     getAggregatedStatsForGames: vi.fn(),
     getAdSpaceSponsors: vi.fn(),
@@ -11,6 +21,7 @@ vi.mock('../../js/db.js', () => ({
     getPlayerTrackingStatuses: vi.fn(),
     getPublicTrackingItems: vi.fn(),
     getTeam: vi.fn(),
+    getAllUsers: vi.fn(),
     updateTeam: vi.fn(),
     getEvents: vi.fn(),
     updateEvent: vi.fn(),
@@ -35,14 +46,14 @@ vi.mock('../../js/auth.js', () => ({
     sendInviteEmail: vi.fn()
 }));
 
-vi.mock('../../apps/app/src/lib/authService', () => ({
+vi.mock('../../apps/app/src/lib/authService.ts', () => ({
     firebaseAuth: { app: { options: { projectId: 'demo-allplays' } } },
     getNativeAuthIdToken: vi.fn()
 }));
 
 import { buildAdminAcceptInviteUrl, buildPublicTeamGamesIcsUrl, buildTeamDetailModel, canExposePublicFanFeed, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp } from '../../apps/app/src/lib/teamDetailService.ts';
 import { collection, getDocs, query, where } from '../../js/firebase.js';
-import { getAggregatedStatsForGames, getAdSpaceSponsors, getConfigs, getEvents, getGames, getLocalAttractionSponsors, getPlayers, getTeam, grantScorekeeperAccess, grantVideographerAccess, inviteAdmin, addTeamAdminEmail, revokeScorekeeperAccess, revokeVideographerAccess, updateEvent, updateGame, updateTeam } from '../../js/db.js';
+import { getAggregatedStatsForGames, getAdSpaceSponsors, getAllUsers, getConfigs, getEvents, getGames, getLocalAttractionSponsors, getPlayers, getTeam, grantScorekeeperAccess, grantVideographerAccess, inviteAdmin, addTeamAdminEmail, revokeScorekeeperAccess, revokeVideographerAccess, updateEvent, updateGame, updateTeam } from '../../js/db.js';
 import { sendInviteEmail } from '../../js/auth.js';
 
 describe('React app team detail model', () => {
@@ -387,6 +398,26 @@ describe('React app team detail model', () => {
             { userId: 'scorekeeper-1', name: 'Pat Star', email: '', playerNames: ['Pat Star'], isGranted: false }
         ]);
 
+        const legacyLinkedModel = buildTeamDetailModel({
+            teamId: 'team-1',
+            team,
+            user: { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] },
+            players: [
+                { id: 'player-2', name: 'Sam Wing' }
+            ],
+            confirmedTeamMembers: [
+                {
+                    id: 'video-1',
+                    fullName: 'Video Parent',
+                    email: 'video@example.com',
+                    parentOf: [{ teamId: 'team-1', playerId: 'player-2' }]
+                }
+            ]
+        });
+        expect(legacyLinkedModel.staffPermissions.videographerGrantTargets).toEqual([
+            { userId: 'video-1', name: 'Video Parent', email: 'video@example.com', playerNames: ['Sam Wing'], isGranted: true }
+        ]);
+
         const parentModel = buildTeamDetailModel({
             teamId: 'team-1',
             team,
@@ -398,11 +429,12 @@ describe('React app team detail model', () => {
 
     it('loads pending admin invites for team admins but not parent members', async () => {
         getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears', ownerId: 'owner-1', adminEmails: ['coach@example.com'] });
-        getPlayers.mockResolvedValue([]);
+        getPlayers.mockResolvedValue([{ id: 'player-1', name: 'Pat Star' }]);
         getGames.mockResolvedValue([]);
         getConfigs.mockResolvedValue([]);
         getAggregatedStatsForGames.mockResolvedValue({});
         getAdSpaceSponsors.mockResolvedValue([]);
+        getAllUsers.mockResolvedValue([{ id: 'video-1', fullName: 'Video Parent', email: 'video@example.com', parentOf: [{ teamId: 'team-1', playerId: 'player-1' }] }]);
         getLocalAttractionSponsors.mockResolvedValue([]);
         const future = Date.now() + 60_000;
         const past = Date.now() - 60_000;
@@ -420,14 +452,20 @@ describe('React app team detail model', () => {
 
         const adminModel = await loadParentTeamDetail('team-1', { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] });
         expect(adminModel.staffPermissions.pendingInvites).toEqual(['pending@example.com']);
+        expect(adminModel.staffPermissions.videographerGrantTargets).toEqual([
+            { userId: 'video-1', name: 'Video Parent', email: 'video@example.com', playerNames: ['Pat Star'], isGranted: false }
+        ]);
+        expect(getAllUsers).toHaveBeenCalledTimes(1);
         expect(getDocs).toHaveBeenCalledTimes(1);
         expect(collection).toHaveBeenCalledWith({}, 'accessCodes');
         expect(where).toHaveBeenCalledWith('teamId', '==', 'team-1');
         expect(query).toHaveBeenCalledWith({ db: {}, name: 'accessCodes' }, { field: 'teamId', op: '==', value: 'team-1' });
 
         getDocs.mockClear();
+        getAllUsers.mockClear();
         const parentModel = await loadParentTeamDetail('team-1', { uid: 'parent-1', email: 'parent@example.com', displayName: 'Parent', roles: ['parent'] });
         expect(parentModel.staffPermissions).toBeNull();
         expect(getDocs).not.toHaveBeenCalled();
+        expect(getAllUsers).not.toHaveBeenCalled();
     });
 });

--- a/tests/unit/app-team-detail-staff-permissions.test.jsx
+++ b/tests/unit/app-team-detail-staff-permissions.test.jsx
@@ -7,7 +7,9 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 const teamDetailMocks = vi.hoisted(() => ({
     loadParentTeamDetail: vi.fn(),
     grantScorekeeperAccessForApp: vi.fn(),
+    grantVideographerAccessForApp: vi.fn(),
     revokeScorekeeperAccessForApp: vi.fn(),
+    revokeVideographerAccessForApp: vi.fn(),
     inviteTeamAdminForApp: vi.fn(),
     saveTeamScheduleNotificationsForApp: vi.fn(),
     buildPublicTeamGamesIcsUrl: vi.fn((teamId) => `https://us-central1-all-plays-prod.cloudfunctions.net/publicTeamGamesIcs?teamId=${encodeURIComponent(teamId)}`),
@@ -142,7 +144,9 @@ beforeEach(() => {
     window.scrollTo = vi.fn();
     publicActionMocks.copyPublicText.mockResolvedValue('copied');
     teamDetailMocks.grantScorekeeperAccessForApp.mockResolvedValue(undefined);
+    teamDetailMocks.grantVideographerAccessForApp.mockResolvedValue(undefined);
     teamDetailMocks.revokeScorekeeperAccessForApp.mockResolvedValue(undefined);
+    teamDetailMocks.revokeVideographerAccessForApp.mockResolvedValue(undefined);
     teamDetailMocks.inviteTeamAdminForApp.mockResolvedValue({
         email: 'newcoach@example.com',
         status: 'sent',
@@ -170,6 +174,8 @@ describe('React app TeamDetail staff permissions overview', () => {
                 { key: 'videographer', title: 'Videographer', grants: ['video@example.com'], emptyText: 'No videographer helpers are assigned yet.' },
                 { key: 'volunteer', title: 'Volunteer', grants: [], emptyText: 'No general volunteer permissions are assigned yet.' }
             ],
+            scorekeeperGrantTargets: [],
+            videographerGrantTargets: [],
             hasAnyStaff: true
         });
 
@@ -193,6 +199,8 @@ describe('React app TeamDetail staff permissions overview', () => {
             staff: [{ label: 'owner@example.com', role: 'Owner' }, { label: 'coach@example.com', role: 'Admin' }],
             pendingInvites: ['pending@example.com'],
             helperPermissions: [],
+            scorekeeperGrantTargets: [],
+            videographerGrantTargets: [],
             hasAnyStaff: true
         });
 
@@ -216,6 +224,8 @@ describe('React app TeamDetail staff permissions overview', () => {
             staff: [{ label: 'owner@example.com', role: 'Owner' }],
             pendingInvites: [],
             helperPermissions: [],
+            scorekeeperGrantTargets: [],
+            videographerGrantTargets: [],
             hasAnyStaff: true
         });
 
@@ -240,6 +250,7 @@ describe('React app TeamDetail staff permissions overview', () => {
             scorekeeperGrantTargets: [
                 { userId: 'parent-1', name: 'Parent One', email: 'parent@example.com', playerNames: ['Sam Wing'], isGranted: false }
             ],
+            videographerGrantTargets: [],
             hasAnyStaff: true
         });
 
@@ -262,6 +273,7 @@ describe('React app TeamDetail staff permissions overview', () => {
             scorekeeperGrantTargets: [
                 { userId: 'scorekeeper-1', name: 'Score Keeper', email: '', playerNames: ['Pat Star'], isGranted: true }
             ],
+            videographerGrantTargets: [],
             hasAnyStaff: true
         });
 
@@ -284,6 +296,7 @@ describe('React app TeamDetail staff permissions overview', () => {
             scorekeeperGrantTargets: [
                 { userId: 'parent-1', name: 'Parent One', email: 'parent@example.com', playerNames: ['Sam Wing'], isGranted: false }
             ],
+            videographerGrantTargets: [],
             hasAnyStaff: true
         });
 
@@ -301,5 +314,50 @@ describe('React app TeamDetail staff permissions overview', () => {
 
         expect(container.textContent).not.toContain('Team Staff & Permissions');
         expect(container.textContent).not.toContain('owner@example.com');
+    });
+
+    it('grants videographer access to an existing linked team member and refreshes staff state', async () => {
+        const { container } = await renderTeamDetail({
+            staff: [{ label: 'owner@example.com', role: 'Owner' }],
+            pendingInvites: [],
+            helperPermissions: [],
+            scorekeeperGrantTargets: [],
+            videographerGrantTargets: [
+                { userId: 'parent-1', name: 'Parent One', email: 'parent@example.com', playerNames: ['Sam Wing'], isGranted: false }
+            ],
+            hasAnyStaff: true
+        });
+
+        await clickButton(container, 'More');
+
+        expect(container.textContent).toContain('Videographer access');
+        expect(container.textContent).toContain('No videographer helper grant. Linked to Sam Wing.');
+        await clickButton(container, 'Grant videographer');
+
+        expect(teamDetailMocks.grantVideographerAccessForApp).toHaveBeenCalledWith('team-1', 'parent-1');
+        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledTimes(2);
+        expect(container.textContent).toContain('Videographer access granted.');
+    });
+
+    it('revokes videographer access from an existing linked team member and refreshes staff state', async () => {
+        const { container } = await renderTeamDetail({
+            staff: [{ label: 'owner@example.com', role: 'Owner' }],
+            pendingInvites: [],
+            helperPermissions: [],
+            scorekeeperGrantTargets: [],
+            videographerGrantTargets: [
+                { userId: 'video-1', name: 'Video Helper', email: '', playerNames: ['Pat Star'], isGranted: true }
+            ],
+            hasAnyStaff: true
+        });
+
+        await clickButton(container, 'More');
+
+        expect(container.textContent).toContain('Can capture live-game camera and media. Linked to Pat Star.');
+        await clickButton(container, 'Revoke videographer');
+
+        expect(teamDetailMocks.revokeVideographerAccessForApp).toHaveBeenCalledWith('team-1', 'video-1');
+        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledTimes(2);
+        expect(container.textContent).toContain('Videographer access revoked.');
     });
 });

--- a/tests/unit/team-scorekeeper-grants.test.js
+++ b/tests/unit/team-scorekeeper-grants.test.js
@@ -45,6 +45,12 @@ function loadScorekeeperHelpers() {
 }
 
 describe('team scorekeeper grants', () => {
+    it('pins the latest db cache-busting version for the team page module', () => {
+        const source = readTeamHtml();
+
+        expect(source).toContain("from './js/db.js?v=35'");
+    });
+
     it('wires the team page to grant and revoke scoped scorekeeper access', () => {
         const source = readTeamHtml();
 

--- a/tests/unit/team-staff-permissions.test.js
+++ b/tests/unit/team-staff-permissions.test.js
@@ -10,6 +10,7 @@ describe('team staff and permissions view model', () => {
             teamPermissions: {
                 scorekeeping: { mode: 'selected', memberIds: [' scorekeeper-1 ', 'stream-score-1', 'scorekeeper-1'] },
                 streaming: { mode: 'selected', memberIds: ['video-1', 'stream-score-1'] },
+                videography: { mode: 'selected', memberIds: ['video-1', 'stream-score-1'] },
                 volunteer: { mode: 'selected', memberIds: ['snacks-1'] }
             },
             streamVolunteerEmails: ['video@example.com']


### PR DESCRIPTION
Closes #1770

## What changed
- added app-side videographer grant and revoke mutators that persist `teamPermissions.videography.memberIds`
- extended the TeamDetail staff permissions model with videographer grant targets sourced from confirmed linked team members
- rendered an inline videographer access panel in TeamDetail with scoped grant/revoke actions, loading protection, and success/error feedback
- corrected staff permission summaries to read videographer grants from `teamPermissions.videography` instead of the streaming permission bucket

## Why
The new TeamDetail screen already supported scoped scorekeeper grants, but videographer access still required falling back to legacy `edit-team.html`. This closes that parity gap for web and Capacitor app flows while keeping the broader legacy manage-staff link for unrelated settings.

## Validation
- ran focused Vitest coverage for TeamDetail service, TeamDetail staff permissions UI, and team staff permission summaries