### PR TITLE
[codex] Keep active games in config assignments

### DIFF
--- a/apps/app/src/lib/teamDetailService.ts
+++ b/apps/app/src/lib/teamDetailService.ts
@@ -1321,6 +1321,7 @@ function dedupeStrings(values: string[]) {
 function isUpcomingAssignedGame(game: any) {
   if (!game || game?.type === 'practice') return false;
   if (isHistoricalGameStatus(game)) return false;
+  if (isActiveGameStatus(game)) return true;
   return isInUpcomingWindow(game?.date);
 }
 
@@ -1328,6 +1329,13 @@ function isHistoricalGameStatus(game: any) {
   const status = cleanString(game?.status).toLowerCase();
   const liveStatus = cleanString(game?.liveStatus).toLowerCase();
   return status === 'completed' || status === 'final' || status === 'cancelled' || liveStatus === 'completed';
+}
+
+function isActiveGameStatus(game: any) {
+  const status = cleanString(game?.status).toLowerCase();
+  const liveStatus = cleanString(game?.liveStatus).toLowerCase();
+  return ['active', 'in_progress', 'in-progress', 'live', 'started', 'running'].includes(status)
+    || ['active', 'in_progress', 'in-progress', 'live', 'started', 'running'].includes(liveStatus);
 }
 
 function normalizeEvents(games: any[], configById: Map<string, TeamDetailStatTrackerConfig> = new Map()) {

--- a/tests/unit/app-team-detail-service.test.js
+++ b/tests/unit/app-team-detail-service.test.js
@@ -667,6 +667,9 @@ describe('React app team detail model', () => {
     });
 
     it('builds read-only stat tracker config summaries for migrated and legacy shapes', () => {
+        const now = new Date('2026-06-12T18:00:00Z').getTime();
+        const dateNowSpy = vi.spyOn(Date, 'now').mockReturnValue(now);
+
         const model = buildTeamDetailModel({
             teamId: 'team-1',
             team: {
@@ -679,6 +682,7 @@ describe('React app team detail model', () => {
                 { id: 'game-1', opponent: 'Falcons', date: new Date('2100-06-01T18:00:00Z'), status: 'scheduled', statTrackerConfigId: 'cfg-basketball' },
                 { id: 'game-2', opponent: 'Tigers', date: new Date('2100-06-02T18:00:00Z'), status: 'scheduled', statTrackerConfigId: 'cfg-legacy' },
                 { id: 'game-3', opponent: 'Orphans', date: new Date('2100-06-03T18:00:00Z'), status: 'scheduled', statTrackerConfigId: 'cfg-missing' },
+                { id: 'live-game', opponent: 'Long Match', date: new Date(now - 4 * 60 * 60 * 1000), status: 'scheduled', liveStatus: 'live', statTrackerConfigId: 'cfg-legacy' },
                 { id: 'stale-game', opponent: 'Past Tigers', date: new Date('2020-06-02T18:00:00Z'), status: 'scheduled', statTrackerConfigId: 'cfg-legacy' }
             ],
             configs: [
@@ -705,6 +709,7 @@ describe('React app team detail model', () => {
             ],
             user: { uid: 'coach-1', email: 'coach@example.com', displayName: 'Coach', roles: ['coach'] }
         });
+        dateNowSpy.mockRestore();
 
         expect(model.statTrackerConfigs).toEqual([
             expect.objectContaining({
@@ -715,6 +720,7 @@ describe('React app team detail model', () => {
                 columnCount: 2,
                 columnNames: ['GOALS', 'SHOTS'],
                 assignedUpcomingGames: [
+                    expect.objectContaining({ gameId: 'live-game', title: 'vs. Long Match' }),
                     expect.objectContaining({ gameId: 'game-2', title: 'vs. Tigers' })
                 ]
             }),
@@ -731,7 +737,10 @@ describe('React app team detail model', () => {
             })
         ]);
         expect(model.statTrackerConfigs.find((config) => config.id === 'cfg-legacy').assignedUpcomingGames)
-            .toEqual([expect.objectContaining({ gameId: 'game-2', title: 'vs. Tigers' })]);
+            .toEqual([
+                expect.objectContaining({ gameId: 'live-game', title: 'vs. Long Match' }),
+                expect.objectContaining({ gameId: 'game-2', title: 'vs. Tigers' })
+            ]);
         expect(model.upcomingEvents.find((event) => event.id === 'game-1')).toMatchObject({
             statTrackerConfigId: 'cfg-basketball',
             statTrackerConfigLabel: 'Varsity Basketball',


### PR DESCRIPTION
Closes #2025.\n\n## Summary\n- treat active/live/in-progress games as assigned stat-config games regardless of the three-hour upcoming window\n- keep historical/final/cancelled games excluded\n- add a regression covering a four-hour-old live game assignment\n\n## Tests\n- npx vitest run tests/unit/app-team-detail-service.test.js --reporter=dot\n- npm run app:build