### PR TITLE
Deny legacy flat game clip Storage access

### DIFF
--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 
 function readText(path) {
     return readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
@@ -16,49 +17,67 @@ function assertMatches(text, pattern, label) {
     }
 }
 
-const firebaseJson = JSON.parse(readText('firebase.json'));
-const firestoreRules = readText('firestore.rules');
-const storageRules = readText('storage.rules');
-const deployProd = readText('.github/workflows/deploy-prod.yml');
-const deployPreview = readText('.github/workflows/deploy-preview.yml');
-const regressionGuards = readText('.github/workflows/regression-guards.yml');
+export function extractMatchBlock(text, startMarker) {
+    const start = text.indexOf(startMarker);
+    if (start === -1) {
+        throw new Error(`Rule block is missing: ${startMarker}`);
+    }
 
-if (firebaseJson.firestore?.rules !== 'firestore.rules') {
-    throw new Error('firebase.json must deploy firestore.rules.');
+    const remainingText = text.slice(start);
+    const nextMatch = remainingText.indexOf('\n    match /', startMarker.length);
+    return nextMatch === -1 ? remainingText : remainingText.slice(0, nextMatch);
 }
 
-if (firebaseJson.firestore?.indexes !== 'firestore.indexes.json') {
-    throw new Error('firebase.json must deploy firestore.indexes.json.');
+export function validateFirebaseRulesCi() {
+    const firebaseJson = JSON.parse(readText('firebase.json'));
+    const firestoreRules = readText('firestore.rules');
+    const storageRules = readText('storage.rules');
+    const legacyGameClipRules = extractMatchBlock(storageRules, 'match /game-clips/{fileName} {');
+    const deployProd = readText('.github/workflows/deploy-prod.yml');
+    const deployPreview = readText('.github/workflows/deploy-preview.yml');
+    const regressionGuards = readText('.github/workflows/regression-guards.yml');
+
+    if (firebaseJson.firestore?.rules !== 'firestore.rules') {
+        throw new Error('firebase.json must deploy firestore.rules.');
+    }
+
+    if (firebaseJson.firestore?.indexes !== 'firestore.indexes.json') {
+        throw new Error('firebase.json must deploy firestore.indexes.json.');
+    }
+
+    if (firebaseJson.storage?.rules !== 'storage.rules') {
+        throw new Error('firebase.json must deploy storage.rules.');
+    }
+
+    assertIncludes(firestoreRules, 'match /mediaFolders/{folderId}', 'Firestore media folder rules');
+    assertIncludes(firestoreRules, 'match /mediaItems/{itemId}', 'Firestore media item rules');
+    assertIncludes(firestoreRules, 'function canReadTeamMediaFolder(teamId, folderData)', 'Firestore media folder visibility rules');
+    assertIncludes(firestoreRules, 'function canReadTeamMediaItem(teamId, itemData)', 'Firestore media item visibility rules');
+    assertIncludes(firestoreRules, 'allow read: if canReadTeamMediaFolder(teamId, resource.data);', 'Firestore media folder read rules');
+    assertIncludes(firestoreRules, 'allow read: if canReadTeamMediaItem(teamId, resource.data);', 'Firestore media item read rules');
+    assertIncludes(firestoreRules, 'allow create, update, delete: if isTeamOwnerOrAdmin(teamId);', 'Firestore media folder write rules');
+    assertIncludes(firestoreRules, 'allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);', 'Firestore media item create rules');
+    assertIncludes(firestoreRules, 'allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaUploadSoftDelete(teamId) || isTeamMediaTitleUpdate(teamId);', 'Firestore media item update rules');
+    assertIncludes(firestoreRules, 'allow delete: if isTeamOwnerOrAdmin(teamId);', 'Firestore media item delete rules');
+
+    assertIncludes(deployProd, 'firestore:rules', 'Production deploy');
+    assertIncludes(deployProd, 'firestore:indexes', 'Production deploy');
+    assertMatches(deployProd, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Production deploy gate');
+
+    assertMatches(deployPreview, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Preview deploy gate');
+
+    assertIncludes(storageRules, 'match /game-clips/{teamId}/{gameId}/{userId}/{fileName}', 'Scoped Storage game clip rules');
+    assertIncludes(storageRules, 'allow get: if canAccessTeamMedia(teamId);', 'Scoped Storage game clip read rules');
+    assertIncludes(storageRules, 'allow create: if canAccessTeamMedia(teamId) &&', 'Scoped Storage game clip create rules');
+    assertIncludes(storageRules, 'request.auth.uid == userId', 'Scoped Storage uploader match rules');
+    assertIncludes(storageRules, 'request.resource.contentType.matches(\'video/.*\')', 'Scoped Storage video content-type rules');
+    assertIncludes(storageRules, 'match /game-clips/{fileName} {', 'Legacy Storage game clip rules');
+    assertIncludes(legacyGameClipRules, 'allow get, create, delete: if false;', 'Legacy Storage deny-all rule');
+
+    assertIncludes(regressionGuards, 'npm run ci:firebase-rules', 'Regression guard workflow');
+    assertIncludes(regressionGuards, 'npm run test:smoke:team-fallback', 'Regression guard workflow');
 }
 
-if (firebaseJson.storage?.rules !== 'storage.rules') {
-    throw new Error('firebase.json must deploy storage.rules.');
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+    validateFirebaseRulesCi();
 }
-
-assertIncludes(firestoreRules, 'match /mediaFolders/{folderId}', 'Firestore media folder rules');
-assertIncludes(firestoreRules, 'match /mediaItems/{itemId}', 'Firestore media item rules');
-assertIncludes(firestoreRules, 'function canReadTeamMediaFolder(teamId, folderData)', 'Firestore media folder visibility rules');
-assertIncludes(firestoreRules, 'function canReadTeamMediaItem(teamId, itemData)', 'Firestore media item visibility rules');
-assertIncludes(firestoreRules, 'allow read: if canReadTeamMediaFolder(teamId, resource.data);', 'Firestore media folder read rules');
-assertIncludes(firestoreRules, 'allow read: if canReadTeamMediaItem(teamId, resource.data);', 'Firestore media item read rules');
-assertIncludes(firestoreRules, 'allow create, update, delete: if isTeamOwnerOrAdmin(teamId);', 'Firestore media folder write rules');
-assertIncludes(firestoreRules, 'allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);', 'Firestore media item create rules');
-assertIncludes(firestoreRules, 'allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaUploadSoftDelete(teamId) || isTeamMediaTitleUpdate(teamId);', 'Firestore media item update rules');
-assertIncludes(firestoreRules, 'allow delete: if isTeamOwnerOrAdmin(teamId);', 'Firestore media item delete rules');
-
-assertIncludes(deployProd, 'firestore:rules', 'Production deploy');
-assertIncludes(deployProd, 'firestore:indexes', 'Production deploy');
-assertMatches(deployProd, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Production deploy gate');
-
-assertMatches(deployPreview, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Preview deploy gate');
-
-assertIncludes(storageRules, 'match /game-clips/{teamId}/{gameId}/{userId}/{fileName}', 'Scoped Storage game clip rules');
-assertIncludes(storageRules, 'allow get: if canAccessTeamMedia(teamId);', 'Scoped Storage game clip read rules');
-assertIncludes(storageRules, 'allow create: if canAccessTeamMedia(teamId) &&', 'Scoped Storage game clip create rules');
-assertIncludes(storageRules, 'request.auth.uid == userId', 'Scoped Storage uploader match rules');
-assertIncludes(storageRules, 'request.resource.contentType.matches(\'video/.*\')', 'Scoped Storage video content-type rules');
-assertIncludes(storageRules, 'match /game-clips/{fileName} {', 'Legacy Storage game clip rules');
-assertIncludes(storageRules, 'allow get, create, delete: if false;', 'Legacy Storage deny-all rule');
-
-assertIncludes(regressionGuards, 'npm run ci:firebase-rules', 'Regression guard workflow');
-assertIncludes(regressionGuards, 'npm run test:smoke:team-fallback', 'Regression guard workflow');

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -18,6 +18,7 @@ function assertMatches(text, pattern, label) {
 
 const firebaseJson = JSON.parse(readText('firebase.json'));
 const firestoreRules = readText('firestore.rules');
+const storageRules = readText('storage.rules');
 const deployProd = readText('.github/workflows/deploy-prod.yml');
 const deployPreview = readText('.github/workflows/deploy-preview.yml');
 const regressionGuards = readText('.github/workflows/regression-guards.yml');
@@ -28,6 +29,10 @@ if (firebaseJson.firestore?.rules !== 'firestore.rules') {
 
 if (firebaseJson.firestore?.indexes !== 'firestore.indexes.json') {
     throw new Error('firebase.json must deploy firestore.indexes.json.');
+}
+
+if (firebaseJson.storage?.rules !== 'storage.rules') {
+    throw new Error('firebase.json must deploy storage.rules.');
 }
 
 assertIncludes(firestoreRules, 'match /mediaFolders/{folderId}', 'Firestore media folder rules');
@@ -46,6 +51,14 @@ assertIncludes(deployProd, 'firestore:indexes', 'Production deploy');
 assertMatches(deployProd, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Production deploy gate');
 
 assertMatches(deployPreview, /needs:\s*\[\s*unit-tests\s*,\s*regression-guards\s*\]/, 'Preview deploy gate');
+
+assertIncludes(storageRules, 'match /game-clips/{teamId}/{gameId}/{userId}/{fileName}', 'Scoped Storage game clip rules');
+assertIncludes(storageRules, 'allow get: if canAccessTeamMedia(teamId);', 'Scoped Storage game clip read rules');
+assertIncludes(storageRules, 'allow create: if canAccessTeamMedia(teamId) &&', 'Scoped Storage game clip create rules');
+assertIncludes(storageRules, 'request.auth.uid == userId', 'Scoped Storage uploader match rules');
+assertIncludes(storageRules, 'request.resource.contentType.matches(\'video/.*\')', 'Scoped Storage video content-type rules');
+assertIncludes(storageRules, 'match /game-clips/{fileName} {', 'Legacy Storage game clip rules');
+assertIncludes(storageRules, 'allow get, create, delete: if false;', 'Legacy Storage deny-all rule');
 
 assertIncludes(regressionGuards, 'npm run ci:firebase-rules', 'Regression guard workflow');
 assertIncludes(regressionGuards, 'npm run test:smoke:team-fallback', 'Regression guard workflow');

--- a/storage.rules
+++ b/storage.rules
@@ -153,7 +153,7 @@ service firebase.storage {
     }
 
     match /game-clips/{fileName} {
-      allow get, create, delete: if isSignedIn();
+      allow get, create, delete: if false;
       allow list, update: if false;
     }
 

--- a/tests/unit/fallback-media-storage.test.js
+++ b/tests/unit/fallback-media-storage.test.js
@@ -31,6 +31,10 @@ function canDeleteScopedFallback({ authUid, pathUserId, isTeamAdmin = false }) {
     return authUid !== null && (isTeamAdmin || authUid === pathUserId);
 }
 
+function canAccessLegacyGameClipFallback({ authUid }) {
+    return authUid !== null && false;
+}
+
 describe('fallback media paths and Storage rules', () => {
     it('builds team-scoped fallback paths with uploader context', () => {
         expect(buildChatAttachmentFallbackPath('team/alpha', 'user 42', 'my photo (1).png', 1700000000000))
@@ -89,10 +93,13 @@ describe('fallback media paths and Storage rules', () => {
         expect(canCreateScopedFallback({ authUid: 'outsider-1', pathUserId: 'scorekeeper-1' })).toBe(false);
     });
 
-    it('hard-denies new legacy flat stat sheet writes and reads', () => {
+    it('hard-denies legacy flat stat sheet and game clip access', () => {
         expect(legacyStatSheetRules).toContain('match /stat-sheets/{fileName} {');
         expect(legacyStatSheetRules).toContain('allow get, create, delete: if false;');
         expect(legacyGameClipRules).toContain('match /game-clips/{fileName} {');
-        expect(legacyGameClipRules).toContain('allow get, create, delete: if isSignedIn();');
+        expect(legacyGameClipRules).toContain('allow get, create, delete: if false;');
+
+        expect(canAccessLegacyGameClipFallback({ authUid: 'signed-in-user' })).toBe(false);
+        expect(canAccessLegacyGameClipFallback({ authUid: null })).toBe(false);
     });
 });

--- a/tests/unit/validate-firebase-rules-ci.test.js
+++ b/tests/unit/validate-firebase-rules-ci.test.js
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { extractMatchBlock } from '../../scripts/validate-firebase-rules-ci.mjs';
+
+describe('validate Firebase rules CI helpers', () => {
+    it('scopes legacy game clip assertions to the flat path block', () => {
+        const storageRules = `rules_version = '2';
+service firebase.storage {
+  match /b/{bucket}/o {
+    match /game-clips/{teamId}/{gameId}/{userId}/{fileName} {
+      allow get: if isSignedIn();
+    }
+
+    match /stat-sheets/{fileName} {
+      allow get, create, delete: if false;
+    }
+
+    match /game-clips/{fileName} {
+      allow get, create, delete: if false;
+      allow list, update: if false;
+    }
+
+    match /athlete-profile-media/{userId}/{profileId}/{fileName} {
+      allow get: if true;
+    }
+  }
+}`;
+
+        const legacyGameClipRules = extractMatchBlock(storageRules, 'match /game-clips/{fileName} {');
+
+        expect(legacyGameClipRules).toContain('allow get, create, delete: if false;');
+        expect(legacyGameClipRules).not.toContain('match /stat-sheets/{fileName}');
+        expect(legacyGameClipRules).not.toContain('match /game-clips/{teamId}/{gameId}/{userId}/{fileName}');
+    });
+});


### PR DESCRIPTION
Closes #1885

## What changed
- changed the legacy `storage.rules` match for `/game-clips/{fileName}` from signed-in-wide access to deny-all
- updated `tests/unit/fallback-media-storage.test.js` to assert the flat legacy game-clips path stays blocked while scoped team/game/uploader paths remain in place
- extended `scripts/validate-firebase-rules-ci.mjs` with explicit Storage regression checks so CI guards both the scoped game-clip rule and the flat-path deny rule

## Root Cause
A temporary legacy Firebase Storage fallback for `/game-clips/{fileName}` was left permissive for any authenticated user after the scoped `game-clips/{teamId}/{gameId}/{userId}/{fileName}` path became the active upload path. The unit test also codified that temporary behavior, so the insecure rule could persist without failing CI.

## Prevention / Learning
When a scoped Storage path replaces a legacy fallback, remove or hard-deny the legacy match immediately and add a CI assertion that checks both sides of the boundary: denied legacy access and allowed scoped access. Do not leave temporary fallback rules encoded as expected behavior in tests.

## Regression Tests
- `npx vitest run tests/unit/fallback-media-storage.test.js --reporter=verbose`
- `node scripts/validate-firebase-rules-ci.mjs`

## Recurrence Risk
Low. The legacy flat path is now deny-all, the focused unit test asserts that behavior, and the Firebase rules CI validation now checks for this exact regression class.