### PR TITLE
Block team fee manual overpayments

### DIFF
--- a/apps/app/src/lib/teamFeesService.ts
+++ b/apps/app/src/lib/teamFeesService.ts
@@ -90,6 +90,14 @@ function normalizeLedgerStatus(balanceCents: number, amountPaidCents: number) {
   return amountPaidCents > 0 ? 'partial' : 'unpaid';
 }
 
+function assertManualPaymentWithinRemainingBalance(paymentAmountCents: number, balanceCents: number, priorPaidCents: number) {
+  if (!Number.isFinite(balanceCents)) return;
+  const remainingBalanceCents = Math.max(0, balanceCents - priorPaidCents);
+  if (paymentAmountCents > remainingBalanceCents) {
+    throw new Error('Manual payment amount cannot exceed the remaining balance.');
+  }
+}
+
 export function buildManualPaymentUpdate({ amount, date, note, actorId, currentBalanceCents, currentPaidCents }: ManualTeamFeePaymentInput) {
   const paymentAmountCents = toFeeCents(amount);
   if (paymentAmountCents === null || paymentAmountCents <= 0) {
@@ -101,6 +109,7 @@ export function buildManualPaymentUpdate({ amount, date, note, actorId, currentB
   const balanceCents = Number.isFinite(currentBalance) ? Math.max(0, currentBalance) : Number.MAX_SAFE_INTEGER;
   const priorPaid = Number(currentPaidCents);
   const priorPaidCents = Number.isFinite(priorPaid) ? Math.max(0, priorPaid) : 0;
+  assertManualPaymentWithinRemainingBalance(paymentAmountCents, balanceCents, priorPaidCents);
   const amountPaidCents = priorPaidCents + paymentAmountCents;
   const remainingBalanceCents = Math.max(0, balanceCents - amountPaidCents);
   const status = normalizeLedgerStatus(balanceCents, amountPaidCents);

--- a/js/db.js
+++ b/js/db.js
@@ -4432,6 +4432,29 @@ export async function updateTeamFeeRecipient(teamId, batchId, recipientId, updat
 
     const recipientRef = doc(db, 'teams', teamId, 'feeBatches', batchId, 'feeRecipients', recipientId);
     const { ledgerEntries = [], ...recipientUpdates } = updates;
+
+    const isManualPaymentUpdate = Object.prototype.hasOwnProperty.call(recipientUpdates, 'manualPayment')
+        || (Array.isArray(ledgerEntries) && ledgerEntries.some((entry) => entry?.type === 'offline_payment'));
+
+    if (isManualPaymentUpdate) {
+        const recipientSnapshot = await getDoc(recipientRef);
+        if (!recipientSnapshot.exists()) {
+            throw new Error('Fee recipient not found.');
+        }
+        const recipient = recipientSnapshot.data() || {};
+        const amountDueRaw = recipient.amountDueCents ?? recipient.adjustedAmountCents ?? recipient.amountCents ?? 0;
+        const amountDueCents = Number.isFinite(Number(amountDueRaw)) ? Math.max(0, Number(amountDueRaw)) : 0;
+        const priorPaidRaw = recipient.amountPaidCents ?? recipient.paidAmountCents ?? 0;
+        const priorPaidCents = Number.isFinite(Number(priorPaidRaw)) ? Math.max(0, Number(priorPaidRaw)) : 0;
+        const remainingBalanceCents = Math.max(0, amountDueCents - priorPaidCents);
+        const manualPaymentAmountRaw = recipientUpdates.manualPayment?.amountPaidCents
+            ?? ledgerEntries.find((entry) => entry?.type === 'offline_payment')?.amountCents;
+        const manualPaymentAmountCents = Number(manualPaymentAmountRaw);
+        if (Number.isFinite(manualPaymentAmountCents) && manualPaymentAmountCents > remainingBalanceCents) {
+            throw new Error('Manual payment amount cannot exceed the remaining balance.');
+        }
+    }
+
     const updatePayload = {
         ...recipientUpdates,
         teamId,

--- a/js/db.js
+++ b/js/db.js
@@ -4432,28 +4432,8 @@ export async function updateTeamFeeRecipient(teamId, batchId, recipientId, updat
 
     const recipientRef = doc(db, 'teams', teamId, 'feeBatches', batchId, 'feeRecipients', recipientId);
     const { ledgerEntries = [], ...recipientUpdates } = updates;
-
     const isManualPaymentUpdate = Object.prototype.hasOwnProperty.call(recipientUpdates, 'manualPayment')
         || (Array.isArray(ledgerEntries) && ledgerEntries.some((entry) => entry?.type === 'offline_payment'));
-
-    if (isManualPaymentUpdate) {
-        const recipientSnapshot = await getDoc(recipientRef);
-        if (!recipientSnapshot.exists()) {
-            throw new Error('Fee recipient not found.');
-        }
-        const recipient = recipientSnapshot.data() || {};
-        const amountDueRaw = recipient.amountDueCents ?? recipient.adjustedAmountCents ?? recipient.amountCents ?? 0;
-        const amountDueCents = Number.isFinite(Number(amountDueRaw)) ? Math.max(0, Number(amountDueRaw)) : 0;
-        const priorPaidRaw = recipient.amountPaidCents ?? recipient.paidAmountCents ?? 0;
-        const priorPaidCents = Number.isFinite(Number(priorPaidRaw)) ? Math.max(0, Number(priorPaidRaw)) : 0;
-        const remainingBalanceCents = Math.max(0, amountDueCents - priorPaidCents);
-        const manualPaymentAmountRaw = recipientUpdates.manualPayment?.amountPaidCents
-            ?? ledgerEntries.find((entry) => entry?.type === 'offline_payment')?.amountCents;
-        const manualPaymentAmountCents = Number(manualPaymentAmountRaw);
-        if (Number.isFinite(manualPaymentAmountCents) && manualPaymentAmountCents > remainingBalanceCents) {
-            throw new Error('Manual payment amount cannot exceed the remaining balance.');
-        }
-    }
 
     const updatePayload = {
         ...recipientUpdates,
@@ -4489,6 +4469,34 @@ export async function updateTeamFeeRecipient(teamId, batchId, recipientId, updat
 
     if (Array.isArray(ledgerEntries) && ledgerEntries.length > 0) {
         updatePayload.paymentLedger = arrayUnion(...ledgerEntries);
+    }
+
+    if (isManualPaymentUpdate) {
+        await runTransaction(db, async (transaction) => {
+            const recipientSnapshot = await transaction.get(recipientRef);
+            if (!recipientSnapshot.exists()) {
+                throw new Error('Fee recipient not found.');
+            }
+            const recipient = recipientSnapshot.data() || {};
+            const amountDueRaw = recipient.amountDueCents ?? recipient.adjustedAmountCents ?? recipient.amountCents ?? 0;
+            const amountDueCents = Number.isFinite(Number(amountDueRaw)) ? Math.max(0, Number(amountDueRaw)) : 0;
+            const priorPaidRaw = recipient.amountPaidCents ?? recipient.paidAmountCents ?? 0;
+            const priorPaidCents = Number.isFinite(Number(priorPaidRaw)) ? Math.max(0, Number(priorPaidRaw)) : 0;
+            const remainingBalanceCents = Math.max(0, amountDueCents - priorPaidCents);
+            const manualPaymentAmountRaw = recipientUpdates.manualPayment?.amountPaidCents
+                ?? ledgerEntries.find((entry) => entry?.type === 'offline_payment')?.amountCents;
+            const manualPaymentAmountCents = Number(manualPaymentAmountRaw);
+
+            if (!Number.isFinite(manualPaymentAmountCents)) {
+                throw new Error('Manual payment amount is required.');
+            }
+            if (manualPaymentAmountCents > remainingBalanceCents) {
+                throw new Error('Manual payment amount cannot exceed the remaining balance.');
+            }
+
+            transaction.update(recipientRef, updatePayload);
+        });
+        return;
     }
 
     await updateDoc(recipientRef, updatePayload);

--- a/js/team-fees-admin.js
+++ b/js/team-fees-admin.js
@@ -399,6 +399,14 @@ function normalizeLedgerStatus(balanceCents, paidCents) {
     return 'unpaid';
 }
 
+function assertManualPaymentWithinRemainingBalance(paymentAmountCents, balanceCents, priorPaidCents) {
+    if (!Number.isFinite(balanceCents)) return;
+    const remainingBalanceCents = Math.max(0, balanceCents - priorPaidCents);
+    if (paymentAmountCents > remainingBalanceCents) {
+        throw new Error('Manual payment amount cannot exceed the remaining balance.');
+    }
+}
+
 export function buildManualPaymentUpdate({ amount, date, note, actorId, currentBalanceCents, currentPaidCents }) {
     const paymentAmountCents = toFeeCents(amount);
     if (paymentAmountCents === null || paymentAmountCents <= 0) {
@@ -410,6 +418,7 @@ export function buildManualPaymentUpdate({ amount, date, note, actorId, currentB
     const balanceCents = Number.isFinite(currentBalance) ? Math.max(0, currentBalance) : Number.MAX_SAFE_INTEGER;
     const priorPaid = Number(currentPaidCents);
     const priorPaidCents = Number.isFinite(priorPaid) ? Math.max(0, priorPaid) : 0;
+    assertManualPaymentWithinRemainingBalance(paymentAmountCents, balanceCents, priorPaidCents);
     const amountPaidCents = priorPaidCents + paymentAmountCents;
     const remainingBalanceCents = Math.max(0, balanceCents - amountPaidCents);
     const status = normalizeLedgerStatus(balanceCents, amountPaidCents);
@@ -815,7 +824,7 @@ function renderRecipients(container, countEl, recipients) {
                     <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-5 gap-3 w-full lg:max-w-7xl">
                         <form data-action="paid" class="rounded-xl border border-gray-200 bg-gray-50 p-3 space-y-2">
                             <div class="text-xs font-bold uppercase tracking-wide text-gray-500">Manual payment</div>
-                            <input name="amount" type="number" min="0" step="0.01" value="${(outstandingCents / 100).toFixed(2)}" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Payment amount">
+                            <input name="amount" type="number" min="0" max="${(outstandingCents / 100).toFixed(2)}" step="0.01" value="${(outstandingCents / 100).toFixed(2)}" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Payment amount">
                             <input name="date" type="date" value="${new Date().toISOString().slice(0, 10)}" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Payment date">
                             <input name="note" type="text" placeholder="Optional note" class="w-full rounded-lg border-gray-300 text-sm" aria-label="Payment note">
                             <button class="w-full rounded-lg bg-green-600 px-3 py-2 text-sm font-semibold text-white hover:bg-green-700">Mark paid</button>
@@ -1148,7 +1157,7 @@ async function initTeamFeesAdminPage() {
     renderFooter(document.getElementById('footer-container'));
 
     const [{ getTeam, getPlayers, getUserProfile, createTeamFeeBatch, getTeamFeeBatch, listTeamFeeBatches, listTeamFeeRecipients, updateTeamFeeRecipient, canModerateChat }, { requireAuth }] = await Promise.all([
-        import('./db.js?v=42'),
+        import('./db.js?v=43'),
         import('./auth.js?v=20')
     ]);
 

--- a/team-fees.html
+++ b/team-fees.html
@@ -45,7 +45,7 @@
 
     <div id="footer-container"></div>
 
-    <script type="module" src="./js/team-fees-admin.js?v=8"></script>
+    <script type="module" src="./js/team-fees-admin.js?v=9"></script>
 </body>
 
 </html>

--- a/tests/unit/app-team-fees-service.test.ts
+++ b/tests/unit/app-team-fees-service.test.ts
@@ -59,16 +59,16 @@ describe('React app team fee offline payment service', () => {
         ]);
     });
 
-    it('builds a paid update when payment covers the balance', () => {
+    it('builds a paid update when payment exactly covers the remaining balance', () => {
         const update = buildManualPaymentUpdate({
-            amount: '50.00',
+            amount: '25.00',
             date: '2026-05-28',
             currentBalanceCents: 5000,
             currentPaidCents: 2500
         });
 
         expect(update.status).toBe('paid');
-        expect(update.amountPaidCents).toBe(7500);
+        expect(update.amountPaidCents).toBe(5000);
         expect(update.remainingBalanceCents).toBe(0);
         expect(update.paidAt).toBe('2026-05-28');
     });
@@ -77,6 +77,22 @@ describe('React app team fee offline payment service', () => {
         expect(() => buildManualPaymentUpdate({ amount: '0', date: '2026-05-28' })).toThrow('greater than $0');
         expect(() => buildManualPaymentUpdate({ amount: '-1.00', date: '2026-05-28' })).toThrow('greater than $0');
         expect(() => buildManualPaymentUpdate({ amount: '5.00', date: '' })).toThrow('payment date');
+    });
+
+    it('rejects offline payments larger than the remaining balance', () => {
+        expect(() => buildManualPaymentUpdate({
+            amount: '25.01',
+            date: '2026-06-09',
+            currentBalanceCents: 2500,
+            currentPaidCents: 0
+        })).toThrow('cannot exceed the remaining balance');
+
+        expect(() => buildManualPaymentUpdate({
+            amount: '10.01',
+            date: '2026-06-09',
+            currentBalanceCents: 2500,
+            currentPaidCents: 1500
+        })).toThrow('cannot exceed the remaining balance');
     });
 
     it('treats positive adjustments as credits that reduce the amount owed', () => {

--- a/tests/unit/db-team-fee-recipient-updates.test.js
+++ b/tests/unit/db-team-fee-recipient-updates.test.js
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const dbSource = readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+
+function buildUpdateTeamFeeRecipient({ db = {}, doc, getDoc, updateDoc, serverTimestamp, arrayUnion, deleteField }) {
+    const start = dbSource.indexOf('export async function updateTeamFeeRecipient');
+    const end = dbSource.indexOf('\nexport async function createTeamFeeBatch', start);
+    expect(start).toBeGreaterThanOrEqual(0);
+    expect(end).toBeGreaterThan(start);
+
+    const functionSource = dbSource
+        .slice(start, end)
+        .replace('export async function updateTeamFeeRecipient', 'return async function updateTeamFeeRecipient');
+
+    return new Function('db', 'doc', 'getDoc', 'updateDoc', 'serverTimestamp', 'arrayUnion', 'deleteField', functionSource)(
+        db,
+        doc,
+        getDoc,
+        updateDoc,
+        serverTimestamp,
+        arrayUnion,
+        deleteField
+    );
+}
+
+describe('updateTeamFeeRecipient manual payment validation', () => {
+    it('rejects manual payments that exceed the recipient remaining balance before persisting', async () => {
+        const updateDoc = vi.fn();
+        const updateTeamFeeRecipient = buildUpdateTeamFeeRecipient({
+            doc: vi.fn((_db, ...parts) => ({ path: parts.join('/') })),
+            getDoc: vi.fn(async () => ({
+                exists: () => true,
+                data: () => ({ amountDueCents: 2500, amountPaidCents: 1500 })
+            })),
+            updateDoc,
+            serverTimestamp: vi.fn(() => 'server-ts'),
+            arrayUnion: vi.fn((...entries) => entries),
+            deleteField: vi.fn(() => 'deleted')
+        });
+
+        await expect(updateTeamFeeRecipient('team-1', 'batch-1', 'recipient-1', {
+            amountPaidCents: 2600,
+            manualPayment: { amountPaidCents: 1100 },
+            ledgerEntries: [{ type: 'offline_payment', amountCents: 1100 }]
+        })).rejects.toThrow('cannot exceed the remaining balance');
+        expect(updateDoc).not.toHaveBeenCalled();
+    });
+
+    it('persists manual payments that stay within the recipient remaining balance', async () => {
+        const updateDoc = vi.fn(async () => undefined);
+        const arrayUnion = vi.fn((...entries) => entries);
+        const deleteField = vi.fn(() => 'deleted');
+        const updateTeamFeeRecipient = buildUpdateTeamFeeRecipient({
+            doc: vi.fn((_db, ...parts) => ({ path: parts.join('/') })),
+            getDoc: vi.fn(async () => ({
+                exists: () => true,
+                data: () => ({ amountDueCents: 2500, amountPaidCents: 1500 })
+            })),
+            updateDoc,
+            serverTimestamp: vi.fn(() => 'server-ts'),
+            arrayUnion,
+            deleteField
+        });
+
+        await expect(updateTeamFeeRecipient('team-1', 'batch-1', 'recipient-1', {
+            status: 'paid',
+            amountPaidCents: 2500,
+            remainingBalanceCents: 0,
+            manualPayment: { amountPaidCents: 1000 },
+            ledgerEntries: [{ type: 'offline_payment', amountCents: 1000 }]
+        })).resolves.toBeUndefined();
+
+        expect(updateDoc).toHaveBeenCalledWith(
+            { path: 'teams/team-1/feeBatches/batch-1/feeRecipients/recipient-1' },
+            expect.objectContaining({
+                amountPaidCents: 2500,
+                remainingBalanceCents: 0,
+                paymentLedger: [{ type: 'offline_payment', amountCents: 1000 }],
+                updatedAt: 'server-ts'
+            })
+        );
+        expect(arrayUnion).toHaveBeenCalledWith({ type: 'offline_payment', amountCents: 1000 });
+    });
+});

--- a/tests/unit/db-team-fee-recipient-updates.test.js
+++ b/tests/unit/db-team-fee-recipient-updates.test.js
@@ -3,7 +3,7 @@ import { readFileSync } from 'node:fs';
 
 const dbSource = readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
 
-function buildUpdateTeamFeeRecipient({ db = {}, doc, getDoc, updateDoc, serverTimestamp, arrayUnion, deleteField }) {
+function buildUpdateTeamFeeRecipient({ db = {}, doc, updateDoc, runTransaction, serverTimestamp, arrayUnion, deleteField }) {
     const start = dbSource.indexOf('export async function updateTeamFeeRecipient');
     const end = dbSource.indexOf('\nexport async function createTeamFeeBatch', start);
     expect(start).toBeGreaterThanOrEqual(0);
@@ -13,11 +13,11 @@ function buildUpdateTeamFeeRecipient({ db = {}, doc, getDoc, updateDoc, serverTi
         .slice(start, end)
         .replace('export async function updateTeamFeeRecipient', 'return async function updateTeamFeeRecipient');
 
-    return new Function('db', 'doc', 'getDoc', 'updateDoc', 'serverTimestamp', 'arrayUnion', 'deleteField', functionSource)(
+    return new Function('db', 'doc', 'updateDoc', 'runTransaction', 'serverTimestamp', 'arrayUnion', 'deleteField', functionSource)(
         db,
         doc,
-        getDoc,
         updateDoc,
+        runTransaction,
         serverTimestamp,
         arrayUnion,
         deleteField
@@ -27,13 +27,18 @@ function buildUpdateTeamFeeRecipient({ db = {}, doc, getDoc, updateDoc, serverTi
 describe('updateTeamFeeRecipient manual payment validation', () => {
     it('rejects manual payments that exceed the recipient remaining balance before persisting', async () => {
         const updateDoc = vi.fn();
-        const updateTeamFeeRecipient = buildUpdateTeamFeeRecipient({
-            doc: vi.fn((_db, ...parts) => ({ path: parts.join('/') })),
-            getDoc: vi.fn(async () => ({
+        const transactionUpdate = vi.fn();
+        const runTransaction = vi.fn(async (_db, handler) => handler({
+            get: vi.fn(async () => ({
                 exists: () => true,
                 data: () => ({ amountDueCents: 2500, amountPaidCents: 1500 })
             })),
+            update: transactionUpdate
+        }));
+        const updateTeamFeeRecipient = buildUpdateTeamFeeRecipient({
+            doc: vi.fn((_db, ...parts) => ({ path: parts.join('/') })),
             updateDoc,
+            runTransaction,
             serverTimestamp: vi.fn(() => 'server-ts'),
             arrayUnion: vi.fn((...entries) => entries),
             deleteField: vi.fn(() => 'deleted')
@@ -45,19 +50,51 @@ describe('updateTeamFeeRecipient manual payment validation', () => {
             ledgerEntries: [{ type: 'offline_payment', amountCents: 1100 }]
         })).rejects.toThrow('cannot exceed the remaining balance');
         expect(updateDoc).not.toHaveBeenCalled();
+        expect(transactionUpdate).not.toHaveBeenCalled();
     });
 
-    it('persists manual payments that stay within the recipient remaining balance', async () => {
-        const updateDoc = vi.fn(async () => undefined);
-        const arrayUnion = vi.fn((...entries) => entries);
-        const deleteField = vi.fn(() => 'deleted');
-        const updateTeamFeeRecipient = buildUpdateTeamFeeRecipient({
-            doc: vi.fn((_db, ...parts) => ({ path: parts.join('/') })),
-            getDoc: vi.fn(async () => ({
+    it('rejects manual payments when the amount cannot be resolved to a finite number', async () => {
+        const updateDoc = vi.fn();
+        const transactionUpdate = vi.fn();
+        const runTransaction = vi.fn(async (_db, handler) => handler({
+            get: vi.fn(async () => ({
                 exists: () => true,
                 data: () => ({ amountDueCents: 2500, amountPaidCents: 1500 })
             })),
+            update: transactionUpdate
+        }));
+        const updateTeamFeeRecipient = buildUpdateTeamFeeRecipient({
+            doc: vi.fn((_db, ...parts) => ({ path: parts.join('/') })),
             updateDoc,
+            runTransaction,
+            serverTimestamp: vi.fn(() => 'server-ts'),
+            arrayUnion: vi.fn((...entries) => entries),
+            deleteField: vi.fn(() => 'deleted')
+        });
+
+        await expect(updateTeamFeeRecipient('team-1', 'batch-1', 'recipient-1', {
+            manualPayment: {}
+        })).rejects.toThrow('Manual payment amount is required');
+        expect(updateDoc).not.toHaveBeenCalled();
+        expect(transactionUpdate).not.toHaveBeenCalled();
+    });
+
+    it('persists manual payments that stay within the recipient remaining balance transactionally', async () => {
+        const updateDoc = vi.fn(async () => undefined);
+        const transactionUpdate = vi.fn();
+        const arrayUnion = vi.fn((...entries) => entries);
+        const deleteField = vi.fn(() => 'deleted');
+        const runTransaction = vi.fn(async (_db, handler) => handler({
+            get: vi.fn(async () => ({
+                exists: () => true,
+                data: () => ({ amountDueCents: 2500, amountPaidCents: 1500 })
+            })),
+            update: transactionUpdate
+        }));
+        const updateTeamFeeRecipient = buildUpdateTeamFeeRecipient({
+            doc: vi.fn((_db, ...parts) => ({ path: parts.join('/') })),
+            updateDoc,
+            runTransaction,
             serverTimestamp: vi.fn(() => 'server-ts'),
             arrayUnion,
             deleteField
@@ -71,7 +108,9 @@ describe('updateTeamFeeRecipient manual payment validation', () => {
             ledgerEntries: [{ type: 'offline_payment', amountCents: 1000 }]
         })).resolves.toBeUndefined();
 
-        expect(updateDoc).toHaveBeenCalledWith(
+        expect(runTransaction).toHaveBeenCalledTimes(1);
+        expect(updateDoc).not.toHaveBeenCalled();
+        expect(transactionUpdate).toHaveBeenCalledWith(
             { path: 'teams/team-1/feeBatches/batch-1/feeRecipients/recipient-1' },
             expect.objectContaining({
                 amountPaidCents: 2500,

--- a/tests/unit/team-fees-admin.test.js
+++ b/tests/unit/team-fees-admin.test.js
@@ -21,8 +21,8 @@ describe('team fees admin page routing', () => {
         const adminSource = readFileSync(new URL('../../js/team-fees-admin.js', import.meta.url), 'utf8');
         const pageSource = readFileSync(new URL('../../team-fees.html', import.meta.url), 'utf8');
 
-        expect(adminSource).toContain("import('./db.js?v=42')");
-        expect(pageSource).toContain('<script type="module" src="./js/team-fees-admin.js?v=8"></script>');
+        expect(adminSource).toContain("import('./db.js?v=43')");
+        expect(pageSource).toContain('<script type="module" src="./js/team-fees-admin.js?v=9"></script>');
     });
 });
 
@@ -140,18 +140,14 @@ describe('buildManualPaymentUpdate', () => {
         expect(updates.remainingBalanceCents).toBe(Number.MAX_SAFE_INTEGER - paymentAmountCents);
         expect(updates.status).toBe('partial');
 
-        // Case 3: currentBalanceCents is 0, and a payment is made
-        updates = buildManualPaymentUpdate({
+        // Case 3: currentBalanceCents is 0, so additional payments are rejected
+        expect(() => buildManualPaymentUpdate({
             amount: paymentAmount,
             date,
             actorId,
-            currentBalanceCents: '0', // Explicitly 0 outstanding balance
+            currentBalanceCents: '0',
             currentPaidCents: '0'
-        });
-
-        expect(updates.amountPaidCents).toBe(paymentAmountCents);
-        expect(updates.remainingBalanceCents).toBe(0); // 0 - 500 = -500, then Math.max(0, -500) = 0
-        expect(updates.status).toBe('paid'); // Correctly 'paid' as 500 >= 0
+        })).toThrow('cannot exceed the remaining balance');
 
         // Case 4: Valid currentBalanceCents (partial payment scenario)
         const initialBalanceCents = 1000; // $10.00 outstanding
@@ -165,6 +161,22 @@ describe('buildManualPaymentUpdate', () => {
         expect(updates.amountPaidCents).toBe(paymentAmountCents); // 500
         expect(updates.remainingBalanceCents).toBe(initialBalanceCents - paymentAmountCents); // 1000 - 500 = 500
         expect(updates.status).toBe('partial');
+    });
+
+    it('rejects manual payments that exceed the remaining balance', () => {
+        expect(() => buildManualPaymentUpdate({
+            amount: '25.01',
+            date: '2026-06-09',
+            currentBalanceCents: '2500',
+            currentPaidCents: '0'
+        })).toThrow('cannot exceed the remaining balance');
+
+        expect(() => buildManualPaymentUpdate({
+            amount: '10.01',
+            date: '2026-06-09',
+            currentBalanceCents: '2500',
+            currentPaidCents: '1500'
+        })).toThrow('cannot exceed the remaining balance');
     });
 });
 


### PR DESCRIPTION
Closes #1929

## What changed
- Reject manual/offline fee payments that exceed a recipient remaining balance in the legacy team fees admin flow.
- Add the same remaining-balance guard to the React app team fee service.
- Add a database-level guard before persisting offline payment ledger updates.
- Update cache-bust versions for the changed legacy team fees modules.

## Root Cause
The manual payment builders added the entered payment amount to prior paid totals and then clamped remaining balance to zero. There was no upper-bound validation in the UI helper or persistence path, so overpayments could be recorded as paid ledger state.

## Prevention / Learning
Money-handling workflows need the same invariant at every write boundary: UI controls may guide the user, but service/builders and persistence helpers must reject impossible financial states before writing them.

## Regression Tests
- `npx vitest run tests/unit/team-fees-admin.test.js tests/unit/db-team-fee-recipient-updates.test.js tests/unit/app-team-fees-service.test.ts`

## Recurrence Risk
Low. The fix validates manual payments in the legacy helper, React app helper, and database update path, with regression coverage for each layer.