### PR TITLE
Add team media album cover selection

### DIFF
--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -21,7 +21,8 @@ import {
   uploadTeamMediaPhoto,
   deleteTeamMediaItem,
   updateTeamMediaItem,
-  moveTeamMediaItems
+  moveTeamMediaItems,
+  setTeamMediaAlbumCover
 } from '../../../../js/db.js';
 import { addPendingFamilyMember, readFamilyMembers } from '../../../../js/family-plan.js';
 import { db, doc, collection, getDoc, serverTimestamp, runTransaction } from '../../../../js/firebase.js';
@@ -229,6 +230,11 @@ export async function updateTeamMediaItemForApp(teamId: string, itemId: string, 
 export async function moveTeamMediaItemForApp(teamId: string, itemId: string, targetFolderId: string) {
   if (!teamId || !itemId || !targetFolderId) throw new Error('Missing team, media item, or destination album ID.');
   return moveTeamMediaItems(teamId, [itemId], targetFolderId);
+}
+
+export async function setTeamMediaAlbumCoverForApp(teamId: string, folderId: string, item: TeamMediaItem) {
+  if (!teamId || !folderId || !item?.id) throw new Error('Choose a photo to use as the album cover.');
+  return setTeamMediaAlbumCover(teamId, folderId, item);
 }
 
 export async function bulkDeleteTeamMediaItemsForApp(teamId: string, items: TeamMediaItem[]) {

--- a/apps/app/src/pages/TeamMedia.test.tsx
+++ b/apps/app/src/pages/TeamMedia.test.tsx
@@ -12,6 +12,7 @@ const parentToolsServiceMocks = vi.hoisted(() => ({
   deleteTeamMediaItemForApp: vi.fn(),
   loadTeamMediaForApp: vi.fn(),
   moveTeamMediaItemForApp: vi.fn(),
+  setTeamMediaAlbumCoverForApp: vi.fn(),
   updateTeamMediaItemForApp: vi.fn(),
   uploadParentTeamMediaFile: vi.fn(),
   uploadParentTeamMediaPhoto: vi.fn()
@@ -93,6 +94,7 @@ describe('TeamMedia bulk delete', () => {
     parentToolsServiceMocks.deleteTeamMediaItemForApp.mockReset();
     parentToolsServiceMocks.loadTeamMediaForApp.mockReset();
     parentToolsServiceMocks.moveTeamMediaItemForApp.mockReset();
+    parentToolsServiceMocks.setTeamMediaAlbumCoverForApp.mockReset();
     parentToolsServiceMocks.updateTeamMediaItemForApp.mockReset();
     parentToolsServiceMocks.uploadParentTeamMediaFile.mockReset();
     parentToolsServiceMocks.uploadParentTeamMediaPhoto.mockReset();

--- a/apps/app/src/pages/TeamMedia.test.tsx
+++ b/apps/app/src/pages/TeamMedia.test.tsx
@@ -205,4 +205,24 @@ describe('TeamMedia bulk delete', () => {
     }));
     expect(await screen.findByText('Photo posted to team chat.')).toBeTruthy();
   });
+
+  it('renders an album without a cover photo using the fallback icon', async () => {
+    parentToolsServiceMocks.loadTeamMediaForApp.mockResolvedValueOnce(createModel({
+      folders: [
+        {
+          id: 'album-1',
+          name: 'Empty album',
+          visibility: 'team',
+          itemCount: 0,
+          items: []
+        }
+      ]
+    }));
+
+    const { container } = renderTeamMedia();
+
+    await screen.findByText('Bears media');
+    expect(screen.getByText('No media in this album.')).toBeTruthy();
+    expect(container.querySelectorAll('img').length).toBe(0);
+  });
 });

--- a/apps/app/src/pages/TeamMedia.test.tsx
+++ b/apps/app/src/pages/TeamMedia.test.tsx
@@ -225,4 +225,26 @@ describe('TeamMedia bulk delete', () => {
     expect(screen.getByText('No media in this album.')).toBeTruthy();
     expect(container.querySelectorAll('img').length).toBe(0);
   });
+
+  it('renders a folder cover image when cover photo metadata exists without a folder item', async () => {
+    parentToolsServiceMocks.loadTeamMediaForApp.mockResolvedValueOnce(createModel({
+      folders: [
+        {
+          id: 'album-1',
+          name: 'Highlights',
+          visibility: 'team',
+          itemCount: 0,
+          coverPhotoId: 'cover-1',
+          coverPhotoUrl: 'https://example.com/cover.jpg',
+          coverPhotoTitle: 'Album cover',
+          items: []
+        }
+      ]
+    }));
+
+    const { container } = renderTeamMedia();
+
+    await screen.findByText('Bears media');
+    expect(container.querySelector('img[src="https://example.com/cover.jpg"]')).toBeTruthy();
+  });
 });

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -711,9 +711,9 @@ async function runWithConcurrency<T>(items: T[], concurrency: number, worker: (i
   await Promise.all(workers);
 }
 
-function isPhotoMediaItem(item: TeamMediaItem | null | undefined) {
+function isPhotoMediaItem(item: TeamMediaItem | null | undefined): item is TeamMediaItem {
   const type = String(item?.type || '').toLowerCase();
-  return type === 'photo' || type.includes('image');
+  return Boolean(item) && (type === 'photo' || type.includes('image'));
 }
 
 function isVideoMediaItem(item: TeamMediaItem) {

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -35,6 +35,7 @@ import {
   bulkDeleteTeamMediaItemsForApp,
   updateTeamMediaItemForApp,
   moveTeamMediaItemForApp,
+  setTeamMediaAlbumCoverForApp,
   type TeamMediaFolder,
   type TeamMediaItem,
   type TeamMediaModel
@@ -60,6 +61,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const [deletingItemId, setDeletingItemId] = useState('');
   const [renamingItemId, setRenamingItemId] = useState('');
   const [movingItemId, setMovingItemId] = useState('');
+  const [coverItemId, setCoverItemId] = useState('');
   const [postingItemId, setPostingItemId] = useState('');
   const postingItemIdRef = useRef('');
   const [message, setMessage] = useState('');
@@ -159,6 +161,32 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
     }
   };
 
+  const handleSetAlbumCover = async (item: TeamMediaItem) => {
+    if (!teamId || !activeFolder?.id || !item?.id) return;
+
+    setCoverItemId(item.id);
+    setError('');
+    setMessage('');
+    try {
+      await setTeamMediaAlbumCoverForApp(teamId, activeFolder.id, item);
+      setModel((current) => current ? {
+        ...current,
+        folders: current.folders.map((folder) => folder.id === activeFolder.id ? {
+          ...folder,
+          coverPhotoId: item.id,
+          coverPhotoUrl: item.url,
+          coverPhotoTitle: item.title || 'Album cover'
+        } : folder)
+      } : current);
+      setMessage('Album cover saved.');
+      await refresh({ showLoading: false, preferredFolderId: activeFolder.id });
+    } catch (coverError: any) {
+      setError(coverError?.message || 'Unable to save album cover.');
+    } finally {
+      setCoverItemId('');
+    }
+  };
+
   const handlePostItemToChat = async (item: TeamMediaItem, caption = '') => {
     if (!teamId || !auth.user || !item?.id || postingItemIdRef.current) return false;
 
@@ -212,7 +240,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const selectedCount = selectedItems.length;
   const selectedMediaTypeLabel = MEDIA_TYPE_FILTERS.find((filter) => filter.id === selectedMediaType)?.label || 'All';
   const emptyStateLabel = selectedMediaType === 'all' ? 'media' : selectedMediaTypeLabel.toLowerCase();
-  const featured = activeFolder?.items[0] || allItems[0] || null;
+  const featured = activeFolder ? getFolderCoverMedia(activeFolder) || allItems[0] || null : allItems[0] || null;
 
   useEffect(() => {
     setSelectedIds((current) => current.filter((itemId) => visibleItemIds.includes(itemId)));
@@ -414,7 +442,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
             <ChevronLeft className="h-4 w-4" aria-hidden="true" />
           </Link>
           <div className="flex h-11 w-11 flex-none items-center justify-center overflow-hidden rounded-2xl bg-primary-50 text-primary-700">
-            {featured?.type === 'photo' ? <img src={featured.url} alt="" className="h-full w-full object-cover" /> : <ImageIcon className="h-5 w-5" aria-hidden="true" />}
+            {isPhotoMediaItem(featured) ? <img src={featured.url} alt="" className="h-full w-full object-cover" /> : <ImageIcon className="h-5 w-5" aria-hidden="true" />}
           </div>
           <div className="min-w-0 flex-1">
             <div className="app-label">Team media</div>
@@ -431,7 +459,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
             <button
               key={folder.id}
               type="button"
-              className={`flex min-h-9 flex-none items-center gap-2 rounded-full border px-3 text-xs font-black ${activeFolder?.id === folder.id ? 'border-primary-600 bg-primary-600 text-white' : 'border-gray-200 bg-gray-50 text-gray-700'}`}
+              className={`flex min-h-9 flex-none items-center gap-2 rounded-full border px-2 py-1 text-xs font-black ${activeFolder?.id === folder.id ? 'border-primary-600 bg-primary-600 text-white' : 'border-gray-200 bg-gray-50 text-gray-700'}`}
               onClick={() => {
                 setActiveFolderId(folder.id);
                 setSelectedMediaType('all');
@@ -439,6 +467,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
               }}
               aria-pressed={activeFolder?.id === folder.id}
             >
+              <FolderCoverThumb folder={folder} active={activeFolder?.id === folder.id} />
               {folder.name || 'Album'}
               <span className={`rounded-full px-1.5 py-0.5 text-[10px] ${activeFolder?.id === folder.id ? 'bg-white/20 text-white' : 'bg-white text-gray-600'}`}>{folder.itemCount}</span>
             </button>
@@ -604,11 +633,13 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
               selected={selectedIds.includes(item.id)}
               renaming={renamingItemId === item.id}
               moving={movingItemId === item.id}
+              settingCover={coverItemId === item.id}
               posting={postingItemId === item.id}
               onToggleSelected={toggleItemSelection}
               onRenameItem={handleRenameItem}
               onDeleteItem={handleDeleteItem}
               onMoveItem={handleMoveItem}
+              onSetAlbumCover={handleSetAlbumCover}
               onPostToChat={handlePostItemToChat}
             />
           )) : (
@@ -680,8 +711,8 @@ async function runWithConcurrency<T>(items: T[], concurrency: number, worker: (i
   await Promise.all(workers);
 }
 
-function isPhotoMediaItem(item: TeamMediaItem) {
-  const type = String(item.type || '').toLowerCase();
+function isPhotoMediaItem(item: TeamMediaItem | null | undefined) {
+  const type = String(item?.type || '').toLowerCase();
   return type === 'photo' || type.includes('image');
 }
 
@@ -709,6 +740,32 @@ function getMediaTypeCounts(items: TeamMediaItem[]) {
   };
 }
 
+function getFolderCoverMedia(folder: TeamMediaFolder | null) {
+  if (!folder) return null;
+
+  const coverPhotoUrl = String(folder.coverPhotoUrl || '').trim();
+  if (coverPhotoUrl) {
+    return {
+      id: String(folder.coverPhotoId || 'album-cover').trim() || 'album-cover',
+      url: coverPhotoUrl,
+      title: String(folder.coverPhotoTitle || folder.name || 'Album cover').trim() || 'Album cover',
+      type: 'photo'
+    };
+  }
+
+  return folder.items[0] || null;
+}
+
+function FolderCoverThumb({ folder, active }: { folder: TeamMediaFolder; active: boolean }) {
+  const cover = getFolderCoverMedia(folder);
+
+  return (
+    <span className={`flex h-6 w-6 flex-none items-center justify-center overflow-hidden rounded-full ${active ? 'bg-white/20 text-white' : 'bg-white text-gray-500'}`} aria-hidden="true">
+      {isPhotoMediaItem(cover) ? <img src={cover.url} alt="" className="h-full w-full object-cover" /> : <ImageIcon className="h-3.5 w-3.5" aria-hidden="true" />}
+    </span>
+  );
+}
+
 function TeamMediaItemCard({
   item,
   onStatus,
@@ -722,11 +779,13 @@ function TeamMediaItemCard({
   selected,
   renaming,
   moving,
+  settingCover,
   posting,
   onToggleSelected,
   onRenameItem,
   onDeleteItem,
   onMoveItem,
+  onSetAlbumCover,
   onPostToChat
 }: {
   item: TeamMediaItem;
@@ -741,11 +800,13 @@ function TeamMediaItemCard({
   selected: boolean;
   renaming: boolean;
   moving: boolean;
+  settingCover: boolean;
   posting: boolean;
   onToggleSelected: (itemId: string, checked: boolean) => void;
   onRenameItem: (item: TeamMediaItem, title: string) => Promise<void>;
   onDeleteItem: (item: TeamMediaItem) => void;
   onMoveItem: (item: TeamMediaItem, targetFolderId: string) => Promise<void>;
+  onSetAlbumCover: (item: TeamMediaItem) => Promise<void>;
   onPostToChat: (item: TeamMediaItem, caption: string) => Promise<boolean>;
 }) {
   const Icon = getItemIcon(item);
@@ -897,6 +958,12 @@ function TeamMediaItemCard({
             <button type="button" className="ghost-button !h-8 !min-h-8 !px-2 !text-xs" onClick={() => setIsPosting((current) => !current)} disabled={posting} aria-label={`Post ${title} to team chat`}>
               {posting ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" /> : <MessageCircle className="h-3.5 w-3.5" aria-hidden="true" />}
               Post to team chat
+            </button>
+          )}
+          {canManage && isPhoto && (
+            <button type="button" className="ghost-button !h-8 !min-h-8 !px-2 !text-xs" onClick={() => onSetAlbumCover(item)} disabled={settingCover} aria-label={`Set ${title} as album cover`}>
+              {settingCover ? <Loader2 className="h-3.5 w-3.5 animate-spin" aria-hidden="true" /> : <ImageIcon className="h-3.5 w-3.5" aria-hidden="true" />}
+              {settingCover ? 'Saving cover' : 'Set as cover'}
             </button>
           )}
           {canMove && (

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -758,10 +758,11 @@ function getFolderCoverMedia(folder: TeamMediaFolder | null) {
 
 function FolderCoverThumb({ folder, active }: { folder: TeamMediaFolder; active: boolean }) {
   const cover = getFolderCoverMedia(folder);
+  const coverUrl = cover && isPhotoMediaItem(cover) ? cover.url : '';
 
   return (
     <span className={`flex h-6 w-6 flex-none items-center justify-center overflow-hidden rounded-full ${active ? 'bg-white/20 text-white' : 'bg-white text-gray-500'}`} aria-hidden="true">
-      {isPhotoMediaItem(cover) ? <img src={cover.url} alt="" className="h-full w-full object-cover" /> : <ImageIcon className="h-3.5 w-3.5" aria-hidden="true" />}
+      {coverUrl ? <img src={coverUrl} alt="" className="h-full w-full object-cover" /> : <ImageIcon className="h-3.5 w-3.5" aria-hidden="true" />}
     </span>
   );
 }

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -263,6 +263,9 @@ async function mockParentToolsModules(page) {
                 export async function moveTeamMediaItemForApp() {
                     return undefined;
                 }
+                export async function setTeamMediaAlbumCoverForApp() {
+                    return undefined;
+                }
             `
         });
     });

--- a/tests/unit/app-parent-tools-household-service.test.js
+++ b/tests/unit/app-parent-tools-household-service.test.js
@@ -6,7 +6,8 @@ const familyPlanMocks = vi.hoisted(() => ({
 }));
 
 const dbMocks = vi.hoisted(() => ({
-    moveTeamMediaItems: vi.fn()
+    moveTeamMediaItems: vi.fn(),
+    setTeamMediaAlbumCover: vi.fn()
 }));
 
 vi.mock('../../js/family-plan.js', () => familyPlanMocks);
@@ -32,7 +33,8 @@ vi.mock('../../js/db.js', () => ({
     uploadTeamMediaPhoto: vi.fn(),
     deleteTeamMediaItem: vi.fn(),
     updateTeamMediaItem: vi.fn(),
-    moveTeamMediaItems: dbMocks.moveTeamMediaItems
+    moveTeamMediaItems: dbMocks.moveTeamMediaItems,
+    setTeamMediaAlbumCover: dbMocks.setTeamMediaAlbumCover
 }));
 vi.mock('../../js/firebase.js', () => ({
     db: {},
@@ -77,7 +79,8 @@ vi.mock('../../apps/app/src/lib/scheduleService.ts', () => ({ loadParentSchedule
 import {
     createParentHouseholdMemberInvite,
     loadParentHouseholdInviteModel,
-    moveTeamMediaItemForApp
+    moveTeamMediaItemForApp,
+    setTeamMediaAlbumCoverForApp
 } from '../../apps/app/src/lib/parentToolsService.ts';
 
 const user = {
@@ -90,6 +93,7 @@ beforeEach(() => {
     familyPlanMocks.readFamilyMembers.mockResolvedValue([]);
     familyPlanMocks.addPendingFamilyMember.mockResolvedValue({ code: 'HOME1234', inviteUrl: 'accept-invite.html?code=HOME1234' });
     dbMocks.moveTeamMediaItems.mockResolvedValue(undefined);
+    dbMocks.setTeamMediaAlbumCover.mockResolvedValue(undefined);
 });
 
 describe('Parent Tools household invite service', () => {
@@ -148,5 +152,24 @@ describe('React app team media move service', () => {
         await expect(moveTeamMediaItemForApp('team-1', '', 'folder-2')).rejects.toThrow('Missing team, media item, or destination album ID.');
         await expect(moveTeamMediaItemForApp('team-1', 'item-1', '')).rejects.toThrow('Missing team, media item, or destination album ID.');
         expect(dbMocks.moveTeamMediaItems).not.toHaveBeenCalled();
+    });
+});
+
+describe('React app team media cover service', () => {
+    it('persists a selected photo through the legacy album cover helper', async () => {
+        const item = { id: 'item-1', title: 'Bench celebration', type: 'photo', url: 'https://example.test/bench.jpg' };
+
+        await setTeamMediaAlbumCoverForApp('team-1', 'folder-2', item);
+
+        expect(dbMocks.setTeamMediaAlbumCover).toHaveBeenCalledWith('team-1', 'folder-2', item);
+    });
+
+    it('rejects missing cover identifiers before calling the legacy helper', async () => {
+        const item = { id: 'item-1', type: 'photo', url: 'https://example.test/bench.jpg' };
+
+        await expect(setTeamMediaAlbumCoverForApp('', 'folder-2', item)).rejects.toThrow('Choose a photo to use as the album cover.');
+        await expect(setTeamMediaAlbumCoverForApp('team-1', '', item)).rejects.toThrow('Choose a photo to use as the album cover.');
+        await expect(setTeamMediaAlbumCoverForApp('team-1', 'folder-2', { ...item, id: '' })).rejects.toThrow('Choose a photo to use as the album cover.');
+        expect(dbMocks.setTeamMediaAlbumCover).not.toHaveBeenCalled();
     });
 });

--- a/tests/unit/app-team-media.test.jsx
+++ b/tests/unit/app-team-media.test.jsx
@@ -14,6 +14,7 @@ const parentToolsServiceMocks = vi.hoisted(() => ({
   deleteTeamMediaItemForApp: vi.fn(),
   updateTeamMediaItemForApp: vi.fn(),
   moveTeamMediaItemForApp: vi.fn(),
+  setTeamMediaAlbumCoverForApp: vi.fn(),
 }));
 
 const publicActionsMocks = vi.hoisted(() => ({
@@ -76,7 +77,12 @@ const mediaModel = (overrides = {}) => ({
 });
 
 async function renderTeamMedia(model = mediaModel()) {
-  parentToolsServiceMocks.loadTeamMediaForApp.mockResolvedValue(model);
+  if (Array.isArray(model)) {
+    model.forEach((entry) => parentToolsServiceMocks.loadTeamMediaForApp.mockResolvedValueOnce(entry));
+    parentToolsServiceMocks.loadTeamMediaForApp.mockResolvedValue(model[model.length - 1]);
+  } else {
+    parentToolsServiceMocks.loadTeamMediaForApp.mockResolvedValue(model);
+  }
   const container = document.createElement('div');
   document.body.appendChild(container);
   const root = createRoot(container);
@@ -133,6 +139,7 @@ beforeEach(() => {
   parentToolsServiceMocks.bulkDeleteTeamMediaItemsForApp.mockResolvedValue(undefined);
   parentToolsServiceMocks.updateTeamMediaItemForApp.mockResolvedValue(undefined);
   parentToolsServiceMocks.moveTeamMediaItemForApp.mockResolvedValue(undefined);
+  parentToolsServiceMocks.setTeamMediaAlbumCoverForApp.mockResolvedValue(undefined);
   chatServiceMocks.sendTeamChatMessage.mockResolvedValue({ conversationId: 'team', createdConversation: null, wantsAi: false });
 });
 
@@ -207,6 +214,93 @@ describe('React app TeamMedia rename flow', () => {
     expect(parentToolsServiceMocks.updateTeamMediaItemForApp).not.toHaveBeenCalled();
     expect(container.textContent).toContain('Tipoff');
     expect(container.textContent).toContain('Media item title cannot be empty.');
+
+    await act(async () => root.unmount());
+  });
+});
+
+describe('React app TeamMedia album cover flow', () => {
+  it('prefers a persisted album cover over the first media item and only shows Set as cover for managers on photos', async () => {
+    const coverModel = mediaModel({
+      canManage: true,
+      folders: [{
+        id: 'folder-1',
+        name: 'Game media',
+        visibility: 'team',
+        itemCount: 2,
+        coverPhotoId: 'cover-1',
+        coverPhotoUrl: 'https://example.test/cover.jpg',
+        coverPhotoTitle: 'Chosen cover',
+        items: [
+          { id: 'owned-photo', title: 'Tipoff', type: 'photo', url: 'https://example.test/tipoff.jpg', uploadedBy: 'user-1' },
+          { id: 'other-file', title: 'Scouting PDF', type: 'file', url: 'https://example.test/scout.pdf', uploadedBy: 'user-2' },
+        ],
+      }],
+    });
+    const { container, root } = await renderTeamMedia(coverModel);
+
+    expect(container.querySelector('img[src="https://example.test/cover.jpg"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Set Tipoff as album cover"]')).not.toBeNull();
+    expect(container.querySelector('[aria-label="Set Scouting PDF as album cover"]')).toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('saves a photo as the album cover, refreshes, and shows the updated thumbnail', async () => {
+    const initialModel = mediaModel({ canManage: true });
+    const refreshedModel = mediaModel({
+      canManage: true,
+      folders: [{
+        ...initialModel.folders[0],
+        coverPhotoId: 'owned-photo',
+        coverPhotoUrl: 'https://example.test/tipoff.jpg',
+        coverPhotoTitle: 'Tipoff',
+      }],
+    });
+    const { container, root } = await renderTeamMedia([initialModel, refreshedModel]);
+
+    await act(async () => {
+      container.querySelector('[aria-label="Set Tipoff as album cover"]').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(parentToolsServiceMocks.setTeamMediaAlbumCoverForApp).toHaveBeenCalledWith(
+      'team-1',
+      'folder-1',
+      expect.objectContaining({ id: 'owned-photo', type: 'photo', url: 'https://example.test/tipoff.jpg' })
+    );
+    expect(container.textContent).toContain('Album cover saved.');
+    expect(container.querySelector('img[src="https://example.test/tipoff.jpg"]')).not.toBeNull();
+
+    await act(async () => root.unmount());
+  });
+
+  it('keeps the current cover visible and shows the error when saving the album cover fails', async () => {
+    parentToolsServiceMocks.setTeamMediaAlbumCoverForApp.mockRejectedValueOnce(new Error('Album cover must use a valid photo URL.'));
+    const coverModel = mediaModel({
+      canManage: true,
+      folders: [{
+        id: 'folder-1',
+        name: 'Game media',
+        visibility: 'team',
+        itemCount: 2,
+        coverPhotoId: 'cover-1',
+        coverPhotoUrl: 'https://example.test/current-cover.jpg',
+        coverPhotoTitle: 'Current cover',
+        items: [
+          { id: 'owned-photo', title: 'Tipoff', type: 'photo', url: 'https://example.test/tipoff.jpg', uploadedBy: 'user-1' },
+          { id: 'other-file', title: 'Scouting PDF', type: 'file', url: 'https://example.test/scout.pdf', uploadedBy: 'user-2' },
+        ],
+      }],
+    });
+    const { container, root } = await renderTeamMedia(coverModel);
+
+    await act(async () => {
+      container.querySelector('[aria-label="Set Tipoff as album cover"]').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(parentToolsServiceMocks.loadTeamMediaForApp).toHaveBeenCalledTimes(1);
+    expect(container.textContent).toContain('Album cover must use a valid photo URL.');
+    expect(container.querySelector('img[src="https://example.test/current-cover.jpg"]')).not.toBeNull();
 
     await act(async () => root.unmount());
   });


### PR DESCRIPTION
Closes #1928

## What changed
- added `setTeamMediaAlbumCoverForApp` so the React route can call the existing legacy album-cover persistence helper
- updated `TeamMedia` to prefer `folder.coverPhotoUrl` and `coverPhotoTitle` for the page header and album pill thumbnails, with first-item fallback only when no saved cover exists
- added a manager-only `Set as cover` action for photo items, kept the current cover in place on failure, and refreshed the active album after a successful save
- added focused regression coverage for the new service helper and the Team Media cover-selection flow

## Root Cause
The React Team Media route never exposed the existing legacy `setTeamMediaAlbumCover` write path and derived album thumbnails only from the first loaded item. That meant persisted `coverPhotoId` / `coverPhotoUrl` / `coverPhotoTitle` metadata was ignored, and managers had no way to set a cover in the shared web/iOS/Android route.

## Prevention / Learning
When migrating legacy media surfaces into the shared React route, carry over both the persisted display metadata and the adjacent manager-only write actions. Do not rebuild album thumbnails from fallback item order alone when the backend already stores canonical folder cover fields.

## Regression Tests
- `tests/unit/app-parent-tools-household-service.test.js`
  - verifies `setTeamMediaAlbumCoverForApp` rejects missing identifiers and forwards valid photo items to the legacy helper
- `tests/unit/app-team-media.test.jsx`
  - verifies saved folder cover metadata wins over first-item fallback
  - verifies `Set as cover` appears only for manager photo items
  - verifies saving a cover refreshes the route and shows `Album cover saved.`
  - verifies a failed cover save keeps the previous cover visible and shows the returned error
- `apps/app/src/pages/TeamMedia.test.tsx`
  - updated the page-local mock surface so the focused TeamMedia test file stays aligned with the route imports