### PR TITLE
[codex] Open single-team hub directly

### DIFF
--- a/apps/app/src/pages/Teams.test.tsx
+++ b/apps/app/src/pages/Teams.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { Teams } from './Teams';
+import type { ParentHomeModel, ParentHomeTeam } from '../lib/homeLogic';
 import type { AuthState } from '../lib/types';
 
 const homeServiceMocks = vi.hoisted(() => ({
@@ -23,9 +24,30 @@ vi.mock('../lib/useShellLayout', () => ({
 }));
 vi.mock('lucide-react', () => {
   const Icon = () => null;
-  return new Proxy({}, {
-    get: () => Icon
-  });
+  return {
+    BarChart3: Icon,
+    CalendarDays: Icon,
+    CheckCircle2: Icon,
+    ChevronDown: Icon,
+    ChevronRight: Icon,
+    ClipboardCheck: Icon,
+    ClipboardList: Icon,
+    Dumbbell: Icon,
+    ExternalLink: Icon,
+    FileText: Icon,
+    Images: Icon,
+    Loader2: Icon,
+    MessageCircle: Icon,
+    Radio: Icon,
+    RefreshCw: Icon,
+    Settings: Icon,
+    Shield: Icon,
+    SlidersHorizontal: Icon,
+    Ticket: Icon,
+    UserRound: Icon,
+    Users: Icon,
+    WalletCards: Icon
+  };
 });
 
 const auth: AuthState = {
@@ -48,7 +70,7 @@ const auth: AuthState = {
   signOut: vi.fn()
 };
 
-const emptyHome = {
+const emptyHome: ParentHomeModel = {
   players: [],
   teams: [],
   upcomingEvents: [],
@@ -62,6 +84,35 @@ const emptyHome = {
     packetsReady: 0
   }
 };
+
+function makeTeam(overrides: Partial<ParentHomeTeam> = {}): ParentHomeTeam {
+  return {
+    teamId: 'team-1',
+    teamName: 'Bears',
+    role: 'parent',
+    sport: 'Basketball',
+    photoUrl: null,
+    players: [],
+    nextEvent: null,
+    eventCount: 0,
+    unreadCount: 0,
+    openActions: 0,
+    ...overrides
+  };
+}
+
+function makeHome(teams: ParentHomeTeam[]): ParentHomeModel {
+  return {
+    ...emptyHome,
+    teams,
+    metrics: {
+      ...emptyHome.metrics,
+      teams: teams.length,
+      players: teams.reduce((total, team) => total + team.players.length, 0),
+      unreadMessages: teams.reduce((total, team) => total + team.unreadCount, 0)
+    }
+  };
+}
 
 function renderTeams() {
   return render(
@@ -93,10 +144,43 @@ describe('Teams empty state', () => {
     renderTeams();
 
     await screen.findByRole('heading', { name: 'No teams linked yet' });
-    const browseLink = screen.getByRole('link', { name: 'Browse teams' });
-    expect(browseLink).toHaveAttribute('href', 'https://allplays.ai/teams.html');
+    const browseLink = screen
+      .getAllByRole('link', { name: 'Browse teams' })
+      .find((link) => link.getAttribute('href') === 'https://allplays.ai/teams.html');
+    expect(browseLink?.getAttribute('href')).toBe('https://allplays.ai/teams.html');
+    expect(browseLink).toBeTruthy();
     fireEvent.click(browseLink);
 
     expect(publicActionMocks.openPublicUrl).toHaveBeenCalledWith('https://allplays.ai/teams.html');
+  });
+
+  it('opens a single linked team directly without the chooser or search field', async () => {
+    const singleTeamHome = makeHome([makeTeam()]);
+    homeServiceMocks.loadParentTeamsSummary.mockResolvedValue(singleTeamHome);
+    homeServiceMocks.loadParentHomeSummary.mockResolvedValue(singleTeamHome);
+
+    renderTeams();
+
+    await screen.findByRole('heading', { name: 'Bears' });
+
+    expect(screen.queryByText('Choose a team')).toBeNull();
+    expect(screen.queryByPlaceholderText('Search teams or players')).toBeNull();
+    expect(screen.getByText('Team hub')).toBeTruthy();
+  });
+
+  it('keeps the chooser available when multiple teams are linked', async () => {
+    const multiTeamHome = makeHome([
+      makeTeam(),
+      makeTeam({ teamId: 'team-2', teamName: 'Sharks', role: 'coach', eventCount: 3 })
+    ]);
+    homeServiceMocks.loadParentTeamsSummary.mockResolvedValue(multiTeamHome);
+    homeServiceMocks.loadParentHomeSummary.mockResolvedValue(multiTeamHome);
+
+    renderTeams();
+
+    await screen.findByText('Choose a team');
+
+    expect(screen.getByPlaceholderText('Search teams or players')).toBeTruthy();
+    expect(screen.getByText('2 teams')).toBeTruthy();
   });
 });

--- a/apps/app/src/pages/Teams.tsx
+++ b/apps/app/src/pages/Teams.tsx
@@ -100,6 +100,7 @@ export function Teams({ auth }: { auth: AuthState }) {
   const selectedTeam = useMemo(() => (
     home.teams.find((team) => team.teamId === selectedTeamId) || home.teams[0] || null
   ), [home.teams, selectedTeamId]);
+  const shouldShowTeamLauncher = home.teams.length > 1;
   const teamRoles = useMemo(() => getLoadedTeamRoles(home.teams), [home.teams]);
   const hasManagementTeam = useMemo(() => home.teams.some((team) => isTeamManagementRole(team.role)), [home.teams]);
 
@@ -132,16 +133,23 @@ export function Teams({ auth }: { auth: AuthState }) {
         </section>
       ) : home.teams.length ? (
         isDesktopWeb ? (
-          <div className="teams-web-workbench">
-            <TeamLauncher teams={home.teams} selectedTeamId={selectedTeam?.teamId || ''} onSelect={selectTeam} variant="rail" />
+          shouldShowTeamLauncher ? (
+            <div className="teams-web-workbench">
+              <TeamLauncher teams={home.teams} selectedTeamId={selectedTeam?.teamId || ''} onSelect={selectTeam} variant="rail" />
+              <div className="min-w-0 space-y-4">
+                {selectedTeam ? <SelectedTeamPanel team={selectedTeam} variant="web" /> : null}
+                {hasManagementTeam ? <WebsiteToolsNotice compact /> : null}
+              </div>
+            </div>
+          ) : (
             <div className="min-w-0 space-y-4">
               {selectedTeam ? <SelectedTeamPanel team={selectedTeam} variant="web" /> : null}
               {hasManagementTeam ? <WebsiteToolsNotice compact /> : null}
             </div>
-          </div>
+          )
         ) : (
           <>
-            <TeamLauncher teams={home.teams} selectedTeamId={selectedTeam?.teamId || ''} onSelect={selectTeam} />
+            {shouldShowTeamLauncher ? <TeamLauncher teams={home.teams} selectedTeamId={selectedTeam?.teamId || ''} onSelect={selectTeam} /> : null}
             {selectedTeam ? <SelectedTeamPanel team={selectedTeam} /> : null}
           </>
         )


### PR DESCRIPTION
Closes #2206

## What changed
- Skips the Teams chooser/search UI when the signed-in user has exactly one linked team.
- Keeps the existing chooser/search behavior for multi-team accounts.
- Adds Teams page coverage for single-team direct open and multi-team chooser behavior.

## Validation
- `npm --prefix apps/app exec -- vitest run src/pages/Teams.test.tsx --reporter=verbose`