### PR TITLE
Add season selection to athlete profile quick editor

### DIFF
--- a/apps/app/src/lib/playerService.test.ts
+++ b/apps/app/src/lib/playerService.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({
+  deleteAthleteProfileMediaByPath: vi.fn(),
+  getAggregatedStatsForPlayer: vi.fn(),
+  getGames: vi.fn(),
+  getPlayerPrivateProfile: vi.fn(),
+  getPlayerTrackingStatuses: vi.fn(),
+  getPlayers: vi.fn(),
+  getPublicTrackingItems: vi.fn(),
+  getTeam: vi.fn(),
+  inviteCoParentToAthlete: vi.fn(),
+  listAthleteProfilesForParent: vi.fn(),
+  listCertificatesForPlayer: vi.fn(),
+  saveAthleteProfile: vi.fn(),
+  updatePlayerProfile: vi.fn(),
+  uploadAthleteProfileMedia: vi.fn(),
+  uploadPlayerPhoto: vi.fn()
+}));
+
+vi.mock('../../../../js/db.js', () => dbMocks);
+vi.mock('../../../../js/parent-incentives.js', () => ({
+  calculateEarnings: vi.fn(),
+  getApplicableRulesForGame: vi.fn(),
+  getCapSetting: vi.fn(),
+  getIncentiveRules: vi.fn(),
+  getPaidGames: vi.fn(),
+  getStatOptionsForTeam: vi.fn(),
+  isCurrentRuleVersion: vi.fn(),
+  markGamePaid: vi.fn(),
+  retireIncentiveRule: vi.fn(),
+  saveCapSetting: vi.fn(),
+  saveIncentiveRule: vi.fn(),
+  toggleIncentiveRule: vi.fn()
+}));
+vi.mock('../../../../js/athlete-profile-utils.js', () => ({
+  buildAthleteProfileShareUrl: vi.fn(() => 'https://allplays.ai/athlete-profile.html?profileId=profile-1')
+}));
+vi.mock('../../../../js/player-profile-stats.js', () => ({
+  collectPlayerVideoClips: vi.fn(() => [])
+}));
+vi.mock('../../../../js/player-tracking-summary.js', () => ({
+  getVisiblePlayerTrackingSummary: vi.fn(() => [])
+}));
+vi.mock('./scheduleLogic', () => ({
+  getOpenScheduleAssignments: vi.fn(() => []),
+  normalizeRsvpResponse: vi.fn(() => 'not_responded')
+}));
+vi.mock('./scheduleService', () => ({
+  loadParentSchedule: vi.fn()
+}));
+
+import { saveParentAthleteProfileDraft } from './playerService';
+
+describe('saveParentAthleteProfileDraft', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMocks.saveAthleteProfile.mockResolvedValue({ id: 'profile-1' });
+  });
+
+  it('passes caller-provided selectedSeasonKeys to saveAthleteProfile', async () => {
+    await saveParentAthleteProfileDraft({
+      user: {
+        uid: 'parent-1',
+        parentOf: [
+          { teamId: 'team-current', playerId: 'player-current' },
+          { teamId: 'team-prior', playerId: 'player-prior' }
+        ]
+      } as any,
+      teamId: 'team-current',
+      playerId: 'player-current',
+      draft: {
+        athlete: { name: 'Sam Player', headline: '2028 Guard' },
+        bio: {},
+        privacy: 'public',
+        clips: [],
+        selectedSeasonKeys: ['team-current::player-current', 'team-prior::player-prior']
+      }
+    });
+
+    expect(dbMocks.saveAthleteProfile).toHaveBeenCalledWith(
+      'parent-1',
+      expect.objectContaining({
+        selectedSeasonKeys: ['team-current::player-current', 'team-prior::player-prior']
+      }),
+      { profileId: expect.any(String) }
+    );
+  });
+});

--- a/apps/app/src/lib/playerService.ts
+++ b/apps/app/src/lib/playerService.ts
@@ -73,6 +73,13 @@ export type ParentAthleteProfileData = {
   profile: Record<string, any> | null;
   shareUrl: string;
   builderUrl: string;
+  seasonOptions: Array<{
+    seasonKey: string;
+    teamId: string;
+    teamName: string;
+    playerId: string;
+    playerName: string;
+  }>;
 };
 
 export type ParentPlayerDetailData = {
@@ -198,6 +205,7 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
     }),
     athleteProfile: buildAthleteProfileData({
       profiles: Array.isArray(athleteProfiles) ? athleteProfiles : [],
+      parentLinks: Array.isArray(user.parentOf) ? user.parentOf : [],
       teamId: resolvedTeamId,
       playerId: resolvedPlayerId
     })
@@ -331,6 +339,9 @@ export async function saveParentAthleteProfileDraft({
 }) {
   assertLinkedParent(user, teamId, playerId);
   const seasonKey = buildParentSeasonKey(teamId, playerId);
+  const selectedSeasonKeys = Array.isArray(draft.selectedSeasonKeys) && draft.selectedSeasonKeys.length
+    ? draft.selectedSeasonKeys
+    : [seasonKey];
   const workingProfileId = profileId || createLocalId('profile');
   let uploadedProfilePhoto: Record<string, any> | null = null;
   let uploadedHighlightClip: Record<string, any> | null = null;
@@ -372,7 +383,7 @@ export async function saveParentAthleteProfileDraft({
       ...draft,
       profilePhoto,
       clips,
-      selectedSeasonKeys: [seasonKey]
+      selectedSeasonKeys
     }, { profileId: workingProfileId });
   } catch (error) {
     if (uploadedProfilePhoto?.storagePath) {
@@ -451,16 +462,45 @@ function buildPlayerIncentiveData({
   };
 }
 
-function buildAthleteProfileData({ profiles, teamId, playerId }: { profiles: Array<Record<string, any>>; teamId: string; playerId: string }): ParentAthleteProfileData {
+function buildAthleteProfileData({
+  profiles,
+  parentLinks,
+  teamId,
+  playerId
+}: {
+  profiles: Array<Record<string, any>>;
+  parentLinks: Array<Record<string, any>>;
+  teamId: string;
+  playerId: string;
+}): ParentAthleteProfileData {
   const profile = profiles.find((candidate) => (
     Array.isArray(candidate?.seasons) &&
     candidate.seasons.some((season: any) => season?.teamId === teamId && season?.playerId === playerId)
   )) || null;
   const profileId = profile?.id || '';
+  const seen = new Set<string>();
+  const seasonOptions = (Array.isArray(parentLinks) ? parentLinks : [])
+    .map((link) => {
+      const optionTeamId = String(link?.teamId || '').trim();
+      const optionPlayerId = String(link?.playerId || link?.childId || '').trim();
+      if (!optionTeamId || !optionPlayerId) return null;
+      const seasonKey = buildParentSeasonKey(optionTeamId, optionPlayerId);
+      if (seen.has(seasonKey)) return null;
+      seen.add(seasonKey);
+      return {
+        seasonKey,
+        teamId: optionTeamId,
+        teamName: String(link?.teamName || '').trim() || 'Team',
+        playerId: optionPlayerId,
+        playerName: String(link?.playerName || link?.childName || link?.name || '').trim() || 'Athlete'
+      };
+    })
+    .filter(Boolean) as ParentAthleteProfileData['seasonOptions'];
   return {
     profile,
     shareUrl: profileId ? buildAthleteProfileShareUrl(getLegacyOrigin(), profileId) : '',
-    builderUrl: buildLegacyUrl('athlete-profile-builder.html', { teamId, playerId, ...(profileId ? { profileId } : {}) })
+    builderUrl: buildLegacyUrl('athlete-profile-builder.html', { teamId, playerId, ...(profileId ? { profileId } : {}) }),
+    seasonOptions
   };
 }
 

--- a/apps/app/src/pages/PlayerDetail.test.tsx
+++ b/apps/app/src/pages/PlayerDetail.test.tsx
@@ -1,0 +1,201 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const playerServiceMocks = vi.hoisted(() => ({
+  loadParentPlayerDetail: vi.fn(),
+  markParentPlayerIncentivePaid: vi.fn(),
+  retireParentPlayerIncentiveRule: vi.fn(),
+  saveParentAthleteProfileDraft: vi.fn(),
+  saveParentPlayerIncentiveCap: vi.fn(),
+  saveParentPlayerIncentiveRule: vi.fn(),
+  sendParentCoParentInvite: vi.fn(),
+  toggleParentPlayerIncentiveRule: vi.fn(),
+  updateParentPlayerEditableProfile: vi.fn()
+}));
+
+vi.mock('../lib/playerService', () => playerServiceMocks);
+
+import { PlayerDetail } from './PlayerDetail';
+import type { AuthState } from '../lib/types';
+
+const auth: AuthState = {
+  user: {
+    uid: 'parent-1',
+    email: 'parent@example.com',
+    displayName: 'Pat Parent',
+    parentOf: [
+      { teamId: 'team-current', teamName: 'Current Team', playerId: 'player-current', playerName: 'Sam Player' },
+      { teamId: 'team-prior', teamName: 'Prior Team', playerId: 'player-prior', playerName: 'Sam Player' }
+    ]
+  } as any,
+  profile: null,
+  loading: false,
+  error: null,
+  roles: ['parent'],
+  isParent: true,
+  isCoach: false,
+  isAdmin: false,
+  isPlatformAdmin: false,
+  refresh: vi.fn(),
+  signOut: vi.fn()
+};
+
+function buildDetailData(overrides: Record<string, any> = {}) {
+  return {
+    child: {
+      teamId: 'team-current',
+      teamName: 'Current Team',
+      playerId: 'player-current',
+      playerName: 'Sam Player'
+    },
+    player: {
+      id: 'player-current',
+      teamId: 'team-current',
+      teamName: 'Current Team',
+      name: 'Sam Player',
+      number: '12',
+      photoUrl: ''
+    },
+    team: { id: 'team-current', name: 'Current Team' },
+    events: [],
+    nextEvent: null,
+    actionCounts: {
+      rsvpNeeded: 0,
+      packetsReady: 0,
+      openAssignments: 0
+    },
+    statRows: [],
+    clips: [],
+    certificates: [],
+    trackingSummary: [],
+    privateProfile: null,
+    incentives: {
+      rules: [],
+      currentRules: [],
+      statOptions: [],
+      maxPerGameCents: null,
+      seasonGameEarnings: [],
+      totalEarnedCents: 0,
+      totalPaidCents: 0,
+      unpaidCents: 0
+    },
+    athleteProfile: {
+      profile: null,
+      shareUrl: '',
+      builderUrl: 'https://allplays.ai/athlete-profile-builder.html?teamId=team-current&playerId=player-current',
+      seasonOptions: [
+        {
+          seasonKey: 'team-current::player-current',
+          teamId: 'team-current',
+          teamName: 'Current Team',
+          playerId: 'player-current',
+          playerName: 'Sam Player'
+        },
+        {
+          seasonKey: 'team-prior::player-prior',
+          teamId: 'team-prior',
+          teamName: 'Prior Team',
+          playerId: 'player-prior',
+          playerName: 'Sam Player'
+        }
+      ]
+    },
+    ...overrides
+  };
+}
+
+function renderPlayerDetail() {
+  return render(
+    <MemoryRouter initialEntries={['/players/team-current/player-current']}>
+      <Routes>
+        <Route path="/players/:teamId/:playerId" element={<PlayerDetail auth={auth} />} />
+        <Route path="/home" element={<div>Home</div>} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+describe('PlayerDetail athlete profile season selection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    playerServiceMocks.loadParentPlayerDetail.mockResolvedValue(buildDetailData());
+    playerServiceMocks.saveParentAthleteProfileDraft.mockResolvedValue({
+      shareUrl: 'https://allplays.ai/athlete-profile.html?profileId=profile-1'
+    });
+    window.scrollTo = vi.fn();
+    window.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
+      callback(0);
+      return 0;
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('preselects existing saved seasons and passes updated selections on save', async () => {
+    playerServiceMocks.loadParentPlayerDetail.mockResolvedValue(buildDetailData({
+      athleteProfile: {
+        profile: {
+          id: 'profile-1',
+          athlete: { name: 'Sam Player' },
+          bio: {},
+          privacy: 'public',
+          clips: [],
+          seasons: [
+            { seasonKey: 'team-current::player-current', teamName: 'Current Team', playerName: 'Sam Player' },
+            { seasonKey: 'team-prior::player-prior', teamName: 'Prior Team', playerName: 'Sam Player' }
+          ]
+        },
+        shareUrl: 'https://allplays.ai/athlete-profile.html?profileId=profile-1',
+        builderUrl: 'https://allplays.ai/athlete-profile-builder.html?teamId=team-current&playerId=player-current&profileId=profile-1',
+        seasonOptions: buildDetailData().athleteProfile.seasonOptions
+      }
+    }));
+
+    renderPlayerDetail();
+
+    await screen.findByText('Sam Player');
+    fireEvent.click(screen.getByRole('button', { name: 'Profile' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Athlete Profile' }));
+    await screen.findByText('Athlete Profile Builder');
+
+    const currentSeason = await screen.findByLabelText('Sam Player Current Team');
+    const priorSeason = screen.getByLabelText('Sam Player Prior Team');
+    expect((currentSeason as HTMLInputElement).checked).toBe(true);
+    expect((priorSeason as HTMLInputElement).checked).toBe(true);
+
+    fireEvent.click(currentSeason);
+    fireEvent.click(screen.getByRole('button', { name: 'Save Athlete Profile' }));
+
+    await waitFor(() => {
+      expect(playerServiceMocks.saveParentAthleteProfileDraft).toHaveBeenCalledWith(expect.objectContaining({
+        draft: expect.objectContaining({
+          selectedSeasonKeys: ['team-prior::player-prior']
+        })
+      }));
+    });
+  });
+
+  it('defaults first save to the current season and blocks zero-season saves', async () => {
+    renderPlayerDetail();
+
+    await screen.findByText('Sam Player');
+    fireEvent.click(screen.getByRole('button', { name: 'Profile' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Athlete Profile' }));
+    await screen.findByText('Athlete Profile Builder');
+
+    const currentSeason = await screen.findByLabelText('Sam Player Current Team');
+    const priorSeason = screen.getByLabelText('Sam Player Prior Team');
+    expect((currentSeason as HTMLInputElement).checked).toBe(true);
+    expect((priorSeason as HTMLInputElement).checked).toBe(false);
+
+    fireEvent.click(currentSeason);
+    fireEvent.click(screen.getByRole('button', { name: 'Save Athlete Profile' }));
+
+    expect(await screen.findByText('Select at least one linked season to build an athlete profile.')).toBeTruthy();
+    expect(playerServiceMocks.saveParentAthleteProfileDraft).not.toHaveBeenCalled();
+  });
+});

--- a/apps/app/src/pages/PlayerDetail.test.tsx
+++ b/apps/app/src/pages/PlayerDetail.test.tsx
@@ -199,6 +199,49 @@ describe('PlayerDetail athlete profile season selection', () => {
     expect(playerServiceMocks.saveParentAthleteProfileDraft).not.toHaveBeenCalled();
   });
 
+  it('preselects saved seasons from older profile shapes without seasonKey', async () => {
+    playerServiceMocks.loadParentPlayerDetail.mockResolvedValue(buildDetailData({
+      athleteProfile: {
+        profile: {
+          id: 'profile-legacy',
+          athlete: { name: 'Sam Player' },
+          bio: {},
+          privacy: 'public',
+          clips: [],
+          seasons: [
+            { teamId: 'team-current', playerId: 'player-current', teamName: 'Current Team', playerName: 'Sam Player' },
+            { teamId: 'team-prior', playerId: 'player-prior', teamName: 'Prior Team', playerName: 'Sam Player' }
+          ]
+        },
+        shareUrl: 'https://allplays.ai/athlete-profile.html?profileId=profile-legacy',
+        builderUrl: 'https://allplays.ai/athlete-profile-builder.html?teamId=team-current&playerId=player-current&profileId=profile-legacy',
+        seasonOptions: buildDetailData().athleteProfile.seasonOptions
+      }
+    }));
+
+    renderPlayerDetail();
+
+    await screen.findByText('Sam Player');
+    fireEvent.click(screen.getByRole('button', { name: 'Profile' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Athlete Profile' }));
+    await screen.findByText('Athlete Profile Builder');
+
+    const currentSeason = await screen.findByLabelText('Sam Player Current Team');
+    const priorSeason = screen.getByLabelText('Sam Player Prior Team');
+    expect((currentSeason as HTMLInputElement).checked).toBe(true);
+    expect((priorSeason as HTMLInputElement).checked).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Athlete Profile' }));
+
+    await waitFor(() => {
+      expect(playerServiceMocks.saveParentAthleteProfileDraft).toHaveBeenCalledWith(expect.objectContaining({
+        draft: expect.objectContaining({
+          selectedSeasonKeys: ['team-current::player-current', 'team-prior::player-prior']
+        })
+      }));
+    });
+  });
+
   it('falls back to the current linked season when season options are missing', async () => {
     playerServiceMocks.loadParentPlayerDetail.mockResolvedValue(buildDetailData({
       athleteProfile: {

--- a/apps/app/src/pages/PlayerDetail.test.tsx
+++ b/apps/app/src/pages/PlayerDetail.test.tsx
@@ -198,4 +198,41 @@ describe('PlayerDetail athlete profile season selection', () => {
     expect(await screen.findByText('Select at least one linked season to build an athlete profile.')).toBeTruthy();
     expect(playerServiceMocks.saveParentAthleteProfileDraft).not.toHaveBeenCalled();
   });
+
+  it('falls back to the current linked season when season options are missing', async () => {
+    playerServiceMocks.loadParentPlayerDetail.mockResolvedValue(buildDetailData({
+      athleteProfile: {
+        profile: {
+          id: 'profile-1',
+          athlete: { name: 'Sam Player' },
+          bio: {},
+          privacy: 'public',
+          clips: [],
+          seasons: [{ teamId: 'team-current', playerId: 'player-current' }]
+        },
+        shareUrl: 'https://allplays.ai/athlete-profile.html?profileId=profile-1',
+        builderUrl: 'https://allplays.ai/athlete-profile-builder.html?teamId=team-current&playerId=player-current&profileId=profile-1'
+      }
+    }));
+
+    renderPlayerDetail();
+
+    await screen.findByText('Sam Player');
+    fireEvent.click(screen.getByRole('button', { name: 'Profile' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Athlete Profile' }));
+    await screen.findByText('Athlete Profile Builder');
+
+    const fallbackSeason = await screen.findByLabelText('Sam Player Current Team');
+    expect((fallbackSeason as HTMLInputElement).checked).toBe(true);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save Athlete Profile' }));
+
+    await waitFor(() => {
+      expect(playerServiceMocks.saveParentAthleteProfileDraft).toHaveBeenCalledWith(expect.objectContaining({
+        draft: expect.objectContaining({
+          selectedSeasonKeys: ['team-current::player-current']
+        })
+      }));
+    });
+  });
 });

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -526,8 +526,22 @@ function EditablePlayerProfileCard({ data, auth, onChanged }: { data: ParentPlay
 
 function AthleteProfileBuilderCard({ data, auth, onChanged }: { data: ParentPlayerDetailData; auth: AuthState; onChanged: () => Promise<void> }) {
   const existing = data.athleteProfile.profile;
-  const seasonOptions = data.athleteProfile.seasonOptions;
   const currentSeasonKey = `${data.child.teamId || ''}::${data.child.playerId || ''}`;
+  const seasonOptions = useMemo(() => {
+    if (Array.isArray(data.athleteProfile.seasonOptions) && data.athleteProfile.seasonOptions.length) {
+      return data.athleteProfile.seasonOptions;
+    }
+    if (!data.child.teamId || !data.child.playerId) {
+      return [];
+    }
+    return [{
+      seasonKey: currentSeasonKey,
+      teamId: data.child.teamId,
+      teamName: data.child.teamName || data.team?.name || 'Team',
+      playerId: data.child.playerId,
+      playerName: data.child.playerName || data.player.name || 'Athlete'
+    }];
+  }, [currentSeasonKey, data.athleteProfile.seasonOptions, data.child.playerId, data.child.playerName, data.child.teamId, data.child.teamName, data.player.name, data.team?.name]);
   const initialSelectedSeasonKeys = useMemo(() => {
     const existingKeys = Array.isArray(existing?.seasons)
       ? existing.seasons

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -545,7 +545,15 @@ function AthleteProfileBuilderCard({ data, auth, onChanged }: { data: ParentPlay
   const initialSelectedSeasonKeys = useMemo(() => {
     const existingKeys = Array.isArray(existing?.seasons)
       ? existing.seasons
-        .map((season: any) => String(season?.seasonKey || '').trim())
+        .map((season: any) => {
+          const seasonKey = String(season?.seasonKey || '').trim();
+          if (seasonKey) {
+            return seasonKey;
+          }
+          const seasonTeamId = String(season?.teamId || '').trim();
+          const seasonPlayerId = String(season?.playerId || '').trim();
+          return seasonTeamId && seasonPlayerId ? `${seasonTeamId}::${seasonPlayerId}` : '';
+        })
         .filter(Boolean)
       : [];
     if (existingKeys.length) {

--- a/apps/app/src/pages/PlayerDetail.tsx
+++ b/apps/app/src/pages/PlayerDetail.tsx
@@ -526,6 +526,19 @@ function EditablePlayerProfileCard({ data, auth, onChanged }: { data: ParentPlay
 
 function AthleteProfileBuilderCard({ data, auth, onChanged }: { data: ParentPlayerDetailData; auth: AuthState; onChanged: () => Promise<void> }) {
   const existing = data.athleteProfile.profile;
+  const seasonOptions = data.athleteProfile.seasonOptions;
+  const currentSeasonKey = `${data.child.teamId || ''}::${data.child.playerId || ''}`;
+  const initialSelectedSeasonKeys = useMemo(() => {
+    const existingKeys = Array.isArray(existing?.seasons)
+      ? existing.seasons
+        .map((season: any) => String(season?.seasonKey || '').trim())
+        .filter(Boolean)
+      : [];
+    if (existingKeys.length) {
+      return [...new Set(existingKeys)];
+    }
+    return currentSeasonKey ? [currentSeasonKey] : [];
+  }, [currentSeasonKey, existing]);
   const [name, setName] = useState(existing?.athlete?.name || data.player.name || data.child.playerName || '');
   const [headline, setHeadline] = useState(existing?.athlete?.headline || '');
   const [position, setPosition] = useState(existing?.bio?.position || '');
@@ -534,6 +547,7 @@ function AthleteProfileBuilderCard({ data, auth, onChanged }: { data: ParentPlay
   const [dominantHand, setDominantHand] = useState(existing?.bio?.dominantHand || '');
   const [achievements, setAchievements] = useState(existing?.bio?.achievements || '');
   const [privacy, setPrivacy] = useState(existing?.privacy === 'public' ? 'public' : 'private');
+  const [selectedSeasonKeys, setSelectedSeasonKeys] = useState<string[]>(initialSelectedSeasonKeys);
   const [saving, setSaving] = useState(false);
   const [status, setStatus] = useState<{ tone: 'error' | 'success'; message: string } | null>(null);
   const [shareUrl, setShareUrl] = useState(data.athleteProfile.shareUrl || '');
@@ -559,9 +573,25 @@ function AthleteProfileBuilderCard({ data, auth, onChanged }: { data: ParentPlay
     };
   }, [headshotPreviewUrl]);
 
+  useEffect(() => {
+    setSelectedSeasonKeys(initialSelectedSeasonKeys);
+  }, [initialSelectedSeasonKeys]);
+
+  const toggleSeasonKey = (seasonKey: string) => {
+    setSelectedSeasonKeys((current) => (
+      current.includes(seasonKey)
+        ? current.filter((key) => key !== seasonKey)
+        : [...current, seasonKey]
+    ));
+  };
+
   const submit = async (event: FormEvent) => {
     event.preventDefault();
     if (headshotError || highlightClipError) return;
+    if (!selectedSeasonKeys.length) {
+      setStatus({ tone: 'error', message: 'Select at least one linked season to build an athlete profile.' });
+      return;
+    }
     setSaving(true);
     setStatus(null);
     try {
@@ -574,6 +604,7 @@ function AthleteProfileBuilderCard({ data, auth, onChanged }: { data: ParentPlay
           athlete: { name, headline },
           bio: { position, graduationYear, hometown, dominantHand, achievements },
           privacy,
+          selectedSeasonKeys,
           clips: existing?.clips || [],
           profilePhoto: existing?.profilePhotoUrl ? {
             url: existing.profilePhotoUrl,
@@ -731,6 +762,30 @@ function AthleteProfileBuilderCard({ data, auth, onChanged }: { data: ParentPlay
             placeholder="Captains, honors, goals, recruiting notes"
           />
         </label>
+        <div className="rounded-2xl border border-gray-200 bg-white p-3">
+          <div className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Selected seasons</div>
+          <p className="mt-1 text-sm font-semibold text-gray-700">Choose which linked seasons roll into the public athlete profile.</p>
+          <div className="mt-3 space-y-2">
+            {seasonOptions.map((option) => {
+              const checked = selectedSeasonKeys.includes(option.seasonKey);
+              return (
+                <label key={option.seasonKey} className={`flex items-start gap-3 rounded-xl border p-3 ${checked ? 'border-primary-300 bg-primary-50' : 'border-gray-200 bg-gray-50'}`}>
+                  <input
+                    type="checkbox"
+                    aria-label={`${option.playerName} ${option.teamName}`}
+                    checked={checked}
+                    onChange={() => toggleSeasonKey(option.seasonKey)}
+                    className="mt-1 h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500"
+                  />
+                  <span className="min-w-0">
+                    <span className="block text-sm font-black text-gray-900">{option.playerName}</span>
+                    <span className="block text-xs font-semibold text-gray-500">{option.teamName}</span>
+                  </span>
+                </label>
+              );
+            })}
+          </div>
+        </div>
         <div className="athlete-profile-privacy grid grid-cols-2 gap-2">
           {(['private', 'public'] as const).map((option) => (
             <button


### PR DESCRIPTION
Closes #1891

## What changed
- added linked-season selection UI inside the PlayerDetail athlete profile quick editor so parents can choose which seasons roll into the public athlete profile
- preselected saved seasons when editing an existing profile and defaulted first-time saves to the current season
- blocked saves with zero selected seasons and surfaced the same validation message used by the legacy flow
- extended playerService to expose season options to the card and to pass caller-provided `selectedSeasonKeys` through to `saveAthleteProfile` instead of overwriting them
- added focused regression tests for payload pass-through, default selection, saved selection hydration, and zero-selection validation

## Root Cause
The React quick editor regressed the legacy flow in two places: it never collected season selection from the UI, and `saveParentAthleteProfileDraft` always replaced the payload with `selectedSeasonKeys: [currentSeasonKey]`. That made every save collapse back to a single hardcoded season even though the backend already supported multi-season profiles.

## Prevention / Learning
When a new app screen narrows an existing workflow, preserve all backend-significant inputs instead of silently hardcoding defaults in the client. For parity migrations, add a focused regression test around every derived save payload field that existed in the legacy flow, especially when the backend already supports broader behavior.

## Regression Tests
- `npx vitest run apps/app/src/lib/playerService.test.ts apps/app/src/pages/PlayerDetail.test.tsx --reporter=verbose`
- verifies `saveParentAthleteProfileDraft` preserves caller-selected `selectedSeasonKeys`
- verifies the quick editor hydrates saved season selections, defaults first saves to the current season, and refuses zero-season saves

## Recurrence Risk
Low. The exact regression path is now covered at both the service payload layer and the PlayerDetail UI layer, which makes future hardcoding or missing-selection regressions much easier to catch.