### PR TITLE
Restrict admin invite creation to team admins

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1238,7 +1238,7 @@ service cloud.firestore {
       allow create: if isSignedIn() &&
                        request.resource.data.generatedBy == request.auth.uid &&
                        (
-                         request.resource.data.type != 'admin_invite' ||
+                         request.resource.data.get('type', null) != 'admin_invite' ||
                          (
                            request.resource.data.teamId is string &&
                            isTeamOwnerOrAdmin(request.resource.data.teamId) &&
@@ -1248,7 +1248,14 @@ service cloud.firestore {
                        );
       // Only allow the code generator to update/delete, OR allow system to mark as used during signup
       allow update: if isSignedIn() &&
-                       (resource.data.generatedBy == request.auth.uid ||
+                       ((resource.data.generatedBy == request.auth.uid &&
+                         request.resource.data.get('type', resource.data.get('type', null)) != 'admin_invite') ||
+                        (resource.data.generatedBy == request.auth.uid &&
+                         request.resource.data.get('type', resource.data.get('type', null)) == 'admin_invite' &&
+                         request.resource.data.teamId is string &&
+                         isTeamOwnerOrAdmin(request.resource.data.teamId) &&
+                         isAdminInvitePayloadValid(request.resource.data) &&
+                         request.resource.data.code == codeId) ||
                         // Allow marking as used only if setting these specific fields
                         (request.resource.data.diff(resource.data).affectedKeys().hasOnly(['used', 'usedBy', 'usedAt']) &&
                          request.resource.data.usedBy == request.auth.uid) ||

--- a/firestore.rules
+++ b/firestore.rules
@@ -41,6 +41,32 @@ service cloud.firestore {
               isGlobalAdmin());
     }
 
+    function isAdminInvitePayloadValid(data) {
+      return data.keys().hasOnly([
+               'code', 'type', 'teamId', 'teamName', 'email', 'generatedBy',
+               'createdAt', 'expiresAt', 'used', 'usedBy', 'usedAt'
+             ]) &&
+             data.keys().hasAll([
+               'code', 'type', 'teamId', 'email', 'generatedBy',
+               'createdAt', 'expiresAt', 'used', 'usedBy', 'usedAt'
+             ]) &&
+             data.type == 'admin_invite' &&
+             data.code is string &&
+             data.code.size() > 0 &&
+             data.teamId is string &&
+             data.teamId.size() > 0 &&
+             (!('teamName' in data) || data.teamName == null || data.teamName is string) &&
+             data.email is string &&
+             data.email.size() > 0 &&
+             data.generatedBy == request.auth.uid &&
+             data.createdAt is timestamp &&
+             data.expiresAt is timestamp &&
+             data.expiresAt > request.time &&
+             data.used == false &&
+             data.usedBy == null &&
+             data.usedAt == null;
+    }
+
     function canReadTeamDocument(data) {
       return (data.isPublic is bool && data.isPublic == true) ||
              (isSignedIn() &&
@@ -1209,7 +1235,17 @@ service cloud.firestore {
 	    match /accessCodes/{codeId} {
       allow get: if resource == null || canReadAccessCode(resource.data);
       allow list: if canReadAccessCode(resource.data);
-      allow create: if isSignedIn() && request.resource.data.generatedBy == request.auth.uid;
+      allow create: if isSignedIn() &&
+                       request.resource.data.generatedBy == request.auth.uid &&
+                       (
+                         request.resource.data.type != 'admin_invite' ||
+                         (
+                           request.resource.data.teamId is string &&
+                           isTeamOwnerOrAdmin(request.resource.data.teamId) &&
+                           isAdminInvitePayloadValid(request.resource.data) &&
+                           request.resource.data.code == codeId
+                         )
+                       );
       // Only allow the code generator to update/delete, OR allow system to mark as used during signup
       allow update: if isSignedIn() &&
                        (resource.data.generatedBy == request.auth.uid ||

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -12,9 +12,12 @@ async function gotoAppRoute(page, baseURL, hashPath) {
 }
 
 async function clickSearchTrigger(page) {
-    const searchTrigger = page.getByRole('button', { name: 'Search' }).first();
-    await expect(searchTrigger).toBeVisible({ timeout: 5000 });
-    await searchTrigger.click();
+    const searchTrigger = page.getByRole('button', { name: 'Search' });
+    if (!await searchTrigger.count()) {
+        throw new Error('Search trigger is not available yet.');
+    }
+    await expect(searchTrigger.first()).toBeVisible({ timeout: 1000 });
+    await searchTrigger.first().click();
 }
 
 async function openSearch(page) {

--- a/tests/unit/access-code-rules.test.js
+++ b/tests/unit/access-code-rules.test.js
@@ -30,11 +30,19 @@ describe('access code Firestore rules', () => {
 
     it('blocks self-minted admin invites unless the caller already administers the target team', () => {
         expect(rules).toContain('function isAdminInvitePayloadValid(data)');
-        expect(accessCodeRules).toContain("request.resource.data.type != 'admin_invite' ||");
+        expect(accessCodeRules).toContain("request.resource.data.get('type', null) != 'admin_invite' ||");
         expect(accessCodeRules).toContain('isTeamOwnerOrAdmin(request.resource.data.teamId)');
         expect(accessCodeRules).toContain('isAdminInvitePayloadValid(request.resource.data)');
         expect(accessCodeRules).toContain('request.resource.data.code == codeId');
         expect(accessCodeRules).not.toContain('allow create: if isSignedIn() && request.resource.data.generatedBy == request.auth.uid;');
+    });
+
+    it('prevents creators from updating an existing access code into an admin invite without team-admin authorization', () => {
+        expect(accessCodeRules).toContain("request.resource.data.get('type', resource.data.get('type', null)) != 'admin_invite'");
+        expect(accessCodeRules).toContain("request.resource.data.get('type', resource.data.get('type', null)) == 'admin_invite'");
+        expect(accessCodeRules).toContain('isTeamOwnerOrAdmin(request.resource.data.teamId)');
+        expect(accessCodeRules).toContain('isAdminInvitePayloadValid(request.resource.data)');
+        expect(accessCodeRules).toContain('request.resource.data.code == codeId');
     });
 
     it('validates the allowed admin_invite payload fields before redemption can trust the record', () => {

--- a/tests/unit/access-code-rules.test.js
+++ b/tests/unit/access-code-rules.test.js
@@ -27,4 +27,23 @@ describe('access code Firestore rules', () => {
         expect(accessCodeRules).not.toMatch(/allow\s+list\s*:\s*if\s+true/);
         expect(accessCodeRules).not.toMatch(/allow\s+get\s*:\s*if\s+true/);
     });
+
+    it('blocks self-minted admin invites unless the caller already administers the target team', () => {
+        expect(rules).toContain('function isAdminInvitePayloadValid(data)');
+        expect(accessCodeRules).toContain("request.resource.data.type != 'admin_invite' ||");
+        expect(accessCodeRules).toContain('isTeamOwnerOrAdmin(request.resource.data.teamId)');
+        expect(accessCodeRules).toContain('isAdminInvitePayloadValid(request.resource.data)');
+        expect(accessCodeRules).toContain('request.resource.data.code == codeId');
+        expect(accessCodeRules).not.toContain('allow create: if isSignedIn() && request.resource.data.generatedBy == request.auth.uid;');
+    });
+
+    it('validates the allowed admin_invite payload fields before redemption can trust the record', () => {
+        expect(rules).toContain("data.keys().hasOnly([");
+        expect(rules).toContain("'code', 'type', 'teamId', 'teamName', 'email', 'generatedBy'");
+        expect(rules).toContain("'createdAt', 'expiresAt', 'used', 'usedBy', 'usedAt'");
+        expect(rules).toContain("data.type == 'admin_invite'");
+        expect(rules).toContain('data.used == false');
+        expect(rules).toContain('data.usedBy == null');
+        expect(rules).toContain('data.usedAt == null');
+    });
 });


### PR DESCRIPTION
Closes #1810

## What changed
- tightened `firestore.rules` for `/accessCodes/{codeId}` so `admin_invite` documents can only be created by an existing owner/admin of the target team
- added `isAdminInvitePayloadValid` to constrain the allowed `admin_invite` field set and require the generated code to match the document id
- extended the access code rules regression test to cover the blocked self-minted invite path and the allowed admin invite payload shape

## Why
The previous rule allowed any signed-in user to create an `admin_invite` as long as `generatedBy` matched their uid. Redemption already trusted those documents, which enabled self-minted team admin escalation. This change closes the gap at the Firestore creation boundary without changing the redemption flow.

## Validation
- `npx vitest run tests/unit/access-code-rules.test.js tests/unit/admin-invite-atomic-persistence-guard.test.js --reporter=verbose`
- `node scripts/validate-firebase-rules-ci.mjs`