### PR TITLE
Make edit-team Sports Connect state metadata-only

### DIFF
--- a/edit-team.html
+++ b/edit-team.html
@@ -453,8 +453,8 @@
                 <div class="rounded-lg border border-blue-200 bg-blue-50 p-4 space-y-3">
                     <div class="flex items-start justify-between gap-3">
                         <div>
-                            <h3 class="font-semibold text-blue-900 text-sm">Registration Provider Metadata</h3>
-                            <p class="text-xs text-blue-700 mt-1">Store registration metadata for this team. Sports Connect details are saved for reference only until a live connector exists. No provider login, sync job, or fetch runs from these fields.</p>
+                            <h3 class="font-semibold text-blue-900 text-sm">Registration Provider Connection</h3>
+                            <p class="text-xs text-blue-700 mt-1">Store registration metadata for this team. Sports Connect details are saved for reference only until a live connector exists. No provider login, sync job, or network call runs from these fields.</p>
                         </div>
                         <button id="clear-registration-provider-btn" type="button" class="shrink-0 px-3 py-1.5 bg-white border border-blue-200 text-blue-700 text-xs font-semibold rounded-lg hover:bg-blue-100 transition">
                             Clear

--- a/edit-team.html
+++ b/edit-team.html
@@ -453,8 +453,8 @@
                 <div class="rounded-lg border border-blue-200 bg-blue-50 p-4 space-y-3">
                     <div class="flex items-start justify-between gap-3">
                         <div>
-                            <h3 class="font-semibold text-blue-900 text-sm">Registration Provider Connection</h3>
-                            <p class="text-xs text-blue-700 mt-1">Configure registration metadata for this team. Sports Connect can be selected now. No provider login, sync job, or network call runs from these fields.</p>
+                            <h3 class="font-semibold text-blue-900 text-sm">Registration Provider Metadata</h3>
+                            <p class="text-xs text-blue-700 mt-1">Store registration metadata for this team. Sports Connect details are saved for reference only until a live connector exists. No provider login, sync job, or fetch runs from these fields.</p>
                         </div>
                         <button id="clear-registration-provider-btn" type="button" class="shrink-0 px-3 py-1.5 bg-white border border-blue-200 text-blue-700 text-xs font-semibold rounded-lg hover:bg-blue-100 transition">
                             Clear
@@ -470,7 +470,7 @@
                                 <option value="League Apps">League Apps</option>
                                 <option value="Other">Other documented source</option>
                             </select>
-                            <p class="text-xs text-blue-700 mt-1">Selecting Sports Connect saves metadata only until a connector is added.</p>
+                            <p class="text-xs text-blue-700 mt-1">Selecting Sports Connect stores metadata only. ALL PLAYS does not fetch live provider data yet.</p>
                         </div>
                         <div>
                             <label class="block text-sm font-medium text-gray-700">Sports Connect Team ID / External Mapping</label>
@@ -487,31 +487,31 @@
                                 placeholder="Save this team to generate a Team ID">
                         </div>
                         <div>
-                            <label class="block text-sm font-medium text-gray-700">Last Sync Status</label>
-                            <input type="text" id="registrationLastSyncStatus"
-                                class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-blue-500 focus:ring-blue-500 border p-2 bg-white"
-                                placeholder="Not synced">
+                            <label class="block text-sm font-medium text-gray-700">Saved Metadata Status</label>
+                            <input type="text" id="registrationLastSyncStatus" readonly
+                                class="mt-1 block w-full rounded-md border-gray-200 bg-white text-gray-600 shadow-sm border p-2"
+                                placeholder="Not configured">
                         </div>
                     </div>
                     <div class="rounded-lg border border-blue-200 bg-white p-3 text-sm text-slate-700 space-y-2">
                         <div class="grid gap-2 sm:grid-cols-3">
                             <div>
-                                <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Connection</p>
+                                <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Provider state</p>
                                 <p id="registration-connection-status" class="font-medium text-slate-900">Not configured</p>
                             </div>
                             <div>
-                                <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Last sync</p>
-                                <p id="registration-sync-status" class="font-medium text-slate-900">Not synced</p>
+                                <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Saved status</p>
+                                <p id="registration-sync-status" class="font-medium text-slate-900">Not configured</p>
                             </div>
                             <div>
-                                <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Last sync time</p>
-                                <p id="registration-sync-time" class="font-medium text-slate-900">Never</p>
+                                <p class="text-xs font-semibold uppercase tracking-wide text-slate-500">Last updated</p>
+                                <p id="registration-sync-time" class="font-medium text-slate-900">Not saved yet</p>
                             </div>
                         </div>
                         <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-                            <p id="registration-connection-help" class="text-xs text-blue-700">Use the manual entry point to re-import stored roster or schedule data. This does not fetch new Sports Connect data.</p>
-                            <button id="registration-refresh-btn" type="button" class="shrink-0 px-3 py-1.5 bg-blue-600 text-white text-xs font-semibold rounded-lg hover:bg-blue-700 transition">
-                                Manual refresh / re-import
+                            <p id="registration-connection-help" class="text-xs text-blue-700">This section stores provider references only. Manual refresh stays unavailable until a real Sports Connect connector is implemented.</p>
+                            <button id="registration-refresh-btn" type="button" disabled aria-disabled="true" class="shrink-0 cursor-not-allowed rounded-lg border border-slate-200 bg-slate-100 px-3 py-1.5 text-xs font-semibold text-slate-500">
+                                Manual refresh unavailable
                             </button>
                         </div>
                     </div>
@@ -739,7 +739,7 @@
         }
 
         function formatRegistrationSyncTime(value) {
-            if (!value) return 'Never';
+            if (!value) return 'Not saved yet';
             const parsed = new Date(value);
             if (Number.isNaN(parsed.getTime())) {
                 return value;
@@ -770,6 +770,19 @@
             return isSportsConnectProvider(provider) ? 'sports-connect' : '';
         }
 
+        function getRegistrationMetadataStatus(provider, externalTeamId) {
+            if (!provider) {
+                return 'Not configured';
+            }
+            if (!externalTeamId) {
+                return 'Metadata incomplete. Add provider mapping.';
+            }
+            if (isSportsConnectProvider(provider)) {
+                return 'Sports Connect metadata only. No live sync.';
+            }
+            return 'Registration metadata only. No live sync.';
+        }
+
         function ensureRegistrationProviderOption(provider) {
             const normalizedProvider = String(provider || '').trim();
             if (!normalizedProvider || ['', 'Sports Connect', 'League Apps', 'Other'].includes(normalizedProvider)) {
@@ -790,24 +803,21 @@
         function renderRegistrationConnectionStatus(source = {}) {
             const provider = document.getElementById('registrationProviderName').value.trim();
             const externalTeamId = document.getElementById('registrationExternalTeamId').value.trim();
-            const lastSyncStatus = document.getElementById('registrationLastSyncStatus').value.trim() || 'Not synced';
+            const metadataStatus = getRegistrationMetadataStatus(provider, externalTeamId);
             const lastSyncTime = getRegistrationLastSyncTime(source);
-            const isSportsConnect = isSportsConnectProvider(provider);
-            let connectionStatus = 'Not configured';
-            let helpText = 'Choose Sports Connect and enter a team ID or mapping to store registration metadata.';
+            let helpText = 'Choose a provider and team mapping to save metadata only. No live Sports Connect fetch runs yet.';
 
             if (provider && externalTeamId) {
-                connectionStatus = isSportsConnect
-                    ? 'Sports Connect metadata configured, not connected'
-                    : 'Registration metadata configured, not connected';
-                helpText = 'Manual refresh / re-import uses already stored roster or schedule data. It does not contact Sports Connect or another provider.';
+                helpText = isSportsConnectProvider(provider)
+                    ? 'Sports Connect is saved as metadata only for this team. Manual refresh stays unavailable until a live connector exists.'
+                    : 'This provider mapping is saved as metadata only. Manual refresh stays unavailable until a live connector exists.';
             } else if (provider) {
-                connectionStatus = `${provider} selected, mapping needed`;
-                helpText = 'Enter a provider team ID or external mapping before relying on this metadata.';
+                helpText = 'Add the provider team ID or mapping to finish saving metadata. No live provider fetch runs yet.';
             }
 
-            document.getElementById('registration-connection-status').textContent = connectionStatus;
-            document.getElementById('registration-sync-status').textContent = lastSyncStatus;
+            document.getElementById('registrationLastSyncStatus').value = metadataStatus;
+            document.getElementById('registration-connection-status').textContent = metadataStatus;
+            document.getElementById('registration-sync-status').textContent = metadataStatus;
             document.getElementById('registration-sync-time').textContent = formatRegistrationSyncTime(lastSyncTime);
             document.getElementById('registration-connection-help').textContent = helpText;
         }
@@ -824,7 +834,6 @@
             ensureRegistrationProviderOption(provider);
             document.getElementById('registrationProviderName').value = provider;
             document.getElementById('registrationExternalTeamId').value = getRegistrationSourceValue(team, 'externalTeamId');
-            document.getElementById('registrationLastSyncStatus').value = getRegistrationSourceValue(team, 'lastSyncStatus') || getRegistrationSourceValue(team, 'syncStatus') || 'Not synced';
             document.getElementById('registrationCopiedTeamId').value = currentTeamId || '';
             renderRegistrationConnectionStatus(currentRegistrationSource || {});
         }
@@ -839,8 +848,8 @@
         function buildRegistrationSourcePayload() {
             const provider = document.getElementById('registrationProviderName').value.trim();
             const externalTeamId = document.getElementById('registrationExternalTeamId').value.trim();
-            const lastSyncStatus = document.getElementById('registrationLastSyncStatus').value.trim();
-            if (!provider && !externalTeamId && !lastSyncStatus) {
+            const metadataStatus = getRegistrationMetadataStatus(provider, externalTeamId);
+            if (!provider && !externalTeamId) {
                 return null;
             }
             return {
@@ -851,7 +860,7 @@
                 teamId: currentTeamId || null,
                 connectionStatus: provider && externalTeamId ? 'metadata_configured' : 'metadata_incomplete',
                 syncEnabled: false,
-                lastSyncStatus: lastSyncStatus || 'Not synced'
+                lastSyncStatus: metadataStatus
             };
         }
 
@@ -1403,12 +1412,10 @@
         });
 
         document.getElementById('clear-registration-provider-btn').addEventListener('click', clearRegistrationProviderFields);
-        ['registrationProviderName', 'registrationExternalTeamId', 'registrationLastSyncStatus'].forEach((id) => {
+        document.getElementById('registration-refresh-btn').disabled = true;
+        ['registrationProviderName', 'registrationExternalTeamId'].forEach((id) => {
             document.getElementById(id).addEventListener('input', () => renderRegistrationConnectionStatus(currentRegistrationSource || {}));
             document.getElementById(id).addEventListener('change', () => renderRegistrationConnectionStatus(currentRegistrationSource || {}));
-        });
-        document.getElementById('registration-refresh-btn').addEventListener('click', () => {
-            alert('Manual re-import uses registration data already stored on this team. No Sports Connect login, sync job, or network fetch is active yet.');
         });
 
         document.getElementById('copy-team-id-btn').addEventListener('click', async () => {

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -1089,14 +1089,15 @@ describe('edit team admin access persistence', () => {
             expect(env.elements.get('registrationProviderName').value).toBe('Sports Connect');
             expect(env.elements.get('registrationExternalTeamId').value).toBe('SC-123');
             expect(env.elements.get('registrationCopiedTeamId').value).toBe('team-1');
-            expect(env.elements.get('registrationLastSyncStatus').value).toBe('Not synced');
-            expect(env.elements.get('registration-connection-status').textContent).toBe('Sports Connect metadata configured, not connected');
-            expect(env.elements.get('registration-sync-status').textContent).toBe('Not synced');
+            expect(env.elements.get('registrationLastSyncStatus').value).toBe('Sports Connect metadata only. No live sync.');
+            expect(env.elements.get('registration-connection-status').textContent).toBe('Sports Connect metadata only. No live sync.');
+            expect(env.elements.get('registration-sync-status').textContent).toBe('Sports Connect metadata only. No live sync.');
             expect(env.elements.get('registration-sync-time').textContent).toContain('2026');
+            expect(env.elements.get('registration-refresh-btn').disabled).toBe(true);
 
             env.elements.get('registrationProviderName').value = 'League Apps';
             env.elements.get('registrationExternalTeamId').value = 'LA-456';
-            env.elements.get('registrationLastSyncStatus').value = 'Documented only';
+            await env.elements.get('registrationProviderName').dispatchEvent(new MockEvent('change'));
             await env.elements.get('team-form').requestSubmit();
 
             expect(env.state.updateCalls).toHaveLength(1);
@@ -1111,7 +1112,7 @@ describe('edit team admin access persistence', () => {
                 providerId: null,
                 connectionStatus: 'metadata_configured',
                 syncEnabled: false,
-                lastSyncStatus: 'Documented only',
+                lastSyncStatus: 'Registration metadata only. No live sync.',
                 lastSyncAt: '2026-05-10T18:30:00.000Z'
             });
 
@@ -1150,11 +1151,11 @@ describe('edit team admin access persistence', () => {
             env.elements.get('registrationExternalTeamId').value = 'SC-987';
             await env.elements.get('registrationProviderName').dispatchEvent(new MockEvent('change'));
 
-            expect(env.elements.get('registration-connection-status').textContent).toBe('Sports Connect metadata configured, not connected');
-            expect(env.elements.get('registration-connection-help').textContent).toContain('does not contact Sports Connect');
-
-            await env.elements.get('registration-refresh-btn').click();
-            expect(env.alerts.at(-1)).toContain('No Sports Connect login, sync job, or network fetch is active yet');
+            expect(env.elements.get('registrationLastSyncStatus').value).toBe('Sports Connect metadata only. No live sync.');
+            expect(env.elements.get('registration-connection-status').textContent).toBe('Sports Connect metadata only. No live sync.');
+            expect(env.elements.get('registration-sync-status').textContent).toBe('Sports Connect metadata only. No live sync.');
+            expect(env.elements.get('registration-connection-help').textContent).toContain('metadata only');
+            expect(env.elements.get('registration-refresh-btn').disabled).toBe(true);
 
             await env.elements.get('team-form').requestSubmit();
 
@@ -1165,7 +1166,7 @@ describe('edit team admin access persistence', () => {
                 teamId: 'team-1',
                 connectionStatus: 'metadata_configured',
                 syncEnabled: false,
-                lastSyncStatus: 'Not synced'
+                lastSyncStatus: 'Sports Connect metadata only. No live sync.'
             });
         } finally {
             env.cleanup();

--- a/tests/unit/edit-team-admin-access-persistence.test.js
+++ b/tests/unit/edit-team-admin-access-persistence.test.js
@@ -613,6 +613,8 @@ describe('edit team admin access persistence', () => {
         expect(html.indexOf('id="isPublic"')).toBeLessThan(advancedIndex);
         expect(html.indexOf('id="teamColorPrimary"')).toBeGreaterThan(advancedIndex);
         expect(html.indexOf('id="registrationProviderName"')).toBeGreaterThan(advancedIndex);
+        expect(html).toContain('Registration Provider Connection');
+        expect(html).toContain('No provider login, sync job, or network call runs from these fields.');
 
         const createEnv = await bootEditTeam({
             currentUser: { uid: 'owner-1', email: 'owner@example.com' },


### PR DESCRIPTION
Closes #2209

## What changed
- renamed the edit-team registration section so it consistently presents provider metadata, not a live connection
- replaced user-editable sync wording with derived metadata-only status text for configured providers, including Sports Connect
- disabled the manual refresh / re-import action and updated helper copy to state that no live provider fetch exists yet
- updated focused unit coverage to assert the metadata-only status model and unavailable refresh control

## Root Cause
The edit-team form reused live-sync language and a user-editable `lastSyncStatus` field from an unfinished connector concept, so saved Sports Connect metadata could coexist with connection/sync labels and an active refresh button that implied a real provider integration existed.

## Prevention / Learning
When a provider workflow is metadata-only, derive and render a single non-editable status from persisted fields instead of exposing free-form sync state or active controls that imply unavailable backend capabilities.

## Regression Tests
- `npx vitest run tests/unit/edit-team-admin-access-persistence.test.js --reporter=verbose`
- updated `tests/unit/edit-team-admin-access-persistence.test.js` to verify Sports Connect reloads with a metadata-only status, persists the normalized metadata status, and keeps manual refresh disabled