### PR TITLE
Defer Parent Tools manual access discovery

### DIFF
--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -351,7 +351,7 @@ export async function loadParentAccessModel(user: AuthUser | null) {
 }
 
 export async function loadParentAccessTeams(): Promise<ParentAccessTeam[]> {
-  const result = await Promise.resolve(discoverPublicTeams({ pageSize: 25 }));
+  const result = await Promise.resolve(discoverPublicTeams({ pageSize: 100 }));
   return normalizeAccessTeams(result?.teams);
 }
 

--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -343,14 +343,16 @@ export function getCertificateUrl(teamId: string, certificateId: string) {
 
 export async function loadParentAccessModel(user: AuthUser | null) {
   if (!user?.uid) return { teams: [], requests: [] };
-  const [{ teams }, requests] = await Promise.all([
-    Promise.resolve(discoverPublicTeams({ pageSize: 100 })),
-    Promise.resolve(listMyParentMembershipRequests(user.uid))
-  ]);
+  const requests = await Promise.resolve(listMyParentMembershipRequests(user.uid));
   return {
-    teams: normalizeAccessTeams(teams),
+    teams: [],
     requests: (requests || []).map(normalizeAccessRequest)
   };
+}
+
+export async function loadParentAccessTeams(): Promise<ParentAccessTeam[]> {
+  const result = await Promise.resolve(discoverPublicTeams({ pageSize: 25 }));
+  return normalizeAccessTeams(result?.teams);
 }
 
 export async function loadParentAccessPlayers(teamId: string): Promise<ParentAccessPlayer[]> {

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -155,9 +155,12 @@ describe('ParentTools access', () => {
         await screen.findByText('Request player access');
         fireEvent.click(screen.getByRole('button', { name: 'Request access without a code' }));
 
-        const teamSelect = screen.getByLabelText('Team') as HTMLSelectElement;
+        const teamSelect = screen.getByRole('combobox', { name: 'Team' }) as HTMLSelectElement;
+        const playerSelect = screen.getByRole('combobox', { name: 'Player' }) as HTMLSelectElement;
         expect(teamSelect).toBeTruthy();
+        expect(playerSelect).toBeTruthy();
         expect(teamSelect.disabled).toBe(true);
+        expect(playerSelect.disabled).toBe(true);
         expect(parentToolsServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(1);
         expect(screen.queryByRole('button', { name: 'Request access without a code' })).toBeNull();
         expect(screen.getByRole('option', { name: 'Loading public teams...' })).toBeTruthy();

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -158,6 +158,8 @@ describe('ParentTools access', () => {
         const teamSelect = screen.getByLabelText('Team') as HTMLSelectElement;
         expect(teamSelect).toBeTruthy();
         expect(teamSelect.disabled).toBe(true);
+        expect(parentToolsServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(1);
+        expect(screen.queryByRole('button', { name: 'Request access without a code' })).toBeNull();
         expect(screen.getByRole('option', { name: 'Loading public teams...' })).toBeTruthy();
 
         await waitFor(() => expect(deferredTeams.resolve).toBeTruthy());

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -146,9 +146,9 @@ describe('ParentTools access', () => {
 
     it('waits for public teams to load before opening the manual request form', async () => {
         type PublicTeamRow = { id: string; name: string; sport: string };
-        let resolveTeams: ((value: PublicTeamRow[]) => void) | null = null;
+        const deferredTeams: { resolve: ((value: PublicTeamRow[]) => void) | null } = { resolve: null };
         parentToolsServiceMocks.loadParentAccessTeams.mockImplementation(() => new Promise<PublicTeamRow[]>((resolve) => {
-            resolveTeams = resolve;
+            deferredTeams.resolve = resolve;
         }));
         renderParentTools();
 
@@ -158,9 +158,9 @@ describe('ParentTools access', () => {
         expect(screen.queryByLabelText('Team')).toBeNull();
         expect(screen.getByRole('button', { name: 'Loading public teams...' })).toBeTruthy();
 
-        const pendingTeamsResolver = resolveTeams;
-        if (!pendingTeamsResolver) throw new Error('Expected public teams loader to be pending.');
-        pendingTeamsResolver([{ id: 'team-1', name: 'Bears', sport: 'Soccer' }]);
+        await waitFor(() => expect(deferredTeams.resolve).toBeTruthy());
+        if (!deferredTeams.resolve) throw new Error('Expected public teams loader to be pending.');
+        deferredTeams.resolve([{ id: 'team-1', name: 'Bears', sport: 'Soccer' }]);
 
         expect(await screen.findByRole('option', { name: 'Bears - Soccer' })).toBeTruthy();
         expect(screen.getByLabelText('Team')).toBeTruthy();

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -144,7 +144,7 @@ describe('ParentTools access', () => {
         expect(screen.getByRole('button', { name: 'Request access without a code' })).toBeTruthy();
     });
 
-    it('waits for public teams to load before opening the manual request form', async () => {
+    it('opens the manual request form immediately while public teams finish loading', async () => {
         type PublicTeamRow = { id: string; name: string; sport: string };
         const deferredTeams: { resolve: ((value: PublicTeamRow[]) => void) | null } = { resolve: null };
         parentToolsServiceMocks.loadParentAccessTeams.mockImplementation(() => new Promise<PublicTeamRow[]>((resolve) => {
@@ -155,15 +155,17 @@ describe('ParentTools access', () => {
         await screen.findByText('Request player access');
         fireEvent.click(screen.getByRole('button', { name: 'Request access without a code' }));
 
-        expect(screen.queryByLabelText('Team')).toBeNull();
-        expect(screen.getByRole('button', { name: 'Loading public teams...' })).toBeTruthy();
+        const teamSelect = screen.getByLabelText('Team') as HTMLSelectElement;
+        expect(teamSelect).toBeTruthy();
+        expect(teamSelect.disabled).toBe(true);
+        expect(screen.getByRole('option', { name: 'Loading public teams...' })).toBeTruthy();
 
         await waitFor(() => expect(deferredTeams.resolve).toBeTruthy());
         if (!deferredTeams.resolve) throw new Error('Expected public teams loader to be pending.');
         deferredTeams.resolve([{ id: 'team-1', name: 'Bears', sport: 'Soccer' }]);
 
         expect(await screen.findByRole('option', { name: 'Bears - Soccer' })).toBeTruthy();
-        expect(screen.getByLabelText('Team')).toBeTruthy();
+        expect((screen.getByLabelText('Team') as HTMLSelectElement).disabled).toBe(false);
     });
 
     it('still submits request access after the redeem panel is added', async () => {

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -158,8 +158,9 @@ describe('ParentTools access', () => {
         expect(screen.queryByLabelText('Team')).toBeNull();
         expect(screen.getByRole('button', { name: 'Loading public teams...' })).toBeTruthy();
 
-        if (!resolveTeams) throw new Error('Expected public teams loader to be pending.');
-        resolveTeams([{ id: 'team-1', name: 'Bears', sport: 'Soccer' }]);
+        const pendingTeamsResolver = resolveTeams;
+        if (!pendingTeamsResolver) throw new Error('Expected public teams loader to be pending.');
+        pendingTeamsResolver([{ id: 'team-1', name: 'Bears', sport: 'Soccer' }]);
 
         expect(await screen.findByRole('option', { name: 'Bears - Soccer' })).toBeTruthy();
         expect(screen.getByLabelText('Team')).toBeTruthy();

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -17,6 +17,7 @@ const parentToolsServiceMocks = vi.hoisted(() => ({
     initiateParentTeamFeeCheckout: vi.fn(),
     loadFamilyShareModel: vi.fn(),
     loadParentAccessModel: vi.fn(),
+    loadParentAccessTeams: vi.fn(),
     loadParentAccessPlayers: vi.fn(),
     loadParentCalendarTools: vi.fn(),
     loadParentCertificates: vi.fn(),
@@ -92,9 +93,11 @@ describe('ParentTools access', () => {
         vi.clearAllMocks();
         delete globalThis.__ALLPLAYS_PARENT_TOOLS_RENDER_TRACKER__;
         parentToolsServiceMocks.loadParentAccessModel.mockResolvedValue({
-            teams: [{ id: 'team-1', name: 'Bears', sport: 'Soccer' }],
             requests: []
         });
+        parentToolsServiceMocks.loadParentAccessTeams.mockResolvedValue([
+            { id: 'team-1', name: 'Bears', sport: 'Soccer' }
+        ]);
         parentToolsServiceMocks.loadParentAccessPlayers.mockResolvedValue([
             { id: 'player-1', name: 'Sam Player', number: '12' }
         ]);
@@ -138,13 +141,16 @@ describe('ParentTools access', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Redeem code' }));
 
         expect(await screen.findByText('Invite code expired.')).toBeTruthy();
-        expect(screen.getByRole('button', { name: 'Send request' })).toBeTruthy();
+        expect(screen.getByRole('button', { name: 'Request access without a code' })).toBeTruthy();
     });
 
     it('still submits request access after the redeem panel is added', async () => {
         renderParentTools();
 
         await screen.findByText('Request player access');
+        fireEvent.click(screen.getByRole('button', { name: 'Request access without a code' }));
+        await screen.findByRole('option', { name: 'Bears - Soccer' });
+        fireEvent.change(screen.getByLabelText('Team'), { target: { value: 'team-1' } });
         await screen.findByRole('option', { name: '#12 Sam Player' });
         const submitButton = screen.getByRole('button', { name: 'Send request' });
         expect(submitButton.hasAttribute('disabled')).toBe(false);
@@ -212,13 +218,15 @@ describe('ParentTools access', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Fees' }));
         await screen.findByText('Team dues');
         expect(parentToolsServiceMocks.loadParentAccessModel).toHaveBeenCalledTimes(1);
-        expect(parentToolsServiceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(1);
+        expect(parentToolsServiceMocks.loadParentAccessTeams).not.toHaveBeenCalled();
+        expect(parentToolsServiceMocks.loadParentAccessPlayers).not.toHaveBeenCalled();
         expect(parentToolsServiceMocks.loadParentFeesForApp).toHaveBeenCalledTimes(1);
 
         fireEvent.click(screen.getByRole('button', { name: 'Access' }));
         await screen.findByText('Request player access');
         expect(parentToolsServiceMocks.loadParentAccessModel).toHaveBeenCalledTimes(1);
-        expect(parentToolsServiceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(1);
+        expect(parentToolsServiceMocks.loadParentAccessTeams).not.toHaveBeenCalled();
+        expect(parentToolsServiceMocks.loadParentAccessPlayers).not.toHaveBeenCalled();
 
         fireEvent.click(screen.getByRole('button', { name: 'Register' }));
         await screen.findByText('Summer Camp');
@@ -432,5 +440,25 @@ describe('ParentTools access', () => {
 
         expect(await screen.findByText('Summer Camp')).toBeTruthy();
         await waitFor(() => expect(parentToolsServiceMocks.loadParentRegistrations).toHaveBeenCalledTimes(2));
+    });
+
+    it('defers public team and player loading until manual access starts', async () => {
+        renderParentTools();
+
+        await screen.findByText('Request player access');
+        expect(parentToolsServiceMocks.loadParentAccessModel).toHaveBeenCalledTimes(1);
+        expect(parentToolsServiceMocks.loadParentAccessTeams).not.toHaveBeenCalled();
+        expect(parentToolsServiceMocks.loadParentAccessPlayers).not.toHaveBeenCalled();
+        expect(screen.getByRole('button', { name: 'Request access without a code' })).toBeTruthy();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Request access without a code' }));
+        await screen.findByRole('option', { name: 'Bears - Soccer' });
+        expect(parentToolsServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(1);
+        expect(parentToolsServiceMocks.loadParentAccessPlayers).not.toHaveBeenCalled();
+
+        fireEvent.change(screen.getByLabelText('Team'), { target: { value: 'team-1' } });
+        await screen.findByRole('option', { name: '#12 Sam Player' });
+        expect(parentToolsServiceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(1);
+        expect(parentToolsServiceMocks.loadParentAccessPlayers).toHaveBeenCalledWith('team-1');
     });
 });

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -144,6 +144,27 @@ describe('ParentTools access', () => {
         expect(screen.getByRole('button', { name: 'Request access without a code' })).toBeTruthy();
     });
 
+    it('waits for public teams to load before opening the manual request form', async () => {
+        type PublicTeamRow = { id: string; name: string; sport: string };
+        let resolveTeams: ((value: PublicTeamRow[]) => void) | null = null;
+        parentToolsServiceMocks.loadParentAccessTeams.mockImplementation(() => new Promise<PublicTeamRow[]>((resolve) => {
+            resolveTeams = resolve;
+        }));
+        renderParentTools();
+
+        await screen.findByText('Request player access');
+        fireEvent.click(screen.getByRole('button', { name: 'Request access without a code' }));
+
+        expect(screen.queryByLabelText('Team')).toBeNull();
+        expect(screen.getByRole('button', { name: 'Loading public teams...' })).toBeTruthy();
+
+        if (!resolveTeams) throw new Error('Expected public teams loader to be pending.');
+        resolveTeams([{ id: 'team-1', name: 'Bears', sport: 'Soccer' }]);
+
+        expect(await screen.findByRole('option', { name: 'Bears - Soccer' })).toBeTruthy();
+        expect(screen.getByLabelText('Team')).toBeTruthy();
+    });
+
     it('still submits request access after the redeem panel is added', async () => {
         renderParentTools();
 

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -173,6 +173,24 @@ describe('ParentTools access', () => {
         expect((screen.getByLabelText('Team') as HTMLSelectElement).disabled).toBe(false);
     });
 
+    it('allows retry when public team loading fails after opening manual requests', async () => {
+        parentToolsServiceMocks.loadParentAccessTeams
+            .mockRejectedValueOnce(new Error('Network hiccup.'))
+            .mockResolvedValueOnce([{ id: 'team-1', name: 'Bears', sport: 'Soccer' }]);
+        renderParentTools();
+
+        await screen.findByText('Request player access');
+        fireEvent.click(screen.getByRole('button', { name: 'Request access without a code' }));
+
+        expect(await screen.findByText('Network hiccup.')).toBeTruthy();
+        const retryButton = screen.getByRole('button', { name: 'Retry loading public teams' });
+        expect(retryButton).toBeTruthy();
+        fireEvent.click(retryButton);
+
+        expect(await screen.findByRole('option', { name: 'Bears - Soccer' })).toBeTruthy();
+        expect(parentToolsServiceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(2);
+    });
+
     it('still submits request access after the redeem panel is added', async () => {
         renderParentTools();
 

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -264,11 +264,11 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
     }
   }, []);
 
-  const openManualRequest = useCallback(() => {
-    setManualRequestOpen(true);
+  const openManualRequest = useCallback(async () => {
     if (!teams.length && !loadingTeams) {
-      void loadTeams();
+      await loadTeams();
     }
+    setManualRequestOpen(true);
   }, [loadTeams, loadingTeams, teams.length]);
 
   const refresh = async () => {

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -265,10 +265,10 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
   }, []);
 
   const openManualRequest = useCallback(async () => {
+    setManualRequestOpen(true);
     if (!teams.length && !loadingTeams) {
       await loadTeams();
     }
-    setManualRequestOpen(true);
   }, [loadTeams, loadingTeams, teams.length]);
 
   const refresh = async () => {

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -401,33 +401,33 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
             </form>
             {manualRequestOpen ? (
               <form className="mt-3 grid gap-3 lg:grid-cols-[1fr_1fr_auto]" onSubmit={submit}>
-                <label className="min-w-0">
-                  <span className="app-label">Team</span>
-                  <select className="auth-input mt-1" value={selectedTeamId} onChange={(event) => setSelectedTeamId(event.target.value)} disabled={loadingTeams || !teams.length}>
+                <div className="min-w-0">
+                  <label className="app-label" htmlFor="parent-access-team">Team</label>
+                  <select id="parent-access-team" aria-label="Team" className="auth-input mt-1" value={selectedTeamId} onChange={(event) => setSelectedTeamId(event.target.value)} disabled={loadingTeams || !teams.length}>
                     <option value="">{loadingTeams ? 'Loading public teams...' : teams.length ? 'Choose a team' : 'No public teams'}</option>
                     {teams.map((team) => (
                       <option key={team.id} value={team.id}>{team.name}{team.sport ? ` - ${team.sport}` : ''}</option>
                     ))}
                   </select>
-                </label>
-                <label className="min-w-0">
-                  <span className="app-label">Player</span>
-                  <select className="auth-input mt-1" value={selectedPlayerId} onChange={(event) => setSelectedPlayerId(event.target.value)} disabled={!selectedTeamId || loadingPlayers}>
+                </div>
+                <div className="min-w-0">
+                  <label className="app-label" htmlFor="parent-access-player">Player</label>
+                  <select id="parent-access-player" aria-label="Player" className="auth-input mt-1" value={selectedPlayerId} onChange={(event) => setSelectedPlayerId(event.target.value)} disabled={!selectedTeamId || loadingPlayers}>
                     <option value="">{selectedTeamId ? (loadingPlayers ? 'Loading players...' : players.length ? 'Choose a player' : 'No players found') : 'Choose a team first'}</option>
                     {players.map((player) => (
                       <option key={player.id} value={player.id}>{player.number ? `#${player.number} ` : ''}{player.name}</option>
                     ))}
                   </select>
-                </label>
-                <label className="min-w-0">
-                  <span className="app-label">Relationship</span>
-                  <select className="auth-input mt-1" value={relation} onChange={(event) => setRelation(event.target.value)}>
+                </div>
+                <div className="min-w-0">
+                  <label className="app-label" htmlFor="parent-access-relation">Relationship</label>
+                  <select id="parent-access-relation" aria-label="Relationship" className="auth-input mt-1" value={relation} onChange={(event) => setRelation(event.target.value)}>
                     <option value="Parent">Parent</option>
                     <option value="Guardian">Guardian</option>
                     <option value="Grandparent">Grandparent</option>
                     <option value="Family">Family</option>
                   </select>
-                </label>
+                </div>
                 <button type="submit" className="primary-button lg:col-span-3" disabled={saving || redeeming || loadingTeams || loadingPlayers || !selectedTeamId || !selectedPlayerId}>
                   {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Shield className="h-4 w-4" aria-hidden="true" />}
                   Send request

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -264,10 +264,10 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
     }
   }, []);
 
-  const openManualRequest = useCallback(async () => {
+  const openManualRequest = useCallback(() => {
     setManualRequestOpen(true);
     if (!teams.length && !loadingTeams) {
-      await loadTeams();
+      void loadTeams();
     }
   }, [loadTeams, loadingTeams, teams.length]);
 

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -409,6 +409,11 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
                       <option key={team.id} value={team.id}>{team.name}{team.sport ? ` - ${team.sport}` : ''}</option>
                     ))}
                   </select>
+                  {!loadingTeams && !teams.length ? (
+                    <button type="button" className="ghost-button mt-2 !min-h-9 text-xs" onClick={loadTeams} disabled={redeeming || saving}>
+                      Retry loading public teams
+                    </button>
+                  ) : null}
                 </div>
                 <div className="min-w-0">
                   <label className="app-label" htmlFor="parent-access-player">Player</label>

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -31,6 +31,7 @@ import {
   initiateParentTeamFeeCheckout,
   loadFamilyShareModel,
   loadParentAccessModel,
+  loadParentAccessTeams,
   loadParentAccessPlayers,
   loadParentCalendarTools,
   loadParentCertificates,
@@ -231,10 +232,12 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
   const [teams, setTeams] = useState<ParentAccessTeam[]>([]);
   const [requests, setRequests] = useState<ParentAccessRequest[]>([]);
   const [players, setPlayers] = useState<ParentAccessPlayer[]>([]);
+  const [manualRequestOpen, setManualRequestOpen] = useState(false);
   const [selectedTeamId, setSelectedTeamId] = useState('');
   const [selectedPlayerId, setSelectedPlayerId] = useState('');
   const [relation, setRelation] = useState('Parent');
   const [loading, setLoading] = useState(true);
+  const [loadingTeams, setLoadingTeams] = useState(false);
   const [loadingPlayers, setLoadingPlayers] = useState(false);
   const [saving, setSaving] = useState(false);
   const [redeemCode, setRedeemCode] = useState('');
@@ -244,10 +247,29 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
 
   const loadAccessModel = async () => {
     const model = await loadParentAccessModel(auth.user);
-    setTeams(model.teams);
     setRequests(model.requests);
-    setSelectedTeamId((current) => current || model.teams[0]?.id || '');
   };
+
+  const loadTeams = useCallback(async () => {
+    setLoadingTeams(true);
+    setError('');
+    try {
+      const rows = await loadParentAccessTeams();
+      setTeams(rows);
+      setSelectedTeamId((current) => rows.some((team) => team.id === current) ? current : '');
+    } catch (loadError: any) {
+      setError(loadError?.message || 'Unable to load public teams.');
+    } finally {
+      setLoadingTeams(false);
+    }
+  }, []);
+
+  const openManualRequest = useCallback(() => {
+    setManualRequestOpen(true);
+    if (!teams.length && !loadingTeams) {
+      void loadTeams();
+    }
+  }, [loadTeams, loadingTeams, teams.length]);
 
   const refresh = async () => {
     setLoading(true);
@@ -265,6 +287,14 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
   useEffect(() => {
     void refresh();
     // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [auth.user?.uid]);
+
+  useEffect(() => {
+    setManualRequestOpen(false);
+    setTeams([]);
+    setPlayers([]);
+    setSelectedTeamId('');
+    setSelectedPlayerId('');
   }, [auth.user?.uid]);
 
   useEffect(() => {
@@ -347,7 +377,7 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
         <ToolHeader icon={Shield} title="Request player access" detail="Use this when you do not have an invite code." action={<button type="button" className="ghost-button !min-h-9 text-xs" onClick={refresh} disabled={loading || redeeming}><RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} aria-hidden="true" />Refresh</button>} />
         {error ? <Status tone="error" message={error} /> : null}
         {message ? <Status tone="success" message={message} /> : null}
-        {loading ? <LoadingBlock label="Loading teams" /> : (
+        {loading ? <LoadingBlock label="Loading access tools" /> : (
           <>
             <form className="mt-3 rounded-2xl border border-primary-100 bg-primary-50/60 p-3" onSubmit={redeem}>
               <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
@@ -369,37 +399,50 @@ function AccessTool({ auth, onAccessChanged }: { auth: AuthState; onAccessChange
               </div>
               <p className="mt-2 text-xs font-semibold text-gray-600">Already have an 8-character player invite? Redeem it here and stay in Parent Tools.</p>
             </form>
-            <form className="mt-3 grid gap-3 lg:grid-cols-[1fr_1fr_auto]" onSubmit={submit}>
-              <label className="min-w-0">
-                <span className="app-label">Team</span>
-                <select className="auth-input mt-1" value={selectedTeamId} onChange={(event) => setSelectedTeamId(event.target.value)}>
-                  {teams.length ? teams.map((team) => (
-                    <option key={team.id} value={team.id}>{team.name}{team.sport ? ` - ${team.sport}` : ''}</option>
-                  )) : <option value="">No public teams</option>}
-                </select>
-              </label>
-              <label className="min-w-0">
-                <span className="app-label">Player</span>
-                <select className="auth-input mt-1" value={selectedPlayerId} onChange={(event) => setSelectedPlayerId(event.target.value)} disabled={!selectedTeamId || loadingPlayers}>
-                  {loadingPlayers ? <option value="">Loading players...</option> : players.length ? players.map((player) => (
-                    <option key={player.id} value={player.id}>{player.number ? `#${player.number} ` : ''}{player.name}</option>
-                  )) : <option value="">No players found</option>}
-                </select>
-              </label>
-              <label className="min-w-0">
-                <span className="app-label">Relationship</span>
-                <select className="auth-input mt-1" value={relation} onChange={(event) => setRelation(event.target.value)}>
-                  <option value="Parent">Parent</option>
-                  <option value="Guardian">Guardian</option>
-                  <option value="Grandparent">Grandparent</option>
-                  <option value="Family">Family</option>
-                </select>
-              </label>
-              <button type="submit" className="primary-button lg:col-span-3" disabled={saving || redeeming || loadingPlayers || !selectedTeamId || !selectedPlayerId}>
-                {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Shield className="h-4 w-4" aria-hidden="true" />}
-                Send request
-              </button>
-            </form>
+            {manualRequestOpen ? (
+              <form className="mt-3 grid gap-3 lg:grid-cols-[1fr_1fr_auto]" onSubmit={submit}>
+                <label className="min-w-0">
+                  <span className="app-label">Team</span>
+                  <select className="auth-input mt-1" value={selectedTeamId} onChange={(event) => setSelectedTeamId(event.target.value)} disabled={loadingTeams || !teams.length}>
+                    <option value="">{loadingTeams ? 'Loading public teams...' : teams.length ? 'Choose a team' : 'No public teams'}</option>
+                    {teams.map((team) => (
+                      <option key={team.id} value={team.id}>{team.name}{team.sport ? ` - ${team.sport}` : ''}</option>
+                    ))}
+                  </select>
+                </label>
+                <label className="min-w-0">
+                  <span className="app-label">Player</span>
+                  <select className="auth-input mt-1" value={selectedPlayerId} onChange={(event) => setSelectedPlayerId(event.target.value)} disabled={!selectedTeamId || loadingPlayers}>
+                    <option value="">{selectedTeamId ? (loadingPlayers ? 'Loading players...' : players.length ? 'Choose a player' : 'No players found') : 'Choose a team first'}</option>
+                    {players.map((player) => (
+                      <option key={player.id} value={player.id}>{player.number ? `#${player.number} ` : ''}{player.name}</option>
+                    ))}
+                  </select>
+                </label>
+                <label className="min-w-0">
+                  <span className="app-label">Relationship</span>
+                  <select className="auth-input mt-1" value={relation} onChange={(event) => setRelation(event.target.value)}>
+                    <option value="Parent">Parent</option>
+                    <option value="Guardian">Guardian</option>
+                    <option value="Grandparent">Grandparent</option>
+                    <option value="Family">Family</option>
+                  </select>
+                </label>
+                <button type="submit" className="primary-button lg:col-span-3" disabled={saving || redeeming || loadingTeams || loadingPlayers || !selectedTeamId || !selectedPlayerId}>
+                  {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Shield className="h-4 w-4" aria-hidden="true" />}
+                  Send request
+                </button>
+              </form>
+            ) : (
+              <div className="mt-3 rounded-2xl border border-dashed border-gray-200 bg-white p-3">
+                <div className="text-sm font-black text-gray-950">Need manual access?</div>
+                <p className="mt-1 text-xs font-semibold text-gray-600">Open the manual request form only when you need to search public teams and request access to a player.</p>
+                <button type="button" className="secondary-button mt-3" onClick={openManualRequest} disabled={redeeming || saving || loadingTeams}>
+                  {loadingTeams ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Shield className="h-4 w-4" aria-hidden="true" />}
+                  {loadingTeams ? 'Loading public teams...' : 'Request access without a code'}
+                </button>
+              </div>
+            )}
           </>
         )}
       </section>

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -16,6 +16,8 @@ async function mockParentToolsModules(page) {
         window.__openedPublicUrls = [];
         window.__sharedUrls = [];
         window.__accessRequests = [];
+        window.__publicTeamLoads = 0;
+        window.__playerLoads = [];
         window.__downloads = [];
         window.__familyCreates = [];
         window.__mediaUploads = [];
@@ -93,11 +95,15 @@ async function mockParentToolsModules(page) {
             body: `
                 export async function loadParentAccessModel() {
                     return {
-                        teams: [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }],
                         requests: [{ id: 'request-1', teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat Star', relation: 'Parent', status: 'pending' }]
                     };
                 }
-                export async function loadParentAccessPlayers() {
+                export async function loadParentAccessTeams() {
+                    window.__publicTeamLoads += 1;
+                    return [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }];
+                }
+                export async function loadParentAccessPlayers(teamId) {
+                    window.__playerLoads.push(String(teamId));
                     return [{ id: 'player-1', name: 'Pat Star', number: '9', photoUrl: null }];
                 }
                 export async function submitParentAccessRequest(teamId, playerId, relation) {
@@ -277,6 +283,15 @@ test('parent tools hub completes access, fees, calendars, share, registration, a
 
     await expect(page.getByRole('heading', { name: 'Family workflows' })).toBeVisible({ timeout: 15000 });
     await expect(page.getByText('Request player access')).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Request access without a code' })).toBeVisible();
+    await expect.poll(() => page.evaluate(() => window.__publicTeamLoads)).toBe(0);
+    await expect.poll(() => page.evaluate(() => window.__playerLoads.length)).toBe(0);
+    await expect(page.getByText('Pat Star')).toBeVisible();
+    await page.getByRole('button', { name: 'Request access without a code' }).click();
+    await expect.poll(() => page.evaluate(() => window.__publicTeamLoads)).toBe(1);
+    await page.getByLabel('Team').selectOption('team-1');
+    await expect.poll(() => page.evaluate(() => window.__playerLoads)).toEqual(['team-1']);
+    await page.getByLabel('Player').selectOption('player-1');
     await page.getByRole('button', { name: /Send request/ }).click();
     await expect.poll(() => page.evaluate(() => window.__accessRequests.at(-1))).toEqual({ teamId: 'team-1', playerId: 'player-1', relation: 'Parent' });
 

--- a/tests/smoke/app-parent-tools.spec.js
+++ b/tests/smoke/app-parent-tools.spec.js
@@ -289,6 +289,7 @@ test('parent tools hub completes access, fees, calendars, share, registration, a
     await expect(page.getByText('Pat Star')).toBeVisible();
     await page.getByRole('button', { name: 'Request access without a code' }).click();
     await expect.poll(() => page.evaluate(() => window.__publicTeamLoads)).toBe(1);
+    await expect(page.getByLabel('Team')).toBeVisible();
     await page.getByLabel('Team').selectOption('team-1');
     await expect.poll(() => page.evaluate(() => window.__playerLoads)).toEqual(['team-1']);
     await page.getByLabel('Player').selectOption('player-1');

--- a/tests/unit/app-parent-tools-integration.test.jsx
+++ b/tests/unit/app-parent-tools-integration.test.jsx
@@ -18,6 +18,7 @@ const serviceMocks = vi.hoisted(() => ({
     initiateParentTeamFeeCheckout: vi.fn(),
     loadFamilyShareModel: vi.fn(),
     loadParentAccessModel: vi.fn(),
+    loadParentAccessTeams: vi.fn(),
     loadParentAccessPlayers: vi.fn(),
     loadParentCalendarTools: vi.fn(),
     loadParentCertificates: vi.fn(),
@@ -152,6 +153,16 @@ async function changeSelectValue(element, value) {
     await flush();
 }
 
+async function openManualAccessRequest(container) {
+    await clickButton(container, 'Request access without a code');
+    await waitForText(container, 'Choose a team');
+    const teamSelect = Array.from(container.querySelectorAll('select')).find((candidate) => candidate.previousElementSibling?.textContent === 'Team');
+    await changeSelectValue(teamSelect, 'team-1');
+    await waitForText(container, 'Choose a player');
+    const playerSelect = Array.from(container.querySelectorAll('select')).find((candidate) => candidate.previousElementSibling?.textContent === 'Player');
+    await changeSelectValue(playerSelect, 'player-1');
+}
+
 beforeEach(() => {
     vi.clearAllMocks();
     window.requestAnimationFrame = (callback) => {
@@ -168,9 +179,9 @@ beforeEach(() => {
     URL.revokeObjectURL = vi.fn();
 
     serviceMocks.loadParentAccessModel.mockResolvedValue({
-        teams: [{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }],
         requests: [{ id: 'request-1', teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat Star', relation: 'Parent', status: 'pending' }]
     });
+    serviceMocks.loadParentAccessTeams.mockResolvedValue([{ id: 'team-1', name: 'Bears', sport: 'Basketball', zip: '66210' }]);
     serviceMocks.loadParentAccessPlayers.mockResolvedValue([{ id: 'player-1', name: 'Pat Star', number: '9', photoUrl: null }]);
     serviceMocks.submitParentAccessRequest.mockResolvedValue({ success: true });
     serviceMocks.loadParentHouseholdInviteModel.mockResolvedValue({
@@ -258,6 +269,7 @@ describe('React app parent tools integration', () => {
         const { container } = await renderParentTools('/parent-tools/access');
         await waitForText(container, 'Request player access');
         expect(container.textContent).toContain('Access requests');
+        await openManualAccessRequest(container);
         await submitForm(container, 'Send request');
         expect(serviceMocks.submitParentAccessRequest).toHaveBeenCalledWith('team-1', 'player-1', 'Parent');
 
@@ -331,7 +343,8 @@ describe('React app parent tools integration', () => {
         const { container } = await renderParentTools('/parent-tools/access');
         await waitForText(container, 'Request player access');
         expect(serviceMocks.loadParentAccessModel).toHaveBeenCalledTimes(1);
-        expect(serviceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(1);
+        expect(serviceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(0);
+        expect(serviceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(0);
 
         await clickButton(container, 'Fees');
         await waitForText(container, 'Team dues');
@@ -340,7 +353,8 @@ describe('React app parent tools integration', () => {
         await clickButton(container, 'Access');
         await waitForText(container, 'Request player access');
         expect(serviceMocks.loadParentAccessModel).toHaveBeenCalledTimes(1);
-        expect(serviceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(1);
+        expect(serviceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(0);
+        expect(serviceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(0);
 
         await clickButton(container, 'Register');
         await waitForText(container, 'Summer Camp');
@@ -379,6 +393,7 @@ describe('React app parent tools integration', () => {
 
         await clickButton(container, 'Access');
         await waitForText(container, 'Request player access');
+        await openManualAccessRequest(container);
         await submitForm(container, 'Send request');
         await waitForText(container, 'Access request sent.');
         expect(serviceMocks.loadParentAccessModel).toHaveBeenCalledTimes(2);
@@ -426,6 +441,7 @@ describe('React app parent tools integration', () => {
 
         await clickButton(container, 'Access');
         await waitForText(container, 'Request player access');
+        await openManualAccessRequest(container);
         await submitForm(container, 'Send request');
 
         await clickButton(container, 'Register');
@@ -437,6 +453,26 @@ describe('React app parent tools integration', () => {
         });
         await waitForText(container, 'Summer Camp');
         expect(serviceMocks.loadParentRegistrations).toHaveBeenCalledTimes(2);
+    });
+
+    it('keeps redeem and existing requests usable before manual discovery, then loads teams and players on demand', async () => {
+        const { container } = await renderParentTools('/parent-tools/access');
+        await waitForText(container, 'Request player access');
+        expect(container.textContent).toContain('Access requests');
+        expect(container.textContent).toContain('Pat Star');
+        expect(serviceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(0);
+        expect(serviceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(0);
+
+        await clickButton(container, 'Request access without a code');
+        await waitForText(container, 'Choose a team');
+        expect(serviceMocks.loadParentAccessTeams).toHaveBeenCalledTimes(1);
+        expect(serviceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(0);
+
+        const teamSelect = Array.from(container.querySelectorAll('select')).find((candidate) => candidate.previousElementSibling?.textContent === 'Team');
+        await changeSelectValue(teamSelect, 'team-1');
+        await waitForText(container, 'Choose a player');
+        expect(serviceMocks.loadParentAccessPlayers).toHaveBeenCalledTimes(1);
+        expect(serviceMocks.loadParentAccessPlayers).toHaveBeenCalledWith('team-1');
     });
 
     it('requires confirmation before revoking a family share link', async () => {

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -154,6 +154,7 @@ import {
     getRegistrationUrl,
     loadFamilyShareModel,
     loadParentAccessModel,
+    loadParentAccessTeams,
     loadParentAccessPlayers,
     loadParentCalendarTools,
     loadParentCertificates,
@@ -208,7 +209,7 @@ describe('React app parent tools service', () => {
         expect(getGoogleCalendarFeedUrl(privateFeedUrl)).toBe(`https://calendar.google.com/calendar/render?cid=${encodeURIComponent(privateFeedUrl)}`);
     });
 
-    it('loads public access teams, selectable players, and submits membership requests', async () => {
+    it('loads access requests first, then lazy-loads public teams and players', async () => {
         dbMocks.discoverPublicTeams.mockResolvedValue({
             teams: [
                 { id: 'team-b', name: 'Wolves', isPublic: false },
@@ -227,14 +228,18 @@ describe('React app parent tools service', () => {
         dbMocks.createParentMembershipRequest.mockResolvedValue({ success: true, requestId: 'request-2' });
 
         await expect(loadParentAccessModel(user)).resolves.toMatchObject({
-            teams: [{ id: 'team-a', name: 'Bears', sport: 'Basketball', zip: '66210' }],
+            teams: [],
             requests: [{ id: 'request-1', playerName: 'Pat Star', status: 'pending' }]
         });
+        await expect(loadParentAccessTeams()).resolves.toEqual([
+            { id: 'team-a', name: 'Bears', sport: 'Basketball', zip: '66210' }
+        ]);
         await expect(loadParentAccessPlayers('team-a')).resolves.toEqual([
             { id: 'player-1', name: 'Pat Star', number: '9', photoUrl: null },
             { id: 'player-2', name: 'Sam Wing', number: '12', photoUrl: 'https://img.example.test/sam.png' }
         ]);
-        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledWith({ pageSize: 100 });
+        expect(dbMocks.listMyParentMembershipRequests).toHaveBeenCalledWith('user-1');
+        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledWith({ pageSize: 25 });
         await submitParentAccessRequest('team-a', 'player-1', 'Guardian');
         expect(dbMocks.createParentMembershipRequest).toHaveBeenCalledWith('team-a', 'player-1', 'Guardian');
     });

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -239,7 +239,7 @@ describe('React app parent tools service', () => {
             { id: 'player-2', name: 'Sam Wing', number: '12', photoUrl: 'https://img.example.test/sam.png' }
         ]);
         expect(dbMocks.listMyParentMembershipRequests).toHaveBeenCalledWith('user-1');
-        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledWith({ pageSize: 25 });
+        expect(dbMocks.discoverPublicTeams).toHaveBeenCalledWith({ pageSize: 100 });
         await submitParentAccessRequest('team-a', 'player-1', 'Guardian');
         expect(dbMocks.createParentMembershipRequest).toHaveBeenCalledWith('team-a', 'player-1', 'Guardian');
     });


### PR DESCRIPTION
Closes #1933

## What changed
- split Parent Tools access loading into a lightweight initial fetch that only loads existing parent membership requests
- added `loadParentAccessTeams()` so public team discovery happens only after the parent opens the manual request form
- stopped auto-selecting the first team, so player loading now waits for an explicit team choice
- updated Parent Tools page, service, integration, and smoke coverage to lock in the deferred fetch sequence

## Root Cause
The access tab mixed first-paint request/redeem data with the heavier manual-request chooser. `loadParentAccessModel()` eagerly called `discoverPublicTeams({ pageSize: 100 })`, and the page auto-selected the first returned team, which immediately triggered `loadParentAccessPlayers()` before the parent had shown intent to start a manual request.

## Prevention / Learning
Keep initial route loads limited to data required for the first useful paint. Optional workflows like team discovery, pickers, and dependent selects should lazy-load behind explicit user intent, and dependent selectors should not auto-select values that trigger more network work.

## Regression Tests
- `npx vitest run apps/app/src/pages/ParentTools.test.tsx tests/unit/app-parent-tools-service.test.js tests/unit/app-parent-tools-integration.test.jsx --reporter=verbose`
- updated `apps/app/src/pages/ParentTools.test.tsx` to prove initial access render does not load teams or players until manual access starts
- updated `tests/unit/app-parent-tools-integration.test.jsx` to prove redeem/existing-request UI stays usable before discovery and that teams/players load on demand
- updated `tests/unit/app-parent-tools-service.test.js` to prove access requests load separately from deferred public-team discovery