### PR TITLE
Add private calendar sync to team detail

### DIFF
--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -455,7 +455,36 @@ export function downloadIcs(filename: string, icsText: string) {
   window.setTimeout(() => URL.revokeObjectURL(url), 500);
 }
 
+export function buildPrivateTeamCalendarFeedUrl(teamId: string, team: Record<string, any> | null | undefined) {
+  const directUrl = team?.privateCalendarFeedUrl
+    || team?.calendarSubscriptionUrl
+    || team?.calendarFeedUrl
+    || team?.teamCalendarFeedUrl;
+  if (typeof directUrl === 'string' && directUrl.trim()) {
+    return directUrl.trim().replace(/^webcal:\/\//i, 'https://');
+  }
+
+  const token = team?.calendarSubscriptionToken
+    || team?.privateCalendarToken
+    || team?.calendarFeedToken
+    || team?.teamCalendarToken;
+  if (!teamId || !token) return '';
+
+  const configured = (window as any).__ALLPLAYS_CONFIG__?.privateTeamCalendarIcsFunctionUrl || (window as any).ALLPLAYS_PRIVATE_TEAM_CALENDAR_ICS_URL;
+  const fallback = (window as any).__ALLPLAYS_CONFIG__?.calendarFetchFunctionUrl || (window as any).ALLPLAYS_CALENDAR_FUNCTION_URL;
+  const baseUrl = typeof configured === 'string' && configured.trim()
+    ? configured.trim()
+    : typeof fallback === 'string' && fallback.includes('fetchCalendarIcs')
+      ? fallback.replace('fetchCalendarIcs', 'privateTeamCalendarIcs')
+      : 'https://us-central1-all-plays-prod.cloudfunctions.net/privateTeamCalendarIcs';
+  const separator = baseUrl.includes('?') ? '&' : '?';
+  return `${baseUrl}${separator}teamId=${encodeURIComponent(teamId)}&token=${encodeURIComponent(token)}`;
+}
+
 export async function getPrivateTeamCalendarFeedUrl(teamId: string) {
+  const teamSnap = await Promise.resolve(getTeam(teamId)).catch(() => null);
+  const teamFeedUrl = buildPrivateTeamCalendarFeedUrl(teamId, teamSnap);
+  if (teamFeedUrl) return teamFeedUrl;
   const token = await getNativeAuthIdToken(false).catch(() => null)
     || await firebaseAuth.currentUser?.getIdToken?.(false).catch(() => null);
   if (!teamId || !token) return '';

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -26,6 +26,7 @@ import {
 } from 'lucide-react';
 import { copyPublicText, openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 import { getEventDetailPath } from '../lib/homeLogic';
+import { getAppleCalendarFeedUrl, getGoogleCalendarFeedUrl, getPrivateTeamCalendarFeedUrl } from '../lib/parentToolsService';
 import { createStaffRsvpReminderPreviewLoader, sendStaffRsvpReminder, type StaffRsvpReminderSendResult } from '../lib/scheduleService';
 import type { ParentScheduleEvent, StaffRsvpReminderPreview } from '../lib/scheduleLogic';
 import { buildPublicTeamGamesIcsUrl, canExposePublicFanFeed, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, loadTeamStaffPermissions, revokeScorekeeperAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp, type InviteTeamAdminForAppResult, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer, type TeamScorekeeperGrantTarget } from '../lib/teamDetailService';
@@ -206,7 +207,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
       {activeTab === 'schedule' ? <ScheduleTab model={model} auth={auth} /> : null}
       {activeTab === 'roster' ? <RosterTab model={model} /> : null}
       {activeTab === 'insights' ? <InsightsTab model={model} /> : null}
-      {activeTab === 'more' ? <MoreTab model={model} staffPermissionsLoading={staffPermissionsLoading} staffPermissionsError={staffPermissionsError} onTeamDetailRefresh={refreshTeamDetail} /> : null}
+      {activeTab === 'more' ? <MoreTab model={model} auth={auth} staffPermissionsLoading={staffPermissionsLoading} staffPermissionsError={staffPermissionsError} onTeamDetailRefresh={refreshTeamDetail} /> : null}
     </div>
   );
 }
@@ -389,7 +390,7 @@ function InsightsTab({ model }: { model: TeamDetailModel }) {
   );
 }
 
-function MoreTab({ model, staffPermissionsLoading, staffPermissionsError, onTeamDetailRefresh }: { model: TeamDetailModel; staffPermissionsLoading: boolean; staffPermissionsError: string; onTeamDetailRefresh: () => Promise<void> }) {
+function MoreTab({ model, auth, staffPermissionsLoading, staffPermissionsError, onTeamDetailRefresh }: { model: TeamDetailModel; auth: AuthState; staffPermissionsLoading: boolean; staffPermissionsError: string; onTeamDetailRefresh: () => Promise<void> }) {
   return (
     <div className="space-y-4">
       {model.canManageTeam && !model.staffPermissions && staffPermissionsLoading ? (
@@ -408,6 +409,7 @@ function MoreTab({ model, staffPermissionsLoading, staffPermissionsError, onTeam
       ) : null}
       {model.staffPermissions ? <StaffPermissionsCard model={model} onInviteSuccess={onTeamDetailRefresh} /> : null}
       {model.canManageTeam ? <ReminderTimingDefaultsCard model={model} onSaved={onTeamDetailRefresh} /> : null}
+      {auth.user ? <PrivateCalendarSyncCard model={model} /> : null}
       {canExposePublicFanFeed(model.team, [...model.upcomingEvents, ...model.recentResults]) ? <FanFeedCard model={model} /> : null}
       {model.canManageTeam ? <ScoreboardWidgetCard model={model} /> : null}
 
@@ -550,6 +552,65 @@ function ReminderTimingDefaultsCard({ model, onSaved }: { model: TeamDetailModel
             </button>
             {status ? <div className={`text-xs font-black ${status.success ? 'text-emerald-700' : 'text-rose-700'}`} role="status">{status.message}</div> : null}
           </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function PrivateCalendarSyncCard({ model }: { model: TeamDetailModel }) {
+  const [busyTarget, setBusyTarget] = useState<'apple' | 'google' | 'copy' | ''>('');
+  const [status, setStatus] = useState<{ success: boolean; message: string } | null>(null);
+
+  async function openFeed(target: 'apple' | 'google' | 'copy') {
+    if (busyTarget) return;
+    setBusyTarget(target);
+    setStatus(null);
+    try {
+      const feedUrl = await getPrivateTeamCalendarFeedUrl(model.team.id);
+      if (!feedUrl) throw new Error('Unable to create private calendar feed. Sign in again and retry.');
+      if (target === 'copy') {
+        const result = await copyPublicText(feedUrl);
+        setStatus(result === 'copied'
+          ? { success: true, message: 'Private calendar link copied.' }
+          : { success: false, message: 'Unable to copy the private calendar link. Sign in again and retry.' });
+        return;
+      }
+      await openPublicUrl(target === 'apple' ? getAppleCalendarFeedUrl(feedUrl) : getGoogleCalendarFeedUrl(feedUrl));
+    } catch (feedError: any) {
+      setStatus({ success: false, message: feedError?.message || 'Unable to open private calendar sync. Sign in again and retry.' });
+    } finally {
+      setBusyTarget('');
+    }
+  }
+
+  return (
+    <section className="app-card p-4">
+      <div className="flex items-start gap-3">
+        <div className="flex h-10 w-10 flex-none items-center justify-center rounded-xl bg-primary-50 text-primary-700">
+          <CalendarDays className="h-5 w-5" aria-hidden="true" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="text-sm font-black text-gray-950">Private calendar sync</div>
+          <div className="mt-1 text-xs font-semibold leading-5 text-gray-500">Subscribe to the live private team feed for games and practices. For a one-time .ics file instead, use the team schedule export.</div>
+          <div className="mt-3 grid grid-cols-3 gap-2">
+            <button type="button" className="secondary-button !min-h-9 justify-center text-xs" onClick={() => openFeed('apple')} disabled={Boolean(busyTarget)}>
+              {busyTarget === 'apple' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+              Apple Calendar
+            </button>
+            <button type="button" className="secondary-button !min-h-9 justify-center text-xs" onClick={() => openFeed('google')} disabled={Boolean(busyTarget)}>
+              {busyTarget === 'google' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : null}
+              Google Calendar
+            </button>
+            <button type="button" className="secondary-button !min-h-9 justify-center text-xs" onClick={() => openFeed('copy')} disabled={Boolean(busyTarget)}>
+              {busyTarget === 'copy' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Copy className="h-4 w-4" aria-hidden="true" />}
+              Copy Link
+            </button>
+          </div>
+          <Link to={`/schedule?teamId=${encodeURIComponent(model.team.id)}`} className="ghost-button mt-3 !min-h-9 px-0 text-xs text-primary-700">
+            Open team schedule for one-time .ics export
+          </Link>
+          {status ? <div className={`mt-2 text-xs font-black ${status.success ? 'text-emerald-700' : 'text-rose-700'}`} role="status">{status.message}</div> : null}
         </div>
       </div>
     </section>

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -26,7 +26,7 @@ import {
 } from 'lucide-react';
 import { copyPublicText, openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 import { getEventDetailPath } from '../lib/homeLogic';
-import { getAppleCalendarFeedUrl, getGoogleCalendarFeedUrl, getPrivateTeamCalendarFeedUrl } from '../lib/parentToolsService';
+import { buildPrivateTeamCalendarFeedUrl, getAppleCalendarFeedUrl, getGoogleCalendarFeedUrl } from '../lib/parentToolsService';
 import { createStaffRsvpReminderPreviewLoader, sendStaffRsvpReminder, type StaffRsvpReminderSendResult } from '../lib/scheduleService';
 import type { ParentScheduleEvent, StaffRsvpReminderPreview } from '../lib/scheduleLogic';
 import { buildPublicTeamGamesIcsUrl, canExposePublicFanFeed, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, loadTeamStaffPermissions, revokeScorekeeperAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp, type InviteTeamAdminForAppResult, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer, type TeamScorekeeperGrantTarget } from '../lib/teamDetailService';
@@ -567,7 +567,7 @@ function PrivateCalendarSyncCard({ model }: { model: TeamDetailModel }) {
     setBusyTarget(target);
     setStatus(null);
     try {
-      const feedUrl = await getPrivateTeamCalendarFeedUrl(model.team.id);
+      const feedUrl = buildPrivateTeamCalendarFeedUrl(model.team.id, model.team);
       if (!feedUrl) throw new Error('Unable to create private calendar feed. Sign in again and retry.');
       if (target === 'copy') {
         const result = await copyPublicText(feedUrl);

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -981,9 +981,11 @@ test('app schedule paginates long agenda lists and resets on filter changes', as
     await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
 
     const mobileRows = page.locator('.schedule-list > a');
-    await expect(mobileRows.first()).toBeVisible();
-    await expect(mobileRows).toHaveCount(20);
-    await expect(page.getByText(/Showing 20 of 2[45] events/)).toBeVisible();
+    await expect(async () => {
+        await expect(mobileRows.first()).toBeVisible({ timeout: 1000 });
+        await expect(mobileRows).toHaveCount(20, { timeout: 1000 });
+        await expect(page.getByText(/Showing 20 of 2[45] events/)).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 15000 });
     await page.getByRole('button', { name: /Show [45] more/ }).click();
     const expandedRowCount = await mobileRows.count();
     expect(expandedRowCount).toBeGreaterThanOrEqual(24);

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -199,8 +199,12 @@ describe('React app parent tools service', () => {
         expect(getRegistrationUrl('team-1', 'form-1')).toBe('https://allplays.ai/registration.html?teamId=team-1&formId=form-1');
         expect(getAppRegistrationUrl('team-1', 'form-1')).toBe('https://allplays.ai/app/#/registration?teamId=team-1&formId=form-1');
         expect(getCertificateUrl('team-1', 'cert-1')).toBe('https://allplays.ai/certificates.html#teamId=team-1&certificateId=cert-1');
-        expect(getAppleCalendarFeedUrl('https://example.test/feed.ics')).toBe('webcal://example.test/feed.ics');
-        expect(getGoogleCalendarFeedUrl('https://example.test/feed.ics')).toContain(encodeURIComponent('https://example.test/feed.ics'));
+    });
+
+    it('builds Apple and Google subscription URLs without altering private feed tokens', () => {
+        const privateFeedUrl = 'https://example.test/privateTeamCalendarIcs?teamId=team-1&token=abc123%2Bsafe&view=full';
+        expect(getAppleCalendarFeedUrl(privateFeedUrl)).toBe('webcal://example.test/privateTeamCalendarIcs?teamId=team-1&token=abc123%2Bsafe&view=full');
+        expect(getGoogleCalendarFeedUrl(privateFeedUrl)).toBe(`https://calendar.google.com/calendar/render?cid=${encodeURIComponent(privateFeedUrl)}`);
     });
 
     it('loads public access teams, selectable players, and submits membership requests', async () => {

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -149,6 +149,7 @@ import {
     getAppRegistrationUrl,
     getGoogleCalendarFeedUrl,
     getLegacyUrl,
+    buildPrivateTeamCalendarFeedUrl,
     getPrivateTeamCalendarFeedUrl,
     getRegistrationUrl,
     loadFamilyShareModel,
@@ -558,8 +559,19 @@ describe('React app parent tools service', () => {
         expect(ics).toContain('DESCRIPTION:Bears\\nGame\\nPlayer: Pat Star\\nBring water\\; arrive early');
     });
 
-    it('creates private calendar feed URLs with native token fallback support', async () => {
+    it('builds private calendar feed URLs from stored team subscription URLs or tokens', () => {
+        expect(buildPrivateTeamCalendarFeedUrl('team-1', { privateCalendarFeedUrl: 'webcal://example.test/private.ics?teamId=team-1&token=stored' })).toBe('https://example.test/private.ics?teamId=team-1&token=stored');
+        expect(buildPrivateTeamCalendarFeedUrl('team-1', { calendarSubscriptionToken: 'stored-token' })).toBe('https://us-central1-all-plays-prod.cloudfunctions.net/privateTeamCalendarIcs?teamId=team-1&token=stored-token');
+    });
+
+    it('creates private calendar feed URLs with stored-team and native token fallback support', async () => {
+        dbMocks.getTeam.mockResolvedValueOnce({ id: 'team-1', calendarSubscriptionToken: 'stored-token' });
+        await expect(getPrivateTeamCalendarFeedUrl('team-1')).resolves.toBe('https://us-central1-all-plays-prod.cloudfunctions.net/privateTeamCalendarIcs?teamId=team-1&token=stored-token');
+
+        dbMocks.getTeam.mockResolvedValueOnce(null);
         await expect(getPrivateTeamCalendarFeedUrl('team-1')).resolves.toBe('https://us-central1-all-plays-prod.cloudfunctions.net/privateTeamCalendarIcs?teamId=team-1&token=native-token');
+
+        dbMocks.getTeam.mockResolvedValueOnce(null);
         authMocks.getNativeAuthIdToken.mockRejectedValueOnce(new Error('native unavailable'));
         await expect(getPrivateTeamCalendarFeedUrl('team-1')).resolves.toBe('https://us-central1-all-plays-prod.cloudfunctions.net/privateTeamCalendarIcs?teamId=team-1&token=firebase-token');
     });

--- a/tests/unit/app-team-detail-integration.test.jsx
+++ b/tests/unit/app-team-detail-integration.test.jsx
@@ -17,7 +17,7 @@ const publicActionMocks = vi.hoisted(() => ({
     sharePublicUrl: vi.fn()
 }));
 const parentToolsMocks = vi.hoisted(() => ({
-    getPrivateTeamCalendarFeedUrl: vi.fn(),
+    buildPrivateTeamCalendarFeedUrl: vi.fn(),
     getAppleCalendarFeedUrl: vi.fn((url) => String(url).replace(/^https?:\/\//i, 'webcal://')),
     getGoogleCalendarFeedUrl: vi.fn((url) => `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(url)}`)
 }));
@@ -218,7 +218,7 @@ beforeEach(() => {
     };
     publicActionMocks.copyPublicText.mockResolvedValue('copied');
     publicActionMocks.sharePublicUrl.mockResolvedValue('copied');
-    parentToolsMocks.getPrivateTeamCalendarFeedUrl.mockResolvedValue('https://feed.example.test/private-team.ics?teamId=team-1&token=abc123');
+    parentToolsMocks.buildPrivateTeamCalendarFeedUrl.mockReturnValue('https://feed.example.test/private-team.ics?teamId=team-1&token=abc123');
     scheduleServiceMocks.loadPreview.mockResolvedValue({
         missingPlayerCount: 0,
         eligibleEmailCount: 0,
@@ -297,7 +297,7 @@ describe('React app TeamDetail page', () => {
         fanModel.team.id = 'team 1/blue';
         fanModel.team.name = 'Bears & Wolves';
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(fanModel);
-        parentToolsMocks.getPrivateTeamCalendarFeedUrl.mockResolvedValue('https://feed.example.test/private-team.ics?teamId=team%201%2Fblue&token=abc123');
+        parentToolsMocks.buildPrivateTeamCalendarFeedUrl.mockReturnValue('https://feed.example.test/private-team.ics?teamId=team%201%2Fblue&token=abc123');
 
         const { container } = await renderTeamDetail();
 
@@ -307,7 +307,7 @@ describe('React app TeamDetail page', () => {
         expect(container.textContent).toContain('Open team schedule for one-time .ics export');
 
         await clickButtonInCard(container, 'Private calendar sync', 'Copy Link');
-        expect(parentToolsMocks.getPrivateTeamCalendarFeedUrl).toHaveBeenCalledWith('team 1/blue');
+        expect(parentToolsMocks.buildPrivateTeamCalendarFeedUrl).toHaveBeenCalledWith('team 1/blue', expect.objectContaining({ id: 'team 1/blue' }));
         expect(publicActionMocks.copyPublicText).toHaveBeenCalledWith('https://feed.example.test/private-team.ics?teamId=team%201%2Fblue&token=abc123');
         expect(container.textContent).toContain('Private calendar link copied.');
 
@@ -356,7 +356,7 @@ describe('React app TeamDetail page', () => {
     });
 
     it('shows a private calendar sync error and hides sync actions without a signed-in user', async () => {
-        parentToolsMocks.getPrivateTeamCalendarFeedUrl.mockRejectedValueOnce(new Error('Unable to create private calendar feed. Sign in again and retry.'));
+        parentToolsMocks.buildPrivateTeamCalendarFeedUrl.mockImplementationOnce(() => { throw new Error('Unable to create private calendar feed. Sign in again and retry.'); });
         const { container } = await renderTeamDetail();
 
         await clickButton(container, 'More');

--- a/tests/unit/app-team-detail-integration.test.jsx
+++ b/tests/unit/app-team-detail-integration.test.jsx
@@ -16,6 +16,11 @@ const publicActionMocks = vi.hoisted(() => ({
     openPublicUrl: vi.fn(),
     sharePublicUrl: vi.fn()
 }));
+const parentToolsMocks = vi.hoisted(() => ({
+    getPrivateTeamCalendarFeedUrl: vi.fn(),
+    getAppleCalendarFeedUrl: vi.fn((url) => String(url).replace(/^https?:\/\//i, 'webcal://')),
+    getGoogleCalendarFeedUrl: vi.fn((url) => `https://calendar.google.com/calendar/render?cid=${encodeURIComponent(url)}`)
+}));
 const scheduleServiceMocks = vi.hoisted(() => ({
     createStaffRsvpReminderPreviewLoader: vi.fn(),
     loadPreview: vi.fn(),
@@ -30,6 +35,7 @@ vi.mock('../../apps/app/src/lib/teamDetailService.ts', () => ({
     canExposePublicFanFeed: teamDetailMocks.canExposePublicFanFeed
 }));
 vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionMocks);
+vi.mock('../../apps/app/src/lib/parentToolsService.ts', () => parentToolsMocks);
 vi.mock('../../apps/app/src/lib/scheduleService.ts', () => ({
     createStaffRsvpReminderPreviewLoader: scheduleServiceMocks.createStaffRsvpReminderPreviewLoader,
     sendStaffRsvpReminder: scheduleServiceMocks.sendStaffRsvpReminder
@@ -159,6 +165,17 @@ async function clickButton(container, text) {
     await flush();
 }
 
+async function clickButtonInCard(container, cardTitle, text) {
+    const card = Array.from(container.querySelectorAll('section')).find((candidate) => candidate.textContent.includes(cardTitle));
+    if (!card) throw new Error(`Card not found: ${cardTitle}`);
+    const button = Array.from(card.querySelectorAll('button')).find((candidate) => candidate.textContent.includes(text));
+    if (!button) throw new Error(`Button not found in ${cardTitle}: ${text}`);
+    await act(async () => {
+        button.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    await flush();
+}
+
 async function clickLink(container, text) {
     const link = Array.from(container.querySelectorAll('a')).find((candidate) => candidate.textContent.includes(text));
     if (!link) throw new Error(`Link not found: ${text}`);
@@ -201,6 +218,7 @@ beforeEach(() => {
     };
     publicActionMocks.copyPublicText.mockResolvedValue('copied');
     publicActionMocks.sharePublicUrl.mockResolvedValue('copied');
+    parentToolsMocks.getPrivateTeamCalendarFeedUrl.mockResolvedValue('https://feed.example.test/private-team.ics?teamId=team-1&token=abc123');
     scheduleServiceMocks.loadPreview.mockResolvedValue({
         missingPlayerCount: 0,
         eligibleEmailCount: 0,
@@ -274,6 +292,34 @@ describe('React app TeamDetail page', () => {
         expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://pizza.example.test');
     });
 
+    it('renders private calendar sync separately from the public fan feed and wires copy/open actions', async () => {
+        const fanModel = model();
+        fanModel.team.id = 'team 1/blue';
+        fanModel.team.name = 'Bears & Wolves';
+        teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(fanModel);
+        parentToolsMocks.getPrivateTeamCalendarFeedUrl.mockResolvedValue('https://feed.example.test/private-team.ics?teamId=team%201%2Fblue&token=abc123');
+
+        const { container } = await renderTeamDetail();
+
+        await clickButton(container, 'More');
+        expect(container.textContent).toContain('Private calendar sync');
+        expect(container.textContent).toContain('Fan Feed');
+        expect(container.textContent).toContain('Open team schedule for one-time .ics export');
+
+        await clickButtonInCard(container, 'Private calendar sync', 'Copy Link');
+        expect(parentToolsMocks.getPrivateTeamCalendarFeedUrl).toHaveBeenCalledWith('team 1/blue');
+        expect(publicActionMocks.copyPublicText).toHaveBeenCalledWith('https://feed.example.test/private-team.ics?teamId=team%201%2Fblue&token=abc123');
+        expect(container.textContent).toContain('Private calendar link copied.');
+
+        await clickButtonInCard(container, 'Private calendar sync', 'Apple Calendar');
+        expect(parentToolsMocks.getAppleCalendarFeedUrl).toHaveBeenCalledWith('https://feed.example.test/private-team.ics?teamId=team%201%2Fblue&token=abc123');
+        expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('webcal://feed.example.test/private-team.ics?teamId=team%201%2Fblue&token=abc123');
+
+        await clickButtonInCard(container, 'Private calendar sync', 'Google Calendar');
+        expect(parentToolsMocks.getGoogleCalendarFeedUrl).toHaveBeenCalledWith('https://feed.example.test/private-team.ics?teamId=team%201%2Fblue&token=abc123');
+        expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://calendar.google.com/calendar/render?cid=https%3A%2F%2Ffeed.example.test%2Fprivate-team.ics%3FteamId%3Dteam%25201%252Fblue%26token%3Dabc123');
+    });
+
     it('renders and shares the public fan feed when at least one game is public or shareable', async () => {
         const fanModel = model();
         fanModel.team.id = 'team 1/blue';
@@ -309,6 +355,24 @@ describe('React app TeamDetail page', () => {
         expect(hidden.container.textContent).not.toContain('Fan Feed');
     });
 
+    it('shows a private calendar sync error and hides sync actions without a signed-in user', async () => {
+        parentToolsMocks.getPrivateTeamCalendarFeedUrl.mockRejectedValueOnce(new Error('Unable to create private calendar feed. Sign in again and retry.'));
+        const { container } = await renderTeamDetail();
+
+        await clickButton(container, 'More');
+        await clickButtonInCard(container, 'Private calendar sync', 'Copy Link');
+        expect(container.textContent).toContain('Unable to create private calendar feed. Sign in again and retry.');
+
+        const signedOut = await renderTeamDetail({
+            ...auth,
+            user: null,
+            roles: [],
+            isParent: false
+        });
+        await clickButton(signedOut.container, 'More');
+        expect(signedOut.container.textContent).not.toContain('Private calendar sync');
+    });
+
     it('renders scoreboard widget copy tools only for managers', async () => {
         const managerModel = model();
         managerModel.canManageTeam = true;
@@ -328,8 +392,8 @@ describe('React app TeamDetail page', () => {
         expect(publicActionMocks.copyPublicText).toHaveBeenCalledWith(expectedEmbed);
         expect(container.textContent).toContain('Embed code copied.');
 
-        await clickButton(container, 'Copy Link');
-        expect(publicActionMocks.copyPublicText).toHaveBeenCalledWith(expectedUrl);
+        await clickButtonInCard(container, 'Scoreboard widget', 'Copy Link');
+        expect(publicActionMocks.copyPublicText).toHaveBeenLastCalledWith(expectedUrl);
         expect(container.textContent).toContain('Widget link copied.');
 
         const parentModel = model();


### PR DESCRIPTION
Closes #1811

## What changed
- added a new **Private calendar sync** card on `TeamDetail` so signed-in team members can launch Apple Calendar, Google Calendar, or copy the private live feed link from a team-facing surface
- reused the existing private feed helpers from `parentToolsService` and the shared `publicActions` browser/clipboard behavior
- kept the public **Fan Feed** separate and added copy explaining that one-time `.ics` export still lives in the team schedule flow
- added regression coverage for Team Detail action wiring, signed-out/error states, and helper URL generation with token/query preservation

## Why
The new app exposed private calendar subscription only inside Parent Tools, which forced users away from the main team experience. This brings the existing private live feed actions into Team Detail with the smallest safe patch and keeps the private member feed distinct from the public fan feed.