### PR TITLE
Warm app search team access on open

### DIFF
--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AppSearchDialog } from './AppSearchDialog';
+import type { AppSearchTeam } from '../lib/searchService';
 import type { AuthState } from '../lib/types';
 
 const { navigateMock, preloadSearchRouteMock } = vi.hoisted(() => ({
@@ -209,7 +210,7 @@ describe('AppSearchDialog', () => {
 
   it('does not block the first player search on slow team hydration', async () => {
     const onClose = vi.fn();
-    let releaseHydration!: (teams: Array<{ id: string; name: string; sport?: string; zip?: string }>) => void;
+    let releaseHydration!: (teams: AppSearchTeam[] | PromiseLike<AppSearchTeam[]>) => void;
     loadAppSearchTeamsMock.mockImplementationOnce(() => new Promise((resolve) => {
       releaseHydration = resolve;
     }));

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -28,10 +28,10 @@ vi.mock('../lib/searchRoutePreload', () => ({
 }));
 
 const { getKnownAppSearchTeamsMock, loadAppSearchTeamsMock, searchAppTeamsMock, searchAppPlayersMock } = vi.hoisted(() => ({
-  getKnownAppSearchTeamsMock: vi.fn((): Array<{ id: string; name: string; sport?: string; zip?: string }> => []),
-  loadAppSearchTeamsMock: vi.fn(async () => [{ id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }]),
-  searchAppTeamsMock: vi.fn(async (_query: string, teams: Array<{ id: string; name: string; sport?: string; zip?: string }>) => teams),
-  searchAppPlayersMock: vi.fn(async () => []),
+  getKnownAppSearchTeamsMock: vi.fn((): AppSearchTeam[] => []),
+  loadAppSearchTeamsMock: vi.fn(async (): Promise<AppSearchTeam[]> => [{ id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }]),
+  searchAppTeamsMock: vi.fn<(query: string, teams: AppSearchTeam[], user: AuthState['user']) => Promise<AppSearchTeam[]>>(),
+  searchAppPlayersMock: vi.fn<(query: string, teamsById: Map<string, AppSearchTeam>, user: AuthState['user']) => Promise<never[]>>(),
 }));
 
 vi.mock('../lib/searchService', () => ({
@@ -263,8 +263,8 @@ describe('AppSearchDialog', () => {
 
   it('does not let the initial cold search overwrite hydrated search results', async () => {
     const onClose = vi.fn();
-    const initialTeams = [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }];
-    const hydratedTeams = [
+    const initialTeams: AppSearchTeam[] = [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }];
+    const hydratedTeams: AppSearchTeam[] = [
       ...initialTeams,
       { id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }
     ];
@@ -282,7 +282,7 @@ describe('AppSearchDialog', () => {
       }
       resolveInitialTeams = resolve;
     }));
-    searchAppPlayersMock.mockImplementation((_query, teamsById) => new Promise((resolve) => {
+    searchAppPlayersMock.mockImplementation((_query: string, teamsById: Map<string, AppSearchTeam>) => new Promise<never[]>((resolve) => {
       if (teamsById.has('team-2')) {
         resolveHydratedPlayers = resolve;
         return;

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -232,4 +232,83 @@ describe('AppSearchDialog', () => {
       expect.objectContaining({ id: 'team-2', name: 'Rockets' })
     ]), null));
   });
+
+  it('ignores stale hydrated teams after the dialog closes before warm loading finishes', async () => {
+    const onClose = vi.fn();
+    const userA = { uid: 'user-a', email: 'a@example.com' } as NonNullable<AuthState['user']>;
+    let releaseHydration!: (teams: AppSearchTeam[] | PromiseLike<AppSearchTeam[]>) => void;
+    getKnownAppSearchTeamsMock.mockReturnValue([{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }]);
+    loadAppSearchTeamsMock.mockImplementationOnce(() => new Promise((resolve) => {
+      releaseHydration = resolve;
+    }));
+
+    const { rerender } = render(
+      <MemoryRouter>
+        <AppSearchDialog auth={{ ...auth, user: userA }} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('button', { name: /Bears/ })).toBeTruthy();
+
+    rerender(
+      <MemoryRouter>
+        <AppSearchDialog auth={{ ...auth, user: userA }} open={false} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    releaseHydration([{ id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }]);
+    await waitFor(() => expect(loadAppSearchTeamsMock).toHaveBeenCalledTimes(1));
+    expect(screen.queryByRole('button', { name: /Rockets/ })).toBeNull();
+  });
+
+  it('does not let the initial cold search overwrite hydrated search results', async () => {
+    const onClose = vi.fn();
+    const initialTeams = [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }];
+    const hydratedTeams = [
+      ...initialTeams,
+      { id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }
+    ];
+    let resolveInitialTeams!: (teams: AppSearchTeam[]) => void;
+    let resolveHydratedTeams!: (teams: AppSearchTeam[]) => void;
+    let resolveInitialPlayers!: (players: never[]) => void;
+    let resolveHydratedPlayers!: (players: never[]) => void;
+
+    getKnownAppSearchTeamsMock.mockReturnValue(initialTeams);
+    loadAppSearchTeamsMock.mockResolvedValue(hydratedTeams);
+    searchAppTeamsMock.mockImplementation((_query, teams) => new Promise((resolve) => {
+      if (teams.some((team) => team.id === 'team-2')) {
+        resolveHydratedTeams = resolve;
+        return;
+      }
+      resolveInitialTeams = resolve;
+    }));
+    searchAppPlayersMock.mockImplementation((_query, teamsById) => new Promise((resolve) => {
+      if (teamsById.has('team-2')) {
+        resolveHydratedPlayers = resolve;
+        return;
+      }
+      resolveInitialPlayers = resolve;
+    }));
+
+    render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'ro' } });
+
+    await waitFor(() => expect(searchAppTeamsMock).toHaveBeenCalledTimes(2));
+
+    resolveHydratedTeams(hydratedTeams);
+    resolveHydratedPlayers([]);
+    expect(await screen.findByRole('button', { name: /Rockets/ })).toBeTruthy();
+
+    resolveInitialTeams(initialTeams);
+    resolveInitialPlayers([]);
+
+    await waitFor(() => expect(searchAppPlayersMock).toHaveBeenCalledTimes(2));
+    expect(screen.queryByRole('button', { name: /Rockets/ })).toBeTruthy();
+    expect(screen.queryByRole('button', { name: /Bears/ })).toBeNull();
+  });
 });

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -26,10 +26,11 @@ vi.mock('../lib/searchRoutePreload', () => ({
   preloadSearchRoute: preloadSearchRouteMock,
 }));
 
-const { getKnownAppSearchTeamsMock, loadAppSearchTeamsMock, searchAppTeamsMock } = vi.hoisted(() => ({
+const { getKnownAppSearchTeamsMock, loadAppSearchTeamsMock, searchAppTeamsMock, searchAppPlayersMock } = vi.hoisted(() => ({
   getKnownAppSearchTeamsMock: vi.fn((): Array<{ id: string; name: string; sport?: string; zip?: string }> => []),
   loadAppSearchTeamsMock: vi.fn(async () => [{ id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }]),
   searchAppTeamsMock: vi.fn(async (_query: string, teams: Array<{ id: string; name: string; sport?: string; zip?: string }>) => teams),
+  searchAppPlayersMock: vi.fn(async () => []),
 }));
 
 vi.mock('../lib/searchService', () => ({
@@ -53,7 +54,7 @@ vi.mock('../lib/searchService', () => ({
   getKnownAppSearchTeams: getKnownAppSearchTeamsMock,
   loadAppSearchTeams: loadAppSearchTeamsMock,
   searchAppTeams: searchAppTeamsMock,
-  searchAppPlayers: vi.fn(async () => []),
+  searchAppPlayers: searchAppPlayersMock,
 }));
 
 const auth: AuthState = {
@@ -82,6 +83,7 @@ describe('AppSearchDialog', () => {
     getKnownAppSearchTeamsMock.mockReturnValue([]);
     loadAppSearchTeamsMock.mockResolvedValue([{ id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }]);
     searchAppTeamsMock.mockImplementation(async (_query, teams) => teams);
+    searchAppPlayersMock.mockResolvedValue([]);
     preloadSearchRouteMock.mockImplementation(async () => true);
   });
 
@@ -149,6 +151,7 @@ describe('AppSearchDialog', () => {
       </MemoryRouter>
     );
 
+    await screen.findByRole('button', { name: /Rockets/ });
     const dialog = screen.getByRole('dialog', { name: 'Search teams, players, actions, and help' });
     fireEvent.keyDown(dialog, { key: 'ArrowDown' });
 
@@ -184,7 +187,7 @@ describe('AppSearchDialog', () => {
     expect(navigateMock).toHaveBeenCalledWith('/teams/team-2');
   });
 
-  it('does not load teams on open and waits for typing before bounded team search queries', async () => {
+  it('starts loading accessible teams on open and reuses that warm load for the first query', async () => {
     const onClose = vi.fn();
 
     render(
@@ -194,11 +197,36 @@ describe('AppSearchDialog', () => {
     );
 
     expect(await screen.findAllByRole('button', { name: /Browse Teams/ })).not.toHaveLength(0);
-    expect(loadAppSearchTeamsMock).not.toHaveBeenCalled();
+    await waitFor(() => expect(loadAppSearchTeamsMock).toHaveBeenCalledTimes(1));
     expect(searchAppTeamsMock).not.toHaveBeenCalled();
 
     fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'ro' } });
-    await waitFor(() => expect(loadAppSearchTeamsMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(searchAppTeamsMock).toHaveBeenCalledWith('ro', expect.arrayContaining([
+      expect.objectContaining({ id: 'team-2', name: 'Rockets' })
+    ]), null));
+    expect(loadAppSearchTeamsMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not block the first player search on slow team hydration', async () => {
+    const onClose = vi.fn();
+    let releaseHydration!: (teams: Array<{ id: string; name: string; sport?: string; zip?: string }>) => void;
+    loadAppSearchTeamsMock.mockImplementationOnce(() => new Promise((resolve) => {
+      releaseHydration = resolve;
+    }));
+
+    render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'ro' } });
+
+    await waitFor(() => expect(searchAppPlayersMock).toHaveBeenCalledWith('ro', expect.any(Map), null));
+    expect(loadAppSearchTeamsMock).toHaveBeenCalledTimes(1);
+    expect(searchAppTeamsMock).toHaveBeenCalledWith('ro', [], null);
+
+    releaseHydration([{ id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }]);
     await waitFor(() => expect(searchAppTeamsMock).toHaveBeenCalledWith('ro', expect.arrayContaining([
       expect.objectContaining({ id: 'team-2', name: 'Rockets' })
     ]), null));

--- a/apps/app/src/components/AppSearchDialog.test.tsx
+++ b/apps/app/src/components/AppSearchDialog.test.tsx
@@ -248,7 +248,7 @@ describe('AppSearchDialog', () => {
       </MemoryRouter>
     );
 
-    expect(await screen.findByRole('button', { name: /Bears/ })).toBeTruthy();
+    await waitFor(() => expect(getKnownAppSearchTeamsMock).toHaveBeenCalledWith(userA));
 
     rerender(
       <MemoryRouter>
@@ -259,6 +259,25 @@ describe('AppSearchDialog', () => {
     releaseHydration([{ id: 'team-2', name: 'Rockets', sport: 'Soccer', zip: '64114' }]);
     await waitFor(() => expect(loadAppSearchTeamsMock).toHaveBeenCalledTimes(1));
     expect(screen.queryByRole('button', { name: /Rockets/ })).toBeNull();
+  });
+
+  it('does not rerun hydrated searches when accessible teams stay the same', async () => {
+    const onClose = vi.fn();
+    const initialTeams: AppSearchTeam[] = [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }];
+
+    getKnownAppSearchTeamsMock.mockReturnValue(initialTeams);
+    loadAppSearchTeamsMock.mockResolvedValue([...initialTeams]);
+
+    render(
+      <MemoryRouter>
+        <AppSearchDialog auth={auth} open={true} onClose={onClose} />
+      </MemoryRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText('Search teams, players, actions, help'), { target: { value: 'zzzz' } });
+
+    await waitFor(() => expect(searchAppTeamsMock).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(searchAppPlayersMock).toHaveBeenCalledTimes(1));
   });
 
   it('does not let the initial cold search overwrite hydrated search results', async () => {
@@ -309,6 +328,6 @@ describe('AppSearchDialog', () => {
 
     await waitFor(() => expect(searchAppPlayersMock).toHaveBeenCalledTimes(2));
     expect(screen.queryByRole('button', { name: /Rockets/ })).toBeTruthy();
-    expect(screen.queryByRole('button', { name: /Bears/ })).toBeNull();
+    expect(screen.queryByRole('button', { name: /Bears/ })).toBeTruthy();
   });
 });

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -52,6 +52,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
 
   useEffect(() => {
     if (!open) return;
+    let cancelled = false;
     openedAtRef.current = Date.now();
     preloadedRoutesRef.current = new Set<string>();
     hydratedTeamsPromiseRef.current = null;
@@ -71,6 +72,7 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     const hydratedTeamsPromise = loadAppSearchTeams(auth.user)
       .then((loadedTeams) => mergeSearchTeams(knownTeams, loadedTeams))
       .then((loadedTeams) => {
+        if (cancelled) return knownTeams;
         baseTeamsRef.current = loadedTeams;
         setBaseTeams(loadedTeams);
         setTeams((currentTeams) => mergeSearchTeams(currentTeams, loadedTeams));
@@ -79,6 +81,10 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       .catch(() => knownTeams);
 
     hydratedTeamsPromiseRef.current = hydratedTeamsPromise;
+
+    return () => {
+      cancelled = true;
+    };
   }, [auth.user, open]);
 
   useEffect(() => {
@@ -102,7 +108,12 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     setPlayersLoading(true);
     setPlayersError('');
     const timeoutId = window.setTimeout(() => {
-      const runSearch = async (accessibleTeams: AppSearchTeam[], options: { teamsLoadingDone?: boolean; playersLoadingDone?: boolean } = {}) => {
+      let hydratedResultsApplied = false;
+
+      const runSearch = async (
+        accessibleTeams: AppSearchTeam[],
+        options: { phase: 'initial' | 'hydrated'; teamsLoadingDone?: boolean; playersLoadingDone?: boolean }
+      ) => {
         const accessibleTeamsById = new Map(accessibleTeams.map((team) => [team.id, team]));
         const [teamsResult, playersResult] = await Promise.allSettled([
           searchAppTeams(trimmedQuery, accessibleTeams, auth.user),
@@ -110,6 +121,8 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
         ]) as [PromiseSettledResult<AppSearchTeam[]>, PromiseSettledResult<AppSearchPlayer[]>];
 
         if (requestId !== searchRequestId.current) return;
+        if (options.phase === 'initial' && hydratedResultsApplied) return;
+        if (options.phase === 'hydrated') hydratedResultsApplied = true;
 
         if (teamsResult.status === 'fulfilled') {
           setTeams(teamsResult.value);
@@ -135,12 +148,12 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
         }
       };
 
-      void runSearch(initialAccessibleTeams, { teamsLoadingDone: false, playersLoadingDone: true });
+      void runSearch(initialAccessibleTeams, { phase: 'initial', teamsLoadingDone: false, playersLoadingDone: true });
 
       void (hydratedTeamsPromiseRef.current || loadAppSearchTeams(auth.user)
         .then((loadedTeams) => mergeSearchTeams(initialAccessibleTeams, loadedTeams))
         .catch(() => initialAccessibleTeams))
-        .then((hydratedTeams) => runSearch(hydratedTeams, { teamsLoadingDone: true, playersLoadingDone: false }))
+        .then((hydratedTeams) => runSearch(hydratedTeams, { phase: 'hydrated', teamsLoadingDone: true, playersLoadingDone: true }))
         .catch(() => {
           if (requestId === searchRequestId.current) {
             setTeamsLoading(false);

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -153,7 +153,14 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       void (hydratedTeamsPromiseRef.current || loadAppSearchTeams(auth.user)
         .then((loadedTeams) => mergeSearchTeams(initialAccessibleTeams, loadedTeams))
         .catch(() => initialAccessibleTeams))
-        .then((hydratedTeams) => runSearch(hydratedTeams, { phase: 'hydrated', teamsLoadingDone: true, playersLoadingDone: true }))
+        .then((hydratedTeams) => {
+          if (requestId !== searchRequestId.current) return;
+          if (hasSameTeamScope(initialAccessibleTeams, hydratedTeams)) {
+            setTeamsLoading(false);
+            return;
+          }
+          return runSearch(hydratedTeams, { phase: 'hydrated', teamsLoadingDone: true, playersLoadingDone: true });
+        })
         .catch(() => {
           if (requestId === searchRequestId.current) {
             setTeamsLoading(false);
@@ -484,6 +491,12 @@ function mergeSearchTeams(...teamLists: AppSearchTeam[][]) {
     if (team?.id) teamsById.set(team.id, team);
   });
   return Array.from(teamsById.values());
+}
+
+function hasSameTeamScope(currentTeams: AppSearchTeam[], nextTeams: AppSearchTeam[]) {
+  if (currentTeams.length !== nextTeams.length) return false;
+  const currentTeamIds = new Set(currentTeams.map((team) => team.id).filter(Boolean));
+  return nextTeams.every((team) => currentTeamIds.has(team.id));
 }
 
 function getPlayerSearchError(error: any) {

--- a/apps/app/src/components/AppSearchDialog.tsx
+++ b/apps/app/src/components/AppSearchDialog.tsx
@@ -39,6 +39,8 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
   const searchRequestId = useRef(0);
   const openedAtRef = useRef(Date.now());
   const preloadedRoutesRef = useRef(new Set<string>());
+  const baseTeamsRef = useRef<AppSearchTeam[]>([]);
+  const hydratedTeamsPromiseRef = useRef<Promise<AppSearchTeam[]> | null>(null);
   const navigate = useNavigate();
 
   const results = useMemo(
@@ -52,17 +54,31 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
     if (!open) return;
     openedAtRef.current = Date.now();
     preloadedRoutesRef.current = new Set<string>();
+    hydratedTeamsPromiseRef.current = null;
     setQuery('');
     setPlayers([]);
     setPlayersError('');
     setPlayersLoading(false);
     const knownTeams = getKnownAppSearchTeams(auth.user);
+    baseTeamsRef.current = knownTeams;
     setBaseTeams(knownTeams);
     setTeams(knownTeams);
     setActiveIndex(0);
     setHelpRoleFilter('all');
     setTeamsLoading(false);
     setTeamsError('');
+
+    const hydratedTeamsPromise = loadAppSearchTeams(auth.user)
+      .then((loadedTeams) => mergeSearchTeams(knownTeams, loadedTeams))
+      .then((loadedTeams) => {
+        baseTeamsRef.current = loadedTeams;
+        setBaseTeams(loadedTeams);
+        setTeams((currentTeams) => mergeSearchTeams(currentTeams, loadedTeams));
+        return loadedTeams;
+      })
+      .catch(() => knownTeams);
+
+    hydratedTeamsPromiseRef.current = hydratedTeamsPromise;
   }, [auth.user, open]);
 
   useEffect(() => {
@@ -80,50 +96,60 @@ export function AppSearchDialog({ auth, open, onClose }: AppSearchDialogProps) {
       return;
     }
 
+    const initialAccessibleTeams = baseTeamsRef.current;
     setTeamsLoading(true);
     setTeamsError('');
     setPlayersLoading(true);
     setPlayersError('');
     const timeoutId = window.setTimeout(() => {
-      loadAppSearchTeams(auth.user)
-        .catch(() => baseTeams)
-        .then(async (loadedTeams) => {
-          const accessibleTeams = mergeSearchTeams(baseTeams, loadedTeams);
-          const accessibleTeamsById = new Map(accessibleTeams.map((team) => [team.id, team]));
-          const results = await Promise.allSettled([
-            searchAppTeams(trimmedQuery, accessibleTeams, auth.user),
-            searchAppPlayers(trimmedQuery, accessibleTeamsById, auth.user)
-          ]) as [PromiseSettledResult<AppSearchTeam[]>, PromiseSettledResult<AppSearchPlayer[]>];
-          return results;
-        })
-        .then(([teamsResult, playersResult]) => {
-          if (requestId !== searchRequestId.current) return;
+      const runSearch = async (accessibleTeams: AppSearchTeam[], options: { teamsLoadingDone?: boolean; playersLoadingDone?: boolean } = {}) => {
+        const accessibleTeamsById = new Map(accessibleTeams.map((team) => [team.id, team]));
+        const [teamsResult, playersResult] = await Promise.allSettled([
+          searchAppTeams(trimmedQuery, accessibleTeams, auth.user),
+          searchAppPlayers(trimmedQuery, accessibleTeamsById, auth.user)
+        ]) as [PromiseSettledResult<AppSearchTeam[]>, PromiseSettledResult<AppSearchPlayer[]>];
 
-          if (teamsResult.status === 'fulfilled') {
-            setTeams(teamsResult.value);
-            setTeamsError('');
-          } else {
-            setTeams([]);
-            setTeamsError(teamsResult.reason?.message || 'Team search unavailable.');
-          }
+        if (requestId !== searchRequestId.current) return;
 
-          if (playersResult.status === 'fulfilled') {
-            setPlayers(playersResult.value);
-          } else {
-            setPlayers([]);
-            setPlayersError(getPlayerSearchError(playersResult.reason));
-          }
-        })
-        .finally(() => {
+        if (teamsResult.status === 'fulfilled') {
+          setTeams(teamsResult.value);
+          setTeamsError('');
+        } else {
+          setTeams([]);
+          setTeamsError(teamsResult.reason?.message || 'Team search unavailable.');
+        }
+
+        if (playersResult.status === 'fulfilled') {
+          setPlayers(playersResult.value);
+          setPlayersError('');
+        } else {
+          setPlayers([]);
+          setPlayersError(getPlayerSearchError(playersResult.reason));
+        }
+
+        if (options.teamsLoadingDone && requestId === searchRequestId.current) {
+          setTeamsLoading(false);
+        }
+        if (options.playersLoadingDone && requestId === searchRequestId.current) {
+          setPlayersLoading(false);
+        }
+      };
+
+      void runSearch(initialAccessibleTeams, { teamsLoadingDone: false, playersLoadingDone: true });
+
+      void (hydratedTeamsPromiseRef.current || loadAppSearchTeams(auth.user)
+        .then((loadedTeams) => mergeSearchTeams(initialAccessibleTeams, loadedTeams))
+        .catch(() => initialAccessibleTeams))
+        .then((hydratedTeams) => runSearch(hydratedTeams, { teamsLoadingDone: true, playersLoadingDone: false }))
+        .catch(() => {
           if (requestId === searchRequestId.current) {
             setTeamsLoading(false);
-            setPlayersLoading(false);
           }
         });
     }, 180);
 
     return () => window.clearTimeout(timeoutId);
-  }, [auth.user, baseTeams, open, query]);
+  }, [auth.user, open, query]);
 
   useEffect(() => {
     setActiveIndex(0);

--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -22,6 +22,8 @@ const teamSearchQueryLimit = 20;
 let cachedTeams: AppSearchTeam[] | null = null;
 let cachedTeamsLoadedAt = 0;
 let cachedTeamsUserKey = '';
+let cachedTeamsPromise: Promise<AppSearchTeam[]> | null = null;
+let cachedTeamsPromiseUserKey = '';
 const playerSearchCache = new Map<string, PlayerSearchCacheEntry>();
 
 type PlayerSearchCacheEntry = {
@@ -284,6 +286,10 @@ export async function loadAppSearchTeams(user: AuthUser | null): Promise<AppSear
     return cachedTeams;
   }
 
+  if (cachedTeamsPromise && cachedTeamsPromiseUserKey === userCacheKey) {
+    return cachedTeamsPromise;
+  }
+
   if (!user) {
     cachedTeams = [];
     cachedTeamsLoadedAt = now;
@@ -291,46 +297,58 @@ export async function loadAppSearchTeams(user: AuthUser | null): Promise<AppSear
     return cachedTeams;
   }
 
-  const [directAccessTeamsResult, homeTeamsResult, streamVolunteerTeamsResult] = await Promise.allSettled([
-    loadDirectAccessSearchTeams(user),
-    user ? loadParentHomeSummary(user) : Promise.resolve(null),
-    user ? loadStreamVolunteerSearchTeams(user) : Promise.resolve([])
-  ]);
+  cachedTeamsPromiseUserKey = userCacheKey;
+  cachedTeamsPromise = (async () => {
+    const [directAccessTeamsResult, homeTeamsResult, streamVolunteerTeamsResult] = await Promise.allSettled([
+      loadDirectAccessSearchTeams(user),
+      user ? loadParentHomeSummary(user) : Promise.resolve(null),
+      user ? loadStreamVolunteerSearchTeams(user) : Promise.resolve([])
+    ]);
 
-  const teamsById = new Map<string, AppSearchTeam>();
+    const teamsById = new Map<string, AppSearchTeam>();
 
-  if (directAccessTeamsResult.status === 'fulfilled') {
-    normalizeTeams(directAccessTeamsResult.value).forEach((team) => {
-      if (canUserDiscoverTeamInAppSearch(team, user)) teamsById.set(team.id, team);
-    });
+    if (directAccessTeamsResult.status === 'fulfilled') {
+      normalizeTeams(directAccessTeamsResult.value).forEach((team) => {
+        if (canUserDiscoverTeamInAppSearch(team, user)) teamsById.set(team.id, team);
+      });
+    }
+
+    if (homeTeamsResult.status === 'fulfilled' && homeTeamsResult.value) {
+      await mergeParentHomeSearchTeams(teamsById, homeTeamsResult.value.teams || [], user);
+    }
+
+    if (streamVolunteerTeamsResult.status === 'fulfilled') {
+      normalizeTeams(streamVolunteerTeamsResult.value).forEach((team) => {
+        if (canUserDiscoverTeamInAppSearch(team, user)) teamsById.set(team.id, team);
+      });
+    }
+
+    if (!teamsById.size) {
+      const firstError = directAccessTeamsResult.status === 'rejected'
+        ? directAccessTeamsResult.reason
+        : homeTeamsResult.status === 'rejected'
+          ? homeTeamsResult.reason
+          : streamVolunteerTeamsResult.status === 'rejected'
+            ? streamVolunteerTeamsResult.reason
+            : null;
+      if (firstError) throw firstError;
+    }
+
+    cachedTeams = Array.from(teamsById.values())
+      .sort((a, b) => a.name.localeCompare(b.name));
+    cachedTeamsLoadedAt = Date.now();
+    cachedTeamsUserKey = userCacheKey;
+    return cachedTeams;
+  })();
+
+  try {
+    return await cachedTeamsPromise;
+  } finally {
+    if (cachedTeamsPromiseUserKey === userCacheKey) {
+      cachedTeamsPromise = null;
+      cachedTeamsPromiseUserKey = '';
+    }
   }
-
-  if (homeTeamsResult.status === 'fulfilled' && homeTeamsResult.value) {
-    await mergeParentHomeSearchTeams(teamsById, homeTeamsResult.value.teams || [], user);
-  }
-
-  if (streamVolunteerTeamsResult.status === 'fulfilled') {
-    normalizeTeams(streamVolunteerTeamsResult.value).forEach((team) => {
-      if (canUserDiscoverTeamInAppSearch(team, user)) teamsById.set(team.id, team);
-    });
-  }
-
-  if (!teamsById.size) {
-    const firstError = directAccessTeamsResult.status === 'rejected'
-      ? directAccessTeamsResult.reason
-      : homeTeamsResult.status === 'rejected'
-        ? homeTeamsResult.reason
-        : streamVolunteerTeamsResult.status === 'rejected'
-          ? streamVolunteerTeamsResult.reason
-          : null;
-    if (firstError) throw firstError;
-  }
-
-  cachedTeams = Array.from(teamsById.values())
-    .sort((a, b) => a.name.localeCompare(b.name));
-  cachedTeamsLoadedAt = now;
-  cachedTeamsUserKey = userCacheKey;
-  return cachedTeams;
 }
 
 export async function searchAppTeams(queryText: string, appAccessTeams: AppSearchTeam[], user: AuthUser | null): Promise<AppSearchTeam[]> {
@@ -535,6 +553,8 @@ export function resetAppSearchCacheForTests() {
   cachedTeams = null;
   cachedTeamsLoadedAt = 0;
   cachedTeamsUserKey = '';
+  cachedTeamsPromise = null;
+  cachedTeamsPromiseUserKey = '';
   playerSearchCache.clear();
 }
 

--- a/tests/unit/app-search-integration.test.jsx
+++ b/tests/unit/app-search-integration.test.jsx
@@ -253,6 +253,64 @@ describe('React app shell search', () => {
         expect(container.querySelector('[data-testid="route"]').textContent).toBe('/players/team-home/player-1');
     });
 
+    it('lets player search start before slow team hydration finishes and merges team results afterward', async () => {
+        let resolveParentHome;
+        homeMocks.loadParentHome.mockImplementationOnce(() => new Promise((resolve) => {
+            resolveParentHome = resolve;
+        }));
+        firebaseMocks.getDocs.mockImplementation(async (request) => {
+            const parts = request?.parts || [];
+            const collectionName = parts.find((part) => part?.collectionName)?.collectionName;
+            const lowerBound = parts.find((part) => part?.type === 'where' && part.field === 'name' && part.op === '>=')?.value;
+            const ownerQuery = parts.find((part) => part?.type === 'where' && part.field === 'ownerId');
+            const adminQuery = parts.find((part) => part?.type === 'where' && part.field === 'adminEmails');
+            const streamMemberQuery = parts.find((part) => part?.type === 'where' && part.field === 'teamPermissions.streaming.memberIds');
+            const streamEmailQuery = parts.find((part) => part?.type === 'where' && part.field === 'streamVolunteerEmails');
+
+            if (collectionName === 'teams') {
+                if (ownerQuery || adminQuery || streamMemberQuery || streamEmailQuery) {
+                    return { docs: [] };
+                }
+                if (lowerBound === 'roc' || lowerBound === 'Roc') {
+                    return { docs: [firestoreTeam('team-2', { name: 'Rockets', sport: 'Soccer', zip: '64114', isPublic: false })] };
+                }
+                return { docs: [] };
+            }
+
+            return {
+                docs: [
+                    firestorePlayer('teams/team-home/players/player-1', { name: 'Roc Star', number: '9' }),
+                    firestorePlayer('teams/team-2/players/player-2', { name: 'Rocket Kid', number: '10' })
+                ]
+            };
+        });
+
+        const { container } = await renderShell();
+
+        await clickButton(container, 'Search');
+        await fillSearch(container, 'roc');
+        await waitForText(container, '#9 Roc Star');
+        expect(container.textContent).toContain('#9 Roc Star');
+        expect(container.textContent).not.toContain('Rocket Kid');
+
+        resolveParentHome({
+            teams: [{
+                teamId: 'team-2',
+                teamName: 'Rockets',
+                sport: 'Soccer',
+                players: [],
+                nextEvent: null,
+                eventCount: 0,
+                unreadCount: 0,
+                openActions: 0
+            }]
+        });
+        await flush(400);
+
+        await waitForText(container, 'Rockets');
+        expect(container.textContent).toContain('#10 Rocket Kid');
+    });
+
     it('avoids repeated Firestore player lookups for narrower mobile search refinements', async () => {
         firebaseMocks.getDocs.mockImplementation(async (request) => {
             const parts = request?.parts || [];


### PR DESCRIPTION
Closes #1943

## What changed
- start `loadAppSearchTeams()` as soon as the app search dialog opens and keep its in-flight promise for reuse
- let the first 2+ character query run `searchAppPlayers()` immediately against the best currently known accessible teams instead of waiting for hydration
- re-run the bounded team and player searches with the hydrated team scope once the warm load resolves
- cache and reuse the in-flight team hydration in `searchService` so repeated query refinements do not start duplicate access-hydration work
- added focused dialog and integration regression tests for warm-load reuse and non-blocking first-query behavior

## Root Cause
`AppSearchDialog` deferred accessible-team hydration until after the user typed a 2+ character query, then serialized both `searchAppTeams()` and `searchAppPlayers()` behind `loadAppSearchTeams()`. That made the first meaningful search wait on multiple access-hydration reads before either team or player results could begin.

## Prevention / Learning
When async hydration only improves search scope, warm it when the surface opens, cache and reuse the in-flight promise, and let the first visible query run against the best currently known scope. Do not serialize user-visible search results behind secondary access-hydration work.

## Regression Tests
- `npx vitest run apps/app/src/components/AppSearchDialog.test.tsx tests/unit/app-search-integration.test.jsx --reporter=verbose`
- `apps/app/src/components/AppSearchDialog.test.tsx` asserts the dialog starts hydration on open, reuses the same warm load, and does not block the first player search on slow hydration
- `tests/unit/app-search-integration.test.jsx` verifies player results can appear before slow hydration finishes and hydrated team/player results merge afterward