### PR TITLE
[codex] Add app error boundaries

### DIFF
--- a/apps/app/src/App.test.tsx
+++ b/apps/app/src/App.test.tsx
@@ -2,10 +2,11 @@
 import { render, screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { MemoryRouter } from 'react-router-dom';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import App from './App';
 
 const suspendedHomePromise = new Promise<never>(() => {});
+let homeRenderMode: 'suspend' | 'throw' = 'suspend';
 
 vi.mock('./lib/useAuth', () => ({
   useAuth: () => ({
@@ -47,6 +48,9 @@ vi.mock('./lib/pushService', () => ({
 
 vi.mock('./pages/Home', () => ({
   Home: () => {
+    if (homeRenderMode === 'throw') {
+      throw new Error('Home page render failed');
+    }
     throw suspendedHomePromise;
   },
 }));
@@ -60,6 +64,15 @@ vi.mock('./pages/Officials', () => ({
 }));
 
 describe('App protected route loading', () => {
+  beforeEach(() => {
+    homeRenderMode = 'suspend';
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it('keeps the app shell visible while a protected route is still loading', async () => {
     render(
       <MemoryRouter initialEntries={['/home']}>
@@ -94,5 +107,21 @@ describe('App protected route loading', () => {
 
     expect(await screen.findByText('Officials assignments page')).toBeTruthy();
     expect(screen.queryByText('Loading ALL PLAYS')).toBeNull();
+  });
+
+  it('keeps the app shell visible when a protected route throws while rendering', async () => {
+    homeRenderMode = 'throw';
+
+    render(
+      <MemoryRouter initialEntries={['/home']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('navigation', { name: 'Primary navigation' })).toBeTruthy();
+    expect(screen.getByRole('alert', { name: 'Screen error' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Go home' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Reload' })).toBeTruthy();
   });
 });

--- a/apps/app/src/App.tsx
+++ b/apps/app/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, ReactNode, Suspense, useEffect, useRef, useState } from 'react';
 import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import { AppShell } from './components/AppShell';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { ProtectedRouteSkeleton } from './components/PageSkeletons';
 import { clearPendingPushRoute, readPendingPushRoute } from './lib/pushNotificationRouting';
 import { shouldReloadTeamsToHome } from './lib/reloadRouting';
@@ -139,6 +140,7 @@ function isBrowserReload() {
 function Protected({ auth, children }: { auth: AuthState; children: ReactNode }) {
   const [bootstrapGraceExpired, setBootstrapGraceExpired] = useState(false);
   const location = useLocation();
+  const navigate = useNavigate();
 
   useEffect(() => {
     const timeoutId = window.setTimeout(() => {
@@ -162,9 +164,15 @@ function Protected({ auth, children }: { auth: AuthState; children: ReactNode })
 
   return (
     <AppShell auth={auth}>
-      <Suspense fallback={<ProtectedRouteLoadingState pathname={location.pathname} />}>
-        {children}
-      </Suspense>
+      <ErrorBoundary
+        name={`route:${location.pathname}`}
+        resetKey={`${location.pathname}${location.search}`}
+        onGoHome={() => navigate('/home', { replace: true })}
+      >
+        <Suspense fallback={<ProtectedRouteLoadingState pathname={location.pathname} />}>
+          {children}
+        </Suspense>
+      </ErrorBoundary>
     </AppShell>
   );
 }

--- a/apps/app/src/components/ErrorBoundary.test.tsx
+++ b/apps/app/src/components/ErrorBoundary.test.tsx
@@ -1,0 +1,68 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ErrorBoundary } from './ErrorBoundary';
+
+function BrokenScreen(): never {
+  throw new Error('render failed');
+}
+
+describe('ErrorBoundary', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete window.__ALLPLAYS_REPORT_REACT_ERROR__;
+  });
+
+  it('renders recovery actions and reports render failures', () => {
+    const onError = vi.fn();
+    const reportHook = vi.fn();
+    const goHome = vi.fn();
+    window.__ALLPLAYS_REPORT_REACT_ERROR__ = reportHook;
+
+    render(
+      <ErrorBoundary name="test-boundary" onError={onError} onGoHome={goHome}>
+        <BrokenScreen />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByRole('alert', { name: 'Screen error' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'This screen ran into a problem.' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Reload' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Go home' }));
+
+    expect(goHome).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({
+      boundaryName: 'test-boundary',
+      error: expect.any(Error),
+      location: expect.any(String)
+    }));
+    expect(reportHook).toHaveBeenCalledWith(expect.objectContaining({
+      boundaryName: 'test-boundary',
+      error: expect.any(Error)
+    }));
+  });
+
+  it('clears the fallback when the reset key changes', () => {
+    const { rerender } = render(
+      <ErrorBoundary name="test-boundary" resetKey="/broken">
+        <BrokenScreen />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByRole('alert', { name: 'Screen error' })).toBeTruthy();
+
+    rerender(
+      <ErrorBoundary name="test-boundary" resetKey="/healthy">
+        <div>Recovered screen</div>
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByText('Recovered screen')).toBeTruthy();
+  });
+});

--- a/apps/app/src/components/ErrorBoundary.test.tsx
+++ b/apps/app/src/components/ErrorBoundary.test.tsx
@@ -65,4 +65,26 @@ describe('ErrorBoundary', () => {
 
     expect(screen.getByText('Recovered screen')).toBeTruthy();
   });
+
+  it('does not clear a newly captured route error when the reset key changed in the same update', () => {
+    const onError = vi.fn();
+    const reportHook = vi.fn();
+    window.__ALLPLAYS_REPORT_REACT_ERROR__ = reportHook;
+
+    const { rerender } = render(
+      <ErrorBoundary name="test-boundary" resetKey="/healthy" onError={onError}>
+        <div>Healthy screen</div>
+      </ErrorBoundary>
+    );
+
+    rerender(
+      <ErrorBoundary name="test-boundary" resetKey="/broken" onError={onError}>
+        <BrokenScreen />
+      </ErrorBoundary>
+    );
+
+    expect(screen.getByRole('alert', { name: 'Screen error' })).toBeTruthy();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(reportHook).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/app/src/components/ErrorBoundary.tsx
+++ b/apps/app/src/components/ErrorBoundary.tsx
@@ -47,8 +47,8 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
     reportReactErrorBoundary(report);
   }
 
-  componentDidUpdate(previousProps: ErrorBoundaryProps) {
-    if (this.state.error && previousProps.resetKey !== this.props.resetKey) {
+  componentDidUpdate(previousProps: ErrorBoundaryProps, previousState: ErrorBoundaryState) {
+    if (this.state.error && previousState.error && previousProps.resetKey !== this.props.resetKey) {
       this.setState({ error: null });
     }
   }

--- a/apps/app/src/components/ErrorBoundary.tsx
+++ b/apps/app/src/components/ErrorBoundary.tsx
@@ -1,0 +1,149 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+type ErrorBoundaryVariant = 'screen' | 'panel';
+
+export interface ReactErrorBoundaryReport {
+  boundaryName: string;
+  error: Error;
+  errorInfo: ErrorInfo;
+  location: string;
+}
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  name: string;
+  variant?: ErrorBoundaryVariant;
+  resetKey?: string;
+  onError?: (report: ReactErrorBoundaryReport) => void;
+  onGoHome?: () => void;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+declare global {
+  interface Window {
+    __ALLPLAYS_REPORT_REACT_ERROR__?: (report: ReactErrorBoundaryReport) => void;
+  }
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    const report = {
+      boundaryName: this.props.name,
+      error,
+      errorInfo,
+      location: getCurrentLocation()
+    };
+
+    this.props.onError?.(report);
+    reportReactErrorBoundary(report);
+  }
+
+  componentDidUpdate(previousProps: ErrorBoundaryProps) {
+    if (this.state.error && previousProps.resetKey !== this.props.resetKey) {
+      this.setState({ error: null });
+    }
+  }
+
+  private reset = () => {
+    this.setState({ error: null });
+  };
+
+  private reload = () => {
+    window.location.reload();
+  };
+
+  private goHome = () => {
+    if (this.props.onGoHome) {
+      this.props.onGoHome();
+      return;
+    }
+
+    if (typeof window !== 'undefined') {
+      window.location.hash = '#/home';
+    }
+
+    this.reset();
+  };
+
+  render() {
+    if (!this.state.error) {
+      return this.props.children;
+    }
+
+    const variant = this.props.variant || 'panel';
+    const content = (
+      <section
+        className={`${variant === 'screen' ? 'app-card w-full max-w-md p-5 text-center' : 'app-card p-5'} space-y-4`}
+        role="alert"
+        aria-label="Screen error"
+      >
+        <div>
+          <div className="app-label">Unexpected error</div>
+          <h1 className={`${variant === 'screen' ? 'text-xl' : 'text-lg'} font-black text-gray-950`}>
+            This screen ran into a problem.
+          </h1>
+          <p className="mt-2 text-sm font-semibold leading-6 text-gray-600">
+            You can retry this screen, go home, or reload ALL PLAYS.
+          </p>
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row">
+          <button type="button" className="primary-button flex-1" onClick={this.reset}>
+            Retry
+          </button>
+          <button type="button" className="secondary-button flex-1" onClick={this.goHome}>
+            Go home
+          </button>
+          <button type="button" className="ghost-button flex-1" onClick={this.reload}>
+            Reload
+          </button>
+        </div>
+      </section>
+    );
+
+    if (variant === 'screen') {
+      return (
+        <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4 py-8">
+          {content}
+        </div>
+      );
+    }
+
+    return content;
+  }
+}
+
+export function reportReactErrorBoundary(report: ReactErrorBoundaryReport) {
+  const reporter = typeof window !== 'undefined' ? window.__ALLPLAYS_REPORT_REACT_ERROR__ : undefined;
+
+  if (reporter) {
+    try {
+      reporter(report);
+    } catch (reportError) {
+      console.error('[error-boundary] report hook failed:', reportError);
+    }
+  }
+
+  console.error('[error-boundary] React render error:', {
+    boundaryName: report.boundaryName,
+    location: report.location,
+    error: report.error,
+    componentStack: report.errorInfo.componentStack
+  });
+}
+
+function getCurrentLocation() {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+
+  return `${window.location.pathname}${window.location.search}${window.location.hash}`;
+}

--- a/apps/app/src/main.tsx
+++ b/apps/app/src/main.tsx
@@ -2,12 +2,15 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import { HashRouter } from 'react-router-dom';
 import App from './App';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import './styles/index.css';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <HashRouter>
-      <App />
-    </HashRouter>
+    <ErrorBoundary name="app-root" variant="screen">
+      <HashRouter>
+        <App />
+      </HashRouter>
+    </ErrorBoundary>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- Add a reusable React error boundary with retry, home, reload, and a report hook for future observability wiring.
- Wrap the app root as a last-resort boundary around the HashRouter.
- Wrap protected route content inside the AppShell so page render crashes keep navigation visible and reset when the route changes.
- Add regression coverage for boundary reporting/recovery and shell-preserving route failures.

Closes #2062

## Validation
- `npm --prefix apps/app test -- --run src/components/ErrorBoundary.test.tsx src/App.test.tsx --reporter=dot`
- `npm run app:build`

## Notes
- `npm run app:build` still reports the existing mixed dynamic/static import warnings and large chunk warning; those are left for the bundle hygiene issue.
