### PR TITLE
Add Stripe checkout retry handling to RegistrationDetail

### DIFF
--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -36,7 +36,7 @@ import {
   normalizeParentFeeRecord,
   sortParentFeeRecords
 } from '../../../../js/parent-dashboard-fees.js';
-import { initiateTeamFeeCheckout } from '../../../../js/stripe-service.js';
+import { cancelStripeRegistrationCheckout, initiateTeamFeeCheckout } from '../../../../js/stripe-service.js';
 import {
   buildPendingRegistrationRecord,
   calculateRegistrationFeeSnapshot,
@@ -352,6 +352,7 @@ export async function submitOfflineRegistration(teamId: string, formId: string, 
       selectedPaymentPlanId: submission.selectedPaymentPlanId,
       status,
       feeSnapshot,
+      checkoutAttemptToken: submission.checkoutAttemptToken,
       now: serverTimestamp()
     });
 
@@ -1148,7 +1149,8 @@ export async function initiateRegistrationCheckout(
   paymentPlanId: string,
   quantity: number,
   amountCents: number,
-  currency: string
+  currency: string,
+  options: { checkoutAttemptToken?: string; retryPayment?: boolean } = {}
 ): Promise<{ success: true, checkoutUrl: string }> {
   if (!teamId || !formId || !registrationId || !paymentPlanId || !quantity || !amountCents || !currency) {
     throw new Error('Missing required fields for checkout.');
@@ -1162,7 +1164,9 @@ export async function initiateRegistrationCheckout(
     paymentPlanId,
     quantity,
     amountCents,
-    currency
+    currency,
+    options.checkoutAttemptToken,
+    options.retryPayment
   );
 
   if (!result?.checkoutUrl) {
@@ -1170,6 +1174,24 @@ export async function initiateRegistrationCheckout(
   }
 
   return { success: true, checkoutUrl: result.checkoutUrl };
+}
+
+export async function cancelRegistrationCheckout(
+  teamId: string,
+  formId: string,
+  registrationId: string,
+  checkoutAttemptToken = ''
+) {
+  if (!teamId || !formId || !registrationId) {
+    throw new Error('Missing required fields for checkout cancellation.');
+  }
+
+  return cancelStripeRegistrationCheckout({
+    teamId,
+    formId,
+    registrationId,
+    checkoutAttemptToken
+  });
 }
 
 export function getCalendarEventShareText(event: ParentScheduleEvent) {

--- a/apps/app/src/pages/RegistrationDetail.test.tsx
+++ b/apps/app/src/pages/RegistrationDetail.test.tsx
@@ -1,21 +1,23 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { RegistrationDetail } from './RegistrationDetail';
 import type { AuthState } from '../lib/types';
 
 const parentToolsServiceMocks = vi.hoisted(() => ({
+  cancelRegistrationCheckout: vi.fn(),
   initiateRegistrationCheckout: vi.fn(),
   loadParentRegistrationDetail: vi.fn(),
   loadPublicRegistrationDetail: vi.fn(),
   loadParentRegistrations: vi.fn(),
   submitOfflineRegistration: vi.fn()
 }));
+const openPublicUrlMock = vi.hoisted(() => vi.fn());
 
 vi.mock('../lib/parentToolsService', () => parentToolsServiceMocks);
 vi.mock('../lib/publicActions', () => ({
-  openPublicUrl: vi.fn()
+  openPublicUrl: openPublicUrlMock
 }));
 
 const auth: AuthState = {
@@ -67,9 +69,9 @@ function buildDetail(overrides: Record<string, any> = {}) {
   };
 }
 
-function renderPublicRegistration() {
+function renderPublicRegistration(path = '/registration?teamId=team-1&formId=form-1') {
   return render(
-    <MemoryRouter initialEntries={['/registration?teamId=team-1&formId=form-1']}>
+    <MemoryRouter initialEntries={[path]}>
       <Routes>
         <Route path="/registration" element={<RegistrationDetail auth={auth} publicAccess />} />
       </Routes>
@@ -91,6 +93,7 @@ function renderParentRegistration() {
 describe('RegistrationDetail payment notice', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    openPublicUrlMock.mockReset();
   });
 
   afterEach(() => {
@@ -118,5 +121,63 @@ describe('RegistrationDetail payment notice', () => {
     expect(await screen.findByRole('button', { name: 'Submit registration' })).toBeTruthy();
     expect(screen.queryByRole('heading', { name: 'Payment' })).toBeNull();
     expect(parentToolsServiceMocks.loadParentRegistrationDetail).toHaveBeenCalledWith(auth.user, 'team-1', 'form-1');
+  });
+
+  it('shows retry guidance and releases cancelled checkout attempts on Stripe cancel returns', async () => {
+    parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
+      paymentNotice: 'Payment will be collected in Stripe before your registration is complete.',
+      onlineCheckout: true
+    }));
+    parentToolsServiceMocks.cancelRegistrationCheckout.mockResolvedValue({ released: true });
+
+    renderPublicRegistration('/registration?teamId=team-1&formId=form-1&registrationId=reg-1&checkoutAttemptToken=tok-1&retryPayment=1&status=cancelled');
+
+    expect(await screen.findByText('Stripe payment was cancelled. You can retry payment for this registration.')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Retry payment with Stripe' })).toBeTruthy();
+    await waitFor(() => expect(parentToolsServiceMocks.cancelRegistrationCheckout).toHaveBeenCalledWith('team-1', 'form-1', 'reg-1', 'tok-1'));
+  });
+
+  it('retries Stripe checkout without creating a duplicate registration', async () => {
+    parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
+      onlineCheckout: true,
+      paymentNotice: 'Pay online.'
+    }));
+    parentToolsServiceMocks.cancelRegistrationCheckout.mockResolvedValue({ released: true });
+    parentToolsServiceMocks.initiateRegistrationCheckout.mockResolvedValue({ success: true, checkoutUrl: 'https://stripe.example/checkout' });
+
+    renderPublicRegistration('/registration?teamId=team-1&formId=form-1&registrationId=reg-1&checkoutAttemptToken=tok-1&retryPayment=1&status=cancelled');
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry payment with Stripe' }));
+
+    await waitFor(() => expect(parentToolsServiceMocks.initiateRegistrationCheckout).toHaveBeenCalledWith(
+      'team-1',
+      'form-1',
+      'reg-1',
+      '',
+      'pay_full',
+      1,
+      12500,
+      'USD',
+      {
+        checkoutAttemptToken: 'tok-1',
+        retryPayment: true
+      }
+    ));
+    expect(parentToolsServiceMocks.submitOfflineRegistration).not.toHaveBeenCalled();
+    expect(openPublicUrlMock).toHaveBeenCalledWith('https://stripe.example/checkout');
+  });
+
+  it('replaces the form with a success confirmation after Stripe success returns', async () => {
+    parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
+      onlineCheckout: true,
+      paymentNotice: 'Pay online.'
+    }));
+
+    renderPublicRegistration('/registration?teamId=team-1&formId=form-1&registrationId=reg-1&checkoutAttemptToken=tok-1&retryPayment=1&status=success');
+
+    expect(await screen.findByRole('heading', { name: 'Payment successful' })).toBeTruthy();
+    expect(screen.getByText('Your registration payment was received. The program organizer will follow up with next steps.')).toBeTruthy();
+    expect(screen.queryByRole('button', { name: 'Retry payment with Stripe' })).toBeNull();
+    expect(screen.queryByRole('button', { name: 'Pay registration with Stripe' })).toBeNull();
   });
 });

--- a/apps/app/src/pages/RegistrationDetail.tsx
+++ b/apps/app/src/pages/RegistrationDetail.tsx
@@ -524,11 +524,11 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
 
 function createCheckoutAttemptToken() {
   const bytes = new Uint8Array(16);
-  if (globalThis.crypto?.getRandomValues) {
-    globalThis.crypto.getRandomValues(bytes);
-    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+  if (!globalThis.crypto?.getRandomValues) {
+    throw new Error('Crypto API not available. Cannot generate secure checkout token.');
   }
-  return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 18)}`;
+  globalThis.crypto.getRandomValues(bytes);
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
 }
 
 function normalizeRegistrationReturnStatus(value: string | null) {

--- a/apps/app/src/pages/RegistrationDetail.tsx
+++ b/apps/app/src/pages/RegistrationDetail.tsx
@@ -46,6 +46,12 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
   const [searchParams] = useSearchParams();
   const teamId = publicAccess ? (searchParams.get('teamId') || '') : (params.teamId || '');
   const formId = publicAccess ? (searchParams.get('formId') || '') : (params.formId || '');
+  const returnRegistrationId = searchParams.get('registrationId') || '';
+  const returnCheckoutAttemptToken = searchParams.get('checkoutAttemptToken') || '';
+  const retryPaymentRequested = searchParams.get('retryPayment') === '1' && Boolean(returnRegistrationId);
+  const returnStatus = normalizeRegistrationReturnStatus(searchParams.get('status'));
+  const isPaymentSuccessReturn = returnStatus === 'success' && Boolean(returnRegistrationId);
+  const isRetryPaymentMode = retryPaymentRequested && !isPaymentSuccessReturn;
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
   const [form, setForm] = useState<ParentRegistrationCard | null>(null);
@@ -63,6 +69,7 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
   const [selectedMergePlayerId, setSelectedMergePlayerId] = useState('');
   const [reloadKey, setReloadKey] = useState(0);
   const formRef = useRef<HTMLFormElement | null>(null);
+  const cancelledCheckoutReleaseKeyRef = useRef('');
 
   useEffect(() => {
     let cancelled = false;
@@ -128,6 +135,23 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
     setSelectedMergePlayerId(selectedReview.linkedPlayerId || '');
   }, [selectedReview?.id]);
 
+  useEffect(() => {
+    if (staffReview || returnStatus !== 'cancelled' || !returnRegistrationId) return;
+
+    const releaseKey = `${teamId}:${formId}:${returnRegistrationId}:${returnCheckoutAttemptToken}`;
+    if (cancelledCheckoutReleaseKeyRef.current === releaseKey) return;
+    cancelledCheckoutReleaseKeyRef.current = releaseKey;
+
+    setMessage('');
+    setError(retryPaymentRequested
+      ? 'Stripe payment was cancelled. You can retry payment for this registration.'
+      : 'Stripe payment was cancelled.');
+
+    void parentToolsService.cancelRegistrationCheckout(teamId, formId, returnRegistrationId, returnCheckoutAttemptToken).catch(() => {
+      // Keep the retry path available even if release cleanup fails.
+    });
+  }, [formId, returnCheckoutAttemptToken, returnRegistrationId, returnStatus, retryPaymentRequested, staffReview, teamId]);
+
   const updateParticipant = (fieldId: string, value: string) => setParticipant((current) => ({ ...current, [fieldId]: value }));
   const updateGuardian = (fieldId: string, value: string) => setGuardian((current) => ({ ...current, [fieldId]: value }));
 
@@ -163,6 +187,33 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
     setSaving(true);
     try {
       const currentFeeSnapshot = calculateRegistrationFeeSnapshot(form, { quantity: currentQuantity, now: new Date() }); // currentQuantity is already effective
+      const checkoutAttemptToken = isRetryPaymentMode ? returnCheckoutAttemptToken : createCheckoutAttemptToken();
+      if (form.onlineCheckout && Number(currentFeeSnapshot.finalAmountDueCents || 0) > 0) {
+        if (isRetryPaymentMode) {
+          if (!checkoutAttemptToken) {
+            setError('We could not restore your previous checkout attempt. Please restart registration or contact the organizer.');
+            return;
+          }
+          const checkout = await parentToolsService.initiateRegistrationCheckout(
+            form.teamId,
+            form.id,
+            returnRegistrationId,
+            requiresRegistrationOption(form) ? currentSelectedOptionId : currentSelectedOptionId || '',
+            currentSelectedPaymentPlanId,
+            currentQuantity,
+            currentFeeSnapshot.finalAmountDueCents,
+            currentFeeSnapshot.currency || form.currency || 'USD',
+            {
+              checkoutAttemptToken,
+              retryPayment: true
+            }
+          );
+          await openPublicUrl(checkout.checkoutUrl);
+          setMessage('Opening Stripe checkout.');
+          return;
+        }
+      }
+
       const result = await parentToolsService.submitOfflineRegistration(form.teamId, form.id, {
         participant: currentParticipant,
         guardian: currentGuardian,
@@ -171,7 +222,8 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
         selectedOptionId: currentSelectedOptionId,
         selectedPaymentPlanId: currentSelectedPaymentPlanId,
         quantity: currentQuantity,
-        feeSnapshot: currentFeeSnapshot
+        feeSnapshot: currentFeeSnapshot,
+        checkoutAttemptToken
       });
       if (result.status === 'waitlisted') {
         setMessage('Registration submitted. You have been added to the waitlist.');
@@ -189,7 +241,10 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
             currentSelectedPaymentPlanId,
             currentQuantity, // currentQuantity is already effective
             checkoutFeeSnapshot.finalAmountDueCents,
-            checkoutFeeSnapshot.currency || form.currency || 'USD'
+            checkoutFeeSnapshot.currency || form.currency || 'USD',
+            {
+              checkoutAttemptToken
+            }
           );
           await openPublicUrl(checkout.checkoutUrl);
           setMessage('Registration submitted. Opening Stripe checkout.');
@@ -374,7 +429,19 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
       {error ? <Status tone="error" message={error} /> : null}
       {placement ? <Status tone={placement.status === 'blocked' ? 'error' : 'success'} message={placement.status === 'waitlisted' ? 'This option is full. Submitting will add you to the waitlist.' : placement.status === 'pending' ? 'This option has capacity. Submitting creates a pending registration.' : placement.message || 'This option is not available.'} /> : null}
 
-      <section className="app-card p-4">
+      {isPaymentSuccessReturn ? (
+        <section className="app-card p-5">
+          <div className="flex items-start gap-3 rounded-2xl border border-emerald-200 bg-emerald-50 p-4 text-emerald-900">
+            <CheckCircle2 className="mt-0.5 h-5 w-5 flex-none" aria-hidden="true" />
+            <div>
+              <h2 className="text-base font-black">Payment successful</h2>
+              <p className="mt-1 text-sm font-semibold text-emerald-800">Your registration payment was received. The program organizer will follow up with next steps.</p>
+            </div>
+          </div>
+        </section>
+      ) : null}
+
+      {!isPaymentSuccessReturn ? <section className="app-card p-4">
         <form ref={formRef} className="grid gap-4" onSubmit={submit}>
           <FieldGroup title="Participant information" fields={form.participantFields || []} values={participant} errors={fieldErrors} prefix="participant" onChange={updateParticipant} disabled={saving} />
           <FieldGroup title="Guardian information" fields={form.guardianFields || []} values={guardian} errors={fieldErrors} prefix="guardian" onChange={updateGuardian} disabled={saving} />
@@ -447,12 +514,27 @@ function RegistrationDetailPage({ auth, publicAccess = false, staffReview = fals
 
           <button type="button" className="primary-button" onClick={submit} disabled={saving || Boolean(message)}>
             {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Send className="h-4 w-4" aria-hidden="true" />}
-            {saving ? (form.onlineCheckout ? 'Opening checkout...' : 'Submitting registration...') : (form.onlineCheckout ? 'Pay registration with Stripe' : 'Submit registration')}
+            {saving ? (form.onlineCheckout ? 'Opening checkout...' : 'Submitting registration...') : (form.onlineCheckout ? (isRetryPaymentMode ? 'Retry payment with Stripe' : 'Pay registration with Stripe') : 'Submit registration')}
           </button>
         </form>
-      </section>
+      </section> : null}
     </div>
   );
+}
+
+function createCheckoutAttemptToken() {
+  const bytes = new Uint8Array(16);
+  if (globalThis.crypto?.getRandomValues) {
+    globalThis.crypto.getRandomValues(bytes);
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+  }
+  return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 18)}`;
+}
+
+function normalizeRegistrationReturnStatus(value: string | null) {
+  const status = String(value || '').trim().toLowerCase();
+  if (status === 'success' || status === 'cancelled') return status;
+  return '';
 }
 
 function collectFieldValues(formElement: HTMLFormElement | null, group: string, fallback: Record<string, string>) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -493,6 +493,67 @@ async function queueDueRegistrationFailedPaymentReminders() {
   return results;
 }
 
+async function reserveRegistrationCheckoutCapacityForRetry(input) {
+  const formRef = buildRegistrationFormRef(input);
+  const registrationRef = buildRegistrationRef(input);
+  const now = admin.firestore.FieldValue.serverTimestamp();
+
+  return firestore.runTransaction(async (transaction) => {
+    const [formSnap, registrationSnap] = await Promise.all([
+      transaction.get(formRef),
+      transaction.get(registrationRef)
+    ]);
+    if (!formSnap.exists) {
+      throw new functions.https.HttpsError('not-found', 'Registration form not found.');
+    }
+    if (!registrationSnap.exists) {
+      throw new functions.https.HttpsError('not-found', 'Registration not found.');
+    }
+
+    const form = formSnap.data() || {};
+    const registration = registrationSnap.data() || {};
+    if (registration.teamId !== input.teamId || registration.formId !== input.formId) {
+      throw new functions.https.HttpsError('failed-precondition', 'Registration does not match the requested form.');
+    }
+    if (!registrationCheckoutAttemptStrictlyMatches(registration, input)) {
+      throw new functions.https.HttpsError('failed-precondition', 'Registration checkout attempt is required to retry this payment.');
+    }
+    if (registration.registrationCapacityReleased !== true) {
+      return { reserved: false, reason: 'already-held' };
+    }
+    if (registration.status !== 'pending') {
+      throw new functions.https.HttpsError('failed-precondition', 'Only pending registrations can retry payment.');
+    }
+
+    const selectedOption = registration.selectedOption || {};
+    const countKey = String(selectedOption.countKey || selectedOption.id || '').trim();
+    const counts = form.registrationOptionCounts || {};
+    const optionCounts = countKey ? counts[countKey] || {} : {};
+    if (!countKey || !counts[countKey] || typeof optionCounts !== 'object') {
+      throw new functions.https.HttpsError('failed-precondition', 'Registration form capacity tracking is not properly configured.');
+    }
+
+    const capacity = Number(selectedOption.capacityLimit || selectedOption.capacity || 0);
+    const enrolled = Math.max(0, Number(optionCounts.enrolled || 0));
+    if (capacity > 0 && enrolled >= capacity) {
+      throw new functions.https.HttpsError('failed-precondition', 'This registration option is no longer available. Please restart registration or contact the organizer.');
+    }
+
+    transaction.update(formRef, {
+      [`registrationOptionCounts.${countKey}.enrolled`]: enrolled + 1,
+      registrationCapacityUpdateId: input.registrationId,
+      updatedAt: now
+    });
+    transaction.set(registrationRef, {
+      registrationCapacityReleased: false,
+      capacityReleasedAt: admin.firestore.FieldValue.delete(),
+      updatedAt: now
+    }, { merge: true });
+
+    return { reserved: true };
+  });
+}
+
 async function releaseRegistrationCheckoutCapacity(input, statusUpdate = {}) {
   const formRef = buildRegistrationFormRef(input);
   const registrationRef = buildRegistrationRef(input);
@@ -1866,15 +1927,18 @@ exports.createStripeRegistrationCheckout = functions.https.onCall(async (data) =
   }
 
   const expectedAmountCents = getRegistrationCheckoutAmountCents(registration);
-  const amountCents = input.amountCents ?? expectedAmountCents;
-  if (input.amountCents !== null && input.amountCents !== expectedAmountCents) {
+  const amountCents = input.retryPayment ? expectedAmountCents : (input.amountCents ?? expectedAmountCents);
+  if (!input.retryPayment && input.amountCents !== null && input.amountCents !== expectedAmountCents) {
     throw new functions.https.HttpsError('failed-precondition', 'Checkout amount does not match the registration fee.');
   }
   const currency = String(
-    input.currency || registration.feeSnapshot?.currency || registration.currency || form.currency || 'usd'
+    (input.retryPayment ? '' : input.currency) || registration.feeSnapshot?.currency || registration.currency || form.currency || 'usd'
   ).trim().toLowerCase() || 'usd';
   if (!registrationCheckoutAttemptMatches(registration, input)) {
     throw new functions.https.HttpsError('failed-precondition', 'Registration checkout attempt does not match.');
+  }
+  if (input.retryPayment && registration.registrationCapacityReleased === true) {
+    await reserveRegistrationCheckoutCapacityForRetry(input);
   }
   if (canReuseRegistrationCheckoutSession(registration, amountCents, input)) {
     return { checkoutUrl: registration.checkoutUrl, sessionId: registration.stripeCheckoutSessionId };

--- a/js/db.js
+++ b/js/db.js
@@ -5701,7 +5701,9 @@ export async function createRegistrationCheckoutSession(
     paymentPlanId,
     quantity,
     amountCents,
-    currency
+    currency,
+    checkoutAttemptToken = '',
+    retryPayment = false
 ) {
     const callable = httpsCallable(functions, 'createStripeRegistrationCheckout');
     const result = await callable({
@@ -5712,7 +5714,9 @@ export async function createRegistrationCheckoutSession(
         paymentPlanId,
         quantity,
         amountCents,
-        currency
+        currency,
+        checkoutAttemptToken,
+        retryPayment
     });
     return result.data;
 }

--- a/teams.html
+++ b/teams.html
@@ -102,7 +102,7 @@
   <div id="footer-container"></div>
 
   <script type="module">
-    import { discoverPublicTeams } from './js/db.js?v=43';
+    import { discoverPublicTeams } from './js/db.js?v=44';
     import { renderHeader, renderFooter, escapeHtml, getSafeImageUrl, resolveZip } from './js/utils.js?v=9';
     import { checkAuth } from './js/auth.js?v=19';
 

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -929,7 +929,9 @@ describe('React app parent tools service', () => {
             paymentPlanId,
             quantity,
             amountCents,
-            currency
+            currency,
+            undefined,
+            undefined
         );
         expect(result).toEqual({ success: true, checkoutUrl: mockCheckoutUrl });
     });

--- a/tests/unit/app-registration-detail.test.jsx
+++ b/tests/unit/app-registration-detail.test.jsx
@@ -680,7 +680,10 @@ describe('RegistrationDetail page', () => {
       'pay_full',
       1,
       10000,
-      'USD'
+      'USD',
+      expect.objectContaining({
+        checkoutAttemptToken: expect.any(String)
+      })
     );
     expect(publicActionsMocks.openPublicUrl).toHaveBeenCalledWith('https://checkout.stripe.com/c/pay-reg-1');
   });
@@ -855,7 +858,10 @@ describe('RegistrationDetail page', () => {
       'pay_full',
       1,
       10000,
-      'USD'
+      'USD',
+      expect.objectContaining({
+        checkoutAttemptToken: expect.any(String)
+      })
     );
     expect(publicActionsMocks.openPublicUrl).toHaveBeenCalledWith('https://checkout.stripe.com/c/pay-reg-1');
   });
@@ -972,7 +978,10 @@ describe('RegistrationDetail page', () => {
       'pay_full',
       1,
       12500,
-      'cad'
+      'cad',
+      expect.objectContaining({
+        checkoutAttemptToken: expect.any(String)
+      })
     );
   });
 
@@ -1030,7 +1039,10 @@ describe('RegistrationDetail page', () => {
       'pay_full',
       1, // Should be 1 because hasQuantityDiscountRule is false
       expect.any(Number),
-      expect.any(String)
+      expect.any(String),
+      expect.objectContaining({
+        checkoutAttemptToken: expect.any(String)
+      })
     );
   });
 
@@ -1094,7 +1106,10 @@ describe('RegistrationDetail page', () => {
       'pay_full',
       2, // Should be 2 because hasQuantityDiscountRule is true and input was changed
       expect.any(Number),
-      expect.any(String)
+      expect.any(String),
+      expect.objectContaining({
+        checkoutAttemptToken: expect.any(String)
+      })
     );
   });
 

--- a/tests/unit/registration-flow.test.js
+++ b/tests/unit/registration-flow.test.js
@@ -711,6 +711,17 @@ describe('public registration flow', () => {
         expect(preparedCheckoutRegistration).toBeNull();
     });
 
+    it('uses secure retry tokens and keeps app retry flow wired to the stored checkout attempt', () => {
+        const appSource = fs.readFileSync('apps/app/src/pages/RegistrationDetail.tsx', 'utf8');
+
+        expect(appSource).toContain('function createCheckoutAttemptToken()');
+        expect(appSource).toContain("throw new Error('Crypto API not available. Cannot generate secure checkout token.');");
+        expect(appSource).not.toContain('Math.random().toString(36).slice(2, 18)');
+        expect(appSource).toContain("const checkoutAttemptToken = isRetryPaymentMode ? returnCheckoutAttemptToken : createCheckoutAttemptToken();");
+        expect(appSource).toContain('retryPayment: true');
+        expect(appSource).toContain("Stripe payment was cancelled. You can retry payment for this registration.");
+    });
+
     it('wires registration Stripe checkout to deployed functions', () => {
         const functionsSource = fs.readFileSync('functions/index.js', 'utf8');
 
@@ -722,7 +733,14 @@ describe('public registration flow', () => {
         expect(functionsSource).toContain('getRegistrationCheckoutAmountCents(registration)');
         expect(functionsSource).toContain("if (input.retryPayment) {");
         expect(functionsSource).toContain("params.set('retryPayment', '1');");
-        expect(functionsSource).toContain('const amountCents = input.amountCents ?? expectedAmountCents;');
+        expect(functionsSource).toContain('reserveRegistrationCheckoutCapacityForRetry');
+        expect(functionsSource).toContain('const amountCents = input.retryPayment ? expectedAmountCents : (input.amountCents ?? expectedAmountCents);');
+        expect(functionsSource).toContain("if (!input.retryPayment && input.amountCents !== null && input.amountCents !== expectedAmountCents)");
+        expect(functionsSource).toContain("(input.retryPayment ? '' : input.currency)");
+        expect(functionsSource).toContain("Registration checkout attempt is required to retry this payment.");
+        expect(functionsSource).toContain("This registration option is no longer available. Please restart registration or contact the organizer.");
+        expect(functionsSource).toContain("registrationCapacityReleased: false");
+        expect(functionsSource).toContain("capacityReleasedAt: admin.firestore.FieldValue.delete()");
         expect(functionsSource).toContain("const currency = String(");
         expect(functionsSource).toContain("form.paymentSettings?.onlineCheckoutEnabled !== true");
         expect(functionsSource).toContain("checkoutStatus: 'open'");

--- a/tests/unit/teams-public-visibility.test.js
+++ b/tests/unit/teams-public-visibility.test.js
@@ -67,7 +67,7 @@ describe('public teams visibility', () => {
     it('wires Browse Teams to the public-only helper path and keeps a defensive client filter', () => {
         const source = readRepoFile('teams.html');
 
-        expect(source).toContain("import { discoverPublicTeams } from './js/db.js?v=43';");
+        expect(source).toContain("import { discoverPublicTeams } from './js/db.js?v=44';");
         expect(source).toContain('discoverPublicTeams(locationFilter');
         expect(source).toContain("{ cursor, pageSize: 24 }");
         expect(source).toContain('allTeams.filter(t => t.isPublic === true)');


### PR DESCRIPTION
Closes #1843

## What changed
- taught `RegistrationDetail` to parse `registrationId`, `checkoutAttemptToken`, `retryPayment`, and `status` from the return URL
- added cancelled-return handling that shows retry guidance, releases the cancelled checkout attempt, and switches the CTA to `Retry payment with Stripe`
- added success-return handling that replaces the editable form with a payment-success confirmation
- split Stripe launch behavior into fresh registration checkout vs retry-existing-registration checkout so retry uses the existing `registrationId` and `checkoutAttemptToken`
- persisted `checkoutAttemptToken` on fresh app-side registration creation and forwarded retry metadata through the checkout service boundary
- added focused component tests for cancelled return, retry checkout reuse, and success return rendering

## Root Cause
`RegistrationDetail` only knew how to create a brand-new registration and immediately open Stripe. It did not carry the legacy Stripe return-state contract into the app route, and the app checkout helper did not pass `checkoutAttemptToken` / `retryPayment` through to the Stripe callable, so cancelled returns lost the original registration context and pushed users toward duplicate submissions.

## Prevention / Learning
When migrating payment flows into the React app, port the whole return-state contract, not just the initial submit path. Query-param parsing, persisted attempt tokens, cancel cleanup, retry-vs-create branching, and focused return-route tests all need to ship together.

## Regression Tests
- `npx vitest run apps/app/src/pages/RegistrationDetail.test.tsx`
- `npm run app:build`
- added coverage for cancelled Stripe return retry guidance and cleanup
- added coverage that retry reuses the existing registration without calling `submitOfflineRegistration`
- added coverage that success return replaces the form with confirmation UI