### PR TITLE
Detect @mentions in team chat and send mentions-category push, dedup with liveChat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Claude Code internal directories
+.claude/
+
 # Dependencies
 node_modules/
 

--- a/functions/index.js
+++ b/functions/index.js
@@ -3206,14 +3206,59 @@ async function sendCategoryNotification({
   title,
   body,
   actorUid = null,
-  linkOverride = null
+  linkOverride = null,
+  excludeUids = []
 }) {
   if (!NOTIFICATION_CATEGORIES.includes(category)) return null;
 
-  const targets = await getTargetsForCategory(teamId, category, actorUid);
+  const allTargets = await getTargetsForCategory(teamId, category, actorUid);
+  const excludeSet = new Set(Array.isArray(excludeUids) ? excludeUids : []);
+  const targets = excludeSet.size
+    ? allTargets.filter((t) => !excludeSet.has(t.uid))
+    : allTargets;
   if (!targets.length) return null;
 
   const link = linkOverride || buildNotificationLink({ category, teamId, gameId });
+  const appRoute = buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId });
+  const maxMulticastTokens = 500;
+  const allResponses = [];
+  let successCount = 0;
+  let failureCount = 0;
+
+  for (let i = 0; i < targets.length; i += maxMulticastTokens) {
+    const targetChunk = targets.slice(i, i + maxMulticastTokens);
+    const sendResult = await admin.messaging().sendEachForMulticast({
+      tokens: targetChunk.map((target) => target.token),
+      notification: { title, body },
+      data: {
+        teamId: String(teamId),
+        gameId: String(gameId || ''),
+        eventId: String(eventId || gameId || ''),
+        category: String(category),
+        appRoute,
+        link
+      },
+      webpush: {
+        fcmOptions: { link }
+      }
+    });
+    allResponses.push(...(Array.isArray(sendResult.responses) ? sendResult.responses : []));
+    successCount += Number(sendResult.successCount || 0);
+    failureCount += Number(sendResult.failureCount || 0);
+    await pruneInvalidTokens(sendResult, targetChunk);
+  }
+
+  return {
+    responses: allResponses,
+    successCount,
+    failureCount
+  };
+}
+
+async function sendDirectTargetsNotification({ targets, category, title, body, teamId, gameId = null, eventId = null }) {
+  if (!targets.length) return null;
+
+  const link = buildNotificationLink({ category, teamId, gameId });
   const appRoute = buildNotificationAppRoute({ category, teamId, gameId, eventId: eventId || gameId });
   const maxMulticastTokens = 500;
   const allResponses = [];
@@ -3592,6 +3637,28 @@ exports.queueDueRegistrationFailedPaymentReminders = functions.pubsub
   .schedule('every 6 hours')
   .onRun(() => queueDueRegistrationFailedPaymentReminders());
 
+function detectMentionedUids(text, members) {
+  if (!text) return [];
+  const mentioned = new Set();
+  const tokens = text.match(/@[\w.'"-]+/gi) || [];
+  for (const token of tokens) {
+    const name = token.slice(1).toLowerCase();
+    if (name === 'all' || name === 'team') {
+      members.forEach((m) => mentioned.add(m.uid));
+      break;
+    }
+    for (const member of members) {
+      const memberName = String(member.displayName || member.name || '').toLowerCase();
+      const memberNameCompact = memberName.replace(/\s+/g, '');
+      const firstName = memberName.split(' ')[0];
+      if (memberNameCompact === name || firstName === name) {
+        mentioned.add(member.uid);
+      }
+    }
+  }
+  return [...mentioned];
+}
+
 exports.notifyTeamChatMessageCreated = functions.firestore
   .document('teams/{teamId}/chatMessages/{messageId}')
   .onCreate(async (snapshot, context) => {
@@ -3608,13 +3675,57 @@ exports.notifyTeamChatMessageCreated = functions.firestore
       ? (text.length > 120 ? `${text.slice(0, 117)}...` : text)
       : 'sent a photo';
 
-    return sendCategoryNotification({
+    // Detect @mentions and send targeted mentions-category pushes
+    let mentionedUids = [];
+    if (text) {
+      const allTargets = await getTargetsForCategory(teamId, 'mentions', null);
+      const members = allTargets.map((t) => ({ uid: t.uid, displayName: '' }));
+      // Also fetch candidate users to get display names for matching
+      const candidateUids = await getCandidateUserIdsForTeam(teamId);
+      const memberMap = new Map(members.map((m) => [m.uid, m]));
+      const userProfileTasks = candidateUids.map(async (uid) => {
+        const userSnap = await firestore.doc(`users/${uid}`).get();
+        const userDoc = userSnap.exists ? (userSnap.data() || {}) : {};
+        const displayName = String(userDoc.displayName || userDoc.fullName || userDoc.name || '').trim();
+        if (memberMap.has(uid)) {
+          memberMap.get(uid).displayName = displayName;
+        }
+      });
+      await Promise.all(userProfileTasks);
+      mentionedUids = detectMentionedUids(text, [...memberMap.values()])
+        .filter((uid) => uid !== actorUid);
+    }
+
+    const results = [];
+
+    if (mentionedUids.length) {
+      await snapshot.ref.update({ mentionedUids });
+      // Send mentions push only to the mentioned users (those who have mentions enabled)
+      const mentionTargets = await getTargetsForCategory(teamId, 'mentions', actorUid);
+      const mentionedSet = new Set(mentionedUids);
+      const filteredMentionTargets = mentionTargets.filter((t) => mentionedSet.has(t.uid));
+      if (filteredMentionTargets.length) {
+        results.push(await sendDirectTargetsNotification({
+          targets: filteredMentionTargets,
+          category: 'mentions',
+          title: `${senderName} mentioned you`,
+          body,
+          teamId
+        }));
+      }
+    }
+
+    // liveChat push — skip users who already got a mentions push
+    results.push(await sendCategoryNotification({
       teamId,
       category: 'liveChat',
       title: `${senderName}: Team Chat`,
       body,
-      actorUid
-    });
+      actorUid,
+      excludeUids: mentionedUids
+    }));
+
+    return results;
   });
 
 exports.postSharedGameCancellationNotification = functions.https.onCall(async (data, context) => {

--- a/functions/index.js
+++ b/functions/index.js
@@ -3681,7 +3681,8 @@ exports.notifyTeamChatMessageCreated = functions.firestore
       const allTargets = await getTargetsForCategory(teamId, 'mentions', null);
       const members = allTargets.map((t) => ({ uid: t.uid, displayName: '' }));
       // Also fetch candidate users to get display names for matching
-      const candidateUids = await getCandidateUserIdsForTeam(teamId);
+      const candidateUsers = await getCandidateUsersForTeam(teamId);
+      const candidateUids = candidateUsers.map((user) => user.uid);
       const memberMap = new Map(members.map((m) => [m.uid, m]));
       const userProfileTasks = candidateUids.map(async (uid) => {
         const userSnap = await firestore.doc(`users/${uid}`).get();

--- a/tests/unit/functions-chat-mention-detection.test.js
+++ b/tests/unit/functions-chat-mention-detection.test.js
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+
+const functionsSource = readFileSync(new URL('../../functions/index.js', import.meta.url), 'utf8');
+
+function getDetectMentionedUids() {
+    const start = functionsSource.indexOf('function detectMentionedUids(');
+    const end = functionsSource.indexOf('\nexports.notifyTeamChatMessageCreated');
+    const slice = functionsSource.slice(start, end);
+    return new Function(`${slice}; return detectMentionedUids;`)();
+}
+
+const detectMentionedUids = getDetectMentionedUids();
+
+describe('detectMentionedUids', () => {
+    it('returns empty array when text is empty or null', () => {
+        const members = [{ uid: 'u1', displayName: 'Alice' }];
+        expect(detectMentionedUids('', members)).toEqual([]);
+        expect(detectMentionedUids(null, members)).toEqual([]);
+        expect(detectMentionedUids(undefined, members)).toEqual([]);
+    });
+
+    it('returns empty array when no @mentions are in the text', () => {
+        const members = [{ uid: 'u1', displayName: 'Alice' }];
+        expect(detectMentionedUids('Great practice today!', members)).toEqual([]);
+    });
+
+    it('detects a single @mention by compact display name', () => {
+        const members = [{ uid: 'u1', displayName: 'Alice' }];
+        expect(detectMentionedUids('Hey @alice nice job!', members)).toEqual(['u1']);
+    });
+
+    it('matches by first name when display name has a last name', () => {
+        const members = [{ uid: 'u2', displayName: 'Bob Smith' }];
+        expect(detectMentionedUids('Good work @bob!', members)).toEqual(['u2']);
+    });
+
+    it('matches compacted full name with no spaces', () => {
+        const members = [{ uid: 'u3', displayName: 'Carol Jones' }];
+        expect(detectMentionedUids('See you @CarolJones', members)).toEqual(['u3']);
+    });
+
+    it('is case-insensitive when matching names', () => {
+        const members = [{ uid: 'u4', displayName: 'Dave' }];
+        expect(detectMentionedUids('Hi @DAVE', members)).toEqual(['u4']);
+        expect(detectMentionedUids('Hi @Dave', members)).toEqual(['u4']);
+        expect(detectMentionedUids('Hi @dave', members)).toEqual(['u4']);
+    });
+
+    it('@all returns all member UIDs', () => {
+        const members = [
+            { uid: 'u1', displayName: 'Alice' },
+            { uid: 'u2', displayName: 'Bob' },
+            { uid: 'u3', displayName: 'Carol' }
+        ];
+        const result = detectMentionedUids('Heads up @all!', members);
+        expect(result.sort()).toEqual(['u1', 'u2', 'u3']);
+    });
+
+    it('@team returns all member UIDs', () => {
+        const members = [
+            { uid: 'u1', displayName: 'Alice' },
+            { uid: 'u2', displayName: 'Bob' }
+        ];
+        const result = detectMentionedUids('Hey @team listen up', members);
+        expect(result.sort()).toEqual(['u1', 'u2']);
+    });
+
+    it('detects multiple distinct @mentions', () => {
+        const members = [
+            { uid: 'u1', displayName: 'Alice' },
+            { uid: 'u2', displayName: 'Bob' },
+            { uid: 'u3', displayName: 'Carol' }
+        ];
+        const result = detectMentionedUids('@alice and @bob great game!', members);
+        expect(result.sort()).toEqual(['u1', 'u2']);
+    });
+
+    it('does not duplicate a UID when the same person is mentioned twice', () => {
+        const members = [{ uid: 'u1', displayName: 'Alice' }];
+        const result = detectMentionedUids('@alice and @Alice again', members);
+        expect(result).toEqual(['u1']);
+    });
+
+    it('returns empty array when @mention token does not match any member', () => {
+        const members = [{ uid: 'u1', displayName: 'Alice' }];
+        expect(detectMentionedUids('Hello @unknown', members)).toEqual([]);
+    });
+
+    it('falls back to name field when displayName is missing', () => {
+        const members = [{ uid: 'u5', displayName: '', name: 'Eve' }];
+        expect(detectMentionedUids('Hey @eve!', members)).toEqual(['u5']);
+    });
+});
+
+describe('notifyTeamChatMessageCreated source wiring', () => {
+    it('exports the notifyTeamChatMessageCreated Firestore trigger', () => {
+        expect(functionsSource).toContain("exports.notifyTeamChatMessageCreated = functions.firestore");
+        expect(functionsSource).toContain(".document('teams/{teamId}/chatMessages/{messageId}')");
+    });
+
+    it('stores mentionedUids on the message document', () => {
+        expect(functionsSource).toContain('snapshot.ref.update({ mentionedUids })');
+    });
+
+    it('sends a mentions-category notification for mentioned users', () => {
+        expect(functionsSource).toContain("category: 'mentions'");
+        expect(functionsSource).toContain('mentioned you');
+    });
+
+    it('sends a liveChat notification with excludeUids to skip mentioned users', () => {
+        expect(functionsSource).toContain("category: 'liveChat'");
+        expect(functionsSource).toContain('excludeUids: mentionedUids');
+    });
+
+    it('sendCategoryNotification accepts excludeUids parameter', () => {
+        expect(functionsSource).toContain('excludeUids = []');
+        expect(functionsSource).toContain('excludeSet.has(t.uid)');
+    });
+});

--- a/tests/unit/functions-chat-mention-detection.test.js
+++ b/tests/unit/functions-chat-mention-detection.test.js
@@ -103,6 +103,12 @@ describe('notifyTeamChatMessageCreated source wiring', () => {
         expect(functionsSource).toContain('snapshot.ref.update({ mentionedUids })');
     });
 
+    it('reuses the existing candidate-user lookup for mention matching', () => {
+        expect(functionsSource).toContain('const candidateUsers = await getCandidateUsersForTeam(teamId);');
+        expect(functionsSource).toContain('const candidateUids = candidateUsers.map((user) => user.uid);');
+        expect(functionsSource).not.toContain('getCandidateUserIdsForTeam');
+    });
+
     it('sends a mentions-category notification for mentioned users', () => {
         expect(functionsSource).toContain("category: 'mentions'");
         expect(functionsSource).toContain('mentioned you');


### PR DESCRIPTION
## Summary
- Add `detectMentionedUids(text, members)` helper: extracts `@token` patterns from message text, matches against team member display names (full compact name or first name, case-insensitive), handles `@all`/`@team` broadcast tokens
- Add `sendDirectTargetsNotification` helper to send FCM to a pre-filtered target list, used to send `mentions` push only to the intersection of mentioned UIDs and users with the `mentions` preference enabled
- Extend `sendCategoryNotification` with a backward-compatible `excludeUids` parameter to avoid double-notifying mentioned users
- Rewrite `notifyTeamChatMessageCreated` to: detect mentions → write `mentionedUids` to the message doc → send `mentions` push to exactly the mentioned+subscribed users → send `liveChat` push to everyone else (sender always excluded)

## Test plan
- [ ] Unit: 17 tests in `tests/unit/functions-chat-mention-detection.test.js` cover `detectMentionedUids` edge cases (empty input, first-name match, compact-name match, `@all`, `@team`, dedup, no-match) and trigger wiring (stores `mentionedUids`, sends both push categories, uses `excludeUids`)
- [ ] Manual: send a message mentioning `@alice` in a team chat; confirm Alice receives a `mentions`-category push and does NOT also receive the generic `liveChat` push for the same message; confirm other team members still receive the `liveChat` push

Closes #2132

https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5)_