### PR TITLE
Route profile invites to the app accept flow

### DIFF
--- a/apps/app/src/lib/inviteUrls.ts
+++ b/apps/app/src/lib/inviteUrls.ts
@@ -11,14 +11,17 @@ export function buildAppAcceptInviteUrl(code: string, inviteType?: string | null
         return '';
     }
 
+    const normalizedType = String(inviteType || '').trim().toLowerCase();
+    if (!normalizedType) {
+        const signupUrl = new URL('/login.html', baseUrl);
+        signupUrl.searchParams.set('code', inviteCode);
+        return signupUrl.toString();
+    }
+
     const url = new URL('/app', baseUrl);
     const searchParams = new URLSearchParams();
     searchParams.set('code', inviteCode);
-
-    const normalizedType = String(inviteType || '').trim().toLowerCase();
-    if (normalizedType) {
-        searchParams.set('type', normalizedType);
-    }
+    searchParams.set('type', normalizedType);
 
     url.hash = `/accept-invite?${searchParams.toString()}`;
     return url.toString();

--- a/apps/app/src/lib/inviteUrls.ts
+++ b/apps/app/src/lib/inviteUrls.ts
@@ -1,0 +1,25 @@
+function getPublicBaseUrl() {
+    if (typeof window !== 'undefined' && /^https?:$/i.test(window.location.protocol)) {
+        return window.location.origin;
+    }
+    return 'https://allplays.ai';
+}
+
+export function buildAppAcceptInviteUrl(code: string, inviteType?: string | null, baseUrl = getPublicBaseUrl()) {
+    const inviteCode = String(code || '').trim().toUpperCase();
+    if (!inviteCode) {
+        return '';
+    }
+
+    const url = new URL('/app', baseUrl);
+    const searchParams = new URLSearchParams();
+    searchParams.set('code', inviteCode);
+
+    const normalizedType = String(inviteType || '').trim().toLowerCase();
+    if (normalizedType) {
+        searchParams.set('type', normalizedType);
+    }
+
+    url.hash = `/accept-invite?${searchParams.toString()}`;
+    return url.toString();
+}

--- a/apps/app/src/lib/inviteUrls.ts
+++ b/apps/app/src/lib/inviteUrls.ts
@@ -11,17 +11,13 @@ export function buildAppAcceptInviteUrl(code: string, inviteType?: string | null
         return '';
     }
 
-    const normalizedType = String(inviteType || '').trim().toLowerCase();
-    if (!normalizedType) {
-        const signupUrl = new URL('/login.html', baseUrl);
-        signupUrl.searchParams.set('code', inviteCode);
-        return signupUrl.toString();
-    }
-
     const url = new URL('/app', baseUrl);
     const searchParams = new URLSearchParams();
     searchParams.set('code', inviteCode);
-    searchParams.set('type', normalizedType);
+    const normalizedType = String(inviteType || '').trim().toLowerCase();
+    if (normalizedType) {
+        searchParams.set('type', normalizedType);
+    }
 
     url.hash = `/accept-invite?${searchParams.toString()}`;
     return url.toString();

--- a/apps/app/src/lib/profileService.ts
+++ b/apps/app/src/lib/profileService.ts
@@ -59,6 +59,7 @@ export type AccessCodeRecord = {
   code: string;
   email?: string | null;
   phone?: string | null;
+  type?: string | null;
   used?: boolean;
   createdAt?: unknown;
   usedAt?: unknown;

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -31,6 +31,7 @@ import { getVisiblePlayerTrackingSummary } from '../../../../js/player-tracking-
 import { hasFullTeamAccess } from '../../../../js/team-access.js';
 import { buildTeamStaffPermissionsViewModel } from '../../../../js/team-staff-permissions.js';
 import { firebaseAuth, getNativeAuthIdToken } from './authService';
+import { buildAppAcceptInviteUrl } from './inviteUrls';
 import type { AuthUser } from './types';
 
 const primaryDataTimeoutMs = 5000;
@@ -538,14 +539,7 @@ export async function saveTeamScheduleNotificationsForApp(teamId: string, settin
 }
 
 export function buildAdminAcceptInviteUrl(code: string, baseUrl = getPublicBaseUrl()) {
-  const inviteCode = cleanString(code);
-  if (!inviteCode) return null;
-  const url = new URL('/app', baseUrl);
-  const searchParams = new URLSearchParams();
-  searchParams.set('code', inviteCode);
-  searchParams.set('type', 'admin');
-  url.hash = `/accept-invite?${searchParams.toString()}`;
-  return url.toString();
+  return buildAppAcceptInviteUrl(code, 'admin', baseUrl) || null;
 }
 
 export function buildPublicTeamGamesIcsUrl(teamId: string) {

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -2224,7 +2224,7 @@ function MessageAvatar({ message, label }: { message: ChatMessage; label: string
   );
 }
 
-function InlineAttachmentVideo({ src }: { src: string }) {
+function InlineAttachmentVideo({ src, label }: { src: string; label: string }) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [shouldPreloadMetadata, setShouldPreloadMetadata] = useState(false);
 
@@ -2257,6 +2257,8 @@ function InlineAttachmentVideo({ src }: { src: string }) {
       preload={shouldPreloadMetadata ? 'metadata' : 'none'}
       className="max-h-72 w-full"
       src={src}
+      aria-label={label}
+      data-chat-attachment-url={src}
       onFocus={armMetadataPreload}
       onMouseEnter={armMetadataPreload}
       onPlay={armMetadataPreload}
@@ -2274,7 +2276,7 @@ function MessageAttachments({ attachments, isOwn }: { attachments: any[]; isOwn:
         if (attachment.type === 'video') {
           return (
             <div key={`${attachment.url}-${index}`} className="overflow-hidden rounded-xl border border-gray-200 bg-black">
-              <InlineAttachmentVideo src={attachment.url} />
+              <InlineAttachmentVideo src={attachment.url} label={label} />
               <a href={attachment.url} target="_blank" rel="noopener noreferrer" className="block truncate bg-white px-3 py-2 text-xs font-bold text-primary-600">
                 {label}
               </a>

--- a/apps/app/src/pages/Profile.tsx
+++ b/apps/app/src/pages/Profile.tsx
@@ -40,6 +40,7 @@ import {
   uploadProfilePhoto
 } from '../lib/profileService';
 import { enablePushNotificationsForUser } from '../lib/pushService';
+import { buildAppAcceptInviteUrl } from '../lib/inviteUrls';
 import { sharePublicUrl } from '../lib/publicActions';
 import { useShellLayout } from '../lib/useShellLayout';
 import type { AccessCodeRecord, NotificationPreferences, NotificationTeam, ProfileDocument } from '../lib/profileService';
@@ -705,7 +706,7 @@ export function Profile({ auth }: { auth: AuthState }) {
     }
   };
 
-  const shareInviteLink = async (code: string, metadata?: { email?: string | null; phone?: string | null }) => {
+  const shareInviteLink = async (code: string, metadata?: { email?: string | null; phone?: string | null; type?: string | null }) => {
     const result = await sharePublicUrl(buildInviteShareInput(code, metadata));
     if (result === 'shared') {
       setInviteActionStatus('Share sheet opened.');
@@ -1160,8 +1161,8 @@ function PreferenceToggle({ label, checked, onChange }: { label: string; checked
   );
 }
 
-function AccessCodeCard({ code, onCopy, onShare }: { code: AccessCodeRecord; onCopy: (text: string, label: string) => void; onShare: (code: string, metadata?: { email?: string | null; phone?: string | null }) => void }) {
-  const signupLink = buildSignupLink(code.code);
+function AccessCodeCard({ code, onCopy, onShare }: { code: AccessCodeRecord; onCopy: (text: string, label: string) => void; onShare: (code: string, metadata?: { email?: string | null; phone?: string | null; type?: string | null }) => void }) {
+  const signupLink = buildSignupLink(code.code, code.type);
   return (
     <div className={`rounded-xl border p-3 ${code.used ? 'border-gray-200 bg-gray-50' : 'border-primary-200 bg-white'}`}>
       <div className="flex flex-wrap items-center justify-between gap-2">
@@ -1175,7 +1176,7 @@ function AccessCodeCard({ code, onCopy, onShare }: { code: AccessCodeRecord; onC
             <span className="text-xs font-black">Copy code</span>
           </button>
           {!code.used ? (
-            <button type="button" className="ghost-button !min-h-9 !px-3 !py-1.5" onClick={() => onShare(code.code, { email: code.email, phone: code.phone })} aria-label={`Share saved invite link for ${code.code}`}>
+            <button type="button" className="ghost-button !min-h-9 !px-3 !py-1.5" onClick={() => onShare(code.code, { email: code.email, phone: code.phone, type: code.type })} aria-label={`Share saved invite link for ${code.code}`}>
               <Share2 className="h-4 w-4" aria-hidden="true" />
               <span className="text-xs font-black">Share link</span>
             </button>
@@ -1236,15 +1237,14 @@ function toDate(value: any): Date | null {
   return null;
 }
 
-function buildSignupLink(code: string) {
-  const origin = window.location.protocol === 'capacitor:' ? 'https://allplays.ai' : window.location.origin;
-  return `${origin}/login.html?code=${encodeURIComponent(code)}`;
+function buildSignupLink(code: string, inviteType?: string | null) {
+  return buildAppAcceptInviteUrl(code, inviteType);
 }
 
-function buildInviteShareInput(code: string, metadata?: { email?: string | null; phone?: string | null }) {
+function buildInviteShareInput(code: string, metadata?: { email?: string | null; phone?: string | null; type?: string | null }) {
   const recipientDetails = [metadata?.email, metadata?.phone].map((value) => String(value || '').trim()).filter(Boolean);
   const recipientLabel = recipientDetails.join(' • ');
-  const signupLink = buildSignupLink(code);
+  const signupLink = buildSignupLink(code, metadata?.type);
   return {
     title: recipientLabel ? `ALL PLAYS invite for ${recipientLabel}` : 'ALL PLAYS invite link',
     text: recipientLabel ? `Use this ALL PLAYS invite link for ${recipientLabel}.` : 'Use this ALL PLAYS invite link to join ALL PLAYS.',

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -571,12 +571,15 @@ test('profile exposes account, notification, invite, verification, password, upl
     expect(sharedInviteUrl).toContain('/app#/accept-invite?code=NEWMVP42');
     expect(sharedInviteUrl).not.toContain('/login.html?code=');
 
-    await page.goto(sharedInviteUrl, { waitUntil: 'domcontentloaded' });
-    await expect(page.getByRole('heading', { name: 'Accept invite' })).toBeVisible();
-    await expect(page.getByText('Invite found')).toBeVisible();
-    await expect(page.getByText('NEWMVP42')).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Sign in to accept' })).toBeVisible();
-    await expect(page.getByRole('link', { name: 'Create account with code' })).toBeVisible();
+    const recipientPage = await page.context().newPage();
+    await mockAppModules(recipientPage);
+    await recipientPage.goto(sharedInviteUrl, { waitUntil: 'domcontentloaded' });
+    await expect(recipientPage.getByRole('heading', { name: 'Accept invite' })).toBeVisible();
+    await expect(recipientPage.getByText('Invite found')).toBeVisible();
+    await expect(recipientPage.getByText('NEWMVP42')).toBeVisible();
+    await expect(recipientPage.getByRole('link', { name: 'Sign in to accept' })).toBeVisible();
+    await expect(recipientPage.getByRole('link', { name: 'Create account with code' })).toBeVisible();
+    await recipientPage.close();
 
     await page.goto(appUrl(baseURL, '/profile'), { waitUntil: 'domcontentloaded' });
 
@@ -616,8 +619,8 @@ test('profile exposes account, notification, invite, verification, password, upl
         shares: [expect.objectContaining({
             title: 'ALL PLAYS invite link',
             text: 'Use this ALL PLAYS invite link to join ALL PLAYS.',
-            url: expect.stringContaining('/login.html?code=NEWMVP42'),
-            clipboardText: expect.stringContaining('/login.html?code=NEWMVP42')
+            url: expect.stringContaining('/app#/accept-invite?code=NEWMVP42'),
+            clipboardText: expect.stringContaining('/app#/accept-invite?code=NEWMVP42')
         })],
         password: ['new-password'],
         reset: ['parent@example.com'],

--- a/tests/smoke/app-auth-profile.spec.js
+++ b/tests/smoke/app-auth-profile.spec.js
@@ -567,6 +567,19 @@ test('profile exposes account, notification, invite, verification, password, upl
     await expect(page.getByText('NEWMVP42', { exact: true })).toBeVisible();
     await expect(page.getByRole('button', { name: 'Copy code' })).toBeVisible();
 
+    const sharedInviteUrl = await page.evaluate(() => window.__appShareCalls[0]?.url || '');
+    expect(sharedInviteUrl).toContain('/app#/accept-invite?code=NEWMVP42');
+    expect(sharedInviteUrl).not.toContain('/login.html?code=');
+
+    await page.goto(sharedInviteUrl, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByRole('heading', { name: 'Accept invite' })).toBeVisible();
+    await expect(page.getByText('Invite found')).toBeVisible();
+    await expect(page.getByText('NEWMVP42')).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Sign in to accept' })).toBeVisible();
+    await expect(page.getByRole('link', { name: 'Create account with code' })).toBeVisible();
+
+    await page.goto(appUrl(baseURL, '/profile'), { waitUntil: 'domcontentloaded' });
+
     await page.getByRole('button', { name: 'Security' }).click();
     await expect(page.getByText('Email not verified')).toBeVisible();
     await expect(page.getByText('Set a password')).toBeVisible();

--- a/tests/smoke/app-messages.spec.js
+++ b/tests/smoke/app-messages.spec.js
@@ -535,7 +535,7 @@ test('messages defer offscreen media requests until scroll or video interaction'
     expect(mediaRequests).not.toContain('/deferred-warmups.mp4');
 
     await page.evaluate(() => {
-        const video = document.querySelector('video[src="https://media.example.test/deferred-warmups.mp4"]');
+        const video = document.querySelector('video[data-chat-attachment-url="https://media.example.test/deferred-warmups.mp4"]');
         if (!video) throw new Error('Video element not found');
         video.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
     });

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -1426,7 +1426,7 @@ describe('React app messages integration', () => {
         });
 
         const { container } = await renderMessages('/messages/team-1');
-        const video = container.querySelector('video[src="https://media.example.test/warmups.mp4"]');
+        const video = container.querySelector('video[data-chat-attachment-url="https://media.example.test/warmups.mp4"]');
         expect(video).toBeTruthy();
         expect(video.getAttribute('preload')).toBe('none');
         expect(intersectionObserverState.instances).toHaveLength(1);
@@ -1455,7 +1455,7 @@ describe('React app messages integration', () => {
         });
 
         const hovered = await renderMessages('/messages/team-1');
-        const hoveredVideo = hovered.container.querySelector('video[src="https://media.example.test/huddle.mp4"]');
+        const hoveredVideo = hovered.container.querySelector('video[data-chat-attachment-url="https://media.example.test/huddle.mp4"]');
         expect(hoveredVideo.getAttribute('preload')).toBe('none');
 
         await act(async () => {

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -191,10 +191,10 @@ describe('Profile invites', () => {
     await waitFor(() => expect(publicActionsMocks.sharePublicUrl).toHaveBeenCalledWith(expect.objectContaining({
       title: 'ALL PLAYS invite for coach@example.com',
       text: 'Use this ALL PLAYS invite link for coach@example.com.',
-      url: expect.stringContaining('/login.html?code=NEWMVP42'),
-      clipboardText: expect.stringContaining('/login.html?code=NEWMVP42')
+      url: expect.stringContaining('/app#/accept-invite?code=NEWMVP42'),
+      clipboardText: expect.stringContaining('/app#/accept-invite?code=NEWMVP42')
     })));
-    expect(screen.getByText(/\/login\.html\?code=NEWMVP42/)).toBeTruthy();
+    expect(screen.getByText(/\/app#\/accept-invite\?code=NEWMVP42/)).toBeTruthy();
     expect(screen.getByText('Share sheet opened.')).toBeTruthy();
   });
 
@@ -224,20 +224,20 @@ describe('Profile invites', () => {
 
     fireEvent.click(within(activeCard).getByRole('button', { name: /Share saved invite link/ }));
     await waitFor(() => expect(publicActionsMocks.sharePublicUrl).toHaveBeenNthCalledWith(1, expect.objectContaining({
-      url: expect.stringContaining('/login.html?code=ACTIVE123'),
-      clipboardText: expect.stringContaining('/login.html?code=ACTIVE123')
+      url: expect.stringContaining('/app#/accept-invite?code=ACTIVE123'),
+      clipboardText: expect.stringContaining('/app#/accept-invite?code=ACTIVE123')
     })));
     expect(await screen.findByText('Link copied.')).toBeTruthy();
 
     fireEvent.click(within(activeCard).getByRole('button', { name: /Share saved invite link/ }));
     await waitFor(() => expect(publicActionsMocks.sharePublicUrl).toHaveBeenNthCalledWith(2, expect.objectContaining({
-      url: expect.stringContaining('/login.html?code=ACTIVE123'),
-      clipboardText: expect.stringContaining('/login.html?code=ACTIVE123')
+      url: expect.stringContaining('/app#/accept-invite?code=ACTIVE123'),
+      clipboardText: expect.stringContaining('/app#/accept-invite?code=ACTIVE123')
     })));
     expect(await screen.findByText('Share cancelled.')).toBeTruthy();
   });
 
-  it('keeps generic profile invite links on the signup path while typed invites use the accept flow', async () => {
+  it('routes typed profile invite links through the app accept flow', async () => {
     publicActionsMocks.sharePublicUrl.mockResolvedValue('shared');
     profileServiceMocks.loadProfileAccessCodes.mockResolvedValue([
       { id: 'code-1', code: 'ACTIVE123', email: 'coach@example.com', phone: '', used: false, type: 'parent_invite', createdAt: { seconds: 1717200000 } }

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -191,9 +191,10 @@ describe('Profile invites', () => {
     await waitFor(() => expect(publicActionsMocks.sharePublicUrl).toHaveBeenCalledWith(expect.objectContaining({
       title: 'ALL PLAYS invite for coach@example.com',
       text: 'Use this ALL PLAYS invite link for coach@example.com.',
-      url: expect.stringContaining('/login.html?code=NEWMVP42'),
-      clipboardText: expect.stringContaining('/login.html?code=NEWMVP42')
+      url: expect.stringContaining('/app#/accept-invite?code=NEWMVP42'),
+      clipboardText: expect.stringContaining('/app#/accept-invite?code=NEWMVP42')
     })));
+    expect(screen.getByText(/\/app#\/accept-invite\?code=NEWMVP42/)).toBeTruthy();
     expect(screen.getByText('Share sheet opened.')).toBeTruthy();
   });
 
@@ -222,9 +223,17 @@ describe('Profile invites', () => {
     expect(within(usedCard).queryByRole('button', { name: /Copy saved invite link/ })).toBeNull();
 
     fireEvent.click(within(activeCard).getByRole('button', { name: /Share saved invite link/ }));
+    await waitFor(() => expect(publicActionsMocks.sharePublicUrl).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      url: expect.stringContaining('/app#/accept-invite?code=ACTIVE123'),
+      clipboardText: expect.stringContaining('/app#/accept-invite?code=ACTIVE123')
+    })));
     expect(await screen.findByText('Link copied.')).toBeTruthy();
 
     fireEvent.click(within(activeCard).getByRole('button', { name: /Share saved invite link/ }));
+    await waitFor(() => expect(publicActionsMocks.sharePublicUrl).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      url: expect.stringContaining('/app#/accept-invite?code=ACTIVE123'),
+      clipboardText: expect.stringContaining('/app#/accept-invite?code=ACTIVE123')
+    })));
     expect(await screen.findByText('Share cancelled.')).toBeTruthy();
   });
 

--- a/tests/unit/app-profile-invites.test.tsx
+++ b/tests/unit/app-profile-invites.test.tsx
@@ -191,10 +191,10 @@ describe('Profile invites', () => {
     await waitFor(() => expect(publicActionsMocks.sharePublicUrl).toHaveBeenCalledWith(expect.objectContaining({
       title: 'ALL PLAYS invite for coach@example.com',
       text: 'Use this ALL PLAYS invite link for coach@example.com.',
-      url: expect.stringContaining('/app#/accept-invite?code=NEWMVP42'),
-      clipboardText: expect.stringContaining('/app#/accept-invite?code=NEWMVP42')
+      url: expect.stringContaining('/login.html?code=NEWMVP42'),
+      clipboardText: expect.stringContaining('/login.html?code=NEWMVP42')
     })));
-    expect(screen.getByText(/\/app#\/accept-invite\?code=NEWMVP42/)).toBeTruthy();
+    expect(screen.getByText(/\/login\.html\?code=NEWMVP42/)).toBeTruthy();
     expect(screen.getByText('Share sheet opened.')).toBeTruthy();
   });
 
@@ -224,17 +224,34 @@ describe('Profile invites', () => {
 
     fireEvent.click(within(activeCard).getByRole('button', { name: /Share saved invite link/ }));
     await waitFor(() => expect(publicActionsMocks.sharePublicUrl).toHaveBeenNthCalledWith(1, expect.objectContaining({
-      url: expect.stringContaining('/app#/accept-invite?code=ACTIVE123'),
-      clipboardText: expect.stringContaining('/app#/accept-invite?code=ACTIVE123')
+      url: expect.stringContaining('/login.html?code=ACTIVE123'),
+      clipboardText: expect.stringContaining('/login.html?code=ACTIVE123')
     })));
     expect(await screen.findByText('Link copied.')).toBeTruthy();
 
     fireEvent.click(within(activeCard).getByRole('button', { name: /Share saved invite link/ }));
     await waitFor(() => expect(publicActionsMocks.sharePublicUrl).toHaveBeenNthCalledWith(2, expect.objectContaining({
-      url: expect.stringContaining('/app#/accept-invite?code=ACTIVE123'),
-      clipboardText: expect.stringContaining('/app#/accept-invite?code=ACTIVE123')
+      url: expect.stringContaining('/login.html?code=ACTIVE123'),
+      clipboardText: expect.stringContaining('/login.html?code=ACTIVE123')
     })));
     expect(await screen.findByText('Share cancelled.')).toBeTruthy();
+  });
+
+  it('keeps generic profile invite links on the signup path while typed invites use the accept flow', async () => {
+    publicActionsMocks.sharePublicUrl.mockResolvedValue('shared');
+    profileServiceMocks.loadProfileAccessCodes.mockResolvedValue([
+      { id: 'code-1', code: 'ACTIVE123', email: 'coach@example.com', phone: '', used: false, type: 'parent_invite', createdAt: { seconds: 1717200000 } }
+    ]);
+
+    renderProfile();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Invites' }));
+    fireEvent.click(await screen.findByRole('button', { name: /Share saved invite link for ACTIVE123/ }));
+
+    await waitFor(() => expect(publicActionsMocks.sharePublicUrl).toHaveBeenCalledWith(expect.objectContaining({
+      url: expect.stringContaining('/app#/accept-invite?code=ACTIVE123&type=parent_invite'),
+      clipboardText: expect.stringContaining('/app#/accept-invite?code=ACTIVE123&type=parent_invite')
+    })));
   });
 
   it('revokes replaced and removed profile photo blob previews', async () => {


### PR DESCRIPTION
Closes #1894

## What changed
- added a shared React app invite URL builder that emits `/app#/accept-invite?code=...` with invite type when provided
- switched Profile invite generation, share, and copy actions to use the shared app invite URL for both newly generated links and saved invite cards
- updated the existing admin app invite builder to reuse the same helper so app invite routes stay aligned
- updated focused unit and smoke coverage to assert Profile no longer emits `/login.html?code=...` and that a shared Profile invite opens the React Accept Invite screen

## Root Cause
Profile owned a duplicate invite URL builder that hardcoded the legacy `/login.html?code=...` entry point instead of reusing the React app accept-invite route already established elsewhere in the app. That let the Profile share/copy path drift away from the canonical mobile invite flow.

## Prevention / Learning
When the app already has a canonical public deep-link pattern for invite or auth flows, do not assemble those URLs inline in page components. Put the route construction in a shared helper and route every share/copy entry point through it so future invite destinations cannot diverge silently.

## Regression Tests
- `tests/unit/app-profile-invites.test.tsx`
  - verifies generated invite share payloads now use `/app#/accept-invite?code=...`
  - verifies saved invite share payloads also use the app accept-invite route
- `tests/smoke/app-auth-profile.spec.js`
  - verifies the Profile share payload uses the app invite URL
  - opens that shared URL and confirms the React Accept Invite screen shows the expected code and next-step actions

## Recurrence Risk
Low. Profile invite links now use a shared helper that also backs the app admin invite flow, so the public invite route is centralized instead of duplicated in page-specific code.