### PR TITLE
Add app stat tracking service foundation

### DIFF
--- a/apps/app/src/lib/statTrackingService.test.ts
+++ b/apps/app/src/lib/statTrackingService.test.ts
@@ -107,7 +107,7 @@ describe('statTrackingService', () => {
     expect(service.getEventLog()).toHaveLength(1);
   });
 
-  it('undoes the last event by deleting the event doc, reversing aggregates, and restoring score', async () => {
+  it('undoes the last event by reversing aggregates before deleting the event doc and restoring score', async () => {
     const dependencies = createDependencies();
     const service = createStatTrackingService({
       statConfig: { columns: ['PTS', 'AST'] },
@@ -138,7 +138,6 @@ describe('statTrackingService', () => {
     const undone = await service.undoLastEvent('team-1', 'game-1', user);
 
     expect(undone?.event.playerId).toBe('player-1');
-    expect(dependencies.deleteDoc).toHaveBeenCalledWith({ path: expect.stringContaining('teams/team-1/games/game-1/events/app-track-') });
     expect(dependencies.setDoc).toHaveBeenCalledWith({ path: 'teams/team-1/games/game-1/aggregatedStats/player-1' }, expect.objectContaining({
       stats: {
         pts: { __increment: -2 }
@@ -148,6 +147,9 @@ describe('statTrackingService', () => {
       homeScore: 10,
       awayScore: 8
     }, user);
+    expect(dependencies.deleteDoc).toHaveBeenCalledWith({ path: expect.stringContaining('teams/team-1/games/game-1/events/app-track-') });
+    expect(dependencies.setDoc.mock.invocationCallOrder[0]).toBeLessThan(dependencies.deleteDoc.mock.invocationCallOrder[0]);
+    expect(dependencies.updateGameScore.mock.invocationCallOrder[0]).toBeLessThan(dependencies.deleteDoc.mock.invocationCallOrder[0]);
     expect(service.getCurrentScore()).toEqual({ homeScore: 10, awayScore: 8 });
     expect(service.getEventLog()).toHaveLength(0);
     expect(await service.undoLastEvent('team-1', 'game-1', user)).toBeNull();
@@ -211,13 +213,135 @@ describe('statTrackingService', () => {
     });
 
     expect(dependencies.setDoc).toHaveBeenNthCalledWith(1, { path: expect.stringContaining('/events/app-track-') }, expect.any(Object));
-    expect(dependencies.setDoc).toHaveBeenNthCalledWith(2, { path: 'teams/team-1/games/game-1/aggregatedStats/player-1' }, expect.objectContaining({
-      stats: {}
-    }), { merge: true });
+    expect(dependencies.setDoc).toHaveBeenNthCalledWith(2, { path: 'teams/team-1/games/game-1/aggregatedStats/player-1' }, {
+      playerName: 'Alex',
+      playerNumber: '4',
+      participated: true,
+      participationStatus: 'appeared',
+      participationSource: 'app-stat-tracker',
+      didNotPlay: false
+    }, { merge: true });
     expect(dependencies.setDoc).toHaveBeenNthCalledWith(3, { path: 'teams/team-1/games/game-1/privatePlayerStats/player-1' }, expect.objectContaining({
       stats: {
         notes: { __increment: 1 }
       }
     }), { merge: true });
+  });
+
+  it('cleans up the event document when aggregate writes fail during record', async () => {
+    const dependencies = createDependencies();
+    dependencies.setDoc
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('aggregate failed'));
+    const service = createStatTrackingService({
+      statConfig: { columns: ['PTS'] },
+      dependencies
+    });
+
+    await expect(service.recordEvent('team-1', 'game-1', {
+      text: '#4 Alex PTS +2',
+      clock: '01:20',
+      period: 'Q1',
+      playerName: 'Alex',
+      playerNumber: '4',
+      undoData: {
+        type: 'stat',
+        playerId: 'player-1',
+        statKey: 'PTS',
+        value: 2,
+        isOpponent: false
+      }
+    }, {
+      uid: 'coach-1'
+    })).rejects.toThrow('aggregate failed');
+
+    expect(dependencies.deleteDoc).toHaveBeenCalledWith({ path: expect.stringContaining('teams/team-1/games/game-1/events/app-track-') });
+    expect(dependencies.updateGameScore).not.toHaveBeenCalled();
+    expect(service.getEventLog()).toHaveLength(0);
+  });
+
+  it('restores aggregate and score state if undo fails to delete the event document', async () => {
+    const dependencies = createDependencies();
+    const service = createStatTrackingService({
+      statConfig: { columns: ['PTS'] },
+      initialScore: { homeScore: 10, awayScore: 8 },
+      dependencies
+    });
+    const user = { uid: 'coach-1' };
+
+    await service.recordEvent('team-1', 'game-1', {
+      text: '#4 Alex PTS +2',
+      clock: '01:20',
+      period: 'Q1',
+      playerName: 'Alex',
+      playerNumber: '4',
+      undoData: {
+        type: 'stat',
+        playerId: 'player-1',
+        statKey: 'PTS',
+        value: 2,
+        isOpponent: false
+      }
+    }, user);
+
+    dependencies.setDoc.mockClear();
+    dependencies.updateGameScore.mockClear();
+    dependencies.deleteDoc.mockRejectedValueOnce(new Error('delete failed'));
+
+    await expect(service.undoLastEvent('team-1', 'game-1', user)).rejects.toThrow('delete failed');
+
+    expect(dependencies.setDoc).toHaveBeenNthCalledWith(1, { path: 'teams/team-1/games/game-1/aggregatedStats/player-1' }, expect.objectContaining({
+      stats: {
+        pts: { __increment: -2 }
+      }
+    }), { merge: true });
+    expect(dependencies.setDoc).toHaveBeenNthCalledWith(2, { path: 'teams/team-1/games/game-1/aggregatedStats/player-1' }, expect.objectContaining({
+      stats: {
+        pts: { __increment: 2 }
+      }
+    }), { merge: true });
+    expect(dependencies.updateGameScore).toHaveBeenNthCalledWith(1, 'team-1', 'game-1', {
+      homeScore: 10,
+      awayScore: 8
+    }, user);
+    expect(dependencies.updateGameScore).toHaveBeenNthCalledWith(2, 'team-1', 'game-1', {
+      homeScore: 12,
+      awayScore: 8
+    }, user);
+    expect(service.getCurrentScore()).toEqual({ homeScore: 12, awayScore: 8 });
+    expect(service.getEventLog()).toHaveLength(1);
+  });
+
+  it('updates the away score for opponent scoring events', async () => {
+    const dependencies = createDependencies();
+    const service = createStatTrackingService({
+      statConfig: { columns: ['PTS'] },
+      initialScore: { homeScore: 10, awayScore: 8 },
+      dependencies
+    });
+
+    await service.recordEvent('team-1', 'game-1', {
+      text: 'Opp Team PTS +3',
+      clock: '01:20',
+      period: 'Q1',
+      teamSide: 'home',
+      undoData: {
+        type: 'stat',
+        playerId: 'opp-1',
+        statKey: 'PTS',
+        value: 3,
+        isOpponent: true
+      }
+    }, {
+      uid: 'coach-1'
+    });
+
+    expect(dependencies.updateGameScore).toHaveBeenCalledWith('team-1', 'game-1', {
+      homeScore: 10,
+      awayScore: 11
+    }, {
+      uid: 'coach-1'
+    });
+    expect(service.getCurrentScore()).toEqual({ homeScore: 10, awayScore: 11 });
   });
 });

--- a/apps/app/src/lib/statTrackingService.test.ts
+++ b/apps/app/src/lib/statTrackingService.test.ts
@@ -1,0 +1,223 @@
+import { describe, expect, it, vi } from 'vitest';
+import { buildTrackerEventDocument, createStatTrackingService } from './statTrackingService';
+
+function createDependencies() {
+  return {
+    db: { name: 'db' } as any,
+    doc: vi.fn((_db: unknown, ...segments: string[]) => ({ path: segments.join('/') })),
+    setDoc: vi.fn(async () => undefined),
+    deleteDoc: vi.fn(async () => undefined),
+    increment: vi.fn((value: number) => ({ __increment: value })),
+    updateGameScore: vi.fn(async () => undefined)
+  };
+}
+
+describe('statTrackingService', () => {
+  it('builds legacy-compatible tracker event documents', () => {
+    const event = buildTrackerEventDocument({
+      text: '#4 Alex PTS +2',
+      clock: '01:20',
+      period: 'Q1',
+      timestamp: 1718150400000,
+      undoData: {
+        type: 'stat',
+        playerId: 'player-1',
+        statKey: 'PTS',
+        value: 2,
+        isOpponent: false
+      }
+    }, {
+      uid: 'coach-1'
+    });
+
+    expect(event).toEqual({
+      text: '#4 Alex PTS +2',
+      gameTime: '01:20',
+      period: 'Q1',
+      timestamp: 1718150400000,
+      type: 'stat',
+      playerId: 'player-1',
+      statKey: 'pts',
+      value: 2,
+      isOpponent: false,
+      createdBy: 'coach-1'
+    });
+  });
+
+  it('records stat events, updates aggregates, and keeps score in sync', async () => {
+    const dependencies = createDependencies();
+    const service = createStatTrackingService({
+      statConfig: { columns: ['PTS', 'AST'] },
+      initialScore: { homeScore: 10, awayScore: 8 },
+      dependencies
+    });
+
+    const result = await service.recordEvent('team-1', 'game-1', {
+      text: '#4 Alex PTS +2',
+      clock: '01:20',
+      period: 'Q1',
+      timestamp: 1001,
+      playerName: 'Alex',
+      playerNumber: '4',
+      teamSide: 'home',
+      undoData: {
+        type: 'stat',
+        playerId: 'player-1',
+        statKey: 'PTS',
+        value: 2,
+        isOpponent: false
+      }
+    }, {
+      uid: 'coach-1',
+      email: 'coach@example.com'
+    });
+
+    expect(result.eventId).toMatch(/^app-track-/);
+    expect(dependencies.setDoc).toHaveBeenNthCalledWith(1, { path: expect.stringContaining('teams/team-1/games/game-1/events/app-track-') }, {
+      text: '#4 Alex PTS +2',
+      gameTime: '01:20',
+      period: 'Q1',
+      timestamp: 1001,
+      type: 'stat',
+      playerId: 'player-1',
+      statKey: 'pts',
+      value: 2,
+      isOpponent: false,
+      createdBy: 'coach-1'
+    });
+    expect(dependencies.setDoc).toHaveBeenNthCalledWith(2, { path: 'teams/team-1/games/game-1/aggregatedStats/player-1' }, {
+      playerName: 'Alex',
+      playerNumber: '4',
+      participated: true,
+      participationStatus: 'appeared',
+      participationSource: 'app-stat-tracker',
+      didNotPlay: false,
+      stats: {
+        pts: { __increment: 2 }
+      }
+    }, { merge: true });
+    expect(dependencies.updateGameScore).toHaveBeenCalledWith('team-1', 'game-1', {
+      homeScore: 12,
+      awayScore: 8
+    }, {
+      uid: 'coach-1',
+      email: 'coach@example.com'
+    });
+    expect(service.getCurrentScore()).toEqual({ homeScore: 12, awayScore: 8 });
+    expect(service.getEventLog()).toHaveLength(1);
+  });
+
+  it('undoes the last event by deleting the event doc, reversing aggregates, and restoring score', async () => {
+    const dependencies = createDependencies();
+    const service = createStatTrackingService({
+      statConfig: { columns: ['PTS', 'AST'] },
+      initialScore: { homeScore: 10, awayScore: 8 },
+      dependencies
+    });
+    const user = { uid: 'coach-1', email: 'coach@example.com' };
+
+    await service.recordEvent('team-1', 'game-1', {
+      text: '#4 Alex PTS +2',
+      clock: '01:20',
+      period: 'Q1',
+      playerName: 'Alex',
+      playerNumber: '4',
+      teamSide: 'home',
+      undoData: {
+        type: 'stat',
+        playerId: 'player-1',
+        statKey: 'PTS',
+        value: 2,
+        isOpponent: false
+      }
+    }, user);
+
+    dependencies.setDoc.mockClear();
+    dependencies.updateGameScore.mockClear();
+
+    const undone = await service.undoLastEvent('team-1', 'game-1', user);
+
+    expect(undone?.event.playerId).toBe('player-1');
+    expect(dependencies.deleteDoc).toHaveBeenCalledWith({ path: expect.stringContaining('teams/team-1/games/game-1/events/app-track-') });
+    expect(dependencies.setDoc).toHaveBeenCalledWith({ path: 'teams/team-1/games/game-1/aggregatedStats/player-1' }, expect.objectContaining({
+      stats: {
+        pts: { __increment: -2 }
+      }
+    }), { merge: true });
+    expect(dependencies.updateGameScore).toHaveBeenCalledWith('team-1', 'game-1', {
+      homeScore: 10,
+      awayScore: 8
+    }, user);
+    expect(service.getCurrentScore()).toEqual({ homeScore: 10, awayScore: 8 });
+    expect(service.getEventLog()).toHaveLength(0);
+    expect(await service.undoLastEvent('team-1', 'game-1', user)).toBeNull();
+  });
+
+  it('rejects unknown stat columns before writing', async () => {
+    const dependencies = createDependencies();
+    const service = createStatTrackingService({
+      statConfig: { columns: ['PTS', 'AST'] },
+      dependencies
+    });
+
+    await expect(service.recordEvent('team-1', 'game-1', {
+      text: '#4 Alex BLK +1',
+      clock: '01:20',
+      period: 'Q1',
+      playerName: 'Alex',
+      playerNumber: '4',
+      undoData: {
+        type: 'stat',
+        playerId: 'player-1',
+        statKey: 'BLK',
+        value: 1,
+        isOpponent: false
+      }
+    }, {
+      uid: 'coach-1'
+    })).rejects.toThrow('Unknown stat column key: blk');
+
+    expect(dependencies.setDoc).not.toHaveBeenCalled();
+    expect(dependencies.updateGameScore).not.toHaveBeenCalled();
+  });
+
+  it('routes private stat definitions to privatePlayerStats while preserving participation', async () => {
+    const dependencies = createDependencies();
+    const service = createStatTrackingService({
+      statConfig: {
+        columns: ['PTS'],
+        statDefinitions: [
+          { id: 'notes', scope: 'player', visibility: 'private' }
+        ]
+      },
+      dependencies
+    });
+
+    await service.recordEvent('team-1', 'game-1', {
+      text: '#4 Alex NOTES +1',
+      clock: '01:20',
+      period: 'Q1',
+      playerName: 'Alex',
+      playerNumber: '4',
+      undoData: {
+        type: 'stat',
+        playerId: 'player-1',
+        statKey: 'notes',
+        value: 1,
+        isOpponent: false
+      }
+    }, {
+      uid: 'coach-1'
+    });
+
+    expect(dependencies.setDoc).toHaveBeenNthCalledWith(1, { path: expect.stringContaining('/events/app-track-') }, expect.any(Object));
+    expect(dependencies.setDoc).toHaveBeenNthCalledWith(2, { path: 'teams/team-1/games/game-1/aggregatedStats/player-1' }, expect.objectContaining({
+      stats: {}
+    }), { merge: true });
+    expect(dependencies.setDoc).toHaveBeenNthCalledWith(3, { path: 'teams/team-1/games/game-1/privatePlayerStats/player-1' }, expect.objectContaining({
+      stats: {
+        notes: { __increment: 1 }
+      }
+    }), { merge: true });
+  });
+});

--- a/apps/app/src/lib/statTrackingService.ts
+++ b/apps/app/src/lib/statTrackingService.ts
@@ -1,0 +1,373 @@
+import { db, deleteDoc, doc, increment, setDoc } from '../../../../js/firebase.js';
+import { splitPlayerStatsByVisibility } from '../../../../js/stat-leaderboards.js';
+
+export type TrackerScoreState = {
+  homeScore: number;
+  awayScore: number;
+};
+
+export type TrackerUser = {
+  uid: string;
+  displayName?: string | null;
+  email?: string | null;
+};
+
+export type TrackerStatConfig = {
+  columns?: string[];
+  statDefinitions?: Array<{ id?: string; scope?: string; visibility?: string }>;
+};
+
+export type TrackerUndoData = {
+  type?: string | null;
+  playerId?: string | null;
+  statKey?: string | null;
+  value?: number | null;
+  isOpponent?: boolean;
+};
+
+export type TrackerEventInput = {
+  text: string;
+  clock?: string | null;
+  gameTime?: string | null;
+  period?: string | null;
+  timestamp?: number | Date | null;
+  undoData?: TrackerUndoData | null;
+  playerName?: string | null;
+  playerNumber?: string | null;
+  teamSide?: 'home' | 'away';
+};
+
+export type TrackerEventDocument = {
+  text: string;
+  gameTime: string;
+  period: string;
+  timestamp: number;
+  type: string;
+  playerId: string | null;
+  statKey: string | null;
+  value: number | null;
+  isOpponent: boolean;
+  createdBy: string;
+};
+
+export type TrackerLogEntry = {
+  eventId: string;
+  event: TrackerEventDocument;
+  scoreBefore: TrackerScoreState;
+  scoreAfter: TrackerScoreState;
+  aggregateStatKey: string | null;
+  aggregateDelta: number;
+  aggregatePlayerId: string | null;
+  isOpponent: boolean;
+  playerName: string;
+  playerNumber: string;
+};
+
+type StatTrackingDependencies = {
+  doc: typeof doc;
+  setDoc: typeof setDoc;
+  deleteDoc: typeof deleteDoc;
+  increment: typeof increment;
+  db: typeof db;
+  updateGameScore: (teamId: string, gameId: string, score: TrackerScoreState, user: TrackerUser) => Promise<unknown>;
+};
+
+const DEFAULT_SCORE: TrackerScoreState = { homeScore: 0, awayScore: 0 };
+const BASE_TRACKER_PERIOD = 'Q1';
+const BASE_PARTICIPATION_SOURCE = 'app-stat-tracker';
+
+function normalizeScoreValue(value: unknown) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function normalizeScoreState(score: Partial<TrackerScoreState> | null | undefined): TrackerScoreState {
+  return {
+    homeScore: normalizeScoreValue(score?.homeScore),
+    awayScore: normalizeScoreValue(score?.awayScore)
+  };
+}
+
+function normalizeText(value: unknown) {
+  return String(value || '').trim();
+}
+
+function normalizeStatKey(value: unknown) {
+  return normalizeText(value).toLowerCase();
+}
+
+function normalizeTimestamp(value: unknown) {
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? Date.now() : value.getTime();
+  }
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : Date.now();
+}
+
+function isScoringStatKey(statKey: string) {
+  return statKey === 'pts' || statKey === 'points' || statKey === 'goals' || statKey === 'goal';
+}
+
+function collectAllowedStatKeys(config: TrackerStatConfig = {}) {
+  const keys = new Set<string>(['fouls', 'time']);
+
+  (Array.isArray(config.columns) ? config.columns : []).forEach((column) => {
+    const normalized = normalizeStatKey(column);
+    if (!normalized) return;
+    keys.add(normalized);
+    if (normalized.endsWith('s')) {
+      keys.add(normalized.slice(0, -1));
+    } else {
+      keys.add(`${normalized}s`);
+    }
+  });
+
+  (Array.isArray(config.statDefinitions) ? config.statDefinitions : []).forEach((definition) => {
+    const normalized = normalizeStatKey(definition?.id);
+    if (normalized) keys.add(normalized);
+  });
+
+  return keys;
+}
+
+function buildTrackerEventDocument(input: TrackerEventInput, user: TrackerUser): TrackerEventDocument {
+  const undoData = input.undoData || {};
+  const statKey = normalizeStatKey(undoData.statKey);
+  const value = Number(undoData.value);
+
+  return {
+    text: String(input.text || ''),
+    gameTime: String(input.gameTime || input.clock || ''),
+    period: String(input.period || BASE_TRACKER_PERIOD),
+    timestamp: normalizeTimestamp(input.timestamp),
+    type: String(undoData.type || 'game_log'),
+    playerId: normalizeText(undoData.playerId) || null,
+    statKey: statKey || null,
+    value: Number.isFinite(value) ? value : null,
+    isOpponent: undoData.isOpponent === true,
+    createdBy: String(user.uid || '')
+  };
+}
+
+function buildParticipationPayload(playerName: string, playerNumber: string) {
+  return {
+    playerName,
+    playerNumber,
+    participated: true,
+    participationStatus: 'appeared',
+    participationSource: BASE_PARTICIPATION_SOURCE,
+    didNotPlay: false
+  };
+}
+
+function createEventIdFactory() {
+  const sessionPrefix = `app-track-${Date.now().toString(36)}`;
+  let index = 0;
+
+  return () => {
+    index += 1;
+    return `${sessionPrefix}-${String(index).padStart(6, '0')}`;
+  };
+}
+
+async function applyAggregateWrite({
+  dependencies,
+  teamId,
+  gameId,
+  playerId,
+  playerName,
+  playerNumber,
+  statKey,
+  delta,
+  statConfig
+}: {
+  dependencies: StatTrackingDependencies;
+  teamId: string;
+  gameId: string;
+  playerId: string;
+  playerName: string;
+  playerNumber: string;
+  statKey: string;
+  delta: number;
+  statConfig: TrackerStatConfig;
+}) {
+  const { publicStats, privateStats } = splitPlayerStatsByVisibility(statConfig || {}, {
+    [statKey]: dependencies.increment(delta)
+  });
+  const basePayload = buildParticipationPayload(playerName, playerNumber);
+  const publicRef = dependencies.doc(dependencies.db, `teams/${teamId}/games/${gameId}/aggregatedStats`, playerId);
+
+  await dependencies.setDoc(publicRef, {
+    ...basePayload,
+    stats: publicStats
+  }, { merge: true });
+
+  if (Object.keys(privateStats).length > 0) {
+    const privateRef = dependencies.doc(dependencies.db, `teams/${teamId}/games/${gameId}/privatePlayerStats`, playerId);
+    await dependencies.setDoc(privateRef, {
+      ...basePayload,
+      stats: privateStats
+    }, { merge: true });
+  }
+}
+
+export function createStatTrackingService({
+  statConfig = {},
+  initialScore = DEFAULT_SCORE,
+  dependencies
+}: {
+  statConfig?: TrackerStatConfig;
+  initialScore?: Partial<TrackerScoreState>;
+  dependencies: StatTrackingDependencies;
+}) {
+  const eventLog: TrackerLogEntry[] = [];
+  const allowedStatKeys = collectAllowedStatKeys(statConfig);
+  const nextEventId = createEventIdFactory();
+  let currentScore = normalizeScoreState(initialScore);
+
+  async function recordEvent(teamId: string, gameId: string, input: TrackerEventInput, user: TrackerUser) {
+    if (!teamId || !gameId) {
+      throw new Error('A scheduled game is required before recording a stat event.');
+    }
+    if (!user?.uid) {
+      throw new Error('Sign in before recording a stat event.');
+    }
+
+    const event = buildTrackerEventDocument(input, user);
+    const statKey = event.statKey;
+    const delta = Number(event.value || 0);
+
+    if (event.type === 'stat' && statKey && !allowedStatKeys.has(statKey)) {
+      throw new Error(`Unknown stat column key: ${statKey}`);
+    }
+
+    const scoreBefore = { ...currentScore };
+    const scoreAfter = { ...scoreBefore };
+    if (event.type === 'stat' && !event.isOpponent && statKey && isScoringStatKey(statKey) && delta !== 0) {
+      const teamSide = input.teamSide === 'away' ? 'away' : 'home';
+      if (teamSide === 'away') {
+        scoreAfter.awayScore = normalizeScoreValue(scoreAfter.awayScore + delta);
+      } else {
+        scoreAfter.homeScore = normalizeScoreValue(scoreAfter.homeScore + delta);
+      }
+    }
+
+    const eventId = nextEventId();
+    const eventRef = dependencies.doc(dependencies.db, `teams/${teamId}/games/${gameId}/events`, eventId);
+    await dependencies.setDoc(eventRef, event);
+
+    if (event.type === 'stat' && !event.isOpponent && event.playerId && statKey && delta !== 0) {
+      await applyAggregateWrite({
+        dependencies,
+        teamId,
+        gameId,
+        playerId: event.playerId,
+        playerName: normalizeText(input.playerName) || 'Player',
+        playerNumber: normalizeText(input.playerNumber),
+        statKey,
+        delta,
+        statConfig
+      });
+    }
+
+    if (scoreAfter.homeScore !== scoreBefore.homeScore || scoreAfter.awayScore !== scoreBefore.awayScore) {
+      await dependencies.updateGameScore(teamId, gameId, scoreAfter, user);
+    }
+
+    currentScore = scoreAfter;
+    const entry: TrackerLogEntry = {
+      eventId,
+      event,
+      scoreBefore,
+      scoreAfter,
+      aggregateStatKey: event.type === 'stat' ? statKey : null,
+      aggregateDelta: event.type === 'stat' ? delta : 0,
+      aggregatePlayerId: event.type === 'stat' ? event.playerId : null,
+      isOpponent: event.isOpponent,
+      playerName: normalizeText(input.playerName) || 'Player',
+      playerNumber: normalizeText(input.playerNumber)
+    };
+    eventLog.push(entry);
+    return entry;
+  }
+
+  async function undoLastEvent(teamId: string, gameId: string, user: TrackerUser) {
+    const entry = eventLog.pop();
+    if (!entry) {
+      return null;
+    }
+
+    const eventRef = dependencies.doc(dependencies.db, `teams/${teamId}/games/${gameId}/events`, entry.eventId);
+    await dependencies.deleteDoc(eventRef);
+
+    if (
+      entry.event.type === 'stat'
+      && !entry.isOpponent
+      && entry.aggregatePlayerId
+      && entry.aggregateStatKey
+      && entry.aggregateDelta !== 0
+    ) {
+      await applyAggregateWrite({
+        dependencies,
+        teamId,
+        gameId,
+        playerId: entry.aggregatePlayerId,
+        playerName: entry.playerName,
+        playerNumber: entry.playerNumber,
+        statKey: entry.aggregateStatKey,
+        delta: -entry.aggregateDelta,
+        statConfig
+      });
+    }
+
+    if (
+      entry.scoreAfter.homeScore !== entry.scoreBefore.homeScore
+      || entry.scoreAfter.awayScore !== entry.scoreBefore.awayScore
+    ) {
+      await dependencies.updateGameScore(teamId, gameId, entry.scoreBefore, user);
+    }
+
+    currentScore = entry.scoreBefore;
+    return entry;
+  }
+
+  function getEventLog() {
+    return eventLog.map((entry) => ({
+      ...entry,
+      scoreBefore: { ...entry.scoreBefore },
+      scoreAfter: { ...entry.scoreAfter },
+      event: { ...entry.event }
+    }));
+  }
+
+  function getCurrentScore() {
+    return { ...currentScore };
+  }
+
+  return {
+    recordEvent,
+    undoLastEvent,
+    getEventLog,
+    getCurrentScore
+  };
+}
+
+export function createDefaultStatTrackingService(options: {
+  statConfig?: TrackerStatConfig;
+  initialScore?: Partial<TrackerScoreState>;
+  updateGameScore: StatTrackingDependencies['updateGameScore'];
+}) {
+  return createStatTrackingService({
+    ...options,
+    dependencies: {
+      db,
+      doc,
+      setDoc,
+      deleteDoc,
+      increment,
+      updateGameScore: options.updateGameScore
+    }
+  });
+}
+
+export { buildTrackerEventDocument };

--- a/apps/app/src/lib/statTrackingService.ts
+++ b/apps/app/src/lib/statTrackingService.ts
@@ -197,10 +197,14 @@ async function applyAggregateWrite({
   const basePayload = buildParticipationPayload(playerName, playerNumber);
   const publicRef = dependencies.doc(dependencies.db, `teams/${teamId}/games/${gameId}/aggregatedStats`, playerId);
 
-  await dependencies.setDoc(publicRef, {
-    ...basePayload,
-    stats: publicStats
-  }, { merge: true });
+  if (Object.keys(publicStats).length > 0) {
+    await dependencies.setDoc(publicRef, {
+      ...basePayload,
+      stats: publicStats
+    }, { merge: true });
+  } else {
+    await dependencies.setDoc(publicRef, basePayload, { merge: true });
+  }
 
   if (Object.keys(privateStats).length > 0) {
     const privateRef = dependencies.doc(dependencies.db, `teams/${teamId}/games/${gameId}/privatePlayerStats`, playerId);
@@ -243,35 +247,65 @@ export function createStatTrackingService({
 
     const scoreBefore = { ...currentScore };
     const scoreAfter = { ...scoreBefore };
-    if (event.type === 'stat' && !event.isOpponent && statKey && isScoringStatKey(statKey) && delta !== 0) {
-      const teamSide = input.teamSide === 'away' ? 'away' : 'home';
-      if (teamSide === 'away') {
+    if (event.type === 'stat' && statKey && isScoringStatKey(statKey) && delta !== 0) {
+      if (event.isOpponent) {
         scoreAfter.awayScore = normalizeScoreValue(scoreAfter.awayScore + delta);
       } else {
-        scoreAfter.homeScore = normalizeScoreValue(scoreAfter.homeScore + delta);
+        const teamSide = input.teamSide === 'away' ? 'away' : 'home';
+        if (teamSide === 'away') {
+          scoreAfter.awayScore = normalizeScoreValue(scoreAfter.awayScore + delta);
+        } else {
+          scoreAfter.homeScore = normalizeScoreValue(scoreAfter.homeScore + delta);
+        }
       }
     }
 
     const eventId = nextEventId();
     const eventRef = dependencies.doc(dependencies.db, `teams/${teamId}/games/${gameId}/events`, eventId);
+    let aggregateApplied = false;
+    let scoreApplied = false;
+
     await dependencies.setDoc(eventRef, event);
 
-    if (event.type === 'stat' && !event.isOpponent && event.playerId && statKey && delta !== 0) {
-      await applyAggregateWrite({
-        dependencies,
-        teamId,
-        gameId,
-        playerId: event.playerId,
-        playerName: normalizeText(input.playerName) || 'Player',
-        playerNumber: normalizeText(input.playerNumber),
-        statKey,
-        delta,
-        statConfig
-      });
-    }
+    try {
+      if (event.type === 'stat' && !event.isOpponent && event.playerId && statKey && delta !== 0) {
+        await applyAggregateWrite({
+          dependencies,
+          teamId,
+          gameId,
+          playerId: event.playerId,
+          playerName: normalizeText(input.playerName) || 'Player',
+          playerNumber: normalizeText(input.playerNumber),
+          statKey,
+          delta,
+          statConfig
+        });
+        aggregateApplied = true;
+      }
 
-    if (scoreAfter.homeScore !== scoreBefore.homeScore || scoreAfter.awayScore !== scoreBefore.awayScore) {
-      await dependencies.updateGameScore(teamId, gameId, scoreAfter, user);
+      if (scoreAfter.homeScore !== scoreBefore.homeScore || scoreAfter.awayScore !== scoreBefore.awayScore) {
+        await dependencies.updateGameScore(teamId, gameId, scoreAfter, user);
+        scoreApplied = true;
+      }
+    } catch (error) {
+      if (scoreApplied) {
+        await dependencies.updateGameScore(teamId, gameId, scoreBefore, user);
+      }
+      if (aggregateApplied && event.playerId && statKey && delta !== 0 && event.type === 'stat' && !event.isOpponent) {
+        await applyAggregateWrite({
+          dependencies,
+          teamId,
+          gameId,
+          playerId: event.playerId,
+          playerName: normalizeText(input.playerName) || 'Player',
+          playerNumber: normalizeText(input.playerNumber),
+          statKey,
+          delta: -delta,
+          statConfig
+        });
+      }
+      await dependencies.deleteDoc(eventRef);
+      throw error;
     }
 
     currentScore = scoreAfter;
@@ -292,42 +326,68 @@ export function createStatTrackingService({
   }
 
   async function undoLastEvent(teamId: string, gameId: string, user: TrackerUser) {
-    const entry = eventLog.pop();
+    const entry = eventLog[eventLog.length - 1];
     if (!entry) {
       return null;
     }
 
     const eventRef = dependencies.doc(dependencies.db, `teams/${teamId}/games/${gameId}/events`, entry.eventId);
-    await dependencies.deleteDoc(eventRef);
+    let aggregateReverted = false;
+    let scoreReverted = false;
 
-    if (
-      entry.event.type === 'stat'
-      && !entry.isOpponent
-      && entry.aggregatePlayerId
-      && entry.aggregateStatKey
-      && entry.aggregateDelta !== 0
-    ) {
-      await applyAggregateWrite({
-        dependencies,
-        teamId,
-        gameId,
-        playerId: entry.aggregatePlayerId,
-        playerName: entry.playerName,
-        playerNumber: entry.playerNumber,
-        statKey: entry.aggregateStatKey,
-        delta: -entry.aggregateDelta,
-        statConfig
-      });
-    }
+    try {
+      if (
+        entry.event.type === 'stat'
+        && !entry.isOpponent
+        && entry.aggregatePlayerId
+        && entry.aggregateStatKey
+        && entry.aggregateDelta !== 0
+      ) {
+        await applyAggregateWrite({
+          dependencies,
+          teamId,
+          gameId,
+          playerId: entry.aggregatePlayerId,
+          playerName: entry.playerName,
+          playerNumber: entry.playerNumber,
+          statKey: entry.aggregateStatKey,
+          delta: -entry.aggregateDelta,
+          statConfig
+        });
+        aggregateReverted = true;
+      }
 
-    if (
-      entry.scoreAfter.homeScore !== entry.scoreBefore.homeScore
-      || entry.scoreAfter.awayScore !== entry.scoreBefore.awayScore
-    ) {
-      await dependencies.updateGameScore(teamId, gameId, entry.scoreBefore, user);
+      if (
+        entry.scoreAfter.homeScore !== entry.scoreBefore.homeScore
+        || entry.scoreAfter.awayScore !== entry.scoreBefore.awayScore
+      ) {
+        await dependencies.updateGameScore(teamId, gameId, entry.scoreBefore, user);
+        scoreReverted = true;
+      }
+
+      await dependencies.deleteDoc(eventRef);
+    } catch (error) {
+      if (aggregateReverted && entry.aggregatePlayerId && entry.aggregateStatKey && entry.aggregateDelta !== 0) {
+        await applyAggregateWrite({
+          dependencies,
+          teamId,
+          gameId,
+          playerId: entry.aggregatePlayerId,
+          playerName: entry.playerName,
+          playerNumber: entry.playerNumber,
+          statKey: entry.aggregateStatKey,
+          delta: entry.aggregateDelta,
+          statConfig
+        });
+      }
+      if (scoreReverted) {
+        await dependencies.updateGameScore(teamId, gameId, entry.scoreAfter, user);
+      }
+      throw error;
     }
 
     currentScore = entry.scoreBefore;
+    eventLog.pop();
     return entry;
   }
 


### PR DESCRIPTION
Closes #1971

## What changed
- added `apps/app/src/lib/statTrackingService.ts` as a shared app-side tracker write service with `recordEvent`, `undoLastEvent`, `getEventLog`, and in-session score tracking
- normalized tracker event writes to the legacy `/teams/{teamId}/games/{gameId}/events/{eventId}` shape used by report and replay readers
- updated aggregated stat writes to use the legacy player stat shape, including private stat routing via `privatePlayerStats`
- added undo support that deletes the last event, reverses aggregate increments, and restores the prior game score through the existing score update path
- added focused Vitest coverage for event-shape compatibility, aggregate updates, undo reversal, score rollback, and stat-config validation

## Root Cause
The app only had a narrow score-only helper that updated live events and partial aggregated scoring data. It did not have a shared tracker write service that emitted legacy `/events` documents or maintained an undoable event ledger, so the app had no compatible foundation for report/replay parity or tracker UI reuse.

## Prevention / Learning
When app code must interoperate with legacy read paths, build the shared write-side contract first and regression-test the persisted document shape before adding new UI flows. That keeps feature-parity work from drifting into app-only payloads that legacy consumers cannot read.

## Regression Tests
- `npx vitest run apps/app/src/lib/statTrackingService.test.ts`
- verifies legacy event document shape for stat writes
- verifies aggregate stat increments and score synchronization
- verifies undo deletes the event, reverses aggregates, and restores prior score
- verifies unknown stat column keys are rejected before any write
- verifies private stat definitions route to `privatePlayerStats` while preserving participation metadata