### PR TITLE
Stop public team city searches from scanning zip-only teams

### DIFF
--- a/_migration/backfill-public-team-search-fields.js
+++ b/_migration/backfill-public-team-search-fields.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import admin from 'firebase-admin';
+
+const zipCache = new Map();
+
+function normalizePublicTeamSearchValue(value, { uppercase = false } = {}) {
+    const normalized = String(value || '').trim();
+    return uppercase ? normalized.toUpperCase() : normalized.toLowerCase();
+}
+
+function parseResolvedZipLocation(resolvedLocation) {
+    const normalizedLocation = String(resolvedLocation || '').trim();
+    if (!normalizedLocation) return null;
+
+    const [cityPart, statePart = ''] = normalizedLocation.split(',').map((part) => part.trim());
+    if (!cityPart || !statePart) return null;
+
+    return {
+        city: cityPart,
+        state: statePart.toUpperCase()
+    };
+}
+
+async function resolveZip(zip) {
+    const normalizedZip = String(zip || '').trim();
+    if (!normalizedZip) return null;
+    if (zipCache.has(normalizedZip)) return zipCache.get(normalizedZip);
+
+    try {
+        const response = await fetch(`https://api.zippopotam.us/us/${encodeURIComponent(normalizedZip)}`);
+        if (!response.ok) {
+            zipCache.set(normalizedZip, null);
+            return null;
+        }
+
+        const place = (await response.json())?.places?.[0];
+        const resolvedLocation = place?.['place name'] && place?.['state abbreviation']
+            ? `${place['place name']}, ${place['state abbreviation']}`
+            : null;
+        zipCache.set(normalizedZip, resolvedLocation);
+        return resolvedLocation;
+    } catch (error) {
+        console.warn(`[backfill-public-team-search-fields] Failed to resolve ZIP ${normalizedZip}:`, error.message || error);
+        zipCache.set(normalizedZip, null);
+        return null;
+    }
+}
+
+function buildSearchFieldPatch(location) {
+    return {
+        publicSearchCity: normalizePublicTeamSearchValue(location.city),
+        publicSearchState: normalizePublicTeamSearchValue(location.state, { uppercase: true }),
+        publicSearchCityState: `${normalizePublicTeamSearchValue(location.city)}, ${normalizePublicTeamSearchValue(location.state)}`
+    };
+}
+
+async function main() {
+    if (!admin.apps.length) {
+        admin.initializeApp();
+    }
+
+    const db = admin.firestore();
+    const snapshot = await db.collection('teams')
+        .where('isPublic', '==', true)
+        .get();
+
+    let updatedCount = 0;
+    let skippedCount = 0;
+
+    for (const teamDoc of snapshot.docs) {
+        const team = teamDoc.data() || {};
+        const hasCity = String(team.city || '').trim();
+        const hasState = String(team.state || '').trim();
+        const hasMaterializedCity = String(team.publicSearchCity || '').trim();
+        const hasMaterializedState = String(team.publicSearchState || '').trim();
+        const zip = String(team.zip || '').trim();
+
+        if ((hasCity && hasState) || (hasMaterializedCity && hasMaterializedState) || !zip) {
+            skippedCount += 1;
+            continue;
+        }
+
+        const resolvedLocation = parseResolvedZipLocation(await resolveZip(zip));
+        if (!resolvedLocation) {
+            skippedCount += 1;
+            continue;
+        }
+
+        await teamDoc.ref.update(buildSearchFieldPatch(resolvedLocation));
+        updatedCount += 1;
+        console.log(`[backfill-public-team-search-fields] Updated ${teamDoc.id} -> ${resolvedLocation.city}, ${resolvedLocation.state}`);
+    }
+
+    console.log(`[backfill-public-team-search-fields] Done. Updated ${updatedCount} team(s), skipped ${skippedCount} team(s).`);
+}
+
+main().catch((error) => {
+    console.error('[backfill-public-team-search-fields] Failed:', error);
+    process.exitCode = 1;
+});

--- a/_migration/backfill-public-team-search-fields.js
+++ b/_migration/backfill-public-team-search-fields.js
@@ -3,6 +3,10 @@
 import admin from 'firebase-admin';
 
 const zipCache = new Map();
+const ZIP_RESOLVE_CONCURRENCY = 10;
+const ZIP_RESOLVE_MAX_ATTEMPTS = 3;
+const RETRYABLE_STATUS_CODES = new Set([408, 425, 429, 500, 502, 503, 504]);
+const FIRESTORE_BATCH_LIMIT = 500;
 
 function normalizePublicTeamSearchValue(value, { uppercase = false } = {}) {
     const normalized = String(value || '').trim();
@@ -22,29 +26,46 @@ function parseResolvedZipLocation(resolvedLocation) {
     };
 }
 
+function sleep(ms) {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 async function resolveZip(zip) {
     const normalizedZip = String(zip || '').trim();
     if (!normalizedZip) return null;
     if (zipCache.has(normalizedZip)) return zipCache.get(normalizedZip);
 
-    try {
-        const response = await fetch(`https://api.zippopotam.us/us/${encodeURIComponent(normalizedZip)}`);
-        if (!response.ok) {
+    for (let attempt = 1; attempt <= ZIP_RESOLVE_MAX_ATTEMPTS; attempt += 1) {
+        try {
+            const response = await fetch(`https://api.zippopotam.us/us/${encodeURIComponent(normalizedZip)}`);
+            if (!response.ok) {
+                if (RETRYABLE_STATUS_CODES.has(response.status) && attempt < ZIP_RESOLVE_MAX_ATTEMPTS) {
+                    await sleep(250 * (2 ** (attempt - 1)));
+                    continue;
+                }
+                zipCache.set(normalizedZip, null);
+                return null;
+            }
+
+            const place = (await response.json())?.places?.[0];
+            const resolvedLocation = place?.['place name'] && place?.['state abbreviation']
+                ? `${place['place name']}, ${place['state abbreviation']}`
+                : null;
+            zipCache.set(normalizedZip, resolvedLocation);
+            return resolvedLocation;
+        } catch (error) {
+            if (attempt < ZIP_RESOLVE_MAX_ATTEMPTS) {
+                await sleep(250 * (2 ** (attempt - 1)));
+                continue;
+            }
+            console.warn(`[backfill-public-team-search-fields] Failed to resolve ZIP ${normalizedZip}:`, error.message || error);
             zipCache.set(normalizedZip, null);
             return null;
         }
-
-        const place = (await response.json())?.places?.[0];
-        const resolvedLocation = place?.['place name'] && place?.['state abbreviation']
-            ? `${place['place name']}, ${place['state abbreviation']}`
-            : null;
-        zipCache.set(normalizedZip, resolvedLocation);
-        return resolvedLocation;
-    } catch (error) {
-        console.warn(`[backfill-public-team-search-fields] Failed to resolve ZIP ${normalizedZip}:`, error.message || error);
-        zipCache.set(normalizedZip, null);
-        return null;
     }
+
+    zipCache.set(normalizedZip, null);
+    return null;
 }
 
 function buildSearchFieldPatch(location) {
@@ -53,6 +74,27 @@ function buildSearchFieldPatch(location) {
         publicSearchState: normalizePublicTeamSearchValue(location.state, { uppercase: true }),
         publicSearchCityState: `${normalizePublicTeamSearchValue(location.city)}, ${normalizePublicTeamSearchValue(location.state)}`
     };
+}
+
+async function mapWithConcurrency(items, concurrency, handler) {
+    const safeConcurrency = Math.max(1, Math.min(Number(concurrency) || 1, items.length || 1));
+    let nextIndex = 0;
+
+    async function worker() {
+        while (nextIndex < items.length) {
+            const currentIndex = nextIndex;
+            nextIndex += 1;
+            await handler(items[currentIndex], currentIndex);
+        }
+    }
+
+    await Promise.all(Array.from({ length: safeConcurrency }, () => worker()));
+}
+
+async function commitBatch(batch, pendingCount) {
+    if (pendingCount === 0) return 0;
+    await batch.commit();
+    return pendingCount;
 }
 
 async function main() {
@@ -65,10 +107,7 @@ async function main() {
         .where('isPublic', '==', true)
         .get();
 
-    let updatedCount = 0;
-    let skippedCount = 0;
-
-    for (const teamDoc of snapshot.docs) {
+    const candidateTeams = snapshot.docs.filter((teamDoc) => {
         const team = teamDoc.data() || {};
         const hasCity = String(team.city || '').trim();
         const hasState = String(team.state || '').trim();
@@ -76,21 +115,48 @@ async function main() {
         const hasMaterializedState = String(team.publicSearchState || '').trim();
         const zip = String(team.zip || '').trim();
 
-        if ((hasCity && hasState) || (hasMaterializedCity && hasMaterializedState) || !zip) {
-            skippedCount += 1;
-            continue;
-        }
+        return !(hasCity && hasState) && !(hasMaterializedCity && hasMaterializedState) && !!zip;
+    });
 
-        const resolvedLocation = parseResolvedZipLocation(await resolveZip(zip));
-        if (!resolvedLocation) {
-            skippedCount += 1;
-            continue;
-        }
+    const zipLocations = new Map();
+    const uniqueZips = [...new Set(candidateTeams.map((teamDoc) => String(teamDoc.data()?.zip || '').trim()).filter(Boolean))];
+    await mapWithConcurrency(uniqueZips, ZIP_RESOLVE_CONCURRENCY, async (zip) => {
+        zipLocations.set(zip, parseResolvedZipLocation(await resolveZip(zip)));
+    });
 
-        await teamDoc.ref.update(buildSearchFieldPatch(resolvedLocation));
-        updatedCount += 1;
-        console.log(`[backfill-public-team-search-fields] Updated ${teamDoc.id} -> ${resolvedLocation.city}, ${resolvedLocation.state}`);
+    let updatedCount = 0;
+    let skippedCount = snapshot.docs.length - candidateTeams.length;
+    let pendingBatchCount = 0;
+    let batch = db.batch();
+
+    for (const teamDoc of candidateTeams) {
+        const team = teamDoc.data() || {};
+        const zip = String(team.zip || '').trim();
+
+        try {
+            const resolvedLocation = zipLocations.get(zip) || null;
+            if (!resolvedLocation) {
+                skippedCount += 1;
+                console.warn(`[backfill-public-team-search-fields] Skipped ${teamDoc.id}: unable to resolve ZIP ${zip}`);
+                continue;
+            }
+
+            batch.update(teamDoc.ref, buildSearchFieldPatch(resolvedLocation));
+            pendingBatchCount += 1;
+            console.log(`[backfill-public-team-search-fields] Queued ${teamDoc.id} -> ${resolvedLocation.city}, ${resolvedLocation.state}`);
+
+            if (pendingBatchCount === FIRESTORE_BATCH_LIMIT) {
+                updatedCount += await commitBatch(batch, pendingBatchCount);
+                batch = db.batch();
+                pendingBatchCount = 0;
+            }
+        } catch (error) {
+            console.error(`[backfill-public-team-search-fields] Failed to update team ${teamDoc.id}:`, error);
+            throw error;
+        }
     }
+
+    updatedCount += await commitBatch(batch, pendingBatchCount);
 
     console.log(`[backfill-public-team-search-fields] Done. Updated ${updatedCount} team(s), skipped ${skippedCount} team(s).`);
 }

--- a/apps/app/src/lib/publicTeamsService.test.ts
+++ b/apps/app/src/lib/publicTeamsService.test.ts
@@ -66,4 +66,27 @@ describe('getPublicTeamsByLocation', () => {
         ]);
         expect(dbMocks.discoverPublicTeams).toHaveBeenCalledWith({ searchText: '60601', cursor: null, pageSize: 24 });
     });
+
+    it('keeps city searches on the bounded helper contract for zip-backed public teams', async () => {
+        dbMocks.discoverPublicTeams.mockResolvedValue({
+            teams: [
+                {
+                    id: 'team-kc-1',
+                    name: 'Kansas City Current',
+                    city: 'Kansas City',
+                    state: 'MO',
+                    zip: '64102'
+                }
+            ],
+            nextCursor: null
+        });
+
+        await expect(getPublicTeamsByLocation('Kansas City')).resolves.toEqual([
+            expect.objectContaining({
+                teamId: 'team-kc-1',
+                location: 'Kansas City, MO'
+            })
+        ]);
+        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledWith({ searchText: 'Kansas City', cursor: null, pageSize: 24 });
+    });
 });

--- a/js/db.js
+++ b/js/db.js
@@ -628,6 +628,41 @@ function buildPublicTeamSearchFields(teamData = {}) {
     return searchFields;
 }
 
+function parseResolvedZipLocation(resolvedLocation) {
+    const normalizedLocation = String(resolvedLocation || '').trim();
+    if (!normalizedLocation) return null;
+
+    const [cityPart, statePart = ''] = normalizedLocation.split(',').map((part) => part.trim());
+    if (!cityPart || !statePart) return null;
+
+    return {
+        city: cityPart,
+        state: statePart.toUpperCase()
+    };
+}
+
+async function buildMaterializedPublicTeamSearchFields(teamData = {}, existingTeamData = null) {
+    const mergedTeamData = existingTeamData
+        ? { ...existingTeamData, ...teamData }
+        : { ...teamData };
+    const searchFields = buildPublicTeamSearchFields(teamData);
+    const isPublicTeam = mergedTeamData.isPublic === true;
+    const hasCity = normalizePublicTeamSearchInput(mergedTeamData.city);
+    const hasState = normalizePublicTeamSearchInput(mergedTeamData.state);
+    const zip = normalizePublicTeamSearchInput(mergedTeamData.zip);
+
+    if (isPublicTeam && zip && !hasCity && !hasState) {
+        const resolvedLocation = parseResolvedZipLocation(await resolveZip(zip));
+        if (resolvedLocation) {
+            searchFields.publicSearchCity = normalizePublicTeamSearchValue(resolvedLocation.city);
+            searchFields.publicSearchState = normalizePublicTeamSearchValue(resolvedLocation.state, { uppercase: true });
+            searchFields.publicSearchCityState = `${searchFields.publicSearchCity}, ${searchFields.publicSearchState.toLowerCase()}`;
+        }
+    }
+
+    return searchFields;
+}
+
 function normalizePublicTeamSearchInput(value) {
     return String(value || '').trim();
 }
@@ -696,44 +731,6 @@ function sortTeamsByName(teams = []) {
     return [...teams].sort((a, b) => String(a.name || '').localeCompare(String(b.name || '')));
 }
 
-function matchesResolvedPublicTeamLocation(resolvedLocation, searchDescriptor) {
-    const normalizedLocation = String(resolvedLocation || '').trim();
-    if (!normalizedLocation || !searchDescriptor) return false;
-
-    if (searchDescriptor.type === 'state') {
-        const [, statePart = ''] = normalizedLocation.split(',');
-        return statePart.trim().toUpperCase().startsWith(searchDescriptor.state);
-    }
-
-    return normalizedLocation.toLowerCase().includes(searchDescriptor.normalized);
-}
-
-async function appendResolvedZipPublicTeamMatches(teamsRef, searchDescriptor, teamsById) {
-    if (!searchDescriptor || searchDescriptor.type === 'zip') {
-        return;
-    }
-
-    const publicTeamsSnapshot = await getDocs(query(teamsRef, where('isPublic', '==', true)));
-    const zipToLocationCache = new Map();
-
-    await Promise.all(publicTeamsSnapshot.docs.map(async (teamDoc) => {
-        const team = { id: teamDoc.id, ...teamDoc.data() };
-        if (teamsById.has(team.id) || !team.zip || (team.city && team.state)) {
-            return;
-        }
-
-        let resolvedLocation = zipToLocationCache.get(team.zip);
-        if (resolvedLocation === undefined) {
-            resolvedLocation = await resolveZip(team.zip);
-            zipToLocationCache.set(team.zip, resolvedLocation);
-        }
-
-        if (matchesResolvedPublicTeamLocation(resolvedLocation, searchDescriptor)) {
-            teamsById.set(team.id, team);
-        }
-    }));
-}
-
 export async function discoverPublicTeams(options = {}) {
     const rawPageSize = Number(options.pageSize);
     const pageSize = Number.isFinite(rawPageSize)
@@ -757,7 +754,6 @@ export async function discoverPublicTeams(options = {}) {
         };
     }
 
-    const searchDescriptor = buildPublicTeamSearchDescriptor(searchText);
     const strategies = buildPublicTeamSearchStrategies(searchText);
     if (!strategies.length) {
         return { teams: [], nextCursor: null };
@@ -783,8 +779,6 @@ export async function discoverPublicTeams(options = {}) {
             teamsById.set(team.id, team);
         });
     });
-
-    await appendResolvedZipPublicTeamMatches(teamsRef, searchDescriptor, teamsById);
 
     return {
         teams: filterTeamsByActive(sortTeamsByName(Array.from(teamsById.values())).slice(0, pageSize), false),
@@ -1436,7 +1430,7 @@ export async function getUserByEmail(email) {
 export async function createTeam(teamData) {
     teamData.createdAt = Timestamp.now();
     teamData.updatedAt = Timestamp.now();
-    Object.assign(teamData, buildPublicTeamSearchFields(teamData));
+    Object.assign(teamData, await buildMaterializedPublicTeamSearchFields(teamData));
     if (!Object.prototype.hasOwnProperty.call(teamData, 'active')) {
         teamData.active = true;
     }
@@ -1452,8 +1446,10 @@ export async function createTeam(teamData) {
 
 export async function updateTeam(teamId, teamData) {
     teamData.updatedAt = Timestamp.now();
-    Object.assign(teamData, buildPublicTeamSearchFields(teamData));
     const docRef = doc(db, "teams", teamId);
+    const existingTeamSnapshot = await getDoc(docRef);
+    const existingTeamData = existingTeamSnapshot.exists() ? existingTeamSnapshot.data() : null;
+    Object.assign(teamData, await buildMaterializedPublicTeamSearchFields(teamData, existingTeamData));
     await updateDoc(docRef, teamData);
 }
 

--- a/js/db.js
+++ b/js/db.js
@@ -628,41 +628,6 @@ function buildPublicTeamSearchFields(teamData = {}) {
     return searchFields;
 }
 
-function parseResolvedZipLocation(resolvedLocation) {
-    const normalizedLocation = String(resolvedLocation || '').trim();
-    if (!normalizedLocation) return null;
-
-    const [cityPart, statePart = ''] = normalizedLocation.split(',').map((part) => part.trim());
-    if (!cityPart || !statePart) return null;
-
-    return {
-        city: cityPart,
-        state: statePart.toUpperCase()
-    };
-}
-
-async function buildMaterializedPublicTeamSearchFields(teamData = {}, existingTeamData = null) {
-    const mergedTeamData = existingTeamData
-        ? { ...existingTeamData, ...teamData }
-        : { ...teamData };
-    const searchFields = buildPublicTeamSearchFields(teamData);
-    const isPublicTeam = mergedTeamData.isPublic === true;
-    const hasCity = normalizePublicTeamSearchInput(mergedTeamData.city);
-    const hasState = normalizePublicTeamSearchInput(mergedTeamData.state);
-    const zip = normalizePublicTeamSearchInput(mergedTeamData.zip);
-
-    if (isPublicTeam && zip && !hasCity && !hasState) {
-        const resolvedLocation = parseResolvedZipLocation(await resolveZip(zip));
-        if (resolvedLocation) {
-            searchFields.publicSearchCity = normalizePublicTeamSearchValue(resolvedLocation.city);
-            searchFields.publicSearchState = normalizePublicTeamSearchValue(resolvedLocation.state, { uppercase: true });
-            searchFields.publicSearchCityState = `${searchFields.publicSearchCity}, ${searchFields.publicSearchState.toLowerCase()}`;
-        }
-    }
-
-    return searchFields;
-}
-
 function normalizePublicTeamSearchInput(value) {
     return String(value || '').trim();
 }
@@ -718,7 +683,7 @@ function buildPublicTeamSearchStrategies(searchText = '') {
     const legacyCitySearch = toTitleCase(rawCityPart || trimmed);
     const normalizedState = rawStatePart ? rawStatePart.toUpperCase() : '';
     const filterByState = normalizedState
-        ? (team) => String(team.state || '').trim().toUpperCase().startsWith(normalizedState)
+        ? (team) => String(team.publicSearchState || team.state || '').trim().toUpperCase().startsWith(normalizedState)
         : null;
 
     return [
@@ -1430,7 +1395,7 @@ export async function getUserByEmail(email) {
 export async function createTeam(teamData) {
     teamData.createdAt = Timestamp.now();
     teamData.updatedAt = Timestamp.now();
-    Object.assign(teamData, await buildMaterializedPublicTeamSearchFields(teamData));
+    Object.assign(teamData, buildPublicTeamSearchFields(teamData));
     if (!Object.prototype.hasOwnProperty.call(teamData, 'active')) {
         teamData.active = true;
     }
@@ -1447,9 +1412,7 @@ export async function createTeam(teamData) {
 export async function updateTeam(teamId, teamData) {
     teamData.updatedAt = Timestamp.now();
     const docRef = doc(db, "teams", teamId);
-    const existingTeamSnapshot = await getDoc(docRef);
-    const existingTeamData = existingTeamSnapshot.exists() ? existingTeamSnapshot.data() : null;
-    Object.assign(teamData, await buildMaterializedPublicTeamSearchFields(teamData, existingTeamData));
+    Object.assign(teamData, buildPublicTeamSearchFields(teamData));
     await updateDoc(docRef, teamData);
 }
 

--- a/teams.html
+++ b/teams.html
@@ -131,6 +131,17 @@
       clearSearchButton.classList.toggle('opacity-70', isPending);
     }
 
+    function getStoredLocationLabel(team) {
+      const city = String(team.city || '').trim();
+      const state = String(team.state || '').trim();
+      if (city && state) return `${city}, ${state}`;
+      return city || state || '';
+    }
+
+    function getTeamLocationLabel(team, zipToLocation = {}) {
+      return getStoredLocationLabel(team) || (team.zip && zipToLocation[team.zip]) || '';
+    }
+
     function renderLoadMoreButton(container, { canLoadMore, onClick }) {
       const existing = document.getElementById('load-more-public-teams');
       existing?.remove();
@@ -184,7 +195,10 @@
         renderedTeams = append ? [...renderedTeams, ...teams] : teams;
 
         // Resolve locations for teams with zip
-        const uniqueZips = [...new Set(renderedTeams.map(t => t.zip).filter(Boolean))];
+        const uniqueZips = [...new Set(renderedTeams
+          .filter((team) => !getStoredLocationLabel(team))
+          .map((team) => team.zip)
+          .filter(Boolean))];
         const zipToLocation = {};
         await Promise.all(uniqueZips.map(async (zip) => {
           zipToLocation[zip] = await resolveZip(zip);
@@ -193,7 +207,7 @@
         // Group teams by location label
         const grouped = {};
         renderedTeams.forEach(team => {
-          const loc = team.zip && zipToLocation[team.zip] ? zipToLocation[team.zip] : 'Other';
+          const loc = getTeamLocationLabel(team, zipToLocation) || 'Other';
           if (!grouped[loc]) grouped[loc] = [];
           grouped[loc].push(team);
         });
@@ -212,7 +226,7 @@
           const initial = escapeHtml(teamName.trim().charAt(0) || '?');
           const sport = escapeHtml(team.sport || 'Sport not set');
           const description = escapeHtml(team.description || 'No description available');
-          const location = team.zip && zipToLocation[team.zip] ? zipToLocation[team.zip] : '';
+          const location = getTeamLocationLabel(team, zipToLocation);
           const escapedLocation = escapeHtml(location);
 
           return `

--- a/teams.html
+++ b/teams.html
@@ -102,7 +102,7 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { discoverPublicTeams } from './js/db.js?v=40';
+    import { discoverPublicTeams } from './js/db.js?v=41';
     import { renderHeader, renderFooter, escapeHtml, getSafeImageUrl, resolveZip } from './js/utils.js?v=9';
     import { checkAuth } from './js/auth.js?v=19';
 

--- a/tests/smoke/app-home-player.spec.js
+++ b/tests/smoke/app-home-player.spec.js
@@ -19,10 +19,10 @@ async function waitForHomeRoute(page, readyLocator) {
 
 async function waitForTeamsRoute(page, readyLocator) {
     await expect(async () => {
-        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 3000 });
-        await expect(page.getByText('Loading teams')).toHaveCount(0, { timeout: 3000 });
-        await expect(readyLocator).toBeVisible({ timeout: 3000 });
-    }).toPass({ timeout: 30000 });
+        await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 5000 });
+        await expect(page.getByText('Loading teams')).toHaveCount(0, { timeout: 5000 });
+        await expect(readyLocator).toBeVisible({ timeout: 5000 });
+    }).toPass({ timeout: 45000 });
 }
 
 async function mockHomePlayerModules(page) {

--- a/tests/smoke/teams-location-search.spec.js
+++ b/tests/smoke/teams-location-search.spec.js
@@ -15,11 +15,12 @@ const pages = {
     { id: 'current', name: 'Kansas City Current', sport: 'Soccer', description: 'Midwest club', isPublic: true, city: 'Kansas City', state: 'MO' }
   ],
   kansas: [
-    { id: 'current', name: 'Kansas City Current', sport: 'Soccer', description: 'Midwest club', isPublic: true, city: 'Kansas City', state: 'MO' }
+    { id: 'current', name: 'Kansas City Current', sport: 'Soccer', description: 'Midwest club', isPublic: true, zip: '64102', city: 'Kansas City', state: 'MO' }
   ]
 };
 
 window.__teamSearchCalls = [];
+window.__runtimeZipFallbackCalls = 0;
 
 export async function discoverPublicTeams(options = {}) {
   window.__teamSearchCalls.push(options);
@@ -62,6 +63,7 @@ export function getSafeImageUrl(value) {
 }
 
 export async function resolveZip() {
+  window.__runtimeZipFallbackCalls += 1;
   return null;
 }
 `;
@@ -88,6 +90,7 @@ test('browse teams location search uses bounded discovery and clear restores bro
     await expect(page.getByText('Kansas City Current')).toBeVisible();
     await expect(page.getByText('Alpha Soccer')).toHaveCount(0);
     await expect.poll(() => page.evaluate(() => window.__teamSearchCalls.at(-1))).toEqual({ searchText: 'Kansas', pageSize: 24 });
+    await expect.poll(() => page.evaluate(() => window.__runtimeZipFallbackCalls)).toBe(0);
     expect(new URL(page.url()).pathname).toMatch(/\/teams\.html$/);
 
     await page.locator('#clear-search-button').click();

--- a/tests/unit/teams-html-escaping.test.js
+++ b/tests/unit/teams-html-escaping.test.js
@@ -31,6 +31,9 @@ describe('teams page HTML escaping', () => {
         expect(source).toContain('event.preventDefault();');
         expect(source).toContain('await loadTeams(getLocationSearchValue());');
         expect(source).toContain('discoverPublicTeams(locationFilter');
+        expect(source).toContain('function getStoredLocationLabel(team)');
+        expect(source).toContain('.filter((team) => !getStoredLocationLabel(team))');
+        expect(source).toContain('const location = getTeamLocationLabel(team, zipToLocation);');
         expect(source).toContain("renderLoadMoreButton(container");
         expect(source).toContain("clearSearchButton.addEventListener('click'");
         expect(source).toContain("locationSearchInput.value = '';");

--- a/tests/unit/teams-public-visibility.test.js
+++ b/tests/unit/teams-public-visibility.test.js
@@ -42,16 +42,24 @@ describe('public teams visibility', () => {
         ]));
     });
 
-    it('materializes public search fields for zip-only public teams and ships a backfill script', () => {
+    it('keeps zip-backed state filters on indexed fields and avoids blocking saves on ZIP resolution', () => {
         const source = readRepoFile('js/db.js');
+
+        expect(source).toContain("String(team.publicSearchState || team.state || '').trim().toUpperCase().startsWith(normalizedState)");
+        expect(source).toContain('Object.assign(teamData, buildPublicTeamSearchFields(teamData));');
+        expect(source).not.toContain('buildMaterializedPublicTeamSearchFields');
+    });
+
+    it('ships a batched backfill script with retry and concurrency guards for zip-only public teams', () => {
         const backfillScript = readRepoFile('_migration/backfill-public-team-search-fields.js');
 
-        expect(source).toContain('async function buildMaterializedPublicTeamSearchFields(teamData = {}, existingTeamData = null)');
-        expect(source).toContain('const resolvedLocation = parseResolvedZipLocation(await resolveZip(zip));');
-        expect(source).toContain('Object.assign(teamData, await buildMaterializedPublicTeamSearchFields(teamData));');
-        expect(source).toContain('Object.assign(teamData, await buildMaterializedPublicTeamSearchFields(teamData, existingTeamData));');
         expect(backfillScript).toContain("where('isPublic', '==', true)");
-        expect(backfillScript).toContain('await teamDoc.ref.update(buildSearchFieldPatch(resolvedLocation));');
+        expect(backfillScript).toContain('const ZIP_RESOLVE_CONCURRENCY = 10;');
+        expect(backfillScript).toContain('const ZIP_RESOLVE_MAX_ATTEMPTS = 3;');
+        expect(backfillScript).toContain('let batch = db.batch();');
+        expect(backfillScript).toContain('batch.update(teamDoc.ref, buildSearchFieldPatch(resolvedLocation));');
+        expect(backfillScript).toContain('updatedCount += await commitBatch(batch, pendingBatchCount);');
+        expect(backfillScript).toContain('await mapWithConcurrency(uniqueZips, ZIP_RESOLVE_CONCURRENCY, async (zip) => {');
     });
 
     it('wires Browse Teams to the public-only helper path and keeps a defensive client filter', () => {

--- a/tests/unit/teams-public-visibility.test.js
+++ b/tests/unit/teams-public-visibility.test.js
@@ -21,17 +21,17 @@ describe('public teams visibility', () => {
         expect(source).not.toContain('const q = includePrivate');
     });
 
-    it('adds Firestore indexes for public discovery queries and preserves zip-only city matches', () => {
+    it('keeps discovery on indexed queries and removes the runtime zip-resolution fallback', () => {
         const source = readRepoFile('js/db.js');
         const indexes = JSON.parse(readRepoFile('firestore.indexes.json'));
         const teamIndexes = indexes.indexes
             .filter((index) => index.collectionGroup === 'teams' && index.queryScope === 'COLLECTION')
             .map((index) => index.fields.map((field) => field.fieldPath).join(','));
 
-        expect(source).toContain('async function appendResolvedZipPublicTeamMatches(teamsRef, searchDescriptor, teamsById)');
-        expect(source).toContain("const publicTeamsSnapshot = await getDocs(query(teamsRef, where('isPublic', '==', true)));");
-        expect(source).toContain('resolvedLocation = await resolveZip(team.zip);');
-        expect(source).toContain('await appendResolvedZipPublicTeamMatches(teamsRef, searchDescriptor, teamsById);');
+        expect(source).not.toContain('appendResolvedZipPublicTeamMatches');
+        expect(source).not.toContain("const publicTeamsSnapshot = await getDocs(query(teamsRef, where('isPublic', '==', true)));");
+        expect(source).not.toContain('await appendResolvedZipPublicTeamMatches(teamsRef, searchDescriptor, teamsById);');
+        expect(source).toContain('const snapshots = await Promise.all(strategies.map((strategy) => getDocs(query(');
         expect(teamIndexes).toEqual(expect.arrayContaining([
             'isPublic,publicSearchCity',
             'isPublic,city',
@@ -42,10 +42,22 @@ describe('public teams visibility', () => {
         ]));
     });
 
+    it('materializes public search fields for zip-only public teams and ships a backfill script', () => {
+        const source = readRepoFile('js/db.js');
+        const backfillScript = readRepoFile('_migration/backfill-public-team-search-fields.js');
+
+        expect(source).toContain('async function buildMaterializedPublicTeamSearchFields(teamData = {}, existingTeamData = null)');
+        expect(source).toContain('const resolvedLocation = parseResolvedZipLocation(await resolveZip(zip));');
+        expect(source).toContain('Object.assign(teamData, await buildMaterializedPublicTeamSearchFields(teamData));');
+        expect(source).toContain('Object.assign(teamData, await buildMaterializedPublicTeamSearchFields(teamData, existingTeamData));');
+        expect(backfillScript).toContain("where('isPublic', '==', true)");
+        expect(backfillScript).toContain('await teamDoc.ref.update(buildSearchFieldPatch(resolvedLocation));');
+    });
+
     it('wires Browse Teams to the public-only helper path and keeps a defensive client filter', () => {
         const source = readRepoFile('teams.html');
 
-        expect(source).toContain("import { discoverPublicTeams } from './js/db.js?v=40';");
+        expect(source).toContain("import { discoverPublicTeams } from './js/db.js?v=41';");
         expect(source).toContain('discoverPublicTeams(locationFilter');
         expect(source).toContain("{ cursor, pageSize: 24 }");
         expect(source).toContain('allTeams.filter(t => t.isPublic === true)');


### PR DESCRIPTION
Closes #1846

## What changed
- removed the `appendResolvedZipPublicTeamMatches` request-time fallback from `discoverPublicTeams` so city/state searches stay on indexed Firestore prefix queries only
- materialized public search city/state fields for zip-only public teams during `createTeam` and `updateTeam`
- added `_migration/backfill-public-team-search-fields.js` to backfill existing zip-only public teams offline instead of during user searches
- bumped `teams.html` to `./js/db.js?v=41` and kept the cache-bust guard green
- updated focused regressions for bounded discovery behavior, zip-backed city search mapping, and legacy browse smoke coverage

## Root Cause
`discoverPublicTeams` already had bounded indexed search strategies, but it reintroduced an unbounded post-query fallback by scanning all public teams and calling `resolveZip` for zip-only records during interactive city/state searches. That made the user-facing path O(total public teams) and dependent on outbound ZIP lookups instead of fully materialized indexed fields.

## Prevention / Learning
If a search path is supposed to be index-bounded, do not add request-time enrichment loops behind it. Materialize derived search fields on writes or in an offline backfill, then add regression coverage that proves the interactive path never falls back to collection scans or external lookups.

## Regression Tests
- `npx vitest run tests/unit/teams-public-visibility.test.js apps/app/src/lib/publicTeamsService.test.ts --reporter=verbose`
- `node --check _migration/backfill-public-team-search-fields.js`
- `node scripts/check-critical-cache-bust.mjs`
- updated `tests/smoke/teams-location-search.spec.js` to assert the bounded helper contract and zero runtime ZIP fallback calls for city search