### PR TITLE
Defer offscreen inline chat video metadata loads

### DIFF
--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -2224,6 +2224,48 @@ function MessageAvatar({ message, label }: { message: ChatMessage; label: string
   );
 }
 
+function InlineAttachmentVideo({ src }: { src: string }) {
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const [shouldPreloadMetadata, setShouldPreloadMetadata] = useState(false);
+
+  useEffect(() => {
+    if (shouldPreloadMetadata) return undefined;
+    const video = videoRef.current;
+    if (!video || typeof IntersectionObserver === 'undefined') return undefined;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries.some((entry) => entry.isIntersecting)) {
+        setShouldPreloadMetadata(true);
+        observer.disconnect();
+      }
+    }, {
+      threshold: 0.01
+    });
+
+    observer.observe(video);
+    return () => observer.disconnect();
+  }, [shouldPreloadMetadata]);
+
+  const armMetadataPreload = useCallback(() => {
+    setShouldPreloadMetadata(true);
+  }, []);
+
+  return (
+    <video
+      ref={videoRef}
+      controls
+      preload={shouldPreloadMetadata ? 'metadata' : 'none'}
+      className="max-h-72 w-full"
+      src={src}
+      onFocus={armMetadataPreload}
+      onMouseEnter={armMetadataPreload}
+      onPlay={armMetadataPreload}
+      onPointerDown={armMetadataPreload}
+      onTouchStart={armMetadataPreload}
+    />
+  );
+}
+
 function MessageAttachments({ attachments, isOwn }: { attachments: any[]; isOwn: boolean }) {
   return (
     <div className={`mb-2 grid gap-2 ${attachments.length > 1 ? 'grid-cols-2' : 'grid-cols-1'}`}>
@@ -2232,7 +2274,7 @@ function MessageAttachments({ attachments, isOwn }: { attachments: any[]; isOwn:
         if (attachment.type === 'video') {
           return (
             <div key={`${attachment.url}-${index}`} className="overflow-hidden rounded-xl border border-gray-200 bg-black">
-              <video controls preload="metadata" className="max-h-72 w-full" src={attachment.url} />
+              <InlineAttachmentVideo src={attachment.url} />
               <a href={attachment.url} target="_blank" rel="noopener noreferrer" className="block truncate bg-white px-3 py-2 text-xs font-bold text-primary-600">
                 {label}
               </a>

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -99,6 +99,10 @@ const resizeObserverState = vi.hoisted(() => ({
     instances: []
 }));
 
+const intersectionObserverState = vi.hoisted(() => ({
+    instances: []
+}));
+
 const animationFrameState = vi.hoisted(() => ({
     nextId: 1,
     callbacks: new Map()
@@ -304,6 +308,26 @@ beforeEach(() => {
 
         trigger() {
             this.callback([], this);
+        }
+    };
+    intersectionObserverState.instances.length = 0;
+    global.IntersectionObserver = class MockIntersectionObserver {
+        constructor(callback) {
+            this.callback = callback;
+            this.elements = [];
+            intersectionObserverState.instances.push(this);
+        }
+
+        observe = vi.fn((element) => {
+            this.elements.push(element);
+        });
+        disconnect = vi.fn();
+        unobserve = vi.fn((element) => {
+            this.elements = this.elements.filter((candidate) => candidate !== element);
+        });
+
+        trigger(element, isIntersecting) {
+            this.callback([{ isIntersecting, target: element }], this);
         }
     };
 
@@ -1332,6 +1356,64 @@ describe('React app messages integration', () => {
         await click(container, 'Open photos and videos');
         expect(container.textContent).toContain('Photos & videos');
         expect(container.textContent).toContain('Tipoff');
+    });
+
+    it('defers inline video metadata until the attachment is visible or hovered', async () => {
+        chatMocks.subscribeToTeamChatMessages.mockImplementation((teamId, conversationId, onMessages) => {
+            onMessages([
+                chatMessage({
+                    id: 'msg-video',
+                    text: '',
+                    attachments: [
+                        {
+                            type: 'video',
+                            url: 'https://media.example.test/warmups.mp4',
+                            name: 'Warmups.mp4'
+                        }
+                    ]
+                })
+            ], { id: 'cursor' });
+            return { unsubscribe: vi.fn() };
+        });
+
+        const { container } = await renderMessages('/messages/team-1');
+        const video = container.querySelector('video[src="https://media.example.test/warmups.mp4"]');
+        expect(video).toBeTruthy();
+        expect(video.getAttribute('preload')).toBe('none');
+        expect(intersectionObserverState.instances).toHaveLength(1);
+
+        await act(async () => {
+            intersectionObserverState.instances[0].trigger(video, true);
+        });
+        await flush();
+        expect(video.getAttribute('preload')).toBe('metadata');
+
+        chatMocks.subscribeToTeamChatMessages.mockImplementationOnce((teamId, conversationId, onMessages) => {
+            onMessages([
+                chatMessage({
+                    id: 'msg-video-hover',
+                    text: '',
+                    attachments: [
+                        {
+                            type: 'video',
+                            url: 'https://media.example.test/huddle.mp4',
+                            name: 'Huddle.mp4'
+                        }
+                    ]
+                })
+            ], { id: 'cursor' });
+            return { unsubscribe: vi.fn() };
+        });
+
+        const hovered = await renderMessages('/messages/team-1');
+        const hoveredVideo = hovered.container.querySelector('video[src="https://media.example.test/huddle.mp4"]');
+        expect(hoveredVideo.getAttribute('preload')).toBe('none');
+
+        await act(async () => {
+            hoveredVideo.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+        });
+        await flush();
+        expect(hoveredVideo.getAttribute('preload')).toBe('metadata');
     });
 
     it('routes ALL PLAYS mentions through the existing AI assistant send path', async () => {


### PR DESCRIPTION
Closes #1908

## What changed
- replaced the inline Messages attachment video element with a small wrapper that defaults to `preload="none"`
- promote inline videos to `preload="metadata"` only after they become visible in the thread or the user interacts with them
- added a focused Messages integration regression test that proves inline video metadata stays deferred offscreen and arms when visible or interacted with

## Root Cause
Inline chat attachment videos in `Messages.tsx` always rendered with `preload="metadata"`, so opening a media-heavy thread immediately triggered browser metadata fetches for every attached video, including videos below the fold.

## Prevention / Learning
In scrollable message threads, inline video attachments should start with the least eager preload mode and only escalate when the video is on screen or the user has signaled intent to play it.

## Regression Tests
- `npx vitest run tests/unit/app-chat-messages-integration.test.jsx --reporter=dot`
- `tests/unit/app-chat-messages-integration.test.jsx` now verifies inline chat videos stay at `preload="none"` until visibility or interaction flips them to `metadata`