### PR TITLE
Use native calendar export in schedule event detail

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -35,10 +35,16 @@ const scheduleServiceMocks = vi.hoisted(() => ({
 }));
 
 vi.mock('../lib/scheduleService', () => scheduleServiceMocks);
+const publicActionMocks = vi.hoisted(() => ({
+  exportCalendarIcsFile: vi.fn(),
+  openPublicUrl: vi.fn(),
+  sharePublicUrl: vi.fn()
+}));
+
 vi.mock('../lib/gameReportService', () => ({ loadGameReportSections: vi.fn() }));
-vi.mock('../lib/publicActions', () => ({ openPublicUrl: vi.fn(), sharePublicUrl: vi.fn() }));
+vi.mock('../lib/publicActions', () => publicActionMocks);
 vi.mock('../lib/liveGameAnnouncer', () => ({ useLiveGameAnnouncer: vi.fn() }));
-vi.mock('../lib/parentToolsService', () => ({ buildParentScheduleEventIcs: vi.fn(() => 'BEGIN:VCALENDAR'), downloadIcs: vi.fn() }));
+vi.mock('../lib/parentToolsService', () => ({ buildParentScheduleEventIcs: vi.fn(() => 'BEGIN:VCALENDAR') }));
 vi.mock('../lib/scheduleHub', () => ({
   buildGameHubDestinations: vi.fn(() => []),
   buildPracticeHubDestinations: vi.fn(() => []),
@@ -122,6 +128,46 @@ describe('ScheduleEventDetail assignments', () => {
     cleanup();
   });
 
+  it('uses native-aware calendar export messaging for shared, downloaded, and failed event exports', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent()],
+      children: []
+    });
+    publicActionMocks.exportCalendarIcsFile.mockResolvedValueOnce('shared');
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Add to Calendar' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add to Calendar' }));
+
+    await waitFor(() => {
+      expect(publicActionMocks.exportCalendarIcsFile).toHaveBeenCalledWith(
+        'Bears-vs. Wolves-2026-06-04.ics',
+        'BEGIN:VCALENDAR'
+      );
+    });
+    await waitFor(() => {
+      expect(screen.getByText('Calendar file ready to share.')).toBeTruthy();
+    });
+
+    publicActionMocks.exportCalendarIcsFile.mockResolvedValueOnce('downloaded');
+    fireEvent.click(screen.getByRole('button', { name: 'Add to Calendar' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Add to Calendar download started.')).toBeTruthy();
+    });
+
+    publicActionMocks.exportCalendarIcsFile.mockRejectedValueOnce(new Error('Sharing is not available on this device. Try the Apple or Google calendar links instead.'));
+    fireEvent.click(screen.getByRole('button', { name: 'Add to Calendar' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Sharing is not available on this device. Try the Apple or Google calendar links instead.')).toBeTruthy();
+    });
+  });
+
   it('refreshes assignment cards after claim and release actions mutate the loaded array in place', async () => {
     const assignments = [
       { role: 'Snacks', value: '', claimable: true, claim: null },
@@ -148,10 +194,10 @@ describe('ScheduleEventDetail assignments', () => {
     renderScheduleEventDetail();
 
     await waitFor(() => {
-      expect(screen.getByRole('button', { name: 'Assignments' })).toBeTruthy();
+      expect(screen.getAllByRole('button', { name: 'Assignments' }).length).toBeGreaterThan(0);
     });
 
-    fireEvent.click(screen.getByRole('button', { name: 'Assignments' }));
+    fireEvent.click(screen.getAllByRole('button', { name: 'Assignments' })[0]);
 
     await waitFor(() => {
       expect(screen.getByText('4 posted · 1 open')).toBeTruthy();
@@ -200,7 +246,7 @@ describe('ScheduleEventDetail staff RSVP overrides', () => {
 
   it('renders staff breakdown controls and refreshes counts after an override', async () => {
     scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
-      events: [buildEvent()],
+      events: [buildEvent({ isTeamAdmin: true })],
       children: []
     });
     scheduleServiceMocks.loadStaffScheduleRsvpBreakdown

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -41,9 +41,9 @@ import {
 } from '../lib/scheduleService';
 import { LINEUP_FORMATIONS, getLineupPublishStatus, hasLineupDraft } from '../lib/gameDayLineupPublish';
 import { loadGameReportSections, type GameReportData, type GameReportInsight, type GameReportPlay, type GameReportPlayerRow } from '../lib/gameReportService';
-import { openPublicUrl, sharePublicUrl } from '../lib/publicActions';
+import { exportCalendarIcsFile, openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 import { useLiveGameAnnouncer } from '../lib/liveGameAnnouncer';
-import { buildParentScheduleEventIcs, downloadIcs } from '../lib/parentToolsService';
+import { buildParentScheduleEventIcs } from '../lib/parentToolsService';
 import {
   buildGameHubDestinations,
   buildPracticeHubDestinations,
@@ -415,15 +415,21 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   const attentionItems = getAttentionItems(selectedEvent, rsvp).filter((item) => item.section !== 'availability' && item.title !== 'Practice packet ready');
   const sections = getEventDetailSections(selectedEvent);
 
-  const addEventToCalendar = () => {
+  const addEventToCalendar = async () => {
     const icsTitle = `${title} | ${selectedEvent.teamName}`;
     const fileDate = selectedEvent.date.toISOString().slice(0, 10);
-    downloadIcs(
-      `${selectedEvent.teamName}-${title}-${fileDate}.ics`,
-      buildParentScheduleEventIcs(selectedEvent, icsTitle)
-    );
+    const filename = `${selectedEvent.teamName}-${title}-${fileDate}.ics`;
     setError(null);
-    setStatusMessage('Add to Calendar download started.');
+    setStatusMessage(null);
+    try {
+      const result = await exportCalendarIcsFile(
+        filename,
+        buildParentScheduleEventIcs(selectedEvent, icsTitle)
+      );
+      setStatusMessage(result === 'shared' ? 'Calendar file ready to share.' : 'Add to Calendar download started.');
+    } catch (calendarError: any) {
+      setError(calendarError?.message || 'Unable to export the calendar file. Try again or use another calendar option.');
+    }
   };
 
   return (

--- a/tests/unit/app-schedule-event-detail-add-to-calendar.test.tsx
+++ b/tests/unit/app-schedule-event-detail-add-to-calendar.test.tsx
@@ -9,14 +9,17 @@ describe('React app schedule event detail add-to-calendar coverage', () => {
     it('keeps the add-to-calendar CTA in the root unit suite', () => {
         const source = readScheduleEventDetailSource();
 
-        expect(source).toContain("import { buildParentScheduleEventIcs, downloadIcs } from '../lib/parentToolsService';");
-        expect(source).toContain('const addEventToCalendar = () => {');
+        expect(source).toContain("import { exportCalendarIcsFile, openPublicUrl, sharePublicUrl } from '../lib/publicActions';");
+        expect(source).toContain("import { buildParentScheduleEventIcs } from '../lib/parentToolsService';");
+        expect(source).toContain('const addEventToCalendar = async () => {');
         expect(source).toContain('const icsTitle = `${title} | ${selectedEvent.teamName}`;');
         expect(source).toContain("const fileDate = selectedEvent.date.toISOString().slice(0, 10);");
-        expect(source).toContain('downloadIcs(');
-        expect(source).toContain('`${selectedEvent.teamName}-${title}-${fileDate}.ics`,');
+        expect(source).toContain('const filename = `${selectedEvent.teamName}-${title}-${fileDate}.ics`;');
+        expect(source).toContain('const result = await exportCalendarIcsFile(');
+        expect(source).toContain('filename,');
         expect(source).toContain('buildParentScheduleEventIcs(selectedEvent, icsTitle)');
-        expect(source).toContain("setStatusMessage('Add to Calendar download started.');");
+        expect(source).toContain("setStatusMessage(result === 'shared' ? 'Calendar file ready to share.' : 'Add to Calendar download started.');");
+        expect(source).toContain("setError(calendarError?.message || 'Unable to export the calendar file. Try again or use another calendar option.');");
         expect(source).toContain('className="secondary-button event-calendar-button mt-1.5 w-full justify-center sm:mt-2"');
         expect(source).toContain('onClick={addEventToCalendar}');
         expect(source).toContain('Add to Calendar');


### PR DESCRIPTION
Closes #1890

## What changed
- switched `ScheduleEventDetail` from legacy `downloadIcs(...)` to `exportCalendarIcsFile(...)`
- made the Add to Calendar action await the helper result and show mobile-aware success copy for `shared` vs web fallback `downloaded`
- added explicit export failure handling with actionable error text
- updated focused Schedule event detail tests to lock in the helper call, filename, success messaging, and failure messaging

## Root Cause
`ScheduleEventDetail` was bypassing the app's native-aware calendar export helper and calling the browser-only `downloadIcs(...)` path directly. That prevented Capacitor builds from using the existing Filesystem + Share handoff already implemented in `publicActions.ts`.

## Prevention / Learning
When a route exports or shares user-facing files, it should use the shared platform-aware helper instead of wiring a browser fallback directly in the page component. Adjacent route tests should assert both the helper invocation and the user-visible result text so web-only regressions do not slip back into mobile flows.

## Regression Tests
- `npx vitest run apps/app/src/pages/ScheduleEventDetail.test.tsx tests/unit/app-schedule-event-detail-add-to-calendar.test.tsx tests/unit/app-public-actions.test.js --reporter=verbose`
- component coverage now verifies `shared`, `downloaded`, and failed Add to Calendar flows from `ScheduleEventDetail`
- source inspection coverage now locks the route to `exportCalendarIcsFile(...)` instead of `downloadIcs(...)`