### PR TITLE
Add staff RSVP overrides to event availability

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -26,6 +26,7 @@ vi.mock('../../../../js/db.js', () => ({
   getPracticePacketCompletions: vi.fn(),
   getPracticeSessions: vi.fn(),
   getPlayers: vi.fn(),
+  getRsvpBreakdownByPlayer: vi.fn(),
   getRsvps: vi.fn(),
   getRsvpSummaries: vi.fn(),
   getTeam: vi.fn(),
@@ -81,11 +82,12 @@ vi.mock('./uxTiming', () => ({ startUxTimer: vi.fn(() => ({ end: vi.fn() })) }))
 vi.mock('./chatService', () => ({ sendTeamChatMessage: vi.fn() }));
 vi.mock('./chatLogic', () => ({ DEFAULT_TEAM_CONVERSATION_ID: 'team' }));
 
-import { updateGame, getPlayers, getRsvps } from '../../../../js/db.js';
-import { buildPlayerScoringLiveEvent, recordPlayerScoringStat, saveScheduledGameLineupDraftForApp } from './scheduleService';
+import { updateGame, getPlayers, getRsvpBreakdownByPlayer, getRsvps, submitRsvpForPlayer } from '../../../../js/db.js';
+import { buildPlayerScoringLiveEvent, loadStaffScheduleRsvpBreakdown, recordPlayerScoringStat, saveScheduledGameLineupDraftForApp, submitStaffScheduleRsvpOverride } from './scheduleService';
 
 describe('player-attributed live scoring', () => {
   beforeEach(() => {
+    (globalThis as any).window = globalThis as any;
     vi.clearAllMocks();
     mocks.transactionGet
       .mockResolvedValueOnce({ exists: () => true, data: () => ({ homeScore: 10, awayScore: 8 }) })
@@ -287,5 +289,56 @@ describe('mobile lineup draft creation', () => {
 
     vi.mocked(getRsvps).mockResolvedValue([{ playerId: 'p1', response: 'maybe' }] as any);
     await expect(saveScheduledGameLineupDraftForApp(event, user, 'basketball-5v5')).rejects.toThrow('No Going players');
+  });
+});
+
+describe('staff RSVP management', () => {
+  const user = { uid: 'coach-1', displayName: 'Coach', email: 'coach@example.com', roles: [] };
+  const event = {
+    id: 'game-1',
+    teamId: 'team-1',
+    childId: 'child-event-player',
+    isDbGame: true,
+    isCancelled: false,
+    availabilityLocked: false,
+    isTeamStaff: true
+  } as any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('maps staff RSVP breakdown rows including no-response players', async () => {
+    vi.mocked(getRsvpBreakdownByPlayer).mockResolvedValue({
+      grouped: {
+        going: [{ playerId: 'p1', playerName: 'Avery Smith', response: 'going' }],
+        maybe: [{ playerId: 'p2', playerName: 'Blake Jones', response: 'maybe' }],
+        not_going: [{ playerId: 'p3', playerName: 'Casey Brown', response: 'not_going' }],
+        not_responded: [{ playerId: 'p4', playerName: 'Devon Lee', response: 'not_responded' }]
+      },
+      counts: { going: 1, maybe: 1, notGoing: 1, notResponded: 1, total: 4 }
+    } as any);
+
+    const result = await loadStaffScheduleRsvpBreakdown(event, user as any);
+
+    expect(getRsvpBreakdownByPlayer).toHaveBeenCalledWith('team-1', 'game-1');
+    expect(result.counts).toEqual({ going: 1, maybe: 1, notGoing: 1, notResponded: 1, total: 4 });
+    expect(result.grouped.not_responded).toEqual([
+      expect.objectContaining({ playerId: 'p4', playerName: 'Devon Lee', response: 'not_responded' })
+    ]);
+  });
+
+  it('submits staff RSVP overrides for the selected player instead of event.childId', async () => {
+    vi.mocked(submitRsvpForPlayer).mockResolvedValue(undefined as any);
+
+    await submitStaffScheduleRsvpOverride(event, user as any, 'player-override', 'going');
+
+    expect(submitRsvpForPlayer).toHaveBeenCalledWith('team-1', 'game-1', 'coach-1', expect.objectContaining({
+      playerId: 'player-override',
+      response: 'going'
+    }));
+    expect(submitRsvpForPlayer).not.toHaveBeenCalledWith('team-1', 'game-1', 'coach-1', expect.objectContaining({
+      playerId: 'child-event-player'
+    }));
   });
 });

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -301,6 +301,7 @@ describe('staff RSVP management', () => {
     isDbGame: true,
     isCancelled: false,
     availabilityLocked: false,
+    isTeamAdmin: true,
     isTeamStaff: true
   } as any;
 
@@ -340,5 +341,10 @@ describe('staff RSVP management', () => {
     expect(submitRsvpForPlayer).not.toHaveBeenCalledWith('team-1', 'game-1', 'coach-1', expect.objectContaining({
       playerId: 'child-event-player'
     }));
+  });
+
+  it('rejects coach-only staff without admin write access', async () => {
+    await expect(submitStaffScheduleRsvpOverride({ ...event, isTeamAdmin: false }, user as any, 'player-override', 'going')).rejects.toThrow('Only team owners and admins can manage player RSVPs.');
+    expect(submitRsvpForPlayer).not.toHaveBeenCalled();
   });
 });

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -7,6 +7,7 @@ import {
   getPracticeSessions,
   getPlayers,
   getRsvps,
+  getRsvpBreakdownByPlayer,
   getRsvpSummaries,
   getTeam,
   getTeams,
@@ -42,6 +43,7 @@ import { filterVisiblePracticeSessions } from '../../../../js/parent-dashboard-p
 import { buildPracticePacketCompletionPayload as buildPracticePacketCompletionPayloadBase } from '../../../../js/parent-dashboard-packets.js';
 import { resolveMyRsvpByChildForGame } from '../../../../js/parent-dashboard-rsvp.js';
 import { buildAvailabilityNoteRows, canViewAvailabilityNotes, formatAvailabilityCutoff, isAvailabilityLocked, normalizeAvailabilityPreferences } from '../../../../js/availability-preferences.js';
+import { buildGameDayRsvpBreakdown } from '../../../../js/game-day-rsvp-breakdown.js';
 import { getEventRideshareSummary } from '../../../../js/rideshare-helpers.js';
 import { mergeAssignmentsWithClaims } from '../../../../js/snack-helpers.js';
 import { hasScorekeepingTeamAccess } from '../../../../js/team-access.js';
@@ -117,6 +119,26 @@ export type ParentScheduleLoadOptions = {
 export type ParentScheduleEventDetailLoadOptions = ParentScheduleLoadOptions & {
   teamId: string;
   eventId: string;
+};
+
+export type StaffScheduleRsvpRow = {
+  playerId: string;
+  playerName: string;
+  playerNumber?: string | number | null;
+  response: RsvpResponse;
+  respondedAt?: unknown;
+  note?: string | null;
+  responderUserId?: string | null;
+};
+
+export type StaffScheduleRsvpBreakdown = {
+  grouped: {
+    going: StaffScheduleRsvpRow[];
+    maybe: StaffScheduleRsvpRow[];
+    not_going: StaffScheduleRsvpRow[];
+    not_responded: StaffScheduleRsvpRow[];
+  };
+  counts: Required<ScheduleRsvpSummary>;
 };
 
 type FirestoreDocument = Record<string, any> & { id: string };
@@ -1881,6 +1903,102 @@ async function nativeSubmitRsvpForPlayer(teamId: string, gameId: string, user: A
     note: compactString(note) || null
   });
   return null;
+}
+
+function assertStaffRsvpManagementEvent(event: ParentScheduleEvent, user: AuthUser | null) {
+  if (!event.isDbGame) {
+    throw new Error('Availability opens after this event is tracked in the schedule.');
+  }
+  if (!user?.uid) {
+    throw new Error('Sign in before managing player RSVPs.');
+  }
+  if (!event.isTeamStaff) {
+    throw new Error('Only team staff can manage player RSVPs.');
+  }
+}
+
+function normalizeStaffScheduleRsvpBreakdown(value: any): StaffScheduleRsvpBreakdown {
+  const grouped = value?.grouped || {};
+  const normalizeRows = (rows: any[], fallbackResponse: RsvpResponse): StaffScheduleRsvpRow[] => (
+    Array.isArray(rows)
+      ? rows.map((row) => ({
+        playerId: compactString(row?.playerId),
+        playerName: compactString(row?.playerName) || 'Player',
+        playerNumber: compactString(row?.playerNumber ?? ''),
+        response: normalizeRsvpResponse(row?.response || fallbackResponse),
+        respondedAt: row?.respondedAt || null,
+        note: compactString(row?.note) || null,
+        responderUserId: compactString(row?.responderUserId) || null
+      })).filter((row) => row.playerId)
+      : []
+  );
+
+  const normalizedGrouped = {
+    going: normalizeRows(grouped.going, 'going'),
+    maybe: normalizeRows(grouped.maybe, 'maybe'),
+    not_going: normalizeRows(grouped.not_going, 'not_going'),
+    not_responded: normalizeRows(grouped.not_responded, 'not_responded')
+  };
+
+  return {
+    grouped: normalizedGrouped,
+    counts: {
+      going: normalizedGrouped.going.length,
+      maybe: normalizedGrouped.maybe.length,
+      notGoing: normalizedGrouped.not_going.length,
+      notResponded: normalizedGrouped.not_responded.length,
+      total: normalizedGrouped.going.length + normalizedGrouped.maybe.length + normalizedGrouped.not_going.length + normalizedGrouped.not_responded.length
+    }
+  };
+}
+
+export async function loadStaffScheduleRsvpBreakdown(event: ParentScheduleEvent, user: AuthUser | null): Promise<StaffScheduleRsvpBreakdown> {
+  assertStaffRsvpManagementEvent(event, user);
+
+  try {
+    const breakdown = await withTimeout(Promise.resolve(getRsvpBreakdownByPlayer(event.teamId, event.id)), 'Staff RSVP breakdown');
+    return normalizeStaffScheduleRsvpBreakdown(breakdown);
+  } catch (error) {
+    if (!isNativeRuntime()) throw error;
+    console.warn('[schedule-service] Falling back to REST RSVP breakdown load:', error);
+    const [players, rsvps] = await Promise.all([
+      loadPlayers(event.teamId),
+      loadRsvps(event.teamId, event.id)
+    ]);
+    return normalizeStaffScheduleRsvpBreakdown(buildGameDayRsvpBreakdown({ players, rsvps }));
+  }
+}
+
+export async function submitStaffScheduleRsvpOverride(event: ParentScheduleEvent, user: AuthUser | null, playerId: string, response: Exclude<RsvpResponse, 'not_responded'>) {
+  assertStaffRsvpManagementEvent(event, user);
+  const normalizedPlayerId = compactString(playerId);
+  if (!normalizedPlayerId) {
+    throw new Error('Select a player before updating the RSVP.');
+  }
+  if (event.isCancelled) {
+    throw new Error('Cancelled events cannot be updated.');
+  }
+  if (event.availabilityLocked) {
+    throw new Error('Availability is locked for this event.');
+  }
+
+  try {
+    await withTimeout(Promise.resolve(submitRsvpForPlayer(event.teamId, event.id, user!.uid, {
+      displayName: user!.displayName || user!.email,
+      playerId: normalizedPlayerId,
+      response,
+      note: null
+    })), 'Staff RSVP override');
+  } catch (error) {
+    if (!isNativeRuntime()) throw error;
+    console.warn('[schedule-service] Falling back to REST staff RSVP override:', error);
+    await nativeSubmitRsvpForPlayer(event.teamId, event.id, user!, normalizedPlayerId, response);
+  }
+
+  return {
+    playerId: normalizedPlayerId,
+    response
+  };
 }
 
 export async function submitParentScheduleRsvp(event: ParentScheduleEvent, user: AuthUser, response: Exclude<RsvpResponse, 'not_responded'>, note = '') {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1912,8 +1912,8 @@ function assertStaffRsvpManagementEvent(event: ParentScheduleEvent, user: AuthUs
   if (!user?.uid) {
     throw new Error('Sign in before managing player RSVPs.');
   }
-  if (!event.isTeamStaff) {
-    throw new Error('Only team staff can manage player RSVPs.');
+  if (!event.isTeamAdmin) {
+    throw new Error('Only team owners and admins can manage player RSVPs.');
   }
 }
 

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -172,9 +172,9 @@ describe('ScheduleEventDetail staff RSVP overrides', () => {
     expect(scheduleServiceMocks.loadStaffScheduleRsvpBreakdown.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
-  it('hides staff override controls for non-staff viewers', async () => {
+  it('hides staff override controls for coach-only staff without admin write access', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
-      events: [buildEvent({ isTeamStaff: false })],
+      events: [buildEvent({ isTeamStaff: true, isTeamAdmin: false })],
       children: []
     });
 

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const scheduleServiceMocks = vi.hoisted(() => ({
+  cancelParentScheduleRideRequest: vi.fn(),
+  cancelPracticeOccurrenceForApp: vi.fn(),
+  cancelScheduledGameForApp: vi.fn(),
+  claimParentScheduleAssignmentSlot: vi.fn(),
+  createParentScheduleRideOffer: vi.fn(),
+  loadParentPracticePacket: vi.fn(),
+  loadParentScheduleAssignments: vi.fn(),
+  loadParentScheduleEventDetail: vi.fn(),
+  loadParentScheduleRideOffers: vi.fn(),
+  loadStaffScheduleRsvpBreakdown: vi.fn(),
+  loadStaffRsvpReminderPreview: vi.fn(),
+  loadAutoFilledLineupDraftPreviewForApp: vi.fn(),
+  markParentPracticePacketComplete: vi.fn(),
+  publishGamePlanForApp: vi.fn(),
+  releaseParentScheduleAssignmentClaim: vi.fn(),
+  requestParentScheduleRideSpot: vi.fn(),
+  sendStaffRsvpReminder: vi.fn(),
+  setParentScheduleRideOfferStatus: vi.fn(),
+  submitParentScheduleRsvp: vi.fn(),
+  submitStaffScheduleRsvpOverride: vi.fn(),
+  summarizeParentScheduleRideOffers: vi.fn(() => ({ offerCount: 0, seatsLeft: 0, requests: 0, pending: 0, confirmed: 0, isFull: false })),
+  loadHomeScoringPlayers: vi.fn(),
+  publishLiveScoreUpdateEvent: vi.fn(),
+  recordPlayerScoringStat: vi.fn(),
+  saveScheduledGameLineupDraftForApp: vi.fn(),
+  updateGameScore: vi.fn(),
+  updateParentScheduleRideRequestStatus: vi.fn()
+}));
+
+vi.mock('../lib/scheduleService', () => scheduleServiceMocks);
+vi.mock('../lib/gameReportService', () => ({ loadGameReportSections: vi.fn() }));
+vi.mock('../lib/publicActions', () => ({ openPublicUrl: vi.fn(), sharePublicUrl: vi.fn() }));
+vi.mock('../lib/liveGameAnnouncer', () => ({ useLiveGameAnnouncer: vi.fn() }));
+vi.mock('../lib/parentToolsService', () => ({ buildParentScheduleEventIcs: vi.fn(() => 'BEGIN:VCALENDAR'), downloadIcs: vi.fn() }));
+vi.mock('../lib/scheduleHub', () => ({
+  buildGameHubDestinations: vi.fn(() => []),
+  buildPracticeHubDestinations: vi.fn(() => []),
+  getPublicPlayerHref: vi.fn(() => '#')
+}));
+
+import { ScheduleEventDetail } from './ScheduleEventDetail';
+import type { AuthState } from '../lib/types';
+
+const auth: AuthState = {
+  user: {
+    uid: 'coach-1',
+    email: 'coach@example.com',
+    displayName: 'Coach Carter'
+  } as any,
+  profile: null,
+  loading: false,
+  error: null,
+  roles: ['coach'],
+  isParent: false,
+  isCoach: true,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: vi.fn(),
+  signOut: vi.fn()
+};
+
+function buildEvent(overrides: Record<string, unknown> = {}) {
+  return {
+    eventKey: 'team-1::game-1::player-1::2026-06-04T18:00:00.000Z::game',
+    id: 'game-1',
+    teamId: 'team-1',
+    teamName: 'Bears',
+    type: 'game',
+    date: new Date('2026-06-04T18:00:00.000Z'),
+    location: 'Main Gym',
+    opponent: 'Wolves',
+    childId: 'player-1',
+    childName: 'Avery Smith',
+    isDbGame: true,
+    isCancelled: false,
+    status: 'scheduled',
+    assignments: [],
+    myRsvp: 'not_responded',
+    myRsvpNote: '',
+    rsvpSummary: { going: 1, maybe: 1, notGoing: 1, notResponded: 1, total: 4 },
+    rideshareSummary: { offerCount: 0, seatsLeft: 0, requests: 0, pending: 0, confirmed: 0, isFull: false },
+    availabilityLocked: false,
+    availabilityNotesVisible: false,
+    availabilityNotes: [],
+    isTeamAdmin: false,
+    isTeamStaff: true,
+    isTeamRsvpReminderManager: false,
+    canUpdateScore: false,
+    calendarUrls: [],
+    ...overrides
+  } as any;
+}
+
+function renderScheduleEventDetail() {
+  return render(
+    <MemoryRouter initialEntries={['/schedule/team-1/game-1?childId=player-1']}>
+      <Routes>
+        <Route path="/schedule/:teamId/:eventId" element={<ScheduleEventDetail auth={auth} />} />
+        <Route path="/schedule" element={<div>Schedule</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('ScheduleEventDetail staff RSVP overrides', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'scrollTo', {
+      value: vi.fn(),
+      writable: true
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders staff breakdown controls and refreshes counts after an override', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent()],
+      children: []
+    });
+    scheduleServiceMocks.loadStaffScheduleRsvpBreakdown
+      .mockResolvedValueOnce({
+        grouped: {
+          going: [{ playerId: 'p1', playerName: 'Avery Smith', playerNumber: '1', response: 'going' }],
+          maybe: [{ playerId: 'p2', playerName: 'Blake Jones', playerNumber: '2', response: 'maybe' }],
+          not_going: [{ playerId: 'p3', playerName: 'Casey Brown', playerNumber: '3', response: 'not_going' }],
+          not_responded: [{ playerId: 'p4', playerName: 'Devon Lee', playerNumber: '4', response: 'not_responded' }]
+        },
+        counts: { going: 1, maybe: 1, notGoing: 1, notResponded: 1, total: 4 }
+      })
+      .mockResolvedValueOnce({
+        grouped: {
+          going: [
+            { playerId: 'p1', playerName: 'Avery Smith', playerNumber: '1', response: 'going' },
+            { playerId: 'p4', playerName: 'Devon Lee', playerNumber: '4', response: 'going' }
+          ],
+          maybe: [{ playerId: 'p2', playerName: 'Blake Jones', playerNumber: '2', response: 'maybe' }],
+          not_going: [{ playerId: 'p3', playerName: 'Casey Brown', playerNumber: '3', response: 'not_going' }],
+          not_responded: []
+        },
+        counts: { going: 2, maybe: 1, notGoing: 1, notResponded: 0, total: 4 }
+      });
+    scheduleServiceMocks.submitStaffScheduleRsvpOverride.mockResolvedValue({ playerId: 'p4', response: 'going' });
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getByText('Staff RSVP overrides')).toBeTruthy();
+    });
+
+    const noResponseRow = screen.getByTestId('staff-rsvp-row-p4');
+    fireEvent.click(within(noResponseRow).getByRole('button', { name: 'Going' }));
+
+    await waitFor(() => {
+      expect(scheduleServiceMocks.submitStaffScheduleRsvpOverride).toHaveBeenCalledWith(expect.any(Object), auth.user, 'p4', 'going');
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Devon Lee marked going.')).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(screen.getAllByText('2 going · 1 maybe · 1 out · 0 missing').length).toBeGreaterThan(0);
+    });
+    expect(scheduleServiceMocks.loadStaffScheduleRsvpBreakdown.mock.calls.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('hides staff override controls for non-staff viewers', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({ isTeamStaff: false })],
+      children: []
+    });
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Availability' })).toBeTruthy();
+    });
+
+    expect(screen.queryByText('Staff RSVP overrides')).toBeNull();
+    expect(scheduleServiceMocks.loadStaffScheduleRsvpBreakdown).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -11,6 +11,7 @@ import {
   loadParentScheduleEventDetail,
   loadParentScheduleAssignments,
   loadParentScheduleRideOffers,
+  loadStaffScheduleRsvpBreakdown,
   loadStaffRsvpReminderPreview,
   loadAutoFilledLineupDraftPreviewForApp,
   markParentPracticePacketComplete,
@@ -20,6 +21,7 @@ import {
   sendStaffRsvpReminder,
   setParentScheduleRideOfferStatus,
   submitParentScheduleRsvp,
+  submitStaffScheduleRsvpOverride,
   summarizeParentScheduleRideOffers,
   loadHomeScoringPlayers,
   publishLiveScoreUpdateEvent,
@@ -30,6 +32,8 @@ import {
   type RideOfferInput,
   type ParentPracticePacket,
   type ParentPracticePacketChild,
+  type StaffScheduleRsvpBreakdown,
+  type StaffScheduleRsvpRow,
   type StaffRsvpReminderSendResult,
   type RideRequestChildInput,
   type ScheduleHomeScoringPlayer,
@@ -171,6 +175,12 @@ type AttentionItem = {
   section: EventDetailSectionId;
 };
 
+type StaffRsvpOverrideStatus = {
+  tone: 'success' | 'error';
+  playerId: string;
+  message: string;
+};
+
 export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   const { teamId = '', eventId = '' } = useParams();
   const [searchParams] = useSearchParams();
@@ -183,6 +193,12 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   const [activeSection, setActiveSection] = useState<EventDetailSectionId>('availability');
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [availabilityNote, setAvailabilityNote] = useState('');
+  const [staffRsvpBreakdown, setStaffRsvpBreakdown] = useState<StaffScheduleRsvpBreakdown | null>(null);
+  const [staffRsvpLoading, setStaffRsvpLoading] = useState(false);
+  const [staffRsvpError, setStaffRsvpError] = useState<string | null>(null);
+  const [staffRsvpSubmittingPlayerId, setStaffRsvpSubmittingPlayerId] = useState<string | null>(null);
+  const [staffRsvpStatus, setStaffRsvpStatus] = useState<StaffRsvpOverrideStatus | null>(null);
+  const [staffRsvpRefreshToken, setStaffRsvpRefreshToken] = useState(0);
 
   const decodedTeamId = decodeURIComponent(teamId);
   const decodedEventId = decodeURIComponent(eventId);
@@ -226,6 +242,39 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   useEffect(() => {
     setAvailabilityNote(selectedEvent?.myRsvpNote || '');
   }, [selectedEvent?.eventKey, selectedEvent?.myRsvpNote]);
+
+  const refreshStaffRsvpBreakdown = useCallback(async (showLoading = true) => {
+    if (!auth.user || !selectedEvent?.isTeamStaff || !selectedEvent.isDbGame) {
+      setStaffRsvpBreakdown(null);
+      setStaffRsvpError(null);
+      return null;
+    }
+    if (showLoading) setStaffRsvpLoading(true);
+    setStaffRsvpError(null);
+    try {
+      const breakdown = await loadStaffScheduleRsvpBreakdown(selectedEvent, auth.user);
+      setStaffRsvpBreakdown(breakdown);
+      return breakdown;
+    } catch (loadError: any) {
+      setStaffRsvpBreakdown(null);
+      setStaffRsvpError(loadError?.message || 'Unable to load staff RSVP breakdown.');
+      return null;
+    } finally {
+      if (showLoading) setStaffRsvpLoading(false);
+    }
+  }, [auth.user, selectedEvent]);
+
+  useEffect(() => {
+    setStaffRsvpStatus(null);
+    setStaffRsvpSubmittingPlayerId(null);
+    if (!selectedEvent?.isTeamStaff || !selectedEvent.isDbGame) {
+      setStaffRsvpBreakdown(null);
+      setStaffRsvpError(null);
+      setStaffRsvpLoading(false);
+      return;
+    }
+    refreshStaffRsvpBreakdown();
+  }, [refreshStaffRsvpBreakdown, selectedEvent?.eventKey]);
 
   const handleRideOffersChanged = useCallback((offers: ScheduleRideOffer[]) => {
     const rideshareSummary = summarizeParentScheduleRideOffers(offers);
@@ -301,6 +350,33 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
       setError(submitError?.message || 'Unable to submit availability.');
     } finally {
       setSubmitting(null);
+    }
+  };
+
+  const submitStaffRsvpOverride = async (player: StaffScheduleRsvpRow, response: Exclude<RsvpResponse, 'not_responded'>) => {
+    if (!auth.user || !selectedEvent) return;
+    setStaffRsvpSubmittingPlayerId(player.playerId);
+    setStaffRsvpStatus(null);
+    setStaffRsvpError(null);
+    try {
+      await submitStaffScheduleRsvpOverride(selectedEvent, auth.user, player.playerId, response);
+      const breakdown = await refreshStaffRsvpBreakdown(false);
+      if (breakdown) {
+        setEvents((current) => current.map((event) => {
+          if (event.teamId !== selectedEvent.teamId || event.id !== selectedEvent.id) return event;
+          return {
+            ...event,
+            myRsvp: event.childId === player.playerId ? response : event.myRsvp,
+            rsvpSummary: breakdown.counts
+          };
+        }));
+      }
+      setStaffRsvpRefreshToken((current) => current + 1);
+      setStaffRsvpStatus({ tone: 'success', playerId: player.playerId, message: `${player.playerName} marked ${rsvpLabels[response].toLowerCase()}.` });
+    } catch (submitError: any) {
+      setStaffRsvpStatus({ tone: 'error', playerId: player.playerId, message: submitError?.message || 'Unable to update player RSVP.' });
+    } finally {
+      setStaffRsvpSubmittingPlayerId(null);
     }
   };
 
@@ -447,6 +523,13 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
             availabilityNote={availabilityNote}
             onAvailabilityNoteChange={setAvailabilityNote}
             onSubmit={submitRsvp}
+            staffRsvpBreakdown={staffRsvpBreakdown}
+            staffRsvpLoading={staffRsvpLoading}
+            staffRsvpError={staffRsvpError}
+            staffRsvpSubmittingPlayerId={staffRsvpSubmittingPlayerId}
+            staffRsvpStatus={staffRsvpStatus}
+            staffRsvpRefreshToken={staffRsvpRefreshToken}
+            onStaffRsvpOverride={submitStaffRsvpOverride}
             attentionItems={attentionItems}
             onSelectSection={selectSection}
           />
@@ -785,7 +868,7 @@ function EventDetailsPanel({ event, open }: { event: ParentScheduleEvent; open: 
   );
 }
 
-function AvailabilitySection({ auth, event, rsvp, canSubmitRsvp, submitting, availabilityNote, onAvailabilityNoteChange, onSubmit, attentionItems, onSelectSection }: {
+function AvailabilitySection({ auth, event, rsvp, canSubmitRsvp, submitting, availabilityNote, onAvailabilityNoteChange, onSubmit, staffRsvpBreakdown, staffRsvpLoading, staffRsvpError, staffRsvpSubmittingPlayerId, staffRsvpStatus, staffRsvpRefreshToken, onStaffRsvpOverride, attentionItems, onSelectSection }: {
   auth: AuthState;
   event: ParentScheduleEvent;
   rsvp: RsvpResponse;
@@ -794,6 +877,13 @@ function AvailabilitySection({ auth, event, rsvp, canSubmitRsvp, submitting, ava
   availabilityNote: string;
   onAvailabilityNoteChange: (note: string) => void;
   onSubmit: (response: Exclude<RsvpResponse, 'not_responded'>) => Promise<void>;
+  staffRsvpBreakdown: StaffScheduleRsvpBreakdown | null;
+  staffRsvpLoading: boolean;
+  staffRsvpError: string | null;
+  staffRsvpSubmittingPlayerId: string | null;
+  staffRsvpStatus: StaffRsvpOverrideStatus | null;
+  staffRsvpRefreshToken: number;
+  onStaffRsvpOverride: (player: StaffScheduleRsvpRow, response: Exclude<RsvpResponse, 'not_responded'>) => Promise<void>;
   attentionItems: AttentionItem[];
   onSelectSection: (sectionId: EventDetailSectionId) => void;
 }) {
@@ -819,7 +909,16 @@ function AvailabilitySection({ auth, event, rsvp, canSubmitRsvp, submitting, ava
       />
       <div className="px-3 pb-3 sm:px-4">
         <AttentionPanel items={attentionItems} onSelectSection={onSelectSection} />
-        <StaffRsvpReminderPanel auth={auth} event={event} />
+        <StaffRsvpBreakdownPanel
+          event={event}
+          breakdown={staffRsvpBreakdown}
+          loading={staffRsvpLoading}
+          error={staffRsvpError}
+          submittingPlayerId={staffRsvpSubmittingPlayerId}
+          status={staffRsvpStatus}
+          onOverride={onStaffRsvpOverride}
+        />
+        <StaffRsvpReminderPanel auth={auth} event={event} refreshToken={staffRsvpRefreshToken} />
         <AvailabilityNotesList event={event} />
         {!event.isDbGame ? <div className="mt-2 text-xs font-semibold text-gray-500">Availability opens after this event is tracked in the schedule.</div> : null}
         {event.availabilityLocked ? <div className="mt-2 text-xs font-semibold text-amber-700">Availability locked {String(event.availabilityCutoffLabel || '').toLowerCase()}.</div> : null}
@@ -828,7 +927,96 @@ function AvailabilitySection({ auth, event, rsvp, canSubmitRsvp, submitting, ava
   );
 }
 
-function StaffRsvpReminderPanel({ auth, event }: { auth: AuthState; event: ParentScheduleEvent }) {
+function StaffRsvpBreakdownPanel({ event, breakdown, loading, error, submittingPlayerId, status, onOverride }: {
+  event: ParentScheduleEvent;
+  breakdown: StaffScheduleRsvpBreakdown | null;
+  loading: boolean;
+  error: string | null;
+  submittingPlayerId: string | null;
+  status: StaffRsvpOverrideStatus | null;
+  onOverride: (player: StaffScheduleRsvpRow, response: Exclude<RsvpResponse, 'not_responded'>) => Promise<void>;
+}) {
+  if (!event.isTeamStaff || !event.isDbGame) return null;
+  if (loading && !breakdown) {
+    return <div className="mt-3 rounded-xl border border-gray-200 bg-white p-3 text-sm font-semibold text-gray-600">Loading team RSVP breakdown…</div>;
+  }
+  if (error && !breakdown) {
+    return <div className="mt-3 rounded-xl border border-rose-200 bg-rose-50 p-3 text-sm font-semibold text-rose-700">{error}</div>;
+  }
+  if (!breakdown) return null;
+
+  return (
+    <div className="mt-3 rounded-xl border border-gray-200 bg-white p-3">
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div>
+          <div className="text-sm font-black text-gray-950">Staff RSVP overrides</div>
+          <div className="mt-1 text-xs font-semibold leading-5 text-gray-600">Review every player, including no response, and update availability inline.</div>
+        </div>
+        <span className="inline-flex min-h-8 items-center rounded-full border border-primary-100 bg-primary-50 px-3 text-xs font-black text-primary-700">
+          {formatRsvpSummary(breakdown.counts)}
+        </span>
+      </div>
+      <div className="mt-3 space-y-3">
+        {(['not_responded', 'going', 'maybe', 'not_going'] as const).map((responseKey) => {
+          const rows = breakdown.grouped[responseKey];
+          if (!rows.length) return null;
+          return (
+            <div key={responseKey}>
+              <div className="mb-2 flex items-center justify-between gap-2">
+                <div className="text-[11px] font-extrabold uppercase tracking-[0.04em] text-gray-500">{rsvpLabels[responseKey]}</div>
+                <span className={`rounded-full border px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadgeClasses[responseKey]}`}>
+                  {rows.length}
+                </span>
+              </div>
+              <div className="space-y-2">
+                {rows.map((player) => {
+                  const inlineStatus = status?.playerId === player.playerId ? status : null;
+                  return (
+                    <div key={player.playerId} className="rounded-xl border border-gray-200 bg-gray-50 p-3" data-testid={`staff-rsvp-row-${player.playerId}`}>
+                      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                        <div className="min-w-0">
+                          <div className="text-sm font-black text-gray-950">{player.playerNumber ? `#${player.playerNumber} ` : ''}{player.playerName}</div>
+                          <div className="mt-1 flex flex-wrap items-center gap-2">
+                            <span className={`rounded-full border px-2 py-0.5 text-[10px] font-extrabold uppercase tracking-[0.04em] ${rsvpBadgeClasses[player.response]}`}>
+                              {rsvpLabels[player.response]}
+                            </span>
+                            {player.note ? <span className="text-xs font-semibold text-gray-500">{player.note}</span> : null}
+                          </div>
+                        </div>
+                        <div className="grid grid-cols-3 gap-1.5 sm:min-w-[220px]">
+                          {(['going', 'maybe', 'not_going'] as const).map((response) => {
+                            const busy = submittingPlayerId === player.playerId;
+                            return (
+                              <button
+                                key={response}
+                                type="button"
+                                className={`min-h-8 rounded-full border px-2 text-[11px] font-black transition ${player.response === response ? rsvpBadgeClasses[response] : 'border-gray-200 bg-white text-gray-600 hover:border-primary-200 hover:bg-primary-50 hover:text-primary-700'}`}
+                                disabled={busy || event.isCancelled || event.availabilityLocked}
+                                onClick={() => onOverride(player, response)}
+                              >
+                                {busy && player.response !== response ? 'Saving' : rsvpLabels[response]}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </div>
+                      {inlineStatus ? <div className={`mt-2 text-xs font-bold ${inlineStatus.tone === 'success' ? 'text-emerald-700' : 'text-rose-700'}`}>{inlineStatus.message}</div> : null}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+      {error && breakdown ? <div className="mt-3 text-xs font-bold text-rose-700">{error}</div> : null}
+      {event.isCancelled ? <div className="mt-3 text-xs font-semibold text-gray-500">Cancelled events cannot be updated.</div> : null}
+      {event.availabilityLocked ? <div className="mt-3 text-xs font-semibold text-amber-700">Availability is locked for this event.</div> : null}
+    </div>
+  );
+}
+
+function StaffRsvpReminderPanel({ auth, event, refreshToken = 0 }: { auth: AuthState; event: ParentScheduleEvent; refreshToken?: number }) {
   const [preview, setPreview] = useState<StaffRsvpReminderPreview | null>(null);
   const [loading, setLoading] = useState(false);
   const [sending, setSending] = useState(false);
@@ -858,7 +1046,7 @@ function StaffRsvpReminderPanel({ auth, event }: { auth: AuthState; event: Paren
     } else {
       setPreview(null);
     }
-  }, [canLoad, refreshPreview]);
+  }, [canLoad, refreshPreview, refreshToken]);
 
   if (!event.isTeamRsvpReminderManager || !event.isDbGame || event.isCancelled) return null;
   if (loading && !preview) {

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -244,7 +244,7 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   }, [selectedEvent?.eventKey, selectedEvent?.myRsvpNote]);
 
   const refreshStaffRsvpBreakdown = useCallback(async (showLoading = true) => {
-    if (!auth.user || !selectedEvent?.isTeamStaff || !selectedEvent.isDbGame) {
+    if (!auth.user || !selectedEvent?.isTeamAdmin || !selectedEvent.isDbGame) {
       setStaffRsvpBreakdown(null);
       setStaffRsvpError(null);
       return null;
@@ -267,7 +267,7 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   useEffect(() => {
     setStaffRsvpStatus(null);
     setStaffRsvpSubmittingPlayerId(null);
-    if (!selectedEvent?.isTeamStaff || !selectedEvent.isDbGame) {
+    if (!selectedEvent?.isTeamAdmin || !selectedEvent.isDbGame) {
       setStaffRsvpBreakdown(null);
       setStaffRsvpError(null);
       setStaffRsvpLoading(false);
@@ -936,7 +936,7 @@ function StaffRsvpBreakdownPanel({ event, breakdown, loading, error, submittingP
   status: StaffRsvpOverrideStatus | null;
   onOverride: (player: StaffScheduleRsvpRow, response: Exclude<RsvpResponse, 'not_responded'>) => Promise<void>;
 }) {
-  if (!event.isTeamStaff || !event.isDbGame) return null;
+  if (!event.isTeamAdmin || !event.isDbGame) return null;
   if (loading && !breakdown) {
     return <div className="mt-3 rounded-xl border border-gray-200 bg-white p-3 text-sm font-semibold text-gray-600">Loading team RSVP breakdown…</div>;
   }

--- a/apps/app/src/styles/index.css
+++ b/apps/app/src/styles/index.css
@@ -1471,8 +1471,8 @@ a {
 
 .chat-audience-pill {
   display: inline-flex;
+  flex: 1 1 0;
   min-width: 0;
-  max-width: 48%;
   height: 34px;
   align-items: center;
   gap: 6px;
@@ -1483,6 +1483,22 @@ a {
   color: #4338ca;
   font-size: 0.75rem;
   font-weight: 900;
+}
+
+.chat-audience-pill span {
+  min-width: 0;
+}
+
+.chat-audience-pill[aria-label="Open Team Email"] {
+  flex: 0 1 auto;
+  max-width: 48%;
+}
+
+@media (min-width: 640px) {
+  .chat-audience-pill {
+    flex: 0 1 auto;
+    max-width: 48%;
+  }
 }
 
 .chat-composer-notice {

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -268,7 +268,7 @@ test('parent tools hub completes access, fees, calendars, share, registration, a
     await mockParentToolsModules(page);
     await page.goto(appUrl(baseURL, '/parent-tools/access'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByRole('heading', { name: 'Family workflows' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Family workflows' })).toBeVisible({ timeout: 15000 });
     await expect(page.getByText('Request player access')).toBeVisible();
     await page.getByRole('button', { name: /Send request/ }).click();
     await expect.poll(() => page.evaluate(() => window.__accessRequests.at(-1))).toEqual({ teamId: 'team-1', playerId: 'player-1', relation: 'Parent' });

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -533,6 +533,28 @@ async function mockScheduleModules(page, options = {}) {
                     window.__scheduleCalls.rideshare.push({ action: 'status', offerId: offer.id, status });
                 }
 
+                export async function loadStaffScheduleRsvpBreakdown() {
+                    return {
+                        counts: { going: 1, maybe: 0, notGoing: 0, notResponded: 1 },
+                        grouped: {
+                            not_responded: [],
+                            going: [],
+                            maybe: [],
+                            not_going: []
+                        }
+                    };
+                }
+
+                export async function submitStaffScheduleRsvpOverride(event, user, playerId, response) {
+                    window.__scheduleCalls.staffRsvps = (window.__scheduleCalls.staffRsvps || []).concat({
+                        eventId: event?.id || null,
+                        userId: user?.uid || null,
+                        playerId,
+                        response
+                    });
+                    return { playerId, response };
+                }
+
                 export async function loadStaffRsvpReminderPreview() {
                     return { missingPlayerCount: 0, eligibleEmailCount: 0, players: [] };
                 }

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -744,7 +744,7 @@ test('iOS-sized schedule smoke covers list, event nav, and rideshare without ove
     await mockScheduleModules(page);
     await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByLabel('Schedule filter', { exact: true })).toBeVisible();
+    await expect(page.getByLabel('Schedule filter', { exact: true })).toBeVisible({ timeout: 15000 });
     await expect(page.locator('.schedule-web-sidebar')).toBeHidden();
     await expect(page.locator('.schedule-list > a').first()).toBeVisible();
     const scheduleRowCount = await page.locator('.schedule-list > a').count();
@@ -792,7 +792,7 @@ test('app schedule event detail exposes parent actions and RSVP', async ({ page,
     await page.goto(appUrl(baseURL, '/schedule/team-1/game-1?childId=player-1'), { waitUntil: 'domcontentloaded' });
 
     const eventSummaryCard = page.locator('.event-summary-card');
-    await expect(eventSummaryCard.getByRole('heading', { name: 'vs. Falcons' })).toBeVisible({ timeout: 10000 });
+    await expect(eventSummaryCard.getByRole('heading', { name: 'vs. Falcons' })).toBeVisible({ timeout: 15000 });
     await expect(page.getByText('Pat · Bears')).toBeVisible();
     await expect(page.getByText('Availability needed')).toBeVisible();
     await expect(page.getByText('Is Pat going?')).toBeVisible();

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -1,8 +1,9 @@
 import { expect, test } from '@playwright/test';
+import { buildUrl } from './helpers/boot-path.js';
 
 function appUrl(baseURL, hashPath) {
     const appBaseURL = process.env.SMOKE_APP_BASE_URL || baseURL;
-    const url = new URL('/', appBaseURL);
+    const url = new URL(buildUrl(appBaseURL, '/'));
     url.hash = hashPath;
     return url.toString();
 }

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -1070,6 +1070,9 @@ describe('React app messages integration', () => {
 
         const { container } = await renderMessages('/messages/team-1');
 
+        expect(container.querySelector('button[aria-label="Voice to text"]')).toBeTruthy();
+        expect(buttonByText(container, 'Audience: Full team')).toBeTruthy();
+
         await click(container, 'Voice to text');
         expect(recognitionInstance.lang).toBe('es-MX');
         expect(recognitionInstance.start).toHaveBeenCalled();


### PR DESCRIPTION
Closes #1818

## What changed
- added `loadStaffScheduleRsvpBreakdown(...)` and `submitStaffScheduleRsvpOverride(...)` in `scheduleService` so the app can load the full per-player RSVP roster and write staff-selected overrides without being tied to `event.childId`
- added a staff-only RSVP breakdown panel inside `ScheduleEventDetail` that groups players into Going, Maybe, Out, and No Response with one-tap override buttons
- refreshed the local RSVP summary and reminder panel state after each override so counts move immediately without a page reload
- added regression coverage for the new service helpers and the ScheduleEventDetail staff override flow

## Why
Legacy game-day already lets staff resolve individual player availability inline. The React app only supported parent self-RSVP plus reminders, so staff could not fix no-response or mistaken attendance from the event detail view. This closes that parity gap with the smallest shared app change, which also works inside the Capacitor shells.