### PR TITLE
Protect parent fee billing metadata

### DIFF
--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -565,9 +565,9 @@ export function Schedule({ auth }: { auth: AuthState }) {
             <Segment active={view === 'calendar'} onClick={() => setView('calendar')} icon={CalendarDays} label="Calendar" />
             <Segment active={view === 'packets'} onClick={() => setView('packets')} icon={ClipboardCheck} label="Packets" />
             <label className="sm:hidden">
-              <span className="sr-only">Desktop schedule filter</span>
+              <span className="sr-only">Schedule filter</span>
               <select
-                aria-label="Desktop schedule filter"
+                aria-label="Schedule filter"
                 className="auth-input min-h-9 truncate !px-3 !py-2 text-xs font-black"
                 value={filter}
                 onChange={(event) => setFilter(event.target.value as ParentScheduleFilter)}

--- a/docs/pr-notes/runs/issue-1901-issue-comment-4638243896-20260606T102637Z/architecture.md
+++ b/docs/pr-notes/runs/issue-1901-issue-comment-4638243896-20260606T102637Z/architecture.md
@@ -1,0 +1,26 @@
+# Architecture
+
+## Current State
+- `feeRecipients/{recipientId}` is parent-readable, so top-level billing metadata stored there is parent-visible by default.
+- Checkout and refund flows already run server-side, but the storage boundary for sensitive billing metadata was too broad.
+
+## Proposed State
+- Keep `feeRecipients/{recipientId}` as the parent-readable summary document.
+- Move Stripe identifiers, refund identifiers, receipt email, refund actor, and admin-only notes into `feeRecipients/{recipientId}/adminBilling/{billingId}`.
+- Clear parent-readable sensitive fields on webhook and refund writes.
+- Sanitize legacy parent models before render and normalization.
+
+## Architecture Decisions
+- Minimal subcollection split instead of schema rewrite.
+- Server-authoritative write split in Cloud Functions.
+- Defense in depth with both rules and frontend sanitization.
+- Preserve existing payment/refund state transitions and stale-checkout guards.
+
+## Controls And Blast Radius
+- Rules: adminBilling is owner/admin only.
+- Write-path changes are limited to team fee checkout/refund handlers and parent fee shaping.
+- Parent-visible docs remain useful but no longer carry processor metadata.
+
+## Rollback
+- Revert functions, rules, UI sanitizer, and tests together as one unit.
+- Prefer fixing any admin reader breakage by teaching it to read `adminBilling`, not by restoring private fields to parent-readable docs.

--- a/docs/pr-notes/runs/issue-1901-issue-comment-4638243896-20260606T102637Z/code-plan.md
+++ b/docs/pr-notes/runs/issue-1901-issue-comment-4638243896-20260606T102637Z/code-plan.md
@@ -1,0 +1,26 @@
+# Code Plan
+
+## Minimal Patch Plan
+1. Cherry-pick PR #1906's focused privacy fix onto a clean branch.
+2. Keep parent-safe fee updates on `feeRecipients/{recipientId}` and move private metadata into `adminBilling`.
+3. Preserve idempotency and stale-session guards in webhook/refund handling.
+4. Add focused coverage for parent sanitization, fee helper output split, and rules CI enforcement of the new `adminBilling` stanza.
+
+## Test Additions Needed
+- Parent fee sanitization assertions in `tests/unit/parent-dashboard-fees.test.js`.
+- Helper assertions for `adminBilling` split in `tests/unit/team-fees-functions.test.js`.
+- Rules CI assertion for `match /adminBilling/{billingId}` and owner/admin-only access in `scripts/validate-firebase-rules-ci.mjs`.
+
+## Known Validation Blockers
+- No emulator-backed Firestore access test in this slice.
+- No real browser payment/refund smoke in this slice.
+
+## Recommended Commands
+```bash
+cd /tmp/allplays-issue-1901-20260606T102637Z
+npm install
+npx vitest run tests/unit/team-fees-functions.test.js tests/unit/parent-dashboard-fees.test.js --reporter=dot
+npx vitest run tests/unit/app-team-fees-service.test.ts tests/unit/app-parent-tools-service.test.js --reporter=dot
+npm run ci:firebase-rules
+git diff --check
+```

--- a/docs/pr-notes/runs/issue-1901-issue-comment-4638243896-20260606T102637Z/qa.md
+++ b/docs/pr-notes/runs/issue-1901-issue-comment-4638243896-20260606T102637Z/qa.md
@@ -1,0 +1,31 @@
+# QA
+
+## QA Plan
+- Validate parent-readable fee docs no longer retain Stripe and admin-only fields after checkout/refund writes.
+- Validate `adminBilling` is the only storage path for private reconciliation metadata.
+- Validate parent dashboard and app parent-tools service consume sanitized fee models.
+- Validate fee status, balance, and refund math still behave correctly.
+
+## Test Matrix
+- Parent fee helper sanitization.
+- Team fee function helper paid/refund output split.
+- App fee service path using shared parent fee normalization.
+- Firestore rules CI coverage for the `adminBilling` rule stanza.
+
+## Highest-Risk Regressions
+1. Missing or weakened `adminBilling` rule coverage.
+2. Legacy ledger aliases leaking private fields.
+3. Admin tools expecting top-level Stripe identifiers.
+4. Refund accounting drift in partial/full refund scenarios.
+
+## Minimum Validation Commands
+```bash
+cd /tmp/allplays-issue-1901-20260606T102637Z
+npx vitest run tests/unit/team-fees-functions.test.js tests/unit/parent-dashboard-fees.test.js --reporter=dot
+npx vitest run tests/unit/app-team-fees-service.test.ts tests/unit/app-parent-tools-service.test.js --reporter=dot
+npm run ci:firebase-rules
+git diff --check
+```
+
+## Remaining Gap
+- No emulator-backed parent-vs-admin rule test was added in this slice.

--- a/docs/pr-notes/runs/issue-1901-issue-comment-4638243896-20260606T102637Z/requirements.md
+++ b/docs/pr-notes/runs/issue-1901-issue-comment-4638243896-20260606T102637Z/requirements.md
@@ -1,0 +1,26 @@
+# Requirements
+
+## Acceptance Criteria
+1. Parent-accessible fee data must not expose Stripe checkout IDs, refund IDs, payment intent IDs, charge IDs, receipt email, or admin refund notes in legacy dashboard or React parent-tools fee models.
+2. Admin workflows must retain reconciliation data under `feeRecipients/{id}/adminBilling/{billingId}`.
+3. Webhook and refund writes must clear or omit sensitive parent-readable billing fields by default.
+4. Legacy fee documents must still render safely when older top-level fields exist.
+5. Parents must still see safe payment state, amounts, refund amounts, dates, and public notes.
+6. Firestore rules must deny parent access to `adminBilling` and allow authorized team owner/admin access.
+7. Automated coverage must verify both parent redaction and admin-only storage paths.
+
+## Out of Scope
+- Parent fee UI redesign.
+- Stripe business-logic changes beyond privacy hardening.
+- Full historical migration of legacy fee records.
+- Expanding `adminBilling` visibility beyond existing fee admins.
+
+## Risks
+- Admin tooling may still expect Stripe identifiers on the top-level recipient doc.
+- Mixed historical data shapes may leak if sanitization misses an alias.
+- Parents may need support references that now rely on amount/date/status instead of processor IDs.
+
+## Open Questions
+- Team owner/admin vs global-admin scope for `adminBilling` access.
+- Whether any refund reason should ever be parent-visible beyond `publicNote`.
+- Whether a separate migration/runbook is needed for historical cleanup.

--- a/firestore.rules
+++ b/firestore.rules
@@ -1904,6 +1904,10 @@ service cloud.firestore {
                            request.resource.data.batchId == batchId;
           allow delete: if isTeamOwnerOrAdmin(teamId) &&
                            resource.data.teamId == teamId;
+
+          match /adminBilling/{billingId} {
+            allow read, create, update, delete: if isTeamOwnerOrAdmin(teamId);
+          }
         }
       }
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -118,6 +118,31 @@ function buildTeamFeeRecipientRef({ teamId, batchId, recipientId }) {
   return firestore.doc(`teams/${teamId}/feeBatches/${batchId}/feeRecipients/${recipientId}`);
 }
 
+function buildTeamFeeAdminBillingRef(recipientRef, id) {
+  const safeId = String(id || 'latest').trim().replace(/[^\w.-]+/g, '_').slice(0, 120);
+  return recipientRef.collection('adminBilling').doc(safeId || 'latest');
+}
+
+function withTeamFeeParentBillingClears(update = {}) {
+  return {
+    ...update,
+    stripePaymentIntentId: null,
+    stripeCustomerId: null,
+    stripeChargeId: null,
+    stripeLastRefundId: null,
+    stripeEventId: null,
+    ...(update.receiptMetadata ? {
+      receiptMetadata: {
+        ...update.receiptMetadata,
+        checkoutSessionId: null,
+        paymentIntentId: null,
+        receiptEmail: null,
+        eventId: null
+      }
+    } : {})
+  };
+}
+
 function buildTeamFeeRefundRequestId(input, uid) {
   const requested = String(input.refundRequestId || '').trim();
   if (requested) return requested;
@@ -1709,12 +1734,14 @@ exports.refundStripeTeamFeePayment = functions.https.onCall(async (data, context
   try {
     await firestore.runTransaction(async (transaction) => {
       const latestSnap = await transaction.get(recipientRef);
+      const refundAdminBillingRef = buildTeamFeeAdminBillingRef(recipientRef, refund.id || refundRequestId);
+      const refundAdminBillingSnap = await transaction.get(refundAdminBillingRef);
       if (!latestSnap.exists) {
         throw new functions.https.HttpsError('not-found', 'Fee recipient not found.');
       }
 
       const latestRecipient = { id: input.recipientId, ...(latestSnap.data() || {}) };
-      if (hasStripeRefundLedgerEntry(latestRecipient, refund.id)) {
+      if (refundAdminBillingSnap.exists || hasStripeRefundLedgerEntry(latestRecipient, refund.id)) {
         transaction.set(refundIntentRef, {
           status: 'recorded',
           stripeRefundId: refund.id || null,
@@ -1729,7 +1756,7 @@ exports.refundStripeTeamFeePayment = functions.https.onCall(async (data, context
         throw new functions.https.HttpsError('failed-precondition', 'Refund amount exceeds the refundable paid amount.');
       }
 
-      const { ledgerEntries = [], ...update } = buildTeamFeeStripeRefundUpdate({
+      const { ledgerEntries = [], adminBilling, ...update } = buildTeamFeeStripeRefundUpdate({
         recipient: latestRecipient,
         refund,
         amountCents: actualRefundAmount,
@@ -1739,9 +1766,12 @@ exports.refundStripeTeamFeePayment = functions.https.onCall(async (data, context
         ledgerRefundedAt
       });
       transaction.set(recipientRef, {
-        ...update,
+        ...withTeamFeeParentBillingClears(update),
         paymentLedger: admin.firestore.FieldValue.arrayUnion(...ledgerEntries)
       }, { merge: true });
+      if (adminBilling) {
+        transaction.set(refundAdminBillingRef, adminBilling, { merge: true });
+      }
       transaction.set(refundIntentRef, {
         status: 'recorded',
         stripeRefundId: refund.id || null,
@@ -2086,21 +2116,36 @@ exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
           : getTeamFeeCheckoutGuardFailure({ recipient, session });
 
         if (shouldMarkTeamFeePaidFromEvent(event) && shouldApplyCheckoutEvent) {
-          transaction.set(recipientRef, buildTeamFeePaidUpdate({
+          const { adminBilling, ...recipientUpdate } = buildTeamFeePaidUpdate({
             recipient,
             session,
             eventId: event.id,
             receivedAt
-          }), { merge: true });
+          });
+          transaction.set(recipientRef, withTeamFeeParentBillingClears(recipientUpdate), { merge: true });
+          if (adminBilling) {
+            transaction.set(buildTeamFeeAdminBillingRef(recipientRef, event.id), adminBilling, { merge: true });
+          }
         } else if (shouldRecordTeamFeeCheckoutNotPaidFromEvent(event) && shouldApplyCheckoutEvent) {
           transaction.set(recipientRef, {
             checkoutStatus: event.type === 'checkout.session.expired' ? 'expired' : 'payment_failed',
-            stripeCheckoutSessionId: session.id || null,
+            stripeCheckoutSessionId: null,
+            stripePaymentIntentId: null,
+            stripeCustomerId: null,
+            stripeEventId: null,
             checkoutAttemptToken: null,
             checkoutUrl: null,
             paymentLink: null,
             checkoutAmountCents: null,
+            updatedAt: receivedAt
+          }, { merge: true });
+          transaction.set(buildTeamFeeAdminBillingRef(recipientRef, event.id), {
+            type: event.type,
+            provider: 'stripe',
+            stripeCheckoutSessionId: session.id || null,
             stripeEventId: event.id,
+            paymentStatus: session.payment_status || null,
+            recordedAt: receivedAt,
             updatedAt: receivedAt
           }, { merge: true });
         }

--- a/functions/index.js
+++ b/functions/index.js
@@ -24,6 +24,7 @@ const {
   shouldApplyTeamFeeCheckoutSession,
   shouldMarkTeamFeePaidFromEvent,
   shouldRecordTeamFeeCheckoutNotPaidFromEvent,
+  getTeamFeeStripePaymentRefs,
   buildTeamFeePaidUpdate,
   buildTeamFeeStripeRefundUpdate
 } = require('./team-fees-core.cjs');
@@ -141,6 +142,28 @@ function withTeamFeeParentBillingClears(update = {}) {
       }
     } : {})
   };
+}
+
+async function fetchTeamFeePaymentAdminBilling(recipientRef) {
+  const latestSnap = await buildTeamFeeAdminBillingRef(recipientRef, 'latest').get();
+  const latest = latestSnap.exists ? (latestSnap.data() || {}) : {};
+  const latestRefs = getTeamFeeStripePaymentRefs(latest);
+  if (latestRefs.paymentIntentId || latestRefs.chargeId) {
+    return latest;
+  }
+
+  const querySnap = await recipientRef.collection('adminBilling')
+    .where('type', '==', 'stripe_checkout_paid')
+    .limit(10)
+    .get();
+  for (const doc of querySnap.docs) {
+    const data = doc.data() || {};
+    const refs = getTeamFeeStripePaymentRefs(data);
+    if (refs.paymentIntentId || refs.chargeId) {
+      return data;
+    }
+  }
+  return {};
 }
 
 function buildTeamFeeRefundRequestId(input, uid) {
@@ -1581,9 +1604,10 @@ exports.refundStripeTeamFeePayment = functions.https.onCall(async (data, context
     throw new functions.https.HttpsError('invalid-argument', error.message || 'Invalid team fee refund request.');
   }
 
+  const recipientRef = buildTeamFeeRecipientRef(input);
   const [teamSnap, recipientSnap, user] = await Promise.all([
     firestore.doc(`teams/${input.teamId}`).get(),
-    buildTeamFeeRecipientRef(input).get(),
+    recipientRef.get(),
     getUserForEligibility(context.auth.uid)
   ]);
 
@@ -1608,8 +1632,8 @@ exports.refundStripeTeamFeePayment = functions.https.onCall(async (data, context
     throw new functions.https.HttpsError('failed-precondition', 'Only Stripe team fee payments can be refunded online.');
   }
 
-  const paymentIntentId = String(recipient.stripePaymentIntentId || '').trim();
-  const chargeId = String(recipient.stripeChargeId || recipient.stripeLatestChargeId || '').trim();
+  const paymentAdminBilling = await fetchTeamFeePaymentAdminBilling(recipientRef);
+  const { paymentIntentId, chargeId } = getTeamFeeStripePaymentRefs(recipient, paymentAdminBilling);
   if (!paymentIntentId && !chargeId) {
     throw new functions.https.HttpsError('failed-precondition', 'This payment is missing a Stripe payment intent or charge reference.');
   }
@@ -1619,7 +1643,6 @@ exports.refundStripeTeamFeePayment = functions.https.onCall(async (data, context
     throw new functions.https.HttpsError('failed-precondition', 'Refund amount exceeds the refundable paid amount.');
   }
 
-  const recipientRef = buildTeamFeeRecipientRef(input);
   const refundRequestId = buildTeamFeeRefundRequestId(input, context.auth.uid);
   const refundIntentRef = recipientRef.collection('refundIntents').doc(refundRequestId);
   let existingRefundResult = null;
@@ -1757,7 +1780,7 @@ exports.refundStripeTeamFeePayment = functions.https.onCall(async (data, context
       }
 
       const { ledgerEntries = [], adminBilling, ...update } = buildTeamFeeStripeRefundUpdate({
-        recipient: latestRecipient,
+        recipient: { ...latestRecipient, adminBilling: paymentAdminBilling },
         refund,
         amountCents: actualRefundAmount,
         actorId: context.auth.uid,
@@ -2125,6 +2148,7 @@ exports.stripeTeamPassWebhook = functions.https.onRequest(async (req, res) => {
           transaction.set(recipientRef, withTeamFeeParentBillingClears(recipientUpdate), { merge: true });
           if (adminBilling) {
             transaction.set(buildTeamFeeAdminBillingRef(recipientRef, event.id), adminBilling, { merge: true });
+            transaction.set(buildTeamFeeAdminBillingRef(recipientRef, 'latest'), adminBilling, { merge: true });
           }
         } else if (shouldRecordTeamFeeCheckoutNotPaidFromEvent(event) && shouldApplyCheckoutEvent) {
           transaction.set(recipientRef, {

--- a/functions/team-fees-core.cjs
+++ b/functions/team-fees-core.cjs
@@ -247,6 +247,30 @@ function buildTeamFeeAdminBillingMetadata({ type, provider = 'stripe', data = {}
     };
 }
 
+function getTeamFeeStripePaymentRefs(...sources) {
+    const pending = [...sources];
+    while (pending.length > 0) {
+        const source = pending.shift();
+        if (!source) continue;
+        if (Array.isArray(source)) {
+            pending.unshift(...source);
+            continue;
+        }
+        if (typeof source !== 'object') continue;
+
+        const paymentIntentId = normalizeString(source.stripePaymentIntentId || source.paymentIntentId);
+        const chargeId = normalizeString(source.stripeChargeId || source.chargeId || source.stripeLatestChargeId);
+        if (paymentIntentId || chargeId) {
+            return { paymentIntentId, chargeId };
+        }
+
+        if (source.adminBilling) pending.unshift(source.adminBilling);
+        if (Array.isArray(source.adminBillingEntries)) pending.unshift(...source.adminBillingEntries);
+    }
+
+    return { paymentIntentId: '', chargeId: '' };
+}
+
 function buildTeamFeeStripeRefundUpdate({ recipient = {}, refund = {}, amountCents = 0, actorId = '', reason = '', refundedAt, ledgerRefundedAt = refundedAt }) {
     const refundAmountCents = Math.round(Number(amountCents || refund.amount || 0));
     const previousPaidCents = getTeamFeePaidCents(recipient);
@@ -256,6 +280,7 @@ function buildTeamFeeStripeRefundUpdate({ recipient = {}, refund = {}, amountCen
     const balanceDueCents = Math.max(0, getTeamFeeTotalCents(recipient) - paidAmountCents);
     const status = paidAmountCents <= 0 ? 'unpaid' : balanceDueCents > 0 ? 'partial' : 'paid';
     const refundStatus = normalizeString(refund.status || 'pending').toLowerCase() || 'pending';
+    const paymentRefs = getTeamFeeStripePaymentRefs(recipient);
 
     return {
         status,
@@ -274,6 +299,7 @@ function buildTeamFeeStripeRefundUpdate({ recipient = {}, refund = {}, amountCen
         stripeCheckoutSessionId: null,
         checkoutAmountCents: null,
         paymentProvider: 'stripe',
+        hasAdminBilling: true,
         stripeLastRefundStatus: refundStatus,
         ledgerEntries: [{
             type: 'stripe_refund',
@@ -286,8 +312,8 @@ function buildTeamFeeStripeRefundUpdate({ recipient = {}, refund = {}, amountCen
             type: 'stripe_refund',
             data: {
                 stripeRefundId: refund.id || null,
-                stripePaymentIntentId: typeof refund.payment_intent === 'string' ? refund.payment_intent : (recipient.stripePaymentIntentId || null),
-                stripeChargeId: typeof refund.charge === 'string' ? refund.charge : (recipient.stripeChargeId || null),
+                stripePaymentIntentId: typeof refund.payment_intent === 'string' ? refund.payment_intent : (paymentRefs.paymentIntentId || null),
+                stripeChargeId: typeof refund.charge === 'string' ? refund.charge : (paymentRefs.chargeId || null),
                 refundAmountCents,
                 status: refundStatus,
                 reason: normalizeString(reason),
@@ -317,6 +343,7 @@ function buildTeamFeePaidUpdate({ recipient = {}, session = {}, eventId, receive
         paymentProvider: 'stripe',
         stripeCheckoutSessionId: null,
         stripePaymentAmountCents: stripePaidAmountCents,
+        hasAdminBilling: true,
         paidAt: receivedAt,
         updatedAt: receivedAt,
         receiptMetadata: {
@@ -365,6 +392,7 @@ module.exports = {
     shouldRecordTeamFeeCheckoutNotPaidFromEvent,
     getTeamFeeStripePaidAmountCents,
     buildTeamFeeAdminBillingMetadata,
+    getTeamFeeStripePaymentRefs,
     buildTeamFeePaidUpdate,
     buildTeamFeeStripeRefundUpdate
 };

--- a/functions/team-fees-core.cjs
+++ b/functions/team-fees-core.cjs
@@ -239,6 +239,14 @@ function getTeamFeeStripePaidAmountCents({ recipient = {}, session = {} } = {}) 
     return 0;
 }
 
+function buildTeamFeeAdminBillingMetadata({ type, provider = 'stripe', data = {} } = {}) {
+    return {
+        type,
+        provider,
+        ...data
+    };
+}
+
 function buildTeamFeeStripeRefundUpdate({ recipient = {}, refund = {}, amountCents = 0, actorId = '', reason = '', refundedAt, ledgerRefundedAt = refundedAt }) {
     const refundAmountCents = Math.round(Number(amountCents || refund.amount || 0));
     const previousPaidCents = getTeamFeePaidCents(recipient);
@@ -266,20 +274,28 @@ function buildTeamFeeStripeRefundUpdate({ recipient = {}, refund = {}, amountCen
         stripeCheckoutSessionId: null,
         checkoutAmountCents: null,
         paymentProvider: 'stripe',
-        stripeLastRefundId: refund.id || null,
         stripeLastRefundStatus: refundStatus,
         ledgerEntries: [{
             type: 'stripe_refund',
             amountCents: refundAmountCents,
             refundAmountCents,
             status: refundStatus,
-            stripeRefundId: refund.id || null,
-            stripePaymentIntentId: typeof refund.payment_intent === 'string' ? refund.payment_intent : (recipient.stripePaymentIntentId || null),
-            stripeChargeId: typeof refund.charge === 'string' ? refund.charge : (recipient.stripeChargeId || null),
-            reason: normalizeString(reason),
-            refundedBy: actorId || null,
             refundedAt: ledgerRefundedAt
-        }]
+        }],
+        adminBilling: buildTeamFeeAdminBillingMetadata({
+            type: 'stripe_refund',
+            data: {
+                stripeRefundId: refund.id || null,
+                stripePaymentIntentId: typeof refund.payment_intent === 'string' ? refund.payment_intent : (recipient.stripePaymentIntentId || null),
+                stripeChargeId: typeof refund.charge === 'string' ? refund.charge : (recipient.stripeChargeId || null),
+                refundAmountCents,
+                status: refundStatus,
+                reason: normalizeString(reason),
+                refundedBy: actorId || null,
+                refundedAt: ledgerRefundedAt,
+                updatedAt: refundedAt
+            }
+        })
     };
 }
 
@@ -299,24 +315,33 @@ function buildTeamFeePaidUpdate({ recipient = {}, session = {}, eventId, receive
         checkoutUrl: null,
         paymentLink: null,
         paymentProvider: 'stripe',
-        stripeCheckoutSessionId: session.id || null,
-        stripePaymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : null,
-        stripeCustomerId: typeof session.customer === 'string' ? session.customer : null,
+        stripeCheckoutSessionId: null,
         stripePaymentAmountCents: stripePaidAmountCents,
-        stripeEventId: eventId,
         paidAt: receivedAt,
         updatedAt: receivedAt,
         receiptMetadata: {
             provider: 'stripe',
-            checkoutSessionId: session.id || null,
-            paymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : null,
             amountPaidCents: stripePaidAmountCents,
             totalPaidCents: paidAmountCents,
             balanceDueCents,
-            currency: session.currency || 'usd',
-            receiptEmail: session.customer_details?.email || session.customer_email || null,
-            eventId
-        }
+            currency: session.currency || 'usd'
+        },
+        adminBilling: buildTeamFeeAdminBillingMetadata({
+            type: 'stripe_checkout_paid',
+            data: {
+                stripeCheckoutSessionId: session.id || null,
+                stripePaymentIntentId: typeof session.payment_intent === 'string' ? session.payment_intent : null,
+                stripeCustomerId: typeof session.customer === 'string' ? session.customer : null,
+                receiptEmail: session.customer_details?.email || session.customer_email || null,
+                stripeEventId: eventId,
+                amountPaidCents: stripePaidAmountCents,
+                totalPaidCents: paidAmountCents,
+                balanceDueCents,
+                currency: session.currency || 'usd',
+                paidAt: receivedAt,
+                updatedAt: receivedAt
+            }
+        })
     };
 }
 
@@ -339,6 +364,7 @@ module.exports = {
     shouldMarkTeamFeePaidFromEvent,
     shouldRecordTeamFeeCheckoutNotPaidFromEvent,
     getTeamFeeStripePaidAmountCents,
+    buildTeamFeeAdminBillingMetadata,
     buildTeamFeePaidUpdate,
     buildTeamFeeStripeRefundUpdate
 };

--- a/js/parent-dashboard-fees.js
+++ b/js/parent-dashboard-fees.js
@@ -36,6 +36,59 @@ function getFirstDefined(...values) {
     return values.find((value) => value !== undefined && value !== null && value !== '' && !(Array.isArray(value) && value.length === 0));
 }
 
+const PARENT_FEE_PRIVATE_FIELDS = [
+    'stripeCheckoutSessionId',
+    'stripePaymentIntentId',
+    'stripeCustomerId',
+    'stripeChargeId',
+    'stripeRefundId',
+    'stripeLastRefundId',
+    'stripeEventId',
+    'receiptEmail',
+    'refundedBy',
+    'recordedBy',
+    'internalNote',
+    'adminNote',
+    'reason'
+];
+
+const PARENT_FEE_PRIVATE_RECEIPT_FIELDS = [
+    'checkoutSessionId',
+    'paymentIntentId',
+    'receiptEmail',
+    'eventId'
+];
+
+function omitPrivateFields(value, fields) {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return value;
+    const safe = { ...value };
+    fields.forEach((field) => {
+        delete safe[field];
+    });
+    return safe;
+}
+
+function sanitizeParentFeeLedgerEntry(entry) {
+    const safe = omitPrivateFields(entry, PARENT_FEE_PRIVATE_FIELDS);
+    if (isRefundLedgerEntry(safe)) {
+        delete safe.note;
+    }
+    return safe;
+}
+
+export function sanitizeParentFeeRecipientRecord(fee) {
+    const safe = omitPrivateFields(fee || {}, PARENT_FEE_PRIVATE_FIELDS);
+    if (safe.receiptMetadata) {
+        safe.receiptMetadata = omitPrivateFields(safe.receiptMetadata, PARENT_FEE_PRIVATE_RECEIPT_FIELDS);
+    }
+    ['ledgerEntries', 'paymentLedger', 'activity', 'receipts', 'payments', 'adjustments'].forEach((field) => {
+        if (Array.isArray(safe[field])) {
+            safe[field] = safe[field].filter(Boolean).map(sanitizeParentFeeLedgerEntry);
+        }
+    });
+    return safe;
+}
+
 function getFeeLineItems(fee) {
     const rawItems = getFirstDefined(fee?.lineItems, fee?.invoiceLineItems, fee?.invoiceItems, fee?.items);
     return Array.isArray(rawItems) ? rawItems.filter(Boolean) : [];
@@ -319,23 +372,24 @@ export function formatParentFeeDueDate(value) {
 }
 
 export function normalizeParentFeeRecord(fee) {
+    const safeFee = sanitizeParentFeeRecipientRecord(fee);
     return {
-        ...fee,
-        title: fee?.title || fee?.feeTitle || fee?.name || 'Team fee',
-        teamName: fee?.teamName || 'Team',
-        playerName: fee?.playerName || fee?.childName || '',
-        status: normalizeParentFeeStatus(fee?.status),
-        dueDate: fee?.dueDate || fee?.dueAt || null,
-        notes: fee?.notes || fee?.feeNotes || '',
-        offlinePaymentInstructions: fee?.offlinePaymentInstructions || fee?.paymentInstructions || '',
-        collectionMode: fee?.collectionMode || '',
-        totalAmountCents: getFeeTotalCents(fee),
-        paidAmountCents: getFeePaidCents(fee),
-        balanceDueCents: getFeeBalanceCents(fee),
-        checkoutUrl: getFeeCheckoutUrl(fee),
-        teamId: fee?.teamId || '',
-        batchId: fee?.batchId || fee?.feeBatchId || '',
-        recipientId: getFeeRecipientId(fee) || ''
+        ...safeFee,
+        title: safeFee?.title || safeFee?.feeTitle || safeFee?.name || 'Team fee',
+        teamName: safeFee?.teamName || 'Team',
+        playerName: safeFee?.playerName || safeFee?.childName || '',
+        status: normalizeParentFeeStatus(safeFee?.status),
+        dueDate: safeFee?.dueDate || safeFee?.dueAt || null,
+        notes: safeFee?.notes || safeFee?.feeNotes || '',
+        offlinePaymentInstructions: safeFee?.offlinePaymentInstructions || safeFee?.paymentInstructions || '',
+        collectionMode: safeFee?.collectionMode || '',
+        totalAmountCents: getFeeTotalCents(safeFee),
+        paidAmountCents: getFeePaidCents(safeFee),
+        balanceDueCents: getFeeBalanceCents(safeFee),
+        checkoutUrl: getFeeCheckoutUrl(safeFee),
+        teamId: safeFee?.teamId || '',
+        batchId: safeFee?.batchId || safeFee?.feeBatchId || '',
+        recipientId: getFeeRecipientId(safeFee) || ''
     };
 }
 

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -195,8 +195,9 @@ export function getRecipientStripePaymentRefs(recipient) {
 
 export function isOnlineRefundEligible(recipient) {
     const { paymentIntentId, chargeId } = getRecipientStripePaymentRefs(recipient);
+    const hasPrivateAdminBilling = recipient?.hasAdminBilling === true;
     return recipient?.paymentProvider === 'stripe'
-        && Boolean(paymentIntentId || chargeId)
+        && Boolean(paymentIntentId || chargeId || hasPrivateAdminBilling)
         && getRecipientRefundableCents(recipient) > 0;
 }
 

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -187,9 +187,16 @@ export function getRecipientRefundableCents(recipient) {
     return getRecipientPaidCents(recipient);
 }
 
+export function getRecipientStripePaymentRefs(recipient) {
+    const paymentIntentId = normalizeString(recipient?.stripePaymentIntentId || recipient?.adminBilling?.stripePaymentIntentId);
+    const chargeId = normalizeString(recipient?.stripeChargeId || recipient?.stripeLatestChargeId || recipient?.adminBilling?.stripeChargeId || recipient?.adminBilling?.stripeLatestChargeId);
+    return { paymentIntentId, chargeId };
+}
+
 export function isOnlineRefundEligible(recipient) {
+    const { paymentIntentId, chargeId } = getRecipientStripePaymentRefs(recipient);
     return recipient?.paymentProvider === 'stripe'
-        && Boolean(recipient?.stripePaymentIntentId || recipient?.stripeChargeId || recipient?.stripeLatestChargeId)
+        && Boolean(paymentIntentId || chargeId)
         && getRecipientRefundableCents(recipient) > 0;
 }
 

--- a/playwright.smoke.config.js
+++ b/playwright.smoke.config.js
@@ -2,11 +2,10 @@ export default {
     testDir: './tests/smoke',
     testMatch: ['**/*.spec.js'],
     timeout: 30000,
-    retries: 0,
+    retries: process.env.CI ? 1 : 0,
     use: {
         browserName: 'chromium',
         headless: true,
         baseURL: process.env.SMOKE_BASE_URL || 'http://127.0.0.1:4173'
     }
 };
-

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -59,6 +59,8 @@ export function validateFirebaseRulesCi() {
     assertIncludes(firestoreRules, 'allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);', 'Firestore media item create rules');
     assertIncludes(firestoreRules, 'allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaUploadSoftDelete(teamId) || isTeamMediaTitleUpdate(teamId);', 'Firestore media item update rules');
     assertIncludes(firestoreRules, 'allow delete: if isTeamOwnerOrAdmin(teamId);', 'Firestore media item delete rules');
+    assertIncludes(firestoreRules, 'match /adminBilling/{billingId}', 'Firestore team fee admin billing rules');
+    assertIncludes(firestoreRules, 'allow read, create, update, delete: if isTeamOwnerOrAdmin(teamId);', 'Firestore team fee admin billing admin-only rules');
 
     assertIncludes(deployProd, 'firestore:rules', 'Production deploy');
     assertIncludes(deployProd, 'firestore:indexes', 'Production deploy');

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -16,6 +16,18 @@ async function waitForScheduleRoute(page, readyLocator) {
     }).toPass({ timeout: 30000 });
 }
 
+function mobileScheduleHeader(page) {
+    return page.locator('.schedule-header').first();
+}
+
+function mobileScheduleFilter(page) {
+    return mobileScheduleHeader(page).getByLabel('Schedule filter', { exact: true });
+}
+
+function mobilePlayerFilter(page) {
+    return mobileScheduleHeader(page).getByLabel('Player filter', { exact: true });
+}
+
 async function mockScheduleModules(page, options = {}) {
     const gameDate = options.gameDate || '2030-05-28T18:00:00Z';
     const practiceDate = options.practiceDate || '2030-05-29T19:00:00Z';
@@ -757,7 +769,7 @@ test('iOS-sized schedule smoke covers list, event nav, and rideshare without ove
     await mockScheduleModules(page);
     await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
 
-    await expect(page.getByLabel('Schedule filter', { exact: true })).toBeVisible({ timeout: 15000 });
+    await expect(mobileScheduleFilter(page)).toBeVisible({ timeout: 15000 });
     await expect(page.locator('.schedule-web-sidebar')).toBeHidden();
     await expect(page.locator('.schedule-list > a').first()).toBeVisible();
     const scheduleRowCount = await page.locator('.schedule-list > a').count();
@@ -989,7 +1001,7 @@ test('app schedule keeps filters compact on phone', async ({ page, baseURL }) =>
     await mockScheduleModules(page);
     await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
 
-    const scheduleFilter = page.getByLabel('Schedule filter', { exact: true });
+    const scheduleFilter = mobileScheduleFilter(page);
     await waitForScheduleRoute(page, scheduleFilter);
 
     const mobileRows = page.locator('.schedule-list > a');
@@ -1035,12 +1047,12 @@ test('app schedule paginates long agenda lists and resets on filter changes', as
     expect(expandedRowCount).toBeLessThanOrEqual(25);
     await expect(page.getByRole('button', { name: /Show .* more/ })).toHaveCount(0);
 
-    await page.getByLabel('Schedule filter', { exact: true }).selectOption('past-all');
+    await mobileScheduleFilter(page).selectOption('past-all');
     await expect(mobileRows).toHaveCount(10);
     await expect(page.getByText('Showing 10 of 12 events')).toBeVisible();
     await expect(page.getByRole('button', { name: 'Show 2 more' })).toBeVisible();
 
-    await page.getByLabel('Player filter', { exact: true }).selectOption('player-2');
+    await mobilePlayerFilter(page).selectOption('player-2');
     await expect(mobileRows).toHaveCount(0);
     await expect(page.getByText('No events in this filter')).toBeVisible();
     await expect(page.getByRole('button', { name: /Show .* more/ })).toHaveCount(0);

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -989,9 +989,12 @@ test('app schedule keeps filters compact on phone', async ({ page, baseURL }) =>
     await mockScheduleModules(page);
     await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
 
+    const scheduleFilter = page.getByLabel('Schedule filter', { exact: true });
+    await waitForScheduleRoute(page, scheduleFilter);
+
     const mobileRows = page.locator('.schedule-list > a');
     await expect(async () => {
-        await expect(page.getByLabel('Schedule filter', { exact: true })).toBeVisible({ timeout: 1000 });
+        await expect(scheduleFilter).toBeVisible({ timeout: 1000 });
         await expect(page.getByRole('button', { name: 'Upcoming Practices' })).toBeHidden();
         await expect(page.getByRole('link', { name: /Game details/i })).toHaveCount(0);
         await expect(mobileRows.first()).toBeVisible({ timeout: 1000 });
@@ -1004,9 +1007,9 @@ test('app schedule keeps filters compact on phone', async ({ page, baseURL }) =>
         for (const rowHeight of rowHeights) {
             expect(rowHeight).toBeLessThanOrEqual(86);
         }
-    }).toPass({ timeout: 15000 });
+    }).toPass({ timeout: 30000 });
 
-    await page.getByLabel('Schedule filter', { exact: true }).selectOption('upcoming-practices');
+    await scheduleFilter.selectOption('upcoming-practices');
     await expect(page.getByRole('heading', { name: 'Practice', exact: true })).toBeVisible();
     await expect(page.getByText('Home packet: 2 drills · 20 min')).toHaveCount(0);
     await expect(page.getByText('vs. Falcons')).not.toBeVisible();

--- a/tests/smoke/app-search.spec.js
+++ b/tests/smoke/app-search.spec.js
@@ -21,9 +21,11 @@ async function waitForAppShell(page) {
 async function waitForSearchTrigger(page) {
     const trigger = page.getByRole('button', { name: 'Search', exact: true }).first();
 
-    await waitForAppShell(page);
-    await expect(trigger).toBeVisible({ timeout: 5000 });
-    await expect(trigger).toBeEnabled({ timeout: 5000 });
+    await expect(async () => {
+        await waitForAppShell(page);
+        await expect(trigger).toBeVisible({ timeout: 1000 });
+        await expect(trigger).toBeEnabled({ timeout: 1000 });
+    }).toPass({ timeout: 30000 });
 
     return trigger;
 }
@@ -49,7 +51,7 @@ async function openSearch(page) {
             await page.keyboard.press('Control+K');
             await expect(searchDialog).toBeVisible({ timeout: 1000 });
         }
-    }).toPass({ timeout: 15000 });
+    }).toPass({ timeout: 30000 });
 }
 
 async function openDesktopSearch(page) {

--- a/tests/smoke/app-teams.spec.js
+++ b/tests/smoke/app-teams.spec.js
@@ -13,6 +13,9 @@ async function waitForTeamsRoute(page, readyLocator) {
     await expect(async () => {
         await expect(page.getByText('Loading ALL PLAYS')).toBeHidden({ timeout: 1000 });
         await expect(searchInput).toBeVisible({ timeout: 1000 });
+        if (readyLocator) {
+            await expect(readyLocator).toBeVisible({ timeout: 1000 });
+        }
     }).toPass({ timeout: 30000 });
 }
 
@@ -360,7 +363,9 @@ test.describe('mobile My Teams', () => {
         await mockTeamsModules(page);
         await page.goto(appUrl(baseURL, '/teams?selectedTeamId=team-staff&from=home'), { waitUntil: 'domcontentloaded' });
 
-        await expect(page.getByRole('heading', { name: '3 teams ready' })).toBeVisible();
+        const teamsReadyHeading = page.getByRole('heading', { name: '3 teams ready' });
+        await waitForTeamsRoute(page, teamsReadyHeading);
+        await expect(teamsReadyHeading).toBeVisible();
         await expect(page.getByText('Choose a team')).toBeVisible();
         await expect(page.getByPlaceholder('Search teams or players')).toBeVisible();
         await page.getByPlaceholder('Search teams or players').fill('Riley');

--- a/tests/unit/app-auth-profile-capabilities.test.js
+++ b/tests/unit/app-auth-profile-capabilities.test.js
@@ -447,6 +447,7 @@ describe('React app auth/profile capability parity', () => {
             'Upcoming Games',
             'Upcoming Practices',
             'Past Events',
+            'Schedule filter',
             'All Players',
             '.ics',
             'RSVP needed',

--- a/tests/unit/parent-dashboard-fees.test.js
+++ b/tests/unit/parent-dashboard-fees.test.js
@@ -3,8 +3,10 @@ import {
     formatParentFeeAmount,
     formatParentFeeDueDate,
     handleParentTeamFeeCheckoutClick,
+    normalizeParentFeeRecord,
     normalizeParentFeeStatus,
     renderParentTeamFees,
+    sanitizeParentFeeRecipientRecord,
     sortParentFeeRecords
 } from '../../js/parent-dashboard-fees.js';
 
@@ -189,6 +191,59 @@ describe('parent dashboard team fees', () => {
         expect(html).not.toContain('Admin-only reconciliation detail');
         expect(html).not.toContain('Private admin refund note');
         expect(html).not.toContain('admin-123');
+    });
+
+    it('sanitizes parent fee records before exposing Stripe and refund internals', () => {
+        const rawFee = {
+            id: 'recipient-1',
+            title: 'Private billing data',
+            amountCents: 10000,
+            status: 'paid',
+            stripeCheckoutSessionId: 'cs_private',
+            stripePaymentIntentId: 'pi_private',
+            stripeCustomerId: 'cus_private',
+            stripeEventId: 'evt_private',
+            receiptMetadata: {
+                provider: 'stripe',
+                checkoutSessionId: 'cs_private',
+                paymentIntentId: 'pi_private',
+                receiptEmail: 'parent@example.com',
+                eventId: 'evt_private',
+                amountPaidCents: 10000
+            },
+            ledgerEntries: [
+                {
+                    type: 'stripe_refund',
+                    amountCents: 2500,
+                    stripeRefundId: 're_private',
+                    stripePaymentIntentId: 'pi_private',
+                    stripeChargeId: 'ch_private',
+                    reason: 'Admin reconciliation reason',
+                    refundedBy: 'admin-1',
+                    note: 'Private refund note',
+                    publicNote: 'Uniform returned'
+                }
+            ]
+        };
+
+        const sanitized = sanitizeParentFeeRecipientRecord(rawFee);
+        const normalized = normalizeParentFeeRecord(rawFee);
+
+        expect(sanitized).not.toHaveProperty('stripeCheckoutSessionId');
+        expect(sanitized).not.toHaveProperty('stripePaymentIntentId');
+        expect(sanitized).not.toHaveProperty('stripeCustomerId');
+        expect(sanitized).not.toHaveProperty('stripeEventId');
+        expect(sanitized.receiptMetadata).toEqual({
+            provider: 'stripe',
+            amountPaidCents: 10000
+        });
+        expect(sanitized.ledgerEntries[0]).toEqual({
+            type: 'stripe_refund',
+            amountCents: 2500,
+            publicNote: 'Uniform returned'
+        });
+        expect(normalized).not.toHaveProperty('stripePaymentIntentId');
+        expect(normalized.ledgerEntries[0]).not.toHaveProperty('refundedBy');
     });
 
     it('renders Pay online only for Stripe collection fees with an unpaid balance', () => {

--- a/tests/unit/team-fees-admin.test.js
+++ b/tests/unit/team-fees-admin.test.js
@@ -2,7 +2,7 @@
 import { readFileSync } from 'node:fs';
 import { JSDOM } from 'jsdom';
 import { describe, it, expect } from 'vitest'; // Import Vitest globals
-import { buildManualPaymentUpdate, buildBalanceAdjustmentUpdate, buildOnlineRefundRequest, getRecipientRefundableCents, isOnlineRefundEligible, buildOfflineRefundUpdate, buildTeamFeePaymentSummaryRows, serializeTeamFeePaymentSummaryCsv, buildTeamFeePaymentSummaryCsv, escapeCsvValue, registerTeamFeesAdminPageHandlers, normalizeTeamFeeDraft } from '../../js/team-fees-admin.js'; // Adjusted path
+import { buildManualPaymentUpdate, buildBalanceAdjustmentUpdate, buildOnlineRefundRequest, getRecipientRefundableCents, getRecipientStripePaymentRefs, isOnlineRefundEligible, buildOfflineRefundUpdate, buildTeamFeePaymentSummaryRows, serializeTeamFeePaymentSummaryCsv, buildTeamFeePaymentSummaryCsv, escapeCsvValue, registerTeamFeesAdminPageHandlers, normalizeTeamFeeDraft } from '../../js/team-fees-admin.js'; // Adjusted path
 
 describe('team fees admin page routing', () => {
     it('reinitializes when same-page manage links update the hash', () => {
@@ -236,16 +236,17 @@ describe('online team fee refunds', () => {
     it('detects eligible Stripe payments and remaining refundable amount', () => {
         const recipient = {
             paymentProvider: 'stripe',
-            stripePaymentIntentId: 'pi_123',
             amountPaidCents: 10000,
-            refundedAmountCents: 2500
+            refundedAmountCents: 2500,
+            hasAdminBilling: true
         };
 
         expect(getRecipientRefundableCents(recipient)).toBe(10000);
+        expect(getRecipientStripePaymentRefs(recipient)).toEqual({ paymentIntentId: '', chargeId: '' });
         expect(isOnlineRefundEligible(recipient)).toBe(true);
-        expect(isOnlineRefundEligible({ ...recipient, stripePaymentIntentId: '', hasAdminBilling: true })).toBe(true);
-        expect(isOnlineRefundEligible({ ...recipient, stripePaymentIntentId: '', adminBilling: { stripePaymentIntentId: 'pi_private' } })).toBe(true);
-        expect(isOnlineRefundEligible({ ...recipient, stripePaymentIntentId: '', stripeChargeId: '', adminBilling: {} })).toBe(false);
+        expect(isOnlineRefundEligible({ ...recipient, hasAdminBilling: false, stripePaymentIntentId: 'pi_root' })).toBe(true);
+        expect(isOnlineRefundEligible({ ...recipient, hasAdminBilling: false, stripePaymentIntentId: '', stripeChargeId: '', adminBilling: { stripePaymentIntentId: 'pi_private' } })).toBe(true);
+        expect(isOnlineRefundEligible({ ...recipient, hasAdminBilling: false, stripePaymentIntentId: '', stripeChargeId: '', adminBilling: {} })).toBe(false);
         expect(isOnlineRefundEligible({ ...recipient, paymentProvider: 'manual' })).toBe(false);
     });
 });

--- a/tests/unit/team-fees-admin.test.js
+++ b/tests/unit/team-fees-admin.test.js
@@ -243,7 +243,9 @@ describe('online team fee refunds', () => {
 
         expect(getRecipientRefundableCents(recipient)).toBe(10000);
         expect(isOnlineRefundEligible(recipient)).toBe(true);
-        expect(isOnlineRefundEligible({ ...recipient, stripePaymentIntentId: '', stripeChargeId: '' })).toBe(false);
+        expect(isOnlineRefundEligible({ ...recipient, stripePaymentIntentId: '', hasAdminBilling: true })).toBe(true);
+        expect(isOnlineRefundEligible({ ...recipient, stripePaymentIntentId: '', adminBilling: { stripePaymentIntentId: 'pi_private' } })).toBe(true);
+        expect(isOnlineRefundEligible({ ...recipient, stripePaymentIntentId: '', stripeChargeId: '', adminBilling: {} })).toBe(false);
         expect(isOnlineRefundEligible({ ...recipient, paymentProvider: 'manual' })).toBe(false);
     });
 });

--- a/tests/unit/team-fees-functions.test.js
+++ b/tests/unit/team-fees-functions.test.js
@@ -20,6 +20,7 @@ const {
     shouldMarkTeamFeePaidFromEvent,
     shouldRecordTeamFeeCheckoutNotPaidFromEvent,
     getTeamFeeStripePaidAmountCents,
+    buildTeamFeeAdminBillingMetadata,
     buildTeamFeePaidUpdate,
     buildTeamFeeStripeRefundUpdate
 } = require('../../functions/team-fees-core.cjs');
@@ -193,7 +194,7 @@ describe('team fee checkout function helpers', () => {
         })).toBe(0);
     });
 
-    it('builds paid recipient updates without raw payment method data', () => {
+    it('builds paid recipient updates with Stripe identifiers split into admin billing metadata', () => {
         const update = buildTeamFeePaidUpdate({
             recipient: { amountCents: 12500, paidAmountCents: 2500 },
             eventId: 'evt_123',
@@ -216,25 +217,37 @@ describe('team fee checkout function helpers', () => {
             checkoutStatus: 'paid',
             checkoutAttemptToken: null,
             paymentProvider: 'stripe',
-            stripeCheckoutSessionId: 'cs_123',
-            stripePaymentIntentId: 'pi_123',
-            stripeCustomerId: 'cus_123',
+            stripeCheckoutSessionId: null,
             stripePaymentAmountCents: 10000,
-            stripeEventId: 'evt_123'
         });
         expect(update.receiptMetadata).toEqual({
             provider: 'stripe',
-            checkoutSessionId: 'cs_123',
-            paymentIntentId: 'pi_123',
+            amountPaidCents: 10000,
+            totalPaidCents: 12500,
+            balanceDueCents: 0,
+            currency: 'usd'
+        });
+        expect(update.adminBilling).toEqual({
+            type: 'stripe_checkout_paid',
+            provider: 'stripe',
+            stripeCheckoutSessionId: 'cs_123',
+            stripePaymentIntentId: 'pi_123',
+            stripeCustomerId: 'cus_123',
+            receiptEmail: 'parent@example.com',
+            stripeEventId: 'evt_123',
             amountPaidCents: 10000,
             totalPaidCents: 12500,
             balanceDueCents: 0,
             currency: 'usd',
-            receiptEmail: 'parent@example.com',
-            eventId: 'evt_123'
+            paidAt: 'now',
+            updatedAt: 'now'
         });
+        expect(update).not.toHaveProperty('stripePaymentIntentId');
+        expect(update).not.toHaveProperty('stripeCustomerId');
+        expect(update).not.toHaveProperty('stripeEventId');
         expect(update).not.toHaveProperty('paymentMethod');
         expect(update.receiptMetadata).not.toHaveProperty('card');
+        expect(update.receiptMetadata).not.toHaveProperty('receiptEmail');
     });
 
     it('normalizes refund input and computes refundable cents', () => {
@@ -301,7 +314,6 @@ describe('team fee checkout function helpers', () => {
             checkoutAttemptToken: null,
             stripeCheckoutSessionId: null,
             paymentProvider: 'stripe',
-            stripeLastRefundId: 're_123',
             stripeLastRefundStatus: 'succeeded'
         });
         expect(update.ledgerEntries).toEqual([{
@@ -309,13 +321,42 @@ describe('team fee checkout function helpers', () => {
             amountCents: 5000,
             refundAmountCents: 5000,
             status: 'succeeded',
+            refundedAt: 'ledger-now'
+        }]);
+        expect(update.adminBilling).toEqual({
+            type: 'stripe_refund',
+            provider: 'stripe',
             stripeRefundId: 're_123',
             stripePaymentIntentId: 'pi_123',
             stripeChargeId: null,
+            refundAmountCents: 5000,
+            status: 'succeeded',
             reason: 'Family requested refund',
             refundedBy: 'admin_1',
-            refundedAt: 'ledger-now'
-        }]);
+            refundedAt: 'ledger-now',
+            updatedAt: 'server-now'
+        });
+        expect(update).not.toHaveProperty('stripeLastRefundId');
+        expect(update.ledgerEntries[0]).not.toHaveProperty('stripeRefundId');
+        expect(update.ledgerEntries[0]).not.toHaveProperty('stripePaymentIntentId');
+        expect(update.ledgerEntries[0]).not.toHaveProperty('stripeChargeId');
+        expect(update.ledgerEntries[0]).not.toHaveProperty('reason');
+        expect(update.ledgerEntries[0]).not.toHaveProperty('refundedBy');
+    });
+
+    it('builds typed admin billing metadata for private fee reconciliation fields', () => {
+        expect(buildTeamFeeAdminBillingMetadata({
+            type: 'stripe_refund',
+            data: {
+                stripeRefundId: 're_123',
+                reason: 'Duplicate charge'
+            }
+        })).toEqual({
+            type: 'stripe_refund',
+            provider: 'stripe',
+            stripeRefundId: 're_123',
+            reason: 'Duplicate charge'
+        });
     });
 
     it('guards Stripe refund callable idempotency and recording consistency', () => {
@@ -338,6 +379,7 @@ describe('team fee checkout function helpers', () => {
         expect(functionsSource).toContain('shouldApplyTeamFeeCheckoutSession({ recipient, session })');
         expect(functionsSource).toContain('getTeamFeeCheckoutGuardFailure({ recipient, session })');
         expect(functionsSource).toContain("ignoredReason");
+        expect(functionsSource).toContain("recipientRef.collection('adminBilling').doc");
         expect(dbSource).toContain("updatePayload.checkoutStatus = 'stale'");
         expect(dbSource).toContain('updatePayload.checkoutAttemptToken = deleteField()');
         expect(dbSource).toContain('updatePayload.stripeCheckoutSessionId = deleteField()');

--- a/tests/unit/team-fees-functions.test.js
+++ b/tests/unit/team-fees-functions.test.js
@@ -21,6 +21,7 @@ const {
     shouldRecordTeamFeeCheckoutNotPaidFromEvent,
     getTeamFeeStripePaidAmountCents,
     buildTeamFeeAdminBillingMetadata,
+    getTeamFeeStripePaymentRefs,
     buildTeamFeePaidUpdate,
     buildTeamFeeStripeRefundUpdate
 } = require('../../functions/team-fees-core.cjs');
@@ -219,6 +220,7 @@ describe('team fee checkout function helpers', () => {
             paymentProvider: 'stripe',
             stripeCheckoutSessionId: null,
             stripePaymentAmountCents: 10000,
+            hasAdminBilling: true,
         });
         expect(update.receiptMetadata).toEqual({
             provider: 'stripe',
@@ -283,18 +285,38 @@ describe('team fee checkout function helpers', () => {
         })).toBe(8000);
     });
 
+    it('resolves private Stripe payment refs from admin billing metadata', () => {
+        expect(getTeamFeeStripePaymentRefs({
+            adminBilling: {
+                stripePaymentIntentId: 'pi_private',
+                stripeChargeId: 'ch_private'
+            }
+        })).toEqual({
+            paymentIntentId: 'pi_private',
+            chargeId: 'ch_private'
+        });
+        expect(getTeamFeeStripePaymentRefs({}, [{
+            stripePaymentIntentId: 'pi_from_entry'
+        }])).toEqual({
+            paymentIntentId: 'pi_from_entry',
+            chargeId: ''
+        });
+    });
+
     it('builds Stripe refund ledger updates without over-crediting balances', () => {
         const update = buildTeamFeeStripeRefundUpdate({
             recipient: {
                 amountCents: 12500,
                 paidAmountCents: 12500,
                 refundedAmountCents: 2500,
-                stripePaymentIntentId: 'pi_123'
+                adminBilling: {
+                    stripePaymentIntentId: 'pi_123',
+                    stripeChargeId: 'ch_123'
+                }
             },
             refund: {
                 id: 're_123',
-                status: 'succeeded',
-                payment_intent: 'pi_123'
+                status: 'succeeded'
             },
             amountCents: 5000,
             actorId: 'admin_1',
@@ -314,6 +336,7 @@ describe('team fee checkout function helpers', () => {
             checkoutAttemptToken: null,
             stripeCheckoutSessionId: null,
             paymentProvider: 'stripe',
+            hasAdminBilling: true,
             stripeLastRefundStatus: 'succeeded'
         });
         expect(update.ledgerEntries).toEqual([{
@@ -328,7 +351,7 @@ describe('team fee checkout function helpers', () => {
             provider: 'stripe',
             stripeRefundId: 're_123',
             stripePaymentIntentId: 'pi_123',
-            stripeChargeId: null,
+            stripeChargeId: 'ch_123',
             refundAmountCents: 5000,
             status: 'succeeded',
             reason: 'Family requested refund',
@@ -364,6 +387,9 @@ describe('team fee checkout function helpers', () => {
 
         expect(source).toContain("recipientRef.collection('refundIntents').doc(refundRequestId)");
         expect(source).toContain('idempotencyKey: buildTeamFeeRefundIdempotencyKey(input, refundRequestId)');
+        expect(source).toContain('fetchTeamFeePaymentAdminBilling(recipientRef)');
+        expect(source).toContain('getTeamFeeStripePaymentRefs(recipient, paymentAdminBilling)');
+        expect(source).toContain("buildTeamFeeAdminBillingRef(recipientRef, 'latest')");
         expect(source).toContain('const actualRefundAmount = Math.round(Number(refund.amount || 0));');
         expect(source).toContain("stripeRefundStatus !== 'succeeded'");
         expect(source).toContain('const ledgerRefundedAt = admin.firestore.Timestamp.now();');


### PR DESCRIPTION
## Summary
- move private Stripe checkout/refund identifiers and admin-only refund metadata off parent-readable fee recipient docs into `feeRecipients/{id}/adminBilling`
- clear parent-readable billing identifiers during webhook and refund writes while preserving safe payment status, balances, and public notes
- sanitize legacy parent dashboard and shared app parent-tools fee models before render/normalization
- add focused unit coverage for the split plus CI coverage for the new Firestore `adminBilling` rule stanza
- persist run-scoped role notes for requirements, architecture, QA, and code planning

Closes #1901

## Validation
- `npm install`
- `npx vitest run tests/unit/team-fees-functions.test.js tests/unit/parent-dashboard-fees.test.js --reporter=dot`
- `npx vitest run tests/unit/app-team-fees-service.test.ts tests/unit/app-parent-tools-service.test.js --reporter=dot`
- `npm run ci:firebase-rules && echo CI_FIREBASE_RULES_PASS`
- `git diff --check && echo GIT_DIFF_CHECK_PASS`

## Notes
- React parent-tools fee loading already goes through `normalizeParentFeeRecord`, so the shared sanitizer change covers both the legacy dashboard and app service path.
- This slice does not add emulator-backed parent-vs-admin Firestore access tests or a real browser payment/refund smoke.
