### PR TITLE
Keep Google popup cancels on the login page

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -134,10 +134,9 @@ export async function loginWithGoogle(activationCode = null) {
     } catch (error) {
         console.log('[Google Auth] Popup error:', error.code, error.message);
 
-        // Fall back to redirect for specific popup-related errors
+        // Fall back to redirect only when the popup cannot be used at all.
+        // User-cancelled or duplicate popup requests should stay on the page.
         if (error.code === 'auth/popup-blocked' ||
-            error.code === 'auth/popup-closed-by-user' ||
-            error.code === 'auth/cancelled-popup-request' ||
             error.code === 'auth/operation-not-supported-in-this-environment') {
 
             console.log('[Google Auth] Falling back to redirect flow...');

--- a/login.html
+++ b/login.html
@@ -97,7 +97,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=16';
+        import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=17';
         import { getUserProfile } from './js/db.js?v=32';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
         import { getPostAuthRedirectUrl } from './js/invite-redirect.js?v=1';

--- a/tests/unit/admin-invite-signup-cache-busting.test.js
+++ b/tests/unit/admin-invite-signup-cache-busting.test.js
@@ -23,20 +23,20 @@ describe('admin invite signup cache busting', () => {
     });
 
     it('bumps auth module consumers after signup flow changes', () => {
-        const authConsumers = [
-            'login.html',
-            'accept-invite.html',
-            'edit-team.html',
-            'js/admin.js',
-            'js/live-game.js',
-            'js/live-tracker.js',
-            'js/track-basketball.js',
-            'js/utils.js'
-        ];
+        const authConsumers = {
+            'login.html': 'auth.js?v=17',
+            'accept-invite.html': 'auth.js?v=16',
+            'edit-team.html': 'auth.js?v=16',
+            'js/admin.js': 'auth.js?v=16',
+            'js/live-game.js': 'auth.js?v=16',
+            'js/live-tracker.js': 'auth.js?v=16',
+            'js/track-basketball.js': 'auth.js?v=16',
+            'js/utils.js': 'auth.js?v=16'
+        };
 
-        for (const relativePath of authConsumers) {
+        for (const [relativePath, expectedVersion] of Object.entries(authConsumers)) {
             const source = readFileSync(resolve(process.cwd(), relativePath), 'utf8');
-            expect(source).toContain('auth.js?v=16');
+            expect(source).toContain(expectedVersion);
         }
     });
 });

--- a/tests/unit/auth-google-popup-fallback.test.js
+++ b/tests/unit/auth-google-popup-fallback.test.js
@@ -1,0 +1,117 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const signInWithPopupMock = vi.fn();
+const signInWithRedirectMock = vi.fn();
+
+vi.mock('../../js/firebase.js?v=17', () => ({
+    auth: { currentUser: null },
+    signInWithEmailAndPassword: vi.fn(),
+    createUserWithEmailAndPassword: vi.fn(),
+    signOut: vi.fn(),
+    onAuthStateChanged: vi.fn(),
+    GoogleAuthProvider: class MockGoogleAuthProvider {},
+    signInWithPopup: signInWithPopupMock,
+    signInWithRedirect: signInWithRedirectMock,
+    getRedirectResult: vi.fn(),
+    sendPasswordResetEmail: vi.fn(),
+    sendEmailVerification: vi.fn(),
+    sendSignInLinkToEmail: vi.fn(),
+    isSignInWithEmailLink: vi.fn(),
+    signInWithEmailLink: vi.fn(),
+    updatePassword: vi.fn()
+}));
+
+vi.mock('../../js/db.js?v=33', () => ({
+    validateAccessCode: vi.fn(),
+    markAccessCodeAsUsed: vi.fn(),
+    updateUserProfile: vi.fn(),
+    redeemParentInvite: vi.fn(),
+    getUserProfile: vi.fn(),
+    getUserTeams: vi.fn(),
+    getUserByEmail: vi.fn(),
+    getTeam: vi.fn(),
+    listMyParentMembershipRequests: vi.fn()
+}));
+
+vi.mock('../../js/signup-flow.js?v=3', () => ({
+    executeEmailPasswordSignup: vi.fn()
+}));
+
+vi.mock('../../js/admin-invite.js?v=4', () => ({
+    redeemAdminInviteAcceptance: vi.fn()
+}));
+
+vi.mock('../../js/parent-membership-utils.js?v=1', () => ({
+    mergeApprovedParentMembershipRequests: vi.fn(() => ({ changed: false, userUpdate: {} }))
+}));
+
+describe('loginWithGoogle popup fallback handling', () => {
+    let sessionStorageMock;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        vi.resetModules();
+
+        sessionStorageMock = {
+            setItem: vi.fn(),
+            getItem: vi.fn(),
+            removeItem: vi.fn()
+        };
+
+        vi.stubGlobal('window', {
+            sessionStorage: sessionStorageMock
+        });
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('falls back to redirect when the popup is blocked', async () => {
+        const popupError = new Error('Popup blocked');
+        popupError.code = 'auth/popup-blocked';
+        popupError.message = 'Popup blocked';
+        signInWithPopupMock.mockRejectedValue(popupError);
+        signInWithRedirectMock.mockResolvedValue(undefined);
+
+        const { loginWithGoogle } = await import('../../js/auth.js');
+
+        await expect(loginWithGoogle('CODE1234')).resolves.toBeNull();
+
+        expect(sessionStorageMock.setItem).toHaveBeenCalledWith('pendingActivationCode', 'CODE1234');
+        expect(signInWithRedirectMock).toHaveBeenCalledTimes(1);
+        expect(sessionStorageMock.removeItem).not.toHaveBeenCalledWith('pendingActivationCode');
+    });
+
+    it('does not redirect when the user closes the popup', async () => {
+        const popupError = new Error('Popup closed by user');
+        popupError.code = 'auth/popup-closed-by-user';
+        popupError.message = 'Popup closed by user';
+        signInWithPopupMock.mockRejectedValue(popupError);
+
+        const { loginWithGoogle } = await import('../../js/auth.js');
+
+        await expect(loginWithGoogle('CODE1234')).rejects.toMatchObject({
+            code: 'auth/popup-closed-by-user'
+        });
+
+        expect(signInWithRedirectMock).not.toHaveBeenCalled();
+        expect(sessionStorageMock.removeItem).toHaveBeenCalledWith('pendingActivationCode');
+    });
+
+    it('does not redirect when Firebase cancels a duplicate popup request', async () => {
+        const popupError = new Error('Popup request cancelled');
+        popupError.code = 'auth/cancelled-popup-request';
+        popupError.message = 'Popup request cancelled';
+        signInWithPopupMock.mockRejectedValue(popupError);
+
+        const { loginWithGoogle } = await import('../../js/auth.js');
+
+        await expect(loginWithGoogle('CODE1234')).rejects.toMatchObject({
+            code: 'auth/cancelled-popup-request'
+        });
+
+        expect(signInWithRedirectMock).not.toHaveBeenCalled();
+        expect(sessionStorageMock.removeItem).toHaveBeenCalledWith('pendingActivationCode');
+    });
+});


### PR DESCRIPTION
Closes #1786

## What changed
- stopped `loginWithGoogle()` from falling back to `signInWithRedirect()` for `auth/popup-closed-by-user` and `auth/cancelled-popup-request`
- kept redirect fallback only for true popup-unavailable cases like `auth/popup-blocked` and unsupported environments
- bumped the login page auth import cache-bust version so browsers pick up the fix
- added a focused regression test covering blocked popup fallback vs user-cancel and duplicate-click popup errors

## Why
Closing the Google popup or triggering Firebase's duplicate popup cancellation should leave the user on `login.html` so they can retry intentionally. Redirect fallback is still preserved for cases where popup auth cannot work at all.