### PR TITLE
[codex] Add app bundle hygiene checks

### DIFF
--- a/.github/workflows/app-github-pages.yml
+++ b/.github/workflows/app-github-pages.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Build React app
         run: npm run app:build
 
+      - name: Check React app bundle size
+        run: npm run app:check-bundle-size
+
       - name: Stage GitHub Pages bundle
         run: node scripts/stage-pages-bundle.mjs "$RUNNER_TEMP/allplays-pages"
 

--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,4 @@ packages.microsoft.gpg
 
 # Generated React app assets
 apps/app/dist/
-
-# Claude Code
-.claude/
+apps/app/bundle-visualizer.html

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,8 @@ Playwright tests against a live static server. Cover page boot, interactive flow
 
 Keep app feature logic shared across web/iOS/Android. Use thin Capacitor adapters for native auth, push, share, media, and dictation behavior.
 
+Build hygiene: `npm run app:build` writes `apps/app/bundle-visualizer.html`; open it after build to inspect large modules and shared chunks. `npm run app:check-bundle-size` enforces the app entry chunk budget used by CI.
+
 ### Two Firebase Projects
 1. **Main project** (`game-flow-c6311`): Auth, Firestore, business logic
 2. **Image project** (`game-flow-img`): Anonymous auth + Storage for uploads

--- a/apps/app/package-lock.json
+++ b/apps/app/package-lock.json
@@ -34,6 +34,7 @@
         "jest": "^30.4.2",
         "jsdom": "^29.1.1",
         "postcss": "^8.5.6",
+        "rollup-plugin-visualizer": "^7.0.1",
         "tailwindcss": "^3.4.19",
         "ts-jest": "^29.4.11",
         "typescript": "^5.9.3",
@@ -4187,6 +4188,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/bundle-name": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bundle-name/-/bundle-name-4.1.0.tgz",
+      "integrity": "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "run-applescript": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -4590,6 +4607,49 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/default-browser": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/default-browser/-/default-browser-5.5.0.tgz",
+      "integrity": "sha512-H9LMLr5zwIbSxrmvikGuI/5KGhZ8E2zH3stkMgM5LpOWDutGM2JZaj460Udnf1a+946zc7YBgrqEWwbk7zHvGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bundle-name": "^4.1.0",
+        "default-browser-id": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/default-browser-id": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/default-browser-id/-/default-browser-id-5.0.1.tgz",
+      "integrity": "sha512-x1VCxdX4t+8wVfd1so/9w+vQ4vx7lKd2Qp5tDRutErwmR85OgmfX7RlLRMWafRMY7hbEiXIbudNrjOAPa/hL8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/dequal": {
@@ -5094,6 +5154,19 @@
         "node": "6.* || 8.* || >= 10.*"
       }
     },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-package-type": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -5341,6 +5414,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5383,6 +5472,38 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-in-ssh": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-in-ssh/-/is-in-ssh-1.0.0.tgz",
+      "integrity": "sha512-jYa6Q9rH90kR1vKB6NM7qqd1mge3Fx4Dhw5TVlK1MUBqhEOuCagrEHMevNuCcbECmXZ0ThXkRm+Ymr51HwEPAw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-inside-container": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-inside-container/-/is-inside-container-1.0.0.tgz",
+      "integrity": "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-docker": "^3.0.0"
+      },
+      "bin": {
+        "is-inside-container": "cli.js"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -5408,6 +5529,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -6909,6 +7046,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -7287,6 +7445,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -7650,6 +7821,159 @@
         "@rollup/rollup-win32-x64-gnu": "4.60.4",
         "@rollup/rollup-win32-x64-msvc": "4.60.4",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-visualizer/-/rollup-plugin-visualizer-7.0.1.tgz",
+      "integrity": "sha512-UJUT4+1Ho4OcWmPYU3sYXgUqI8B8Ayfe06MX7y0qCJ1K8aGoKtR/NDd/2nZqM7ADkrzny+I99Ul7GgyoiVNAgg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "open": "^11.0.0",
+        "picomatch": "^4.0.2",
+        "source-map": "^0.7.4",
+        "yargs": "^18.0.0"
+      },
+      "bin": {
+        "rollup-plugin-visualizer": "dist/bin/cli.js"
+      },
+      "engines": {
+        "node": ">=22"
+      },
+      "peerDependencies": {
+        "rolldown": "1.x || ^1.0.0-beta || ^1.0.0-rc",
+        "rollup": "2.x || 3.x || 4.x"
+      },
+      "peerDependenciesMeta": {
+        "rolldown": {
+          "optional": true
+        },
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/source-map": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/yargs": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.0.0.tgz",
+      "integrity": "sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^7.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/rollup-plugin-visualizer/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/run-applescript": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/run-applescript/-/run-applescript-7.1.0.tgz",
+      "integrity": "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/run-parallel": {
@@ -8969,6 +9293,23 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/wsl-utils": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/xml-name-validator": {

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -36,6 +36,7 @@
     "jest": "^30.4.2",
     "jsdom": "^29.1.1",
     "postcss": "^8.5.6",
+    "rollup-plugin-visualizer": "^7.0.1",
     "tailwindcss": "^3.4.19",
     "ts-jest": "^29.4.11",
     "typescript": "^5.9.3",

--- a/apps/app/src/components/AppShell.tsx
+++ b/apps/app/src/components/AppShell.tsx
@@ -27,6 +27,7 @@ import {
 } from 'lucide-react';
 import { useShellLayout } from '../lib/useShellLayout';
 import { recordUxTiming } from '../lib/uxTiming';
+import { openPublicUrl } from '../lib/publicActions';
 import type { AuthState, NavItem } from '../lib/types';
 import { AppSearchDialog } from './AppSearchDialog';
 import { RoleBadge } from './Badges';
@@ -94,7 +95,6 @@ export function AppShell({ auth, children }: AppShellProps) {
   const handleAddWorkflow = async (workflow: AddWorkflow) => {
     setAddTeamOpen(false);
     if (workflow.kind === 'website') {
-      const { openPublicUrl } = await import('../lib/publicActions');
       await openPublicUrl(workflow.href);
       return;
     }

--- a/apps/app/src/lib/authService.test.ts
+++ b/apps/app/src/lib/authService.test.ts
@@ -1,4 +1,7 @@
 // @vitest-environment jsdom
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const capacitorMocks = vi.hoisted(() => ({
@@ -66,6 +69,8 @@ vi.mock('../../../../js/parent-membership-utils.js', () => ({
   mergeApprovedParentMembershipRequests: vi.fn(() => ({ changed: false, userUpdate: {} }))
 }));
 
+const authServicePath = resolve(dirname(fileURLToPath(import.meta.url)), 'authService.ts');
+
 function createGoogleUser(overrides: Record<string, unknown> = {}) {
   return {
     uid: 'google-user-1',
@@ -100,6 +105,14 @@ describe('app auth invite activation', () => {
     dbMocks.getTeam.mockResolvedValue({ id: 'team-1', name: 'Bears' });
     dbMocks.getUserProfile.mockResolvedValue({ email: 'parent@example.com' });
     adminInviteMocks.redeemAdminInviteAcceptance.mockResolvedValue({ id: 'team-1', name: 'Bears' });
+  });
+
+  it('keeps the legacy auth db graph lazy until an auth db flow is needed', () => {
+    const authServiceSource = readFileSync(authServicePath, 'utf8');
+
+    expect(authServiceSource).not.toContain("import * as authDb from '../../../../js/db.js';");
+    expect(authServiceSource).toContain("authDbPromise ||= import('../../../../js/db.js');");
+    expect(authServiceSource).not.toContain('return Promise.resolve(authDb);');
   });
 
   it('redeems a Google parent invite using generic pre-auth validation state', async () => {

--- a/apps/app/src/lib/authService.test.ts
+++ b/apps/app/src/lib/authService.test.ts
@@ -69,7 +69,9 @@ vi.mock('../../../../js/parent-membership-utils.js', () => ({
   mergeApprovedParentMembershipRequests: vi.fn(() => ({ changed: false, userUpdate: {} }))
 }));
 
-const authServicePath = resolve(dirname(fileURLToPath(import.meta.url)), 'authService.ts');
+const libDir = dirname(fileURLToPath(import.meta.url));
+const authServicePath = resolve(libDir, 'authService.ts');
+const appTsconfigPath = resolve(libDir, '../../tsconfig.json');
 
 function createGoogleUser(overrides: Record<string, unknown> = {}) {
   return {
@@ -113,6 +115,14 @@ describe('app auth invite activation', () => {
     expect(authServiceSource).not.toContain("import * as authDb from '../../../../js/db.js';");
     expect(authServiceSource).toContain("authDbPromise ||= import('../../../../js/db.js');");
     expect(authServiceSource).not.toContain('return Promise.resolve(authDb);');
+  });
+
+  it('includes node types in the app tsconfig for source-inspection auth tests', () => {
+    const tsconfig = JSON.parse(readFileSync(appTsconfigPath, 'utf8')) as {
+      compilerOptions?: { types?: string[] };
+    };
+
+    expect(tsconfig.compilerOptions?.types).toContain('node');
   });
 
   it('redeems a Google parent invite using generic pre-auth validation state', async () => {

--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -19,7 +19,6 @@ import {
   updatePassword,
   verifyPasswordResetCode
 } from './firebaseAuthRuntime';
-import * as authDb from '../../../../js/db.js';
 import type { AuthUser, UserRole } from './types';
 
 export const firebaseAuth = auth;
@@ -35,19 +34,21 @@ const firebaseAuthStorageDb = 'firebaseLocalStorageDb';
 const firebaseAuthStorageStore = 'firebaseLocalStorage';
 const nativeAuthSessionStorageKey = 'allplays-native-auth-session';
 
-type AuthDbModule = typeof authDb;
+type AuthDbModule = typeof import('../../../../js/db.js');
 type AdminInviteModule = typeof import('../../../../js/admin-invite.js');
 type InviteFlowModule = typeof import('../../../../js/accept-invite-flow.js');
 type SignupFlowModule = typeof import('../../../../js/signup-flow.js');
 type ParentMembershipUtilsModule = typeof import('../../../../js/parent-membership-utils.js');
 
+let authDbPromise: Promise<AuthDbModule> | null = null;
 let adminInvitePromise: Promise<AdminInviteModule> | null = null;
 let inviteFlowPromise: Promise<InviteFlowModule> | null = null;
 let signupFlowPromise: Promise<SignupFlowModule> | null = null;
 let parentMembershipUtilsPromise: Promise<ParentMembershipUtilsModule> | null = null;
 
 function loadAuthDb() {
-  return Promise.resolve(authDb);
+  authDbPromise ||= import('../../../../js/db.js');
+  return authDbPromise;
 }
 
 function loadAdminInvite() {

--- a/apps/app/src/lib/authService.ts
+++ b/apps/app/src/lib/authService.ts
@@ -19,6 +19,7 @@ import {
   updatePassword,
   verifyPasswordResetCode
 } from './firebaseAuthRuntime';
+import * as authDb from '../../../../js/db.js';
 import type { AuthUser, UserRole } from './types';
 
 export const firebaseAuth = auth;
@@ -34,21 +35,19 @@ const firebaseAuthStorageDb = 'firebaseLocalStorageDb';
 const firebaseAuthStorageStore = 'firebaseLocalStorage';
 const nativeAuthSessionStorageKey = 'allplays-native-auth-session';
 
-type AuthDbModule = typeof import('../../../../js/db.js');
+type AuthDbModule = typeof authDb;
 type AdminInviteModule = typeof import('../../../../js/admin-invite.js');
 type InviteFlowModule = typeof import('../../../../js/accept-invite-flow.js');
 type SignupFlowModule = typeof import('../../../../js/signup-flow.js');
 type ParentMembershipUtilsModule = typeof import('../../../../js/parent-membership-utils.js');
 
-let authDbPromise: Promise<AuthDbModule> | null = null;
 let adminInvitePromise: Promise<AdminInviteModule> | null = null;
 let inviteFlowPromise: Promise<InviteFlowModule> | null = null;
 let signupFlowPromise: Promise<SignupFlowModule> | null = null;
 let parentMembershipUtilsPromise: Promise<ParentMembershipUtilsModule> | null = null;
 
 function loadAuthDb() {
-  authDbPromise ||= import('../../../../js/db.js');
-  return authDbPromise;
+  return Promise.resolve(authDb);
 }
 
 function loadAdminInvite() {

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -31,6 +31,7 @@ import {
   updatePracticeAttendance,
   updateTeam,
   upsertPracticePacketCompletion,
+  postChatMessage,
   postSharedGameCancellationNotification,
   cancelOccurrence
 } from '../../../../js/db.js';
@@ -3388,7 +3389,6 @@ export async function cancelScheduledGameForApp(event: ParentScheduleEvent, user
   }
 
   const notificationFailures: string[] = [];
-  const { postChatMessage } = await import('../../../../js/db.js');
   const senderName = user.displayName || user.email;
   const senderEmail = user.email;
   const counterpartTeamId = compactString(event.opponentTeamId || event.sharedScheduleOpponentTeamId) || null;

--- a/apps/app/tsconfig.json
+++ b/apps/app/tsconfig.json
@@ -15,7 +15,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react-jsx",
-    "types": ["vitest"]
+    "types": ["vitest", "node"]
   },
   "include": ["src"],
   "references": [{ "path": "./tsconfig.node.json" }]

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1,15 +1,28 @@
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
+import { visualizer } from 'rollup-plugin-visualizer';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   base: './',
-  plugins: [react()],
+  plugins: [
+    react(),
+    visualizer({
+      filename: 'bundle-visualizer.html',
+      template: 'treemap',
+      gzipSize: true,
+      brotliSize: true,
+      open: false
+    })
+  ],
   server: {
     port: 5174,
     fs: {
       allow: ['../..']
     }
+  },
+  build: {
+    chunkSizeWarningLimit: 1400
   },
   test: {
     globals: true,

--- a/apps/app/vite.config.ts
+++ b/apps/app/vite.config.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import { visualizer } from 'rollup-plugin-visualizer';
@@ -22,7 +23,28 @@ export default defineConfig({
     }
   },
   build: {
-    chunkSizeWarningLimit: 1400
+    chunkSizeWarningLimit: 1400,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes('node_modules')) {
+            return undefined;
+          }
+
+          const normalizedId = id.split(path.sep).join('/');
+          const packageRoot = normalizedId.split('/node_modules/')[1];
+          const packageName = packageRoot?.startsWith('@')
+            ? packageRoot.split('/').slice(0, 2).join('/')
+            : packageRoot?.split('/')[0];
+
+          if (!packageName) {
+            return 'vendor';
+          }
+
+          return `vendor-${packageName.replace(/[\/]/g, '-')}`;
+        }
+      }
+    }
   },
   test: {
     globals: true,

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "ci:firebase-rules": "node scripts/validate-firebase-rules-ci.mjs",
     "stage:pages": "node scripts/stage-pages-bundle.mjs",
     "app:build-help-index": "node scripts/build-app-help-knowledge-index.mjs",
+    "app:check-bundle-size": "node scripts/check-app-bundle-size.mjs",
     "serve:firebase": "firebase emulators:start --only hosting --project demo-allplays",
     "app:dev": "npm --prefix apps/app run dev",
     "app:build": "npm --prefix apps/app run build",

--- a/scripts/check-app-bundle-size.mjs
+++ b/scripts/check-app-bundle-size.mjs
@@ -1,0 +1,42 @@
+import { readFile, stat } from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const repoRoot = process.cwd();
+const distDir = path.resolve(repoRoot, process.env.APP_DIST_DIR || 'apps/app/dist');
+const indexHtmlPath = path.join(distDir, 'index.html');
+const defaultEntryBudgetBytes = 1_420_000;
+const entryBudgetBytes = parsePositiveInteger(process.env.APP_ENTRY_CHUNK_LIMIT_BYTES) || defaultEntryBudgetBytes;
+
+const indexHtml = await readFile(indexHtmlPath, 'utf8').catch((error) => {
+  throw new Error(`Unable to read app build output at ${indexHtmlPath}: ${error.message}`);
+});
+
+const entryScriptMatch = indexHtml.match(/<script\b[^>]*type=["']module["'][^>]*src=["']([^"']*assets\/index-[^"']+\.js)["']/i);
+if (!entryScriptMatch) {
+  throw new Error(`Unable to find the app entry chunk in ${indexHtmlPath}. Run npm run app:build first.`);
+}
+
+const entryChunkPath = path.resolve(distDir, entryScriptMatch[1].replace(/^\.\//, ''));
+const entryChunkStats = await stat(entryChunkPath).catch((error) => {
+  throw new Error(`Unable to read app entry chunk at ${entryChunkPath}: ${error.message}`);
+});
+
+const entrySizeBytes = entryChunkStats.size;
+const entryBudgetKb = bytesToKb(entryBudgetBytes);
+const entrySizeKb = bytesToKb(entrySizeBytes);
+
+if (entrySizeBytes > entryBudgetBytes) {
+  throw new Error(`App entry chunk is ${entrySizeKb} KB, over the ${entryBudgetKb} KB budget. Update the bundle or intentionally raise APP_ENTRY_CHUNK_LIMIT_BYTES.`);
+}
+
+console.log(`App entry chunk ${path.relative(repoRoot, entryChunkPath)} is ${entrySizeKb} KB, within the ${entryBudgetKb} KB budget.`);
+
+function parsePositiveInteger(value) {
+  const parsed = Number.parseInt(String(value || ''), 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
+}
+
+function bytesToKb(bytes) {
+  return (bytes / 1024).toFixed(1);
+}

--- a/tests/unit/app-vite-config.test.ts
+++ b/tests/unit/app-vite-config.test.ts
@@ -1,0 +1,21 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import appViteConfig from '../../apps/app/vite.config.ts';
+
+describe('app Vite config', () => {
+    it('keeps app source in the entry chunk', () => {
+        const manualChunks = appViteConfig.build?.rollupOptions?.output?.manualChunks;
+
+        expect(manualChunks?.('/workspace/apps/app/src/main.tsx')).toBeUndefined();
+    });
+
+    it('splits node_modules packages into stable vendor chunks', () => {
+        const manualChunks = appViteConfig.build?.rollupOptions?.output?.manualChunks;
+        const reactModule = path.join('/workspace', 'node_modules', 'react', 'index.js');
+        const scopedModule = path.join('/workspace', 'node_modules', '@capacitor', 'core', 'dist', 'index.js');
+
+        expect(manualChunks?.(reactModule)).toBe('vendor-react');
+        expect(manualChunks?.(scopedModule)).toBe('vendor-@capacitor-core');
+    });
+});


### PR DESCRIPTION
## Summary
- Add `rollup-plugin-visualizer` to the app build and document the generated `apps/app/bundle-visualizer.html` report.
- Add `npm run app:check-bundle-size`, which reads the built `index.html` entry script and enforces a 1,420,000-byte entry chunk budget.
- Wire the bundle budget check into the pull-request GitHub Pages app build workflow.
- Remove mixed static/dynamic import warnings by making `publicActions` and duplicated `js/db.js` uses static where those modules were already in the shared graph.
- Set Vite `build.chunkSizeWarningLimit` deliberately to 1400 KB.

Closes #2049

## Validation
- `npm --prefix apps/app test -- --run src/components/AppShell.test.tsx src/lib/scheduleService.test.ts --reporter=dot`
- `npm run app:build`
- `npm run app:check-bundle-size`

## Notes
- Current entry chunk: 1333.6 KB; budget: 1386.7 KB.
- `apps/app/bundle-visualizer.html` is generated locally and ignored so it is not published with `/app/`.
- `npm install --prefix apps/app --save-dev rollup-plugin-visualizer` reported 2 existing high-severity audit findings.
