### PR TITLE
Use summary schedule load for parent calendar tools

### DIFF
--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -386,7 +386,10 @@ export async function initiateParentTeamFeeCheckout(teamId: string, batchId: str
 
 export async function loadParentCalendarTools(user: AuthUser | null) {
   if (!user?.uid) return { events: [], teams: [] };
-  const schedule = await loadParentSchedule(user);
+  const schedule = await loadParentSchedule(user, {
+    hydrateDetails: false,
+    expandStaffPlayers: false
+  });
   const teamsById = new Map<string, ParentCalendarTeam>();
   (schedule.events || []).forEach((event) => {
     if (!event.teamId) return;

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -534,7 +534,7 @@ describe('React app parent tools service', () => {
         expect(isParentTeamFeePayActionAllowed({ status: 'adjusted', balanceDueCents: 0 })).toBe(false);
     });
 
-    it('loads schedule tools and builds escaped ICS content', async () => {
+    it('loads calendar tools with lightweight parent schedule options and builds escaped ICS content', async () => {
         const event = {
             eventKey: 'team-1::event-1::player-1',
             id: 'event-1',
@@ -548,11 +548,18 @@ describe('React app parent tools service', () => {
             childName: 'Pat Star',
             notes: 'Bring water; arrive early'
         };
-        scheduleMocks.loadParentSchedule.mockResolvedValue({ children: [], events: [event] });
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            children: [],
+            events: [event, { id: 'event-2', teamId: 'team-1', teamName: 'Bears', type: 'practice', date: new Date('2100-06-02T18:00:00Z') }]
+        });
 
         await expect(loadParentCalendarTools(user)).resolves.toMatchObject({
-            events: [event],
-            teams: [{ teamId: 'team-1', teamName: 'Bears', eventCount: 1 }]
+            events: [event, { id: 'event-2', teamId: 'team-1', teamName: 'Bears', type: 'practice', date: new Date('2100-06-02T18:00:00Z') }],
+            teams: [{ teamId: 'team-1', teamName: 'Bears', eventCount: 2 }]
+        });
+        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledWith(user, {
+            hydrateDetails: false,
+            expandStaffPlayers: false
         });
 
         const ics = buildParentScheduleIcs([event], 'Family, Schedule');


### PR DESCRIPTION
Closes #1896

## What changed
- Updated `loadParentCalendarTools` to call `loadParentSchedule` with `{ hydrateDetails: false, expandStaffPlayers: false }`.
- Kept the existing Parent Tools calendar output shape unchanged so export, agenda copy, and per-team counts still use the same lightweight event list.
- Added a regression unit test that verifies the lightweight loader options are passed and that team event counts still build correctly from summary events.

## Root Cause
`loadParentCalendarTools` reused `loadParentSchedule` without overriding its defaults. That silently enabled full event-detail hydration and staff roster expansion for a workflow that only needs summary schedule data, causing unnecessary RSVP, rideshare, assignment, and roster reads.

## Prevention / Learning
When a parent-facing workflow only needs summary schedule data, shared schedule loaders must be called with explicit minimal options instead of relying on heavyweight defaults. Add a regression assertion on those options so future refactors cannot reintroduce hidden hydration work.

## Regression Tests
- `npx vitest run tests/unit/app-parent-tools-service.test.js --reporter=verbose`
- Added assertions in `tests/unit/app-parent-tools-service.test.js` that `loadParentSchedule` is called with `{ hydrateDetails: false, expandStaffPlayers: false }` and that lightweight events still produce the expected team counts.