### PR TITLE
Prevent hidden Parent Tools tab rerenders

### DIFF
--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -73,6 +73,7 @@ function renderParentTools() {
 describe('ParentTools access', () => {
     beforeEach(() => {
         vi.clearAllMocks();
+        delete globalThis.__ALLPLAYS_PARENT_TOOLS_RENDER_TRACKER__;
         parentToolsServiceMocks.loadParentAccessModel.mockResolvedValue({
             teams: [{ id: 'team-1', name: 'Bears', sport: 'Soccer' }],
             requests: []
@@ -89,6 +90,7 @@ describe('ParentTools access', () => {
     });
 
     afterEach(() => {
+        delete globalThis.__ALLPLAYS_PARENT_TOOLS_RENDER_TRACKER__;
         cleanup();
     });
 
@@ -255,6 +257,58 @@ describe('ParentTools access', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Register' }));
         expect(await screen.findByText('Summer Camp')).toBeTruthy();
         expect(parentToolsServiceMocks.loadParentRegistrations).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not rerender inactive visited panels when only the active tab changes', async () => {
+        parentToolsServiceMocks.loadParentFeesForApp.mockResolvedValue([
+            {
+                id: 'fee-1',
+                title: 'Team dues',
+                teamId: 'team-1',
+                teamName: 'Bears',
+                playerName: 'Sam Player',
+                status: 'open',
+                amountLabel: '$100',
+                dueLabel: 'Today',
+                statusLabel: 'Open',
+                balanceDueCents: 10000,
+                canPay: false,
+                lineItems: [],
+                installments: [],
+                ledgerEntries: []
+            }
+        ]);
+        parentToolsServiceMocks.loadParentCalendarTools.mockResolvedValue({
+            events: [],
+            teams: []
+        });
+
+        const renderCounts: Record<string, number> = {};
+        globalThis.__ALLPLAYS_PARENT_TOOLS_RENDER_TRACKER__ = (toolId) => {
+            renderCounts[toolId] = (renderCounts[toolId] || 0) + 1;
+        };
+
+        renderParentTools();
+
+        await screen.findByText('Request player access');
+        expect(renderCounts.access).toBe(1);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Fees' }));
+        await screen.findByText('Team dues');
+        expect(renderCounts.fees).toBe(1);
+        expect(renderCounts.access).toBe(1);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Calendar' }));
+        await screen.findByText('No team schedules');
+        expect(renderCounts.calendar).toBe(1);
+        expect(renderCounts.fees).toBe(1);
+        expect(renderCounts.access).toBe(1);
+
+        fireEvent.click(screen.getByRole('button', { name: 'Fees' }));
+        await screen.findByText('Team dues');
+        expect(renderCounts.fees).toBe(1);
+        expect(renderCounts.calendar).toBe(1);
+        expect(renderCounts.access).toBe(1);
     });
 
     it('defers hidden fees refresh after access changes until fees is reopened', async () => {

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
-import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ParentTools } from './ParentTools';
 import type { AuthState } from '../lib/types';
@@ -59,11 +59,28 @@ const auth: AuthState = {
     signOut: vi.fn().mockResolvedValue(undefined)
 };
 
-function renderParentTools() {
+function ParentToolsRoute() {
+    return <ParentTools auth={auth} />;
+}
+
+function InvalidParentToolsButton() {
+    const navigate = useNavigate();
+    return <button type="button" onClick={() => navigate('/parent-tools/not-a-real-tab')}>Go invalid</button>;
+}
+
+function renderParentTools(initialEntries: string[] = ['/parent-tools/access'], includeInvalidButton = false) {
     return render(
-        <MemoryRouter initialEntries={['/parent-tools/access']}>
+        <MemoryRouter initialEntries={initialEntries}>
             <Routes>
-                <Route path="/parent-tools/:toolId" element={<ParentTools auth={auth} />} />
+                <Route
+                    path="/parent-tools/:toolId"
+                    element={(
+                        <>
+                            {includeInvalidButton ? <InvalidParentToolsButton /> : null}
+                            <ParentToolsRoute />
+                        </>
+                    )}
+                />
                 <Route path="/accept-invite" element={<div>Accept invite route</div>} />
             </Routes>
         </MemoryRouter>
@@ -257,6 +274,21 @@ describe('ParentTools access', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Register' }));
         expect(await screen.findByText('Summer Camp')).toBeTruthy();
         expect(parentToolsServiceMocks.loadParentRegistrations).toHaveBeenCalledTimes(2);
+    });
+
+    it('redirects invalid tabs without triggering a hook order violation', async () => {
+        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+        renderParentTools(['/parent-tools/access'], true);
+
+        await screen.findByText('Request player access');
+        fireEvent.click(screen.getByRole('button', { name: 'Go invalid' }));
+
+        expect(await screen.findByText('Request player access')).toBeTruthy();
+        expect(consoleErrorSpy).not.toHaveBeenCalledWith(expect.stringContaining('Rendered fewer hooks than expected'));
+        expect(consoleErrorSpy).not.toHaveBeenCalledWith(expect.stringContaining('change in the order of Hooks'));
+
+        consoleErrorSpy.mockRestore();
     });
 
     it('does not rerender inactive visited panels when only the active tab changes', async () => {

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -155,8 +155,6 @@ export function ParentTools({ auth }: { auth: AuthState }) {
     }));
   }, [activeTool]);
 
-  if (!activeTool) return <Navigate to="/parent-tools/access" replace />;
-
   const setTool = useCallback((nextTool: ParentToolId) => {
     navigate(`/parent-tools/${nextTool}`);
     window.requestAnimationFrame(() => {
@@ -174,6 +172,8 @@ export function ParentTools({ auth }: { auth: AuthState }) {
     } : current);
     setStaleTools(() => new Set(accessDependentToolIds.filter((id) => id !== currentActiveTool && currentVisitedTools.includes(id))));
   }, []);
+
+  if (!activeTool) return <Navigate to="/parent-tools/access" replace />;
 
   return (
     <div className="parent-tools-page space-y-3">

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react';
+import { memo, useCallback, useEffect, useMemo, useRef, useState, type FormEvent, type ReactNode } from 'react';
 import { Link, Navigate, useNavigate, useParams } from 'react-router-dom';
 import type { LucideIcon } from 'lucide-react';
 import {
@@ -57,6 +57,10 @@ import type { AuthState } from '../lib/types';
 
 type ParentToolId = 'access' | 'household' | 'fees' | 'calendar' | 'share' | 'registrations' | 'certificates';
 
+declare global {
+  var __ALLPLAYS_PARENT_TOOLS_RENDER_TRACKER__: ((toolId: ParentToolId) => void) | undefined;
+}
+
 const tools: Array<{ id: ParentToolId; label: string; icon: LucideIcon }> = [
   { id: 'access', label: 'Access', icon: Shield },
   { id: 'household', label: 'Household', icon: Users },
@@ -70,6 +74,45 @@ const tools: Array<{ id: ParentToolId; label: string; icon: LucideIcon }> = [
 const validToolIds = new Set(tools.map((tool) => tool.id));
 const accessDependentToolIds = tools.map((tool) => tool.id).filter((id): id is ParentToolId => id !== 'access');
 const initialToolRefreshVersions = Object.fromEntries(tools.map((tool) => [tool.id, 0])) as Record<ParentToolId, number>;
+
+function trackParentToolRender(toolId: ParentToolId) {
+  globalThis.__ALLPLAYS_PARENT_TOOLS_RENDER_TRACKER__?.(toolId);
+}
+
+const MemoizedAccessTool = memo(function MemoizedAccessTool(props: { auth: AuthState; onAccessChanged: () => void }) {
+  trackParentToolRender('access');
+  return <AccessTool {...props} />;
+});
+
+const MemoizedHouseholdInviteTool = memo(function MemoizedHouseholdInviteTool(props: { auth: AuthState; refreshVersion: number }) {
+  trackParentToolRender('household');
+  return <HouseholdInviteTool {...props} />;
+});
+
+const MemoizedFeesTool = memo(function MemoizedFeesTool(props: { auth: AuthState; refreshVersion: number }) {
+  trackParentToolRender('fees');
+  return <FeesTool {...props} />;
+});
+
+const MemoizedCalendarTool = memo(function MemoizedCalendarTool(props: { auth: AuthState; refreshVersion: number }) {
+  trackParentToolRender('calendar');
+  return <CalendarTool {...props} />;
+});
+
+const MemoizedFamilyShareTool = memo(function MemoizedFamilyShareTool(props: { auth: AuthState; refreshVersion: number }) {
+  trackParentToolRender('share');
+  return <FamilyShareTool {...props} />;
+});
+
+const MemoizedRegistrationsTool = memo(function MemoizedRegistrationsTool(props: { auth: AuthState; refreshVersion: number }) {
+  trackParentToolRender('registrations');
+  return <RegistrationsTool {...props} />;
+});
+
+const MemoizedCertificatesTool = memo(function MemoizedCertificatesTool(props: { auth: AuthState; refreshVersion: number }) {
+  trackParentToolRender('certificates');
+  return <CertificatesTool {...props} />;
+});
 
 export function ParentTools({ auth }: { auth: AuthState }) {
   const { toolId = 'access' } = useParams();
@@ -114,14 +157,14 @@ export function ParentTools({ auth }: { auth: AuthState }) {
 
   if (!activeTool) return <Navigate to="/parent-tools/access" replace />;
 
-  const setTool = (nextTool: ParentToolId) => {
+  const setTool = useCallback((nextTool: ParentToolId) => {
     navigate(`/parent-tools/${nextTool}`);
     window.requestAnimationFrame(() => {
       window.scrollTo({ top: 0, behavior: 'smooth' });
     });
-  };
+  }, [navigate]);
 
-  const handleAccessChanged = () => {
+  const handleAccessChanged = useCallback(() => {
     const currentActiveTool = activeToolRef.current;
     const currentVisitedTools = visitedToolsRef.current;
 
@@ -130,7 +173,7 @@ export function ParentTools({ auth }: { auth: AuthState }) {
       [currentActiveTool]: current[currentActiveTool] + 1
     } : current);
     setStaleTools(() => new Set(accessDependentToolIds.filter((id) => id !== currentActiveTool && currentVisitedTools.includes(id))));
-  };
+  }, []);
 
   return (
     <div className="parent-tools-page space-y-3">
@@ -168,13 +211,13 @@ export function ParentTools({ auth }: { auth: AuthState }) {
         </div>
       </div>
 
-      <KeepAliveTool active={activeTool === 'access'} mounted={visitedTools.includes('access')}><AccessTool auth={auth} onAccessChanged={handleAccessChanged} /></KeepAliveTool>
-      <KeepAliveTool active={activeTool === 'household'} mounted={visitedTools.includes('household')}><HouseholdInviteTool auth={auth} refreshVersion={toolRefreshVersions.household} /></KeepAliveTool>
-      <KeepAliveTool active={activeTool === 'fees'} mounted={visitedTools.includes('fees')}><FeesTool auth={auth} refreshVersion={toolRefreshVersions.fees} /></KeepAliveTool>
-      <KeepAliveTool active={activeTool === 'calendar'} mounted={visitedTools.includes('calendar')}><CalendarTool auth={auth} refreshVersion={toolRefreshVersions.calendar} /></KeepAliveTool>
-      <KeepAliveTool active={activeTool === 'share'} mounted={visitedTools.includes('share')}><FamilyShareTool auth={auth} refreshVersion={toolRefreshVersions.share} /></KeepAliveTool>
-      <KeepAliveTool active={activeTool === 'registrations'} mounted={visitedTools.includes('registrations')}><RegistrationsTool auth={auth} refreshVersion={toolRefreshVersions.registrations} /></KeepAliveTool>
-      <KeepAliveTool active={activeTool === 'certificates'} mounted={visitedTools.includes('certificates')}><CertificatesTool auth={auth} refreshVersion={toolRefreshVersions.certificates} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'access'} mounted={visitedTools.includes('access')}><MemoizedAccessTool auth={auth} onAccessChanged={handleAccessChanged} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'household'} mounted={visitedTools.includes('household')}><MemoizedHouseholdInviteTool auth={auth} refreshVersion={toolRefreshVersions.household} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'fees'} mounted={visitedTools.includes('fees')}><MemoizedFeesTool auth={auth} refreshVersion={toolRefreshVersions.fees} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'calendar'} mounted={visitedTools.includes('calendar')}><MemoizedCalendarTool auth={auth} refreshVersion={toolRefreshVersions.calendar} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'share'} mounted={visitedTools.includes('share')}><MemoizedFamilyShareTool auth={auth} refreshVersion={toolRefreshVersions.share} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'registrations'} mounted={visitedTools.includes('registrations')}><MemoizedRegistrationsTool auth={auth} refreshVersion={toolRefreshVersions.registrations} /></KeepAliveTool>
+      <KeepAliveTool active={activeTool === 'certificates'} mounted={visitedTools.includes('certificates')}><MemoizedCertificatesTool auth={auth} refreshVersion={toolRefreshVersions.certificates} /></KeepAliveTool>
     </div>
   );
 }

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -37,6 +37,8 @@ async function mockScheduleModules(page, options = {}) {
     }).join(',\n                            ');
 
     await page.addInitScript(() => {
+        window.localStorage.clear();
+        window.sessionStorage.clear();
         const RealDate = Date;
         const fixedNow = new RealDate('2026-05-20T12:00:00Z').getTime();
         class FixedDate extends RealDate {

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -75,6 +75,8 @@ async function openDesktopSearch(page) {
 
 async function mockSearchModules(page) {
     await page.addInitScript(() => {
+        window.localStorage.clear();
+        window.sessionStorage.clear();
         window.__openedPublicUrls = [];
         window.__teamSearchQueries = [];
         window.__loadAppSearchTeamsCalls = 0;


### PR DESCRIPTION
Closes #1854

## What changed
- wrapped each Parent Tools workflow panel in a memoized component so visited hidden tabs stay mounted without rerendering on unrelated tab switches
- stabilized the access-change callback so the Access panel also stays render-isolated until its own data actually changes
- added a focused ParentTools regression test that counts panel renders across tab switches, alongside the existing stale-refresh coverage

## Root Cause
ParentTools preserved visited tabs in the tree, but it recreated fresh child elements on every parent render. Because hidden panels still received new React elements and the Access tab also received a new callback reference each time, inactive visited workflows kept participating in reconciliation whenever `activeTool` changed.

## Prevention / Learning
For keep-alive tab containers, preserving mount state is not enough. Hidden panels also need memoized component boundaries and stable parent-supplied props so navigation-only state changes do not cascade through cached workflow trees.

## Regression Tests
- `npx vitest run apps/app/src/pages/ParentTools.test.tsx --reporter=verbose`
- `apps/app/src/pages/ParentTools.test.tsx` now verifies inactive visited panels do not rerender when only the active tab changes
- existing stale-refresh tests still verify deferred invalidation only refreshes the reopened tab

## Recurrence Risk
Low. The cached panels now sit behind `React.memo` with stable props, and the new render-count regression test guards the exact tab-switch path that was causing hidden workflow rerenders.