### PR TITLE
Fix live note undo handling

### DIFF
--- a/tests/unit/track-live-live-events.test.js
+++ b/tests/unit/track-live-live-events.test.js
@@ -18,6 +18,19 @@ describe('track-live live event publishing', () => {
     expect(source).toContain('description: `Corrected stat: ${statKey.toUpperCase()} adjusted`');
   });
 
+  it('removes live note state and emits an undo event when notes are undone', () => {
+    const source = readTrackLive();
+
+    expect(source).toContain('const liveNote = addLiveNoteRecord(clean, type);');
+    expect(source).toContain("type: 'note'");
+    expect(source).toContain('liveNoteId: liveNote?.id || null');
+    expect(source).toContain("} else if (undoData && undoData.type === 'note') {");
+    expect(source).toContain('removeLiveNoteRecord(undoData.liveNoteId, undoData.liveNoteText || undoData.note);');
+    expect(source).toContain('scheduleLiveHasData();');
+    expect(source).toContain('description: `Undo: ${entry.text}`');
+    expect(source).toContain("removedNote: undoData.liveNoteText || undoData.note || ''");
+  });
+
   it('wires bounded goal-sport controls into track-live', () => {
     const source = readTrackLive();
 

--- a/tests/unit/track-live-live-events.test.js
+++ b/tests/unit/track-live-live-events.test.js
@@ -18,15 +18,19 @@ describe('track-live live event publishing', () => {
     expect(source).toContain('description: `Corrected stat: ${statKey.toUpperCase()} adjusted`');
   });
 
-  it('removes live note state and emits an undo event when notes are undone', () => {
+  it('only emits note undo events when the original note was published live', () => {
     const source = readTrackLive();
 
     expect(source).toContain('const liveNote = addLiveNoteRecord(clean, type);');
+    expect(source).toContain('const noteWasPublished = gameState.isRunning;');
+    expect(source).toContain('wasPublished: noteWasPublished');
+    expect(source).toContain('if (noteWasPublished) {');
     expect(source).toContain("type: 'note'");
     expect(source).toContain('liveNoteId: liveNote?.id || null');
     expect(source).toContain("} else if (undoData && undoData.type === 'note') {");
     expect(source).toContain('removeLiveNoteRecord(undoData.liveNoteId, undoData.liveNoteText || undoData.note);');
     expect(source).toContain('scheduleLiveHasData();');
+    expect(source).toContain('if (undoData.wasPublished) {');
     expect(source).toContain('description: `Undo: ${entry.text}`');
     expect(source).toContain("removedNote: undoData.liveNoteText || undoData.note || ''");
   });

--- a/track-live.html
+++ b/track-live.html
@@ -2050,14 +2050,16 @@
             if (!logText) return false;
 
             const liveNote = addLiveNoteRecord(clean, type);
+            const noteWasPublished = gameState.isRunning;
             await addLogEntry(logText, {
                 type: 'note',
                 note: clean,
                 noteType: type,
                 liveNoteId: liveNote?.id || null,
-                liveNoteText: liveNote?.text || clean
+                liveNoteText: liveNote?.text || clean,
+                wasPublished: noteWasPublished
             });
-            if (gameState.isRunning) {
+            if (noteWasPublished) {
                 broadcastLiveEvent(currentTeamId, currentGameId, {
                     type: 'note',
                     period: gameState.currentPeriod,
@@ -2889,16 +2891,18 @@
             } else if (undoData && undoData.type === 'note') {
                 removeLiveNoteRecord(undoData.liveNoteId, undoData.liveNoteText || undoData.note);
                 scheduleLiveHasData();
-                broadcastLiveEvent(currentTeamId, currentGameId, {
-                    type: 'undo',
-                    period: gameState.currentPeriod,
-                    gameClockMs: gameState.elapsed,
-                    homeScore,
-                    awayScore,
-                    description: `Undo: ${entry.text}`,
-                    removedNote: undoData.liveNoteText || undoData.note || '',
-                    createdBy: currentUser?.uid || null
-                }).catch(console.warn);
+                if (undoData.wasPublished) {
+                    broadcastLiveEvent(currentTeamId, currentGameId, {
+                        type: 'undo',
+                        period: gameState.currentPeriod,
+                        gameClockMs: gameState.elapsed,
+                        homeScore,
+                        awayScore,
+                        description: `Undo: ${entry.text}`,
+                        removedNote: undoData.liveNoteText || undoData.note || '',
+                        createdBy: currentUser?.uid || null
+                    }).catch(console.warn);
+                }
             }
 
             if (undoData && undoData.type === 'football_score') {

--- a/track-live.html
+++ b/track-live.html
@@ -2049,8 +2049,14 @@
             const logText = buildGameNoteLogText(clean, type);
             if (!logText) return false;
 
-            addLiveNoteRecord(clean, type);
-            await addLogEntry(logText, { type: 'note', note: clean, noteType: type });
+            const liveNote = addLiveNoteRecord(clean, type);
+            await addLogEntry(logText, {
+                type: 'note',
+                note: clean,
+                noteType: type,
+                liveNoteId: liveNote?.id || null,
+                liveNoteText: liveNote?.text || clean
+            });
             if (gameState.isRunning) {
                 broadcastLiveEvent(currentTeamId, currentGameId, {
                     type: 'note',
@@ -2061,6 +2067,7 @@
                     description: logText,
                     note: clean,
                     noteType: type,
+                    liveNoteId: liveNote?.id || null,
                     createdBy: currentUser?.uid || null
                 }).catch(console.warn);
             }
@@ -2877,6 +2884,19 @@
                     awayScore,
                     baseballState: gameState.baseballState,
                     description: `Undo: ${entry.text}`,
+                    createdBy: currentUser?.uid || null
+                }).catch(console.warn);
+            } else if (undoData && undoData.type === 'note') {
+                removeLiveNoteRecord(undoData.liveNoteId, undoData.liveNoteText || undoData.note);
+                scheduleLiveHasData();
+                broadcastLiveEvent(currentTeamId, currentGameId, {
+                    type: 'undo',
+                    period: gameState.currentPeriod,
+                    gameClockMs: gameState.elapsed,
+                    homeScore,
+                    awayScore,
+                    description: `Undo: ${entry.text}`,
+                    removedNote: undoData.liveNoteText || undoData.note || '',
                     createdBy: currentUser?.uid || null
                 }).catch(console.warn);
             }


### PR DESCRIPTION
Closes #2205

## What changed
- store each manual or voice live note's generated `liveNoteId` in the log entry undo metadata when the note is created
- add a `note` branch in `undoLogEntry(...)` so Undo Last and the per-row ✕ control call `removeLiveNoteRecord(...)`, update live-note state, and refresh live-data sync state
- emit an explicit live `undo` event for note removals so viewers receive a compensating correction after a published note is undone
- add a focused regression test covering note undo wiring in `track-live.html`

## Root Cause
`appendGameNote(...)` logged note entries with `undoData.type = 'note'`, but `undoLogEntry(...)` had no matching `note` handler. Undo therefore only removed the visible log row and never removed the underlying live note or summary entry, and it never published a compensating live event.

## Prevention / Learning
When a tracker action writes structured `undoData`, every `undoData.type` must have an explicit undo branch plus a focused regression test that verifies both local state rollback and live broadcast side effects. Stable IDs should be carried into undo metadata whenever the tracked item can appear multiple times.

## Regression Tests
- `npx vitest run tests/unit/track-live-live-events.test.js --reporter=verbose`

## Recurrence Risk
Low. The note undo path now removes note state by stable note ID and a regression test guards the missing-branch failure mode that caused this bug.