### PR TITLE
Preserve help context through page reference

### DIFF
--- a/help-page-reference.html
+++ b/help-page-reference.html
@@ -6,10 +6,11 @@
   <title>Help - File-by-File Page Reference</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <script type="module" src="/js/telemetry.js?v=1"></script>
+  <script type="module" src="./js/help-context.js?v=1"></script>
 </head>
 <body class="bg-slate-50 text-slate-900 min-h-screen">
   <main class="max-w-7xl mx-auto px-4 py-8">
-    <a href="help.html" class="text-sm text-blue-700 hover:text-blue-900">← Back to Help Portal</a>
+    <a href="help.html" data-help-back-link class="text-sm text-blue-700 hover:text-blue-900">← Back to Help Portal</a>
     <h1 class="mt-2 text-3xl font-extrabold">File-by-File Page Reference</h1>
     <p class="mt-2 text-slate-600">Each page, what it does, and which role should use it.</p>
 

--- a/help.html
+++ b/help.html
@@ -151,7 +151,7 @@
           </div>
           <div class="mt-3 flex flex-wrap items-center justify-between gap-3">
             <p id="help-summary" class="text-sm text-slate-600"></p>
-            <a href="help-page-reference.html" class="text-sm font-semibold text-primary-700 hover:text-primary-800">View file-by-file page reference</a>
+            <a id="help-page-reference-link" href="help-page-reference.html" class="text-sm font-semibold text-primary-700 hover:text-primary-800">View file-by-file page reference</a>
           </div>
         </section>
 
@@ -451,6 +451,7 @@
         const grid = document.getElementById('help-grid');
         const empty = document.getElementById('help-empty');
         const summary = document.getElementById('help-summary');
+        const pageReferenceLink = document.getElementById('help-page-reference-link');
 
         function escapeHtml(v){return String(v).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');}
 
@@ -485,6 +486,14 @@
             return query ? `${file}?${query}` : file;
         }
 
+        function syncPageReferenceLink() {
+            if (!pageReferenceLink) {
+                return;
+            }
+
+            pageReferenceLink.href = buildWorkflowHref('help-page-reference.html');
+        }
+
         function render() {
             const q = (searchInput.value || '').toLowerCase().trim();
             const role = roleSelect.value;
@@ -516,6 +525,7 @@
         }
 
         applyRoleFromUrl();
+        syncPageReferenceLink();
         searchInput.addEventListener('input', render);
         roleSelect.addEventListener('change', render);
         render();

--- a/tests/unit/help-navigation-wiring.test.js
+++ b/tests/unit/help-navigation-wiring.test.js
@@ -29,7 +29,8 @@ describe('help navigation wiring', () => {
         const helpHtml = readRepoFile('help.html');
         expect(helpHtml).toContain("new URLSearchParams(window.location.search).get('role')");
         expect(helpHtml).toContain('option.value.toLowerCase() === requestedRoleKey');
-        expect(helpHtml).toMatch(/applyRoleFromUrl\(\);\s*searchInput\.addEventListener/);
+        expect(helpHtml).toContain("pageReferenceLink.href = buildWorkflowHref('help-page-reference.html');");
+        expect(helpHtml).toMatch(/applyRoleFromUrl\(\);\s*syncPageReferenceLink\(\);\s*searchInput\.addEventListener/);
     });
 
     it('renders multi-page help portal links', () => {

--- a/tests/unit/help-page-reference-integrity.test.js
+++ b/tests/unit/help-page-reference-integrity.test.js
@@ -17,12 +17,16 @@ function extractReferenceFiles(html) {
 describe('help page reference integrity', () => {
     it('keeps the file-by-file page reference discoverable from help center', () => {
         const helpHtml = readRepoFile('help.html');
-        expect(helpHtml).toContain('href="help-page-reference.html"');
+        expect(helpHtml).toContain('id="help-page-reference-link"');
+        expect(helpHtml).toContain("pageReferenceLink.href = buildWorkflowHref('help-page-reference.html');");
         expect(helpHtml).toContain('View file-by-file page reference');
     });
 
     it('lists only shipped html files in help-page-reference.html', () => {
         const referenceHtml = readRepoFile('help-page-reference.html');
+        expect(referenceHtml).toContain('data-help-back-link');
+        expect(referenceHtml).toContain('./js/help-context.js?v=1');
+
         const referencedFiles = extractReferenceFiles(referenceHtml);
 
         expect(referencedFiles).toContain('edit-schedule.html');

--- a/tests/unit/help-team-context-links.test.js
+++ b/tests/unit/help-team-context-links.test.js
@@ -30,6 +30,10 @@ function readWorkflowLinks(document) {
     return Array.from(document.querySelectorAll('#help-grid article a')).map((link) => new URL(link.href));
 }
 
+function readPageReferenceLink(document) {
+    return new URL(document.getElementById('help-page-reference-link').href);
+}
+
 function bootStaticPage(relativePath, search = '') {
     const html = readRepoFile(relativePath);
     const dom = new JSDOM(html, {
@@ -57,6 +61,16 @@ describe('help team-context deep links', () => {
             expect(link.searchParams.get('teamId')).toBe('TEAM123');
             expect(link.searchParams.get('role')).toBe('parent');
         });
+    });
+
+    it('preserves team context on the page-reference link', () => {
+        const document = bootHelpPage('?context=team&teamId=TEAM123&role=coach');
+
+        const link = readPageReferenceLink(document);
+        expect(link.pathname).toBe('/help-page-reference.html');
+        expect(link.searchParams.get('context')).toBe('team');
+        expect(link.searchParams.get('teamId')).toBe('TEAM123');
+        expect(link.searchParams.get('role')).toBe('coach');
     });
 
     it('restores workflow cards with original team context after clearing a zero-match search', () => {
@@ -100,10 +114,22 @@ describe('help team-context deep links', () => {
         expect(link.searchParams.get('role')).toBe('coach');
     });
 
+    it('preserves team context on the page-reference back link', () => {
+        const { document } = bootStaticPage('help-page-reference.html', '?context=team&teamId=TEAM123&role=coach');
+
+        preserveHelpBackLinkContext(document, '?context=team&teamId=TEAM123&role=coach');
+
+        const link = new URL(document.querySelector('[data-help-back-link]').href);
+        expect(link.pathname).toBe('/help.html');
+        expect(link.searchParams.get('context')).toBe('team');
+        expect(link.searchParams.get('teamId')).toBe('TEAM123');
+        expect(link.searchParams.get('role')).toBe('coach');
+    });
+
     it('wires help context preservation into every workflow back link', () => {
         const repoRoot = process.cwd();
         const htmlPages = readdirSync(repoRoot)
-            .filter((file) => /^workflow-.*\.html$/.test(file) || file === 'help-team-operations.html')
+            .filter((file) => /^workflow-.*\.html$/.test(file) || file === 'help-team-operations.html' || file === 'help-page-reference.html')
             .sort();
 
         expect(htmlPages.length).toBeGreaterThan(0);


### PR DESCRIPTION
Closes #1923

## What changed
- updated `help.html` to route the File-by-File Page Reference link through the existing team-context URL builder so `context`, `teamId`, and `role` survive when opening the reference page
- updated `help-page-reference.html` to use the shared `help-context.js` back-link preservation pattern with `data-help-back-link`
- added focused regression coverage for the page-reference entry link and back-link round trip

## Root Cause
`help.html` preserved team-scoped help context for workflow cards, but the page-reference link bypassed that helper and used a plain static href. `help-page-reference.html` also used a plain back link without the shared help-context wiring, so visiting the reference page dropped the original query params and broke subsequent team-scoped workflow deep links.

## Prevention / Learning
When a help surface participates in team-scoped navigation, every outbound and return link must use the shared context-preservation path instead of hardcoded `help.html` or workflow hrefs. Future help/navigation additions should extend the existing helper pattern and add a regression test for the full round trip, not just the first hop.

## Regression Tests
- `npx vitest run tests/unit/help-team-context-links.test.js tests/unit/help-page-reference-integrity.test.js --reporter=verbose`
- added assertions that the page-reference entry link preserves `context`, `teamId`, and `role`
- added assertions that `help-page-reference.html` loads `help-context.js` and preserves the back-link query string

## Recurrence Risk
Low. The fix reuses the existing shared help-context mechanism and adds targeted tests for the exact navigation path that was previously uncovered.