### PR TITLE
Add baseball and softball game plan formations

### DIFF
--- a/game-day.html
+++ b/game-day.html
@@ -542,6 +542,36 @@
                     { id: 'pf', name: 'Power Forward' },
                     { id: 'c', name: 'Center' }
                 ]
+            },
+            'baseball-diamond': {
+                name: 'Baseball Diamond',
+                numPeriods: 7,
+                positions: [
+                    { id: 'pitcher', name: 'Pitcher (P)' },
+                    { id: 'catcher', name: 'Catcher (C)' },
+                    { id: 'first-base', name: 'First Base (1B)' },
+                    { id: 'second-base', name: 'Second Base (2B)' },
+                    { id: 'third-base', name: 'Third Base (3B)' },
+                    { id: 'shortstop', name: 'Shortstop (SS)' },
+                    { id: 'left-field', name: 'Left Field (LF)' },
+                    { id: 'center-field', name: 'Center Field (CF)' },
+                    { id: 'right-field', name: 'Right Field (RF)' }
+                ]
+            },
+            'softball-diamond': {
+                name: 'Softball Diamond',
+                numPeriods: 7,
+                positions: [
+                    { id: 'pitcher', name: 'Pitcher (P)' },
+                    { id: 'catcher', name: 'Catcher (C)' },
+                    { id: 'first-base', name: 'First Base (1B)' },
+                    { id: 'second-base', name: 'Second Base (2B)' },
+                    { id: 'third-base', name: 'Third Base (3B)' },
+                    { id: 'shortstop', name: 'Shortstop (SS)' },
+                    { id: 'left-field', name: 'Left Field (LF)' },
+                    { id: 'center-field', name: 'Center Field (CF)' },
+                    { id: 'right-field', name: 'Right Field (RF)' }
+                ]
             }
         };
 
@@ -578,6 +608,28 @@
                 'sf': { left: 78, top: 42 },
                 'pf': { left: 28, top: 67 },
                 'c':  { left: 72, top: 67 },
+            },
+            'baseball-diamond': {
+                'pitcher':     { left: 50, top: 56 },
+                'catcher':     { left: 50, top: 78 },
+                'first-base':  { left: 70, top: 56 },
+                'second-base': { left: 58, top: 44 },
+                'third-base':  { left: 30, top: 56 },
+                'shortstop':   { left: 42, top: 44 },
+                'left-field':  { left: 24, top: 24 },
+                'center-field': { left: 50, top: 16 },
+                'right-field': { left: 76, top: 24 },
+            },
+            'softball-diamond': {
+                'pitcher':     { left: 50, top: 56 },
+                'catcher':     { left: 50, top: 78 },
+                'first-base':  { left: 70, top: 56 },
+                'second-base': { left: 58, top: 44 },
+                'third-base':  { left: 30, top: 56 },
+                'shortstop':   { left: 42, top: 44 },
+                'left-field':  { left: 24, top: 24 },
+                'center-field': { left: 50, top: 16 },
+                'right-field': { left: 76, top: 24 },
             }
         };
 

--- a/game-plan.html
+++ b/game-plan.html
@@ -170,6 +170,22 @@
                                 <p class="text-sm text-gray-600">5 court positions + bench</p>
                             </div>
                         </div>
+                        <div class="formation-card cursor-pointer border-2 border-gray-300 rounded-xl p-6 hover:border-primary-500 hover:bg-primary-50 transition"
+                             data-formation="baseball-diamond">
+                            <div class="text-center">
+                                <div class="text-4xl mb-3">⚾</div>
+                                <h3 class="text-xl font-bold text-gray-900 mb-2">Baseball Diamond</h3>
+                                <p class="text-sm text-gray-600">9 fielding positions + bench</p>
+                            </div>
+                        </div>
+                        <div class="formation-card cursor-pointer border-2 border-gray-300 rounded-xl p-6 hover:border-primary-500 hover:bg-primary-50 transition"
+                             data-formation="softball-diamond">
+                            <div class="text-center">
+                                <div class="text-4xl mb-3">🥎</div>
+                                <h3 class="text-xl font-bold text-gray-900 mb-2">Softball Diamond</h3>
+                                <p class="text-sm text-gray-600">9 fielding positions + bench</p>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
@@ -185,9 +201,9 @@
                     <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-6">
                         <div>
                             <label class="block text-sm font-semibold text-gray-700 mb-2">Number of Periods</label>
-                            <input type="number" id="num-periods" min="2" max="4" value="2"
+                            <input type="number" id="num-periods" min="1" max="12" value="2"
                                    class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary-500">
-                            <p class="text-xs text-gray-500 mt-1">Typically 2 halves or 4 quarters</p>
+                            <p class="text-xs text-gray-500 mt-1">Examples: 2 halves, 4 quarters, or 7 innings</p>
                         </div>
                         <div>
                             <label class="block text-sm font-semibold text-gray-700 mb-2">Minutes per Period</label>
@@ -319,6 +335,34 @@
                     { id: 'pf', name: 'Power Forward (PF)' },
                     { id: 'c', name: 'Center (C)' }
                 ]
+            },
+            'baseball-diamond': {
+                name: 'Baseball Diamond',
+                positions: [
+                    { id: 'pitcher', name: 'Pitcher (P)' },
+                    { id: 'catcher', name: 'Catcher (C)' },
+                    { id: 'first-base', name: 'First Base (1B)' },
+                    { id: 'second-base', name: 'Second Base (2B)' },
+                    { id: 'third-base', name: 'Third Base (3B)' },
+                    { id: 'shortstop', name: 'Shortstop (SS)' },
+                    { id: 'left-field', name: 'Left Field (LF)' },
+                    { id: 'center-field', name: 'Center Field (CF)' },
+                    { id: 'right-field', name: 'Right Field (RF)' }
+                ]
+            },
+            'softball-diamond': {
+                name: 'Softball Diamond',
+                positions: [
+                    { id: 'pitcher', name: 'Pitcher (P)' },
+                    { id: 'catcher', name: 'Catcher (C)' },
+                    { id: 'first-base', name: 'First Base (1B)' },
+                    { id: 'second-base', name: 'Second Base (2B)' },
+                    { id: 'third-base', name: 'Third Base (3B)' },
+                    { id: 'shortstop', name: 'Shortstop (SS)' },
+                    { id: 'left-field', name: 'Left Field (LF)' },
+                    { id: 'center-field', name: 'Center Field (CF)' },
+                    { id: 'right-field', name: 'Right Field (RF)' }
+                ]
             }
         };
 
@@ -398,6 +442,7 @@
                 periodDuration: 25,
                 subTimes: [7, 14, 21],
                 formationId: null,
+                periodPrefix: null,
                 lineups: {}
             };
 
@@ -416,6 +461,28 @@
                 return {
                     ...gamePlanDefaults,
                     formationId: 'soccer-9v9'
+                };
+            }
+
+            if (sport === 'baseball') {
+                return {
+                    ...gamePlanDefaults,
+                    numPeriods: 7,
+                    periodDuration: 1,
+                    subTimes: [],
+                    formationId: 'baseball-diamond',
+                    periodPrefix: 'I'
+                };
+            }
+
+            if (sport === 'softball') {
+                return {
+                    ...gamePlanDefaults,
+                    numPeriods: 7,
+                    periodDuration: 1,
+                    subTimes: [],
+                    formationId: 'softball-diamond',
+                    periodPrefix: 'I'
                 };
             }
 
@@ -648,7 +715,7 @@
             document.getElementById('sub-times-input').value = gamePlan.subTimes.join(',');
             renderSubTimesDisplay();
 
-            const hasPlan = gamePlan.formationId && (gamePlan.subTimes || []).length > 0;
+            const hasPlan = !!gamePlan.formationId;
 
             document.getElementById('planning-wizard').classList.remove('hidden');
 
@@ -724,13 +791,13 @@
             const formation = FORMATIONS[gamePlan.formationId];
             const subTimesText = (gamePlan.subTimes && gamePlan.subTimes.length > 0)
                 ? gamePlan.subTimes.join(', ')
-                : '—';
+                : 'None';
             document.getElementById('plan-summary-formation').textContent = formation ? formation.name : 'Not set';
             document.getElementById('plan-summary-periods').textContent = gamePlan.numPeriods || '—';
             document.getElementById('plan-summary-duration').textContent = gamePlan.periodDuration || '—';
             document.getElementById('plan-summary-subs').textContent = subTimesText;
 
-            const ready = formation && subTimesText !== '—';
+            const ready = formation && Number(gamePlan.numPeriods) > 0 && Number(gamePlan.periodDuration) > 0;
             summary.classList.toggle('hidden', !ready);
         }
 

--- a/tests/unit/game-day-entry.test.js
+++ b/tests/unit/game-day-entry.test.js
@@ -77,4 +77,13 @@ describe('game day entry page wiring', () => {
         expect(source).toContain('scoreUpdatedBy: state.user?.uid || null');
         expect(source).toContain('scoreStreamSessionId: state.game?.broadcastSession?.id || null');
     });
+
+    it('registers baseball and softball diamond formations before rendering saved game plans', () => {
+        const source = readFileSync(resolve(process.cwd(), 'game-day.html'), 'utf8');
+
+        expect(source).toContain("'baseball-diamond': {");
+        expect(source).toContain("'softball-diamond': {");
+        expect(source).toContain("{ id: 'pitcher', name: 'Pitcher (P)' }");
+        expect(source).toContain("'pitcher':     { left: 50, top: 56 }");
+    });
 });

--- a/tests/unit/game-plan-switching.test.js
+++ b/tests/unit/game-plan-switching.test.js
@@ -88,7 +88,9 @@ function buildHarness(overrides = {}) {
         },
         FORMATIONS: {
             'soccer-9v9': { name: 'Soccer 9v9', positions: [{ id: 'keeper', name: 'Keeper' }] },
-            'basketball-5v5': { name: 'Basketball 5v5', positions: [{ id: 'pg', name: 'Point Guard' }] }
+            'basketball-5v5': { name: 'Basketball 5v5', positions: [{ id: 'pg', name: 'Point Guard' }] },
+            'baseball-diamond': { name: 'Baseball Diamond', positions: [{ id: 'pitcher', name: 'Pitcher' }] },
+            'softball-diamond': { name: 'Softball Diamond', positions: [{ id: 'pitcher', name: 'Pitcher' }] }
         },
         document,
         recentAssignments: new Map([['stale-key', Date.now()]]),
@@ -160,6 +162,58 @@ ${loadGameBody}
 }
 
 describe('game plan game switching', () => {
+    it('adds baseball and softball defaults so diamond sports skip the blocked formation step', async () => {
+        const { harness, document, deps } = buildHarness({
+            currentTeam: { sport: 'Baseball' }
+        });
+
+        await harness.loadGame({
+            id: 'game-baseball',
+            opponent: 'Sharks',
+            date: '2026-04-04T19:00:00.000Z'
+        });
+
+        expect(harness.getState().gamePlan).toMatchObject({
+            formationId: 'baseball-diamond',
+            numPeriods: 7,
+            periodDuration: 1,
+            periodPrefix: 'I',
+            subTimes: []
+        });
+        expect(document.getElementById('step-lineup').classList.contains('hidden')).toBe(false);
+        expect(document.getElementById('step-formation').classList.contains('hidden')).toBe(true);
+        expect(deps.renderSubMatrix).toHaveBeenCalledTimes(1);
+    });
+
+    it('maps softball teams to the softball diamond defaults', async () => {
+        const { harness } = buildHarness({
+            currentTeam: { sport: 'Softball' }
+        });
+
+        await harness.loadGame({
+            id: 'game-softball',
+            opponent: 'Panthers',
+            date: '2026-04-04T19:00:00.000Z'
+        });
+
+        expect(harness.getState().gamePlan).toMatchObject({
+            formationId: 'softball-diamond',
+            numPeriods: 7,
+            periodDuration: 1,
+            periodPrefix: 'I',
+            subTimes: []
+        });
+    });
+
+    it('includes baseball and softball formation cards in the chooser markup', () => {
+        const source = readGamePlanPage();
+
+        expect(source).toContain('data-formation="baseball-diamond"');
+        expect(source).toContain('Baseball Diamond');
+        expect(source).toContain('data-formation="softball-diamond"');
+        expect(source).toContain('Softball Diamond');
+    });
+
     it('clears saved lineup assignments when switching to a game without a plan', async () => {
         const { harness, deps } = buildHarness();
 


### PR DESCRIPTION
Closes #1949

## What changed
- Added Baseball Diamond and Softball Diamond formation cards to `game-plan.html` so baseball and softball teams can choose a valid fielding layout.
- Added sport-specific default game plan setup for baseball and softball with seven innings, inning prefix `I`, and diamond formation IDs.
- Updated planner hydration so any sport with a valid default formation can open directly into lineup building instead of getting sent back to a blocked formation step.
- Expanded the focused regression test to cover baseball and softball defaults plus the new chooser markup.

## Root Cause
`game-plan.html` hardcoded both the visible formation chooser and `createDefaultGamePlan()` for soccer and basketball only. Baseball and softball teams therefore loaded with no valid `formationId`, and `loadGame()` pushed them back to Step 1 where no diamond option existed.

## Prevention / Learning
When a workflow is sport-aware, keep the visible option list and the sport-to-default mapping in the same change set. Add a regression test that covers both the sport-specific default path and the chooser markup so supported sports cannot silently fall out of one side of the flow.

## Regression Tests
- `tests/unit/game-plan-switching.test.js`
- `npx vitest run tests/unit/game-plan-switching.test.js tests/unit/game-plan-playing-time-summary.test.js tests/unit/game-plan-interop.test.js --reporter=verbose`