### PR TITLE
Centralize parent schedule watch CTA eligibility

### DIFF
--- a/family.html
+++ b/family.html
@@ -467,6 +467,7 @@
                 childName: child.playerName,
                 title: game.title || null,
                 status: game.status || 'scheduled',
+                liveStatus: game.liveStatus || null,
                 isCancelled,
                 isHome: game.isHome ?? null,
                 kitColor: game.kitColor || null,

--- a/family.html
+++ b/family.html
@@ -175,6 +175,7 @@
   <script type="module">
     import { getFamilyShareToken, getTeam, getGames, getTrackedCalendarEventUids } from './js/db.js?v=40';
     import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence, getCalendarEventTrackingId, isTrackedCalendarEvent } from './js/utils.js?v=11';
+    import { resolveScheduleWatchCta } from './js/schedule-watch-cta.js?v=1';
 
     renderFooter(document.getElementById('footer-container'));
 
@@ -821,6 +822,7 @@
     function renderDayModalEvent(ev) {
       const timeStr = ev.date.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
       const title = ev.type === 'practice' ? (ev.title || 'Practice') : `vs. ${ev.opponent || 'TBD'}`;
+      const watchCta = resolveScheduleWatchCta(ev);
       return `
         <div class="mb-4 p-4 rounded-lg border border-gray-200 ${ev.isCancelled ? 'opacity-60' : ''}">
           <div class="text-xs font-semibold uppercase ${ev.type === 'practice' ? 'text-amber-700' : 'text-primary-700'}">${ev.type}</div>
@@ -834,6 +836,16 @@
           ${ev.childNames?.length ? `<div class="text-xs text-gray-500 mt-1">For ${escapeHtml(ev.childNames.join(', '))}</div>` : ''}
           ${!ev.isCancelled && ev.isDbGame && ev.type === 'game' ? `
             <div class="mt-3">
+              ${watchCta ? `
+              <a href="${watchCta.href}"
+                 class="inline-flex items-center gap-1 text-sm font-semibold ${watchCta.kind === 'live' ? 'text-red-600 hover:text-red-700' : 'text-teal-600 hover:text-teal-700'} mr-3">
+                ${watchCta.label}
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path>
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                </svg>
+              </a>
+              ` : ''}
               <a href="game.html?teamId=${escapeAttr(ev.teamId)}&gameId=${escapeAttr(ev.id)}"
                  class="inline-flex items-center gap-1 text-sm font-semibold text-primary-600 hover:text-primary-700">
                 View Game Details
@@ -890,6 +902,7 @@
         const typeColor = game.type === 'practice' ? 'bg-amber-100 text-amber-800' : 'bg-primary-100 text-primary-800';
         const isCancelled = game.isCancelled;
         const childLabel = game.childNames.join(', ') || game.childName || 'Player';
+        const watchCta = resolveScheduleWatchCta(game);
         return `
           <div class="p-6 hover:bg-gray-50 transition flex flex-col sm:flex-row gap-4 sm:items-start ${isCancelled ? 'opacity-60' : ''}">
             <div class="flex-shrink-0 w-24 text-center sm:text-left">
@@ -921,6 +934,16 @@
             </div>
             ${!isCancelled && game.isDbGame && game.type === 'game' ? `
               <div class="flex-shrink-0">
+                ${watchCta ? `
+                <a href="${watchCta.href}"
+                   class="inline-flex items-center gap-1 text-sm font-semibold ${watchCta.kind === 'live' ? 'text-red-600 hover:text-red-700' : 'text-teal-600 hover:text-teal-700'} mr-3">
+                  ${watchCta.label}
+                  <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path>
+                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                  </svg>
+                </a>
+                ` : ''}
                 <a href="game.html?teamId=${escapeAttr(game.teamId)}&gameId=${escapeAttr(game.id)}"
                    class="inline-flex items-center gap-1 text-sm font-medium text-primary-600 hover:text-primary-700">
                   View

--- a/js/schedule-watch-cta.js
+++ b/js/schedule-watch-cta.js
@@ -1,0 +1,43 @@
+function normalizeStatus(value) {
+    return String(value || '').trim().toLowerCase();
+}
+
+function isPrivateGame(game) {
+    return game?.isPrivate === true || normalizeStatus(game?.visibility) === 'private';
+}
+
+function isDeletedGame(game) {
+    return normalizeStatus(game?.status) === 'deleted' || normalizeStatus(game?.liveStatus) === 'deleted';
+}
+
+function isCancelledGame(game) {
+    return game?.isCancelled === true || normalizeStatus(game?.status) === 'cancelled';
+}
+
+export function resolveScheduleWatchCta(game) {
+    if (!game || normalizeStatus(game.type) === 'practice') return null;
+    if (isCancelledGame(game) || isDeletedGame(game) || isPrivateGame(game)) return null;
+
+    const teamId = String(game.teamId || '').trim();
+    const gameId = String(game.gameId || game.id || '').trim();
+    if (!teamId || !gameId) return null;
+
+    const liveStatus = normalizeStatus(game.liveStatus);
+    if (liveStatus === 'completed') {
+        return {
+            kind: 'replay',
+            label: 'Watch Replay',
+            href: `live-game.html?teamId=${encodeURIComponent(teamId)}&gameId=${encodeURIComponent(gameId)}&replay=true`
+        };
+    }
+
+    if (liveStatus === 'live') {
+        return {
+            kind: 'live',
+            label: 'Watch Live',
+            href: `live-game.html?teamId=${encodeURIComponent(teamId)}&gameId=${encodeURIComponent(gameId)}`
+        };
+    }
+
+    return null;
+}

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -1877,6 +1877,7 @@
                                 childName: child.playerName,
                                 title: game.title || null,
                                 status: game.status || 'scheduled',
+                                liveStatus: game.liveStatus || null,
                                 isCancelled,
                                 isHome: game.isHome ?? null,
                                 kitColor: game.kitColor || null,

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -408,6 +408,7 @@
             saveCapSetting as saveCapSettingFn,
         } from './js/parent-incentives.js?v=3';
         import { requireAuth, checkAuth } from './js/auth.js?v=19';
+        import { resolveScheduleWatchCta } from './js/schedule-watch-cta.js?v=1';
         import {
             resolvePracticePacketSessionIdForEvent as resolvePracticePacketSessionIdForEventBase,
             resolvePracticePacketContextForEvent as resolvePracticePacketContextForEventBase,
@@ -2725,6 +2726,7 @@
                     ? attendance.players.filter(p => p.status === 'absent').length
                     : 0;
                 const rosterSize = attendanceRecorded ? attendance.players.length : 0;
+                const watchCta = resolveScheduleWatchCta(game);
 
                 return `
                 <div class="p-6 hover:bg-gray-50 transition flex flex-col sm:flex-row gap-4 sm:items-center ${isCancelled ? 'opacity-60' : ''}">
@@ -2811,6 +2813,16 @@
                     ${renderEventRideshare(game)}
                     ${!isCancelled && game.isDbGame ? `
                     <div class="flex-shrink-0 text-right">
+                         ${watchCta ? `
+                         <a href="${watchCta.href}"
+                            class="inline-flex items-center gap-1 text-sm font-semibold ${watchCta.kind === 'live' ? 'text-red-600 hover:text-red-700' : 'text-teal-600 hover:text-teal-700'} mb-2">
+                             ${watchCta.label}
+                             <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M14.752 11.168l-3.197-2.132A1 1 0 0010 9.87v4.263a1 1 0 001.555.832l3.197-2.132a1 1 0 000-1.664z"></path>
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M21 12a9 9 0 11-18 0 9 9 0 0118 0z"></path>
+                            </svg>
+                         </a><br>
+                         ` : ''}
                          <a href="game.html?teamId=${game.teamId}&gameId=${game.id}"
                             class="inline-flex items-center gap-1 text-sm font-medium text-primary-600 hover:text-primary-700">
                              View Details

--- a/tests/unit/schedule-watch-cta.test.js
+++ b/tests/unit/schedule-watch-cta.test.js
@@ -56,11 +56,13 @@ describe('schedule watch CTA resolver', () => {
 
         expect(parentDashboard).toContain("import { resolveScheduleWatchCta } from './js/schedule-watch-cta.js?v=1';");
         expect(parentDashboard).toContain('const watchCta = resolveScheduleWatchCta(game);');
+        expect(parentDashboard).toContain('liveStatus: game.liveStatus || null,');
         expect(parentDashboard).toContain('View Details');
 
         expect(familyPage).toContain("import { resolveScheduleWatchCta } from './js/schedule-watch-cta.js?v=1';");
         expect(familyPage).toContain('const watchCta = resolveScheduleWatchCta(ev);');
         expect(familyPage).toContain('const watchCta = resolveScheduleWatchCta(game);');
+        expect(familyPage).toContain('liveStatus: game.liveStatus || null,');
         expect(familyPage).toContain('View Game Details');
         expect(familyPage).toContain('>\n                  View\n');
     });

--- a/tests/unit/schedule-watch-cta.test.js
+++ b/tests/unit/schedule-watch-cta.test.js
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolveScheduleWatchCta } from '../../js/schedule-watch-cta.js';
+
+function readRepoFile(relativePath) {
+    return readFileSync(new URL(`../../${relativePath}`, import.meta.url), 'utf8');
+}
+
+function game(overrides = {}) {
+    return {
+        id: 'game-1',
+        teamId: 'team-1',
+        type: 'game',
+        status: 'scheduled',
+        liveStatus: 'scheduled',
+        visibility: 'public',
+        isPrivate: false,
+        isCancelled: false,
+        ...overrides
+    };
+}
+
+describe('schedule watch CTA resolver', () => {
+    it('returns a live CTA for active public games', () => {
+        expect(resolveScheduleWatchCta(game({ liveStatus: 'live' }))).toEqual({
+            kind: 'live',
+            label: 'Watch Live',
+            href: 'live-game.html?teamId=team-1&gameId=game-1'
+        });
+    });
+
+    it('returns a replay CTA for completed live games', () => {
+        expect(resolveScheduleWatchCta(game({ status: 'completed', liveStatus: 'completed' }))).toEqual({
+            kind: 'replay',
+            label: 'Watch Replay',
+            href: 'live-game.html?teamId=team-1&gameId=game-1&replay=true'
+        });
+    });
+
+    it('suppresses CTAs for practices, cancelled/deleted/private games, scheduled games, and records without viewer routes', () => {
+        expect(resolveScheduleWatchCta(game({ type: 'practice', liveStatus: 'live' }))).toBeNull();
+        expect(resolveScheduleWatchCta(game({ status: 'cancelled', liveStatus: 'live' }))).toBeNull();
+        expect(resolveScheduleWatchCta(game({ isCancelled: true, liveStatus: 'completed' }))).toBeNull();
+        expect(resolveScheduleWatchCta(game({ status: 'deleted', liveStatus: 'live' }))).toBeNull();
+        expect(resolveScheduleWatchCta(game({ liveStatus: 'deleted' }))).toBeNull();
+        expect(resolveScheduleWatchCta(game({ visibility: 'private', liveStatus: 'live' }))).toBeNull();
+        expect(resolveScheduleWatchCta(game({ isPrivate: true, liveStatus: 'completed' }))).toBeNull();
+        expect(resolveScheduleWatchCta(game({ liveStatus: 'scheduled' }))).toBeNull();
+        expect(resolveScheduleWatchCta(game({ teamId: '', liveStatus: 'live' }))).toBeNull();
+        expect(resolveScheduleWatchCta(game({ id: '', gameId: '', liveStatus: 'completed' }))).toBeNull();
+    });
+
+    it('is wired into parent and family schedule renderers without removing details links', () => {
+        const parentDashboard = readRepoFile('parent-dashboard.html');
+        const familyPage = readRepoFile('family.html');
+
+        expect(parentDashboard).toContain("import { resolveScheduleWatchCta } from './js/schedule-watch-cta.js?v=1';");
+        expect(parentDashboard).toContain('const watchCta = resolveScheduleWatchCta(game);');
+        expect(parentDashboard).toContain('View Details');
+
+        expect(familyPage).toContain("import { resolveScheduleWatchCta } from './js/schedule-watch-cta.js?v=1';");
+        expect(familyPage).toContain('const watchCta = resolveScheduleWatchCta(ev);');
+        expect(familyPage).toContain('const watchCta = resolveScheduleWatchCta(game);');
+        expect(familyPage).toContain('View Game Details');
+        expect(familyPage).toContain('>\n                  View\n');
+    });
+});


### PR DESCRIPTION
Closes #1868

## What changed
- added `js/schedule-watch-cta.js` with a single `resolveScheduleWatchCta()` helper that decides live, replay, or no CTA from existing game fields
- wired parent dashboard schedule cards and family schedule list/day-modal cards to use the shared resolver
- preserved the existing `View Details` and `View` fallback links while only showing watch CTAs for eligible games
- added focused regression coverage for the CTA state matrix and page wiring

## Root Cause
Parent and family schedule surfaces had no shared watch CTA decision path, so the eligibility rules were effectively duplicated by omission. That made these pages drift from the live/replay behavior already supported elsewhere and left no focused regression coverage for the game-state combinations.

## Prevention / Learning
When a CTA depends on a bounded state matrix, centralize the resolver before wiring multiple pages. Keep rendering paths thin, reuse the same helper everywhere, and add a regression test that locks the allow and suppress cases together.

## Regression Tests
- `npx vitest run tests/unit/schedule-watch-cta.test.js --reporter=verbose`
- verifies live CTA, replay CTA, and no-CTA suppression for practices, cancelled, deleted, private, scheduled, and invalid-route records
- verifies parent and family schedule renderers both call the shared resolver and keep their fallback details links intact