### PR TITLE
Bound native profile photo capture size

### DIFF
--- a/apps/app/src/lib/profileService.ts
+++ b/apps/app/src/lib/profileService.ts
@@ -262,7 +262,9 @@ export async function acquireProfilePhoto(source: ProfilePhotoSource): Promise<F
       quality: 85,
       resultType: CameraResultType.Uri,
       source: source === 'camera' ? CameraSource.Camera : CameraSource.Photos,
-      correctOrientation: true
+      correctOrientation: true,
+      width: profilePhotoMaxDimensionPx,
+      height: profilePhotoMaxDimensionPx
     });
 
     if (!photo.webPath) {

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -483,6 +483,7 @@ describe('Profile invites', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Take photo' }));
 
     await waitFor(() => expect(profileServiceMocks.acquireProfilePhoto).toHaveBeenCalledWith('camera'));
+    expect(profileServiceMocks.normalizeProfilePhoto).not.toHaveBeenCalled();
     await waitFor(() => expect(URL.createObjectURL).toHaveBeenCalled());
     expect((container.querySelector('img') as HTMLImageElement | null)?.getAttribute('src')).toBe('blob:native-camera.jpg');
 

--- a/tests/unit/app-profile-service.test.ts
+++ b/tests/unit/app-profile-service.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const capacitorState = vi.hoisted(() => ({
+    isNative: true,
+    plugins: new Set(['Camera'])
+}));
+
+const cameraMocks = vi.hoisted(() => ({
+    getPhoto: vi.fn()
+}));
+
+const capacitorMock = vi.hoisted(() => ({
+    isNativePlatform: () => capacitorState.isNative,
+    isPluginAvailable: (pluginName: string) => capacitorState.plugins.has(pluginName)
+}));
+
+vi.mock('@capacitor/core', () => ({
+    Capacitor: capacitorMock
+}), { virtual: true });
+
+vi.mock('../../apps/app/node_modules/@capacitor/core/dist/index.cjs.js', () => ({
+    Capacitor: capacitorMock
+}));
+
+vi.mock('@capacitor/camera', () => ({
+    Camera: cameraMocks,
+    CameraResultType: { Uri: 'uri' },
+    CameraSource: { Camera: 'camera', Photos: 'photos' }
+}), { virtual: true });
+
+vi.mock('../../apps/app/node_modules/@capacitor/camera/dist/plugin.cjs.js', () => ({
+    Camera: cameraMocks,
+    CameraResultType: { Uri: 'uri' },
+    CameraSource: { Camera: 'camera', Photos: 'photos' }
+}));
+
+vi.mock('../../js/db.js', () => ({
+    createAccessCode: vi.fn(),
+    createAccountMergeRequest: vi.fn(),
+    generateAccessCode: vi.fn(),
+    getNotificationPreferencesForTeam: vi.fn(),
+    getParentTeams: vi.fn(),
+    getUserAccessCodes: vi.fn(),
+    getUserProfile: vi.fn(),
+    getUserTeamsWithAccess: vi.fn(),
+    saveNotificationPreferencesForTeam: vi.fn(),
+    updateUserProfile: vi.fn(),
+    upsertNotificationDeviceToken: vi.fn(),
+    uploadUserPhoto: vi.fn()
+}));
+
+vi.mock('../../js/notification-preferences.js', () => ({
+    normalizeTeamNotificationPreferences: vi.fn((preferences) => preferences || {
+        liveChat: true,
+        liveScore: false,
+        schedule: true
+    })
+}));
+
+vi.mock('../../js/firebase-runtime-config.js', () => ({
+    resolveImageFirebaseConfig: vi.fn(() => ({ apiKey: 'demo-key', storageBucket: 'demo-bucket' }))
+}));
+
+vi.mock('../../js/team-visibility.js', () => ({
+    isTeamActive: vi.fn(() => true)
+}));
+
+vi.mock('../../apps/app/src/lib/authService.ts', () => ({
+    firebaseAuth: { app: { options: { projectId: 'demo-allplays' } } },
+    getNativeAuthIdToken: vi.fn()
+}));
+
+import { acquireProfilePhoto } from '../../apps/app/src/lib/profileService.ts';
+
+describe('React app profile photo service', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        capacitorState.isNative = true;
+        capacitorState.plugins = new Set(['Camera']);
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: {
+                protocol: 'capacitor:'
+            }
+        });
+        cameraMocks.getPhoto.mockResolvedValue({
+            webPath: 'https://example.test/profile-photo.jpg',
+            format: 'jpeg'
+        });
+        vi.stubGlobal('fetch', vi.fn(async () => ({
+            ok: true,
+            status: 200,
+            blob: async () => new Blob(['bounded-photo'], { type: 'image/jpeg' })
+        })));
+        vi.stubGlobal('createImageBitmap', vi.fn(async () => ({
+            width: 1024,
+            height: 768,
+            close: vi.fn()
+        })));
+    });
+
+    it('requests bounded native profile photos and skips canvas resize for already bounded images', async () => {
+        const createElementSpy = vi.spyOn(document, 'createElement');
+
+        const file = await acquireProfilePhoto('photos');
+
+        expect(cameraMocks.getPhoto).toHaveBeenCalledWith({
+            quality: 85,
+            resultType: 'uri',
+            source: 'photos',
+            correctOrientation: true,
+            width: 1024,
+            height: 1024
+        });
+        expect(file).toBeInstanceOf(File);
+        expect(file.type).toBe('image/jpeg');
+        expect(file.size).toBe(new Blob(['bounded-photo'], { type: 'image/jpeg' }).size);
+        expect(file.name).toMatch(/^profile-library-\d+\.jpeg$/);
+        expect(createElementSpy).not.toHaveBeenCalledWith('canvas');
+    });
+});


### PR DESCRIPTION
Closes #1882

## What changed
- Passed `width` and `height` bounds of 1024px into `Camera.getPhoto` for native profile photo capture and library selection.
- Added a focused `profileService` unit test that verifies bounded native sizing is requested and that already bounded images do not go through a canvas resize pass.
- Extended the Profile native chooser integration test to assert the native path does not trigger a second normalization round-trip before preview/upload.

## Root Cause
The native profile photo flow requested original full-resolution assets from the Capacitor Camera plugin, then relied on JavaScript-side normalization to shrink them afterward. On modern mobile photos, that forced fetch, decode, canvas draw, and re-encode work onto the WebView path before the preview appeared.

## Prevention / Learning
When native media plugins support bounded output, request the target dimensions at acquisition time instead of defaulting to full-resolution assets and fixing size later in JavaScript. Keep JS normalization as a fallback safety net, not the default path for common mobile captures.

## Regression Tests
- `npx vitest run tests/unit/app-profile-service.test.ts tests/unit/app-profile-invites.test.tsx --reporter=verbose`
- `tests/unit/app-profile-service.test.ts` asserts `Camera.getPhoto` receives bounded width/height options and skips canvas resizing for an already bounded image.
- `tests/unit/app-profile-invites.test.tsx` asserts the native chooser path previews/uploads without calling `normalizeProfilePhoto` a second time.