### PR TITLE
Fix team ICS practice event summaries

### DIFF
--- a/team.html
+++ b/team.html
@@ -2936,6 +2936,14 @@
             button.hidden = !canExposePublicFanFeed(team, games);
         }
 
+        function escapeIcsText(value) {
+            return String(value || '')
+                .replace(/\\/g, '\\\\')
+                .replace(/;/g, '\\;')
+                .replace(/,/g, '\\,')
+                .replace(/\r?\n/g, '\\n');
+        }
+
         function getIcsEventSummary(event, teamName) {
             const isPractice = event?.type === 'practice' || event?.isPractice;
             if (isPractice) {
@@ -2961,9 +2969,9 @@
                     `DTSTAMP:${formatIcsDate(new Date())}`,
                     `DTSTART:${start}`,
                     `DTEND:${end}`,
-                    `SUMMARY:${summary}`,
-                    `LOCATION:${(game.location || 'TBD').replace(/,/g, '\\,')}`,
-                    `DESCRIPTION:Status: ${game.status || 'scheduled'}`,
+                    `SUMMARY:${escapeIcsText(summary)}`,
+                    `LOCATION:${escapeIcsText(game.location || 'TBD')}`,
+                    `DESCRIPTION:${escapeIcsText(`Status: ${game.status || 'scheduled'}`)}`,
                     'END:VEVENT'
                 );
             });

--- a/team.html
+++ b/team.html
@@ -2936,6 +2936,14 @@
             button.hidden = !canExposePublicFanFeed(team, games);
         }
 
+        function getIcsEventSummary(event, teamName) {
+            const isPractice = event?.type === 'practice' || event?.isPractice;
+            if (isPractice) {
+                return event.title?.trim() || 'Practice';
+            }
+            return `${teamName} vs ${event.opponent || 'TBD'}`;
+        }
+
         function buildIcs(games) {
             const teamName = currentTeam?.name || 'Team';
             const lines = ['BEGIN:VCALENDAR', 'VERSION:2.0', 'PRODID:-//ALL PLAYS//EN'];
@@ -2945,7 +2953,7 @@
                 const start = formatIcsDate(date);
                 const endDate = new Date(date.getTime() + 60 * 60 * 1000); // default 1 hour
                 const end = formatIcsDate(endDate);
-                const summary = `${teamName} vs ${game.opponent || 'TBD'}`;
+                const summary = getIcsEventSummary(game, teamName);
                 const uid = `${game.id || summary}-${currentTeamId}@gameflow`;
                 lines.push(
                     'BEGIN:VEVENT',

--- a/tests/unit/team-ics-export.test.js
+++ b/tests/unit/team-ics-export.test.js
@@ -29,6 +29,7 @@ function extractFunction(source, name) {
 function createTeamIcsHooks() {
     const source = readTeamPageSource();
     const formatIcsDateSource = extractFunction(source, 'formatIcsDate');
+    const escapeIcsTextSource = extractFunction(source, 'escapeIcsText');
     const getIcsEventSummarySource = extractFunction(source, 'getIcsEventSummary');
     const buildIcsSource = extractFunction(source, 'buildIcs');
 
@@ -36,9 +37,10 @@ function createTeamIcsHooks() {
 let currentTeam = { name: 'Wildcats' };
 let currentTeamId = 'team-1';
 ${formatIcsDateSource}
+${escapeIcsTextSource}
 ${getIcsEventSummarySource}
 ${buildIcsSource}
-return { buildIcs, getIcsEventSummary };
+return { buildIcs, getIcsEventSummary, escapeIcsText };
 `)();
 }
 
@@ -70,5 +72,25 @@ describe('team ICS export', () => {
         expect(ics).toContain('SUMMARY:Pitching practice');
         expect(ics).not.toContain('SUMMARY:Wildcats vs TBD');
         expect(ics).toContain('SUMMARY:Wildcats vs Lions');
+    });
+
+    it('escapes ICS control characters in practice titles', () => {
+        const { buildIcs, escapeIcsText } = createTeamIcsHooks();
+        const title = 'Pitching\\Practice;Plan, A\nLOCATION:Injected';
+        const ics = buildIcs([
+            {
+                id: 'practice-2',
+                type: 'practice',
+                title,
+                opponent: null,
+                date: new Date('2026-06-12T18:00:00Z'),
+                location: 'Main Field',
+                status: 'scheduled'
+            }
+        ]);
+
+        expect(escapeIcsText(title)).toBe('Pitching\\\\Practice\\;Plan\\, A\\nLOCATION:Injected');
+        expect(ics).toContain('SUMMARY:Pitching\\\\Practice\\;Plan\\, A\\nLOCATION:Injected');
+        expect(ics).not.toContain('\r\nLOCATION:Injected\r\nLOCATION:Main Field');
     });
 });

--- a/tests/unit/team-ics-export.test.js
+++ b/tests/unit/team-ics-export.test.js
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+function readTeamPageSource() {
+    return readFileSync(new URL('../../team.html', import.meta.url), 'utf8');
+}
+
+function extractFunction(source, name) {
+    const start = source.indexOf(`function ${name}`);
+    if (start === -1) {
+        throw new Error(`Function ${name} not found`);
+    }
+
+    const bodyStart = source.indexOf('{', start);
+    let depth = 0;
+
+    for (let index = bodyStart; index < source.length; index += 1) {
+        const char = source[index];
+        if (char === '{') depth += 1;
+        if (char === '}') depth -= 1;
+        if (depth === 0) {
+            return source.slice(start, index + 1);
+        }
+    }
+
+    throw new Error(`Function ${name} did not terminate`);
+}
+
+function createTeamIcsHooks() {
+    const source = readTeamPageSource();
+    const formatIcsDateSource = extractFunction(source, 'formatIcsDate');
+    const getIcsEventSummarySource = extractFunction(source, 'getIcsEventSummary');
+    const buildIcsSource = extractFunction(source, 'buildIcs');
+
+    return new Function(`
+let currentTeam = { name: 'Wildcats' };
+let currentTeamId = 'team-1';
+${formatIcsDateSource}
+${getIcsEventSummarySource}
+${buildIcsSource}
+return { buildIcs, getIcsEventSummary };
+`)();
+}
+
+describe('team ICS export', () => {
+    it('preserves practice titles instead of exporting practice events as games', () => {
+        const { buildIcs, getIcsEventSummary } = createTeamIcsHooks();
+        const ics = buildIcs([
+            {
+                id: 'practice-1',
+                type: 'practice',
+                title: 'Pitching practice',
+                opponent: null,
+                date: new Date('2026-06-10T18:00:00Z'),
+                location: 'Main Field',
+                status: 'scheduled'
+            },
+            {
+                id: 'game-1',
+                type: 'game',
+                opponent: 'Lions',
+                date: new Date('2026-06-11T18:00:00Z'),
+                location: 'North Field',
+                status: 'scheduled'
+            }
+        ]);
+
+        expect(getIcsEventSummary({ type: 'practice', title: 'Pitching practice' }, 'Wildcats')).toBe('Pitching practice');
+        expect(getIcsEventSummary({ type: 'practice', title: '   ' }, 'Wildcats')).toBe('Practice');
+        expect(ics).toContain('SUMMARY:Pitching practice');
+        expect(ics).not.toContain('SUMMARY:Wildcats vs TBD');
+        expect(ics).toContain('SUMMARY:Wildcats vs Lions');
+    });
+});


### PR DESCRIPTION
Closes #1863

## What changed
- added a small `getIcsEventSummary` helper in `team.html` so practice events export their saved practice title, with a `Practice` fallback
- kept game exports on the existing `${teamName} vs ${opponent}` format
- added a focused unit regression test that extracts the team-page ICS helpers and verifies practice and game summaries both serialize correctly

## Root Cause
The team page ICS export reused `getGames(teamId)` for a mixed list of games and practices, but `buildIcs()` assumed every event was a game and always formatted `SUMMARY` as `${teamName} vs ${game.opponent || 'TBD'}`. Practices store `type: 'practice'` and `title`, so they were mislabeled as game-style `vs TBD` entries.

## Prevention / Learning
When schedule exports consume mixed event collections, summary generation must branch on event type instead of assuming one canonical shape. For legacy inline page helpers, add a focused extraction-based unit test around the serialized output whenever calendar text is type-dependent.

## Regression Tests
- `npx vitest run tests/unit/team-ics-export.test.js --reporter=verbose`
- verifies practice events export `SUMMARY:Pitching practice`
- verifies blank practice titles fall back to `SUMMARY:Practice`
- verifies game events still export `SUMMARY:Wildcats vs Lions`