### PR TITLE
Keep social quick shares team-first by default

### DIFF
--- a/apps/app/src/pages/Home.tsx
+++ b/apps/app/src/pages/Home.tsx
@@ -1264,6 +1264,7 @@ function SocialComposerModal({
   const [visibility, setVisibility] = useState<SocialVisibility>(activePreset.defaultVisibility);
   const [teamId, setTeamId] = useState(home.teams[0]?.teamId || '');
   const [playerKey, setPlayerKey] = useState(initialPreset.prefersPlayer && home.players[0] ? `${home.players[0].teamId}::${home.players[0].playerId}` : '');
+  const [playerTaggingEnabled, setPlayerTaggingEnabled] = useState(initialPreset.prefersPlayer);
   const [caption, setCaption] = useState('');
   const [mediaFile, setMediaFile] = useState<File | null>(null);
   const [detailsOpen, setDetailsOpen] = useState(false);
@@ -1271,17 +1272,20 @@ function SocialComposerModal({
   const [submitting, setSubmitting] = useState(false);
   const [localError, setLocalError] = useState('');
 
-  const selectedPlayer = activePreset.prefersPlayer
-    ? home.players.find((player) => `${player.teamId}::${player.playerId}` === playerKey) || home.players[0] || null
-    : home.players.find((player) => `${player.teamId}::${player.playerId}` === playerKey) || null;
-  const selectedTeam = selectedPlayer
+  const supportsOptionalPlayerTagging = type === 'game_recap' || type === 'team_media' || type === 'practice_packet';
+  const playerSelectionEnabled = activePreset.prefersPlayer || playerTaggingEnabled;
+  const fallbackPlayer = home.players.find((player) => player.teamId === teamId) || home.players[0] || null;
+  const selectedPlayer = playerSelectionEnabled
+    ? home.players.find((player) => `${player.teamId}::${player.playerId}` === playerKey) || (activePreset.prefersPlayer ? fallbackPlayer : null)
+    : null;
+  const selectedTeam = playerSelectionEnabled && selectedPlayer
     ? home.teams.find((team) => team.teamId === selectedPlayer.teamId) || home.teams.find((team) => team.teamId === teamId) || home.teams[0] || null
     : home.teams.find((team) => team.teamId === teamId) || home.teams[0] || null;
   const suggestedTitle = getComposerSuggestedTitle(type, selectedTeam, selectedPlayer);
   const visibleUserIds = visibility === 'friends' || visibility === 'friends_and_team'
     ? social.friends.map((friend) => friend.userId)
     : [];
-  const subjectLabel = selectedPlayer
+  const subjectLabel = playerSelectionEnabled && selectedPlayer
     ? `${selectedPlayer.playerName} · ${selectedPlayer.teamName}`
     : selectedTeam?.teamName || 'Choose team';
 
@@ -1291,12 +1295,13 @@ function SocialComposerModal({
     setPresetId(nextPreset.id);
     setVisibility(nextPreset.defaultVisibility);
     setLocalError('');
-    if (nextPreset.prefersPlayer && !playerKey && home.players[0]) {
-      setPlayerKey(`${home.players[0].teamId}::${home.players[0].playerId}`);
-      setTeamId(home.players[0].teamId);
-    }
-    if (!nextPreset.prefersPlayer) {
-      setPlayerKey('');
+    setPlayerTaggingEnabled(nextPreset.prefersPlayer);
+    if (nextPreset.prefersPlayer) {
+      const nextPlayer = home.players.find((player) => `${player.teamId}::${player.playerId}` === playerKey) || home.players[0] || null;
+      if (nextPlayer) {
+        setPlayerKey(`${nextPlayer.teamId}::${nextPlayer.playerId}`);
+        setTeamId(nextPlayer.teamId);
+      }
     }
   };
 
@@ -1410,22 +1415,55 @@ function SocialComposerModal({
                   {home.teams.length ? home.teams.map((team) => <option key={team.teamId} value={team.teamId}>{team.teamName}</option>) : <option value="">No team linked</option>}
                 </select>
               </label>
-              <label className="block sm:col-span-2">
-                <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Player</span>
-                <select
-                  value={playerKey}
-                  onChange={(event) => {
-                    const nextKey = event.target.value;
-                    setPlayerKey(nextKey);
-                    const nextPlayer = home.players.find((player) => `${player.teamId}::${player.playerId}` === nextKey);
-                    if (nextPlayer?.teamId) setTeamId(nextPlayer.teamId);
-                  }}
-                  className="mt-1 min-h-11 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm font-bold outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100"
-                >
-                  <option value="">Team post</option>
-                  {home.players.map((player) => <option key={`${player.teamId}-${player.playerId}`} value={`${player.teamId}::${player.playerId}`}>{player.playerName} · {player.teamName}</option>)}
-                </select>
-              </label>
+              {supportsOptionalPlayerTagging ? (
+                <div className="block sm:col-span-2">
+                  <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Optional</span>
+                  <div className="mt-1 rounded-xl border border-gray-200 bg-gray-50 p-3">
+                    <div className="flex flex-wrap items-center justify-between gap-2">
+                      <div>
+                        <div className="text-sm font-black text-gray-950">Tag a player</div>
+                        <div className="mt-0.5 text-xs font-semibold text-gray-500">Keep this team-first unless you explicitly want to tag one player.</div>
+                      </div>
+                      <button
+                        type="button"
+                        className={`rounded-full px-3 py-1.5 text-xs font-black ${playerTaggingEnabled ? 'bg-primary-600 text-white' : 'bg-white text-primary-700 ring-1 ring-primary-100'}`}
+                        onClick={() => {
+                          if (playerTaggingEnabled) {
+                            setPlayerTaggingEnabled(false);
+                            return;
+                          }
+                          const nextPlayer = home.players.find((player) => player.teamId === (selectedTeam?.teamId || teamId)) || home.players[0] || null;
+                          if (nextPlayer) {
+                            setPlayerKey(`${nextPlayer.teamId}::${nextPlayer.playerId}`);
+                            setTeamId(nextPlayer.teamId);
+                          }
+                          setPlayerTaggingEnabled(true);
+                        }}
+                      >
+                        {playerTaggingEnabled ? 'Remove player tag' : 'Tag a player'}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ) : null}
+              {playerSelectionEnabled ? (
+                <label className="block sm:col-span-2">
+                  <span className="text-xs font-black uppercase tracking-[0.04em] text-gray-500">Player</span>
+                  <select
+                    value={playerKey}
+                    onChange={(event) => {
+                      const nextKey = event.target.value;
+                      setPlayerKey(nextKey);
+                      const nextPlayer = home.players.find((player) => `${player.teamId}::${player.playerId}` === nextKey);
+                      if (nextPlayer?.teamId) setTeamId(nextPlayer.teamId);
+                    }}
+                    className="mt-1 min-h-11 w-full rounded-xl border border-gray-200 bg-white px-3 text-sm font-bold outline-none focus:border-primary-400 focus:ring-2 focus:ring-primary-100"
+                  >
+                    {activePreset.prefersPlayer ? null : <option value="">Choose player</option>}
+                    {home.players.map((player) => <option key={`${player.teamId}-${player.playerId}`} value={`${player.teamId}::${player.playerId}`}>{player.playerName} · {player.teamName}</option>)}
+                  </select>
+                </label>
+              ) : null}
             </div>
           ) : null}
 

--- a/tests/unit/app-home-player-integration.test.jsx
+++ b/tests/unit/app-home-player-integration.test.jsx
@@ -214,6 +214,32 @@ async function attachComposerFile(container, fileName = 'social.png') {
     return file;
 }
 
+function findLabel(container, text) {
+    const normalized = text.trim().toLowerCase();
+    return Array.from(container.querySelectorAll('label')).find((candidate) => {
+        const heading = candidate.querySelector('span');
+        return heading?.textContent?.trim().toLowerCase() === normalized;
+    }) || null;
+}
+
+function getSelectByLabel(container, text) {
+    const label = findLabel(container, text);
+    const select = label?.querySelector('select') || null;
+    if (!select) {
+        throw new Error(`Select not found for label: ${text}`);
+    }
+    return select;
+}
+
+async function changeSelectByLabel(container, text, value) {
+    const select = getSelectByLabel(container, text);
+    await act(async () => {
+        select.value = value;
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+    await flush();
+}
+
 beforeEach(() => {
     vi.clearAllMocks();
     window.requestAnimationFrame = (callback) => {
@@ -601,7 +627,7 @@ describe('React app Home and player drill-in integration', () => {
         }));
     });
 
-    it('keeps advanced audience and subject controls tucked behind composer chips', async () => {
+    it('keeps team-first presets player-free by default and submits a team-scoped payload', async () => {
         const { container } = await renderApp('/home?section=feed&social=create&type=practice_packet');
         await waitForText(container, 'What happened?');
 
@@ -612,7 +638,8 @@ describe('React app Home and player drill-in integration', () => {
 
         await clickButton(container, 'Team');
         await waitForText(container, 'Audience');
-        expect(container.textContent).toContain('Player');
+        expect(findLabel(container, 'Player')).toBeNull();
+        expect(container.textContent).toContain('Tag a player');
 
         await clickButton(container, 'Practice packet is ready.');
         await clickLastButton(container, 'Post');
@@ -622,8 +649,126 @@ describe('React app Home and player drill-in integration', () => {
             title: 'Bears practice packet',
             caption: 'Practice packet is ready.',
             teamId: 'team-1',
+            playerIds: [],
+            playerNames: [],
+            sourceType: 'team',
             route: '/schedule?teamId=team-1',
             visibleUserIds: []
+        }));
+    });
+
+    it('shows the player selector only after explicit opt-in on team-first presets', async () => {
+        const { container } = await renderApp('/home?section=feed&social=create&type=game_recap');
+        await waitForText(container, 'What happened?');
+
+        await clickButton(container, 'Bears');
+        await waitForText(container, 'Audience');
+        expect(findLabel(container, 'Player')).toBeNull();
+
+        await clickButton(container, 'Tag a player');
+        await waitForText(container, 'Remove player tag');
+        expect(getSelectByLabel(container, 'Player').value).toBe('team-1::player-1');
+
+        await clickButton(container, 'Hard fought game today.');
+        await clickLastButton(container, 'Post');
+        expect(socialMocks.createSocialPost).toHaveBeenCalledWith(auth.user, expect.objectContaining({
+            type: 'game_recap',
+            title: 'Bears game recap',
+            caption: 'Hard fought game today.',
+            teamId: 'team-1',
+            playerIds: ['player-1'],
+            playerNames: ['Pat Star'],
+            sourceType: 'player',
+            sourceId: 'player-1'
+        }));
+    });
+
+    it('lets team changes stick on team-first presets until player tagging is explicitly enabled', async () => {
+        homeMocks.loadParentHome.mockResolvedValue({
+            players: [
+                {
+                    teamId: 'team-1',
+                    teamName: 'Bears',
+                    playerId: 'player-1',
+                    playerName: 'Pat Star',
+                    nextEvent: null,
+                    rsvpNeeded: 0,
+                    packetsReady: 0,
+                    openAssignments: 0,
+                    unreadCount: 0
+                },
+                {
+                    teamId: 'team-2',
+                    teamName: 'Wolves',
+                    playerId: 'player-2',
+                    playerName: 'Sam Swift',
+                    nextEvent: null,
+                    rsvpNeeded: 0,
+                    packetsReady: 0,
+                    openAssignments: 0,
+                    unreadCount: 0
+                }
+            ],
+            teams: [
+                {
+                    teamId: 'team-1',
+                    teamName: 'Bears',
+                    role: 'Parent',
+                    sport: 'Basketball',
+                    players: [{ teamId: 'team-1', teamName: 'Bears', playerId: 'player-1', playerName: 'Pat Star' }],
+                    nextEvent: null,
+                    eventCount: 2,
+                    unreadCount: 0,
+                    openActions: 0
+                },
+                {
+                    teamId: 'team-2',
+                    teamName: 'Wolves',
+                    role: 'Parent',
+                    sport: 'Soccer',
+                    players: [{ teamId: 'team-2', teamName: 'Wolves', playerId: 'player-2', playerName: 'Sam Swift' }],
+                    nextEvent: null,
+                    eventCount: 1,
+                    unreadCount: 0,
+                    openActions: 0
+                }
+            ],
+            upcomingEvents: [],
+            actionItems: [],
+            fees: [],
+            metrics: {
+                players: 2,
+                teams: 2,
+                rsvpNeeded: 0,
+                unreadMessages: 0,
+                packetsReady: 0
+            }
+        });
+
+        const { container } = await renderApp('/home?section=feed&social=create&type=player_moment');
+        await waitForText(container, 'What happened?');
+        await clickButton(container, 'Change share type');
+        await clickButton(container, 'Recap');
+        await clickButton(container, 'Bears');
+        await waitForText(container, 'Audience');
+
+        expect(findLabel(container, 'Player')).toBeNull();
+        await changeSelectByLabel(container, 'Team', 'team-2');
+        expect(getSelectByLabel(container, 'Team').value).toBe('team-2');
+
+        await clickButton(container, 'Great team win today.');
+        await clickLastButton(container, 'Post');
+        expect(socialMocks.createSocialPost).toHaveBeenCalledWith(auth.user, expect.objectContaining({
+            type: 'game_recap',
+            title: 'Wolves game recap',
+            caption: 'Great team win today.',
+            teamId: 'team-2',
+            teamName: 'Wolves',
+            playerIds: [],
+            playerNames: [],
+            sourceType: 'team',
+            sourceId: 'team-2',
+            route: '/schedule?teamId=team-2'
         }));
     });
 


### PR DESCRIPTION
Closes #2202

## What changed
- kept Game recap, Photo or video, and Practice update in a team-first flow by default
- hid the Player selector for those presets until the user explicitly chooses `Tag a player`
- stopped stale player selection from overriding team changes on team-first presets unless player tagging is turned on
- added focused Home composer integration coverage for default team scope, explicit player tagging, and team switching regression behavior

## Root Cause
The Home social composer always resolved a selected player from `playerKey` for non-player presets and always rendered the Player selector in the details panel. That let hidden player state silently flip team-oriented posts into player-scoped payloads and caused team changes to be overridden by prior player context.

## Prevention / Learning
For mixed-scope composers, optional scope changes must be explicit in both UI state and payload derivation. Hidden or stale selection state should never affect submission semantics unless the user has actively opted into that narrower scope.

## Regression Tests
- `npx vitest run tests/unit/app-home-player-integration.test.jsx --reporter=verbose`
- team-first Practice update details hide the Player selector by default and submit `sourceType: 'team'`
- Game recap only includes player payload fields after explicit `Tag a player` opt-in
- changing Team on a team-first preset keeps the selected `teamId` unless player tagging is enabled

## Recurrence Risk
Low. The composer now gates player scope behind explicit opt-in and the new integration tests cover the exact stale-state path that caused the regression.