### PR TITLE
Add Messages inline video preload regression coverage

### DIFF
--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -1370,6 +1370,43 @@ describe('React app messages integration', () => {
         expect(container.textContent).toContain('Tipoff');
     });
 
+    it('keeps inline videos on preload=none when a thread first opens', async () => {
+        chatMocks.subscribeToTeamChatMessages.mockImplementation((teamId, conversationId, onMessages) => {
+            onMessages([
+                chatMessage({
+                    id: 'msg-video-initial',
+                    text: '',
+                    attachments: [
+                        {
+                            type: 'video',
+                            url: 'https://media.example.test/warmups.mp4',
+                            name: 'Warmups.mp4'
+                        },
+                        {
+                            type: 'video',
+                            url: 'https://media.example.test/huddle.mp4',
+                            name: 'Huddle.mp4'
+                        }
+                    ]
+                })
+            ], { id: 'cursor' });
+            return { unsubscribe: vi.fn() };
+        });
+
+        const { container } = await renderMessages('/messages/team-1');
+        const videos = Array.from(container.querySelectorAll('video'));
+        expect(videos).toHaveLength(2);
+        videos.forEach((video) => {
+            expect(video.getAttribute('preload')).toBe('none');
+        });
+        expect(intersectionObserverState.instances).toHaveLength(2);
+
+        await flush();
+        videos.forEach((video) => {
+            expect(video.getAttribute('preload')).toBe('none');
+        });
+    });
+
     it('defers inline video metadata until the attachment is visible or hovered', async () => {
         chatMocks.subscribeToTeamChatMessages.mockImplementation((teamId, conversationId, onMessages) => {
             onMessages([


### PR DESCRIPTION
Closes #1915

## What changed
- added a focused Messages integration test that opens a thread with inline video attachments and asserts each inline `<video>` stays on `preload="none"` during initial render
- kept the change scoped to `tests/unit/app-chat-messages-integration.test.jsx` without adding smoke coverage or broader performance instrumentation
- preserved the existing follow-up coverage that verifies metadata preload upgrades only after visibility or direct interaction

## Root Cause
Messages already had the deferred inline video behavior, but the integration suite did not pin the initial thread-open contract tightly enough. That left room for a future regression to switch inline videos back to eager metadata preload without a focused test failure.

## Prevention / Learning
For first-paint performance protections, add a route-level regression test that asserts the initial DOM loading attributes before any observer callback or user interaction can upgrade behavior. Keep the assertion adjacent to the bounded rendering path instead of relying on broad smoke coverage.

## Regression Tests
- `npx vitest run tests/unit/app-chat-messages-integration.test.jsx --reporter=verbose`