### PR TITLE
Keep parent dashboard visible during access repair

### DIFF
--- a/js/db.js
+++ b/js/db.js
@@ -91,6 +91,8 @@ import {
 
 export async function normalizeParentScopeLinks(parentLinks = []) {
     const activeLinks = [];
+    let blockedLinkCount = 0;
+    let staleLinkCount = 0;
     const teamCache = new Map();
     const playerCache = new Map();
     const seenKeys = new Set();
@@ -109,7 +111,10 @@ export async function normalizeParentScopeLinks(parentLinks = []) {
             team = await getTeam(teamId, { includeInactive: true });
             teamCache.set(teamId, team || null);
         }
-        if (!team || !isTeamActive(team)) continue;
+        if (!team || !isTeamActive(team)) {
+            staleLinkCount += 1;
+            continue;
+        }
 
         let playerSnap = playerCache.get(playerKey);
         if (playerSnap === undefined) {
@@ -118,6 +123,7 @@ export async function normalizeParentScopeLinks(parentLinks = []) {
             } catch (error) {
                 if (error?.code === 'permission-denied') {
                     console.warn('[parent-scope] Preserving legacy player link while roster permissions are being repaired:', error);
+                    blockedLinkCount += 1;
                     playerSnap = { blockedByPermissions: true };
                 } else {
                     throw error;
@@ -139,10 +145,16 @@ export async function normalizeParentScopeLinks(parentLinks = []) {
             continue;
         }
 
-        if (!playerSnap?.exists()) continue;
+        if (!playerSnap?.exists()) {
+            staleLinkCount += 1;
+            continue;
+        }
 
         const player = { id: playerSnap.id, ...playerSnap.data() };
-        if (player.active === false) continue;
+        if (player.active === false) {
+            staleLinkCount += 1;
+            continue;
+        }
 
         activeLinks.push({
             ...link,
@@ -158,7 +170,9 @@ export async function normalizeParentScopeLinks(parentLinks = []) {
     return {
         activeLinks,
         parentTeamIds: [...new Set(activeLinks.map((link) => link.teamId))],
-        parentPlayerKeys: [...new Set(activeLinks.map((link) => `${link.teamId}::${link.playerId}`))]
+        parentPlayerKeys: [...new Set(activeLinks.map((link) => `${link.teamId}::${link.playerId}`))],
+        blockedLinkCount,
+        staleLinkCount
     };
 }
 import { normalizeStatTrackerConfig, splitPlayerStatsByVisibility } from './stat-leaderboards.js?v=2';
@@ -4592,11 +4606,27 @@ export async function getParentDashboardData(userId) {
     const userProfile = await getUserProfile(userId);
     if (!userProfile || !userProfile.parentOf || userProfile.parentOf.length === 0) {
         const registrationApplications = await listParentRegistrationApplicationsForProfile(userProfile || {});
-        return { upcomingGames: [], children: [], registrationApplications };
+        return {
+            upcomingGames: [],
+            children: [],
+            registrationApplications,
+            dashboardState: {
+                kind: 'no-links',
+                blockedLinkCount: 0,
+                staleLinkCount: 0,
+                teamEventErrors: 0
+            }
+        };
     }
 
     const normalizedParentScope = await normalizeParentScopeLinks(userProfile.parentOf);
     const children = normalizedParentScope.activeLinks;
+    const dashboardState = {
+        kind: 'ready',
+        blockedLinkCount: normalizedParentScope.blockedLinkCount || 0,
+        staleLinkCount: normalizedParentScope.staleLinkCount || 0,
+        teamEventErrors: 0
+    };
     const existingParentTeamIds = Array.isArray(userProfile.parentTeamIds) ? userProfile.parentTeamIds : [];
     const existingParentPlayerKeys = Array.isArray(userProfile.parentPlayerKeys) ? userProfile.parentPlayerKeys : [];
     const normalizedParentTeamIds = normalizedParentScope.parentTeamIds;
@@ -4627,13 +4657,21 @@ export async function getParentDashboardData(userId) {
     now.setHours(0, 0, 0, 0);
 
     for (const child of children) {
-        const team = await getTeam(child.teamId);
-        if (!team) continue;
         activeChildren.push(child);
 
         let events = eventsByTeam.get(child.teamId);
-        if (!events) {
-            events = await getEvents(child.teamId);
+        if (events === undefined) {
+            try {
+                events = await getEvents(child.teamId);
+            } catch (error) {
+                console.warn('[parent-dashboard] Failed to load team events for parent child link:', {
+                    teamId: child.teamId,
+                    playerId: child.playerId,
+                    error
+                });
+                dashboardState.teamEventErrors += 1;
+                events = [];
+            }
             eventsByTeam.set(child.teamId, events);
         }
 
@@ -4661,7 +4699,19 @@ export async function getParentDashboardData(userId) {
 
     const registrationApplications = await listParentRegistrationApplicationsForProfile(userProfile);
 
-    return { upcomingGames, children: activeChildren, registrationApplications };
+    if (activeChildren.length === 0) {
+        if (dashboardState.blockedLinkCount > 0) {
+            dashboardState.kind = 'access-blocked';
+        } else if (dashboardState.staleLinkCount > 0) {
+            dashboardState.kind = 'stale-links';
+        } else {
+            dashboardState.kind = 'no-links';
+        }
+    } else if (dashboardState.blockedLinkCount > 0 || dashboardState.teamEventErrors > 0) {
+        dashboardState.kind = 'degraded';
+    }
+
+    return { upcomingGames, children: activeChildren, registrationApplications, dashboardState };
 }
 
 export async function updatePlayerProfile(teamId, playerId, data) {

--- a/parent-dashboard.html
+++ b/parent-dashboard.html
@@ -388,7 +388,7 @@
             listFamilyShareTokens,
             revokeFamilyShareToken,
             updateFamilyShareTokenCalendars
-        } from './js/db.js?v=40';
+        } from './js/db.js?v=41';
         import { renderHeader, renderFooter, escapeHtml, fetchAndParseCalendar, extractOpponent, isPracticeEvent, expandRecurrence, getCalendarEventTrackingId, isTrackedCalendarEvent } from './js/utils.js?v=11';
         import {
             getIncentiveRules,
@@ -1544,7 +1544,7 @@
                 updateShareLinkControlsReady();
                 await loadShareLinks();
                 await loadParentCertificateLinks(data.children);
-                renderPlayers(data.children);
+                renderPlayers(data.children, data.dashboardState || null);
                 renderRegistrationApplications(data.registrationApplications || []);
                 teamChildrenByTeamId.clear();
                 (data.children || []).forEach((child) => {
@@ -1596,6 +1596,46 @@
 
             } catch (error) {
                 console.error(error);
+                renderDashboardLoadFailure(error);
+            }
+        }
+
+        function getParentDashboardStateMessage(dashboardState) {
+            switch (dashboardState?.kind) {
+                case 'access-blocked':
+                    return 'We could not verify your roster access yet. Try again in a moment or use Request Team Access below.';
+                case 'stale-links':
+                    return 'Your player links look stale. Ask a coach to refresh access or submit a new access request below.';
+                case 'degraded':
+                    return 'Some roster or schedule details are still syncing. Core dashboard links are still available.';
+                case 'load-error':
+                    return 'We could not load the parent dashboard right now. Refresh to try again.';
+                default:
+                    return '';
+            }
+        }
+
+        function renderDashboardLoadFailure(error) {
+            renderPlayers([], { kind: 'load-error', message: error?.message || '' });
+
+            const teamChats = document.getElementById('team-chats-list');
+            if (teamChats) {
+                teamChats.innerHTML = '<div class="text-center py-4 text-gray-500 text-sm">Team links are temporarily unavailable.</div>';
+            }
+
+            const familyPlanCard = document.getElementById('family-plan-card');
+            if (familyPlanCard) {
+                familyPlanCard.innerHTML = '<div class="p-6 text-center text-sm text-gray-500">Family plan details are temporarily unavailable.</div>';
+            }
+
+            const scheduleList = document.getElementById('schedule-list');
+            if (scheduleList) {
+                scheduleList.innerHTML = '<div class="text-center py-12 text-sm text-gray-500">Schedule data could not be loaded right now.</div>';
+            }
+
+            const practicePackets = document.getElementById('practice-packets-list');
+            if (practicePackets) {
+                practicePackets.innerHTML = '<div class="text-center py-12 text-sm text-gray-500">Practice packet data could not be loaded right now.</div>';
             }
         }
 
@@ -2568,14 +2608,26 @@
             }).join('');
         }
 
-        function renderPlayers(children) {
+        function renderPlayers(children, dashboardState = null) {
             const container = document.getElementById('my-players-list');
+            const statusMessage = dashboardState?.message || getParentDashboardStateMessage(dashboardState);
+            const statusHtml = statusMessage
+                ? `<div class="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">${escapeHtml(statusMessage)}</div>`
+                : '';
+
             if (!children || children.length === 0) {
-                container.innerHTML = `<div class="text-center py-8 text-gray-500 text-sm">No players linked yet.</div>`;
+                const emptyMessage = dashboardState?.kind === 'access-blocked'
+                    ? 'We are holding your saved player links while access finishes syncing.'
+                    : dashboardState?.kind === 'stale-links'
+                        ? 'No active linked players were found for this account.'
+                        : dashboardState?.kind === 'load-error'
+                            ? 'Please refresh and try again.'
+                            : 'No players linked yet.';
+                container.innerHTML = `${statusHtml}<div class="text-center py-8 text-gray-500 text-sm">${escapeHtml(emptyMessage)}</div>`;
                 return;
             }
 
-            container.innerHTML = children.map(child => {
+            container.innerHTML = `${statusHtml}${children.map(child => {
                 const certificates = certificatesByPlayerKey.get(parentCertificateKey(child.teamId, child.playerId)) || [];
                 return `
                 <div class="rounded-xl border border-gray-200 overflow-hidden">
@@ -2624,7 +2676,7 @@
                     </div>
                 </div>
             `;
-            }).join('');
+            }).join('')}`;
         }
 
         function renderTeamChats(children, unreadCounts = {}) {

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -24,11 +24,12 @@ async function waitForTeamDetailRoute(page, teamName) {
     }).toPass({ timeout: 30000 });
 }
 
-async function mockTeamsModules(page) {
-    await page.addInitScript(() => {
+async function mockTeamsModules(page, { scenario = '' } = {}) {
+    await page.addInitScript(({ scenarioName }) => {
         window.__openedPublicUrls = [];
         window.__homeLoads = 0;
-    });
+        window.__teamsScenario = scenarioName;
+    }, { scenarioName: scenario });
 
     await page.route(/\/src\/lib\/useAuth\.ts(\?.*)?$/, async (route) => {
         await route.fulfill({
@@ -123,10 +124,10 @@ async function mockTeamsModules(page) {
 
                 export async function loadParentHome() {
                     window.__homeLoads += 1;
-                    if (window.location.hash.includes('scenario=error')) {
+                    if (window.__teamsScenario === 'error') {
                         throw new Error('Team service down');
                     }
-                    if (window.location.hash.includes('scenario=empty')) {
+                    if (window.__teamsScenario === 'empty') {
                         return {
                             players: [],
                             teams: [],
@@ -399,7 +400,7 @@ test.describe('mobile My Teams', () => {
     });
 
     test('renders empty and error states with recovery links instead of spinners', async ({ page, baseURL }) => {
-        await mockTeamsModules(page);
+        await mockTeamsModules(page, { scenario: 'empty' });
         await page.goto(appUrl(baseURL, '/teams?scenario=empty'), { waitUntil: 'domcontentloaded' });
 
         await expect(page.getByRole('heading', { name: 'No teams linked yet' })).toBeVisible();
@@ -411,7 +412,7 @@ test.describe('mobile My Teams', () => {
     });
 
     test('shows load failures without trapping the user in loading state', async ({ page, baseURL }) => {
-        await mockTeamsModules(page);
+        await mockTeamsModules(page, { scenario: 'error' });
         await page.goto(appUrl(baseURL, '/teams?scenario=error'), { waitUntil: 'domcontentloaded' });
 
         await expect(page.getByText('Team service down')).toBeVisible();

--- a/tests/unit/db-parent-scope-normalization.test.js
+++ b/tests/unit/db-parent-scope-normalization.test.js
@@ -105,7 +105,9 @@ describe('parent scope normalization', () => {
                 }
             ],
             parentTeamIds: ['team-active'],
-            parentPlayerKeys: ['team-active::player-active']
+            parentPlayerKeys: ['team-active::player-active'],
+            blockedLinkCount: 0,
+            staleLinkCount: 3
         });
     });
 
@@ -153,7 +155,9 @@ describe('parent scope normalization', () => {
                 }
             ],
             parentTeamIds: ['team-active'],
-            parentPlayerKeys: ['team-active::player-blocked']
+            parentPlayerKeys: ['team-active::player-blocked'],
+            blockedLinkCount: 1,
+            staleLinkCount: 0
         });
     });
 
@@ -180,7 +184,9 @@ describe('parent scope normalization', () => {
                 }
             ],
             parentTeamIds: ['team-active'],
-            parentPlayerKeys: ['team-active::player-active']
+            parentPlayerKeys: ['team-active::player-active'],
+            blockedLinkCount: 0,
+            staleLinkCount: 1
         });
         const getTeam = vi.fn().mockResolvedValue({ id: 'team-active', name: 'Active Team', active: true });
         const getEvents = vi.fn().mockResolvedValue([]);
@@ -213,5 +219,72 @@ describe('parent scope normalization', () => {
                 playerPhotoUrl: null
             }
         ]);
+        expect(result.dashboardState).toEqual({
+            kind: 'ready',
+            blockedLinkCount: 0,
+            staleLinkCount: 1,
+            teamEventErrors: 0
+        });
+    });
+
+    it('keeps player cards visible when team event reads fail during parent access repair', async () => {
+        const getUserProfile = vi.fn().mockResolvedValue({
+            parentOf: [
+                { teamId: 'team-active', playerId: 'player-active', teamName: 'Active Team', playerName: 'Avery Lee' }
+            ],
+            parentTeamIds: [],
+            parentPlayerKeys: []
+        });
+        const updateUserProfile = vi.fn().mockResolvedValue(undefined);
+        const listParentRegistrationApplicationsForProfile = vi.fn().mockResolvedValue([]);
+        const normalizeParentScopeLinks = vi.fn().mockResolvedValue({
+            activeLinks: [
+                {
+                    teamId: 'team-active',
+                    playerId: 'player-active',
+                    teamName: 'Active Team',
+                    playerName: 'Avery Lee',
+                    playerNumber: '9',
+                    playerPhotoUrl: null
+                }
+            ],
+            parentTeamIds: ['team-active'],
+            parentPlayerKeys: ['team-active::player-active'],
+            blockedLinkCount: 1,
+            staleLinkCount: 0
+        });
+        const getEvents = vi.fn(async () => {
+            const error = new Error('blocked');
+            error.code = 'permission-denied';
+            throw error;
+        });
+        const getParentDashboardData = buildGetParentDashboardData({
+            getUserProfile,
+            updateUserProfile,
+            listParentRegistrationApplicationsForProfile,
+            normalizeParentScopeLinks,
+            getTeam: vi.fn(),
+            getEvents
+        });
+
+        const result = await getParentDashboardData('parent-1');
+
+        expect(result.children).toEqual([
+            {
+                teamId: 'team-active',
+                playerId: 'player-active',
+                teamName: 'Active Team',
+                playerName: 'Avery Lee',
+                playerNumber: '9',
+                playerPhotoUrl: null
+            }
+        ]);
+        expect(result.upcomingGames).toEqual([]);
+        expect(result.dashboardState).toEqual({
+            kind: 'degraded',
+            blockedLinkCount: 1,
+            staleLinkCount: 0,
+            teamEventErrors: 1
+        });
     });
 });

--- a/tests/unit/family-plan.test.js
+++ b/tests/unit/family-plan.test.js
@@ -375,5 +375,6 @@ describe('family plan helpers', () => {
         expect(html).toContain('Link created and copied to clipboard.');
         expect(html).toContain('id="retry-share-links-btn"');
         expect(html).toContain("from './js/db.js?v=41'");
+        expect(html).not.toContain("from './js/db.js?v=40'");
     });
 });

--- a/tests/unit/family-plan.test.js
+++ b/tests/unit/family-plan.test.js
@@ -374,6 +374,6 @@ describe('family plan helpers', () => {
         expect(html).toContain('function updateShareLinkControlsReady()');
         expect(html).toContain('Link created and copied to clipboard.');
         expect(html).toContain('id="retry-share-links-btn"');
-        expect(html).toContain("from './js/db.js?v=40'");
+        expect(html).toContain("from './js/db.js?v=41'");
     });
 });

--- a/tests/unit/parent-dashboard-active-player-filter.test.js
+++ b/tests/unit/parent-dashboard-active-player-filter.test.js
@@ -31,8 +31,11 @@ describe('parent dashboard active player filtering', () => {
         expect(functionSource).toContain('parentTeamIds: normalizedParentTeamIds');
         expect(functionSource).toContain('parentPlayerKeys: expectedParentPlayerKeys');
         expect(functionSource).toContain('activeChildren.push(child);');
+        expect(functionSource).not.toContain('const team = await getTeam(child.teamId);');
         expect(functionSource).toContain('childName: child.playerName');
         expect(functionSource).not.toContain('const playerRef = doc(db, `teams/${child.teamId}/players`, child.playerId);');
-        expect(dashboardSource).toContain("./js/db.js?v=40");
+        expect(functionSource).toContain("dashboardState.kind = 'degraded';");
+        expect(dashboardSource).toContain('renderPlayers(data.children, data.dashboardState || null);');
+        expect(dashboardSource).toContain("./js/db.js?v=41");
     });
 });

--- a/tests/unit/parent-dashboard-loader-state.test.js
+++ b/tests/unit/parent-dashboard-loader-state.test.js
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+function readParentDashboardSource() {
+    return readFileSync(new URL('../../parent-dashboard.html', import.meta.url), 'utf8');
+}
+
+describe('parent dashboard loader failure states', () => {
+    it('renders a visible fallback when the initial dashboard load fails', () => {
+        const source = readParentDashboardSource();
+
+        expect(source).toContain('function renderDashboardLoadFailure(error) {');
+        expect(source).toContain("renderPlayers([], { kind: 'load-error', message: error?.message || '' });");
+        expect(source).toContain('Schedule data could not be loaded right now.');
+        expect(source).toContain('Practice packet data could not be loaded right now.');
+        expect(source).toContain('renderDashboardLoadFailure(error);');
+    });
+
+    it('distinguishes blocked and stale linked-player states in the player list', () => {
+        const source = readParentDashboardSource();
+
+        expect(source).toContain("case 'access-blocked':");
+        expect(source).toContain("case 'stale-links':");
+        expect(source).toContain('We are holding your saved player links while access finishes syncing.');
+        expect(source).toContain('No active linked players were found for this account.');
+    });
+});


### PR DESCRIPTION
Closes #1833

## What changed
- Preserved parent dashboard child cards even when roster verification is partially blocked by permission timing or stale access repair.
- Added dashboard state metadata from `getParentDashboardData()` so the UI can distinguish normal, degraded, blocked, stale-link, and no-link states.
- Updated `parent-dashboard.html` to render a visible recovery message instead of failing silently, and added a loader-failure fallback for key dashboard sections.
- Added focused regression coverage for blocked roster reads, degraded event loading, and visible dashboard fallback behavior.

## Root Cause
`getParentDashboardData()` treated roster and event reads as hard requirements for rendering parent children. When roster verification or adjacent team reads were blocked during parent scope repair, the dashboard could end up with no rendered players or a silent init failure, while `parent-dashboard.html` only logged the error to the console.

## Prevention / Learning
When a parent-facing page depends on access repair or partially trusted linkage data, do not collapse the whole UI to an empty or blank state on recoverable permission errors. Return explicit degraded-state metadata from the data layer and require the page to render a user-visible fallback that preserves safe profile metadata without exposing private roster fields.

## Regression Tests
- `npx vitest run tests/unit/db-parent-scope-normalization.test.js tests/unit/parent-dashboard-active-player-filter.test.js tests/unit/parent-dashboard-loader-state.test.js --reporter=verbose`
- `node scripts/check-critical-cache-bust.mjs`