### PR TITLE
Replace protected-route spinners with shared skeletons

### DIFF
--- a/apps/app/src/App.test.tsx
+++ b/apps/app/src/App.test.tsx
@@ -68,7 +68,9 @@ describe('App protected route loading', () => {
     );
 
     expect(await screen.findByRole('navigation', { name: 'Primary navigation' })).toBeTruthy();
-    expect(screen.getByText('Loading page')).toBeTruthy();
+    expect(screen.getByRole('status', { name: 'Loading Home' })).toBeTruthy();
+    expect(screen.queryByText('Loading page')).toBeNull();
+    expect(screen.queryByText('Preparing your ALL PLAYS workspace...')).toBeNull();
     expect(screen.queryByText('Loading ALL PLAYS')).toBeNull();
   });
 

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, ReactNode, Suspense, useEffect, useRef, useState } from 'react';
 import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { AppShell } from './components/AppShell';
+import { ProtectedRouteSkeleton } from './components/PageSkeletons';
 import { clearPendingPushRoute, readPendingPushRoute } from './lib/pushNotificationRouting';
 import { shouldReloadTeamsToHome } from './lib/reloadRouting';
 import { addPushNotificationOpenListener } from './lib/pushService';
@@ -137,6 +138,7 @@ function isBrowserReload() {
 
 function Protected({ auth, children }: { auth: AuthState; children: ReactNode }) {
   const [bootstrapGraceExpired, setBootstrapGraceExpired] = useState(false);
+  const location = useLocation();
 
   useEffect(() => {
     const timeoutId = window.setTimeout(() => {
@@ -160,7 +162,7 @@ function Protected({ auth, children }: { auth: AuthState; children: ReactNode })
 
   return (
     <AppShell auth={auth}>
-      <Suspense fallback={<ProtectedRouteLoadingState />}>
+      <Suspense fallback={<ProtectedRouteLoadingState pathname={location.pathname} />}>
         {children}
       </Suspense>
     </AppShell>
@@ -179,13 +181,6 @@ function LoadingScreen() {
   );
 }
 
-function ProtectedRouteLoadingState() {
-  return (
-    <div className="app-card flex min-h-[240px] items-center justify-center p-5 text-center">
-      <div>
-        <div className="text-base font-black text-gray-950">Loading page</div>
-        <div className="mt-1 text-sm font-semibold text-gray-500">Preparing your ALL PLAYS workspace...</div>
-      </div>
-    </div>
-  );
+function ProtectedRouteLoadingState({ pathname }: { pathname: string }) {
+  return <ProtectedRouteSkeleton pathname={pathname} />;
 }

--- a/apps/app/src/components/PageSkeletons.test.tsx
+++ b/apps/app/src/components/PageSkeletons.test.tsx
@@ -1,0 +1,18 @@
+// @vitest-environment jsdom
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { ProtectedRouteSkeleton } from './PageSkeletons';
+
+describe('ProtectedRouteSkeleton', () => {
+  it.each([
+    ['/home', 'Loading Home'],
+    ['/schedule', 'Loading schedule'],
+    ['/schedule/team-1/event-1', 'Loading event'],
+    ['/messages', 'Loading team chats'],
+    ['/messages/team-1', 'Loading team chat'],
+    ['/teams/team-1', 'Loading team']
+  ])('renders the right skeleton for %s', (pathname, label) => {
+    render(<ProtectedRouteSkeleton pathname={pathname} />);
+    expect(screen.getByRole('status', { name: label })).toBeTruthy();
+  });
+});

--- a/apps/app/src/components/PageSkeletons.tsx
+++ b/apps/app/src/components/PageSkeletons.tsx
@@ -1,0 +1,170 @@
+import type { ReactNode } from 'react';
+
+type SkeletonBlockProps = {
+  className?: string;
+  children?: ReactNode;
+};
+
+export function SkeletonBlock({ className = '', children }: SkeletonBlockProps) {
+  return <div aria-hidden="true" className={`animate-pulse rounded-2xl bg-gray-200/80 ${className}`}>{children}</div>;
+}
+
+export function SkeletonCard({ className = '', lines = 3 }: { className?: string; lines?: number }) {
+  return (
+    <section className={`app-card p-4 ${className}`}>
+      <div className="space-y-3">
+        <SkeletonBlock className="h-4 w-28 rounded-full" />
+        <SkeletonBlock className="h-7 w-3/4" />
+        <div className="space-y-2">
+          {Array.from({ length: lines }).map((_, index) => (
+            <SkeletonBlock key={index} className={`h-3 ${index === lines - 1 ? 'w-1/2' : 'w-full'}`} />
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function SkeletonListRows({ rows = 4, leading = 'dot' }: { rows?: number; leading?: 'dot' | 'avatar' | 'date'; }) {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: rows }).map((_, index) => (
+        <section key={index} className="app-card p-3">
+          <div className="flex items-start gap-3">
+            {leading === 'avatar' ? <SkeletonBlock className="h-11 w-11 flex-none rounded-xl" /> : null}
+            {leading === 'date' ? <SkeletonBlock className="h-12 w-12 flex-none rounded-xl" /> : null}
+            {leading === 'dot' ? <SkeletonBlock className="mt-1 h-3 w-3 flex-none rounded-full" /> : null}
+            <div className="min-w-0 flex-1 space-y-2">
+              <div className="flex items-center gap-2">
+                <SkeletonBlock className="h-3 w-24 rounded-full" />
+                <SkeletonBlock className="h-3 w-14 rounded-full" />
+              </div>
+              <SkeletonBlock className="h-5 w-2/3" />
+              <SkeletonBlock className="h-3 w-5/6" />
+              <div className="flex flex-wrap gap-2">
+                <SkeletonBlock className="h-5 w-16 rounded-full" />
+                <SkeletonBlock className="h-5 w-20 rounded-full" />
+              </div>
+            </div>
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+export function SkeletonDetailHeader({ showTabs = false }: { showTabs?: boolean }) {
+  return (
+    <div className="space-y-3">
+      <section className="app-card overflow-hidden p-4">
+        <div className="flex items-start gap-3">
+          <SkeletonBlock className="h-16 w-16 flex-none rounded-2xl" />
+          <div className="min-w-0 flex-1 space-y-2">
+            <SkeletonBlock className="h-3 w-24 rounded-full" />
+            <SkeletonBlock className="h-7 w-2/3" />
+            <SkeletonBlock className="h-3 w-5/6" />
+            <div className="flex flex-wrap gap-2 pt-1">
+              <SkeletonBlock className="h-6 w-20 rounded-full" />
+              <SkeletonBlock className="h-6 w-24 rounded-full" />
+              <SkeletonBlock className="h-6 w-16 rounded-full" />
+            </div>
+          </div>
+        </div>
+      </section>
+      {showTabs ? (
+        <div className="grid grid-cols-4 gap-2">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <SkeletonBlock key={index} className="h-11 rounded-2xl" />
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function SkeletonStatus({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div role="status" aria-live="polite" aria-label={label} className="space-y-4">
+      <span className="sr-only">{label}</span>
+      {children}
+    </div>
+  );
+}
+
+export function HomePageSkeleton() {
+  return (
+    <SkeletonStatus label="Loading Home">
+      <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+        <SkeletonCard lines={2} />
+        <SkeletonCard lines={2} />
+        <SkeletonCard lines={2} />
+        <SkeletonCard lines={2} />
+      </div>
+      <SkeletonListRows rows={3} leading="date" />
+    </SkeletonStatus>
+  );
+}
+
+export function SchedulePageSkeleton() {
+  return (
+    <SkeletonStatus label="Loading schedule">
+      <div className="grid gap-3 md:grid-cols-4">
+        <SkeletonBlock className="h-11 rounded-2xl" />
+        <SkeletonBlock className="h-11 rounded-2xl" />
+        <SkeletonBlock className="h-11 rounded-2xl" />
+        <SkeletonBlock className="h-11 rounded-2xl" />
+      </div>
+      <SkeletonListRows rows={4} leading="date" />
+    </SkeletonStatus>
+  );
+}
+
+export function MessagesPageSkeleton({ embedded = false }: { embedded?: boolean }) {
+  return (
+    <SkeletonStatus label={embedded ? 'Loading team chat' : 'Loading team chats'}>
+      <section className={`app-card p-3 sm:p-4 ${embedded ? 'chat-window-embedded' : ''}`}>
+        <div className="flex items-center justify-between gap-3">
+          <div className="min-w-0 flex-1 space-y-2">
+            <SkeletonBlock className="h-3 w-20 rounded-full" />
+            <SkeletonBlock className="h-7 w-40" />
+            <SkeletonBlock className="h-3 w-36" />
+          </div>
+          <SkeletonBlock className="h-10 w-10 flex-none rounded-full" />
+        </div>
+      </section>
+      <SkeletonListRows rows={embedded ? 5 : 4} leading="avatar" />
+    </SkeletonStatus>
+  );
+}
+
+export function TeamDetailPageSkeleton() {
+  return (
+    <SkeletonStatus label="Loading team">
+      <SkeletonDetailHeader showTabs />
+      <div className="grid gap-3 md:grid-cols-2">
+        <SkeletonCard />
+        <SkeletonCard />
+      </div>
+      <SkeletonListRows rows={3} leading="avatar" />
+    </SkeletonStatus>
+  );
+}
+
+export function EventDetailPageSkeleton() {
+  return (
+    <SkeletonStatus label="Loading event">
+      <SkeletonDetailHeader showTabs />
+      <SkeletonCard lines={2} />
+      <SkeletonListRows rows={2} leading="avatar" />
+    </SkeletonStatus>
+  );
+}
+
+export function ProtectedRouteSkeleton({ pathname }: { pathname: string }) {
+  if (pathname.startsWith('/schedule/')) return <EventDetailPageSkeleton />;
+  if (pathname.startsWith('/schedule')) return <SchedulePageSkeleton />;
+  if (pathname.startsWith('/messages/')) return <MessagesPageSkeleton embedded />;
+  if (pathname.startsWith('/messages')) return <MessagesPageSkeleton />;
+  if (pathname.startsWith('/teams/')) return <TeamDetailPageSkeleton />;
+  return <HomePageSkeleton />;
+}

--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -26,6 +26,7 @@ import {
   Users,
   type LucideIcon
 } from 'lucide-react';
+import { HomePageSkeleton } from '../components/PageSkeletons';
 import { loadParentHomeSummaryBootstrap, loadParentHomeWithSecondaryData } from '../lib/homeService';
 import {
   blockFriend,
@@ -332,13 +333,7 @@ export function Home({ auth }: { auth: AuthState }) {
       {error ? <Status tone="error" message={error} /> : null}
       {socialStatus ? <Status tone={socialStatus.tone} message={socialStatus.message} /> : null}
 
-      {loading ? (
-        <section className="app-card p-6 text-center">
-          <Loader2 className="mx-auto h-8 w-8 animate-spin text-primary-600" aria-hidden="true" />
-          <div className="mt-3 text-sm font-black text-gray-900">Loading Home</div>
-          <div className="mt-1 text-xs font-semibold text-gray-500">Pulling players, teams, schedule, chat, and fees.</div>
-        </section>
-      ) : null}
+      {loading ? <HomePageSkeleton /> : null}
 
       {!loading && activeSection === 'today' ? <TodaySection home={home} social={social} socialLoading={socialLoading} onOpenComposer={openComposer} officialsAccess={officialsAccess} /> : null}
       {!loading && activeSection === 'feed' ? (

--- a/apps/app/src/pages/Messages.tsx
+++ b/apps/app/src/pages/Messages.tsx
@@ -57,6 +57,7 @@ import {
   type TeamEmailTemplate,
   type ChatTeam
 } from '../lib/chatService';
+import { MessagesPageSkeleton } from '../components/PageSkeletons';
 import {
   DEFAULT_TEAM_CONVERSATION_ID,
   MAX_CHAT_MEDIA_SIZE,
@@ -288,12 +289,7 @@ function InboxList({
   const trimmedQuery = searchQuery.trim();
 
   if (loading) {
-    return (
-      <section className="app-card flex min-h-44 items-center justify-center p-5 text-sm font-bold text-gray-500">
-        <Loader2 className="mr-2 h-4 w-4 animate-spin" aria-hidden="true" />
-        Loading team chats...
-      </section>
-    );
+    return <MessagesPageSkeleton />;
   }
 
   if (error) {
@@ -1474,12 +1470,7 @@ function ChatWindow({
   }, [selectedConversationId, teamId]);
 
   if (loadingContext) {
-    return (
-      <section className={`chat-window app-card flex min-h-[520px] items-center justify-center p-5 ${embedded ? 'chat-window-embedded' : ''}`}>
-        <Loader2 className="mr-2 h-5 w-5 animate-spin text-primary-600" aria-hidden="true" />
-        <span className="text-sm font-black text-gray-600">Loading team chat...</span>
-      </section>
-    );
+    return <MessagesPageSkeleton embedded={embedded} />;
   }
 
   if (error) {

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState, type FormEvent, type ReactNode } from 'react';
 import { AlertCircle, CalendarDays, CheckCircle2, ChevronDown, ChevronLeft, ChevronRight, ClipboardCheck, Copy, Download, Filter, Link as LinkIcon, ListChecks, MapPin, RefreshCw } from 'lucide-react';
 import { Link } from 'react-router-dom';
+import { SchedulePageSkeleton } from '../components/PageSkeletons';
 import { addTeamCalendarUrl, createScheduleImportGame, createScheduleImportPractice, loadParentSchedule, removeTeamCalendarUrl, type ParentScheduleChild } from '../lib/scheduleService';
 import { getCachedAppData, loadCachedAppData } from '../lib/appDataCache';
 import { startUxTimer } from '../lib/uxTiming';
@@ -1553,13 +1554,7 @@ function ScheduleActionQueue({ events }: { events: ParentScheduleEvent[] }) {
 }
 
 function LoadingSchedule() {
-  return (
-    <div className="app-card p-6 text-center">
-      <RefreshCw className="mx-auto h-8 w-8 animate-spin text-primary-600" aria-hidden="true" />
-      <div className="mt-3 text-sm font-black text-gray-900">Loading schedule</div>
-      <div className="mt-1 text-xs font-semibold text-gray-500">Pulling teams, players, RSVP status, and calendar details.</div>
-    </div>
-  );
+  return <SchedulePageSkeleton />;
 }
 
 function ScheduleList({ events, visibleCount, pageSize, onShowMore }: {

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -213,6 +213,28 @@ function renderScheduleEventDetailWithRouteControls(initialEntry = '/schedule/te
   );
 }
 
+describe('ScheduleEventDetail loading states', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('shows the shared event skeleton while event details are loading', () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockReturnValue(new Promise(() => {}));
+
+    render(
+      <MemoryRouter initialEntries={['/schedule/team-1/game-1']}>
+        <Routes>
+          <Route path="/schedule/:teamId/:eventId" element={<ScheduleEventDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('status', { name: 'Loading event' })).toBeTruthy();
+    expect(screen.queryByText('Pulling parent actions and game-day details.')).toBeNull();
+  });
+});
+
 describe('ScheduleEventDetail lineup draft guards', () => {
   it('allows empty lineup drafts to persist when a coach and formation are present', () => {
     expect(shouldPersistLineupDraft(auth.user, 'basketball-5v5', {})).toBe(true);

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -96,6 +96,7 @@ import {
   type ScheduleHubDestination,
   type ScheduleHubIcon
 } from '../lib/scheduleHub';
+import { EventDetailPageSkeleton } from '../components/PageSkeletons';
 import {
   canRequestScheduleRide,
   findScheduleRideRequestForChild,
@@ -512,13 +513,7 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
   };
 
   if (loading) {
-    return (
-      <div className="app-card p-6 text-center">
-        <RefreshCw className="mx-auto h-8 w-8 animate-spin text-primary-600" aria-hidden="true" />
-        <div className="mt-3 text-sm font-black text-gray-900">Loading event</div>
-        <div className="mt-1 text-xs font-semibold text-gray-500">Pulling parent actions and game-day details.</div>
-      </div>
-    );
+    return <EventDetailPageSkeleton />;
   }
 
   if (!selectedEvent) {

--- a/apps/app/src/pages/TeamDetail.test.tsx
+++ b/apps/app/src/pages/TeamDetail.test.tsx
@@ -144,6 +144,21 @@ describe('TeamDetail', () => {
     cleanup();
   });
 
+  it('shows the shared team skeleton while team detail is loading', () => {
+    teamDetailServiceMocks.loadParentTeamDetail.mockReturnValue(new Promise(() => {}));
+
+    render(
+      <MemoryRouter initialEntries={['/teams/team-1']}>
+        <Routes>
+          <Route path="/teams/:teamId" element={<TeamDetail auth={auth} />} />
+        </Routes>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('status', { name: 'Loading team' })).toBeTruthy();
+    expect(screen.queryByText('Getting the team photo, roster, schedule, standings, and parent-visible insights.')).toBeNull();
+  });
+
   it('does not reload team detail when the auth object identity changes but the signed-in user does not', async () => {
     const initialAuth: AuthState = { ...auth, user: { ...auth.user! } as AuthState['user'] };
     const nextAuth: AuthState = { ...auth, user: { ...auth.user! } as AuthState['user'] };

--- a/apps/app/src/pages/TeamDetail.tsx
+++ b/apps/app/src/pages/TeamDetail.tsx
@@ -27,6 +27,7 @@ import {
   Users,
   Zap
 } from 'lucide-react';
+import { TeamDetailPageSkeleton } from '../components/PageSkeletons';
 import { copyPublicText, openPublicUrl, sharePublicUrl } from '../lib/publicActions';
 import { getEventDetailPath } from '../lib/homeLogic';
 import { buildPrivateTeamCalendarFeedUrl, getAppleCalendarFeedUrl, getGoogleCalendarFeedUrl } from '../lib/parentToolsService';
@@ -279,15 +280,7 @@ export function TeamDetail({ auth }: { auth: AuthState }) {
   if (!teamId) return <Navigate to="/teams" replace />;
 
   if (loading) {
-    return (
-      <div className="space-y-4">
-        <section className="app-card p-5 text-center">
-          <Loader2 className="mx-auto h-8 w-8 animate-spin text-primary-600" aria-hidden="true" />
-          <div className="mt-3 text-sm font-black text-gray-950">Loading team</div>
-          <div className="mt-1 text-xs font-semibold text-gray-500">Getting the team photo, roster, schedule, standings, and parent-visible insights.</div>
-        </section>
-      </div>
-    );
+    return <TeamDetailPageSkeleton />;
   }
 
   if (error || !model) {


### PR DESCRIPTION
Closes #2039

## What changed
- added shared content-shaped loading primitives and route-aware page skeletons in `apps/app/src/components/PageSkeletons.tsx`
- replaced the generic protected-route `Suspense` fallback in `apps/app/src/App.tsx` with route-specific skeletons so protected navigation keeps the shell visible without the `Loading page` handoff
- swapped spinner/card loading states on Home, Schedule, Messages, TeamDetail, and ScheduleEventDetail to the shared skeleton treatment
- added focused regression coverage for protected-route skeleton selection plus TeamDetail and ScheduleEventDetail loading states

## Root Cause
Protected routes used a single generic `Suspense` loading card while each page implemented its own data-loading spinner independently. That split route loading and page data loading into two unrelated phases, causing a visible handoff from a generic placeholder to a second centered spinner instead of one continuous content-shaped loading state.

## Prevention / Learning
When protected app pages lazy-load and then fetch data, the route fallback and page-level loading state should share the same skeleton primitives and be selected by route shape. Adding or changing protected pages should extend the shared skeleton map first instead of introducing one-off spinner placeholders.

## Regression Tests
- `npm --prefix apps/app test -- --run src/App.test.tsx src/components/PageSkeletons.test.tsx src/pages/TeamDetail.test.tsx src/pages/ScheduleEventDetail.test.tsx`
- `npm --prefix apps/app run build`

## Recurrence Risk
Medium: the shared skeleton path now covers the targeted protected routes, but future protected pages could still regress if they bypass the shared skeleton components.