### PR TITLE
Stabilize desktop search smoke boot wait

### DIFF
--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -15,7 +15,6 @@ async function gotoAppRoute(page, baseURL, hashPath) {
 async function waitForAppShell(page) {
     await expect(async () => {
         await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
-        await expect(page.getByRole('button', { name: 'Search', exact: true }).first()).toBeVisible({ timeout: 1000 });
     }).toPass({ timeout: 30000 });
 }
 
@@ -55,19 +54,21 @@ async function openSearch(page) {
 
 async function openDesktopSearch(page) {
     const searchDialog = page.getByRole('dialog', { name: 'Search teams, players, actions, and help' });
-    await waitForAppShell(page);
 
     await expect(async () => {
         if (await searchDialog.isVisible().catch(() => false)) {
             return;
         }
 
+        await waitForAppShell(page);
         await page.keyboard.press('Control+K');
 
         try {
             await expect(searchDialog).toBeVisible({ timeout: 1000 });
         } catch {
-            await clickSearchTrigger(page);
+            const trigger = page.getByRole('button', { name: 'Search', exact: true }).first();
+            await expect(trigger).toBeVisible({ timeout: 1000 });
+            await trigger.click();
             await expect(searchDialog).toBeVisible({ timeout: 1000 });
         }
     }).toPass({ timeout: 30000 });


### PR DESCRIPTION
## What changed
- Stop using a specific shell chrome selector as the desktop search readiness gate.
- Retry the actual Ctrl+K/dialog open path, and only validate/click the Search trigger as a fallback.
- Keep the loading-screen wait inside the retry loop so slow app boots get another attempt instead of a stale failure.

## Why
The preview-smoke lane repeatedly hit false negatives while desktop search was still settling. The durable check is whether the search dialog can open, not whether a particular nav variant or button is visible at a single instant.

## Validation
- git diff --check
- node --check tests/smoke/app-search.spec.js
- SMOKE_APP_BASE_URL=http://127.0.0.1:5188 npm run test:smoke -- tests/smoke/app-search.spec.js -g "desktop search supports typed keyboard navigation from the dialog"