### PR TITLE
Parallelize parent team reads for profile alerts

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -81,7 +81,7 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=32';
+        import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=33';
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=15';
 

--- a/js/db.js
+++ b/js/db.js
@@ -981,13 +981,9 @@ export async function getParentTeams(userId, options = {}) {
     const teamIds = [...new Set(profile.parentOf.map(p => p.teamId).filter(Boolean))];
     if (teamIds.length === 0) return [];
 
-    const teams = [];
-    for (const teamId of teamIds) {
-        const team = await getTeam(teamId, { includeInactive });
-        if (team) {
-            teams.push(team);
-        }
-    }
+    const teams = (await Promise.all(
+        teamIds.map((teamId) => getTeam(teamId, { includeInactive }))
+    )).filter(Boolean);
 
     // Sort by name for consistency with other helpers
     return teams.sort((a, b) => (a.name || '').localeCompare(b.name || ''));

--- a/tests/unit/dashboard-parent-membership-sync.test.js
+++ b/tests/unit/dashboard-parent-membership-sync.test.js
@@ -21,6 +21,7 @@ describe('dashboard parent membership sync', () => {
     it('uses the rich auth path before loading parent-linked teams', () => {
         const html = readRepoFile('dashboard.html');
 
+        expect(html).toContain("import { getTeams, getUserTeamsWithAccess, getParentTeams, deleteTeam, getUserProfile, getUnreadChatCounts } from './js/db.js?v=33';");
         expect(html).toContain("import { checkAuth } from './js/auth.js?v=15';");
         expect(html).toContain('function requireSyncedAuth()');
         expect(html).toContain('const user = await requireSyncedAuth();');

--- a/tests/unit/db-parent-teams.test.js
+++ b/tests/unit/db-parent-teams.test.js
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const dbSource = readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+
+function buildGetParentTeams({ getUserProfile, getTeam }) {
+    const start = dbSource.indexOf('export async function getParentTeams');
+    const end = dbSource.indexOf('// User profiles', start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+
+    const functionSource = dbSource
+        .slice(start, end)
+        .replace('export async function getParentTeams', 'return async function getParentTeams');
+
+    return new Function('getUserProfile', 'getTeam', functionSource)(getUserProfile, getTeam);
+}
+
+describe('getParentTeams', () => {
+    it('starts all parent-linked team reads before awaiting any individual team result', async () => {
+        const pendingTeamReads = [];
+        const getUserProfile = vi.fn().mockResolvedValue({
+            parentOf: [
+                { teamId: 'team-b' },
+                { teamId: 'team-a' },
+                { teamId: 'team-b' },
+                { teamId: 'team-c' }
+            ]
+        });
+        const getTeam = vi.fn((teamId, options) => new Promise((resolve) => {
+            pendingTeamReads.push({ teamId, options, resolve });
+        }));
+        const getParentTeams = buildGetParentTeams({ getUserProfile, getTeam });
+
+        const teamsPromise = getParentTeams('parent-1', { includeInactive: true });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(getUserProfile).toHaveBeenCalledWith('parent-1');
+        expect(getTeam).toHaveBeenCalledTimes(3);
+        expect(pendingTeamReads.map((entry) => entry.teamId)).toEqual(['team-b', 'team-a', 'team-c']);
+        expect(pendingTeamReads.map((entry) => entry.options)).toEqual([
+            { includeInactive: true },
+            { includeInactive: true },
+            { includeInactive: true }
+        ]);
+
+        pendingTeamReads.find((entry) => entry.teamId === 'team-b')?.resolve({ id: 'team-b', name: 'Bravo' });
+        pendingTeamReads.find((entry) => entry.teamId === 'team-a')?.resolve({ id: 'team-a', name: 'Alpha' });
+        pendingTeamReads.find((entry) => entry.teamId === 'team-c')?.resolve({ id: 'team-c', name: 'Charlie' });
+
+        await expect(teamsPromise).resolves.toEqual([
+            { id: 'team-a', name: 'Alpha' },
+            { id: 'team-b', name: 'Bravo' },
+            { id: 'team-c', name: 'Charlie' }
+        ]);
+    });
+});


### PR DESCRIPTION
Closes #1802

## What changed
- parallelized `getParentTeams()` in `js/db.js` so parent-linked team documents load with one `Promise.all()` batch instead of a per-team await loop
- kept the existing parent team dedupe, active-team filtering, and name sorting behavior intact for notification team loading
- added a regression unit test that executes the helper from source and verifies all parent team reads are kicked off before any individual team promise resolves

## Why
Profile > Alerts was gated on serialized parent-team document reads, which made notification team readiness scale linearly with the number of linked teams for parent accounts. This change removes that waterfall without changing downstream alert preference behavior.