### PR TITLE
[codex] Persist fee recipient parent contacts

### DIFF
--- a/apps/app/src/lib/teamFeesService.ts
+++ b/apps/app/src/lib/teamFeesService.ts
@@ -499,7 +499,9 @@ function toRosterPlayer(player: any): TeamFeeRosterPlayer {
 }
 
 function normalizeRosterPlayerParentContact(player: any) {
-  const parentRecords = Array.isArray(player?.parents) ? player.parents : [];
+  const privateParents = Array.isArray(player?.privateProfileParents) ? player.privateProfileParents : [];
+  const publicParents = Array.isArray(player?.parents) ? player.parents : [];
+  const parentRecords = privateParents.length > 0 ? privateParents : publicParents;
   const primaryParent = parentRecords.find((parent: any) => normalizeString(parent?.email || parent?.parentEmail || parent?.guardianEmail))
     || parentRecords[0]
     || {};

--- a/apps/app/src/lib/teamFeesService.ts
+++ b/apps/app/src/lib/teamFeesService.ts
@@ -42,6 +42,8 @@ export type TeamFeeRosterPlayer = {
   id: string;
   name: string;
   number: string;
+  parentName: string;
+  parentEmail: string;
 };
 
 export type CreateTeamFeeBatchInput = {
@@ -338,6 +340,8 @@ export async function createTeamFeeBatchForApp({ teamId, title, amount, dueDate,
     playerKey: `${teamId}::${player.id}`,
     playerName: player.name,
     playerNumber: player.number,
+    parentName: player.parentName,
+    parentEmail: player.parentEmail,
     feeTitle: cleanTitle,
     amountCents,
     dueDate: draft.dueDate,
@@ -484,9 +488,42 @@ function toRecipientSummary(recipient: any): TeamFeeRecipientSummary {
 }
 
 function toRosterPlayer(player: any): TeamFeeRosterPlayer {
+  const parentContact = normalizeRosterPlayerParentContact(player);
   return {
     id: String(player?.id || ''),
     name: normalizeString(player?.name || player?.displayName) || 'Roster member',
-    number: normalizeString(player?.number)
+    number: normalizeString(player?.number),
+    parentName: parentContact.parentName,
+    parentEmail: parentContact.parentEmail
   };
+}
+
+function normalizeRosterPlayerParentContact(player: any) {
+  const parentRecords = Array.isArray(player?.parents) ? player.parents : [];
+  const primaryParent = parentRecords.find((parent: any) => normalizeString(parent?.email || parent?.parentEmail || parent?.guardianEmail))
+    || parentRecords[0]
+    || {};
+  const parentName = normalizeString(
+    player?.parentName
+    || player?.guardianName
+    || player?.parent?.name
+    || player?.guardian?.name
+    || primaryParent.name
+    || primaryParent.displayName
+    || primaryParent.fullName
+    || primaryParent.email
+    || primaryParent.parentEmail
+    || primaryParent.guardianEmail
+  );
+  const parentEmail = normalizeString(
+    player?.parentEmail
+    || player?.guardianEmail
+    || player?.parent?.email
+    || player?.guardian?.email
+    || primaryParent.email
+    || primaryParent.parentEmail
+    || primaryParent.guardianEmail
+  ).toLowerCase();
+
+  return { parentName, parentEmail };
 }

--- a/tests/unit/app-team-fees-service.test.ts
+++ b/tests/unit/app-team-fees-service.test.ts
@@ -255,7 +255,7 @@ describe('React app team fee offline payment service', () => {
 
         expect(model.canManageFees).toBe(true);
         expect(model.selectedBatch?.id).toBe('batch-1');
-        expect(model.rosterPlayers).toEqual([{ id: 'player-1', name: 'Pat Star', number: '12' }]);
+        expect(model.rosterPlayers).toEqual([{ id: 'player-1', name: 'Pat Star', number: '12', parentName: '', parentEmail: '' }]);
         expect(model.recipients[0]).toMatchObject({
             id: 'recipient-1',
             playerName: 'Pat Star',
@@ -295,7 +295,7 @@ describe('React app team fee offline payment service', () => {
         dbMocks.getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears', ownerId: 'coach-1' });
         dbMocks.getPlayers.mockResolvedValue([
             { id: 'player-1', name: 'Pat Star', number: '12', active: true },
-            { id: 'player-2', name: 'Chris Doe', number: '7', active: true },
+            { id: 'player-2', name: 'Chris Doe', number: '7', active: true, parents: [{ name: 'Dana Doe', email: 'Dana@Example.com' }] },
             { id: 'player-3', name: 'Inactive Player', active: false }
         ]);
         dbMocks.createTeamFeeBatch.mockResolvedValue({ id: 'batch-9' });
@@ -330,6 +330,8 @@ describe('React app team fee offline payment service', () => {
                 playerId: 'player-2',
                 playerKey: 'team-1::player-2',
                 playerName: 'Chris Doe',
+                parentName: 'Dana Doe',
+                parentEmail: 'dana@example.com',
                 amountCents: 2500,
                 dueDate: '2026-06-15',
                 status: 'unpaid'
@@ -356,8 +358,8 @@ describe('React app team fee offline payment service', () => {
         });
 
         expect(dbMocks.createTeamFeeBatch).toHaveBeenCalledWith('team-1', expect.any(Object), [
-            expect.objectContaining({ playerId: 'player-1' }),
-            expect.objectContaining({ playerId: 'player-2' })
+            expect.objectContaining({ playerId: 'player-1', parentName: '', parentEmail: '' }),
+            expect.objectContaining({ playerId: 'player-2', parentName: '', parentEmail: '' })
         ], expect.any(Object));
     });
 

--- a/tests/unit/app-team-fees-service.test.ts
+++ b/tests/unit/app-team-fees-service.test.ts
@@ -339,10 +339,19 @@ describe('React app team fee offline payment service', () => {
         ], expect.objectContaining({ uid: 'coach-1' }));
     });
 
-    it('creates a whole-roster fee batch from active players only', async () => {
+    it('creates a whole-roster fee batch from active players only and uses private-profile parent contacts', async () => {
         dbMocks.getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears', ownerId: 'coach-1' });
         dbMocks.getPlayers.mockResolvedValue([
-            { id: 'player-1', name: 'Pat Star', active: true },
+            {
+                id: 'player-1',
+                name: 'Pat Star',
+                active: true,
+                privateProfileParents: [{
+                    name: 'Pat Parent',
+                    email: 'Pat.Parent@Example.com',
+                    userId: 'parent-1'
+                }]
+            },
             { id: 'player-2', name: 'Chris Doe', active: true },
             { id: 'player-3', name: 'Inactive Player', active: false }
         ]);
@@ -358,7 +367,7 @@ describe('React app team fee offline payment service', () => {
         });
 
         expect(dbMocks.createTeamFeeBatch).toHaveBeenCalledWith('team-1', expect.any(Object), [
-            expect.objectContaining({ playerId: 'player-1', parentName: '', parentEmail: '' }),
+            expect.objectContaining({ playerId: 'player-1', parentName: 'Pat Parent', parentEmail: 'pat.parent@example.com' }),
             expect.objectContaining({ playerId: 'player-2', parentName: '', parentEmail: '' })
         ], expect.any(Object));
     });


### PR DESCRIPTION
Closes #2019.\n\n## Summary\n- carry parent name and email through the app roster fee mapper\n- populate parentName and parentEmail on app-created fee recipient docs\n- support direct parent fields, guardian aliases, and parent array records\n\n## Tests\n- npx vitest run tests/unit/app-team-fees-service.test.ts --reporter=dot\n- npm run app:build