### PR TITLE
Lazy-load Schedule staff import helpers

### DIFF
--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -2,7 +2,6 @@ import { useEffect, useMemo, useState, type FormEvent, type ReactNode } from 're
 import { AlertCircle, CalendarDays, CheckCircle2, ChevronDown, ChevronLeft, ChevronRight, ClipboardCheck, Copy, Download, Filter, Link as LinkIcon, ListChecks, MapPin, RefreshCw } from 'lucide-react';
 import { Link } from 'react-router-dom';
 import { addTeamCalendarUrl, createScheduleImportGame, createScheduleImportPractice, loadParentSchedule, removeTeamCalendarUrl, type ParentScheduleChild } from '../lib/scheduleService';
-import { generateScheduleAiImportRows } from '../lib/scheduleAiImport';
 import { getCachedAppData, loadCachedAppData } from '../lib/appDataCache';
 import { startUxTimer } from '../lib/uxTiming';
 import { useShellLayout } from '../lib/useShellLayout';
@@ -29,14 +28,6 @@ import {
   type ScheduleTimeRange,
   type ScheduleViewMode
 } from '../lib/scheduleLogic';
-import {
-  SCHEDULE_CSV_IMPORT_FIELDS,
-  buildScheduleImportPreview,
-  inferScheduleCsvMapping,
-  parseCsvText,
-  type ScheduleCsvImportMapping,
-  type ScheduleCsvImportPreviewRow
-} from '../lib/scheduleCsvImport';
 import type { AuthState } from '../lib/types';
 
 const filterOptions: Array<{ value: ParentScheduleFilter; label: string }> = [
@@ -71,6 +62,61 @@ const rsvpBadgeClasses: Record<RsvpResponse, string> = {
   not_going: 'border-rose-200 bg-rose-50 text-rose-700',
   not_responded: 'border-primary-200 bg-primary-50 text-primary-700'
 };
+
+type ScheduleCsvImportFieldKey = 'startDateTime' | 'date' | 'startTime' | 'endTime' | 'eventType' | 'opponent' | 'title' | 'location' | 'arrivalTime' | 'isHome' | 'notes';
+type ScheduleCsvImportMapping = Partial<Record<ScheduleCsvImportFieldKey, string>>;
+type ScheduleCsvImportNormalizedRow = {
+  rowNumber: number;
+  eventType: 'game' | 'practice';
+  startsAt: string;
+  endsAt: string | null;
+  opponent: string | null;
+  title: string | null;
+  location: string | null;
+  arrivalTime: string | null;
+  isHome: boolean | null;
+  notes: string | null;
+};
+type ScheduleCsvImportPreviewRow = {
+  rowNumber: number;
+  draft: Record<string, string>;
+  normalized: ScheduleCsvImportNormalizedRow;
+  errors: string[];
+};
+
+const SCHEDULE_CSV_IMPORT_FIELDS: Array<{ key: ScheduleCsvImportFieldKey; label: string }> = [
+  { key: 'startDateTime', label: 'Start Date & Time' },
+  { key: 'date', label: 'Date' },
+  { key: 'startTime', label: 'Start Time' },
+  { key: 'endTime', label: 'End Time' },
+  { key: 'eventType', label: 'Event Type' },
+  { key: 'opponent', label: 'Opponent' },
+  { key: 'title', label: 'Title' },
+  { key: 'location', label: 'Location' },
+  { key: 'arrivalTime', label: 'Arrival Time' },
+  { key: 'isHome', label: 'Home / Away' },
+  { key: 'notes', label: 'Notes' }
+];
+
+type ScheduleCsvImportModule = typeof import('../lib/scheduleCsvImport');
+type ScheduleAiImportModule = typeof import('../lib/scheduleAiImport');
+
+let scheduleCsvImportModulePromise: Promise<ScheduleCsvImportModule> | null = null;
+let scheduleAiImportModulePromise: Promise<ScheduleAiImportModule> | null = null;
+
+function loadScheduleCsvImportModule() {
+  if (!scheduleCsvImportModulePromise) {
+    scheduleCsvImportModulePromise = import('../lib/scheduleCsvImport');
+  }
+  return scheduleCsvImportModulePromise;
+}
+
+function loadScheduleAiImportModule() {
+  if (!scheduleAiImportModulePromise) {
+    scheduleAiImportModulePromise = import('../lib/scheduleAiImport');
+  }
+  return scheduleAiImportModulePromise;
+}
 
 export function Schedule({ auth }: { auth: AuthState }) {
   const { isDesktopWeb } = useShellLayout();
@@ -229,6 +275,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
     setScheduleImportPreviewSource(null);
     if (!file) return;
     try {
+      const { parseCsvText, inferScheduleCsvMapping } = await loadScheduleCsvImportModule();
       const parsed = parseCsvText(await file.text());
       setCsvHeaders(parsed.headers);
       setCsvRows(parsed.rows);
@@ -239,7 +286,8 @@ export function Schedule({ auth }: { auth: AuthState }) {
     }
   };
 
-  const handleCsvPreview = () => {
+  const handleCsvPreview = async () => {
+    const { buildScheduleImportPreview } = await loadScheduleCsvImportModule();
     const preview = buildScheduleImportPreview({
       rows: csvRows,
       mapping: csvMapping,
@@ -295,6 +343,7 @@ export function Schedule({ auth }: { auth: AuthState }) {
 
     setProcessingAiImport(true);
     try {
+      const { generateScheduleAiImportRows } = await loadScheduleAiImportModule();
       const result = await generateScheduleAiImportRows({
         teamName: selectedCalendarTeam.teamName,
         text: aiScheduleText,

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -10,7 +10,9 @@ const scheduleMocks = vi.hoisted(() => ({
     createScheduleImportPractice: vi.fn(),
     loadParentSchedule: vi.fn(),
     removeTeamCalendarUrl: vi.fn(),
-    generateScheduleAiImportRows: vi.fn()
+    generateScheduleAiImportRows: vi.fn(),
+    aiModuleLoads: 0,
+    csvModuleLoads: 0
 }));
 const layoutState = vi.hoisted(() => ({
     isDesktopWeb: true,
@@ -19,9 +21,17 @@ const layoutState = vi.hoisted(() => ({
 }));
 
 vi.mock('../../apps/app/src/lib/scheduleService.ts', () => scheduleMocks);
-vi.mock('../../apps/app/src/lib/scheduleAiImport.ts', () => ({
-    generateScheduleAiImportRows: scheduleMocks.generateScheduleAiImportRows
-}));
+vi.mock('../../apps/app/src/lib/scheduleAiImport.ts', async () => {
+    scheduleMocks.aiModuleLoads += 1;
+    return {
+        generateScheduleAiImportRows: scheduleMocks.generateScheduleAiImportRows
+    };
+});
+
+vi.mock('../../apps/app/src/lib/scheduleCsvImport.ts', async (importOriginal) => {
+    scheduleMocks.csvModuleLoads += 1;
+    return await importOriginal();
+});
 vi.mock('../../apps/app/src/lib/useShellLayout.ts', () => ({
     useShellLayout: () => layoutState
 }));
@@ -255,6 +265,17 @@ describe('React app desktop Schedule controls', () => {
         expect(buttonByText(container, 'Show 2 more')).toBeTruthy();
     });
 
+    it('does not load AI or CSV helpers for parent-only initial render', async () => {
+        const { container } = await renderSchedule();
+        await waitForText(container, 'Main Gym');
+
+        expect(scheduleMocks.aiModuleLoads).toBe(0);
+        expect(scheduleMocks.csvModuleLoads).toBe(0);
+        expect(container.textContent).not.toContain('Add external calendar');
+        expect(container.textContent).not.toContain('Draft schedule with AI');
+        expect(container.textContent).not.toContain('Import schedule CSV');
+    });
+
     it('shows staff-only calendar import and refreshes after save', async () => {
         scheduleMocks.loadParentSchedule.mockResolvedValue({
             children: [
@@ -404,6 +425,7 @@ describe('React app desktop Schedule controls', () => {
 
         const { container } = await renderSchedule();
         await waitForText(container, 'Import schedule CSV');
+        const csvModuleLoadsBeforeUpload = scheduleMocks.csvModuleLoads;
         const input = container.querySelector('input[aria-label="Schedule CSV file"]');
         const file = new File([
             'Type,Date,Start,End,Opponent,Title,Location\n',
@@ -416,9 +438,11 @@ describe('React app desktop Schedule controls', () => {
             input.dispatchEvent(new Event('change', { bubbles: true }));
             await Promise.resolve();
         });
+        await waitForText(container, 'Loaded schedule.csv');
 
         await clickButton(container, 'Preview rows');
         await waitForText(container, 'Game vs Tigers');
+        expect(scheduleMocks.csvModuleLoads).toBe(csvModuleLoadsBeforeUpload + 1);
         expect(container.textContent).toContain('Speed Session');
 
         await clickButton(container, 'Import rows');
@@ -468,12 +492,14 @@ describe('React app desktop Schedule controls', () => {
 
         const { container } = await renderSchedule();
         await waitForText(container, 'Draft schedule with AI');
+        const aiModuleLoadsBeforeGenerate = scheduleMocks.aiModuleLoads;
         const textarea = container.querySelector('textarea[aria-label="Schedule text or AI instructions"]');
         expect(textarea).toBeTruthy();
 
         await changeTextarea(textarea, '4/2 6:30 PM vs Tigers at Field 1');
         await clickButton(container, 'Generate draft rows');
         await waitForText(container, 'AI draft preview 1 row(s)');
+        expect(scheduleMocks.aiModuleLoads).toBe(aiModuleLoadsBeforeGenerate + 1);
         expect(scheduleMocks.generateScheduleAiImportRows).toHaveBeenCalledWith(expect.objectContaining({
             teamName: 'Bears',
             text: '4/2 6:30 PM vs Tigers at Field 1',
@@ -553,6 +579,7 @@ describe('React app desktop Schedule controls', () => {
             input.dispatchEvent(new Event('change', { bubbles: true }));
             await Promise.resolve();
         });
+        await waitForText(container, 'Loaded bad-schedule.csv');
 
         await clickButton(container, 'Preview rows');
         await waitForText(container, 'Start time is invalid.');
@@ -583,6 +610,7 @@ describe('React app desktop Schedule controls', () => {
             input.dispatchEvent(new Event('change', { bubbles: true }));
             await Promise.resolve();
         });
+        await waitForText(container, 'Loaded partial-schedule.csv');
 
         await clickButton(container, 'Preview rows');
         await waitForText(container, 'Game vs Tigers');

--- a/tests/unit/app-schedule-lazy-load.test.tsx
+++ b/tests/unit/app-schedule-lazy-load.test.tsx
@@ -1,0 +1,19 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const scheduleSource = readFileSync(new URL('../../apps/app/src/pages/Schedule.tsx', import.meta.url), 'utf8');
+
+describe('Schedule lazy-load guards', () => {
+    it('does not statically import staff AI or CSV helpers at the route level', () => {
+        expect(scheduleSource).not.toContain("from '../lib/scheduleAiImport'");
+        expect(scheduleSource).not.toContain("from '../lib/scheduleCsvImport'");
+    });
+
+    it('loads staff AI and CSV helpers through on-demand dynamic imports', () => {
+        expect(scheduleSource).toContain("scheduleCsvImportModulePromise = import('../lib/scheduleCsvImport')");
+        expect(scheduleSource).toContain("scheduleAiImportModulePromise = import('../lib/scheduleAiImport')");
+        expect(scheduleSource).toContain("const { parseCsvText, inferScheduleCsvMapping } = await loadScheduleCsvImportModule();");
+        expect(scheduleSource).toContain("const { buildScheduleImportPreview } = await loadScheduleCsvImportModule();");
+        expect(scheduleSource).toContain("const { generateScheduleAiImportRows } = await loadScheduleAiImportModule();");
+    });
+});


### PR DESCRIPTION
Closes #1888

## What changed
- Removed the Schedule route's top-level imports of `../lib/scheduleAiImport` and `../lib/scheduleCsvImport`.
- Added cached dynamic import helpers so CSV parsing/mapping loads only when a staff user uploads or previews a CSV, and AI import code loads only when a staff user generates AI draft rows.
- Kept the existing staff UI intact while moving the heavy helper loading behind those staff-only interactions.
- Added a source-level lazy-load guard test and updated the Schedule desktop control test to prove parent renders stay clean while staff CSV/AI flows still work.

## Root Cause
The Schedule route statically imported staff-only AI and CSV helper modules at module scope. That forced Vite to include firebase-ai and CSV parsing code in the Schedule route chunk for every Schedule visit, even when the user was a parent who never opened staff import tools.

## Prevention / Learning
Admin-only panels, import tools, and other hidden workflows should load their heavy helpers at the first real interaction point instead of at route module load. When a route must stay lean for parent-facing first render, add a source-level regression test that blocks static imports of staff-only dependencies.

## Regression Tests
- `npx vitest run tests/unit/app-schedule-lazy-load.test.tsx tests/unit/app-schedule-desktop-controls.test.jsx --reporter=dot`
- `npm run app:build`

## Recurrence Risk
Low. The route now has explicit dynamic-import guards plus unit coverage that fails if staff AI/CSV helpers become static imports again or if staff workflows stop working after lazy loading.