### PR TITLE
Reuse TeamDetail base snapshot for deferred tabs

### DIFF
--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -196,7 +196,21 @@ export type TeamDetailSponsorsPayload = {
   sponsors: TeamDetailSponsor[];
 };
 
+type TeamDetailBaseSnapshot = {
+  teamId: string;
+  team: any;
+  players: any[];
+  games: any[];
+  configs: any[];
+};
+
 type FirestoreDocument = Record<string, any> & { id: string };
+
+const teamDetailBaseSnapshotCache = new Map<string, TeamDetailBaseSnapshot>();
+
+export function __resetTeamDetailBaseSnapshotCacheForTests() {
+  teamDetailBaseSnapshotCache.clear();
+}
 
 function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = primaryDataTimeoutMs): Promise<T> {
   let timeoutId: number | undefined;
@@ -217,6 +231,39 @@ function getProjectId() {
   const projectId = firebaseAuth.app?.options?.projectId;
   if (!projectId) throw new Error('Firebase project ID is missing.');
   return projectId;
+}
+
+function cacheTeamDetailBaseSnapshot(snapshot: TeamDetailBaseSnapshot) {
+  teamDetailBaseSnapshotCache.set(cleanString(snapshot.teamId), {
+    teamId: cleanString(snapshot.teamId),
+    team: snapshot.team,
+    players: Array.isArray(snapshot.players) ? snapshot.players : [],
+    games: Array.isArray(snapshot.games) ? snapshot.games : [],
+    configs: Array.isArray(snapshot.configs) ? snapshot.configs : []
+  });
+}
+
+async function loadTeamDetailBaseSnapshot(teamId: string): Promise<TeamDetailBaseSnapshot> {
+  const normalizedTeamId = cleanString(teamId);
+  const cachedSnapshot = teamDetailBaseSnapshotCache.get(normalizedTeamId);
+  if (cachedSnapshot?.team) return cachedSnapshot;
+
+  const [team, players, games, configs] = await Promise.all([
+    loadTeamDocument(normalizedTeamId),
+    loadTeamPlayers(normalizedTeamId),
+    loadTeamGames(normalizedTeamId),
+    loadTeamConfigs(normalizedTeamId)
+  ]);
+
+  const snapshot = {
+    teamId: normalizedTeamId,
+    team,
+    players: Array.isArray(players) ? players : [],
+    games: Array.isArray(games) ? games : [],
+    configs: Array.isArray(configs) ? configs : []
+  };
+  cacheTeamDetailBaseSnapshot(snapshot);
+  return snapshot;
 }
 
 function getFirestoreBaseUrl() {
@@ -540,12 +587,7 @@ export async function loadParentTeamDetail(
   options: { includeDeferredData?: boolean } = {}
 ): Promise<TeamDetailModel> {
   const includeDeferredData = options.includeDeferredData === true;
-  const [team, players, games, configs] = await Promise.all([
-    loadTeamDocument(teamId),
-    loadTeamPlayers(teamId),
-    loadTeamGames(teamId),
-    loadTeamConfigs(teamId)
-  ]);
+  const { team, players, games, configs } = await loadTeamDetailBaseSnapshot(teamId);
 
   if (!team) throw new Error('Team not found.');
 
@@ -588,12 +630,7 @@ export async function loadParentTeamDetail(
 }
 
 export async function loadTeamDetailInsights(teamId: string, user: AuthUser | null): Promise<TeamDetailInsightsPayload> {
-  const [team, players, games, configs] = await Promise.all([
-    loadTeamDocument(teamId),
-    loadTeamPlayers(teamId),
-    loadTeamGames(teamId),
-    loadTeamConfigs(teamId)
-  ]);
+  const { team, players, games, configs } = await loadTeamDetailBaseSnapshot(teamId);
 
   if (!team) throw new Error('Team not found.');
 
@@ -628,10 +665,7 @@ export async function loadTeamDetailSponsors(teamId: string): Promise<TeamDetail
 }
 
 export async function loadTeamStaffPermissions(teamId: string, user: AuthUser | null): Promise<TeamStaffPermissionsSummary | null> {
-  const [team, players] = await Promise.all([
-    loadTeamDocument(teamId),
-    loadTeamPlayers(teamId)
-  ]);
+  const { team, players } = await loadTeamDetailBaseSnapshot(teamId);
 
   if (!team || !hasFullTeamAccess(user, team)) return null;
 

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -212,6 +212,10 @@ export function __resetTeamDetailBaseSnapshotCacheForTests() {
   teamDetailBaseSnapshotCache.clear();
 }
 
+function invalidateTeamDetailBaseSnapshotCache(teamId: string) {
+  teamDetailBaseSnapshotCache.delete(cleanString(teamId));
+}
+
 function withTimeout<T>(promise: Promise<T>, label: string, timeoutMs = primaryDataTimeoutMs): Promise<T> {
   let timeoutId: number | undefined;
   const timeout = new Promise<T>((_, reject) => {
@@ -464,6 +468,7 @@ export async function grantScorekeeperAccessForApp(teamId: string, memberUserId:
   if (!normalizedTeamId) throw new Error('Team ID is required.');
   if (!normalizedUserId) throw new Error('Team member user ID is required.');
   await grantScorekeeperAccess(normalizedTeamId, normalizedUserId);
+  invalidateTeamDetailBaseSnapshotCache(normalizedTeamId);
 }
 
 export async function revokeScorekeeperAccessForApp(teamId: string, memberUserId: string) {
@@ -472,6 +477,7 @@ export async function revokeScorekeeperAccessForApp(teamId: string, memberUserId
   if (!normalizedTeamId) throw new Error('Team ID is required.');
   if (!normalizedUserId) throw new Error('Team member user ID is required.');
   await revokeScorekeeperAccess(normalizedTeamId, normalizedUserId);
+  invalidateTeamDetailBaseSnapshotCache(normalizedTeamId);
 }
 
 export async function grantVideographerAccessForApp(teamId: string, memberUserId: string) {
@@ -480,6 +486,7 @@ export async function grantVideographerAccessForApp(teamId: string, memberUserId
   if (!normalizedTeamId) throw new Error('Team ID is required.');
   if (!normalizedUserId) throw new Error('Team member user ID is required.');
   await grantVideographerAccess(normalizedTeamId, normalizedUserId);
+  invalidateTeamDetailBaseSnapshotCache(normalizedTeamId);
 }
 
 export async function revokeVideographerAccessForApp(teamId: string, memberUserId: string) {
@@ -488,6 +495,7 @@ export async function revokeVideographerAccessForApp(teamId: string, memberUserI
   if (!normalizedTeamId) throw new Error('Team ID is required.');
   if (!normalizedUserId) throw new Error('Team member user ID is required.');
   await revokeVideographerAccess(normalizedTeamId, normalizedUserId);
+  invalidateTeamDetailBaseSnapshotCache(normalizedTeamId);
 }
 
 export async function saveTeamScheduleNotificationsForApp(teamId: string, settings: Partial<TeamScheduleNotificationSettings>) {

--- a/tests/unit/app-team-detail-integration.test.jsx
+++ b/tests/unit/app-team-detail-integration.test.jsx
@@ -540,23 +540,28 @@ describe('React app TeamDetail page', () => {
     it('loads deferred insights and sponsors once, then reuses them across tab switches', async () => {
         const { container } = await renderTeamDetail();
 
+        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
         expect(teamDetailMocks.loadTeamDetailInsights).not.toHaveBeenCalled();
         expect(teamDetailMocks.loadTeamDetailSponsors).not.toHaveBeenCalled();
 
         await clickButton(container, 'Insights');
+        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
         expect(teamDetailMocks.loadTeamDetailInsights).toHaveBeenCalledTimes(1);
         expect(container.textContent).toContain('Bring ball');
 
         await clickButton(container, 'Overview');
         await clickButton(container, 'Insights');
+        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
         expect(teamDetailMocks.loadTeamDetailInsights).toHaveBeenCalledTimes(1);
 
         await clickButton(container, 'More');
+        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
         expect(teamDetailMocks.loadTeamDetailSponsors).toHaveBeenCalledTimes(1);
         expect(container.textContent).toContain('Pizza Place');
 
         await clickButton(container, 'Schedule');
         await clickButton(container, 'More');
+        expect(teamDetailMocks.loadParentTeamDetail).toHaveBeenCalledTimes(1);
         expect(teamDetailMocks.loadTeamDetailSponsors).toHaveBeenCalledTimes(1);
     });
 

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@capacitor/core', () => ({
     Capacitor: {
@@ -51,10 +51,15 @@ vi.mock('../../apps/app/src/lib/authService.ts', () => ({
     getNativeAuthIdToken: vi.fn()
 }));
 
-import { buildAdminAcceptInviteUrl, buildPublicTeamGamesIcsUrl, buildTeamDetailModel, canExposePublicFanFeed, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, loadTeamDetailInsights, loadTeamDetailSponsors, loadTeamStaffPermissions, revokeScorekeeperAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp } from '../../apps/app/src/lib/teamDetailService.ts';
+import { __resetTeamDetailBaseSnapshotCacheForTests, buildAdminAcceptInviteUrl, buildPublicTeamGamesIcsUrl, buildTeamDetailModel, canExposePublicFanFeed, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, loadTeamDetailInsights, loadTeamDetailSponsors, loadTeamStaffPermissions, revokeScorekeeperAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp } from '../../apps/app/src/lib/teamDetailService.ts';
 import { collection, getDocs, query, where } from '../../js/firebase.js';
 import { getAggregatedStatsForGames, getAdSpaceSponsors, getAllUsers, getConfigs, getEvents, getGames, getLocalAttractionSponsors, getPlayerTrackingStatuses, getPlayers, getPublicTrackingItems, getTeam, grantScorekeeperAccess, grantVideographerAccess, inviteAdmin, addTeamAdminEmail, revokeScorekeeperAccess, revokeVideographerAccess, updateEvent, updateGame, updateTeam } from '../../js/db.js';
 import { sendInviteEmail } from '../../js/auth.js';
+
+beforeEach(() => {
+    __resetTeamDetailBaseSnapshotCacheForTests();
+    vi.clearAllMocks();
+});
 
 describe('React app team detail model', () => {
 
@@ -470,6 +475,59 @@ describe('React app team detail model', () => {
         expect(parentModel.staffPermissions).toBeNull();
         expect(getDocs).not.toHaveBeenCalled();
         expect(getAllUsers).not.toHaveBeenCalled();
+    });
+
+    it('reuses the initial base snapshot for deferred insights and staff permissions', async () => {
+        getTeam.mockResolvedValue({
+            id: 'team-1',
+            name: 'Bears',
+            sport: 'Basketball',
+            ownerId: 'owner-1',
+            adminEmails: ['coach@example.com'],
+            teamPermissions: { videography: { mode: 'selected', memberIds: ['video-1'] } }
+        });
+        getPlayers.mockResolvedValue([{ id: 'player-1', name: 'Pat Star', photoUrl: 'https://img.example.test/player.png' }]);
+        getGames.mockResolvedValue([
+            { id: 'game-1', opponent: 'Falcons', date: new Date('2026-05-01T18:00:00Z'), status: 'completed', homeScore: 42, awayScore: 35, isHome: true }
+        ]);
+        getConfigs.mockResolvedValue([{
+            id: 'basketball',
+            name: 'Basketball',
+            columns: ['pts'],
+            statDefinitions: [{ id: 'pts', label: 'Points', acronym: 'PTS', topStat: true, visibility: 'public', scope: 'player' }]
+        }]);
+        getAggregatedStatsForGames.mockResolvedValue({ 'player-1': { pts: 88 } });
+        getPublicTrackingItems.mockResolvedValue([{ id: 'item-1', title: 'Bring ball', public: true }]);
+        getPlayerTrackingStatuses.mockResolvedValue([{ itemId: 'item-1', playerId: 'player-1', status: 'complete', public: true }]);
+        getAllUsers.mockResolvedValue([{ id: 'video-1', fullName: 'Video Parent', email: 'video@example.com', parentOf: [{ teamId: 'team-1', playerId: 'player-1' }] }]);
+        const future = Date.now() + 60_000;
+        getDocs.mockResolvedValue({
+            docs: [
+                { id: 'invite-1', data: () => ({ email: 'pending@example.com', teamId: 'team-1', type: 'admin_invite', used: false, expiresAt: { toMillis: () => future } }) }
+            ]
+        });
+
+        const user = { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'], parentOf: [{ teamId: 'team-1', playerId: 'player-1' }] };
+        await loadParentTeamDetail('team-1', user, { includeDeferredData: false });
+        const insights = await loadTeamDetailInsights('team-1', user);
+        const staffPermissions = await loadTeamStaffPermissions('team-1', user);
+        const sponsors = await loadTeamDetailSponsors('team-1');
+
+        expect(getTeam).toHaveBeenCalledTimes(1);
+        expect(getPlayers).toHaveBeenCalledTimes(1);
+        expect(getGames).toHaveBeenCalledTimes(1);
+        expect(getConfigs).toHaveBeenCalledTimes(1);
+        expect(getAggregatedStatsForGames).toHaveBeenCalledWith('team-1', ['game-1']);
+        expect(getPublicTrackingItems).toHaveBeenCalledWith('team-1');
+        expect(getPlayerTrackingStatuses).toHaveBeenCalledWith('team-1', ['player-1']);
+        expect(insights.leaderboards[0].leaders[0]).toMatchObject({ playerId: 'player-1', formattedValue: '88' });
+        expect(staffPermissions.pendingInvites).toEqual(['pending@example.com']);
+        expect(staffPermissions.videographerGrantTargets).toEqual([
+            { userId: 'video-1', name: 'Video Parent', email: 'video@example.com', playerNames: ['Pat Star'], isGranted: true }
+        ]);
+        expect(getLocalAttractionSponsors).toHaveBeenCalledWith('team-1');
+        expect(getAdSpaceSponsors).toHaveBeenCalledWith('team-1');
+        expect(sponsors.sponsors).toEqual([]);
     });
 
     it('loads deferred insights and sponsors only when requested', async () => {

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -128,6 +128,51 @@ describe('React app team detail model', () => {
         expect(grantVideographerAccess).not.toHaveBeenCalled();
     });
 
+    it('invalidates cached team detail snapshots after scorekeeper mutations so refreshed permissions reflect the write', async () => {
+        getTeam
+            .mockResolvedValueOnce({
+                id: 'team-1',
+                name: 'Bears',
+                ownerId: 'owner-1',
+                adminEmails: ['coach@example.com'],
+                teamPermissions: { scorekeeping: { mode: 'selected', memberIds: [] } }
+            })
+            .mockResolvedValueOnce({
+                id: 'team-1',
+                name: 'Bears',
+                ownerId: 'owner-1',
+                adminEmails: ['coach@example.com'],
+                teamPermissions: { scorekeeping: { mode: 'selected', memberIds: ['parent-1'] } }
+            });
+        getPlayers.mockResolvedValue([
+            {
+                id: 'player-1',
+                name: 'Pat Star',
+                parents: [{ userId: 'parent-1', name: 'Parent One', email: 'parent@example.com' }]
+            }
+        ]);
+        getGames.mockResolvedValue([]);
+        getConfigs.mockResolvedValue([]);
+        getAllUsers.mockResolvedValue([]);
+        getDocs.mockResolvedValue({ docs: [] });
+        grantScorekeeperAccess.mockResolvedValue(undefined);
+
+        const managerUser = { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] };
+
+        const beforeGrant = await loadTeamStaffPermissions('team-1', managerUser);
+        expect(beforeGrant.scorekeeperGrantTargets).toEqual([
+            { userId: 'parent-1', name: 'Parent One', email: 'parent@example.com', playerNames: ['Pat Star'], isGranted: false }
+        ]);
+
+        await grantScorekeeperAccessForApp('team-1', 'parent-1');
+
+        const afterGrant = await loadTeamStaffPermissions('team-1', managerUser);
+        expect(afterGrant.scorekeeperGrantTargets).toEqual([
+            { userId: 'parent-1', name: 'Parent One', email: 'parent@example.com', playerNames: ['Pat Star'], isGranted: true }
+        ]);
+        expect(getTeam).toHaveBeenCalledTimes(2);
+    });
+
     it('normalizes and saves team schedule reminder defaults with the legacy payload', async () => {
         updateTeam.mockResolvedValue(undefined);
         getEvents.mockResolvedValue([


### PR DESCRIPTION
Closes #1917

## What changed
- cached the initial Team Detail base snapshot of team, players, games, and configs inside `teamDetailService`
- updated deferred Insights and staff-permissions loaders to derive from that cached snapshot instead of re-fetching the same base data
- added a focused service regression test that proves the underlying base loaders only run once across initial load plus deferred tab hydration
- tightened the Team Detail page integration test to assert tab switches do not trigger another base page load

## Root Cause
Deferred Team Detail loaders were implemented as isolated entry points that rebuilt the same team, players, games, and configs snapshot already fetched for the page, so opening Insights or More repeated the base reads and reintroduced loading work.

## Prevention / Learning
When splitting route data into eager and deferred loaders, keep one cached base snapshot per page session and have deferred loaders compute from that shared snapshot instead of re-entering the same base fetch helpers.

## Regression Tests
- `npx vitest run tests/unit/app-team-detail-service.test.js tests/unit/app-team-detail-integration.test.jsx --reporter=verbose`
- `tests/unit/app-team-detail-service.test.js` now asserts initial Team Detail load plus deferred Insights and staff-permissions hydration only call `getTeam/getPlayers/getGames/getConfigs` once
- `tests/unit/app-team-detail-integration.test.jsx` now asserts switching Overview, Insights, and More does not re-run `loadParentTeamDetail`