### PR TITLE
Fix team media append ordering and album read amplification

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -899,6 +899,15 @@ service cloud.firestore {
              data.updatedAt == request.time;
     }
 
+    function isTeamMediaUploadCounterUpdate(teamId) {
+      return hasTeamMediaUploadGrant(teamId) &&
+             resource.data.get('visibility', 'team') == 'team' &&
+             request.resource.data.diff(resource.data).affectedKeys().hasOnly(['nextMediaOrder', 'updatedAt']) &&
+             request.resource.data.get('nextMediaOrder', 0) is number &&
+             request.resource.data.get('nextMediaOrder', 0) == resource.data.get('nextMediaOrder', 0) + 1 &&
+             request.resource.data.updatedAt == request.time;
+    }
+
     function isOwnTeamMediaUploadSoftDelete(teamId) {
       return canAccessTeamChat(teamId) &&
              resource.data.type in ['photo', 'file'] &&
@@ -1410,7 +1419,8 @@ service cloud.firestore {
 
       match /mediaFolders/{folderId} {
         allow read: if canReadTeamMediaFolder(teamId, resource.data);
-        allow create, update, delete: if isTeamOwnerOrAdmin(teamId);
+        allow create, delete: if isTeamOwnerOrAdmin(teamId);
+        allow update: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCounterUpdate(teamId);
       }
 
       match /mediaItems/{itemId} {

--- a/js/db.js
+++ b/js/db.js
@@ -614,10 +614,33 @@ export async function createTeamMediaFolder(teamId, draft = {}) {
         name: folder.name,
         visibility: folder.visibility,
         order: existingFolders.length,
+        nextMediaOrder: 0,
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp()
     });
     return docRef.id;
+}
+
+async function reserveNextTeamMediaOrder(teamId, folderId) {
+    const folderRef = doc(db, `teams/${teamId}/mediaFolders`, folderId);
+    return runTransaction(db, async (transaction) => {
+        const folderSnapshot = await transaction.get(folderRef);
+        if (!folderSnapshot.exists()) {
+            throw new Error('Choose a folder for this media item.');
+        }
+
+        const folderData = folderSnapshot.data() || {};
+        const nextMediaOrder = Number.isFinite(Number(folderData.nextMediaOrder))
+            ? Number(folderData.nextMediaOrder)
+            : Date.now();
+
+        transaction.update(folderRef, {
+            nextMediaOrder: nextMediaOrder + 1,
+            updatedAt: serverTimestamp()
+        });
+
+        return nextMediaOrder;
+    });
 }
 
 export async function updateTeamMediaFolder(teamId, folderId, draft = {}) {
@@ -652,13 +675,13 @@ export async function createTeamMediaLink(teamId, folderId, media = {}) {
     if (!teamId || !cleanFolderId) throw new Error('Choose a folder for this media link.');
     if (!title || !url) throw new Error('Media title and URL are required.');
     if (!isSafeTeamMediaUrl(url)) throw new Error('Use a valid http or https media link.');
-    const existingItems = await getTeamMediaItems(teamId, cleanFolderId);
+    const order = await reserveNextTeamMediaOrder(teamId, cleanFolderId);
     const docRef = await addDoc(getTeamMediaItemsRef(teamId), {
         folderId: cleanFolderId,
         title,
         url,
         type: 'video-link',
-        order: existingItems.length,
+        order,
         deleted: false,
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp()
@@ -716,7 +739,7 @@ export async function uploadTeamMediaPhoto(teamId, folderId, file, options = {})
     });
 
     const url = await getDownloadURL(snapshot.ref);
-    const existingItems = await getTeamMediaItems(cleanTeamId, cleanFolderId);
+    const order = await reserveNextTeamMediaOrder(cleanTeamId, cleanFolderId);
     const docRef = await addDoc(getTeamMediaItemsRef(cleanTeamId), {
         folderId: cleanFolderId,
         title: String(file.name || 'Uploaded photo').trim() || 'Uploaded photo',
@@ -726,7 +749,7 @@ export async function uploadTeamMediaPhoto(teamId, folderId, file, options = {})
         uploadedBy: currentUser.uid,
         size: Number(file.size || 0),
         mimeType: file.type || 'image/jpeg',
-        order: existingItems.length,
+        order,
         deleted: false,
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp()
@@ -762,7 +785,7 @@ export async function uploadTeamMediaFile(teamId, folderId, file, options = {}) 
     });
 
     const url = await getDownloadURL(snapshot.ref);
-    const existingItems = await getTeamMediaItems(cleanTeamId, cleanFolderId);
+    const order = await reserveNextTeamMediaOrder(cleanTeamId, cleanFolderId);
     const docRef = await addDoc(getTeamMediaItemsRef(cleanTeamId), {
         folderId: cleanFolderId,
         title: String(file.name || 'Uploaded file').trim() || 'Uploaded file',
@@ -773,7 +796,7 @@ export async function uploadTeamMediaFile(teamId, folderId, file, options = {}) 
         uploadedBy: currentUser.uid,
         size: Number(file.size || 0),
         mimeType: file.type,
-        order: existingItems.length,
+        order,
         deleted: false,
         createdAt: serverTimestamp(),
         updatedAt: serverTimestamp()

--- a/js/db.js
+++ b/js/db.js
@@ -630,9 +630,7 @@ async function reserveNextTeamMediaOrder(teamId, folderId) {
         }
 
         const folderData = folderSnapshot.data() || {};
-        const nextMediaOrder = Number.isFinite(Number(folderData.nextMediaOrder))
-            ? Number(folderData.nextMediaOrder)
-            : Date.now();
+        const nextMediaOrder = Number(folderData.nextMediaOrder || 0);
 
         transaction.update(folderRef, {
             nextMediaOrder: nextMediaOrder + 1,

--- a/js/team-media.js
+++ b/js/team-media.js
@@ -16,7 +16,7 @@ import {
     bulkDeleteTeamMediaItems,
     setTeamMediaAlbumCover,
     updateTeamMediaItem // Add this new import
-} from './db.js?v=33';
+} from './db.js?v=34';
 import {
     canContributeTeamMedia,
     canDeleteTeamMediaItem,

--- a/team-media.html
+++ b/team-media.html
@@ -96,6 +96,6 @@
         <section id="album-detail"></section>
     </main>
 
-    <script type="module" src="js/team-media.js?v=5"></script>
+    <script type="module" src="js/team-media.js?v=6"></script>
 </body>
 </html>

--- a/tests/unit/app-team-media.test.jsx
+++ b/tests/unit/app-team-media.test.jsx
@@ -220,7 +220,10 @@ describe('React app TeamMedia upload flow', () => {
   });
 
   it('uploads every selected photo and renders per-file status rows', async () => {
-    parentToolsServiceMocks.uploadParentTeamMediaPhoto.mockResolvedValue(undefined);
+    const pendingResolvers = [];
+    parentToolsServiceMocks.uploadParentTeamMediaPhoto.mockImplementation(() => new Promise((resolve) => {
+      pendingResolvers.push(resolve);
+    }));
 
     const { container, root } = await renderTeamMedia(uploadableModel());
     const photoInput = container.querySelector('input[accept="image/*"]');
@@ -235,6 +238,12 @@ describe('React app TeamMedia upload flow', () => {
     expect(parentToolsServiceMocks.uploadParentTeamMediaPhoto).toHaveBeenCalledTimes(2);
     expect(parentToolsServiceMocks.uploadParentTeamMediaPhoto).toHaveBeenNthCalledWith(1, 'team-1', 'folder-1', files[0]);
     expect(parentToolsServiceMocks.uploadParentTeamMediaPhoto).toHaveBeenNthCalledWith(2, 'team-1', 'folder-1', files[1]);
+    expect(pendingResolvers).toHaveLength(2);
+
+    await act(async () => {
+      pendingResolvers.splice(0).forEach((resolve) => resolve());
+    });
+
     expect(container.textContent).toContain('Upload progress');
     expect(container.textContent).toContain('tipoff.jpg');
     expect(container.textContent).toContain('bench.png');

--- a/tests/unit/team-media-db-ordering.test.js
+++ b/tests/unit/team-media-db-ordering.test.js
@@ -1,0 +1,166 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const folderState = vi.hoisted(() => ({ nextMediaOrder: 0 }));
+const addDocState = vi.hoisted(() => ({ nextId: 1 }));
+const firebaseMocks = vi.hoisted(() => ({
+    addDoc: vi.fn(async (_collectionRef, data) => ({ id: `media-${addDocState.nextId++}`, data })),
+    collection: vi.fn((_db, path) => ({ path })),
+    getCountFromServer: vi.fn(),
+    getDoc: vi.fn(),
+    getDocs: vi.fn(),
+    getDownloadURL: vi.fn(async () => 'https://cdn.example.test/uploaded-file'),
+    doc: vi.fn((_db, path, id) => ({ path: `${path}/${id}` })),
+    orderBy: vi.fn(),
+    query: vi.fn((...parts) => parts),
+    runTransaction: vi.fn(async (_db, callback) => callback({
+        get: async () => ({
+            exists: () => true,
+            data: () => ({ nextMediaOrder: folderState.nextMediaOrder })
+        }),
+        update: (_ref, payload) => {
+            folderState.nextMediaOrder = payload.nextMediaOrder;
+        }
+    })),
+    serverTimestamp: vi.fn(() => 'server-ts'),
+    where: vi.fn(),
+    writeBatch: vi.fn(),
+}));
+
+const uploadTaskQueue = vi.hoisted(() => []);
+
+vi.mock('../../js/firebase.js?v=17', () => ({
+    db: {},
+    auth: { currentUser: { uid: 'user-1' } },
+    storage: {},
+    functions: {},
+    collection: firebaseMocks.collection,
+    getDocs: firebaseMocks.getDocs,
+    getDoc: firebaseMocks.getDoc,
+    doc: firebaseMocks.doc,
+    addDoc: firebaseMocks.addDoc,
+    updateDoc: vi.fn(),
+    deleteDoc: vi.fn(),
+    setDoc: vi.fn(),
+    query: firebaseMocks.query,
+    where: firebaseMocks.where,
+    orderBy: firebaseMocks.orderBy,
+    Timestamp: { now: vi.fn(() => ({ toMillis: () => Date.now() })) },
+    increment: vi.fn(),
+    arrayUnion: vi.fn(),
+    arrayRemove: vi.fn(),
+    deleteField: vi.fn(),
+    limit: vi.fn(),
+    startAfter: vi.fn(),
+    getCountFromServer: firebaseMocks.getCountFromServer,
+    onSnapshot: vi.fn(),
+    serverTimestamp: firebaseMocks.serverTimestamp,
+    collectionGroup: vi.fn(),
+    writeBatch: firebaseMocks.writeBatch,
+    runTransaction: firebaseMocks.runTransaction,
+    httpsCallable: vi.fn(),
+    ref: vi.fn((_storage, path) => ({ fullPath: path })),
+    uploadBytes: vi.fn(),
+    getDownloadURL: firebaseMocks.getDownloadURL,
+    deleteObject: vi.fn()
+}));
+
+vi.mock('../../js/firebase-images.js?v=6', () => ({
+    imageStorage: {},
+    ensureImageAuth: vi.fn(),
+    requireImageAuth: vi.fn()
+}));
+
+vi.mock('../../js/team-media-utils.js?v=3', () => ({
+    buildBulkDeleteUpdates: vi.fn(),
+    buildMoveUpdates: vi.fn(),
+    buildReorderUpdates: vi.fn(),
+    isSafeTeamMediaUrl: vi.fn(() => true),
+    isSupportedTeamMediaDocument: vi.fn(() => true),
+    isSupportedTeamMediaImage: vi.fn(() => true),
+    normalizeTeamMediaFolderDraft: vi.fn((draft = {}) => ({
+        name: String(draft.name || '').trim(),
+        visibility: String(draft.visibility || 'team').trim() || 'team'
+    })),
+    normalizeAlbumVisibility: vi.fn((value) => value),
+    sortByMediaOrder: vi.fn((items) => items)
+}));
+
+vi.mock('../../js/vendor/firebase-storage.js', () => ({
+    uploadBytesResumable: vi.fn((_storageRef, _file, _metadata) => {
+        const task = {
+            snapshot: { ref: { fullPath: 'team-media/mock-upload' } },
+            on: vi.fn((_event, _progress, _error, complete) => {
+                uploadTaskQueue.push(() => complete());
+            })
+        };
+        return task;
+    })
+}));
+
+describe('team media db ordering', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        folderState.nextMediaOrder = 0;
+        addDocState.nextId = 1;
+        uploadTaskQueue.length = 0;
+    });
+
+    it('assigns unique sequential orders to concurrent photo uploads without album reads', async () => {
+        const { uploadTeamMediaPhoto } = await import('../../js/db.js');
+        const files = [
+            new File(['photo-1'], 'tipoff.jpg', { type: 'image/jpeg' }),
+            new File(['photo-2'], 'bench.jpg', { type: 'image/jpeg' })
+        ];
+
+        const uploadPromises = files.map((file) => uploadTeamMediaPhoto('team-1', 'folder-1', file));
+        expect(uploadTaskQueue).toHaveLength(2);
+
+        uploadTaskQueue.splice(0).forEach((complete) => complete());
+        await Promise.all(uploadPromises);
+
+        expect(firebaseMocks.getDocs).not.toHaveBeenCalled();
+        expect(firebaseMocks.runTransaction).toHaveBeenCalledTimes(2);
+        expect(firebaseMocks.addDoc).toHaveBeenNthCalledWith(1, { path: 'teams/team-1/mediaItems' }, expect.objectContaining({
+            folderId: 'folder-1',
+            title: 'tipoff.jpg',
+            order: 0,
+            type: 'photo'
+        }));
+        expect(firebaseMocks.addDoc).toHaveBeenNthCalledWith(2, { path: 'teams/team-1/mediaItems' }, expect.objectContaining({
+            folderId: 'folder-1',
+            title: 'bench.jpg',
+            order: 1,
+            type: 'photo'
+        }));
+    });
+
+    it('reuses the folder counter for link and file appends without reloading album items', async () => {
+        folderState.nextMediaOrder = Number.NaN;
+        const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(5000);
+        const { createTeamMediaLink, uploadTeamMediaFile } = await import('../../js/db.js');
+        const file = new File(['doc'], 'lineup.pdf', { type: 'application/pdf' });
+
+        const linkId = await createTeamMediaLink('team-1', 'folder-1', {
+            title: 'Replay',
+            url: 'https://video.example.test/replay'
+        });
+        const filePromise = uploadTeamMediaFile('team-1', 'folder-1', file);
+        uploadTaskQueue.splice(0).forEach((complete) => complete());
+        const fileId = await filePromise;
+        dateNowSpy.mockRestore();
+
+        expect(linkId).toBe('media-1');
+        expect(fileId).toBe('media-2');
+        expect(firebaseMocks.getDocs).not.toHaveBeenCalled();
+        expect(firebaseMocks.addDoc).toHaveBeenNthCalledWith(1, { path: 'teams/team-1/mediaItems' }, expect.objectContaining({
+            title: 'Replay',
+            order: 5000,
+            type: 'video-link'
+        }));
+        expect(firebaseMocks.addDoc).toHaveBeenNthCalledWith(2, { path: 'teams/team-1/mediaItems' }, expect.objectContaining({
+            title: 'lineup.pdf',
+            order: 5001,
+            type: 'file'
+        }));
+    });
+});

--- a/tests/unit/team-media-db-ordering.test.js
+++ b/tests/unit/team-media-db-ordering.test.js
@@ -134,9 +134,8 @@ describe('team media db ordering', () => {
         }));
     });
 
-    it('reuses the folder counter for link and file appends without reloading album items', async () => {
+    it('starts legacy folders at zero when the media order counter is missing', async () => {
         folderState.nextMediaOrder = Number.NaN;
-        const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(5000);
         const { createTeamMediaLink, uploadTeamMediaFile } = await import('../../js/db.js');
         const file = new File(['doc'], 'lineup.pdf', { type: 'application/pdf' });
 
@@ -147,19 +146,18 @@ describe('team media db ordering', () => {
         const filePromise = uploadTeamMediaFile('team-1', 'folder-1', file);
         uploadTaskQueue.splice(0).forEach((complete) => complete());
         const fileId = await filePromise;
-        dateNowSpy.mockRestore();
 
         expect(linkId).toBe('media-1');
         expect(fileId).toBe('media-2');
         expect(firebaseMocks.getDocs).not.toHaveBeenCalled();
         expect(firebaseMocks.addDoc).toHaveBeenNthCalledWith(1, { path: 'teams/team-1/mediaItems' }, expect.objectContaining({
             title: 'Replay',
-            order: 5000,
+            order: 0,
             type: 'video-link'
         }));
         expect(firebaseMocks.addDoc).toHaveBeenNthCalledWith(2, { path: 'teams/team-1/mediaItems' }, expect.objectContaining({
             title: 'lineup.pdf',
-            order: 5001,
+            order: 1,
             type: 'file'
         }));
     });

--- a/tests/unit/team-media-item-rename.test.js
+++ b/tests/unit/team-media-item-rename.test.js
@@ -16,7 +16,7 @@ const mocks = vi.hoisted(() => ({
     checkAuth: vi.fn()
 }));
 
-vi.mock('../../js/db.js?v=33', () => {
+vi.mock('../../js/db.js?v=34', () => {
     return {
         getTeam: mocks.getTeam,
         getTeamMediaFolders: mocks.getTeamMediaFolders,

--- a/tests/unit/team-media-page.test.js
+++ b/tests/unit/team-media-page.test.js
@@ -21,7 +21,7 @@ describe('team media entry point', () => {
         const pageJs = readRepoFile('js/team-media.js');
         const rules = readRepoFile('firestore.rules');
 
-        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=5"></script>');
+        expect(pageHtml).toContain('<script type="module" src="js/team-media.js?v=6"></script>');
         expect(pageHtml).toContain('id="team-media-upload-panel"');
         expect(pageHtml).toContain('id="team-media-admin-panel"');
         expect(pageHtml).toContain('id="bulk-actions"');

--- a/tests/unit/team-media-rules.test.js
+++ b/tests/unit/team-media-rules.test.js
@@ -15,11 +15,16 @@ describe('team media Firestore rules', () => {
         const mediaRules = rules.slice(mediaRulesStart, mediaRulesEnd);
 
         expect(mediaRules).toContain('allow read: if canReadTeamMediaFolder(teamId, resource.data);');
+        expect(mediaRules).toContain('allow create, delete: if isTeamOwnerOrAdmin(teamId);');
+        expect(mediaRules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCounterUpdate(teamId);');
         expect(mediaRules).toContain('allow read: if canReadTeamMediaItem(teamId, resource.data);');
         expect(mediaRules).toContain('allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);');
         expect(mediaRules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaUploadSoftDelete(teamId) || isTeamMediaTitleUpdate(teamId);');
         expect(rules).toContain("teamId in get(userPath).data.get('teamMediaUploadTeamIds', [])");
         expect(rules).toContain("teamId in get(userPath).data.get('mediaUploadTeamIds', [])");
+        expect(rules).toContain('function isTeamMediaUploadCounterUpdate(teamId) {');
+        expect(rules).toContain("request.resource.data.diff(resource.data).affectedKeys().hasOnly(['nextMediaOrder', 'updatedAt'])");
+        expect(rules).toContain("request.resource.data.get('nextMediaOrder', 0) == resource.data.get('nextMediaOrder', 0) + 1");
         expect(rules).toContain('return hasTeamMediaUploadGrant(teamId) &&');
         expect(rules).toContain('canUploadTeamMediaFolder(teamId, data.folderId)');
         expect(rules).toContain("data.type in ['photo', 'file']");

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -34,12 +34,16 @@ describe('team media page wiring', () => {
         const rules = fs.readFileSync(path.join(repoRoot, 'firestore.rules'), 'utf8');
         expect(rules).toContain('match /mediaFolders/{folderId}');
         expect(rules).toContain('allow read: if canReadTeamMediaFolder(teamId, resource.data);');
+        expect(rules).toContain('allow create, delete: if isTeamOwnerOrAdmin(teamId);');
+        expect(rules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCounterUpdate(teamId);');
         expect(rules).toContain('allow read: if canReadTeamMediaItem(teamId, resource.data);');
         expect(rules).toContain('allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);');
         expect(rules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaUploadSoftDelete(teamId) || isTeamMediaTitleUpdate(teamId);');
         expect(rules).toContain("folderData.get('visibility', 'team') == 'team'");
         expect(rules).toContain("get(folderPath).data.get('visibility', 'team') == 'team'");
         expect(rules).toContain("teamId in get(userPath).data.get('teamMediaUploadTeamIds', [])");
+        expect(rules).toContain('function isTeamMediaUploadCounterUpdate(teamId) {');
+        expect(rules).toContain("request.resource.data.get('nextMediaOrder', 0) == resource.data.get('nextMediaOrder', 0) + 1");
         expect(rules).toContain('canUploadTeamMediaFolder(teamId, data.folderId)');
     });
 

--- a/tests/unit/team-media-wiring.test.js
+++ b/tests/unit/team-media-wiring.test.js
@@ -14,11 +14,11 @@ describe('team media page wiring', () => {
         const page = fs.readFileSync(path.join(repoRoot, 'team-media.html'), 'utf8');
         const source = fs.readFileSync(path.join(repoRoot, 'js/team-media.js'), 'utf8');
 
-        expect(page).toContain('src="js/team-media.js?v=5"');
+        expect(page).toContain('src="js/team-media.js?v=6"');
         expect(page).toContain('Add album');
         expect(page).toContain('Upload files');
         expect(page).toContain('Save video link');
-        expect(source).toContain("from './db.js?v=33'");
+        expect(source).toContain("from './db.js?v=34'");
         expect(source).toContain("import { checkAuth } from './auth.js?v=15';");
         expect(source).toContain('checkAuth(async (user) => {');
         expect(source).toContain('team.html#teamId=${encodeURIComponent(state.teamId)}');


### PR DESCRIPTION
Closes #1778

## What changed
- added a folder-scoped `nextMediaOrder` counter in `js/db.js` and reserve order values through a Firestore transaction before writing media items
- reused that atomic append path for photo uploads, file uploads, and saved video links so they no longer read the full album just to compute `order`
- initialized new media folders with `nextMediaOrder: 0`
- bumped the legacy team media cache-bust imports so the updated `db.js` logic is picked up by the browser
- added focused tests for concurrent photo uploads and repeated link/file appends, plus tightened the React Team Media upload test to prove the batch photo flow starts concurrent uploads

## Why
The React Team Media photo flow uploads multiple files in parallel. The old `getTeamMediaItems(...).length` approach burned reads per file and let concurrent uploads assign duplicate `order` values, which made album ordering unstable. The new folder counter keeps append ordering monotonic without album reload scans.