### PR TITLE
Add read-only app stat config team detail view

### DIFF
--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -26,7 +26,7 @@ import { collection, db, getDocs, query, where } from '../../../../js/firebase.j
 import { describeScheduleReminderWindow, normalizeScheduleNotificationSettings } from '../../../../js/schedule-notifications.js';
 import { calculateSeasonRecord, listSeasonLabels } from '../../../../js/season-record.js';
 import { computeNativeStandings } from '../../../../js/native-standings.js';
-import { buildPlayerLeaderboardSnapshot, selectAnalyticsConfig } from '../../../../js/stat-leaderboards.js';
+import { buildPlayerLeaderboardSnapshot, normalizeStatTrackerConfig, selectAnalyticsConfig } from '../../../../js/stat-leaderboards.js';
 import { getVisiblePlayerTrackingSummary } from '../../../../js/player-tracking-summary.js';
 import { hasFullTeamAccess } from '../../../../js/team-access.js';
 import { buildTeamStaffPermissionsViewModel } from '../../../../js/team-staff-permissions.js';
@@ -79,6 +79,25 @@ export type TeamDetailEvent = {
   homeScore: number | null;
   awayScore: number | null;
   isCancelled: boolean;
+  statTrackerConfigId: string;
+  statTrackerConfigLabel: string;
+  statTrackerConfigBaseType: string;
+  statTrackerConfigExists: boolean;
+  statTrackerConfigIsBasketball: boolean;
+};
+
+export type TeamDetailStatTrackerConfig = {
+  id: string;
+  name: string;
+  baseType: string;
+  isBasketball: boolean;
+  columnCount: number;
+  columnNames: string[];
+  assignedUpcomingGames: Array<{
+    gameId: string;
+    title: string;
+    date: Date;
+  }>;
 };
 
 export type TeamDetailLeaderboard = {
@@ -199,6 +218,7 @@ export type TeamDetailModel = {
   leaderboards: TeamDetailLeaderboard[];
   trackingSummaries: TeamDetailTrackingSummary[];
   sponsors: TeamDetailSponsor[];
+  statTrackerConfigs: TeamDetailStatTrackerConfig[];
   canManageTeam: boolean;
   staffPermissions: TeamStaffPermissionsSummary | null;
   counts: {
@@ -798,7 +818,8 @@ export function buildTeamDetailModel({
 }): TeamDetailModel {
   const normalizedPlayers = normalizePlayers(players, linkedPlayerIds);
   const normalizedInactivePlayers = normalizePlayers(players, linkedPlayerIds, { inactiveOnly: true });
-  const normalizedEvents = normalizeEvents(games);
+  const normalizedStatTrackerConfigs = buildTeamStatTrackerConfigs(configs, games);
+  const normalizedEvents = normalizeEvents(games, normalizedStatTrackerConfigs.byId);
   const seasonLabels = listSeasonLabels(games);
   const currentYearLabel = String(new Date().getFullYear());
   const seasonLabel = seasonLabels.includes(currentYearLabel) ? currentYearLabel : (seasonLabels[0] || currentYearLabel);
@@ -849,6 +870,7 @@ export function buildTeamDetailModel({
     leaderboards,
     trackingSummaries,
     sponsors: sponsors.slice(0, 4),
+    statTrackerConfigs: normalizedStatTrackerConfigs.items,
     canManageTeam,
     staffPermissions,
     counts: {
@@ -1037,12 +1059,98 @@ function getSelectedPermissionIds(team: Record<string, any>, kind: string) {
     .filter(Boolean));
 }
 
-function normalizeEvents(games: any[]) {
+function buildTeamStatTrackerConfigs(configs: any[], games: any[]) {
+  const byId = new Map<string, TeamDetailStatTrackerConfig>();
+
+  const items = (Array.isArray(configs) ? configs : [])
+    .map((config) => normalizeTeamStatTrackerConfig(config))
+    .filter((config) => config.id)
+    .sort((a, b) => a.name.localeCompare(b.name));
+
+  items.forEach((config) => {
+    byId.set(config.id, config);
+  });
+
+  (Array.isArray(games) ? games : []).forEach((game) => {
+    const configId = cleanString(game?.statTrackerConfigId);
+    if (!configId || !isUpcomingAssignedGame(game)) return;
+    const config = byId.get(configId);
+    if (!config) return;
+    config.assignedUpcomingGames.push({
+      gameId: cleanString(game?.id || game?.gameId),
+      title: cleanString(game?.title) || `vs. ${cleanString(game?.opponent) || 'TBD'}`,
+      date: toDate(game?.date)
+    });
+  });
+
+  items.forEach((config) => {
+    config.assignedUpcomingGames.sort((a, b) => a.date.getTime() - b.date.getTime());
+  });
+
+  return { items, byId };
+}
+
+function normalizeTeamStatTrackerConfig(config: any): TeamDetailStatTrackerConfig {
+  const rawColumns = extractStatColumnNames(config?.columns);
+  const normalized = normalizeStatTrackerConfig({
+    ...config,
+    columns: rawColumns,
+    statDefinitions: Array.isArray(config?.statDefinitions) ? config.statDefinitions : []
+  });
+  const columnNames = dedupeStrings(
+    normalized.columns.length
+      ? normalized.columns
+      : (normalized.statDefinitions || [])
+        .filter((definition: any) => !definition?.formula)
+        .map((definition: any) => cleanString(definition?.acronym || definition?.label || definition?.id))
+  );
+  const baseType = cleanString(config?.baseType) || 'Custom';
+
+  return {
+    id: cleanString(config?.id || config?.configId),
+    name: cleanString(config?.name) || `${baseType} config`,
+    baseType,
+    isBasketball: baseType.toLowerCase() === 'basketball',
+    columnCount: columnNames.length,
+    columnNames,
+    assignedUpcomingGames: []
+  };
+}
+
+function extractStatColumnNames(columns: any) {
+  return dedupeStrings((Array.isArray(columns) ? columns : [])
+    .map((column) => {
+      if (typeof column === 'string') return cleanString(column);
+      if (column && typeof column === 'object') {
+        return cleanString(column.acronym || column.key || column.id || column.label || column.name);
+      }
+      return '';
+    }));
+}
+
+function dedupeStrings(values: string[]) {
+  return Array.from(new Set((Array.isArray(values) ? values : []).map((value) => cleanString(value)).filter(Boolean)));
+}
+
+function isUpcomingAssignedGame(game: any) {
+  if (!game || game?.type === 'practice') return false;
+  return !isHistoricalGameStatus(game);
+}
+
+function isHistoricalGameStatus(game: any) {
+  const status = cleanString(game?.status).toLowerCase();
+  const liveStatus = cleanString(game?.liveStatus).toLowerCase();
+  return status === 'completed' || status === 'final' || status === 'cancelled' || liveStatus === 'completed';
+}
+
+function normalizeEvents(games: any[], configById: Map<string, TeamDetailStatTrackerConfig> = new Map()) {
   const now = new Date();
   const events = (Array.isArray(games) ? games : [])
     .map((game) => {
       const date = toDate(game?.date);
       const type = game?.type === 'practice' ? 'practice' : 'game';
+      const statTrackerConfigId = cleanString(game?.statTrackerConfigId);
+      const matchedConfig = statTrackerConfigId ? configById.get(statTrackerConfigId) : null;
       return {
         id: cleanString(game?.id || game?.gameId),
         type,
@@ -1059,7 +1167,14 @@ function normalizeEvents(games: any[]) {
         publicCalendar: game?.publicCalendar === true,
         homeScore: toNullableNumber(game?.homeScore),
         awayScore: toNullableNumber(game?.awayScore),
-        isCancelled: cleanString(game?.status).toLowerCase() === 'cancelled'
+        isCancelled: cleanString(game?.status).toLowerCase() === 'cancelled',
+        statTrackerConfigId,
+        statTrackerConfigLabel: statTrackerConfigId
+          ? (matchedConfig?.name || `Missing config (${statTrackerConfigId})`)
+          : 'No config assigned',
+        statTrackerConfigBaseType: matchedConfig?.baseType || '',
+        statTrackerConfigExists: Boolean(matchedConfig),
+        statTrackerConfigIsBasketball: matchedConfig?.isBasketball === true
       } as TeamDetailEvent;
     })
     .filter((event) => event.id && event.date);

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -1134,7 +1134,8 @@ function dedupeStrings(values: string[]) {
 
 function isUpcomingAssignedGame(game: any) {
   if (!game || game?.type === 'practice') return false;
-  return !isHistoricalGameStatus(game);
+  if (isHistoricalGameStatus(game)) return false;
+  return isInUpcomingWindow(game?.date);
 }
 
 function isHistoricalGameStatus(game: any) {
@@ -1144,7 +1145,6 @@ function isHistoricalGameStatus(game: any) {
 }
 
 function normalizeEvents(games: any[], configById: Map<string, TeamDetailStatTrackerConfig> = new Map()) {
-  const now = new Date();
   const events = (Array.isArray(games) ? games : [])
     .map((game) => {
       const date = toDate(game?.date);
@@ -1181,12 +1181,16 @@ function normalizeEvents(games: any[], configById: Map<string, TeamDetailStatTra
 
   return {
     upcoming: events
-      .filter((event) => !event.isCancelled && event.status.toLowerCase() !== 'completed' && event.date.getTime() >= now.getTime() - 3 * 60 * 60 * 1000)
+      .filter((event) => !event.isCancelled && event.status.toLowerCase() !== 'completed' && isInUpcomingWindow(event.date))
       .sort((a, b) => a.date.getTime() - b.date.getTime()),
     recent: events
-      .filter((event) => event.status.toLowerCase() === 'completed' || (event.homeScore !== null && event.awayScore !== null && event.date.getTime() < now.getTime()))
+      .filter((event) => event.status.toLowerCase() === 'completed' || (event.homeScore !== null && event.awayScore !== null && event.date.getTime() < Date.now()))
       .sort((a, b) => b.date.getTime() - a.date.getTime())
   };
+}
+
+function isInUpcomingWindow(value: any) {
+  return toDate(value).getTime() >= Date.now() - 3 * 60 * 60 * 1000;
 }
 
 function buildStandings(team: Record<string, any>, games: any[]) {

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -103,6 +103,7 @@ const model = {
   leaderboards: [],
   trackingSummaries: [],
   sponsors: [],
+  statTrackerConfigs: [],
   canManageTeam: false,
   staffPermissions: null,
   counts: { games: 0, practices: 0, completedGames: 0 }

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -586,13 +586,14 @@ function InsightsTab({ model, loading, error }: { model: TeamDetailModel; loadin
 }
 
 function MoreTab({ model, auth, staffPermissionsLoading, staffPermissionsError, sponsorsLoading, sponsorsError, onTeamDetailRefresh }: { model: TeamDetailModel; auth: AuthState; staffPermissionsLoading: boolean; staffPermissionsError: string; sponsorsLoading: boolean; sponsorsError: string; onTeamDetailRefresh: () => Promise<void> }) {
+  const statTrackerConfigs = model.statTrackerConfigs || [];
   const orphanedConfigAssignments = model.canManageTeam
     ? model.upcomingEvents.filter((event) => event.type === 'game' && event.statTrackerConfigId && !event.statTrackerConfigExists)
     : [];
 
   return (
     <div className="space-y-4">
-      {model.canManageTeam ? <StatTrackerConfigsCard configs={model.statTrackerConfigs} orphanedAssignments={orphanedConfigAssignments} /> : null}
+      {model.canManageTeam ? <StatTrackerConfigsCard configs={statTrackerConfigs} orphanedAssignments={orphanedConfigAssignments} /> : null}
       {model.canManageTeam && !model.staffPermissions && staffPermissionsLoading ? (
         <section className="app-card p-4">
           <div className="flex items-center gap-3 text-sm font-semibold text-gray-600">
@@ -673,6 +674,8 @@ function MoreTab({ model, auth, staffPermissionsLoading, staffPermissionsError, 
 }
 
 function StatTrackerConfigsCard({ configs, orphanedAssignments }: { configs: TeamDetailModel['statTrackerConfigs']; orphanedAssignments: TeamDetailModel['upcomingEvents'] }) {
+  const safeConfigs = configs || [];
+
   return (
     <section className="app-card p-4">
       <div className="flex items-start justify-between gap-3">
@@ -680,11 +683,11 @@ function StatTrackerConfigsCard({ configs, orphanedAssignments }: { configs: Tea
           <div className="text-sm font-black text-gray-950">Stat tracker configs</div>
           <div className="mt-1 text-xs font-semibold leading-5 text-gray-500">Read-only view of this team&apos;s tracker setups, sport routing, and scheduled game assignments.</div>
         </div>
-        <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-black text-gray-700">{configs.length} config{configs.length === 1 ? '' : 's'}</span>
+        <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-black text-gray-700">{safeConfigs.length} config{safeConfigs.length === 1 ? '' : 's'}</span>
       </div>
 
       <div className="mt-3 space-y-3">
-        {configs.length ? configs.map((config) => (
+        {safeConfigs.length ? safeConfigs.map((config) => (
           <div key={config.id} className="rounded-xl border border-gray-200 bg-gray-50 p-3">
             <div className="flex flex-wrap items-start justify-between gap-2">
               <div>

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -334,7 +334,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
       </section>
 
       {activeTab === 'overview' ? <OverviewTab model={model} /> : null}
-      {activeTab === 'schedule' ? <ScheduleTab model={model} auth={auth} /> : null}
+      {activeTab === 'schedule' ? <ScheduleTab model={model} auth={auth} onOpenStatTrackerConfigs={() => setActiveTab('more')} /> : null}
       {activeTab === 'roster' ? <RosterTab model={model} authUser={auth.user} onRefresh={refreshTeamDetail} rosterInviteLoading={rosterInviteLoading} rosterInviteError={rosterInviteError} rosterInviteSummaries={rosterInviteSummaries} onInviteCreated={refreshRosterInvites} /> : null}
       {activeTab === 'insights' ? <InsightsTab model={model} loading={insightsLoading} error={insightsError} /> : null}
       {activeTab === 'more' ? <MoreTab model={model} auth={auth} staffPermissionsLoading={staffPermissionsLoading} staffPermissionsError={staffPermissionsError} sponsorsLoading={sponsorsLoading} sponsorsError={sponsorsError} onTeamDetailRefresh={refreshTeamDetail} /> : null}
@@ -415,7 +415,7 @@ function OverviewTab({ model }: { model: TeamDetailModel }) {
   );
 }
 
-function ScheduleTab({ model, auth }: { model: TeamDetailModel; auth: AuthState }) {
+function ScheduleTab({ model, auth, onOpenStatTrackerConfigs }: { model: TeamDetailModel; auth: AuthState; onOpenStatTrackerConfigs: () => void }) {
   const events = [...model.upcomingEvents.slice(0, 8), ...model.recentResults.slice(0, 3)];
   const reminderPreviewLoader = useMemo(() => createStaffRsvpReminderPreviewLoader(), [model.team.id]);
   return (
@@ -428,7 +428,7 @@ function ScheduleTab({ model, auth }: { model: TeamDetailModel; auth: AuthState 
         <Link to={`/schedule?teamId=${encodeURIComponent(model.team.id)}`} className="secondary-button !min-h-9 text-xs">Open</Link>
       </div>
       <div className="mt-3 space-y-2">
-        {events.length ? events.map((event) => <TeamEventRow key={`${event.id}-${event.date.toISOString()}`} event={event} model={model} auth={auth} reminderPreviewLoader={reminderPreviewLoader} />) : (
+        {events.length ? events.map((event) => <TeamEventRow key={`${event.id}-${event.date.toISOString()}`} event={event} model={model} auth={auth} reminderPreviewLoader={reminderPreviewLoader} onOpenStatTrackerConfigs={onOpenStatTrackerConfigs} />) : (
           <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">No team events found.</div>
         )}
       </div>
@@ -586,8 +586,13 @@ function InsightsTab({ model, loading, error }: { model: TeamDetailModel; loadin
 }
 
 function MoreTab({ model, auth, staffPermissionsLoading, staffPermissionsError, sponsorsLoading, sponsorsError, onTeamDetailRefresh }: { model: TeamDetailModel; auth: AuthState; staffPermissionsLoading: boolean; staffPermissionsError: string; sponsorsLoading: boolean; sponsorsError: string; onTeamDetailRefresh: () => Promise<void> }) {
+  const orphanedConfigAssignments = model.canManageTeam
+    ? model.upcomingEvents.filter((event) => event.type === 'game' && event.statTrackerConfigId && !event.statTrackerConfigExists)
+    : [];
+
   return (
     <div className="space-y-4">
+      {model.canManageTeam ? <StatTrackerConfigsCard configs={model.statTrackerConfigs} orphanedAssignments={orphanedConfigAssignments} /> : null}
       {model.canManageTeam && !model.staffPermissions && staffPermissionsLoading ? (
         <section className="app-card p-4">
           <div className="flex items-center gap-3 text-sm font-semibold text-gray-600">
@@ -665,6 +670,72 @@ function MoreTab({ model, auth, staffPermissionsLoading, staffPermissionsError, 
       ) : null}
     </div>
   );
+}
+
+function StatTrackerConfigsCard({ configs, orphanedAssignments }: { configs: TeamDetailModel['statTrackerConfigs']; orphanedAssignments: TeamDetailModel['upcomingEvents'] }) {
+  return (
+    <section className="app-card p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-sm font-black text-gray-950">Stat tracker configs</div>
+          <div className="mt-1 text-xs font-semibold leading-5 text-gray-500">Read-only view of this team&apos;s tracker setups, sport routing, and scheduled game assignments.</div>
+        </div>
+        <span className="rounded-full bg-gray-100 px-2.5 py-1 text-xs font-black text-gray-700">{configs.length} config{configs.length === 1 ? '' : 's'}</span>
+      </div>
+
+      <div className="mt-3 space-y-3">
+        {configs.length ? configs.map((config) => (
+          <div key={config.id} className="rounded-xl border border-gray-200 bg-gray-50 p-3">
+            <div className="flex flex-wrap items-start justify-between gap-2">
+              <div>
+                <div className="text-sm font-black text-gray-950">{config.name}</div>
+                <div className="mt-1 flex flex-wrap gap-1.5">
+                  <span className="rounded-full bg-white px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.04em] text-gray-700">{config.baseType || 'Custom'}</span>
+                  {config.isBasketball ? <span className="rounded-full bg-amber-100 px-2 py-0.5 text-[10px] font-black uppercase tracking-[0.04em] text-amber-800">Basketball tracker routing</span> : null}
+                </div>
+              </div>
+              <span className="rounded-full bg-primary-50 px-2.5 py-1 text-xs font-black text-primary-700">{formatConfigColumnSummary(config.columnCount, config.columnNames)}</span>
+            </div>
+            <div className="mt-3 text-xs font-semibold text-gray-600">Columns: <span className="font-black text-gray-900">{config.columnNames.length ? config.columnNames.join(', ') : 'None configured'}</span></div>
+            <div className="mt-3">
+              <div className="text-[11px] font-black uppercase tracking-[0.04em] text-gray-500">Assigned upcoming games</div>
+              {config.assignedUpcomingGames.length ? (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {config.assignedUpcomingGames.map((game) => (
+                    <span key={`${config.id}-${game.gameId}`} className="rounded-full bg-white px-2.5 py-1 text-xs font-black text-gray-700">
+                      {game.title} · {formatEventDate(game.date)}
+                    </span>
+                  ))}
+                </div>
+              ) : (
+                <div className="mt-2 text-xs font-semibold text-gray-500">No upcoming games assigned.</div>
+              )}
+            </div>
+          </div>
+        )) : (
+          <div className="rounded-xl border border-gray-200 bg-gray-50 p-4 text-sm font-semibold text-gray-500">No stat tracker configs found for this team.</div>
+        )}
+
+        {orphanedAssignments.length ? (
+          <div className="rounded-xl border border-rose-200 bg-rose-50 p-3">
+            <div className="text-[11px] font-black uppercase tracking-[0.04em] text-rose-700">Missing config assignments</div>
+            <div className="mt-2 flex flex-wrap gap-2">
+              {orphanedAssignments.map((event) => (
+                <span key={event.id} className="rounded-full bg-white px-2.5 py-1 text-xs font-black text-rose-700">{event.title} · {event.statTrackerConfigId}</span>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}
+
+function formatConfigColumnSummary(columnCount: number, columnNames: string[]) {
+  if (!columnCount) return 'No columns';
+  const preview = columnNames.slice(0, 3).join(', ');
+  const remainder = columnCount - Math.min(columnNames.length, 3);
+  return `${columnCount} column${columnCount === 1 ? '' : 's'}${preview ? ` · ${preview}${remainder > 0 ? ` +${remainder}` : ''}` : ''}`;
 }
 
 function InlineDeferredLoading({ copy }: { copy: string }) {
@@ -1299,7 +1370,7 @@ function SummaryStat({ icon: Icon, label, value }: { icon: LucideIcon; label: st
   );
 }
 
-function TeamEventRow({ event, model, auth, reminderPreviewLoader }: { event: TeamDetailEvent; model: TeamDetailModel; auth: AuthState; reminderPreviewLoader: ReturnType<typeof createStaffRsvpReminderPreviewLoader> }) {
+function TeamEventRow({ event, model, auth, reminderPreviewLoader, onOpenStatTrackerConfigs }: { event: TeamDetailEvent; model: TeamDetailModel; auth: AuthState; reminderPreviewLoader: ReturnType<typeof createStaffRsvpReminderPreviewLoader>; onOpenStatTrackerConfigs: () => void }) {
   const childId = '';
   const teamId = model.team.id;
   const eventPath = getEventDetailPath({ teamId, id: event.id, childId });
@@ -1320,12 +1391,35 @@ function TeamEventRow({ event, model, auth, reminderPreviewLoader }: { event: Te
               <span>{event.date.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })}</span>
               <span className="truncate">{event.location}</span>
             </div>
+            {model.canManageTeam && event.type === 'game' ? <TeamEventStatConfigSummary event={event} onOpenStatTrackerConfigs={onOpenStatTrackerConfigs} /> : null}
           </div>
           {event.homeScore !== null && event.awayScore !== null ? <div className="text-sm font-black text-gray-950">{event.homeScore}-{event.awayScore}</div> : null}
           <ChevronRight className="h-4 w-4 flex-none text-gray-300" aria-hidden="true" />
         </Link>
       </div>
       <TeamEventReminderAction event={event} model={model} auth={auth} reminderPreviewLoader={reminderPreviewLoader} />
+    </div>
+  );
+}
+
+function TeamEventStatConfigSummary({ event, onOpenStatTrackerConfigs }: { event: TeamDetailEvent; onOpenStatTrackerConfigs: () => void }) {
+  const pillClassName = event.statTrackerConfigId
+    ? (event.statTrackerConfigExists ? 'bg-primary-50 text-primary-700' : 'bg-rose-50 text-rose-700')
+    : 'bg-gray-100 text-gray-700';
+
+  return (
+    <div className="mt-2 flex flex-wrap items-center gap-2 text-[11px] font-semibold">
+      <span className={`rounded-full px-2 py-0.5 font-black ${pillClassName}`}>{event.statTrackerConfigLabel}</span>
+      {event.statTrackerConfigIsBasketball ? <span className="rounded-full bg-amber-100 px-2 py-0.5 font-black text-amber-800">Basketball</span> : null}
+      {event.statTrackerConfigId && event.statTrackerConfigExists ? (
+        <button type="button" className="font-black text-primary-700" onClick={(clickEvent) => {
+          clickEvent.preventDefault();
+          clickEvent.stopPropagation();
+          onOpenStatTrackerConfigs();
+        }}>
+          View config
+        </button>
+      ) : null}
     </div>
   );
 }

--- a/tests/unit/app-team-detail-integration.test.jsx
+++ b/tests/unit/app-team-detail-integration.test.jsx
@@ -120,12 +120,12 @@ function model() {
             { id: 'player-1', name: 'Pat Star', number: '9', photoUrl: 'https://img.example.test/player.png', position: 'Guard', isLinked: true }
         ],
         upcomingEvents: [
-            { id: 'game-1', type: 'game', title: 'vs. Falcons', date: nextDate, location: 'Main Gym', opponent: 'Falcons', status: '', liveStatus: '', visibility: '', isPrivate: false, isPublic: false, shareable: true, publicCalendar: false, homeScore: null, awayScore: null, isCancelled: false }
+            { id: 'game-1', type: 'game', title: 'vs. Falcons', date: nextDate, location: 'Main Gym', opponent: 'Falcons', status: '', liveStatus: '', visibility: '', isPrivate: false, isPublic: false, shareable: true, publicCalendar: false, homeScore: null, awayScore: null, isCancelled: false, statTrackerConfigId: 'cfg-basketball', statTrackerConfigLabel: 'Varsity Basketball', statTrackerConfigBaseType: 'Basketball', statTrackerConfigExists: true, statTrackerConfigIsBasketball: true }
         ],
         recentResults: [
-            { id: 'game-final', type: 'game', title: 'vs. Wolves', date: new Date('2026-05-01T18:00:00Z'), location: 'Main Gym', opponent: 'Wolves', status: 'completed', liveStatus: '', visibility: '', isPrivate: false, isPublic: false, shareable: false, publicCalendar: false, homeScore: 42, awayScore: 35, isCancelled: false }
+            { id: 'game-final', type: 'game', title: 'vs. Wolves', date: new Date('2026-05-01T18:00:00Z'), location: 'Main Gym', opponent: 'Wolves', status: 'completed', liveStatus: '', visibility: '', isPrivate: false, isPublic: false, shareable: false, publicCalendar: false, homeScore: 42, awayScore: 35, isCancelled: false, statTrackerConfigId: '', statTrackerConfigLabel: 'No config assigned', statTrackerConfigBaseType: '', statTrackerConfigExists: false, statTrackerConfigIsBasketball: false }
         ],
-        nextEvent: { id: 'game-1', type: 'game', title: 'vs. Falcons', date: nextDate, location: 'Main Gym', opponent: 'Falcons', status: '', liveStatus: '', visibility: '', isPrivate: false, isPublic: false, shareable: true, publicCalendar: false, homeScore: null, awayScore: null, isCancelled: false },
+        nextEvent: { id: 'game-1', type: 'game', title: 'vs. Falcons', date: nextDate, location: 'Main Gym', opponent: 'Falcons', status: '', liveStatus: '', visibility: '', isPrivate: false, isPublic: false, shareable: true, publicCalendar: false, homeScore: null, awayScore: null, isCancelled: false, statTrackerConfigId: 'cfg-basketball', statTrackerConfigLabel: 'Varsity Basketball', statTrackerConfigBaseType: 'Basketball', statTrackerConfigExists: true, statTrackerConfigIsBasketball: true },
         record: { label: '2100', wins: 4, losses: 2, ties: 1, gamesPlayed: 7, winPercentage: 64.3 },
         standings: {
             enabled: true,
@@ -145,6 +145,15 @@ function model() {
             items: [{ id: 'item-1', title: 'Bring ball', description: 'For warmups', isComplete: false }]
         }],
         sponsors: [{ id: 'sponsor-1', name: 'Pizza Place', description: 'After the game', imageUrl: 'https://img.example.test/pizza.png', websiteUrl: 'https://pizza.example.test' }],
+        statTrackerConfigs: [{
+            id: 'cfg-basketball',
+            name: 'Varsity Basketball',
+            baseType: 'Basketball',
+            isBasketball: true,
+            columnCount: 4,
+            columnNames: ['PTS', 'REB', 'AST', 'STL'],
+            assignedUpcomingGames: [{ gameId: 'game-1', title: 'vs. Falcons', date: nextDate }]
+        }],
         canManageTeam: false,
         staffPermissions: null,
         counts: { games: 8, practices: 3, completedGames: 7 }
@@ -678,7 +687,7 @@ describe('React app TeamDetail page', () => {
         managerModel.canManageTeam = true;
         managerModel.upcomingEvents = [
             managerModel.upcomingEvents[0],
-            { id: 'game-2', type: 'game', title: 'at Tigers', date: new Date('2100-06-03T18:00:00Z'), location: 'North Gym', opponent: 'Tigers', status: '', liveStatus: '', visibility: '', isPrivate: false, isPublic: false, shareable: true, publicCalendar: false, homeScore: null, awayScore: null, isCancelled: false }
+            { id: 'game-2', type: 'game', title: 'at Tigers', date: new Date('2100-06-03T18:00:00Z'), location: 'North Gym', opponent: 'Tigers', status: '', liveStatus: '', visibility: '', isPrivate: false, isPublic: false, shareable: true, publicCalendar: false, homeScore: null, awayScore: null, isCancelled: false, statTrackerConfigId: '', statTrackerConfigLabel: 'No config assigned', statTrackerConfigBaseType: '', statTrackerConfigExists: false, statTrackerConfigIsBasketball: false }
         ];
         managerModel.nextEvent = managerModel.upcomingEvents[0];
         teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(managerModel);
@@ -724,6 +733,52 @@ describe('React app TeamDetail page', () => {
         expect(scheduleServiceMocks.sendStaffRsvpReminder).toHaveBeenCalledTimes(1);
         expect(scheduleServiceMocks.sendStaffRsvpReminder).toHaveBeenCalledWith(expect.objectContaining({ id: 'game-1', teamId: 'team-1' }), managerAuth.user, managerAuth.profile);
         expect(container.textContent).toContain('RSVP reminder sent to team chat and 4 parent/guardian emails.');
+    });
+
+    it('shows staff-only stat tracker config summaries and game assignments', async () => {
+        const managerAuth = {
+            ...auth,
+            user: { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] },
+            roles: ['coach'],
+            isParent: false,
+            isCoach: true
+        };
+        const managerModel = model();
+        managerModel.canManageTeam = true;
+        managerModel.upcomingEvents = [
+            managerModel.upcomingEvents[0],
+            { id: 'game-2', type: 'game', title: 'at Tigers', date: new Date('2100-06-03T18:00:00Z'), location: 'North Gym', opponent: 'Tigers', status: '', liveStatus: '', visibility: '', isPrivate: false, isPublic: false, shareable: true, publicCalendar: false, homeScore: null, awayScore: null, isCancelled: false, statTrackerConfigId: 'cfg-deleted', statTrackerConfigLabel: 'Missing config (cfg-deleted)', statTrackerConfigBaseType: '', statTrackerConfigExists: false, statTrackerConfigIsBasketball: false }
+        ];
+        managerModel.statTrackerConfigs = [{
+            id: 'cfg-basketball',
+            name: 'Varsity Basketball',
+            baseType: 'Basketball',
+            isBasketball: true,
+            columnCount: 4,
+            columnNames: ['PTS', 'REB', 'AST', 'STL'],
+            assignedUpcomingGames: [{ gameId: 'game-1', title: 'vs. Falcons', date: new Date('2100-06-01T18:00:00Z') }]
+        }];
+        teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(managerModel);
+
+        const { container } = await renderTeamDetail(managerAuth);
+        await clickButton(container, 'Schedule');
+        expect(container.textContent).toContain('Varsity Basketball');
+        expect(container.textContent).toContain('Basketball');
+        expect(container.textContent).toContain('Missing config (cfg-deleted)');
+
+        await clickButton(container, 'View config');
+        expect(container.textContent).toContain('Stat tracker configs');
+        expect(container.textContent).toContain('Basketball tracker routing');
+        expect(container.textContent).toContain('4 columns · PTS, REB, AST +1');
+        expect(container.textContent).toContain('vs. Falcons · Tue, Jun 1');
+        expect(container.textContent).toContain('Missing config assignments');
+
+        teamDetailMocks.loadParentTeamDetail.mockResolvedValueOnce(model());
+        const hidden = await renderTeamDetail();
+        await clickButton(hidden.container, 'Schedule');
+        expect(hidden.container.textContent).not.toContain('Varsity Basketball');
+        await clickButton(hidden.container, 'More');
+        expect(hidden.container.textContent).not.toContain('Stat tracker configs');
     });
 
     it('hides inline RSVP reminders for parents and events with no missing players', async () => {

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -334,11 +334,22 @@ describe('React app team detail model', () => {
         expect(model.linkedPlayers.map((player) => player.id)).toEqual(['player-1']);
         expect(model.record).toMatchObject({ wins: 1, losses: 0, ties: 0, gamesPlayed: 1 });
         expect(model.upcomingEvents.map((event) => event.id)).toEqual(['game-1', 'practice-1']);
-        expect(model.upcomingEvents[0]).toMatchObject({ shareable: true, isPrivate: false, publicCalendar: false, liveStatus: '' });
+        expect(model.upcomingEvents[0]).toMatchObject({ shareable: true, isPrivate: false, publicCalendar: false, liveStatus: '', statTrackerConfigLabel: 'No config assigned', statTrackerConfigExists: false });
         expect(model.standings.currentRow.record).toBe('1-0');
         expect(model.leaderboards[0].leaders[0]).toMatchObject({ playerId: 'player-1', formattedValue: '88' });
         expect(model.trackingSummaries[0].items[0]).toMatchObject({ title: 'Bring ball', isComplete: true });
         expect(model.sponsors[0].imageUrl).toBe('https://img.example.test/pizza.png');
+        expect(model.statTrackerConfigs).toEqual([
+            expect.objectContaining({
+                id: 'basketball',
+                name: 'Basketball',
+                baseType: 'Custom',
+                isBasketball: false,
+                columnCount: 1,
+                columnNames: ['pts'],
+                assignedUpcomingGames: []
+            })
+        ]);
         expect(model.canManageTeam).toBe(false);
     });
 
@@ -409,6 +420,83 @@ describe('React app team detail model', () => {
         expect(model.recentResults.map((event) => event.id)).toEqual(['scored-past', 'final-game']);
         expect(model.counts).toMatchObject({ games: 4, practices: 1, completedGames: 1 });
         expect(model.sponsors.map((sponsor) => sponsor.id)).toEqual(['s1', 's2', 's3', 's4']);
+    });
+
+    it('builds read-only stat tracker config summaries for migrated and legacy shapes', () => {
+        const model = buildTeamDetailModel({
+            teamId: 'team-1',
+            team: {
+                name: 'Bears',
+                sport: 'Basketball',
+                ownerId: 'coach-1',
+                adminEmails: ['coach@example.com']
+            },
+            games: [
+                { id: 'game-1', opponent: 'Falcons', date: new Date('2100-06-01T18:00:00Z'), status: 'scheduled', statTrackerConfigId: 'cfg-basketball' },
+                { id: 'game-2', opponent: 'Tigers', date: new Date('2100-06-02T18:00:00Z'), status: 'scheduled', statTrackerConfigId: 'cfg-legacy' },
+                { id: 'game-3', opponent: 'Orphans', date: new Date('2100-06-03T18:00:00Z'), status: 'scheduled', statTrackerConfigId: 'cfg-missing' }
+            ],
+            configs: [
+                {
+                    id: 'cfg-basketball',
+                    name: 'Varsity Basketball',
+                    baseType: 'Basketball',
+                    columns: ['PTS', 'REB', 'AST']
+                },
+                {
+                    id: 'cfg-legacy',
+                    name: 'Legacy Soccer',
+                    baseType: 'Soccer',
+                    columns: [
+                        { label: 'Goals', acronym: 'GOALS' },
+                        { name: 'Shots', key: 'SHOTS' }
+                    ],
+                    statDefinitions: [
+                        { id: 'goals', label: 'Goals', acronym: 'GOALS' },
+                        { id: 'shots', label: 'Shots', acronym: 'SHOTS' },
+                        { id: 'shotpct', label: 'Shot%', acronym: 'Shot%', formula: '(GOALS/SHOTS)*100' }
+                    ]
+                }
+            ],
+            user: { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] }
+        });
+
+        expect(model.statTrackerConfigs).toEqual([
+            expect.objectContaining({
+                id: 'cfg-legacy',
+                name: 'Legacy Soccer',
+                baseType: 'Soccer',
+                isBasketball: false,
+                columnCount: 2,
+                columnNames: ['GOALS', 'SHOTS'],
+                assignedUpcomingGames: [
+                    expect.objectContaining({ gameId: 'game-2', title: 'vs. Tigers' })
+                ]
+            }),
+            expect.objectContaining({
+                id: 'cfg-basketball',
+                name: 'Varsity Basketball',
+                baseType: 'Basketball',
+                isBasketball: true,
+                columnCount: 3,
+                columnNames: ['PTS', 'REB', 'AST'],
+                assignedUpcomingGames: [
+                    expect.objectContaining({ gameId: 'game-1', title: 'vs. Falcons' })
+                ]
+            })
+        ]);
+        expect(model.upcomingEvents.find((event) => event.id === 'game-1')).toMatchObject({
+            statTrackerConfigId: 'cfg-basketball',
+            statTrackerConfigLabel: 'Varsity Basketball',
+            statTrackerConfigExists: true,
+            statTrackerConfigIsBasketball: true
+        });
+        expect(model.upcomingEvents.find((event) => event.id === 'game-3')).toMatchObject({
+            statTrackerConfigId: 'cfg-missing',
+            statTrackerConfigLabel: 'Missing config (cfg-missing)',
+            statTrackerConfigExists: false,
+            statTrackerConfigIsBasketball: false
+        });
     });
 
     it('adds staff permissions only for users with full team access', () => {

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -434,7 +434,8 @@ describe('React app team detail model', () => {
             games: [
                 { id: 'game-1', opponent: 'Falcons', date: new Date('2100-06-01T18:00:00Z'), status: 'scheduled', statTrackerConfigId: 'cfg-basketball' },
                 { id: 'game-2', opponent: 'Tigers', date: new Date('2100-06-02T18:00:00Z'), status: 'scheduled', statTrackerConfigId: 'cfg-legacy' },
-                { id: 'game-3', opponent: 'Orphans', date: new Date('2100-06-03T18:00:00Z'), status: 'scheduled', statTrackerConfigId: 'cfg-missing' }
+                { id: 'game-3', opponent: 'Orphans', date: new Date('2100-06-03T18:00:00Z'), status: 'scheduled', statTrackerConfigId: 'cfg-missing' },
+                { id: 'stale-game', opponent: 'Past Tigers', date: new Date('2020-06-02T18:00:00Z'), status: 'scheduled', statTrackerConfigId: 'cfg-legacy' }
             ],
             configs: [
                 {
@@ -485,6 +486,8 @@ describe('React app team detail model', () => {
                 ]
             })
         ]);
+        expect(model.statTrackerConfigs.find((config) => config.id === 'cfg-legacy').assignedUpcomingGames)
+            .toEqual([expect.objectContaining({ gameId: 'game-2', title: 'vs. Tigers' })]);
         expect(model.upcomingEvents.find((event) => event.id === 'game-1')).toMatchObject({
             statTrackerConfigId: 'cfg-basketball',
             statTrackerConfigLabel: 'Varsity Basketball',


### PR DESCRIPTION
Closes #1968

## What changed
- projected team stat tracker configs into the app Team Detail view model with legacy and migrated shape tolerance
- added a staff-only read-only stat config section in `TeamDetail` that lists config name, base sport, basketball badge, column summary, and assigned upcoming games
- surfaced each scheduled game's `statTrackerConfigId` as a readable assignment label with graceful orphan handling
- added focused service and integration coverage for legacy config shapes, assignment rendering, basketball badging, and parent exclusion

## Root Cause
The app already loaded `teams/{teamId}/statTrackerConfigs`, but `TeamDetail` never normalized or exposed that data in its view model or UI. Because the projection layer was missing, game rows could not resolve `statTrackerConfigId` to a visible label, and legacy config shapes had no app-facing reader.

## Prevention / Learning
When an app route already fetches a related collection, treat the feature as incomplete until there is an explicit view-model projection plus a rendering test for the consuming screen. For mixed legacy Firestore shapes, normalize at the service boundary instead of letting UI code assume the latest schema.

## Regression Tests
- `npx vitest run tests/unit/app-team-detail-service.test.js tests/unit/app-team-detail-integration.test.jsx apps/app/src/pages/TeamDetail.test.tsx`
- service coverage verifies legacy and migrated config shape normalization, column summaries, per-game assignment mapping, and orphaned config fallback
- integration coverage verifies staff-only rendering, basketball badging, More-tab config listing, and parent non-access to the stat config UI