### PR TITLE
Load Team Media albums on demand

### DIFF
--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -198,6 +198,7 @@ export type TeamMediaFolder = Record<string, any> & {
   id: string;
   itemCount: number;
   items: TeamMediaItem[];
+  itemsLoaded?: boolean;
 };
 
 export type TeamMediaItem = Record<string, any> & {
@@ -707,7 +708,11 @@ function getPublicRegistrationTeamName(form: Record<string, any>) {
   return compactString(form.teamName || form.team?.name || form.organizationName || form.clubName) || 'Team';
 }
 
-export async function loadTeamMediaForApp(user: AuthUser | null, teamId: string): Promise<TeamMediaModel> {
+export async function loadTeamMediaForApp(
+  user: AuthUser | null,
+  teamId: string,
+  options: { initialFolderId?: string; folderIds?: string[] } = {}
+): Promise<TeamMediaModel> {
   if (!teamId) throw new Error('Team is required.');
   const team = await Promise.resolve(getTeam(teamId));
   if (!team) throw new Error('Team not found.');
@@ -719,18 +724,37 @@ export async function loadTeamMediaForApp(user: AuthUser | null, teamId: string)
   const folders = await Promise.resolve(getTeamMediaFolders(teamId, { includePrivate: canManage }));
   const visibleFolders = (folders || [])
     .filter((folder: any) => canManage || canReadTeamMediaAlbum(folder, false));
-  const itemSets = await Promise.all(visibleFolders.map((folder: any) => (
-    Promise.resolve(getTeamMediaItems(teamId, folder.id)).catch(() => [])
-  )));
-  const folderCards = visibleFolders.map((folder: any, index: number) => {
-    const items = sortByMediaOrder(itemSets[index] || [])
+  const requestedFolderIds = new Set(
+    (Array.isArray(options.folderIds) ? options.folderIds : [])
+      .map((folderId) => compactString(folderId))
+      .filter(Boolean)
+  );
+  const initialFolderId = compactString(options.initialFolderId);
+  if (!requestedFolderIds.size) {
+    const fallbackFolderId = initialFolderId || compactString(visibleFolders[0]?.id);
+    if (fallbackFolderId) requestedFolderIds.add(fallbackFolderId);
+  }
+
+  const itemSets = new Map<string, TeamMediaItem[]>();
+  await Promise.all(visibleFolders.map(async (folder: any) => {
+    const folderId = compactString(folder?.id);
+    if (!folderId || !requestedFolderIds.has(folderId)) return;
+    const items = sortByMediaOrder(await Promise.resolve(getTeamMediaItems(teamId, folderId)).catch(() => []))
       .map(toTeamMediaItem)
       .filter((item: TeamMediaItem) => item.url && isSafeTeamMediaUrl(item.url));
+    itemSets.set(folderId, items);
+  }));
+
+  const folderCards = visibleFolders.map((folder: any) => {
+    const folderId = compactString(folder?.id);
+    const loadedItems = itemSets.get(folderId);
+    const fallbackCount = Number(folder?.itemCount ?? folder?.mediaCount ?? folder?.totalItems ?? 0);
     return {
       ...folder,
-      id: folder.id,
-      itemCount: items.length,
-      items
+      id: folderId,
+      itemCount: loadedItems ? loadedItems.length : Number.isFinite(fallbackCount) && fallbackCount >= 0 ? fallbackCount : 0,
+      items: loadedItems || [],
+      itemsLoaded: Boolean(loadedItems)
     };
   });
 

--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -736,23 +736,31 @@ export async function loadTeamMediaForApp(
   }
 
   const itemSets = new Map<string, TeamMediaItem[]>();
+  const fallbackCounts = new Map<string, number>();
   await Promise.all(visibleFolders.map(async (folder: any) => {
     const folderId = compactString(folder?.id);
-    if (!folderId || !requestedFolderIds.has(folderId)) return;
+    if (!folderId) return;
+    const storedCount = getStoredMediaCount(folder);
+    const shouldLoadItems = requestedFolderIds.has(folderId);
+    if (!shouldLoadItems && storedCount !== null) {
+      fallbackCounts.set(folderId, storedCount);
+      return;
+    }
     const items = sortByMediaOrder(await Promise.resolve(getTeamMediaItems(teamId, folderId)).catch(() => []))
       .map(toTeamMediaItem)
       .filter((item: TeamMediaItem) => item.url && isSafeTeamMediaUrl(item.url));
-    itemSets.set(folderId, items);
+    fallbackCounts.set(folderId, items.length);
+    if (shouldLoadItems) itemSets.set(folderId, items);
   }));
 
   const folderCards = visibleFolders.map((folder: any) => {
     const folderId = compactString(folder?.id);
     const loadedItems = itemSets.get(folderId);
-    const fallbackCount = Number(folder?.itemCount ?? folder?.mediaCount ?? folder?.totalItems ?? 0);
+    const fallbackCount = fallbackCounts.get(folderId);
     return {
       ...folder,
       id: folderId,
-      itemCount: loadedItems ? loadedItems.length : Number.isFinite(fallbackCount) && fallbackCount >= 0 ? fallbackCount : 0,
+      itemCount: loadedItems ? loadedItems.length : Number.isFinite(fallbackCount) ? fallbackCount : 0,
       items: loadedItems || [],
       itemsLoaded: Boolean(loadedItems)
     };
@@ -881,6 +889,11 @@ function toTeamMediaItem(item: any): TeamMediaItem {
     title: compactString(item.title || item.fileName || item.name) || (item.type === 'file' ? 'File' : item.type === 'photo' ? 'Photo' : 'Media'),
     type: compactString(item.type || item.mediaType) || 'media'
   };
+}
+
+function getStoredMediaCount(folder: any) {
+  const count = Number(folder?.itemCount ?? folder?.mediaCount ?? folder?.totalItems);
+  return Number.isFinite(count) && count >= 0 ? count : null;
 }
 
 function normalizeFamilyChildren(children: any[]) {

--- a/apps/app/src/pages/TeamMedia.tsx
+++ b/apps/app/src/pages/TeamMedia.tsx
@@ -67,13 +67,23 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
 
-  const refresh = async ({ showLoading = model === null, preferredFolderId = '' }: { showLoading?: boolean; preferredFolderId?: string } = {}) => {
+  const refresh = async ({ showLoading = model === null, preferredFolderId = '', folderIdsToLoad = [] }: { showLoading?: boolean; preferredFolderId?: string; folderIdsToLoad?: string[] } = {}) => {
     if (!teamId) return;
     if (showLoading) setLoading(true);
     setError('');
     try {
-      const nextModel = await loadTeamMediaForApp(auth.user, teamId);
-      setModel(nextModel);
+      const nextModel = await loadTeamMediaForApp(auth.user, teamId, {
+        initialFolderId: preferredFolderId || activeFolderId,
+        folderIds: folderIdsToLoad
+      });
+      setModel((currentModel) => ({
+        ...nextModel,
+        folders: nextModel.folders.map((folder) => {
+          if (folder.itemsLoaded || folder.items.length) return { ...folder, itemsLoaded: true };
+          const cachedFolder = currentModel?.folders.find((currentFolder) => currentFolder.id === folder.id && (currentFolder.itemsLoaded || currentFolder.items.length));
+          return cachedFolder ? { ...folder, items: cachedFolder.items, itemCount: cachedFolder.itemCount, itemsLoaded: true } : folder;
+        })
+      }));
       setActiveFolderId((current) => {
         if (preferredFolderId && nextModel.folders.some((folder) => folder.id === preferredFolderId)) return preferredFolderId;
         if (current && nextModel.folders.some((folder) => folder.id === current)) return current;
@@ -130,7 +140,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
     try {
       await deleteTeamMediaItemForApp(teamId, item);
       setMessage('Media item deleted.');
-      await refresh({ showLoading: false });
+      await refresh({ showLoading: false, preferredFolderId: activeFolder?.id || '', folderIdsToLoad: activeFolder?.id ? [activeFolder.id] : [] });
     } catch (deleteError: any) {
       setError(deleteError?.message || 'Unable to delete media item.');
     } finally {
@@ -151,7 +161,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
     setMessage('');
     try {
       await moveTeamMediaItemForApp(teamId, item.id, targetFolderId);
-      await refresh({ showLoading: false, preferredFolderId: targetFolderId });
+      await refresh({ showLoading: false, preferredFolderId: targetFolderId, folderIdsToLoad: [activeFolder?.id || '', targetFolderId].filter(Boolean) });
       const destinationName = model?.folders.find((folder) => folder.id === targetFolderId)?.name || 'the selected album';
       setMessage(`Media item moved to ${destinationName}.`);
     } catch (moveError: any) {
@@ -179,7 +189,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
         } : folder)
       } : current);
       setMessage('Album cover saved.');
-      await refresh({ showLoading: false, preferredFolderId: activeFolder.id });
+      await refresh({ showLoading: false, preferredFolderId: activeFolder.id, folderIdsToLoad: [activeFolder.id] });
     } catch (coverError: any) {
       setError(coverError?.message || 'Unable to save album cover.');
     } finally {
@@ -232,7 +242,8 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   }, [auth.user?.uid, teamId]);
 
   const activeFolder = useMemo(() => model?.folders.find((folder) => folder.id === activeFolderId) || model?.folders[0] || null, [activeFolderId, model]);
-  const allItems = useMemo(() => model?.folders.flatMap((folder) => folder.items.map((item) => ({ ...item, folderName: folder.name || 'Album' }))) || [], [model]);
+  const totalItemCount = useMemo(() => (model?.folders || []).reduce((sum, folder) => sum + (Number(folder.itemCount) || 0), 0), [model]);
+  const loadedItems = useMemo(() => model?.folders.flatMap((folder) => folder.items.map((item) => ({ ...item, folderName: folder.name || 'Album' }))) || [], [model]);
   const mediaTypeCounts = useMemo(() => getMediaTypeCounts(activeFolder?.items || []), [activeFolder]);
   const filteredItems = useMemo(() => (activeFolder?.items || []).filter((item) => matchesMediaTypeFilter(item, selectedMediaType)), [activeFolder, selectedMediaType]);
   const visibleItemIds = useMemo(() => filteredItems.map((item) => item.id).filter(Boolean), [filteredItems]);
@@ -240,7 +251,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
   const selectedCount = selectedItems.length;
   const selectedMediaTypeLabel = MEDIA_TYPE_FILTERS.find((filter) => filter.id === selectedMediaType)?.label || 'All';
   const emptyStateLabel = selectedMediaType === 'all' ? 'media' : selectedMediaTypeLabel.toLowerCase();
-  const featured = activeFolder ? getFolderCoverMedia(activeFolder) || allItems[0] || null : allItems[0] || null;
+  const featured = activeFolder ? getFolderCoverMedia(activeFolder) || loadedItems[0] || null : loadedItems[0] || null;
 
   useEffect(() => {
     setSelectedIds((current) => current.filter((itemId) => visibleItemIds.includes(itemId)));
@@ -263,7 +274,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
     try {
       await bulkDeleteTeamMediaItemsForApp(teamId, selectedItems);
       setSelectedIds([]);
-      await refresh({ showLoading: false, preferredFolderId: activeFolder?.id || '' });
+      await refresh({ showLoading: false, preferredFolderId: activeFolder?.id || '', folderIdsToLoad: activeFolder?.id ? [activeFolder.id] : [] });
       setMessage(`${deleteCount} media item${deleteCount === 1 ? '' : 's'} deleted.`);
     } catch (deleteError: any) {
       setError(deleteError?.message || 'Unable to delete selected media items.');
@@ -307,7 +318,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
 
       if (uploaded > 0) {
         const resultMessage = getPhotoUploadMessage(uploaded, failed);
-        await refresh({ showLoading: false, preferredFolderId: activeFolder.id });
+        await refresh({ showLoading: false, preferredFolderId: activeFolder.id, folderIdsToLoad: [activeFolder.id] });
         if (failed > 0) {
           setError(resultMessage);
           setMessage('');
@@ -354,7 +365,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
       }
 
       if (uploaded > 0) {
-        await refresh({ showLoading: false, preferredFolderId: activeFolder.id });
+        await refresh({ showLoading: false, preferredFolderId: activeFolder.id, folderIdsToLoad: [activeFolder.id] });
         const resultMessage = getFileUploadMessage(uploaded, failed);
         if (failed > 0) {
           setError(resultMessage);
@@ -383,7 +394,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
       const folderId = await createTeamMediaAlbumForApp(teamId, { name, visibility: albumVisibility });
       setMessage('Album created. You can add photos, files, or links now.');
       setAlbumName('');
-      await refresh({ showLoading: false, preferredFolderId: String(folderId || '') });
+      await refresh({ showLoading: false, preferredFolderId: String(folderId || ''), folderIdsToLoad: folderId ? [String(folderId)] : [] });
     } catch (albumError: any) {
       setError(albumError?.message || 'Unable to create album. Check your connection and permissions, then try again.');
     } finally {
@@ -402,7 +413,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
       setMessage('Media link added.');
       setLinkTitle('');
       setLinkUrl('');
-      await refresh({ showLoading: false });
+      await refresh({ showLoading: false, preferredFolderId: activeFolder.id, folderIdsToLoad: [activeFolder.id] });
     } catch (linkError: any) {
       setError(linkError?.message || 'Unable to add media link.');
     } finally {
@@ -447,7 +458,7 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
           <div className="min-w-0 flex-1">
             <div className="app-label">Team media</div>
             <h1 className="truncate text-xl font-black leading-tight text-gray-950">{model.team.name || 'Team'} media</h1>
-            <p className="mt-0.5 truncate text-xs font-semibold text-gray-600">{model.folders.length} albums - {allItems.length} items</p>
+            <p className="mt-0.5 truncate text-xs font-semibold text-gray-600">{model.folders.length} albums - {totalItemCount} items</p>
           </div>
           <button type="button" className="ghost-button !h-9 !min-h-9 !w-9 !flex-none !p-0 sm:!w-auto sm:!px-3 text-xs" onClick={() => refresh({ showLoading: false })} disabled={Boolean(uploading) || creatingAlbum} aria-label="Refresh media" title="Refresh media">
             <RefreshCw className={`h-4 w-4 ${uploading || creatingAlbum ? 'animate-spin' : ''}`} aria-hidden="true" />
@@ -461,9 +472,13 @@ export function TeamMedia({ auth }: { auth: AuthState }) {
               type="button"
               className={`flex min-h-9 flex-none items-center gap-2 rounded-full border px-2 py-1 text-xs font-black ${activeFolder?.id === folder.id ? 'border-primary-600 bg-primary-600 text-white' : 'border-gray-200 bg-gray-50 text-gray-700'}`}
               onClick={() => {
-                setActiveFolderId(folder.id);
                 setSelectedMediaType('all');
                 setSelectedIds([]);
+                if (folder.itemsLoaded || folder.items.length) {
+                  setActiveFolderId(folder.id);
+                  return;
+                }
+                void refresh({ showLoading: false, preferredFolderId: folder.id, folderIdsToLoad: [folder.id] });
               }}
               aria-pressed={activeFolder?.id === folder.id}
             >

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -721,17 +721,20 @@ describe('React app parent tools service', () => {
         expect(dbMocks.listCertificatesForPlayer).toHaveBeenCalledWith('team-1', 'player-1', { status: 'published', limit: 25 });
     });
 
-    it('loads team media, filters unsafe items, and exposes upload/link helpers', async () => {
+    it('loads only the requested team media album items and leaves other albums lazy', async () => {
         const photoFile = new File(['photo'], 'photo.jpg', { type: 'image/jpeg' });
         const docFile = new File(['doc'], 'packet.pdf', { type: 'application/pdf' });
         dbMocks.getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears' });
         dbMocks.getTeamMediaFolders.mockResolvedValue([
-            { id: 'folder-1', name: 'Game photos', visibility: 'team', order: 2 },
-            { id: 'folder-private', name: 'Private', visibility: 'private', order: 1 }
+            { id: 'folder-1', name: 'Game photos', visibility: 'team', order: 2, itemCount: 4 },
+            { id: 'folder-2', name: 'Game video', visibility: 'team', order: 3, itemCount: 2 },
+            { id: 'folder-private', name: 'Private', visibility: 'private', order: 1, itemCount: 9 }
         ]);
         dbMocks.getTeamMediaItems.mockImplementation(async (teamId, folderId) => (folderId === 'folder-1' ? [
             { id: 'bad', title: 'Bad', type: 'photo', url: 'javascript:alert(1)', order: 1 },
             { id: 'photo-1', title: 'Tipoff', type: 'photo', url: 'https://img.example.test/photo.jpg', order: 0 }
+        ] : folderId === 'folder-2' ? [
+            { id: 'video-1', title: 'Replay', type: 'video_link', url: 'https://video.example.test/replay', order: 0 }
         ] : []));
         dbMocks.uploadTeamMediaPhoto.mockResolvedValue('photo-2');
         dbMocks.uploadTeamMediaFile.mockResolvedValue('file-1');
@@ -743,12 +746,32 @@ describe('React app parent tools service', () => {
             canManage: false,
             canContribute: true,
             canPostChat: true,
-            folders: [{
-                id: 'folder-1',
-                itemCount: 1,
-                items: [{ id: 'photo-1', title: 'Tipoff', type: 'photo', url: 'https://img.example.test/photo.jpg' }]
-            }]
+            folders: [
+                {
+                    id: 'folder-1',
+                    itemCount: 1,
+                    itemsLoaded: true,
+                    items: [{ id: 'photo-1', title: 'Tipoff', type: 'photo', url: 'https://img.example.test/photo.jpg' }]
+                },
+                {
+                    id: 'folder-2',
+                    itemCount: 2,
+                    itemsLoaded: false,
+                    items: []
+                }
+            ]
         });
+        expect(dbMocks.getTeamMediaItems).toHaveBeenCalledTimes(1);
+        expect(dbMocks.getTeamMediaItems).toHaveBeenCalledWith('team-1', 'folder-1');
+
+        await expect(loadTeamMediaForApp(user, 'team-1', { folderIds: ['folder-2'] })).resolves.toMatchObject({
+            folders: [
+                { id: 'folder-1', itemCount: 4, itemsLoaded: false, items: [] },
+                { id: 'folder-2', itemCount: 1, itemsLoaded: true, items: [{ id: 'video-1', title: 'Replay' }] }
+            ]
+        });
+        expect(dbMocks.getTeamMediaItems).toHaveBeenCalledTimes(2);
+        expect(dbMocks.getTeamMediaItems).toHaveBeenLastCalledWith('team-1', 'folder-2');
 
         await expect(createTeamMediaAlbumForApp('team-1', { name: '  Spring photos  ', visibility: 'private' })).resolves.toBe('folder-new');
         await uploadParentTeamMediaPhoto('team-1', 'folder-1', photoFile);

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -727,7 +727,8 @@ describe('React app parent tools service', () => {
         dbMocks.getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears' });
         dbMocks.getTeamMediaFolders.mockResolvedValue([
             { id: 'folder-1', name: 'Game photos', visibility: 'team', order: 2, itemCount: 4 },
-            { id: 'folder-2', name: 'Game video', visibility: 'team', order: 3, itemCount: 2 },
+            { id: 'folder-2', name: 'Game video', visibility: 'team', order: 3 },
+            { id: 'folder-3', name: 'Highlights', visibility: 'team', order: 4, itemCount: 2 },
             { id: 'folder-private', name: 'Private', visibility: 'private', order: 1, itemCount: 9 }
         ]);
         dbMocks.getTeamMediaItems.mockImplementation(async (teamId, folderId) => (folderId === 'folder-1' ? [
@@ -735,6 +736,8 @@ describe('React app parent tools service', () => {
             { id: 'photo-1', title: 'Tipoff', type: 'photo', url: 'https://img.example.test/photo.jpg', order: 0 }
         ] : folderId === 'folder-2' ? [
             { id: 'video-1', title: 'Replay', type: 'video_link', url: 'https://video.example.test/replay', order: 0 }
+        ] : folderId === 'folder-3' ? [
+            { id: 'highlight-1', title: 'Highlight', type: 'photo', url: 'https://img.example.test/highlight.jpg', order: 0 }
         ] : []));
         dbMocks.uploadTeamMediaPhoto.mockResolvedValue('photo-2');
         dbMocks.uploadTeamMediaFile.mockResolvedValue('file-1');
@@ -755,22 +758,30 @@ describe('React app parent tools service', () => {
                 },
                 {
                     id: 'folder-2',
+                    itemCount: 1,
+                    itemsLoaded: false,
+                    items: []
+                },
+                {
+                    id: 'folder-3',
                     itemCount: 2,
                     itemsLoaded: false,
                     items: []
                 }
             ]
         });
-        expect(dbMocks.getTeamMediaItems).toHaveBeenCalledTimes(1);
-        expect(dbMocks.getTeamMediaItems).toHaveBeenCalledWith('team-1', 'folder-1');
+        expect(dbMocks.getTeamMediaItems).toHaveBeenCalledTimes(2);
+        expect(dbMocks.getTeamMediaItems).toHaveBeenNthCalledWith(1, 'team-1', 'folder-1');
+        expect(dbMocks.getTeamMediaItems).toHaveBeenNthCalledWith(2, 'team-1', 'folder-2');
 
         await expect(loadTeamMediaForApp(user, 'team-1', { folderIds: ['folder-2'] })).resolves.toMatchObject({
             folders: [
                 { id: 'folder-1', itemCount: 4, itemsLoaded: false, items: [] },
-                { id: 'folder-2', itemCount: 1, itemsLoaded: true, items: [{ id: 'video-1', title: 'Replay' }] }
+                { id: 'folder-2', itemCount: 1, itemsLoaded: true, items: [{ id: 'video-1', title: 'Replay' }] },
+                { id: 'folder-3', itemCount: 2, itemsLoaded: false, items: [] }
             ]
         });
-        expect(dbMocks.getTeamMediaItems).toHaveBeenCalledTimes(2);
+        expect(dbMocks.getTeamMediaItems).toHaveBeenCalledTimes(3);
         expect(dbMocks.getTeamMediaItems).toHaveBeenLastCalledWith('team-1', 'folder-2');
 
         await expect(createTeamMediaAlbumForApp('team-1', { name: '  Spring photos  ', visibility: 'private' })).resolves.toBe('folder-new');

--- a/tests/unit/app-team-media.test.jsx
+++ b/tests/unit/app-team-media.test.jsx
@@ -566,6 +566,7 @@ describe('React app TeamMedia move flow', () => {
         name: 'Album A',
         visibility: 'team',
         itemCount: 1,
+        itemsLoaded: true,
         items: [{ id: 'owned-photo', title: 'Tipoff', type: 'photo', url: 'https://example.test/tipoff.jpg', uploadedBy: 'user-1' }],
       },
       {
@@ -573,6 +574,7 @@ describe('React app TeamMedia move flow', () => {
         name: 'Album B',
         visibility: 'team',
         itemCount: 0,
+        itemsLoaded: true,
         items: [],
       },
     ],
@@ -608,8 +610,8 @@ describe('React app TeamMedia move flow', () => {
     const initialModel = twoAlbumModel();
     const movedModel = twoAlbumModel();
     movedModel.folders = [
-      { ...initialModel.folders[0], itemCount: 0, items: [] },
-      { ...initialModel.folders[1], itemCount: 1, items: initialModel.folders[0].items },
+      { ...initialModel.folders[0], itemCount: 0, itemsLoaded: true, items: [] },
+      { ...initialModel.folders[1], itemCount: 1, itemsLoaded: true, items: initialModel.folders[0].items },
     ];
     parentToolsServiceMocks.loadTeamMediaForApp
       .mockResolvedValueOnce(initialModel)
@@ -628,9 +630,143 @@ describe('React app TeamMedia move flow', () => {
     });
 
     expect(parentToolsServiceMocks.moveTeamMediaItemForApp).toHaveBeenCalledWith('team-1', 'owned-photo', 'folder-2');
+    expect(parentToolsServiceMocks.loadTeamMediaForApp).toHaveBeenLastCalledWith(auth.user, 'team-1', {
+      initialFolderId: 'folder-2',
+      folderIds: ['folder-1', 'folder-2'],
+    });
     expect(container.textContent).toContain('Media item moved to Album B.');
     expect(container.textContent).toContain('Album B');
     expect(container.textContent).toContain('Tipoff');
+
+    await act(async () => root.unmount());
+  });
+
+  it('lazy-loads unopened albums once and reuses the cached album on later switches', async () => {
+    const initialModel = mediaModel({
+      canManage: true,
+      folders: [
+        {
+          id: 'folder-1',
+          name: 'Album A',
+          visibility: 'team',
+          itemCount: 1,
+          itemsLoaded: true,
+          items: [{ id: 'owned-photo', title: 'Tipoff', type: 'photo', url: 'https://example.test/tipoff.jpg', uploadedBy: 'user-1' }],
+        },
+        {
+          id: 'folder-2',
+          name: 'Album B',
+          visibility: 'team',
+          itemCount: 1,
+          itemsLoaded: false,
+          items: [],
+        },
+      ],
+    });
+    const hydratedModel = mediaModel({
+      canManage: true,
+      folders: [
+        initialModel.folders[0],
+        {
+          id: 'folder-2',
+          name: 'Album B',
+          visibility: 'team',
+          itemCount: 1,
+          itemsLoaded: true,
+          items: [{ id: 'video-1', title: 'Replay', type: 'video_link', url: 'https://example.test/replay', uploadedBy: 'user-1' }],
+        },
+      ],
+    });
+    parentToolsServiceMocks.loadTeamMediaForApp
+      .mockResolvedValueOnce(initialModel)
+      .mockResolvedValueOnce(hydratedModel);
+
+    const { container, root } = await renderTeamMedia(initialModel);
+
+    expect(parentToolsServiceMocks.loadTeamMediaForApp).toHaveBeenNthCalledWith(1, auth.user, 'team-1', {
+      initialFolderId: '',
+      folderIds: [],
+    });
+
+    click(Array.from(container.querySelectorAll('button')).find((button) => button.textContent.includes('Album B')));
+    await act(async () => {});
+
+    expect(parentToolsServiceMocks.loadTeamMediaForApp).toHaveBeenNthCalledWith(2, auth.user, 'team-1', {
+      initialFolderId: 'folder-2',
+      folderIds: ['folder-2'],
+    });
+    expect(container.textContent).toContain('Replay');
+
+    click(Array.from(container.querySelectorAll('button')).find((button) => button.textContent.includes('Album A')));
+    click(Array.from(container.querySelectorAll('button')).find((button) => button.textContent.includes('Album B')));
+    await act(async () => {});
+
+    expect(parentToolsServiceMocks.loadTeamMediaForApp).toHaveBeenCalledTimes(2);
+
+    await act(async () => root.unmount());
+  });
+
+  it('refreshes only the active album after a delete', async () => {
+    globalThis.confirm = vi.fn(() => true);
+    const initialModel = mediaModel({
+      canManage: true,
+      folders: [
+        {
+          id: 'folder-1',
+          name: 'Album A',
+          visibility: 'team',
+          itemCount: 1,
+          itemsLoaded: true,
+          items: [{ id: 'owned-photo', title: 'Tipoff', type: 'photo', url: 'https://example.test/tipoff.jpg', uploadedBy: 'user-1' }],
+        },
+        {
+          id: 'folder-2',
+          name: 'Album B',
+          visibility: 'team',
+          itemCount: 3,
+          itemsLoaded: false,
+          items: [],
+        },
+      ],
+    });
+    const refreshedModel = mediaModel({
+      canManage: true,
+      folders: [
+        {
+          id: 'folder-1',
+          name: 'Album A',
+          visibility: 'team',
+          itemCount: 0,
+          itemsLoaded: true,
+          items: [],
+        },
+        {
+          id: 'folder-2',
+          name: 'Album B',
+          visibility: 'team',
+          itemCount: 3,
+          itemsLoaded: false,
+          items: [],
+        },
+      ],
+    });
+    parentToolsServiceMocks.loadTeamMediaForApp
+      .mockResolvedValueOnce(initialModel)
+      .mockResolvedValueOnce(refreshedModel);
+
+    const { container, root } = await renderTeamMedia(initialModel);
+
+    await act(async () => {
+      container.querySelector('[aria-label="Delete Tipoff"]').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(parentToolsServiceMocks.deleteTeamMediaItemForApp).toHaveBeenCalledWith('team-1', expect.objectContaining({ id: 'owned-photo' }));
+    expect(parentToolsServiceMocks.loadTeamMediaForApp).toHaveBeenLastCalledWith(auth.user, 'team-1', {
+      initialFolderId: 'folder-1',
+      folderIds: ['folder-1'],
+    });
+    expect(container.textContent).toContain('Media item deleted.');
+    expect(container.textContent).toContain('No media in this album.');
 
     await act(async () => root.unmount());
   });


### PR DESCRIPTION
Closes #1905

## What changed
- changed `loadTeamMediaForApp` to return folder metadata for every visible album but hydrate item lists only for the requested initial album or explicitly requested folder ids
- added `itemsLoaded` state so the Team Media page can distinguish cached albums from metadata-only albums
- updated `TeamMedia.tsx` to lazy-load unopened albums on tab switch, reuse loaded album contents in-session, and refresh only the affected album(s) after delete, move, upload, add-link, create-album, and cover-update flows
- replaced the header-wide item flatten count with metadata-based album totals so the page no longer depends on eagerly loaded item arrays

## Root Cause
`loadTeamMediaForApp` eagerly ran `Promise.all(getTeamMediaItems(...))` for every visible album and `TeamMedia.tsx` reused that full-hydration contract for initial load and every mutation refresh. That made one active-album workflow pay the cost of loading unrelated albums and rebuilding flattened item state.

## Prevention / Learning
For album- or tab-scoped UIs, keep collection metadata and child-item hydration separate. Load only the active scope up front, cache hydrated scopes explicitly, and make mutation refresh APIs accept the smallest affected scope instead of defaulting to full-library reloads.

## Regression Tests
- updated `tests/unit/app-parent-tools-service.test.js` to prove initial Team Media load hydrates only one album and that targeted folder requests load only the requested album
- updated `tests/unit/app-team-media.test.jsx` to prove unopened albums lazy-load once, cached albums do not refetch on later switches, and delete/move flows refresh only the affected album ids

## Recurrence Risk
Low: the service and page now both have focused regression coverage around scoped album hydration and scoped refresh behavior.