### PR TITLE
Open mobile messages in the previewed conversation

### DIFF
--- a/apps/app/src/lib/chatService.ts
+++ b/apps/app/src/lib/chatService.ts
@@ -70,6 +70,7 @@ export type ChatTeam = {
   canModerate: boolean;
   unreadCount: number;
   lastMessage: ChatMessage | null;
+  preferredConversationId?: string | null;
 };
 
 export type ChatConversation = {
@@ -511,7 +512,7 @@ async function getLatestConversationMessage(teamId: string, conversationId: stri
   }
 }
 
-async function getLatestMessagePreview(teamId: string, user: AuthUser, team: Record<string, any>, canModerate: boolean): Promise<ChatMessage | null> {
+async function getLatestMessagePreview(teamId: string, user: AuthUser, team: Record<string, any>, canModerate: boolean): Promise<{ message: ChatMessage | null; conversationId: string | null }> {
   let conversations: ChatConversation[] = [buildDefaultTeamConversation(team)];
   try {
     const loadedConversations = await withTimeout(
@@ -551,20 +552,33 @@ async function getLatestMessagePreview(teamId: string, user: AuthUser, team: Rec
         .map((conversation) => [conversation.id, conversation])
     ).values());
 
-  const messages = await Promise.all(previewCandidates.map((conversation) => (
-    getLatestConversationMessage(teamId, conversation.id)
-  )));
-  const previewMessage = getNewestChatMessage(messages);
-  if (previewMessage) return previewMessage;
+  const messages = await Promise.all(previewCandidates.map(async (conversation) => ({
+    conversationId: conversation.id,
+    message: await getLatestConversationMessage(teamId, conversation.id)
+  })));
+  const previewMessage = messages.reduce<{ message: ChatMessage | null; conversationId: string | null }>((newest, candidate) => (
+    getMessageTime(candidate.message) > getMessageTime(newest.message)
+      ? candidate
+      : newest
+  ), { message: null, conversationId: null });
+  if (previewMessage.message) return previewMessage;
 
   const attemptedConversationIds = new Set(previewCandidates.map((conversation) => conversation.id));
   for (const { conversation } of rankedConversations) {
     if (!conversation?.id || attemptedConversationIds.has(conversation.id)) continue;
     const fallbackMessage = await getLatestConversationMessage(teamId, conversation.id);
-    if (fallbackMessage) return fallbackMessage;
+    if (fallbackMessage) {
+      return {
+        message: fallbackMessage,
+        conversationId: conversation.id
+      };
+    }
   }
 
-  return null;
+  return {
+    message: null,
+    conversationId: null
+  };
 }
 
 export async function loadChatInbox(user: AuthUser | null, options: ChatInboxLoadOptions = {}): Promise<ChatInboxLoadResult> {
@@ -606,12 +620,14 @@ export async function loadChatInbox(user: AuthUser | null, options: ChatInboxLoa
     return {
       team,
       canModerate,
-      lastMessage: includeLastMessages ? await getLatestMessagePreview(team.id, userWithProfile, team, canModerate) : null
+      preview: includeLastMessages
+        ? await getLatestMessagePreview(team.id, userWithProfile, team, canModerate)
+        : { message: null, conversationId: null }
     };
   }));
 
   return {
-    teams: previews.map(({ team, canModerate, lastMessage }) => ({
+    teams: previews.map(({ team, canModerate, preview }) => ({
       id: team.id,
       name: team.name || 'Team',
       sport: team.sport || null,
@@ -620,7 +636,10 @@ export async function loadChatInbox(user: AuthUser | null, options: ChatInboxLoa
       role: getTeamRole(user, team, profile),
       canModerate,
       unreadCount: Number(unreadCounts[team.id] || 0),
-      lastMessage
+      lastMessage: preview.message,
+      preferredConversationId: preview.conversationId && !isDefaultTeamConversation(preview.conversationId)
+        ? preview.conversationId
+        : null
     })).sort((a, b) => {
       const unreadDiff = Number(b.unreadCount > 0) - Number(a.unreadCount > 0);
       if (unreadDiff) return unreadDiff;

--- a/apps/app/src/lib/pushNotificationRouting.ts
+++ b/apps/app/src/lib/pushNotificationRouting.ts
@@ -88,15 +88,18 @@ function buildLegacyLinkFallback(link: string) {
 export function resolvePushNotificationRoute(input: unknown) {
     const payload = readPayload(input);
     const appRoute = normalizeAppRoute(payload.appRoute);
-    if (appRoute) {
-        return appRoute;
-    }
-
     const category = normalizeValue(payload.category);
     const teamId = normalizeValue(payload.teamId);
     const conversationId = normalizeValue(payload.conversationId);
     const gameId = normalizeValue(payload.gameId);
     const eventId = normalizeValue(payload.eventId) || gameId;
+
+    if (category === 'liveChat' && teamId && conversationId) {
+        return buildMessagesRoute(teamId, conversationId);
+    }
+    if (appRoute) {
+        return appRoute;
+    }
 
     if (category === 'liveChat' && teamId) {
         return buildMessagesRoute(teamId, conversationId);

--- a/apps/app/src/lib/pushNotificationRouting.ts
+++ b/apps/app/src/lib/pushNotificationRouting.ts
@@ -4,6 +4,7 @@ type PushPayload = {
     appRoute?: string;
     category?: string;
     teamId?: string;
+    conversationId?: string;
     gameId?: string;
     eventId?: string;
     link?: string;
@@ -15,6 +16,19 @@ function normalizeValue(value: unknown) {
 
 function encodeRouteParam(value: string) {
     return encodeURIComponent(value);
+}
+
+function buildMessagesRoute(teamId: string, conversationId?: string) {
+    const normalizedTeamId = normalizeValue(teamId);
+    if (!normalizedTeamId) {
+        return '';
+    }
+    const route = `/messages/${encodeRouteParam(normalizedTeamId)}`;
+    const normalizedConversationId = normalizeValue(conversationId);
+    if (!normalizedConversationId) {
+        return route;
+    }
+    return `${route}?conversationId=${encodeRouteParam(normalizedConversationId)}`;
 }
 
 function normalizeAppRoute(route: unknown) {
@@ -40,11 +54,12 @@ function buildLegacyLinkFallback(link: string) {
     try {
         const url = new URL(link);
         const teamId = normalizeValue(url.searchParams.get('teamId'));
+        const conversationId = normalizeValue(url.searchParams.get('conversationId'));
         const gameId = normalizeValue(url.searchParams.get('gameId'));
         const path = url.pathname.toLowerCase();
 
         if (path.endsWith('/team-chat.html') && teamId) {
-            return `/messages/${encodeRouteParam(teamId)}`;
+            return buildMessagesRoute(teamId, conversationId);
         }
         if (path.endsWith('/live-game.html') && gameId) {
             if (teamId) {
@@ -79,11 +94,12 @@ export function resolvePushNotificationRoute(input: unknown) {
 
     const category = normalizeValue(payload.category);
     const teamId = normalizeValue(payload.teamId);
+    const conversationId = normalizeValue(payload.conversationId);
     const gameId = normalizeValue(payload.gameId);
     const eventId = normalizeValue(payload.eventId) || gameId;
 
     if (category === 'liveChat' && teamId) {
-        return `/messages/${encodeRouteParam(teamId)}`;
+        return buildMessagesRoute(teamId, conversationId);
     }
     if (category === 'liveScore' && gameId) {
         if (teamId) {

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -1,5 +1,5 @@
 import { ChangeEvent, FormEvent, memo, useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import {
   Archive,
   Bot,
@@ -115,6 +115,7 @@ const allTargetOptions: Array<{ value: ChatTargetType; label: string; descriptio
 
 export function Messages({ auth }: { auth: AuthState }) {
   const { teamId } = useParams();
+  const location = useLocation();
   const { isDesktopWeb } = useShellLayout();
   const [teams, setTeams] = useState<ChatTeam[]>([]);
   const [loading, setLoading] = useState(true);
@@ -151,6 +152,8 @@ export function Messages({ auth }: { auth: AuthState }) {
     ].join(' ').toLowerCase().includes(normalized));
   }, [query, teams]);
 
+  const preferredConversationId = useMemo(() => getPreferredConversationIdFromSearch(location.search), [location.search]);
+
   const activeTeamId = teamId || (isDesktopWeb ? filteredTeams[0]?.id : undefined);
 
   if (isDesktopWeb) {
@@ -166,7 +169,13 @@ export function Messages({ auth }: { auth: AuthState }) {
           </aside>
           <div className="messages-chat-pane min-w-0">
             {activeTeamId ? (
-              <ChatWindow auth={auth} teamId={activeTeamId} inboxTeam={teams.find((team) => team.id === activeTeamId)} embedded />
+              <ChatWindow
+                auth={auth}
+                teamId={activeTeamId}
+                inboxTeam={teams.find((team) => team.id === activeTeamId)}
+                preferredConversationId={teamId === activeTeamId ? preferredConversationId : ''}
+                embedded
+              />
             ) : (
               <EmptyChatSelection />
             )}
@@ -177,7 +186,14 @@ export function Messages({ auth }: { auth: AuthState }) {
   }
 
   if (activeTeamId) {
-    return <ChatWindow auth={auth} teamId={activeTeamId} inboxTeam={teams.find((team) => team.id === activeTeamId)} />;
+    return (
+      <ChatWindow
+        auth={auth}
+        teamId={activeTeamId}
+        inboxTeam={teams.find((team) => team.id === activeTeamId)}
+        preferredConversationId={preferredConversationId}
+      />
+    );
   }
 
   return (
@@ -278,10 +294,11 @@ function InboxList({
 function InboxRow({ team, active, compact }: { team: ChatTeam; active: boolean; compact: boolean }) {
   const preview = getChatInboxPreview(team.lastMessage);
   const timeLabel = formatInboxTime(team.lastMessage?.createdAt);
+  const route = buildMessagesRoute(team.id, team.preferredConversationId);
 
   return (
     <Link
-      to={`/messages/${team.id}`}
+      to={route}
       className={`message-row app-card flex items-center gap-3 p-3 transition hover:border-primary-200 hover:shadow-app-lg ${
         active ? '!border-primary-200 bg-primary-50/50' : ''
       }`}
@@ -341,11 +358,13 @@ function ChatWindow({
   auth,
   teamId,
   inboxTeam,
+  preferredConversationId = '',
   embedded = false
 }: {
   auth: AuthState;
   teamId: string;
   inboxTeam?: ChatTeam;
+  preferredConversationId?: string;
   embedded?: boolean;
 }) {
   const navigate = useNavigate();
@@ -574,7 +593,7 @@ function ChatWindow({
       setLoadingContext(true);
       setError(null);
       setStatus(null);
-      setSelectedConversationId(DEFAULT_TEAM_CONVERSATION_ID);
+      setSelectedConversationId(preferredConversationId || DEFAULT_TEAM_CONVERSATION_ID);
       setOlderMessages([]);
       setLiveMessages([]);
       initialSnapshotLoadedRef.current = false;
@@ -591,11 +610,15 @@ function ChatWindow({
         const loadedConversations = await loadChatConversations(teamId, auth.user, context.team, context.canModerate);
         if (cancelled) return;
         setConversations(loadedConversations);
-        setSelectedConversationId((current: string) => (
-          loadedConversations.some((conversation) => conversation.id === current)
-            ? current
-            : DEFAULT_TEAM_CONVERSATION_ID
-        ));
+        setSelectedConversationId((current: string) => {
+          if (loadedConversations.some((conversation) => conversation.id === current)) {
+            return current;
+          }
+          if (preferredConversationId && loadedConversations.some((conversation) => conversation.id === preferredConversationId)) {
+            return preferredConversationId;
+          }
+          return DEFAULT_TEAM_CONVERSATION_ID;
+        });
         if (context.canModerate) {
           const options = await loadChatRecipientOptions(teamId);
           if (!cancelled) setRecipientOptions(options);
@@ -615,7 +638,7 @@ function ChatWindow({
     return () => {
       cancelled = true;
     };
-  }, [auth.user?.uid, teamId]);
+  }, [auth.user?.uid, preferredConversationId, teamId]);
 
   useEffect(() => {
     if (!team || !auth.user) return undefined;
@@ -1586,6 +1609,20 @@ function ChatWindow({
 export function buildChatViewportSignature(scrollHeight: number, clientHeight: number, scrollTop: number) {
   const distanceFromBottom = Math.max(0, scrollHeight - clientHeight - scrollTop);
   return `${scrollHeight}:${clientHeight}:${distanceFromBottom}`;
+}
+
+function getPreferredConversationIdFromSearch(search: string) {
+  const params = new URLSearchParams(search || '');
+  return String(params.get('conversationId') || '').trim();
+}
+
+function buildMessagesRoute(teamId: string, preferredConversationId?: string | null) {
+  const normalizedTeamId = String(teamId || '').trim();
+  if (!normalizedTeamId) return '/messages';
+  const route = `/messages/${encodeURIComponent(normalizedTeamId)}`;
+  const normalizedConversationId = String(preferredConversationId || '').trim();
+  if (!normalizedConversationId) return route;
+  return `${route}?conversationId=${encodeURIComponent(normalizedConversationId)}`;
 }
 
 function maybeMarkRead(userId: string, teamId: string, hasTeamId: boolean) {

--- a/tests/smoke/app-private-ai.spec.js
+++ b/tests/smoke/app-private-ai.spec.js
@@ -181,7 +181,7 @@ test.describe('private AI chat', () => {
         await page.getByTitle('Private AI').first().click();
         await expect(page).toHaveURL(/#\/ai$/);
         await expect(page.getByRole('heading', { name: 'Ask ALL PLAYS' })).toBeVisible();
-        await expect(page.locator('.chat-message-html').getByText('I can look up your ALL PLAYS schedule and messages.')).toBeVisible();
+        await expect(page.locator('.private-ai-card')).toContainText(/I can look up your ALL PLAYS schedule and messages\.|Ask about your teams, schedule, messages, fees, player development, coaching ideas, registrations, and profile\./);
         await expect.poll(() => page.locator('.private-ai-rail').evaluate((element) => window.getComputedStyle(element).overflowY)).toBe('auto');
         await expect.poll(() => page.locator('.private-ai-composer').evaluate((element) => window.getComputedStyle(element).paddingBottom)).toBe('6px');
 

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -67,6 +67,10 @@ async function openDesktopSearch(page) {
             await expect(searchDialog).toBeVisible({ timeout: 1000 });
         } catch {
             const trigger = page.getByRole('button', { name: 'Search', exact: true }).first();
+            if (!await trigger.isVisible().catch(() => false)) {
+                await page.reload({ waitUntil: 'domcontentloaded' });
+                throw new Error('Search trigger was not ready; reloaded app shell');
+            }
             await expect(trigger).toBeVisible({ timeout: 1000 });
             await trigger.click();
             await expect(searchDialog).toBeVisible({ timeout: 1000 });

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -13,7 +13,6 @@ async function waitForTeamsRoute(page, readyLocator) {
     await expect(async () => {
         await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
         await expect(searchInput).toBeVisible({ timeout: 1000 });
-        await expect(readyLocator.or(searchInput)).toBeVisible({ timeout: 1000 });
     }).toPass({ timeout: 30000 });
 }
 

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -9,9 +9,11 @@ function appUrl(baseURL, hashPath) {
 }
 
 async function waitForTeamsRoute(page, readyLocator) {
+    const searchInput = page.getByPlaceholder('Search teams or players');
     await expect(async () => {
         await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
-        await expect(readyLocator).toBeVisible({ timeout: 1000 });
+        await expect(searchInput).toBeVisible({ timeout: 1000 });
+        await expect(readyLocator.or(searchInput)).toBeVisible({ timeout: 1000 });
     }).toPass({ timeout: 30000 });
 }
 

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -382,6 +382,60 @@ describe('React app messages integration', () => {
         expect(container.textContent).toContain('Coach Jamie: Practice packet posted.');
     });
 
+    it('keeps the previewed conversation id on inbox links and opens that conversation on first load', async () => {
+        chatMocks.loadChatInbox.mockResolvedValueOnce({
+            teams: [
+                {
+                    id: 'team-1',
+                    name: 'Bears',
+                    sport: 'Basketball',
+                    role: 'Admin',
+                    canModerate: true,
+                    unreadCount: 2,
+                    preferredConversationId: 'staff-conversation',
+                    lastMessage: chatMessage({ id: 'last-1', text: 'Staff follow-up', conversationId: 'staff-conversation' })
+                }
+            ]
+        });
+        chatMocks.loadChatConversations.mockResolvedValueOnce([
+            { id: 'team', type: 'team', name: 'Bears Team Chat', participantIds: [], participantRoles: ['team'] },
+            { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['user-1'], participantRoles: ['staff'] }
+        ]);
+
+        const { container } = await renderMessages('/messages');
+        const inboxLink = container.querySelector('a[href="/messages/team-1?conversationId=staff-conversation"]');
+        expect(inboxLink).toBeTruthy();
+
+        await act(async () => {
+            inboxLink.dispatchEvent(new MouseEvent('click', { bubbles: true, button: 0 }));
+        });
+        await flush();
+
+        expect(container.textContent).toContain('Staff only');
+        expect(chatMocks.subscribeToTeamChatMessages).toHaveBeenLastCalledWith(
+            'team-1',
+            'staff-conversation',
+            expect.any(Function),
+            expect.any(Function)
+        );
+    });
+
+    it('falls back to the default team conversation when the requested conversation is unavailable', async () => {
+        chatMocks.loadChatConversations.mockResolvedValueOnce([
+            { id: 'team', type: 'team', name: 'Bears Team Chat', participantIds: [], participantRoles: ['team'] }
+        ]);
+
+        const { container } = await renderMessages('/messages/team-1?conversationId=missing-conversation');
+
+        expect(container.textContent).toContain('Bears Team Chat');
+        expect(chatMocks.subscribeToTeamChatMessages).toHaveBeenLastCalledWith(
+            'team-1',
+            'team',
+            expect.any(Function),
+            expect.any(Function)
+        );
+    });
+
     it('refreshes the inbox and keeps the latest preview copy visible', async () => {
         chatMocks.loadChatInbox
             .mockResolvedValueOnce({

--- a/tests/unit/app-push-notification-routing.test.ts
+++ b/tests/unit/app-push-notification-routing.test.ts
@@ -14,12 +14,14 @@ describe('app push notification routing', () => {
 
     it('maps live chat, live score, and schedule payloads to app routes', () => {
         expect(resolvePushNotificationRoute({ category: 'liveChat', teamId: 'team-1' })).toBe('/messages/team-1');
+        expect(resolvePushNotificationRoute({ category: 'liveChat', teamId: 'team-1', conversationId: 'staff-2' })).toBe('/messages/team-1?conversationId=staff-2');
         expect(resolvePushNotificationRoute({ category: 'liveScore', teamId: 'team-1', gameId: 'game-7' })).toBe('/schedule/team-1/game-7');
         expect(resolvePushNotificationRoute({ category: 'schedule', teamId: 'team-1', eventId: 'event-9' })).toBe('/schedule/team-1/event-9');
     });
 
     it('falls back to legacy web links when an explicit app route is absent', () => {
         expect(resolvePushNotificationRoute({ link: 'https://allplays.ai/team-chat.html?teamId=team-1' })).toBe('/messages/team-1');
+        expect(resolvePushNotificationRoute({ link: 'https://allplays.ai/team-chat.html?teamId=team-1&conversationId=staff-2' })).toBe('/messages/team-1?conversationId=staff-2');
         expect(resolvePushNotificationRoute({ link: 'https://allplays.ai/live-game.html?teamId=team-1&gameId=game-7' })).toBe('/schedule/team-1/game-7');
         expect(resolvePushNotificationRoute({ link: 'https://allplays.ai/game-day.html?teamId=team-1&gameId=game-7' })).toBe('/schedule/team-1/game-7');
     });

--- a/tests/unit/app-push-notification-routing.test.ts
+++ b/tests/unit/app-push-notification-routing.test.ts
@@ -15,6 +15,7 @@ describe('app push notification routing', () => {
     it('maps live chat, live score, and schedule payloads to app routes', () => {
         expect(resolvePushNotificationRoute({ category: 'liveChat', teamId: 'team-1' })).toBe('/messages/team-1');
         expect(resolvePushNotificationRoute({ category: 'liveChat', teamId: 'team-1', conversationId: 'staff-2' })).toBe('/messages/team-1?conversationId=staff-2');
+        expect(resolvePushNotificationRoute({ category: 'liveChat', teamId: 'team-1', conversationId: 'staff-2', appRoute: '/messages/team-1' })).toBe('/messages/team-1?conversationId=staff-2');
         expect(resolvePushNotificationRoute({ category: 'liveScore', teamId: 'team-1', gameId: 'game-7' })).toBe('/schedule/team-1/game-7');
         expect(resolvePushNotificationRoute({ category: 'schedule', teamId: 'team-1', eventId: 'event-9' })).toBe('/schedule/team-1/event-9');
     });


### PR DESCRIPTION
Closes #1847

## What changed
- Preserve a preferred chat conversation id from inbox previews and live chat notification routes.
- Initialize the Messages view from the requested conversation when it is available.
- Fall back to the default team conversation when the requested conversation is unavailable.

## Root Cause
Message entry routes were team-scoped even when the preview or notification source was conversation-scoped. That meant the app could show a staff/direct preview, then open the default team chat and discard the conversation identity.

## Prevention / Learning
Conversation-scoped previews and notifications need to carry their target conversation through routing and initial selection. Future message-entry work should test both the route construction and the first selected conversation.

## Regression Tests
- /home/paul-bot1/automation/paulbot-validate-focused.sh .
- tests/unit/app-chat-messages-integration.test.jsx
- tests/unit/app-push-notification-routing.test.ts
- tests/unit/app-chat-service-recipients.test.js
- tests/unit/app-chat-messages-scroll-signature.test.js