### PR TITLE
[codex] Sanitize formatted chat HTML

### DIFF
--- a/apps/app/package-lock.json
+++ b/apps/app/package-lock.json
@@ -17,6 +17,7 @@
         "@capacitor/share": "^8.0.1",
         "@capawesome/capacitor-badge": "^8.0.2",
         "@capgo/capacitor-speech-recognition": "^8.1.3",
+        "dompurify": "^3.4.10",
         "firebase": "^12.13.0",
         "lucide-react": "^0.468.0",
         "react": "^19.2.0",
@@ -3340,6 +3341,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
@@ -4693,6 +4701,15 @@
       "dev": true,
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.10",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
+      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -19,6 +19,7 @@
     "@capacitor/filesystem": "^8.1.2",
     "@capacitor/share": "^8.0.1",
     "@capgo/capacitor-speech-recognition": "^8.1.3",
+    "dompurify": "^3.4.10",
     "firebase": "^12.13.0",
     "lucide-react": "^0.468.0",
     "react": "^19.2.0",

--- a/apps/app/src/lib/chatLogic.ts
+++ b/apps/app/src/lib/chatLogic.ts
@@ -375,11 +375,25 @@ function sanitizeFormattedChatHtml(html: string) {
 }
 
 function sanitizeFormattedChatHtmlFallback(html: string) {
+  let safeAnchorDepth = 0;
+
   return String(html || '').replace(/<\/?([a-z][a-z0-9-]*)(\s[^>]*)?>/gi, (tag, rawTagName, rawAttributes = '') => {
     const tagName = String(rawTagName || '').toLowerCase();
     if (!allowedChatHtmlTags.has(tagName)) return '';
-    if (tag.startsWith('</')) return `</${tagName}>`;
-    if (tagName === 'a') return sanitizeChatAnchorTag(rawAttributes);
+    if (tag.startsWith('</')) {
+      if (tagName === 'a') {
+        if (safeAnchorDepth < 1) return '';
+        safeAnchorDepth -= 1;
+      }
+      return `</${tagName}>`;
+    }
+    if (tagName === 'a') {
+      const sanitizedAnchorTag = sanitizeChatAnchorTag(rawAttributes);
+      if (sanitizedAnchorTag) {
+        safeAnchorDepth += 1;
+      }
+      return sanitizedAnchorTag;
+    }
     if (tagName === 'span') {
       return /\bclass=(["'])chat-mention\1/i.test(rawAttributes) ? '<span class="chat-mention">' : '<span>';
     }
@@ -388,11 +402,16 @@ function sanitizeFormattedChatHtmlFallback(html: string) {
 }
 
 function sanitizeChatAnchorTag(rawAttributes: string) {
-  const hrefMatch = String(rawAttributes || '').match(/\bhref=(["'])(.*?)\1/i);
+  const attributes = String(rawAttributes || '');
+  const hrefMatch = attributes.match(/^\s*href=(["'])([^"'\s>]+)\1(?:\s+target=(["'])_blank\3)?(?:\s+rel=(["'])noopener noreferrer\4)?\s*$/i);
   const href = hrefMatch ? hrefMatch[2] : '';
-  if (!isChatUrlSafe(href)) return '<a>';
+  if (!isChatUrlSafe(href)) return '';
   return `<a href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer">`;
 }
+
+export const __chatHtmlTestUtils = {
+  sanitizeFormattedChatHtmlFallback
+};
 
 export function formatChatMessageHtml(text: string) {
   let formatted = escapeHtml(text || '');

--- a/apps/app/src/lib/chatLogic.ts
+++ b/apps/app/src/lib/chatLogic.ts
@@ -1,3 +1,4 @@
+import DOMPurifyModule from 'dompurify';
 import {
   DEFAULT_TEAM_CONVERSATION_ID,
   buildDefaultTeamConversation,
@@ -69,6 +70,29 @@ export const chatReactionKeys = new Set(chatReactions.map((reaction) => reaction
 
 const aiMentionRegex = /@all\s*plays/ig;
 const urlRegex = /(\bhttps?:\/\/[^\s<]+[^\s<.,;:!?"'\])>]|\bwww\.[^\s<]+[^\s<.,;:!?"'\])>])/gi;
+const allowedChatHtmlTags = new Set(['strong', 'em', 'del', 'code', 'a', 'span']);
+const chatHtmlSanitizeConfig = {
+  ALLOWED_TAGS: ['strong', 'em', 'del', 'code', 'a', 'span'],
+  ALLOWED_ATTR: ['href', 'target', 'rel', 'class'],
+  ALLOW_DATA_ATTR: false
+};
+
+type DomPurifyInstance = {
+  sanitize: (html: string, config?: Record<string, unknown>) => string;
+};
+
+type DomPurifyFactory = (window: Window) => DomPurifyInstance;
+
+function getDomPurify(): DomPurifyInstance | null {
+  const candidate = DOMPurifyModule as unknown as DomPurifyInstance | DomPurifyFactory;
+  if (typeof (candidate as DomPurifyInstance).sanitize === 'function') {
+    return candidate as DomPurifyInstance;
+  }
+  if (typeof candidate === 'function' && typeof window !== 'undefined') {
+    return (candidate as DomPurifyFactory)(window);
+  }
+  return null;
+}
 
 export function toChatDate(value: any): Date | null {
   if (!value) return null;
@@ -341,6 +365,35 @@ function escapeHtml(value: string) {
     .replace(/'/g, '&#039;');
 }
 
+function sanitizeFormattedChatHtml(html: string) {
+  const purifier = getDomPurify();
+  if (purifier) {
+    return purifier.sanitize(html, chatHtmlSanitizeConfig);
+  }
+
+  return sanitizeFormattedChatHtmlFallback(html);
+}
+
+function sanitizeFormattedChatHtmlFallback(html: string) {
+  return String(html || '').replace(/<\/?([a-z][a-z0-9-]*)(\s[^>]*)?>/gi, (tag, rawTagName, rawAttributes = '') => {
+    const tagName = String(rawTagName || '').toLowerCase();
+    if (!allowedChatHtmlTags.has(tagName)) return '';
+    if (tag.startsWith('</')) return `</${tagName}>`;
+    if (tagName === 'a') return sanitizeChatAnchorTag(rawAttributes);
+    if (tagName === 'span') {
+      return /\bclass=(["'])chat-mention\1/i.test(rawAttributes) ? '<span class="chat-mention">' : '<span>';
+    }
+    return `<${tagName}>`;
+  });
+}
+
+function sanitizeChatAnchorTag(rawAttributes: string) {
+  const hrefMatch = String(rawAttributes || '').match(/\bhref=(["'])(.*?)\1/i);
+  const href = hrefMatch ? hrefMatch[2] : '';
+  if (!isChatUrlSafe(href)) return '<a>';
+  return `<a href="${escapeHtml(href)}" target="_blank" rel="noopener noreferrer">`;
+}
+
 export function formatChatMessageHtml(text: string) {
   let formatted = escapeHtml(text || '');
 
@@ -360,7 +413,7 @@ export function formatChatMessageHtml(text: string) {
   formatted = formatted.replace(/\b_([^_]+)_\b/g, '<em>$1</em>');
   formatted = formatted.replace(/~([^~]+)~/g, '<del>$1</del>');
 
-  return formatted;
+  return sanitizeFormattedChatHtml(formatted);
 }
 
 export function getSortedChatMessages(messages: any[] = []) {

--- a/tests/unit/app-chat-logic.test.js
+++ b/tests/unit/app-chat-logic.test.js
@@ -27,6 +27,26 @@ describe('React app chat logic', () => {
         expect(html).not.toContain('<script>');
     });
 
+    it('sanitizes formatted chat html as a backstop against hostile input', () => {
+        const html = formatChatMessageHtml([
+            '<img src=x onerror=alert(1)>',
+            '<a href="javascript:alert(1)">bad</a>',
+            'https://safe.example.test/path?x=&quot; onclick=&quot;alert(1)',
+            '`<svg onload=alert(1)>`',
+            '@ALL PLAYS'
+        ].join(' '));
+
+        expect(html).not.toContain('<img');
+        expect(html).not.toContain('<svg');
+        expect(html).not.toMatch(/<[^>]+\sonerror=/i);
+        expect(html).not.toMatch(/<[^>]+\sonclick=/i);
+        expect(html).not.toContain('href="javascript:');
+        expect(html).toContain('<code>&lt;svg onload=alert(1)&gt;</code>');
+        expect(html).toContain('<span class="chat-mention">@ALL PLAYS</span>');
+        expect(html).toContain('target="_blank"');
+        expect(html).toContain('rel="noopener noreferrer"');
+    });
+
     it('accepts only explicit http links from the composer link action', () => {
         expect(isChatComposerLinkSafe('https://allplays.ai/game.html')).toBe(true);
         expect(isChatComposerLinkSafe('http://localhost:5174/#/messages')).toBe(true);

--- a/tests/unit/app-chat-logic.test.js
+++ b/tests/unit/app-chat-logic.test.js
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+    __chatHtmlTestUtils,
     DEFAULT_TEAM_CONVERSATION_ID,
     buildChatAudienceMetadata,
     buildEmailAudienceMetadata,
@@ -45,6 +46,12 @@ describe('React app chat logic', () => {
         expect(html).toContain('<span class="chat-mention">@ALL PLAYS</span>');
         expect(html).toContain('target="_blank"');
         expect(html).toContain('rel="noopener noreferrer"');
+    });
+
+    it('strips malformed or unsafe anchors in the fallback chat sanitizer', () => {
+        expect(__chatHtmlTestUtils.sanitizeFormattedChatHtmlFallback('<a href="javascript:alert(1)">bad</a>')).toBe('bad');
+        expect(__chatHtmlTestUtils.sanitizeFormattedChatHtmlFallback('<a href="https://safe.example.test" onload="alert(1)">safe</a>')).toBe('safe');
+        expect(__chatHtmlTestUtils.sanitizeFormattedChatHtmlFallback('<a href="https://safe.example.test">safe</a>')).toBe('<a href="https://safe.example.test" target="_blank" rel="noopener noreferrer">safe</a>');
     });
 
     it('accepts only explicit http links from the composer link action', () => {


### PR DESCRIPTION
Closes #2059.\n\n## Summary\n- add DOMPurify as a browser sanitizer backstop for formatted chat and AI message HTML\n- keep a strict allowlist for generated markdown tags and link attributes\n- add a non-DOM fallback sanitizer for unit-test/runtime contexts without window\n- add hostile-input coverage for raw HTML, unsafe links, and attribute breakout attempts\n\n## Tests\n- npx vitest run tests/unit/app-chat-logic.test.js --reporter=dot\n- npm run app:build\n\n## Notes\n- npm install reported 2 existing high-severity audit findings.\n- app build still emits the existing mixed-import/chunk-size warnings; entry chunk size increases because DOMPurify is now included in the formatter path.