### PR TITLE
Lazy-load inline chat attachment images

### DIFF
--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -2283,7 +2283,13 @@ function MessageAttachments({ attachments, isOwn }: { attachments: any[]; isOwn:
         }
         return (
           <a key={`${attachment.url}-${index}`} href={attachment.url} target="_blank" rel="noopener noreferrer" className="block overflow-hidden rounded-xl border border-gray-200">
-            <img src={attachment.url} alt={label} className={`max-h-72 w-full object-cover ${isOwn ? 'bg-primary-500' : 'bg-white'}`} />
+            <img
+              src={attachment.url}
+              alt={label}
+              loading="lazy"
+              decoding="async"
+              className={`max-h-72 w-full object-cover ${isOwn ? 'bg-primary-500' : 'bg-white'}`}
+            />
           </a>
         );
       })}

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -1330,7 +1330,7 @@ describe('React app messages integration', () => {
         expect(container.textContent).toContain('Media link copied.');
     });
 
-    it('renders team media photo posts inline and includes them in the gallery', async () => {
+    it('renders team media photo posts inline with native lazy-loading and includes them in the gallery', async () => {
         chatMocks.subscribeToTeamChatMessages.mockImplementation((teamId, conversationId, onMessages) => {
             onMessages([
                 chatMessage({
@@ -1350,8 +1350,12 @@ describe('React app messages integration', () => {
         const { container } = await renderMessages('/messages/team-1');
 
         const inlinePhoto = container.querySelector('img[alt="Tipoff"]');
+        const inlinePhotoLink = container.querySelector('a[href="https://media.example.test/tipoff.jpg"]');
         expect(inlinePhoto).toBeTruthy();
         expect(inlinePhoto.getAttribute('src')).toBe('https://media.example.test/tipoff.jpg');
+        expect(inlinePhoto.getAttribute('loading')).toBe('lazy');
+        expect(inlinePhoto.getAttribute('decoding')).toBe('async');
+        expect(inlinePhotoLink).toBeTruthy();
 
         await click(container, 'Open photos and videos');
         expect(container.textContent).toContain('Photos & videos');


### PR DESCRIPTION
Closes #1907

## What changed
- added browser-native `loading="lazy"` and `decoding="async"` to inline image attachments rendered by `MessageAttachments` in the React Messages thread
- extended the Messages integration test to assert the inline chat image keeps its existing open/save link behavior while carrying the lazy-loading attributes

## Root Cause
`MessageAttachments` rendered inline image attachments with a plain `<img>` tag, so browsers were free to eagerly fetch below-the-fold chat photos as soon as the thread mounted.

## Prevention / Learning
For scrollable chat feeds and attachment lists, default inline images to browser-native lazy loading and async decoding unless a specific above-the-fold requirement justifies eager loading.

## Regression Tests
- `npx vitest run tests/unit/app-chat-messages-integration.test.jsx --reporter=verbose`
- updated `tests/unit/app-chat-messages-integration.test.jsx` to verify inline team media images render with `loading="lazy"` and `decoding="async"` and remain linked to the original media URL