### PR TITLE
Add in-app live chat to schedule event detail

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -91,8 +91,8 @@ const liveGameReactionsServiceMocks = vi.hoisted(() => ({
 vi.mock('../lib/liveGameReactionsService', () => liveGameReactionsServiceMocks);
 vi.mock('../lib/parentToolsService', () => ({ buildParentScheduleEventIcs: vi.fn(() => 'BEGIN:VCALENDAR') }));
 const scheduleHubMocks = vi.hoisted(() => ({
-  buildGameHubDestinations: vi.fn(() => []),
-  buildPracticeHubDestinations: vi.fn(() => []),
+  buildGameHubDestinations: vi.fn<() => any[]>(() => []),
+  buildPracticeHubDestinations: vi.fn<() => any[]>(() => []),
   getPublicPlayerHref: vi.fn(() => '#')
 }));
 vi.mock('../lib/scheduleHub', () => scheduleHubMocks);

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -58,6 +58,18 @@ const gameWrapupServiceMocks = vi.hoisted(() => ({
 vi.mock('../lib/gameWrapupService', () => gameWrapupServiceMocks);
 vi.mock('../lib/publicActions', () => publicActionMocks);
 vi.mock('../lib/liveGameAnnouncer', () => ({ useLiveGameAnnouncer: vi.fn() }));
+const liveGameChatServiceMocks = vi.hoisted(() => ({
+  canUseLiveGameChat: vi.fn<(game: unknown, options?: unknown) => boolean>(() => true),
+  getLiveGameChatNotice: vi.fn<(game: unknown, options?: unknown) => string | null>(() => null),
+  sendLiveGameChatMessage: vi.fn<(teamId: string, gameId: string, input: unknown) => Promise<unknown>>(),
+  subscribeToLiveGameChat: vi.fn<(
+    teamId: string,
+    gameId: string,
+    callback: (messages: Array<{ id: string; text?: string | null; senderName?: string | null; createdAt?: unknown }>) => void,
+    onError?: (error: unknown) => void
+  ) => () => void>(() => vi.fn())
+}));
+vi.mock('../lib/liveGameChatService', () => liveGameChatServiceMocks);
 const liveGameReactionsServiceMocks = vi.hoisted(() => ({
   canUseLiveGameReactions: vi.fn<(game: unknown, options?: unknown) => boolean>(() => true),
   getLiveGameReactionNotice: vi.fn<(game: unknown, options?: unknown) => string | null>(() => null),
@@ -78,11 +90,12 @@ const liveGameReactionsServiceMocks = vi.hoisted(() => ({
 }));
 vi.mock('../lib/liveGameReactionsService', () => liveGameReactionsServiceMocks);
 vi.mock('../lib/parentToolsService', () => ({ buildParentScheduleEventIcs: vi.fn(() => 'BEGIN:VCALENDAR') }));
-vi.mock('../lib/scheduleHub', () => ({
+const scheduleHubMocks = vi.hoisted(() => ({
   buildGameHubDestinations: vi.fn(() => []),
   buildPracticeHubDestinations: vi.fn(() => []),
   getPublicPlayerHref: vi.fn(() => '#')
 }));
+vi.mock('../lib/scheduleHub', () => scheduleHubMocks);
 const practiceTimelineServiceMocks = vi.hoisted(() => ({
   loadPracticeTimelineModel: vi.fn(),
   savePracticeTimelineForApp: vi.fn(),
@@ -195,6 +208,10 @@ describe('ScheduleEventDetail assignments', () => {
     liveGameReactionsServiceMocks.canUseLiveGameReactions.mockReturnValue(true);
     liveGameReactionsServiceMocks.getLiveGameReactionNotice.mockReturnValue(null);
     liveGameReactionsServiceMocks.subscribeToLiveGameReactions.mockReturnValue(vi.fn());
+    liveGameChatServiceMocks.canUseLiveGameChat.mockReturnValue(true);
+    liveGameChatServiceMocks.getLiveGameChatNotice.mockReturnValue(null);
+    liveGameChatServiceMocks.subscribeToLiveGameChat.mockReturnValue(vi.fn());
+    scheduleHubMocks.buildGameHubDestinations.mockReturnValue([]);
     Object.defineProperty(window, 'scrollTo', {
       value: vi.fn(),
       writable: true
@@ -263,6 +280,98 @@ describe('ScheduleEventDetail assignments', () => {
 
     expect((screen.getByRole('button', { name: 'Heart' }) as HTMLButtonElement).disabled).toBe(true);
     expect(liveGameReactionsServiceMocks.sendLiveGameReaction).not.toHaveBeenCalled();
+  });
+
+  it('renders in-route live chat, streams messages, and keeps watch live links external', async () => {
+    let chatCallback: (messages: Array<{ id: string; text?: string | null; senderName?: string | null; createdAt?: unknown }>) => void = () => {};
+    liveGameChatServiceMocks.subscribeToLiveGameChat.mockImplementation((_teamId, _gameId, callback) => {
+      chatCallback = callback;
+      return vi.fn();
+    });
+    liveGameChatServiceMocks.sendLiveGameChatMessage.mockResolvedValue({ id: 'sent-1' });
+    scheduleHubMocks.buildGameHubDestinations.mockReturnValue([
+      {
+        id: 'watch-live',
+        icon: 'video',
+        title: 'Watch live',
+        detail: 'Open the live stream.',
+        actionLabel: 'Watch live',
+        url: 'https://allplays.ai/live-game.html?teamId=team-1&gameId=game-1',
+        shareTitle: 'Watch live',
+        shareText: 'Watch live',
+        shareLabel: 'Watch live',
+        actionKind: 'open'
+      }
+    ]);
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({ liveStatus: 'live', status: 'live' })],
+      children: []
+    });
+
+    const { unmount } = renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('live-game-chat-panel')).toBeTruthy();
+    });
+
+    chatCallback([
+      { id: 'm2', text: 'Second', senderName: 'Parent Two', createdAt: '2026-06-04T18:02:00.000Z' },
+      { id: 'm1', text: 'First', senderName: 'Parent One', createdAt: '2026-06-04T18:01:00.000Z' }
+    ]);
+
+    await waitFor(() => {
+      const messageRows = screen.getAllByTestId(/live-chat-message-/);
+      expect(messageRows).toHaveLength(2);
+      expect(messageRows[0]?.textContent).toContain('First');
+      expect(messageRows[1]?.textContent).toContain('Second');
+    });
+
+    fireEvent.change(screen.getByLabelText('Live chat message'), { target: { value: 'Let\'s go Bears' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Send' }));
+
+    await waitFor(() => {
+      expect(liveGameChatServiceMocks.sendLiveGameChatMessage).toHaveBeenCalledWith('team-1', 'game-1', expect.objectContaining({
+        text: 'Let\'s go Bears',
+        user: auth.user
+      }));
+    });
+    expect((screen.getByLabelText('Live chat message') as HTMLTextAreaElement).value).toBe('');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Watch live' }));
+    expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://allplays.ai/live-game.html?teamId=team-1&gameId=game-1');
+
+    const unsubscribe = liveGameChatServiceMocks.subscribeToLiveGameChat.mock.results[0]?.value as ReturnType<typeof vi.fn>;
+    unmount();
+    expect(unsubscribe).toHaveBeenCalled();
+  });
+
+  it('shows the locked live chat notice and disables the composer when chat is unavailable', async () => {
+    liveGameChatServiceMocks.canUseLiveGameChat.mockReturnValue(false);
+    liveGameChatServiceMocks.getLiveGameChatNotice.mockReturnValue('Live chat is closed during replay.');
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({ liveStatus: 'completed', status: 'completed' })],
+      children: []
+    });
+
+    renderScheduleEventDetail();
+
+    await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
+    });
+    fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Live chat is closed during replay.')).toBeTruthy();
+    });
+
+    expect((screen.getByLabelText('Live chat message') as HTMLTextAreaElement).disabled).toBe(true);
+    expect((screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement).disabled).toBe(true);
+    expect(liveGameChatServiceMocks.sendLiveGameChatMessage).not.toHaveBeenCalled();
   });
 
   it('uses native-aware calendar export messaging for shared, downloaded, and failed event exports', async () => {

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -67,6 +67,13 @@ import { loadGameReportSections, type GameReportData, type GameReportInsight, ty
 import { exportCalendarIcsFile, openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 import { useLiveGameAnnouncer } from '../lib/liveGameAnnouncer';
 import {
+  canUseLiveGameChat,
+  getLiveGameChatNotice,
+  sendLiveGameChatMessage,
+  subscribeToLiveGameChat,
+  type LiveGameChatMessage
+} from '../lib/liveGameChatService';
+import {
   canUseLiveGameReactions,
   getLiveGameReactionNotice,
   liveGameReactionOptions,
@@ -1906,6 +1913,132 @@ function LiveGameReactionsPanel({ auth, event }: { auth: AuthState; event: Paren
   );
 }
 
+function LiveGameChatPanel({ auth, event }: { auth: AuthState; event: ParentScheduleEvent }) {
+  const [messages, setMessages] = useState<LiveGameChatMessage[]>([]);
+  const [messageText, setMessageText] = useState('');
+  const [anonymousDisplayName, setAnonymousDisplayName] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [sending, setSending] = useState(false);
+  const [status, setStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
+
+  const canChat = canUseLiveGameChat(event, { now: new Date() });
+  const chatNotice = getLiveGameChatNotice(event, { now: new Date() });
+  const canSend = canChat && Boolean(messageText.trim()) && !sending;
+
+  useEffect(() => {
+    if (!event.isDbGame || !event.teamId || !event.id) return undefined;
+
+    setLoading(true);
+    setStatus(null);
+    const unsubscribe = subscribeToLiveGameChat(event.teamId, event.id, (nextMessages) => {
+      setMessages(sortLiveGameChatMessages(nextMessages));
+      setLoading(false);
+    }, (subscribeError: any) => {
+      setStatus({ tone: 'error', message: subscribeError?.message || 'Unable to load live chat.' });
+      setLoading(false);
+    });
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, [event.id, event.isDbGame, event.teamId]);
+
+  const sendMessage = async (submitEvent: FormEvent) => {
+    submitEvent.preventDefault();
+    if (!canChat || !event.teamId || !event.id || !messageText.trim() || sending) return;
+
+    setSending(true);
+    setStatus(null);
+    try {
+      await sendLiveGameChatMessage(event.teamId, event.id, {
+        text: messageText,
+        user: auth.user || undefined,
+        anonymousDisplayName
+      });
+      setMessageText('');
+      setStatus({ tone: 'success', message: 'Message sent.' });
+    } catch (sendError: any) {
+      setStatus({ tone: 'error', message: sendError?.message || 'Unable to send message.' });
+    } finally {
+      setSending(false);
+    }
+  };
+
+  if (!event.isDbGame) return null;
+
+  return (
+    <div className="mt-3 rounded-2xl border border-sky-200 bg-sky-50/60 p-3" data-testid="live-game-chat-panel">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0">
+          <div className="text-xs font-black uppercase tracking-[0.04em] text-sky-700">Live chat</div>
+          <div className="mt-1 text-sm font-semibold text-gray-900">Read and send game-day chat without leaving this screen.</div>
+        </div>
+        <div className="rounded-full bg-white px-3 py-1 text-xs font-black text-sky-700 shadow-sm">
+          {messages.length ? `${messages.length} messages` : 'Ready'}
+        </div>
+      </div>
+
+      <div className="mt-3 rounded-2xl border border-white/80 bg-white p-3 shadow-sm">
+        <div className="max-h-64 space-y-2 overflow-y-auto pr-1" aria-label="Live chat messages">
+          {loading ? (
+            <div className="text-sm font-semibold text-gray-500">Loading live chat…</div>
+          ) : messages.length ? messages.map((message) => (
+            <article key={message.id} className="rounded-xl border border-gray-100 bg-gray-50 p-2.5" data-testid={`live-chat-message-${message.id}`}>
+              <div className="flex items-center justify-between gap-2">
+                <div className="truncate text-sm font-black text-gray-950">{message.senderName || 'Fan'}</div>
+                <div className="text-[11px] font-semibold text-gray-500">{formatLiveGameChatTimestamp(message.createdAt)}</div>
+              </div>
+              <div className="mt-1 text-sm font-semibold leading-5 text-gray-700">{String(message.text || '').trim() || ' '}</div>
+            </article>
+          )) : (
+            <div className="text-sm font-semibold text-gray-500">No messages yet. Start the game-day chat.</div>
+          )}
+        </div>
+
+        <form className="mt-3 space-y-2" onSubmit={sendMessage}>
+          {!auth.user ? (
+            <label className="block">
+              <span className="app-label">Display name</span>
+              <input
+                className="auth-input mt-1 min-h-10 !px-3 !py-2 text-sm"
+                value={anonymousDisplayName}
+                onChange={(changeEvent) => setAnonymousDisplayName(changeEvent.target.value)}
+                maxLength={60}
+                placeholder="Your name"
+                disabled={!canChat || sending}
+              />
+            </label>
+          ) : null}
+          <label className="block">
+            <span className="sr-only">Live chat message</span>
+            <textarea
+              aria-label="Live chat message"
+              className="auth-input min-h-24 resize-none !px-3 !py-2 text-sm font-semibold"
+              value={messageText}
+              onChange={(changeEvent) => setMessageText(changeEvent.target.value)}
+              placeholder={canChat ? 'Send a message to fans and parents' : 'Live chat is locked'}
+              maxLength={280}
+              disabled={!canChat || sending}
+            />
+          </label>
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="text-xs font-semibold text-gray-500">{chatNotice || 'Shared with the same live-game chat stream as the web viewer.'}</div>
+            <button
+              type="submit"
+              className="primary-button min-h-10 px-4 text-sm disabled:opacity-60"
+              disabled={!canSend}
+            >
+              {sending ? 'Sending' : 'Send'}
+            </button>
+          </div>
+        </form>
+      </div>
+
+      {status ? <div className="mt-3"><Status tone={status.tone} message={status.message} /></div> : null}
+    </div>
+  );
+}
+
 function GameHubSection({ auth, event, childEvents, onScoreUpdated, onWrapupCompleted, onGameCancelled, onPracticeOccurrenceCancelled, onGamePlanPublished }: { auth: AuthState; event: ParentScheduleEvent; childEvents: ParentScheduleEvent[]; onScoreUpdated: (homeScore: number, awayScore: number) => void; onWrapupCompleted: (payload: { homeScore: number; awayScore: number; postGameNotes: string; summary: string; practiceFeedItems: PracticeFeedItem[] }) => void; onGameCancelled: () => void; onPracticeOccurrenceCancelled: () => void; onGamePlanPublished: (gamePlan: Record<string, any>) => void }) {
   const [shareStatus, setShareStatus] = useState<string | null>(null);
   const [cancelStatus, setCancelStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
@@ -2026,6 +2159,7 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onWrapupComp
 
           {canUpdateScore ? <LiveScoreEditor auth={auth} event={event} onScoreUpdated={onScoreUpdated} /> : null}
           {!isPractice ? <LiveGameReactionsPanel auth={auth} event={event} /> : null}
+          {!isPractice ? <LiveGameChatPanel auth={auth} event={event} /> : null}
 
           {canWrapup ? <GameWrapupPanel auth={auth} event={event} onWrapupCompleted={onWrapupCompleted} /> : null}
 
@@ -3870,6 +4004,28 @@ function GameHubDestinationCard({ destination, onShare }: {
       </div>
     </article>
   );
+}
+
+function sortLiveGameChatMessages(messages: LiveGameChatMessage[]) {
+  return [...messages].sort((left, right) => getLiveGameChatTimestampValue(left.createdAt) - getLiveGameChatTimestampValue(right.createdAt));
+}
+
+function getLiveGameChatTimestampValue(value: unknown) {
+  if (value && typeof value === 'object' && typeof (value as { toDate?: () => Date }).toDate === 'function') {
+    return (value as { toDate: () => Date }).toDate().getTime();
+  }
+  const parsed = new Date(value as any);
+  const timestamp = parsed.getTime();
+  return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+function formatLiveGameChatTimestamp(value: unknown) {
+  const timestamp = getLiveGameChatTimestampValue(value);
+  if (!timestamp) return 'Now';
+  return new Date(timestamp).toLocaleTimeString([], {
+    hour: 'numeric',
+    minute: '2-digit'
+  });
 }
 
 function formatAssignment(assignment?: { role?: string; value?: string; claim?: { claimedByName?: string } | null }) {


### PR DESCRIPTION
Closes #1840

## What changed
- added an inline live chat panel to `ScheduleEventDetail` for game events so fans and parents can read and send messages without leaving the React route
- wired the panel to `subscribeToLiveGameChat` and `sendLiveGameChatMessage`, with chronological message rendering, inline send feedback, and cleanup on unmount
- used `canUseLiveGameChat` and `getLiveGameChatNotice` to drive locked-state messaging and disabled composer behavior while keeping the existing Watch live external-link card intact
- added focused route tests covering live chat rendering, subscription updates, send behavior, locked-state gating, unsubscribe cleanup, and coexistence with the external Watch live action

## Root Cause
`GameDetail` previously carried the React live chat integration, but the later route consolidation into `ScheduleEventDetail` only preserved the external live/replay launcher cards. The shared `liveGameChatService` helpers already existed, but no component on the active schedule detail route consumed them, so chat parity was lost when the old route stopped being the primary surface.

## Prevention / Learning
When replacing or consolidating app routes, treat the outgoing route as a feature inventory, not just a navigation target. Port adjacent real-time panels and keep focused parity tests on the new canonical route so route swaps do not silently drop embedded capabilities while helper services remain unused.

## Regression Tests
- `npx vitest run apps/app/src/pages/ScheduleEventDetail.test.tsx`
- verified the new test coverage for in-route live chat streaming, send behavior, locked composer state, and preserving the external Watch live action