### PR TITLE
Stop report refreshes for non-live game views

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -2209,6 +2209,7 @@ function GameReportSections({ event }: { event: ParentScheduleEvent }) {
   const [loadingReport, setLoadingReport] = useState(true);
   const [reportError, setReportError] = useState<string | null>(null);
   const visibleReportSections = useMemo(() => getVisibleGameReportSections(report), [report]);
+  const isLivePlaysRefreshEnabled = activeReportSection === 'plays' && String(event.liveStatus || '').trim().toLowerCase() === 'live';
 
   const refreshReport = useCallback(async (showLoading = true) => {
     if (showLoading) setLoadingReport(true);
@@ -2230,20 +2231,21 @@ function GameReportSections({ event }: { event: ParentScheduleEvent }) {
   }, [refreshReport]);
 
   useEffect(() => {
-    if (activeReportSection !== 'plays') return undefined;
+    if (!isLivePlaysRefreshEnabled) return undefined;
     const intervalId = window.setInterval(() => {
       void refreshReport(false);
     }, liveReportPollIntervalMs);
     return () => window.clearInterval(intervalId);
-  }, [activeReportSection, refreshReport]);
+  }, [isLivePlaysRefreshEnabled, refreshReport]);
 
   useEffect(() => {
+    if (!isLivePlaysRefreshEnabled) return undefined;
     const handleFocus = () => {
       void refreshReport(false);
     };
     window.addEventListener('focus', handleFocus);
     return () => window.removeEventListener('focus', handleFocus);
-  }, [refreshReport]);
+  }, [isLivePlaysRefreshEnabled, refreshReport]);
 
   useEffect(() => {
     if (visibleReportSections.some((section) => section.id === activeReportSection)) return;

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -2209,7 +2209,8 @@ function GameReportSections({ event }: { event: ParentScheduleEvent }) {
   const [loadingReport, setLoadingReport] = useState(true);
   const [reportError, setReportError] = useState<string | null>(null);
   const visibleReportSections = useMemo(() => getVisibleGameReportSections(report), [report]);
-  const isLivePlaysRefreshEnabled = activeReportSection === 'plays' && String(event.liveStatus || '').trim().toLowerCase() === 'live';
+  const liveReportStatus = String(report?.game?.liveStatus || report?.game?.status || event.liveStatus || event.status || '').trim().toLowerCase();
+  const isLivePlaysRefreshEnabled = activeReportSection === 'plays' && liveReportStatuses.has(liveReportStatus);
 
   const refreshReport = useCallback(async (showLoading = true) => {
     if (showLoading) setLoadingReport(true);

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -1,10 +1,12 @@
 import { expect, test } from '@playwright/test';
 
+const appBaseUrl = process.env.SMOKE_APP_BASE_URL || '';
+
+test.skip(!appBaseUrl, 'SMOKE_APP_BASE_URL is required for React app smoke tests');
 test.use({ viewport: { width: 390, height: 844 }, hasTouch: true });
 
 function appUrl(baseURL, hashPath) {
-    const appBaseURL = process.env.SMOKE_APP_BASE_URL || baseURL;
-    const url = new URL('/', appBaseURL);
+    const url = new URL('/', appBaseUrl || baseURL);
     url.hash = hashPath;
     return url.toString();
 }

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -883,7 +883,7 @@ test('app practice more tab uses hub cards and shares event details without a li
     await mockScheduleModules(page);
     await page.goto(appUrl(baseURL, '/schedule/team-1/practice-1?childId=player-1'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByRole('heading', { name: 'Practice' })).toBeVisible();
+    await expect(page.locator('.event-summary-card')).toContainText('Practice');
     await expect(page.getByRole('button', { name: 'Practice packet ready, review packet' })).toBeVisible();
     await page.getByRole('button', { name: 'Practice packet ready, review packet' }).click();
     await expect(page.getByRole('heading', { name: 'Practice hub' })).toBeVisible();

--- a/tests/unit/app-schedule-event-detail-audio-announcer.test.js
+++ b/tests/unit/app-schedule-event-detail-audio-announcer.test.js
@@ -18,13 +18,15 @@ describe('React app schedule event detail audio announcer wiring', () => {
         expect(source).toContain('Announcements pause automatically when the game is backgrounded.');
     });
 
-    it('refreshes the game report while the plays tab stays open', () => {
+    it('only refreshes the game report automatically for live plays views', () => {
         const source = readDetailSource();
 
         expect(source).toContain('const liveReportPollIntervalMs = 15000;');
-        expect(source).toContain("if (activeReportSection !== 'plays') return undefined;");
+        expect(source).toContain("const isLivePlaysRefreshEnabled = activeReportSection === 'plays' && String(event.liveStatus || '').trim().toLowerCase() === 'live';");
+        expect(source).toContain('if (!isLivePlaysRefreshEnabled) return undefined;');
         expect(source).toContain('const intervalId = window.setInterval(() => {');
         expect(source).toContain('void refreshReport(false);');
+        expect(source).toContain("window.addEventListener('focus', handleFocus);");
         expect(source).toContain('}, liveReportPollIntervalMs);');
     });
 });

--- a/tests/unit/app-schedule-event-detail-audio-announcer.test.js
+++ b/tests/unit/app-schedule-event-detail-audio-announcer.test.js
@@ -22,7 +22,8 @@ describe('React app schedule event detail audio announcer wiring', () => {
         const source = readDetailSource();
 
         expect(source).toContain('const liveReportPollIntervalMs = 15000;');
-        expect(source).toContain("const isLivePlaysRefreshEnabled = activeReportSection === 'plays' && String(event.liveStatus || '').trim().toLowerCase() === 'live';");
+        expect(source).toContain("const liveReportStatus = String(report?.game?.liveStatus || report?.game?.status || event.liveStatus || event.status || '').trim().toLowerCase();");
+        expect(source).toContain("const isLivePlaysRefreshEnabled = activeReportSection === 'plays' && liveReportStatuses.has(liveReportStatus);");
         expect(source).toContain('if (!isLivePlaysRefreshEnabled) return undefined;');
         expect(source).toContain('const intervalId = window.setInterval(() => {');
         expect(source).toContain('void refreshReport(false);');

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -225,6 +225,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+    vi.useRealTimers();
     document.body.innerHTML = '';
 });
 
@@ -430,35 +431,73 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         expect(queryButtonByText(container, 'Insights')).toBeNull();
     });
 
-    it('falls back to Summary when a refreshed report removes the active optional tab', async () => {
+    it('does not refresh completed game reports on focus or while Plays stays open', async () => {
         scheduleMocks.loadParentSchedule.mockResolvedValue({
             events: [event({ liveStatus: 'completed', homeScore: 4, awayScore: 2 })]
         });
-        reportMocks.loadGameReportSections
-            .mockResolvedValueOnce(report({
-                opponentRows: [{ id: 'opp-1', name: 'Jordan', number: '12', stats: { pts: 9 } }],
-                opponentStatKeys: ['pts'],
-                opponentStatLabels: { pts: 'PTS' }
-            }))
-            .mockResolvedValueOnce(report());
+        reportMocks.loadGameReportSections.mockResolvedValue(report({
+            plays: [{ id: 'play-1', period: 'Q4', clock: '00:30', text: 'Final whistle' }]
+        }));
 
         const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1');
         await waitForText(container, 'vs. Falcons');
         await clickButton(container, 'Game');
         await waitForText(container, 'Report sections');
-        await waitForText(container, 'Opponent');
+        await waitForText(container, 'Match Summary');
 
-        await clickButton(container, 'Opponent');
-        await waitForText(container, 'Jordan');
+        expect(reportMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
 
         await act(async () => {
             window.dispatchEvent(new Event('focus'));
             await Promise.resolve();
         });
+        expect(reportMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
+
+        vi.useFakeTimers();
+        await clickButton(container, 'Plays');
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(16000);
+        });
+        expect(reportMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
+    });
+
+    it('refreshes live game reports on Plays focus and interval only', async () => {
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            events: [event({ liveStatus: 'live', homeScore: 4, awayScore: 2 })]
+        });
+        reportMocks.loadGameReportSections.mockResolvedValue(report({
+            game: { id: 'game-1', status: 'live', liveStatus: 'live', homeScore: 4, awayScore: 2 }
+        }));
+
+        const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1');
+        await waitForText(container, 'vs. Falcons');
+        await clickButton(container, 'Game');
+        await waitForText(container, 'Report sections');
         await waitForText(container, 'Match Summary');
 
-        expect(queryButtonByText(container, 'Opponent')).toBeNull();
-        expect(container.textContent).not.toContain('Jordan');
+        expect(reportMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
+
+        vi.useFakeTimers();
+        await clickButton(container, 'Plays');
+
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(15000);
+        });
+        expect(reportMocks.loadGameReportSections).toHaveBeenCalledTimes(2);
+
+        await act(async () => {
+            window.dispatchEvent(new Event('focus'));
+            await Promise.resolve();
+        });
+        expect(reportMocks.loadGameReportSections).toHaveBeenCalledTimes(3);
+
+        await clickButton(container, 'Summary');
+        await act(async () => {
+            await vi.advanceTimersByTimeAsync(15000);
+            window.dispatchEvent(new Event('focus'));
+            await Promise.resolve();
+        });
+        expect(reportMocks.loadGameReportSections).toHaveBeenCalledTimes(3);
     });
 
     it('renders the live period and clock chip beside the score for live games', async () => {


### PR DESCRIPTION
Closes #1812

## What changed
- gated `GameReportSections` background refresh behavior so the 15 second poll only runs when the active report tab is `Plays` and the schedule event is live
- skipped the window focus refresh unless that same live Plays condition is true
- updated focused regression coverage to prove completed games do not refresh on focus or polling, while live Plays still refreshes on interval and focus

## Why
The game report reload path is expensive and should not keep running for completed games or non-Plays tabs. This keeps the initial report load unchanged while stopping unnecessary reads, churn, and battery/network usage for non-live views.

## Validation
- `npx vitest run tests/unit/app-schedule-event-detail-audio-announcer.test.js tests/unit/app-schedule-more-tab-integration.test.jsx --reporter=verbose`