### PR TITLE
Lock Firestore game reads to authorized viewers

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -365,6 +365,63 @@ service cloud.firestore {
              (isTeamOwnerOrAdmin(teamId) || isParentForTeam(teamId));
     }
 
+    function isPublicGameReadTeam(teamData) {
+      return teamData.get('isPublic', false) == true &&
+             teamData.get('active', true) != false;
+    }
+
+    function isShareableGameDocument(data) {
+      let visibility = data.get('visibility', '');
+      return visibility != 'private' &&
+             data.get('isPrivate', false) != true &&
+             data.get('private', false) != true &&
+             (
+               visibility == 'public' ||
+               data.get('isPublic', false) == true ||
+               data.get('public', false) == true ||
+               data.get('shareable', false) == true ||
+               data.get('isShareable', false) == true ||
+               data.get('publicCalendar', false) == true
+             );
+    }
+
+    function canReadPublicGameDocument(teamData, data) {
+      return data.get('type', 'game') == 'game' &&
+             data.get('visibility', '') != 'private' &&
+             data.get('isPrivate', false) != true &&
+             data.get('private', false) != true &&
+             data.get('status', '') != 'deleted' &&
+             data.get('liveStatus', '') != 'deleted' &&
+             (isPublicGameReadTeam(teamData) || isShareableGameDocument(data));
+    }
+
+    function isAuthorizedOfficialForGame(data) {
+      return isSignedIn() && (
+        request.auth.uid in data.get('officiatingAuthorizedUserIds', []) ||
+        (request.auth.token.email != null &&
+         request.auth.token.email.lower() in data.get('officiatingAuthorizedEmails', []))
+      );
+    }
+
+    function canReadGameDocument(teamId, gameId, data) {
+      let teamPath = /databases/$(database)/documents/teams/$(teamId);
+      return isTeamOwnerOrAdmin(teamId) ||
+             isParentForTeam(teamId) ||
+             canScorekeepGame(teamId, gameId) ||
+             canVideographGame(teamId, gameId) ||
+             isAuthorizedOfficialForGame(data) ||
+             (exists(teamPath) && canReadPublicGameDocument(get(teamPath).data, data));
+    }
+
+    function canReadCollectionGroupGameDocument(teamPath, data) {
+      return exists(/databases/$(database)/documents/$(teamPath)) &&
+             (
+               isGlobalAdmin() ||
+               canReadTeamDocument(get(/databases/$(database)/documents/$(teamPath)).data) ||
+               canReadPublicGameDocument(get(/databases/$(database)/documents/$(teamPath)).data, data)
+             );
+    }
+
     function isTrackingItemPayloadValid(teamId, data) {
       return data.keys().hasOnly([
                'teamId', 'name', 'description', 'visibility', 'status', 'active', 'archived',
@@ -1287,7 +1344,7 @@ service cloud.firestore {
 
 	    // Collection group rule for games - allows cross-team queries (e.g., live games, recent games)
 	    match /{path=**}/games/{gameId} {
-      allow read: if true;  // Public read for collection group queries
+      allow read: if canReadCollectionGroupGameDocument(path, resource.data);
     }
 
     // Collection group rule for players - enables collectionGroup('players') queries.
@@ -1650,7 +1707,7 @@ service cloud.firestore {
 
       // Games subcollection
       match /games/{gameId} {
-        allow read: if true;  // Public game data
+        allow read: if canReadGameDocument(teamId, gameId, resource.data);
         allow create, delete: if isTeamOwnerOrAdmin(teamId);
         allow update: if isTeamOwnerOrAdmin(teamId) ||
                         (isOfficialForGame() && isOfficialGameUpdate()) ||

--- a/firestore.rules
+++ b/firestore.rules
@@ -67,13 +67,17 @@ service cloud.firestore {
              data.usedAt == null;
     }
 
+    function canReadManagedTeamDocument(data) {
+      return isSignedIn() &&
+             (data.ownerId == request.auth.uid ||
+              (request.auth.token.email != null &&
+               request.auth.token.email.lower() in data.get('adminEmails', [])) ||
+              isGlobalAdmin());
+    }
+
     function canReadTeamDocument(data) {
       return (data.isPublic is bool && data.isPublic == true) ||
-             (isSignedIn() &&
-              (data.ownerId == request.auth.uid ||
-               (request.auth.token.email != null &&
-                request.auth.token.email.lower() in data.get('adminEmails', [])) ||
-               isGlobalAdmin()));
+             canReadManagedTeamDocument(data);
     }
 
     function isSafeDocumentId(documentId) {
@@ -416,8 +420,7 @@ service cloud.firestore {
     function canReadCollectionGroupGameDocument(teamPath, data) {
       return exists(/databases/$(database)/documents/$(teamPath)) &&
              (
-               isGlobalAdmin() ||
-               canReadTeamDocument(get(/databases/$(database)/documents/$(teamPath)).data) ||
+               canReadManagedTeamDocument(get(/databases/$(database)/documents/$(teamPath)).data) ||
                canReadPublicGameDocument(get(/databases/$(database)/documents/$(teamPath)).data, data)
              );
     }

--- a/scripts/validate-firebase-rules-ci.mjs
+++ b/scripts/validate-firebase-rules-ci.mjs
@@ -55,6 +55,10 @@ export function validateFirebaseRulesCi() {
     assertIncludes(firestoreRules, 'function canReadTeamMediaItem(teamId, itemData)', 'Firestore media item visibility rules');
     assertIncludes(firestoreRules, 'allow read: if canReadTeamMediaFolder(teamId, resource.data);', 'Firestore media folder read rules');
     assertIncludes(firestoreRules, 'allow read: if canReadTeamMediaItem(teamId, resource.data);', 'Firestore media item read rules');
+    assertIncludes(firestoreRules, 'function canReadGameDocument(teamId, gameId, data)', 'Firestore game visibility helper');
+    assertIncludes(firestoreRules, 'function canReadCollectionGroupGameDocument(teamPath, data)', 'Firestore collection-group game visibility helper');
+    assertIncludes(firestoreRules, 'allow read: if canReadGameDocument(teamId, gameId, resource.data);', 'Firestore team game read rules');
+    assertIncludes(firestoreRules, 'allow read: if canReadCollectionGroupGameDocument(path, resource.data);', 'Firestore collection-group game read rules');
     assertIncludes(firestoreRules, 'allow create, update, delete: if isTeamOwnerOrAdmin(teamId);', 'Firestore media folder write rules');
     assertIncludes(firestoreRules, 'allow create: if isTeamOwnerOrAdmin(teamId) || isTeamMediaUploadCreate(teamId, request.resource.data);', 'Firestore media item create rules');
     assertIncludes(firestoreRules, 'allow update: if isTeamOwnerOrAdmin(teamId) || isOwnTeamMediaUploadSoftDelete(teamId) || isTeamMediaTitleUpdate(teamId);', 'Firestore media item update rules');

--- a/tests/unit/game-read-rules.test.js
+++ b/tests/unit/game-read-rules.test.js
@@ -14,6 +14,7 @@ describe('game Firestore read rules', () => {
     it('replaces unconditional game reads with shared visibility helpers', () => {
         expect(rules).toContain('function canReadGameDocument(teamId, gameId, data)');
         expect(rules).toContain('function canReadCollectionGroupGameDocument(teamPath, data)');
+        expect(rules).toContain('function canReadManagedTeamDocument(data)');
         expect(rules).toContain('function canReadPublicGameDocument(teamData, data)');
         expect(teamGamesRules).toContain('allow read: if canReadGameDocument(teamId, gameId, resource.data);');
         expect(collectionGroupGamesRules).toContain('allow read: if canReadCollectionGroupGameDocument(path, resource.data);');
@@ -31,6 +32,8 @@ describe('game Firestore read rules', () => {
         expect(rules).toContain("isPublicGameReadTeam(teamData) || isShareableGameDocument(data)");
         expect(rules).toContain("data.get('shareable', false) == true");
         expect(rules).toContain("data.get('publicCalendar', false) == true");
+        expect(rules).toContain('canReadManagedTeamDocument(get(/databases/$(database)/documents/$(teamPath)).data)');
+        expect(rules).not.toContain('canReadTeamDocument(get(/databases/$(database)/documents/$(teamPath)).data)');
     });
 
     it('preserves signed-in access for team staff, parents, scoped helpers, and officials', () => {

--- a/tests/unit/game-read-rules.test.js
+++ b/tests/unit/game-read-rules.test.js
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+const collectionGroupGamesMatch = rules.match(/match \/{path=\*\*}\/games\/\{gameId} \{[\s\S]*?\n\s*}/);
+const collectionGroupGamesRules = collectionGroupGamesMatch?.[0] || '';
+const teamGamesStart = rules.indexOf('match /games/{gameId} {');
+const teamGamesEnd = rules.indexOf('// Events subcollection', teamGamesStart);
+const teamGamesRules = teamGamesStart === -1 || teamGamesEnd === -1
+    ? ''
+    : rules.slice(teamGamesStart, teamGamesEnd);
+
+describe('game Firestore read rules', () => {
+    it('replaces unconditional game reads with shared visibility helpers', () => {
+        expect(rules).toContain('function canReadGameDocument(teamId, gameId, data)');
+        expect(rules).toContain('function canReadCollectionGroupGameDocument(teamPath, data)');
+        expect(rules).toContain('function canReadPublicGameDocument(teamData, data)');
+        expect(teamGamesRules).toContain('allow read: if canReadGameDocument(teamId, gameId, resource.data);');
+        expect(collectionGroupGamesRules).toContain('allow read: if canReadCollectionGroupGameDocument(path, resource.data);');
+        expect(teamGamesRules).not.toContain('allow read: if true;');
+        expect(collectionGroupGamesRules).not.toContain('allow read: if true;');
+    });
+
+    it('keeps private-team private games unreadable to outsiders while allowing public or shareable games', () => {
+        expect(rules).toContain("data.get('type', 'game') == 'game'");
+        expect(rules).toContain("data.get('visibility', '') != 'private'");
+        expect(rules).toContain("data.get('isPrivate', false) != true");
+        expect(rules).toContain("data.get('private', false) != true");
+        expect(rules).toContain("data.get('status', '') != 'deleted'");
+        expect(rules).toContain("data.get('liveStatus', '') != 'deleted'");
+        expect(rules).toContain("isPublicGameReadTeam(teamData) || isShareableGameDocument(data)");
+        expect(rules).toContain("data.get('shareable', false) == true");
+        expect(rules).toContain("data.get('publicCalendar', false) == true");
+    });
+
+    it('preserves signed-in access for team staff, parents, scoped helpers, and officials', () => {
+        expect(rules).toContain('isTeamOwnerOrAdmin(teamId)');
+        expect(rules).toContain('isParentForTeam(teamId)');
+        expect(rules).toContain('canScorekeepGame(teamId, gameId)');
+        expect(rules).toContain('canVideographGame(teamId, gameId)');
+        expect(rules).toContain('isAuthorizedOfficialForGame(data)');
+        expect(rules).toContain("request.auth.uid in data.get('officiatingAuthorizedUserIds', [])");
+    });
+});


### PR DESCRIPTION
Closes #1941

## What changed
- Replaced the unconditional `allow read: if true` game rules with shared Firestore helpers that only allow raw game reads for authorized team viewers or for public/shareable games.
- Scoped `teams/{teamId}/games/{gameId}` reads to team admins, linked parents, scoped scorekeepers, videographers, authorized officials, and public/shareable fan-visible games.
- Scoped the collection-group `games` rule to the same public visibility boundary plus admin-safe reads, and added CI/unit guards so future rule edits cannot silently reopen global public reads.

## Root Cause
The raw Firestore rules treated every document in both `teams/{teamId}/games/{gameId}` and the collection-group `games` path as publicly readable. Product code and the public calendar flow filtered visibility later, but the security boundary at Firestore never enforced team privacy, per-game shareability, or deleted/private status.

## Prevention / Learning
When the product has a public/shareable subset of a document type, the Firestore rule must encode that subset directly instead of relying on downstream UI or function filtering. Future PaulBot fixes should look for `allow read: if true` on mixed-visibility collections and add a reusable rule helper plus a focused regression test before shipping.

## Regression Tests
- `npx vitest run tests/unit/game-read-rules.test.js --reporter=verbose`
- `npm run ci:firebase-rules`

## Recurrence Risk
Medium. The read boundary is now locked down, but game visibility still exists in both rules and app/public-feed helpers, so any future visibility flag changes need to update both layers.