### PR TITLE
Defer Team Detail staff permissions until More tab opens

### DIFF
--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -535,10 +535,6 @@ export async function loadParentTeamDetail(teamId: string, user: AuthUser | null
 
   if (!team) throw new Error('Team not found.');
 
-  const canManageTeam = hasFullTeamAccess(user, team);
-  const pendingAdminInvites = canManageTeam ? await loadPendingAdminInvites(teamId).catch(() => []) : [];
-  const confirmedTeamMembers = canManageTeam ? await Promise.resolve(getAllUsers()).catch(() => []) : [];
-
   const linkedPlayerIds = getLinkedPlayerIds(user, teamId, players);
   const completedGameIds = (Array.isArray(games) ? games : [])
     .filter(isCompletedGame)
@@ -565,6 +561,27 @@ export async function loadParentTeamDetail(teamId: string, user: AuthUser | null
     trackingItems,
     trackingStatuses,
     sponsors: [...normalizeSponsorList(adSponsors), ...normalizeSponsorList(localSponsors)],
+    includeStaffPermissions: false
+  });
+}
+
+export async function loadTeamStaffPermissions(teamId: string, user: AuthUser | null): Promise<TeamStaffPermissionsSummary | null> {
+  const [team, players] = await Promise.all([
+    loadTeamDocument(teamId),
+    loadTeamPlayers(teamId)
+  ]);
+
+  if (!team || !hasFullTeamAccess(user, team)) return null;
+
+  const [pendingAdminInvites, confirmedTeamMembers] = await Promise.all([
+    loadPendingAdminInvites(teamId).catch(() => []),
+    Promise.resolve(getAllUsers()).catch(() => [])
+  ]);
+
+  return buildTeamStaffPermissionsSummary({
+    teamId,
+    team,
+    players,
     pendingAdminInvites,
     confirmedTeamMembers
   });
@@ -583,7 +600,8 @@ export function buildTeamDetailModel({
   trackingStatuses = [],
   sponsors = [],
   pendingAdminInvites = [],
-  confirmedTeamMembers = []
+  confirmedTeamMembers = [],
+  includeStaffPermissions = true
 }: {
   teamId: string;
   team: Record<string, any>;
@@ -598,6 +616,7 @@ export function buildTeamDetailModel({
   sponsors?: TeamDetailSponsor[];
   pendingAdminInvites?: any[];
   confirmedTeamMembers?: any[];
+  includeStaffPermissions?: boolean;
 }): TeamDetailModel {
   const normalizedPlayers = normalizePlayers(players, linkedPlayerIds);
   const normalizedEvents = normalizeEvents(games);
@@ -610,13 +629,8 @@ export function buildTeamDetailModel({
   const leaderboards = buildLeaderboards(configs, normalizedPlayers, seasonStatsByPlayerId, team?.sport);
   const trackingSummaries = buildTrackingSummaries(normalizedPlayers, linkedPlayerIds, trackingItems, trackingStatuses);
   const canManageTeam = hasFullTeamAccess(user, team);
-  const staffPermissions = canManageTeam
-    ? {
-      ...buildTeamStaffPermissionsViewModel({ ...team, id: teamId }, pendingAdminInvites),
-      scorekeepingMode: cleanString(team?.teamPermissions?.scorekeeping?.mode),
-      scorekeeperGrantTargets: buildPermissionGrantTargets(team, players, 'scorekeeping', confirmedTeamMembers, teamId),
-      videographerGrantTargets: buildPermissionGrantTargets(team, players, 'videography', confirmedTeamMembers, teamId)
-    }
+  const staffPermissions = canManageTeam && includeStaffPermissions
+    ? buildTeamStaffPermissionsSummary({ teamId, team, players, pendingAdminInvites, confirmedTeamMembers })
     : null;
 
   return {
@@ -662,6 +676,27 @@ export function buildTeamDetailModel({
       practices: games.filter((game: any) => game?.type === 'practice').length,
       completedGames: completedGames.length
     }
+  };
+}
+
+function buildTeamStaffPermissionsSummary({
+  teamId,
+  team,
+  players = [],
+  pendingAdminInvites = [],
+  confirmedTeamMembers = []
+}: {
+  teamId: string;
+  team: Record<string, any>;
+  players?: any[];
+  pendingAdminInvites?: any[];
+  confirmedTeamMembers?: any[];
+}): TeamStaffPermissionsSummary {
+  return {
+    ...buildTeamStaffPermissionsViewModel({ ...team, id: teamId }, pendingAdminInvites),
+    scorekeepingMode: cleanString(team?.teamPermissions?.scorekeeping?.mode),
+    scorekeeperGrantTargets: buildPermissionGrantTargets(team, players, 'scorekeeping', confirmedTeamMembers, teamId),
+    videographerGrantTargets: buildPermissionGrantTargets(team, players, 'videography', confirmedTeamMembers, teamId)
   };
 }
 

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -102,7 +102,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [activeTab, auth.user, model, teamId]);
+  }, [activeTab, auth.user, model?.canManageTeam, model?.staffPermissions, teamId]);
 
   useEffect(() => {
     const scroll = () => {

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -28,7 +28,7 @@ import { copyPublicText, openPublicUrl, sharePublicUrl } from '../lib/publicActi
 import { getEventDetailPath } from '../lib/homeLogic';
 import { createStaffRsvpReminderPreviewLoader, sendStaffRsvpReminder, type StaffRsvpReminderSendResult } from '../lib/scheduleService';
 import type { ParentScheduleEvent, StaffRsvpReminderPreview } from '../lib/scheduleLogic';
-import { buildPublicTeamGamesIcsUrl, canExposePublicFanFeed, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp, type InviteTeamAdminForAppResult, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer, type TeamScorekeeperGrantTarget } from '../lib/teamDetailService';
+import { buildPublicTeamGamesIcsUrl, canExposePublicFanFeed, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, loadTeamStaffPermissions, revokeScorekeeperAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp, type InviteTeamAdminForAppResult, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer, type TeamScorekeeperGrantTarget } from '../lib/teamDetailService';
 import type { AuthState } from '../lib/types';
 
 type TeamTab = 'overview' | 'schedule' | 'roster' | 'insights' | 'more';
@@ -47,6 +47,8 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
   const [activeTab, setActiveTab] = useState<TeamTab>('overview');
+  const [staffPermissionsLoading, setStaffPermissionsLoading] = useState(false);
+  const [staffPermissionsError, setStaffPermissionsError] = useState('');
 
   useEffect(() => {
     let cancelled = false;
@@ -56,11 +58,17 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
       setError('');
       try {
         const nextModel = await loadParentTeamDetail(teamId, auth.user);
-        if (!cancelled) setModel(nextModel);
+        if (!cancelled) {
+          setModel(nextModel);
+          setStaffPermissionsError('');
+          setStaffPermissionsLoading(false);
+        }
       } catch (loadError: any) {
         if (!cancelled) {
           setError(loadError?.message || 'Unable to load this team.');
           setModel(null);
+          setStaffPermissionsError('');
+          setStaffPermissionsLoading(false);
         }
       } finally {
         if (!cancelled) setLoading(false);
@@ -71,6 +79,30 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
       cancelled = true;
     };
   }, [auth.user, teamId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadStaffPermissionsForMoreTab() {
+      if (!teamId || activeTab !== 'more' || !model?.canManageTeam || model.staffPermissions || staffPermissionsLoading) return;
+      setStaffPermissionsLoading(true);
+      setStaffPermissionsError('');
+      try {
+        const staffPermissions = await loadTeamStaffPermissions(teamId, auth.user);
+        if (!cancelled) {
+          setModel((currentModel) => currentModel ? { ...currentModel, staffPermissions } : currentModel);
+        }
+      } catch (loadError: any) {
+        if (!cancelled) setStaffPermissionsError(loadError?.message || 'Unable to load team staff permissions.');
+      } finally {
+        if (!cancelled) setStaffPermissionsLoading(false);
+      }
+    }
+
+    void loadStaffPermissionsForMoreTab();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, auth.user, model, staffPermissionsLoading, teamId]);
 
   useEffect(() => {
     const scroll = () => {
@@ -90,7 +122,16 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
   async function refreshTeamDetail() {
     if (!teamId) return;
     const nextModel = await loadParentTeamDetail(teamId, auth.user);
+    if (activeTab === 'more' && nextModel.canManageTeam) {
+      const staffPermissions = await loadTeamStaffPermissions(teamId, auth.user);
+      setModel({ ...nextModel, staffPermissions });
+      setStaffPermissionsError('');
+      setStaffPermissionsLoading(false);
+      return;
+    }
     setModel(nextModel);
+    setStaffPermissionsError('');
+    setStaffPermissionsLoading(false);
   }
 
   const tabBadges = useMemo(() => ({
@@ -165,7 +206,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
       {activeTab === 'schedule' ? <ScheduleTab model={model} auth={auth} /> : null}
       {activeTab === 'roster' ? <RosterTab model={model} /> : null}
       {activeTab === 'insights' ? <InsightsTab model={model} /> : null}
-      {activeTab === 'more' ? <MoreTab model={model} onTeamDetailRefresh={refreshTeamDetail} /> : null}
+      {activeTab === 'more' ? <MoreTab model={model} staffPermissionsLoading={staffPermissionsLoading} staffPermissionsError={staffPermissionsError} onTeamDetailRefresh={refreshTeamDetail} /> : null}
     </div>
   );
 }
@@ -348,9 +389,23 @@ function InsightsTab({ model }: { model: TeamDetailModel }) {
   );
 }
 
-function MoreTab({ model, onTeamDetailRefresh }: { model: TeamDetailModel; onTeamDetailRefresh: () => Promise<void> }) {
+function MoreTab({ model, staffPermissionsLoading, staffPermissionsError, onTeamDetailRefresh }: { model: TeamDetailModel; staffPermissionsLoading: boolean; staffPermissionsError: string; onTeamDetailRefresh: () => Promise<void> }) {
   return (
     <div className="space-y-4">
+      {model.canManageTeam && !model.staffPermissions && staffPermissionsLoading ? (
+        <section className="app-card p-4">
+          <div className="flex items-center gap-3 text-sm font-semibold text-gray-600">
+            <Loader2 className="h-4 w-4 animate-spin text-primary-600" aria-hidden="true" />
+            Loading team staff permissions…
+          </div>
+        </section>
+      ) : null}
+      {model.canManageTeam && !model.staffPermissions && staffPermissionsError ? (
+        <section className="app-card p-4">
+          <div className="text-sm font-black text-gray-950">Team staff permissions unavailable</div>
+          <div className="mt-1 text-xs font-semibold text-rose-700">{staffPermissionsError}</div>
+        </section>
+      ) : null}
       {model.staffPermissions ? <StaffPermissionsCard model={model} onInviteSuccess={onTeamDetailRefresh} /> : null}
       {model.canManageTeam ? <ReminderTimingDefaultsCard model={model} onSaved={onTeamDetailRefresh} /> : null}
       {canExposePublicFanFeed(model.team, [...model.upcomingEvents, ...model.recentResults]) ? <FanFeedCard model={model} /> : null}

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -102,7 +102,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [activeTab, auth.user, model, staffPermissionsLoading, teamId]);
+  }, [activeTab, auth.user, model, teamId]);
 
   useEffect(() => {
     const scroll = () => {

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -377,6 +377,10 @@ async function mockHomePlayerModules(page) {
                     };
                 }
 
+                export async function loadTeamStaffPermissions() {
+                    return null;
+                }
+
                 export function buildPublicTeamGamesIcsUrl(teamId) {
                     return teamId ? 'https://calendar.example.test/publicTeamGamesIcs?teamId=' + encodeURIComponent(teamId) : '';
                 }

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -227,6 +227,10 @@ async function mockSearchModules(page) {
                     };
                 }
 
+                export async function loadTeamStaffPermissions() {
+                    return null;
+                }
+
                 export function buildPublicTeamGamesIcsUrl(teamId) {
                     return teamId ? 'https://calendar.example.test/publicTeamGamesIcs?teamId=' + encodeURIComponent(teamId) : '';
                 }

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -32,13 +32,15 @@ async function openDesktopSearch(page) {
     const searchButton = page.getByRole('button', { name: 'Search' });
     const searchDialog = page.getByRole('dialog', { name: 'Search teams, players, actions, and help' });
 
-    await expect(searchButton).toBeVisible({ timeout: 15000 });
     await expect(async () => {
         await page.keyboard.press('Control+K');
 
         try {
             await expect(searchDialog).toBeVisible({ timeout: 1000 });
         } catch {
+            if (!await searchButton.count()) {
+                throw new Error('Desktop search did not open from the keyboard shortcut and the search button was unavailable.');
+            }
             await searchButton.click();
             await expect(searchDialog).toBeVisible({ timeout: 1000 });
         }

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -219,6 +219,10 @@ async function mockTeamsModules(page) {
                     };
                 }
 
+                export async function loadTeamStaffPermissions() {
+                    return null;
+                }
+
                 export function buildPublicTeamGamesIcsUrl(teamId) {
                     return teamId ? 'https://calendar.example.test/publicTeamGamesIcs?teamId=' + encodeURIComponent(teamId) : '';
                 }

--- a/tests/unit/app-team-detail-integration.test.jsx
+++ b/tests/unit/app-team-detail-integration.test.jsx
@@ -396,16 +396,9 @@ describe('React app TeamDetail page', () => {
         managerModel.canManageTeam = true;
         managerModel.staffPermissions = null;
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(managerModel);
+        let resolveStaffPermissions;
         teamDetailMocks.loadTeamStaffPermissions.mockImplementationOnce(() => new Promise((resolve) => {
-            setTimeout(() => resolve({
-                staff: [{ label: 'coach@example.com', role: 'Admin' }],
-                pendingInvites: ['pending@example.com'],
-                helperPermissions: [],
-                scorekeepingMode: '',
-                scorekeeperGrantTargets: [],
-                videographerGrantTargets: [],
-                hasAnyStaff: true
-            }), 0);
+            resolveStaffPermissions = resolve;
         }));
 
         const { container } = await renderTeamDetail({
@@ -426,6 +419,22 @@ describe('React app TeamDetail page', () => {
         expect(container.textContent).toContain('Loading team staff permissions');
         expect(container.textContent).not.toContain('Team Staff & Permissions');
 
+        await act(async () => {
+            resolveStaffPermissions({
+                staff: [{ label: 'coach@example.com', role: 'Admin' }],
+                pendingInvites: ['pending@example.com'],
+                helperPermissions: [],
+                scorekeepingMode: '',
+                scorekeeperGrantTargets: [],
+                videographerGrantTargets: [],
+                hasAnyStaff: true
+            });
+        });
+        await flush();
+
+        expect(container.textContent).not.toContain('Loading team staff permissions');
+        expect(container.textContent).toContain('Team Staff & Permissions');
+        expect(container.textContent).toContain('coach@example.com · Admin');
     });
 
     it('exposes schedule, parent action links, and recent scores', async () => {

--- a/tests/unit/app-team-detail-integration.test.jsx
+++ b/tests/unit/app-team-detail-integration.test.jsx
@@ -6,6 +6,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 const teamDetailMocks = vi.hoisted(() => ({
     loadParentTeamDetail: vi.fn(),
+    loadTeamStaffPermissions: vi.fn(),
     saveTeamScheduleNotificationsForApp: vi.fn(),
     buildPublicTeamGamesIcsUrl: vi.fn((teamId) => `https://us-central1-all-plays-prod.cloudfunctions.net/publicTeamGamesIcs?teamId=${encodeURIComponent(teamId)}`),
     canExposePublicFanFeed: vi.fn((team, events = []) => (events || []).some((event) => event?.type === 'game' && event?.visibility !== 'private' && event?.isPrivate !== true && event?.status !== 'deleted' && event?.liveStatus !== 'deleted' && ((team?.isPublic !== false && team?.active !== false) || event?.isPublic === true || event?.shareable === true || event?.publicCalendar === true)))
@@ -23,6 +24,7 @@ const scheduleServiceMocks = vi.hoisted(() => ({
 
 vi.mock('../../apps/app/src/lib/teamDetailService.ts', () => ({
     loadParentTeamDetail: teamDetailMocks.loadParentTeamDetail,
+    loadTeamStaffPermissions: teamDetailMocks.loadTeamStaffPermissions,
     saveTeamScheduleNotificationsForApp: teamDetailMocks.saveTeamScheduleNotificationsForApp,
     buildPublicTeamGamesIcsUrl: teamDetailMocks.buildPublicTeamGamesIcsUrl,
     canExposePublicFanFeed: teamDetailMocks.canExposePublicFanFeed
@@ -222,6 +224,7 @@ beforeEach(() => {
         hasExplicitReminderHours: true,
         summary: 'Team default reminder window: 24 hours before event start.'
     });
+    teamDetailMocks.loadTeamStaffPermissions.mockResolvedValue(null);
     teamDetailMocks.loadParentTeamDetail.mockResolvedValue(model());
 });
 
@@ -386,6 +389,43 @@ describe('React app TeamDetail page', () => {
         const hidden = await renderTeamDetail();
         await clickButton(hidden.container, 'More');
         expect(hidden.container.textContent).not.toContain('Reminder timing defaults');
+    });
+
+    it('renders overview content before deferred staff permissions resolve and keeps More lazy', async () => {
+        const managerModel = model();
+        managerModel.canManageTeam = true;
+        managerModel.staffPermissions = null;
+        teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(managerModel);
+        teamDetailMocks.loadTeamStaffPermissions.mockImplementationOnce(() => new Promise((resolve) => {
+            setTimeout(() => resolve({
+                staff: [{ label: 'coach@example.com', role: 'Admin' }],
+                pendingInvites: ['pending@example.com'],
+                helperPermissions: [],
+                scorekeepingMode: '',
+                scorekeeperGrantTargets: [],
+                videographerGrantTargets: [],
+                hasAnyStaff: true
+            }), 0);
+        }));
+
+        const { container } = await renderTeamDetail({
+            ...auth,
+            user: { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] },
+            roles: ['coach'],
+            isParent: false,
+            isCoach: true
+        });
+
+        expect(container.textContent).toContain('Bears');
+        expect(container.textContent).toContain('Season record (2100)');
+        expect(teamDetailMocks.loadTeamStaffPermissions).not.toHaveBeenCalled();
+
+        await clickButton(container, 'More');
+
+        expect(teamDetailMocks.loadTeamStaffPermissions).toHaveBeenCalledWith('team-1', expect.objectContaining({ uid: 'coach-1' }));
+        expect(container.textContent).toContain('Loading team staff permissions');
+        expect(container.textContent).not.toContain('Team Staff & Permissions');
+
     });
 
     it('exposes schedule, parent action links, and recent scores', async () => {

--- a/tests/unit/app-team-detail-integration.test.jsx
+++ b/tests/unit/app-team-detail-integration.test.jsx
@@ -415,6 +415,7 @@ describe('React app TeamDetail page', () => {
 
         await clickButton(container, 'More');
 
+        expect(teamDetailMocks.loadTeamStaffPermissions).toHaveBeenCalledTimes(1);
         expect(teamDetailMocks.loadTeamStaffPermissions).toHaveBeenCalledWith('team-1', expect.objectContaining({ uid: 'coach-1' }));
         expect(container.textContent).toContain('Loading team staff permissions');
         expect(container.textContent).not.toContain('Team Staff & Permissions');

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -51,7 +51,7 @@ vi.mock('../../apps/app/src/lib/authService.ts', () => ({
     getNativeAuthIdToken: vi.fn()
 }));
 
-import { buildAdminAcceptInviteUrl, buildPublicTeamGamesIcsUrl, buildTeamDetailModel, canExposePublicFanFeed, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, revokeScorekeeperAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp } from '../../apps/app/src/lib/teamDetailService.ts';
+import { buildAdminAcceptInviteUrl, buildPublicTeamGamesIcsUrl, buildTeamDetailModel, canExposePublicFanFeed, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, loadTeamStaffPermissions, revokeScorekeeperAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp } from '../../apps/app/src/lib/teamDetailService.ts';
 import { collection, getDocs, query, where } from '../../js/firebase.js';
 import { getAggregatedStatsForGames, getAdSpaceSponsors, getAllUsers, getConfigs, getEvents, getGames, getLocalAttractionSponsors, getPlayers, getTeam, grantScorekeeperAccess, grantVideographerAccess, inviteAdmin, addTeamAdminEmail, revokeScorekeeperAccess, revokeVideographerAccess, updateEvent, updateGame, updateTeam } from '../../js/db.js';
 import { sendInviteEmail } from '../../js/auth.js';
@@ -427,7 +427,7 @@ describe('React app team detail model', () => {
         expect(parentModel.staffPermissions).toBeNull();
     });
 
-    it('loads pending admin invites for team admins but not parent members', async () => {
+    it('does not load staff permissions during the initial team detail fetch', async () => {
         getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears', ownerId: 'owner-1', adminEmails: ['coach@example.com'] });
         getPlayers.mockResolvedValue([{ id: 'player-1', name: 'Pat Star' }]);
         getGames.mockResolvedValue([]);
@@ -451,9 +451,41 @@ describe('React app team detail model', () => {
         });
 
         const adminModel = await loadParentTeamDetail('team-1', { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] });
-        expect(adminModel.staffPermissions.pendingInvites).toEqual(['pending@example.com']);
-        expect(adminModel.staffPermissions.videographerGrantTargets).toEqual([
-            { userId: 'video-1', name: 'Video Parent', email: 'video@example.com', playerNames: ['Pat Star'], isGranted: false }
+        expect(adminModel.canManageTeam).toBe(true);
+        expect(adminModel.staffPermissions).toBeNull();
+        expect(getAllUsers).not.toHaveBeenCalled();
+        expect(getDocs).not.toHaveBeenCalled();
+
+        getDocs.mockClear();
+        getAllUsers.mockClear();
+        const parentModel = await loadParentTeamDetail('team-1', { uid: 'parent-1', email: 'parent@example.com', displayName: 'Parent', roles: ['parent'] });
+        expect(parentModel.staffPermissions).toBeNull();
+        expect(getDocs).not.toHaveBeenCalled();
+        expect(getAllUsers).not.toHaveBeenCalled();
+    });
+
+    it('loads deferred staff permissions only when requested for a team manager', async () => {
+        getTeam.mockResolvedValue({
+            id: 'team-1',
+            name: 'Bears',
+            ownerId: 'owner-1',
+            adminEmails: ['coach@example.com'],
+            teamPermissions: { videography: { mode: 'selected', memberIds: ['video-1'] } }
+        });
+        getPlayers.mockResolvedValue([{ id: 'player-1', name: 'Pat Star' }]);
+        getAllUsers.mockResolvedValue([{ id: 'video-1', fullName: 'Video Parent', email: 'video@example.com', parentOf: [{ teamId: 'team-1', playerId: 'player-1' }] }]);
+        const future = Date.now() + 60_000;
+        getDocs.mockResolvedValue({
+            docs: [
+                { id: 'invite-1', data: () => ({ email: 'pending@example.com', teamId: 'team-1', type: 'admin_invite', used: false, expiresAt: { toMillis: () => future } }) }
+            ]
+        });
+
+        const staffPermissions = await loadTeamStaffPermissions('team-1', { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] });
+
+        expect(staffPermissions.pendingInvites).toEqual(['pending@example.com']);
+        expect(staffPermissions.videographerGrantTargets).toEqual([
+            { userId: 'video-1', name: 'Video Parent', email: 'video@example.com', playerNames: ['Pat Star'], isGranted: true }
         ]);
         expect(getAllUsers).toHaveBeenCalledTimes(1);
         expect(getDocs).toHaveBeenCalledTimes(1);
@@ -463,8 +495,8 @@ describe('React app team detail model', () => {
 
         getDocs.mockClear();
         getAllUsers.mockClear();
-        const parentModel = await loadParentTeamDetail('team-1', { uid: 'parent-1', email: 'parent@example.com', displayName: 'Parent', roles: ['parent'] });
-        expect(parentModel.staffPermissions).toBeNull();
+        const parentStaffPermissions = await loadTeamStaffPermissions('team-1', { uid: 'parent-1', email: 'parent@example.com', displayName: 'Parent', roles: ['parent'] });
+        expect(parentStaffPermissions).toBeNull();
         expect(getDocs).not.toHaveBeenCalled();
         expect(getAllUsers).not.toHaveBeenCalled();
     });

--- a/tests/unit/app-team-detail-staff-permissions.test.jsx
+++ b/tests/unit/app-team-detail-staff-permissions.test.jsx
@@ -6,6 +6,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 const teamDetailMocks = vi.hoisted(() => ({
     loadParentTeamDetail: vi.fn(),
+    loadTeamStaffPermissions: vi.fn(),
     grantScorekeeperAccessForApp: vi.fn(),
     grantVideographerAccessForApp: vi.fn(),
     revokeScorekeeperAccessForApp: vi.fn(),
@@ -90,6 +91,7 @@ function makeModel(staffPermissions) {
 
 async function renderTeamDetail(staffPermissions) {
     teamDetailMocks.loadParentTeamDetail.mockResolvedValue(makeModel(staffPermissions));
+    teamDetailMocks.loadTeamStaffPermissions.mockResolvedValue(staffPermissions);
     const container = document.createElement('div');
     document.body.appendChild(container);
     const root = createRoot(container);


### PR DESCRIPTION
Closes #1794

## What changed
- removed coach/admin staff-permissions work from the initial `loadParentTeamDetail()` path so Team Detail overview data no longer waits on pending invite queries or `getAllUsers()`
- added a dedicated `loadTeamStaffPermissions()` loader for the admin-only More tab payload
- updated `TeamDetail.tsx` to lazy-load staff permissions when the More tab is opened while keeping the rest of the page renderable immediately
- added regression coverage proving the initial team detail load skips `getAllUsers()` and that staff permissions are fetched only on demand

## Why
Coach and admin users were paying the cost of hidden More-tab data before any visible Team Detail overview content could render. This change keeps the critical path focused on overview data and defers the expensive full-users read until the staff-permissions UI is actually needed.

## Validation
- `npx vitest run tests/unit/app-team-detail-service.test.js tests/unit/app-team-detail-integration.test.jsx tests/unit/app-team-detail-staff-permissions.test.jsx --reporter=verbose`