### PR TITLE
Collapse mobile schedule staff tools

### DIFF
--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useState, type FormEvent } from 'react';
-import { AlertCircle, CalendarDays, CheckCircle2, ChevronLeft, ChevronRight, ClipboardCheck, Copy, Download, Filter, Link as LinkIcon, ListChecks, MapPin, RefreshCw } from 'lucide-react';
+import { useEffect, useMemo, useState, type FormEvent, type ReactNode } from 'react';
+import { AlertCircle, CalendarDays, CheckCircle2, ChevronDown, ChevronLeft, ChevronRight, ClipboardCheck, Copy, Download, Filter, Link as LinkIcon, ListChecks, MapPin, RefreshCw } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { addTeamCalendarUrl, createScheduleImportGame, createScheduleImportPractice, loadParentSchedule, removeTeamCalendarUrl, type ParentScheduleChild } from '../lib/scheduleService';
 import { generateScheduleAiImportRows } from '../lib/scheduleAiImport';
@@ -108,6 +108,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
   const [processingAiImport, setProcessingAiImport] = useState(false);
   const [importingCsv, setImportingCsv] = useState(false);
   const [removingCalendarUrl, setRemovingCalendarUrl] = useState<string | null>(null);
+  const [mobileStaffToolsOpen, setMobileStaffToolsOpen] = useState(false);
 
   const clearAiPreview = () => {
     if (scheduleImportPreviewSource === 'ai') {
@@ -215,6 +216,12 @@ export function Schedule({ auth }: { auth: AuthState }) {
     }
     return manageableTeamOptions.length === 1 ? manageableTeamOptions[0] : null;
   }, [manageableTeamOptions, selectedTeamId]);
+
+  useEffect(() => {
+    if (isDesktopWeb || !selectedCalendarTeam) {
+      setMobileStaffToolsOpen(false);
+    }
+  }, [isDesktopWeb, selectedCalendarTeam]);
 
   const handleCsvFileChange = async (file: File | null) => {
     setCsvImportErrors([]);
@@ -656,55 +663,45 @@ export function Schedule({ auth }: { auth: AuthState }) {
             </div>
           ) : null}
 
-          {selectedCalendarTeam ? (
-            <>
-            <CalendarSourcePanel
+          {isDesktopWeb && selectedCalendarTeam ? (
+            <ScheduleStaffTools
               teamName={selectedCalendarTeam.teamName}
               calendarUrl={calendarUrl}
               calendarUrls={selectedCalendarTeam.calendarUrls || []}
-              error={calendarUrlError}
-              saving={savingCalendarUrl}
-              removingUrl={removingCalendarUrl}
+              calendarUrlError={calendarUrlError}
+              savingCalendarUrl={savingCalendarUrl}
+              removingCalendarUrl={removingCalendarUrl}
+              aiScheduleText={aiScheduleText}
+              aiScheduleImageName={aiScheduleImageName}
+              aiPreviewRows={scheduleImportPreviewSource === 'ai' ? csvPreviewRows : []}
+              aiImportErrors={aiImportErrors}
+              processingAiImport={processingAiImport}
+              csvHeaders={csvHeaders}
+              csvMapping={csvMapping}
+              csvPreviewRows={scheduleImportPreviewSource === 'csv' ? csvPreviewRows : []}
+              csvImportErrors={csvImportErrors}
+              csvFileName={csvFileName}
+              importingCsv={importingCsv}
               onCalendarUrlChange={(value) => {
                 setCalendarUrl(value);
                 if (calendarUrlError) setCalendarUrlError(null);
               }}
-              onSubmit={handleAddCalendarUrl}
-              onRemove={handleRemoveCalendarUrl}
-            />
-            <ScheduleAiImportPanel
-              teamName={selectedCalendarTeam.teamName}
-              text={aiScheduleText}
-              imageName={aiScheduleImageName}
-              previewRows={scheduleImportPreviewSource === 'ai' ? csvPreviewRows : []}
-              errors={aiImportErrors}
-              processing={processingAiImport}
-              importing={importingCsv}
-              onTextChange={(value) => {
+              onAddCalendarUrl={handleAddCalendarUrl}
+              onRemoveCalendarUrl={handleRemoveCalendarUrl}
+              onAiTextChange={(value) => {
                 setAiScheduleText(value);
                 clearAiPreview();
                 if (aiImportErrors.length) setAiImportErrors([]);
               }}
-              onImageChange={handleAiImageChange}
-              onGeneratePreview={handleAiGeneratePreview}
-              onImport={handleCsvImport}
-              onClear={handleAiClear}
+              onAiImageChange={handleAiImageChange}
+              onAiGeneratePreview={handleAiGeneratePreview}
+              onImportCsv={handleCsvImport}
+              onClearAi={handleAiClear}
+              onCsvFileChange={handleCsvFileChange}
+              onCsvMappingChange={(field, value) => setCsvMapping((current) => ({ ...current, [field]: value || undefined }))}
+              onCsvPreview={handleCsvPreview}
+              onClearCsv={handleCsvClear}
             />
-            <ScheduleCsvImportPanel
-              teamName={selectedCalendarTeam.teamName}
-              headers={csvHeaders}
-              mapping={csvMapping}
-              previewRows={scheduleImportPreviewSource === 'csv' ? csvPreviewRows : []}
-              errors={csvImportErrors}
-              fileName={csvFileName}
-              importing={importingCsv}
-              onFileChange={handleCsvFileChange}
-              onMappingChange={(field, value) => setCsvMapping((current) => ({ ...current, [field]: value || undefined }))}
-              onPreview={handleCsvPreview}
-              onImport={handleCsvImport}
-              onClear={handleCsvClear}
-            />
-            </>
           ) : null}
 
           {statusMessage ? <Status tone="success" message={statusMessage} /> : null}
@@ -739,9 +736,188 @@ export function Schedule({ auth }: { auth: AuthState }) {
               onShowMore={() => setVisibleListCount((current) => Math.min(current + listPageSize, listEntries.length))}
             />
           )}
+
+          {!isDesktopWeb && selectedCalendarTeam ? (
+            <MobileScheduleStaffToolsSection
+              open={mobileStaffToolsOpen}
+              teamName={selectedCalendarTeam.teamName}
+              onToggle={() => setMobileStaffToolsOpen((current) => !current)}
+            >
+              <ScheduleStaffTools
+                teamName={selectedCalendarTeam.teamName}
+                calendarUrl={calendarUrl}
+                calendarUrls={selectedCalendarTeam.calendarUrls || []}
+                calendarUrlError={calendarUrlError}
+                savingCalendarUrl={savingCalendarUrl}
+                removingCalendarUrl={removingCalendarUrl}
+                aiScheduleText={aiScheduleText}
+                aiScheduleImageName={aiScheduleImageName}
+                aiPreviewRows={scheduleImportPreviewSource === 'ai' ? csvPreviewRows : []}
+                aiImportErrors={aiImportErrors}
+                processingAiImport={processingAiImport}
+                csvHeaders={csvHeaders}
+                csvMapping={csvMapping}
+                csvPreviewRows={scheduleImportPreviewSource === 'csv' ? csvPreviewRows : []}
+                csvImportErrors={csvImportErrors}
+                csvFileName={csvFileName}
+                importingCsv={importingCsv}
+                onCalendarUrlChange={(value) => {
+                  setCalendarUrl(value);
+                  if (calendarUrlError) setCalendarUrlError(null);
+                }}
+                onAddCalendarUrl={handleAddCalendarUrl}
+                onRemoveCalendarUrl={handleRemoveCalendarUrl}
+                onAiTextChange={(value) => {
+                  setAiScheduleText(value);
+                  clearAiPreview();
+                  if (aiImportErrors.length) setAiImportErrors([]);
+                }}
+                onAiImageChange={handleAiImageChange}
+                onAiGeneratePreview={handleAiGeneratePreview}
+                onImportCsv={handleCsvImport}
+                onClearAi={handleAiClear}
+                onCsvFileChange={handleCsvFileChange}
+                onCsvMappingChange={(field, value) => setCsvMapping((current) => ({ ...current, [field]: value || undefined }))}
+                onCsvPreview={handleCsvPreview}
+                onClearCsv={handleCsvClear}
+              />
+            </MobileScheduleStaffToolsSection>
+          ) : null}
         </div>
       </div>
     </div>
+  );
+}
+
+function MobileScheduleStaffToolsSection({ open, teamName, onToggle, children }: { open: boolean; teamName: string; onToggle: () => void; children: ReactNode }) {
+  return (
+    <section className="app-card p-3" aria-label="Manage schedule tools">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between gap-3 text-left"
+        aria-expanded={open}
+        aria-controls="mobile-schedule-staff-tools"
+        onClick={onToggle}
+      >
+        <div className="min-w-0">
+          <div className="app-label">Staff schedule tools</div>
+          <h2 className="mt-1 text-base font-black text-gray-950">Manage schedule</h2>
+          <p className="mt-1 text-xs font-semibold leading-5 text-gray-500">Calendar feeds and imports for {teamName} stay tucked away until you need them.</p>
+        </div>
+        <ChevronDown className={`h-5 w-5 flex-none text-gray-500 transition ${open ? 'rotate-180' : ''}`} aria-hidden="true" />
+      </button>
+      {open ? (
+        <div id="mobile-schedule-staff-tools" className="mt-3 space-y-3">
+          {children}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function ScheduleStaffTools({
+  teamName,
+  calendarUrl,
+  calendarUrls,
+  calendarUrlError,
+  savingCalendarUrl,
+  removingCalendarUrl,
+  aiScheduleText,
+  aiScheduleImageName,
+  aiPreviewRows,
+  aiImportErrors,
+  processingAiImport,
+  csvHeaders,
+  csvMapping,
+  csvPreviewRows,
+  csvImportErrors,
+  csvFileName,
+  importingCsv,
+  onCalendarUrlChange,
+  onAddCalendarUrl,
+  onRemoveCalendarUrl,
+  onAiTextChange,
+  onAiImageChange,
+  onAiGeneratePreview,
+  onImportCsv,
+  onClearAi,
+  onCsvFileChange,
+  onCsvMappingChange,
+  onCsvPreview,
+  onClearCsv
+}: {
+  teamName: string;
+  calendarUrl: string;
+  calendarUrls: string[];
+  calendarUrlError: string | null;
+  savingCalendarUrl: boolean;
+  removingCalendarUrl: string | null;
+  aiScheduleText: string;
+  aiScheduleImageName: string;
+  aiPreviewRows: ScheduleCsvImportPreviewRow[];
+  aiImportErrors: string[];
+  processingAiImport: boolean;
+  csvHeaders: string[];
+  csvMapping: ScheduleCsvImportMapping;
+  csvPreviewRows: ScheduleCsvImportPreviewRow[];
+  csvImportErrors: string[];
+  csvFileName: string;
+  importingCsv: boolean;
+  onCalendarUrlChange: (value: string) => void;
+  onAddCalendarUrl: (event: FormEvent<HTMLFormElement>) => void;
+  onRemoveCalendarUrl: (url: string) => void;
+  onAiTextChange: (value: string) => void;
+  onAiImageChange: (file: File | null) => void;
+  onAiGeneratePreview: () => void;
+  onImportCsv: () => void;
+  onClearAi: () => void;
+  onCsvFileChange: (file: File | null) => void;
+  onCsvMappingChange: (field: keyof ScheduleCsvImportMapping, value: string) => void;
+  onCsvPreview: () => void;
+  onClearCsv: () => void;
+}) {
+  return (
+    <>
+      <CalendarSourcePanel
+        teamName={teamName}
+        calendarUrl={calendarUrl}
+        calendarUrls={calendarUrls}
+        error={calendarUrlError}
+        saving={savingCalendarUrl}
+        removingUrl={removingCalendarUrl}
+        onCalendarUrlChange={onCalendarUrlChange}
+        onSubmit={onAddCalendarUrl}
+        onRemove={onRemoveCalendarUrl}
+      />
+      <ScheduleAiImportPanel
+        teamName={teamName}
+        text={aiScheduleText}
+        imageName={aiScheduleImageName}
+        previewRows={aiPreviewRows}
+        errors={aiImportErrors}
+        processing={processingAiImport}
+        importing={importingCsv}
+        onTextChange={onAiTextChange}
+        onImageChange={onAiImageChange}
+        onGeneratePreview={onAiGeneratePreview}
+        onImport={onImportCsv}
+        onClear={onClearAi}
+      />
+      <ScheduleCsvImportPanel
+        teamName={teamName}
+        headers={csvHeaders}
+        mapping={csvMapping}
+        previewRows={csvPreviewRows}
+        errors={csvImportErrors}
+        fileName={csvFileName}
+        importing={importingCsv}
+        onFileChange={onCsvFileChange}
+        onMappingChange={onCsvMappingChange}
+        onPreview={onCsvPreview}
+        onImport={onImportCsv}
+        onClear={onClearCsv}
+      />
+    </>
   );
 }
 

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -180,6 +180,7 @@ async function mockScheduleModules(page, options = {}) {
                         rsvpSummary: overrides.rsvpSummary || { going: 1, maybe: 0, notGoing: 0, notResponded: 1 },
                         rideshareSummary: overrides.rideshareSummary || { offerCount: 1, seatsLeft: 2, requests: 1, pending: 1, confirmed: 0, isFull: false },
                         assignments: overrides.assignments || getAssignments(),
+                        isTeamStaff: overrides.isTeamStaff === true,
                         availabilityLocked: false,
                         availabilityCutoffLabel: 'No cutoff',
                         availabilityPreferences: { cutoffMinutesBeforeStart: 0, noteVisibility: 'team' },

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -35,6 +35,7 @@ async function mockScheduleModules(page, options = {}) {
     const scheduleLoadError = options.scheduleLoadError || '';
     const rideshareLoadError = options.rideshareLoadError || '';
     const assignmentClaimError = options.assignmentClaimError || '';
+    const staffManageable = options.staffManageable === true;
     const gameStatus = options.gameStatus || 'scheduled';
     const gameLiveStatus = options.gameLiveStatus || null;
     const gameHomeScore = options.gameHomeScore ?? null;
@@ -321,8 +322,8 @@ async function mockScheduleModules(page, options = {}) {
                             { teamId: 'team-1', teamName: 'Bears', playerId: 'player-2', playerName: 'Sam' }
                         ],
                         events: [
-                            baseEvent({ eventKey: 'game-1-player-1', id: 'game-1', childId: 'player-1', childName: 'Pat', date: new Date(${JSON.stringify(gameDate)}), rideshareSummary, status: ${JSON.stringify(gameStatus)}, liveStatus: ${JSON.stringify(gameLiveStatus)}, homeScore: ${JSON.stringify(gameHomeScore)}, awayScore: ${JSON.stringify(gameAwayScore)} }),
-                            baseEvent({ eventKey: 'game-1-player-2', id: 'game-1', childId: 'player-2', childName: 'Sam', date: new Date(${JSON.stringify(gameDate)}), myRsvp: 'maybe', rideshareSummary, status: ${JSON.stringify(gameStatus)}, liveStatus: ${JSON.stringify(gameLiveStatus)}, homeScore: ${JSON.stringify(gameHomeScore)}, awayScore: ${JSON.stringify(gameAwayScore)} }),
+                            baseEvent({ eventKey: 'game-1-player-1', id: 'game-1', childId: 'player-1', childName: 'Pat', date: new Date(${JSON.stringify(gameDate)}), rideshareSummary, status: ${JSON.stringify(gameStatus)}, liveStatus: ${JSON.stringify(gameLiveStatus)}, homeScore: ${JSON.stringify(gameHomeScore)}, awayScore: ${JSON.stringify(gameAwayScore)}, isTeamStaff: ${JSON.stringify(staffManageable)} }),
+                            baseEvent({ eventKey: 'game-1-player-2', id: 'game-1', childId: 'player-2', childName: 'Sam', date: new Date(${JSON.stringify(gameDate)}), myRsvp: 'maybe', rideshareSummary, status: ${JSON.stringify(gameStatus)}, liveStatus: ${JSON.stringify(gameLiveStatus)}, homeScore: ${JSON.stringify(gameHomeScore)}, awayScore: ${JSON.stringify(gameAwayScore)}, isTeamStaff: ${JSON.stringify(staffManageable)} }),
                             baseEvent({
                                 eventKey: 'practice-1-player-1',
                                 id: 'practice-1',
@@ -785,6 +786,25 @@ test('iOS-sized schedule smoke covers list, event nav, and rideshare without ove
     await expect(page.getByRole('heading', { name: 'Rideshare' })).toBeVisible();
     await expect(page.getByText('Dana Driver')).toBeVisible();
     await expect(page.getByText('Request spot')).toBeVisible();
+    expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBe(true);
+});
+
+test('iOS-sized staff schedule keeps tools collapsed below the event list', async ({ page, baseURL }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await mockScheduleModules(page, { isCoach: true, staffManageable: true });
+    await page.goto(appUrl(baseURL, '/schedule'), { waitUntil: 'domcontentloaded' });
+
+    await expect(mobileScheduleFilter(page)).toBeVisible({ timeout: 15000 });
+    await expect(page.locator('.schedule-list > a').first()).toBeVisible();
+    await expect(page.getByRole('button', { name: /Manage schedule/ })).toBeVisible();
+    await expect(page.getByText('Add external calendar')).toHaveCount(0);
+    await expect(page.getByText('Draft schedule with AI')).toHaveCount(0);
+    await expect(page.getByText('Import schedule CSV')).toHaveCount(0);
+
+    await page.getByRole('button', { name: /Manage schedule/ }).click();
+    await expect(page.getByText('Add external calendar')).toBeVisible();
+    await expect(page.getByText('Draft schedule with AI')).toBeVisible();
+    await expect(page.getByText('Import schedule CSV')).toBeVisible();
     expect(await page.evaluate(() => document.documentElement.scrollWidth <= document.documentElement.clientWidth + 1)).toBe(true);
 });
 

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -12,13 +12,18 @@ const scheduleMocks = vi.hoisted(() => ({
     removeTeamCalendarUrl: vi.fn(),
     generateScheduleAiImportRows: vi.fn()
 }));
+const layoutState = vi.hoisted(() => ({
+    isDesktopWeb: true,
+    isNative: false,
+    isMobileWeb: false
+}));
 
 vi.mock('../../apps/app/src/lib/scheduleService.ts', () => scheduleMocks);
 vi.mock('../../apps/app/src/lib/scheduleAiImport.ts', () => ({
     generateScheduleAiImportRows: scheduleMocks.generateScheduleAiImportRows
 }));
 vi.mock('../../apps/app/src/lib/useShellLayout.ts', () => ({
-    useShellLayout: () => ({ isDesktopWeb: true, isNative: false, isMobileWeb: false })
+    useShellLayout: () => layoutState
 }));
 
 import { Schedule } from '../../apps/app/src/pages/Schedule.tsx';
@@ -97,6 +102,12 @@ function queryButtonByText(container, text) {
     return Array.from(container.querySelectorAll('button')).find((candidate) => candidate.textContent.trim() === text) || null;
 }
 
+function buttonContainingText(container, text) {
+    const button = Array.from(container.querySelectorAll('button')).find((candidate) => candidate.textContent.includes(text));
+    if (!button) throw new Error(`Button not found: ${text}`);
+    return button;
+}
+
 function selectByLabel(container, label) {
     const select = Array.from(container.querySelectorAll('select')).find((candidate) => candidate.getAttribute('aria-label') === label);
     if (!select) throw new Error(`Select not found: ${label}`);
@@ -137,6 +148,9 @@ beforeEach(() => {
     vi.clearAllMocks();
     clearAppDataCache('app-schedule-summary');
     document.body.innerHTML = '';
+    layoutState.isDesktopWeb = true;
+    layoutState.isNative = false;
+    layoutState.isMobileWeb = false;
     scheduleMocks.addTeamCalendarUrl.mockResolvedValue({ added: true, calendarUrls: ['https://example.com/team.ics'] });
     scheduleMocks.createScheduleImportGame.mockResolvedValue('game-new');
     scheduleMocks.createScheduleImportPractice.mockResolvedValue('practice-new');
@@ -263,6 +277,36 @@ describe('React app desktop Schedule controls', () => {
         expect(scheduleMocks.loadParentSchedule).toHaveBeenCalledTimes(2);
         expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(1, auth.user, { hydrateDetails: false, expandStaffPlayers: false });
         expect(scheduleMocks.loadParentSchedule).toHaveBeenNthCalledWith(2, auth.user, { hydrateDetails: false, expandStaffPlayers: false });
+    });
+
+    it('keeps mobile staff schedule tools collapsed until explicitly opened', async () => {
+        layoutState.isDesktopWeb = false;
+        layoutState.isMobileWeb = true;
+        scheduleMocks.loadParentSchedule.mockResolvedValue({
+            children: [
+                { playerId: 'player-1', playerName: 'Pat', teamId: 'team-1', teamName: 'Bears' }
+            ],
+            events: [event({ isTeamStaff: true })]
+        });
+
+        const { container } = await renderSchedule();
+        await waitForText(container, 'Falcons');
+        await waitForText(container, 'Manage schedule');
+
+        expect(container.textContent).not.toContain('Add external calendar');
+        expect(container.textContent).not.toContain('Draft schedule with AI');
+        expect(container.textContent).not.toContain('Import schedule CSV');
+        expect(container.querySelector('.schedule-list > a')).toBeTruthy();
+        expect(buttonContainingText(container, 'Manage schedule').getAttribute('aria-expanded')).toBe('false');
+
+        await act(async () => {
+            buttonContainingText(container, 'Manage schedule').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+        });
+
+        expect(buttonContainingText(container, 'Manage schedule').getAttribute('aria-expanded')).toBe('true');
+        await waitForText(container, 'Add external calendar');
+        expect(container.textContent).toContain('Draft schedule with AI');
+        expect(container.textContent).toContain('Import schedule CSV');
     });
 
     it('reuses the cached schedule when the route remounts', async () => {


### PR DESCRIPTION
Closes #1945

## What changed
- kept desktop schedule staff tooling in its current always-visible position
- moved mobile and Capacitor staff schedule tools behind a new collapsed `Manage schedule` section rendered after the primary schedule list
- extracted the shared staff-tool panels into a reusable helper so mobile and desktop keep the same calendar, AI import, and CSV import behavior
- added a focused unit regression for mobile collapsed behavior and a matching smoke scenario for an iPhone-sized staff view

## Root Cause
`Schedule.tsx` auto-selected the only staff-manageable team and unconditionally rendered three full staff management panels before the schedule list on every layout. That desktop-first placement leaked onto non-desktop shells, so mobile staff users landed below heavy admin UI instead of seeing the schedule first.

## Prevention / Learning
When a route mixes a primary read-and-act flow with secondary admin tooling, do not reuse desktop placement on mobile by default. Keep the primary list visible first on small shells and require an explicit affordance before expanding heavyweight management panels.

## Regression Tests
- `npx vitest run tests/unit/app-schedule-desktop-controls.test.jsx --reporter=verbose`
- added `tests/unit/app-schedule-desktop-controls.test.jsx` coverage asserting mobile staff tools stay hidden until `Manage schedule` is opened
- added `tests/smoke/app-schedule.spec.js` coverage for an iPhone-sized staff schedule route with collapsed-then-expanded staff tools

## Recurrence Risk
Low. The mobile-only collapse path now has a focused unit regression and adjacent smoke coverage, while desktop behavior remains unchanged.