### PR TITLE
Guard mobile team alert preferences while loading

### DIFF
--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -132,6 +132,7 @@ export function Profile({ auth }: { auth: AuthState }) {
   const alertsEmpty = activeProfileSection === 'alerts' && notificationTeamsLoaded && notificationTeams.length === 0;
   const alertsReady = activeProfileSection === 'alerts' && notificationTeamsLoaded && Boolean(selectedNotificationTeam);
   const selectedTeamPreferencesHydrated = Boolean(selectedTeamId) && loadedNotificationTeamId === selectedTeamId;
+  const selectedTeamPreferencesLoading = alertsReady && Boolean(selectedTeamId) && !selectedTeamPreferencesHydrated;
 
   const selectProfileSection = (sectionId: ProfileSectionId) => {
     setActiveProfileSection(sectionId);
@@ -506,6 +507,10 @@ export function Profile({ auth }: { auth: AuthState }) {
   const saveNotifications = async () => {
     if (!user || !selectedTeamId) {
       setNotificationStatus({ message: 'Select a team first.', tone: 'error' });
+      return;
+    }
+    if (!selectedTeamPreferencesHydrated) {
+      setNotificationStatus({ message: 'Wait for this team’s alert preferences to finish loading.', tone: 'error' });
       return;
     }
 
@@ -940,15 +945,25 @@ export function Profile({ auth }: { auth: AuthState }) {
               </div>
             </div>
 
-            <details className="mt-3 rounded-2xl border border-gray-200 bg-white p-3">
+            <details className="mt-3 rounded-2xl border border-gray-200 bg-white p-3" open>
               <summary className="cursor-pointer text-sm font-black text-gray-700">Customize alerts</summary>
-              <div className="mt-3 grid gap-2 sm:grid-cols-3">
-                <PreferenceToggle label="Live Chat" checked={notificationPreferences.liveChat} onChange={(checked) => setNotificationPreferences((current) => ({ ...current, liveChat: checked }))} />
-                <PreferenceToggle label="Live Score" checked={notificationPreferences.liveScore} onChange={(checked) => setNotificationPreferences((current) => ({ ...current, liveScore: checked }))} />
-                <PreferenceToggle label="Schedule Changes" checked={notificationPreferences.schedule} onChange={(checked) => setNotificationPreferences((current) => ({ ...current, schedule: checked }))} />
-              </div>
+              {selectedTeamPreferencesLoading ? (
+                <div className="mt-3 rounded-2xl border border-gray-200 bg-gray-50 p-3" role="status" aria-live="polite">
+                  <div className="flex items-center gap-2 text-sm font-black text-gray-900">
+                    <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                    Loading alerts for {selectedNotificationTeam?.name || 'this team'}…
+                  </div>
+                  <p className="mt-2 text-sm font-semibold leading-6 text-gray-600">Team-specific alert toggles will unlock as soon as the selected team’s saved preferences finish loading.</p>
+                </div>
+              ) : (
+                <div className="mt-3 grid gap-2 sm:grid-cols-3">
+                  <PreferenceToggle label="Live Chat" checked={notificationPreferences.liveChat} onChange={(checked) => setNotificationPreferences((current) => ({ ...current, liveChat: checked }))} />
+                  <PreferenceToggle label="Live Score" checked={notificationPreferences.liveScore} onChange={(checked) => setNotificationPreferences((current) => ({ ...current, liveScore: checked }))} />
+                  <PreferenceToggle label="Schedule Changes" checked={notificationPreferences.schedule} onChange={(checked) => setNotificationPreferences((current) => ({ ...current, schedule: checked }))} />
+                </div>
+              )}
               <div className="mt-3 flex flex-wrap items-center gap-2">
-                <button type="button" className="primary-button" onClick={saveNotifications} disabled={busy === 'notifications' || !selectedTeamId}>
+                <button type="button" className="primary-button" onClick={saveNotifications} disabled={busy === 'notifications' || !selectedTeamId || !selectedTeamPreferencesHydrated}>
                   {busy === 'notifications' ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Save className="h-4 w-4" aria-hidden="true" />}
                   Save preferences
                 </button>

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -270,7 +270,7 @@ export function Profile({ auth }: { auth: AuthState }) {
         console.warn('[profile] Unable to load notification preferences:', error);
         if (!cancelled) {
           setNotificationPreferences(emptyPreferences);
-          setLoadedNotificationTeamId('');
+          setLoadedNotificationTeamId(selectedTeamId);
           setNotificationStatus({ message: 'Unable to load notification preferences.', tone: 'error' });
         }
       }

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -534,7 +534,8 @@ test('profile exposes account, notification, invite, verification, password, upl
     await expect(gameDayAlertsButton).toBeEnabled();
     await gameDayAlertsButton.click();
     await expect(page.getByText('Game-day alerts are on for this team.')).toBeVisible();
-    await page.getByText('Customize alerts').click();
+    await expect(page.getByText('Customize alerts')).toBeVisible();
+    await expect(page.getByLabel('Live Chat')).toBeVisible();
     await expect(page.getByLabel('Live Chat')).toBeChecked();
     await expect(page.getByLabel('Live Score')).toBeChecked();
     await expect(page.getByLabel('Schedule Changes')).toBeChecked();

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -386,15 +386,14 @@ describe('Profile invites', () => {
     expect((saveButton as HTMLButtonElement).disabled).toBe(false);
   });
 
-  it('renders and saves only the final selected team after rapid team switches', async () => {
-    const secondTeamPreferences = createDeferred<{ liveChat: boolean; liveScore: boolean; schedule: boolean }>();
+  it('renders fallback toggles and re-enables team actions when preference loading fails', async () => {
     profileServiceMocks.loadNotificationTeams.mockResolvedValue([
       { id: 'team-1', name: 'Blue Team' },
       { id: 'team-2', name: 'Gold Team' }
     ]);
     profileServiceMocks.loadNotificationPreferences
       .mockResolvedValueOnce({ liveChat: true, liveScore: false, schedule: false })
-      .mockReturnValueOnce(secondTeamPreferences.promise);
+      .mockRejectedValueOnce(new Error('temporary outage'));
     profileServiceMocks.saveNotificationPreferences.mockImplementation(async (_userId, _teamId, preferences) => preferences);
 
     renderProfile();
@@ -403,28 +402,28 @@ describe('Profile invites', () => {
 
     await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(1));
     const teamSelect = await screen.findByLabelText('Team');
+    const gameDayButton = await screen.findByRole('button', { name: 'Turn on game-day alerts' });
+    const saveButton = screen.getByRole('button', { name: 'Save preferences' });
 
     fireEvent.change(teamSelect, { target: { value: 'team-2' } });
-    await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(2));
-    expect(screen.getByText('Loading alerts for Gold Team…')).toBeTruthy();
 
-    fireEvent.change(teamSelect, { target: { value: 'team-1' } });
+    await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('Unable to load notification preferences.')).toBeTruthy();
     await waitFor(() => expect(screen.queryByText('Loading alerts for Gold Team…')).toBeNull());
     expect(screen.getByLabelText('Live Chat')).toBeTruthy();
+    expect((screen.getByLabelText('Live Chat') as HTMLInputElement).checked).toBe(true);
     expect((screen.getByLabelText('Live Score') as HTMLInputElement).checked).toBe(false);
+    expect((screen.getByLabelText('Schedule Changes') as HTMLInputElement).checked).toBe(true);
+    expect((gameDayButton as HTMLButtonElement).disabled).toBe(false);
+    expect((saveButton as HTMLButtonElement).disabled).toBe(false);
 
-    secondTeamPreferences.resolve({ liveChat: false, liveScore: false, schedule: false });
-
-    const saveButton = screen.getByRole('button', { name: 'Save preferences' });
     fireEvent.click(saveButton);
 
-    await waitFor(() => expect(profileServiceMocks.saveNotificationPreferences).toHaveBeenCalledWith('user-1', 'team-1', {
+    await waitFor(() => expect(profileServiceMocks.saveNotificationPreferences).toHaveBeenCalledWith('user-1', 'team-2', {
       liveChat: true,
       liveScore: false,
-      schedule: false
+      schedule: true
     }));
-    expect(screen.queryByText('Loading alerts for Gold Team…')).toBeNull();
-    expect(profileServiceMocks.saveNotificationPreferences).not.toHaveBeenCalledWith('user-1', 'team-2', expect.anything());
   });
 
   it('uploads the normalized profile photo instead of the original selection', async () => {

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -343,7 +343,7 @@ describe('Profile invites', () => {
     expect(await screen.findByText('Game-day alerts are on for this team.')).toBeTruthy();
   });
 
-  it('keeps game-day alerts disabled until the selected team preferences finish hydrating', async () => {
+  it('hides stale team toggles and disables team actions until the new team preferences finish hydrating', async () => {
     const secondTeamPreferences = createDeferred<{ liveChat: boolean; liveScore: boolean; schedule: boolean }>();
     profileServiceMocks.loadNotificationTeams.mockResolvedValue([
       { id: 'team-1', name: 'Blue Team' },
@@ -361,20 +361,70 @@ describe('Profile invites', () => {
     await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(1));
     const teamSelect = await screen.findByLabelText('Team');
     const gameDayButton = await screen.findByRole('button', { name: 'Turn on game-day alerts' });
+    const saveButton = screen.getByRole('button', { name: 'Save preferences' });
+    expect(screen.getByLabelText('Live Chat')).toBeTruthy();
     expect((gameDayButton as HTMLButtonElement).disabled).toBe(false);
+    expect((saveButton as HTMLButtonElement).disabled).toBe(false);
 
     fireEvent.change(teamSelect, { target: { value: 'team-2' } });
 
     await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(2));
+    expect(screen.getByText('Loading alerts for Gold Team…')).toBeTruthy();
+    expect(screen.queryByLabelText('Live Chat')).toBeNull();
     expect((gameDayButton as HTMLButtonElement).disabled).toBe(true);
+    expect((saveButton as HTMLButtonElement).disabled).toBe(true);
 
     fireEvent.click(gameDayButton);
+    fireEvent.click(saveButton);
     expect(pushServiceMocks.enablePushNotificationsForUser).not.toHaveBeenCalled();
     expect(profileServiceMocks.saveNotificationPreferences).not.toHaveBeenCalled();
 
     secondTeamPreferences.resolve({ liveChat: false, liveScore: false, schedule: false });
 
-    await waitFor(() => expect((gameDayButton as HTMLButtonElement).disabled).toBe(false));
+    await waitFor(() => expect(screen.getByLabelText('Live Chat')).toBeTruthy());
+    expect((gameDayButton as HTMLButtonElement).disabled).toBe(false);
+    expect((saveButton as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  it('renders and saves only the final selected team after rapid team switches', async () => {
+    const secondTeamPreferences = createDeferred<{ liveChat: boolean; liveScore: boolean; schedule: boolean }>();
+    profileServiceMocks.loadNotificationTeams.mockResolvedValue([
+      { id: 'team-1', name: 'Blue Team' },
+      { id: 'team-2', name: 'Gold Team' }
+    ]);
+    profileServiceMocks.loadNotificationPreferences
+      .mockResolvedValueOnce({ liveChat: true, liveScore: false, schedule: false })
+      .mockReturnValueOnce(secondTeamPreferences.promise);
+    profileServiceMocks.saveNotificationPreferences.mockImplementation(async (_userId, _teamId, preferences) => preferences);
+
+    renderProfile();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Alerts' }));
+
+    await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(1));
+    const teamSelect = await screen.findByLabelText('Team');
+
+    fireEvent.change(teamSelect, { target: { value: 'team-2' } });
+    await waitFor(() => expect(profileServiceMocks.loadNotificationPreferences).toHaveBeenCalledTimes(2));
+    expect(screen.getByText('Loading alerts for Gold Team…')).toBeTruthy();
+
+    fireEvent.change(teamSelect, { target: { value: 'team-1' } });
+    await waitFor(() => expect(screen.queryByText('Loading alerts for Gold Team…')).toBeNull());
+    expect(screen.getByLabelText('Live Chat')).toBeTruthy();
+    expect((screen.getByLabelText('Live Score') as HTMLInputElement).checked).toBe(false);
+
+    secondTeamPreferences.resolve({ liveChat: false, liveScore: false, schedule: false });
+
+    const saveButton = screen.getByRole('button', { name: 'Save preferences' });
+    fireEvent.click(saveButton);
+
+    await waitFor(() => expect(profileServiceMocks.saveNotificationPreferences).toHaveBeenCalledWith('user-1', 'team-1', {
+      liveChat: true,
+      liveScore: false,
+      schedule: false
+    }));
+    expect(screen.queryByText('Loading alerts for Gold Team…')).toBeNull();
+    expect(profileServiceMocks.saveNotificationPreferences).not.toHaveBeenCalledWith('user-1', 'team-2', expect.anything());
   });
 
   it('uploads the normalized profile photo instead of the original selection', async () => {


### PR DESCRIPTION
Closes #1845

## What changed
- added an explicit selected-team preference loading state in `Profile` Alerts
- hid the per-team toggle controls while a newly selected team's preferences are still loading
- disabled `Save preferences` and `Turn on game-day alerts` until `loadedNotificationTeamId` matches `selectedTeamId`
- added regression coverage for stale-toggle hiding, disabled actions during team switches, and rapid switch behavior that saves only the final selected team

## Root Cause
The Alerts UI kept rendering the last loaded `notificationPreferences` while `selectedTeamId` had already changed to a different team. Because the save action used `selectedTeamId` instead of the team that originally loaded those toggle values, a fast save during the async gap could persist team A's stale preferences onto team B.

## Prevention / Learning
When UI state is keyed by an entity id and data loads asynchronously, treat `selectedId` and `loadedId` as separate state machines. Do not render or enable entity-specific controls until they are synchronized, and add regression tests that cover rapid selection changes before async hydration completes.

## Regression Tests
- `npx vitest run tests/unit/app-profile-invites.test.tsx --reporter=verbose`
- added a test that switches from team A to team B and verifies stale toggles are hidden and team actions stay disabled until hydration completes
- added a test that rapidly switches teams and verifies only the final selected team's preferences are rendered and saved