### PR TITLE
Honor game-day event detail deep links

### DIFF
--- a/apps/app/src/lib/pushNotificationRouting.ts
+++ b/apps/app/src/lib/pushNotificationRouting.ts
@@ -31,6 +31,17 @@ function buildMessagesRoute(teamId: string, conversationId?: string) {
     return `${route}?conversationId=${encodeRouteParam(normalizedConversationId)}`;
 }
 
+function buildScheduleEventRoute(teamId: string, eventId: string, section?: string) {
+    const normalizedTeamId = normalizeValue(teamId);
+    const normalizedEventId = normalizeValue(eventId);
+    if (!normalizedTeamId || !normalizedEventId) {
+        return '';
+    }
+    const route = `/schedule/${encodeRouteParam(normalizedTeamId)}/${encodeRouteParam(normalizedEventId)}`;
+    const normalizedSection = normalizeValue(section);
+    return normalizedSection ? `${route}?section=${encodeRouteParam(normalizedSection)}` : route;
+}
+
 function normalizeAppRoute(route: unknown) {
     const value = normalizeValue(route);
     if (!value.startsWith('/')) {
@@ -63,13 +74,13 @@ function buildLegacyLinkFallback(link: string) {
         }
         if (path.endsWith('/live-game.html') && gameId) {
             if (teamId) {
-                return `/schedule/${encodeRouteParam(teamId)}/${encodeRouteParam(gameId)}`;
+                return buildScheduleEventRoute(teamId, gameId, 'game');
             }
             return '/schedule';
         }
         if (path.endsWith('/game-day.html')) {
             if (teamId && gameId) {
-                return `/schedule/${encodeRouteParam(teamId)}/${encodeRouteParam(gameId)}`;
+                return buildScheduleEventRoute(teamId, gameId, 'game');
             }
             if (gameId) {
                 return `/games/${encodeRouteParam(gameId)}`;
@@ -106,7 +117,7 @@ export function resolvePushNotificationRoute(input: unknown) {
     }
     if (category === 'liveScore' && gameId) {
         if (teamId) {
-            return `/schedule/${encodeRouteParam(teamId)}/${encodeRouteParam(gameId)}`;
+            return buildScheduleEventRoute(teamId, gameId, 'game');
         }
         return `/games/${encodeRouteParam(gameId)}`;
     }

--- a/apps/app/src/pages/GameDetail.test.tsx
+++ b/apps/app/src/pages/GameDetail.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
-import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const scheduleServiceMocks = vi.hoisted(() => ({
@@ -31,6 +31,11 @@ const auth: AuthState = {
   signOut: vi.fn()
 }
 
+function LocationProbe() {
+  const location = useLocation()
+  return <div data-testid="location">{`${location.pathname}${location.search}`}</div>
+}
+
 function renderGameDetail(path = '/games/game-1') {
   return render(
     <MemoryRouter initialEntries={[path]}>
@@ -41,7 +46,9 @@ function renderGameDetail(path = '/games/game-1') {
             <h1>Availability</h1>
             <div>Rideshare</div>
             <div>Assignments</div>
+            <div>Game hub</div>
             <div>Live event workflow</div>
+            <LocationProbe />
           </div>
         )}
         />
@@ -60,7 +67,7 @@ describe('GameDetail route resolution', () => {
     cleanup()
   })
 
-  it('routes /games/:gameId into the schedule event detail workflow', async () => {
+  it('routes /games/:gameId into the schedule event detail workflow with game section context', async () => {
     scheduleServiceMocks.resolveParentGameRoute.mockResolvedValue({
       teamId: 'team-bears',
       eventId: 'game-1',
@@ -75,6 +82,7 @@ describe('GameDetail route resolution', () => {
       expect(screen.getByText('Live event workflow')).toBeTruthy()
     })
 
+    expect(screen.getByTestId('location').textContent).toBe('/schedule/team-bears/game-1?childId=player-7&section=game')
     expect(screen.getByRole('heading', { name: 'Availability' })).toBeTruthy()
     expect(screen.getByText('Rideshare')).toBeTruthy()
     expect(screen.getByText('Assignments')).toBeTruthy()

--- a/apps/app/src/pages/GameDetail.tsx
+++ b/apps/app/src/pages/GameDetail.tsx
@@ -65,8 +65,13 @@ export function GameDetail({ auth }: { auth: AuthState }) {
 
   const redirectTarget = useMemo(() => {
     if (!state.targetRoute) return ''
-    const childQuery = state.targetRoute.childId ? `?childId=${encodeURIComponent(state.targetRoute.childId)}` : ''
-    return `/schedule/${encodeURIComponent(state.targetRoute.teamId)}/${encodeURIComponent(state.targetRoute.eventId)}${childQuery}`
+    const params = new URLSearchParams()
+    if (state.targetRoute.childId) {
+      params.set('childId', state.targetRoute.childId)
+    }
+    params.set('section', 'game')
+    const search = params.toString()
+    return `/schedule/${encodeURIComponent(state.targetRoute.teamId)}/${encodeURIComponent(state.targetRoute.eventId)}${search ? `?${search}` : ''}`
   }, [state.targetRoute])
 
   if (redirectTarget) {

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -122,6 +122,16 @@ import type { AuthState } from '../lib/types';
 type EventDetailSectionId = 'availability' | 'rideshare' | 'assignments' | 'game';
 type GameReportSectionId = 'summary' | 'players' | 'plays' | 'opponent' | 'insights' | 'media';
 
+const eventDetailSectionIds = new Set<EventDetailSectionId>(['availability', 'rideshare', 'assignments', 'game']);
+
+export function parseEventDetailSection(section: string | null | undefined): EventDetailSectionId {
+  const normalized = String(section || '').trim().toLowerCase();
+  if (normalized && eventDetailSectionIds.has(normalized as EventDetailSectionId)) {
+    return normalized as EventDetailSectionId;
+  }
+  return 'availability';
+}
+
 function cloneScheduleAssignments(assignments: ScheduleAssignment[] = []) {
   return assignments.map((assignment) => ({
     ...assignment,
@@ -255,7 +265,7 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   const [error, setError] = useState<string | null>(null);
   const [statusMessage, setStatusMessage] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState<RsvpResponse | null>(null);
-  const [activeSection, setActiveSection] = useState<EventDetailSectionId>('availability');
+  const [activeSection, setActiveSection] = useState<EventDetailSectionId>(() => parseEventDetailSection(searchParams.get('section')));
   const [detailsOpen, setDetailsOpen] = useState(false);
   const [availabilityNote, setAvailabilityNote] = useState('');
   const [staffRsvpBreakdown, setStaffRsvpBreakdown] = useState<StaffScheduleRsvpBreakdown | null>(null);
@@ -298,6 +308,10 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
     loadEvent();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [auth.user?.uid, decodedTeamId, decodedEventId]);
+
+  useEffect(() => {
+    setActiveSection(parseEventDetailSection(searchParams.get('section')));
+  }, [searchParams]);
 
   const selectedEvent = useMemo(() => {
     if (!events.length) return null;

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -2595,7 +2595,7 @@ function LiveScoreEditor({ auth, event, onScoreUpdated }: { auth: AuthState; eve
       setLoadingHomePlayers(true);
       try {
         const players = await loadHomeScoringPlayers(event.teamId, event.id);
-        if (!cancelled) setHomePlayers(players);
+        if (!cancelled) setHomePlayers(Array.isArray(players) ? players : []);
       } catch (error) {
         console.warn('[schedule-event-detail] Unable to load home scoring players:', error);
         if (!cancelled) setHomePlayers([]);

--- a/tests/unit/app-game-detail-baseball-walk.test.jsx
+++ b/tests/unit/app-game-detail-baseball-walk.test.jsx
@@ -47,6 +47,7 @@ async function renderGameDetail(initialPath = '/games/game-baseball') {
                 React.createElement('h1', null, 'Availability'),
                 React.createElement('div', null, 'Rideshare'),
                 React.createElement('div', null, 'Assignments'),
+                React.createElement('div', null, 'Game hub'),
                 React.createElement('div', null, 'Live event workflow')
             )
         },
@@ -82,7 +83,7 @@ describe('app GameDetail route resolution', () => {
         });
 
         expect(router.state.location.pathname).toBe('/schedule/team-baseball/game-baseball');
-        expect(router.state.location.search).toBe('?childId=player-1');
+        expect(router.state.location.search).toBe('?childId=player-1&section=game');
         expect(container.textContent).toContain('Availability');
         expect(container.textContent).toContain('Rideshare');
         expect(container.textContent).toContain('Assignments');

--- a/tests/unit/app-notification-open-routing.test.jsx
+++ b/tests/unit/app-notification-open-routing.test.jsx
@@ -96,7 +96,7 @@ describe('app notification open routing', () => {
 
     it.each([
         [{ category: 'liveChat', teamId: 'team-1' }, '/messages/team-1'],
-        [{ category: 'liveScore', teamId: 'team-1', gameId: 'game-7' }, '/schedule/team-1/game-7'],
+        [{ category: 'liveScore', teamId: 'team-1', gameId: 'game-7' }, '/schedule/team-1/game-7?section=game'],
         [{ category: 'liveScore', gameId: 'game-7' }, '/games/game-7'],
         [{ category: 'schedule', teamId: 'team-1', eventId: 'event-9' }, '/schedule/team-1/event-9']
     ])('navigates to the expected route when a notification is opened: %o', async (payload, expectedRoute) => {

--- a/tests/unit/app-push-notification-routing.test.ts
+++ b/tests/unit/app-push-notification-routing.test.ts
@@ -16,7 +16,7 @@ describe('app push notification routing', () => {
         expect(resolvePushNotificationRoute({ category: 'liveChat', teamId: 'team-1' })).toBe('/messages/team-1');
         expect(resolvePushNotificationRoute({ category: 'liveChat', teamId: 'team-1', conversationId: 'staff-2' })).toBe('/messages/team-1?conversationId=staff-2');
         expect(resolvePushNotificationRoute({ category: 'liveChat', teamId: 'team-1', conversationId: 'staff-2', appRoute: '/messages/team-1' })).toBe('/messages/team-1?conversationId=staff-2');
-        expect(resolvePushNotificationRoute({ category: 'liveScore', teamId: 'team-1', gameId: 'game-7' })).toBe('/schedule/team-1/game-7');
+        expect(resolvePushNotificationRoute({ category: 'liveScore', teamId: 'team-1', gameId: 'game-7' })).toBe('/schedule/team-1/game-7?section=game');
         expect(resolvePushNotificationRoute({ category: 'liveScore', gameId: 'game-7' })).toBe('/games/game-7');
         expect(resolvePushNotificationRoute({ category: 'schedule', teamId: 'team-1', eventId: 'event-9' })).toBe('/schedule/team-1/event-9');
     });
@@ -24,8 +24,8 @@ describe('app push notification routing', () => {
     it('falls back to legacy web links when an explicit app route is absent', () => {
         expect(resolvePushNotificationRoute({ link: 'https://allplays.ai/team-chat.html?teamId=team-1' })).toBe('/messages/team-1');
         expect(resolvePushNotificationRoute({ link: 'https://allplays.ai/team-chat.html?teamId=team-1&conversationId=staff-2' })).toBe('/messages/team-1?conversationId=staff-2');
-        expect(resolvePushNotificationRoute({ link: 'https://allplays.ai/live-game.html?teamId=team-1&gameId=game-7' })).toBe('/schedule/team-1/game-7');
-        expect(resolvePushNotificationRoute({ link: 'https://allplays.ai/game-day.html?teamId=team-1&gameId=game-7' })).toBe('/schedule/team-1/game-7');
+        expect(resolvePushNotificationRoute({ link: 'https://allplays.ai/live-game.html?teamId=team-1&gameId=game-7' })).toBe('/schedule/team-1/game-7?section=game');
+        expect(resolvePushNotificationRoute({ link: 'https://allplays.ai/game-day.html?teamId=team-1&gameId=game-7' })).toBe('/schedule/team-1/game-7?section=game');
     });
 
     it('keeps and clears pending notification routes for delayed auth hydration', () => {

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -49,7 +49,7 @@ vi.mock('../../apps/app/src/lib/scheduleService.ts', () => scheduleMocks);
 vi.mock('../../apps/app/src/lib/gameReportService.ts', () => reportMocks);
 vi.mock('../../apps/app/src/lib/publicActions.ts', () => publicActionMocks);
 
-import { ScheduleEventDetail } from '../../apps/app/src/pages/ScheduleEventDetail.tsx';
+import { ScheduleEventDetail, parseEventDetailSection } from '../../apps/app/src/pages/ScheduleEventDetail.tsx';
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;
 
@@ -235,6 +235,14 @@ afterEach(() => {
 });
 
 describe('React app ScheduleEventDetail More tab integration', () => {
+    it('parses only supported event detail sections and falls back to availability', () => {
+        expect(parseEventDetailSection('game')).toBe('game');
+        expect(parseEventDetailSection('rideshare')).toBe('rideshare');
+        expect(parseEventDetailSection('assignments')).toBe('assignments');
+        expect(parseEventDetailSection('invalid')).toBe('availability');
+        expect(parseEventDetailSection(null)).toBe('availability');
+    });
+
     it('renders the practice More tab with text-only sharing wired to the primary top card', async () => {
         scheduleMocks.loadParentSchedule.mockResolvedValue({
             events: [
@@ -327,6 +335,37 @@ describe('React app ScheduleEventDetail More tab integration', () => {
             { id: 'player-1', name: 'Pat' }
         );
         await waitForText(container, 'Pat marked complete.');
+    });
+
+    it('opens the game hub immediately when the route requests section=game', async () => {
+        scheduleMocks.loadParentScheduleEventDetail.mockResolvedValue({
+            events: [
+                event({
+                    liveStatus: 'completed',
+                    homeScore: 4,
+                    awayScore: 2
+                })
+            ]
+        });
+        reportMocks.loadGameReportSections.mockResolvedValue(report());
+
+        const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1&section=game');
+        await waitForText(container, 'Game hub');
+
+        expect(container.textContent).toContain('Watch replay');
+        expect(container.textContent).toContain('Match report');
+        expect(container.textContent).not.toContain('Is Pat going?');
+    });
+
+    it('falls back to Availability when the route section is invalid', async () => {
+        scheduleMocks.loadParentScheduleEventDetail.mockResolvedValue({
+            events: [event()]
+        });
+
+        const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1&section=not-real');
+        await waitForText(container, 'Is Pat going?');
+
+        expect(container.textContent).not.toContain('Game hub');
     });
 
     it('renders the completed game More tab with replay and report actions wired to public URLs', async () => {


### PR DESCRIPTION
Closes #1803

## What changed
- Taught `ScheduleEventDetail` to parse and honor the `section` query param on initial render and when the route changes, with safe fallback to `availability` for unsupported values.
- Updated push notification routing so live-score and legacy game-day/live-game links open schedule event routes with `?section=game`.
- Updated `/games/:gameId` resolution so `GameDetail` redirects into the schedule event route while preserving `childId` and adding `section=game`.
- Added focused regression coverage for section parsing, first-paint game-hub rendering, invalid-section fallback, push routing, notification-open routing, and `/games/:gameId` redirect behavior.

## Root Cause
The route contract for section-targeted schedule-event links already existed in route builders, but `ScheduleEventDetail` never initialized or synchronized `activeSection` from the `section` query param. At the same time, game-centric entry points like live-score push routing and `/games/:gameId` redirects did not consistently append `section=game`, so game-day opens silently fell back to the default Availability tab.

## Prevention / Learning
When a route helper emits feature-specific query params, the destination page must own a single validated parser for them and tests must cover both the source entry points and the destination first-paint state. For game-day and similar workflow links, treat route construction and route consumption as one contract, not two loosely related implementations.

## Regression Tests
- `tests/unit/app-schedule-more-tab-integration.test.jsx` covers valid section parsing, invalid fallback, and rendering `/schedule/...?...&section=game` directly into Game hub before any click.
- `tests/unit/app-push-notification-routing.test.ts` verifies live-score and legacy game-day/live-game links now resolve to `?section=game` schedule routes.
- `tests/unit/app-notification-open-routing.test.jsx` verifies notification-open navigation lands on the `?section=game` route.
- `apps/app/src/pages/GameDetail.test.tsx` and `tests/unit/app-game-detail-baseball-walk.test.jsx` verify `/games/:gameId` redirects preserve `childId` and add `section=game`.

## Recurrence Risk
Low. Section parsing is now centralized and the affected entry points are covered by focused routing and integration tests.