### PR TITLE
[codex] Validate app fee batch recipients

### DIFF
--- a/apps/app/src/lib/teamFeesService.ts
+++ b/apps/app/src/lib/teamFeesService.ts
@@ -94,7 +94,7 @@ export function toFeeCents(value: string | number | null | undefined) {
   const normalized = String(value ?? '').replace(/[$,]/g, '').trim();
   if (!normalized) return null;
   const parsed = Number(normalized);
-  if (!Number.isFinite(parsed)) return null;
+  if (!Number.isFinite(parsed) || parsed < 0) return null;
   return Math.round(parsed * 100);
 }
 
@@ -314,14 +314,18 @@ export async function createTeamFeeBatchForApp({ teamId, title, amount, dueDate,
     .filter((player) => player?.active !== false)
     .map(toRosterPlayer)
     .filter((player) => player.id);
+  const activePlayersById = new Map(activePlayers.map((player) => [player.id, player]));
+  const requestedRecipientIds = Array.from(new Set((recipientIds || []).map(normalizeString).filter(Boolean)));
+  const invalidRecipientIds = requestedRecipientIds.filter((recipientId) => !activePlayersById.has(recipientId));
+  if (!applyToWholeRoster && invalidRecipientIds.length) {
+    throw new Error(`One or more selected recipients are no longer on the active roster: ${invalidRecipientIds.join(', ')}.`);
+  }
+
   const selectedPlayers = applyToWholeRoster
     ? activePlayers
-    : activePlayers.filter((player) => new Set((recipientIds || []).map(normalizeString).filter(Boolean)).has(player.id));
+    : requestedRecipientIds.map((recipientId) => activePlayersById.get(recipientId)).filter(Boolean) as TeamFeeRosterPlayer[];
 
   if (!selectedPlayers.length) throw new Error('Select at least one roster recipient.');
-  if (!applyToWholeRoster && selectedPlayers.length !== new Set((recipientIds || []).map(normalizeString).filter(Boolean)).size) {
-    throw new Error('One or more selected recipients are no longer on the active roster.');
-  }
 
   const draft = {
     title: cleanTitle,

--- a/tests/unit/app-team-fees-service.test.ts
+++ b/tests/unit/app-team-fees-service.test.ts
@@ -84,6 +84,7 @@ describe('React app team fee offline payment service', () => {
     });
 
     it('rejects invalid amount and missing payment date', () => {
+        expect(() => buildManualPaymentUpdate({ amount: '-0.01', date: '2026-05-28' })).toThrow('greater than $0');
         expect(() => buildManualPaymentUpdate({ amount: '0', date: '2026-05-28' })).toThrow('greater than $0');
         expect(() => buildManualPaymentUpdate({ amount: '-1.00', date: '2026-05-28' })).toThrow('greater than $0');
         expect(() => buildManualPaymentUpdate({ amount: '5.00', date: '' })).toThrow('payment date');
@@ -337,6 +338,26 @@ describe('React app team fee offline payment service', () => {
                 status: 'unpaid'
             })
         ], expect.objectContaining({ uid: 'coach-1' }));
+    });
+
+    it('rejects fee batch recipients that are not active roster players', async () => {
+        dbMocks.getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears', ownerId: 'coach-1' });
+        dbMocks.getPlayers.mockResolvedValue([
+            { id: 'player-1', name: 'Pat Star', active: true },
+            { id: 'player-2', name: 'Inactive Player', active: false }
+        ]);
+
+        await expect(createTeamFeeBatchForApp({
+            teamId: 'team-1',
+            title: 'Tournament dues',
+            amount: '25.00',
+            dueDate: '2026-06-15',
+            applyToWholeRoster: false,
+            recipientIds: ['player-1', 'missing-player', 'player-2'],
+            user: { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: [] }
+        })).rejects.toThrow('missing-player, player-2');
+
+        expect(dbMocks.createTeamFeeBatch).not.toHaveBeenCalled();
     });
 
     it('creates a whole-roster fee batch from active players only and uses private-profile parent contacts', async () => {


### PR DESCRIPTION
Closes #2020.\n\n## Summary\n- validate every submitted fee recipient ID against the freshly loaded active roster\n- report the invalid recipient IDs instead of relying on set cardinality\n- reject negative team fee creation amounts at parsing time\n\n## Tests\n- npx vitest run tests/unit/app-team-fees-service.test.ts --reporter=dot\n- npm run app:build