### PR TITLE
Preload highlighted app search routes

### DIFF
--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -133,7 +133,7 @@ describe('AppSearchDialog', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
-  it('navigates search results immediately while preloading the route in the background', async () => {
+  it('preloads a keyboard-highlighted route before Enter and reuses it on navigation', async () => {
     const onClose = vi.fn();
     let releasePreload!: () => void;
     preloadSearchRouteMock.mockImplementationOnce(() => new Promise<boolean>((resolve) => {
@@ -149,13 +149,39 @@ describe('AppSearchDialog', () => {
       </MemoryRouter>
     );
 
-    fireEvent.click(await screen.findByRole('button', { name: /Rockets/ }));
+    const dialog = screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' });
+    fireEvent.keyDown(dialog, { key: 'ArrowDown' });
 
     await waitFor(() => expect(preloadSearchRouteMock).toHaveBeenCalledWith('/teams/team-2'));
+    expect(navigateMock).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(dialog, { key: 'Enter' });
     expect(navigateMock).toHaveBeenCalledWith('/teams/team-2');
 
     releasePreload();
     await waitFor(() => expect(preloadSearchRouteMock).toHaveBeenCalledTimes(1));
+  });
+
+  it('dedupes repeated hover preloads for the same route within one dialog session', async () => {
+    const onClose = vi.fn();
+    getKnownAppSearchTeamsMock.mockReturnValue([{ id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }]);
+
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <Routes>
+          <Route path="*" element={<AppSearchDialog auth={auth} open={true} onClose={onClose} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    const rocketsResult = await screen.findByRole('button', { name: /Rockets/ });
+    fireEvent.mouseEnter(rocketsResult);
+    fireEvent.mouseEnter(rocketsResult);
+    fireEvent.click(rocketsResult);
+
+    await waitFor(() => expect(preloadSearchRouteMock).toHaveBeenCalledWith('/teams/team-2'));
+    expect(preloadSearchRouteMock).toHaveBeenCalledTimes(1);
+    expect(navigateMock).toHaveBeenCalledWith('/teams/team-2');
   });
 
   it('does not load teams on open and waits for typing before bounded team search queries', async () => {

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -38,6 +38,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
   const [helpRoleFilter, setHelpRoleFilter] = useState<AppSearchHelpRoleFilter>('all');
   const searchRequestId = useRef(0);
   const openedAtRef = useRef(Date.now());
+  const preloadedRoutesRef = useRef(new Set<string>());
   const navigate = useNavigate();
 
   const results = useMemo(
@@ -49,6 +50,8 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
 
   useEffect(() => {
     if (!open) return;
+    openedAtRef.current = Date.now();
+    preloadedRoutesRef.current = new Set<string>();
     setQuery('');
     setPlayers([]);
     setPlayersError('');
@@ -134,12 +137,24 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
 
   if (!open) return null;
 
+  const preloadResultRoute = (item: AppSearchItem | undefined) => {
+    const route = item?.route;
+    if (!route || preloadedRoutesRef.current.has(route)) return;
+    preloadedRoutesRef.current.add(route);
+    void preloadSearchRoute(route);
+  };
+
+  const setActiveResultIndex = (index: number) => {
+    setActiveIndex(index);
+    preloadResultRoute(flatResults[index]);
+  };
+
   const openResult = async (item: AppSearchItem | undefined) => {
     if (!item) return;
     onClose();
     setQuery('');
     if (item.route) {
-      void preloadSearchRoute(item.route);
+      preloadResultRoute(item);
       navigate(item.route);
       return;
     }
@@ -156,12 +171,14 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     }
     if (event.key === 'ArrowDown') {
       event.preventDefault();
-      setActiveIndex((value) => Math.min(flatResults.length - 1, value + 1));
+      const nextIndex = Math.min(flatResults.length - 1, activeIndex + 1);
+      setActiveResultIndex(nextIndex);
       return;
     }
     if (event.key === 'ArrowUp') {
       event.preventDefault();
-      setActiveIndex((value) => Math.max(0, value - 1));
+      const nextIndex = Math.max(0, activeIndex - 1);
+      setActiveResultIndex(nextIndex);
       return;
     }
     if (event.key === 'Enter') {
@@ -247,7 +264,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
               activeIndex={activeIndex}
               offset={0}
               onOpen={openResult}
-              onHover={setActiveIndex}
+              onHover={setActiveResultIndex}
             />
 
             <SearchSection
@@ -258,7 +275,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
               status={teamsStatus}
               statusTone={teamsError ? 'error' : 'neutral'}
               onOpen={openResult}
-              onHover={setActiveIndex}
+              onHover={setActiveResultIndex}
             />
 
             <SearchSection
@@ -268,7 +285,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
               offset={results.actions.length + results.teams.length}
               status={helpStatus}
               onOpen={openResult}
-              onHover={setActiveIndex}
+              onHover={setActiveResultIndex}
             />
 
             <SearchSection
@@ -279,7 +296,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
               status={playersStatus}
               statusTone={playersError ? 'error' : 'neutral'}
               onOpen={openResult}
-              onHover={setActiveIndex}
+              onHover={setActiveResultIndex}
             />
 
             {!teamsLoading && !playersLoading && flatResults.length === 0 ? (

--- a/tests/unit/app-search-integration.test.jsx
+++ b/tests/unit/app-search-integration.test.jsx
@@ -30,6 +30,10 @@ const publicActionMocks = vi.hoisted(() => ({
     openPublicUrl: vi.fn()
 }));
 
+const routePreloadMocks = vi.hoisted(() => ({
+    preloadSearchRoute: vi.fn(async () => true)
+}));
+
 const helpMocks = vi.hoisted(() => ({
     searchHelpKnowledge: vi.fn()
 }));
@@ -39,6 +43,7 @@ vi.mock('../../js/firebase.js', () => firebaseMocks);
 vi.mock('../../apps/app/src/lib/homeService.ts', () => homeMocks);
 vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionMocks);
 vi.mock('../../apps/app/src/lib/helpKnowledgeService.ts', () => helpMocks);
+vi.mock('../../apps/app/src/lib/searchRoutePreload.ts', () => routePreloadMocks);
 
 import { AppShell } from '../../apps/app/src/components/AppShell.tsx';
 import { resetAppSearchCacheForTests } from '../../apps/app/src/lib/searchService.ts';
@@ -210,6 +215,7 @@ beforeEach(() => {
         };
     });
     helpMocks.searchHelpKnowledge.mockReturnValue([]);
+    routePreloadMocks.preloadSearchRoute.mockResolvedValue(true);
 });
 
 afterEach(() => {
@@ -469,6 +475,23 @@ describe('React app shell search', () => {
         await clickButton(container, 'Browse Teams');
 
         expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://allplays.ai/teams.html');
+        expect(routePreloadMocks.preloadSearchRoute).not.toHaveBeenCalled();
+    });
+
+    it('preloads a highlighted app route before Enter and does not preload it twice on selection', async () => {
+        const { container } = await renderShell();
+
+        await clickButton(container, 'Search');
+        await fillSearch(container, 'bea');
+        expect(container.textContent).toContain('Bears');
+
+        await pressDialogKey(container, 'ArrowDown');
+        expect(routePreloadMocks.preloadSearchRoute).toHaveBeenCalledWith('/teams/team-1');
+        expect(container.querySelector('[data-testid="route"]').textContent).toBe('/home');
+
+        await pressDialogKey(container, 'Enter');
+        expect(container.querySelector('[data-testid="route"]').textContent).toBe('/teams/team-1');
+        expect(routePreloadMocks.preloadSearchRoute).toHaveBeenCalledTimes(1);
     });
 
     it('opens the add workflow launcher with native and website actions', async () => {


### PR DESCRIPTION
Closes #1849

## What changed
- start `preloadSearchRoute()` as soon as a route-backed search result becomes active from keyboard navigation or hover
- dedupe route preloads per dialog session so Enter or click on an already warmed result does not trigger a second import
- add focused regressions for keyboard preloading, hover deduping, and href-only results staying out of the preload path

## Root Cause
`AppSearchDialog` only called `preloadSearchRoute()` inside `openResult()`, so the same click or Enter event both started the lazy import and navigated into a Suspense-backed route. On cold chunks, that left no preload head start and exposed the global loading screen.

## Prevention / Learning
When a picker navigates into lazy routes, preload on highlight or hover instead of waiting for selection, and scope deduping to the picker session so repeated focus changes do not create redundant imports.

## Regression Tests
- `apps/app/src/components/AppSearchDialog.test.tsx` verifies keyboard-highlighted results preload before Enter and repeated hover on the same route only preloads once per dialog session
- `tests/unit/app-search-integration.test.jsx` verifies route-backed app results preload before Enter, selection does not preload twice, and website-only href actions do not call the route preloader

## Recurrence Risk
Low. The preload timing now follows the active-result state instead of the selection event, and focused tests cover the exact keyboard, hover, and href branches that allowed the bug.