### PR TITLE
Route mobile game detail to live schedule event

### DIFF
--- a/apps/app/src/pages/GameDetail.test.tsx
+++ b/apps/app/src/pages/GameDetail.test.tsx
@@ -1,22 +1,24 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+// @vitest-environment jsdom
 
-const liveGameChatMocks = vi.hoisted(() => ({
-  canUseLiveGameChat: vi.fn(),
-  getLiveGameChatNotice: vi.fn(),
-  sendLiveGameChatMessage: vi.fn(),
-  subscribeToLiveGameChat: vi.fn(() => vi.fn())
-}));
+import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-vi.mock('../lib/liveGameChatService', () => liveGameChatMocks);
+const scheduleServiceMocks = vi.hoisted(() => ({
+  loadParentSchedule: vi.fn()
+}))
 
-import { GameDetail } from './GameDetail';
-import { mockGames } from '../data/mockData';
-import type { AuthState } from '../lib/types';
+vi.mock('../lib/scheduleService', () => scheduleServiceMocks)
+
+import { GameDetail } from './GameDetail'
+import type { AuthState } from '../lib/types'
 
 const auth: AuthState = {
-  user: null,
+  user: {
+    uid: 'parent-1',
+    email: 'parent@example.com',
+    displayName: 'Pat Parent'
+  } as any,
   profile: null,
   loading: false,
   error: null,
@@ -27,117 +29,83 @@ const auth: AuthState = {
   isPlatformAdmin: false,
   refresh: vi.fn(),
   signOut: vi.fn()
-};
+}
 
 function renderGameDetail(path = '/games/game-1') {
   return render(
     <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route path="/games/:gameId" element={<GameDetail auth={auth} />} />
-        <Route path="/schedule" element={<div>Schedule</div>} />
+        <Route path="/schedule/:teamId/:eventId" element={(
+          <div>
+            <h1>Availability</h1>
+            <div>Rideshare</div>
+            <div>Assignments</div>
+            <div>Live event workflow</div>
+          </div>
+        )}
+        />
+        <Route path="/schedule" element={<div>Schedule home</div>} />
       </Routes>
     </MemoryRouter>
-  );
+  )
 }
 
-describe('GameDetail play-by-play audio', () => {
+describe('GameDetail route resolution', () => {
   beforeEach(() => {
-    vi.clearAllMocks();
-    liveGameChatMocks.canUseLiveGameChat.mockReturnValue(true);
-    liveGameChatMocks.getLiveGameChatNotice.mockReturnValue(null);
-    liveGameChatMocks.subscribeToLiveGameChat.mockImplementation((...args: any[]) => {
-      const callback = args[2] as (messages: Array<{ id: string; senderName: string; text: string }>) => void;
-      callback([{ id: 'chat-1', senderName: 'Jamie', text: 'Let\'s go Bears!' }]);
-      return vi.fn();
-    });
-    liveGameChatMocks.sendLiveGameChatMessage.mockResolvedValue(undefined);
-    localStorage.clear();
-    vi.stubGlobal('speechSynthesis', { speak: vi.fn(), cancel: vi.fn() });
-    vi.stubGlobal('SpeechSynthesisUtterance', vi.fn(function MockUtterance(this: SpeechSynthesisUtterance, text: string) {
-      this.text = text;
-    }));
-  });
+    vi.clearAllMocks()
+  })
 
-  it('renders an accessible announcer toggle and live play-by-play events', () => {
-    renderGameDetail();
+  afterEach(() => {
+    cleanup()
+  })
 
-    expect(screen.getByRole('button', { name: 'Enable play-by-play audio announcements' })).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Live play by play' })).toBeInTheDocument();
-    expect(screen.getByText('#9 Kevin scored 2 points')).toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'Live chat' })).toBeInTheDocument();
-    expect(liveGameChatMocks.subscribeToLiveGameChat).toHaveBeenCalledWith('team-bears', 'game-1', expect.any(Function), expect.any(Function));
-    expect(screen.getByText("Let's go Bears!")).toBeInTheDocument();
-  });
+  it('routes /games/:gameId into the schedule event detail workflow', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValue({
+      children: [],
+      events: [
+        {
+          id: 'game-1',
+          teamId: 'team-bears',
+          childId: 'player-7',
+          type: 'game'
+        }
+      ]
+    })
 
-  it('announces displayed game events once when enabled', () => {
-    renderGameDetail();
+    renderGameDetail()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Enable play-by-play audio announcements' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Disable play-by-play audio announcements' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Enable play-by-play audio announcements' }));
-
-    expect(speechSynthesis.speak).toHaveBeenCalledTimes(2);
-    expect(SpeechSynthesisUtterance).toHaveBeenCalledWith('Q1. #9 Kevin scored 2 points');
-    expect(SpeechSynthesisUtterance).toHaveBeenCalledWith('Q1. #12 Paul defensive rebound');
-    expect(localStorage.getItem('allplaysPlayAnnouncerEnabled')).toBe('true');
-  });
-
-  it('sends anonymous live chat messages from the game detail panel', async () => {
-    renderGameDetail();
-
-    fireEvent.change(screen.getByLabelText('Display name'), { target: { value: 'Pat Parent' } });
-    fireEvent.change(screen.getByLabelText('Message'), { target: { value: 'Great hustle!' } });
-    fireEvent.click(screen.getByRole('button', { name: 'Send message' }));
+    expect(screen.getByText('Opening game')).toBeTruthy()
 
     await waitFor(() => {
-      expect(liveGameChatMocks.sendLiveGameChatMessage).toHaveBeenCalledWith('team-bears', 'game-1', {
-        text: 'Great hustle!',
-        user: null,
-        anonymousDisplayName: 'Pat Parent'
-      });
-    });
-  });
+      expect(screen.getByText('Live event workflow')).toBeTruthy()
+    })
 
-  it('does not resubscribe when the game object is recreated with the same ids', () => {
-    const unsubscribe = vi.fn();
-    const originalGame = mockGames[0];
+    expect(screen.getByRole('heading', { name: 'Availability' })).toBeTruthy()
+    expect(screen.getByText('Rideshare')).toBeTruthy()
+    expect(screen.getByText('Assignments')).toBeTruthy()
+    expect(screen.queryByText('Live chat')).toBeNull()
+    expect(screen.queryByText('Player Performance')).toBeNull()
+    expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenCalledWith(auth.user, {
+      hydrateDetails: false,
+      expandStaffPlayers: false
+    })
+  })
 
-    liveGameChatMocks.subscribeToLiveGameChat.mockReturnValue(unsubscribe);
+  it('shows a recovery state when the game cannot be resolved', async () => {
+    scheduleServiceMocks.loadParentSchedule.mockResolvedValue({
+      children: [],
+      events: []
+    })
 
-    try {
-      const view = renderGameDetail();
+    renderGameDetail('/games/missing-game')
 
-      expect(liveGameChatMocks.subscribeToLiveGameChat).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.getByText('Game not available')).toBeTruthy()
+    })
 
-      mockGames[0] = {
-        ...originalGame,
-        liveEvents: [...(originalGame.liveEvents || [])]
-      };
-
-      view.rerender(
-        <MemoryRouter initialEntries={['/games/game-1']}>
-          <Routes>
-            <Route path="/games/:gameId" element={<GameDetail auth={auth} />} />
-            <Route path="/schedule" element={<div>Schedule</div>} />
-          </Routes>
-        </MemoryRouter>
-      );
-
-      expect(liveGameChatMocks.subscribeToLiveGameChat).toHaveBeenCalledTimes(1);
-      expect(unsubscribe).not.toHaveBeenCalled();
-    } finally {
-      mockGames[0] = originalGame;
-    }
-  });
-
-  it('shows the locked notice and disables the composer when live chat is closed', () => {
-    liveGameChatMocks.canUseLiveGameChat.mockReturnValue(false);
-    liveGameChatMocks.getLiveGameChatNotice.mockReturnValue('Live chat opens on game day and closes after the live window ends.');
-
-    renderGameDetail('/games/game-2');
-
-    expect(screen.getByText('Live chat opens on game day and closes after the live window ends.')).toBeInTheDocument();
-    expect(screen.getByLabelText('Message')).toBeDisabled();
-    expect(screen.getByRole('button', { name: 'Send message' })).toBeDisabled();
-  });
-});
+    expect(screen.getByText(/could not find this game in your live schedule/i)).toBeTruthy()
+    expect(screen.getByRole('link', { name: 'Schedule' }).getAttribute('href')).toBe('/schedule')
+    expect(screen.queryByText('Live event workflow')).toBeNull()
+  })
+})

--- a/apps/app/src/pages/GameDetail.tsx
+++ b/apps/app/src/pages/GameDetail.tsx
@@ -1,336 +1,112 @@
-import { useEffect, useMemo, useState, type FormEvent } from 'react';
-import { Link, Navigate, useParams } from 'react-router-dom';
-import { BarChart3, Brain, Car, ClipboardCheck, FileText, ListTree, MessageCircleReply, Radio, Share2, Shield, Trophy, Users } from 'lucide-react';
-import { LiveGameAnnouncerToggle } from '../components/LiveGameAnnouncerToggle';
-import { mockGames, mockPlayers, mockTeams } from '../data/mockData';
-import { canUseLiveGameChat, getLiveGameChatNotice, sendLiveGameChatMessage, subscribeToLiveGameChat, type LiveGameChatMessage } from '../lib/liveGameChatService';
-import { applyWalk, createBaseballLiveState, type BaseballBases, type BaseballLiveState } from '../lib/sportScoring/baseballScorekeepingService';
-import { createPlayAnnouncer } from '../lib/liveGameAnnouncerService';
-import type { AuthState } from '../lib/types';
+import { useEffect, useMemo, useState } from 'react'
+import { AlertCircle, ChevronLeft, RefreshCw } from 'lucide-react'
+import { Link, Navigate, useParams } from 'react-router-dom'
+import { loadParentSchedule } from '../lib/scheduleService'
+import type { ParentScheduleEvent } from '../lib/scheduleLogic'
+import type { AuthState } from '../lib/types'
+
+type ResolutionState = {
+  loading: boolean
+  targetEvent: ParentScheduleEvent | null
+  error: string | null
+}
+
+function pickTargetEvent(events: ParentScheduleEvent[], gameId: string) {
+  const matches = events.filter((event) => event.id === gameId)
+  return matches.find((event) => event.type === 'game') || matches[0] || null
+}
 
 export function GameDetail({ auth }: { auth: AuthState }) {
-  const { gameId } = useParams();
-  const game = mockGames.find((item) => item.id === gameId);
-  const [baseballState, setBaseballState] = useState<BaseballLiveState>(() => createBaseballLiveState());
-  const [lastScoringAction, setLastScoringAction] = useState('Ready for pitch');
-  const team = game ? mockTeams.find((item) => item.id === game.teamId) : null;
-  const canScoreBaseball = (auth.isCoach || auth.isAdmin) && (team?.sport === 'Baseball' || team?.sport === 'Softball');
-  const liveEvents = game?.liveEvents || [];
-  const announcer = useMemo(() => createPlayAnnouncer(), []);
-  const [announcementsEnabled, setAnnouncementsEnabled] = useState(() => announcer.isEnabled());
-  const [chatMessages, setChatMessages] = useState<LiveGameChatMessage[]>([]);
-  const [chatDraft, setChatDraft] = useState('');
-  const [anonymousDisplayName, setAnonymousDisplayName] = useState('');
-  const [chatError, setChatError] = useState<string | null>(null);
-  const [chatSending, setChatSending] = useState(false);
-  const [chatReady, setChatReady] = useState(false);
+  const { gameId = '' } = useParams()
+  const [state, setState] = useState<ResolutionState>({
+    loading: true,
+    targetEvent: null,
+    error: null
+  })
 
   useEffect(() => {
-    if (!game) return;
+    let cancelled = false
 
-    announcer.setEnabled(announcementsEnabled);
-    if (!announcementsEnabled) return;
+    async function resolveGameRoute() {
+      if (!auth.user || !gameId) {
+        if (!cancelled) {
+          setState({ loading: false, targetEvent: null, error: 'This game is not available right now.' })
+        }
+        return
+      }
 
-    liveEvents.forEach((event) => {
-      announcer.announceEvent(event, { playbackSessionId: game.id });
-    });
+      setState({ loading: true, targetEvent: null, error: null })
+
+      try {
+        const result = await loadParentSchedule(auth.user, { hydrateDetails: false, expandStaffPlayers: false })
+        const targetEvent = pickTargetEvent(result.events, gameId)
+
+        if (cancelled) return
+
+        if (!targetEvent) {
+          setState({
+            loading: false,
+            targetEvent: null,
+            error: 'We could not find this game in your live schedule. Open Schedule to find the event or refresh after the team shares access.'
+          })
+          return
+        }
+
+        setState({ loading: false, targetEvent, error: null })
+      } catch (error: any) {
+        if (cancelled) return
+        setState({
+          loading: false,
+          targetEvent: null,
+          error: error?.message || 'Unable to open this game right now.'
+        })
+      }
+    }
+
+    resolveGameRoute()
 
     return () => {
-      announcer.setPaused(true);
-    };
-  }, [announcer, announcementsEnabled, game, liveEvents]);
-
-  useEffect(() => {
-    if (!game) return;
-
-    setChatReady(false);
-    setChatError(null);
-
-    return subscribeToLiveGameChat(game.teamId, game.id, (messages) => {
-      setChatMessages(messages);
-      setChatReady(true);
-    }, () => {
-      setChatError('Live chat is temporarily unavailable.');
-      setChatReady(true);
-    });
-  }, [game?.id, game?.teamId]);
-
-  if (!game) {
-    return <Navigate to="/schedule" replace />;
-  }
-
-  const currentGame = game;
-  const players = mockPlayers.filter((player) => currentGame.playerIds.includes(player.id));
-  const liveChatEnabled = canUseLiveGameChat(currentGame, { isReplay: currentGame.status === 'past' });
-  const liveChatNotice = getLiveGameChatNotice(currentGame, { isReplay: currentGame.status === 'past' });
-
-  async function handleChatSubmit(event: FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-
-    if (!liveChatEnabled) {
-      setChatError(liveChatNotice || 'Live chat is unavailable right now.');
-      return;
+      cancelled = true
     }
+  }, [auth.user, gameId])
 
-    setChatError(null);
-    setChatSending(true);
-    try {
-      await sendLiveGameChatMessage(currentGame.teamId, currentGame.id, {
-        text: chatDraft,
-        user: auth.user,
-        anonymousDisplayName
-      });
-      setChatDraft('');
-    } catch (error) {
-      setChatError(error instanceof Error ? error.message : 'Unable to send message.');
-    } finally {
-      setChatSending(false);
-    }
+  const redirectTarget = useMemo(() => {
+    if (!state.targetEvent) return ''
+    const childQuery = state.targetEvent.childId ? `?childId=${encodeURIComponent(state.targetEvent.childId)}` : ''
+    return `/schedule/${encodeURIComponent(state.targetEvent.teamId)}/${encodeURIComponent(state.targetEvent.id)}${childQuery}`
+  }, [state.targetEvent])
+
+  if (redirectTarget) {
+    return <Navigate to={redirectTarget} replace />
   }
 
-  function toggleBase(base: keyof BaseballBases) {
-    setBaseballState((current) => ({
-      ...current,
-      bases: {
-        ...current.bases,
-        [base]: !current.bases[base]
-      }
-    }));
-  }
-
-  function recordWalk() {
-    const result = applyWalk(baseballState);
-    setBaseballState(result.state);
-    setLastScoringAction(result.description);
+  if (state.loading) {
+    return (
+      <div className="app-card p-6 text-center">
+        <RefreshCw className="mx-auto h-8 w-8 animate-spin text-primary-600" aria-hidden="true" />
+        <div className="mt-3 text-sm font-black text-gray-900">Opening game</div>
+        <div className="mt-1 text-xs font-semibold text-gray-500">Routing you to the live event workflow.</div>
+      </div>
+    )
   }
 
   return (
-    <div className="space-y-4">
-      <section className="app-card p-4">
-        <div className="flex flex-wrap items-start justify-between gap-3">
+    <div className="space-y-3">
+      <Link to="/schedule" className="ghost-button min-h-9 px-3 text-xs">
+        <ChevronLeft className="h-4 w-4" aria-hidden="true" />
+        Schedule
+      </Link>
+      <div className="app-card p-4 sm:p-5">
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 flex-none items-center justify-center rounded-full bg-amber-50 text-amber-700">
+            <AlertCircle className="h-5 w-5" aria-hidden="true" />
+          </div>
           <div>
-            <div className="app-label">{game.type}</div>
-            <h1 className="mt-1 text-2xl font-black text-gray-950">{game.teamName} vs {game.opponent}</h1>
-            <p className="mt-2 text-sm font-semibold leading-6 text-gray-600">{game.dateLabel} · {game.timeLabel} · {game.location}</p>
-          </div>
-          <Link to={`/messages/${game.teamId}`} className="secondary-button">
-            <MessageCircleReply className="h-4 w-4" aria-hidden="true" />
-            Reply
-          </Link>
-        </div>
-        <div className="mt-4">
-          <LiveGameAnnouncerToggle
-            enabled={announcementsEnabled}
-            supported={announcer.isSupported()}
-            onToggle={setAnnouncementsEnabled}
-          />
-        </div>
-      </section>
-
-      {liveEvents.length > 0 ? (
-        <section className="app-card p-4" aria-labelledby="live-play-by-play-heading">
-          <h2 id="live-play-by-play-heading" className="app-section-title">Live play by play</h2>
-          <div className="mt-3 space-y-2">
-            {liveEvents.map((event) => (
-              <div key={event.id} className="rounded-xl border border-gray-200 bg-white p-3">
-                <div className="text-xs font-black uppercase tracking-wide text-primary-700">{event.period || 'Live'}</div>
-                <div className="mt-1 text-sm font-semibold text-gray-700">{event.description}</div>
-              </div>
-            ))}
-          </div>
-        </section>
-      ) : null}
-
-      <section className="app-card p-4" aria-labelledby="live-game-chat-heading">
-        <div className="flex items-start justify-between gap-3">
-          <div>
-            <div className="app-label">Game day chat</div>
-            <h2 id="live-game-chat-heading" className="mt-1 text-lg font-black text-gray-950">Live chat</h2>
-          </div>
-          <div className="rounded-full bg-primary-50 px-3 py-1 text-[11px] font-black uppercase tracking-wide text-primary-700">
-            {liveChatEnabled ? 'Open' : 'Locked'}
+            <div className="text-sm font-black text-gray-950">Game not available</div>
+            <div className="mt-1 text-sm font-semibold leading-6 text-gray-600">{state.error || 'Open Schedule to find the live event details for this game.'}</div>
           </div>
         </div>
-
-        {liveChatNotice ? (
-          <div className="mt-3 rounded-2xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm font-semibold text-amber-900">
-            {liveChatNotice}
-          </div>
-        ) : null}
-
-        <div className="mt-3 space-y-2" data-testid="live-game-chat-thread">
-          {chatMessages.length > 0 ? chatMessages.map((message) => (
-            <div key={message.id} className="rounded-2xl border border-gray-200 bg-gray-50 p-3">
-              <div className="text-xs font-black uppercase tracking-wide text-gray-500">{message.senderName || 'Fan'}</div>
-              <div className="mt-1 text-sm font-semibold text-gray-700">{message.text || ''}</div>
-            </div>
-          )) : (
-            <div className="rounded-2xl border border-dashed border-gray-200 bg-gray-50 px-3 py-4 text-sm font-semibold text-gray-500">
-              {chatReady ? 'No live game chat messages yet.' : 'Connecting to live game chat...'}
-            </div>
-          )}
-        </div>
-
-        <form className="mt-3 space-y-3" onSubmit={handleChatSubmit}>
-          {!auth.user ? (
-            <label className="block">
-              <span className="mb-1 block text-xs font-black uppercase tracking-wide text-gray-500">Display name</span>
-              <input
-                type="text"
-                aria-label="Display name"
-                className="auth-input"
-                value={anonymousDisplayName}
-                onChange={(event) => setAnonymousDisplayName(event.target.value)}
-                placeholder="Your first name"
-                disabled={chatSending}
-              />
-            </label>
-          ) : null}
-
-          <label className="block">
-            <span className="mb-1 block text-xs font-black uppercase tracking-wide text-gray-500">Message</span>
-            <textarea
-              aria-label="Message"
-              className="auth-input min-h-24"
-              value={chatDraft}
-              onChange={(event) => setChatDraft(event.target.value)}
-              placeholder={liveChatEnabled ? 'Send encouragement, updates, or reactions.' : 'Live chat is locked right now.'}
-              disabled={chatSending || !liveChatEnabled}
-            />
-          </label>
-
-          {chatError ? <div className="text-sm font-semibold text-rose-700">{chatError}</div> : null}
-
-          <div className="flex justify-end">
-            <button type="submit" className="primary-button" disabled={chatSending || !liveChatEnabled}>
-              {chatSending ? 'Sending...' : 'Send message'}
-            </button>
-          </div>
-        </form>
-      </section>
-
-      {auth.isCoach || auth.isAdmin ? (
-        <section className="app-card p-4">
-          <div className="flex items-center gap-2 text-sm font-black text-primary-800">
-            <Shield className="h-4 w-4" aria-hidden="true" />
-            Admin buttons
-          </div>
-          <div className="mt-3 grid gap-2 sm:grid-cols-4">
-            {['Lineup', 'Tracker', 'RSVP', 'Wrap-up'].map((label) => (
-              <Link key={label} to={`/capabilities/${label === 'Lineup' ? 'game-plan' : label === 'Tracker' ? 'track-standard' : label === 'RSVP' ? 'game-day' : 'game-report'}`} className="secondary-button justify-center">
-                {label}
-              </Link>
-            ))}
-          </div>
-        </section>
-      ) : null}
-
-      {canScoreBaseball ? (
-        <section className="app-card p-4" aria-labelledby="baseball-live-scoring-title">
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div>
-              <div className="app-label">Baseball live scoring</div>
-              <h2 id="baseball-live-scoring-title" className="mt-1 text-lg font-black text-gray-950">Scorekeeper actions</h2>
-              <p className="mt-1 text-xs font-semibold text-gray-500">{lastScoringAction}</p>
-            </div>
-            <button type="button" className="primary-button" onClick={recordWalk}>Walk</button>
-          </div>
-
-          <div className="mt-4 grid gap-3 sm:grid-cols-3">
-            <div className="rounded-2xl border border-gray-200 bg-gray-50 p-3">
-              <div className="text-xs font-black uppercase tracking-wide text-gray-500">Score</div>
-              <div className="mt-1 text-sm font-black text-gray-950">{game.teamName} {baseballState.homeScore} · {game.opponent} {baseballState.awayScore}</div>
-            </div>
-            <div className="rounded-2xl border border-gray-200 bg-gray-50 p-3">
-              <div className="text-xs font-black uppercase tracking-wide text-gray-500">Count</div>
-              <div className="mt-1 text-sm font-black text-gray-950" data-testid="baseball-count">{baseballState.balls}-{baseballState.strikes}</div>
-            </div>
-            <div className="rounded-2xl border border-gray-200 bg-gray-50 p-3">
-              <div className="text-xs font-black uppercase tracking-wide text-gray-500">Game state</div>
-              <div className="mt-1 text-sm font-black text-gray-950">{baseballState.half === 'top' ? 'Top' : 'Bottom'} {baseballState.inning} · {baseballState.outs} outs</div>
-            </div>
-          </div>
-
-          <div className="mt-4 flex flex-wrap gap-2" aria-label="Base runners">
-            {([
-              ['first', '1B'],
-              ['second', '2B'],
-              ['third', '3B']
-            ] as const).map(([base, label]) => (
-              <button
-                key={base}
-                type="button"
-                data-testid={`baseball-base-${base}`}
-                aria-pressed={baseballState.bases[base]}
-                onClick={() => toggleBase(base)}
-                className={`rounded-full border px-3 py-1.5 text-xs font-black ${baseballState.bases[base] ? 'border-primary-500 bg-primary-600 text-white' : 'border-gray-200 bg-white text-gray-600'}`}
-              >
-                {label} {baseballState.bases[base] ? 'occupied' : 'empty'}
-              </button>
-            ))}
-          </div>
-        </section>
-      ) : null}
-
-      <section className="grid gap-3 lg:grid-cols-3">
-        <div className="app-card p-4 lg:col-span-2">
-          <h2 className="app-section-title">Availability</h2>
-          <div className="mt-3 space-y-2">
-            {players.map((player) => (
-              <div key={player.id} className="rounded-xl border border-gray-200 bg-gray-50 p-3">
-                <div className="flex items-center justify-between gap-3">
-                  <div>
-                    <div className="text-sm font-black text-gray-950">{player.name}</div>
-                    <div className="text-xs font-semibold text-gray-500">#{player.number} · {player.teamName}</div>
-                  </div>
-                  <div className="flex flex-wrap justify-end gap-1.5">
-                    {['Going', 'Maybe', 'Out'].map((label) => (
-                      <button key={label} type="button" className="rounded-full border border-gray-200 bg-white px-2.5 py-1 text-[11px] font-black text-gray-600 hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700">
-                        {label}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        <div className="space-y-3">
-          <Info icon={Car} title="Rideshare" detail={`${game.rideshare.seatsLeft} seats open · ${game.rideshare.requests} requests`} />
-          <Info icon={ClipboardCheck} title="Assignments" detail={game.assignments.join(', ')} />
-          <Info icon={Radio} title="Game" detail="Live tracker, stream, and postgame report hooks." />
-        </div>
-      </section>
-
-      <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <Action icon={Share2} label="Share" to="/capabilities/game-report" />
-        <Action icon={FileText} label="Match Report" to="/capabilities/game-report" />
-        <Action icon={Brain} label="Insights" to="/capabilities/game-day" />
-        <Action icon={BarChart3} label="Player Performance" to="/capabilities/player-profile" />
-        <Action icon={ListTree} label="Play by Play" to="/capabilities/live-game" />
-        <Action icon={Users} label="Opponent Stats" to="/capabilities/track-standard" />
-        <Action icon={Trophy} label="Match Summary" to="/capabilities/game-report" />
-      </section>
+      </div>
     </div>
-  );
-}
-
-function Info({ icon: Icon, title, detail }: { icon: typeof Car; title: string; detail: string }) {
-  return (
-    <div className="app-card p-4">
-      <Icon className="h-5 w-5 text-primary-600" aria-hidden="true" />
-      <div className="mt-2 text-sm font-black text-gray-950">{title}</div>
-      <div className="mt-1 text-xs font-semibold leading-5 text-gray-600">{detail}</div>
-    </div>
-  );
-}
-
-function Action({ icon: Icon, label, to }: { icon: typeof Share2; label: string; to: string }) {
-  return (
-    <Link to={to} className="app-card flex min-h-24 flex-col justify-between p-4 transition hover:border-primary-200 hover:shadow-app-lg">
-      <Icon className="h-5 w-5 text-primary-600" aria-hidden="true" />
-      <span className="text-sm font-black text-gray-950">{label}</span>
-    </Link>
-  );
+  )
 }

--- a/tests/unit/app-game-detail-baseball-walk.test.jsx
+++ b/tests/unit/app-game-detail-baseball-walk.test.jsx
@@ -5,80 +5,11 @@ import { RouterProvider, createMemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { GameDetail } from '../../apps/app/src/pages/GameDetail.tsx';
 
-vi.mock('../../apps/app/src/data/mockData', () => ({
-    mockPlayers: [
-        {
-            id: 'player-baseball-1',
-            name: 'Slugger',
-            teamId: 'team-baseball',
-            teamName: 'Sharks',
-            number: '7',
-            role: 'athlete'
-        },
-        {
-            id: 'player-basketball-1',
-            name: 'Guard',
-            teamId: 'team-basketball',
-            teamName: 'Bears',
-            number: '12',
-            role: 'athlete'
-        }
-    ],
-    mockTeams: [
-        {
-            id: 'team-baseball',
-            name: 'Sharks',
-            sport: 'Baseball',
-            role: 'Coach',
-            record: '8-3',
-            rosterSize: 11,
-            nextGameId: 'game-baseball',
-            unreadCount: 0
-        },
-        {
-            id: 'team-basketball',
-            name: 'Bears',
-            sport: 'Basketball',
-            role: 'Coach',
-            record: '5-2',
-            rosterSize: 9,
-            nextGameId: 'game-basketball',
-            unreadCount: 0
-        }
-    ],
-    mockGames: [
-        {
-            id: 'game-baseball',
-            teamId: 'team-baseball',
-            teamName: 'Sharks',
-            opponent: 'Falcons',
-            type: 'game',
-            dateLabel: 'Sat, May 23',
-            timeLabel: '10:30 AM',
-            location: 'Diamond 1',
-            playerIds: ['player-baseball-1'],
-            availability: 'needed',
-            rideshare: { seatsLeft: 2, requests: 1 },
-            assignments: ['Scorebook: Jamie'],
-            status: 'upcoming'
-        },
-        {
-            id: 'game-basketball',
-            teamId: 'team-basketball',
-            teamName: 'Bears',
-            opponent: 'Rockets',
-            type: 'game',
-            dateLabel: 'Thu, May 28',
-            timeLabel: '7:15 PM',
-            location: 'North Gym',
-            playerIds: ['player-basketball-1'],
-            availability: 'maybe',
-            rideshare: { seatsLeft: 4, requests: 0 },
-            assignments: ['Clock: Assigned'],
-            status: 'upcoming'
-        }
-    ]
+const scheduleServiceMocks = vi.hoisted(() => ({
+    loadParentSchedule: vi.fn()
 }));
+
+vi.mock('../../apps/app/src/lib/scheduleService', () => scheduleServiceMocks);
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -107,6 +38,15 @@ async function renderGameDetail(initialPath = '/games/game-baseball') {
     const root = createRoot(container);
     const router = createMemoryRouter([
         { path: '/games/:gameId', element: React.createElement(GameDetail, { auth: coachAuth }) },
+        {
+            path: '/schedule/:teamId/:eventId',
+            element: React.createElement('div', null,
+                React.createElement('h1', null, 'Availability'),
+                React.createElement('div', null, 'Rideshare'),
+                React.createElement('div', null, 'Assignments'),
+                React.createElement('div', null, 'Live event workflow')
+            )
+        },
         { path: '/schedule', element: React.createElement('div', null, 'Schedule') }
     ], {
         initialEntries: [initialPath]
@@ -119,66 +59,63 @@ async function renderGameDetail(initialPath = '/games/game-baseball') {
     return { container, root, router };
 }
 
-function getButton(container, text) {
-    const button = Array.from(container.querySelectorAll('button')).find((candidate) => candidate.textContent.includes(text));
-    if (!button) throw new Error(`Missing button: ${text}`);
-    return button;
-}
-
 afterEach(() => {
     document.body.innerHTML = '';
     vi.clearAllMocks();
 });
 
-describe('app GameDetail baseball walk scoring', () => {
-    it('applies a walk from the UI and updates bases, score, and count', async () => {
-        const { container, root } = await renderGameDetail();
-
-        await act(async () => {
-            container.querySelector('[data-testid="baseball-base-first"]').click();
-        });
-        await act(async () => {
-            container.querySelector('[data-testid="baseball-base-second"]').click();
-        });
-        await act(async () => {
-            container.querySelector('[data-testid="baseball-base-third"]').click();
-        });
-        await act(async () => {
-            getButton(container, 'Walk').click();
+describe('app GameDetail route resolution', () => {
+    it('routes tracked games into the live schedule event detail workflow', async () => {
+        scheduleServiceMocks.loadParentSchedule.mockResolvedValue({
+            children: [],
+            events: [
+                {
+                    id: 'game-baseball',
+                    teamId: 'team-baseball',
+                    childId: 'player-1',
+                    type: 'game'
+                }
+            ]
         });
 
-        expect(container.textContent).toContain('Walk, 1 run scored');
-        expect(container.textContent).toContain('Sharks 0 · Falcons 1');
-        expect(container.querySelector('[data-testid="baseball-count"]').textContent).toBe('0-0');
-        expect(container.querySelector('[data-testid="baseball-base-first"]').getAttribute('aria-pressed')).toBe('true');
-        expect(container.querySelector('[data-testid="baseball-base-second"]').getAttribute('aria-pressed')).toBe('true');
-        expect(container.querySelector('[data-testid="baseball-base-third"]').getAttribute('aria-pressed')).toBe('true');
+        const { container, root, router } = await renderGameDetail();
 
         await act(async () => {
-            root.unmount();
+            await Promise.resolve();
         });
-    });
 
-    it('hides baseball scoring controls for non-baseball games', async () => {
-        const { container, root } = await renderGameDetail('/games/game-basketball');
-
-        expect(container.textContent).not.toContain('Baseball live scoring');
+        expect(router.state.location.pathname).toBe('/schedule/team-baseball/game-baseball');
+        expect(router.state.location.search).toBe('?childId=player-1');
+        expect(container.textContent).toContain('Availability');
+        expect(container.textContent).toContain('Rideshare');
+        expect(container.textContent).toContain('Assignments');
+        expect(container.textContent).toContain('Live event workflow');
+        expect(container.textContent).not.toContain('Live chat');
+        expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenCalledWith(coachAuth.user, {
+            hydrateDetails: false,
+            expandStaffPlayers: false
+        });
 
         await act(async () => {
             root.unmount();
         });
     });
 
-    it('keeps hook order stable when navigating from a valid game to a missing game', async () => {
-        const { container, root, router } = await renderGameDetail('/games/game-baseball');
-
-        expect(container.textContent).toContain('Baseball live scoring');
-
-        await act(async () => {
-            await router.navigate('/games/unknown-game');
+    it('shows a recovery state when the game cannot be resolved', async () => {
+        scheduleServiceMocks.loadParentSchedule.mockResolvedValue({
+            children: [],
+            events: []
         });
 
-        expect(container.textContent).toContain('Schedule');
+        const { container, root } = await renderGameDetail('/games/unknown-game');
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(container.textContent).toContain('Game not available');
+        expect(container.textContent).toContain('We could not find this game in your live schedule.');
+        expect(container.querySelector('a[href="/schedule"]')?.textContent).toContain('Schedule');
 
         await act(async () => {
             root.unmount();


### PR DESCRIPTION
Closes #1734

## What changed
- Replaced the mobile `/games/:gameId` screen with a resolver that loads the signed-in user's schedule and redirects tracked games into the live `/schedule/:teamId/:eventId` workflow.
- Added a clear recovery state when a `gameId` cannot be matched to a live schedule event, with a direct path back to Schedule instead of falling through to mock content.
- Updated the focused app/page regression tests and the older unit regression so they now verify live schedule routing behavior instead of the removed mock game detail UI.

## Why
The shipped mobile game route was still rendering a demo-style screen with mock data and dead-end controls. This change makes every valid mobile game entry point land in the existing service-backed schedule event detail flow, which already owns RSVP, rideshare, assignments, and game hub actions.