### PR TITLE
Reject stale Stripe team-fee checkout webhooks

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -19,6 +19,8 @@ const {
   buildTeamFeeCheckoutUrls,
   buildTeamFeeCheckoutMetadata,
   canReuseTeamFeeCheckoutSession,
+  getTeamFeeCheckoutGuardFailure,
+  shouldApplyTeamFeeCheckoutSession,
   shouldMarkTeamFeePaidFromEvent,
   shouldRecordTeamFeeCheckoutNotPaidFromEvent,
   buildTeamFeePaidUpdate,
@@ -1494,6 +1496,7 @@ exports.createStripeTeamFeeCheckout = functions.https.onCall(async (data, contex
   const stripe = createStripeClient();
   const { appUrl } = getStripeConfig();
   const { successUrl, cancelUrl } = buildTeamFeeCheckoutUrls(appUrl, input);
+  const checkoutAttemptToken = (crypto.randomUUID ? crypto.randomUUID() : crypto.randomBytes(16).toString('hex')).replace(/-/g, '');
   const title = recipient.feeTitle || recipient.title || 'Team fee';
   const playerName = recipient.playerName || recipient.childName || '';
   const description = playerName ? `${title} for ${playerName}` : title;
@@ -1513,7 +1516,12 @@ exports.createStripeTeamFeeCheckout = functions.https.onCall(async (data, contex
     cancel_url: cancelUrl,
     customer_email: email || recipient.parentEmail || recipient.email || undefined,
     client_reference_id: `${input.teamId}:${input.batchId}:${input.recipientId}`,
-    metadata: buildTeamFeeCheckoutMetadata({ ...input, payerUid: context.auth.uid })
+    metadata: buildTeamFeeCheckoutMetadata({
+      ...input,
+      payerUid: context.auth.uid,
+      checkoutAttemptToken,
+      checkoutAmountCents: amountCents
+    })
   });
 
   const now = admin.firestore.FieldValue.serverTimestamp();
@@ -1523,6 +1531,7 @@ exports.createStripeTeamFeeCheckout = functions.https.onCall(async (data, contex
     checkoutStatus: 'open',
     paymentProvider: 'stripe',
     stripeCheckoutSessionId: session.id,
+    checkoutAttemptToken,
     stripePaymentStatus: session.payment_status || 'unpaid',
     checkoutAmountCents: amountCents,
     balanceDueCents: amountCents,
@@ -2068,17 +2077,27 @@ exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
           throw new Error('Team fee recipient not found for Stripe webhook.');
         }
 
-        if (shouldMarkTeamFeePaidFromEvent(event)) {
+        const recipient = recipientSnap.data() || {};
+        const shouldApplyCheckoutEvent = shouldApplyTeamFeeCheckoutSession({ recipient, session });
+        const ignoredReason = shouldApplyCheckoutEvent
+          ? null
+          : getTeamFeeCheckoutGuardFailure({ recipient, session });
+
+        if (shouldMarkTeamFeePaidFromEvent(event) && shouldApplyCheckoutEvent) {
           transaction.set(recipientRef, buildTeamFeePaidUpdate({
-            recipient: recipientSnap.data() || {},
+            recipient,
             session,
             eventId: event.id,
             receivedAt
           }), { merge: true });
-        } else {
+        } else if (shouldRecordTeamFeeCheckoutNotPaidFromEvent(event) && shouldApplyCheckoutEvent) {
           transaction.set(recipientRef, {
             checkoutStatus: event.type === 'checkout.session.expired' ? 'expired' : 'payment_failed',
             stripeCheckoutSessionId: session.id || null,
+            checkoutAttemptToken: null,
+            checkoutUrl: null,
+            paymentLink: null,
+            checkoutAmountCents: null,
             stripeEventId: event.id,
             updatedAt: receivedAt
           }, { merge: true });
@@ -2090,6 +2109,8 @@ exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
           type: event.type,
           checkoutSessionId: session.id || null,
           recipientPath: recipientRef.path,
+          ignored: shouldApplyCheckoutEvent !== true,
+          ignoredReason,
           receivedAt
         });
       });

--- a/functions/team-fees-core.cjs
+++ b/functions/team-fees-core.cjs
@@ -179,7 +179,8 @@ function getTeamFeeCheckoutGuardFailure({ recipient = {}, session = {} } = {}) {
 
     const recipientToken = normalizeCheckoutAttemptToken(recipient.checkoutAttemptToken);
     const sessionToken = normalizeCheckoutAttemptToken(session.metadata?.checkoutAttemptToken);
-    if (!recipientToken || !sessionToken || recipientToken !== sessionToken) {
+    const isLegacyCheckoutSession = !recipientToken && !sessionToken;
+    if (!isLegacyCheckoutSession && (!recipientToken || !sessionToken || recipientToken !== sessionToken)) {
         return 'checkout_attempt_mismatch';
     }
 

--- a/functions/team-fees-core.cjs
+++ b/functions/team-fees-core.cjs
@@ -2,6 +2,15 @@ function normalizeString(value) {
     return String(value || '').trim();
 }
 
+function normalizeCheckoutAttemptToken(value, label = 'checkoutAttemptToken') {
+    const token = normalizeString(value);
+    if (!token) return '';
+    if (!/^[A-Za-z0-9_-]{16,128}$/.test(token)) {
+        throw new Error(`${label} is invalid.`);
+    }
+    return token;
+}
+
 function normalizeTeamFeeCheckoutInput(data = {}) {
     const teamId = normalizeString(data.teamId);
     const batchId = normalizeString(data.batchId);
@@ -129,23 +138,68 @@ function buildTeamFeeCheckoutUrls(appUrl, { teamId, batchId, recipientId }) {
     };
 }
 
-function buildTeamFeeCheckoutMetadata({ teamId, batchId, recipientId, payerUid }) {
-    return {
+function buildTeamFeeCheckoutMetadata({ teamId, batchId, recipientId, payerUid, checkoutAttemptToken = '', checkoutAmountCents = 0 }) {
+    const metadata = {
         product: 'team_fee',
         teamId,
         batchId,
         recipientId,
         payerUid
     };
+
+    const normalizedToken = normalizeCheckoutAttemptToken(checkoutAttemptToken);
+    if (normalizedToken) {
+        metadata.checkoutAttemptToken = normalizedToken;
+    }
+
+    const amountCents = Math.round(Number(checkoutAmountCents || 0));
+    if (Number.isFinite(amountCents) && amountCents > 0) {
+        metadata.checkoutAmountCents = String(amountCents);
+    }
+
+    return metadata;
 }
 
 function canReuseTeamFeeCheckoutSession(recipient = {}, amountCents = 0) {
     return Boolean(
         recipient.checkoutUrl &&
         recipient.stripeCheckoutSessionId &&
+        normalizeCheckoutAttemptToken(recipient.checkoutAttemptToken) &&
         recipient.checkoutStatus === 'open' &&
         Number(recipient.checkoutAmountCents) === Number(amountCents)
     );
+}
+
+function getTeamFeeCheckoutGuardFailure({ recipient = {}, session = {} } = {}) {
+    const activeSessionId = normalizeString(recipient.stripeCheckoutSessionId);
+    const sessionId = normalizeString(session.id);
+    if (!activeSessionId || !sessionId || activeSessionId !== sessionId) {
+        return 'checkout_session_mismatch';
+    }
+
+    const recipientToken = normalizeCheckoutAttemptToken(recipient.checkoutAttemptToken);
+    const sessionToken = normalizeCheckoutAttemptToken(session.metadata?.checkoutAttemptToken);
+    if (!recipientToken || !sessionToken || recipientToken !== sessionToken) {
+        return 'checkout_attempt_mismatch';
+    }
+
+    const sessionAmountCents = getTeamFeeStripePaidAmountCents({ recipient, session });
+    const expectedCheckoutAmountCents = Math.round(Number(recipient.checkoutAmountCents || 0));
+    if (!Number.isFinite(sessionAmountCents) || sessionAmountCents <= 0) {
+        return 'checkout_amount_missing';
+    }
+    if (!Number.isFinite(expectedCheckoutAmountCents) || expectedCheckoutAmountCents <= 0 || sessionAmountCents !== expectedCheckoutAmountCents) {
+        return 'checkout_amount_mismatch';
+    }
+    if (sessionAmountCents !== getTeamFeeBalanceCents(recipient)) {
+        return 'balance_mismatch';
+    }
+
+    return '';
+}
+
+function shouldApplyTeamFeeCheckoutSession({ recipient = {}, session = {} } = {}) {
+    return !getTeamFeeCheckoutGuardFailure({ recipient, session });
 }
 
 function shouldMarkTeamFeePaidFromEvent(event = {}) {
@@ -204,6 +258,12 @@ function buildTeamFeeStripeRefundUpdate({ recipient = {}, refund = {}, amountCen
         amountRefundedCents: refundedAmountCents,
         lastRefundedAt: refundedAt,
         updatedAt: refundedAt,
+        checkoutStatus: 'stale',
+        checkoutAttemptToken: null,
+        checkoutUrl: null,
+        paymentLink: null,
+        stripeCheckoutSessionId: null,
+        checkoutAmountCents: null,
         paymentProvider: 'stripe',
         stripeLastRefundId: refund.id || null,
         stripeLastRefundStatus: refundStatus,
@@ -234,6 +294,9 @@ function buildTeamFeePaidUpdate({ recipient = {}, session = {}, eventId, receive
         amountPaidCents: paidAmountCents,
         balanceDueCents,
         checkoutStatus: 'paid',
+        checkoutAttemptToken: null,
+        checkoutUrl: null,
+        paymentLink: null,
         paymentProvider: 'stripe',
         stripeCheckoutSessionId: session.id || null,
         stripePaymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : null,
@@ -270,6 +333,8 @@ module.exports = {
     buildTeamFeeCheckoutUrls,
     buildTeamFeeCheckoutMetadata,
     canReuseTeamFeeCheckoutSession,
+    getTeamFeeCheckoutGuardFailure,
+    shouldApplyTeamFeeCheckoutSession,
     shouldMarkTeamFeePaidFromEvent,
     shouldRecordTeamFeeCheckoutNotPaidFromEvent,
     getTeamFeeStripePaidAmountCents,

--- a/js/db.js
+++ b/js/db.js
@@ -4140,6 +4140,31 @@ export async function updateTeamFeeRecipient(teamId, batchId, recipientId, updat
         updatedAt: serverTimestamp()
     };
 
+    const invalidatesOnlineCheckout = [
+        'status',
+        'amountDueCents',
+        'balanceDueCents',
+        'remainingBalanceCents',
+        'amountPaidCents',
+        'paidAmountCents',
+        'amountRefundedCents',
+        'refundedAmountCents',
+        'manualPayment',
+        'refunded',
+        'adjustment',
+        'paidAt',
+        'lastRefundedAt'
+    ].some((key) => Object.prototype.hasOwnProperty.call(recipientUpdates, key));
+
+    if (invalidatesOnlineCheckout) {
+        updatePayload.checkoutStatus = 'stale';
+        updatePayload.checkoutAttemptToken = deleteField();
+        updatePayload.checkoutUrl = deleteField();
+        updatePayload.paymentLink = deleteField();
+        updatePayload.stripeCheckoutSessionId = deleteField();
+        updatePayload.checkoutAmountCents = deleteField();
+    }
+
     if (Array.isArray(ledgerEntries) && ledgerEntries.length > 0) {
         updatePayload.paymentLedger = arrayUnion(...ledgerEntries);
     }

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -1140,7 +1140,7 @@ async function initTeamFeesAdminPage() {
     renderFooter(document.getElementById('footer-container'));
 
     const [{ getTeam, getPlayers, getUserProfile, createTeamFeeBatch, getTeamFeeBatch, listTeamFeeBatches, listTeamFeeRecipients, updateTeamFeeRecipient, canModerateChat }, { requireAuth }] = await Promise.all([
-        import('./db.js?v=36'),
+        import('./db.js?v=37'),
         import('./auth.js?v=14')
     ]);
 

--- a/team-fees.html
+++ b/team-fees.html
@@ -45,7 +45,7 @@
 
     <div id="footer-container"></div>
 
-    <script type="module" src="./js/team-fees-admin.js?v=7"></script>
+    <script type="module" src="./js/team-fees-admin.js?v=8"></script>
 </body>
 
 </html>

--- a/tests/unit/team-fees-admin.test.js
+++ b/tests/unit/team-fees-admin.test.js
@@ -16,6 +16,14 @@ describe('team fees admin page routing', () => {
         expect(registrations.map(({ eventName }) => eventName)).toEqual(['DOMContentLoaded', 'hashchange']);
         expect(registrations[1].handler).toBe(registrations[0].handler);
     });
+
+    it('pins the team fees page shell and admin module to the latest cache-busted versions', () => {
+        const adminSource = readFileSync(new URL('../../js/team-fees-admin.js', import.meta.url), 'utf8');
+        const pageSource = readFileSync(new URL('../../team-fees.html', import.meta.url), 'utf8');
+
+        expect(adminSource).toContain("import('./db.js?v=37')");
+        expect(pageSource).toContain('<script type="module" src="./js/team-fees-admin.js?v=8"></script>');
+    });
 });
 
 describe('create offline team fee form', () => {

--- a/tests/unit/team-fees-functions.test.js
+++ b/tests/unit/team-fees-functions.test.js
@@ -15,6 +15,8 @@ const {
     buildTeamFeeCheckoutUrls,
     buildTeamFeeCheckoutMetadata,
     canReuseTeamFeeCheckoutSession,
+    getTeamFeeCheckoutGuardFailure,
+    shouldApplyTeamFeeCheckoutSession,
     shouldMarkTeamFeePaidFromEvent,
     shouldRecordTeamFeeCheckoutNotPaidFromEvent,
     getTeamFeeStripePaidAmountCents,
@@ -83,12 +85,27 @@ describe('team fee checkout function helpers', () => {
             recipientId: 'player_789',
             payerUid: 'user_123'
         });
+        expect(buildTeamFeeCheckoutMetadata({
+            ...input,
+            payerUid: 'user_123',
+            checkoutAttemptToken: 'tok_1234567890abcdef',
+            checkoutAmountCents: 7500
+        })).toEqual({
+            product: 'team_fee',
+            teamId: 'team_123',
+            batchId: 'batch_456',
+            recipientId: 'player_789',
+            payerUid: 'user_123',
+            checkoutAttemptToken: 'tok_1234567890abcdef',
+            checkoutAmountCents: '7500'
+        });
     });
 
     it('reuses only currently open checkout sessions for the same amount', () => {
         const recipient = {
             checkoutUrl: 'https://checkout.stripe.test/session',
             stripeCheckoutSessionId: 'cs_123',
+            checkoutAttemptToken: 'tok_1234567890abcdef',
             checkoutStatus: 'open',
             checkoutAmountCents: 7500
         };
@@ -97,6 +114,31 @@ describe('team fee checkout function helpers', () => {
         expect(canReuseTeamFeeCheckoutSession({ ...recipient, checkoutStatus: 'payment_failed' }, 7500)).toBe(false);
         expect(canReuseTeamFeeCheckoutSession({ ...recipient, checkoutStatus: 'expired' }, 7500)).toBe(false);
         expect(canReuseTeamFeeCheckoutSession({ ...recipient, checkoutAmountCents: 8000 }, 7500)).toBe(false);
+        expect(canReuseTeamFeeCheckoutSession({ ...recipient, checkoutAttemptToken: '' }, 7500)).toBe(false);
+    });
+
+    it('rejects stale team fee checkout sessions when session, token, or balance drifted', () => {
+        const recipient = {
+            stripeCheckoutSessionId: 'cs_current',
+            checkoutAttemptToken: 'tok_current_123456',
+            checkoutAmountCents: 7500,
+            amountDueCents: 7500,
+            paidAmountCents: 0
+        };
+        const session = {
+            id: 'cs_current',
+            amount_total: 7500,
+            metadata: {
+                checkoutAttemptToken: 'tok_current_123456'
+            }
+        };
+
+        expect(shouldApplyTeamFeeCheckoutSession({ recipient, session })).toBe(true);
+        expect(getTeamFeeCheckoutGuardFailure({ recipient, session })).toBe('');
+        expect(getTeamFeeCheckoutGuardFailure({ recipient, session: { ...session, id: 'cs_old' } })).toBe('checkout_session_mismatch');
+        expect(getTeamFeeCheckoutGuardFailure({ recipient, session: { ...session, metadata: { checkoutAttemptToken: 'tok_old_1234567890' } } })).toBe('checkout_attempt_mismatch');
+        expect(getTeamFeeCheckoutGuardFailure({ recipient, session: { ...session, amount_total: 7000 } })).toBe('checkout_amount_mismatch');
+        expect(getTeamFeeCheckoutGuardFailure({ recipient: { ...recipient, amountDueCents: 9000 }, session })).toBe('balance_mismatch');
     });
 
     it('marks paid immediate and async team fee checkout sessions as paid', () => {
@@ -159,6 +201,7 @@ describe('team fee checkout function helpers', () => {
             amountPaidCents: 12500,
             balanceDueCents: 0,
             checkoutStatus: 'paid',
+            checkoutAttemptToken: null,
             paymentProvider: 'stripe',
             stripeCheckoutSessionId: 'cs_123',
             stripePaymentIntentId: 'pi_123',
@@ -241,6 +284,9 @@ describe('team fee checkout function helpers', () => {
             balanceDueCents: 5000,
             refundedAmountCents: 7500,
             amountRefundedCents: 7500,
+            checkoutStatus: 'stale',
+            checkoutAttemptToken: null,
+            stripeCheckoutSessionId: null,
             paymentProvider: 'stripe',
             stripeLastRefundId: 're_123',
             stripeLastRefundStatus: 'succeeded'
@@ -268,6 +314,20 @@ describe('team fee checkout function helpers', () => {
         expect(source).toContain("stripeRefundStatus !== 'succeeded'");
         expect(source).toContain('const ledgerRefundedAt = admin.firestore.Timestamp.now();');
         expect(source).toContain('hasStripeRefundLedgerEntry(latestRecipient, refund.id)');
+    });
+
+    it('guards team fee webhook processing behind the current checkout attempt', () => {
+        const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+        const dbSource = readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+
+        expect(functionsSource).toContain('checkoutAttemptToken');
+        expect(functionsSource).toContain('checkoutAmountCents: amountCents');
+        expect(functionsSource).toContain('shouldApplyTeamFeeCheckoutSession({ recipient, session })');
+        expect(functionsSource).toContain('getTeamFeeCheckoutGuardFailure({ recipient, session })');
+        expect(functionsSource).toContain("ignoredReason");
+        expect(dbSource).toContain("updatePayload.checkoutStatus = 'stale'");
+        expect(dbSource).toContain('updatePayload.checkoutAttemptToken = deleteField()');
+        expect(dbSource).toContain('updatePayload.stripeCheckoutSessionId = deleteField()');
     });
 
     it('does not mark the recipient fully paid when the balance grew after checkout creation', () => {

--- a/tests/unit/team-fees-functions.test.js
+++ b/tests/unit/team-fees-functions.test.js
@@ -132,6 +132,16 @@ describe('team fee checkout function helpers', () => {
                 checkoutAttemptToken: 'tok_current_123456'
             }
         };
+        const legacyRecipient = {
+            stripeCheckoutSessionId: 'cs_legacy',
+            checkoutAmountCents: 7500,
+            amountDueCents: 7500,
+            paidAmountCents: 0
+        };
+        const legacySession = {
+            id: 'cs_legacy',
+            metadata: {}
+        };
 
         expect(shouldApplyTeamFeeCheckoutSession({ recipient, session })).toBe(true);
         expect(getTeamFeeCheckoutGuardFailure({ recipient, session })).toBe('');
@@ -139,6 +149,9 @@ describe('team fee checkout function helpers', () => {
         expect(getTeamFeeCheckoutGuardFailure({ recipient, session: { ...session, metadata: { checkoutAttemptToken: 'tok_old_1234567890' } } })).toBe('checkout_attempt_mismatch');
         expect(getTeamFeeCheckoutGuardFailure({ recipient, session: { ...session, amount_total: 7000 } })).toBe('checkout_amount_mismatch');
         expect(getTeamFeeCheckoutGuardFailure({ recipient: { ...recipient, amountDueCents: 9000 }, session })).toBe('balance_mismatch');
+        expect(shouldApplyTeamFeeCheckoutSession({ recipient: legacyRecipient, session: legacySession })).toBe(true);
+        expect(getTeamFeeCheckoutGuardFailure({ recipient: legacyRecipient, session: legacySession })).toBe('');
+        expect(getTeamFeeCheckoutGuardFailure({ recipient: legacyRecipient, session: { ...legacySession, metadata: { checkoutAttemptToken: 'tok_new_1234567890' } } })).toBe('checkout_attempt_mismatch');
     });
 
     it('marks paid immediate and async team fee checkout sessions as paid', () => {


### PR DESCRIPTION
Closes #1821

## What changed
- added a checkout attempt token and expected amount to Stripe team-fee checkout session metadata, then persisted the active attempt on the fee recipient
- guarded team-fee webhook processing so only the current session id, current attempt token, and current outstanding balance can mark a recipient paid or failed
- invalidated existing online checkout attempts whenever team-fee recipient payment state or balance is changed through admin-side recipient updates, and cleared active checkout state after paid/refund processing
- added regression coverage for stale session id, stale attempt token, amount drift, and source-level wiring for webhook and invalidation behavior

## Why
Older Stripe Checkout links could still be completed after the fee balance changed, which could over-credit the ledger or duplicate collection. This change makes team-fee checkout processing honor only the current active attempt and current expected balance.

## Validation
- `npx vitest run tests/unit/team-fees-functions.test.js --reporter=verbose`
- `node -c functions/index.js && node -c functions/team-fees-core.cjs`