### PR TITLE
Add mobile filter to My Teams launcher

### DIFF
--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -241,17 +241,15 @@ function TeamLauncher({ teams, selectedTeamId, onSelect, variant = 'grid' }: {
           {teams.length} team{teams.length === 1 ? '' : 's'}
         </span>
       </div>
-      {isRail ? (
-        <label className="mt-3 block px-1">
-          <span className="sr-only">Filter teams</span>
-          <input
-            className="auth-input !min-h-10 !px-3 !py-2 text-sm"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search teams or players"
-          />
-        </label>
-      ) : null}
+      <label className="mt-3 block px-1">
+        <span className="sr-only">Filter teams</span>
+        <input
+          className="auth-input !min-h-10 !px-3 !py-2 text-sm"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search teams or players"
+        />
+      </label>
       <div className={`${isRail ? 'teams-team-rail-list mt-3 space-y-2' : 'mt-3 grid gap-2 xl:grid-cols-2'}`}>
         {visibleTeams.length ? visibleTeams.map((team) => (
           <TeamLauncherRow key={team.teamId} team={team} selected={team.teamId === selectedTeamId} onSelect={() => onSelect(team.teamId)} compact={isRail} />

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -13,10 +13,8 @@ async function gotoAppRoute(page, baseURL, hashPath) {
 }
 
 async function clickSearchTrigger(page) {
-    const searchTrigger = page.getByRole('button', { name: 'Search' }).first();
-    const titledSearchTrigger = page.locator('button[title*="Search"]').first();
-    const trigger = await searchTrigger.count() ? searchTrigger : titledSearchTrigger;
-    await expect(trigger).toBeVisible({ timeout: 3000 });
+    const trigger = page.locator('button[aria-label="Search"], button[title*="Search"]').first();
+    await expect(trigger).toBeVisible({ timeout: 10000 });
     await trigger.click();
 }
 

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -325,6 +325,14 @@ test.describe('mobile My Teams', () => {
 
         await expect(page.getByRole('heading', { name: '3 teams ready' })).toBeVisible();
         await expect(page.getByText('Choose a team')).toBeVisible();
+        await expect(page.getByPlaceholder('Search teams or players')).toBeVisible();
+        await page.getByPlaceholder('Search teams or players').fill('Riley');
+        await expect(page.getByRole('button', { name: /Rockets/ }).first()).toBeVisible();
+        await expect(page.getByRole('button', { name: /Staff Wolves/ })).toHaveCount(0);
+        await expect(page.getByRole('button', { name: /Bears/ })).toHaveCount(0);
+        await page.getByPlaceholder('Search teams or players').fill('zzz');
+        await expect(page.getByText('No teams match that search.')).toBeVisible();
+        await page.getByPlaceholder('Search teams or players').fill('Staff Wolves');
         await expect(page.getByRole('button', { name: /Staff Wolves/ }).first()).toHaveAttribute('aria-pressed', 'true');
         await expect(page.locator('a[aria-label="Staff Wolves messages"]')).toBeVisible();
         await expect(page.locator('a[aria-label="Staff Wolves schedule"]')).toHaveCount(0);
@@ -340,6 +348,7 @@ test.describe('mobile My Teams', () => {
         await expect.poll(() => page.evaluate(() => window.__openedPublicUrls.at(-1))).toBe('https://allplays.ai/team.html#teamId=team-staff');
         await expect(page).toHaveURL(/#\/teams/);
 
+        await page.getByPlaceholder('Search teams or players').fill('Bears');
         await page.getByRole('button', { name: /Bears/ }).first().click();
         await expect(page.getByRole('button', { name: /Bears/ }).first()).toHaveAttribute('aria-pressed', 'true');
         await expect(page.getByText('Pat Star, Sam Wing')).toBeVisible();

--- a/tests/unit/app-teams-integration.test.jsx
+++ b/tests/unit/app-teams-integration.test.jsx
@@ -109,6 +109,20 @@ async function clickLink(container, text) {
     await flush();
 }
 
+async function typeIntoInput(container, placeholder, value) {
+    const input = Array.from(container.querySelectorAll('input')).find((candidate) => candidate.getAttribute('placeholder') === placeholder);
+    if (!input) {
+        throw new Error(`Input not found: ${placeholder}`);
+    }
+    await act(async () => {
+        const prototype = Object.getPrototypeOf(input);
+        const descriptor = Object.getOwnPropertyDescriptor(prototype, 'value');
+        descriptor?.set?.call(input, value);
+        input.dispatchEvent(new Event('input', { bubbles: true }));
+    });
+    await flush();
+}
+
 beforeEach(() => {
     vi.clearAllMocks();
     window.requestAnimationFrame = (callback) => {
@@ -210,10 +224,25 @@ describe('React app Teams page', () => {
         expect(buttonByText(container, '6 more')).toBeTruthy();
     });
 
-    it('selects teams in place and keeps player/chat links available', async () => {
+    it('filters the mobile launcher by team and player text before selecting a result', async () => {
         const { container } = await renderTeams('/teams?selectedTeamId=team-staff&from=home');
         await waitForText(container, 'Staff Wolves');
 
+        const filterInput = container.querySelector('input[placeholder="Search teams or players"]');
+        expect(filterInput).toBeTruthy();
+
+        await typeIntoInput(container, 'Search teams or players', 'Pat');
+        expect(Array.from(container.querySelectorAll('button')).some((button) => button.textContent.includes('Bears'))).toBe(true);
+        expect(Array.from(container.querySelectorAll('button')).some((button) => button.textContent.includes('Staff Wolves'))).toBe(false);
+
+        await typeIntoInput(container, 'Search teams or players', 'Wolves');
+        expect(Array.from(container.querySelectorAll('button')).some((button) => button.textContent.includes('Staff Wolves'))).toBe(true);
+        expect(Array.from(container.querySelectorAll('button')).some((button) => button.textContent.includes('Bears'))).toBe(false);
+
+        await typeIntoInput(container, 'Search teams or players', 'zzz');
+        expect(container.textContent).toContain('No teams match that search.');
+
+        await typeIntoInput(container, 'Search teams or players', 'Bears');
         await clickButton(container, 'Bears');
 
         expect(buttonByText(container, 'Bears').getAttribute('aria-pressed')).toBe('true');


### PR DESCRIPTION
Closes #1798

## What changed
- exposed the existing `Search teams or players` filter input on the mobile My Teams launcher instead of limiting it to the desktop rail layout
- kept the current `filterTeams` behavior so mobile users can narrow by team name or linked player without changing selection, chat, schedule, or hub shortcuts
- extended mobile-focused regression coverage in the app integration test and Playwright smoke flow, including no-match behavior and filtered team selection

## Why
The filtering logic already existed, but mobile users could not access it because the input was only rendered for the desktop launcher variant. This patch makes the existing local filter available on mobile with the smallest safe UI change.