### PR TITLE
Load Player Detail from scoped schedule data

### DIFF
--- a/apps/app/src/lib/playerService.ts
+++ b/apps/app/src/lib/playerService.ts
@@ -33,7 +33,7 @@ import { buildAthleteProfileShareUrl } from '../../../../js/athlete-profile-util
 import { collectPlayerVideoClips } from '../../../../js/player-profile-stats.js';
 import { getVisiblePlayerTrackingSummary } from '../../../../js/player-tracking-summary.js';
 import { getOpenScheduleAssignments, normalizeRsvpResponse, type ParentScheduleEvent } from './scheduleLogic';
-import { loadParentSchedule, type ParentScheduleChild } from './scheduleService';
+import { loadParentPlayerSchedule, type ParentScheduleChild } from './scheduleService';
 import type { AuthUser } from './types';
 
 export type ParentPlayerStatRow = {
@@ -107,7 +107,7 @@ export async function loadParentPlayerDetail(user: AuthUser | null, teamId: stri
     throw new Error('Player details require a signed-in user.');
   }
 
-  const schedule = await loadParentSchedule(user);
+  const schedule = await loadParentPlayerSchedule(user, { teamId, playerId });
   const child = findLinkedChild(schedule.children, teamId, playerId);
   if (!child) {
     throw new Error('This player is not linked to your account.');

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -121,6 +121,11 @@ export type ParentScheduleEventDetailLoadOptions = ParentScheduleLoadOptions & {
   eventId: string;
 };
 
+export type ParentPlayerScheduleLoadOptions = ParentScheduleLoadOptions & {
+  teamId?: string;
+  playerId: string;
+};
+
 export type ParentGameRouteResolution = {
   teamId: string;
   eventId: string;
@@ -1853,6 +1858,48 @@ export async function loadParentScheduleEventDetail(user: AuthUser | null, optio
     return { children, events };
   } catch (error: any) {
     timer.end({ hydrateDetails, expandStaffPlayers, teamId: requestedTeamId, eventId: requestedEventId, error: error?.message || 'Unable to load schedule event detail.' });
+    throw error;
+  }
+}
+
+export async function loadParentPlayerSchedule(user: AuthUser | null, options: ParentPlayerScheduleLoadOptions): Promise<ParentScheduleLoadResult> {
+  const requestedTeamId = compactString(options?.teamId);
+  const requestedPlayerId = compactString(options?.playerId);
+
+  if (!user?.uid || !requestedPlayerId) {
+    return { children: [], events: [] };
+  }
+
+  const timer = startUxTimer('parent player schedule load');
+  const hydrateDetails = options.hydrateDetails !== false;
+
+  try {
+    const profile = await loadProfileDocument(user.uid);
+    const children = normalizeChildLinks(user, profile as Record<string, unknown>);
+    const child = (requestedTeamId && requestedPlayerId)
+      ? children.find((entry) => entry.teamId === requestedTeamId && entry.playerId === requestedPlayerId)
+      : children.find((entry) => entry.playerId === requestedPlayerId);
+
+    if (!child) {
+      timer.end({ hydrateDetails, teamId: requestedTeamId || null, playerId: requestedPlayerId, childLinks: children.length, eventRows: 0 });
+      return { children, events: [] };
+    }
+
+    const events = await buildTeamSchedule(child.teamId, [child], user);
+    if (hydrateDetails && events.length) {
+      await hydrateEventDetails(events, user);
+    }
+    timer.end({
+      hydrateDetails,
+      requestedTeamId: requestedTeamId || null,
+      resolvedTeamId: child.teamId,
+      playerId: child.playerId,
+      childLinks: children.length,
+      eventRows: events.length
+    });
+    return { children, events };
+  } catch (error: any) {
+    timer.end({ hydrateDetails, teamId: requestedTeamId || null, playerId: requestedPlayerId, error: error?.message || 'Unable to load player schedule.' });
     throw error;
   }
 }

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -1876,9 +1876,27 @@ export async function loadParentPlayerSchedule(user: AuthUser | null, options: P
   try {
     const profile = await loadProfileDocument(user.uid);
     const children = normalizeChildLinks(user, profile as Record<string, unknown>);
-    const child = (requestedTeamId && requestedPlayerId)
+    let child = (requestedTeamId && requestedPlayerId)
       ? children.find((entry) => entry.teamId === requestedTeamId && entry.playerId === requestedPlayerId)
       : children.find((entry) => entry.playerId === requestedPlayerId);
+
+    if (!child && requestedTeamId) {
+      const team = await loadTeam(requestedTeamId).catch(() => null);
+      const teamWithId = team ? { ...team, id: team.id || requestedTeamId } : null;
+      if (teamWithId && isTeamStaff(teamWithId, user)) {
+        const player = (await loadPlayers(requestedTeamId).catch(() => []))
+          .find((entry: any) => compactString(entry?.id) === requestedPlayerId && isActiveRosterPlayer(entry));
+        if (player) {
+          child = {
+            teamId: requestedTeamId,
+            teamName: compactString(teamWithId.name) || requestedTeamId,
+            playerId: requestedPlayerId,
+            playerName: normalizePlayerName(player)
+          };
+          children.push(child);
+        }
+      }
+    }
 
     if (!child) {
       timer.end({ hydrateDetails, teamId: requestedTeamId || null, playerId: requestedPlayerId, childLinks: children.length, eventRows: 0 });

--- a/tests/unit/app-player-service.test.js
+++ b/tests/unit/app-player-service.test.js
@@ -19,7 +19,7 @@ const dbMocks = vi.hoisted(() => ({
 }));
 
 const scheduleMocks = vi.hoisted(() => ({
-    loadParentSchedule: vi.fn()
+    loadParentPlayerSchedule: vi.fn()
 }));
 
 const profileStatMocks = vi.hoisted(() => ({
@@ -99,7 +99,7 @@ function user() {
 
 beforeEach(() => {
     vi.clearAllMocks();
-    scheduleMocks.loadParentSchedule.mockResolvedValue({
+    scheduleMocks.loadParentPlayerSchedule.mockResolvedValue({
         children: [
             { teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat' },
             { teamId: 'team-2', teamName: 'Thunder', playerId: 'player-2', playerName: 'Sam' }
@@ -199,7 +199,10 @@ describe('React app parent player detail service', () => {
     it('loads a team-scoped linked player with schedule actions, stats, clips, certificates, and tracking', async () => {
         const detail = await loadParentPlayerDetail(user(), 'team-1', 'player-1');
 
-        expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledWith(expect.objectContaining({ uid: 'user-1' }));
+        expect(scheduleMocks.loadParentPlayerSchedule).toHaveBeenCalledWith(expect.objectContaining({ uid: 'user-1' }), {
+            teamId: 'team-1',
+            playerId: 'player-1'
+        });
         expect(dbMocks.getTeam).toHaveBeenCalledWith('team-1', { includeInactive: true });
         expect(dbMocks.getPlayers).toHaveBeenCalledWith('team-1', { includeInactive: true });
         expect(dbMocks.getGames).toHaveBeenCalledWith('team-1');
@@ -262,10 +265,35 @@ describe('React app parent player detail service', () => {
 
     it('falls back to the legacy player-only route and blocks unlinked players', async () => {
         const legacyDetail = await loadParentPlayerDetail(user(), '', 'player-2');
+        expect(scheduleMocks.loadParentPlayerSchedule).toHaveBeenCalledWith(expect.objectContaining({ uid: 'user-1' }), {
+            teamId: '',
+            playerId: 'player-2'
+        });
         expect(legacyDetail.child).toMatchObject({ teamId: 'team-2', playerId: 'player-2' });
 
         await expect(loadParentPlayerDetail(user(), 'team-9', 'player-9')).rejects.toThrow('This player is not linked to your account.');
         await expect(loadParentPlayerDetail(null, 'team-1', 'player-1')).rejects.toThrow('signed-in user');
+    });
+
+    it('ignores off-team schedule rows when computing player detail data', async () => {
+        scheduleMocks.loadParentPlayerSchedule.mockResolvedValueOnce({
+            children: [
+                { teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat' },
+                { teamId: 'team-2', teamName: 'Thunder', playerId: 'player-2', playerName: 'Sam' }
+            ],
+            events: [
+                event({ id: 'game-next', teamId: 'team-1', childId: 'player-1', date: new Date('2100-06-01T18:00:00Z') }),
+                event({ id: 'game-final', teamId: 'team-1', childId: 'player-1', status: 'completed', liveStatus: 'completed', myRsvp: 'going', date: new Date('2000-06-01T18:00:00Z') }),
+                event({ id: 'other-team-game', teamId: 'team-2', teamName: 'Thunder', childId: 'player-2', childName: 'Sam', date: new Date('2100-06-03T18:00:00Z') })
+            ]
+        });
+
+        const detail = await loadParentPlayerDetail(user(), 'team-1', 'player-1');
+
+        expect(detail.events.map((item) => item.id)).toEqual(['game-final', 'game-next']);
+        expect(detail.nextEvent?.id).toBe('game-next');
+        expect(dbMocks.getAggregatedStatsForPlayer).toHaveBeenCalledTimes(1);
+        expect(dbMocks.getAggregatedStatsForPlayer).toHaveBeenCalledWith('team-1', 'game-final', 'player-1');
     });
 
     it('keeps the player page usable when optional profile data fails', async () => {

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -128,7 +128,7 @@ vi.mock('../../js/snack-helpers.js', () => ({
     }))
 }));
 
-import { addTeamCalendarUrl, cancelPracticeOccurrenceForApp, createScheduleImportGame, createScheduleImportPractice, createStaffRsvpReminderPreviewLoader, loadParentSchedule, loadParentScheduleEventDetail, parseRecurringPracticeOccurrenceId, removeTeamCalendarUrl } from '../../apps/app/src/lib/scheduleService.ts';
+import { addTeamCalendarUrl, cancelPracticeOccurrenceForApp, createScheduleImportGame, createScheduleImportPractice, createStaffRsvpReminderPreviewLoader, loadParentPlayerSchedule, loadParentSchedule, loadParentScheduleEventDetail, parseRecurringPracticeOccurrenceId, removeTeamCalendarUrl } from '../../apps/app/src/lib/scheduleService.ts';
 import { getScheduleForecastHref, getScheduleMapHref } from '../../apps/app/src/lib/scheduleLogic.ts';
 
 function installWindow(protocol = 'http:') {
@@ -396,6 +396,30 @@ describe('React app schedule service contract integration', () => {
             opponent: 'Eagles',
             location: 'Imported Field'
         });
+    });
+
+    it('loads one linked player schedule without a cross-team fan-out', async () => {
+        dbMocks.getTeams.mockResolvedValue([
+            { id: 'team-staff-1', name: 'Staff Team 1', ownerId: 'user-1' },
+            { id: 'team-staff-2', name: 'Staff Team 2', ownerId: 'user-1' }
+        ]);
+
+        const result = await loadParentPlayerSchedule(user(), { teamId: 'team-1', playerId: 'player-1' });
+
+        expect(profileMocks.loadProfileDocument).toHaveBeenCalledWith('user-1');
+        expect(dbMocks.getTeams).not.toHaveBeenCalled();
+        expect(dbMocks.getTeam).toHaveBeenCalledTimes(1);
+        expect(dbMocks.getTeam).toHaveBeenCalledWith('team-1');
+        expect(dbMocks.getGames).toHaveBeenCalledTimes(1);
+        expect(dbMocks.getGames).toHaveBeenCalledWith('team-1');
+        expect(dbMocks.getPracticeSessions).toHaveBeenCalledTimes(1);
+        expect(dbMocks.getPracticeSessions).toHaveBeenCalledWith('team-1');
+        expect(result.children).toEqual([
+            { teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat' },
+            { teamId: 'team-1', teamName: 'Bears', playerId: 'player-2', playerName: 'Sam' }
+        ]);
+        expect(new Set(result.events.map((event) => event.childId))).toEqual(new Set(['player-1']));
+        expect(result.events.every((event) => event.teamId === 'team-1')).toBe(true);
     });
 
     it('loads schedule event detail without expanding the full team schedule', async () => {

--- a/tests/unit/app-schedule-service-contracts.test.js
+++ b/tests/unit/app-schedule-service-contracts.test.js
@@ -422,6 +422,39 @@ describe('React app schedule service contract integration', () => {
         expect(result.events.every((event) => event.teamId === 'team-1')).toBe(true);
     });
 
+    it('lets staff load a roster player detail without expanding every staff team', async () => {
+        profileMocks.loadProfileDocument.mockResolvedValue({ parentOf: [] });
+        dbMocks.getTeam.mockResolvedValue({
+            id: 'team-1',
+            name: 'Bears',
+            ownerId: 'coach-1',
+            calendarUrls: ['mock://team-calendar'],
+            availabilityPreferences: { noteVisibility: 'team' }
+        });
+        dbMocks.getPlayers.mockResolvedValue([
+            { id: 'player-1', name: 'Pat', active: true },
+            { id: 'player-2', name: 'Sam', active: true }
+        ]);
+
+        const result = await loadParentPlayerSchedule({
+            ...user(),
+            uid: 'coach-1',
+            email: 'coach@example.com',
+            parentOf: [],
+            coachOf: ['team-1']
+        }, { teamId: 'team-1', playerId: 'player-2' });
+
+        expect(dbMocks.getTeams).not.toHaveBeenCalled();
+        expect(dbMocks.getTeam).toHaveBeenCalledWith('team-1');
+        expect(dbMocks.getPlayers).toHaveBeenCalledTimes(1);
+        expect(dbMocks.getPlayers).toHaveBeenCalledWith('team-1', { includeInactive: true });
+        expect(result.children).toEqual([
+            { teamId: 'team-1', teamName: 'Bears', playerId: 'player-2', playerName: 'Sam' }
+        ]);
+        expect(new Set(result.events.map((event) => event.childId))).toEqual(new Set(['player-2']));
+        expect(result.events.every((event) => event.teamId === 'team-1')).toBe(true);
+    });
+
     it('loads schedule event detail without expanding the full team schedule', async () => {
         dbMocks.getGame.mockResolvedValue({
             id: 'game-1',


### PR DESCRIPTION
Closes #1940

## What changed
- added `loadParentPlayerSchedule()` in `apps/app/src/lib/scheduleService.ts` to resolve one linked child and build schedule rows only for that child’s team/player scope
- switched `loadParentPlayerDetail()` to use the scoped loader instead of the full `loadParentSchedule(user)` path
- added focused regression coverage to prove Player Detail no longer depends on the full parent schedule fan-out and ignores off-team rows

## Root Cause
`loadParentPlayerDetail()` reused `loadParentSchedule(user)`, which first expanded every accessible team and, for staff teams, every roster player into per-child schedule rows before the player page filtered back down to one athlete. That made Player Detail pay the cost of whole-account schedule expansion even when it only needed one linked player.

## Prevention / Learning
When a route needs one player or one event, use a caller-scoped schedule loader instead of reusing the account-wide parent schedule path. Shared schedule helpers should default to the smallest scope that satisfies the caller, and roster-expansion behavior should require explicit opt-in.

## Regression Tests
- `npx vitest run tests/unit/app-player-service.test.js --reporter=verbose`
- `npx vitest run tests/unit/app-schedule-service-contracts.test.js --reporter=verbose`
- added service regression assertions that Player Detail calls the new scoped loader, preserves player-only fallback resolution, and ignores off-team schedule rows when computing next event and stats