### PR TITLE
Migrate stat configs when team sport changes

### DIFF
--- a/edit-team.html
+++ b/edit-team.html
@@ -1815,13 +1815,15 @@
                 }
 
                 if (currentTeamId) {
-                    await updateTeam(currentTeamId, teamData);
-
+                    const [existingConfigs, existingGames] = await Promise.all([
+                        getConfigs(currentTeamId),
+                        getGames(currentTeamId)
+                    ]);
                     const migrationPlan = buildTeamSportConfigMigrationPlan({
                         previousSport: currentTeamSport,
                         nextSport: teamData.sport,
-                        configs: await getConfigs(currentTeamId),
-                        games: await getGames(currentTeamId)
+                        configs: existingConfigs,
+                        games: existingGames
                     });
 
                     if (migrationPlan.sportChanged) {
@@ -1836,6 +1838,8 @@
                             })));
                         }
                     }
+
+                    await updateTeam(currentTeamId, teamData);
                     currentTeamSport = teamData.sport;
                 } else {
                     const newTeamId = await createTeam(teamData);

--- a/edit-team.html
+++ b/edit-team.html
@@ -555,8 +555,9 @@
     <div id="footer-container"></div>
 
     <script type="module">
-        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes } from './js/db.js?v=40';
+        import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame } from './js/db.js?v=40';
         import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';
+        import { buildTeamSportConfigMigrationPlan } from './js/team-stat-config-migration.js?v=1';
         import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth, sendInviteEmail } from './js/auth.js?v=19';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
@@ -590,6 +591,7 @@
         let rolloverAccessPreview = null;
         let currentRegistrationSource = null;
         let currentTeamPassConfig = {};
+        let currentTeamSport = '';
         let lastRenderedRolloverSourceTeamId = null;
         let isInitPending = true;
         let selectedRegistrationTeam = null;
@@ -1264,6 +1266,7 @@
                 document.getElementById('name').value = team.name || '';
                 document.getElementById('description').value = team.description || '';
                 document.getElementById('sport').value = team.sport || '';
+                currentTeamSport = team.sport || '';
                 document.getElementById('teamColorPrimary').value = getTeamColorValue(team, 'primary', '#5ec9c5');
                 document.getElementById('teamColorSecondary').value = getTeamColorValue(team, 'secondary', '#d32f3a');
                 document.getElementById('notificationEmail').value = team.notificationEmail || '';
@@ -1813,6 +1816,27 @@
 
                 if (currentTeamId) {
                     await updateTeam(currentTeamId, teamData);
+
+                    const migrationPlan = buildTeamSportConfigMigrationPlan({
+                        previousSport: currentTeamSport,
+                        nextSport: teamData.sport,
+                        configs: await getConfigs(currentTeamId),
+                        games: await getGames(currentTeamId)
+                    });
+
+                    if (migrationPlan.sportChanged) {
+                        let targetConfigId = migrationPlan.targetConfigId;
+                        if (!targetConfigId && migrationPlan.shouldCreateTargetConfig) {
+                            targetConfigId = await addConfig(currentTeamId, migrationPlan.targetConfigData);
+                        }
+                        if (targetConfigId && migrationPlan.gameIdsToUpdate.length > 0) {
+                            await Promise.all(migrationPlan.gameIdsToUpdate.map((gameId) => updateGame(currentTeamId, gameId, {
+                                sport: teamData.sport,
+                                statTrackerConfigId: targetConfigId
+                            })));
+                        }
+                    }
+                    currentTeamSport = teamData.sport;
                 } else {
                     const newTeamId = await createTeam(teamData);
                     currentTeamId = newTeamId;

--- a/js/team-stat-config-migration.js
+++ b/js/team-stat-config-migration.js
@@ -1,0 +1,60 @@
+import { getDefaultStatConfigForSport } from './stat-config-presets.js?v=1';
+
+function normalizeSportLabel(value) {
+    return String(value || '').trim().toLowerCase();
+}
+
+function isHistoricalGame(game = {}) {
+    const status = String(game?.status || '').trim().toLowerCase();
+    const liveStatus = String(game?.liveStatus || '').trim().toLowerCase();
+    return status === 'completed' || status === 'final' || status === 'cancelled' || liveStatus === 'completed';
+}
+
+export function buildTeamSportConfigMigrationPlan({ previousSport = '', nextSport = '', configs = [], games = [] } = {}) {
+    const normalizedPreviousSport = normalizeSportLabel(previousSport);
+    const normalizedNextSport = normalizeSportLabel(nextSport);
+    const safeConfigs = Array.isArray(configs) ? configs : [];
+    const safeGames = Array.isArray(games) ? games : [];
+
+    if (!normalizedNextSport || normalizedPreviousSport === normalizedNextSport) {
+        return {
+            sportChanged: false,
+            targetConfigId: null,
+            targetConfigData: null,
+            shouldCreateTargetConfig: false,
+            gameIdsToUpdate: []
+        };
+    }
+
+    const matchingConfig = safeConfigs.find((config) => (
+        normalizeSportLabel(config?.baseType) === normalizedNextSport &&
+        Array.isArray(config?.columns) &&
+        config.columns.length > 0
+    ));
+    const targetConfigData = matchingConfig ? null : getDefaultStatConfigForSport(nextSport);
+
+    const sourceConfigIds = safeConfigs
+        .filter((config) => {
+            const baseType = normalizeSportLabel(config?.baseType);
+            return !!String(config?.id || '').trim() &&
+                !!baseType &&
+                baseType !== normalizedNextSport &&
+                baseType === normalizedPreviousSport;
+        })
+        .map((config) => String(config.id).trim());
+
+    const sourceConfigIdSet = new Set(sourceConfigIds);
+    const gameIdsToUpdate = safeGames
+        .filter((game) => !isHistoricalGame(game))
+        .filter((game) => sourceConfigIdSet.has(String(game?.statTrackerConfigId || '').trim()))
+        .map((game) => String(game.id || '').trim())
+        .filter(Boolean);
+
+    return {
+        sportChanged: true,
+        targetConfigId: matchingConfig ? String(matchingConfig.id || '').trim() || null : null,
+        targetConfigData,
+        shouldCreateTargetConfig: !matchingConfig && !!targetConfigData,
+        gameIdsToUpdate
+    };
+}

--- a/tests/smoke/admin-invite-redemption.spec.js
+++ b/tests/smoke/admin-invite-redemption.spec.js
@@ -62,6 +62,18 @@ export async function getTeamAccessCodes() {
     return [];
 }
 
+export async function getConfigs() {
+    return [];
+}
+
+export async function getGames() {
+    return [];
+}
+
+export async function updateGame() {
+    return undefined;
+}
+
 export async function inviteAdmin(teamId, email) {
     window.__lastAdminInvite = { teamId, email };
     return {

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -389,7 +389,7 @@ function extractEditTeamModule() {
 const editTeamModuleSource = extractEditTeamModule();
 const runEditTeamModule = new AsyncFunction('deps', editTeamModuleSource);
 
-async function bootEditTeam(initialState, overrides = {}) {
+async function bootEditTeam(initialState, overrides = {}, dependencyOverrides = {}) {
     const env = createEnvironment(initialState, overrides);
     const previousGlobals = new Map();
     const globalOverrides = {
@@ -414,7 +414,7 @@ async function bootEditTeam(initialState, overrides = {}) {
         });
     }
 
-    const deps = {
+    const baseDeps = {
         db: {
             async createTeam(teamData) {
                 env.state.createCalls = env.state.createCalls || [];
@@ -537,6 +537,55 @@ async function bootEditTeam(initialState, overrides = {}) {
         }
     };
 
+    const deps = {
+        ...baseDeps,
+        ...dependencyOverrides,
+        db: {
+            ...baseDeps.db,
+            ...(dependencyOverrides.db || {})
+        },
+        utils: {
+            ...baseDeps.utils,
+            ...(dependencyOverrides.utils || {})
+        },
+        auth: {
+            ...baseDeps.auth,
+            ...(dependencyOverrides.auth || {})
+        },
+        teamAdminBanner: {
+            ...baseDeps.teamAdminBanner,
+            ...(dependencyOverrides.teamAdminBanner || {})
+        },
+        liveStreamUtils: {
+            ...baseDeps.liveStreamUtils,
+            ...(dependencyOverrides.liveStreamUtils || {})
+        },
+        statConfigPresets: {
+            ...baseDeps.statConfigPresets,
+            ...(dependencyOverrides.statConfigPresets || {})
+        },
+        teamStatConfigMigration: {
+            ...baseDeps.teamStatConfigMigration,
+            ...(dependencyOverrides.teamStatConfigMigration || {})
+        },
+        teamAccess: {
+            ...baseDeps.teamAccess,
+            ...(dependencyOverrides.teamAccess || {})
+        },
+        rolloverAccess: {
+            ...baseDeps.rolloverAccess,
+            ...(dependencyOverrides.rolloverAccess || {})
+        },
+        rosterRolloverPreview: {
+            ...baseDeps.rosterRolloverPreview,
+            ...(dependencyOverrides.rosterRolloverPreview || {})
+        },
+        editTeamAdminInvites: {
+            ...baseDeps.editTeamAdminInvites,
+            ...(dependencyOverrides.editTeamAdminInvites || {})
+        }
+    };
+
     env.cleanup = () => {
         for (const [key, descriptor] of previousGlobals.entries()) {
             if (descriptor) {
@@ -626,6 +675,89 @@ describe('edit team admin access persistence', () => {
                 ownerEmail: 'owner@example.com'
             });
             expect(env.state.createCalls[0].teamData.registrationSource).toBeNull();
+        } finally {
+            env.cleanup();
+        }
+    });
+
+    it('runs sport migration before saving the new team sport so failed migrations can be retried', async () => {
+        const initialState = {
+            currentUser: { uid: 'owner-1', email: 'owner@example.com' },
+            team: {
+                id: 'team-1',
+                ownerId: 'owner-1',
+                name: 'Sharks',
+                description: 'Travel team',
+                sport: 'Basketball',
+                notificationEmail: 'notify@example.com',
+                leagueUrl: '',
+                standingsConfig: { enabled: false, rankingMode: 'points', tiebreakers: [] },
+                zip: '66209',
+                isPublic: true,
+                adminEmails: []
+            },
+            configs: [
+                { id: 'cfg-basketball', baseType: 'Basketball', columns: ['PTS'] }
+            ],
+            games: [
+                { id: 'game-1', status: 'scheduled', statTrackerConfigId: 'cfg-basketball' }
+            ],
+            updateCalls: [],
+            updateGameCalls: [],
+            operationOrder: []
+        };
+
+        const env = await bootEditTeam(initialState, undefined, {
+            teamStatConfigMigration: {
+                buildTeamSportConfigMigrationPlan() {
+                    return {
+                        sportChanged: true,
+                        shouldCreateTargetConfig: true,
+                        targetConfigId: null,
+                        targetConfigData: { baseType: 'Soccer', columns: ['GOALS'] },
+                        gameIdsToUpdate: ['game-1']
+                    };
+                }
+            },
+            db: {
+                async getConfigs() {
+                    initialState.operationOrder.push('getConfigs');
+                    return deepClone(initialState.configs || []);
+                },
+                async getGames() {
+                    initialState.operationOrder.push('getGames');
+                    return deepClone(initialState.games || []);
+                },
+                async addConfig() {
+                    initialState.operationOrder.push('addConfig');
+                    return 'cfg-soccer';
+                },
+                async updateGame(teamId, gameId, gameData) {
+                    initialState.operationOrder.push(`updateGame:${gameId}`);
+                    initialState.updateGameCalls.push({ teamId, gameId, gameData: deepClone(gameData) });
+                    throw new Error('game migration failed');
+                },
+                async updateTeam(teamId, teamData) {
+                    initialState.operationOrder.push('updateTeam');
+                    initialState.updateCalls.push({ teamId, teamData: deepClone(teamData) });
+                    initialState.team = { ...initialState.team, ...deepClone(teamData), id: teamId };
+                }
+            }
+        });
+        try {
+            env.elements.get('sport').value = 'Soccer';
+
+            await env.elements.get('team-form').requestSubmit();
+
+            expect(initialState.operationOrder).toEqual([
+                'getConfigs',
+                'getGames',
+                'addConfig',
+                'updateGame:game-1'
+            ]);
+            expect(initialState.updateCalls).toEqual([]);
+            expect(initialState.team.sport).toBe('Basketball');
+            expect(env.alerts.at(-1)).toContain('game migration failed');
         } finally {
             env.cleanup();
         }

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -341,12 +341,16 @@ function extractEditTeamModule() {
 
     return match[1]
         .replace(
-            "import { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes } from './js/db.js?v=40';",
-            'const { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes } = deps.db;'
+            /import\s+\{\s*createTeam,\s*updateTeam,\s*getTeam,\s*getUserProfile,\s*getUserTeamsWithAccess,\s*getPlayers,\s*copySelectedPlayersForTeamRollover,\s*uploadTeamPhoto,\s*addConfig,\s*getUnreadChatCount,\s*inviteAdmin,\s*addTeamAdminEmail,\s*getAllUsers,\s*getTeamAccessCodes(?:,\s*getConfigs,\s*getGames,\s*updateGame)?\s*\}\s+from\s+'\.\/js\/db\.js\?v=40';/,
+            'const { createTeam, updateTeam, getTeam, getUserProfile, getUserTeamsWithAccess, getPlayers, copySelectedPlayersForTeamRollover, uploadTeamPhoto, addConfig, getUnreadChatCount, inviteAdmin, addTeamAdminEmail, getAllUsers, getTeamAccessCodes, getConfigs, getGames, updateGame } = deps.db;'
         )
         .replace(
             "import { getDefaultStatConfigForSport } from './js/stat-config-presets.js?v=1';",
             'const { getDefaultStatConfigForSport } = deps.statConfigPresets;'
+        )
+        .replace(
+            "import { buildTeamSportConfigMigrationPlan } from './js/team-stat-config-migration.js?v=1';",
+            'const { buildTeamSportConfigMigrationPlan } = deps.teamStatConfigMigration;'
         )
         .replace(
             "import { renderHeader, renderFooter, getUrlParams, escapeHtml } from './js/utils.js?v=8';",
@@ -454,6 +458,16 @@ async function bootEditTeam(initialState, overrides = {}) {
             },
             async getTeamAccessCodes(teamId) {
                 return (env.state.teamAccessCodes || []).filter((code) => code.teamId === teamId);
+            },
+            async getConfigs() {
+                return deepClone(env.state.configs || []);
+            },
+            async getGames() {
+                return deepClone(env.state.games || []);
+            },
+            async updateGame(teamId, gameId, gameData) {
+                env.state.updateGameCalls = env.state.updateGameCalls || [];
+                env.state.updateGameCalls.push({ teamId, gameId, gameData: deepClone(gameData) });
             }
         },
         utils: {
@@ -494,6 +508,16 @@ async function bootEditTeam(initialState, overrides = {}) {
         statConfigPresets: {
             getDefaultStatConfigForSport() {
                 return null;
+            }
+        },
+        teamStatConfigMigration: {
+            buildTeamSportConfigMigrationPlan() {
+                return {
+                    sportChanged: false,
+                    needsNewConfig: false,
+                    targetConfigId: null,
+                    gameIdsToUpdate: []
+                };
             }
         },
         teamAccess: await import('../../js/team-access.js'),

--- a/tests/unit/edit-team-stat-schema-defaults.test.js
+++ b/tests/unit/edit-team-stat-schema-defaults.test.js
@@ -18,10 +18,14 @@ describe('edit team stat schema defaults', () => {
         const source = readEditTeamSource();
 
         expect(source).toContain("from './js/team-stat-config-migration.js?v=1'");
+        expect(source).toContain('const [existingConfigs, existingGames] = await Promise.all([');
+        expect(source).toContain('getConfigs(currentTeamId),');
+        expect(source).toContain('getGames(currentTeamId)');
         expect(source).toContain('const migrationPlan = buildTeamSportConfigMigrationPlan({');
-        expect(source).toContain('configs: await getConfigs(currentTeamId),');
-        expect(source).toContain('games: await getGames(currentTeamId)');
+        expect(source).toContain('configs: existingConfigs,');
+        expect(source).toContain('games: existingGames');
         expect(source).toContain('statTrackerConfigId: targetConfigId');
         expect(source).toContain('sport: teamData.sport');
+        expect(source).toContain('await updateTeam(currentTeamId, teamData);');
     });
 });

--- a/tests/unit/edit-team-stat-schema-defaults.test.js
+++ b/tests/unit/edit-team-stat-schema-defaults.test.js
@@ -13,4 +13,15 @@ describe('edit team stat schema defaults', () => {
         expect(source).toContain('const defaultStatConfig = getDefaultStatConfigForSport(teamData.sport);');
         expect(source).toContain('const configId = await addConfig(newTeamId, defaultStatConfig);');
     });
+
+    it('migrates stat config selection when an existing team changes sports', () => {
+        const source = readEditTeamSource();
+
+        expect(source).toContain("from './js/team-stat-config-migration.js?v=1'");
+        expect(source).toContain('const migrationPlan = buildTeamSportConfigMigrationPlan({');
+        expect(source).toContain('configs: await getConfigs(currentTeamId),');
+        expect(source).toContain('games: await getGames(currentTeamId)');
+        expect(source).toContain('statTrackerConfigId: targetConfigId');
+        expect(source).toContain('sport: teamData.sport');
+    });
 });

--- a/tests/unit/team-stat-config-migration.test.js
+++ b/tests/unit/team-stat-config-migration.test.js
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+import { buildTeamSportConfigMigrationPlan } from '../../js/team-stat-config-migration.js';
+
+describe('team stat config migration', () => {
+    it('creates a matching config and remaps incomplete games when the team sport changes', () => {
+        const plan = buildTeamSportConfigMigrationPlan({
+            previousSport: 'Basketball',
+            nextSport: 'Soccer',
+            configs: [
+                { id: 'cfg-basketball', baseType: 'Basketball', columns: ['PTS', 'REB', 'AST'] }
+            ],
+            games: [
+                { id: 'game-upcoming', status: 'scheduled', statTrackerConfigId: 'cfg-basketball' },
+                { id: 'game-history', status: 'completed', statTrackerConfigId: 'cfg-basketball' }
+            ]
+        });
+
+        expect(plan.sportChanged).toBe(true);
+        expect(plan.shouldCreateTargetConfig).toBe(true);
+        expect(plan.targetConfigId).toBeNull();
+        expect(plan.targetConfigData).toMatchObject({
+            baseType: 'Soccer',
+            columns: ['GOALS', 'SHOTS', 'SHOTS_ON_TARGET', 'ASSISTS', 'SAVES']
+        });
+        expect(plan.gameIdsToUpdate).toEqual(['game-upcoming']);
+    });
+
+    it('reuses an existing matching config instead of creating a duplicate', () => {
+        const plan = buildTeamSportConfigMigrationPlan({
+            previousSport: 'Basketball',
+            nextSport: 'Soccer',
+            configs: [
+                { id: 'cfg-basketball', baseType: 'Basketball', columns: ['PTS', 'REB', 'AST'] },
+                { id: 'cfg-soccer', baseType: 'Soccer', columns: ['GOALS', 'SHOTS'] }
+            ],
+            games: [
+                { id: 'game-upcoming', status: 'scheduled', statTrackerConfigId: 'cfg-basketball' }
+            ]
+        });
+
+        expect(plan.shouldCreateTargetConfig).toBe(false);
+        expect(plan.targetConfigId).toBe('cfg-soccer');
+        expect(plan.gameIdsToUpdate).toEqual(['game-upcoming']);
+    });
+
+    it('does not remap historical games or unchanged sports', () => {
+        const unchangedPlan = buildTeamSportConfigMigrationPlan({
+            previousSport: 'Soccer',
+            nextSport: 'Soccer',
+            configs: [
+                { id: 'cfg-soccer', baseType: 'Soccer', columns: ['GOALS'] }
+            ],
+            games: [
+                { id: 'game-upcoming', status: 'scheduled', statTrackerConfigId: 'cfg-soccer' }
+            ]
+        });
+        expect(unchangedPlan).toMatchObject({
+            sportChanged: false,
+            shouldCreateTargetConfig: false,
+            gameIdsToUpdate: []
+        });
+
+        const historicalPlan = buildTeamSportConfigMigrationPlan({
+            previousSport: 'Basketball',
+            nextSport: 'Soccer',
+            configs: [
+                { id: 'cfg-basketball', baseType: 'Basketball', columns: ['PTS'] }
+            ],
+            games: [
+                { id: 'game-final', status: 'final', statTrackerConfigId: 'cfg-basketball' },
+                { id: 'game-live-complete', liveStatus: 'completed', statTrackerConfigId: 'cfg-basketball' }
+            ]
+        });
+
+        expect(historicalPlan.gameIdsToUpdate).toEqual([]);
+    });
+});


### PR DESCRIPTION
Closes #1828

## What changed
- added a focused `team-stat-config-migration` helper to plan sport-change stat config migration
- updated `edit-team.html` so saving an existing team after a sport change now:
  - reuses an existing stat tracker config for the new sport when available
  - creates the default config for the new sport when none exists
  - reassigns incomplete games that still point at the old sport's config to the new sport config
- added regression coverage for the migration planner and for the edit-team wiring

## Root Cause
`edit-team.html` only persisted `team.sport` for existing teams. It never reconciled `statTrackerConfigs` or future game `statTrackerConfigId` references, so schedule and tracking flows could keep resolving the old sport's schema after the team sport changed.

## Prevention / Learning
When a parent record owns typed child configuration that downstream records reference by ID, changing the parent's type is a migration event, not a simple field update. Future fixes should update or create the matching child config and reconcile incomplete dependent records in the same save flow.

## Regression Tests
- `npx vitest run tests/unit/team-stat-config-migration.test.js tests/unit/edit-team-stat-schema-defaults.test.js --reporter=verbose`
- `tests/unit/team-stat-config-migration.test.js` covers config creation, config reuse, and historical-game exclusion
- `tests/unit/edit-team-stat-schema-defaults.test.js` verifies the edit-team page wires the migration flow into saves for existing teams