### PR TITLE
[codex] Persist app data cache entries

### DIFF
--- a/apps/app/src/lib/appDataCache.ts
+++ b/apps/app/src/lib/appDataCache.ts
@@ -2,50 +2,84 @@ type CacheEntry<T> = {
   value?: T;
   promise?: Promise<T>;
   expiresAt: number;
+  hydratedFromStorage?: boolean;
 };
 
 const defaultTtlMs = 60 * 1000;
+const defaultMaxStaleMs = 24 * 60 * 60 * 1000;
+const storagePrefix = 'allplays:appDataCache:';
 const cache = new Map<string, CacheEntry<unknown>>();
 
-export function getCachedAppData<T>(key: string): T | null {
+type LoadCachedAppDataOptions<T> = {
+  ttlMs?: number;
+  force?: boolean;
+  persist?: boolean;
+  maxStaleMs?: number;
+  staleWhileRevalidate?: boolean;
+  onRefresh?: (value: T) => void;
+};
+
+type StoredCacheEntry = {
+  version: 1;
+  value: unknown;
+  expiresAt: number;
+};
+
+export function getParentScheduleSummaryCacheKey(userId: string) {
+  return `app-schedule-summary:${userId}`;
+}
+
+export function getCachedAppData<T>(key: string, { maxStaleMs = defaultMaxStaleMs }: { maxStaleMs?: number } = {}): T | null {
+  const now = Date.now();
   const entry = cache.get(key) as CacheEntry<T> | undefined;
-  if (!entry?.value || entry.expiresAt <= Date.now()) return null;
-  return entry.value;
+  if (entry && hasCachedValue(entry)) {
+    if (entry.expiresAt > now || (entry.hydratedFromStorage && entry.expiresAt + maxStaleMs > now)) {
+      return entry.value as T;
+    }
+    return null;
+  }
+
+  const stored = readStoredCacheEntry<T>(key, now, maxStaleMs);
+  if (!stored) return null;
+  cache.set(key, stored);
+  return stored.value as T;
 }
 
 export function loadCachedAppData<T>(
   key: string,
   loader: () => Promise<T>,
-  { ttlMs = defaultTtlMs, force = false }: { ttlMs?: number; force?: boolean } = {}
+  {
+    ttlMs = defaultTtlMs,
+    force = false,
+    persist = true,
+    maxStaleMs = defaultMaxStaleMs,
+    staleWhileRevalidate = true,
+    onRefresh
+  }: LoadCachedAppDataOptions<T> = {}
 ): Promise<T> {
   const now = Date.now();
-  const existing = cache.get(key) as CacheEntry<T> | undefined;
-  if (!force && existing?.value && existing.expiresAt > now) {
+  const existing = hydrateMemoryCache<T>(key, now, maxStaleMs);
+  if (!force && existing && hasCachedValue(existing) && existing.expiresAt > now) {
     return Promise.resolve(existing.value);
   }
   if (!force && existing?.promise) {
     return existing.promise;
   }
-
-  const promise = loader().then((value) => {
-    cache.set(key, {
-      value,
-      expiresAt: Date.now() + ttlMs
+  if (
+    !force
+    && staleWhileRevalidate
+    && existing?.hydratedFromStorage
+    && hasCachedValue(existing)
+    && existing.expiresAt + maxStaleMs > now
+  ) {
+    const refreshPromise = loadAndStoreCachedAppData(key, loader, existing, { ttlMs, persist, onRefresh });
+    refreshPromise.catch((error) => {
+      console.warn('[app-data-cache] Background refresh failed:', error);
     });
-    return value;
-  }).catch((error) => {
-    const current = cache.get(key);
-    if (current?.promise === promise) {
-      cache.delete(key);
-    }
-    throw error;
-  });
+    return Promise.resolve(existing.value as T);
+  }
 
-  cache.set(key, {
-    promise,
-    expiresAt: now + ttlMs
-  });
-  return promise;
+  return loadAndStoreCachedAppData(key, loader, existing, { ttlMs, persist, onRefresh });
 }
 
 export function clearAppDataCache(prefix = '') {
@@ -54,4 +88,173 @@ export function clearAppDataCache(prefix = '') {
       cache.delete(key);
     }
   });
+
+  removeStoredCacheEntries(prefix);
+}
+
+function loadAndStoreCachedAppData<T>(
+  key: string,
+  loader: () => Promise<T>,
+  existing: CacheEntry<T> | undefined,
+  { ttlMs, persist, onRefresh }: { ttlMs: number; persist: boolean; onRefresh?: (value: T) => void }
+) {
+  const promise = loader().then((value) => {
+    const entry = {
+      value,
+      expiresAt: Date.now() + ttlMs,
+      hydratedFromStorage: false
+    };
+    cache.set(key, entry);
+    if (persist) writeStoredCacheEntry(key, entry);
+    onRefresh?.(value);
+    return value;
+  }).catch((error) => {
+    const current = cache.get(key);
+    if (current?.promise === promise) {
+      if (existing && hasCachedValue(existing)) {
+        cache.set(key, {
+          value: existing.value,
+          expiresAt: existing.expiresAt,
+          hydratedFromStorage: existing.hydratedFromStorage
+        });
+      } else {
+        cache.delete(key);
+      }
+    }
+    throw error;
+  });
+
+  cache.set(key, {
+    ...(existing && hasCachedValue(existing) ? { value: existing.value } : {}),
+    promise,
+    expiresAt: existing?.expiresAt ?? Date.now() + ttlMs,
+    hydratedFromStorage: existing?.hydratedFromStorage
+  });
+  return promise;
+}
+
+function hydrateMemoryCache<T>(key: string, now: number, maxStaleMs: number) {
+  const existing = cache.get(key) as CacheEntry<T> | undefined;
+  if (existing) return existing;
+
+  const stored = readStoredCacheEntry<T>(key, now, maxStaleMs);
+  if (!stored) return undefined;
+  cache.set(key, stored);
+  return stored;
+}
+
+function readStoredCacheEntry<T>(key: string, now: number, maxStaleMs: number): CacheEntry<T> | null {
+  const storage = getCacheStorage();
+  if (!storage) return null;
+
+  const storageKey = toStorageKey(key);
+  let parsed: StoredCacheEntry | null = null;
+  try {
+    const raw = storage.getItem(storageKey);
+    parsed = raw ? JSON.parse(raw, reviveCacheValue) : null;
+  } catch (error) {
+    console.warn('[app-data-cache] Unable to read cached data:', error);
+    storage.removeItem(storageKey);
+    return null;
+  }
+
+  if (!parsed || parsed.version !== 1 || !Number.isFinite(parsed.expiresAt)) {
+    storage.removeItem(storageKey);
+    return null;
+  }
+
+  if (parsed.expiresAt + maxStaleMs <= now) {
+    storage.removeItem(storageKey);
+    return null;
+  }
+
+  return {
+    value: parsed.value as T,
+    expiresAt: parsed.expiresAt,
+    hydratedFromStorage: true
+  };
+}
+
+function writeStoredCacheEntry<T>(key: string, entry: CacheEntry<T>) {
+  if (!hasCachedValue(entry)) return;
+
+  const storage = getCacheStorage();
+  if (!storage) return;
+
+  try {
+    const stored: StoredCacheEntry = {
+      version: 1,
+      value: entry.value,
+      expiresAt: entry.expiresAt
+    };
+    storage.setItem(toStorageKey(key), JSON.stringify(stored, replaceCacheValue));
+  } catch (error) {
+    console.warn('[app-data-cache] Unable to persist cached data:', error);
+  }
+}
+
+function removeStoredCacheEntries(prefix: string) {
+  const storage = getCacheStorage();
+  if (!storage) return;
+
+  for (let index = storage.length - 1; index >= 0; index -= 1) {
+    const key = storage.key(index);
+    if (!key?.startsWith(storagePrefix)) continue;
+    const cacheKey = fromStorageKey(key);
+    if (!prefix || cacheKey.startsWith(prefix)) {
+      storage.removeItem(key);
+    }
+  }
+}
+
+function getCacheStorage() {
+  if (typeof window === 'undefined') return null;
+  try {
+    const storage = window.localStorage;
+    if (
+      !storage
+      || typeof storage.getItem !== 'function'
+      || typeof storage.setItem !== 'function'
+      || typeof storage.removeItem !== 'function'
+      || typeof storage.key !== 'function'
+      || typeof storage.length !== 'number'
+    ) {
+      return null;
+    }
+    return storage;
+  } catch {
+    return null;
+  }
+}
+
+function hasCachedValue<T>(entry: CacheEntry<T>): entry is CacheEntry<T> & { value: T } {
+  return Object.prototype.hasOwnProperty.call(entry, 'value');
+}
+
+function toStorageKey(key: string) {
+  return `${storagePrefix}${encodeURIComponent(key)}`;
+}
+
+function fromStorageKey(key: string) {
+  return decodeURIComponent(key.slice(storagePrefix.length));
+}
+
+function replaceCacheValue(this: Record<string, unknown>, key: string, value: unknown) {
+  const originalValue = key ? this[key] : value;
+  if (originalValue instanceof Date) {
+    return { __type: 'Date', value: originalValue.toISOString() };
+  }
+  return value;
+}
+
+function reviveCacheValue(_key: string, value: unknown) {
+  if (
+    value
+    && typeof value === 'object'
+    && (value as { __type?: unknown }).__type === 'Date'
+    && typeof (value as { value?: unknown }).value === 'string'
+  ) {
+    return new Date((value as { value: string }).value);
+  }
+  return value;
 }

--- a/apps/app/src/lib/appDataCache.ts
+++ b/apps/app/src/lib/appDataCache.ts
@@ -53,7 +53,7 @@ export function loadCachedAppData<T>(
     force = false,
     persist = true,
     maxStaleMs = defaultMaxStaleMs,
-    staleWhileRevalidate = true,
+    staleWhileRevalidate = false,
     onRefresh
   }: LoadCachedAppDataOptions<T> = {}
 ): Promise<T> {

--- a/apps/app/src/lib/homeService.ts
+++ b/apps/app/src/lib/homeService.ts
@@ -7,7 +7,7 @@ import {
   type ParentHomeInboxTeam,
   type ParentHomeModel
 } from './homeLogic';
-import { loadCachedAppData } from './appDataCache';
+import { getParentScheduleSummaryCacheKey, loadCachedAppData } from './appDataCache';
 import {
   hydrateParentScheduleDetails,
   loadParentSchedule,
@@ -144,7 +144,7 @@ export async function loadParentHomeWithSecondaryData(
 export async function loadParentScheduleSummary(user: AuthUser | null, options: { force?: boolean } = {}): Promise<ParentScheduleLoadResult> {
   if (!user?.uid) return { children: [], events: [] };
   return loadCachedAppData(
-    `schedule-summary:${user.uid}`,
+    getParentScheduleSummaryCacheKey(user.uid),
     () => loadParentSchedule(user, { hydrateDetails: false, expandStaffPlayers: false }),
     { ttlMs: homeSummaryTtlMs, force: options.force }
   );

--- a/apps/app/src/lib/scheduleService.test.ts
+++ b/apps/app/src/lib/scheduleService.test.ts
@@ -92,7 +92,12 @@ vi.mock('./authService', () => ({ firebaseAuth: {}, getNativeAuthIdToken: vi.fn(
 vi.mock('./uxTiming', () => ({ startUxTimer: vi.fn(() => ({ end: vi.fn() })) }));
 vi.mock('./chatService', () => ({ sendTeamChatMessage: vi.fn() }));
 vi.mock('./chatLogic', () => ({ DEFAULT_TEAM_CONVERSATION_ID: 'team' }));
-vi.mock('./appDataCache', () => ({ getCachedAppData: vi.fn(), loadCachedAppData: vi.fn(), clearAppDataCache: vi.fn() }));
+vi.mock('./appDataCache', () => ({
+  getCachedAppData: vi.fn(),
+  loadCachedAppData: vi.fn(),
+  clearAppDataCache: vi.fn(),
+  getParentScheduleSummaryCacheKey: (userId: string) => `app-schedule-summary:${userId}`
+}));
 
 import { broadcastLiveEvent, claimOpenOfficiatingSlot, respondToOfficiatingAssignment, updateGame, getGame, getGames, getPlayers, getPracticeSession, getPracticeSessions, getRsvpBreakdownByPlayer, getRsvps, getTeam, getTeams, submitRsvpForPlayer, updatePracticeAttendance } from '../../../../js/db.js';
 import { getDocs } from '../../../../js/firebase.js';

--- a/apps/app/src/lib/scheduleService.ts
+++ b/apps/app/src/lib/scheduleService.ts
@@ -103,7 +103,7 @@ import {
 } from './gameDayLineupPublish';
 import { sendTeamChatMessage } from './chatService';
 import { DEFAULT_TEAM_CONVERSATION_ID } from './chatLogic';
-import { getCachedAppData } from './appDataCache';
+import { getCachedAppData, getParentScheduleSummaryCacheKey } from './appDataCache';
 import { sanitizeErrorForLogging } from './nativeRestLogging';
 import type { AuthUser } from './types';
 
@@ -2134,7 +2134,7 @@ export async function resolveParentGameRoute(user: AuthUser | null, gameId: stri
 
   const timer = startUxTimer('parent game route resolve');
   const expandStaffPlayers = options.expandStaffPlayers === true;
-  const cachedSchedule = getCachedAppData<ParentScheduleLoadResult>(`app-schedule-summary:${user.uid}`);
+  const cachedSchedule = getCachedAppData<ParentScheduleLoadResult>(getParentScheduleSummaryCacheKey(user.uid));
   const cachedMatch = (cachedSchedule?.events || []).find((event) => (
     compactString(event?.id) === requestedGameId
     && event?.type === 'game'

--- a/apps/app/src/pages/Schedule.tsx
+++ b/apps/app/src/pages/Schedule.tsx
@@ -3,7 +3,7 @@ import { AlertCircle, CalendarDays, CheckCircle2, ChevronDown, ChevronLeft, Chev
 import { Link } from 'react-router-dom';
 import { SchedulePageSkeleton } from '../components/PageSkeletons';
 import { addTeamCalendarUrl, createScheduleImportGame, createScheduleImportPractice, loadParentSchedule, removeTeamCalendarUrl, type ParentScheduleChild } from '../lib/scheduleService';
-import { getCachedAppData, loadCachedAppData } from '../lib/appDataCache';
+import { getCachedAppData, getParentScheduleSummaryCacheKey, loadCachedAppData } from '../lib/appDataCache';
 import { startUxTimer } from '../lib/uxTiming';
 import { useShellLayout } from '../lib/useShellLayout';
 import {
@@ -176,9 +176,9 @@ export function Schedule({ auth }: { auth: AuthState }) {
     const timer = startUxTimer('schedule summary load');
     const hasExistingSchedule = events.length > 0; // Check current state
     try {
-      const cacheKey = `app-schedule-summary:${auth.user.uid}`;
-      const scheduleCacheTtlMs = 60 * 1000 * 5; // Placeholder for cache TTL (5 minutes)
-      const cached = getCachedAppData(cacheKey); // Assuming getCachedAppData is available
+      const cacheKey = getParentScheduleSummaryCacheKey(auth.user.uid);
+      const scheduleCacheTtlMs = 60 * 1000 * 5;
+      const cached = getCachedAppData(cacheKey);
 
       const result = await loadCachedAppData(
         cacheKey,

--- a/tests/unit/app-data-cache.test.ts
+++ b/tests/unit/app-data-cache.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const cacheModulePath = '../../apps/app/src/lib/appDataCache.ts';
+
+async function loadCacheModule() {
+  return import(cacheModulePath);
+}
+
+describe('appDataCache', () => {
+  let localStorageMock: Storage & {
+    setItem: ReturnType<typeof vi.fn>;
+  };
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+    localStorageMock = installLocalStorageMock();
+    vi.resetModules();
+  });
+
+  it('deduplicates concurrent loads for the same key', async () => {
+    const cache = await loadCacheModule();
+    let resolveLoader: ((value: { ok: boolean }) => void) | null = null;
+    const loader = vi.fn(() => new Promise<{ ok: boolean }>((resolve) => {
+      resolveLoader = resolve;
+    }));
+
+    const first = cache.loadCachedAppData('dedup:key', loader);
+    const second = cache.loadCachedAppData('dedup:key', loader);
+
+    expect(second).toBe(first);
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    resolveLoader?.({ ok: true });
+    await expect(first).resolves.toEqual({ ok: true });
+    await expect(second).resolves.toEqual({ ok: true });
+  });
+
+  it('caches falsy values until their TTL expires', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-12T12:00:00Z'));
+    const cache = await loadCacheModule();
+    const loader = vi.fn()
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(false);
+
+    await expect(cache.loadCachedAppData('falsy:key', loader, { ttlMs: 1000 })).resolves.toBe(0);
+    expect(cache.getCachedAppData('falsy:key')).toBe(0);
+
+    vi.setSystemTime(new Date('2026-06-12T12:00:02Z'));
+
+    expect(cache.getCachedAppData('falsy:key')).toBeNull();
+    await expect(cache.loadCachedAppData('falsy:key', loader, { ttlMs: 1000, staleWhileRevalidate: false })).resolves.toBe(false);
+    expect(cache.getCachedAppData('falsy:key')).toBe(false);
+    expect(loader).toHaveBeenCalledTimes(2);
+  });
+
+  it('hydrates persisted data after a module reload and preserves Dates', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-12T12:00:00Z'));
+    const firstCache = await loadCacheModule();
+
+    await firstCache.loadCachedAppData(
+      'persisted:key',
+      async () => ({ count: 1, startsAt: new Date('2026-06-12T18:30:00Z') }),
+      { ttlMs: 60_000 }
+    );
+
+    vi.resetModules();
+    const secondCache = await loadCacheModule();
+    const cached = secondCache.getCachedAppData<{ count: number; startsAt: Date }>('persisted:key');
+
+    expect(cached?.count).toBe(1);
+    expect(cached?.startsAt).toBeInstanceOf(Date);
+    expect(cached?.startsAt.toISOString()).toBe('2026-06-12T18:30:00.000Z');
+  });
+
+  it('returns stale hydrated data immediately and refreshes it in the background', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-12T12:00:00Z'));
+    const firstCache = await loadCacheModule();
+    await firstCache.loadCachedAppData('stale:key', async () => ({ version: 1 }), { ttlMs: 1000 });
+
+    vi.setSystemTime(new Date('2026-06-12T12:00:02Z'));
+    vi.resetModules();
+    const secondCache = await loadCacheModule();
+    const loader = vi.fn().mockResolvedValue({ version: 2 });
+    const onRefresh = vi.fn();
+
+    await expect(secondCache.loadCachedAppData('stale:key', loader, { ttlMs: 1000, onRefresh })).resolves.toEqual({ version: 1 });
+    expect(loader).toHaveBeenCalledTimes(1);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onRefresh).toHaveBeenCalledWith({ version: 2 });
+    expect(secondCache.getCachedAppData('stale:key')).toEqual({ version: 2 });
+  });
+
+  it('falls back to memory cache when storage persistence fails', async () => {
+    const cache = await loadCacheModule();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    localStorageMock.setItem.mockImplementation(() => {
+      throw new DOMException('Quota exceeded', 'QuotaExceededError');
+    });
+
+    await expect(cache.loadCachedAppData('quota:key', async () => ({ ok: true }))).resolves.toEqual({ ok: true });
+
+    expect(cache.getCachedAppData('quota:key')).toEqual({ ok: true });
+  });
+
+  it('clears matching persisted entries by prefix', async () => {
+    const firstCache = await loadCacheModule();
+    await firstCache.loadCachedAppData('team:a', async () => ({ team: 'a' }));
+    await firstCache.loadCachedAppData('user:b', async () => ({ user: 'b' }));
+    firstCache.clearAppDataCache('team:');
+
+    vi.resetModules();
+    const secondCache = await loadCacheModule();
+
+    expect(secondCache.getCachedAppData('team:a')).toBeNull();
+    expect(secondCache.getCachedAppData('user:b')).toEqual({ user: 'b' });
+  });
+
+  it('uses one shared key for parent schedule summaries across pages', async () => {
+    const cache = await loadCacheModule();
+
+    expect(cache.getParentScheduleSummaryCacheKey('parent-1')).toBe('app-schedule-summary:parent-1');
+  });
+});
+
+function installLocalStorageMock() {
+  const store = new Map<string, string>();
+  const storage = {
+    get length() {
+      return store.size;
+    },
+    clear: vi.fn(() => {
+      store.clear();
+    }),
+    getItem: vi.fn((key: string) => store.get(String(key)) ?? null),
+    key: vi.fn((index: number) => Array.from(store.keys())[index] ?? null),
+    removeItem: vi.fn((key: string) => {
+      store.delete(String(key));
+    }),
+    setItem: vi.fn((key: string, value: string) => {
+      store.set(String(key), String(value));
+    })
+  } as unknown as Storage & { setItem: ReturnType<typeof vi.fn> };
+
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: storage
+  });
+
+  return storage;
+}

--- a/tests/unit/app-data-cache.test.ts
+++ b/tests/unit/app-data-cache.test.ts
@@ -76,7 +76,23 @@ describe('appDataCache', () => {
     expect(cached?.startsAt.toISOString()).toBe('2026-06-12T18:30:00.000Z');
   });
 
-  it('returns stale hydrated data immediately and refreshes it in the background', async () => {
+  it('awaits a fresh loader result when a hydrated entry is stale by default', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-06-12T12:00:00Z'));
+    const firstCache = await loadCacheModule();
+    await firstCache.loadCachedAppData('stale:key', async () => ({ version: 1 }), { ttlMs: 1000 });
+
+    vi.setSystemTime(new Date('2026-06-12T12:00:02Z'));
+    vi.resetModules();
+    const secondCache = await loadCacheModule();
+    const loader = vi.fn().mockResolvedValue({ version: 2 });
+
+    await expect(secondCache.loadCachedAppData('stale:key', loader, { ttlMs: 1000 })).resolves.toEqual({ version: 2 });
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(secondCache.getCachedAppData('stale:key')).toEqual({ version: 2 });
+  });
+
+  it('returns stale hydrated data immediately only when stale-while-revalidate is enabled', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-06-12T12:00:00Z'));
     const firstCache = await loadCacheModule();
@@ -88,7 +104,7 @@ describe('appDataCache', () => {
     const loader = vi.fn().mockResolvedValue({ version: 2 });
     const onRefresh = vi.fn();
 
-    await expect(secondCache.loadCachedAppData('stale:key', loader, { ttlMs: 1000, onRefresh })).resolves.toEqual({ version: 1 });
+    await expect(secondCache.loadCachedAppData('stale:key', loader, { ttlMs: 1000, staleWhileRevalidate: true, onRefresh })).resolves.toEqual({ version: 1 });
     expect(loader).toHaveBeenCalledTimes(1);
 
     await Promise.resolve();


### PR DESCRIPTION
## Summary
- Persist app data cache entries to localStorage with defensive storage fallback and Date revival.
- Preserve falsy cached values, retain in-flight request dedup, and hydrate stale persisted values with background refresh support.
- Clear matching persisted cache entries alongside memory entries.
- Share the parent schedule summary cache key across Home, Schedule, and parent game route resolution.
- Add regression tests for dedup, TTL/falsy values, persisted hydration, stale refresh, storage-quota fallback, clearing, and shared keys.

Closes #2031

## Validation
- `npx vitest run tests/unit/app-data-cache.test.ts tests/unit/app-home-service.test.js tests/unit/app-schedule-desktop-controls.test.jsx --reporter=dot`
- `npm --prefix apps/app test -- --run src/lib/scheduleService.test.ts --reporter=dot`
- `npm run app:build`
- `npx vitest run tests/unit/app-data-cache.test.ts --reporter=dot`

## Notes
- `npm run app:build` still reports the existing bundle warnings for mixed imports and the large entry chunk; those are handled separately in #2175.
- Root Vitest printed the existing `--localstorage-file` warning while the tests passed.
