### PR TITLE
Defer team detail insights and sponsor hydration

### DIFF
--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -187,6 +187,15 @@ export type TeamDetailModel = {
   };
 };
 
+export type TeamDetailInsightsPayload = {
+  leaderboards: TeamDetailLeaderboard[];
+  trackingSummaries: TeamDetailTrackingSummary[];
+};
+
+export type TeamDetailSponsorsPayload = {
+  sponsors: TeamDetailSponsor[];
+};
+
 type FirestoreDocument = Record<string, any> & { id: string };
 
 function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = primaryDataTimeoutMs): Promise<T> {
@@ -525,7 +534,12 @@ function getPublicBaseUrl() {
   return 'https://allplays.ai';
 }
 
-export async function loadParentTeamDetail(teamId: string, user: AuthUser | null): Promise<TeamDetailModel> {
+export async function loadParentTeamDetail(
+  teamId: string,
+  user: AuthUser | null,
+  options: { includeDeferredData?: boolean } = {}
+): Promise<TeamDetailModel> {
+  const includeDeferredData = options.includeDeferredData === true;
   const [team, players, games, configs] = await Promise.all([
     loadTeamDocument(teamId),
     loadTeamPlayers(teamId),
@@ -541,13 +555,21 @@ export async function loadParentTeamDetail(teamId: string, user: AuthUser | null
     .map((game: any) => cleanString(game.id || game.gameId))
     .filter(Boolean);
 
-  const [seasonStatsByPlayerId, trackingItems, trackingStatuses, localSponsors, adSponsors] = await Promise.all([
-    completedGameIds.length ? Promise.resolve(getAggregatedStatsForGames(teamId, completedGameIds)).catch(() => ({})) : Promise.resolve({}),
-    linkedPlayerIds.length ? Promise.resolve(getPublicTrackingItems(teamId)).catch(() => []) : Promise.resolve([]),
-    linkedPlayerIds.length ? Promise.resolve(getPlayerTrackingStatuses(teamId, linkedPlayerIds)).catch(() => []) : Promise.resolve([]),
-    Promise.resolve(getLocalAttractionSponsors(teamId)).catch(() => []),
-    Promise.resolve(getAdSpaceSponsors(teamId)).catch(() => [])
-  ]);
+  const [seasonStatsByPlayerId, trackingItems, trackingStatuses, localSponsors, adSponsors] = includeDeferredData
+    ? await Promise.all([
+      completedGameIds.length ? Promise.resolve(getAggregatedStatsForGames(teamId, completedGameIds)).catch(() => ({})) : Promise.resolve({}),
+      linkedPlayerIds.length ? Promise.resolve(getPublicTrackingItems(teamId)).catch(() => []) : Promise.resolve([]),
+      linkedPlayerIds.length ? Promise.resolve(getPlayerTrackingStatuses(teamId, linkedPlayerIds)).catch(() => []) : Promise.resolve([]),
+      Promise.resolve(getLocalAttractionSponsors(teamId)).catch(() => []),
+      Promise.resolve(getAdSpaceSponsors(teamId)).catch(() => [])
+    ])
+    : await Promise.all([
+      Promise.resolve({}),
+      Promise.resolve([]),
+      Promise.resolve([]),
+      Promise.resolve([]),
+      Promise.resolve([])
+    ]);
 
   return buildTeamDetailModel({
     teamId,
@@ -563,6 +585,46 @@ export async function loadParentTeamDetail(teamId: string, user: AuthUser | null
     sponsors: [...normalizeSponsorList(adSponsors), ...normalizeSponsorList(localSponsors)],
     includeStaffPermissions: false
   });
+}
+
+export async function loadTeamDetailInsights(teamId: string, user: AuthUser | null): Promise<TeamDetailInsightsPayload> {
+  const [team, players, games, configs] = await Promise.all([
+    loadTeamDocument(teamId),
+    loadTeamPlayers(teamId),
+    loadTeamGames(teamId),
+    loadTeamConfigs(teamId)
+  ]);
+
+  if (!team) throw new Error('Team not found.');
+
+  const linkedPlayerIds = getLinkedPlayerIds(user, teamId, players);
+  const completedGameIds = (Array.isArray(games) ? games : [])
+    .filter(isCompletedGame)
+    .map((game: any) => cleanString(game.id || game.gameId))
+    .filter(Boolean);
+
+  const [seasonStatsByPlayerId, trackingItems, trackingStatuses] = await Promise.all([
+    completedGameIds.length ? Promise.resolve(getAggregatedStatsForGames(teamId, completedGameIds)).catch(() => ({})) : Promise.resolve({}),
+    linkedPlayerIds.length ? Promise.resolve(getPublicTrackingItems(teamId)).catch(() => []) : Promise.resolve([]),
+    linkedPlayerIds.length ? Promise.resolve(getPlayerTrackingStatuses(teamId, linkedPlayerIds)).catch(() => []) : Promise.resolve([])
+  ]);
+
+  const normalizedPlayers = normalizePlayers(players, linkedPlayerIds);
+  return {
+    leaderboards: buildLeaderboards(configs, normalizedPlayers, seasonStatsByPlayerId, team?.sport),
+    trackingSummaries: buildTrackingSummaries(normalizedPlayers, linkedPlayerIds, trackingItems, trackingStatuses)
+  };
+}
+
+export async function loadTeamDetailSponsors(teamId: string): Promise<TeamDetailSponsorsPayload> {
+  const [localSponsors, adSponsors] = await Promise.all([
+    Promise.resolve(getLocalAttractionSponsors(teamId)).catch(() => []),
+    Promise.resolve(getAdSpaceSponsors(teamId)).catch(() => [])
+  ]);
+
+  return {
+    sponsors: [...normalizeSponsorList(adSponsors), ...normalizeSponsorList(localSponsors)].slice(0, 4)
+  };
 }
 
 export async function loadTeamStaffPermissions(teamId: string, user: AuthUser | null): Promise<TeamStaffPermissionsSummary | null> {

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -29,7 +29,7 @@ import { getEventDetailPath } from '../lib/homeLogic';
 import { buildPrivateTeamCalendarFeedUrl, getAppleCalendarFeedUrl, getGoogleCalendarFeedUrl } from '../lib/parentToolsService';
 import { createStaffRsvpReminderPreviewLoader, sendStaffRsvpReminder, type StaffRsvpReminderSendResult } from '../lib/scheduleService';
 import type { ParentScheduleEvent, StaffRsvpReminderPreview } from '../lib/scheduleLogic';
-import { buildPublicTeamGamesIcsUrl, canExposePublicFanFeed, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, loadTeamStaffPermissions, revokeScorekeeperAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp, type InviteTeamAdminForAppResult, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer, type TeamScorekeeperGrantTarget } from '../lib/teamDetailService';
+import { buildPublicTeamGamesIcsUrl, canExposePublicFanFeed, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, loadTeamDetailInsights, loadTeamDetailSponsors, loadTeamStaffPermissions, revokeScorekeeperAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp, type InviteTeamAdminForAppResult, type TeamDetailEvent, type TeamDetailModel, type TeamDetailPlayer, type TeamScorekeeperGrantTarget } from '../lib/teamDetailService';
 import type { AuthState } from '../lib/types';
 
 type TeamTab = 'overview' | 'schedule' | 'roster' | 'insights' | 'more';
@@ -50,6 +50,12 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
   const [activeTab, setActiveTab] = useState<TeamTab>('overview');
   const [staffPermissionsLoading, setStaffPermissionsLoading] = useState(false);
   const [staffPermissionsError, setStaffPermissionsError] = useState('');
+  const [insightsLoading, setInsightsLoading] = useState(false);
+  const [insightsError, setInsightsError] = useState('');
+  const [insightsLoaded, setInsightsLoaded] = useState(false);
+  const [sponsorsLoading, setSponsorsLoading] = useState(false);
+  const [sponsorsError, setSponsorsError] = useState('');
+  const [sponsorsLoaded, setSponsorsLoaded] = useState(false);
 
   useEffect(() => {
     let cancelled = false;
@@ -58,11 +64,17 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
       setLoading(true);
       setError('');
       try {
-        const nextModel = await loadParentTeamDetail(teamId, auth.user);
+        const nextModel = await loadParentTeamDetail(teamId, auth.user, { includeDeferredData: false });
         if (!cancelled) {
           setModel(nextModel);
           setStaffPermissionsError('');
           setStaffPermissionsLoading(false);
+          setInsightsLoading(false);
+          setInsightsError('');
+          setInsightsLoaded(false);
+          setSponsorsLoading(false);
+          setSponsorsError('');
+          setSponsorsLoaded(false);
         }
       } catch (loadError: any) {
         if (!cancelled) {
@@ -70,6 +82,12 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
           setModel(null);
           setStaffPermissionsError('');
           setStaffPermissionsLoading(false);
+          setInsightsLoading(false);
+          setInsightsError('');
+          setInsightsLoaded(false);
+          setSponsorsLoading(false);
+          setSponsorsError('');
+          setSponsorsLoaded(false);
         }
       } finally {
         if (!cancelled) setLoading(false);
@@ -106,6 +124,56 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
   }, [activeTab, auth.user, model?.canManageTeam, model?.staffPermissions, teamId]);
 
   useEffect(() => {
+    let cancelled = false;
+    async function loadInsightsForTab() {
+      if (!teamId || activeTab !== 'insights' || !model || insightsLoaded || insightsLoading) return;
+      setInsightsLoading(true);
+      setInsightsError('');
+      try {
+        const insights = await loadTeamDetailInsights(teamId, auth.user);
+        if (!cancelled) {
+          setModel((currentModel) => currentModel ? { ...currentModel, ...insights } : currentModel);
+          setInsightsLoaded(true);
+        }
+      } catch (loadError: any) {
+        if (!cancelled) setInsightsError(loadError?.message || 'Unable to load team insights.');
+      } finally {
+        if (!cancelled) setInsightsLoading(false);
+      }
+    }
+
+    void loadInsightsForTab();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, auth.user, insightsLoaded, insightsLoading, model, teamId]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadSponsorsForMoreTab() {
+      if (!teamId || activeTab !== 'more' || !model || sponsorsLoaded || sponsorsLoading) return;
+      setSponsorsLoading(true);
+      setSponsorsError('');
+      try {
+        const sponsorPayload = await loadTeamDetailSponsors(teamId);
+        if (!cancelled) {
+          setModel((currentModel) => currentModel ? { ...currentModel, ...sponsorPayload } : currentModel);
+          setSponsorsLoaded(true);
+        }
+      } catch (loadError: any) {
+        if (!cancelled) setSponsorsError(loadError?.message || 'Unable to load team sponsors.');
+      } finally {
+        if (!cancelled) setSponsorsLoading(false);
+      }
+    }
+
+    void loadSponsorsForMoreTab();
+    return () => {
+      cancelled = true;
+    };
+  }, [activeTab, model, sponsorsLoaded, sponsorsLoading, teamId]);
+
+  useEffect(() => {
     const scroll = () => {
       try {
         window.scrollTo({ top: 0, behavior: 'smooth' });
@@ -122,15 +190,21 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
 
   async function refreshTeamDetail() {
     if (!teamId) return;
-    const nextModel = await loadParentTeamDetail(teamId, auth.user);
+    const nextModel = await loadParentTeamDetail(teamId, auth.user, { includeDeferredData: false });
+    const mergedModel = {
+      ...nextModel,
+      leaderboards: model?.leaderboards || nextModel.leaderboards,
+      trackingSummaries: model?.trackingSummaries || nextModel.trackingSummaries,
+      sponsors: model?.sponsors || nextModel.sponsors
+    };
     if (activeTab === 'more' && nextModel.canManageTeam) {
       const staffPermissions = await loadTeamStaffPermissions(teamId, auth.user);
-      setModel({ ...nextModel, staffPermissions });
+      setModel({ ...mergedModel, staffPermissions });
       setStaffPermissionsError('');
       setStaffPermissionsLoading(false);
       return;
     }
-    setModel(nextModel);
+    setModel(mergedModel);
     setStaffPermissionsError('');
     setStaffPermissionsLoading(false);
   }
@@ -206,8 +280,8 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
       {activeTab === 'overview' ? <OverviewTab model={model} /> : null}
       {activeTab === 'schedule' ? <ScheduleTab model={model} auth={auth} /> : null}
       {activeTab === 'roster' ? <RosterTab model={model} /> : null}
-      {activeTab === 'insights' ? <InsightsTab model={model} /> : null}
-      {activeTab === 'more' ? <MoreTab model={model} auth={auth} staffPermissionsLoading={staffPermissionsLoading} staffPermissionsError={staffPermissionsError} onTeamDetailRefresh={refreshTeamDetail} /> : null}
+      {activeTab === 'insights' ? <InsightsTab model={model} loading={insightsLoading} error={insightsError} /> : null}
+      {activeTab === 'more' ? <MoreTab model={model} auth={auth} staffPermissionsLoading={staffPermissionsLoading} staffPermissionsError={staffPermissionsError} sponsorsLoading={sponsorsLoading} sponsorsError={sponsorsError} onTeamDetailRefresh={refreshTeamDetail} /> : null}
     </div>
   );
 }
@@ -325,13 +399,15 @@ function RosterTab({ model }: { model: TeamDetailModel }) {
   );
 }
 
-function InsightsTab({ model }: { model: TeamDetailModel }) {
+function InsightsTab({ model, loading, error }: { model: TeamDetailModel; loading: boolean; error: string }) {
   return (
     <div className="space-y-4">
       <section className="app-card p-4">
         <div className="text-sm font-black text-gray-950">Player checklist</div>
         <div className="mt-0.5 text-xs font-semibold text-gray-500">Public tracking items visible for your linked player.</div>
         <div className="mt-3 space-y-3">
+          {loading ? <InlineDeferredLoading copy="Loading player tracking…" /> : null}
+          {!loading && error ? <InlineDeferredError title="Player checklist unavailable" message={error} /> : null}
           {model.trackingSummaries.length ? model.trackingSummaries.map((summary) => (
             <div key={summary.playerId} className="rounded-xl border border-gray-200 bg-gray-50 p-3">
               <div className="flex items-center gap-3">
@@ -355,9 +431,9 @@ function InsightsTab({ model }: { model: TeamDetailModel }) {
                 ))}
               </div>
             </div>
-          )) : (
+          )) : !loading && !error ? (
             <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">No parent-visible tracking items for your players yet.</div>
-          )}
+          ) : null}
         </div>
       </section>
 
@@ -365,6 +441,8 @@ function InsightsTab({ model }: { model: TeamDetailModel }) {
         <div className="text-sm font-black text-gray-950">Leaderboards</div>
         <div className="mt-0.5 text-xs font-semibold text-gray-500">Public top stats from completed tracked games.</div>
         <div className="mt-3 grid gap-2 lg:grid-cols-2">
+          {loading ? <InlineDeferredLoading copy="Loading leaderboards…" /> : null}
+          {!loading && error ? <InlineDeferredError title="Leaderboards unavailable" message={error} /> : null}
           {model.leaderboards.length ? model.leaderboards.map((leaderboard) => (
             <div key={leaderboard.id} className="rounded-xl border border-gray-200 bg-white p-3">
               <div className="text-sm font-black text-gray-950">{leaderboard.label}</div>
@@ -381,16 +459,16 @@ function InsightsTab({ model }: { model: TeamDetailModel }) {
                 ))}
               </div>
             </div>
-          )) : (
+          )) : !loading && !error ? (
             <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">Leaderboards appear after public stat configs and completed tracked games exist.</div>
-          )}
+          ) : null}
         </div>
       </section>
     </div>
   );
 }
 
-function MoreTab({ model, auth, staffPermissionsLoading, staffPermissionsError, onTeamDetailRefresh }: { model: TeamDetailModel; auth: AuthState; staffPermissionsLoading: boolean; staffPermissionsError: string; onTeamDetailRefresh: () => Promise<void> }) {
+function MoreTab({ model, auth, staffPermissionsLoading, staffPermissionsError, sponsorsLoading, sponsorsError, onTeamDetailRefresh }: { model: TeamDetailModel; auth: AuthState; staffPermissionsLoading: boolean; staffPermissionsError: string; sponsorsLoading: boolean; sponsorsError: string; onTeamDetailRefresh: () => Promise<void> }) {
   return (
     <div className="space-y-4">
       {model.canManageTeam && !model.staffPermissions && staffPermissionsLoading ? (
@@ -440,6 +518,9 @@ function MoreTab({ model, auth, staffPermissionsLoading, staffPermissionsError, 
         </section>
       ) : null}
 
+      {sponsorsLoading ? <InlineDeferredLoading copy="Loading local attractions and sponsors…" /> : null}
+      {!sponsorsLoading && sponsorsError ? <InlineDeferredError title="Sponsors unavailable" message={sponsorsError} /> : null}
+
       {model.sponsors.length ? (
         <section className="app-card p-4">
           <div className="text-sm font-black text-gray-950">Local attractions and sponsors</div>
@@ -465,6 +546,26 @@ function MoreTab({ model, auth, staffPermissionsLoading, staffPermissionsError, 
           </div>
         </section>
       ) : null}
+    </div>
+  );
+}
+
+function InlineDeferredLoading({ copy }: { copy: string }) {
+  return (
+    <div className="rounded-xl border border-primary-200 bg-primary-50 p-4">
+      <div className="flex items-center gap-3 text-sm font-semibold text-gray-600">
+        <Loader2 className="h-4 w-4 animate-spin text-primary-600" aria-hidden="true" />
+        {copy}
+      </div>
+    </div>
+  );
+}
+
+function InlineDeferredError({ title, message }: { title: string; message: string }) {
+  return (
+    <div className="rounded-xl border border-rose-200 bg-rose-50 p-4">
+      <div className="text-sm font-black text-gray-950">{title}</div>
+      <div className="mt-1 text-xs font-semibold text-rose-700">{message}</div>
     </div>
   );
 }

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -146,7 +146,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [activeTab, auth.user, insightsLoaded, insightsLoading, model, teamId]);
+  }, [activeTab, auth.user, insightsLoaded, Boolean(model), teamId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -171,7 +171,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [activeTab, model, sponsorsLoaded, sponsorsLoading, teamId]);
+  }, [activeTab, Boolean(model), sponsorsLoaded, teamId]);
 
   useEffect(() => {
     const scroll = () => {

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -634,7 +634,11 @@ test('my teams opens from Home data with selected team, player, and chat routes'
     await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
 
     await page.locator('a[href="#/teams/team-1"]').first().click();
-    await expect(page.getByRole('heading', { name: 'Bears' })).toBeVisible();
+    await expect(async () => {
+        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
+        await expect(page.getByText('Loading team')).toHaveCount(0, { timeout: 1000 });
+        await expect(page.getByRole('heading', { name: 'Bears' })).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 30000 });
     await expect(page.locator('img[src="https://img.example.test/bears.png"]').first()).toBeVisible();
     await expect(page.getByRole('button', { name: 'Roster' })).toBeVisible();
     await page.getByRole('button', { name: 'Roster' }).click();

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -17,6 +17,14 @@ async function waitForHomeRoute(page, readyLocator) {
     }).toPass({ timeout: 30000 });
 }
 
+async function waitForTeamsRoute(page, readyLocator) {
+    await expect(async () => {
+        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 3000 });
+        await expect(page.getByText('Loading teams')).toHaveCount(0, { timeout: 3000 });
+        await expect(readyLocator).toBeVisible({ timeout: 3000 });
+    }).toPass({ timeout: 30000 });
+}
+
 async function mockHomePlayerModules(page) {
     await page.addInitScript(() => {
         window.__playerLoads = [];
@@ -389,6 +397,17 @@ async function mockHomePlayerModules(page) {
                     return null;
                 }
 
+                export async function loadTeamDetailInsights() {
+                    return {
+                        leaderboards: [{ id: 'pts', label: 'Points', leaders: [{ playerId: 'player-1', playerName: 'Pat Star', playerNumber: '9', photoUrl: 'https://img.example.test/player.png', rank: 1, formattedValue: '88' }] }],
+                        trackingSummaries: [{ playerId: 'player-1', playerName: 'Pat Star', photoUrl: 'https://img.example.test/player.png', items: [{ id: 'item-1', title: 'Bring ball', description: '', isComplete: false }] }]
+                    };
+                }
+
+                export async function loadTeamDetailSponsors() {
+                    return { sponsors: [{ id: 'sponsor-1', name: 'Pizza Place', description: 'After the game', imageUrl: 'https://img.example.test/pizza.png', websiteUrl: 'https://pizza.example.test' }] };
+                }
+
                 export function buildPublicTeamGamesIcsUrl(teamId) {
                     return teamId ? 'https://calendar.example.test/publicTeamGamesIcs?teamId=' + encodeURIComponent(teamId) : '';
                 }
@@ -614,7 +633,7 @@ test('my teams opens from Home data with selected team, player, and chat routes'
     await mockHomePlayerModules(page);
     await page.goto(appUrl(baseURL, '/teams?selectedTeamId=team-1&from=home'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByRole('heading', { name: '1 team ready' })).toBeVisible();
+    await waitForTeamsRoute(page, page.getByRole('heading', { name: '1 team ready' }));
     await expect(page.getByText('Choose a team')).toBeVisible();
     await expect(page.getByRole('link', { name: /Chat/ })).toHaveAttribute('href', '#/messages/team-1');
     await expect(page.getByText('Team navigation')).toBeVisible();

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -919,9 +919,12 @@ test('app practice more tab uses hub cards and shares event details without a li
     await expect(page.locator('.event-summary-card')).toContainText('Practice');
     await expect(page.getByRole('button', { name: 'Practice packet ready, review packet' })).toBeVisible();
     await page.getByRole('button', { name: 'Practice packet ready, review packet' }).click();
-    await expect(page.getByRole('heading', { name: 'Practice hub' })).toBeVisible();
+    await expect(async () => {
+        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
+        await expect(page.getByRole('heading', { name: 'Practice hub' })).toBeVisible({ timeout: 1000 });
+        await expect(page.getByText('2 drills · 20 min · Main Gym')).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 30000 });
     const practiceHub = page.locator('.app-card').filter({ has: page.getByRole('heading', { name: 'Practice hub' }) });
-    await expect(page.getByText('2 drills · 20 min · Main Gym')).toBeVisible();
     await expect(practiceHub.locator('article').first().getByRole('heading', { name: 'Share practice' })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Open packet' })).toHaveCount(0);
     await expect(page.getByRole('button', { name: 'Open team' })).toBeVisible();

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -281,6 +281,14 @@ async function mockSearchModules(page) {
                     return null;
                 }
 
+                export async function loadTeamDetailInsights() {
+                    return { leaderboards: [], trackingSummaries: [] };
+                }
+
+                export async function loadTeamDetailSponsors() {
+                    return { sponsors: [] };
+                }
+
                 export function buildPublicTeamGamesIcsUrl(teamId) {
                     return teamId ? 'https://calendar.example.test/publicTeamGamesIcs?teamId=' + encodeURIComponent(teamId) : '';
                 }

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -396,8 +396,12 @@ test.describe('desktop app global search', () => {
         await page.getByLabel('Search teams, players, actions, help').fill('rock');
         await expect(page.getByRole('button', { name: /Rockets/ })).toBeVisible();
         await page.getByRole('button', { name: /Rockets/ }).click();
-        await expect(page).toHaveURL(/#\/teams\/team-2$/);
-        await expect(page.getByRole('heading', { name: 'Rockets' })).toBeVisible();
+        await expect(async () => {
+            await expect(page).toHaveURL(/#\/teams\/team-2$/, { timeout: 1000 });
+            await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
+            await expect(page.getByText('Loading team')).toHaveCount(0, { timeout: 1000 });
+            await expect(page.getByRole('heading', { name: 'Rockets' })).toBeVisible({ timeout: 1000 });
+        }).toPass({ timeout: 30000 });
 
         await openDesktopSearch(page);
         await page.getByRole('button', { name: /Browse Teams/ }).click();

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -238,6 +238,26 @@ async function mockTeamsModules(page) {
                     return null;
                 }
 
+                export async function loadTeamDetailInsights(teamId) {
+                    if (teamId === 'team-empty') {
+                        return { leaderboards: [], trackingSummaries: [] };
+                    }
+                    return {
+                        leaderboards: [{ id: 'pts', label: 'Points', leaders: [{ playerId: 'player-1', playerName: 'Pat Star', playerNumber: '9', photoUrl: 'https://img.example.test/player.png', rank: 1, formattedValue: '88' }] }],
+                        trackingSummaries: [{ playerId: 'player-1', playerName: 'Pat Star', photoUrl: 'https://img.example.test/player.png', items: [
+                            { id: 'item-1', title: 'Bring ball', description: 'For warmups', isComplete: true },
+                            { id: 'item-2', title: 'Upload waiver', description: '', isComplete: false }
+                        ] }]
+                    };
+                }
+
+                export async function loadTeamDetailSponsors(teamId) {
+                    if (teamId === 'team-empty') {
+                        return { sponsors: [] };
+                    }
+                    return { sponsors: [{ id: 'sponsor-1', name: 'Pizza Place', description: 'After the game', imageUrl: 'https://img.example.test/pizza.png', websiteUrl: 'https://pizza.example.test' }] };
+                }
+
                 export function buildPublicTeamGamesIcsUrl(teamId) {
                     return teamId ? 'https://calendar.example.test/publicTeamGamesIcs?teamId=' + encodeURIComponent(teamId) : '';
                 }

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -15,6 +15,14 @@ async function waitForTeamsRoute(page, readyLocator) {
     }).toPass({ timeout: 30000 });
 }
 
+async function waitForTeamDetailRoute(page, teamName) {
+    await expect(async () => {
+        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
+        await expect(page.getByText('Loading team')).toHaveCount(0, { timeout: 1000 });
+        await expect(page.getByRole('heading', { name: teamName })).toBeVisible({ timeout: 1000 });
+    }).toPass({ timeout: 30000 });
+}
+
 async function mockTeamsModules(page) {
     await page.addInitScript(() => {
         window.__openedPublicUrls = [];
@@ -394,7 +402,7 @@ test.describe('mobile My Teams', () => {
         await mockTeamsModules(page);
         await page.goto(appUrl(baseURL, '/teams/team-1'), { waitUntil: 'domcontentloaded' });
 
-        await expect(page.getByRole('heading', { name: 'Bears' })).toBeVisible();
+        await waitForTeamDetailRoute(page, 'Bears');
         await expect(page.getByText('4-2').first()).toBeVisible();
         await expect(page.getByText('Parent actions')).toBeVisible();
         await expect(page.locator('a[href="#/schedule?teamId=team-1&filter=availability"]')).toBeVisible();
@@ -442,8 +450,7 @@ test.describe('mobile My Teams', () => {
         await mockTeamsModules(page);
         await page.goto(appUrl(baseURL, '/teams/team-empty'), { waitUntil: 'domcontentloaded' });
 
-        await expect(page.getByText('Loading team')).toHaveCount(0);
-        await expect(page.getByRole('heading', { name: /Empty Team/i })).toBeVisible();
+        await waitForTeamDetailRoute(page, /Empty Team/i);
         await expect(page.getByText('No completed games yet')).toBeVisible();
         await expect(page.getByText('Schedule is clear for now')).toBeVisible();
 

--- a/tests/unit/app-team-detail-integration.test.jsx
+++ b/tests/unit/app-team-detail-integration.test.jsx
@@ -6,6 +6,8 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 const teamDetailMocks = vi.hoisted(() => ({
     loadParentTeamDetail: vi.fn(),
+    loadTeamDetailInsights: vi.fn(),
+    loadTeamDetailSponsors: vi.fn(),
     loadTeamStaffPermissions: vi.fn(),
     saveTeamScheduleNotificationsForApp: vi.fn(),
     buildPublicTeamGamesIcsUrl: vi.fn((teamId) => `https://us-central1-all-plays-prod.cloudfunctions.net/publicTeamGamesIcs?teamId=${encodeURIComponent(teamId)}`),
@@ -29,6 +31,8 @@ const scheduleServiceMocks = vi.hoisted(() => ({
 
 vi.mock('../../apps/app/src/lib/teamDetailService.ts', () => ({
     loadParentTeamDetail: teamDetailMocks.loadParentTeamDetail,
+    loadTeamDetailInsights: teamDetailMocks.loadTeamDetailInsights,
+    loadTeamDetailSponsors: teamDetailMocks.loadTeamDetailSponsors,
     loadTeamStaffPermissions: teamDetailMocks.loadTeamStaffPermissions,
     saveTeamScheduleNotificationsForApp: teamDetailMocks.saveTeamScheduleNotificationsForApp,
     buildPublicTeamGamesIcsUrl: teamDetailMocks.buildPublicTeamGamesIcsUrl,
@@ -126,6 +130,29 @@ function model() {
         canManageTeam: false,
         staffPermissions: null,
         counts: { games: 8, practices: 3, completedGames: 7 }
+    };
+}
+
+function coreModel() {
+    return {
+        ...model(),
+        leaderboards: [],
+        trackingSummaries: [],
+        sponsors: []
+    };
+}
+
+function deferredInsightsModel() {
+    const fullModel = model();
+    return {
+        leaderboards: fullModel.leaderboards,
+        trackingSummaries: fullModel.trackingSummaries
+    };
+}
+
+function deferredSponsorsModel() {
+    return {
+        sponsors: model().sponsors
     };
 }
 
@@ -243,7 +270,9 @@ beforeEach(() => {
         summary: 'Team default reminder window: 24 hours before event start.'
     });
     teamDetailMocks.loadTeamStaffPermissions.mockResolvedValue(null);
-    teamDetailMocks.loadParentTeamDetail.mockResolvedValue(model());
+    teamDetailMocks.loadParentTeamDetail.mockResolvedValue(coreModel());
+    teamDetailMocks.loadTeamDetailInsights.mockResolvedValue(deferredInsightsModel());
+    teamDetailMocks.loadTeamDetailSponsors.mockResolvedValue(deferredSponsorsModel());
 });
 
 afterEach(() => {
@@ -259,7 +288,7 @@ describe('React app TeamDetail page', () => {
     it('loads parent-facing team.html features with team and player photos', async () => {
         const { container } = await renderTeamDetail();
 
-        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledWith('team-1', auth.user);
+        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledWith('team-1', auth.user, { includeDeferredData: false });
         expect(container.textContent).toContain('Bears');
         expect(container.querySelector('img[src="https://img.example.test/team.png"]')).toBeTruthy();
         expect(container.textContent).toContain('Season record (2100)');
@@ -274,11 +303,15 @@ describe('React app TeamDetail page', () => {
         expect(Array.from(container.querySelectorAll('a')).map((link) => link.getAttribute('href'))).toContain('/players/team-1/player-1');
 
         await clickButton(container, 'Insights');
+        expect(teamDetailMocks.loadTeamDetailInsights).toHaveBeenCalledTimes(1);
+        expect(teamDetailMocks.loadTeamDetailInsights).toHaveBeenCalledWith('team-1', auth.user);
         expect(container.textContent).toContain('Bring ball');
         expect(container.textContent).toContain('Points');
         expect(container.textContent).toContain('88');
 
         await clickButton(container, 'More');
+        expect(teamDetailMocks.loadTeamDetailSponsors).toHaveBeenCalledTimes(1);
+        expect(teamDetailMocks.loadTeamDetailSponsors).toHaveBeenCalledWith('team-1');
         expect(container.textContent).toContain('Website team page');
         expect(container.textContent).toContain('Media albums');
         expect(container.textContent).toContain('Watch stream');
@@ -476,11 +509,13 @@ describe('React app TeamDetail page', () => {
         expect(container.textContent).toContain('Bears');
         expect(container.textContent).toContain('Season record (2100)');
         expect(teamDetailMocks.loadTeamStaffPermissions).not.toHaveBeenCalled();
+        expect(teamDetailMocks.loadTeamDetailSponsors).not.toHaveBeenCalled();
 
         await clickButton(container, 'More');
 
         expect(teamDetailMocks.loadTeamStaffPermissions).toHaveBeenCalledTimes(1);
         expect(teamDetailMocks.loadTeamStaffPermissions).toHaveBeenCalledWith('team-1', expect.objectContaining({ uid: 'coach-1' }));
+        expect(teamDetailMocks.loadTeamDetailSponsors).toHaveBeenCalledTimes(1);
         expect(container.textContent).toContain('Loading team staff permissions');
         expect(container.textContent).not.toContain('Team Staff & Permissions');
 
@@ -500,6 +535,51 @@ describe('React app TeamDetail page', () => {
         expect(container.textContent).not.toContain('Loading team staff permissions');
         expect(container.textContent).toContain('Team Staff & Permissions');
         expect(container.textContent).toContain('coach@example.com · Admin');
+    });
+
+    it('loads deferred insights and sponsors once, then reuses them across tab switches', async () => {
+        const { container } = await renderTeamDetail();
+
+        expect(teamDetailMocks.loadTeamDetailInsights).not.toHaveBeenCalled();
+        expect(teamDetailMocks.loadTeamDetailSponsors).not.toHaveBeenCalled();
+
+        await clickButton(container, 'Insights');
+        expect(teamDetailMocks.loadTeamDetailInsights).toHaveBeenCalledTimes(1);
+        expect(container.textContent).toContain('Bring ball');
+
+        await clickButton(container, 'Overview');
+        await clickButton(container, 'Insights');
+        expect(teamDetailMocks.loadTeamDetailInsights).toHaveBeenCalledTimes(1);
+
+        await clickButton(container, 'More');
+        expect(teamDetailMocks.loadTeamDetailSponsors).toHaveBeenCalledTimes(1);
+        expect(container.textContent).toContain('Pizza Place');
+
+        await clickButton(container, 'Schedule');
+        await clickButton(container, 'More');
+        expect(teamDetailMocks.loadTeamDetailSponsors).toHaveBeenCalledTimes(1);
+    });
+
+    it('keeps the page usable when deferred Insights or More hydration fails', async () => {
+        teamDetailMocks.loadTeamDetailInsights.mockRejectedValueOnce(new Error('Insights offline'));
+        teamDetailMocks.loadTeamDetailSponsors.mockRejectedValueOnce(new Error('Sponsors offline'));
+
+        const { container } = await renderTeamDetail();
+
+        expect(container.textContent).toContain('Season record (2100)');
+
+        await clickButton(container, 'Insights');
+        expect(container.textContent).toContain('Player checklist unavailable');
+        expect(container.textContent).toContain('Insights offline');
+        expect(container.textContent).toContain('Leaderboards unavailable');
+
+        await clickButton(container, 'Overview');
+        expect(container.textContent).toContain('Season record (2100)');
+
+        await clickButton(container, 'More');
+        expect(container.textContent).toContain('Sponsors unavailable');
+        expect(container.textContent).toContain('Sponsors offline');
+        expect(container.textContent).toContain('Website team page');
     });
 
     it('exposes schedule, parent action links, and recent scores', async () => {
@@ -611,6 +691,8 @@ describe('React app TeamDetail page', () => {
         emptyModel.sponsors = [];
         emptyModel.counts = { games: 0, practices: 0, completedGames: 0 };
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(emptyModel);
+        teamDetailMocks.loadTeamDetailInsights.mockResolvedValueOnce({ leaderboards: [], trackingSummaries: [] });
+        teamDetailMocks.loadTeamDetailSponsors.mockResolvedValueOnce({ sponsors: [] });
 
         const { container } = await renderTeamDetail();
         expect(container.textContent).toContain('No completed games yet');

--- a/tests/unit/app-team-detail-integration.test.jsx
+++ b/tests/unit/app-team-detail-integration.test.jsx
@@ -560,6 +560,41 @@ describe('React app TeamDetail page', () => {
         expect(teamDetailMocks.loadTeamDetailSponsors).toHaveBeenCalledTimes(1);
     });
 
+    it('applies deferred insights and sponsors after async loads resolve', async () => {
+        let resolveInsights;
+        let resolveSponsors;
+        teamDetailMocks.loadTeamDetailInsights.mockImplementationOnce(() => new Promise((resolve) => {
+            resolveInsights = resolve;
+        }));
+        teamDetailMocks.loadTeamDetailSponsors.mockImplementationOnce(() => new Promise((resolve) => {
+            resolveSponsors = resolve;
+        }));
+
+        const { container } = await renderTeamDetail();
+
+        await clickButton(container, 'Insights');
+        expect(container.textContent).toContain('Loading player tracking…');
+
+        await act(async () => {
+            resolveInsights(deferredInsightsModel());
+        });
+        await flush();
+
+        expect(container.textContent).toContain('Bring ball');
+        expect(container.textContent).not.toContain('Loading player tracking…');
+
+        await clickButton(container, 'More');
+        expect(container.textContent).toContain('Loading local attractions and sponsors…');
+
+        await act(async () => {
+            resolveSponsors(deferredSponsorsModel());
+        });
+        await flush();
+
+        expect(container.textContent).toContain('Pizza Place');
+        expect(container.textContent).not.toContain('Loading local attractions and sponsors…');
+    });
+
     it('keeps the page usable when deferred Insights or More hydration fails', async () => {
         teamDetailMocks.loadTeamDetailInsights.mockRejectedValueOnce(new Error('Insights offline'));
         teamDetailMocks.loadTeamDetailSponsors.mockRejectedValueOnce(new Error('Sponsors offline'));

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -51,9 +51,9 @@ vi.mock('../../apps/app/src/lib/authService.ts', () => ({
     getNativeAuthIdToken: vi.fn()
 }));
 
-import { buildAdminAcceptInviteUrl, buildPublicTeamGamesIcsUrl, buildTeamDetailModel, canExposePublicFanFeed, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, loadTeamStaffPermissions, revokeScorekeeperAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp } from '../../apps/app/src/lib/teamDetailService.ts';
+import { buildAdminAcceptInviteUrl, buildPublicTeamGamesIcsUrl, buildTeamDetailModel, canExposePublicFanFeed, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, loadTeamDetailInsights, loadTeamDetailSponsors, loadTeamStaffPermissions, revokeScorekeeperAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp } from '../../apps/app/src/lib/teamDetailService.ts';
 import { collection, getDocs, query, where } from '../../js/firebase.js';
-import { getAggregatedStatsForGames, getAdSpaceSponsors, getAllUsers, getConfigs, getEvents, getGames, getLocalAttractionSponsors, getPlayers, getTeam, grantScorekeeperAccess, grantVideographerAccess, inviteAdmin, addTeamAdminEmail, revokeScorekeeperAccess, revokeVideographerAccess, updateEvent, updateGame, updateTeam } from '../../js/db.js';
+import { getAggregatedStatsForGames, getAdSpaceSponsors, getAllUsers, getConfigs, getEvents, getGames, getLocalAttractionSponsors, getPlayerTrackingStatuses, getPlayers, getPublicTrackingItems, getTeam, grantScorekeeperAccess, grantVideographerAccess, inviteAdmin, addTeamAdminEmail, revokeScorekeeperAccess, revokeVideographerAccess, updateEvent, updateGame, updateTeam } from '../../js/db.js';
 import { sendInviteEmail } from '../../js/auth.js';
 
 describe('React app team detail model', () => {
@@ -450,18 +450,57 @@ describe('React app team detail model', () => {
             ]
         });
 
-        const adminModel = await loadParentTeamDetail('team-1', { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] });
+        const adminModel = await loadParentTeamDetail('team-1', { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] }, { includeDeferredData: false });
         expect(adminModel.canManageTeam).toBe(true);
         expect(adminModel.staffPermissions).toBeNull();
+        expect(adminModel.leaderboards).toEqual([]);
+        expect(adminModel.trackingSummaries).toEqual([]);
+        expect(adminModel.sponsors).toEqual([]);
         expect(getAllUsers).not.toHaveBeenCalled();
         expect(getDocs).not.toHaveBeenCalled();
+        expect(getAggregatedStatsForGames).not.toHaveBeenCalled();
+        expect(getPublicTrackingItems).not.toHaveBeenCalled();
+        expect(getPlayerTrackingStatuses).not.toHaveBeenCalled();
+        expect(getLocalAttractionSponsors).not.toHaveBeenCalled();
+        expect(getAdSpaceSponsors).not.toHaveBeenCalled();
 
         getDocs.mockClear();
         getAllUsers.mockClear();
-        const parentModel = await loadParentTeamDetail('team-1', { uid: 'parent-1', email: 'parent@example.com', displayName: 'Parent', roles: ['parent'] });
+        const parentModel = await loadParentTeamDetail('team-1', { uid: 'parent-1', email: 'parent@example.com', displayName: 'Parent', roles: ['parent'] }, { includeDeferredData: false });
         expect(parentModel.staffPermissions).toBeNull();
         expect(getDocs).not.toHaveBeenCalled();
         expect(getAllUsers).not.toHaveBeenCalled();
+    });
+
+    it('loads deferred insights and sponsors only when requested', async () => {
+        getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears', sport: 'Basketball' });
+        getPlayers.mockResolvedValue([{ id: 'player-1', name: 'Pat Star', photoUrl: 'https://img.example.test/player.png' }]);
+        getGames.mockResolvedValue([
+            { id: 'game-1', opponent: 'Falcons', date: new Date('2026-05-01T18:00:00Z'), status: 'completed', homeScore: 42, awayScore: 35, isHome: true }
+        ]);
+        getConfigs.mockResolvedValue([{
+            id: 'basketball',
+            name: 'Basketball',
+            columns: ['pts'],
+            statDefinitions: [{ id: 'pts', label: 'Points', acronym: 'PTS', topStat: true, visibility: 'public', scope: 'player' }]
+        }]);
+        getAggregatedStatsForGames.mockResolvedValue({ 'player-1': { pts: 88 } });
+        getPublicTrackingItems.mockResolvedValue([{ id: 'item-1', title: 'Bring ball', public: true }]);
+        getPlayerTrackingStatuses.mockResolvedValue([{ itemId: 'item-1', playerId: 'player-1', status: 'complete', public: true }]);
+        getLocalAttractionSponsors.mockResolvedValue([{ id: 'local-1', name: 'Museum', description: 'Visit downtown', imageUrl: null, websiteUrl: 'https://museum.example.test' }]);
+        getAdSpaceSponsors.mockResolvedValue([{ id: 'ad-1', name: 'Pizza Place', description: 'After game', imageUrl: null, websiteUrl: 'https://pizza.example.test' }]);
+
+        const insights = await loadTeamDetailInsights('team-1', { uid: 'parent-1', email: 'parent@example.com', displayName: 'Parent', roles: ['parent'], parentOf: [{ teamId: 'team-1', playerId: 'player-1' }] });
+        const sponsors = await loadTeamDetailSponsors('team-1');
+
+        expect(getAggregatedStatsForGames).toHaveBeenCalledWith('team-1', ['game-1']);
+        expect(getPublicTrackingItems).toHaveBeenCalledWith('team-1');
+        expect(getPlayerTrackingStatuses).toHaveBeenCalledWith('team-1', ['player-1']);
+        expect(insights.leaderboards[0].leaders[0]).toMatchObject({ playerId: 'player-1', formattedValue: '88' });
+        expect(insights.trackingSummaries[0].items[0]).toMatchObject({ title: 'Bring ball', isComplete: true });
+        expect(getLocalAttractionSponsors).toHaveBeenCalledWith('team-1');
+        expect(getAdSpaceSponsors).toHaveBeenCalledWith('team-1');
+        expect(sponsors.sponsors.map((sponsor) => sponsor.id)).toEqual(['ad-1', 'local-1']);
     });
 
     it('loads deferred staff permissions only when requested for a team manager', async () => {

--- a/tests/unit/app-team-detail-staff-permissions.test.jsx
+++ b/tests/unit/app-team-detail-staff-permissions.test.jsx
@@ -6,6 +6,8 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom';
 
 const teamDetailMocks = vi.hoisted(() => ({
     loadParentTeamDetail: vi.fn(),
+    loadTeamDetailInsights: vi.fn(),
+    loadTeamDetailSponsors: vi.fn(),
     loadTeamStaffPermissions: vi.fn(),
     grantScorekeeperAccessForApp: vi.fn(),
     grantVideographerAccessForApp: vi.fn(),
@@ -25,7 +27,7 @@ const publicActionMocks = vi.hoisted(() => ({
 vi.mock('../../apps/app/src/lib/teamDetailService.ts', () => teamDetailMocks);
 vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionMocks);
 vi.mock('../../apps/app/src/lib/scheduleService.ts', () => ({
-    loadStaffRsvpReminderPreview: vi.fn(),
+    createStaffRsvpReminderPreviewLoader: vi.fn(() => ({ loadPreview: vi.fn() })),
     sendStaffRsvpReminder: vi.fn()
 }));
 
@@ -145,6 +147,8 @@ beforeEach(() => {
     };
     window.scrollTo = vi.fn();
     publicActionMocks.copyPublicText.mockResolvedValue('copied');
+    teamDetailMocks.loadTeamDetailInsights.mockResolvedValue({ leaderboards: [], trackingSummaries: [] });
+    teamDetailMocks.loadTeamDetailSponsors.mockResolvedValue({ sponsors: [] });
     teamDetailMocks.grantScorekeeperAccessForApp.mockResolvedValue(undefined);
     teamDetailMocks.grantVideographerAccessForApp.mockResolvedValue(undefined);
     teamDetailMocks.revokeScorekeeperAccessForApp.mockResolvedValue(undefined);


### PR DESCRIPTION
Closes #1855

## What changed
- split TeamDetail bootstrap so the first route render only loads core team, roster, and schedule data
- added deferred `loadTeamDetailInsights` and `loadTeamDetailSponsors` loaders that run only when the Insights or More tab opens
- kept deferred data cached after first load so later tab switches reuse it instead of refetching
- added inline loading and error states for deferred Insights and More content so the page stays usable if those requests fail
- updated focused TeamDetail service and integration tests to prove non-core queries stay out of the initial bootstrap and only fire once per tab

## Root Cause
`loadParentTeamDetail` eagerly awaited leaderboards, tracking summaries, and sponsor queries during the route bootstrap, so TeamDetail could not paint until tab-specific data finished even though Overview, Schedule, and Roster did not need it.

## Prevention / Learning
When a route has secondary tabs, keep the initial loader limited to first-paint dependencies and move tab-specific data behind explicit deferred loaders with tab-local loading and error states. Regression tests should assert both that bootstrap skips those queries and that each deferred loader runs once on first tab open.

## Regression Tests
- `npx vitest run tests/unit/app-team-detail-service.test.js tests/unit/app-team-detail-integration.test.jsx tests/unit/app-team-detail-staff-permissions.test.jsx --reporter=verbose`
- service regression verifies initial bootstrap does not call aggregated stats, tracking, or sponsor queries until deferred loaders run
- integration regression verifies Insights and More hydrate once on first open, reuse cached data on later tab switches, and show inline errors without breaking the rest of the page