### PR TITLE
Clarify roster import empty state

### DIFF
--- a/edit-roster.html
+++ b/edit-roster.html
@@ -54,8 +54,8 @@
                     <div id="registration-roster-import" class="hidden border-b border-emerald-200 bg-emerald-50 p-4">
                         <div class="flex items-start justify-between gap-3">
                             <div>
-                                <h3 class="font-semibold text-emerald-900">Import from registration provider</h3>
-                                <p class="text-sm text-emerald-800">Preview players and guardian/contact records from the latest registration snapshot before importing.</p>
+                                <h3 id="registration-roster-import-title" class="font-semibold text-emerald-900">Import stored registration roster</h3>
+                                <p id="registration-roster-import-description" class="text-sm text-emerald-800">Preview players and guardian/contact records from the latest stored registration snapshot before importing. This uses saved provider data only and does not fetch Sports Connect live.</p>
                                 <p id="registration-roster-import-status" class="mt-2 text-sm text-emerald-700"></p>
                             </div>
                             <button id="registration-roster-preview-btn" type="button"
@@ -553,7 +553,7 @@
         import { checkAuth, sendInviteEmail } from './js/auth.js?v=22';
         import { renderTeamAdminBanner } from './js/team-admin-banner.js';
         import { hasFullTeamAccess, normalizeTeamPermissions } from './js/team-access.js';
-        import { formatRegistrationRosterImportResults, getRegistrationRosterPlayers, isExternallyLinkedRosterTeam, planRegistrationRosterImport } from './js/edit-roster-registration-import.js?v=1';
+        import { formatRegistrationRosterImportResults, getRegistrationRosterPlayers, hasConfiguredRegistrationProviderMetadata, isExternallyLinkedRosterTeam, planRegistrationRosterImport } from './js/edit-roster-registration-import.js?v=2';
         import { buildRegistrationReviewCsv, buildRegistrationReviewCsvFilename, getDefaultRegistrationReviewCsvColumnKeys, getRegistrationReviewCsvColumnDefinitions, matchesRegistrationReviewScreeningStatus, summarizeRegistrationReviewScreening } from './js/registration-review.js?v=5';
         import { buildRosterPrintHtml } from './js/roster-print.js?v=2';
         import { getApp } from './js/vendor/firebase-app.js';
@@ -924,11 +924,13 @@
 
         function renderRegistrationRosterImport(team = {}) {
             const container = document.getElementById('registration-roster-import');
+            const title = document.getElementById('registration-roster-import-title');
+            const description = document.getElementById('registration-roster-import-description');
             const status = document.getElementById('registration-roster-import-status');
             const previewButton = document.getElementById('registration-roster-preview-btn');
             const importButton = document.getElementById('registration-roster-import-btn');
             const preview = document.getElementById('registration-roster-import-preview');
-            if (!container || !status || !previewButton || !importButton || !preview) return;
+            if (!container || !title || !description || !status || !previewButton || !importButton || !preview) return;
 
             registrationRosterImportPlan = null;
             container.classList.remove('hidden');
@@ -936,16 +938,30 @@
             preview.innerHTML = '';
 
             const sourcePlayers = getRegistrationRosterPlayers(team);
-            const hasSnapshot = isExternallyLinkedRosterTeam(team);
-            previewButton.disabled = !hasSnapshot || sourcePlayers.length === 0;
+            const hasStoredSnapshot = isExternallyLinkedRosterTeam(team);
+            const hasConfiguredMetadata = hasConfiguredRegistrationProviderMetadata(team);
+            const hasImportableSnapshot = hasStoredSnapshot && sourcePlayers.length > 0;
+
+            title.textContent = hasConfiguredMetadata && !hasImportableSnapshot
+                ? 'Registration provider metadata saved'
+                : 'Import stored registration roster';
+            description.textContent = hasImportableSnapshot
+                ? 'Preview players and guardian/contact records from the latest stored registration snapshot before importing. This uses saved provider data only and does not fetch Sports Connect live.'
+                : (hasConfiguredMetadata
+                    ? 'Sports Connect metadata is saved for this team, but roster import only works after a registration roster snapshot has been stored. This page does not fetch provider data live.'
+                    : 'Roster import works from a stored registration snapshot. Connect a provider and save provider data before importing here.');
+
+            previewButton.classList.toggle('hidden', !hasImportableSnapshot);
+            importButton.classList.toggle('hidden', !hasImportableSnapshot);
+            previewButton.disabled = !hasImportableSnapshot;
             previewButton.classList.toggle('opacity-50', previewButton.disabled);
             importButton.disabled = true;
             importButton.classList.toggle('opacity-50', importButton.disabled);
-            status.textContent = hasSnapshot
-                ? (sourcePlayers.length > 0
-                    ? `${sourcePlayers.length} player${sourcePlayers.length === 1 ? '' : 's'} available in the latest source snapshot. Preview before importing.`
-                    : 'No roster players were found in the latest source snapshot.')
-                : 'No registration provider data is available yet. Connect or load a registration roster snapshot before importing.';
+            status.textContent = hasImportableSnapshot
+                ? `${sourcePlayers.length} player${sourcePlayers.length === 1 ? '' : 's'} available in the latest stored roster snapshot. Preview before importing.`
+                : (hasConfiguredMetadata
+                    ? 'Required next step: save or load a registration roster snapshot for this team, then return here to preview and import the stored data.'
+                    : 'No registration provider data is available yet. Connect a provider and save a registration roster snapshot before importing.');
         }
 
         async function handleRegistrationRosterPreview() {
@@ -955,9 +971,9 @@
 
             const sourcePlayers = getRegistrationRosterPlayers(currentTeam);
             if (sourcePlayers.length === 0) {
-                status.textContent = isExternallyLinkedRosterTeam(currentTeam)
-                    ? 'No roster players were found in the latest source snapshot.'
-                    : 'No registration provider data is available yet. Connect or load a registration roster snapshot before importing.';
+                status.textContent = hasConfiguredRegistrationProviderMetadata(currentTeam)
+                    ? 'No stored registration roster snapshot is available yet. Save or load provider data for this team before previewing import.'
+                    : 'No registration provider data is available yet. Connect a provider and save a registration roster snapshot before previewing import.';
                 return;
             }
 

--- a/js/edit-roster-registration-import.js
+++ b/js/edit-roster-registration-import.js
@@ -312,7 +312,7 @@ function buildPreviewRow({ status, sourcePlayer = {}, payload = null, existingPl
 }
 
 export function hasConfiguredRegistrationProviderMetadata(team = {}) {
-    const source = asObject(team.registrationSource);
+    const source = firstNonEmptyObject(team.registrationSource, team.registrationProvider);
     return !!(
         team.registrationSourceId ||
         team.externalRegistrationTeamId ||

--- a/js/edit-roster-registration-import.js
+++ b/js/edit-roster-registration-import.js
@@ -311,6 +311,22 @@ function buildPreviewRow({ status, sourcePlayer = {}, payload = null, existingPl
     };
 }
 
+export function hasConfiguredRegistrationProviderMetadata(team = {}) {
+    const source = asObject(team.registrationSource);
+    return !!(
+        team.registrationSourceId ||
+        team.externalRegistrationTeamId ||
+        source.provider ||
+        source.providerId ||
+        source.providerName ||
+        source.externalTeamId ||
+        source.teamId ||
+        source.connectionStatus ||
+        source.lastSyncStatus ||
+        source.syncStatus
+    );
+}
+
 export function isExternallyLinkedRosterTeam(team = {}) {
     return !!(
         team.registrationSourceSnapshot ||

--- a/tests/smoke/team-fallback-regressions.spec.js
+++ b/tests/smoke/team-fallback-regressions.spec.js
@@ -146,6 +146,9 @@ export function getRegistrationRosterPlayers() {
 export function isExternallyLinkedRosterTeam() {
     return false;
 }
+export function hasConfiguredRegistrationProviderMetadata() {
+    return false;
+}
 export function planRegistrationRosterImport() {
     return { operations: [], results: { conflicts: [] } };
 }

--- a/tests/unit/edit-roster-registration-import.test.js
+++ b/tests/unit/edit-roster-registration-import.test.js
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import {
     formatRegistrationRosterImportResults,
     getRegistrationRosterPlayers,
+    hasConfiguredRegistrationProviderMetadata,
     isExternallyLinkedRosterTeam,
     planRegistrationRosterImport
 } from '../../js/edit-roster-registration-import.js';
@@ -12,7 +13,10 @@ function readEditRoster() {
 }
 
 describe('registration roster import planning', () => {
-    it('detects linked roster teams and source roster snapshots', () => {
+    it('distinguishes configured provider metadata from stored import snapshots', () => {
+        expect(hasConfiguredRegistrationProviderMetadata({})).toBe(false);
+        expect(hasConfiguredRegistrationProviderMetadata({ registrationSourceId: 'sports-connect' })).toBe(true);
+        expect(hasConfiguredRegistrationProviderMetadata({ registrationSource: { provider: 'Sports Connect', externalTeamId: 'team-123' } })).toBe(true);
         expect(isExternallyLinkedRosterTeam({})).toBe(false);
         expect(isExternallyLinkedRosterTeam({ registrationSourceId: 'sports-connect' })).toBe(false);
         expect(isExternallyLinkedRosterTeam({ registrationSource: { rosterPlayers: [{ id: 'p1' }] } })).toBe(true);
@@ -345,15 +349,19 @@ describe('registration roster import wiring', () => {
         const source = readEditRoster();
 
         expect(source).toContain('id="registration-roster-import"');
-        expect(source).toContain('Import from registration provider');
+        expect(source).toContain('id="registration-roster-import-title"');
+        expect(source).toContain('Import stored registration roster');
         expect(source).toContain('Preview Import');
-        expect(source).toContain("import { formatRegistrationRosterImportResults, getRegistrationRosterPlayers, isExternallyLinkedRosterTeam, planRegistrationRosterImport } from './js/edit-roster-registration-import.js?v=1';");
+        expect(source).toContain("import { formatRegistrationRosterImportResults, getRegistrationRosterPlayers, hasConfiguredRegistrationProviderMetadata, isExternallyLinkedRosterTeam, planRegistrationRosterImport } from './js/edit-roster-registration-import.js?v=2';");
+        expect(source).toContain('hasConfiguredRegistrationProviderMetadata(team)');
+        expect(source).toContain('Registration provider metadata saved');
+        expect(source).toContain('This page does not fetch provider data live.');
+        expect(source).toContain('save or load a registration roster snapshot for this team');
         expect(source).toContain('planRegistrationRosterImport({');
         expect(source).toContain('renderRegistrationRosterImportPreview');
         expect(source).toContain('registration-roster-import-row');
         expect(source).toContain('selectedOperationIds');
         expect(source).toContain('Conflicted rows are skipped automatically');
-        expect(source).toContain('No registration provider data is available yet.');
         expect(source).toContain('fields: rosterFieldDefinitions');
         expect(source).toContain('setPlayerPrivateRosterProfileFields(currentTeamId, playerId, operation.privateRosterFields)');
         expect(source).toContain('function getPlayerImportSourceType');

--- a/tests/unit/edit-roster-registration-import.test.js
+++ b/tests/unit/edit-roster-registration-import.test.js
@@ -17,6 +17,7 @@ describe('registration roster import planning', () => {
         expect(hasConfiguredRegistrationProviderMetadata({})).toBe(false);
         expect(hasConfiguredRegistrationProviderMetadata({ registrationSourceId: 'sports-connect' })).toBe(true);
         expect(hasConfiguredRegistrationProviderMetadata({ registrationSource: { provider: 'Sports Connect', externalTeamId: 'team-123' } })).toBe(true);
+        expect(hasConfiguredRegistrationProviderMetadata({ registrationProvider: { providerName: 'Sports Connect', externalTeamId: 'team-legacy' } })).toBe(true);
         expect(isExternallyLinkedRosterTeam({})).toBe(false);
         expect(isExternallyLinkedRosterTeam({ registrationSourceId: 'sports-connect' })).toBe(false);
         expect(isExternallyLinkedRosterTeam({ registrationSource: { rosterPlayers: [{ id: 'p1' }] } })).toBe(true);


### PR DESCRIPTION
Closes #2210

## What changed
- distinguished saved registration provider metadata from actual stored roster snapshot data in `js/edit-roster-registration-import.js`
- updated `edit-roster.html` import panel copy and state handling so metadata-only teams no longer look immediately importable
- hid the preview/import actions until a stored roster snapshot exists and added explicit next-step messaging for admins
- added regression coverage in `tests/unit/edit-roster-registration-import.test.js` for the metadata-vs-snapshot split and the updated roster import wiring copy

## Root Cause
The roster import page used `isExternallyLinkedRosterTeam()` as both a provider-configuration check and an import-readiness check. That helper only recognized snapshot-like roster data, while the page kept static import-focused copy, so metadata-only Sports Connect teams fell into a generic empty state that did not explain the missing stored snapshot prerequisite.

## Prevention / Learning
When a workflow depends on staged external data, model and test the states separately: provider metadata configured, stored snapshot available, and importable records present. Do not reuse a single "linked" helper for both configuration detection and operational readiness if the product only supports stored-data imports.

## Regression Tests
- `npx vitest run tests/unit/edit-roster-registration-import.test.js --reporter=verbose`
- unit assertions now verify metadata-only teams are detected separately from stored import snapshots
- static wiring assertions now verify the roster page copy explains that imports use stored data and require a saved roster snapshot before preview/import actions appear