### PR TITLE
Speed up legacy game deep link resolution

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -22,6 +22,7 @@ vi.mock('../../../../js/firebase.js', () => ({
 
 vi.mock('../../../../js/db.js', () => ({
   getAssignmentClaims: vi.fn(),
+  getGame: vi.fn(),
   getGames: vi.fn(),
   getPracticePacketCompletions: vi.fn(),
   getPracticeSessions: vi.fn(),
@@ -82,8 +83,50 @@ vi.mock('./uxTiming', () => ({ startUxTimer: vi.fn(() => ({ end: vi.fn() })) }))
 vi.mock('./chatService', () => ({ sendTeamChatMessage: vi.fn() }));
 vi.mock('./chatLogic', () => ({ DEFAULT_TEAM_CONVERSATION_ID: 'team' }));
 
-import { updateGame, getPlayers, getRsvpBreakdownByPlayer, getRsvps, submitRsvpForPlayer } from '../../../../js/db.js';
-import { buildPlayerScoringLiveEvent, loadStaffScheduleRsvpBreakdown, recordPlayerScoringStat, saveScheduledGameLineupDraftForApp, submitStaffScheduleRsvpOverride } from './scheduleService';
+import { updateGame, getGame, getGames, getPlayers, getPracticeSessions, getRsvpBreakdownByPlayer, getRsvps, getTeams, submitRsvpForPlayer } from '../../../../js/db.js';
+import { fetchAndParseCalendar } from '../../../../js/utils.js';
+import { loadProfileDocument } from './profileService';
+import { buildPlayerScoringLiveEvent, loadStaffScheduleRsvpBreakdown, recordPlayerScoringStat, resolveParentGameRoute, saveScheduledGameLineupDraftForApp, submitStaffScheduleRsvpOverride } from './scheduleService';
+
+describe('parent game route resolution', () => {
+  beforeEach(() => {
+    (globalThis as any).window = globalThis as any;
+    vi.clearAllMocks();
+    vi.mocked(loadProfileDocument).mockResolvedValue({
+      parentOf: [
+        { teamId: 'team-alpha', playerId: 'child-1', playerName: 'Avery' },
+        { teamId: 'team-bravo', playerId: 'child-2', playerName: 'Blake' }
+      ]
+    } as any);
+    vi.mocked(getTeams).mockResolvedValue([] as any);
+    vi.mocked(getGame).mockImplementation(async (teamId: string, gameId: string) => {
+      if (teamId === 'team-bravo' && gameId === 'game-7') {
+        return { id: 'game-7', type: 'game' } as any;
+      }
+      return null as any;
+    });
+    vi.mocked(getGames).mockResolvedValue([] as any);
+    vi.mocked(getPracticeSessions).mockResolvedValue([] as any);
+    vi.mocked(fetchAndParseCalendar).mockResolvedValue([] as any);
+  });
+
+  it('resolves a game route without loading full schedules or calendars', async () => {
+    const result = await resolveParentGameRoute({ uid: 'parent-1', email: 'parent@example.com', roles: [] } as any, 'game-7', {
+      expandStaffPlayers: false
+    });
+
+    expect(result).toEqual({
+      teamId: 'team-bravo',
+      eventId: 'game-7',
+      childId: 'child-2'
+    });
+    expect(getGame).toHaveBeenCalledWith('team-alpha', 'game-7');
+    expect(getGame).toHaveBeenCalledWith('team-bravo', 'game-7');
+    expect(getGames).not.toHaveBeenCalled();
+    expect(getPracticeSessions).not.toHaveBeenCalled();
+    expect(fetchAndParseCalendar).not.toHaveBeenCalled();
+  });
+});
 
 describe('player-attributed live scoring', () => {
   beforeEach(() => {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -121,6 +121,12 @@ export type ParentScheduleEventDetailLoadOptions = ParentScheduleLoadOptions & {
   eventId: string;
 };
 
+export type ParentGameRouteResolution = {
+  teamId: string;
+  eventId: string;
+  childId: string | null;
+};
+
 export type StaffScheduleRsvpRow = {
   playerId: string;
   playerName: string;
@@ -1847,6 +1853,49 @@ export async function loadParentScheduleEventDetail(user: AuthUser | null, optio
     return { children, events };
   } catch (error: any) {
     timer.end({ hydrateDetails, expandStaffPlayers, teamId: requestedTeamId, eventId: requestedEventId, error: error?.message || 'Unable to load schedule event detail.' });
+    throw error;
+  }
+}
+
+export async function resolveParentGameRoute(user: AuthUser | null, gameId: string, options: ParentScheduleLoadOptions = {}): Promise<ParentGameRouteResolution | null> {
+  const requestedGameId = compactString(gameId);
+
+  if (!user?.uid || !requestedGameId) {
+    return null;
+  }
+
+  const timer = startUxTimer('parent game route resolve');
+  const expandStaffPlayers = options.expandStaffPlayers === true;
+
+  try {
+    const profile = await loadProfileDocument(user.uid);
+    const { children, byTeam, staffTeams } = await buildParentScheduleTeamChildren(user, profile as Record<string, unknown>, { expandStaffPlayers });
+    const teamEntries = [...byTeam.entries()];
+
+    const matches = await mapWithConcurrency(teamEntries, parentScheduleTeamConcurrency, async ([teamId, teamChildren]) => {
+      try {
+        const game = await loadGameById(teamId, requestedGameId);
+        const eventId = compactString(game?.id || game?.gameId || requestedGameId);
+        if (!game || eventId !== requestedGameId) return null;
+        const childId = (teamChildren || [])
+          .map((child) => compactString(child?.playerId))
+          .find((value) => value && !value.startsWith(`staff-team-${teamId}`)) || null;
+        return {
+          teamId,
+          eventId,
+          childId
+        };
+      } catch (error) {
+        console.warn('[schedule-service] Failed to resolve game route for team:', teamId, error);
+        return null;
+      }
+    });
+
+    const resolution = matches.find(Boolean) || null;
+    timer.end({ gameId: requestedGameId, expandStaffPlayers, childLinks: children.length, teams: byTeam.size, staffTeams: staffTeams.length, matched: Boolean(resolution) });
+    return resolution;
+  } catch (error: any) {
+    timer.end({ gameId: requestedGameId, expandStaffPlayers, error: error?.message || 'Unable to resolve game route.' });
     throw error;
   }
 }

--- a/apps/app/src/pages/GameDetail.test.tsx
+++ b/apps/app/src/pages/GameDetail.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const scheduleServiceMocks = vi.hoisted(() => ({
-  loadParentSchedule: vi.fn()
+  resolveParentGameRoute: vi.fn()
 }))
 
 vi.mock('../lib/scheduleService', () => scheduleServiceMocks)
@@ -61,16 +61,10 @@ describe('GameDetail route resolution', () => {
   })
 
   it('routes /games/:gameId into the schedule event detail workflow', async () => {
-    scheduleServiceMocks.loadParentSchedule.mockResolvedValue({
-      children: [],
-      events: [
-        {
-          id: 'game-1',
-          teamId: 'team-bears',
-          childId: 'player-7',
-          type: 'game'
-        }
-      ]
+    scheduleServiceMocks.resolveParentGameRoute.mockResolvedValue({
+      teamId: 'team-bears',
+      eventId: 'game-1',
+      childId: 'player-7'
     })
 
     renderGameDetail()
@@ -86,17 +80,13 @@ describe('GameDetail route resolution', () => {
     expect(screen.getByText('Assignments')).toBeTruthy()
     expect(screen.queryByText('Live chat')).toBeNull()
     expect(screen.queryByText('Player Performance')).toBeNull()
-    expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenCalledWith(auth.user, {
-      hydrateDetails: false,
+    expect(scheduleServiceMocks.resolveParentGameRoute).toHaveBeenCalledWith(auth.user, 'game-1', {
       expandStaffPlayers: false
     })
   })
 
   it('shows a recovery state when the game cannot be resolved', async () => {
-    scheduleServiceMocks.loadParentSchedule.mockResolvedValue({
-      children: [],
-      events: []
-    })
+    scheduleServiceMocks.resolveParentGameRoute.mockResolvedValue(null)
 
     renderGameDetail('/games/missing-game')
 

--- a/apps/app/src/pages/GameDetail.tsx
+++ b/apps/app/src/pages/GameDetail.tsx
@@ -1,26 +1,20 @@
 import { useEffect, useMemo, useState } from 'react'
 import { AlertCircle, ChevronLeft, RefreshCw } from 'lucide-react'
 import { Link, Navigate, useParams } from 'react-router-dom'
-import { loadParentSchedule } from '../lib/scheduleService'
-import type { ParentScheduleEvent } from '../lib/scheduleLogic'
+import { resolveParentGameRoute, type ParentGameRouteResolution } from '../lib/scheduleService'
 import type { AuthState } from '../lib/types'
 
 type ResolutionState = {
   loading: boolean
-  targetEvent: ParentScheduleEvent | null
+  targetRoute: ParentGameRouteResolution | null
   error: string | null
-}
-
-function pickTargetEvent(events: ParentScheduleEvent[], gameId: string) {
-  const matches = events.filter((event) => event.id === gameId)
-  return matches.find((event) => event.type === 'game') || matches[0] || null
 }
 
 export function GameDetail({ auth }: { auth: AuthState }) {
   const { gameId = '' } = useParams()
   const [state, setState] = useState<ResolutionState>({
     loading: true,
-    targetEvent: null,
+    targetRoute: null,
     error: null
   })
 
@@ -30,34 +24,33 @@ export function GameDetail({ auth }: { auth: AuthState }) {
     async function resolveGameRoute() {
       if (!auth.user || !gameId) {
         if (!cancelled) {
-          setState({ loading: false, targetEvent: null, error: 'This game is not available right now.' })
+          setState({ loading: false, targetRoute: null, error: 'This game is not available right now.' })
         }
         return
       }
 
-      setState({ loading: true, targetEvent: null, error: null })
+      setState({ loading: true, targetRoute: null, error: null })
 
       try {
-        const result = await loadParentSchedule(auth.user, { hydrateDetails: false, expandStaffPlayers: false })
-        const targetEvent = pickTargetEvent(result.events, gameId)
+        const targetRoute = await resolveParentGameRoute(auth.user, gameId, { expandStaffPlayers: false })
 
         if (cancelled) return
 
-        if (!targetEvent) {
+        if (!targetRoute) {
           setState({
             loading: false,
-            targetEvent: null,
+            targetRoute: null,
             error: 'We could not find this game in your live schedule. Open Schedule to find the event or refresh after the team shares access.'
           })
           return
         }
 
-        setState({ loading: false, targetEvent, error: null })
+        setState({ loading: false, targetRoute, error: null })
       } catch (error: any) {
         if (cancelled) return
         setState({
           loading: false,
-          targetEvent: null,
+          targetRoute: null,
           error: error?.message || 'Unable to open this game right now.'
         })
       }
@@ -71,10 +64,10 @@ export function GameDetail({ auth }: { auth: AuthState }) {
   }, [auth.user, gameId])
 
   const redirectTarget = useMemo(() => {
-    if (!state.targetEvent) return ''
-    const childQuery = state.targetEvent.childId ? `?childId=${encodeURIComponent(state.targetEvent.childId)}` : ''
-    return `/schedule/${encodeURIComponent(state.targetEvent.teamId)}/${encodeURIComponent(state.targetEvent.id)}${childQuery}`
-  }, [state.targetEvent])
+    if (!state.targetRoute) return ''
+    const childQuery = state.targetRoute.childId ? `?childId=${encodeURIComponent(state.targetRoute.childId)}` : ''
+    return `/schedule/${encodeURIComponent(state.targetRoute.teamId)}/${encodeURIComponent(state.targetRoute.eventId)}${childQuery}`
+  }, [state.targetRoute])
 
   if (redirectTarget) {
     return <Navigate to={redirectTarget} replace />

--- a/tests/support/lucide-react-stub.ts
+++ b/tests/support/lucide-react-stub.ts
@@ -6,8 +6,10 @@ function createIcon(name: string) {
   };
 }
 
+export const AlertCircle = createIcon('AlertCircle');
 export const Bell = createIcon('Bell');
 export const ChevronDown = createIcon('ChevronDown');
+export const ChevronLeft = createIcon('ChevronLeft');
 export const ChevronUp = createIcon('ChevronUp');
 export const CheckCircle2 = createIcon('CheckCircle2');
 export const Clipboard = createIcon('Clipboard');

--- a/tests/unit/app-game-detail-baseball-walk.test.jsx
+++ b/tests/unit/app-game-detail-baseball-walk.test.jsx
@@ -9,7 +9,10 @@ const scheduleServiceMocks = vi.hoisted(() => ({
     resolveParentGameRoute: vi.fn()
 }));
 
-vi.mock('../../apps/app/src/lib/scheduleService', () => scheduleServiceMocks);
+vi.mock('../../apps/app/src/lib/scheduleService', async (importOriginal) => ({
+    ...(await importOriginal()),
+    ...scheduleServiceMocks
+}));
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 

--- a/tests/unit/app-game-detail-baseball-walk.test.jsx
+++ b/tests/unit/app-game-detail-baseball-walk.test.jsx
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { GameDetail } from '../../apps/app/src/pages/GameDetail.tsx';
 
 const scheduleServiceMocks = vi.hoisted(() => ({
-    loadParentSchedule: vi.fn()
+    resolveParentGameRoute: vi.fn()
 }));
 
 vi.mock('../../apps/app/src/lib/scheduleService', () => scheduleServiceMocks);
@@ -66,16 +66,10 @@ afterEach(() => {
 
 describe('app GameDetail route resolution', () => {
     it('routes tracked games into the live schedule event detail workflow', async () => {
-        scheduleServiceMocks.loadParentSchedule.mockResolvedValue({
-            children: [],
-            events: [
-                {
-                    id: 'game-baseball',
-                    teamId: 'team-baseball',
-                    childId: 'player-1',
-                    type: 'game'
-                }
-            ]
+        scheduleServiceMocks.resolveParentGameRoute.mockResolvedValue({
+            teamId: 'team-baseball',
+            eventId: 'game-baseball',
+            childId: 'player-1'
         });
 
         const { container, root, router } = await renderGameDetail();
@@ -91,8 +85,7 @@ describe('app GameDetail route resolution', () => {
         expect(container.textContent).toContain('Assignments');
         expect(container.textContent).toContain('Live event workflow');
         expect(container.textContent).not.toContain('Live chat');
-        expect(scheduleServiceMocks.loadParentSchedule).toHaveBeenCalledWith(coachAuth.user, {
-            hydrateDetails: false,
+        expect(scheduleServiceMocks.resolveParentGameRoute).toHaveBeenCalledWith(coachAuth.user, 'game-baseball', {
             expandStaffPlayers: false
         });
 
@@ -102,10 +95,7 @@ describe('app GameDetail route resolution', () => {
     });
 
     it('shows a recovery state when the game cannot be resolved', async () => {
-        scheduleServiceMocks.loadParentSchedule.mockResolvedValue({
-            children: [],
-            events: []
-        });
+        scheduleServiceMocks.resolveParentGameRoute.mockResolvedValue(null);
 
         const { container, root } = await renderGameDetail('/games/unknown-game');
 


### PR DESCRIPTION
Closes #1857

## What changed
- added `resolveParentGameRoute` in `apps/app/src/lib/scheduleService.ts` to resolve `/games/:gameId` from directly accessible team/game records instead of bootstrapping the full parent schedule
- updated `GameDetail` to use the lightweight resolver and redirect straight to `/schedule/:teamId/:eventId`, preserving `childId` when a real linked child is available
- added regression coverage proving the resolver skips full schedule loading and imported calendar fetches, and updated the route test to assert `GameDetail` uses the new resolver

## Root Cause
`GameDetail` resolved legacy `/games/:gameId` links by calling `loadParentSchedule(...)` and filtering the resulting event list client-side. That reused a full-screen schedule bootstrap for a single-record lookup, which unnecessarily loaded unrelated team schedules, practice-session hydration, and imported calendars before redirecting.

## Prevention / Learning
When a route only needs a single canonical event target, do not reuse a broad schedule bootstrap that is optimized for rendering an entire screen. Add a narrow resolver that queries only the minimum identifying records first, then cover it with a regression test that fails if full schedule or calendar loading sneaks back into the path.

## Regression Tests
- `npm exec vitest run apps/app/src/pages/GameDetail.test.tsx apps/app/src/lib/scheduleService.test.ts`
- `apps/app/src/lib/scheduleService.test.ts` verifies `resolveParentGameRoute` resolves a DB-backed game without calling full schedule or calendar-loading code
- `apps/app/src/pages/GameDetail.test.tsx` verifies `/games/:gameId` now uses `resolveParentGameRoute` and still redirects into the live schedule event workflow