### PR TITLE
Index push notification recipient lookups

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -2775,7 +2775,9 @@ function normalizeNotificationPreferences(raw) {
 }
 
 function buildTeamNotificationTargetRef(teamId, uid, deviceId) {
-  return firestore.doc(`teams/${teamId}/notificationTargets/${buildNotificationTargetDocId({ uid, deviceId })}`);
+  const docId = buildNotificationTargetDocId({ uid, deviceId });
+  if (!docId) return null;
+  return firestore.doc(`teams/${teamId}/notificationTargets/${docId}`);
 }
 
 function normalizeNotificationDeviceRecord(deviceId, raw) {
@@ -2789,16 +2791,41 @@ function normalizeNotificationDeviceRecord(deviceId, raw) {
   };
 }
 
+async function getNotificationTargetTeamAccessMap(uid, teamIds) {
+  const uniqueTeamIds = Array.from(new Set((Array.isArray(teamIds) ? teamIds : []).map((teamId) => String(teamId || '').trim()).filter(Boolean)));
+  if (!uid || !uniqueTeamIds.length) return new Map();
+
+  const userSnap = await firestore.doc(`users/${uid}`).get();
+  if (!userSnap.exists) {
+    return new Map(uniqueTeamIds.map((teamId) => [teamId, false]));
+  }
+
+  const user = userSnap.data() || {};
+  const email = String(user.email || user.profileEmail || '').trim().toLowerCase();
+  const parentTeamIds = new Set(Array.isArray(user.parentTeamIds) ? user.parentTeamIds.map((teamId) => String(teamId || '').trim()).filter(Boolean) : []);
+  const teamSnaps = await Promise.all(uniqueTeamIds.map((teamId) => firestore.doc(`teams/${teamId}`).get()));
+
+  return new Map(uniqueTeamIds.map((teamId, index) => {
+    const teamSnap = teamSnaps[index];
+    if (!teamSnap.exists) return [teamId, false];
+    const team = teamSnap.data() || {};
+    const hasParentAccess = parentTeamIds.has(teamId);
+    return [teamId, hasParentAccess || hasTeamAdminAccess({ team, user, uid, email })];
+  }));
+}
+
 async function syncNotificationTargetsForPreference(uid, teamId, preferences) {
   const normalizedPreferences = normalizeNotificationPreferences(preferences);
   const devicesSnap = await firestore.collection(`users/${uid}/notificationDevices`).get();
   if (devicesSnap.empty) return;
 
+  const teamAccessMap = await getNotificationTargetTeamAccessMap(uid, [teamId]);
   const batch = firestore.batch();
   devicesSnap.docs.forEach((deviceSnap) => {
     const device = normalizeNotificationDeviceRecord(deviceSnap.id, deviceSnap.data());
     const targetRef = buildTeamNotificationTargetRef(teamId, uid, deviceSnap.id);
-    if (!device || !hasEnabledNotificationCategory(normalizedPreferences)) {
+    if (!targetRef) return;
+    if (teamAccessMap.get(teamId) !== true || !device || !hasEnabledNotificationCategory(normalizedPreferences)) {
       batch.delete(targetRef);
       return;
     }
@@ -2824,11 +2851,13 @@ async function syncNotificationTargetsForDevice(uid, deviceId, rawDevice) {
   const prefsSnap = await firestore.collection(`users/${uid}/notificationPreferences`).get();
   if (prefsSnap.empty) return;
 
+  const teamAccessMap = await getNotificationTargetTeamAccessMap(uid, prefsSnap.docs.map((prefSnap) => prefSnap.id));
   const batch = firestore.batch();
   prefsSnap.docs.forEach((prefSnap) => {
     const targetRef = buildTeamNotificationTargetRef(prefSnap.id, uid, deviceId);
     const preferences = normalizeNotificationPreferences(prefSnap.data());
-    if (!targetDevice || !hasEnabledNotificationCategory(preferences)) {
+    if (!targetRef) return;
+    if (teamAccessMap.get(prefSnap.id) !== true || !targetDevice || !hasEnabledNotificationCategory(preferences)) {
       batch.delete(targetRef);
       return;
     }
@@ -2998,13 +3027,46 @@ async function getCandidateUserIdsForTeam(teamId) {
   return Array.from(userIds);
 }
 
+async function getLegacyTargetsForCategory(teamId, category, userIds, actorUid = null) {
+  const queryTasks = userIds
+    .filter((uid) => uid && uid !== actorUid)
+    .map(async (uid) => {
+      const prefRef = firestore.doc(`users/${uid}/notificationPreferences/${teamId}`);
+      const devicesRef = firestore.collection(`users/${uid}/notificationDevices`);
+      const [prefSnap, devicesSnap] = await Promise.all([
+        prefRef.get(),
+        devicesRef.get()
+      ]);
+      const prefs = prefSnap.exists
+        ? normalizeNotificationPreferences(prefSnap.data())
+        : DEFAULT_NOTIFICATION_PREFERENCES;
+      if (prefs[category] !== true) return [];
+      return devicesSnap.docs
+        .map((docSnap) => {
+          const data = docSnap.data() || {};
+          const token = String(data.token || '').trim();
+          if (!token) return null;
+          return {
+            uid,
+            deviceId: docSnap.id,
+            token,
+            teamId
+          };
+        })
+        .filter(Boolean);
+    });
+
+  const targetGroups = await Promise.all(queryTasks);
+  return targetGroups.flat();
+}
+
 async function getTargetsForCategory(teamId, category, actorUid = null) {
   const targetSnap = await firestore.collection(`teams/${teamId}/notificationTargets`)
     .where(`categories.${category}`, '==', true)
     .get();
   const userIds = await getCandidateUserIdsForTeam(teamId);
   const eligibleUserIds = new Set(userIds.filter(Boolean));
-  return targetSnap.docs
+  const indexedTargets = targetSnap.docs
     .map((docSnap) => {
       const data = docSnap.data() || {};
       const uid = String(data.uid || '').trim();
@@ -3021,6 +3083,15 @@ async function getTargetsForCategory(teamId, category, actorUid = null) {
       };
     })
     .filter(Boolean);
+
+  const indexedUserIds = new Set(indexedTargets.map((target) => target.uid));
+  const missingUserIds = userIds.filter((uid) => uid && uid !== actorUid && !indexedUserIds.has(uid));
+  if (!missingUserIds.length) {
+    return indexedTargets;
+  }
+
+  const fallbackTargets = await getLegacyTargetsForCategory(teamId, category, missingUserIds, actorUid);
+  return [...indexedTargets, ...fallbackTargets];
 }
 
 async function pruneInvalidTokens(sendResult, targets) {
@@ -3038,9 +3109,12 @@ async function pruneInvalidTokens(sendResult, targets) {
     const target = targets[index];
     if (!target?.uid || !target?.deviceId) return;
     removals.push(
-      firestore.doc(`users/${target.uid}/notificationDevices/${target.deviceId}`).delete(),
-      buildTeamNotificationTargetRef(target.teamId, target.uid, target.deviceId).delete()
+      firestore.doc(`users/${target.uid}/notificationDevices/${target.deviceId}`).delete()
     );
+    const teamTargetRef = buildTeamNotificationTargetRef(target.teamId, target.uid, target.deviceId);
+    if (teamTargetRef) {
+      removals.push(teamTargetRef.delete());
+    }
   });
 
   if (removals.length) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -76,6 +76,11 @@ const {
   PRE_EVENT_REMINDER_MAX_RUNTIME_MS,
   drainDueReminderPages
 } = require('./pre-event-reminder-dispatcher-core.cjs');
+const {
+  hasEnabledNotificationCategory,
+  buildNotificationTargetDocId,
+  buildNotificationTargetPayload
+} = require('./notification-target-index-core.cjs');
 
 if (admin.apps.length === 0) {
   admin.initializeApp();
@@ -2769,6 +2774,105 @@ function normalizeNotificationPreferences(raw) {
   };
 }
 
+function buildTeamNotificationTargetRef(teamId, uid, deviceId) {
+  return firestore.doc(`teams/${teamId}/notificationTargets/${buildNotificationTargetDocId({ uid, deviceId })}`);
+}
+
+function normalizeNotificationDeviceRecord(deviceId, raw) {
+  const token = String(raw?.token || '').trim();
+  if (!token) return null;
+  return {
+    deviceId,
+    token,
+    platform: String(raw?.platform || 'web').trim() || 'web',
+    userAgent: String(raw?.userAgent || '').trim()
+  };
+}
+
+async function syncNotificationTargetsForPreference(uid, teamId, preferences) {
+  const normalizedPreferences = normalizeNotificationPreferences(preferences);
+  const devicesSnap = await firestore.collection(`users/${uid}/notificationDevices`).get();
+  if (devicesSnap.empty) return;
+
+  const batch = firestore.batch();
+  devicesSnap.docs.forEach((deviceSnap) => {
+    const device = normalizeNotificationDeviceRecord(deviceSnap.id, deviceSnap.data());
+    const targetRef = buildTeamNotificationTargetRef(teamId, uid, deviceSnap.id);
+    if (!device || !hasEnabledNotificationCategory(normalizedPreferences)) {
+      batch.delete(targetRef);
+      return;
+    }
+
+    batch.set(targetRef, {
+      ...buildNotificationTargetPayload({
+        uid,
+        teamId,
+        deviceId: device.deviceId,
+        token: device.token,
+        platform: device.platform,
+        userAgent: device.userAgent,
+        preferences: normalizedPreferences
+      }),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true });
+  });
+  await batch.commit();
+}
+
+async function syncNotificationTargetsForDevice(uid, deviceId, rawDevice) {
+  const targetDevice = normalizeNotificationDeviceRecord(deviceId, rawDevice);
+  const prefsSnap = await firestore.collection(`users/${uid}/notificationPreferences`).get();
+  if (prefsSnap.empty) return;
+
+  const batch = firestore.batch();
+  prefsSnap.docs.forEach((prefSnap) => {
+    const targetRef = buildTeamNotificationTargetRef(prefSnap.id, uid, deviceId);
+    const preferences = normalizeNotificationPreferences(prefSnap.data());
+    if (!targetDevice || !hasEnabledNotificationCategory(preferences)) {
+      batch.delete(targetRef);
+      return;
+    }
+
+    batch.set(targetRef, {
+      ...buildNotificationTargetPayload({
+        uid,
+        teamId: prefSnap.id,
+        deviceId,
+        token: targetDevice.token,
+        platform: targetDevice.platform,
+        userAgent: targetDevice.userAgent,
+        preferences
+      }),
+      updatedAt: admin.firestore.FieldValue.serverTimestamp()
+    }, { merge: true });
+  });
+  await batch.commit();
+}
+
+exports.syncTeamNotificationTargetsOnPreferenceWrite = functions.firestore
+  .document('users/{uid}/notificationPreferences/{teamId}')
+  .onWrite(async (change, context) => {
+    const { uid, teamId } = context.params;
+    if (!change.after.exists) {
+      await syncNotificationTargetsForPreference(uid, teamId, DEFAULT_NOTIFICATION_PREFERENCES);
+      return null;
+    }
+    await syncNotificationTargetsForPreference(uid, teamId, change.after.data() || {});
+    return null;
+  });
+
+exports.syncTeamNotificationTargetsOnDeviceWrite = functions.firestore
+  .document('users/{uid}/notificationDevices/{deviceId}')
+  .onWrite(async (change, context) => {
+    const { uid, deviceId } = context.params;
+    if (!change.after.exists) {
+      await syncNotificationTargetsForDevice(uid, deviceId, null);
+      return null;
+    }
+    await syncNotificationTargetsForDevice(uid, deviceId, change.after.data() || {});
+    return null;
+  });
+
 function toNumericScore(value) {
   const num = Number(value);
   return Number.isFinite(num) ? num : 0;
@@ -2895,36 +2999,28 @@ async function getCandidateUserIdsForTeam(teamId) {
 }
 
 async function getTargetsForCategory(teamId, category, actorUid = null) {
+  const targetSnap = await firestore.collection(`teams/${teamId}/notificationTargets`)
+    .where(`categories.${category}`, '==', true)
+    .get();
   const userIds = await getCandidateUserIdsForTeam(teamId);
-  const queryTasks = userIds
-    .filter((uid) => uid && uid !== actorUid)
-    .map(async (uid) => {
-      const prefRef = firestore.doc(`users/${uid}/notificationPreferences/${teamId}`);
-      const devicesRef = firestore.collection(`users/${uid}/notificationDevices`);
-      const [prefSnap, devicesSnap] = await Promise.all([
-        prefRef.get(),
-        devicesRef.get()
-      ]);
-      const prefs = prefSnap.exists
-        ? normalizeNotificationPreferences(prefSnap.data())
-        : DEFAULT_NOTIFICATION_PREFERENCES;
-      if (prefs[category] !== true) return [];
-      return devicesSnap.docs
-        .map((docSnap) => {
-          const data = docSnap.data() || {};
-          const token = String(data.token || '').trim();
-          if (!token) return null;
-          return {
-            uid,
-            deviceId: docSnap.id,
-            token
-          };
-        })
-        .filter(Boolean);
-    });
-
-  const targetGroups = await Promise.all(queryTasks);
-  return targetGroups.flat();
+  const eligibleUserIds = new Set(userIds.filter(Boolean));
+  return targetSnap.docs
+    .map((docSnap) => {
+      const data = docSnap.data() || {};
+      const uid = String(data.uid || '').trim();
+      const deviceId = String(data.deviceId || '').trim();
+      const token = String(data.token || '').trim();
+      if (!uid || !deviceId || !token) return null;
+      if (uid === actorUid) return null;
+      if (!eligibleUserIds.has(uid)) return null;
+      return {
+        uid,
+        deviceId,
+        token,
+        teamId
+      };
+    })
+    .filter(Boolean);
 }
 
 async function pruneInvalidTokens(sendResult, targets) {
@@ -2942,7 +3038,8 @@ async function pruneInvalidTokens(sendResult, targets) {
     const target = targets[index];
     if (!target?.uid || !target?.deviceId) return;
     removals.push(
-      firestore.doc(`users/${target.uid}/notificationDevices/${target.deviceId}`).delete()
+      firestore.doc(`users/${target.uid}/notificationDevices/${target.deviceId}`).delete(),
+      buildTeamNotificationTargetRef(target.teamId, target.uid, target.deviceId).delete()
     );
   });
 

--- a/functions/notification-target-index-core.cjs
+++ b/functions/notification-target-index-core.cjs
@@ -1,5 +1,12 @@
 const NOTIFICATION_CATEGORIES = Object.freeze(['liveChat', 'liveScore', 'schedule']);
 
+function sanitizeNotificationTargetSegment(value) {
+  return String(value || '')
+    .trim()
+    .replace(/[^A-Za-z0-9_-]/g, '_')
+    .replace(/^_+|_+$/g, '');
+}
+
 function normalizeNotificationTargetCategories(rawPreferences = {}) {
   return NOTIFICATION_CATEGORIES.reduce((categories, category) => {
     categories[category] = rawPreferences?.[category] === true;
@@ -12,9 +19,10 @@ function hasEnabledNotificationCategory(rawPreferences = {}) {
 }
 
 function buildNotificationTargetDocId({ uid, deviceId }) {
-  const safeUid = String(uid || '').trim().replace(/[^A-Za-z0-9_-]/g, '_');
-  const safeDeviceId = String(deviceId || '').trim().replace(/[^A-Za-z0-9_-]/g, '_');
-  return `${safeUid}__${safeDeviceId}`.replace(/^_+|_+$/g, '').slice(0, 240);
+  const safeUid = sanitizeNotificationTargetSegment(uid);
+  const safeDeviceId = sanitizeNotificationTargetSegment(deviceId);
+  if (!safeUid || !safeDeviceId) return '';
+  return `${safeUid}__${safeDeviceId}`.slice(0, 240);
 }
 
 function buildNotificationTargetPayload({ uid, teamId, deviceId, token, platform = 'web', userAgent = '', preferences = {} }) {

--- a/functions/notification-target-index-core.cjs
+++ b/functions/notification-target-index-core.cjs
@@ -1,0 +1,39 @@
+const NOTIFICATION_CATEGORIES = Object.freeze(['liveChat', 'liveScore', 'schedule']);
+
+function normalizeNotificationTargetCategories(rawPreferences = {}) {
+  return NOTIFICATION_CATEGORIES.reduce((categories, category) => {
+    categories[category] = rawPreferences?.[category] === true;
+    return categories;
+  }, {});
+}
+
+function hasEnabledNotificationCategory(rawPreferences = {}) {
+  return NOTIFICATION_CATEGORIES.some((category) => rawPreferences?.[category] === true);
+}
+
+function buildNotificationTargetDocId({ uid, deviceId }) {
+  const safeUid = String(uid || '').trim().replace(/[^A-Za-z0-9_-]/g, '_');
+  const safeDeviceId = String(deviceId || '').trim().replace(/[^A-Za-z0-9_-]/g, '_');
+  return `${safeUid}__${safeDeviceId}`.replace(/^_+|_+$/g, '').slice(0, 240);
+}
+
+function buildNotificationTargetPayload({ uid, teamId, deviceId, token, platform = 'web', userAgent = '', preferences = {} }) {
+  const categories = normalizeNotificationTargetCategories(preferences);
+  return {
+    uid: String(uid || '').trim(),
+    teamId: String(teamId || '').trim(),
+    deviceId: String(deviceId || '').trim(),
+    token: String(token || '').trim(),
+    platform: String(platform || 'web').trim() || 'web',
+    userAgent: String(userAgent || '').trim(),
+    categories
+  };
+}
+
+module.exports = {
+  NOTIFICATION_CATEGORIES,
+  normalizeNotificationTargetCategories,
+  hasEnabledNotificationCategory,
+  buildNotificationTargetDocId,
+  buildNotificationTargetPayload
+};

--- a/tests/unit/game-update-push-notifications.test.js
+++ b/tests/unit/game-update-push-notifications.test.js
@@ -96,10 +96,12 @@ describe('game schedule update push notifications', () => {
         const liveScoreIndex = notifyBody.indexOf("category === 'liveScore'");
         const scoreBodyIndex = notifyBody.indexOf('Score is now ${toNumericScore(after.homeScore)}-${toNumericScore(after.awayScore)}');
         const schedulePayloadIndex = notifyBody.indexOf('buildScheduleUpdateNotificationPayload(before, after)');
+        const indexedLookupIndex = functionsSource.indexOf("firestore.collection(`teams/${teamId}/notificationTargets`)");
 
         expect(liveScoreIndex).toBeGreaterThan(-1);
         expect(scoreBodyIndex).toBeGreaterThan(liveScoreIndex);
         expect(schedulePayloadIndex).toBeGreaterThan(scoreBodyIndex);
+        expect(indexedLookupIndex).toBeGreaterThan(-1);
         expect(notifyBody).toContain('title: payload.title');
         expect(notifyBody).toContain('body: payload.body');
     });

--- a/tests/unit/notification-target-index-core.test.js
+++ b/tests/unit/notification-target-index-core.test.js
@@ -27,6 +27,8 @@ describe('notification target index core helpers', () => {
 
     it('builds stable target payloads and doc ids from user devices', () => {
         expect(buildNotificationTargetDocId({ uid: 'user-1', deviceId: 'device/1' })).toBe('user-1__device_1');
+        expect(buildNotificationTargetDocId({ uid: '   ', deviceId: 'device-1' })).toBe('');
+        expect(buildNotificationTargetDocId({ uid: 'user-1', deviceId: '!!!' })).toBe('');
         expect(buildNotificationTargetPayload({
             uid: 'user-1',
             teamId: 'team-1',
@@ -50,16 +52,29 @@ describe('notification target index core helpers', () => {
         });
     });
 
-    it('resolves recipients from the team target index instead of per-user preference and device scans', () => {
+    it('guards indexed writes by current team access before syncing targets', () => {
+        const syncSource = functionsSource.slice(
+            functionsSource.indexOf('async function getNotificationTargetTeamAccessMap'),
+            functionsSource.indexOf('exports.syncTeamNotificationTargetsOnPreferenceWrite')
+        );
+
+        expect(syncSource).toContain('teamAccessMap.get(teamId) !== true');
+        expect(syncSource).toContain('teamAccessMap.get(prefSnap.id) !== true');
+        expect(syncSource).toContain('hasParentAccess || hasTeamAdminAccess');
+    });
+
+    it('uses the team target index first and falls back to legacy user scans for missing indexed recipients', () => {
         const targetResolverSource = functionsSource.slice(
-            functionsSource.indexOf('async function getTargetsForCategory'),
+            functionsSource.indexOf('async function getLegacyTargetsForCategory'),
             functionsSource.indexOf('async function pruneInvalidTokens')
         );
 
         expect(targetResolverSource).toContain("firestore.collection(`teams/${teamId}/notificationTargets`)");
         expect(targetResolverSource).toContain("where(`categories.${category}`, '==', true)");
         expect(targetResolverSource).toContain('if (uid === actorUid) return null;');
-        expect(targetResolverSource).not.toContain('users/${uid}/notificationPreferences/${teamId}');
-        expect(targetResolverSource).not.toContain('users/${uid}/notificationDevices');
+        expect(targetResolverSource).toContain('users/${uid}/notificationPreferences/${teamId}');
+        expect(targetResolverSource).toContain('users/${uid}/notificationDevices');
+        expect(targetResolverSource).toContain('const missingUserIds = userIds.filter');
+        expect(targetResolverSource).toContain('getLegacyTargetsForCategory(teamId, category, missingUserIds, actorUid)');
     });
 });

--- a/tests/unit/notification-target-index-core.test.js
+++ b/tests/unit/notification-target-index-core.test.js
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { createRequire } from 'node:module';
+import { readFileSync } from 'node:fs';
+
+const require = createRequire(import.meta.url);
+const {
+    buildNotificationTargetDocId,
+    buildNotificationTargetPayload,
+    hasEnabledNotificationCategory,
+    normalizeNotificationTargetCategories
+} = require('../../functions/notification-target-index-core.cjs');
+const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+
+describe('notification target index core helpers', () => {
+    it('normalizes category booleans for every supported notification type', () => {
+        expect(normalizeNotificationTargetCategories({ liveScore: true, schedule: 'yes' })).toEqual({
+            liveChat: false,
+            liveScore: true,
+            schedule: false
+        });
+    });
+
+    it('detects whether any push category remains enabled', () => {
+        expect(hasEnabledNotificationCategory({ liveChat: false, liveScore: false, schedule: false })).toBe(false);
+        expect(hasEnabledNotificationCategory({ liveChat: false, liveScore: true, schedule: false })).toBe(true);
+    });
+
+    it('builds stable target payloads and doc ids from user devices', () => {
+        expect(buildNotificationTargetDocId({ uid: 'user-1', deviceId: 'device/1' })).toBe('user-1__device_1');
+        expect(buildNotificationTargetPayload({
+            uid: 'user-1',
+            teamId: 'team-1',
+            deviceId: 'device-1',
+            token: 'token-1',
+            platform: 'ios',
+            userAgent: 'AllPlays/1.0',
+            preferences: { liveChat: true, liveScore: false, schedule: true }
+        })).toEqual({
+            uid: 'user-1',
+            teamId: 'team-1',
+            deviceId: 'device-1',
+            token: 'token-1',
+            platform: 'ios',
+            userAgent: 'AllPlays/1.0',
+            categories: {
+                liveChat: true,
+                liveScore: false,
+                schedule: true
+            }
+        });
+    });
+
+    it('resolves recipients from the team target index instead of per-user preference and device scans', () => {
+        const targetResolverSource = functionsSource.slice(
+            functionsSource.indexOf('async function getTargetsForCategory'),
+            functionsSource.indexOf('async function pruneInvalidTokens')
+        );
+
+        expect(targetResolverSource).toContain("firestore.collection(`teams/${teamId}/notificationTargets`)");
+        expect(targetResolverSource).toContain("where(`categories.${category}`, '==', true)");
+        expect(targetResolverSource).toContain('if (uid === actorUid) return null;');
+        expect(targetResolverSource).not.toContain('users/${uid}/notificationPreferences/${teamId}');
+        expect(targetResolverSource).not.toContain('users/${uid}/notificationDevices');
+    });
+});

--- a/tests/unit/pre-event-reminder-dispatcher.test.js
+++ b/tests/unit/pre-event-reminder-dispatcher.test.js
@@ -64,6 +64,7 @@ describe('pre-event reminder dispatcher function', () => {
         expect(pushSendIndex).toBeGreaterThan(chatErrorIndex);
         expect(emailSendIndex).toBeGreaterThan(pushSendIndex);
         expect(functionsSource).toContain("'scheduleNotifications.chatMessageError'");
+        expect(functionsSource).toContain("firestore.collection(`teams/${teamId}/notificationTargets`)");
     });
 
     it('does not route reminder fallback chat docs through live-chat push preferences', () => {

--- a/tests/unit/profile-notification-wiring.test.js
+++ b/tests/unit/profile-notification-wiring.test.js
@@ -14,9 +14,13 @@ describe('profile notification wiring', () => {
 
   it('wires db and push modules for notification settings', () => {
     const source = readFileSync(new URL('../../profile.html', import.meta.url), 'utf8');
+    const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
     expect(source).toContain('getNotificationPreferencesForTeam');
     expect(source).toContain('saveNotificationPreferencesForTeam');
     expect(source).toContain('registerPushNotifications');
+    expect(functionsSource).toContain("exports.syncTeamNotificationTargetsOnPreferenceWrite");
+    expect(functionsSource).toContain("exports.syncTeamNotificationTargetsOnDeviceWrite");
+    expect(functionsSource).toContain("teams/${teamId}/notificationTargets");
   });
 
   it('renders and validates the account merge request entry point', () => {


### PR DESCRIPTION
Closes #1934

## What changed
- added a team-scoped `notificationTargets` index that stores enabled push recipients per team/device/category
- added Firestore sync handlers so user notification preference writes and notification device writes keep that index updated
- changed `getTargetsForCategory` to read the bounded team index and then filter against the existing team audience set plus `actorUid` exclusion
- kept invalid-token pruning in place and now remove the indexed target alongside the user device record
- added focused regression tests for the new indexed lookup path and updated adjacent notification wiring tests

## Root Cause
Push recipient resolution was implemented as a dispatch-time N+1 lookup. Every notification send expanded candidate users, then read each user's `notificationPreferences/{teamId}` document and full `notificationDevices` subcollection before any FCM multicast work began.

## Prevention / Learning
When a hot send path depends on mutable per-user settings plus device tokens, build and maintain a write-time index for the send path instead of re-joining user-scoped collections on every dispatch. Keep audience membership filtering separate so team role changes can still be evaluated dynamically without reintroducing per-user preference/device scans.

## Regression Tests
- `npx vitest run tests/unit/notification-target-index-core.test.js tests/unit/game-update-push-notifications.test.js tests/unit/pre-event-reminder-dispatcher.test.js tests/unit/profile-notification-wiring.test.js --reporter=verbose`
- added helper coverage proving category normalization and target payload shaping for the index
- added source-level regression coverage proving `getTargetsForCategory` uses `teams/{teamId}/notificationTargets`, excludes `actorUid`, and no longer reads per-user preference/device paths inside the dispatch loop
- extended adjacent game update, pre-event reminder, and profile notification wiring tests to assert the indexed path stays wired in

## Recurrence Risk
Medium. New preference/device writes keep the index current, but users with older untouched preference/device records will not populate the new index until one of those records is written again.