### PR TITLE
Show search-empty state in mobile messages

### DIFF
--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -171,7 +171,16 @@ export function Messages({ auth }: { auth: AuthState }) {
           <aside className="messages-list-pane">
             <InboxSearch query={query} onChange={setQuery} />
             <div className="messages-list-scroll">
-              <InboxList teams={filteredTeams} loading={loading} error={error} activeTeamId={activeTeamId || ''} compact />
+              <InboxList
+                teams={filteredTeams}
+                loading={loading}
+                error={error}
+                activeTeamId={activeTeamId || ''}
+                searchQuery={query}
+                totalTeamsCount={teams.length}
+                onClearSearch={() => setQuery('')}
+                compact
+              />
             </div>
           </aside>
           <div className="messages-chat-pane min-w-0">
@@ -207,7 +216,15 @@ export function Messages({ auth }: { auth: AuthState }) {
     <div className="messages-page space-y-4">
       <MessagesHeader teams={teams} loading={loading} onRefresh={refreshInbox} />
       <InboxSearch query={query} onChange={setQuery} />
-      <InboxList teams={filteredTeams} loading={loading} error={error} activeTeamId="" />
+      <InboxList
+        teams={filteredTeams}
+        loading={loading}
+        error={error}
+        activeTeamId=""
+        searchQuery={query}
+        totalTeamsCount={teams.length}
+        onClearSearch={() => setQuery('')}
+      />
     </div>
   );
 }
@@ -254,14 +271,22 @@ function InboxList({
   loading,
   error,
   activeTeamId,
+  searchQuery,
+  totalTeamsCount,
+  onClearSearch,
   compact = false
 }: {
   teams: ChatTeam[];
   loading: boolean;
   error: string | null;
   activeTeamId: string;
+  searchQuery: string;
+  totalTeamsCount: number;
+  onClearSearch: () => void;
   compact?: boolean;
 }) {
+  const trimmedQuery = searchQuery.trim();
+
   if (loading) {
     return (
       <section className="app-card flex min-h-44 items-center justify-center p-5 text-sm font-bold text-gray-500">
@@ -280,6 +305,19 @@ function InboxList({
   }
 
   if (!teams.length) {
+    if (trimmedQuery && totalTeamsCount > 0) {
+      return (
+        <section className="app-card p-6 text-center">
+          <Search className="mx-auto h-10 w-10 text-gray-300" aria-hidden="true" />
+          <div className="mt-3 text-base font-black text-gray-950">No team chats match “{trimmedQuery}”</div>
+          <div className="mt-1 text-sm font-semibold leading-6 text-gray-500">Try a different search or clear it to see all team chats.</div>
+          <button type="button" className="secondary-button mx-auto mt-4" onClick={onClearSearch}>
+            Clear search
+          </button>
+        </section>
+      );
+    }
+
     return (
       <section className="app-card p-6 text-center">
         <MessageCircle className="mx-auto h-10 w-10 text-gray-300" aria-hidden="true" />

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -280,6 +280,14 @@ test('messages inbox and team chat exercise real migrated chat UX', async ({ pag
     await expect.poll(() => searchInput.evaluate((element) => window.getComputedStyle(element).fontSize)).toBe('16px');
     await searchInput.click();
     await expect.poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth + 1)).toBe(true);
+    await searchInput.fill('volleyball');
+    await expect(page.getByText('No team chats match “volleyball”')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Clear search' })).toBeVisible();
+    await expect(page.getByText('No team chats yet')).toBeHidden();
+    await page.getByRole('button', { name: 'Clear search' }).click();
+    await expect(searchInput).toHaveValue('');
+    await expect(page.getByRole('link', { name: /Bears/ }).first()).toBeVisible();
+    await expect(page.getByRole('link', { name: /Thunder/ }).first()).toBeVisible();
 
     await openTeamThread(page, 'Bears');
     const thread = page.locator('.chat-messages-scroll');

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -594,6 +594,46 @@ describe('React app messages integration', () => {
         expect(container.textContent).not.toContain('Thunder');
     });
 
+    it('shows a search-specific empty state and restores the inbox when cleared', async () => {
+        chatMocks.loadChatInbox.mockResolvedValueOnce({
+            teams: [
+                {
+                    id: 'team-1',
+                    name: 'Bears',
+                    sport: 'Basketball',
+                    role: 'Admin',
+                    canModerate: true,
+                    unreadCount: 2,
+                    lastMessage: chatMessage({ id: 'last-1', text: 'Practice packet posted.' })
+                },
+                {
+                    id: 'team-2',
+                    name: 'Thunder',
+                    sport: 'Soccer',
+                    role: 'Parent',
+                    canModerate: false,
+                    unreadCount: 0,
+                    lastMessage: chatMessage({ id: 'last-2', senderName: 'Morgan', text: 'Tournament schedule changed.' })
+                }
+            ]
+        });
+        const { container } = await renderMessages('/messages');
+        const search = container.querySelector('input[placeholder="Search team chats"]');
+
+        await setFieldValue(search, 'volleyball');
+
+        expect(container.textContent).toContain('No team chats match “volleyball”');
+        expect(container.textContent).toContain('Clear search');
+        expect(container.textContent).not.toContain('No team chats yet');
+        expect(container.textContent).not.toContain('Join or create a team to start messaging.');
+
+        await click(container, 'Clear search');
+
+        expect(search.value).toBe('');
+        expect(container.textContent).toContain('Bears');
+        expect(container.textContent).toContain('Thunder');
+    });
+
     it('auto-selects the first filtered team in the desktop messages workspace', async () => {
         layoutMocks.isDesktopWeb = true;
         const { container } = await renderMessages('/messages');


### PR DESCRIPTION
Closes #1900

## What changed
- Added a search-specific empty state in `Messages`/`InboxList` for cases where a non-empty search query filters an existing inbox down to zero matches.
- Kept the existing onboarding empty state unchanged for truly empty inboxes.
- Added a visible `Clear search` action that resets the query and restores the full inbox list.
- Extended focused inbox regression coverage in the jsdom integration test and mobile smoke spec.

## Root Cause
`Messages` filtered the inbox list before rendering, but `InboxList` only received the filtered array and had a single `teams.length === 0` branch. That meant a search miss was indistinguishable from a truly empty inbox, so the onboarding card rendered for users who actually had team chats.

## Prevention / Learning
When a surface supports client-side filtering, pass enough source-list and filter-state context to distinguish a true empty dataset from a filtered no-results state. Add a regression test that verifies the recovery path, not just the positive filter match.

## Regression Tests
- `tests/unit/app-chat-messages-integration.test.jsx` now asserts that a no-match search shows search-specific copy, hides onboarding copy, and restores inbox rows after `Clear search`.
- `tests/smoke/app-messages.spec.js` now covers the mobile zero-result search and clear flow.
- `npm run app:build`