### PR TITLE
Fix live tracker finalization writing 0 for all player playing time

### DIFF
--- a/js/live-tracker-finish.js
+++ b/js/live-tracker-finish.js
@@ -121,7 +121,7 @@ export function buildFinishCompletionPlan({
     const baseData = {
       playerName: player.name,
       playerNumber: player.num,
-      timeMs: safeStatsByPlayerId[player.id]?.timeMs || 0,
+      timeMs: safeStatsByPlayerId[player.id]?.time || 0,
       participated: actuallyParticipated,
       participationStatus: actuallyParticipated ? 'appeared' : 'did-not-appear',
       participationSource: 'live-tracker-finish',

--- a/tests/unit/live-tracker-finish.test.js
+++ b/tests/unit/live-tracker-finish.test.js
@@ -89,7 +89,7 @@ describe('live tracker finish completion plan', () => {
           participationStatus: 'appeared',
           participationSource: 'live-tracker-finish',
           stats: { pts: 2, ast: 1, fouls: 0 },
-          timeMs: 0
+          timeMs: 123000
         }
       },
       {
@@ -101,7 +101,7 @@ describe('live tracker finish completion plan', () => {
           participationStatus: 'appeared',
           participationSource: 'live-tracker-finish',
           stats: { pts: 3, ast: 0, fouls: 2 },
-          timeMs: 0
+          timeMs: 118000
         }
       }
     ]);
@@ -379,5 +379,28 @@ describe('live tracker finish completion plan', () => {
   it('wires the shared save-and-complete workflow through live tracker', () => {
     const source = readFileSync(new URL('../../js/live-tracker.js', import.meta.url), 'utf8');
     expect(source).toContain('runSaveAndCompleteWorkflow');
+  });
+
+  it('preserves accumulated playing time from .time field rather than writing 0 (regression: issue #2124)', () => {
+    // live-tracker accumulates elapsed time in state.stats[id].time (not .timeMs).
+    // Finalization must read .time so player playing-time is not zeroed out on game completion.
+    const plan = buildFinishCompletionPlan({
+      requestedHome: 10,
+      requestedAway: 8,
+      liveHome: 10,
+      liveAway: 8,
+      columns: ['PTS'],
+      roster: [{ id: 'player-1', name: 'Jordan Smith', num: '23' }],
+      statsByPlayerId: {
+        'player-1': { time: 90000, timeMs: 0, pts: 12, fouls: 2 }
+      },
+      statTrackerConfig: {},
+      teamId: 'team-1',
+      gameId: 'game-1'
+    });
+
+    const playerWrite = plan.aggregatedStatsWrites.find(w => w.playerId === 'player-1');
+    expect(playerWrite).toBeDefined();
+    expect(playerWrite.data.timeMs).toBe(90000);
   });
 });


### PR DESCRIPTION
## Summary
- One-line fix in `js/live-tracker-finish.js`: change `safeStatsByPlayerId[player.id]?.timeMs` to `safeStatsByPlayerId[player.id]?.time`
- `live-tracker.js` accumulates elapsed milliseconds in `state.stats[id].time` (incremental syncs already correctly write `timeMs: state.stats[playerId]?.time || 0`), but the finalization path was reading `.timeMs` — which is always `0` — instead of `.time`
- The non-live finish flow in `js/track-finish.js` already used `.time` correctly; this aligns the live path

## Test plan
- [ ] Unit: updated two existing assertions in `live-tracker-finish.test.js` that silently accepted `timeMs: 0` despite player having `time: 123000`/`118000` (these tests were unknowingly confirming the bug); added regression test asserting `{ time: 90000, timeMs: 0 }` input produces `timeMs: 90000` output — all 10 tests pass
- [ ] Manual: track a live game, put players on court for several minutes, tap Save & Complete; open the game report and verify player minutes show correct non-zero values

Closes #2124

https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5

---
_Generated by [Claude Code](https://claude.ai/code/session_01VzkF5qtJCGzoh9go8VzBF5)_