### PR TITLE
[codex] Lock team privilege fields in rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -80,6 +80,12 @@ service cloud.firestore {
              canReadManagedTeamDocument(data);
     }
 
+    function keepsTeamPrivilegeFieldsImmutable() {
+      return request.resource.data.get('ownerId', '') == resource.data.get('ownerId', '') &&
+             request.resource.data.get('isAdmin', false) == resource.data.get('isAdmin', false) &&
+             request.resource.data.get('isPlatformAdmin', false) == resource.data.get('isPlatformAdmin', false);
+    }
+
     function isSafeDocumentId(documentId) {
       return documentId is string &&
              documentId.size() > 0 &&
@@ -1513,7 +1519,7 @@ service cloud.firestore {
     match /teams/{teamId} {
       allow read: if canReadTeamDocument(resource.data);
       allow create: if isSignedIn() && request.resource.data.ownerId == request.auth.uid;
-      allow update: if isTeamOwnerOrAdmin(teamId);
+      allow update: if isTeamOwnerOrAdmin(teamId) && keepsTeamPrivilegeFieldsImmutable();
       allow delete: if isGlobalAdmin();
 
 	      // Players subcollection

--- a/tests/unit/team-update-rules.test.js
+++ b/tests/unit/team-update-rules.test.js
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const rules = readFileSync(resolve(process.cwd(), 'firestore.rules'), 'utf8');
+
+describe('team update Firestore rules', () => {
+    it('keeps ownership and privilege fields immutable on team updates', () => {
+        expect(rules).toContain('function keepsTeamPrivilegeFieldsImmutable()');
+        expect(rules).toContain("request.resource.data.get('ownerId', '') == resource.data.get('ownerId', '')");
+        expect(rules).toContain("request.resource.data.get('isAdmin', false) == resource.data.get('isAdmin', false)");
+        expect(rules).toContain("request.resource.data.get('isPlatformAdmin', false) == resource.data.get('isPlatformAdmin', false)");
+        expect(rules).toContain('allow update: if isTeamOwnerOrAdmin(teamId) && keepsTeamPrivilegeFieldsImmutable();');
+    });
+});


### PR DESCRIPTION
Closes #2057.\n\n## Summary\n- add a Firestore rules helper that keeps team owner and legacy privilege flags immutable\n- require that helper on top-level team updates\n- add a source-level regression test for the rule wiring\n\n## Tests\n- npx vitest run tests/unit/team-update-rules.test.js --reporter=dot\n- npm run ci:firebase-rules