### PR TITLE
Stop rewriting events when saving reminder defaults

### DIFF
--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -10,9 +10,6 @@ import {
   getTeam,
   getAllUsers,
   updateTeam,
-  getEvents,
-  updateEvent,
-  updateGame,
   grantScorekeeperAccess,
   grantVideographerAccess,
   inviteAdmin,
@@ -23,7 +20,7 @@ import {
 import { sendInviteEmail } from '../../../../js/auth.js';
 import { inviteExistingTeamAdmin } from '../../../../js/edit-team-admin-invites.js';
 import { collection, db, getDocs, query, where } from '../../../../js/firebase.js';
-import { buildScheduleNotificationMetadata, describeScheduleReminderWindow, normalizeScheduleNotificationSettings } from '../../../../js/schedule-notifications.js';
+import { describeScheduleReminderWindow, normalizeScheduleNotificationSettings } from '../../../../js/schedule-notifications.js';
 import { calculateSeasonRecord, listSeasonLabels } from '../../../../js/season-record.js';
 import { computeNativeStandings } from '../../../../js/native-standings.js';
 import { buildPlayerLeaderboardSnapshot, selectAnalyticsConfig } from '../../../../js/stat-leaderboards.js';
@@ -503,37 +500,14 @@ export async function saveTeamScheduleNotificationsForApp(teamId: string, settin
   const normalizedTeamId = cleanString(teamId);
   if (!normalizedTeamId) throw new Error('Team ID is required.');
   const normalizedSettings = normalizeTeamScheduleNotifications(settings);
-  const teamScheduleNotifications = {
-    enabled: normalizedSettings.enabled,
-    reminderHours: normalizedSettings.reminderHours,
-    delivery: normalizedSettings.delivery
-  };
 
   await updateTeam(normalizedTeamId, {
-    scheduleNotifications: teamScheduleNotifications
-  });
-
-  const events = await Promise.resolve(getEvents(normalizedTeamId)).catch(() => []);
-  for (const event of Array.isArray(events) ? events : []) {
-    const eventId = cleanString(event?.id || event?.gameId);
-    if (!eventId) continue;
-    const eventType = cleanString(event?.type).toLowerCase() === 'practice' ? 'practice' : 'game';
-    const isCanceled = ['cancelled', 'canceled'].includes(cleanString(event?.status).toLowerCase()) || event?.deleted === true;
-    const payload = {
-      scheduleNotifications: buildScheduleNotificationMetadata({
-        settings: teamScheduleNotifications,
-        action: isCanceled ? 'cancelled' : 'updated',
-        eventDate: event?.date,
-        canceled: isCanceled
-      })
-    };
-
-    if (eventType === 'practice') {
-      await updateEvent(normalizedTeamId, eventId, payload);
-    } else {
-      await updateGame(normalizedTeamId, eventId, payload);
+    scheduleNotifications: {
+      enabled: normalizedSettings.enabled,
+      reminderHours: normalizedSettings.reminderHours,
+      delivery: normalizedSettings.delivery
     }
-  }
+  });
 
   return normalizedSettings;
 }

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -173,10 +173,10 @@ describe('React app team detail model', () => {
         expect(getTeam).toHaveBeenCalledTimes(2);
     });
 
-    it('normalizes and saves team schedule reminder defaults with the legacy payload', async () => {
+    it('normalizes and saves team schedule reminder defaults without rewriting existing events', async () => {
         updateTeam.mockResolvedValue(undefined);
         getEvents.mockResolvedValue([
-            { id: 'game-1', type: 'game', date: new Date('2100-06-01T18:00:00Z'), status: 'scheduled' },
+            { id: 'game-1', type: 'game', date: new Date('2000-06-01T18:00:00Z'), status: 'completed' },
             { id: 'practice-1', type: 'practice', date: new Date('2100-06-02T18:00:00Z'), status: 'cancelled' }
         ]);
         updateGame.mockResolvedValue(undefined);
@@ -191,28 +191,9 @@ describe('React app team detail model', () => {
                 delivery: 'team_chat'
             }
         });
-        expect(getEvents).toHaveBeenCalledWith('team-1');
-        expect(updateGame).toHaveBeenCalledWith('team-1', 'game-1', {
-            scheduleNotifications: expect.objectContaining({
-                enabled: false,
-                reminderHours: 24,
-                delivery: 'team_chat',
-                reminderStatus: 'disabled',
-                nextReminderAt: null,
-                lastAction: 'updated'
-            })
-        });
-        expect(updateEvent).toHaveBeenCalledWith('team-1', 'practice-1', {
-            scheduleNotifications: expect.objectContaining({
-                enabled: false,
-                reminderHours: 24,
-                delivery: 'team_chat',
-                reminderStatus: 'canceled',
-                nextReminderAt: null,
-                reminderCanceled: true,
-                lastAction: 'cancelled'
-            })
-        });
+        expect(getEvents).not.toHaveBeenCalled();
+        expect(updateGame).not.toHaveBeenCalled();
+        expect(updateEvent).not.toHaveBeenCalled();
         expect(saved).toMatchObject({
             enabled: false,
             reminderHours: 24,


### PR DESCRIPTION
Closes #1947

## What changed
- removed the legacy event backfill loop from `saveTeamScheduleNotificationsForApp`
- kept the save path focused on a single `teams/{teamId}.scheduleNotifications` write using normalized defaults
- updated the team detail service regression test to prove existing game and practice docs are not read or rewritten during this save

## Root Cause
`saveTeamScheduleNotificationsForApp` treated a team-level default save like a migration. After writing the team doc, it always called `getEvents()` and fanned out `updateGame()` or `updateEvent()` across the full schedule history, even though the Team Detail UI explicitly describes the setting as applying to future schedule events.

## Prevention / Learning
When a setting is described as a future default, persist it at the owning scope only. Do not hide unbounded backfills or migrations behind an interactive settings save, especially on Firestore collections that grow with team history.

## Regression Tests
- `npx vitest run tests/unit/app-team-detail-service.test.js tests/unit/app-team-detail-integration.test.jsx --reporter=dot`
- `tests/unit/app-team-detail-service.test.js` now asserts the reminder-default save updates the team doc while never calling `getEvents`, `updateGame`, or `updateEvent`, including when mocked existing events include canceled and historical records.