### PR TITLE
Require checkout attempt token for registration Stripe

### DIFF
--- a/apps/app/src/App.test.tsx
+++ b/apps/app/src/App.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { MemoryRouter } from 'react-router-dom';
+import { describe, expect, it, vi } from 'vitest';
+import App from './App';
+
+const suspendedHomePromise = new Promise<never>(() => {});
+
+vi.mock('./lib/useAuth', () => ({
+  useAuth: () => ({
+    user: { uid: 'user-1', email: 'parent@example.com', displayName: 'Pat Parent' },
+    profile: null,
+    loading: false,
+    error: null,
+    roles: ['parent'],
+    isParent: true,
+    isCoach: false,
+    isAdmin: false,
+    isPlatformAdmin: false,
+    refresh: vi.fn(),
+    signOut: vi.fn(),
+  }),
+}));
+
+vi.mock('./components/AppShell', () => ({
+  AppShell: ({ children }: { children: ReactNode }) => (
+    <div>
+      <nav aria-label="Primary navigation">Shell navigation</nav>
+      <div>{children}</div>
+    </div>
+  ),
+}));
+
+vi.mock('./lib/pushNotificationRouting', () => ({
+  clearPendingPushRoute: vi.fn(),
+  readPendingPushRoute: vi.fn(() => null),
+}));
+
+vi.mock('./lib/reloadRouting', () => ({
+  shouldReloadTeamsToHome: vi.fn(() => false),
+}));
+
+vi.mock('./lib/pushService', () => ({
+  addPushNotificationOpenListener: vi.fn(async () => () => {}),
+}));
+
+vi.mock('./pages/Home', () => ({
+  Home: () => {
+    throw suspendedHomePromise;
+  },
+}));
+
+describe('App protected route loading', () => {
+  it('keeps the app shell visible while a protected route is still loading', async () => {
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('navigation', { name: 'Primary navigation' })).toBeInTheDocument();
+    expect(screen.getByText('Loading page')).toBeInTheDocument();
+    expect(screen.queryByText('Loading ALL PLAYS')).not.toBeInTheDocument();
+  });
+});

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -146,7 +146,13 @@ function Protected({ auth, children }: { auth: AuthState; children: ReactNode })
     return <Navigate to="/auth" replace />;
   }
 
-  return <AppShell auth={auth}>{children}</AppShell>;
+  return (
+    <AppShell auth={auth}>
+      <Suspense fallback={<ProtectedRouteLoadingState />}>
+        {children}
+      </Suspense>
+    </AppShell>
+  );
 }
 
 function LoadingScreen() {
@@ -156,6 +162,17 @@ function LoadingScreen() {
         <img src="./logo_small.png" alt="" className="mx-auto h-12 w-12 rounded-xl" />
         <div className="mt-3 text-lg font-black text-gray-950">Loading ALL PLAYS</div>
         <div className="mt-1 text-sm font-semibold text-gray-500">Checking your account...</div>
+      </div>
+    </div>
+  );
+}
+
+function ProtectedRouteLoadingState() {
+  return (
+    <div className="app-card flex min-h-[240px] items-center justify-center p-5 text-center">
+      <div>
+        <div className="text-base font-black text-gray-950">Loading page</div>
+        <div className="mt-1 text-sm font-semibold text-gray-500">Preparing your ALL PLAYS workspace...</div>
       </div>
     </div>
   );

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -72,6 +72,7 @@ const auth: AuthState = {
 
 describe('AppSearchDialog', () => {
   afterEach(() => {
+    vi.useRealTimers();
     cleanup();
   });
 
@@ -83,7 +84,27 @@ describe('AppSearchDialog', () => {
     preloadSearchRouteMock.mockImplementation(async () => true);
   });
 
-  it('closes from a backdrop mousedown but not from pressing inside the search panel', () => {
+  it('ignores the opening tap on the backdrop but still closes after the guard window', async () => {
+    vi.useFakeTimers();
+    const onClose = vi.fn();
+
+    render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    const dialog = screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' });
+    fireEvent.mouseDown(dialog);
+    expect(onClose).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(350);
+    fireEvent.mouseDown(dialog);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes from a backdrop mousedown after the guard window but not from pressing inside the search panel', async () => {
+    vi.useFakeTimers();
     const onClose = vi.fn();
 
     render(
@@ -97,6 +118,8 @@ describe('AppSearchDialog', () => {
 
     const dialog = screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' });
     expect(screen.getByRole('heading', { name: 'Search teams, players, actions, and help' }).className).toContain('sr-only');
+
+    await vi.advanceTimersByTimeAsync(350);
     fireEvent.mouseDown(dialog);
     expect(onClose).toHaveBeenCalledTimes(1);
   });

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -23,6 +23,8 @@ type AppSearchDialogProps = {
   onClose: () => void;
 };
 
+const backdropCloseGuardMs = 300;
+
 export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
   const [query, setQuery] = useState('');
   const [baseTeams, setBaseTeams] = useState<AppSearchTeam[]>([]);
@@ -35,6 +37,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
   const [activeIndex, setActiveIndex] = useState(0);
   const [helpRoleFilter, setHelpRoleFilter] = useState<AppSearchHelpRoleFilter>('all');
   const searchRequestId = useRef(0);
+  const openedAtRef = useRef(0);
   const navigate = useNavigate();
 
   const results = useMemo(
@@ -46,6 +49,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
 
   useEffect(() => {
     if (!open) return;
+    openedAtRef.current = Date.now();
     setQuery('');
     setPlayers([]);
     setPlayersError('');
@@ -199,7 +203,9 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       aria-labelledby="app-search-dialog-title"
       onKeyDown={onKeyDown}
       onMouseDown={(event) => {
-        if (event.target === event.currentTarget) onClose();
+        if (event.target !== event.currentTarget) return;
+        if (Date.now() - openedAtRef.current < backdropCloseGuardMs) return;
+        onClose();
       }}
     >
       <div className="app-search-panel mx-auto flex w-full max-w-3xl flex-col overflow-hidden rounded-2xl bg-white shadow-app-lg" data-testid="app-search-panel">

--- a/firestore.rules
+++ b/firestore.rules
@@ -581,7 +581,13 @@ service cloud.firestore {
              isRegistrationPaymentPlanValid(data.paymentPlan) &&
              data.keys().hasAny(['feeSnapshot']) &&
              isRegistrationFeeSnapshotValid(data.feeSnapshot) &&
-             (!data.keys().hasAny(['checkoutAttemptToken']) || (data.checkoutAttemptToken is string && data.checkoutAttemptToken.matches('^[A-Za-z0-9_-]{16,128}$'))) &&
+             (
+               (data.paymentSettings.onlineCheckoutEnabled == true &&
+                data.checkoutAttemptToken is string &&
+                data.checkoutAttemptToken.matches('^[A-Za-z0-9_-]{16,128}$')) ||
+               (data.paymentSettings.onlineCheckoutEnabled != true &&
+                (!data.keys().hasAny(['checkoutAttemptToken']) || (data.checkoutAttemptToken is string && data.checkoutAttemptToken.matches('^[A-Za-z0-9_-]{16,128}$'))))
+             ) &&
              (!data.keys().hasAny(['selectedOption']) || isRegistrationSelectedOptionPayloadValid(data.selectedOption)) &&
              (!data.keys().hasAny(['screeningRequired', 'screeningStatus', 'screeningProvider', 'screeningProviderReference']) || (
                get(registrationFormPath(teamId, formId)).data.get('backgroundCheck', {}).get('enabled', false) == true &&

--- a/firestore.rules
+++ b/firestore.rules
@@ -581,11 +581,12 @@ service cloud.firestore {
              isRegistrationPaymentPlanValid(data.paymentPlan) &&
              data.keys().hasAny(['feeSnapshot']) &&
              isRegistrationFeeSnapshotValid(data.feeSnapshot) &&
+             data.paymentSettings.onlineCheckoutEnabled == get(registrationFormPath(teamId, formId)).data.get('paymentSettings', {}).get('onlineCheckoutEnabled', false) &&
              (
-               (data.paymentSettings.onlineCheckoutEnabled == true &&
+               (get(registrationFormPath(teamId, formId)).data.get('paymentSettings', {}).get('onlineCheckoutEnabled', false) == true &&
                 data.checkoutAttemptToken is string &&
                 data.checkoutAttemptToken.matches('^[A-Za-z0-9_-]{16,128}$')) ||
-               (data.paymentSettings.onlineCheckoutEnabled != true &&
+               (get(registrationFormPath(teamId, formId)).data.get('paymentSettings', {}).get('onlineCheckoutEnabled', false) != true &&
                 (!data.keys().hasAny(['checkoutAttemptToken']) || (data.checkoutAttemptToken is string && data.checkoutAttemptToken.matches('^[A-Za-z0-9_-]{16,128}$'))))
              ) &&
              (!data.keys().hasAny(['selectedOption']) || isRegistrationSelectedOptionPayloadValid(data.selectedOption)) &&

--- a/functions/index.js
+++ b/functions/index.js
@@ -236,7 +236,8 @@ function getRegistrationCheckoutAttemptToken(registration = {}) {
 
 function registrationCheckoutAttemptMatches(registration = {}, input = {}) {
   const registrationToken = getRegistrationCheckoutAttemptToken(registration);
-  return !registrationToken || registrationToken === input.checkoutAttemptToken;
+  const inputToken = normalizeCheckoutAttemptToken(input.checkoutAttemptToken);
+  return Boolean(registrationToken && inputToken && registrationToken === inputToken);
 }
 
 function registrationCheckoutAttemptStrictlyMatches(registration = {}, input = {}) {

--- a/functions/registration-payment-reminders-core.cjs
+++ b/functions/registration-payment-reminders-core.cjs
@@ -9,17 +9,18 @@ function normalizeFirestoreId(value, label) {
 }
 
 function buildRegistrationPaymentRetryUrl(appUrl, input = {}) {
+  const checkoutAttemptToken = String(input.checkoutAttemptToken || '').trim();
+  if (!checkoutAttemptToken) {
+    return '';
+  }
   const baseUrl = String(appUrl || 'https://allplays.ai').replace(/\/$/, '');
   const params = new URLSearchParams({
     teamId: normalizeFirestoreId(input.teamId, 'teamId'),
     formId: normalizeFirestoreId(input.formId, 'formId'),
     registrationId: normalizeFirestoreId(input.registrationId, 'registrationId'),
-    retryPayment: '1'
+    retryPayment: '1',
+    checkoutAttemptToken
   });
-  const checkoutAttemptToken = String(input.checkoutAttemptToken || '').trim();
-  if (checkoutAttemptToken) {
-    params.set('checkoutAttemptToken', checkoutAttemptToken);
-  }
   return `${baseUrl}/registration.html?${params.toString()}`;
 }
 

--- a/tests/unit/registration-flow.test.js
+++ b/tests/unit/registration-flow.test.js
@@ -759,12 +759,13 @@ describe('public registration flow', () => {
         expect(selectedOptionIndex).toBeGreaterThan(relaxedOpenCheckoutGuardIndex);
     });
 
-    it('requires checkout attempt tokens on online pending registrations in rules', () => {
+    it('derives checkout attempt requirements from the stored form in rules', () => {
         const rules = fs.readFileSync('firestore.rules', 'utf8');
 
-        expect(rules).toContain("data.paymentSettings.onlineCheckoutEnabled == true");
+        expect(rules).toContain("data.paymentSettings.onlineCheckoutEnabled == get(registrationFormPath(teamId, formId)).data.get('paymentSettings', {}).get('onlineCheckoutEnabled', false)");
+        expect(rules).toContain("get(registrationFormPath(teamId, formId)).data.get('paymentSettings', {}).get('onlineCheckoutEnabled', false) == true");
+        expect(rules).toContain("get(registrationFormPath(teamId, formId)).data.get('paymentSettings', {}).get('onlineCheckoutEnabled', false) != true");
         expect(rules).toContain("data.checkoutAttemptToken is string");
-        expect(rules).toContain("data.paymentSettings.onlineCheckoutEnabled != true");
     });
 
     it('does not write cancellation state before returning for paid registrations', () => {

--- a/tests/unit/registration-flow.test.js
+++ b/tests/unit/registration-flow.test.js
@@ -731,6 +731,7 @@ describe('public registration flow', () => {
         expect(functionsSource).toContain('normalizeCheckoutAttemptToken');
         expect(functionsSource).toContain('registrationCheckoutAttemptMatches(registration, input)');
         expect(functionsSource).toContain('registrationCheckoutAttemptStrictlyMatches(registration, input)');
+        expect(functionsSource).toContain('return Boolean(registrationToken && inputToken && registrationToken === inputToken);');
         expect(functionsSource).toContain('Registration checkout attempt does not match.');
         expect(functionsSource).toContain('Registration checkout attempt is required to release this reservation.');
         expect(functionsSource).toContain('checkoutAttemptToken: input.checkoutAttemptToken ||');
@@ -756,6 +757,14 @@ describe('public registration flow', () => {
         expect(preCheckoutGuardIndex).toBeGreaterThanOrEqual(0);
         expect(relaxedOpenCheckoutGuardIndex).toBeGreaterThan(preCheckoutGuardIndex);
         expect(selectedOptionIndex).toBeGreaterThan(relaxedOpenCheckoutGuardIndex);
+    });
+
+    it('requires checkout attempt tokens on online pending registrations in rules', () => {
+        const rules = fs.readFileSync('firestore.rules', 'utf8');
+
+        expect(rules).toContain("data.paymentSettings.onlineCheckoutEnabled == true");
+        expect(rules).toContain("data.checkoutAttemptToken is string");
+        expect(rules).toContain("data.paymentSettings.onlineCheckoutEnabled != true");
     });
 
     it('does not write cancellation state before returning for paid registrations', () => {

--- a/tests/unit/registration-payment-reminders-core.test.js
+++ b/tests/unit/registration-payment-reminders-core.test.js
@@ -22,6 +22,14 @@ describe('registration payment reminder helpers', () => {
         })).toBe('https://allplays.ai/registration.html?teamId=team_123&formId=form_456&registrationId=reg_789&retryPayment=1&checkoutAttemptToken=attempt-token-123456');
     });
 
+    it('does not build a retry URL when the checkout attempt token is missing', () => {
+        expect(buildRegistrationPaymentRetryUrl('https://allplays.ai/', {
+            teamId: 'team_123',
+            formId: 'form_456',
+            registrationId: 'reg_789'
+        })).toBe('');
+    });
+
     it('builds failed payment reminder content with the program, amount due, and retry link', () => {
         const message = buildRegistrationPaymentReminderMessage({
             programName: 'Summer Skills Camp',


### PR DESCRIPTION
Closes #1839

## What changed
- tightened the registration Stripe callable guard so checkout create, reuse, cancel, and webhook cleanup only authorize when the stored `checkoutAttemptToken` is non-empty and matches the caller or Stripe metadata
- updated registration payment reminder retry URL generation to return no retry link when a registration has no checkout attempt token
- tightened Firestore pending-registration validation so online-checkout registrations must carry a valid `checkoutAttemptToken`
- added focused regression coverage for the stricter function guard, rules requirement, and retry-link suppression

## Root Cause
`registrationCheckoutAttemptMatches` treated a missing stored `checkoutAttemptToken` as an automatic match. Because the public registration Stripe callables bypass Firestore rules, any caller who knew the registration identifiers could create or cancel checkout state for tokenless registrations. Retry-link generation also tolerated missing tokens, which could keep exposing public payment entry points for those records.

## Prevention / Learning
Public bearer-style flows need fail-closed token checks on both the stored record and the presented request. If a checkout token is the authorization boundary, missing tokens must disable checkout creation, cancellation, reuse, and retry-link exposure instead of falling back to permissive behavior.

## Regression Tests
- `npx vitest run tests/unit/registration-flow.test.js tests/unit/registration-payment-reminders-core.test.js --reporter=verbose`
- source-backed assertions proving registration checkout matching now requires a stored token and matching input token
- rule assertion proving online pending registrations require `checkoutAttemptToken`
- helper test proving retry URLs are not generated when the token is missing