### PR TITLE
Skip redundant Profile alerts preference reload

### DIFF
--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -131,6 +131,7 @@ export function Profile({ auth }: { auth: AuthState }) {
   const alertsLoading = activeProfileSection === 'alerts' && !notificationTeamsLoaded;
   const alertsEmpty = activeProfileSection === 'alerts' && notificationTeamsLoaded && notificationTeams.length === 0;
   const alertsReady = activeProfileSection === 'alerts' && notificationTeamsLoaded && Boolean(selectedNotificationTeam);
+  const selectedTeamPreferencesHydrated = Boolean(selectedTeamId) && loadedNotificationTeamId === selectedTeamId;
 
   const selectProfileSection = (sectionId: ProfileSectionId) => {
     setActiveProfileSection(sectionId);
@@ -553,7 +554,9 @@ export function Profile({ auth }: { auth: AuthState }) {
     setNotificationStatus(null);
 
     try {
-      const currentPreferences = await loadNotificationPreferences(user.uid, teamId);
+      const currentPreferences = loadedNotificationTeamId === teamId
+        ? notificationPreferences
+        : await loadNotificationPreferences(user.uid, teamId);
       const nextPreferences = normalizeNotificationPreferences({
         ...currentPreferences,
         ...gameDayDefaultPreferences
@@ -930,7 +933,7 @@ export function Profile({ auth }: { auth: AuthState }) {
               <div className="rounded-2xl border border-primary-100 bg-primary-50 p-3">
                 <div className="text-sm font-black text-primary-900">Game-day alerts</div>
                 <p className="mt-1 text-sm font-semibold leading-6 text-primary-800">One tap enables push on this device and turns on schedule changes and live score updates for the selected team.</p>
-                <button type="button" className="primary-button mt-3" onClick={turnOnGameDayAlerts} disabled={busy === 'game-day-alerts' || !selectedTeamId}>
+                <button type="button" className="primary-button mt-3" onClick={turnOnGameDayAlerts} disabled={busy === 'game-day-alerts' || !selectedTeamId || !selectedTeamPreferencesHydrated}>
                   {busy === 'game-day-alerts' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Upload className="h-4 w-4" aria-hidden="true" />}
                   Turn on game-day alerts
                 </button>

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -530,7 +530,9 @@ test('profile exposes account, notification, invite, verification, password, upl
     await page.getByRole('button', { name: 'Alerts' }).click();
     await expect(page.getByText('Notification preferences')).toBeVisible();
     await expect(page.getByLabel('Team')).toHaveValue('team-1');
-    await page.getByRole('button', { name: 'Turn on game-day alerts' }).click();
+    const gameDayAlertsButton = page.getByRole('button', { name: 'Turn on game-day alerts' });
+    await expect(gameDayAlertsButton).toBeEnabled();
+    await gameDayAlertsButton.click();
     await expect(page.getByText('Game-day alerts are on for this team.')).toBeVisible();
     await page.getByText('Customize alerts').click();
     await expect(page.getByLabel('Live Chat')).toBeChecked();

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -584,7 +584,6 @@ test('profile exposes account, notification, invite, verification, password, upl
         uploads: [{ name: 'avatar.png', type: 'image/png' }],
         push: 1,
         notificationLoads: [
-            { userId: 'user-1', teamId: 'team-1' },
             { userId: 'user-1', teamId: 'team-1' }
         ],
         notificationSaves: [

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -65,8 +65,6 @@ async function mockSearchModules(page) {
             status: 200,
             contentType: 'application/javascript',
             body: `
-                import './firebaseAuthRuntime.ts';
-
                 export function useAuth() {
                     const user = {
                         uid: 'user-1',

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -305,16 +305,19 @@ describe('React app auth/profile capability parity', () => {
         expect(profilePage).toContain("disabled={busy === 'push-device' || !user}");
     });
 
-    it('refreshes team preferences before turning on game-day alerts', () => {
+    it('uses hydrated team preferences before turning on game-day alerts', () => {
         const profilePage = readProjectFile('apps/app/src/pages/Profile.tsx');
         const turnOnStart = profilePage.indexOf('const turnOnGameDayAlerts = async () => {');
         const turnOnEnd = profilePage.indexOf('  const sendPasswordReset = async () => {');
         const turnOnGameDayAlerts = profilePage.slice(turnOnStart, turnOnEnd);
 
+        expect(profilePage).toContain("const selectedTeamPreferencesHydrated = Boolean(selectedTeamId) && loadedNotificationTeamId === selectedTeamId;");
+        expect(profilePage).toContain("disabled={busy === 'game-day-alerts' || !selectedTeamId || !selectedTeamPreferencesHydrated}");
         expect(turnOnGameDayAlerts).toContain('const teamId = selectedTeamId;');
-        expect(turnOnGameDayAlerts).toContain('const currentPreferences = await loadNotificationPreferences(user.uid, teamId);');
+        expect(turnOnGameDayAlerts).toContain('const currentPreferences = loadedNotificationTeamId === teamId');
+        expect(turnOnGameDayAlerts).toContain('? notificationPreferences');
+        expect(turnOnGameDayAlerts).toContain(': await loadNotificationPreferences(user.uid, teamId);');
         expect(turnOnGameDayAlerts).toContain('...currentPreferences,');
-        expect(turnOnGameDayAlerts).not.toContain('...notificationPreferences,');
         expect(turnOnGameDayAlerts.indexOf('await enablePushNotificationsForUser(user.uid);')).toBeLessThan(
             turnOnGameDayAlerts.indexOf('saveNotificationPreferences(user.uid, teamId, nextPreferences)')
         );

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -316,11 +316,9 @@ describe('Profile invites', () => {
     expect(screen.getByRole('link', { name: 'Go to My Teams' }).getAttribute('href')).toBe('/teams');
   });
 
-  it('refreshes alert preferences before saving game-day alerts', async () => {
+  it('uses hydrated alert preferences before saving game-day alerts', async () => {
     profileServiceMocks.loadNotificationTeams.mockResolvedValue([{ id: 'team-1', name: 'Blue Team' }]);
-    profileServiceMocks.loadNotificationPreferences
-      .mockResolvedValueOnce({ liveChat: false, liveScore: false, schedule: false })
-      .mockResolvedValueOnce({ liveChat: true, liveScore: false, schedule: false });
+    profileServiceMocks.loadNotificationPreferences.mockResolvedValueOnce({ liveChat: true, liveScore: false, schedule: false });
     profileServiceMocks.saveNotificationPreferences.mockImplementation(async (_userId, _teamId, preferences) => preferences);
 
     renderProfile();
@@ -330,17 +328,53 @@ describe('Profile invites', () => {
     await waitFor(() => expect((screen.getByLabelText('Team') as HTMLSelectElement).value).toBe('team-1'));
     await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(1));
 
-    fireEvent.click(screen.getByRole('button', { name: 'Turn on game-day alerts' }));
+    const gameDayButton = await screen.findByRole('button', { name: 'Turn on game-day alerts' });
+    expect((gameDayButton as HTMLButtonElement).disabled).toBe(false);
+    fireEvent.click(gameDayButton);
 
     await waitFor(() => expect(pushServiceMocks.enablePushNotificationsForUser).toHaveBeenCalledTimes(1));
     await waitFor(() => expect(profileServiceMocks.saveNotificationPreferences).toHaveBeenCalledTimes(1));
-    expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(2);
+    expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(1);
     expect(profileServiceMocks.saveNotificationPreferences).toHaveBeenCalledWith('user-1', 'team-1', {
       liveChat: true,
       liveScore: true,
       schedule: true
     });
     expect(await screen.findByText('Game-day alerts are on for this team.')).toBeTruthy();
+  });
+
+  it('keeps game-day alerts disabled until the selected team preferences finish hydrating', async () => {
+    const secondTeamPreferences = createDeferred<{ liveChat: boolean; liveScore: boolean; schedule: boolean }>();
+    profileServiceMocks.loadNotificationTeams.mockResolvedValue([
+      { id: 'team-1', name: 'Blue Team' },
+      { id: 'team-2', name: 'Gold Team' }
+    ]);
+    profileServiceMocks.loadNotificationPreferences
+      .mockResolvedValueOnce({ liveChat: true, liveScore: false, schedule: false })
+      .mockReturnValueOnce(secondTeamPreferences.promise);
+    profileServiceMocks.saveNotificationPreferences.mockImplementation(async (_userId, _teamId, preferences) => preferences);
+
+    renderProfile();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Alerts' }));
+
+    await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(1));
+    const teamSelect = await screen.findByLabelText('Team');
+    const gameDayButton = await screen.findByRole('button', { name: 'Turn on game-day alerts' });
+    expect((gameDayButton as HTMLButtonElement).disabled).toBe(false);
+
+    fireEvent.change(teamSelect, { target: { value: 'team-2' } });
+
+    await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(2));
+    expect((gameDayButton as HTMLButtonElement).disabled).toBe(true);
+
+    fireEvent.click(gameDayButton);
+    expect(pushServiceMocks.enablePushNotificationsForUser).not.toHaveBeenCalled();
+    expect(profileServiceMocks.saveNotificationPreferences).not.toHaveBeenCalled();
+
+    secondTeamPreferences.resolve({ liveChat: false, liveScore: false, schedule: false });
+
+    await waitFor(() => expect((gameDayButton as HTMLButtonElement).disabled).toBe(false));
   });
 
   it('uploads the normalized profile photo instead of the original selection', async () => {


### PR DESCRIPTION
Closes #1842

## What changed
- added a hydrated fast path in `Profile.tsx` so the game-day alerts CTA reuses already-loaded `notificationPreferences` when `loadedNotificationTeamId` matches the selected team
- disabled the game-day alerts CTA until the selected team's preferences are hydrated, preventing stale in-memory preferences from being reused after a team switch
- kept the existing narrow fallback fetch in place for any non-hydrated path
- updated focused unit coverage to assert both the no-refetch hydrated path and the disabled-until-hydrated behavior

## Root Cause
The game-day alerts CTA did not trust the Profile page's hydrated notification state. It always reloaded preferences before saving because the button could be pressed while `selectedTeamId` had changed but `notificationPreferences` still belonged to the previous team.

## Prevention / Learning
When a screen already tracks both resource data and the id it was hydrated for, use that hydration marker as the source of truth for action readiness. Disable write actions until the selected entity and hydrated entity match, and only fall back to a fetch when that guard is not satisfied.

## Regression Tests
- `npx vitest run tests/unit/app-profile-invites.test.tsx tests/unit/app-auth-profile-capabilities.test.js --reporter=verbose`
- `tests/unit/app-profile-invites.test.tsx` now verifies the hydrated path avoids a second `loadNotificationPreferences` call and that switching teams keeps the CTA disabled until the new team's preferences finish loading
- `tests/unit/app-auth-profile-capabilities.test.js` now asserts the implementation uses `loadedNotificationTeamId` plus in-memory `notificationPreferences` instead of always forcing a reload