### PR TITLE
Preserve household invite redirects after login

### DIFF
--- a/js/invite-redirect.js
+++ b/js/invite-redirect.js
@@ -5,7 +5,16 @@ export function normalizeInviteCode(inviteCode) {
 
 function normalizeInviteType(inviteType) {
     const normalized = typeof inviteType === 'string' ? inviteType.trim().toLowerCase() : '';
-    return normalized === 'parent' || normalized === 'admin' ? normalized : null;
+
+    if (normalized === 'parent' || normalized === 'admin' || normalized === 'household') {
+        return normalized;
+    }
+
+    if (normalized === 'household_invite') {
+        return 'household';
+    }
+
+    return null;
 }
 
 export function getPostAuthRedirectUrl(defaultRedirectUrl, inviteCode, shouldRedeemInvite = false, inviteType = null) {

--- a/js/login-page.js
+++ b/js/login-page.js
@@ -67,6 +67,8 @@ export function getGoogleAuthModeForLoginPage({ isLogin = true, urlCodeParam = n
     return 'signup';
 }
 
+const REDEEMABLE_INVITE_TYPES = new Set(['', 'parent', 'admin', 'household', 'household_invite']);
+
 export function createLoginRedirectCoordinator({
     windowObject = window,
     getRedirectUrl,
@@ -77,8 +79,7 @@ export function createLoginRedirectCoordinator({
     const urlInviteType = typeof urlParams.get('type') === 'string'
         ? urlParams.get('type').trim().toLowerCase()
         : '';
-    const shouldRedeemInviteFromLogin = Boolean(urlCodeParam) &&
-        (!urlInviteType || urlInviteType === 'parent' || urlInviteType === 'admin');
+    const shouldRedeemInviteFromLogin = Boolean(urlCodeParam) && REDEEMABLE_INVITE_TYPES.has(urlInviteType);
     let inviteRedemptionOverride = null;
 
     function getPostAuthRedirect(userWithRoles, shouldRedeemInvite = false) {

--- a/login.html
+++ b/login.html
@@ -100,8 +100,8 @@
         import { login, signup, checkAuth, loginWithGoogle, handleGoogleRedirectResult, resetPassword, getRedirectUrl } from './js/auth.js?v=22';
         import { getUserProfile } from './js/db.js?v=45';
         import { renderHeader, renderFooter } from './js/utils.js?v=8';
-        import { getPostAuthRedirectUrl } from './js/invite-redirect.js?v=1';
-        import * as loginPageModule from './js/login-page.js?v=4';
+        import { getPostAuthRedirectUrl } from './js/invite-redirect.js?v=2';
+        import * as loginPageModule from './js/login-page.js?v=5';
 
         renderFooter(document.getElementById('footer-container'));
 

--- a/tests/smoke/login-invite-redirect.spec.js
+++ b/tests/smoke/login-invite-redirect.spec.js
@@ -127,6 +127,29 @@ test('email/password login from a type-less invite link redirects existing users
     await expect(page).toHaveURL(/\/accept-invite\.html\?code=AB12CD34$/);
 });
 
+test('email/password login from a household invite link redirects existing users to accept-invite', async ({ page, baseURL }) => {
+    await mockInviteLoginModules(page, {
+        profile: {
+            parentOf: [{ teamId: 'team-1' }]
+        },
+        defaultRedirect: 'parent-dashboard.html'
+    });
+
+    await page.goto(buildUrl(baseURL, '/login.html?code=ab12cd34&type=household'), {
+        waitUntil: 'domcontentloaded'
+    });
+
+    await expect(page.locator('#form-title')).toHaveText('Sign Up');
+    await page.locator('#toggle-btn').click();
+    await expect(page.locator('#form-title')).toHaveText('Login');
+
+    await page.locator('#email').fill('household@example.com');
+    await page.locator('#password').fill('secret123');
+    await page.locator('#login-form').dispatchEvent('submit');
+
+    await expect(page).toHaveURL(/\/accept-invite\.html\?code=AB12CD34&type=household$/);
+});
+
 test('google redirect login mode keeps existing admin invites on accept-invite', async ({ page, baseURL }) => {
     await page.addInitScript(() => {
         window.sessionStorage.setItem('postGoogleAuthMode', 'login');

--- a/tests/unit/invite-redirect.test.js
+++ b/tests/unit/invite-redirect.test.js
@@ -18,6 +18,14 @@ describe('invite redirect helper', () => {
         expect(getPostAuthRedirectUrl('dashboard.html', 'abcd1234', true, 'Admin')).toBe('accept-invite.html?code=ABCD1234&type=admin');
     });
 
+    it('preserves household invite redirects when redemption is requested', () => {
+        expect(getPostAuthRedirectUrl('dashboard.html', 'abcd1234', true, 'household')).toBe('accept-invite.html?code=ABCD1234&type=household');
+    });
+
+    it('normalizes household_invite redirects to the household accept-invite route', () => {
+        expect(getPostAuthRedirectUrl('dashboard.html', 'abcd1234', true, 'household_invite')).toBe('accept-invite.html?code=ABCD1234&type=household');
+    });
+
     it('uses default redirect when no valid code exists', () => {
         expect(getPostAuthRedirectUrl('dashboard.html', '', true)).toBe('dashboard.html');
     });

--- a/tests/unit/login-page-cache-busting.test.js
+++ b/tests/unit/login-page-cache-busting.test.js
@@ -3,11 +3,14 @@ import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
 describe('login page cache busting', () => {
-    it('loads the current login-page coordinator module version', () => {
+    it('loads the current login redirect helper module versions', () => {
         const source = readFileSync(resolve(process.cwd(), 'login.html'), 'utf8');
 
         expect(source).toContain(
-            "import * as loginPageModule from './js/login-page.js?v=4';"
+            "import { getPostAuthRedirectUrl } from './js/invite-redirect.js?v=2';"
+        );
+        expect(source).toContain(
+            "import * as loginPageModule from './js/login-page.js?v=5';"
         );
     });
 });

--- a/tests/unit/login-page.test.js
+++ b/tests/unit/login-page.test.js
@@ -83,6 +83,17 @@ describe('login page redirect coordination', () => {
             .toBe('accept-invite.html?code=AB12CD34&type=admin');
     });
 
+    it('redeems household invite links after login', () => {
+        const { coordinator } = createCoordinator({
+            search: '?code=ab12cd34&type=household',
+            defaultRedirect: 'parent-dashboard.html'
+        });
+
+        expect(coordinator.shouldRedeemInviteFromLogin).toBe(true);
+        expect(coordinator.getPostAuthRedirect({ uid: 'user-1' }, coordinator.shouldRedeemInviteFromLogin))
+            .toBe('accept-invite.html?code=AB12CD34&type=household');
+    });
+
     it('redeems type-less 8-character invite links after login', () => {
         const { coordinator } = createCoordinator({
             search: '?code=ab12cd34',


### PR DESCRIPTION
Closes #2207

## What changed
- allow `type=household` invite links to stay on the post-auth invite redemption path instead of falling back to the normal dashboard redirect
- normalize `household_invite` to the public `household` invite route in the shared redirect helper
- bump the `login.html` cache-busted imports for the updated redirect modules
- add focused unit coverage for household invite redirect coordination and helper normalization
- add a focused smoke regression covering existing-user login from a household invite link

## Root Cause
The login redirect coordinator and invite redirect helper each hard-coded redeemable invite types to blank, `parent`, and `admin`. When an existing user followed a household invite link with `type=household`, the login flow treated it as non-redeemable and redirected to the default dashboard after auth, so `accept-invite.html` never got a chance to redeem the invite.

## Prevention / Learning
When invite acceptance supports a new access-code type, update the shared post-auth redirect whitelist and invite-type normalization helpers at the same time. Back that change with a focused login redirect regression test for the new type so auth redirects and redemption routes cannot drift apart.

## Regression Tests
- `npx vitest run tests/unit/login-page.test.js tests/unit/invite-redirect.test.js tests/unit/login-page-cache-busting.test.js`
- `npx playwright test tests/smoke/login-invite-redirect.spec.js --config=playwright.smoke.config.js --grep "type-less invite link|household invite link|admin invites"`

## Recurrence Risk
Low. The redirect decision and invite-type normalization are now both covered for household invites in unit tests and in the existing login invite smoke flow.