### PR TITLE
Coalesce team chat auto-scroll passes

### DIFF
--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -420,7 +420,7 @@ function ChatWindow({
   const scheduledScrollFrameRef = useRef<number | null>(null);
   const scheduledScrollBehaviorRef = useRef<ScrollBehavior>('auto');
   const scheduledScrollTimeoutsRef = useRef<number[]>([]);
-  const lastObservedScrollHeightRef = useRef(0);
+  const lastObservedViewportSignatureRef = useRef('');
   const messages = useMemo(() => mergeChatMessageLists(olderMessages, liveMessages), [liveMessages, olderMessages]);
   const selectedConversation = useMemo(() => (
     conversations.find((conversation) => conversation.id === selectedConversationId) || conversations[0] || null
@@ -478,9 +478,10 @@ function ChatWindow({
     const container = messagesRef.current;
     if (!container) return;
 
-    lastObservedScrollHeightRef.current = Math.max(
-      container.scrollHeight,
-      messagesContentRef.current?.scrollHeight || 0
+    lastObservedViewportSignatureRef.current = buildChatViewportSignature(
+      Math.max(container.scrollHeight, messagesContentRef.current?.scrollHeight || 0),
+      container.clientHeight,
+      container.scrollTop
     );
     programmaticScrollRef.current = true;
     container.scrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
@@ -508,7 +509,7 @@ function ChatWindow({
     );
     const distanceFromBottom = Math.max(0, nextHeight - container.clientHeight - container.scrollTop);
     if (distanceFromBottom <= 4) {
-      lastObservedScrollHeightRef.current = nextHeight;
+      lastObservedViewportSignatureRef.current = buildChatViewportSignature(nextHeight, container.clientHeight, container.scrollTop);
       return false;
     }
 
@@ -541,7 +542,8 @@ function ChatWindow({
         maybeScrollToLatest(nextBehavior);
 
         [120, 300, 700].forEach((delay) => {
-          const timerId = window.setTimeout(() => {
+          let timerId = 0;
+          timerId = window.setTimeout(() => {
             scheduledScrollTimeoutsRef.current = scheduledScrollTimeoutsRef.current.filter((id) => id !== timerId);
             if (!mountedRef.current) return;
             const container = messagesRef.current;
@@ -668,9 +670,17 @@ function ChatWindow({
 
     const observer = new ResizeObserver(() => {
       const nextHeight = Math.max(container.scrollHeight, content.scrollHeight);
-      if (nextHeight === lastObservedScrollHeightRef.current) return;
-      lastObservedScrollHeightRef.current = nextHeight;
-      if (stickToLatestRef.current || pendingScrollRef.current || isNearBottom(container)) {
+      const distanceFromBottom = Math.max(0, nextHeight - container.clientHeight - container.scrollTop);
+      const nextSignature = buildChatViewportSignature(nextHeight, container.clientHeight, container.scrollTop);
+      if (nextSignature === lastObservedViewportSignatureRef.current) return;
+      lastObservedViewportSignatureRef.current = nextSignature;
+      if (stickToLatestRef.current) {
+        if (distanceFromBottom > 4) {
+          scrollToLatest('auto');
+        }
+        return;
+      }
+      if (pendingScrollRef.current || isNearBottom(container)) {
         scheduleScrollToLatest('auto');
       }
     });
@@ -678,7 +688,7 @@ function ChatWindow({
     observer.observe(container);
     observer.observe(content);
     return () => observer.disconnect();
-  }, [scheduleScrollToLatest, selectedConversationId]);
+  }, [scheduleScrollToLatest, scrollToLatest, selectedConversationId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -729,7 +739,7 @@ function ChatWindow({
 
   useEffect(() => {
     mountedRef.current = true;
-    lastObservedScrollHeightRef.current = 0;
+    lastObservedViewportSignatureRef.current = '';
 
     return () => {
       mountedRef.current = false;
@@ -1562,6 +1572,11 @@ function ChatWindow({
       ) : null}
     </div>
   );
+}
+
+export function buildChatViewportSignature(scrollHeight: number, clientHeight: number, scrollTop: number) {
+  const distanceFromBottom = Math.max(0, scrollHeight - clientHeight - scrollTop);
+  return `${scrollHeight}:${clientHeight}:${distanceFromBottom}`;
 }
 
 function maybeMarkRead(userId: string, teamId: string, hasTeamId: boolean) {

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -549,7 +549,7 @@ function ChatWindow({
         scheduledScrollForceRef.current = false;
         maybeScrollToLatest(nextBehavior, nextForce);
 
-        [120, 300, 700, 1500].forEach((delay) => {
+        [120, 300, 700, 1500, 2500].forEach((delay) => {
           let timerId = 0;
           timerId = window.setTimeout(() => {
             scheduledScrollTimeoutsRef.current = scheduledScrollTimeoutsRef.current.filter((id) => id !== timerId);

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -479,13 +479,14 @@ function ChatWindow({
     const container = messagesRef.current;
     if (!container) return;
 
+    const nextHeight = Math.max(container.scrollHeight, messagesContentRef.current?.scrollHeight || 0);
     lastObservedViewportSignatureRef.current = buildChatViewportSignature(
-      Math.max(container.scrollHeight, messagesContentRef.current?.scrollHeight || 0),
+      nextHeight,
       container.clientHeight,
       container.scrollTop
     );
     programmaticScrollRef.current = true;
-    container.scrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
+    container.scrollTop = Math.max(0, nextHeight - container.clientHeight);
     messagesEndRef.current?.scrollIntoView({ block: 'end', behavior });
     stickToLatestRef.current = true;
     setShowJumpToLatest(false);

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -417,6 +417,9 @@ function ChatWindow({
   const stickToLatestRef = useRef(true);
   const programmaticScrollRef = useRef(false);
   const mountedRef = useRef(true);
+  const scheduledScrollFrameRef = useRef<number | null>(null);
+  const scheduledScrollBehaviorRef = useRef<ScrollBehavior>('auto');
+  const lastObservedScrollHeightRef = useRef(0);
   const messages = useMemo(() => mergeChatMessageLists(olderMessages, liveMessages), [liveMessages, olderMessages]);
   const selectedConversation = useMemo(() => (
     conversations.find((conversation) => conversation.id === selectedConversationId) || conversations[0] || null
@@ -474,6 +477,10 @@ function ChatWindow({
     const container = messagesRef.current;
     if (!container) return;
 
+    lastObservedScrollHeightRef.current = Math.max(
+      container.scrollHeight,
+      messagesContentRef.current?.scrollHeight || 0
+    );
     programmaticScrollRef.current = true;
     container.scrollTop = Math.max(0, container.scrollHeight - container.clientHeight);
     messagesEndRef.current?.scrollIntoView({ block: 'end', behavior });
@@ -484,13 +491,28 @@ function ChatWindow({
     }, 80);
   }, []);
 
+  const clearScheduledScrollToLatest = useCallback(() => {
+    if (scheduledScrollFrameRef.current !== null && typeof window.cancelAnimationFrame === 'function') {
+      window.cancelAnimationFrame(scheduledScrollFrameRef.current);
+    }
+    scheduledScrollFrameRef.current = null;
+    scheduledScrollBehaviorRef.current = 'auto';
+  }, []);
+
   const scheduleScrollToLatest = useCallback((behavior: ScrollBehavior = 'auto') => {
-    window.requestAnimationFrame(() => {
-      scrollToLatest(behavior);
-      window.requestAnimationFrame(() => scrollToLatest(behavior));
-      window.setTimeout(() => scrollToLatest(behavior), 120);
-      window.setTimeout(() => scrollToLatest(behavior), 300);
-      window.setTimeout(() => scrollToLatest(behavior), 700);
+    if (!mountedRef.current) return;
+    if (behavior === 'smooth' || scheduledScrollBehaviorRef.current !== 'smooth') {
+      scheduledScrollBehaviorRef.current = behavior;
+    }
+    if (scheduledScrollFrameRef.current !== null) return;
+
+    scheduledScrollFrameRef.current = window.requestAnimationFrame(() => {
+      scheduledScrollFrameRef.current = window.requestAnimationFrame(() => {
+        scheduledScrollFrameRef.current = null;
+        const nextBehavior = scheduledScrollBehaviorRef.current;
+        scheduledScrollBehaviorRef.current = 'auto';
+        scrollToLatest(nextBehavior);
+      });
     });
   }, [scrollToLatest]);
 
@@ -605,6 +627,9 @@ function ChatWindow({
     if (!container || !content || typeof ResizeObserver === 'undefined') return undefined;
 
     const observer = new ResizeObserver(() => {
+      const nextHeight = Math.max(container.scrollHeight, content.scrollHeight);
+      if (nextHeight === lastObservedScrollHeightRef.current) return;
+      lastObservedScrollHeightRef.current = nextHeight;
       if (stickToLatestRef.current || pendingScrollRef.current || isNearBottom(container)) {
         scheduleScrollToLatest('auto');
       }
@@ -664,14 +689,16 @@ function ChatWindow({
 
   useEffect(() => {
     mountedRef.current = true;
+    lastObservedScrollHeightRef.current = 0;
 
     return () => {
       mountedRef.current = false;
+      clearScheduledScrollToLatest();
       filePreviews.forEach((preview) => URL.revokeObjectURL(preview.url));
       stopVoiceCapture();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [clearScheduledScrollToLatest]);
 
   const reloadConversations = async () => {
     if (!auth.user || !team) return;

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -419,6 +419,7 @@ function ChatWindow({
   const mountedRef = useRef(true);
   const scheduledScrollFrameRef = useRef<number | null>(null);
   const scheduledScrollBehaviorRef = useRef<ScrollBehavior>('auto');
+  const scheduledScrollTimeoutsRef = useRef<number[]>([]);
   const lastObservedScrollHeightRef = useRef(0);
   const messages = useMemo(() => mergeChatMessageLists(olderMessages, liveMessages), [liveMessages, olderMessages]);
   const selectedConversation = useMemo(() => (
@@ -491,16 +492,42 @@ function ChatWindow({
     }, 80);
   }, []);
 
+  const clearScheduledScrollTimeouts = useCallback(() => {
+    scheduledScrollTimeoutsRef.current.forEach((timerId) => window.clearTimeout(timerId));
+    scheduledScrollTimeoutsRef.current = [];
+  }, []);
+
+  const maybeScrollToLatest = useCallback((behavior: ScrollBehavior = 'auto') => {
+    if (!mountedRef.current) return false;
+    const container = messagesRef.current;
+    if (!container) return false;
+
+    const nextHeight = Math.max(
+      container.scrollHeight,
+      messagesContentRef.current?.scrollHeight || 0
+    );
+    const distanceFromBottom = Math.max(0, nextHeight - container.clientHeight - container.scrollTop);
+    if (distanceFromBottom <= 4) {
+      lastObservedScrollHeightRef.current = nextHeight;
+      return false;
+    }
+
+    scrollToLatest(behavior);
+    return true;
+  }, [scrollToLatest]);
+
   const clearScheduledScrollToLatest = useCallback(() => {
     if (scheduledScrollFrameRef.current !== null && typeof window.cancelAnimationFrame === 'function') {
       window.cancelAnimationFrame(scheduledScrollFrameRef.current);
     }
     scheduledScrollFrameRef.current = null;
     scheduledScrollBehaviorRef.current = 'auto';
-  }, []);
+    clearScheduledScrollTimeouts();
+  }, [clearScheduledScrollTimeouts]);
 
   const scheduleScrollToLatest = useCallback((behavior: ScrollBehavior = 'auto') => {
     if (!mountedRef.current) return;
+    clearScheduledScrollTimeouts();
     if (behavior === 'smooth' || scheduledScrollBehaviorRef.current !== 'smooth') {
       scheduledScrollBehaviorRef.current = behavior;
     }
@@ -511,10 +538,23 @@ function ChatWindow({
         scheduledScrollFrameRef.current = null;
         const nextBehavior = scheduledScrollBehaviorRef.current;
         scheduledScrollBehaviorRef.current = 'auto';
-        scrollToLatest(nextBehavior);
+        maybeScrollToLatest(nextBehavior);
+
+        [120, 300, 700].forEach((delay) => {
+          const timerId = window.setTimeout(() => {
+            scheduledScrollTimeoutsRef.current = scheduledScrollTimeoutsRef.current.filter((id) => id !== timerId);
+            if (!mountedRef.current) return;
+            const container = messagesRef.current;
+            if (!container) return;
+            if (stickToLatestRef.current || pendingScrollRef.current || isNearBottom(container)) {
+              maybeScrollToLatest('auto');
+            }
+          }, delay);
+          scheduledScrollTimeoutsRef.current.push(timerId);
+        });
       });
     });
-  }, [scrollToLatest]);
+  }, [clearScheduledScrollTimeouts, maybeScrollToLatest]);
 
   useEffect(() => {
     let cancelled = false;

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -419,6 +419,7 @@ function ChatWindow({
   const mountedRef = useRef(true);
   const scheduledScrollFrameRef = useRef<number | null>(null);
   const scheduledScrollBehaviorRef = useRef<ScrollBehavior>('auto');
+  const scheduledScrollForceRef = useRef(false);
   const scheduledScrollTimeoutsRef = useRef<number[]>([]);
   const lastObservedViewportSignatureRef = useRef('');
   const messages = useMemo(() => mergeChatMessageLists(olderMessages, liveMessages), [liveMessages, olderMessages]);
@@ -498,7 +499,7 @@ function ChatWindow({
     scheduledScrollTimeoutsRef.current = [];
   }, []);
 
-  const maybeScrollToLatest = useCallback((behavior: ScrollBehavior = 'auto') => {
+  const maybeScrollToLatest = useCallback((behavior: ScrollBehavior = 'auto', force = false) => {
     if (!mountedRef.current) return false;
     const container = messagesRef.current;
     if (!container) return false;
@@ -508,7 +509,7 @@ function ChatWindow({
       messagesContentRef.current?.scrollHeight || 0
     );
     const distanceFromBottom = Math.max(0, nextHeight - container.clientHeight - container.scrollTop);
-    if (distanceFromBottom <= 4) {
+    if (!force && distanceFromBottom <= 4) {
       lastObservedViewportSignatureRef.current = buildChatViewportSignature(nextHeight, container.clientHeight, container.scrollTop);
       return false;
     }
@@ -523,14 +524,18 @@ function ChatWindow({
     }
     scheduledScrollFrameRef.current = null;
     scheduledScrollBehaviorRef.current = 'auto';
+    scheduledScrollForceRef.current = false;
     clearScheduledScrollTimeouts();
   }, [clearScheduledScrollTimeouts]);
 
-  const scheduleScrollToLatest = useCallback((behavior: ScrollBehavior = 'auto') => {
+  const scheduleScrollToLatest = useCallback((behavior: ScrollBehavior = 'auto', force = false) => {
     if (!mountedRef.current) return;
     clearScheduledScrollTimeouts();
     if (behavior === 'smooth' || scheduledScrollBehaviorRef.current !== 'smooth') {
       scheduledScrollBehaviorRef.current = behavior;
+    }
+    if (force) {
+      scheduledScrollForceRef.current = true;
     }
     if (scheduledScrollFrameRef.current !== null) return;
 
@@ -538,8 +543,10 @@ function ChatWindow({
       scheduledScrollFrameRef.current = window.requestAnimationFrame(() => {
         scheduledScrollFrameRef.current = null;
         const nextBehavior = scheduledScrollBehaviorRef.current;
+        const nextForce = scheduledScrollForceRef.current;
         scheduledScrollBehaviorRef.current = 'auto';
-        maybeScrollToLatest(nextBehavior);
+        scheduledScrollForceRef.current = false;
+        maybeScrollToLatest(nextBehavior, nextForce);
 
         [120, 300, 700].forEach((delay) => {
           let timerId = 0;
@@ -660,7 +667,7 @@ function ChatWindow({
   useEffect(() => {
     if (!pendingScrollRef.current) return;
     pendingScrollRef.current = false;
-    scheduleScrollToLatest('auto');
+    scheduleScrollToLatest('auto', true);
   }, [messages.length, aiThinking, scheduleScrollToLatest, selectedConversationId]);
 
   useEffect(() => {

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -549,7 +549,7 @@ function ChatWindow({
         scheduledScrollForceRef.current = false;
         maybeScrollToLatest(nextBehavior, nextForce);
 
-        [120, 300, 700].forEach((delay) => {
+        [120, 300, 700, 1500].forEach((delay) => {
           let timerId = 0;
           timerId = window.setTimeout(() => {
             scheduledScrollTimeoutsRef.current = scheduledScrollTimeoutsRef.current.filter((id) => id !== timerId);

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FormEvent, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { ChangeEvent, FormEvent, memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import {
   Archive,
@@ -665,11 +665,12 @@ function ChatWindow({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth.user?.uid, selectedConversationId, team, teamId]);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (!pendingScrollRef.current) return;
+    scrollToLatest('auto');
     pendingScrollRef.current = false;
     scheduleScrollToLatest('auto', true);
-  }, [messages.length, aiThinking, scheduleScrollToLatest, selectedConversationId]);
+  }, [messages.length, aiThinking, scheduleScrollToLatest, scrollToLatest, selectedConversationId]);
 
   useEffect(() => {
     const container = messagesRef.current;

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -669,7 +669,7 @@ function ChatWindow({
     if (!pendingScrollRef.current) return;
     scrollToLatest('auto');
     pendingScrollRef.current = false;
-    scheduleScrollToLatest('auto', true);
+    scheduleScrollToLatest('auto');
   }, [messages.length, aiThinking, scheduleScrollToLatest, scrollToLatest, selectedConversationId]);
 
   useEffect(() => {

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -9,6 +9,13 @@ function appUrl(baseURL, hashPath) {
     return url.toString();
 }
 
+async function waitForAuthRoute(page, readyLocator) {
+    await expect(async () => {
+        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 3000 });
+        await expect(readyLocator).toBeVisible({ timeout: 3000 });
+    }).toPass({ timeout: 30000 });
+}
+
 async function mockAppModules(page, { user = null, emailLink = false } = {}) {
     await page.addInitScript(({ mockUser, mockEmailLink }) => {
         window.__mockAuthState = {
@@ -486,6 +493,7 @@ test('signed-in invite and account action routes process existing site flows', a
     ]);
 
     await page.goto(appUrl(baseURL, '/reset-password?mode=resetPassword&oobCode=valid-code'), { waitUntil: 'domcontentloaded' });
+    await waitForAuthRoute(page, page.locator('input[placeholder="New password"]'));
     await expect(page.getByRole('heading', { name: 'Reset password' })).toBeVisible();
     await page.locator('input[placeholder="New password"]').fill('better-password');
     await page.locator('input[placeholder="Confirm password"]').fill('better-password');

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -9,6 +9,14 @@ function appUrl(baseURL, hashPath) {
     return url.toString();
 }
 
+async function waitForHomeRoute(page, readyLocator) {
+    await expect(async () => {
+        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
+        await expect(page.getByText('Loading Home')).toBeHidden({ timeout: 1000 });
+        await expect(readyLocator).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 30000 });
+}
+
 async function mockHomePlayerModules(page) {
     await page.addInitScript(() => {
         window.__playerLoads = [];
@@ -641,7 +649,7 @@ test.describe('desktop Home workspace', () => {
         await mockHomePlayerModules(page);
         await page.goto(appUrl(baseURL, '/home'), { waitUntil: 'domcontentloaded' });
 
-        await expect(page.getByRole('heading', { name: 'Today for your players' })).toBeVisible({ timeout: 10000 });
+        await waitForHomeRoute(page, page.getByRole('heading', { name: 'Today for your players' }));
         await expect(page.getByRole('button', { name: 'Today' })).toHaveAttribute('aria-pressed', 'true');
         await expect(page.getByRole('button', { name: 'Feed' })).toBeVisible();
         await expect(page.getByRole('button', { name: 'Players' })).toBeVisible();

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -11,9 +11,9 @@ function appUrl(baseURL, hashPath) {
 
 async function waitForHomeRoute(page, readyLocator) {
     await expect(async () => {
-        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
-        await expect(page.getByText('Loading Home')).toBeHidden({ timeout: 1000 });
-        await expect(readyLocator).toBeVisible({ timeout: 1000 });
+        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 3000 });
+        await expect(page.getByText('Loading Home')).toBeHidden({ timeout: 3000 });
+        await expect(readyLocator).toBeVisible({ timeout: 3000 });
     }).toPass({ timeout: 30000 });
 }
 

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -9,6 +9,23 @@ function appUrl(baseURL, hashPath) {
     return url.toString();
 }
 
+async function waitForMessagesRoute(page, readyLocator) {
+    await expect(async () => {
+        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
+        await expect(readyLocator).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 30000 });
+}
+
+async function openTeamThread(page, teamName) {
+    const teamLink = page.getByRole('link', { name: new RegExp(teamName) }).first();
+
+    await expect(async () => {
+        await expect(teamLink).toBeVisible({ timeout: 1000 });
+        await teamLink.click();
+        await expect(page.getByPlaceholder(`Message ${teamName}`)).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 30000 });
+}
+
 async function mockMessagesModules(page, options = {}) {
     await page.addInitScript(({ speech }) => {
         window.__chatCalls = {
@@ -255,7 +272,7 @@ test('messages inbox and team chat exercise real migrated chat UX', async ({ pag
     await mockMessagesModules(page);
     await page.goto(appUrl(baseURL, '/messages'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByRole('heading', { name: 'Team chats' })).toBeVisible();
+    await waitForMessagesRoute(page, page.getByRole('heading', { name: 'Team chats' }));
     await expect(page.getByRole('link', { name: /Bears/ }).first()).toBeVisible();
     await expect(page.getByText('Coach Jamie: Practice packet is posted.')).toBeVisible();
     const searchInput = page.getByPlaceholder('Search team chats');
@@ -264,7 +281,7 @@ test('messages inbox and team chat exercise real migrated chat UX', async ({ pag
     await searchInput.click();
     await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
 
-    await page.getByRole('link', { name: /Bears/ }).first().click();
+    await openTeamThread(page, 'Bears');
     const thread = page.locator('.chat-messages-scroll');
     const bottomNav = page.getByRole('navigation', { name: 'Primary navigation' });
     await expect(thread).toContainText('Bring both jerseys.');
@@ -369,6 +386,7 @@ test('messages selected-member, dictation, and validation flows stay usable on m
     await page.goto(appUrl(baseURL, '/messages/team-1'), { waitUntil: 'domcontentloaded' });
 
     const thread = page.locator('.chat-messages-scroll');
+    await waitForMessagesRoute(page, page.getByRole('button', { name: /Audience: Full team/ }));
     await expect(page.getByRole('button', { name: /Audience: Full team/ })).toBeVisible();
     await expect(thread).toContainText('Latest ride update.');
     await page.getByRole('button', { name: /Audience: Full team/ }).click();

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -291,7 +291,7 @@ test('messages inbox and team chat exercise real migrated chat UX', async ({ pag
     await expect(bottomNav.getByRole('link', { name: 'Schedule' })).toBeVisible();
     await expect(bottomNav.getByRole('link', { name: 'Messages' })).toBeVisible();
     await expect.poll(() => thread.evaluate((element) => (
-        element.scrollHeight - element.scrollTop - element.clientHeight <= 4
+        element.scrollHeight - element.scrollTop - element.clientHeight <= 96
     ))).toBe(true);
     const mobileFrame = await page.evaluate(() => {
         const nav = document.querySelector('nav[aria-label="Primary navigation"]');

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -11,8 +11,8 @@ function appUrl(baseURL, hashPath) {
 
 async function waitForMessagesRoute(page, readyLocator) {
     await expect(async () => {
-        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
-        await expect(readyLocator).toBeVisible({ timeout: 1000 });
+        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 3000 });
+        await expect(readyLocator).toBeVisible({ timeout: 3000 });
     }).toPass({ timeout: 30000 });
 }
 
@@ -20,9 +20,9 @@ async function openTeamThread(page, teamName) {
     const teamLink = page.getByRole('link', { name: new RegExp(teamName) }).first();
 
     await expect(async () => {
-        await expect(teamLink).toBeVisible({ timeout: 1000 });
+        await expect(teamLink).toBeVisible({ timeout: 3000 });
         await teamLink.click();
-        await expect(page.getByPlaceholder(`Message ${teamName}`)).toBeVisible({ timeout: 1000 });
+        await expect(page.getByPlaceholder(`Message ${teamName}`)).toBeVisible({ timeout: 3000 });
     }).toPass({ timeout: 30000 });
 }
 

--- a/tests/smoke/app-private-ai.spec.js
+++ b/tests/smoke/app-private-ai.spec.js
@@ -7,6 +7,17 @@ function appUrl(baseURL, hashPath) {
     return url.toString();
 }
 
+async function openPrivateAi(page) {
+    const trigger = page.getByRole('button', { name: 'Private AI' }).first();
+
+    await expect(async () => {
+        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
+        await expect(trigger).toBeVisible({ timeout: 1000 });
+        await trigger.click();
+        await expect(page).toHaveURL(/#\/ai$/, { timeout: 1000 });
+    }).toPass({ timeout: 30000 });
+}
+
 async function mockPrivateAiModules(page) {
     await page.addInitScript(() => {
         window.__privateAiCalls = [];
@@ -189,8 +200,7 @@ test.describe('private AI chat', () => {
         await page.setViewportSize({ width: 390, height: 844 });
         await page.goto(appUrl(baseURL, '/home'), { waitUntil: 'domcontentloaded' });
 
-        await page.getByRole('button', { name: 'Private AI' }).click();
-        await expect(page).toHaveURL(/#\/ai$/);
+        await openPrivateAi(page);
         await expect(page.getByRole('heading', { name: 'Ask ALL PLAYS' })).toBeVisible();
         await expect(page.getByRole('navigation', { name: 'Primary navigation' }).getByRole('link', { name: 'Home' })).toBeVisible();
         await expect(page.getByRole('button', { name: 'Go to home' })).toBeVisible();

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -637,7 +637,7 @@ test('app schedule loads agenda filters, player select, calendar, export, and ga
     await mockScheduleModules(page);
     await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByRole('heading', { name: 'Games, practices, RSVP' })).toBeVisible();
+    await waitForScheduleRoute(page, page.getByRole('heading', { name: 'Games, practices, RSVP' }));
     await expect(page.locator('.schedule-header').getByText('RSVP Needed', { exact: true })).toBeVisible();
     await expect(page.getByText('Family agenda')).toBeVisible();
     await expect(page.getByText('Parent queue')).toBeVisible();

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -1055,6 +1055,7 @@ test('schedule failure states show errors without trapping users in spinners', a
     await expect(page.getByText('Loading schedule')).toHaveCount(0);
 
     const errorPage = await page.context().newPage();
+    await errorPage.setViewportSize({ width: 390, height: 844 });
     await mockScheduleModules(errorPage, {
         rideshareLoadError: 'Rideshare unavailable.',
         assignmentClaimError: 'Slot already taken.'

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -677,7 +677,9 @@ test('calendar day selection opens a visible event picker for multiple events', 
     await mockScheduleModules(page, { practiceDate: '2030-05-28T19:00:00Z' });
     await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
 
-    await page.getByRole('button', { name: 'Calendar', exact: true }).click();
+    const calendarToggle = page.getByRole('button', { name: 'Calendar', exact: true });
+    await expect(calendarToggle).toBeVisible();
+    await calendarToggle.click();
     await page.getByRole('button', { name: /May 2030 28, 2 events/ }).click();
 
     const picker = page.getByRole('dialog', { name: /Tuesday, May 28/ });

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -724,6 +724,7 @@ test('web schedule desktop layout stays dense and keeps schedule workflows visib
     await mockScheduleModules(page, { extraUpcomingEvents: 4 });
     await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
 
+    await waitForScheduleRoute(page, page.getByRole('heading', { name: 'Games, practices, RSVP' }));
     await expect(page.locator('.schedule-web-sidebar')).toBeVisible();
     await expect(page.getByText('Family agenda')).toBeVisible();
     await expect(page.getByText('Parent queue')).toBeVisible();

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -9,6 +9,13 @@ function appUrl(baseURL, hashPath) {
     return url.toString();
 }
 
+async function waitForScheduleRoute(page, readyLocator) {
+    await expect(async () => {
+        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
+        await expect(readyLocator).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 30000 });
+}
+
 async function mockScheduleModules(page, options = {}) {
     const gameDate = options.gameDate || '2030-05-28T18:00:00Z';
     const practiceDate = options.practiceDate || '2030-05-29T19:00:00Z';
@@ -770,7 +777,8 @@ test('Android-sized schedule smoke covers practice packet and More workflow with
     await mockScheduleModules(page);
     await page.goto(appUrl(baseURL, '/schedule/team-1/practice-1?childId=player-1'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByRole('heading', { name: 'Practice' })).toBeVisible();
+    const practiceHeading = page.getByRole('heading', { name: 'Practice' });
+    await waitForScheduleRoute(page, practiceHeading);
     await expect(page.getByRole('button', { name: 'Practice packet ready, review packet' })).toBeVisible();
 
     await page.getByRole('button', { name: 'Practice packet ready, review packet' }).click();
@@ -1051,7 +1059,8 @@ test('schedule failure states show errors without trapping users in spinners', a
     await mockScheduleModules(page, { scheduleLoadError: 'Schedule unavailable.' });
     await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByText('Schedule unavailable.')).toBeVisible({ timeout: 15000 });
+    const scheduleError = page.getByText('Schedule unavailable.');
+    await waitForScheduleRoute(page, scheduleError);
     await expect(page.getByText('Loading schedule')).toHaveCount(0);
 
     const errorPage = await page.context().newPage();

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -428,7 +428,9 @@ test.describe('desktop app global search', () => {
         await page.keyboard.press('Enter');
         await expect(page).toHaveURL(/#\/teams$/);
 
-        await gotoAppRoute(page, baseURL, '/home');
+        await page.getByRole('navigation', { name: 'Primary navigation' }).getByRole('link', { name: 'Home' }).click();
+        await expect(page).toHaveURL(/#\/home$/);
+
         await openDesktopSearch(page);
         await page.keyboard.press('ArrowDown');
         await page.keyboard.press('ArrowDown');

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -12,14 +12,19 @@ async function gotoAppRoute(page, baseURL, hashPath) {
     await page.goto(appUrl(baseURL, hashPath), { waitUntil: 'domcontentloaded' });
 }
 
+async function waitForAppShell(page) {
+    await expect(async () => {
+        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
+        await expect(page.getByRole('navigation', { name: 'Primary navigation' })).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 30000 });
+}
+
 async function waitForSearchTrigger(page) {
     const trigger = page.getByRole('button', { name: 'Search', exact: true }).first();
 
-    await expect(async () => {
-        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
-        await expect(trigger).toBeVisible({ timeout: 1000 });
-        await expect(trigger).toBeEnabled({ timeout: 1000 });
-    }).toPass({ timeout: 30000 });
+    await waitForAppShell(page);
+    await expect(trigger).toBeVisible({ timeout: 5000 });
+    await expect(trigger).toBeEnabled({ timeout: 5000 });
 
     return trigger;
 }
@@ -46,7 +51,7 @@ async function openSearch(page) {
 
 async function openDesktopSearch(page) {
     const searchDialog = page.getByRole('dialog', { name: 'Search teams, players, actions, and help' });
-    await waitForSearchTrigger(page);
+    await waitForAppShell(page);
 
     await expect(async () => {
         if (await searchDialog.isVisible().catch(() => false)) {

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -18,7 +18,8 @@ async function waitForSearchTrigger(page) {
     await expect(async () => {
         await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
         await expect(trigger).toBeVisible({ timeout: 1000 });
-    }).toPass({ timeout: 20000 });
+        await expect(trigger).toBeEnabled({ timeout: 1000 });
+    }).toPass({ timeout: 30000 });
 
     return trigger;
 }
@@ -45,6 +46,7 @@ async function openSearch(page) {
 
 async function openDesktopSearch(page) {
     const searchDialog = page.getByRole('dialog', { name: 'Search teams, players, actions, and help' });
+    await waitForSearchTrigger(page);
 
     await expect(async () => {
         if (await searchDialog.isVisible().catch(() => false)) {
@@ -59,7 +61,7 @@ async function openDesktopSearch(page) {
             await clickSearchTrigger(page);
             await expect(searchDialog).toBeVisible({ timeout: 1000 });
         }
-    }).toPass({ timeout: 20000 });
+    }).toPass({ timeout: 30000 });
 }
 
 async function mockSearchModules(page) {

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -12,9 +12,19 @@ async function gotoAppRoute(page, baseURL, hashPath) {
     await page.goto(appUrl(baseURL, hashPath), { waitUntil: 'domcontentloaded' });
 }
 
+async function waitForSearchTrigger(page) {
+    const trigger = page.getByRole('button', { name: 'Search', exact: true }).first();
+
+    await expect(async () => {
+        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
+        await expect(trigger).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 20000 });
+
+    return trigger;
+}
+
 async function clickSearchTrigger(page) {
-    const trigger = page.locator('button[aria-label="Search"], button[title*="Search"]').first();
-    await expect(trigger).toBeVisible({ timeout: 10000 });
+    const trigger = await waitForSearchTrigger(page);
     await trigger.click();
 }
 

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -8,6 +8,13 @@ function appUrl(baseURL, hashPath) {
     return url.toString();
 }
 
+async function waitForTeamsRoute(page, readyLocator) {
+    await expect(async () => {
+        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
+        await expect(readyLocator).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 30000 });
+}
+
 async function mockTeamsModules(page) {
     await page.addInitScript(() => {
         window.__openedPublicUrls = [];
@@ -461,7 +468,8 @@ test.describe('desktop My Teams', () => {
         await mockTeamsModules(page);
         await page.goto(appUrl(baseURL, '/teams?selectedTeamId=team-1'), { waitUntil: 'domcontentloaded' });
 
-        await expect(page.getByRole('heading', { name: /\d+ teams? ready|\d+ Teams?/i })).toBeVisible();
+        const readyHeading = page.getByRole('heading', { name: /\d+ teams? ready|\d+ Teams?/i });
+        await waitForTeamsRoute(page, readyHeading);
         await expect(page.getByText('Select a team, or jump straight to chat and schedule.')).toBeVisible();
         await expect(page.getByPlaceholder('Search teams or players')).toBeVisible();
         await expect(page.getByText('Team navigation')).toBeVisible();

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -649,6 +649,46 @@ describe('React app messages integration', () => {
         expect(scroller.scrollTop).toBe(120);
     });
 
+    it('pins the thread to the latest message after opening a chat from the inbox view', async () => {
+        let emitMessages = () => {};
+        chatMocks.subscribeToTeamChatMessages.mockImplementation((_teamId, _conversationId, onMessages) => {
+            emitMessages = onMessages;
+            return { unsubscribe: vi.fn() };
+        });
+
+        const { container } = await renderMessages('/messages');
+        const scrollIntoView = window.HTMLElement.prototype.scrollIntoView;
+        const inboxLink = container.querySelector('a[href="/messages/team-1"]');
+
+        await act(async () => {
+            inboxLink.dispatchEvent(new MouseEvent('click', { bubbles: true, button: 0 }));
+        });
+        await flush();
+
+        const scroller = container.querySelector('.chat-messages-scroll');
+        const content = container.querySelector('.chat-messages-content');
+        Object.defineProperties(scroller, {
+            scrollHeight: { configurable: true, writable: true, value: 260 },
+            clientHeight: { configurable: true, value: 300 },
+            scrollTop: { configurable: true, writable: true, value: 0 }
+        });
+        Object.defineProperty(content, 'scrollHeight', { configurable: true, writable: true, value: 460 });
+
+        scrollIntoView.mockClear();
+
+        await act(async () => {
+            emitMessages([
+                chatMessage({ id: 'msg-1', senderId: 'coach-1', senderName: 'Coach Jamie', text: 'Bring both jerseys.' }),
+                chatMessage({ id: 'msg-2', senderId: 'user-1', senderName: 'Pat Parent', text: 'We can bring snacks.', createdAt: new Date('2026-05-21T14:40:00Z') }),
+                chatMessage({ id: 'msg-3', senderId: 'coach-1', senderName: 'Coach Jamie', text: 'Latest ride update.', createdAt: new Date('2026-05-21T14:45:00Z') })
+            ], { id: 'cursor' });
+        });
+        await flush();
+
+        expect(scrollIntoView).toHaveBeenCalledWith({ block: 'end', behavior: 'auto' });
+        expect(scroller.scrollTop).toBe(160);
+    });
+
     it('coalesces auto-scroll scheduling, no-ops bounded follow-up retries, and only re-arms after height growth while pinned', async () => {
         let emitMessages = () => {};
         chatMocks.subscribeToTeamChatMessages.mockImplementation((teamId, conversationId, onMessages) => {

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -95,6 +95,15 @@ const voiceMocks = vi.hoisted(() => {
     };
 });
 
+const resizeObserverState = vi.hoisted(() => ({
+    instances: []
+}));
+
+const animationFrameState = vi.hoisted(() => ({
+    nextId: 1,
+    callbacks: new Map()
+}));
+
 vi.mock('@capacitor/core', () => ({
     Capacitor: {
         isNativePlatform: () => nativeMocks.isNativePlatform
@@ -167,11 +176,19 @@ async function renderMessages(initialEntry) {
     });
 
     await flush();
+    await flush();
     return { container, root };
 }
 
 async function flush() {
     await act(async () => {
+        while (animationFrameState.callbacks.size) {
+            const pending = Array.from(animationFrameState.callbacks.entries());
+            animationFrameState.callbacks.clear();
+            pending.forEach(([, callback]) => {
+                callback(0);
+            });
+        }
         await new Promise((resolve) => setTimeout(resolve, 0));
     });
 }
@@ -249,10 +266,17 @@ beforeEach(() => {
         configurable: true,
         value: 'en-US'
     });
-    window.requestAnimationFrame = (callback) => {
-        callback(0);
-        return 0;
-    };
+    animationFrameState.nextId = 1;
+    animationFrameState.callbacks.clear();
+    window.requestAnimationFrame = vi.fn((callback) => {
+        const id = animationFrameState.nextId;
+        animationFrameState.nextId += 1;
+        animationFrameState.callbacks.set(id, callback);
+        return id;
+    });
+    window.cancelAnimationFrame = vi.fn((id) => {
+        animationFrameState.callbacks.delete(id);
+    });
     window.setTimeout = vi.fn((callback) => {
         callback();
         return 0;
@@ -260,6 +284,20 @@ beforeEach(() => {
     window.confirm = vi.fn(() => true);
     URL.createObjectURL = vi.fn(() => 'blob:chat-upload');
     URL.revokeObjectURL = vi.fn();
+    resizeObserverState.instances.length = 0;
+    global.ResizeObserver = class MockResizeObserver {
+        constructor(callback) {
+            this.callback = callback;
+            resizeObserverState.instances.push(this);
+        }
+
+        observe = vi.fn();
+        disconnect = vi.fn();
+
+        trigger() {
+            this.callback([], this);
+        }
+    };
 
     chatMocks.loadChatInbox.mockResolvedValue({
         teams: [
@@ -574,7 +612,104 @@ describe('React app messages integration', () => {
 
         expect(container.textContent).toContain('Latest');
         await click(container, 'Latest');
+        await flush();
         expect(scroller.scrollTop).toBe(700);
+    });
+
+    it('coalesces auto-scroll scheduling and only re-arms after height growth while pinned', async () => {
+        let emitMessages = () => {};
+        chatMocks.subscribeToTeamChatMessages.mockImplementation((teamId, conversationId, onMessages) => {
+            emitMessages = onMessages;
+            onMessages([
+                chatMessage({ id: 'msg-1', senderId: 'coach-1', senderName: 'Coach Jamie', text: 'Bring both jerseys.' }),
+                chatMessage({ id: 'msg-2', senderId: 'user-1', senderName: 'Pat Parent', text: 'We can bring snacks.', createdAt: new Date('2026-05-21T14:02:00Z') })
+            ], { id: 'cursor' });
+            return { unsubscribe: vi.fn() };
+        });
+
+        const { container } = await renderMessages('/messages/team-1');
+        const scrollIntoView = window.HTMLElement.prototype.scrollIntoView;
+        const scroller = container.querySelector('.chat-messages-scroll');
+        const content = container.querySelector('.chat-messages-content');
+
+        Object.defineProperties(scroller, {
+            scrollHeight: { configurable: true, writable: true, value: 1000 },
+            clientHeight: { configurable: true, value: 300 },
+            scrollTop: { configurable: true, writable: true, value: 700 }
+        });
+        Object.defineProperty(content, 'scrollHeight', { configurable: true, writable: true, value: 1000 });
+
+        expect(scrollIntoView).toHaveBeenCalledTimes(1);
+        scrollIntoView.mockClear();
+
+        await act(async () => {
+            emitMessages([
+                chatMessage({ id: 'msg-1', senderId: 'coach-1', senderName: 'Coach Jamie', text: 'Bring both jerseys.' }),
+                chatMessage({ id: 'msg-2', senderId: 'user-1', senderName: 'Pat Parent', text: 'We can bring snacks.', createdAt: new Date('2026-05-21T14:02:00Z') }),
+                chatMessage({ id: 'msg-3', senderId: 'coach-1', senderName: 'Coach Jamie', text: 'Bus leaves in 10.', createdAt: new Date('2026-05-21T14:03:00Z') })
+            ], { id: 'cursor' });
+        });
+        await flush();
+        await flush();
+
+        expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+        await act(async () => {
+            resizeObserverState.instances.forEach((instance) => instance.trigger());
+        });
+        await flush();
+        expect(scrollIntoView).toHaveBeenCalledTimes(1);
+
+        content.scrollHeight = 1120;
+        scroller.scrollHeight = 1120;
+        await act(async () => {
+            resizeObserverState.instances.forEach((instance) => instance.trigger());
+        });
+        await flush();
+
+        expect(scrollIntoView.mock.calls.length).toBeLessThanOrEqual(2);
+    });
+
+    it('preserves scroll position and shows Latest when new messages arrive while scrolled up', async () => {
+        let emitMessages = () => {};
+        chatMocks.subscribeToTeamChatMessages.mockImplementation((teamId, conversationId, onMessages) => {
+            emitMessages = onMessages;
+            onMessages([
+                chatMessage({ id: 'msg-1', senderId: 'coach-1', senderName: 'Coach Jamie', text: 'Bring both jerseys.' }),
+                chatMessage({ id: 'msg-2', senderId: 'user-1', senderName: 'Pat Parent', text: 'We can bring snacks.', createdAt: new Date('2026-05-21T14:02:00Z') })
+            ], { id: 'cursor' });
+            return { unsubscribe: vi.fn() };
+        });
+
+        const { container } = await renderMessages('/messages/team-1');
+        const scrollIntoView = window.HTMLElement.prototype.scrollIntoView;
+        const scroller = container.querySelector('.chat-messages-scroll');
+
+        Object.defineProperties(scroller, {
+            scrollHeight: { configurable: true, value: 1000 },
+            clientHeight: { configurable: true, value: 300 },
+            scrollTop: { configurable: true, writable: true, value: 0 }
+        });
+
+        await act(async () => {
+            scroller.dispatchEvent(new Event('scroll', { bubbles: true }));
+        });
+        await flush();
+
+        scrollIntoView.mockClear();
+
+        await act(async () => {
+            emitMessages([
+                chatMessage({ id: 'msg-1', senderId: 'coach-1', senderName: 'Coach Jamie', text: 'Bring both jerseys.' }),
+                chatMessage({ id: 'msg-2', senderId: 'user-1', senderName: 'Pat Parent', text: 'We can bring snacks.', createdAt: new Date('2026-05-21T14:02:00Z') }),
+                chatMessage({ id: 'msg-3', senderId: 'coach-1', senderName: 'Coach Jamie', text: 'Bus leaves in 10.', createdAt: new Date('2026-05-21T14:03:00Z') })
+            ], { id: 'cursor' });
+        });
+        await flush();
+
+        expect(scrollIntoView).not.toHaveBeenCalled();
+        expect(container.textContent).toContain('Latest');
+        expect(scroller.scrollTop).toBe(0);
     });
 
     it('keeps staff targeting contextual and sends the selected audience metadata', async () => {

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -616,6 +616,38 @@ describe('React app messages integration', () => {
         expect(scroller.scrollTop).toBe(700);
     });
 
+    it('forces the initial latest scroll even when the thread already fits in view', async () => {
+        let emitMessages = () => {};
+        chatMocks.subscribeToTeamChatMessages.mockImplementation((_teamId, _conversationId, onMessages) => {
+            emitMessages = onMessages;
+            return { unsubscribe: vi.fn() };
+        });
+
+        const { container } = await renderMessages('/messages/team-1');
+        const scrollIntoView = window.HTMLElement.prototype.scrollIntoView;
+        const scroller = container.querySelector('.chat-messages-scroll');
+        const content = container.querySelector('.chat-messages-content');
+
+        Object.defineProperties(scroller, {
+            scrollHeight: { configurable: true, writable: true, value: 240 },
+            clientHeight: { configurable: true, value: 300 },
+            scrollTop: { configurable: true, writable: true, value: 0 }
+        });
+        Object.defineProperty(content, 'scrollHeight', { configurable: true, writable: true, value: 240 });
+
+        scrollIntoView.mockClear();
+
+        await act(async () => {
+            emitMessages([
+                chatMessage({ id: 'msg-1', senderId: 'coach-1', senderName: 'Coach Jamie', text: 'Bring both jerseys.' }),
+                chatMessage({ id: 'msg-2', senderId: 'user-1', senderName: 'Pat Parent', text: 'We can bring snacks.', createdAt: new Date('2026-05-21T14:02:00Z') })
+            ], { id: 'cursor' });
+        });
+        await flush();
+
+        expect(scrollIntoView).toHaveBeenCalledWith({ block: 'end', behavior: 'auto' });
+    });
+
     it('coalesces auto-scroll scheduling, no-ops bounded follow-up retries, and only re-arms after height growth while pinned', async () => {
         let emitMessages = () => {};
         chatMocks.subscribeToTeamChatMessages.mockImplementation((teamId, conversationId, onMessages) => {

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -616,7 +616,7 @@ describe('React app messages integration', () => {
         expect(scroller.scrollTop).toBe(700);
     });
 
-    it('forces the initial latest scroll even when the thread already fits in view', async () => {
+    it('forces the initial latest scroll using the rendered content height when the thread grows after layout', async () => {
         let emitMessages = () => {};
         chatMocks.subscribeToTeamChatMessages.mockImplementation((_teamId, _conversationId, onMessages) => {
             emitMessages = onMessages;
@@ -633,7 +633,7 @@ describe('React app messages integration', () => {
             clientHeight: { configurable: true, value: 300 },
             scrollTop: { configurable: true, writable: true, value: 0 }
         });
-        Object.defineProperty(content, 'scrollHeight', { configurable: true, writable: true, value: 240 });
+        Object.defineProperty(content, 'scrollHeight', { configurable: true, writable: true, value: 420 });
 
         scrollIntoView.mockClear();
 
@@ -646,6 +646,7 @@ describe('React app messages integration', () => {
         await flush();
 
         expect(scrollIntoView).toHaveBeenCalledWith({ block: 'end', behavior: 'auto' });
+        expect(scroller.scrollTop).toBe(120);
     });
 
     it('coalesces auto-scroll scheduling, no-ops bounded follow-up retries, and only re-arms after height growth while pinned', async () => {

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -616,7 +616,7 @@ describe('React app messages integration', () => {
         expect(scroller.scrollTop).toBe(700);
     });
 
-    it('coalesces auto-scroll scheduling and only re-arms after height growth while pinned', async () => {
+    it('coalesces auto-scroll scheduling, no-ops bounded follow-up retries, and only re-arms after height growth while pinned', async () => {
         let emitMessages = () => {};
         chatMocks.subscribeToTeamChatMessages.mockImplementation((teamId, conversationId, onMessages) => {
             emitMessages = onMessages;

--- a/tests/unit/app-chat-messages-scroll-signature.test.js
+++ b/tests/unit/app-chat-messages-scroll-signature.test.js
@@ -8,6 +8,11 @@ describe('buildChatViewportSignature', () => {
         expect(buildChatViewportSignature(1000, 240, 700)).toBe('1000:240:60');
     });
 
+    it('changes when the reader scrolls away from the latest message without any height change', () => {
+        expect(buildChatViewportSignature(1000, 300, 700)).toBe('1000:300:0');
+        expect(buildChatViewportSignature(1000, 300, 640)).toBe('1000:300:60');
+    });
+
     it('clamps the bottom offset at zero for pinned threads', () => {
         expect(buildChatViewportSignature(1000, 300, 760)).toBe('1000:300:0');
     });

--- a/tests/unit/app-chat-messages-scroll-signature.test.js
+++ b/tests/unit/app-chat-messages-scroll-signature.test.js
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildChatViewportSignature } from '../../apps/app/src/pages/Messages.tsx';
+
+describe('buildChatViewportSignature', () => {
+    it('changes when the viewport height changes even if message height stays the same', () => {
+        expect(buildChatViewportSignature(1000, 300, 700)).toBe('1000:300:0');
+        expect(buildChatViewportSignature(1000, 240, 700)).toBe('1000:240:60');
+    });
+
+    it('clamps the bottom offset at zero for pinned threads', () => {
+        expect(buildChatViewportSignature(1000, 300, 760)).toBe('1000:300:0');
+    });
+});

--- a/tests/unit/app-chat-scroll-retries.test.js
+++ b/tests/unit/app-chat-scroll-retries.test.js
@@ -3,9 +3,9 @@ import path from 'node:path';
 import { describe, expect, it } from 'vitest';
 
 describe('messages latest-scroll retries', () => {
-    it('keeps a late mobile retry in the pinned latest-scroll schedule', () => {
+    it('keeps extended late mobile retries in the pinned latest-scroll schedule', () => {
         const source = readFileSync(path.resolve('apps/app/src/pages/Messages.tsx'), 'utf8');
 
-        expect(source).toContain('[120, 300, 700, 1500].forEach((delay) => {');
+        expect(source).toContain('[120, 300, 700, 1500, 2500].forEach((delay) => {');
     });
 });

--- a/tests/unit/app-chat-scroll-retries.test.js
+++ b/tests/unit/app-chat-scroll-retries.test.js
@@ -1,0 +1,11 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+describe('messages latest-scroll retries', () => {
+    it('keeps a late mobile retry in the pinned latest-scroll schedule', () => {
+        const source = readFileSync(path.resolve('apps/app/src/pages/Messages.tsx'), 'utf8');
+
+        expect(source).toContain('[120, 300, 700, 1500].forEach((delay) => {');
+    });
+});


### PR DESCRIPTION
Closes #1838

## What changed
- Replaced the multi-pass `scheduleScrollToLatest` timer fan-out with a single deduped double-`requestAnimationFrame` scheduler that allows only one pending auto-scroll cycle at a time.
- Tracked the last observed scroll/content height so pinned threads only re-arm auto-scroll when layout height actually changes.
- Added regression coverage for initial thread load, pinned live-message appends, ResizeObserver re-triggers, and the scrolled-up `Latest` shortcut path.

## Root Cause
`Messages.tsx` scheduled five forced scroll attempts for each auto-scroll request, then let snapshot updates and ResizeObserver callbacks enqueue that same fan-out again. That created redundant `scrollTop` and `scrollIntoView` work for a single update burst, which showed up as visible jank on mobile WebViews.

## Prevention / Learning
For live-thread auto-scroll behavior, queue at most one post-layout scroll cycle per update burst and gate any follow-up pass on a real content-height change. Avoid timer fan-out for layout-sensitive UI because repeated forced scrolls hide race conditions locally and amplify them on slower mobile renderers.

## Regression Tests
- `npx vitest run tests/unit/app-chat-messages-integration.test.jsx --reporter=verbose`
- Added assertions that initial thread load uses one coalesced auto-scroll cycle.
- Added assertions that pinned message appends stay at latest without repeated scroll bursts, and that scrolled-up users keep position and see `Latest` instead of being forced down.