### PR TITLE
Defer team chat recipient option hydration

### DIFF
--- a/apps/app/src/lib/chatLogic.ts
+++ b/apps/app/src/lib/chatLogic.ts
@@ -243,13 +243,16 @@ export function buildEmailAudienceMetadata({
   if (selectedConversation && !isDefaultTeamConversation(selectedConversationId)) {
     const optionIds = new Set(recipientOptions.map((option) => option.id));
     const participantIds: unknown[] = Array.isArray(selectedConversation.participantIds) ? selectedConversation.participantIds : [];
-    const recipientIds = Array.from(new Set<string>(participantIds.flatMap((id: unknown) => {
+    const normalizedRecipientIds = Array.from(new Set<string>(participantIds.flatMap((id: unknown) => {
       const raw = String(id || '').trim();
       if (!raw) return [];
       if (raw.toLowerCase().startsWith('email:')) return [getRecipientOptionId('email', raw.slice(6))];
       if (raw.toLowerCase().startsWith('user:')) return [getRecipientOptionId('user', raw.slice(5))];
       return [raw, getRecipientOptionId('user', raw)];
-    }).filter((id: string) => optionIds.has(id))));
+    })));
+    const recipientIds = optionIds.size > 0
+      ? normalizedRecipientIds.filter((id: string) => optionIds.has(id))
+      : normalizedRecipientIds;
     return {
       targetType: 'individuals',
       recipientIds,

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -483,6 +483,8 @@ function ChatWindow({
   const pendingScrollRef = useRef(false);
   const stickToLatestRef = useRef(true);
   const recipientOptionsPromiseRef = useRef<Promise<ChatRecipientOption[]> | null>(null);
+  const recipientOptionsRequestIdRef = useRef(0);
+  const currentTeamIdRef = useRef(teamId);
   const programmaticScrollRef = useRef(false);
   const mountedRef = useRef(true);
   const scheduledScrollFrameRef = useRef<number | null>(null);
@@ -516,11 +518,18 @@ function ChatWindow({
     if (recipientOptionsLoaded) return recipientOptions;
     if (recipientOptionsPromiseRef.current) return recipientOptionsPromiseRef.current;
 
+    const requestTeamId = teamId;
+    const requestId = recipientOptionsRequestIdRef.current + 1;
+    recipientOptionsRequestIdRef.current = requestId;
     setRecipientOptionsLoading(true);
     setRecipientOptionsError(null);
-    const request = loadChatRecipientOptions(teamId)
+    const request = loadChatRecipientOptions(requestTeamId)
       .then((options) => {
-        if (mountedRef.current) {
+        if (
+          mountedRef.current
+          && currentTeamIdRef.current === requestTeamId
+          && recipientOptionsRequestIdRef.current === requestId
+        ) {
           setRecipientOptions(options);
           setRecipientOptionsLoaded(true);
         }
@@ -528,15 +537,25 @@ function ChatWindow({
       })
       .catch((loadError: any) => {
         const message = loadError?.message || 'Unable to load recipient options.';
-        if (mountedRef.current) {
+        if (
+          mountedRef.current
+          && currentTeamIdRef.current === requestTeamId
+          && recipientOptionsRequestIdRef.current === requestId
+        ) {
           setRecipientOptionsLoaded(false);
           setRecipientOptionsError(message);
         }
         throw loadError;
       })
       .finally(() => {
-        recipientOptionsPromiseRef.current = null;
-        if (mountedRef.current) {
+        if (recipientOptionsPromiseRef.current === request) {
+          recipientOptionsPromiseRef.current = null;
+        }
+        if (
+          mountedRef.current
+          && currentTeamIdRef.current === requestTeamId
+          && recipientOptionsRequestIdRef.current === requestId
+        ) {
           setRecipientOptionsLoading(false);
         }
       });
@@ -668,6 +687,10 @@ function ChatWindow({
   }, [clearScheduledScrollTimeouts, maybeScrollToLatest]);
 
   useEffect(() => {
+    currentTeamIdRef.current = teamId;
+  }, [teamId]);
+
+  useEffect(() => {
     let cancelled = false;
 
     async function loadContext() {
@@ -679,6 +702,7 @@ function ChatWindow({
       setOlderMessages([]);
       setLiveMessages([]);
       recipientOptionsPromiseRef.current = null;
+      recipientOptionsRequestIdRef.current += 1;
       setRecipientOptions([]);
       setRecipientOptionsLoading(false);
       setRecipientOptionsLoaded(false);

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -420,6 +420,9 @@ function ChatWindow({
   const [conversations, setConversations] = useState<ChatConversation[]>([]);
   const [selectedConversationId, setSelectedConversationId] = useState(DEFAULT_TEAM_CONVERSATION_ID);
   const [recipientOptions, setRecipientOptions] = useState<ChatRecipientOption[]>([]);
+  const [recipientOptionsLoading, setRecipientOptionsLoading] = useState(false);
+  const [recipientOptionsLoaded, setRecipientOptionsLoaded] = useState(false);
+  const [recipientOptionsError, setRecipientOptionsError] = useState<string | null>(null);
   const [selectedRecipientTarget, setSelectedRecipientTarget] = useState<ChatTargetType>('full_team');
   const [selectedRecipientIds, setSelectedRecipientIds] = useState<string[]>([]);
   const [liveMessages, setLiveMessages] = useState<ChatMessage[]>([]);
@@ -479,6 +482,7 @@ function ChatWindow({
   const initialSnapshotLoadedRef = useRef(false);
   const pendingScrollRef = useRef(false);
   const stickToLatestRef = useRef(true);
+  const recipientOptionsPromiseRef = useRef<Promise<ChatRecipientOption[]> | null>(null);
   const programmaticScrollRef = useRef(false);
   const mountedRef = useRef(true);
   const scheduledScrollFrameRef = useRef<number | null>(null);
@@ -506,6 +510,39 @@ function ChatWindow({
   const audienceSummary = useMemo(() => getAudienceSummaryText(audienceMetadata, recipientOptions), [audienceMetadata, recipientOptions]);
   const mediaEntries = useMemo(() => collectThreadMedia(messages), [messages]);
   const teamName = team?.name || inboxTeam?.name || 'Team chat';
+
+  const ensureRecipientOptionsLoaded = useCallback(async () => {
+    if (!canModerate) return [] as ChatRecipientOption[];
+    if (recipientOptionsLoaded) return recipientOptions;
+    if (recipientOptionsPromiseRef.current) return recipientOptionsPromiseRef.current;
+
+    setRecipientOptionsLoading(true);
+    setRecipientOptionsError(null);
+    const request = loadChatRecipientOptions(teamId)
+      .then((options) => {
+        if (mountedRef.current) {
+          setRecipientOptions(options);
+          setRecipientOptionsLoaded(true);
+        }
+        return options;
+      })
+      .catch((loadError: any) => {
+        const message = loadError?.message || 'Unable to load recipient options.';
+        if (mountedRef.current) {
+          setRecipientOptionsLoaded(false);
+          setRecipientOptionsError(message);
+        }
+        throw loadError;
+      })
+      .finally(() => {
+        recipientOptionsPromiseRef.current = null;
+        if (mountedRef.current) {
+          setRecipientOptionsLoading(false);
+        }
+      });
+    recipientOptionsPromiseRef.current = request;
+    return request;
+  }, [canModerate, recipientOptions, recipientOptionsLoaded, teamId]);
 
   const setVoiceDraftTranscript = useCallback((transcript: string) => {
     const normalizedTranscript = String(transcript || '').trim();
@@ -641,6 +678,11 @@ function ChatWindow({
       setSelectedConversationId(preferredConversationId || DEFAULT_TEAM_CONVERSATION_ID);
       setOlderMessages([]);
       setLiveMessages([]);
+      recipientOptionsPromiseRef.current = null;
+      setRecipientOptions([]);
+      setRecipientOptionsLoading(false);
+      setRecipientOptionsLoaded(false);
+      setRecipientOptionsError(null);
       initialSnapshotLoadedRef.current = false;
       pendingScrollRef.current = true;
       stickToLatestRef.current = true;
@@ -664,11 +706,8 @@ function ChatWindow({
           }
           return DEFAULT_TEAM_CONVERSATION_ID;
         });
-        if (context.canModerate) {
-          const options = await loadChatRecipientOptions(teamId);
-          if (!cancelled) setRecipientOptions(options);
-        } else {
-          setRecipientOptions([]);
+        if (!context.canModerate) {
+          setRecipientOptionsLoaded(true);
         }
       } catch (loadError: any) {
         if (!cancelled) {
@@ -1101,6 +1140,7 @@ function ChatWindow({
     setEmailStatus(null);
     setEmailHistoryStatus(null);
     setSelectedEmailDraftId('');
+    void ensureRecipientOptionsLoaded().catch(() => undefined);
     void reloadEmailDrafts();
     void reloadEmailTemplates();
     void reloadSentEmailHistory();
@@ -1551,7 +1591,10 @@ function ChatWindow({
         onAttach={() => setShowAttachSheet(true)}
         onRemoveFile={removeFile}
         onVoice={toggleVoiceCapture}
-        onAudience={() => setShowAudienceSheet(true)}
+        onAudience={() => {
+          setShowAudienceSheet(true);
+          void ensureRecipientOptionsLoaded().catch(() => undefined);
+        }}
         onTeamEmail={openEmailSheet}
         onMention={insertAllPlaysMention}
       />
@@ -1574,8 +1617,13 @@ function ChatWindow({
           selectedTarget={selectedRecipientTarget}
           selectedRecipientIds={selectedRecipientIds}
           recipientOptions={recipientOptions}
+          recipientOptionsLoading={recipientOptionsLoading}
+          recipientOptionsError={recipientOptionsError}
           onTargetChange={handleAudienceTargetChange}
           onRecipientsChange={setSelectedRecipientIds}
+          onRetryRecipientOptions={() => {
+            void ensureRecipientOptionsLoaded().catch(() => undefined);
+          }}
           onClose={() => setShowAudienceSheet(false)}
         />
       ) : null}
@@ -1613,6 +1661,8 @@ function ChatWindow({
           savingTemplate={emailSavingTemplate}
           loadingHistory={emailLoadingHistory}
           loadingTemplates={emailLoadingTemplates}
+          recipientOptionsLoading={recipientOptionsLoading}
+          recipientOptionsError={recipientOptionsError}
           status={emailStatus}
           historyStatus={emailHistoryStatus}
           sentEmails={sentEmails}
@@ -1629,6 +1679,9 @@ function ChatWindow({
           onRefreshDrafts={reloadEmailDrafts}
           onRefreshHistory={reloadSentEmailHistory}
           onRefreshTemplates={reloadEmailTemplates}
+          onRetryRecipientOptions={() => {
+            void ensureRecipientOptionsLoaded().catch(() => undefined);
+          }}
           onStatusClose={() => setEmailStatus(null)}
           onHistoryStatusClose={() => setEmailHistoryStatus(null)}
           onClose={() => setShowEmailSheet(false)}
@@ -1717,6 +1770,8 @@ function TeamEmailSheet({
   savingTemplate,
   loadingHistory,
   loadingTemplates,
+  recipientOptionsLoading,
+  recipientOptionsError,
   status,
   historyStatus,
   sentEmails,
@@ -1733,6 +1788,7 @@ function TeamEmailSheet({
   onRefreshDrafts,
   onRefreshHistory,
   onRefreshTemplates,
+  onRetryRecipientOptions,
   onStatusClose,
   onHistoryStatusClose,
   onClose
@@ -1749,6 +1805,8 @@ function TeamEmailSheet({
   savingTemplate: boolean;
   loadingHistory: boolean;
   loadingTemplates: boolean;
+  recipientOptionsLoading: boolean;
+  recipientOptionsError: string | null;
   status: ChatStatus | null;
   historyStatus: ChatStatus | null;
   sentEmails: SentTeamEmail[];
@@ -1765,6 +1823,7 @@ function TeamEmailSheet({
   onRefreshDrafts: () => void;
   onRefreshHistory: () => void;
   onRefreshTemplates: () => void;
+  onRetryRecipientOptions: () => void;
   onStatusClose: () => void;
   onHistoryStatusClose: () => void;
   onClose: () => void;
@@ -1773,7 +1832,12 @@ function TeamEmailSheet({
   const draftAudienceSupported = audienceMetadata.targetType === 'individuals';
   const missingSelectedRecipients = audienceMetadata.targetType === 'individuals' && audienceMetadata.recipientIds.length === 0;
   const canSendEmail = Boolean(subject.trim() && body.trim()) && !missingSelectedRecipients && !sending;
-  const canSaveDraft = draftAudienceSupported && Boolean(subject.trim() && body.trim()) && !missingSelectedRecipients && !savingDraft;
+  const canSaveDraft = draftAudienceSupported
+    && !recipientOptionsLoading
+    && !recipientOptionsError
+    && Boolean(subject.trim() && body.trim())
+    && !missingSelectedRecipients
+    && !savingDraft;
   const canSaveTemplate = Boolean(templateName.trim() && subject.trim() && body.trim()) && !savingTemplate;
 
   useEffect(() => {
@@ -1792,6 +1856,19 @@ function TeamEmailSheet({
         <div className="rounded-xl border border-gray-200 bg-gray-50 px-3 py-2 text-sm font-bold text-gray-700">
           Audience: {audienceSummary}
         </div>
+        {recipientOptionsLoading ? (
+          <div className="rounded-xl border border-gray-200 bg-white px-3 py-2 text-sm font-bold text-gray-500">
+            <Loader2 className="mr-2 inline h-4 w-4 animate-spin" aria-hidden="true" />
+            Loading recipient options...
+          </div>
+        ) : recipientOptionsError ? (
+          <div className="rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-bold text-rose-700">
+            <div>{recipientOptionsError}</div>
+            <button type="button" className="ghost-button mt-2 !h-8 !min-h-8 !px-2 text-xs" onClick={onRetryRecipientOptions}>
+              Retry recipient load
+            </button>
+          </div>
+        ) : null}
         <div className="space-y-3 rounded-2xl border border-gray-200 bg-gray-50 p-3">
           <div className="flex items-start justify-between gap-3">
             <div>
@@ -2521,15 +2598,21 @@ function AudienceSheet({
   selectedTarget,
   selectedRecipientIds,
   recipientOptions,
+  recipientOptionsLoading,
+  recipientOptionsError,
   onTargetChange,
   onRecipientsChange,
+  onRetryRecipientOptions,
   onClose
 }: {
   selectedTarget: ChatTargetType;
   selectedRecipientIds: string[];
   recipientOptions: ChatRecipientOption[];
+  recipientOptionsLoading: boolean;
+  recipientOptionsError: string | null;
   onTargetChange: (target: ChatTargetType) => void;
   onRecipientsChange: (ids: string[]) => void;
+  onRetryRecipientOptions: () => void;
   onClose: () => void;
 }) {
   const toggleRecipient = (recipientId: string) => {
@@ -2569,7 +2652,19 @@ function AudienceSheet({
       {selectedTarget === 'individuals' ? (
         <>
           <div className="mt-4 max-h-72 overflow-y-auto rounded-xl border border-gray-200">
-            {recipientOptions.length ? recipientOptions.map((option) => (
+            {recipientOptionsLoading ? (
+              <div className="p-3 text-sm font-semibold text-gray-500">
+                <Loader2 className="mr-2 inline h-4 w-4 animate-spin" aria-hidden="true" />
+                Loading recipient options...
+              </div>
+            ) : recipientOptionsError ? (
+              <div className="p-3 text-sm font-semibold text-rose-700">
+                <div>{recipientOptionsError}</div>
+                <button type="button" className="ghost-button mt-3 !h-8 !min-h-8 !px-2 text-xs" onClick={onRetryRecipientOptions}>
+                  Retry recipient load
+                </button>
+              </div>
+            ) : recipientOptions.length ? recipientOptions.map((option) => (
               <label key={option.id} className="flex cursor-pointer items-center gap-3 border-b border-gray-100 px-3 py-2 last:border-b-0">
                 <input
                   type="checkbox"
@@ -2586,7 +2681,7 @@ function AudienceSheet({
               <div className="p-3 text-sm font-semibold text-gray-500">No roster or community members are available yet.</div>
             )}
           </div>
-          {needsSelectedRecipient ? (
+          {needsSelectedRecipient && !recipientOptionsLoading && !recipientOptionsError ? (
             <div className="mt-3 rounded-xl border border-rose-200 bg-rose-50 px-3 py-2 text-sm font-bold text-rose-700">
               Choose at least one selected member, or switch back to Full team.
             </div>
@@ -2594,7 +2689,7 @@ function AudienceSheet({
         </>
       ) : null}
 
-      <button type="button" className="primary-button mt-4 w-full" onClick={onClose} disabled={needsSelectedRecipient}>Done</button>
+      <button type="button" className="primary-button mt-4 w-full" onClick={onClose} disabled={needsSelectedRecipient || recipientOptionsLoading}>Done</button>
     </Sheet>
   );
 }

--- a/tests/unit/app-chat-email-templates-integration.test.tsx
+++ b/tests/unit/app-chat-email-templates-integration.test.tsx
@@ -140,7 +140,7 @@ describe('Messages team email templates', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: /audience:/i }));
     fireEvent.click(screen.getByRole('button', { name: /selected members/i }));
-    fireEvent.click(screen.getAllByRole('checkbox')[0]);
+    fireEvent.click((await screen.findAllByRole('checkbox'))[0]);
     fireEvent.click(screen.getByRole('button', { name: 'Done' }));
 
     fireEvent.click(screen.getByRole('button', { name: 'Open Team Email' }));
@@ -173,7 +173,7 @@ describe('Messages team email templates', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: /audience:/i }));
     fireEvent.click(screen.getByRole('button', { name: /selected members/i }));
-    fireEvent.click(screen.getAllByRole('checkbox')[0]);
+    fireEvent.click((await screen.findAllByRole('checkbox'))[0]);
     fireEvent.click(screen.getByRole('button', { name: 'Done' }));
     fireEvent.click(screen.getByRole('button', { name: 'Open Team Email' }));
 
@@ -208,7 +208,7 @@ describe('Messages team email templates', () => {
 
     fireEvent.click(await screen.findByRole('button', { name: /audience:/i }));
     fireEvent.click(screen.getByRole('button', { name: /selected members/i }));
-    fireEvent.click(screen.getAllByRole('checkbox')[0]);
+    fireEvent.click((await screen.findAllByRole('checkbox'))[0]);
     fireEvent.click(screen.getByRole('button', { name: 'Done' }));
     fireEvent.click(screen.getByRole('button', { name: 'Open Team Email' }));
     await screen.findByRole('dialog', { name: 'Team Email' });

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -205,6 +205,16 @@ async function flush() {
     });
 }
 
+function createDeferred() {
+    let resolve;
+    let reject;
+    const promise = new Promise((nextResolve, nextReject) => {
+        resolve = nextResolve;
+        reject = nextReject;
+    });
+    return { promise, resolve, reject };
+}
+
 function buttonByText(container, text) {
     const button = Array.from(container.querySelectorAll('button')).find((candidate) => candidate.textContent.trim() === text || candidate.getAttribute('aria-label') === text);
     if (!button) {
@@ -973,6 +983,56 @@ describe('React app messages integration', () => {
         expect(scrollIntoView).not.toHaveBeenCalled();
         expect(container.textContent).toContain('Latest');
         expect(scroller.scrollTop).toBe(0);
+    });
+
+    it('renders the moderator thread before lazy recipient options finish loading', async () => {
+        const deferredRecipients = createDeferred();
+        chatMocks.loadChatRecipientOptions.mockImplementationOnce(() => deferredRecipients.promise);
+
+        const { container } = await renderMessages('/messages/team-1');
+
+        expect(container.textContent).toContain('Bring both jerseys.');
+        expect(chatMocks.loadChatRecipientOptions).not.toHaveBeenCalled();
+
+        await click(container, 'Team Email');
+
+        expect(chatMocks.loadChatRecipientOptions).toHaveBeenCalledTimes(1);
+        expect(container.textContent).toContain('Loading recipient options...');
+        expect(container.textContent).toContain('Bring both jerseys.');
+
+        await act(async () => {
+            deferredRecipients.resolve([
+                { id: 'user:coach-1', name: 'Coach Jamie', detail: 'Staff' },
+                { id: 'player:player-1', name: 'Pat', detail: '#9' }
+            ]);
+        });
+        await flush();
+
+        expect(container.textContent).not.toContain('Loading recipient options...');
+        await click(container, 'Close Team Email');
+        await click(container, 'Audience: Full team');
+        await click(container, 'Selected members');
+        expect(container.textContent).toContain('Coach Jamie');
+    });
+
+    it('loads recipient options once on first moderator tool open and reuses the cache', async () => {
+        const { container } = await renderMessages('/messages/team-1');
+
+        expect(chatMocks.loadChatRecipientOptions).not.toHaveBeenCalled();
+
+        await click(container, 'Team Email');
+        expect(chatMocks.loadChatRecipientOptions).toHaveBeenCalledTimes(1);
+
+        await click(container, 'Close Team Email');
+        await click(container, 'Audience: Full team');
+        await click(container, 'Selected members');
+
+        expect(chatMocks.loadChatRecipientOptions).toHaveBeenCalledTimes(1);
+        expect(container.textContent).toContain('Coach Jamie');
+
+        await click(container, 'Done');
+        await click(container, 'Team Email');
+        expect(chatMocks.loadChatRecipientOptions).toHaveBeenCalledTimes(1);
     });
 
     it('keeps staff targeting contextual and sends the selected audience metadata', async () => {

--- a/tests/unit/app-chat-messages-integration.test.jsx
+++ b/tests/unit/app-chat-messages-integration.test.jsx
@@ -1035,6 +1035,90 @@ describe('React app messages integration', () => {
         expect(chatMocks.loadChatRecipientOptions).toHaveBeenCalledTimes(1);
     });
 
+    it('ignores stale recipient option loads after switching teams', async () => {
+        layoutMocks.isDesktopWeb = true;
+        const deferredRecipients = createDeferred();
+        chatMocks.loadChatInbox.mockResolvedValueOnce({
+            teams: [
+                {
+                    id: 'team-1',
+                    name: 'Bears',
+                    sport: 'Basketball',
+                    role: 'Admin',
+                    canModerate: true,
+                    unreadCount: 2,
+                    lastMessage: chatMessage({ id: 'last-1', text: 'Practice packet posted.' })
+                },
+                {
+                    id: 'team-2',
+                    name: 'Thunder',
+                    sport: 'Soccer',
+                    role: 'Admin',
+                    canModerate: true,
+                    unreadCount: 0,
+                    lastMessage: chatMessage({ id: 'last-2', senderName: 'Coach Taylor', text: 'Travel roster posted.' })
+                }
+            ]
+        });
+        chatMocks.loadChatTeamContext.mockImplementation(async (requestedTeamId) => ({
+            team: {
+                id: requestedTeamId,
+                name: requestedTeamId === 'team-1' ? 'Bears' : 'Thunder',
+                sport: requestedTeamId === 'team-1' ? 'Basketball' : 'Soccer'
+            },
+            profile: { fullName: 'Pat Parent', photoUrl: '' },
+            canModerate: true
+        }));
+        chatMocks.loadChatConversations.mockImplementation(async (requestedTeamId) => ([
+            {
+                id: 'team',
+                type: 'team',
+                name: requestedTeamId === 'team-1' ? 'Bears Team Chat' : 'Thunder Team Chat',
+                participantIds: [],
+                participantRoles: ['team']
+            }
+        ]));
+        chatMocks.loadChatRecipientOptions
+            .mockImplementationOnce(() => deferredRecipients.promise)
+            .mockResolvedValueOnce([
+                { id: 'user:coach-2', name: 'Coach Taylor', detail: 'Staff' }
+            ]);
+
+        const { container } = await renderMessages('/messages');
+
+        await click(container, 'Team Email');
+        expect(chatMocks.loadChatRecipientOptions).toHaveBeenCalledTimes(1);
+        expect(chatMocks.loadChatRecipientOptions).toHaveBeenLastCalledWith('team-1');
+
+        const thunderLink = container.querySelector('a[href="/messages/team-2"]');
+        await act(async () => {
+            thunderLink.dispatchEvent(new MouseEvent('click', { bubbles: true, button: 0 }));
+        });
+        await flush();
+
+        await act(async () => {
+            deferredRecipients.resolve([
+                { id: 'user:coach-1', name: 'Coach Jamie', detail: 'Staff' }
+            ]);
+        });
+        await flush();
+
+        await click(container, 'Close Team Email');
+        await click(container, 'Team Email');
+
+        expect(chatMocks.loadChatRecipientOptions).toHaveBeenCalledTimes(2);
+        expect(chatMocks.loadChatRecipientOptions).toHaveBeenLastCalledWith('team-2');
+        expect(container.textContent).toContain('Thunder Team Chat');
+
+        await click(container, 'Close Team Email');
+        await click(container, 'Audience: Full team');
+        await click(container, 'Selected members');
+
+        const recipientLabels = Array.from(container.querySelectorAll('label')).map((label) => label.textContent || '');
+        expect(recipientLabels.some((label) => label.includes('Coach Taylor'))).toBe(true);
+        expect(recipientLabels.some((label) => label.includes('Coach Jamie'))).toBe(false);
+    });
+
     it('keeps staff targeting contextual and sends the selected audience metadata', async () => {
         const { container } = await renderMessages('/messages/team-1');
 


### PR DESCRIPTION
Closes #1751

## What changed
- Removed eager moderator recipient hydration from `Messages` initial chat context so the thread and composer render as soon as team context and conversations are ready.
- Added on-demand recipient option loading when moderators first open Audience or Team Email, with in-sheet loading/error UI and per-chat-session caching.
- Preserved selected-recipient email metadata when recipient options have not hydrated yet, and added focused integration coverage for immediate thread render plus one-time recipient fetch reuse.

## Root Cause
`Messages` awaited `loadChatRecipientOptions(teamId)` inside the initial `loadContext()` path for moderators. That secondary recipient workflow fans out through roster and guardian/profile lookups, so large-team recipient hydration blocked first paint of the primary chat thread.

## Prevention / Learning
Keep first-paint chat data separate from moderator-only secondary workflows. Recipient pickers, admin sheets, and email tools should lazy-load their own data, show local loading/error UI, and cache successful results for the active session instead of coupling that work to route boot.

## Regression Tests
- `npx vitest run tests/unit/app-chat-messages-integration.test.jsx tests/unit/app-chat-service-recipients.test.js --reporter=verbose`
- `tests/unit/app-chat-messages-integration.test.jsx` now verifies moderator chat renders before deferred recipient hydration resolves.
- `tests/unit/app-chat-messages-integration.test.jsx` now verifies recipient options load once on first Audience or Team Email open and are reused afterward.