### PR TITLE
Add Messages inline image loading coverage

### DIFF
--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -1293,7 +1293,7 @@ describe('React app messages integration', () => {
         expect(container.textContent).toContain('Older update');
     });
 
-    it('opens the shared media gallery with share, save, and copy actions', async () => {
+    it('renders inline chat image attachments with deferred loading attrs and gallery actions', async () => {
         chatMocks.subscribeToTeamChatMessages.mockImplementation((teamId, conversationId, onMessages) => {
             onMessages([
                 chatMessage({
@@ -1311,6 +1311,14 @@ describe('React app messages integration', () => {
             return { unsubscribe: vi.fn() };
         });
         const { container } = await renderMessages('/messages/team-1');
+
+        const inlineImage = container.querySelector('img[alt="Lineup.jpg"]');
+        const inlineImageLink = container.querySelector('a[href="https://media.example.test/lineup.jpg"]');
+        expect(inlineImage).toBeTruthy();
+        expect(inlineImage.getAttribute('src')).toBe('https://media.example.test/lineup.jpg');
+        expect(inlineImage.getAttribute('loading')).toBe('lazy');
+        expect(inlineImage.getAttribute('decoding')).toBe('async');
+        expect(inlineImageLink).toBeTruthy();
 
         await click(container, 'Open photos and videos');
         expect(container.textContent).toContain('Photos & videos');


### PR DESCRIPTION
Closes #1914

## What changed
- Extended `tests/unit/app-chat-messages-integration.test.jsx` to cover the existing inline chat image attachment render path for `type: 'image'` attachments.
- Added assertions that initial thread open renders the inline image with `loading="lazy"` and `decoding="async"`.
- Kept the existing gallery action assertions in the same focused Messages integration test surface.

## Root Cause
Messages integration coverage only asserted deferred-loading attributes for team media photo posts, not the default inline chat image attachment path that uses normalized `type: 'image'` attachments. That left the main Messages image render path unprotected against regressions.

## Prevention / Learning
When deferred-loading or preload behavior matters for media, add focused assertions for each attachment kind that reaches the shared renderer, especially normalized chat upload types like `image` versus `photo`.

## Regression Tests
- `npx vitest run tests/unit/app-chat-messages-integration.test.jsx --reporter=verbose`

## Recurrence Risk
Low. Runtime behavior was already correct, and this adds a direct integration assertion on the previously uncovered inline chat image path.