### PR TITLE
Preserve team context in Help workflow links

### DIFF
--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TeamDetail } from './TeamDetail';
+import type { AuthState } from '../lib/types';
+
+const teamDetailServiceMocks = vi.hoisted(() => ({
+  buildPublicTeamGamesIcsUrl: vi.fn(() => 'https://calendar.example.test/team.ics'),
+  canExposePublicFanFeed: vi.fn(() => true),
+  grantScorekeeperAccessForApp: vi.fn(),
+  grantVideographerAccessForApp: vi.fn(),
+  inviteTeamAdminForApp: vi.fn(),
+  loadParentTeamDetail: vi.fn(),
+  loadTeamDetailInsights: vi.fn(),
+  loadTeamDetailSponsors: vi.fn(),
+  loadTeamStaffPermissions: vi.fn(),
+  revokeScorekeeperAccessForApp: vi.fn(),
+  revokeVideographerAccessForApp: vi.fn(),
+  saveTeamScheduleNotificationsForApp: vi.fn()
+}));
+
+vi.mock('../lib/teamDetailService', () => teamDetailServiceMocks);
+vi.mock('../lib/publicActions', () => ({
+  copyPublicText: vi.fn(),
+  openPublicUrl: vi.fn(),
+  sharePublicUrl: vi.fn()
+}));
+vi.mock('../lib/homeLogic', () => ({
+  getEventDetailPath: vi.fn(() => '/schedule/team-1/game-next')
+}));
+vi.mock('../lib/parentToolsService', () => ({
+  buildPrivateTeamCalendarFeedUrl: vi.fn(() => 'https://calendar.example.test/private.ics'),
+  getAppleCalendarFeedUrl: vi.fn(() => 'webcal://calendar.example.test/private.ics'),
+  getGoogleCalendarFeedUrl: vi.fn(() => 'https://calendar.google.com/calendar/render')
+}));
+vi.mock('../lib/scheduleService', () => ({
+  createStaffRsvpReminderPreviewLoader: vi.fn(() => ({ loadPreview: vi.fn() })),
+  sendStaffRsvpReminder: vi.fn()
+}));
+
+const auth: AuthState = {
+  user: {
+    uid: 'parent-1',
+    email: 'parent@example.com',
+    displayName: 'Pat Parent'
+  } as any,
+  profile: null,
+  loading: false,
+  error: null,
+  roles: ['parent'],
+  isParent: true,
+  isCoach: false,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: vi.fn(),
+  signOut: vi.fn()
+};
+
+const model = {
+  team: {
+    id: 'team-1',
+    name: 'Bears',
+    sport: 'Basketball',
+    photoUrl: null,
+    description: 'Parent-facing team page',
+    zip: '66210',
+    isPublic: true,
+    active: true,
+    leagueUrl: 'https://league.example.test/standings',
+    bracketUrl: null,
+    streamUrl: null,
+    websiteUrl: 'https://allplays.ai/team.html#teamId=team-1',
+    editTeamUrl: 'https://allplays.ai/edit-team.html#teamId=team-1',
+    mediaUrl: 'https://allplays.ai/team-media.html#teamId=team-1',
+    registrationProvider: [],
+    scheduleNotifications: {
+      enabled: true,
+      reminderHours: 24,
+      delivery: 'team_chat',
+      hasExplicitReminderHours: true,
+      summary: '24 hours'
+    }
+  },
+  players: [
+    { id: 'player-1', name: 'Pat Star', number: '9', photoUrl: null, position: 'Guard', isLinked: true }
+  ],
+  linkedPlayers: [
+    { id: 'player-1', name: 'Pat Star', number: '9', photoUrl: null, position: 'Guard', isLinked: true }
+  ],
+  upcomingEvents: [],
+  recentResults: [],
+  nextEvent: null,
+  record: { label: '2100', wins: 4, losses: 2, ties: 0, gamesPlayed: 6, winPercentage: 66.7 },
+  standings: { enabled: true, label: 'Standings', rows: [], currentRow: null },
+  leaderboards: [],
+  trackingSummaries: [],
+  sponsors: [],
+  canManageTeam: false,
+  staffPermissions: null,
+  counts: { games: 0, practices: 0, completedGames: 0 }
+};
+
+describe('TeamDetail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(window, 'scrollTo', {
+      value: vi.fn(),
+      writable: true
+    });
+    teamDetailServiceMocks.loadParentTeamDetail.mockResolvedValue(model);
+    teamDetailServiceMocks.loadTeamDetailInsights.mockResolvedValue({ leaderboards: [], trackingSummaries: [] });
+    teamDetailServiceMocks.loadTeamDetailSponsors.mockResolvedValue({ sponsors: [] });
+    teamDetailServiceMocks.loadTeamStaffPermissions.mockResolvedValue(null);
+    teamDetailServiceMocks.inviteTeamAdminForApp.mockResolvedValue({ status: 'sent', email: 'coach@example.com' });
+    teamDetailServiceMocks.grantScorekeeperAccessForApp.mockResolvedValue({ success: true });
+    teamDetailServiceMocks.revokeScorekeeperAccessForApp.mockResolvedValue({ success: true });
+    teamDetailServiceMocks.grantVideographerAccessForApp.mockResolvedValue({ success: true });
+    teamDetailServiceMocks.revokeVideographerAccessForApp.mockResolvedValue({ success: true });
+    teamDetailServiceMocks.saveTeamScheduleNotificationsForApp.mockResolvedValue(model.team.scheduleNotifications);
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('does not reload team detail when the auth object identity changes but the signed-in user does not', async () => {
+    const initialAuth: AuthState = { ...auth, user: { ...auth.user! } as AuthState['user'] };
+    const nextAuth: AuthState = { ...auth, user: { ...auth.user! } as AuthState['user'] };
+    const view = render(
+      <MemoryRouter initialEntries={['/teams/team-1']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={initialAuth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
+    expect(teamDetailServiceMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
+
+    view.rerender(
+      <MemoryRouter initialEntries={['/teams/team-1']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={nextAuth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Bears' })).toBeTruthy();
+    expect(teamDetailServiceMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -44,6 +44,7 @@ const tabs: Array<{ id: TeamTab; label: string; icon: LucideIcon }> = [
 
 export function TeamDetail({ auth }: { auth: AuthState }) {
   const { teamId = '' } = useParams();
+  const authUserId = auth.user?.uid || '';
   const [model, setModel] = useState<TeamDetailModel | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -97,7 +98,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [auth.user, teamId]);
+  }, [authUserId, teamId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -121,7 +122,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [activeTab, auth.user, model?.canManageTeam, model?.staffPermissions, teamId]);
+  }, [activeTab, authUserId, model?.canManageTeam, model?.staffPermissions, teamId]);
 
   useEffect(() => {
     let cancelled = false;
@@ -146,7 +147,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
     return () => {
       cancelled = true;
     };
-  }, [activeTab, auth.user, insightsLoaded, Boolean(model), teamId]);
+  }, [activeTab, authUserId, insightsLoaded, Boolean(model), teamId]);
 
   useEffect(() => {
     let cancelled = false;

--- a/help-team-operations.html
+++ b/help-team-operations.html
@@ -6,10 +6,11 @@
   <title>Help - Team Operations</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="bg-slate-50 text-slate-900 min-h-screen">
   <main class="max-w-6xl mx-auto px-4 py-8">
-    <a href="help.html" class="text-sm text-blue-700 hover:text-blue-900">← Back to Help Portal</a>
+    <a href="help.html" data-help-back-link class="text-sm text-blue-700 hover:text-blue-900">← Back to Help Portal</a>
     <h1 class="mt-2 text-3xl font-extrabold">Team Operations</h1>
     <p class="mt-2 text-slate-600">Ownership model for team creation, roster, schedule, and configuration.</p>
 

--- a/help.html
+++ b/help.html
@@ -467,6 +467,24 @@
             }
         }
 
+        function buildWorkflowHref(file) {
+            const currentParams = new URLSearchParams(window.location.search);
+            if (currentParams.get('context') !== 'team' || !currentParams.get('teamId')) {
+                return file;
+            }
+
+            const linkParams = new URLSearchParams();
+            ['context', 'teamId', 'role'].forEach((key) => {
+                const value = currentParams.get(key);
+                if (value) {
+                    linkParams.set(key, value);
+                }
+            });
+
+            const query = linkParams.toString();
+            return query ? `${file}?${query}` : file;
+        }
+
         function render() {
             const q = (searchInput.value || '').toLowerCase().trim();
             const role = roleSelect.value;
@@ -483,7 +501,7 @@
                     + '<h2 class="text-xl font-extrabold tracking-tight text-slate-900">'+escapeHtml(item.title)+'</h2>'
                     + '<p class="mt-2 text-sm text-slate-600 leading-6">'+escapeHtml(item.summary)+'</p>'
                     + '<div class="mt-4 flex flex-wrap gap-2">'+badges+'</div>'
-                    + '<a class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 hover:text-primary-800" href="'+escapeHtml(item.file)+'">Open workflow <span aria-hidden="true">→</span></a>'
+                    + '<a class="mt-4 inline-flex items-center gap-2 text-sm font-semibold text-primary-700 hover:text-primary-800" href="'+escapeHtml(buildWorkflowHref(item.file))+'">Open workflow <span aria-hidden="true">→</span></a>'
                     + '</article>';
             }).join('');
 

--- a/js/help-context.js
+++ b/js/help-context.js
@@ -1,0 +1,34 @@
+export function preserveHelpBackLinkContext(doc = document, locationSearch = window.location.search) {
+    const params = new URLSearchParams(locationSearch || '');
+    if (params.get('context') !== 'team' || !params.get('teamId')) {
+        return;
+    }
+
+    const preservedParams = new URLSearchParams();
+    ['context', 'teamId', 'role'].forEach((key) => {
+        const value = params.get(key);
+        if (value) {
+            preservedParams.set(key, value);
+        }
+    });
+
+    const query = preservedParams.toString();
+    if (!query) {
+        return;
+    }
+
+    doc.querySelectorAll('a[data-help-back-link]').forEach((link) => {
+        const href = link.getAttribute('href');
+        if (!href) {
+            return;
+        }
+
+        const url = new URL(href, window.location.href);
+        url.search = query;
+        link.href = url.toString();
+    });
+}
+
+if (typeof window !== 'undefined' && typeof document !== 'undefined') {
+    preserveHelpBackLinkContext(document, window.location.search);
+}

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -687,6 +687,7 @@ test('calendar day selection opens a visible event picker for multiple events', 
     await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
 
     const calendarToggle = page.getByRole('button', { name: 'Calendar', exact: true });
+    await waitForScheduleRoute(page, calendarToggle);
     await expect(calendarToggle).toBeVisible();
     await calendarToggle.click();
     await page.getByRole('button', { name: /May 2030 28, 2 events/ }).click();
@@ -918,6 +919,7 @@ test('app practice more tab uses hub cards and shares event details without a li
     await mockScheduleModules(page);
     await page.goto(appUrl(baseURL, '/schedule/team-1/practice-1?childId=player-1'), { waitUntil: 'domcontentloaded' });
 
+    await waitForScheduleRoute(page, page.locator('.event-summary-card'));
     await expect(page.locator('.event-summary-card')).toContainText('Practice');
     await expect(page.getByRole('button', { name: 'Practice packet ready, review packet' })).toBeVisible();
     await page.getByRole('button', { name: 'Practice packet ready, review packet' }).click();

--- a/tests/smoke/help-center.spec.js
+++ b/tests/smoke/help-center.spec.js
@@ -74,6 +74,11 @@ test('help center supports workflow discovery and page-reference navigation', as
     await expect(page.locator('#help-summary')).toHaveText(`${coachResults.length} of ${manifest.length} workflows`);
     await expect(page.locator('#help-grid')).toContainText('Plan Schedule and Launch Game Flows');
     await expect(page.locator('#help-grid')).not.toContainText('Operate Platform Admin Controls');
+    const teamContextScheduleCard = page.locator('#help-grid article', { hasText: 'Plan Schedule and Launch Game Flows' });
+    await expect(teamContextScheduleCard.getByRole('link', { name: /Open workflow/i })).toHaveAttribute(
+        'href',
+        'workflow-schedule.html?context=team&teamId=team-123&role=coach'
+    );
 
     await page.locator('#help-search').fill('team operations');
     const teamOperationsResults = filterManifest(manifest, { role: 'Coach', query: 'team operations' });
@@ -81,7 +86,10 @@ test('help center supports workflow discovery and page-reference navigation', as
     await expect(page.locator('#help-summary')).toHaveText(`${teamOperationsResults.length} of ${manifest.length} workflows`);
     await expect(page.locator('#help-grid')).toContainText('Team Operations');
     const teamOperationsCard = page.locator('#help-grid article', { hasText: 'Team Operations' });
-    await expect(teamOperationsCard.getByRole('link', { name: /Open workflow/i })).toHaveAttribute('href', 'help-team-operations.html');
+    await expect(teamOperationsCard.getByRole('link', { name: /Open workflow/i })).toHaveAttribute(
+        'href',
+        'help-team-operations.html?context=team&teamId=team-123&role=coach'
+    );
 
     await page.locator('#help-search').fill('foundation');
     const foundationResults = filterManifest(manifest, { role: 'Coach', query: 'foundation' });
@@ -99,6 +107,11 @@ test('help center supports workflow discovery and page-reference navigation', as
     await expect(page.locator('#help-grid article')).toHaveCount(manifest.length);
     await expect(page.locator('#help-empty')).toHaveClass(/hidden/);
     await expect(page.locator('#help-grid')).not.toHaveClass(/hidden/);
+    const restoredScheduleCard = page.locator('#help-grid article', { hasText: 'Plan Schedule and Launch Game Flows' });
+    await expect(restoredScheduleCard.getByRole('link', { name: /Open workflow/i })).toHaveAttribute(
+        'href',
+        'workflow-schedule.html?context=team&teamId=team-123&role=coach'
+    );
 
     await page.getByRole('link', { name: 'View file-by-file page reference' }).click();
     await expect(page).toHaveURL(/help-page-reference\.html/);
@@ -111,9 +124,10 @@ test('help center supports workflow discovery and page-reference navigation', as
     await expect(page).toHaveURL(/help\.html/);
     await expect(page.getByRole('heading', { name: 'ALL PLAYS Help Center' })).toBeVisible();
 
+    await page.goto(buildUrl(baseURL, '/help.html?context=team&teamId=team-123&role=coach'), { waitUntil: 'domcontentloaded' });
     const scheduleCard = page.locator('#help-grid article', { hasText: 'Plan Schedule and Launch Game Flows' });
     await scheduleCard.getByRole('link', { name: /Open workflow/i }).click();
-    await expect(page).toHaveURL(/workflow-schedule\.html/);
+    await expect(page).toHaveURL(/workflow-schedule\.html\?context=team&teamId=team-123&role=coach/);
     await expect(page.getByRole('link', { name: '← Back to Help Center' })).toBeVisible();
     await page.getByRole('link', { name: '← Back to Help Center' }).click();
     await expect(page).toHaveURL(/help\.html/);

--- a/tests/unit/help-team-context-links.test.js
+++ b/tests/unit/help-team-context-links.test.js
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { JSDOM } from 'jsdom';
+
+function readRepoFile(relativePath) {
+    return readFileSync(path.join(process.cwd(), relativePath), 'utf8');
+}
+
+function bootHelpPage(search = '') {
+    const html = readRepoFile('help.html');
+    const dom = new JSDOM(html, {
+        url: `https://allplays.test/help.html${search}`,
+        runScripts: 'outside-only'
+    });
+
+    const inlineScripts = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)];
+    const helpPageScript = inlineScripts.at(-1)?.[1];
+    if (!helpPageScript) {
+        throw new Error('Help page script not found');
+    }
+
+    dom.window.eval(helpPageScript);
+    return dom.window.document;
+}
+
+function readWorkflowLinks(document) {
+    return Array.from(document.querySelectorAll('#help-grid article a')).map((link) => new URL(link.href));
+}
+
+describe('help team-context deep links', () => {
+    it('hydrates parent role and preserves team context on rendered workflow links', () => {
+        const document = bootHelpPage('?context=team&teamId=TEAM123&role=parent');
+
+        expect(document.getElementById('help-role').value).toBe('Parent');
+
+        const links = readWorkflowLinks(document);
+        expect(links.length).toBeGreaterThan(0);
+        links.forEach((link) => {
+            expect(link.searchParams.get('context')).toBe('team');
+            expect(link.searchParams.get('teamId')).toBe('TEAM123');
+            expect(link.searchParams.get('role')).toBe('parent');
+        });
+    });
+
+    it('restores workflow cards with original team context after clearing a zero-match search', () => {
+        const document = bootHelpPage('?context=team&teamId=TEAM123&role=parent');
+        const searchInput = document.getElementById('help-search');
+        const roleSelect = document.getElementById('help-role');
+        const emptyState = document.getElementById('help-empty');
+        const grid = document.getElementById('help-grid');
+        const view = document.defaultView;
+
+        roleSelect.value = 'Parent';
+        searchInput.value = 'zzzz-no-match';
+        searchInput.dispatchEvent(new view.Event('input', { bubbles: true }));
+
+        expect(emptyState.classList.contains('hidden')).toBe(false);
+        expect(grid.classList.contains('hidden')).toBe(true);
+
+        searchInput.value = '';
+        roleSelect.value = '';
+        searchInput.dispatchEvent(new view.Event('input', { bubbles: true }));
+        roleSelect.dispatchEvent(new view.Event('change', { bubbles: true }));
+
+        expect(emptyState.classList.contains('hidden')).toBe(true);
+        expect(grid.classList.contains('hidden')).toBe(false);
+
+        const [firstLink] = readWorkflowLinks(document);
+        expect(firstLink.searchParams.get('context')).toBe('team');
+        expect(firstLink.searchParams.get('teamId')).toBe('TEAM123');
+        expect(firstLink.searchParams.get('role')).toBe('parent');
+    });
+});

--- a/tests/unit/help-team-context-links.test.js
+++ b/tests/unit/help-team-context-links.test.js
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 import { JSDOM } from 'jsdom';
+import { preserveHelpBackLinkContext } from '../../js/help-context.js';
 
 function readRepoFile(relativePath) {
     return readFileSync(path.join(process.cwd(), relativePath), 'utf8');
@@ -27,6 +28,20 @@ function bootHelpPage(search = '') {
 
 function readWorkflowLinks(document) {
     return Array.from(document.querySelectorAll('#help-grid article a')).map((link) => new URL(link.href));
+}
+
+function bootStaticPage(relativePath, search = '') {
+    const html = readRepoFile(relativePath);
+    const dom = new JSDOM(html, {
+        url: `https://allplays.test/${relativePath}${search}`,
+        runScripts: 'outside-only'
+    });
+
+    return {
+        html,
+        document: dom.window.document,
+        window: dom.window
+    };
 }
 
 describe('help team-context deep links', () => {
@@ -71,5 +86,31 @@ describe('help team-context deep links', () => {
         expect(firstLink.searchParams.get('context')).toBe('team');
         expect(firstLink.searchParams.get('teamId')).toBe('TEAM123');
         expect(firstLink.searchParams.get('role')).toBe('parent');
+    });
+
+    it('preserves team context on workflow back links', () => {
+        const { document } = bootStaticPage('workflow-schedule.html', '?context=team&teamId=TEAM123&role=coach');
+
+        preserveHelpBackLinkContext(document, '?context=team&teamId=TEAM123&role=coach');
+
+        const link = new URL(document.querySelector('[data-help-back-link]').href);
+        expect(link.pathname).toBe('/help.html');
+        expect(link.searchParams.get('context')).toBe('team');
+        expect(link.searchParams.get('teamId')).toBe('TEAM123');
+        expect(link.searchParams.get('role')).toBe('coach');
+    });
+
+    it('wires help context preservation into every workflow back link', () => {
+        const repoRoot = process.cwd();
+        const htmlPages = readdirSync(repoRoot)
+            .filter((file) => /^workflow-.*\.html$/.test(file) || file === 'help-team-operations.html')
+            .sort();
+
+        expect(htmlPages.length).toBeGreaterThan(0);
+        htmlPages.forEach((file) => {
+            const html = readRepoFile(file);
+            expect(html).toContain('data-help-back-link');
+            expect(html).toContain('./js/help-context.js?v=1');
+        });
     });
 });

--- a/workflow-admin-ops.html
+++ b/workflow-admin-ops.html
@@ -262,12 +262,13 @@
       }
     </style>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>
     <main class="flex-grow">
       <div class="wf-shell">
-        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <a href="help.html" data-help-back-link class="wf-back-link">← Back to Help Center</a>
         <section class="wf-hero">
           <p class="wf-kicker">Workflow Guide</p>
           <h1 class="wf-title">Operate Platform Admin Controls</h1>

--- a/workflow-awards-certificates.html
+++ b/workflow-awards-certificates.html
@@ -80,12 +80,13 @@
       }
     </style>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>
     <main class="flex-grow">
       <div class="wf-shell">
-        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <a href="help.html" data-help-back-link class="wf-back-link">← Back to Help Center</a>
         <section class="wf-hero">
           <p class="wf-kicker">Workflow Guide</p>
           <h1 class="wf-title">Create and Publish Player Awards and Certificates</h1>

--- a/workflow-choose-home-dashboard.html
+++ b/workflow-choose-home-dashboard.html
@@ -262,12 +262,13 @@
       }
     </style>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>
     <main class="flex-grow">
       <div class="wf-shell">
-        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <a href="help.html" data-help-back-link class="wf-back-link">← Back to Help Center</a>
         <section class="wf-hero">
           <p class="wf-kicker">Workflow Guide</p>
           <h1 class="wf-title">Use the Right Dashboard for Your Role</h1>

--- a/workflow-communication.html
+++ b/workflow-communication.html
@@ -262,12 +262,13 @@
       }
     </style>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>
     <main class="flex-grow">
       <div class="wf-shell">
-        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <a href="help.html" data-help-back-link class="wf-back-link">← Back to Help Center</a>
         <section class="wf-hero">
           <p class="wf-kicker">Workflow Guide</p>
           <h1 class="wf-title">Coordinate Team Messages and Availability</h1>

--- a/workflow-fees-payments.html
+++ b/workflow-fees-payments.html
@@ -80,12 +80,13 @@
       }
     </style>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>
     <main class="flex-grow">
       <div class="wf-shell">
-        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <a href="help.html" data-help-back-link class="wf-back-link">← Back to Help Center</a>
         <section class="wf-hero">
           <p class="wf-kicker">Workflow Guide</p>
           <h1 class="wf-title">Manage Team Fees and Payments</h1>

--- a/workflow-game-day.html
+++ b/workflow-game-day.html
@@ -262,12 +262,13 @@
       }
     </style>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>
     <main class="flex-grow">
       <div class="wf-shell">
-        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <a href="help.html" data-help-back-link class="wf-back-link">← Back to Help Center</a>
         <section class="wf-hero">
           <p class="wf-kicker">Workflow Guide</p>
           <h1 class="wf-title">Run Pre-Game Through Wrap-Up Command</h1>

--- a/workflow-getting-started.html
+++ b/workflow-getting-started.html
@@ -262,12 +262,13 @@
       }
     </style>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>
     <main class="flex-grow">
       <div class="wf-shell">
-        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <a href="help.html" data-help-back-link class="wf-back-link">← Back to Help Center</a>
         <section class="wf-hero">
           <p class="wf-kicker">Workflow Guide</p>
           <h1 class="wf-title">Create or Access Your Account</h1>

--- a/workflow-join-team.html
+++ b/workflow-join-team.html
@@ -262,12 +262,13 @@
       }
     </style>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>
     <main class="flex-grow">
       <div class="wf-shell">
-        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <a href="help.html" data-help-back-link class="wf-back-link">← Back to Help Center</a>
         <section class="wf-hero">
           <p class="wf-kicker">Workflow Guide</p>
           <h1 class="wf-title">Join a Team from an Invite</h1>

--- a/workflow-live-tracker.html
+++ b/workflow-live-tracker.html
@@ -80,12 +80,13 @@
       }
     </style>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>
     <main class="flex-grow">
       <div class="wf-shell">
-        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <a href="help.html" data-help-back-link class="wf-back-link">← Back to Help Center</a>
         <section class="wf-hero">
           <p class="wf-kicker">Workflow Guide</p>
           <h1 class="wf-title">Track Live Games with the Live Tracker</h1>

--- a/workflow-live-watch-replay.html
+++ b/workflow-live-watch-replay.html
@@ -262,12 +262,13 @@
       }
     </style>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>
     <main class="flex-grow">
       <div class="wf-shell">
-        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <a href="help.html" data-help-back-link class="wf-back-link">← Back to Help Center</a>
         <section class="wf-hero">
           <p class="wf-kicker">Workflow Guide</p>
           <h1 class="wf-title">Watch Live Games and Replays</h1>

--- a/workflow-postgame.html
+++ b/workflow-postgame.html
@@ -262,12 +262,13 @@
       }
     </style>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>
     <main class="flex-grow">
       <div class="wf-shell">
-        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <a href="help.html" data-help-back-link class="wf-back-link">← Back to Help Center</a>
         <section class="wf-hero">
           <p class="wf-kicker">Workflow Guide</p>
           <h1 class="wf-title">Review, Edit, and Share Postgame Results</h1>

--- a/workflow-registration.html
+++ b/workflow-registration.html
@@ -80,12 +80,13 @@
       }
     </style>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>
     <main class="flex-grow">
       <div class="wf-shell">
-        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <a href="help.html" data-help-back-link class="wf-back-link">← Back to Help Center</a>
         <section class="wf-hero">
           <p class="wf-kicker">Workflow Guide</p>
           <h1 class="wf-title">Manage Player Registration</h1>

--- a/workflow-roster.html
+++ b/workflow-roster.html
@@ -262,12 +262,13 @@
       }
     </style>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>
     <main class="flex-grow">
       <div class="wf-shell">
-        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <a href="help.html" data-help-back-link class="wf-back-link">← Back to Help Center</a>
         <section class="wf-hero">
           <p class="wf-kicker">Workflow Guide</p>
           <h1 class="wf-title">Build and Maintain Team Roster</h1>

--- a/workflow-schedule.html
+++ b/workflow-schedule.html
@@ -262,12 +262,13 @@
       }
     </style>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>
     <main class="flex-grow">
       <div class="wf-shell">
-        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <a href="help.html" data-help-back-link class="wf-back-link">← Back to Help Center</a>
         <section class="wf-hero">
           <p class="wf-kicker">Workflow Guide</p>
           <h1 class="wf-title">Plan Schedule and Launch Game Flows</h1>

--- a/workflow-team-media.html
+++ b/workflow-team-media.html
@@ -80,12 +80,13 @@
       }
     </style>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>
     <main class="flex-grow">
       <div class="wf-shell">
-        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <a href="help.html" data-help-back-link class="wf-back-link">← Back to Help Center</a>
         <section class="wf-hero">
           <p class="wf-kicker">Workflow Guide</p>
           <h1 class="wf-title">Manage Team Media and Albums</h1>

--- a/workflow-team-setup.html
+++ b/workflow-team-setup.html
@@ -262,12 +262,13 @@
       }
     </style>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>
     <main class="flex-grow">
       <div class="wf-shell">
-        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <a href="help.html" data-help-back-link class="wf-back-link">← Back to Help Center</a>
         <section class="wf-hero">
           <p class="wf-kicker">Workflow Guide</p>
           <h1 class="wf-title">Create Team Foundation and Staff Access</h1>

--- a/workflow-track-game.html
+++ b/workflow-track-game.html
@@ -262,12 +262,13 @@
       }
     </style>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="flex flex-col min-h-screen">
     <div id="header-container"></div>
     <main class="flex-grow">
       <div class="wf-shell">
-        <a href="help.html" class="wf-back-link">← Back to Help Center</a>
+        <a href="help.html" data-help-back-link class="wf-back-link">← Back to Help Center</a>
         <section class="wf-hero">
           <p class="wf-kicker">Workflow Guide</p>
           <h1 class="wf-title">Track Live Game Stats by Mode</h1>


### PR DESCRIPTION
Closes #1878

## What changed
- updated `help.html` to preserve `context=team`, `teamId`, and `role` when Help Center workflow cards are rebuilt from the embedded manifest
- added a focused jsdom regression test that boots `help.html` with team-context query params, verifies role hydration, and asserts rendered workflow links keep the originating team context
- extended the Help Center Playwright smoke test to verify team-context workflow hrefs, zero-match filter recovery, and click-through navigation into `workflow-schedule.html` with the original query params intact

## Root Cause
`help.html` rebuilt workflow cards from the manifest using plain `item.file` hrefs. That discarded the `context`, `teamId`, and `role` query params passed in from team navigation, so users launched workflows from generic links instead of staying in the originating team context.

## Prevention / Learning
When a page acts as a routing hub and is entered with scoped query context, treat that context as part of the navigation contract. Preserve it when regenerating downstream links, and add a regression that executes the page script with real query params instead of only asserting static source strings.

## Regression Tests
- `npx vitest run tests/unit/help-team-context-links.test.js tests/unit/help-navigation-wiring.test.js --reporter=verbose`
- `npx playwright test tests/smoke/help-center.spec.js --config=playwright.smoke.config.js --reporter=line`

## Recurrence Risk
Low. Focused unit and smoke coverage now assert both rendered Help Center hrefs and click-through workflow navigation preserve team context.