### PR TITLE
[codex] Surface parent fee checkout metadata

### DIFF
--- a/apps/app/src/lib/parentToolsService.ts
+++ b/apps/app/src/lib/parentToolsService.ts
@@ -104,6 +104,9 @@ export type ParentFeeAppRecord = Record<string, any> & {
   feeNotes?: string;
   offlinePaymentInstructions?: string;
   paymentInstructions?: string;
+  collectionMode?: string;
+  checkoutUrl?: string;
+  checkoutStatus?: string;
   canPay: boolean;
   checkoutInitiatable: boolean;
   paymentAction: 'checkoutUrl' | 'createCheckout' | '';
@@ -927,13 +930,22 @@ function normalizeAccessRequest(request: any): ParentAccessRequest {
 
 function toParentFeeAppRecord(fee: any): ParentFeeAppRecord {
   const normalized = normalizeParentFeeRecord(fee);
-  const meta = getParentFeeStatusMeta(normalized.status);
-  const canOpenCheckoutUrl = isParentTeamFeePayActionAllowed(normalized) && Boolean(normalized.checkoutUrl);
-  const checkoutInitiatable = canInitiateParentTeamFeeCheckout(normalized);
-  return {
+  const collectionMode = compactString(normalized.collectionMode);
+  const checkoutUrl = compactString(normalized.checkoutUrl);
+  const checkoutStatus = compactString(normalized.checkoutStatus);
+  const parentFee = {
     ...normalized,
-    amountLabel: formatParentFeeAmount(normalized),
-    dueLabel: formatParentFeeDueDate(normalized.dueDate),
+    collectionMode,
+    checkoutUrl,
+    checkoutStatus
+  };
+  const meta = getParentFeeStatusMeta(normalized.status);
+  const canOpenCheckoutUrl = isParentTeamFeePayActionAllowed(parentFee) && hasReusableParentTeamFeeCheckoutUrl(parentFee);
+  const checkoutInitiatable = canInitiateParentTeamFeeCheckout(parentFee);
+  return {
+    ...parentFee,
+    amountLabel: formatParentFeeAmount(parentFee),
+    dueLabel: formatParentFeeDueDate(parentFee.dueDate),
     statusLabel: meta.label,
     canPay: canOpenCheckoutUrl || checkoutInitiatable,
     checkoutInitiatable,
@@ -944,7 +956,25 @@ function toParentFeeAppRecord(fee: any): ParentFeeAppRecord {
   };
 }
 
+function isOnlineParentTeamFeeCollection(fee: any) {
+  const collectionMode = compactString(fee?.collectionMode).toLowerCase();
+  if (!collectionMode) {
+    return Boolean(compactString(fee?.checkoutUrl));
+  }
+
+  return ['online_stripe', 'stripe', 'stripe_checkout', 'online'].includes(collectionMode);
+}
+
+function hasReusableParentTeamFeeCheckoutUrl(fee: any) {
+  if (!compactString(fee?.checkoutUrl)) return false;
+
+  const checkoutStatus = compactString(fee?.checkoutStatus).toLowerCase();
+  return !checkoutStatus || checkoutStatus === 'open';
+}
+
 export function isParentTeamFeePayActionAllowed(fee: any) {
+  if (!isOnlineParentTeamFeeCollection(fee)) return false;
+
   const status = compactString(fee?.status).toLowerCase();
   if (status === 'paid' || status === 'canceled' || status === 'cancelled') return false;
 
@@ -957,7 +987,7 @@ export function isParentTeamFeePayActionAllowed(fee: any) {
 export function canInitiateParentTeamFeeCheckout(fee: any) {
   return Boolean(
     isParentTeamFeePayActionAllowed(fee)
-    && !fee?.checkoutUrl
+    && !hasReusableParentTeamFeeCheckoutUrl(fee)
     && compactString(fee?.teamId)
     && compactString(fee?.batchId)
     && compactString(fee?.recipientId)

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter, Route, Routes, useNavigate } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ParentTools } from './ParentTools';
 import type { AuthState } from '../lib/types';
+import { openPublicUrl } from '../lib/publicActions';
 
 const parentToolsServiceMocks = vi.hoisted(() => ({
     buildParentScheduleIcs: vi.fn(),
@@ -329,6 +330,48 @@ describe('ParentTools access', () => {
         fireEvent.click(screen.getByRole('button', { name: 'Register' }));
         expect(await screen.findByText('Summer Camp')).toBeTruthy();
         expect(parentToolsServiceMocks.loadParentRegistrations).toHaveBeenCalledTimes(2);
+    });
+
+    it('regenerates stale team fee checkout links instead of opening the stored URL', async () => {
+        parentToolsServiceMocks.loadParentFeesForApp.mockResolvedValue([
+            {
+                id: 'fee-1',
+                title: 'Team dues',
+                teamId: 'team-1',
+                batchId: 'batch-1',
+                recipientId: 'recipient-1',
+                teamName: 'Bears',
+                playerName: 'Sam Player',
+                status: 'open',
+                amountLabel: '$100',
+                dueLabel: 'Today',
+                statusLabel: 'Open',
+                balanceDueCents: 10000,
+                checkoutUrl: 'https://pay.example.test/stale',
+                checkoutStatus: 'stale',
+                canPay: true,
+                checkoutInitiatable: true,
+                paymentAction: 'createCheckout',
+                lineItems: [],
+                installments: [],
+                ledgerEntries: []
+            }
+        ]);
+        parentToolsServiceMocks.initiateParentTeamFeeCheckout.mockResolvedValue({
+            success: true,
+            checkoutUrl: 'https://pay.example.test/fresh'
+        });
+
+        renderParentTools(['/parent-tools/fees']);
+
+        await screen.findByText('Team dues');
+        fireEvent.click(screen.getByRole('button', { name: 'Pay fee' }));
+
+        await waitFor(() => {
+            expect(parentToolsServiceMocks.initiateParentTeamFeeCheckout).toHaveBeenCalledWith('team-1', 'batch-1', 'recipient-1');
+        });
+        expect(openPublicUrl).toHaveBeenCalledWith('https://pay.example.test/fresh');
+        expect(openPublicUrl).not.toHaveBeenCalledWith('https://pay.example.test/stale');
     });
 
     it('redirects invalid tabs without triggering a hook order violation', async () => {

--- a/apps/app/src/pages/ParentTools.test.tsx
+++ b/apps/app/src/pages/ParentTools.test.tsx
@@ -332,6 +332,40 @@ describe('ParentTools access', () => {
         expect(parentToolsServiceMocks.loadParentRegistrations).toHaveBeenCalledTimes(2);
     });
 
+    it('opens reusable team fee checkout links when legacy fee payloads omit paymentAction', async () => {
+        parentToolsServiceMocks.loadParentFeesForApp.mockResolvedValue([
+            {
+                id: 'fee-1',
+                title: 'Team dues',
+                teamId: 'team-1',
+                teamName: 'Bears',
+                playerName: 'Sam Player',
+                status: 'open',
+                amountLabel: '$100',
+                dueLabel: 'Today',
+                statusLabel: 'Open',
+                balanceDueCents: 10000,
+                checkoutUrl: 'https://pay.example.test/legacy',
+                canPay: true,
+                checkoutInitiatable: false,
+                paymentAction: '',
+                lineItems: [],
+                installments: [],
+                ledgerEntries: []
+            }
+        ]);
+
+        renderParentTools(['/parent-tools/fees']);
+
+        await screen.findByText('Team dues');
+        fireEvent.click(screen.getByRole('button', { name: 'Pay fee' }));
+
+        await waitFor(() => {
+            expect(openPublicUrl).toHaveBeenCalledWith('https://pay.example.test/legacy');
+        });
+        expect(parentToolsServiceMocks.initiateParentTeamFeeCheckout).not.toHaveBeenCalled();
+    });
+
     it('regenerates stale team fee checkout links instead of opening the stored URL', async () => {
         parentToolsServiceMocks.loadParentFeesForApp.mockResolvedValue([
             {

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -506,9 +506,12 @@ function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: n
     setPayingFeeId(feeKey);
     setFeeErrors((current) => ({ ...current, [feeKey]: '' }));
     try {
-      if (fee.checkoutUrl) {
+      if (fee.paymentAction === 'checkoutUrl' && fee.checkoutUrl) {
         await openPublicUrl(String(fee.checkoutUrl));
         return;
+      }
+      if (fee.paymentAction !== 'createCheckout') {
+        throw new Error('Checkout is not available for this fee.');
       }
       const checkout = await initiateParentTeamFeeCheckout(String(fee.teamId || ''), String(fee.batchId || ''), String(fee.recipientId || ''));
       await openPublicUrl(checkout.checkoutUrl);

--- a/apps/app/src/pages/ParentTools.tsx
+++ b/apps/app/src/pages/ParentTools.tsx
@@ -503,18 +503,24 @@ function FeesTool({ auth, refreshVersion }: { auth: AuthState; refreshVersion: n
   const balanceCents = visibleFees.reduce((sum, fee) => sum + Number(fee.balanceDueCents ?? fee.amountDueCents ?? 0), 0);
   const payFee = async (fee: ParentFeeAppRecord) => {
     const feeKey = getFeeCardKey(fee);
+    const checkoutStatus = String(fee.checkoutStatus || '').toLowerCase();
+    const reusableCheckoutUrl = Boolean(fee.checkoutUrl) && (!checkoutStatus || checkoutStatus === 'open');
     setPayingFeeId(feeKey);
     setFeeErrors((current) => ({ ...current, [feeKey]: '' }));
     try {
-      if (fee.paymentAction === 'checkoutUrl' && fee.checkoutUrl) {
+      if (fee.paymentAction === 'checkoutUrl' || (!fee.paymentAction && reusableCheckoutUrl)) {
         await openPublicUrl(String(fee.checkoutUrl));
         return;
       }
-      if (fee.paymentAction !== 'createCheckout') {
+      if (fee.paymentAction === 'createCheckout' || (!fee.paymentAction && fee.checkoutInitiatable)) {
+        const checkout = await initiateParentTeamFeeCheckout(String(fee.teamId || ''), String(fee.batchId || ''), String(fee.recipientId || ''));
+        await openPublicUrl(checkout.checkoutUrl);
+        return;
+      }
+      if (!reusableCheckoutUrl) {
         throw new Error('Checkout is not available for this fee.');
       }
-      const checkout = await initiateParentTeamFeeCheckout(String(fee.teamId || ''), String(fee.batchId || ''), String(fee.recipientId || ''));
-      await openPublicUrl(checkout.checkoutUrl);
+      await openPublicUrl(String(fee.checkoutUrl));
     } catch (payError: any) {
       setFeeErrors((current) => ({ ...current, [feeKey]: payError?.message || 'Unable to open checkout. Please try again.' }));
     } finally {

--- a/tests/unit/app-parent-tools-service.test.js
+++ b/tests/unit/app-parent-tools-service.test.js
@@ -508,14 +508,32 @@ describe('React app parent tools service', () => {
                 id: 'fee-2',
                 title: 'Uniform',
                 status: 'paid',
+                collectionMode: 'online_stripe',
+                checkoutStatus: 'paid',
                 amountDueCents: 5000,
                 balanceDueCents: 0,
                 checkoutUrl: 'https://pay.example.test/paid'
             },
             {
+                id: 'fee-3',
+                title: 'Offline fee',
+                status: 'unpaid',
+                collectionMode: 'offline_manual',
+                checkoutStatus: 'open',
+                amountDueCents: 9000,
+                balanceDueCents: 9000,
+                checkoutUrl: 'https://pay.example.test/offline',
+                teamId: 'team-1',
+                batchId: 'batch-1',
+                recipientId: 'recipient-3',
+                offlinePaymentInstructions: 'Pay by cash or check.'
+            },
+            {
                 id: 'fee-1',
                 title: 'Dues',
                 status: 'unpaid',
+                collectionMode: 'online_stripe',
+                checkoutStatus: 'open',
                 amountDueCents: 12000,
                 balanceDueCents: 12000,
                 checkoutUrl: 'https://pay.example.test/open',
@@ -530,11 +548,14 @@ describe('React app parent tools service', () => {
         const fees = await loadParentFeesForApp(user);
 
         expect(dbMocks.listParentTeamFeeRecipients).toHaveBeenCalledWith('user-1', user.parentOf);
-        expect(fees.map((fee) => fee.title)).toEqual(['Dues', 'Uniform']);
+        expect(fees.map((fee) => fee.title)).toEqual(['Dues', 'Offline fee', 'Uniform']);
         expect(fees[0]).toMatchObject({
             amountLabel: '$120',
             dueLabel: 'No due date',
             statusLabel: 'Open',
+            collectionMode: 'online_stripe',
+            checkoutStatus: 'open',
+            checkoutUrl: 'https://pay.example.test/open',
             notes: 'Bring jersey deposit form.',
             offlinePaymentInstructions: 'Cash or check accepted at practice.',
             canPay: true,
@@ -544,23 +565,34 @@ describe('React app parent tools service', () => {
             installments: [{ label: 'Deposit', amountCents: 5000 }],
             ledgerEntries: [{ label: 'Adjustment', amountCents: -1000 }]
         });
-        expect(fees[1].canPay).toBe(false);
+        expect(fees[1]).toMatchObject({
+            collectionMode: 'offline_manual',
+            checkoutStatus: 'open',
+            checkoutUrl: 'https://pay.example.test/offline',
+            offlinePaymentInstructions: 'Pay by cash or check.',
+            canPay: false,
+            checkoutInitiatable: false,
+            paymentAction: ''
+        });
+        expect(fees[2].canPay).toBe(false);
     });
 
     it('marks unpaid team fees without checkout URLs as initiatable only when identifiers exist', async () => {
         dbMocks.listParentTeamFeeRecipients.mockResolvedValue([
-            { id: 'missing-team', title: 'Missing team', status: 'unpaid', balanceDueCents: 1500, batchId: 'batch-1', recipientId: 'recipient-1' },
-            { id: 'paid', title: 'Paid', status: 'paid', balanceDueCents: 1500, teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' },
-            { id: 'partial', title: 'Partial', status: 'partial', balanceDueCents: 2500, teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' },
-            { id: 'adjusted', title: 'Adjusted', status: 'adjusted', balanceDueCents: 3000, checkoutUrl: 'https://pay.example.test/adjusted', teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' },
-            { id: 'adjusted-zero', title: 'Adjusted zero', status: 'adjusted', balanceDueCents: 0, checkoutUrl: 'https://pay.example.test/adjusted-zero', teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' },
-            { id: 'zero', title: 'Zero', status: 'unpaid', balanceDueCents: 0, teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' }
+            { id: 'missing-team', title: 'Missing team', status: 'unpaid', collectionMode: 'online_stripe', balanceDueCents: 1500, batchId: 'batch-1', recipientId: 'recipient-1' },
+            { id: 'paid', title: 'Paid', status: 'paid', collectionMode: 'online_stripe', balanceDueCents: 1500, teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' },
+            { id: 'partial', title: 'Partial', status: 'partial', collectionMode: 'online_stripe', balanceDueCents: 2500, teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' },
+            { id: 'adjusted', title: 'Adjusted', status: 'adjusted', collectionMode: 'online_stripe', checkoutStatus: 'open', balanceDueCents: 3000, checkoutUrl: 'https://pay.example.test/adjusted', teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' },
+            { id: 'stale', title: 'Stale', status: 'unpaid', collectionMode: 'online_stripe', checkoutStatus: 'stale', balanceDueCents: 3000, checkoutUrl: 'https://pay.example.test/stale', teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' },
+            { id: 'adjusted-zero', title: 'Adjusted zero', status: 'adjusted', collectionMode: 'online_stripe', balanceDueCents: 0, checkoutUrl: 'https://pay.example.test/adjusted-zero', teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' },
+            { id: 'zero', title: 'Zero', status: 'unpaid', collectionMode: 'online_stripe', balanceDueCents: 0, teamId: 'team-1', batchId: 'batch-1', recipientId: 'recipient-1' }
         ]);
 
         const fees = await loadParentFeesForApp(user);
         const partialFee = fees.find((fee) => fee.id === 'partial');
 
         const adjustedFee = fees.find((fee) => fee.id === 'adjusted');
+        const staleFee = fees.find((fee) => fee.id === 'stale');
 
         expect(partialFee).toMatchObject({
             canPay: true,
@@ -572,15 +604,21 @@ describe('React app parent tools service', () => {
             checkoutInitiatable: false,
             paymentAction: 'checkoutUrl'
         });
+        expect(staleFee).toMatchObject({
+            canPay: true,
+            checkoutInitiatable: true,
+            paymentAction: 'createCheckout'
+        });
         expect(fees.find((fee) => fee.id === 'missing-team').canPay).toBe(false);
         expect(fees.find((fee) => fee.id === 'paid').canPay).toBe(false);
         expect(fees.find((fee) => fee.id === 'adjusted-zero').canPay).toBe(false);
         expect(fees.find((fee) => fee.id === 'zero').canPay).toBe(false);
         expect(canInitiateParentTeamFeeCheckout(partialFee)).toBe(true);
-        expect(isParentTeamFeePayActionAllowed({ status: 'partially_paid', balanceDueCents: 1 })).toBe(true);
-        expect(isParentTeamFeePayActionAllowed({ status: 'adjusted', balanceDueCents: 1 })).toBe(true);
-        expect(isParentTeamFeePayActionAllowed({ status: 'open', balanceDueCents: 1 })).toBe(true);
-        expect(isParentTeamFeePayActionAllowed({ status: 'adjusted', balanceDueCents: 0 })).toBe(false);
+        expect(isParentTeamFeePayActionAllowed({ status: 'partially_paid', collectionMode: 'online_stripe', balanceDueCents: 1 })).toBe(true);
+        expect(isParentTeamFeePayActionAllowed({ status: 'adjusted', collectionMode: 'online_stripe', balanceDueCents: 1 })).toBe(true);
+        expect(isParentTeamFeePayActionAllowed({ status: 'open', collectionMode: 'online_stripe', balanceDueCents: 1 })).toBe(true);
+        expect(isParentTeamFeePayActionAllowed({ status: 'unpaid', collectionMode: 'offline_manual', balanceDueCents: 1 })).toBe(false);
+        expect(isParentTeamFeePayActionAllowed({ status: 'adjusted', collectionMode: 'online_stripe', balanceDueCents: 0 })).toBe(false);
     });
 
     it('loads calendar tools with lightweight parent schedule options and builds escaped ICS content', async () => {


### PR DESCRIPTION
Closes #2021.\n\n## Summary\n- add parent fee collection mode, checkout URL, and checkout status fields to the app fee record contract\n- gate parent fee payment actions to online Stripe collection and active/reusable checkout links\n- regenerate stale online checkout links instead of opening stale URLs\n- preserve offline fee metadata without showing a Stripe pay action\n\n## Tests\n- npx vitest run tests/unit/app-parent-tools-service.test.js apps/app/src/pages/ParentTools.test.tsx --reporter=dot\n- npm run app:build