### PR TITLE
[codex] Surface parent fee checkout metadata

### DIFF
--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -32,7 +32,7 @@ import {
   normalizeParentFeeRecord,
   sortParentFeeRecords
 } from '../../../../js/parent-dashboard-fees.js';
-import { initiateTeamFeeCheckout } from '../../../../js/stripe-service.js';
+import { cancelStripeRegistrationCheckout, initiateTeamFeeCheckout } from '../../../../js/stripe-service.js';
 import {
   buildPendingRegistrationRecord,
   calculateRegistrationFeeSnapshot,
@@ -308,6 +308,7 @@ export async function submitOfflineRegistration(teamId: string, formId: string, 
       selectedPaymentPlanId: submission.selectedPaymentPlanId,
       status,
       feeSnapshot,
+      checkoutAttemptToken: submission.checkoutAttemptToken,
       now: serverTimestamp()
     });
 
@@ -933,21 +934,63 @@ export async function initiateRegistrationCheckout(
   paymentPlanId: string,
   quantity: number,
   amountCents: number,
-  currency: string
+  currency: string,
+  options: { checkoutAttemptToken?: string, returnToApp?: boolean } = {}
 ): Promise<{ success: true, checkoutUrl: string }> {
   if (!teamId || !formId || !registrationId || !paymentPlanId || !quantity || !amountCents || !currency) {
     throw new Error('Missing required fields for checkout.');
+  }
+
+  const result = options.checkoutAttemptToken
+    ? await createRegistrationCheckoutSession(
+      teamId,
+      formId,
+      registrationId,
+      selectedOptionId,
+      paymentPlanId,
+      quantity,
+      amountCents,
+      currency,
+      options
+    )
+    : await createRegistrationCheckoutSession(
+      teamId,
+      formId,
+      registrationId,
+      selectedOptionId,
+      paymentPlanId,
+      quantity,
+      amountCents,
+      currency
+    );
+
+  if (!result?.checkoutUrl) {
+    throw new Error('Failed to get checkout URL.');
+  }
+
+  return { success: true, checkoutUrl: result.checkoutUrl };
+}
+
+export async function retryRegistrationCheckout(
+  teamId: string,
+  formId: string,
+  registrationId: string,
+  checkoutAttemptToken: string
+): Promise<{ success: true, checkoutUrl: string }> {
+  if (!teamId || !formId || !registrationId || !checkoutAttemptToken) {
+    throw new Error('Missing required fields for payment retry.');
   }
 
   const result = await createRegistrationCheckoutSession(
     teamId,
     formId,
     registrationId,
-    selectedOptionId,
-    paymentPlanId,
-    quantity,
-    amountCents,
-    currency
+    '',
+    '',
+    1,
+    undefined,
+    '',
+    { checkoutAttemptToken, retryPayment: true, returnToApp: true }
   );
 
   if (!result?.checkoutUrl) {
@@ -955,6 +998,16 @@ export async function initiateRegistrationCheckout(
   }
 
   return { success: true, checkoutUrl: result.checkoutUrl };
+}
+
+export async function releaseCancelledRegistrationCheckout(
+  teamId: string,
+  formId: string,
+  registrationId: string,
+  checkoutAttemptToken: string
+) {
+  if (!teamId || !formId || !registrationId) return { released: false };
+  return cancelStripeRegistrationCheckout({ teamId, formId, registrationId, checkoutAttemptToken });
 }
 
 export function getCalendarEventShareText(event: ParentScheduleEvent) {

--- a/apps/app/src/pages/RegistrationDetail.test.tsx
+++ b/apps/app/src/pages/RegistrationDetail.test.tsx
@@ -1,14 +1,17 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { RegistrationDetail } from './RegistrationDetail';
 import type { AuthState } from '../lib/types';
+import { openPublicUrl } from '../lib/publicActions';
 
 const parentToolsServiceMocks = vi.hoisted(() => ({
   initiateRegistrationCheckout: vi.fn(),
   loadParentRegistrationDetail: vi.fn(),
   loadPublicRegistrationDetail: vi.fn(),
   loadParentRegistrations: vi.fn(),
+  releaseCancelledRegistrationCheckout: vi.fn(),
+  retryRegistrationCheckout: vi.fn(),
   submitOfflineRegistration: vi.fn()
 }));
 
@@ -66,9 +69,9 @@ function buildDetail(overrides: Record<string, any> = {}) {
   };
 }
 
-function renderPublicRegistration() {
+function renderPublicRegistration(query = 'teamId=team-1&formId=form-1') {
   return render(
-    <MemoryRouter initialEntries={['/registration?teamId=team-1&formId=form-1']}>
+    <MemoryRouter initialEntries={[`/registration?${query}`]}>
       <Routes>
         <Route path="/registration" element={<RegistrationDetail auth={auth} publicAccess />} />
       </Routes>
@@ -113,5 +116,95 @@ describe('RegistrationDetail payment notice', () => {
     expect(await screen.findByRole('button', { name: 'Submit registration' })).toBeInTheDocument();
     expect(screen.queryByRole('heading', { name: 'Payment' })).not.toBeInTheDocument();
     expect(parentToolsServiceMocks.loadParentRegistrationDetail).toHaveBeenCalledWith(auth.user, 'team-1', 'form-1');
+  });
+
+  it('shows canceled checkout retry state and releases the canceled attempt', async () => {
+    parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
+      paymentNotice: 'Payment will be collected in Stripe before your registration is complete.',
+      onlineCheckout: true
+    }));
+
+    renderPublicRegistration('teamId=team-1&formId=form-1&registrationId=reg-1&checkoutAttemptToken=attempt-token-123456&retryPayment=1&status=cancelled');
+
+    expect(await screen.findByText('Stripe payment was canceled. You can retry payment for your existing registration.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Retry payment with Stripe' })).toBeInTheDocument();
+    await waitFor(() => {
+      expect(parentToolsServiceMocks.releaseCancelledRegistrationCheckout).toHaveBeenCalledWith('team-1', 'form-1', 'reg-1', 'attempt-token-123456');
+    });
+  });
+
+  it('retries checkout without creating a duplicate registration', async () => {
+    parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
+      onlineCheckout: true
+    }));
+    parentToolsServiceMocks.retryRegistrationCheckout.mockResolvedValue({
+      success: true,
+      checkoutUrl: 'https://checkout.stripe.com/retry-session'
+    });
+
+    renderPublicRegistration('teamId=team-1&formId=form-1&registrationId=reg-1&checkoutAttemptToken=attempt-token-123456&retryPayment=1&status=cancelled');
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry payment with Stripe' }));
+
+    await waitFor(() => {
+      expect(parentToolsServiceMocks.retryRegistrationCheckout).toHaveBeenCalledWith('team-1', 'form-1', 'reg-1', 'attempt-token-123456');
+      expect(parentToolsServiceMocks.submitOfflineRegistration).not.toHaveBeenCalled();
+      expect(openPublicUrl).toHaveBeenCalledWith('https://checkout.stripe.com/retry-session');
+    });
+  });
+
+  it('renders success return confirmation instead of the editable registration form', async () => {
+    parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
+      onlineCheckout: true
+    }));
+
+    renderPublicRegistration('teamId=team-1&formId=form-1&registrationId=reg-1&checkoutAttemptToken=attempt-token-123456&status=success');
+
+    expect(await screen.findByRole('heading', { name: 'Payment successful' })).toBeInTheDocument();
+    expect(screen.getByText('Your registration payment was received. The program organizer will follow up with next steps.')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Pay registration with Stripe' })).not.toBeInTheDocument();
+  });
+
+  it('stores the checkout attempt token when starting a fresh app checkout', async () => {
+    let submittedCheckoutAttemptToken = '';
+    parentToolsServiceMocks.loadPublicRegistrationDetail.mockResolvedValue(buildDetail({
+      onlineCheckout: true
+    }));
+    parentToolsServiceMocks.submitOfflineRegistration.mockImplementation(async (_teamId, _formId, submission) => {
+      submittedCheckoutAttemptToken = submission.checkoutAttemptToken;
+      return {
+        success: true,
+        status: 'pending',
+        registrationId: 'reg-1',
+        feeSnapshot: {
+          finalAmountDueCents: 12500,
+          currency: 'USD'
+        }
+      };
+    });
+    parentToolsServiceMocks.initiateRegistrationCheckout.mockResolvedValue({
+      success: true,
+      checkoutUrl: 'https://checkout.stripe.com/fresh-session'
+    });
+
+    renderPublicRegistration();
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Pay registration with Stripe' }));
+
+    await waitFor(() => {
+      expect(submittedCheckoutAttemptToken).toMatch(/^[a-f0-9]{32}$/);
+      expect(parentToolsServiceMocks.initiateRegistrationCheckout).toHaveBeenCalledWith(
+        'team-1',
+        'form-1',
+        'reg-1',
+        '',
+        'pay_full',
+        1,
+        12500,
+        'USD',
+        { checkoutAttemptToken: submittedCheckoutAttemptToken, returnToApp: true }
+      );
+      expect(openPublicUrl).toHaveBeenCalledWith('https://checkout.stripe.com/fresh-session');
+    });
   });
 });

--- a/apps/app/src/pages/RegistrationDetail.tsx
+++ b/apps/app/src/pages/RegistrationDetail.tsx
@@ -48,6 +48,14 @@ export function RegistrationDetail({ auth, publicAccess = false }: { auth: AuthS
   const [selectedPaymentPlanId, setSelectedPaymentPlanId] = useState('pay_full');
   const [reloadKey, setReloadKey] = useState(0);
   const formRef = useRef<HTMLFormElement | null>(null);
+  const releaseAttemptRef = useRef('');
+  const retryRegistrationId = String(searchParams.get('registrationId') || '').trim();
+  const retryCheckoutAttemptToken = String(searchParams.get('checkoutAttemptToken') || '').trim();
+  const stripeReturnStatus = String(searchParams.get('status') || '').trim().toLowerCase();
+  const retryPaymentRequested = searchParams.get('retryPayment') === '1' && Boolean(retryRegistrationId);
+  const retryCheckoutReady = Boolean(retryRegistrationId) && (retryPaymentRequested || stripeReturnStatus === 'cancelled');
+  const stripeSuccessReturn = Boolean(retryRegistrationId) && stripeReturnStatus === 'success';
+  const stripeCancelledReturn = Boolean(retryRegistrationId) && stripeReturnStatus === 'cancelled';
 
   useEffect(() => {
     let cancelled = false;
@@ -83,6 +91,19 @@ export function RegistrationDetail({ auth, publicAccess = false }: { auth: AuthS
       cancelled = true;
     };
   }, [auth.user?.uid, teamId, formId, publicAccess, reloadKey]);
+
+  useEffect(() => {
+    if (!stripeCancelledReturn) return;
+    const releaseKey = `${teamId}:${formId}:${retryRegistrationId}:${retryCheckoutAttemptToken}`;
+    if (!teamId || !formId || releaseAttemptRef.current === releaseKey) return;
+    releaseAttemptRef.current = releaseKey;
+    void Promise.resolve(parentToolsService.releaseCancelledRegistrationCheckout(
+      teamId,
+      formId,
+      retryRegistrationId,
+      retryCheckoutAttemptToken
+    )).catch(() => undefined);
+  }, [teamId, formId, retryRegistrationId, retryCheckoutAttemptToken, stripeCancelledReturn]);
 
   const activeOptions: any[] = useMemo(() => form ? ((Array.isArray(form.options) && form.options.length) ? form.options : getActiveRegistrationOptions(form, form.registrationOptionCounts || {})) : [], [form]);
   const paymentPlanChoices: any[] = useMemo(() => form ? ((Array.isArray(form.paymentPlans) && form.paymentPlans.length) ? form.paymentPlans : getPaymentPlanChoices(form)) : [], [form]);
@@ -131,7 +152,24 @@ export function RegistrationDetail({ auth, publicAccess = false }: { auth: AuthS
 
     setSaving(true);
     try {
+      if (retryCheckoutReady) {
+        if (!retryCheckoutAttemptToken) {
+          setError('This payment retry link is missing its secure checkout token. Please use the latest payment link from the organizer.');
+          return;
+        }
+        const checkout = await parentToolsService.retryRegistrationCheckout(
+          form.teamId,
+          form.id,
+          retryRegistrationId,
+          retryCheckoutAttemptToken
+        );
+        await openPublicUrl(checkout.checkoutUrl);
+        setMessage('Opening Stripe checkout for your existing registration.');
+        return;
+      }
+
       const currentFeeSnapshot = calculateRegistrationFeeSnapshot(form, { quantity: currentQuantity, now: new Date() }); // currentQuantity is already effective
+      const checkoutAttemptToken = form.onlineCheckout ? createCheckoutAttemptToken() : '';
       const result = await parentToolsService.submitOfflineRegistration(form.teamId, form.id, {
         participant: currentParticipant,
         guardian: currentGuardian,
@@ -140,7 +178,8 @@ export function RegistrationDetail({ auth, publicAccess = false }: { auth: AuthS
         selectedOptionId: currentSelectedOptionId,
         selectedPaymentPlanId: currentSelectedPaymentPlanId,
         quantity: currentQuantity,
-        feeSnapshot: currentFeeSnapshot
+        feeSnapshot: currentFeeSnapshot,
+        checkoutAttemptToken
       });
       if (result.status === 'waitlisted') {
         setMessage('Registration submitted. You have been added to the waitlist.');
@@ -158,7 +197,8 @@ export function RegistrationDetail({ auth, publicAccess = false }: { auth: AuthS
             currentSelectedPaymentPlanId,
             currentQuantity, // currentQuantity is already effective
             checkoutFeeSnapshot.finalAmountDueCents,
-            checkoutFeeSnapshot.currency || form.currency || 'USD'
+            checkoutFeeSnapshot.currency || form.currency || 'USD',
+            { checkoutAttemptToken, returnToApp: publicAccess }
           );
           await openPublicUrl(checkout.checkoutUrl);
           setMessage('Registration submitted. Opening Stripe checkout.');
@@ -206,9 +246,21 @@ export function RegistrationDetail({ auth, publicAccess = false }: { auth: AuthS
       </section>
 
       {message ? <Status tone="success" message={message} /> : null}
+      {stripeCancelledReturn ? <Status tone="error" message="Stripe payment was canceled. You can retry payment for your existing registration." /> : null}
       {error ? <Status tone="error" message={error} /> : null}
       {placement ? <Status tone={placement.status === 'blocked' ? 'error' : 'success'} message={placement.status === 'waitlisted' ? 'This option is full. Submitting will add you to the waitlist.' : placement.status === 'pending' ? 'This option has capacity. Submitting creates a pending registration.' : placement.message || 'This option is not available.'} /> : null}
 
+      {stripeSuccessReturn ? (
+        <section className="app-card p-5">
+          <div className="flex items-start gap-3">
+            <CheckCircle2 className="mt-0.5 h-5 w-5 flex-none text-emerald-600" aria-hidden="true" />
+            <div>
+              <h2 className="text-base font-black text-gray-950">Payment successful</h2>
+              <p className="mt-1 text-sm font-semibold leading-6 text-gray-600">Your registration payment was received. The program organizer will follow up with next steps.</p>
+            </div>
+          </div>
+        </section>
+      ) : (
       <section className="app-card p-4">
         <form ref={formRef} className="grid gap-4" onSubmit={submit}>
           <FieldGroup title="Participant information" fields={form.participantFields || []} values={participant} errors={fieldErrors} prefix="participant" onChange={updateParticipant} disabled={saving} />
@@ -282,10 +334,11 @@ export function RegistrationDetail({ auth, publicAccess = false }: { auth: AuthS
 
           <button type="button" className="primary-button" onClick={submit} disabled={saving || Boolean(message)}>
             {saving ? <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" /> : <Send className="h-4 w-4" aria-hidden="true" />}
-            {saving ? (form.onlineCheckout ? 'Opening checkout...' : 'Submitting registration...') : (form.onlineCheckout ? 'Pay registration with Stripe' : 'Submit registration')}
+            {saving ? (form.onlineCheckout ? 'Opening checkout...' : 'Submitting registration...') : retryCheckoutReady ? 'Retry payment with Stripe' : (form.onlineCheckout ? 'Pay registration with Stripe' : 'Submit registration')}
           </button>
         </form>
       </section>
+      )}
     </div>
   );
 }
@@ -298,6 +351,15 @@ function collectFieldValues(formElement: HTMLFormElement | null, group: string, 
     if (fieldId) values[fieldId] = input.value;
   });
   return values;
+}
+
+function createCheckoutAttemptToken() {
+  const bytes = new Uint8Array(16);
+  if (globalThis.crypto?.getRandomValues) {
+    globalThis.crypto.getRandomValues(bytes);
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join('');
+  }
+  return `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 18)}`.replace(/[^A-Za-z0-9_-]/g, '').slice(0, 64);
 }
 
 function validate(form: ParentRegistrationCard, participant: Record<string, string>, guardian: Record<string, string>, waiverAccepted: boolean, selectedOptionId: string, quantity: number, selectedPaymentPlanId: string, hasQuantityDiscount: boolean) {

--- a/functions/index.js
+++ b/functions/index.js
@@ -223,7 +223,8 @@ function normalizeRegistrationCheckoutInput(data = {}) {
     amountCents,
     currency,
     checkoutAttemptToken: normalizeCheckoutAttemptToken(data.checkoutAttemptToken),
-    retryPayment: data.retryPayment === true || String(data.retryPayment || '').trim() === '1'
+    retryPayment: data.retryPayment === true || String(data.retryPayment || '').trim() === '1',
+    returnToApp: data.returnToApp === true || String(data.returnToApp || '').trim() === '1'
   };
 }
 
@@ -250,6 +251,7 @@ function buildRegistrationReminderMailRef(mailDocId) {
 
 function buildRegistrationCheckoutUrls(appUrl, input) {
   const baseUrl = String(appUrl || 'https://allplays.ai').replace(/\/$/, '');
+  const route = input.returnToApp ? '/app/#/registration' : '/registration.html';
   const params = new URLSearchParams({
     teamId: input.teamId,
     formId: input.formId,
@@ -262,8 +264,8 @@ function buildRegistrationCheckoutUrls(appUrl, input) {
     params.set('retryPayment', '1');
   }
   return {
-    successUrl: `${baseUrl}/registration.html?${params.toString()}&status=success`,
-    cancelUrl: `${baseUrl}/registration.html?${params.toString()}&status=cancelled`
+    successUrl: `${baseUrl}${route}?${params.toString()}&status=success`,
+    cancelUrl: `${baseUrl}${route}?${params.toString()}&status=cancelled`
   };
 }
 

--- a/js/db.js
+++ b/js/db.js
@@ -5593,10 +5593,11 @@ export async function createRegistrationCheckoutSession(
     paymentPlanId,
     quantity,
     amountCents,
-    currency
+    currency,
+    options = {}
 ) {
     const callable = httpsCallable(functions, 'createStripeRegistrationCheckout');
-    const result = await callable({
+    const payload = {
         teamId,
         formId,
         registrationId,
@@ -5605,7 +5606,18 @@ export async function createRegistrationCheckoutSession(
         quantity,
         amountCents,
         currency
-    });
+    };
+    const checkoutAttemptToken = String(options.checkoutAttemptToken || '').trim();
+    if (checkoutAttemptToken) {
+        payload.checkoutAttemptToken = checkoutAttemptToken;
+    }
+    if (options.retryPayment === true) {
+        payload.retryPayment = true;
+    }
+    if (options.returnToApp === true) {
+        payload.returnToApp = true;
+    }
+    const result = await callable(payload);
     return result.data;
 }
 

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -74,6 +74,7 @@ const registrationMocks = vi.hoisted(() => ({
         paymentPlan: { id: submission.selectedPaymentPlanId || 'pay_full' },
         status: submission.status || 'pending',
         feeSnapshot: submission.feeSnapshot,
+        checkoutAttemptToken: submission.checkoutAttemptToken,
         submittedAt: submission.now
     })),
     calculateRegistrationFeeSnapshot: vi.fn((form) => ({ finalAmountDueCents: form.finalAmountDueCents ?? 0 })),
@@ -125,6 +126,7 @@ const scheduleMocks = vi.hoisted(() => ({
 }));
 
 const stripeMocks = vi.hoisted(() => ({
+    cancelStripeRegistrationCheckout: vi.fn(),
     initiateTeamFeeCheckout: vi.fn()
 }));
 
@@ -172,6 +174,8 @@ import {
     updateTeamMediaItemForApp,
     initiateRegistrationCheckout,
     initiateParentTeamFeeCheckout,
+    releaseCancelledRegistrationCheckout,
+    retryRegistrationCheckout,
     canInitiateParentTeamFeeCheckout,
     isParentTeamFeePayActionAllowed
 } from '../../apps/app/src/lib/parentToolsService.ts';
@@ -248,6 +252,7 @@ describe('React app parent tools service', () => {
             waiverAccepted: true,
             selectedOption: { id: 'opt-1', countKey: 'opt-1-key' },
             selectedPaymentPlanId: 'pay_full',
+            checkoutAttemptToken: 'attempt-token-123456',
             submittedAt: new Date(),
         };
 
@@ -316,6 +321,7 @@ describe('React app parent tools service', () => {
                 waiverAccepted: true,
                 selectedOption: expect.objectContaining({ id: 'opt-1' }),
                 status: 'pending',
+                checkoutAttemptToken: 'attempt-token-123456',
             })
         );
     });
@@ -796,6 +802,66 @@ describe('React app parent tools service', () => {
             currency
         );
         expect(result).toEqual({ success: true, checkoutUrl: mockCheckoutUrl });
+    });
+
+    it('passes checkout attempt token options for app registration checkout retries', async () => {
+        const mockCheckoutUrl = 'https://checkout.stripe.com/retry-session';
+        dbMocks.createRegistrationCheckoutSession.mockResolvedValue({ checkoutUrl: mockCheckoutUrl });
+
+        await expect(initiateRegistrationCheckout(
+            'team-1',
+            'form-reg-1',
+            'reg-abc',
+            'option-xyz',
+            'plan-123',
+            1,
+            7500,
+            'USD',
+            { checkoutAttemptToken: 'attempt-token-123456', returnToApp: true }
+        )).resolves.toEqual({ success: true, checkoutUrl: mockCheckoutUrl });
+
+        expect(dbMocks.createRegistrationCheckoutSession).toHaveBeenCalledWith(
+            'team-1',
+            'form-reg-1',
+            'reg-abc',
+            'option-xyz',
+            'plan-123',
+            1,
+            7500,
+            'USD',
+            { checkoutAttemptToken: 'attempt-token-123456', returnToApp: true }
+        );
+
+        dbMocks.createRegistrationCheckoutSession.mockResolvedValueOnce({ checkoutUrl: 'https://checkout.stripe.com/existing-session' });
+
+        await expect(retryRegistrationCheckout('team-1', 'form-reg-1', 'reg-abc', 'attempt-token-123456'))
+            .resolves.toEqual({ success: true, checkoutUrl: 'https://checkout.stripe.com/existing-session' });
+
+        expect(dbMocks.createRegistrationCheckoutSession).toHaveBeenLastCalledWith(
+            'team-1',
+            'form-reg-1',
+            'reg-abc',
+            '',
+            '',
+            1,
+            undefined,
+            '',
+            { checkoutAttemptToken: 'attempt-token-123456', retryPayment: true, returnToApp: true }
+        );
+    });
+
+    it('releases canceled registration checkout attempts through Stripe service', async () => {
+        stripeMocks.cancelStripeRegistrationCheckout.mockResolvedValue({ released: true });
+
+        await expect(releaseCancelledRegistrationCheckout('team-1', 'form-reg-1', 'reg-abc', 'attempt-token-123456'))
+            .resolves.toEqual({ released: true });
+
+        expect(stripeMocks.cancelStripeRegistrationCheckout).toHaveBeenCalledWith({
+            teamId: 'team-1',
+            formId: 'form-reg-1',
+            registrationId: 'reg-abc',
+            checkoutAttemptToken: 'attempt-token-123456'
+        });
     });
 
     it('throws error if required fields are missing for checkout', async () => {


### PR DESCRIPTION
Closes #2021.

## Summary
- surface parent fee collection mode and checkout metadata in app fee records
- prevent duplicate parent checkout attempts by reusing existing checkout sessions and guarding active calls
- add regression coverage for parent fee normalization and registration checkout retry flows

## Validation
- npx vitest run tests/unit/app-parent-tools-service.test.js --reporter=dot
- cd apps/app && npx vitest run src/pages/RegistrationDetail.test.tsx --reporter=dot

Note: an earlier broad npm test invocation ran the full unit suite because the package script hard-codes tests/unit; it surfaced existing unrelated local failures, so the targeted commands above are the validation for this PR.