### PR TITLE
Route gameId-only live score pushes through GameDetail

### DIFF
--- a/apps/app/src/lib/pushNotificationRouting.ts
+++ b/apps/app/src/lib/pushNotificationRouting.ts
@@ -108,7 +108,7 @@ export function resolvePushNotificationRoute(input: unknown) {
         if (teamId) {
             return `/schedule/${encodeRouteParam(teamId)}/${encodeRouteParam(gameId)}`;
         }
-        return '/schedule';
+        return `/games/${encodeRouteParam(gameId)}`;
     }
     if (category === 'schedule') {
         if (teamId && eventId) {

--- a/tests/unit/app-notification-open-routing.test.jsx
+++ b/tests/unit/app-notification-open-routing.test.jsx
@@ -4,22 +4,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createRoot } from 'react-dom/client';
 import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { addPushNotificationOpenListener } from '../../apps/app/src/lib/pushService.ts';
+import { resolvePushNotificationRoute } from '../../apps/app/src/lib/pushNotificationRouting.ts';
 
 const pushListenerState = vi.hoisted(() => ({ listener: null }));
 
 vi.mock('../../apps/app/src/lib/pushService.ts', () => ({
     addPushNotificationOpenListener: vi.fn(async (onRouteOpen) => {
         pushListenerState.listener = (event) => {
-            const data = event.notification?.data || {};
-            if (data.category === 'liveChat') {
-                onRouteOpen(`/messages/${encodeURIComponent(data.teamId)}`);
-                return;
-            }
-            if (data.category === 'liveScore') {
-                onRouteOpen(`/schedule/${encodeURIComponent(data.teamId)}/${encodeURIComponent(data.gameId)}`);
-                return;
-            }
-            onRouteOpen(`/schedule/${encodeURIComponent(data.teamId)}/${encodeURIComponent(data.eventId)}`);
+            const route = resolvePushNotificationRoute(event.notification?.data || {});
+            onRouteOpen(route);
         };
         return async () => {
             pushListenerState.listener = null;
@@ -57,6 +50,7 @@ function NotificationOpenHarness() {
                 <Route path="/home" element={<div>Home</div>} />
                 <Route path="/messages/:teamId" element={<div>Messages</div>} />
                 <Route path="/schedule/:teamId/:eventId" element={<div>Schedule Event</div>} />
+                <Route path="/games/:gameId" element={<div>Game Detail</div>} />
             </Routes>
             <LocationProbe />
         </>
@@ -103,6 +97,7 @@ describe('app notification open routing', () => {
     it.each([
         [{ category: 'liveChat', teamId: 'team-1' }, '/messages/team-1'],
         [{ category: 'liveScore', teamId: 'team-1', gameId: 'game-7' }, '/schedule/team-1/game-7'],
+        [{ category: 'liveScore', gameId: 'game-7' }, '/games/game-7'],
         [{ category: 'schedule', teamId: 'team-1', eventId: 'event-9' }, '/schedule/team-1/event-9']
     ])('navigates to the expected route when a notification is opened: %o', async (payload, expectedRoute) => {
         const { container, root } = await renderHarness();

--- a/tests/unit/app-push-notification-routing.test.ts
+++ b/tests/unit/app-push-notification-routing.test.ts
@@ -17,6 +17,7 @@ describe('app push notification routing', () => {
         expect(resolvePushNotificationRoute({ category: 'liveChat', teamId: 'team-1', conversationId: 'staff-2' })).toBe('/messages/team-1?conversationId=staff-2');
         expect(resolvePushNotificationRoute({ category: 'liveChat', teamId: 'team-1', conversationId: 'staff-2', appRoute: '/messages/team-1' })).toBe('/messages/team-1?conversationId=staff-2');
         expect(resolvePushNotificationRoute({ category: 'liveScore', teamId: 'team-1', gameId: 'game-7' })).toBe('/schedule/team-1/game-7');
+        expect(resolvePushNotificationRoute({ category: 'liveScore', gameId: 'game-7' })).toBe('/games/game-7');
         expect(resolvePushNotificationRoute({ category: 'schedule', teamId: 'team-1', eventId: 'event-9' })).toBe('/schedule/team-1/event-9');
     });
 


### PR DESCRIPTION
Closes #1932

## What changed
- Updated `resolvePushNotificationRoute` so `liveScore` payloads with `gameId` but no `teamId` now route to `/games/:gameId` instead of falling back to `/schedule`.
- Added a unit regression test for the gameId-only `liveScore` payload shape.
- Updated notification-open routing coverage to use the real push route resolver and assert the gameId-only notification path navigates to `/games/:gameId`.

## Root Cause
`resolvePushNotificationRoute` treated all `liveScore` notifications as team-scoped schedule links. When `teamId` was missing, it dropped the user on `/schedule` even if `gameId` was present, bypassing the existing `/games/:gameId` recovery flow that can resolve the correct event from game context alone.

## Prevention / Learning
When a notification payload may arrive partially scoped, route helpers should fall back to the app's existing identifier-specific recovery route instead of a generic landing page. Future push-routing changes need regression coverage for the minimum valid payload shape, not only the fully hydrated happy path.

## Regression Tests
- `npx vitest run tests/unit/app-push-notification-routing.test.ts tests/unit/app-notification-open-routing.test.jsx apps/app/src/pages/GameDetail.test.tsx --reporter=verbose`
- Added coverage for `liveScore + gameId-only -> /games/:gameId` in `tests/unit/app-push-notification-routing.test.ts`
- Added notification-open coverage for `liveScore + gameId-only` in `tests/unit/app-notification-open-routing.test.jsx`
- Reused existing `apps/app/src/pages/GameDetail.test.tsx` coverage to validate `/games/:gameId` still resolves into the schedule event workflow or the existing recovery state

## Recurrence Risk
Low. The fallback now matches the existing gameId-only deep-link behavior and the focused tests cover both route resolution and notification-open navigation.