### PR TITLE
Use native handoff for Parent Tools calendar export

### DIFF
--- a/android/app/capacitor.build.gradle
+++ b/android/app/capacitor.build.gradle
@@ -13,6 +13,7 @@ dependencies {
     implementation project(':capacitor-firebase-messaging')
     implementation project(':capacitor-browser')
     implementation project(':capacitor-camera')
+    implementation project(':capacitor-filesystem')
     implementation project(':capacitor-share')
     implementation project(':capgo-capacitor-speech-recognition')
 

--- a/android/capacitor.settings.gradle
+++ b/android/capacitor.settings.gradle
@@ -14,6 +14,9 @@ project(':capacitor-browser').projectDir = new File('../node_modules/@capacitor/
 include ':capacitor-camera'
 project(':capacitor-camera').projectDir = new File('../node_modules/@capacitor/camera/android')
 
+include ':capacitor-filesystem'
+project(':capacitor-filesystem').projectDir = new File('../node_modules/@capacitor/filesystem/android')
+
 include ':capacitor-share'
 project(':capacitor-share').projectDir = new File('../node_modules/@capacitor/share/android')
 

--- a/apps/app/package-lock.json
+++ b/apps/app/package-lock.json
@@ -13,6 +13,7 @@
         "@capacitor/browser": "^8.0.3",
         "@capacitor/camera": "^8.2.0",
         "@capacitor/core": "^8.3.4",
+        "@capacitor/filesystem": "^8.1.2",
         "@capacitor/share": "^8.0.1",
         "@capgo/capacitor-speech-recognition": "^8.1.3",
         "firebase": "^12.13.0",
@@ -738,6 +739,18 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@capacitor/filesystem": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/filesystem/-/filesystem-8.1.2.tgz",
+      "integrity": "sha512-doaaMfGoFR2hWU6aV6u83I+5ZsGyJVq+Gz4r9lMpJzUKMm1eMu0hLnFdV1aXZlU9FlK/RndFrVD8oRZfNOqWgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@capacitor/synapse": "^1.0.4"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
     "node_modules/@capacitor/share": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/@capacitor/share/-/share-8.0.1.tgz",
@@ -746,6 +759,12 @@
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
       }
+    },
+    "node_modules/@capacitor/synapse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.4.tgz",
+      "integrity": "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==",
+      "license": "ISC"
     },
     "node_modules/@capgo/capacitor-speech-recognition": {
       "version": "8.1.3",

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -15,6 +15,7 @@
     "@capacitor/browser": "^8.0.3",
     "@capacitor/camera": "^8.2.0",
     "@capacitor/core": "^8.3.4",
+    "@capacitor/filesystem": "^8.1.2",
     "@capacitor/share": "^8.0.1",
     "@capgo/capacitor-speech-recognition": "^8.1.3",
     "firebase": "^12.13.0",

--- a/apps/app/src/lib/publicActions.ts
+++ b/apps/app/src/lib/publicActions.ts
@@ -1,5 +1,6 @@
 import { Browser } from '@capacitor/browser';
 import { Capacitor } from '@capacitor/core';
+import { Directory, Encoding, Filesystem } from '@capacitor/filesystem';
 import { Share } from '@capacitor/share';
 
 export type SharePublicUrlInput = {
@@ -12,6 +13,8 @@ export type SharePublicUrlInput = {
 export type SharePublicUrlResult = 'shared' | 'copied' | 'failed' | 'cancelled';
 
 export type CopyPublicTextResult = 'copied' | 'failed';
+
+export type ExportCalendarIcsResult = 'shared' | 'downloaded';
 
 function isNativePluginAvailable(pluginName: string) {
   return Capacitor.isNativePlatform() && Boolean((Capacitor as any).isPluginAvailable?.(pluginName));
@@ -102,4 +105,54 @@ export async function sharePublicUrl(input: SharePublicUrlInput): Promise<ShareP
   }
 
   return 'failed';
+}
+
+export async function exportCalendarIcsFile(filename: string, icsText: string): Promise<ExportCalendarIcsResult> {
+  const safeFilename = sanitizeFileName(filename || 'all-plays-schedule.ics');
+  const calendarText = String(icsText || '');
+  if (!calendarText.trim()) throw new Error('Calendar export is empty.');
+
+  if (isNativePluginAvailable('Filesystem') && isNativePluginAvailable('Share')) {
+    const canShare = await Share.canShare?.();
+    if (canShare && canShare.value === false) {
+      throw new Error('Sharing is not available on this device. Try the Apple or Google calendar links instead.');
+    }
+
+    const writeResult = await Filesystem.writeFile({
+      path: `calendar-exports/${Date.now()}-${safeFilename}`,
+      data: calendarText,
+      directory: Directory.Cache,
+      encoding: Encoding.UTF8,
+      recursive: true
+    });
+
+    await Share.share({
+      title: 'ALL PLAYS calendar export',
+      text: 'Share this .ics file with Calendar, Files, Gmail, or another app.',
+      files: [writeResult.uri],
+      dialogTitle: 'Export calendar'
+    });
+
+    return 'shared';
+  }
+
+  downloadBlobFile(safeFilename, calendarText, 'text/calendar;charset=utf-8');
+  return 'downloaded';
+}
+
+function downloadBlobFile(filename: string, fileText: string, contentType: string) {
+  const blob = new Blob([fileText], { type: contentType });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 500);
+}
+
+function sanitizeFileName(value: string) {
+  const clean = String(value || 'all-plays-schedule.ics').trim().replace(/[^a-z0-9._-]+/gi, '-').replace(/^-+|-+$/g, '');
+  return clean.toLowerCase().endsWith('.ics') ? clean : `${clean || 'all-plays-schedule'}.ics`;
 }

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -19,13 +19,12 @@ import {
   Ticket,
   Users
 } from 'lucide-react';
-import { openPublicUrl, sharePublicUrl } from '../lib/publicActions';
+import { exportCalendarIcsFile, openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 import { redeemSignedInInvite } from '../lib/inviteRedemption';
 import {
   buildParentScheduleIcs,
   createParentFamilyShare,
   createParentHouseholdMemberInvite,
-  downloadIcs,
   getAppleCalendarFeedUrl,
   getGoogleCalendarFeedUrl,
   getPrivateTeamCalendarFeedUrl,
@@ -467,6 +466,7 @@ function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refreshVersio
   const [teams, setTeams] = useState<ParentCalendarTeam[]>([]);
   const [loading, setLoading] = useState(true);
   const [busyTeamId, setBusyTeamId] = useState('');
+  const [exporting, setExporting] = useState(false);
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
 
@@ -490,13 +490,22 @@ function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refreshVersio
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth.user?.uid, refreshVersion]);
 
-  const download = () => {
+  const download = async () => {
     if (!events.length) {
       setMessage('No events to export yet.');
       return;
     }
-    downloadIcs('all-plays-family-schedule.ics', buildParentScheduleIcs(events));
-    setMessage('Calendar download started.');
+    setExporting(true);
+    setError('');
+    setMessage('');
+    try {
+      await exportCalendarIcsFile('all-plays-family-schedule.ics', buildParentScheduleIcs(events));
+      setMessage('Calendar file ready to share.');
+    } catch (downloadError: any) {
+      setError(downloadError?.message || 'Unable to export the calendar file. Try again or use the Apple or Google calendar links instead.');
+    } finally {
+      setExporting(false);
+    }
   };
 
   const copyAgenda = async () => {
@@ -534,9 +543,9 @@ function CalendarTool({ auth, refreshVersion }: { auth: AuthState; refreshVersio
         {error ? <Status tone="error" message={error} /> : null}
         {message ? <Status tone="success" message={message} /> : null}
         <div className="mt-3 grid gap-2 sm:grid-cols-3">
-          <button type="button" className="secondary-button justify-center" onClick={download} disabled={loading}>
-            <Download className="h-4 w-4" aria-hidden="true" />
-            Download .ics
+          <button type="button" className="secondary-button justify-center" onClick={() => { void download(); }} disabled={loading || exporting}>
+            {exporting ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Download className="h-4 w-4" aria-hidden="true" />}
+            {exporting ? 'Preparing .ics' : 'Download .ics'}
           </button>
           <button type="button" className="secondary-button justify-center" onClick={copyAgenda} disabled={loading}>
             <Copy className="h-4 w-4" aria-hidden="true" />

--- a/ios/App/CapApp-SPM/Package.swift
+++ b/ios/App/CapApp-SPM/Package.swift
@@ -16,6 +16,7 @@ let package = Package(
         .package(name: "CapacitorFirebaseMessaging", path: "../../../node_modules/@capacitor-firebase/messaging"),
         .package(name: "CapacitorBrowser", path: "../../../node_modules/@capacitor/browser"),
         .package(name: "CapacitorCamera", path: "../../../node_modules/@capacitor/camera"),
+        .package(name: "CapacitorFilesystem", path: "../../../node_modules/@capacitor/filesystem"),
         .package(name: "CapacitorShare", path: "../../../node_modules/@capacitor/share"),
         .package(name: "CapgoCapacitorSpeechRecognition", path: "../../../node_modules/@capgo/capacitor-speech-recognition")
     ],
@@ -29,6 +30,7 @@ let package = Package(
                 .product(name: "CapacitorFirebaseMessaging", package: "CapacitorFirebaseMessaging"),
                 .product(name: "CapacitorBrowser", package: "CapacitorBrowser"),
                 .product(name: "CapacitorCamera", package: "CapacitorCamera"),
+                .product(name: "CapacitorFilesystem", package: "CapacitorFilesystem"),
                 .product(name: "CapacitorShare", package: "CapacitorShare"),
                 .product(name: "CapgoCapacitorSpeechRecognition", package: "CapgoCapacitorSpeechRecognition")
             ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@capacitor/browser": "^8.0.3",
         "@capacitor/camera": "^8.2.0",
         "@capacitor/core": "^8.3.4",
+        "@capacitor/filesystem": "^8.1.2",
         "@capacitor/ios": "^8.3.4",
         "@capacitor/share": "^8.0.1",
         "@capgo/capacitor-speech-recognition": "^8.1.3",
@@ -244,6 +245,18 @@
         "tslib": "^2.1.0"
       }
     },
+    "node_modules/@capacitor/filesystem": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/@capacitor/filesystem/-/filesystem-8.1.2.tgz",
+      "integrity": "sha512-doaaMfGoFR2hWU6aV6u83I+5ZsGyJVq+Gz4r9lMpJzUKMm1eMu0hLnFdV1aXZlU9FlK/RndFrVD8oRZfNOqWgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@capacitor/synapse": "^1.0.4"
+      },
+      "peerDependencies": {
+        "@capacitor/core": ">=8.0.0"
+      }
+    },
     "node_modules/@capacitor/ios": {
       "version": "8.3.4",
       "resolved": "https://registry.npmjs.org/@capacitor/ios/-/ios-8.3.4.tgz",
@@ -261,6 +274,12 @@
       "peerDependencies": {
         "@capacitor/core": ">=8.0.0"
       }
+    },
+    "node_modules/@capacitor/synapse": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@capacitor/synapse/-/synapse-1.0.4.tgz",
+      "integrity": "sha512-/C1FUo8/OkKuAT4nCIu/34ny9siNHr9qtFezu4kxm6GY1wNFxrCFWjfYx5C1tUhVGz3fxBABegupkpjXvjCHrw==",
+      "license": "ISC"
     },
     "node_modules/@capgo/capacitor-speech-recognition": {
       "version": "8.1.3",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@capacitor/browser": "^8.0.3",
     "@capacitor/camera": "^8.2.0",
     "@capacitor/core": "^8.3.4",
+    "@capacitor/filesystem": "^8.1.2",
     "@capacitor/ios": "^8.3.4",
     "@capacitor/share": "^8.0.1",
     "@capgo/capacitor-speech-recognition": "^8.1.3",

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -78,6 +78,10 @@ async function mockParentToolsModules(page) {
                     window.__sharedUrls.push(input);
                     return 'shared';
                 }
+                export async function exportCalendarIcsFile(filename, text) {
+                    window.__downloads.push({ filename, text });
+                    return 'downloaded';
+                }
             `
         });
     });

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -33,6 +33,7 @@ const serviceMocks = vi.hoisted(() => ({
 }));
 
 const publicActionMocks = vi.hoisted(() => ({
+    exportCalendarIcsFile: vi.fn().mockResolvedValue('downloaded'),
     openPublicUrl: vi.fn(),
     sharePublicUrl: vi.fn().mockResolvedValue('shared')
 }));
@@ -286,7 +287,8 @@ describe('React app parent tools integration', () => {
         await clickButton(container, 'Calendar');
         await waitForText(container, 'Calendar tools');
         await clickButton(container, 'Download .ics');
-        expect(serviceMocks.downloadIcs).toHaveBeenCalledWith('all-plays-family-schedule.ics', 'BEGIN:VCALENDAR\r\nEND:VCALENDAR');
+        expect(publicActionMocks.exportCalendarIcsFile).toHaveBeenCalledWith('all-plays-family-schedule.ics', 'BEGIN:VCALENDAR\r\nEND:VCALENDAR');
+        expect(container.textContent).toContain('Calendar file ready to share.');
         await clickButton(container, 'Copy agenda');
         expect(navigator.clipboard.writeText).toHaveBeenCalledWith('Bears Practice');
         await clickButton(container, 'Apple');
@@ -581,6 +583,38 @@ describe('React app parent tools integration', () => {
 
         expect(container.textContent).toContain('Stripe session failed.');
         expect(publicActionMocks.openPublicUrl).not.toHaveBeenCalled();
+    });
+
+    it('shows calendar export success only after the handoff resolves', async () => {
+        let resolveExport;
+        const pendingExport = new Promise((resolve) => {
+            resolveExport = resolve;
+        });
+        publicActionMocks.exportCalendarIcsFile.mockImplementationOnce(() => pendingExport);
+
+        const { container } = await renderParentTools('/parent-tools/calendar');
+        await waitForText(container, 'Calendar tools');
+
+        await clickButton(container, 'Download .ics');
+
+        expect(publicActionMocks.exportCalendarIcsFile).toHaveBeenCalledWith('all-plays-family-schedule.ics', 'BEGIN:VCALENDAR\r\nEND:VCALENDAR');
+        expect(container.textContent).not.toContain('Calendar file ready to share.');
+
+        await act(async () => {
+            resolveExport('shared');
+        });
+        await waitForText(container, 'Calendar file ready to share.');
+    });
+
+    it('shows an actionable calendar export error when native handoff fails', async () => {
+        publicActionMocks.exportCalendarIcsFile.mockRejectedValueOnce(new Error('Sharing is not available on this device. Try the Apple or Google calendar links instead.'));
+
+        const { container } = await renderParentTools('/parent-tools/calendar');
+        await waitForText(container, 'Calendar tools');
+        await clickButton(container, 'Download .ics');
+
+        await waitForText(container, 'Sharing is not available on this device. Try the Apple or Google calendar links instead.');
+        expect(container.textContent).not.toContain('Calendar file ready to share.');
     });
 
     it('filters team media albums by media type in the app', async () => {

--- a/tests/unit/app-public-actions-native-wiring.test.js
+++ b/tests/unit/app-public-actions-native-wiring.test.js
@@ -1,0 +1,18 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('app public actions native wiring', () => {
+    it('registers the Filesystem plugin in the app package plus Android and iOS Capacitor manifests', () => {
+        const appPackage = JSON.parse(readFileSync('apps/app/package.json', 'utf8'));
+        const androidBuild = readFileSync('android/app/capacitor.build.gradle', 'utf8');
+        const androidSettings = readFileSync('android/capacitor.settings.gradle', 'utf8');
+        const iosPackage = readFileSync('ios/App/CapApp-SPM/Package.swift', 'utf8');
+
+        expect(appPackage.dependencies['@capacitor/filesystem']).toBeTruthy();
+        expect(androidBuild).toContain("implementation project(':capacitor-filesystem')");
+        expect(androidSettings).toContain("include ':capacitor-filesystem'");
+        expect(androidSettings).toContain("project(':capacitor-filesystem').projectDir = new File('../node_modules/@capacitor/filesystem/android')");
+        expect(iosPackage).toContain('.package(name: "CapacitorFilesystem", path: "../../../node_modules/@capacitor/filesystem")');
+        expect(iosPackage).toContain('.product(name: "CapacitorFilesystem", package: "CapacitorFilesystem")');
+    });
+});

--- a/tests/unit/app-public-actions.test.js
+++ b/tests/unit/app-public-actions.test.js
@@ -11,7 +11,12 @@ const browserMocks = vi.hoisted(() => ({
 }));
 
 const shareMocks = vi.hoisted(() => ({
+    canShare: vi.fn(),
     share: vi.fn()
+}));
+
+const filesystemMocks = vi.hoisted(() => ({
+    writeFile: vi.fn()
 }));
 
 vi.mock('../../apps/app/node_modules/@capacitor/core/dist/index.cjs.js', () => ({
@@ -27,6 +32,12 @@ vi.mock('../../apps/app/node_modules/@capacitor/browser/dist/plugin.cjs.js', () 
 
 vi.mock('../../apps/app/node_modules/@capacitor/share/dist/plugin.cjs.js', () => ({
     Share: shareMocks
+}));
+
+vi.mock('../../apps/app/node_modules/@capacitor/filesystem/dist/plugin.cjs.js', () => ({
+    Directory: { Cache: 'CACHE' },
+    Encoding: { UTF8: 'utf8' },
+    Filesystem: filesystemMocks
 }));
 
 async function loadPublicActions() {
@@ -57,7 +68,9 @@ beforeEach(() => {
     nativeState.isNative = false;
     nativeState.plugins = new Set();
     browserMocks.open.mockResolvedValue(undefined);
+    shareMocks.canShare.mockResolvedValue({ value: true });
     shareMocks.share.mockResolvedValue(undefined);
+    filesystemMocks.writeFile.mockResolvedValue({ uri: 'file:///cache/calendar.ics' });
     Object.defineProperty(navigator, 'share', {
         configurable: true,
         value: undefined
@@ -199,6 +212,70 @@ describe('React app public URL actions', () => {
             url: 'https://allplays.ai/live-game.html?teamId=team-1&gameId=game-1&replay=true',
             dialogTitle: 'Bears vs Falcons replay'
         });
+    });
+
+    it('writes and shares a native .ics file in Capacitor', async () => {
+        installNativeCapacitor(['Filesystem', 'Share']);
+        const { exportCalendarIcsFile } = await loadPublicActions();
+
+        const result = await exportCalendarIcsFile('Family Schedule.ics', 'BEGIN:VCALENDAR\r\nEND:VCALENDAR');
+
+        expect(result).toBe('shared');
+        expect(filesystemMocks.writeFile).toHaveBeenCalledWith(expect.objectContaining({
+            path: expect.stringMatching(/^calendar-exports\/\d+-Family-Schedule\.ics$/),
+            data: 'BEGIN:VCALENDAR\r\nEND:VCALENDAR',
+            directory: 'CACHE',
+            encoding: 'utf8',
+            recursive: true
+        }));
+        expect(shareMocks.share).toHaveBeenCalledWith({
+            title: 'ALL PLAYS calendar export',
+            text: 'Share this .ics file with Calendar, Files, Gmail, or another app.',
+            files: ['file:///cache/calendar.ics'],
+            dialogTitle: 'Export calendar'
+        });
+    });
+
+    it('keeps the web anchor download path for browser .ics exports', async () => {
+        const { exportCalendarIcsFile } = await loadPublicActions();
+        const originalCreateElement = document.createElement.bind(document);
+        const linkClick = vi.fn();
+        const linkRemove = vi.fn();
+        const appendChild = vi.spyOn(document.body, 'appendChild');
+        let createdLink;
+
+        vi.spyOn(document, 'createElement').mockImplementation((tagName, options) => {
+            if (String(tagName).toLowerCase() === 'a') {
+                createdLink = originalCreateElement('a');
+                createdLink.click = linkClick;
+                createdLink.remove = linkRemove;
+                return createdLink;
+            }
+            return originalCreateElement(tagName, options);
+        });
+
+        URL.createObjectURL = vi.fn(() => 'blob:test-calendar');
+        URL.revokeObjectURL = vi.fn();
+
+        const result = await exportCalendarIcsFile('Family Schedule.ics', 'BEGIN:VCALENDAR\r\nEND:VCALENDAR');
+
+        expect(result).toBe('downloaded');
+        expect(createdLink.download).toBe('Family-Schedule.ics');
+        expect(createdLink.href).toBe('blob:test-calendar');
+        expect(appendChild).toHaveBeenCalledWith(createdLink);
+        expect(linkClick).toHaveBeenCalled();
+        expect(linkRemove).toHaveBeenCalled();
+
+        document.createElement.mockRestore();
+        appendChild.mockRestore();
+    });
+
+    it('throws when the native .ics handoff fails', async () => {
+        installNativeCapacitor(['Filesystem', 'Share']);
+        shareMocks.share.mockRejectedValueOnce(new Error('Native share failed.'));
+        const { exportCalendarIcsFile } = await loadPublicActions();
+
+        await expect(exportCalendarIcsFile('family.ics', 'BEGIN:VCALENDAR\r\nEND:VCALENDAR')).rejects.toThrow('Native share failed.');
     });
 
     it('reports native share cancellation without showing a false failure', async () => {


### PR DESCRIPTION
Closes #1836

## What changed
- added a native-aware `exportCalendarIcsFile` helper in `apps/app/src/lib/publicActions.ts`
- on Capacitor, the helper now writes the generated `.ics` payload to a temporary cache file with `@capacitor/filesystem` and launches the native share sheet with `@capacitor/share`
- on web, the helper keeps the existing Blob plus anchor download behavior
- updated `ParentTools` so the Calendar tab awaits the real export handoff, shows success only after resolve, and shows an actionable error if native sharing is unavailable or fails
- added focused regression coverage for native export, browser fallback, deferred success UI, and rejected native handoff UI

## Root Cause
Parent Tools reused a browser-only DOM download helper for `.ics` export and immediately showed a success message without waiting for any native delivery path. In a Capacitor shell, that meant the app could report success even though no usable calendar file handoff occurred.

## Prevention / Learning
When app flows need to deliver files from a Capacitor shell, do not reuse browser-only download primitives as if they were cross-platform. Put platform branching in a shared helper, return a real async result, and make UI success states depend on the actual native handoff completing.

## Regression Tests
- `npx vitest run tests/unit/app-public-actions.test.js --reporter=dot`
- `npx vitest run tests/unit/app-parent-tools-integration.test.jsx --reporter=dot`
- `npm run app:build`