### PR TITLE
[codex] Fix fee recipient rules helper arity

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1407,8 +1407,8 @@ service cloud.firestore {
     // Collection group rule for assigned team fee recipient records.
     // Parents can only read records tied directly to their account or linked players.
     match /{path=**}/feeRecipients/{recipientId} {
-      allow read: if isTeamFeeRecipientForCurrentParent(resource.data) ||
-                     (resource.data.get('teamId', '') is string &&
+      allow read: if resource.data.get('teamId', '') is string &&
+                     (isTeamFeeRecipientForCurrentParent(resource.data, resource.data.get('teamId', '')) ||
                       isTeamOwnerOrAdmin(resource.data.get('teamId', '')));
       allow create: if request.resource.data.get('teamId', '') is string &&
                        isTeamOwnerOrAdmin(request.resource.data.get('teamId', ''));

--- a/tests/unit/app-schedule-desktop-controls.test.jsx
+++ b/tests/unit/app-schedule-desktop-controls.test.jsx
@@ -476,6 +476,10 @@ describe('React app desktop Schedule controls', () => {
         const parentOnly = await renderSchedule();
         await waitForText(parentOnly.container, 'Main Gym');
         expect(parentOnly.container.textContent).not.toContain('Draft schedule with AI');
+        await act(async () => {
+            parentOnly.root.unmount();
+        });
+        parentOnly.container.remove();
 
         const aiRow = {
             rowNumber: 1,

--- a/tests/unit/team-fee-recipient-rules.test.js
+++ b/tests/unit/team-fee-recipient-rules.test.js
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const rules = readFileSync(new URL('../../firestore.rules', import.meta.url), 'utf8');
+
+describe('team fee recipient Firestore rules', () => {
+    it('passes teamId to the parent recipient helper for collection-group reads', () => {
+        expect(rules).toContain('function isTeamFeeRecipientForCurrentParent(data, teamId)');
+        expect(rules).not.toContain('isTeamFeeRecipientForCurrentParent(resource.data) ||');
+        expect(rules).toContain("isTeamFeeRecipientForCurrentParent(resource.data, resource.data.get('teamId', ''))");
+        expect(rules).toContain('isTeamFeeRecipientForCurrentParent(resource.data, resource.data.teamId)');
+    });
+});


### PR DESCRIPTION
Closes #2060.

## Summary
- pass `teamId` into the collection-group fee recipient parent helper
- keep owner/admin access gated by the same teamId guard
- add a static rules regression for both supported helper call sites

## Validation
- npx vitest run tests/unit/team-fee-recipient-rules.test.js tests/unit/validate-firebase-rules-ci.test.js --reporter=dot
- npm run ci:firebase-rules