### PR TITLE
Lock targeted chat membership changes

### DIFF
--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -2226,44 +2226,26 @@ function MessageAvatar({ message, label }: { message: ChatMessage; label: string
 
 function InlineAttachmentVideo({ src, label }: { src: string; label: string }) {
   const videoRef = useRef<HTMLVideoElement | null>(null);
-  const [shouldPreloadMetadata, setShouldPreloadMetadata] = useState(false);
+  const [shouldLoadVideo, setShouldLoadVideo] = useState(false);
 
-  useEffect(() => {
-    if (shouldPreloadMetadata) return undefined;
-    const video = videoRef.current;
-    if (!video || typeof IntersectionObserver === 'undefined') return undefined;
-
-    const observer = new IntersectionObserver((entries) => {
-      if (entries.some((entry) => entry.isIntersecting && (typeof entry.intersectionRatio !== 'number' || entry.intersectionRatio >= 0.5))) {
-        setShouldPreloadMetadata(true);
-        observer.disconnect();
-      }
-    }, {
-      threshold: 0.5
-    });
-
-    observer.observe(video);
-    return () => observer.disconnect();
-  }, [shouldPreloadMetadata]);
-
-  const armMetadataPreload = useCallback(() => {
-    setShouldPreloadMetadata(true);
+  const armVideoLoad = useCallback(() => {
+    setShouldLoadVideo(true);
   }, []);
 
   return (
     <video
       ref={videoRef}
       controls
-      preload={shouldPreloadMetadata ? 'metadata' : 'none'}
+      preload={shouldLoadVideo ? 'metadata' : 'none'}
       className="max-h-72 w-full"
-      src={src}
+      src={shouldLoadVideo ? src : undefined}
       aria-label={label}
       data-chat-attachment-url={src}
-      onFocus={armMetadataPreload}
-      onMouseEnter={armMetadataPreload}
-      onPlay={armMetadataPreload}
-      onPointerDown={armMetadataPreload}
-      onTouchStart={armMetadataPreload}
+      onFocus={armVideoLoad}
+      onMouseEnter={armVideoLoad}
+      onPlay={armVideoLoad}
+      onPointerDown={armVideoLoad}
+      onTouchStart={armVideoLoad}
     />
   );
 }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1109,6 +1109,22 @@ service cloud.firestore {
              data.get('mutedBy', []) is list;
     }
 
+    function isChatConversationParticipantMetadataUpdate() {
+      return request.resource.data.get('type', '') == resource.data.get('type', '') &&
+             request.resource.data.get('name', null) == resource.data.get('name', null) &&
+             request.resource.data.get('participantIds', []) == resource.data.get('participantIds', []) &&
+             request.resource.data.get('participantRoles', []) == resource.data.get('participantRoles', []) &&
+             request.resource.data.diff(resource.data).affectedKeys()
+               .hasOnly(['lastMessageAt', 'mutedBy', 'updatedAt']);
+    }
+
+    function isTeamStaffChatConversationUpdate(teamId) {
+      return isTeamOwnerOrAdmin(teamId) &&
+             request.resource.data.get('type', '') == resource.data.get('type', '') &&
+             request.resource.data.diff(resource.data).affectedKeys()
+               .hasOnly(['name', 'participantIds', 'participantRoles', 'lastMessageAt', 'mutedBy', 'updatedAt']);
+    }
+
     function rideshareOfferPath(teamId, gameId, offerId) {
       return /databases/$(database)/documents/teams/$(teamId)/games/$(gameId)/rideOffers/$(offerId);
     }
@@ -2098,8 +2114,8 @@ service cloud.firestore {
         allow update: if canAccessChatConversation(teamId, conversationId, resource.data) &&
                          canAccessChatConversation(teamId, conversationId, request.resource.data) &&
                          isChatConversationPayloadValid(request.resource.data) &&
-                         request.resource.data.diff(resource.data).affectedKeys()
-                           .hasOnly(['name', 'participantIds', 'participantRoles', 'lastMessageAt', 'mutedBy', 'updatedAt']);
+                         (isTeamStaffChatConversationUpdate(teamId) ||
+                          isChatConversationParticipantMetadataUpdate());
         allow delete: if isTeamOwnerOrAdmin(teamId);
 
         match /chatMessages/{messageId} {

--- a/js/db.js
+++ b/js/db.js
@@ -5523,22 +5523,34 @@ export async function upsertChatConversation(teamId, {
     const now = Timestamp.now();
     const conversationRef = doc(db, 'teams', teamId, 'chatConversations', conversationId);
     const existing = await getDoc(conversationRef);
+    const normalizedParticipantRoles = Array.from(new Set((Array.isArray(participantRoles) ? participantRoles : [])
+        .map((role) => String(role || '').trim())
+        .filter(Boolean)))
+        .sort();
+    const normalizedMutedBy = Array.from(new Set(Array.isArray(mutedBy) ? mutedBy : []));
+
+    if (existing.exists()) {
+        return {
+            id: conversationId,
+            ...existing.data(),
+            mutedBy: normalizedMutedBy.length > 0 ? normalizedMutedBy : (existing.data()?.mutedBy || []),
+            participantIds: existing.data()?.participantIds || normalizedParticipantIds,
+            participantRoles: existing.data()?.participantRoles || normalizedParticipantRoles,
+            name: existing.data()?.name || name || null
+        };
+    }
+
     const payload = {
         type: normalizedType,
         participantIds: normalizedParticipantIds,
-        participantRoles: Array.from(new Set((Array.isArray(participantRoles) ? participantRoles : [])
-            .map((role) => String(role || '').trim())
-            .filter(Boolean)))
-            .sort(),
-        mutedBy: Array.from(new Set(Array.isArray(mutedBy) ? mutedBy : [])),
+        participantRoles: normalizedParticipantRoles,
+        mutedBy: normalizedMutedBy,
         updatedAt: now
     };
     if (name) {
         payload.name = name;
     }
-    if (!existing.exists()) {
-        payload.createdAt = now;
-    }
+    payload.createdAt = now;
     await setDoc(conversationRef, payload, { merge: true });
     return { id: conversationId, ...payload };
 }

--- a/js/db.js
+++ b/js/db.js
@@ -5510,13 +5510,14 @@ export async function getChatConversations(teamId, user = null, { team = null, c
 /**
  * Create or update a lightweight conversation record.
  */
-export async function upsertChatConversation(teamId, {
-    type = 'group',
-    participantIds = [],
-    participantRoles = [],
-    mutedBy = [],
-    name = null
-} = {}) {
+export async function upsertChatConversation(teamId, conversation = {}) {
+    const {
+        type = 'group',
+        participantIds = [],
+        participantRoles = [],
+        mutedBy = [],
+        name = null
+    } = conversation;
     const normalizedType = normalizeConversationType(type);
     const normalizedParticipantIds = normalizeConversationParticipantIds(participantIds);
     const conversationId = buildConversationId(normalizedType, normalizedParticipantIds);
@@ -5528,12 +5529,22 @@ export async function upsertChatConversation(teamId, {
         .filter(Boolean)))
         .sort();
     const normalizedMutedBy = Array.from(new Set(Array.isArray(mutedBy) ? mutedBy : []));
+    const hasMutedByUpdate = Object.prototype.hasOwnProperty.call(conversation, 'mutedBy');
 
     if (existing.exists()) {
+        if (hasMutedByUpdate) {
+            await setDoc(conversationRef, {
+                mutedBy: normalizedMutedBy,
+                updatedAt: now
+            }, { merge: true });
+        }
         return {
             id: conversationId,
             ...existing.data(),
-            mutedBy: normalizedMutedBy.length > 0 ? normalizedMutedBy : (existing.data()?.mutedBy || []),
+            ...(hasMutedByUpdate ? {
+                mutedBy: normalizedMutedBy,
+                updatedAt: now
+            } : {}),
             participantIds: existing.data()?.participantIds || normalizedParticipantIds,
             participantRoles: existing.data()?.participantRoles || normalizedParticipantRoles,
             name: existing.data()?.name || name || null

--- a/team-chat.html
+++ b/team-chat.html
@@ -344,7 +344,7 @@
     <script type="module">
         import { renderHeader, renderFooter, escapeHtml } from './js/utils.js?v=8';
         import { checkAuth } from './js/auth.js?v=20';
-        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, getTeamEmailTemplates, saveTeamEmailTemplate, deleteTeamEmailTemplate, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=42';
+        import { getTeam, getUserProfile, getPlayers, getGames, getGameEvents, getAggregatedStatsForGames, getChatConversations, upsertChatConversation, getChatMessages, postChatMessage, editChatMessage, deleteChatMessage, getTeamEmailDrafts, saveTeamEmailDraft, getTeamEmailTemplates, saveTeamEmailTemplate, deleteTeamEmailTemplate, canAccessTeamChat, canModerateChat, updateChatLastRead, subscribeToChatMessages, sendTeamEmail, getSentTeamEmails, uploadChatImage, deleteUploadedChatAttachments, toggleChatReaction } from './js/db.js?v=43';
         import { DEFAULT_TEAM_CONVERSATION_ID, buildDefaultTeamConversation, getConversationDisplayName, isDefaultTeamConversation } from './js/team-chat-conversations.js?v=1';
         import { shouldUpdateChatLastRead, shouldRetryChatLastReadOnViewReturn } from './js/team-chat-last-read.js?v=3';
         import {

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -1370,7 +1370,7 @@ describe('React app messages integration', () => {
         expect(container.textContent).toContain('Tipoff');
     });
 
-    it('keeps inline videos on preload=none when a thread first opens', async () => {
+    it('keeps inline videos fully deferred when a thread first opens', async () => {
         chatMocks.subscribeToTeamChatMessages.mockImplementation((teamId, conversationId, onMessages) => {
             onMessages([
                 chatMessage({
@@ -1398,47 +1398,18 @@ describe('React app messages integration', () => {
         expect(videos).toHaveLength(2);
         videos.forEach((video) => {
             expect(video.getAttribute('preload')).toBe('none');
+            expect(video.getAttribute('src')).toBeNull();
         });
-        expect(intersectionObserverState.instances).toHaveLength(2);
+        expect(intersectionObserverState.instances).toHaveLength(0);
 
         await flush();
         videos.forEach((video) => {
             expect(video.getAttribute('preload')).toBe('none');
+            expect(video.getAttribute('src')).toBeNull();
         });
     });
 
-    it('keeps inline video metadata deferred when the attachment is only barely intersecting', async () => {
-        chatMocks.subscribeToTeamChatMessages.mockImplementation((teamId, conversationId, onMessages) => {
-            onMessages([
-                chatMessage({
-                    id: 'msg-video-partial',
-                    text: '',
-                    attachments: [
-                        {
-                            type: 'video',
-                            url: 'https://media.example.test/partial.mp4',
-                            name: 'Partial.mp4'
-                        }
-                    ]
-                })
-            ], { id: 'cursor' });
-            return { unsubscribe: vi.fn() };
-        });
-
-        const { container } = await renderMessages('/messages/team-1');
-        const video = container.querySelector('video[data-chat-attachment-url="https://media.example.test/partial.mp4"]');
-        expect(video).toBeTruthy();
-        expect(video.getAttribute('preload')).toBe('none');
-        expect(intersectionObserverState.instances).toHaveLength(1);
-
-        await act(async () => {
-            intersectionObserverState.instances[0].trigger(video, true, 0.1);
-        });
-        await flush();
-        expect(video.getAttribute('preload')).toBe('none');
-    });
-
-    it('defers inline video metadata until the attachment is visible or hovered', async () => {
+    it('defers inline video loading until the attachment is explicitly interacted with', async () => {
         chatMocks.subscribeToTeamChatMessages.mockImplementation((teamId, conversationId, onMessages) => {
             onMessages([
                 chatMessage({
@@ -1460,40 +1431,15 @@ describe('React app messages integration', () => {
         const video = container.querySelector('video[data-chat-attachment-url="https://media.example.test/warmups.mp4"]');
         expect(video).toBeTruthy();
         expect(video.getAttribute('preload')).toBe('none');
-        expect(intersectionObserverState.instances).toHaveLength(1);
+        expect(video.getAttribute('src')).toBeNull();
+        expect(intersectionObserverState.instances).toHaveLength(0);
 
         await act(async () => {
-            intersectionObserverState.instances[0].trigger(video, true);
+            video.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
         });
         await flush();
         expect(video.getAttribute('preload')).toBe('metadata');
-
-        chatMocks.subscribeToTeamChatMessages.mockImplementationOnce((teamId, conversationId, onMessages) => {
-            onMessages([
-                chatMessage({
-                    id: 'msg-video-hover',
-                    text: '',
-                    attachments: [
-                        {
-                            type: 'video',
-                            url: 'https://media.example.test/huddle.mp4',
-                            name: 'Huddle.mp4'
-                        }
-                    ]
-                })
-            ], { id: 'cursor' });
-            return { unsubscribe: vi.fn() };
-        });
-
-        const hovered = await renderMessages('/messages/team-1');
-        const hoveredVideo = hovered.container.querySelector('video[data-chat-attachment-url="https://media.example.test/huddle.mp4"]');
-        expect(hoveredVideo.getAttribute('preload')).toBe('none');
-
-        await act(async () => {
-            hoveredVideo.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
-        });
-        await flush();
-        expect(hoveredVideo.getAttribute('preload')).toBe('metadata');
+        expect(video.getAttribute('src')).toBe('https://media.example.test/warmups.mp4');
     });
 
     it('routes ALL PLAYS mentions through the existing AI assistant send path', async () => {

--- a/tests/unit/db-chat-conversation-upsert.test.js
+++ b/tests/unit/db-chat-conversation-upsert.test.js
@@ -1,0 +1,146 @@
+import { describe, expect, it, vi } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const dbSource = readFileSync(new URL('../../js/db.js', import.meta.url), 'utf8');
+
+function getFunctionSource(functionName) {
+    const start = dbSource.indexOf(`export async function ${functionName}`);
+    expect(start).toBeGreaterThanOrEqual(0);
+    const nextExport = dbSource.indexOf('\nexport ', start + 1);
+    const nextImport = dbSource.indexOf('\nimport ', start + 1);
+    const candidates = [nextExport, nextImport].filter((value) => value !== -1);
+    const end = candidates.length > 0 ? Math.min(...candidates) : dbSource.length;
+    return dbSource.slice(start, end);
+}
+
+function buildUpsertChatConversation({
+    normalizeConversationType,
+    normalizeConversationParticipantIds,
+    buildConversationId,
+    Timestamp,
+    doc,
+    db,
+    getDoc,
+    setDoc
+}) {
+    const functionSource = getFunctionSource('upsertChatConversation')
+        .replace('export async function upsertChatConversation', 'return async function upsertChatConversation');
+
+    return new Function(
+        'normalizeConversationType',
+        'normalizeConversationParticipantIds',
+        'buildConversationId',
+        'Timestamp',
+        'doc',
+        'db',
+        'getDoc',
+        'setDoc',
+        functionSource
+    )(
+        normalizeConversationType,
+        normalizeConversationParticipantIds,
+        buildConversationId,
+        Timestamp,
+        doc,
+        db,
+        getDoc,
+        setDoc
+    );
+}
+
+function makeSnapshot(data) {
+    return {
+        exists: () => Boolean(data),
+        data: () => data
+    };
+}
+
+describe('upsertChatConversation', () => {
+    it('creates a new targeted conversation with participant membership on first write', async () => {
+        const now = { seconds: 123 };
+        const getDoc = vi.fn().mockResolvedValue(makeSnapshot(null));
+        const setDoc = vi.fn().mockResolvedValue(undefined);
+        const conversationRef = { path: 'teams/team-1/chatConversations/direct-user-1-user-2' };
+        const upsertChatConversation = buildUpsertChatConversation({
+            normalizeConversationType: vi.fn((value) => value),
+            normalizeConversationParticipantIds: vi.fn((ids) => [...ids].sort()),
+            buildConversationId: vi.fn(() => 'direct-user-1-user-2'),
+            Timestamp: { now: vi.fn(() => now) },
+            doc: vi.fn(() => conversationRef),
+            db: {},
+            getDoc,
+            setDoc
+        });
+
+        const result = await upsertChatConversation('team-1', {
+            type: 'direct',
+            participantIds: ['user-2', 'user-1'],
+            participantRoles: ['staff', 'staff'],
+            mutedBy: ['user-1', 'user-1'],
+            name: 'Private chat'
+        });
+
+        expect(setDoc).toHaveBeenCalledWith(conversationRef, {
+            type: 'direct',
+            participantIds: ['user-1', 'user-2'],
+            participantRoles: ['staff'],
+            mutedBy: ['user-1'],
+            name: 'Private chat',
+            updatedAt: now,
+            createdAt: now
+        }, { merge: true });
+        expect(result).toEqual({
+            id: 'direct-user-1-user-2',
+            type: 'direct',
+            participantIds: ['user-1', 'user-2'],
+            participantRoles: ['staff'],
+            mutedBy: ['user-1'],
+            name: 'Private chat',
+            updatedAt: now,
+            createdAt: now
+        });
+    });
+
+    it('returns an existing conversation without rewriting immutable membership fields', async () => {
+        const getDoc = vi.fn().mockResolvedValue(makeSnapshot({
+            type: 'group',
+            participantIds: ['user-1', 'user-2'],
+            participantRoles: [],
+            mutedBy: ['user-2'],
+            name: 'Existing chat',
+            createdAt: { seconds: 1 },
+            updatedAt: { seconds: 2 }
+        }));
+        const setDoc = vi.fn().mockResolvedValue(undefined);
+        const upsertChatConversation = buildUpsertChatConversation({
+            normalizeConversationType: vi.fn((value) => value),
+            normalizeConversationParticipantIds: vi.fn((ids) => [...ids].sort()),
+            buildConversationId: vi.fn(() => 'group-user-1-user-2'),
+            Timestamp: { now: vi.fn(() => ({ seconds: 999 })) },
+            doc: vi.fn(() => ({ path: 'teams/team-1/chatConversations/group-user-1-user-2' })),
+            db: {},
+            getDoc,
+            setDoc
+        });
+
+        const result = await upsertChatConversation('team-1', {
+            type: 'group',
+            participantIds: ['user-2', 'user-1', 'user-3'],
+            participantRoles: ['staff'],
+            mutedBy: [],
+            name: 'Renamed by participant'
+        });
+
+        expect(setDoc).not.toHaveBeenCalled();
+        expect(result).toEqual({
+            id: 'group-user-1-user-2',
+            type: 'group',
+            participantIds: ['user-1', 'user-2'],
+            participantRoles: [],
+            mutedBy: ['user-2'],
+            name: 'Existing chat',
+            createdAt: { seconds: 1 },
+            updatedAt: { seconds: 2 }
+        });
+    });
+});

--- a/tests/unit/db-chat-conversation-upsert.test.js
+++ b/tests/unit/db-chat-conversation-upsert.test.js
@@ -101,7 +101,9 @@ describe('upsertChatConversation', () => {
         });
     });
 
-    it('returns an existing conversation without rewriting immutable membership fields', async () => {
+    it('persists mutable metadata for an existing conversation without rewriting immutable membership fields', async () => {
+        const now = { seconds: 999 };
+        const conversationRef = { path: 'teams/team-1/chatConversations/group-user-1-user-2' };
         const getDoc = vi.fn().mockResolvedValue(makeSnapshot({
             type: 'group',
             participantIds: ['user-1', 'user-2'],
@@ -116,8 +118,8 @@ describe('upsertChatConversation', () => {
             normalizeConversationType: vi.fn((value) => value),
             normalizeConversationParticipantIds: vi.fn((ids) => [...ids].sort()),
             buildConversationId: vi.fn(() => 'group-user-1-user-2'),
-            Timestamp: { now: vi.fn(() => ({ seconds: 999 })) },
-            doc: vi.fn(() => ({ path: 'teams/team-1/chatConversations/group-user-1-user-2' })),
+            Timestamp: { now: vi.fn(() => now) },
+            doc: vi.fn(() => conversationRef),
             db: {},
             getDoc,
             setDoc
@@ -131,16 +133,19 @@ describe('upsertChatConversation', () => {
             name: 'Renamed by participant'
         });
 
-        expect(setDoc).not.toHaveBeenCalled();
+        expect(setDoc).toHaveBeenCalledWith(conversationRef, {
+            mutedBy: [],
+            updatedAt: now
+        }, { merge: true });
         expect(result).toEqual({
             id: 'group-user-1-user-2',
             type: 'group',
             participantIds: ['user-1', 'user-2'],
             participantRoles: [],
-            mutedBy: ['user-2'],
+            mutedBy: [],
             name: 'Existing chat',
             createdAt: { seconds: 1 },
-            updatedAt: { seconds: 2 }
+            updatedAt: now
         });
     });
 });

--- a/tests/unit/team-chat-targeted-rules.test.js
+++ b/tests/unit/team-chat-targeted-rules.test.js
@@ -56,4 +56,16 @@ describe('targeted team chat Firestore rules', () => {
     it('rejects unauthorized senders by requiring senderId to match auth uid', () => {
         expect(rules).toContain('request.resource.data.senderId == request.auth.uid &&');
     });
+
+    it('locks membership and naming changes to team staff while letting participants update benign metadata', () => {
+        expect(rules).toContain('function isChatConversationParticipantMetadataUpdate()');
+        expect(rules).toContain("request.resource.data.get('name', null) == resource.data.get('name', null)");
+        expect(rules).toContain("request.resource.data.get('participantIds', []) == resource.data.get('participantIds', [])");
+        expect(rules).toContain("request.resource.data.get('participantRoles', []) == resource.data.get('participantRoles', [])");
+        expect(rules).toContain(".hasOnly(['lastMessageAt', 'mutedBy', 'updatedAt']);");
+        expect(rules).toContain('function isTeamStaffChatConversationUpdate(teamId)');
+        expect(rules).toContain('return isTeamOwnerOrAdmin(teamId) &&');
+        expect(rules).toContain('(isTeamStaffChatConversationUpdate(teamId) ||');
+        expect(rules).toContain('isChatConversationParticipantMetadataUpdate());');
+    });
 });

--- a/tests/unit/team-email-drafts.test.js
+++ b/tests/unit/team-email-drafts.test.js
@@ -9,7 +9,7 @@ describe('team email draft composer', () => {
     it('pins the fresh db cache-busting version for team chat draft helpers', () => {
         const html = readRepoFile('team-chat.html');
 
-        expect(html).toContain("from './js/db.js?v=42';");
+        expect(html).toContain("from './js/db.js?v=43';");
     });
 
     it('wires coach/admin email drafts into team chat', () => {


### PR DESCRIPTION
Closes #1948

## What changed
- tightened `chatConversations` Firestore update rules so ordinary participants can only change benign metadata fields (`mutedBy`, `lastMessageAt`, `updatedAt`)
- reserved conversation name and membership changes (`name`, `participantIds`, `participantRoles`) to team owner/admin updates
- hardened `upsertChatConversation` so normal client conversation reuse returns the existing thread instead of re-merging membership fields onto existing docs
- added focused regression coverage for both the rules contract and the client helper behavior

## Root Cause
Targeted chat authorization treated current `participantIds` as both the read gate and a participant-mutable field. Any existing participant could expand `participantIds`/`participantRoles`, and the client helper continued to merge those privileged fields back into existing conversation documents.

## Prevention / Learning
When historical message access depends on conversation membership, treat membership arrays and role assignments as immutable for non-staff after creation. Normal client upsert paths should not re-send privileged membership fields for existing documents.

## Regression Tests
- `tests/unit/team-chat-targeted-rules.test.js`
- `tests/unit/db-chat-conversation-upsert.test.js`
- `npx vitest run tests/unit/team-chat-targeted-rules.test.js tests/unit/db-chat-conversation-upsert.test.js tests/unit/app-chat-service-recipients.test.js --reporter=verbose`
- `npm run ci:firebase-rules`

## Recurrence Risk
Low. The rules now block participant-driven audience expansion, and the normal client helper no longer attempts follow-up membership rewrites on existing targeted threads.