### PR TITLE
Skip insights computation in buildTeamDetailModel when deferred data is not requested

### DIFF
--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -869,7 +869,8 @@ export async function loadParentTeamDetail(
     trackingItems,
     trackingStatuses,
     sponsors: [...normalizeSponsorList(adSponsors), ...normalizeSponsorList(localSponsors)],
-    includeStaffPermissions: false
+    includeStaffPermissions: false,
+    includeInsights: includeDeferredData
   });
 }
 
@@ -959,7 +960,8 @@ export function buildTeamDetailModel({
   sponsors = [],
   pendingAdminInvites = [],
   confirmedTeamMembers = [],
-  includeStaffPermissions = true
+  includeStaffPermissions = true,
+  includeInsights = true
 }: {
   teamId: string;
   team: Record<string, any>;
@@ -975,6 +977,7 @@ export function buildTeamDetailModel({
   pendingAdminInvites?: any[];
   confirmedTeamMembers?: any[];
   includeStaffPermissions?: boolean;
+  includeInsights?: boolean;
 }): TeamDetailModel {
   const normalizedPlayers = normalizePlayers(players, linkedPlayerIds);
   const normalizedInactivePlayers = normalizePlayers(players, linkedPlayerIds, { inactiveOnly: true });
@@ -986,8 +989,8 @@ export function buildTeamDetailModel({
   const record = calculateSeasonRecord(games, { seasonLabel });
   const completedGames = games.filter(isCompletedGame);
   const standings = buildStandings(team, games);
-  const leaderboards = buildLeaderboards(configs, normalizedPlayers, seasonStatsByPlayerId, team?.sport);
-  const trackingSummaries = buildTrackingSummaries(normalizedPlayers, linkedPlayerIds, trackingItems, trackingStatuses);
+  const leaderboards = includeInsights ? buildLeaderboards(configs, normalizedPlayers, seasonStatsByPlayerId, team?.sport) : [];
+  const trackingSummaries = includeInsights ? buildTrackingSummaries(normalizedPlayers, linkedPlayerIds, trackingItems, trackingStatuses) : [];
   const canManageTeam = hasFullTeamAccess(user, team);
   const canManageAdmins = canManageTeamAdmins(user, team);
   const staffPermissions = canManageTeam && includeStaffPermissions

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -949,6 +949,43 @@ describe('React app team detail model', () => {
         expect(sponsors.sponsors.map((sponsor) => sponsor.id)).toEqual(['ad-1', 'local-1']);
     });
 
+    it('skips leaderboards and trackingSummaries when includeInsights is false', () => {
+        const teamBase = {
+            teamId: 'team-1',
+            team: { name: 'Bears', sport: 'Basketball' },
+            players: [
+                { id: 'player-1', name: 'Pat Star', number: '9' },
+                { id: 'player-2', name: 'Sam Wing', number: '12' }
+            ],
+            configs: [{
+                id: 'basketball',
+                name: 'Basketball',
+                columns: ['pts'],
+                statDefinitions: [{ id: 'pts', label: 'Points', acronym: 'PTS', topStat: true, visibility: 'public', scope: 'player' }]
+            }],
+            seasonStatsByPlayerId: {
+                'player-1': { pts: 88 },
+                'player-2': { pts: 31 }
+            },
+            trackingItems: [{ id: 'item-1', title: 'Bring ball', public: true }],
+            trackingStatuses: [{ itemId: 'item-1', playerId: 'player-1', status: 'complete', public: true }],
+            user: { uid: 'user-1', email: 'parent@example.com', displayName: 'Parent', roles: ['parent'], parentOf: [{ teamId: 'team-1', playerId: 'player-1' }] }
+        };
+
+        const deferredModel = buildTeamDetailModel({ ...teamBase, includeInsights: false });
+        expect(deferredModel.leaderboards).toEqual([]);
+        expect(deferredModel.trackingSummaries).toEqual([]);
+
+        const fullModel = buildTeamDetailModel({ ...teamBase, includeInsights: true });
+        expect(fullModel.leaderboards.length).toBeGreaterThan(0);
+        expect(fullModel.leaderboards[0].leaders[0]).toMatchObject({ playerId: 'player-1', formattedValue: '88' });
+        expect(fullModel.trackingSummaries[0].items[0]).toMatchObject({ title: 'Bring ball', isComplete: true });
+
+        const defaultModel = buildTeamDetailModel({ ...teamBase });
+        expect(defaultModel.leaderboards.length).toBeGreaterThan(0);
+        expect(defaultModel.trackingSummaries.length).toBeGreaterThan(0);
+    });
+
     it('loads deferred staff permissions only when requested for a team manager', async () => {
         getTeam.mockResolvedValue({
             id: 'team-1',


### PR DESCRIPTION
## Summary
- Add `includeInsights` parameter to `buildTeamDetailModel` (default `true`)
- When `includeInsights` is `false`, skip `buildLeaderboards` and `buildTrackingSummaries` and return empty arrays, avoiding wasted CPU on the initial team load path
- Pass `includeInsights: includeDeferredData` from `loadParentTeamDetail` so the initial overview and settings loads skip insight derivation entirely — it is recomputed by `loadTeamDetailInsights` when the Insights tab is opened

## Test plan
- [ ] Unit: new test in `app-team-detail-service.test.js` calls `buildTeamDetailModel` with `includeInsights: false` and asserts empty `leaderboards`/`trackingSummaries`; also verifies the default (`true`) still produces populated data
- [ ] Manual: open a team from the Teams page — overview and settings load normally; tap Insights — leaderboards and tracking summaries still load correctly

Closes #2134

https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5)_