### PR TITLE
Restrict parent fee billing metadata

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1904,6 +1904,10 @@ service cloud.firestore {
                            request.resource.data.batchId == batchId;
           allow delete: if isTeamOwnerOrAdmin(teamId) &&
                            resource.data.teamId == teamId;
+
+          match /adminBilling/{billingId} {
+            allow read, create, update, delete: if isTeamOwnerOrAdmin(teamId);
+          }
         }
       }
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -118,6 +118,31 @@ function buildTeamFeeRecipientRef({ teamId, batchId, recipientId }) {
   return firestore.doc(`teams/${teamId}/feeBatches/${batchId}/feeRecipients/${recipientId}`);
 }
 
+function buildTeamFeeAdminBillingRef(recipientRef, id) {
+  const safeId = String(id || 'latest').trim().replace(/[^\w.-]+/g, '_').slice(0, 120);
+  return recipientRef.collection('adminBilling').doc(safeId || 'latest');
+}
+
+function withTeamFeeParentBillingClears(update = {}) {
+  return {
+    ...update,
+    stripePaymentIntentId: null,
+    stripeCustomerId: null,
+    stripeChargeId: null,
+    stripeLastRefundId: null,
+    stripeEventId: null,
+    ...(update.receiptMetadata ? {
+      receiptMetadata: {
+        ...update.receiptMetadata,
+        checkoutSessionId: null,
+        paymentIntentId: null,
+        receiptEmail: null,
+        eventId: null
+      }
+    } : {})
+  };
+}
+
 function buildTeamFeeRefundRequestId(input, uid) {
   const requested = String(input.refundRequestId || '').trim();
   if (requested) return requested;
@@ -1709,12 +1734,14 @@ exports.refundStripeTeamFeePayment = functions.https.onCall(async (data, context
   try {
     await firestore.runTransaction(async (transaction) => {
       const latestSnap = await transaction.get(recipientRef);
+      const refundAdminBillingRef = buildTeamFeeAdminBillingRef(recipientRef, refund.id || refundRequestId);
+      const refundAdminBillingSnap = await transaction.get(refundAdminBillingRef);
       if (!latestSnap.exists) {
         throw new functions.https.HttpsError('not-found', 'Fee recipient not found.');
       }
 
       const latestRecipient = { id: input.recipientId, ...(latestSnap.data() || {}) };
-      if (hasStripeRefundLedgerEntry(latestRecipient, refund.id)) {
+      if (refundAdminBillingSnap.exists || hasStripeRefundLedgerEntry(latestRecipient, refund.id)) {
         transaction.set(refundIntentRef, {
           status: 'recorded',
           stripeRefundId: refund.id || null,
@@ -1729,7 +1756,7 @@ exports.refundStripeTeamFeePayment = functions.https.onCall(async (data, context
         throw new functions.https.HttpsError('failed-precondition', 'Refund amount exceeds the refundable paid amount.');
       }
 
-      const { ledgerEntries = [], ...update } = buildTeamFeeStripeRefundUpdate({
+      const { ledgerEntries = [], adminBilling, ...update } = buildTeamFeeStripeRefundUpdate({
         recipient: latestRecipient,
         refund,
         amountCents: actualRefundAmount,
@@ -1739,9 +1766,12 @@ exports.refundStripeTeamFeePayment = functions.https.onCall(async (data, context
         ledgerRefundedAt
       });
       transaction.set(recipientRef, {
-        ...update,
+        ...withTeamFeeParentBillingClears(update),
         paymentLedger: admin.firestore.FieldValue.arrayUnion(...ledgerEntries)
       }, { merge: true });
+      if (adminBilling) {
+        transaction.set(refundAdminBillingRef, adminBilling, { merge: true });
+      }
       transaction.set(refundIntentRef, {
         status: 'recorded',
         stripeRefundId: refund.id || null,
@@ -2086,21 +2116,36 @@ exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
           : getTeamFeeCheckoutGuardFailure({ recipient, session });
 
         if (shouldMarkTeamFeePaidFromEvent(event) && shouldApplyCheckoutEvent) {
-          transaction.set(recipientRef, buildTeamFeePaidUpdate({
+          const { adminBilling, ...recipientUpdate } = buildTeamFeePaidUpdate({
             recipient,
             session,
             eventId: event.id,
             receivedAt
-          }), { merge: true });
+          });
+          transaction.set(recipientRef, withTeamFeeParentBillingClears(recipientUpdate), { merge: true });
+          if (adminBilling) {
+            transaction.set(buildTeamFeeAdminBillingRef(recipientRef, event.id), adminBilling, { merge: true });
+          }
         } else if (shouldRecordTeamFeeCheckoutNotPaidFromEvent(event) && shouldApplyCheckoutEvent) {
           transaction.set(recipientRef, {
             checkoutStatus: event.type === 'checkout.session.expired' ? 'expired' : 'payment_failed',
-            stripeCheckoutSessionId: session.id || null,
+            stripeCheckoutSessionId: null,
+            stripePaymentIntentId: null,
+            stripeCustomerId: null,
+            stripeEventId: null,
             checkoutAttemptToken: null,
             checkoutUrl: null,
             paymentLink: null,
             checkoutAmountCents: null,
+            updatedAt: receivedAt
+          }, { merge: true });
+          transaction.set(buildTeamFeeAdminBillingRef(recipientRef, event.id), {
+            type: event.type,
+            provider: 'stripe',
+            stripeCheckoutSessionId: session.id || null,
             stripeEventId: event.id,
+            paymentStatus: session.payment_status || null,
+            recordedAt: receivedAt,
             updatedAt: receivedAt
           }, { merge: true });
         }

--- a/functions/team-fees-core.cjs
+++ b/functions/team-fees-core.cjs
@@ -239,6 +239,14 @@ function getTeamFeeStripePaidAmountCents({ recipient = {}, session = {} } = {}) 
     return 0;
 }
 
+function buildTeamFeeAdminBillingMetadata({ type, provider = 'stripe', data = {} } = {}) {
+    return {
+        type,
+        provider,
+        ...data
+    };
+}
+
 function buildTeamFeeStripeRefundUpdate({ recipient = {}, refund = {}, amountCents = 0, actorId = '', reason = '', refundedAt, ledgerRefundedAt = refundedAt }) {
     const refundAmountCents = Math.round(Number(amountCents || refund.amount || 0));
     const previousPaidCents = getTeamFeePaidCents(recipient);
@@ -266,20 +274,28 @@ function buildTeamFeeStripeRefundUpdate({ recipient = {}, refund = {}, amountCen
         stripeCheckoutSessionId: null,
         checkoutAmountCents: null,
         paymentProvider: 'stripe',
-        stripeLastRefundId: refund.id || null,
         stripeLastRefundStatus: refundStatus,
         ledgerEntries: [{
             type: 'stripe_refund',
             amountCents: refundAmountCents,
             refundAmountCents,
             status: refundStatus,
-            stripeRefundId: refund.id || null,
-            stripePaymentIntentId: typeof refund.payment_intent === 'string' ? refund.payment_intent : (recipient.stripePaymentIntentId || null),
-            stripeChargeId: typeof refund.charge === 'string' ? refund.charge : (recipient.stripeChargeId || null),
-            reason: normalizeString(reason),
-            refundedBy: actorId || null,
             refundedAt: ledgerRefundedAt
-        }]
+        }],
+        adminBilling: buildTeamFeeAdminBillingMetadata({
+            type: 'stripe_refund',
+            data: {
+                stripeRefundId: refund.id || null,
+                stripePaymentIntentId: typeof refund.payment_intent === 'string' ? refund.payment_intent : (recipient.stripePaymentIntentId || null),
+                stripeChargeId: typeof refund.charge === 'string' ? refund.charge : (recipient.stripeChargeId || null),
+                refundAmountCents,
+                status: refundStatus,
+                reason: normalizeString(reason),
+                refundedBy: actorId || null,
+                refundedAt: ledgerRefundedAt,
+                updatedAt: refundedAt
+            }
+        })
     };
 }
 
@@ -299,24 +315,33 @@ function buildTeamFeePaidUpdate({ recipient = {}, session = {}, eventId, receive
         checkoutUrl: null,
         paymentLink: null,
         paymentProvider: 'stripe',
-        stripeCheckoutSessionId: session.id || null,
-        stripePaymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : null,
-        stripeCustomerId: typeof session.customer === 'string' ? session.customer : null,
+        stripeCheckoutSessionId: null,
         stripePaymentAmountCents: stripePaidAmountCents,
-        stripeEventId: eventId,
         paidAt: receivedAt,
         updatedAt: receivedAt,
         receiptMetadata: {
             provider: 'stripe',
-            checkoutSessionId: session.id || null,
-            paymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : null,
             amountPaidCents: stripePaidAmountCents,
             totalPaidCents: paidAmountCents,
             balanceDueCents,
-            currency: session.currency || 'usd',
-            receiptEmail: session.customer_details?.email || session.customer_email || null,
-            eventId
-        }
+            currency: session.currency || 'usd'
+        },
+        adminBilling: buildTeamFeeAdminBillingMetadata({
+            type: 'stripe_checkout_paid',
+            data: {
+                stripeCheckoutSessionId: session.id || null,
+                stripePaymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : null,
+                stripeCustomerId: typeof session.customer === 'string' ? session.customer : null,
+                receiptEmail: session.customer_details?.email || session.customer_email || null,
+                stripeEventId: eventId,
+                amountPaidCents: stripePaidAmountCents,
+                totalPaidCents: paidAmountCents,
+                balanceDueCents,
+                currency: session.currency || 'usd',
+                paidAt: receivedAt,
+                updatedAt: receivedAt
+            }
+        })
     };
 }
 
@@ -339,6 +364,7 @@ module.exports = {
     shouldMarkTeamFeePaidFromEvent,
     shouldRecordTeamFeeCheckoutNotPaidFromEvent,
     getTeamFeeStripePaidAmountCents,
+    buildTeamFeeAdminBillingMetadata,
     buildTeamFeePaidUpdate,
     buildTeamFeeStripeRefundUpdate
 };

--- a/js/parent-dashboard-fees.js
+++ b/js/parent-dashboard-fees.js
@@ -36,6 +36,59 @@ function getFirstDefined(...values) {
     return values.find((value) => value !== undefined && value !== null && value !== '' && !(Array.isArray(value) && value.length === 0));
 }
 
+const PARENT_FEE_PRIVATE_FIELDS = [
+    'stripeCheckoutSessionId',
+    'stripePaymentIntentId',
+    'stripeCustomerId',
+    'stripeChargeId',
+    'stripeRefundId',
+    'stripeLastRefundId',
+    'stripeEventId',
+    'receiptEmail',
+    'refundedBy',
+    'recordedBy',
+    'internalNote',
+    'adminNote',
+    'reason'
+];
+
+const PARENT_FEE_PRIVATE_RECEIPT_FIELDS = [
+    'checkoutSessionId',
+    'paymentIntentId',
+    'receiptEmail',
+    'eventId'
+];
+
+function omitPrivateFields(value, fields) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
+    const safe = { ...value };
+    fields.forEach((field) => {
+        delete safe[field];
+    });
+    return safe;
+}
+
+function sanitizeParentFeeLedgerEntry(entry) {
+    const safe = omitPrivateFields(entry, PARENT_FEE_PRIVATE_FIELDS);
+    if (isRefundLedgerEntry(safe)) {
+        delete safe.note;
+    }
+    return safe;
+}
+
+export function sanitizeParentFeeRecipientRecord(fee) {
+    const safe = omitPrivateFields(fee || {}, PARENT_FEE_PRIVATE_FIELDS);
+    if (safe.receiptMetadata) {
+        safe.receiptMetadata = omitPrivateFields(safe.receiptMetadata, PARENT_FEE_PRIVATE_RECEIPT_FIELDS);
+    }
+    ['ledgerEntries', 'paymentLedger', 'activity', 'receipts', 'payments', 'adjustments'].forEach((field) => {
+        if (Array.isArray(safe[field])) {
+            safe[field] = safe[field].filter(Boolean).map(sanitizeParentFeeLedgerEntry);
+        }
+    });
+    return safe;
+}
+
 function getFeeLineItems(fee) {
     const rawItems = getFirstDefined(fee?.lineItems, fee?.invoiceLineItems, fee?.invoiceItems, fee?.items);
     return Array.isArray(rawItems) ? rawItems.filter(Boolean) : [];
@@ -319,23 +372,24 @@ export function formatParentFeeDueDate(value) {
 }
 
 export function normalizeParentFeeRecord(fee) {
+    const safeFee = sanitizeParentFeeRecipientRecord(fee);
     return {
-        ...fee,
-        title: fee?.title || fee?.feeTitle || fee?.name || 'Team fee',
-        teamName: fee?.teamName || 'Team',
-        playerName: fee?.playerName || fee?.childName || '',
-        status: normalizeParentFeeStatus(fee?.status),
-        dueDate: fee?.dueDate || fee?.dueAt || null,
-        notes: fee?.notes || fee?.feeNotes || '',
-        offlinePaymentInstructions: fee?.offlinePaymentInstructions || fee?.paymentInstructions || '',
-        collectionMode: fee?.collectionMode || '',
-        totalAmountCents: getFeeTotalCents(fee),
-        paidAmountCents: getFeePaidCents(fee),
-        balanceDueCents: getFeeBalanceCents(fee),
-        checkoutUrl: getFeeCheckoutUrl(fee),
-        teamId: fee?.teamId || '',
-        batchId: fee?.batchId || fee?.feeBatchId || '',
-        recipientId: getFeeRecipientId(fee) || ''
+        ...safeFee,
+        title: safeFee?.title || safeFee?.feeTitle || safeFee?.name || 'Team fee',
+        teamName: safeFee?.teamName || 'Team',
+        playerName: safeFee?.playerName || safeFee?.childName || '',
+        status: normalizeParentFeeStatus(safeFee?.status),
+        dueDate: safeFee?.dueDate || safeFee?.dueAt || null,
+        notes: safeFee?.notes || safeFee?.feeNotes || '',
+        offlinePaymentInstructions: safeFee?.offlinePaymentInstructions || safeFee?.paymentInstructions || '',
+        collectionMode: safeFee?.collectionMode || '',
+        totalAmountCents: getFeeTotalCents(safeFee),
+        paidAmountCents: getFeePaidCents(safeFee),
+        balanceDueCents: getFeeBalanceCents(safeFee),
+        checkoutUrl: getFeeCheckoutUrl(safeFee),
+        teamId: safeFee?.teamId || '',
+        batchId: safeFee?.batchId || safeFee?.feeBatchId || '',
+        recipientId: getFeeRecipientId(safeFee) || ''
     };
 }
 

--- a/tests/unit/parent-dashboard-fees.test.js
+++ b/tests/unit/parent-dashboard-fees.test.js
@@ -3,8 +3,10 @@ import {
     formatParentFeeAmount,
     formatParentFeeDueDate,
     handleParentTeamFeeCheckoutClick,
+    normalizeParentFeeRecord,
     normalizeParentFeeStatus,
     renderParentTeamFees,
+    sanitizeParentFeeRecipientRecord,
     sortParentFeeRecords
 } from '../../js/parent-dashboard-fees.js';
 
@@ -189,6 +191,59 @@ describe('parent dashboard team fees', () => {
         expect(html).not.toContain('Admin-only reconciliation detail');
         expect(html).not.toContain('Private admin refund note');
         expect(html).not.toContain('admin-123');
+    });
+
+    it('sanitizes parent fee records before exposing Stripe and refund internals', () => {
+        const rawFee = {
+            id: 'recipient-1',
+            title: 'Private billing data',
+            amountCents: 10000,
+            status: 'paid',
+            stripeCheckoutSessionId: 'cs_private',
+            stripePaymentIntentId: 'pi_private',
+            stripeCustomerId: 'cus_private',
+            stripeEventId: 'evt_private',
+            receiptMetadata: {
+                provider: 'stripe',
+                checkoutSessionId: 'cs_private',
+                paymentIntentId: 'pi_private',
+                receiptEmail: 'parent@example.com',
+                eventId: 'evt_private',
+                amountPaidCents: 10000
+            },
+            ledgerEntries: [
+                {
+                    type: 'stripe_refund',
+                    amountCents: 2500,
+                    stripeRefundId: 're_private',
+                    stripePaymentIntentId: 'pi_private',
+                    stripeChargeId: 'ch_private',
+                    reason: 'Admin reconciliation reason',
+                    refundedBy: 'admin-1',
+                    note: 'Private refund note',
+                    publicNote: 'Uniform returned'
+                }
+            ]
+        };
+
+        const sanitized = sanitizeParentFeeRecipientRecord(rawFee);
+        const normalized = normalizeParentFeeRecord(rawFee);
+
+        expect(sanitized).not.toHaveProperty('stripeCheckoutSessionId');
+        expect(sanitized).not.toHaveProperty('stripePaymentIntentId');
+        expect(sanitized).not.toHaveProperty('stripeCustomerId');
+        expect(sanitized).not.toHaveProperty('stripeEventId');
+        expect(sanitized.receiptMetadata).toEqual({
+            provider: 'stripe',
+            amountPaidCents: 10000
+        });
+        expect(sanitized.ledgerEntries[0]).toEqual({
+            type: 'stripe_refund',
+            amountCents: 2500,
+            publicNote: 'Uniform returned'
+        });
+        expect(normalized).not.toHaveProperty('stripePaymentIntentId');
+        expect(normalized.ledgerEntries[0]).not.toHaveProperty('refundedBy');
     });
 
     it('renders Pay online only for Stripe collection fees with an unpaid balance', () => {

--- a/tests/unit/team-fees-functions.test.js
+++ b/tests/unit/team-fees-functions.test.js
@@ -20,6 +20,7 @@ const {
     shouldMarkTeamFeePaidFromEvent,
     shouldRecordTeamFeeCheckoutNotPaidFromEvent,
     getTeamFeeStripePaidAmountCents,
+    buildTeamFeeAdminBillingMetadata,
     buildTeamFeePaidUpdate,
     buildTeamFeeStripeRefundUpdate
 } = require('../../functions/team-fees-core.cjs');
@@ -193,7 +194,7 @@ describe('team fee checkout function helpers', () => {
         })).toBe(0);
     });
 
-    it('builds paid recipient updates without raw payment method data', () => {
+    it('builds paid recipient updates with Stripe identifiers split into admin billing metadata', () => {
         const update = buildTeamFeePaidUpdate({
             recipient: { amountCents: 12500, paidAmountCents: 2500 },
             eventId: 'evt_123',
@@ -216,25 +217,37 @@ describe('team fee checkout function helpers', () => {
             checkoutStatus: 'paid',
             checkoutAttemptToken: null,
             paymentProvider: 'stripe',
-            stripeCheckoutSessionId: 'cs_123',
-            stripePaymentIntentId: 'pi_123',
-            stripeCustomerId: 'cus_123',
+            stripeCheckoutSessionId: null,
             stripePaymentAmountCents: 10000,
-            stripeEventId: 'evt_123'
         });
         expect(update.receiptMetadata).toEqual({
             provider: 'stripe',
-            checkoutSessionId: 'cs_123',
-            paymentIntentId: 'pi_123',
+            amountPaidCents: 10000,
+            totalPaidCents: 12500,
+            balanceDueCents: 0,
+            currency: 'usd'
+        });
+        expect(update.adminBilling).toEqual({
+            type: 'stripe_checkout_paid',
+            provider: 'stripe',
+            stripeCheckoutSessionId: 'cs_123',
+            stripePaymentIntentId: 'pi_123',
+            stripeCustomerId: 'cus_123',
+            receiptEmail: 'parent@example.com',
+            stripeEventId: 'evt_123',
             amountPaidCents: 10000,
             totalPaidCents: 12500,
             balanceDueCents: 0,
             currency: 'usd',
-            receiptEmail: 'parent@example.com',
-            eventId: 'evt_123'
+            paidAt: 'now',
+            updatedAt: 'now'
         });
+        expect(update).not.toHaveProperty('stripePaymentIntentId');
+        expect(update).not.toHaveProperty('stripeCustomerId');
+        expect(update).not.toHaveProperty('stripeEventId');
         expect(update).not.toHaveProperty('paymentMethod');
         expect(update.receiptMetadata).not.toHaveProperty('card');
+        expect(update.receiptMetadata).not.toHaveProperty('receiptEmail');
     });
 
     it('normalizes refund input and computes refundable cents', () => {
@@ -301,7 +314,6 @@ describe('team fee checkout function helpers', () => {
             checkoutAttemptToken: null,
             stripeCheckoutSessionId: null,
             paymentProvider: 'stripe',
-            stripeLastRefundId: 're_123',
             stripeLastRefundStatus: 'succeeded'
         });
         expect(update.ledgerEntries).toEqual([{
@@ -309,13 +321,42 @@ describe('team fee checkout function helpers', () => {
             amountCents: 5000,
             refundAmountCents: 5000,
             status: 'succeeded',
+            refundedAt: 'ledger-now'
+        }]);
+        expect(update.adminBilling).toEqual({
+            type: 'stripe_refund',
+            provider: 'stripe',
             stripeRefundId: 're_123',
             stripePaymentIntentId: 'pi_123',
             stripeChargeId: null,
+            refundAmountCents: 5000,
+            status: 'succeeded',
             reason: 'Family requested refund',
             refundedBy: 'admin_1',
-            refundedAt: 'ledger-now'
-        }]);
+            refundedAt: 'ledger-now',
+            updatedAt: 'server-now'
+        });
+        expect(update).not.toHaveProperty('stripeLastRefundId');
+        expect(update.ledgerEntries[0]).not.toHaveProperty('stripeRefundId');
+        expect(update.ledgerEntries[0]).not.toHaveProperty('stripePaymentIntentId');
+        expect(update.ledgerEntries[0]).not.toHaveProperty('stripeChargeId');
+        expect(update.ledgerEntries[0]).not.toHaveProperty('reason');
+        expect(update.ledgerEntries[0]).not.toHaveProperty('refundedBy');
+    });
+
+    it('builds typed admin billing metadata for private fee reconciliation fields', () => {
+        expect(buildTeamFeeAdminBillingMetadata({
+            type: 'stripe_refund',
+            data: {
+                stripeRefundId: 're_123',
+                reason: 'Duplicate charge'
+            }
+        })).toEqual({
+            type: 'stripe_refund',
+            provider: 'stripe',
+            stripeRefundId: 're_123',
+            reason: 'Duplicate charge'
+        });
     });
 
     it('guards Stripe refund callable idempotency and recording consistency', () => {
@@ -338,6 +379,7 @@ describe('team fee checkout function helpers', () => {
         expect(functionsSource).toContain('shouldApplyTeamFeeCheckoutSession({ recipient, session })');
         expect(functionsSource).toContain('getTeamFeeCheckoutGuardFailure({ recipient, session })');
         expect(functionsSource).toContain("ignoredReason");
+        expect(functionsSource).toContain("recipientRef.collection('adminBilling').doc");
         expect(dbSource).toContain("updatePayload.checkoutStatus = 'stale'");
         expect(dbSource).toContain('updatePayload.checkoutAttemptToken = deleteField()');
         expect(dbSource).toContain('updatePayload.stripeCheckoutSessionId = deleteField()');


### PR DESCRIPTION
## Summary\n- move Stripe checkout/refund identifiers and admin refund notes into fee recipient adminBilling subcollection records\n- clear parent-readable billing identifier fields when webhook/refund writers update feeRecipients\n- sanitize legacy parent fee records before rendering or returning React parent-tools fee models\n- add Firestore rules so adminBilling is coach/admin-only\n\n## Tests\n- npx vitest run tests/unit/team-fees-functions.test.js tests/unit/parent-dashboard-fees.test.js tests/unit/app-parent-tools-service.test.js --reporter=dot\n- npx vitest run tests/unit/team-fees-functions.test.js tests/unit/team-fees-admin.test.js tests/unit/app-team-fees-service.test.ts tests/unit/parent-dashboard-fees.test.js tests/unit/app-parent-tools-service.test.js --reporter=dot\n- npm run ci:firebase-rules\n- git diff --check\n\n## Notes\n- npm run app:build is blocked in this checkout because apps/app build invokes tsc but apps/app does not install TypeScript locally.\n- Running the broader app-parent-tools-integration suite also hits existing unrelated React component setup failures around TeamMedia/ParentTools and missing Firebase vendor source maps.\n\nFixes #1901