### PR TITLE
Use cached schedule summary for game route resolution

### DIFF
--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -82,9 +82,11 @@ vi.mock('./authService', () => ({ firebaseAuth: {}, getNativeAuthIdToken: vi.fn(
 vi.mock('./uxTiming', () => ({ startUxTimer: vi.fn(() => ({ end: vi.fn() })) }));
 vi.mock('./chatService', () => ({ sendTeamChatMessage: vi.fn() }));
 vi.mock('./chatLogic', () => ({ DEFAULT_TEAM_CONVERSATION_ID: 'team' }));
+vi.mock('./appDataCache', () => ({ getCachedAppData: vi.fn(), loadCachedAppData: vi.fn(), clearAppDataCache: vi.fn() }));
 
 import { updateGame, getGame, getGames, getPlayers, getPracticeSessions, getRsvpBreakdownByPlayer, getRsvps, getTeams, submitRsvpForPlayer } from '../../../../js/db.js';
 import { fetchAndParseCalendar } from '../../../../js/utils.js';
+import { getCachedAppData } from './appDataCache';
 import { loadProfileDocument } from './profileService';
 import { buildPlayerScoringLiveEvent, loadStaffScheduleRsvpBreakdown, recordPlayerScoringStat, resolveParentGameRoute, saveScheduledGameLineupDraftForApp, submitStaffScheduleRsvpOverride } from './scheduleService';
 
@@ -105,12 +107,43 @@ describe('parent game route resolution', () => {
       }
       return null as any;
     });
+    vi.mocked(getCachedAppData).mockReturnValue(null);
     vi.mocked(getGames).mockResolvedValue([] as any);
     vi.mocked(getPracticeSessions).mockResolvedValue([] as any);
     vi.mocked(fetchAndParseCalendar).mockResolvedValue([] as any);
   });
 
-  it('resolves a game route without loading full schedules or calendars', async () => {
+  it('resolves a game route from the cached schedule summary before scanning teams', async () => {
+    vi.mocked(getCachedAppData).mockReturnValue({
+      children: [],
+      events: [
+        {
+          id: 'game-7',
+          teamId: 'team-bravo',
+          type: 'game',
+          childId: 'child-2'
+        }
+      ]
+    } as any);
+
+    const result = await resolveParentGameRoute({ uid: 'parent-1', email: 'parent@example.com', roles: [] } as any, 'game-7', {
+      expandStaffPlayers: false
+    });
+
+    expect(result).toEqual({
+      teamId: 'team-bravo',
+      eventId: 'game-7',
+      childId: 'child-2'
+    });
+    expect(getCachedAppData).toHaveBeenCalledWith('app-schedule-summary:parent-1');
+    expect(loadProfileDocument).not.toHaveBeenCalled();
+    expect(getGame).not.toHaveBeenCalled();
+    expect(getGames).not.toHaveBeenCalled();
+    expect(getPracticeSessions).not.toHaveBeenCalled();
+    expect(fetchAndParseCalendar).not.toHaveBeenCalled();
+  });
+
+  it('resolves a game route without loading full schedules or calendars when cache misses', async () => {
     const result = await resolveParentGameRoute({ uid: 'parent-1', email: 'parent@example.com', roles: [] } as any, 'game-7', {
       expandStaffPlayers: false
     });

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -94,6 +94,7 @@ import {
 } from './gameDayLineupPublish';
 import { sendTeamChatMessage } from './chatService';
 import { DEFAULT_TEAM_CONVERSATION_ID } from './chatLogic';
+import { getCachedAppData } from './appDataCache';
 import type { AuthUser } from './types';
 
 const primaryDataTimeoutMs = 5000;
@@ -1931,6 +1932,23 @@ export async function resolveParentGameRoute(user: AuthUser | null, gameId: stri
 
   const timer = startUxTimer('parent game route resolve');
   const expandStaffPlayers = options.expandStaffPlayers === true;
+  const cachedSchedule = getCachedAppData<ParentScheduleLoadResult>(`app-schedule-summary:${user.uid}`);
+  const cachedMatch = (cachedSchedule?.events || []).find((event) => (
+    compactString(event?.id) === requestedGameId
+    && event?.type === 'game'
+    && compactString(event?.teamId)
+  ));
+
+  if (cachedMatch) {
+    const childId = compactString(cachedMatch.childId);
+    const resolution = {
+      teamId: compactString(cachedMatch.teamId),
+      eventId: requestedGameId,
+      childId: childId && !childId.startsWith(`staff-team-${compactString(cachedMatch.teamId)}`) ? childId : null
+    };
+    timer.end({ gameId: requestedGameId, expandStaffPlayers, cacheHit: true, matched: true });
+    return resolution;
+  }
 
   try {
     const profile = await loadProfileDocument(user.uid);
@@ -1957,10 +1975,10 @@ export async function resolveParentGameRoute(user: AuthUser | null, gameId: stri
     });
 
     const resolution = matches.find(Boolean) || null;
-    timer.end({ gameId: requestedGameId, expandStaffPlayers, childLinks: children.length, teams: byTeam.size, staffTeams: staffTeams.length, matched: Boolean(resolution) });
+    timer.end({ gameId: requestedGameId, expandStaffPlayers, cacheHit: false, childLinks: children.length, teams: byTeam.size, staffTeams: staffTeams.length, matched: Boolean(resolution) });
     return resolution;
   } catch (error: any) {
-    timer.end({ gameId: requestedGameId, expandStaffPlayers, error: error?.message || 'Unable to resolve game route.' });
+    timer.end({ gameId: requestedGameId, expandStaffPlayers, cacheHit: false, error: error?.message || 'Unable to resolve game route.' });
     throw error;
   }
 }


### PR DESCRIPTION
Closes #1951

## What changed
- updated `resolveParentGameRoute` to check `app-schedule-summary:${user.uid}` before scanning team game documents
- reused the cached event's `teamId`, `eventId`, and `childId` when the summary already contains the requested game
- kept the existing per-team `getGame` fallback unchanged for cache misses or stale summaries
- added a regression test that proves the cache-hit path avoids `getGame` and other schedule fan-out reads

## Root Cause
`resolveParentGameRoute` ignored the in-memory schedule summary that `Schedule` already populates and always fanned out `getGame` calls across every visible team. That made `/games/:gameId` deep links pay repeated network/database lookups even when the matching event was already in local app state.

## Prevention / Learning
For schedule-driven route resolution, check the nearest hydrated summary cache before issuing per-team fallback reads. Cache-backed route resolvers should only fan out to team or entity lookups when the summary is missing or does not contain the target record.

## Regression Tests
- `npx vitest run apps/app/src/lib/scheduleService.test.ts apps/app/src/pages/GameDetail.test.tsx`
- added `apps/app/src/lib/scheduleService.test.ts` coverage asserting cached route resolution returns the match without calling `getGame`, `getGames`, `getPracticeSessions`, or calendar fetches