### PR TITLE
Lazy-mount optional Game Hub panels

### DIFF
--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -763,6 +763,74 @@ describe('ScheduleEventDetail assignments', () => {
     });
   });
 
+  it('resets deferred game hub panels before rendering a switched event', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockImplementation(async (_user, { eventId }) => ({
+      events: [eventId === 'game-2'
+        ? buildEvent({
+            eventKey: 'team-1::game-2::player-1::2026-06-05T18:00:00.000Z::game',
+            id: 'game-2',
+            opponent: 'Lions',
+            liveStatus: 'completed',
+            status: 'completed',
+            canUpdateScore: true,
+            isTeamStaff: true
+          })
+        : buildEvent({
+            liveStatus: 'completed',
+            status: 'completed',
+            canUpdateScore: true,
+            isTeamStaff: true
+          })],
+      children: []
+    }));
+    scheduleServiceMocks.loadHomeScoringPlayers.mockResolvedValue([]);
+    gameReportServiceMocks.loadGameReportSections.mockImplementation(async (event) => ({
+      game: { id: event.id, liveStatus: 'completed', status: 'completed', homeScore: 42, awayScore: 38 },
+      plays: [],
+      summary: event.id === 'game-2' ? 'Second game report.' : 'First game report.',
+      opponentRows: [],
+      opponentStatKeys: [],
+      teamInsights: [],
+      playerInsightRows: [],
+      highlightClips: [],
+      statSheetPhotoUrl: null,
+      teamStatKeys: [],
+      teamStats: {},
+      statKeys: [],
+      playerRows: [],
+      statLabels: {},
+      hasPlayingTime: false,
+      team: { id: event.teamId }
+    }));
+
+    renderScheduleEventDetailWithRouteControls();
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'Game hub' })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Report sections' }));
+    await waitFor(() => {
+      expect(gameReportServiceMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('First game report.')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Switch game' }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /Lions/ })).toBeTruthy();
+    });
+    expect(screen.queryByText('First game report.')).toBeNull();
+    expect(screen.queryByText('Second game report.')).toBeNull();
+    expect(gameReportServiceMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Report sections' }));
+    await waitFor(() => {
+      expect(gameReportServiceMocks.loadGameReportSections).toHaveBeenCalledTimes(2);
+      expect(screen.getByText('Second game report.')).toBeTruthy();
+    });
+  });
+
   it('executes substitutions against shared game-day rotation fields and renders live logs', async () => {
     const gamePlan = {
       formationId: 'basketball-5v5',

--- a/apps/app/src/pages/ScheduleEventDetail.test.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.test.tsx
@@ -62,7 +62,10 @@ const publicActionMocks = vi.hoisted(() => ({
   sharePublicUrl: vi.fn()
 }));
 
-vi.mock('../lib/gameReportService', () => ({ loadGameReportSections: vi.fn() }));
+const gameReportServiceMocks = vi.hoisted(() => ({
+  loadGameReportSections: vi.fn()
+}));
+vi.mock('../lib/gameReportService', () => gameReportServiceMocks);
 const gameWrapupServiceMocks = vi.hoisted(() => ({
   buildAppWrapupCompletionPayload: vi.fn(({ homeScore, awayScore, postGameNotes }) => ({
     homeScore,
@@ -372,6 +375,7 @@ describe('ScheduleEventDetail assignments', () => {
     });
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Live reactions' }));
 
     await waitFor(() => {
       expect(screen.getByTestId('live-game-reactions-panel')).toBeTruthy();
@@ -407,6 +411,7 @@ describe('ScheduleEventDetail assignments', () => {
     });
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Live reactions' }));
 
     await waitFor(() => {
       expect(screen.getByText('Live reactions are closed during replay.')).toBeTruthy();
@@ -568,7 +573,7 @@ describe('ScheduleEventDetail assignments', () => {
       expect(scheduleServiceMocks.undoRecordedPlayerGameStat).toHaveBeenCalledWith('team-1', 'game-1', expect.objectContaining({ trackerEventId: 'tracker-foul-1', liveEventId: 'live-foul-1', statKey: 'fouls' }), auth.user);
     });
     expect(screen.getByLabelText('Team foul bonus state').textContent).toContain('Q1 · No bonus');
-    expect(screen.getByText('Undo #12 Avery Smith FOULS +1')).toBeTruthy();
+    expect(screen.getByText('Last foul undone.')).toBeTruthy();
 
     fireEvent.click(screen.getByRole('button', { name: 'Advance period' }));
 
@@ -610,6 +615,7 @@ describe('ScheduleEventDetail assignments', () => {
       expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
     });
     fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Live chat' }));
 
     await waitFor(() => {
       expect(screen.getByTestId('live-game-chat-panel')).toBeTruthy();
@@ -660,6 +666,7 @@ describe('ScheduleEventDetail assignments', () => {
       expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
     });
     fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Live chat' }));
 
     await waitFor(() => {
       expect(screen.getByText('Live chat is closed during replay.')).toBeTruthy();
@@ -668,6 +675,92 @@ describe('ScheduleEventDetail assignments', () => {
     expect((screen.getByLabelText('Live chat message') as HTMLTextAreaElement).disabled).toBe(true);
     expect((screen.getByRole('button', { name: 'Send' }) as HTMLButtonElement).disabled).toBe(true);
     expect(liveGameChatServiceMocks.sendLiveGameChatMessage).not.toHaveBeenCalled();
+  });
+
+  it('keeps deferred game hub panels idle until staff opens them', async () => {
+    scheduleServiceMocks.loadParentScheduleEventDetail.mockResolvedValue({
+      events: [buildEvent({
+        liveStatus: 'live',
+        status: 'live',
+        canUpdateScore: true,
+        isTeamStaff: true,
+        gamePlan: {
+          formationId: 'basketball-5v5',
+          lineups: { 'Q1-pg': 'p1' },
+          publishedLineups: {},
+          publishedVersion: 0
+        }
+      })],
+      children: []
+    });
+    scheduleServiceMocks.loadHomeScoringPlayers.mockResolvedValue([]);
+    scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp.mockResolvedValue({
+      formationId: 'basketball-5v5',
+      formationName: 'Basketball 5v5',
+      numPeriods: 4,
+      positions: [],
+      availablePlayers: [{ id: 'p1', name: 'Avery Smith', number: '1' }],
+      goingPlayers: [{ id: 'p1', name: 'Avery Smith', number: '1' }],
+      gamePlan: {
+        formationId: 'basketball-5v5',
+        lineups: { 'Q1-pg': 'p1' },
+        publishedLineups: {},
+        publishedVersion: 0
+      }
+    });
+    gameReportServiceMocks.loadGameReportSections.mockResolvedValue({
+      game: { id: 'game-1', liveStatus: 'completed', status: 'completed', homeScore: 42, awayScore: 38 },
+      plays: [],
+      summary: 'Loaded on demand.',
+      opponentRows: [],
+      opponentStatKeys: [],
+      teamInsights: [],
+      playerInsightRows: [],
+      highlightClips: [],
+      statSheetPhotoUrl: null,
+      teamStatKeys: [],
+      teamStats: {},
+      statKeys: [],
+      playerRows: [],
+      statLabels: {},
+      hasPlayingTime: false,
+      team: { id: 'team-1' }
+    });
+
+    renderScheduleEventDetailWithRouteControls();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('live-game-clock-panel')).toBeTruthy();
+    });
+    expect(screen.getByRole('button', { name: 'Home score up' })).toBeTruthy();
+    expect(liveGameChatServiceMocks.subscribeToLiveGameChat).not.toHaveBeenCalled();
+    expect(liveGameReactionsServiceMocks.subscribeToLiveGameReactions).not.toHaveBeenCalled();
+    expect(scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp).not.toHaveBeenCalled();
+    expect(gameReportServiceMocks.loadGameReportSections).not.toHaveBeenCalled();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Live chat' }));
+    await waitFor(() => {
+      expect(liveGameChatServiceMocks.subscribeToLiveGameChat).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('live-game-chat-panel')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Live reactions' }));
+    await waitFor(() => {
+      expect(liveGameReactionsServiceMocks.subscribeToLiveGameReactions).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('live-game-reactions-panel')).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Lineup builder' }));
+    await waitFor(() => {
+      expect(scheduleServiceMocks.loadAutoFilledLineupDraftPreviewForApp).toHaveBeenCalledTimes(1);
+      expect(screen.getByRole('button', { name: /#1 Avery Smith/i })).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Report sections' }));
+    await waitFor(() => {
+      expect(gameReportServiceMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
+      expect(screen.getByText('Loaded on demand.')).toBeTruthy();
+    });
   });
 
   it('executes substitutions against shared game-day rotation fields and renders live logs', async () => {
@@ -722,6 +815,7 @@ describe('ScheduleEventDetail assignments', () => {
       expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
     });
     fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Live substitutions' }));
 
     await waitFor(() => {
       expect(screen.getByTestId('game-day-substitution-panel')).toBeTruthy();
@@ -1306,9 +1400,10 @@ describe('ScheduleEventDetail wrap-up', () => {
       expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
     });
     fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Post-game wrap-up' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Post-game wrap-up')).toBeTruthy();
+      expect(screen.getByLabelText('Post-game notes')).toBeTruthy();
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Final home score up' }));
@@ -1359,9 +1454,10 @@ describe('ScheduleEventDetail wrap-up', () => {
       expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
     });
     fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Post-game wrap-up' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Post-game wrap-up')).toBeTruthy();
+      expect(screen.getByLabelText('Post-game notes')).toBeTruthy();
     });
 
     fireEvent.change(screen.getByLabelText('Post-game notes'), { target: { value: 'Finished stronger on the glass.' } });
@@ -1405,9 +1501,10 @@ describe('ScheduleEventDetail wrap-up', () => {
       expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
     });
     fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Post-game wrap-up' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Post-game wrap-up')).toBeTruthy();
+      expect(screen.getByLabelText('Post-game notes')).toBeTruthy();
     });
 
     fireEvent.click(screen.getByRole('checkbox', { name: 'Generate AI summary' }));
@@ -1452,9 +1549,10 @@ describe('ScheduleEventDetail wrap-up', () => {
       expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
     });
     fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Post-game wrap-up' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Post-game wrap-up')).toBeTruthy();
+      expect(screen.getByLabelText('Post-game notes')).toBeTruthy();
     });
 
     fireEvent.change(screen.getByLabelText('Post-game notes'), { target: { value: 'Finished stronger on the glass.' } });
@@ -1569,9 +1667,10 @@ describe('ScheduleEventDetail lineup builder', () => {
     });
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Lineup builder' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Lineup builder')).toBeTruthy();
+      expect(screen.getByTestId('lineup-slot-Q1-sg')).toBeTruthy();
     });
 
     fireEvent.click(screen.getByRole('button', { name: /#2 Blake Jones/i }));
@@ -1637,9 +1736,10 @@ describe('ScheduleEventDetail lineup builder', () => {
     });
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Lineup builder' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Lineup builder')).toBeTruthy();
+      expect(screen.getByTestId('lineup-slot-Q1-pg')).toBeTruthy();
     });
 
     const publishButton = screen.getByRole('button', { name: 'Publish lineup' }) as HTMLButtonElement;
@@ -1709,9 +1809,10 @@ describe('ScheduleEventDetail lineup builder', () => {
     });
 
     fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Lineup builder' }));
 
     await waitFor(() => {
-      expect(screen.getByText('Lineup builder')).toBeTruthy();
+      expect(screen.getByTestId('lineup-slot-Q1-pg')).toBeTruthy();
     });
 
     fireEvent.doubleClick(screen.getByTestId('lineup-slot-Q1-pg'));
@@ -1786,6 +1887,7 @@ describe('ScheduleEventDetail statsheet import', () => {
       expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
     });
     fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Statsheet import' }));
 
     await waitFor(() => {
       expect(screen.getByTestId('statsheet-import-panel')).toBeTruthy();
@@ -1836,6 +1938,7 @@ describe('ScheduleEventDetail statsheet import', () => {
       expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
     });
     fireEvent.click(screen.getAllByRole('button', { name: 'Game' })[0]);
+    fireEvent.click(screen.getByRole('button', { name: 'Statsheet import' }));
 
     const fileInput = rendered.container.querySelector('input[type="file"]') as HTMLInputElement;
     fireEvent.change(fileInput, { target: { files: [new File(['sheet'], 'statsheet.png', { type: 'image/png' })] } });
@@ -1900,6 +2003,12 @@ describe('ScheduleEventDetail statsheet import', () => {
     const rendered = renderScheduleEventDetailWithRouteControls();
 
     await waitFor(() => {
+      expect(screen.getAllByRole('button', { name: 'Game' }).length).toBeGreaterThan(0);
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Statsheet import' }));
+
+    await waitFor(() => {
       expect(screen.getByTestId('statsheet-import-panel')).toBeTruthy();
     });
 
@@ -1921,6 +2030,8 @@ describe('ScheduleEventDetail statsheet import', () => {
       expect(screen.queryByDisplayValue('Avery Smith')).toBeNull();
     });
     expect(screen.queryByAltText('Statsheet preview')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Statsheet import' }));
 
     fileInput = rendered.container.querySelector('input[type="file"]') as HTMLInputElement;
     fireEvent.change(fileInput, { target: { files: [new File(['sheet-2'], 'statsheet-2.png', { type: 'image/png' })] } });

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -695,7 +695,7 @@ export function ScheduleEventDetail({ auth }: { auth: AuthState }) {
             onAssignmentsChanged={handleAssignmentsChanged}
           />
         ) : null}
-        {activeSection === 'game' ? <GameHubSection auth={auth} event={selectedEvent} childEvents={events} onScoreUpdated={handleScoreUpdated} onLiveClockUpdated={handleLiveClockUpdated} onWrapupCompleted={handleWrapupCompleted} onStatsheetImported={handleStatsheetImported} onGameCancelled={handleGameCancelled} onPracticeOccurrenceCancelled={handlePracticeOccurrenceCancelled} onGamePlanPublished={handleGamePlanPublished} /> : null}
+        {activeSection === 'game' ? <GameHubSection key={selectedEvent.eventKey} auth={auth} event={selectedEvent} childEvents={events} onScoreUpdated={handleScoreUpdated} onLiveClockUpdated={handleLiveClockUpdated} onWrapupCompleted={handleWrapupCompleted} onStatsheetImported={handleStatsheetImported} onGameCancelled={handleGameCancelled} onPracticeOccurrenceCancelled={handlePracticeOccurrenceCancelled} onGamePlanPublished={handleGamePlanPublished} /> : null}
       </div>
     </div>
   );

--- a/apps/app/src/pages/ScheduleEventDetail.tsx
+++ b/apps/app/src/pages/ScheduleEventDetail.tsx
@@ -2076,10 +2076,47 @@ function LiveGameChatPanel({ auth, event }: { auth: AuthState; event: ParentSche
   );
 }
 
+function LazyGameHubPanel({
+  panelId,
+  title,
+  description,
+  open,
+  onToggle,
+  children
+}: {
+  panelId: string;
+  title: string;
+  description: string;
+  open: boolean;
+  onToggle: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <div className="mt-3">
+      <button
+        type="button"
+        className="flex min-h-11 w-full items-center justify-between gap-3 rounded-2xl border border-gray-200 bg-gray-50 px-4 py-3 text-left transition hover:border-primary-200 hover:bg-primary-50"
+        onClick={onToggle}
+        aria-label={title}
+        aria-expanded={open}
+        aria-controls={panelId}
+      >
+        <div className="min-w-0">
+          <div className="text-sm font-black text-gray-950">{title}</div>
+          <div className="mt-1 text-xs font-semibold text-gray-500">{description}</div>
+        </div>
+        <ChevronDown className={`h-4 w-4 flex-none text-gray-500 transition ${open ? 'rotate-180' : ''}`} aria-hidden="true" />
+      </button>
+      {open ? <div id={panelId}>{children}</div> : null}
+    </div>
+  );
+}
+
 function GameHubSection({ auth, event, childEvents, onScoreUpdated, onLiveClockUpdated, onWrapupCompleted, onStatsheetImported, onGameCancelled, onPracticeOccurrenceCancelled, onGamePlanPublished }: { auth: AuthState; event: ParentScheduleEvent; childEvents: ParentScheduleEvent[]; onScoreUpdated: (homeScore: number, awayScore: number) => void; onLiveClockUpdated: (payload: Partial<ParentScheduleEvent> & { period?: string | null }) => void; onWrapupCompleted: (payload: { homeScore: number; awayScore: number; postGameNotes: string; summary: string; practiceFeedItems: PracticeFeedItem[] }) => void; onStatsheetImported: (payload: { homeScore: number; awayScore: number; statSheetPhotoUrl?: string | null }) => void; onGameCancelled: () => void; onPracticeOccurrenceCancelled: () => void; onGamePlanPublished: (gamePlan: Record<string, any>) => void }) {
   const [shareStatus, setShareStatus] = useState<string | null>(null);
   const [cancelStatus, setCancelStatus] = useState<{ tone: 'success' | 'error'; message: string } | null>(null);
   const [cancelling, setCancelling] = useState(false);
+  const [openPanels, setOpenPanels] = useState<Record<string, boolean>>({});
   const statusLabel = getEventStatusLabel(event);
   const scoreLabel = getScoreLabel(event);
   const [liveClockNow, setLiveClockNow] = useState(() => new Date());
@@ -2099,6 +2136,17 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onLiveClockU
     const intervalId = window.setInterval(() => setLiveClockNow(new Date()), 1000);
     return () => window.clearInterval(intervalId);
   }, [event.eventKey, event.liveClockRunning, event.liveClockMs, event.liveClockUpdatedAt]);
+
+  useEffect(() => {
+    setOpenPanels({});
+  }, [event.eventKey]);
+
+  const togglePanel = useCallback((panelId: string) => {
+    setOpenPanels((current) => ({
+      ...current,
+      [panelId]: !current[panelId]
+    }));
+  }, []);
 
   const cancelGame = async () => {
     if (!auth.user) return;
@@ -2197,19 +2245,76 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onLiveClockU
           {canUpdateScore ? <LiveGameClockPanel auth={auth} event={event} onLiveClockUpdated={onLiveClockUpdated} /> : null}
           {canUpdateScore ? <LiveScoreEditor auth={auth} event={event} onScoreUpdated={onScoreUpdated} /> : null}
           {canUpdateScore ? <GameDayFoulTrackerPanel auth={auth} event={event} /> : null}
-          {!isPractice ? <LiveGameReactionsPanel auth={auth} event={event} /> : null}
-          {!isPractice ? <LiveGameChatPanel auth={auth} event={event} /> : null}
 
-          {canWrapup ? <GameWrapupPanel auth={auth} event={event} onWrapupCompleted={onWrapupCompleted} /> : null}
+          {!isPractice ? (
+            <LazyGameHubPanel
+              panelId="game-hub-reactions-panel"
+              title="Live reactions"
+              description="Start the shared reaction stream only when you need it."
+              open={Boolean(openPanels.reactions)}
+              onToggle={() => togglePanel('reactions')}
+            >
+              <LiveGameReactionsPanel auth={auth} event={event} />
+            </LazyGameHubPanel>
+          ) : null}
+          {!isPractice ? (
+            <LazyGameHubPanel
+              panelId="game-hub-chat-panel"
+              title="Live chat"
+              description="Open chat on demand instead of subscribing during first paint."
+              open={Boolean(openPanels.chat)}
+              onToggle={() => togglePanel('chat')}
+            >
+              <LiveGameChatPanel auth={auth} event={event} />
+            </LazyGameHubPanel>
+          ) : null}
 
-          {canWrapup ? <StatsheetImportPanel event={event} onImported={onStatsheetImported} /> : null}
+          {canWrapup ? (
+            <LazyGameHubPanel
+              panelId="game-hub-wrapup-panel"
+              title="Post-game wrap-up"
+              description="Load wrap-up tools only when staff is ready to finish the game."
+              open={Boolean(openPanels.wrapup)}
+              onToggle={() => togglePanel('wrapup')}
+            >
+              <GameWrapupPanel auth={auth} event={event} onWrapupCompleted={onWrapupCompleted} />
+            </LazyGameHubPanel>
+          ) : null}
 
-          {canPublishLineup ? (
-            <GameHubLineupBuilderPanel auth={auth} event={event} onGamePlanSaved={onGamePlanPublished} />
+          {canWrapup ? (
+            <LazyGameHubPanel
+              panelId="game-hub-statsheet-panel"
+              title="Statsheet import"
+              description="Defer photo analysis and roster context until someone opens import."
+              open={Boolean(openPanels.statsheet)}
+              onToggle={() => togglePanel('statsheet')}
+            >
+              <StatsheetImportPanel event={event} onImported={onStatsheetImported} />
+            </LazyGameHubPanel>
           ) : null}
 
           {canPublishLineup ? (
-            <GameDaySubstitutionPanel auth={auth} event={event} />
+            <LazyGameHubPanel
+              panelId="game-hub-lineup-panel"
+              title="Lineup builder"
+              description="Only load lineup preview data after staff opens lineup tools."
+              open={Boolean(openPanels.lineup)}
+              onToggle={() => togglePanel('lineup')}
+            >
+              <GameHubLineupBuilderPanel auth={auth} event={event} onGamePlanSaved={onGamePlanPublished} />
+            </LazyGameHubPanel>
+          ) : null}
+
+          {canPublishLineup ? (
+            <LazyGameHubPanel
+              panelId="game-hub-substitutions-panel"
+              title="Live substitutions"
+              description="Keep substitution planning idle until the bench actually needs it."
+              open={Boolean(openPanels.substitutions)}
+              onToggle={() => togglePanel('substitutions')}
+            >
+              <GameDaySubstitutionPanel auth={auth} event={event} />
+            </LazyGameHubPanel>
           ) : null}
 
           {canCancelGame ? (
@@ -2269,7 +2374,17 @@ function GameHubSection({ auth, event, childEvents, onScoreUpdated, onLiveClockU
 
       {shareStatus ? <Status tone={shareStatus.startsWith('Unable') ? 'error' : 'success'} message={shareStatus} /> : null}
       {cancelStatus ? <Status tone={cancelStatus.tone} message={cancelStatus.message} /> : null}
-      {!isPractice ? <GameReportSections event={event} /> : null}
+      {!isPractice ? (
+        <LazyGameHubPanel
+          panelId="game-hub-report-panel"
+          title="Report sections"
+          description="Load reports and live play refreshes only when someone opens reports."
+          open={Boolean(openPanels.report)}
+          onToggle={() => togglePanel('report')}
+        >
+          <GameReportSections event={event} />
+        </LazyGameHubPanel>
+      ) : null}
     </section>
   );
 }

--- a/tests/smoke/app-schedule.spec.js
+++ b/tests/smoke/app-schedule.spec.js
@@ -1031,6 +1031,7 @@ test('app schedule event detail exposes parent actions and RSVP', async ({ page,
     await page.getByRole('button', { name: 'Game', exact: true }).click();
     await expect(page.getByRole('heading', { name: 'Game hub' })).toBeVisible();
     await expect(page.getByText('Report sections')).toBeVisible();
+    await page.getByRole('button', { name: 'Report sections' }).click();
     await expect(page.getByText('Pat helped set the tone early and the team finished strong.')).toBeVisible();
     const reportSections = page.locator('.app-card').filter({ has: page.getByText('Report sections') });
     await expect(reportSections.locator('strong').filter({ hasText: 'Strong start' })).toBeVisible();

--- a/tests/unit/app-schedule-more-tab-integration.test.jsx
+++ b/tests/unit/app-schedule-more-tab-integration.test.jsx
@@ -448,6 +448,7 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         await waitForText(container, 'vs. Falcons');
         await clickButton(container, 'Game');
         await waitForText(container, 'Report sections');
+        await clickButton(container, 'Report sections');
         await waitForText(container, 'Match Summary');
 
         expect(queryButtonByText(container, 'Summary')).not.toBeNull();
@@ -481,6 +482,7 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         await waitForText(container, 'vs. Falcons');
         await clickButton(container, 'Game');
         await waitForText(container, 'Report sections');
+        await clickButton(container, 'Report sections');
         await waitForText(container, 'Match Summary');
 
         expect(queryButtonByText(container, 'Opponent')).not.toBeNull();
@@ -500,6 +502,7 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         await waitForText(container, 'vs. Falcons');
         await clickButton(container, 'Game');
         await waitForText(container, 'Report sections');
+        await clickButton(container, 'Report sections');
         await waitForText(container, 'Match Summary');
 
         expect(reportMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
@@ -530,6 +533,7 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         await waitForText(container, 'vs. Falcons');
         await clickButton(container, 'Game');
         await waitForText(container, 'Report sections');
+        await clickButton(container, 'Report sections');
         await waitForText(container, 'Match Summary');
 
         expect(reportMocks.loadGameReportSections).toHaveBeenCalledTimes(1);
@@ -799,6 +803,7 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         await waitForText(container, 'vs. Falcons');
         await clickButton(container, 'Game');
         await waitForText(container, 'Lineup builder');
+        await clickButton(container, 'Lineup builder');
         await waitForText(container, 'No lineup draft is available yet.');
 
         expect(container.querySelector('#game-hub-lineup-formation')).not.toBeNull();
@@ -815,6 +820,7 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         await waitForText(container, 'vs. Falcons');
         await clickButton(container, 'Game');
         await waitForText(container, 'Lineup builder');
+        await clickButton(container, 'Lineup builder');
 
         const select = container.querySelector('#game-hub-lineup-formation');
         await act(async () => {
@@ -857,6 +863,8 @@ describe('React app ScheduleEventDetail More tab integration', () => {
         const { container } = await renderDetail('/schedule/team-1/game-1?childId=player-1');
         await waitForText(container, 'vs. Falcons');
         await clickButton(container, 'Game');
+        await waitForText(container, 'Lineup builder');
+        await clickButton(container, 'Lineup builder');
         await waitForText(container, 'Published v1. 1 draft assignment unpublished.');
 
         await clickButton(container, 'Publish lineup');


### PR DESCRIPTION
Closes #2184

## What changed
- wrapped non-primary Game Hub tools in explicit lazy accordions so they do not mount on initial `section=game` render
- kept the core live-game controls mounted immediately: live clock, score editor, and foul tracking
- deferred mount for live reactions, live chat, post-game wrap-up, statsheet import, lineup builder, live substitutions, and report sections until the user opens each panel
- updated focused `ScheduleEventDetail` tests to open deferred panels explicitly and added a regression test that proves chat, reactions, lineup preview, and report loading stay idle until opened

## Root Cause
`GameHubSection` eagerly rendered optional secondary panels as soon as the Game Hub opened. Because those panels start subscriptions and loaders inside mount effects, one navigation triggered chat and reactions listeners, lineup preview loading, report loading, and other secondary work before the scorekeeper asked for those tools.

## Prevention / Learning
If a game-day panel starts network work or subscriptions on mount and is not required for the first scoring interaction, gate its mount behind an explicit open action and add a route-adjacent regression test that asserts the loader stays idle until that action happens.

## Regression Tests
- `npx vitest run apps/app/src/pages/ScheduleEventDetail.test.tsx`
- added regression coverage that verifies Game Hub initial render does **not** call `subscribeToLiveGameChat`, `subscribeToLiveGameReactions`, `loadAutoFilledLineupDraftPreviewForApp`, or `loadGameReportSections` until their panels are opened
- updated adjacent Game Hub tests so deferred panels are opened before asserting prior behavior, covering chat, reactions, substitutions, wrap-up, lineup, and statsheet workflows