### PR TITLE
Add direct match report access from completed live game

### DIFF
--- a/js/live-game.js
+++ b/js/live-game.js
@@ -154,6 +154,7 @@ const els = {
   replayPlay: q('#replay-play'),
   replayGameLink: q('#replay-game-link'),
   replayReportLink: q('#replay-report-link'),
+  watchReportBtn: q('#watch-report-btn'),
   shareGameBtn: q('#share-game-btn'),
 
   notLiveOverlay: q('#not-live-overlay'),
@@ -254,7 +255,10 @@ function updateShareButton() {
   if (els.replayReportLink) {
     const reportUrl = `game.html#teamId=${state.teamId}&gameId=${state.gameId}`;
     els.replayReportLink.href = reportUrl;
-    els.replayReportLink.classList.toggle('hidden', !state.isReplay);
+    els.replayReportLink.classList.toggle('hidden', !(state.isReplay || state.game?.status === 'completed' || state.game?.liveStatus === 'completed'));
+  }
+  if (els.watchReportBtn) {
+    els.watchReportBtn.href = `game.html#teamId=${state.teamId}&gameId=${state.gameId}`;
   }
 }
 

--- a/live-game.html
+++ b/live-game.html
@@ -574,7 +574,10 @@
       <div>
         <h2 class="text-base font-bold mb-1">Game Ended</h2>
         <p id="final-score" class="text-xl text-teal font-bold mb-3">0 - 0</p>
-        <button id="watch-replay-btn" class="bg-teal text-ink px-4 py-2 rounded-lg font-medium text-sm">Watch Replay</button>
+        <div class="flex flex-wrap gap-2">
+          <button id="watch-replay-btn" class="bg-teal text-ink px-4 py-2 rounded-lg font-medium text-sm">Watch Replay</button>
+          <a id="watch-report-btn" href="#" class="inline-flex items-center rounded-lg border border-teal/30 px-4 py-2 text-sm font-medium text-teal hover:bg-ink/80">Match Report</a>
+        </div>
       </div>
     </div>
   </div>

--- a/tests/unit/live-game-completed-report-link.test.js
+++ b/tests/unit/live-game-completed-report-link.test.js
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readRepoFile(relativePath) {
+    return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+describe('live game completed-state match report path', () => {
+    it('keeps a direct match report action on the completed live page', () => {
+        const html = readRepoFile('live-game.html');
+        const js = readRepoFile('js/live-game.js');
+
+        expect(html).toContain('id="watch-report-btn"');
+        expect(html).toContain('Match Report');
+        expect(js).toContain("watchReportBtn: q('#watch-report-btn')");
+        expect(js).toContain('els.watchReportBtn.href = `game.html#teamId=${state.teamId}&gameId=${state.gameId}`;');
+        expect(js).toContain("els.replayReportLink.classList.toggle('hidden', !(state.isReplay || state.game?.status === 'completed' || state.game?.liveStatus === 'completed'));");
+    });
+});


### PR DESCRIPTION
Closes #1856

## What changed
- added a direct `Match Report` action to the completed live-game overlay so users can jump straight to the report after the final score
- updated the existing header `Match Report` link to stay visible on completed live-game pages, not just in replay mode
- added a focused regression test that checks the completed-state UI wiring for the direct report path

## Root Cause
The live-game page treated report access as a replay-only affordance. `updateShareButton()` hid `replay-report-link` unless `state.isReplay` was true, and the completed-game overlay only rendered a `Watch Replay` CTA. That left completed live viewers with no direct route to `game.html`.

## Prevention / Learning
For end-state workflow handoffs, do not gate destination links behind an intermediate mode unless the product explicitly requires it. When a workflow promises multiple post-game paths, completed-state overlays and persistent header actions should both expose them directly.

## Regression Tests
- `npx vitest run tests/unit/live-game-completed-report-link.test.js tests/unit/live-game-replay-init.test.js --reporter=verbose`
- added `tests/unit/live-game-completed-report-link.test.js` to assert the completed overlay and completed-page visibility logic both preserve a direct match report path