### PR TITLE
Fix app roster accepted parent invite status

### DIFF
--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -896,10 +896,8 @@ export function buildRosterParentInviteSummaries({
   const acceptedCounts = new Map<string, number>();
 
   (Array.isArray(confirmedTeamMembers) ? confirmedTeamMembers : []).forEach((member) => {
-    (Array.isArray(member?.parentOf) ? member.parentOf : []).forEach((link: any) => {
-      if (cleanString(link?.teamId) !== normalizedTeamId) return;
-      const playerId = cleanString(link?.playerId);
-      if (!playerId) return;
+    const linkedPlayerIds = getAcceptedParentPlayerIds(member, normalizedTeamId);
+    linkedPlayerIds.forEach((playerId) => {
       acceptedCounts.set(playerId, (acceptedCounts.get(playerId) || 0) + 1);
     });
   });
@@ -931,6 +929,31 @@ export function buildRosterParentInviteSummaries({
         latestPendingCode: cleanString(pendingInvites[0]?.code).toUpperCase()
       };
     });
+}
+
+function getAcceptedParentPlayerIds(member: any, teamId: string) {
+  const normalizedTeamId = cleanString(teamId);
+  if (!normalizedTeamId) return [] as string[];
+
+  const linkedPlayerIds = new Set<string>();
+  (Array.isArray(member?.parentOf) ? member.parentOf : []).forEach((link: any) => {
+    if (cleanString(link?.teamId) !== normalizedTeamId) return;
+    const playerId = cleanString(link?.playerId);
+    if (playerId) linkedPlayerIds.add(playerId);
+  });
+
+  const parentTeamIds = Array.isArray(member?.parentTeamIds) ? member.parentTeamIds.map((value: any) => cleanString(value)) : [];
+  const parentPlayerKeys = Array.isArray(member?.parentPlayerKeys) ? member.parentPlayerKeys : [];
+  if (parentTeamIds.includes(normalizedTeamId)) {
+    parentPlayerKeys.forEach((value: any) => {
+      const [keyTeamId, keyPlayerId] = cleanString(value).split('::');
+      if (keyTeamId === normalizedTeamId && keyPlayerId) {
+        linkedPlayerIds.add(keyPlayerId);
+      }
+    });
+  }
+
+  return [...linkedPlayerIds];
 }
 
 function buildTeamStaffPermissionsSummary({

--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -942,16 +942,13 @@ function getAcceptedParentPlayerIds(member: any, teamId: string) {
     if (playerId) linkedPlayerIds.add(playerId);
   });
 
-  const parentTeamIds = Array.isArray(member?.parentTeamIds) ? member.parentTeamIds.map((value: any) => cleanString(value)) : [];
   const parentPlayerKeys = Array.isArray(member?.parentPlayerKeys) ? member.parentPlayerKeys : [];
-  if (parentTeamIds.includes(normalizedTeamId)) {
-    parentPlayerKeys.forEach((value: any) => {
-      const [keyTeamId, keyPlayerId] = cleanString(value).split('::');
-      if (keyTeamId === normalizedTeamId && keyPlayerId) {
-        linkedPlayerIds.add(keyPlayerId);
-      }
-    });
-  }
+  parentPlayerKeys.forEach((value: any) => {
+    const [keyTeamId, keyPlayerId] = cleanString(value).split('::');
+    if (keyTeamId === normalizedTeamId && keyPlayerId) {
+      linkedPlayerIds.add(keyPlayerId);
+    }
+  });
 
   return [...linkedPlayerIds];
 }

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -137,7 +137,6 @@ describe('React app team detail model', () => {
             confirmedTeamMembers: [
                 {
                     id: 'parent-1',
-                    parentTeamIds: ['team-1'],
                     parentPlayerKeys: ['team-1::player-1']
                 },
                 {

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -54,7 +54,7 @@ vi.mock('../../apps/app/src/lib/authService.ts', () => ({
     getNativeAuthIdToken: vi.fn()
 }));
 
-import { __resetTeamDetailBaseSnapshotCacheForTests, buildAdminAcceptInviteUrl, buildPublicTeamGamesIcsUrl, buildTeamDetailModel, canExposePublicFanFeed, createRosterParentInviteForApp, deactivateRosterPlayerForApp, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, loadTeamDetailInsights, loadTeamDetailSponsors, loadTeamStaffPermissions, reactivateRosterPlayerForApp, revokeScorekeeperAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp } from '../../apps/app/src/lib/teamDetailService.ts';
+import { __resetTeamDetailBaseSnapshotCacheForTests, buildAdminAcceptInviteUrl, buildPublicTeamGamesIcsUrl, buildRosterParentInviteSummaries, buildTeamDetailModel, canExposePublicFanFeed, createRosterParentInviteForApp, deactivateRosterPlayerForApp, grantScorekeeperAccessForApp, grantVideographerAccessForApp, inviteTeamAdminForApp, loadParentTeamDetail, loadTeamDetailInsights, loadTeamDetailSponsors, loadTeamStaffPermissions, reactivateRosterPlayerForApp, revokeScorekeeperAccessForApp, revokeVideographerAccessForApp, saveTeamScheduleNotificationsForApp } from '../../apps/app/src/lib/teamDetailService.ts';
 import { collection, getDocs, query, where } from '../../js/firebase.js';
 import { getAggregatedStatsForGames, getAdSpaceSponsors, getAllUsers, getConfigs, getEvents, getGames, getLocalAttractionSponsors, getPlayerTrackingStatuses, getPlayers, getPublicTrackingItems, getTeam, grantScorekeeperAccess, grantVideographerAccess, inviteAdmin, inviteParent, addTeamAdminEmail, revokeScorekeeperAccess, revokeVideographerAccess, deactivatePlayer, reactivatePlayer, updateEvent, updateGame, updateTeam } from '../../js/db.js';
 import { sendInviteEmail } from '../../js/auth.js';
@@ -122,6 +122,49 @@ describe('React app team detail model', () => {
             inviteUrl: 'http://localhost:3000/app#/accept-invite?code=ABCD1234&type=parent',
             status: 'pending'
         });
+    });
+
+    it('treats accepted roster invites as linked when legacy parent scope is stored in parentPlayerKeys', () => {
+        const summaries = buildRosterParentInviteSummaries({
+            teamId: 'team-1',
+            players: [
+                { id: 'player-1', name: 'Pat Star' },
+                { id: 'player-2', name: 'Sam Wing' }
+            ],
+            pendingParentInvites: [
+                { playerId: 'player-1', code: 'PENDING1', type: 'parent_invite', used: false }
+            ],
+            confirmedTeamMembers: [
+                {
+                    id: 'parent-1',
+                    parentTeamIds: ['team-1'],
+                    parentPlayerKeys: ['team-1::player-1']
+                },
+                {
+                    id: 'parent-2',
+                    parentOf: [{ teamId: 'team-1', playerId: 'player-2' }],
+                    parentTeamIds: ['team-1'],
+                    parentPlayerKeys: ['team-1::player-2']
+                }
+            ]
+        });
+
+        expect(summaries).toEqual([
+            {
+                playerId: 'player-1',
+                status: 'accepted',
+                acceptedParentCount: 1,
+                pendingInviteCount: 1,
+                latestPendingCode: 'PENDING1'
+            },
+            {
+                playerId: 'player-2',
+                status: 'accepted',
+                acceptedParentCount: 1,
+                pendingInviteCount: 0,
+                latestPendingCode: ''
+            }
+        ]);
     });
 
     it('wraps scorekeeper and roster active-state mutations with app validation', async () => {


### PR DESCRIPTION
Closes #1961

## What changed
- fixed app roster parent invite status derivation to honor legacy-approved parent links stored in `parentPlayerKeys` plus `parentTeamIds`, not just `parentOf`
- kept the existing app invite generation/copy/share flow intact while making accepted status match legacy membership state
- added a focused regression test covering accepted status when legacy parent scope is stored outside `parentOf`

## Root Cause
The app roster status helper only treated `users/{uid}.parentOf[]` as proof of an accepted parent link. Legacy-approved parent access can also be represented by `parentTeamIds[]` plus `parentPlayerKeys[]`, so some valid accepted invites were shown as pending or none in the app.

## Prevention / Learning
When app parity depends on legacy access state, derive status from the full legacy contract, not a single convenience field. For parent access specifically, treat `parentOf`, `parentTeamIds`, and `parentPlayerKeys` as the authoritative compatibility set.

## Regression Tests
- `npx vitest run tests/unit/app-team-detail-service.test.js apps/app/src/pages/TeamDetail.test.tsx tests/unit/app-team-detail-integration.test.jsx`
- added coverage proving `buildRosterParentInviteSummaries(...)` marks a player accepted when the legacy link is represented via `parentTeamIds` + `parentPlayerKeys`