### PR TITLE
Scope player search to accessible teams

### DIFF
--- a/apps/app/src/lib/searchService.ts
+++ b/apps/app/src/lib/searchService.ts
@@ -2,7 +2,6 @@ import { isTeamActive } from '../../../../js/team-visibility.js';
 import {
   db,
   collection,
-  collectionGroup,
   doc,
   getDoc,
   getDocs,
@@ -898,47 +897,7 @@ async function loadPlayerSearchDocsByTeam(rawQuery: string, prefixes: string[], 
 }
 
 async function loadPlayerSearchDocs(rawQuery: string, prefixes: string[], isNumeric: boolean, teamIds: string[] = []) {
-  const playersRef = collectionGroup(db, 'players');
-  const nameQueryCount = prefixes.length;
-  const playerQueries = prefixes.map((prefix) => getDocs(query(
-    playersRef,
-    orderBy('name'),
-    where('name', '>=', prefix),
-    where('name', '<=', `${prefix}\uf8ff`),
-    limit(playerSearchQueryLimit)
-  )));
-
-  if (isNumeric) {
-    playerQueries.push(getDocs(query(
-      playersRef,
-      orderBy('number'),
-      where('number', '>=', rawQuery),
-      where('number', '<=', `${rawQuery}\uf8ff`),
-      limit(playerSearchQueryLimit)
-    )));
-  }
-
-  const snapshots = await Promise.allSettled(playerQueries);
-  const rejected = snapshots
-    .filter((snapshot: any) => snapshot.status === 'rejected')
-    .map((snapshot: any) => snapshot.reason)
-    .filter(Boolean);
-  const onlyPermissionDeniedFailures = rejected.length > 0
-    && snapshots.every((snapshot: any) => snapshot.status === 'rejected')
-    && rejected.every((error: any) => error?.code === 'permission-denied');
-  if (onlyPermissionDeniedFailures) {
-    return loadPlayerSearchDocsByTeam(rawQuery, prefixes, isNumeric, teamIds);
-  }
-
-  const result = buildPlayerSearchDocsFromSnapshots(snapshots, nameQueryCount, isNumeric);
-  const onlyEmptyPermissionDeniedFailures = result.docs.length === 0
-    && result.rejected.length > 0
-    && result.rejected.every((error: any) => error?.code === 'permission-denied');
-  if (onlyEmptyPermissionDeniedFailures) {
-    return loadPlayerSearchDocsByTeam(rawQuery, prefixes, isNumeric, teamIds);
-  }
-
-  return result;
+  return loadPlayerSearchDocsByTeam(rawQuery, prefixes, isNumeric, teamIds);
 }
 
 function buildAppSearchPlayersFromDocs(docs: any[], teamsById: Map<string, AppSearchTeam>, user: AuthUser | null, tokens: string[]) {

--- a/js/global-search.js
+++ b/js/global-search.js
@@ -13,6 +13,7 @@ import {
 
 let cachedTeams = null;
 let cachedTeamsLoadedAt = 0;
+const playerSearchTeamLimit = 8;
 
 let currentUser = null;
 let keyHandlerInstalled = false;
@@ -137,8 +138,31 @@ function buildPlayerSearchDocsFromSnapshots(snaps, nameQueryCount, isNumeric) {
     };
 }
 
+function getPlayerSearchTeamIds(rawQuery, teamsById) {
+    const searchableTeams = filterSearchableTeams(Array.from(teamsById.values()), currentUser);
+    if (!searchableTeams.length) return [];
+
+    const privateTeams = searchableTeams.filter((team) => team?.isPublic === false);
+    const publicTeams = searchableTeams.filter((team) => team?.isPublic !== false);
+    const tokens = splitTokens(rawQuery);
+    const rankedPublicTeams = tokens.length === 0
+        ? publicTeams
+        : publicTeams
+            .map((team) => ({
+                team,
+                score: scoreText([team.name, team.sport, team.zip].filter(Boolean).join(' '), tokens)
+            }))
+            .sort((a, b) => b.score - a.score)
+            .map((entry) => entry.team);
+
+    return [...privateTeams, ...rankedPublicTeams]
+        .slice(0, playerSearchTeamLimit)
+        .map((team) => String(team?.id || '').trim())
+        .filter(Boolean);
+}
+
 async function loadPlayerSearchDocsByTeam(prefixes, rawQuery, isNumeric, teamsById) {
-    const teamIds = Array.from(teamsById.keys()).map((teamId) => String(teamId || '').trim()).filter(Boolean);
+    const teamIds = getPlayerSearchTeamIds(rawQuery, teamsById);
     if (teamIds.length === 0) {
         return { docs: [], exhaustiveForNarrowerQueries: false, rejected: [] };
     }

--- a/js/global-search.js
+++ b/js/global-search.js
@@ -3,7 +3,7 @@ import { getTeams } from './db.js?v=42';
 import { canUserDiscoverPlayerInSearch, filterSearchableTeams } from './global-search-visibility.js?v=2';
 import {
     db,
-    collectionGroup,
+    collection,
     getDocs,
     query,
     where,
@@ -168,6 +168,10 @@ async function loadPlayerSearchDocsByTeam(prefixes, rawQuery, isNumeric, teamsBy
     }));
 
     return buildPlayerSearchDocsFromSnapshots(snaps, nameQueryCount, isNumeric);
+}
+
+async function loadPlayerSearchDocs(prefixes, rawQuery, isNumeric, teamsById) {
+    return loadPlayerSearchDocsByTeam(prefixes, rawQuery, isNumeric, teamsById);
 }
 
 function renderResultRow(item, isActive) {
@@ -468,41 +472,7 @@ function openModal({ initialQuery = '' } = {}) {
         const isNumeric = /^[0-9]+$/.test(q);
 
         try {
-            const playersRef = collectionGroup(db, 'players');
-            const queries = [];
-
-            for (const prefix of prefixes) {
-                queries.push(
-                    getDocs(query(
-                        playersRef,
-                        orderBy('name'),
-                        where('name', '>=', prefix),
-                        where('name', '<=', `${prefix}\uf8ff`),
-                        limit(20)
-                    ))
-                );
-            }
-
-            if (isNumeric) {
-                queries.push(
-                    getDocs(query(
-                        playersRef,
-                        orderBy('number'),
-                        where('number', '>=', q),
-                        where('number', '<=', `${q}\uf8ff`),
-                        limit(20)
-                    ))
-                );
-            }
-
-            const snaps = await Promise.allSettled(queries);
-            const baseResult = buildPlayerSearchDocsFromSnapshots(snaps, prefixes.length, isNumeric);
-            const onlyPermissionDeniedFailures = baseResult.docs.length === 0
-                && baseResult.rejected.length > 0
-                && baseResult.rejected.every((error) => (error?.code || '') === 'permission-denied');
-            const result = onlyPermissionDeniedFailures
-                ? await loadPlayerSearchDocsByTeam(prefixes, q, isNumeric, modalState.teamsById)
-                : baseResult;
+            const result = await loadPlayerSearchDocs(prefixes, q, isNumeric, modalState.teamsById);
             if (!modalState || reqId !== modalState.playersReqId) return;
 
             const rejected = result.rejected;

--- a/tests/unit/app-search-integration.test.jsx
+++ b/tests/unit/app-search-integration.test.jsx
@@ -346,7 +346,10 @@ describe('React app shell search', () => {
         await clickButton(container, 'Search');
         const getPlayerSearchCallCount = () => firebaseMocks.getDocs.mock.calls.filter(([request]) => {
             const parts = request?.parts || [];
-            return parts.some((part) => part?.collectionName === 'players');
+            return parts.some((part) => {
+                const collectionName = part?.collectionName;
+                return collectionName === 'players' || String(collectionName || '').endsWith('/players');
+            });
         }).length;
         const baselinePlayerCalls = getPlayerSearchCallCount();
         await fillSearch(container, 'pa');

--- a/tests/unit/app-search-service.test.js
+++ b/tests/unit/app-search-service.test.js
@@ -711,7 +711,7 @@ describe('React app search service', () => {
         expect(teams.find((team) => team.id === 'team-private-hidden')).toBeUndefined();
     });
 
-    it('searches players by Firestore collection group and filters by visible teams', async () => {
+    it('searches players only within visible team collections and filters local results', async () => {
         const visibleTeams = new Map([
             ['team-1', { id: 'team-1', name: 'Bears', sport: 'Basketball', fromAppAccess: true }],
             ['team-private', { id: 'team-private', name: 'Private', sport: 'Soccer', isPublic: false }]
@@ -730,7 +730,9 @@ describe('React app search service', () => {
 
         const players = await searchAppPlayers('pat', visibleTeams, auth.user);
 
-        expect(firebaseMocks.collectionGroup).toHaveBeenCalledWith(firebaseMocks.db, 'players');
+        expect(firebaseMocks.collectionGroup).not.toHaveBeenCalled();
+        expect(firebaseMocks.collection).toHaveBeenCalledWith(firebaseMocks.db, 'teams/team-1/players');
+        expect(firebaseMocks.collection).toHaveBeenCalledWith(firebaseMocks.db, 'teams/team-private/players');
         expect(firebaseMocks.getDocs).toHaveBeenCalled();
         expect(players).toEqual([{
             id: 'player:team-1:player-1',
@@ -786,8 +788,10 @@ describe('React app search service', () => {
             '#10 Pat Stone'
         ]);
 
+        const callsBeforeMultiToken = firebaseMocks.getDocs.mock.calls.length;
         const multiTokenPlayers = await searchAppPlayers('pat s', visibleTeams, auth.user);
-        expect(firebaseMocks.getDocs).toHaveBeenCalledTimes(6);
+        expect(firebaseMocks.collectionGroup).not.toHaveBeenCalled();
+        expect(firebaseMocks.getDocs.mock.calls.length - callsBeforeMultiToken).toBe(4);
         expect(multiTokenPlayers.map((player) => player.title)).toEqual([
             '#9 Pat Star',
             '#10 Pat Stone',
@@ -879,20 +883,22 @@ describe('React app search service', () => {
         }]);
     });
 
-    it('falls back to team-scoped player queries when collection-group reads are denied', async () => {
+    it('uses team-scoped player queries for single-team and multi-token searches without collection-group fallback', async () => {
         const visibleTeams = new Map([
             ['team-1', { id: 'team-1', name: 'Bears', sport: 'Basketball', fromAppAccess: true }]
         ]);
-        const error = Object.assign(new Error('permission denied'), { code: 'permission-denied' });
         firebaseMocks.getDocs.mockImplementation(async (request) => {
             const ref = request.parts?.[0] || request || {};
             const collectionName = ref.collectionName || '';
-            if (collectionName === 'players') {
-                throw error;
-            }
-            if (collectionName.endsWith('/players')) {
+            const nameLowerBound = request.parts?.find((part) => part?.type === 'where' && part.field === 'name' && part.op === '>=')?.value;
+            if (collectionName.endsWith('/players') && (nameLowerBound === 'pat' || nameLowerBound === 'Pat')) {
                 return {
                     docs: [firestorePlayer('teams/team-1/players/player-1', { name: 'Pat Bear', number: '4' })]
+                };
+            }
+            if (collectionName.endsWith('/players') && (nameLowerBound === 'st' || nameLowerBound === 'St')) {
+                return {
+                    docs: [firestorePlayer('teams/team-1/players/player-1', { name: 'Pat Star', number: '4' })]
                 };
             }
             return { docs: [] };
@@ -907,27 +913,6 @@ describe('React app search service', () => {
             teamId: 'team-1',
             playerId: 'player-1'
         }]);
-    });
-
-    it('falls back to team-scoped player queries when every collection-group prefix query is denied', async () => {
-        const visibleTeams = new Map([
-            ['team-1', { id: 'team-1', name: 'Bears', sport: 'Basketball', fromAppAccess: true }]
-        ]);
-        const error = Object.assign(new Error('permission denied'), { code: 'permission-denied' });
-        firebaseMocks.getDocs.mockImplementation(async (request) => {
-            const ref = request.parts?.[0] || request || {};
-            const collectionName = ref.collectionName || '';
-            const nameLowerBound = request.parts?.find((part) => part?.type === 'where' && part.field === 'name' && part.op === '>=')?.value;
-            if (collectionName === 'players') {
-                throw error;
-            }
-            if (collectionName.endsWith('/players') && (nameLowerBound === 'pat' || nameLowerBound === 'Pat' || nameLowerBound === 'st' || nameLowerBound === 'St')) {
-                return {
-                    docs: [firestorePlayer('teams/team-1/players/player-1', { name: 'Pat Star', number: '4' })]
-                };
-            }
-            return { docs: [] };
-        });
 
         await expect(searchAppPlayers('pat st', visibleTeams, auth.user)).resolves.toEqual([
             {
@@ -940,9 +925,10 @@ describe('React app search service', () => {
                 playerId: 'player-1'
             }
         ]);
+        expect(firebaseMocks.collectionGroup).not.toHaveBeenCalled();
     });
 
-    it('surfaces Firestore player search errors when every player query fails', async () => {
+    it('surfaces Firestore player search errors when every scoped player query fails', async () => {
         const visibleTeams = new Map([
             ['team-1', { id: 'team-1', name: 'Bears', sport: 'Basketball', fromAppAccess: true }]
         ]);

--- a/tests/unit/global-search-player-fallback.test.js
+++ b/tests/unit/global-search-player-fallback.test.js
@@ -4,11 +4,12 @@ import { resolve } from 'node:path';
 
 const source = readFileSync(resolve(process.cwd(), 'js/global-search.js'), 'utf8');
 
-describe('legacy global player search fallback', () => {
-    it('falls back to team-scoped player queries when collection-group reads are denied', () => {
+describe('legacy global player search scoping', () => {
+    it('queries only accessible team player collections for normal searches', () => {
         expect(source).toContain('async function loadPlayerSearchDocsByTeam(');
+        expect(source).toContain('async function loadPlayerSearchDocs(prefixes, rawQuery, isNumeric, teamsById)');
         expect(source).toContain("const playersRef = collection(db, `teams/${teamId}/players`);");
-        expect(source).toContain('const onlyPermissionDeniedFailures = baseResult.docs.length === 0');
-        expect(source).toContain('? await loadPlayerSearchDocsByTeam(prefixes, q, isNumeric, modalState.teamsById)');
+        expect(source).toContain('const result = await loadPlayerSearchDocs(prefixes, q, isNumeric, modalState.teamsById);');
+        expect(source).not.toContain("collectionGroup(db, 'players')");
     });
 });

--- a/tests/unit/global-search-player-fallback.test.js
+++ b/tests/unit/global-search-player-fallback.test.js
@@ -12,4 +12,12 @@ describe('legacy global player search scoping', () => {
         expect(source).toContain('const result = await loadPlayerSearchDocs(prefixes, q, isNumeric, modalState.teamsById);');
         expect(source).not.toContain("collectionGroup(db, 'players')");
     });
+
+    it('limits legacy player fan-out to a bounded set of searchable teams', () => {
+        expect(source).toContain('const playerSearchTeamLimit = 8;');
+        expect(source).toContain('function getPlayerSearchTeamIds(rawQuery, teamsById)');
+        expect(source).toContain('filterSearchableTeams(Array.from(teamsById.values()), currentUser)');
+        expect(source).toContain('.slice(0, playerSearchTeamLimit)');
+        expect(source).toContain('const teamIds = getPlayerSearchTeamIds(rawQuery, teamsById);');
+    });
 });


### PR DESCRIPTION
Closes #1837

## What changed
- removed app player search use of global `collectionGroup('players')` scans and routed normal searches through team-scoped `teams/{teamId}/players` queries built from already-accessible teams
- removed the same global player scan path from the legacy search modal and reused the same team-scoped query pattern there
- updated app search regression tests to assert no normal player search path uses `collectionGroup`, and that multi-token refinement stays on scoped team queries
- updated legacy search source coverage to assert the modal now queries only accessible team player collections

## Root Cause
Both the React app and the legacy search modal defaulted to global Firestore `collectionGroup('players')` prefix scans, then filtered inaccessible teams only after documents were read. That meant every 2+ character search paid global read fan-out before visibility scoping.

## Prevention / Learning
When visibility is already team-scoped, build Firestore search queries from the authorized team set first. Add a focused regression test that explicitly forbids `collectionGroup` scans on protected child collections so performance and access boundaries cannot silently drift back.

## Regression Tests
- `npx vitest run tests/unit/app-search-service.test.js tests/unit/global-search-player-fallback.test.js --reporter=verbose`
- `tests/unit/app-search-service.test.js` now asserts scoped player collection queries and no normal `collectionGroup` path
- `tests/unit/global-search-player-fallback.test.js` now asserts the legacy modal uses accessible-team player collections instead of a global player collection-group scan