### PR TITLE
Skip inbox load for mobile chat deep links

### DIFF
--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -121,6 +121,7 @@ export function Messages({ auth }: { auth: AuthState }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [query, setQuery] = useState('');
+  const shouldLoadInbox = isDesktopWeb || !teamId;
 
   const refreshInbox = async () => {
     if (!auth.user) return;
@@ -138,9 +139,15 @@ export function Messages({ auth }: { auth: AuthState }) {
   };
 
   useEffect(() => {
+    if (!shouldLoadInbox) {
+      setLoading(false);
+      setError(null);
+      setTeams([]);
+      return;
+    }
     refreshInbox();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [auth.user?.uid]);
+  }, [auth.user?.uid, shouldLoadInbox]);
 
   const filteredTeams = useMemo(() => {
     const normalized = query.trim().toLowerCase();

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -420,6 +420,26 @@ describe('React app messages integration', () => {
         );
     });
 
+    it('skips inbox loading for direct mobile thread deep links and keeps conversation targeting', async () => {
+        chatMocks.loadChatConversations.mockResolvedValueOnce([
+            { id: 'team', type: 'team', name: 'Bears Team Chat', participantIds: [], participantRoles: ['team'] },
+            { id: 'staff-conversation', type: 'group', name: 'Staff only', participantIds: ['user-1'], participantRoles: ['staff'] }
+        ]);
+
+        const { container } = await renderMessages('/messages/team-1?conversationId=staff-conversation');
+
+        expect(chatMocks.loadChatInbox).not.toHaveBeenCalled();
+        expect(chatMocks.loadChatTeamContext).toHaveBeenCalledWith('team-1', auth.user);
+        expect(chatMocks.subscribeToTeamChatMessages).toHaveBeenLastCalledWith(
+            'team-1',
+            'staff-conversation',
+            expect.any(Function),
+            expect.any(Function)
+        );
+        expect(container.textContent).toContain('Staff only');
+        expect(container.textContent).toContain('Bring both jerseys.');
+    });
+
     it('falls back to the default team conversation when the requested conversation is unavailable', async () => {
         chatMocks.loadChatConversations.mockResolvedValueOnce([
             { id: 'team', type: 'team', name: 'Bears Team Chat', participantIds: [], participantRoles: ['team'] }
@@ -427,6 +447,7 @@ describe('React app messages integration', () => {
 
         const { container } = await renderMessages('/messages/team-1?conversationId=missing-conversation');
 
+        expect(chatMocks.loadChatInbox).not.toHaveBeenCalled();
         expect(container.textContent).toContain('Bears Team Chat');
         expect(chatMocks.subscribeToTeamChatMessages).toHaveBeenLastCalledWith(
             'team-1',
@@ -434,6 +455,49 @@ describe('React app messages integration', () => {
             expect.any(Function),
             expect.any(Function)
         );
+    });
+
+    it('loads the inbox for the inbox route and desktop two-pane thread route', async () => {
+        await renderMessages('/messages');
+        expect(chatMocks.loadChatInbox).toHaveBeenCalledTimes(1);
+
+        vi.clearAllMocks();
+        layoutMocks.isDesktopWeb = true;
+        chatMocks.loadChatInbox.mockResolvedValue({
+            teams: [
+                {
+                    id: 'team-1',
+                    name: 'Bears',
+                    sport: 'Basketball',
+                    role: 'Admin',
+                    canModerate: true,
+                    unreadCount: 2,
+                    lastMessage: chatMessage({ id: 'last-1', text: 'Practice packet posted.' })
+                }
+            ]
+        });
+        chatMocks.loadChatTeamContext.mockResolvedValue({
+            team: { id: 'team-1', name: 'Bears', sport: 'Basketball' },
+            profile: { fullName: 'Pat Parent', photoUrl: '' },
+            canModerate: true
+        });
+        chatMocks.loadChatConversations.mockResolvedValue([
+            { id: 'team', type: 'team', name: 'Bears Team Chat', participantIds: [], participantRoles: ['team'] }
+        ]);
+        chatMocks.loadChatRecipientOptions.mockResolvedValue([
+            { id: 'user:coach-1', name: 'Coach Jamie', detail: 'Staff' },
+            { id: 'player:player-1', name: 'Pat', detail: '#9' }
+        ]);
+        chatMocks.subscribeToTeamChatMessages.mockImplementation((teamId, conversationId, onMessages) => {
+            onMessages([
+                chatMessage({ id: 'msg-1', senderId: 'coach-1', senderName: 'Coach Jamie', text: 'Bring both jerseys.' }),
+                chatMessage({ id: 'msg-2', senderId: 'user-1', senderName: 'Pat Parent', text: 'We can bring snacks.', createdAt: new Date('2026-05-21T14:02:00Z') })
+            ], { id: 'cursor' });
+            return { unsubscribe: vi.fn() };
+        });
+
+        await renderMessages('/messages/team-1');
+        expect(chatMocks.loadChatInbox).toHaveBeenCalledTimes(1);
     });
 
     it('refreshes the inbox and keeps the latest preview copy visible', async () => {


### PR DESCRIPTION
Closes #1898

## What changed
- gated `Messages` inbox loading so mobile direct thread routes like `/messages/:teamId` skip `loadChatInbox`
- kept inbox loading for `/messages` and desktop two-pane message views
- added route-aware regression coverage for mobile deep links, conversationId notification targets, and inbox-loading behavior on inbox and desktop routes

## Root Cause
`Messages` always called `refreshInbox()` on mount for every route. That meant mobile deep links into `/messages/:teamId` fetched the full inbox even though the mobile route rendered only `ChatWindow`, which already loads the team context, conversation selection, and live message subscription independently.

## Prevention / Learning
When a route has separate inbox and thread surfaces, only load the heavyweight inbox data for the surface that actually renders it. Add route-aware regression tests for direct deep links so notification-open paths do not silently pick up unnecessary background fetches.

## Regression Tests
- `npx vitest run tests/unit/app-chat-messages-integration.test.jsx --reporter=verbose`
- added assertions that mobile `/messages/:teamId` and `/messages/:teamId?conversationId=...` do not call `loadChatInbox`
- added assertions that `/messages` and desktop two-pane thread routes still call `loadChatInbox` exactly once